### PR TITLE
Stencil: Dedupe ranges after sorting

### DIFF
--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -1144,7 +1144,8 @@ func (s *Service) GetStencil(ctx context.Context, args shared.RequestArgs, reque
 	}
 	trace.Log(traceLog.Int("numRanges", len(adjustedRanges)))
 
-	return sortRanges(adjustedRanges), nil
+	sortedRanges := sortRanges(adjustedRanges)
+	return dedupeRanges(sortedRanges), nil
 }
 
 func (s *Service) GetMonikersByPosition(ctx context.Context, bundleID int, path string, line, character int) (_ [][]precise.MonikerData, err error) {

--- a/internal/codeintel/codenav/service_stencil_test.go
+++ b/internal/codeintel/codenav/service_stencil_test.go
@@ -69,3 +69,61 @@ func TestStencil(t *testing.T) {
 		t.Errorf("unexpected range (-want +got):\n%s", diff)
 	}
 }
+
+func TestStencilWithDuplicateRanges(t *testing.T) {
+	// Set up mocks
+	mockStore := NewMockStore()
+	mockLsifStore := NewMockLsifStore()
+	mockUploadSvc := NewMockUploadService()
+	mockGitserverClient := NewMockGitserverClient()
+	mockGitServer := codeintelgitserver.New(database.NewMockDB(), &observation.TestContext)
+
+	// Init service
+	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, &observation.TestContext)
+
+	// Set up request state
+	mockRequestState := RequestState{}
+	mockRequestState.SetLocalCommitCache(mockGitserverClient)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, 50)
+	uploads := []types.Dump{
+		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
+		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
+		{ID: 52, Commit: "deadbeef", Root: "sub3/"},
+		{ID: 53, Commit: "deadbeef", Root: "sub4/"},
+	}
+	mockRequestState.SetUploadsDataLoader(uploads)
+
+	expectedRanges := []types.Range{
+		{Start: types.Position{Line: 10, Character: 20}, End: types.Position{Line: 10, Character: 30}},
+		{Start: types.Position{Line: 11, Character: 20}, End: types.Position{Line: 11, Character: 30}},
+		{Start: types.Position{Line: 12, Character: 20}, End: types.Position{Line: 12, Character: 30}},
+		{Start: types.Position{Line: 13, Character: 20}, End: types.Position{Line: 13, Character: 30}},
+		{Start: types.Position{Line: 14, Character: 20}, End: types.Position{Line: 14, Character: 30}},
+		{Start: types.Position{Line: 15, Character: 20}, End: types.Position{Line: 15, Character: 30}},
+		{Start: types.Position{Line: 16, Character: 20}, End: types.Position{Line: 16, Character: 30}},
+		{Start: types.Position{Line: 17, Character: 20}, End: types.Position{Line: 17, Character: 30}},
+		{Start: types.Position{Line: 18, Character: 20}, End: types.Position{Line: 18, Character: 30}},
+		{Start: types.Position{Line: 19, Character: 20}, End: types.Position{Line: 19, Character: 30}},
+	}
+	mockLsifStore.GetStencilFunc.PushReturn(nil, nil)
+
+	// Duplicate the ranges to test that we dedupe them
+	mockLsifStore.GetStencilFunc.PushReturn(append(expectedRanges, expectedRanges...), nil)
+
+	mockRequest := shared.RequestArgs{
+		RepositoryID: 42,
+		Commit:       mockCommit,
+		Path:         mockPath,
+		Line:         10,
+		Character:    20,
+		Limit:        50,
+	}
+	ranges, err := svc.GetStencil(context.Background(), mockRequest, mockRequestState)
+	if err != nil {
+		t.Fatalf("unexpected error querying hover: %s", err)
+	}
+
+	if diff := cmp.Diff(expectedRanges, ranges); diff != "" {
+		t.Errorf("unexpected range (-want +got):\n%s", diff)
+	}
+}

--- a/internal/codeintel/codenav/utils.go
+++ b/internal/codeintel/codenav/utils.go
@@ -117,3 +117,13 @@ func sortRanges(ranges []types.Range) []types.Range {
 
 	return ranges
 }
+
+func dedupeRanges(ranges []types.Range) []types.Range {
+	dedup := ranges[:1]
+	for _, s := range ranges[1:] {
+		if s != dedup[len(dedup)-1] {
+			dedup = append(dedup, s)
+		}
+	}
+	return dedup
+}

--- a/internal/codeintel/codenav/utils.go
+++ b/internal/codeintel/codenav/utils.go
@@ -119,6 +119,10 @@ func sortRanges(ranges []types.Range) []types.Range {
 }
 
 func dedupeRanges(ranges []types.Range) []types.Range {
+	if len(ranges) == 0 {
+		return ranges
+	}
+
 	dedup := ranges[:1]
 	for _, s := range ranges[1:] {
 		if s != dedup[len(dedup)-1] {


### PR DESCRIPTION
## Description

Stencil sometimes appears to return duplicate ranges for the same file. It isn't clear why this happens but @chrismwendt and @efritz suggested that it could be due to multiple LSIF dumps.

This PR simply de-duplicates the results after they have been sorted. We shouldn't ever have duplicate ranges.

## Test plan

Tested locally by manually duplicating results in the code, and also added a test for this.

I wasn't able to replicate this bug locally though (without forcing it in the code), which makes me a little uneasy. Adding a comment below to see if anyone else might be able to