### PR TITLE
Disable eslint autofix on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -51,7 +51,6 @@
   "eslint.lintTask.enable": false,
   "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
   },
   "eslint.codeActionsOnSave.mode": "problems",
   "eslint.options": { "cache": true },


### PR DESCRIPTION
I am really unhappy with the current state of our frontend VS Code setup and it seems [others are too](https://sourcegraph.slack.com/archives/C01C3NCGD40/p1659431879407129). Whenever I save a file in VS Code, it takes a couple of seconds, sometimes even much longer depending on how many files I have open, to prettify the code and save the file. Most of the time is spent in eslint's autofix implementaiton.

The worst part is that a user config can not override a workspace config so the only workaround I have at the moment is to disable the `eslint` VS Code extension which of course removes all linter warnings in the editor, something I don't want either.

Take a look at this example. This is after a fresh VS Code restart and all I do is save the file. Notice how long it takes to run the eslint step:

https://user-images.githubusercontent.com/458591/194905685-e413b926-9509-486f-ba81-519ca97186ca.mov

I propose that we remove this default to improve the feedback cycle. People who want to enable this feature can still do this using user-level config files.

If you have auto-fixeable errors in a file, you can still use the VS Code command to fix them for you:

![Screenshot 2022-10-10 at 17 59 37](https://user-images.githubusercontent.com/458591/194907956-3708a9dc-7345-451d-8f70-0f574dcec01d.png)


## What is the impact?

I would argue that the impact of this change is rather small. There are already linter issues that are not auto-fixable that can stay unnoticed until the change hits CI. With this change, our autofixeable rules (and I am mainly looking at the import ordering?) would behave the same way now.

If there are shared concerns that this could slow us down because we push more invalid code to our CI servers, I suggest we look into setting up [husky](https://typicode.github.io/husky/#/) and force linter checks to pass in a pre-commit hook instead. This would only happen once per logical change and already be a great improvement to the current workflow.

## Test plan

I can haz instant save.

https://user-images.githubusercontent.com/458591/194906710-8c3970d2-d65d-4dd5-8763-dab0c3e4de24.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
