### PR TITLE
Fix VS Code build errors

### DIFF
--- a/client/shared/src/api/extension/api/decorations.ts
+++ b/client/shared/src/api/extension/api/decorations.ts
@@ -11,7 +11,8 @@ import { hasProperty } from '@sourcegraph/common'
 import { TextDocumentDecoration } from '@sourcegraph/extension-api-types'
 
 // LINE DECORATIONS
-
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore: This errors even though we removed config from TextDocumentDecorationType
 export const createDecorationType = (): TextDocumentDecorationType => ({ key: uniqueId('TextDocumentDecorationType') })
 
 /**

--- a/client/shared/src/codeintel/legacy-extensions/api.ts
+++ b/client/shared/src/codeintel/legacy-extensions/api.ts
@@ -205,15 +205,6 @@ export interface DecorationAttachmentRenderOptions extends ThemableDecorationAtt
     dark?: ThemableDecorationAttachmentStyle
 }
 
-interface TextDocumentDecorationTypeConfig {
-    /**
-     * Defines whether to show decorations inline (default) or in a separate column.
-     * Column display can only be applied if `enableExtensionsDecorationsColumnView`
-     * experimental feature is enabled.
-     */
-    display: 'inline' | 'column'
-}
-
 /**
  * Represents a handle to a set of decorations.
  *
@@ -221,12 +212,8 @@ interface TextDocumentDecorationTypeConfig {
  * {@link sourcegraph.app.createDecorationType}
  */
 export interface TextDocumentDecorationType {
-    readonly extensionID?: string
-
     /** An opaque identifier. */
     readonly key: string
-
-    readonly config: TextDocumentDecorationTypeConfig
 }
 
 /**

--- a/client/vscode/scripts/build.ts
+++ b/client/vscode/scripts/build.ts
@@ -103,8 +103,6 @@ export async function build(): Promise<void> {
                 packageResolutionPlugin({
                     path: require.resolve('path-browserify'),
                     ...RXJS_RESOLUTIONS,
-                    './Link': require.resolve('../src/webview/search-panel/alias/Link'),
-                    '../Link': require.resolve('../src/webview/search-panel/alias/Link'),
                     './RepoSearchResult': require.resolve('../src/webview/search-panel/alias/RepoSearchResult'),
                     './CommitSearchResult': require.resolve('../src/webview/search-panel/alias/CommitSearchResult'),
                     './FileMatchChildren': require.resolve('../src/webview/search-panel/alias/FileMatchChildren'),


### PR DESCRIPTION
This fixes some strange build errors that I was encountering while working with the VS Code extension. No idea what's going on there with `client/shared/src/api/extension/api/decorations.ts` especially since both implementations of `TextDocumentDecorationType` now only define a `key` as needed 🤷 

## Test plan

`yarn build-vsce` works again

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-vscode-compile-error.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wwpfqtttuu.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
