### PR TITLE
monitoring: support folders, streamline generation

### DIFF
--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/grafana-tools/sdk"
+	grafanasdk "github.com/grafana-tools/sdk"
 	"github.com/prometheus/prometheus/model/labels"
 	"gopkg.in/yaml.v2"
 
@@ -55,6 +55,8 @@ type GenerateOptions struct {
 
 // Generate is the main Sourcegraph monitoring generator entrypoint.
 func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard) error {
+	ctx := context.TODO()
+
 	logger.Info("Regenerating monitoring", log.String("options", fmt.Sprintf("%+v", opts)))
 
 	var generatedAssets []string
@@ -71,22 +73,117 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 		return errors.Wrap(validationErrors, "Validation failed")
 	}
 
-	// Generate Grafana content for all dashboards
+	// Set up disk directories
+	if opts.GrafanaDir != "" {
+		os.MkdirAll(opts.GrafanaDir, os.ModePerm)
+	}
+	if opts.PrometheusDir != "" {
+		os.MkdirAll(opts.PrometheusDir, os.ModePerm)
+	}
+	if opts.DocsDir != "" {
+		os.MkdirAll(opts.DocsDir, os.ModePerm)
+	}
+
+	// Generate Grafana content for all dashboards. If grafanaClient is not nil, Grafana
+	// should be reloaded.
+	var grafanaClient *grafanasdk.Client
+	var grafanaFolderID int
+	if opts.GrafanaURL != "" && opts.Reload {
+		gclog := logger.Scoped("grafana.client", "grafana client setup")
+
+		// DefaultHTTPClient is used unless additional headers are requested
+		httpClient := grafanasdk.DefaultHTTPClient
+		if len(opts.GrafanaHeaders) > 0 {
+			gclog.Debug("Adding additional headers to Grafana requests",
+				log.String("headers", fmt.Sprintf("%v", opts.GrafanaHeaders)))
+			httpClient.Transport = headertransport.NewAddHeaderTransport(httpClient.Transport, opts.GrafanaHeaders)
+		}
+
+		// Init Grafana client
+		var err error
+		grafanaClient, err = grafanasdk.NewClient(opts.GrafanaURL, opts.GrafanaCredentials, httpClient)
+		if err != nil {
+			return errors.Wrap(err, "Failed to initialize Grafana client")
+		}
+		if opts.GrafanaFolder != "" {
+			gclog.Debug("Preparing dashboard folder", log.String("folder", opts.GrafanaFolder))
+
+			// Get all the folders and look up the customer by the customer name (title)
+			folders, err := grafanaClient.GetAllFolders(ctx)
+			if err != nil {
+				return errors.Wrap(err, "Unable to get all folders from Grafana API")
+			}
+			for _, folder := range folders {
+				if folder.Title == opts.GrafanaFolder {
+					gclog.Debug("Found existing folder", log.Int("folder.id", folder.ID))
+					grafanaFolderID = folder.ID
+				}
+			}
+
+			// folderId is not found, create it
+			if grafanaFolderID == 0 {
+				gclog.Debug("No existing folder found, creating a new one")
+				folder, err := grafanaClient.CreateFolder(ctx, grafanasdk.Folder{
+					Title: opts.GrafanaFolder,
+				})
+				if err != nil {
+					return errors.Wrapf(err, "Error creating new folder %s", opts.GrafanaFolder)
+				}
+
+				gclog.Debug("Created folder",
+					log.String("folder.title", folder.Title),
+					log.Int("folder.id", folder.ID))
+				grafanaFolderID = folder.ID
+			}
+		}
+	}
+
+	// Generate Garafana home dasboard "Overview"
+	{
+		data, err := grafana.Home(opts.InjectLabelMatchers)
+		if err != nil {
+			return errors.Wrap(err, "failed to generate home dashboard")
+		}
+		if opts.GrafanaDir != "" {
+			generatedDashboard := "home.json"
+			generatedAssets = append(generatedAssets, generatedDashboard)
+			if err = os.WriteFile(filepath.Join(opts.GrafanaDir, generatedDashboard), data, os.ModePerm); err != nil {
+				return errors.Wrap(err, "failed to generate home dashboard")
+			}
+		}
+		if grafanaClient != nil {
+			logger.Debug("Reloading Grafana dashboard",
+				log.Int("folder.id", grafanaFolderID))
+			if _, err := grafanaClient.SetRawDashboardWithParam(ctx, grafanasdk.RawBoardRequest{
+				Dashboard: data,
+				Parameters: grafanasdk.SetDashboardParams{
+					Overwrite: true,
+					FolderID:  grafanaFolderID,
+				},
+			}); err != nil {
+				return errors.Wrapf(err, "Could not reload Grafana dashboard 'Overview'")
+			} else {
+				logger.Info("Reloaded Grafana dashboard")
+			}
+		}
+	}
+
+	// Generate per-dashboard assets
 	for _, dashboard := range dashboards {
 		// Logger for dashboard
 		dlog := logger.With(log.String("dashboard", dashboard.Name))
 
+		glog := dlog.Scoped("grafana", "grafana dashboard generation").
+			With(log.String("instance", opts.GrafanaURL))
+
+		glog.Debug("Rendering Grafana assets")
+		board, err := dashboard.renderDashboard(opts.InjectLabelMatchers)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to render dashboard %q", dashboard.Name)
+		}
+
 		// Prepare Grafana assets
 		if opts.GrafanaDir != "" {
-			glog := dlog.Scoped("grafana", "grafana dashboard generation").
-				With(log.String("instance", opts.GrafanaURL))
-			os.MkdirAll(opts.GrafanaDir, os.ModePerm)
-
-			glog.Debug("Rendering Grafana assets")
-			board, err := dashboard.renderDashboard(opts.InjectLabelMatchers)
-			if err != nil {
-				return errors.Wrapf(err, "Failed to render dashboard %q", dashboard.Name)
-			}
 			data, err := json.MarshalIndent(board, "", "  ")
 			if err != nil {
 				return errors.Wrapf(err, "Invalid dashboard %q", dashboard.Name)
@@ -98,88 +195,24 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 				return errors.Wrapf(err, "Could not write dashboard %q to output", dashboard.Name)
 			}
 			generatedAssets = append(generatedAssets, generatedDashboard)
-
-			// Reload specific dashboard
-			if opts.Reload {
-
-				// DefaultHTTPClient is used unless additional headers are requested
-				httpClient := sdk.DefaultHTTPClient
-
-				if len(opts.GrafanaHeaders) > 0 {
-					glog.Debug("Adding additional headers to Grafana requests")
-					glog.Debug(fmt.Sprintf("%v", opts.GrafanaHeaders))
-					adt := headertransport.NewAddHeaderTransport(httpClient.Transport, opts.GrafanaHeaders)
-					httpClient.Transport = adt
-				}
-
-				glog.Debug("Reloading Grafana instance")
-				client, err := sdk.NewClient(opts.GrafanaURL, opts.GrafanaCredentials, httpClient)
-				if err != nil {
-					return errors.Wrapf(err, "Failed to initialize Grafana client for dashboard %q", dashboard.Title)
-				}
-
-				var folderId int
-
-				if opts.GrafanaFolder != "" {
-					glog.Debug(fmt.Sprintf("Attempting to create dashboards in folder %s", opts.GrafanaFolder))
-					ctx := context.Background()
-
-					// Get all the folders and look up the customer by the customer name (title)
-					folders, err := client.GetAllFolders(ctx)
-					if err != nil {
-						return errors.Wrap(err, "Unable to get all folders from Grafana API")
-					}
-					for _, folder := range folders {
-						if folder.Title == opts.GrafanaFolder {
-							glog.Debug("Existing folder found. Using it.")
-							folderId = folder.ID
-						}
-					}
-
-					// folderId is not found, create it
-					if folderId == 0 {
-						glog.Debug("No existing folder found. Trying to create one.")
-						f := sdk.Folder{
-							Title: opts.GrafanaFolder,
-						}
-
-						folder, err := client.CreateFolder(ctx, f)
-						if err != nil {
-							return errors.Wrapf(err, "Error creating new folder %s", opts.GrafanaFolder)
-						}
-
-						glog.Debug(fmt.Sprintf("Folder created with title %s and id %v", folder.Title, folder.ID))
-						folderId = folder.ID
-					}
-				}
-
-				_, err = client.SetDashboard(context.Background(), *board, sdk.SetDashboardParams{Overwrite: true, FolderID: folderId})
-				if err != nil {
-					return errors.Wrapf(err, "Could not reload Grafana instance for dashboard %q", dashboard.Title)
-				} else {
-					glog.Info("Reloaded Grafana instance")
-				}
-			}
 		}
