### PR TITLE
sg: allow injecting custom headers to Grafana

### DIFF
--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -968,6 +968,8 @@ Flags:
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--grafana.creds="<value>"`: Credentials for the Grafana instance to reload (default: admin:admin)
 * `--grafana.dir="<value>"`: Output directory for generated Grafana assets (default: $SG_ROOT/docker-images/grafana/config/provisioning/dashboards/sourcegraph/)
+* `--grafana.folder="<value>"`: Folder on Grafana instance to put generated dashboards in
+* `--grafana.headers="<value>"`: Additional headers for HTTP requests to the Grafana instance
 * `--grafana.url="<value>"`: Address for the Grafana instance to reload (default: http://127.0.0.1:3370)
 * `--inject-label-matcher="<value>"`: Labels to inject into all selectors in Prometheus expressions: observable queries, dashboard template variables, etc.
 * `--no-prune`: Toggles pruning of dangling generated assets through simple heuristic - should be disabled during builds.

--- a/monitoring/command/generate.go
+++ b/monitoring/command/generate.go
@@ -73,6 +73,10 @@ func Generate(cmdRoot string, sgRoot string) *cli.Command {
 				EnvVars: []string{"GRAFANA_HEADERS"},
 				Usage:   "Additional headers for HTTP requests to the Grafana instance",
 			},
+			&cli.StringFlag{
+				Name:  "grafana.folder",
+				Usage: "Folder on Grafana instance to put generated dashboards in",
+			},
 
 			&cli.StringFlag{
 				Name:    "prometheus.dir",
@@ -127,6 +131,7 @@ func Generate(cmdRoot string, sgRoot string) *cli.Command {
 				GrafanaDir:         os.Expand(c.String("grafana.dir"), expandWithSgRoot),
 				GrafanaURL:         c.String("grafana.url"),
 				GrafanaCredentials: c.String("grafana.creds"),
+				GrafanaFolder:      c.String("grafana.folder"),
 				GrafanaHeaders: func() map[string]string {
 					h := make(map[string]string)
 					for _, entry := range c.StringSlice("grafana.headers") {

--- a/monitoring/command/generate.go
+++ b/monitoring/command/generate.go
@@ -73,6 +73,7 @@ func Generate(cmdRoot string, sgRoot string) *cli.Command {
 				EnvVars: []string{"GRAFANA_HEADERS"},
 				Usage:   "Additional headers for HTTP requests to the Grafana instance",
 			},
+
 			&cli.StringFlag{
 				Name:    "prometheus.dir",
 				EnvVars: []string{"PROMETHEUS_DIR"},

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/grafana-tools/sdk"
+	grafanasdk "github.com/grafana-tools/sdk"
 	"github.com/prometheus/prometheus/model/labels"
 	"gopkg.in/yaml.v2"
 
@@ -34,8 +34,10 @@ type GenerateOptions struct {
 	// GrafanaCredentials is the basic auth credentials for the Grafana instance at
 	// GrafanaURL, e.g. "admin:admin"
 	GrafanaCredentials string
-	//GrafanaHeaders are additional HTTP headers to add to all requests to the target Grafana instance
+	// GrafanaHeaders are additional HTTP headers to add to all requests to the target Grafana instance
 	GrafanaHeaders map[string]string
+	// GrafanaFolder is the folder on the destination Grafana instance to upload the dashboards to
+	GrafanaFolder string
 
 	// Output directory for generated Prometheus assets
 	PrometheusDir string
@@ -53,6 +55,8 @@ type GenerateOptions struct {
 
 // Generate is the main Sourcegraph monitoring generator entrypoint.
 func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard) error {
+	ctx := context.TODO()
+
 	logger.Info("Regenerating monitoring", log.String("options", fmt.Sprintf("%+v", opts)))
 
 	var generatedAssets []string
@@ -69,22 +73,117 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 		return errors.Wrap(validationErrors, "Validation failed")
 	}
 
-	// Generate Grafana content for all dashboards
+	// Set up disk directories
+	if opts.GrafanaDir != "" {
+		os.MkdirAll(opts.GrafanaDir, os.ModePerm)
+	}
+	if opts.PrometheusDir != "" {
+		os.MkdirAll(opts.PrometheusDir, os.ModePerm)
+	}
+	if opts.DocsDir != "" {
+		os.MkdirAll(opts.DocsDir, os.ModePerm)
+	}
+
+	// Generate Grafana content for all dashboards. If grafanaClient is not nil, Grafana
+	// should be reloaded.
+	var grafanaClient *grafanasdk.Client
+	var grafanaFolderID int
+	if opts.GrafanaURL != "" && opts.Reload {
+		gclog := logger.Scoped("grafana.client", "grafana client setup")
+
+		// DefaultHTTPClient is used unless additional headers are requested
+		httpClient := grafanasdk.DefaultHTTPClient
+		if len(opts.GrafanaHeaders) > 0 {
+			gclog.Debug("Adding additional headers to Grafana requests",
+				log.String("headers", fmt.Sprintf("%v", opts.GrafanaHeaders)))
+			httpClient.Transport = headertransport.NewAddHeaderTransport(httpClient.Transport, opts.GrafanaHeaders)
+		}
+
+		// Init Grafana client
+		var err error
+		grafanaClient, err = grafanasdk.NewClient(opts.GrafanaURL, opts.GrafanaCredentials, httpClient)
+		if err != nil {
+			return errors.Wrap(err, "Failed to initialize Grafana client")
+		}
+		if opts.GrafanaFolder != "" {
+			gclog.Debug("Preparing dashboard folder", log.String("folder", opts.GrafanaFolder))
+
+			// Get all the folders and look up the customer by the customer name (title)
+			folders, err := grafanaClient.GetAllFolders(ctx)
+			if err != nil {
+				return errors.Wrap(err, "Unable to get all folders from Grafana API")
+			}
+			for _, folder := range folders {
+				if folder.Title == opts.GrafanaFolder {
+					gclog.Debug("Found existing folder", log.Int("folder.id", folder.ID))
+					grafanaFolderID = folder.ID
+				}
+			}
+
+			// folderId is not found, create it
+			if grafanaFolderID == 0 {
+				gclog.Debug("No existing folder found, creating a new one")
+				folder, err := grafanaClient.CreateFolder(ctx, grafanasdk.Folder{
+					Title: opts.GrafanaFolder,
+				})
+				if err != nil {
+					return errors.Wrapf(err, "Error creating new folder %s", opts.GrafanaFolder)
+				}
+
+				gclog.Debug("Created folder",
+					log.String("folder.title", folder.Title),
+					log.Int("folder.id", folder.ID))
+				grafanaFolderID = folder.ID
+			}
+		}
+	}
+
+	// Generate Garafana home dasboard "Overview"
+	{
+		data, err := grafana.Home(opts.InjectLabelMatchers)
+		if err != nil {
+			return errors.Wrap(err, "failed to generate home dashboard")
+		}
+		if opts.GrafanaDir != "" {
+			generatedDashboard := "home.json"
+			generatedAssets = append(generatedAssets, generatedDashboard)
+			if err = os.WriteFile(filepath.Join(opts.GrafanaDir, generatedDashboard), data, os.ModePerm); err != nil {
+				return errors.Wrap(err, "failed to generate home dashboard")
+			}
+		}
+		if grafanaClient != nil {
+			logger.Debug("Reloading Grafana dashboard",
+				log.Int("folder.id", grafanaFolderID))
+			if _, err := grafanaClient.SetRawDashboardWithParam(ctx, grafanasdk.RawBoardRequest{
+				Dashboard: data,
+				Parameters: grafanasdk.SetDashboardParams{
+					Overwrite: true,
+					FolderID:  grafanaFolderID,
+				},
+			}); err != nil {
+				return errors.Wrapf(err, "Could not reload Grafana dashboard 'Overview'")
+			} else {
+				logger.Info("Reloaded Grafana dashboard")
+			}
+		}
+	}
+
+	// Generate per-dashboard assets
 	for _, dashboard := range dashboards {
 		// Logger for dashboard
 		dlog := logger.With(log.String("dashboard", dashboard.Name))
 
+		glog := dlog.Scoped("grafana", "grafana dashboard generation").
+			With(log.String("instance", opts.GrafanaURL))
+
+		glog.Debug("Rendering Grafana assets")
+		board, err := dashboard.renderDashboard(opts.InjectLabelMatchers, opts.GrafanaFolder)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to render dashboard %q", dashboard.Name)
+		}
+
 		// Prepare Grafana assets
 		if opts.GrafanaDir != "" {
-			glog := dlog.Scoped("grafana", "grafana dashboard generation").
-				With(log.String("instance", opts.GrafanaURL))
-			os.MkdirAll(opts.GrafanaDir, os.ModePerm)
-
-			glog.Debug("Rendering Grafana assets")
-			board, err := dashboard.renderDashboard(opts.InjectLabelMatchers)
-			if err != nil {
-				return errors.Wrapf(err, "Failed to render dashboard %q", dashboard.Name)
-			}
 			data, err := json.MarshalIndent(board, "", "  ")
 			if err != nil {
 				return errors.Wrapf(err, "Invalid dashboard %q", dashboard.Name)
@@ -96,51 +195,24 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 				return errors.Wrapf(err, "Could not write dashboard %q to output", dashboard.Name)
 			}
 			generatedAssets = append(generatedAssets, generatedDashboard)
-
-			// Reload specific dashboard
-			if opts.Reload {
-
-				// DefaultHTTPClient is used unless additional headers are requested
-				httpClient := sdk.DefaultHTTPClient
-
-				if len(opts.GrafanaHeaders) > 0 {
-					glog.Debug("Adding additional headers to Grafana requests", log.String("headers", fmt.Sprintf("%v", opts.GrafanaHeaders))
-					adt := headertransport.NewAddHeaderTransport(httpClient.Transport, opts.GrafanaHeaders)
-					httpClient.Transport = adt
-				}
-
-				glog.Debug("Reloading Grafana instance")
-				client, err := sdk.NewClient(opts.GrafanaURL, opts.GrafanaCredentials, httpClient)
-				if err != nil {
-					return errors.Wrapf(err, "Failed to initialize Grafana client for dashboard %q", dashboard.Title)
-				}
-				_, err = client.SetDashboard(context.Background(), *board, sdk.SetDashboardParams{Overwrite: true})
-				if err != nil {
-					return errors.Wrapf(err, "Could not reload Grafana instance for dashboard %q", dashboard.Title)
-				} else {
-					glog.Info("Reloaded Grafana instance")
-				}
-			}
 		}
-
-		// Generate home page
-		if opts.GrafanaDir != "" {
-			data, err := grafana.Home(opts.InjectLabelMatchers)
-			if err != nil {
-				return errors.Wrap(err, "failed to generate home dashboard")
-			}
-			generatedDashboard := "home.json"
-			generatedAssets = append(generatedAssets, generatedDashboard)
-			if err = os.WriteFile(filepath.Join(opts.GrafanaDir, generatedDashboard), data, os.ModePerm); err != nil {
-				return errors.Wrap(err, "failed to generate home dashboard")
+		// Reload specific dashboard
+		if grafanaClient != nil {
+			glog.Debug("Reloading Grafana dashboard",
+				log.Int("folder.id", grafanaFolderID))
+			if _, err := grafanaClient.SetDashboard(ctx, *board, grafanasdk.SetDashboardParams{
+				Overwrite: true,
+				FolderID:  grafanaFolderID,
+			}); err != nil {
+				return errors.Wrapf(err, "Could not reload Grafana dashboard %q", dashboard.Title)
+			} else {
+				glog.Info("Reloaded Grafana dashboard")
 			}
 		}
 
 		// Prepare Prometheus assets
 		if opts.PrometheusDir != "" {
 			plog := dlog.Scoped("prometheus", "prometheus rules generation")
-
-			os.MkdirAll(opts.PrometheusDir, os.ModePerm)
 
 			plog.Debug("Rendering Prometheus assets")
 			promAlertsFile, err := dashboard.renderRules(opts.InjectLabelMatchers)
@@ -198,8 +270,6 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 
 	// Generate documentation
 	if opts.DocsDir != "" {
-		os.MkdirAll(opts.DocsDir, os.ModePerm)
-
 		logger.Debug("Rendering docs")
 		docs, err := renderDocumentation(dashboards)
 		if err != nil {

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring/internal/grafana"
+	"github.com/sourcegraph/sourcegraph/monitoring/monitoring/internal/headertransport"
 )
 
 // GenerateOptions declares options for the monitoring generator.
@@ -105,7 +106,7 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 				if len(opts.GrafanaHeaders) > 0 {
 					glog.Debug("Adding additional headers to Grafana requests")
 					glog.Debug(fmt.Sprintf("%v", opts.GrafanaHeaders))
-					adt := NewAddHeaderTransport(httpClient.Transport, opts.GrafanaHeaders)
+					adt := headertransport.NewAddHeaderTransport(httpClient.Transport, opts.GrafanaHeaders)
 					httpClient.Transport = adt
 				}
 

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -105,7 +105,7 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 				if len(opts.GrafanaHeaders) > 0 {
 					glog.Debug("Adding additional headers to Grafana requests")
 					glog.Debug(fmt.Sprintf("%v", opts.GrafanaHeaders))
-					adt := NewAddHeaderTransport(nil, opts.GrafanaHeaders)
+					adt := NewAddHeaderTransport(httpClient.Transport, opts.GrafanaHeaders)
 					httpClient.Transport = adt
 				}
 

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -96,7 +96,7 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 		if len(opts.GrafanaHeaders) > 0 {
 			gclog.Debug("Adding additional headers to Grafana requests",
 				log.String("headers", fmt.Sprintf("%v", opts.GrafanaHeaders)))
-			httpClient.Transport = headertransport.NewAddHeaderTransport(httpClient.Transport, opts.GrafanaHeaders)
+			httpClient.Transport = headertransport.New(httpClient.Transport, opts.GrafanaHeaders)
 		}
 
 		// Init Grafana client

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -104,8 +104,7 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 				httpClient := sdk.DefaultHTTPClient
 
 				if len(opts.GrafanaHeaders) > 0 {
-					glog.Debug("Adding additional headers to Grafana requests")
-					glog.Debug(fmt.Sprintf("%v", opts.GrafanaHeaders))
+					glog.Debug("Adding additional headers to Grafana requests", log.String("headers", fmt.Sprintf("%v", opts.GrafanaHeaders))
 					adt := headertransport.NewAddHeaderTransport(httpClient.Transport, opts.GrafanaHeaders)
 					httpClient.Transport = adt
 				}

--- a/monitoring/monitoring/http.go
+++ b/monitoring/monitoring/http.go
@@ -1,0 +1,28 @@
+package monitoring
+
+import "net/http"
+
+// AddHeaderTransport implements http.RoundTripper and allows us to inject
+// additional HTTP headers on requests
+type AddHeaderTransport struct {
+	T http.RoundTripper
+
+	additionalHeaders map[string]string
+}
+
+func (adt *AddHeaderTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	for header, value := range adt.additionalHeaders {
+		req.Header.Add(header, value)
+	}
+	return adt.T.RoundTrip(req)
+}
+
+func NewAddHeaderTransport(T http.RoundTripper, headers map[string]string) *AddHeaderTransport {
+	if T == nil {
+		T = http.DefaultTransport
+	}
+	return &AddHeaderTransport{
+		T:                 T,
+		additionalHeaders: headers,
+	}
+}

--- a/monitoring/monitoring/internal/grafana/home.json.tmpl
+++ b/monitoring/monitoring/internal/grafana/home.json.tmpl
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 28,
+  "id": 0,
   "links": [],
   "panels": [
     {

--- a/monitoring/monitoring/internal/headertransport/headertransport.go
+++ b/monitoring/monitoring/internal/headertransport/headertransport.go
@@ -17,7 +17,7 @@ func (adt *AddHeaderTransport) RoundTrip(req *http.Request) (*http.Response, err
 	return adt.T.RoundTrip(req)
 }
 
-func NewAddHeaderTransport(t http.RoundTripper, headers map[string]string) *AddHeaderTransport {
+func New(t http.RoundTripper, headers map[string]string) *AddHeaderTransport {
 	if t == nil {
 		t = http.DefaultTransport
 	}

--- a/monitoring/monitoring/internal/headertransport/headertransport.go
+++ b/monitoring/monitoring/internal/headertransport/headertransport.go
@@ -17,12 +17,12 @@ func (adt *AddHeaderTransport) RoundTrip(req *http.Request) (*http.Response, err
 	return adt.T.RoundTrip(req)
 }
 
-func NewAddHeaderTransport(T http.RoundTripper, headers map[string]string) *AddHeaderTransport {
-	if T == nil {
-		T = http.DefaultTransport
+func NewAddHeaderTransport(t http.RoundTripper, headers map[string]string) *AddHeaderTransport {
+	if t == nil {
+		t = http.DefaultTransport
 	}
 	return &AddHeaderTransport{
-		T:                 T,
+		T:                 t,
 		additionalHeaders: headers,
 	}
 }

--- a/monitoring/monitoring/internal/headertransport/headertransport.go
+++ b/monitoring/monitoring/internal/headertransport/headertransport.go
@@ -1,4 +1,4 @@
-package monitoring
+package headertransport
 
 import "net/http"
 

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -92,10 +92,21 @@ func (c *Dashboard) noAlertsDefined() bool {
 }
 
 // renderDashboard generates the Grafana renderDashboard for this container.
-func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher) (*sdk.Board, error) {
+// UIDs are globally unique identifiers for a given dashboard on Grafana. For normal Sourcegraph usage,
+// there is only ever a single dashboard with a given name but Cloud usage requires multiple copies
+// of the same dashboards to exist for different folders so we allow the ability to inject custom
+// label matchers and folder names to uniquely id the dashboards. UIDs need to be deterministic however
+// to generate appropriate alerts and documentations
+func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher, folder string) (*sdk.Board, error) {
+	// If the folder is not specified simply use the name for the UID
+	uid := c.Name
+	if folder != "" {
+		uid = fmt.Sprintf("%s-%s", folder, uid)
+	}
+
 	board := sdk.NewBoard(c.Title)
 	board.Version = uint(rand.Uint32())
-	board.UID = c.Name
+	board.UID = uid
 	board.ID = 0
 	board.Timezone = "utc"
 	board.Timepicker.RefreshIntervals = []string{"5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"}

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -593,7 +593,6 @@ commands:
         -p 0.0.0.0:3370:3370 ${ADD_HOST_FLAG} \
         -v "${GRAFANA_DISK}":/var/lib/grafana \
         -v "$(pwd)"/dev/grafana/all:/sg_config_grafana/provisioning/datasources \
-        -v "$(pwd)"/docker-images/grafana/config/provisioning/dashboards:/sg_grafana_additional_dashboards \
         sourcegraph/grafana:dev >"${GRAFANA_LOG_FILE}" 2>&1
     install: |
       mkdir -p "${GRAFANA_DISK}"


### PR DESCRIPTION
Allow setting additional headers to be attached to all HTTP requests to a target grafana instances in `sg monitoring generate --reload`.

## Test plan
### Without the headers
```bash
#!/bin/bash

