### PR TITLE
ranking: Try out Aho-Corasick

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -198,6 +198,7 @@ require (
 require github.com/XSAM/otelsql v0.15.0
 
 require (
+	github.com/cloudflare/ahocorasick v0.0.0-20210425175752-730270c3e184 // indirect
 	github.com/cloudflare/circl v1.2.0 // indirect
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/emicklei/go-restful v2.16.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -431,6 +431,8 @@ github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudflare/ahocorasick v0.0.0-20210425175752-730270c3e184 h1:8yL+85JpbwrIc6m+7N1iYrjn/22z68jwrTIBOJHNe4k=
+github.com/cloudflare/ahocorasick v0.0.0-20210425175752-730270c3e184/go.mod h1:tGWUZLZp9ajsxUOnHmFFLnqnlKXsCn6GReG4jAD59H0=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cloudflare/circl v1.2.0 h1:NheeISPSUcYftKlfrLuOo4T62FkmD4t4jviLfFFYaec=
 github.com/cloudflare/circl v1.2.0/go.mod h1:Ch2UgYr6ti2KTtlejELlROl0YIYj7SLjAC8M+INXlMk=

--- a/internal/codeintel/ranking/file_reference_graph.go
+++ b/internal/codeintel/ranking/file_reference_graph.go
@@ -91,10 +91,6 @@ func (s *Service) buildFileReferenceGraph(ctx context.Context, repoName api.Repo
 			return nil
 		}
 
-		// isSymbolCharacter := func(r rune) bool {
-		// 	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_'
-		// }
-
 		emitted := map[string]struct{}{}
 		for _, matchingIndex := range matcher.Match(content) {
 			for _, path := range searchTermsAndPaths[matchingIndex].paths {
@@ -110,85 +106,6 @@ func (s *Service) buildFileReferenceGraph(ctx context.Context, repoName api.Repo
 				}
 			}
 		}
-
-		// // Build a list of index pairs indicating `[start, end)` ranges of words
-		// // that appear in the given content.
-		// indexes := []int{}
-
-		// for cursor := 0; cursor < len(content); {
-		// 	// Advance past non-symbol characters
-		// 	if !isSymbolCharacter(content[cursor]) {
-		// 		cursor++
-		// 		continue
-		// 	}
-
-		// 	// Here, the cursor points to the first symbol character in a word.
-		// 	// Mark this index (inclusive) as the start of the word. We'll add
-		// 	// the end index below.
-		// 	indexes = append(indexes, cursor)
-
-		// 	// Advance through all the symbol characters
-		// 	for cursor++; cursor < len(content); {
-		// 		if !isSymbolCharacter(content[cursor]) {
-		// 			break
-		// 		}
-
-		// 		cursor++
-		// 	}
-
-		// 	// Here, the cursor points to the first non-symbol character after the
-		// 	// previous word. Close the range started above by marking this index
-		// 	// (exclusive) as the end of the word.
-		// 	indexes = append(indexes, cursor)
-
-		// 	// Skip useless predicate re-check at the head of the loop
-		// 	cursor++
-		// }
-
-		// Search for each target symbol in the document by comparing it to each of
-		// the words we've identified above. Once we find a match we can emit edges
-		// relating to all of the associated paths and move on to the next symbol.
-
-		// emitted := map[string]struct{}{}
-		// for _, searchTermAndPaths := range searchTermsAndPaths {
-		// 	allEmitted := true
-		// 	for _, p := range searchTermAndPaths.paths {
-		// 		if _, ok := emitted[p]; !ok {
-		// 			allEmitted = false
-		// 			break
-		// 		}
-		// 	}
-		// 	if allEmitted {
-		// 		continue
-		// 	}
-
-		// 	symbol := searchTermAndPaths.symbol
-		// 	n := len(symbol)
-
-		// 	for i := 0; i < len(indexes); i += 2 {
-		// 		lo := indexes[i]
-		// 		hi := indexes[i+1]
-
-		// 		if hi-lo != n || string(content[lo:hi]) == symbol {
-		// 			continue
-		// 		}
-
-		// 		for _, path := range searchTermAndPaths.paths {
-		// 			if _, ok := emitted[path]; ok {
-		// 				continue
-		// 			}
-		// 			emitted[path] = struct{}{}
-
-		// 			select {
-		// 			case ch <- streamedEdge{from: h.Name, to: path}:
-		// 			case <-ctx.Done():
-		// 				return ctx.Err()
-		// 			}
-		// 		}
-
-		// 		break
-		// 	}
-		// }
 
 		return nil
 	}

--- a/internal/codeintel/ranking/file_reference_graph.go
+++ b/internal/codeintel/ranking/file_reference_graph.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/cloudflare/ahocorasick"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -65,6 +67,16 @@ func (s *Service) buildFileReferenceGraph(ctx context.Context, repoName api.Repo
 		}
 	}
 
