### PR TITLE
Disable flaky GitHub browser extension test

### DIFF
--- a/client/browser/src/integration/github.test.ts
+++ b/client/browser/src/integration/github.test.ts
@@ -9,7 +9,7 @@ import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing
 import { readEnvironmentBoolean, readEnvironmentString, retry } from '@sourcegraph/shared/src/testing/utils'
 
 import { BrowserIntegrationTestContext, createBrowserIntegrationTestContext } from './context'
-import { closeInstallPageTab, percySnapshot } from './shared'
+import { closeInstallPageTab } from './shared'
 
 describe('GitHub', () => {
     let driver: Driver

--- a/client/browser/src/integration/github.test.ts
+++ b/client/browser/src/integration/github.test.ts
@@ -149,168 +149,172 @@ describe('GitHub', () => {
         })
     })
 
-    it('shows hover tooltips when hovering a token and respects "Enable single click to go to definition" setting', async () => {
-        mockUrls(['https://github.com/*path/find-definition'])
+    // TODO(#42743): This test is flaky on CI and was disabled to unblock the pipeline.
+    // We need to investigate on what is causing the flakieness and remove it to
+    // bring it back.
+    //
+    // it('shows hover tooltips when hovering a token and respects "Enable single click to go to definition" setting', async () => {
+    //     mockUrls(['https://github.com/*path/find-definition'])
 
-        const { mockExtension, Extensions, extensionSettings } = setupExtensionMocking({
-            pollyServer: testContext.server,
-            sourcegraphBaseUrl: driver.sourcegraphBaseUrl,
-        })
+    //     const { mockExtension, Extensions, extensionSettings } = setupExtensionMocking({
+    //         pollyServer: testContext.server,
+    //         sourcegraphBaseUrl: driver.sourcegraphBaseUrl,
+    //     })
 
-        const userSettings: Settings = {
-            extensions: extensionSettings,
-        }
-        testContext.overrideGraphQL({
-            ViewerConfiguration: () => ({
-                viewerConfiguration: {
-                    subjects: [
-                        {
-                            __typename: 'User',
-                            displayName: 'Test User',
-                            id: 'TestUserSettingsID',
-                            latestSettings: {
-                                id: 123,
-                                contents: JSON.stringify(userSettings),
-                            },
-                            username: 'test',
-                            viewerCanAdminister: true,
-                            settingsURL: '/users/test/settings',
-                        },
-                    ],
-                    merged: { contents: JSON.stringify(userSettings), messages: [] },
-                },
-            }),
-            UserSettingsURL: () => ({
-                currentUser: {
-                    settingsURL: 'users/john-doe/settings',
-                },
-            }),
-            Extensions,
-        })
+    //     const userSettings: Settings = {
+    //         extensions: extensionSettings,
+    //     }
+    //     testContext.overrideGraphQL({
+    //         ViewerConfiguration: () => ({
+    //             viewerConfiguration: {
+    //                 subjects: [
+    //                     {
+    //                         __typename: 'User',
+    //                         displayName: 'Test User',
+    //                         id: 'TestUserSettingsID',
+    //                         latestSettings: {
+    //                             id: 123,
+    //                             contents: JSON.stringify(userSettings),
+    //                         },
+    //                         username: 'test',
+    //                         viewerCanAdminister: true,
+    //                         settingsURL: '/users/test/settings',
+    //                     },
+    //                 ],
+    //                 merged: { contents: JSON.stringify(userSettings), messages: [] },
+    //             },
+    //         }),
+    //         UserSettingsURL: () => ({
+    //             currentUser: {
+    //                 settingsURL: 'users/john-doe/settings',
+    //             },
+    //         }),
+    //         Extensions,
+    //     })
 
-        // Serve a mock extension with a simple hover provider
-        mockExtension({
-            id: 'simple/hover',
-            bundle: function extensionBundle(): void {
-                // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-                const sourcegraph = require('sourcegraph') as typeof import('sourcegraph')
+    //     // Serve a mock extension with a simple hover provider
+    //     mockExtension({
+    //         id: 'simple/hover',
+    //         bundle: function extensionBundle(): void {
+    //             // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+    //             const sourcegraph = require('sourcegraph') as typeof import('sourcegraph')
 
-                function activate(context: sourcegraph.ExtensionContext): void {
-                    context.subscriptions.add(
-                        sourcegraph.languages.registerHoverProvider(['*'], {
-                            provideHover: (document, position) => {
-                                const range = document.getWordRangeAtPosition(position)
-                                const token = document.getText(range)
-                                if (!token) {
-                                    return null
-                                }
-                                return {
-                                    contents: {
-                                        value: `User is hovering over ${token}`,
-                                        kind: sourcegraph.MarkupKind.Markdown,
-                                    },
-                                    range,
-                                }
-                            },
-                        })
-                    )
+    //             function activate(context: sourcegraph.ExtensionContext): void {
+    //                 context.subscriptions.add(
+    //                     sourcegraph.languages.registerHoverProvider(['*'], {
+    //                         provideHover: (document, position) => {
+    //                             const range = document.getWordRangeAtPosition(position)
+    //                             const token = document.getText(range)
+    //                             if (!token) {
+    //                                 return null
+    //                             }
+    //                             return {
+    //                                 contents: {
+    //                                     value: `User is hovering over ${token}`,
+    //                                     kind: sourcegraph.MarkupKind.Markdown,
+    //                                 },
+    //                                 range,
+    //                             }
+    //                         },
+    //                     })
+    //                 )
 
-                    context.subscriptions.add(
-                        sourcegraph.languages.registerDefinitionProvider(['*'], {
-                            provideDefinition: () =>
-                                new sourcegraph.Location(
-                                    new URL(
-                                        'https://github.com/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go'
-                                    ),
-                                    new sourcegraph.Range(
-                                        new sourcegraph.Position(4, 5),
-                                        new sourcegraph.Position(5, 14)
-                                    )
-                                ),
-                        })
-                    )
-                }
+    //                 context.subscriptions.add(
+    //                     sourcegraph.languages.registerDefinitionProvider(['*'], {
+    //                         provideDefinition: () =>
+    //                             new sourcegraph.Location(
+    //                                 new URL(
+    //                                     'https://github.com/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go'
+    //                                 ),
+    //                                 new sourcegraph.Range(
+    //                                     new sourcegraph.Position(4, 5),
+    //                                     new sourcegraph.Position(5, 14)
+    //                                 )
+    //                             ),
+    //                     })
+    //                 )
+    //             }
 
-                exports.activate = activate
-            },
-        })
+    //             exports.activate = activate
+    //         },
+    //     })
 
-        let hasRedirectedToDefinition = false
+    //     let hasRedirectedToDefinition = false
 
-        // For some reason in test requested definition URL is different from the actual one:
-        // 'https://github.com/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go/blob/HEAD/#L5:6' instead of
-        // 'https://github.com/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go#L5:6'.
-        // The former URL is returns 404 page so for test sake we intercept such requests and track the fact of redirect.
-        testContext.server
-            .get(
-                'https://github.com/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go/blob/HEAD/#L5:6'
-            )
-            .intercept((request, response) => {
-                response.sendStatus(200)
-                hasRedirectedToDefinition = true
-            })
+    //     // For some reason in test requested definition URL is different from the actual one:
+    //     // 'https://github.com/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go/blob/HEAD/#L5:6' instead of
+    //     // 'https://github.com/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go#L5:6'.
+    //     // The former URL is returns 404 page so for test sake we intercept such requests and track the fact of redirect.
+    //     testContext.server
+    //         .get(
+    //             'https://github.com/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go/blob/HEAD/#L5:6'
+    //         )
+    //         .intercept((request, response) => {
+    //             response.sendStatus(200)
+    //             hasRedirectedToDefinition = true
+    //         })
 
-        const openPageAndGetToken = async () => {
-            await driver.page.goto(
-                'https://github.com/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go'
-            )
-            await driver.page.waitForSelector('[data-testid="code-view-toolbar"] [data-testid="open-on-sourcegraph"]')
+    //     const openPageAndGetToken = async () => {
+    //         await driver.page.goto(
+    //             'https://github.com/sourcegraph/jsonrpc2/blob/4fb7cd90793ee6ab445f466b900e6bffb9b63d78/call_opt.go'
+    //         )
+    //         await driver.page.waitForSelector('[data-testid="code-view-toolbar"] [data-testid="open-on-sourcegraph"]')
 
-            // Pause to give codeintellify time to register listeners for
-            // tokenization (only necessary in CI, not sure why).
-            await driver.page.waitForTimeout(1000)
+    //         // Pause to give codeintellify time to register listeners for
+    //         // tokenization (only necessary in CI, not sure why).
+    //         await driver.page.waitForTimeout(1000)
 
-            const lineSelector = '.js-file-line-container tr'
+    //         const lineSelector = '.js-file-line-container tr'
 
-            // Trigger tokenization of the line.
-            const lineNumber = 16
-            const line = await driver.page.waitForSelector(`${lineSelector}:nth-child(${lineNumber})`, {
-                timeout: 10000,
-            })
+    //         // Trigger tokenization of the line.
+    //         const lineNumber = 16
+    //         const line = await driver.page.waitForSelector(`${lineSelector}:nth-child(${lineNumber})`, {
+    //             timeout: 10000,
+    //         })
 
-            if (!line) {
-                throw new Error(`Found no line with number ${lineNumber}`)
-            }
+    //         if (!line) {
+    //             throw new Error(`Found no line with number ${lineNumber}`)
+    //         }
 
-            const [token] = await line.$x('.//span[text()="CallOption"]')
-            return token
-        }
+    //         const [token] = await line.$x('.//span[text()="CallOption"]')
+    //         return token
+    //     }
 
-        let token = await openPageAndGetToken()
+    //     let token = await openPageAndGetToken()
 
-        // 1. Check that hovering a token shows code intel popup.
-        await token.hover()
-        await driver.findElementWithText('User is hovering over CallOption', {
-            selector: ' [data-testid="hover-overlay-content"] > p',
-            fuzziness: 'contains',
-            wait: {
-                timeout: 6000,
-            },
-        })
+    //     // 1. Check that hovering a token shows code intel popup.
+    //     await token.hover()
+    //     await driver.findElementWithText('User is hovering over CallOption', {
+    //         selector: ' [data-testid="hover-overlay-content"] > p',
+    //         fuzziness: 'contains',
+    //         wait: {
+    //             timeout: 6000,
+    //         },
+    //     })
 
-        await percySnapshot(driver.page, 'Browser extension: GitHub - blob view with code intel popup')
+    //     await percySnapshot(driver.page, 'Browser extension: GitHub - blob view with code intel popup')
 
-        // 2. Check that token click does not do anything by default
-        await token.click()
-        await driver.page.waitForTimeout(1000)
-        assert(!hasRedirectedToDefinition, 'Expected to not be redirected to definition')
+    //     // 2. Check that token click does not do anything by default
+    //     await token.click()
+    //     await driver.page.waitForTimeout(1000)
+    //     assert(!hasRedirectedToDefinition, 'Expected to not be redirected to definition')
 
-        // 3. Enable click-to-def setting and check that it redirects to the proper page
-        await driver.setClickGoToDefOptionFlag(true)
-        token = await openPageAndGetToken()
-        await token.hover()
-        await driver.findElementWithText('User is hovering over CallOption', {
-            selector: ' [data-testid="hover-overlay-content"] > p',
-            fuzziness: 'contains',
-            wait: {
-                timeout: 6000,
-            },
-        })
-        await token.click()
-        await driver.page.waitForTimeout(1000)
+    //     // 3. Enable click-to-def setting and check that it redirects to the proper page
+    //     await driver.setClickGoToDefOptionFlag(true)
+    //     token = await openPageAndGetToken()
+    //     await token.hover()
+    //     await driver.findElementWithText('User is hovering over CallOption', {
+    //         selector: ' [data-testid="hover-overlay-content"] > p',
+    //         fuzziness: 'contains',
+    //         wait: {
+    //             timeout: 6000,
+    //         },
+    //     })
+    //     await token.click()
+    //     await driver.page.waitForTimeout(1000)
 
-        assert(hasRedirectedToDefinition, 'Expected to be redirected to definition')
-    })
+    //     assert(hasRedirectedToDefinition, 'Expected to be redirected to definition')
+    // })
 
     describe('Pull request pages', () => {
         describe('Files Changed view', () => {


### PR DESCRIPTION
This PR disables a [flaky test](https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1665173346025319) that was run as part of the GitHub browser extension tests.

We need to [do more investigation and fix it before we turn it back on](https://github.com/sourcegraph/sourcegraph/issues/42743).

## Test plan

We only disable a test. If CI is green we can ship.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-disable-flaky-gh-bext-test.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-gvewxmufbl.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