-
-		// Generate home page
-		if opts.GrafanaDir != "" {
-			data, err := grafana.Home(opts.InjectLabelMatchers)
-			if err != nil {
-				return errors.Wrap(err, "failed to generate home dashboard")
-			}
-			generatedDashboard := "home.json"
-			generatedAssets = append(generatedAssets, generatedDashboard)
-			if err = os.WriteFile(filepath.Join(opts.GrafanaDir, generatedDashboard), data, os.ModePerm); err != nil {
-				return errors.Wrap(err, "failed to generate home dashboard")
+		// Reload specific dashboard
+		if grafanaClient != nil {
+			glog.Debug("Reloading Grafana dashboard",
+				log.Int("folder.id", grafanaFolderID))
+			if _, err := grafanaClient.SetDashboard(ctx, *board, grafanasdk.SetDashboardParams{
+				Overwrite: true,
+				FolderID:  grafanaFolderID,
+			}); err != nil {
+				return errors.Wrapf(err, "Could not reload Grafana dashboard %q", dashboard.Title)
+			} else {
+				glog.Info("Reloaded Grafana dashboard")
 			}
 		}
 
 		// Prepare Prometheus assets
 		if opts.PrometheusDir != "" {
 			plog := dlog.Scoped("prometheus", "prometheus rules generation")
-
-			os.MkdirAll(opts.PrometheusDir, os.ModePerm)
 
 			plog.Debug("Rendering Prometheus assets")
 			promAlertsFile, err := dashboard.renderRules(opts.InjectLabelMatchers)
@@ -237,8 +270,6 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 
 	// Generate documentation
 	if opts.DocsDir != "" {
-		os.MkdirAll(opts.DocsDir, os.ModePerm)
-
 		logger.Debug("Rendering docs")
 		docs, err := renderDocumentation(dashboards)
 		if err != nil {

--- a/monitoring/monitoring/internal/grafana/home.json.tmpl
+++ b/monitoring/monitoring/internal/grafana/home.json.tmpl
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 28,
+  "id": 0,
   "links": [],
   "panels": [
     {

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -593,7 +593,6 @@ commands:
         -p 0.0.0.0:3370:3370 ${ADD_HOST_FLAG} \
         -v "${GRAFANA_DISK}":/var/lib/grafana \
         -v "$(pwd)"/dev/grafana/all:/sg_config_grafana/provisioning/datasources \
-        -v "$(pwd)"/docker-images/grafana/config/provisioning/dashboards:/sg_grafana_additional_dashboards \
         sourcegraph/grafana:dev >"${GRAFANA_LOG_FILE}" 2>&1
     install: |
       mkdir -p "${GRAFANA_DISK}"


### PR DESCRIPTION
Patch for https://github.com/sourcegraph/sourcegraph/pull/42542

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```sh
rm -rf $HOME/.sourcegraph-dev/data/grafana
sg run grafana
```

```sh
SRC_DEVELOPMENT=true SRC_LOG_LEVEL=debug go run ./dev/sg monitoring generate \
        --reload \
        --grafana.folder="test-folder"
```