### PR TITLE
Add PersonalAccessToken type and refactor improper uses of OAuthBearerToken

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service_collaborators.go
+++ b/cmd/frontend/graphqlbackend/external_service_collaborators.go
@@ -58,7 +58,7 @@ func (r *externalServiceResolver) InvitableCollaborators(ctx context.Context) ([
 	}
 	baseURL = extsvc.NormalizeBaseURL(baseURL)
 	githubUrl, _ := github.APIRoot(baseURL)
-	client := github.NewV4Client(r.externalService.URN(), githubUrl, &auth.OAuthBearerToken{Token: githubCfg.Token}, nil)
+	client := github.NewV4Client(r.externalService.URN(), githubUrl, &auth.PersonalAccessToken{Token: githubCfg.Token}, nil)
 
 	possibleRepos := githubCfg.Repos
 	if len(possibleRepos) == 0 {

--- a/cmd/frontend/internal/httpapi/releasecache/cache_test.go
+++ b/cmd/frontend/internal/httpapi/releasecache/cache_test.go
@@ -140,7 +140,7 @@ func newTestClient(t *testing.T) *github.V4Client {
 	u, err := url.Parse("https://api.github.com")
 	require.NoError(t, err)
 
-	a := auth.OAuthBearerToken{Token: os.Getenv("GITHUB_TOKEN")}
+	a := auth.PersonalAccessToken{Token: os.Getenv("GITHUB_TOKEN")}
 
 	return github.NewV4Client("https://github.com", u, &a, doer)
 }

--- a/cmd/frontend/internal/httpapi/releasecache/config.go
+++ b/cmd/frontend/internal/httpapi/releasecache/config.go
@@ -93,7 +93,7 @@ func parseSiteConfig(conf *conf.Unified) (*config, error) {
 
 // NewReleaseCache builds a new VersionCache based on the current site config.
 func (c *config) NewReleaseCache(logger log.Logger) ReleaseCache {
-	client := github.NewV4Client(c.urn, c.api, &auth.OAuthBearerToken{Token: c.token}, nil)
+	client := github.NewV4Client(c.urn, c.api, &auth.PersonalAccessToken{Token: c.token}, nil)
 
 	return newReleaseCache(logger, client, c.owner, c.name)
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
@@ -132,8 +132,8 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 			ExternalServiceType: githubRepo.ExternalRepo.ServiceType,
 			ExternalServiceID:   githubRepo.ExternalRepo.ServiceID,
 		},
-		&auth.OAuthBearerTokenWithSSH{
-			OAuthBearerToken: auth.OAuthBearerToken{Token: gitHubToken},
+		&auth.PersonalAccessTokenWithSSH{
+			PersonalAccessToken: auth.PersonalAccessToken{Token: gitHubToken},
 		},
 	); err != nil {
 		t.Fatal(err)

--- a/enterprise/cmd/frontend/internal/batches/resolvers/code_host_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/code_host_connection_test.go
@@ -55,7 +55,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 			ExternalServiceID:   ghRepo.ExternalRepo.ServiceID,
 			ExternalServiceType: ghRepo.ExternalRepo.ServiceType,
 		}
-		token := &auth.OAuthBearerToken{Token: "SOSECRET"}
+		token := &auth.PersonalAccessToken{Token: "SOSECRET"}
 		if err := bstore.CreateSiteCredential(ctx, cred, token); err != nil {
 			t.Fatal(err)
 		}
@@ -161,7 +161,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 			ExternalServiceID:   ghRepo.ExternalRepo.ServiceID,
 			ExternalServiceType: ghRepo.ExternalRepo.ServiceType,
 			UserID:              userID,
-		}, &auth.OAuthBearerToken{Token: "SOSECRET"})
+		}, &auth.PersonalAccessToken{Token: "SOSECRET"})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -169,7 +169,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 			ExternalServiceID:   bbsRepo.ExternalRepo.ServiceID,
 			ExternalServiceType: bbsRepo.ExternalRepo.ServiceType,
 		}
-		token := &auth.OAuthBearerToken{Token: "SOSECRET"}
+		token := &auth.PersonalAccessToken{Token: "SOSECRET"}
 		if err := bstore.CreateSiteCredential(ctx, siteCred, token); err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
@@ -511,7 +511,7 @@ func TestPermissionLevels(t *testing.T) {
 							ExternalServiceID:   "https://github.com/",
 							ExternalServiceType: extsvc.TypeGitHub,
 							UserID:              tc.user,
-						}, &auth.OAuthBearerToken{Token: "SOSECRET"})
+						}, &auth.PersonalAccessToken{Token: "SOSECRET"})
 						if err != nil {
 							t.Fatal(err)
 						}
@@ -521,7 +521,7 @@ func TestPermissionLevels(t *testing.T) {
 							ExternalServiceID:   "https://github.com/",
 							ExternalServiceType: extsvc.TypeGitHub,
 						}
-						token := &auth.OAuthBearerToken{Token: "SOSECRET"}
+						token := &auth.PersonalAccessToken{Token: "SOSECRET"}
 						if err := bstore.CreateSiteCredential(ctx, cred, token); err != nil {
 							t.Fatal(err)
 						}
@@ -834,7 +834,7 @@ query($includeLocallyExecutedSpecs: Boolean) {
 							ExternalServiceID:   "https://github.com/",
 							ExternalServiceType: extsvc.TypeGitHub,
 							UserID:              tc.user,
-						}, &auth.OAuthBearerToken{Token: "SOSECRET"})
+						}, &auth.PersonalAccessToken{Token: "SOSECRET"})
 						if err != nil {
 							t.Fatal(err)
 						}
@@ -844,7 +844,7 @@ query($includeLocallyExecutedSpecs: Boolean) {
 							ExternalServiceID:   "https://github.com/",
 							ExternalServiceType: extsvc.TypeGitHub,
 						}
-						token := &auth.OAuthBearerToken{Token: "SOSECRET"}
+						token := &auth.PersonalAccessToken{Token: "SOSECRET"}
 						if err := bstore.CreateSiteCredential(ctx, cred, token); err != nil {
 							t.Fatal(err)
 						}
@@ -1312,7 +1312,7 @@ query($includeLocallyExecutedSpecs: Boolean) {
 							ExternalServiceID:   "https://github.com/",
 							ExternalServiceType: extsvc.TypeGitHub,
 							UserID:              tc.user,
-						}, &auth.OAuthBearerToken{Token: "SOSECRET"})
+						}, &auth.PersonalAccessToken{Token: "SOSECRET"})
 						if err != nil {
 							t.Fatal(err)
 						}
@@ -1322,7 +1322,7 @@ query($includeLocallyExecutedSpecs: Boolean) {
 							ExternalServiceID:   "https://github.com/",
 							ExternalServiceType: extsvc.TypeGitHub,
 						}
