### PR TITLE
Fuzzy finder: add global file mode

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyFiles.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFiles.tsx
@@ -5,13 +5,21 @@ import { getDocumentNode, gql } from '@sourcegraph/http-client'
 import { Icon } from '@sourcegraph/wildcard'
 
 import { getWebGraphQLClient } from '../../backend/graphql'
+import { SearchValue } from '../../fuzzyFinder/FuzzySearch'
 import { createUrlFunction } from '../../fuzzyFinder/WordSensitiveFuzzySearch'
-import { FileNamesResult, FileNamesVariables } from '../../graphql-operations'
+import {
+    FileNamesResult,
+    FileNamesVariables,
+    FuzzyFinderFilesResult,
+    FuzzyFinderFilesVariables,
+} from '../../graphql-operations'
 
 import { FuzzyFSM, newFuzzyFSMFromValues } from './FuzzyFsm'
-import { FuzzyRepoRevision } from './FuzzyRepoRevision'
+import { emptyFuzzyCache, PersistableQueryResult } from './FuzzyLocalCache'
+import { FuzzyQuery } from './FuzzyQuery'
+import { FuzzyRepoRevision, fuzzyRepoRevisionSearchFilter } from './FuzzyRepoRevision'
 
-export const FUZZY_FILES_QUERY = gql`
+export const FUZZY_GIT_LSFILES_QUERY = gql`
     query FileNames($repository: String!, $commit: String!) {
         repository(name: $repository) {
             id
@@ -19,6 +27,36 @@ export const FUZZY_FILES_QUERY = gql`
                 id
                 fileNames
             }
+        }
+    }
+`
+
+export const FUZZY_FILES_QUERY = gql`
+    query FuzzyFinderFiles($query: String!) {
+        search(patternType: regexp, query: $query) {
+            results {
+                results {
+                    ... on FileMatch {
+                        __typename
+                        ...FileMatchFields
+                    }
+                }
+            }
+        }
+    }
+    fragment FileMatchFields on FileMatch {
+        symbols {
+            name
+            containerName
+            kind
+            language
+            url
+        }
+        repository {
+            name
+        }
+        file {
+            path
         }
     }
 `
@@ -31,7 +69,7 @@ export async function loadFilesFSM(
     try {
         const client = apolloClient || (await getWebGraphQLClient())
         const response = await client.query<FileNamesResult, FileNamesVariables>({
-            query: getDocumentNode(FUZZY_FILES_QUERY),
+            query: getDocumentNode(FUZZY_GIT_LSFILES_QUERY),
             variables: { repository: repoRevision.repositoryName, commit: repoRevision.revision },
         })
         if (response.errors && response.errors.length > 0) {
@@ -55,4 +93,46 @@ export function newFuzzyFSM(filenames: string[], createUrl: createUrlFunction): 
         })),
         createUrl
     )
+}
+
+export class FuzzyFiles extends FuzzyQuery {
+    constructor(
+        private readonly client: ApolloClient<object> | undefined,
+        onNamesChanged: () => void,
+        private readonly repoRevision: React.MutableRefObject<FuzzyRepoRevision>
+    ) {
+        // Symbol results should not be cached because stale symbol data is complicated to evict/invalidate.
+        super(onNamesChanged, emptyFuzzyCache)
+    }
+
+    /* override */ protected searchValues(): SearchValue[] {
+        return [...this.queryResults.values()].map(({ text, url }) => ({
+            text,
+            url,
+            icon: <Icon aria-label={text} svgPath={mdiFileDocumentOutline} />,
+        }))
+    }
+
+    /* override */ protected rawQuery(query: string): string {
+        return `${fuzzyRepoRevisionSearchFilter(this.repoRevision.current)}type:path count:100 ${query}`
+    }
+
+    /* override */ protected async handleRawQueryPromise(query: string): Promise<PersistableQueryResult[]> {
+        const client = this.client || (await getWebGraphQLClient())
+        const response = await client.query<FuzzyFinderFilesResult, FuzzyFinderFilesVariables>({
+            query: getDocumentNode(FUZZY_FILES_QUERY),
+            variables: { query },
+        })
+        const results = response.data?.search?.results?.results || []
+        const queryResults: PersistableQueryResult[] = []
+        for (const result of results) {
+            if (result.__typename === 'FileMatch') {
+                queryResults.push({
+                    text: `${result.repository.name}/${result.file.path}`,
+                    url: `/${result.repository.name}/-/blob/${result.file.path}`,
+                })
+            }
+        }
+        return queryResults
+    }
 }

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.mocks.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.mocks.tsx
@@ -9,7 +9,7 @@ import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/teleme
 import { FileNamesResult, FuzzyFinderRepoResult, FuzzyFinderSymbolsResult, SymbolKind } from '../../graphql-operations'
 import { ThemePreference } from '../../theme'
 
