### PR TITLE
sg: dev-private uses master branch

### DIFF
--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -216,7 +216,7 @@ func startExec(ctx *cli.Context) error {
 
 		// dev-private exists, try to update the configuration
 		update := std.Out.Pending(output.Styled(output.StylePending, "Updating dev-private..."))
-		if err := sgrun.Bash(ctx.Context, "git pull origin main").
+		if err := sgrun.Bash(ctx.Context, "git pull origin master").
 			Dir(devPrivatePath).
 			Run().Wait(); err != nil {
 


### PR DESCRIPTION
The auto pull of dev-private specifies `main` which does not exist on dev-private

## Test plan
```
cd dev-private && git branch -a | egrep "origin/master|origin/main"
  remotes/origin/HEAD -> origin/master
  remotes/origin/master`
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
