### PR TITLE
executorqueue: Never write http header twice

### DIFF
--- a/enterprise/cmd/frontend/internal/executorqueue/queuehandler.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queuehandler.go
@@ -85,6 +85,7 @@ func validateExecutorToken(w http.ResponseWriter, r *http.Request, expectedAcces
 	}
 	if token == "" {
 		http.Error(w, "no token value in the HTTP Authorization request header (recommended) or basic auth (deprecated)", http.StatusUnauthorized)
+		return false
 	}
 
 	if token != expectedAccessToken {


### PR DESCRIPTION
If the auth token was empty, there was a case where we would attempt to write the HTTP header twice. Early return prevents that.

## Test plan

Existing test suite.