### PR TITLE
search: Make integration test less flaky (maybe?)

### DIFF
--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -334,9 +334,11 @@ describe('Search', () => {
     describe('Search button', () => {
         test('Clicking search button executes search', async () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=regexp')
+            const editor = await createEditorAPI(driver, queryInputSelector)
+            editor.focus()
+            await driver.page.keyboard.type(' hello')
+
             await driver.page.waitForSelector('.test-search-button', { visible: true })
-            // Note: Delay added because this test has been intermittently failing without it. Monaco search bar may drop events if it gets too many too fast.
-            await driver.page.keyboard.type(' hello', { delay: 500 })
             await driver.page.click('.test-search-button')
             await driver.assertWindowLocation('/search?q=context:global+test+hello&patternType=regexp')
         })

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -335,7 +335,7 @@ describe('Search', () => {
         test('Clicking search button executes search', async () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=regexp')
             const editor = await createEditorAPI(driver, queryInputSelector)
-            editor.focus()
+            await editor.focus()
             await driver.page.keyboard.type(' hello')
 
             await driver.page.waitForSelector('.test-search-button', { visible: true })


### PR DESCRIPTION
Context: https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1664918793414989

Seems generally a good idea to wait until the input is ready to receive key events.

## Test plan


CI

## App preview:

- [Web](https://sg-web-fkling-search-test-flake.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-kmhmofimua.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
