### PR TITLE
executors: Support setting multiple docker registry mirrors

### DIFF
--- a/enterprise/cmd/executor/internal/command/firecracker.go
+++ b/enterprise/cmd/executor/internal/command/firecracker.go
@@ -123,8 +123,8 @@ type dockerDaemonConfig struct {
 // for the optional docker daemon config file.
 const dockerDaemonConfigFilename = "docker-daemon.json"
 
-func newDockerDaemonConfig(tmpDir, mirrorAddress string) (_ string, err error) {
-	c, err := json.Marshal(&dockerDaemonConfig{RegistryMirrors: []string{mirrorAddress}})
+func newDockerDaemonConfig(tmpDir string, mirrorAddresses []string) (_ string, err error) {
+	c, err := json.Marshal(&dockerDaemonConfig{RegistryMirrors: mirrorAddresses})
 	if err != nil {
 		return "", errors.Wrap(err, "marshalling docker daemon config")
 	}
@@ -139,9 +139,9 @@ func newDockerDaemonConfig(tmpDir, mirrorAddress string) (_ string, err error) {
 // it will be mounted into the new virtual machine instance and executed.
 func setupFirecracker(ctx context.Context, runner commandRunner, logger Logger, name, workspaceDevice, tmpDir string, options Options, operations *Operations) error {
 	var daemonConfigFile string
-	if options.FirecrackerOptions.DockerRegistryMirrorURL != "" {
+	if len(options.FirecrackerOptions.DockerRegistryMirrorURLs) > 0 {
 		var err error
-		daemonConfigFile, err = newDockerDaemonConfig(tmpDir, options.FirecrackerOptions.DockerRegistryMirrorURL)
+		daemonConfigFile, err = newDockerDaemonConfig(tmpDir, options.FirecrackerOptions.DockerRegistryMirrorURLs)
 		if err != nil {
 			return err
 		}

--- a/enterprise/cmd/executor/internal/command/runner.go
+++ b/enterprise/cmd/executor/internal/command/runner.go
@@ -67,10 +67,10 @@ type FirecrackerOptions struct {
 	// virtual machine and executed on startup.
 	VMStartupScriptPath string
 
-	// DockerRegistryMirrorURL is an optional parameter to configure a docker
-	// registry mirror for the VMs docker daemon on startup. When set, /etc/docker/daemon.json
+	// DockerRegistryMirrorURLs is an optional parameter to configure docker
+	// registry mirrors for the VMs docker daemon on startup. When set, /etc/docker/daemon.json
 	// will be mounted into the VM.
-	DockerRegistryMirrorURL string
+	DockerRegistryMirrorURLs []string
 }
 
 type ResourceOptions struct {

--- a/enterprise/cmd/executor/internal/config/config.go
+++ b/enterprise/cmd/executor/internal/config/config.go
@@ -69,7 +69,7 @@ func (c *Config) Load() {
 	c.NodeExporterURL = c.GetOptional("NODE_EXPORTER_URL", "The URL of the node_exporter instance, without the /metrics path.")
 	c.DockerRegistryNodeExporterURL = c.GetOptional("DOCKER_REGISTRY_NODE_EXPORTER_URL", "The URL of the Docker Registry instance's node_exporter, without the /metrics path.")
 	c.MaxActiveTime = c.GetInterval("EXECUTOR_MAX_ACTIVE_TIME", "0", "The maximum time that can be spent by the worker dequeueing records to be handled.")
-	c.DockerRegistryMirrorURL = c.GetOptional("EXECUTOR_DOCKER_REGISTRY_MIRROR_URL", "The address of a docker registry mirror to use in firecracker VMs.")
+	c.DockerRegistryMirrorURL = c.GetOptional("EXECUTOR_DOCKER_REGISTRY_MIRROR_URL", "The address of a docker registry mirror to use in firecracker VMs. Supports multiple values, separated with a comma.")
 
 	hn := hostname.Get()
 	// Be unique but also descriptive.

--- a/enterprise/cmd/executor/internal/run/util.go
+++ b/enterprise/cmd/executor/internal/run/util.go
@@ -132,12 +132,12 @@ func workerOptions(c *config.Config) workerutil.WorkerOptions {
 
 func firecrackerOptions(c *config.Config) command.FirecrackerOptions {
 	return command.FirecrackerOptions{
-		Enabled:                 c.UseFirecracker,
-		Image:                   c.FirecrackerImage,
-		KernelImage:             c.FirecrackerKernelImage,
-		SandboxImage:            c.FirecrackerSandboxImage,
-		VMStartupScriptPath:     c.VMStartupScriptPath,
-		DockerRegistryMirrorURL: c.DockerRegistryMirrorURL,
+		Enabled:                  c.UseFirecracker,
+		Image:                    c.FirecrackerImage,
+		KernelImage:              c.FirecrackerKernelImage,
+		SandboxImage:             c.FirecrackerSandboxImage,
+		VMStartupScriptPath:      c.VMStartupScriptPath,
+		DockerRegistryMirrorURLs: strings.Split(c.DockerRegistryMirrorURL, ","),
 	}
 }
 


### PR DESCRIPTION
We want to use mirror.gcr.io as an additional mirror to reduce load further, so providing an option to set multiple here.

For now, we will only support scraping metrics from one docker registry mirror instance, as the other upstream one we want to use won't be scrapeable anyways.

## Test plan

Will test in k8s env.