### PR TITLE
Add analytics to docs.sourcegraph.com

### DIFF
--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -15,7 +15,7 @@
 			<meta name="viewport" content="width=device-width, initial-scale=1" />
 			{{block "seo" . }}{{end}}
 			{{block "head" .}}{{end}}
-            <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "a3a591d105ce4bdc807d6cecfb925cad"}'></script><!-- End Cloudflare Web Analytics -->
+            <script defer data-domain="docs.sourcegraph.com" src="https://plausible.io/js/plausible.js"></script>
 		</head>
 
         <!-- Default to light theme if no JavaScript -->


### PR DESCRIPTION
This implements [Plausible analytics](https://plausible.io/docs.sourcegraph.com) on docs.sourcegraph.com as an analytics solution.

Currently, the Cloudflare script that is being removed in this PR was never configured and GTM was removed in [this PR](https://github.com/sourcegraph/sourcegraph/pull/39705/files).

## Test plan
- Ensure all tests pass and data is being tracked in production
