### PR TITLE
Fix handling of exact matches in the fuzzy finder

### DIFF
--- a/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.ts
+++ b/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.ts
@@ -42,18 +42,27 @@ export class CaseInsensitiveFuzzySearch extends FuzzySearch {
         const isEmptyQuery = parameters.query.length === 0
         const candidates: ScoredSearchValue[] = []
         const queryParts = parameters.query.split(this.spaceSeparator).filter(part => part.length > 0)
-        for (const value of searchValues) {
-            let score = 0
-            for (const queryPart of queryParts) {
-                const partScore = fzy.score(queryPart, value.text)
-                score += partScore
-            }
-            const isAcceptableScore = !isNaN(score) && score > 0.2
-            if (isEmptyQuery || isAcceptableScore) {
-                candidates.push({
-                    score,
-                    text: value.text,
-                })
+        if (queryParts.length === 0) {
+            // Empty query, match all values
+            candidates.push(...searchValues.map(value => ({ score: 0, text: value.text })))
+        } else {
+            for (const value of searchValues) {
+                let score = 0
+                if (queryParts.length === 1 && queryParts[0] === value.text) {
+                    score = 1 // exact match, special-cased because fzy.score returns `Infinity`
+                } else {
+                    for (const queryPart of queryParts) {
+                        const partScore = fzy.score(queryPart, value.text)
+                        score += partScore
+                    }
+                }
+                const isAcceptableScore = !isNaN(score) && isFinite(score) && score > 0.2
+                if (isEmptyQuery || isAcceptableScore) {
+                    candidates.push({
+                        score,
+                        text: value.text,
+                    })
+                }
             }
         }
 

--- a/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.ts
+++ b/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.ts
@@ -15,6 +15,10 @@ class CacheCandidate {
     }
 }
 
+// The 0.2 value was chosen by manually observing the behavior and confirming
+// that it seems to give relevant results without too much noise.
+const FZY_MINIMUM_SCORE_THRESHOLD = 0.2
+
 /**
  * FuzzySearch implementation that uses the original fzy filtering algorithm from https://github.com/jhawthorn/fzy.js
  */
@@ -56,7 +60,7 @@ export class CaseInsensitiveFuzzySearch extends FuzzySearch {
                         score += partScore
                     }
                 }
-                const isAcceptableScore = !isNaN(score) && isFinite(score) && score > 0.2
+                const isAcceptableScore = !isNaN(score) && isFinite(score) && score > FZY_MINIMUM_SCORE_THRESHOLD
                 if (isEmptyQuery || isAcceptableScore) {
                     candidates.push({
                         score,


### PR DESCRIPTION
Previously, copy-pasting the exact file path into the fuzzy finder returned matches for all files in the repository. This commit fixes the behavior so that only the exact match is highlighted.

For some reason, I was not able to reproduce the browser behavior in our tests. We even have a test case for exact matches and it passes with correct behavior before this PR. I had implemented a fix for the same bug in the past, and added a test case to catch regressions, but something changed recently where the tests still pass but the behavior in the browser regressed.  Either way, the behavior in the browser works as expected now when you copy-paste



## Test plan

Manually verified the new behavior in the browser.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-fuzzzy.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-dcemzaivsz.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
