### PR TITLE
Fix double punctuation typo

### DIFF
--- a/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/index.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/index.tsx
@@ -100,7 +100,7 @@ export const UsersManagement: React.FunctionComponent<RouteComponentProps<{}>> =
                 <UsersList onActionEnd={refetch} />
             </Card>
             <Text className="font-italic text-center mt-2">
-                All events are generated from entries in the event logs table and are updated every 24 hours..
+                All events are generated from entries in the event logs table and are updated every 24 hours.
             </Text>
         </>
     )

--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/index.tsx
@@ -195,7 +195,7 @@ export const AnalyticsUsersPage: FC<RouteComponentProps> = () => {
                 </div>
             </Card>
             <Text className="font-italic text-center mt-2">
-                All events are generated from entries in the event logs table and are updated every 24 hours..
+                All events are generated from entries in the event logs table and are updated every 24 hours.
             </Text>
         </>
     )


### PR DESCRIPTION
Quick fix for a typo I noticed in the user page. Turns out analytics page was also affected

## Test plan

![Screenshot 2022-10-10 at 16 15 08](https://user-images.githubusercontent.com/458591/194886875-3fffa11f-a728-4738-b74c-efd4c7f2ee53.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-typo.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-cjnlbpzwyj.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
