### PR TITLE
Prevent race conditions when updating site config by checking Last ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - WIP changesets in Gitlab >= 14.0 are now prefixed with `Draft:` instead of `WIP:` to accomodate for the [breaking change in Gitlab 14.0](https://docs.gitlab.com/ee/update/removals.html#wip-merge-requests-renamed-draft-merge-requests). [#42024](https://github.com/sourcegraph/sourcegraph/pull/42024)
+- When updating the site configuration, the provided Last ID is now used to prevent race conditions when simultaneous config updates occur. [#42691](https://github.com/sourcegraph/sourcegraph/pull/42691)
 
 ### Removed
 

--- a/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -435,7 +435,14 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
             restartToApply = await updateSiteConfiguration(lastConfigurationID, newContents).toPromise<boolean>()
         } catch (error) {
             logger.error(error)
-            this.setState({ saving: false, error })
+            this.setState({
+                saving: false,
+                error: new Error(
+                    String(error) +
+                        '\nError occured while attempting to save site configuration. Please backup changes before reloading the page.'
+                ),
+            })
+            throw error
         }
 
         const oldContents = lastConfiguration?.effectiveContents || ''

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -119,7 +119,7 @@ func overrideSiteConfig(ctx context.Context, logger log.Logger, db database.DB) 
 		}
 		raw.Site = string(site)
 
-		err = cs.Write(ctx, raw)
+		err = cs.Write(ctx, raw, raw.ID)
 		if err != nil {
 			return errors.Wrap(err, "writing site config overrides to database")
 		}
@@ -445,16 +445,19 @@ func (c *configurationSource) Read(ctx context.Context) (conftypes.RawUnified, e
 	}
 
 	return conftypes.RawUnified{
+		ID:                 site.ID,
 		Site:               site.Contents,
 		ServiceConnections: serviceConnections(c.logger),
 	}, nil
 }
 
