### PR TITLE
ci: modify get pods in sourcegraph qa script

### DIFF
--- a/dev/ci/integration/cluster/test.sh
+++ b/dev/ci/integration/cluster/test.sh
@@ -17,8 +17,15 @@ function cluster_capture_state() {
   set -x
 
   echo "--- dump diagnostics"
+  # The reason have the grep here and filter out the otel-agents in Pending state is due to how otel-agents
+  # are scheduled. The otel agent is deployed using a DaemonSet, which means on every node, k8s will schedule a
+  # otel-agent, even if the node isn't running anything else. For this QA scenario we don't want to run anything
+  # more than what we want, so if you look in deploy-sourcegraph/overlays/otel-agent-patch.yaml you'll see
+  # the otel-agent DaemonSet is patched with a podAffinity. PodAffinity ensures that a Pod will only be scheduled
+  # that matches a certain condition, if the Pod doesn't match it's status will be PENDING - hence we filter them
+  # out
   # Get overview of all pods
-  kubectl get pods
+  kubectl get pods | grep -v -e "otel-agent-.*Pending"
 
   # Get specifics of pods
   kubectl describe pods >"$root_dir/describe_pods.log" 2>&1


### PR DESCRIPTION
Related PR: https://github.com/sourcegraph/deploy-sourcegraph/pull/4187


This modifies the output we fetch from k8s to filter out the Pending otel-agent pods which are in a Pending state due to the podAffinity that is added in the above PR
## Test plan
1.     Created our own namespace
2.     Checkout out deploy-sourcegraph
3.     run ./overlay-generate-cluster.sh low-resource generated-cluster
4.     kubectl apply -n "$NAMESPACE" --recursive --validate -f generated-cluster

Closes #42484 