### PR TITLE
Make "security events" part of the audit log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Git server access logs are now compliant with the audit logging format. Breaking change: The 'actor' field is now nested under 'audit' field. [#41865](https://github.com/sourcegraph/sourcegraph/pull/41865)
 - All Perforce rules are now stored together in one column and evaluated on a "last rule takes precedence" basis. [#41785](https://github.com/sourcegraph/sourcegraph/pull/41785)
+- Security events are now a part of the audit log. [#42653](https://github.com/sourcegraph/sourcegraph/pull/42653)
 
 ### Fixed
 

--- a/enterprise/internal/batches/store/changeset_specs_test.go
+++ b/enterprise/internal/batches/store/changeset_specs_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/search"
 	bt "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -638,6 +639,7 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, clock 
 	t.Run("GetRewirerMappings", func(t *testing.T) {
 		// Create some test data
 		user := bt.CreateTestUser(t, s.DatabaseDB(), true)
+		ctx = actor.WithActor(ctx, &actor.Actor{UID: user.ID})
 		batchSpec := bt.CreateBatchSpec(t, ctx, s, "get-rewirer-mappings", user.ID, 0)
 		var mappings = make(btypes.RewirerMappings, 3)
 		changesetSpecIDs := make([]int64, 0, cap(mappings))
@@ -958,6 +960,7 @@ func testStoreChangesetSpecsCurrentState(t *testing.T, ctx context.Context, s *S
 
 	// Create a user.
 	user := bt.CreateTestUser(t, s.DatabaseDB(), false)
+	ctx = actor.WithActor(ctx, &actor.Actor{UID: user.ID})
 
 	// Next, we need old and new batch specs.
 	oldBatchSpec := bt.CreateBatchSpec(t, ctx, s, "old", user.ID, 0)
@@ -1056,6 +1059,7 @@ func testStoreChangesetSpecsCurrentStateAndTextSearch(t *testing.T, ctx context.
 
 	// Create a user.
 	user := bt.CreateTestUser(t, s.DatabaseDB(), false)
+	ctx = actor.WithActor(ctx, &actor.Actor{UID: user.ID})
 
 	// Next, we need old and new batch specs.
 	oldBatchSpec := bt.CreateBatchSpec(t, ctx, s, "old", user.ID, 0)
@@ -1231,6 +1235,7 @@ func testStoreChangesetSpecsTextSearch(t *testing.T, ctx context.Context, s *Sto
 
 	// Create a user.
 	user := bt.CreateTestUser(t, s.DatabaseDB(), false)
+	ctx = actor.WithActor(ctx, &actor.Actor{UID: user.ID})
 
 	// Next, we need a batch spec.
 	oldBatchSpec := bt.CreateBatchSpec(t, ctx, s, "text", user.ID, 0)

--- a/enterprise/internal/batches/store/changeset_specs_test.go
+++ b/enterprise/internal/batches/store/changeset_specs_test.go
@@ -639,7 +639,7 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, clock 
 	t.Run("GetRewirerMappings", func(t *testing.T) {
 		// Create some test data
 		user := bt.CreateTestUser(t, s.DatabaseDB(), true)
-		ctx = actor.WithActor(ctx, &actor.Actor{UID: user.ID})
+		ctx = actor.WithInternalActor(ctx)
 		batchSpec := bt.CreateBatchSpec(t, ctx, s, "get-rewirer-mappings", user.ID, 0)
 		var mappings = make(btypes.RewirerMappings, 3)
 		changesetSpecIDs := make([]int64, 0, cap(mappings))
@@ -960,7 +960,7 @@ func testStoreChangesetSpecsCurrentState(t *testing.T, ctx context.Context, s *S
 
 	// Create a user.
 	user := bt.CreateTestUser(t, s.DatabaseDB(), false)
-	ctx = actor.WithActor(ctx, &actor.Actor{UID: user.ID})
+	ctx = actor.WithInternalActor(ctx)
 
 	// Next, we need old and new batch specs.
 	oldBatchSpec := bt.CreateBatchSpec(t, ctx, s, "old", user.ID, 0)
@@ -1059,7 +1059,7 @@ func testStoreChangesetSpecsCurrentStateAndTextSearch(t *testing.T, ctx context.
 
 	// Create a user.
 	user := bt.CreateTestUser(t, s.DatabaseDB(), false)
-	ctx = actor.WithActor(ctx, &actor.Actor{UID: user.ID})
+	ctx = actor.WithInternalActor(ctx)
 
 	// Next, we need old and new batch specs.
 	oldBatchSpec := bt.CreateBatchSpec(t, ctx, s, "old", user.ID, 0)
@@ -1235,7 +1235,7 @@ func testStoreChangesetSpecsTextSearch(t *testing.T, ctx context.Context, s *Sto
 
 	// Create a user.
 	user := bt.CreateTestUser(t, s.DatabaseDB(), false)
-	ctx = actor.WithActor(ctx, &actor.Actor{UID: user.ID})
+	ctx = actor.WithInternalActor(ctx)
 
 	// Next, we need a batch spec.
 	oldBatchSpec := bt.CreateBatchSpec(t, ctx, s, "text", user.ID, 0)

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -117,7 +117,7 @@ func (d *db) EventLogs() EventLogStore {
 }
 
 func (d *db) SecurityEventLogs() SecurityEventLogsStore {
-	return SecurityEventLogsWith(d.Store)
+	return SecurityEventLogsWith(d.logger, d.Store)
 }
 
 func (d *db) ExternalServices() ExternalServiceStore {

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -133,7 +133,7 @@ func (s *securityEventLogsStore) InsertList(ctx context.Context, events []*Secur
 	return nil
 }
 
-func auditLogEnabled() bool {
+func securityEventsAuditLogEnabled() bool {
 	logCfg := conf.Get().Log
 	if logCfg != nil {
 		auditCfg := logCfg.AuditLog

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -113,7 +113,9 @@ func (s *securityEventLogsStore) InsertList(ctx context.Context, events []*Secur
 
 	if _, err := s.Handle().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
 		return errors.Wrap(err, "INSERT")
-	} else if auditLogEnabled() {
+	}
+
+	if securityEventsAuditLogEnabled() {
 		for _, event := range events {
 			audit.Log(ctx, s.logger, audit.Record{
 				Entity: "security events",

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -134,10 +134,8 @@ func (s *securityEventLogsStore) InsertList(ctx context.Context, events []*Secur
 }
 
 func securityEventsAuditLogEnabled() bool {
-	logCfg := conf.Get().Log
-	if logCfg != nil {
-		auditCfg := logCfg.AuditLog
-		if auditCfg != nil {
+	if logCfg := conf.Get().Log; logCfg != nil {
+		if auditCfg := logCfg.AuditLog; auditCfg != nil {
 			return auditCfg.SecurityEvents
 		}
 	}

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -3,13 +3,15 @@ package database
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/internal/audit"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/version"
@@ -54,6 +56,13 @@ type SecurityEvent struct {
 	Timestamp       time.Time
 }
 
+func (e *SecurityEvent) parseArgument() string {
+	if e.Argument == nil {
+		return fmt.Sprintf("%s", []byte(`{}`))
+	}
+	return fmt.Sprintf("%s", e.Argument)
+}
+
 // SecurityEventLogsStore provides persistence for security events.
 type SecurityEventLogsStore interface {
 	basestore.ShareableStore
@@ -76,9 +85,9 @@ type securityEventLogsStore struct {
 }
 
 // SecurityEventLogsWith instantiates and returns a new SecurityEventLogsStore
-// using the other store handle.
-func SecurityEventLogsWith(other basestore.ShareableStore) SecurityEventLogsStore {
-	logger := log.Scoped("SecurityEvents", "Security events store")
+// using the other store handle, and a scoped sub-logger of the passed base logger.
+func SecurityEventLogsWith(baseLogger log.Logger, other basestore.ShareableStore) SecurityEventLogsStore {
+	logger := baseLogger.Scoped("SecurityEvents", "Security events store")
 	return &securityEventLogsStore{logger: logger, Store: basestore.NewWithHandle(other.Handle())}
 }
 
@@ -89,17 +98,13 @@ func (s *securityEventLogsStore) Insert(ctx context.Context, event *SecurityEven
 func (s *securityEventLogsStore) InsertList(ctx context.Context, events []*SecurityEvent) error {
 	vals := make([]*sqlf.Query, len(events))
 	for index, event := range events {
-		argument := event.Argument
-		if argument == nil {
-			argument = []byte(`{}`)
-		}
 		vals[index] = sqlf.Sprintf(`(%s, %s, %s, %s, %s, %s, %s, %s)`,
 			event.Name,
 			event.URL,
 			event.UserID,
 			event.AnonymousUserID,
 			event.Source,
-			argument,
+			event.parseArgument(),
 			version.Version(),
 			event.Timestamp.UTC(),
 		)
@@ -108,8 +113,39 @@ func (s *securityEventLogsStore) InsertList(ctx context.Context, events []*Secur
 
 	if _, err := s.Handle().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
 		return errors.Wrap(err, "INSERT")
+	} else {
+		if auditLogEnabled() {
+			for _, event := range events {
+				audit.Log(ctx, s.logger, audit.Record{
+					Entity: "security events",
+					Action: string(event.Name),
+					Fields: []log.Field{
+						log.Object("event",
+							log.String("URL", event.URL),
+							log.String("source", event.Source),
+							log.String("argument", event.parseArgument()),
+							log.String("version", version.Version()),
+							log.String("timestamp", event.Timestamp.UTC().String()),
+						),
+					},
+				})
+			}
+		}
 	}
 	return nil
+}
+
+func auditLogEnabled() bool {
+	logCfg := conf.Get().Log
+	if logCfg != nil {
+		auditCfg := logCfg.AuditLog
+		if auditCfg != nil {
+			return auditCfg.SecurityEvents
+		}
+	}
+
+	// enabled by default for security events
+	return true
 }
 
 func (s *securityEventLogsStore) LogEvent(ctx context.Context, e *SecurityEvent) {
@@ -117,12 +153,6 @@ func (s *securityEventLogsStore) LogEvent(ctx context.Context, e *SecurityEvent)
 }
 
 func (s *securityEventLogsStore) LogEventList(ctx context.Context, events []*SecurityEvent) {
-	// We don't want to begin logging authentication or authorization events in
-	// on-premises installations yet.
-	if !envvar.SourcegraphDotComMode() {
-		return
-	}
-
 	if err := s.InsertList(ctx, events); err != nil {
 		names := make([]string, len(events))
 		for i, e := range events {

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -113,23 +113,21 @@ func (s *securityEventLogsStore) InsertList(ctx context.Context, events []*Secur
 
 	if _, err := s.Handle().ExecContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
 		return errors.Wrap(err, "INSERT")
-	} else {
-		if auditLogEnabled() {
-			for _, event := range events {
-				audit.Log(ctx, s.logger, audit.Record{
-					Entity: "security events",
-					Action: string(event.Name),
-					Fields: []log.Field{
-						log.Object("event",
-							log.String("URL", event.URL),
-							log.String("source", event.Source),
-							log.String("argument", event.parseArgument()),
-							log.String("version", version.Version()),
-							log.String("timestamp", event.Timestamp.UTC().String()),
-						),
-					},
-				})
-			}
+	} else if auditLogEnabled() {
+		for _, event := range events {
+			audit.Log(ctx, s.logger, audit.Record{
+				Entity: "security events",
+				Action: string(event.Name),
+				Fields: []log.Field{
+					log.Object("event",
+						log.String("URL", event.URL),
+						log.String("source", event.Source),
+						log.String("argument", event.parseArgument()),
+						log.String("version", version.Version()),
+						log.String("timestamp", event.Timestamp.UTC().String()),
+					),
+				},
+			})
 		}
 	}
 	return nil

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -56,7 +56,7 @@ type SecurityEvent struct {
 	Timestamp       time.Time
 }
 
-func (e *SecurityEvent) parseArgument() string {
+func (e *SecurityEvent) marshalArgumentAsJSON() string {
 	if e.Argument == nil {
 		return "{}"
 	}
@@ -104,7 +104,7 @@ func (s *securityEventLogsStore) InsertList(ctx context.Context, events []*Secur
 			event.UserID,
 			event.AnonymousUserID,
 			event.Source,
-			event.parseArgument(),
+			event.marshalArgumentAsJSON(),
 			version.Version(),
 			event.Timestamp.UTC(),
 		)
@@ -124,7 +124,7 @@ func (s *securityEventLogsStore) InsertList(ctx context.Context, events []*Secur
 					log.Object("event",
 						log.String("URL", event.URL),
 						log.String("source", event.Source),
-						log.String("argument", event.parseArgument()),
+						log.String("argument", event.marshalArgumentAsJSON()),
 						log.String("version", version.Version()),
 						log.String("timestamp", event.Timestamp.UTC().String()),
 					),

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -58,7 +58,7 @@ type SecurityEvent struct {
 
 func (e *SecurityEvent) parseArgument() string {
 	if e.Argument == nil {
-		return fmt.Sprintf("%s", []byte(`{}`))
+		return "{}"
 	}
 	return fmt.Sprintf("%s", e.Argument)
 }

--- a/internal/database/security_event_logs_test.go
+++ b/internal/database/security_event_logs_test.go
@@ -92,6 +92,7 @@ func filterAudit(logs []logtest.CapturedLog) []logtest.CapturedLog {
 }
 
 func assertAuditField(t *testing.T, field map[string]any) {
+    t.Helper()
 	assert.NotEmpty(t, field["auditId"])
 	assert.NotEmpty(t, field["entity"])
 

--- a/internal/database/security_event_logs_test.go
+++ b/internal/database/security_event_logs_test.go
@@ -92,7 +92,7 @@ func filterAudit(logs []logtest.CapturedLog) []logtest.CapturedLog {
 }
 
 func assertAuditField(t *testing.T, field map[string]any) {
-    t.Helper()
+	t.Helper()
 	assert.NotEmpty(t, field["auditId"])
 	assert.NotEmpty(t, field["entity"])
 
@@ -103,7 +103,7 @@ func assertAuditField(t *testing.T, field map[string]any) {
 }
 
 func assertEventField(t *testing.T, field map[string]any) {
-    t.Helper()
+	t.Helper()
 	assert.NotEmpty(t, field["URL"])
 	assert.NotEmpty(t, field["source"])
 	assert.NotEmpty(t, field["argument"])

--- a/internal/database/security_event_logs_test.go
+++ b/internal/database/security_event_logs_test.go
@@ -102,6 +102,7 @@ func assertAuditField(t *testing.T, field map[string]any) {
 }
 
 func assertEventField(t *testing.T, field map[string]any) {
+    t.Helper()
 	assert.NotEmpty(t, field["URL"])
 	assert.NotEmpty(t, field["source"])
 	assert.NotEmpty(t, field["argument"])

--- a/internal/database/security_event_logs_test.go
+++ b/internal/database/security_event_logs_test.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/sourcegraph/log/logtest"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestSecurityEventLogs_ValidInfo(t *testing.T) {
@@ -17,7 +19,7 @@ func TestSecurityEventLogs_ValidInfo(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	logger := logtest.Scoped(t)
+	logger, exportLogs := logtest.Captured(t)
 	db := NewDB(logger, dbtest.NewDB(logger, t))
 	ctx := context.Background()
 
@@ -69,4 +71,70 @@ func TestSecurityEventLogs_ValidInfo(t *testing.T) {
 			assert.Equal(t, tc.err, got)
 		})
 	}
+
+	logs := exportLogs()
+	auditLogs := filterAudit(logs)
+	assert.Equal(t, 3, len(auditLogs))
+	for _, auditLog := range auditLogs {
+		assertAuditField(t, auditLog.Fields["audit"].(map[string]any))
+		assertEventField(t, auditLog.Fields["event"].(map[string]any))
+	}
+}
+
+func filterAudit(logs []logtest.CapturedLog) []logtest.CapturedLog {
+	var filtered []logtest.CapturedLog
+	for _, log := range logs {
+		if log.Fields["audit"] != nil {
+			filtered = append(filtered, log)
+		}
+	}
+	return filtered
+}
+
+func assertAuditField(t *testing.T, field map[string]any) {
+	assert.NotEmpty(t, field["auditId"])
+	assert.NotEmpty(t, field["entity"])
+
+	actorField := field["actor"].(map[string]any)
+	assert.NotEmpty(t, actorField["actorUID"])
+	assert.NotEmpty(t, actorField["ip"])
+	assert.NotEmpty(t, actorField["X-Forwarded-For"])
+}
+
+func assertEventField(t *testing.T, field map[string]any) {
+	assert.NotEmpty(t, field["URL"])
+	assert.NotEmpty(t, field["source"])
+	assert.NotEmpty(t, field["argument"])
+	assert.NotEmpty(t, field["version"])
+	assert.NotEmpty(t, field["timestamp"])
+}
+
+func TestSecurityEventLogs_WithAuditLogDisabled(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	conf.Mock(
+		&conf.Unified{
+			SiteConfiguration: schema.SiteConfiguration{
+				Log: &schema.Log{
+					AuditLog: &schema.AuditLog{
+						SecurityEvents: false,
+					},
+				},
+			},
+		},
+	)
+	defer conf.Mock(nil)
+
+	logger, exportLogs := logtest.Captured(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := context.Background()
+
+	err := db.SecurityEventLogs().Insert(ctx, &SecurityEvent{Name: "test_event", URL: "http://sourcegraph.com", Source: "Web", UserID: 1, AnonymousUserID: ""})
+	assert.Nilf(t, err, "insert failed")
+
+	logs := exportLogs()
+	auditLogs := filterAudit(logs)
+	assert.Equal(t, 0, len(auditLogs))
 }

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -1661,9 +1661,7 @@ func testUserAddedRepos(store repos.Store) func(*testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		ctx = actor.WithActor(ctx, &actor.Actor{
-			UID: userID,
-		})
+		ctx = actor.WithInternalActor(ctx)
 
 		userService := &types.ExternalService{
 			Kind:            extsvc.KindGitHub,

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/log/logtest"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/repos/webhookworker"
@@ -1660,6 +1661,9 @@ func testUserAddedRepos(store repos.Store) func(*testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		ctx = actor.WithActor(ctx, &actor.Actor{
+			UID: userID,
+		})
 
 		userService := &types.ExternalService{
 			Kind:            extsvc.KindGitHub,


### PR DESCRIPTION
## Description

Security events will be included in the audit log  **by default**.

Further details in [RFC 734](https://docs.google.com/document/d/1tv1wNxfqtg4qfJ6jhbd9rFMIt1JCEjGEFzvV5j_i-sI/edit#heading=h.trqab8y0kufp).

### Implementation details

I made calls to `audit.Log` from the `SecurityEventLogsStore`. I wasn’t 100% sure if this is pure enough (e.g., if we needed to consider some kind of service layer delegating to the store), but we [do regularly call `sourcegraph/log`](https://sourcegraph.sourcegraph.com/search?q=context%3Aglobal+repo%3A%5Egithub%5C.com%2Fsourcegraph%2Fsourcegraph%24+file%3AStore+lang%3AGo+sourcegraph%2Flog+and+Logger&patternType=standard&groupBy=path) from the stores, which is the basis for the audit log anyway.

### :warning: Major change

Security events will be enabled by default on all environments. We originally wanted them on .com only (because we expected huge volumes of data from the multi-tenant cloud). Since single-tenancy is the new default, having them everywhere is beneficial. This was discussed in [RFC 734](https://docs.google.com/document/d/1tv1wNxfqtg4qfJ6jhbd9rFMIt1JCEjGEFzvV5j_i-sI/edit#heading=h.trqab8y0kufp) and [RFC 732](https://docs.google.com/document/d/1tv1wNxfqtg4qfJ6jhbd9rFMIt1JCEjGEFzvV5j_i-sI/edit#)

### Enabling the audit log for security events

They’re [enabled by default](https://sourcegraph.sourcegraph.com/-/editor?remote_url=https%3A%2F%2Fgithub.com%2Fsourcegraph%2Fsourcegraph.git&branch=mv%2Fauditlog%2Fsecurity-events&file=internal%2Fdatabase%2Fsecurity_event_logs.go&start_row=145&start_col=14&end_row=145&end_col=14&editor=JetBrains&version=v2.0.1), but can be tweaked in the site config:

```
  “log”: {
    “auditLog”: {
      “securityEvents”: true,
      “graphQL”: true,
      “gitserverAccess”: false
    }
  }
```

### Sample audit logs

```
{
  “SeverityText”: “INFO”,
  “Timestamp”: 1665061820174215000,
  “InstrumentationScope”: “server.SecurityEvents”,
  “Caller”: “audit/audit.go:33",
  “Function”: “github.com/sourcegraph/sourcegraph/internal/audit.Log”,
  “Body”: “PasswordChanged (sampling immunity token: 17edbf05-9992-46c7-be44-206b3aa2cc6a)“,
  “Resource”: {
    “service.name”: “frontend”,
    “service.version”: “0.0.0+dev”,
    “service.instance.id”: “Michals-MacBook-Pro-2.local”
  },
  “Attributes”: {
    “audit”: {
      “auditId”: “17edbf05-9992-46c7-be44-206b3aa2cc6a”,
      “entity”: “security events”,
      “actor”: {
        “actorUID”: “714b75b1-8abd-4379-9278-1a6ad50d12ce”,
        “ip”: “127.0.0.1",
        “X-Forwarded-For”: “127.0.0.1, 127.0.0.1"
      }
    },
    “event”: {
      “URL”: “/-/reset-password-code”,
      “source”: “BACKEND”,
      “argument”: “{\“requester\“:0}“,
      “version”: “0.0.0+dev”,
      “timestamp”: “2022-10-06 13:10:20.171337 +0000 UTC”
    }
  }
}
```

## Test plan

- [Automated tests](https://sourcegraph.sourcegraph.com/-/editor?remote_url=https%3A%2F%2Fgithub.com%2Fsourcegraph%2Fsourcegraph.git&branch=mv%2Fauditlog%2Fsecurity-events&file=internal%2Fdatabase%2Fsecurity_event_logs_test.go&start_row=77&start_col=9&end_row=77&end_col=9&editor=JetBrains&version=v2.0.1)
- Manual exploratory testing