### PR TITLE
sg monitoring: do not generate UIDs when folder is specified

### DIFF
--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -177,7 +177,7 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 			With(log.String("instance", opts.GrafanaURL))
 
 		glog.Debug("Rendering Grafana assets")
-		board, err := dashboard.renderDashboard(opts.InjectLabelMatchers)
+		board, err := dashboard.renderDashboard(opts.InjectLabelMatchers, opts.GrafanaFolder != "")
 		if err != nil {
 			return errors.Wrapf(err, "Failed to render dashboard %q", dashboard.Name)
 		}

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -177,7 +177,7 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 			With(log.String("instance", opts.GrafanaURL))
 
 		glog.Debug("Rendering Grafana assets")
-		board, err := dashboard.renderDashboard(opts.InjectLabelMatchers, opts.GrafanaFolder != "")
+		board, err := dashboard.renderDashboard(opts.InjectLabelMatchers, opts.GrafanaFolder)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to render dashboard %q", dashboard.Name)
 		}

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -92,12 +92,13 @@ func (c *Dashboard) noAlertsDefined() bool {
 }
 
 // renderDashboard generates the Grafana renderDashboard for this container.
-func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher, generateUID bool) (*sdk.Board, error) {
+func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher, folder string) (*sdk.Board, error) {
+
 	uid := c.Name
-	// Passing a null to the UID field causes Grafana to randomly generate a UID
-	if generateUID {
-		uid = ""
+	if folder != "" {
+		uid = fmt.Sprintf("%s-%s", folder, uid)
 	}
+
 	board := sdk.NewBoard(c.Title)
 	board.Version = uint(rand.Uint32())
 	board.UID = uid

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -92,8 +92,13 @@ func (c *Dashboard) noAlertsDefined() bool {
 }
 
 // renderDashboard generates the Grafana renderDashboard for this container.
+// UIDs are globally unique identifiers for a given dashboard on Grafana. For normal Sourcegraph usage,
+// there is only ever a single dashboard with a given name but Cloud usage requires multiple copies
+// of the same dashboards to exist for different folders so we allow the ability to inject custom
+// label matchers and folder names to uniquely id the dashboards. UIDs need to be deterministic however
+// to generate appropriate alerts and documentations
 func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher, folder string) (*sdk.Board, error) {
-
+	// If the folder is not specified simply use the name for the UID
 	uid := c.Name
 	if folder != "" {
 		uid = fmt.Sprintf("%s-%s", folder, uid)

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -92,10 +92,15 @@ func (c *Dashboard) noAlertsDefined() bool {
 }
 
 // renderDashboard generates the Grafana renderDashboard for this container.
-func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher) (*sdk.Board, error) {
+func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher, generateUID bool) (*sdk.Board, error) {
+	uid := c.Name
+	// Passing a null to the UID field causes Grafana to randomly generate a UID
+	if generateUID {
+		uid = ""
+	}
 	board := sdk.NewBoard(c.Title)
 	board.Version = uint(rand.Uint32())
-	board.UID = c.Name
+	board.UID = uid
 	board.ID = 0
 	board.Timezone = "utc"
 	board.Timepicker.RefreshIntervals = []string{"5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"}


### PR DESCRIPTION
~~Grafana will generate a UID if a `null` is passed to the dashboard request.~~

Pass in the `folder` name and construct a uid of `folder-dashboard`.

## Test plan
`sg run grafana`
Observe that the default dashboards are there with their predefined UIDs

```bash
SRC_LOG_LEVEL=debug go run ./dev/sg monitoring generate \
	--reload \
	--grafana.folder="test1"
```
Observe that the folder `test1` is generated and populated. Click on the `Code Intelligence > Code Nav` dashboard in this folder. The UID in the URL should look like `http://localhost:3370/-/debug/grafana/d/test1-codeintel-codenav/code-intelligence-code-nav?orgId=1`.