### PR TITLE
executor: Fix unmarshal method for srcCliStep

### DIFF
--- a/enterprise/internal/executor/client_types.go
+++ b/enterprise/internal/executor/client_types.go
@@ -100,7 +100,7 @@ func (j *Job) UnmarshalJSON(bytes []byte) error {
 
 	if v["dockerSteps"] != nil {
 		dockerSteps := v["dockerSteps"].([]interface{})
-		jobDockerSteps := make([]DockerStep, len(dockerSteps), len(dockerSteps))
+		jobDockerSteps := make([]DockerStep, len(dockerSteps))
 		for i, s := range dockerSteps {
 			step := s.(map[string]interface{})
 			jobDockerSteps[i] = DockerStep{
@@ -115,11 +115,11 @@ func (j *Job) UnmarshalJSON(bytes []byte) error {
 
 	if v["cliSteps"] != nil {
 		cliSteps := v["cliSteps"].([]interface{})
-		jobCliSteps := make([]CliStep, len(cliSteps), len(cliSteps))
+		jobCliSteps := make([]CliStep, len(cliSteps))
 		for i, s := range cliSteps {
 			step := s.(map[string]interface{})
 			jobCliSteps[i] = CliStep{
-				Commands: toStringSlice(step["commands"]),
+				Commands: toStringSlice(step["command"]),
 				Dir:      toString(step["dir"]),
 				Env:      toStringSlice(step["env"]),
 			}
@@ -145,7 +145,7 @@ func toStringSlice(input interface{}) []string {
 	}
 
 	slice := input.([]interface{})
-	strings := make([]string, len(slice), len(slice))
+	strings := make([]string, len(slice))
 	for i, v := range slice {
 		strings[i] = toString(v)
 	}

--- a/enterprise/internal/executor/client_types_test.go
+++ b/enterprise/internal/executor/client_types_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/executor"
@@ -47,7 +47,7 @@ func TestJob_UnmarshalJSON(t *testing.T) {
 		"env": ["FOO=BAR"]
 	}],
 	"cliSteps": [{
-		"commands": ["x", "y", "z"],
+		"command": ["x", "y", "z"],
 		"dir": "raz/daz",
 		"env": ["BAZ=FAZ"]
 	}],
@@ -113,7 +113,7 @@ func TestJob_UnmarshalJSON(t *testing.T) {
 		"env": ["FOO=BAR"]
 	}],
 	"cliSteps": [{
-		"commands": ["x", "y", "z"],
+		"command": ["x", "y", "z"],
 		"dir": "raz/daz",
 		"env": ["BAZ=FAZ"]
 	}],
@@ -160,7 +160,9 @@ func TestJob_UnmarshalJSON(t *testing.T) {
 			var actual executor.Job
 			err := json.Unmarshal([]byte(test.input), &actual)
 			require.NoError(t, err)
-			assert.Equal(t, test.expected, actual)
+			if diff := cmp.Diff(test.expected, actual); diff != "" {
+				t.Fatal(diff)
+			}
 		})
 	}
 }


### PR DESCRIPTION
I have NO idea why, but for src-cli step we somehow chose the json label "command" vs "commands".. although the go field is named "commands". Fun. Probably a typo but can't fix it without breaking backcompat.

Another thing I found: assert.Equal doesn't deep check all objects, so the slices weren't compared. cmp.Diff would've found this bug.

## Test plan

Added test and verified locally things work again. 