### PR TITLE
Add hostname validation 

### DIFF
--- a/cmd/gitserver/server/list_gitolite.go
+++ b/cmd/gitserver/server/list_gitolite.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
+	"github.com/sourcegraph/sourcegraph/internal/security"
 )
 
 func (s *Server) handleListGitolite(w http.ResponseWriter, r *http.Request) {
@@ -35,7 +36,7 @@ func (g gitoliteFetcher) listRepos(ctx context.Context, gitoliteHost string, w h
 		err   error
 	)
 
-	if gitoliteHost != "" {
+	if gitoliteHost != "" || !security.ValidateRemoteAddr(gitoliteHost) {
 		if repos, err = g.client.ListRepos(ctx, gitoliteHost); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -4,6 +4,7 @@ package security
 
 import (
 	"fmt"
+	"net"
 	"unicode"
 	"unicode/utf8"
 
@@ -11,6 +12,24 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
+
+// ValidateRemoteAddr validates if the input is a valid IP or a valid hostname.
+// It validates the hostname by attempting to resolve it.
+func ValidateRemoteAddr(raddr string) bool {
+
+	validIP := net.ParseIP(raddr) != nil
+	validHost := true
+
+	_, err := net.LookupHost(raddr)
+
+	if err != nil {
+		// we cannot resolve the addr
+		validHost = false
+	}
+
+	return validIP == true || validHost == true
+
+}
 
 // maxPasswordRunes is the maximum number of UTF-8 runes that a password can contain.
 // This safety limit is to protect us from a DDOS attack caused by hashing very large passwords on Sourcegraph.com.

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -21,6 +21,11 @@ type passwordTest struct {
 	errorStr string
 }
 
+type addrTest struct {
+	addr string
+	pass bool
+}
+
 // setMockPasswordPolicyConfig helper for returning a customized mock config
 func setMockPasswordPolicyConfig(opts mockPolicyOpts) {
 	conf.Mock(&conf.Unified{
@@ -126,4 +131,21 @@ func TestPasswordPolicy(t *testing.T) {
 		password = "thisshouldnowpassaswell"
 		assert.Nil(t, ValidatePassword(password))
 	})
+}
+
+func TestAddrValidation(t *testing.T) {
+	var addrTests = []addrTest{
+		{"127/0.0.1", false},
+		{"-oFooBaz", false},
+		{"sourcegraph com", false},
+		{"127.0.0.1", true},
+		{"sourcegraph.com", true},
+	}
+
+	t.Run("correctly validates addresses", func(t *testing.T) {
+		for _, a := range addrTests {
+			assert.True(t, ValidateRemoteAddr(a.addr) == a.pass)
+		}
+	})
+
 }


### PR DESCRIPTION
Add functionality that validates hostnames and IP addresses. Validate gitolite addresses.

## Test plan

- [ ] ci tests
- [ ] manual tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
