### PR TITLE
Remove function and interface previously used to fetch user perms for external services

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
-	eauthz "github.com/sourcegraph/sourcegraph/enterprise/internal/authz"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -351,7 +350,7 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 
 	byServiceID := s.providersByServiceID()
 	accounts := s.db.UserExternalAccounts()
-	logger := s.logger.Scoped("fetchUserPermsViaExternalServices", "sync permissions using external accounts (logging connections)").With(log.Int32("userID", user.ID))
+	logger := s.logger.Scoped("fetchUserPermsViaExternalAccounts", "sync permissions using external accounts (logging connections)").With(log.Int32("userID", user.ID))
 
 	// Check if the user has an external account for every authz provider respectively,
 	// and try to fetch the account when not.
@@ -599,154 +598,6 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 	return repoIDs, subRepoPerms, nil
 }
 
-// fetchUserPermsViaExternalServices uses user code connections to list all
-// accessible private repositories on code hosts for the given user.
-func (s *PermsSyncer) fetchUserPermsViaExternalServices(ctx context.Context, userID int32, fetchOpts authz.FetchPermsOptions) (repoIDs []uint32, err error) {
-	logger := s.logger.Scoped("fetchUserPermsViaExternalServices", "sync permissions using code host connections").With(log.Int32("userID", userID))
-
-	has, err := s.permsStore.UserIsMemberOfOrgHasCodeHostConnection(ctx, userID)
-	if err != nil {
-		return nil, errors.Wrap(err, "check user organization membership with a code host connection")
-	}
-
-	// NOTE: User-centric permissions syncing needs parity from the repo-centric
-	//  permissions syncing. Therefore, if the user is not a member of any
-	//  organization that has a code host connection connected, there is no point to
-	//  do the user-centric syncing.
-	if !has {
-		return []uint32{}, nil
-	}
-
-	svcs, err := s.db.ExternalServices().List(ctx,
-		database.ExternalServicesListOptions{
-			NamespaceUserID: userID,
-			Kinds:           []string{extsvc.KindGitHub, extsvc.KindGitLab},
-		},
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "list user external services")
-	}
-
-	var repoSpecs, includeContainsSpecs, excludeContainsSpecs []api.ExternalRepoSpec
-	for _, svc := range svcs {
-		svcLogger := logger.With(log.Int32("svc.ID", int32(svc.ID)))
-
-		provider, err := eauthz.ProviderFromExternalService(ctx, s.db.ExternalServices(), conf.Get().SiteConfiguration, svc, s.db)
-		if err != nil {
-			return nil, errors.Wrapf(err, "new provider from external service %d", svc.ID)
-		}
-		if provider == nil {
-			// NOTE: User code host connection can only be added on sourcegraph.com, and
-			//  authorization is enforced for everything, it does not make sense that we cannot
-			//  derive an `authz.Provider` from it.
-			svcLogger.Warn("noAuthzProvider")
-			continue
-		}
-
-		token, err := extsvc.ExtractEncryptableToken(ctx, svc.Config, svc.Kind)
-		if err != nil {
-			return nil, errors.Wrapf(err, "extract token from external service %d", svc.ID)
-		}
-		if token == "" {
-			return nil, errors.Errorf("empty token from external service %d", svc.ID)
-		}
-
-		if err := s.waitForRateLimit(ctx, provider.URN(), 1, "user"); err != nil {
-			return nil, errors.Wrap(err, "wait for rate limiter")
-		}
-
-		extPerms, err := provider.FetchUserPermsByToken(ctx, token, fetchOpts)
-		if err != nil {
-			// The "401 Unauthorized" is returned by code hosts when the token is no longer valid
-			unauthorized := errcode.IsUnauthorized(err)
-
-			forbidden := errcode.IsForbidden(err)
-
-			// Detect GitHub account suspension error
-			accountSuspended := errcode.IsAccountSuspended(err)
-
-			if unauthorized || accountSuspended || forbidden {
-				svcLogger.Warn("expiredExternalService",
-					log.Bool("unauthorized", unauthorized),
-					log.Bool("accountSuspended", accountSuspended),
-					log.Bool("forbidden", forbidden),
-				)
-
-				// We still want to continue processing other external services
-				continue
-			}
-
-			// Skip this external account if unimplemented
-			if errors.Is(err, &authz.ErrUnimplemented{}) {
-				svcLogger.Debug("unimplemented", log.Error(err))
-				continue
-			}
-
-			return nil, errors.Wrapf(err, "fetch user permissions for external service %d", svc.ID)
-		}
-
-		if extPerms == nil {
-			continue
-		}
-
-		for _, exact := range extPerms.Exacts {
-			repoSpecs = append(repoSpecs,
-				api.ExternalRepoSpec{
-					ID:          string(exact),
-					ServiceType: provider.ServiceType(),
-					ServiceID:   provider.ServiceID(),
-				},
-			)
-		}
-		for _, includePrefix := range extPerms.IncludeContains {
-			includeContainsSpecs = append(includeContainsSpecs,
-				api.ExternalRepoSpec{
-					ID:          string(includePrefix),
-					ServiceType: provider.ServiceType(),
-					ServiceID:   provider.ServiceID(),
-				},
-			)
-		}
-		for _, excludePrefix := range extPerms.ExcludeContains {
-			excludeContainsSpecs = append(excludeContainsSpecs,
-				api.ExternalRepoSpec{
-					ID:          string(excludePrefix),
-					ServiceType: provider.ServiceType(),
-					ServiceID:   provider.ServiceID(),
-				},
-			)
-		}
-	}
-
-	// Get corresponding internal database IDs
-	repoNames, err := s.listPrivateRepoNamesBySpecs(ctx, repoSpecs)
-	if err != nil {
-		return nil, errors.Wrap(err, "list external repositories by exact matching")
-	}
-
-	// Exclusions are relative to inclusions, so if there is no inclusion, exclusion
-	// are meaningless and no need to trigger a DB query.
-	if len(includeContainsSpecs) > 0 {
-		rs, err := s.reposStore.RepoStore().ListMinimalRepos(ctx,
-			database.ReposListOptions{
-				ExternalRepoIncludeContains: includeContainsSpecs,
-				ExternalRepoExcludeContains: excludeContainsSpecs,
-				OnlyPrivate:                 true,
-			},
-		)
-		if err != nil {
-			return nil, errors.Wrap(err, "list external repositories by contains matching")
-		}
-		repoNames = append(repoNames, rs...)
-	}
-
-	repoIDs = make([]uint32, 0, len(repoNames))
-	for _, r := range repoNames {
-		repoIDs = append(repoIDs, uint32(r.ID))
-	}
-	return repoIDs, nil
-}
-
 // syncUserPerms processes permissions syncing request in user-centric way. When `noPerms` is true,
 // the method will use partial results to update permissions tables even when error occurs.
 func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms bool, fetchOpts authz.FetchPermsOptions) (err error) {
@@ -780,12 +631,6 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 		return errors.Wrap(err, "fetch user permissions via external accounts")
 	}
 
