### PR TITLE
Fix legacy-extensions by passing settings instead of observable

### DIFF
--- a/client/shared/src/codeintel/legacy-extensions/api.ts
+++ b/client/shared/src/codeintel/legacy-extensions/api.ts
@@ -3,7 +3,7 @@
 import { Observable } from 'rxjs'
 
 import { GraphQLResult } from '@sourcegraph/http-client'
-import { Settings } from '@sourcegraph/shared/src/settings/settings'
+import { Settings, SettingsCascade } from '@sourcegraph/shared/src/settings/settings'
 
 import { PlatformContext } from '../../platform/context'
 
@@ -1012,7 +1012,7 @@ export interface CodeIntelContext extends Pick<PlatformContext, 'requestGraphQL'
 
 export type SettingsGetter = <T>(setting: string) => T | undefined
 
-export function newSettingsGetter(settingsCascade: Settings): SettingsGetter {
+export function newSettingsGetter(settingsCascade: SettingsCascade<Settings>): SettingsGetter {
     return <T>(setting: string): T | undefined =>
         settingsCascade.final && (settingsCascade.final[setting] as T | undefined)
 }

--- a/client/shared/src/extensions/createNoopLoadedController.ts
+++ b/client/shared/src/extensions/createNoopLoadedController.ts
@@ -39,7 +39,7 @@ export function createNoopController(platformContext: PlatformContext): Controll
                 const extensionHostAPI = injectNewCodeintel(createExtensionHostAPI(extensionHostState), {
                     requestGraphQL: platformContext.requestGraphQL,
                     telemetryService: platformContext.telemetryService,
-                    settings: newSettingsGetter(platformContext.settings),
+                    settings: newSettingsGetter(settingsCascade),
                 })
                 const remoteExtensionHostAPI = pretendRemote(extensionHostAPI)
                 const exposedToClient = initMainThreadAPI(remoteExtensionHostAPI, platformContext).exposedToClient


### PR DESCRIPTION
See this comment for more details: https://github.com/sourcegraph/sourcegraph/pull/42224#issuecomment-1271661406

In short: after disabling extensions we were seeing more queries than before. Suspicion was that these global settings we have on sourcegraph.com didn't have any effect:

<img width="872" alt="screenshot_2022-10-07_16 29 29@2x" src="https://user-images.githubusercontent.com/1185253/194577915-9f4f4ddf-8280-4a85-aad2-cec4a618cf03.png">

So I dug into the code where we access the settings and copied these settings to my local instance.

Here's the results:

![image](https://user-images.githubusercontent.com/1185253/194578018-fdca7bf6-19bb-4690-a85a-60cbfa671c1a.png)


Turns out that all of the `getSetting` calls returned `undefined` because `context.settings()` always returned `undefined`, because `newSettingsGetter` didn't receive the `SettingsCascade<Settings>` it expected but the `platformContext.settings`, which is an Observable.

Why that didn't produce a type error? No idea

How to verify that this is correct? No idea




## Test plan

- But I did test this locally and can confirm that now settings are propagated from my global settings. I added print statements to `getSetting` in `api.ts` that print the values.

## App preview:

- [Web](https://sg-web-mrn-fix-missing-settings.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-oqmnfvvidi.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
