### PR TITLE
Add "indexing repositories" status messages

### DIFF
--- a/client/web/src/nav/StatusMessagesNavItem.mocks.ts
+++ b/client/web/src/nav/StatusMessagesNavItem.mocks.ts
@@ -23,6 +23,11 @@ export const allStatusMessages: StatusMessagesResult['statusMessages'] = [
         __typename: 'CloningProgress',
         message: '477260 repositories enqueued for cloning. 11 repositories currently cloning...',
     },
+    {
+        __typename: 'IndexingProgress',
+        indexed: 15,
+        notIndexed: 23,
+    },
 ]
 
 export const newStatusMessageMock = (

--- a/client/web/src/nav/StatusMessagesNavItem.story.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.story.tsx
@@ -39,3 +39,25 @@ export const AllMessageTypes: Story = () => (
 )
 
 AllMessageTypes.storyName = 'All message types'
+
+export const IndexingMessage: Story = () => (
+    <WebStory>
+        {() => (
+            <MockedTestProvider
+                mocks={[
+                    newStatusMessageMock([
+                        {
+                            __typename: 'IndexingProgress',
+                            indexed: 15,
+                            notIndexed: 23,
+                        },
+                    ]),
+                ]}
+            >
+                <StatusMessagesNavItem disablePolling={true} />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
+
+IndexingMessage.storyName = 'Indexing progress'

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react'
 
-import { mdiInformation, mdiAlert, mdiSync, mdiCheckboxMarkedCircle } from '@mdi/js'
+import { mdiInformation, mdiAlert, mdiSync, mdiMagnifyScan, mdiCheckboxMarkedCircle } from '@mdi/js'
 import classNames from 'classnames'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
@@ -174,14 +174,23 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
         } else if (data.statusMessages?.some(({ __typename: type }) => type === 'CloningProgress')) {
             codeHostMessage = 'Cloning repositories...'
             icon = CloudSyncIconRefresh
+        } else if (data.statusMessages?.some(({ __typename: type }) => type === 'IndexingProgress')) {
+            codeHostMessage = 'Indexing repositories...'
+            icon = CloudSyncIconRefresh
         } else {
             codeHostMessage = 'Repositories up to date'
             icon = CloudCheckIconRefresh
         }
 
+        const iconProps = { as: icon }
+
         return (
             <Tooltip content={isOpen ? undefined : codeHostMessage}>
-                <Icon as={icon} size="md" {...(isOpen ? { 'aria-hidden': true } : { 'aria-label': codeHostMessage })} />
+                <Icon
+                    {...iconProps}
+                    size="md"
+                    {...(isOpen ? { 'aria-hidden': true } : { 'aria-label': codeHostMessage })}
+                />
             </Tooltip>
         )
     }, [data, isOpen])
@@ -216,6 +225,22 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
                                 message={status.message}
                                 title="Cloning repositories"
                                 messageHint="Not all repositories available for search yet."
+                                linkTo="/site-admin/repositories"
+                                linkText="View repositories"
+                                linkOnClick={toggleIsOpen}
+                                entryType="progress"
+                            />
+                        )
+                    }
+                    if (status.__typename === 'IndexingProgress') {
+                        return (
+                            <StatusMessagesNavItemEntry
+                                key="indexing-progress"
+                                message={`Indexing repositories. ${status.indexed} out of ${
+                                    status.indexed + status.notIndexed
+                                } indexed.`}
+                                title="Indexing repositories"
+                                messageHint="Indexing repositories speeds up search."
                                 linkTo="/site-admin/repositories"
                                 linkText="View repositories"
                                 linkOnClick={toggleIsOpen}

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react'
 
-import { mdiInformation, mdiAlert, mdiSync, mdiMagnifyScan, mdiCheckboxMarkedCircle } from '@mdi/js'
+import { mdiInformation, mdiAlert, mdiSync, mdiCheckboxMarkedCircle } from '@mdi/js'
 import classNames from 'classnames'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
@@ -182,15 +182,9 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
             icon = CloudCheckIconRefresh
         }
 
-        const iconProps = { as: icon }
-
         return (
             <Tooltip content={isOpen ? undefined : codeHostMessage}>
-                <Icon
-                    {...iconProps}
-                    size="md"
-                    {...(isOpen ? { 'aria-hidden': true } : { 'aria-label': codeHostMessage })}
-                />
+                <Icon as={icon} size="md" {...(isOpen ? { 'aria-hidden': true } : { 'aria-label': codeHostMessage })} />
             </Tooltip>
         )
     }, [data, isOpen])

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react'
 
