### PR TITLE
jetbrains: replace non-null assertions around lineMatches property

### DIFF
--- a/client/jetbrains/webview/src/search/js-to-java-bridge.ts
+++ b/client/jetbrains/webview/src/search/js-to-java-bridge.ts
@@ -289,11 +289,15 @@ async function createPreviewContentForContentMatch(
 ): Promise<PreviewContent> {
     const fileName = splitPath(match.path)[1]
     const content = convertCarriageReturnLineFeedToLineFeed(await loadContent(match))
-    const characterCountUntilLine = getCharacterCountUntilLine(content, match.lineMatches![lineMatchIndex].lineNumber)
+
+    const lineNumberAtLineMatchIndex = match.lineMatches ? match.lineMatches[lineMatchIndex].lineNumber : 0
+    const offsetAndLengthsAtLineMatchIndex = match.lineMatches ? match.lineMatches[lineMatchIndex].offsetAndLengths : []
+
+    const characterCountUntilLine = getCharacterCountUntilLine(content, lineNumberAtLineMatchIndex)
     const absoluteOffsetAndLengths = getAbsoluteOffsetAndLengths(
         content,
-        match.lineMatches![lineMatchIndex].lineNumber,
-        match.lineMatches![lineMatchIndex].offsetAndLengths,
+        lineNumberAtLineMatchIndex,
+        offsetAndLengthsAtLineMatchIndex,
         characterCountUntilLine
     )
 
@@ -305,7 +309,7 @@ async function createPreviewContentForContentMatch(
         commit: match.commit,
         path: match.path,
         content: encodeContent(content),
-        lineNumber: match.lineMatches![lineMatchIndex].lineNumber,
+        lineNumber: lineNumberAtLineMatchIndex,
         absoluteOffsetAndLengths,
     }
 }

--- a/client/jetbrains/webview/src/search/results/FileSearchResult.tsx
+++ b/client/jetbrains/webview/src/search/results/FileSearchResult.tsx
@@ -90,7 +90,12 @@ export const FileSearchResult: React.FunctionComponent<Props> = ({
 
     const onClick = (): void =>
         lines.length
-            ? selectResult(getResultId(match, match.type === 'content' ? match.lineMatches![0] : match.symbols[0]))
+            ? selectResult(getResultId(match,
+                match.type === 'content'
+                    ? match.lineMatches
+                        ? match.lineMatches[0]
+                        : undefined
+                    : match.symbols[0]))
             : undefined
 
     const title = (

--- a/client/jetbrains/webview/src/search/results/TrimmedCodeLineWithHighlights.tsx
+++ b/client/jetbrains/webview/src/search/results/TrimmedCodeLineWithHighlights.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 
-import { ContentMatch } from '@sourcegraph/shared/src/search/stream'
+import { LineMatch } from '@sourcegraph/shared/src/search/stream'
 
 import styles from './FileSearchResult.module.scss'
 
 interface Props {
-    line: NonNullable<ContentMatch['lineMatches']>[0]
+    line: LineMatch
 }
 
 export const TrimmedCodeLineWithHighlights: React.FunctionComponent<Props> = React.memo<Props>(

--- a/client/jetbrains/webview/src/search/results/utils.ts
+++ b/client/jetbrains/webview/src/search/results/utils.ts
@@ -1,4 +1,4 @@
-import { ContentMatch, SearchMatch, SymbolMatch } from '@sourcegraph/shared/src/search/stream'
+import { LineMatch, SearchMatch, MatchedSymbol } from '@sourcegraph/shared/src/search/stream'
 
 const SUPPORTED_TYPES = new Set(['commit', 'content', 'path', 'symbol', 'repo'])
 const ID_SEPERATOR = '-#-'
@@ -10,10 +10,12 @@ export function getFirstResultId(results: SearchMatch[]): string | null {
         return getResultId(
             firstSupportedMatch,
             firstSupportedMatch.type === 'content'
-                ? firstSupportedMatch.lineMatches![0]
+                ? firstSupportedMatch.lineMatches
+                    ? firstSupportedMatch.lineMatches[0]
+                    : undefined
                 : firstSupportedMatch.type === 'symbol'
-                ? firstSupportedMatch.symbols[0]
-                : undefined
+                    ? firstSupportedMatch.symbols[0]
+                    : undefined
         )
     }
     return null
@@ -42,8 +44,8 @@ export function getMatchIdForResult(resultId: string): string {
     return resultId.split(ID_SEPERATOR)[0]
 }
 
-export type LineMatchItem = NonNullable<ContentMatch['lineMatches']>[0]
-export type SymbolMatchItem = SymbolMatch['symbols'][0]
+export type LineMatchItem = LineMatch
+export type SymbolMatchItem = MatchedSymbol
 export function getResultId(match: SearchMatch, lineOrSymbolMatch?: LineMatchItem | SymbolMatchItem): string {
     if (match.type === 'content') {
         return `${getMatchId(match)}${ID_SEPERATOR}${match.lineMatches?.indexOf(lineOrSymbolMatch as LineMatchItem)}`

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -79,7 +79,7 @@ export interface Location {
     column: number
 }
 
-interface LineMatch {
+export interface LineMatch {
     line: string
     lineNumber: number
     offsetAndLengths: number[][]


### PR DESCRIPTION
Replace non-null assertions that I added hastily in https://github.com/sourcegraph/sourcegraph/pull/42271 with explicit checks.  


## Test plan
Build extension and start in sandboxed mode, pointed at local dev instance
Do the following with local dev instance on `main`, and then again with local dev instance on `3.41`:
- Run a literal search, regex search, structural search, and symbol search, and verify that results and result previews are rendered 
- Run a search that produces no results
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tl-jetbrains-typesafe.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-arketkaxxr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
