### PR TITLE
insights: additional unit tests to cover series based backfill search job step

### DIFF
--- a/enterprise/internal/insights/pipeline/backfill.go
+++ b/enterprise/internal/insights/pipeline/backfill.go
@@ -236,7 +236,8 @@ func makeRunSearchFunc(logger log.Logger, searchHandlers map[types.GenerationMet
 		groupContext, groupCancel := context.WithCancel(ctx)
 		defer groupCancel()
 		g := group.New().WithContext(groupContext).WithMaxConcurrency(searchWorkerLimit).WithCancelOnError()
-		for _, job := range jobs {
+		for i := 0; i < len(jobs); i++ {
+			job := jobs[i]
 			g.Go(func(ctx context.Context) error {
 				h := searchHandlers[series.GenerationMethod]
 				searchPoints, err := h(ctx, job, series, *job.RecordTime)

--- a/enterprise/internal/insights/pipeline/backfill_test.go
+++ b/enterprise/internal/insights/pipeline/backfill_test.go
@@ -141,11 +141,29 @@ func TestMakeSearchJobs(t *testing.T) {
 		Repo: &itypes.MinimalRepo{ID: api.RepoID(1), Name: api.RepoName("testrepo")},
 	}
 
-	backfillReqInvalidQuery := backfillReq
-	backfillReqInvalidQuery.Series.Query = "patterntype:regexp i++"
+	backfillReqInvalidQuery := &BackfillRequest{
+		Series: &types.InsightSeries{
+			ID:                  1,
+			SeriesID:            "abc",
+			Query:               "patterntype:regexp i++",
+			CreatedAt:           createdDate,
+			SampleIntervalUnit:  string(types.Week),
+			SampleIntervalValue: 1,
+		},
+		Repo: &itypes.MinimalRepo{ID: api.RepoID(1), Name: api.RepoName("testrepo")},
+	}
 
-	backfillReqRepoQuery := backfillReq
-	backfillReqRepoQuery.Series.Query = "test query repo:repoA"
+	backfillReqRepoQuery := &BackfillRequest{
+		Series: &types.InsightSeries{
+			ID:                  1,
+			SeriesID:            "abc",
+			Query:               "test query repo:repoA",
+			CreatedAt:           createdDate,
+			SampleIntervalUnit:  string(types.Week),
+			SampleIntervalValue: 1,
+		},
+		Repo: &itypes.MinimalRepo{ID: api.RepoID(1), Name: api.RepoName("testrepo")},
+	}
 
 	basicCommitClient := newFakeCommitClient(&firstCommit, recentCommits)
 	// used to simulate a single call to recent commits failing
@@ -172,10 +190,48 @@ func TestMakeSearchJobs(t *testing.T) {
 		want         autogold.Value
 	}{
 		{commitClient: basicCommitClient, backfillReq: backfillReq, workers: 1,
-			want: autogold.Want("Base case single worker", []string{"error occured: false"})},
-		{commitClient: basicCommitClient, backfillReq: backfillReq, workers: 5, want: autogold.Want("Base case multiple workers", []string{"error occured: false"})},
-		{commitClient: newFakeCommitClient(&recentFirstCommit, recentCommits), backfillReq: backfillReq, workers: 1, want: autogold.Want("First commit during backfill period", []string{"error occured: false"})},
-		{commitClient: newFakeCommitClient(&recentFirstCommit, recentCommits), backfillReq: backfillReq, workers: 5, want: autogold.Want("First commit during backfill period multiple workers", []string{"error occured: false"})},
+			want: autogold.Want("Base case single worker", []string{
+				"job recordtime:2022-04-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2022-03-25T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2022-03-18T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2022-03-11T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2022-03-04T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2022-02-25T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2022-02-18T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2022-02-11T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2022-02-04T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2022-01-28T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2022-01-21T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"job recordtime:2022-01-14T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+				"error occured: false",
+			})},
+		{commitClient: basicCommitClient, backfillReq: backfillReq, workers: 5, want: autogold.Want("Base case multiple workers", []string{
+			"job recordtime:2022-04-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2022-03-25T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2022-03-18T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2022-03-11T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2022-03-04T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2022-02-25T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2022-02-18T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2022-02-11T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2022-02-04T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2022-01-28T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2022-01-21T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2022-01-14T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"error occured: false",
+		})},
+		{commitClient: newFakeCommitClient(&recentFirstCommit, recentCommits), backfillReq: backfillReq, workers: 1, want: autogold.Want("First commit during backfill period", []string{
+			"job recordtime:2022-04-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2022-03-25T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2022-03-18T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"error occured: false",
+		})},
+		{commitClient: newFakeCommitClient(&recentFirstCommit, recentCommits), backfillReq: backfillReq, workers: 5, want: autogold.Want("First commit during backfill period multiple workers", []string{
+			"job recordtime:2022-04-01T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2022-03-25T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"job recordtime:2022-03-18T00:00:00Z query:fork:no archived:no patterntype:literal count:99999999 test query repo:^testrepo$@1",
+			"error occured: false",
+		})},
 		{commitClient: basicCommitClient, backfillReq: backfillReq, workers: 1, cancled: true, want: autogold.Want("Cancled case single worker", []string{"error occured: true"})},
 		{commitClient: basicCommitClient, backfillReq: backfillReq, workers: 5, cancled: true, want: autogold.Want("Cancled case multiple workers", []string{"error occured: true"})},
 		{commitClient: &fakeCommitClient{
@@ -193,12 +249,12 @@ func TestMakeSearchJobs(t *testing.T) {
 		{commitClient: &fakeCommitClient{
 			firstCommit:   basicCommitClient.FirstCommit,
 			recentCommits: recentsErrorAfter(6, recentCommits),
-		}, backfillReq: backfillReq, workers: 1, want: autogold.Want("Error in some jobs single worker", []string{"error occured: false"})},
+		}, backfillReq: backfillReq, workers: 1, want: autogold.Want("Error in some jobs single worker", []string{"error occured: true"})},
 		{commitClient: &fakeCommitClient{
 			firstCommit:   basicCommitClient.FirstCommit,
 			recentCommits: recentsErrorAfter(6, recentCommits),
-		}, backfillReq: backfillReq, workers: 5, want: autogold.Want("Error in some jobs multiple worker", []string{"error occured: false"})},
-		{commitClient: basicCommitClient, backfillReq: backfillReqInvalidQuery, workers: 1, want: autogold.Want("Invalid query", []string{"error occured: false"})},
+		}, backfillReq: backfillReq, workers: 5, want: autogold.Want("Error in some jobs multiple worker", []string{"error occured: true"})},
+		{commitClient: basicCommitClient, backfillReq: backfillReqInvalidQuery, workers: 1, want: autogold.Want("Invalid query", []string{"error occured: true"})},
 		{commitClient: basicCommitClient, backfillReq: backfillReqRepoQuery, workers: 1, want: autogold.Want("Query with repo: in it ", []string{"error occured: false"})},
 	}
 

--- a/enterprise/internal/insights/pipeline/backfill_test.go
+++ b/enterprise/internal/insights/pipeline/backfill_test.go
@@ -26,10 +26,12 @@ import (
 func makeTestJobGenerator(numJobs int) SearchJobGenerator {
 	return func(ctx context.Context, req requestContext) (context.Context, *requestContext, []*queryrunner.SearchJob, error) {
 		jobs := make([]*queryrunner.SearchJob, 0, numJobs)
+		recordDate := time.Date(2022, time.April, 1, 0, 0, 0, 0, time.UTC)
 		for i := 0; i < numJobs; i++ {
 			jobs = append(jobs, &queryrunner.SearchJob{
 				SeriesID:    req.backfillRequest.Series.SeriesID,
 				SearchQuery: "test search",
+				RecordTime:  &recordDate,
 			})
 		}
 		return ctx, &req, jobs, nil
@@ -302,14 +304,6 @@ func TestMakeRunSearch(t *testing.T) {
 			incomingErr: errors.New("earlier error"),
 			jobs:        jobs,
 			want:        autogold.Want("incoming error", []string{"error occured: true"}),
-		},
-		{
-			backfillReq: backfillReq,
-			workers:     1,
-			handlers:    defaultHandlers,
-			incomingErr: errors.New("earlier error"),
-			jobs:        jobs,
-			want:        autogold.Want("incoming error", nil),
 		},
 		{
 			backfillReq: backfillReq,


### PR DESCRIPTION
Adds unit tests for the step of running searches to verify functionality.  Fixes iteration bug when there are multiple workers running searches.

resolves https://github.com/sourcegraph/sourcegraph/issues/42463

## Test plan
Unit tests pass
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
