### PR TITLE
repos: use fake token for GitHub webhook tests

### DIFF
--- a/cmd/frontend/webhooks/github_webhooks_test.go
+++ b/cmd/frontend/webhooks/github_webhooks_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	gh "github.com/google/go-github/v43/github"
@@ -123,7 +122,7 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 		DisplayName: "GitHub",
 		Config: extsvc.NewUnencryptedConfig(marshalJSON(t, &schema.GitHubConnection{
 			Url:      "https://github.com",
-			Token:    os.Getenv("GITHUB_TOKEN"),
+			Token:    "fake",
 			Repos:    []string{"sourcegraph/sourcegraph"},
 			Webhooks: []*schema.GitHubWebhook{{Org: "sourcegraph", Secret: secret}},
 		})),

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -2495,8 +2494,6 @@ func testEnqueueWebhookBuildJob(s repos.Store) func(*testing.T) {
 			},
 		}})
 
-		token := os.Getenv("GITHUB_TOKEN")
-
 		esStore := s.ExternalServiceStore()
 		repoStore := s.RepoStore()
 		workerStore := webhookworker.CreateWorkerStore(logger, s.Handle())
@@ -2511,7 +2508,7 @@ func testEnqueueWebhookBuildJob(s repos.Store) func(*testing.T) {
 
 		ghConn := &schema.GitHubConnection{
 			Url:      "https://github.com",
-			Token:    token,
+			Token:    "fake",
 			Repos:    []string{string(repo.Name)},
 			Webhooks: []*schema.GitHubWebhook{{Org: "ghe.sgdev.org", Secret: "secret"}},
 		}


### PR DESCRIPTION
We don't need a real token since it doesn't actually talk to GitHub. I noticed this since I didn't have GITHUB_TOKEN set in my devenv which lead to these tests failing.

Test Plan: go test ./...