### PR TITLE
search ui: better align smart search collapse icon

### DIFF
--- a/client/web/src/search/suggestion/QuerySuggestion.module.scss
+++ b/client/web/src/search/suggestion/QuerySuggestion.module.scss
@@ -20,6 +20,7 @@
     font-size: 0.75rem;
     text-align: left;
     display: flex;
+    align-items: baseline;
     justify-content: space-between;
     color: var(--body-color);
     background-color: var(--color-bg-2);

--- a/client/web/src/search/suggestion/SmartSearch.tsx
+++ b/client/web/src/search/suggestion/SmartSearch.tsx
@@ -108,7 +108,7 @@ export const SmartSearch: React.FunctionComponent<React.PropsWithChildren<SmartS
                                 </span>
                             </span>
                         </span>
-                        <span className="d-flex align-items-baseline flex-shrink-0 ml-2">
+                        <span className="d-flex align-items-center flex-shrink-0 ml-2">
                             {isCollapsed ? (
                                 <>
                                     <span className="text-muted mr-2 flex-shrink-0">Show queries</span>


### PR DESCRIPTION
Expand/collapse chevron in the smart search box was slightly missaligned.

## Test plan

Before:
![image](https://user-images.githubusercontent.com/206864/194953710-51b857b5-f8cf-4d48-ad3a-9285ee0df1e5.png)
After:
![image](https://user-images.githubusercontent.com/206864/194953733-3c20e623-6581-4dee-b8ad-18e1cc2c41e7.png)

## App preview:

- [Web](https://sg-web-jp-smartsearchcollapsealign.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qxwrbwwltb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
