### PR TITLE
Adds clarity regarding different upgrade paths

### DIFF
--- a/doc/admin/updates/index.md
+++ b/doc/admin/updates/index.md
@@ -9,9 +9,9 @@ A new version of Sourcegraph is released every month (with patch releases in bet
 ## Choosing the Correct Upgrade Path
 We support two upgrade paths: moving minor version ahead, i.e. `3.42` to `3.43` (standard upgrade), moving to many minor versions ahead, i.e `3.36` to `3.43` (multi-version upgrades). It is vital that you choose the correct upgrade path when upgrading your instance. If you attempt to upgrade multiple versions using the standard upgrade process, it will fail. 
 
-### Standard upgrades (for upgrading to no more than one version ahead)
+### Standard upgrades
 
-A **standard upgrade** moves an instance from one version to an adjacent minor version, for example the upgrade `v3.41 -> v3.42`. Note that patch releases do not have to be adopted when moving between minor versions. For example, upgrading from `v3.41.0 -> v3.41.1 -> v3.42.0` has an unnecessary step.
+A **standard upgrade** moves an instance from *one version to an adjacent minor version*, for example the upgrade `v3.41 -> v3.42`. Note that patch releases do not have to be adopted when moving between minor versions. For example, upgrading from `v3.41.0 -> v3.41.1 -> v3.42.0` has an unnecessary step.
 
 > NOTE: Due to its compatibility with previous versions, we support the upgrade `v3.43 -> v4.0.1` as a one-minor-version "standard" upgrade.
 
@@ -28,9 +28,9 @@ To perform a standard upgrade, check the notes and follow the guide for your spe
 - [Single-container Sourcegraph with Docker](server.md#upgrade-procedure)
 - [Pure-docker custom deployments](pure_docker.md)
 
-### Multi-version upgrades (for upgrading multiple minor versions ahead)
+### Multi-version upgrades
 
-A **multi-version** upgrade moves an instance multiple minor versions ahead. We currently support jumping from `v3.20` to any future version (using a version of the `migrator` at least as new as the target version).
+A **multi-version** upgrade moves an instance *multiple minor versions ahead*. We currently support jumping from `v3.20` to any future version (using a version of the `migrator` at least as new as the target version).
 
 This upgrade process involves spinning down the active instance (incurring a definite downtime period), running a migration utility on the database, and spinning up the infrastructure for the new target instance. This migration utility performs both schema migrations, as well as data migrations that generally happen slowly in the background over several versions.
 

--- a/doc/admin/updates/index.md
+++ b/doc/admin/updates/index.md
@@ -6,7 +6,10 @@ For product update notes, please refer to the [changelog](../../CHANGELOG.md).
 
 A new version of Sourcegraph is released every month (with patch releases in between, released as needed). Check the [Sourcegraph blog](https://about.sourcegraph.com/blog) or the site admin updates page to learn about updates. We actively maintain the two most recent monthly releases of Sourcegraph.
 
-### Standard upgrades
+## Choosing the Correct Upgrade Path
+We support two upgrade paths: moving minor version ahead, i.e. `3.42` to `3.43` (standard upgrade), moving to many minor versions ahead, i.e `3.36` to `3.43` (multi-version upgrades). It is vital that you choose the correct upgrade path when upgrading your instance. If you attempt to upgrade multiple versions using the standard upgrade process, it will fail. 
+
+### Standard upgrades (for upgrading to no more than one version ahead)
 
 A **standard upgrade** moves an instance from one version to an adjacent minor version, for example the upgrade `v3.41 -> v3.42`. Note that patch releases do not have to be adopted when moving between minor versions. For example, upgrading from `v3.41.0 -> v3.41.1 -> v3.42.0` has an unnecessary step.
 
@@ -25,7 +28,7 @@ To perform a standard upgrade, check the notes and follow the guide for your spe
 - [Single-container Sourcegraph with Docker](server.md#upgrade-procedure)
 - [Pure-docker custom deployments](pure_docker.md)
 
-### Multi-version upgrades
+### Multi-version upgrades (for upgrading multiple minor versions ahead)
 
 A **multi-version** upgrade moves an instance multiple minor versions ahead. We currently support jumping from `v3.20` to any future version (using a version of the `migrator` at least as new as the target version).
 


### PR DESCRIPTION
It is not immediately clear on first visiting this page that there are two upgrade paths. A customer may pick the wrong path, not realizing that it will lead to a complete failure of their instance, requiring reversion and repair. This update aims to clarify that choosing the right upgrade path is vital to a successful upgrade.



## Test plan
eye test
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
