### PR TITLE
notebooks: notebook query blocks request chunk matches by default

### DIFF
--- a/client/web/src/notebooks/notebook/index.ts
+++ b/client/web/src/notebooks/notebook/index.ts
@@ -169,6 +169,7 @@ export class Notebook {
                             patternType: SearchPatternType.standard,
                             caseSensitive: false,
                             trace: undefined,
+                            chunkMatches: true,
                         }
                     ).pipe(startWith(emptyAggregateResults)),
                 })


### PR DESCRIPTION
This slipped through the cracks when the web app was migrated to use chunk matches. Notebook blocks also use the `StreamingSearchResultsList` component, so updating notebooks to pass `chunkMatches: true` on search requests.

## Test plan
Manually verify that notebook query blocks work as expected

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tl-notebooks-request-chunk-matches.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nwqyhxmyjs.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
