### PR TITLE
Update `count:500` queries to debug Zoekt load

### DIFF
--- a/client/shared/src/codeintel/legacy-extensions/search/providers.test.ts
+++ b/client/shared/src/codeintel/legacy-extensions/search/providers.test.ts
@@ -106,7 +106,7 @@ describe('search providers', () => {
         const schedule = () => {
             if (tick === currentTick) {
                 if (clock) {
-                    clock.tick(5020)
+                    clock.tick(5000)
                 }
 
                 setTimeout(schedule, 100)
@@ -167,7 +167,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 1)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
-                'count:50',
+                'count:51',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -191,7 +191,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 1)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
-                'count:50',
+                'count:51',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo\\ with\\ spaces$@rev',
@@ -216,7 +216,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
-                'count:50',
+                'count:51',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -224,7 +224,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.secondCall.args[0], [
                 '^foobar$',
-                'count:50',
+                'count:51',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -268,7 +268,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
-                'count:50',
+                'count:51',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -276,7 +276,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.secondCall.args[0], [
                 '^foobar$',
-                'count:50',
+                'count:51',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$',
@@ -307,7 +307,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 3)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
-                'count:50',
+                'count:51',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -315,7 +315,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.secondCall.args[0], [
                 '^foobar$',
-                'count:50',
+                'count:51',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -323,7 +323,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.thirdCall.args[0], [
                 '^foobar$',
-                'count:50',
+                'count:51',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -349,7 +349,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
-                'count:50',
+                'count:51',
                 'case:yes',
                 'fork:yes',
                 'patternType:regexp',
@@ -358,7 +358,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.secondCall.args[0], [
                 '^foobar$',
-                'count:50',
+                'count:51',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -622,7 +622,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 1)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
-                'count:50',
+                'count:51',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -656,7 +656,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '^foobar$',
-                'count:50',
+                'count:51',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -664,7 +664,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.secondCall.args[0], [
                 '^foobar$',
-                'count:50',
+                'count:51',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$',

--- a/client/shared/src/codeintel/legacy-extensions/search/providers.test.ts
+++ b/client/shared/src/codeintel/legacy-extensions/search/providers.test.ts
@@ -106,7 +106,7 @@ describe('search providers', () => {
         const schedule = () => {
             if (tick === currentTick) {
                 if (clock) {
-                    clock.tick(5000)
+                    clock.tick(5020)
                 }
 
                 setTimeout(schedule, 100)
@@ -395,7 +395,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '\\bfoobar\\b',
-                'count:500',
+                'count:502',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -403,7 +403,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.secondCall.args[0], [
                 '\\bfoobar\\b',
-                'count:500',
+                'count:502',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -438,7 +438,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 2)
             assertQuery(searchStub.firstCall.args[0], [
                 '\\bfoobar\\b',
-                'count:500',
+                'count:502',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo\\ with\\ spaces$@rev',
@@ -446,7 +446,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.secondCall.args[0], [
                 '\\bfoobar\\b',
-                'count:500',
+                'count:502',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo\\ with\\ spaces$',
@@ -486,7 +486,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 4)
             assertQuery(searchStub.getCall(0).args[0], [
                 '\\bfoobar\\b',
-                'count:500',
+                'count:502',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$@rev',
@@ -494,7 +494,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.getCall(1).args[0], [
                 '\\bfoobar\\b',
-                'count:500',
+                'count:502',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -502,7 +502,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.getCall(2).args[0], [
                 '\\bfoobar\\b',
-                'count:500',
+                'count:502',
                 'case:yes',
                 'patternType:regexp',
                 'repo:^sourcegraph.test/repo$',
@@ -511,7 +511,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.getCall(3).args[0], [
                 '\\bfoobar\\b',
-                'count:500',
+                'count:502',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -552,7 +552,7 @@ describe('search providers', () => {
             assert.strictEqual(searchStub.callCount, 4)
             assertQuery(searchStub.getCall(0).args[0], [
                 '\\bfoobar\\b',
-                'count:500',
+                'count:502',
                 'case:yes',
                 'fork:yes',
                 'patternType:regexp',
@@ -561,7 +561,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.getCall(1).args[0], [
                 '\\bfoobar\\b',
-                'count:500',
+                'count:502',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',
@@ -569,7 +569,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.getCall(2).args[0], [
                 '\\bfoobar\\b',
-                'count:500',
+                'count:502',
                 'case:yes',
                 'fork:yes',
                 'index:only',
@@ -579,7 +579,7 @@ describe('search providers', () => {
             ])
             assertQuery(searchStub.getCall(3).args[0], [
                 '\\bfoobar\\b',
-                'count:500',
+                'count:502',
                 'case:yes',
                 'patternType:regexp',
                 '-repo:^sourcegraph.test/repo$',

--- a/client/shared/src/codeintel/legacy-extensions/search/queries.test.ts
+++ b/client/shared/src/codeintel/legacy-extensions/search/queries.test.ts
@@ -58,7 +58,7 @@ describe('search requests', () => {
                     '\\btoken\\b',
                     'type:file',
                     'patternType:regexp',
-                    'count:500',
+                    'count:502',
                     'case:yes',
                     'file:\\.(cpp)$',
                 ],

--- a/client/shared/src/codeintel/legacy-extensions/search/queries.test.ts
+++ b/client/shared/src/codeintel/legacy-extensions/search/queries.test.ts
@@ -23,7 +23,7 @@ describe('search requests', () => {
                     '^token$',
                     'type:symbol',
                     'patternType:regexp',
-                    'count:50',
+                    'count:51',
                     'case:yes',
                     'file:\\.(cpp)$',
                 ],

--- a/client/shared/src/codeintel/legacy-extensions/search/queries.ts
+++ b/client/shared/src/codeintel/legacy-extensions/search/queries.ts
@@ -58,7 +58,7 @@ export function referencesQuery({
     if (/\w$/.test(searchToken)) {
         pattern += '\\b'
     }
-    return [pattern, 'type:file', 'patternType:regexp', 'count:500', 'case:yes', fileExtensionTerm(doc, fileExts)]
+    return [pattern, 'type:file', 'patternType:regexp', 'count:502', 'case:yes', fileExtensionTerm(doc, fileExts)]
 }
 
 const excludelist = new Set(['thrift', 'proto', 'graphql'])

--- a/client/shared/src/codeintel/legacy-extensions/search/queries.ts
+++ b/client/shared/src/codeintel/legacy-extensions/search/queries.ts
@@ -27,7 +27,7 @@ export function definitionQuery({
         `^${searchToken}$`,
         'type:symbol',
         'patternType:regexp',
-        'count:50',
+        'count:51',
         'case:yes',
         fileExtensionTerm(doc, fileExts),
     ]

--- a/client/web/src/codeintel/searchBased.ts
+++ b/client/web/src/codeintel/searchBased.ts
@@ -57,7 +57,7 @@ export function referencesQuery({
     if (/\w$/.test(searchToken)) {
         pattern += '\\b'
     }
-    return [pattern, 'type:file', 'patternType:regexp', 'count:500', 'case:yes', fileExtensionTerm(path, fileExts)]
+    return [pattern, 'type:file', 'patternType:regexp', 'count:501', 'case:yes', fileExtensionTerm(path, fileExts)]
 }
 /**
  * Constructs a file term containing include-listed extensions. If the current

--- a/client/web/src/codeintel/searchBased.ts
+++ b/client/web/src/codeintel/searchBased.ts
@@ -26,7 +26,7 @@ export function definitionQuery({
         `^${searchToken}$`,
         'type:symbol',
         'patternType:regexp',
-        'count:50',
+        'count:52',
         'case:yes',
         fileExtensionTerm(path, fileExts),
     ]


### PR DESCRIPTION
Followup from https://github.com/sourcegraph/sourcegraph/pull/42224

We're unable to reproduce the `count:500` queries locally so this PR is an attempt to debug the problem in production, Honeycomb style!

## Test plan

See updated test cases. 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-fuzzy-exact.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-gzvjsppzfz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
