### PR TITLE
executor: Add missing host header to reverse proxy

### DIFF
--- a/enterprise/cmd/executor/internal/worker/workspace/clone.go
+++ b/enterprise/cmd/executor/internal/worker/workspace/clone.go
@@ -211,6 +211,7 @@ func newGitProxyServer(endpointURL, gitServicePath, repositoryName, accessToken 
 		// clone tokens. This is mostly a gate to finding when we accidentally
 		// would access another repo.
 		if !strings.HasPrefix(r.URL.Path, "/"+repositoryName+"/") {
+			fmt.Printf("INVALID REQUEST: %q %q\n", r.URL.Path, repositoryName)
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}

--- a/enterprise/cmd/executor/internal/worker/workspace/clone.go
+++ b/enterprise/cmd/executor/internal/worker/workspace/clone.go
@@ -197,8 +197,7 @@ func newGitProxyServer(endpointURL, gitServicePath, repositoryName, accessToken 
 		Director: func(req *http.Request) {
 			d(req)
 
-			fmt.Printf("Post director\n")
-
+			req.Host = upstream.Host
 			// Add authentication. We don't add this in the git clone URL directly
 			// to never tell git about the clone secret.
 			req.Header.Set("Authorization", fmt.Sprintf("%s %s", SchemeExecutorToken, accessToken))

--- a/enterprise/cmd/executor/internal/worker/workspace/clone.go
+++ b/enterprise/cmd/executor/internal/worker/workspace/clone.go
@@ -197,11 +197,14 @@ func newGitProxyServer(endpointURL, gitServicePath, repositoryName, accessToken 
 		Director: func(req *http.Request) {
 			d(req)
 
+			fmt.Printf("Post director\n")
+
 			// Add authentication. We don't add this in the git clone URL directly
 			// to never tell git about the clone secret.
 			req.Header.Set("Authorization", fmt.Sprintf("%s %s", SchemeExecutorToken, accessToken))
 			req.Header.Set("X-Sourcegraph-Actor-UID", "internal")
 			req.URL.User = url.User("executor")
+			fmt.Printf("Req: %#+v\n", req)
 		},
 	}
 
@@ -210,7 +213,8 @@ func newGitProxyServer(endpointURL, gitServicePath, repositoryName, accessToken 
 		// This is _not_ a security measure, that should be handled by additional
 		// clone tokens. This is mostly a gate to finding when we accidentally
 		// would access another repo.
-		if !strings.HasPrefix(r.URL.Path, "/"+repositoryName+"/") {
+		fmt.Printf("Request: %q %q\n", r.URL.Path, repositoryName)
+		if strings.HasPrefix(r.URL.Path, "/"+repositoryName+"/") {
 			fmt.Printf("INVALID REQUEST: %q %q\n", r.URL.Path, repositoryName)
 			w.WriteHeader(http.StatusForbidden)
 			return

--- a/enterprise/cmd/executor/internal/worker/workspace/clone.go
+++ b/enterprise/cmd/executor/internal/worker/workspace/clone.go
@@ -214,7 +214,7 @@ func newGitProxyServer(endpointURL, gitServicePath, repositoryName, accessToken 
 		// clone tokens. This is mostly a gate to finding when we accidentally
 		// would access another repo.
 		fmt.Printf("Request: %q %q\n", r.URL.Path, repositoryName)
-		if strings.HasPrefix(r.URL.Path, "/"+repositoryName+"/") {
+		if !strings.HasPrefix(r.URL.Path, "/"+repositoryName+"/") {
 			fmt.Printf("INVALID REQUEST: %q %q\n", r.URL.Path, repositoryName)
 			w.WriteHeader(http.StatusForbidden)
 			return

--- a/enterprise/cmd/executor/internal/worker/workspace/clone.go
+++ b/enterprise/cmd/executor/internal/worker/workspace/clone.go
@@ -203,7 +203,6 @@ func newGitProxyServer(endpointURL, gitServicePath, repositoryName, accessToken 
 			req.Header.Set("Authorization", fmt.Sprintf("%s %s", SchemeExecutorToken, accessToken))
 			req.Header.Set("X-Sourcegraph-Actor-UID", "internal")
 			req.URL.User = url.User("executor")
-			fmt.Printf("Req: %#+v\n", req)
 		},
 	}
 
@@ -212,9 +211,7 @@ func newGitProxyServer(endpointURL, gitServicePath, repositoryName, accessToken 
 		// This is _not_ a security measure, that should be handled by additional
 		// clone tokens. This is mostly a gate to finding when we accidentally
 		// would access another repo.
-		fmt.Printf("Request: %q %q\n", r.URL.Path, repositoryName)
 		if !strings.HasPrefix(r.URL.Path, "/"+repositoryName+"/") {
-			fmt.Printf("INVALID REQUEST: %q %q\n", r.URL.Path, repositoryName)
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}


### PR DESCRIPTION
In k8s, the ingress controller directs the traffic to the right pod by inspecting the Host header. We need to set that for it to work properly.

## Test plan

Verified in a test vm.