### PR TITLE
Leverage statement hash to annotate spans from db driver

### DIFF
--- a/enterprise/internal/database/database.go
+++ b/enterprise/internal/database/database.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
@@ -72,14 +73,14 @@ func (d *insightsDB) Done(err error) error {
 }
 
 func (d *insightsDB) QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error) {
-	return d.Handle().QueryContext(ctx, q, args...)
+	return d.Handle().QueryContext(dbconn.SkipFrameForQuerySource(ctx), q, args...)
 }
 
 func (d *insightsDB) ExecContext(ctx context.Context, q string, args ...any) (sql.Result, error) {
-	return d.Handle().ExecContext(ctx, q, args...)
+	return d.Handle().ExecContext(dbconn.SkipFrameForQuerySource(ctx), q, args...)
 
 }
 
 func (d *insightsDB) QueryRowContext(ctx context.Context, q string, args ...any) *sql.Row {
-	return d.Handle().QueryRowContext(ctx, q, args...)
+	return d.Handle().QueryRowContext(dbconn.SkipFrameForQuerySource(ctx), q, args...)
 }

--- a/internal/database/dbconn/dynamic_metadata.go
+++ b/internal/database/dbconn/dynamic_metadata.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // instrumentQuery modifies the query text to include front-loaded metadata that is
@@ -35,7 +38,10 @@ func instrumentQuery(ctx context.Context, query string, numArguments int) (conte
 		metadataLines = append(metadataLines, "-- (could not infer source)")
 	}
 
-	fmt.Printf("> %s\n\n\n\n", strings.Join(metadataLines, "\n"))
+	// Set the hash on the span.
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(attribute.Int64("db.statement.checksum", int64(hash)))
+
 	return ctx, strings.Join(append(metadataLines, query), "\n")
 }
 

--- a/internal/database/dbconn/dynamic_metadata.go
+++ b/internal/database/dbconn/dynamic_metadata.go
@@ -112,8 +112,8 @@ frameLoop:
 
 		// If we match a function that was explicitly tagged as not the true
 		// source of the query, skip
-		for _, prefix := range getFunctionsSkippedForQuerySource(ctx) {
-			if frame.Function == prefix {
+		for _, function := range getFunctionsSkippedForQuerySource(ctx) {
+			if frame.Function == function {
 				continue frameLoop
 			}
 		}


### PR DESCRIPTION
@efritz actually, the order in which things are happening is the opposite in what we talked in the call. When we're inside the `instrumentQuery`, we're after having gone through the `otelsql` tracing injection (see the diagram on `extendedConn`. This makes it very simple to actually annotate the span. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

![image](https://user-images.githubusercontent.com/10151/195353266-cd80b789-37fa-46e0-9f49-3e52d15a3789.png)

