### PR TITLE
[SG-41675] Migration from shema.ts type usage to graphql-operations - `client/web/src/repo`

### DIFF
--- a/client/web/src/repo/actions/GoToCodeHostAction.story.tsx
+++ b/client/web/src/repo/actions/GoToCodeHostAction.story.tsx
@@ -5,10 +5,10 @@ import { mdiGithub, mdiGitlab, mdiBitbucket } from '@mdi/js'
 import { Meta, Story, DecoratorFn } from '@storybook/react'
 
 import { PhabricatorIcon } from '@sourcegraph/shared/src/components/icons'
-import { ExternalServiceKind } from '@sourcegraph/shared/src/schema'
 import { Button, Popover, PopoverTrigger, Icon } from '@sourcegraph/wildcard'
 
 import { WebStory } from '../../components/WebStory'
+import { ExternalServiceKind } from '../../graphql-operations'
 
 const decorator: DecoratorFn = story => <div className="container mt-3">{story()}</div>
 

--- a/client/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/client/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -26,7 +26,6 @@ import { getHoverActions } from '@sourcegraph/shared/src/hover/actions'
 import { HoverContext } from '@sourcegraph/shared/src/hover/HoverOverlay'
 import { getModeFromPath } from '@sourcegraph/shared/src/languages'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
-import * as GQL from '@sourcegraph/shared/src/schema'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
@@ -52,6 +51,7 @@ import {
     GitCommitFields,
     RepositoryCommitResult,
     RepositoryCommitVariables,
+    RepositoryComparisonFileDiffConnection,
     RepositoryFields,
     Scalars,
 } from '../../graphql-operations'
@@ -347,7 +347,7 @@ export class RepositoryCommitPage extends React.Component<RepositoryCommitPagePr
         )
     }
 
