### PR TITLE
web: use generated settings type

### DIFF
--- a/client/search-ui/src/components/FileSearchResult.test.tsx
+++ b/client/search-ui/src/components/FileSearchResult.test.tsx
@@ -74,7 +74,7 @@ describe('FileSearchResult', () => {
             subjects: [
                 {
                     lastID: 1,
-                    settings: { 'search.contextLines': '3' },
+                    settings: { 'search.contextLines': 3 },
                     extensions: null,
                     subject: {
                         __typename: 'User' as const,

--- a/client/shared/src/settings/settings.test.ts
+++ b/client/shared/src/settings/settings.test.ts
@@ -122,19 +122,19 @@ describe('mergeSettings', () => {
                     b?: { [key: string]: { [key: string]: string }[] }
                 } & Settings
             >([
-                { quicklinks: [{ name: 'main repo', value: '/github.com/org/main-repo' }] },
-                { quicklinks: [{ name: 'About Sourcegraph', value: 'https://docs.internal/about-sourcegraph' }] },
+                { quicklinks: [{ name: 'main repo', url: '/github.com/org/main-repo' }] },
+                { quicklinks: [{ name: 'About Sourcegraph', url: 'https://docs.internal/about-sourcegraph' }] },
                 {
                     quicklinks: [
-                        { name: 'mycorp extensions', value: 'https://sourcegraph.com/extensions?query=mycorp%2F' },
+                        { name: 'mycorp extensions', url: 'https://sourcegraph.com/extensions?query=mycorp%2F' },
                     ],
                 },
             ])
         ).toEqual({
             quicklinks: [
-                { name: 'main repo', value: '/github.com/org/main-repo' },
-                { name: 'About Sourcegraph', value: 'https://docs.internal/about-sourcegraph' },
-                { name: 'mycorp extensions', value: 'https://sourcegraph.com/extensions?query=mycorp%2F' },
+                { name: 'main repo', url: '/github.com/org/main-repo' },
+                { name: 'About Sourcegraph', url: 'https://docs.internal/about-sourcegraph' },
+                { name: 'mycorp extensions', url: 'https://sourcegraph.com/extensions?query=mycorp%2F' },
             ],
         }))
     test('merges search.repositoryGroups property', () =>
@@ -229,6 +229,7 @@ describe('mergeSettings', () => {
                 {
                     'search.savedQueries': [
                         {
+                            key: '1',
                             description: 'global saved query',
                             query: 'type:diff global',
                             notify: true,
@@ -238,6 +239,7 @@ describe('mergeSettings', () => {
                 {
                     'search.savedQueries': [
                         {
+                            key: '2',
                             description: 'org saved query',
                             query: 'type:diff org',
                             notify: true,
@@ -247,6 +249,7 @@ describe('mergeSettings', () => {
                 {
                     'search.savedQueries': [
                         {
+                            key: '3',
                             description: 'user saved query',
                             query: 'type:diff user',
                             notify: true,
@@ -257,16 +260,19 @@ describe('mergeSettings', () => {
         ).toEqual({
             'search.savedQueries': [
                 {
+                    key: '1',
                     description: 'global saved query',
                     query: 'type:diff global',
                     notify: true,
                 },
                 {
+                    key: '2',
                     description: 'org saved query',
                     query: 'type:diff org',
                     notify: true,
                 },
                 {
+                    key: '3',
                     description: 'user saved query',
                     query: 'type:diff user',
                     notify: true,

--- a/client/shared/src/settings/settings.ts
+++ b/client/shared/src/settings/settings.ts
@@ -3,6 +3,7 @@ import { cloneDeep, isFunction } from 'lodash'
 import { createAggregateError, ErrorLike, isErrorLike, parseJSONCOrError } from '@sourcegraph/common'
 
 import * as GQL from '../schema'
+import { Settings as GeneratedSettingsType } from '../schema/settings.schema'
 
 /**
  * A dummy type to represent the "subject" for client settings (i.e., settings stored in the client application,
@@ -17,28 +18,7 @@ export interface IClient {
 /**
  * A subset of the settings JSON Schema type containing the minimum needed by this library.
  */
-export interface Settings {
-    extensions?: { [extensionID: string]: boolean }
-    'codeIntel.referencesPanel'?: 'tree-view' | 'tabbed'
-    experimentalFeatures?: {
-        batchChangesExecution?: boolean
-        showSearchContext?: boolean
-        showSearchContextManagement?: boolean
-        fuzzyFinder?: boolean
-        fuzzyFinderAll?: boolean
-        fuzzyFinderCaseInsensitiveFileCountThreshold?: number
-        fuzzyFinderActions?: boolean
-        clientSearchResultRanking?: string
-        coolCodeIntel?: boolean
-        codeIntelRepositoryBadge?: {
-            enabled: boolean
-            forNerds?: boolean
-        }
-        enableGoImportsSearchQueryTransform?: boolean
-        enableLegacyExtensions?: boolean
-        enableLazyFileResultSyntaxHighlighting?: boolean
-        enableMergedFileSymbolSidebar?: boolean
-    }
+export interface Settings extends GeneratedSettingsType {
     [key: string]: any
 
     // These properties should never exist on Settings but do exist on SettingsCascade. This makes it so the

--- a/client/shared/src/settings/settings.ts
+++ b/client/shared/src/settings/settings.ts
@@ -16,7 +16,7 @@ export interface IClient {
 }
 
 /**
- * A subset of the settings JSON Schema type containing the minimum needed by this library.
+ * A JSON Settings Schema type containing properties to prevent its misuse in a place of SettingsCascade.
  */
 export interface Settings extends GeneratedSettingsType {
     [key: string]: any

--- a/client/shared/src/testing/searchTestHelpers.ts
+++ b/client/shared/src/testing/searchTestHelpers.ts
@@ -9,6 +9,7 @@ import { pretendProxySubscribable, pretendRemote } from '../api/util'
 import { Controller } from '../extensions/controller'
 import { PlatformContext } from '../platform/context'
 import { AggregateStreamingSearchResults, ContentMatch, RepositoryMatch } from '../search/stream'
+import { SettingsCascade } from '../settings/settings'
 
 export const RESULT: ContentMatch = {
     type: 'content',
@@ -602,10 +603,10 @@ export const HIGHLIGHTED_FILE_LINES_LONG_REQUEST = sinon.fake((parameters: Fetch
     of(parameters.ranges.map(range => HIGHLIGHTED_FILE_LINES_LONG[0].slice(range.startLine, range.endLine)))
 )
 
-export const NOOP_SETTINGS_CASCADE = {
+export const NOOP_SETTINGS_CASCADE = ({
     subjects: null,
     final: null,
-}
+} as any) as SettingsCascade
 
 export const extensionsController: Controller = {
     executeCommand: () => Promise.resolve(),

--- a/client/web/src/global/Notices.test.tsx
+++ b/client/web/src/global/Notices.test.tsx
@@ -25,7 +25,7 @@ describe('Notices', () => {
     test('no notices', () =>
         expect(
             renderWithBrandedContext(
-                <Notices location="home" settingsCascade={{ subjects: [], final: { notices: null } }} />
+                <Notices location="home" settingsCascade={{ subjects: [], final: { notices: undefined } }} />
             ).asFragment()
         ).toMatchSnapshot())
 })

--- a/client/web/src/open-in-editor/useOpenCurrentUrlInEditor.ts
+++ b/client/web/src/open-in-editor/useOpenCurrentUrlInEditor.ts
@@ -11,7 +11,7 @@ import { EditorSettings } from './editor-settings'
  * @returns A function to open the current location in your preferred editor
  */
 export const useOpenCurrentUrlInEditor = (): ((
-    editorSettings: EditorSettings,
+    editorSettings: EditorSettings | undefined,
     externalServiceType: string | undefined,
     sourcegraphURL: string,
     editorIndex?: number
@@ -19,7 +19,7 @@ export const useOpenCurrentUrlInEditor = (): ((
     const location = useLocation()
     return useCallback(
         (
-            editorSettings: EditorSettings,
+            editorSettings: EditorSettings | undefined,
             externalServiceType: string | undefined,
             sourcegraphURL: string,
             editorIndex = 0


### PR DESCRIPTION
## Context

We have [JSON schema for settings](https://github.com/sourcegraph/sourcegraph/blob/main/schema/settings.schema.json) and [already generate Typescript types from it](https://github.com/sourcegraph/sourcegraph/blob/main/client/shared/gulpfile.js#L165). But it's not used in [the global `Settings` type](https://github.com/sourcegraph/sourcegraph/blob/main/client/shared/src/settings/settings.ts#L20) we maintain manually. This PR replaces the hardcoded `Settings` type with the generated one.

## Test plan

CI ✅

## App preview:

- [Web](https://sg-web-vb-use-generated-settings-type.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-kdraqjeqau.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
