### PR TITLE
nix: set REDIS_ENDPOINT envvar

### DIFF
--- a/dev/nix/start-redis.sh
+++ b/dev/nix/start-redis.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+export REDIS_ENDPOINT="127.0.0.1:6379"
+
 data="${SG_DATA_DIR:-$HOME/.sourcegraph}/redis"
 
 if [ ! -d "$data" ]; then


### PR DESCRIPTION
Some of our tests seem to depend on this environment variable being set. It not being set doesn't lead to them failing, but rather a lot of log spam. Setting this avoids the logspam.

Test Plan: go test ./internal/repos has less noise