### PR TITLE
insights: chore: remove recording preemptive points logic

### DIFF
--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -189,16 +189,14 @@ func (s *ScopedBackfiller) ScopedBackfill(ctx context.Context, definitions []ity
 
 	analyzer := baseAnalyzer(frontend, stats)
 	var totalJobs []*queryrunner.Job
-	var totalPreempted []store.RecordSeriesPointArgs
 	err = iterator.ForEach(ctx, func(repoName string, id api.RepoID) error {
-		jobs, preempted, err, multi := analyzer.buildForRepo(ctx, index[repoName], repoName, id)
+		jobs, err, multi := analyzer.buildForRepo(ctx, index[repoName], repoName, id)
 		if err != nil {
 			return err
 		} else if multi != nil {
 			return multi
 		}
 		totalJobs = append(totalJobs, jobs...)
-		totalPreempted = append(totalPreempted, preempted...)
 
 		return nil
 	})
@@ -213,10 +211,6 @@ func (s *ScopedBackfiller) ScopedBackfill(ctx context.Context, definitions []ity
 		if err != nil {
 			return err
 		}
-	}
-	err = s.insightsStore.RecordSeriesPoints(ctx, totalPreempted)
-	if err != nil {
-		return err
 	}
 	return nil
 }
@@ -478,15 +472,12 @@ func (h *historicalEnqueuer) buildFrames(ctx context.Context, definitions []ityp
 	var multi error
 
 	hardErr := h.repoIterator(ctx, func(repoName string, id api.RepoID) error {
-		jobs, preempted, err, softErr := h.analyzer.buildForRepo(ctx, definitions, repoName, id)
+		jobs, err, softErr := h.analyzer.buildForRepo(ctx, definitions, repoName, id)
 		if err != nil {
 			return err
 		}
 		if softErr != nil {
 			multi = errors.Append(multi, softErr)
-		}
-		if err := h.insightsStore.RecordSeriesPoints(ctx, preempted); err != nil {
-			return errors.Wrap(err, "RecordSeriesPoints Zero Value")
 		}
 		for _, job := range jobs {
 			err := h.enqueueQueryRunnerJob(ctx, job)
@@ -502,7 +493,7 @@ func (h *historicalEnqueuer) buildFrames(ctx context.Context, definitions []ityp
 	return hardErr
 }
 
-func (a *backfillAnalyzer) buildForRepo(ctx context.Context, definitions []itypes.InsightSeries, repoName string, id api.RepoID) (jobs []*queryrunner.Job, preempted []store.RecordSeriesPointArgs, err error, softErr error) {
+func (a *backfillAnalyzer) buildForRepo(ctx context.Context, definitions []itypes.InsightSeries, repoName string, id api.RepoID) (jobs []*queryrunner.Job, err error, softErr error) {
 	span, ctx := ot.StartSpanFromContext(policy.WithShouldTrace(ctx, true), "historical_enqueuer.buildForRepo")
 	span.SetTag("repo_id", id)
 	defer func() {
@@ -527,16 +518,16 @@ func (a *backfillAnalyzer) buildForRepo(ctx context.Context, definitions []itype
 
 		if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) || gitdomain.IsRepoNotExist(err) {
 			log15.Warn("insights backfill repository skipped - missing rev/repo", "repo_id", id, "repo_name", repoName)
-			return nil, nil, nil, softErr // no error - repo may not be cloned yet (or not even pushed to code host yet)
+			return nil, nil, softErr // no error - repo may not be cloned yet (or not even pushed to code host yet)
 		}
 		if errors.Is(err, discovery.EmptyRepoErr) {
 			log15.Warn("insights backfill repository skipped - empty repo", "repo_id", id, "repo_name", repoName)
-			return nil, nil, nil, softErr // repository is empty
+			return nil, nil, softErr // repository is empty
 		}
 		// soft error, repo may be in a bad state but others might be OK.
 		softErr = errors.Append(softErr, errors.Wrap(err, "FirstEverCommit "+repoName))
 		log15.Error("insights backfill repository skipped", "repo_id", id, "repo_name", repoName, "error", err)
-		return nil, nil, nil, softErr
+		return nil, nil, softErr
 	}
 
 	// For every series that we want to potentially gather historical data for, try.
@@ -559,11 +550,11 @@ func (a *backfillAnalyzer) buildForRepo(ctx context.Context, definitions []itype
 
 			err := a.limiter.Wait(ctx)
 			if err != nil {
-				return nil, nil, errors.Wrap(err, "limiter.Wait"), nil
+				return nil, errors.Wrap(err, "limiter.Wait"), nil
 			}
 
 			// Build historical data for this unique timeframe+repo+series.
-			err, job, pre := a.analyzeSeries(ctx, &buildSeriesContext{
+			err, job := a.analyzeSeries(ctx, &buildSeriesContext{
 				execution:       queryExecution,
 				repoName:        api.RepoName(repoName),
 				id:              id,
@@ -576,14 +567,13 @@ func (a *backfillAnalyzer) buildForRepo(ctx context.Context, definitions []itype
 				a.statistics[series.SeriesID].Errored += 1
 				continue
 			}
-			preempted = append(preempted, pre...)
 			if job != nil {
 				jobs = append(jobs, job)
 			}
 		}
 	}
 	log15.Info("[historical_enqueuer_backfill] buildForRepo end", "repo_id", id, "repo_name", repoName)
-	return jobs, preempted, nil, softErr
+	return jobs, nil, softErr
 }
 
 // buildSeriesContext describes context/parameters for a call to analyzeSeries()
@@ -610,7 +600,7 @@ type buildSeriesContext struct {
 //
 // It may return both hard errors (e.g. DB connection failure, future series are unlikely to build)
 // and soft errors (e.g. user's search query is invalid, future series are likely to build.)
-func (a *backfillAnalyzer) analyzeSeries(ctx context.Context, bctx *buildSeriesContext) (err error, job *queryrunner.Job, preempted []store.RecordSeriesPointArgs) {
+func (a *backfillAnalyzer) analyzeSeries(ctx context.Context, bctx *buildSeriesContext) (err error, job *queryrunner.Job) {
 	query := bctx.series.Query
 	// TODO(slimsag): future: use the search query parser here to avoid any false-positives like a
 	// search query with `content:"repo:"`.
@@ -621,7 +611,7 @@ func (a *backfillAnalyzer) analyzeSeries(ctx context.Context, bctx *buildSeriesC
 		//
 		// Another possibility is that they are specifying a non-default branch with the `repo:`
 		// filter. We would need to handle this below if so - we don't today.
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	// Optimization: If the timeframe we're building data for starts (or ends) before the first commit in the
@@ -631,7 +621,7 @@ func (a *backfillAnalyzer) analyzeSeries(ctx context.Context, bctx *buildSeriesC
 	if bctx.execution.RecordingTime.Before(bctx.firstHEADCommit.Author.Date) {
 		a.statistics[bctx.seriesID].Preempted += 1
 		// We don't save empty series points in this case.
-		return err, nil, []store.RecordSeriesPointArgs{}
+		return err, nil
 		// return // success - nothing else to do
 	}
 
@@ -703,7 +693,7 @@ func (a *backfillAnalyzer) analyzeSeries(ctx context.Context, bctx *buildSeriesC
 	}
 
 	job = queryrunner.ToQueueJob(bctx.execution, bctx.seriesID, newQueryStr, priority.Unindexed, priority.FromTimeInterval(bctx.execution.RecordingTime, bctx.series.CreatedAt))
-	return err, job, preempted
+	return err, job
 }
 
 // cachedGitFirstEverCommit is a simple in-memory cache for gitFirstEverCommit calls. It does so


### PR DESCRIPTION
we don't preempt points anymore (we record them in stats, but we don't record them as 0). so some code can be removed

## Test plan

Created a global insight with/without the changes and observed the data was the same in the db anyway