go run ./dev/sg monitoring generate \
	--reload \
	--grafana.url=https://monitoring.sgdev.org \
	--grafana.dir="test" \
	--inject-label-matcher=project_id=sourcegraph-managed-sg \
	--prometheus.dir="" \
	--prometheus.url="" 

❌ Could not reload Grafana instance for dashboard "Frontend": invalid character 'I' looking for beginning of value 
``` 
and the request is rejected. The error presumably comes from trying to JSON decode the IAP oauth page.

### With headers injected
Run with a valid key injected as the `Proxy-Authorization` header:

```bash
#!/bin/bash

TOKEN=$(gcloud auth print-identity-token --audiences="781898298627-fpi0ne87b2nmvrl724hqodhesugnkvhl.apps.googleusercontent.com" --impersonate-service-account="mi-github@sourcegraph-secrets.iam.gserviceaccount.com" --include-email)

go run ./dev/sg monitoring generate \
	--reload \
	--grafana.url=https://monitoring.sgdev.org \
	--grafana.dir="test" \
	--inject-label-matcher=project_id=sourcegraph-managed-sg \
	--prometheus.dir="" \
	--prometheus.url="" \
	--grafana.headers=Proxy-Authorization="Bearer ${TOKEN}"
```
The command will run for a few seconds and the dashboards are updated correctly.