### PR TITLE
search ui: allow scrolling long notebooks with arrow keys

### DIFF
--- a/client/web/src/notebooks/notebook/useNotebookEventHandlers.ts
+++ b/client/web/src/notebooks/notebook/useNotebookEventHandlers.ts
@@ -100,7 +100,7 @@ export function useNotebookEventHandlers({
             const target = event.target as HTMLElement
 
             // Don't handle keydown events if the alt/option key is pressed.
-            // This allows using Opt+Arrow to page up/down on macOS.
+            // This allows using Opt+Arrow keys to page up/down on macOS.
             if (event.altKey) {
                 return
             }
@@ -150,9 +150,12 @@ export function useNotebookEventHandlers({
                     event.preventDefault()
                 } else {
                     // If the block is not visible in the direction we're moving, scroll the window. Otherwise, move the selection.
+                    // Also allow scrolling beyond the selected block if it is the first/last block.
                     if (
                         (event.key === 'ArrowUp' && !isTopOfBlockVisible(selectedBlockId)) ||
-                        (event.key === 'ArrowDown' && !isBottomOfBlockVisible(selectedBlockId))
+                        (event.key === 'ArrowDown' && !isBottomOfBlockVisible(selectedBlockId)) ||
+                        (event.key === 'ArrowUp' && selectedBlockId === notebook.getFirstBlockId()) ||
+                        (event.key === 'ArrowDown' && selectedBlockId === notebook.getLastBlockId())
                     ) {
                         return
                     }


### PR DESCRIPTION
Closes #35166

- Using Opt+up/down will no longer move focus. This is to allow using these keys to be used for page up/down on Mac.
- When focused on a very long notebook block, the arrow keys will scroll until reaching to bottom/top of the block before changing focus again.
- When focused on the first or last block of the notebook, allow scrolling beyond them (up for the first block, down for the last block) with the arrow keys.

## Test plan

https://user-images.githubusercontent.com/206864/195206055-74a86b65-dd2a-4b2d-beb7-d6aea05c63ea.mp4



## App preview:

- [Web](https://sg-web-jp-notebookarrows.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wxgmmulcjl.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

