### PR TITLE
batches: fix webhook log page responsiveness

### DIFF
--- a/client/web/src/site-admin/webhooks/WebhookLogNode.module.scss
+++ b/client/web/src/site-admin/webhooks/WebhookLogNode.module.scss
@@ -14,7 +14,7 @@
     margin-bottom: -0.5rem;
 
     .message-panel-container {
-        padding-top: calc(var(--spacer)*0.5);
+        padding-top: calc(var(--spacer) * 0.5);
         display: grid;
     }
 

--- a/client/web/src/site-admin/webhooks/WebhookLogNode.module.scss
+++ b/client/web/src/site-admin/webhooks/WebhookLogNode.module.scss
@@ -13,6 +13,11 @@
     // background runs all the way to the next border.
     margin-bottom: -0.5rem;
 
+    .message-panel-container {
+        padding-top: calc(var(--spacer)*0.5);
+        display: grid;
+    }
+
     @media (--sm-breakpoint-down) {
         padding: 0 !important;
         background: transparent;

--- a/client/web/src/site-admin/webhooks/WebhookLogNode.story.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogNode.story.tsx
@@ -11,7 +11,7 @@ import {
     LARGE_HEADERS_JSON,
     LARGE_BODY_JSON,
     LARGE_HEADERS_PLAIN,
-    LARGE_BODY_PLAIN
+    LARGE_BODY_PLAIN,
 } from './story/fixtures'
 import { WebhookLogNode } from './WebhookLogNode'
 
@@ -83,7 +83,7 @@ export const Collapsed: Story<StoryArguments> = args => (
                             method: 'POST',
                             url: '/my/awesome/url',
                             version: 'HTTP/1.1',
-                        }
+                        },
                     })}
                 />
             </>
@@ -92,35 +92,46 @@ export const Collapsed: Story<StoryArguments> = args => (
 )
 
 export const ExpandedRequest: Story<StoryArguments> = args => (
-    <WebStory>{() => <>
-        <WebhookLogNode node={webhookLogNode(args)} initiallyExpanded={true} />
-        <WebhookLogNode
-            node={webhookLogNode(args, {
-           request: {
-               headers: LARGE_HEADERS_JSON,
-               body: LARGE_BODY_JSON,
-               method: 'POST',
-               url: '/my/awesome/url',
-               version: 'HTTP/1.1',
-           }
-        })}
-            initiallyExpanded={true} />
-    </>}</WebStory>
+    <WebStory>
+        {() => (
+            <>
+                <WebhookLogNode node={webhookLogNode(args)} initiallyExpanded={true} />
+                <WebhookLogNode
+                    node={webhookLogNode(args, {
+                        request: {
+                            headers: LARGE_HEADERS_JSON,
+                            body: LARGE_BODY_JSON,
+                            method: 'POST',
+                            url: '/my/awesome/url',
+                            version: 'HTTP/1.1',
+                        },
+                    })}
+                    initiallyExpanded={true}
+                />
+            </>
+        )}
+    </WebStory>
 )
 
 ExpandedRequest.storyName = 'expanded request'
 
 export const ExpandedResponse: Story<StoryArguments> = args => (
     <WebStory>
-        {() => <>
-            <WebhookLogNode node={webhookLogNode(args)} initiallyExpanded={true} initialTabIndex={1} />
-            <WebhookLogNode node={webhookLogNode(args, {
-                response: {
-                    headers: LARGE_HEADERS_PLAIN,
-                    body: LARGE_BODY_PLAIN,
-                }
-            })} initiallyExpanded={true} initialTabIndex={1} />
-        </>}
+        {() => (
+            <>
+                <WebhookLogNode node={webhookLogNode(args)} initiallyExpanded={true} initialTabIndex={1} />
+                <WebhookLogNode
+                    node={webhookLogNode(args, {
+                        response: {
+                            headers: LARGE_HEADERS_PLAIN,
+                            body: LARGE_BODY_PLAIN,
+                        },
+                    })}
+                    initiallyExpanded={true}
+                    initialTabIndex={1}
+                />
+            </>
+        )}
     </WebStory>
 )
 

--- a/client/web/src/site-admin/webhooks/WebhookLogNode.story.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogNode.story.tsx
@@ -6,7 +6,13 @@ import { Container } from '@sourcegraph/wildcard'
 import { WebStory } from '../../components/WebStory'
 import { WebhookLogFields } from '../../graphql-operations'
 
