### PR TITLE
CodeMirror blob: Wrap `stencil` tokens in links to definitions

### DIFF
--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -107,10 +107,9 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
     const enableLazyBlobSyntaxHighlighting = useExperimentalFeatures(
         features => features.enableLazyBlobSyntaxHighlighting ?? false
     )
-    let enableTokenKeyboardNavigation =
+    const enableTokenKeyboardNavigation =
         isSettingsValid(props.settingsCascade) &&
         props.settingsCascade.final['codeIntel.blobKeyboardNavigation'] === 'token'
-    enableTokenKeyboardNavigation = true
 
     const lineOrRange = useMemo(() => parseQueryAndHash(props.location.search, props.location.hash), [
         props.location.search,

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -107,9 +107,10 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
     const enableLazyBlobSyntaxHighlighting = useExperimentalFeatures(
         features => features.enableLazyBlobSyntaxHighlighting ?? false
     )
-    const enableTokenKeyboardNavigation =
+    let enableTokenKeyboardNavigation =
         isSettingsValid(props.settingsCascade) &&
         props.settingsCascade.final['codeIntel.blobKeyboardNavigation'] === 'token'
+    enableTokenKeyboardNavigation = true
 
     const lineOrRange = useMemo(() => parseQueryAndHash(props.location.search, props.location.hash), [
         props.location.search,

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -19,6 +19,8 @@ import { createUpdateableField, editorHeight, useCodeMirror } from '@sourcegraph
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import { parseQueryAndHash, UIPositionSpec } from '@sourcegraph/shared/src/util/url'
 
+import { useExperimentalFeatures } from '../../stores'
+
 import { BlobInfo, BlobProps, updateBrowserHistoryIfChanged } from './Blob'
 import { blobPropsFacet } from './codemirror'
 import { showGitBlameDecorations } from './codemirror/blame-decorations'
@@ -119,18 +121,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
 
     const blameDecorations = useMemo(() => (blameHunks ? [showGitBlameDecorations.of(blameHunks)] : []), [blameHunks])
 
-    const tokenLinks = useMemo(() => {
-        if (!blobInfo.stencil) {
-            return []
-        }
-
-        return blobInfo.stencil.map(range => ({
-            range,
-            url: `?${toPositionOrRangeQueryParameter({
-                position: { line: range.start.line + 1, character: range.start.character + 1 },
-            })}#tab=references`,
-        }))
-    }, [blobInfo.stencil])
+    const preloadGoToDefinition = useExperimentalFeatures(features => features.preloadGoToDefinition ?? false)
 
     // Keep history and location in a ref so that we can use the latest value in
     // the onSelection callback without having to recreate it and having to
@@ -180,7 +171,13 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
                 initialSelection: position.line !== undefined ? position : null,
                 navigateToLineOnAnyClick: navigateToLineOnAnyClick ?? false,
             }),
-            tokenKeyboardNavigation ? tokensAsLinks.of({ history, links: tokenLinks }) : [],
+            tokenKeyboardNavigation
+                ? tokensAsLinks({
+                      history,
+                      blobInfo,
+                      preloadGoToDefinition,
+                  })
+                : [],
             syntaxHighlight.of(blobInfo),
             pinnedRangeField.init(() => (hasPin ? position : null)),
             extensionsController !== null && !navigateToLineOnAnyClick
@@ -201,7 +198,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         // further below. However they are still needed here because we need to
         // set initial values when we re-initialize the editor.
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [onSelection, blobInfo, extensionsController, disableStatusBar, disableDecorations, tokenLinks]
+        [onSelection, blobInfo, extensionsController, disableStatusBar, disableDecorations]
     )
 
     const editorRef = useRef<EditorView>()

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -175,7 +175,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
                 ? tokensAsLinks({
                       history,
                       blobInfo,
-                      preloadGoToDefinition: true,
+                      preloadGoToDefinition,
                   })
                 : [],
             syntaxHighlight.of(blobInfo),

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -175,7 +175,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
                 ? tokensAsLinks({
                       history,
                       blobInfo,
-                      preloadGoToDefinition,
+                      preloadGoToDefinition: true,
                   })
                 : [],
             syntaxHighlight.of(blobInfo),

--- a/client/web/src/repo/blob/codemirror/tokens-as-links.ts
+++ b/client/web/src/repo/blob/codemirror/tokens-as-links.ts
@@ -1,9 +1,15 @@
-import { Facet, RangeSetBuilder } from '@codemirror/state'
+import { Extension, RangeSetBuilder, StateEffect, StateField } from '@codemirror/state'
 import { Decoration, DecorationSet, EditorView, PluginValue, ViewPlugin, ViewUpdate } from '@codemirror/view'
 import { History } from 'history'
+import { Observable, Subject, Subscription } from 'rxjs'
+import { concatMap, debounceTime, map } from 'rxjs/operators'
+import { DeepNonNullable } from 'utility-types'
 
-import { logger } from '@sourcegraph/common'
-import { UIRange } from '@sourcegraph/shared/src/util/url'
+import { logger, toPositionOrRangeQueryParameter } from '@sourcegraph/common'
+import { toPrettyBlobURL, UIRange } from '@sourcegraph/shared/src/util/url'
+
+import { BlobInfo } from '../Blob'
+import { DefinitionResponse, fetchDefinitionsFromRanges } from '../definitions'
 
 import { SelectedLineRange, selectedLines } from './linenumbers'
 
@@ -43,8 +49,108 @@ const focusSelectedLine = ViewPlugin.fromClass(
     }
 )
 
