### PR TITLE
gitserver: correctly join path to CloneFromShard

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -2023,13 +2023,17 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, opts *cloneOp
 			return "", errors.Errorf("cannot clone from the same gitserver instance")
 		}
 
-		remoteURL, err = vcs.ParseURL(filepath.Join(opts.CloneFromShard, "git", string(repo)))
+		remoteURL, err = vcs.ParseURL(opts.CloneFromShard)
+		if err != nil {
+			return "", err
+		}
+		remoteURL = remoteURL.JoinPath("git", string(repo))
 	} else {
 		// We may be attempting to clone a private repo so we need an internal actor.
 		remoteURL, err = s.getRemoteURL(actor.WithInternalActor(ctx), repo)
-	}
-	if err != nil {
-		return "", err
+		if err != nil {
+			return "", err
+		}
 	}
 
 	// isCloneable causes a network request, so we limit the number that can

--- a/internal/vcs/url.go
+++ b/internal/vcs/url.go
@@ -19,6 +19,7 @@ package vcs
 import (
 	"fmt"
 	"net/url"
+	"path"
 	"strings"
 
 	"github.com/grafana/regexp"
@@ -158,10 +159,43 @@ const (
 // any existing path and the resulting path cleaned of any ./ or ../ elements.
 // Any sequences of multiple / characters will be reduced to a single /.
 func (u *URL) JoinPath(elem ...string) *URL {
-	return &URL{
-		URL:    *u.URL.JoinPath(elem...),
-		format: u.format,
+	// Until our minimum version is go1.19 we copy-pasta the implementation of
+	// URL.JoinPath
+
+	// START copy from go stdlib URL.JoinPath
+	elem = append([]string{u.EscapedPath()}, elem...)
+	var p string
+	if !strings.HasPrefix(elem[0], "/") {
+		// Return a relative path if u is relative,
+		// but ensure that it contains no ../ elements.
+		elem[0] = "/" + elem[0]
+		p = path.Join(elem...)[1:]
+	} else {
+		p = path.Join(elem...)
 	}
+	// path.Join will remove any trailing slashes.
+	// Preserve at least one.
+	if strings.HasSuffix(elem[len(elem)-1], "/") && !strings.HasSuffix(p, "/") {
+		p += "/"
+	}
+	// END copy from go stdlib URL.JoinPath
+
+	// We don't have access to URL.setPath, so we work around it by parsing
+	// the URL as a path. This is extremely ugly hacks, but it makes the
+	// stdlib tests from go1.19 pass.
+	up, err := url.Parse("file:///" + p)
+	if err != nil {
+		u2 := *u
+		u2.Path = p
+		u2.RawPath = ""
+		return &u2
+	}
+
+	u2 := *u
+	u2.Path = strings.TrimPrefix(up.Path, "/")
+	u2.RawPath = strings.TrimPrefix(up.RawPath, "/")
+
+	return &u2
 }
 
 // String will return standard url.URL.String() if the url has a .Scheme set, but if

--- a/internal/vcs/url.go
+++ b/internal/vcs/url.go
@@ -154,6 +154,16 @@ const (
 	formatLocal
 )
 
+// JoinPath returns a new URL with the provided path elements joined to
+// any existing path and the resulting path cleaned of any ./ or ../ elements.
+// Any sequences of multiple / characters will be reduced to a single /.
+func (u *URL) JoinPath(elem ...string) *URL {
+	return &URL{
+		URL:    *u.URL.JoinPath(elem...),
+		format: u.format,
+	}
+}
+
 // String will return standard url.URL.String() if the url has a .Scheme set, but if
 // not it will produce an rsync format URL, eg `git@foo.com:foo/bar.git`
 func (u *URL) String() string {


### PR DESCRIPTION
filepath is the incorrect package to use for joining a path onto a URL (use path package). Additionally, path.Join is not correct to use on a URL since it is supposed to operate on a path, not a URL. In go1.19 path join additionally does cleaning. This means things like "http://" will change into "http:/", leading to the feature breaking.

This commit introduces a wrapper around url.JoinPath in our url wrapper package and uses that in gitserver.

Test Plan: go test works on go1.19