### PR TITLE
vscode: vscode extension requests chunk matches by default

### DIFF
--- a/client/vscode/src/webview/search-panel/SearchResultsView.tsx
+++ b/client/vscode/src/webview/search-panel/SearchResultsView.tsx
@@ -147,6 +147,7 @@ export const SearchResultsView: React.FunctionComponent<React.PropsWithChildren<
                     patternType,
                     version: LATEST_VERSION,
                     trace: undefined,
+                    chunkMatches: true,
                 })
                 .then(() => {
                     editorReference.current?.focus()


### PR DESCRIPTION
Stacked on #42675

The VSCode extension re-uses search result UI components [which now only support chunk matches](https://github.com/sourcegraph/sourcegraph/pull/42271), so the extension should just request chunk matches by default as well.

## Test plan
Verify the VSCode extension continues to work as expected
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
