### PR TITLE
search: don't calculate match groups if there are zero MatchItems

### DIFF
--- a/client/shared/src/components/ranking/LineRanking.test.tsx
+++ b/client/shared/src/components/ranking/LineRanking.test.tsx
@@ -270,6 +270,13 @@ describe('components/FileMatchContext', () => {
                 ]
             `)
         })
+
+        test('no matches', () => {
+            const maxMatches = 3
+            const context = 1
+            const { grouped } = calculateMatchGroupsSorted([], maxMatches, context)
+            expect(grouped).toMatchInlineSnapshot(`[]`)
+        })
     })
 })
 

--- a/client/shared/src/components/ranking/LineRanking.test.tsx
+++ b/client/shared/src/components/ranking/LineRanking.test.tsx
@@ -275,7 +275,7 @@ describe('components/FileMatchContext', () => {
             const maxMatches = 3
             const context = 1
             const { grouped } = calculateMatchGroupsSorted([], maxMatches, context)
-            expect(grouped).toMatchInlineSnapshot(`[]`)
+            expect(grouped).toMatchInlineSnapshot('[]')
         })
     })
 })

--- a/client/shared/src/components/ranking/LineRanking.ts
+++ b/client/shared/src/components/ranking/LineRanking.ts
@@ -115,6 +115,10 @@ export const calculateMatchGroupsSorted = (
     maxMatches: number,
     context: number
 ): { matches: MatchItem[]; grouped: MatchGroup[] } => {
+    if (matches.length === 0) {
+        return { matches: [], grouped: [] }
+    }
+
     const sortedMatches = matches.sort((a, b) => {
         if (a.startLine < b.startLine) {
             return -1


### PR DESCRIPTION
Short circuit in the client search result line ranking logic if there are no matches. 

## Test plan
Set `"experimentalFeatures"."clientSearchResultRanking": "by-line-number"` in settings and activate smart search
Run a search that produces no results
Run a search that activates one or more smart search rules
Verify the web app doesn't crash 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tl-dont-index-empty-array-line.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-fsbqyvblhj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
