### PR TITLE
GraphQL API: add `inactiveSince: DateTime` filter parameter to `users` query

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1316,6 +1316,10 @@ type Query {
         Returns users who have been active in a given period of time.
         """
         activePeriod: UserActivePeriod
+        """
+        Returns users who have NOT been active since a given point in time.
+        """
+        inactiveSince: DateTime
     ): UserConnection!
     """
     Looks up an organization by name.

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/sourcegraph/log"
@@ -33,7 +32,6 @@ func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
 		opt.Tag = *args.Tag
 	}
 	if args.InactiveSince != nil {
-		fmt.Printf("inactiveSince=%s\n", args.InactiveSince.Time)
 		opt.InactiveSince = args.InactiveSince.Time
 	}
 	args.ConnectionArgs.Set(&opt.LimitOffset)

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -31,6 +31,9 @@ func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
 	if args.Tag != nil {
 		opt.Tag = *args.Tag
 	}
+	if args.InactiveSince != nil {
+		opt.InactiveSince = *args.InactiveSince
+	}
 	args.ConnectionArgs.Set(&opt.LimitOffset)
 	return &userConnectionResolver{db: r.db, opt: opt, activePeriod: args.ActivePeriod}
 }

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/sourcegraph/log"
@@ -32,6 +33,7 @@ func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
 		opt.Tag = *args.Tag
 	}
 	if args.InactiveSince != nil {
+		fmt.Printf("inactiveSince=%s\n", args.InactiveSince.Time)
 		opt.InactiveSince = args.InactiveSince.Time
 	}
 	args.ConnectionArgs.Set(&opt.LimitOffset)

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -3,6 +3,7 @@ package graphqlbackend
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/sourcegraph/log"
 
@@ -14,12 +15,15 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func (r *schemaResolver) Users(args *struct {
+type usersArgs struct {
 	graphqlutil.ConnectionArgs
-	Query        *string
-	Tag          *string
-	ActivePeriod *string
-}) *userConnectionResolver {
+	Query         *string
+	Tag           *string
+	ActivePeriod  *string
+	InactiveSince *time.Time
+}
+
+func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
 	var opt database.UsersListOptions
 	if args.Query != nil {
 		opt.Query = *args.Query

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -3,12 +3,12 @@ package graphqlbackend
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/transport/graphql"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/usagestats"
@@ -20,7 +20,7 @@ type usersArgs struct {
 	Query         *string
 	Tag           *string
 	ActivePeriod  *string
-	InactiveSince *time.Time
+	InactiveSince *graphql.DateTime
 }
 
 func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
@@ -32,7 +32,7 @@ func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
 		opt.Tag = *args.Tag
 	}
 	if args.InactiveSince != nil {
-		opt.InactiveSince = *args.InactiveSince
+		opt.InactiveSince = args.InactiveSince.Time
 	}
 	args.ConnectionArgs.Set(&opt.LimitOffset)
 	return &userConnectionResolver{db: r.db, opt: opt, activePeriod: args.ActivePeriod}

--- a/cmd/frontend/graphqlbackend/users_test.go
+++ b/cmd/frontend/graphqlbackend/users_test.go
@@ -1,9 +1,15 @@
 package graphqlbackend
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/sourcegraph/log/logtest"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -41,6 +47,118 @@ func TestUsers(t *testing.T) {
 						"totalCount": 2
 					}
 				}
