### PR TITLE
Revert Last ID check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - WIP changesets in Gitlab >= 14.0 are now prefixed with `Draft:` instead of `WIP:` to accomodate for the [breaking change in Gitlab 14.0](https://docs.gitlab.com/ee/update/removals.html#wip-merge-requests-renamed-draft-merge-requests). [#42024](https://github.com/sourcegraph/sourcegraph/pull/42024)
-- When updating the site configuration, the provided Last ID is now used to prevent race conditions when simultaneous config updates occur. [#42691](https://github.com/sourcegraph/sourcegraph/pull/42691)
 
 ### Removed
 

--- a/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -435,14 +435,7 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
             restartToApply = await updateSiteConfiguration(lastConfigurationID, newContents).toPromise<boolean>()
         } catch (error) {
             logger.error(error)
-            this.setState({
-                saving: false,
-                error: new Error(
-                    String(error) +
-                        '\nError occured while attempting to save site configuration. Please backup changes before reloading the page.'
-                ),
-            })
-            throw error
+            this.setState({ saving: false, error })
         }
 
         const oldContents = lastConfiguration?.effectiveContents || ''

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -131,11 +131,7 @@ func (r *siteConfigurationResolver) ID(ctx context.Context) (int32, error) {
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return 0, err
 	}
-	conf, err := r.db.Conf().SiteGetLatest(ctx)
-	if err != nil {
-		return 0, err
-	}
-	return conf.ID, nil
+	return 0, nil // TODO(slimsag): future: return the real ID here to prevent races
 }
 
 func (r *siteConfigurationResolver) EffectiveContents(ctx context.Context) (JSONCString, error) {
@@ -184,7 +180,8 @@ func (r *schemaResolver) UpdateSiteConfiguration(ctx context.Context, args *stru
 		return false, errors.Errorf("error unredacting secrets: %s", err)
 	}
 	prev.Site = unredacted
-	if err := globals.ConfigurationServerFrontendOnly.Write(ctx, prev, args.LastID); err != nil {
+	// TODO(slimsag): future: actually pass lastID through to prevent race conditions
+	if err := globals.ConfigurationServerFrontendOnly.Write(ctx, prev); err != nil {
 		return false, err
 	}
 	return globals.ConfigurationServerFrontendOnly.NeedServerRestart(), nil

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -119,7 +119,7 @@ func overrideSiteConfig(ctx context.Context, logger log.Logger, db database.DB) 
 		}
 		raw.Site = string(site)
 
-		err = cs.Write(ctx, raw, raw.ID)
+		err = cs.Write(ctx, raw)
 		if err != nil {
 			return errors.Wrap(err, "writing site config overrides to database")
 		}
@@ -445,19 +445,16 @@ func (c *configurationSource) Read(ctx context.Context) (conftypes.RawUnified, e
 	}
 
 	return conftypes.RawUnified{
-		ID:                 site.ID,
 		Site:               site.Contents,
 		ServiceConnections: serviceConnections(c.logger),
 	}, nil
 }
 
