### PR TITLE
symbols: Handle error from sem.Acquire()

### DIFF
--- a/cmd/symbols/internal/database/writer/writer.go
+++ b/cmd/symbols/internal/database/writer/writer.go
@@ -42,7 +42,10 @@ func NewDatabaseWriter(
 }
 
 func (w *databaseWriter) WriteDBFile(ctx context.Context, args search.SymbolsParameters, dbFile string) error {
-	w.sem.Acquire(ctx, 1)
+	err := w.sem.Acquire(ctx, 1)
+	if err != nil {
+		return err
+	}
 	defer w.sem.Release(1)
 
 	if newestDBFile, oldCommit, ok, err := w.getNewestCommit(ctx, args); err != nil {


### PR DESCRIPTION
Saw an error in GCP:

```
 panic: semaphore: released more than held

goroutine 546244 [running]:
golang.org/x/sync/semaphore.(*Weighted).Release(0xc002770aa0, 0xe600?)
	golang.org/x/sync@v0.0.0-20220722155255-886fb9371eb4/semaphore/semaphore.go:103 +0xbd
github.com/sourcegraph/sourcegraph/cmd/symbols/internal/database/writer.(*databaseWriter).WriteDBFile(0xc002767f80, {0x27728e0, 0xc00c68d520}, {{0xc00c6d8210, 0x16}, {0xc033c9edb0, 0x28}, {0xc005b766a0, 0x19}, 0x1, ...}, ...)
	github.com/sourcegraph/sourcegraph/cmd/symbols/internal/database/writer/writer.go:52 +0x1a2
github.com/sourcegraph/sourcegraph/cmd/symbols/internal/database/writer.(*cachedDatabaseWriter).GetOrCreateDatabaseFile.func1({0x27728e0?, 0xc00c68d520?}, {0xc01b32f4a0?, 0x2009071?})
	github.com/sourcegraph/sourcegraph/cmd/symbols/internal/database/writer/cache.go:39 +0x85
github.com/sourcegraph/sourcegraph/internal/diskcache.doFetch({0x27728e0, 0xc00c68d520}, {0xc00aa0b3b0, 0xe9}, 0xc01b600680, {0x2779298, 0xc01457fb80})
	github.com/sourcegraph/sourcegraph/internal/diskcache/cache.go:260 +0x472
github.com/sourcegraph/sourcegraph/internal/diskcache.(*store).OpenWithPath.func2({0x2772368, 0xc0154e2f30})
	github.com/sourcegraph/sourcegraph/internal/diskcache/cache.go:185 +0x2ee
```

From [Slack](https://sourcegraph.slack.com/archives/CMBA8F926/p1665311930188129)

## Test plan

Handling the error is almost certainly more correct.
