### PR TITLE
codeintel: increase level of honeycomb sample for symbols service

### DIFF
--- a/cmd/symbols/shared/main.go
+++ b/cmd/symbols/shared/main.go
@@ -74,7 +74,7 @@ func Main(setup SetupFunc) {
 		Registerer: prometheus.DefaultRegisterer,
 		HoneyDataset: &honey.Dataset{
 			Name:       "codeintel-symbols",
-			SampleRate: 5,
+			SampleRate: 20,
 		},
 	}
 


### PR DESCRIPTION
Think itd be a good idea to reduce the amount of events the symbols service sends to honeycomb ~~(so we can free up quota for other services :smugcat: from codeintel)~~

cc @bobheadxi 

![image](https://user-images.githubusercontent.com/18282288/194605509-f5b5fbf9-bd9a-42cf-a358-3028aa3d3d45.png)

## Test plan

N/A, no really its not relevant
