### PR TITLE
executors: Use containerd as runtime

### DIFF
--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexPage.story.tsx
@@ -159,7 +159,7 @@ const completedSteps: LsifIndexStepsFields = {
                 'ignite',
                 'run',
                 '--runtime',
-                'docker',
+                'containerd',
                 '--network-plugin',
                 'docker-bridge',
                 '--cpus',

--- a/enterprise/cmd/executor/internal/command/firecracker.go
+++ b/enterprise/cmd/executor/internal/command/firecracker.go
@@ -168,7 +168,7 @@ func setupFirecracker(ctx context.Context, runner commandRunner, logger Logger, 
 		Env: []string{fmt.Sprintf("CNI_CONF_DIR=%s", cniConfigDir)},
 		Command: flatten(
 			"ignite", "run",
-			"--runtime", "docker",
+			"--runtime", "containerd",
 			"--network-plugin", "cni",
 			firecrackerResourceFlags(options.ResourceOptions),
 			firecrackerCopyfileFlags(options.FirecrackerOptions.VMStartupScriptPath, daemonConfigFile),

--- a/enterprise/cmd/executor/internal/command/firecracker_test.go
+++ b/enterprise/cmd/executor/internal/command/firecracker_test.go
@@ -146,7 +146,7 @@ func TestSetupFirecracker(t *testing.T) {
 	expected := []string{
 		strings.Join([]string{
 			"ignite run",
-			"--runtime docker --network-plugin cni",
+			"--runtime containerd --network-plugin cni",
 			"--cpus 4 --memory 20G --size 1T",
 			"--copy-files /vm-startup.sh:/vm-startup.sh",
 			"--volumes /dev/loopX:/work",

--- a/enterprise/cmd/executor/internal/run/install.go
+++ b/enterprise/cmd/executor/internal/run/install.go
@@ -127,7 +127,7 @@ func ensureExecutorVMImage(ctx context.Context, logger log.Logger, c *config.Con
 	// be a race condition and it is imported multiple times. Also, this would
 	// happen for the first job, which is not desirable.
 	logger.Info("Ensuring VM image is imported", log.String("image", c.FirecrackerImage))
-	cmd := exec.CommandContext(ctx, "ignite", "image", "import", "--runtime", "docker", c.FirecrackerImage)
+	cmd := exec.CommandContext(ctx, "ignite", "image", "import", "--runtime", "containerd", c.FirecrackerImage)
 	// Forward output.
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -147,7 +147,7 @@ func ensureKernelImage(ctx context.Context, logger log.Logger, c *config.Config)
 	// be a race condition and it is imported multiple times. Also, this would
 	// happen for the first job, which is not desirable.
 	logger.Info("Ensuring kernel is imported", log.String("image", c.FirecrackerKernelImage))
-	cmd := exec.CommandContext(ctx, "ignite", "kernel", "import", "--runtime", "docker", c.FirecrackerKernelImage)
+	cmd := exec.CommandContext(ctx, "ignite", "kernel", "import", "--runtime", "containerd", c.FirecrackerKernelImage)
 	// Forward output.
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -206,7 +206,7 @@ EOF
 function generate_ignite_base_image() {
   # TODO: Find a way to use executor install image executor-vm here.
   docker build -t "${EXECUTOR_FIRECRACKER_IMAGE}" --build-arg SRC_CLI_VERSION="${SRC_CLI_VERSION}" /tmp/executor-vm
-  ignite image import --runtime docker "${EXECUTOR_FIRECRACKER_IMAGE}"
+  ignite image import --runtime containerd "${EXECUTOR_FIRECRACKER_IMAGE}"
   docker image rm "${EXECUTOR_FIRECRACKER_IMAGE}"
   # Remove intermediate layers and base image used in executor-vm.
   # TODO: This removes the already pulled sandbox image.


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
