### PR TITLE
reference panel: use search context if set

### DIFF
--- a/client/shared/src/codeintel/legacy-extensions/api.ts
+++ b/client/shared/src/codeintel/legacy-extensions/api.ts
@@ -970,7 +970,6 @@ export interface Range {
 // on a tight deadline so we decided not to do this refactoring during the
 // initial migration.
 let context: CodeIntelContext | undefined
-let _searchContext: string | undefined
 
 export function requestGraphQL<T>(query: string, vars?: { [name: string]: unknown }): Promise<GraphQLResult<T>> {
     if (!context) {
@@ -986,13 +985,6 @@ export function requestGraphQL<T>(query: string, vars?: { [name: string]: unknow
             .requestGraphQL<T, any>({ request: query, variables: vars as any, mightContainPrivateInfo: true })
             .toPromise()
     )
-}
-
-export function setCodeIntelSearchContext(newSearchContext: string | undefined): void {
-    _searchContext = newSearchContext
-}
-export function searchContext(): string | undefined {
-    return _searchContext
 }
 
 export function getSetting<T>(key: string): T | undefined {

--- a/client/shared/src/codeintel/legacy-extensions/util/api.ts
+++ b/client/shared/src/codeintel/legacy-extensions/util/api.ts
@@ -1,6 +1,7 @@
 import { once } from 'lodash'
 import gql from 'tagged-template-noop'
 
+import { searchContext } from '../../searchContext'
 import * as sourcegraph from '../api'
 import { cache } from '../util'
 
@@ -524,8 +525,8 @@ export class API {
      * @param fileLocal Set to false to not request this field, which is absent in older versions of Sourcegraph.
      */
     public async search(searchQuery: string, fileLocal = true): Promise<SearchResult[]> {
-        const searchContext = sourcegraph.searchContext()
-        const query = searchContext ? `context:${searchContext} ${searchQuery}` : searchQuery
+        const context = searchContext()
+        const query = context ? `context:${context} ${searchQuery}` : searchQuery
 
         interface Response {
             search: {

--- a/client/shared/src/codeintel/searchContext.ts
+++ b/client/shared/src/codeintel/searchContext.ts
@@ -1,0 +1,16 @@
+// NOTE(2022-09-08) We store global state at the module level because that was
+// the easiest way to inline sourcegraph/code-intel-extensions into the main
+// repository. The old extension code imported from the npm package
+// 'sourcegraph' and it would have required a large refactoring to pass around
+// the state for all methods. It would be nice to refactor the code one day to
+// avoid storing state at the module level, but we had to deprecate extensions
+// on a tight deadline so we decided not to do this refactoring during the
+// initial migration.
+let _searchContext: string | undefined
+export function setCodeIntelSearchContext(newSearchContext: string | undefined): void {
+    _searchContext = newSearchContext
+}
+
+export function searchContext(): string | undefined {
+    return _searchContext
+}

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -32,7 +32,7 @@ import { getEnabledExtensions } from '@sourcegraph/shared/src/api/client/enabled
 import { preloadExtensions } from '@sourcegraph/shared/src/api/client/preload'
 import { NotificationType } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
 import { fetchHighlightedFileLineRanges } from '@sourcegraph/shared/src/backend/file'
-import { setCodeIntelSearchContext } from '@sourcegraph/shared/src/codeintel/legacy-extensions/api'
+import { setCodeIntelSearchContext } from '@sourcegraph/shared/src/codeintel/searchContext'
 import { Controller as ExtensionsController } from '@sourcegraph/shared/src/extensions/controller'
 import { createController as createExtensionsController } from '@sourcegraph/shared/src/extensions/createLazyLoadedController'
 import { createNoopController } from '@sourcegraph/shared/src/extensions/createNoopLoadedController'

--- a/client/web/src/codeintel/useSearchBasedCodeIntel.ts
+++ b/client/web/src/codeintel/useSearchBasedCodeIntel.ts
@@ -27,6 +27,7 @@ import {
 import { SettingsGetter } from './settings'
 import { sortByProximity } from './sort'
 import { isDefined } from './util/helpers'
+import { searchContext } from '@sourcegraph/shared/src/codeintel/legacy-extensions/api'
 
 type LocationHandler = (locations: Location[]) => void
 
@@ -318,6 +319,11 @@ async function searchAndFilterReferences({
 }
 
 async function executeSearchQuery(terms: string[]): Promise<SearchResult[]> {
+    const context = searchContext()
+    if (context) {
+        terms.push(`context:${context}`)
+    }
+
     interface Response {
         search: {
             results: {
@@ -326,6 +332,7 @@ async function executeSearchQuery(terms: string[]): Promise<SearchResult[]> {
             }
         }
     }
+
     const client = await getWebGraphQLClient()
     const result = await client.query<Response, CodeIntelSearch2Variables>({
         query: getDocumentNode(CODE_INTEL_SEARCH_QUERY),

--- a/client/web/src/codeintel/useSearchBasedCodeIntel.ts
+++ b/client/web/src/codeintel/useSearchBasedCodeIntel.ts
@@ -8,6 +8,7 @@ import { createAggregateError, ErrorLike } from '@sourcegraph/common'
 import { Range as ExtensionRange, Position as ExtensionPosition } from '@sourcegraph/extension-api-types'
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { LanguageSpec } from '@sourcegraph/shared/src/codeintel/legacy-extensions/language-specs/language-spec'
+import { searchContext } from '@sourcegraph/shared/src/codeintel/searchContext'
 import { toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
 
 import { getWebGraphQLClient } from '../backend/graphql'
@@ -27,7 +28,6 @@ import {
 import { SettingsGetter } from './settings'
 import { sortByProximity } from './sort'
 import { isDefined } from './util/helpers'
-import { searchContext } from '@sourcegraph/shared/src/codeintel/legacy-extensions/api'
 
 type LocationHandler = (locations: Location[]) => void
 


### PR DESCRIPTION
Slack thread with context: https://sourcegraph.slack.com/archives/CHXHX7XAS/p1659571561078019

Long story short: the extensions-based reference panel took the searchContext of a user into account when executing search queries for search-based code intel. See [this bit of code here](https://sourcegraph.com/github.com/sourcegraph/code-intel-extensions@ef4bbe5ff954be401c04e083f4063f6320ca5939/-/blob/template/src/util/api.ts?L527:15)

When building the new reference panel I forgot to port this over.

This now ports the behavior by using the helpers added to `legacy-extensions` when porting the old extensions code over.

## Video to demonstrate how it works

https://user-images.githubusercontent.com/1185253/194897972-2bffc0fa-e927-4423-8306-2902c9d6530c.mp4

## Test plan

Tested locally with and without search context.

## App preview:

- [Web](https://sg-web-mrn-search-context-ref-panel.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-rfxtcqhvuq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
