### PR TITLE
ranking: Add initial service

### DIFF
--- a/enterprise/cmd/worker/internal/codeintel/ranking_indexer.go
+++ b/enterprise/cmd/worker/internal/codeintel/ranking_indexer.go
@@ -1,0 +1,39 @@
+package codeintel
+
+import (
+	"context"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/codeintel"
+
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/ranking/background/indexer"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+)
+
+type rankingIndexerJob struct{}
+
+func NewRankingIndexerJob() job.Job {
+	return &rankingIndexerJob{}
+}
+
+func (j *rankingIndexerJob) Description() string {
+	return ""
+}
+
+func (j *rankingIndexerJob) Config() []env.Config {
+	return []env.Config{
+		indexer.ConfigInst,
+	}
+}
+
+func (j *rankingIndexerJob) Routines(startupCtx context.Context, logger log.Logger) ([]goroutine.BackgroundRoutine, error) {
+	services, err := codeintel.InitServices()
+	if err != nil {
+		return nil, err
+	}
+
+	return indexer.NewIndexer(services.RankingService), nil
+}

--- a/enterprise/cmd/worker/main.go
+++ b/enterprise/cmd/worker/main.go
@@ -56,7 +56,6 @@ func main() {
 		"export-usage-telemetry":        telemetry.NewTelemetryJob(),
 		"webhook-build-job":             repos.NewWebhookBuildJob(),
 
-		// fresh
 		"codeintel-upload-janitor":                    codeintel.NewUploadJanitorJob(),
 		"codeintel-upload-expirer":                    codeintel.NewUploadExpirerJob(),
 		"codeintel-commitgraph-updater":               codeintel.NewCommitGraphUpdaterJob(),
@@ -65,6 +64,9 @@ func main() {
 		"codeintel-autoindexing-dependency-scheduler": codeintel.NewAutoindexingDependencySchedulerJob(),
 		"codeintel-autoindexing-janitor":              codeintel.NewAutoindexingJanitorJob(),
 		"codeintel-metrics-reporter":                  codeintel.NewMetricsReporterJob(),
+
+		// Note: experimental (not documented)
+		"codeintel-ranking-indexer": codeintel.NewRankingIndexerJob(),
 	}
 
 	if err := shared.Start(logger, additionalJobs, migrations.RegisterEnterpriseMigrators); err != nil {

--- a/internal/codeintel/ranking/README.md
+++ b/internal/codeintel/ranking/README.md
@@ -1,0 +1,3 @@
+# Ranking
+
+This package is an experimental service to show value in ranking search results. Do not depend on this API as it's unlikely to remain stable for some time.

--- a/internal/codeintel/ranking/background/indexer/config.go
+++ b/internal/codeintel/ranking/background/indexer/config.go
@@ -1,0 +1,19 @@
+package indexer
+
+import (
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/env"
+)
+
+type config struct {
+	env.BaseConfig
+
+	Interval time.Duration
+}
+
+var ConfigInst = &config{}
+
+func (c *config) Load() {
+	c.Interval = c.GetInterval("CODEINTEL_RANKING_INDEXER_INTERVAL", "10s", "The frequency with which to run periodic codeintel rank indexing tasks.")
+}

--- a/internal/codeintel/ranking/background/indexer/iface.go
+++ b/internal/codeintel/ranking/background/indexer/iface.go
@@ -1,0 +1,11 @@
+package indexer
+
+import (
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+)
+
+type RankingService interface {
+	RepositoryIndexer(interval time.Duration) goroutine.BackgroundRoutine
+}

--- a/internal/codeintel/ranking/background/indexer/init.go
+++ b/internal/codeintel/ranking/background/indexer/init.go
@@ -1,0 +1,11 @@
+package indexer
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+)
+
+func NewIndexer(rankingSvc RankingService) []goroutine.BackgroundRoutine {
+	return []goroutine.BackgroundRoutine{
+		rankingSvc.RepositoryIndexer(ConfigInst.Interval),
+	}
+}

--- a/internal/codeintel/ranking/indexer.go
+++ b/internal/codeintel/ranking/indexer.go
@@ -27,6 +27,5 @@ func (s *Service) indexRepositories(ctx context.Context) (err error) {
 	_, _, endObservation := s.operations.indexRepositories.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	// TODO
 	return errors.New("codeintel.ranking.service.indexRepositories unimplemented")
 }

--- a/internal/codeintel/ranking/indexer.go
+++ b/internal/codeintel/ranking/indexer.go
@@ -1,0 +1,24 @@
+package ranking
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+func (s *Service) RepositoryIndexer(interval time.Duration) goroutine.BackgroundRoutine {
+	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.HandlerFunc(func(ctx context.Context) error {
+		return s.indexRepositories(ctx)
+	}))
+}
+
+func (s *Service) indexRepositories(ctx context.Context) (err error) {
+	_, _, endObservation := s.operations.indexRepositories.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	// TODO
+	return errors.New("codeintel.ranking.service.indexRepositories unimplemented")
+}

--- a/internal/codeintel/ranking/indexer.go
+++ b/internal/codeintel/ranking/indexer.go
@@ -3,6 +3,8 @@ package ranking
 import (
 	"context"
 	"errors"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
@@ -15,7 +17,13 @@ func (s *Service) RepositoryIndexer(interval time.Duration) goroutine.Background
 	}))
 }
 