+			`,
+		},
+	})
+}
+
+func TestUsers_InactiveSince(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := context.Background()
+
+	schema := mustParseGraphQLSchema(t, db)
+
+	now := time.Now()
+	daysAgo := func(days int) time.Time {
+		return now.Add(-time.Duration(days) * 24 * time.Hour)
+	}
+
+	var users = []struct {
+		user        database.NewUser
+		lastEventAt time.Time
+	}{
+		{user: database.NewUser{Username: "user-1", Password: "user-1"}, lastEventAt: daysAgo(1)},
+		{user: database.NewUser{Username: "user-2", Password: "user-2"}, lastEventAt: daysAgo(2)},
+		{user: database.NewUser{Username: "user-3", Password: "user-3"}, lastEventAt: daysAgo(3)},
+		{user: database.NewUser{Username: "user-4", Password: "user-4"}, lastEventAt: daysAgo(4)},
+	}
+
+	for _, newUser := range users {
+		u, err := db.Users().Create(ctx, newUser.user)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		event := &database.Event{
+			UserID:    uint32(u.ID),
+			Timestamp: newUser.lastEventAt,
+			Name:      "testevent",
+			Source:    "test",
+		}
+		if err := db.EventLogs().Insert(ctx, event); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ctx = actor.WithInternalActor(ctx)
+
+	query := `
+		query InactiveUsers($since: DateTime) {
+			users(inactiveSince: $since) {
+				nodes { username }
+				totalCount
+			}
+		}
+	`
+
+	RunTests(t, []*Test{
+		{
+			Context:   ctx,
+			Schema:    schema,
+			Query:     query,
+			Variables: map[string]any{"since": daysAgo(4).Format(time.RFC3339Nano)},
+			ExpectedResult: `
+			{"users": { "nodes": [], "totalCount": 0 }}
+			`,
+		},
+		{
+			Context:   ctx,
+			Schema:    schema,
+			Query:     query,
+			Variables: map[string]any{"since": daysAgo(3).Format(time.RFC3339Nano)},
+			ExpectedResult: `
+			{"users": { "nodes": [{ "username": "user-4" }], "totalCount": 1 }}
+			`,
+		},
+		{
+			Context:   ctx,
+			Schema:    schema,
+			Query:     query,
+			Variables: map[string]any{"since": daysAgo(2).Format(time.RFC3339Nano)},
+			ExpectedResult: `
+			{"users": { "nodes": [{ "username": "user-3" }, { "username": "user-4" }], "totalCount": 2 }}
+			`,
+		},
+		{
+			Context:   ctx,
+			Schema:    schema,
+			Query:     query,
+			Variables: map[string]any{"since": daysAgo(1).Format(time.RFC3339Nano)},
+			ExpectedResult: `
+			{"users": { "nodes": [
+				{ "username": "user-2" },
+				{ "username": "user-3" },
+				{ "username": "user-4" }
+			], "totalCount": 3 }}
+			`,
+		},
+		{
+			Context:   ctx,
+			Schema:    schema,
+			Query:     query,
+			Variables: map[string]any{"since": daysAgo(0).Format(time.RFC3339Nano)},
+			ExpectedResult: `
+			{"users": { "nodes": [
+				{ "username": "user-1" },
+				{ "username": "user-2" },
+				{ "username": "user-3" },
+				{ "username": "user-4" }
+			], "totalCount": 4 }}
 			`,
 		},
 	})

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -803,6 +803,10 @@ type UsersListOptions struct {
 
 	Tag string // only include users with this tag
 
+	// InactiveSince filters out users that have had an eventlog entry with a
+	// `timestamp` greater-than-or-equal to the given timestamp.
+	InactiveSince time.Time
+
 	*LimitOffset
 }
 
@@ -854,6 +858,15 @@ SELECT id, created_at, deleted_at
 FROM users
 ORDER BY id ASC
 `
+const listUsersInactiveCond = `
+NOT EXISTS (
+	SELECT 1 FROM event_logs
+	WHERE
+		event_logs.user_id = u.id
+	AND
+		timestamp >= %s
+)
+`
 
 func (*userStore) listSQL(opt UsersListOptions) (conds []*sqlf.Query) {
 	conds = []*sqlf.Query{sqlf.Sprintf("TRUE")}
@@ -877,6 +890,11 @@ func (*userStore) listSQL(opt UsersListOptions) (conds []*sqlf.Query) {
 	if opt.Tag != "" {
 		conds = append(conds, sqlf.Sprintf("%s::text = ANY(u.tags)", opt.Tag))
 	}
+
+	if !opt.InactiveSince.IsZero() {
+		conds = append(conds, sqlf.Sprintf(listUsersInactiveCond, opt.InactiveSince))
+	}
+
 	return conds
 }
 

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -859,13 +859,13 @@ FROM users
 ORDER BY id ASC
 `
 const listUsersInactiveCond = `
-NOT EXISTS (
+(NOT EXISTS (
 	SELECT 1 FROM event_logs
 	WHERE
 		event_logs.user_id = u.id
 	AND
 		timestamp >= %s
-)
+))
 `
 
 func (*userStore) listSQL(opt UsersListOptions) (conds []*sqlf.Query) {


### PR DESCRIPTION
This should help make `src users clean` (added in https://github.com/sourcegraph/src-cli/pull/826) much less resource-intensive and faster by filtering the users that are returned on the server.

`src users clean` will need to be updated to make use of this parameter and only request users that have been inactive since the `-days` flag of the command.

## Usage

```graphql
query InactiveUsers {
  users(inactiveSince: "2022-09-20T10:15:30Z") {
    totalCount
    nodes {
      username
    }
  }
}
```

## Test plan

- Manual testing of this query in API console