### PR TITLE
conf: make 'email.smtp.username' a secret

### DIFF
--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -206,6 +206,7 @@ var siteConfigSecrets = []struct {
 	editPaths []string
 }{
 	{readPath: `executors\.accessToken`, editPaths: []string{"executors.accessToken"}},
+	{readPath: `email\.smtp.username`, editPaths: []string{"email.smtp", "username"}},
 	{readPath: `email\.smtp.password`, editPaths: []string{"email.smtp", "password"}},
 	{readPath: `organizationInvitations.signingKey`, editPaths: []string{"organizationInvitations", "signingKey"}},
 	{readPath: `githubClientSecret`, editPaths: []string{"githubClientSecret"}},

--- a/internal/conf/validate_test.go
+++ b/internal/conf/validate_test.go
@@ -387,6 +387,7 @@ func getTestSiteWithSecrets(
   },
   "externalService.userMode": "all",
   "email.smtp": {
+    "username": "%s",
     "password": "%s"
   },
   "organizationInvitations": {
@@ -410,6 +411,7 @@ func getTestSiteWithSecrets(
 		email,
 		executorsAccessToken,
 		authOpenIDClientSecret, authGitHubClientSecret, authGitLabClientSecret,
+		emailSMTPPassword, // used again as username
 		emailSMTPPassword,
 		organizationInvitationsSigningKey,
 		githubClientSecret,


### PR DESCRIPTION
It seems certain services like Postmark ask us to use an access token as both the username and the password when connecting to their SMTP servers.

Postmark allows a workaround to generate a token for a non-sensititve username but it does not appear available through the API, which means we cannot leverage it for Cloud - I've reached out to their support regarding this. Postmark so far appears to be the best service for Cloud needs regardless ([RFC 705](https://docs.google.com/document/d/1eaShaXlpMEezawuwTZ26nuo5g_1MjQmjpp8VvQTokzw/edit#heading=h.v3ytfg49xrgm)) so I'd like to accommodate their requirements by making `email.smtp.username` a secret on our end.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

unit tests