### PR TITLE
security: update go version in asdf to 1.18.7

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.18.1
+golang 1.18.7
 nodejs 16.7.0
 # We're using yarn classic to install yarn 3.x as defined in package.json
 yarn 1.22.19

--- a/dev/sg/checks.go
+++ b/dev/sg/checks.go
@@ -35,7 +35,7 @@ var checks = map[string]check.CheckFunc{
 	"asdf":                  check.CommandOutputContains("asdf", "version"),
 	"git":                   check.Combine(check.InPath("git"), checkGitVersion(">= 2.34.1")),
 	"yarn":                  check.Combine(check.InPath("yarn"), checkYarnVersion("~> 1.22.4")),
-	"go":                    check.Combine(check.InPath("go"), checkGoVersion("~> 1.18.1")),
+	"go":                    check.Combine(check.InPath("go"), checkGoVersion("~> 1.18.7")),
 	"node":                  check.Combine(check.InPath("node"), check.CommandOutputContains(`node -e "console.log(\"foobar\")"`, "foobar")),
 	"rust":                  check.Combine(check.InPath("cargo"), check.CommandOutputContains(`cargo version`, "1.58.0")),
 	"docker-installed":      check.WrapErrMessage(check.InPath("docker"), "if Docker is installed and the check fails, you might need to start Docker.app and restart terminal and 'sg setup'"),


### PR DESCRIPTION
Update go version to latest security release see https://groups.google.com/g/golang-announce/c/xtuG5faxtaU
## Test plan
Green CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
