### PR TITLE
usage stats: filter out sourcegraph employee admins from user counts

### DIFF
--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -106,11 +106,11 @@ func hasFindRefsOccurred(ctx context.Context) (_ bool, err error) {
 
 func getTotalUsersCount(ctx context.Context, db database.DB) (_ int, err error) {
 	defer recordOperation("getTotalUsersCount")(&err)
-	return db.Users().Count(ctx, &database.UsersListOptions{})
+	return db.Users().Count(ctx, &database.UsersListOptions{ExcludeSourcegraphAdmins: true})
 }
 
 func getTotalOrgsCount(ctx context.Context, db database.DB) (_ int, err error) {
-	defer recordOperation("getTotalUsersCount")(&err)
+	defer recordOperation("getTotalOrgsCount")(&err)
 	return db.Orgs().Count(ctx, database.OrgsListOptions{})
 }
 

--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -842,7 +842,9 @@ func (l *eventLogStore) SiteUsageCurrentPeriods(ctx context.Context) (types.Site
 
 func (l *eventLogStore) siteUsageCurrentPeriods(ctx context.Context, now time.Time, opt *SiteUsageOptions) (summary types.SiteUsageSummary, err error) {
 	conds := []*sqlf.Query{sqlf.Sprintf("TRUE")}
-	conds = buildCommonUsageConds(&opt.CommonUsageOptions, conds)
+	if opt != nil {
+		conds = buildCommonUsageConds(&opt.CommonUsageOptions, conds)
+	}
 
 	query := sqlf.Sprintf(siteUsageCurrentPeriodsQuery, now, now, now, now, sqlf.Join(conds, ") AND ("))
 

--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -525,7 +525,7 @@ func createCountUniqueUserConds(opt *CountUniqueUsersOptions) []*sqlf.Query {
 		// This may incur false positives, but we acknowledge this risk as we would prefer to
 		// undercount rather than overcount.
 		if opt.ExcludeSourcegraphAdmins {
-			conds = append(conds, sqlf.Sprintf("users.username NOT ILIKE 'managed-%%' AND users.username NOT ILIKE 'sourcegraph-management-%%' AND users.username != 'sourcegraph-admin'"))
+			conds = append(conds, sqlf.Sprintf("users.username IS NULL OR (users.username NOT ILIKE 'managed-%%' AND users.username NOT ILIKE 'sourcegraph-management-%%' AND users.username != 'sourcegraph-admin')"))
 		}
 		if opt.EventFilters != nil {
 			if opt.EventFilters.ByEventNamePrefix != "" {
@@ -831,7 +831,7 @@ func (l *eventLogStore) siteUsageCurrentPeriods(ctx context.Context, now time.Ti
 		// This may incur false positives, but we acknowledge this risk as we would prefer to
 		// undercount rather than overcount.
 		if opt.ExcludeSourcegraphAdmins {
-			conds = append(conds, sqlf.Sprintf("users.username NOT ILIKE 'managed-%%' AND users.username NOT ILIKE 'sourcegraph-management-%%' AND users.username != 'sourcegraph-admin'"))
+			conds = append(conds, sqlf.Sprintf("users.username IS NULL OR (users.username NOT ILIKE 'managed-%%' AND users.username NOT ILIKE 'sourcegraph-management-%%' AND users.username != 'sourcegraph-admin')"))
 		}
 	}
 

--- a/internal/database/event_logs_test.go
+++ b/internal/database/event_logs_test.go
@@ -200,26 +200,49 @@ func TestEventLogs_SiteUsageMultiplePeriods(t *testing.T) {
 	db := NewDB(logger, dbtest.NewDB(logger, t))
 	ctx := context.Background()
 
+	// Several of the events will belong to a Sourcegraph employee admin user
+	sgAdmin, err := db.Users().Create(ctx, NewUser{Username: "sourcegraph-admin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	user1, err := db.Users().Create(ctx, NewUser{Username: "a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	user2, err := db.Users().Create(ctx, NewUser{Username: "b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	user3, err := db.Users().Create(ctx, NewUser{Username: "c"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	user4, err := db.Users().Create(ctx, NewUser{Username: "d"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	now := time.Now()
 	startDate, _ := calcStartDate(now, Daily, 3)
 	secondDay := startDate.Add(time.Hour * 24)
 	thirdDay := startDate.Add(time.Hour * 24 * 2)
 
 	events := []*Event{
-		makeTestEvent(&Event{UserID: 1, Timestamp: startDate}),
-		makeTestEvent(&Event{UserID: 1, Timestamp: startDate}),
-		makeTestEvent(&Event{UserID: 2, Timestamp: startDate}),
-		makeTestEvent(&Event{UserID: 2, Timestamp: startDate}),
+		makeTestEvent(&Event{UserID: uint32(sgAdmin.ID), Timestamp: startDate}),
+		makeTestEvent(&Event{UserID: uint32(sgAdmin.ID), Timestamp: startDate}),
+		makeTestEvent(&Event{UserID: uint32(user1.ID), Timestamp: startDate}),
+		makeTestEvent(&Event{UserID: uint32(user1.ID), Timestamp: startDate}),
 
-		makeTestEvent(&Event{UserID: 1, Timestamp: secondDay}),
-		makeTestEvent(&Event{UserID: 2, Timestamp: secondDay}),
-		makeTestEvent(&Event{UserID: 3, Timestamp: secondDay}),
-		makeTestEvent(&Event{UserID: 1, Timestamp: secondDay}),
+		makeTestEvent(&Event{UserID: uint32(sgAdmin.ID), Timestamp: secondDay}),
+		makeTestEvent(&Event{UserID: uint32(user1.ID), Timestamp: secondDay}),
+		makeTestEvent(&Event{UserID: uint32(user2.ID), Timestamp: secondDay}),
+		makeTestEvent(&Event{UserID: uint32(sgAdmin.ID), Timestamp: secondDay}),
 
-		makeTestEvent(&Event{UserID: 5, Timestamp: thirdDay}),
-		makeTestEvent(&Event{UserID: 6, Timestamp: thirdDay}),
-		makeTestEvent(&Event{UserID: 7, Timestamp: thirdDay}),
-		makeTestEvent(&Event{UserID: 8, Timestamp: thirdDay}),
+		makeTestEvent(&Event{UserID: uint32(user1.ID), Timestamp: thirdDay}),
+		makeTestEvent(&Event{UserID: uint32(user2.ID), Timestamp: thirdDay}),
+		makeTestEvent(&Event{UserID: uint32(user3.ID), Timestamp: thirdDay}),
+		makeTestEvent(&Event{UserID: uint32(user4.ID), Timestamp: thirdDay}),
 	}
 
 	for _, e := range events {
@@ -236,6 +259,15 @@ func TestEventLogs_SiteUsageMultiplePeriods(t *testing.T) {
 	assertUsageValue(t, values.DAUs[0], startDate.Add(time.Hour*24*2), 4, 4, 0, 0)
 	assertUsageValue(t, values.DAUs[1], startDate.Add(time.Hour*24), 3, 3, 0, 0)
 	assertUsageValue(t, values.DAUs[2], startDate, 2, 2, 0, 0)
+
+	values, err = db.EventLogs().SiteUsageMultiplePeriods(ctx, now, 3, 0, 0, &CountUniqueUsersOptions{ExcludeSourcegraphAdmins: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertUsageValue(t, values.DAUs[0], startDate.Add(time.Hour*24*2), 4, 4, 0, 0)
+	assertUsageValue(t, values.DAUs[1], startDate.Add(time.Hour*24), 2, 2, 0, 0)
+	assertUsageValue(t, values.DAUs[2], startDate, 1, 1, 0, 0)
 }
 
 func TestEventLogs_UsersUsageCounts(t *testing.T) {
@@ -399,6 +431,131 @@ func TestEventLogs_SiteUsage(t *testing.T) {
 		IntegrationUniquesMonth: 11,
 		IntegrationUniquesWeek:  7,
 		IntegrationUniquesDay:   5,
+	}
+	if diff := cmp.Diff(expectedSummary, summary); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestEventLogs_SiteUsage_ExcludeSourcegraphAdmins(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	logger := logtest.Scoped(t)
+	t.Parallel()
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := context.Background()
+
+	// This unix timestamp is equivalent to `Friday, May 15, 2020 10:30:00 PM GMT` and is set to
+	// be a consistent value so that the tests don't fail when someone runs it at some particular
+	// time that falls too near the edge of a week.
+	now := time.Unix(1589581800, 0).UTC()
+
+	// Several of the events will belong to a Sourcegraph employee admin user
+	sgAdmin, err := db.Users().Create(ctx, NewUser{Username: "sourcegraph-admin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	user1, err := db.Users().Create(ctx, NewUser{Username: "a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	user2, err := db.Users().Create(ctx, NewUser{Username: "b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	days := map[time.Time]struct {
+		users   []uint32
+		names   []string
+		sources []string
+	}{
+		// Today
+		now: {
+			[]uint32{uint32(sgAdmin.ID)},
+			[]string{"ViewSiteAdminX"},
+			[]string{"test", "CODEHOSTINTEGRATION"},
+		},
+		// This week
+		now.Add(-time.Hour * 24 * 3): {
+			[]uint32{uint32(sgAdmin.ID), uint32(user1.ID)},
+			[]string{"ViewRepository", "ViewTree"},
+			[]string{"test", "CODEHOSTINTEGRATION"},
+		},
+		// This month
+		now.Add(-time.Hour * 24 * 6): {
+			[]uint32{uint32(user2.ID)},
+			[]string{"ViewSiteAdminX", "SavedSearchSlackClicked"},
+			[]string{"test", "CODEHOSTINTEGRATION"},
+		},
+	}
+
+	for day, data := range days {
+		for _, user := range data.users {
+			for _, name := range data.names {
+				for _, source := range data.sources {
+					for i := 0; i < 5; i++ {
+						e := &Event{
+							UserID: user,
+							Name:   name,
+							URL:    "http://sourcegraph.com",
+							Source: source,
+							// Jitter current time +/- 30 minutes
+							Timestamp: day.Add(time.Minute * time.Duration(rand.Intn(60)-30)),
+						}
+
+						if err := db.EventLogs().Insert(ctx, e); err != nil {
+							t.Fatal(err)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	el := &eventLogStore{Store: basestore.NewWithHandle(db.Handle())}
+	summary, err := el.siteUsageCurrentPeriods(ctx, now, &SiteUsageOptions{ExcludeSourcegraphAdmins: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedSummary := types.SiteUsageSummary{
+		Month:                   time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC),
+		Week:                    now.Truncate(time.Hour * 24).Add(-time.Hour * 24 * 5), // the previous Sunday
+		Day:                     now.Truncate(time.Hour * 24),
+		UniquesMonth:            3,
+		UniquesWeek:             2,
+		UniquesDay:              1,
+		RegisteredUniquesMonth:  3,
+		RegisteredUniquesWeek:   2,
+		RegisteredUniquesDay:    1,
+		IntegrationUniquesMonth: 3,
+		IntegrationUniquesWeek:  2,
+		IntegrationUniquesDay:   1,
+	}
+	if diff := cmp.Diff(expectedSummary, summary); diff != "" {
+		t.Fatal(diff)
+	}
+
+	summary, err = el.siteUsageCurrentPeriods(ctx, now, &SiteUsageOptions{ExcludeSourcegraphAdmins: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedSummary = types.SiteUsageSummary{
+		Month:                   time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC),
+		Week:                    now.Truncate(time.Hour * 24).Add(-time.Hour * 24 * 5), // the previous Sunday
+		Day:                     now.Truncate(time.Hour * 24),
+		UniquesMonth:            2,
+		UniquesWeek:             1,
+		UniquesDay:              0,
+		RegisteredUniquesMonth:  2,
+		RegisteredUniquesWeek:   1,
+		RegisteredUniquesDay:    0,
+		IntegrationUniquesMonth: 2,
+		IntegrationUniquesWeek:  1,
+		IntegrationUniquesDay:   0,
 	}
 	if diff := cmp.Diff(expectedSummary, summary); diff != "" {
 		t.Fatal(diff)

--- a/internal/database/event_logs_test.go
+++ b/internal/database/event_logs_test.go
@@ -205,6 +205,9 @@ func TestEventLogs_SiteUsageMultiplePeriods(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := db.UserEmails().Add(ctx, sgAdmin.ID, "admin@sourcegraph.com", nil); err != nil {
+		t.Fatal(err)
+	}
 
 	user1, err := db.Users().Create(ctx, NewUser{Username: "a"})
 	if err != nil {
@@ -260,7 +263,7 @@ func TestEventLogs_SiteUsageMultiplePeriods(t *testing.T) {
 	assertUsageValue(t, values.DAUs[1], startDate.Add(time.Hour*24), 3, 3, 0, 0)
 	assertUsageValue(t, values.DAUs[2], startDate, 2, 2, 0, 0)
 
-	values, err = db.EventLogs().SiteUsageMultiplePeriods(ctx, now, 3, 0, 0, &CountUniqueUsersOptions{ExcludeSourcegraphAdmins: true})
+	values, err = db.EventLogs().SiteUsageMultiplePeriods(ctx, now, 3, 0, 0, &CountUniqueUsersOptions{CommonUsageOptions{ExcludeSourcegraphAdmins: true}, nil})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -456,6 +459,9 @@ func TestEventLogs_SiteUsage_ExcludeSourcegraphAdmins(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := db.UserEmails().Add(ctx, sgAdmin.ID, "admin@sourcegraph.com", nil); err != nil {
+		t.Fatal(err)
+	}
 
 	user1, err := db.Users().Create(ctx, NewUser{Username: "a"})
 	if err != nil {
@@ -515,7 +521,7 @@ func TestEventLogs_SiteUsage_ExcludeSourcegraphAdmins(t *testing.T) {
 	}
 
 	el := &eventLogStore{Store: basestore.NewWithHandle(db.Handle())}
-	summary, err := el.siteUsageCurrentPeriods(ctx, now, &SiteUsageOptions{ExcludeSourcegraphAdmins: false})
+	summary, err := el.siteUsageCurrentPeriods(ctx, now, &SiteUsageOptions{CommonUsageOptions{ExcludeSourcegraphAdmins: false}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -538,7 +544,7 @@ func TestEventLogs_SiteUsage_ExcludeSourcegraphAdmins(t *testing.T) {
 		t.Fatal(diff)
 	}
 
-	summary, err = el.siteUsageCurrentPeriods(ctx, now, &SiteUsageOptions{ExcludeSourcegraphAdmins: true})
+	summary, err = el.siteUsageCurrentPeriods(ctx, now, &SiteUsageOptions{CommonUsageOptions{ExcludeSourcegraphAdmins: true}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -898,20 +898,37 @@ func (*userStore) listSQL(opt UsersListOptions) (conds []*sqlf.Query) {
 	}
 
 	// NOTE: This is a hack which should be replaced when we have proper user types.
-	// However, for billing purposes and more accurate ping data, we need a way to exclude
-	// Sourcegraph (employee) admins when counting users. The following username patterns
-	// are used to filter out Sourcegraph admins:
+	// However, for billing purposes and more accurate ping data, we need a way to
+	// exclude Sourcegraph (employee) admins when counting users. The following
+	// username patterns, in conjunction with the presence of a corresponding
+	// "@sourcegraph.com" email address, are used to filter out Sourcegraph admins:
 	//
 	// - managed-*
 	// - sourcegraph-management-*
 	// - sourcegraph-admin
 	//
-	// This may incur false positives, but we acknowledge this risk as we would prefer to
-	// undercount rather than overcount.
+	// This method of filtering is imperfect and may still incur false positives, but
+	// the two together should help prevent that in the majority of cases, and we
+	// acknowledge this risk as we would prefer to undercount rather than overcount.
 	if opt.ExcludeSourcegraphAdmins {
-		conds = append(conds, sqlf.Sprintf("u.username NOT ILIKE 'managed-%%' AND u.username NOT ILIKE 'sourcegraph-management-%%' AND u.username != 'sourcegraph-admin'"))
-	}
+		conds = append(conds, sqlf.Sprintf(`
+-- The user does not...
+NOT(
+	-- ...have a known Sourcegraph admin username pattern
+	(u.username ILIKE 'managed-%%'
+		OR u.username ILIKE 'sourcegraph-management-%%'
+		OR u.username = 'sourcegraph-admin')
+	-- ...and have a matching sourcegraph email address
+	AND EXISTS (
+		SELECT
+			1 FROM user_emails
+		WHERE
+			user_emails.user_id = u.id
+			AND user_emails.email ILIKE '%%@sourcegraph.com')
+)
+`))
 
+	}
 	return conds
 }
 

--- a/internal/database/users_test.go
+++ b/internal/database/users_test.go
@@ -294,32 +294,21 @@ func TestUsers_ListCount(t *testing.T) {
 	}
 
 	// Create three users with common Sourcegraph admin username patterns.
-	_, err = db.Users().Create(ctx, NewUser{
-		Email:                 "b@b.com",
-		Username:              "sourcegraph-admin",
-		Password:              "p",
-		EmailVerificationCode: "c",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = db.Users().Create(ctx, NewUser{
-		Email:                 "c@c.com",
-		Username:              "sourcegraph-management-abc",
-		Password:              "p",
-		EmailVerificationCode: "c",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = db.Users().Create(ctx, NewUser{
-		Email:                 "c@c.com",
-		Username:              "managed-abc",
-		Password:              "p",
-		EmailVerificationCode: "c",
-	})
-	if err != nil {
-		t.Fatal(err)
+	for _, admin := range []struct {
+		username string
+		email    string
+	}{
+		{"sourcegraph-admin", "admin@sourcegraph.com"},
+		{"sourcegraph-management-abc", "support@sourcegraph.com"},
+		{"managed-abc", "abc-support@sourcegraph.com"},
+	} {
+		user, err := db.Users().Create(ctx, NewUser{Username: admin.username})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := db.UserEmails().Add(ctx, user.ID, admin.email, nil); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	if count, err := db.Users().Count(ctx, &UsersListOptions{ExcludeSourcegraphAdmins: false}); err != nil {

--- a/internal/database/users_test.go
+++ b/internal/database/users_test.go
@@ -292,6 +292,52 @@ func TestUsers_ListCount(t *testing.T) {
 	} else if want := 0; count != want {
 		t.Errorf("got %d, want %d", count, want)
 	}
+
+	// Create three users with common Sourcegraph admin username patterns.
+	_, err = db.Users().Create(ctx, NewUser{
+		Email:                 "b@b.com",
+		Username:              "sourcegraph-admin",
+		Password:              "p",
+		EmailVerificationCode: "c",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Users().Create(ctx, NewUser{
+		Email:                 "c@c.com",
+		Username:              "sourcegraph-management-abc",
+		Password:              "p",
+		EmailVerificationCode: "c",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Users().Create(ctx, NewUser{
+		Email:                 "c@c.com",
+		Username:              "managed-abc",
+		Password:              "p",
+		EmailVerificationCode: "c",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if count, err := db.Users().Count(ctx, &UsersListOptions{ExcludeSourcegraphAdmins: false}); err != nil {
+		t.Fatal(err)
+	} else if want := 3; count != want {
+		t.Errorf("got %d, want %d", count, want)
+	}
+
+	if count, err := db.Users().Count(ctx, &UsersListOptions{ExcludeSourcegraphAdmins: true}); err != nil {
+		t.Fatal(err)
+	} else if want := 0; count != want {
+		t.Errorf("got %d, want %d", count, want)
+	}
+	if users, err := db.Users().List(ctx, &UsersListOptions{ExcludeSourcegraphAdmins: true}); err != nil {
+		t.Fatal(err)
+	} else if len(users) > 0 {
+		t.Errorf("got %d, want empty", len(users))
+	}
 }
 
 func TestUsers_Update(t *testing.T) {

--- a/internal/usagestats/usage_stats.go
+++ b/internal/usagestats/usage_stats.go
@@ -152,7 +152,7 @@ func GetByUserID(ctx context.Context, db database.DB, userID int32) (*types.User
 func GetUsersActiveTodayCount(ctx context.Context, db database.DB) (int, error) {
 	now := timeNow().UTC()
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
-	return db.EventLogs().CountUniqueUsersAll(ctx, today, today.AddDate(0, 0, 1), &database.CountUniqueUsersOptions{ExcludeSystemUsers: true, ExcludeSourcegraphAdmins: true})
+	return db.EventLogs().CountUniqueUsersAll(ctx, today, today.AddDate(0, 0, 1), &database.CountUniqueUsersOptions{CommonUsageOptions: database.CommonUsageOptions{ExcludeSystemUsers: true, ExcludeSourcegraphAdmins: true}})
 }
 
 // ListRegisteredUsersToday returns a list of the registered users that were active today.
@@ -223,9 +223,11 @@ func activeUsers(ctx context.Context, db database.DB, dayPeriods, weekPeriods, m
 	}
 
 	return db.EventLogs().SiteUsageMultiplePeriods(ctx, timeNow().UTC(), dayPeriods, weekPeriods, monthPeriods, &database.CountUniqueUsersOptions{
-		ExcludeSystemUsers:       true,
-		ExcludeNonActiveUsers:    true,
-		ExcludeSourcegraphAdmins: true,
+		CommonUsageOptions: database.CommonUsageOptions{
+			ExcludeSystemUsers:       true,
+			ExcludeNonActiveUsers:    true,
+			ExcludeSourcegraphAdmins: true,
+		},
 	})
 }
 

--- a/internal/usagestats/usage_stats.go
+++ b/internal/usagestats/usage_stats.go
@@ -152,7 +152,7 @@ func GetByUserID(ctx context.Context, db database.DB, userID int32) (*types.User
 func GetUsersActiveTodayCount(ctx context.Context, db database.DB) (int, error) {
 	now := timeNow().UTC()
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
-	return db.EventLogs().CountUniqueUsersAll(ctx, today, today.AddDate(0, 0, 1), &database.CountUniqueUsersOptions{ExcludeSystemUsers: true})
+	return db.EventLogs().CountUniqueUsersAll(ctx, today, today.AddDate(0, 0, 1), &database.CountUniqueUsersOptions{ExcludeSystemUsers: true, ExcludeSourcegraphAdmins: true})
 }
 
 // ListRegisteredUsersToday returns a list of the registered users that were active today.
@@ -212,7 +212,7 @@ func GetSiteUsageStatistics(ctx context.Context, db database.DB, opt *SiteUsageS
 	return usage, nil
 }
 
-// activeUsers returns counts of active users in the given number of days, weeks, or months, as selected (including the current, partially completed period).
+// activeUsers returns counts of active (non-SG) users in the given number of days, weeks, or months, as selected (including the current, partially completed period).
 func activeUsers(ctx context.Context, db database.DB, dayPeriods, weekPeriods, monthPeriods int) (*types.SiteUsageStatistics, error) {
 	if dayPeriods == 0 && weekPeriods == 0 && monthPeriods == 0 {
 		return &types.SiteUsageStatistics{
@@ -223,8 +223,9 @@ func activeUsers(ctx context.Context, db database.DB, dayPeriods, weekPeriods, m
 	}
 
 	return db.EventLogs().SiteUsageMultiplePeriods(ctx, timeNow().UTC(), dayPeriods, weekPeriods, monthPeriods, &database.CountUniqueUsersOptions{
-		ExcludeSystemUsers:    true,
-		ExcludeNonActiveUsers: true,
+		ExcludeSystemUsers:       true,
+		ExcludeNonActiveUsers:    true,
+		ExcludeSourcegraphAdmins: true,
 	})
 }
 

--- a/internal/usagestats/usage_stats_test.go
+++ b/internal/usagestats/usage_stats_test.go
@@ -255,15 +255,17 @@ func TestUserUsageStatistics_getUsersActiveToday(t *testing.T) {
 
 	ctx := context.Background()
 
-	user1 := types.User{
-		ID: 1,
+	user1, err := db.Users().Create(ctx, database.NewUser{Username: "user1"})
+	if err != nil {
+		t.Fatal(err)
 	}
-	user2 := types.User{
-		ID: 2,
+	user2, err := db.Users().Create(ctx, database.NewUser{Username: "user2"})
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// Test single user
-	err := logLocalEvents(ctx, db, []Event{{
+	err = logLocalEvents(ctx, db, []Event{{
 		EventName:        "ViewBlob",
 		URL:              "https://sourcegraph.example.com/",
 		UserID:           user1.ID,
@@ -362,11 +364,13 @@ func TestUserUsageStatistics_DAUs_WAUs_MAUs(t *testing.T) {
 
 	db := setupForTest(t)
 
-	user1 := types.User{
-		ID: 1,
+	user1, err := db.Users().Create(ctx, database.NewUser{Username: "user1"})
+	if err != nil {
+		t.Fatal(err)
 	}
-	user2 := types.User{
-		ID: 2,
+	user2, err := db.Users().Create(ctx, database.NewUser{Username: "user2"})
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// hardcode "now" as 2018/03/31
@@ -380,7 +384,7 @@ func TestUserUsageStatistics_DAUs_WAUs_MAUs(t *testing.T) {
 
 	// 2018/02/27 (2 users, 1 registered)
 	mockTimeNow(oneMonthFourDaysAgo)
-	err := logLocalEvents(ctx, db, []Event{{
+	err = logLocalEvents(ctx, db, []Event{{
 		EventName:        "ViewBlob",
 		URL:              "https://sourcegraph.example.com/",
 		UserID:           user1.ID,


### PR DESCRIPTION
Closes https://github.com/sourcegraph/analytics/issues/557.

This is based on the resolution from [this slack thread](https://sourcegraph.slack.com/archives/C03JR7S7KRP/p1661358698098739), in which it was determined that Sourcegraph employee admin accounts are distinguishable by usernames that follow one of the following patterns:
- `managed-*`
- `sourcegraph-management-*`
- `sourcegraph-admin`

Filtering out users based on these username patterns is a hack that may hit false positives, and the longterm solution is having proper user types to filter on instead. That being said, overcounting from ping data is a massive pain felt today which warrants this as a stopgap. As Dan acknowledges in the thread:

> We'd rather undercount than overcount here, so I'm willing to accept the risk that a customer creates their own user with a name that has `managed-` as a prefix or whatever.

Nonetheless, I've added comments inline with the code to remind us of the longterm goal and discourage any further reliance on this pattern.

## Test plan

Added additional unit tests for the new filter and verified existing usage stats tests are still passing.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
