### PR TITLE
encryption: Add support for webhook encryption

### DIFF
--- a/internal/encryption/keyring/ring.go
+++ b/internal/encryption/keyring/ring.go
@@ -106,6 +106,13 @@ func NewRing(ctx context.Context, keyConfig *schema.EncryptionKeys) (*Ring, erro
 		}
 	}
 
+	if keyConfig.WebhookKey != nil {
+		r.WebhookKey, err = NewKey(ctx, keyConfig.WebhookKey, keyConfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if keyConfig.WebhookLogKey != nil {
 		r.WebhookLogKey, err = NewKey(ctx, keyConfig.WebhookLogKey, keyConfig)
 		if err != nil {
@@ -120,6 +127,7 @@ type Ring struct {
 	BatchChangesCredentialKey encryption.Key
 	ExternalServiceKey        encryption.Key
 	UserExternalAccountKey    encryption.Key
+	WebhookKey                encryption.Key
 	WebhookLogKey             encryption.Key
 }
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -536,6 +536,7 @@ type EncryptionKeys struct {
 	EnableCache            bool           `json:"enableCache,omitempty"`
 	ExternalServiceKey     *EncryptionKey `json:"externalServiceKey,omitempty"`
 	UserExternalAccountKey *EncryptionKey `json:"userExternalAccountKey,omitempty"`
+	WebhookKey             *EncryptionKey `json:"webhookKey,omitempty"`
 	WebhookLogKey          *EncryptionKey `json:"webhookLogKey,omitempty"`
 }
 type ExcludedAWSCodeCommitRepo struct {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1706,6 +1706,9 @@
         },
         "webhookLogKey": {
           "$ref": "#/definitions/EncryptionKey"
+        },
+         "webhookKey": {
+          "$ref": "#/definitions/EncryptionKey"
         }
       }
     },


### PR DESCRIPTION
We need to encrypt the `secret` column in the new webhooks table so we
need to allow configuration of an encryption key for this.

Closes https://github.com/sourcegraph/sourcegraph/issues/42686

## Test plan

None needed, only a basic schema update