-func (c *configurationSource) Write(ctx context.Context, input conftypes.RawUnified, lastID int32) error {
+func (c *configurationSource) Write(ctx context.Context, input conftypes.RawUnified) error {
+	// TODO(slimsag): future: pass lastID through for race prevention
 	site, err := c.db.Conf().SiteGetLatest(ctx)
 	if err != nil {
 		return errors.Wrap(err, "ConfStore.SiteGetLatest")
-	}
-	if site.ID != lastID {
-		return errors.New("site config has been modified by another request, write not allowed")
 	}
 	_, err = c.db.Conf().SiteCreateIfUpToDate(ctx, &site.ID, input.Site)
 	if err != nil {

--- a/cmd/frontend/internal/cli/config_test.go
+++ b/cmd/frontend/internal/cli/config_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,8 +12,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestServiceConnections(t *testing.T) {
@@ -25,29 +22,6 @@ func TestServiceConnections(t *testing.T) {
 	if reflect.DeepEqual(sc, conftypes.ServiceConnections{}) {
 		t.Fatal("expected non-empty service connections")
 	}
-}
-
-func TestWriteSiteConfig(t *testing.T) {
-	db := database.NewMockDB()
-	confStore := database.NewMockConfStore()
-	conf := &database.SiteConfig{ID: 1}
-	confStore.SiteGetLatestFunc.SetDefaultReturn(
-		conf,
-		nil,
-	)
-	logger := logtest.Scoped(t)
-	db.ConfFunc.SetDefaultReturn(confStore)
-	confSource := newConfigurationSource(logger, db)
-
-	t.Run("error when incorrect last ID", func(t *testing.T) {
-		err := confSource.Write(context.Background(), conftypes.RawUnified{}, conf.ID-1)
-		assert.Error(t, err)
-	})
-
-	t.Run("no error when correct last ID", func(t *testing.T) {
-		err := confSource.Write(context.Background(), conftypes.RawUnified{}, conf.ID)
-		assert.NoError(t, err)
-	})
 }
 
 func TestReadSiteConfigFile(t *testing.T) {

--- a/internal/conf/conftypes/conftypes.go
+++ b/internal/conf/conftypes/conftypes.go
@@ -28,7 +28,6 @@ type ServiceConnections struct {
 
 // RawUnified is the unparsed variant of conf.Unified.
 type RawUnified struct {
-	ID                 int32
 	Site               string
 	ServiceConnections ServiceConnections
 }

--- a/internal/conf/mocks_test.go
+++ b/internal/conf/mocks_test.go
@@ -36,7 +36,7 @@ func NewMockConfigurationSource() *MockConfigurationSource {
 			},
 		},
 		WriteFunc: &ConfigurationSourceWriteFunc{
-			defaultHook: func(context.Context, conftypes.RawUnified, int32) (r0 error) {
+			defaultHook: func(context.Context, conftypes.RawUnified) (r0 error) {
 				return
 			},
 		},
@@ -54,7 +54,7 @@ func NewStrictMockConfigurationSource() *MockConfigurationSource {
 			},
 		},
 		WriteFunc: &ConfigurationSourceWriteFunc{
-			defaultHook: func(context.Context, conftypes.RawUnified, int32) error {
+			defaultHook: func(context.Context, conftypes.RawUnified) error {
 				panic("unexpected invocation of MockConfigurationSource.Write")
 			},
 		},
@@ -183,24 +183,24 @@ func (c ConfigurationSourceReadFuncCall) Results() []interface{} {
 // ConfigurationSourceWriteFunc describes the behavior when the Write method
 // of the parent MockConfigurationSource instance is invoked.
 type ConfigurationSourceWriteFunc struct {
-	defaultHook func(context.Context, conftypes.RawUnified, int32) error
-	hooks       []func(context.Context, conftypes.RawUnified, int32) error
+	defaultHook func(context.Context, conftypes.RawUnified) error
+	hooks       []func(context.Context, conftypes.RawUnified) error
 	history     []ConfigurationSourceWriteFuncCall
 	mutex       sync.Mutex
 }
 
 // Write delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockConfigurationSource) Write(v0 context.Context, v1 conftypes.RawUnified, v2 int32) error {
-	r0 := m.WriteFunc.nextHook()(v0, v1, v2)
-	m.WriteFunc.appendCall(ConfigurationSourceWriteFuncCall{v0, v1, v2, r0})
+func (m *MockConfigurationSource) Write(v0 context.Context, v1 conftypes.RawUnified) error {
+	r0 := m.WriteFunc.nextHook()(v0, v1)
+	m.WriteFunc.appendCall(ConfigurationSourceWriteFuncCall{v0, v1, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the Write method of the
 // parent MockConfigurationSource instance is invoked and the hook queue is
 // empty.
-func (f *ConfigurationSourceWriteFunc) SetDefaultHook(hook func(context.Context, conftypes.RawUnified, int32) error) {
+func (f *ConfigurationSourceWriteFunc) SetDefaultHook(hook func(context.Context, conftypes.RawUnified) error) {
 	f.defaultHook = hook
 }
 
@@ -208,7 +208,7 @@ func (f *ConfigurationSourceWriteFunc) SetDefaultHook(hook func(context.Context,
 // Write method of the parent MockConfigurationSource instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *ConfigurationSourceWriteFunc) PushHook(hook func(context.Context, conftypes.RawUnified, int32) error) {
+func (f *ConfigurationSourceWriteFunc) PushHook(hook func(context.Context, conftypes.RawUnified) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -217,19 +217,19 @@ func (f *ConfigurationSourceWriteFunc) PushHook(hook func(context.Context, conft
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ConfigurationSourceWriteFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, conftypes.RawUnified, int32) error {
+	f.SetDefaultHook(func(context.Context, conftypes.RawUnified) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ConfigurationSourceWriteFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, conftypes.RawUnified, int32) error {
+	f.PushHook(func(context.Context, conftypes.RawUnified) error {
 		return r0
 	})
 }
 
-func (f *ConfigurationSourceWriteFunc) nextHook() func(context.Context, conftypes.RawUnified, int32) error {
+func (f *ConfigurationSourceWriteFunc) nextHook() func(context.Context, conftypes.RawUnified) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -268,9 +268,6 @@ type ConfigurationSourceWriteFuncCall struct {
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 conftypes.RawUnified
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 int32
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -279,7 +276,7 @@ type ConfigurationSourceWriteFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ConfigurationSourceWriteFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/conf/server.go
+++ b/internal/conf/server.go
@@ -11,7 +11,7 @@ import (
 // "raw" configuration.
 type ConfigurationSource interface {
 	// Write updates the configuration. The Deployment field is ignored.
-	Write(ctx context.Context, data conftypes.RawUnified, lastID int32) error
+	Write(ctx context.Context, data conftypes.RawUnified) error
 	Read(ctx context.Context) (conftypes.RawUnified, error)
 }
 
@@ -41,7 +41,7 @@ func NewServer(source ConfigurationSource) *Server {
 }
 
 // Write validates and writes input to the server's source.
-func (s *Server) Write(ctx context.Context, input conftypes.RawUnified, lastID int32) error {
+func (s *Server) Write(ctx context.Context, input conftypes.RawUnified) error {
 	// Parse the configuration so that we can diff it (this also validates it
 	// is proper JSON).
 	_, err := ParseConfig(input)
@@ -49,7 +49,7 @@ func (s *Server) Write(ctx context.Context, input conftypes.RawUnified, lastID i
 		return err
 	}
 
-	err = s.source.Write(ctx, input, lastID)
+	err = s.source.Write(ctx, input)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This reverts commit 3a582762078efc8305844ed6663f95fdc18cc9b9.

Something in the Last ID check seems to be causing requests to time out.

## Test plan

🤞 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