-func (c *configurationSource) Write(ctx context.Context, input conftypes.RawUnified) error {
-	// TODO(slimsag): future: pass lastID through for race prevention
+func (c *configurationSource) Write(ctx context.Context, input conftypes.RawUnified, lastID int32) error {
 	site, err := c.db.Conf().SiteGetLatest(ctx)
 	if err != nil {
 		return errors.Wrap(err, "ConfStore.SiteGetLatest")
+	}
+	if site.ID != lastID {
+		return errors.New("site config has been modified by another request, write not allowed")
 	}
 	_, err = c.db.Conf().SiteCreateIfUpToDate(ctx, &site.ID, input.Site)
 	if err != nil {

--- a/dev/authtest/code_intel_test.go
+++ b/dev/authtest/code_intel_test.go
@@ -69,7 +69,7 @@ func TestCodeIntelEndpoints(t *testing.T) {
 
 	t.Run("LSIF upload", func(t *testing.T) {
 		// Update site configuration to enable "lsifEnforceAuth".
-		siteConfig, err := client.SiteConfiguration()
+		siteConfig, lastID, err := client.SiteConfiguration()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -77,21 +77,25 @@ func TestCodeIntelEndpoints(t *testing.T) {
 		oldSiteConfig := new(schema.SiteConfiguration)
 		*oldSiteConfig = *siteConfig
 		defer func() {
-			err = client.UpdateSiteConfiguration(oldSiteConfig)
+			_, lastID, err := client.SiteConfiguration()
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = client.UpdateSiteConfiguration(oldSiteConfig, lastID)
 			if err != nil {
 				t.Fatal(err)
 			}
 		}()
 
 		siteConfig.LsifEnforceAuth = true
-		err = client.UpdateSiteConfiguration(siteConfig)
+		err = client.UpdateSiteConfiguration(siteConfig, lastID)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		// Retry because the configuration update endpoint is eventually consistent
 		var lastBody string
-		err = gqltestutil.Retry(10*time.Second, func() error {
+		err = gqltestutil.Retry(15*time.Second, func() error {
 			resp, err := userClient.Post(*baseURL+"/.api/lsif/upload?commit=6ffc6072f5ed13d8e8782490705d9689cd2c546a&repository=github.com/sgtest/private", nil)
 			if err != nil {
 				t.Fatal(err)
@@ -161,7 +165,7 @@ func TestCodeIntelEndpoints(t *testing.T) {
 }
 
 func setExecutorAccessToken(t *testing.T, token string) func() {
-	siteConfig, err := client.SiteConfiguration()
+	siteConfig, lastID, err := client.SiteConfiguration()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,11 +174,15 @@ func setExecutorAccessToken(t *testing.T, token string) func() {
 	*oldSiteConfig = *siteConfig
 	siteConfig.ExecutorsAccessToken = token
 
-	if err := client.UpdateSiteConfiguration(siteConfig); err != nil {
+	if err := client.UpdateSiteConfiguration(siteConfig, lastID); err != nil {
 		t.Fatal(err)
 	}
 	return func() {
-		if err := client.UpdateSiteConfiguration(oldSiteConfig); err != nil {
+		_, lastID, err := client.SiteConfiguration()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := client.UpdateSiteConfiguration(oldSiteConfig, lastID); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/dev/gqltest/main_test.go
+++ b/dev/gqltest/main_test.go
@@ -82,7 +82,7 @@ func TestMain(m *testing.M) {
 
 	licenseKey := os.Getenv("SOURCEGRAPH_LICENSE_KEY")
 	if licenseKey != "" {
-		siteConfig, err := client.SiteConfiguration()
+		siteConfig, lastID, err := client.SiteConfiguration()
 		if err != nil {
 			log.Fatal("Failed to get site configuration:", err)
 		}
@@ -94,7 +94,7 @@ func TestMain(m *testing.M) {
 			}
 
 			siteConfig.LicenseKey = licenseKey
-			err = client.UpdateSiteConfiguration(siteConfig)
+			err = client.UpdateSiteConfiguration(siteConfig, lastID)
 			if err != nil {
 				return errors.Wrap(err, "update site configuration")
 			}

--- a/dev/gqltest/organization_test.go
+++ b/dev/gqltest/organization_test.go
@@ -115,21 +115,25 @@ func TestOrganization(t *testing.T) {
 
 		// Update site configuration to set "auth.userOrgMap" which makes the new user join
 		// the organization (gqltest-org) automatically.
-		siteConfig, err := client.SiteConfiguration()
+		siteConfig, lastID, err := client.SiteConfiguration()
 		if err != nil {
 			t.Fatal(err)
 		}
 		oldSiteConfig := new(schema.SiteConfiguration)
 		*oldSiteConfig = *siteConfig
 		defer func() {
-			err = client.UpdateSiteConfiguration(oldSiteConfig)
+			_, lastID, err := client.SiteConfiguration()
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = client.UpdateSiteConfiguration(oldSiteConfig, lastID)
 			if err != nil {
 				t.Fatal(err)
 			}
 		}()
 
 		siteConfig.AuthUserOrgMap = map[string][]string{"*": {testOrgName}}
-		err = client.UpdateSiteConfiguration(siteConfig)
+		err = client.UpdateSiteConfiguration(siteConfig, lastID)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -103,8 +103,8 @@ type searchClient interface {
 	SearchFiles(query string) (*gqltestutil.SearchFileResults, error)
 	SearchAll(query string) ([]*gqltestutil.AnyResult, error)
 
-	UpdateSiteConfiguration(config *schema.SiteConfiguration) error
-	SiteConfiguration() (*schema.SiteConfiguration, error)
+	UpdateSiteConfiguration(config *schema.SiteConfiguration, lastID int32) error
+	SiteConfiguration() (*schema.SiteConfiguration, int32, error)
 
 	OverwriteSettings(subjectID, contents string) error
 	AuthenticatedUserID() string

--- a/dev/gqltest/site_config_test.go
+++ b/dev/gqltest/site_config_test.go
@@ -20,14 +20,18 @@ func TestSiteConfig(t *testing.T) {
 		removeTestUserAfterTest(t, testClient1.AuthenticatedUserID())
 
 		// Update site configuration to not allow sign up for builtin auth provider.
-		siteConfig, err := client.SiteConfiguration()
+		siteConfig, lastID, err := client.SiteConfiguration()
 		if err != nil {
 			t.Fatal(err)
 		}
 		oldSiteConfig := new(schema.SiteConfiguration)
 		*oldSiteConfig = *siteConfig
 		defer func() {
-			err = client.UpdateSiteConfiguration(oldSiteConfig)
+			_, lastID, err := client.SiteConfiguration()
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = client.UpdateSiteConfiguration(oldSiteConfig, lastID)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -41,7 +45,7 @@ func TestSiteConfig(t *testing.T) {
 				},
 			},
 		}
-		err = client.UpdateSiteConfiguration(siteConfig)
+		err = client.UpdateSiteConfiguration(siteConfig, lastID)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -342,14 +342,18 @@ func syncUserPerms(t *testing.T, userID, userName string) {
 func enableSubRepoPermissions(t *testing.T) {
 	t.Helper()
 
-	siteConfig, err := client.SiteConfiguration()
+	siteConfig, lastID, err := client.SiteConfiguration()
 	if err != nil {
 		t.Fatal(err)
 	}
 	oldSiteConfig := new(schema.SiteConfiguration)
 	*oldSiteConfig = *siteConfig
 	t.Cleanup(func() {
-		err = client.UpdateSiteConfiguration(oldSiteConfig)
+		_, lastID, err := client.SiteConfiguration()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = client.UpdateSiteConfiguration(oldSiteConfig, lastID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -361,7 +365,7 @@ func enableSubRepoPermissions(t *testing.T) {
 			Enabled: true,
 		},
 	}
-	err = client.UpdateSiteConfiguration(siteConfig)
+	err = client.UpdateSiteConfiguration(siteConfig, lastID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cmd/init-sg/main.go
+++ b/internal/cmd/init-sg/main.go
@@ -88,13 +88,13 @@ func initSourcegraph() {
 	}
 
 	// Ensure site configuration is set up correctly
-	siteConfig, err := client.SiteConfiguration()
+	siteConfig, lastID, err := client.SiteConfiguration()
 	if err != nil {
 		log.Fatal(err)
 	}
 	if siteConfig.ExternalURL != *baseURL {
 		siteConfig.ExternalURL = *baseURL
-		err = client.UpdateSiteConfiguration(siteConfig)
+		err = client.UpdateSiteConfiguration(siteConfig, lastID)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -146,10 +146,10 @@ func (c *cachedConfigurationSource) Read(ctx context.Context) (conftypes.RawUnif
 	return *c.entry, nil
 }
 
-func (c *cachedConfigurationSource) Write(ctx context.Context, input conftypes.RawUnified) error {
+func (c *cachedConfigurationSource) Write(ctx context.Context, input conftypes.RawUnified, lastID int32) error {
 	c.entryMu.Lock()
 	defer c.entryMu.Unlock()
-	if err := c.source.Write(ctx, input); err != nil {
+	if err := c.source.Write(ctx, input, lastID); err != nil {
 		return err
 	}
 	c.entry = &input
@@ -211,6 +211,7 @@ func startSiteConfigEscapeHatchWorker(c ConfigurationSource) {
 	var (
 		ctx                                        = context.Background()
 		lastKnownFileContents, lastKnownDBContents string
+		lastKnownConfigID                          int32
 		logger                                     = sglog.Scoped("SiteConfigEscapeHatch", "escape hatch for site config").With(sglog.String("path", siteConfigEscapeHatchPath))
 	)
 	go func() {
@@ -229,6 +230,7 @@ func startSiteConfigEscapeHatchWorker(c ConfigurationSource) {
 			}
 			lastKnownDBContents = config.Site
 			lastKnownFileContents = config.Site
+			lastKnownConfigID = config.ID
 			break
 		}
 
@@ -251,7 +253,7 @@ func startSiteConfigEscapeHatchWorker(c ConfigurationSource) {
 					continue
 				}
 				config.Site = string(newFileContents)
-				err = c.Write(ctx, config)
+				err = c.Write(ctx, config, lastKnownConfigID)
 				if err != nil {
 					logger.Warn("failed to save edit to database, trying again in 1s (write error)", sglog.Error(err))
 					time.Sleep(1 * time.Second)
@@ -277,6 +279,7 @@ func startSiteConfigEscapeHatchWorker(c ConfigurationSource) {
 					continue
 				}
 				lastKnownFileContents = newDBConfig.Site
+				lastKnownConfigID = newDBConfig.ID
 			}
 			time.Sleep(1 * time.Second)
 		}

--- a/internal/conf/conftypes/conftypes.go
+++ b/internal/conf/conftypes/conftypes.go
@@ -28,6 +28,7 @@ type ServiceConnections struct {
 
 // RawUnified is the unparsed variant of conf.Unified.
 type RawUnified struct {
+	ID                 int32
 	Site               string
 	ServiceConnections ServiceConnections
 }

--- a/internal/conf/mocks_test.go
+++ b/internal/conf/mocks_test.go
@@ -36,7 +36,7 @@ func NewMockConfigurationSource() *MockConfigurationSource {
 			},
 		},
 		WriteFunc: &ConfigurationSourceWriteFunc{
-			defaultHook: func(context.Context, conftypes.RawUnified) (r0 error) {
+			defaultHook: func(context.Context, conftypes.RawUnified, int32) (r0 error) {
 				return
 			},
 		},
@@ -54,7 +54,7 @@ func NewStrictMockConfigurationSource() *MockConfigurationSource {
 			},
 		},
 		WriteFunc: &ConfigurationSourceWriteFunc{
-			defaultHook: func(context.Context, conftypes.RawUnified) error {
+			defaultHook: func(context.Context, conftypes.RawUnified, int32) error {
 				panic("unexpected invocation of MockConfigurationSource.Write")
 			},
 		},
@@ -183,24 +183,24 @@ func (c ConfigurationSourceReadFuncCall) Results() []interface{} {
 // ConfigurationSourceWriteFunc describes the behavior when the Write method
 // of the parent MockConfigurationSource instance is invoked.
 type ConfigurationSourceWriteFunc struct {
-	defaultHook func(context.Context, conftypes.RawUnified) error
-	hooks       []func(context.Context, conftypes.RawUnified) error
+	defaultHook func(context.Context, conftypes.RawUnified, int32) error
+	hooks       []func(context.Context, conftypes.RawUnified, int32) error
 	history     []ConfigurationSourceWriteFuncCall
 	mutex       sync.Mutex
 }
 
 // Write delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockConfigurationSource) Write(v0 context.Context, v1 conftypes.RawUnified) error {
-	r0 := m.WriteFunc.nextHook()(v0, v1)
-	m.WriteFunc.appendCall(ConfigurationSourceWriteFuncCall{v0, v1, r0})
+func (m *MockConfigurationSource) Write(v0 context.Context, v1 conftypes.RawUnified, v2 int32) error {
+	r0 := m.WriteFunc.nextHook()(v0, v1, v2)
+	m.WriteFunc.appendCall(ConfigurationSourceWriteFuncCall{v0, v1, v2, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the Write method of the
 // parent MockConfigurationSource instance is invoked and the hook queue is
 // empty.
-func (f *ConfigurationSourceWriteFunc) SetDefaultHook(hook func(context.Context, conftypes.RawUnified) error) {
+func (f *ConfigurationSourceWriteFunc) SetDefaultHook(hook func(context.Context, conftypes.RawUnified, int32) error) {
 	f.defaultHook = hook
 }
 
@@ -208,7 +208,7 @@ func (f *ConfigurationSourceWriteFunc) SetDefaultHook(hook func(context.Context,
 // Write method of the parent MockConfigurationSource instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *ConfigurationSourceWriteFunc) PushHook(hook func(context.Context, conftypes.RawUnified) error) {
+func (f *ConfigurationSourceWriteFunc) PushHook(hook func(context.Context, conftypes.RawUnified, int32) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -217,19 +217,19 @@ func (f *ConfigurationSourceWriteFunc) PushHook(hook func(context.Context, conft
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ConfigurationSourceWriteFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, conftypes.RawUnified) error {
+	f.SetDefaultHook(func(context.Context, conftypes.RawUnified, int32) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ConfigurationSourceWriteFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, conftypes.RawUnified) error {
+	f.PushHook(func(context.Context, conftypes.RawUnified, int32) error {
 		return r0
 	})
 }
 
-func (f *ConfigurationSourceWriteFunc) nextHook() func(context.Context, conftypes.RawUnified) error {
+func (f *ConfigurationSourceWriteFunc) nextHook() func(context.Context, conftypes.RawUnified, int32) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -268,6 +268,9 @@ type ConfigurationSourceWriteFuncCall struct {
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 conftypes.RawUnified
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int32
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -276,7 +279,7 @@ type ConfigurationSourceWriteFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ConfigurationSourceWriteFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/conf/server.go
+++ b/internal/conf/server.go
@@ -11,7 +11,7 @@ import (
 // "raw" configuration.
 type ConfigurationSource interface {
 	// Write updates the configuration. The Deployment field is ignored.
-	Write(ctx context.Context, data conftypes.RawUnified) error
+	Write(ctx context.Context, data conftypes.RawUnified, lastID int32) error
 	Read(ctx context.Context) (conftypes.RawUnified, error)
 }
 
@@ -41,7 +41,7 @@ func NewServer(source ConfigurationSource) *Server {
 }
 
 // Write validates and writes input to the server's source.
-func (s *Server) Write(ctx context.Context, input conftypes.RawUnified) error {
+func (s *Server) Write(ctx context.Context, input conftypes.RawUnified, lastID int32) error {
 	// Parse the configuration so that we can diff it (this also validates it
 	// is proper JSON).
 	_, err := ParseConfig(input)
@@ -49,7 +49,7 @@ func (s *Server) Write(ctx context.Context, input conftypes.RawUnified) error {
 		return err
 	}
 
-	err = s.source.Write(ctx, input)
+	err = s.source.Write(ctx, input, lastID)
 	if err != nil {
 		return err
 	}

--- a/internal/gqltestutil/settings.go
+++ b/internal/gqltestutil/settings.go
@@ -152,11 +152,12 @@ query ViewerSettings {
 // SiteConfiguration returns current effective site configuration.
 //
 // This method requires the authenticated user to be a site admin.
-func (c *Client) SiteConfiguration() (*schema.SiteConfiguration, error) {
+func (c *Client) SiteConfiguration() (*schema.SiteConfiguration, int32, error) {
 	const query = `
 query Site {
 	site {
 		configuration {
+            id
 			effectiveContents
 		}
 	}
@@ -167,6 +168,7 @@ query Site {
 		Data struct {
 			Site struct {
 				Configuration struct {
+					ID                int32  `json:"id"`
 					EffectiveContents string `json:"effectiveContents"`
 				} `json:"configuration"`
 			} `json:"site"`
@@ -174,33 +176,35 @@ query Site {
 	}
 	err := c.GraphQL("", query, nil, &resp)
 	if err != nil {
-		return nil, errors.Wrap(err, "request GraphQL")
+		return nil, 0, errors.Wrap(err, "request GraphQL")
 	}
 
 	config := new(schema.SiteConfiguration)
 	err = jsonc.Unmarshal(resp.Data.Site.Configuration.EffectiveContents, config)
 	if err != nil {
-		return nil, errors.Wrap(err, "unmarshal configuration")
+		return nil, 0, errors.Wrap(err, "unmarshal configuration")
 	}
-	return config, nil
+
+	return config, resp.Data.Site.Configuration.ID, nil
 }
 
 // UpdateSiteConfiguration updates site configuration.
 //
 // This method requires the authenticated user to be a site admin.
-func (c *Client) UpdateSiteConfiguration(config *schema.SiteConfiguration) error {
+func (c *Client) UpdateSiteConfiguration(config *schema.SiteConfiguration, lastID int32) error {
 	input, err := jsoniter.Marshal(config)
 	if err != nil {
 		return errors.Wrap(err, "marshal configuration")
 	}
 
 	const query = `
-mutation UpdateSiteConfiguration($input: String!) {
-	updateSiteConfiguration(lastID: 0, input: $input)
+mutation UpdateSiteConfiguration($lastID: Int!, $input: String!) {
+	updateSiteConfiguration(lastID: $lastID, input: $input)
 }
 `
 	variables := map[string]any{
-		"input": string(input),
+		"lastID": lastID,
+		"input":  string(input),
 	}
 	err = c.GraphQL("", query, variables, nil)
 	if err != nil {


### PR DESCRIPTION
Solves #35428 

Adds a check when making Site Config updates to ensure that race conditions don't occur. The Last ID, which is supplied alongside a site config update, is used to determine if a site config update happened before this update was attempted.

See Loom for demonstration in UI: https://www.loom.com/share/f315821af6af4c11ba333f294a81d57f

## Test plan

Unit tests, integration tests, and manual testing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
