### PR TITLE
Audit log: Enable security events by default

### DIFF
--- a/cmd/gitserver/server/internal/accesslog/accesslog_test.go
+++ b/cmd/gitserver/server/internal/accesslog/accesslog_test.go
@@ -55,7 +55,7 @@ func (a *accessLogConf) SiteConfig() schema.SiteConfiguration {
 			AuditLog: &schema.AuditLog{
 				GitserverAccess: !a.disabled,
 				GraphQL:         false,
-				SecurityEvents:  false,
+				BackgroundJobs:  false,
 			},
 		},
 	}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -68,12 +68,12 @@ type ApiRatelimit struct {
 
 // AuditLog description: EXPERIMENTAL: Configuration for audit logging (specially formatted log entries for tracking sensitive events)
 type AuditLog struct {
+	// BackgroundJobs description: Capture security events performed by the background jobs (adds significant noise).
+	BackgroundJobs bool `json:"backgroundJobs,omitempty"`
 	// GitserverAccess description: Capture gitserver access logs as part of the audit log.
 	GitserverAccess bool `json:"gitserverAccess"`
 	// GraphQL description: Capture GraphQL requests and responses as part of the audit log.
 	GraphQL bool `json:"graphQL"`
-	// SecurityEvents description: Capture security events as part of the audit log.
-	SecurityEvents bool `json:"securityEvents"`
 }
 
 // AuthAccessTokens description: Settings for access tokens, which enable external tools to access the Sourcegraph API with the privileges of the user.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1215,10 +1215,10 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "securityEvents": {
-              "description": "Capture security events as part of the audit log.",
+            "backgroundJobs": {
+              "description": "Capture security events performed by the background jobs (adds significant noise).",
               "type": "boolean",
-              "default": true
+              "default": false
             },
             "graphQL": {
               "description": "Capture GraphQL requests and responses as part of the audit log.",


### PR DESCRIPTION
## Description

- Remove `log.auditLog.securityEvents` setting, and enable it on by default. This means that malicious site admins would not be able to disable this at all, so the system gets some minimal set of security events all the time.
- Add a new `log.auditLog.backgroundJobs` setting. This setting is not activated yet (TBD soon). The goal will be to allow audit actions performed by "internal" actors to appear in the audit log.

## Test plan

- Existing automated tests + relevant changes
- Manually verified that security events are always on without any additional settings
