### PR TITLE
search: compute zoekt SearchOptions in one call

### DIFF
--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -120,13 +120,15 @@ func zoektSearchIgnorePaths(ctx context.Context, client zoekt.Streamer, p *proto
 		zoektIgnorePaths(ignoredPaths),
 	))
 
-	k := zoektutil.ResultCountFactor(1, int32(p.Limit), false)
-	opts := zoektutil.SearchOpts(ctx, k, int32(p.Limit), nil)
+	opts := (&zoektutil.Options{
+		NumRepos:       1,
+		FileMatchLimit: int32(p.Limit),
+	}).ToSearch(ctx)
 	if deadline, ok := ctx.Deadline(); ok {
 		opts.MaxWallTime = time.Until(deadline) - 100*time.Millisecond
 	}
 
-	res, err := client.Search(ctx, q, &opts)
+	res, err := client.Search(ctx, q, opts)
 	if err != nil {
 		return false, err
 	}

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -482,7 +482,11 @@ func TestZoektResultCountFactor(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ResultCountFactor(tt.numRepos, tt.pattern.FileMatchLimit, tt.globalSearch)
+			got := (&Options{
+				NumRepos:       tt.numRepos,
+				FileMatchLimit: tt.pattern.FileMatchLimit,
+				GlobalSearch:   tt.globalSearch,
+			}).resultCountFactor()
 			if tt.want != got {
 				t.Fatalf("Want scaling factor %d but got %d", tt.want, got)
 			}


### PR DESCRIPTION
At every callsite we computed an opaque k value and then called another function to generate the search options. We can simplify this into a single API.

This change was motivated since I wanted to adjust this logic and potentially add a new parameter. So took the opportunity to simplify the API.

Test Plan: go test