### PR TITLE
insights: add real search code to series based backfilling

### DIFF
--- a/enterprise/internal/insights/pipeline/backfill.go
+++ b/enterprise/internal/insights/pipeline/backfill.go
@@ -239,12 +239,16 @@ func makeRunSearchFunc(logger log.Logger, searchHandlers map[types.GenerationMet
 					return err
 				}
 				mu.Lock()
+				defer mu.Unlock()
 				points = append(points, searchPoints...)
-				mu.Unlock()
 				return nil
 			})
 		}
 		err := g.Wait()
+		// don't return any points if they don't all succeed
+		if err != nil {
+			points = nil
+		}
 		return ctx, reqContext, points, err
 	}
 }

--- a/enterprise/internal/insights/pipeline/backfill.go
+++ b/enterprise/internal/insights/pipeline/backfill.go
@@ -50,7 +50,7 @@ func NewBackfiller(jobGenerator SearchJobGenerator, searchRunner SearchRunner, r
 		searchJobGenerator: jobGenerator,
 		searchRunner:       searchRunner,
 		persister:          resultsPersister,
-		logger:             log.Scoped("insights_backfill_pipeline", ""),
+		logger:             log.Scoped("insightsBackfiller", ""),
 	}
 
 }
@@ -121,6 +121,9 @@ func makeSearchJobsFunc(logger log.Logger, commitClient gitCommitClient, compres
 			})
 		}
 		err = g.Wait()
+		if err != nil {
+			jobs = nil
+		}
 		return ctx, &reqContext, jobs, err
 	}
 }

