### PR TITLE
admin area: make the "Updates" page prettier

### DIFF
--- a/client/web/src/site-admin/SiteAdminUpdatesPage.module.scss
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.module.scss
@@ -1,8 +1,8 @@
-.info {
-    margin-top: 2rem;
-}
-
 .alert {
     margin-top: 1rem;
     margin-bottom: 1rem;
+}
+
+.last-checked {
+    border-left: 1px solid var(--border-color-2);
 }

--- a/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -1,19 +1,21 @@
 import React, { useMemo } from 'react'
 
-import { mdiCloudDownload } from '@mdi/js'
+import { mdiOpenInNew, mdiCheckCircle } from '@mdi/js'
 import { parseISO } from 'date-fns'
 import formatDistance from 'date-fns/formatDistance'
+import { SiteUpdateCheckResult, SiteUpdateCheckVariables } from 'src/graphql-operations'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
-import { isErrorLike } from '@sourcegraph/common'
+import { useQuery } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { LoadingSpinner, useObservable, Link, Alert, Icon, Code, H2, Text } from '@sourcegraph/wildcard'
+import { LoadingSpinner, Link, PageHeader, Alert, Icon, Code, Container, Text } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../components/PageTitle'
 
-import { fetchSiteUpdateCheck } from './backend'
+import { SITE_UPDATE_CHECK } from './backend'
 
 import styles from './SiteAdminUpdatesPage.module.scss'
+import classNames from 'classnames'
 
 interface Props extends TelemetryProps {}
 
@@ -25,80 +27,86 @@ export const SiteAdminUpdatesPage: React.FunctionComponent<React.PropsWithChildr
         telemetryService.logViewEvent('SiteAdminUpdates')
     }, [telemetryService])
 
-    const state = useObservable(useMemo(() => fetchSiteUpdateCheck(), []))
+    const { data, loading, error } = useQuery<SiteUpdateCheckResult, SiteUpdateCheckVariables>(SITE_UPDATE_CHECK, {})
     const autoUpdateCheckingEnabled = window.context.site['update.channel'] === 'release'
-
-    if (state === undefined) {
-        return <LoadingSpinner />
-    }
-
-    const updateCheck = state.updateCheck
 
     return (
         <div>
             <PageTitle title="Updates - Admin" />
-            <H2>Updates</H2>
-            {isErrorLike(state) && <ErrorAlert error={state} />}
-            {updateCheck && (updateCheck.pending || updateCheck.checkedAt) && (
-                <div>
-                    {updateCheck.pending && (
-                        <Alert className={styles.alert} variant="primary">
-                            <LoadingSpinner /> Checking for updates... (reload in a few seconds)
-                        </Alert>
-                    )}
-                    {!updateCheck.errorMessage &&
-                        (updateCheck.updateVersionAvailable ? (
-                            <Alert className={styles.alert} variant="success">
-                                <Icon aria-hidden={true} svgPath={mdiCloudDownload} /> Update available:{' '}
-                                <Link to="https://about.sourcegraph.com">{updateCheck.updateVersionAvailable}</Link>
-                            </Alert>
-                        ) : (
-                            <Alert className={styles.alert} variant="success">
-                                Up to date.
-                            </Alert>
-                        ))}
-                    {updateCheck.errorMessage && (
-                        <ErrorAlert
-                            className={styles.alert}
-                            prefix="Error checking for updates"
-                            error={updateCheck.errorMessage}
-                        />
-                    )}
-                </div>
-            )}
+            <PageHeader path={[{ text: 'Updates' }]} headingElement="h2" className="mb-3" />
 
-            {!autoUpdateCheckingEnabled && (
-                <Alert className={styles.alert} variant="warning">
-                    Automatic update checking is disabled.
-                </Alert>
-            )}
+            <Container>
+                {error && !loading && <ErrorAlert error={error} />}
+                {loading && !error && <LoadingSpinner />}
+                {data && (
+                    <>
+                        <Text className="mb-2">
+                            Version {data.site.productVersion}{' '}
+                            <small className="text-muted">
+                                (
+                                <Link to="https://about.sourcegraph.com/changelog" target="_blank" rel="noopener">
+                                    changelog
+                                </Link>
+                                )
+                            </small>
+                            <br />
+                        </Text>
 
-            <Text className="site-admin-updates_page__info">
-                <small>
-                    <strong>Current product version:</strong> {state.productVersion} ({state.buildVersion})
-                </small>
-                <br />
-                <small>
-                    <strong>Last update check:</strong>{' '}
-                    {updateCheck.checkedAt
-                        ? formatDistance(parseISO(updateCheck.checkedAt), new Date(), {
-                              addSuffix: true,
-                          })
-                        : 'never'}
-                    .
-                </small>
-                <br />
-                <small>
-                    <strong>Automatic update checking:</strong> {autoUpdateCheckingEnabled ? 'on' : 'off'}.{' '}
-                    <Link to="/site-admin/configuration">Configure</Link> <Code>update.channel</Code> to{' '}
-                    {autoUpdateCheckingEnabled ? 'disable' : 'enable'}.
-                </small>
-            </Text>
-            <Text>
-                <Link to="https://about.sourcegraph.com/changelog" target="_blank" rel="noopener">
-                    Sourcegraph changelog
-                </Link>
-            </Text>
+                        <div>
+                            {data.site.updateCheck.pending && (
+                                <Alert className={styles.alert} variant="primary">
+                                    <LoadingSpinner /> Checking for updates... (reload in a few seconds)
+                                </Alert>
+                            )}
+                            {data.site.updateCheck.errorMessage && (
+                                <ErrorAlert
+                                    className={styles.alert}
+                                    prefix="Error checking for updates"
+                                    error={data.site.updateCheck.errorMessage}
+                                />
+                            )}
+                            {!data.site.updateCheck.errorMessage && (
+                                <small>
+                                    {data.site.updateCheck.updateVersionAvailable ? (
+                                        <Link to="https://about.sourcegraph.com">
+                                            Update available to version {data.site.updateCheck.updateVersionAvailable}{' '}
+                                            <Icon aria-hidden={true} svgPath={mdiOpenInNew} />
+                                        </Link>
+                                    ) : (
+                                        <span>
+                                            <Icon
+                                                aria-hidden={true}
+                                                className="text-success mr-1"
+                                                svgPath={mdiCheckCircle}
+                                            />
+                                            Up to date
+                                        </span>
+                                    )}
+                                    <span className={classNames('text-muted pl-2 ml-2', styles.lastChecked)}>
+                                        {data.site.updateCheck.checkedAt
+                                            ? `Last checked ${formatDistance(
+                                                  parseISO(data.site.updateCheck.checkedAt),
+                                                  new Date(),
+                                                  {
+                                                      addSuffix: true,
+                                                  }
+                                              )}`
+                                            : 'Never checked for updates'}
+                                    </span>
+                                </small>
+                            )}
+                        </div>
+                    </>
+                )}
+            </Container>
+
+            <small>
+                {autoUpdateCheckingEnabled
+                    ? 'Automatically checking for updates.'
+                    : 'Automatic checking for updates disabled.'}{' '}
+                Change <Code>update.channel</Code> in <Link to="/site-admin/configuration">site configuration</Link> to{' '}
+                {autoUpdateCheckingEnabled ? 'disable' : 'enable'} automatic checking.
+            </small>
         </div>
     )
 }

