### PR TITLE
search/jetbrains: introduce type ContentMatchWithLineMatches for clients still using line matches

### DIFF
--- a/client/jetbrains/webview/src/search/js-to-java-bridge.ts
+++ b/client/jetbrains/webview/src/search/js-to-java-bridge.ts
@@ -2,7 +2,7 @@ import { encode } from 'js-base64'
 
 import { splitPath } from '@sourcegraph/shared/src/components/RepoLink'
 import {
-    ContentMatch,
+    ContentMatchWithLineMatches,
     getRepoMatchUrl,
     PathMatch,
     SearchMatch,
@@ -158,7 +158,7 @@ export async function indicateFinishedLoading(
 export async function onPreviewChange(match: SearchMatch, lineOrSymbolMatchIndex?: number): Promise<void> {
     try {
         const initiationDateTime = new Date()
-        if (match.type === 'content' || match.type === 'path' || match.type === 'symbol') {
+        if (match.type === 'contentWithLineMatches' || match.type === 'path' || match.type === 'symbol') {
             lastPreviewUpdateCallSendDateTime = initiationDateTime
             await callJava({
                 action: 'previewLoading',
@@ -249,7 +249,7 @@ export async function createPreviewContent(
         }
     }
 
-    if (match.type === 'content') {
+    if (match.type === 'contentWithLineMatches') {
         return createPreviewContentForContentMatch(match, lineOrSymbolMatchIndex as number)
     }
 
@@ -284,7 +284,7 @@ export async function createPreviewContent(
 }
 
 async function createPreviewContentForContentMatch(
-    match: ContentMatch,
+    match: ContentMatchWithLineMatches,
     lineMatchIndex: number
 ): Promise<PreviewContent> {
     const fileName = splitPath(match.path)[1]

--- a/client/jetbrains/webview/src/search/lib/blob.ts
+++ b/client/jetbrains/webview/src/search/lib/blob.ts
@@ -1,5 +1,5 @@
 import { gql } from '@sourcegraph/http-client'
-import { ContentMatch, PathMatch, SymbolMatch } from '@sourcegraph/shared/src/search/stream'
+import {ContentMatchWithLineMatches, PathMatch, SymbolMatch} from '@sourcegraph/shared/src/search/stream'
 
 import { BlobContentResult, BlobContentVariables } from '../../graphql-operations'
 import { getMatchId } from '../results/utils'
@@ -12,7 +12,7 @@ const THIRTY_MINUTES = 30 * 60 * 1000
 const cachedContentRequests = new ExpirationCache<string, Promise<string | null>>(THIRTY_MINUTES)
 const inflightRequestAbortControllers: Set<AbortController> = new Set()
 
-export async function loadContent(match: ContentMatch | PathMatch | SymbolMatch): Promise<string | null> {
+export async function loadContent(match: ContentMatchWithLineMatches | PathMatch | SymbolMatch): Promise<string | null> {
     const cacheKey = getMatchId(match)
 
     if (cachedContentRequests.has(cacheKey)) {
@@ -35,7 +35,7 @@ export async function loadContent(match: ContentMatch | PathMatch | SymbolMatch)
     return loadPromise
 }
 
-async function fetchBlobContent(match: ContentMatch | PathMatch | SymbolMatch): Promise<string | null> {
+async function fetchBlobContent(match: ContentMatchWithLineMatches | PathMatch | SymbolMatch): Promise<string | null> {
     const abortController = new AbortController()
     inflightRequestAbortControllers.add(abortController)
     try {

--- a/client/jetbrains/webview/src/search/results/FileSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/FileSearchResult.tsx
@@ -4,7 +4,7 @@ import AlphaSBoxIcon from 'mdi-react/AlphaSBoxIcon'
 import FileDocumentIcon from 'mdi-react/FileDocumentIcon'
 
 import { formatRepositoryStarCount, SearchResultStar } from '@sourcegraph/search-ui'
-import { ContentMatch, SymbolMatch } from '@sourcegraph/shared/src/search/stream'
+import {ContentMatchWithLineMatches, SymbolMatch} from '@sourcegraph/shared/src/search/stream'
 import { SymbolIcon } from '@sourcegraph/shared/src/symbols/SymbolIcon'
 
 import { InfoDivider } from './InfoDivider'
@@ -18,7 +18,7 @@ import { getResultId } from './utils'
 import styles from './FileSearchResult.module.scss'
 
 function renderResultElementsForContentMatch(
-    match: ContentMatch,
+    match: ContentMatchWithLineMatches,
     selectedResult: string | null,
     selectResult: (resultId: string) => void,
     openResult: (resultId: string) => void
@@ -46,7 +46,7 @@ function renderResultElementsForContentMatch(
 interface Props {
     selectResult: (resultId: string) => void
     selectedResult: null | string
-    match: ContentMatch | SymbolMatch
+    match: ContentMatchWithLineMatches | SymbolMatch
     openResult: (resultId: string) => void
 }
 
@@ -82,22 +82,24 @@ export const FileSearchResult: React.FunctionComponent<Props> = ({
     openResult,
 }: Props) => {
     const lines =
-        match.type === 'content'
+        match.type === 'contentWithLineMatches'
             ? renderResultElementsForContentMatch(match, selectedResult, selectResult, openResult)
-            : renderResultElementsForSymbolMatch(match, selectedResult, selectResult, openResult)
+            : match.type === 'symbol'
+                ? renderResultElementsForSymbolMatch(match, selectedResult, selectResult, openResult)
+                : []
 
     const formattedRepositoryStarCount = formatRepositoryStarCount(match.repoStars)
 
     const onClick = (): void =>
         lines.length
-            ? selectResult(getResultId(match, match.type === 'content' ? match.lineMatches![0] : match.symbols[0]))
+            ? selectResult(getResultId(match, match.type === 'contentWithLineMatches' ? match.lineMatches[0] : match.symbols[0]))
             : undefined
 
     const title = (
         <SearchResultHeader onClick={onClick}>
             <SearchResultLayout
                 iconColumn={{
-                    icon: match.type === 'content' ? FileDocumentIcon : AlphaSBoxIcon,
+                    icon: match.type === 'contentWithLineMatches' ? FileDocumentIcon : AlphaSBoxIcon,
                     repoName: match.repository,
                 }}
                 infoColumn={

--- a/client/jetbrains/webview/src/search/results/SearchResultList.story.tsx
+++ b/client/jetbrains/webview/src/search/results/SearchResultList.story.tsx
@@ -34,7 +34,7 @@ export const JetBrainsSearchResultListStory: Story = () => {
 
     const matches: SearchMatch[] = [
         {
-            type: 'content',
+            type: 'contentWithLineMatches',
             path: '/CHANGELOG.md',
             repository: 'test-repository',
             repoStars: 1,

--- a/client/jetbrains/webview/src/search/results/SearchResultList.tsx
+++ b/client/jetbrains/webview/src/search/results/SearchResultList.tsx
@@ -38,7 +38,7 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
     const matchIdToMatchMap = useMemo((): Map<string, SearchMatch> => {
         const map = new Map<string, SearchMatch>()
         for (const match of matches) {
-            if (['commit', 'content', 'path', 'repo', 'symbol'].includes(match.type)) {
+            if (['commit', 'contentWithLineMatches', 'path', 'repo', 'symbol'].includes(match.type)) {
                 map.set(getMatchId(match), match)
             }
         }
@@ -54,7 +54,7 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
                 if (match) {
                     onPreviewChange(
                         match,
-                        match.type === 'content' || match.type === 'symbol'
+                        match.type === 'contentWithLineMatches' || match.type === 'symbol'
                             ? getLineOrSymbolMatchIndexForFileResult(resultId)
                             : undefined
                     )
@@ -81,7 +81,7 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
                 if (match) {
                     onOpen(
                         match,
-                        match.type === 'content' || match.type === 'symbol'
+                        match.type === 'contentWithLineMatches' || match.type === 'symbol'
                             ? getLineOrSymbolMatchIndexForFileResult(resultId)
                             : undefined
                     )
@@ -130,7 +130,7 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
                 if (match) {
                     onOpen(
                         match,
-                        match.type === 'content' || match.type === 'symbol'
+                        match.type === 'contentWithLineMatches' || match.type === 'symbol'
                             ? getLineOrSymbolMatchIndexForFileResult(selectedResultId)
                             : undefined
                     )
@@ -186,7 +186,7 @@ export const SearchResultList: React.FunctionComponent<Props> = ({
                                 openResult={openResult}
                             />
                         )
-                    case 'content':
+                    case 'contentWithLineMatches':
                         return (
                             <FileSearchResult
                                 key={`${match.repository}-${match.path}`}

--- a/client/jetbrains/webview/src/search/results/TrimmedCodeLineWithHighlights.tsx
+++ b/client/jetbrains/webview/src/search/results/TrimmedCodeLineWithHighlights.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 
-import { ContentMatch } from '@sourcegraph/shared/src/search/stream'
+import {ContentMatchWithLineMatches} from '@sourcegraph/shared/src/search/stream'
 
 import styles from './FileSearchResult.module.scss'
 
 interface Props {
-    line: NonNullable<ContentMatch['lineMatches']>[0]
+    line: ContentMatchWithLineMatches['lineMatches'][0]
 }
 
 export const TrimmedCodeLineWithHighlights: React.FunctionComponent<Props> = React.memo<Props>(

--- a/client/jetbrains/webview/src/search/results/utils.ts
+++ b/client/jetbrains/webview/src/search/results/utils.ts
@@ -1,4 +1,4 @@
-import { ContentMatch, SearchMatch, SymbolMatch } from '@sourcegraph/shared/src/search/stream'
+import {ContentMatchWithLineMatches, SearchMatch, SymbolMatch} from '@sourcegraph/shared/src/search/stream'
 
 const SUPPORTED_TYPES = new Set(['commit', 'content', 'path', 'symbol', 'repo'])
 const ID_SEPERATOR = '-#-'
@@ -9,11 +9,11 @@ export function getFirstResultId(results: SearchMatch[]): string | null {
     if (firstSupportedMatch) {
         return getResultId(
             firstSupportedMatch,
-            firstSupportedMatch.type === 'content'
-                ? firstSupportedMatch.lineMatches![0]
+            firstSupportedMatch.type === 'contentWithLineMatches'
+                ? firstSupportedMatch.lineMatches[0]
                 : firstSupportedMatch.type === 'symbol'
-                ? firstSupportedMatch.symbols[0]
-                : undefined
+                    ? firstSupportedMatch.symbols[0]
+                    : undefined
         )
     }
     return null
@@ -24,7 +24,7 @@ export function getMatchId(match: SearchMatch): string {
         return `${match.repository}-${match.oid.slice(0, 7)}`
     }
 
-    if (match.type === 'content' || match.type === 'path' || match.type === 'symbol') {
+    if (match.type === 'contentWithLineMatches' || match.type === 'path' || match.type === 'symbol') {
         return `${match.repository}-${match.path}`
     }
 
@@ -42,11 +42,11 @@ export function getMatchIdForResult(resultId: string): string {
     return resultId.split(ID_SEPERATOR)[0]
 }
 
-export type LineMatchItem = NonNullable<ContentMatch['lineMatches']>[0]
+export type LineMatchItem = ContentMatchWithLineMatches['lineMatches'][0]
 export type SymbolMatchItem = SymbolMatch['symbols'][0]
 export function getResultId(match: SearchMatch, lineOrSymbolMatch?: LineMatchItem | SymbolMatchItem): string {
-    if (match.type === 'content') {
-        return `${getMatchId(match)}${ID_SEPERATOR}${match.lineMatches?.indexOf(lineOrSymbolMatch as LineMatchItem)}`
+    if (match.type === 'contentWithLineMatches') {
+        return `${getMatchId(match)}${ID_SEPERATOR}${match.lineMatches.indexOf(lineOrSymbolMatch as LineMatchItem)}`
     }
     if (match.type === 'symbol') {
         return `${getMatchId(match)}${ID_SEPERATOR}${match.symbols.indexOf(lineOrSymbolMatch as SymbolMatchItem)}`

--- a/client/search-ui/src/results/StreamingSearchResultsList.tsx
+++ b/client/search-ui/src/results/StreamingSearchResultsList.tsx
@@ -205,13 +205,10 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                         />
                     )
                 default:
+                    const exhaustiveCheck: never = result.type
                     // eslint-disable-next-line no-console
-                    console.error(`Unexpected result type, ${result.type}`)
-                    return <Alert className="d-flex m-3" variant="info">
-                        <Text className="m-0">
-                            <strong>Unexpected result type: </strong> <Code>{result.type}</Code>
-                        </Text>
-                    </Alert>
+                    console.error(`Unexpected result type, ${exhaustiveCheck as string}`)
+                    return <></>
             }
         },
         [

--- a/client/search-ui/src/results/StreamingSearchResultsList.tsx
+++ b/client/search-ui/src/results/StreamingSearchResultsList.tsx
@@ -30,6 +30,7 @@ import {
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import {Alert, Code, Text} from '@sourcegraph/wildcard';
 
 import { smartSearchClickedEvent } from '../util/events'
 
@@ -203,6 +204,14 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                             as="li"
                         />
                     )
+                default:
+                    // eslint-disable-next-line no-console
+                    console.error(`Unexpected result type, ${result.type}`)
+                    return <Alert className="d-flex m-3" variant="info">
+                        <Text className="m-0">
+                            <strong>Unexpected result type: </strong> <Code>{result.type}</Code>
+                        </Text>
+                    </Alert>
             }
         },
         [

--- a/client/search-ui/src/results/StreamingSearchResultsList.tsx
+++ b/client/search-ui/src/results/StreamingSearchResultsList.tsx
@@ -30,7 +30,6 @@ import {
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import {Alert, Code, Text} from '@sourcegraph/wildcard';
 
 import { smartSearchClickedEvent } from '../util/events'
 

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -29,7 +29,7 @@ export type SearchEvent =
     | { type: 'error'; data: ErrorLike }
     | { type: 'done'; data: {} }
 
-export type SearchMatch = ContentMatch | RepositoryMatch | CommitMatch | SymbolMatch | PathMatch
+export type SearchMatch = ContentMatch | ContentMatchWithLineMatches | RepositoryMatch | CommitMatch | SymbolMatch | PathMatch
 
 export interface PathMatch {
     type: 'path'
@@ -51,8 +51,20 @@ export interface ContentMatch {
     repoLastFetched?: string
     branches?: string[]
     commit?: string
-    lineMatches?: LineMatch[]
-    chunkMatches?: ChunkMatch[]
+    chunkMatches: ChunkMatch[]
+    hunks?: DecoratedHunk[]
+}
+
+export interface ContentMatchWithLineMatches {
+    type: 'contentWithLineMatches'
+    path: string
+    pathMatches?: Range[]
+    repository: string
+    repoStars?: number
+    repoLastFetched?: string
+    branches?: string[]
+    commit?: string
+    lineMatches: LineMatch[]
     hunks?: DecoratedHunk[]
 }
 
@@ -534,7 +546,7 @@ export function getRevision(branches?: string[], version?: string): string {
     return revision
 }
 
-export function getFileMatchUrl(fileMatch: ContentMatch | SymbolMatch | PathMatch): string {
+export function getFileMatchUrl(fileMatch: ContentMatch | ContentMatchWithLineMatches | SymbolMatch | PathMatch): string {
     const revision = getRevision(fileMatch.branches, fileMatch.commit)
     return `/${fileMatch.repository}${revision ? '@' + revision : ''}/-/blob/${fileMatch.path}`
 }
@@ -558,6 +570,7 @@ export function getMatchUrl(match: SearchMatch): string {
     switch (match.type) {
         case 'path':
         case 'content':
+        case 'contentWithLineMatches':
         case 'symbol':
             return getFileMatchUrl(match)
         case 'commit':

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -353,20 +353,20 @@ describe('Search', () => {
                         { type: 'repo', repository: 'github.com/sourcegraph/sourcegraph' },
                         {
                             type: 'content',
-                            lineMatches: [],
+                            chunkMatches: [],
                             path: 'stream.ts',
                             repository: 'github.com/sourcegraph/sourcegraph',
                         },
                         {
                             type: 'content',
-                            lineMatches: [],
+                            chunkMatches: [],
                             path: 'stream.ts',
                             repository: 'github.com/sourcegraph/sourcegraph',
                             commit: 'abcd',
                         },
                         {
                             type: 'content',
-                            lineMatches: [],
+                            chunkMatches: [],
                             path: 'stream.ts',
                             repository: 'github.com/sourcegraph/sourcegraph',
                             branches: ['test/branch'],

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -365,11 +365,13 @@ func fromContentMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.Sear
 	var (
 		eventLineMatches  []streamhttp.EventLineMatch
 		eventChunkMatches []streamhttp.ChunkMatch
+		typ               streamhttp.MatchType
 	)
 
 	if enableChunkMatches {
 		eventChunkMatches = fromChunkMatches(fm.ChunkMatches)
 	} else {
+		typ = streamhttp.ContentMatchWithLineMatchesType
 		lineMatches := fm.ChunkMatches.AsLineMatches()
 		eventLineMatches = make([]streamhttp.EventLineMatch, 0, len(lineMatches))
 		for _, lm := range lineMatches {
@@ -382,7 +384,7 @@ func fromContentMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.Sear
 	}
 
 	contentEvent := &streamhttp.EventContentMatch{
-		Type:         streamhttp.ContentMatchType,
+		Type:         typ,
 		Path:         fm.Path,
 		PathMatches:  fromRanges(fm.PathMatches),
 		RepositoryID: int32(fm.Repo.ID),

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -208,6 +208,7 @@ const (
 	SymbolMatchType
 	CommitMatchType
 	PathMatchType
+	ContentMatchWithLineMatchesType
 )
 
 func (t MatchType) MarshalJSON() ([]byte, error) {
@@ -222,6 +223,8 @@ func (t MatchType) MarshalJSON() ([]byte, error) {
 		return []byte(`"commit"`), nil
 	case PathMatchType:
 		return []byte(`"path"`), nil
+	case ContentMatchWithLineMatchesType:
+		return []byte(`"contentWithLineMatches"`), nil
 	default:
 		return nil, errors.Errorf("unknown MatchType: %d", t)
 	}


### PR DESCRIPTION
Following up on [this feedback](https://github.com/sourcegraph/sourcegraph/pull/42271#issuecomment-1268286970)

The `ContentMatch` type has been migrated to use chunk matches, which is the default result type requested by the web app. However, the JetBrains plugin still relies on the `LineMatch` result type. This PR adds a new type, `ContentMatchWithLineMatches`, which continues to support line matches. The `type` property of this type has value `contentWithLineMatches`. Separating these two content match types allows for a type-safe way for the web app to request chunk matches while the JetBrains plugin continues to request line matches.



## Test plan
Manually test a few content and symbol searches in the plugin locally
CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
