### PR TITLE
Fix information on how an auth provider user's account is linked to a Sourcegraph account

### DIFF
--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -443,10 +443,14 @@ Some proxies add a prefix to the username header value. For example, Google IAP 
 In most cases, the link between a Sourcegraph account and an authentication provider account happens via email.
 
 Consequently, you can only sign in via an auth provider if your email on Sourcegraph matches the one configured in the auth provider.
+
 Let's say the email field in your Sourcegraph account was kept blank when a site admin created the account for you, but the username matches your username on GitHub or GitLab. Will this work? If you try to sign in to SG with GitHub or GitLab, it won't work, and you will see an error informing you that a verified email is missing.
 
-Exceptions to this rule are [HTTP Proxies](#http-authentication-proxies) - there's an option to make the match via username only - and [Bitbucket Server and Bitbucket Data Center](../config/authorization_and_authentication.md###bitbucket-server-bitbucket-data-center-authorization).
-We don't support OAuth for Bitbucket, but the link between the chosen auth provider and a user's Bitbucket account happens via username.
+Exceptions to this rule are [HTTP Proxies](#http-authentication-proxies), where there's an option to make the link via username only.
+For [Bitbucket](../config/authorization_and_authentication.md#bitbucket-server-bitbucket-data-center-authorization), we don't support OAuth. Still, the match between the chosen auth provider used with Bitbucket and a user's Bitbucket account happens via username.
+
+**Using only a username to match a Sourcegraph account to an auth provider account is not recommended**.
+Usernames in Sourcegraph are mutable, so a malicious user could change a username, elevating their privileges.**
 
 ## Linking accounts from multiple auth providers
 Sourcegraph will automatically link accounts from multiple external auth providers, resulting in a single user account on Sourcegraph. That way a user can login with multiple auth methods and end up being logged in with the same Sourcegraph account. In general, to link accounts, the following condition needs to be met:

--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -449,7 +449,7 @@ Let's say the email field in your Sourcegraph account was kept blank when a site
 Exceptions to this rule are [HTTP Proxies](#http-authentication-proxies), where there's an option to make the link via username only.
 For [Bitbucket](../config/authorization_and_authentication.md#bitbucket-server-bitbucket-data-center-authorization), we don't support OAuth. Still, the match between the chosen auth provider used with Bitbucket and a user's Bitbucket account happens via username.
 
-**Using only a username to match a Sourcegraph account to an auth provider account is not recommended**.
+Using only a username to match a Sourcegraph account to an auth provider account is not recommended, as you can see [here](../repo/permissions#username), for example.
 Usernames in Sourcegraph are mutable, so a malicious user could change a username, elevating their privileges.
 
 ## Linking accounts from multiple auth providers

--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -449,7 +449,7 @@ Let's say the email field in your Sourcegraph account was kept blank when a site
 Exceptions to this rule are [HTTP Proxies](#http-authentication-proxies), where there's an option to make the link via username only.
 For [Bitbucket](../config/authorization_and_authentication.md#bitbucket-server-bitbucket-data-center-authorization), we don't support OAuth. Still, the match between the chosen auth provider used with Bitbucket and a user's Bitbucket account happens via username.
 
-Using only a username to match a Sourcegraph account to an auth provider account is not recommended, as you can see [here](../repo/permissions#username), for example.
+Using only a username to match a Sourcegraph account to an auth provider account is not recommended, as you can see [here](../repo/permissions.md#username), for example.
 Usernames in Sourcegraph are mutable, so a malicious user could change a username, elevating their privileges.
 
 ## Linking accounts from multiple auth providers

--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -445,8 +445,8 @@ In most cases, the link between a Sourcegraph account and an authentication prov
 Consequently, you can only sign in via an auth provider if your email on Sourcegraph matches the one configured in the auth provider.
 Let's say the email field in your Sourcegraph account was kept blank when a site admin created the account for you, but the username matches your username on GitHub or GitLab. Will this work? If you try to sign in to SG with GitHub or GitLab, it won't work, and you will see an error informing you that a verified email is missing.
 
-Exceptions to this rule are [HTTP Proxies](#http-authentication-proxies) - there's an option to make this link via username only - and [Bitbucket Server and Bitbucket Data Center](../config/authorization_and_authentication.md#bitbucket-server-bitbucket-data-center-authorization).
-We don't support OAuth for Bitbucket, but the match between the chosen auth provider and a user's Bitbucket account happens via username.
+Exceptions to this rule are [HTTP Proxies](#http-authentication-proxies) - there's an option to make the match via username only - and [Bitbucket Server and Bitbucket Data Center](../config/authorization_and_authentication.md###bitbucket-server-bitbucket-data-center-authorization).
+We don't support OAuth for Bitbucket, but the link between the chosen auth provider and a user's Bitbucket account happens via username.
 
 ## Linking accounts from multiple auth providers
 Sourcegraph will automatically link accounts from multiple external auth providers, resulting in a single user account on Sourcegraph. That way a user can login with multiple auth methods and end up being logged in with the same Sourcegraph account. In general, to link accounts, the following condition needs to be met:

--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -450,7 +450,7 @@ Exceptions to this rule are [HTTP Proxies](#http-authentication-proxies), where 
 For [Bitbucket](../config/authorization_and_authentication.md#bitbucket-server-bitbucket-data-center-authorization), we don't support OAuth. Still, the match between the chosen auth provider used with Bitbucket and a user's Bitbucket account happens via username.
 
 **Using only a username to match a Sourcegraph account to an auth provider account is not recommended**.
-Usernames in Sourcegraph are mutable, so a malicious user could change a username, elevating their privileges.**
+Usernames in Sourcegraph are mutable, so a malicious user could change a username, elevating their privileges.
 
 ## Linking accounts from multiple auth providers
 Sourcegraph will automatically link accounts from multiple external auth providers, resulting in a single user account on Sourcegraph. That way a user can login with multiple auth methods and end up being logged in with the same Sourcegraph account. In general, to link accounts, the following condition needs to be met:

--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -440,10 +440,13 @@ Some proxies add a prefix to the username header value. For example, Google IAP 
 
 ## Linking a Sourcegraph account to an auth provider
 
-The link between a Sourcegraph account and an authentication provider account happens via email only.
-Consequently, you can only sign in with [GitHub](#github), [GitLab](#gitlab), or other supported auth providers ([SAML](saml/index.md),  [OpenID Connect](#openid-connect), [HTTP Proxies](#http-authentication-proxies)) if your email on Sourcegraph matches the one configured in the auth provider.
+In most cases, the link between a Sourcegraph account and an authentication provider account happens via email.
 
+Consequently, you can only sign in via an auth provider if your email on Sourcegraph matches the one configured in the auth provider.
 Let's say the email field in your Sourcegraph account was kept blank when a site admin created the account for you, but the username matches your username on GitHub or GitLab. Will this work? If you try to sign in to SG with GitHub or GitLab, it won't work, and you will see an error informing you that a verified email is missing.
+
+Exceptions to this rule are [HTTP Proxies](#http-authentication-proxies) - there's an option to make this link via username only - and [Bitbucket Server and Bitbucket Data Center](../config/authorization_and_authentication.md#bitbucket-server-bitbucket-data-center-authorization).
+We don't support OAuth for Bitbucket, but the match between the chosen auth provider and a user's Bitbucket account happens via username.
 
 ## Linking accounts from multiple auth providers
 Sourcegraph will automatically link accounts from multiple external auth providers, resulting in a single user account on Sourcegraph. That way a user can login with multiple auth methods and end up being logged in with the same Sourcegraph account. In general, to link accounts, the following condition needs to be met:


### PR DESCRIPTION
In the docs on how we link a user's auth provider account to an SG account, there was a piece of incomplete (hence wrong) information that I committed -- two exceptions were not mentioned. This PR fixes this.

## Test plan
All tests should pass.
