### PR TITLE
frontend: allow cross-origin static assets loading to fix the Phabricator native extension initialization

### DIFF
--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -258,6 +258,16 @@ func handleCORSRequest(w http.ResponseWriter, r *http.Request, policy crossOrigi
 		return false
 	}
 
+	// If the crossOriginPolicyAssets is used and the requested asset is not from the extension folder,
+	// we do not write ANY Access-Control-Allow-* CORS headers, which triggers the browser's default
+	// (and strict) behavior of not allowing cross-origin requests.
+	//
+	// We allow cross-origin requests for assets in the `./ui/assets/extension` folder because they
+	// are required for the native Phabricator extension.
+	if policy == crossOriginPolicyAssets && !strings.HasPrefix(r.URL.Path, "/extension/") {
+		return false
+	}
+
 	// crossOriginPolicyAPI and crossOriginPolicyAssets - handling of API and static assets routes.
 	//
 	// Even if the request was not from a trusted origin, we will allow the browser to send it AND


### PR DESCRIPTION
## Context

Closes the customer issue raised in [the #escalation-engineering channel](https://sourcegraph.slack.com/archives/C03TGHH1S3V):
1. https://github.com/sourcegraph/sourcegraph/issues/42555
2. [Slack thread](https://sourcegraph.slack.com/archives/C03TGHH1S3V/p1665048359663189).

## Details

The Phabricator native extension loads static assets via the fetch interface. https://github.com/sourcegraph/sourcegraph/blob/39147a4c8a8b5055146875ee01f2cb288a217480/client/browser/src/native-integration/phabricator/integration.main.ts#L24-L25

Around a year ago, we [made CORS enforcement of non-API routes even more strict](https://github.com/sourcegraph/sourcegraph/pull/27246):

> Forbids cross-origin requests for all non-API routes, even if they are from an allowed origin in the site config `corsOrigin` setting 

This change prevents the Phabricator native extension from loading static assets required for its functionality.

## Changes

This PR enables cross-origin requests for static assets served from the `/.assets` API handler. It is OK from the security perspective because the assets handler only serves files from the `./ui/assets` folder, and we don't store any sensitive information there.

UPD: [going to look into restricting this rule to specific static assets rather than all](https://sourcegraph.slack.com/archives/C03TGHH1S3V/p1665382829569059?thread_ts=1665048359.663189&cid=C03TGHH1S3V).

## Test plan

1. `EXTENSION_PERMISSIONS_ALL_URLS=true yarn run dev` in `client/browser`.
4. `./dev/phabricator/e2e.sh` from the root of the repo to start the Phabricator instance locally.
5. Manually follow the steps described in `client/browser/src/end-to-end/phabricator.test.ts`.
    – Why manually? It looks like we do not run end-to-end browser extension tests on CI, and they failed for me locally. [Following up on that in the #integrations channel](https://sourcegraph.slack.com/archives/C01LZKLRF0C/p1665379800710059).
6. Stop after setting up Sourcegraph URL in the Phabricator app configuration to `https://sourcegraph.test:3443`.
7. Run Sourcegraph locally `sg start`.
8. Add the Phabricator URL to the `corsOrigin` site-config field.
4. Refresh the Phabricator page. 
    - Notice that `phabricator.bundle.js` is loaded successfully.
    - Notice that `style.bundle.css?v=0.0.0` is loaded successfully.