-import { FUZZY_FILES_QUERY } from './FuzzyFiles'
+import { FUZZY_GIT_LSFILES_QUERY } from './FuzzyFiles'
 import { FuzzyFinderContainer } from './FuzzyFinder'
 import { FUZZY_REPOS_QUERY } from './FuzzyRepos'
 import { FUZZY_SYMBOLS_QUERY } from './FuzzySymbols'
@@ -47,7 +47,7 @@ export const FuzzyWrapper: React.FunctionComponent<FuzzyWrapperProps> = props =>
 
 export const FUZZY_FILES_MOCK: MockedResponse<FileNamesResult> = {
     request: {
-        query: getDocumentNode(FUZZY_FILES_QUERY),
+        query: getDocumentNode(FUZZY_GIT_LSFILES_QUERY),
         variables: { repository: 'github.com/sourcegraph/sourcegraph', commit: 'main' },
     },
     result: {

--- a/client/web/src/components/fuzzyFinder/FuzzyRepoRevision.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyRepoRevision.tsx
@@ -1,5 +1,14 @@
-
 export interface FuzzyRepoRevision {
-    repositoryName: string;
-    revision: string;
+    repositoryName: string
+    revision: string
+}
+
+export function fuzzyRepoRevisionSearchFilter({ repositoryName, revision }: FuzzyRepoRevision): string {
+    if (repositoryName && revision) {
+        return `repo:${repositoryName}@${revision} `
+    }
+    if (repositoryName) {
+        return `repo:${repositoryName} `
+    }
+    return ''
 }

--- a/client/web/src/components/fuzzyFinder/FuzzySymbols.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzySymbols.tsx
@@ -10,7 +10,7 @@ import { SearchValue } from '../../fuzzyFinder/FuzzySearch'
 
 import { emptyFuzzyCache, PersistableQueryResult } from './FuzzyLocalCache'
 import { FuzzyQuery } from './FuzzyQuery'
-import { FuzzyRepoRevision } from './FuzzyRepoRevision'
+import { FuzzyRepoRevision, fuzzyRepoRevisionSearchFilter } from './FuzzyRepoRevision'
 
 export const FUZZY_SYMBOLS_QUERY = gql`
     fragment FileMatchFields on FileMatch {
@@ -52,16 +52,6 @@ export class FuzzySymbols extends FuzzyQuery {
         // Symbol results should not be cached because stale symbol data is complicated to evict/invalidate.
         super(onNamesChanged, emptyFuzzyCache)
     }
-    private repoFilter(): string {
-        const { repositoryName, revision } = this.repoRevision.current
-        if (repositoryName && revision) {
-            return `repo:${repositoryName}@${revision} `
-        }
-        if (repositoryName) {
-            return `repo:${repositoryName} `
-        }
-        return ''
-    }
 
     /* override */ protected searchValues(): SearchValue[] {
         const repositoryName = this.repoRevision.current.repositoryName
@@ -80,7 +70,7 @@ export class FuzzySymbols extends FuzzyQuery {
     }
 
     /* override */ protected rawQuery(query: string): string {
-        return `${this.repoFilter()}type:symbol count:10 ${query}`
+        return `${fuzzyRepoRevisionSearchFilter(this.repoRevision.current)}type:symbol count:10 ${query}`
     }
 
     /* override */ protected async handleRawQueryPromise(query: string): Promise<PersistableQueryResult[]> {


### PR DESCRIPTION
Previously, the files tab was disabled outside a repository page. Now,
the files tab does global file searches instead.

## Test plan

- `sg start`
- Open `/search` page
- Open Files fuzzy finder with Cmd+P
- Search for any file

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-global-files.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-ityyfpygrb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
