### PR TITLE
JetBrains: Specify auth headers

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/api/GraphQlClient.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/api/GraphQlClient.java
@@ -22,8 +22,8 @@ import java.nio.charset.StandardCharsets;
 
 public class GraphQlClient {
     @NotNull
-    public static GraphQlResponse callGraphQLService(@NotNull String instanceUrl, @Nullable String accessToken, @NotNull String query, @NotNull JsonObject variables) throws IOException {
-        HttpPost request = createRequest(instanceUrl, accessToken, query, variables);
+    public static GraphQlResponse callGraphQLService(@NotNull String instanceUrl, @Nullable String accessToken, @Nullable String requestHeaders, @NotNull String query, @NotNull JsonObject variables) throws IOException {
+        HttpPost request = createRequest(instanceUrl, accessToken, requestHeaders, query, variables);
         try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
             CloseableHttpResponse httpResponse = client.execute(request);
             GraphQlResponse response = new GraphQlResponse(getStatusCode(httpResponse), getResponseBody(httpResponse));
@@ -43,13 +43,24 @@ public class GraphQlClient {
     }
 
     @NotNull
-    private static HttpPost createRequest(@NotNull String instanceUrl, @Nullable String accessToken, @NotNull String query, @NotNull JsonObject variables) {
+    private static HttpPost createRequest(@NotNull String instanceUrl, @Nullable String accessToken, @Nullable String requestHeadersAsString, @NotNull String query, @NotNull JsonObject variables) {
+        String[] pairs = requestHeadersAsString != null ? requestHeadersAsString.split(",") : new String[0];
         HttpPost request = new HttpPost(getGraphQLApiURI(instanceUrl));
 
         request.setHeader("Content-Type", "application/json");
         request.setHeader("X-Sourcegraph-Should-Trace", "false");
         if (accessToken != null) {
             request.setHeader("Authorization", "token " + accessToken);
+        }
+        // Do some checks to make sure the request is same, but fail silently
+        if (pairs.length % 2 == 0) {
+            for (int i = 0; i < pairs.length; i += 2) {
+                String headerName = pairs[i].trim();
+                String headerValue = pairs[i + 1].trim();
+                if (headerName.matches("[\\w-]+")) {
+                    request.setHeader(headerName, headerValue);
+                }
+            }
         }
 
         JsonObject body = new JsonObject();

--- a/client/jetbrains/src/main/java/com/sourcegraph/api/GraphQlClient.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/api/GraphQlClient.java
@@ -52,7 +52,7 @@ public class GraphQlClient {
         if (accessToken != null) {
             request.setHeader("Authorization", "token " + accessToken);
         }
-        // Do some checks to make sure the request is same, but fail silently
+        // Do some checks to make sure the string and its parts are well-formed, but fail silently in each case
         if (pairs.length % 2 == 0) {
             for (int i = 0; i < pairs.length; i += 2) {
                 String headerName = pairs[i].trim();

--- a/client/jetbrains/src/main/java/com/sourcegraph/api/GraphQlClient.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/api/GraphQlClient.java
@@ -22,8 +22,8 @@ import java.nio.charset.StandardCharsets;
 
 public class GraphQlClient {
     @NotNull
-    public static GraphQlResponse callGraphQLService(@NotNull String instanceUrl, @Nullable String accessToken, @Nullable String requestHeaders, @NotNull String query, @NotNull JsonObject variables) throws IOException {
-        HttpPost request = createRequest(instanceUrl, accessToken, requestHeaders, query, variables);
+    public static GraphQlResponse callGraphQLService(@NotNull String instanceUrl, @Nullable String accessToken, @Nullable String customRequestHeaders, @NotNull String query, @NotNull JsonObject variables) throws IOException {
+        HttpPost request = createRequest(instanceUrl, accessToken, customRequestHeaders, query, variables);
         try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
             CloseableHttpResponse httpResponse = client.execute(request);
             GraphQlResponse response = new GraphQlResponse(getStatusCode(httpResponse), getResponseBody(httpResponse));
@@ -43,8 +43,8 @@ public class GraphQlClient {
     }
 
     @NotNull
-    private static HttpPost createRequest(@NotNull String instanceUrl, @Nullable String accessToken, @Nullable String requestHeadersAsString, @NotNull String query, @NotNull JsonObject variables) {
-        String[] pairs = requestHeadersAsString != null ? requestHeadersAsString.split(",") : new String[0];
+    private static HttpPost createRequest(@NotNull String instanceUrl, @Nullable String accessToken, @Nullable String customRequestHeadersAsString, @NotNull String query, @NotNull JsonObject variables) {
+        String[] pairs = customRequestHeadersAsString != null ? customRequestHeadersAsString.split(",") : new String[0];
         HttpPost request = new HttpPost(getGraphQLApiURI(instanceUrl));
 
         request.setHeader("Content-Type", "application/json");

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ApiAuthenticator.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ApiAuthenticator.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
 public class ApiAuthenticator {
     private final static Logger logger = Logger.getInstance(ApiAuthenticator.class);
 
-    public static void testConnection(@NotNull String instanceUrl, @Nullable String accessToken, @NotNull Consumer<ConnectionStatus> callback) {
+    public static void testConnection(@NotNull String instanceUrl, @Nullable String accessToken, @Nullable String requestHeaders, @NotNull Consumer<ConnectionStatus> callback) {
         new Thread(() -> {
             String query = "" +
                 "query {" +
@@ -25,7 +25,7 @@ public class ApiAuthenticator {
                 "}";
 
             try {
-                GraphQlResponse response = GraphQlClient.callGraphQLService(instanceUrl, accessToken, query, new JsonObject());
+                GraphQlResponse response = GraphQlClient.callGraphQLService(instanceUrl, accessToken, requestHeaders, query, new JsonObject());
                 if (response.getStatusCode() == 200) {
                     JsonElement id = response.getBodyAsJson().getAsJsonObject("data").getAsJsonObject("currentUser").get("id");
                     callback.accept(id.isJsonNull() ? ConnectionStatus.COULD_CONNECT_BUT_NOT_AUTHENTICATED : ConnectionStatus.AUTHENTICATED);

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ApiAuthenticator.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ApiAuthenticator.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
 public class ApiAuthenticator {
     private final static Logger logger = Logger.getInstance(ApiAuthenticator.class);
 
-    public static void testConnection(@NotNull String instanceUrl, @Nullable String accessToken, @Nullable String requestHeaders, @NotNull Consumer<ConnectionStatus> callback) {
+    public static void testConnection(@NotNull String instanceUrl, @Nullable String accessToken, @Nullable String customRequestHeaders, @NotNull Consumer<ConnectionStatus> callback) {
         new Thread(() -> {
             String query = "" +
                 "query {" +
@@ -25,7 +25,7 @@ public class ApiAuthenticator {
                 "}";
 
             try {
-                GraphQlResponse response = GraphQlClient.callGraphQLService(instanceUrl, accessToken, requestHeaders, query, new JsonObject());
+                GraphQlResponse response = GraphQlClient.callGraphQLService(instanceUrl, accessToken, customRequestHeaders, query, new JsonObject());
                 if (response.getStatusCode() == 200) {
                     JsonElement id = response.getBodyAsJson().getAsJsonObject("data").getAsJsonObject("currentUser").get("id");
                     callback.accept(id.isJsonNull() ? ConnectionStatus.COULD_CONNECT_BUT_NOT_AUTHENTICATED : ConnectionStatus.AUTHENTICATED);

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -20,6 +20,7 @@ public class ConfigUtil {
         JsonObject configAsJson = new JsonObject();
         configAsJson.addProperty("instanceURL", ConfigUtil.getSourcegraphUrl(project));
         configAsJson.addProperty("accessToken", ConfigUtil.getInstanceType(project) == SettingsComponent.InstanceType.ENTERPRISE ? ConfigUtil.getAccessToken(project) : null);
+        configAsJson.addProperty("requestHeadersAsString", ConfigUtil.getRequestHeaders(project));
         configAsJson.addProperty("isGlobbingEnabled", ConfigUtil.isGlobbingEnabled(project));
         configAsJson.addProperty("pluginVersion", ConfigUtil.getPluginVersion());
         configAsJson.addProperty("anonymousUserId", ConfigUtil.getAnonymousUserId());

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -86,6 +86,24 @@ public class ConfigUtil {
     }
 
     @NotNull
+    public static String getRequestHeaders(@NotNull Project project) {
+        // Project level
+        String projectLevelRequestHeaders = getProjectLevelConfig(project).getRequestHeaders();
+        if (projectLevelRequestHeaders != null && projectLevelRequestHeaders.length() > 0) {
+            return projectLevelRequestHeaders;
+        }
+
+        // Application level
+        String applicationLevelRequestHeaders = getApplicationLevelConfig().getRequestHeaders();
+        if (applicationLevelRequestHeaders != null && applicationLevelRequestHeaders.length() > 0) {
+            return applicationLevelRequestHeaders;
+        }
+
+        // Default
+        return "";
+    }
+
+    @NotNull
     public static String getDefaultBranchName(@NotNull Project project) {
         // Project level
         String projectLevelDefaultBranchName = getProjectLevelConfig(project).getDefaultBranchName();

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -20,7 +20,7 @@ public class ConfigUtil {
         JsonObject configAsJson = new JsonObject();
         configAsJson.addProperty("instanceURL", ConfigUtil.getSourcegraphUrl(project));
         configAsJson.addProperty("accessToken", ConfigUtil.getInstanceType(project) == SettingsComponent.InstanceType.ENTERPRISE ? ConfigUtil.getAccessToken(project) : null);
-        configAsJson.addProperty("requestHeadersAsString", ConfigUtil.getRequestHeaders(project));
+        configAsJson.addProperty("customRequestHeadersAsString", ConfigUtil.getCustomRequestHeaders(project));
         configAsJson.addProperty("isGlobbingEnabled", ConfigUtil.isGlobbingEnabled(project));
         configAsJson.addProperty("pluginVersion", ConfigUtil.getPluginVersion());
         configAsJson.addProperty("anonymousUserId", ConfigUtil.getAnonymousUserId());
@@ -87,17 +87,17 @@ public class ConfigUtil {
     }
 
     @NotNull
-    public static String getRequestHeaders(@NotNull Project project) {
+    public static String getCustomRequestHeaders(@NotNull Project project) {
         // Project level
-        String projectLevelRequestHeaders = getProjectLevelConfig(project).getRequestHeaders();
-        if (projectLevelRequestHeaders != null && projectLevelRequestHeaders.length() > 0) {
-            return projectLevelRequestHeaders;
+        String projectLevelCustomRequestHeaders = getProjectLevelConfig(project).getCustomRequestHeaders();
+        if (projectLevelCustomRequestHeaders != null && projectLevelCustomRequestHeaders.length() > 0) {
+            return projectLevelCustomRequestHeaders;
         }
 
         // Application level
-        String applicationLevelRequestHeaders = getApplicationLevelConfig().getRequestHeaders();
-        if (applicationLevelRequestHeaders != null && applicationLevelRequestHeaders.length() > 0) {
-            return applicationLevelRequestHeaders;
+        String applicationLevelCustomRequestHeaders = getApplicationLevelConfig().getCustomRequestHeaders();
+        if (applicationLevelCustomRequestHeaders != null && applicationLevelCustomRequestHeaders.length() > 0) {
+            return applicationLevelCustomRequestHeaders;
         }
 
         // Default

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
@@ -4,21 +4,29 @@ import org.jetbrains.annotations.Nullable;
 
 public class PluginSettingChangeContext {
     @Nullable
-    final public String oldUrl;
+    public final String oldUrl;
 
     @Nullable
-    final public String oldAccessToken;
+    public final String oldAccessToken;
 
     @Nullable
-    final public String newUrl;
+    public final String newUrl;
 
     @Nullable
-    final public String newAccessToken;
+    public final String newAccessToken;
 
-    public PluginSettingChangeContext(@Nullable String oldUrl, @Nullable String oldAccessToken, @Nullable String newUrl, @Nullable String newAccessToken) {
+    @Nullable
+    public final String newRequestHeaders;
+
+    public PluginSettingChangeContext(@Nullable String oldUrl,
+                                      @Nullable String oldAccessToken,
+                                      @Nullable String newUrl,
+                                      @Nullable String newAccessToken,
+                                      @Nullable String newRequestHeaders) {
         this.oldUrl = oldUrl;
         this.oldAccessToken = oldAccessToken;
         this.newUrl = newUrl;
         this.newAccessToken = newAccessToken;
+        this.newRequestHeaders = newRequestHeaders;
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
@@ -16,17 +16,17 @@ public class PluginSettingChangeContext {
     public final String newAccessToken;
 
     @Nullable
-    public final String newRequestHeaders;
+    public final String newCustomRequestHeaders;
 
     public PluginSettingChangeContext(@Nullable String oldUrl,
                                       @Nullable String oldAccessToken,
                                       @Nullable String newUrl,
                                       @Nullable String newAccessToken,
-                                      @Nullable String newRequestHeaders) {
+                                      @Nullable String newCustomRequestHeaders) {
         this.oldUrl = oldUrl;
         this.oldAccessToken = oldAccessToken;
         this.newUrl = newUrl;
         this.newAccessToken = newAccessToken;
-        this.newRequestHeaders = newRequestHeaders;
+        this.newCustomRequestHeaders = newCustomRequestHeaders;
     }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -54,7 +54,7 @@ public class SettingsChangeListener implements Disposable {
 
                 // Notify user about a successful connection
                 if (context.newUrl != null) {
-                    ApiAuthenticator.testConnection(context.newUrl, context.newAccessToken, (status) -> {
+                    ApiAuthenticator.testConnection(context.newUrl, context.newAccessToken, context.newRequestHeaders, (status) -> {
                         if (ConfigUtil.didAuthenticationFailLastTime() && status == ApiAuthenticator.ConnectionStatus.AUTHENTICATED) {
                             notifyAboutSuccessfulConnection();
                         }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -54,7 +54,7 @@ public class SettingsChangeListener implements Disposable {
 
                 // Notify user about a successful connection
                 if (context.newUrl != null) {
-                    ApiAuthenticator.testConnection(context.newUrl, context.newAccessToken, context.newRequestHeaders, (status) -> {
+                    ApiAuthenticator.testConnection(context.newUrl, context.newAccessToken, context.newCustomRequestHeaders, (status) -> {
                         if (ConfigUtil.didAuthenticationFailLastTime() && status == ApiAuthenticator.ConnectionStatus.AUTHENTICATED) {
                             notifyAboutSuccessfulConnection();
                         }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -154,7 +154,7 @@ public class SettingsComponent {
 
             for (int i = 0; i < pairs.length; i += 2) {
                 String headerName = pairs[i].trim();
-                if (!headerName.matches("[a-zA-Z0-9_-]+")) {
+                if (!headerName.matches("[\\w-]+")) {
                     return new ValidationInfo("Invalid HTTP header name: " + headerName, requestHeadersTextField);
                 }
             }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -139,6 +139,7 @@ public class SettingsComponent {
             .addComponent(enterprisePanelContent, 1)
             .getPanel();
 
+        // Create the "Request headers" text box
         JBLabel requestHeadersLabel = new JBLabel("Request headers:");
         requestHeadersTextField = new JBTextField();
         requestHeadersTextField.getEmptyText().setText("Client-ID, client-one, X-Extra, some metadata");

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -173,8 +173,6 @@ public class SettingsComponent {
             .getPanel();
         userAuthenticationPanel.setBorder(IdeBorderFactory.createTitledBorder("User Authentication", true, JBUI.insetsTop(8)));
 
-        // Value can be: [a-zA-Z0-9_ :;.,\/"'?!(){}[\]@<>=+*#$&`|~^%-]+
-
         return userAuthenticationPanel;
     }
 
@@ -296,7 +294,6 @@ public class SettingsComponent {
         //noinspection DialogTitleCapitalization
         defaultBranchNameTextField.getEmptyText().setText("main");
         defaultBranchNameTextField.setToolTipText("Usually \"main\" or \"master\", but can be any name");
-        String defaultBranchNameTooltip = "The branch to use if the current branch is not yet pushed";
 
         JBLabel remoteUrlReplacementsLabel = new JBLabel("Remote URL replacements:");
         remoteUrlReplacementsTextField = new JBTextField();
@@ -312,7 +309,7 @@ public class SettingsComponent {
 
         JPanel navigationSettingsPanel = FormBuilder.createFormBuilder()
             .addLabeledComponent(defaultBranchNameLabel, defaultBranchNameTextField)
-            .addTooltip(defaultBranchNameTooltip)
+            .addTooltip("The branch to use if the current branch is not yet pushed")
             .addLabeledComponent(remoteUrlReplacementsLabel, remoteUrlReplacementsTextField)
             .addTooltip("You can replace specified strings in your repo's remote URL.")
             .addTooltip("Use any number of pairs: \"search1, replacement1, search2, replacement2, ...\".")

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -35,7 +35,7 @@ public class SettingsComponent {
     private JBTextField accessTokenTextField;
     private JBLabel userDocsLinkComment;
     private JBLabel accessTokenLinkComment;
-    private JBTextField requestHeadersTextField;
+    private JBTextField customRequestHeadersTextField;
     private JBTextField defaultBranchNameTextField;
     private JBTextField remoteUrlReplacementsTextField;
     private JBCheckBox globbingCheckBox;
@@ -140,23 +140,23 @@ public class SettingsComponent {
             .getPanel();
 
         // Create the "Request headers" text box
-        JBLabel requestHeadersLabel = new JBLabel("Request headers:");
-        requestHeadersTextField = new JBTextField();
-        requestHeadersTextField.getEmptyText().setText("Client-ID, client-one, X-Extra, some metadata");
-        requestHeadersTextField.setToolTipText("You can even overwrite \"Authorization\" that Access token sets above.");
-        addValidation(requestHeadersTextField, () -> {
-            if (requestHeadersTextField.getText().length() == 0) {
+        JBLabel customRequestHeadersLabel = new JBLabel("Custom request headers:");
+        customRequestHeadersTextField = new JBTextField();
+        customRequestHeadersTextField.getEmptyText().setText("Client-ID, client-one, X-Extra, some metadata");
+        customRequestHeadersTextField.setToolTipText("You can even overwrite \"Authorization\" that Access token sets above.");
+        addValidation(customRequestHeadersTextField, () -> {
+            if (customRequestHeadersTextField.getText().length() == 0) {
                 return null;
             }
-            String[] pairs = requestHeadersTextField.getText().split(",");
+            String[] pairs = customRequestHeadersTextField.getText().split(",");
             if (pairs.length % 2 != 0) {
-                return new ValidationInfo("Must be a comma-separated list of pairs", requestHeadersTextField);
+                return new ValidationInfo("Must be a comma-separated list of pairs", customRequestHeadersTextField);
             }
 
             for (int i = 0; i < pairs.length; i += 2) {
                 String headerName = pairs[i].trim();
                 if (!headerName.matches("[\\w-]+")) {
-                    return new ValidationInfo("Invalid HTTP header name: " + headerName, requestHeadersTextField);
+                    return new ValidationInfo("Invalid HTTP header name: " + headerName, customRequestHeadersTextField);
                 }
             }
             return null;
@@ -166,7 +166,7 @@ public class SettingsComponent {
         JPanel userAuthenticationPanel = FormBuilder.createFormBuilder()
             .addComponent(dotComPanel)
             .addComponent(enterprisePanel, 5)
-            .addLabeledComponent(requestHeadersLabel, requestHeadersTextField)
+            .addLabeledComponent(customRequestHeadersLabel, customRequestHeadersTextField)
             .addTooltip("Any custom headers to send with every request to Sourcegraph.")
             .addTooltip("Use any number of pairs: \"header1, value1, header2, value2, ...\".")
             .addTooltip("Whitespace around commas doesn't matter.")
@@ -197,12 +197,12 @@ public class SettingsComponent {
     }
 
     @NotNull
-    public String getRequestHeaders() {
-        return requestHeadersTextField.getText();
+    public String getCustomRequestHeaders() {
+        return customRequestHeadersTextField.getText();
     }
 
-    public void setRequestHeaders(@NotNull String requestHeaders) {
-        this.requestHeadersTextField.setText(requestHeaders);
+    public void setCustomRequestHeaders(@NotNull String customRequestHeaders) {
+        this.customRequestHeadersTextField.setText(customRequestHeaders);
     }
 
     @NotNull

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -61,7 +61,8 @@ public class SettingsConfigurable implements Configurable {
         String oldAccessToken = ConfigUtil.getAccessToken(project);
         String newUrl = mySettingsComponent.getEnterpriseUrl();
         String newAccessToken = mySettingsComponent.getAccessToken();
-        PluginSettingChangeContext context = new PluginSettingChangeContext(oldUrl, oldAccessToken, newUrl, newAccessToken);
+        String newRequestHeaders = mySettingsComponent.getRequestHeaders();
+        PluginSettingChangeContext context = new PluginSettingChangeContext(oldUrl, oldAccessToken, newUrl, newAccessToken, newRequestHeaders);
 
         publisher.beforeAction(context);
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -42,6 +42,7 @@ public class SettingsConfigurable implements Configurable {
         return !mySettingsComponent.getInstanceType().equals(ConfigUtil.getInstanceType(project))
             || !mySettingsComponent.getEnterpriseUrl().equals(ConfigUtil.getEnterpriseUrl(project))
             || !(mySettingsComponent.getAccessToken().equals(ConfigUtil.getAccessToken(project)) || mySettingsComponent.getAccessToken().isEmpty() && ConfigUtil.getAccessToken(project) == null)
+            || !mySettingsComponent.getRequestHeaders().equals(ConfigUtil.getRequestHeaders(project))
             || !mySettingsComponent.getDefaultBranchName().equals(ConfigUtil.getDefaultBranchName(project))
             || !mySettingsComponent.getRemoteUrlReplacements().equals(ConfigUtil.getRemoteUrlReplacements(project))
             || mySettingsComponent.isGlobbingEnabled() != ConfigUtil.isGlobbingEnabled(project)
@@ -79,6 +80,11 @@ public class SettingsConfigurable implements Configurable {
         } else {
             aSettings.accessToken = newAccessToken;
         }
+        if (pSettings.requestHeaders != null) {
+            pSettings.requestHeaders = mySettingsComponent.getRequestHeaders();
+        } else {
+            aSettings.requestHeaders = mySettingsComponent.getRequestHeaders();
+        }
         if (pSettings.defaultBranch != null) {
             pSettings.defaultBranch = mySettingsComponent.getDefaultBranchName();
         } else {
@@ -106,6 +112,7 @@ public class SettingsConfigurable implements Configurable {
         mySettingsComponent.setEnterpriseUrl(ConfigUtil.getEnterpriseUrl(project));
         String accessToken = ConfigUtil.getAccessToken(project);
         mySettingsComponent.setAccessToken(accessToken != null ? accessToken : "");
+        mySettingsComponent.setRequestHeaders(ConfigUtil.getRequestHeaders(project));
         String defaultBranchName = ConfigUtil.getDefaultBranchName(project);
         mySettingsComponent.setDefaultBranchName(defaultBranchName);
         String remoteUrlReplacements = ConfigUtil.getRemoteUrlReplacements(project);

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -42,7 +42,7 @@ public class SettingsConfigurable implements Configurable {
         return !mySettingsComponent.getInstanceType().equals(ConfigUtil.getInstanceType(project))
             || !mySettingsComponent.getEnterpriseUrl().equals(ConfigUtil.getEnterpriseUrl(project))
             || !(mySettingsComponent.getAccessToken().equals(ConfigUtil.getAccessToken(project)) || mySettingsComponent.getAccessToken().isEmpty() && ConfigUtil.getAccessToken(project) == null)
-            || !mySettingsComponent.getRequestHeaders().equals(ConfigUtil.getRequestHeaders(project))
+            || !mySettingsComponent.getCustomRequestHeaders().equals(ConfigUtil.getCustomRequestHeaders(project))
             || !mySettingsComponent.getDefaultBranchName().equals(ConfigUtil.getDefaultBranchName(project))
             || !mySettingsComponent.getRemoteUrlReplacements().equals(ConfigUtil.getRemoteUrlReplacements(project))
             || mySettingsComponent.isGlobbingEnabled() != ConfigUtil.isGlobbingEnabled(project)
@@ -61,8 +61,8 @@ public class SettingsConfigurable implements Configurable {
         String oldAccessToken = ConfigUtil.getAccessToken(project);
         String newUrl = mySettingsComponent.getEnterpriseUrl();
         String newAccessToken = mySettingsComponent.getAccessToken();
-        String newRequestHeaders = mySettingsComponent.getRequestHeaders();
-        PluginSettingChangeContext context = new PluginSettingChangeContext(oldUrl, oldAccessToken, newUrl, newAccessToken, newRequestHeaders);
+        String newCustomRequestHeaders = mySettingsComponent.getCustomRequestHeaders();
+        PluginSettingChangeContext context = new PluginSettingChangeContext(oldUrl, oldAccessToken, newUrl, newAccessToken, newCustomRequestHeaders);
 
         publisher.beforeAction(context);
 
@@ -81,10 +81,10 @@ public class SettingsConfigurable implements Configurable {
         } else {
             aSettings.accessToken = newAccessToken;
         }
-        if (pSettings.requestHeaders != null) {
-            pSettings.requestHeaders = mySettingsComponent.getRequestHeaders();
+        if (pSettings.customRequestHeaders != null) {
+            pSettings.customRequestHeaders = mySettingsComponent.getCustomRequestHeaders();
         } else {
-            aSettings.requestHeaders = mySettingsComponent.getRequestHeaders();
+            aSettings.customRequestHeaders = mySettingsComponent.getCustomRequestHeaders();
         }
         if (pSettings.defaultBranch != null) {
             pSettings.defaultBranch = mySettingsComponent.getDefaultBranchName();
@@ -113,7 +113,7 @@ public class SettingsConfigurable implements Configurable {
         mySettingsComponent.setEnterpriseUrl(ConfigUtil.getEnterpriseUrl(project));
         String accessToken = ConfigUtil.getAccessToken(project);
         mySettingsComponent.setAccessToken(accessToken != null ? accessToken : "");
-        mySettingsComponent.setRequestHeaders(ConfigUtil.getRequestHeaders(project));
+        mySettingsComponent.setCustomRequestHeaders(ConfigUtil.getCustomRequestHeaders(project));
         String defaultBranchName = ConfigUtil.getDefaultBranchName(project);
         mySettingsComponent.setDefaultBranchName(defaultBranchName);
         String remoteUrlReplacements = ConfigUtil.getRemoteUrlReplacements(project);

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
@@ -18,6 +18,8 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
     @Nullable
     public String accessToken;
     @Nullable
+    public String requestHeaders;
+    @Nullable
     public String defaultBranch;
     @Nullable
     public String remoteUrlReplacements;
@@ -50,6 +52,11 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
     @Nullable
     public String getAccessToken() {
         return accessToken;
+    }
+
+    @Nullable
+    public String getRequestHeaders() {
+        return requestHeaders;
     }
 
     @Nullable
@@ -100,6 +107,7 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
         this.instanceType = settings.instanceType;
         this.url = settings.url;
         this.accessToken = settings.accessToken;
+        this.requestHeaders = settings.requestHeaders;
         this.defaultBranch = settings.defaultBranch;
         this.remoteUrlReplacements = settings.remoteUrlReplacements;
         this.isGlobbingEnabled = settings.isGlobbingEnabled;

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
@@ -18,7 +18,7 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
     @Nullable
     public String accessToken;
     @Nullable
-    public String requestHeaders;
+    public String customRequestHeaders;
     @Nullable
     public String defaultBranch;
     @Nullable
@@ -55,8 +55,8 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
     }
 
     @Nullable
-    public String getRequestHeaders() {
-        return requestHeaders;
+    public String getCustomRequestHeaders() {
+        return customRequestHeaders;
     }
 
     @Nullable
@@ -107,7 +107,7 @@ public class SourcegraphApplicationService implements PersistentStateComponent<S
         this.instanceType = settings.instanceType;
         this.url = settings.url;
         this.accessToken = settings.accessToken;
-        this.requestHeaders = settings.requestHeaders;
+        this.customRequestHeaders = settings.customRequestHeaders;
         this.defaultBranch = settings.defaultBranch;
         this.remoteUrlReplacements = settings.remoteUrlReplacements;
         this.isGlobbingEnabled = settings.isGlobbingEnabled;

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
@@ -19,6 +19,8 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
     @Nullable
     public String accessToken;
     @Nullable
+    public String requestHeaders;
+    @Nullable
     public String defaultBranch;
     @Nullable
     public String remoteUrlReplacements;
@@ -50,6 +52,11 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
     @Nullable
     public String getAccessToken() {
         return accessToken;
+    }
+
+    @Nullable
+    public String getRequestHeaders() {
+        return requestHeaders;
     }
 
     @Nullable
@@ -87,6 +94,7 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
         this.instanceType = settings.instanceType;
         this.url = settings.url;
         this.accessToken = settings.accessToken;
+        this.requestHeaders = settings.requestHeaders;
         this.defaultBranch = settings.defaultBranch;
         this.remoteUrlReplacements = settings.remoteUrlReplacements;
         this.isGlobbingEnabled = settings.isGlobbingEnabled;

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
@@ -19,7 +19,7 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
     @Nullable
     public String accessToken;
     @Nullable
-    public String requestHeaders;
+    public String customRequestHeaders;
     @Nullable
     public String defaultBranch;
     @Nullable
@@ -55,8 +55,8 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
     }
 
     @Nullable
-    public String getRequestHeaders() {
-        return requestHeaders;
+    public String getCustomRequestHeaders() {
+        return customRequestHeaders;
     }
 
     @Nullable
@@ -94,7 +94,7 @@ public class SourcegraphProjectService implements PersistentStateComponent<Sourc
         this.instanceType = settings.instanceType;
         this.url = settings.url;
         this.accessToken = settings.accessToken;
-        this.requestHeaders = settings.requestHeaders;
+        this.customRequestHeaders = settings.customRequestHeaders;
         this.defaultBranch = settings.defaultBranch;
         this.remoteUrlReplacements = settings.remoteUrlReplacements;
         this.isGlobbingEnabled = settings.isGlobbingEnabled;

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -36,6 +36,7 @@ public class GraphQlLogger {
     private static void logEvent(Project project, @NotNull Event event, @Nullable Consumer<Integer> callback) {
         String instanceUrl = ConfigUtil.getSourcegraphUrl(project);
         String accessToken = ConfigUtil.getInstanceType(project) == SettingsComponent.InstanceType.ENTERPRISE ? ConfigUtil.getAccessToken(project) : null;
+        String requestHeaders = ConfigUtil.getRequestHeaders(project);
         new Thread(() -> {
             String query = "" +
                 "mutation LogEvents($events: [Event!]) {" +
@@ -50,7 +51,7 @@ public class GraphQlLogger {
             variables.add("events", events);
 
             try {
-                int responseStatusCode = GraphQlClient.callGraphQLService(instanceUrl, accessToken, query, variables).getStatusCode();
+                int responseStatusCode = GraphQlClient.callGraphQLService(instanceUrl, accessToken, requestHeaders, query, variables).getStatusCode();
                 if (callback != null) {
                     callback.accept(responseStatusCode);
                 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -36,7 +36,7 @@ public class GraphQlLogger {
     private static void logEvent(Project project, @NotNull Event event, @Nullable Consumer<Integer> callback) {
         String instanceUrl = ConfigUtil.getSourcegraphUrl(project);
         String accessToken = ConfigUtil.getInstanceType(project) == SettingsComponent.InstanceType.ENTERPRISE ? ConfigUtil.getAccessToken(project) : null;
-        String requestHeaders = ConfigUtil.getRequestHeaders(project);
+        String customRequestHeaders = ConfigUtil.getCustomRequestHeaders(project);
         new Thread(() -> {
             String query = "" +
                 "mutation LogEvents($events: [Event!]) {" +
@@ -51,7 +51,7 @@ public class GraphQlLogger {
             variables.add("events", events);
 
             try {
-                int responseStatusCode = GraphQlClient.callGraphQLService(instanceUrl, accessToken, requestHeaders, query, variables).getStatusCode();
+                int responseStatusCode = GraphQlClient.callGraphQLService(instanceUrl, accessToken, customRequestHeaders, query, variables).getStatusCode();
                 if (callback != null) {
                     callback.accept(responseStatusCode);
                 }

--- a/client/jetbrains/webview/src/bridge-mock/call-java-mock.ts
+++ b/client/jetbrains/webview/src/bridge-mock/call-java-mock.ts
@@ -38,7 +38,7 @@ export function callJava(request: Request): Promise<object> {
         const onFailureCallback = (errorCode: number, errorMessage: string): void => {
             reject(new Error(`${errorCode} - ${errorMessage}`))
         }
-        console.log(`Got this request: ${requestAsString}`)
+        console.log(`The mock Java backend just received this request: ${requestAsString}`)
         handleRequest(request, onSuccessCallback, onFailureCallback)
     })
 }
@@ -54,8 +54,10 @@ function handleRequest(
             onSuccessCallback(
                 JSON.stringify({
                     instanceURL,
-                    isGlobbingEnabled: true,
                     accessToken,
+                    requestHeadersAsString: 'Client-ID,55,Test,a999999',
+                    isGlobbingEnabled: true,
+                    pluginVersion: '1.2.3',
                     anonymousUserId: 'test',
                     pluginVersion: '1.2.3',
                 })

--- a/client/jetbrains/webview/src/bridge-mock/call-java-mock.ts
+++ b/client/jetbrains/webview/src/bridge-mock/call-java-mock.ts
@@ -55,7 +55,7 @@ function handleRequest(
                 JSON.stringify({
                     instanceURL,
                     accessToken,
-                    customRequestHeadersAsString: 'Client-ID,55,Test,a999999',
+                    customRequestHeadersAsString: 'Client-ID,99999,X-Test-Header,Some value',
                     isGlobbingEnabled: true,
                     pluginVersion: '1.2.3',
                     anonymousUserId: 'test',

--- a/client/jetbrains/webview/src/bridge-mock/call-java-mock.ts
+++ b/client/jetbrains/webview/src/bridge-mock/call-java-mock.ts
@@ -55,11 +55,10 @@ function handleRequest(
                 JSON.stringify({
                     instanceURL,
                     accessToken,
-                    requestHeadersAsString: 'Client-ID,55,Test,a999999',
+                    customRequestHeadersAsString: 'Client-ID,55,Test,a999999',
                     isGlobbingEnabled: true,
                     pluginVersion: '1.2.3',
                     anonymousUserId: 'test',
-                    pluginVersion: '1.2.3',
                 })
             )
             break

--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -43,6 +43,7 @@ interface Props {
     instanceURL: string
     isGlobbingEnabled: boolean
     accessToken: string | null
+    requestHeaders: Record<string, string> | null
     onPreviewChange: (match: SearchMatch, lineOrSymbolMatchIndex?: number) => Promise<void>
     onPreviewClear: () => Promise<void>
     onOpen: (match: SearchMatch, lineOrSymbolMatchIndex?: number) => Promise<void>
@@ -75,6 +76,7 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     instanceURL,
     isGlobbingEnabled,
     accessToken,
+    requestHeaders,
     onPreviewChange,
     onPreviewClear,
     onOpen,
@@ -96,9 +98,10 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
                     'Content-Type': 'application/json',
                     'X-Sourcegraph-Should-Trace': new URLSearchParams(window.location.search).get('trace') || 'false',
                     ...(accessToken && { Authorization: `token ${accessToken}` }),
+                    ...requestHeaders,
                 },
             }),
-        [instanceURL, accessToken]
+        [instanceURL, accessToken, requestHeaders]
     )
 
     const settingsCascade: SettingsCascadeOrError =

--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -43,7 +43,7 @@ interface Props {
     instanceURL: string
     isGlobbingEnabled: boolean
     accessToken: string | null
-    requestHeaders: Record<string, string> | null
+    customRequestHeaders: Record<string, string> | null
     onPreviewChange: (match: SearchMatch, lineOrSymbolMatchIndex?: number) => Promise<void>
     onPreviewClear: () => Promise<void>
     onOpen: (match: SearchMatch, lineOrSymbolMatchIndex?: number) => Promise<void>
@@ -76,7 +76,7 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     instanceURL,
     isGlobbingEnabled,
     accessToken,
-    requestHeaders,
+    customRequestHeaders,
     onPreviewChange,
     onPreviewClear,
     onOpen,
@@ -98,10 +98,10 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
                     'Content-Type': 'application/json',
                     'X-Sourcegraph-Should-Trace': new URLSearchParams(window.location.search).get('trace') || 'false',
                     ...(accessToken && { Authorization: `token ${accessToken}` }),
-                    ...requestHeaders,
+                    ...customRequestHeaders,
                 },
             }),
-        [instanceURL, accessToken, requestHeaders]
+        [instanceURL, accessToken, customRequestHeaders]
     )
 
     const settingsCascade: SettingsCascadeOrError =

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -94,7 +94,7 @@ export function applyConfig(config: PluginConfig): void {
     requestHeaders = parseRequestHeadersString(config.requestHeadersAsString)
     anonymousUserId = config.anonymousUserId || 'no-user-id'
     pluginVersion = config.pluginVersion
-    polyfillEventSource(accessToken ? { Authorization: `token ${accessToken}` } : {})
+    polyfillEventSource({...(accessToken ? { Authorization: `token ${accessToken}` } : {}), ...requestHeaders})
 }
 
 function parseRequestHeadersString(requestHeadersString: string | null): Record<string, string> | null {

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -27,6 +27,7 @@ let isDarkTheme = false
 let instanceURL = 'https://sourcegraph.com/'
 let isGlobbingEnabled = false
 let accessToken: string | null = null
+let requestHeaders: Record<string, string> | null = {}
 let anonymousUserId: string
 let pluginVersion: string
 let initialSearch: Search | null = null
@@ -90,9 +91,30 @@ export function applyConfig(config: PluginConfig): void {
     instanceURL = config.instanceURL
     isGlobbingEnabled = config.isGlobbingEnabled || false
     accessToken = config.accessToken || null
+    requestHeaders = parseRequestHeadersString(config.requestHeadersAsString)
     anonymousUserId = config.anonymousUserId || 'no-user-id'
     pluginVersion = config.pluginVersion
     polyfillEventSource(accessToken ? { Authorization: `token ${accessToken}` } : {})
+}
+
+function parseRequestHeadersString(requestHeadersString: string | null): Record<string, string> | null {
+    const requestHeaders: Record<string, string> = {}
+    if (!requestHeadersString) {
+        return null
+    }
+    const requestHeadersArray = requestHeadersString.split(',')
+    if (requestHeadersArray.length % 2 !== 0) {
+        return null
+    }
+    for (let index = 0; index < requestHeadersArray.length; index += 2) {
+        const headerName = requestHeaders[requestHeadersArray[index]]
+        const value = requestHeadersArray[index + 1]
+        // Skip invalid keys
+        if (headerName.match(/^[\w-]+$/)) {
+            requestHeaders[headerName] = value
+        }
+    }
+    return requestHeaders
 }
 
 export function applyTheme(theme: Theme, rootElement: Element = document.documentElement): void {

--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -74,6 +74,7 @@ export function renderReactApp(): void {
             instanceURL={instanceURL}
             isGlobbingEnabled={isGlobbingEnabled}
             accessToken={accessToken}
+            requestHeaders={requestHeaders}
             initialSearch={initialSearch}
             onOpen={onOpen}
             onPreviewChange={onPreviewChange}
@@ -107,11 +108,11 @@ function parseRequestHeadersString(requestHeadersString: string | null): Record<
         return null
     }
     for (let index = 0; index < requestHeadersArray.length; index += 2) {
-        const headerName = requestHeaders[requestHeadersArray[index]]
-        const value = requestHeadersArray[index + 1]
+        const name = requestHeaders[requestHeadersArray[index]].trim()
+        const value = requestHeadersArray[index + 1].trim()
         // Skip invalid keys
-        if (headerName.match(/^[\w-]+$/)) {
-            requestHeaders[headerName] = value
+        if (name.match(/^[\w-]+$/)) {
+            requestHeaders[name] = value
         }
     }
     return requestHeaders
@@ -162,7 +163,7 @@ export function applyTheme(theme: Theme, rootElement: Element = document.documen
 
 export async function updateVersionAndAuthDataFromServer(): Promise<void> {
     try {
-        const { site, currentUser } = await getSiteVersionAndAuthenticatedUser(instanceURL, accessToken)
+        const { site, currentUser } = await getSiteVersionAndAuthenticatedUser(instanceURL, accessToken, requestHeaders)
         authenticatedUser = currentUser
         backendVersion = site?.productVersion || null
         isServerAccessSuccessful = true

--- a/client/jetbrains/webview/src/search/js-to-java-bridge.ts
+++ b/client/jetbrains/webview/src/search/js-to-java-bridge.ts
@@ -110,10 +110,10 @@ export async function getConfigAlwaysFulfill(): Promise<PluginConfig> {
         return {
             instanceURL: 'https://sourcegraph.com/',
             accessToken: null,
+            customRequestHeadersAsString: null,
             isGlobbingEnabled: false,
             pluginVersion: '0.0.0',
             anonymousUserId: 'no-user-id',
-            pluginVersion: '0.0.0',
         }
     }
 }

--- a/client/jetbrains/webview/src/search/js-to-java-bridge.ts
+++ b/client/jetbrains/webview/src/search/js-to-java-bridge.ts
@@ -109,8 +109,9 @@ export async function getConfigAlwaysFulfill(): Promise<PluginConfig> {
         console.error(`Failed to get config: ${(error as Error).message}`)
         return {
             instanceURL: 'https://sourcegraph.com/',
-            isGlobbingEnabled: false,
             accessToken: null,
+            isGlobbingEnabled: false,
+            pluginVersion: '0.0.0',
             anonymousUserId: 'no-user-id',
             pluginVersion: '0.0.0',
         }

--- a/client/jetbrains/webview/src/search/lib/requestGraphQl.ts
+++ b/client/jetbrains/webview/src/search/lib/requestGraphQl.ts
@@ -1,7 +1,7 @@
 import { asError } from '@sourcegraph/common'
 import { GRAPHQL_URI, GraphQLResult } from '@sourcegraph/http-client'
 
-import { getAccessToken, getInstanceURL } from '..'
+import { getAccessToken, getCustomRequestHeaders, getInstanceURL } from '..'
 
 export const requestGraphQL = async <R, V = object>(
     request: string,
@@ -10,6 +10,7 @@ export const requestGraphQL = async <R, V = object>(
 ): Promise<GraphQLResult<R>> => {
     const instanceURL = getInstanceURL()
     const accessToken = getAccessToken()
+    const customRequestHeaders = getCustomRequestHeaders()
 
     const nameMatch = request.match(/^\s*(?:query|mutation)\s+(\w+)/)
     const apiURL = `${GRAPHQL_URI}${nameMatch ? '?' + nameMatch[1] : ''}`
@@ -19,6 +20,11 @@ export const requestGraphQL = async <R, V = object>(
     headers.set('X-Sourcegraph-Should-Trace', new URLSearchParams(window.location.search).get('trace') || 'false')
     if (accessToken) {
         headers.set('Authorization', `token ${accessToken}`)
+    }
+    if (customRequestHeaders) {
+        for (const [name, value] of Object.entries(customRequestHeaders)) {
+            headers.set(name, value)
+        }
     }
 
     let response: Response | null = null

--- a/client/jetbrains/webview/src/search/types.d.ts
+++ b/client/jetbrains/webview/src/search/types.d.ts
@@ -21,6 +21,7 @@ export interface PluginConfig {
     instanceURL: string
     isGlobbingEnabled: boolean
     accessToken: string | null
+    requestHeadersAsString: string | null
     anonymousUserId: string
     pluginVersion: string
 }

--- a/client/jetbrains/webview/src/search/types.d.ts
+++ b/client/jetbrains/webview/src/search/types.d.ts
@@ -19,11 +19,11 @@ export interface Theme {
 
 export interface PluginConfig {
     instanceURL: string
-    isGlobbingEnabled: boolean
     accessToken: string | null
     requestHeadersAsString: string | null
-    anonymousUserId: string
+    isGlobbingEnabled: boolean
     pluginVersion: string
+    anonymousUserId: string
 }
 
 export interface Search {

--- a/client/jetbrains/webview/src/search/types.d.ts
+++ b/client/jetbrains/webview/src/search/types.d.ts
@@ -20,7 +20,7 @@ export interface Theme {
 export interface PluginConfig {
     instanceURL: string
     accessToken: string | null
-    requestHeadersAsString: string | null
+    customRequestHeadersAsString: string | null
     isGlobbingEnabled: boolean
     pluginVersion: string
     anonymousUserId: string

--- a/client/jetbrains/webview/src/sourcegraph-api-access/api-gateway.ts
+++ b/client/jetbrains/webview/src/sourcegraph-api-access/api-gateway.ts
@@ -51,7 +51,8 @@ export interface SiteVersionAndCurrentUser {
 
 export async function getSiteVersionAndAuthenticatedUser(
     instanceURL: string,
-    accessToken: string | null
+    accessToken: string | null,
+    requestHeaders: { [name: string]: string } | null
 ): Promise<SiteVersionAndCurrentUser> {
     if (!instanceURL) {
         return { site: null, currentUser: null }
@@ -66,6 +67,7 @@ export async function getSiteVersionAndAuthenticatedUser(
             'Content-Type': 'application/json',
             'X-Sourcegraph-Should-Trace': new URLSearchParams(window.location.search).get('trace') || 'false',
             ...(accessToken && { Authorization: `token ${accessToken}` }),
+            ...requestHeaders,
         },
     }).toPromise()
 

--- a/client/jetbrains/webview/src/sourcegraph-api-access/api-gateway.ts
+++ b/client/jetbrains/webview/src/sourcegraph-api-access/api-gateway.ts
@@ -52,7 +52,7 @@ export interface SiteVersionAndCurrentUser {
 export async function getSiteVersionAndAuthenticatedUser(
     instanceURL: string,
     accessToken: string | null,
-    requestHeaders: { [name: string]: string } | null
+    customRequestHeaders: { [name: string]: string } | null
 ): Promise<SiteVersionAndCurrentUser> {
     if (!instanceURL) {
         return { site: null, currentUser: null }
@@ -67,7 +67,7 @@ export async function getSiteVersionAndAuthenticatedUser(
             'Content-Type': 'application/json',
             'X-Sourcegraph-Should-Trace': new URLSearchParams(window.location.search).get('trace') || 'false',
             ...(accessToken && { Authorization: `token ${accessToken}` }),
-            ...requestHeaders,
+            ...customRequestHeaders,
         },
     }).toPromise()
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/39803

Adds this section to the UI:

![CleanShot 2022-10-07 at 13 23 40@2x](https://user-images.githubusercontent.com/2552265/194542251-f47b3920-c040-4d1d-ab1b-f537a30106e0.png)

- It saves to project/application settings like the rest of the settings.
- It adds the custom headers to all types of requests we do, both on the Java and JS side of things.
- The UI verifies if the format of the custom headers is fine and shows helpful error messages. Also, the places where we parse the custom headers list string are also foolproof, they won't break if the user messes up the string manually.
- The comma-separated nature of the string is inelegant in my opinion, but the remote URL replacements were already that way, and I just decided to ride that train. I spent too much time once again trying to make it work with a proper key-value table UI: this part of the IntelliJ SDK is not documented, and their code examples don't help because it's all Kotlin. So I actually spent hours trying to make it work, but making a smooth UX would've needed many more hours of trial-and-error, so I just reverted and went with this weird comma-separated list.

## Test plan

When checking the code, I don't advise going commit by commit because I made some refactors during it and it's a mess, I think it's easier to go on the whole thing.

Tested the requests with Pipedream/RequestBin: [30-sec Loom](https://www.loom.com/share/174bcf8bf409445fa3a206c6cfda2b21)

## App preview:

- [Web](https://sg-web-dv-jetbrains-specify-auth-headers.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hityoboasy.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
