### PR TITLE
Fix bug in `isSafari` helper method

### DIFF
--- a/client/common/src/util/browserDetection.ts
+++ b/client/common/src/util/browserDetection.ts
@@ -3,7 +3,7 @@ export function isChrome(): boolean {
 }
 
 export function isSafari(): boolean {
-    return !!window.navigator.userAgent.match(/safari/i)
+    return !!window.navigator.userAgent.match(/safari/i) && !isChrome()
 }
 
 export function isFirefox(): boolean {

--- a/client/shared/src/keyboardShortcuts/keyboardShortcuts.ts
+++ b/client/shared/src/keyboardShortcuts/keyboardShortcuts.ts
@@ -1,4 +1,4 @@
-import { isMacPlatform, getBrowserName } from '@sourcegraph/common'
+import { isMacPlatform, isSafari } from '@sourcegraph/common'
 
 import { KeyboardShortcut } from '../keyboardShortcuts'
 
@@ -56,8 +56,7 @@ export const KEYBOARD_SHORTCUTS: KEYBOARD_SHORTCUT_MAPPING = {
     },
     fuzzyFinderSymbols: {
         title: 'Fuzzy find symbols',
-        // NOTE: `isSafari()` returns true in Google Chrome on macOS.
-        keybindings: [{ held: getBrowserName() === 'safari' ? ['Mod', 'Shift'] : ['Mod'], ordered: ['o'] }],
+        keybindings: [{ held: isSafari() ? ['Mod', 'Shift'] : ['Mod'], ordered: ['o'] }],
         hideInHelp: true,
     },
     copyFullQuery: {


### PR DESCRIPTION
This helper previously returned `true` for me locally in Google Chrome.

## Test plan

- Add a `console.log(isSafari())` print statement
- Run `sg start`
- Verify it's false in Chrome and Firefox and true in Safari
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-is-safari.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-rqdibbkirm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
