### PR TITLE
graphqlbackend: use StableSort for InvitableCollaborators

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service_collaborators.go
+++ b/cmd/frontend/graphqlbackend/external_service_collaborators.go
@@ -208,7 +208,7 @@ func filterInvitableCollaborators(
 	// invite are people who recently committed to code, which means they're more active and more
 	// likely the person you want to invite (compared to e.g. if we hit a very old repo and the
 	// committer is say no longer working at that organization.)
-	sort.Slice(recentCommitters, func(i, j int) bool {
+	sort.SliceStable(recentCommitters, func(i, j int) bool {
 		a := recentCommitters[i].date
 		b := recentCommitters[j].date
 		return a.After(b)
@@ -276,7 +276,7 @@ func filterInvitableCollaborators(
 		current := invitablePerDomain[domain(person.email)]
 		invitablePerDomain[domain(person.email)] = current + 1
 	}
-	sort.Slice(invitable, func(i, j int) bool {
+	sort.SliceStable(invitable, func(i, j int) bool {
 		// First, sort popular personal email domains lower.
 		iDomain := domain(invitable[i].email)
 		jDomain := domain(invitable[j].email)

--- a/cmd/frontend/graphqlbackend/external_service_collaborators_test.go
+++ b/cmd/frontend/graphqlbackend/external_service_collaborators_test.go
@@ -202,14 +202,14 @@ func TestExternalServiceCollaborators_filterInvitableCollaborators(t *testing.T)
 			authUserEmails:   emails(),
 			want: autogold.Want("popular personal email domains last", []*invitableCollaboratorResolver{
 				{
-					email: "sqs@sourcegraph.com",
+					email: "stephen@sourcegraph.com",
 				},
-				{email: "stephen@sourcegraph.com"},
 				{email: "beyang@sourcegraph.com"},
+				{email: "sqs@sourcegraph.com"},
+				{email: "steve@gmail.com"},
 				{email: "rando@gmail.com"},
 				{email: "kimbo@gmail.com"},
 				{email: "george@gmail.com"},
-				{email: "steve@gmail.com"},
 			}),
 		},
 	}


### PR DESCRIPTION
Our tests do not specify a date, which means for the initial sort all elements are regarded as equal. Go changed the implementation of sort in go1.19, which means a test for this function started to fail even though the sort was still correct. Switching to StableSort not only makes the algorithm deterministic across sorting algorithms, but it also seems like a better tie breaking condition (respect initial order)

Test Plan: go test