### PR TITLE
gitserver: remove `mocks.MergeBase` and `mocks.ReadFile`

### DIFF
--- a/cmd/searcher/internal/search/filter.go
+++ b/cmd/searcher/internal/search/filter.go
@@ -12,15 +12,14 @@ import (
 	"github.com/sourcegraph/zoekt/ignore"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 // NewFilter calls gitserver to retrieve the ignore-file. If the file doesn't
 // exist we return an empty ignore.Matcher.
-func NewFilter(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID) (FilterFunc, error) {
-	ignoreFile, err := gitserver.NewClient(db).ReadFile(ctx, repo, commit, ignore.IgnoreFile, nil)
+func NewFilter(ctx context.Context, client gitserver.Client, repo api.RepoName, commit api.CommitID) (FilterFunc, error) {
+	ignoreFile, err := client.ReadFile(ctx, repo, commit, ignore.IgnoreFile, nil)
 	if err != nil {
 		// We do not ignore anything if the ignore file does not exist.
 		if strings.Contains(err.Error(), "file does not exist") {

--- a/cmd/searcher/internal/search/search_test.go
+++ b/cmd/searcher/internal/search/search_test.go
@@ -17,11 +17,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log/logtest"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/internal/search"
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
@@ -285,7 +285,7 @@ abc.txt
 	}
 
 	s := newStore(t, files)
-	s.FilterTar = func(_ context.Context, _ database.DB, _ api.RepoName, _ api.CommitID) (search.FilterFunc, error) {
+	s.FilterTar = func(_ context.Context, _ gitserver.Client, _ api.RepoName, _ api.CommitID) (search.FilterFunc, error) {
 		return func(hdr *tar.Header) bool {
 			return hdr.Name == "ignore.me"
 		}, nil

--- a/cmd/searcher/internal/search/store.go
+++ b/cmd/searcher/internal/search/store.go
@@ -67,7 +67,7 @@ type Store struct {
 	FetchTarPaths func(ctx context.Context, repo api.RepoName, commit api.CommitID, paths []string) (io.ReadCloser, error)
 
 	// FilterTar returns a FilterFunc that filters out files we don't want to write to disk
-	FilterTar func(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID) (FilterFunc, error)
+	FilterTar func(ctx context.Context, client gitserver.Client, repo api.RepoName, commit api.CommitID) (FilterFunc, error)
 
 	// Path is the directory to store the cache
 	Path string
@@ -274,7 +274,7 @@ func (s *Store) fetch(ctx context.Context, repo api.RepoName, commit api.CommitI
 
 	filter.CommitIgnore = func(hdr *tar.Header) bool { return false } // default: don't filter
 	if s.FilterTar != nil {
-		filter.CommitIgnore, err = s.FilterTar(ctx, s.DB, repo, commit)
+		filter.CommitIgnore, err = s.FilterTar(ctx, gitserver.NewClient(s.DB), repo, commit)
 		if err != nil {
 			return nil, errors.Errorf("error while calling FilterTar: %w", err)
 		}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/service"
@@ -25,7 +26,8 @@ import (
 var _ graphqlbackend.BatchChangeResolver = &batchChangeResolver{}
 
 type batchChangeResolver struct {
-	store *store.Store
+	store           *store.Store
+	gitserverClient gitserver.Client
 
 	batchChange *btypes.BatchChange
 
@@ -198,9 +200,10 @@ func (r *batchChangeResolver) Changesets(
 	}
 	opts.BatchChangeID = r.batchChange.ID
 	return &changesetsConnectionResolver{
-		store:    r.store,
-		opts:     opts,
-		optsSafe: safe,
+		store:           r.store,
+		gitserverClient: r.gitserverClient,
+		opts:            opts,
+		optsSafe:        safe,
 	}, nil
 }
 
@@ -308,9 +311,10 @@ func (r *batchChangeResolver) BulkOperations(
 	}
 
 	return &bulkOperationConnectionResolver{
-		store:         r.store,
-		batchChangeID: r.batchChange.ID,
-		opts:          opts,
+		store:           r.store,
+		gitserverClient: r.gitserverClient,
+		batchChangeID:   r.batchChange.ID,
+		opts:            opts,
 	}, nil
 }
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_connection.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_connection.go
@@ -9,13 +9,15 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 )
 
 var _ graphqlbackend.BatchChangesConnectionResolver = &batchChangesConnectionResolver{}
 
 type batchChangesConnectionResolver struct {
-	store *store.Store
-	opts  store.ListBatchChangesOpts
+	store           *store.Store
+	opts            store.ListBatchChangesOpts
+	gitserverClient gitserver.Client
 
 	// cache results because they are used by multiple fields
 	once         sync.Once
@@ -31,7 +33,7 @@ func (r *batchChangesConnectionResolver) Nodes(ctx context.Context) ([]graphqlba
 	}
 	resolvers := make([]graphqlbackend.BatchChangeResolver, 0, len(nodes))
 	for _, c := range nodes {
-		resolvers = append(resolvers, &batchChangeResolver{store: r.store, batchChange: c})
+		resolvers = append(resolvers, &batchChangeResolver{store: r.store, gitserverClient: r.gitserverClient, batchChange: c})
 	}
 	return resolvers, nil
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 	"github.com/sourcegraph/sourcegraph/lib/batches/execution"
@@ -145,10 +146,10 @@ func (r *batchSpecWorkspaceStepResolver) DiffStat(ctx context.Context) (*graphql
 
 func (r *batchSpecWorkspaceStepResolver) Diff(ctx context.Context) (graphqlbackend.PreviewRepositoryComparisonResolver, error) {
 	if r.CachedResultFound() {
-		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), r.repo, r.baseRev, r.cachedResult.Diff)
+		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(r.store.DatabaseDB()), r.repo, r.baseRev, r.cachedResult.Diff)
 	}
 	if r.stepInfo.Diff != nil {
-		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), r.repo, r.baseRev, *r.stepInfo.Diff)
+		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(r.store.DatabaseDB()), r.repo, r.baseRev, *r.stepInfo.Diff)
 	}
 	return nil, nil
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/bulk_operation_connection.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/bulk_operation_connection.go
@@ -9,12 +9,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 )
 
 type bulkOperationConnectionResolver struct {
-	store         *store.Store
-	batchChangeID int64
-	opts          store.ListBulkOperationsOpts
+	store           *store.Store
+	batchChangeID   int64
+	opts            store.ListBulkOperationsOpts
+	gitserverClient gitserver.Client
 
 	// Cache results because they are used by multiple fields
 	once           sync.Once
@@ -57,7 +59,7 @@ func (r *bulkOperationConnectionResolver) Nodes(ctx context.Context) ([]graphqlb
 
 	resolvers := make([]graphqlbackend.BulkOperationResolver, 0, len(bulkOperations))
 	for _, b := range bulkOperations {
-		resolvers = append(resolvers, &bulkOperationResolver{store: r.store, bulkOperation: b})
+		resolvers = append(resolvers, &bulkOperationResolver{store: r.store, gitserverClient: r.gitserverClient, bulkOperation: b})
 	}
 
 	return resolvers, nil

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_connection_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/log/logtest"
@@ -199,7 +200,7 @@ func TestRewirerMappings(t *testing.T) {
 			publishA = &btypes.RewirerMapping{ChangesetSpecID: 4}
 			publishB = &btypes.RewirerMapping{ChangesetSpecID: 5}
 		)
-		rmf := newRewirerMappingsFacade(nil, 0, nil)
+		rmf := newRewirerMappingsFacade(nil, gitserver.NewMockClient(), 0, nil)
 		rmf.All = btypes.RewirerMappings{detach, hidden, noAction, publishA, publishB}
 		addResolverFixture(rmf, detach, &mockChangesetApplyPreviewResolver{
 			visible: &mockVisibleChangesetApplyPreviewResolver{
@@ -401,7 +402,7 @@ func TestRewirerMappings(t *testing.T) {
 		}
 
 		s := &store.Store{}
-		rmf := newRewirerMappingsFacade(s, 1, nil)
+		rmf := newRewirerMappingsFacade(s, gitserver.NewMockClient(), 1, nil)
 		rmf.batchChange = &btypes.BatchChange{}
 
 		mapping := &btypes.RewirerMapping{}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_connection.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_connection.go
@@ -11,10 +11,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/syncer"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 )
 
 type changesetsConnectionResolver struct {
-	store *store.Store
+	store           *store.Store
+	gitserverClient gitserver.Client
 
 	opts store.ListChangesetsOpts
 	// 🚨 SECURITY: If the given opts do not reveal hidden information about a
@@ -55,7 +57,7 @@ func (r *changesetsConnectionResolver) Nodes(ctx context.Context) ([]graphqlback
 
 	resolvers := make([]graphqlbackend.ChangesetResolver, 0, len(changesetsPage))
 	for _, c := range changesetsPage {
-		resolvers = append(resolvers, NewChangesetResolverWithNextSync(r.store, c, reposByID[c.RepoID], scheduledSyncs[c.ID]))
+		resolvers = append(resolvers, NewChangesetResolverWithNextSync(r.store, r.gitserverClient, c, reposByID[c.RepoID], scheduledSyncs[c.ID]))
 	}
 
 	return resolvers, nil

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_job_error.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_job_error.go
@@ -4,20 +4,22 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 type changesetJobErrorResolver struct {
-	store     *store.Store
-	changeset *btypes.Changeset
-	repo      *types.Repo
-	error     string
+	store           *store.Store
+	changeset       *btypes.Changeset
+	repo            *types.Repo
+	error           string
+	gitserverClient gitserver.Client
 }
 
 var _ graphqlbackend.ChangesetJobErrorResolver = &changesetJobErrorResolver{}
 
 func (r *changesetJobErrorResolver) Changeset() graphqlbackend.ChangesetResolver {
-	return NewChangesetResolver(r.store, r.changeset, r.repo)
+	return NewChangesetResolver(r.store, r.gitserverClient, r.changeset, r.repo)
 }
 
 func (r *changesetJobErrorResolver) Error() *string {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
@@ -178,7 +178,7 @@ func (r *changesetDescriptionResolver) DiffStat() *graphqlbackend.DiffStat {
 }
 
 func (r *changesetDescriptionResolver) Diff(ctx context.Context) (graphqlbackend.PreviewRepositoryComparisonResolver, error) {
-	return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), r.repoResolver, r.spec.BaseRev, string(r.spec.Diff))
+	return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(r.store.DatabaseDB()), r.repoResolver, r.spec.BaseRev, string(r.spec.Diff))
 }
 
 func (r *changesetDescriptionResolver) Commits() []graphqlbackend.GitCommitDescriptionResolver {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/graph-gophers/graphql-go"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/log/logtest"
@@ -1380,6 +1381,7 @@ func TestRepositoryPermissions(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 
 	bstore := store.New(db, &observation.TestContext, nil)
+	gitserverClient := gitserver.NewMockClient()
 	sr := &Resolver{store: bstore}
 	s, err := newSchema(db, sr)
 	if err != nil {
@@ -1412,7 +1414,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		// Create 2 changesets for 2 repositories
 		changesetBaseRefOid := "f00b4r"
 		changesetHeadRefOid := "b4rf00"
-		mockRepoComparison(t, changesetBaseRefOid, changesetHeadRefOid, testDiff)
+		mockRepoComparison(t, *gitserverClient, changesetBaseRefOid, changesetHeadRefOid, testDiff)
 		changesetDiffStat := apitest.DiffStat{Added: 2, Deleted: 2}
 
 		changesets := make([]*btypes.Changeset, 0, len(repos))

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -1181,9 +1181,6 @@ func (c *clientImplementor) GetDefaultBranch(ctx context.Context, repo api.RepoN
 
 // MergeBase returns the merge base commit for the specified commits.
 func (c *clientImplementor) MergeBase(ctx context.Context, repo api.RepoName, a, b api.CommitID) (api.CommitID, error) {
-	if Mocks.MergeBase != nil {
-		return Mocks.MergeBase(repo, a, b)
-	}
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: MergeBase")
 	span.SetTag("A", a)
 	span.SetTag("B", b)
@@ -1250,10 +1247,6 @@ func (c *clientImplementor) GetBehindAhead(ctx context.Context, repo api.RepoNam
 // ReadFile returns the first maxBytes of the named file at commit. If maxBytes <= 0, the entire
 // file is read. (If you just need to check a file's existence, use Stat, not ReadFile.)
 func (c *clientImplementor) ReadFile(ctx context.Context, repo api.RepoName, commit api.CommitID, name string, checker authz.SubRepoPermissionChecker) ([]byte, error) {
-	if Mocks.ReadFile != nil {
-		return Mocks.ReadFile(commit, name)
-	}
-
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: ReadFile")
 	span.SetTag("Name", name)
 	defer span.Finish()

--- a/internal/gitserver/mocks.go
+++ b/internal/gitserver/mocks.go
@@ -18,8 +18,6 @@ import (
 var Mocks, emptyMocks struct {
 	ExecReader      func(args []string) (reader io.ReadCloser, err error)
 	ResolveRevision func(spec string, opt ResolveRevisionOptions) (api.CommitID, error)
-	MergeBase       func(repo api.RepoName, a, b api.CommitID) (api.CommitID, error)
-	ReadFile        func(commit api.CommitID, name string) ([]byte, error)
 }
 
 // ResetMocks clears the mock functions set on Mocks (so that subsequent tests don't inadvertently


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/42943 and https://github.com/sourcegraph/sourcegraph/issues/42944

## Test plan
Existing tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
