### PR TITLE
search ui: Continue to support line match rendering for VSCE backwards compatibility

### DIFF
--- a/client/search-ui/src/components/FileMatchChildren.test.tsx
+++ b/client/search-ui/src/components/FileMatchChildren.test.tsx
@@ -6,7 +6,7 @@ import sinon from 'sinon'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
 import {
-    RESULT,
+    CHUNK_MATCH_RESULT,
     HIGHLIGHTED_FILE_LINES_SIMPLE_REQUEST,
     NOOP_SETTINGS_CASCADE,
     HIGHLIGHTED_FILE_LINES,
@@ -37,7 +37,7 @@ const defaultProps = {
             endLine: 4,
         },
     ],
-    result: RESULT,
+    result: CHUNK_MATCH_RESULT,
     allMatches: true,
     subsetMatches: 10,
     fetchHighlightedFileLineRanges: HIGHLIGHTED_FILE_LINES_SIMPLE_REQUEST,

--- a/client/search-ui/src/components/FileSearchResult.test.tsx
+++ b/client/search-ui/src/components/FileSearchResult.test.tsx
@@ -10,7 +10,8 @@ import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
 import {
     HIGHLIGHTED_FILE_LINES_REQUEST,
     NOOP_SETTINGS_CASCADE,
-    RESULT,
+    CHUNK_MATCH_RESULT,
+    LINE_MATCH_RESULT,
 } from '@sourcegraph/shared/src/testing/searchTestHelpers'
 import '@sourcegraph/shared/dev/mockReactVisibilitySensor'
 
@@ -23,7 +24,19 @@ describe('FileSearchResult', () => {
     const defaultProps = {
         index: 0,
         location: history.location,
-        result: RESULT,
+        result: CHUNK_MATCH_RESULT,
+        icon: FileIcon,
+        onSelect: sinon.spy(),
+        expanded: true,
+        showAllMatches: true,
+        fetchHighlightedFileLineRanges: HIGHLIGHTED_FILE_LINES_REQUEST,
+        settingsCascade: NOOP_SETTINGS_CASCADE,
+        telemetryService: NOOP_TELEMETRY_SERVICE,
+    }
+    const lineMatchResultProps = {
+        index: 0,
+        location: history.location,
+        result: LINE_MATCH_RESULT,
         icon: FileIcon,
         onSelect: sinon.spy(),
         expanded: true,
@@ -35,6 +48,12 @@ describe('FileSearchResult', () => {
 
     it('renders one result container', () => {
         const { container } = renderWithBrandedContext(<FileSearchResult {...defaultProps} />)
+        expect(getByTestId(container, 'result-container')).toBeVisible()
+        expect(getAllByTestId(container, 'result-container').length).toBe(1)
+    })
+
+    it('renders one result container with legacy line match format', () => {
+        const { container } = renderWithBrandedContext(<FileSearchResult {...lineMatchResultProps} />)
         expect(getByTestId(container, 'result-container')).toBeVisible()
         expect(getAllByTestId(container, 'result-container').length).toBe(1)
     })

--- a/client/search-ui/src/components/FileSearchResult.tsx
+++ b/client/search-ui/src/components/FileSearchResult.tsx
@@ -148,7 +148,19 @@ export const FileSearchResult: React.FunctionComponent<React.PropsWithChildren<P
                       startLine: match.contentStart.line,
                       endLine: match.ranges[match.ranges.length - 1].end.line,
                       aggregableBadges: match.aggregableBadges,
-                  })) || []
+                  }))
+                || result.lineMatches?.map(match => ({
+                    highlightRanges: match.offsetAndLengths.map(offsetAndLength => ({
+                        startLine: match.lineNumber,
+                        startCharacter: offsetAndLength[0],
+                        endLine: match.lineNumber,
+                        endCharacter: offsetAndLength[0] + offsetAndLength[1],
+                    })),
+                    content: match.line,
+                    startLine: match.lineNumber,
+                    endLine: match.lineNumber,
+                    aggregableBadges: match.aggregableBadges,
+                })) || []
                 : [],
         [result]
     )

--- a/client/shared/src/testing/searchTestHelpers.ts
+++ b/client/shared/src/testing/searchTestHelpers.ts
@@ -10,7 +10,7 @@ import { Controller } from '../extensions/controller'
 import { PlatformContext } from '../platform/context'
 import { AggregateStreamingSearchResults, ContentMatch, RepositoryMatch } from '../search/stream'
 
