### PR TITLE
Search: replace errors.Group with lib/group

### DIFF
--- a/internal/search/job/jobutil/combinators.go
+++ b/internal/search/job/jobutil/combinators.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/group"
 )
 
 // NewSequentialJob will create a job that sequentially runs a list of jobs.
@@ -156,12 +157,12 @@ func (p *ParallelJob) Run(ctx context.Context, clients job.RuntimeClients, s str
 	defer func() { finish(alert, err) }()
 
 	var (
-		g          errors.Group
+		g          = group.New().WithContext(ctx)
 		maxAlerter search.MaxAlerter
 	)
 	for _, child := range p.children {
 		child := child
-		g.Go(func() error {
+		g.Go(func(ctx context.Context) error {
 			alert, err := child.Run(ctx, clients, s)
 			maxAlerter.Add(alert)
 			return err


### PR DESCRIPTION
We use `errors.Group` in a couple of places, but that implementation of a goroutine group does not have any panic handlers, so panics that happen in child goroutines will crash the process. This replaces the uses of `errors.Group` in search code with `lib/group`, which will [propagate the panic](https://github.com/sourcegraph/sourcegraph/pull/42679) to the caller of `g.Wait()` rather than crashing the process. 

We have top-level panic handlers that will log those errors in the request middleware.

## Test plan

Backend integration tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
