### PR TITLE
Fix buggy ctrl-n and ctrl-p handlers

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -214,18 +214,14 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
                 case event.key === 'Escape':
                     props.onClose()
                     break
-                case event.key === 'n':
-                    if (event.ctrlKey) {
-                        event.preventDefault()
-                        setRoundedFocusIndex(1)
-                        break
-                    }
-                case event.key === 'p':
-                    if (event.ctrlKey) {
-                        event.preventDefault()
-                        setRoundedFocusIndex(-1)
-                        break
-                    }
+                case event.key === 'n' && event.ctrlKey:
+                    event.preventDefault()
+                    setRoundedFocusIndex(1)
+                    break
+                case event.key === 'p' && event.ctrlKey:
+                    event.preventDefault()
+                    setRoundedFocusIndex(-1)
+                    break
                 case event.key === 'ArrowDown':
                     event.preventDefault() // Don't move the cursor to the end of the input.
                     setRoundedFocusIndex(1)


### PR DESCRIPTION
Context https://sourcegraph.slack.com/archives/C03CSAER9LK/p1665505922799359

## Test plan

- Run `sg start`
- Start fuzzy finder
- Type query that contains `n` and `p`
- Use ctrl-n and ctrl-p to cycle through the items
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-ctrl-n.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-vgmayahzmq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
