### PR TITLE
search ui: change copy query button glyph to match copy path button

### DIFF
--- a/client/search-ui/src/input/toggles/CopyQueryButton.tsx
+++ b/client/search-ui/src/input/toggles/CopyQueryButton.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef, useEffect } from 'react'
 
-import { mdiClipboardOutline } from '@mdi/js'
+import { mdiContentCopy } from '@mdi/js'
 import VisuallyHidden from '@reach/visually-hidden'
 import copy from 'copy-to-clipboard'
 import { Observable, merge, of } from 'rxjs'
@@ -55,7 +55,7 @@ export const CopyQueryButton: React.FunctionComponent<React.PropsWithChildren<Pr
                     aria-label={copyFullQueryTooltip}
                     onClick={nextClick}
                 >
-                    <Icon aria-hidden={true} svgPath={mdiClipboardOutline} />
+                    <Icon aria-hidden={true} svgPath={mdiContentCopy} />
                 </Button>
             </Tooltip>
             {fullCopyShortcut?.keybindings.map((keybinding, index) => (


### PR DESCRIPTION
The glyph in the copy query button [does not match](https://sourcegraph.slack.com/archives/C020S8AT3LN/p1665687035925439) the one used in the copy path button (in search results and blob pages). This fixes it.

![image](https://user-images.githubusercontent.com/206864/195718094-473fd904-752a-4369-b5c0-a5c6c515ab75.png)

![image](https://user-images.githubusercontent.com/206864/195718116-81d55de3-590c-4bc1-b7d1-797c35b447b7.png)

## Test plan

Verify with visual tests.

## App preview:

- [Web](https://sg-web-jp-copybutton.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-pvckjemjpr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
