### PR TITLE
Revert "codeintel: Offload reference counts to cold table (#42266)"

### DIFF
--- a/internal/codeintel/uploads/internal/store/store_uploads.go
+++ b/internal/codeintel/uploads/internal/store/store_uploads.go
@@ -577,11 +577,7 @@ const softDeleteExpiredUploadsQuery = `
 WITH candidates AS (
 	SELECT u.id
 	FROM lsif_uploads u
-	JOIN lsif_uploads_reference_counts urc ON urc.upload_id = u.id
-	WHERE
-		u.state = 'completed' AND
-		u.expired AND
-		urc.reference_count = 0
+	WHERE u.state = 'completed' AND u.expired AND u.reference_count = 0
 	-- Lock these rows in a deterministic order so that we don't
 	-- deadlock with other processes updating the lsif_uploads table.
 	ORDER BY u.id FOR UPDATE
@@ -815,13 +811,7 @@ const backfillReferenceCountBatchQuery = `
 -- source: internal/codeintel/uploads/internal/store/store_uploads.go:BackfillReferenceCountBatch
 SELECT u.id
 FROM lsif_uploads u
-WHERE
-	u.state = 'completed' AND
-	NOT EXISTS (
-		SELECT 1
-		FROM lsif_uploads_reference_counts urc
-		WHERE urc.upload_id = u.id
-	)
+WHERE u.state = 'completed' AND u.reference_count IS NULL
 ORDER BY u.id
 FOR UPDATE SKIP LOCKED
 LIMIT %s
@@ -1010,7 +1000,7 @@ canonical_package_reference_counts AS (
 	WHERE ru.rank = 1
 ),
 
--- Count (and rank) the set of edges that cross over from the target list of uploads
+-- Count (and ranks) the set of edges that cross over from the target list of uploads
 -- to existing uploads that provide a dependent package. This is the modifier by which
 -- dependency reference counts must be altered in order for existing package reference
 -- counts to remain up-to-date.
@@ -1044,10 +1034,11 @@ canonical_dependency_reference_counts AS (
 	GROUP BY rc.id
 ),
 
