### PR TITLE
executors: Enable shallow cloning for auto indexing

### DIFF
--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform.go
@@ -48,11 +48,18 @@ func transformRecord(index types.Index, accessToken string) (apiclient.Job, erro
 		outfile = defaultOutfile
 	}
 
+	fetchTags := false
+	// TODO: Temporary workaround. LSIF-go needs tags, but they make git fetching slower.
+	if strings.HasPrefix(index.Indexer, "sourcegraph/lsif-go") {
+		fetchTags = true
+	}
+
 	return apiclient.Job{
 		ID:             index.ID,
 		Commit:         index.Commit,
 		RepositoryName: index.RepositoryName,
-		FetchTags:      true,
+		ShallowClone:   true,
+		FetchTags:      fetchTags,
 		DockerSteps:    dockerSteps,
 		CliSteps: []apiclient.CliStep{
 			{

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform_test.go
@@ -42,7 +42,8 @@ func TestTransformRecord(t *testing.T) {
 		ID:                  42,
 		Commit:              "deadbeef",
 		RepositoryName:      "linux",
-		FetchTags:           true,
+		ShallowClone:        true,
+		FetchTags:           false,
 		VirtualMachineFiles: nil,
 		DockerSteps: []apiclient.DockerStep{
 			{
@@ -121,7 +122,8 @@ func TestTransformRecordWithoutIndexer(t *testing.T) {
 		ID:                  42,
 		Commit:              "deadbeef",
 		RepositoryName:      "linux",
-		FetchTags:           true,
+		ShallowClone:        true,
+		FetchTags:           false,
 		VirtualMachineFiles: nil,
 		DockerSteps: []apiclient.DockerStep{
 			{


### PR DESCRIPTION
Took some measurements on the sg/sg repo:

```
Fetch duration:

No tags, shallow: ran for 1 second and 668 milliseconds
Full clone: ran for 10 seconds and 207 milliseconds
Tags, shallow: ran for 7 seconds and 706 milliseconds

Checkout duration:

No tags, shallow: 1 second and 338 milliseconds
Full clone: ran for 1 second and 547 milliseconds
Tags, shallow: ran for 1 second and 404 milliseconds
```

So clearly shallow clones without tags are fastest. Until lsif-go can live without tags, we have to still fetch them for these jobs. This is meant to be a temporary workaround to get overall faster performance.


## Test plan

Will check post-deploy that indexing still works. Also tested locally and indexers still seem to pass.