### PR TITLE
insights: Add a function to get a list of repos

### DIFF
--- a/enterprise/internal/insights/query/querybuilder/builder.go
+++ b/enterprise/internal/insights/query/querybuilder/builder.go
@@ -331,6 +331,9 @@ func SetCaseSensitivity(query BasicQuery, sensitive bool) (BasicQuery, error) {
 
 func SelectRepoQuery(query BasicQuery, defaultParams searchquery.Parameters) (BasicQuery, error) {
 	insightsQuery, err := withDefaults(query, defaultParams)
+	if err != nil {
+		return "", errors.Wrap(err, "withDefaults")
+	}
 	plan, err := searchquery.Pipeline(searchquery.Init(string(insightsQuery), searchquery.SearchTypeLiteral))
 	if err != nil {
 		return "", errors.Wrap(err, "Pipeline")

--- a/enterprise/internal/insights/query/streaming/decoder.go
+++ b/enterprise/internal/insights/query/streaming/decoder.go
@@ -7,8 +7,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute/client"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	streamapi "github.com/sourcegraph/sourcegraph/internal/search/streaming/api"
 	streamhttp "github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
+	itypes "github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 type StreamDecoderEvents struct {
@@ -31,7 +33,7 @@ type TabulationResult struct {
 
 type SelectRepoResult struct {
 	StreamDecoderEvents
-	Repos []string
+	Repos []itypes.MinimalRepo
 }
 
 // TabulationDecoder will tabulate the result counts per repository.
@@ -262,7 +264,7 @@ func ComputeTextDecoder() (client.ComputeTextExtraStreamDecoder, *ComputeTabulat
 
 func SelectRepoDecoder() (streamhttp.FrontendStreamDecoder, *SelectRepoResult) {
 	repoResult := &SelectRepoResult{
-		Repos: []string{},
+		Repos: []itypes.MinimalRepo{},
 	}
 
 	return streamhttp.FrontendStreamDecoder{
@@ -287,7 +289,7 @@ func SelectRepoDecoder() (streamhttp.FrontendStreamDecoder, *SelectRepoResult) {
 			for _, match := range matches {
 				switch match := match.(type) {
 				case *streamhttp.EventRepoMatch:
-					repoResult.Repos = append(repoResult.Repos, match.Repository)
+					repoResult.Repos = append(repoResult.Repos, itypes.MinimalRepo{ID: api.RepoID(match.RepositoryID), Name: api.RepoName(match.Repository)})
 				}
 			}
 		},

--- a/enterprise/internal/insights/query/streaming_query_executor.go
+++ b/enterprise/internal/insights/query/streaming_query_executor.go
@@ -38,6 +38,9 @@ func NewStreamingExecutor(postgres database.DB, clock func() time.Time) *Streami
 
 func (c *StreamingQueryExecutor) ExecuteRepoList(ctx context.Context, query string) ([]itypes.MinimalRepo, error) {
 	modified, err := querybuilder.SelectRepoQuery(querybuilder.BasicQuery(query), querybuilder.CodeInsightsQueryDefaults(false))
+	if err != nil {
+		return nil, errors.Wrap(err, "SelectRepoQuery")
+	}
 
 	decoder, selectRepoResult := streaming.SelectRepoDecoder()
 	err = streaming.Search(ctx, modified.String(), nil, decoder)

--- a/enterprise/internal/insights/query/streaming_query_executor.go
+++ b/enterprise/internal/insights/query/streaming_query_executor.go
@@ -17,6 +17,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+
+	itypes "github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 type StreamingQueryExecutor struct {
@@ -34,7 +36,7 @@ func NewStreamingExecutor(postgres database.DB, clock func() time.Time) *Streami
 	}
 }
 
-func (c *StreamingQueryExecutor) ExecuteRepoList(ctx context.Context, query string) ([]string, error) {
+func (c *StreamingQueryExecutor) ExecuteRepoList(ctx context.Context, query string) ([]itypes.MinimalRepo, error) {
 	modified, err := querybuilder.SelectRepoQuery(querybuilder.BasicQuery(query), querybuilder.CodeInsightsQueryDefaults(false))
 
 	decoder, selectRepoResult := streaming.SelectRepoDecoder()


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/42761

## Description

I used streaming search because it seems more robust for strategic scale customers, and set up an `Executor` that gets specifically a list of repositories and returns that.

## Test plan

Since this isn't hooked up to anything, I tested it by adding a bit of code into one of the graphql resolvers and just hardcoding some different querystrings there to see that it gave me the expected results. For example:

```
	executor := query.NewStreamingExecutor(i.postgresDB, time.Now)
	repoList, err := executor.ExecuteRepoList(ctx, "file:.go")
	if err != nil {
		fmt.Println("ERROR:", err)
	}
	fmt.Println(repoList)
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
