### PR TITLE
Hide Sourcegraph operator login by default

### DIFF
--- a/client/web/src/auth/SignInPage.test.tsx
+++ b/client/web/src/auth/SignInPage.test.tsx
@@ -1,3 +1,4 @@
+import { within } from '@testing-library/dom'
 import { Route, Routes } from 'react-router-dom-v5-compat'
 
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
@@ -47,6 +48,102 @@ describe('SignInPage', () => {
                 { route: '/sign-in' }
             ).asFragment()
         ).toMatchSnapshot()
+    })
+
+    describe('with Sourcegraph auth provider', () => {
+        const withSourcegraphOperator: SourcegraphContext['authProviders'] = [
+            ...authProviders,
+            {
+                displayName: 'Sourcegraph Employee',
+                isBuiltin: false,
+                serviceType: 'openidconnect',
+                authenticationURL: '',
+            },
+        ]
+
+        it('renders page with 3 providers (experimentalFeature disabled)', () => {
+            const rendered = renderWithBrandedContext(
+                <Routes>
+                    <Route
+                        path="/sign-in"
+                        element={
+                            <SignInPage
+                                authenticatedUser={null}
+                                context={{
+                                    allowSignup: true,
+                                    sourcegraphDotComMode: false,
+                                    authProviders: withSourcegraphOperator,
+                                    resetPasswordEnabled: true,
+                                    xhrHeaders: {},
+                                    experimentalFeatures: {},
+                                }}
+                            />
+                        }
+                    />
+                </Routes>,
+                { route: '/sign-in' }
+            )
+            expect(
+                within(rendered.baseElement).queryByText(txt => txt.includes('Sourcegraph Employee'))
+            ).toBeInTheDocument()
+            expect(rendered.asFragment()).toMatchSnapshot()
+        })
+
+        it('renders page with 2 providers (experimentalFeature enabled)', () => {
+            const rendered = renderWithBrandedContext(
+                <Routes>
+                    <Route
+                        path="/sign-in"
+                        element={
+                            <SignInPage
+                                authenticatedUser={null}
+                                context={{
+                                    allowSignup: true,
+                                    sourcegraphDotComMode: false,
+                                    authProviders: withSourcegraphOperator,
+                                    resetPasswordEnabled: true,
+                                    xhrHeaders: {},
+                                    experimentalFeatures: { hideSourcegraphOperatorLogin: true },
+                                }}
+                            />
+                        }
+                    />
+                </Routes>,
+                { route: '/sign-in' }
+            )
+            expect(
+                within(rendered.baseElement).queryByText(txt => txt.includes('Sourcegraph Employee'))
+            ).not.toBeInTheDocument()
+            expect(rendered.asFragment()).toMatchSnapshot()
+        })
+
+        it('renders page with 3 providers (experimentalFeature enabled & url-param present)', () => {
+            const rendered = renderWithBrandedContext(
+                <Routes>
+                    <Route
+                        path="/sign-in"
+                        element={
+                            <SignInPage
+                                authenticatedUser={null}
+                                context={{
+                                    allowSignup: true,
+                                    sourcegraphDotComMode: false,
+                                    authProviders: withSourcegraphOperator,
+                                    resetPasswordEnabled: true,
+                                    xhrHeaders: {},
+                                    experimentalFeatures: { hideSourcegraphOperatorLogin: true },
+                                }}
+                            />
+                        }
+                    />
+                </Routes>,
+                { route: '/sign-in?sourcegraph-operator' }
+            )
+            expect(
+                within(rendered.baseElement).queryByText(txt => txt.includes('Sourcegraph Employee'))
+            ).toBeInTheDocument()
+            expect(rendered.asFragment()).toMatchSnapshot()
+        })
     })
 
     it('renders sign in page (cloud)', () => {

--- a/client/web/src/auth/SignInPage.test.tsx
+++ b/client/web/src/auth/SignInPage.test.tsx
@@ -38,6 +38,7 @@ describe('SignInPage', () => {
                                     authProviders,
                                     resetPasswordEnabled: true,
                                     xhrHeaders: {},
+                                    experimentalFeatures: {},
                                 }}
                             />
                         }
@@ -63,6 +64,7 @@ describe('SignInPage', () => {
                                     authProviders,
                                     resetPasswordEnabled: true,
                                     xhrHeaders: {},
+                                    experimentalFeatures: {},
                                 }}
                             />
                         }
