### PR TITLE
Eliminate bitbucket.com mentions everywhere

### DIFF
--- a/client/search-ui/src/components/CodeHostIcon.tsx
+++ b/client/search-ui/src/components/CodeHostIcon.tsx
@@ -13,7 +13,6 @@ export const CodeHostIcon: React.FunctionComponent<
     const iconMap: { [key: string]: string } = {
         'github.com': mdiGithub,
         'gitlab.com': mdiGitlab,
-        'bitbucket.com': mdiBitbucket,
         'bitbucket.org': mdiBitbucket,
     }
 

--- a/client/web/src/communitySearchContexts/CommunitySearchContextPage.tsx
+++ b/client/web/src/communitySearchContexts/CommunitySearchContextPage.tsx
@@ -246,7 +246,7 @@ const RepoLink: React.FunctionComponent<React.PropsWithChildren<{ repo: string }
                 </Link>
             </>
         )}
-        {repo.startsWith('bitbucket.com') && (
+        {repo.startsWith('bitbucket.org') && (
             <>
                 <Link to={`https://${repo}`} target="_blank" rel="noopener noreferrer" onClick={RepoLinkClicked(repo)}>
                     <Icon className={styles.repoListIcon} aria-hidden={true} svgPath={mdiBitbucket} />

--- a/client/web/src/enterprise/batches/detail/WebhookAlert.story.tsx
+++ b/client/web/src/enterprise/batches/detail/WebhookAlert.story.tsx
@@ -45,7 +45,7 @@ const batchChange = (totalCount: number, hasNextPage: boolean) => ({
                 },
                 {
                     externalServiceKind: 'BITBUCKETSERVER' as ExternalServiceKind,
-                    externalServiceURL: 'https://bitbucket.com/',
+                    externalServiceURL: 'https://bitbucket.org/',
                 },
             ],
             pageInfo: { hasNextPage },

--- a/client/web/src/search/results/sidebar/SearchFiltersSidebar.story.tsx
+++ b/client/web/src/search/results/sidebar/SearchFiltersSidebar.story.tsx
@@ -73,8 +73,8 @@ const filters: Filter[] = [
         kind: 'repo',
     },
     {
-        label: 'bitbucket.com/com/test',
-        value: 'repo:^bitbucket\\.com/com/test$',
+        label: 'bitbucket.org/com/test',
+        value: 'repo:^bitbucket\\.org/com/test$',
         count: 1,
         limitHit: true,
         kind: 'repo',

--- a/enterprise/internal/batches/testing/repos.go
+++ b/enterprise/internal/batches/testing/repos.go
@@ -39,9 +39,9 @@ func TestRepo(t *testing.T, store database.ExternalServiceStore, serviceKind str
 	case extsvc.KindGitLab:
 		svc.Config = extsvc.NewUnencryptedConfig(`{"url": "https://gitlab.com", "token": "abc", "projectQuery": ["repo"]}`)
 	case extsvc.KindBitbucketCloud:
-		svc.Config = extsvc.NewUnencryptedConfig(`{"url": "https://bitbucket.com", "username": "user", "appPassword": "pass"}`)
+		svc.Config = extsvc.NewUnencryptedConfig(`{"url": "https://bitbucket.org", "username": "user", "appPassword": "pass"}`)
 	case extsvc.KindBitbucketServer:
-		svc.Config = extsvc.NewUnencryptedConfig(`{"url": "https://bitbucket.com", "username": "user", "token": "abc", "repos": ["owner/name"]}`)
+		svc.Config = extsvc.NewUnencryptedConfig(`{"url": "https://bitbucket.org", "username": "user", "token": "abc", "repos": ["owner/name"]}`)
 	case extsvc.KindAWSCodeCommit:
 		svc.Config = extsvc.NewUnencryptedConfig(`{"region": "us-east-1", "accessKeyID": "abc", "secretAccessKey": "abc", "gitCredentials": {"username": "user", "password": "pass"}}`)
 	default:

--- a/enterprise/internal/database/external_services_test.go
+++ b/enterprise/internal/database/external_services_test.go
@@ -378,7 +378,7 @@ func TestValidateExternalServiceConfig(t *testing.T) {
 			desc: "valid with url, username, token, repositoryQuery",
 			config: `
 			{
-				"url": "https://bitbucket.com/",
+				"url": "https://bitbucket.org/",
 				"username": "admin",
 				"token": "secret-token",
 				"repositoryQuery": ["none"]
@@ -390,7 +390,7 @@ func TestValidateExternalServiceConfig(t *testing.T) {
 			desc: "valid with url, username, token, repos",
 			config: `
 			{
-				"url": "https://bitbucket.com/",
+				"url": "https://bitbucket.org/",
 				"username": "admin",
 				"token": "secret-token",
 				"repos": ["sourcegraph/sourcegraph"]
@@ -422,7 +422,7 @@ func TestValidateExternalServiceConfig(t *testing.T) {
 		{
 			kind:   extsvc.KindBitbucketServer,
 			desc:   "bad url scheme",
-			config: `{"url": "badscheme://bitbucket.com"}`,
+			config: `{"url": "badscheme://bitbucket.org"}`,
 			assert: includes("url: Does not match pattern '^https?://'"),
 		},
 		{

--- a/internal/codeintel/policies/internal/store/store_configuration_test.go
+++ b/internal/codeintel/policies/internal/store/store_configuration_test.go
@@ -55,7 +55,7 @@ func TestGetConfigurationPolicies(t *testing.T) {
 
 	insertRepo(t, db, 41, "gitlab.com/test1")
 	insertRepo(t, db, 42, "github.com/test2")
-	insertRepo(t, db, 43, "bitbucket.com/test3")
+	insertRepo(t, db, 43, "bitbucket.org/test3")
 	insertRepo(t, db, 44, "localhost/secret-repo")
 
 	for policyID, patterns := range map[int][]string{

--- a/internal/repos/store_test.go
+++ b/internal/repos/store_test.go
@@ -542,7 +542,7 @@ func mkExternalServices(now time.Time) types.ExternalServices {
 	bitbucketServerSvc := types.ExternalService{
 		Kind:        extsvc.KindBitbucketServer,
 		DisplayName: "Bitbucket Server - Test",
-		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://bitbucket.com", "token": "abc", "username": "user", "repos": ["owner/name"]}`),
+		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://bitbucket.org", "token": "abc", "username": "user", "repos": ["owner/name"]}`),
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
@@ -550,7 +550,7 @@ func mkExternalServices(now time.Time) types.ExternalServices {
 	bitbucketCloudSvc := types.ExternalService{
 		Kind:        extsvc.KindBitbucketCloud,
 		DisplayName: "Bitbucket Cloud - Test",
-		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://bitbucket.com", "username": "user", "appPassword": "password"}`),
+		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://bitbucket.org", "username": "user", "appPassword": "password"}`),
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}

--- a/internal/types/secret_test.go
+++ b/internal/types/secret_test.go
@@ -43,8 +43,8 @@ func TestExternalService_RedactedConfig(t *testing.T) {
 		},
 		{
 			kind: extsvc.KindBitbucketCloud,
-			in:   schema.BitbucketCloudConnection{AppPassword: "foobar", Url: "https://bitbucket.com"},
-			out:  schema.BitbucketCloudConnection{AppPassword: RedactedSecret, Url: "https://bitbucket.com"},
+			in:   schema.BitbucketCloudConnection{AppPassword: "foobar", Url: "https://bitbucket.org"},
+			out:  schema.BitbucketCloudConnection{AppPassword: RedactedSecret, Url: "https://bitbucket.org"},
 		},
 		{
 			kind: extsvc.KindAWSCodeCommit,
@@ -203,7 +203,7 @@ func TestExternalService_UnredactConfig(t *testing.T) {
 		},
 		{
 			kind: extsvc.KindBitbucketCloud,
-			old:  schema.BitbucketCloudConnection{AppPassword: "foobar", Url: "https://bitbucket.com"},
+			old:  schema.BitbucketCloudConnection{AppPassword: "foobar", Url: "https://bitbucket.org"},
 			in:   schema.BitbucketCloudConnection{AppPassword: RedactedSecret, Url: "https://bitbucket.corp.com"},
 			out:  schema.BitbucketCloudConnection{AppPassword: "foobar", Url: "https://bitbucket.corp.com"},
 		},

--- a/internal/types/typestest/typestest.go
+++ b/internal/types/typestest/typestest.go
@@ -129,7 +129,7 @@ func MakeExternalServices() types.ExternalServices {
 	bitbucketServerSvc := types.ExternalService{
 		Kind:        extsvc.KindBitbucketServer,
 		DisplayName: "Bitbucket Server - Test",
-		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://bitbucket.com", "username": "foo", "token": "abc", "repositoryQuery": ["none"]}`),
+		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://bitbucket.org", "username": "foo", "token": "abc", "repositoryQuery": ["none"]}`),
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
@@ -137,7 +137,7 @@ func MakeExternalServices() types.ExternalServices {
 	bitbucketCloudSvc := types.ExternalService{
 		Kind:        extsvc.KindBitbucketCloud,
 		DisplayName: "Bitbucket Cloud - Test",
-		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://bitbucket.com", "username": "foo", "appPassword": "abc"}`),
+		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://bitbucket.org", "username": "foo", "appPassword": "abc"}`),
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -70,7 +70,7 @@
       "type": "string"
     },
     "gitURLType": {
-      "description": "The type of Git URLs to use for cloning and fetching Git repositories on this Bitbucket Server / Bitbucket Data Center instance.\n\nIf \"http\", Sourcegraph will access Bitbucket Server / Bitbucket Data Center repositories using Git URLs of the form http(s)://bitbucket.example.com/scm/myproject/myrepo.git (using https: if the Bitbucket Server / Bitbucket Data Center instance uses HTTPS).\n\nIf \"ssh\", Sourcegraph will access Bitbucket Server / Bitbucket Data Center repositories using Git URLs of the form ssh://git@example.bitbucket.com/myproject/myrepo.git. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.",
+      "description": "The type of Git URLs to use for cloning and fetching Git repositories on this Bitbucket Server / Bitbucket Data Center instance.\n\nIf \"http\", Sourcegraph will access Bitbucket Server / Bitbucket Data Center repositories using Git URLs of the form http(s)://bitbucket.example.com/scm/myproject/myrepo.git (using https: if the Bitbucket Server / Bitbucket Data Center instance uses HTTPS).\n\nIf \"ssh\", Sourcegraph will access Bitbucket Server / Bitbucket Data Center repositories using Git URLs of the form ssh://git@example.bitbucket.org/myproject/myrepo.git. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.",
       "type": "string",
       "enum": ["http", "ssh"],
       "default": "http",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -279,7 +279,7 @@ type BitbucketServerConnection struct {
 	//
 	// If "http", Sourcegraph will access Bitbucket Server / Bitbucket Data Center repositories using Git URLs of the form http(s)://bitbucket.example.com/scm/myproject/myrepo.git (using https: if the Bitbucket Server / Bitbucket Data Center instance uses HTTPS).
 	//
-	// If "ssh", Sourcegraph will access Bitbucket Server / Bitbucket Data Center repositories using Git URLs of the form ssh://git@example.bitbucket.com/myproject/myrepo.git. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.
+	// If "ssh", Sourcegraph will access Bitbucket Server / Bitbucket Data Center repositories using Git URLs of the form ssh://git@example.bitbucket.org/myproject/myrepo.git. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.
 	GitURLType string `json:"gitURLType,omitempty"`
 	// InitialRepositoryEnablement description: Deprecated and ignored field which will be removed entirely in the next release. BitBucket repositories can no longer be enabled or disabled explicitly.
 	InitialRepositoryEnablement bool `json:"initialRepositoryEnablement,omitempty"`


### PR DESCRIPTION
I've changed all our `bitbucket.com` mentions to `bitbucket.org`

Why: Mainly because it seems silly. Bitbucket.com doesn't contain any repos. [source](https://community.atlassian.com/t5/Bitbucket-questions/What-will-be-the-URL-to-access-the-API-of-a-custom-Bitbucket/qaq-p/707674)
- Bitbucket Cloud is at `bitbucket.org`
- Bitbucket Server is **anywhere but** *.bitbucket.org, *.bitbucket.com, and *.bitbucket.io
- Bitbucket Server might be like `bitbucket.company.com`, but this change doesn't affect that case

My change almost exclusively affects tests, stories, and comments. The two places where it affects production code are:
1. `CodeHostIcon.tsx`: I've removed `bitbucket.com` from the icon map. This won't cause a problem because there are no repos at `bitbucket.com`
2. `CommunitySearchContextPage.tsx`: It's practically a bug fix. It almost surely never worked because no repo starts with `bitbucket.com`

## Test plan

If tests pass I feel confident that this change is fine.