### PR TITLE
Fix usages of of the phrase Sourcegraph Cloud

### DIFF
--- a/client/browser/src/browser-extension/options-menu/OptionsPage.story.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.story.tsx
@@ -111,7 +111,7 @@ export const AllOptionsPages: Story = (args = {}) => (
             <H2 className="mt-5 text-center">Not synced repository</H2>
             <div className="d-flex justify-content-center mb-3">
                 <div className="mx-4">
-                    <H3 className="text-center">Sourcegraph Cloud</H3>
+                    <H3 className="text-center">Sourcegraph.com</H3>
                     <OptionsPageWrapper
                         sourcegraphUrl="https://sourcegraph.com"
                         currentUser={{ settingsURL: '/users/john-doe/settings', siteAdmin: false }}

--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -119,9 +119,7 @@ export const SignUpPage: React.FunctionComponent<React.PropsWithChildren<SignUpP
                 icon={SourcegraphIcon}
                 iconLinkTo={context.sourcegraphDotComMode ? '/search' : undefined}
                 iconClassName="bg-transparent"
-                title={
-                    context.sourcegraphDotComMode ? 'Sign up for Sourcegraph Cloud' : 'Sign up for Sourcegraph Server'
-                }
+                title={context.sourcegraphDotComMode ? 'Sign up for Sourcegraph.com' : 'Sign up for Sourcegraph Server'}
                 lessPadding={true}
                 body={
                     <div className={classNames('pb-5', signInSignUpCommonStyles.signupPageContainer)}>

--- a/client/web/src/auth/UnlockAccount.tsx
+++ b/client/web/src/auth/UnlockAccount.tsx
@@ -99,7 +99,7 @@ export const UnlockAccountPage: React.FunctionComponent<React.PropsWithChildren<
                 lessPadding={true}
                 title={
                     props.context.sourcegraphDotComMode
-                        ? 'Unlock your Sourcegraph Cloud account'
+                        ? 'Unlock your Sourcegraph.com account'
                         : 'Unlock your Sourcegraph Server account'
                 }
                 body={body}

--- a/client/web/src/components/SelfHostedCta/SelfHostedCta.tsx
+++ b/client/web/src/components/SelfHostedCta/SelfHostedCta.tsx
@@ -30,10 +30,6 @@ export const SelfHostedCta: React.FunctionComponent<React.PropsWithChildren<Self
         telemetryService.log('InstallSourcegraphCTAClicked', { page }, { page })
     }
 
-    const selfVsCloudDocumentsLinkOnClick = (): void => {
-        telemetryService.log('SelfVsCloudDocsLink', { page }, { page })
-    }
-
     const helpGettingStartedCTAOnClick = (): void => {
         telemetryService.log('HelpGettingStartedCTA', { page }, { page })
     }
@@ -56,15 +52,6 @@ export const SelfHostedCta: React.FunctionComponent<React.PropsWithChildren<Self
                             {...linkProps}
                         >
                             Learn how to install
-                        </Link>
-                    </li>
-                    <li>
-                        <Link
-                            onClick={selfVsCloudDocumentsLinkOnClick}
-                            to="https://docs.sourcegraph.com/code_search/explanations/sourcegraph_cloud#who-is-sourcegraph-cloud-for-why-should-i-use-this-over-sourcegraph-self-hosted"
-                            {...linkProps}
-                        >
-                            Self-hosted vs. cloud features
                         </Link>
                     </li>
                 </ul>

--- a/client/web/src/notebooks/notebookPage/ShareNotebookModal.tsx
+++ b/client/web/src/notebooks/notebookPage/ShareNotebookModal.tsx
@@ -23,7 +23,7 @@ interface ShareNotebookModalProps extends TelemetryProps {
 
 function getSelectedShareOptionDescription(shareOption: ShareOption, isSourcegraphDotCom: boolean): string {
     if (shareOption.namespaceType === 'User') {
-        const withAccess = isSourcegraphDotCom ? 'on Sourcegraph Cloud' : 'with access to the Sourcegraph instance'
+        const withAccess = isSourcegraphDotCom ? 'on Sourcegraph.com' : 'with access to the Sourcegraph instance'
         return shareOption.isPublic
             ? `Everyone ${withAccess} can view the notebook, but only you can edit it`
             : 'Only you can view and edit the notebook'
@@ -85,7 +85,7 @@ export const ShareNotebookModal: React.FunctionComponent<React.PropsWithChildren
                             })
                         }
                         label={`Everyone ${
-                            isSourcegraphDotCom ? 'on Sourcegraph Cloud' : 'with access to the Sourcegraph instance'
+                            isSourcegraphDotCom ? 'on Sourcegraph.com' : 'with access to the Sourcegraph instance'
                         } can view the notebook`}
                     />
                 )}

