### PR TITLE
sg: make bg tasks less intrusive

### DIFF
--- a/dev/sg/internal/background/background.go
+++ b/dev/sg/internal/background/background.go
@@ -92,15 +92,15 @@ func Wait(ctx context.Context, out *std.Output) {
 				out.Write(jobOutput)
 			}
 			jobs.wg.Done()
-			if jobs.verbose {
-				out.WriteLine(output.Line(output.EmojiSuccess, output.StyleSuccess, "Background jobs done!"))
-			}
 		}
 	}()
 	jobs.wg.Wait()
 
 	// Done!
 	close(jobs.output)
+	if jobs.verbose {
+		out.WriteLine(output.Line(output.EmojiSuccess, output.StyleSuccess, "Background jobs done!"))
+	}
 	span.Succeeded()
 }
 

--- a/dev/sg/internal/background/background.go
+++ b/dev/sg/internal/background/background.go
@@ -77,8 +77,10 @@ func Wait(ctx context.Context, out *std.Output) {
 	defer span.End()
 
 	firstResultWithOutput := true
-	out.WriteLine(output.Styledf(output.StylePending, "Waiting for %d remaining background %s to complete...",
-		count, pluralize("job", "jobs", count)))
+	if jobs.verbose {
+		out.WriteLine(output.Styledf(output.StylePending, "Waiting for %d remaining background %s to complete...",
+			count, pluralize("job", "jobs", count)))
+	}
 	go func() {
 		// Stream job output as they complete
 		for jobOutput := range jobs.output {
@@ -90,6 +92,9 @@ func Wait(ctx context.Context, out *std.Output) {
 				out.Write(jobOutput)
 			}
 			jobs.wg.Done()
+			if jobs.verbose {
+				out.WriteLine(output.Line(output.EmojiSuccess, output.StyleSuccess, "Background jobs done!"))
+			}
 		}
 	}()
 	jobs.wg.Wait()

--- a/dev/sg/internal/background/background.go
+++ b/dev/sg/internal/background/background.go
@@ -96,7 +96,6 @@ func Wait(ctx context.Context, out *std.Output) {
 
 	// Done!
 	close(jobs.output)
-	out.WriteLine(output.Line(output.EmojiSuccess, output.StyleSuccess, "Background jobs done!"))
 	span.Succeeded()
 }
 

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -225,7 +225,13 @@ var sg = &cli.App{
 		}
 
 		// Check for updates, unless we are running update manually.
-		if cmd.Args().First() != "update" {
+		skipBackgroundTasks := map[string]struct{}{
+			"update":   {},
+			"version":  {},
+			"live":     {},
+			"teammate": {},
+		}
+		if _, skipped := skipBackgroundTasks[cmd.Args().First()]; !skipped {
 			background.Run(cmd.Context, func(ctx context.Context, out *std.Output) {
 				err := checkSgVersionAndUpdate(ctx, out, cmd.Bool("skip-auto-update"))
 				if err != nil {

--- a/dev/sg/sg_update.go
+++ b/dev/sg/sg_update.go
@@ -48,7 +48,7 @@ func updateToPrebuiltSG(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	// We use the RountTripper to make an HTTP request without having to deal
+	// We use the RoundTripper to make an HTTP request without having to deal
 	// with redirections.
 	resp, err := http.DefaultTransport.RoundTrip(req)
 	if err != nil {


### PR DESCRIPTION
In some contexts, having the final ✅  printed by the background task succeeding is very confusing as it makes you think your command worked whereas it did not. Also prevents the bg jobs to run on a few commands where there's no way that it'll have time to complete. 

See https://sourcegraph.slack.com/archives/C01N83PS4TU/p1665478325331859

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally. 