### PR TITLE
graphql: Separate executors from codeintel

### DIFF
--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -32,6 +32,7 @@ type Services struct {
 	AuthzResolver                   graphqlbackend.AuthzResolver
 	BatchChangesResolver            graphqlbackend.BatchChangesResolver
 	CodeIntelResolver               graphqlbackend.CodeIntelResolver
+	ExecutorResolver                graphqlbackend.ExecutorResolver
 	InsightsResolver                graphqlbackend.InsightsResolver
 	CodeMonitorsResolver            graphqlbackend.CodeMonitorsResolver
 	LicenseResolver                 graphqlbackend.LicenseResolver

--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -10,7 +10,6 @@ import (
 	policiesgraphql "github.com/sourcegraph/sourcegraph/internal/codeintel/policies/transport/graphql"
 	sharedresolvers "github.com/sourcegraph/sourcegraph/internal/codeintel/shared/resolvers"
 	uploadsgraphql "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/transport/graphql"
-	executor "github.com/sourcegraph/sourcegraph/internal/services/executors/transport/graphql"
 )
 
 type CodeIntelResolver interface {
@@ -23,13 +22,8 @@ type CodeIntelResolver interface {
 	NodeResolvers() map[string]NodeByIDFunc
 
 	AutoindexingServiceResolver
-	ExecutorResolver
 	UploadsServiceResolver
 	PoliciesServiceResolver
-}
-
-type ExecutorResolver interface {
-	ExecutorResolver() executor.Resolver
 }
 
 type AutoindexingServiceResolver interface {

--- a/cmd/frontend/graphqlbackend/executors.go
+++ b/cmd/frontend/graphqlbackend/executors.go
@@ -8,8 +8,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	executor "github.com/sourcegraph/sourcegraph/internal/services/executors/transport/graphql"
 	gql "github.com/sourcegraph/sourcegraph/internal/services/executors/transport/graphql"
 )
+
+type ExecutorResolver interface {
+	ExecutorResolver() executor.Resolver
+}
 
 func (r *schemaResolver) Executors(ctx context.Context, args *struct {
 	Query  *string
@@ -22,7 +27,7 @@ func (r *schemaResolver) Executors(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	executors, err := r.CodeIntelResolver.ExecutorResolver().Executors(ctx, args.Query, args.Active, args.First, args.After)
+	executors, err := r.ExecutorResolver.ExecutorResolver().Executors(ctx, args.Query, args.Active, args.First, args.After)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +44,7 @@ func executorByID(ctx context.Context, db database.DB, gqlID graphql.ID, r *sche
 		return nil, err
 	}
 
-	executor, err := r.CodeIntelResolver.ExecutorResolver().Executor(ctx, gqlID)
+	executor, err := r.ExecutorResolver.ExecutorResolver().Executor(ctx, gqlID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/executors.graphql
+++ b/cmd/frontend/graphqlbackend/executors.graphql
@@ -1,0 +1,152 @@
+extend type Query {
+    """
+    Retrieve active executor compute instances.
+    """
+    executors(
+        """
+        An (optional) search query that searches over the hostname, queue name, os, architecture, and
+        version properties.
+        """
+        query: String
+
+        """
+        Whether to show only executors that have sent a heartbeat in the last fifteen minutes.
+        """
+        active: Boolean
+
+        """
+        Returns the first n executors.
+        """
+        first: Int
+
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): ExecutorConnection!
+
+    """
+    Returns true if executors have been configured on the Sourcegraph instance.
+    This is based on heuristics and doesn't necessarily mean that they would be
+    working.
+    """
+    areExecutorsConfigured: Boolean!
+}
+
+"""
+A list of active executors compute instances.
+"""
+type ExecutorConnection {
+    """
+    A list of executors.
+    """
+    nodes: [Executor!]!
+
+    """
+    The total number of executors in this result set.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+An active executor compute instance.
+"""
+type Executor implements Node {
+    """
+    The unique identifier of this executor.
+    """
+    id: ID!
+
+    """
+    The hostname of the executor instance.
+    """
+    hostname: String!
+
+    """
+    The queue name that the executor polls for work.
+    """
+    queueName: String!
+
+    """
+    Active is true, if a heartbeat from the executor has been received at most three heartbeat intervals ago.
+    """
+    active: Boolean!
+
+    """
+    The operating system running the executor.
+    """
+    os: String!
+
+    """
+    The machine architure running the executor.
+    """
+    architecture: String!
+
+    """
+    The version of Git used by the executor.
+    """
+    dockerVersion: String!
+
+    """
+    The version of the executor.
+    """
+    executorVersion: String!
+
+    """
+    The version of Docker used by the executor.
+    """
+    gitVersion: String!
+
+    """
+    The version of Ignite used by the executor.
+    """
+    igniteVersion: String!
+
+    """
+    The version of src-cli used by the executor.
+    """
+    srcCliVersion: String!
+
+    """
+    The first time the executor sent a heartbeat to the Sourcegraph instance.
+    """
+    firstSeenAt: DateTime!
+
+    """
+    The last time the executor sent a heartbeat to the Sourcegraph instance.
+    """
+    lastSeenAt: DateTime!
+    """
+    The compatibility of the executor with respect to the Sourcegraph instance.
+    If outdated, please make sure that the executor and the Sourcegraph backend are of compatible versions. This means they should match in major and minor version, but they may be 1 minor version apart.
+    If too new, please update the Sourcegraph instance to match the version of the executor or downgrade the executor.
+
+    Compatibility can be null if the executor or Sourcegraph instance runs in dev mode or there's a version mismatch.
+    """
+    compatibility: ExecutorCompatibility
+}
+
+"""
+The compatibility of the executor with the sourcegraph instance.
+"""
+enum ExecutorCompatibility {
+    """
+    Executor version is more than one version behind the Sourcegraph instance.
+    """
+    OUTDATED
+
+    """
+    Executor is up-to-date with the Sourcegraph instance.
+    """
+    UP_TO_DATE
+
+    """
+    Executor version is more than one version ahead of the Sourcegraph instance.
+    """
+    VERSION_AHEAD
+}

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -342,23 +342,23 @@ func prometheusGraphQLRequestName(requestName string) string {
 }
 
 func NewSchemaWithNotebooksResolver(db database.DB, notebooks NotebooksResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, nil, nil, nil, nil, notebooks, nil, nil)
+	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, notebooks, nil, nil)
 }
 
 func NewSchemaWithAuthzResolver(db database.DB, authz AuthzResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, authz, nil, nil, nil, nil, nil, nil, nil)
+	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, authz, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func NewSchemaWithBatchChangesResolver(db database.DB, batchChanges BatchChangesResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(db), batchChanges, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	return NewSchema(db, gitserver.NewClient(db), batchChanges, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func NewSchemaWithCodeMonitorsResolver(db database.DB, codeMonitors CodeMonitorsResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, codeMonitors, nil, nil, nil, nil, nil, nil)
+	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, nil, codeMonitors, nil, nil, nil, nil, nil, nil)
 }
 
 func NewSchemaWithLicenseResolver(db database.DB, license LicenseResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, nil, license, nil, nil, nil, nil, nil)
+	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, nil, nil, license, nil, nil, nil, nil, nil)
 }
 
 func NewSchema(
@@ -366,6 +366,7 @@ func NewSchema(
 	gitserverClient gitserver.Client,
 	batchChanges BatchChangesResolver,
 	codeIntel CodeIntelResolver,
+	executors ExecutorResolver,
 	insights InsightsResolver,
 	authz AuthzResolver,
 	codeMonitors CodeMonitorsResolver,
@@ -397,6 +398,12 @@ func NewSchema(
 		for kind, res := range codeIntel.NodeResolvers() {
 			resolver.nodeByIDFns[kind] = res
 		}
+	}
+
+	if executors != nil {
+		EnterpriseResolvers.executorsResolver = executors
+		resolver.ExecutorResolver = executors
+		schemas = append(schemas, executorsSchema)
 	}
 
 	if insights != nil {
@@ -495,6 +502,7 @@ type schemaResolver struct {
 	BatchChangesResolver
 	AuthzResolver
 	CodeIntelResolver
+	ExecutorResolver
 	ComputeResolver
 	InsightsResolver
 	CodeMonitorsResolver
@@ -575,6 +583,7 @@ func newSchemaResolver(db database.DB, gitserverClient gitserver.Client) *schema
 // in enterprise mode. These resolver instances are nil when running as OSS.
 var EnterpriseResolvers = struct {
 	codeIntelResolver           CodeIntelResolver
+	executorsResolver           ExecutorResolver
 	computeResolver             ComputeResolver
 	insightsResolver            InsightsResolver
 	authzResolver               AuthzResolver

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -349,8 +349,8 @@ func NewSchemaWithAuthzResolver(db database.DB, authz AuthzResolver) (*graphql.S
 	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, authz, nil, nil, nil, nil, nil, nil, nil)
 }
 
-func NewSchemaWithBatchChangesResolver(db database.DB, batchChanges BatchChangesResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(db), batchChanges, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+func NewSchemaWithBatchChangesResolver(db database.DB, batchChanges BatchChangesResolver, executorsResolver ExecutorResolver) (*graphql.Schema, error) {
+	return NewSchema(db, gitserver.NewClient(db), batchChanges, nil, executorsResolver, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func NewSchemaWithCodeMonitorsResolver(db database.DB, codeMonitors CodeMonitorsResolver) (*graphql.Schema, error) {
@@ -381,6 +381,10 @@ func NewSchema(
 	schemas := []string{mainSchema}
 
 	if batchChanges != nil {
+		if executors == nil {
+			return nil, errors.New("graphql: batches requires executors to also be initialized")
+		}
+
 		EnterpriseResolvers.batchChangesResolver = batchChanges
 		resolver.BatchChangesResolver = batchChanges
 		schemas = append(schemas, batchesSchema)
@@ -391,6 +395,10 @@ func NewSchema(
 	}
 
 	if codeIntel != nil {
+		if executors == nil {
+			return nil, errors.New("graphql: codeintel requires executors to also be initialized")
+		}
+
 		EnterpriseResolvers.codeIntelResolver = codeIntel
 		resolver.CodeIntelResolver = codeIntel
 		schemas = append(schemas, codeIntelSchema)

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -19,6 +19,11 @@ var batchesSchema string
 //go:embed codeintel.graphql
 var codeIntelSchema string
 
+// executors is the Executors raw graqhql schema.
+//
+//go:embed executors.graphql
+var executorsSchema string
+
 // dotcomSchema is the Dotcom schema extension raw graqhql schema.
 //
 //go:embed dotcom.graphql

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1574,39 +1574,6 @@ type Query {
     ): WebhookLogConnection!
 
     """
-    Retrieve active executor compute instances.
-    """
-    executors(
-        """
-        An (optional) search query that searches over the hostname, queue name, os, architecture, and
-        version properties.
-        """
-        query: String
-
-        """
-        Whether to show only executors that have sent a heartbeat in the last fifteen minutes.
-        """
-        active: Boolean
-
-        """
-        Returns the first n executors.
-        """
-        first: Int
-
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-    ): ExecutorConnection!
-
-    """
-    Returns true if executors have been configured on the Sourcegraph instance.
-    This is based on heuristics and doesn't necessarily mean that they would be
-    working.
-    """
-    areExecutorsConfigured: Boolean!
-
-    """
     (experimental)
     Get invitation based on the JWT in the invitation URL
     """
@@ -1670,104 +1637,6 @@ type Query {
         """
         kind: ExternalServiceKind
     ): WebhookConnection!
-}
-
-"""
-A list of active executors compute instances.
-"""
-type ExecutorConnection {
-    """
-    A list of executors.
-    """
-    nodes: [Executor!]!
-
-    """
-    The total number of executors in this result set.
-    """
-    totalCount: Int!
-
-    """
-    Pagination information.
-    """
-    pageInfo: PageInfo!
-}
-
-"""
-An active executor compute instance.
-"""
-type Executor implements Node {
-    """
-    The unique identifier of this executor.
-    """
-    id: ID!
-
-    """
-    The hostname of the executor instance.
-    """
-    hostname: String!
-
-    """
-    The queue name that the executor polls for work.
-    """
-    queueName: String!
-
-    """
-    Active is true, if a heartbeat from the executor has been received at most three heartbeat intervals ago.
-    """
-    active: Boolean!
-
-    """
-    The operating system running the executor.
-    """
-    os: String!
-
-    """
-    The machine architure running the executor.
-    """
-    architecture: String!
-
-    """
-    The version of Git used by the executor.
-    """
-    dockerVersion: String!
-
-    """
-    The version of the executor.
-    """
-    executorVersion: String!
-
-    """
-    The version of Docker used by the executor.
-    """
-    gitVersion: String!
-
-    """
-    The version of Ignite used by the executor.
-    """
-    igniteVersion: String!
-
-    """
-    The version of src-cli used by the executor.
-    """
-    srcCliVersion: String!
-
-    """
-    The first time the executor sent a heartbeat to the Sourcegraph instance.
-    """
-    firstSeenAt: DateTime!
-
-    """
-    The last time the executor sent a heartbeat to the Sourcegraph instance.
-    """
-    lastSeenAt: DateTime!
-    """
-    The compatibility of the executor with respect to the Sourcegraph instance.
-    If outdated, please make sure that the executor and the Sourcegraph backend are of compatible versions. This means they should match in major and minor version, but they may be 1 minor version apart.
-    If too new, please update the Sourcegraph instance to match the version of the executor or downgrade the executor.
-
-    Compatibility can be null if the executor or Sourcegraph instance runs in dev mode or there's a version mismatch.
-    """
-    compatibility: ExecutorCompatibility
 }
 
 """
@@ -2028,26 +1897,6 @@ enum SearchQueryOutputFormat {
     Mermaid flowchart format.
     """
     MERMAID
-}
-
-"""
-The compatibility of the executor with the sourcegraph instance.
-"""
-enum ExecutorCompatibility {
-    """
-    Executor version is more than one version behind the Sourcegraph instance.
-    """
-    OUTDATED
-
-    """
-    Executor is up-to-date with the Sourcegraph instance.
-    """
-    UP_TO_DATE
-
-    """
-    Executor version is more than one version ahead of the Sourcegraph instance.
-    """
-    VERSION_AHEAD
 }
 
 """

--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -25,7 +25,7 @@ func mustParseGraphQLSchema(t *testing.T, db database.DB) *graphql.Schema {
 func mustParseGraphQLSchemaWithClient(t *testing.T, db database.DB, gitserverClient gitserver.Client) *graphql.Schema {
 	t.Helper()
 
-	parsedSchema, parseSchemaErr := NewSchema(db, gitserverClient, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	parsedSchema, parseSchemaErr := NewSchema(db, gitserverClient, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if parseSchemaErr != nil {
 		t.Fatal(parseSchemaErr)
 	}

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -281,6 +281,7 @@ func Main(enterpriseSetupHook func(db database.DB, codeIntelServices codeintel.S
 		gitserver.NewClient(db),
 		enterprise.BatchChangesResolver,
 		enterprise.CodeIntelResolver,
+		enterprise.ExecutorResolver,
 		enterprise.InsightsResolver,
 		enterprise.AuthzResolver,
 		enterprise.CodeMonitorsResolver,

--- a/enterprise/cmd/frontend/internal/batches/resolvers/main_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/main_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	executor "github.com/sourcegraph/sourcegraph/internal/services/executors/transport/graphql"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -118,8 +119,14 @@ func parseJSONTime(t testing.TB, ts string) time.Time {
 	return timestamp
 }
 
+type mockExecutorResolver struct{}
+
+func (mockExecutorResolver) ExecutorResolver() executor.Resolver {
+	return nil
+}
+
 func newSchema(db database.DB, r graphqlbackend.BatchChangesResolver) (*graphql.Schema, error) {
-	return graphqlbackend.NewSchemaWithBatchChangesResolver(db, r)
+	return graphqlbackend.NewSchemaWithBatchChangesResolver(db, r, mockExecutorResolver{})
 }
 
 func newGitHubExternalService(t *testing.T, store database.ExternalServiceStore) *types.ExternalService {

--- a/enterprise/cmd/frontend/internal/codeintel/init.go
+++ b/enterprise/cmd/frontend/internal/codeintel/init.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
-	executorgraphql "github.com/sourcegraph/sourcegraph/internal/services/executors/transport/graphql"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
@@ -68,8 +67,6 @@ func Init(
 		scopedContext("codenav"),
 	)
 
-	executorResolver := executorgraphql.New(db)
-
 	policyRootResolver := policiesgraphql.NewRootResolver(
 		codeIntelServices.PoliciesService,
 		scopedContext("policies"),
@@ -85,7 +82,6 @@ func Init(
 	enterpriseServices.CodeIntelResolver = newResolver(
 		autoindexingRootResolver,
 		codenavRootResolver,
-		executorResolver,
 		policyRootResolver,
 		uploadRootResolver,
 	)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers.go
@@ -11,13 +11,11 @@ import (
 	policiesgraphql "github.com/sourcegraph/sourcegraph/internal/codeintel/policies/transport/graphql"
 	sharedresolvers "github.com/sourcegraph/sourcegraph/internal/codeintel/shared/resolvers"
 	uploadsgraphql "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/transport/graphql"
-	executor "github.com/sourcegraph/sourcegraph/internal/services/executors/transport/graphql"
 )
 
 type Resolver struct {
 	autoIndexingRootResolver autoindexinggraphql.RootResolver
 	codenavResolver          codenavgraphql.RootResolver
-	executorResolver         executor.Resolver
 	policiesRootResolver     policiesgraphql.RootResolver
 	uploadsRootResolver      uploadsgraphql.RootResolver
 }
@@ -25,14 +23,12 @@ type Resolver struct {
 func newResolver(
 	autoIndexingRootResolver autoindexinggraphql.RootResolver,
 	codenavResolver codenavgraphql.RootResolver,
-	executorResolver executor.Resolver,
 	policiesRootResolver policiesgraphql.RootResolver,
 	uploadsRootResolver uploadsgraphql.RootResolver,
 ) *Resolver {
 	return &Resolver{
 		autoIndexingRootResolver: autoIndexingRootResolver,
 		codenavResolver:          codenavResolver,
-		executorResolver:         executorResolver,
 		policiesRootResolver:     policiesRootResolver,
 		uploadsRootResolver:      uploadsRootResolver,
 	}
@@ -50,10 +46,6 @@ func (r *Resolver) NodeResolvers() map[string]gql.NodeByIDFunc {
 			return r.ConfigurationPolicyByID(ctx, id)
 		},
 	}
-}
-
-func (r *Resolver) ExecutorResolver() executor.Resolver {
-	return r.executorResolver
 }
 
 func (r *Resolver) LSIFUploadByID(ctx context.Context, id graphql.ID) (_ sharedresolvers.LSIFUploadResolver, err error) {

--- a/enterprise/cmd/frontend/internal/executors/init.go
+++ b/enterprise/cmd/frontend/internal/executors/init.go
@@ -1,0 +1,24 @@
+package executors
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/services/executors/transport/graphql"
+)
+
+func Init(
+	ctx context.Context,
+	db database.DB,
+	codeIntelServices codeintel.Services,
+	conf conftypes.UnifiedWatchable,
+	enterpriseServices *enterprise.Services,
+	observationContext *observation.Context,
+) error {
+	enterpriseServices.ExecutorResolver = newResolver(graphql.New(db))
+	return nil
+}

--- a/enterprise/cmd/frontend/internal/executors/resolvers.go
+++ b/enterprise/cmd/frontend/internal/executors/resolvers.go
@@ -1,0 +1,21 @@
+package executors
+
+import (
+	executor "github.com/sourcegraph/sourcegraph/internal/services/executors/transport/graphql"
+)
+
+type Resolver struct {
+	executorResolver executor.Resolver
+}
+
+func newResolver(
+	executorResolver executor.Resolver,
+) *Resolver {
+	return &Resolver{
+		executorResolver: executorResolver,
+	}
+}
+
+func (r *Resolver) ExecutorResolver() executor.Resolver {
+	return r.executorResolver
+}

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/compute"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/dotcom"
 	executor "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executorqueue"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executors"
 	licensing "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing/init"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/notebooks"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry"
@@ -55,6 +56,7 @@ var initFunctions = map[string]EnterpriseInitializer{
 	"batches":        batches.Init,
 	"codeintel":      codeintelinit.Init,
 	"codemonitors":   codemonitors.Init,
+	"executors":      executors.Init,
 	"compute":        compute.Init,
 	"dotcom":         dotcom.Init,
 	"insights":       insights.Init,


### PR DESCRIPTION
Separate the executors initialization from codeintel, which is distinct.

## Test plan

Ran locally.