### PR TITLE
batches: refactor spec / executions tab

### DIFF
--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
@@ -247,6 +247,9 @@ SpecFile.argTypes = {
     supersedingBatchSpec: {
         defaultValue: false,
     },
+    viewerCanAdminister: {
+        defaultValue: false,
+    }
 }
 
 export const Archived = Template.bind({})

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -106,7 +106,8 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
     )
 
     const isBatchSpecLocallyCreated = batchChange.currentSpec.source === BatchSpecSource.LOCAL
-    const shouldDisplayOldUI = !isExecutionEnabled || isBatchSpecLocallyCreated
+    const shouldDisplayExecutionsTab =
+        isExecutionEnabled && !isBatchSpecLocallyCreated && batchChange.viewerCanAdminister
 
     // We track the current tab in a URL parameter so that tabs are easy to navigate to
     // and share.
@@ -178,12 +179,30 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                         </span>
                     </span>
                 </Tab>
-                <SpecOrExecutionTab
-                    shouldDisplayOldUI={shouldDisplayOldUI}
-                    viewerCanAdminister={batchChange.viewerCanAdminister}
-                    executionsCount={executionsCount}
-                    specsHasNextPage={batchChange.batchSpecs.pageInfo.hasNextPage}
-                />
+                {shouldDisplayExecutionsTab ? (
+                    <Tab>
+                        <span>
+                            <Icon aria-hidden={true} className="text-muted mr-2" svgPath={mdiFileDocument} />
+                            <span className="text-content" data-tab-content="Executions">
+                                Executions
+                            </span>
+                            {executionsCount > 0 && (
+                                <Badge variant="warning" pill={true} className="ml-2">
+                                    {executionsCount} {batchChange.batchSpecs.pageInfo.hasNextPage && <>+</>}
+                                </Badge>
+                            )}
+                        </span>
+                    </Tab>
+                ) : (
+                    <Tab>
+                        <span>
+                            <Icon aria-hidden={true} className="text-muted mr-2" svgPath={mdiFileDocument} />
+                            <span className="text-content" data-tab-content="Spec">
+                                Spec
+                            </span>
+                        </span>
+                    </Tab>
+                )}
                 <Tab>
                     <span>
                         <Icon aria-hidden={true} className="text-muted mr-2" svgPath={mdiArchive} />
@@ -234,13 +253,42 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                         history={history}
                     />
                 </TabPanel>
-                <SpecOrExecutionPanel
-                    shouldDisplayOldUI={shouldDisplayOldUI}
-                    batchChange={batchChange}
-                    isLightTheme={isLightTheme}
-                    history={history}
-                    location={location}
-                />
+                <TabPanel>
+                    {shouldDisplayExecutionsTab ? (
+                        <Container>
+                            <BatchChangeBatchSpecList
+                                history={history}
+                                location={location}
+                                batchChangeID={batchChange.id}
+                                currentSpecID={batchChange.currentSpec.id}
+                                isLightTheme={isLightTheme}
+                            />
+                        </Container>
+                    ) : (
+                        <>
+                            <div className="d-flex flex-wrap justify-content-between align-items-baseline mb-2 test-batches-spec">
+                                <BatchSpecMeta
+                                    createdAt={batchChange.createdAt}
+                                    lastApplier={batchChange.lastApplier}
+                                    lastAppliedAt={batchChange.lastAppliedAt}
+                                />
+                                <BatchSpecDownloadButton
+                                    name={batchChange.name}
+                                    isLightTheme={isLightTheme}
+                                    originalInput={batchChange.currentSpec.originalInput}
+                                />
+                            </div>
+                            <Container>
+                                <BatchSpec
+                                    name={batchChange.name}
+                                    originalInput={batchChange.currentSpec.originalInput}
+                                    isLightTheme={isLightTheme}
+                                    className={styles.batchSpec}
+                                />
+                            </Container>
+                        </>
+                    )}
+                </TabPanel>
                 <TabPanel>
                     <BatchChangeChangesets
                         batchChangeID={batchChange.id}
@@ -265,105 +313,4 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
             </TabPanels>
         </BatchChangeTabs>
     )
