### PR TITLE
ranking: Add default ranking implementations

### DIFF
--- a/internal/codeintel/ranking/iface.go
+++ b/internal/codeintel/ranking/iface.go
@@ -1,0 +1,13 @@
+package ranking
+
+import (
+	"context"
+
+	"github.com/grafana/regexp"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+type GitserverClient interface {
+	ListFilesForRepo(ctx context.Context, repo api.RepoName, commit string, pattern *regexp.Regexp) (_ []string, err error)
+}

--- a/internal/codeintel/ranking/init.go
+++ b/internal/codeintel/ranking/init.go
@@ -1,7 +1,9 @@
 package ranking
 
 import (
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/ranking/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -9,22 +11,30 @@ import (
 // GetService creates or returns an already-initialized ranking service.
 // If the service is not yet initialized, it will use the provided dependencies.
 func GetService(
+	db database.DB,
 	uploadSvc *uploads.Service,
+	gitserverClient GitserverClient,
 ) *Service {
 	svc, _ := initServiceMemo.Init(serviceDependencies{
+		db,
 		uploadSvc,
+		gitserverClient,
 	})
 
 	return svc
 }
 
 type serviceDependencies struct {
-	uploadsService *uploads.Service
+	db              database.DB
+	uploadsService  *uploads.Service
+	gitserverClient GitserverClient
 }
 
 var initServiceMemo = memo.NewMemoizedConstructorWithArg(func(deps serviceDependencies) (*Service, error) {
 	return newService(
+		store.New(deps.db, scopedContext("store")),
 		deps.uploadsService,
+		deps.gitserverClient,
 		scopedContext("service"),
 	), nil
 })

--- a/internal/codeintel/ranking/internal/store/observability.go
+++ b/internal/codeintel/ranking/internal/store/observability.go
@@ -1,0 +1,34 @@
+package store
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type operations struct {
+	getStaleSourcedCommits      *observation.Operation
+	insertDependencyIndexingJob *observation.Operation
+}
+
+func newOperations(observationContext *observation.Context) *operations {
+	m := metrics.NewREDMetrics(
+		observationContext.Registerer,
+		"codeintel_ranking_store",
+		metrics.WithLabels("op"),
+		metrics.WithCountHelp("Total number of method invocations."),
+	)
+
+	op := func(name string) *observation.Operation {
+		return observationContext.Operation(observation.Op{
+			Name:              fmt.Sprintf("codeintel.ranking.store.%s", name),
+			MetricLabelValues: []string{name},
+			Metrics:           m,
+		})
+	}
+
+	return &operations{
+		getStaleSourcedCommits: op("StaleSourcedCommits"),
+	}
+}

--- a/internal/codeintel/ranking/internal/store/store.go
+++ b/internal/codeintel/ranking/internal/store/store.go
@@ -1,0 +1,74 @@
+package store
+
+import (
+	"context"
+
+	"github.com/keegancsmith/sqlf"
+	logger "github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+// Store provides the interface for ranking storage.
+type Store interface {
+	// Transactions
+	Transact(ctx context.Context) (Store, error)
+	Done(err error) error
+
+	GetStarRank(ctx context.Context, rapoName api.RepoName) (float64, error)
+}
+
+// store manages the ranking store.
+type store struct {
+	db         *basestore.Store
+	logger     logger.Logger
+	operations *operations
+}
+
+// New returns a new ranking store.
+func New(db database.DB, observationContext *observation.Context) Store {
+	return &store{
+		db:         basestore.NewWithHandle(db.Handle()),
+		logger:     logger.Scoped("ranking.store", ""),
+		operations: newOperations(observationContext),
+	}
+}
+
+func (s *store) Transact(ctx context.Context) (Store, error) {
+	return s.transact(ctx)
+}
+
+func (s *store) transact(ctx context.Context) (*store, error) {
+	tx, err := s.db.Transact(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &store{
+		logger:     s.logger,
+		db:         tx,
+		operations: s.operations,
+	}, nil
+}
+
+func (s *store) Done(err error) error {
+	return s.db.Done(err)
+}
+
+func (s *store) GetStarRank(ctx context.Context, repoName api.RepoName) (float64, error) {
+	rank, _, err := basestore.ScanFirstFloat(s.db.Query(ctx, sqlf.Sprintf(getStarRankQuery, repoName)))
+	return rank, err
+}
+
+const getStarRankQuery = `
+SELECT
+	1 - (
+		(DENSE_RANK() OVER (ORDER BY stars DESC))::float /
+		(SELECT COUNT(*) FROM repo)::float
+	)
+FROM repo
+WHERE name = %s
+`

--- a/internal/codeintel/services.go
+++ b/internal/codeintel/services.go
@@ -46,7 +46,7 @@ var initServicesMemo = memo.NewMemoizedConstructorWithArg(func(dbs Databases) (S
 	policiesSvc := policies.GetService(db, uploadsSvc, gitserverClient)
 	autoIndexingSvc := autoindexing.GetService(db, uploadsSvc, dependenciesSvc, policiesSvc, gitserverClient, repoUpdaterClient)
 	codenavSvc := codenav.GetService(db, codeIntelDB, uploadsSvc, gitserverClient)
-	rankingSvc := ranking.GetService(uploadsSvc)
+	rankingSvc := ranking.GetService(db, uploadsSvc, gitserverClient)
 
 	return Services{
 		AutoIndexingService: autoIndexingSvc,

--- a/internal/codeintel/stores/gitserver/client.go
+++ b/internal/codeintel/stores/gitserver/client.go
@@ -420,6 +420,10 @@ func (c *Client) ListFiles(ctx context.Context, repositoryID int, commit string,
 		return nil, err
 	}
 
+	return c.ListFilesForRepo(ctx, repo, commit, pattern)
+}
+
+func (c *Client) ListFilesForRepo(ctx context.Context, repo api.RepoName, commit string, pattern *regexp.Regexp) (_ []string, err error) {
 	matching, err := gitserver.NewClient(c.db).ListFiles(ctx, repo, api.CommitID(commit), pattern, authz.DefaultSubRepoPermsChecker)
 	if err == nil {
 		return matching, nil


### PR DESCRIPTION
This PR adds a **really cruddy** implementation of ranking for repositories (percentile by star count), as well as ranking of text documents within a repo (percentile in lexicographic order).

This code should not be used in a production setting and isn't currently hooked to anything. This is only to give @keegancsmith a foundation to build off of on the Zoekt indexing side in a way that doesn't always spurt "unimplemented" errors.

## Test plan

New code is currently unused and experimental.