### PR TITLE
codeintel-db: Differentiate connection via types

### DIFF
--- a/cmd/worker/shared/init/codeintel/db.go
+++ b/cmd/worker/shared/init/codeintel/db.go
@@ -6,9 +6,9 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/memo"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -19,13 +19,13 @@ func InitDB() (*sql.DB, error) {
 	return initDBMemo.Init()
 }
 
-func InitDBWithLogger(logger log.Logger) (database.DB, error) {
+func InitDBWithLogger(logger log.Logger) (stores.CodeIntelDB, error) {
 	rawDB, err := InitDB()
 	if err != nil {
 		return nil, err
 	}
 
-	return database.NewDB(logger, rawDB), nil
+	return stores.NewCodeIntelDB(rawDB), nil
 }
 
 var initDBMemo = memo.NewMemoizedConstructor(func() (*sql.DB, error) {

--- a/enterprise/cmd/frontend/internal/codeintel/services.go
+++ b/enterprise/cmd/frontend/internal/codeintel/services.go
@@ -52,10 +52,9 @@ func NewServices(ctx context.Context, config *Config, siteConfig conftypes.Watch
 	}
 
 	// Connect to the separate LSIF database
-	codeIntelDBConnection := mustInitializeCodeIntelDB(logger)
+	codeIntelLsifStore := mustInitializeCodeIntelDB(logger)
 
-	// Initialize lsif stores (TODO: these should be integrated, they are basically pointing to the same thing)
-	codeIntelLsifStore := database.NewDBWith(observationContext.Logger, codeIntelDBConnection)
+	// Initialize blob stores
 	uploadStore, err := lsifuploadstore.New(context.Background(), config.LSIFUploadStoreConfig, observationContext)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -112,7 +112,7 @@ func main() {
 		logger.Fatal("Failed to create sub-repo client", log.Error(err))
 	}
 
-	uploadsSvc := uploads.GetService(db, database.NewDBWith(logger, codeIntelDB), gitserverClient)
+	uploadsSvc := uploads.GetService(db, codeIntelDB, gitserverClient)
 
 	// Initialize worker
 	rootContext := actor.WithInternalActor(context.Background())

--- a/internal/codeintel/codenav/init.go
+++ b/internal/codeintel/codenav/init.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/internal/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/internal/store"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -17,8 +18,8 @@ var (
 // GetService creates or returns an already-initialized symbols service.
 // If the service is not yet initialized, it will use the provided dependencies.
 func GetService(
-	db,
-	codeIntelDB database.DB,
+	db database.DB,
+	codeIntelDB stores.CodeIntelDB,
 	uploadSvc UploadService,
 	gitserver GitserverClient,
 ) *Service {

--- a/internal/codeintel/codenav/internal/lsifstore/lsifstore.go
+++ b/internal/codeintel/codenav/internal/lsifstore/lsifstore.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
@@ -49,7 +49,7 @@ type store struct {
 	operations *operations
 }
 
-func New(db database.DB, observationContext *observation.Context) LsifStore {
+func New(db stores.CodeIntelDB, observationContext *observation.Context) LsifStore {
 	return &store{
 		db:         basestore.NewWithHandle(db.Handle()),
 		serializer: NewSerializer(),

--- a/internal/codeintel/codenav/internal/lsifstore/lsifstore_locations_test.go
+++ b/internal/codeintel/codenav/internal/lsifstore/lsifstore_locations_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
-	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -68,16 +68,15 @@ func TestDatabaseReferences(t *testing.T) {
 
 func populateTestStore(t testing.TB) LsifStore {
 	logger := logtest.Scoped(t)
-	sqlDB := dbtest.NewDB(logger, t)
-	db := database.NewDB(logger, sqlDB)
-	store := New(db, &observation.TestContext)
+	codeIntelDB := stores.NewCodeIntelDB(dbtest.NewDB(logger, t))
+	store := New(codeIntelDB, &observation.TestContext)
 
 	contents, err := os.ReadFile("./testdata/lsif-go@ad3507cb.sql")
 	if err != nil {
 		t.Fatalf("unexpected error reading testdata: %s", err)
 	}
 
-	tx, err := db.Transact(context.Background())
+	tx, err := codeIntelDB.Transact(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error starting transaction: %s", err)
 	}

--- a/internal/codeintel/uploads/init.go
+++ b/internal/codeintel/uploads/init.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/policies"
 	policiesEnterprise "github.com/sourcegraph/sourcegraph/internal/codeintel/policies/enterprise"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/internal/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/internal/store"
@@ -33,7 +34,7 @@ type RepoUpdaterClient interface {
 // If the service is not yet initialized, it will use the provided dependencies.
 func GetService(
 	db database.DB,
-	codeIntelDB database.DB,
+	codeIntelDB stores.CodeIntelDB,
 	gsc GitserverClient,
 ) *Service {
 	svcOnce.Do(func() {

--- a/internal/codeintel/uploads/internal/lsifstore/lsifstore.go
+++ b/internal/codeintel/uploads/internal/lsifstore/lsifstore.go
@@ -3,7 +3,7 @@ package lsifstore
 import (
 	"context"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
@@ -30,7 +30,7 @@ type store struct {
 	operations *operations
 }
 
-func New(db database.DB, observationContext *observation.Context) LsifStore {
+func New(db stores.CodeIntelDB, observationContext *observation.Context) LsifStore {
 	return &store{
 		db:         basestore.NewWithHandle(db.Handle()),
 		serializer: NewSerializer(),

--- a/internal/codeintel/uploads/internal/lsifstore/lsifstore_documents_test.go
+++ b/internal/codeintel/uploads/internal/lsifstore/lsifstore_documents_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log/logtest"
 
-	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/stores"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -43,16 +43,15 @@ const testBundleID = 1
 
 func populateTestStore(t testing.TB) LsifStore {
 	logger := logtest.Scoped(t)
-	sqlDB := dbtest.NewDB(logger, t)
-	db := database.NewDB(logger, sqlDB)
-	store := New(db, &observation.TestContext)
+	codeIntelDB := stores.NewCodeIntelDB(dbtest.NewDB(logger, t))
+	store := New(codeIntelDB, &observation.TestContext)
 
 	contents, err := os.ReadFile("./testdata/lsif-go@ad3507cb.sql")
 	if err != nil {
 		t.Fatalf("unexpected error reading testdata: %s", err)
 	}
 
-	tx, err := db.Transact(context.Background())
+	tx, err := codeIntelDB.Transact(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error starting transaction: %s", err)
 	}


### PR DESCRIPTION
Do not use `database.DB` with codeintel-db connections.

## Test plan

Unit tests and local testing.