-						token := &auth.OAuthBearerToken{Token: "SOSECRET"}
+						token := &auth.PersonalAccessToken{Token: "SOSECRET"}
 						if err := bstore.CreateSiteCredential(ctx, cred, token); err != nil {
 							t.Fatal(err)
 						}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -1171,11 +1171,11 @@ func (r *Resolver) generateAuthenticatorForCredential(ctx context.Context, exter
 			Passphrase: keypair.Passphrase,
 		}
 	} else {
-		a = &auth.OAuthBearerTokenWithSSH{
-			OAuthBearerToken: auth.OAuthBearerToken{Token: credential},
-			PrivateKey:       keypair.PrivateKey,
-			PublicKey:        keypair.PublicKey,
-			Passphrase:       keypair.Passphrase,
+		a = &auth.PersonalAccessTokenWithSSH{
+			PersonalAccessToken: auth.PersonalAccessToken{Token: credential},
+			PrivateKey:          keypair.PrivateKey,
+			PublicKey:           keypair.PublicKey,
+			Passphrase:          keypair.Passphrase,
 		}
 	}
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -1637,7 +1637,7 @@ func TestDeleteBatchChangesCredential(t *testing.T) {
 
 	bstore := store.New(db, &observation.TestContext, nil)
 
-	authenticator := &auth.OAuthBearerToken{Token: "SOSECRET"}
+	authenticator := &auth.PersonalAccessToken{Token: "SOSECRET"}
 	userCred, err := bstore.UserCredentials().Create(ctx, database.UserCredentialScope{
 		Domain:              database.UserCredentialDomainBatches,
 		ExternalServiceType: extsvc.TypeGitHub,
@@ -2292,7 +2292,7 @@ func TestCheckBatchChangesCredential(t *testing.T) {
 
 	bstore := store.New(db, &observation.TestContext, nil)
 
-	authenticator := &auth.OAuthBearerToken{Token: "SOSECRET"}
+	authenticator := &auth.PersonalAccessToken{Token: "SOSECRET"}
 	userCred, err := bstore.UserCredentials().Create(ctx, database.UserCredentialScope{
 		Domain:              database.UserCredentialDomainBatches,
 		ExternalServiceType: extsvc.TypeGitHub,

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
@@ -101,8 +101,8 @@ func testBitbucketServerWebhook(db database.DB, userID int32) func(*testing.T) {
 			ExternalServiceType: bitbucketRepo.ExternalRepo.ServiceType,
 			ExternalServiceID:   bitbucketRepo.ExternalRepo.ServiceID,
 		},
-			&auth.OAuthBearerTokenWithSSH{
-				OAuthBearerToken: auth.OAuthBearerToken{Token: bitbucketServerToken},
+			&auth.PersonalAccessTokenWithSSH{
+				PersonalAccessToken: auth.PersonalAccessToken{Token: bitbucketServerToken},
 			},
 		); err != nil {
 			t.Fatal(err)

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -96,8 +96,8 @@ func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 			ExternalServiceType: githubRepo.ExternalRepo.ServiceType,
 			ExternalServiceID:   githubRepo.ExternalRepo.ServiceID,
 		},
-			&auth.OAuthBearerTokenWithSSH{
-				OAuthBearerToken: auth.OAuthBearerToken{Token: token},
+			&auth.PersonalAccessTokenWithSSH{
+				PersonalAccessToken: auth.PersonalAccessToken{Token: token},
 			},
 		); err != nil {
 			t.Fatal(err)

--- a/enterprise/cmd/repo-updater/internal/authz/integration_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/integration_test.go
@@ -87,7 +87,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			cli := extsvcGitHub.NewV3Client(logtest.Scoped(t), svc.URN(), uri, &auth.OAuthBearerToken{Token: token}, doer)
+			cli := extsvcGitHub.NewV3Client(logtest.Scoped(t), svc.URN(), uri, &auth.PersonalAccessToken{Token: token}, doer)
 
 			testDB := database.NewDB(logger, dbtest.NewDB(logger, t))
 			ctx := actor.WithInternalActor(context.Background())
@@ -167,7 +167,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			cli := extsvcGitHub.NewV3Client(logtest.Scoped(t), svc.URN(), uri, &auth.OAuthBearerToken{Token: token}, doer)
+			cli := extsvcGitHub.NewV3Client(logtest.Scoped(t), svc.URN(), uri, &auth.PersonalAccessToken{Token: token}, doer)
 
 			testDB := database.NewDB(logger, dbtest.NewDB(logger, t))
 			ctx := actor.WithInternalActor(context.Background())
@@ -252,7 +252,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 		})
 	})
 
-	// This integration tests performs a repository-centric permissions syncing against
+	// This integration tests performs a user-centric permissions syncing against
 	// https://github.com, then check if permissions are correctly granted for the test
 	// user "sourcegraph-vcr", who is a collaborator of "sourcegraph-vcr-repos/private-org-repo-1".
 	t.Run("user-centric", func(t *testing.T) {
@@ -270,7 +270,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			cli := extsvcGitHub.NewV3Client(logtest.Scoped(t), svc.URN(), uri, &auth.OAuthBearerToken{Token: token}, doer)
+			cli := extsvcGitHub.NewV3Client(logtest.Scoped(t), svc.URN(), uri, &auth.PersonalAccessToken{Token: token}, doer)
 
 			testDB := database.NewDB(logger, dbtest.NewDB(logger, t))
 			ctx := actor.WithInternalActor(context.Background())
@@ -353,7 +353,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			cli := extsvcGitHub.NewV3Client(logtest.Scoped(t), svc.URN(), uri, &auth.OAuthBearerToken{Token: token}, doer)
+			cli := extsvcGitHub.NewV3Client(logtest.Scoped(t), svc.URN(), uri, &auth.PersonalAccessToken{Token: token}, doer)
 
 			testDB := database.NewDB(logger, dbtest.NewDB(logger, t))
 			ctx := actor.WithInternalActor(context.Background())

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -275,7 +275,7 @@ func (s *PermsSyncer) getUserGitHubAppInstallations(ctx context.Context, acct *e
 	}
 
 	oauthToken := &auth.OAuthBearerToken{
-		Token:              tok.AccessToken,
+		AccessToken:        tok.AccessToken,
 		RefreshToken:       tok.RefreshToken,
 		Expiry:             tok.Expiry,
 		RefreshFunc:        database.GetAccountRefreshAndStoreOAuthTokenFunc(db, acct.ID, github.GetOAuthContext(acct.ServiceID)),

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -57,7 +57,7 @@ func NewProvider(urn string, opts ProviderOptions) *Provider {
 	if opts.GitHubClient == nil {
 		apiURL, _ := github.APIRoot(opts.GitHubURL)
 		opts.GitHubClient = github.NewV3Client(log.Scoped("provider.github.v3", "provider github client"),
-			urn, apiURL, &auth.OAuthBearerToken{Token: opts.BaseToken}, nil)
+			urn, apiURL, &auth.PersonalAccessToken{Token: opts.BaseToken}, nil)
 	}
 
 	codeHost := extsvc.NewCodeHost(opts.GitHubURL, extsvc.TypeGitHub)
@@ -349,7 +349,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 	}
 
 	oauthToken := &auth.OAuthBearerToken{
-		Token:        tok.AccessToken,
+		AccessToken:  tok.AccessToken,
 		RefreshToken: tok.RefreshToken,
 		Expiry:       tok.Expiry,
 	}
@@ -366,7 +366,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 // FetchUserPermsByToken is the same as FetchUserPerms, but it only requires a
 // token.
 func (p *Provider) FetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	return p.fetchUserPermsByToken(ctx, "", &auth.OAuthBearerToken{Token: token}, opts)
+	return p.fetchUserPermsByToken(ctx, "", &auth.OAuthBearerToken{AccessToken: token}, opts)
 }
 
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to

--- a/enterprise/internal/authz/gitlab/oauth.go
+++ b/enterprise/internal/authz/gitlab/oauth.go
@@ -109,7 +109,7 @@ func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Acco
 	}
 
 	token := &auth.OAuthBearerToken{
-		Token:              tok.AccessToken,
+		AccessToken:        tok.AccessToken,
 		RefreshToken:       tok.RefreshToken,
 		Expiry:             tok.Expiry,
 		RefreshFunc:        database.GetAccountRefreshAndStoreOAuthTokenFunc(p.db, account.ID, gitlab.GetOAuthContext(strings.TrimSuffix(p.ServiceID(), "/"))),

--- a/enterprise/internal/batches/reconciler/executor_test.go
+++ b/enterprise/internal/batches/reconciler/executor_test.go
@@ -606,7 +606,7 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 				Err:                     tc.sourcerErr,
 				ChangesetExists:         tc.alreadyExists,
 				IsArchivedPushErrorTrue: tc.isRepoArchived,
-				CurrentAuthenticator:    &auth.OAuthBearerTokenWithSSH{OAuthBearerToken: auth.OAuthBearerToken{Token: "token"}},
+				CurrentAuthenticator:    &auth.PersonalAccessTokenWithSSH{PersonalAccessToken: auth.PersonalAccessToken{Token: "token"}},
 			}
 
 			if tc.sourcerMetadata != nil {
@@ -900,7 +900,7 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 			user:       user,
 			extSvc:     gitHubExtSvc,
 			repo:       gitHubRepo,
-			credential: &auth.OAuthBearerToken{Token: "my-secret-github-token"},
+			credential: &auth.PersonalAccessToken{Token: "my-secret-github-token"},
 			wantPushConfig: &gitprotocol.PushConfig{
 				RemoteURL: "https://my-secret-github-token@github.com/sourcegraph/" + string(gitHubRepo.Name),
 			},
@@ -924,7 +924,7 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 			user:       user,
 			extSvc:     gitLabExtSvc,
 			repo:       gitLabRepo,
-			credential: &auth.OAuthBearerToken{Token: "my-secret-gitlab-token"},
+			credential: &auth.PersonalAccessToken{Token: "my-secret-gitlab-token"},
 			wantPushConfig: &gitprotocol.PushConfig{
 				RemoteURL: "https://git:my-secret-gitlab-token@gitlab.com/sourcegraph/" + string(gitLabRepo.Name),
 			},
@@ -986,11 +986,11 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 			user:   admin,
 			extSvc: bbsSSHExtsvc,
 			repo:   bbsSSHRepo,
-			credential: &auth.OAuthBearerTokenWithSSH{
-				OAuthBearerToken: auth.OAuthBearerToken{Token: "test"},
-				PrivateKey:       "private key",
-				PublicKey:        "public key",
-				Passphrase:       "passphrase",
+			credential: &auth.PersonalAccessTokenWithSSH{
+				PersonalAccessToken: auth.PersonalAccessToken{Token: "test"},
+				PrivateKey:          "private key",
+				PublicKey:           "public key",
+				Passphrase:          "passphrase",
 			},
 			wantPushConfig: &gitprotocol.PushConfig{
 				RemoteURL:  "ssh://git@bitbucket.sgdev.org:7999/" + string(bbsSSHRepo.Name),
@@ -1003,7 +1003,7 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 			user:       admin,
 			extSvc:     bbsSSHExtsvc,
 			repo:       bbsSSHRepo,
-			credential: &auth.OAuthBearerToken{Token: "test"},
+			credential: &auth.PersonalAccessToken{Token: "test"},
 			wantErr:    true,
 		},
 	}

--- a/enterprise/internal/batches/reconciler/reconciler_test.go
+++ b/enterprise/internal/batches/reconciler/reconciler_test.go
@@ -139,7 +139,7 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 			fakeSource := &stesting.FakeChangesetSource{
 				Svc:                  extSvc,
 				FakeMetadata:         githubPR,
-				CurrentAuthenticator: &auth.OAuthBearerTokenWithSSH{},
+				CurrentAuthenticator: &auth.PersonalAccessTokenWithSSH{},
 			}
 			if changesetSpec != nil {
 				fakeSource.WantHeadRef = changesetSpec.HeadRef

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -1171,7 +1171,7 @@ func (s *Service) FetchUsernameForBitbucketServerToken(ctx context.Context, exte
 	defer endObservation(1, observation.Args{})
 
 	// Get a changeset source for the external service and use the given authenticator.
-	css, err := s.sourcer.ForExternalService(ctx, s.store, &auth.OAuthBearerToken{Token: token}, store.GetExternalServiceIDsOpts{
+	css, err := s.sourcer.ForExternalService(ctx, s.store, &auth.PersonalAccessToken{Token: token}, store.GetExternalServiceIDsOpts{
 		ExternalServiceType: externalServiceType,
 		ExternalServiceID:   externalServiceID,
 	})

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -904,7 +904,7 @@ index e5af166..d44c3fc 100644
 				ctx,
 				"https://github.com/",
 				extsvc.TypeGitHub,
-				&auth.OAuthBearerToken{Token: "test123"},
+				&auth.PersonalAccessToken{Token: "test123"},
 			); err != nil {
 				t.Fatal(err)
 			}
@@ -919,7 +919,7 @@ index e5af166..d44c3fc 100644
 				ctx,
 				"https://github.com/",
 				extsvc.TypeGitHub,
-				&auth.OAuthBearerToken{Token: "test123"},
+				&auth.PersonalAccessToken{Token: "test123"},
 			); err == nil {
 				t.Fatal("unexpected nil-error returned from ValidateAuthenticator")
 			}

--- a/enterprise/internal/batches/sources/bitbucketcloud_test.go
+++ b/enterprise/internal/batches/sources/bitbucketcloud_test.go
@@ -96,6 +96,8 @@ func TestBitbucketCloudSource_WithAuthenticator(t *testing.T) {
 			&auth.OAuthBearerToken{},
 			&auth.OAuthBearerTokenWithSSH{},
 			&auth.OAuthClient{},
+			&auth.PersonalAccessToken{},
+			&auth.PersonalAccessTokenWithSSH{},
 		} {
 			t.Run(fmt.Sprintf("%T", au), func(t *testing.T) {
 				newSource, err := s.WithAuthenticator(au)

--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -67,6 +67,8 @@ func (s BitbucketServerSource) WithAuthenticator(a auth.Authenticator) (Changese
 		*auth.OAuthBearerTokenWithSSH,
 		*auth.BasicAuth,
 		*auth.BasicAuthWithSSH,
+		*auth.PersonalAccessToken,
+		*auth.PersonalAccessTokenWithSSH,
 		*bitbucketserver.SudoableOAuthClient:
 		break
 

--- a/enterprise/internal/batches/sources/bitbucketserver_test.go
+++ b/enterprise/internal/batches/sources/bitbucketserver_test.go
@@ -647,6 +647,7 @@ func TestBitbucketServerSource_WithAuthenticator(t *testing.T) {
 			"BasicAuth":           &auth.BasicAuth{},
 			"OAuthBearerToken":    &auth.OAuthBearerToken{},
 			"SudoableOAuthClient": &bitbucketserver.SudoableOAuthClient{},
+			"PersonalAccessToken": &auth.PersonalAccessToken{},
 		} {
 			t.Run(name, func(t *testing.T) {
 				src, err := bbsSrc.WithAuthenticator(tc)

--- a/enterprise/internal/batches/sources/github.go
+++ b/enterprise/internal/batches/sources/github.go
@@ -64,7 +64,7 @@ func newGithubSource(urn string, c *schema.GitHubConnection, cf *httpcli.Factory
 
 	var authr = au
 	if au == nil {
-		authr = &auth.OAuthBearerToken{Token: c.Token}
+		authr = &auth.PersonalAccessToken{Token: c.Token}
 	}
 
 	return &GithubSource{
@@ -79,8 +79,8 @@ func (s GithubSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfi
 
 func (s GithubSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error) {
 	switch a.(type) {
-	case *auth.OAuthBearerToken,
-		*auth.OAuthBearerTokenWithSSH:
+	case *auth.PersonalAccessToken,
+		*auth.PersonalAccessTokenWithSSH:
 		break
 
 	default:

--- a/enterprise/internal/batches/sources/github_test.go
+++ b/enterprise/internal/batches/sources/github_test.go
@@ -582,7 +582,7 @@ func TestGithubSource_WithAuthenticator(t *testing.T) {
 	}
 
 	t.Run("supported", func(t *testing.T) {
-		src, err := githubSrc.WithAuthenticator(&auth.OAuthBearerToken{})
+		src, err := githubSrc.WithAuthenticator(&auth.PersonalAccessToken{})
 		if err != nil {
 			t.Errorf("unexpected non-nil error: %v", err)
 		}
@@ -596,9 +596,10 @@ func TestGithubSource_WithAuthenticator(t *testing.T) {
 
 	t.Run("unsupported", func(t *testing.T) {
 		for name, tc := range map[string]auth.Authenticator{
-			"nil":         nil,
-			"BasicAuth":   &auth.BasicAuth{},
-			"OAuthClient": &auth.OAuthClient{},
+			"nil":              nil,
+			"BasicAuth":        &auth.BasicAuth{},
+			"OAuthClient":      &auth.OAuthClient{},
+			"OAuthBearerToken": &auth.OAuthBearerToken{},
 		} {
 			t.Run(name, func(t *testing.T) {
 				src, err := githubSrc.WithAuthenticator(tc)

--- a/enterprise/internal/batches/sources/gitlab.go
+++ b/enterprise/internal/batches/sources/gitlab.go
@@ -64,12 +64,7 @@ func newGitLabSource(urn string, c *schema.GitLabConnection, cf *httpcli.Factory
 	// Don't modify passed-in parameter.
 	var authr auth.Authenticator
 	if c.Token != "" {
-		switch c.TokenType {
-		case "oauth":
-			authr = &auth.OAuthBearerToken{Token: c.Token}
-		default:
-			authr = &gitlab.SudoableToken{Token: c.Token}
-		}
+		authr = &gitlab.SudoableToken{PersonalAccessToken: auth.PersonalAccessToken{Token: c.Token}}
 	}
 
 	provider := gitlab.NewClientProvider(urn, baseURL, cli)
@@ -85,8 +80,8 @@ func (s GitLabSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfi
 
 func (s GitLabSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error) {
 	switch a.(type) {
-	case *auth.OAuthBearerToken,
-		*auth.OAuthBearerTokenWithSSH:
+	case *auth.PersonalAccessToken,
+		*auth.PersonalAccessTokenWithSSH:
 		break
 
 	default:

--- a/enterprise/internal/batches/sources/gitlab_test.go
+++ b/enterprise/internal/batches/sources/gitlab_test.go
@@ -1250,7 +1250,7 @@ func TestGitLabSource_WithAuthenticator(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected non-nil error: %v", err)
 		}
-		src, err = src.WithAuthenticator(&auth.OAuthBearerToken{})
+		src, err = src.WithAuthenticator(&auth.PersonalAccessToken{})
 		if err != nil {
 			t.Errorf("unexpected non-nil error: %v", err)
 		}

--- a/enterprise/internal/batches/sources/sources.go
+++ b/enterprise/internal/batches/sources/sources.go
@@ -183,12 +183,12 @@ func GitserverPushConfig(repo *types.Repo, au auth.Authenticator) (*protocol.Pus
 
 	extSvcType := repo.ExternalRepo.ServiceType
 	switch av := au.(type) {
-	case *auth.OAuthBearerTokenWithSSH:
-		if err := setOAuthTokenAuth(cloneURL, extSvcType, av.Token); err != nil {
+	case *auth.PersonalAccessTokenWithSSH:
+		if err := setTokenAuth(cloneURL, extSvcType, av.Token); err != nil {
 			return nil, err
 		}
-	case *auth.OAuthBearerToken:
-		if err := setOAuthTokenAuth(cloneURL, extSvcType, av.Token); err != nil {
+	case *auth.PersonalAccessToken:
+		if err := setTokenAuth(cloneURL, extSvcType, av.Token); err != nil {
 			return nil, err
 		}
 
@@ -351,9 +351,9 @@ func loadSiteCredential(ctx context.Context, s SourcerStore, opts store.GetSiteC
 	return nil, nil
 }
 
-// setOAuthTokenAuth sets the user part of the given URL to use the provided OAuth token,
+// setTokenAuth sets the user part of the given URL to use the provided OAuth token,
 // with the specific quirks per code host.
-func setOAuthTokenAuth(u *vcs.URL, extSvcType, token string) error {
+func setTokenAuth(u *vcs.URL, extSvcType, token string) error {
 	switch extSvcType {
 	case extsvc.TypeGitHub:
 		u.User = url.User(token)
@@ -365,7 +365,7 @@ func setOAuthTokenAuth(u *vcs.URL, extSvcType, token string) error {
 		return errors.New("require username/token to push commits to BitbucketServer")
 
 	default:
-		panic(fmt.Sprintf("setOAuthTokenAuth: invalid external service type %q", extSvcType))
+		panic(fmt.Sprintf("setTokenAuth: invalid external service type %q", extSvcType))
 	}
 	return nil
 }

--- a/enterprise/internal/batches/sources/sources_test.go
+++ b/enterprise/internal/batches/sources/sources_test.go
@@ -178,12 +178,12 @@ func TestLoadExternalService(t *testing.T) {
 }
 
 func TestGitserverPushConfig(t *testing.T) {
-	oauthHTTPSAuthenticator := auth.OAuthBearerToken{Token: "bearer-test"}
-	oauthSSHAuthenticator := auth.OAuthBearerTokenWithSSH{
-		OAuthBearerToken: oauthHTTPSAuthenticator,
-		PrivateKey:       "private-key",
-		Passphrase:       "passphrase",
-		PublicKey:        "public-key",
+	patHTTPSAuthenticator := auth.PersonalAccessToken{Token: "bearer-test"}
+	patSSHAuthenticator := auth.PersonalAccessTokenWithSSH{
+		PersonalAccessToken: patHTTPSAuthenticator,
+		PrivateKey:          "private-key",
+		Passphrase:          "passphrase",
+		PublicKey:           "public-key",
 	}
 	basicHTTPSAuthenticator := auth.BasicAuth{Username: "basic", Password: "pw"}
 	basicSSHAuthenticator := auth.BasicAuthWithSSH{
@@ -216,7 +216,7 @@ func TestGitserverPushConfig(t *testing.T) {
 			repoName:            "github.com/sourcegraph/sourcegraph",
 			externalServiceType: extsvc.TypeGitHub,
 			cloneURLs:           []string{"https://github.com/sourcegraph/sourcegraph"},
-			authenticator:       &oauthHTTPSAuthenticator,
+			authenticator:       &patHTTPSAuthenticator,
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL: "https://bearer-test@github.com/sourcegraph/sourcegraph",
 			},
@@ -226,7 +226,7 @@ func TestGitserverPushConfig(t *testing.T) {
 			repoName:            "github.com/sourcegraph/sourcegraph",
 			externalServiceType: extsvc.TypeGitHub,
 			cloneURLs:           []string{"git@github.com:sourcegraph/sourcegraph.git"},
-			authenticator:       &oauthSSHAuthenticator,
+			authenticator:       &patSSHAuthenticator,
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL:  "git@github.com:sourcegraph/sourcegraph.git",
 				PrivateKey: "private-key",
@@ -238,7 +238,7 @@ func TestGitserverPushConfig(t *testing.T) {
 			repoName:            "sourcegraph/sourcegraph",
 			externalServiceType: extsvc.TypeGitLab,
 			cloneURLs:           []string{"https://gitlab.com/sourcegraph/sourcegraph"},
-			authenticator:       &oauthHTTPSAuthenticator,
+			authenticator:       &patHTTPSAuthenticator,
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL: "https://git:bearer-test@gitlab.com/sourcegraph/sourcegraph",
 			},
@@ -248,7 +248,7 @@ func TestGitserverPushConfig(t *testing.T) {
 			repoName:            "sourcegraph/sourcegraph",
 			externalServiceType: extsvc.TypeGitLab,
 			cloneURLs:           []string{"git@gitlab.com:sourcegraph/sourcegraph.git"},
-			authenticator:       &oauthSSHAuthenticator,
+			authenticator:       &patSSHAuthenticator,
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL:  "git@gitlab.com:sourcegraph/sourcegraph.git",
 				PrivateKey: "private-key",
@@ -348,8 +348,8 @@ func TestSourcer_ForChangeset(t *testing.T) {
 		},
 	}
 
-	siteToken := &auth.OAuthBearerToken{Token: "site"}
-	userToken := &auth.OAuthBearerToken{Token: "user"}
+	siteToken := &auth.PersonalAccessToken{Token: "site"}
+	userToken := &auth.OAuthBearerToken{AccessToken: "user"}
 
 	t.Run("created changesets", func(t *testing.T) {
 		bc := &btypes.BatchChange{ID: 1, LastApplierID: 3}

--- a/enterprise/internal/batches/store/site_credentials_test.go
+++ b/enterprise/internal/batches/store/site_credentials_test.go
@@ -29,7 +29,7 @@ func testStoreSiteCredentials(t *testing.T, ctx context.Context, s *Store, clock
 				ExternalServiceType: externalServiceTypes[i],
 				ExternalServiceID:   "https://someurl.test",
 			}
-			token := &auth.OAuthBearerToken{Token: "123"}
+			token := &auth.PersonalAccessToken{Token: "123"}
 
 			if err := s.CreateSiteCredential(ctx, cred, token); err != nil {
 				t.Fatal(err)

--- a/enterprise/internal/batches/testing/credentials.go
+++ b/enterprise/internal/batches/testing/credentials.go
@@ -23,7 +23,7 @@ func CreateTestSiteCredential(t *testing.T, bstore createSiteCredentialer, repo 
 	if err := bstore.CreateSiteCredential(
 		context.Background(),
 		cred,
-		&auth.OAuthBearerToken{Token: "test"},
+		&auth.PersonalAccessToken{Token: "test"},
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/codeintel/uploads/transport/http/auth/github.go
+++ b/internal/codeintel/uploads/transport/http/auth/github.go
@@ -59,7 +59,7 @@ func uncachedEnforceAuthViaGitHub(ctx context.Context, githubToken, repoName str
 	logger := log.Scoped("uncachedEnforceAuthViaGitHub", "uncached authentication enforcement")
 
 	ghClient := github.NewV3Client(logger,
-		extsvc.URNCodeIntel, githubURL, &auth.OAuthBearerToken{Token: githubToken}, nil)
+		extsvc.URNCodeIntel, githubURL, &auth.PersonalAccessToken{Token: githubToken}, nil)
 
 	if author, err := checkGitHubPermissions(ctx, repoName, ghClient); err != nil {
 		if githubErr := new(github.APIError); errors.As(err, &githubErr) {

--- a/internal/database/authenticator.go
+++ b/internal/database/authenticator.go
@@ -24,6 +24,8 @@ const (
 	AuthenticatorTypeOAuthBearerTokenWithSSH            AuthenticatorType = "OAuthBearerTokenWithSSH"
 	AuthenticatorTypeBitbucketServerSudoableOAuthClient AuthenticatorType = "BitbucketSudoableOAuthClient"
 	AuthenticatorTypeGitLabSudoableToken                AuthenticatorType = "GitLabSudoableToken"
+	AuthenticatorTypePersonalAccessToken                AuthenticatorType = "PersonalAccessToken"
+	AuthenticatorTypePersonalAccessTokenWithSSH         AuthenticatorType = "PersonalAccessTokenWithSSH"
 )
 
 // NullAuthenticator represents an authenticator that may be null. It implements
@@ -79,6 +81,10 @@ func MarshalAuthenticator(a auth.Authenticator) (string, error) {
 		t = AuthenticatorTypeOAuthBearerToken
 	case *auth.OAuthBearerTokenWithSSH:
 		t = AuthenticatorTypeOAuthBearerTokenWithSSH
+	case *auth.PersonalAccessToken:
+		t = AuthenticatorTypePersonalAccessToken
+	case *auth.PersonalAccessTokenWithSSH:
+		t = AuthenticatorTypePersonalAccessTokenWithSSH
 	case *bitbucketserver.SudoableOAuthClient:
 		t = AuthenticatorTypeBitbucketServerSudoableOAuthClient
 	case *gitlab.SudoableToken:
@@ -125,6 +131,10 @@ func UnmarshalAuthenticator(raw string) (auth.Authenticator, error) {
 		a = &auth.OAuthBearerToken{}
 	case AuthenticatorTypeOAuthBearerTokenWithSSH:
 		a = &auth.OAuthBearerTokenWithSSH{}
+	case AuthenticatorTypePersonalAccessToken:
+		a = &auth.PersonalAccessToken{}
+	case AuthenticatorTypePersonalAccessTokenWithSSH:
+		a = &auth.PersonalAccessTokenWithSSH{}
 	case AuthenticatorTypeBitbucketServerSudoableOAuthClient:
 		a = &bitbucketserver.SudoableOAuthClient{}
 	case AuthenticatorTypeGitLabSudoableToken:

--- a/internal/database/oauth_token_helper.go
+++ b/internal/database/oauth_token_helper.go
@@ -42,7 +42,7 @@ func externalAccountTokenRefresher(db DB, externalAccountID int32, refreshToken 
 			return nil, errors.Wrap(err, "save refreshed token")
 		}
 		return &auth.OAuthBearerToken{
-			Token:        refreshedToken.AccessToken,
+			AccessToken:  refreshedToken.AccessToken,
 			RefreshToken: refreshedToken.RefreshToken,
 			Expiry:       refreshedToken.Expiry,
 		}, nil
@@ -64,7 +64,7 @@ func externalServiceTokenRefresher(db DB, externalServiceID int64, refreshToken 
 		}
 
 		oauthBearerToken := &auth.OAuthBearerToken{
-			Token:        refreshedToken.AccessToken,
+			AccessToken:  refreshedToken.AccessToken,
 			RefreshToken: refreshedToken.RefreshToken,
 			Expiry:       refreshedToken.Expiry,
 		}
@@ -79,7 +79,7 @@ func externalServiceTokenRefresher(db DB, externalServiceID int64, refreshToken 
 			return nil, errors.Wrap(err, "decrypt config")
 		}
 
-		config, err = jsonc.Edit(config, oauthBearerToken.Token, "token")
+		config, err = jsonc.Edit(config, oauthBearerToken.AccessToken, "token")
 		if err != nil {
 			return nil, errors.Wrap(err, "update OAuth token")
 		}
@@ -109,7 +109,7 @@ func GetServiceRefreshAndStoreOAuthTokenFunc(db DB, externalServiceID int64, oau
 			return "", "", time.Time{}, err
 		}
 
-		return token.Token, token.RefreshToken, token.Expiry, nil
+		return token.AccessToken, token.RefreshToken, token.Expiry, nil
 	}
 }
 
@@ -121,6 +121,6 @@ func GetAccountRefreshAndStoreOAuthTokenFunc(db DB, externalAccountID int32, oau
 			return "", "", time.Time{}, err
 		}
 
-		return token.Token, token.RefreshToken, token.Expiry, nil
+		return token.AccessToken, token.RefreshToken, token.Expiry, nil
 	}
 }

--- a/internal/database/oauth_token_helper_test.go
+++ b/internal/database/oauth_token_helper_test.go
@@ -88,7 +88,7 @@ func TestExternalServiceTokenRefresher(t *testing.T) {
 
 	newToken, err := externalServiceTokenRefresher(db, 2, "refresh_token")(ctx, doer, oauthutil.OAuthContext{})
 	require.NoError(t, err)
-	assert.Equal(t, expectedNewToken, newToken.Token)
+	assert.Equal(t, expectedNewToken, newToken.AccessToken)
 }
 
 func TestExternalAccountTokenRefresher(t *testing.T) {
@@ -142,5 +142,5 @@ func TestExternalAccountTokenRefresher(t *testing.T) {
 	expectedNewToken := "new-token"
 	newToken, err := externalAccountTokenRefresher(db, 1, "refresh_token")(ctx, doer, oauthutil.OAuthContext{})
 	require.NoError(t, err)
-	assert.Equal(t, expectedNewToken, newToken.Token)
+	assert.Equal(t, expectedNewToken, newToken.AccessToken)
 }

--- a/internal/database/user_credentials_test.go
+++ b/internal/database/user_credentials_test.go
@@ -271,7 +271,7 @@ func TestUserCredentials_Delete(t *testing.T) {
 					ExternalServiceType: "github",
 					ExternalServiceID:   "https://github.com",
 				}
-				token := &auth.OAuthBearerToken{Token: "abcdef"}
+				token := &auth.OAuthBearerToken{AccessToken: "abcdef"}
 
 				cred, err := fx.db.Create(fx.internalCtx, scope, token)
 				require.NoError(t, err)
@@ -290,7 +290,7 @@ func TestUserCredentials_Delete(t *testing.T) {
 			ExternalServiceType: "github",
 			ExternalServiceID:   "https://github.com",
 		}
-		token := &auth.OAuthBearerToken{Token: "abcdef"}
+		token := &auth.OAuthBearerToken{AccessToken: "abcdef"}
 
 		cred, err := fx.db.Create(fx.internalCtx, scope, token)
 		require.NoError(t, err)
@@ -325,7 +325,7 @@ func TestUserCredentials_GetByID(t *testing.T) {
 					ExternalServiceType: "github",
 					ExternalServiceID:   "https://github.com",
 				}
-				token := &auth.OAuthBearerToken{Token: "abcdef"}
+				token := &auth.OAuthBearerToken{AccessToken: "abcdef"}
 
 				cred, err := fx.db.Create(fx.internalCtx, scope, token)
 				require.NoError(t, err)
@@ -344,7 +344,7 @@ func TestUserCredentials_GetByID(t *testing.T) {
 			ExternalServiceType: "github",
 			ExternalServiceID:   "https://github.com",
 		}
-		token := &auth.OAuthBearerToken{Token: "abcdef"}
+		token := &auth.OAuthBearerToken{AccessToken: "abcdef"}
 
 		want, err := fx.db.Create(fx.internalCtx, scope, token)
 		require.NoError(t, err)
@@ -366,7 +366,7 @@ func TestUserCredentials_GetByScope(t *testing.T) {
 		ExternalServiceType: "github",
 		ExternalServiceID:   "https://github.com",
 	}
-	token := &auth.OAuthBearerToken{Token: "abcdef"}
+	token := &auth.OAuthBearerToken{AccessToken: "abcdef"}
 
 	t.Run("nonextant", func(t *testing.T) {
 		cred, err := fx.db.GetByScope(fx.internalCtx, scope)
@@ -426,7 +426,7 @@ func TestUserCredentials_List(t *testing.T) {
 		ExternalServiceType: "gitlab",
 		ExternalServiceID:   "https://gitlab.com",
 	}
-	token := &auth.OAuthBearerToken{Token: "abcdef"}
+	token := &auth.OAuthBearerToken{AccessToken: "abcdef"}
 
 	// Unlike the other tests in this file, we'll set up a couple of credentials
 	// right now, and then list from there.
@@ -626,13 +626,15 @@ func createUserCredentialAuths(t *testing.T) map[string]auth.Authenticator {
 		&auth.OAuthClient{Client: createOAuthClient(t, "abc", "def")},
 		&auth.BasicAuth{Username: "foo", Password: "bar"},
 		&auth.BasicAuthWithSSH{BasicAuth: auth.BasicAuth{Username: "foo", Password: "bar"}, PrivateKey: "private", PublicKey: "public", Passphrase: "pass"},
-		&auth.OAuthBearerToken{Token: "abcdef"},
-		&auth.OAuthBearerTokenWithSSH{OAuthBearerToken: auth.OAuthBearerToken{Token: "abcdef"}, PrivateKey: "private", PublicKey: "public", Passphrase: "pass"},
+		&auth.OAuthBearerToken{AccessToken: "abcdef"},
+		&auth.OAuthBearerTokenWithSSH{OAuthBearerToken: auth.OAuthBearerToken{AccessToken: "abcdef"}, PrivateKey: "private", PublicKey: "public", Passphrase: "pass"},
+		&auth.PersonalAccessToken{Token: "abcdef"},
+		&auth.PersonalAccessTokenWithSSH{PersonalAccessToken: auth.PersonalAccessToken{Token: "abcdef"}, PrivateKey: "private", PublicKey: "public", Passphrase: "pass"},
 		&bitbucketserver.SudoableOAuthClient{
 			Client:   auth.OAuthClient{Client: createOAuthClient(t, "ghi", "jkl")},
 			Username: "neo",
 		},
-		&gitlab.SudoableToken{Token: "mnop", Sudo: "qrs"},
+		&gitlab.SudoableToken{PersonalAccessToken: auth.PersonalAccessToken{Token: "mnop"}, Sudo: "qrs"},
 	} {
 		auths[reflect.TypeOf(a).String()] = a
 	}

--- a/internal/extsvc/auth/oauth_bearer_test.go
+++ b/internal/extsvc/auth/oauth_bearer_test.go
@@ -3,11 +3,14 @@ package auth
 import (
 	"net/http"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOAuthBearerToken(t *testing.T) {
 	t.Run("Authenticate", func(t *testing.T) {
-		token := &OAuthBearerToken{Token: "abcdef"}
+		token := &OAuthBearerToken{AccessToken: "abcdef"}
 
 		req, err := http.NewRequest("GET", "/", nil)
 		if err != nil {
@@ -18,16 +21,16 @@ func TestOAuthBearerToken(t *testing.T) {
 			t.Errorf("unexpected non-nil error: %v", err)
 		}
 
-		if have, want := req.Header.Get("Authorization"), "Bearer "+token.Token; have != want {
+		if have, want := req.Header.Get("Authorization"), "Bearer "+token.AccessToken; have != want {
 			t.Errorf("unexpected header: have=%q want=%q", have, want)
 		}
 	})
 
 	t.Run("Hash", func(t *testing.T) {
 		hashes := []string{
-			(&OAuthBearerToken{Token: ""}).Hash(),
-			(&OAuthBearerToken{Token: "foobar"}).Hash(),
-			(&OAuthBearerToken{Token: "foobar\x00"}).Hash(),
+			(&OAuthBearerToken{AccessToken: ""}).Hash(),
+			(&OAuthBearerToken{AccessToken: "foobar"}).Hash(),
+			(&OAuthBearerToken{AccessToken: "foobar\x00"}).Hash(),
 		}
 
 		seen := make(map[string]struct{})
@@ -37,5 +40,26 @@ func TestOAuthBearerToken(t *testing.T) {
 			}
 			seen[hash] = struct{}{}
 		}
+	})
+
+	t.Run("NeedsRefresh", func(t *testing.T) {
+		token := &OAuthBearerToken{AccessToken: "abcdef", Expiry: time.Now().Add(-1 * time.Hour)}
+
+		assert.True(t, token.NeedsRefresh())
+	})
+
+	t.Run("Refresh", func(t *testing.T) {
+		refreshCalled := false
+
+		token := &OAuthBearerToken{AccessToken: "abcdef", RefreshToken: "refresh", RefreshFunc: func(obt *OAuthBearerToken) (string, string, time.Time, error) {
+			refreshCalled = true
+			return "newToken", "newRefresh", time.Time{}, nil
+		}}
+
+		token.Refresh()
+
+		assert.True(t, refreshCalled)
+		assert.Equal(t, token.AccessToken, "newToken")
+		assert.Equal(t, token.RefreshToken, "newRefresh")
 	})
 }

--- a/internal/extsvc/auth/personal_access_token.go
+++ b/internal/extsvc/auth/personal_access_token.go
@@ -1,0 +1,55 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"time"
+)
+
+// PersonalAccessToken implements Personal Access Token authentication for extsvc
+// clients.
+type PersonalAccessToken struct {
+	Token  string     `json:"token"`
+	Expiry *time.Time `json:"expiry,omitempty"`
+}
+
+func (token *PersonalAccessToken) Authenticate(req *http.Request) error {
+	req.Header.Set("Authorization", "Bearer "+token.Token)
+	return nil
+}
+
+func (token *PersonalAccessToken) Hash() string {
+	key := sha256.Sum256([]byte(token.Token))
+	return hex.EncodeToString(key[:])
+}
+
+// WithToken returns an Oauth Bearer Token authenticator with a new token
+func (token *PersonalAccessToken) WithToken(newToken string) *PersonalAccessToken {
+	return &PersonalAccessToken{
+		Token: newToken,
+	}
+}
+
+// PersonalAccessTokenWithSSH implements Personal Access Token authentication for extsvc
+// clients and holds an additional RSA keypair.
+type PersonalAccessTokenWithSSH struct {
+	PersonalAccessToken
+
+	PrivateKey string
+	PublicKey  string
+	Passphrase string
+}
+
+func (token *PersonalAccessTokenWithSSH) SSHPrivateKey() (privateKey, passphrase string) {
+	return token.PrivateKey, token.Passphrase
+}
+
+func (token *PersonalAccessTokenWithSSH) SSHPublicKey() string {
+	return token.PublicKey
+}
+
+func (token *PersonalAccessTokenWithSSH) Hash() string {
+	shaSum := sha256.Sum256([]byte(token.Token + token.PrivateKey + token.Passphrase + token.PublicKey))
+	return hex.EncodeToString(shaSum[:])
+}

--- a/internal/extsvc/auth/personal_access_token_test.go
+++ b/internal/extsvc/auth/personal_access_token_test.go
@@ -1,0 +1,41 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestPersonalAccessToken(t *testing.T) {
+	t.Run("Authenticate", func(t *testing.T) {
+		token := &PersonalAccessToken{Token: "abcdef"}
+
+		req, err := http.NewRequest("GET", "/", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := token.Authenticate(req); err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		}
+
+		if have, want := req.Header.Get("Authorization"), "Bearer "+token.Token; have != want {
+			t.Errorf("unexpected header: have=%q want=%q", have, want)
+		}
+	})
+
+	t.Run("Hash", func(t *testing.T) {
+		hashes := []string{
+			(&PersonalAccessToken{Token: ""}).Hash(),
+			(&PersonalAccessToken{Token: "foobar"}).Hash(),
+			(&PersonalAccessToken{Token: "foobar\x00"}).Hash(),
+		}
+
+		seen := make(map[string]struct{})
+		for _, hash := range hashes {
+			if _, ok := seen[hash]; ok {
+				t.Errorf("non-unique hash: %q", hash)
+			}
+			seen[hash] = struct{}{}
+		}
+	})
+}

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -41,7 +41,7 @@ type Client struct {
 
 	// Auth is the authentication method used when accessing the server.
 	// Supported types are:
-	// * auth.OAuthBearerToken for a personal access token; see also
+	// * auth.PersonalAccessToken for a personal access token; see also
 	//   https://bitbucket.example.com/plugins/servlet/access-tokens/manage
 	// * auth.BasicAuth for a username and password combination. Typically
 	//   these are only used when the server doesn't support personal access
@@ -70,7 +70,7 @@ func NewClient(urn string, config *schema.BitbucketServerConnection, httpClient 
 
 	if config.Authorization == nil {
 		if config.Token != "" {
-			client.Auth = &auth.OAuthBearerToken{Token: config.Token}
+			client.Auth = &auth.PersonalAccessToken{Token: config.Token}
 		} else {
 			client.Auth = &auth.BasicAuth{
 				Username: config.Username,

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -1085,8 +1085,8 @@ func TestAuth(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			want := &auth.OAuthBearerToken{Token: "foo"}
-			if have, ok := client.Auth.(*auth.OAuthBearerToken); !ok {
+			want := &auth.PersonalAccessToken{Token: "foo"}
+			if have, ok := client.Auth.(*auth.PersonalAccessToken); !ok {
 				t.Errorf("unexpected Authenticator: have=%T want=%T", client.Auth, want)
 			} else if diff := cmp.Diff(have, want); diff != "" {
 				t.Errorf("unexpected token:\n%s", diff)
@@ -1194,8 +1194,8 @@ func TestAuth(t *testing.T) {
 
 		t.Run("errors", func(t *testing.T) {
 			for name, a := range map[string]auth.Authenticator{
-				"OAuth 2 token": &auth.OAuthBearerToken{Token: "abcdef"},
-				"nil":           nil,
+				"Personal access token": &auth.PersonalAccessToken{Token: "abcdef"},
+				"nil":                   nil,
 			} {
 				t.Run(name, func(t *testing.T) {
 					client := &Client{Auth: a}
@@ -1220,7 +1220,7 @@ func TestClient_WithAuthenticator(t *testing.T) {
 		Auth:      &auth.BasicAuth{Username: "johnsson", Password: "mothersmaidenname"},
 	}
 
-	newToken := &auth.OAuthBearerToken{Token: "new_token"}
+	newToken := &auth.PersonalAccessToken{Token: "new_token"}
 	newClient := old.WithAuthenticator(newToken)
 	if old == newClient {
 		t.Fatal("both clients have the same address")

--- a/internal/extsvc/github/v3_test.go
+++ b/internal/extsvc/github/v3_test.go
@@ -687,10 +687,10 @@ func TestV3Client_WithAuthenticator(t *testing.T) {
 	old := &V3Client{
 		log:    logtest.Scoped(t),
 		apiURL: uri,
-		auth:   &auth.OAuthBearerToken{Token: "old_token"},
+		auth:   &auth.OAuthBearerToken{AccessToken: "old_token"},
 	}
 
-	newToken := &auth.OAuthBearerToken{Token: "new_token"}
+	newToken := &auth.OAuthBearerToken{AccessToken: "new_token"}
 	new := old.WithAuthenticator(newToken)
 	if old == new {
 		t.Fatal("both clients have the same address")
@@ -871,7 +871,7 @@ func TestSyncWebhook_CreateListFindDelete(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			token := os.Getenv(fmt.Sprintf("%s_ACCESS_TOKEN", name))
-			client = client.WithAuthenticator(&auth.OAuthBearerToken{Token: token})
+			client = client.WithAuthenticator(&auth.PersonalAccessToken{Token: token})
 
 			id, err := client.CreateSyncWebhook(ctx, tc.repoName, "https://target-url.com", "secret")
 			if err != nil {

--- a/internal/extsvc/github/v4_test.go
+++ b/internal/extsvc/github/v4_test.go
@@ -792,10 +792,10 @@ func TestV4Client_WithAuthenticator(t *testing.T) {
 
 	old := &V4Client{
 		apiURL: uri,
-		auth:   &auth.OAuthBearerToken{Token: "old_token"},
+		auth:   &auth.OAuthBearerToken{AccessToken: "old_token"},
 	}
 
-	newToken := &auth.OAuthBearerToken{Token: "new_token"}
+	newToken := &auth.OAuthBearerToken{AccessToken: "new_token"}
 	new := old.WithAuthenticator(newToken)
 	if old == new {
 		t.Fatal("both clients have the same address")

--- a/internal/extsvc/github/vcr_test.go
+++ b/internal/extsvc/github/vcr_test.go
@@ -9,18 +9,18 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 )
 
-// vcrToken is the OAuthBearerToken used for updating VCR fixtures used in tests in this
+// vcrToken is the PersonalAccessToken used for updating VCR fixtures used in tests in this
 // package.
 //
 // Please use the token of the "sourcegraph-vcr" user for GITHUB_TOKEN, which can be found
 // in 1Password.
-var vcrToken = &auth.OAuthBearerToken{
+var vcrToken = &auth.PersonalAccessToken{
 	Token: os.Getenv("GITHUB_TOKEN"),
 }
 
 // Please use the token of the "GitHub Enterprise Admin Account" user for GHE_TOKEN,
 // which can be found in 1Password.
-var gheToken = &auth.OAuthBearerToken{
+var gheToken = &auth.PersonalAccessToken{
 	Token: os.Getenv("GHE_TOKEN"),
 }
 

--- a/internal/extsvc/gitlab/auth.go
+++ b/internal/extsvc/gitlab/auth.go
@@ -25,8 +25,8 @@ var TokenMissingRefreshCounter = promauto.NewCounter(prometheus.CounterOpts{
 
 // SudoableToken represents a personal access token with an optional sudo scope.
 type SudoableToken struct {
-	Token string
-	Sudo  string
+	auth.PersonalAccessToken
+	Sudo string
 }
 
 var _ auth.Authenticator = &SudoableToken{}

--- a/internal/extsvc/gitlab/auth_test.go
+++ b/internal/extsvc/gitlab/auth_test.go
@@ -3,11 +3,13 @@ package gitlab
 import (
 	"net/http"
 	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 )
 
 func TestSudoableToken(t *testing.T) {
 	t.Run("Authenticate without Sudo", func(t *testing.T) {
-		token := SudoableToken{Token: "abcdef"}
+		token := SudoableToken{PersonalAccessToken: auth.PersonalAccessToken{Token: "abcdef"}}
 
 		req, err := http.NewRequest("GET", "/", nil)
 		if err != nil {
@@ -27,7 +29,7 @@ func TestSudoableToken(t *testing.T) {
 	})
 
 	t.Run("Authenticate with Sudo", func(t *testing.T) {
-		token := SudoableToken{Token: "abcdef", Sudo: "neo"}
+		token := SudoableToken{PersonalAccessToken: auth.PersonalAccessToken{Token: "abcdef"}, Sudo: "neo"}
 
 		req, err := http.NewRequest("GET", "/", nil)
 		if err != nil {
@@ -48,10 +50,10 @@ func TestSudoableToken(t *testing.T) {
 
 	t.Run("Hash", func(t *testing.T) {
 		hashes := []string{
-			(&SudoableToken{Token: ""}).Hash(),
-			(&SudoableToken{Token: "foobar"}).Hash(),
-			(&SudoableToken{Token: "foobar", Sudo: "neo"}).Hash(),
-			(&SudoableToken{Token: "foobar\x00"}).Hash(),
+			(&SudoableToken{PersonalAccessToken: auth.PersonalAccessToken{Token: ""}}).Hash(),
+			(&SudoableToken{PersonalAccessToken: auth.PersonalAccessToken{Token: "foobar"}}).Hash(),
+			(&SudoableToken{PersonalAccessToken: auth.PersonalAccessToken{Token: "foobar"}, Sudo: "neo"}).Hash(),
+			(&SudoableToken{PersonalAccessToken: auth.PersonalAccessToken{Token: "foobar\x00"}}).Hash(),
 		}
 
 		seen := make(map[string]struct{})

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -121,7 +121,7 @@ func (p *ClientProvider) GetPATClient(personalAccessToken, sudo string) *Client 
 	if personalAccessToken == "" {
 		return p.getClient(nil)
 	}
-	return p.getClient(&SudoableToken{Token: personalAccessToken, Sudo: sudo})
+	return p.getClient(&SudoableToken{PersonalAccessToken: auth.PersonalAccessToken{Token: personalAccessToken}, Sudo: sudo})
 }
 
 // GetOAuthClient returns a client authenticated by the OAuth token.
@@ -129,7 +129,7 @@ func (p *ClientProvider) GetOAuthClient(oauthToken string) *Client {
 	if oauthToken == "" {
 		return p.getClient(nil)
 	}
-	return p.getClient(&auth.OAuthBearerToken{Token: oauthToken})
+	return p.getClient(&auth.OAuthBearerToken{AccessToken: oauthToken})
 }
 
 // GetClient returns an unauthenticated client.

--- a/internal/extsvc/gitlab/client_test.go
+++ b/internal/extsvc/gitlab/client_test.go
@@ -113,8 +113,8 @@ func TestClient_doWithBaseURL(t *testing.T) {
 
 	provider := NewClientProvider("Test", baseURL, doer)
 
-	client := provider.getClient(&auth.OAuthBearerToken{Token: "bad token", RefreshToken: "refresh token", RefreshFunc: func(obt *auth.OAuthBearerToken) (string, string, time.Time, error) {
-		obt.Token = "refreshed-token"
+	client := provider.getClient(&auth.OAuthBearerToken{AccessToken: "bad token", RefreshToken: "refresh token", RefreshFunc: func(obt *auth.OAuthBearerToken) (string, string, time.Time, error) {
+		obt.AccessToken = "refreshed-token"
 		obt.RefreshToken = "refresh-now"
 
 		return "refreshed-token", "refresh-now", time.Now().Add(1 * time.Hour), nil

--- a/internal/oauthutil/token.go
+++ b/internal/oauthutil/token.go
@@ -67,11 +67,11 @@ type tokenJSON struct {
 	ErrorURI         string         `json:"error_uri"`
 }
 
-func (e *tokenJSON) expiry() (t time.Time) {
+func (e *tokenJSON) expiry() time.Time {
 	if v := e.ExpiresIn; v != 0 {
 		return time.Now().Add(time.Duration(v) * time.Second)
 	}
-	return
+	return time.Time{}
 }
 
 type expirationTime int32

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -97,8 +97,8 @@ func (s BitbucketServerSource) ListRepos(ctx context.Context, results chan Sourc
 
 func (s BitbucketServerSource) WithAuthenticator(a auth.Authenticator) (Source, error) {
 	switch a.(type) {
-	case *auth.OAuthBearerToken,
-		*auth.OAuthBearerTokenWithSSH,
+	case *auth.PersonalAccessToken,
+		*auth.PersonalAccessTokenWithSSH,
 		*auth.BasicAuth,
 		*auth.BasicAuthWithSSH,
 		*bitbucketserver.SudoableOAuthClient:

--- a/internal/repos/bitbucketserver_test.go
+++ b/internal/repos/bitbucketserver_test.go
@@ -181,7 +181,7 @@ func TestBitbucketServerSource_WithAuthenticator(t *testing.T) {
 	t.Run("supported", func(t *testing.T) {
 		for name, tc := range map[string]auth.Authenticator{
 			"BasicAuth":           &auth.BasicAuth{},
-			"OAuthBearerToken":    &auth.OAuthBearerToken{},
+			"PersonalAccessToken": &auth.PersonalAccessToken{},
 			"SudoableOAuthClient": &bitbucketserver.SudoableOAuthClient{},
 		} {
 			t.Run(name, func(t *testing.T) {

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -157,7 +157,7 @@ func newGithubSource(
 	if err != nil {
 		return nil, err
 	}
-	token := &auth.OAuthBearerToken{Token: c.Token}
+	token := &auth.PersonalAccessToken{Token: c.Token}
 	urn := svc.URN()
 
 	var (
@@ -257,8 +257,8 @@ func newGithubSource(
 
 func (s *GitHubSource) WithAuthenticator(a auth.Authenticator) (Source, error) {
 	switch a.(type) {
-	case *auth.OAuthBearerToken,
-		*auth.OAuthBearerTokenWithSSH:
+	case *auth.PersonalAccessToken,
+		*auth.PersonalAccessTokenWithSSH:
 		break
 
 	default:

--- a/internal/repos/github_test.go
+++ b/internal/repos/github_test.go
@@ -568,7 +568,7 @@ func TestGithubSource_WithAuthenticator(t *testing.T) {
 	}
 
 	t.Run("supported", func(t *testing.T) {
-		src, err := githubSrc.WithAuthenticator(&auth.OAuthBearerToken{})
+		src, err := githubSrc.WithAuthenticator(&auth.PersonalAccessToken{})
 		if err != nil {
 			t.Errorf("unexpected non-nil error: %v", err)
 		}
@@ -722,7 +722,7 @@ func TestRepositoryQuery_Do(t *testing.T) {
 			}
 
 			apiURL, _ := url.Parse("https://api.github.com")
-			token := &auth.OAuthBearerToken{Token: os.Getenv("GITHUB_TOKEN")}
+			token := &auth.PersonalAccessToken{Token: os.Getenv("GITHUB_TOKEN")}
 
 			q := repositoryQuery{
 				Logger:   logtest.Scoped(t),

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -140,8 +140,8 @@ func newGitLabSource(ctx context.Context, logger log.Logger, db database.DB, svc
 
 func (s GitLabSource) WithAuthenticator(a auth.Authenticator) (Source, error) {
 	switch a.(type) {
-	case *auth.OAuthBearerToken,
-		*auth.OAuthBearerTokenWithSSH:
+	case *auth.PersonalAccessToken,
+		*auth.PersonalAccessTokenWithSSH:
 		break
 
 	default:

--- a/internal/repos/gitlab_test.go
+++ b/internal/repos/gitlab_test.go
@@ -237,7 +237,7 @@ func TestGitLabSource_WithAuthenticator(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected non-nil error: %v", err)
 		}
-		src, err = src.(UserSource).WithAuthenticator(&auth.OAuthBearerToken{})
+		src, err = src.(UserSource).WithAuthenticator(&auth.PersonalAccessToken{})
 		if err != nil {
 			t.Errorf("unexpected non-nil error: %v", err)
 		}

--- a/internal/repos/webhook_build_handler.go
+++ b/internal/repos/webhook_build_handler.go
@@ -65,7 +65,7 @@ func (w *webhookBuildHandler) handleKindGitHub(ctx context.Context, logger log.L
 	if err != nil {
 		return errcode.MakeNonRetryable(errors.Wrap(err, "handleKindGitHub: parse baseURL failed"))
 	}
-	client := github.NewV3Client(logger, svc.URN(), baseURL, &auth.OAuthBearerToken{Token: conn.Token}, w.doer)
+	client := github.NewV3Client(logger, svc.URN(), baseURL, &auth.PersonalAccessToken{Token: conn.Token}, w.doer)
 
 	// TODO: Not make an API call upon every request. We would need a way to save
 	// whether or not we created a hook locally


### PR DESCRIPTION
This PR adds a dedicated `PersonalAccessToken` type. We have been using `OAuthBearerToken` as a representation for Personal Access Tokens, because the `Authenticate` method is the same. However, this makes it very difficult to extend the functionality of OAuthTokens because Personal Access Tokens have to be kept in mind all the time.

So I went through all uses of OAuthBearerToken and determined whether or not a PAT is actually being used and adjusted accordingly.

## Test plan

Added tests. Adjusted tests. All tests still pass. Tested manually. Might require some testing from other teams as well just for sanity.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