--- a/enterprise/internal/insights/pipeline/backfill.go
+++ b/enterprise/internal/insights/pipeline/backfill.go
@@ -98,11 +98,17 @@ func makeSearchJobsFunc(logger log.Logger, commitClient gitCommitClient, compres
 
 		searchPlan := compressionPlan.FilterFrames(ctx, frames, req.Repo.ID)
 
-		workerFunc := func(queryExecution *compression.QueryExecution, mu *sync.Mutex) func(ctx context.Context) error {
-			return func(ctx context.Context) error {
+		mu := &sync.Mutex{}
+
+		groupContext, groupCancel := context.WithCancel(ctx)
+		defer groupCancel()
+		g := group.New().WithContext(groupContext).WithMaxConcurrency(searchJobWorkerLimit).WithCancelOnError()
+		for i := len(searchPlan.Executions) - 1; i >= 0; i-- {
+			execution := searchPlan.Executions[i]
+			g.Go(func(ctx context.Context) error {
 				// Build historical data for this unique timeframe+repo+series.
 				err, job, _ := buildJob(ctx, &buildSeriesContext{
-					execution:       queryExecution,
+					execution:       execution,
 					repoName:        req.Repo.Name,
 					id:              req.Repo.ID,
 					firstHEADCommit: firstHEADCommit,
@@ -115,20 +121,7 @@ func makeSearchJobsFunc(logger log.Logger, commitClient gitCommitClient, compres
 					jobs = append(jobs, job)
 				}
 				return err
-			}
-		}
-
-		mu := &sync.Mutex{}
-		groupContext, groupCancel := context.WithCancel(ctx)
-		defer groupCancel()
-		g := group.New().WithContext(groupContext).WithMaxConcurrency(searchJobWorkerLimit).WithCancelOnError()
-		for i := len(searchPlan.Executions) - 1; i >= 0; i-- {
-			execution := searchPlan.Executions[i]
-			if execution != nil {
-				f := workerFunc(execution, mu)
-				g.Go(f)
-			}
-
+			})
 		}
 		err = g.Wait()
 		if err != nil {

--- a/enterprise/internal/insights/pipeline/backfill_test.go
+++ b/enterprise/internal/insights/pipeline/backfill_test.go
@@ -42,7 +42,7 @@ func makeJobGenerator(numJobs int) SearchJobGenerator {
 
 func searchRunner(ctx context.Context, reqContext *requestContext, jobs []*queryrunner.Job, err error) (context.Context, *requestContext, []store.RecordSeriesPointArgs, error) {
 	points := make([]store.RecordSeriesPointArgs, 0, len(jobs))
-	for _, _ = range jobs {
+	for range jobs {
 		points = append(points, store.RecordSeriesPointArgs{Point: store.SeriesPoint{Value: 10}})
 	}
 	return ctx, reqContext, points, nil

--- a/enterprise/internal/insights/pipeline/backfill_test.go
+++ b/enterprise/internal/insights/pipeline/backfill_test.go
@@ -33,7 +33,7 @@ func makeJobGenerator(numJobs int) SearchJobGenerator {
 		for i := 0; i < numJobs; i++ {
 			jobs = append(jobs, &queryrunner.Job{
 				SeriesID:    req.backfillRequest.Series.SeriesID,
-				SearchQuery: fmt.Sprintf("%d", i),
+				SearchQuery: "test search",
 			})
 		}
 		return ctx, &req, jobs, nil

--- a/enterprise/internal/insights/pipeline/backfill_test.go
+++ b/enterprise/internal/insights/pipeline/backfill_test.go
@@ -122,6 +122,19 @@ func TestMakeSearchJobs(t *testing.T) {
 		},
 		Repo: &itypes.MinimalRepo{ID: api.RepoID(1), Name: api.RepoName("testrepo")},
 	}
+
+	backfillReqInvalidQuery := &BackfillRequest{
+		Series: &types.InsightSeries{
+			ID:                  1,
+			SeriesID:            "abc",
+			Query:               "patterntype:regexp i++",
+			CreatedAt:           createdDate,
+			SampleIntervalUnit:  string(types.Week),
+			SampleIntervalValue: 1,
+		},
+		Repo: &itypes.MinimalRepo{ID: api.RepoID(1), Name: api.RepoName("testrepo")},
+	}
+
 	basicCommitClient := newFakeCommitClient(&firstCommit, recentCommits)
 	// used to simulate a single call to recent commits failing
 	recentsErrorAfter := func(times int, commits []*gitdomain.Commit) func(ctx context.Context, repoName api.RepoName, target time.Time) ([]*gitdomain.Commit, error) {
@@ -211,6 +224,7 @@ func TestMakeSearchJobs(t *testing.T) {
 			firstCommit:   basicCommitClient.FirstCommit,
 			recentCommits: recentsErrorAfter(6, recentCommits),
 		}, backfillReq: backfillReq, workers: 5, want: autogold.Want("Error in some jobs multiple worker", []string{"error occured: true"})},
+		{commitClient: basicCommitClient, backfillReq: backfillReqInvalidQuery, workers: 1, want: autogold.Want("Invalid query", []string{"error occured: true"})},
 	}
 
 	for _, tc := range testCases {

--- a/enterprise/internal/insights/pipeline/backfill_test.go
+++ b/enterprise/internal/insights/pipeline/backfill_test.go
@@ -3,13 +3,23 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/hexops/autogold"
 
+	"github.com/sourcegraph/log/logtest"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background/queryrunner"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/compression"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+	itypes "github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // type SearchJobGenerator func(ctx context.Context, req requestContext) (context.Context, *requestContext, []*queryrunner.Job, error)
@@ -54,17 +64,154 @@ func TestBackfillStepsConnected(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		got := runCounts{}
-		countingPersister := func(ctx context.Context, reqContext *requestContext, points []store.RecordSeriesPointArgs, err error) (*requestContext, error) {
-			for _, p := range points {
-				got.resultCount++
-				got.totalCount += int(p.Point.Value)
+		t.Run(tc.want.Name(), func(t *testing.T) {
+			got := runCounts{}
+			countingPersister := func(ctx context.Context, reqContext *requestContext, points []store.RecordSeriesPointArgs, err error) (*requestContext, error) {
+				for _, p := range points {
+					got.resultCount++
+					got.totalCount += int(p.Point.Value)
+				}
+				return reqContext, nil
 			}
-			return reqContext, nil
-		}
 
-		backfiller := NewBackfiller(makeJobGenerator(tc.numJobs), searchRunner, countingPersister)
-		got.err = backfiller.Run(context.Background(), BackfillRequest{Series: &types.InsightSeries{SeriesID: "1"}})
-		tc.want.Equal(t, got)
+			backfiller := NewBackfiller(makeJobGenerator(tc.numJobs), searchRunner, countingPersister)
+			got.err = backfiller.Run(context.Background(), BackfillRequest{Series: &types.InsightSeries{SeriesID: "1"}})
+			tc.want.Equal(t, got)
+		})
 	}
+}
+
+type fakeCommitClient struct {
+	firstCommit   func(ctx context.Context, repoName api.RepoName) (*gitdomain.Commit, error)
+	recentCommits func(ctx context.Context, repoName api.RepoName, target time.Time) ([]*gitdomain.Commit, error)
+}
+
+func (f *fakeCommitClient) FirstCommit(ctx context.Context, repoName api.RepoName) (*gitdomain.Commit, error) {
+	return f.firstCommit(ctx, repoName)
+}
+func (f *fakeCommitClient) RecentCommits(ctx context.Context, repoName api.RepoName, target time.Time) ([]*gitdomain.Commit, error) {
+	return f.recentCommits(ctx, repoName, target)
+}
+
+func newFakeCommitClient(first *gitdomain.Commit, recents []*gitdomain.Commit) gitCommitClient {
+	return &fakeCommitClient{
+		firstCommit: func(ctx context.Context, repoName api.RepoName) (*gitdomain.Commit, error) { return first, nil },
+		recentCommits: func(ctx context.Context, repoName api.RepoName, target time.Time) ([]*gitdomain.Commit, error) {
+			return recents, nil
+		},
+	}
+}
+
+func TestMakeSearchJobs(t *testing.T) {
+	// Setup
+	firstCommit := gitdomain.Commit{ID: "1", Committer: &gitdomain.Signature{}}
+	recentCommits := []*gitdomain.Commit{{ID: "1", Committer: &gitdomain.Signature{}}, {ID: "2", Committer: &gitdomain.Signature{}}}
+	createdDate := time.Date(2022, time.April, 1, 1, 0, 0, 0, time.UTC)
+	backfillReq := &BackfillRequest{
+		Series: &types.InsightSeries{
+			ID:                  1,
+			SeriesID:            "abc",
+			Query:               "test query",
+			CreatedAt:           createdDate,
+			SampleIntervalUnit:  string(types.Month),
+			SampleIntervalValue: 1,
+		},
+		Repo: &itypes.MinimalRepo{ID: api.RepoID(1), Name: api.RepoName("testrepo")},
+	}
+	basicCommitClient := newFakeCommitClient(&firstCommit, recentCommits)
+	// used to simulate a single call to recent commits failing
+	recentsErrorAfter := func(times int, commits []*gitdomain.Commit) func(ctx context.Context, repoName api.RepoName, target time.Time) ([]*gitdomain.Commit, error) {
+		var called *int
+		called = new(int)
+		var mu sync.Mutex
+		return func(ctx context.Context, repoName api.RepoName, target time.Time) ([]*gitdomain.Commit, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			if *called >= times {
+				return nil, errors.New("error hit")
+			}
+			*called++
+			return commits, nil
+		}
+	}
+
+	testCases := []struct {
+		commitClient gitCommitClient
+		backfillReq  *BackfillRequest
+		workers      int
+		cancled      bool
+		want         autogold.Value
+	}{
+		{commitClient: basicCommitClient, backfillReq: backfillReq, workers: 1,
+			want: autogold.Want("Base case single worker", []string{
+				"job recordtime:2022-03-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2022-02-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2022-01-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2021-12-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2021-11-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2021-10-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2021-09-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2021-08-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2021-07-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2021-06-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2021-05-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"error occured: false",
+			})},
+		{commitClient: basicCommitClient, backfillReq: backfillReq, workers: 5, want: autogold.Want("Base case multiple workers", []string{
+			"job recordtime:2021-11-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2021-10-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2021-12-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2021-11-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2021-11-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2021-09-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2021-08-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2021-06-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2021-05-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2021-11-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2021-06-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"error occured: false",
+		})},
+		{commitClient: basicCommitClient, backfillReq: backfillReq, workers: 1, cancled: true, want: autogold.Want("Cancled case single worker", []string{"error occured: true"})},
+		{commitClient: basicCommitClient, backfillReq: backfillReq, workers: 5, cancled: true, want: autogold.Want("Cancled case multiple workers", []string{"error occured: true"})},
+		{commitClient: &fakeCommitClient{
+			firstCommit: func(ctx context.Context, repoName api.RepoName) (*gitdomain.Commit, error) {
+				return nil, errors.New("somethings wrong")
+			},
+			recentCommits: basicCommitClient.RecentCommits,
+		}, backfillReq: backfillReq, workers: 1, want: autogold.Want("First commit error", []string{"error occured: true"})},
+		{commitClient: &fakeCommitClient{
+			firstCommit: func(ctx context.Context, repoName api.RepoName) (*gitdomain.Commit, error) {
+				return nil, discovery.EmptyRepoErr
+			},
+			recentCommits: basicCommitClient.RecentCommits,
+		}, backfillReq: backfillReq, workers: 1, want: autogold.Want("Empty repo", []string{"error occured: false"})},
+		{commitClient: &fakeCommitClient{
+			firstCommit:   basicCommitClient.FirstCommit,
+			recentCommits: recentsErrorAfter(6, recentCommits),
+		}, backfillReq: backfillReq, workers: 1, want: autogold.Want("Error in some jobs single worker", []string{"error occured: true"})},
+		{commitClient: &fakeCommitClient{
+			firstCommit:   basicCommitClient.FirstCommit,
+			recentCommits: recentsErrorAfter(6, recentCommits),
+		}, backfillReq: backfillReq, workers: 5, want: autogold.Want("Error in some jobs multiple worker", []string{"error occured: true"})},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.want.Name(), func(t *testing.T) {
+			testCtx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tc.cancled {
+				cancel()
+			}
+			jobsFunc := makeSearchJobsFunc(logtest.NoOp(t), tc.commitClient, &compression.NoopFilter{}, tc.workers)
+			_, _, jobs, err := jobsFunc(testCtx, requestContext{backfillRequest: tc.backfillReq})
+
+			got := []string{}
+			for _, j := range jobs {
+				got = append(got, fmt.Sprintf("job recordtime:%s query:%s", j.RecordTime.Format(time.RFC3339Nano), j.SearchQuery))
+			}
+			got = append(got, fmt.Sprintf("error occured: %v", err != nil))
+			tc.want.Equal(t, got)
+		})
+	}
+
 }

--- a/enterprise/internal/insights/pipeline/readme.md
+++ b/enterprise/internal/insights/pipeline/readme.md
@@ -3,17 +3,31 @@ This is an exploration into reimagining what the backfilling or potentially even
 Below is a diagram to explain the flow this approach takes.
 
 ```mermaid
-graph TD
-
-subgraph worker
-  Poll[Poll jobs] --> |New work found| RunBackfiller[Run Backfiller]
-end
+flowchart TB
 
 subgraph backfiller
-  GenSearchJobs[Build Search Jobs] --> RunSearch[Search Runner]
-  RunSearch --> SaveResults[Save Points]
+
+subgraph BuildSearchJob[Build Search Jobs]
+  GetTimeIntervals[Get Time Intervals] --> CompressTimeIntervals[Run Compression]
+  subgraph FindRevisionBuildSearch[Find revision & build search job]
+    Worker1[Worker 1]
+    Workern[Worker n]
+  end
+  CompressTimeIntervals --> FindRevisionBuildSearch
 end
 
-RunBackfiller -->|Request backfill for series and repo| GenSearchJobs
-SaveResults --> |Update results| RunBackfiller
+
+
+subgraph RunSearchJobs[Run Search Jobs]
+  subgraph SearchRunners[Search Runners]
+    SearchWorker1[Worker 1]
+    SearchWorkern[Worker n]
+  end
+end
+
+FindRevisionBuildSearch --> RunSearchJobs
+RunSearchJobs --> SaveResults[Save Results]
+
+end
+
 ```


### PR DESCRIPTION
Adds real code to execute the search jobs.

Also refactored the steps to avoid channels to make error handling easier.  This now ensures that each steps succeeds/fails before moving on to the next step.  This gives up a little speed that could be achieved by starting searching as soon as we know the first search, but makes handling errors much simpler.

This passes along a request context to each step.  I used to to give access to the original series def.  I think there will also be additional things we want to accumulate as we go, such as some statistics and we can add those types of things to it.

Added tests for first step of creating search jobs for a series + repo.  More tests to come as part of https://github.com/sourcegraph/sourcegraph/issues/42463

closes https://github.com/sourcegraph/sourcegraph/issues/42426

## Test plan
unit tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