-import { webhookLogNode } from './story/fixtures'
+import {
+    webhookLogNode,
+    LARGE_HEADERS_JSON,
+    LARGE_BODY_JSON,
+    LARGE_HEADERS_PLAIN,
+    LARGE_BODY_PLAIN
+} from './story/fixtures'
 import { WebhookLogNode } from './WebhookLogNode'
 
 import gridStyles from './WebhookLogPage.module.scss'
@@ -54,26 +60,67 @@ type StoryArguments = Pick<WebhookLogFields, 'receivedAt' | 'statusCode'>
 export const Collapsed: Story<StoryArguments> = args => (
     <WebStory>
         {() => (
-            <WebhookLogNode
-                node={webhookLogNode(args, {
-                    externalService: {
-                        displayName: 'GitLab',
-                    },
-                })}
-            />
+            <>
+                <WebhookLogNode
+                    node={webhookLogNode(args, {
+                        externalService: {
+                            displayName: 'GitLab',
+                        },
+                    })}
+                />
+                <WebhookLogNode
+                    node={webhookLogNode(args, {
+                        externalService: {
+                            displayName: 'BitBucket Server',
+                        },
+                        response: {
+                            headers: LARGE_HEADERS_PLAIN,
+                            body: LARGE_BODY_PLAIN,
+                        },
+                        request: {
+                            headers: LARGE_HEADERS_JSON,
+                            body: LARGE_BODY_JSON,
+                            method: 'POST',
+                            url: '/my/awesome/url',
+                            version: 'HTTP/1.1',
+                        }
+                    })}
+                />
+            </>
         )}
     </WebStory>
 )
 
 export const ExpandedRequest: Story<StoryArguments> = args => (
-    <WebStory>{() => <WebhookLogNode node={webhookLogNode(args)} initiallyExpanded={true} />}</WebStory>
+    <WebStory>{() => <>
+        <WebhookLogNode node={webhookLogNode(args)} initiallyExpanded={true} />
+        <WebhookLogNode
+            node={webhookLogNode(args, {
+           request: {
+               headers: LARGE_HEADERS_JSON,
+               body: LARGE_BODY_JSON,
+               method: 'POST',
+               url: '/my/awesome/url',
+               version: 'HTTP/1.1',
+           }
+        })}
+            initiallyExpanded={true} />
+    </>}</WebStory>
 )
 
 ExpandedRequest.storyName = 'expanded request'
 
 export const ExpandedResponse: Story<StoryArguments> = args => (
     <WebStory>
-        {() => <WebhookLogNode node={webhookLogNode(args)} initiallyExpanded={true} initialTabIndex={1} />}
+        {() => <>
+            <WebhookLogNode node={webhookLogNode(args)} initiallyExpanded={true} initialTabIndex={1} />
+            <WebhookLogNode node={webhookLogNode(args, {
+                response: {
+                    headers: LARGE_HEADERS_PLAIN,
+                    body: LARGE_BODY_PLAIN,
+                }
+            })} initiallyExpanded={true} initialTabIndex={1} />
+        </>}
     </WebStory>
 )
 

--- a/client/web/src/site-admin/webhooks/WebhookLogNode.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogNode.tsx
@@ -67,10 +67,10 @@ export const WebhookLogNode: React.FunctionComponent<React.PropsWithChildren<Pro
                         </TabList>
                         <TabPanels>
                             <TabPanel>
-                                <MessagePanel className="pt-2" message={request} requestOrStatusCode={request} />
+                                <MessagePanel className={styles.messagePanelContainer} message={request} requestOrStatusCode={request} />
                             </TabPanel>
                             <TabPanel>
-                                <MessagePanel className="pt-2" message={response} requestOrStatusCode={statusCode} />
+                                <MessagePanel className={styles.messagePanelContainer} message={response} requestOrStatusCode={statusCode} />
                             </TabPanel>
                         </TabPanels>
                     </Tabs>

--- a/client/web/src/site-admin/webhooks/WebhookLogNode.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogNode.tsx
@@ -67,10 +67,18 @@ export const WebhookLogNode: React.FunctionComponent<React.PropsWithChildren<Pro
                         </TabList>
                         <TabPanels>
                             <TabPanel>
