### PR TITLE
Remove gitserver.Mocks.Commits

### DIFF
--- a/cmd/frontend/graphqlbackend/commit_search_result.go
+++ b/cmd/frontend/graphqlbackend/commit_search_result.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
@@ -27,8 +28,9 @@ func (r *CommitSearchResultResolver) Commit() *GitCommitResolver {
 		if r.gitCommitResolver != nil {
 			return
 		}
-		repoResolver := NewRepositoryResolver(r.db, r.Repo.ToRepo())
-		r.gitCommitResolver = NewGitCommitResolver(r.db, repoResolver, r.CommitMatch.Commit.ID, &r.CommitMatch.Commit)
+		gitserverClient := gitserver.NewClient(r.db)
+		repoResolver := NewRepositoryResolver(r.db, gitserverClient, r.Repo.ToRepo())
+		r.gitCommitResolver = NewGitCommitResolver(r.db, gitserverClient, repoResolver, r.CommitMatch.Commit.ID, &r.CommitMatch.Commit)
 	})
 	return r.gitCommitResolver
 }

--- a/cmd/frontend/graphqlbackend/file_match.go
+++ b/cmd/frontend/graphqlbackend/file_match.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
@@ -33,7 +34,7 @@ func (fm *FileMatchResolver) File() *GitTreeEntryResolver {
 }
 
 func (fm *FileMatchResolver) Commit() *GitCommitResolver {
-	commit := NewGitCommitResolver(fm.db, fm.RepoResolver, fm.CommitID, nil)
+	commit := NewGitCommitResolver(fm.db, gitserver.NewClient(fm.db), fm.RepoResolver, fm.CommitID, nil)
 	commit.inputRev = fm.InputRev
 	return commit
 }

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -40,9 +40,10 @@ func (r *schemaResolver) gitCommitByID(ctx context.Context, id graphql.ID) (*Git
 //
 // Prefer using NewGitCommitResolver to create an instance of the commit resolver.
 type GitCommitResolver struct {
-	logger       log.Logger
-	db           database.DB
-	repoResolver *RepositoryResolver
+	logger          log.Logger
+	db              database.DB
+	gitserverClient gitserver.Client
+	repoResolver    *RepositoryResolver
 
 	// inputRev is the Git revspec that the user originally requested that resolved to this Git commit. It is used
 	// to avoid redirecting a user browsing a revision "mybranch" to the absolute commit ID as they follow links in the UI.
@@ -66,9 +67,10 @@ type GitCommitResolver struct {
 // NewGitCommitResolver returns a new CommitResolver. When commit is set to nil,
 // commit will be loaded lazily as needed by the resolver. Pass in a commit when
 // you have batch-loaded a bunch of them and already have them at hand.
-func NewGitCommitResolver(db database.DB, repo *RepositoryResolver, id api.CommitID, commit *gitdomain.Commit) *GitCommitResolver {
+func NewGitCommitResolver(db database.DB, gsClient gitserver.Client, repo *RepositoryResolver, id api.CommitID, commit *gitdomain.Commit) *GitCommitResolver {
 	return &GitCommitResolver{
 		db:              db,
+		gitserverClient: gsClient,
 		repoResolver:    repo,
 		includeUserInfo: true,
 		gitRepo:         repo.RepoName(),
@@ -84,7 +86,7 @@ func (r *GitCommitResolver) resolveCommit(ctx context.Context) (*gitdomain.Commi
 		}
 
 		opts := gitserver.ResolveRevisionOptions{}
-		r.commit, r.commitErr = gitserver.NewClient(r.db).GetCommit(ctx, r.gitRepo, api.CommitID(r.oid), opts, authz.DefaultSubRepoPermsChecker)
+		r.commit, r.commitErr = r.gitserverClient.GetCommit(ctx, r.gitRepo, api.CommitID(r.oid), opts, authz.DefaultSubRepoPermsChecker)
 	})
 	return r.commit, r.commitErr
 }
@@ -257,7 +259,7 @@ func (r *GitCommitResolver) path(ctx context.Context, path string, validate func
 	defer span.Finish()
 	span.SetTag("path", path)
 
-	stat, err := gitserver.NewClient(r.db).Stat(ctx, authz.DefaultSubRepoPermsChecker, r.gitRepo, api.CommitID(r.oid), path)
+	stat, err := r.gitserverClient.Stat(ctx, authz.DefaultSubRepoPermsChecker, r.gitRepo, api.CommitID(r.oid), path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -272,7 +274,7 @@ func (r *GitCommitResolver) path(ctx context.Context, path string, validate func
 }
 
 func (r *GitCommitResolver) FileNames(ctx context.Context) ([]string, error) {
-	return gitserver.NewClient(r.db).LsFiles(ctx, authz.DefaultSubRepoPermsChecker, r.gitRepo, api.CommitID(r.oid))
+	return r.gitserverClient.LsFiles(ctx, authz.DefaultSubRepoPermsChecker, r.gitRepo, api.CommitID(r.oid))
 }
 
 func (r *GitCommitResolver) Languages(ctx context.Context) ([]string, error) {
@@ -319,13 +321,14 @@ func (r *GitCommitResolver) Ancestors(ctx context.Context, args *struct {
 	After *string
 }) (*gitCommitConnectionResolver, error) {
 	return &gitCommitConnectionResolver{
-		db:            r.db,
-		revisionRange: string(r.oid),
-		first:         args.ConnectionArgs.First,
-		query:         args.Query,
-		path:          args.Path,
-		after:         args.After,
-		repo:          r.repoResolver,
+		db:              r.db,
+		gitserverClient: r.gitserverClient,
+		revisionRange:   string(r.oid),
+		first:           args.ConnectionArgs.First,
+		query:           args.Query,
+		path:            args.Path,
+		after:           args.After,
+		repo:            r.repoResolver,
 	}, nil
 }
 
@@ -337,7 +340,8 @@ func (r *GitCommitResolver) Diff(ctx context.Context, args *struct {
 	if args.Base != nil {
 		base = *args.Base
 	}
-	return NewRepositoryComparison(ctx, r.db, r.repoResolver, &RepositoryComparisonInput{
+	client := gitserver.NewClient(r.db)
+	return NewRepositoryComparison(ctx, r.db, client, r.repoResolver, &RepositoryComparisonInput{
 		Base:         &base,
 		Head:         &oidString,
 		FetchMissing: false,
@@ -347,7 +351,7 @@ func (r *GitCommitResolver) Diff(ctx context.Context, args *struct {
 func (r *GitCommitResolver) BehindAhead(ctx context.Context, args *struct {
 	Revspec string
 }) (*behindAheadCountsResolver, error) {
-	counts, err := gitserver.NewClient(r.db).GetBehindAhead(ctx, r.gitRepo, args.Revspec, string(r.oid))
+	counts, err := r.gitserverClient.GetBehindAhead(ctx, r.gitRepo, args.Revspec, string(r.oid))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -21,6 +21,7 @@ import (
 func TestGitCommitResolver(t *testing.T) {
 	ctx := context.Background()
 	db := database.NewMockDB()
+	client := gitserver.NewClient(db)
 
 	commit := &gitdomain.Commit{
 		ID:      "c1",
@@ -39,8 +40,8 @@ func TestGitCommitResolver(t *testing.T) {
 	}
 
 	t.Run("URL Escaping", func(t *testing.T) {
-		repo := NewRepositoryResolver(db, &types.Repo{Name: "xyz"})
-		commitResolver := NewGitCommitResolver(db, repo, "c1", commit)
+		repo := NewRepositoryResolver(db, gitserver.NewClient(db), &types.Repo{Name: "xyz"})
+		commitResolver := NewGitCommitResolver(db, client, repo, "c1", commit)
 		{
 			inputRev := "master^1"
 			commitResolver.inputRev = &inputRev
@@ -115,10 +116,10 @@ func TestGitCommitResolver(t *testing.T) {
 			},
 		}} {
 			t.Run(tc.name, func(t *testing.T) {
-				repo := NewRepositoryResolver(db, &types.Repo{Name: "bob-repo"})
+				repo := NewRepositoryResolver(db, gitserver.NewClient(db), &types.Repo{Name: "bob-repo"})
 				// We pass no commit here to test that it gets lazy loaded via
 				// the git.GetCommit mock above.
-				r := NewGitCommitResolver(db, repo, "c1", nil)
+				r := NewGitCommitResolver(db, client, repo, "c1", nil)
 
 				have, err := tc.have(r)
 				if err != nil {

--- a/cmd/frontend/graphqlbackend/git_tree_entry_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry_test.go
@@ -16,7 +16,7 @@ func TestGitTreeEntry_RawZipArchiveURL(t *testing.T) {
 	db := database.NewMockDB()
 	got := NewGitTreeEntryResolver(db,
 		&GitCommitResolver{
-			repoResolver: NewRepositoryResolver(db, &types.Repo{Name: "my/repo"}),
+			repoResolver: NewRepositoryResolver(db, gitserver.NewClient(db), &types.Repo{Name: "my/repo"}),
 		},
 		CreateFileInfo("a/b", true)).
 		RawZipArchiveURL()
@@ -41,7 +41,7 @@ func TestGitTreeEntry_Content(t *testing.T) {
 	db := database.NewMockDB()
 	gitTree := NewGitTreeEntryResolver(db,
 		&GitCommitResolver{
-			repoResolver: NewRepositoryResolver(db, &types.Repo{Name: "my/repo"}),
+			repoResolver: NewRepositoryResolver(db, gitserver.NewClient(db), &types.Repo{Name: "my/repo"}),
 		},
 		CreateFileInfo(wantPath, true))
 

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -18,7 +18,6 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-
 	sglog "github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -28,6 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	sgtrace "github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
@@ -668,7 +668,7 @@ func (r *schemaResolver) repositoryByID(ctx context.Context, id graphql.ID) (*Re
 	if err != nil {
 		return nil, err
 	}
-	return NewRepositoryResolver(r.db, repo), nil
+	return NewRepositoryResolver(r.db, gitserver.NewClient(r.db), repo), nil
 }
 
 type RedirectResolver struct {
@@ -705,7 +705,7 @@ func (r *schemaResolver) RepositoryRedirect(ctx context.Context, args *repositor
 		if err != nil {
 			return nil, err
 		}
-		return &repositoryRedirect{repo: NewRepositoryResolver(r.db, repo)}, nil
+		return &repositoryRedirect{repo: NewRepositoryResolver(r.db, gitserver.NewClient(r.db), repo)}, nil
 	}
 	var name api.RepoName
 	if args.Name != nil {
@@ -737,7 +737,7 @@ func (r *schemaResolver) RepositoryRedirect(ctx context.Context, args *repositor
 		}
 		return nil, err
 	}
-	return &repositoryRedirect{repo: NewRepositoryResolver(r.db, repo)}, nil
+	return &repositoryRedirect{repo: NewRepositoryResolver(r.db, gitserver.NewClient(r.db), repo)}, nil
 }
 
 func (r *schemaResolver) PhabricatorRepo(ctx context.Context, args *struct {

--- a/cmd/frontend/graphqlbackend/hunk.go
+++ b/cmd/frontend/graphqlbackend/hunk.go
@@ -49,7 +49,7 @@ func (r *hunkResolver) Message() string {
 }
 
 func (r *hunkResolver) Commit(ctx context.Context) (*GitCommitResolver, error) {
-	return NewGitCommitResolver(r.db, r.repo, r.hunk.CommitID, nil), nil
+	return NewGitCommitResolver(r.db, gitserver.NewClient(r.db), r.repo, r.hunk.CommitID, nil), nil
 }
 
 func (r *hunkResolver) Filename() string {

--- a/cmd/frontend/graphqlbackend/preview_repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/preview_repository_comparison_test.go
@@ -100,7 +100,7 @@ index 9bd8209..d2acfa9 100644
 
 	repo := &types.Repo{ID: api.RepoID(1), Name: "github.com/sourcegraph/sourcegraph", CreatedAt: time.Now()}
 
-	previewComparisonResolver, err := NewPreviewRepositoryComparisonResolver(ctx, db, NewRepositoryResolver(db, repo), string(wantHeadRevision), testDiff)
+	previewComparisonResolver, err := NewPreviewRepositoryComparisonResolver(ctx, db, NewRepositoryResolver(db, gitserver.NewClient(db), repo), string(wantHeadRevision), testDiff)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -225,7 +226,7 @@ func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*Repository
 			break
 		}
 
-		resolvers = append(resolvers, NewRepositoryResolver(r.db, repo))
+		resolvers = append(resolvers, NewRepositoryResolver(r.db, gitserver.NewClient(r.db), repo))
 	}
 	return resolvers, nil
 }

--- a/cmd/frontend/graphqlbackend/repository_contributor.go
+++ b/cmd/frontend/graphqlbackend/repository_contributor.go
@@ -30,12 +30,13 @@ func (r *repositoryContributorResolver) Commits(args *struct {
 		revisionRange = *r.args.RevisionRange
 	}
 	return &gitCommitConnectionResolver{
-		db:            r.db,
-		revisionRange: revisionRange,
-		path:          r.args.Path,
-		author:        &r.email, // TODO(sqs): support when contributor resolves to user, and user has multiple emails
-		after:         r.args.AfterDate,
-		first:         args.First,
-		repo:          r.repo,
+		db:              r.db,
+		gitserverClient: r.repo.gitserverClient,
+		revisionRange:   revisionRange,
+		path:            r.args.Path,
+		author:          &r.email, // TODO(sqs): support when contributor resolves to user, and user has multiple emails
+		after:           r.args.AfterDate,
+		first:           args.First,
+		repo:            r.repo,
 	}
 }

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -105,7 +105,7 @@ func TestRepositoryHydration(t *testing.T) {
 		db := database.NewMockDB()
 		db.ReposFunc.SetDefaultReturn(rs)
 
-		repoResolver := NewRepositoryResolver(db, minimalRepo)
+		repoResolver := NewRepositoryResolver(db, gitserver.NewClient(db), minimalRepo)
 		assertRepoResolverHydrated(ctx, t, repoResolver, hydratedRepo)
 		mockrequire.CalledOnce(t, rs.GetFunc)
 	})
@@ -120,7 +120,7 @@ func TestRepositoryHydration(t *testing.T) {
 		db := database.NewMockDB()
 		db.ReposFunc.SetDefaultReturn(rs)
 
-		repoResolver := NewRepositoryResolver(db, minimalRepo)
+		repoResolver := NewRepositoryResolver(db, gitserver.NewClient(db), minimalRepo)
 		_, err := repoResolver.Description(ctx)
 		require.ErrorIs(t, err, dbErr)
 
@@ -207,7 +207,8 @@ func TestRepository_DefaultBranch(t *testing.T) {
 				gitserver.Mocks.ResolveRevision = nil
 			})
 
-			res := &RepositoryResolver{RepoMatch: result.RepoMatch{Name: "repo"}, logger: logtest.Scoped(t)}
+			gsClient := gitserver.NewClient(database.NewMockDB())
+			res := &RepositoryResolver{RepoMatch: result.RepoMatch{Name: "repo"}, logger: logtest.Scoped(t), gitserverClient: gsClient}
 			branch, err := res.DefaultBranch(ctx)
 			if tt.wantErr != nil && err != nil {
 				if tt.wantErr.Error() != err.Error() {

--- a/cmd/frontend/graphqlbackend/repository_text_search_index_test.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index_test.go
@@ -36,7 +36,7 @@ func TestRetrievingAndDeduplicatingIndexedRefs(t *testing.T) {
 	defer gitserver.ResetMocks()
 
 	repoIndexResolver := &repositoryTextSearchIndexResolver{
-		repo: NewRepositoryResolver(db, &types.Repo{Name: "alice/repo"}),
+		repo: NewRepositoryResolver(db, gitserver.NewClient(db), &types.Repo{Name: "alice/repo"}),
 		client: &backend.FakeSearcher{Repos: []*zoekt.RepoListEntry{{
 			Repository: zoekt.Repository{
 				Name: string("alice/repo"),

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -89,7 +89,7 @@ func (c *SearchResultsResolver) repositoryResolvers(ctx context.Context, ids []a
 	err := c.db.Repos().StreamMinimalRepos(ctx, database.ReposListOptions{
 		IDs: ids,
 	}, func(repo *types.MinimalRepo) {
-		resolvers = append(resolvers, NewRepositoryResolver(c.db, repo.ToRepo()))
+		resolvers = append(resolvers, NewRepositoryResolver(c.db, gitserver.NewClient(c.db), repo.ToRepo()))
 	})
 	if err != nil {
 		return nil, err
@@ -143,7 +143,7 @@ func matchesToResolvers(db database.DB, matches []result.Match) []SearchResultRe
 		if existing, ok := repoResolvers[repoKey{repoName, rev}]; ok {
 			return existing
 		}
-		resolver := NewRepositoryResolver(db, repoName.ToRepo())
+		resolver := NewRepositoryResolver(db, gitserver.NewClient(db), repoName.ToRepo())
 		resolver.RepoMatch.Rev = rev
 		repoResolvers[repoKey{repoName, rev}] = resolver
 		return resolver

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -525,7 +526,8 @@ func (r *UserResolver) PublicRepositories(ctx context.Context) ([]*RepositoryRes
 				ID:   repo.RepoID,
 				Name: api.RepoName(repo.RepoURI),
 			},
-			db: r.db,
+			db:              r.db,
+			gitserverClient: gitserver.NewClient(r.db),
 			innerRepo: &types.Repo{
 				ID: repo.RepoID,
 			},

--- a/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -110,7 +111,7 @@ func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*graphqlbac
 	}
 	resolvers := make([]*graphqlbackend.RepositoryResolver, len(repos))
 	for i := range repos {
-		resolvers[i] = graphqlbackend.NewRepositoryResolver(r.db, repos[i])
+		resolvers[i] = graphqlbackend.NewRepositoryResolver(r.db, gitserver.NewClient(r.db), repos[i])
 	}
 	return resolvers, nil
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	gql "github.com/sourcegraph/sourcegraph/internal/services/executors/transport/graphql"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
@@ -47,7 +48,7 @@ func newBatchSpecWorkspaceResolverWithRepo(store *store.Store, workspace *btypes
 		execution:    execution,
 		batchSpec:    batchSpec,
 		repo:         repo,
-		repoResolver: graphqlbackend.NewRepositoryResolver(store.DatabaseDB(), repo),
+		repoResolver: graphqlbackend.NewRepositoryResolver(store.DatabaseDB(), gitserver.NewClient(store.DatabaseDB()), repo),
 	}
 }
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
@@ -80,11 +81,12 @@ func (r *changesetSpecResolver) Type() string {
 }
 
 func (r *changesetSpecResolver) Description(ctx context.Context) (graphqlbackend.ChangesetDescription, error) {
+	db := r.store.DatabaseDB()
 	descriptionResolver := &changesetDescriptionResolver{
 		store: r.store,
 		spec:  r.changesetSpec,
 		// Note: r.repo can never be nil, because Description is a VisibleChangesetSpecResolver-only field.
-		repoResolver: graphqlbackend.NewRepositoryResolver(r.store.DatabaseDB(), r.repo),
+		repoResolver: graphqlbackend.NewRepositoryResolver(db, gitserver.NewClient(db), r.repo),
 		diffStat:     r.changesetSpec.DiffStat(),
 	}
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolved_batch_spec_workspace.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolved_batch_spec_workspace.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/service"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 )
 
 type resolvedBatchSpecWorkspaceResolver struct {
@@ -49,7 +50,8 @@ func (r *resolvedBatchSpecWorkspaceResolver) SearchResultPaths() []string {
 
 func (r *resolvedBatchSpecWorkspaceResolver) computeRepoResolver(ctx context.Context) *graphqlbackend.RepositoryResolver {
 	r.repoResolverOnce.Do(func() {
-		r.repoResolver = graphqlbackend.NewRepositoryResolver(r.store.DatabaseDB(), r.workspace.Repo)
+		db := r.store.DatabaseDB()
+		r.repoResolver = graphqlbackend.NewRepositoryResolver(db, gitserver.NewClient(db), r.workspace.Repo)
 	})
 
 	return r.repoResolver

--- a/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
@@ -12,6 +12,7 @@ import (
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -193,7 +194,7 @@ func toResultResolverList(ctx context.Context, cmd compute.Command, matches []re
 		if existing, ok := repoResolvers[repoKey{repoName, rev}]; ok {
 			return existing
 		}
-		resolver := gql.NewRepositoryResolver(db, repoName.ToRepo())
+		resolver := gql.NewRepositoryResolver(db, gitserver.NewClient(db), repoName.ToRepo())
 		resolver.RepoMatch.Rev = rev
 		repoResolvers[repoKey{repoName, rev}] = resolver
 		return resolver

--- a/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -402,7 +403,7 @@ func (r *searchContextResolver) Repositories(ctx context.Context) ([]graphqlback
 
 	searchContextRepositories := make([]graphqlbackend.SearchContextRepositoryRevisionsResolver, len(repoRevs))
 	for idx, repoRev := range repoRevs {
-		searchContextRepositories[idx] = &searchContextRepositoryRevisionsResolver{graphqlbackend.NewRepositoryResolver(r.db, repoRev.Repo.ToRepo()), repoRev.Revisions}
+		searchContextRepositories[idx] = &searchContextRepositoryRevisionsResolver{graphqlbackend.NewRepositoryResolver(r.db, gitserver.NewClient(r.db), repoRev.Repo.ToRepo()), repoRev.Revisions}
 	}
 	return searchContextRepositories, nil
 }

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -1498,10 +1498,6 @@ func (c *clientImplementor) GetCommit(ctx context.Context, repo api.RepoName, id
 
 // Commits returns all commits matching the options.
 func (c *clientImplementor) Commits(ctx context.Context, repo api.RepoName, opt CommitsOptions, checker authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error) {
-	if Mocks.Commits != nil {
-		return Mocks.Commits(repo, opt)
-	}
-
 	opt = addNameOnly(opt, checker)
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: Commits")
 	span.SetTag("Opt", opt)

--- a/internal/gitserver/git_command.go
+++ b/internal/gitserver/git_command.go
@@ -82,6 +82,7 @@ func NewLocalGitCommand(repo api.RepoName, arg ...string) *LocalGitCommand {
 		command: exec.Command(git, arg...), // no need for including "git" in args here
 		repo:    repo,
 		args:    args,
+		Logger:  log.Scoped("local", "local git command logger"),
 	}
 }
 

--- a/internal/gitserver/mocks.go
+++ b/internal/gitserver/mocks.go
@@ -28,7 +28,6 @@ var Mocks, emptyMocks struct {
 	NewFileReader    func(commit api.CommitID, name string) (io.ReadCloser, error)
 	Stat             func(commit api.CommitID, name string) (fs.FileInfo, error)
 	GetCommit        func(api.CommitID) (*gitdomain.Commit, error)
-	Commits          func(repo api.RepoName, opt CommitsOptions) ([]*gitdomain.Commit, error)
 }
 
 // ResetMocks clears the mock functions set on Mocks (so that subsequent tests don't inadvertently


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/38089

Removes the `gitserver.Mocks.Commits` mock and all references to it. Part of this involved threading the gitserver client through more functions/structs to enable using the properly mocked client for testing.

## Test plan
Ensure unit/integration tests pass, run the app locally and do a spot check

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
