### PR TITLE
migrations/frontend: Add column repo_status to gitserver_repos table

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -9808,6 +9808,19 @@
           "Comment": ""
         },
         {
+          "Name": "repo_status",
+          "Index": 9,
+          "TypeName": "text",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
           "Name": "shard_id",
           "Index": 3,
           "TypeName": "text",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1325,6 +1325,7 @@ Indexes:
  last_fetched    | timestamp with time zone |           | not null | now()
  last_changed    | timestamp with time zone |           | not null | now()
  repo_size_bytes | bigint                   |           |          | 
+ repo_status     | text                     |           |          | 
 Indexes:
     "gitserver_repos_pkey" PRIMARY KEY, btree (repo_id)
     "gitserver_repos_cloned_status_idx" btree (repo_id) WHERE clone_status = 'cloned'::text

--- a/migrations/frontend/1665524865_add_column_repo_status_to_gitserver_repos_table/down.sql
+++ b/migrations/frontend/1665524865_add_column_repo_status_to_gitserver_repos_table/down.sql
@@ -1,0 +1,5 @@
+-- Undo the changes made in the up migration
+
+ALTER TABLE gitserver_repos
+      DROP COLUMN IF EXISTS repo_status;
+

--- a/migrations/frontend/1665524865_add_column_repo_status_to_gitserver_repos_table/metadata.yaml
+++ b/migrations/frontend/1665524865_add_column_repo_status_to_gitserver_repos_table/metadata.yaml
@@ -1,0 +1,2 @@
+name: add column repo_status to gitserver_repos table
+parents: [1665399117, 1662636054]

--- a/migrations/frontend/1665524865_add_column_repo_status_to_gitserver_repos_table/up.sql
+++ b/migrations/frontend/1665524865_add_column_repo_status_to_gitserver_repos_table/up.sql
@@ -1,14 +1,2 @@
--- Perform migration here.
---
--- See /migrations/README.md. Highlights:
---  * Make migrations idempotent (use IF EXISTS)
---  * Make migrations backwards-compatible (old readers/writers must continue to work)
---  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement
---    is defined per file, and that each such statement is NOT wrapped in a transaction.
---    Each such migration must also declare "createIndexConcurrently: true" in their
---    associated metadata.yaml file.
---  * If you are modifying Postgres extensions, you must also declare "privileged: true"
---    in the associated metadata.yaml file.
-
 ALTER TABLE gitserver_repos
       ADD COLUMN IF NOT EXISTS repo_status text;

--- a/migrations/frontend/1665524865_add_column_repo_status_to_gitserver_repos_table/up.sql
+++ b/migrations/frontend/1665524865_add_column_repo_status_to_gitserver_repos_table/up.sql
@@ -1,0 +1,14 @@
+-- Perform migration here.
+--
+-- See /migrations/README.md. Highlights:
+--  * Make migrations idempotent (use IF EXISTS)
+--  * Make migrations backwards-compatible (old readers/writers must continue to work)
+--  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement
+--    is defined per file, and that each such statement is NOT wrapped in a transaction.
+--    Each such migration must also declare "createIndexConcurrently: true" in their
+--    associated metadata.yaml file.
+--  * If you are modifying Postgres extensions, you must also declare "privileged: true"
+--    in the associated metadata.yaml file.
+
+ALTER TABLE gitserver_repos
+      ADD COLUMN IF NOT EXISTS repo_status text;

--- a/migrations/frontend/1665524865_add_column_repo_status_to_gitserver_repos_table/up.sql
+++ b/migrations/frontend/1665524865_add_column_repo_status_to_gitserver_repos_table/up.sql
@@ -1,2 +1,7 @@
 ALTER TABLE gitserver_repos
+      -- repo_status indicates the "live" status of a cloned repo and
+      -- is to be used in addition to clone_status. For example, it
+      -- may indicate if a repo is currently being "fetched" or if it
+      -- is currently being garbage collcted by one of the cleanup
+      -- jobs.
       ADD COLUMN IF NOT EXISTS repo_status text;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -2021,7 +2021,8 @@ CREATE TABLE gitserver_repos (
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     last_fetched timestamp with time zone DEFAULT now() NOT NULL,
     last_changed timestamp with time zone DEFAULT now() NOT NULL,
-    repo_size_bytes bigint
+    repo_size_bytes bigint,
+    repo_status text
 );
 
 CREATE TABLE gitserver_repos_statistics (


### PR DESCRIPTION
Fixes #42394 

The issue title says to add a boolean column, but with careful thought a text column named `repo_status` is a better fit.

## Test plan

1. Tested both `sg migration up` and `sg migration downto` locally.


https://user-images.githubusercontent.com/2682729/195206940-b17eeae7-37c3-4a44-80e9-70367ee19bc9.mov


2. main-dry-run: https://buildkite.com/sourcegraph/sourcegraph/builds/177272

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
