### PR TITLE
Add AuthenticatorWithRefresh interface for refreshable tokens

### DIFF
--- a/cmd/frontend/webhooks/github_webhooks_test.go
+++ b/cmd/frontend/webhooks/github_webhooks_test.go
@@ -116,6 +116,11 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 
 	ctx := context.Background()
 
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		token = "test-token"
+	}
+
 	secret := "secret"
 	esStore := db.ExternalServices()
 	extSvc := &types.ExternalService{
@@ -123,7 +128,7 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 		DisplayName: "GitHub",
 		Config: extsvc.NewUnencryptedConfig(marshalJSON(t, &schema.GitHubConnection{
 			Url:      "https://github.com",
-			Token:    os.Getenv("GITHUB_TOKEN"),
+			Token:    token,
 			Repos:    []string{"sourcegraph/sourcegraph"},
 			Webhooks: []*schema.GitHubWebhook{{Org: "sourcegraph", Secret: secret}},
 		})),
@@ -131,7 +136,7 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 
 	err := esStore.Upsert(ctx, extSvc)
 	if err != nil {
-		t.Fatal(t)
+		t.Fatal(err)
 	}
 
 	hook := GitHubWebhook{

--- a/internal/extsvc/auth/auth.go
+++ b/internal/extsvc/auth/auth.go
@@ -27,6 +27,21 @@ type Authenticator interface {
 	Hash() string
 }
 
+type AuthenticatorWithRefresh interface {
+	// Must implement the base Authenticator interface
+	Authenticator
+
+	// ShouldRefresh returns true if the Authenticator is no longer valid and
+	// needs to be refreshed, such as checking if an OAuth token is close to
+	// expiry or already expired.
+	ShouldRefresh() bool
+
+	// Refresh refreshes the Authenticator. This should be an in-place mutation,
+	// and if any storage updates should happen after refreshing, that is done
+	// here as well.
+	Refresh() error
+}
+
 // AuthenticatorWithSSH wraps the Authenticator interface and augments it by
 // additional methods to authenticate over SSH with this credential, in addition
 // to the enclosed Authenticator. This can be used for a credential that needs

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -1227,7 +1227,7 @@ func TestClient_WithAuthenticator(t *testing.T) {
 	}
 
 	if newClient.Auth != newToken {
-		t.Fatalf("auth: want %q but got %q", newToken, newClient.Auth)
+		t.Fatalf("auth: want %p but got %p", newToken, newClient.Auth)
 	}
 
 	if newClient.URL != old.URL {

--- a/internal/extsvc/github/v3_test.go
+++ b/internal/extsvc/github/v3_test.go
@@ -697,7 +697,7 @@ func TestV3Client_WithAuthenticator(t *testing.T) {
 	}
 
 	if new.auth != newToken {
-		t.Fatalf("token: want %q but got %q", newToken, new.auth)
+		t.Fatalf("token: want %p but got %p", newToken, new.auth)
 	}
 }
 

--- a/internal/extsvc/github/v4_test.go
+++ b/internal/extsvc/github/v4_test.go
@@ -802,7 +802,7 @@ func TestV4Client_WithAuthenticator(t *testing.T) {
 	}
 
 	if new.auth != newToken {
-		t.Fatalf("token: want %q but got %q", newToken, new.auth)
+		t.Fatalf("token: want %p but got %p", newToken, new.auth)
 	}
 }
 

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -2494,6 +2494,9 @@ func testEnqueueWebhookBuildJob(s repos.Store) func(*testing.T) {
 		}})
 
 		token := os.Getenv("GITHUB_TOKEN")
+		if token == "" {
+			token = "test-token"
+		}
 
 		esStore := s.ExternalServiceStore()
 		repoStore := s.RepoStore()


### PR DESCRIPTION
This PR implements a new interface that Auth tokens can implement if their able to be refreshed.

It allows us to be flexible in token implementations while keeping a uniform interface for those tokens to be used.

By having the `RefreshFunc` for `OAuthBearerToken` be flexible, we can have custom token storage happen (write to DB) after a Refresh occurs). This will be implemented in a separate PR

## Test plan

Tests adjusted and still pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