--- Determine the set of reference count values to write to the lsif_uploads_reference_counts
--- table. We will actually persist these values in two steps: a distinct insert and a distinct
--- update to minimize lock contention on existing rows.
-calculated_reference_counts AS (
+-- Determine the set of reference count values to write to the lsif_uploads table, then
+-- lock all of the affected rows in a deterministic order. This should prevent hitting
+-- deadlock conditions when multiple bulk operations are happening over intersecting
+-- rows of the same table.
+locked_uploads AS (
 	SELECT
 		u.id,
 
@@ -1056,7 +1047,7 @@ calculated_reference_counts AS (
 		-- this row is a dependency of the target upload list and we only be incrementally
 		-- modifying the row's reference count.
 		--
-		CASE WHEN ru.id IS NOT NULL THEN COALESCE(pkg_refcount.count, 0) ELSE urc.reference_count END +
+		CASE WHEN ru.id IS NOT NULL THEN COALESCE(pkg_refcount.count, 0) ELSE u.reference_count END +
 
 		-- If ru.id IN canonical_dependency_reference_counts, then we incrementally modify
 		-- the row's reference count proportional the number of additional dependent edges
@@ -1064,41 +1055,18 @@ calculated_reference_counts AS (
 		-- to specify if we are adding or removing a set of upload records.
 		COALESCE(dep_refcount.count, 0) * %s AS reference_count
 	FROM lsif_uploads u
-	LEFT JOIN lsif_uploads_reference_counts urc ON urc.upload_id = u.id
 	LEFT JOIN ranked_uploads_providing_packages ru ON ru.id = u.id
 	LEFT JOIN canonical_package_reference_counts pkg_refcount ON pkg_refcount.id = u.id
 	LEFT JOIN canonical_dependency_reference_counts dep_refcount ON dep_refcount.id = u.id
 	-- Prevent creating no-op updates for every row in the table
 	WHERE ru.id IS NOT NULL OR dep_refcount.id IS NOT NULL
-),
-
--- Insert reference counts for uploads that don't already exist
-new_reference_counts AS (
-	INSERT INTO lsif_uploads_reference_counts (upload_id, reference_count)
-	SELECT crc.id, crc.reference_count FROM calculated_reference_counts crc
-	ON CONFLICT DO NOTHING
-	RETURNING upload_id AS id
-),
-
--- Deterministically order the reference counts that already exist but need to be
--- updated. This ordering/locking sequence should prevent hitting deadlock conditions
--- when multiple bulk operations are happening over intersecting rows of the same table.
-
-locked_updates AS (
-	SELECT
-		urc.upload_id,
-		crc.reference_count
-	FROM lsif_uploads_reference_counts urc
-	JOIN calculated_reference_counts crc ON crc.id = urc.upload_id
-	WHERE urc.upload_id NOT IN (SELECT id FROM new_reference_counts)
-	ORDER BY urc.upload_id
-	FOR UPDATE
+	ORDER BY u.id FOR UPDATE
 )
 
--- Perform the update actual
-UPDATE lsif_uploads_reference_counts urc
+-- Perform deterministically ordered update
+UPDATE lsif_uploads u
 SET reference_count = lu.reference_count
-FROM locked_updates lu WHERE lu.upload_id = urc.upload_id
+FROM locked_uploads lu WHERE lu.id = u.id
 `
 
 // UpdateUploadsVisibleToCommits uses the given commit graph and the tip of non-stale branches and tags to determine the

--- a/internal/codeintel/uploads/internal/store/store_uploads_test.go
+++ b/internal/codeintel/uploads/internal/store/store_uploads_test.go
@@ -780,7 +780,7 @@ func TestBackfillReferenceCountBatch(t *testing.T) {
 	if err := store.BackfillReferenceCountBatch(context.Background(), n/2); err != nil {
 		t.Fatalf("unexpected error performing up migration: %s", err)
 	}
-	referenceCountQuery := sqlf.Sprintf("SELECT urc.reference_count FROM lsif_uploads_reference_counts urc ORDER BY urc.upload_id")
+	referenceCountQuery := sqlf.Sprintf("SELECT u.reference_count FROM lsif_uploads u WHERE u.reference_count IS NOT NULL ORDER BY u.id")
 	if referenceCounts, err := basestore.ScanInts(db.QueryContext(context.Background(), referenceCountQuery.Query(sqlf.PostgresBindVar), referenceCountQuery.Args()...)); err != nil {
 		t.Fatalf("unexpected error querying uploads: %s", err)
 	} else if diff := cmp.Diff(expectedReferenceCounts[:n/2], referenceCounts); diff != "" {
@@ -2059,7 +2059,7 @@ func getProtectedUploads(t testing.TB, db database.DB, repositoryID int) []int {
 func assertReferenceCounts(t *testing.T, store database.DB, expectedReferenceCountsByID map[int]int) {
 	db := basestore.NewWithHandle(store.Handle())
 
-	referenceCountsByID, err := scanIntPairs(db.Query(context.Background(), sqlf.Sprintf(`SELECT upload_id, reference_count FROM lsif_uploads_reference_counts ORDER BY upload_id`)))
+	referenceCountsByID, err := scanIntPairs(db.Query(context.Background(), sqlf.Sprintf(`SELECT id, reference_count FROM lsif_uploads`)))
 	if err != nil {
 		t.Fatalf("unexpected error querying reference counts: %s", err)
 	}


### PR DESCRIPTION
This reverts commit 05c79feb51e6535afcb8d2fb3d31cdea3ccfa361.

Un-YOLO: https://github.com/sourcegraph/sourcegraph/pull/42266. This reverts the queries but not the new table (which is a pain to undo in the migrations, and we'll forward-fix this once half our environments aren't deployed).

## Test plan

N/A.