### PR TITLE
Add missing db field when creating a provider

### DIFF
--- a/enterprise/internal/authz/github/app.go
+++ b/enterprise/internal/authz/github/app.go
@@ -99,5 +99,6 @@ func newAppProvider(
 			}, nil
 		},
 		InstallationID: &installationID,
+		db:             db,
 	}, nil
 }


### PR DESCRIPTION
Just a quick fix to avoid the nil pointer error triggered by the missing DB field when creating a new Provider.

## Test plan
Manually tested and confirmed that no panics are not shown anymore triggered by the nil DB.
 
