### PR TITLE
Update "Get Started" signup links/copy

### DIFF
--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -569,8 +569,10 @@ export function buildSearchURLQuery(
     return searchParameters.toString().replace(/%2F/g, '/').replace(/%3A/g, ':')
 }
 
-export function buildGetStartedURL(source: string, returnTo?: string): string {
-    const url = new URL('https://about.sourcegraph.com/get-started/self-hosted')
+export function buildGetStartedURL(source: string, returnTo?: string, forDotcom?: boolean): string {
+    // Still support directing to dotcom signup links when needed
+    const path = forDotcom ? 'https://sourcegraph.com/sign-up' : 'https://signup.sourcegraph.com'
+    const url = new URL(path)
     url.searchParams.set('utm_medium', 'inproduct')
     url.searchParams.set('utm_source', source)
     url.searchParams.set('utm_campaign', 'inproduct-cta')

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
@@ -102,6 +102,7 @@ export const CodeMonitoringGettingStarted: React.FunctionComponent<
                             className={styles.createButton}
                             eventName="SignUpPLGMonitor_GettingStarted"
                             text="Get started with code monitors"
+                            forDotcom={false}
                         />
                     )}
                 </div>
@@ -172,6 +173,7 @@ export const CodeMonitoringGettingStarted: React.FunctionComponent<
                                     className={styles.createButton}
                                     eventName="SignUpPLGMonitor_GettingStarted"
                                     text="Get started"
+                                    forDotcom={true}
                                 />
                             </Card>
                         </div>

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringSignUpLink.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringSignUpLink.tsx
@@ -10,15 +10,16 @@ export const CodeMonitorSignUpLink: React.FunctionComponent<
         className?: string
         text: string
         eventName: string
+        forDotcom: boolean
     }>
-> = ({ className, text, eventName }) => {
+> = ({ className, text, eventName, forDotcom }) => {
     const onClick = (): void => {
         eventLogger.log(eventName)
     }
     return (
         <ButtonLink
             onClick={onClick}
-            to={buildGetStartedURL('code-monitoring', '/code-monitoring/new')}
+            to={buildGetStartedURL('code-monitoring', '/code-monitoring/new', forDotcom)}
             className={className}
             variant="primary"
         >

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -289,7 +289,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                                         Log in
                                     </Button>
                                     <ButtonLink className={styles.signUp} to={buildGetStartedURL('nav')} size="sm">
-                                        Get started
+                                        Get free trial
                                     </ButtonLink>
                                 </div>
                             </NavAction>


### PR DESCRIPTION
Updates the "get started" links in the main application header and on the unauthenticated "Code monitoring" page. Links should match what is specified in [this doc](https://docs.google.com/document/d/1WHWrCoEwncTo3EI3YxMlefNOg81ejrN8ygEIevHPVMM/edit#).

Note: you can ignore uses of `buildGetStartedURL` used in extensions-related components, as those will be removed by #42340.

## Test plan
Confirm the links are rendering as expected with the correct copy.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
