### PR TITLE
Change Sourcegraph Cloud to Sourcegraph.com

### DIFF
--- a/client/browser/src/browser-extension/options-menu/OptionsPage.story.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.story.tsx
@@ -90,10 +90,10 @@ export const AllOptionsPages: Story = (args = {}) => (
 
             <div className="d-flex justify-content-center mt-5">
                 <div className="mx-4">
-                    <H3 className="text-center">On Sourcegraph Cloud</H3>
+                    <H3 className="text-center">On Sourcegraph.com</H3>
                     <OptionsPageWrapper
                         requestPermissionsHandler={requestPermissionsHandler}
-                        showSourcegraphCloudAlert={true}
+                        showSourcegraphComAlert={true}
                         sourcegraphUrl={args.sourcegraphUrl}
                         version={args.version}
                     />
@@ -117,7 +117,7 @@ export const AllOptionsPages: Story = (args = {}) => (
                         currentUser={{ settingsURL: '/users/john-doe/settings', siteAdmin: false }}
                         hasRepoSyncError={true}
                         requestPermissionsHandler={requestPermissionsHandler}
-                        showSourcegraphCloudAlert={args.showSourcegraphCloudAlert}
+                        showSourcegraphComAlert={args.showSourcegraphComAlert}
                         version={args.version}
                     />
                 </div>
@@ -152,7 +152,7 @@ AllOptionsPages.argTypes = {
         control: { type: 'text' },
         defaultValue: '0.0.0',
     },
-    showSourcegraphCloudAlert: {
+    showSourcegraphComAlert: {
         control: { type: 'boolean' },
         defaultValue: false,
     },

--- a/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.tsx
@@ -42,7 +42,7 @@ export interface OptionsPageProps {
 
     initialShowAdvancedSettings?: boolean
     isFullPage: boolean
-    showSourcegraphCloudAlert?: boolean
+    showSourcegraphComAlert?: boolean
     permissionAlert?: { name: string; icon?: React.ComponentType<{ className?: string }> }
     requestPermissionsHandler?: React.MouseEventHandler
 
@@ -67,7 +67,7 @@ export const OptionsPage: React.FunctionComponent<React.PropsWithChildren<Option
     onToggleActivated,
     initialShowAdvancedSettings = false,
     isFullPage,
-    showSourcegraphCloudAlert,
+    showSourcegraphComAlert,
     permissionAlert,
     requestPermissionsHandler,
     optionFlags,
@@ -123,7 +123,7 @@ export const OptionsPage: React.FunctionComponent<React.PropsWithChildren<Option
                 <PermissionAlert {...permissionAlert} onClickGrantPermissions={requestPermissionsHandler} />
             )}
 
-            {showSourcegraphCloudAlert && <SourcegraphCloudAlert />}
+            {showSourcegraphComAlert && <SourcegraphComAlert />}
 
             {hasRepoSyncError && currentUser && (
                 <RepoSyncErrorAlert sourcegraphUrl={sourcegraphUrl} currentUser={currentUser} />
@@ -163,7 +163,7 @@ export const OptionsPage: React.FunctionComponent<React.PropsWithChildren<Option
                 <div className={styles.splitSectionPart}>
                     <Link to="https://sourcegraph.com/search" {...NEW_TAB_LINK_PROPS}>
                         <Icon className="mr-2" aria-hidden={true} svgPath={mdiEarth} />
-                        Sourcegraph Cloud
+                        Sourcegraph.com
                     </Link>
                 </div>
                 <div className={styles.splitSectionPart}>
@@ -259,11 +259,11 @@ const RepoSyncErrorAlert: React.FunctionComponent<
     )
 }
 
-const SourcegraphCloudAlert: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
+const SourcegraphComAlert: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <section className={classNames('bg-2', styles.section)}>
         <H4>
             <Icon aria-hidden={true} className="mr-2" svgPath={mdiCheckCircleOutline} />
-            You're on Sourcegraph Cloud
+            You're on Sourcegraph.com
         </H4>
         <Text>Naturally, the browser extension is not necessary to browse public code on sourcegraph.com.</Text>
     </section>

--- a/client/browser/src/browser-extension/scripts/optionsPage.main.tsx
+++ b/client/browser/src/browser-extension/scripts/optionsPage.main.tsx
@@ -196,13 +196,13 @@ const Options: React.FunctionComponent<React.PropsWithChildren<unknown>> = () =>
         ])
     )
 
-    const showSourcegraphCloudAlert = currentTabStatus?.status.host.endsWith('sourcegraph.com')
+    const showSourcegraphComAlert = currentTabStatus?.status.host.endsWith('sourcegraph.com')
 
     let permissionAlert: Optional<KnownCodeHost, 'host' | 'icon'> | undefined
     if (
         currentTabStatus &&
         !currentTabStatus?.status.hasPermissions &&
-        !showSourcegraphCloudAlert &&
+        !showSourcegraphComAlert &&
         !PERMISSIONS_PROTOCOL_BLOCKLIST.has(currentTabStatus.status.protocol)
     ) {
         const knownCodeHost = knownCodeHosts.find(({ host }) => host === currentTabStatus.status.host)
@@ -267,7 +267,7 @@ const Options: React.FunctionComponent<React.PropsWithChildren<unknown>> = () =>
                     onChangeOptionFlag={handleChangeOptionFlag}
                     hasRepoSyncError={currentTabStatus?.status.hasRepoSyncError}
                     currentUser={currentUser}
-                    showSourcegraphCloudAlert={showSourcegraphCloudAlert}
+                    showSourcegraphComAlert={showSourcegraphComAlert}
                     permissionAlert={permissionAlert}
                     requestPermissionsHandler={currentTabStatus?.handler}
                 />


### PR DESCRIPTION
This changes the term "Sourcegraph Cloud" to "Sourcegraph.com" in the browser extension settings. c.f. https://sourcegraph.slack.com/archives/C03CSAER9LK/p1665229967605479

## Test plan

![Screenshot 2022-10-11 at 10 43 01](https://user-images.githubusercontent.com/458591/195042670-92193975-98f3-47b9-8cb8-061bd8cceb4d.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-sourcagraph-cloud-fix.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-phzxdsqyzh.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