-export const RESULT: ContentMatch = {
+export const CHUNK_MATCH_RESULT: ContentMatch = {
     type: 'content',
     path: '.travis.yml',
     repository: 'github.com/golang/oauth2',
@@ -36,6 +36,19 @@ export const RESULT: ContentMatch = {
                     },
                 },
             ],
+        },
+    ],
+}
+
+export const LINE_MATCH_RESULT: ContentMatch = {
+    type: 'content',
+    path: '.travis.yml',
+    repository: 'github.com/golang/oauth2',
+    lineMatches: [
+        {
+            line: '  - go test -v golang.org/x/oauth2/...',
+            lineNumber: 12,
+            offsetAndLengths: [[7, 4]],
         },
     ],
 }
@@ -329,7 +342,7 @@ export const SEARCH_RESULT: AggregateStreamingSearchResults = {
             kind: 'repo',
         },
     ],
-    results: [RESULT],
+    results: [CHUNK_MATCH_RESULT],
 }
 
 export const MULTIPLE_SEARCH_RESULT: AggregateStreamingSearchResults = {
@@ -340,7 +353,7 @@ export const MULTIPLE_SEARCH_RESULT: AggregateStreamingSearchResults = {
         skipped: [],
     },
     results: [
-        RESULT,
+        CHUNK_MATCH_RESULT,
         MULTIPLE_MATCH_RESULT,
         {
             type: 'content',
@@ -385,7 +398,7 @@ export const COLLAPSABLE_SEARCH_RESULT: AggregateStreamingSearchResults = {
         skipped: [],
     },
     results: [
-        RESULT,
+        CHUNK_MATCH_RESULT,
         MULTIPLE_MATCH_RESULT,
         {
             type: 'content',

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -19,7 +19,8 @@ import {
     HIGHLIGHTED_FILE_LINES_REQUEST,
     MULTIPLE_SEARCH_RESULT,
     REPO_MATCH_RESULT,
-    RESULT,
+    CHUNK_MATCH_RESULT,
+    LINE_MATCH_RESULT,
 } from '@sourcegraph/shared/src/testing/searchTestHelpers'
 
 import { AuthenticatedUser } from '../../auth'
@@ -157,7 +158,7 @@ describe('StreamingSearchResults', () => {
     it('should render correct components for file match and repository match', () => {
         const results: AggregateStreamingSearchResults = {
             ...streamingSearchResult,
-            results: [RESULT, REPO_MATCH_RESULT],
+            results: [CHUNK_MATCH_RESULT, REPO_MATCH_RESULT],
         }
         renderWrapper(<StreamingSearchResults {...defaultProps} streamSearch={() => of(results)} />)
         expect(screen.getAllByTestId('result-container').length).toBe(2)
@@ -165,6 +166,18 @@ describe('StreamingSearchResults', () => {
 
         expect(screen.getAllByTestId('result-container')[0]).toHaveAttribute('data-result-type', 'content')
         expect(screen.getAllByTestId('result-container')[1]).toHaveAttribute('data-result-type', 'repo')
+    })
+
+    it('should render correct components for file match using legacy line match format', () => {
+        const results: AggregateStreamingSearchResults = {
+            ...streamingSearchResult,
+            results: [LINE_MATCH_RESULT],
+        }
+
+        renderWrapper(<StreamingSearchResults {...defaultProps} streamSearch={() => of(results)} />)
+        expect(screen.getAllByTestId('result-container').length).toBe(1)
+
+        expect(screen.getAllByTestId('result-container')[0]).toHaveAttribute('data-result-type', 'content')
     })
 
     it('should log view, query, and results fetched events', () => {


### PR DESCRIPTION
Some clients, such as the VSCode extension, may have a Sourcegraph instance on an older version of the streaming API where chunk matches were not yet available. The FileSearchResult component will need to continue to support rendering line matches in such cases so that these clients are compatible with older versions of Sourcegraph.

## Test plan
Added unit tests 
Manually tested a query in the web app with `chunkMatches: true` set on the API request, then tested the same query with `chunkMatches: false` and verified that both rendered as expected

With `chunkMatches: true`:
![Screen Shot 2022-10-14 at 11 24 51 AM](https://user-images.githubusercontent.com/70350613/195895004-4133fcf2-d1a6-4d40-8313-a8ea59db31de.png)

With `chunkMatches: false`:

https://user-images.githubusercontent.com/70350613/195895450-c13454c2-239a-4e95-9d59-ee351a981cf1.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tl-render-linematches.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-drdgsoopxb.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
