### PR TITLE
Revert "sg: execute bash in interactive mode (#42689)"

### DIFF
--- a/dev/sg/internal/usershell/command.go
+++ b/dev/sg/internal/usershell/command.go
@@ -37,12 +37,6 @@ func wrap(ctx context.Context, cmd string) wrapped {
 	case ShellType(ctx) == FishShell:
 		w.Command = fmt.Sprintf("fish || true; %s", cmd)
 
-	case ShellType(ctx) == BashShell:
-		// -i sets the bash shell to be interactive, since this IS an interactive step but more importantly
-		// on some platforms (I'm looking at you Ubuntu runner from github actions) the ~/.bashrc file has a section
-		// where it EXITs early out of the bashrc file if it is not running in interactive mode ...
-		w.ShellFlags = []string{"-i", "-c"}
-		w.Command = fmt.Sprintf("source %s || true; %s", ShellConfigPath(ctx), cmd)
 	default:
 		// The above interactive shell approach fails on OSX because the default shell configuration
 		// prints sessions restoration informations that will mess with the output. So we fall back


### PR DESCRIPTION
This reverts commit a4ae7a7241a6a173dad235d26dfdda88cb3ad421.

This will require a follow up fix in the ubuntu setup action.

Closes #42853 

## Test plan
1. Dockerfile
```
from ubuntu:22.04

RUN apt update && apt install -y ca-certificates vim sudo
COPY ./go1.18.7.linux-arm64.tar.gz /tmp/
RUN tar -C /usr/local -xzf /tmp/go1.18.7.linux-arm64.tar.gz && rm /tmp/go1.18.7.linux-arm64.tar.gz

ENTRYPOINT "/bin/bash"
```
2. `docker run -ti $SRC/sourcgraph:/home/test ubuntu-22`
3. `git bisect` good commit `5dd5022b6a`
5. `go run ./dev/sg setup`

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