+var rankingEnabled, _ = strconv.ParseBool(os.Getenv("ENABLE_EXPERIMENTAL_RANKING"))
+
 func (s *Service) indexRepositories(ctx context.Context) (err error) {
+	if !rankingEnabled {
+		return nil
+	}
+
 	_, _, endObservation := s.operations.indexRepositories.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 

--- a/internal/codeintel/ranking/init.go
+++ b/internal/codeintel/ranking/init.go
@@ -1,0 +1,34 @@
+package ranking
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads"
+	"github.com/sourcegraph/sourcegraph/internal/memo"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+// GetService creates or returns an already-initialized ranking service.
+// If the service is not yet initialized, it will use the provided dependencies.
+func GetService(
+	uploadSvc *uploads.Service,
+) *Service {
+	svc, _ := initServiceMemo.Init(serviceDependencies{
+		uploadSvc,
+	})
+
+	return svc
+}
+
+type serviceDependencies struct {
+	uploadsService *uploads.Service
+}
+
+var initServiceMemo = memo.NewMemoizedConstructorWithArg(func(deps serviceDependencies) (*Service, error) {
+	return newService(
+		deps.uploadsService,
+		scopedContext("service"),
+	), nil
+})
+
+func scopedContext(component string) *observation.Context {
+	return observation.ScopedContext("codeintel", "ranking", component)
+}

--- a/internal/codeintel/ranking/observability.go
+++ b/internal/codeintel/ranking/observability.go
@@ -1,0 +1,35 @@
+package ranking
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type operations struct {
+	getRepoRank       *observation.Operation
+	indexRepositories *observation.Operation
+}
+
+func newOperations(observationContext *observation.Context) *operations {
+	m := metrics.NewREDMetrics(
+		observationContext.Registerer,
+		"codeintel_ranking",
+		metrics.WithLabels("op"),
+		metrics.WithCountHelp("Total number of method invocations."),
+	)
+
+	op := func(name string) *observation.Operation {
+		return observationContext.Operation(observation.Op{
+			Name:              fmt.Sprintf("codeintel.ranking.%s", name),
+			MetricLabelValues: []string{name},
+			Metrics:           m,
+		})
+	}
+
+	return &operations{
+		getRepoRank:       op("GetRepoRank"),
+		indexRepositories: op("IndexRepositories"),
+	}
+}

--- a/internal/codeintel/ranking/observability.go
+++ b/internal/codeintel/ranking/observability.go
@@ -9,6 +9,7 @@ import (
 
 type operations struct {
 	getRepoRank       *observation.Operation
+	getDocumentRanks  *observation.Operation
 	indexRepositories *observation.Operation
 }
 
@@ -30,6 +31,7 @@ func newOperations(observationContext *observation.Context) *operations {
 
 	return &operations{
 		getRepoRank:       op("GetRepoRank"),
+		getDocumentRanks:  op("GetDocumentRanks"),
 		indexRepositories: op("IndexRepositories"),
 	}
 }

--- a/internal/codeintel/ranking/service.go
+++ b/internal/codeintel/ranking/service.go
@@ -35,3 +35,11 @@ func (s *Service) GetRepoRank(ctx context.Context, repoName api.RepoName) (_ flo
 	// TODO
 	return 0, errors.New("codeintel.ranking.service.GetRepoRank unimplemented")
 }
+
+func (s *Service) GetDocumentRanks(ctx context.Context, repoName api.RepoName) (_ map[string]float64, err error) {
+	_, _, endObservation := s.operations.getDocumentRanks.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	// TODO
+	return nil, errors.New("codeintel.ranking.service.GetDocumentRanks unimplemented")
+}

--- a/internal/codeintel/ranking/service.go
+++ b/internal/codeintel/ranking/service.go
@@ -1,0 +1,37 @@
+package ranking
+
+import (
+	"context"
+	"errors"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type Service struct {
+	uploadSvc  *uploads.Service
+	operations *operations
+	logger     log.Logger
+}
+
+func newService(
+	uploadSvc *uploads.Service,
+	observationContext *observation.Context,
+) *Service {
+	return &Service{
+		uploadSvc:  uploadSvc,
+		operations: newOperations(observationContext),
+		logger:     observationContext.Logger,
+	}
+}
+
+func (s *Service) GetRepoRank(ctx context.Context, repoName api.RepoName) (_ float64, err error) {
+	_, _, endObservation := s.operations.getRepoRank.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	// TODO
+	return 0, errors.New("codeintel.ranking.service.GetRepoRank unimplemented")
+}

--- a/internal/codeintel/ranking/service.go
+++ b/internal/codeintel/ranking/service.go
@@ -32,7 +32,6 @@ func (s *Service) GetRepoRank(ctx context.Context, repoName api.RepoName) (_ flo
 	_, _, endObservation := s.operations.getRepoRank.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	// TODO
 	return 0, errors.New("codeintel.ranking.service.GetRepoRank unimplemented")
 }
 
@@ -40,6 +39,5 @@ func (s *Service) GetDocumentRanks(ctx context.Context, repoName api.RepoName) (
 	_, _, endObservation := s.operations.getDocumentRanks.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	// TODO
 	return nil, errors.New("codeintel.ranking.service.GetDocumentRanks unimplemented")
 }


### PR DESCRIPTION
This is a stub implementation of a codeintel ranking service. Next steps (post-merge) will be to:

1. Add usable stub implementations (star count + lexicographic ordering of files)
2. Have @keegancsmith integrate with a branch of search code that consumes these rankings
3. Begin indexing repo rankings in the background
4. Modify service API definitions to return indexed rank when it exists (discuss fallback expectations)

## Test plan

No new testable behavior.