+	symbolsMatcherByExtension := map[string]*ahocorasick.Matcher{}
+	for extension, searchTermsAndPaths := range searchTermsAndPathsByExtension {
+		var symbols []string
+		for _, searchTermAndPaths := range searchTermsAndPaths {
+			symbols = append(symbols, searchTermAndPaths.symbol)
+		}
+
+		symbolsMatcherByExtension[extension] = ahocorasick.NewStringMatcher(symbols)
+	}
+
 	extensions := make([]string, 0, len(searchTermsAndPathsByExtension))
 	for extension := range searchTermsAndPathsByExtension {
 		extensions = append(extensions, extension)
@@ -73,89 +85,110 @@ func (s *Service) buildFileReferenceGraph(ctx context.Context, repoName api.Repo
 	extractGraphEdges := func(h *tar.Header, content []byte) error {
 		extension := filepath.Ext(h.Name)
 		searchTermsAndPaths := searchTermsAndPathsByExtension[extension]
-
-		isSymbolCharacter := func(r byte) bool {
-			return ('a' <= r && r <= 'z') || ('A' <= r && r <= 'Z') || ('0' <= r && r <= '9') || (r == '_')
+		matcher, ok := symbolsMatcherByExtension[extension]
+		if !ok {
+			// WHY?
+			return nil
 		}
 
-		// Build a list of index pairs indicating `[start, end)` ranges of words
-		// that appear in the given content.
-		indexes := []int{}
+		// isSymbolCharacter := func(r rune) bool {
+		// 	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_'
+		// }
 
-		for cursor := 0; cursor < len(content); {
-			// Advance past non-symbol characters
-			if !isSymbolCharacter(content[cursor]) {
-				cursor++
-				continue
-			}
-
-			// Here, the cursor points to the first symbol character in a word.
-			// Mark this index (inclusive) as the start of the word. We'll add
-			// the end index below.
-			indexes = append(indexes, cursor)
-
-			// Advance through all the symbol characters
-			for cursor++; cursor < len(content); {
-				if !isSymbolCharacter(content[cursor]) {
-					break
+		emitted := map[string]struct{}{}
+		for _, matchingIndex := range matcher.Match(content) {
+			for _, path := range searchTermsAndPaths[matchingIndex].paths {
+				if _, ok := emitted[path]; ok {
+					continue
 				}
+				emitted[path] = struct{}{}
 
-				cursor++
+				select {
+				case ch <- streamedEdge{from: h.Name, to: path}:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
 			}
-
-			// Here, the cursor points to the first non-symbol character after the
-			// previous word. Close the range started above by marking this index
-			// (exclusive) as the end of the word.
-			indexes = append(indexes, cursor)
-
-			// Skip useless predicate re-check at the head of the loop
-			cursor++
 		}
+
+		// // Build a list of index pairs indicating `[start, end)` ranges of words
+		// // that appear in the given content.
+		// indexes := []int{}
+
+		// for cursor := 0; cursor < len(content); {
+		// 	// Advance past non-symbol characters
+		// 	if !isSymbolCharacter(content[cursor]) {
+		// 		cursor++
+		// 		continue
+		// 	}
+
+		// 	// Here, the cursor points to the first symbol character in a word.
+		// 	// Mark this index (inclusive) as the start of the word. We'll add
+		// 	// the end index below.
+		// 	indexes = append(indexes, cursor)
+
+		// 	// Advance through all the symbol characters
+		// 	for cursor++; cursor < len(content); {
+		// 		if !isSymbolCharacter(content[cursor]) {
+		// 			break
+		// 		}
+
+		// 		cursor++
+		// 	}
+
+		// 	// Here, the cursor points to the first non-symbol character after the
+		// 	// previous word. Close the range started above by marking this index
+		// 	// (exclusive) as the end of the word.
+		// 	indexes = append(indexes, cursor)
+
+		// 	// Skip useless predicate re-check at the head of the loop
+		// 	cursor++
+		// }
 
 		// Search for each target symbol in the document by comparing it to each of
 		// the words we've identified above. Once we find a match we can emit edges
 		// relating to all of the associated paths and move on to the next symbol.
 
-		emitted := map[string]struct{}{}
-		for _, searchTermAndPaths := range searchTermsAndPaths {
-			allEmitted := true
-			for _, p := range searchTermAndPaths.paths {
-				if _, ok := emitted[p]; !ok {
-					allEmitted = false
-					break
-				}
-			}
-			if allEmitted {
-				continue
-			}
+		// emitted := map[string]struct{}{}
+		// for _, searchTermAndPaths := range searchTermsAndPaths {
+		// 	allEmitted := true
+		// 	for _, p := range searchTermAndPaths.paths {
+		// 		if _, ok := emitted[p]; !ok {
+		// 			allEmitted = false
+		// 			break
+		// 		}
+		// 	}
+		// 	if allEmitted {
+		// 		continue
+		// 	}
 
-			symbol := searchTermAndPaths.symbol
-			n := len(symbol)
+		// 	symbol := searchTermAndPaths.symbol
+		// 	n := len(symbol)
 
-			for i := 0; i < len(indexes); i += 2 {
-				lo := indexes[i]
-				hi := indexes[i+1]
+		// 	for i := 0; i < len(indexes); i += 2 {
+		// 		lo := indexes[i]
+		// 		hi := indexes[i+1]
 
-				if hi-lo != n || string(content[lo:hi]) == symbol {
-					continue
-				}
+		// 		if hi-lo != n || string(content[lo:hi]) == symbol {
+		// 			continue
+		// 		}
 
-				for _, path := range searchTermAndPaths.paths {
-					if _, ok := emitted[path]; ok {
-						continue
-					}
-					emitted[path] = struct{}{}
+		// 		for _, path := range searchTermAndPaths.paths {
+		// 			if _, ok := emitted[path]; ok {
+		// 				continue
+		// 			}
+		// 			emitted[path] = struct{}{}
 
-					select {
-					case ch <- streamedEdge{from: h.Name, to: path}:
-					case <-ctx.Done():
-						return ctx.Err()
-					}
-				}
+		// 			select {
+		// 			case ch <- streamedEdge{from: h.Name, to: path}:
+		// 			case <-ctx.Done():
+		// 				return ctx.Err()
+		// 			}
+		// 		}
 
-				break
-			}
-		}
+		// 		break
+		// 	}
+		// }
 
 		return nil
 	}

--- a/internal/codeintel/ranking/indexer.go
+++ b/internal/codeintel/ranking/indexer.go
@@ -2,6 +2,7 @@ package ranking
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strconv"
 	"time"
@@ -50,6 +51,9 @@ func (s *Service) indexRepositories(ctx context.Context) (err error) {
 func (s *Service) indexRepository(ctx context.Context, repoName api.RepoName) (err error) {
 	_, _, endObservation := s.operations.indexRepository.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
+
+	start := time.Now()
+	defer func() { fmt.Printf("Finished indexing %s in %s\n", repoName, time.Since(start)) }()
 
 	graph, err := s.buildFileReferenceGraph(ctx, repoName)
 	if err != nil {

--- a/internal/codeintel/ranking/indexer_test.go
+++ b/internal/codeintel/ranking/indexer_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestIndexRepository(t *testing.T) {
-	t.Skip() // Flaky
-
 	ctx := context.Background()
 	mockStore := NewMockStore()
 	gitserverClient := NewMockGitserverClient()


### PR DESCRIPTION
Following up on https://github.com/sourcegraph/sourcegraph/pull/42931#pullrequestreview-1141880082 and https://github.com/sourcegraph/sourcegraph/pull/42931#discussion_r995387498.

This PR replaces some of the occurrence search machinery with Aho-Corasick for string search.

| repo                                 | old elapsed | new elapsed | delta           |
| ------------------------------------ | ----------- | ----------- | --------------- |
| github.com/hashicorp/errwrap         |  20.89ms    |  16.37ms    | 21.63% decrease |
| github.com/hashicorp/go-multierror   |  12.10ms    |  12.55ms    |  3.71% increase |
| github.com/sourcegraph/lsif-go       |  23.56ms    |  24.24ms    |  2.88% increase |
| github.com/sourcegraph-testing/etcd  | 106.92ms    | 105.79ms    |  1.05% decrease |
| github.com/sourcegraph-testing/tidb  |  89.54ms    | 100.78ms    | 12.55% increase |
| github.com/sourcegraph-testing/titan |  18.79ms    |  21.52ms    | 14.52% increase |
| github.com/sourcegraph-testing/zap   |  21.72ms    |  29.25ms    | 34.66% increase |
| github.com/sourcegraph/sourcegraph   | 149.12ms    | 218.26ms    | 46.36% increase |
| github.com/vishvananda/netlink       |  19.89ms    |  25.98ms    | 30.61% increase |

In the original approach, I split the _document_ into words over a linear pass, then compared those words against symbols. In this approach, I create a Aho-Corsaick trie out of the search symbols, then run it over the document. In both approaches we have a linear search over the document, but in the former we break all of the possible occurrences on word boundaries; on the later we only look for substrings. There is a difference in semantics here, and I'm sure we can account for that.

It's also slower, but we can probably optimize whatever is the issue here. I think the approach is probably sound if we can address the problem above.

## Test plan

N/A.