### PR TITLE
sg: add "client codehost add-github" subcommand 

### DIFF
--- a/dev/sg/client/codehost.go
+++ b/dev/sg/client/codehost.go
@@ -7,12 +7,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-var GitHubHundredThousandsRepos = []string{
-	"pld-linux",        // 20k
-	"londonappbrewery", // 30k
-	"wp-plugins",       // 50k
-}
-
 func AddGitHubCodeHost(client *gqltestutil.Client, displayName string, conn *schema.GitHubConnection) error {
 	b, err := json.Marshal(conn)
 	if err != nil {

--- a/dev/sg/client/codehost.go
+++ b/dev/sg/client/codehost.go
@@ -1,4 +1,4 @@
-package scaletesting
+package client
 
 import (
 	"encoding/json"

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -286,6 +286,7 @@ var sg = &cli.App{
 		installCommand,
 		funkyLogoCommand,
 		analyticsCommand,
+		clientCommand,
 	},
 	ExitErrHandler: func(cmd *cli.Context, err error) {
 		if err == nil {

--- a/dev/sg/scaletesting/codehost.go
+++ b/dev/sg/scaletesting/codehost.go
@@ -1,0 +1,37 @@
+package scaletesting
+
+import (
+	"encoding/json"
+
+	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+var GitHubHundredThousandsRepos = []string{
+	"pld-linux",        // 20k
+	"londonappbrewery", // 30k
+	"wp-plugins",       // 50k
+}
+
+func AddGitHubCodeHost(client *gqltestutil.Client, displayName string, conn *schema.GitHubConnection) error {
+	b, err := json.Marshal(conn)
+	if err != nil {
+		return err
+	}
+	input := gqltestutil.AddExternalServiceInput{
+		Kind:        "GITHUB",
+		DisplayName: displayName,
+		Config:      string(b),
+	}
+	_, err = client.AddExternalService(input)
+	return err
+}
+
+func AddCodeHostsByGitHubOrgs(client *gqltestutil.Client, token string, displayName string, orgs []string) error {
+	conn := schema.GitHubConnection{
+		Url:   "https://github.com",
+		Token: token,
+		Orgs:  orgs,
+	}
+	return AddGitHubCodeHost(client, displayName, &conn)
+}

--- a/dev/sg/sg_client.go
+++ b/dev/sg/sg_client.go
@@ -22,7 +22,7 @@ var clientCommand = &cli.Command{
 			Subcommands: []*cli.Command{
 				{
 					Name:      "add-github",
-					ArgsUsage: " org1 org2",
+					ArgsUsage: " org1 [org2 ...]",
 					Usage:     "Add a GitHub codehost on a given Sourcegraph instance",
 					Flags: []cli.Flag{
 						&cli.StringFlag{

--- a/dev/sg/sg_client.go
+++ b/dev/sg/sg_client.go
@@ -11,13 +11,13 @@ import (
 )
 
 var clientCommand = &cli.Command{
-	Name:  "client",
-	Usage: "Perform common tasks on a Sourcegraph instance",
+	Name:     "client",
+	Usage:    "Perform common tasks on a Sourcegraph instance",
+	Category: CategoryUtil,
 	Subcommands: []*cli.Command{
 		{
 			Name:      "codehost",
 			ArgsUsage: " ",
-			Category:  CategoryUtil,
 			Usage:     "Interact with codehosts on a given Sourcegraph instance",
 			Subcommands: []*cli.Command{
 				{

--- a/dev/sg/sg_client.go
+++ b/dev/sg/sg_client.go
@@ -3,64 +3,88 @@ package main
 import (
 	"fmt"
 
+	cl "github.com/sourcegraph/sourcegraph/dev/sg/client"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
-	"github.com/sourcegraph/sourcegraph/dev/sg/scaletesting"
 	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
-	"github.com/sourcegraph/sourcegraph/lib/output"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/urfave/cli/v2"
 )
 
 var clientCommand = &cli.Command{
 	Name:  "client",
 	Usage: "Perform common tasks on a Sourcegraph instance",
-	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name: "baseurl",
-		},
-		&cli.StringFlag{
-			Name: "email",
-		},
-		&cli.StringFlag{
-			Name: "password",
-		},
-	},
 	Subcommands: []*cli.Command{
 		{
 			Name:      "codehost",
 			ArgsUsage: " ",
 			Category:  CategoryUtil,
-			Usage:     "TODO",
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name: "token",
-				},
-			},
+			Usage:     "Interact with codehosts on a given Sourcegraph instance",
 			Subcommands: []*cli.Command{
 				{
-					Name:      "add",
-					ArgsUsage: "",
-					Usage:     "TODO",
+					Name:      "add-github",
+					ArgsUsage: " org1 org2",
+					Usage:     "Add a GitHub codehost on a given Sourcegraph instance",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:        "baseurl",
+							Usage:       "Base URL to reach the Sourcegraph instance",
+							DefaultText: "https://sourcegraph.test:3443",
+						},
+						&cli.StringFlag{
+							Name:        "email",
+							Usage:       "Email or username used to sign-in",
+							DefaultText: "sourcegraph@sourcegraph.com",
+						},
+						&cli.StringFlag{
+							Name:        "password",
+							Usage:       "Password used to sign-in",
+							DefaultText: "sourcegraphsourcegraph",
+						},
+						&cli.StringFlag{
+							Name:  "token",
+							Usage: "GitHub token to associate with the new code host",
+						},
+						&cli.StringFlag{
+							Name:     "display-name",
+							Usage:    "Display name to give to the new code host",
+							Required: true,
+						},
+					},
 					Action: func(cmd *cli.Context) error {
 						client, err := gqltestutil.SignIn(cmd.String("baseurl"), cmd.String("email"), cmd.String("password"))
 						if err != nil {
-							return err
+							return errors.Wrap(err, "Failed to sign-in on the Sourcegraph instance")
 						}
-						err = scaletesting.AddCodeHostsByGitHubOrgs(client, cmd.String("token"), "test", cmd.Args().Slice())
+						extSvcs, err := client.ExternalServices()
 						if err != nil {
-							return err
+							return errors.Wrap(err, "Could not list code hosts")
 						}
-						resp, err := client.ExternalService("test")
+						displayName := cmd.String("display-name")
+						for _, s := range extSvcs {
+							if s.DisplayName == displayName {
+								std.Out.WriteFailuref("A code host named '%s' already exists with the following definition", displayName)
+								std.Out.WriteMarkdown(fmt.Sprintf("`%s`", s.Config))
+								return errors.New("code host already exists")
+							}
+						}
+						std.Out.WriteNoticef("Creating new code host named '%s'", displayName)
+						err = cl.AddCodeHostsByGitHubOrgs(client, cmd.String("token"), displayName, cmd.Args().Slice())
 						if err != nil {
-							return err
+							return errors.Wrap(err, "Could not add code host")
 						}
-						std.Out.WriteSuccessf(
-							"Added CodeHost %s%s%s",
-							output.StyleOrange,
-							"test",
-							output.StyleReset,
-						)
-						std.Out.WriteMarkdown(fmt.Sprintf("`%s`", resp["config"]))
-						return nil
+						extSvcs, err = client.ExternalServices()
+						if err != nil {
+							return errors.Wrap(err, "Could not list code hosts")
+						}
+						for _, s := range extSvcs {
+							if s.DisplayName == displayName {
+								std.Out.WriteSuccessf("Added CodeHost '%s'", displayName)
+								std.Out.WriteMarkdown(fmt.Sprintf("`%s`", s.Config))
+								return nil
+							}
+						}
+						std.Out.WriteFailuref("A code host named '%s' already exists with the following definition", displayName)
+						return errors.Wrap(err, "Could find newly added code host")
 					},
 				},
 			},

--- a/dev/sg/sg_client.go
+++ b/dev/sg/sg_client.go
@@ -41,7 +41,7 @@ var clientCommand = &cli.Command{
 							DefaultText: "sourcegraphsourcegraph",
 						},
 						&cli.StringFlag{
-							Name:  "token",
+							Name:  "github.token",
 							Usage: "GitHub token to associate with the new code host",
 						},
 						&cli.StringFlag{
@@ -68,7 +68,7 @@ var clientCommand = &cli.Command{
 							}
 						}
 						std.Out.WriteNoticef("Creating new code host named '%s'", displayName)
-						err = cl.AddCodeHostsByGitHubOrgs(client, cmd.String("token"), displayName, cmd.Args().Slice())
+						err = cl.AddCodeHostsByGitHubOrgs(client, cmd.String("github.token"), displayName, cmd.Args().Slice())
 						if err != nil {
 							return errors.Wrap(err, "Could not add code host")
 						}

--- a/dev/sg/sg_client.go
+++ b/dev/sg/sg_client.go
@@ -84,7 +84,7 @@ var clientCommand = &cli.Command{
 							}
 						}
 						std.Out.WriteFailuref("A code host named '%s' already exists with the following definition", displayName)
-						return errors.Wrap(err, "Could find newly added code host")
+						return errors.Wrap(err, "Could not find newly added code host")
 					},
 				},
 			},

--- a/dev/sg/sg_client.go
+++ b/dev/sg/sg_client.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/dev/sg/scaletesting"
+	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+	"github.com/urfave/cli/v2"
+)
+
+var clientCommand = &cli.Command{
+	Name:  "client",
+	Usage: "Perform common tasks on a Sourcegraph instance",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name: "baseurl",
+		},
+		&cli.StringFlag{
+			Name: "email",
+		},
+		&cli.StringFlag{
+			Name: "password",
+		},
+	},
+	Subcommands: []*cli.Command{
+		{
+			Name:      "codehost",
+			ArgsUsage: " ",
+			Category:  CategoryUtil,
+			Usage:     "TODO",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name: "token",
+				},
+			},
+			Subcommands: []*cli.Command{
+				{
+					Name:      "add",
+					ArgsUsage: "",
+					Usage:     "TODO",
+					Action: func(cmd *cli.Context) error {
+						client, err := gqltestutil.SignIn(cmd.String("baseurl"), cmd.String("email"), cmd.String("password"))
+						if err != nil {
+							return err
+						}
+						err = scaletesting.AddCodeHostsByGitHubOrgs(client, cmd.String("token"), "test", cmd.Args().Slice())
+						if err != nil {
+							return err
+						}
+						resp, err := client.ExternalService("test")
+						if err != nil {
+							return err
+						}
+						std.Out.WriteSuccessf(
+							"Added CodeHost %s%s%s",
+							output.StyleOrange,
+							"test",
+							output.StyleReset,
+						)
+						std.Out.WriteMarkdown(fmt.Sprintf("`%s`", resp["config"]))
+						return nil
+					},
+				},
+			},
+		},
+	},
+}

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1388,5 +1388,5 @@ Flags:
 * `--display-name="<value>"`: Display name to give to the new code host
 * `--email="<value>"`: Email or username used to sign-in
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
+* `--github.token="<value>"`: GitHub token to associate with the new code host
 * `--password="<value>"`: Password used to sign-in
-* `--token="<value>"`: GitHub token to associate with the new code host

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1365,3 +1365,28 @@ Flags:
 
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--raw`: view raw data
+
+## sg client
+
+Perform common tasks on a Sourcegraph instance.
+
+
+### sg client codehost
+
+Interact with codehosts on a given Sourcegraph instance.
+
+
+#### sg client codehost add-github
+
+Add a GitHub codehost on a given Sourcegraph instance.
+
+Arguments: ` org1 org2`
+
+Flags:
+
+* `--baseurl="<value>"`: Base URL to reach the Sourcegraph instance
+* `--display-name="<value>"`: Display name to give to the new code host
+* `--email="<value>"`: Email or username used to sign-in
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
+* `--password="<value>"`: Password used to sign-in
+* `--token="<value>"`: GitHub token to associate with the new code host

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1380,7 +1380,7 @@ Interact with codehosts on a given Sourcegraph instance.
 
 Add a GitHub codehost on a given Sourcegraph instance.
 
-Arguments: ` org1 org2`
+Arguments: ` org1 [org2 ...]`
 
 Flags:
 

--- a/internal/gqltestutil/external_service.go
+++ b/internal/gqltestutil/external_service.go
@@ -170,7 +170,7 @@ query {
 	var resp externalServicesResp
 	err := c.GraphQL("", q, nil, &resp)
 	if err != nil {
-		return nil, errors.Wrap(err, "request GraphQL")
+		return nil, errors.Wrap(err, "GraphQL request")
 	}
 	return resp.Data.ExternalServices.Nodes, nil
 }


### PR DESCRIPTION
The `sg client codehost add-github` command takes a given Sourcegraph instance and will remotely add code hosts as specified by the flags. I envisioned adding this to `mg` instead, but it was less straightforward as would need to deal with its yaml config, which is less "instant" to use compared to this. 

The original use case for this is to be able to easily add code hosts on the `scaletesting` instance. 

Possible things to do in the future: 

- Define a set of sourcegraph instances. In `sg.config.yaml` + secrets ? 
- Define "profiles" for codehosts, such as "large repo", "giga repo", "100k repos" for more convenient use? 

At this stage, let's keep things simple. 

See https://github.com/sourcegraph/handbook/pull/5131 for how it's being used in the docs. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

<img width="945" alt="image" src="https://user-images.githubusercontent.com/10151/193822440-207804be-e60b-4e80-86e3-0befc87e3b3c.png">
