### PR TITLE
Fuzzy finder: use centered scroll

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -194,7 +194,7 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
             const index = newNumber % queryResult.resultCount
             const nextIndex = index < 0 ? queryResult.resultCount + index : index
             setFocusIndex(nextIndex)
-            document.querySelector(`#fuzzy-modal-result-${nextIndex}`)?.scrollIntoView(false)
+            document.querySelector(`#fuzzy-modal-result-${nextIndex}`)?.scrollIntoView({ block: 'center' })
         },
         [focusIndex, setFocusIndex, queryResult]
     )


### PR DESCRIPTION
Addresses feedback https://sourcegraph.slack.com/archives/C03CSAER9LK/p1665562043151399?thread_ts=1665505922.799359&cid=C03CSAER9LK


## Test plan

- `sg start`
- Open file finder in the sg repo
- Scroll up and down, validate the position of the highlighted item stays in the middle
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-fuzzy-scroll.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-zfekslzvrb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
