### PR TITLE
add --name-only flag before span is started 

### DIFF
--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -1502,6 +1502,7 @@ func (c *clientImplementor) Commits(ctx context.Context, repo api.RepoName, opt 
 		return Mocks.Commits(repo, opt)
 	}
 
+	opt = addNameOnly(opt, checker)
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: Commits")
 	span.SetTag("Opt", opt)
 	defer span.Finish()
@@ -1509,7 +1510,6 @@ func (c *clientImplementor) Commits(ctx context.Context, repo api.RepoName, opt 
 	if err := checkSpecArgSafety(opt.Range); err != nil {
 		return nil, err
 	}
-	opt = addNameOnly(opt, checker)
 	return c.commitLog(ctx, repo, opt, checker)
 }
 


### PR DESCRIPTION
add --name-only flag before span is started to ensure it is correctly set in the span tag

Noticed while looking at a trace for a request that should have sub-repo perms enabled and `--name-only` was `false`. 



## Test plan

Existing unit tests passing is sufficient
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