-    private queryDiffs = (args: FilteredConnectionQueryArguments): Observable<GQL.IFileDiffConnection> =>
+    private queryDiffs = (args: FilteredConnectionQueryArguments): Observable<RepositoryComparisonFileDiffConnection> =>
         queryRepositoryComparisonFileDiffs({
             ...args,
             repo: this.props.repo.id,

--- a/client/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
+++ b/client/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
@@ -12,14 +12,13 @@ import { gql } from '@sourcegraph/http-client'
 import { ActionItemAction } from '@sourcegraph/shared/src/actions/ActionItem'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
-import * as GQL from '@sourcegraph/shared/src/schema'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { FileSpec, RepoSpec, ResolvedRevisionSpec, RevisionSpec } from '@sourcegraph/shared/src/util/url'
 import { LoadingSpinner, Text } from '@sourcegraph/wildcard'
 
 import { queryGraphQL } from '../../backend/graphql'
 import { PageTitle } from '../../components/PageTitle'
-import { Scalars } from '../../graphql-operations'
+import { RepositoryComparisonRangeFields, Scalars, RepositoryComparisonRepository } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
 
 import { RepositoryCompareAreaPageProps } from './RepositoryCompareArea'
@@ -30,27 +29,33 @@ function queryRepositoryComparison(args: {
     repo: Scalars['ID']
     base: string | null
     head: string | null
-}): Observable<GQL.IGitRevisionRange> {
+}): Observable<RepositoryComparisonRangeFields> {
     return queryGraphQL(
         gql`
             query RepositoryComparison($repo: ID!, $base: String, $head: String) {
                 node(id: $repo) {
-                    ... on Repository {
-                        comparison(base: $base, head: $head) {
-                            range {
-                                expr
-                                baseRevSpec {
-                                    object {
-                                        oid
-                                    }
-                                }
-                                headRevSpec {
-                                    object {
-                                        oid
-                                    }
-                                }
-                            }
-                        }
+                    ...RepositoryComparisonRepository
+                }
+            }
+
+            fragment RepositoryComparisonRepository on Repository {
+                comparison(base: $base, head: $head) {
+                    range {
+                        ...RepositoryComparisonRangeFields
+                    }
+                }
+            }
+
+            fragment RepositoryComparisonRangeFields on GitRevisionRange {
+                expr
+                baseRevSpec {
+                    object {
+                        oid
+                    }
+                }
+                headRevSpec {
+                    object {
+                        oid
                     }
                 }
             }
@@ -61,7 +66,7 @@ function queryRepositoryComparison(args: {
             if (!data || !data.node) {
                 throw createAggregateError(errors)
             }
-            const repo = data.node as GQL.IRepository
+            const repo = data.node as RepositoryComparisonRepository
             if (
                 !repo.comparison ||
                 !repo.comparison.range ||
@@ -99,7 +104,7 @@ interface Props
 
 interface State {
     /** The comparison's range, null when no comparison is requested, undefined while loading, or an error. */
-    rangeOrError?: null | GQL.IGitRevisionRange | ErrorLike
+    rangeOrError?: null | RepositoryComparisonRangeFields | ErrorLike
 }
 
 /** A page with an overview of the comparison. */

--- a/client/web/src/repo/releases/RepositoryReleasesTagsPage.test.tsx
+++ b/client/web/src/repo/releases/RepositoryReleasesTagsPage.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react'
 import * as H from 'history'
 import { of } from 'rxjs'
 
-import { IRepository, IGitRef } from '@sourcegraph/shared/src/schema'
+import { RepositoryFields } from '../../graphql-operations'
 
 import { RepositoryReleasesTagsPage } from './RepositoryReleasesTagsPage'
 
@@ -14,11 +14,11 @@ describe('RepositoryReleasesTagsPage', () => {
                 <RepositoryReleasesTagsPage
                     history={history}
                     location={history.location}
-                    repo={{ id: '123' } as IRepository}
+                    repo={{ id: '123' } as RepositoryFields}
                     queryGitReferences={() =>
                         of({
                             totalCount: 0,
-                            nodes: [] as IGitRef[],
+                            nodes: [],
                             __typename: 'GitRefConnection',
                             pageInfo: { __typename: 'PageInfo', endCursor: '', hasNextPage: false },
                         })

--- a/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
+++ b/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
@@ -9,7 +9,6 @@ import { Form } from '@sourcegraph/branded/src/components/Form'
 import { numberWithCommas, pluralize } from '@sourcegraph/common'
 import { gql, dataOrThrowErrors } from '@sourcegraph/http-client'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
-import * as GQL from '@sourcegraph/shared/src/schema'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 import { Button, ButtonGroup, Link, CardHeader, CardBody, Card, Input, Label, Tooltip } from '@sourcegraph/wildcard'
 
@@ -26,6 +25,7 @@ import {
 import { PageTitle } from '../../components/PageTitle'
 import { Timestamp } from '../../components/time/Timestamp'
 import {
+    ContributorCommitNodeFields,
     RepositoryContributorNodeFields,
     RepositoryContributorsResult,
     RepositoryContributorsVariables,
@@ -59,7 +59,7 @@ const RepositoryContributorNode: React.FunctionComponent<React.PropsWithChildren
     path,
     globbing,
 }) => {
-    const commit = node.commits.nodes[0] as GQL.IGitCommit | undefined
+    const commit = node.commits.nodes[0] as ContributorCommitNodeFields | undefined
 
     const query: string = [
         searchQueryForRepoRevision(repoName, globbing),
@@ -148,14 +148,18 @@ const CONTRIBUTORS_QUERY = gql`
         count
         commits(first: 1) {
             nodes {
-                oid
-                abbreviatedOID
-                url
-                subject
-                author {
-                    date
-                }
+                ...ContributorCommitNodeFields
             }
+        }
+    }
+
+    fragment ContributorCommitNodeFields on GitCommit {
+        oid
+        abbreviatedOID
+        url
+        subject
+        author {
+            date
         }
     }
 `

--- a/client/web/src/repo/tree/BranchesTab.tsx
+++ b/client/web/src/repo/tree/BranchesTab.tsx
@@ -7,7 +7,6 @@ import { catchError, map, mapTo, startWith, switchMap } from 'rxjs/operators'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { isErrorLike, asError, ErrorLike } from '@sourcegraph/common'
-import * as GQL from '@sourcegraph/shared/src/schema'
 import { Button, Card, CardHeader, Icon, LoadingSpinner, useEventObservable } from '@sourcegraph/wildcard'
 
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../../components/FilteredConnection'
@@ -34,8 +33,8 @@ interface OverviewTabProps {
 }
 
 interface Data {
-    defaultBranch: GQL.IGitRef | null
-    activeBranches: GQL.IGitRef[]
+    defaultBranch: GitRefFields | null
+    activeBranches: GitRefFields[]
     hasMoreActiveBranches: boolean
 }
 

--- a/client/web/src/repo/tree/HomeTab.tsx
+++ b/client/web/src/repo/tree/HomeTab.tsx
@@ -9,7 +9,6 @@ import { catchError, map, mapTo, startWith, switchMap } from 'rxjs/operators'
 import { ErrorMessage } from '@sourcegraph/branded/src/components/alerts'
 import { asError, ErrorLike, pluralize, encodeURIPathComponent } from '@sourcegraph/common'
 import { gql, useQuery } from '@sourcegraph/http-client'
-import * as GQL from '@sourcegraph/shared/src/schema'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import {
     Button,
@@ -30,6 +29,7 @@ import {
     GetRepoBatchChangesSummaryResult,
     GetRepoBatchChangesSummaryVariables,
     GitCommitFields,
+    TreeCommitsAncestorFields,
     TreePageRepositoryFields,
 } from '../../graphql-operations'
 import { fetchBlob } from '../blob/backend'
@@ -143,7 +143,7 @@ export const HomeTab: React.FunctionComponent<React.PropsWithChildren<Props>> = 
     )
 
     const queryCommits = useCallback(
-        (args: { first?: number }): Observable<GQL.IGitCommitConnection> => {
+        (args: { first?: number }): Observable<TreeCommitsAncestorFields> => {
             const after: string | undefined = showOlderCommits ? undefined : formatISO(subYears(Date.now(), 1))
             return fetchTreeCommits({
                 ...args,

--- a/client/web/src/repo/tree/TreeEntriesSection.tsx
+++ b/client/web/src/repo/tree/TreeEntriesSection.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 import { identity } from 'lodash'
 
 import { FileDecorationsByPath } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
-import * as GQL from '@sourcegraph/shared/src/schema'
+import { TreeEntryFields } from '@sourcegraph/shared/src/graphql-operations'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Link, Icon } from '@sourcegraph/wildcard'
 
@@ -65,7 +65,7 @@ const TreeEntry: React.FunctionComponent<
 
 interface TreeEntriesSectionProps extends ThemeProps {
     parentPath: string
-    entries: Pick<GQL.ITreeEntry, 'name' | 'isDirectory' | 'url' | 'path'>[]
+    entries: Pick<TreeEntryFields, 'name' | 'isDirectory' | 'url' | 'path'>[]
     fileDecorationsByPath: FileDecorationsByPath
 }
 

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -15,7 +15,6 @@ import { FileDecorationsByPath } from '@sourcegraph/shared/src/api/extension/ext
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { TreeFields } from '@sourcegraph/shared/src/graphql-operations'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
-import * as GQL from '@sourcegraph/shared/src/schema'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Button, Heading, Text, useObservable } from '@sourcegraph/wildcard'
@@ -23,7 +22,7 @@ import { Button, Heading, Text, useObservable } from '@sourcegraph/wildcard'
 import { getFileDecorations } from '../../backend/features'
 import { queryGraphQL } from '../../backend/graphql'
 import { FilteredConnection } from '../../components/FilteredConnection'
-import { GitCommitFields, Scalars, TreePageRepositoryFields } from '../../graphql-operations'
+import { GitCommitFields, Scalars, TreeCommitsAncestorFields, TreePageRepositoryFields } from '../../graphql-operations'
 import { GitCommitNodeProps, GitCommitNode } from '../commits/GitCommitNode'
 import { gitCommitFragment } from '../commits/RepositoryCommitsPage'
 
@@ -38,7 +37,7 @@ export const fetchTreeCommits = memoizeObservable(
         first?: number
         filePath?: string
         after?: string
-    }): Observable<GQL.IGitCommitConnection> =>
+    }): Observable<TreeCommitsAncestorFields> =>
         queryGraphQL(
             gql`
                 query TreeCommits($repo: ID!, $revspec: String!, $first: Int, $filePath: String, $after: String) {
@@ -47,15 +46,19 @@ export const fetchTreeCommits = memoizeObservable(
                         ... on Repository {
                             commit(rev: $revspec) {
                                 ancestors(first: $first, path: $filePath, after: $after) {
-                                    nodes {
-                                        ...GitCommitFields
-                                    }
-                                    pageInfo {
-                                        hasNextPage
-                                    }
+                                    ...TreeCommitsAncestorFields
                                 }
                             }
                         }
+                    }
+                }
+
+                fragment TreeCommitsAncestorFields on GitCommitConnection {
+                    nodes {
+                        ...GitCommitFields
+                    }
+                    pageInfo {
+                        hasNextPage
                     }
                 }
                 ${gitCommitFragment}
@@ -114,7 +117,7 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
         ) ?? {}
 
     const queryCommits = useCallback(
-        (args: { first?: number }): Observable<GQL.IGitCommitConnection> => {
+        (args: { first?: number }): Observable<TreeCommitsAncestorFields> => {
             const after: string | undefined = showOlderCommits ? undefined : formatISO(subYears(Date.now(), 1))
             return fetchTreeCommits({
                 ...args,


### PR DESCRIPTION
## Description
Migrate typing using from `schema.ts` to `graphql-oparations`

## Success criteria

1. All imports from `schema.ts` in the `client/web/src/repo` folders are replaced with respective imports from `graphql-operations`.

## Ref
[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/41675)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-41675)

## Test Plan
- Verify that all usage of `schema.ts` types has been migrated to their equivalent typing from `graphql-oparations.ts` file in `client/web` package(`repo` folders).