### PR TITLE
Mute audit log actions performed by internal actors.

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -18,13 +18,19 @@ func Log(ctx context.Context, logger log.Logger, record Record) {
 	var fields []log.Field
 
 	client := requestclient.FromContext(ctx)
-	auditId := uuid.New().String()
+	act := actor.FromContext(ctx)
 
+	//TODO make this configurable
+	if act.Internal {
+		return
+	}
+
+	auditId := uuid.New().String()
 	fields = append(fields, log.Object("audit",
 		log.String("auditId", auditId),
 		log.String("entity", record.Entity),
 		log.Object("actor",
-			log.String("actorUID", actorId(actor.FromContext(ctx))),
+			log.String("actorUID", actorId(act)),
 			log.String("ip", ip(client)),
 			log.String("X-Forwarded-For", forwardedFor(client)))))
 	fields = append(fields, record.Fields...)


### PR DESCRIPTION
## Description

Mute noisy audit logs performed by internal actors (e.g. background jobs). I'll follow-up with another PR that'll make this configurable.

## Test plan

Confirm locally & on S2 logs once deployed.