### PR TITLE
docs: Tweak webhook docs

### DIFF
--- a/cmd/frontend/webhooks/github_webhooks.go
+++ b/cmd/frontend/webhooks/github_webhooks.go
@@ -135,7 +135,7 @@ func (h *GitHubWebhook) getExternalService(r *http.Request, body []byte) (*types
 	}
 	gc, ok := c.(*schema.GitHubConnection)
 	if !ok {
-		return nil, errors.Errorf("invalid configuration, recieved github webhook for non-github external service: %v", externalServiceID)
+		return nil, errors.Errorf("invalid configuration, received github webhook for non-github external service: %v", externalServiceID)
 	}
 
 	// 🚨 SECURITY: Try to authenticate the request with any of the stored secrets

--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -130,8 +130,8 @@ To set up webhooks:
 
 1. In Sourcegraph, go to **Site admin > Manage code hosts** and edit the GitHub configuration.
 1. Add the `"webhooks"` property to the configuration (you can generate a secret with `openssl rand -hex 32`):<br /> `"webhooks": [{"org": "your_org", "secret": "verylongrandomsecret"}]`
-1. Click **Update repositories**.
-1. Copy the webhook URL displayed below the **Update repositories** button.
+1. Click **Update configuration**.
+1. Copy the webhook URL displayed below the **Update configuration** button.
 1. On GitHub, go to the settings page of your organization. From there, click **Settings**, then **Webhooks**, then **Add webhook**.
 1. Fill in the webhook form:
    * **Payload URL**: the URL you copied above from Sourcegraph.


### PR DESCRIPTION
The wrong label was used for the button on the external service config
page.

## Test plan

Docs only change