### PR TITLE
gitserver: fix p4-fusion command args

### DIFF
--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -239,6 +239,19 @@ func configureRemoteGitCommand(cmd *exec.Cmd, tlsConf *tlsConfig) {
 		extraArgs = append(extraArgs, "-c", "protocol.version=2")
 	}
 
+	// p4-fusion command doesn't support -c argument and passing this causes warning
+	// logs. This removes all -c arguments
+	if executable == "p4-fusion" {
+		idx := 0
+		for _, arg := range extraArgs {
+			if arg != "-c" {
+				extraArgs[idx] = arg
+				idx++
+			}
+		}
+		extraArgs = extraArgs[:idx]
+	}
+
 	cmd.Args = append(cmd.Args[:1], append(extraArgs, cmd.Args[1:]...)...)
 }
 

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -243,10 +243,18 @@ func configureRemoteGitCommand(cmd *exec.Cmd, tlsConf *tlsConfig) {
 	// logs. This removes all -c arguments
 	if executable == "p4-fusion" {
 		idx := 0
+		foundC := false
 		for _, arg := range extraArgs {
+			// skipping arg after -c
+			if foundC {
+				foundC = false
+				continue
+			}
 			if arg != "-c" {
 				extraArgs[idx] = arg
 				idx++
+			} else {
+				foundC = true
 			}
 		}
 		extraArgs = extraArgs[:idx]

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -239,28 +239,37 @@ func configureRemoteGitCommand(cmd *exec.Cmd, tlsConf *tlsConfig) {
 		extraArgs = append(extraArgs, "-c", "protocol.version=2")
 	}
 
-	// p4-fusion command doesn't support -c argument and passing this causes warning
-	// logs. This removes all -c arguments
 	if executable == "p4-fusion" {
-		idx := 0
-		foundC := false
-		for _, arg := range extraArgs {
-			// skipping arg after -c
-			if foundC {
-				foundC = false
-				continue
-			}
-			if arg != "-c" {
-				extraArgs[idx] = arg
-				idx++
-			} else {
-				foundC = true
-			}
-		}
-		extraArgs = extraArgs[:idx]
+		extraArgs = removeUnsupportedP4Args(extraArgs)
 	}
 
 	cmd.Args = append(cmd.Args[:1], append(extraArgs, cmd.Args[1:]...)...)
+}
+
+// removeUnsupportedP4Args removes all -c arguments as `p4-fusion` command doesn't
+// support -c argument and passing this causes warning logs.
+func removeUnsupportedP4Args(args []string) []string {
+	if len(args) == 0 {
+		return args
+	}
+
+	idx := 0
+	foundC := false
+	for _, arg := range args {
+		if arg == "-c" {
+			// removing any -c
+			foundC = true
+		} else if foundC {
+			// removing the argument following -c and resetting the flag
+			foundC = false
+		} else {
+			// keep the argument
+			args[idx] = arg
+			idx++
+		}
+	}
+	args = args[:idx]
+	return args
 }
 
 // writeTempFile writes data to the TempFile with pattern. Returns the path of

--- a/cmd/gitserver/server/serverutil_test.go
+++ b/cmd/gitserver/server/serverutil_test.go
@@ -158,6 +158,57 @@ func TestConfigureRemoteP4FusionCommandWithoutCArgs(t *testing.T) {
 	assert.Equal(t, expectedArgs, input.Args)
 }
 
+func TestRemoveUnsupportedP4Args(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        []string
+		expectedArgs []string
+	}{
+		{
+			name:         "empty args",
+			input:        []string{},
+			expectedArgs: []string{},
+		},
+		{
+			name:         "single -c token without a follow-up, removed",
+			input:        []string{"-c"},
+			expectedArgs: []string{},
+		},
+		{
+			name:         "no -c args, nothing removed",
+			input:        []string{"normal", "args"},
+			expectedArgs: []string{"normal", "args"},
+		},
+		{
+			name:         "single -c arg removed",
+			input:        []string{"normal", "args", "-c", "oops", "normal_again"},
+			expectedArgs: []string{"normal", "args", "normal_again"},
+		},
+		{
+			name:         "multiple -c args removed",
+			input:        []string{"normal", "args", "-c", "oops", "normal_again", "-c", "oops2"},
+			expectedArgs: []string{"normal", "args", "normal_again"},
+		},
+		{
+			name:         "repeated -c token",
+			input:        []string{"-c", "-c", "-c", "not_good", "normal", "args"},
+			expectedArgs: []string{"normal", "args"},
+		},
+		{
+			name:         "only -c args, everything removed",
+			input:        []string{"-c", "oops", "-c", "-c", "not_good"},
+			expectedArgs: []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualArgs := removeUnsupportedP4Args(test.input)
+			assert.Equal(t, test.expectedArgs, actualArgs)
+		})
+	}
+}
+
 func TestConfigureRemoteGitCommand_tls(t *testing.T) {
 	baseEnv := []string{
 		"GIT_ASKPASS=true",

--- a/cmd/gitserver/server/serverutil_test.go
+++ b/cmd/gitserver/server/serverutil_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetTlsExternal(t *testing.T) {
@@ -150,15 +151,11 @@ func TestConfigureRemoteP4FusionCommandWithoutCArgs(t *testing.T) {
 		"GIT_HTTP_USER_AGENT=git/Sourcegraph-Bot",
 	}
 	input := exec.Command("p4-fusion", "--path", "some_path", "--client", "some_client", "--user", "some_user")
-	expectedArgs := []string{"p4-fusion", "credential.helper=", "protocol.version=2", "--path", "some_path", "--client", "some_client", "--user", "some_user"}
+	expectedArgs := []string{"p4-fusion", "--path", "some_path", "--client", "some_client", "--user", "some_user"}
 
 	configureRemoteGitCommand(input, &tlsConfig{})
-	if !reflect.DeepEqual(input.Env, expectedEnv) {
-		t.Errorf("\ngot:  %s\nwant: %s\n", input.Env, expectedEnv)
-	}
-	if !reflect.DeepEqual(input.Args, expectedArgs) {
-		t.Errorf("\ngot:  %s\nwant: %s\n", input.Args, expectedArgs)
-	}
+	assert.Equal(t, expectedEnv, input.Env)
+	assert.Equal(t, expectedArgs, input.Args)
 }
 
 func TestConfigureRemoteGitCommand_tls(t *testing.T) {

--- a/cmd/gitserver/server/serverutil_test.go
+++ b/cmd/gitserver/server/serverutil_test.go
@@ -143,6 +143,24 @@ func TestConfigureRemoteGitCommand(t *testing.T) {
 	}
 }
 
+func TestConfigureRemoteP4FusionCommandWithoutCArgs(t *testing.T) {
+	expectedEnv := []string{
+		"GIT_ASKPASS=true",
+		"GIT_SSH_COMMAND=ssh -o BatchMode=yes -o ConnectTimeout=30",
+		"GIT_HTTP_USER_AGENT=git/Sourcegraph-Bot",
+	}
+	input := exec.Command("p4-fusion", "--path", "some_path", "--client", "some_client", "--user", "some_user")
+	expectedArgs := []string{"p4-fusion", "credential.helper=", "protocol.version=2", "--path", "some_path", "--client", "some_client", "--user", "some_user"}
+
+	configureRemoteGitCommand(input, &tlsConfig{})
+	if !reflect.DeepEqual(input.Env, expectedEnv) {
+		t.Errorf("\ngot:  %s\nwant: %s\n", input.Env, expectedEnv)
+	}
+	if !reflect.DeepEqual(input.Args, expectedArgs) {
+		t.Errorf("\ngot:  %s\nwant: %s\n", input.Args, expectedArgs)
+	}
+}
+
 func TestConfigureRemoteGitCommand_tls(t *testing.T) {
 	baseEnv := []string{
 		"GIT_ASKPASS=true",


### PR DESCRIPTION
New code removes any -c arguments added to `p4-fusion` command, because they trigger unnecessary warnings in logs.

Test plan:
new unit test added

Closes https://github.com/sourcegraph/sourcegraph/issues/42389