### PR TITLE
Update ui/assets/.gitignore to ignore *.hot-update.json files

### DIFF
--- a/ui/assets/.gitignore
+++ b/ui/assets/.gitignore
@@ -9,3 +9,4 @@
 !img/**
 *.DS_Store
 stats.json
+*.hot-update.json


### PR DESCRIPTION
Whenever I run `yarn watch-web` I end up with a bunch of untracked `.hot-update.json` files in the `ui/assets` directory:

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	ui/assets/runtime.e769c685d3f89b2a9437.hot-update.json
```

It would be useful to also clean those up (i.e. remove them) automatically somehow.


## Test plan

n/a