### PR TITLE
ranking: serve rank instead of 1-rank

### DIFF
--- a/internal/codeintel/ranking/pagerank.go
+++ b/internal/codeintel/ranking/pagerank.go
@@ -42,7 +42,7 @@ func (s *Service) pageRankFromStreamingGraph(ctx context.Context, graph streamin
 
 	ranks := map[string][]float64{}
 	g.Rank(pageRankFollowProbability, pageRankTolerance, func(identifier int, rank float64) {
-		ranks[idsToName[identifier]] = []float64{1 - rank}
+		ranks[idsToName[identifier]] = []float64{rank}
 	})
 
 	return ranks, nil

--- a/internal/codeintel/ranking/service.go
+++ b/internal/codeintel/ranking/service.go
@@ -59,7 +59,7 @@ func (s *Service) GetRepoRank(ctx context.Context, repoName api.RepoName) (_ []f
 		return nil, err
 	}
 
-	return []float64{1 - squashRange(userRank), 1 - starRank}, nil
+	return []float64{squashRange(userRank), starRank}, nil
 }
 
 // copy pasta

--- a/internal/codeintel/ranking/service.go
+++ b/internal/codeintel/ranking/service.go
@@ -112,7 +112,7 @@ func (s *Service) GetDocumentRanks(ctx context.Context, repoName api.RepoName) (
 	n := float64(len(paths))
 	ranks := make(map[string][]float64, len(paths))
 	for i, path := range paths {
-		ranks[path] = rank(path, float64(i)/n)
+		ranks[path] = rank(path, 1.0-float64(i)/n)
 	}
 
 	return ranks, nil
@@ -123,22 +123,22 @@ var testPattern = lazyregexp.New("test")
 // copy pasta + modified
 // https://github.com/sourcegraph/zoekt/blob/f89a534103a224663d23b4579959854dd7816942/build/builder.go#L872-L918
 func rank(name string, nameRank float64) []float64 {
-	generated := 0.0
+	generated := 1.0
 	if strings.HasSuffix(name, "min.js") || strings.HasSuffix(name, "js.map") {
-		generated = 1.0
+		generated = 0.0
 	}
 
-	vendor := 0.0
+	vendor := 1.0
 	if strings.Contains(name, "vendor/") || strings.Contains(name, "node_modules/") {
-		vendor = 1.0
+		vendor = 0.0
 	}
 
-	test := 0.0
+	test := 1.0
 	if testPattern.MatchString(name) {
-		test = 1.0
+		test = 0.0
 	}
 
-	// Smaller is earlier (=better).
+	// Bigger is earlier (=better).
 	return []float64{
 		// Prefer docs that are not generated
 		generated,
@@ -150,16 +150,16 @@ func rank(name string, nameRank float64) []float64 {
 		test,
 
 		// With short names
-		squashRange(float64(len(name))),
+		1.0 - squashRange(float64(len(name))),
 
 		// // With many symbols
-		// 1.0 - squashRange(len(d.Symbols)),
+		// squashRange(len(d.Symbols)),
 
 		// // With short content
-		// squashRange(len(d.Content)),
+		// 1.0 - squashRange(len(d.Content)),
 
 		// // That is present is as many branches as possible
-		// 1.0 - squashRange(len(d.Branches)),
+		// squashRange(len(d.Branches)),
 
 		// Preserve original ordering.
 		nameRank,

--- a/internal/codeintel/ranking/service_test.go
+++ b/internal/codeintel/ranking/service_test.go
@@ -25,10 +25,10 @@ func TestGetRepoRank(t *testing.T) {
 		t.Fatalf("unexpected error getting repo rank: %s", err)
 	}
 
-	if expected := 1.0; !cmpFloat(rank[0], expected) {
+	if expected := 0.0; !cmpFloat(rank[0], expected) {
 		t.Errorf("unexpected rank[0]. want=%.5f have=%.5f", expected, rank[0])
 	}
-	if expected := 0.4; !cmpFloat(rank[1], expected) {
+	if expected := 0.6; !cmpFloat(rank[1], expected) {
 		t.Errorf("unexpected rank[1]. want=%.5f have=%.5f", expected, rank[1])
 	}
 }
@@ -58,10 +58,10 @@ func TestGetRepoRankWithUserBoostedScores(t *testing.T) {
 		t.Fatalf("unexpected error getting repo rank: %s", err)
 	}
 
-	if expected := 1 - (400.0 / 401.0); !cmpFloat(rank[0], expected) {
+	if expected := 400.0 / 401.0; !cmpFloat(rank[0], expected) {
 		t.Errorf("unexpected rank[0]. want=%.5f have=%.5f", expected, rank[0])
 	}
-	if expected := 0.4; !cmpFloat(rank[1], expected) {
+	if expected := 0.6; !cmpFloat(rank[1], expected) {
 		t.Errorf("unexpected rank[1]. want=%.5f have=%.5f", expected, rank[1])
 	}
 }

--- a/internal/codeintel/ranking/service_test.go
+++ b/internal/codeintel/ranking/service_test.go
@@ -94,22 +94,24 @@ func TestGetDocumentRanks(t *testing.T) {
 	}
 
 	expected := map[string][]float64{
-		"code/a.go":           {0, 0, 0, 0.900, 0.00 / 13.0},
-		"code/b.go":           {0, 0, 0, 0.900, 1.00 / 13.0},
-		"code/c.go":           {0, 0, 0, 0.900, 2.00 / 13.0},
-		"code/d.go":           {0, 0, 0, 0.900, 3.00 / 13.0},
-		"main.go":             {0, 0, 0, 0.875, 4.00 / 13.0},
-		"node_modules/bar.js": {0, 1, 0, 0.950, 5.00 / 13.0},
-		"node_modules/baz.js": {0, 1, 0, 0.950, 6.00 / 13.0},
-		"node_modules/foo.js": {0, 1, 0, 0.950, 7.00 / 13.0},
-		"rendered/web/min.js": {1, 0, 0, 0.950, 8.00 / 13.0},
-		"test/a.go":           {0, 0, 1, 0.900, 9.00 / 13.0},
-		"test/b.go":           {0, 0, 1, 0.900, 10.0 / 13.0},
-		"test/c.go":           {0, 0, 1, 0.900, 11.0 / 13.0},
-		"test/d.go":           {0, 0, 1, 0.900, 12.0 / 13.0},
+		"code/a.go":           {1, 1, 1, 0.100, 1 - (0.00 / 13.0)},
+		"code/b.go":           {1, 1, 1, 0.100, 1 - (1.00 / 13.0)},
+		"code/c.go":           {1, 1, 1, 0.100, 1 - (2.00 / 13.0)},
+		"code/d.go":           {1, 1, 1, 0.100, 1 - (3.00 / 13.0)},
+		"main.go":             {1, 1, 1, 0.125, 1 - (4.00 / 13.0)},
+		"node_modules/bar.js": {1, 0, 1, 0.050, 1 - (5.00 / 13.0)},
+		"node_modules/baz.js": {1, 0, 1, 0.050, 1 - (6.00 / 13.0)},
+		"node_modules/foo.js": {1, 0, 1, 0.050, 1 - (7.00 / 13.0)},
+		"rendered/web/min.js": {0, 1, 1, 0.050, 1 - (8.00 / 13.0)},
+		"test/a.go":           {1, 1, 0, 0.100, 1 - (9.00 / 13.0)},
+		"test/b.go":           {1, 1, 0, 0.100, 1 - (10.0 / 13.0)},
+		"test/c.go":           {1, 1, 0, 0.100, 1 - (11.0 / 13.0)},
+		"test/d.go":           {1, 1, 0, 0.100, 1 - (12.0 / 13.0)},
 	}
 
-	if diff := cmp.Diff(expected, ranks); diff != "" {
+	opt := cmp.Comparer(cmpFloat)
+
+	if diff := cmp.Diff(expected, ranks, opt); diff != "" {
 		t.Errorf("unexpected ranks (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
In the code we use both rank and 1-rank, which isn't necessary and causes confusion (at least for me).

Zoekt originally used 1-rank in its sorting logic for documents. In Zoekt, ranking happened within sorting, so the logic was very confined.

When we copied the ranking logic from Zoekt to frontend we copied the approach.  However, now that ranking  happens in frontend and sorting in Zoekt, we should stop using 1-rank and just serve rank which is much more intuitive.

## Test plan
updated unit test

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
