### PR TITLE
Docs: Repurpose “Testing a pull request” page

### DIFF
--- a/doc/dev/background-information/testing_pr.md
+++ b/doc/dev/background-information/testing_pr.md
@@ -1,19 +1,16 @@
 # Testing a pull request 
 
-When submitting a pull request to a Sourcegraph-maintained extension repository, there are a few tests you'll need to pass before the request can be reviewed. These tests run logical tests that we author to make sure our code runs as expected.
+When submitting a pull request to Sourcegraph, there are a few tests you'll need to pass before the request can be reviewed. These tests run logical tests that we author to make sure our code runs as expected.
 
 ## What are the tests?
 - **Prettier** is responsible for mostly visual choices like if we have a line of code that's longer than 70 characters, it will fail. This has nothing to do with the correctness of the code, more of a stylistic choice we make as a team to make sure we all use the same standard.
 - **eslint** is similar but more so focused on the logic aspect of the code. We use eslint to avoid bad patterns which otherwise stylistically make sense but lead to potentially buggy code
 - **Husky** ([link](https://typicode.github.io/husky/#/)) and **Semantic Pull Requests** ([link](https://github.com/zeke/semantic-pull-requests)) ensure your commit messages have enough semantic information to be able to trigger a release. For example, `feat:` tag is for new features.
-- Update README.md and manifest accordingly
 
-## Run the following commands before submitting your Pull Request:
-1. `npm run prettier` : applies prettier to your code
-1. `npm run prettier-check`: checks if your code is passing the prettier checks
-1. `npm run eslint`: checks if your code is passing the eslint checks
+## Manual formatting and linting tools
 
+If you don't want to wait for CI to find out whether you've made a mistake, you can either use an editor or IDE that hooks itself up with prettier and eslint, _or_ use the following commands manually before submitting your pull request:
 
-## After the Pull Request has been submitted:
-1. Add `team/extensibility` to label
-2. Edit the PR title by adding a semantic prefix like `fix:` or `feat:` to the front. See more examples on our [GitHub Pull Requests](https://github.com/sourcegraph/sourcegraph-vscode/pulls) page.
+1. `yarn format` : applies prettier to your code (takes about 30s to run)
+1. `yarn format:check`: checks if your code is passing the prettier checks (takes about 30s to run)
+1. `yarn eslint`: checks if your code is passing the eslint checks (takes about 2s to run)


### PR DESCRIPTION
I wondered how to run `prettier` manually.
Searched the docs for "prettier", got four hits: https://docs.sourcegraph.com/search?q=prettier&v=
This page was the only one that mentioned running prettier manually: https://docs.sourcegraph.com/dev/background-information/testing_pr

It was a page for extension developers, but this audience was not specified anywhere, not even the folder structure.
We don't have extensions anymore, plus the commands didn't work, so I've looked up the correct commands in `package.json` and re-worded the page to talk to all devs.

The next time I'm wondering how to run prettier, this page would help me.

## Test plan

Just a docs change, no testing is needed besides another pair of eyes reading through it.