### PR TITLE
ci: fix annotation grafana query

### DIFF
--- a/enterprise/dev/ci/scripts/annotate.sh
+++ b/enterprise/dev/ci/scripts/annotate.sh
@@ -18,7 +18,7 @@ generate_grafana_link() {
     # embedded as a value in other json (aka the query we send to grafana)
     expression="$(cat <<EOF | jq -sR .
 {app="buildkite", build="$BUILDKITE_BUILD_NUMBER", branch="main", state="failed"}
-|~ "(?i)failed|panic|FAIL \\|" # this is a case insensitive regular expression, feel free to unleash your regex-fu!
+|~ "(?i)failed|panic|FAIL \\\\|" # this is a case insensitive regular expression, feel free to unleash your regex-fu!
 EOF
     )"
     # On Darwin use gdate


### PR DESCRIPTION
The link "View Grafana logs" in the annotation has a small bug and the query in it doesn't work properly
## Test plan
Run the bash script locally
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
