### PR TITLE
Fuzzy finder: add ability to toggle between global and local symbols/files

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyFiles.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFiles.tsx
@@ -99,7 +99,8 @@ export class FuzzyFiles extends FuzzyQuery {
     constructor(
         private readonly client: ApolloClient<object> | undefined,
         onNamesChanged: () => void,
-        private readonly repoRevision: React.MutableRefObject<FuzzyRepoRevision>
+        private readonly repoRevision: React.MutableRefObject<FuzzyRepoRevision>,
+        private readonly isGlobalFilesRef: React.MutableRefObject<boolean>
     ) {
         // Symbol results should not be cached because stale symbol data is complicated to evict/invalidate.
         super(onNamesChanged, emptyFuzzyCache)
@@ -114,7 +115,8 @@ export class FuzzyFiles extends FuzzyQuery {
     }
 
     /* override */ protected rawQuery(query: string): string {
-        return `${fuzzyRepoRevisionSearchFilter(this.repoRevision.current)}type:path count:100 ${query}`
+        const repoFilter = this.isGlobalFilesRef.current ? '' : fuzzyRepoRevisionSearchFilter(this.repoRevision.current)
+        return `${repoFilter}type:path count:100 ${query}`
     }
 
     /* override */ protected async handleRawQueryPromise(query: string): Promise<PersistableQueryResult[]> {

--- a/client/web/src/components/fuzzyFinder/FuzzyFiles.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFiles.tsx
@@ -5,13 +5,21 @@ import { getDocumentNode, gql } from '@sourcegraph/http-client'
 import { Icon } from '@sourcegraph/wildcard'
 
 import { getWebGraphQLClient } from '../../backend/graphql'
+import { SearchValue } from '../../fuzzyFinder/FuzzySearch'
 import { createUrlFunction } from '../../fuzzyFinder/WordSensitiveFuzzySearch'
-import { FileNamesResult, FileNamesVariables } from '../../graphql-operations'
+import {
+    FileNamesResult,
+    FileNamesVariables,
+    FuzzyFinderFilesResult,
+    FuzzyFinderFilesVariables,
+} from '../../graphql-operations'
 
 import { FuzzyFSM, newFuzzyFSMFromValues } from './FuzzyFsm'
-import { FuzzyRepoRevision } from './FuzzyRepoRevision'
+import { emptyFuzzyCache, PersistableQueryResult } from './FuzzyLocalCache'
+import { FuzzyQuery } from './FuzzyQuery'
+import { FuzzyRepoRevision, fuzzyRepoRevisionSearchFilter } from './FuzzyRepoRevision'
 
-export const FUZZY_FILES_QUERY = gql`
+export const FUZZY_GIT_LSFILES_QUERY = gql`
     query FileNames($repository: String!, $commit: String!) {
         repository(name: $repository) {
             id
@@ -19,6 +27,36 @@ export const FUZZY_FILES_QUERY = gql`
                 id
                 fileNames
             }
+        }
+    }
+`
+
+export const FUZZY_FILES_QUERY = gql`
+    query FuzzyFinderFiles($query: String!) {
+        search(patternType: regexp, query: $query) {
+            results {
+                results {
+                    ... on FileMatch {
+                        __typename
+                        ...FileMatchFields
+                    }
+                }
+            }
+        }
+    }
+    fragment FileMatchFields on FileMatch {
+        symbols {
+            name
+            containerName
+            kind
+            language
+            url
+        }
+        repository {
+            name
+        }
+        file {
+            path
         }
     }
 `
@@ -31,7 +69,7 @@ export async function loadFilesFSM(
     try {
         const client = apolloClient || (await getWebGraphQLClient())
         const response = await client.query<FileNamesResult, FileNamesVariables>({
-            query: getDocumentNode(FUZZY_FILES_QUERY),
+            query: getDocumentNode(FUZZY_GIT_LSFILES_QUERY),
             variables: { repository: repoRevision.repositoryName, commit: repoRevision.revision },
         })
         if (response.errors && response.errors.length > 0) {
@@ -55,4 +93,46 @@ export function newFuzzyFSM(filenames: string[], createUrl: createUrlFunction): 
         })),
         createUrl
     )
+}
+
+export class FuzzyFiles extends FuzzyQuery {
+    constructor(
+        private readonly client: ApolloClient<object> | undefined,
+        onNamesChanged: () => void,
+        private readonly repoRevision: React.MutableRefObject<FuzzyRepoRevision>
+    ) {
+        // Symbol results should not be cached because stale symbol data is complicated to evict/invalidate.
+        super(onNamesChanged, emptyFuzzyCache)
+    }
+
+    /* override */ protected searchValues(): SearchValue[] {
+        return [...this.queryResults.values()].map(({ text, url }) => ({
+            text,
+            url,
+            icon: <Icon aria-label={text} svgPath={mdiFileDocumentOutline} />,
+        }))
+    }
+
+    /* override */ protected rawQuery(query: string): string {
+        return `${fuzzyRepoRevisionSearchFilter(this.repoRevision.current)}type:path count:100 ${query}`
+    }
+
+    /* override */ protected async handleRawQueryPromise(query: string): Promise<PersistableQueryResult[]> {
+        const client = this.client || (await getWebGraphQLClient())
+        const response = await client.query<FuzzyFinderFilesResult, FuzzyFinderFilesVariables>({
+            query: getDocumentNode(FUZZY_FILES_QUERY),
+            variables: { query },
+        })
+        const results = response.data?.search?.results?.results || []
+        const queryResults: PersistableQueryResult[] = []
+        for (const result of results) {
+            if (result.__typename === 'FileMatch') {
+                queryResults.push({
+                    text: `${result.repository.name}/${result.file.path}`,
+                    url: `/${result.repository.name}/-/blob/${result.file.path}`,
+                })
+            }
+        }
+        return queryResults
+    }
 }

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.mocks.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.mocks.tsx
@@ -9,7 +9,7 @@ import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/teleme
 import { FileNamesResult, FuzzyFinderRepoResult, FuzzyFinderSymbolsResult, SymbolKind } from '../../graphql-operations'
 import { ThemePreference } from '../../theme'
 
-import { FUZZY_FILES_QUERY } from './FuzzyFiles'
+import { FUZZY_GIT_LSFILES_QUERY } from './FuzzyFiles'
 import { FuzzyFinderContainer } from './FuzzyFinder'
 import { FUZZY_REPOS_QUERY } from './FuzzyRepos'
 import { FUZZY_SYMBOLS_QUERY } from './FuzzySymbols'
@@ -47,7 +47,7 @@ export const FuzzyWrapper: React.FunctionComponent<FuzzyWrapperProps> = props =>
 
 export const FUZZY_FILES_MOCK: MockedResponse<FileNamesResult> = {
     request: {
-        query: getDocumentNode(FUZZY_FILES_QUERY),
+        query: getDocumentNode(FUZZY_GIT_LSFILES_QUERY),
         variables: { repository: 'github.com/sourcegraph/sourcegraph', commit: 'main' },
     },
     result: {

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
@@ -44,7 +44,6 @@ export const FuzzyFinderContainer: React.FunctionComponent<FuzzyFinderContainerP
 
     const openFuzzyFinder = useCallback(
         (tab: FuzzyTabKey): void => {
-            console.log({ repositoryName: repositoryName.current, isOnlyFiles: tabsRef.current.isOnlyFilesEnabled() })
             if (tabsRef.current.isOnlyFilesEnabled() && !repositoryName.current) {
                 return // Legacy mode: only activate inside a repository
             }

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, Dispatch, SetStateAction, useCallback } from 'react'
+import React, { useEffect, Dispatch, SetStateAction, useCallback, useRef } from 'react'
 
 import * as H from 'history'
 
@@ -27,23 +27,52 @@ export interface FuzzyFinderContainerProps
  */
 export const FuzzyFinderContainer: React.FunctionComponent<FuzzyFinderContainerProps> = props => {
     const { isVisible, setIsVisible } = props
+    const isVisibleRef = useRef(isVisible)
+    isVisibleRef.current = isVisible
     const state = useFuzzyState(props, () => setIsVisible(false))
-    const { tabs, activeTab, setActiveTab, repoRevision } = state
-    const shortcuts = useFuzzyShortcuts(props.settingsCascade.final)
+    const { tabs, activeTab, setActiveTab, repoRevision, toggleGlobalFiles, toggleGlobalSymbols } = state
+
+    // We need useRef to access the latest state inside `openFuzzyFinder` below.
+    // The keyboard shortcut does not pick up changes to the callback even if we
+    // declare them as dependencies of `openFuzzyFinder`.
+    const tabsRef = useRef(tabs)
+    tabsRef.current = tabs
+    const repositoryName = useRef('')
+    repositoryName.current = repoRevision.repositoryName
+    const activeTabRef = useRef(activeTab)
+    activeTabRef.current = activeTab
 
     const openFuzzyFinder = useCallback(
         (tab: FuzzyTabKey): void => {
-            const newTab = tabs.focusNamedTab(tab)
-            if (newTab) {
-                setActiveTab(newTab)
+            console.log({ repositoryName: repositoryName.current, isOnlyFiles: tabsRef.current.isOnlyFilesEnabled() })
+            if (tabsRef.current.isOnlyFilesEnabled() && !repositoryName.current) {
+                return // Legacy mode: only activate inside a repository
             }
-            if (isVisible) {
-                return
+            const activeTab = activeTabRef.current
+            const isVisible = isVisibleRef.current
+            if (!isVisible) {
+                setIsVisible(true)
             }
-            setIsVisible(true)
+            if (isVisible && tab === activeTab) {
+                switch (tab) {
+                    case 'files':
+                        toggleGlobalFiles()
+                        break
+                    case 'symbols':
+                        toggleGlobalSymbols()
+                        break
+                }
+            } else {
+                const newTab = tabsRef.current.focusNamedTab(tab)
+                if (newTab) {
+                    setActiveTab(newTab)
+                }
+            }
         },
-        [tabs, setActiveTab, isVisible, setIsVisible]
+        [setActiveTab, setIsVisible, toggleGlobalFiles, toggleGlobalSymbols]
     )
+
+    const shortcuts = useFuzzyShortcuts(props.settingsCascade.final)
 
     useEffect(() => {
         if (isVisible) {

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
@@ -50,6 +50,11 @@
     }
 }
 
+.search-query {
+    display: flex;
+    margin-left: auto;
+}
+
 .result-count {
     flex: 1;
 }

--- a/client/web/src/components/fuzzyFinder/FuzzyRepoRevision.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyRepoRevision.tsx
@@ -1,5 +1,14 @@
-
 export interface FuzzyRepoRevision {
-    repositoryName: string;
-    revision: string;
+    repositoryName: string
+    revision: string
+}
+
+export function fuzzyRepoRevisionSearchFilter({ repositoryName, revision }: FuzzyRepoRevision): string {
+    if (repositoryName && revision) {
+        return `repo:${repositoryName}@${revision} `
+    }
+    if (repositoryName) {
+        return `repo:${repositoryName} `
+    }
+    return ''
 }

--- a/client/web/src/components/fuzzyFinder/FuzzySymbols.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzySymbols.tsx
@@ -10,7 +10,7 @@ import { SearchValue } from '../../fuzzyFinder/FuzzySearch'
 
 import { emptyFuzzyCache, PersistableQueryResult } from './FuzzyLocalCache'
 import { FuzzyQuery } from './FuzzyQuery'
-import { FuzzyRepoRevision } from './FuzzyRepoRevision'
+import { FuzzyRepoRevision, fuzzyRepoRevisionSearchFilter } from './FuzzyRepoRevision'
 
 export const FUZZY_SYMBOLS_QUERY = gql`
     fragment FileMatchFields on FileMatch {
@@ -52,16 +52,6 @@ export class FuzzySymbols extends FuzzyQuery {
         // Symbol results should not be cached because stale symbol data is complicated to evict/invalidate.
         super(onNamesChanged, emptyFuzzyCache)
     }
-    private repoFilter(): string {
-        const { repositoryName, revision } = this.repoRevision.current
-        if (repositoryName && revision) {
-            return `repo:${repositoryName}@${revision} `
-        }
-        if (repositoryName) {
-            return `repo:${repositoryName} `
-        }
-        return ''
-    }
 
     /* override */ protected searchValues(): SearchValue[] {
         const repositoryName = this.repoRevision.current.repositoryName
@@ -80,7 +70,7 @@ export class FuzzySymbols extends FuzzyQuery {
     }
 
     /* override */ protected rawQuery(query: string): string {
-        return `${this.repoFilter()}type:symbol count:10 ${query}`
+        return `${fuzzyRepoRevisionSearchFilter(this.repoRevision.current)}type:symbol count:10 ${query}`
     }
 
     /* override */ protected async handleRawQueryPromise(query: string): Promise<PersistableQueryResult[]> {


### PR DESCRIPTION
Previously, the symbol tab was always either global (when outside a repo page) and always local (when inside a repo page). The files tab was always local when inside a repo and it returned 0 results when outside a repo page (with no explanation why it didn't find a file matching the query).

Now, both the symbol and file tabs support both local and global modes, and you can toggle between them regarless of the current page.

Demo https://www.loom.com/share/2d2690666da849758ba260cfb0ce64e8

## Test plan

- `sg start`
- Enable experimental feature flag `fuzzyFinderAll`
- From a non-repo page: validate that the symbols and files tabs are both global and the "Everywhere" checkbox is checked and it's disabled (there's no way to enable local mode)
- From a repo page: validate that the symbols and files tabs allow checking off the "Everywhere" box to toggle between global and local mode
- Validate that the search query can be clicked to open the search page
- Validate that the Cmd+O and Cmd+P shortcuts toggle between local and global mode
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-toggle-global.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-kggoclzthx.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
