### PR TITLE
sg: add "grafana.folder" argument to monitoring

### DIFF
--- a/monitoring/command/generate.go
+++ b/monitoring/command/generate.go
@@ -73,6 +73,10 @@ func Generate(cmdRoot string, sgRoot string) *cli.Command {
 				EnvVars: []string{"GRAFANA_HEADERS"},
 				Usage:   "Additional headers for HTTP requests to the Grafana instance",
 			},
+			&cli.StringFlag{
+				Name:  "grafana.folder",
+				Usage: "Folder on Grafana instance to put generated dashboards in",
+			},
 
 			&cli.StringFlag{
 				Name:    "prometheus.dir",
@@ -127,6 +131,7 @@ func Generate(cmdRoot string, sgRoot string) *cli.Command {
 				GrafanaDir:         os.Expand(c.String("grafana.dir"), expandWithSgRoot),
 				GrafanaURL:         c.String("grafana.url"),
 				GrafanaCredentials: c.String("grafana.creds"),
+				GrafanaFolder:      c.String("grafana.folder"),
 				GrafanaHeaders: func() map[string]string {
 					h := make(map[string]string)
 					for _, entry := range c.StringSlice("grafana.headers") {

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/grafana-tools/sdk"
+	grafanasdk "github.com/grafana-tools/sdk"
 	"github.com/prometheus/prometheus/model/labels"
 	"gopkg.in/yaml.v2"
 
@@ -55,6 +55,8 @@ type GenerateOptions struct {
 
 // Generate is the main Sourcegraph monitoring generator entrypoint.
 func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard) error {
+	ctx := context.TODO()
+
 	logger.Info("Regenerating monitoring", log.String("options", fmt.Sprintf("%+v", opts)))
 
 	var generatedAssets []string
@@ -71,22 +73,117 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 		return errors.Wrap(validationErrors, "Validation failed")
 	}
 
-	// Generate Grafana content for all dashboards
+	// Set up disk directories
+	if opts.GrafanaDir != "" {
+		os.MkdirAll(opts.GrafanaDir, os.ModePerm)
+	}
+	if opts.PrometheusDir != "" {
+		os.MkdirAll(opts.PrometheusDir, os.ModePerm)
+	}
+	if opts.DocsDir != "" {
+		os.MkdirAll(opts.DocsDir, os.ModePerm)
+	}
+
+	// Generate Grafana content for all dashboards. If grafanaClient is not nil, Grafana
+	// should be reloaded.
+	var grafanaClient *grafanasdk.Client
+	var grafanaFolderID int
+	if opts.GrafanaURL != "" && opts.Reload {
+		gclog := logger.Scoped("grafana.client", "grafana client setup")
+
+		// DefaultHTTPClient is used unless additional headers are requested
+		httpClient := grafanasdk.DefaultHTTPClient
+		if len(opts.GrafanaHeaders) > 0 {
+			gclog.Debug("Adding additional headers to Grafana requests",
+				log.String("headers", fmt.Sprintf("%v", opts.GrafanaHeaders)))
+			httpClient.Transport = headertransport.NewAddHeaderTransport(httpClient.Transport, opts.GrafanaHeaders)
+		}
+
+		// Init Grafana client
+		var err error
+		grafanaClient, err = grafanasdk.NewClient(opts.GrafanaURL, opts.GrafanaCredentials, httpClient)
+		if err != nil {
+			return errors.Wrap(err, "Failed to initialize Grafana client")
+		}
+		if opts.GrafanaFolder != "" {
+			gclog.Debug("Preparing dashboard folder", log.String("folder", opts.GrafanaFolder))
+
+			// Get all the folders and look up the customer by the customer name (title)
+			folders, err := grafanaClient.GetAllFolders(ctx)
+			if err != nil {
+				return errors.Wrap(err, "Unable to get all folders from Grafana API")
+			}
+			for _, folder := range folders {
+				if folder.Title == opts.GrafanaFolder {
+					gclog.Debug("Found existing folder", log.Int("folder.id", folder.ID))
+					grafanaFolderID = folder.ID
+				}
+			}
+
+			// folderId is not found, create it
+			if grafanaFolderID == 0 {
+				gclog.Debug("No existing folder found, creating a new one")
+				folder, err := grafanaClient.CreateFolder(ctx, grafanasdk.Folder{
+					Title: opts.GrafanaFolder,
+				})
+				if err != nil {
+					return errors.Wrapf(err, "Error creating new folder %s", opts.GrafanaFolder)
+				}
+
+				gclog.Debug("Created folder",
+					log.String("folder.title", folder.Title),
+					log.Int("folder.id", folder.ID))
+				grafanaFolderID = folder.ID
+			}
+		}
+	}
+
+	// Generate Garafana home dasboard "Overview"
+	{
+		data, err := grafana.Home(opts.InjectLabelMatchers)
+		if err != nil {
+			return errors.Wrap(err, "failed to generate home dashboard")
+		}
+		if opts.GrafanaDir != "" {
+			generatedDashboard := "home.json"
+			generatedAssets = append(generatedAssets, generatedDashboard)
+			if err = os.WriteFile(filepath.Join(opts.GrafanaDir, generatedDashboard), data, os.ModePerm); err != nil {
+				return errors.Wrap(err, "failed to generate home dashboard")
+			}
+		}
+		if grafanaClient != nil {
+			logger.Debug("Reloading Grafana dashboard",
+				log.Int("folder.id", grafanaFolderID))
+			if _, err := grafanaClient.SetRawDashboardWithParam(ctx, grafanasdk.RawBoardRequest{
+				Dashboard: data,
+				Parameters: grafanasdk.SetDashboardParams{
+					Overwrite: true,
+					FolderID:  grafanaFolderID,
+				},
+			}); err != nil {
+				return errors.Wrapf(err, "Could not reload Grafana dashboard 'Overview'")
+			} else {
+				logger.Info("Reloaded Grafana dashboard")
+			}
+		}
+	}
+
+	// Generate per-dashboard assets
 	for _, dashboard := range dashboards {
 		// Logger for dashboard
 		dlog := logger.With(log.String("dashboard", dashboard.Name))
 
+		glog := dlog.Scoped("grafana", "grafana dashboard generation").
+			With(log.String("instance", opts.GrafanaURL))
+
+		glog.Debug("Rendering Grafana assets")
+		board, err := dashboard.renderDashboard(opts.InjectLabelMatchers)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to render dashboard %q", dashboard.Name)
+		}
+
 		// Prepare Grafana assets
 		if opts.GrafanaDir != "" {
-			glog := dlog.Scoped("grafana", "grafana dashboard generation").
-				With(log.String("instance", opts.GrafanaURL))
-			os.MkdirAll(opts.GrafanaDir, os.ModePerm)
-
-			glog.Debug("Rendering Grafana assets")
-			board, err := dashboard.renderDashboard(opts.InjectLabelMatchers)
-			if err != nil {
-				return errors.Wrapf(err, "Failed to render dashboard %q", dashboard.Name)
-			}
 			data, err := json.MarshalIndent(board, "", "  ")
 			if err != nil {
 				return errors.Wrapf(err, "Invalid dashboard %q", dashboard.Name)
@@ -98,88 +195,24 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 				return errors.Wrapf(err, "Could not write dashboard %q to output", dashboard.Name)
 			}
 			generatedAssets = append(generatedAssets, generatedDashboard)
-
-			// Reload specific dashboard
-			if opts.Reload {
-
-				// DefaultHTTPClient is used unless additional headers are requested
-				httpClient := sdk.DefaultHTTPClient
-
-				if len(opts.GrafanaHeaders) > 0 {
-					glog.Debug("Adding additional headers to Grafana requests")
-					glog.Debug(fmt.Sprintf("%v", opts.GrafanaHeaders))
-					adt := headertransport.NewAddHeaderTransport(httpClient.Transport, opts.GrafanaHeaders)
-					httpClient.Transport = adt
-				}
-
-				glog.Debug("Reloading Grafana instance")
-				client, err := sdk.NewClient(opts.GrafanaURL, opts.GrafanaCredentials, httpClient)
-				if err != nil {
-					return errors.Wrapf(err, "Failed to initialize Grafana client for dashboard %q", dashboard.Title)
-				}
-
-				var folderId int
-
-				if opts.GrafanaFolder != "" {
-					glog.Debug(fmt.Sprintf("Attempting to create dashboards in folder %s", opts.GrafanaFolder))
-					ctx := context.Background()
-
-					// Get all the folders and look up the customer by the customer name (title)
-					folders, err := client.GetAllFolders(ctx)
-					if err != nil {
-						return errors.Wrap(err, "Unable to get all folders from Grafana API")
-					}
-					for _, folder := range folders {
-						if folder.Title == opts.GrafanaFolder {
-							glog.Debug("Existing folder found. Using it.")
-							folderId = folder.ID
-						}
-					}
-
-					// folderId is not found, create it
-					if folderId == 0 {
-						glog.Debug("No existing folder found. Trying to create one.")
-						f := sdk.Folder{
-							Title: opts.GrafanaFolder,
-						}
-
-						folder, err := client.CreateFolder(ctx, f)
-						if err != nil {
-							return errors.Wrapf(err, "Error creating new folder %s", opts.GrafanaFolder)
-						}
-
-						glog.Debug(fmt.Sprintf("Folder created with title %s and id %v", folder.Title, folder.ID))
-						folderId = folder.ID
-					}
-				}
-
-				_, err = client.SetDashboard(context.Background(), *board, sdk.SetDashboardParams{Overwrite: true, FolderID: folderId})
-				if err != nil {
-					return errors.Wrapf(err, "Could not reload Grafana instance for dashboard %q", dashboard.Title)
-				} else {
-					glog.Info("Reloaded Grafana instance")
-				}
-			}
 		}
-
-		// Generate home page
-		if opts.GrafanaDir != "" {
-			data, err := grafana.Home(opts.InjectLabelMatchers)
-			if err != nil {
-				return errors.Wrap(err, "failed to generate home dashboard")
-			}
-			generatedDashboard := "home.json"
-			generatedAssets = append(generatedAssets, generatedDashboard)
-			if err = os.WriteFile(filepath.Join(opts.GrafanaDir, generatedDashboard), data, os.ModePerm); err != nil {
-				return errors.Wrap(err, "failed to generate home dashboard")
+		// Reload specific dashboard
+		if grafanaClient != nil {
+			glog.Debug("Reloading Grafana dashboard",
+				log.Int("folder.id", grafanaFolderID))
+			if _, err := grafanaClient.SetDashboard(ctx, *board, grafanasdk.SetDashboardParams{
+				Overwrite: true,
+				FolderID:  grafanaFolderID,
+			}); err != nil {
+				return errors.Wrapf(err, "Could not reload Grafana dashboard %q", dashboard.Title)
+			} else {
+				glog.Info("Reloaded Grafana dashboard")
 			}
 		}
 
 		// Prepare Prometheus assets
 		if opts.PrometheusDir != "" {
 			plog := dlog.Scoped("prometheus", "prometheus rules generation")
-
-			os.MkdirAll(opts.PrometheusDir, os.ModePerm)
 
 			plog.Debug("Rendering Prometheus assets")
 			promAlertsFile, err := dashboard.renderRules(opts.InjectLabelMatchers)
@@ -237,8 +270,6 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 
 	// Generate documentation
 	if opts.DocsDir != "" {
-		os.MkdirAll(opts.DocsDir, os.ModePerm)
-
 		logger.Debug("Rendering docs")
 		docs, err := renderDocumentation(dashboards)
 		if err != nil {

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -177,7 +177,7 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 			With(log.String("instance", opts.GrafanaURL))
 
 		glog.Debug("Rendering Grafana assets")
-		board, err := dashboard.renderDashboard(opts.InjectLabelMatchers)
+		board, err := dashboard.renderDashboard(opts.InjectLabelMatchers, opts.GrafanaFolder)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to render dashboard %q", dashboard.Name)
 		}

--- a/monitoring/monitoring/internal/grafana/home.json.tmpl
+++ b/monitoring/monitoring/internal/grafana/home.json.tmpl
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 28,
+  "id": 0,
   "links": [],
   "panels": [
     {

--- a/monitoring/monitoring/internal/headertransport/headertransport.go
+++ b/monitoring/monitoring/internal/headertransport/headertransport.go
@@ -17,12 +17,12 @@ func (adt *AddHeaderTransport) RoundTrip(req *http.Request) (*http.Response, err
 	return adt.T.RoundTrip(req)
 }
 
-func NewAddHeaderTransport(T http.RoundTripper, headers map[string]string) *AddHeaderTransport {
-	if T == nil {
-		T = http.DefaultTransport
+func NewAddHeaderTransport(t http.RoundTripper, headers map[string]string) *AddHeaderTransport {
+	if t == nil {
+		t = http.DefaultTransport
 	}
 	return &AddHeaderTransport{
-		T:                 T,
+		T:                 t,
 		additionalHeaders: headers,
 	}
 }

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -92,10 +92,21 @@ func (c *Dashboard) noAlertsDefined() bool {
 }
 
 // renderDashboard generates the Grafana renderDashboard for this container.
-func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher) (*sdk.Board, error) {
+// UIDs are globally unique identifiers for a given dashboard on Grafana. For normal Sourcegraph usage,
+// there is only ever a single dashboard with a given name but Cloud usage requires multiple copies
+// of the same dashboards to exist for different folders so we allow the ability to inject custom
+// label matchers and folder names to uniquely id the dashboards. UIDs need to be deterministic however
+// to generate appropriate alerts and documentations
+func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher, folder string) (*sdk.Board, error) {
+	// If the folder is not specified simply use the name for the UID
+	uid := c.Name
+	if folder != "" {
+		uid = fmt.Sprintf("%s-%s", folder, uid)
+	}
+
 	board := sdk.NewBoard(c.Title)
 	board.Version = uint(rand.Uint32())
-	board.UID = c.Name
+	board.UID = uid
 	board.ID = 0
 	board.Timezone = "utc"
 	board.Timepicker.RefreshIntervals = []string{"5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"}

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -593,7 +593,6 @@ commands:
         -p 0.0.0.0:3370:3370 ${ADD_HOST_FLAG} \
         -v "${GRAFANA_DISK}":/var/lib/grafana \
         -v "$(pwd)"/dev/grafana/all:/sg_config_grafana/provisioning/datasources \
-        -v "$(pwd)"/docker-images/grafana/config/provisioning/dashboards:/sg_grafana_additional_dashboards \
         sourcegraph/grafana:dev >"${GRAFANA_LOG_FILE}" 2>&1
     install: |
       mkdir -p "${GRAFANA_DISK}"


### PR DESCRIPTION
Add optional `grafana.folder` argument to `sg monitoring generate` to allow the Grafana Client to upload the dashboards to a specific folder. `sg` will attempt to find the folder on the remote server and override the dashboards. If it can't find it, it will create it. `sg` will also set the UID of the resulting dashboards to include the folder name to keep them globally unique.

## Test plan

`sg start monitoring` to start a local Grafana instance. Verify that the only folder that exists is `General`.

![Screen Shot 2022-10-04 at 16 28 40](https://user-images.githubusercontent.com/8784265/193933688-c79692b4-447a-4903-8fa4-9ba076023db2.png)


### Loading dashboards into a non-existent folder

```bash

#!/bin/bash

SRC_LOG_LEVEL=debug go run ./dev/sg monitoring generate \
	--reload \
	--grafana.folder="test1" 
```

Look for debug messages like:
```
1665090245235709000	DEBUG	generate.grafana.client	monitoring/generator.go:125	github.com/sourcegraph/sourcegraph/monitoring/monitoring.Generate	No existing folder found, creating a new one	{"Resource": {"service.name": "sg", "service.version": "dev", "service.instance.id": "1e6cf8e8-f058-4f5a-9c88-6d1317d0b51c"}, "Attributes": {}}
```

And verify the folder now exists and the dashboards are populated correctly:
![Screen Shot 2022-10-06 at 16 04 47](https://user-images.githubusercontent.com/8784265/194418398-df320a31-6102-4e10-ac10-dc4547427394.png)


### Loading dashboard into pre-existing folder

```bash

#!/bin/bash

SRC_LOG_LEVEL=debug go run ./dev/sg monitoring generate \
	--reload \
	--grafana.folder="test1" 
```

and look for log messages like:
```
1664919020647296000	DEBUG	generate.grafana	monitoring/generator.go:134	github.com/sourcegraph/sourcegraph/monitoring/monitoring.Generate	Existing folder found. Using it.	{"Resource": {"service.name": "sg", "service.version": "dev", "service.instance.id": "70a705bd-80ac-4ffb-b94e-ad151290c268"}, "Attributes": {"dashboard": "frontend", "instance": "http://127.0.0.1:3370"}}
```

and verify the dashboards still exist.