### PR TITLE
Charts: Fix bar chart focus and voice over navigation

### DIFF
--- a/client/web/src/integration/search-aggregation.test.ts
+++ b/client/web/src/integration/search-aggregation.test.ts
@@ -304,7 +304,7 @@ describe('Search aggregation', () => {
             const editor = await createEditorAPI(driver, QUERY_INPUT_SELECTOR)
             await editor.waitForIt()
 
-            await driver.page.waitForSelector('[aria-label="chart content group"] a')
+            await driver.page.waitForSelector('[aria-label="Bar chart content"] a')
             await driver.page.click('[aria-label="Sidebar search aggregation chart"] a')
 
             expect(await editor.getValue()).toStrictEqual('insights repo:sourcegraph/sourcegraph')
@@ -312,10 +312,10 @@ describe('Search aggregation', () => {
             await driver.page.waitForSelector('[data-testid="expand-aggregation-ui"]')
             await driver.page.click('[data-testid="expand-aggregation-ui"]')
             await driver.page.waitForSelector(
-                '[aria-label="Expanded search aggregation chart"] [aria-label="chart content group"] g:nth-child(2) a'
+                '[aria-label="Expanded search aggregation chart"] [aria-label="Bar chart content"] g:nth-child(2) a'
             )
             await driver.page.click(
-                '[aria-label="Expanded search aggregation chart"] [aria-label="chart content group"] g:nth-child(2) a'
+                '[aria-label="Expanded search aggregation chart"] [aria-label="Bar chart content"] g:nth-child(2) a'
             )
 
             expect(await editor.getValue()).toStrictEqual('insights repo:sourecegraph/about')

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
@@ -45,6 +45,7 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
         maxAngleXTick,
         stacked = false,
         sortByValue,
+        'aria-label': ariaLabel = 'Bar chart',
         getDatumHover,
         getScaleXTicks,
         getTruncatedXTick,
@@ -92,7 +93,15 @@ export function BarChart<Datum>(props: BarChartProps<Datum>): ReactElement {
     }
 
     return (
-        <SvgRoot {...attributes} width={outerWidth} height={outerHeight} xScale={xScale} yScale={yScale}>
+        <SvgRoot
+            {...attributes}
+            width={outerWidth}
+            height={outerHeight}
+            role="group"
+            aria-label={ariaLabel}
+            xScale={xScale}
+            yScale={yScale}
+        >
             <SvgAxisLeft pixelsPerTick={pixelsPerYTick} />
             <SvgAxisBottom
                 pixelsPerTick={pixelsPerXTick}

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChartContent.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChartContent.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, ReactElement, SVGProps, useRef, useState } from 'react'
+import { FocusEventHandler, MouseEvent, ReactElement, SVGProps, useRef, useState } from 'react'
 
 import { Group } from '@visx/group'
 import classNames from 'classnames'
@@ -65,11 +65,25 @@ export function BarChartContent<Datum>(props: BarChartContentProps<Datum>): Reac
         onBarHover?.(datum)
     }
 
+    const handleBarFocus = (datum: Datum, category: Category<Datum>, node: Element): void => {
+        setActiveSegment({ datum, category, node })
+    }
+
+    const handleBlurCapture: FocusEventHandler<SVGSVGElement> = event => {
+        const relatedTarget = event.relatedTarget as Element
+        const currentTarget = event.currentTarget as Element
+
+        if (!currentTarget.contains(relatedTarget)) {
+            setActiveSegment(null)
+        }
+    }
+
     return (
         <Group
             {...attributes}
             innerRef={rootRef}
             className={classNames(styles.root, { [styles.rootWithHoveredLinkPoint]: withActiveLink })}
+            onBlurCapture={handleBlurCapture}
         >
             {stacked ? (
                 <StackedBars
@@ -102,11 +116,12 @@ export function BarChartContent<Datum>(props: BarChartContentProps<Datum>): Reac
                     onBarHover={handleBarHover}
                     onBarLeave={() => setActiveSegment(null)}
                     onBarClick={onBarClick}
+                    onBarFocus={handleBarFocus}
                 />
             )}
 
             {activeSegment && rootRef.current && (
-                <Tooltip containerElement={rootRef.current}>
+                <Tooltip containerElement={rootRef.current} activeElement={activeSegment.node as HTMLElement}>
                     <BarTooltipContent
                         category={activeSegment.category}
                         activeBar={activeSegment.datum}

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChartContent.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChartContent.tsx
@@ -87,7 +87,6 @@ export function BarChartContent<Datum>(props: BarChartContentProps<Datum>): Reac
         >
             {stacked ? (
                 <StackedBars
-                    aria-label="chart content group"
                     categories={categories}
                     xScale={xScale}
                     yScale={yScale}
@@ -101,7 +100,6 @@ export function BarChartContent<Datum>(props: BarChartContentProps<Datum>): Reac
                 />
             ) : (
                 <GroupedBars
-                    aria-label="chart content group"
                     activeSegment={activeSegment}
                     categories={categories}
                     xScale={xScale}

--- a/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.tsx
@@ -26,6 +26,7 @@ interface GroupedBarsProps<Datum> extends ComponentProps<typeof Group> {
     onBarHover: (datum: Datum, category: Category<Datum>) => void
     onBarLeave: () => void
     onBarClick: (event: MouseEvent, datum: Datum, index: number) => void
+    onBarFocus: (datum: Datum, category: Category<Datum>, node: Element) => void
 }
 
 const isSafari = getBrowserName() === 'safari'
@@ -46,6 +47,7 @@ export function GroupedBars<Datum>(props: GroupedBarsProps<Datum>): ReactElement
         onBarHover,
         onBarLeave,
         onBarClick,
+        onBarFocus,
         ...attributes
     } = props
 
@@ -109,7 +111,7 @@ export function GroupedBars<Datum>(props: GroupedBarsProps<Datum>): ReactElement
                             <MaybeLink
                                 key={`bar-group-bar-${category.id}-${getDatumName(datum)}`}
                                 to={getDatumLink(datum)}
-                                onFocus={() => onBarHover(datum, category)}
+                                onFocus={event => onBarFocus(datum, category, event.target)}
                                 onClick={event => onBarClick(event, datum, index)}
                             >
                                 <rect

--- a/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.tsx
@@ -88,13 +88,15 @@ export function GroupedBars<Datum>(props: GroupedBarsProps<Datum>): ReactElement
     }
 
     return (
-        <Group {...attributes} pointerEvents="bounding-rect">
+        <Group {...attributes} pointerEvents="bounding-rect" aria-label="Bar chart content" role="list">
             {categories.map(category => (
                 <Group key={category.id} left={xScale(category.id)} height={height}>
                     {category.data.map((datum, index) => {
                         const isOneDatumCategory = category.data.length === 1
+                        const value = getDatumValue(datum)
+                        const name = getDatumName(datum)
                         const barWidth = isOneDatumCategory ? xScale.bandwidth() : xCategoriesScale.bandwidth()
-                        const barHeight = height - yScale(getDatumValue(datum))
+                        const barHeight = height - yScale(value)
                         const barX = isOneDatumCategory ? 0 : xCategoriesScale(getDatumName(datum))
                         const barY = yScale(getDatumValue(datum))
 
@@ -107,12 +109,18 @@ export function GroupedBars<Datum>(props: GroupedBarsProps<Datum>): ReactElement
                                       { className: styles.barFade, opacity: isSafari ? 0.5 : 1 }
                                 : {}
 
+                        const barLabelText = `${name}, Value: ${value}`
+                        const barCategoryLabelText = isOneDatumCategory
+                            ? barLabelText
+                            : `Category: ${category.id}, ${barLabelText}`
+
                         return (
                             <MaybeLink
-                                key={`bar-group-bar-${category.id}-${getDatumName(datum)}`}
+                                key={`bar-group-bar-${category.id}-${name}`}
                                 to={getDatumLink(datum)}
                                 onFocus={event => onBarFocus(datum, category, event.target)}
                                 onClick={event => onBarClick(event, datum, index)}
+                                aria-label={barCategoryLabelText}
                             >
                                 <rect
                                     x={barX}
@@ -134,6 +142,7 @@ export function GroupedBars<Datum>(props: GroupedBarsProps<Datum>): ReactElement
                 height={height}
                 fill="transparent"
                 opacity={0}
+                aria-hidden={true}
                 onMouseMove={handleGroupMouseMove}
                 onMouseLeave={onBarLeave}
                 onClick={handleGroupClick}

--- a/client/wildcard/src/components/Charts/components/bar-chart/types.ts
+++ b/client/wildcard/src/components/Charts/components/bar-chart/types.ts
@@ -3,4 +3,5 @@ import { Category } from './utils/get-grouped-categories'
 export interface ActiveSegment<Datum> {
     category: Category<Datum>
     datum: Datum
+    node?: Element
 }

--- a/client/wildcard/src/components/Charts/components/line-chart/LineChart.test.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/LineChart.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { assert, stub } from 'sinon'
 
@@ -15,7 +15,7 @@ interface RenderChartArgs {
 const renderChart = ({ series }: RenderChartArgs) => render(<LineChart width={400} height={400} series={series} />)
 
 describe('LineChart', () => {
-    // Non exhaustive smoke tests to check that the chart renders correctly
+    // Non-exhaustive smoke tests to check that the chart renders correctly
     // All other general rendering tests are covered by chromatic
     describe('should render', () => {
         it('empty series', () => {
@@ -25,21 +25,24 @@ describe('LineChart', () => {
         it('series with data', () => {
             renderChart(defaultArgs)
 
+            // Query chart series list
+            const element = screen.getByLabelText('Chart series')
+
             // Check number of series rendered
-            expect(screen.getAllByRole('listitem')).toHaveLength(totalSeries)
+            expect(within(element).getAllByRole('listitem')).toHaveLength(totalSeries)
 
             // Check number of data points rendered
             expect(screen.getAllByRole(/(link|graphics-dataunit)/)).toHaveLength(totalDataPoints)
 
             // Spot check y axis labels
-            expect(screen.getByLabelText(/tick axis 1 of 8. value: 8/i)).toBeInTheDocument()
-            expect(screen.getByLabelText(/tick axis 4 of 8. value: 20/i)).toBeInTheDocument()
-            expect(screen.getByLabelText(/tick axis 8 of 8. value: 36/i)).toBeInTheDocument()
+            expect(screen.getByLabelText(/axis tick, value: 8/i)).toBeInTheDocument()
+            expect(screen.getByLabelText(/axis tick, value: 20/i)).toBeInTheDocument()
+            expect(screen.getByLabelText(/axis tick, value: 36/i)).toBeInTheDocument()
 
             // Spot check x axis labels
-            expect(screen.getByLabelText(/tick axis 1 of 8. value:.*jan 01/i)).toBeInTheDocument()
-            expect(screen.getByLabelText(/tick axis 4 of 8. value:.*oct 01/i)).toBeInTheDocument()
-            expect(screen.getByLabelText(/tick axis 8 of 8. value:.*oct 01/i)).toBeInTheDocument()
+            expect(screen.getByLabelText(/axis tick, value: .*jan 01 2021/i)).toBeInTheDocument()
+            expect(screen.getByLabelText(/axis tick, value: .*oct 01 2021/i)).toBeInTheDocument()
+            expect(screen.getByLabelText(/axis tick, value: .*oct 01 2022/i)).toBeInTheDocument()
         })
     })
 

--- a/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
@@ -102,7 +102,7 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
                 margin: {
                     top: 16,
                     right: 16,
-                    left: yAxisElement?.getBBox?.().width ?? 0,
+                    left: (yAxisElement?.getBBox?.().width ?? 0) + 8,
                     bottom: xAxisReference?.getBBox?.().height ?? 0,
                 },
             }),

--- a/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
@@ -204,7 +204,7 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
                 tickFormat={formatDateTick}
             />
 
-            <Group top={content.top} left={content.left} role="list">
+            <Group top={content.top} left={content.left} aria-label="Chart series" role="list">
                 {stacked && <StackedArea dataSeries={activeSeries} xScale={xScale} yScale={yScale} />}
 
                 {activeSeries.map(line => (

--- a/client/wildcard/src/components/Charts/core/components/SvgRoot.tsx
+++ b/client/wildcard/src/components/Charts/core/components/SvgRoot.tsx
@@ -122,7 +122,10 @@ export const SvgAxisLeft: FC<SvgAxisLeftProps> = props => {
     const { content, yScale, setPadding } = useContext(SVGRootContext)
 
     const handleResize = ({ width = 0 }): void => {
-        setPadding(padding => ({ ...padding, left: width }))
+        // Why + 8, because visx adds internally negative margin to each
+        // tick (tickLength * tickSign) which is "-8" in our case see
+        // https://github.com/airbnb/visx/blob/a3b79fd3bae63b100b1a8781f844631a2f3aa2ea/packages/visx-axis/src/axis/Axis.tsx#L60
+        setPadding(padding => ({ ...padding, left: width + 8 }))
     }
 
     const { ref } = useResizeObserver({ onResize: handleResize })

--- a/client/wildcard/src/components/Charts/core/components/axis/Axis.module.scss
+++ b/client/wildcard/src/components/Charts/core/components/axis/Axis.module.scss
@@ -26,11 +26,4 @@
         stroke: var(--border-color-2);
         stroke-width: 1;
     }
-
-    &--vertical {
-        line {
-            // Hide line ticks visually and hide them from voice over
-            stroke-width: 0;
-        }
-    }
 }

--- a/client/wildcard/src/components/Charts/core/components/axis/Axis.tsx
+++ b/client/wildcard/src/components/Charts/core/components/axis/Axis.tsx
@@ -9,8 +9,6 @@ import {
 } from '@visx/axis'
 import { GridRows } from '@visx/grid'
 import { Group } from '@visx/group'
-import { TextProps } from '@visx/text'
-import classNames from 'classnames'
 
 import { Tick } from './Tick'
 import { formatYTick, getXScaleTicks, getYScaleTicks } from './tick-formatters'
@@ -18,10 +16,11 @@ import { formatYTick, getXScaleTicks, getYScaleTicks } from './tick-formatters'
 import styles from './Axis.module.scss'
 
 // TODO: Remove this prop generation, see https://github.com/sourcegraph/sourcegraph/issues/39874
-const getTickYLabelProps: TickLabelProps<number> = (value, index, values): Partial<TextProps> => ({
+const getTickYLabelProps: TickLabelProps<number> = value => ({
     dy: '0.25em',
     textAnchor: 'end',
-    'aria-label': `Tick axis ${index + 1} of ${values.length}. Value: ${value}`,
+    'aria-label': `Axis tick, Value: ${value}`,
+    role: 'listitem',
 })
 
 type OwnSharedAxisProps = Omit<SharedAxisProps<AxisScale>, 'tickLabelProps'>
@@ -57,9 +56,10 @@ export const AxisLeft = memo(
                     scale={scale}
                     tickValues={tickValues}
                     className={styles.gridLine}
+                    aria-hidden={true}
                 />
 
-                <Group innerRef={reference} top={top} left={left}>
+                <Group innerRef={reference} top={top} left={left} role="list" aria-label="X axis">
                     <VisxAxisLeft
                         {...attributes}
                         scale={scale}
@@ -67,8 +67,8 @@ export const AxisLeft = memo(
                         tickFormat={tickFormat}
                         tickLabelProps={getTickYLabelProps}
                         tickComponent={tickComponent}
-                        axisLineClassName={classNames(styles.axisLine, styles.axisLineVertical)}
-                        tickClassName={classNames(styles.axisTick, styles.axisTickVertical)}
+                        hideTicks={true}
+                        hideAxisLine={true}
                     />
                 </Group>
             </>
@@ -79,9 +79,10 @@ export const AxisLeft = memo(
 AxisLeft.displayName = 'AxisLeft'
 
 // TODO: Remove this prop generation, see https://github.com/sourcegraph/sourcegraph/issues/39874
-const getTickXLabelProps: TickLabelProps<Date> = (value, index, values): Partial<TextProps> => ({
-    'aria-label': `Tick axis ${index + 1} of ${values.length}. Value: ${value}`,
+const getTickXLabelProps: TickLabelProps<Date> = value => ({
+    'aria-label': `Axis tick, Value: ${value}`,
     textAnchor: 'middle',
+    role: 'listitem',
 })
 
 export interface AxisBottomProps extends OwnSharedAxisProps {
@@ -93,7 +94,7 @@ export const AxisBottom = memo(
         const { scale, top, left, width, tickValues, tickComponent = Tick, ...attributes } = props
 
         return (
-            <Group innerRef={reference} top={top} left={left} width={width}>
+            <Group innerRef={reference} top={top} left={left} width={width} role="list" aria-label="X axis">
                 <VisxAsixBottom
                     {...attributes}
                     scale={scale}
@@ -102,6 +103,7 @@ export const AxisBottom = memo(
                     tickLabelProps={getTickXLabelProps}
                     axisLineClassName={styles.axisLine}
                     tickClassName={styles.axisTick}
+                    tickLineProps={{ 'aria-hidden': true }}
                 />
             </Group>
         )

--- a/client/wildcard/src/components/Charts/core/components/axis/Tick.tsx
+++ b/client/wildcard/src/components/Charts/core/components/axis/Tick.tsx
@@ -18,6 +18,7 @@ export const Tick: FC<TickProps> = props => {
         formattedValue = '',
         className,
         'aria-label': ariaLabel,
+        role = 'listitem',
         getTruncatedTick,
         ...tickLabelProps
     } = props
@@ -36,8 +37,7 @@ export const Tick: FC<TickProps> = props => {
     // phrase in voice over we hide nested children from a11y tree and put explicit aria-label
     // on the parent Group element with role text
     return (
-        // eslint-disable-next-line jsx-a11y/aria-role
-        <Group role="text" aria-label={ariaLabel}>
+        <Group role={role} aria-label={ariaLabel}>
             <text
                 aria-hidden={true}
                 className={classNames(styles.tick, className)}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/40873

https://user-images.githubusercontent.com/18492575/193600060-d89dd863-5e70-4334-a7d8-ffd9fad763eb.mov

Note: there is a small problem with empty group over axis ticks, this comes from the fact that aria description doesn't work properly for axis tick elements and we can't use visual hidden element because we use `dangerouslySetInnerHTML` in order to fix other problems with empty ticks measurements that we had with search aggregation project. 

Also in Safari X axis tick line is pronounced, it should be hidden from voice over but Visx doesn't expose any api for this line. I will address this problem later with fixing this right in visx UI axis components.

## Todo 
- [x] Fix voice over UX
- [x] Fix focus management flow

## Test plan
- Open bar chart storybook demo and go through the first and the third (one group chart and multi groups bar chart) chart with Voice over
- Try to navigate with keyboard in storybook stories
- Check that the aggregation search bar chart works properly with voice over and focus management (all links/bars should be reachable through keyboard) 
- Check Voice over navigation in Safari (apparently there are a few differences) 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-bar-chart-focus.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-svfbsfjepx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
