### PR TITLE
tFix bug around how legacy extensions load settings

### DIFF
--- a/client/shared/src/extensions/createNoopLoadedController.ts
+++ b/client/shared/src/extensions/createNoopLoadedController.ts
@@ -19,10 +19,7 @@ export function createNoopController(platformContext: PlatformContext): Controll
     }> = new Promise((resolve, reject) => {
         platformContext.settings.subscribe(settingsCascade => {
             ;(async () => {
-                const [injectNewCodeintel, newSettingsGetter] = await Promise.all([
-                    import('../codeintel/api').then(module => module.injectNewCodeintel),
-                    import('../codeintel/legacy-extensions/api').then(module => module.newSettingsGetter),
-                ])
+                const injectNewCodeintel = await import('../codeintel/api').then(module => module.injectNewCodeintel)
 
                 if (!isSettingsValid(settingsCascade)) {
                     throw new Error('Settings are not valid')
@@ -39,7 +36,7 @@ export function createNoopController(platformContext: PlatformContext): Controll
                 const extensionHostAPI = injectNewCodeintel(createExtensionHostAPI(extensionHostState), {
                     requestGraphQL: platformContext.requestGraphQL,
                     telemetryService: platformContext.telemetryService,
-                    settings: newSettingsGetter(platformContext.settings),
+                    settings: key => settingsCascade.final[key],
                 })
                 const remoteExtensionHostAPI = pretendRemote(extensionHostAPI)
                 const exposedToClient = initMainThreadAPI(remoteExtensionHostAPI, platformContext).exposedToClient


### PR DESCRIPTION
Context: https://github.com/sourcegraph/sourcegraph/pull/42224



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-extensions-settings.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

