### PR TITLE
ranking: Optimize occurrence search in text

### DIFF
--- a/internal/codeintel/ranking/indexer.go
+++ b/internal/codeintel/ranking/indexer.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
-	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
@@ -47,8 +46,6 @@ func (s *Service) indexRepositories(ctx context.Context) (err error) {
 	s.logger.Debug("Refreshed all ranking indexes")
 	return nil
 }
-
-var symbolPattern = lazyregexp.New(`func ([A-Z][^(]*)`)
 
 func (s *Service) indexRepository(ctx context.Context, repoName api.RepoName) (err error) {
 	_, _, endObservation := s.operations.indexRepository.With(ctx, &err, observation.Args{})


### PR DESCRIPTION
This changes makes building the graph of occurrences much faster at the repository level.

| repo                                 | old elapsed   | new elapsed  | delta             |
| ------------------------------------ | ------------- | ------------ | ----------------- |
| github.com/hashicorp/errwrap         |   30.999917ms |  34.877709ms | 12.5090% increase |
| github.com/hashicorp/go-multierror   |   36.660083ms |  19.638958ms | 46.4296% decrease |
| github.com/sourcegraph-testing/etcd  | 7442.524167ms | 164.114583ms | 97.7949% decrease |
| github.com/sourcegraph-testing/titan |  871.272625ms |  26.117250ms | 97.0024% decrease |
| github.com/sourcegraph-testing/zap   | 1020.263416ms |  30.088333ms | 97.0509% decrease |
| github.com/sourcegraph/lsif-go       |  414.748291ms |  22.405125ms | 94.5979% decrease |
| github.com/sourcegraph/sourcegraph   | 4462.920959ms | 163.551500ms | 96.3353% decrease |
| github.com/vishvananda/netlink       | 1311.637542ms |  26.809584ms | 97.9560% decrease |

Previously we did trickery with fanning out searches over the same text buffer using regex on word boundaries. Since the regex is always the same _class_ (basically `\b\w+\b`, where the exact contents of the word change), we can pre-compute the words from the text buffer _once_, and do subsequent passes over that. Since we only need to track indexes, we can do cheap lookup operations (and a linear scan over the indexes is **fast**).

## Test plan

Tested locally.