### PR TITLE
Add site config last ID checks

### DIFF
--- a/dev/authtest/code_intel_test.go
+++ b/dev/authtest/code_intel_test.go
@@ -95,7 +95,7 @@ func TestCodeIntelEndpoints(t *testing.T) {
 
 		// Retry because the configuration update endpoint is eventually consistent
 		var lastBody string
-		err = gqltestutil.Retry(10*time.Second, func() error {
+		err = gqltestutil.Retry(15*time.Second, func() error {
 			resp, err := userClient.Post(*baseURL+"/.api/lsif/upload?commit=6ffc6072f5ed13d8e8782490705d9689cd2c546a&repository=github.com/sgtest/private", nil)
 			if err != nil {
 				t.Fatal(err)

--- a/dev/gqltest/main_test.go
+++ b/dev/gqltest/main_test.go
@@ -82,7 +82,7 @@ func TestMain(m *testing.M) {
 
 	licenseKey := os.Getenv("SOURCEGRAPH_LICENSE_KEY")
 	if licenseKey != "" {
-		siteConfig, err := client.SiteConfiguration()
+		siteConfig, lastID, err := client.SiteConfiguration()
 		if err != nil {
 			log.Fatal("Failed to get site configuration:", err)
 		}
@@ -94,7 +94,7 @@ func TestMain(m *testing.M) {
 			}
 
 			siteConfig.LicenseKey = licenseKey
-			err = client.UpdateSiteConfiguration(siteConfig)
+			err = client.UpdateSiteConfiguration(siteConfig, lastID)
 			if err != nil {
 				return errors.Wrap(err, "update site configuration")
 			}

--- a/dev/gqltest/organization_test.go
+++ b/dev/gqltest/organization_test.go
@@ -115,21 +115,25 @@ func TestOrganization(t *testing.T) {
 
 		// Update site configuration to set "auth.userOrgMap" which makes the new user join
 		// the organization (gqltest-org) automatically.
-		siteConfig, err := client.SiteConfiguration()
+		siteConfig, lastID, err := client.SiteConfiguration()
 		if err != nil {
 			t.Fatal(err)
 		}
 		oldSiteConfig := new(schema.SiteConfiguration)
 		*oldSiteConfig = *siteConfig
 		defer func() {
-			err = client.UpdateSiteConfiguration(oldSiteConfig)
+			_, lastID, err := client.SiteConfiguration()
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = client.UpdateSiteConfiguration(oldSiteConfig, lastID)
 			if err != nil {
 				t.Fatal(err)
 			}
 		}()
 
 		siteConfig.AuthUserOrgMap = map[string][]string{"*": {testOrgName}}
-		err = client.UpdateSiteConfiguration(siteConfig)
+		err = client.UpdateSiteConfiguration(siteConfig, lastID)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -103,8 +103,8 @@ type searchClient interface {
 	SearchFiles(query string) (*gqltestutil.SearchFileResults, error)
 	SearchAll(query string) ([]*gqltestutil.AnyResult, error)
 
-	UpdateSiteConfiguration(config *schema.SiteConfiguration) error
-	SiteConfiguration() (*schema.SiteConfiguration, error)
+	UpdateSiteConfiguration(config *schema.SiteConfiguration, lastID int32) error
+	SiteConfiguration() (*schema.SiteConfiguration, int32, error)
 
 	OverwriteSettings(subjectID, contents string) error
 	AuthenticatedUserID() string

--- a/dev/gqltest/site_config_test.go
+++ b/dev/gqltest/site_config_test.go
@@ -20,14 +20,18 @@ func TestSiteConfig(t *testing.T) {
 		removeTestUserAfterTest(t, testClient1.AuthenticatedUserID())
 
 		// Update site configuration to not allow sign up for builtin auth provider.
-		siteConfig, err := client.SiteConfiguration()
+		siteConfig, lastID, err := client.SiteConfiguration()
 		if err != nil {
 			t.Fatal(err)
 		}
 		oldSiteConfig := new(schema.SiteConfiguration)
 		*oldSiteConfig = *siteConfig
 		defer func() {
-			err = client.UpdateSiteConfiguration(oldSiteConfig)
+			_, lastID, err := client.SiteConfiguration()
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = client.UpdateSiteConfiguration(oldSiteConfig, lastID)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -41,7 +45,7 @@ func TestSiteConfig(t *testing.T) {
 				},
 			},
 		}
-		err = client.UpdateSiteConfiguration(siteConfig)
+		err = client.UpdateSiteConfiguration(siteConfig, lastID)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -342,14 +342,18 @@ func syncUserPerms(t *testing.T, userID, userName string) {
 func enableSubRepoPermissions(t *testing.T) {
 	t.Helper()
 
-	siteConfig, err := client.SiteConfiguration()
+	siteConfig, lastID, err := client.SiteConfiguration()
 	if err != nil {
 		t.Fatal(err)
 	}
 	oldSiteConfig := new(schema.SiteConfiguration)
 	*oldSiteConfig = *siteConfig
 	t.Cleanup(func() {
-		err = client.UpdateSiteConfiguration(oldSiteConfig)
+		_, lastID, err := client.SiteConfiguration()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = client.UpdateSiteConfiguration(oldSiteConfig, lastID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -361,7 +365,7 @@ func enableSubRepoPermissions(t *testing.T) {
 			Enabled: true,
 		},
 	}
-	err = client.UpdateSiteConfiguration(siteConfig)
+	err = client.UpdateSiteConfiguration(siteConfig, lastID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cmd/init-sg/main.go
+++ b/internal/cmd/init-sg/main.go
@@ -88,13 +88,13 @@ func initSourcegraph() {
 	}
 
 	// Ensure site configuration is set up correctly
-	siteConfig, err := client.SiteConfiguration()
+	siteConfig, lastID, err := client.SiteConfiguration()
 	if err != nil {
 		log.Fatal(err)
 	}
 	if siteConfig.ExternalURL != *baseURL {
 		siteConfig.ExternalURL = *baseURL
-		err = client.UpdateSiteConfiguration(siteConfig)
+		err = client.UpdateSiteConfiguration(siteConfig, lastID)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/internal/gqltestutil/settings.go
+++ b/internal/gqltestutil/settings.go
@@ -152,11 +152,12 @@ query ViewerSettings {
 // SiteConfiguration returns current effective site configuration.
 //
 // This method requires the authenticated user to be a site admin.
-func (c *Client) SiteConfiguration() (*schema.SiteConfiguration, error) {
+func (c *Client) SiteConfiguration() (*schema.SiteConfiguration, int32, error) {
 	const query = `
 query Site {
 	site {
 		configuration {
+            id
 			effectiveContents
 		}
 	}
@@ -167,6 +168,7 @@ query Site {
 		Data struct {
 			Site struct {
 				Configuration struct {
+					ID                int32  `json:"id"`
 					EffectiveContents string `json:"effectiveContents"`
 				} `json:"configuration"`
 			} `json:"site"`
@@ -174,33 +176,35 @@ query Site {
 	}
 	err := c.GraphQL("", query, nil, &resp)
 	if err != nil {
-		return nil, errors.Wrap(err, "request GraphQL")
+		return nil, 0, errors.Wrap(err, "request GraphQL")
 	}
 
 	config := new(schema.SiteConfiguration)
 	err = jsonc.Unmarshal(resp.Data.Site.Configuration.EffectiveContents, config)
 	if err != nil {
-		return nil, errors.Wrap(err, "unmarshal configuration")
+		return nil, 0, errors.Wrap(err, "unmarshal configuration")
 	}
-	return config, nil
+
+	return config, resp.Data.Site.Configuration.ID, nil
 }
 
 // UpdateSiteConfiguration updates site configuration.
 //
 // This method requires the authenticated user to be a site admin.
-func (c *Client) UpdateSiteConfiguration(config *schema.SiteConfiguration) error {
+func (c *Client) UpdateSiteConfiguration(config *schema.SiteConfiguration, lastID int32) error {
 	input, err := jsoniter.Marshal(config)
 	if err != nil {
 		return errors.Wrap(err, "marshal configuration")
 	}
 
 	const query = `
-mutation UpdateSiteConfiguration($input: String!) {
-	updateSiteConfiguration(lastID: 0, input: $input)
+mutation UpdateSiteConfiguration($lastID: Int!, $input: String!) {
+	updateSiteConfiguration(lastID: $lastID, input: $input)
 }
 `
 	variables := map[string]any{
-		"input": string(input),
+		"lastID": lastID,
+		"input":  string(input),
 	}
 	err = c.GraphQL("", query, variables, nil)
 	if err != nil {


### PR DESCRIPTION
Adds proper handling of Last ID of site configuration to client.

Updating site configuration fails if the incorrect Last ID is supplied, to prevent race conditions.

## Test plan

Tests updated. Unit tests passing. Fingers crossed for integration tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
