### PR TITLE
Search backend: parse regex with `syntax.Perl` flags`

### DIFF
--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/grafana/regexp"
+	"github.com/grafana/regexp/syntax"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -142,7 +143,7 @@ func (f *RepoContainsFilePredicate) parseNode(n Node) error {
 			if f.Path != "" {
 				return errors.New("cannot specify path multiple times")
 			}
-			if _, err := regexp.Compile(v.Value); err != nil {
+			if _, err := syntax.Parse(v.Value, syntax.Perl); err != nil {
 				return errors.Errorf("`contains.file` predicate has invalid `path` argument: %w", err)
 			}
 			f.Path = v.Value
@@ -150,7 +151,7 @@ func (f *RepoContainsFilePredicate) parseNode(n Node) error {
 			if f.Content != "" {
 				return errors.New("cannot specify content multiple times")
 			}
-			if _, err := regexp.Compile(v.Value); err != nil {
+			if _, err := syntax.Parse(v.Value, syntax.Perl); err != nil {
 				return errors.Errorf("`contains.file` predicate has invalid `content` argument: %w", err)
 			}
 			f.Content = v.Value
@@ -185,7 +186,7 @@ type RepoContainsContentPredicate struct {
 }
 
 func (f *RepoContainsContentPredicate) Unmarshal(params string, negated bool) error {
-	if _, err := regexp.Compile(params); err != nil {
+	if _, err := syntax.Parse(params, syntax.Perl); err != nil {
 		return errors.Errorf("contains.content argument: %w", err)
 	}
 	if params == "" {
@@ -207,7 +208,7 @@ type RepoContainsPathPredicate struct {
 }
 
 func (f *RepoContainsPathPredicate) Unmarshal(params string, negated bool) error {
-	if _, err := regexp.Compile(params); err != nil {
+	if _, err := syntax.Parse(params, syntax.Perl); err != nil {
 		return errors.Errorf("contains.path argument: %w", err)
 	}
 	if params == "" {
@@ -252,7 +253,7 @@ func (f *RepoHasDescriptionPredicate) Unmarshal(params string, negated bool) (er
 		return &NegatedPredicateError{f.Field() + ":" + f.Name()}
 	}
 
-	if _, err := regexp.Compile(params); err != nil {
+	if _, err := syntax.Parse(params, syntax.Perl); err != nil {
 		return errors.Errorf("invalid repo:has.description() argument: %w", err)
 	}
 	if len(params) == 0 {
@@ -313,7 +314,7 @@ func (f *FileContainsContentPredicate) Unmarshal(params string, negated bool) er
 		return &NegatedPredicateError{f.Field() + ":" + f.Name()}
 	}
 
-	if _, err := regexp.Compile(params); err != nil {
+	if _, err := syntax.Parse(params, syntax.Perl); err != nil {
 		return errors.Errorf("file:contains.content argument: %w", err)
 	}
 	if params == "" {

--- a/internal/search/zoekt/query.go
+++ b/internal/search/zoekt/query.go
@@ -91,11 +91,17 @@ func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *search.Fea
 func QueryForFileContentArgs(opt query.RepoHasFileContentArgs, caseSensitive bool) zoekt.Q {
 	var children []zoekt.Q
 	if opt.Path != "" {
-		re, _ := syntax.Parse(opt.Path, 0)
+		re, err := syntax.Parse(opt.Path, syntax.Perl)
+		if err != nil {
+			panic(err)
+		}
 		children = append(children, &zoekt.Regexp{Regexp: re, FileName: true, CaseSensitive: caseSensitive})
 	}
 	if opt.Content != "" {
-		re, _ := syntax.Parse(opt.Content, 0)
+		re, err := syntax.Parse(opt.Content, syntax.Perl)
+		if err != nil {
+			panic(err)
+		}
 		children = append(children, &zoekt.Regexp{Regexp: re, Content: true, CaseSensitive: caseSensitive})
 	}
 	q := zoekt.NewAnd(children...)


### PR DESCRIPTION
This PR is split into two commits:
1) For predicates, switch to `syntax.Parse(s, syntax.Perl)`. This avoids the extra work (and memory usage) of compiling the regex, and makes it explicit that we are parsing with the `Perl` syntax.
2) Use `syntax.Perl` when parsing the regex to pass to Zoekt. Previously, we were using `0`, which means we may fail to parse a pattern that successfully parsed during validation. This also changes it so we explicitly panic on error rather than ignoring the error. We'll [panic later](https://sourcegraph.slack.com/archives/C07KZF47K/p1665438172736089?thread_ts=1665438165.932229&cid=C07KZF47K) anways, so I'd rather get the error message that caused it instead of something seemingly unrelated.

## Test plan

Unit tests, integration tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
