### PR TITLE
CodeMirror blob: disable auto completion suggestions from the browser

### DIFF
--- a/client/web/src/repo/blob/codemirror/search.ts
+++ b/client/web/src/repo/blob/codemirror/search.ts
@@ -60,6 +60,7 @@ class SearchPanel implements Panel {
             name: 'search',
             placeholder: 'Find...',
             className: 'form-control form-control-sm mr-2',
+            autocomplete: 'off',
             onchange: this.commit,
             onkeyup: this.commit,
         })


### PR DESCRIPTION
Previously, the browser would suggest completions when typing queries in the CodeMirror search component. These suggestions were mostly noisy so this commit disables the `autocomplete` attribute.

## Test plan

- Use Google Chrome
- Open any file with the CM blob
- Use Cmd+F to open the search component
- Type stuff, the browser shouldn't display any autocomplete suggestions like from the screenshot below


![CleanShot 2022-10-05 at 11 18 04](https://user-images.githubusercontent.com/1408093/194026786-10854f9d-405b-4315-b566-767634bc7d86.png)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-disable-autocomplete.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-djdouyksxj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
