### PR TITLE
Add chart about what happens to entities when user/org is deleted

### DIFF
--- a/doc/admin/user_data_deletion.md
+++ b/doc/admin/user_data_deletion.md
@@ -16,3 +16,17 @@ When deleting a user with either option, the following information is removed:
 - Bulk operations on changesets and batch changes created by the user.
 
 > WARNING: If deleted and recreated a user will no longer have access to the configurations and customizations they may have made for their old account. The database will store information about their previous configuration, but a user associated with a new `id` in the `users` table in PostgreSQL will be created. For example, site admin privileges will have to be re-assigned if a once site admin user is deleted and recreated. 
+
+## Entities deletion
+
+When a user or organization is deleted, here is what happens to their entities: 
+
+| Entity | Deleted when you delete the creator? | Details |
+| ------ | ------------------------------------ | ------- |
+| Batch Change | Yes | If you delete the user or organization that owns the batch change, it gets deleted from our database and no longer appears in the UI. |
+| Code Insight chart | Sometimes | Private insights never shared with others are deleted. Insights shared to org-visible or global dashboards persist as long as the org and global dashboard continue to exist. |
+| Code Insight dashboard | Sometimes | If the dashboard was private to the user it is deleted on the user deletion; if it was private to the org it is deleted on the org deletion. If it was a global dashboard, it will continue to exist. |
+| Code Monitor | Yes | If the user that created the code monitor is deleted, their code monitors are deleted and will no longer trigger new actions. |
+| Search Notebook | Yes | If you delete the user or organization that owns the notebook, it no longer appears in the UI. In the organization-owned case, it's still preserved in the database. |
+| Search Context | Yes | If you delete the user or organization that owns the context, it no longer appears in the UI. |
+| Settings file (extensions, experimental features, defaults) | Yes | If you delete the user organization, the associated settings file is deleted. |

--- a/doc/admin/user_data_deletion.md
+++ b/doc/admin/user_data_deletion.md
@@ -19,14 +19,14 @@ When deleting a user with either option, the following information is removed:
 
 ## Entities deletion
 
-When a user or organization is deleted, here is what happens to their entities: 
+When a user or organization is deleted (for both "delete" or "delete forever"), here is what happens to their entities: 
 
 | Entity | Deleted when you delete the creator? | Details |
 | ------ | ------------------------------------ | ------- |
-| Batch Change | Yes | If you delete the user or organization that owns the batch change, it gets deleted from our database and no longer appears in the UI. |
+| Batch Change | Yes | If you delete the user or organization that owns the batch change, the batch change and all associated information gets deleted from our database and no longer appears in the UI. |
 | Code Insight chart | Sometimes | Private insights never shared with others are deleted. Insights shared to org-visible or global dashboards persist as long as the org and global dashboard continue to exist. |
 | Code Insight dashboard | Sometimes | If the dashboard was private to the user it is deleted on the user deletion; if it was private to the org it is deleted on the org deletion. If it was a global dashboard, it will continue to exist. |
 | Code Monitor | Yes | If the user that created the code monitor is deleted, their code monitors are deleted and will no longer trigger new actions. |
 | Search Notebook | Yes | If you delete the user or organization that owns the notebook, it no longer appears in the UI. In the organization-owned case, it's still preserved in the database. |
-| Search Context | Yes | If you delete the user or organization that owns the context, it no longer appears in the UI. |
-| Settings file (extensions, experimental features, defaults) | Yes | If you delete the user organization, the associated settings file is deleted. |
+| Search Context | Yes | If you delete the user or organization that owns the context, it no longer appears in the UI.  In cases where it was an organization notebook, it is preserved in the database. |
+| Settings file (extensions, experimental features, defaults) | Yes | If you delete the user or organization, the associated settings file is deleted. |


### PR DESCRIPTION
Originally [collected here](https://docs.google.com/spreadsheets/d/1yD6FQyfUOhtU-PyqdXQ27TdevgKJXhNWXRHVAo2bp0k/edit#gid=0) and [requested docs here.](https://sourcegraph.slack.com/archives/C0W2E592M/p1663364199125809?thread_ts=1663361531.173799&cid=C0W2E592M). We frequently get a lot of customer questions about this when they need to delete users, like from [this strategic customer](https://sourcegraph.slack.com/archives/C0W2E592M/p1663361674402709?thread_ts=1663361531.173799&cid=C0W2E592M). 

## Test plan

Reviewed manually, screenshot: 

![image](https://user-images.githubusercontent.com/11967660/193315975-d840fdb8-6b7e-4b88-82d7-cf02f1fa4d84.png)
