### PR TITLE
Make audit logs immune to sampling

### DIFF
--- a/cmd/gitserver/server/internal/accesslog/accesslog_test.go
+++ b/cmd/gitserver/server/internal/accesslog/accesslog_test.go
@@ -82,15 +82,14 @@ func TestHTTPMiddleware(t *testing.T) {
 		assert.Contains(t, logs[1].Message, accessEventMessage)
 		assert.Equal(t, "github.com/foo/bar", logs[1].Fields["params"].(map[string]any)["repo"])
 
-		auditLogFields := map[string]interface{}{
-			"entity": "gitserver",
-			"actor": map[string]interface{}{
-				"actorUID":        "unknown",
-				"ip":              "192.168.1.1",
-				"X-Forwarded-For": "",
-			},
-		}
-		assert.Equal(t, auditLogFields, logs[1].Fields["audit"])
+		auditFields := logs[1].Fields["audit"].(map[string]interface{})
+		assert.Equal(t, "gitserver", auditFields["entity"])
+		assert.NotEmpty(t, auditFields["auditId"])
+
+		actorFields := auditFields["actor"].(map[string]interface{})
+		assert.Equal(t, "unknown", actorFields["actorUID"])
+		assert.Equal(t, "192.168.1.1", actorFields["ip"])
+		assert.Equal(t, "", actorFields["X-Forwarded-For"])
 	})
 
 	t.Run("handle, no recording", func(t *testing.T) {

--- a/cmd/gitserver/server/internal/accesslog/accesslog_test.go
+++ b/cmd/gitserver/server/internal/accesslog/accesslog_test.go
@@ -79,7 +79,7 @@ func TestHTTPMiddleware(t *testing.T) {
 		logs := exportLogs()
 		require.Len(t, logs, 2)
 		assert.Equal(t, accessLoggingEnabledMessage, logs[0].Message)
-		assert.Equal(t, accessEventMessage, logs[1].Message)
+		assert.Contains(t, logs[1].Message, accessEventMessage)
 		assert.Equal(t, "github.com/foo/bar", logs[1].Fields["params"].(map[string]any)["repo"])
 
 		auditLogFields := map[string]interface{}{
@@ -142,7 +142,7 @@ func TestHTTPMiddleware(t *testing.T) {
 		logs = exportLogs()
 		require.Len(t, logs, 2)
 		assert.Equal(t, accessLoggingEnabledMessage, logs[0].Message)
-		assert.Equal(t, accessEventMessage, logs[1].Message)
+		assert.Contains(t, logs[1].Message, accessEventMessage)
 	})
 }
 

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -18,8 +18,10 @@ func Log(ctx context.Context, logger log.Logger, record Record) {
 	var fields []log.Field
 
 	client := requestclient.FromContext(ctx)
+	auditId := uuid.New().String()
 
 	fields = append(fields, log.Object("audit",
+		log.String("auditId", auditId),
 		log.String("entity", record.Entity),
 		log.Object("actor",
 			log.String("actorUID", actorId(actor.FromContext(ctx))),
@@ -27,7 +29,8 @@ func Log(ctx context.Context, logger log.Logger, record Record) {
 			log.String("X-Forwarded-For", forwardedFor(client)))))
 	fields = append(fields, record.Fields...)
 
-	logger.Info(fmt.Sprintf("%s (sampling immunity token: %s)", record.Action, uuid.New().String()), fields...)
+	// message string looks like: #{record.Action} (sampling immunity token: #{auditId})
+	logger.Info(fmt.Sprintf("%s (sampling immunity token: %s)", record.Action, auditId), fields...)
 }
 
 func actorId(act *actor.Actor) string {

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -2,7 +2,9 @@ package audit
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -25,7 +27,7 @@ func Log(ctx context.Context, logger log.Logger, record Record) {
 			log.String("X-Forwarded-For", forwardedFor(client)))))
 	fields = append(fields, record.Fields...)
 
-	logger.Info(record.Action, fields...)
+	logger.Info(fmt.Sprintf("%s (sampling immunity token: %s)", record.Action, uuid.New().String()), fields...)
 }
 
 func actorId(act *actor.Actor) string {

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -139,7 +139,7 @@ func TestLog(t *testing.T) {
 				t.Fatal("expected to capture one log exactly")
 			}
 
-			assert.Equal(t, "test audit action", logs[0].Message)
+			assert.Contains(t, logs[0].Message, "test audit action")
 			assert.Equal(t, tc.expectedEntry, logs[0].Fields)
 		})
 	}

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -139,8 +139,21 @@ func TestLog(t *testing.T) {
 				t.Fatal("expected to capture one log exactly")
 			}
 
