### PR TITLE
sg hack hour 14 oct

### DIFF
--- a/dev/sg/internal/run/command.go
+++ b/dev/sg/internal/run/command.go
@@ -32,6 +32,8 @@ type Command struct {
 	ExternalSecrets map[string]secrets.ExternalSecret `yaml:"external_secrets"`
 	Description     string                            `yaml:"description"`
 
+	w io.Writer
+
 	// ATTENTION: If you add a new field here, be sure to also handle that
 	// field in `Merge` (below).
 }
@@ -184,15 +186,15 @@ func startCmd(ctx context.Context, dir string, cmd Command, parentEnv map[string
 	logger := newCmdLogger(commandCtx, cmd.Name, std.Out.Output)
 	if cmd.IgnoreStdout {
 		std.Out.WriteLine(output.Styledf(output.StyleSuggestion, "Ignoring stdout of %s", cmd.Name))
-		stdoutWriter = sc.stdoutBuf
+		stdoutWriter = io.MultiWriter(sc.stdoutBuf, cmd.w)
 	} else {
-		stdoutWriter = io.MultiWriter(logger, sc.stdoutBuf)
+		stdoutWriter = io.MultiWriter(logger, sc.stdoutBuf, cmd.w)
 	}
 	if cmd.IgnoreStderr {
 		std.Out.WriteLine(output.Styledf(output.StyleSuggestion, "Ignoring stderr of %s", cmd.Name))
 		stderrWriter = sc.stderrBuf
 	} else {
-		stderrWriter = io.MultiWriter(logger, sc.stderrBuf)
+		stderrWriter = io.MultiWriter(logger, sc.stderrBuf, cmd.w)
 	}
 
 	if cmd.Preamble != "" {

--- a/dev/sg/internal/run/pid.go
+++ b/dev/sg/internal/run/pid.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-type pidFile struct {
+type PidFile struct {
 	Args    []string `json:"args"`
 	Pid     int      `json:"pid"`
 	LogFile string   `json:"logfile"`
@@ -37,7 +37,7 @@ func PidExistsWithArgs(args []string) (int, bool, error) {
 		}
 		defer f.Close()
 
-		var content pidFile
+		var content PidFile
 		if err := json.NewDecoder(f).Decode(&content); err != nil {
 			return 0, false, errors.Wrapf(err, "could not check pidfile %q", match)
 		}
@@ -111,7 +111,7 @@ func writePid(logfile string) error {
 	pidFileName := fmt.Sprintf("sg.pid.%d.json", os.Getpid())
 	pidFilePath := filepath.Join(homeDir, ".sourcegraph", pidFileName)
 
-	content := pidFile{
+	content := PidFile{
 		Args:    os.Args[1:],
 		Pid:     os.Getpid(),
 		LogFile: logfile,
@@ -152,13 +152,12 @@ func createLogFile() (*logFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	path := filepath.Join(homeDir, ".sourcegraph", "logs", f.Name())
 	closer := func() {
 		f.Close()
-		_ = os.Remove(path)
+		_ = os.Remove(f.Name())
 	}
 
 	// TODO clean
 	interrupt.Register(func() { os.Remove(f.Name()) })
-	return &logFile{w: f, closer: closer, path: path}, nil
+	return &logFile{w: f, closer: closer, path: f.Name()}, nil
 }

--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -75,8 +75,12 @@ func Commands(ctx context.Context, parentEnv map[string]string, verbose bool, cm
 
 	cmdNames := make(map[string]struct{}, len(cmds))
 
+	logFile, err := createLogFile()
+	defer logFile.closer()
+
 	for i, cmd := range cmds {
 		cmdNames[cmd.Name] = struct{}{}
+		cmd.w = logFile.w
 
 		wg.Add(1)
 
@@ -107,7 +111,7 @@ func Commands(ctx context.Context, parentEnv map[string]string, verbose bool, cm
 		return err
 	}
 
-	if err := writePid(); err != nil {
+	if err := writePid(logFile.path); err != nil {
 		return err
 	}
 

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -294,6 +294,7 @@ var sg = &cli.App{
 		installCommand,
 		funkyLogoCommand,
 		analyticsCommand,
+		logsCommand,
 	},
 	ExitErrHandler: func(cmd *cli.Context, err error) {
 		if err == nil {

--- a/dev/sg/sg_logs.go
+++ b/dev/sg/sg_logs.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/nxadm/tail"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var (
+	logsCommand = &cli.Command{
+		Name:   "logs",
+		Usage:  "",
+		Action: logsExec,
+	}
+)
+
+func logsExec(ctx *cli.Context) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return errors.Wrap(err, "could not check pidfiles")
+	}
+
+	pattern := filepath.Join(homeDir, ".sourcegraph", "sg.pid.*")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return errors.Wrap(err, "could not list pidfiles")
+	}
+
+	var tailFile *tail.Tail
+
+	for _, match := range matches {
+		f, err := os.Open(match)
+		if err != nil {
+			return errors.Wrapf(err, "could not check pidfile %q", match)
+		}
+		defer f.Close()
+
+		var content run.PidFile
+		if err := json.NewDecoder(f).Decode(&content); err != nil {
+			return errors.Wrapf(err, "could not check pidfile %q", match)
+		}
+
+		tailFile, err = tail.TailFile(content.LogFile, tail.Config{})
+		if err != nil {
+			return err
+		}
+		break
+	}
+
+	out := std.Out.Output
+
+	for lines := range tailFile.Lines {
+		if lines.Err != nil {
+			return lines.Err
+		}
+		out.Write(lines.Text)
+	}
+	tailFile.Wait() // this just waits ... it doesn't wait for MORE data
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -205,11 +205,11 @@ require (
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	go.opentelemetry.io/otel/metric v0.31.0 // indirect
 	go.uber.org/goleak v1.1.12 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )
 
 require github.com/hmarr/codeowners v0.4.0
@@ -219,6 +219,7 @@ require (
 	github.com/coreos/go-iptables v0.6.0
 	github.com/dcadenas/pagerank v0.0.0-20171013173705-af922e3ceea8
 	github.com/hashicorp/hcl v1.0.0
+	github.com/nxadm/tail v1.4.8
 	github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.13
 	github.com/prometheus/prometheus v0.37.1
 	go.opentelemetry.io/otel/exporters/jaeger v1.9.0


### PR DESCRIPTION
Tees the output of all commands into a `~/.sourcegraph/logs/sg.PID.logs` file that you can use to grep against. 

Perhaps we could have a `sg tail` command that takes that and prints it back so teammate can do things like `sg tail | grep gitserver` and only get the GitServer output as they originally mentionned. 

Perhaps it would be cool to keep the colors somehow. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Loosely tested locally 🫕