### PR TITLE
Search: add hover, completion, and docs for repo metadata

### DIFF
--- a/client/search-ui/src/results/sidebar/SearchReference.tsx
+++ b/client/search-ui/src/results/sidebar/SearchReference.tsx
@@ -225,7 +225,8 @@ To use this filter, the search query must contain \`type:diff\` or \`type:commit
     {
         ...createQueryExampleFromString('has({key:value})'),
         field: FilterType.repo,
-        description: 'Search inside repositories associated with a key:value pair that matches the provided key:value pair.',
+        description:
+            'Search inside repositories associated with a key:value pair that matches the provided key:value pair.',
         examples: ['repo:has(owner:jordan)', '-repo:has(team:search)'],
         showSuggestions: false,
     },

--- a/client/search-ui/src/results/sidebar/SearchReference.tsx
+++ b/client/search-ui/src/results/sidebar/SearchReference.tsx
@@ -216,6 +216,20 @@ To use this filter, the search query must contain \`type:diff\` or \`type:commit
         showSuggestions: false,
     },
     {
+        ...createQueryExampleFromString('has.tag({any string})'),
+        field: FilterType.repo,
+        description: 'Search inside repositories that are tagged with the provided string.',
+        examples: ['repo:has.tag(ocaml)', '-repo:has.tag(golang)'],
+        showSuggestions: false,
+    },
+    {
+        ...createQueryExampleFromString('has({key:value})'),
+        field: FilterType.repo,
+        description: 'Search inside repositories associated with a key:value pair that matches the provided key:value pair.',
+        examples: ['repo:has(owner:jordan)', '-repo:has(team:search)'],
+        showSuggestions: false,
+    },
+    {
         ...createQueryExampleFromString('{revision}'),
         field: FilterType.rev,
         commonRank: 20,

--- a/client/shared/src/search/query/completion.test.ts
+++ b/client/shared/src/search/query/completion.test.ts
@@ -383,6 +383,8 @@ describe('getCompletionItems()', () => {
               "has.file(path:\${1:CHANGELOG} content:\${2:fix}) ",
               "has.commit.after(\${1:1 month ago}) ",
               "has.description(\${1}) ",
+              "has.tag(\${1}) ",
+              "has(\${1:key}:\${2:value}) ",
               "^repo/with\\\\ a\\\\ space$ "
             ]
         `)
@@ -404,7 +406,9 @@ describe('getCompletionItems()', () => {
               "has.content(\${1:TODO}) ",
               "has.file(path:\${1:CHANGELOG} content:\${2:fix}) ",
               "has.commit.after(\${1:1 month ago}) ",
-              "has.description(\${1}) "
+              "has.description(\${1}) ",
+              "has.tag(\${1}) ",
+              "has(\${1:key}:\${2:value}) "
             ]
         `)
     })

--- a/client/shared/src/search/query/hover.test.ts
+++ b/client/shared/src/search/query/hover.test.ts
@@ -745,6 +745,27 @@ test('returns repo:has.commit.after hovers', () => {
     `)
 })
 
+test('returns repo:has.tag hovers', () => {
+    const input = 'repo:has.tag(tag)'
+    const scannedQuery = toSuccess(scanSearchQuery(input, false, SearchPatternType.standard))
+
+    expect(getHoverResult(scannedQuery, new Position(1, 8), editor.createModel(input))).toMatchInlineSnapshot(`
+        {
+          "contents": [
+            {
+              "value": "**Built-in predicate**. Search only inside repositories that are tagged with the given tag"
+            }
+          ],
+          "range": {
+            "startLineNumber": 1,
+            "endLineNumber": 1,
+            "startColumn": 6,
+            "endColumn": 18
+          }
+        }
+    `)
+})
+
 test('returns multiline hovers', () => {
     const input = `repo:contains.file(
       path:foo

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -172,6 +172,10 @@ const toPredicateHover = (token: MetaPredicate): string => {
             return `**Built-in predicate**. Search only inside repositories that have been committed to since \`${parameters}\`.`
         case 'has.description':
             return '**Built-in predicate**. Search only inside repositories that have a **description** matching the given regular expression'
+        case 'has.tag':
+            return '**Built-in predicate**. Search only inside repositories that are tagged with the given tag'
+        case 'has':
+            return '**Built-in predicate**. Search only inside repositories that are associated with the given key:value pair'
     }
     return ''
 }

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -198,6 +198,16 @@ export const predicateCompletion = (field: string): Completion[] => {
                 insertText: 'has.description(${1})',
                 asSnippet: true,
             },
+            {
+                label: 'has.tag(...)',
+                insertText: 'has.tag(${1})',
+                asSnippet: true,
+            },
+            {
+                label: 'has(...)',
+                insertText: 'has(${1:key}:${2:value})',
+                asSnippet: true,
+            },
         ]
     }
     return []


### PR DESCRIPTION
I added highlighting for `repo:has(key:value)` and `repo:has.tag()`, but missed hovers, completion, and sidebar docs. This fixes that. 

## Test plan

Updated unit tests, manually tested. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cc-repo-metadata-query-bar.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qjhemaakvf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