@@ -96,6 +98,7 @@ describe('SignInPage', () => {
                                     authProviders,
                                     xhrHeaders: {},
                                     resetPasswordEnabled: true,
+                                    experimentalFeatures: {},
                                 }}
                             />
                         }

--- a/client/web/src/auth/SignInPage.test.tsx
+++ b/client/web/src/auth/SignInPage.test.tsx
@@ -51,38 +51,9 @@ describe('SignInPage', () => {
     })
 
     describe('with Sourcegraph auth provider', () => {
-        const withSourcegraphOperator: SourcegraphContext['authProviders'] = [
-            ...authProviders,
-            {
-                displayName: 'Sourcegraph Employee',
-                isBuiltin: false,
-                serviceType: 'openidconnect',
-                authenticationURL: '',
-            },
-        ]
-
         it('renders page with 3 providers (experimentalFeature disabled)', () => {
-            const rendered = renderWithBrandedContext(
-                <Routes>
-                    <Route
-                        path="/sign-in"
-                        element={
-                            <SignInPage
-                                authenticatedUser={null}
-                                context={{
-                                    allowSignup: true,
-                                    sourcegraphDotComMode: false,
-                                    authProviders: withSourcegraphOperator,
-                                    resetPasswordEnabled: true,
-                                    xhrHeaders: {},
-                                    experimentalFeatures: {},
-                                }}
-                            />
-                        }
-                    />
-                </Routes>,
-                { route: '/sign-in' }
-            )
+            const rendered = render(false, '/sign-in')
+
             expect(
                 within(rendered.baseElement).queryByText(txt => txt.includes('Sourcegraph Employee'))
             ).toBeInTheDocument()
@@ -90,27 +61,7 @@ describe('SignInPage', () => {
         })
 
         it('renders page with 2 providers (experimentalFeature enabled)', () => {
-            const rendered = renderWithBrandedContext(
-                <Routes>
-                    <Route
-                        path="/sign-in"
-                        element={
-                            <SignInPage
-                                authenticatedUser={null}
-                                context={{
-                                    allowSignup: true,
-                                    sourcegraphDotComMode: false,
-                                    authProviders: withSourcegraphOperator,
-                                    resetPasswordEnabled: true,
-                                    xhrHeaders: {},
-                                    experimentalFeatures: { hideSourcegraphOperatorLogin: true },
-                                }}
-                            />
-                        }
-                    />
-                </Routes>,
-                { route: '/sign-in' }
-            )
+            const rendered = render(true, '/sign-in')
             expect(
                 within(rendered.baseElement).queryByText(txt => txt.includes('Sourcegraph Employee'))
             ).not.toBeInTheDocument()
@@ -118,7 +69,25 @@ describe('SignInPage', () => {
         })
 
         it('renders page with 3 providers (experimentalFeature enabled & url-param present)', () => {
-            const rendered = renderWithBrandedContext(
+            const rendered = render(true, '/sign-in?sourcegraph-operator')
+            expect(
+                within(rendered.baseElement).queryByText(txt => txt.includes('Sourcegraph Employee'))
+            ).toBeInTheDocument()
+            expect(rendered.asFragment()).toMatchSnapshot()
+        })
+
+        function render(hideSourcegraphOperatorLogin: boolean, route: string) {
+            const withSourcegraphOperator: SourcegraphContext['authProviders'] = [
+                ...authProviders,
+                {
+                    displayName: 'Sourcegraph Employee',
+                    isBuiltin: false,
+                    serviceType: 'openidconnect',
+                    authenticationURL: '',
+                },
+            ]
+
+            return renderWithBrandedContext(
                 <Routes>
                     <Route
                         path="/sign-in"
@@ -131,19 +100,15 @@ describe('SignInPage', () => {
                                     authProviders: withSourcegraphOperator,
                                     resetPasswordEnabled: true,
                                     xhrHeaders: {},
-                                    experimentalFeatures: { hideSourcegraphOperatorLogin: true },
+                                    experimentalFeatures: { hideSourcegraphOperatorLogin },
                                 }}
                             />
                         }
                     />
                 </Routes>,
-                { route: '/sign-in?sourcegraph-operator' }
+                { route }
             )
-            expect(
-                within(rendered.baseElement).queryByText(txt => txt.includes('Sourcegraph Employee'))
-            ).toBeInTheDocument()
-            expect(rendered.asFragment()).toMatchSnapshot()
-        })
+        }
     })
 
     it('renders sign in page (cloud)', () => {

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -11,7 +11,7 @@ import { Alert, Icon, Text, Link, AnchorLink, Button } from '@sourcegraph/wildca
 import { AuthenticatedUser } from '../auth'
 import { HeroPage } from '../components/HeroPage'
 import { PageTitle } from '../components/PageTitle'
-import { SourcegraphContext } from '../jscontext'
+import { AuthProvider, SourcegraphContext } from '../jscontext'
 import { eventLogger } from '../tracking/eventLogger'
 
 import { SourcegraphIcon } from './icons'
@@ -34,15 +34,23 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
 
     const location = useLocation()
     const [error, setError] = useState<Error | null>(null)
+    const showSourcegraphOperatorLogin = new URLSearchParams(location.search).has('sourcegraph-operator')
+
+    const isSourcegraphOperatorProvider = (provider: AuthProvider): boolean =>
+        provider.serviceType === 'openidconnect' && provider.displayName === 'Sourcegraph Employee'
 
     if (props.authenticatedUser) {
         const returnTo = getReturnTo(location)
         return <Navigate to={returnTo} replace={true} />
     }
 
-    const [[builtInAuthProvider], thirdPartyAuthProviders] = partition(
+    const [[builtInAuthProvider], nonBuiltinAuthProviders] = partition(
         props.context.authProviders,
         provider => provider.isBuiltin
+    )
+
+    const thirdPartyAuthProviders = nonBuiltinAuthProviders.filter(
+        provider => showSourcegraphOperatorLogin || !isSourcegraphOperatorProvider(provider)
     )
 
     const body =

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -25,7 +25,12 @@ interface SignInPageProps {
     authenticatedUser: AuthenticatedUser | null
     context: Pick<
         SourcegraphContext,
-        'allowSignup' | 'authProviders' | 'sourcegraphDotComMode' | 'xhrHeaders' | 'resetPasswordEnabled'
+        | 'allowSignup'
+        | 'authProviders'
+        | 'sourcegraphDotComMode'
+        | 'xhrHeaders'
+        | 'resetPasswordEnabled'
+        | 'experimentalFeatures'
     >
 }
 
@@ -34,7 +39,11 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
 
     const location = useLocation()
     const [error, setError] = useState<Error | null>(null)
-    const showSourcegraphOperatorLogin = new URLSearchParams(location.search).has('sourcegraph-operator')
+
+    const isOperatorHidingEnabled = props.context.experimentalFeatures.hideSourcegraphOperatorLogin ?? false
+
+    const showSourcegraphOperatorLogin =
+        !isOperatorHidingEnabled || new URLSearchParams(location.search).has('sourcegraph-operator')
 
     const isSourcegraphOperatorProvider = (provider: AuthProvider): boolean =>
         provider.serviceType === 'openidconnect' && provider.displayName === 'Sourcegraph Employee'

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -359,3 +359,551 @@ exports[`SignInPage renders sign in page (server) 1`] = `
   </div>
 </DocumentFragment>
 `;
+
+exports[`SignInPage with Sourcegraph auth provider renders page with 2 providers (experimentalFeature enabled) 1`] = `
+<DocumentFragment>
+  <div
+    class="signinSignupPage"
+  >
+    <div
+      class="heroPage lessPadding"
+    >
+      <div
+        class="iconWrapper bg-transparent"
+      >
+        <svg
+          aria-hidden="true"
+          class="mdi-icon iconInline icon"
+          fill="none"
+          height="64"
+          role="img"
+          viewBox="0 0 52 52"
+          width="65"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M30.8 51.8c-2.8.5-5.5-1.3-6-4.1L17.2 6.2c-.5-2.8 1.3-5.5 4.1-6s5.5 1.3 6 4.1l7.6 41.5c.5 2.8-1.4 5.5-4.1 6z"
+            fill="#FF5543"
+          />
+          <path
+            d="M10.9 44.7C9.1 45 7.3 44.4 6 43c-1.8-2.2-1.6-5.4.6-7.2L38.7 8.5c2.2-1.8 5.4-1.6 7.2.6 1.8 2.2 1.6 5.4-.6 7.2l-32 27.3c-.7.6-1.6 1-2.4 1.1z"
+            fill="#A112FF"
+          />
+          <path
+            d="M46.8 38.1c-.9.2-1.8.1-2.6-.2L4.4 23.8c-2.7-1-4.1-3.9-3.1-6.6 1-2.7 3.9-4.1 6.6-3.1l39.7 14.1c2.7 1 4.1 3.9 3.1 6.6-.6 1.8-2.2 3-3.9 3.3z"
+            fill="#00CBEC"
+          />
+        </svg>
+      </div>
+      <h1
+        class="h1 title"
+      >
+        Sign in to Sourcegraph
+      </h1>
+      <div
+        class="mb-4 pb-5 signinPageContainer"
+      >
+        <div
+          class="test-signin-form rounded p-4 my-3 signinSignupForm mt-4"
+        >
+          <form
+            class=""
+          >
+            <label
+              class="label w-100 form-group"
+            >
+              <div
+                class="mb-2"
+              >
+                <p
+                  class="alignLeft"
+                >
+                  Username or email
+                </p>
+              </div>
+              <div
+                class="container loader-input loaderInput"
+              >
+                <input
+                  autocapitalize="off"
+                  autocomplete="username"
+                  class="form-control with-invalid-icon"
+                  id="username-or-email"
+                  required=""
+                  type="text"
+                  value=""
+                />
+              </div>
+            </label>
+            <div
+              class="form-group d-flex flex-column align-content-start position-relative"
+            >
+              <label
+                class="label align-self-start"
+                for="password"
+              >
+                Password
+              </label>
+              <div
+                class="container loader-input loaderInput"
+              >
+                <input
+                  autocomplete="current-password"
+                  class="form-control with-invalid-icon"
+                  id="password"
+                  name="password"
+                  placeholder=" "
+                  required=""
+                  type="password"
+                  value=""
+                />
+              </div>
+              <small
+                class="form-text text-muted align-self-end position-absolute"
+              >
+                <a
+                  class="anchorLink"
+                  href="/password-reset"
+                >
+                  Forgot password?
+                </a>
+              </small>
+            </div>
+            <div
+              class="form-group"
+            >
+              <button
+                class="btn btnPrimary btnBlock"
+                type="submit"
+              >
+                Sign in
+              </button>
+            </div>
+          </form>
+          <div
+            class="mb-3 py-1 d-flex align-items-center"
+          >
+            <div
+              class="w-100 border"
+            />
+            <small
+              class="px-2 text-muted "
+            >
+              OR
+            </small>
+            <div
+              class="w-100 border"
+            />
+          </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnSecondary btnBlock"
+              href="/.auth/github/login?pc=f00bar"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M12,2A10,10 0 0,0 2,12C2,16.42 4.87,20.17 8.84,21.5C9.34,21.58 9.5,21.27 9.5,21C9.5,20.77 9.5,20.14 9.5,19.31C6.73,19.91 6.14,17.97 6.14,17.97C5.68,16.81 5.03,16.5 5.03,16.5C4.12,15.88 5.1,15.9 5.1,15.9C6.1,15.97 6.63,16.93 6.63,16.93C7.5,18.45 8.97,18 9.54,17.76C9.63,17.11 9.89,16.67 10.17,16.42C7.95,16.17 5.62,15.31 5.62,11.5C5.62,10.39 6,9.5 6.65,8.79C6.55,8.54 6.2,7.5 6.75,6.15C6.75,6.15 7.59,5.88 9.5,7.17C10.29,6.95 11.15,6.84 12,6.84C12.85,6.84 13.71,6.95 14.5,7.17C16.41,5.88 17.25,6.15 17.25,6.15C17.8,7.5 17.45,8.54 17.35,8.79C18,9.5 18.38,10.39 18.38,11.5C18.38,15.32 16.04,16.16 13.81,16.41C14.17,16.72 14.5,17.33 14.5,18.26C14.5,19.6 14.5,20.68 14.5,21C14.5,21.27 14.66,21.59 15.17,21.5C19.14,20.16 22,16.42 22,12A10,10 0 0,0 12,2Z"
+                />
+              </svg>
+               Continue with GitHub
+            </a>
+          </div>
+        </div>
+        <p
+          class=""
+        >
+          New to Sourcegraph? 
+          <a
+            class="anchorLink"
+            href="/sign-up"
+          >
+            Sign up
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SignInPage with Sourcegraph auth provider renders page with 3 providers (experimentalFeature disabled) 1`] = `
+<DocumentFragment>
+  <div
+    class="signinSignupPage"
+  >
+    <div
+      class="heroPage lessPadding"
+    >
+      <div
+        class="iconWrapper bg-transparent"
+      >
+        <svg
+          aria-hidden="true"
+          class="mdi-icon iconInline icon"
+          fill="none"
+          height="64"
+          role="img"
+          viewBox="0 0 52 52"
+          width="65"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M30.8 51.8c-2.8.5-5.5-1.3-6-4.1L17.2 6.2c-.5-2.8 1.3-5.5 4.1-6s5.5 1.3 6 4.1l7.6 41.5c.5 2.8-1.4 5.5-4.1 6z"
+            fill="#FF5543"
+          />
+          <path
+            d="M10.9 44.7C9.1 45 7.3 44.4 6 43c-1.8-2.2-1.6-5.4.6-7.2L38.7 8.5c2.2-1.8 5.4-1.6 7.2.6 1.8 2.2 1.6 5.4-.6 7.2l-32 27.3c-.7.6-1.6 1-2.4 1.1z"
+            fill="#A112FF"
+          />
+          <path
+            d="M46.8 38.1c-.9.2-1.8.1-2.6-.2L4.4 23.8c-2.7-1-4.1-3.9-3.1-6.6 1-2.7 3.9-4.1 6.6-3.1l39.7 14.1c2.7 1 4.1 3.9 3.1 6.6-.6 1.8-2.2 3-3.9 3.3z"
+            fill="#00CBEC"
+          />
+        </svg>
+      </div>
+      <h1
+        class="h1 title"
+      >
+        Sign in to Sourcegraph
+      </h1>
+      <div
+        class="mb-4 pb-5 signinPageContainer"
+      >
+        <div
+          class="test-signin-form rounded p-4 my-3 signinSignupForm mt-4"
+        >
+          <form
+            class=""
+          >
+            <label
+              class="label w-100 form-group"
+            >
+              <div
+                class="mb-2"
+              >
+                <p
+                  class="alignLeft"
+                >
+                  Username or email
+                </p>
+              </div>
+              <div
+                class="container loader-input loaderInput"
+              >
+                <input
+                  autocapitalize="off"
+                  autocomplete="username"
+                  class="form-control with-invalid-icon"
+                  id="username-or-email"
+                  required=""
+                  type="text"
+                  value=""
+                />
+              </div>
+            </label>
+            <div
+              class="form-group d-flex flex-column align-content-start position-relative"
+            >
+              <label
+                class="label align-self-start"
+                for="password"
+              >
+                Password
+              </label>
+              <div
+                class="container loader-input loaderInput"
+              >
+                <input
+                  autocomplete="current-password"
+                  class="form-control with-invalid-icon"
+                  id="password"
+                  name="password"
+                  placeholder=" "
+                  required=""
+                  type="password"
+                  value=""
+                />
+              </div>
+              <small
+                class="form-text text-muted align-self-end position-absolute"
+              >
+                <a
+                  class="anchorLink"
+                  href="/password-reset"
+                >
+                  Forgot password?
+                </a>
+              </small>
+            </div>
+            <div
+              class="form-group"
+            >
+              <button
+                class="btn btnPrimary btnBlock"
+                type="submit"
+              >
+                Sign in
+              </button>
+            </div>
+          </form>
+          <div
+            class="mb-3 py-1 d-flex align-items-center"
+          >
+            <div
+              class="w-100 border"
+            />
+            <small
+              class="px-2 text-muted "
+            >
+              OR
+            </small>
+            <div
+              class="w-100 border"
+            />
+          </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnSecondary btnBlock"
+              href="/.auth/github/login?pc=f00bar"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M12,2A10,10 0 0,0 2,12C2,16.42 4.87,20.17 8.84,21.5C9.34,21.58 9.5,21.27 9.5,21C9.5,20.77 9.5,20.14 9.5,19.31C6.73,19.91 6.14,17.97 6.14,17.97C5.68,16.81 5.03,16.5 5.03,16.5C4.12,15.88 5.1,15.9 5.1,15.9C6.1,15.97 6.63,16.93 6.63,16.93C7.5,18.45 8.97,18 9.54,17.76C9.63,17.11 9.89,16.67 10.17,16.42C7.95,16.17 5.62,15.31 5.62,11.5C5.62,10.39 6,9.5 6.65,8.79C6.55,8.54 6.2,7.5 6.75,6.15C6.75,6.15 7.59,5.88 9.5,7.17C10.29,6.95 11.15,6.84 12,6.84C12.85,6.84 13.71,6.95 14.5,7.17C16.41,5.88 17.25,6.15 17.25,6.15C17.8,7.5 17.45,8.54 17.35,8.79C18,9.5 18.38,10.39 18.38,11.5C18.38,15.32 16.04,16.16 13.81,16.41C14.17,16.72 14.5,17.33 14.5,18.26C14.5,19.6 14.5,20.68 14.5,21C14.5,21.27 14.66,21.59 15.17,21.5C19.14,20.16 22,16.42 22,12A10,10 0 0,0 12,2Z"
+                />
+              </svg>
+               Continue with GitHub
+            </a>
+          </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnSecondary btnBlock"
+              href=""
+            >
+              Continue with Sourcegraph Employee
+            </a>
+          </div>
+        </div>
+        <p
+          class=""
+        >
+          New to Sourcegraph? 
+          <a
+            class="anchorLink"
+            href="/sign-up"
+          >
+            Sign up
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SignInPage with Sourcegraph auth provider renders page with 3 providers (experimentalFeature enabled & url-param present) 1`] = `
+<DocumentFragment>
+  <div
+    class="signinSignupPage"
+  >
+    <div
+      class="heroPage lessPadding"
+    >
+      <div
+        class="iconWrapper bg-transparent"
+      >
+        <svg
+          aria-hidden="true"
+          class="mdi-icon iconInline icon"
+          fill="none"
+          height="64"
+          role="img"
+          viewBox="0 0 52 52"
+          width="65"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M30.8 51.8c-2.8.5-5.5-1.3-6-4.1L17.2 6.2c-.5-2.8 1.3-5.5 4.1-6s5.5 1.3 6 4.1l7.6 41.5c.5 2.8-1.4 5.5-4.1 6z"
+            fill="#FF5543"
+          />
+          <path
+            d="M10.9 44.7C9.1 45 7.3 44.4 6 43c-1.8-2.2-1.6-5.4.6-7.2L38.7 8.5c2.2-1.8 5.4-1.6 7.2.6 1.8 2.2 1.6 5.4-.6 7.2l-32 27.3c-.7.6-1.6 1-2.4 1.1z"
+            fill="#A112FF"
+          />
+          <path
+            d="M46.8 38.1c-.9.2-1.8.1-2.6-.2L4.4 23.8c-2.7-1-4.1-3.9-3.1-6.6 1-2.7 3.9-4.1 6.6-3.1l39.7 14.1c2.7 1 4.1 3.9 3.1 6.6-.6 1.8-2.2 3-3.9 3.3z"
+            fill="#00CBEC"
+          />
+        </svg>
+      </div>
+      <h1
+        class="h1 title"
+      >
+        Sign in to Sourcegraph
+      </h1>
+      <div
+        class="mb-4 pb-5 signinPageContainer"
+      >
+        <div
+          class="test-signin-form rounded p-4 my-3 signinSignupForm mt-4"
+        >
+          <form
+            class=""
+          >
+            <label
+              class="label w-100 form-group"
+            >
+              <div
+                class="mb-2"
+              >
+                <p
+                  class="alignLeft"
+                >
+                  Username or email
+                </p>
+              </div>
+              <div
+                class="container loader-input loaderInput"
+              >
+                <input
+                  autocapitalize="off"
+                  autocomplete="username"
+                  class="form-control with-invalid-icon"
+                  id="username-or-email"
+                  required=""
+                  type="text"
+                  value=""
+                />
+              </div>
+            </label>
+            <div
+              class="form-group d-flex flex-column align-content-start position-relative"
+            >
+              <label
+                class="label align-self-start"
+                for="password"
+              >
+                Password
+              </label>
+              <div
+                class="container loader-input loaderInput"
+              >
+                <input
+                  autocomplete="current-password"
+                  class="form-control with-invalid-icon"
+                  id="password"
+                  name="password"
+                  placeholder=" "
+                  required=""
+                  type="password"
+                  value=""
+                />
+              </div>
+              <small
+                class="form-text text-muted align-self-end position-absolute"
+              >
+                <a
+                  class="anchorLink"
+                  href="/password-reset"
+                >
+                  Forgot password?
+                </a>
+              </small>
+            </div>
+            <div
+              class="form-group"
+            >
+              <button
+                class="btn btnPrimary btnBlock"
+                type="submit"
+              >
+                Sign in
+              </button>
+            </div>
+          </form>
+          <div
+            class="mb-3 py-1 d-flex align-items-center"
+          >
+            <div
+              class="w-100 border"
+            />
+            <small
+              class="px-2 text-muted "
+            >
+              OR
+            </small>
+            <div
+              class="w-100 border"
+            />
+          </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnSecondary btnBlock"
+              href="/.auth/github/login?pc=f00bar"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M12,2A10,10 0 0,0 2,12C2,16.42 4.87,20.17 8.84,21.5C9.34,21.58 9.5,21.27 9.5,21C9.5,20.77 9.5,20.14 9.5,19.31C6.73,19.91 6.14,17.97 6.14,17.97C5.68,16.81 5.03,16.5 5.03,16.5C4.12,15.88 5.1,15.9 5.1,15.9C6.1,15.97 6.63,16.93 6.63,16.93C7.5,18.45 8.97,18 9.54,17.76C9.63,17.11 9.89,16.67 10.17,16.42C7.95,16.17 5.62,15.31 5.62,11.5C5.62,10.39 6,9.5 6.65,8.79C6.55,8.54 6.2,7.5 6.75,6.15C6.75,6.15 7.59,5.88 9.5,7.17C10.29,6.95 11.15,6.84 12,6.84C12.85,6.84 13.71,6.95 14.5,7.17C16.41,5.88 17.25,6.15 17.25,6.15C17.8,7.5 17.45,8.54 17.35,8.79C18,9.5 18.38,10.39 18.38,11.5C18.38,15.32 16.04,16.16 13.81,16.41C14.17,16.72 14.5,17.33 14.5,18.26C14.5,19.6 14.5,20.68 14.5,21C14.5,21.27 14.66,21.59 15.17,21.5C19.14,20.16 22,16.42 22,12A10,10 0 0,0 12,2Z"
+                />
+              </svg>
+               Continue with GitHub
+            </a>
+          </div>
+          <div
+            class="mb-2"
+          >
+            <a
+              class="anchorLink btn btnSecondary btnBlock"
+              href=""
+            >
+              Continue with Sourcegraph Employee
+            </a>
+          </div>
+        </div>
+        <p
+          class=""
+        >
+          New to Sourcegraph? 
+          <a
+            class="anchorLink"
+            href="/sign-up?sourcegraph-operator"
+          >
+            Sign up
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -631,6 +631,8 @@ type ExperimentalFeatures struct {
 	GitServerPinnedRepos map[string]string `json:"gitServerPinnedRepos,omitempty"`
 	// GoPackages description: Allow adding Go package host connections
 	GoPackages string `json:"goPackages,omitempty"`
+	// HideSourcegraphOperatorLogin description: Enables hiding Sourcegraph operator auth provider on login page.
+	HideSourcegraphOperatorLogin bool `json:"hideSourcegraphOperatorLogin,omitempty"`
 	// InsightsAlternateLoadingStrategy description: Use an in-memory strategy of loading Code Insights. Should only be used for benchmarking on large instances, not for customer use currently.
 	InsightsAlternateLoadingStrategy bool `json:"insightsAlternateLoadingStrategy,omitempty"`
 	// JvmPackages description: Allow adding JVM package host connections

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -546,6 +546,11 @@
           "description": "Use an in-memory strategy of loading Code Insights. Should only be used for benchmarking on large instances, not for customer use currently.",
           "type": "boolean",
           "default": false
+        },
+        "hideSourcegraphOperatorLogin": {
+          "description": "Enables hiding Sourcegraph operator auth provider on login page.",
+          "type": "boolean",
+          "default": false
         }
       },
       "examples": [


### PR DESCRIPTION
Based on feedback from @malomarrec the Sourcegraph employee login method we add to the default login screen is confusing for our users. This PR changes our login screen UX - when `hideSourcegraphOperatorLogin` experimental feature (added in this PR, to be enabled by default on Cloud) is enabled, Sourcegraph operator login on our sign-in page will be hidden by default, and only shown when `sourcegraph-operator` URL param is present.

The current (suboptimal) check based on provider type/name will be improved when [RFC 744](https://docs.google.com/document/d/1zHW_bBB5xeTqPcgt4UcW9BI-oKvG_jMwooriolsZB-0/edit?usp=sharing) is implemented. 


New default (with flag on):
<img width="661" alt="Screenshot 2022-10-03 at 10 39 43" src="https://user-images.githubusercontent.com/1022220/193535532-cccabd03-3724-4e8a-95d5-428253a23ef9.png">

When flag is off or (when flag is on and with URL param):
<img width="669" alt="Screenshot 2022-10-03 at 10 39 53" src="https://user-images.githubusercontent.com/1022220/193535542-fa0c910d-b558-4114-aefb-02749e2630eb.png">

## Test plan

- tested locally
- sign-in page unit tests

## App preview:

- [Web](https://sg-web-hide-sourcegraph-login.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ordnskflrs.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
