### PR TITLE
packages: stop fetching/gitPushDependencyTag if package not found

### DIFF
--- a/cmd/gitserver/server/vcs_packages_syncer.go
+++ b/cmd/gitserver/server/vcs_packages_syncer.go
@@ -276,13 +276,13 @@ func (s *vcsPackagesSyncer) gitPushDependencyTag(ctx context.Context, bareGitDir
 
 	err = s.source.Download(ctx, workDir, dep)
 	// We should not return err when dependency is not found
-	if err != nil && errcode.IsNotFound(err) {
-		s.logger.With(
-			log.String("dependency", dep.VersionedPackageSyntax()),
-			log.String("error", err.Error()),
-		).Warn("Error during dependency download")
-		return nil
-	} else if err != nil {
+	if err != nil {
+		if errcode.IsNotFound(err) {
+			s.logger.With(
+				log.String("dependency", dep.VersionedPackageSyntax()),
+				log.String("error", err.Error()),
+			).Warn("Error during dependency download")
+		}
 		return err
 	}
 

--- a/cmd/gitserver/server/vcs_packages_syncer.go
+++ b/cmd/gitserver/server/vcs_packages_syncer.go
@@ -275,7 +275,6 @@ func (s *vcsPackagesSyncer) gitPushDependencyTag(ctx context.Context, bareGitDir
 	defer os.RemoveAll(workDir)
 
 	err = s.source.Download(ctx, workDir, dep)
-	// We should not return err when dependency is not found
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			s.logger.With(

--- a/cmd/gitserver/server/vcs_packages_syncer_test.go
+++ b/cmd/gitserver/server/vcs_packages_syncer_test.go
@@ -198,7 +198,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 			t.Fatal("Cannot parse Maven dependency")
 		}
 		err = s.gitPushDependencyTag(ctx, string(dir), springBootDep)
-		require.NoError(t, err)
+		require.NotNil(t, err)
 	})
 }
 


### PR DESCRIPTION
On S2 and dotcom we have a lot of packages that fail to clone but the error message that show up like this:

    failed to clone python/asvdb: get clone command: failed to fetch repo
    for file://python/asvdb: command [git branch --force latest v0.4.2]
    failed with output fatal: Not a valid object name: 'v0.4.2'.: exit
    status 128

<img width="955" alt="screenshot_2022-10-13_12 01 40@2x" src="https://user-images.githubusercontent.com/1185253/195567384-36b8f22f-09a8-46e2-a536-a05b3f215668.png">

It's very cryptic. The reason for that is that we've previously *ignored* when a package wasn't found and then continued to execute the `Fetch()` method that would then try to `git branch --force latest <version>` to set the latest tag, etc.

This change here logs the not-found error and also returns it. All the callers that _should_ ignore an error like this (`fetchRevSpec`) already ignore errors from `gitPushDependencyTag`.

## Ideally...

Ideally we'd never insert packages into `lsif_dependency_repos` if they can't be found. But that's out of the scope here, I think. So what we do instead is we delete the packages on S2 that couldn't be found by hand.

On dotcom it's an issue though that we have thousands of packages constantly being recloned and failing.

## Test plan

- Tested manually by reproducing setup from S2