### PR TITLE
frontend: revert part of #42736 to fix asset loading

### DIFF
--- a/cmd/frontend/internal/app/assetsutil/url.go
+++ b/cmd/frontend/internal/app/assetsutil/url.go
@@ -1,13 +1,28 @@
 package assetsutil
 
 import (
+	"log"
 	"net/url"
 	"path"
+
+	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 
-// baseURL is the path prefix under which static assets should
-// be served.
-var baseURL = &url.URL{}
+var (
+	assetsRoot = env.Get("ASSETS_ROOT", "/.assets", "URL to web assets")
+
+	// baseURL is the path prefix under which static assets should
+	// be served.
+	baseURL = &url.URL{}
+)
+
+func init() {
+	var err error
+	baseURL, err = url.Parse(assetsRoot)
+	if err != nil {
+		log.Fatalln("Parsing ASSETS_ROOT failed:", err)
+	}
+}
 
 // URL returns a URL, possibly relative, to the asset at path
 // p.

--- a/cmd/frontend/internal/app/assetsutil/url.go
+++ b/cmd/frontend/internal/app/assetsutil/url.go
@@ -1,7 +1,7 @@
 package assetsutil
 
 import (
-	"log"
+	"fmt"
 	"net/url"
 	"path"
 
@@ -20,7 +20,7 @@ func init() {
 	var err error
 	baseURL, err = url.Parse(assetsRoot)
 	if err != nil {
-		log.Fatalln("Parsing ASSETS_ROOT failed:", err)
+		panic(fmt.Sprintf("Parsing ASSETS_ROOT failed: %s", err))
 	}
 }
 


### PR DESCRIPTION
The seemingly unused `init` function removed in #42736 was load bearing, but not in an obvious way: the global variable it set was used in a different part of the package when generating asset URLs. Without that variable, asset URLs are missing their `.assets` section, and are therefore resulting in requests that Sourcegraph is routing to the repo handler.

This PR reinstates the `init`, but closer to the actual code that uses it.

Fixes #42854.

## Test plan

Observed that asset loading failed on `main` (and on dot-com); observed that asset loading works again with this change.