+class DefinitionManager implements PluginValue {
+    private subscription: Subscription
+    private visiblePositionRange: Subject<{ from: number; to: number }>
+
+    constructor(private view: EditorView, private blobInfo: BlobInfo) {
+        this.visiblePositionRange = new Subject()
+        this.subscription = this.visiblePositionRange
+            .pipe(
+                debounceTime(200),
+                concatMap(({ from, to }) => this.getDefinitionsLinksWithinRange(view, from, to))
+            )
+            .subscribe(definitionLinks => {
+                requestAnimationFrame(() => {
+                    this.view.dispatch({
+                        effects: setTokenLinks.of(definitionLinks),
+                    })
+                })
+            })
+
+        // Trigger first update
+        this.visiblePositionRange.next({ from: view.viewport.from, to: view.viewport.to })
+    }
+
+    public update(update: ViewUpdate): void {
+        if (update.viewportChanged) {
+            this.visiblePositionRange?.next({ from: update.view.viewport.from, to: update.view.viewport.to })
+        }
+    }
+
+    public destroy(): void {
+        this.subscription?.unsubscribe()
+        requestAnimationFrame(() => {
+            this.view.dispatch({
+                effects: setTokenLinks.of([]),
+            })
+        })
+    }
+
+    /**
+     * Fetch definitions for all stencil ranges within the viewport.
+     */
+    private getDefinitionsLinksWithinRange(
+        view: EditorView,
+        lineFrom: number,
+        lineTo: number
+    ): Observable<TokenLink[]> {
+        const { repoName, filePath, revision, commitID } = this.blobInfo
+
+        const from = view.state.doc.lineAt(lineFrom).number
+        const to = view.state.doc.lineAt(lineTo).number
+
+        // We only want to fetch definitions for ranges that:
+        // 1. We know are valid (i.e. already set in the state)
+        // 2. Are within the current viewport
+        const ranges = view.state
+            .field(tokenLinks)
+            .filter(({ range }) => range.start.line + 1 >= from && range.end.line + 1 <= to)
+            .map(({ range }) => range)
+
+        /**
+         * Fetch definitions from known ranges, and convert to `TokenLink`s
+         */
+        return fetchDefinitionsFromRanges({ ranges, repoName, filePath, revision }).pipe(
+            map(results => {
+                if (results === null) {
+                    return []
+                }
+
+                return results
+                    .filter((result): result is DeepNonNullable<DefinitionResponse> => Boolean(result.definition))
+                    .map(({ range, definition }) => {
+                        // Preserve the users current revision (e.g., a Git branch name instead of a Git commit SHA)
+                        // This avoids navigating the user from (e.g.) a URL with a nice Git
+                        // branch name to a URL with a full Git commit SHA.
+                        const targetRevision =
+                            definition.resource.repository.name === repoName &&
+                            definition.resource.commit.oid === commitID
+                                ? revision
+                                : definition.resource.commit.oid
+
+                        return {
+                            range,
+                            url: toPrettyBlobURL({
+                                repoName: definition.resource.repository.name,
+                                filePath: definition.resource.path,
+                                revision: targetRevision,
+                                position: definition.range
+                                    ? {
+                                          line: definition.range.start.line + 1,
+                                          character: definition.range.start.character,
+                                      }
+                                    : undefined,
+                            }),
+                        }
+                    })
+            })
+        )
+    }
+}
+
 /**
- * Given a set of ranges, returns a decoration set that adds a link to each range.
+ * Given a set of TokenLinks, returns a decoration set that wraps each specified range in a `<a>` tag.
  */
 function tokenLinksToRangeSet(view: EditorView, links: TokenLink[]): DecorationSet {
     const builder = new RangeSetBuilder<Decoration>()
@@ -70,20 +176,40 @@ function tokenLinksToRangeSet(view: EditorView, links: TokenLink[]): DecorationS
     return builder.finish()
 }
 
