### PR TITLE
batches: hardcode search version for workspace resolver

### DIFF
--- a/enterprise/internal/batches/service/workspace_resolver.go
+++ b/enterprise/internal/batches/service/workspace_resolver.go
@@ -3,8 +3,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"net/url"
 	"os"
 	"path"
 	"sort"
@@ -404,20 +402,8 @@ func (wr *workspaceResolver) resolveRepositoriesMatchingQuery(ctx context.Contex
 
 const internalSearchClientUserAgent = "Batch Changes repository resolver"
 
-func newSearchRequest(baseURL, query string) (*http.Request, error) {
-	// We explicitly add the version here because `streaminghttp.NewRequest` gets bumped to the latest
-	// version when there's a new one. We want to manually update our version of Search when the time comes.
-	u := fmt.Sprintf("%s/search/stream?v=%s&q=%s", baseURL, searchAPIVersion, url.QueryEscape(query))
-	req, err := http.NewRequest("GET", u, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Accept", "text/event-stream")
-	return req, nil
-}
-
 func (wr *workspaceResolver) runSearch(ctx context.Context, query string, onMatches func(matches []streamhttp.EventMatch)) (err error) {
-	req, err := newSearchRequest(wr.frontendInternalURL, query)
+	req, err := streamhttp.NewRequestWithVersion(wr.frontendInternalURL, query, searchAPIVersion)
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/batches/service/workspace_resolver.go
+++ b/enterprise/internal/batches/service/workspace_resolver.go
@@ -38,6 +38,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+const searchAPIVersion = "V3"
+
 // RepoRevision describes a repository on a branch at a fixed revision.
 type RepoRevision struct {
 	Repo        *types.Repo
@@ -405,7 +407,7 @@ const internalSearchClientUserAgent = "Batch Changes repository resolver"
 func newSearchRequest(baseURL, query string) (*http.Request, error) {
 	// We explicitly add the version here because `streaminghttp.NewRequest` gets bumped to the latest
 	// version when there's a new one. We want to manually update our version of Search when the time comes.
-	u := baseURL + "/search/stream?v=V3&q=" + url.QueryEscape(query)
+	u := fmt.Sprintf("%s/search/stream?v=%s&q=%s", baseURL, searchAPIVersion, url.QueryEscape(query))
 	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/batches/service/workspace_resolver_test.go
+++ b/enterprise/internal/batches/service/workspace_resolver_test.go
@@ -444,8 +444,8 @@ func newStreamSearchTestServer(t *testing.T, matches map[string][]streamhttp.Eve
 		}
 
 		v := req.URL.Query().Get("v")
-		if v != "V3" {
-			http.Error(w, "only v3 search allowed", http.StatusBadRequest)
+		if v != searchAPIVersion {
+			http.Error(w, "wrong search api version", http.StatusBadRequest)
 			return
 		}
 

--- a/enterprise/internal/batches/service/workspace_resolver_test.go
+++ b/enterprise/internal/batches/service/workspace_resolver_test.go
@@ -443,6 +443,12 @@ func newStreamSearchTestServer(t *testing.T, matches map[string][]streamhttp.Eve
 			return
 		}
 
+		v := req.URL.Query().Get("v")
+		if v != "V3" {
+			http.Error(w, "only v3 search allowed", http.StatusBadRequest)
+			return
+		}
+
 		match, ok := matches[q]
 		if !ok {
 			t.Logf("unknown query %q", q)

--- a/internal/search/streaming/http/client.go
+++ b/internal/search/streaming/http/client.go
@@ -3,6 +3,7 @@ package http
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -15,7 +16,14 @@ const maxPayloadSize = 10 * 1024 * 1024 // 10mb
 
 // NewRequest returns an http.Request against the streaming API for query.
 func NewRequest(baseURL string, query string) (*http.Request, error) {
-	u := baseURL + "/search/stream?q=" + url.QueryEscape(query)
+	// when an empty string is passed as version, the route handler defaults to using the
+	// latest supported version.
+	return NewRequestWithVersion(baseURL, query, "")
+}
+
+// NewRequestWithVersion returns an http.Request against the streaming API for query with the specified version.
+func NewRequestWithVersion(baseURL, query, version string) (*http.Request, error) {
+	u := fmt.Sprintf("%s/search/stream?v=%s&q=%s", baseURL, version, url.QueryEscape(query))
 	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The assumption for the original issue is that we don't use the latest version of Search's API for resolving workspaces. That assumption was wrong as we in fact don't specify the version when making a request to the API. This PR ensures the version is explicitly defined in the query parameter when constructing the URL, and it's never[ overridden in the route handler ](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@bo/use-v3-search-batch-change/-/blob/cmd/frontend/internal/search/search.go?L229%3A2-242%3A3=)for Search.

I added a check in [newStreamSearchTestServer method](https://sourcegraph.com/-/editor?remote_url=git%40github.com%3Asourcegraph%2Fsourcegraph.git&branch=bo%2Fuse-v3-search-batch-change&file=enterprise%2Finternal%2Fbatches%2Fservice%2Fworkspace_resolver_test.go&editor=VSCode&version=2.2.12&start_row=445&start_col=2&end_row=449&end_col=3) which fails if the version isn't V3, that way we always have to explicitly define the version the workspace resolver uses when making a call to the search API.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Confirm everything works fine as normal.

Closes #42495