### PR TITLE
search ui: show case toggle when smart search is enabled

### DIFF
--- a/client/search-ui/src/input/toggles/Toggles.tsx
+++ b/client/search-ui/src/input/toggles/Toggles.tsx
@@ -136,35 +136,33 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
     return (
         <div className={classNames(className, styles.toggleContainer)}>
             <>
-                {/* Hide the other toggles if lucky search is enabled */}
+                <QueryInputToggle
+                    title="Case sensitivity"
+                    isActive={caseSensitive}
+                    onToggle={toggleCaseSensitivity}
+                    iconSvgPath={mdiFormatLetterCase}
+                    interactive={props.interactive}
+                    className="test-case-sensitivity-toggle"
+                    disableOn={[
+                        {
+                            condition: findFilter(navbarSearchQuery, 'case', FilterKind.Subexpression) !== undefined,
+                            reason: 'Query already contains one or more case subexpressions',
+                        },
+                        {
+                            condition:
+                                findFilter(navbarSearchQuery, 'patterntype', FilterKind.Subexpression) !== undefined,
+                            reason:
+                                'Query contains one or more patterntype subexpressions, cannot apply global case-sensitivity',
+                        },
+                        {
+                            condition: patternType === SearchPatternType.structural,
+                            reason: 'Structural search is always case sensitive',
+                        },
+                    ]}
+                />
+                {/* Hide regex and structural search toggles if lucky search is enabled */}
                 {(!showSmartSearch || patternType !== SearchPatternType.lucky) && (
                     <>
-                        <QueryInputToggle
-                            title="Case sensitivity"
-                            isActive={caseSensitive}
-                            onToggle={toggleCaseSensitivity}
-                            iconSvgPath={mdiFormatLetterCase}
-                            interactive={props.interactive}
-                            className="test-case-sensitivity-toggle"
-                            disableOn={[
-                                {
-                                    condition:
-                                        findFilter(navbarSearchQuery, 'case', FilterKind.Subexpression) !== undefined,
-                                    reason: 'Query already contains one or more case subexpressions',
-                                },
-                                {
-                                    condition:
-                                        findFilter(navbarSearchQuery, 'patterntype', FilterKind.Subexpression) !==
-                                        undefined,
-                                    reason:
-                                        'Query contains one or more patterntype subexpressions, cannot apply global case-sensitivity',
-                                },
-                                {
-                                    condition: patternType === SearchPatternType.structural,
-                                    reason: 'Structural search is always case sensitive',
-                                },
-                            ]}
-                        />
                         <QueryInputToggle
                             title="Regular expression"
                             isActive={patternType === SearchPatternType.regexp}
@@ -199,9 +197,9 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
                                 ]}
                             />
                         )}
-                        {(showSmartSearch || showCopyQueryButton) && <div className={styles.separator} />}
                     </>
                 )}
+                {(showSmartSearch || showCopyQueryButton) && <div className={styles.separator} />}
                 {showSmartSearch && (
                     <SmartSearchToggle
                         className="test-smart-search-toggle"


### PR DESCRIPTION
Shows case toggle when smart search is enabled. This enables two things:

- User learns more easily that case-sensitive search is available, since the toggle isn't hidden anymore
- Allows running case-sensitive smart searches

![image](https://user-images.githubusercontent.com/206864/194952161-c87d2b1c-9d3d-439f-911b-0b179a8c80f2.png)
![image](https://user-images.githubusercontent.com/206864/194952195-693098d8-fc6d-4529-9d2b-223a3e7d455f.png)


## Test plan

- Verify case toggle is shown and works when smart search is enabled
- Verify that structural and regex toggles are still hidden/shown when smart search is enabled/disabled

## App preview:

- [Web](https://sg-web-jp-luckycasesensitive.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vqavgducur.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
