### PR TITLE
Remove Index:bool from RepoListOptions since it's useless

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -211,9 +211,11 @@ func (s *repos) ListIndexable(ctx context.Context) (repos []types.MinimalRepo, e
 		return s.cache.List(ctx)
 	}
 
-	trueP := true
+	if !conf.SearchIndexEnabled() {
+		return []types.MinimalRepo{}, nil
+	}
+
 	return s.store.ListMinimalRepos(ctx, database.ReposListOptions{
-		Index:      &trueP,
 		OnlyCloned: true,
 	})
 }

--- a/enterprise/internal/insights/discovery/all_repos_iterator_test.go
+++ b/enterprise/internal/insights/discovery/all_repos_iterator_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/hexops/autogold"
-	"github.com/hexops/valast"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -52,29 +52,24 @@ func TestAllReposIterator(t *testing.T) {
 		autogold.Want("items0", []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}).Equal(t, each)
 	}
 
-	trueP := true
 	// Were the RepoStore.List calls as we expected?
 	autogold.Want("repoStoreListCalls0", []database.ReposListOptions{
 		{
-			Index:       valast.Addr(true).(*bool),
 			LimitOffset: &database.LimitOffset{Limit: 1000},
 		},
 		{
-			Index: valast.Addr(true).(*bool),
 			LimitOffset: &database.LimitOffset{
 				Limit:  1000,
 				Offset: 3,
 			},
 		},
 		{
-			Index: valast.Addr(true).(*bool),
 			LimitOffset: &database.LimitOffset{
 				Limit:  1000,
 				Offset: 6,
 			},
 		},
 		{
-			Index: valast.Addr(true).(*bool),
 			LimitOffset: &database.LimitOffset{
 				Limit:  1000,
 				Offset: 9,
@@ -108,25 +103,21 @@ func TestAllReposIterator(t *testing.T) {
 		autogold.Want("items2", []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}).Equal(t, each)
 		autogold.Want("repoStoreListCalls2", []database.ReposListOptions{
 			{
-				Index:       &trueP,
 				LimitOffset: &database.LimitOffset{Limit: 1000},
 			},
 			{
-				Index: &trueP,
 				LimitOffset: &database.LimitOffset{
 					Limit:  1000,
 					Offset: 3,
 				},
 			},
 			{
-				Index: &trueP,
 				LimitOffset: &database.LimitOffset{
 					Limit:  1000,
 					Offset: 6,
 				},
 			},
 			{
-				Index: &trueP,
 				LimitOffset: &database.LimitOffset{
 					Limit:  1000,
 					Offset: 9,

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -677,12 +676,6 @@ type ReposListOptions struct {
 	// OnlyPrivate excludes non-private repositories from the list.
 	OnlyPrivate bool
 
-	// Index when set will only include repositories which should be indexed
-	// if true. If false it will exclude repositories which should be
-	// indexed. An example use case of this is for indexed search only
-	// indexing a subset of repositories.
-	Index *bool
-
 	// List of fields by which to order the return repositories.
 	OrderBy RepoListOrderBy
 
@@ -1063,16 +1056,6 @@ func (s *repoStore) listSQL(ctx context.Context, tr *trace.Trace, opt ReposListO
 
 	if len(opt.URIs) > 0 {
 		where = append(where, sqlf.Sprintf("uri = ANY (%s)", pq.Array(opt.URIs)))
-	}
-
-	if opt.Index != nil {
-		// We don't currently have an index column, but when we want the
-		// indexable repositories to be a subset it will live in the database
-		// layer. So we do the filtering here.
-		indexAll := conf.SearchIndexEnabled()
-		if indexAll != *opt.Index {
-			where = append(where, sqlf.Sprintf("false"))
-		}
 	}
 
 	if (len(opt.ExternalServiceIDs) != 0 && (opt.UserID != 0 || opt.OrgID != 0)) ||


### PR DESCRIPTION
This was added in anticipation of a feature that didn't arrive: ability to only index a subset of repositories (by adding a `index boolean` column to `repo`).

The change here removes the option but preserves the original behaviour: on dotcom the option was and is ignored, on non-dotcom instances we return an empty list of repositories if indexing has been disabled (but this time without hitting the databse).

## Test plan

- Existing tests
