### PR TITLE
sg: add src-cli wrapper

### DIFF
--- a/dev/sg/dependencies/helpers.go
+++ b/dev/sg/dependencies/helpers.go
@@ -243,6 +243,28 @@ func checkGitVersion(versionConstraint string) func(context.Context) error {
 	}
 }
 
+func checkSrcCliVersion(versionConstraint string) func(context.Context) error {
+	return func(ctx context.Context) error {
+		lines, err := usershell.Command(ctx, "src version").StdOut().Run().Lines()
+		if err != nil {
+			return errors.Wrapf(err, "failed to run 'src version'")
+		}
+
+		if len(lines) < 2 {
+			return errors.Newf("unexpected output from src: %s", strings.Join(lines, "\n"))
+		}
+		out := lines[0]
+
+		elems := strings.Split(out, " ")
+		if len(elems) != 3 {
+			return errors.Newf("unexpected output from src: %s", out)
+		}
+
+		trimmed := strings.TrimSpace(elems[2])
+		return check.Version("src", trimmed, versionConstraint)
+	}
+}
+
 func getToolVersionConstraint(ctx context.Context, tool string) (string, error) {
 	tools, err := root.Run(run.Cmd(ctx, "cat .tool-versions")).Lines()
 	if err != nil {

--- a/dev/sg/dependencies/mac.go
+++ b/dev/sg/dependencies/mac.go
@@ -249,4 +249,15 @@ YOU NEED TO RESTART 'sg setup' AFTER RUNNING THIS COMMAND!`,
 			dependencyGcloud(),
 		},
 	},
+	{
+		Name:      "Internal tooling",
+		DependsOn: []string{depsHomebrew},
+		Checks: []*dependency{
+			{
+				Name:  "src",
+				Check: checkAction(check.InPath("src")),
+				Fix:   cmdFix(`brew install sourcegraph/src-cli/src-cli`),
+			},
+		},
+	},
 }

--- a/dev/sg/dependencies/mac.go
+++ b/dev/sg/dependencies/mac.go
@@ -252,11 +252,12 @@ YOU NEED TO RESTART 'sg setup' AFTER RUNNING THIS COMMAND!`,
 	{
 		Name:      "Internal tooling",
 		DependsOn: []string{depsHomebrew},
+		Enabled:   enableForTeammatesOnly(),
 		Checks: []*dependency{
 			{
 				Name:  "src",
-				Check: checkAction(check.InPath("src")),
-				Fix:   cmdFix(`brew install sourcegraph/src-cli/src-cli`),
+				Check: checkAction(check.Combine(check.InPath("src"), checkSrcCliVersion(">= 4.0.2"))),
+				Fix:   cmdFix(`brew upgrade sourcegraph/src-cli/src-cli || brew install sourcegraph/src-cli/src-cli`),
 			},
 		},
 	},

--- a/dev/sg/dependencies/mac.go
+++ b/dev/sg/dependencies/mac.go
@@ -135,7 +135,14 @@ var Mac = []category{
 		},
 	},
 	categoryCloneRepositories(),
-	categoryProgrammingLanguagesAndTools(),
+	categoryProgrammingLanguagesAndTools(
+		// src-cli is installed differently on Ubuntu and Mac
+		&dependency{
+			Name:  "src",
+			Check: checkAction(check.Combine(check.InPath("src"), checkSrcCliVersion(">= 4.0.2"))),
+			Fix:   cmdFix(`brew upgrade sourcegraph/src-cli/src-cli || brew install sourcegraph/src-cli/src-cli`),
+		},
+	),
 	{
 		Name:      "Postgres database",
 		DependsOn: []string{depsHomebrew},
@@ -247,18 +254,6 @@ YOU NEED TO RESTART 'sg setup' AFTER RUNNING THIS COMMAND!`,
 		Enabled:   enableForTeammatesOnly(),
 		Checks: []*dependency{
 			dependencyGcloud(),
-		},
-	},
-	{
-		Name:      "Internal tooling",
-		DependsOn: []string{depsHomebrew},
-		Enabled:   enableForTeammatesOnly(),
-		Checks: []*dependency{
-			{
-				Name:  "src",
-				Check: checkAction(check.Combine(check.InPath("src"), checkSrcCliVersion(">= 4.0.2"))),
-				Fix:   cmdFix(`brew upgrade sourcegraph/src-cli/src-cli || brew install sourcegraph/src-cli/src-cli`),
-			},
 		},
 	},
 }

--- a/dev/sg/dependencies/shared.go
+++ b/dev/sg/dependencies/shared.go
@@ -116,8 +116,9 @@ NOTE: You can ignore this if you're not a Sourcegraph teammate.`,
 }
 
 // categoryProgrammingLanguagesAndTools sets up programming languages and tooling using
-// asdf, which is uniform across platforms.
-func categoryProgrammingLanguagesAndTools() category {
+// asdf, which is uniform across platforms. It takes an optional list of additonalChecks, useful
+// when they depend on the plaftorm we're installing them on.
+func categoryProgrammingLanguagesAndTools(additionalChecks ...*dependency) category {
 	return category{
 		Name:      "Programming languages & tooling",
 		DependsOn: []string{depsCloneRepo, depsBaseUtilities},

--- a/dev/sg/dependencies/ubuntu.go
+++ b/dev/sg/dependencies/ubuntu.go
@@ -247,7 +247,7 @@ YOU NEED TO RESTART 'sg setup' AFTER RUNNING THIS COMMAND!`,
 		Checks: []*dependency{
 			{
 				Name:  "src",
-				Check: checkAction(check.InPath("src")),
+				Check: checkAction(check.Combine(check.InPath("src"), checkSrcCliVersion(">= 4.0.2"))),
 				Fix:   cmdFix(`sudo curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /usr/local/bin/src && sudo chmod +x /usr/local/bin/src`),
 			},
 		},

--- a/dev/sg/dependencies/ubuntu.go
+++ b/dev/sg/dependencies/ubuntu.go
@@ -242,7 +242,7 @@ YOU NEED TO RESTART 'sg setup' AFTER RUNNING THIS COMMAND!`,
 	},
 	{
 		Name:      "Internal tooling",
-		DependsOn: []string{depsHomebrew},
+		DependsOn: []string{depsBaseUtilities},
 		Enabled:   enableForTeammatesOnly(),
 		Checks: []*dependency{
 			{

--- a/dev/sg/dependencies/ubuntu.go
+++ b/dev/sg/dependencies/ubuntu.go
@@ -240,4 +240,16 @@ YOU NEED TO RESTART 'sg setup' AFTER RUNNING THIS COMMAND!`,
 			dependencyGcloud(),
 		},
 	},
+	{
+		Name:      "Internal tooling",
+		DependsOn: []string{depsHomebrew},
+		Enabled:   enableForTeammatesOnly(),
+		Checks: []*dependency{
+			{
+				Name:  "src",
+				Check: checkAction(check.InPath("src")),
+				Fix:   cmdFix(`sudo curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /usr/local/bin/src && sudo chmod +x /usr/local/bin/src`),
+			},
+		},
+	},
 }

--- a/dev/sg/dependencies/ubuntu.go
+++ b/dev/sg/dependencies/ubuntu.go
@@ -128,7 +128,14 @@ var Ubuntu = []category{
 		},
 	},
 	categoryCloneRepositories(),
-	categoryProgrammingLanguagesAndTools(),
+	categoryProgrammingLanguagesAndTools(
+		// src-cli is installed differently on Ubuntu and Mac
+		&dependency{
+			Name:  "src",
+			Check: checkAction(check.Combine(check.InPath("src"), checkSrcCliVersion(">= 4.0.2"))),
+			Fix:   cmdFix(`sudo curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /usr/local/bin/src && sudo chmod +x /usr/local/bin/src`),
+		},
+	),
 	{
 		Name:      "Postgres database",
 		DependsOn: []string{depsBaseUtilities},
@@ -238,18 +245,6 @@ YOU NEED TO RESTART 'sg setup' AFTER RUNNING THIS COMMAND!`,
 		Enabled:   enableForTeammatesOnly(),
 		Checks: []*dependency{
 			dependencyGcloud(),
-		},
-	},
-	{
-		Name:      "Internal tooling",
-		DependsOn: []string{depsBaseUtilities},
-		Enabled:   enableForTeammatesOnly(),
-		Checks: []*dependency{
-			{
-				Name:  "src",
-				Check: checkAction(check.Combine(check.InPath("src"), checkSrcCliVersion(">= 4.0.2"))),
-				Fix:   cmdFix(`sudo curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /usr/local/bin/src && sudo chmod +x /usr/local/bin/src`),
-			},
 		},
 	},
 }

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -278,6 +278,7 @@ var sg = &cli.App{
 		auditCommand,
 		pageCommand,
 		srcCommand,
+		srcCtxCommand,
 
 		// Util
 		helpCommand,

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -269,7 +269,7 @@ var sg = &cli.App{
 		secretCommand,
 		setupCommand,
 		srcCommand,
-		srcCtxCommand,
+		srcInstanceCommand,
 
 		// Company
 		teammateCommand,

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -268,6 +268,8 @@ var sg = &cli.App{
 		// Dev environment
 		secretCommand,
 		setupCommand,
+		srcCommand,
+		srcCtxCommand,
 
 		// Company
 		teammateCommand,
@@ -277,8 +279,6 @@ var sg = &cli.App{
 		opsCommand,
 		auditCommand,
 		pageCommand,
-		srcCommand,
-		srcCtxCommand,
 
 		// Util
 		helpCommand,

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -277,6 +277,7 @@ var sg = &cli.App{
 		opsCommand,
 		auditCommand,
 		pageCommand,
+		srcCommand,
 
 		// Util
 		helpCommand,

--- a/dev/sg/sg_src.go
+++ b/dev/sg/sg_src.go
@@ -23,9 +23,9 @@ type srcSecrets struct {
 	Instances map[string]srcInstance `json:"instances"`
 }
 
-var srcCtxCommand = &cli.Command{
-	Name:      "src-ctx",
-	UsageText: "sg src-ctx [command]",
+var srcInstanceCommand = &cli.Command{
+	Name:      "src-instance",
+	UsageText: "sg src-instance [command]",
 	Usage:     "Interact with Sourcegraph instances that 'sg src' will use",
 	Category:  CategoryDev,
 	Subcommands: []*cli.Command{
@@ -67,7 +67,7 @@ var srcCtxCommand = &cli.Command{
 					return errors.Wrap(err, "failed to save instance")
 				}
 				std.Out.WriteSuccessf("src instance %s added", name)
-				std.Out.WriteSuggestionf("Run 'sg src-ctx use %s' to switch to that instance for 'sg src'", name)
+				std.Out.WriteSuggestionf("Run 'sg src-instance use %s' to switch to that instance for 'sg src'", name)
 				return nil
 			},
 		},
@@ -118,7 +118,7 @@ var srcCtxCommand = &cli.Command{
 var srcCommand = &cli.Command{
 	Name:      "src",
 	UsageText: "sg src [src-cli args]\nsg src help # get src-cli help",
-	Usage:     "Run src-cli on a given instance defined with 'sg src-ctx'",
+	Usage:     "Run src-cli on a given instance defined with 'sg src-instance'",
 	Category:  CategoryDev,
 	Action: func(cmd *cli.Context) error {
 		_, sc, err := getSrcInstances(cmd.Context, std.Out)
@@ -128,7 +128,7 @@ var srcCommand = &cli.Command{
 		instanceName := sc.Current
 		if instanceName == "" {
 			std.Out.WriteFailuref("Instance not found, register one with 'sg src register-instance'")
-			return errors.New("set an instance with sg src-ctx use [instance-name]")
+			return errors.New("set an instance with sg src-instance use [instance-name]")
 		}
 		instance, ok := sc.Instances[instanceName]
 		if !ok {

--- a/dev/sg/sg_src.go
+++ b/dev/sg/sg_src.go
@@ -104,6 +104,7 @@ var srcCommand = &cli.Command{
 	},
 }
 
+// getSrcSecret retrieves src-cli secrets from the context secrets store
 func getSrcSecret(ctx context.Context, out *std.Output) (*secrets.Store, *srcSecrets, error) {
 	sec, err := secrets.FromContext(ctx)
 	if err != nil {

--- a/dev/sg/sg_src.go
+++ b/dev/sg/sg_src.go
@@ -34,7 +34,7 @@ var srcCtxCommand = &cli.Command{
 			Usage:     "Register (or edit an existing) Sourcegraph instance to target with src-cli",
 			UsageText: "sg src instance register [name] [endpoint]",
 			Action: func(cmd *cli.Context) error {
-				store, sc, err := getSrcSecret(cmd.Context, std.Out)
+				store, sc, err := getSrcInstances(cmd.Context, std.Out)
 				if err != nil {
 					return errors.Wrap(err, "failed to read existing instances")
 				}
@@ -75,7 +75,7 @@ var srcCtxCommand = &cli.Command{
 			Name:  "use",
 			Usage: "Set current src-cli instance to use with 'sg src'",
 			Action: func(cmd *cli.Context) error {
-				store, sc, err := getSrcSecret(cmd.Context, std.Out)
+				store, sc, err := getSrcInstances(cmd.Context, std.Out)
 				if err != nil {
 					return err
 				}
@@ -97,7 +97,7 @@ var srcCtxCommand = &cli.Command{
 			Name:  "list",
 			Usage: "List registered instances for src-cli",
 			Action: func(cmd *cli.Context) error {
-				_, sc, err := getSrcSecret(cmd.Context, std.Out)
+				_, sc, err := getSrcInstances(cmd.Context, std.Out)
 				if err != nil {
 					return err
 				}
@@ -121,7 +121,7 @@ var srcCommand = &cli.Command{
 	Usage:     "Run src-cli on a given instance defined with 'sg src-ctx'",
 	Category:  CategoryCompany,
 	Action: func(cmd *cli.Context) error {
-		_, sc, err := getSrcSecret(cmd.Context, std.Out)
+		_, sc, err := getSrcInstances(cmd.Context, std.Out)
 		if err != nil {
 			return err
 		}
@@ -145,8 +145,8 @@ var srcCommand = &cli.Command{
 	},
 }
 
-// getSrcSecret retrieves src-cli secrets from the context secrets store
-func getSrcSecret(ctx context.Context, out *std.Output) (*secrets.Store, *srcSecrets, error) {
+// getSrcInstances retrieves src instances configuration from the secrets store
+func getSrcInstances(ctx context.Context, out *std.Output) (*secrets.Store, *srcSecrets, error) {
 	sec, err := secrets.FromContext(ctx)
 	if err != nil {
 		return nil, nil, err

--- a/dev/sg/sg_src.go
+++ b/dev/sg/sg_src.go
@@ -52,7 +52,7 @@ var srcCommand = &cli.Command{
 				{
 					Name:    "register",
 					Usage:   "",
-					Aliases: []string{"update, add"},
+					Aliases: []string{"update"},
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:     "name",

--- a/dev/sg/sg_src.go
+++ b/dev/sg/sg_src.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/secrets"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/usershell"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+	"github.com/urfave/cli/v2"
+)
+
+type srcInstance struct {
+	AccessToken string `json:"access_token"`
+	Endpoint    string `json:"endpoint"`
+}
+
+type srcSecrets struct {
+	Instances map[string]srcInstance `json:"instances"`
+}
+
+var srcCommand = &cli.Command{
+	Name:      "src",
+	UsageText: "sg src [instance] [src-cli args]",
+	Usage:     "Run src-cli on a given instance",
+	Category:  CategoryCompany,
+	Action: func(cmd *cli.Context) error {
+		_, sc, err := getSrcSecret(cmd.Context, std.Out)
+		if err != nil {
+			return err
+		}
+		instance, ok := sc.Instances[cmd.Args().Get(0)]
+		if !ok {
+			std.Out.WriteFailuref("Instance not found, register one with 'sg src register-instance'")
+			return errors.New("instance not found")
+		}
+		srcArgs := cmd.Args().Slice()[1:]
+		c := usershell.Command(cmd.Context, append([]string{"src"}, srcArgs...)...)
+		c = c.Env(map[string]string{
+			"SRC_ACCESS_TOKEN": instance.AccessToken,
+			"SRC_ENDPOINT":     instance.Endpoint,
+		})
+		return c.Run().Stream(os.Stdout)
+	},
+	Subcommands: []*cli.Command{
+		{
+			Name:      "instance",
+			UsageText: "todo",
+			Subcommands: []*cli.Command{
+				{
+					Name:    "register",
+					Usage:   "",
+					Aliases: []string{"update, add"},
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:     "name",
+							Usage:    "Name for the new instance (ex: s2)",
+							Required: true,
+						},
+						&cli.StringFlag{
+							Name:     "endpoint",
+							Usage:    "Endpoint for the new instance (ex: https://sourcegraph.sourcegraph.com)",
+							Required: true,
+						},
+						&cli.StringFlag{
+							Name:     "access-token",
+							Usage:    "AccessToken for the new instance",
+							Required: true,
+						},
+					},
+					Action: func(cmd *cli.Context) error {
+						store, sc, err := getSrcSecret(cmd.Context, std.Out)
+						if err != nil {
+							return err
+						}
+						sc.Instances[cmd.String("name")] = srcInstance{
+							Endpoint:    cmd.String("endpoint"),
+							AccessToken: cmd.String("access-token"),
+						}
+						if err := store.PutAndSave("src", sc); err != nil {
+							return err
+						}
+						return nil
+					},
+				},
+				{
+					Name:  "list",
+					Usage: "",
+					Action: func(cmd *cli.Context) error {
+						_, sc, err := getSrcSecret(cmd.Context, std.Out)
+						if err != nil {
+							return err
+						}
+						for name, instance := range sc.Instances {
+							std.Out.WriteLine(output.Linef("", output.StyleBold, "|%-16s|%-32s|", "Name", "Endpoint"))
+							std.Out.WriteLine(output.Linef("", output.StyleReset, "|%-16s|%-32s|", name, instance.Endpoint))
+						}
+						return nil
+					},
+				},
+			},
+		},
+	},
+}
+
+func getSrcSecret(ctx context.Context, out *std.Output) (*secrets.Store, *srcSecrets, error) {
+	sec, err := secrets.FromContext(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	sc := srcSecrets{Instances: map[string]srcInstance{}}
+	err = sec.Get("src", &sc)
+	if err != nil && !errors.Is(err, secrets.ErrSecretNotFound) {
+		return nil, nil, err
+	}
+	return sec, &sc, nil
+}

--- a/dev/sg/sg_src.go
+++ b/dev/sg/sg_src.go
@@ -50,9 +50,8 @@ var srcCommand = &cli.Command{
 			UsageText: "todo",
 			Subcommands: []*cli.Command{
 				{
-					Name:    "register",
-					Usage:   "",
-					Aliases: []string{"update"},
+					Name:  "register",
+					Usage: "Register (or edit an existing) Sourcegraph instance to target with src-cli",
 					Flags: []cli.Flag{
 						&cli.StringFlag{
 							Name:     "name",

--- a/dev/sg/sg_src.go
+++ b/dev/sg/sg_src.go
@@ -48,7 +48,8 @@ var srcCommand = &cli.Command{
 	Subcommands: []*cli.Command{
 		{
 			Name:      "instance",
-			UsageText: "todo",
+			Usage:     "Interact with Sourcegraph instances that src-cli will use",
+			UsageText: "sg src instance [command]",
 			Subcommands: []*cli.Command{
 				{
 					Name:      "register",

--- a/dev/sg/sg_src.go
+++ b/dev/sg/sg_src.go
@@ -32,14 +32,14 @@ var srcCtxCommand = &cli.Command{
 		{
 			Name:      "register",
 			Usage:     "Register (or edit an existing) Sourcegraph instance to target with src-cli",
-			UsageText: "sg src instance register [name] [endpoint] [access_token]",
+			UsageText: "sg src instance register [name] [endpoint]",
 			Action: func(cmd *cli.Context) error {
 				store, sc, err := getSrcSecret(cmd.Context, std.Out)
 				if err != nil {
 					return errors.Wrap(err, "failed to read existing instances")
 				}
-				if cmd.Args().Len() < 3 {
-					return errors.Newf("not enough arguments, want %d got %d", 3, cmd.Args().Len())
+				if cmd.Args().Len() != 2 {
+					return errors.Newf("not enough arguments, want %d got %d", 2, cmd.Args().Len())
 				}
 
 				name := cmd.Args().First()
@@ -52,7 +52,12 @@ var srcCtxCommand = &cli.Command{
 					return errors.New("cannot parse [endpoint], scheme must be http or https")
 				}
 
-				accessToken := cmd.Args().Slice()[2]
+				accessToken, err := std.Out.PromptPasswordf(
+					os.Stdin,
+					`Please enter the access token for Sourcegraph instance named %s (%s):`,
+					name,
+					endpoint,
+				)
 
 				sc.Instances[name] = srcInstance{
 					Endpoint:    endpoint,

--- a/dev/sg/sg_src.go
+++ b/dev/sg/sg_src.go
@@ -27,7 +27,7 @@ var srcCtxCommand = &cli.Command{
 	Name:      "src-ctx",
 	UsageText: "sg src-ctx [command]",
 	Usage:     "Interact with Sourcegraph instances that 'sg src' will use",
-	Category:  CategoryCompany,
+	Category:  CategoryDev,
 	Subcommands: []*cli.Command{
 		{
 			Name:      "register",
@@ -119,7 +119,7 @@ var srcCommand = &cli.Command{
 	Name:      "src",
 	UsageText: "sg src [src-cli args]\nsg src help # get src-cli help",
 	Usage:     "Run src-cli on a given instance defined with 'sg src-ctx'",
-	Category:  CategoryCompany,
+	Category:  CategoryDev,
 	Action: func(cmd *cli.Context) error {
 		_, sc, err := getSrcInstances(cmd.Context, std.Out)
 		if err != nil {

--- a/dev/sg/sg_src.go
+++ b/dev/sg/sg_src.go
@@ -58,6 +58,9 @@ var srcInstanceCommand = &cli.Command{
 					name,
 					endpoint,
 				)
+				if err != nil {
+					return errors.Wrapf(err, "failed to read access token")
+				}
 
 				sc.Instances[name] = srcInstance{
 					Endpoint:    endpoint,

--- a/dev/sg/sg_src.go
+++ b/dev/sg/sg_src.go
@@ -19,90 +19,124 @@ type srcInstance struct {
 }
 
 type srcSecrets struct {
+	Current   string                 `json:"current"`
 	Instances map[string]srcInstance `json:"instances"`
+}
+
+var srcCtxCommand = &cli.Command{
+	Name:      "src-ctx",
+	UsageText: "sg src-ctx [command]",
+	Usage:     "Interact with Sourcegraph instances that 'sg src' will use",
+	Category:  CategoryCompany,
+	Subcommands: []*cli.Command{
+		{
+			Name:      "register",
+			Usage:     "Register (or edit an existing) Sourcegraph instance to target with src-cli",
+			UsageText: "sg src instance register [name] [endpoint] [access_token]",
+			Action: func(cmd *cli.Context) error {
+				store, sc, err := getSrcSecret(cmd.Context, std.Out)
+				if err != nil {
+					return errors.Wrap(err, "failed to read existing instances")
+				}
+				if cmd.Args().Len() < 3 {
+					return errors.Newf("not enough arguments, want %d got %d", 3, cmd.Args().Len())
+				}
+
+				name := cmd.Args().First()
+				endpoint := cmd.Args().Slice()[1]
+				endpointUrl, err := url.Parse(endpoint)
+				if err != nil {
+					return errors.Wrapf(err, "cannot parse [endpoint]")
+				}
+				if endpointUrl.Scheme != "http" && endpointUrl.Scheme != "https" {
+					return errors.New("cannot parse [endpoint], scheme must be http or https")
+				}
+
+				accessToken := cmd.Args().Slice()[2]
+
+				sc.Instances[name] = srcInstance{
+					Endpoint:    endpoint,
+					AccessToken: accessToken,
+				}
+				if err := store.PutAndSave("src", sc); err != nil {
+					return errors.Wrap(err, "failed to save instance")
+				}
+				std.Out.WriteSuccessf("src instance %s added", name)
+				std.Out.WriteSuggestionf("Run 'sg src-ctx use %s' to switch to that instance for 'sg src'", name)
+				return nil
+			},
+		},
+		{
+			Name:  "use",
+			Usage: "Set current src-cli instance to use with 'sg src'",
+			Action: func(cmd *cli.Context) error {
+				store, sc, err := getSrcSecret(cmd.Context, std.Out)
+				if err != nil {
+					return err
+				}
+				name := cmd.Args().First()
+				instance, ok := sc.Instances[name]
+				if !ok {
+					std.Out.WriteFailuref("Instance not found, register one with 'sg src register-instance'")
+					return errors.New("instance not found")
+				}
+				sc.Current = name
+				if err := store.PutAndSave("src", sc); err != nil {
+					return errors.Wrap(err, "failed to save instance")
+				}
+				std.Out.WriteSuccessf("Switched to %s (%s)", name, instance.Endpoint)
+				return nil
+			},
+		},
+		{
+			Name:  "list",
+			Usage: "List registered instances for src-cli",
+			Action: func(cmd *cli.Context) error {
+				_, sc, err := getSrcSecret(cmd.Context, std.Out)
+				if err != nil {
+					return err
+				}
+				std.Out.WriteLine(output.Linef("", output.StyleReset, "| %-16s| %-32s|", "Name", "Endpoint"))
+				for name, instance := range sc.Instances {
+					if name == sc.Current {
+						std.Out.WriteLine(output.Linef("", output.StyleSuccess, "| %-16s| %-32s|", name, instance.Endpoint))
+					} else {
+						std.Out.WriteLine(output.Linef("", output.StyleReset, "| %-16s| %-32s|", name, instance.Endpoint))
+					}
+				}
+				return nil
+			},
+		},
+	},
 }
 
 var srcCommand = &cli.Command{
 	Name:      "src",
-	UsageText: "sg src [instance] [src-cli args]",
-	Usage:     "Run src-cli on a given instance",
+	UsageText: "sg src [src-cli args]\nsg src help # get src-cli help",
+	Usage:     "Run src-cli on a given instance defined with 'sg src-ctx'",
 	Category:  CategoryCompany,
 	Action: func(cmd *cli.Context) error {
 		_, sc, err := getSrcSecret(cmd.Context, std.Out)
 		if err != nil {
 			return err
 		}
-		instance, ok := sc.Instances[cmd.Args().Get(0)]
+		instanceName := sc.Current
+		if instanceName == "" {
+			std.Out.WriteFailuref("Instance not found, register one with 'sg src register-instance'")
+			return errors.New("set an instance with sg src-ctx use [instance-name]")
+		}
+		instance, ok := sc.Instances[instanceName]
 		if !ok {
 			std.Out.WriteFailuref("Instance not found, register one with 'sg src register-instance'")
 			return errors.New("instance not found")
 		}
-		srcArgs := cmd.Args().Slice()[1:]
-		c := usershell.Command(cmd.Context, append([]string{"src"}, srcArgs...)...)
+
+		c := usershell.Command(cmd.Context, append([]string{"src"}, cmd.Args().Slice()...)...)
 		c = c.Env(map[string]string{
 			"SRC_ACCESS_TOKEN": instance.AccessToken,
 			"SRC_ENDPOINT":     instance.Endpoint,
 		})
 		return c.Run().Stream(os.Stdout)
-	},
-	Subcommands: []*cli.Command{
-		{
-			Name:      "instance",
-			Usage:     "Interact with Sourcegraph instances that src-cli will use",
-			UsageText: "sg src instance [command]",
-			Subcommands: []*cli.Command{
-				{
-					Name:      "register",
-					Usage:     "Register (or edit an existing) Sourcegraph instance to target with src-cli",
-					UsageText: "sg src instance register [name] [endpoint] [access_token]",
-					Action: func(cmd *cli.Context) error {
-						store, sc, err := getSrcSecret(cmd.Context, std.Out)
-						if err != nil {
-							return errors.Wrap(err, "failed to read existing instances")
-						}
-						if cmd.Args().Len() < 3 {
-							return errors.Newf("not enough arguments, want %d got %d", 3, cmd.Args().Len())
-						}
-
-						name := cmd.Args().First()
-						endpoint := cmd.Args().Slice()[1]
-						endpointUrl, err := url.Parse(endpoint)
-						if err != nil {
-							return errors.Wrapf(err, "cannot parse [endpoint]")
-						}
-						if endpointUrl.Scheme != "http" && endpointUrl.Scheme != "https" {
-							return errors.New("cannot parse [endpoint], scheme must be http or https")
-						}
-
-						accessToken := cmd.Args().Slice()[2]
-
-						sc.Instances[name] = srcInstance{
-							Endpoint:    endpoint,
-							AccessToken: accessToken,
-						}
-						if err := store.PutAndSave("src", sc); err != nil {
-							return errors.Wrap(err, "failed to save instance")
-						}
-						return nil
-					},
-				},
-				{
-					Name:  "list",
-					Usage: "List registered instances for src-cli",
-					Action: func(cmd *cli.Context) error {
-						_, sc, err := getSrcSecret(cmd.Context, std.Out)
-						if err != nil {
-							return err
-						}
-						std.Out.WriteLine(output.Linef("", output.StyleBold, "| %-16s| %-32s|", "Name", "Endpoint"))
-						for name, instance := range sc.Instances {
-							std.Out.WriteLine(output.Linef("", output.StyleReset, "| %-16s| %-32s|", name, instance.Endpoint))
-						}
-						return nil
-					},
-				},
-			},
-		},
 	},
 }
 

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1288,10 +1288,10 @@ Flags:
 
 ### sg src instance
 
-
+Interact with Sourcegraph instances that src-cli will use.
 
 ```sh
-$ todo
+$ sg src instance [command]
 ```
 
 #### sg src instance register

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1296,19 +1296,19 @@ $ todo
 
 #### sg src instance register
 
+Register (or edit an existing) Sourcegraph instance to target with src-cli.
 
-
+```sh
+$ sg src instance register [name] [endpoint] [access_token]
+```
 
 Flags:
 
-* `--access-token="<value>"`: AccessToken for the new instance
-* `--endpoint="<value>"`: Endpoint for the new instance (ex: https://sourcegraph.sourcegraph.com)
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
-* `--name="<value>"`: Name for the new instance (ex: s2)
 
 #### sg src instance list
 
-
+List registered instances for src-cli.
 
 
 Flags:

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1276,25 +1276,26 @@ Flags:
 
 ## sg src
 
-Run src-cli on a given instance.
+Run src-cli on a given instance defined with 'sg src-ctx'.
 
 ```sh
-$ sg src [instance] [src-cli args]
+$ sg src [src-cli args]
+$ sg src help # get src-cli help
 ```
 
 Flags:
 
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 
-### sg src instance
+## sg src-ctx
 
-Interact with Sourcegraph instances that src-cli will use.
+Interact with Sourcegraph instances that 'sg src' will use.
 
 ```sh
-$ sg src instance [command]
+$ sg src-ctx [command]
 ```
 
-#### sg src instance register
+### sg src-ctx register
 
 Register (or edit an existing) Sourcegraph instance to target with src-cli.
 
@@ -1306,7 +1307,16 @@ Flags:
 
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 
-#### sg src instance list
+### sg src-ctx use
+
+Set current src-cli instance to use with 'sg src'.
+
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
+
+### sg src-ctx list
 
 List registered instances for src-cli.
 

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1274,6 +1274,47 @@ Flags:
 * `--priority, -p="<value>"`: Alert priority, importance decreases from P1 (critical) to P5 (lowest), defaults to P5 (default: P5)
 * `--url="<value>"`: URL field for alert details (optional)
 
+## sg src
+
+Run src-cli on a given instance.
+
+```sh
+$ sg src [instance] [src-cli args]
+```
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
+
+### sg src instance
+
+
+
+```sh
+$ todo
+```
+
+#### sg src instance register
+
+
+
+
+Flags:
+
+* `--access-token="<value>"`: AccessToken for the new instance
+* `--endpoint="<value>"`: Endpoint for the new instance (ex: https://sourcegraph.sourcegraph.com)
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
+* `--name="<value>"`: Name for the new instance (ex: s2)
+
+#### sg src instance list
+
+
+
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
+
 ## sg help
 
 Get help and docs about sg.

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1054,6 +1054,57 @@ Flags:
 * `--fix, -f`: Fix all checks
 * `--oss`: Omit Sourcegraph-teammate-specific setup
 
+## sg src
+
+Run src-cli on a given instance defined with 'sg src-instance'.
+
+```sh
+$ sg src [src-cli args]
+$ sg src help # get src-cli help
+```
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
+
+## sg src-instance
+
+Interact with Sourcegraph instances that 'sg src' will use.
+
+```sh
+$ sg src-instance [command]
+```
+
+### sg src-instance register
+
+Register (or edit an existing) Sourcegraph instance to target with src-cli.
+
+```sh
+$ sg src instance register [name] [endpoint]
+```
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
+
+### sg src-instance use
+
+Set current src-cli instance to use with 'sg src'.
+
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
+
+### sg src-instance list
+
+List registered instances for src-cli.
+
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
+
 ## sg teammate
 
 Get information about Sourcegraph teammates.
@@ -1273,57 +1324,6 @@ Flags:
 * `--opsgenie.token="<value>"`: OpsGenie token
 * `--priority, -p="<value>"`: Alert priority, importance decreases from P1 (critical) to P5 (lowest), defaults to P5 (default: P5)
 * `--url="<value>"`: URL field for alert details (optional)
-
-## sg src
-
-Run src-cli on a given instance defined with 'sg src-ctx'.
-
-```sh
-$ sg src [src-cli args]
-$ sg src help # get src-cli help
-```
-
-Flags:
-
-* `--feedback`: provide feedback about this command by opening up a GitHub discussion
-
-## sg src-ctx
-
-Interact with Sourcegraph instances that 'sg src' will use.
-
-```sh
-$ sg src-ctx [command]
-```
-
-### sg src-ctx register
-
-Register (or edit an existing) Sourcegraph instance to target with src-cli.
-
-```sh
-$ sg src instance register [name] [endpoint] [access_token]
-```
-
-Flags:
-
-* `--feedback`: provide feedback about this command by opening up a GitHub discussion
-
-### sg src-ctx use
-
-Set current src-cli instance to use with 'sg src'.
-
-
-Flags:
-
-* `--feedback`: provide feedback about this command by opening up a GitHub discussion
-
-### sg src-ctx list
-
-List registered instances for src-cli.
-
-
-Flags:
-
-* `--feedback`: provide feedback about this command by opening up a GitHub discussion
 
 ## sg help
 


### PR DESCRIPTION
This is a follow-up to https://github.com/sourcegraph/sourcegraph/pull/42503#issuecomment-1269765910

This adds a manual wrapper for `src-cli` (with its accompanying `sg setup` task). 
I didn't want to open the pandora box of dealing with `sg` plugins so went with a straightforward approach to explore that problem space and ship this earlier.  

It works by registering instances with `sg src-instance register [name]` which stores those in the secrets and then running `sg src [src args]...` to run `src-cli` against that instance (after it's been set with `sg src-instance use`). Basically it's like kubectx. 

```
$ sg src-instance register scaletesting https://scaletesting.sgdev.org REDACTED-TOKEN
✅ src instance scaletesting added
💡 Run 'sg src-instance use scaletesting' to switch to that instance for 'sg src'

$ sg src-instance use scaletesting
✅ Switched to scaletesting (https://scaletesting.sgdev.org)

$ sg src-instance list
| Name            | Endpoint                        |
| foobar          | https://google.com              |
| scaletesting    | https://scaletesting.sgdev.org  | # this is green in the terminal
| test2           | https://scaletesting.sgdev.org  |
| test3           | htt://scaletesting.sgdev.org    |

$ sg src seach foobar
✱ 30+ results for "foobar" in 11ms
ghe.sgdev.org/sourcegraph/FooBarWidget-default_value_for (https://scaletesting.sgdev.org/ghe.sgdev.org/sourcegraph/FooBarWidget-default_value_for)
--------------------------------------------------------------------------------
(https://scaletesting.sgdev.org/github.com/genjidb/genji/-/blob/internal/expr/functions/definition_test.go)
github.com/genjidb/genji › definition_test.go (3 matches)
--------------------------------------------------------------------------------
      46 |              def, err := table.GetFunc("math", "foobar")
  ------------------------------------------------------------------------------
      49 |              def, err = table.GetFunc("", "foobar")
  ------------------------------------------------------------------------------
      55 |              def, err := table.GetFunc("foobar", "foobar")
--------------------------------------------------------------------------------
(https://scaletesting.sgdev.org/ghe.sgdev.org/milton/jtdaugherty-brick/-/blob/docs/guide.rst)
ghe.sgdev.org/milton/jtdaugherty-brick › guide.rst (3 matches)
# ...
```


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally. 