-import { mdiInformation, mdiAlert, mdiSync, mdiCheckboxMarkedCircle } from '@mdi/js'
+import { mdiInformation, mdiAlert, mdiSync, mdiCheckboxMarkedCircle, mdiDatabaseSyncOutline } from '@mdi/js'
 import classNames from 'classnames'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
@@ -30,7 +30,7 @@ import { STATUS_MESSAGES } from './StatusMessagesNavItemQueries'
 
 import styles from './StatusMessagesNavItem.module.scss'
 
-type EntryType = 'progress' | 'warning' | 'success' | 'error'
+type EntryType = 'progress' | 'warning' | 'success' | 'error' | 'indexing'
 
 interface StatusMessageEntryProps {
     title: string
@@ -82,6 +82,15 @@ function entryIcon(entryType: EntryType): JSX.Element {
                     aria-label="In progress"
                 />
             )
+        case 'indexing':
+            return (
+                <Icon
+                    {...sharedProps}
+                    className={classNames('text-primary', styles.icon)}
+                    svgPath={mdiDatabaseSyncOutline}
+                    aria-label="Indexing"
+                />
+            )
     }
 }
 
@@ -105,6 +114,8 @@ const getBorderClassname = (entryType: EntryType): string => {
         case 'success':
             return styles.entryBorderSuccess
         case 'progress':
+            return styles.entryBorderProgress
+        case 'indexing':
             return styles.entryBorderProgress
         default:
             return ''
@@ -163,28 +174,32 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
         }
 
         let codeHostMessage
-        let icon
+        let iconProps
         if (
             data.statusMessages?.some(
                 ({ __typename: type }) => type === 'ExternalServiceSyncError' || type === 'SyncError'
             )
         ) {
             codeHostMessage = 'Syncing repositories failed!'
-            icon = CloudAlertIconRefresh
+            iconProps = { as: CloudAlertIconRefresh }
         } else if (data.statusMessages?.some(({ __typename: type }) => type === 'CloningProgress')) {
             codeHostMessage = 'Cloning repositories...'
-            icon = CloudSyncIconRefresh
+            iconProps = { as: CloudSyncIconRefresh }
         } else if (data.statusMessages?.some(({ __typename: type }) => type === 'IndexingProgress')) {
             codeHostMessage = 'Indexing repositories...'
-            icon = CloudSyncIconRefresh
+            iconProps = { as: CloudSyncIconRefresh }
         } else {
             codeHostMessage = 'Repositories up to date'
-            icon = CloudCheckIconRefresh
+            iconProps = { as: CloudCheckIconRefresh }
         }
 
         return (
             <Tooltip content={isOpen ? undefined : codeHostMessage}>
-                <Icon as={icon} size="md" {...(isOpen ? { 'aria-hidden': true } : { 'aria-label': codeHostMessage })} />
+                <Icon
+                    {...iconProps}
+                    size="md"
+                    {...(isOpen ? { 'aria-hidden': true } : { 'aria-label': codeHostMessage })}
+                />
             </Tooltip>
         )
     }, [data, isOpen])
@@ -238,7 +253,7 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
                                 linkTo="/site-admin/repositories"
                                 linkText="View repositories"
                                 linkOnClick={toggleIsOpen}
-                                entryType="progress"
+                                entryType="indexing"
                             />
                         )
                     }

