### PR TITLE
sg: add pidfile

### DIFF
--- a/dev/sg/internal/run/pid.go
+++ b/dev/sg/internal/run/pid.go
@@ -1,0 +1,118 @@
+package run
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/interrupt"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"k8s.io/utils/strings/slices"
+)
+
+type pidFile struct {
+	Args []string `json:"args"`
+	Pid  int      `json:"pid"`
+}
+
+func PidExistsWithArgs(args []string) (int, bool, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return 0, false, errors.Wrap(err, "could not check pidfiles")
+	}
+
+	pattern := filepath.Join(homeDir, ".sourcegraph", "sg.pid.*")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return 0, false, errors.Wrap(err, "could not list pidfiles")
+	}
+
+	for _, match := range matches {
+		f, err := os.Open(match)
+		if err != nil {
+			return 0, false, errors.Wrapf(err, "could not check pidfile %q", match)
+		}
+		defer f.Close()
+
+		var content pidFile
+		if err := json.NewDecoder(f).Decode(&content); err != nil {
+			return 0, false, errors.Wrapf(err, "could not check pidfile %q", match)
+		}
+
+		if slices.Equal(content.Args, args) {
+			// If a pid already exists, let's check if it's still running.
+			alive, err := isPidAlive(int32(content.Pid))
+			if err != nil {
+				return 0, true, errors.Wrapf(err, "could not check if pid %d is alive", content.Pid)
+			}
+			if !alive {
+				// Trash the pidfile and return that it's not running.
+				_ = os.Remove(match)
+			}
+			return content.Pid, true, nil
+		}
+	}
+
+	return 0, false, nil
+}
+
+// On Unix systems, os.FindProcess always returns a os.Proc, regardless if the process is running or not. Therefore,
+// we need more work to check if it's alive or not.
+// Reference: https://github.com/shirou/gopsutil/blob/c141152a7b8f59b63e060fa8450f5cd5e7196dfb/process/process_posix.go#L73
+func isPidAlive(pid int32) (bool, error) {
+	if pid <= 0 {
+		return false, fmt.Errorf("invalid pid %v", pid)
+	}
+	proc, err := os.FindProcess(int(pid))
+	if err != nil {
+		return false, err
+	}
+	err = proc.Signal(syscall.Signal(0))
+	if err == nil {
+		return true, nil
+	}
+	if err.Error() == "os: process already finished" {
+		return false, nil
+	}
+	errno, ok := err.(syscall.Errno)
+	if !ok {
+		return false, err
+	}
+	switch errno {
+	case syscall.ESRCH:
+		return false, nil
+	case syscall.EPERM:
+		return true, nil
+	}
+	return false, err
+}
+
+func writePid() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	pidFileName := fmt.Sprintf("sg.pid.%d.json", os.Getpid())
+	pidFilePath := filepath.Join(homeDir, ".sourcegraph", pidFileName)
+
+	content := pidFile{
+		Args: os.Args[1:],
+		Pid:  os.Getpid(),
+	}
+
+	b, err := json.Marshal(content)
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(pidFilePath, b, 0644); err != nil {
+		return err
+	}
+
+	interrupt.Register(func() { os.Remove(pidFilePath) })
+
+	return nil
+}

--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/grafana/regexp"
@@ -35,36 +36,77 @@ type pidFile struct {
 	Pid  int      `json:"pid"`
 }
 
