### PR TITLE
Backend: add stacktrace to panic handler

### DIFF
--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -271,7 +272,7 @@ func loggingRecoverer(logger log.Logger, handler http.Handler) http.Handler {
 		defer func() {
 			if r := recover(); r != nil {
 				err := errors.Errorf("handler panic: %v", redact.Safe(r))
-				logger.Error("handler panic", log.Error(err))
+				logger.Error("handler panic", log.Error(err), log.String("stacktrace", string(debug.Stack())))
 				w.WriteHeader(http.StatusInternalServerError)
 			}
 		}()


### PR DESCRIPTION
This adds a stacktrace to the middleware that catches panics. Catching the panic keeps the process from crashing, but without the stacktrace, it makes it really difficult to debug why the panic was happening in the first place. 

Inspired by [this debugging session](https://sourcegraph.slack.com/archives/CHEKCRWKV/p1665113964050739?thread_ts=1665052545.120739&cid=CHEKCRWKV). 

## Test plan

Manually tested that a log message from a panic includes the stack trace. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
