### PR TITLE
chore: Move type into consumer package

### DIFF
--- a/internal/codeintel/autoindexing/dependency_indexing_scheduler.go
+++ b/internal/codeintel/autoindexing/dependency_indexing_scheduler.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/shared"
-	codeinteltypes "github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -76,7 +75,7 @@ func (h *dependencyIndexingSchedulerHandler) Handle(ctx context.Context, logger 
 		return nil
 	}
 
-	job := record.(codeinteltypes.DependencyIndexingJob)
+	job := record.(shared.DependencyIndexingJob)
 
 	if job.ExternalServiceKind != "" {
 		externalServices, err := h.extsvcStore.List(ctx, database.ExternalServicesListOptions{

--- a/internal/codeintel/autoindexing/dependency_indexing_scheduler_test.go
+++ b/internal/codeintel/autoindexing/dependency_indexing_scheduler_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	autoindexingshared "github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/shared"
 	codeinteltypes "github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -73,7 +74,7 @@ func TestDependencyIndexingSchedulerHandler(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	job := codeinteltypes.DependencyIndexingJob{
+	job := autoindexingshared.DependencyIndexingJob{
 		UploadID:            42,
 		ExternalServiceKind: "",
 		ExternalServiceSync: time.Time{},
@@ -174,7 +175,7 @@ func TestDependencyIndexingSchedulerHandlerCustomer(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	job := codeinteltypes.DependencyIndexingJob{
+	job := autoindexingshared.DependencyIndexingJob{
 		UploadID:            42,
 		ExternalServiceKind: "",
 		ExternalServiceSync: time.Time{},
@@ -267,7 +268,7 @@ func TestDependencyIndexingSchedulerHandlerRequeueNotCloned(t *testing.T) {
 		repoUpdater:        mockRepoUpdater,
 	}
 
-	job := codeinteltypes.DependencyIndexingJob{
+	job := autoindexingshared.DependencyIndexingJob{
 		UploadID:            42,
 		ExternalServiceKind: "",
 		ExternalServiceSync: time.Time{},
@@ -329,7 +330,7 @@ func TestDependencyIndexingSchedulerHandlerSkipNonExistant(t *testing.T) {
 		repoStore:          mockRepoStore,
 	}
 
-	job := codeinteltypes.DependencyIndexingJob{
+	job := autoindexingshared.DependencyIndexingJob{
 		UploadID:            42,
 		ExternalServiceKind: "",
 		ExternalServiceSync: time.Time{},
@@ -374,7 +375,7 @@ func TestDependencyIndexingSchedulerHandlerShouldSkipRepository(t *testing.T) {
 		repoStore:          mockRepoStore,
 	}
 
-	job := codeinteltypes.DependencyIndexingJob{
+	job := autoindexingshared.DependencyIndexingJob{
 		ExternalServiceKind: "",
 		ExternalServiceSync: time.Time{},
 		UploadID:            42,

--- a/internal/codeintel/autoindexing/dependency_sync_scheduler.go
+++ b/internal/codeintel/autoindexing/dependency_sync_scheduler.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
-	codeinteltypes "github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	uploadsshared "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
@@ -69,7 +68,7 @@ func (h *dependencySyncSchedulerHandler) Handle(ctx context.Context, logger log.
 		return nil
 	}
 
-	job := record.(codeinteltypes.DependencySyncingJob)
+	job := record.(shared.DependencySyncingJob)
 
 	scanner, err := h.uploadsSvc.ReferencesForUpload(ctx, job.UploadID)
 	if err != nil {

--- a/internal/codeintel/autoindexing/dependency_sync_scheduler_test.go
+++ b/internal/codeintel/autoindexing/dependency_sync_scheduler_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/sourcegraph/log/logtest"
 
+	autoindexingshared "github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
-	codeinteltypes "github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -39,7 +39,7 @@ func TestDependencySyncSchedulerJVM(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	job := codeinteltypes.DependencySyncingJob{
+	job := autoindexingshared.DependencySyncingJob{
 		UploadID: 42,
 	}
 	if err := handler.Handle(context.Background(), logger, job); err != nil {
@@ -91,7 +91,7 @@ func TestDependencySyncSchedulerGomod(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	job := codeinteltypes.DependencySyncingJob{
+	job := autoindexingshared.DependencySyncingJob{
 		UploadID: 42,
 	}
 	if err := handler.Handle(context.Background(), logger, job); err != nil {

--- a/internal/codeintel/autoindexing/internal/store/workerutil.go
+++ b/internal/codeintel/autoindexing/internal/store/workerutil.go
@@ -7,7 +7,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
 
-	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -124,7 +124,7 @@ var dependencySyncingJobColumns = []*sqlf.Query{
 	sqlf.Sprintf("lsif_dependency_syncing_jobs.upload_id"),
 }
 
-func scanDependencySyncingJob(s dbutil.Scanner) (job types.DependencySyncingJob, err error) {
+func scanDependencySyncingJob(s dbutil.Scanner) (job shared.DependencySyncingJob, err error) {
 	return job, s.Scan(
 		&job.ID,
 		&job.State,
@@ -178,7 +178,7 @@ var dependencyIndexingJobColumns = []*sqlf.Query{
 	sqlf.Sprintf("lsif_dependency_indexing_jobs.external_service_sync"),
 }
 
-func scanDependencyIndexingJob(s dbutil.Scanner) (job types.DependencyIndexingJob, err error) {
+func scanDependencyIndexingJob(s dbutil.Scanner) (job shared.DependencyIndexingJob, err error) {
 	return job, s.Scan(
 		&job.ID,
 		&job.State,

--- a/internal/codeintel/autoindexing/shared/workerutil.go
+++ b/internal/codeintel/autoindexing/shared/workerutil.go
@@ -1,4 +1,4 @@
-package types
+package shared
 
 import "time"
 


### PR DESCRIPTION
Move these shared types into the only package where they're used.

## Test plan

N/A.