### PR TITLE
sg.config.yaml: Add command enterprise-single-gitserver

### DIFF
--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -37,6 +37,7 @@ Available comamndsets in `sg.config.yaml`:
 * enterprise-codeinsights
 * enterprise-codeintel 🧠
 * enterprise-e2e
+* enterprise-single-gitserver
 * iam
 * monitoring
 * monitoring-alerts

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -809,6 +809,30 @@ commandsets:
       - zoekt-web-0
       - zoekt-web-1
 
+  enterprise-single-gitserver: &enterprise_set
+    requiresDevPrivate: true
+    checks:
+      - docker
+      - redis
+      - postgres
+      - git
+    commands:
+      - frontend
+      - worker
+      - repo-updater
+      - web
+      - gitserver-0
+      - searcher
+      - symbols
+      - caddy
+      - docsite
+      - syntax-highlighter
+      - github-proxy
+      - zoekt-index-0
+      - zoekt-index-1
+      - zoekt-web-0
+      - zoekt-web-1
+
   enterprise-e2e:
     <<: *enterprise_set
     env:

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -832,6 +832,8 @@ commandsets:
       - zoekt-index-1
       - zoekt-web-0
       - zoekt-web-1
+    env:
+      SRC_GIT_SERVERS: 127.0.0.1:3501
 
   enterprise-e2e:
     <<: *enterprise_set


### PR DESCRIPTION
For times when we explicitly want a single gitserver instance to ease debugging a very specific issue.

## Test plan

New command set for `sg start`. Tested that command works locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
