### PR TITLE
search ui: fix color contrast issues

### DIFF
--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -135,6 +135,7 @@ $theme-colors: (
     --danger-2: #e9aaaa;
     --danger-3: #b52626;
     --danger-4: #fbeaea;
+    --danger-text: var(--oc-red-8);
     --body-color: var(--gray-08);
     --body-bg: var(--gray-01);
     --color-bg-1: var(--white);
@@ -155,8 +156,8 @@ $theme-colors: (
     // Start query highlighting
     --search-query-text-color: var(--gray-12);
     --search-filter-keyword-color: var(--primary);
-    --search-filter-separator-color: var(--oc-gray-6);
-    --search-path-separator-color: var(--oc-gray-6);
+    --search-filter-separator-color: var(--oc-gray-7);
+    --search-path-separator-color: var(--oc-gray-7);
     --search-keyword-color: var(--purple);
     --search-regexp-meta-assertion-color: var(--oc-red-9);
     --search-regexp-meta-delimited-color: var(--oc-red-9);
@@ -230,6 +231,7 @@ $theme-colors: (
     --danger-2: #6b1515;
     --danger-3: #801b1b;
     --danger-4: #3d0a0a;
+    --danger-text: var(--oc-red-6);
     --body-color: var(--gray-04);
     --body-bg: var(--gray-12);
     --color-bg-1: var(--gray-11);
@@ -250,8 +252,8 @@ $theme-colors: (
     // Start query highlighting
     --search-query-text-color: var(--gray-04);
     --search-filter-keyword-color: #4393e7;
-    --search-filter-separator-color: var(--oc-gray-6);
-    --search-path-separator-color: var(--oc-gray-6);
+    --search-filter-separator-color: var(--oc-gray-5);
+    --search-path-separator-color: var(--oc-gray-5);
     --search-keyword-color: var(--pink);
     --search-regexp-meta-assertion-color: var(--oc-red-5);
     --search-regexp-meta-delimited-color: var(--oc-red-5);

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.module.scss
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.module.scss
@@ -52,7 +52,7 @@
 }
 
 .test-action-error {
-    color: var(--danger);
+    color: var(--danger-text);
 }
 
 .action-button-row {


### PR DESCRIPTION
Closes #34734
Closes #35736

## Test plan

Verify the new colors meet the minimum contrast requirement of 4.5 using the Chrome devtools

![image](https://user-images.githubusercontent.com/206864/195162361-bd7bf652-c31e-40d7-bbd7-3fc7b5f9148c.png)

![image](https://user-images.githubusercontent.com/206864/195162508-128590b7-2419-46e7-a954-d4e036503331.png)


## App preview:

- [Web](https://sg-web-jp-searchconstrast.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-jyhnbdxqrr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
