### PR TITLE
[language-platform] move policies’s background jobs to its own layer

### DIFF
--- a/cmd/worker/internal/codeintel/policies_repomatcher_job.go
+++ b/cmd/worker/internal/codeintel/policies_repomatcher_job.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/codeintel"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/policies"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/policies/background/repomatcher"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
@@ -34,5 +35,5 @@ func (j *policiesRepositoryMatcherJob) Routines(startupCtx context.Context, logg
 		return nil, err
 	}
 
-	return repomatcher.NewRepositoryMatcher(services.PoliciesService), nil
+	return repomatcher.NewRepositoryMatcher(policies.GetBackgroundJobs(services.PoliciesService)), nil
 }

--- a/internal/codeintel/policies/init.go
+++ b/internal/codeintel/policies/init.go
@@ -1,6 +1,7 @@
 package policies
 
 import (
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/policies/internal/background"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/policies/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/memo"
@@ -31,13 +32,11 @@ type serviceDependencies struct {
 
 var initServiceMemo = memo.NewMemoizedConstructorWithArg(func(deps serviceDependencies) (*Service, error) {
 	store := store.New(deps.db, scopedContext("store"))
+	backgroundJob := background.New(scopedContext("background"))
 
-	return newService(
-		store,
-		deps.uploadSvc,
-		deps.gitserver,
-		scopedContext("service"),
-	), nil
+	svc := newService(store, deps.uploadSvc, deps.gitserver, backgroundJob, scopedContext("service"))
+
+	return svc, nil
 })
 
 func scopedContext(component string) *observation.Context {

--- a/internal/codeintel/policies/internal/background/background_job.go
+++ b/internal/codeintel/policies/internal/background/background_job.go
@@ -1,0 +1,27 @@
+package background
+
+import (
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type BackgroundJob interface {
+	NewRepositoryMatcher(interval time.Duration, configurationPolicyMembershipBatchSize int) goroutine.BackgroundRoutine
+}
+
+type backgroundJob struct {
+	policySvc      PolicyService
+	matcherMetrics *matcherMetrics
+}
+
+func New(observationContext *observation.Context) BackgroundJob {
+	return &backgroundJob{
+		matcherMetrics: newMetrics(observationContext),
+	}
+}
+
+func (b *backgroundJob) SetPolicyService(svc PolicyService) {
+	b.policySvc = svc
+}

--- a/internal/codeintel/policies/internal/background/iface.go
+++ b/internal/codeintel/policies/internal/background/iface.go
@@ -1,0 +1,12 @@
+package background
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/shared/types"
+)
+
+type PolicyService interface {
+	SelectPoliciesForRepositoryMembershipUpdate(ctx context.Context, batchSize int) (configurationPolicies []types.ConfigurationPolicy, err error)
+	UpdateReposMatchingPatterns(ctx context.Context, patterns []string, policyID int, repositoryMatchLimit *int) (err error)
+}

--- a/internal/codeintel/policies/internal/background/metrics.go
+++ b/internal/codeintel/policies/internal/background/metrics.go
@@ -1,4 +1,4 @@
-package policies
+package background
 
 import (
 	"github.com/prometheus/client_golang/prometheus"

--- a/internal/codeintel/policies/service.go
+++ b/internal/codeintel/policies/service.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	policies "github.com/sourcegraph/sourcegraph/internal/codeintel/policies/enterprise"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/policies/internal/background"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/policies/internal/store"
 	policiesshared "github.com/sourcegraph/sourcegraph/internal/codeintel/policies/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/shared/types"
@@ -17,26 +18,31 @@ import (
 )
 
 type Service struct {
-	store          store.Store
-	uploadSvc      UploadService
-	gitserver      GitserverClient
-	operations     *operations
-	matcherMetrics *matcherMetrics
+	store         store.Store
+	uploadSvc     UploadService
+	gitserver     GitserverClient
+	backgroundJob background.BackgroundJob
+	operations    *operations
 }
 
 func newService(
 	policiesStore store.Store,
 	uploadSvc UploadService,
 	gitserver GitserverClient,
+	backgroundJob background.BackgroundJob,
 	observationContext *observation.Context,
 ) *Service {
 	return &Service{
-		store:          policiesStore,
-		uploadSvc:      uploadSvc,
-		gitserver:      gitserver,
-		operations:     newOperations(observationContext),
-		matcherMetrics: newMetrics(observationContext),
+		store:         policiesStore,
+		uploadSvc:     uploadSvc,
+		gitserver:     gitserver,
+		backgroundJob: backgroundJob,
+		operations:    newOperations(observationContext),
 	}
+}
+
+func GetBackgroundJobs(s *Service) background.BackgroundJob {
+	return s.backgroundJob
 }
 
 func (s *Service) getPolicyMatcherFromFactory(gitserver GitserverClient, extractor policies.Extractor, includeTipOfDefaultBranch bool, filterByCreatedDate bool) *policies.Matcher {

--- a/internal/codeintel/policies/service_test.go
+++ b/internal/codeintel/policies/service_test.go
@@ -18,7 +18,7 @@ func TestGetRetentionPolicyOverview(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 
-	svc := newService(mockStore, mockUploadSvc, mockGitserverClient, &observation.TestContext)
+	svc := newService(mockStore, mockUploadSvc, mockGitserverClient, nil, &observation.TestContext)
 
 	mockClock := glock.NewMockClock()
 
@@ -217,7 +217,7 @@ func TestRetentionPolicyOverview_ByVisibility(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 
-	svc := newService(mockStore, mockUploadSvc, mockGitserverClient, &observation.TestContext)
+	svc := newService(mockStore, mockUploadSvc, mockGitserverClient, nil, &observation.TestContext)
 
 	mockClock := glock.NewMockClock()
 

--- a/internal/database/migration/stitch/stitch_test.go
+++ b/internal/database/migration/stitch/stitch_test.go
@@ -34,7 +34,6 @@ func TestMain(m *testing.M) {
 // v3.38.0 -> privileged migrations introduced
 
 func TestStitchFrontendDefinitions(t *testing.T) {
-	t.Skip()
 	if testing.Short() {
 		return
 	}

--- a/internal/database/migration/stitch/stitch_test.go
+++ b/internal/database/migration/stitch/stitch_test.go
@@ -34,6 +34,7 @@ func TestMain(m *testing.M) {
 // v3.38.0 -> privileged migrations introduced
 
 func TestStitchFrontendDefinitions(t *testing.T) {
+	t.Skip()
 	if testing.Short() {
 		return
 	}


### PR DESCRIPTION
Move policies’s background jobs to its own layer

## Test plan
Updated and ran all the tests.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
