### PR TITLE
sg: remove unused

### DIFF
--- a/dev/sg/dependencies/helpers.go
+++ b/dev/sg/dependencies/helpers.go
@@ -85,36 +85,6 @@ func pathExists(path string) (bool, error) {
 	return false, err
 }
 
-func checkInMainRepoOrRepoInDirectory(context.Context) error {
-	_, err := root.RepositoryRoot()
-	if err != nil {
-		ok, err := pathExists("sourcegraph")
-		if !ok || err != nil {
-			return errors.New("'sg setup' is not run in sourcegraph and repository is also not found in current directory")
-		}
-		return nil
-	}
-	return nil
-}
-
-func checkDevPrivateInParentOrInCurrentDirectory(context.Context) error {
-	ok, err := pathExists("dev-private")
-	if ok && err == nil {
-		return nil
-	}
-	wd, err := os.Getwd()
-	if err != nil {
-		return errors.Wrap(err, "failed to check for dev-private repository")
-	}
-
-	p := filepath.Join(wd, "..", "dev-private")
-	ok, err = pathExists(p)
-	if ok && err == nil {
-		return nil
-	}
-	return errors.New("could not find dev-private repository either in current directory or one above")
-}
-
 // checkPostgresConnection succeeds connecting to the default user database works, regardless
 // of if it's running locally or with docker.
 func checkPostgresConnection(ctx context.Context) error {

--- a/dev/sg/internal/std/output.go
+++ b/dev/sg/internal/std/output.go
@@ -83,11 +83,11 @@ func (o *Output) writeExpanded(line output.FancyLine) {
 	o.WriteLine(line)
 }
 
-// WriteHeading writes a line that is prefixed Buildkite log output management stuffs such
+// writeCollapsed writes a line that is prefixed Buildkite log output management stuffs such
 // that subsequent lines are collapsed if we are in Buildkite.
 //
 // Learn more: https://buildkite.com/docs/pipelines/managing-log-output
-func (o *Output) writeCollapsed(line output.FancyLine) {
+func (o *Output) writeCollapsed(line output.FancyLine) { //nolint:unused
 	if o.buildkite {
 		line.Prefix = "---"
 	}

--- a/dev/sg/linters/misc.go
+++ b/dev/sg/linters/misc.go
@@ -2,5 +2,4 @@ package linters
 
 var (
 	noLocalHost = runScript("Check for localhost usage", "dev/check/no-localhost-guard.sh") // CI:LOCALHOST_OK
-	submodules  = runScript("Check submodules", "dev/check/submodule.sh")
 )


### PR DESCRIPTION
Most of these are just unused code as reported by lint. But in two things worth closer consideration:

- writeCollapsed is unused, but is a useful API. So marking with nolint.
- submodules linter is unused, but maybe it should be? If not we should probably remove the script as well.

Test Plan: CI