### PR TITLE
web: fix `<Menu />` in Safari 16 by preventing item blur event from bubbling

### DIFF
--- a/client/wildcard/src/components/Menu/MenuItem.tsx
+++ b/client/wildcard/src/components/Menu/MenuItem.tsx
@@ -18,11 +18,19 @@ export type MenuItemProps = ReachMenuItemProps
  *
  * @see — Docs https://reach.tech/menu-button#menuitem
  */
-export const MenuItem = React.forwardRef(({ children, className, disabled, ...props }, reference) => {
+export const MenuItem = React.forwardRef(function MenuItem({ children, className, disabled, ...props }, reference) {
     const Component = disabled ? MenuDisabledItem : ReachMenuItem
 
     return (
-        <Component ref={reference} {...props} className={classNames(styles.dropdownItem, className)}>
+        <Component
+            ref={reference}
+            {...props}
+            // NOTE: In Safari 16.0+, the onBlur event bubbling up to the MenuButton
+            // prevents the menu from opening properly. We prevent this event from
+            // bubbling up as ReachUI is managing focus state for us internally.
+            onBlur={event => event.stopPropagation()}
+            className={classNames(styles.dropdownItem, className)}
+        >
             {children}
         </Component>
     )

--- a/client/wildcard/src/components/Menu/MenuLink.tsx
+++ b/client/wildcard/src/components/Menu/MenuLink.tsx
@@ -19,8 +19,18 @@ export type MenuLinkProps = ReachMenuLinkProps
  *
  * @see — Docs https://reach.tech/menu-button#menulink
  */
-export const MenuLink = React.forwardRef(({ className, disabled, ...props }, reference) => {
+export const MenuLink = React.forwardRef(function MenuLink({ className, disabled, ...props }, reference) {
     const Component = disabled ? MenuDisabledLink : ReachMenuLink
 
-    return <Component ref={reference} {...props} className={classNames(styles.dropdownItem, className)} />
+    return (
+        <Component
+            ref={reference}
+            {...props}
+            // NOTE: In Safari 16.0+, the onBlur event bubbling up to the MenuButton
+            // prevents the menu from opening properly. We prevent this event from
+            // bubbling up as ReachUI is managing focus state for us internally.
+            onBlur={event => event.stopPropagation()}
+            className={classNames(styles.dropdownItem, className)}
+        />
+    )
 }) as ForwardReferenceComponent<'a', MenuLinkProps>


### PR DESCRIPTION
As observed [in Slack](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1665406816465699), menus that rely on the `<Menu />` family of Wildcard components are broken in Safari 16 due to multiple blur events firing when the menu first opens and focus is transferred to the menu popover itself. The behavior has so far exclusively been observed in Safari 16.0 and 16.1. There is evidence that it may be fixed by 16.4, based on the currently available technology preview.

Tested both with keyboard navigation and mouse navigation in Safari 16, Chrome, and Firefox.

Safari | Chrome
:-----:|:-----:
<video src="https://user-images.githubusercontent.com/8942601/194956590-ad3205c9-34ce-4722-89f9-8f5e004ed26f.mov"> | <video src="https://user-images.githubusercontent.com/8942601/194956600-13d9c3d8-c8f3-4182-94d6-06ef6877dba6.mov">

I have filed the follow-up ticket https://github.com/sourcegraph/sourcegraph/issues/42780 to revisit after Safari 16.4 is released.

## Test plan

Fix was manually tested, see recordings above.



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-no-blur-bubble.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vjkyzqpqrf.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
