### PR TITLE
Revert "Revert "validate settings and site config in DB layer, not elsewhere (#42039)" (#42282)"

### DIFF
--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -172,12 +172,6 @@ func (r *schemaResolver) UpdateSiteConfiguration(ctx context.Context, args *stru
 		return false, errors.Errorf("blank site configuration is invalid (you can clear the site configuration by entering an empty JSON object: {})")
 	}
 
-	if problems, err := conf.ValidateSite(args.Input); err != nil {
-		return false, errors.Errorf("failed to validate site configuration: %w", err)
-	} else if len(problems) > 0 {
-		return false, errors.Errorf("site configuration is invalid: %s", strings.Join(problems, ","))
-	}
-
 	prev := conf.Raw()
 	unredacted, err := conf.UnredactSecrets(args.Input, prev)
 	if err != nil {

--- a/internal/database/conf.go
+++ b/internal/database/conf.go
@@ -3,11 +3,12 @@ package database
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"time"
 
 	"github.com/keegancsmith/sqlf"
-	"github.com/sourcegraph/jsonx"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/confdefaults"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -132,9 +133,11 @@ RETURNING %s -- siteConfigColumns
 `
 
 func (s *confStore) createIfUpToDate(ctx context.Context, lastID *int32, contents string) (*SiteConfig, error) {
-	// Validate JSON syntax before saving.
-	if _, errs := jsonx.Parse(contents, jsonx.ParseOptions{Comments: true, TrailingCommas: true}); len(errs) > 0 {
-		return nil, errors.Errorf("invalid settings JSON: %v", errs)
+	// Validate config for syntax and by the JSON Schema.
+	if problems, err := conf.ValidateSite(contents); err != nil {
+		return nil, errors.Errorf("failed to validate site configuration: %w", err)
+	} else if len(problems) > 0 {
+		return nil, errors.Errorf("site configuration is invalid: %s", strings.Join(problems, ","))
 	}
 
 	latest, err := s.getLatest(ctx)

--- a/internal/database/conf_test.go
+++ b/internal/database/conf_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
@@ -43,7 +45,7 @@ func TestSiteCreate_RejectInvalidJSON(t *testing.T) {
 
 	_, err := db.Conf().SiteCreateIfUpToDate(ctx, nil, malformedJSON)
 
-	if err == nil || !strings.Contains(err.Error(), "invalid settings JSON") {
+	if err == nil || !strings.Contains(err.Error(), "failed to parse JSON") {
 		t.Fatalf("expected parse error after creating configuration with malformed JSON, got: %+v", err)
 	}
 }
@@ -80,11 +82,11 @@ func TestSiteCreateIfUpToDate(t *testing.T) {
 				{
 					input{
 						lastID:   0,
-						contents: `"This is a test."`,
+						contents: `{"defaultRateLimit": 0,"auth.providers": []}`,
 					},
 					output{
 						ID:       2,
-						contents: `"This is a test."`,
+						contents: `{"defaultRateLimit": 0,"auth.providers": []}`,
 					},
 				},
 			},
@@ -95,21 +97,21 @@ func TestSiteCreateIfUpToDate(t *testing.T) {
 				{
 					input{
 						lastID:   0,
-						contents: `"This is the first one."`,
+						contents: `{"defaultRateLimit": 0,"auth.providers": []}`,
 					},
 					output{
 						ID:       2,
-						contents: `"This is the first one."`,
+						contents: `{"defaultRateLimit": 0,"auth.providers": []}`,
 					},
 				},
 				{
 					input{
 						lastID:   2,
-						contents: `"This is the second one."`,
+						contents: `{"defaultRateLimit": 1,"auth.providers": []}`,
 					},
 					output{
 						ID:       3,
-						contents: `"This is the second one."`,
+						contents: `{"defaultRateLimit": 1,"auth.providers": []}`,
 					},
 				},
 			},
@@ -120,22 +122,23 @@ func TestSiteCreateIfUpToDate(t *testing.T) {
 				{
 					input{
 						lastID:   0,
-						contents: `"This is the first one."`,
+						contents: `{"defaultRateLimit": 0,"auth.providers": []}`,
 					},
 					output{
 						ID:       2,
-						contents: `"This is the first one."`,
+						contents: `{"defaultRateLimit": 0,"auth.providers": []}`,
 					},
 				},
 				{
 					input{
-						lastID:   0,
-						contents: `"This configuration is now behind the first one, so it shouldn't be saved."`,
+						lastID: 0,
+						// This configuration is now behind the first one, so it shouldn't be saved
+						contents: `{"defaultRateLimit": 1,"auth.providers": []}`,
 					},
 					output{
 						ID:       2,
-						contents: `"This is the first one."`,
-						err:      ErrNewerEdit,
+						contents: `{"defaultRateLimit": 1,"auth.providers": []}`,
+						err:      errors.Append(ErrNewerEdit),
 					},
 				},
 			},
@@ -146,24 +149,29 @@ func TestSiteCreateIfUpToDate(t *testing.T) {
 				{
 					input{
 						lastID: 0,
-						contents: `{"fieldA": "valueA",
+						contents: `{"disableBuiltInSearches": true,
 
 // This is a comment.
-             "fieldB": "valueB",
+             "defaultRateLimit": 42,
+             "auth.providers": [],
 						}`,
 					},
 					output{
 						ID: 2,
-						contents: `{"fieldA": "valueA",
+						contents: `{"disableBuiltInSearches": true,
 
 // This is a comment.
-             "fieldB": "valueB",
+             "defaultRateLimit": 42,
+             "auth.providers": [],
 						}`,
 					},
 				},
 			},
 		},
 	} {
+		// we were running the same test all the time, see this gist for more information
+		// https://gist.github.com/posener/92a55c4cd441fc5e5e85f27bca008721
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			db := NewDB(logger, dbtest.NewDB(logger, t))
@@ -171,7 +179,7 @@ func TestSiteCreateIfUpToDate(t *testing.T) {
 			for _, p := range test.sequence {
 				output, err := db.Conf().SiteCreateIfUpToDate(ctx, &p.input.lastID, p.input.contents)
 				if err != nil {
-					if err == p.expected.err {
+					if errors.Is(err, p.expected.err) {
 						continue
 					}
 					t.Fatal(err)

--- a/internal/database/conf_test.go
+++ b/internal/database/conf_test.go
@@ -43,7 +43,7 @@ func TestSiteCreate_RejectInvalidJSON(t *testing.T) {
 
 	malformedJSON := "[This is malformed.}"
 
-	_, err := db.Conf().SiteCreateIfUpToDate(ctx, nil, malformedJSON)
+	_, err := db.Conf().SiteCreateIfUpToDate(ctx, nil, malformedJSON, false)
 
 	if err == nil || !strings.Contains(err.Error(), "failed to parse JSON") {
 		t.Fatalf("expected parse error after creating configuration with malformed JSON, got: %+v", err)
@@ -177,7 +177,7 @@ func TestSiteCreateIfUpToDate(t *testing.T) {
 			db := NewDB(logger, dbtest.NewDB(logger, t))
 			ctx := context.Background()
 			for _, p := range test.sequence {
-				output, err := db.Conf().SiteCreateIfUpToDate(ctx, &p.input.lastID, p.input.contents)
+				output, err := db.Conf().SiteCreateIfUpToDate(ctx, &p.input.lastID, p.input.contents, false)
 				if err != nil {
 					if errors.Is(err, p.expected.err) {
 						continue

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -3020,7 +3020,7 @@ func NewMockConfStore() *MockConfStore {
 			},
 		},
 		SiteCreateIfUpToDateFunc: &ConfStoreSiteCreateIfUpToDateFunc{
-			defaultHook: func(context.Context, *int32, string) (r0 *SiteConfig, r1 error) {
+			defaultHook: func(context.Context, *int32, string, bool) (r0 *SiteConfig, r1 error) {
 				return
 			},
 		},
@@ -3052,7 +3052,7 @@ func NewStrictMockConfStore() *MockConfStore {
 			},
 		},
 		SiteCreateIfUpToDateFunc: &ConfStoreSiteCreateIfUpToDateFunc{
-			defaultHook: func(context.Context, *int32, string) (*SiteConfig, error) {
+			defaultHook: func(context.Context, *int32, string, bool) (*SiteConfig, error) {
 				panic("unexpected invocation of MockConfStore.SiteCreateIfUpToDate")
 			},
 		},
@@ -3294,24 +3294,24 @@ func (c ConfStoreHandleFuncCall) Results() []interface{} {
 // SiteCreateIfUpToDate method of the parent MockConfStore instance is
 // invoked.
 type ConfStoreSiteCreateIfUpToDateFunc struct {
-	defaultHook func(context.Context, *int32, string) (*SiteConfig, error)
-	hooks       []func(context.Context, *int32, string) (*SiteConfig, error)
+	defaultHook func(context.Context, *int32, string, bool) (*SiteConfig, error)
+	hooks       []func(context.Context, *int32, string, bool) (*SiteConfig, error)
 	history     []ConfStoreSiteCreateIfUpToDateFuncCall
 	mutex       sync.Mutex
 }
 
 // SiteCreateIfUpToDate delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockConfStore) SiteCreateIfUpToDate(v0 context.Context, v1 *int32, v2 string) (*SiteConfig, error) {
-	r0, r1 := m.SiteCreateIfUpToDateFunc.nextHook()(v0, v1, v2)
-	m.SiteCreateIfUpToDateFunc.appendCall(ConfStoreSiteCreateIfUpToDateFuncCall{v0, v1, v2, r0, r1})
+func (m *MockConfStore) SiteCreateIfUpToDate(v0 context.Context, v1 *int32, v2 string, v3 bool) (*SiteConfig, error) {
+	r0, r1 := m.SiteCreateIfUpToDateFunc.nextHook()(v0, v1, v2, v3)
+	m.SiteCreateIfUpToDateFunc.appendCall(ConfStoreSiteCreateIfUpToDateFuncCall{v0, v1, v2, v3, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the SiteCreateIfUpToDate
 // method of the parent MockConfStore instance is invoked and the hook queue
 // is empty.
-func (f *ConfStoreSiteCreateIfUpToDateFunc) SetDefaultHook(hook func(context.Context, *int32, string) (*SiteConfig, error)) {
+func (f *ConfStoreSiteCreateIfUpToDateFunc) SetDefaultHook(hook func(context.Context, *int32, string, bool) (*SiteConfig, error)) {
 	f.defaultHook = hook
 }
 
@@ -3319,7 +3319,7 @@ func (f *ConfStoreSiteCreateIfUpToDateFunc) SetDefaultHook(hook func(context.Con
 // SiteCreateIfUpToDate method of the parent MockConfStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *ConfStoreSiteCreateIfUpToDateFunc) PushHook(hook func(context.Context, *int32, string) (*SiteConfig, error)) {
+func (f *ConfStoreSiteCreateIfUpToDateFunc) PushHook(hook func(context.Context, *int32, string, bool) (*SiteConfig, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3328,19 +3328,19 @@ func (f *ConfStoreSiteCreateIfUpToDateFunc) PushHook(hook func(context.Context, 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ConfStoreSiteCreateIfUpToDateFunc) SetDefaultReturn(r0 *SiteConfig, r1 error) {
-	f.SetDefaultHook(func(context.Context, *int32, string) (*SiteConfig, error) {
+	f.SetDefaultHook(func(context.Context, *int32, string, bool) (*SiteConfig, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ConfStoreSiteCreateIfUpToDateFunc) PushReturn(r0 *SiteConfig, r1 error) {
-	f.PushHook(func(context.Context, *int32, string) (*SiteConfig, error) {
+	f.PushHook(func(context.Context, *int32, string, bool) (*SiteConfig, error) {
 		return r0, r1
 	})
 }
 
-func (f *ConfStoreSiteCreateIfUpToDateFunc) nextHook() func(context.Context, *int32, string) (*SiteConfig, error) {
+func (f *ConfStoreSiteCreateIfUpToDateFunc) nextHook() func(context.Context, *int32, string, bool) (*SiteConfig, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3383,6 +3383,9 @@ type ConfStoreSiteCreateIfUpToDateFuncCall struct {
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
 	Arg2 string
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 bool
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *SiteConfig
@@ -3394,7 +3397,7 @@ type ConfStoreSiteCreateIfUpToDateFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ConfStoreSiteCreateIfUpToDateFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/database/settings.go
+++ b/internal/database/settings.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/keegancsmith/sqlf"
-	"github.com/sourcegraph/jsonx"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -47,12 +46,7 @@ func (s *settingsStore) Transact(ctx context.Context) (SettingsStore, error) {
 }
 
 func (o *settingsStore) CreateIfUpToDate(ctx context.Context, subject api.SettingsSubject, lastID *int32, authorUserID *int32, contents string) (latestSetting *api.Settings, err error) {
-	// Validate JSON syntax before saving.
-	if _, errs := jsonx.Parse(contents, jsonx.ParseOptions{Comments: true, TrailingCommas: true}); len(errs) > 0 {
-		return nil, errors.Errorf("invalid settings JSON: %v", errs)
-	}
-
-	// Validate setting schema
+	// Validate settings for syntax and by the JSON Schema.
 	if problems := conf.ValidateSettings(contents); len(problems) > 0 {
 		return nil, errors.Errorf("invalid settings: %s", strings.Join(problems, ","))
 	}

--- a/internal/database/settings_test.go
+++ b/internal/database/settings_test.go
@@ -115,7 +115,7 @@ func TestCreateIfUpToDate(t *testing.T) {
 
 	t.Run("syntactically invalid settings", func(t *testing.T) {
 		contents := `{`
-		wantErr := "invalid settings JSON: [CloseBraceExpected]"
+		wantErr := "invalid settings: failed to parse JSON: [CloseBraceExpected]"
 		_, err := db.Settings().CreateIfUpToDate(ctx, api.SettingsSubject{User: &u.ID}, nil, nil, contents)
 		if err == nil || err.Error() != wantErr {
 			t.Errorf("got err %q, want %q", err, wantErr)


### PR DESCRIPTION
This reverts commit 768f5349999128bddfc2fbdb6594d24ccb53586a.

This revives the PR
- #42039

## Test plan

Tested it out locally manually. It works ™️ 
Steps to repeat the test:

1. Use an incorrect site config, e.g. add `"foo": "bar"` somewhere to the site configuration json
2. Run `sg start enterprise`
3. You should see the following error in the logs:
```
[2022-10-14 17:23:2626.617629] [       frontend] fatal: failed to apply site config overrides: writing site config overrides to database: ConfStore.SiteCreateIfUpToDate: site configuration is invalid: (root): Additional property foo is not allowed
``` 
4. Fix the site config, remove the added invalid property
5. Try again to run `sg start enterprise`
6. Everything should work

