### PR TITLE
Popover: Stop triggering close events when already closed

### DIFF
--- a/client/search-ui/src/input/SearchContextDropdown.test.tsx
+++ b/client/search-ui/src/input/SearchContextDropdown.test.tsx
@@ -116,7 +116,10 @@ describe('SearchContextDropdown', () => {
         )
 
         userEvent.click(screen.getByTestId('dropdown-toggle'))
-        userEvent.type(document.body, '{esc}')
+        userEvent.type(document.body, '{esc}', {
+            // We need to skip, otherwise the close event will trigger due to a "click away"
+            skipClick: true,
+        })
 
         act(() => {
             // Wait for the next frame

--- a/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.tsx
+++ b/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.tsx
@@ -55,7 +55,11 @@ export const PopoverContent = forwardRef(function PopoverContent(props, referenc
     })
 
     // Close popover on escape
-    useKeyboard({ detectKeys: ['Escape'] }, () => setOpen({ isOpen: false, reason: PopoverOpenEventReason.Esc }))
+    useKeyboard({ detectKeys: ['Escape'] }, () => {
+        if (isOpen) {
+            setOpen({ isOpen: false, reason: PopoverOpenEventReason.Esc })
+        }
+    })
 
     // Native behavior of browsers about focus elements says - if element that gets focus
     // is in outside the visible viewport then browser should scroll to this element automatically.

--- a/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.tsx
+++ b/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.tsx
@@ -56,7 +56,9 @@ export const PopoverContent = forwardRef(function PopoverContent(props, referenc
 
     // Close popover on escape
     useKeyboard({ detectKeys: ['Escape'] }, () => {
-        if (isOpen) {
+        // Only fire if we can be sure that the popover is open.
+        // Both for controlled and uncontrolled popovers.
+        if (isOpen || isOpenContext) {
             setOpen({ isOpen: false, reason: PopoverOpenEventReason.Esc })
         }
     })


### PR DESCRIPTION
## Description

For controlled Popovers, this event listener was present even if the popover was closed. It meant that any consumer that listened to `onOpenChange` events from the `Popover`, might incorrectly respond to a close event.

This was causing a bug where the <kbd>ESC</kbd> key was returning focus to the search bar

## Test plan

Tested locally

## App preview:

- [Web](https://sg-web-tr-popover-escape-trigger.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-lsxoieoadm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
