### PR TITLE
remove 3.25 pinned version from docs link

### DIFF
--- a/doc/dev/background-information/workers.md
+++ b/doc/dev/background-information/workers.md
@@ -12,7 +12,7 @@ Examples:
 
 A **worker** is an generic process configured with a _store_ and a _handler_. In short, the store describes how to interact with where jobs are persisted; the handler (supplied by the user) describes how to process each job. Both of these components will be discussed in more detail below.
 
-The **store** is responsible for selecting the next available job from the backing persistence layer and suitably _locking_ it from other consumers as well as updating the job records as they make progress in the handler. Generally, this will be an instance of [dbworker/store.Store](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v3.25.0/-/blob/internal/workerutil/dbworker/store/store.go#L204:6), although there are [other implementations](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v3.25.0/-/blob/enterprise/cmd/executor/internal/apiclient/client.go#L51:6).
+The **store** is responsible for selecting the next available job from the backing persistence layer and suitably _locking_ it from other consumers as well as updating the job records as they make progress in the handler. Generally, this will be an instance of [dbworker/store.Store](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Einternal/workerutil/dbworker/store/store%5C.go+NewStore&patternType=standard), although there are [other implementations](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v3.25.0/-/blob/enterprise/cmd/executor/internal/apiclient/client.go#L51:6).
 
 The **handler** is responsible for handling a single job once dequeued from the associated store. Handlers can be fairly minimal, but there are a number of hooks which can be overridden to customize the behavior of the worker.
 


### PR DESCRIPTION
The docs here linked to version 3.25 of workerutil which is quite out of date, this changes the link to a search on latest.

## Test plan

N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
