### PR TITLE
snap cursor to pattern if one exists in the search query

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -72,10 +72,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
     onChange,
     onSubmit,
     autoFocus,
-    onFocus = () => {
-        console.log(queryState.query)
-        console.log(queryState.query)
-    },
+    onFocus,
     onBlur,
     isSourcegraphDotCom,
     globbing,

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -245,10 +245,10 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
         }
 
         const query = editor.state.facet(queryTokens)
-        let patternFilterIdx = -1 //= query.tokens.lastIndexOf(a => a.type === 'pattern')
+        let patternFilterIdx = -1
         for (let i = 0; i < query.tokens.length; i++) {
-            // this is bad I know, this language makes me so sad
             let c = query.tokens[i] as Pattern
+            // it seems Pattern doesn't detect content:asdf fields
             if (c.type === 'pattern') {
                 patternFilterIdx = i
             }

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -246,7 +246,6 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
 
         const query = editor.state.facet(queryTokens)
         let patternFilterIdx = -1 //= query.tokens.lastIndexOf(a => a.type === 'pattern')
-
         for (let i = 0; i < query.tokens.length; i++) {
             // this is bad I know, this language makes me so sad
             let c = query.tokens[i] as Pattern
@@ -254,12 +253,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
                 patternFilterIdx = i
             }
         }
-        //           (token): token is Pattern =>
-        //                 // // Inclusive end so that the filter is highlighted when
-        //                 // // the cursor is positioned directly after the value
-        //                 token.type === 'pattern' // asdf
         if (patternFilterIdx !== -1) {
-            console.log("found pattern")
             editor.dispatch({
                 selection: EditorSelection.cursor(query.tokens[patternFilterIdx].range.end),
                 scrollIntoView: true
@@ -356,7 +350,6 @@ export const CodeMirrorQueryInput: React.FunctionComponent<
                     Prec.low([
                         tokenInfo(),
                         highlightFocusedFilter,
-                        selectContentFilter,
                         // It baffels me but the syntax highlighting extension has
                         // to come after the highlight current filter extension,
                         // otherwise CodeMirror keeps steeling the focus.
@@ -599,33 +592,6 @@ const highlightFocusedFilter = ViewPlugin.define(
     }),
     {
         decorations: plugin => plugin.decorations,
-    }
-)
-
-const selectContentFilter = ViewPlugin.define(
-    () => ({
-        sel: EditorSelection,
-        update(update: ViewUpdate) {
-            if (update.focusChanged && update.view.hasFocus) {
-                // do a thing
-                const query = update.state.facet(queryTokens)
-                // const position = update.state.selection.main.head
-                const focusedFilter = query.tokens.find(
-                    (token): token is Pattern =>
-                        // // Inclusive end so that the filter is highlighted when
-                        // // the cursor is positioned directly after the value
-                        token.type === 'pattern' // asdf
-                )
-                if (!focusedFilter) {
-                    return
-                }
-                console.log("findme")
-                this.sel = EditorSelection.cursor(focusedFilter.range.end)
-                console.log(this.sel)
-            }
-        }
-    }), {
-        selection: plugin => plugin.sel,
     }
 )
 


### PR DESCRIPTION
Something that always bothers me is after every search I have to rearrange my cursor to select the pattern if I want to iterate through different searches. This is incredibly tedious, so I wanted to see what life would be like if we pull the cursor to the pattern in the query if it exists.

This is just a hack PR - not even sure if this is good behavior yet. Just throwing out for some feedback.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-hack-search-query-autoselector.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

