### PR TITLE
[SG-35755] Wildcard button: text in disabled buttons is too bright in dark mode

### DIFF
--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -102,6 +102,7 @@ $theme-colors: (
     --merged-2: #c6b6f6;
     --merged-3: #6b47d6;
     --light-text: var(--white);
+    --light-text-disabled: rgba(255, 255, 255, 0.6);
     --dark-text: var(--gray-08);
     --line-number-color: var(--gray-06);
     --header-icon-color: var(--gray-05);

--- a/client/wildcard/src/components/Button/Button.module.scss
+++ b/client/wildcard/src/components/Button/Button.module.scss
@@ -270,7 +270,7 @@
     --btn-light-color-variant: var(--primary-2);
     --btn-dark-color-variant: var(--primary-3);
     --btn-light-disabled-text-color: var(--light-text);
-    --btn-dark-disabled-text-color: rgba(var(--text-light), 0.6);
+    --btn-dark-disabled-text-color: var(--light-text-disabled);
 }
 
 .btn-secondary {


### PR DESCRIPTION
### Description
In `dark mode`, the text color in `disabled` buttons is too bright in `primary`.
Using **gray** text would make it clearer that the button is disabled.

Fixes #35755

### Refs
[SourceGraph Issue](https://github.com/sourcegraph/sourcegraph/issues/35755)
[GitStart Issue](https://app.gitstart.com/clients/sourcegraph/tickets/SG-35755)

### Success Criteria
The disabled button styles in the dark mode are updated to reflect the latest changes in [Figma mockups](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/%E2%9C%B3%EF%B8%8F-Wildcard-Design-System?node-id=908%3A2513).

### Test Plan
- Compare the disabled button states of the `primary` on the local storybook and remote storybook to ensure it meets the success criteria.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-contractors-sg-35755.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xwcwoskuag.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