-	externalServicesRepoIDs, err := s.fetchUserPermsViaExternalServices(ctx, user.ID, fetchOpts)
-	if err != nil {
-		tryTouchUserPerms()
-		return errors.Wrap(err, "fetch user permissions via external services")
-	}
-
 	// Save permissions to database
 	p := &authz.UserPermissions{
 		UserID: user.ID,
@@ -800,9 +645,6 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 	// Looping over two slices individually in order to avoid unnecessary memory allocation.
 	for i := range externalAccountsRepoIDs {
 		p.IDs[int32(externalAccountsRepoIDs[i])] = struct{}{}
-	}
-	for i := range externalServicesRepoIDs {
-		p.IDs[int32(externalServicesRepoIDs[i])] = struct{}{}
 	}
 
 	// Set sub-repository permissions

--- a/enterprise/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/internal/authz/bitbucketserver/provider.go
@@ -156,12 +156,6 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 	}, err
 }
 
-// FetchUserPermsByToken is the same as FetchUserPerms, but it only requires a
-// token.
-func (p *Provider) FetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	return nil, errors.New("not implemented")
-}
-
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to
 // the given repo on the code host. The user ID has the same value as it would
 // be used as extsvc.Account.AccountID. The returned list includes both direct access

--- a/enterprise/internal/authz/gerrit/gerrit.go
+++ b/enterprise/internal/authz/gerrit/gerrit.go
@@ -119,10 +119,6 @@ func (p Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, o
 	return nil, &authz.ErrUnimplemented{Feature: "gerrit.FetchRepoPerms"}
 }
 
