### PR TITLE
web: Fix grammar on external service page

### DIFF
--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -318,7 +318,7 @@ const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJob
                 <div className="flex-shrink-0 flex-grow-1 mr-2">
                     {node.startedAt && (
                         <>
-                            {node.finishedAt === null && <>Running since </>}
+                            {node.finishedAt === null && <>Running for </>}
                             {node.finishedAt !== null && <>Ran for </>}
                             <Duration
                                 start={node.startedAt}


### PR DESCRIPTION
It shoul be "Running for" since we display a timer counting up.
