### PR TITLE
all: update log to use non-error version of Sync

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -198,7 +198,7 @@ var sg = &cli.App{
 			os.Setenv(log.EnvLogFormat, "console")
 		}
 		liblog := log.Init(log.Resource{Name: "sg", Version: BuildCommit})
-		interrupt.Register(func() { _ = liblog.Sync() })
+		interrupt.Register(liblog.Sync)
 
 		// Add autosuggestion hooks to commands with subcommands but no action
 		addSuggestionHooks(cmd.App.Commands)

--- a/enterprise/internal/authz/perforce/cmd/scanprotects/main.go
+++ b/enterprise/internal/authz/perforce/cmd/scanprotects/main.go
@@ -34,11 +34,7 @@ func main() {
 		Version:    version.Version(),
 		InstanceID: hostname.Get(),
 	})
-	defer func() {
-		if err := liblog.Sync(); err != nil {
-			fmt.Println("Error syncing logger", err)
-		}
-	}()
+	defer liblog.Sync()
 
 	logger := log.Scoped("scanprotects", "")
 	run(logger, *depot, os.Stdin)

--- a/go.mod
+++ b/go.mod
@@ -140,7 +140,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
 	github.com/sourcegraph/go-rendezvous v0.0.0-20210910070954-ef39ade5591d
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
-	github.com/sourcegraph/log v0.0.0-20220901143117-fc0516a694c9
+	github.com/sourcegraph/log v0.0.0-20221006140640-7c567caa79cb
 	github.com/sourcegraph/run v0.9.0
 	github.com/sourcegraph/scip v0.1.0
 	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220203145655-4d2a39d3038a

--- a/go.sum
+++ b/go.sum
@@ -2086,8 +2086,8 @@ github.com/sourcegraph/httpgzip v0.0.0-20211015085752-0bad89b3b4df h1:VaS8k40GiN
 github.com/sourcegraph/httpgzip v0.0.0-20211015085752-0bad89b3b4df/go.mod h1:RqWagzxNGCvucQQC9vX6aps474LCCOgshDpUTTyb+O8=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf h1:oAdWFqhStsWiiMP/vkkHiMXqFXzl1XfUNOdxKJbd6bI=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf/go.mod h1:ppFaPm6kpcHnZGqQTFhUIAQRIEhdQDWP1PCv4/ON354=
-github.com/sourcegraph/log v0.0.0-20220901143117-fc0516a694c9 h1:JjFyvx9hCD5+JpuRV6t+gTQgGFvwkxXMZzOc4sLiPqc=
-github.com/sourcegraph/log v0.0.0-20220901143117-fc0516a694c9/go.mod h1:UxiwB6C3xk3xOySJpW1R0MDUyfGuJRFS5Z8C+SA5p2I=
+github.com/sourcegraph/log v0.0.0-20221006140640-7c567caa79cb h1:cgfkhaHK7OMlkwROcC4oSFRPZT/KRGFwx7M2i8T0A1c=
+github.com/sourcegraph/log v0.0.0-20221006140640-7c567caa79cb/go.mod h1:UxiwB6C3xk3xOySJpW1R0MDUyfGuJRFS5Z8C+SA5p2I=
 github.com/sourcegraph/oauth2 v0.0.0-20210825125341-77c1d99ece3c h1:HGa4iJr6MGKnB5qbU7tI511NdGuHUHnNCqP67G6KmfE=
 github.com/sourcegraph/oauth2 v0.0.0-20210825125341-77c1d99ece3c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 github.com/sourcegraph/otelsql v0.0.0-20220905085252-74375c884fff h1:u/Lf5xLBDYfRjyeGk8+zUqXrWwRzMIwFbhqKPIWo79Q=

--- a/internal/audit/integration/cmd/main.go
+++ b/internal/audit/integration/cmd/main.go
@@ -27,12 +27,7 @@ func main() {
 		InstanceID: "",
 	})
 
-	defer func() {
-		err := callbacks.Sync()
-		if err != nil {
-			os.Exit(-1)
-		}
-	}()
+	defer callbacks.Sync()
 
 	logger := log.Scoped("test", "logger with sampling config")
 


### PR DESCRIPTION
Most call sites did not check the error of Sync, so the API was updated to not return an error.

Test Plan: go test