### PR TITLE
dev/sg: update 'sg rfc' with new RFC terms, modernize command

### DIFF
--- a/dev/sg/sg_rfc.go
+++ b/dev/sg/sg_rfc.go
@@ -14,7 +14,7 @@ import (
 var rfcCommand = &cli.Command{
 	Name:  "rfc",
 	Usage: `List, search, and open Sourcegraph RFCs`,
-	Description: fmt.Sprintf("List, search, and open Sourcegraph RFCs in the following drives:\n\n%s", func() (out string) {
+	Description: fmt.Sprintf("Sourcegraph RFCs live in the following drives - see flags to configure which drive to query:\n\n%s", func() (out string) {
 		for _, d := range []rfc.DriveSpec{rfc.PublicDrive, rfc.PrivateDrive} {
 			out += fmt.Sprintf("* %s: https://drive.google.com/drive/folders/%s\n", d.DisplayName, d.FolderID)
 		}

--- a/dev/sg/sg_rfc.go
+++ b/dev/sg/sg_rfc.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/rfc"
@@ -11,6 +14,12 @@ import (
 var rfcCommand = &cli.Command{
 	Name:  "rfc",
 	Usage: `List, search, and open Sourcegraph RFCs`,
+	Description: fmt.Sprintf("List, search, and open Sourcegraph RFCs in the following drives:\n\n%s", func() (out string) {
+		for _, d := range []rfc.DriveSpec{rfc.PublicDrive, rfc.PrivateDrive} {
+			out += fmt.Sprintf("* %s: https://drive.google.com/drive/folders/%s\n", d.DisplayName, d.FolderID)
+		}
+		return out
+	}()),
 	UsageText: `
 # List all Public RFCs
 sg rfc list
@@ -34,43 +43,53 @@ sg rfc --private open 420
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name:     "private",
-			Usage:    "perform the rfc action on the private RFC drive",
+			Usage:    "perform the RFC action on the private RFC drive",
 			Required: false,
 			Value:    false,
 		},
 	},
-	Action: rfcExec,
-}
-
-func rfcExec(ctx *cli.Context) error {
-	args := ctx.Args().Slice()
-	if len(args) == 0 {
-		args = append(args, "list")
-	}
-
-	driveSpec := rfc.PublicDrive
-	if ctx.Bool("private") {
-		driveSpec = rfc.PrivateDrive
-	}
-
-	switch args[0] {
-	case "list":
-		return rfc.List(ctx.Context, driveSpec, std.Out)
-
-	case "search":
-		if len(args) != 2 {
-			return errors.New("no search query given")
-		}
-
-		return rfc.Search(ctx.Context, args[1], driveSpec, std.Out)
-
-	case "open":
-		if len(args) != 2 {
-			return errors.New("no number given")
-		}
-
-		return rfc.Open(ctx.Context, args[1], driveSpec, std.Out)
-	}
-
-	return nil
+	Subcommands: []*cli.Command{
+		{
+			Name:      "list",
+			ArgsUsage: " ",
+			Usage:     "List Sourcegraph RFCs",
+			Action: func(c *cli.Context) error {
+				driveSpec := rfc.PublicDrive
+				if c.Bool("private") {
+					driveSpec = rfc.PrivateDrive
+				}
+				return rfc.List(c.Context, driveSpec, std.Out)
+			},
+		},
+		{
+			Name:      "search",
+			ArgsUsage: "[query]",
+			Usage:     "Search Sourcegraph RFCs",
+			Action: func(c *cli.Context) error {
+				driveSpec := rfc.PublicDrive
+				if c.Bool("private") {
+					driveSpec = rfc.PrivateDrive
+				}
+				if c.Args().Len() == 0 {
+					return errors.New("no search query given")
+				}
+				return rfc.Search(c.Context, strings.Join(c.Args().Slice(), " "), driveSpec, std.Out)
+			},
+		},
+		{
+			Name:      "open",
+			ArgsUsage: "[number]",
+			Usage:     "Open a Sourcegraph RFC - find and list RFC numbers with 'sg rfc list' or 'sg rfc search'",
+			Action: func(c *cli.Context) error {
+				driveSpec := rfc.PublicDrive
+				if c.Bool("private") {
+					driveSpec = rfc.PrivateDrive
+				}
+				if c.Args().Len() == 0 {
+					return errors.New("no RFC given")
+				}
+				return rfc.Open(c.Context, c.Args().First(), driveSpec, std.Out)
+			},
+		},
+	},
 }

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1151,7 +1151,7 @@ Flags:
 
 List, search, and open Sourcegraph RFCs.
 
-List, search, and open Sourcegraph RFCs in the following drives:
+Sourcegraph RFCs live in the following drives - see flags to configure which drive to query:
 
 * Public: https://drive.google.com/drive/folders/1zP3FxdDlcSQGC1qvM9lHZRaHH4I9Jwwa
 * Private: https://drive.google.com/drive/folders/1KCq4tMLnVlC0a1rwGuU5OSCw6mdDxLuv

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1151,6 +1151,12 @@ Flags:
 
 List, search, and open Sourcegraph RFCs.
 
+List, search, and open Sourcegraph RFCs in the following drives:
+
+* Public: https://drive.google.com/drive/folders/1zP3FxdDlcSQGC1qvM9lHZRaHH4I9Jwwa
+* Private: https://drive.google.com/drive/folders/1KCq4tMLnVlC0a1rwGuU5OSCw6mdDxLuv
+
+
 ```sh
 # List all Public RFCs
 $ sg rfc list
@@ -1173,8 +1179,36 @@ $ sg rfc --private open 420
 
 Flags:
 
+* `--private`: perform the RFC action on the private RFC drive
+
+### sg rfc list
+
+List Sourcegraph RFCs.
+
+
+Flags:
+
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
-* `--private`: perform the rfc action on the private RFC drive
+
+### sg rfc search
+
+Search Sourcegraph RFCs.
+
+Arguments: `[query]`
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
+
+### sg rfc open
+
+Open a Sourcegraph RFC - find and list RFC numbers with 'sg rfc list' or 'sg rfc search'.
+
+Arguments: `[number]`
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
 
 ## sg adr
 


### PR DESCRIPTION
Was playing around with `sg rfc` with @burmudar and noticed that many of the new RFC modifiers (`PRIVATE`, `DONE`) are not supported, and we also have this nil pointer being rendered for unknown modifiers (often misspellings).

This extends `sg rfc` to support the new terms and the `PRIVATE` modifier, and also modernizes the `sg rfc` command so that the subcommands are real subcommands and thus render in docs, support help flags, and support autocompletions.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`go run ./dev/sg rfc -h`

`go run ./dev/sg rfc search -h`

`go run ./dev/sg rfc list`

<img width="711" alt="image" src="https://user-images.githubusercontent.com/23356519/195413054-1b0c4ded-43e2-4cff-9588-903f458ed0cd.png">
