### PR TITLE
Fix code insight live preview aria labels 

### DIFF
--- a/client/web/src/enterprise/insights/components/creation-ui/creation-ui-layout/CreationUiLayout.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/creation-ui-layout/CreationUiLayout.tsx
@@ -21,5 +21,12 @@ export const CreationUIForm = forwardRef((props, reference) => {
 export const CreationUIPreview = forwardRef((props, reference) => {
     const { as: Component = 'aside', className, ...attributes } = props
 
-    return <Component ref={reference} {...attributes} className={classNames(styles.rootLivePreview, className)} />
+    return (
+        <Component
+            {...attributes}
+            ref={reference}
+            aria-label="Code Insight live preview card"
+            className={classNames(styles.rootLivePreview, className)}
+        />
+    )
 }) as ForwardReferenceComponent<'aside', {}>

--- a/client/web/src/enterprise/insights/components/creation-ui/creation-ui-layout/CreationUiLayout.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/creation-ui-layout/CreationUiLayout.tsx
@@ -25,7 +25,7 @@ export const CreationUIPreview = forwardRef((props, reference) => {
         <Component
             {...attributes}
             ref={reference}
-            aria-label="Code Insight live preview card"
+            aria-label="Code Insight live preview"
             className={classNames(styles.rootLivePreview, className)}
         />
     )

--- a/client/web/src/enterprise/insights/components/creation-ui/live-preview/LivePreviewCard.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/live-preview/LivePreviewCard.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, HTMLAttributes } from 'react'
+import React, { FC, forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
 
 import { mdiRefresh } from '@mdi/js'
 import { ParentSize } from '@visx/responsive'
@@ -21,25 +21,40 @@ export interface LivePreviewUpdateButtonProps {
     onClick: () => void
 }
 
-const LivePreviewUpdateButton: React.FunctionComponent<
-    React.PropsWithChildren<LivePreviewUpdateButtonProps>
-> = props => {
+const LivePreviewUpdateButton: FC<LivePreviewUpdateButtonProps> = props => {
     const { disabled, onClick } = props
 
     return (
-        <Button variant="icon" disabled={disabled} className={styles.updateButton} onClick={onClick}>
-            Live preview <Icon svgPath={mdiRefresh} inline={false} aria-hidden={true} height="1rem" width="1rem" />
+        <Button
+            aria-label="Update code insight live preview"
+            variant="icon"
+            disabled={disabled}
+            className={styles.updateButton}
+            onClick={onClick}
+        >
+            Live preview
+            <Icon svgPath={mdiRefresh} inline={false} aria-hidden={true} height="1rem" width="1rem" />
         </Button>
     )
 }
 
-const LivePreviewLoading = InsightCardLoading
+const LivePreviewLoading: FC<PropsWithChildren<unknown>> = props => (
+    <InsightCardLoading {...props} aria-label="Loading insight live preview" />
+)
+
 const LivePreviewHeader = InsightCardHeader
 
 const LivePreviewBlurBackdrop = forwardRef((props, reference) => {
     const { as: Component = 'svg', className, ...attributes } = props
 
-    return <Component ref={reference} className={classNames(styles.chartWithMock, className)} {...attributes} />
+    return (
+        <Component
+            {...attributes}
+            ref={reference}
+            aria-hidden={true}
+            className={classNames(styles.chartWithMock, className)}
+        />
+    )
 }) as ForwardReferenceComponent<'svg', {}>
 
 const LivePreviewBanner: React.FunctionComponent<React.PropsWithChildren<unknown>> = props => (
@@ -60,7 +75,7 @@ const LivePreviewLegend: React.FunctionComponent<React.PropsWithChildren<LivePre
     const { series } = props
 
     return (
-        <LegendList className="mt-3">
+        <LegendList aria-label="Live preview chart legend" className="mt-3">
             {series.map(series => (
                 <LegendItem key={series.id} color={series.color} name={series.name} />
             ))}

--- a/client/web/src/enterprise/insights/components/views/card/InsightCard.tsx
+++ b/client/web/src/enterprise/insights/components/views/card/InsightCard.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, HTMLAttributes, ReactNode } from 'react'
+import React, { FC, forwardRef, HTMLAttributes, ReactNode, PropsWithChildren } from 'react'
 
 import classNames from 'classnames'
 import { useLocation } from 'react-router-dom'
@@ -76,12 +76,16 @@ const InsightCardHeader = forwardRef(function InsightCardHeader(props, reference
     )
 }) as ForwardReferenceComponent<'header', InsightCardTitleProps>
 
-const InsightCardLoading: React.FunctionComponent<React.PropsWithChildren<unknown>> = props => (
-    <InsightCardBanner>
-        <LoadingSpinner />
-        {props.children}
-    </InsightCardBanner>
-)
+const InsightCardLoading: FC<PropsWithChildren<HTMLAttributes<HTMLElement>>> = props => {
+    const { 'aria-label': ariaLabel = 'loading', children, ...attributes } = props
+
+    return (
+        <InsightCardBanner {...attributes}>
+            <LoadingSpinner aria-label={ariaLabel} />
+            {children}
+        </InsightCardBanner>
+    )
+}
 
 const InsightCardBanner: React.FunctionComponent<React.PropsWithChildren<HTMLAttributes<HTMLDivElement>>> = props => (
     <div {...props} className={classNames(styles.loadingContent, props.className)}>

--- a/client/web/src/enterprise/insights/pages/insights/creation/LineChartLivePreview.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/LineChartLivePreview.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react'
+import { useContext, useMemo, FC, HTMLAttributes } from 'react'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { useDeepMemo, Text, Series } from '@sourcegraph/wildcard'
@@ -31,18 +31,17 @@ export interface LivePreviewSeries {
     stroke: string
 }
 
-interface LineChartLivePreviewProps {
+interface LineChartLivePreviewProps extends HTMLAttributes<HTMLElement> {
     disabled: boolean
     repositories: string
     stepValue: string
     step: InsightStep
     isAllReposMode: boolean
-    className?: string
     series: LivePreviewSeries[]
 }
 
-export const LineChartLivePreview: React.FunctionComponent<LineChartLivePreviewProps> = props => {
-    const { disabled, repositories, stepValue, step, series, isAllReposMode, className } = props
+export const LineChartLivePreview: FC<LineChartLivePreviewProps> = props => {
+    const { disabled, repositories, stepValue, step, series, isAllReposMode, ...attributes } = props
     const { getInsightPreviewContent: getLivePreviewContent } = useContext(CodeInsightsBackendContext)
     const seriesToggleState = useSeriesToggle()
 
@@ -74,7 +73,7 @@ export const LineChartLivePreview: React.FunctionComponent<LineChartLivePreviewP
     const { state, update } = useLivePreview(getLivePreview)
 
     return (
-        <aside className={className}>
+        <aside {...attributes}>
             <LivePreviewUpdateButton disabled={disabled} onClick={update} />
 
             <LivePreviewCard>

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGoupCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGoupCreationForm.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react'
+import { FC, FormHTMLAttributes, ReactNode } from 'react'
 
 import classNames from 'classnames'
 
@@ -23,7 +23,7 @@ import { CaptureGroupSeriesInfoBadge } from './info-badge/CaptureGroupSeriesInfo
 import { CaptureGroupQueryInput } from './query-input/CaptureGroupQueryInput'
 import { SearchQueryChecks } from './search-query-checks/SearchQueryChecks'
 
-interface CaptureGroupCreationFormProps {
+interface CaptureGroupCreationFormProps extends Omit<FormHTMLAttributes<HTMLFormElement>, 'title' | 'children'> {
     form: Form<CaptureGroupFormFields>
     title: useFieldAPI<CaptureGroupFormFields['title']>
     repositories: useFieldAPI<CaptureGroupFormFields['repositories']>
@@ -34,7 +34,6 @@ interface CaptureGroupCreationFormProps {
 
     dashboardReferenceCount?: number
     isFormClearActive: boolean
-    className?: string
     children: (inputs: RenderPropertyInputs) => ReactNode
 
     onFormReset: () => void
@@ -56,10 +55,10 @@ export const CaptureGroupCreationForm: FC<CaptureGroupCreationFormProps> = props
         step,
         stepValue,
         dashboardReferenceCount,
-        className,
         isFormClearActive,
         children,
         onFormReset,
+        ...attributes
     } = props
 
     const {
@@ -70,7 +69,7 @@ export const CaptureGroupCreationForm: FC<CaptureGroupCreationFormProps> = props
 
     return (
         // eslint-disable-next-line react/forbid-elements
-        <form noValidate={true} className={className} onSubmit={handleSubmit} onReset={onFormReset}>
+        <form {...attributes} noValidate={true} onSubmit={handleSubmit} onReset={onFormReset}>
             <FormGroup
                 name="insight repositories"
                 title="Targeted repositories"

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGroupCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGroupCreationContent.tsx
@@ -30,8 +30,8 @@ const INITIAL_VALUES: CaptureGroupFormFields = {
 }
 
 interface CaptureGroupCreationContentProps {
-    touched: boolean
     initialValues?: Partial<CaptureGroupFormFields>
+    touched: boolean
     className?: string
     children: (inputs: RenderPropertyInputs) => ReactNode
     onSubmit: (values: CaptureGroupFormFields) => SubmissionErrors | Promise<SubmissionErrors> | void
@@ -40,7 +40,7 @@ interface CaptureGroupCreationContentProps {
 }
 
 export const CaptureGroupCreationContent: FC<CaptureGroupCreationContentProps> = props => {
-    const { touched, className, initialValues = {}, children, onSubmit, onChange = noop } = props
+    const { touched, initialValues = {}, className, children, onSubmit, onChange = noop } = props
 
     const form = useForm<CaptureGroupFormFields>({
         initialValues: { ...INITIAL_VALUES, ...initialValues },
@@ -118,6 +118,7 @@ export const CaptureGroupCreationContent: FC<CaptureGroupCreationContentProps> =
     return (
         <CreationUiLayout className={className}>
             <CreationUIForm
+                aria-label="Capture Group Insight creation form"
                 as={CaptureGroupCreationForm}
                 form={form}
                 title={title}

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGroupCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGroupCreationContent.tsx
@@ -118,7 +118,7 @@ export const CaptureGroupCreationContent: FC<CaptureGroupCreationContentProps> =
     return (
         <CreationUiLayout className={className}>
             <CreationUIForm
-                aria-label="Capture Group Insight creation form"
+                aria-label="Detect and track Insight creation form"
                 as={CaptureGroupCreationForm}
                 form={form}
                 title={title}

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightCreationContent.tsx
@@ -115,7 +115,7 @@ export const ComputeInsightCreationContent: FC<ComputeInsightCreationContentProp
     return (
         <CreationUiLayout {...attributes}>
             <CreationUIForm
-                aria-label="Compute Insight creation form"
+                aria-label="Group results Insight creation form"
                 noValidate={true}
                 onSubmit={handleSubmit}
                 onReset={handleFormReset}

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightCreationContent.tsx
@@ -114,7 +114,12 @@ export const ComputeInsightCreationContent: FC<ComputeInsightCreationContentProp
 
     return (
         <CreationUiLayout {...attributes}>
-            <CreationUIForm noValidate={true} onSubmit={handleSubmit} onReset={handleFormReset}>
+            <CreationUIForm
+                aria-label="Compute Insight creation form"
+                noValidate={true}
+                onSubmit={handleSubmit}
+                onReset={handleFormReset}
+            >
                 <FormGroup
                     name="insight repositories"
                     title="Targeted repositories"
@@ -132,7 +137,7 @@ export const ComputeInsightCreationContent: FC<ComputeInsightCreationContentProp
                     />
                 </FormGroup>
 
-                <hr className="my-4 w-100" />
+                <hr aria-hidden={true} className="my-4 w-100" />
 
                 <FormGroup
                     innerRef={series.input.ref}
@@ -167,13 +172,13 @@ export const ComputeInsightCreationContent: FC<ComputeInsightCreationContentProp
                     />
                 </FormGroup>
 
-                <hr className="my-4 w-100" />
+                <hr aria-hidden={true} className="my-4 w-100" />
 
                 <FormGroup name="map result" title="Map result">
                     <ComputeInsightMapPicker series={validSeries} {...groupBy.input} />
                 </FormGroup>
 
-                <hr className="my-4 w-100" />
+                <hr aria-hidden={true} className="my-4 w-100" />
 
                 <FormGroup name="chart settings group" title="Chart settings">
                     <Input
@@ -186,7 +191,7 @@ export const ComputeInsightCreationContent: FC<ComputeInsightCreationContentProp
                     />
                 </FormGroup>
 
-                <hr className="my-4 w-100" />
+                <hr aria-hidden={true} className="my-4 w-100" />
 
                 {children({
                     submitting: formAPI.submitting,

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeLivePreview.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeLivePreview.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react'
+import { HTMLAttributes, useContext, useMemo, FC } from 'react'
 
 import { groupBy } from 'lodash'
 
@@ -33,7 +33,7 @@ interface LanguageUsageDatum {
     group?: string
 }
 
-interface ComputeLivePreviewProps {
+interface ComputeLivePreviewProps extends HTMLAttributes<HTMLElement> {
     disabled: boolean
     repositories: string
     className?: string
@@ -41,8 +41,8 @@ interface ComputeLivePreviewProps {
     series: EditableDataSeries[]
 }
 
-export const ComputeLivePreview: React.FunctionComponent<ComputeLivePreviewProps> = props => {
-    const { disabled, repositories, series, groupBy, className } = props
+export const ComputeLivePreview: FC<ComputeLivePreviewProps> = props => {
+    const { disabled, repositories, series, groupBy, ...attribute } = props
     const { getInsightPreviewContent } = useContext(CodeInsightsBackendContext)
 
     const settings = useDeepMemo({
@@ -74,7 +74,7 @@ export const ComputeLivePreview: React.FunctionComponent<ComputeLivePreviewProps
     const { state, update } = useLivePreview(getLivePreview)
 
     return (
-        <aside className={className}>
+        <aside {...attribute}>
             <LivePreviewUpdateButton disabled={disabled} onClick={update} />
 
             <LivePreviewCard>

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/LangStatsInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/LangStatsInsightCreationContent.tsx
@@ -96,7 +96,7 @@ export const LangStatsInsightCreationContent: FC<LangStatsInsightCreationContent
     return (
         <CreationUiLayout data-testid="code-stats-insight-creation-page-content" className={className}>
             <CreationUIForm
-                aria-label="Lang stats Insight creation form"
+                aria-label="Language usage Insight creation form"
                 as={LangStatsInsightCreationForm}
                 handleSubmit={handleSubmit}
                 submitErrors={formAPI.submitErrors}

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/LangStatsInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/LangStatsInsightCreationContent.tsx
@@ -96,6 +96,7 @@ export const LangStatsInsightCreationContent: FC<LangStatsInsightCreationContent
     return (
         <CreationUiLayout data-testid="code-stats-insight-creation-page-content" className={className}>
             <CreationUIForm
+                aria-label="Lang stats Insight creation form"
                 as={LangStatsInsightCreationForm}
                 handleSubmit={handleSubmit}
                 submitErrors={formAPI.submitErrors}

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/lang-stats-insight-creation-form/LangStatsInsightCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/lang-stats-insight-creation-form/LangStatsInsightCreationForm.tsx
@@ -1,6 +1,4 @@
-import { FC, FormEventHandler, ReactNode } from 'react'
-
-import classNames from 'classnames'
+import { FC, FormEventHandler, FormHTMLAttributes, ReactNode } from 'react'
 
 import { Input } from '@sourcegraph/wildcard'
 
@@ -15,11 +13,11 @@ import { LangStatsCreationFormFields } from '../../types'
 
 import styles from './LangStatsInsightCreationForm.module.scss'
 
-export interface LangStatsInsightCreationFormProps {
+export interface LangStatsInsightCreationFormProps
+    extends Omit<FormHTMLAttributes<HTMLFormElement>, 'title' | 'children'> {
     handleSubmit: FormEventHandler
     submitErrors: SubmissionErrors
     submitting: boolean
-    className?: string
     isFormClearActive: boolean
     dashboardReferenceCount?: number
 
@@ -42,7 +40,6 @@ export const LangStatsInsightCreationForm: FC<LangStatsInsightCreationFormProps>
         handleSubmit,
         submitErrors,
         submitting,
-        className,
         title,
         repository,
         threshold,
@@ -50,16 +47,12 @@ export const LangStatsInsightCreationForm: FC<LangStatsInsightCreationFormProps>
         dashboardReferenceCount,
         onFormReset,
         children,
+        ...attributes
     } = props
 
     return (
         // eslint-disable-next-line react/forbid-elements
-        <form
-            noValidate={true}
-            className={classNames(className, 'd-flex flex-column')}
-            onSubmit={handleSubmit}
-            onReset={onFormReset}
-        >
+        <form {...attributes} noValidate={true} onSubmit={handleSubmit} onReset={onFormReset}>
             {/*
                 a11y-ignore
                 Rule: aria-allowed-role ARIA - role should be appropriate for the element
@@ -103,7 +96,7 @@ export const LangStatsInsightCreationForm: FC<LangStatsInsightCreationFormProps>
                 <CodeInsightDashboardsVisibility className="mt-5 mb-n1" dashboardCount={dashboardReferenceCount} />
             )}
 
-            <hr className={styles.formSeparator} />
+            <hr aria-hidden={true} className={styles.formSeparator} />
 
             {children({ submitting, submitErrors, isFormClearActive })}
         </form>

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/live-preview-chart/LangStatsInsightLivePreview.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/components/live-preview-chart/LangStatsInsightLivePreview.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react'
+import { FC, HTMLAttributes, useContext, useMemo } from 'react'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { useDeepMemo } from '@sourcegraph/wildcard'
@@ -19,7 +19,7 @@ import { CodeInsightsBackendContext, CategoricalChartContent } from '../../../..
 
 import { DEFAULT_PREVIEW_MOCK } from './constants'
 
-export interface LangStatsInsightLivePreviewProps {
+export interface LangStatsInsightLivePreviewProps extends HTMLAttributes<HTMLElement> {
     /**
      * Disable prop to disable live preview.
      * Used in a consumer of this component when some required fields
@@ -28,15 +28,14 @@ export interface LangStatsInsightLivePreviewProps {
     disabled?: boolean
     repository: string
     threshold: number
-    className?: string
 }
 
 /**
  * Displays live preview chart for creation UI with the latest insights settings
  * from creation UI form.
  */
-export const LangStatsInsightLivePreview: React.FunctionComponent<LangStatsInsightLivePreviewProps> = props => {
-    const { repository = '', threshold, disabled = false, className } = props
+export const LangStatsInsightLivePreview: FC<LangStatsInsightLivePreviewProps> = props => {
+    const { repository = '', threshold, disabled = false, ...attributes } = props
     const { getLangStatsInsightContent } = useContext(CodeInsightsBackendContext)
 
     const settings = useDeepMemo({
@@ -56,7 +55,7 @@ export const LangStatsInsightLivePreview: React.FunctionComponent<LangStatsInsig
     const { state, update } = useLivePreview(getLivePreviewContent)
 
     return (
-        <aside className={className}>
+        <aside {...attributes}>
             <LivePreviewUpdateButton disabled={disabled} onClick={update} />
 
             <LivePreviewCard>

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/SearchInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/SearchInsightCreationContent.tsx
@@ -75,7 +75,7 @@ export const SearchInsightCreationContent: FC<SearchInsightCreationContentProps>
     return (
         <CreationUiLayout data-testid={dataTestId} className={className}>
             <CreationUIForm
-                aria-label="Search Insight creation form"
+                aria-label="Track changes Insight creation form"
                 as={SearchInsightCreationForm}
                 handleSubmit={handleSubmit}
                 submitErrors={formAPI.submitErrors}

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/SearchInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/SearchInsightCreationContent.tsx
@@ -75,6 +75,7 @@ export const SearchInsightCreationContent: FC<SearchInsightCreationContentProps>
     return (
         <CreationUiLayout data-testid={dataTestId} className={className}>
             <CreationUIForm
+                aria-label="Search insight creation form"
                 as={SearchInsightCreationForm}
                 handleSubmit={handleSubmit}
                 submitErrors={formAPI.submitErrors}

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/SearchInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/SearchInsightCreationContent.tsx
@@ -75,7 +75,7 @@ export const SearchInsightCreationContent: FC<SearchInsightCreationContentProps>
     return (
         <CreationUiLayout data-testid={dataTestId} className={className}>
             <CreationUIForm
-                aria-label="Search insight creation form"
+                aria-label="Search Insight creation form"
                 as={SearchInsightCreationForm}
                 handleSubmit={handleSubmit}
                 submitErrors={formAPI.submitErrors}

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/SearchInsightCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/SearchInsightCreationForm.tsx
@@ -57,7 +57,6 @@ export const SearchInsightCreationForm: FC<CreationSearchInsightFormProps> = pro
         series,
         stepValue,
         step,
-        className,
         isFormClearActive,
         dashboardReferenceCount,
         children,

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/SearchInsightCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/SearchInsightCreationForm.tsx
@@ -1,4 +1,4 @@
-import { FC, FormEventHandler, ReactNode } from 'react'
+import { FC, FormEventHandler, ReactNode, FormHTMLAttributes } from 'react'
 
 import { Checkbox, Input, Link } from '@sourcegraph/wildcard'
 
@@ -15,12 +15,11 @@ import {
 import { useUiFeatures } from '../../../../../hooks'
 import { CreateInsightFormFields } from '../types'
 
-interface CreationSearchInsightFormProps {
+interface CreationSearchInsightFormProps extends Omit<FormHTMLAttributes<HTMLFormElement>, 'title' | 'children'> {
     handleSubmit: FormEventHandler
     submitErrors: SubmissionErrors
     submitting: boolean
     submitted: boolean
-    className?: string
     isFormClearActive: boolean
     dashboardReferenceCount?: number
 
@@ -63,13 +62,14 @@ export const SearchInsightCreationForm: FC<CreationSearchInsightFormProps> = pro
         dashboardReferenceCount,
         children,
         onFormReset,
+        ...attributes
     } = props
 
     const { licensed } = useUiFeatures()
 
     return (
         // eslint-disable-next-line react/forbid-elements
-        <form noValidate={true} onSubmit={handleSubmit} onReset={onFormReset} className={className}>
+        <form {...attributes} noValidate={true} onSubmit={handleSubmit} onReset={onFormReset}>
             <FormGroup
                 name="insight repositories"
                 title="Targeted repositories"
@@ -109,7 +109,7 @@ export const SearchInsightCreationForm: FC<CreationSearchInsightFormProps> = pro
                     </Link>
                 </small>
 
-                <hr className="my-4 w-100" />
+                <hr aria-hidden={true} className="my-4 w-100" />
             </FormGroup>
 
             <FormGroup
@@ -128,7 +128,7 @@ export const SearchInsightCreationForm: FC<CreationSearchInsightFormProps> = pro
                 />
             </FormGroup>
 
-            <hr className="my-4 w-100" />
+            <hr aria-hidden={true} className="my-4 w-100" />
 
             <FormGroup name="chart settings group" title="Chart settings">
                 <Input
@@ -155,7 +155,7 @@ export const SearchInsightCreationForm: FC<CreationSearchInsightFormProps> = pro
                 <CodeInsightDashboardsVisibility className="mt-5 mb-n1" dashboardCount={dashboardReferenceCount} />
             )}
 
-            <hr className="my-4 w-100" />
+            <hr aria-hidden={true} className="my-4 w-100" />
 
             {children({ submitting, submitErrors, isFormClearActive })}
         </form>

--- a/client/web/src/integration/insights/insight/dashboard-cards.test.ts
+++ b/client/web/src/integration/insights/insight/dashboard-cards.test.ts
@@ -51,7 +51,7 @@ describe('Code insights [Dashboard card]', () => {
         await driver.page.waitForSelector('[aria-label="Pie chart"]')
 
         const numberOfArcs = await driver.page.$$eval('[aria-label="Pie chart"] path', elements => elements.length)
-        const numberHeadings = await driver.page.$$eval('[aria-label="Pie chart"] h3', elements => elements.length)
+        const numberHeadings = await driver.page.$$eval('[aria-label="Pie chart"] p', elements => elements.length)
 
         // Why 12?, because LANG_STAT_INSIGHT_CONTENT mock has 14 entries and only five of them
         // are rendered because all other (7 groups) are too small, and they are grouped and presented

--- a/client/web/src/integration/insights/insight/insight-chart-focus.test.ts
+++ b/client/web/src/integration/insights/insight/insight-chart-focus.test.ts
@@ -20,7 +20,7 @@ describe('Code insights [Insight Card] should has a proper focus management ', (
     let testContext: WebIntegrationTestContext
 
     before(async () => {
-        driver = await createDriverForTest({ devtools: true })
+        driver = await createDriverForTest()
     })
 
     beforeEach(async function () {
@@ -121,11 +121,15 @@ describe('Code insights [Insight Card] should has a proper focus management ', (
 
         for (let arcIndex = 0; arcIndex < Math.min(arcs.length, 6); arcIndex++) {
             await driver.page.keyboard.press(Key.Tab)
-            assert.strictEqual(
-                await hasFocus(driver, `[aria-label="Pie chart"] a:nth-child(${arcIndex + 1})`),
-                true,
-                'Insight pie arc should be focused'
+
+            const aElement = await driver.page.evaluate(
+                (arcIndex: number) => document.querySelector(`[aria-label="Pie chart"] g:nth-child(${arcIndex + 1}) a`),
+                arcIndex
             )
+
+            const activeElement = await driver.page.evaluate(() => document.activeElement)
+
+            assert.strictEqual(aElement === activeElement, true, 'Insight pie arc should be focused')
         }
     })
 })

--- a/client/wildcard/src/components/Charts/components/line-chart/components/legend-list/LegendList.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/components/legend-list/LegendList.tsx
@@ -36,6 +36,7 @@ export const LegendItem: React.FunctionComponent<React.PropsWithChildren<LegendI
 }) => (
     <li {...attributes} className={classNames({ 'text-muted': !selected && !hovered }, styles.legendItem, className)}>
         <span
+            aria-hidden={true}
             /* eslint-disable-next-line react/forbid-dom-props */
             style={{ backgroundColor: selected || hovered ? color : undefined }}
             className={classNames([styles.legendMark, { [styles.unselected]: !selected }])}

--- a/client/wildcard/src/components/Charts/components/pie-chart/PieChart.tsx
+++ b/client/wildcard/src/components/Charts/components/pie-chart/PieChart.tsx
@@ -98,31 +98,32 @@ export function PieChart<Datum>(props: PieChartProps<Datum>): ReactElement | nul
                         return (
                             <Group role="list">
                                 {arcs.map((arc, index) => (
-                                    <MaybeLink
-                                        key={getDatumName(arc.data)}
-                                        to={getDatumLink(arc.data)}
-                                        target="_blank"
-                                        rel="noopener"
-                                        role={getDatumLink(arc.data) ? 'link' : 'graphics-dataunit'}
-                                        aria-label={`Name: ${getDatumName(arc.data)}. Value: ${getSubtitle(
-                                            arc,
-                                            total
-                                        )}.`}
-                                        className={styles.link}
-                                        onClick={event => onDatumLinkClick(event, arc.data, index)}
-                                    >
-                                        <PieArc
-                                            arc={arc}
-                                            path={pie.path}
-                                            title={getDatumName(arc.data)}
-                                            subtitle={getSubtitle(arc, total)}
-                                            className={classNames(styles.arcPath, {
-                                                [styles.arcPathWithLink]: !!getDatumLink(arc.data),
-                                            })}
-                                            getColor={getDatumColor}
-                                            onPointerMove={() => setHoveredArc(arc)}
-                                        />
-                                    </MaybeLink>
+                                    <Group key={getDatumName(arc.data)} role="listitem">
+                                        <MaybeLink
+                                            to={getDatumLink(arc.data)}
+                                            target="_blank"
+                                            rel="noopener"
+                                            role={getDatumLink(arc.data) ? 'link' : 'graphics-dataunit'}
+                                            aria-label={`Name: ${getDatumName(arc.data)}. Value: ${getSubtitle(
+                                                arc,
+                                                total
+                                            )}.`}
+                                            className={styles.link}
+                                            onClick={event => onDatumLinkClick(event, arc.data, index)}
+                                        >
+                                            <PieArc
+                                                arc={arc}
+                                                path={pie.path}
+                                                title={getDatumName(arc.data)}
+                                                subtitle={getSubtitle(arc, total)}
+                                                className={classNames(styles.arcPath, {
+                                                    [styles.arcPathWithLink]: !!getDatumLink(arc.data),
+                                                })}
+                                                getColor={getDatumColor}
+                                                onPointerMove={() => setHoveredArc(arc)}
+                                            />
+                                        </MaybeLink>
+                                    </Group>
                                 ))}
                             </Group>
                         )

--- a/client/wildcard/src/components/Charts/components/pie-chart/PieChart.tsx
+++ b/client/wildcard/src/components/Charts/components/pie-chart/PieChart.tsx
@@ -83,6 +83,7 @@ export function PieChart<Datum>(props: PieChartProps<Datum>): ReactElement | nul
         <svg
             {...attributes}
             aria-label="Pie chart"
+            role="group"
             width={width}
             height={height}
             className={classNames(styles.svg, className)}
@@ -95,18 +96,19 @@ export function PieChart<Datum>(props: PieChartProps<Datum>): ReactElement | nul
                             : pie.arcs
 
                         return (
-                            <Group>
+                            <Group role="list">
                                 {arcs.map((arc, index) => (
                                     <MaybeLink
                                         key={getDatumName(arc.data)}
                                         to={getDatumLink(arc.data)}
                                         target="_blank"
                                         rel="noopener"
-                                        className={styles.link}
                                         role={getDatumLink(arc.data) ? 'link' : 'graphics-dataunit'}
-                                        aria-label={`Element ${index + 1} of ${arcs.length}. Name: ${getDatumName(
-                                            arc.data
-                                        )}. Value: ${getSubtitle(arc, total)}.`}
+                                        aria-label={`Name: ${getDatumName(arc.data)}. Value: ${getSubtitle(
+                                            arc,
+                                            total
+                                        )}.`}
+                                        className={styles.link}
                                         onClick={event => onDatumLinkClick(event, arc.data, index)}
                                     >
                                         <PieArc

--- a/client/wildcard/src/components/Charts/components/pie-chart/components/PieArc.module.scss
+++ b/client/wildcard/src/components/Charts/components/pie-chart/components/PieArc.module.scss
@@ -11,6 +11,7 @@
 
 .label-title {
     font-weight: 400;
+    font-size: 1rem;
     color: var(--body-color);
     background-color: var(--body-bg);
     text-decoration: none;

--- a/client/wildcard/src/components/Charts/components/pie-chart/components/PieArc.tsx
+++ b/client/wildcard/src/components/Charts/components/pie-chart/components/PieArc.tsx
@@ -1,4 +1,4 @@
-import { PointerEventHandler, ReactElement } from 'react'
+import { ReactElement, SVGProps } from 'react'
 
 import { Annotation, HtmlLabel, Connector } from '@visx/annotation'
 import { Group } from '@visx/group'
@@ -15,19 +15,17 @@ import styles from './PieArc.module.scss'
 const CONNECTION_LINE_LENGTH = 15
 const CONNECTION_LINE_MARGIN = 2
 
-interface PieArcProps<Datum> {
+interface PieArcProps<Datum> extends Omit<SVGProps<SVGGElement>, 'path'> {
     title: string
     subtitle: string
     path: ArcType<unknown, PieArcDatum<Datum>>
     arc: PieArcDatum<Datum>
     className?: string
     getColor: (datum: Datum) => string | undefined
-    onPointerMove?: PointerEventHandler
-    onPointerOut?: PointerEventHandler
 }
 
 export function PieArc<Datum>(props: PieArcProps<Datum>): ReactElement {
-    const { title, subtitle, path, arc, getColor, className, onPointerMove, onPointerOut } = props
+    const { title, subtitle, path, arc, getColor, className, ...attributes } = props
 
     const pathValue = path(arc) ?? ''
 
@@ -53,12 +51,12 @@ export function PieArc<Datum>(props: PieArcProps<Datum>): ReactElement {
     const labelY = normalY * CONNECTION_LINE_LENGTH
 
     return (
-        <Group aria-hidden={true} className={styles.arc} onPointerMove={onPointerMove} onPointerOut={onPointerOut}>
+        <Group {...attributes} className={styles.arc}>
             <path
                 data-testid="pie-chart-arc-element"
-                className={classNames(className, styles.arcPath)}
                 d={pathValue}
                 fill={getColor(arc.data) ?? DEFAULT_FALLBACK_COLOR}
+                className={classNames(className, styles.arcPath)}
             />
 
             <Annotation x={surfaceX} y={surfaceY} dx={labelX} dy={labelY}>
@@ -70,7 +68,13 @@ export function PieArc<Datum>(props: PieArcProps<Datum>): ReactElement {
                 </HtmlLabel>
             </Annotation>
 
-            <circle className={styles.labelCircle} r={2} cx={surfaceX + labelX} cy={surfaceY + labelY} />
+            <circle
+                aria-hidden={true}
+                className={styles.labelCircle}
+                r={2}
+                cx={surfaceX + labelX}
+                cy={surfaceY + labelY}
+            />
         </Group>
     )
 }

--- a/client/wildcard/src/components/Charts/components/pie-chart/components/PieArc.tsx
+++ b/client/wildcard/src/components/Charts/components/pie-chart/components/PieArc.tsx
@@ -6,7 +6,7 @@ import { PieArcDatum } from '@visx/shape/lib/shapes/Pie'
 import classNames from 'classnames'
 import { Arc as ArcType } from 'd3-shape'
 
-import { H3 } from '../../../../Typography'
+import { Text } from '../../../../Typography'
 import { DEFAULT_FALLBACK_COLOR } from '../../../constants'
 
 import styles from './PieArc.module.scss'
@@ -63,7 +63,7 @@ export function PieArc<Datum>(props: PieArcProps<Datum>): ReactElement {
                 <Connector className={styles.labelLine} type="line" />
 
                 <HtmlLabel showAnchorLine={false} className={styles.label}>
-                    <H3 className={styles.labelTitle}>{title}</H3>
+                    <Text className={styles.labelTitle}>{title}</Text>
                     <small className={styles.labelSubTitle}>{subtitle}</small>
                 </HtmlLabel>
             </Annotation>

--- a/client/wildcard/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/client/wildcard/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { FC, SVGProps } from 'react'
 
 import classNames from 'classnames'
 
@@ -6,8 +6,7 @@ import { Icon } from '../Icon'
 
 import styles from './LoadingSpinner.module.scss'
 
-export interface LoadingSpinnerProps {
-    className?: string
+export interface LoadingSpinnerProps extends SVGProps<SVGSVGElement> {
     /**
      * Whether to show loading spinner with icon-inline
      *
@@ -16,14 +15,17 @@ export interface LoadingSpinnerProps {
     inline?: boolean
 }
 
-export const LoadingSpinner: React.FunctionComponent<React.PropsWithChildren<LoadingSpinnerProps>> = ({
-    inline = true,
-    className,
-    ...props
-}) => {
-    const finalClassName = classNames(styles.loadingSpinner, className)
+export const LoadingSpinner: FC<LoadingSpinnerProps> = props => {
+    const { inline = true, className, ...attribute } = props
 
     return (
-        <Icon inline={inline} aria-label="Loading" aria-live="polite" className={finalClassName} as="div" {...props} />
+        <Icon
+            as="div"
+            inline={inline}
+            aria-label="Loading"
+            aria-live="polite"
+            className={classNames(styles.loadingSpinner, className)}
+            {...attribute}
+        />
     )
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/42715
Closes https://github.com/sourcegraph/sourcegraph/issues/41687
 
## Background 

This PR marks up the creation UI pages in the following way (as it's presented on the schema below)

<img src="https://user-images.githubusercontent.com/18492575/194647350-cd60e376-281d-4c2d-b864-24e4a34e819d.png" width="400"/>

For example, I recorded a high-level walk-through of two versions of the creation UI live preview screen readers. 

| Search-based | Lang stats  |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/18492575/194648658-f4e5401e-fc7b-4963-8a07-ea084cc2b8ea.mov" /> |  <video src="https://user-images.githubusercontent.com/18492575/194648649-65814772-c040-44f9-89c9-6dbdcdcbb60d.mov" />  |



## Test plan
- Go through search-based, capture group, lang stats (compute powered) creation UI with a screen reader to the live preview card
- Make sure that initial (bluer chart and description message), loading and data states are pronounced correctly 
- Make sure that you check both the line and pie charts card.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-live-preview-aria.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-idpwptukul.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
