### PR TITLE
batches: show empty display names correctly in the namespace selector

### DIFF
--- a/client/web/src/enterprise/batches/create/NamespaceSelector.tsx
+++ b/client/web/src/enterprise/batches/create/NamespaceSelector.tsx
@@ -10,9 +10,9 @@ type PartialNamespace =
 const getNamespaceDisplayName = (namespace: PartialNamespace): string => {
     switch (namespace.__typename) {
         case 'User':
-            return namespace.displayName ?? namespace.username
+            return namespace.displayName ? namespace.displayName : namespace.username
         case 'Org':
-            return namespace.displayName ?? namespace.name
+            return namespace.displayName ? namespace.displayName : namespace.name
     }
 }
 


### PR DESCRIPTION
Noticed this while preparing today's demo: creating an organisation without a display name results in an empty string that isn't handled properly by the `??` operator in use. Although I don't think this will affect the user in the same way, we might as well be consistent.

## Test plan

Tested the four scenarios: organisations with and without display names, and users with and without display names.

## App preview:

- [Web](https://sg-web-aharvey-fix-namespace-selector.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-pedecopjms.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