-			assert.Contains(t, logs[0].Message, "test audit action")
-			assert.Equal(t, tc.expectedEntry, logs[0].Fields)
+			assert.Contains(t, logs[0].Message, "test audit action (sampling immunity token")
+
+			// non-audit fields are preserved
+			assert.Equal(t, tc.expectedEntry["additional"], logs[0].Fields["additional"])
+
+			expectedAudit := tc.expectedEntry["audit"].(map[string]interface{})
+			actualAudit := logs[0].Fields["audit"].(map[string]interface{})
+			assert.Equal(t, expectedAudit["entity"], actualAudit["entity"])
+			assert.NotEmpty(t, actualAudit["auditId"])
+
+			expectedActor := expectedAudit["actor"].(map[string]interface{})
+			actualActor := actualAudit["actor"].(map[string]interface{})
+			assert.Equal(t, expectedActor["actorUID"], actualActor["actorUID"])
+			assert.Equal(t, expectedActor["ip"], actualActor["ip"])
+			assert.Equal(t, expectedActor["X-Forwarded-For"], actualActor["X-Forwarded-For"])
 		})
 	}
 }

--- a/internal/audit/integration/cmd/main.go
+++ b/internal/audit/integration/cmd/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"os"
+	"strconv"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/audit"
+)
+
+func main() {
+	args := os.Args
+
+	// binary name, audit logs count
+	if len(args) != 2 {
+		os.Exit(-1)
+	}
+
+	ctx := context.Background()
+
+	callbacks := log.Init(log.Resource{
+		Name:       "Audit Resource",
+		Namespace:  "Audit Integration Testing",
+		Version:    "",
+		InstanceID: "",
+	})
+
+	defer func() {
+		err := callbacks.Sync()
+		if err != nil {
+			os.Exit(-1)
+		}
+	}()
+
+	logger := log.Scoped("test", "logger with sampling config")
+
+	logsCount, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		os.Exit(-1)
+	}
+
+	for i := 0; i < logsCount; i++ {
+		audit.Log(ctx, logger, audit.Record{
+			Entity: "integration test",
+			Action: "sampling testing",
+			Fields: nil,
+		})
+	}
+}

--- a/internal/audit/integration/integration_test.go
+++ b/internal/audit/integration/integration_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestIntegration(t *testing.T) {
+	// audit logs are logged under INFO severity
 	t.Setenv("SRC_LOG_LEVEL", "info")
 
 	// start sampling after 5 messages

--- a/internal/audit/integration/integration_test.go
+++ b/internal/audit/integration/integration_test.go
@@ -1,0 +1,39 @@
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/sourcegraph/run"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIntegration(t *testing.T) {
+	t.Setenv("SRC_LOG_LEVEL", "info")
+
+	// start sampling after 5 messages
+	t.Setenv("SRC_LOG_SAMPLING_INITIAL", "5")
+
+	// create 10 log messages, none of them should be sampled
+	output, _ := run.Cmd(context.Background(), "go", "run", "./cmd/", "10").Run().String()
+
+	logMessages := filterAuditLogs(output)
+	if len(logMessages) == 0 {
+		t.Fatal("no log output captured")
+	}
+
+	// capture all 10 despite the sampling setting (5)
+	assert.Equal(t, 10, len(logMessages))
+}
+
+func filterAuditLogs(output string) []string {
+	lines := strings.Split(output, "\n")
+	var filtered []string
+	for _, line := range lines {
+		if strings.Contains(line, "{\"audit\"") {
+			filtered = append(filtered, line)
+		}
+	}
+	return filtered
+}


### PR DESCRIPTION
### Problem

Telemetry sampling is a native observability concept that helps the emitter to reduce the volume of telemetry data to a manageable level. This is usually fine as long as we're not talking audit log - **we don't want to drop any actions that will appear in the security audit log**.

### Solution

Our [internal logging standard](https://docs.sourcegraph.com/admin/observability/logs#log-sampling) says the following:

>  The first 100 identical log entries per second will always be output, but thereafter only every 100th identical message will be output.

The key part here is the phrase **identical message**. Our [sourcegraph/log](https://github.com/sourcegraph/log) library wraps Uber's Zap, and they indeed [sample based on the log message](https://sourcegraph.com/github.com/uber-go/zap/-/blob/zapcore/sampler.go?L221). The other fields in the structured log entry are not considered. 

To make each audit log message unique, we append a ["sampling immunity token"](https://sourcegraph.sourcegraph.com/-/editor?remote_url=https%3A%2F%2Fgithub.com%2Fsourcegraph%2Fsourcegraph.git&branch=mv%2Fauditlog%2Fsampling-immunity&file=internal%2Faudit%2Faudit.go&start_row=29&start_col=20&end_row=29&end_col=20&editor=JetBrains&version=v2.0.1) in the log message.

**Note**: we can change the implementation in the future, for example, if we make `sourcegraph/log` to make a sampling decision based on the structured log fields instead of wrapping the default Zap behavior 

## Test plan

Automated integration test.
