### PR TITLE
insights: add util to check for a field in a query

### DIFF
--- a/enterprise/internal/insights/query/querybuilder/parser.go
+++ b/enterprise/internal/insights/query/querybuilder/parser.go
@@ -59,7 +59,6 @@ func ParametersFromQueryPlan(plan query.Plan) []query.Parameter {
 }
 
 func ContainsField(rawQuery, field string) (bool, error) {
-
 	plan, err := ParseQuery(rawQuery, "literal")
 	if err != nil {
 		return false, errors.Wrap(err, "ParseQuery")
@@ -71,6 +70,5 @@ func ContainsField(rawQuery, field string) (bool, error) {
 			}
 		}
 	}
-
 	return false, nil
 }

--- a/enterprise/internal/insights/query/querybuilder/parser.go
+++ b/enterprise/internal/insights/query/querybuilder/parser.go
@@ -1,6 +1,8 @@
 package querybuilder
 
 import (
+	"strings"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
 	"github.com/sourcegraph/sourcegraph/internal/search/client"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
@@ -54,4 +56,21 @@ func ParametersFromQueryPlan(plan query.Plan) []query.Parameter {
 		parameters = append(parameters, basic.Parameters...)
 	}
 	return parameters
+}
+
+func ContainsField(rawQuery, field string) (bool, error) {
+
+	plan, err := ParseQuery(rawQuery, "literal")
+	if err != nil {
+		return false, errors.Wrap(err, "ParseQuery")
+	}
+	for _, basic := range plan {
+		for _, param := range basic.Parameters {
+			if strings.EqualFold(field, param.Field) && param.Value != "" {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
 }

--- a/enterprise/internal/insights/query/querybuilder/parser_test.go
+++ b/enterprise/internal/insights/query/querybuilder/parser_test.go
@@ -184,6 +184,12 @@ func TestContainsField(t *testing.T) {
 			query.FieldRepo,
 			true,
 		},
+		{
+			"doesn't count empty field",
+			"mysearch repo:",
+			query.FieldRepo,
+			false,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/enterprise/internal/insights/query/querybuilder/parser_test.go
+++ b/enterprise/internal/insights/query/querybuilder/parser_test.go
@@ -172,6 +172,18 @@ func TestContainsField(t *testing.T) {
 			query.FieldRepo,
 			true,
 		},
+		{
+			"field in first plan of query",
+			"(file:test repo:test) OR (some other search)",
+			query.FieldRepo,
+			true,
+		},
+		{
+			"field in 2nd plan of query",
+			"(some other search) OR (file:test repo:test) ",
+			query.FieldRepo,
+			true,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/enterprise/internal/insights/query/querybuilder/parser_test.go
+++ b/enterprise/internal/insights/query/querybuilder/parser_test.go
@@ -128,3 +128,60 @@ func TestDetectSearchType(t *testing.T) {
 		})
 	}
 }
+
+func TestContainsField(t *testing.T) {
+	testCases := []struct {
+		name  string
+		query string
+		field string
+		found bool
+	}{
+		{
+			"field not present",
+			"select:repo",
+			query.FieldRepo,
+			false,
+		},
+		{
+			"field present",
+			"select:file repo:test",
+			query.FieldRepo,
+			true,
+		},
+		{
+			"field multiple times",
+			"(file:test repo:test) OR (file:nottest repo:nottest)",
+			query.FieldRepo,
+			true,
+		},
+		{
+			"finds alias",
+			"r:test thing",
+			query.FieldRepo,
+			true,
+		},
+		{
+			"does not false positive",
+			`file:test content:"repo:"`,
+			query.FieldRepo,
+			false,
+		},
+		{
+			"is not case sensitive",
+			`rEpO:test my search`,
+			query.FieldRepo,
+			true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			found, err := ContainsField(tc.query, tc.field)
+			if err != nil {
+				t.Errorf("expected valid query, got error: %v", err)
+			}
+			if diff := cmp.Diff(found, tc.found); diff != "" {
+				t.Errorf("expected %v, got %v", tc.found, found)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Checks if a field is specified in the search query and accounts for aliases.  

For example the following will return true because the `r:` is an alias for `repo:`
`ContainsField("r:myrepo mysearch", query.FieldRepo)` 

Currently when backfilling an insight there is a check to ensure there isn't a `repo` filter present in the search query.  This function can be a replacement for checking for the substring `repo:`.  

## Test plan
Unit tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
