### PR TITLE
ghe-feeder: allow to force org-name

### DIFF
--- a/internal/cmd/ghe-feeder/main.go
+++ b/internal/cmd/ghe-feeder/main.go
@@ -64,6 +64,7 @@ func main() {
 	cloneRepoTimeout := flag.Duration("cloneRepoTimeout", time.Minute*3, "how long to wait for a repo to clone")
 	numCloningAttempts := flag.Int("numCloningAttempts", 5, "number of cloning attempts before giving up")
 	numSimultaneousClones := flag.Int("numSimultaneousClones", 10, "number of simultaneous github.com clones")
+	forceOrg := flag.String("force-org", "", "always use this org when adding repositories")
 
 	help := flag.Bool("help", false, "Show help")
 
@@ -184,6 +185,7 @@ func main() {
 			log15.Error("failed to create worker scratch dir", "scratchDir", *scratchDir, "error", err)
 			os.Exit(1)
 		}
+
 		wkr := &worker{
 			name:               name,
 			client:             gheClient,
@@ -203,6 +205,11 @@ func main() {
 			cloneRepoTimeout:   *cloneRepoTimeout,
 			numCloningAttempts: *numCloningAttempts,
 		}
+		if *forceOrg != "" {
+			wkr.currentOrg = *forceOrg
+			wkr.currentMaxRepos = math.MaxInt
+		}
+
 		wkrs = append(wkrs, wkr)
 		go wkr.run(ctx)
 	}

--- a/internal/cmd/ghe-feeder/worker.go
+++ b/internal/cmd/ghe-feeder/worker.go
@@ -119,7 +119,9 @@ type worker struct {
 func (wkr *worker) run(ctx context.Context) {
 	defer wkr.wg.Done()
 
-	wkr.currentOrg, wkr.currentMaxRepos = randomOrgNameAndSize()
+	if wkr.currentOrg == "" {
+		wkr.currentOrg, wkr.currentMaxRepos = randomOrgNameAndSize()
+	}
 
 	wkr.logger.Debug("switching to org", "org", wkr.currentOrg)
 


### PR DESCRIPTION
This adds a flag to manually specify the organization you want to import the repositories in. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Manually testd. See https://ghe.sgdev.org/scaletesting-10k-repos