-                                <MessagePanel className={styles.messagePanelContainer} message={request} requestOrStatusCode={request} />
+                                <MessagePanel
+                                    className={styles.messagePanelContainer}
+                                    message={request}
+                                    requestOrStatusCode={request}
+                                />
                             </TabPanel>
                             <TabPanel>
-                                <MessagePanel className={styles.messagePanelContainer} message={response} requestOrStatusCode={statusCode} />
+                                <MessagePanel
+                                    className={styles.messagePanelContainer}
+                                    message={response}
+                                    requestOrStatusCode={statusCode}
+                                />
                             </TabPanel>
                         </TabPanels>
                     </Tabs>

--- a/client/web/src/site-admin/webhooks/WebhookLogPageHeader.module.scss
+++ b/client/web/src/site-admin/webhooks/WebhookLogPageHeader.module.scss
@@ -2,7 +2,7 @@
 
 .grid {
     display: grid;
-    grid-template-columns: max-content max-content 1fr max-content max-content;
+    grid-template-columns: max-content max-content 1fr max-content;
     column-gap: 1rem;
     row-gap: 1rem;
 
@@ -48,7 +48,7 @@
         margin-bottom: 0;
     }
 
-    grid-column: 4 / 5;
+    grid-column: 3 / 4;
     align-self: end;
 
     @media (--sm-breakpoint-down) {
@@ -58,7 +58,7 @@
 }
 
 .error-button {
-    grid-column: 5 / 6;
+    grid-column: 4 / 5;
     align-self: end;
 
     @media (--sm-breakpoint-down) {

--- a/client/web/src/site-admin/webhooks/story/fixtures.ts
+++ b/client/web/src/site-admin/webhooks/story/fixtures.ts
@@ -56,7 +56,7 @@ export const HEADERS_PLAIN = [
     },
     {
         name: 'Content-Length',
-        values: [LARGE_BODY_PLAIN.length.toString()],
+        values: [BODY_PLAIN.length.toString()],
     },
     {
         name: 'X-Complex-Header',
@@ -71,7 +71,7 @@ export const LARGE_HEADERS_PLAIN = [
     },
     {
         name: 'Content-Length',
-        values: [BODY_PLAIN.length.toString()],
+        values: [LARGE_BODY_PLAIN.length.toString()],
     },
     {
         name: 'X-Complex-Header',

--- a/client/web/src/site-admin/webhooks/story/fixtures.ts
+++ b/client/web/src/site-admin/webhooks/story/fixtures.ts
@@ -10,7 +10,9 @@ import {
 import { WEBHOOK_LOG_PAGE_HEADER } from '../backend'
 
 export const BODY_JSON = '{"this is":"valid JSON","that should be":["re","indented"]}'
+export const LARGE_BODY_JSON = '{"message": "webhooks: Add database Create method (#42639)\\n\\nAdd the Create method for the WebhookStore.\\r\\n\\r\\nThis change also switches to use two ids:\\r\\n\\r\\n\`id\` which is an auto-incremented id which we can use for sorting and pagination.\\r\\n\`rand_id\` which is an UUID and will be the user facing id use in the GraphQL layer\\r\\nand as part of the webhook URL.\\r\\n\\r\\nCo-authored-by: Someone"}'
 export const BODY_PLAIN = 'this is definitely not valid JSON\n\tand should not be reformatted in any way'
+export const LARGE_BODY_PLAIN = 'External service not found because we decided to be amazing and let you look for it'
 
 export const HEADERS_JSON = [
     {
@@ -27,7 +29,41 @@ export const HEADERS_JSON = [
     },
 ]
 
+export const LARGE_HEADERS_JSON = [
+    {
+        name: 'Content-Type',
+        values: ['application/json; charset=utf-8'],
+    },
+    {
+        name: 'Content-Length',
+        values: [LARGE_BODY_JSON.length.toString()],
+    },
+    {
+        name: 'X-Complex-Header',
+        values: ['value 1', 'value 2'],
+    },
+    {
+        name: 'X-Scheme',
+        values: ['https']
+    }
+]
+
 export const HEADERS_PLAIN = [
+    {
+        name: 'Content-Type',
+        values: ['text/plain'],
+    },
+    {
+        name: 'Content-Length',
+        values: [LARGE_BODY_PLAIN.length.toString()],
+    },
+    {
+        name: 'X-Complex-Header',
+        values: ['value 1', 'value 2'],
+    },
+]
+
+export const LARGE_HEADERS_PLAIN = [
     {
         name: 'Content-Type',
         values: ['text/plain'],

--- a/client/web/src/site-admin/webhooks/story/fixtures.ts
+++ b/client/web/src/site-admin/webhooks/story/fixtures.ts
@@ -10,7 +10,8 @@ import {
 import { WEBHOOK_LOG_PAGE_HEADER } from '../backend'
 
 export const BODY_JSON = '{"this is":"valid JSON","that should be":["re","indented"]}'
-export const LARGE_BODY_JSON = '{"message": "webhooks: Add database Create method (#42639)\\n\\nAdd the Create method for the WebhookStore.\\r\\n\\r\\nThis change also switches to use two ids:\\r\\n\\r\\n\`id\` which is an auto-incremented id which we can use for sorting and pagination.\\r\\n\`rand_id\` which is an UUID and will be the user facing id use in the GraphQL layer\\r\\nand as part of the webhook URL.\\r\\n\\r\\nCo-authored-by: Someone"}'
+export const LARGE_BODY_JSON =
+    '{"message": "webhooks: Add database Create method (#42639)\\n\\nAdd the Create method for the WebhookStore.\\r\\n\\r\\nThis change also switches to use two ids:\\r\\n\\r\\n`id` which is an auto-incremented id which we can use for sorting and pagination.\\r\\n`rand_id` which is an UUID and will be the user facing id use in the GraphQL layer\\r\\nand as part of the webhook URL.\\r\\n\\r\\nCo-authored-by: Someone"}'
 export const BODY_PLAIN = 'this is definitely not valid JSON\n\tand should not be reformatted in any way'
 export const LARGE_BODY_PLAIN = 'External service not found because we decided to be amazing and let you look for it'
 
@@ -44,8 +45,8 @@ export const LARGE_HEADERS_JSON = [
     },
     {
         name: 'X-Scheme',
-        values: ['https']
-    }
+        values: ['https'],
+    },
 ]
 
 export const HEADERS_PLAIN = [


### PR DESCRIPTION
This PR fixes [this](https://sourcegraph.slack.com/archives/C01LJ9DK8ES/p1665154654734739).

When the content of the request / response body of a webhook is larger than the [width of the `MessagePanel`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@bo/fix-webhook-logs-page/-/blob/client/web/src/site-admin/webhooks/WebhookLogNode.tsx?L69%3A29-82%3A40=) it causes the panel to extend out of it's container. This makes the page look really bad and out of shape when a node is expanded.

There was also an extra column [in the `grid-template-column` for the WebhookLogPageHeader component](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/client/web/src/site-admin/webhooks/WebhookLogPageHeader.module.scss?L5%3A5-5%3A68=&utm_source=VSCode-2.2.12), which caused the component's width to expand out of it's parent container when the number of errors is >1000. This PR ensures the grid for the header defines the correct number of columns.
![CleanShot 2022-10-10 at 12 56 16](https://user-images.githubusercontent.com/25608335/194850927-544be1bd-8b5d-4174-bc0e-a3af7ddf807f.png)

------

| Before 	| After 	|
|--------	|-------	|
| ![image (1)](https://user-images.githubusercontent.com/25608335/194850453-018ea3d6-9cb3-4028-bd4f-4ce71e3b6032.png)       	| ![CleanShot 2022-10-09 at 01 58 15](https://user-images.githubusercontent.com/25608335/194753949-7568591c-71dd-415d-8823-ed064ab11b22.gif)      	|
| ![image](https://user-images.githubusercontent.com/25608335/194850456-3204f2c4-e449-491e-85ab-dae43de4bddb.png)       	| <img width="728" alt="CleanShot 2022-10-09 at 01 59 43@2x" src="https://user-images.githubusercontent.com/25608335/194753950-1e473fad-612e-48dc-a068-fefd5d93a2ad.png">      	|





## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Test with random webhook requests with large headers (length)

## App preview:

- [Web](https://sg-web-bo-fix-webhook-logs-page.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nvlagpaamt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