--- a/client/web/src/nav/StatusMessagesNavItemQueries.ts
+++ b/client/web/src/nav/StatusMessagesNavItemQueries.ts
@@ -9,6 +9,13 @@ export const STATUS_MESSAGES = gql`
                 message
             }
 
+            ... on IndexingProgress {
+                __typename
+
+                notIndexed
+                indexed
+            }
+
             ... on SyncError {
                 __typename
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -7684,9 +7684,24 @@ type SyncError {
 }
 
 """
+FOR INTERNAL USE ONLY: A status message produced when repositories are being
+indexed for search.
+"""
+type IndexingProgress {
+    """
+    The number of repositories that have not been indexed yet.
+    """
+    notIndexed: Int!
+    """
+    The number of repositories that have been indexed.
+    """
+    indexed: Int!
+}
+
+"""
 FOR INTERNAL USE ONLY: A status message
 """
-union StatusMessage = CloningProgress | ExternalServiceSyncError | SyncError
+union StatusMessage = CloningProgress | ExternalServiceSyncError | SyncError | IndexingProgress
 
 """
 An arbitrarily large integer encoded as a decimal string.

--- a/cmd/frontend/graphqlbackend/status_messages.go
+++ b/cmd/frontend/graphqlbackend/status_messages.go
@@ -47,6 +47,13 @@ func (r *statusMessageResolver) ToSyncError() (*statusMessageResolver, bool) {
 	return r, r.message.SyncError != nil
 }
 
+func (r *statusMessageResolver) ToIndexingProgress() (*indexingProgressMessageResolver, bool) {
+	if r.message.Indexing != nil {
+		return &indexingProgressMessageResolver{message: r.message.Indexing}, true
+	}
+	return nil, false
+}
+
 func (r *statusMessageResolver) Message() (string, error) {
 	if r.message.Cloning != nil {
 		return r.message.Cloning.Message, nil
@@ -69,3 +76,10 @@ func (r *statusMessageResolver) ExternalService(ctx context.Context) (*externalS
 
 	return &externalServiceResolver{logger: log.Scoped("externalServiceResolver", ""), db: r.db, externalService: externalService}, nil
 }
+
+type indexingProgressMessageResolver struct {
+	message *repos.IndexingProgress
+}
+
+func (r *indexingProgressMessageResolver) NotIndexed() int32 { return int32(r.message.NotIndexed) }
+func (r *indexingProgressMessageResolver) Indexed() int32    { return int32(r.message.Indexed) }

--- a/internal/repos/status_messages.go
+++ b/internal/repos/status_messages.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -68,6 +69,25 @@ func FetchStatusMessages(ctx context.Context, db database.DB) ([]StatusMessage, 
 		})
 	}
 
+	// On Sourcegraph.com we don't index all repositories, which makes
+	// determining the index status a bit more complicated than for other
+	// instances.
+	// So for now we don't return the indexing message on sourcegraph.com.
+	if !envvar.SourcegraphDotComMode() {
+		zoektRepoStats, err := db.ZoektRepos().GetStatistics(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "loading repo statistics")
+		}
+		if zoektRepoStats.NotIndexed > 0 {
+			messages = append(messages, StatusMessage{
+				Indexing: &IndexingProgress{
+					NotIndexed: zoektRepoStats.NotIndexed,
+					Indexed:    zoektRepoStats.Indexed,
+				},
+			})
+		}
+	}
+
 	return messages, nil
 }
 
@@ -95,4 +115,10 @@ type StatusMessage struct {
 	Cloning                  *CloningProgress          `json:"cloning"`
 	ExternalServiceSyncError *ExternalServiceSyncError `json:"external_service_sync_error"`
 	SyncError                *SyncError                `json:"sync_error"`
+	Indexing                 *IndexingProgress         `json:"indexing"`
+}
+
+type IndexingProgress struct {
+	NotIndexed int
+	Indexed    int
 }

--- a/internal/repos/status_messages.go
+++ b/internal/repos/status_messages.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -74,6 +75,11 @@ func FetchStatusMessages(ctx context.Context, db database.DB) ([]StatusMessage, 
 	// instances.
 	// So for now we don't return the indexing message on sourcegraph.com.
 	if !envvar.SourcegraphDotComMode() {
+		// Check feature flag
+		if !featureflag.FromContext(ctx).GetBoolOr("indexing-status-message", false) {
+			return messages, nil
+		}
+
 		zoektRepoStats, err := db.ZoektRepos().GetStatistics(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "loading repo statistics")

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -13,15 +13,53 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/log/logtest"
+	"github.com/sourcegraph/zoekt"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
+
+func newMockFeatureFlagStore(user, anonymous, global map[string]bool) *mockFeatureFlagStore {
+	if user == nil {
+		user = make(map[string]bool)
+	}
+	if anonymous == nil {
+		anonymous = make(map[string]bool)
+	}
+	if global == nil {
+		global = make(map[string]bool)
+	}
+
+	return &mockFeatureFlagStore{
+		userFlags:          user,
+		anonymousUserFlags: anonymous,
+		globalFlags:        global,
+	}
+}
+
+type mockFeatureFlagStore struct {
+	userFlags          map[string]bool
+	anonymousUserFlags map[string]bool
+	globalFlags        map[string]bool
+}
+
+func (m *mockFeatureFlagStore) GetUserFlags(context.Context, int32) (map[string]bool, error) {
+	return m.userFlags, nil
+}
+
+func (m *mockFeatureFlagStore) GetAnonymousUserFlags(context.Context, string) (map[string]bool, error) {
+	return m.anonymousUserFlags, nil
+}
+
+func (m *mockFeatureFlagStore) GetGlobalFeatureFlags(context.Context) (map[string]bool, error) {
+	return m.globalFlags, nil
+}
 
 func TestStatusMessages(t *testing.T) {
 	if testing.Short() {
@@ -30,6 +68,8 @@ func TestStatusMessages(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
+	memoryStore := newMockFeatureFlagStore(nil, nil, map[string]bool{"indexing-status-message": true})
+	ctx = featureflag.WithFlags(ctx, memoryStore)
 
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := NewStore(logtest.Scoped(t), db)
@@ -47,15 +87,18 @@ func TestStatusMessages(t *testing.T) {
 		name  string
 		repos types.Repos
 		// maps repoName to CloneStatus
-		cloneStatus      map[string]types.CloneStatus
+		cloneStatus map[string]types.CloneStatus
+		// indexed is list of repo names that are indexed
+		indexed          []string
 		gitserverFailure map[string]bool
 		sourcerErr       error
 		res              []StatusMessage
 		err              string
 	}{
 		{
-			name:        "site-admin: all cloned",
+			name:        "site-admin: all cloned and indexed",
 			cloneStatus: map[string]types.CloneStatus{"foobar": types.CloneStatusCloned},
+			indexed:     []string{"foobar"},
 			repos:       []*types.Repo{{Name: "foobar"}},
 			res:         nil,
 		},
@@ -69,6 +112,9 @@ func TestStatusMessages(t *testing.T) {
 						Message: "1 repository enqueued for cloning.",
 					},
 				},
+				{
+					Indexing: &IndexingProgress{NotIndexed: 1},
+				},
 			},
 		},
 		{
@@ -81,6 +127,9 @@ func TestStatusMessages(t *testing.T) {
 						Message: "1 repository currently cloning...",
 					},
 				},
+				{
+					Indexing: &IndexingProgress{NotIndexed: 1},
+				},
 			},
 		},
 		{
@@ -92,6 +141,9 @@ func TestStatusMessages(t *testing.T) {
 					Cloning: &CloningProgress{
 						Message: "1 repository enqueued for cloning. 1 repository currently cloning...",
 					},
+				},
+				{
+					Indexing: &IndexingProgress{NotIndexed: 2},
 				},
 			},
 		},
@@ -113,11 +165,15 @@ func TestStatusMessages(t *testing.T) {
 				"repo-5": types.CloneStatusCloned,
 				"repo-6": types.CloneStatusCloned,
 			},
+			indexed: []string{"repo-6"},
 			res: []StatusMessage{
 				{
 					Cloning: &CloningProgress{
 						Message: "2 repositories enqueued for cloning. 2 repositories currently cloning...",
 					},
+				},
+				{
+					Indexing: &IndexingProgress{Indexed: 1, NotIndexed: 5},
 				},
 			},
 		},
@@ -128,6 +184,7 @@ func TestStatusMessages(t *testing.T) {
 				"foobar": types.CloneStatusCloned,
 				"barfoo": types.CloneStatusCloned,
 			},
+			indexed:          []string{"foobar", "barfoo"},
 			gitserverFailure: map[string]bool{"foobar": true},
 			res: []StatusMessage{
 				{
@@ -144,6 +201,7 @@ func TestStatusMessages(t *testing.T) {
 				"foobar": types.CloneStatusCloned,
 				"barfoo": types.CloneStatusCloned,
 			},
+			indexed:          []string{"foobar", "barfoo"},
 			gitserverFailure: map[string]bool{"foobar": true, "barfoo": true},
 			res: []StatusMessage{
 				{
@@ -169,7 +227,6 @@ func TestStatusMessages(t *testing.T) {
 
 	for _, tc := range testCases {
 		tc := tc
-		ctx := context.Background()
 
 		t.Run(tc.name, func(t *testing.T) {
 			stored := tc.repos.Clone()
@@ -214,6 +271,18 @@ func TestStatusMessages(t *testing.T) {
 					ShardID:     "test",
 					CloneStatus: cloneStatus,
 					LastError:   lastError,
+				})
+				require.NoError(t, err)
+			}
+			for _, repoName := range tc.indexed {
+				id := uint32(idMapping[api.RepoName(repoName)])
+				if id == 0 {
+					continue
+				}
+				err := db.ZoektRepos().UpdateIndexStatuses(ctx, map[uint32]*zoekt.MinimalRepoListEntry{
+					id: {
+						Branches: []zoekt.RepositoryBranch{{Name: "main", Version: "d34db33f"}},
+					},
 				})
 				require.NoError(t, err)
 			}

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -25,42 +25,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func newMockFeatureFlagStore(user, anonymous, global map[string]bool) *mockFeatureFlagStore {
-	if user == nil {
-		user = make(map[string]bool)
-	}
-	if anonymous == nil {
-		anonymous = make(map[string]bool)
-	}
-	if global == nil {
-		global = make(map[string]bool)
-	}
-
-	return &mockFeatureFlagStore{
-		userFlags:          user,
-		anonymousUserFlags: anonymous,
-		globalFlags:        global,
-	}
-}
-
-type mockFeatureFlagStore struct {
-	userFlags          map[string]bool
-	anonymousUserFlags map[string]bool
-	globalFlags        map[string]bool
-}
-
-func (m *mockFeatureFlagStore) GetUserFlags(context.Context, int32) (map[string]bool, error) {
-	return m.userFlags, nil
-}
-
-func (m *mockFeatureFlagStore) GetAnonymousUserFlags(context.Context, string) (map[string]bool, error) {
-	return m.anonymousUserFlags, nil
-}
-
-func (m *mockFeatureFlagStore) GetGlobalFeatureFlags(context.Context) (map[string]bool, error) {
-	return m.globalFlags, nil
-}
-
 func TestStatusMessages(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
@@ -68,7 +32,7 @@ func TestStatusMessages(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	memoryStore := newMockFeatureFlagStore(nil, nil, map[string]bool{"indexing-status-message": true})
+	memoryStore := featureflag.NewMemoryStore(nil, nil, map[string]bool{"indexing-status-message": true})
 	ctx = featureflag.WithFlags(ctx, memoryStore)
 
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -421,9 +421,10 @@ commands:
     install: |
       mkdir -p .bin
       export GOBIN="${PWD}/.bin"
-      go install github.com/sourcegraph/zoekt/cmd/zoekt-archive-index
-      go install github.com/sourcegraph/zoekt/cmd/zoekt-git-index
-      go install github.com/sourcegraph/zoekt/cmd/zoekt-sourcegraph-indexserver
+      cd ../zoekt
+      go install ./cmd/zoekt-archive-index
+      go install ./cmd/zoekt-git-index
+      go install ./cmd/zoekt-sourcegraph-indexserver
     checkBinary: .bin/zoekt-sourcegraph-indexserver
     env: &zoektenv
       CTAGS_COMMAND: cmd/symbols/universal-ctags-dev
@@ -447,7 +448,9 @@ commands:
   zoekt-web-template: &zoekt_webserver_template
     install: |
       mkdir -p .bin
-      env GOBIN="${PWD}/.bin" go install github.com/sourcegraph/zoekt/cmd/zoekt-webserver
+      export GOBIN="${PWD}/.bin"
+      cd ../zoekt
+      go install ./cmd/zoekt-webserver
     checkBinary: .bin/zoekt-webserver
     env:
       JAEGER_DISABLED: true

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -421,10 +421,9 @@ commands:
     install: |
       mkdir -p .bin
       export GOBIN="${PWD}/.bin"
-      cd ../zoekt
-      go install ./cmd/zoekt-archive-index
-      go install ./cmd/zoekt-git-index
-      go install ./cmd/zoekt-sourcegraph-indexserver
+      go install github.com/sourcegraph/zoekt/cmd/zoekt-archive-index
+      go install github.com/sourcegraph/zoekt/cmd/zoekt-git-index
+      go install github.com/sourcegraph/zoekt/cmd/zoekt-sourcegraph-indexserver
     checkBinary: .bin/zoekt-sourcegraph-indexserver
     env: &zoektenv
       CTAGS_COMMAND: cmd/symbols/universal-ctags-dev
@@ -448,9 +447,7 @@ commands:
   zoekt-web-template: &zoekt_webserver_template
     install: |
       mkdir -p .bin
-      export GOBIN="${PWD}/.bin"
-      cd ../zoekt
-      go install ./cmd/zoekt-webserver
+      env GOBIN="${PWD}/.bin" go install github.com/sourcegraph/zoekt/cmd/zoekt-webserver
     checkBinary: .bin/zoekt-webserver
     env:
       JAEGER_DISABLED: true


### PR DESCRIPTION
This adds a feature-flagged status message that shows indexing status. It's not enabled on dotcom, because indexing (more specifically: what _should_ be indexed) is a different story. But I want to enable it on S2 and once we've done some testing, I want to enable it by default.

<img width="306" alt="screenshot_2022-11-08_15 52 39@2x" src="https://user-images.githubusercontent.com/1185253/200596871-d6e91af6-e3cf-4660-9921-f0455ad99f7f.png">

## Demo Video

https://user-images.githubusercontent.com/1185253/200598882-0e2c9fb7-95b9-4fc8-b3bc-b9a7d78ff8d7.mp4


## Test plan

- Manual testing
- Storybook