### PR TITLE
codeintel: Unexport unused service methods

### DIFF
--- a/internal/codeintel/autoindexing/dependency_indexing_scheduler.go
+++ b/internal/codeintel/autoindexing/dependency_indexing_scheduler.go
@@ -9,6 +9,7 @@ import (
 	"time"
 	"unsafe"
 
+	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -18,6 +19,7 @@ import (
 	codeinteltypes "github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
@@ -41,7 +43,7 @@ func (s *Service) NewDependencyIndexingScheduler(pollInterval time.Duration, num
 		repoStore:          s.repoStore,
 		extsvcStore:        s.externalServiceStore,
 		gitserverRepoStore: s.gitserverRepoStore,
-		indexEnqueuer:      s,
+		indexEnqueuer:      &AutoIndexingServiceForDepSchedulingShim{s},
 		workerStore:        s.dependencyIndexingStore,
 		repoUpdater:        s.repoUpdater,
 	}
@@ -53,6 +55,51 @@ func (s *Service) NewDependencyIndexingScheduler(pollInterval time.Duration, num
 		Metrics:           s.depencencyIndexMetrics,
 		HeartbeatInterval: 1 * time.Second,
 	})
+}
+
+// QueueIndexesForPackage enqueues index jobs for a dependency of a recently-processed precise code
+// intelligence index.
+func (s *Service) queueIndexesForPackage(ctx context.Context, pkg precise.Package) (err error) {
+	ctx, trace, endObservation := s.operations.queueIndexForPackage.With(ctx, &err, observation.Args{
+		LogFields: []otlog.Field{
+			otlog.String("scheme", pkg.Scheme),
+			otlog.String("name", pkg.Name),
+			otlog.String("version", pkg.Version),
+		},
+	})
+	defer endObservation(1, observation.Args{})
+
+	repoName, revision, ok := InferRepositoryAndRevision(pkg)
+	if !ok {
+		return nil
+	}
+	trace.Log(otlog.String("repoName", string(repoName)))
+	trace.Log(otlog.String("revision", revision))
+
+	resp, err := s.repoUpdater.EnqueueRepoUpdate(ctx, repoName)
+	if err != nil {
+		if errcode.IsNotFound(err) {
+			return nil
+		}
+
+		return errors.Wrap(err, "repoUpdater.EnqueueRepoUpdate")
+	}
+
+	commit, err := s.gitserverClient.ResolveRevision(ctx, int(resp.ID), revision)
+	if err != nil {
+		if errcode.IsNotFound(err) {
+			return nil
+		}
+
+		return errors.Wrap(err, "gitserverClient.ResolveRevision")
+	}
+
+	_, err = s.queueIndexForRepositoryAndCommit(ctx, int(resp.ID), string(commit), "", false, false, nil) // trace)
+	return err
+}
+
+func (s *Service) insertDependencyIndexingJob(ctx context.Context, uploadID int, externalServiceKind string, syncTime time.Time) (id int, err error) {
+	return s.store.InsertDependencyIndexingJob(ctx, uploadID, externalServiceKind, syncTime)
 }
 
 type dependencyIndexingSchedulerHandler struct {

--- a/internal/codeintel/autoindexing/dependency_sync_scheduler.go
+++ b/internal/codeintel/autoindexing/dependency_sync_scheduler.go
@@ -42,7 +42,7 @@ func (s *Service) NewDependencySyncScheduler(pollInterval time.Duration) *worker
 	handler := &dependencySyncSchedulerHandler{
 		uploadsSvc:      s.uploadSvc,
 		depsSvc:         s.depsSvc,
-		autoindexingSvc: s,
+		autoindexingSvc: &AutoIndexingServiceForDepSchedulingShim{s},
 		workerStore:     workerStore,
 		extsvcStore:     s.externalServiceStore,
 	}

--- a/internal/codeintel/autoindexing/iface.go
+++ b/internal/codeintel/autoindexing/iface.go
@@ -42,3 +42,15 @@ type AutoIndexingServiceForDepScheduling interface {
 type PolicyMatcher interface {
 	CommitsDescribedByPolicyInternal(ctx context.Context, repositoryID int, policies []codeinteltypes.ConfigurationPolicy, now time.Time, filterCommits ...string) (map[string][]policies.PolicyMatch, error)
 }
+
+type AutoIndexingServiceForDepSchedulingShim struct {
+	*Service
+}
+
+func (s *AutoIndexingServiceForDepSchedulingShim) QueueIndexesForPackage(ctx context.Context, pkg precise.Package) error {
+	return s.Service.queueIndexesForPackage(ctx, pkg)
+}
+
+func (s *AutoIndexingServiceForDepSchedulingShim) InsertDependencyIndexingJob(ctx context.Context, uploadID int, externalServiceKind string, syncTime time.Time) (id int, err error) {
+	return s.Service.insertDependencyIndexingJob(ctx, uploadID, externalServiceKind, syncTime)
+}

--- a/internal/codeintel/autoindexing/internal/store/store.go
+++ b/internal/codeintel/autoindexing/internal/store/store.go
@@ -47,8 +47,6 @@ type Store interface {
 	GetLanguagesRequestedBy(ctx context.Context, userID int) (_ []string, err error)
 	SetRequestLanguageSupport(ctx context.Context, userID int, language string) (err error)
 
-	// GetUnsafeDB returns the underlying database handle. This is used by the
-	// resolvers that have the old convention of using the database handle directly.
 	GetUnsafeDB() database.DB
 
 	WorkerutilStore(observationContext *observation.Context) dbworkerstore.Store

--- a/internal/codeintel/autoindexing/observability.go
+++ b/internal/codeintel/autoindexing/observability.go
@@ -10,30 +10,21 @@ import (
 )
 
 type operations struct {
-	// Commits
-	getStaleSourcedCommits *observation.Operation
-	updateSourcedCommits   *observation.Operation
-	deleteSourcedCommits   *observation.Operation
-
 	// Indexes
-	getIndexes                     *observation.Operation
-	getIndexByID                   *observation.Operation
-	getIndexesByIDs                *observation.Operation
-	getRecentIndexesSummary        *observation.Operation
-	getLastIndexScanForRepository  *observation.Operation
-	deleteIndexByID                *observation.Operation
-	deleteIndexesWithoutRepository *observation.Operation
-	queueRepoRev                   *observation.Operation
-	queueIndex                     *observation.Operation
-	queueIndexForPackage           *observation.Operation
+	getIndexes                    *observation.Operation
+	getIndexByID                  *observation.Operation
+	getIndexesByIDs               *observation.Operation
+	getRecentIndexesSummary       *observation.Operation
+	getLastIndexScanForRepository *observation.Operation
+	deleteIndexByID               *observation.Operation
+	queueRepoRev                  *observation.Operation
+	queueIndex                    *observation.Operation
+	queueIndexForPackage          *observation.Operation
 
 	// Index Configuration
 	getIndexConfigurationByRepositoryID    *observation.Operation
 	updateIndexConfigurationByRepositoryID *observation.Operation
 	inferIndexConfiguration                *observation.Operation
-
-	// Auth
-	checkCurrentUserIsSiteAdmin *observation.Operation
 
 	// Tags
 	getListTags *observation.Operation
@@ -42,8 +33,7 @@ type operations struct {
 	getLanguagesRequestedBy   *observation.Operation
 	setRequestLanguageSupport *observation.Operation
 
-	insertDependencyIndexingJob *observation.Operation
-	handleIndexScheduler        *observation.Operation
+	handleIndexScheduler *observation.Operation
 }
 
 func newOperations(observationContext *observation.Context) *operations {
@@ -75,30 +65,21 @@ func newOperations(observationContext *observation.Context) *operations {
 	})
 
 	return &operations{
-		// Commits
-		getStaleSourcedCommits: op("GetStaleSourcedCommits"),
-		updateSourcedCommits:   op("UpdateSourcedCommits"),
-		deleteSourcedCommits:   op("DeleteSourcedCommits"),
-
 		// Indexes
-		getIndexes:                     op("GetIndexes"),
-		getIndexByID:                   op("GetIndexByID"),
-		getIndexesByIDs:                op("GetIndexesByIDs"),
-		getRecentIndexesSummary:        op("GetRecentIndexesSummary"),
-		getLastIndexScanForRepository:  op("GetLastIndexScanForRepository"),
-		deleteIndexByID:                op("DeleteIndexByID"),
-		deleteIndexesWithoutRepository: op("DeleteIndexesWithoutRepository"),
-		queueRepoRev:                   op("QueueRepoRev"),
-		queueIndex:                     op("QueueIndex"),
-		queueIndexForPackage:           op("QueueIndexForPackage"),
+		getIndexes:                    op("GetIndexes"),
+		getIndexByID:                  op("GetIndexByID"),
+		getIndexesByIDs:               op("GetIndexesByIDs"),
+		getRecentIndexesSummary:       op("GetRecentIndexesSummary"),
+		getLastIndexScanForRepository: op("GetLastIndexScanForRepository"),
+		deleteIndexByID:               op("DeleteIndexByID"),
+		queueRepoRev:                  op("QueueRepoRev"),
+		queueIndex:                    op("QueueIndex"),
+		queueIndexForPackage:          op("QueueIndexForPackage"),
 
 		// Index Configuration
 		getIndexConfigurationByRepositoryID:    op("GetIndexConfigurationByRepositoryID"),
 		updateIndexConfigurationByRepositoryID: op("UpdateIndexConfigurationByRepositoryID"),
 		inferIndexConfiguration:                op("InferIndexConfiguration"),
-
-		// Auth
-		checkCurrentUserIsSiteAdmin: op("CheckCurrentUserIsSiteAdmin"),
 
 		// Tags
 		getListTags: op("GetListTags"),
@@ -107,7 +88,6 @@ func newOperations(observationContext *observation.Context) *operations {
 		getLanguagesRequestedBy:   op("GetLanguagesRequestedBy"),
 		setRequestLanguageSupport: op("SetRequestLanguageSupport"),
 
-		insertDependencyIndexingJob: op("InsertDependencyIndexingJob"),
-		handleIndexScheduler:        handleIndexScheduler,
+		handleIndexScheduler: handleIndexScheduler,
 	}
 }

--- a/internal/codeintel/autoindexing/service.go
+++ b/internal/codeintel/autoindexing/service.go
@@ -17,64 +17,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
-	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/symbols"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
-	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/autoindex/config"
-	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
-
-// var _ service = (*Service)(nil)
-
-// TODO - remove or re-sync with implementation
-type service interface {
-	// Commits
-	GetStaleSourcedCommits(ctx context.Context, minimumTimeSinceLastCheck time.Duration, limit int, now time.Time) (_ []shared.SourcedCommits, err error)
-	UpdateSourcedCommits(ctx context.Context, repositoryID int, commit string, now time.Time) (indexesUpdated int, err error)
-	DeleteSourcedCommits(ctx context.Context, repositoryID int, commit string, maximumCommitLag time.Duration, now time.Time) (indexesDeleted int, err error)
-
-	// Indexes
-	GetIndexes(ctx context.Context, opts types.GetIndexesOptions) (_ []types.Index, _ int, err error)
-	GetIndexByID(ctx context.Context, id int) (_ types.Index, _ bool, err error)
-	GetIndexesByIDs(ctx context.Context, ids ...int) (_ []types.Index, err error)
-	GetRecentIndexesSummary(ctx context.Context, repositoryID int) (summaries []shared.IndexesWithRepositoryNamespace, err error)
-	GetLastIndexScanForRepository(ctx context.Context, repositoryID int) (_ *time.Time, err error)
-	DeleteIndexByID(ctx context.Context, id int) (_ bool, err error)
-	DeleteIndexesWithoutRepository(ctx context.Context, now time.Time) (map[int]int, error)
-	QueueIndexes(ctx context.Context, repositoryID int, rev, configuration string, force, bypassLimit bool) (_ []types.Index, err error)
-	QueueIndexesForPackage(ctx context.Context, pkg precise.Package) (err error)
-
-	// Index configurations
-	GetIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int) (_ shared.IndexConfiguration, _ bool, err error)
-	InferIndexConfiguration(ctx context.Context, repositoryID int, commit string, bypassLimit bool) (_ *config.IndexConfiguration, hints []config.IndexJobHint, err error)
-	UpdateIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int, data []byte) (err error)
-
-	// Tags
-	GetListTags(ctx context.Context, repo api.RepoName, commitObjs ...string) (_ []*gitdomain.Tag, err error)
-
-	// Utilities
-	GetUnsafeDB() database.DB
-	WorkerutilStore() dbworkerstore.Store
-	DependencySyncStore() dbworkerstore.Store
-	DependencyIndexingStore() dbworkerstore.Store
-	NewIndexResetter(interval time.Duration) *dbworker.Resetter
-	NewDependencyIndexResetter(interval time.Duration) *dbworker.Resetter
-	InsertDependencyIndexingJob(ctx context.Context, uploadID int, externalServiceKind string, syncTime time.Time) (id int, err error)
-
-	ListFiles(ctx context.Context, repositoryID int, commit string, pattern *regexp.Regexp) ([]string, error)
-
-	// Symbols client
-	GetSupportedByCtags(ctx context.Context, filepath string, repoName api.RepoName) (bool, string, error)
-
-	// Language Support
-	GetLanguagesRequestedBy(ctx context.Context, userID int) (_ []string, err error)
-	SetRequestLanguageSupport(ctx context.Context, userID int, language string) (err error)
-}
 
 type Service struct {
 	store                   store.Store
@@ -142,13 +92,6 @@ func (s *Service) WorkerutilStore() dbworkerstore.Store         { return s.worke
 func (s *Service) DependencySyncStore() dbworkerstore.Store     { return s.dependencySyncStore }
 func (s *Service) DependencyIndexingStore() dbworkerstore.Store { return s.dependencyIndexingStore }
 
-func (s *Service) InsertDependencyIndexingJob(ctx context.Context, uploadID int, externalServiceKind string, syncTime time.Time) (id int, err error) {
-	ctx, _, endObservation := s.operations.insertDependencyIndexingJob.With(ctx, &err, observation.Args{})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.InsertDependencyIndexingJob(ctx, uploadID, externalServiceKind, syncTime)
-}
-
 func (s *Service) GetIndexes(ctx context.Context, opts types.GetIndexesOptions) (_ []types.Index, _ int, err error) {
 	ctx, _, endObservation := s.operations.getIndexes.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
@@ -191,33 +134,27 @@ func (s *Service) DeleteIndexByID(ctx context.Context, id int) (_ bool, err erro
 	return s.store.DeleteIndexByID(ctx, id)
 }
 
-func (s *Service) DeleteIndexesWithoutRepository(ctx context.Context, now time.Time) (_ map[int]int, err error) {
-	ctx, _, endObservation := s.operations.deleteIndexesWithoutRepository.With(ctx, &err, observation.Args{})
-	defer endObservation(1, observation.Args{})
+//
+// Used by upload janitor, we need our own version of that janitor
 
+func (s *Service) DeleteIndexesWithoutRepository(ctx context.Context, now time.Time) (_ map[int]int, err error) {
 	return s.store.DeleteIndexesWithoutRepository(ctx, now)
 }
 
 func (s *Service) GetStaleSourcedCommits(ctx context.Context, minimumTimeSinceLastCheck time.Duration, limit int, now time.Time) (_ []shared.SourcedCommits, err error) {
-	ctx, _, endObservation := s.operations.getStaleSourcedCommits.With(ctx, &err, observation.Args{})
-	defer endObservation(1, observation.Args{})
-
 	return s.store.GetStaleSourcedCommits(ctx, minimumTimeSinceLastCheck, limit, now)
 }
 
 func (s *Service) UpdateSourcedCommits(ctx context.Context, repositoryID int, commit string, now time.Time) (indexesUpdated int, err error) {
-	ctx, _, endObservation := s.operations.updateSourcedCommits.With(ctx, &err, observation.Args{})
-	defer endObservation(1, observation.Args{})
-
 	return s.store.UpdateSourcedCommits(ctx, repositoryID, commit, now)
 }
 
 func (s *Service) DeleteSourcedCommits(ctx context.Context, repositoryID int, commit string, maximumCommitLag time.Duration, now time.Time) (indexesDeleted int, err error) {
-	ctx, _, endObservation := s.operations.deleteSourcedCommits.With(ctx, &err, observation.Args{})
-	defer endObservation(1, observation.Args{})
-
 	return s.store.DeleteSourcedCommits(ctx, repositoryID, commit, maximumCommitLag)
 }
+
+//
+//
 
 func (s *Service) GetIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int) (_ shared.IndexConfiguration, _ bool, err error) {
 	ctx, _, endObservation := s.operations.getIndexConfigurationByRepositoryID.With(ctx, &err, observation.Args{})
@@ -344,37 +281,6 @@ func (s *Service) QueueRepoRev(ctx context.Context, repositoryID int, rev string
 	return s.store.QueueRepoRev(ctx, repositoryID, rev)
 }
 
-func (s *Service) ProcessRepoRevs(ctx context.Context, batchSize int) (err error) {
-	ctx, _, endObservation := s.operations.queueRepoRev.With(ctx, &err, observation.Args{
-		LogFields: []otlog.Field{
-			otlog.Int("batchSize", batchSize),
-		},
-	})
-	defer endObservation(1, observation.Args{})
-
-	tx, err := s.store.Transact(ctx)
-	if err != nil {
-		return err
-	}
-	defer func() { err = tx.Done(err) }()
-
-	repoRevs, err := tx.GetQueuedRepoRev(ctx, batchSize)
-	if err != nil {
-		return err
-	}
-
-	ids := make([]int, 0, len(repoRevs))
-	for _, repoRev := range repoRevs {
-		if _, err := s.QueueIndexes(ctx, repoRev.RepositoryID, repoRev.Rev, "", false, false); err != nil {
-			return err
-		}
-
-		ids = append(ids, repoRev.ID)
-	}
-
-	return tx.MarkRepoRevsAsProcessed(ctx, ids)
-}
-
 // QueueIndexes enqueues a set of index jobs for the following repository and commit. If a non-empty
 // configuration is given, it will be used to determine the set of jobs to enqueue. Otherwise, it will
 // the configuration will be determined based on the regular index scheduling rules: first read any
@@ -402,47 +308,6 @@ func (s *Service) QueueIndexes(ctx context.Context, repositoryID int, rev, confi
 	trace.Log(otlog.String("commit", commit))
 
 	return s.queueIndexForRepositoryAndCommit(ctx, repositoryID, commit, configuration, force, bypassLimit, nil) // trace)
-}
-
-// QueueIndexesForPackage enqueues index jobs for a dependency of a recently-processed precise code
-// intelligence index.
-func (s *Service) QueueIndexesForPackage(ctx context.Context, pkg precise.Package) (err error) {
-	ctx, trace, endObservation := s.operations.queueIndexForPackage.With(ctx, &err, observation.Args{
-		LogFields: []otlog.Field{
-			otlog.String("scheme", pkg.Scheme),
-			otlog.String("name", pkg.Name),
-			otlog.String("version", pkg.Version),
-		},
-	})
-	defer endObservation(1, observation.Args{})
-
-	repoName, revision, ok := InferRepositoryAndRevision(pkg)
-	if !ok {
-		return nil
-	}
-	trace.Log(otlog.String("repoName", string(repoName)))
-	trace.Log(otlog.String("revision", revision))
-
-	resp, err := s.repoUpdater.EnqueueRepoUpdate(ctx, repoName)
-	if err != nil {
-		if errcode.IsNotFound(err) {
-			return nil
-		}
-
-		return errors.Wrap(err, "repoUpdater.EnqueueRepoUpdate")
-	}
-
-	commit, err := s.gitserverClient.ResolveRevision(ctx, int(resp.ID), revision)
-	if err != nil {
-		if errcode.IsNotFound(err) {
-			return nil
-		}
-
-		return errors.Wrap(err, "gitserverClient.ResolveRevision")
-	}
-
-	_, err = s.queueIndexForRepositoryAndCommit(ctx, int(resp.ID), string(commit), "", false, false, nil) // trace)
-	return err
 }
 
 // queueIndexForRepositoryAndCommit determines a set of index jobs to enqueue for the given repository and commit.

--- a/internal/codeintel/autoindexing/service.go
+++ b/internal/codeintel/autoindexing/service.go
@@ -29,8 +29,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var _ service = (*Service)(nil)
+// var _ service = (*Service)(nil)
 
+// TODO - remove or re-sync with implementation
 type service interface {
 	// Commits
 	GetStaleSourcedCommits(ctx context.Context, minimumTimeSinceLastCheck time.Duration, limit int, now time.Time) (_ []shared.SourcedCommits, err error)

--- a/internal/codeintel/autoindexing/service_test.go
+++ b/internal/codeintel/autoindexing/service_test.go
@@ -504,7 +504,7 @@ func TestQueueIndexesForPackage(t *testing.T) {
 
 	scheduler := newService(mockDBStore, mockUploadSvc, nil, nil, nil, nil, nil, nil, mockGitserverClient, nil, mockRepoUpdater, inferenceService, &observation.TestContext)
 
-	_ = scheduler.QueueIndexesForPackage(context.Background(), precise.Package{
+	_ = scheduler.queueIndexesForPackage(context.Background(), precise.Package{
 		Scheme:  "gomod",
 		Name:    "https://github.com/sourcegraph/sourcegraph",
 		Version: "v3.26.0-4e7eeb0f8a96",

--- a/internal/codeintel/autoindexing/transport/graphql/iface.go
+++ b/internal/codeintel/autoindexing/transport/graphql/iface.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	uploadshared "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
-	"github.com/sourcegraph/sourcegraph/internal/database"
+	database "github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/autoindex/config"
 )

--- a/internal/codeintel/codenav/observability.go
+++ b/internal/codeintel/codenav/observability.go
@@ -12,20 +12,15 @@ import (
 )
 
 type operations struct {
-	getReferences                        *observation.Operation
-	getImplementations                   *observation.Operation
-	getDiagnostics                       *observation.Operation
-	getHover                             *observation.Operation
-	getDefinitions                       *observation.Operation
-	getRanges                            *observation.Operation
-	getStencil                           *observation.Operation
-	getMonikersByPosition                *observation.Operation
-	getBulkMonikerLocations              *observation.Operation
-	getPackageInformation                *observation.Operation
-	getUploadsWithDefinitionsForMonikers *observation.Operation
-	getUploadIDsWithReferences           *observation.Operation
-	getDumpsByIDs                        *observation.Operation
-	getClosestDumpsForBlob               *observation.Operation
+	getReferences          *observation.Operation
+	getImplementations     *observation.Operation
+	getDiagnostics         *observation.Operation
+	getHover               *observation.Operation
+	getDefinitions         *observation.Operation
+	getRanges              *observation.Operation
+	getStencil             *observation.Operation
+	getDumpsByIDs          *observation.Operation
+	getClosestDumpsForBlob *observation.Operation
 }
 
 func newOperations(observationContext *observation.Context) *operations {
@@ -45,20 +40,15 @@ func newOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
-		getReferences:                        op("getReferences"),
-		getImplementations:                   op("getImplementations"),
-		getDiagnostics:                       op("getDiagnostics"),
-		getHover:                             op("getHover"),
-		getDefinitions:                       op("getDefinitions"),
-		getRanges:                            op("getRanges"),
-		getStencil:                           op("getStencil"),
-		getMonikersByPosition:                op("GetMonikersByPosition"),
-		getBulkMonikerLocations:              op("GetBulkMonikerLocations"),
-		getPackageInformation:                op("GetPackageInformation"),
-		getUploadsWithDefinitionsForMonikers: op("GetUploadsWithDefinitionsForMonikers"),
-		getUploadIDsWithReferences:           op("GetUploadIDsWithReferences"),
-		getDumpsByIDs:                        op("GetDumpsByIDs"),
-		getClosestDumpsForBlob:               op("GetClosestDumpsForBlob"),
+		getReferences:          op("getReferences"),
+		getImplementations:     op("getImplementations"),
+		getDiagnostics:         op("getDiagnostics"),
+		getHover:               op("getHover"),
+		getDefinitions:         op("getDefinitions"),
+		getRanges:              op("getRanges"),
+		getStencil:             op("getStencil"),
+		getDumpsByIDs:          op("GetDumpsByIDs"),
+		getClosestDumpsForBlob: op("GetClosestDumpsForBlob"),
 	}
 }
 

--- a/internal/codeintel/codenav/observability.go
+++ b/internal/codeintel/codenav/observability.go
@@ -12,15 +12,20 @@ import (
 )
 
 type operations struct {
-	getReferences          *observation.Operation
-	getImplementations     *observation.Operation
-	getDiagnostics         *observation.Operation
-	getHover               *observation.Operation
-	getDefinitions         *observation.Operation
-	getRanges              *observation.Operation
-	getStencil             *observation.Operation
-	getDumpsByIDs          *observation.Operation
-	getClosestDumpsForBlob *observation.Operation
+	getReferences                        *observation.Operation
+	getImplementations                   *observation.Operation
+	getDiagnostics                       *observation.Operation
+	getHover                             *observation.Operation
+	getDefinitions                       *observation.Operation
+	getRanges                            *observation.Operation
+	getStencil                           *observation.Operation
+	getMonikersByPosition                *observation.Operation
+	getBulkMonikerLocations              *observation.Operation
+	getPackageInformation                *observation.Operation
+	getUploadsWithDefinitionsForMonikers *observation.Operation
+	getUploadIDsWithReferences           *observation.Operation
+	getDumpsByIDs                        *observation.Operation
+	getClosestDumpsForBlob               *observation.Operation
 }
 
 func newOperations(observationContext *observation.Context) *operations {
@@ -40,15 +45,20 @@ func newOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
-		getReferences:          op("getReferences"),
-		getImplementations:     op("getImplementations"),
-		getDiagnostics:         op("getDiagnostics"),
-		getHover:               op("getHover"),
-		getDefinitions:         op("getDefinitions"),
-		getRanges:              op("getRanges"),
-		getStencil:             op("getStencil"),
-		getDumpsByIDs:          op("GetDumpsByIDs"),
-		getClosestDumpsForBlob: op("GetClosestDumpsForBlob"),
+		getReferences:                        op("getReferences"),
+		getImplementations:                   op("getImplementations"),
+		getDiagnostics:                       op("getDiagnostics"),
+		getHover:                             op("getHover"),
+		getDefinitions:                       op("getDefinitions"),
+		getRanges:                            op("getRanges"),
+		getStencil:                           op("getStencil"),
+		getMonikersByPosition:                op("GetMonikersByPosition"),
+		getBulkMonikerLocations:              op("GetBulkMonikerLocations"),
+		getPackageInformation:                op("GetPackageInformation"),
+		getUploadsWithDefinitionsForMonikers: op("GetUploadsWithDefinitionsForMonikers"),
+		getUploadIDsWithReferences:           op("GetUploadIDsWithReferences"),
+		getDumpsByIDs:                        op("GetDumpsByIDs"),
+		getClosestDumpsForBlob:               op("GetClosestDumpsForBlob"),
 	}
 }
 

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -20,6 +20,31 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+var _ service = (*Service)(nil)
+
+type service interface {
+	GetDefinitions(ctx context.Context, args shared.RequestArgs, requestState RequestState) (_ []types.UploadLocation, err error)
+	GetDiagnostics(ctx context.Context, args shared.RequestArgs, requestState RequestState) (diagnosticsAtUploads []shared.DiagnosticAtUpload, _ int, err error)
+	GetHover(ctx context.Context, args shared.RequestArgs, requestState RequestState) (_ string, _ types.Range, _ bool, err error)
+	GetImplementations(ctx context.Context, args shared.RequestArgs, requestState RequestState, cursor shared.ImplementationsCursor) (_ []types.UploadLocation, nextCursor shared.ImplementationsCursor, err error)
+	GetRanges(ctx context.Context, args shared.RequestArgs, requestState RequestState, startLine, endLine int) (adjustedRanges []shared.AdjustedCodeIntelligenceRange, err error)
+	GetReferences(ctx context.Context, args shared.RequestArgs, requestState RequestState, cursor shared.ReferencesCursor) (_ []types.UploadLocation, nextCursor shared.ReferencesCursor, err error)
+	GetStencil(ctx context.Context, args shared.RequestArgs, requestState RequestState) (adjustedRanges []types.Range, err error)
+
+	GetMonikersByPosition(ctx context.Context, bundleID int, path string, line, character int) (_ [][]precise.MonikerData, err error)
+	GetBulkMonikerLocations(ctx context.Context, tableName string, uploadIDs []int, monikers []precise.MonikerData, limit, offset int) (_ []shared.Location, _ int, err error)
+	GetPackageInformation(ctx context.Context, bundleID int, path, packageInformationID string) (_ precise.PackageInformationData, _ bool, err error)
+	GetClosestDumpsForBlob(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []types.Dump, err error)
+
+	// Uploads Service
+	GetDumpsByIDs(ctx context.Context, ids []int) (_ []types.Dump, err error)
+	GetUploadsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) (_ []types.Dump, err error)
+	GetUploadIDsWithReferences(ctx context.Context, orderedMonikers []precise.QualifiedMonikerData, ignoreIDs []int, repositoryID int, commit string, limit int, offset int) (ids []int, recordsScanned int, totalCount int, err error)
+
+	// Utilities
+	GetUnsafeDB() database.DB
+}
+
 type Service struct {
 	store      store.Store
 	lsifstore  lsifstore.LsifStore
@@ -293,7 +318,7 @@ func (s *Service) GetReferences(ctx context.Context, args shared.RequestArgs, re
 // getUploadsWithDefinitionsForMonikers returns the set of uploads that provide any of the given monikers.
 // This method will not return uploads for commits which are unknown to gitserver.
 func (s *Service) getUploadsWithDefinitionsForMonikers(ctx context.Context, orderedMonikers []precise.QualifiedMonikerData, requestState RequestState) ([]types.Dump, error) {
-	uploads, err := s.uploadSvc.GetDumpsWithDefinitionsForMonikers(ctx, orderedMonikers)
+	uploads, err := s.GetUploadsWithDefinitionsForMonikers(ctx, orderedMonikers)
 	if err != nil {
 		return nil, errors.Wrap(err, "dbstore.DefinitionDumps")
 	}
@@ -315,7 +340,7 @@ func (r *Service) getOrderedMonikers(ctx context.Context, visibleUploads []visib
 	monikerSet := newQualifiedMonikerSet()
 
 	for i := range visibleUploads {
-		rangeMonikers, err := r.lsifstore.GetMonikersByPosition(
+		rangeMonikers, err := r.GetMonikersByPosition(
 			ctx,
 			visibleUploads[i].Upload.ID,
 			visibleUploads[i].TargetPathWithoutRoot,
@@ -332,7 +357,7 @@ func (r *Service) getOrderedMonikers(ctx context.Context, visibleUploads []visib
 					continue
 				}
 
-				packageInformationData, _, err := r.lsifstore.GetPackageInformation(
+				packageInformationData, _, err := r.GetPackageInformation(
 					ctx,
 					visibleUploads[i].Upload.ID,
 					visibleUploads[i].TargetPathWithoutRoot,
@@ -430,7 +455,7 @@ func (s *Service) getPageRemoteLocations(
 		}
 
 		// Find the next batch of indexes to perform a moniker search over
-		referenceUploadIDs, recordsScanned, totalRecords, err := s.uploadSvc.GetUploadIDsWithReferences(
+		referenceUploadIDs, recordsScanned, totalRecords, err := s.GetUploadIDsWithReferences(
 			ctx,
 			orderedMonikers,
 			ignoreIDs,
@@ -638,7 +663,7 @@ func (s *Service) getBulkMonikerLocations(ctx context.Context, uploads []types.D
 		args = append(args, moniker.MonikerData)
 	}
 
-	locations, totalCount, err := s.lsifstore.GetBulkMonikerLocations(ctx, tableName, ids, args, limit, offset)
+	locations, totalCount, err := s.GetBulkMonikerLocations(ctx, tableName, ids, args, limit, offset)
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "lsifStore.GetBulkMonikerLocations")
 	}
@@ -1123,11 +1148,66 @@ func (s *Service) GetStencil(ctx context.Context, args shared.RequestArgs, reque
 	return dedupeRanges(sortedRanges), nil
 }
 
+func (s *Service) GetMonikersByPosition(ctx context.Context, bundleID int, path string, line, character int) (_ [][]precise.MonikerData, err error) {
+	ctx, _, endObservation := s.operations.getMonikersByPosition.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	return s.lsifstore.GetMonikersByPosition(ctx, bundleID, path, line, character)
+}
+
+func (s *Service) GetBulkMonikerLocations(ctx context.Context, tableName string, uploadIDs []int, monikers []precise.MonikerData, limit, offset int) (_ []shared.Location, _ int, err error) {
+	ctx, _, endObservation := s.operations.getBulkMonikerLocations.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	return s.lsifstore.GetBulkMonikerLocations(ctx, tableName, uploadIDs, monikers, limit, offset)
+}
+
+func (s *Service) GetUploadsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) (_ []types.Dump, err error) {
+	ctx, _, endObservation := s.operations.getUploadsWithDefinitionsForMonikers.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	uploadDumps, err := s.uploadSvc.GetDumpsWithDefinitionsForMonikers(ctx, monikers)
+	if err != nil {
+		return nil, err
+	}
+	dumps := updateSvcDumpToSharedDump(uploadDumps)
+
+	return dumps, nil
+}
+
 func (s *Service) GetDumpsByIDs(ctx context.Context, ids []int) (_ []types.Dump, err error) {
 	ctx, _, endObservation := s.operations.getDumpsByIDs.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	return s.uploadSvc.GetDumpsByIDs(ctx, ids)
+	uploadDumps, err := s.uploadSvc.GetDumpsByIDs(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	dumps := updateSvcDumpToSharedDump(uploadDumps)
+
+	return dumps, nil
+}
+
+func (s *Service) GetUploadIDsWithReferences(
+	ctx context.Context,
+	orderedMonikers []precise.QualifiedMonikerData,
+	ignoreIDs []int,
+	repositoryID int,
+	commit string,
+	limit int,
+	offset int,
+) (ids []int, recordsScanned int, totalCount int, err error) {
+	ctx, _, endObservation := s.operations.getUploadIDsWithReferences.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	return s.uploadSvc.GetUploadIDsWithReferences(ctx, orderedMonikers, ignoreIDs, repositoryID, commit, limit, offset)
+}
+
+func (s *Service) GetPackageInformation(ctx context.Context, bundleID int, path, packageInformationID string) (_ precise.PackageInformationData, _ bool, err error) {
+	ctx, _, endObservation := s.operations.getPackageInformation.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	return s.lsifstore.GetPackageInformation(ctx, bundleID, path, packageInformationID)
 }
 
 func (s *Service) GetClosestDumpsForBlob(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []types.Dump, err error) {
@@ -1146,15 +1226,17 @@ func (s *Service) GetClosestDumpsForBlob(ctx context.Context, repositoryID int, 
 	if err != nil {
 		return nil, err
 	}
+
+	uploadCandidates := updateSvcDumpToSharedDump(candidates)
 	trace.Log(
 		traceLog.Int("numCandidates", len(candidates)),
-		traceLog.String("candidates", uploadIDsToString(candidates)),
+		traceLog.String("candidates", uploadIDsToString(uploadCandidates)),
 	)
 
 	commitChecker := NewCommitCache(s.gitserver)
 	commitChecker.SetResolvableCommit(repositoryID, commit)
 
-	candidatesWithCommits, err := filterUploadsWithCommits(ctx, commitChecker, candidates)
+	candidatesWithCommits, err := filterUploadsWithCommits(ctx, commitChecker, uploadCandidates)
 	if err != nil {
 		return nil, err
 	}
@@ -1180,7 +1262,7 @@ func (s *Service) GetClosestDumpsForBlob(ctx context.Context, repositoryID int, 
 			// TODO(efritz) - ensure there's a valid document path for this condition as well
 		}
 
-		filtered = append(filtered, candidates[i])
+		filtered = append(filtered, uploadCandidates[i])
 	}
 	trace.Log(
 		traceLog.Int("numFiltered", len(filtered)),

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -20,8 +20,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var _ service = (*Service)(nil)
+// var _ service = (*Service)(nil)
 
+// TODO - remove or re-sync with implementation
 type service interface {
 	GetDefinitions(ctx context.Context, args shared.RequestArgs, requestState RequestState) (_ []types.UploadLocation, err error)
 	GetDiagnostics(ctx context.Context, args shared.RequestArgs, requestState RequestState) (diagnosticsAtUploads []shared.DiagnosticAtUpload, _ int, err error)

--- a/internal/codeintel/codenav/service_definitions_test.go
+++ b/internal/codeintel/codenav/service_definitions_test.go
@@ -215,7 +215,7 @@ func TestDefinitionsRemote(t *testing.T) {
 		Line:         10,
 		Character:    20,
 	}
-	remoteUploads := updateSvcDumpToSharedDump(dumps)
+	remoteUploads := dumps
 	adjustedLocations, err := svc.GetDefinitions(context.Background(), mockRequest, mockRequestState)
 	if err != nil {
 		t.Fatalf("unexpected error querying definitions: %s", err)

--- a/internal/codeintel/policies/observability.go
+++ b/internal/codeintel/policies/observability.go
@@ -8,10 +8,6 @@ import (
 )
 
 type operations struct {
-	// Not used yet.
-	commitsMatchingIndexingPolicies  *observation.Operation
-	commitsMatchingRetentionPolicies *observation.Operation
-
 	// Configurations
 	getConfigurationPolicies      *observation.Operation
 	getConfigurationPoliciesByID  *observation.Operation
@@ -46,10 +42,6 @@ func newOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
-		// Not used yet.
-		commitsMatchingIndexingPolicies:  op("CommitsMatchingIndexingPolicies"),
-		commitsMatchingRetentionPolicies: op("CommitsMatchingRetentionPolicies"),
-
 		// Configurations
 		getConfigurationPolicies:      op("GetConfigurationPolicies"),
 		getConfigurationPoliciesByID:  op("GetConfigurationPoliciesByID"),

--- a/internal/codeintel/policies/repomatcher.go
+++ b/internal/codeintel/policies/repomatcher.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
-	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 func (s *Service) NewRepositoryMatcher(interval time.Duration, configurationPolicyMembershipBatchSize int) goroutine.BackgroundRoutine {
@@ -17,7 +15,7 @@ func (s *Service) NewRepositoryMatcher(interval time.Duration, configurationPoli
 }
 
 func (s *Service) handleRepositoryMatcherBatch(ctx context.Context, batchSize int) error {
-	policies, err := s.SelectPoliciesForRepositoryMembershipUpdate(ctx, batchSize)
+	policies, err := s.store.SelectPoliciesForRepositoryMembershipUpdate(ctx, batchSize)
 	if err != nil {
 		return err
 	}
@@ -36,7 +34,7 @@ func (s *Service) handleRepositoryMatcherBatch(ctx context.Context, batchSize in
 		// Always call this even if patterns are not supplied. Otherwise we run into the
 		// situation where we have deleted all of the patterns associated with a policy
 		// but it still has entries in the lookup table.
-		if err := s.UpdateReposMatchingPatterns(ctx, patterns, policy.ID, repositoryMatchLimit); err != nil {
+		if err := s.store.UpdateReposMatchingPatterns(ctx, patterns, policy.ID, repositoryMatchLimit); err != nil {
 			return err
 		}
 
@@ -44,23 +42,4 @@ func (s *Service) handleRepositoryMatcherBatch(ctx context.Context, batchSize in
 	}
 
 	return nil
-}
-
-func (s *Service) SelectPoliciesForRepositoryMembershipUpdate(ctx context.Context, batchSize int) (configurationPolicies []types.ConfigurationPolicy, err error) {
-	ctx, _, endObservation := s.operations.selectPoliciesForRepositoryMembershipUpdate.With(ctx, &err, observation.Args{})
-	defer endObservation(1, observation.Args{})
-
-	configurationPolicies, err = s.store.SelectPoliciesForRepositoryMembershipUpdate(ctx, batchSize)
-	if err != nil {
-		return nil, err
-	}
-
-	return configurationPolicies, nil
-}
-
-func (s *Service) UpdateReposMatchingPatterns(ctx context.Context, patterns []string, policyID int, repositoryMatchLimit *int) (err error) {
-	ctx, _, endObservation := s.operations.updateReposMatchingPatterns.With(ctx, &err, observation.Args{})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.UpdateReposMatchingPatterns(ctx, patterns, policyID, repositoryMatchLimit)
 }

--- a/internal/codeintel/policies/service.go
+++ b/internal/codeintel/policies/service.go
@@ -15,31 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// var _ service = (*Service)(nil)
-
-// TODO - remove or re-sync with implementation
-type service interface {
-	// Configurations
-	GetConfigurationPolicies(ctx context.Context, opts types.GetConfigurationPoliciesOptions) ([]types.ConfigurationPolicy, int, error)
-	GetConfigurationPolicyByID(ctx context.Context, id int) (_ types.ConfigurationPolicy, _ bool, err error)
-	CreateConfigurationPolicy(ctx context.Context, configurationPolicy types.ConfigurationPolicy) (types.ConfigurationPolicy, error)
-	UpdateConfigurationPolicy(ctx context.Context, policy types.ConfigurationPolicy) (err error)
-	DeleteConfigurationPolicyByID(ctx context.Context, id int) (err error)
-
-	// Retention Policy
-	GetRetentionPolicyOverview(ctx context.Context, upload types.Upload, matchesOnly bool, first int, after int64, query string, now time.Time) (matches []types.RetentionPolicyMatchCandidate, totalCount int, err error)
-
-	// Repository
-	GetPreviewRepositoryFilter(ctx context.Context, patterns []string, limit, offset int) (_ []int, totalCount int, repositoryMatchLimit *int, _ error)
-	GetPreviewGitObjectFilter(ctx context.Context, repositoryID int, gitObjectType types.GitObjectType, pattern string) (map[string][]string, error)
-	SelectPoliciesForRepositoryMembershipUpdate(ctx context.Context, batchSize int) (configurationPolicies []types.ConfigurationPolicy, err error)
-	UpdateReposMatchingPatterns(ctx context.Context, patterns []string, policyID int, repositoryMatchLimit *int) (err error)
-
-	// GetUnsafeDB returns the underlying database handle. This is used by the
-	// resolvers that have the old convention of using the database handle directly.
-	GetUnsafeDB() database.DB
-}
-
 type Service struct {
 	store          store.Store
 	uploadSvc      UploadService
@@ -329,10 +304,12 @@ func policyByID(policies []types.ConfigurationPolicy, id int) *types.Configurati
 	if id == -1 {
 		return nil
 	}
+
 	for _, policy := range policies {
 		if policy.ID == id {
 			return &policy
 		}
 	}
+
 	return nil
 }

--- a/internal/codeintel/policies/service.go
+++ b/internal/codeintel/policies/service.go
@@ -15,8 +15,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var _ service = (*Service)(nil)
+// var _ service = (*Service)(nil)
 
+// TODO - remove or re-sync with implementation
 type service interface {
 	// Configurations
 	GetConfigurationPolicies(ctx context.Context, opts types.GetConfigurationPoliciesOptions) ([]types.ConfigurationPolicy, int, error)

--- a/internal/codeintel/uploads/backfill.go
+++ b/internal/codeintel/uploads/backfill.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/opentracing/opentracing-go/log"
-
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
-	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -21,11 +18,6 @@ func (s *Service) NewCommittedAtBackfiller(interval time.Duration, batchSize int
 // this value set. This method is used to backfill old upload records prior to this value being reliably set
 // during processing.
 func (s *Service) backfillCommittedAtBatch(ctx context.Context, batchSize int) (err error) {
-	ctx, _, endObservation := s.operations.backfillCommittedAtBatch.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.Int("batchSize", batchSize),
-	}})
-	defer endObservation(1, observation.Args{})
-
 	tx, err := s.store.Transact(ctx)
 	defer func() {
 		err = tx.Done(err)

--- a/internal/codeintel/uploads/expirer.go
+++ b/internal/codeintel/uploads/expirer.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"time"
 
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/log"
 
 	policiesEnterprise "github.com/sourcegraph/sourcegraph/internal/codeintel/policies/enterprise"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
-	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -57,7 +55,7 @@ func (e *Service) handleExpiredUploadsBatch(ctx context.Context, cfg expirerConf
 	// the backlog. Note that this set of repositories require a fresh commit graph, so we're not trying to
 	// process records that have been uploaded but the commits from which they are visible have yet to be
 	// determined (and appearing as if they are visible to no commit).
-	repositories, err := e.SetRepositoriesForRetentionScan(ctx, cfg.repositoryProcessDelay, cfg.repositoryBatchSize)
+	repositories, err := e.store.SetRepositoriesForRetentionScan(ctx, cfg.repositoryProcessDelay, cfg.repositoryBatchSize)
 	if err != nil {
 		return errors.Wrap(err, "uploadSvc.SelectRepositoriesForRetentionScan")
 	}
@@ -79,18 +77,6 @@ func (e *Service) handleExpiredUploadsBatch(ctx context.Context, cfg expirerConf
 	}
 
 	return err
-}
-
-func (s *Service) SetRepositoriesForRetentionScan(ctx context.Context, processDelay time.Duration, limit int) (_ []int, err error) {
-	ctx, _, endObservation := s.operations.setRepositoriesForRetentionScan.With(ctx, &err, observation.Args{
-		LogFields: []otlog.Field{
-			otlog.Int("processDelay in ms", int(processDelay.Milliseconds())),
-			otlog.Int("limit", limit),
-		},
-	})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.SetRepositoriesForRetentionScan(ctx, processDelay, limit)
 }
 
 func (e *Service) handleRepository(ctx context.Context, repositoryID int, cfg expirerConfig, now time.Time) error {
@@ -219,7 +205,7 @@ func (e *Service) handleUploads(
 	// records with the given expired identifiers so that the expiredUploadDeleter process can remove then once
 	// they are no longer referenced.
 
-	if updateErr := e.UpdateUploadRetention(ctx, protectedUploadIDs, expiredUploadIDs); updateErr != nil {
+	if updateErr := e.store.UpdateUploadRetention(ctx, protectedUploadIDs, expiredUploadIDs); updateErr != nil {
 		if updateErr := errors.Wrap(err, "uploadSvc.UpdateUploadRetention"); err == nil {
 			err = updateErr
 		} else {

--- a/internal/codeintel/uploads/metrics.go
+++ b/internal/codeintel/uploads/metrics.go
@@ -60,7 +60,7 @@ func (s *Service) MetricReporters(observationContext *observation.Context) {
 		Name: "src_codeintel_commit_graph_total",
 		Help: "Total number of repositories with stale commit graphs.",
 	}, func() float64 {
-		dirtyRepositories, err := s.GetDirtyRepositories(context.Background())
+		dirtyRepositories, err := s.store.GetDirtyRepositories(context.Background())
 		if err != nil {
 			observationContext.Logger.Error("Failed to determine number of dirty repositories", log.Error(err))
 		}
@@ -72,7 +72,7 @@ func (s *Service) MetricReporters(observationContext *observation.Context) {
 		Name: "src_codeintel_commit_graph_queued_duration_seconds_total",
 		Help: "The maximum amount of time a repository has had a stale commit graph.",
 	}, func() float64 {
-		age, err := s.GetRepositoriesMaxStaleAge(context.Background())
+		age, err := s.store.GetRepositoriesMaxStaleAge(context.Background())
 		if err != nil {
 			observationContext.Logger.Error("Failed to determine stale commit graph age", log.Error(err))
 			return 0

--- a/internal/codeintel/uploads/observability.go
+++ b/internal/codeintel/uploads/observability.go
@@ -12,23 +12,15 @@ import (
 
 type operations struct {
 	// Commits
-	getOldestCommitDate       *observation.Operation
 	getCommitsVisibleToUpload *observation.Operation
-	getStaleSourcedCommits    *observation.Operation
 	getCommitGraphMetadata    *observation.Operation
-	updateSourcedCommits      *observation.Operation
-	deleteSourcedCommits      *observation.Operation
 
 	// Repositories
 	getRepoName                             *observation.Operation
 	getRepositoriesForIndexScan             *observation.Operation
-	getRepositoriesMaxStaleAge              *observation.Operation
 	getDirtyRepositories                    *observation.Operation
 	getRecentUploadsSummary                 *observation.Operation
 	getLastUploadRetentionScanForRepository *observation.Operation
-	setRepositoryAsDirty                    *observation.Operation
-	updateDirtyRepositories                 *observation.Operation
-	setRepositoriesForRetentionScan         *observation.Operation
 
 	// Uploads
 	getUploads                        *observation.Operation
@@ -37,33 +29,18 @@ type operations struct {
 	getVisibleUploadsMatchingMonikers *observation.Operation
 	getUploadDocumentsForPath         *observation.Operation
 	updateUploadsVisibleToCommits     *observation.Operation
-	updateUploadRetention             *observation.Operation
-	backfillReferenceCountBatch       *observation.Operation
-	updateUploadsReferenceCounts      *observation.Operation
-	softDeleteExpiredUploads          *observation.Operation
-	deleteUploadsWithoutRepository    *observation.Operation
-	deleteUploadsStuckUploading       *observation.Operation
-	hardDeleteUploads                 *observation.Operation
 	deleteUploadByID                  *observation.Operation
 	inferClosestUploads               *observation.Operation
-	backfillCommittedAtBatch          *observation.Operation
 
 	// Dumps
-	findClosestDumps                   *observation.Operation
-	findClosestDumpsFromGraphFragment  *observation.Operation
 	getDumpsWithDefinitionsForMonikers *observation.Operation
 	getDumpsByIDs                      *observation.Operation
 
-	// Packages
-	updatePackages *observation.Operation
-
 	// References
-	updatePackageReferences *observation.Operation
-	referencesForUpload     *observation.Operation
+	referencesForUpload *observation.Operation
 
 	// Audit Logs
 	getAuditLogsForUpload *observation.Operation
-	deleteOldAuditLogs    *observation.Operation
 
 	// Tags
 	getListTags *observation.Operation
@@ -106,23 +83,15 @@ func newOperations(observationContext *observation.Context) *operations {
 
 	return &operations{
 		// Commits
-		getOldestCommitDate:       op("GetOldestCommitDate"),
 		getCommitsVisibleToUpload: op("GetCommitsVisibleToUpload"),
-		getStaleSourcedCommits:    op("GetStaleSourcedCommits"),
 		getCommitGraphMetadata:    op("GetCommitGraphMetadata"),
-		updateSourcedCommits:      op("UpdateSourcedCommits"),
-		deleteSourcedCommits:      op("DeleteSourcedCommits"),
 
 		// Repositories
 		getRepoName:                             op("GetRepoName"),
 		getRepositoriesForIndexScan:             op("GetRepositoriesForIndexScan"),
-		getRepositoriesMaxStaleAge:              op("GetRepositoriesMaxStaleAge"),
 		getDirtyRepositories:                    op("GetDirtyRepositories"),
 		getRecentUploadsSummary:                 op("GetRecentUploadsSummary"),
 		getLastUploadRetentionScanForRepository: op("GetLastUploadRetentionScanForRepository"),
-		setRepositoryAsDirty:                    op("SetRepositoryAsDirty"),
-		updateDirtyRepositories:                 op("UpdateDirtyRepositories"),
-		setRepositoriesForRetentionScan:         op("SetRepositoriesForRetentionScan"),
 
 		// Uploads
 		getUploads:                        op("GetUploads"),
@@ -131,33 +100,18 @@ func newOperations(observationContext *observation.Context) *operations {
 		getVisibleUploadsMatchingMonikers: op("GetVisibleUploadsMatchingMonikers"),
 		getUploadDocumentsForPath:         op("GetUploadDocumentsForPath"),
 		updateUploadsVisibleToCommits:     op("UpdateUploadsVisibleToCommits"),
-		updateUploadRetention:             op("UpdateUploadRetention"),
-		backfillReferenceCountBatch:       op("BackfillReferenceCountBatch"),
-		updateUploadsReferenceCounts:      op("UpdateUploadsReferenceCounts"),
-		deleteUploadsWithoutRepository:    op("DeleteUploadsWithoutRepository"),
-		deleteUploadsStuckUploading:       op("DeleteUploadsStuckUploading"),
-		softDeleteExpiredUploads:          op("SoftDeleteExpiredUploads"),
-		hardDeleteUploads:                 op("HardDeleteUploads"),
 		deleteUploadByID:                  op("DeleteUploadByID"),
 		inferClosestUploads:               op("InferClosestUploads"),
-		backfillCommittedAtBatch:          op("BackfillCommittedAtBatch"),
 
 		// Dumps
-		findClosestDumps:                   op("FindClosestDumps"),
-		findClosestDumpsFromGraphFragment:  op("FindClosestDumpsFromGraphFragment"),
 		getDumpsWithDefinitionsForMonikers: op("GetDumpsWithDefinitionsForMonikers"),
 		getDumpsByIDs:                      op("GetDumpsByIDs"),
 
-		// Packages
-		updatePackages: op("UpdatePackages"),
-
 		// References
-		updatePackageReferences: op("UpdatePackageReferences"),
-		referencesForUpload:     op("ReferencesForUpload"),
+		referencesForUpload: op("ReferencesForUpload"),
 
 		// Audit Logs
 		getAuditLogsForUpload: op("GetAuditLogsForUpload"),
-		deleteOldAuditLogs:    op("DeleteOldAuditLogs"),
 
 		// Tags
 		getListTags: op("GetListTags"),

--- a/internal/codeintel/uploads/reference_counts.go
+++ b/internal/codeintel/uploads/reference_counts.go
@@ -4,23 +4,11 @@ import (
 	"context"
 	"time"
 
-	"github.com/opentracing/opentracing-go/log"
-
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
-	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 func (s *Service) NewReferenceCountUpdater(interval time.Duration, batchSize int) goroutine.BackgroundRoutine {
 	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.HandlerFunc(func(ctx context.Context) error {
-		return s.backfillReferenceCountBatch(ctx, batchSize)
+		return s.store.BackfillReferenceCountBatch(ctx, batchSize)
 	}))
-}
-
-func (s *Service) backfillReferenceCountBatch(ctx context.Context, batchSize int) (err error) {
-	ctx, _, endObservation := s.operations.backfillReferenceCountBatch.With(ctx, &err, observation.Args{
-		LogFields: []log.Field{log.Int("batchSize", batchSize)},
-	})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.BackfillReferenceCountBatch(ctx, batchSize)
 }

--- a/internal/codeintel/uploads/service.go
+++ b/internal/codeintel/uploads/service.go
@@ -24,8 +24,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var _ service = (*Service)(nil)
+// var _ service = (*Service)(nil)
 
+// TODO - remove or re-sync with implementation
 type service interface {
 	// Commits
 	GetOldestCommitDate(ctx context.Context, repositoryID int) (time.Time, bool, error)

--- a/internal/codeintel/uploads/service.go
+++ b/internal/codeintel/uploads/service.go
@@ -23,65 +23,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// var _ service = (*Service)(nil)
-
-// TODO - remove or re-sync with implementation
-type service interface {
-	// Commits
-	GetOldestCommitDate(ctx context.Context, repositoryID int) (time.Time, bool, error)
-	GetCommitsVisibleToUpload(ctx context.Context, uploadID, limit int, token *string) (_ []string, nextToken *string, err error)
-	GetStaleSourcedCommits(ctx context.Context, minimumTimeSinceLastCheck time.Duration, limit int, now time.Time) (_ []shared.SourcedCommits, err error)
-	GetCommitGraphMetadata(ctx context.Context, repositoryID int) (stale bool, updatedAt *time.Time, err error)
-	UpdateSourcedCommits(ctx context.Context, repositoryID int, commit string, now time.Time) (uploadsUpdated int, err error)
-	DeleteSourcedCommits(ctx context.Context, repositoryID int, commit string, maximumCommitLag time.Duration, now time.Time) (uploadsUpdated int, uploadsDeleted int, err error)
-
-	// Repositories
-	GetRepoName(ctx context.Context, repositoryID int) (_ string, err error)
-	GetRepositoriesForIndexScan(ctx context.Context, table, column string, processDelay time.Duration, allowGlobalPolicies bool, repositoryMatchLimit *int, limit int, now time.Time) (_ []int, err error)
-	GetRepositoriesMaxStaleAge(ctx context.Context) (_ time.Duration, err error)
-	GetDirtyRepositories(ctx context.Context) (_ map[int]int, err error)
-	SetRepositoryAsDirty(ctx context.Context, repositoryID int) (err error)
-	SetRepositoriesForRetentionScan(ctx context.Context, processDelay time.Duration, limit int) (_ []int, err error)
-
-	// Uploads
-	GetUploads(ctx context.Context, opts types.GetUploadsOptions) (uploads []types.Upload, totalCount int, err error)
-	GetUploadByID(ctx context.Context, id int) (_ types.Upload, _ bool, err error)
-	GetUploadsByIDs(ctx context.Context, ids ...int) (_ []types.Upload, err error)
-	GetUploadIDsWithReferences(ctx context.Context, orderedMonikers []precise.QualifiedMonikerData, ignoreIDs []int, repositoryID int, commit string, limit int, offset int) (ids []int, recordsScanned int, totalCount int, err error)
-	GetUploadDocumentsForPath(ctx context.Context, bundleID int, pathPattern string) ([]string, int, error)
-	GetRecentUploadsSummary(ctx context.Context, repositoryID int) (upload []shared.UploadsWithRepositoryNamespace, err error)
-	GetLastUploadRetentionScanForRepository(ctx context.Context, repositoryID int) (_ *time.Time, err error)
-	UpdateUploadsVisibleToCommits(ctx context.Context, repositoryID int, graph *gitdomain.CommitGraph, refDescriptions map[string][]gitdomain.RefDescription, maxAgeForNonStaleBranches, maxAgeForNonStaleTags time.Duration, dirtyToken int, now time.Time) error
-	UpdateUploadRetention(ctx context.Context, protectedIDs, expiredIDs []int) (err error)
-	UpdateUploadsReferenceCounts(ctx context.Context, ids []int, dependencyUpdateType shared.DependencyReferenceCountUpdateType) (updated int, err error)
-	SoftDeleteExpiredUploads(ctx context.Context) (count int, err error)
-	HardDeleteExpiredUploads(ctx context.Context) (count int, err error)
-	DeleteUploadsStuckUploading(ctx context.Context, uploadedBefore time.Time) (_ int, err error)
-	DeleteUploadsWithoutRepository(ctx context.Context, now time.Time) (_ map[int]int, err error)
-	DeleteUploadByID(ctx context.Context, id int) (_ bool, err error)
-	InferClosestUploads(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) ([]types.Dump, error)
-
-	// Dumps
-	FindClosestDumps(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string) (_ []types.Dump, err error)
-	FindClosestDumpsFromGraphFragment(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string, commitGraph *gitdomain.CommitGraph) (_ []types.Dump, err error)
-	GetDumpsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) (_ []types.Dump, err error)
-	GetDumpsByIDs(ctx context.Context, ids []int) (_ []types.Dump, err error)
-
-	// Packages
-	UpdatePackages(ctx context.Context, dumpID int, packages []precise.Package) (err error)
-
-	// References
-	UpdatePackageReferences(ctx context.Context, dumpID int, references []precise.PackageReference) (err error)
-	ReferencesForUpload(ctx context.Context, uploadID int) (_ shared.PackageReferenceScanner, err error)
-
-	// Audit Logs
-	GetAuditLogsForUpload(ctx context.Context, uploadID int) (_ []types.UploadLog, err error)
-	DeleteOldAuditLogs(ctx context.Context, maxAge time.Duration, now time.Time) (count int, err error)
-
-	// Tags
-	GetListTags(ctx context.Context, repo api.RepoName, commitObjs ...string) (_ []*gitdomain.Tag, err error)
-}
-
 type Service struct {
 	store             store.Store
 	repoStore         RepoStore
@@ -133,6 +74,14 @@ func newService(
 		operations:        newOperations(observationContext),
 		clock:             glock.NewRealClock(),
 	}
+}
+
+// NOTE: Used by autoindexing (for some reason?)
+func (s *Service) GetDirtyRepositories(ctx context.Context) (_ map[int]int, err error) {
+	ctx, _, endObservation := s.operations.getDirtyRepositories.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	return s.store.GetDirtyRepositories(ctx)
 }
 
 func (s *Service) GetCommitsVisibleToUpload(ctx context.Context, uploadID, limit int, token *string) (_ []string, nextToken *string, err error) {
@@ -370,12 +319,4 @@ func (s *Service) GetListTags(ctx context.Context, repo api.RepoName, commitObjs
 	defer endObservation(1, observation.Args{})
 
 	return s.gitserverClient.ListTags(ctx, repo, commitObjs...)
-}
-
-// NOTE: Used by autoindexing (for some reason?)
-func (s *Service) GetDirtyRepositories(ctx context.Context) (_ map[int]int, err error) {
-	ctx, _, endObservation := s.operations.getDirtyRepositories.With(ctx, &err, observation.Args{})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.GetDirtyRepositories(ctx)
 }

--- a/internal/codeintel/uploads/service.go
+++ b/internal/codeintel/uploads/service.go
@@ -135,18 +135,18 @@ func newService(
 	}
 }
 
-func (s *Service) GetCommitGraphMetadata(ctx context.Context, repositoryID int) (stale bool, updatedAt *time.Time, err error) {
-	ctx, _, endObservation := s.operations.getCommitGraphMetadata.With(ctx, &err, observation.Args{LogFields: []log.Field{log.Int("repositoryID", repositoryID)}})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.GetCommitGraphMetadata(ctx, repositoryID)
-}
-
 func (s *Service) GetCommitsVisibleToUpload(ctx context.Context, uploadID, limit int, token *string) (_ []string, nextToken *string, err error) {
 	ctx, _, endObservation := s.operations.getCommitsVisibleToUpload.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
 	return s.store.GetCommitsVisibleToUpload(ctx, uploadID, limit, token)
+}
+
+func (s *Service) GetCommitGraphMetadata(ctx context.Context, repositoryID int) (stale bool, updatedAt *time.Time, err error) {
+	ctx, _, endObservation := s.operations.getCommitGraphMetadata.With(ctx, &err, observation.Args{LogFields: []log.Field{log.Int("repositoryID", repositoryID)}})
+	defer endObservation(1, observation.Args{})
+
+	return s.store.GetCommitGraphMetadata(ctx, repositoryID)
 }
 
 func (s *Service) GetRepoName(ctx context.Context, repositoryID int) (_ string, err error) {

--- a/internal/codeintel/uploads/service.go
+++ b/internal/codeintel/uploads/service.go
@@ -76,14 +76,6 @@ func newService(
 	}
 }
 
-// NOTE: Used by autoindexing (for some reason?)
-func (s *Service) GetDirtyRepositories(ctx context.Context) (_ map[int]int, err error) {
-	ctx, _, endObservation := s.operations.getDirtyRepositories.With(ctx, &err, observation.Args{})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.GetDirtyRepositories(ctx)
-}
-
 func (s *Service) GetCommitsVisibleToUpload(ctx context.Context, uploadID, limit int, token *string) (_ []string, nextToken *string, err error) {
 	ctx, _, endObservation := s.operations.getCommitsVisibleToUpload.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
@@ -119,6 +111,14 @@ func (s *Service) GetRepositoriesForIndexScan(ctx context.Context, table, column
 	defer endObservation(1, observation.Args{})
 
 	return s.store.GetRepositoriesForIndexScan(ctx, table, column, processDelay, allowGlobalPolicies, repositoryMatchLimit, limit, now)
+}
+
+// NOTE: Used by autoindexing (for some reason?)
+func (s *Service) GetDirtyRepositories(ctx context.Context) (_ map[int]int, err error) {
+	ctx, _, endObservation := s.operations.getDirtyRepositories.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	return s.store.GetDirtyRepositories(ctx)
 }
 
 func (s *Service) GetUploads(ctx context.Context, opts types.GetUploadsOptions) (uploads []types.Upload, totalCount int, err error) {

--- a/internal/codeintel/uploads/service.go
+++ b/internal/codeintel/uploads/service.go
@@ -3,7 +3,6 @@ package uploads
 import (
 	"context"
 	"fmt"
-	"sort"
 	"time"
 
 	"github.com/derision-test/glock"
@@ -136,26 +135,6 @@ func newService(
 	}
 }
 
-func (s *Service) GetCommitsVisibleToUpload(ctx context.Context, uploadID, limit int, token *string) (_ []string, nextToken *string, err error) {
-	ctx, _, endObservation := s.operations.getCommitsVisibleToUpload.With(ctx, &err, observation.Args{})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.GetCommitsVisibleToUpload(ctx, uploadID, limit, token)
-}
-
-func (s *Service) GetStaleSourcedCommits(ctx context.Context, minimumTimeSinceLastCheck time.Duration, limit int, now time.Time) (_ []shared.SourcedCommits, err error) {
-	ctx, _, endObservation := s.operations.getStaleSourcedCommits.With(ctx, &err, observation.Args{
-		LogFields: []log.Field{
-			log.Int("minimumTimeSinceLastCheck in ms", int(minimumTimeSinceLastCheck.Milliseconds())),
-			log.Int("limit", limit),
-			log.String("now", now.String()),
-		},
-	})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.GetStaleSourcedCommits(ctx, minimumTimeSinceLastCheck, limit, now)
-}
-
 func (s *Service) GetCommitGraphMetadata(ctx context.Context, repositoryID int) (stale bool, updatedAt *time.Time, err error) {
 	ctx, _, endObservation := s.operations.getCommitGraphMetadata.With(ctx, &err, observation.Args{LogFields: []log.Field{log.Int("repositoryID", repositoryID)}})
 	defer endObservation(1, observation.Args{})
@@ -163,22 +142,11 @@ func (s *Service) GetCommitGraphMetadata(ctx context.Context, repositoryID int) 
 	return s.store.GetCommitGraphMetadata(ctx, repositoryID)
 }
 
-func (s *Service) GetOldestCommitDate(ctx context.Context, repositoryID int) (time.Time, bool, error) {
-	ctx, _, endObservation := s.operations.getOldestCommitDate.With(ctx, nil, observation.Args{
-		LogFields: []log.Field{log.Int("repositoryID", repositoryID)},
-	})
+func (s *Service) GetCommitsVisibleToUpload(ctx context.Context, uploadID, limit int, token *string) (_ []string, nextToken *string, err error) {
+	ctx, _, endObservation := s.operations.getCommitsVisibleToUpload.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	return s.store.GetOldestCommitDate(ctx, repositoryID)
-}
-
-func (s *Service) SetRepositoryAsDirty(ctx context.Context, repositoryID int) (err error) {
-	ctx, _, endObservation := s.operations.setRepositoryAsDirty.With(ctx, &err, observation.Args{
-		LogFields: []log.Field{log.Int("repositoryID", repositoryID)},
-	})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.SetRepositoryAsDirty(ctx, repositoryID)
+	return s.store.GetCommitsVisibleToUpload(ctx, uploadID, limit, token)
 }
 
 func (s *Service) GetRepoName(ctx context.Context, repositoryID int) (_ string, err error) {
@@ -202,13 +170,6 @@ func (s *Service) GetRepositoriesForIndexScan(ctx context.Context, table, column
 	defer endObservation(1, observation.Args{})
 
 	return s.store.GetRepositoriesForIndexScan(ctx, table, column, processDelay, allowGlobalPolicies, repositoryMatchLimit, limit, now)
-}
-
-func (s *Service) GetRepositoriesMaxStaleAge(ctx context.Context) (_ time.Duration, err error) {
-	ctx, _, endObservation := s.operations.getRepositoriesMaxStaleAge.With(ctx, &err, observation.Args{})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.GetRepositoriesMaxStaleAge(ctx)
 }
 
 func (s *Service) GetUploads(ctx context.Context, opts types.GetUploadsOptions) (uploads []types.Upload, totalCount int, err error) {
@@ -249,32 +210,6 @@ func (s *Service) GetUploadIDsWithReferences(ctx context.Context, orderedMoniker
 	defer endObservation(1, observation.Args{})
 
 	return s.store.GetUploadIDsWithReferences(ctx, orderedMonikers, ignoreIDs, repositoryID, commit, limit, offset, trace)
-}
-
-func (s *Service) UpdateUploadRetention(ctx context.Context, protectedIDs, expiredIDs []int) (err error) {
-	ctx, _, endObservation := s.operations.updateUploadRetention.With(ctx, &err, observation.Args{
-		LogFields: []log.Field{log.String("protectedIDs", fmt.Sprintf("%v", protectedIDs)), log.String("expiredIDs", fmt.Sprintf("%v", expiredIDs))},
-	})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.UpdateUploadRetention(ctx, protectedIDs, expiredIDs)
-}
-func (s *Service) UpdateUploadsReferenceCounts(ctx context.Context, ids []int, dependencyUpdateType shared.DependencyReferenceCountUpdateType) (updated int, err error) {
-	ctx, _, endObservation := s.operations.updateUploadsReferenceCounts.With(ctx, &err, observation.Args{
-		LogFields: []log.Field{log.String("ids", fmt.Sprintf("%v", ids))},
-	})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.UpdateUploadsReferenceCounts(ctx, ids, dependencyUpdateType)
-}
-
-func (s *Service) DeleteUploadsWithoutRepository(ctx context.Context, now time.Time) (_ map[int]int, err error) {
-	ctx, _, endObservation := s.operations.deleteUploadsWithoutRepository.With(ctx, &err, observation.Args{
-		LogFields: []log.Field{log.String("now", now.String())},
-	})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.DeleteUploadsWithoutRepository(ctx, now)
 }
 
 func (s *Service) DeleteUploadByID(ctx context.Context, id int) (_ bool, err error) {
@@ -365,30 +300,6 @@ func (s *Service) InferClosestUploads(ctx context.Context, repositoryID int, com
 	return dumps, nil
 }
 
-func (s *Service) FindClosestDumps(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string) (_ []types.Dump, err error) {
-	ctx, _, endObservation := s.operations.findClosestDumps.With(ctx, &err, observation.Args{
-		LogFields: []log.Field{
-			log.Int("repositoryID", repositoryID), log.String("commit", commit), log.String("path", path),
-			log.Bool("rootMustEnclosePath", rootMustEnclosePath), log.String("indexer", indexer),
-		},
-	})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.FindClosestDumps(ctx, repositoryID, commit, path, rootMustEnclosePath, indexer)
-}
-
-func (s *Service) FindClosestDumpsFromGraphFragment(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string, commitGraph *gitdomain.CommitGraph) (_ []types.Dump, err error) {
-	ctx, _, endObservation := s.operations.findClosestDumpsFromGraphFragment.With(ctx, &err, observation.Args{
-		LogFields: []log.Field{
-			log.Int("repositoryID", repositoryID), log.String("commit", commit), log.String("path", path),
-			log.Bool("rootMustEnclosePath", rootMustEnclosePath), log.String("indexer", indexer),
-		},
-	})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.FindClosestDumpsFromGraphFragment(ctx, repositoryID, commit, path, rootMustEnclosePath, indexer, commitGraph)
-}
-
 func (s *Service) GetDumpsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) (_ []types.Dump, err error) {
 	ctx, _, endObservation := s.operations.getDumpsWithDefinitionsForMonikers.With(ctx, &err, observation.Args{
 		LogFields: []log.Field{log.String("monikers", fmt.Sprintf("%v", monikers))},
@@ -405,24 +316,6 @@ func (s *Service) GetDumpsByIDs(ctx context.Context, ids []int) (_ []types.Dump,
 	defer endObservation(1, observation.Args{})
 
 	return s.store.GetDumpsByIDs(ctx, ids)
-}
-
-func (s *Service) UpdatePackages(ctx context.Context, dumpID int, packages []precise.Package) (err error) {
-	ctx, _, endObservation := s.operations.updatePackages.With(ctx, &err, observation.Args{
-		LogFields: []log.Field{log.Int("dumpID", dumpID), log.String("packages", fmt.Sprintf("%v", packages))},
-	})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.UpdatePackages(ctx, dumpID, packages)
-}
-
-func (s *Service) UpdatePackageReferences(ctx context.Context, dumpID int, references []precise.PackageReference) (err error) {
-	ctx, _, endObservation := s.operations.updatePackageReferences.With(ctx, &err, observation.Args{
-		LogFields: []log.Field{log.Int("dumpID", dumpID), log.String("references", fmt.Sprintf("%v", references))},
-	})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.UpdatePackageReferences(ctx, dumpID, references)
 }
 
 func (s *Service) ReferencesForUpload(ctx context.Context, uploadID int) (_ shared.PackageReferenceScanner, err error) {
@@ -479,12 +372,10 @@ func (s *Service) GetListTags(ctx context.Context, repo api.RepoName, commitObjs
 	return s.gitserverClient.ListTags(ctx, repo, commitObjs...)
 }
 
-func uploadIDs(uploads []types.Upload) []int {
-	ids := make([]int, 0, len(uploads))
-	for i := range uploads {
-		ids = append(ids, uploads[i].ID)
-	}
-	sort.Ints(ids)
+// NOTE: Used by autoindexing (for some reason?)
+func (s *Service) GetDirtyRepositories(ctx context.Context) (_ map[int]int, err error) {
+	ctx, _, endObservation := s.operations.getDirtyRepositories.With(ctx, &err, observation.Args{})
+	defer endObservation(1, observation.Args{})
 
-	return ids
+	return s.store.GetDirtyRepositories(ctx)
 }


### PR DESCRIPTION
Refactor to remove unused exported methods from service layers.

1. Removed `service` interface in each package as it was private and blocked refactor tools from working
2. Un-exported each method used only by the service itself
3. Removed observability wrapping from non-exported methods
4. Replaced unexported methods that proxy to the store with a call directly to the store 
5. Cleaned out observability fields

Let's just keep hacking at these services until they're clean. It'll take a bit of time but I think it's coming together already.

cc @Numbers88s I'm not opposed to adding back service interfaces, but they weren't explicitly used anywhere (we should use the iface type as the export instead of the struct if we're committing).

## Test plan

Ran locally.