--- a/client/web/src/org/members/InviteMemberModal.tsx
+++ b/client/web/src/org/members/InviteMemberModal.tsx
@@ -103,7 +103,7 @@ export const InviteMemberModal: React.FunctionComponent<React.PropsWithChildren<
                 <div className="d-flex flex-row position-relative mt-2">
                     <small>
                         <span className="text-muted">
-                            During open beta for Sourcegraph Cloud for small teams, all members invited to your
+                            During open beta for Sourcegraph.com for small teams, all members invited to your
                             organization will be admins for your organization.{' '}
                         </span>
                         <Link to="#">Learn more.</Link>

--- a/client/web/src/org/openBeta/NewOrganizationPage.tsx
+++ b/client/web/src/org/openBeta/NewOrganizationPage.tsx
@@ -278,7 +278,7 @@ export const NewOrgOpenBetaPage: React.FunctionComponent<React.PropsWithChildren
                             <span className={styles.cbLabel}>
                                 I accept the{' '}
                                 <Link to="https://about.sourcegraph.com/terms-cloud">terms of service</Link> for
-                                participating in the Sourcegraph Cloud for small teams open beta.
+                                participating in the Sourcegraph.com for small teams open beta.
                             </span>
                         }
                     />

--- a/client/web/src/org/settings/codeHosts/InstallGitHubAppSuccessPage.tsx
+++ b/client/web/src/org/settings/codeHosts/InstallGitHubAppSuccessPage.tsx
@@ -65,7 +65,7 @@ export const InstallGitHubAppSuccessPage: React.FunctionComponent<React.PropsWit
                             />
                         )}
                     </div>
-                    <H2 className="text-center">Sourcegraph Cloud for GitHub installed on {data?.account.login}</H2>
+                    <H2 className="text-center">Sourcegraph.com for GitHub installed on {data?.account.login}</H2>
                     <br />
                     <Text alignment="center" className="mr-3 ml-3">
                         <b>One more thing:</b> to finish setup, let the requestor know that the Sourcegraph Cloud for

--- a/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
+++ b/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
@@ -22,7 +22,7 @@ export const AboutOrganizationPage: React.FunctionComponent<React.PropsWithChild
             <PageHeader
                 headingElement="h2"
                 path={[{ text: 'Organizations' }]}
-                description="Support for organizations is not currently available on Sourcegraph Cloud."
+                description="Support for organizations is not currently available on Sourcegraph.com."
                 className="mb-3"
             />
             <SelfHostedCta


### PR DESCRIPTION
I noticed a couple of usages of the phrase Sourcegraph Cloud through the product so I decided to do a project wide search and replace all usages inside user facing parts of the app (there are still numerous code comments that I wanted to leave unchanged).

- There's one remaining use of the term Sourcegraph Cloud that I don't really understand what it's about so I kept it 😅 : https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/org/settings/codeHosts/InstallGitHubAppSuccessPage.tsx?L68-74
- Some places reference the teams beta but I didn't remove the code for it to avoid breaking anything. This PR should only change user facing text.

## Test plan

We believe in the CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-sourcegraph-cloud.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hvnfdufwol.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
