### PR TITLE
e2e tests: use a smaller repo

### DIFF
--- a/client/web/src/regression/codeintel.test.ts
+++ b/client/web/src/regression/codeintel.test.ts
@@ -35,7 +35,7 @@ describe('Code graph regression test suite', () => {
     }
 
     const testRepoSlugs = [
-        'sourcegraph/sourcegraph',
+        'sourcegraph/run',
         'sourcegraph-testing/prometheus-common',
         'sourcegraph-testing/prometheus-client-golang',
         'sourcegraph-testing/prometheus-redefinitions',


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/42637

Cloning sourcegraph/sourcegraph in the e2e results in timeouts. This perhaps is not the best approach here as cloning sourcegraph should work, so I'll let the owner of that test make the final call. I suppose we could increase the timeout.

But this has been plaguing our CI pipeline for a while, so let's first fix it. 

cc @sourcegraph/repo-management 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Green CI