### PR TITLE
Move the "isDotCom" check back to LogEventList to stop errors from ap…

### DIFF
--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/audit"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -151,6 +152,11 @@ func (s *securityEventLogsStore) LogEvent(ctx context.Context, e *SecurityEvent)
 }
 
 func (s *securityEventLogsStore) LogEventList(ctx context.Context, events []*SecurityEvent) {
+	// TODO: removing this causes local errors, will be tackled soon
+	if !envvar.SourcegraphDotComMode() {
+		return
+	}
+
 	if err := s.InsertList(ctx, events); err != nil {
 		names := make([]string, len(events))
 		for i, e := range events {


### PR DESCRIPTION
### Description

Hotfix - roll back a [code change](https://github.com/sourcegraph/sourcegraph/pull/42653/files/c4bb345afeb066498cb66b9752e316d963747788#diff-1585167609de38a192596ab11cbc14fed85262279f78da1101a3ce48ec8e2c69L120) that has caused a bunch of errors appearing locally.

<img width="633" alt="screenshot_2022-10-10_17 19 48@2x" src="https://user-images.githubusercontent.com/3193149/194909197-32f00877-e3da-4d0c-ac57-65639e1ee60f.png">


## Test plan

The tests must pass.