### PR TITLE
docs/update Update AMI links to cover all regions.

### DIFF
--- a/doc/admin/deploy/aws-ami.md
+++ b/doc/admin/deploy/aws-ami.md
@@ -38,27 +38,29 @@ Following these docs will provision the following resources:
 8. Click **Launch instance**, and navigate to the public IP address in your browser. (Look for the IPv4 Public IP value in your EC2
    instance page under the Description panel.)
 
-Once the instance has started, please allow ~5 minutes for Sourcegraph to initialize. (During this time you may observe a `404 page not found` response.)
+Once the instance has started, please allow ~5 minutes for Sourcegraph to initialize. During this time you may observe a `404 page not found` response.
 
 To configure SSL, and lock down the instance from the public internet, see the [networking](#networking) section.
 
-> NOTE: If you cannot access the Sourcegraph homepage after 8 minutes, please try reboot your instance.
+> NOTE: If you cannot access the Sourcegraph homepage after 10 minutes, please try reboot your instance.
 
 ### Instance size chart
 
 Select an AMI according to the number of users and repositories you have using this table. If you fall between two sizes, choose the larger of the two.
 
+For example, if you have 8,000 users with 80,000 repositories, your instance size would be **M**. If you have 1,000 users with 80,000 repositories, you should still go with size **M**.
+
 |                  |                                                  **XS**                                                  |                        **S**                         |                        **M**                         |                                                  **L**                                                  |                                                  **XL**                                                  |
 | :--------------- | :------------------------------------------------------------------------------------------------------: | :--------------------------------------------------: | :--------------------------------------------------: | :-----------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------------: |
 | **Users**        |                                                   500                                                    |                        1,000                         |                        5,000                         |                                                 10,000                                                  |                                                  20,000                                                  |
 | **Repositories** |                                                  5,000                                                   |                        10,000                        |                        50,000                        |                                                 100,000                                                 |                                                 250,000                                                  |
-| **Recommended**  |                                               m6a.2xlarge                                                |                     m6a.4xlarge                      |                     m6a.8xlarge                      |                                              m6a.12xlarge                                               |                                               m6a.24xlarge                                               |
-| **Minimum**      |                                               m6a.2xlarge                                                |                     m6a.2xlarge                      |                     m6a.4xlarge                      |                                               m6a.8xlarge                                               |                                               m6a.12xlarge                                               |
-| **AMI (Latest Release)** | [sourcegraph-XS (v4.0.0)](https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#ImageDetails:imageId=ami-0ee5cdc5e89a4bee2) | [sourcegraph-S (v4.0.0)](https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#ImageDetails:imageId=ami-0d23989399a89b0dc) | [sourcegraph-M (v4.0.0)](https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#ImageDetails:imageId=ami-0f23794abf480565e) | [sourcegraph-L (v4.0.0)](https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#ImageDetails:imageId=ami-021db30b6db9b0634) | [sourcegraph-XL (v4.0.0)](https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#ImageDetails:imageId=ami-04b10e0fabedb6eac) |
+| **Recommended Type**  |                                               m6a.2xlarge                                                |                     m6a.4xlarge                      |                     m6a.8xlarge                      |                                              m6a.12xlarge                                               |                                               m6a.24xlarge                                               |
+| **Minimum Type**      |                                               m6a.2xlarge                                                |                     m6a.2xlarge                      |                     m6a.4xlarge                      |                                               m6a.8xlarge                                               |                                               m6a.12xlarge                                               |
+| **AMIs List** | [size-XS AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-XS) | [size-S AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-S) | [size-M AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-M) | [size-L AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-L) | [size-XL AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-XL) |
 
-<span class="badge badge-critical">IMPORTANT</span> AMIs are currently only available in the **us-west-2 (Oregon)** region. More regions are coming soon.
+Click [here](https://github.com/sourcegraph/deploy#amazon-ec2-amis) to see the completed list of AMI IDs published in each region.
 
-For example, if you have 8,000 users with 80,000 repositories, your instance size would be **M**. If you have 1,000 users with 80,000 repositories, you should still go with size **M**.
+<span class="badge badge-critical">IMPORTANT</span> The default AMI user name is **ec2-user**.
 
 > NOTE: AMIs are optimized for the specific set of resources provided by the instance type, please ensure you use the correct AMI for the associated EC2 instance type. You can [resize your EC2 instance anytime](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-resize.html), but your Sourcegraph AMI must match accordingly. If needed, follow the [upgrade steps](#upgrade) to switch to the correct AMI image that is optimized for your EC2 instance type.
 


### PR DESCRIPTION
Close: https://github.com/sourcegraph/sourcegraph/issues/41771
RE: https://sourcegraph.slack.com/archives/C02VDNKBWDU/p1664823430464849

AMIs are now published in all regions [[list of AMIs](https://github.com/sourcegraph/deploy#releases)], update AMI links to not link to a specific region only so that the link would work for all regions.

Also update docs to include the default AMI user as brought up in [this slack thread](https://sourcegraph.slack.com/archives/C02QXK6PKMX/p1664823144859459?thread_ts=1664298017.917229&cid=C02QXK6PKMX).

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Manually tested. The links will bring up the AMI for each size associated with each region. 