### PR TITLE
Fix the native code host integration on GitLab.com

### DIFF
--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 ## Unreleased
 
 - Updated the info text when accessing an unindexed repository [pull/42509](https://github.com/sourcegraph/sourcegraph/pull/42509)
+- Fix an issue that caused the native code host integration to not work on gitlab.com [pull/#](https://github.com/sourcegraph/sourcegraph/pull/#)
 
 ## Chrome & Firefox v22.9.27.1330, Safari v1.16
 

--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 ## Unreleased
 
 - Updated the info text when accessing an unindexed repository [pull/42509](https://github.com/sourcegraph/sourcegraph/pull/42509)
-- Fix an issue that caused the native code host integration to not work on gitlab.com [pull/#](https://github.com/sourcegraph/sourcegraph/pull/#)
+- Fix an issue that caused the native code host integration to not work on gitlab.com [pull/42748](https://github.com/sourcegraph/sourcegraph/pull/42748)
 
 ## Chrome & Firefox v22.9.27.1330, Safari v1.16
 


### PR DESCRIPTION
This PR fixes an issue that we discovered when upgrading the native code host integration on `gitlab.com`: https://gitlab.com/gitlab-org/gitlab/-/issues/377382

```
Uncaught Error: Tried to call background page function from in-page integration
    mf repo.ts:93
    Ng userEvents.tsx:35
    getContext userEvents.tsx:35
    BT codeHost.tsx:725
    qT codeHost.tsx:725
    <anonymous> codeHost.tsx:725
    <anonymous> codeHost.tsx:725
    <anonymous> codeHost.tsx:725
    <anonymous> codeHost.tsx:725
```

This code path was unfortunately never working if the browser extension code was executed in the native code host integration (so the JS is executed as part of the GitHub main thread and not an extension) but since we have never updated the native extension, we did not find out about this until now.

The fix here is to detect the case when the branch is run via native extensions (`isInPage`) and call `fetchCache` from the main thread in this case. We also have to make sure that we do not include credentials (ie cookies) with this request to mimic a public user accessing the URL.

cc @souldzin

## Test plan

- I've changed all `gitlab.com` URLs inside the browser extension code to match on `127.0.0.1` (my GitLab test instance).
- This caused [the issue to repro](https://gitlab.com/gitlab-org/gitlab/-/issues/377382).
- I then changed `node_modules/@sourcegraph/code-host-integration` to symlink to the output of the `build` step
- You can see my changes will no longer throw with this error.

![Screenshot 2022-10-10 at 13 43 44](https://user-images.githubusercontent.com/458591/194860036-91d6e06f-8c88-423a-89fc-1099922b987c.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-native-code-host.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ofmhzygfas.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
