### PR TITLE
`lib/group`: propagate panics from child goroutines

### DIFF
--- a/lib/group/group_test.go
+++ b/lib/group/group_test.go
@@ -52,6 +52,19 @@ func TestGroup(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("propagate panic", func(t *testing.T) {
+		g := New()
+		for i := 0; i < 10; i++ {
+			i := i
+			g.Go(func() {
+				if i == 5 {
+					panic(i)
+				}
+			})
+		}
+		require.Panics(t, func() { g.Wait() })
+	})
 }
 
 func TestErrorGroup(t *testing.T) {


### PR DESCRIPTION
Scoped concurrency is nice. `lib/group` gets you part way there by taking care of all the tricky goroutine spawning and joining. One thing that is painful about using goroutines in general is that unhandled panics in spawned goroutines will crash the entire process. `lib/group` currently handles this by always catching panics in child goroutines and logging them.

However, logging is not always the correct solution. Especially since you sometimes need to know that your task did not succeed (which can happen even with tasks that do not return errors). Instead, panics can be _moved_ into the calling goroutine, which will usually have its own panic handlers.

This PR updates the `lib/group` package so that any panics in spawned goroutines are recovered then propagated to the calling goroutine when `g.Wait()` is called. This adds some safety without throwing away any information.

Additionally, the error message for the propagated panic **includes the stack trace from the child goroutine**, which is a huge boon for debugging. Frequently, things that implement `recover` will lose the stack trace information, so it's really difficult to figure out what caused the panic in the first place.

## Test plan

Added test. Manually tested for a readable stack trace from a child goroutine. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
