### PR TITLE
dev/sg: Fix spinner for dev-private update

### DIFF
--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -225,6 +225,8 @@ func startExec(ctx *cli.Context) error {
 			std.Out.Write("")
 			std.Out.Write(err.Error())
 			std.Out.Write("")
+		} else {
+			update.Complete(output.Line(output.EmojiSuccess, output.StyleSuccess, "Done updating dev-private"))
 		}
 	}
 


### PR DESCRIPTION
After we introduced the `dev-private` update check when running `sg start`:

- #42531 

The output `Updating dev-private...` is showing up repeatedly in the terminal because it's an `output.Pending` spinner and it's missing a call to close it after the update is done. [Reported here](https://sourcegraph.slack.com/archives/C01N83PS4TU/p1665003972649409)

This fix adds the missing call to `Complete` on the pending spinner so that it can stop producing output.

## Test plan
- run `sg start`
- observe the terminal output is fixed