-func (p Provider) FetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	return nil, &authz.ErrUnimplemented{Feature: "gerrit.FetchUserPermsByToken"}
-}
-
 func (p Provider) ServiceType() string {
 	return p.codeHost.ServiceType
 }

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -346,12 +346,6 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 	return p.fetchUserPermsByToken(ctx, extsvc.AccountID(account.AccountID), tok.AccessToken, opts)
 }
 
-// FetchUserPermsByToken is the same as FetchUserPerms, but it only requires a
-// token.
-func (p *Provider) FetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	return p.fetchUserPermsByToken(ctx, "", token, opts)
-}
-
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to
 // the given project on the code host. The user ID has the same value as it would
 // be used as extsvc.Account.AccountID. The returned list includes both direct access

--- a/enterprise/internal/authz/gitlab/oauth.go
+++ b/enterprise/internal/authz/gitlab/oauth.go
@@ -112,13 +112,6 @@ func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Acco
 	return listProjects(ctx, client)
 }
 
-// FetchUserPermsByToken is the same as FetchUserPerms, but it only requires a
-// token.
-func (p *OAuthProvider) FetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	client := p.clientProvider.GetOAuthClient(token)
-	return listProjects(ctx, client)
-}
-
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to
 // the given project on the code host. The user ID has the same value as it would
 // be used as extsvc.Account.AccountID. The returned list includes both direct access

--- a/enterprise/internal/authz/gitlab/sudo.go
+++ b/enterprise/internal/authz/gitlab/sudo.go
@@ -213,13 +213,6 @@ func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Accou
 	return listProjects(ctx, client)
 }
 
-// FetchUserPermsByToken is the same as FetchUserPerms, but it only requires a
-// token.
-func (p *SudoProvider) FetchUserPermsByToken(ctx context.Context, token string, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	client := p.clientProvider.GetOAuthClient(token)
-	return listProjects(ctx, client)
-}
-
 // listProjects is a helper function to request for all private projects that are accessible
 // (access level: 20 => Reporter access) by the authenticated or impersonated user in the client.
 // It may return partial but valid results in case of error, and it is up to callers to decide

--- a/enterprise/internal/authz/perforce/perforce.go
+++ b/enterprise/internal/authz/perforce/perforce.go
@@ -191,12 +191,6 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 	return perms, errors.Wrap(err, "FetchUserPerms")
 }
 
-// FetchUserPermsByToken is the same as FetchUserPerms, but it only requires a
-// token.
-func (p *Provider) FetchUserPermsByToken(_ context.Context, _ string, _ authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
-	return nil, &authz.ErrUnimplemented{Feature: "perforce.FetchUserPermsByToken"}
-}
-
 // getAllUserEmails returns a set of username -> email pairs of all users in the Perforce server.
 func (p *Provider) getAllUserEmails(ctx context.Context) (map[string]string, error) {
 	if p.cachedAllUserEmails != nil && cacheIsUpToDate(p.emailsCacheLastUpdate) {

--- a/internal/authz/iface.go
+++ b/internal/authz/iface.go
@@ -121,10 +121,6 @@ type Provider interface {
 	// to decide whether to discard.
 	FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, opts FetchPermsOptions) ([]extsvc.AccountID, error)
 
-	// FetchUserPermsByToken is similar to FetchUserPerms but only requires a token
-	// in order to communicate with the code host.
-	FetchUserPermsByToken(ctx context.Context, token string, opts FetchPermsOptions) (*ExternalUserPermissions, error)
-
 	// ServiceType returns the service type (e.g., "gitlab") of this authz provider.
 	ServiceType() string
 


### PR DESCRIPTION
Issue #42794 

As we only support code host connections added by site admins, via the Site Admin area, there's no need to keep, in our codebase, some code that was used, in the past (for dotcom) to fetch permissions for code host connections added by users.

This PR removes the `fetchUserPermsViaExternalServices` function and an interface used by this it.


## Test plan
Unit tests were updated to reflect the changes and all tests are passing as seen [here]( https://buildkite.com/sourcegraph/sourcegraph/builds/177228), in this build.