-func PidExistsWithArgs(args []string) (int, bool) {
+func PidExistsWithArgs(args []string) (int, bool, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return 0, false
+		return 0, false, errors.Wrap(err, "could not check pidfiles")
 	}
 
 	pattern := filepath.Join(homeDir, ".sourcegraph", "sg.pid.*")
 	matches, err := filepath.Glob(pattern)
 	if err != nil {
-		return 0, false
+		return 0, false, errors.Wrap(err, "could not list pidfiles")
 	}
 
 	for _, match := range matches {
 		f, err := os.Open(match)
 		if err != nil {
-			return 0, false
+			return 0, false, errors.Wrapf(err, "could not check pidfile %q", match)
 		}
 		defer f.Close()
 
 		var content pidFile
 		if err := json.NewDecoder(f).Decode(&content); err != nil {
-			return 0, false
+			return 0, false, errors.Wrapf(err, "could not check pidfile %q", match)
 		}
 
 		if slices.Equal(content.Args, args) {
-			return content.Pid, true
+			// If a pid already exists, let's check if it's still running.
+			alive, err := isPidAlive(int32(content.Pid))
+			if err != nil {
+				return 0, true, errors.Wrapf(err, "could not check if pid %d is alive", content.Pid)
+			}
+			if !alive {
+				// Trash the pidfile and return that it's not running.
+				_ = os.Remove(match)
+				return 0, false, nil
+			}
+			return content.Pid, true, nil
 		}
 	}
 
-	return 0, false
+	return 0, false, nil
+}
+
+// On Unix systems, os.FindProcess always returns a os.Proc, regardless if the process is running or not. Therefore,
+// we need more work to check if it's alive or not.
+// Reference: https://github.com/shirou/gopsutil/blob/c141152a7b8f59b63e060fa8450f5cd5e7196dfb/process/process_posix.go#L73
+func isPidAlive(pid int32) (bool, error) {
+	if pid <= 0 {
+		return false, fmt.Errorf("invalid pid %v", pid)
+	}
+	proc, err := os.FindProcess(int(pid))
+	if err != nil {
+		return false, err
+	}
+	err = proc.Signal(syscall.Signal(0))
+	if err == nil {
+		return true, nil
+	}
+	if err.Error() == "os: process already finished" {
+		return false, nil
+	}
+	errno, ok := err.(syscall.Errno)
+	if !ok {
+		return false, err
+	}
+	switch errno {
+	case syscall.ESRCH:
+		return false, nil
+	case syscall.EPERM:
+		return true, nil
+	}
+	return false, err
 }
 
 func writePid() error {

--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -69,7 +69,6 @@ func PidExistsWithArgs(args []string) (int, bool, error) {
 			if !alive {
 				// Trash the pidfile and return that it's not running.
 				_ = os.Remove(match)
-				return 0, false, nil
 			}
 			return content.Pid, true, nil
 		}

--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -132,8 +132,6 @@ type cmdRunner struct {
 
 	repositoryRoot string
 	parentEnv      map[string]string
-
-	processes map[string]int
 }
 
 func (c *cmdRunner) runAndWatch(ctx context.Context, cmd Command, reload <-chan struct{}) error {

--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -3,7 +3,6 @@ package run
 import (
 	"context"
 	"crypto/md5"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -12,13 +11,11 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/grafana/regexp"
 	"github.com/rjeczalik/notify"
 	"golang.org/x/sync/semaphore"
-	"k8s.io/utils/strings/slices"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/analytics"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
@@ -30,111 +27,6 @@ import (
 )
 
 const MAX_CONCURRENT_BUILD_PROCS = 4
-
-type pidFile struct {
-	Args []string `json:"args"`
-	Pid  int      `json:"pid"`
-}
-
-func PidExistsWithArgs(args []string) (int, bool, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return 0, false, errors.Wrap(err, "could not check pidfiles")
-	}
-
-	pattern := filepath.Join(homeDir, ".sourcegraph", "sg.pid.*")
-	matches, err := filepath.Glob(pattern)
-	if err != nil {
-		return 0, false, errors.Wrap(err, "could not list pidfiles")
-	}
-
-	for _, match := range matches {
-		f, err := os.Open(match)
-		if err != nil {
-			return 0, false, errors.Wrapf(err, "could not check pidfile %q", match)
-		}
-		defer f.Close()
-
-		var content pidFile
-		if err := json.NewDecoder(f).Decode(&content); err != nil {
-			return 0, false, errors.Wrapf(err, "could not check pidfile %q", match)
-		}
-
-		if slices.Equal(content.Args, args) {
-			// If a pid already exists, let's check if it's still running.
-			alive, err := isPidAlive(int32(content.Pid))
-			if err != nil {
-				return 0, true, errors.Wrapf(err, "could not check if pid %d is alive", content.Pid)
-			}
-			if !alive {
-				// Trash the pidfile and return that it's not running.
-				_ = os.Remove(match)
-			}
-			return content.Pid, true, nil
-		}
-	}
-
-	return 0, false, nil
-}
-
-// On Unix systems, os.FindProcess always returns a os.Proc, regardless if the process is running or not. Therefore,
-// we need more work to check if it's alive or not.
-// Reference: https://github.com/shirou/gopsutil/blob/c141152a7b8f59b63e060fa8450f5cd5e7196dfb/process/process_posix.go#L73
-func isPidAlive(pid int32) (bool, error) {
-	if pid <= 0 {
-		return false, fmt.Errorf("invalid pid %v", pid)
-	}
-	proc, err := os.FindProcess(int(pid))
-	if err != nil {
-		return false, err
-	}
-	err = proc.Signal(syscall.Signal(0))
-	if err == nil {
-		return true, nil
-	}
-	if err.Error() == "os: process already finished" {
-		return false, nil
-	}
-	errno, ok := err.(syscall.Errno)
-	if !ok {
-		return false, err
-	}
-	switch errno {
-	case syscall.ESRCH:
-		return false, nil
-	case syscall.EPERM:
-		return true, nil
-	}
-	return false, err
-}
-
-func writePid() error {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-
-	pidFileName := fmt.Sprintf("sg.pid.%d.json", os.Getpid())
-	pidFilePath := filepath.Join(homeDir, ".sourcegraph", pidFileName)
-
-	content := pidFile{
-		Args: os.Args[1:],
-		Pid:  os.Getpid(),
-	}
-
-	b, err := json.Marshal(content)
-	if err != nil {
-		return err
-	}
-
-	if err := os.WriteFile(pidFilePath, b, 0644); err != nil {
-		return err
-	}
-
-	interrupt.Register(func() { os.Remove(pidFilePath) })
-
-	return nil
-}
 
 func Commands(ctx context.Context, parentEnv map[string]string, verbose bool, cmds ...Command) error {
 	chs := make([]<-chan struct{}, 0, len(cmds))

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -167,8 +167,8 @@ func startExec(ctx *cli.Context) error {
 	}
 
 	if pid, exists := run.PidExistsWithArgs(os.Args[1:]); exists {
-		std.Out.WriteAlertf("Found 'sg %s' already running. Process: %d", strings.Join(os.Args[1:], " "), pid)
-		return errors.New("no double sg allowed")
+		std.Out.WriteAlertf("Found 'sg %s' already running with the same arguments. Process: %d", strings.Join(os.Args[1:], " "), pid)
+		return errors.New("no concurrent sg start with same arguments allowed")
 	}
 
 	commandset := args[0]

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -166,6 +166,11 @@ func startExec(ctx *cli.Context) error {
 		}
 	}
 
+	if pid, exists := run.PidExistsWithArgs(os.Args[1:]); exists {
+		std.Out.WriteAlertf("Found 'sg %s' already running. Process: %d", strings.Join(os.Args[1:], " "), pid)
+		return errors.New("no double sg allowed")
+	}
+
 	commandset := args[0]
 	set, ok := config.Commandsets[commandset]
 	if !ok {

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -166,7 +166,12 @@ func startExec(ctx *cli.Context) error {
 		}
 	}
 
-	if pid, exists := run.PidExistsWithArgs(os.Args[1:]); exists {
+	pid, exists, err := run.PidExistsWithArgs(os.Args[1:])
+	if err != nil {
+		std.Out.WriteAlertf("Could not check if 'sg %s' is already running with the same arguments. Process: %d", strings.Join(os.Args[1:], " "), pid)
+		return errors.Wrap(err, "Failed to check if sg is already running with the same arguments or not.")
+	}
+	if exists {
 		std.Out.WriteAlertf("Found 'sg %s' already running with the same arguments. Process: %d", strings.Join(os.Args[1:], " "), pid)
 		return errors.New("no concurrent sg start with same arguments allowed")
 	}


### PR DESCRIPTION
TODOs:

- [x] Do not stop process startup if processes in pid files are dead (because they crashed and didn't clean up pidfile)

## Test plan

- Manually tested during SG hacking hour 
- (@jhchabran) Manually tested the pid purging scenario
  - `sg start otel` 
  - `cp ~/.sourcegraph/sg.pid.*.json ~`
  - kill sg 
  - `ls ~/.sourcegraph/sg.pid.*.json` got nothing, good 
  - `cp ~/sg.pid.*.json ~/.sourcegraph/` 
  - `sg start otel` saw my `println` saying it got trashed 
  - starts fine even with the existing file (and a new one is created).  