-}
-
-interface SpecOrExecutionTabProps {
-    shouldDisplayOldUI: boolean
-    viewerCanAdminister: boolean
-    executionsCount: number
-    specsHasNextPage: boolean
-}
-
-const SpecOrExecutionTab: React.FunctionComponent<SpecOrExecutionTabProps> = props => {
-    if (props.shouldDisplayOldUI) {
-        return (
-            <Tab>
-                <span>
-                    <Icon aria-hidden={true} className="text-muted mr-2" svgPath={mdiFileDocument} />
-                    <span className="text-content" data-tab-content="Spec">
-                        Spec
-                    </span>
-                </span>
-            </Tab>
-        )
-    }
-
-    if (props.viewerCanAdminister) {
-        return (
-            <Tab>
-                <span>
-                    <Icon aria-hidden={true} className="text-muted mr-2" svgPath={mdiFileDocument} />
-                    <span className="text-content" data-tab-content="Executions">
-                        Executions
-                    </span>
-                    {props.executionsCount > 0 && (
-                        <Badge variant="warning" pill={true} className="ml-2">
-                            {props.executionsCount} {props.specsHasNextPage && <>+</>}
-                        </Badge>
-                    )}
-                </span>
-            </Tab>
-        )
-    }
-
-    return null
-}
-
-interface SpecOrExecutionPanelProps {
-    shouldDisplayOldUI: boolean
-    batchChange: BatchChangeFields
-    isLightTheme: boolean
-    history: H.History
-    location: H.Location
-}
-
-const SpecOrExecutionPanel: React.FunctionComponent<SpecOrExecutionPanelProps> = ({
-    shouldDisplayOldUI,
-    batchChange,
-    isLightTheme,
-    history,
-    location,
-}) => {
-    if (shouldDisplayOldUI) {
-        return (
-            <>
-                <div className="d-flex flex-wrap justify-content-between align-items-baseline mb-2 test-batches-spec">
-                    <BatchSpecMeta
-                        createdAt={batchChange.createdAt}
-                        lastApplier={batchChange.lastApplier}
-                        lastAppliedAt={batchChange.lastAppliedAt}
-                    />
-                    <BatchSpecDownloadButton
-                        name={batchChange.name}
-                        isLightTheme={isLightTheme}
-                        originalInput={batchChange.currentSpec.originalInput}
-                    />
-                </div>
-                <Container>
-                    <BatchSpec
-                        name={batchChange.name}
-                        originalInput={batchChange.currentSpec.originalInput}
-                        isLightTheme={isLightTheme}
-                        className={styles.batchSpec}
-                    />
-                </Container>
-            </>
-        )
-    }
-
-    if (batchChange.viewerCanAdminister) {
-        return (
-            <Container>
-                <BatchChangeBatchSpecList
-                    history={history}
-                    location={location}
-                    batchChangeID={batchChange.id}
-                    currentSpecID={batchChange.currentSpec.id}
-                    isLightTheme={isLightTheme}
-                />
-            </Container>
-        )
-    }
-
-    return null
 }

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -96,7 +96,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
 }) => {
     const isExecutionEnabled = isBatchChangesExecutionEnabled(settingsCascade)
 
-    const executionsCount = useMemo(
+    const pendingExecutionsCount = useMemo(
         () =>
             batchChange.batchSpecs.nodes.filter(
                 node => node.state === BatchSpecState.PROCESSING || node.state === BatchSpecState.QUEUED
@@ -185,9 +185,9 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                             <span className="text-content" data-tab-content="Executions">
                                 Executions
                             </span>
-                            {executionsCount > 0 && (
+                            {pendingExecutionsCount > 0 && (
                                 <Badge variant="warning" pill={true} className="ml-2">
-                                    {executionsCount} {batchChange.batchSpecs.pageInfo.hasNextPage && <>+</>}
+                                    {pendingExecutionsCount} {batchChange.batchSpecs.pageInfo.hasNextPage && <>+</>}
                                 </Badge>
                             )}
                         </span>

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -32,7 +32,7 @@ import styles from './BatchChangeDetailsTabs.module.scss'
 export enum TabName {
     Changesets = 'changesets',
     Chart = 'chart',
-    // Non-SSBC
+    // Non-SSBC or SSBC with viewerCanAdminister=false
     Spec = 'spec',
     // SSBC-only
     Executions = 'executions',
@@ -40,20 +40,19 @@ export enum TabName {
     BulkOperations = 'bulkoperations',
 }
 
-const getTabIndex = (tabName: string, isExecutionEnabled: boolean): number =>
-    ([
+const getTabIndex = (tabName: string, shouldDisplayExecutionsTab: boolean): number => ([
         TabName.Changesets,
         TabName.Chart,
-        isExecutionEnabled ? TabName.Executions : TabName.Spec,
+        shouldDisplayExecutionsTab ? TabName.Executions : TabName.Spec,
         TabName.Archived,
         TabName.BulkOperations,
     ] as string[]).indexOf(tabName)
 
-const getTabName = (tabIndex: number, isExecutionEnabled: boolean): TabName =>
+const getTabName = (tabIndex: number, shouldDisplayExecutionsTab: boolean): TabName => 
     [
         TabName.Changesets,
         TabName.Chart,
-        isExecutionEnabled ? TabName.Executions : TabName.Spec,
+        shouldDisplayExecutionsTab ? TabName.Executions : TabName.Spec,
         TabName.Archived,
         TabName.BulkOperations,
     ][tabIndex]
@@ -114,7 +113,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
     const history = useHistory()
     const location = useLocation()
     const initialURLTab = new URLSearchParams(location.search).get('tab')
-    const defaultTabIndex = getTabIndex(initialURLTab || initialTab, isExecutionEnabled) || 0
+    const defaultTabIndex = getTabIndex(initialURLTab || initialTab, shouldDisplayExecutionsTab) || 0
 
     // The executions tab uses an additional custom short URL, "/executions".
     const [customShortPath, setCustomShortPath] = useState(
@@ -126,7 +125,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
             const urlParameters = new URLSearchParams(location.search)
             resetFilteredConnectionURLQuery(urlParameters)
 
-            const newTabName = getTabName(index, isExecutionEnabled)
+            const newTabName = getTabName(index, shouldDisplayExecutionsTab)
 
             // The executions tab uses a custom short URL.
             if (newTabName === TabName.Executions) {
@@ -142,7 +141,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                 if (index === 0) {
                     urlParameters.delete('tab')
                 } else {
-                    urlParameters.set('tab', getTabName(index, isExecutionEnabled))
+                    urlParameters.set('tab', getTabName(index, shouldDisplayExecutionsTab))
                 }
                 // Make sure to unset the custom short path, if we were previously on a
                 // tab that had one.
@@ -154,7 +153,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                 history.replace({ ...newLocation, search: urlParameters.toString() })
             }
         },
-        [history, location, isExecutionEnabled, customShortPath]
+        [history, location, shouldDisplayExecutionsTab, customShortPath]
     )
 
     return (


### PR DESCRIPTION
#42454 introduced  a regression to the BatchChange details tab bar, in the past we decided whether to show the Spec or execution based on the following:

* Is server-side execution enabled for that instance?
* Is the current spec locally created or created on the server side?

With the addition of the `viewerCanAdminister` field, it became possible to display both the `Spec` and `Execution` tab if the current spec was locally created and the user viewing the details page can administer the batch spec. The resulted in a weird state in the UI.

<img width="1435" alt="CleanShot 2022-10-12 at 18 38 24@2x" src="https://user-images.githubusercontent.com/25608335/195411983-26706af1-ffcb-43ff-a648-50225be4a33f.png">

This PR refactors the current implementation so we handle each state appropriately.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Test with both locally-created and server-side Batch Changes.

| Local 	| Server Side 	| Server Side (viewerCanAdminister = false) |
|-------	|-------------	|-------------------                                          |
|![CleanShot 2022-10-12 at 19 45 16](https://user-images.githubusercontent.com/25608335/195412344-233151fd-23cc-4ef6-86fc-8a7775fd9224.png)| ![CleanShot 2022-10-12 at 19 46 08](https://user-images.githubusercontent.com/25608335/195412418-72045f66-49a5-4cc9-8e2b-6129210b07e5.png) | ![CleanShot 2022-10-12 at 19 53 50](https://user-images.githubusercontent.com/25608335/195413896-16156f51-a187-485a-9a04-5d69095ecde6.png) |

## App preview:

- [Web](https://sg-web-bo-remove-execution-tab-local-bc.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-xsuifsufzy.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

