### PR TITLE
Add check for assertion expiration during the SAML auth flow

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/saml/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/middleware.go
@@ -162,16 +162,16 @@ func samlSPHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) 
 			}
 
 			var exp time.Duration
-			// 🚨 SECURITY: TODO(sqs): We *should* uncomment the line below to make our own sessions
-			// only last for as long as the IdP said the authn grant is active for. Unfortunately,
-			// until we support refreshing SAML authn in the background
-			// (https://github.com/sourcegraph/sourcegraph/issues/11340), this provides a bad user
-			// experience because users need to re-authenticate via SAML every minute or so
-			// (assuming their SAML IdP, like many, has a 1-minute access token validity period).
-			//
-			// if info.SessionNotOnOrAfter != nil {
-			// 	exp = time.Until(*info.SessionNotOnOrAfter)
-			// }
+			t, err := time.Parse(time.RFC3339, info.expirationTime)
+			if err != nil {
+				log15.Error("Error parsing expiration time for the asse.", "error", err)
+				http.Error(w, "Failed to retrieve user: "+err.Error(), http.StatusInternalServerError)
+				return
+			}
+			if info.expirationTime != "" {
+				exp = time.Until(t)
+			}
+
 			if err := session.SetActor(w, r, actor, exp, user.CreatedAt); err != nil {
 				log15.Error("Error setting SAML-authenticated actor in session.", "err", err)
 				http.Error(w, "Error starting SAML-authenticated session. Try signing in again.", http.StatusInternalServerError)

--- a/enterprise/cmd/frontend/internal/auth/saml/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/middleware.go
@@ -42,7 +42,7 @@ func Middleware(db database.DB) *auth.Middleware {
 
 // authHandler is the new SAML HTTP auth handler.
 //
-// It uses github.com/russelhaering/gosaml2 and (unlike authHandler1) makes it possible to support
+// It uses github.com/russellhaering/gosaml2 and (unlike authHandler1) makes it possible to support
 // multiple auth providers with SAML and expose more SAML functionality.
 func authHandler(db database.DB, w http.ResponseWriter, r *http.Request, next http.Handler, isAPIRequest bool) {
 	// Delegate to SAML ACS and metadata endpoint handlers.
@@ -164,7 +164,7 @@ func samlSPHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) 
 			var exp time.Duration
 			t, err := time.Parse(time.RFC3339, info.expirationTime)
 			if err != nil {
-				log15.Error("Error parsing expiration time for the asse.", "error", err)
+				log15.Error("Error parsing expiration time.", "error", err)
 				http.Error(w, "Failed to retrieve user: "+err.Error(), http.StatusInternalServerError)
 				return
 			}

--- a/enterprise/cmd/frontend/internal/auth/saml/user.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/user.go
@@ -47,7 +47,9 @@ func readAuthnResponse(p *provider, encodedResp string) (*authnResponseInfo, err
 	if err != nil {
 		return nil, errors.Errorf("parsing SAML encoded response: %+v", err)
 	}
-	notOnOrAfter = decodedResponse.Assertions[0].Conditions.NotOnOrAfter
+	if decodedResponse.Assertions[0].Conditions != nil && decodedResponse.Assertions[0].Conditions.NotOnOrAfter != "" {
+		notOnOrAfter = decodedResponse.Assertions[0].Conditions.NotOnOrAfter
+	}
 
 	pi, err := p.getCachedInfoAndError()
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/auth/saml/user_test.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/user_test.go
@@ -42,6 +42,7 @@ func TestReadAuthnResponse(t *testing.T) {
 		email:                "bob@example.com",
 		unnormalizedUsername: "bob@example.com",
 		displayName:          "Bob Yang",
+		expirationTime:       "2018-05-20T17:13:04.795Z",
 	}); !reflect.DeepEqual(info, want) {
 		t.Errorf("got != want\n got %+v\nwant %+v", info, want)
 	}


### PR DESCRIPTION
Issue #42827 

This PR sets an expiration date/time for sessions based on the value `Conditions.NotOnOrAfter` which can be present in a SAML response.

Notes
1. Some Identity Providers have a default value of 60 minutes (Auth0 and Azure AD)  for  `Conditions.NotOnOrAfter`; others have 74 minutes (such as Ping Identity). Consequently, users that haven't set a custom `NotOnOrAfter` value on their IdPs, will have to re-login into SG when the assertion expires. 

_Are you ok with that? I am concerned about the UX here but, at the same time, it would be good to honor the user configuration in their IdPs._ Tough decision!

3. Also, when the assertion expires, some links on SG, when clicked, will redirect the user to the login page — this is expected. But other links, when clicked, will return a 401 + the UI will show a message asking the user to try to reload the page (see the image attached).

_This is very annoying,  so some changes in the front end should be made to avoid that (hopefully) before merging this PR - if we decide to go ahead with the changes proposed here ._

6. To solve item/concern 1, my initial idea was to find a way to refresh the assertion silently/in the background, as recommended by an old TODO left in our codebase (see the diff), and avoid making the user log in again. But this doesn't look like the way things work with SAML. SAML assertions are validated during login so, once the 'NotOnOrAfter' window closes, it is expected that the user loses access to the system.


## Test plan
Unit tests updated and passed. Manually tested that, when an assertion expires, the user has to re-login.

<img width="945" alt="Screen Shot 2022-10-12 at 7 39 46 PM" src="https://user-images.githubusercontent.com/1552863/195483787-8cff28f9-92f7-4c5f-a4b9-bc281d4239b6.png">
