### PR TITLE
ci: get token from github app

### DIFF
--- a/enterprise/dev/ci/scripts/app-token/main.go
+++ b/enterprise/dev/ci/scripts/app-token/main.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"time"
+
+	"github.com/golang-jwt/jwt"
+	"github.com/google/go-github/v47/github"
+	"golang.org/x/oauth2"
+)
+
+func main() {
+	appID := os.Getenv("GITHUB_APP_ID")
+
+	jwt := genJwtToken(appID)
+
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: jwt},
+	)
+
+	tc := oauth2.NewClient(ctx, ts)
+	ghc := github.NewClient(tc)
+
+	fmt.Println(*getInstallAccessToken(ctx, ghc))
+
+}
+
+func genJwtToken(appID string) string {
+	rawPem, err := ioutil.ReadFile("private.pem")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	privPem, _ := pem.Decode(rawPem)
+	priv, err := x509.ParsePKCS1PrivateKey(privPem.Bytes)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Create new JWT token with 10 minute (max duration) expiry
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"iat": time.Now().Unix() - 60,
+		"exp": time.Now().Unix() + (10 * 60),
+		"iss": appID,
+	})
+
+	jwtString, err := token.SignedString(priv)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return jwtString
+
+}
+
+func getInstallAccessToken(ctx context.Context, ghc *github.Client) *string {
+	// Get organation installation ID
+	orgInstallation, _, err := ghc.Apps.FindOrganizationInstallation(ctx, "sourcegraph")
+	if err != nil {
+		log.Fatal(err)
+	}
+	orgID := orgInstallation.ID
+
+	// Create new installation token with 60 minute duraction with default read contents permissions
+	token, _, err := ghc.Apps.CreateInstallationToken(ctx, *orgID, &github.InstallationTokenOptions{
+		Repositories: []string{"sourcegraph"},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return token.Token
+
+}

--- a/go.mod
+++ b/go.mod
@@ -201,7 +201,9 @@ require (
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/emicklei/go-restful v2.16.0+incompatible // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
+	github.com/google/go-github/v47 v47.1.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1022,6 +1022,7 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/gogo/status v1.1.0/go.mod h1:BFv9nrluPLmrS0EmGVvLaPNmRosr9KapBYd5/hpY1WM=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.1.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
@@ -1141,6 +1142,8 @@ github.com/google/go-github/v41 v41.0.0 h1:HseJrM2JFf2vfiZJ8anY2hqBjdfY1Vlj/K27u
 github.com/google/go-github/v41 v41.0.0/go.mod h1:XgmCA5H323A9rtgExdTcnDkcqp6S30AVACCBDOonIxg=
 github.com/google/go-github/v43 v43.0.0 h1:y+GL7LIsAIF2NZlJ46ZoC/D1W1ivZasT0lnWHMYPZ+U=
 github.com/google/go-github/v43 v43.0.0/go.mod h1:ZkTvvmCXBvsfPpTHXnH/d2hP9Y0cTbvN9kr5xqyXOIc=
+github.com/google/go-github/v47 v47.1.0 h1:Cacm/WxQBOa9lF0FT0EMjZ2BWMetQ1TQfyurn4yF1z8=
+github.com/google/go-github/v47 v47.1.0/go.mod h1:VPZBXNbFSJGjyjFRUKo9vZGawTajnWzC/YjGw/oFKi0=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=


### PR DESCRIPTION
Gets an installation token from the buildkite-token github app to use in place of PAT's to avoid rate limiting. 

Part of https://github.com/sourcegraph/sourcegraph/issues/41728


## Test plan

to be created