### PR TITLE
remove key field from codehost json field

### DIFF
--- a/internal/extsvc/versions/store.go
+++ b/internal/extsvc/versions/store.go
@@ -16,7 +16,7 @@ var (
 type Version struct {
 	ExternalServiceKind string `json:"external_service_kind"`
 	Version             string `json:"version"`
-	Key                 string `json:"key"`
+	Key                 string `json:"-"`
 }
 
 func storeVersions(versions []*Version) error {


### PR DESCRIPTION
[Context](https://sourcegraph.slack.com/archives/C07KZF47K/p1665431134849859)

#42024 added an extra field to the [Version struct for external services](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/internal/extsvc/versions/store.go?L16%3A1-20%3A2=&utm_source=VSCode-2.2.12), this field is used merely as an identifier to recognize different GitLab versions. This stuct was used to send ping data for `code_host_versions` and the `Key` field was sent as part of the ping payload (which shouldn't be).

This PR ensures the field isn't being sent when we marshal the versions for sending pings.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Check the `code_host_versions` ping data and confirm the field isn't being sent.