### PR TITLE
Fix step to save bundle size on main builds

### DIFF
--- a/enterprise/dev/ci/internal/ci/cache_helpers.go
+++ b/enterprise/dev/ci/internal/ci/cache_helpers.go
@@ -13,12 +13,12 @@ func withYarnCache() buildkite.StepOpt {
 	})
 }
 
-func withBundleSizeCache() buildkite.StepOpt {
+func withBundleSizeCache(commit string) buildkite.StepOpt {
 	return buildkite.Cache(&buildkite.CacheOptions{
 		ID:          "bundle_size_cache",
 		Key:         "bundle_size_cache-{{ git.commit }}",
 		RestoreKeys: []string{"bundle_size_cache-{{ git.commit }}"},
-		Paths:       []string{"ui/assets/stats-{{ git.commit }}.json"},
+		Paths:       []string{"ui/assets/stats-" + commit + ".json"},
 		Compress:    true,
 	})
 }

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -222,7 +222,7 @@ func addWebEnterpriseBuild(pipeline *bk.Pipeline, opts CoreTestOperationsOptions
 		cmds = append(cmds,
 			// Emit a stats.json file for bundle size diffs
 			bk.Env("WEBPACK_EXPORT_STATS_FILENAME", "stats-"+commit+".json"),
-			withBundleSizeCache())
+			withBundleSizeCache(commit))
 	}
 
 	if opts.CreateBundleSizeDiff {


### PR DESCRIPTION
This fixes the files to cache on a `main` branch for the new bundle size builds. Unfortunately it seems that `{{ git.commit }}` is not interpolated for `Paths`:

![Screenshot 2022-10-12 at 10 50 26](https://user-images.githubusercontent.com/458591/195296759-a0d9d77c-e6c8-4ff3-b36a-6b71b64b6185.png)

## Test plan

`sg ci build main-dry-run`: https://buildkite.com/sourcegraph/sourcegraph/builds/177328#0183cb78-8759-4a5d-8789-8638d57695e0

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
