### PR TITLE
Codemirror blob: Scroll search match into view

### DIFF
--- a/client/web/src/repo/blob/codemirror/search.ts
+++ b/client/web/src/repo/blob/codemirror/search.ts
@@ -128,6 +128,42 @@ class SearchPanel implements Panel {
 
         if (!query.eq(this.query)) {
             this.view.dispatch({ effects: setSearchQuery.of(query) })
+
+            // The following code scrolls next match into view if there is no
+            // match in the visible viewport. This is done by searching for the
+            // text from the currently top visible line and determining whether
+            // the next match is in the current viewport
+
+            const { scrollTop } = this.view.scrollDOM
+
+            // Get top visible line. More than half of the line must be visible.
+            // We don't use `view.viewportLineBlocks` because that also includes
+            // lines that are rendered but not actually visible.
+            let topLineBlock = this.view.lineBlockAtHeight(scrollTop)
+            if (Math.abs(topLineBlock.bottom - scrollTop) <= topLineBlock.height / 2) {
+                topLineBlock = this.view.lineBlockAtHeight(scrollTop + topLineBlock.height)
+            }
+
+            let result = getSearchQuery(this.view.state).getCursor(this.view.state.doc, topLineBlock.from).next()
+            if (result.done) {
+                // No match in the remainder of the document, wrap around
+                result = getSearchQuery(this.view.state).getCursor(this.view.state.doc).next()
+                if (result.done) {
+                    // Search term is not in the document, nothing to do
+                    return
+                }
+            }
+
+            const matchLineBlock = this.view.lineBlockAt(result.value.from)
+            const matchLineCenter = matchLineBlock.top + matchLineBlock.height / 2
+
+            if (matchLineCenter < scrollTop || matchLineCenter > scrollTop + this.view.scrollDOM.clientHeight) {
+                this.view.dispatch({
+                    effects: EditorView.scrollIntoView(result.value.from, {
+                        y: 'center',
+                    }),
+                })
+            }
         }
     }
 


### PR DESCRIPTION
Addresses #42482 

This commit adds logic to scroll the next occurrence of the blob search term into view if no match is present in the current viewport.

It doesn't look like CodeMirror provides an API to actually "select" a specific match. An alternative approach would be to just determine whether any match is visible and then call [`findNext`](https://codemirror.net/docs/ref/#search.findNext) to actually select the next match, but I'm actually not sure how deterministic it is.


https://user-images.githubusercontent.com/179026/193851289-744ac1c0-0444-497d-a0ed-37c6cf8c2a86.mp4



## Test plan

- Go to any file (e.g. `github.com/sourcegraph/sourcegraph/-/blob/doc/dev/background-information/web/temporary_settings.md?view=code`)
- Search for a term that is present in the document, *after* the currently visible content -> next occurrence is scrolled into view.
- Search for a term that is present in the document, *before* the currently visible content -> first occurrence should be scrolled into view
- Search for a term that is *not* present in the document -> nothing should happen