### PR TITLE
Fuzzy finder: use wildcard Button component for actions

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -13,7 +13,7 @@ import { mergedHandler } from '../../fuzzyFinder/WordSensitiveFuzzySearch'
 
 import { FuzzyRepoRevision } from './FuzzyRepoRevision'
 import { fuzzyErrors, FuzzyState, fuzzyIsActive, FuzzyTabs, FuzzyTabKey } from './FuzzyTabs'
-import { HighlightedLink, linkStyle } from './HighlightedLink'
+import { HighlightedLink } from './HighlightedLink'
 
 import styles from './FuzzyModal.module.scss'
 
@@ -243,7 +243,7 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
                 case event.key === 'Enter':
                     if (focusIndex < queryResult.resultCount) {
                         const fileAnchor = document.querySelector<HTMLAnchorElement>(
-                            `#fuzzy-modal-result-${focusIndex} .${linkStyle}`
+                            `#fuzzy-modal-result-${focusIndex} [data-fuzzy-clickable=true]`
                         )
                         fileAnchor?.click()
                     }

--- a/client/web/src/components/fuzzyFinder/HighlightedLink.module.scss
+++ b/client/web/src/components/fuzzyFinder/HighlightedLink.module.scss
@@ -12,3 +12,8 @@
     height: 100%;
     max-height: 1em;
 }
+
+.button-link {
+    padding: 0;
+    font-weight: 400;
+}

--- a/client/web/src/components/fuzzyFinder/HighlightedLink.tsx
+++ b/client/web/src/components/fuzzyFinder/HighlightedLink.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { Link, Code } from '@sourcegraph/wildcard'
+import { Link, Code, Button } from '@sourcegraph/wildcard'
 
 import styles from './HighlightedLink.module.scss'
 
@@ -77,25 +77,23 @@ export const HighlightedLink: React.FunctionComponent<React.PropsWithChildren<Hi
 
     return props.url ? (
         <Code>
-            <Link key="link" tabIndex={-1} className={styles.link} to={props.url} onClick={props.onClick}>
+            <Link
+                key="link"
+                data-fuzzy-clickable={true}
+                tabIndex={-1}
+                className={styles.link}
+                to={props.url}
+                onClick={props.onClick}
+            >
                 {props.icon && <span key="icon">{props.icon}</span>}
                 {spans}
             </Link>
         </Code>
     ) : (
-        <Link
-            key="link"
-            tabIndex={-1}
-            className={styles.link}
-            to={`/commands/${props.text}`}
-            onClick={event => {
-                event.preventDefault()
-                props.onClick?.()
-            }}
-        >
+        <Button variant="link" className={styles.buttonLink} data-fuzzy-clickable={true} onClick={props.onClick}>
             {props.icon && <span key="icon">{props.icon}</span>}
             {spans}
-        </Link>
+        </Button>
     )
 }
 


### PR DESCRIPTION
This commit replaces the hacky usage of a `Link` component with a more idiomatic `Button`.

A few issues that I've noticed:

- The height of the `<li>` item is 22.313px when it's a button and 20px when it's a link
- The full width of the row is not clickable when it's a button, I can only click on the text. The full width is clickable when it's a link.

## Test plan

To test locally:
- `sg start`
- Cmd+K
- Optionally, focus on the "Repos" tab and then back to "All" to have repos listed

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-fuzzy-button.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ysvzktqnjt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
