### PR TITLE
Use temporary settings to track configurable "time saved" analytics fields

### DIFF
--- a/client/shared/src/settings/temporary/TemporarySettings.ts
+++ b/client/shared/src/settings/temporary/TemporarySettings.ts
@@ -45,6 +45,8 @@ export interface TemporarySettingsSchema {
     // TODO #41002: Remove this temporary setting.
     // This temporary setting is now turned on by default with no UI to toggle it off.
     'coreWorkflowImprovements.enabled_deprecated': boolean
+    'batches.minSavedPerChangeset': number
+    'search.notebooks.minSavedPerView': number
 }
 
 /**

--- a/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
@@ -4,11 +4,11 @@ import { mdiInformationOutline } from '@mdi/js'
 import classNames from 'classnames'
 
 import { useQuery } from '@sourcegraph/http-client'
+import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { H3, Icon, LoadingSpinner, Tooltip } from '@sourcegraph/wildcard'
 
 import { GlobalChangesetsStatsResult, GlobalChangesetsStatsVariables } from '../../../graphql-operations'
 import { DEFAULT_MINS_SAVED_PER_CHANGESET } from '../../../site-admin/analytics/AnalyticsBatchChangesPage'
-import { MIN_PER_ITEM_SAVED_KEY } from '../../../site-admin/analytics/components/TimeSavedCalculatorGroup'
 import { ChangesetStatusClosed, ChangesetStatusOpen } from '../detail/changesets/ChangesetStatusCell'
 
 import { GLOBAL_CHANGESETS_STATS } from './backend'
@@ -20,6 +20,10 @@ interface BatchChangeStatsBarProps {
 }
 
 export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildren<BatchChangeStatsBarProps>> = () => {
+    const [minSavedPerChangeset = DEFAULT_MINS_SAVED_PER_CHANGESET] = useTemporarySetting(
+        'batches.minSavedPerChangeset'
+    )
+
     const { data, loading } = useQuery<GlobalChangesetsStatsResult, GlobalChangesetsStatsVariables>(
         GLOBAL_CHANGESETS_STATS,
         {}
@@ -36,9 +40,6 @@ export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildre
         return null
     }
 
-    const numMinPerItemSaved: number =
-        parseInt(localStorage.getItem(MIN_PER_ITEM_SAVED_KEY) || '0', 10) || DEFAULT_MINS_SAVED_PER_CHANGESET
-
     return (
         <div className={classNames(styles.statsBar, 'text-muted')}>
             <div className={styles.leftSide}>
@@ -52,7 +53,7 @@ export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildre
                 </div>
                 <div className="pr-4">
                     <H3 className="font-weight-bold mb-1">
-                        {Math.round((data.globalChangesetsStats.merged * numMinPerItemSaved) / 60).toFixed(2)}
+                        {Math.round((data.globalChangesetsStats.merged * minSavedPerChangeset) / 60).toFixed(2)}
                     </H3>
                     <span>
                         Hours saved

--- a/client/web/src/site-admin/analytics/AnalyticsBatchChangesPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsBatchChangesPage/index.tsx
@@ -11,7 +11,7 @@ import { eventLogger } from '../../../tracking/eventLogger'
 import { AnalyticsPageTitle } from '../components/AnalyticsPageTitle'
 import { ChartContainer } from '../components/ChartContainer'
 import { HorizontalSelect } from '../components/HorizontalSelect'
-import { TimeSavedCalculator } from '../components/TimeSavedCalculatorGroup'
+import { TimeSavedCalculator, TimeSavedCalculatorProps } from '../components/TimeSavedCalculatorGroup'
 import { ValueLegendList, ValueLegendListProps } from '../components/ValueLegendList'
 import { useChartFilters } from '../useChartFilters'
 import { StandardDatum } from '../utils'
@@ -85,15 +85,16 @@ export const AnalyticsBatchChangesPage: React.FunctionComponent<RouteComponentPr
             },
         ]
 
-        const calculatorProps = {
+        const calculatorProps: TimeSavedCalculatorProps = {
             page: 'BatchChanges',
             dateRange: dateRange.value,
             label: 'Changesets merged',
             color: 'var(--cyan)',
             value: changesetsMerged.summary.totalCount,
-            minPerItem: DEFAULT_MINS_SAVED_PER_CHANGESET,
+            defaultMinPerItem: DEFAULT_MINS_SAVED_PER_CHANGESET,
             description:
                 'Batch Changes automates opening changesets across many repositories and codehosts. It also significantly reduces the time required to manage cross-repository changes via tracking and management functions that are superior to custom solutions, spreadsheets and manually reaching out to developers.',
+            temporarySettingsKey: 'batches.minSavedPerChangeset',
         }
 
         return [stats, legends, calculatorProps]

--- a/client/web/src/site-admin/analytics/AnalyticsNotebooksPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsNotebooksPage/index.tsx
@@ -12,7 +12,7 @@ import { eventLogger } from '../../../tracking/eventLogger'
 import { AnalyticsPageTitle } from '../components/AnalyticsPageTitle'
 import { ChartContainer } from '../components/ChartContainer'
 import { HorizontalSelect } from '../components/HorizontalSelect'
-import { TimeSavedCalculator } from '../components/TimeSavedCalculatorGroup'
+import { TimeSavedCalculator, TimeSavedCalculatorProps } from '../components/TimeSavedCalculatorGroup'
 import { ToggleSelect } from '../components/ToggleSelect'
 import { ValueLegendList, ValueLegendListProps } from '../components/ValueLegendList'
 import { useChartFilters } from '../useChartFilters'
@@ -102,15 +102,16 @@ export const AnalyticsNotebooksPage: React.FunctionComponent<RouteComponentProps
             },
         ]
 
-        const calculatorProps = {
+        const calculatorProps: TimeSavedCalculatorProps = {
             page: 'Notebooks',
             label: 'Views',
             color: 'var(--body-color)',
             dateRange: dateRange.value,
             value: views.summary.totalCount,
-            minPerItem: 5,
+            defaultMinPerItem: 5,
             description:
                 'Notebooks reduce the time it takes to create living documentation and share it. Each notebook view accounts for time saved by both creators and consumers of notebooks.',
+            temporarySettingsKey: 'search.notebooks.minSavedPerView',
         }
 
         return [stats, legends, calculatorProps]

--- a/client/web/src/site-admin/analytics/components/TimeSavedCalculatorGroup.tsx
+++ b/client/web/src/site-admin/analytics/components/TimeSavedCalculatorGroup.tsx
@@ -2,6 +2,8 @@ import React, { useMemo, useState, useEffect } from 'react'
 
 import classNames from 'classnames'
 
+import { TemporarySettingsSchema } from '@sourcegraph/shared/src/settings/temporary/TemporarySettings'
+import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { Card, Input, Text, H2 } from '@sourcegraph/wildcard'
 
 import { AnalyticsDateRange } from '../../../graphql-operations'
@@ -250,38 +252,37 @@ export const TimeSavedCalculatorGroup: React.FunctionComponent<TimeSavedCalculat
     )
 }
 
-interface TimeSavedCalculator {
+export interface TimeSavedCalculatorProps {
     page: string
     color: string
     label: string
     value: number
-    minPerItem: number
+    defaultMinPerItem: number
     description: string
     percentage?: number
     dateRange: AnalyticsDateRange
+    temporarySettingsKey: keyof TemporarySettingsSchema
 }
 
-export const TimeSavedCalculator: React.FunctionComponent<TimeSavedCalculator> = ({
+export const TimeSavedCalculator: React.FunctionComponent<TimeSavedCalculatorProps> = ({
     page,
     color,
     label,
     value,
-    minPerItem,
+    defaultMinPerItem,
     description,
     percentage,
     dateRange,
+    temporarySettingsKey,
 }) => {
-    const [minPerItemSaved, setMinPerItemSaved] = useState(minPerItem)
+    const [minPerItemSavedSetting, setMinPerItemSaved] = useTemporarySetting(temporarySettingsKey, defaultMinPerItem)
+    const minPerItemSaved = Number(minPerItemSavedSetting) || defaultMinPerItem
     const [inputChangeLogged, setInputChangeLogged] = useState(false)
     const hoursSaved = useMemo(() => (minPerItemSaved * value * (percentage ?? 100)) / (60 * 100), [
         value,
         minPerItemSaved,
         percentage,
     ])
-
-    useEffect(() => {
-        setMinPerItemSaved(minPerItem)
-    }, [minPerItem])
 
     const projectedHoursSaved = useMemo(() => {
         if (dateRange === AnalyticsDateRange.LAST_WEEK) {


### PR DESCRIPTION

https://user-images.githubusercontent.com/8942601/194971280-dc652bd7-08d8-4f31-bfc5-593515ab04ee.mov


## Test plan

Tested locally. Observed updated temporary settings in the database.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
