### PR TITLE
ranking: send repo rank to zoekt

### DIFF
--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -173,7 +175,30 @@ func (h *searchIndexerServer) serveConfiguration(w http.ResponseWriter, r *http.
 			return string(commitID), err
 		}
 
-		priority := float64(repo.Stars) + repoRankFromConfig(siteConfig, string(repo.Name))
+		var priority float64
+
+		// We have to enable experimental ranking either for all or none of the repos.
+		// We cannot mix star-based priorities [0, inf] with ranks [0, 1], because in
+		// Zoekt, shards are sorted and searched based on their priority, and the rank
+		// and star-count are in principle not comparable.
+		if rankingEnabled, _ := strconv.ParseBool(os.Getenv("ENABLE_EXPERIMENTAL_RANKING")); rankingEnabled {
+			rankVec, err := h.codeIntelServices.RankingService.GetRepoRank(ctx, repo.Name)
+			if err != nil {
+				return nil, errors.Wrapf(err, "serveConfiguration: error getting repo rank")
+			}
+			// Hack: we take the first non-zero rank as priority. This is fine for now
+			// because, unlike documents, repos don't have categorical ranks like
+			// "generated" or "test" (yet). In the future we can persist the full ranking
+			// vector in the Zoekt shard.
+			for _, r := range rankVec {
+				if r > 0 {
+					priority = r
+					break
+				}
+			}
+		} else {
+			priority = float64(repo.Stars) + repoRankFromConfig(siteConfig, string(repo.Name))
+		}
 
 		return &searchbackend.RepoIndexOptions{
 			Name:       string(repo.Name),


### PR DESCRIPTION
DO NOT ENABLE THIS ON .COM, otherwise this will negatively impact the ranking of freshly indexed repos.

This is behind the same ENV variable (ENABLE_EXPERIMENTAL_RANKING) that the ranking service uses.

If enabled, frontend-internal returns the rank instead of the star-count in the RepoIndexOptions.

Alternatives considered:
We could send the ranking vector to Zoekt and persist it in the shard, maybe as part of rawConfig. However, this would require a slightly bigger change with pretty much the same effect, at least for the demo.

## Test plan
- Ran Sourcegraph locally and verified that priority was set as expected in the metadata of new shards.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
