### PR TITLE
tracking-issue: tidy up sensitive data logging

### DIFF
--- a/internal/cmd/tracking-issue/README.md
+++ b/internal/cmd/tracking-issue/README.md
@@ -14,8 +14,6 @@ Usage of ./tracking-issue:
         GitHub organization to list issues from (default "sourcegraph")
   -token string
         GitHub personal access token (default "$GITHUB_TOKEN")
-  -verbose
-        If true, print the resulting tracking issue bodies to stdout
 ```
 
 ## Deployment
@@ -28,4 +26,4 @@ In order to deploy a new version, first run `docker build -t sourcegraph/trackin
 
 Run the tests with `go test`, update fixtures (i.e. GitHub issues and PRs data) with `go test -update.fixture` and update the generated tracking issue golden file with `go test -update`.
 
-You can also run the tool manually in `-dry` mode with `-verbose` output to visualize the resulting tracking issues without updating them on GitHub.
+You can also run the tool manually in `-dry` mode to visualize the resulting tracking issues without updating them on GitHub.

--- a/internal/cmd/tracking-issue/issue.go
+++ b/internal/cmd/tracking-issue/issue.go
@@ -9,18 +9,20 @@ import (
 )
 
 // Issue represents an existing GitHub Issue.
+//
+// 🚨 SECURITY: Issues may carry potentially sensitive data - log with care.
 type Issue struct {
-	ID                  string
-	Title               string
-	Body                string
-	Number              int
-	URL                 string
-	State               string
-	Repository          string
-	Private             bool
-	Labels              []string
-	Assignees           []string
-	Milestone           string
+	ID         string
+	Number     int
+	URL        string
+	State      string
+	Repository string
+	Assignees  []string
+
+	// 🚨 SECURITY: Private issues may carry potentially sensitive data - log with care,
+	// and check this field where relevant (e.g. SafeTitle, SafeLabels, etc)
+	Private bool
+
 	MilestoneNumber     int
 	Author              string
 	CreatedAt           time.Time
@@ -34,6 +36,11 @@ type Issue struct {
 	// Populate and get with .IdentifyingLabels()
 	identifyingLabels     []string
 	identifyingLabelsOnce sync.Once
+
+	// 🚨 SECURITY: Title, Body, Milestone, and Labels are potentially sensitive fields -
+	// log with care, and use SafeTitle, SafeLabels etc instead when rendering data.
+	Title, Body, Milestone string
+	Labels                 []string
 }
 
 func (issue *Issue) Closed() bool {

--- a/internal/cmd/tracking-issue/main.go
+++ b/internal/cmd/tracking-issue/main.go
@@ -10,8 +10,9 @@ import (
 	"strings"
 
 	"github.com/machinebox/graphql"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"golang.org/x/oauth2"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 const (
@@ -26,11 +27,10 @@ func main() {
 	token := flag.String("token", os.Getenv("GITHUB_TOKEN"), "GitHub personal access token")
 	org := flag.String("org", "sourcegraph", "GitHub organization to list issues from")
 	dry := flag.Bool("dry", false, "If true, do not update GitHub tracking issues in-place, but print them to stdout")
-	verbose := flag.Bool("verbose", false, "If true, print the resulting tracking issue bodies to stdout")
 
 	flag.Parse()
 
-	if err := run(*token, *org, *dry, *verbose); err != nil {
+	if err := run(*token, *org, *dry); err != nil {
 		if isRateLimitErr(err) {
 			log.Printf("Github API limit reached - soft failing. Err: %s\n", err)
 		} else {
@@ -48,7 +48,7 @@ func isRateLimitErr(err error) bool {
 	return strings.Contains(baseErr.Error(), "API rate limit exceeded")
 }
 
-func run(token, org string, dry, verbose bool) (err error) {
+func run(token, org string, dry bool) (err error) {
 	if token == "" {
 		return errors.Errorf("no -token given")
 	}
@@ -96,23 +96,19 @@ func run(token, org string, dry, verbose bool) (err error) {
 
 		updated, ok := trackingIssue.UpdateBody(RenderTrackingIssue(context))
 		if !ok {
-			log.Printf("failed to patch work section in %q %s", trackingIssue.Title, trackingIssue.URL)
+			log.Printf("failed to patch work section in %q %s", trackingIssue.SafeTitle(), trackingIssue.URL)
 			continue
 		}
 		if !updated {
-			log.Printf("%q %s not modified.", trackingIssue.Title, trackingIssue.URL)
+			log.Printf("%q %s not modified.", trackingIssue.SafeTitle(), trackingIssue.URL)
 			continue
 		}
 
 		if !dry {
-			log.Printf("%q %s modified", trackingIssue.Title, trackingIssue.URL)
+			log.Printf("%q %s modified", trackingIssue.SafeTitle(), trackingIssue.URL)
 			updatedTrackingIssues = append(updatedTrackingIssues, trackingIssue)
 		} else {
-			log.Printf("%q %s modified, but not updated due to -dry=true.", trackingIssue.Title, trackingIssue.URL)
-		}
-
-		if verbose {
-			log.Printf("%q %s body\n%s\n\n", trackingIssue.Title, trackingIssue.URL, trackingIssue.Body)
+			log.Printf("%q %s modified, but not updated due to -dry=true.", trackingIssue.SafeTitle(), trackingIssue.URL)
 		}
 	}
 


### PR DESCRIPTION
If the tracking-issue-bot user is granted access to private repos, it can currently emit potentially sensitive data. This updates callsites that log sensitive data and adds more docstrings about this matter.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Unit tests