--- a/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 
 import { mdiOpenInNew, mdiCheckCircle } from '@mdi/js'
 import { parseISO } from 'date-fns'
+import classNames from 'classnames'
 import formatDistance from 'date-fns/formatDistance'
 import { SiteUpdateCheckResult, SiteUpdateCheckVariables } from 'src/graphql-operations'
 
@@ -15,7 +16,6 @@ import { PageTitle } from '../components/PageTitle'
 import { SITE_UPDATE_CHECK } from './backend'
 
 import styles from './SiteAdminUpdatesPage.module.scss'
-import classNames from 'classnames'
 
 interface Props extends TelemetryProps {}
 

--- a/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo } from 'react'
 
 import { mdiOpenInNew, mdiCheckCircle } from '@mdi/js'
-import { parseISO } from 'date-fns'
 import classNames from 'classnames'
+import { parseISO } from 'date-fns'
 import formatDistance from 'date-fns/formatDistance'
 import { SiteUpdateCheckResult, SiteUpdateCheckVariables } from 'src/graphql-operations'
 

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -686,23 +686,23 @@ export function deleteOrganization(organization: Scalars['ID'], hard?: boolean):
         .toPromise()
 }
 
-export function fetchSiteUpdateCheck(): Observable<SiteUpdateCheckResult['site']> {
-    return requestGraphQL<SiteUpdateCheckResult, SiteUpdateCheckVariables>(
-        gql`
-            query SiteUpdateCheck {
-                site {
-                    buildVersion
-                    productVersion
-                    updateCheck {
-                        pending
-                        checkedAt
-                        errorMessage
-                        updateVersionAvailable
-                    }
-                }
+export const SITE_UPDATE_CHECK = gql`
+    query SiteUpdateCheck {
+        site {
+            buildVersion
+            productVersion
+            updateCheck {
+                pending
+                checkedAt
+                errorMessage
+                updateVersionAvailable
             }
-        `
-    ).pipe(
+        }
+    }
+`
+
+export function fetchSiteUpdateCheck(): Observable<SiteUpdateCheckResult['site']> {
+    return requestGraphQL<SiteUpdateCheckResult, SiteUpdateCheckVariables>(SITE_UPDATE_CHECK).pipe(
         map(dataOrThrowErrors),
         map(data => data.site)
     )


### PR DESCRIPTION
This makes `/site-admin/updates` a bit prettier, thanks to @quinnkeast.

## Figma

Here: https://www.figma.com/file/459B4a8704zFuwqKPA8joL/Settings-sidebar-unification?node-id=1822%3A5178

## Before / After

| Before | after |
|-------|------|
| <img width="1246" src="https://user-images.githubusercontent.com/1185253/193267936-38f16d81-3de2-4d21-9868-58a39ff8b79e.png"> | <img width="1246" alt="screenshot_2022-09-30_14 19 38@2x" src="https://user-images.githubusercontent.com/1185253/193268098-42eb955f-640a-40c5-a976-c65c00b59af1.png"> |
| <img width="1260" alt="screenshot_2022-09-30_14 34 15@2x" src="https://user-images.githubusercontent.com/1185253/193270705-9e8fe74f-32ae-4cce-b631-00194d714fb0.png"> | <img width="1260" alt="screenshot_2022-09-30_14 25 59@2x" src="https://user-images.githubusercontent.com/1185253/193269128-1c7214e8-972b-4a75-b8ac-25ad06d37d85.png"> |


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-mrn-admin-updates-page.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-bjnovwagaf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

