### PR TITLE
insights: maintain state about backfills throughout the entire series lifecycle

### DIFF
--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -633,7 +633,7 @@ func (a *backfillAnalyzer) analyzeSeries(ctx context.Context, bctx *buildSeriesC
 	// We need a way to find out in that historical timeframe what the total # of results was.
 	// There are only two ways to do that:
 	//
-	// 1. Run `type:diff` searches, this would give us matching lines added/removed/changed over
+	// 1. Run `type:dff` searches, this would give us matching lines added/removed/changed over
 	//    time. To use this, we would need to ensure we *start* looking for historical data at the
 	//    very first commit in the repo, and keep a running tally of added/removed/changed lines -
 	//    this requires a lot of book-keeping.

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -12,8 +12,9 @@ import (
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/segmentio/ksuid"
-	sglog "github.com/sourcegraph/log"
 	"golang.org/x/time/rate"
+
+	sglog "github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
@@ -633,7 +634,7 @@ func (a *backfillAnalyzer) analyzeSeries(ctx context.Context, bctx *buildSeriesC
 	// We need a way to find out in that historical timeframe what the total # of results was.
 	// There are only two ways to do that:
 	//
-	// 1. Run `type:dff` searches, this would give us matching lines added/removed/changed over
+	// 1. Run `type:diff` searches, this would give us matching lines added/removed/changed over
 	//    time. To use this, we would need to ensure we *start* looking for historical data at the
 	//    very first commit in the repo, and keep a running tally of added/removed/changed lines -
 	//    this requires a lot of book-keeping.

--- a/enterprise/internal/insights/scheduler/backfill.go
+++ b/enterprise/internal/insights/scheduler/backfill.go
@@ -1,7 +1,85 @@
 package scheduler
 
-import "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+import (
+	"context"
 
-type BackfillScheduler interface {
-	Backfill(series types.InsightSeries) error
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/scheduler/iterator"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type SeriesBackfill struct {
+	Id             int
+	SeriesId       int
+	repoIteratorId int
+	EstimatedCost  float64
+	State          BackfillState
 }
+
+type BackfillState string
+
+const (
+	BackfillStateNew        BackfillState = "new"
+	BackfillStateProcessing BackfillState = "processing"
+	BackfillStateCompleted  BackfillState = "completed"
+	BackfillStateFailed     BackfillState = "failed"
+)
+
+func loadBackfill(ctx context.Context, store *basestore.Store, id int) (*SeriesBackfill, error) {
+	q := "SELECT %s FROM insight_series_backfill WHERE id = %s"
+	row := store.QueryRow(ctx, sqlf.Sprintf(q, backfillColumnsJoin, id))
+	var tmp SeriesBackfill
+	if err := row.Scan(
+		&tmp.Id,
+		&tmp.SeriesId,
+		&tmp.repoIteratorId,
+		&tmp.EstimatedCost,
+		&tmp.State,
+	); err != nil {
+		return nil, err
+	}
+	return &tmp, nil
+}
+
+func NewBackfill(ctx context.Context, store basestore.Store, series types.InsightSeries, repos []int32) (_ *SeriesBackfill, err error) {
+	tx, err := store.Transact(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	itr, err := iterator.New(ctx, tx, repos)
+	if err != nil {
+		return nil, err
+	}
+
+	q := "INSERT INTO insight_series_backfill (series_id, estimated_cost, repo_iterator_id) VALUES(%s, %s, %s) RETURNING id;"
+	cost := 0 // either calculate or take in cost here
+	row := tx.QueryRow(ctx, sqlf.Sprintf(q, series.ID, cost, itr.Id))
+	id, err := basestore.ScanInt(row)
+	if err != nil {
+		return nil, err
+	}
+
+	return loadBackfill(ctx, tx, id)
+}
+
+func (sb *SeriesBackfill) repoIterator(ctx context.Context, store *basestore.Store) (*iterator.PersistentRepoIterator, error) {
+	if sb.repoIteratorId == 0 {
+		return nil, errors.Newf("invalid repo_iterator_id on backfill_id: %d", sb.Id)
+	}
+	return iterator.Load(ctx, store, sb.repoIteratorId)
+}
+
+var backfillColumns = []*sqlf.Query{
+	sqlf.Sprintf("insight_series_backfill.id"),
+	sqlf.Sprintf("insight_series_backfill.series_id"),
+	sqlf.Sprintf("insight_series_backfill.repo_iterator_id"),
+	sqlf.Sprintf("insight_series_backfill.estimated_cost"),
+	sqlf.Sprintf("insight_series_backfill.state"),
+}
+
+var backfillColumnsJoin = sqlf.Join(backfillColumns, ", ")

--- a/enterprise/internal/insights/scheduler/backfill.go
+++ b/enterprise/internal/insights/scheduler/backfill.go
@@ -3,13 +3,37 @@ package scheduler
 import (
 	"context"
 
+	"github.com/derision-test/glock"
 	"github.com/keegancsmith/sqlf"
 
+	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/scheduler/iterator"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
+
+type backfillStore struct {
+	*basestore.Store
+	clock glock.Clock
+}
+
+func newBackfillStore(edb edb.InsightsDB) *backfillStore {
+	return newBackfillStoreWithClock(edb, glock.NewRealClock())
+}
+func newBackfillStoreWithClock(edb edb.InsightsDB, clock glock.Clock) *backfillStore {
+	return &backfillStore{Store: basestore.NewWithHandle(edb.Handle()), clock: clock}
+}
+
+func (s *backfillStore) With(other basestore.ShareableStore) *backfillStore {
+	return &backfillStore{Store: s.Store.With(other)}
+}
+
+func (s *backfillStore) Transact(ctx context.Context) (*backfillStore, error) {
+	txBase, err := s.Store.Transact(ctx)
+	return &backfillStore{Store: txBase}, err
+}
 
 type SeriesBackfill struct {
 	Id             int
@@ -28,50 +52,79 @@ const (
 	BackfillStateFailed     BackfillState = "failed"
 )
 
-func loadBackfill(ctx context.Context, store *basestore.Store, id int) (*SeriesBackfill, error) {
+func NewBackfill(ctx context.Context, store *backfillStore, series types.InsightSeries) (_ *SeriesBackfill, err error) {
+	q := "INSERT INTO insight_series_backfill (series_id, state) VALUES(%s, %s) RETURNING %s;"
+	row := store.QueryRow(ctx, sqlf.Sprintf(q, series.ID, string(BackfillStateNew), backfillColumnsJoin))
+	return scanBackfill(row)
+}
+
+func loadBackfill(ctx context.Context, store *backfillStore, id int) (*SeriesBackfill, error) {
 	q := "SELECT %s FROM insight_series_backfill WHERE id = %s"
 	row := store.QueryRow(ctx, sqlf.Sprintf(q, backfillColumnsJoin, id))
+	return scanBackfill(row)
+}
+
+func scanBackfill(scanner dbutil.Scanner) (*SeriesBackfill, error) {
 	var tmp SeriesBackfill
-	if err := row.Scan(
+	var cost *float64
+	if err := scanner.Scan(
 		&tmp.Id,
 		&tmp.SeriesId,
-		&tmp.repoIteratorId,
-		&tmp.EstimatedCost,
+		&dbutil.NullInt{N: &tmp.repoIteratorId},
+		&cost,
 		&tmp.State,
 	); err != nil {
 		return nil, err
 	}
+	if cost != nil {
+		tmp.EstimatedCost = *cost
+	}
 	return &tmp, nil
 }
 
-func NewBackfill(ctx context.Context, store basestore.Store, series types.InsightSeries, repos []int32) (_ *SeriesBackfill, err error) {
+func (b *SeriesBackfill) SetBackfillScope(ctx context.Context, store *backfillStore, repos []int32, cost float64) (*SeriesBackfill, error) {
+	if b == nil || b.Id == 0 {
+		return nil, errors.New("invalid series backfill")
+	}
+
 	tx, err := store.Transact(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { err = tx.Done(err) }()
 
-	itr, err := iterator.New(ctx, tx, repos)
+	itr, err := iterator.NewWithClock(ctx, tx.Store, store.clock, repos)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "iterator.New")
 	}
 
-	q := "INSERT INTO insight_series_backfill (series_id, estimated_cost, repo_iterator_id) VALUES(%s, %s, %s) RETURNING id;"
-	cost := 0 // either calculate or take in cost here
-	row := tx.QueryRow(ctx, sqlf.Sprintf(q, series.ID, cost, itr.Id))
-	id, err := basestore.ScanInt(row)
-	if err != nil {
-		return nil, err
-	}
-
-	return loadBackfill(ctx, tx, id)
+	q := "UPDATE insight_series_backfill set repo_iterator_id = %s, estimated_cost = %s, state = %s where id = %s RETURNING %s"
+	row := tx.QueryRow(ctx, sqlf.Sprintf(q, itr.Id, cost, string(BackfillStateProcessing), b.Id, backfillColumnsJoin))
+	return scanBackfill(row)
 }
 
-func (sb *SeriesBackfill) repoIterator(ctx context.Context, store *basestore.Store) (*iterator.PersistentRepoIterator, error) {
+func (b *SeriesBackfill) SetCompleted(ctx context.Context, store *backfillStore) error {
+	return b.setState(ctx, store, BackfillStateCompleted)
+}
+
+func (b *SeriesBackfill) SetFailed(ctx context.Context, store *backfillStore) error {
+	return b.setState(ctx, store, BackfillStateFailed)
+}
+
+func (b *SeriesBackfill) setState(ctx context.Context, store *backfillStore, newState BackfillState) error {
+	err := store.Exec(ctx, sqlf.Sprintf("update insight_series_backfill set state = %s where id = %s;", string(newState), b.Id))
+	if err != nil {
+		return err
+	}
+	b.State = newState
+	return nil
+}
+
+func (sb *SeriesBackfill) repoIterator(ctx context.Context, store *backfillStore) (*iterator.PersistentRepoIterator, error) {
 	if sb.repoIteratorId == 0 {
 		return nil, errors.Newf("invalid repo_iterator_id on backfill_id: %d", sb.Id)
 	}
-	return iterator.Load(ctx, store, sb.repoIteratorId)
+	return iterator.LoadWithClock(ctx, store.Store, sb.repoIteratorId, store.clock)
 }
 
 var backfillColumns = []*sqlf.Query{

--- a/enterprise/internal/insights/scheduler/backfill_test.go
+++ b/enterprise/internal/insights/scheduler/backfill_test.go
@@ -37,14 +37,14 @@ func Test_NewBackfill(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	backfill, err := NewBackfill(ctx, store, series)
+	backfill, err := store.NewBackfill(ctx, series)
 	require.NoError(t, err)
 
 	autogold.Want("backfill loaded successfully", SeriesBackfill{Id: 1, SeriesId: 1, State: BackfillState("new")}).Equal(t, *backfill)
 
 	var updated *SeriesBackfill
 	t.Run("set scope on newly created backfill", func(t *testing.T) {
-		updated, err = backfill.SetBackfillScope(ctx, store, []int32{1, 3, 6, 8}, 100)
+		updated, err = backfill.SetScope(ctx, store, []int32{1, 3, 6, 8}, 100)
 		require.NoError(t, err)
 
 		autogold.Want("set scope on newly created backfill", &SeriesBackfill{

--- a/enterprise/internal/insights/scheduler/backfill_test.go
+++ b/enterprise/internal/insights/scheduler/backfill_test.go
@@ -1,0 +1,79 @@
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/derision-test/glock"
+	"github.com/hexops/autogold"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/log/logtest"
+	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+)
+
+func Test_NewBackfill(t *testing.T) {
+	logger := logtest.Scoped(t)
+	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t))
+	ctx := context.Background()
+	insightStore := store.NewInsightStore(insightsDB)
+	now := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := glock.NewMockClockAt(now)
+	store := newBackfillStoreWithClock(insightsDB, clock)
+
+	series, err := insightStore.CreateSeries(ctx, types.InsightSeries{
+		SeriesID:            "asdf",
+		Query:               "query1",
+		SampleIntervalUnit:  string(types.Month),
+		SampleIntervalValue: 1,
+		GenerationMethod:    types.Search,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	backfill, err := NewBackfill(ctx, store, series)
+	require.NoError(t, err)
+
+	autogold.Want("backfill loaded successfully", SeriesBackfill{Id: 1, SeriesId: 1, State: BackfillState("new")}).Equal(t, *backfill)
+
+	var updated *SeriesBackfill
+	t.Run("set scope on newly created backfill", func(t *testing.T) {
+		updated, err = backfill.SetBackfillScope(ctx, store, []int32{1, 3, 6, 8}, 100)
+		require.NoError(t, err)
+
+		autogold.Want("set scope on newly created backfill", &SeriesBackfill{
+			Id: 1, SeriesId: 1, repoIteratorId: 1,
+			EstimatedCost: 100,
+			State:         BackfillState("processing"),
+		}).Equal(t, updated)
+	})
+
+	t.Run("set state to failed", func(t *testing.T) {
+		err := backfill.SetFailed(ctx, store)
+		require.NoError(t, err)
+
+		autogold.Want("set state to failed", &SeriesBackfill{Id: 1, SeriesId: 1, State: BackfillState("failed")}).Equal(t, backfill)
+	})
+
+	t.Run("set state to completed", func(t *testing.T) {
+		err := backfill.SetCompleted(ctx, store)
+		require.NoError(t, err)
+
+		autogold.Want("set state to completed", &SeriesBackfill{Id: 1, SeriesId: 1, State: BackfillState("completed")}).Equal(t, backfill)
+	})
+
+	t.Run("load repo iterator", func(t *testing.T) {
+		iterator, err := updated.repoIterator(ctx, store)
+		require.NoError(t, err)
+		jsonified, err := json.Marshal(iterator)
+		require.NoError(t, err)
+
+		autogold.Want("load repo iterator", `{"Id":1,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"0001-01-01T00:00:00Z","CompletedAt":"0001-01-01T00:00:00Z","RuntimeDuration":0,"PercentComplete":0,"TotalCount":4,"SuccessCount":0,"Cursor":0}`).Equal(t, string(jsonified))
+	})
+}

--- a/enterprise/internal/insights/scheduler/iterator/repo_iterator_test.go
+++ b/enterprise/internal/insights/scheduler/iterator/repo_iterator_test.go
@@ -22,7 +22,7 @@ import (
 
 type testFunc func(context.Context, api.RepoID, finishFunc) bool
 
-func testForNextAndFinish(t *testing.T, store *basestore.Store, itr *persistentRepoIterator, seen []api.RepoID, do testFunc) (*persistentRepoIterator, []api.RepoID) {
+func testForNextAndFinish(t *testing.T, store *basestore.Store, itr *PersistentRepoIterator, seen []api.RepoID, do testFunc) (*PersistentRepoIterator, []api.RepoID) {
 	ctx := context.Background()
 
 	for true {
@@ -126,7 +126,7 @@ func TestForNextAndFinish(t *testing.T) {
 		got, seen := testForNextAndFinish(t, store, itr, seen, do)
 
 		require.Equal(t, got.Cursor, 2)
-		reloaded, _ := LoadWithClock(ctx, store, got.id, clock)
+		reloaded, _ := LoadWithClock(ctx, store, got.Id, clock)
 		require.Equal(t, reloaded.Cursor, got.Cursor)
 
 		// now iterate from the starting position _after_ reloading from the db
@@ -149,7 +149,7 @@ func TestNew(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	load, err := Load(ctx, store, itr.id)
+	load, err := Load(ctx, store, itr.Id)
 	if err != nil {
 		return
 	}

--- a/enterprise/internal/insights/scheduler/iterator/repo_iterator_test.go
+++ b/enterprise/internal/insights/scheduler/iterator/repo_iterator_test.go
@@ -69,7 +69,7 @@ func TestForNextAndFinish(t *testing.T) {
 			return true
 		})
 		jsonify, _ := json.Marshal(got)
-		autogold.Want("iterate with no errors and no interruptions", `{"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:05Z","RuntimeDuration":5000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":5,"Cursor":5}`).Equal(t, string(jsonify))
+		autogold.Want("iterate with no errors and no interruptions", `{"Id":1,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:05Z","RuntimeDuration":5000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":5,"Cursor":5}`).Equal(t, string(jsonify))
 	})
 
 	t.Run("iterate with one error and no interruptions", func(t *testing.T) {
@@ -92,7 +92,7 @@ func TestForNextAndFinish(t *testing.T) {
 			return true
 		})
 		jsonify, _ := json.Marshal(got)
-		autogold.Want("iterate with 1 error and no interruptions", `{"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:05Z","RuntimeDuration":5000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":4,"Cursor":5}`).Equal(t, string(jsonify))
+		autogold.Want("iterate with 1 error and no interruptions", `{"Id":2,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:05Z","RuntimeDuration":5000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":4,"Cursor":5}`).Equal(t, string(jsonify))
 		autogold.Want("iterate with 1 error and no interruptions error check", errorMap{6: &IterationError{
 			id:            1,
 			RepoId:        6,
@@ -132,7 +132,7 @@ func TestForNextAndFinish(t *testing.T) {
 		// now iterate from the starting position _after_ reloading from the db
 		secondItr, _ := testForNextAndFinish(t, store, reloaded, seen, do)
 		jsonify, _ := json.Marshal(secondItr)
-		autogold.Want("iterate with no error and 1 interruptions", `{"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:06Z","RuntimeDuration":5000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":5,"Cursor":5}`).Equal(t, string(jsonify))
+		autogold.Want("iterate with no error and 1 interruptions", `{"Id":3,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"2021-01-01T00:00:06Z","RuntimeDuration":5000000000,"PercentComplete":1,"TotalCount":5,"SuccessCount":5,"Cursor":5}`).Equal(t, string(jsonify))
 	})
 }
 

--- a/enterprise/internal/insights/scheduler/scheduler_test.go
+++ b/enterprise/internal/insights/scheduler/scheduler_test.go
@@ -2,9 +2,14 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 
 	"github.com/sourcegraph/log/logtest"
@@ -21,4 +26,62 @@ func Test_SchedulerStartsAndStops(t *testing.T) {
 
 	routines := NewScheduler(ctx, insightsDB, &observation.TestContext).Routines()
 	goroutine.MonitorBackgroundRoutines(ctx, routines...)
+}
+
+func Test_SchedulerMovesBackfillFromNewToProcessing(t *testing.T) {
+	logger := logtest.Scoped(t)
+	// ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+	// defer cancel()
+	ctx := context.Background()
+	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t))
+	bfs := newBackfillStore(insightsDB)
+	insightsStore := store.NewInsightStore(insightsDB)
+
+	scheduler := NewScheduler(ctx, insightsDB, &observation.TestContext)
+
+	series, err := insightsStore.CreateSeries(ctx, types.InsightSeries{
+		SeriesID:            "series1",
+		Query:               "asdf",
+		SampleIntervalUnit:  string(types.Month),
+		SampleIntervalValue: 1,
+		GenerationMethod:    types.Search,
+	})
+	require.NoError(t, err)
+
+	backfill, err := bfs.NewBackfill(ctx, series)
+	require.NoError(t, err)
+
+	err = scheduler.EnqueueBackfill(ctx, backfill)
+	require.NoError(t, err)
+
+	dequeue, found, err := scheduler.newBackfillStore.Dequeue(ctx, "test", nil)
+	require.NoError(t, err)
+	if !found {
+		t.Fatal(errors.New("no queued record found"))
+	}
+	job, _ := dequeue.(*BaseJob)
+	require.Equal(t, backfill.Id, job.backfillId)
+
+	modified, err := backfill.SetScope(ctx, bfs, []int32{1, 5, 7}, 100)
+	require.NoError(t, err)
+	require.Equal(t, 1, modified.repoIteratorId)
+
+	err = scheduler.newBackfillStore.Requeue(ctx, dequeue.RecordID(), time.Time{})
+	require.NoError(t, err)
+	// now the record should only show up to the in progress handler
+
+	dequeue, found, err = scheduler.newBackfillStore.Dequeue(ctx, "test", nil)
+	require.NoError(t, err)
+	if found {
+		t.Fatal(errors.New("found record that should not be visible to the new backfill store"))
+	}
+
+	// now ensure the in progress handler _can_ pick it up
+	dequeue, found, err = scheduler.inProgressStore.Dequeue(ctx, "test", nil)
+	require.NoError(t, err)
+	if !found {
+		t.Fatal(errors.New("no queued record found"))
+	}
+	job, _ = dequeue.(*BaseJob)
+	require.Equal(t, backfill.Id, job.backfillId)
 }

--- a/enterprise/internal/insights/scheduler/scheduler_test.go
+++ b/enterprise/internal/insights/scheduler/scheduler_test.go
@@ -18,24 +18,25 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-func Test_SchedulerStartsAndStops(t *testing.T) {
+func Test_MonitorStartsAndStops(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
 	defer cancel()
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t))
 
-	routines := NewScheduler(ctx, insightsDB, &observation.TestContext).Routines()
+	routines := NewBackgroundJobMonitor(ctx, insightsDB, &observation.TestContext).Routines()
 	goroutine.MonitorBackgroundRoutines(ctx, routines...)
 }
 
-func Test_SchedulerMovesBackfillFromNewToProcessing(t *testing.T) {
+func Test_MonitorMovesBackfillFromNewToProcessing(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t))
 	bfs := newBackfillStore(insightsDB)
 	insightsStore := store.NewInsightStore(insightsDB)
 
-	scheduler := NewScheduler(ctx, insightsDB, &observation.TestContext)
+	scheduler := NewScheduler(insightsDB, &observation.TestContext)
+	monitor := NewBackgroundJobMonitor(ctx, insightsDB, &observation.TestContext)
 
 	series, err := insightsStore.CreateSeries(ctx, types.InsightSeries{
 		SeriesID:            "series1",
@@ -52,7 +53,7 @@ func Test_SchedulerMovesBackfillFromNewToProcessing(t *testing.T) {
 	err = scheduler.EnqueueBackfill(ctx, backfill)
 	require.NoError(t, err)
 
-	dequeue, found, err := scheduler.newBackfillStore.Dequeue(ctx, "test", nil)
+	dequeue, found, err := monitor.newBackfillStore.Dequeue(ctx, "test", nil)
 	require.NoError(t, err)
 	if !found {
 		t.Fatal(errors.New("no queued record found"))
@@ -64,18 +65,18 @@ func Test_SchedulerMovesBackfillFromNewToProcessing(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, modified.repoIteratorId)
 
-	err = scheduler.newBackfillStore.Requeue(ctx, dequeue.RecordID(), time.Time{})
+	err = monitor.newBackfillStore.Requeue(ctx, dequeue.RecordID(), time.Time{})
 	require.NoError(t, err)
 	// now the record should only show up to the in progress handler
 
-	dequeue, found, err = scheduler.newBackfillStore.Dequeue(ctx, "test", nil)
+	dequeue, found, err = monitor.newBackfillStore.Dequeue(ctx, "test", nil)
 	require.NoError(t, err)
 	if found {
 		t.Fatal(errors.New("found record that should not be visible to the new backfill store"))
 	}
 
 	// now ensure the in progress handler _can_ pick it up
-	dequeue, found, err = scheduler.inProgressStore.Dequeue(ctx, "test", nil)
+	dequeue, found, err = monitor.inProgressStore.Dequeue(ctx, "test", nil)
 	require.NoError(t, err)
 	if !found {
 		t.Fatal(errors.New("no queued record found"))

--- a/enterprise/internal/insights/scheduler/scheduler_test.go
+++ b/enterprise/internal/insights/scheduler/scheduler_test.go
@@ -30,8 +30,6 @@ func Test_SchedulerStartsAndStops(t *testing.T) {
 
 func Test_SchedulerMovesBackfillFromNewToProcessing(t *testing.T) {
 	logger := logtest.Scoped(t)
-	// ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
-	// defer cancel()
 	ctx := context.Background()
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t))
 	bfs := newBackfillStore(insightsDB)

--- a/internal/database/schema.codeinsights.json
+++ b/internal/database/schema.codeinsights.json
@@ -76,6 +76,15 @@
       "CycleOption": "NO"
     },
     {
+      "Name": "insight_series_backfill_id_seq",
+      "TypeName": "integer",
+      "StartValue": 1,
+      "MinimumValue": 1,
+      "MaximumValue": 2147483647,
+      "Increment": 1,
+      "CycleOption": "NO"
+    },
+    {
       "Name": "insight_series_id_seq",
       "TypeName": "integer",
       "StartValue": 1,
@@ -1113,6 +1122,99 @@
       "Triggers": []
     },
     {
+      "Name": "insight_series_backfill",
+      "Comment": "",
+      "Columns": [
+        {
+          "Name": "estimated_cost",
+          "Index": 4,
+          "TypeName": "double precision",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "id",
+          "Index": 1,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "nextval('insight_series_backfill_id_seq'::regclass)",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "repo_iterator_id",
+          "Index": 3,
+          "TypeName": "integer",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "series_id",
+          "Index": 2,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "state",
+          "Index": 5,
+          "TypeName": "text",
+          "IsNullable": false,
+          "Default": "'new'::text",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        }
+      ],
+      "Indexes": [
+        {
+          "Name": "insight_series_backfill_pk",
+          "IsPrimaryKey": true,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX insight_series_backfill_pk ON insight_series_backfill USING btree (id)",
+          "ConstraintType": "p",
+          "ConstraintDefinition": "PRIMARY KEY (id)"
+        }
+      ],
+      "Constraints": [
+        {
+          "Name": "insight_series_backfill_series_id_fk",
+          "ConstraintType": "f",
+          "RefTableName": "insight_series",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "FOREIGN KEY (series_id) REFERENCES insight_series(id) ON DELETE CASCADE"
+        }
+      ],
+      "Triggers": []
+    },
+    {
       "Name": "insight_view",
       "Comment": "Views for insight data series. An insight view is an abstraction on top of an insight data series that allows for lightweight modifications to filters or metadata without regenerating the underlying series.",
       "Columns": [
@@ -1536,6 +1638,19 @@
       "Comment": "",
       "Columns": [
         {
+          "Name": "backfill_id",
+          "Index": 14,
+          "TypeName": "integer",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
           "Name": "cancel",
           "Index": 13,
           "TypeName": "boolean",
@@ -1727,7 +1842,15 @@
           "ConstraintDefinition": ""
         }
       ],
-      "Constraints": null,
+      "Constraints": [
+        {
+          "Name": "insights_background_jobs_backfill_id_fkey",
+          "ConstraintType": "f",
+          "RefTableName": "insight_series_backfill",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "FOREIGN KEY (backfill_id) REFERENCES insight_series_backfill(id) ON DELETE CASCADE"
+        }
+      ],
       "Triggers": []
     },
     {
@@ -2652,5 +2775,14 @@
       "Triggers": []
     }
   ],
-  "Views": null
+  "Views": [
+    {
+      "Name": "insights_jobs_backfill_in_progress",
+      "Definition": " SELECT jobs.id,\n    jobs.state,\n    jobs.failure_message,\n    jobs.queued_at,\n    jobs.started_at,\n    jobs.finished_at,\n    jobs.process_after,\n    jobs.num_resets,\n    jobs.num_failures,\n    jobs.last_heartbeat_at,\n    jobs.execution_logs,\n    jobs.worker_hostname,\n    jobs.cancel,\n    jobs.backfill_id,\n    isb.state AS backfill_state,\n    isb.estimated_cost\n   FROM (insights_background_jobs jobs\n     JOIN insight_series_backfill isb ON ((jobs.backfill_id = isb.id)))\n  WHERE (isb.state = 'processing'::text);"
+    },
+    {
+      "Name": "insights_jobs_backfill_new",
+      "Definition": " SELECT jobs.id,\n    jobs.state,\n    jobs.failure_message,\n    jobs.queued_at,\n    jobs.started_at,\n    jobs.finished_at,\n    jobs.process_after,\n    jobs.num_resets,\n    jobs.num_failures,\n    jobs.last_heartbeat_at,\n    jobs.execution_logs,\n    jobs.worker_hostname,\n    jobs.cancel,\n    jobs.backfill_id,\n    isb.state AS backfill_state,\n    isb.estimated_cost\n   FROM (insights_background_jobs jobs\n     JOIN insight_series_backfill isb ON ((jobs.backfill_id = isb.id)))\n  WHERE (isb.state = 'new'::text);"
+    }
+  ]
 }

--- a/migrations/codeinsights/1665616961_backfill_table/down.sql
+++ b/migrations/codeinsights/1665616961_backfill_table/down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS insight_series_backfill;
+
+ALTER TABLE insights_background_jobs
+    DROP COLUMN IF EXISTS backfill_id;

--- a/migrations/codeinsights/1665616961_backfill_table/down.sql
+++ b/migrations/codeinsights/1665616961_backfill_table/down.sql
@@ -1,8 +1,8 @@
-DROP TABLE IF EXISTS insight_series_backfill;
+DROP VIEW IF EXISTS insights_jobs_backfill_in_progress;
+
+DROP VIEW IF EXISTS insights_jobs_backfill_new;
 
 ALTER TABLE insights_background_jobs
     DROP COLUMN IF EXISTS backfill_id;
 
-DROP VIEW IF EXISTS insights_jobs_backfill_in_progress;
-
-DROP VIEW IF EXISTS insights_jobs_backfill_new;
+DROP TABLE IF EXISTS insight_series_backfill;

--- a/migrations/codeinsights/1665616961_backfill_table/down.sql
+++ b/migrations/codeinsights/1665616961_backfill_table/down.sql
@@ -3,6 +3,6 @@ DROP TABLE IF EXISTS insight_series_backfill;
 ALTER TABLE insights_background_jobs
     DROP COLUMN IF EXISTS backfill_id;
 
-DROP VIEW IF EXISTS insights_jobs_backfill_ready;
+DROP VIEW IF EXISTS insights_jobs_backfill_in_progress;
 
 DROP VIEW IF EXISTS insights_jobs_backfill_new;

--- a/migrations/codeinsights/1665616961_backfill_table/down.sql
+++ b/migrations/codeinsights/1665616961_backfill_table/down.sql
@@ -2,3 +2,7 @@ DROP TABLE IF EXISTS insight_series_backfill;
 
 ALTER TABLE insights_background_jobs
     DROP COLUMN IF EXISTS backfill_id;
+
+DROP VIEW IF EXISTS insights_jobs_backfill_ready;
+
+DROP VIEW IF EXISTS insights_jobs_backfill_new;

--- a/migrations/codeinsights/1665616961_backfill_table/metadata.yaml
+++ b/migrations/codeinsights/1665616961_backfill_table/metadata.yaml
@@ -1,0 +1,2 @@
+name: backfill_table
+parents: [1665003565]

--- a/migrations/codeinsights/1665616961_backfill_table/up.sql
+++ b/migrations/codeinsights/1665616961_backfill_table/up.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS insight_series_backfill
 );
 
 ALTER TABLE insights_background_jobs
-    ADD COLUMN IF NOT EXISTS backfill_id INT NOT NULL DEFAULT 0; -- the default is really just for safety, there is nothing in this table yet.
+    ADD COLUMN IF NOT EXISTS backfill_id INT REFERENCES insight_series_backfill(id) ON DELETE CASCADE;
 
 CREATE OR REPLACE VIEW insights_jobs_backfill_in_progress AS
 SELECT jobs.*, isb.state AS backfill_state, isb.estimated_cost

--- a/migrations/codeinsights/1665616961_backfill_table/up.sql
+++ b/migrations/codeinsights/1665616961_backfill_table/up.sql
@@ -13,3 +13,15 @@ CREATE TABLE IF NOT EXISTS insight_series_backfill
 
 ALTER TABLE insights_background_jobs
     ADD COLUMN IF NOT EXISTS backfill_id INT NOT NULL DEFAULT 0; -- the default is really just for safety, there is nothing in this table yet.
+
+CREATE OR REPLACE VIEW insights_jobs_backfill_ready AS
+SELECT jobs.*, isb.state AS backfill_state, isb.estimated_cost
+FROM insights_background_jobs jobs
+         JOIN insight_series_backfill isb ON jobs.backfill_id = isb.id
+WHERE isb.state = 'processing';
+
+CREATE OR REPLACE VIEW insights_jobs_backfill_new AS
+SELECT jobs.*, isb.state AS backfill_state, isb.estimated_cost
+FROM insights_background_jobs jobs
+         JOIN insight_series_backfill isb ON jobs.backfill_id = isb.id
+WHERE isb.state = 'new';

--- a/migrations/codeinsights/1665616961_backfill_table/up.sql
+++ b/migrations/codeinsights/1665616961_backfill_table/up.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS insight_series_backfill
 ALTER TABLE insights_background_jobs
     ADD COLUMN IF NOT EXISTS backfill_id INT NOT NULL DEFAULT 0; -- the default is really just for safety, there is nothing in this table yet.
 
-CREATE OR REPLACE VIEW insights_jobs_backfill_ready AS
+CREATE OR REPLACE VIEW insights_jobs_backfill_in_progress AS
 SELECT jobs.*, isb.state AS backfill_state, isb.estimated_cost
 FROM insights_background_jobs jobs
          JOIN insight_series_backfill isb ON jobs.backfill_id = isb.id

--- a/migrations/codeinsights/1665616961_backfill_table/up.sql
+++ b/migrations/codeinsights/1665616961_backfill_table/up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS insight_series_backfill
+(
+    id               SERIAL
+        CONSTRAINT insight_series_backfill_pk PRIMARY KEY,
+    series_id        INT  NOT NULL,
+    repo_iterator_id INT,
+    estimated_cost   DOUBLE PRECISION,
+    state            TEXT NOT NULL DEFAULT 'new',
+
+    CONSTRAINT insight_series_backfill_series_id_fk
+        FOREIGN KEY (series_id) REFERENCES insight_series (id) ON DELETE CASCADE
+);
+
+ALTER TABLE insights_background_jobs
+    ADD COLUMN IF NOT EXISTS backfill_id INT NOT NULL DEFAULT 0; -- the default is really just for safety, there is nothing in this table yet.


### PR DESCRIPTION
Adds the persistence layer for backfilling.

New table: `insight_series_backfill` contains state about backfills throughout their lifecycle. This holds a reference to a repo_iterator (which we may want to invert this relationship in the future, but moving forward for now)

2 new workers:
1. One monitors jobs queued that link to a backfill in state `new` (view: `insights_jobs_backfill_new`)
2. One monitors jobs queued that link to a backfill in state `processing` (view: `insights_jobs_backfill_in_progress`)

There seems to be an error message from the first Worker when a job moves to the other view. This doens't actually block the functionality, but I'll follow up when I'm back and look into why

>  worker.insights-job.background store/store.go:697 heartbeat lost a job {"recordID": 2, "debug": "{\"id\":2,\"state\":\"failed\",\"failure_message\":\"repoIterator: invalid repo_iterator_id on backfill_id: 1\",\"queued_at\":\"2022-10-13T22:23:28.439224+00:00\",\"started_at\":\"2022-10-13T22:23:30.317181+00:00\",\"finished_at\":\"2022-10-13T22:23:30.332529+00:00\",\"process_after\":null,\"num_resets\":0,\"num_failures\":1,\"last_heartbeat_at\":\"2022-10-13T22:23:30.331636+00:00\",\"execution_logs\":null,\"worker_hostname\":\"Courys-MacBook-Pro-2.local\",\"cancel\":false,\"backfill_id\":1}", "options.workerHostname": ""}

Also includes a unit test to ensure jobs queued only show up in their appropriate handlers.

There are a few todo comments, I'm leaving these in so that it is clear where to hook other functionality in.

## Test plan

Other than unit tests, I manually hooked this up in the API and had it create some work


After a new backfill is inserted and the handler (which does nothing yet) runs

| id | state | failure\_message | queued\_at | started\_at | finished\_at | process\_after | num\_resets | num\_failures | last\_heartbeat\_at | execution\_logs | worker\_hostname | cancel | backfill\_id | backfill\_state | estimated\_cost |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 1 | completed | null | 2022-10-13 22:19:27.018209 +00:00 | 2022-10-13 22:19:30.382483 +00:00 | 2022-10-13 22:19:30.393954 +00:00 | null | 0 | 0 | 2022-10-13 22:19:30.382483 +00:00 | null | Courys-MacBook-Pro-2.local | false | 1 | new | null |

After manually setting the state to processing and requeueing

| id | state | failure\_message | queued\_at | started\_at | finished\_at | process\_after | num\_resets | num\_failures | last\_heartbeat\_at | execution\_logs | worker\_hostname | cancel | backfill\_id | backfill\_state | estimated\_cost |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 1 | completed | null | 2022-10-13 22:19:27.018209 +00:00 | 2022-10-13 22:19:30.382483 +00:00 | 2022-10-13 22:19:30.393954 +00:00 | null | 0 | 0 | 2022-10-13 22:19:30.382483 +00:00 | null | Courys-MacBook-Pro-2.local | false | 1 | processing | null |
| 2 | failed | repoIterator: invalid repo\_iterator\_id on backfill\_id: 1 | 2022-10-13 22:23:28.439224 +00:00 | 2022-10-13 22:23:30.317181 +00:00 | 2022-10-13 22:23:30.332529 +00:00 | null | 0 | 1 | 2022-10-13 22:23:30.331636 +00:00 | null | Courys-MacBook-Pro-2.local | false | 1 | processing | null |

