### PR TITLE
Introduce internal/gqlutil package

### DIFF
--- a/cmd/frontend/graphqlbackend/access_token.go
+++ b/cmd/frontend/graphqlbackend/access_token.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 // accessTokenResolver resolves an access token.
@@ -61,8 +62,10 @@ func (r *accessTokenResolver) Creator(ctx context.Context) (*UserResolver, error
 	return UserByIDInt32(ctx, r.db, r.accessToken.CreatorUserID)
 }
 
-func (r *accessTokenResolver) CreatedAt() DateTime { return DateTime{Time: r.accessToken.CreatedAt} }
+func (r *accessTokenResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.accessToken.CreatedAt}
+}
 
-func (r *accessTokenResolver) LastUsedAt() *DateTime {
-	return DateTimeOrNil(r.accessToken.LastUsedAt)
+func (r *accessTokenResolver) LastUsedAt() *gqlutil.DateTime {
+	return gqlutil.DateTimeOrNil(r.accessToken.LastUsedAt)
 }

--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -92,10 +93,10 @@ type BitbucketProjectsPermissionJobResolver interface {
 	InternalJobID() int32
 	State() string
 	FailureMessage() *string
-	QueuedAt() DateTime
-	StartedAt() *DateTime
-	FinishedAt() *DateTime
-	ProcessAfter() *DateTime
+	QueuedAt() gqlutil.DateTime
+	StartedAt() *gqlutil.DateTime
+	FinishedAt() *gqlutil.DateTime
+	ProcessAfter() *gqlutil.DateTime
 	NumResets() int32
 	NumFailures() int32
 	ProjectKey() string
@@ -111,7 +112,7 @@ type UserPermissionResolver interface {
 
 type PermissionsInfoResolver interface {
 	Permissions() []string
-	SyncedAt() *DateTime
-	UpdatedAt() DateTime
+	SyncedAt() *gqlutil.DateTime
+	UpdatedAt() gqlutil.DateTime
 	Unrestricted() bool
 }

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/externallink"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	gql "github.com/sourcegraph/sourcegraph/internal/services/executors/transport/graphql"
 )
 
@@ -203,7 +204,7 @@ type DetachChangesetsArgs struct {
 type ListBatchChangeBulkOperationArgs struct {
 	First        int32
 	After        *string
-	CreatedAfter *DateTime
+	CreatedAfter *gqlutil.DateTime
 }
 
 type CreateChangesetCommentsArgs struct {
@@ -316,8 +317,8 @@ type BulkOperationResolver interface {
 	Errors(ctx context.Context) ([]ChangesetJobErrorResolver, error)
 	Initiator(ctx context.Context) (*UserResolver, error)
 	ChangesetCount() int32
-	CreatedAt() DateTime
-	FinishedAt() *DateTime
+	CreatedAt() gqlutil.DateTime
+	FinishedAt() *gqlutil.DateTime
 }
 
 type ChangesetJobErrorResolver interface {
@@ -336,10 +337,10 @@ type BatchSpecResolver interface {
 	Description() BatchChangeDescriptionResolver
 
 	Creator(context.Context) (*UserResolver, error)
-	CreatedAt() DateTime
+	CreatedAt() gqlutil.DateTime
 	Namespace(context.Context) (*NamespaceResolver, error)
 
-	ExpiresAt() *DateTime
+	ExpiresAt() *gqlutil.DateTime
 
 	ApplyURL(ctx context.Context) (*string, error)
 
@@ -355,8 +356,8 @@ type BatchSpecResolver interface {
 
 	AutoApplyEnabled() bool
 	State(context.Context) (string, error)
-	StartedAt(ctx context.Context) (*DateTime, error)
-	FinishedAt(ctx context.Context) (*DateTime, error)
+	StartedAt(ctx context.Context) (*gqlutil.DateTime, error)
+	FinishedAt(ctx context.Context) (*gqlutil.DateTime, error)
 	FailureMessage(ctx context.Context) (*string, error)
 	WorkspaceResolution(ctx context.Context) (BatchSpecWorkspaceResolutionResolver, error)
 	ImportingChangesets(ctx context.Context, args *ListImportingChangesetsArgs) (ChangesetSpecConnectionResolver, error)
@@ -466,7 +467,7 @@ type ChangesetSpecResolver interface {
 	ID() graphql.ID
 	// Type returns a value of type btypes.ChangesetSpecDescriptionType.
 	Type() string
-	ExpiresAt() *DateTime
+	ExpiresAt() *gqlutil.DateTime
 
 	ToHiddenChangesetSpec() (HiddenChangesetSpecResolver, bool)
 	ToVisibleChangesetSpec() (VisibleChangesetSpecResolver, bool)
@@ -557,13 +558,13 @@ type BatchChangesCredentialResolver interface {
 	ExternalServiceKind() string
 	ExternalServiceURL() string
 	SSHPublicKey(ctx context.Context) (*string, error)
-	CreatedAt() DateTime
+	CreatedAt() gqlutil.DateTime
 	IsSiteCredential() bool
 }
 
 type ChangesetCountsArgs struct {
-	From            *DateTime
-	To              *DateTime
+	From            *gqlutil.DateTime
+	To              *gqlutil.DateTime
 	IncludeArchived bool
 }
 
@@ -641,16 +642,16 @@ type BatchChangeResolver interface {
 	State() string
 	Creator(ctx context.Context) (*UserResolver, error)
 	LastApplier(ctx context.Context) (*UserResolver, error)
-	LastAppliedAt() *DateTime
+	LastAppliedAt() *gqlutil.DateTime
 	ViewerCanAdminister(ctx context.Context) (bool, error)
 	URL(ctx context.Context) (string, error)
 	Namespace(ctx context.Context) (n NamespaceResolver, err error)
-	CreatedAt() DateTime
-	UpdatedAt() DateTime
+	CreatedAt() gqlutil.DateTime
+	UpdatedAt() gqlutil.DateTime
 	ChangesetsStats(ctx context.Context) (ChangesetsStatsResolver, error)
 	Changesets(ctx context.Context, args *ListChangesetsArgs) (ChangesetsConnectionResolver, error)
 	ChangesetCountsOverTime(ctx context.Context, args *ChangesetCountsArgs) ([]ChangesetCountsResolver, error)
-	ClosedAt() *DateTime
+	ClosedAt() *gqlutil.DateTime
 	DiffStat(ctx context.Context) (*DiffStat, error)
 	CurrentSpec(ctx context.Context) (BatchSpecResolver, error)
 	BulkOperations(ctx context.Context, args *ListBatchChangeBulkOperationArgs) (BulkOperationConnectionResolver, error)
@@ -677,9 +678,9 @@ type BatchSpecWorkspaceFileConnectionResolver interface {
 
 type BatchWorkspaceFileResolver interface {
 	ID() graphql.ID
-	ModifiedAt() DateTime
-	CreatedAt() DateTime
-	UpdatedAt() DateTime
+	ModifiedAt() gqlutil.DateTime
+	CreatedAt() gqlutil.DateTime
+	UpdatedAt() gqlutil.DateTime
 
 	Path() string
 	Name() string
@@ -742,9 +743,9 @@ type ChangesetLabelResolver interface {
 type ChangesetResolver interface {
 	ID() graphql.ID
 
-	CreatedAt() DateTime
-	UpdatedAt() DateTime
-	NextSyncAt(ctx context.Context) (*DateTime, error)
+	CreatedAt() gqlutil.DateTime
+	UpdatedAt() gqlutil.DateTime
+	NextSyncAt(ctx context.Context) (*gqlutil.DateTime, error)
 	// State returns a value of type *btypes.ChangesetState.
 	State() string
 	BatchChanges(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error)
@@ -787,7 +788,7 @@ type ExternalChangesetResolver interface {
 
 	Error() *string
 	SyncerError() *string
-	ScheduleEstimateAt(ctx context.Context) (*DateTime, error)
+	ScheduleEstimateAt(ctx context.Context) (*gqlutil.DateTime, error)
 
 	CurrentSpec(ctx context.Context) (VisibleChangesetSpecResolver, error)
 }
@@ -801,11 +802,11 @@ type ChangesetEventsConnectionResolver interface {
 type ChangesetEventResolver interface {
 	ID() graphql.ID
 	Changeset() ExternalChangesetResolver
-	CreatedAt() DateTime
+	CreatedAt() gqlutil.DateTime
 }
 
 type ChangesetCountsResolver interface {
-	Date() DateTime
+	Date() gqlutil.DateTime
 	Total() int32
 	Merged() int32
 	Closed() int32
@@ -818,8 +819,8 @@ type ChangesetCountsResolver interface {
 
 type BatchSpecWorkspaceResolutionResolver interface {
 	State() string
-	StartedAt() *DateTime
-	FinishedAt() *DateTime
+	StartedAt() *gqlutil.DateTime
+	FinishedAt() *gqlutil.DateTime
 	FailureMessage() *string
 
 	Workspaces(ctx context.Context, args *ListWorkspacesArgs) (BatchSpecWorkspaceConnectionResolver, error)
@@ -847,9 +848,9 @@ type BatchSpecWorkspaceResolver interface {
 	ID() graphql.ID
 
 	State() string
-	QueuedAt() *DateTime
-	StartedAt() *DateTime
-	FinishedAt() *DateTime
+	QueuedAt() *gqlutil.DateTime
+	StartedAt() *gqlutil.DateTime
+	FinishedAt() *gqlutil.DateTime
 	CachedResultFound() bool
 	StepCacheResultCount() int32
 	BatchSpec(ctx context.Context) (BatchSpecResolver, error)
@@ -908,8 +909,8 @@ type BatchSpecWorkspaceStepResolver interface {
 	Skipped() bool
 	OutputLines(ctx context.Context, args *BatchSpecWorkspaceStepOutputLinesArgs) (*[]string, error)
 
-	StartedAt() *DateTime
-	FinishedAt() *DateTime
+	StartedAt() *gqlutil.DateTime
+	FinishedAt() *gqlutil.DateTime
 
 	ExitCode() *int32
 	Environment() ([]BatchSpecWorkspaceEnvironmentVariableResolver, error)

--- a/cmd/frontend/graphqlbackend/code_monitors.go
+++ b/cmd/frontend/graphqlbackend/code_monitors.go
@@ -6,6 +6,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 type CodeMonitorsResolver interface {
@@ -35,7 +36,7 @@ type MonitorConnectionResolver interface {
 type MonitorResolver interface {
 	ID() graphql.ID
 	CreatedBy(ctx context.Context) (*UserResolver, error)
-	CreatedAt() DateTime
+	CreatedAt() gqlutil.DateTime
 	Description() string
 	Owner(ctx context.Context) (NamespaceResolver, error)
 	Enabled() bool
@@ -63,7 +64,7 @@ type MonitorTriggerEventResolver interface {
 	ID() graphql.ID
 	Status() (string, error)
 	Message() *string
-	Timestamp() (DateTime, error)
+	Timestamp() (gqlutil.DateTime, error)
 	Actions(ctx context.Context, args *ListActionArgs) (MonitorActionConnectionResolver, error)
 	ResultCount() int32
 	Query() *string
@@ -128,7 +129,7 @@ type MonitorActionEventResolver interface {
 	ID() graphql.ID
 	Status() (string, error)
 	Message() *string
-	Timestamp() DateTime
+	Timestamp() gqlutil.DateTime
 }
 
 type ListEventsArgs struct {

--- a/cmd/frontend/graphqlbackend/dotcom.go
+++ b/cmd/frontend/graphqlbackend/dotcom.go
@@ -6,6 +6,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 type DotcomRootResolver interface {
@@ -37,7 +38,7 @@ type ProductSubscription interface {
 	Account(context.Context) (*UserResolver, error)
 	ActiveLicense(context.Context) (ProductLicense, error)
 	ProductLicenses(context.Context, *graphqlutil.ConnectionArgs) (ProductLicenseConnection, error)
-	CreatedAt() DateTime
+	CreatedAt() gqlutil.DateTime
 	IsArchived() bool
 	URL(context.Context) (string, error)
 	URLForSiteAdmin(context.Context) *string
@@ -78,7 +79,7 @@ type ProductLicense interface {
 	Subscription(context.Context) (ProductSubscription, error)
 	Info() (*ProductLicenseInfo, error)
 	LicenseKey() string
-	CreatedAt() DateTime
+	CreatedAt() gqlutil.DateTime
 }
 
 // ProductLicenseInput implements the GraphQL type ProductLicenseInput.

--- a/cmd/frontend/graphqlbackend/event_log.go
+++ b/cmd/frontend/graphqlbackend/event_log.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 type userEventLogResolver struct {
@@ -51,6 +52,6 @@ func (s *userEventLogResolver) Version() string {
 	return s.event.Version
 }
 
-func (s *userEventLogResolver) Timestamp() DateTime {
-	return DateTime{Time: s.event.Timestamp}
+func (s *userEventLogResolver) Timestamp() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: s.event.Timestamp}
 }

--- a/cmd/frontend/graphqlbackend/execution_log_entry.go
+++ b/cmd/frontend/graphqlbackend/execution_log_entry.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
 type ExecutionLogEntryResolver interface {
 	Key() string
 	Command() []string
-	StartTime() DateTime
+	StartTime() gqlutil.DateTime
 	ExitCode() *int32
 	Out(ctx context.Context) (string, error)
 	DurationMilliseconds() *int32
@@ -42,8 +43,8 @@ func (r *executionLogEntryResolver) ExitCode() *int32 {
 	return &val
 }
 
-func (r *executionLogEntryResolver) StartTime() DateTime {
-	return DateTime{Time: r.entry.StartTime}
+func (r *executionLogEntryResolver) StartTime() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.entry.StartTime}
 }
 
 func (r *executionLogEntryResolver) DurationMilliseconds() *int32 {

--- a/cmd/frontend/graphqlbackend/extension_registry.go
+++ b/cmd/frontend/graphqlbackend/extension_registry.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -114,9 +115,9 @@ type RegistryExtension interface {
 	Publisher(ctx context.Context) (RegistryPublisher, error)
 	Name() string
 	Manifest(ctx context.Context) (ExtensionManifest, error)
-	CreatedAt() *DateTime
-	UpdatedAt() *DateTime
-	PublishedAt(context.Context) (*DateTime, error)
+	CreatedAt() *gqlutil.DateTime
+	UpdatedAt() *gqlutil.DateTime
+	PublishedAt(context.Context) (*gqlutil.DateTime, error)
 	URL() string
 	RemoteURL() *string
 	RegistryName() (string, error)

--- a/cmd/frontend/graphqlbackend/external_account.go
+++ b/cmd/frontend/graphqlbackend/external_account.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 type externalAccountResolver struct {
@@ -50,8 +51,12 @@ func (r *externalAccountResolver) ServiceType() string { return r.account.Servic
 func (r *externalAccountResolver) ServiceID() string   { return r.account.ServiceID }
 func (r *externalAccountResolver) ClientID() string    { return r.account.ClientID }
 func (r *externalAccountResolver) AccountID() string   { return r.account.AccountID }
-func (r *externalAccountResolver) CreatedAt() DateTime { return DateTime{Time: r.account.CreatedAt} }
-func (r *externalAccountResolver) UpdatedAt() DateTime { return DateTime{Time: r.account.UpdatedAt} }
+func (r *externalAccountResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.account.CreatedAt}
+}
+func (r *externalAccountResolver) UpdatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.account.UpdatedAt}
+}
 
 func (r *externalAccountResolver) RefreshURL() *string {
 	// TODO(sqs): Not supported.

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -89,12 +90,12 @@ func (r *externalServiceResolver) Config(ctx context.Context) (JSONCString, erro
 	return JSONCString(redacted), nil
 }
 
-func (r *externalServiceResolver) CreatedAt() DateTime {
-	return DateTime{Time: r.externalService.CreatedAt}
+func (r *externalServiceResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.externalService.CreatedAt}
 }
 
-func (r *externalServiceResolver) UpdatedAt() DateTime {
-	return DateTime{Time: r.externalService.UpdatedAt}
+func (r *externalServiceResolver) UpdatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.externalService.UpdatedAt}
 }
 
 func (r *externalServiceResolver) Namespace(ctx context.Context) (*NamespaceResolver, error) {
@@ -174,18 +175,18 @@ func (r *externalServiceResolver) RepoCount(ctx context.Context) (int32, error) 
 	return r.db.ExternalServices().RepoCount(ctx, r.externalService.ID)
 }
 
-func (r *externalServiceResolver) LastSyncAt() *DateTime {
+func (r *externalServiceResolver) LastSyncAt() *gqlutil.DateTime {
 	if r.externalService.LastSyncAt.IsZero() {
 		return nil
 	}
-	return &DateTime{Time: r.externalService.LastSyncAt}
+	return &gqlutil.DateTime{Time: r.externalService.LastSyncAt}
 }
 
-func (r *externalServiceResolver) NextSyncAt() *DateTime {
+func (r *externalServiceResolver) NextSyncAt() *gqlutil.DateTime {
 	if r.externalService.NextSyncAt.IsZero() {
 		return nil
 	}
-	return &DateTime{Time: r.externalService.NextSyncAt}
+	return &gqlutil.DateTime{Time: r.externalService.NextSyncAt}
 }
 
 var scopeCache = rcache.New("extsvc_token_scope")
@@ -338,22 +339,22 @@ func (r *externalServiceSyncJobResolver) FailureMessage() *string {
 	return &r.job.FailureMessage
 }
 
-func (r *externalServiceSyncJobResolver) QueuedAt() DateTime {
-	return DateTime{Time: r.job.QueuedAt}
+func (r *externalServiceSyncJobResolver) QueuedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.job.QueuedAt}
 }
 
-func (r *externalServiceSyncJobResolver) StartedAt() *DateTime {
+func (r *externalServiceSyncJobResolver) StartedAt() *gqlutil.DateTime {
 	if r.job.StartedAt.IsZero() {
 		return nil
 	}
 
-	return &DateTime{Time: r.job.StartedAt}
+	return &gqlutil.DateTime{Time: r.job.StartedAt}
 }
 
-func (r *externalServiceSyncJobResolver) FinishedAt() *DateTime {
+func (r *externalServiceSyncJobResolver) FinishedAt() *gqlutil.DateTime {
 	if r.job.FinishedAt.IsZero() {
 		return nil
 	}
 
-	return &DateTime{Time: r.job.FinishedAt}
+	return &gqlutil.DateTime{Time: r.job.FinishedAt}
 }

--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -6,6 +6,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 // This file just contains stub GraphQL resolvers and data types for Code Insights which merely
@@ -76,7 +77,7 @@ type InsightsArgs struct {
 }
 
 type InsightsDataPointResolver interface {
-	DateTime() DateTime
+	DateTime() gqlutil.DateTime
 	Value() float64
 }
 
@@ -85,12 +86,12 @@ type InsightStatusResolver interface {
 	PendingJobs() int32
 	CompletedJobs() int32
 	FailedJobs() int32
-	BackfillQueuedAt() *DateTime
+	BackfillQueuedAt() *gqlutil.DateTime
 }
 
 type InsightsPointsArgs struct {
-	From             *DateTime
-	To               *DateTime
+	From             *gqlutil.DateTime
+	To               *gqlutil.DateTime
 	IncludeRepoRegex *string
 	ExcludeRepoRegex *string
 }
@@ -118,7 +119,7 @@ type InsightConnectionResolver interface {
 
 type InsightDirtyQueryResolver interface {
 	Reason(ctx context.Context) string
-	Time(ctx context.Context) DateTime
+	Time(ctx context.Context) gqlutil.DateTime
 	Count(ctx context.Context) int32
 }
 

--- a/cmd/frontend/graphqlbackend/notebooks.go
+++ b/cmd/frontend/graphqlbackend/notebooks.go
@@ -6,6 +6,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 type NotebooksOrderBy string
@@ -37,7 +38,7 @@ type NotebookConnectionResolver interface {
 
 type NotebookStarResolver interface {
 	User(context.Context) (*UserResolver, error)
-	CreatedAt() DateTime
+	CreatedAt() gqlutil.DateTime
 }
 
 type NotebookStarConnectionResolver interface {
@@ -54,8 +55,8 @@ type NotebookResolver interface {
 	Updater(ctx context.Context) (*UserResolver, error)
 	Namespace(ctx context.Context) (*NamespaceResolver, error)
 	Public(ctx context.Context) bool
-	UpdatedAt(ctx context.Context) DateTime
-	CreatedAt(ctx context.Context) DateTime
+	UpdatedAt(ctx context.Context) gqlutil.DateTime
+	CreatedAt(ctx context.Context) gqlutil.DateTime
 	ViewerCanManage(ctx context.Context) (bool, error)
 	ViewerHasStarred(ctx context.Context) (bool, error)
 	Stars(ctx context.Context, args ListNotebookStarsArgs) (NotebookStarConnectionResolver, error)

--- a/cmd/frontend/graphqlbackend/oobmigrations.go
+++ b/cmd/frontend/graphqlbackend/oobmigrations.go
@@ -7,6 +7,7 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 
 	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
 
@@ -104,11 +105,13 @@ func (r *outOfBandMigrationResolver) Deprecated() *string {
 	return strptr(r.m.Deprecated.String())
 }
 
-func (r *outOfBandMigrationResolver) Progress() float64      { return r.m.Progress }
-func (r *outOfBandMigrationResolver) Created() DateTime      { return DateTime{r.m.Created} }
-func (r *outOfBandMigrationResolver) LastUpdated() *DateTime { return DateTimeOrNil(r.m.LastUpdated) }
-func (r *outOfBandMigrationResolver) NonDestructive() bool   { return r.m.NonDestructive }
-func (r *outOfBandMigrationResolver) ApplyReverse() bool     { return r.m.ApplyReverse }
+func (r *outOfBandMigrationResolver) Progress() float64         { return r.m.Progress }
+func (r *outOfBandMigrationResolver) Created() gqlutil.DateTime { return gqlutil.DateTime{r.m.Created} }
+func (r *outOfBandMigrationResolver) LastUpdated() *gqlutil.DateTime {
+	return gqlutil.DateTimeOrNil(r.m.LastUpdated)
+}
+func (r *outOfBandMigrationResolver) NonDestructive() bool { return r.m.NonDestructive }
+func (r *outOfBandMigrationResolver) ApplyReverse() bool   { return r.m.ApplyReverse }
 
 func (r *outOfBandMigrationResolver) Errors() []*outOfBandMigrationErrorResolver {
 	resolvers := make([]*outOfBandMigrationErrorResolver, 0, len(r.m.Errors))
@@ -124,5 +127,7 @@ type outOfBandMigrationErrorResolver struct {
 	e oobmigration.MigrationError
 }
 
-func (r *outOfBandMigrationErrorResolver) Message() string   { return r.e.Message }
-func (r *outOfBandMigrationErrorResolver) Created() DateTime { return DateTime{r.e.Created} }
+func (r *outOfBandMigrationErrorResolver) Message() string { return r.e.Message }
+func (r *outOfBandMigrationErrorResolver) Created() gqlutil.DateTime {
+	return gqlutil.DateTime{r.e.Created}
+}

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -137,7 +138,7 @@ func (o *OrgResolver) URL() string { return "/organizations/" + o.org.Name }
 
 func (o *OrgResolver) SettingsURL() *string { return strptr(o.URL() + "/settings") }
 
-func (o *OrgResolver) CreatedAt() DateTime { return DateTime{Time: o.org.CreatedAt} }
+func (o *OrgResolver) CreatedAt() gqlutil.DateTime { return gqlutil.DateTime{Time: o.org.CreatedAt} }
 
 func (o *OrgResolver) Members(ctx context.Context) (*staticUserConnectionResolver, error) {
 	// 🚨 SECURITY: Only org members can list other org members.

--- a/cmd/frontend/graphqlbackend/org_invitation.go
+++ b/cmd/frontend/graphqlbackend/org_invitation.go
@@ -7,6 +7,7 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 // organizationInvitationResolver implements the GraphQL type OrganizationInvitation.
@@ -66,13 +67,15 @@ func (r *organizationInvitationResolver) RecipientEmail() (*string, error) {
 	}
 	return &r.v.RecipientEmail, nil
 }
-func (r *organizationInvitationResolver) CreatedAt() DateTime { return DateTime{Time: r.v.CreatedAt} }
-func (r *organizationInvitationResolver) NotifiedAt() *DateTime {
-	return DateTimeOrNil(r.v.NotifiedAt)
+func (r *organizationInvitationResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.v.CreatedAt}
+}
+func (r *organizationInvitationResolver) NotifiedAt() *gqlutil.DateTime {
+	return gqlutil.DateTimeOrNil(r.v.NotifiedAt)
 }
 
-func (r *organizationInvitationResolver) RespondedAt() *DateTime {
-	return DateTimeOrNil(r.v.RespondedAt)
+func (r *organizationInvitationResolver) RespondedAt() *gqlutil.DateTime {
+	return gqlutil.DateTimeOrNil(r.v.RespondedAt)
 }
 
 func (r *organizationInvitationResolver) ResponseType() *string {
@@ -106,12 +109,12 @@ func (r *organizationInvitationResolver) RespondURL(ctx context.Context) (*strin
 	return nil, nil
 }
 
-func (r *organizationInvitationResolver) RevokedAt() *DateTime {
-	return DateTimeOrNil(r.v.RevokedAt)
+func (r *organizationInvitationResolver) RevokedAt() *gqlutil.DateTime {
+	return gqlutil.DateTimeOrNil(r.v.RevokedAt)
 }
 
-func (r *organizationInvitationResolver) ExpiresAt() *DateTime {
-	return DateTimeOrNil(r.v.ExpiresAt)
+func (r *organizationInvitationResolver) ExpiresAt() *gqlutil.DateTime {
+	return gqlutil.DateTimeOrNil(r.v.ExpiresAt)
 }
 
 func (r *organizationInvitationResolver) IsVerifiedEmail() *bool {

--- a/cmd/frontend/graphqlbackend/org_members.go
+++ b/cmd/frontend/graphqlbackend/org_members.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -113,12 +114,12 @@ func (r *organizationMembershipResolver) User(ctx context.Context) (*UserResolve
 	return UserByIDInt32(ctx, r.db, r.membership.UserID)
 }
 
-func (r *organizationMembershipResolver) CreatedAt() DateTime {
-	return DateTime{Time: r.membership.CreatedAt}
+func (r *organizationMembershipResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.membership.CreatedAt}
 }
 
-func (r *organizationMembershipResolver) UpdatedAt() DateTime {
-	return DateTime{Time: r.membership.UpdatedAt}
+func (r *organizationMembershipResolver) UpdatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.membership.UpdatedAt}
 }
 
 type OrgMemberAutocompleteSearchItemResolver struct {

--- a/cmd/frontend/graphqlbackend/product_license_info.go
+++ b/cmd/frontend/graphqlbackend/product_license_info.go
@@ -2,6 +2,8 @@ package graphqlbackend
 
 import (
 	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 // GetConfiguredProductLicenseInfo is called to obtain the product subscription info when creating
@@ -32,6 +34,6 @@ func (r ProductLicenseInfo) UserCount() int32 {
 	return int32(r.UserCountValue)
 }
 
-func (r ProductLicenseInfo) ExpiresAt() DateTime {
-	return DateTime{Time: r.ExpiresAtValue}
+func (r ProductLicenseInfo) ExpiresAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.ExpiresAtValue}
 }

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -266,11 +267,11 @@ func (r *RepositoryResolver) Enabled() bool { return true }
 // the marshalling of timestamps is significant in our postgres client. So we
 // deprecate the fields and return fake data for created_at.
 // https://github.com/sourcegraph/sourcegraph/pull/4668
-func (r *RepositoryResolver) CreatedAt() DateTime {
-	return DateTime{Time: time.Now()}
+func (r *RepositoryResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: time.Now()}
 }
 
-func (r *RepositoryResolver) UpdatedAt() *DateTime {
+func (r *RepositoryResolver) UpdatedAt() *gqlutil.DateTime {
 	return nil
 }
 

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	repoupdaterprotocol "github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
@@ -146,7 +147,7 @@ func (r *repositoryMirrorInfoResolver) LastError(ctx context.Context) (*string, 
 	return strptr(info.LastError), nil
 }
 
-func (r *repositoryMirrorInfoResolver) UpdatedAt(ctx context.Context) (*DateTime, error) {
+func (r *repositoryMirrorInfoResolver) UpdatedAt(ctx context.Context) (*gqlutil.DateTime, error) {
 	info, err := r.computeGitserverRepo(ctx)
 	if err != nil {
 		return nil, err
@@ -156,7 +157,7 @@ func (r *repositoryMirrorInfoResolver) UpdatedAt(ctx context.Context) (*DateTime
 		return nil, nil
 	}
 
-	return &DateTime{Time: info.LastFetched}, nil
+	return &gqlutil.DateTime{Time: info.LastFetched}, nil
 }
 
 func (r *repositoryMirrorInfoResolver) ByteSize(ctx context.Context) (BigInt, error) {
@@ -202,8 +203,8 @@ func (r *updateScheduleResolver) IntervalSeconds() int32 {
 	return int32(r.schedule.IntervalSeconds)
 }
 
-func (r *updateScheduleResolver) Due() DateTime {
-	return DateTime{Time: r.schedule.Due}
+func (r *updateScheduleResolver) Due() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.schedule.Due}
 }
 
 func (r *updateScheduleResolver) Index() int32 {

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 )
 
@@ -75,8 +76,8 @@ type repositoryTextSearchIndexStatus struct {
 	entry zoekt.RepoListEntry
 }
 
-func (r *repositoryTextSearchIndexStatus) UpdatedAt() DateTime {
-	return DateTime{Time: r.entry.IndexMetadata.IndexTime}
+func (r *repositoryTextSearchIndexStatus) UpdatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.entry.IndexMetadata.IndexTime}
 }
 
 func (r *repositoryTextSearchIndexStatus) ContentByteSize() BigInt {

--- a/cmd/frontend/graphqlbackend/search_contexts.go
+++ b/cmd/frontend/graphqlbackend/search_contexts.go
@@ -6,6 +6,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -39,7 +40,7 @@ type SearchContextResolver interface {
 	Public() bool
 	AutoDefined() bool
 	Spec() string
-	UpdatedAt() DateTime
+	UpdatedAt() gqlutil.DateTime
 	Namespace(ctx context.Context) (*NamespaceResolver, error)
 	ViewerCanManage(ctx context.Context) bool
 	Repositories(ctx context.Context) ([]SearchContextRepositoryRevisionsResolver, error)

--- a/cmd/frontend/graphqlbackend/settings.go
+++ b/cmd/frontend/graphqlbackend/settings.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -36,8 +37,8 @@ func (o *settingsResolver) Contents() JSONCString {
 	return JSONCString(o.settings.Contents)
 }
 
-func (o *settingsResolver) CreatedAt() DateTime {
-	return DateTime{Time: o.settings.CreatedAt}
+func (o *settingsResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: o.settings.CreatedAt}
 }
 
 func (o *settingsResolver) Author(ctx context.Context) (*UserResolver, error) {

--- a/cmd/frontend/graphqlbackend/site_monitoring.go
+++ b/cmd/frontend/graphqlbackend/site_monitoring.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/opentracing/opentracing-go/ext"
 
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	srcprometheus "github.com/sourcegraph/sourcegraph/internal/src-prometheus"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
@@ -13,11 +14,11 @@ import (
 // MonitoringAlert implements GraphQL getters on top of srcprometheus.MonitoringAlert
 type MonitoringAlert srcprometheus.MonitoringAlert
 
-func (r *MonitoringAlert) Timestamp() DateTime { return DateTime{r.TimestampValue} }
-func (r *MonitoringAlert) Name() string        { return r.NameValue }
-func (r *MonitoringAlert) ServiceName() string { return r.ServiceNameValue }
-func (r *MonitoringAlert) Owner() string       { return r.OwnerValue }
-func (r *MonitoringAlert) Average() float64    { return r.AverageValue }
+func (r *MonitoringAlert) Timestamp() gqlutil.DateTime { return gqlutil.DateTime{r.TimestampValue} }
+func (r *MonitoringAlert) Name() string                { return r.NameValue }
+func (r *MonitoringAlert) ServiceName() string         { return r.ServiceNameValue }
+func (r *MonitoringAlert) Owner() string               { return r.OwnerValue }
+func (r *MonitoringAlert) Average() float64            { return r.AverageValue }
 
 func (r *siteResolver) MonitoringStatistics(ctx context.Context, args *struct {
 	Days *int32

--- a/cmd/frontend/graphqlbackend/site_update_check.go
+++ b/cmd/frontend/graphqlbackend/site_update_check.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/updatecheck"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 func (r *siteResolver) UpdateCheck(ctx context.Context) (*updateCheckResolver, error) {
@@ -33,11 +34,11 @@ type updateCheckResolver struct {
 
 func (r *updateCheckResolver) Pending() bool { return r.pending }
 
-func (r *updateCheckResolver) CheckedAt() *DateTime {
+func (r *updateCheckResolver) CheckedAt() *gqlutil.DateTime {
 	if r.last == nil {
 		return nil
 	}
-	return &DateTime{Time: r.last.Date}
+	return &gqlutil.DateTime{Time: r.last.Date}
 }
 
 func (r *updateCheckResolver) ErrorMessage() *string {

--- a/cmd/frontend/graphqlbackend/survey_response.go
+++ b/cmd/frontend/graphqlbackend/survey_response.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -60,8 +61,8 @@ func (s *surveyResponseResolver) OtherUseCase() *string {
 	return s.surveyResponse.OtherUseCase
 }
 
-func (s *surveyResponseResolver) CreatedAt() DateTime {
-	return DateTime{Time: s.surveyResponse.CreatedAt}
+func (s *surveyResponseResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: s.surveyResponse.CreatedAt}
 }
 
 // SurveySubmissionInput contains a satisfaction (NPS) survey response.

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -157,12 +158,12 @@ func (r *UserResolver) URL() string {
 
 func (r *UserResolver) SettingsURL() *string { return strptr(r.URL() + "/settings") }
 
-func (r *UserResolver) CreatedAt() DateTime {
-	return DateTime{Time: r.user.CreatedAt}
+func (r *UserResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.user.CreatedAt}
 }
 
-func (r *UserResolver) UpdatedAt() *DateTime {
-	return &DateTime{Time: r.user.UpdatedAt}
+func (r *UserResolver) UpdatedAt() *gqlutil.DateTime {
+	return &gqlutil.DateTime{Time: r.user.UpdatedAt}
 }
 
 func (r *UserResolver) settingsSubject() api.SettingsSubject {

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
-	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/transport/graphql"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/usagestats"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -20,7 +20,7 @@ type usersArgs struct {
 	Query         *string
 	Tag           *string
 	ActivePeriod  *string
-	InactiveSince *graphql.DateTime
+	InactiveSince *gqlutil.DateTime
 }
 
 func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {

--- a/cmd/frontend/graphqlbackend/webhook_logs.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -219,8 +220,8 @@ func (r *webhookLogResolver) ID() graphql.ID {
 	return marshalWebhookLogID(r.log.ID)
 }
 
-func (r *webhookLogResolver) ReceivedAt() DateTime {
-	return DateTime{Time: r.log.ReceivedAt}
+func (r *webhookLogResolver) ReceivedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.log.ReceivedAt}
 }
 
 func (r *webhookLogResolver) ExternalService(ctx context.Context) (*externalServiceResolver, error) {

--- a/cmd/frontend/graphqlbackend/webhooks.go
+++ b/cmd/frontend/graphqlbackend/webhooks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -56,12 +57,12 @@ func (r *webhookResolver) Secret(ctx context.Context) (*string, error) {
 	return &s, nil
 }
 
-func (r *webhookResolver) CreatedAt() DateTime {
-	return DateTime{Time: r.hook.CreatedAt}
+func (r *webhookResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.hook.CreatedAt}
 }
 
-func (r *webhookResolver) UpdatedAt() DateTime {
-	return DateTime{Time: r.hook.UpdatedAt}
+func (r *webhookResolver) UpdatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.hook.UpdatedAt}
 }
 
 func (r *schemaResolver) Webhooks(ctx context.Context, args *struct {

--- a/cmd/frontend/registry/api/extension_remote_graphql.go
+++ b/cmd/frontend/registry/api/extension_remote_graphql.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/ui/router"
 	registry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/client"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 // registryExtensionRemoteResolver implements the GraphQL type RegistryExtension with data from a
@@ -49,16 +50,16 @@ func (r *registryExtensionRemoteResolver) Manifest(context.Context) (graphqlback
 	return NewExtensionManifest(r.v.Manifest), nil
 }
 
-func (r *registryExtensionRemoteResolver) CreatedAt() *graphqlbackend.DateTime {
-	return &graphqlbackend.DateTime{Time: r.v.CreatedAt}
+func (r *registryExtensionRemoteResolver) CreatedAt() *gqlutil.DateTime {
+	return &gqlutil.DateTime{Time: r.v.CreatedAt}
 }
 
-func (r *registryExtensionRemoteResolver) UpdatedAt() *graphqlbackend.DateTime {
-	return &graphqlbackend.DateTime{Time: r.v.UpdatedAt}
+func (r *registryExtensionRemoteResolver) UpdatedAt() *gqlutil.DateTime {
+	return &gqlutil.DateTime{Time: r.v.UpdatedAt}
 }
 
-func (r *registryExtensionRemoteResolver) PublishedAt(context.Context) (*graphqlbackend.DateTime, error) {
-	return &graphqlbackend.DateTime{Time: r.v.PublishedAt}, nil
+func (r *registryExtensionRemoteResolver) PublishedAt(context.Context) (*gqlutil.DateTime, error) {
+	return &gqlutil.DateTime{Time: r.v.PublishedAt}, nil
 }
 
 func (r *registryExtensionRemoteResolver) URL() string {

--- a/enterprise/cmd/frontend/internal/authz/resolvers/bitbucket_projects_permission_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/bitbucket_projects_permission_jobs.go
@@ -6,6 +6,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -51,20 +52,20 @@ func (j bitbucketProjectsPermissionJobResolver) FailureMessage() *string {
 	return j.job.FailureMessage
 }
 
-func (j bitbucketProjectsPermissionJobResolver) QueuedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: j.job.QueuedAt}
+func (j bitbucketProjectsPermissionJobResolver) QueuedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: j.job.QueuedAt}
 }
 
-func (j bitbucketProjectsPermissionJobResolver) StartedAt() *graphqlbackend.DateTime {
-	return graphqlbackend.DateTimeOrNil(j.job.StartedAt)
+func (j bitbucketProjectsPermissionJobResolver) StartedAt() *gqlutil.DateTime {
+	return gqlutil.DateTimeOrNil(j.job.StartedAt)
 }
 
-func (j bitbucketProjectsPermissionJobResolver) FinishedAt() *graphqlbackend.DateTime {
-	return graphqlbackend.DateTimeOrNil(j.job.FinishedAt)
+func (j bitbucketProjectsPermissionJobResolver) FinishedAt() *gqlutil.DateTime {
+	return gqlutil.DateTimeOrNil(j.job.FinishedAt)
 }
 
-func (j bitbucketProjectsPermissionJobResolver) ProcessAfter() *graphqlbackend.DateTime {
-	return graphqlbackend.DateTimeOrNil(j.job.ProcessAfter)
+func (j bitbucketProjectsPermissionJobResolver) ProcessAfter() *gqlutil.DateTime {
+	return gqlutil.DateTimeOrNil(j.job.ProcessAfter)
 }
 
 func (j bitbucketProjectsPermissionJobResolver) NumResets() int32 {

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -520,15 +521,15 @@ func (r *permissionsInfoResolver) Permissions() []string {
 	return strings.Split(strings.ToUpper(r.perms.String()), ",")
 }
 
-func (r *permissionsInfoResolver) SyncedAt() *graphqlbackend.DateTime {
+func (r *permissionsInfoResolver) SyncedAt() *gqlutil.DateTime {
 	if r.syncedAt.IsZero() {
 		return nil
 	}
-	return &graphqlbackend.DateTime{Time: r.syncedAt}
+	return &gqlutil.DateTime{Time: r.syncedAt}
 }
 
-func (r *permissionsInfoResolver) UpdatedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.updatedAt}
+func (r *permissionsInfoResolver) UpdatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.updatedAt}
 }
 
 func (r *permissionsInfoResolver) Unrestricted() bool {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/apitest/types.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/apitest/types.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/lib/batches"
 )
 
@@ -213,8 +214,8 @@ type BatchSpec struct {
 	// Alias for the above.
 	OnlyWithoutCredential BatchChangesCodeHostsConnection
 
-	CreatedAt graphqlbackend.DateTime
-	ExpiresAt *graphqlbackend.DateTime
+	CreatedAt gqlutil.DateTime
+	ExpiresAt *gqlutil.DateTime
 
 	// NEW
 	SupersedingBatchSpec *BatchSpec
@@ -223,8 +224,8 @@ type BatchSpec struct {
 	State               string
 	WorkspaceResolution BatchSpecWorkspaceResolution
 
-	StartedAt      graphqlbackend.DateTime
-	FinishedAt     graphqlbackend.DateTime
+	StartedAt      gqlutil.DateTime
+	FinishedAt     gqlutil.DateTime
 	FailureMessage string
 	ViewerCanRetry bool
 }
@@ -264,7 +265,7 @@ type ChangesetSpec struct {
 
 	Description ChangesetSpecDescription
 
-	ExpiresAt *graphqlbackend.DateTime
+	ExpiresAt *gqlutil.DateTime
 }
 
 type ChangesetSpecConnection struct {
@@ -422,8 +423,8 @@ type BatchSpecWorkspace struct {
 	Unsupported        bool
 
 	State          string
-	StartedAt      graphqlbackend.DateTime
-	FinishedAt     graphqlbackend.DateTime
+	StartedAt      gqlutil.DateTime
+	FinishedAt     gqlutil.DateTime
 	FailureMessage string
 	PlaceInQueue   int
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -102,12 +103,12 @@ func (r *batchChangeResolver) LastApplier(ctx context.Context) (*graphqlbackend.
 	return user, err
 }
 
-func (r *batchChangeResolver) LastAppliedAt() *graphqlbackend.DateTime {
+func (r *batchChangeResolver) LastAppliedAt() *gqlutil.DateTime {
 	if r.batchChange.LastAppliedAt.IsZero() {
 		return nil
 	}
 
-	return &graphqlbackend.DateTime{Time: r.batchChange.LastAppliedAt}
+	return &gqlutil.DateTime{Time: r.batchChange.LastAppliedAt}
 }
 
 func (r *batchChangeResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
@@ -164,19 +165,19 @@ func (r *batchChangeResolver) computeBatchSpec(ctx context.Context) (*btypes.Bat
 	return r.batchSpec, r.batchSpecErr
 }
 
-func (r *batchChangeResolver) CreatedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.batchChange.CreatedAt}
+func (r *batchChangeResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.batchChange.CreatedAt}
 }
 
-func (r *batchChangeResolver) UpdatedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.batchChange.UpdatedAt}
+func (r *batchChangeResolver) UpdatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.batchChange.UpdatedAt}
 }
 
-func (r *batchChangeResolver) ClosedAt() *graphqlbackend.DateTime {
+func (r *batchChangeResolver) ClosedAt() *gqlutil.DateTime {
 	if !r.batchChange.Closed() {
 		return nil
 	}
-	return &graphqlbackend.DateTime{Time: r.batchChange.ClosedAt}
+	return &gqlutil.DateTime{Time: r.batchChange.ClosedAt}
 }
 
 func (r *batchChangeResolver) ChangesetsStats(ctx context.Context) (graphqlbackend.ChangesetsStatsResolver, error) {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/lib/batches"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -185,12 +186,12 @@ func (r *batchSpecResolver) ApplyURL(ctx context.Context) (*string, error) {
 	return &url, nil
 }
 
-func (r *batchSpecResolver) CreatedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.batchSpec.CreatedAt}
+func (r *batchSpecResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.batchSpec.CreatedAt}
 }
 
-func (r *batchSpecResolver) ExpiresAt() *graphqlbackend.DateTime {
-	return &graphqlbackend.DateTime{Time: r.batchSpec.ExpiresAt()}
+func (r *batchSpecResolver) ExpiresAt() *gqlutil.DateTime {
+	return &gqlutil.DateTime{Time: r.batchSpec.ExpiresAt()}
 }
 
 func (r *batchSpecResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
@@ -342,7 +343,7 @@ func (r *batchSpecResolver) State(ctx context.Context) (string, error) {
 	return state.ToGraphQL(), nil
 }
 
-func (r *batchSpecResolver) StartedAt(ctx context.Context) (*graphqlbackend.DateTime, error) {
+func (r *batchSpecResolver) StartedAt(ctx context.Context) (*gqlutil.DateTime, error) {
 	if !r.batchSpec.CreatedFromRaw {
 		return nil, nil
 	}
@@ -364,10 +365,10 @@ func (r *batchSpecResolver) StartedAt(ctx context.Context) (*graphqlbackend.Date
 		return nil, nil
 	}
 
-	return &graphqlbackend.DateTime{Time: stats.StartedAt}, nil
+	return &gqlutil.DateTime{Time: stats.StartedAt}, nil
 }
 
-func (r *batchSpecResolver) FinishedAt(ctx context.Context) (*graphqlbackend.DateTime, error) {
+func (r *batchSpecResolver) FinishedAt(ctx context.Context) (*gqlutil.DateTime, error) {
 	if !r.batchSpec.CreatedFromRaw {
 		return nil, nil
 	}
@@ -389,7 +390,7 @@ func (r *batchSpecResolver) FinishedAt(ctx context.Context) (*graphqlbackend.Dat
 		return nil, nil
 	}
 
-	return &graphqlbackend.DateTime{Time: stats.FinishedAt}, nil
+	return &gqlutil.DateTime{Time: stats.FinishedAt}, nil
 }
 
 func (r *batchSpecResolver) FailureMessage(ctx context.Context) (*string, error) {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/lib/batches/schema"
@@ -117,8 +118,8 @@ func TestBatchSpecResolver(t *testing.T) {
 		Creator:             &apitest.User{ID: userAPIID, DatabaseID: userID},
 		ViewerCanAdminister: true,
 
-		CreatedAt: graphqlbackend.DateTime{Time: spec.CreatedAt.Truncate(time.Second)},
-		ExpiresAt: &graphqlbackend.DateTime{Time: spec.ExpiresAt().Truncate(time.Second)},
+		CreatedAt: gqlutil.DateTime{Time: spec.CreatedAt.Truncate(time.Second)},
+		ExpiresAt: &gqlutil.DateTime{Time: spec.ExpiresAt().Truncate(time.Second)},
 
 		ChangesetSpecs: apitest.ChangesetSpecConnection{
 			TotalCount: 1,
@@ -325,8 +326,8 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 		AllCodeHosts:          codeHosts,
 		OnlyWithoutCredential: codeHosts,
 
-		CreatedAt: graphqlbackend.DateTime{Time: spec.CreatedAt.Truncate(time.Second)},
-		ExpiresAt: &graphqlbackend.DateTime{Time: spec.ExpiresAt().Truncate(time.Second)},
+		CreatedAt: gqlutil.DateTime{Time: spec.CreatedAt.Truncate(time.Second)},
+		ExpiresAt: &gqlutil.DateTime{Time: spec.ExpiresAt().Truncate(time.Second)},
 
 		ChangesetSpecs: apitest.ChangesetSpecConnection{
 			Nodes: []apitest.ChangesetSpec{},
@@ -371,7 +372,7 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 	jobs[1].StartedAt = minAgo(99)
 	setJobProcessing(t, ctx, bstore, jobs[1])
 	want.State = "PROCESSING"
-	want.StartedAt = graphqlbackend.DateTime{Time: jobs[1].StartedAt}
+	want.StartedAt = gqlutil.DateTime{Time: jobs[1].StartedAt}
 	queryAndAssertBatchSpec(t, userCtx, s, apiID, want)
 
 	// 3/3 processing
@@ -393,7 +394,7 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 	setJobCompleted(t, ctx, bstore, jobs[1])
 	want.State = "COMPLETED"
 	want.ApplyURL = &applyUrl
-	want.FinishedAt = graphqlbackend.DateTime{Time: jobs[0].FinishedAt}
+	want.FinishedAt = gqlutil.DateTime{Time: jobs[0].FinishedAt}
 	// Nothing to retry
 	want.ViewerCanRetry = false
 	queryAndAssertBatchSpec(t, userCtx, s, apiID, want)
@@ -413,7 +414,7 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 	setJobProcessing(t, ctx, bstore, jobs[0])
 	setJobProcessing(t, ctx, bstore, jobs[2])
 	want.State = "PROCESSING"
-	want.FinishedAt = graphqlbackend.DateTime{}
+	want.FinishedAt = gqlutil.DateTime{}
 	want.ApplyURL = nil
 	want.ViewerCanRetry = false
 	queryAndAssertBatchSpec(t, userCtx, s, apiID, want)
@@ -436,7 +437,7 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 	setJobCanceled(t, ctx, bstore, jobs[2])
 
 	want.State = "CANCELED"
-	want.FinishedAt = graphqlbackend.DateTime{Time: jobs[0].FinishedAt}
+	want.FinishedAt = gqlutil.DateTime{Time: jobs[0].FinishedAt}
 	want.ViewerCanRetry = true
 	want.FailureMessage = ""
 	queryAndAssertBatchSpec(t, userCtx, s, apiID, want)

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	gql "github.com/sourcegraph/sourcegraph/internal/services/executors/transport/graphql"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
@@ -242,7 +243,7 @@ func (r *batchSpecWorkspaceResolver) Stages() graphqlbackend.BatchSpecWorkspaceS
 	return &batchSpecWorkspaceStagesResolver{store: r.store, execution: r.execution}
 }
 
-func (r *batchSpecWorkspaceResolver) StartedAt() *graphqlbackend.DateTime {
+func (r *batchSpecWorkspaceResolver) StartedAt() *gqlutil.DateTime {
 	if r.workspace.Skipped {
 		return nil
 	}
@@ -252,10 +253,10 @@ func (r *batchSpecWorkspaceResolver) StartedAt() *graphqlbackend.DateTime {
 	if r.execution.StartedAt.IsZero() {
 		return nil
 	}
-	return &graphqlbackend.DateTime{Time: r.execution.StartedAt}
+	return &gqlutil.DateTime{Time: r.execution.StartedAt}
 }
 
-func (r *batchSpecWorkspaceResolver) QueuedAt() *graphqlbackend.DateTime {
+func (r *batchSpecWorkspaceResolver) QueuedAt() *gqlutil.DateTime {
 	if r.workspace.Skipped {
 		return nil
 	}
@@ -265,10 +266,10 @@ func (r *batchSpecWorkspaceResolver) QueuedAt() *graphqlbackend.DateTime {
 	if r.execution.CreatedAt.IsZero() {
 		return nil
 	}
-	return &graphqlbackend.DateTime{Time: r.execution.CreatedAt}
+	return &gqlutil.DateTime{Time: r.execution.CreatedAt}
 }
 
-func (r *batchSpecWorkspaceResolver) FinishedAt() *graphqlbackend.DateTime {
+func (r *batchSpecWorkspaceResolver) FinishedAt() *gqlutil.DateTime {
 	if r.workspace.Skipped {
 		return nil
 	}
@@ -278,7 +279,7 @@ func (r *batchSpecWorkspaceResolver) FinishedAt() *graphqlbackend.DateTime {
 	if r.execution.FinishedAt.IsZero() {
 		return nil
 	}
-	return &graphqlbackend.DateTime{Time: r.execution.FinishedAt}
+	return &gqlutil.DateTime{Time: r.execution.FinishedAt}
 }
 
 func (r *batchSpecWorkspaceResolver) FailureMessage() *string {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/externallink"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -31,16 +32,16 @@ func (r *batchSpecWorkspaceFileResolver) ID() graphql.ID {
 	return marshalWorkspaceFileRandID(r.file.RandID)
 }
 
-func (r *batchSpecWorkspaceFileResolver) ModifiedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.file.ModifiedAt}
+func (r *batchSpecWorkspaceFileResolver) ModifiedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.file.ModifiedAt}
 }
 
-func (r *batchSpecWorkspaceFileResolver) CreatedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.file.CreatedAt}
+func (r *batchSpecWorkspaceFileResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.file.CreatedAt}
 }
 
-func (r *batchSpecWorkspaceFileResolver) UpdatedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.file.UpdatedAt}
+func (r *batchSpecWorkspaceFileResolver) UpdatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.file.UpdatedAt}
 }
 
 func (r *batchSpecWorkspaceFileResolver) Name() string {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/externallink"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -70,21 +71,21 @@ func TestBatchSpecWorkspaceFileResolver(t *testing.T) {
 			getActual: func() (interface{}, error) {
 				return resolver.ModifiedAt(), nil
 			},
-			expected: graphqlbackend.DateTime{Time: date},
+			expected: gqlutil.DateTime{Time: date},
 		},
 		{
 			name: "CreatedAt",
 			getActual: func() (interface{}, error) {
 				return resolver.CreatedAt(), nil
 			},
-			expected: graphqlbackend.DateTime{Time: date},
+			expected: gqlutil.DateTime{Time: date},
 		},
 		{
 			name: "UpdatedAt",
 			getActual: func() (interface{}, error) {
 				return resolver.UpdatedAt(), nil
 			},
-			expected: graphqlbackend.DateTime{Time: date},
+			expected: gqlutil.DateTime{Time: date},
 		},
 		{
 			name: "IsDirectory",

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_resolution.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_resolution.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/search"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -23,18 +24,18 @@ func (r *batchSpecWorkspaceResolutionResolver) State() string {
 	return r.resolution.State.ToGraphQL()
 }
 
-func (r *batchSpecWorkspaceResolutionResolver) StartedAt() *graphqlbackend.DateTime {
+func (r *batchSpecWorkspaceResolutionResolver) StartedAt() *gqlutil.DateTime {
 	if r.resolution.StartedAt.IsZero() {
 		return nil
 	}
-	return &graphqlbackend.DateTime{Time: r.resolution.StartedAt}
+	return &gqlutil.DateTime{Time: r.resolution.StartedAt}
 }
 
-func (r *batchSpecWorkspaceResolutionResolver) FinishedAt() *graphqlbackend.DateTime {
+func (r *batchSpecWorkspaceResolutionResolver) FinishedAt() *gqlutil.DateTime {
 	if r.resolution.FinishedAt.IsZero() {
 		return nil
 	}
-	return &graphqlbackend.DateTime{Time: r.resolution.FinishedAt}
+	return &gqlutil.DateTime{Time: r.resolution.FinishedAt}
 }
 
 func (r *batchSpecWorkspaceResolutionResolver) FailureMessage() *string {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 	"github.com/sourcegraph/sourcegraph/lib/batches/execution"
 )
@@ -61,18 +62,18 @@ func (r *batchSpecWorkspaceStepResolver) OutputLines(ctx context.Context, args *
 	return &lines, nil
 }
 
-func (r *batchSpecWorkspaceStepResolver) StartedAt() *graphqlbackend.DateTime {
+func (r *batchSpecWorkspaceStepResolver) StartedAt() *gqlutil.DateTime {
 	if r.stepInfo.StartedAt.IsZero() {
 		return nil
 	}
-	return &graphqlbackend.DateTime{Time: r.stepInfo.StartedAt}
+	return &gqlutil.DateTime{Time: r.stepInfo.StartedAt}
 }
 
-func (r *batchSpecWorkspaceStepResolver) FinishedAt() *graphqlbackend.DateTime {
+func (r *batchSpecWorkspaceStepResolver) FinishedAt() *gqlutil.DateTime {
 	if r.stepInfo.FinishedAt.IsZero() {
 		return nil
 	}
-	return &graphqlbackend.DateTime{Time: r.stepInfo.FinishedAt}
+	return &gqlutil.DateTime{Time: r.stepInfo.FinishedAt}
 }
 
 func (r *batchSpecWorkspaceStepResolver) ExitCode() *int32 {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/bulk_operation.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/bulk_operation.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -96,15 +97,15 @@ func (r *bulkOperationResolver) ChangesetCount() int32 {
 	return r.bulkOperation.ChangesetCount
 }
 
-func (r *bulkOperationResolver) CreatedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.bulkOperation.CreatedAt}
+func (r *bulkOperationResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.bulkOperation.CreatedAt}
 }
 
-func (r *bulkOperationResolver) FinishedAt() *graphqlbackend.DateTime {
+func (r *bulkOperationResolver) FinishedAt() *gqlutil.DateTime {
 	if r.bulkOperation.FinishedAt.IsZero() {
 		return nil
 	}
-	return &graphqlbackend.DateTime{Time: r.bulkOperation.FinishedAt}
+	return &gqlutil.DateTime{Time: r.bulkOperation.FinishedAt}
 }
 
 func changesetJobTypeToBulkOperationType(t btypes.ChangesetJobType) (string, error) {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -192,15 +193,15 @@ func (r *changesetResolver) BatchChanges(ctx context.Context, args *graphqlbacke
 	return &batchChangesConnectionResolver{store: r.store, opts: opts}, nil
 }
 
-func (r *changesetResolver) CreatedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.changeset.CreatedAt}
+func (r *changesetResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.changeset.CreatedAt}
 }
 
-func (r *changesetResolver) UpdatedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.changeset.UpdatedAt}
+func (r *changesetResolver) UpdatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.changeset.UpdatedAt}
 }
 
-func (r *changesetResolver) NextSyncAt(ctx context.Context) (*graphqlbackend.DateTime, error) {
+func (r *changesetResolver) NextSyncAt(ctx context.Context) (*gqlutil.DateTime, error) {
 	// If code host syncs are disabled, the syncer is not actively syncing
 	// changesets and the next sync time cannot be determined.
 	if conf.Get().DisableAutoCodeHostSyncs {
@@ -214,7 +215,7 @@ func (r *changesetResolver) NextSyncAt(ctx context.Context) (*graphqlbackend.Dat
 	if nextSyncAt.IsZero() {
 		return nil, nil
 	}
-	return &graphqlbackend.DateTime{Time: nextSyncAt}, nil
+	return &gqlutil.DateTime{Time: nextSyncAt}, nil
 }
 
 func (r *changesetResolver) Title(ctx context.Context) (*string, error) {
@@ -352,7 +353,7 @@ func (r *changesetResolver) Error() *string { return r.changeset.FailureMessage 
 
 func (r *changesetResolver) SyncerError() *string { return r.changeset.SyncErrorMessage }
 
-func (r *changesetResolver) ScheduleEstimateAt(ctx context.Context) (*graphqlbackend.DateTime, error) {
+func (r *changesetResolver) ScheduleEstimateAt(ctx context.Context) (*gqlutil.DateTime, error) {
 	// We need to find out how deep in the queue this changeset is.
 	place, err := r.store.GetChangesetPlaceInSchedulerQueue(ctx, r.changeset.ID)
 	if err == store.ErrNoResults {
@@ -363,7 +364,7 @@ func (r *changesetResolver) ScheduleEstimateAt(ctx context.Context) (*graphqlbac
 
 	// Now we can ask the scheduler to estimate where this item would fall in
 	// the schedule.
-	return graphqlbackend.DateTimeOrNil(config.ActiveWindow().Estimate(r.store.Clock()(), place)), nil
+	return gqlutil.DateTimeOrNil(config.ActiveWindow().Estimate(r.store.Clock()(), place)), nil
 }
 
 func (r *changesetResolver) CurrentSpec(ctx context.Context) (graphqlbackend.VisibleChangesetSpecResolver, error) {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts.go
@@ -1,16 +1,16 @@
 package resolvers
 
 import (
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/state"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 type changesetCountsResolver struct {
 	counts *state.ChangesetCounts
 }
 
-func (r *changesetCountsResolver) Date() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.counts.Time}
+func (r *changesetCountsResolver) Date() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.counts.Time}
 }
 func (r *changesetCountsResolver) Total() int32                { return r.counts.Total }
 func (r *changesetCountsResolver) Merged() int32               { return r.counts.Merged }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_event.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_event.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 type changesetEventResolver struct {
@@ -25,8 +26,8 @@ func (r *changesetEventResolver) ID() graphql.ID {
 	return marshalChangesetEventID(r.ChangesetEvent.ID)
 }
 
-func (r *changesetEventResolver) CreatedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.ChangesetEvent.CreatedAt}
+func (r *changesetEventResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.ChangesetEvent.CreatedAt}
 }
 
 func (r *changesetEventResolver) Changeset() graphqlbackend.ExternalChangesetResolver {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
@@ -13,6 +13,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -93,8 +94,8 @@ func (r *changesetSpecResolver) Description(ctx context.Context) (graphqlbackend
 	return descriptionResolver, nil
 }
 
-func (r *changesetSpecResolver) ExpiresAt() *graphqlbackend.DateTime {
-	return &graphqlbackend.DateTime{Time: r.changesetSpec.ExpiresAt()}
+func (r *changesetSpecResolver) ExpiresAt() *gqlutil.DateTime {
+	return &gqlutil.DateTime{Time: r.changesetSpec.ExpiresAt()}
 }
 
 func (r *changesetSpecResolver) ForkTarget() graphqlbackend.ForkTargetInterface {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/batches"
 )
@@ -123,7 +124,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 							Deleted: 3,
 						},
 					},
-					ExpiresAt: &graphqlbackend.DateTime{Time: spec.ExpiresAt().Truncate(time.Second)},
+					ExpiresAt: &gqlutil.DateTime{Time: spec.ExpiresAt().Truncate(time.Second)},
 				}
 			},
 		},
@@ -173,7 +174,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 							Deleted: 3,
 						},
 					},
-					ExpiresAt: &graphqlbackend.DateTime{Time: spec.ExpiresAt().Truncate(time.Second)},
+					ExpiresAt: &gqlutil.DateTime{Time: spec.ExpiresAt().Truncate(time.Second)},
 				}
 			},
 		},
@@ -223,7 +224,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 							Deleted: 3,
 						},
 					},
-					ExpiresAt: &graphqlbackend.DateTime{Time: spec.ExpiresAt().Truncate(time.Second)},
+					ExpiresAt: &gqlutil.DateTime{Time: spec.ExpiresAt().Truncate(time.Second)},
 				}
 			},
 		},
@@ -241,7 +242,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 						},
 						ExternalID: spec.ExternalID,
 					},
-					ExpiresAt: &graphqlbackend.DateTime{Time: spec.ExpiresAt().Truncate(time.Second)},
+					ExpiresAt: &gqlutil.DateTime{Time: spec.ExpiresAt().Truncate(time.Second)},
 				}
 			},
 		},

--- a/enterprise/cmd/frontend/internal/batches/resolvers/credential.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/credential.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -99,8 +100,8 @@ func (c *batchChangesUserCredentialResolver) SSHPublicKey(ctx context.Context) (
 	return nil, nil
 }
 
-func (c *batchChangesUserCredentialResolver) CreatedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: c.credential.CreatedAt}
+func (c *batchChangesUserCredentialResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: c.credential.CreatedAt}
 }
 
 func (c *batchChangesUserCredentialResolver) IsSiteCredential() bool {
@@ -143,8 +144,8 @@ func (c *batchChangesSiteCredentialResolver) SSHPublicKey(ctx context.Context) (
 	return nil, nil
 }
 
-func (c *batchChangesSiteCredentialResolver) CreatedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: c.credential.CreatedAt}
+func (c *batchChangesSiteCredentialResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: c.credential.CreatedAt}
 }
 
 func (c *batchChangesSiteCredentialResolver) IsSiteCredential() bool {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/main_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/main_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	executor "github.com/sourcegraph/sourcegraph/internal/services/executors/transport/graphql"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -97,7 +98,7 @@ var testDiffGraphQL = apitest.FileDiffs{
 func marshalDateTime(t testing.TB, ts time.Time) string {
 	t.Helper()
 
-	dt := graphqlbackend.DateTime{Time: ts}
+	dt := gqlutil.DateTime{Time: ts}
 
 	bs, err := dt.MarshalJSON()
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/main_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/main_test.go
@@ -17,6 +17,7 @@ import (
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -155,7 +156,7 @@ func newResolverWithClock(logger log.Logger, db database.DB, clock func() time.T
 func marshalDateTime(t testing.TB, ts time.Time) string {
 	t.Helper()
 
-	dt := graphqlbackend.DateTime{Time: ts}
+	dt := gqlutil.DateTime{Time: ts}
 
 	bs, err := dt.MarshalJSON()
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -768,8 +769,8 @@ func (m *monitor) CreatedBy(ctx context.Context) (*graphqlbackend.UserResolver, 
 	return graphqlbackend.UserByIDInt32(ctx, m.db, m.Monitor.CreatedBy)
 }
 
-func (m *monitor) CreatedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: m.Monitor.CreatedAt}
+func (m *monitor) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: m.Monitor.CreatedAt}
 }
 
 func (m *monitor) Description() string {
@@ -978,11 +979,11 @@ func (m *monitorTriggerEvent) Message() *string {
 	return m.FailureMessage
 }
 
-func (m *monitorTriggerEvent) Timestamp() (graphqlbackend.DateTime, error) {
+func (m *monitorTriggerEvent) Timestamp() (gqlutil.DateTime, error) {
 	if m.FinishedAt == nil {
-		return graphqlbackend.DateTime{Time: m.db.CodeMonitors().Now()}, nil
+		return gqlutil.DateTime{Time: m.db.CodeMonitors().Now()}, nil
 	}
-	return graphqlbackend.DateTime{Time: *m.FinishedAt}, nil
+	return gqlutil.DateTime{Time: *m.FinishedAt}, nil
 }
 
 func (m *monitorTriggerEvent) Actions(ctx context.Context, args *graphqlbackend.ListActionArgs) (graphqlbackend.MonitorActionConnectionResolver, error) {
@@ -1335,11 +1336,11 @@ func (m *monitorActionEvent) Message() *string {
 	return m.FailureMessage
 }
 
-func (m *monitorActionEvent) Timestamp() graphqlbackend.DateTime {
+func (m *monitorActionEvent) Timestamp() gqlutil.DateTime {
 	if m.FinishedAt == nil {
-		return graphqlbackend.DateTime{Time: m.db.CodeMonitors().Now()}
+		return gqlutil.DateTime{Time: m.db.CodeMonitors().Now()}
 	}
-	return graphqlbackend.DateTime{Time: *m.FinishedAt}
+	return gqlutil.DateTime{Time: *m.FinishedAt}
 }
 
 func validateSlackURL(urlString string) error {

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 // productLicense implements the GraphQL type ProductLicense.
@@ -97,8 +98,8 @@ func (r *productLicense) Info() (*graphqlbackend.ProductLicenseInfo, error) {
 
 func (r *productLicense) LicenseKey() string { return r.v.LicenseKey }
 
-func (r *productLicense) CreatedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.v.CreatedAt}
+func (r *productLicense) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.v.CreatedAt}
 }
 
 func generateProductLicenseForSubscription(ctx context.Context, db database.DB, subscriptionID string, input *graphqlbackend.ProductLicenseInput) (id string, err error) {

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 // productSubscription implements the GraphQL type ProductSubscription.
@@ -116,8 +117,8 @@ func (r *productSubscription) ProductLicenses(ctx context.Context, args *graphql
 	return &productLicenseConnection{db: r.db, opt: opt}, nil
 }
 
-func (r *productSubscription) CreatedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.v.CreatedAt}
+func (r *productSubscription) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.v.CreatedAt}
 }
 
 func (r *productSubscription) IsArchived() bool { return r.v.ArchivedAt != nil }

--- a/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/notebooks/resolvers/resolvers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/notebooks"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -450,12 +451,12 @@ func (r *notebookResolver) Public(ctx context.Context) bool {
 	return r.notebook.Public
 }
 
-func (r *notebookResolver) UpdatedAt(ctx context.Context) graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.notebook.UpdatedAt}
+func (r *notebookResolver) UpdatedAt(ctx context.Context) gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.notebook.UpdatedAt}
 }
 
-func (r *notebookResolver) CreatedAt(ctx context.Context) graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.notebook.CreatedAt}
+func (r *notebookResolver) CreatedAt(ctx context.Context) gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.notebook.CreatedAt}
 }
 
 func (r *notebookResolver) ViewerCanManage(ctx context.Context) (bool, error) {

--- a/enterprise/cmd/frontend/internal/notebooks/resolvers/stars_resolvers.go
+++ b/enterprise/cmd/frontend/internal/notebooks/resolvers/stars_resolvers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/notebooks"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 func marshalNotebookStarCursor(cursor int64) string {
@@ -60,8 +61,8 @@ func (r *notebookStarResolver) User(ctx context.Context) (*graphqlbackend.UserRe
 	return graphqlbackend.UserByIDInt32(ctx, r.db, r.star.UserID)
 }
 
-func (r *notebookStarResolver) CreatedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.star.CreatedAt}
+func (r *notebookStarResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.star.CreatedAt}
 }
 
 func (r *notebookResolver) notebookStarsToResolvers(notebookStars []*notebooks.NotebookStar) []graphqlbackend.NotebookStarResolver {

--- a/enterprise/cmd/frontend/internal/registry/extension_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_graphql.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry/stores"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -54,23 +55,23 @@ func (r *extensionDBResolver) Manifest(ctx context.Context) (graphqlbackend.Exte
 	return registry.NewExtensionManifest(&release.Manifest), nil
 }
 
-func (r *extensionDBResolver) CreatedAt() *graphqlbackend.DateTime {
-	return &graphqlbackend.DateTime{Time: r.v.CreatedAt}
+func (r *extensionDBResolver) CreatedAt() *gqlutil.DateTime {
+	return &gqlutil.DateTime{Time: r.v.CreatedAt}
 }
 
-func (r *extensionDBResolver) UpdatedAt() *graphqlbackend.DateTime {
-	return &graphqlbackend.DateTime{Time: r.v.UpdatedAt}
+func (r *extensionDBResolver) UpdatedAt() *gqlutil.DateTime {
+	return &gqlutil.DateTime{Time: r.v.UpdatedAt}
 }
 
-func (r *extensionDBResolver) PublishedAt(ctx context.Context) (*graphqlbackend.DateTime, error) {
+func (r *extensionDBResolver) PublishedAt(ctx context.Context) (*gqlutil.DateTime, error) {
 	release, err := r.release(ctx)
 	if err != nil {
 		return nil, err
 	}
 	if release == nil {
-		return &graphqlbackend.DateTime{Time: time.Time{}}, nil
+		return &gqlutil.DateTime{Time: time.Time{}}, nil
 	}
-	return &graphqlbackend.DateTime{Time: release.CreatedAt}, nil
+	return &gqlutil.DateTime{Time: release.CreatedAt}, nil
 }
 
 func (r *extensionDBResolver) URL() string {

--- a/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -364,8 +365,8 @@ func (r *searchContextResolver) Spec() string {
 	return searchcontexts.GetSearchContextSpec(r.sc)
 }
 
-func (r *searchContextResolver) UpdatedAt() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: r.sc.UpdatedAt}
+func (r *searchContextResolver) UpdatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.sc.UpdatedAt}
 }
 
 func (r *searchContextResolver) Namespace(ctx context.Context) (*graphqlbackend.NamespaceResolver, error) {

--- a/enterprise/internal/insights/resolvers/dynamic_insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/dynamic_insight_series_resolver.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/query"
@@ -64,7 +65,7 @@ func (e emptyInsightStatusResolver) FailedJobs() int32 {
 	return 0
 }
 
-func (e emptyInsightStatusResolver) BackfillQueuedAt() *graphqlbackend.DateTime {
+func (e emptyInsightStatusResolver) BackfillQueuedAt() *gqlutil.DateTime {
 	current := time.Now().AddDate(-1, 0, 0)
-	return graphqlbackend.DateTimeOrNil(&current)
+	return gqlutil.DateTimeOrNil(&current)
 }

--- a/enterprise/internal/insights/resolvers/insight_dirty_query_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_dirty_query_resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 )
@@ -18,8 +19,8 @@ func (i *insightDirtyQueryResolver) Reason(ctx context.Context) string {
 	return i.data.Reason
 }
 
-func (i *insightDirtyQueryResolver) Time(ctx context.Context) graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: i.data.ForTime}
+func (i *insightDirtyQueryResolver) Time(ctx context.Context) gqlutil.DateTime {
+	return gqlutil.DateTime{Time: i.data.ForTime}
 }
 
 func (i *insightDirtyQueryResolver) Count(ctx context.Context) int32 {

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 
@@ -169,8 +170,8 @@ var _ graphqlbackend.InsightsDataPointResolver = insightsDataPointResolver{}
 
 type insightsDataPointResolver struct{ p store.SeriesPoint }
 
-func (i insightsDataPointResolver) DateTime() graphqlbackend.DateTime {
-	return graphqlbackend.DateTime{Time: i.p.Time}
+func (i insightsDataPointResolver) DateTime() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: i.p.Time}
 }
 
 func (i insightsDataPointResolver) Value() float64 { return i.p.Value }
@@ -184,8 +185,8 @@ func (i insightStatusResolver) TotalPoints() int32   { return i.totalPoints }
 func (i insightStatusResolver) PendingJobs() int32   { return i.pendingJobs }
 func (i insightStatusResolver) CompletedJobs() int32 { return i.completedJobs }
 func (i insightStatusResolver) FailedJobs() int32    { return i.failedJobs }
-func (i insightStatusResolver) BackfillQueuedAt() *graphqlbackend.DateTime {
-	return graphqlbackend.DateTimeOrNil(i.backfillQueuedAt)
+func (i insightStatusResolver) BackfillQueuedAt() *gqlutil.DateTime {
+	return gqlutil.DateTimeOrNil(i.backfillQueuedAt)
 }
 
 func NewStatusResolver(status *queryrunner.JobsStatus, queuedAt *time.Time) *insightStatusResolver {

--- a/internal/codeintel/autoindexing/transport/graphql/utils.go
+++ b/internal/codeintel/autoindexing/transport/graphql/utils.go
@@ -2,10 +2,8 @@ package graphql
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -13,7 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/shared"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // strPtr creates a pointer to the given value. If the value is an
@@ -24,39 +21,6 @@ func strPtr(val string) *string {
 	}
 
 	return &val
-}
-
-// DateTime implements the DateTime GraphQL scalar type.
-type DateTime struct{ time.Time }
-
-// DateTimeOrNil is a helper function that returns nil for time == nil and otherwise wraps time in
-// DateTime.
-func DateTimeOrNil(time *time.Time) *DateTime {
-	if time == nil {
-		return nil
-	}
-	return &DateTime{Time: *time}
-}
-
-func (DateTime) ImplementsGraphQLType(name string) bool {
-	return name == "DateTime"
-}
-
-func (v DateTime) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.Time.Format(time.RFC3339))
-}
-
-func (v *DateTime) UnmarshalGraphQL(input any) error {
-	s, ok := input.(string)
-	if !ok {
-		return errors.Errorf("invalid GraphQL DateTime scalar value input (got %T, expected string)", input)
-	}
-	t, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return err
-	}
-	*v = DateTime{Time: t}
-	return nil
 }
 
 func marshalLSIFIndexGQLID(indexID int64) graphql.ID {

--- a/internal/codeintel/shared/resolvers/audit_log_resolver.go
+++ b/internal/codeintel/shared/resolvers/audit_log_resolver.go
@@ -6,18 +6,19 @@ import (
 	"github.com/graph-gophers/graphql-go"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/shared/types"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 type LSIFUploadsAuditLogsResolver interface {
-	LogTimestamp() DateTime
-	UploadDeletedAt() *DateTime
+	LogTimestamp() gqlutil.DateTime
+	UploadDeletedAt() *gqlutil.DateTime
 	Reason() *string
 	ChangedColumns() []AuditLogColumnChange
 	UploadID() graphql.ID
 	InputCommit() string
 	InputRoot() string
 	InputIndexer() string
-	UploadedAt() DateTime
+	UploadedAt() gqlutil.DateTime
 	Operation() string
 	// AssociatedIndex(ctx context.Context) (LSIFIndexResolver, error)
 }
@@ -44,12 +45,12 @@ func (r *lsifUploadsAuditLogResolver) ChangedColumns() (values []AuditLogColumnC
 	return values
 }
 
-func (r *lsifUploadsAuditLogResolver) LogTimestamp() DateTime {
-	return DateTime{Time: r.log.LogTimestamp}
+func (r *lsifUploadsAuditLogResolver) LogTimestamp() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.log.LogTimestamp}
 }
 
-func (r *lsifUploadsAuditLogResolver) UploadDeletedAt() *DateTime {
-	return DateTimeOrNil(r.log.RecordDeletedAt)
+func (r *lsifUploadsAuditLogResolver) UploadDeletedAt() *gqlutil.DateTime {
+	return gqlutil.DateTimeOrNil(r.log.RecordDeletedAt)
 }
 
 func (r *lsifUploadsAuditLogResolver) UploadID() graphql.ID {
@@ -58,8 +59,8 @@ func (r *lsifUploadsAuditLogResolver) UploadID() graphql.ID {
 func (r *lsifUploadsAuditLogResolver) InputCommit() string  { return r.log.Commit }
 func (r *lsifUploadsAuditLogResolver) InputRoot() string    { return r.log.Root }
 func (r *lsifUploadsAuditLogResolver) InputIndexer() string { return r.log.Indexer }
-func (r *lsifUploadsAuditLogResolver) UploadedAt() DateTime {
-	return DateTime{Time: r.log.UploadedAt}
+func (r *lsifUploadsAuditLogResolver) UploadedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.log.UploadedAt}
 }
 
 func (r *lsifUploadsAuditLogResolver) Operation() string {

--- a/internal/codeintel/shared/resolvers/execution_log_entry_resolver.go
+++ b/internal/codeintel/shared/resolvers/execution_log_entry_resolver.go
@@ -4,13 +4,14 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
 type ExecutionLogEntryResolver interface {
 	Key() string
 	Command() []string
-	StartTime() DateTime
+	StartTime() gqlutil.DateTime
 	ExitCode() *int32
 	Out(ctx context.Context) (string, error)
 	DurationMilliseconds() *int32
@@ -39,8 +40,8 @@ func (r *executionLogEntryResolver) ExitCode() *int32 {
 	return &val
 }
 
-func (r *executionLogEntryResolver) StartTime() DateTime {
-	return DateTime{Time: r.entry.StartTime}
+func (r *executionLogEntryResolver) StartTime() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.entry.StartTime}
 }
 
 func (r *executionLogEntryResolver) DurationMilliseconds() *int32 {

--- a/internal/codeintel/shared/resolvers/index_resolvers.go
+++ b/internal/codeintel/shared/resolvers/index_resolvers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/shared/types"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
@@ -19,11 +20,11 @@ type LSIFIndexResolver interface {
 	InputRoot() string
 	InputIndexer() string
 	Indexer() types.CodeIntelIndexerResolver
-	QueuedAt() DateTime
+	QueuedAt() gqlutil.DateTime
 	State() string
 	Failure() *string
-	StartedAt() *DateTime
-	FinishedAt() *DateTime
+	StartedAt() *gqlutil.DateTime
+	FinishedAt() *gqlutil.DateTime
 	Steps() IndexStepsResolver
 	PlaceInQueue() *int32
 	AssociatedUpload(ctx context.Context) (LSIFUploadResolver, error)
@@ -60,14 +61,18 @@ func NewIndexResolver(autoindexingSvc AutoIndexingService, uploadsSvc UploadsSer
 	}
 }
 
-func (r *indexResolver) ID() graphql.ID        { return marshalLSIFIndexGQLID(int64(r.index.ID)) }
-func (r *indexResolver) InputCommit() string   { return r.index.Commit }
-func (r *indexResolver) InputRoot() string     { return r.index.Root }
-func (r *indexResolver) InputIndexer() string  { return r.index.Indexer }
-func (r *indexResolver) QueuedAt() DateTime    { return DateTime{Time: r.index.QueuedAt} }
-func (r *indexResolver) Failure() *string      { return r.index.FailureMessage }
-func (r *indexResolver) StartedAt() *DateTime  { return DateTimeOrNil(r.index.StartedAt) }
-func (r *indexResolver) FinishedAt() *DateTime { return DateTimeOrNil(r.index.FinishedAt) }
+func (r *indexResolver) ID() graphql.ID             { return marshalLSIFIndexGQLID(int64(r.index.ID)) }
+func (r *indexResolver) InputCommit() string        { return r.index.Commit }
+func (r *indexResolver) InputRoot() string          { return r.index.Root }
+func (r *indexResolver) InputIndexer() string       { return r.index.Indexer }
+func (r *indexResolver) QueuedAt() gqlutil.DateTime { return gqlutil.DateTime{Time: r.index.QueuedAt} }
+func (r *indexResolver) Failure() *string           { return r.index.FailureMessage }
+func (r *indexResolver) StartedAt() *gqlutil.DateTime {
+	return gqlutil.DateTimeOrNil(r.index.StartedAt)
+}
+func (r *indexResolver) FinishedAt() *gqlutil.DateTime {
+	return gqlutil.DateTimeOrNil(r.index.FinishedAt)
+}
 func (r *indexResolver) Steps() IndexStepsResolver {
 	return NewIndexStepsResolver(r.autoindexingSvc, r.index)
 }

--- a/internal/codeintel/shared/resolvers/summary.go
+++ b/internal/codeintel/shared/resolvers/summary.go
@@ -1,14 +1,15 @@
 package sharedresolvers
 
 import (
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 type CodeIntelRepositorySummaryResolver interface {
 	RecentUploads() []LSIFUploadsWithRepositoryNamespaceResolver
 	RecentIndexes() []LSIFIndexesWithRepositoryNamespaceResolver
-	LastUploadRetentionScan() *DateTime
-	LastIndexScan() *DateTime
+	LastUploadRetentionScan() *gqlutil.DateTime
+	LastIndexScan() *gqlutil.DateTime
 }
 
 type repositorySummaryResolver struct {
@@ -60,10 +61,10 @@ func (r *repositorySummaryResolver) RecentIndexes() []LSIFIndexesWithRepositoryN
 	return resolvers
 }
 
-func (r *repositorySummaryResolver) LastUploadRetentionScan() *DateTime {
-	return DateTimeOrNil(r.summary.LastUploadRetentionScan)
+func (r *repositorySummaryResolver) LastUploadRetentionScan() *gqlutil.DateTime {
+	return gqlutil.DateTimeOrNil(r.summary.LastUploadRetentionScan)
 }
 
-func (r *repositorySummaryResolver) LastIndexScan() *DateTime {
-	return DateTimeOrNil(r.summary.LastIndexScan)
+func (r *repositorySummaryResolver) LastIndexScan() *gqlutil.DateTime {
+	return gqlutil.DateTimeOrNil(r.summary.LastIndexScan)
 }

--- a/internal/codeintel/shared/resolvers/upload_resolver.go
+++ b/internal/codeintel/shared/resolvers/upload_resolver.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/shared/types"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
@@ -19,11 +20,11 @@ type LSIFUploadResolver interface {
 	Tags(ctx context.Context) ([]string, error)
 	InputRoot() string
 	IsLatestForRepo() bool
-	UploadedAt() DateTime
+	UploadedAt() gqlutil.DateTime
 	State() string
 	Failure() *string
-	StartedAt() *DateTime
-	FinishedAt() *DateTime
+	StartedAt() *gqlutil.DateTime
+	FinishedAt() *gqlutil.DateTime
 	InputIndexer() string
 	Indexer() types.CodeIntelIndexerResolver
 	PlaceInQueue() *int32
@@ -68,12 +69,18 @@ func (r *UploadResolver) ID() graphql.ID        { return marshalLSIFUploadGQLID(
 func (r *UploadResolver) InputCommit() string   { return r.upload.Commit }
 func (r *UploadResolver) InputRoot() string     { return r.upload.Root }
 func (r *UploadResolver) IsLatestForRepo() bool { return r.upload.VisibleAtTip }
-func (r *UploadResolver) UploadedAt() DateTime  { return DateTime{Time: r.upload.UploadedAt} }
-func (r *UploadResolver) Failure() *string      { return r.upload.FailureMessage }
-func (r *UploadResolver) StartedAt() *DateTime  { return DateTimeOrNil(r.upload.StartedAt) }
-func (r *UploadResolver) FinishedAt() *DateTime { return DateTimeOrNil(r.upload.FinishedAt) }
-func (r *UploadResolver) InputIndexer() string  { return r.upload.Indexer }
-func (r *UploadResolver) PlaceInQueue() *int32  { return toInt32(r.upload.Rank) }
+func (r *UploadResolver) UploadedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.upload.UploadedAt}
+}
+func (r *UploadResolver) Failure() *string { return r.upload.FailureMessage }
+func (r *UploadResolver) StartedAt() *gqlutil.DateTime {
+	return gqlutil.DateTimeOrNil(r.upload.StartedAt)
+}
+func (r *UploadResolver) FinishedAt() *gqlutil.DateTime {
+	return gqlutil.DateTimeOrNil(r.upload.FinishedAt)
+}
+func (r *UploadResolver) InputIndexer() string { return r.upload.Indexer }
+func (r *UploadResolver) PlaceInQueue() *int32 { return toInt32(r.upload.Rank) }
 
 func (r *UploadResolver) Tags(ctx context.Context) (tagsNames []string, err error) {
 	tags, err := r.uploadsSvc.GetListTags(ctx, api.RepoName(r.upload.RepositoryName), r.upload.Commit)

--- a/internal/codeintel/shared/resolvers/utils.go
+++ b/internal/codeintel/shared/resolvers/utils.go
@@ -2,7 +2,6 @@ package sharedresolvers
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"io/fs"
 	"os"
 	"strconv"
@@ -12,41 +11,7 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
-
-// DateTime implements the DateTime GraphQL scalar type.
-type DateTime struct{ time.Time }
-
-// DateTimeOrNil is a helper function that returns nil for time == nil and otherwise wraps time in
-// DateTime.
-func DateTimeOrNil(time *time.Time) *DateTime {
-	if time == nil {
-		return nil
-	}
-	return &DateTime{Time: *time}
-}
-
-func (DateTime) ImplementsGraphQLType(name string) bool {
-	return name == "DateTime"
-}
-
-func (v DateTime) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.Time.Format(time.RFC3339))
-}
-
-func (v *DateTime) UnmarshalGraphQL(input any) error {
-	s, ok := input.(string)
-	if !ok {
-		return errors.Errorf("invalid GraphQL DateTime scalar value input (got %T, expected string)", input)
-	}
-	t, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return err
-	}
-	*v = DateTime{Time: t}
-	return nil
-}
 
 // strPtr creates a pointer to the given value. If the value is an
 // empty string, a nil pointer is returned.

--- a/internal/codeintel/uploads/transport/graphql/commitgraph_resolver.go
+++ b/internal/codeintel/uploads/transport/graphql/commitgraph_resolver.go
@@ -3,11 +3,13 @@ package graphql
 import (
 	"context"
 	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 type CodeIntelligenceCommitGraphResolver interface {
 	Stale(ctx context.Context) (bool, error)
-	UpdatedAt(ctx context.Context) (*DateTime, error)
+	UpdatedAt(ctx context.Context) (*gqlutil.DateTime, error)
 }
 
 type CommitGraphResolver struct {
@@ -26,6 +28,6 @@ func (r *CommitGraphResolver) Stale(ctx context.Context) (bool, error) {
 	return r.stale, nil
 }
 
-func (r *CommitGraphResolver) UpdatedAt(ctx context.Context) (*DateTime, error) {
-	return DateTimeOrNil(r.updatedAt), nil
+func (r *CommitGraphResolver) UpdatedAt(ctx context.Context) (*gqlutil.DateTime, error) {
+	return gqlutil.DateTimeOrNil(r.updatedAt), nil
 }

--- a/internal/codeintel/uploads/transport/graphql/utils.go
+++ b/internal/codeintel/uploads/transport/graphql/utils.go
@@ -2,10 +2,8 @@ package graphql
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -13,41 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
-
-// DateTime implements the DateTime GraphQL scalar type.
-type DateTime struct{ time.Time }
-
-// DateTimeOrNil is a helper function that returns nil for time == nil and otherwise wraps time in
-// DateTime.
-func DateTimeOrNil(time *time.Time) *DateTime {
-	if time == nil {
-		return nil
-	}
-	return &DateTime{Time: *time}
-}
-
-func (DateTime) ImplementsGraphQLType(name string) bool {
-	return name == "DateTime"
-}
-
-func (v DateTime) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.Time.Format(time.RFC3339))
-}
-
-func (v *DateTime) UnmarshalGraphQL(input any) error {
-	s, ok := input.(string)
-	if !ok {
-		return errors.Errorf("invalid GraphQL DateTime scalar value input (got %T, expected string)", input)
-	}
-	t, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return err
-	}
-	*v = DateTime{Time: t}
-	return nil
-}
 
 func unmarshalLSIFUploadGQLID(id graphql.ID) (uploadID int64, err error) {
 	// First, try to unmarshal the ID as a string and then convert it to an

--- a/internal/gqlutil/datetime.go
+++ b/internal/gqlutil/datetime.go
@@ -1,4 +1,4 @@
-package graphqlbackend
+package gqlutil
 
 import (
 	"encoding/json"

--- a/internal/gqlutil/datetime_test.go
+++ b/internal/gqlutil/datetime_test.go
@@ -1,4 +1,4 @@
-package graphqlbackend
+package gqlutil
 
 import (
 	"testing"


### PR DESCRIPTION
Since the new code intel pattern requires some of the `graphqlbackend` internals, but shouldn't import from a `cmd` directory, I've moved these into a separate internal package to get rid of 5x the same code duplicated across the codebase.



## Test plan

Just moved code, go compiler and test suite should find any issues.