### PR TITLE
Remove unauthenticated user alerts on extensions pages

### DIFF
--- a/client/web/src/extensions/ExtensionRegistry.tsx
+++ b/client/web/src/extensions/ExtensionRegistry.tsx
@@ -12,8 +12,7 @@ import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { ExtensionCategory, EXTENSION_CATEGORIES } from '@sourcegraph/shared/src/schema/extensionSchema'
 import { Settings, SettingsCascadeProps, SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { buildGetStartedURL } from '@sourcegraph/shared/src/util/url'
-import { AlertLink, useLocalStorage, useEventObservable, Alert, Link, Input } from '@sourcegraph/wildcard'
+import { useLocalStorage, useEventObservable, Link, Input } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../components/PageTitle'
 import {
@@ -119,7 +118,7 @@ export type ConfiguredExtensionCache = Map<string, MinimalConfiguredRegistryExte
 export const ExtensionRegistry: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
     useEffect(() => eventLogger.logViewEvent('ExtensionsOverview'), [])
 
-    const { history, location, settingsCascade, platformContext, authenticatedUser } = props
+    const { history, location, settingsCascade, platformContext } = props
 
     // Update the cache after each response. This speeds up client-side filtering.
     // Lazy initialize cache ref. Don't mind the `useState` abuse:
@@ -356,14 +355,6 @@ export const ExtensionRegistry: React.FunctionComponent<React.PropsWithChildren<
                                     spellCheck={false}
                                 />
                             </Form>
-                            {!authenticatedUser && (
-                                <Alert className="my-4" variant="info">
-                                    <span>An account is required to create, enable and disable extensions. </span>
-                                    <AlertLink to={buildGetStartedURL('extension-registry', '/extensions')}>
-                                        Get started!
-                                    </AlertLink>
-                                </Alert>
-                            )}
                             <ExtensionsList
                                 {...props}
                                 data={isLoading ? LOADING : data}

--- a/client/web/src/extensions/ExtensionToggle.tsx
+++ b/client/web/src/extensions/ExtensionToggle.tsx
@@ -21,8 +21,6 @@ interface Props extends SettingsCascadeProps, PlatformContextProps<'updateSettin
     className?: string
     /** Render big toggle */
     big?: boolean
-    userCannotToggle?: boolean
-    onHover?: (value: boolean) => void
     /** Additional logic to run on toggle */
     onToggleChange?: (enabled: boolean) => void
     /** Additional logic to run on update error */
@@ -84,8 +82,6 @@ export const ExtensionToggle: React.FunctionComponent<React.PropsWithChildren<Pr
     enabled,
     className,
     big,
-    userCannotToggle,
-    onHover,
     onToggleChange,
     onToggleError,
     subject,
@@ -160,12 +156,11 @@ export const ExtensionToggle: React.FunctionComponent<React.PropsWithChildren<Pr
 
     const props: React.ComponentProps<typeof ToggleBig> = {
         onToggle,
-        onHover,
         className,
         value: optimisticEnabled,
-        title: userCannotToggle || !subject ? undefined : optimisticEnabled ? 'Click to disable' : 'Click to enable',
+        title: !subject ? undefined : optimisticEnabled ? 'Click to disable' : 'Click to enable',
         ['data-testid']: `extension-toggle-${extensionID}`,
-        disabled: userCannotToggle || !subject,
+        disabled: !subject,
     }
 
     return (

--- a/client/web/src/extensions/extension/ExtensionAreaHeader.tsx
+++ b/client/web/src/extensions/extension/ExtensionAreaHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react'
+import React, { useState, useMemo } from 'react'
 
 import { mdiPuzzleOutline } from '@mdi/js'
 import classNames from 'classnames'
@@ -7,8 +7,7 @@ import { NavLink, RouteComponentProps } from 'react-router-dom'
 import { isErrorLike } from '@sourcegraph/common'
 import { isExtensionEnabled, splitExtensionID } from '@sourcegraph/shared/src/extensions/extension'
 import { ExtensionManifest } from '@sourcegraph/shared/src/schema/extensionSchema'
-import { buildGetStartedURL } from '@sourcegraph/shared/src/util/url'
-import { PageHeader, AlertLink, useTimeoutManager, Alert, Icon, Text } from '@sourcegraph/wildcard'
+import { PageHeader, useTimeoutManager, Alert, Icon, Text } from '@sourcegraph/wildcard'
 
 import { NavItemWithIconDescriptor } from '../../util/contributions'
 import { ExtensionToggle } from '../ExtensionToggle'
@@ -67,19 +66,6 @@ export const ExtensionAreaHeader: React.FunctionComponent<React.PropsWithChildre
         [feedbackTimeoutManager, isSiteAdmin]
     )
 
-    /**
-     * Display a CTA on hover over the toggle only when the user is unauthenticated
-     */
-    const [showCta, setShowCta] = useState(false)
-    const ctaTimeoutManager = useTimeoutManager()
-
-    const onHover = useCallback(() => {
-        if (!props.authenticatedUser && !showCta) {
-            setShowCta(true)
-            ctaTimeoutManager.setTimeout(() => setShowCta(false), FEEDBACK_DELAY * 2)
-        }
-    }, [ctaTimeoutManager, showCta, props.authenticatedUser])
-
     return (
         <div className={props.className}>
             <div className="container">
@@ -116,14 +102,8 @@ export const ExtensionAreaHeader: React.FunctionComponent<React.PropsWithChildre
                                             <span className="font-weight-medium">{name}</span> is {change}
                                         </Alert>
                                     )}
-                                    {showCta && (
-                                        <Alert className={classNames('mb-0 py-1', styles.alert)} variant="info">
-                                            An account is required to create and configure extensions.{' '}
-                                            <AlertLink to={buildGetStartedURL('extension')}>Get started!</AlertLink>
-                                        </Alert>
-                                    )}
                                     {/* If site admin, render user toggle and site toggle (both small) */}
-                                    {props.authenticatedUser?.siteAdmin && siteSubject?.subject ? (
+                                    {isSiteAdmin && siteSubject?.subject ? (
                                         (() => {
                                             const enabledForMe = isExtensionEnabled(
                                                 props.settingsCascade.final,
@@ -151,8 +131,6 @@ export const ExtensionAreaHeader: React.FunctionComponent<React.PropsWithChildre
                                                             platformContext={props.platformContext}
                                                             onToggleChange={onToggleChange}
                                                             big={false}
-                                                            onHover={onHover}
-                                                            userCannotToggle={!props.authenticatedUser}
                                                             subject={props.authenticatedUser}
                                                         />
                                                     </div>
@@ -175,8 +153,6 @@ export const ExtensionAreaHeader: React.FunctionComponent<React.PropsWithChildre
                                                             platformContext={props.platformContext}
                                                             onToggleChange={onToggleChange}
                                                             big={false}
-                                                            onHover={onHover}
-                                                            userCannotToggle={!props.authenticatedUser}
                                                             subject={siteSubject.subject}
                                                         />
                                                     </div>
@@ -195,8 +171,6 @@ export const ExtensionAreaHeader: React.FunctionComponent<React.PropsWithChildre
                                             platformContext={props.platformContext}
                                             onToggleChange={onToggleChange}
                                             big={true}
-                                            onHover={onHover}
-                                            userCannotToggle={!props.authenticatedUser}
                                             subject={props.authenticatedUser}
                                         />
                                     )}


### PR DESCRIPTION
Extensions pages are available only when [`enableLegacyExtensions`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@451111a416c46752b0e44143b9ebf8588a7d1c4d/-/blob/schema/site.schema.json?L539%3A1-544%3A11=) site config param [is set to `true`](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%40451111a+extensionsAreaRoutes%3D&patternType=standard). As not authenticated user can only access extensions pages on sourcegraph.com (but not on the private instances), and sourcegraph.com has legacy extensions disabled by default, we no longer need *"An account is required to create and configure extensions."* like alerts.

## Test plan
- CI passes

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
