### PR TITLE
insights: Add hasCodeInsights to window context

### DIFF
--- a/cmd/frontend/hooks/hooks.go
+++ b/cmd/frontend/hooks/hooks.go
@@ -12,7 +12,8 @@ var PostAuthMiddleware func(http.Handler) http.Handler
 // LicenseInfo contains information about the legitimate usage of the current
 // license on the instance.
 type LicenseInfo struct {
-	CurrentPlan string `json:"currentPlan"`
+	CurrentPlan     string `json:"currentPlan"`
+	HasCodeInsights bool   `json:"hasCodeInsights"`
 
 	CodeScaleLimit         string `json:"codeScaleLimit"`
 	CodeScaleCloseToLimit  bool   `json:"codeScaleCloseToLimit"`

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -56,8 +56,15 @@ func Init(ctx context.Context, db database.DB, conf conftypes.UnifiedWatchable, 
 			return nil
 		}
 
+		hasCodeInsights := false
+		licenseErrorHasCodeInsights := licensing.Check(licensing.FeatureCodeInsights)
+		if licenseErrorHasCodeInsights == nil {
+			hasCodeInsights = true
+		}
+
 		licenseInfo := &hooks.LicenseInfo{
-			CurrentPlan: string(info.Plan()),
+			CurrentPlan:     string(info.Plan()),
+			HasCodeInsights: hasCodeInsights,
 		}
 		if info.Plan() == licensing.PlanBusiness0 {
 			const codeScaleLimit = 100 * 1024 * 1024 * 1024


### PR DESCRIPTION
## Description

Should we add this? The motivation being for devx on the frontend.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
