### PR TITLE
Make gitserver cleanup to use an internal actor to avoid security eve…

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -197,7 +197,7 @@ func main() {
 
 	go syncRateLimiters(ctx, logger, externalServiceStore, rateLimitSyncerLimitPerSecond)
 	go debugserver.NewServerRoutine(ready).Start()
-	go gitserver.Janitor(janitorInterval)
+	go gitserver.Janitor(actor.WithInternalActor(ctx), janitorInterval)
 	go gitserver.SyncRepoState(syncRepoStateInterval, syncRepoStateBatchSize, syncRepoStateUpdatePerSecond)
 
 	gitserver.StartClonePipeline(ctx)

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -547,7 +548,7 @@ func (s *Server) cleanupRepos(gitServerAddrs gitserver.GitServerAddresses) {
 		logger.Error("failed to write periodic stats", log.Error(err))
 	}
 
-	err = s.setRepoSizes(context.Background(), repoToSize)
+	err = s.setRepoSizes(actor.WithInternalActor(context.Background()), repoToSize)
 	if err != nil {
 		logger.Error("setting repo sizes", log.Error(err))
 	}

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -173,7 +172,7 @@ const reposStatsName = "repos-stats.json"
 // 10. Perform sg-maintenance
 // 11. Git prune
 // 12. Only during first run: Set sizes of repos which don't have it in a database.
-func (s *Server) cleanupRepos(gitServerAddrs gitserver.GitServerAddresses) {
+func (s *Server) cleanupRepos(ctx context.Context, gitServerAddrs gitserver.GitServerAddresses) {
 	janitorRunning.Set(1)
 	janitorStart := time.Now()
 	defer func() {
@@ -548,7 +547,7 @@ func (s *Server) cleanupRepos(gitServerAddrs gitserver.GitServerAddresses) {
 		logger.Error("failed to write periodic stats", log.Error(err))
 	}
 
-	err = s.setRepoSizes(actor.WithInternalActor(context.Background()), repoToSize)
+	err = s.setRepoSizes(ctx, repoToSize)
 	if err != nil {
 		logger.Error("setting repo sizes", log.Error(err))
 	}

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sourcegraph/log/logtest"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
@@ -82,7 +83,7 @@ UPDATE gitserver_repos SET repo_size_bytes = 5 where repo_id = 3;
 		t.Fatalf("unexpected error while inserting test data: %s", err)
 	}
 
-	s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
+	s.cleanupRepos(actor.WithInternalActor(context.Background()), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
 
 	for i := 1; i <= 3; i++ {
 		repo, err := s.DB.GitserverRepos().GetByID(context.Background(), api.RepoID(i))
@@ -145,7 +146,7 @@ func TestCleanupInactive(t *testing.T) {
 		DB:     database.NewMockDB(),
 	}
 	s.testSetup(t)
-	s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
+	s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
 
 	if _, err := os.Stat(repoA); os.IsNotExist(err) {
 		t.Error("expected repoA not to be removed")
@@ -178,7 +179,7 @@ func TestCleanupWrongShard(t *testing.T) {
 		}
 		s.testSetup(t)
 		s.Hostname = "does-not-exist"
-		s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0", "gitserver-1"}})
+		s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0", "gitserver-1"}})
 
 		if _, err := os.Stat(repoA); err != nil {
 			t.Error("expected repoA not to be removed")
@@ -209,7 +210,7 @@ func TestCleanupWrongShard(t *testing.T) {
 		}
 		s.testSetup(t)
 		s.Hostname = "gitserver-0"
-		s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0.cluster.local:3178", "gitserver-1.cluster.local:3178"}})
+		s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0.cluster.local:3178", "gitserver-1.cluster.local:3178"}})
 
 		if _, err := os.Stat(repoA); err != nil {
 			t.Error("expected repoA not to be removed")
@@ -240,7 +241,7 @@ func TestCleanupWrongShard(t *testing.T) {
 		}
 		s.testSetup(t)
 		wrongShardReposDeleteLimit = -1
-		s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0", "gitserver-1"}})
+		s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0", "gitserver-1"}})
 
 		if _, err := os.Stat(repoA); os.IsNotExist(err) {
 			t.Error("expected repoA not to be removed")
@@ -306,7 +307,7 @@ func TestGitGCAuto(t *testing.T) {
 		DB:     database.NewMockDB(),
 	}
 	s.testSetup(t)
-	s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
+	s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
 
 	// Verify that there are no more GC-able objects in the repository.
 	if !strings.Contains(countObjects(), "count: 0") {
@@ -427,7 +428,7 @@ func TestCleanupExpired(t *testing.T) {
 		DB: database.NewMockDB(),
 	}
 	s.testSetup(t)
-	s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
+	s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
 
 	// repos that shouldn't be re-cloned
 	if repoNewTime.Before(modTime(repoNew)) {
@@ -532,7 +533,7 @@ func TestCleanup_RemoveNonExistentRepos(t *testing.T) {
 		s.testSetup(t)
 		s.DB = mockDB
 
-		s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
+		s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
 
 		// nothing should happen if test env not declared to true
 		if _, err := os.Stat(repoExists); err != nil {
@@ -552,7 +553,7 @@ func TestCleanup_RemoveNonExistentRepos(t *testing.T) {
 		s.testSetup(t)
 		s.DB = mockDB
 
-		s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
+		s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
 
 		if _, err := os.Stat(repoNotExists); err == nil {
 			t.Fatal("repo not existing in DB was not removed")
@@ -694,7 +695,7 @@ func TestCleanupOldLocks(t *testing.T) {
 
 	s := &Server{ReposDir: root, Logger: logtest.Scoped(t), DB: database.NewMockDB()}
 	s.testSetup(t)
-	s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
+	s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
 
 	isRemoved := func(path string) bool {
 		_, err := os.Stat(path)
@@ -1550,7 +1551,7 @@ update gitserver_repos set repo_size_bytes = 228 where repo_id = 1;
 		t.Fatalf("unexpected error while inserting test data: %s", err)
 	}
 
-	s.cleanupRepos(gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
+	s.cleanupRepos(context.Background(), gitserver.GitServerAddresses{Addresses: []string{"gitserver-0"}})
 
 	for i := 1; i <= 3; i++ {
 		repo, err := s.DB.GitserverRepos().GetByID(context.Background(), 1)

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -507,10 +507,10 @@ func (s *Server) Handler() http.Handler {
 
 // Janitor does clean up tasks over s.ReposDir and is expected to run in a
 // background goroutine.
-func (s *Server) Janitor(interval time.Duration) {
+func (s *Server) Janitor(ctx context.Context, interval time.Duration) {
 	for {
 		gitserverAddrs := currentGitserverAddresses()
-		s.cleanupRepos(actor.WithInternalActor(context.Background()), gitserverAddrs)
+		s.cleanupRepos(actor.WithInternalActor(ctx), gitserverAddrs)
 		time.Sleep(interval)
 	}
 }

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -510,7 +510,7 @@ func (s *Server) Handler() http.Handler {
 func (s *Server) Janitor(interval time.Duration) {
 	for {
 		gitserverAddrs := currentGitserverAddresses()
-		s.cleanupRepos(gitserverAddrs)
+		s.cleanupRepos(actor.WithInternalActor(context.Background()), gitserverAddrs)
 		time.Sleep(interval)
 	}
 }

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -10,7 +10,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/audit"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -152,11 +151,6 @@ func (s *securityEventLogsStore) LogEvent(ctx context.Context, e *SecurityEvent)
 }
 
 func (s *securityEventLogsStore) LogEventList(ctx context.Context, events []*SecurityEvent) {
-	// TODO: removing this causes local errors, will be tackled soon
-	if !envvar.SourcegraphDotComMode() {
-		return
-	}
-
 	if err := s.InsertList(ctx, events); err != nil {
 		names := make([]string, len(events))
 		for i, e := range events {


### PR DESCRIPTION
### Problem

We've recently deployed a [change](https://github.com/sourcegraph/sourcegraph/pull/42653) that made "security events" a part of the audit log and enabled it by default on every environment. @mrnugget has noticed that the change caused a bunch of errors to appear in the logs during the same day. 

The issue has been [hotfixed](https://github.com/sourcegraph/sourcegraph/pull/42763) by rolling back [the bit of code](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/commit/58a59b188430c8ef92528b5411acf99928da6edb?visible=1) that caused the errors. Luckily, the errors haven't been in the [newly added audit-logging code](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/commit/040059239070cf54a956b720843897f50724f6be#diff-65ea563100c640f7eef39bb91d6285f9R118). Still, due to a unfortunate combination of circumstances, we've executed code that hasn't run in production for a long time and has caused the errors.

### Explanation

The errors occur when the [LogEventList](https://sourcegraph.sourcegraph.com/-/editor?remote_url=https://github.com/sourcegraph/sourcegraph.git&branch=mv/auditlog/security-events/gitserver-janitor-internal-actor&file=internal/database/security_event_logs.go&start_row=152&start_col=33&end_row=152&end_col=33&editor=JetBrains&version=v2.0.1) method receives one or more events that don't have a valid `UserID` _and_ don't have a valid `AnonymousUserID` either.

I've located one place in the codebase in the gitserver cleanup logic with the following execution path:

- [cleanupRepos](https://sourcegraph.sourcegraph.com/-/editor?remote_url=https://github.com/sourcegraph/sourcegraph.git&branch=mv/auditlog/security-events/gitserver-janitor-internal-actor&file=cmd/gitserver/server/cleanup.go&start_row=550&start_col=4&end_row=550&end_col=4&editor=JetBrains&version=v2.0.1) 
  - [setRepoSizes ](https://sourcegraph.sourcegraph.com/-/editor?remote_url=https://github.com/sourcegraph/sourcegraph.git&branch=mv/auditlog/security-events/gitserver-janitor-internal-actor&file=cmd/gitserver/server/cleanup.go&start_row=589&start_col=17&end_row=589&end_col=17&editor=JetBrains&version=v2.0.1)
    - [fetchRepos](https://sourcegraph.sourcegraph.com/-/editor?remote_url=https://github.com/sourcegraph/sourcegraph.git&branch=mv/auditlog/security-events/gitserver-janitor-internal-actor&file=cmd/gitserver/server/cleanup.go&start_row=626&start_col=17&end_row=626&end_col=17&editor=JetBrains&version=v2.0.1) 
      - [ListMinimalRepos](https://sourcegraph.sourcegraph.com/-/editor?remote_url=https://github.com/sourcegraph/sourcegraph.git&branch=mv/auditlog/security-events/gitserver-janitor-internal-actor&file=internal/database/repos.go&start_row=862&start_col=20&end_row=862&end_col=20&editor=JetBrains&version=v2.0.1) 
        - [StreamMinimalRepos](https://sourcegraph.sourcegraph.com/-/editor?remote_url=https://github.com/sourcegraph/sourcegraph.git&branch=mv/auditlog/security-events/gitserver-janitor-internal-actor&file=internal/database/repos.go&start_row=846&start_col=8&end_row=846&end_col=8&editor=JetBrains&version=v2.0.1) 
          - [logPrivateRepoAccessGranted](https://sourcegraph.sourcegraph.com/-/editor?remote_url=https://github.com/sourcegraph/sourcegraph.git&branch=mv/auditlog/security-events/gitserver-janitor-internal-actor&file=internal/database/repos.go&start_row=181&start_col=4&end_row=181&end_col=4&editor=JetBrains&version=v2.0.1) 
            - [boom](https://sourcegraph.sourcegraph.com/-/editor?remote_url=https://github.com/sourcegraph/sourcegraph.git&branch=mv/auditlog/security-events/gitserver-janitor-internal-actor&file=internal/database/security_event_logs.go&start_row=114&start_col=27&end_row=114&end_col=27&editor=JetBrains&version=v2.0.1) (the error is swallowed internally by SecurityEventLogs, but it gets logged)

### Solution

- use an internal actor in the gitserver cleanup process so [that this condition is met](https://sourcegraph.sourcegraph.com/-/editor?remote_url=https://github.com/sourcegraph/sourcegraph.git&branch=mv/auditlog/security-events/gitserver-janitor-internal-actor&file=internal/database/repos.go&start_row=177&start_col=19&end_row=177&end_col=19&editor=JetBrains&version=v2.0.1)
- re-enable the security events in the audit log

## Test plan

- wrote a failing test that exposed the problem
- manually confirmed that I couldn't see any more errors locally
