### PR TITLE
nix: up max_connections and enforce no locale for postgres

### DIFF
--- a/dev/nix/start-postgres.sh
+++ b/dev/nix/start-postgres.sh
@@ -18,10 +18,11 @@ if [ ! -d "$PGHOST" ]; then
 fi
 if [ ! -d "$PGDATA" ]; then
   echo 'Initializing postgresql database...'
-  initdb "$PGDATA" --nosync -E UNICODE --auth=trust >/dev/null
+  initdb "$PGDATA" --nosync --encoding=UTF8 --no-locale --auth=trust >/dev/null
   cat <<-EOF >>"$PGDATA"/postgresql.conf
 	    unix_socket_directories = '$PGHOST'
 	    listen_addresses = 'localhost'
+	    max_connections = 250
 	    shared_buffers = 12MB
 	    fsync = off
 	    synchronous_commit = off


### PR DESCRIPTION
I had to do both of these to make "go test ./..." happy on my devenv.

Test Plan: go test ./... passes.
