### PR TITLE
insights: run TestInsightsMigrator even if DISABLE_CODE_INSIGHTS

### DIFF
--- a/enterprise/internal/oobmigration/migrations/insights/migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/insights/migrator_test.go
@@ -25,6 +25,10 @@ func TestInsightsMigrator(t *testing.T) {
 		t.Skip()
 	}
 
+	// We can still run this test even if a dev has disabled code insights in
+	// there env.
+	t.Setenv("DISABLE_CODE_INSIGHTS", "")
+
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	frontendDB := database.NewDB(logger, dbtest.NewDB(logger, t))


### PR DESCRIPTION
I had this test failing for me locally when doing "go test ./...". I had this envvar set. Rather than skipping the test, we can just ensure code insights are enabled for the test.

Test Plan: go test