-interface TokensAsLinksFacet {
-    history: History
-    links: TokenLink[]
-}
+const setTokenLinks = StateEffect.define<TokenLink[]>()
+const tokenLinks = StateField.define<TokenLink[]>({
+    create() {
+        return []
+    },
+    update(currentLinks, transaction) {
+        for (const effect of transaction.effects) {
+            if (effect.is(setTokenLinks)) {
+                const mergedLinks: TokenLink[] = []
 
-/**
- * Facet with which we can provide TokenLinks and have them rendered as interactive links.
- */
-export const tokensAsLinks = Facet.define<TokensAsLinksFacet, TokensAsLinksFacet>({
-    combine: source => source[0],
-    enables: facet => [
-        focusSelectedLine,
-        EditorView.decorations.compute([facet], state => {
-            const { links } = state.facet(facet)
+                for (const base of currentLinks) {
+                    const updated = effect.value.find(
+                        link =>
+                            link.range.start.line === base.range.start.line &&
+                            link.range.start.character === base.range.start.character &&
+                            link.range.end.line === base.range.end.line &&
+                            link.range.end.character === base.range.end.character
+                    )
+
+                    if (updated) {
+                        mergedLinks.push(updated)
+                    } else {
+                        mergedLinks.push(base)
+                    }
+                }
+
+                return mergedLinks
+            }
+        }
+
+        return currentLinks
+    },
+    provide(field) {
+        return EditorView.decorations.from(field, links => {
             let decorations: DecorationSet | null = null
 
             return view => {
@@ -93,19 +219,40 @@ export const tokensAsLinks = Facet.define<TokensAsLinksFacet, TokensAsLinksFacet
 
                 return (decorations = tokenLinksToRangeSet(view, links))
             }
-        }),
+        })
+    },
+})
+
+interface TokensAsLinksConfiguration {
+    history: History
+    blobInfo: BlobInfo
+    preloadGoToDefinition: boolean
+}
+
+export const tokensAsLinks = ({ history, blobInfo, preloadGoToDefinition }: TokensAsLinksConfiguration): Extension => {
+    const referencesLinks =
+        blobInfo.stencil?.map(range => ({
+            range,
+            url: `?${toPositionOrRangeQueryParameter({
+                position: { line: range.start.line + 1, character: range.start.character + 1 },
+            })}#tab=references`,
+        })) ?? []
+
+    return [
+        focusSelectedLine,
+        tokenLinks.init(() => referencesLinks),
+        preloadGoToDefinition ? ViewPlugin.define(view => new DefinitionManager(view, blobInfo)) : [],
         EditorView.domEventHandlers({
-            click(event: MouseEvent, view: EditorView) {
+            click(event: MouseEvent) {
                 const target = event.target as HTMLElement
 
                 // Check to see if the clicked target is a token link.
                 // If it is, push the link to the history stack.
                 if (target.matches('[data-token-link]')) {
                     event.preventDefault()
-                    const { history } = view.state.facet(facet)
                     history.push(target.getAttribute('href')!)
                 }
             },
         }),
-    ],
-})
+    ]
+}

--- a/client/web/src/repo/blob/definitions.ts
+++ b/client/web/src/repo/blob/definitions.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'rxjs'
+import { Observable, of } from 'rxjs'
 import { map } from 'rxjs/operators'
 
 import { memoizeObservable } from '@sourcegraph/common'
@@ -81,6 +81,10 @@ export interface DefinitionResponse {
 export const fetchDefinitionsFromRanges = memoizeObservable(
     (options: FetchDefinitionsFromRangesOptions): Observable<DefinitionResponse[] | null> => {
         const { repoName, revision, filePath, ranges } = options
+
+        if (ranges.length < 1) {
+            return of(null)
+        }
 
         const result = requestGraphQL<FetchDefinitionsResult, FetchDefinitionsVariables>(
             `

--- a/client/web/src/repo/blob/definitions.ts
+++ b/client/web/src/repo/blob/definitions.ts
@@ -1,0 +1,150 @@
+import { Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
+
+import { memoizeObservable } from '@sourcegraph/common'
+import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
+import { makeRepoURI, UIRange } from '@sourcegraph/shared/src/util/url'
+
+import { requestGraphQL } from '../../backend/graphql'
+import { DefinitionFields } from '../../graphql-operations'
+
+const buildRangeKey = (range: UIRange): string => {
+    const { start, end } = range
+    return `L${start.line}C${start.character}L${end.line}C${end.character}`
+}
+
+export const DefinitionFieldsFragment = gql`
+    fragment DefinitionFields on Location {
+        resource {
+            path
+            repository {
+                name
+            }
+            commit {
+                oid
+            }
+        }
+        range {
+            start {
+                line
+                character
+            }
+            end {
+                line
+                character
+            }
+        }
+    }
+`
+
+interface FetchDefinitionsResult {
+    repository: {
+        commit: {
+            blob: {
+                lsif: {
+                    [key: string]: {
+                        nodes: DefinitionFields[]
+                    }
+                }
+            }
+        }
+    }
+}
+
+interface FetchDefinitionsVariables {
+    repoName: string
+    revision: string
+    filePath: string
+}
+
+interface FetchDefinitionsFromRangesOptions {
+    repoName: string
+    revision: string
+    filePath: string
+    ranges: UIRange[]
+}
+
+export interface DefinitionResponse {
+    range: UIRange
+    definition: DefinitionFields | null
+}
+
+/**
+ * Fetches definitions for the given ranges.
+ *
+ * Note: This currently works by batching multiple definition queries into a single request through GQL query aliases.
+ * It should only be used for ranges that are known to contain definition information ahead of time (e.g. through a `stencil` API call).
+ *
+ * TODO: Introduce a new backend API that can fetch definitions for multiple ranges in a single request.
+ * GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/43179
+ */
+export const fetchDefinitionsFromRanges = memoizeObservable(
+    (options: FetchDefinitionsFromRangesOptions): Observable<DefinitionResponse[] | null> => {
+        const { repoName, revision, filePath, ranges } = options
+
+        const result = requestGraphQL<FetchDefinitionsResult, FetchDefinitionsVariables>(
+            `
+        query Definitions(
+            $repoName: String!
+            $revision: String!
+            $filePath: String!
+        ) {
+            repository(name: $repoName) {
+                commit(rev: $revision) {
+                    blob(path: $filePath) {
+                        lsif {
+                            ${ranges.map(
+                                range => `
+                                ${buildRangeKey(range)}: definitions(line: ${range.start.line}, character: ${
+                                    range.start.character
+                                }) {
+                                    nodes {
+                                        ...DefinitionFields
+                                    }
+                                }`
+                            )}
+                        }
+                    }
+                }
+            }
+        }
+
+        ${DefinitionFieldsFragment}
+    `,
+            {
+                repoName,
+                revision,
+                filePath,
+            }
+        ).pipe(
+            map(dataOrThrowErrors),
+            map(data => {
+                if (!data.repository?.commit) {
+                    throw new Error('Commit not found')
+                }
+
+                const lsif = data.repository.commit.blob?.lsif
+
+                if (!lsif) {
+                    return null
+                }
+
+                const definitions = ranges.map(range => {
+                    const key = buildRangeKey(range)
+                    return {
+                        range: { start: range.start, end: range.end },
+                        definition: lsif[key]?.nodes[0] ?? null,
+                    }
+                })
+
+                return definitions
+            })
+        )
+
+        return result
+    },
+    options => {
+        const { repoName, revision, filePath, ranges } = options
+        return `${makeRepoURI({ repoName, revision, filePath })}?${ranges.map(buildRangeKey).join(',')}`
+    }
+)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1908,6 +1908,8 @@ type SettingsExperimentalFeatures struct {
 	HomepageUserInvitation *bool `json:"homepageUserInvitation,omitempty"`
 	// InsightsAlternateLoadingStrategy description: Use an in-memory strategy of loading Code Insights. Should only be used for benchmarking on large instances, not for customer use currently.
 	InsightsAlternateLoadingStrategy bool `json:"insightsAlternateLoadingStrategy,omitempty"`
+	// PreloadGoToDefinition description: Preload definitions for available tokens in the visible viewport.
+	PreloadGoToDefinition bool `json:"preloadGoToDefinition,omitempty"`
 	// ProactiveSearchResultsAggregations description: Search results aggregations are triggered automatically with a search.
 	ProactiveSearchResultsAggregations *bool `json:"proactiveSearchResultsAggregations,omitempty"`
 	// SearchContextsQuery description: DEPRECATED: This feature is now permanently enabled. Enables query based search contexts

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -444,6 +444,11 @@
           "description": "Use an in-memory strategy of loading Code Insights. Should only be used for benchmarking on large instances, not for customer use currently.",
           "type": "boolean",
           "default": false
+        },
+        "preloadGoToDefinition": {
+          "description": "Preload definitions for available tokens in the visible viewport.",
+          "type": "boolean",
+          "default": false
         }
       },
       "group": "Experimental"


### PR DESCRIPTION
https://user-images.githubusercontent.com/9516420/195355312-355d038c-8d75-4aff-a347-dda1ffab9bc8.mp4

## Description

This is a follow up to https://github.com/sourcegraph/sourcegraph/pull/42936 that now enables keyboard controls for directly navigation to a definition.

**Prefetching definitions**

This is quite a shift from our current setup, right now we only fetch definition/references/hover information when a possible token is _hovered_. This PR changes that so, when we have `stencil` ranges, we prefetch all definition information within the current viewport. We don't have a backend API that supports that yet (created https://github.com/sourcegraph/sourcegraph/issues/43179 to address this), but this PR batches the definitions into a single GQL query so we don't suffer too much on client perf. I've gated this behind an experimental feature, although I wouldn't object to removing this if there's no backend concerns.

## Test plan

Tested locally

`sg start web-standalone`

Navigate to a file with precise code intel like: https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/backend/external_services.go?L31
