### PR TITLE
sg: check dev-private rather than forced update

### DIFF
--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -239,7 +239,7 @@ func shouldUpdateDevPrivate(ctx context.Context, path string) (bool, error) {
 	if err := sgrun.Bash(ctx, "git fetch origin master").Dir(path).Run().Wait(); err != nil {
 		return false, err
 	}
-	// now we check if there are any changes ie. if the output is empty, we're not missing out on anything
+	// Now we check if there are any changes. If the output is empty, we're not missing out on anything.
 	output, err := sgrun.Bash(ctx, "git diff --shortstat origin/HEAD").Dir(path).Run().String()
 	if err != nil {
 		return false, err

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -218,7 +218,7 @@ func startExec(ctx *cli.Context) error {
 		update := std.Out.Pending(output.Styled(output.StylePending, "Checking for dev-private changes..."))
 		shouldUpdate, err := shouldUpdateDevPrivate(ctx.Context, devPrivatePath)
 		if shouldUpdate {
-			update.WriteLine(output.Line(output.EmojiInfo, output.StyleSuggestion, "We found some changes in dev-private that you're missing out on! If you want the new changes, do a git stash and then a git pull!"))
+			update.WriteLine(output.Line(output.EmojiInfo, output.StyleSuggestion, "We found some changes in dev-private that you're missing out on! If you want the new changes, 'cd ../dev-private' and then do a 'git stash' and a 'git pull'!"))
 		}
 		if err != nil {
 			update.Close()


### PR DESCRIPTION
Based on the discussion [here](https://github.com/sourcegraph/sourcegraph/pull/42531#issuecomment-1268447884) I thought I take @mrnugget suggestion for a ride and it seems nice 👌🏼 

## Examples:
### An error occured
![Screenshot 2022-10-06 at 11 15 59](https://user-images.githubusercontent.com/1001709/194275042-f8eb51b7-fe72-4905-af65-418c802c2215.png)

### You're missing out on changes
![Screenshot 2022-10-06 at 11 16 41](https://user-images.githubusercontent.com/1001709/194275204-9e702a75-d6c9-4de3-8264-bfd3003221e3.png)

### No changes
![Screenshot 2022-10-06 at 11 17 57](https://user-images.githubusercontent.com/1001709/194275643-9a6e8003-56f0-43f2-8a7d-6efe0b41ab57.png)

## Test plan
Tested locally
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
