### PR TITLE
search history: fix infinite loop when logs are empty

### DIFF
--- a/client/web/src/search/input/useRecentSearches.ts
+++ b/client/web/src/search/input/useRecentSearches.ts
@@ -49,7 +49,7 @@ export function useRecentSearches(): {
     )
 
     useEffect(() => {
-        if (recentSearches) {
+        if (state !== 'success' && recentSearches) {
             if (recentSearches && recentSearches.length > 0) {
                 setState('success')
             } else {
@@ -67,7 +67,7 @@ export function useRecentSearches(): {
                     })
             }
         }
-    }, [recentSearches, loadFromEventLog, setRecentSearches])
+    }, [recentSearches, loadFromEventLog, setRecentSearches, state])
 
     // Adds a new search to the top of the recent searches list.
     // If the search is already in the recent searches list, it moves it to the top.


### PR DESCRIPTION
Repro:
- clear temp settings 
- clear `event_logs` table
- load homepage

Expected: 
`useRecentSearches` only tries to load event logs once

Actual:
`useRecentSearches` continuously tries to load event logs because the current list is empty

This fixes it by checking if the list has been previously loaded, and prevent loading again even when empty.


## Test plan

Verify manually via Chrome network tools that the infinite loop is gone

## App preview:

- [Web](https://sg-web-jp-recentsearchesinfiniteloop.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-phoesmfgxk.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
