### PR TITLE
codeintel: Pull background tasks into policies service

### DIFF
--- a/cmd/worker/internal/codeintel/policies_repomatcher_job.go
+++ b/cmd/worker/internal/codeintel/policies_repomatcher_job.go
@@ -3,9 +3,6 @@ package codeintel
 import (
 	"context"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"go.opentelemetry.io/otel"
-
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
@@ -17,8 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
-	"github.com/sourcegraph/sourcegraph/internal/observation"
-	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
 type policiesRepositoryMatcherJob struct{}
@@ -38,13 +33,6 @@ func (j *policiesRepositoryMatcherJob) Config() []env.Config {
 }
 
 func (j *policiesRepositoryMatcherJob) Routines(startupCtx context.Context, logger log.Logger) ([]goroutine.BackgroundRoutine, error) {
-	observationCtx := &observation.Context{
-		Logger:     logger.Scoped("routines", "codeintel job routines"),
-		Tracer:     &trace.Tracer{TracerProvider: otel.GetTracerProvider()},
-		Registerer: prometheus.DefaultRegisterer,
-	}
-	metrics := repomatcher.NewMetrics(observationCtx)
-
 	rawDB, err := workerdb.Init()
 	if err != nil {
 		return nil, err
@@ -65,7 +53,5 @@ func (j *policiesRepositoryMatcherJob) Routines(startupCtx context.Context, logg
 	uploadSvc := uploads.GetService(db, codeIntelDB, gitserverClient)
 	policySvc := policies.GetService(db, uploadSvc, gitserverClient)
 
-	return []goroutine.BackgroundRoutine{
-		repomatcher.NewMatcher(policySvc, metrics),
-	}, nil
+	return repomatcher.NewMatchers(policySvc), nil
 }

--- a/internal/codeintel/policies/background/repomatcher/iface.go
+++ b/internal/codeintel/policies/background/repomatcher/iface.go
@@ -1,12 +1,11 @@
 package repomatcher
 
 import (
-	"context"
+	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 )
 
 type PolicyService interface {
-	SelectPoliciesForRepositoryMembershipUpdate(ctx context.Context, batchSize int) (configurationPolicies []types.ConfigurationPolicy, err error)
-	UpdateReposMatchingPatterns(ctx context.Context, patterns []string, policyID int, repositoryMatchLimit *int) (err error)
+	NewRepoMatcher(interval time.Duration, configurationPolicyMembershipBatchSize int) goroutine.BackgroundRoutine
 }

--- a/internal/codeintel/policies/background/repomatcher/init.go
+++ b/internal/codeintel/policies/background/repomatcher/init.go
@@ -1,14 +1,11 @@
 package repomatcher
 
 import (
-	"context"
-
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 )
 
-func NewMatcher(policySvc PolicyService, metrics *metrics) goroutine.BackgroundRoutine {
-	return goroutine.NewPeriodicGoroutine(context.Background(), ConfigInst.Interval, &matcher{
-		policySvc: policySvc,
-		metrics:   metrics,
-	})
+func NewMatchers(policySvc PolicyService) []goroutine.BackgroundRoutine {
+	return []goroutine.BackgroundRoutine{
+		policySvc.NewRepoMatcher(ConfigInst.Interval, ConfigInst.ConfigurationPolicyMembershipBatchSize),
+	}
 }

--- a/internal/codeintel/policies/metrics.go
+++ b/internal/codeintel/policies/metrics.go
@@ -1,4 +1,4 @@
-package repomatcher
+package policies
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
@@ -6,11 +6,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-type metrics struct {
+type matcherMetrics struct {
 	numPoliciesUpdated prometheus.Counter
 }
 
-func NewMetrics(observationContext *observation.Context) *metrics {
+func newMetrics(observationContext *observation.Context) *matcherMetrics {
 	counter := func(name, help string) prometheus.Counter {
 		counter := prometheus.NewCounter(prometheus.CounterOpts{
 			Name: name,
@@ -26,7 +26,7 @@ func NewMetrics(observationContext *observation.Context) *metrics {
 		"The number of configuration policies whose repository membership list was updated.",
 	)
 
-	return &metrics{
+	return &matcherMetrics{
 		numPoliciesUpdated: numPoliciesUpdated,
 	}
 }

--- a/internal/codeintel/policies/service.go
+++ b/internal/codeintel/policies/service.go
@@ -40,10 +40,11 @@ type service interface {
 }
 
 type Service struct {
-	store      store.Store
-	uploadSvc  UploadService
-	gitserver  GitserverClient
-	operations *operations
+	store          store.Store
+	uploadSvc      UploadService
+	gitserver      GitserverClient
+	operations     *operations
+	matcherMetrics *matcherMetrics
 }
 
 func newService(
@@ -53,10 +54,11 @@ func newService(
 	observationContext *observation.Context,
 ) *Service {
 	return &Service{
-		store:      policiesStore,
-		uploadSvc:  uploadSvc,
-		gitserver:  gitserver,
-		operations: newOperations(observationContext),
+		store:          policiesStore,
+		uploadSvc:      uploadSvc,
+		gitserver:      gitserver,
+		operations:     newOperations(observationContext),
+		matcherMetrics: newMetrics(observationContext),
 	}
 }
 


### PR DESCRIPTION
[This is the `policies` effort that moves the non-worker-machinery behavior of the `internal/codeintel/{service}/background/{x}` packages into the `internal/codeintel/{service}` package directly. This should allow us to collapse and unexport more of each service's surface area.

## Test plan

Existing pipelines.