### PR TITLE
webhooks: Properly validate webhook payloads

### DIFF
--- a/cmd/frontend/webhooks/github_webhooks.go
+++ b/cmd/frontend/webhooks/github_webhooks.go
@@ -138,17 +138,8 @@ func (h *GitHubWebhook) getExternalService(r *http.Request, body []byte) (*types
 		return nil, errors.Errorf("invalid configuration, recieved github webhook for non-github external service: %v", externalServiceID)
 	}
 
-	// 🚨 SECURITY: Try to authenticate the request with any of the stored secrets
-	// If there are no secrets or no secret managed to authenticate the request,
-	// we return an error to the client.
-	for _, hook := range gc.Webhooks {
-		if hook.Secret == "" {
-			continue
-		}
-
-		if err = gh.ValidateSignature(sig, body, []byte(hook.Secret)); err == nil {
-			return e, nil
-		}
+	if err := validateAnyConfiguredSecret(gc, sig, body); err != nil {
+		return nil, errors.Wrap(err, "validating webhook payload")
 	}
 	return e, nil
 }
@@ -179,15 +170,36 @@ func (h *GitHubWebhook) findAndValidateExternalService(ctx context.Context, sig 
 			continue
 		}
 
-		for _, hook := range gc.Webhooks {
-			if hook.Secret == "" {
-				continue
-			}
-
-			if err = gh.ValidateSignature(sig, body, []byte(hook.Secret)); err == nil {
-				return e, nil
-			}
+		if err := validateAnyConfiguredSecret(gc, sig, body); err == nil {
+			return e, nil
 		}
 	}
 	return nil, errors.Errorf("couldn't find any external service for webhook")
+}
+
+func validateAnyConfiguredSecret(c *schema.GitHubConnection, sig string, body []byte) error {
+	if sig == "" {
+		// No signature, this implies no secret was configured
+		return nil
+	}
+
+	// 🚨 SECURITY: Try to authenticate the request with any of the stored secrets
+	// If there are no secrets or no secret managed to authenticate the request,
+	// we return an error to the client.
+	if len(c.Webhooks) == 0 {
+		return errors.Errorf("no webhooks defined")
+	}
+
+	for _, hook := range c.Webhooks {
+		if hook.Secret == "" {
+			continue
+		}
+
+		if err := gh.ValidateSignature(sig, body, []byte(hook.Secret)); err == nil {
+			return nil
+		}
+	}
+
+	// If we make it here then none of our webhook secrets were valid
+	return errors.Errorf("unable to validate webhook signature")
 }


### PR DESCRIPTION
Our old code would check all configured webhooks in an external service
but if none of them were able to validate the payload, we'd return as if
it had been validated.

We also correctly handle the case where a payload is not signed. In this
case we can return early.

## Test plan

Unit tests updated
