### PR TITLE
[fix] Make "internal" gitlab repos behave like private repositories

### DIFF
--- a/enterprise/internal/authz/gitlab/oauth_test.go
+++ b/enterprise/internal/authz/gitlab/oauth_test.go
@@ -74,7 +74,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 		},
 		&mockDoer{
 			do: func(r *http.Request) (*http.Response, error) {
-				want := "https://gitlab.com/api/v4/projects?min_access_level=20&per_page=100&visibility=private"
+				want := "https://gitlab.com/api/v4/projects?min_access_level=20&per_page=100&visibility=private&visibility=internal"
 				if r.URL.String() != want {
 					return nil, errors.Errorf("URL: want %q but got %q", want, r.URL)
 				}

--- a/enterprise/internal/authz/gitlab/oauth_test.go
+++ b/enterprise/internal/authz/gitlab/oauth_test.go
@@ -74,7 +74,11 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 		},
 		&mockDoer{
 			do: func(r *http.Request) (*http.Response, error) {
-				want := "https://gitlab.com/api/v4/projects?min_access_level=20&per_page=100&visibility=private&visibility=internal"
+				visibility := r.URL.Query().Get("visibility")
+				if visibility != "private" && visibility != "internal" {
+					return nil, errors.Errorf("URL visibility: want private or internal, got %s", visibility)
+				}
+				want := fmt.Sprintf("https://gitlab.com/api/v4/projects?min_access_level=20&per_page=100&visibility=%s", visibility)
 				if r.URL.String() != want {
 					return nil, errors.Errorf("URL: want %q but got %q", want, r.URL)
 				}
@@ -85,7 +89,10 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 					return nil, errors.Errorf("HTTP Authorization: want %q but got %q", want, got)
 				}
 
-				body := `[{"id": 1}, {"id": 2}, {"id": 3}]`
+				body := `[{"id": 1}, {"id": 2}]`
+				if visibility == "internal" {
+					body = `[{"id": 3}]`
+				}
 				return &http.Response{
 					Status:     http.StatusText(http.StatusOK),
 					StatusCode: http.StatusOK,

--- a/enterprise/internal/authz/gitlab/sudo.go
+++ b/enterprise/internal/authz/gitlab/sudo.go
@@ -226,33 +226,37 @@ func (p *SudoProvider) FetchUserPermsByToken(ctx context.Context, token string, 
 // whether to discard.
 func listProjects(ctx context.Context, client *gitlab.Client) (*authz.ExternalUserPermissions, error) {
 	q := make(url.Values)
-	q.Add("visibility", "private") // This method is meant to return only private or internal projects
-	q.Add("visibility", "internal")
 	q.Add("min_access_level", "20") // 20 => Reporter access (i.e. have access to project code)
 	q.Add("per_page", "100")        // 100 is the maximum page size
-
-	// The next URL to request for projects, and it is reused in the succeeding for loop.
-	nextURL := "projects?" + q.Encode()
 
 	// 100 matches the maximum page size, thus a good default to avoid multiple allocations
 	// when appending the first 100 results to the slice.
 	projectIDs := make([]extsvc.RepoID, 0, 100)
-	for {
-		projects, next, err := client.ListProjects(ctx, nextURL)
-		if err != nil {
-			return &authz.ExternalUserPermissions{
-				Exacts: projectIDs,
-			}, err
-		}
 
-		for _, p := range projects {
-			projectIDs = append(projectIDs, extsvc.RepoID(strconv.Itoa(p.ID)))
-		}
+	// This method is meant to return only private or internal projects
+	for _, visibility := range []string{"private", "internal"} {
+		q.Set("visibility", visibility)
 
-		if next == nil {
-			break
+		// The next URL to request for projects, and it is reused in the succeeding for loop.
+		nextURL := "projects?" + q.Encode()
+
+		for {
+			projects, next, err := client.ListProjects(ctx, nextURL)
+			if err != nil {
+				return &authz.ExternalUserPermissions{
+					Exacts: projectIDs,
+				}, err
+			}
+
+			for _, p := range projects {
+				projectIDs = append(projectIDs, extsvc.RepoID(strconv.Itoa(p.ID)))
+			}
+
+			if next == nil {
+				break
+			}
+			nextURL = *next
 		}
-		nextURL = *next
 	}
 
 	return &authz.ExternalUserPermissions{

--- a/enterprise/internal/authz/gitlab/sudo.go
+++ b/enterprise/internal/authz/gitlab/sudo.go
@@ -226,7 +226,8 @@ func (p *SudoProvider) FetchUserPermsByToken(ctx context.Context, token string, 
 // whether to discard.
 func listProjects(ctx context.Context, client *gitlab.Client) (*authz.ExternalUserPermissions, error) {
 	q := make(url.Values)
-	q.Add("visibility", "private")  // This method is meant to return only private projects
+	q.Add("visibility", "private") // This method is meant to return only private or internal projects
+	q.Add("visibility", "internal")
 	q.Add("min_access_level", "20") // 20 => Reporter access (i.e. have access to project code)
 	q.Add("per_page", "100")        // 100 is the maximum page size
 

--- a/enterprise/internal/authz/gitlab/sudo_test.go
+++ b/enterprise/internal/authz/gitlab/sudo_test.go
@@ -270,7 +270,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 		},
 		&mockDoer{
 			do: func(r *http.Request) (*http.Response, error) {
-				want := "https://gitlab.com/api/v4/projects?min_access_level=20&per_page=100&visibility=private"
+				want := "https://gitlab.com/api/v4/projects?min_access_level=20&per_page=100&visibility=private&visibility=internal"
 				if r.URL.String() != want {
 					return nil, errors.Errorf("URL: want %q but got %q", want, r.URL)
 				}

--- a/enterprise/internal/authz/gitlab/sudo_test.go
+++ b/enterprise/internal/authz/gitlab/sudo_test.go
@@ -270,7 +270,11 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 		},
 		&mockDoer{
 			do: func(r *http.Request) (*http.Response, error) {
-				want := "https://gitlab.com/api/v4/projects?min_access_level=20&per_page=100&visibility=private&visibility=internal"
+				visibility := r.URL.Query().Get("visibility")
+				if visibility != "private" && visibility != "internal" {
+					return nil, errors.Errorf("URL visibility: want private or internal, got %s", visibility)
+				}
+				want := fmt.Sprintf("https://gitlab.com/api/v4/projects?min_access_level=20&per_page=100&visibility=%s", visibility)
 				if r.URL.String() != want {
 					return nil, errors.Errorf("URL: want %q but got %q", want, r.URL)
 				}
@@ -287,7 +291,10 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 					return nil, errors.Errorf("HTTP Sudo: want %q but got %q", want, got)
 				}
 
-				body := `[{"id": 1}, {"id": 2}, {"id": 3}]`
+				body := `[{"id": 1}, {"id": 2}]`
+				if visibility == "internal" {
+					body = `[{"id": 3}]`
+				}
 				return &http.Response{
 					Status:     http.StatusText(http.StatusOK),
 					StatusCode: http.StatusOK,

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -208,7 +208,7 @@ func (s GitLabSource) makeRepo(proj *gitlab.Project) *types.Repo {
 		Fork:         proj.ForkedFromProject != nil,
 		Archived:     proj.Archived,
 		Stars:        proj.StarCount,
-		Private:      proj.Visibility == "private",
+		Private:      proj.Visibility == "private" || proj.Visibility == "internal",
 		Sources: map[string]*types.SourceInfo{
 			urn: {
 				ID:       urn,

--- a/internal/repos/testdata/golden/GitLabSource_makeRepo_path-pattern
+++ b/internal/repos/testdata/golden/GitLabSource_makeRepo_path-pattern
@@ -41,7 +41,7 @@
    "Description": "Gitaly is a Git RPC service for handling all the git calls made by GitLab",
    "Fork": false,
    "Archived": false,
-   "Private": false,
+   "Private": true,
    "CreatedAt": "0001-01-01T00:00:00Z",
    "UpdatedAt": "0001-01-01T00:00:00Z",
    "DeletedAt": "0001-01-01T00:00:00Z",

--- a/internal/repos/testdata/golden/GitLabSource_makeRepo_simple
+++ b/internal/repos/testdata/golden/GitLabSource_makeRepo_simple
@@ -41,7 +41,7 @@
    "Description": "Gitaly is a Git RPC service for handling all the git calls made by GitLab",
    "Fork": false,
    "Archived": false,
-   "Private": false,
+   "Private": true,
    "CreatedAt": "0001-01-01T00:00:00Z",
    "UpdatedAt": "0001-01-01T00:00:00Z",
    "DeletedAt": "0001-01-01T00:00:00Z",

--- a/internal/repos/testdata/golden/GitLabSource_makeRepo_ssh
+++ b/internal/repos/testdata/golden/GitLabSource_makeRepo_ssh
@@ -41,7 +41,7 @@
    "Description": "Gitaly is a Git RPC service for handling all the git calls made by GitLab",
    "Fork": false,
    "Archived": false,
-   "Private": false,
+   "Private": true,
    "CreatedAt": "0001-01-01T00:00:00Z",
    "UpdatedAt": "0001-01-01T00:00:00Z",
    "DeletedAt": "0001-01-01T00:00:00Z",


### PR DESCRIPTION
fixes #41909

## Test plan

Added unit tests.

Tested manually against gitlab.sgdev.org.

1. Created an "internal" repository
2. Added 2 users to my local sg instance
3. Connected the gitlab.sgdev.org as an OAuth source and added external service with repo permissions syncing based on OAuth
4. Verified that
  a. Site admin can see the repository (site admins are godlike and can see everything)
  b. User who did not add Gitlab in Settings -> Account Security cannot search the repository
  c. User who added Gitlab in Settings -> Account Security can search the repository

Tested the changes for sudo gitlab auth provider by adding a private repository as well and running the following queries from terminal (see the [xh tool docs here](https://github.com/ducaale/xh/blob/master/README.md)):
```
xh "https://gitlab.sgdev.org/api/v4/projects?visibility=private&min_access_level=20&per_page=100&membership=true" "PRIVATE-TOKEN: <redacted>"
xh "https://gitlab.sgdev.org/api/v4/projects?visibility=internal&min_access_level=20&per_page=100&membership=true" "PRIVATE-TOKEN: <redacted>"
``` 
And validated that I can see the repo with proper visibility based on the query param, but not without it.
