### PR TITLE
Combobox: Support auto scrolling for combobox keyboard navigation

### DIFF
--- a/client/search-ui/src/input/SearchContextMenu.tsx
+++ b/client/search-ui/src/input/SearchContextMenu.tsx
@@ -279,6 +279,7 @@ export const SearchContextMenuItem: FC<SearchContextMenuItemProps> = props => {
     return (
         <ComboboxOption
             value={spec}
+            selected={selected}
             data-testid="search-context-menu-item"
             data-search-context-spec={spec}
             data-selected={selected || undefined}

--- a/client/wildcard/src/components/Combobox/Combobox.module.scss
+++ b/client/wildcard/src/components/Combobox/Combobox.module.scss
@@ -13,6 +13,8 @@
 }
 
 .list {
+    overflow: auto;
+
     [data-reach-combobox-option]:hover {
         background-color: var(--dropdown-link-hover-bg);
         color: var(--dropdown-link-hover-color);

--- a/client/wildcard/src/components/Combobox/Combobox.story.tsx
+++ b/client/wildcard/src/components/Combobox/Combobox.story.tsx
@@ -39,6 +39,7 @@ export const ComboboxDemo = () => (
         <Grid columnCount={3}>
             <CommonSearchDemo />
             <ComboboxOpenOnFocusDemo />
+            <ScrollableListDemo />
             <ComboboxWithIcon />
             <ComboboxCustomSuggestionRenderDemo />
             <ComboboxServerSideSearchDemo />
@@ -80,6 +81,30 @@ const ComboboxOpenOnFocusDemo = () => (
                 <ComboboxOption value="github.com/sourcegraph/deploy" />
                 <ComboboxOption value="github.com/sourcegraph/handbook" />
                 <ComboboxOption value="github.com/sourcegraph/with-long-loooooong-repo-name" />
+            </ComboboxList>
+        </ComboboxPopover>
+    </Combobox>
+)
+
+const ScrollableListDemo = () => (
+    <Combobox aria-label="Choose a repo" openOnFocus={true} style={{ maxWidth: '20rem' }}>
+        <ComboboxInput
+            label="Repository"
+            placeholder="Focus and navigate with arrow"
+            message="You need to specify repo name (github.com/sg/sg) and then pick one of the suggestions items."
+        />
+
+        <ComboboxPopover>
+            <ComboboxList style={{ maxHeight: 155 }}>
+                <ComboboxOption value="github.com/sourcegraph/sourcegraph" />
+                <ComboboxOption value="github.com/sourcegraph/about" />
+                <ComboboxOption value="github.com/sourcegraph/deploy" />
+                <ComboboxOption value="github.com/sourcegraph/handbook" />
+                <ComboboxOption value="github.com/sourcegraph/4.0" />
+                <ComboboxOption value="github.com/sourcegraph/sorokin" />
+                <ComboboxOption value="github.com/sourcegraph/1.1" />
+                <ComboboxOption value="github.com/sourcegraph/2.0" />
+                <ComboboxOption value="github.com/sourcegraph/extensions" />
             </ComboboxList>
         </ComboboxPopover>
     </Combobox>


### PR DESCRIPTION
## Problem 
Prior to this PR `Combobox` component didn't scroll the suggestion list if user navigation goes through suggested items that are hidden due to list scroll sizes. See the following video with this problem.

https://user-images.githubusercontent.com/18492575/194866437-fb9aabbf-47ef-483b-ba85-31b730cf4c21.mov

You can see that the last item is partially hidden due to list sizes; when we navigate to this item, it doesn't show up in the visible area. It makes hidden items in the list scroll container unreachable with the keyboard.

https://user-images.githubusercontent.com/18492575/194868638-0276e925-424e-4dab-9124-ba7000e09a69.mov

## Test plan
- Check that it's possible to see all items in the suggested item list even if they are hidden (as you navigate to them with the keyboard)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-combobox-navigation.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-nabxazijgg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
