### PR TITLE
Bump defaults for code intel auto indexing scheduling

### DIFF
--- a/doc/code_navigation/how-to/enable_auto_indexing.md
+++ b/doc/code_navigation/how-to/enable_auto_indexing.md
@@ -32,10 +32,10 @@ Once auto-indexing has been enabled, [create auto-indexing policies](configure_a
 
 The frequency of index job scheduling can be tuned via the following environment variables read by `worker` service containers running the [`codeintel-auto-indexing`](../../../admin/workers.md#codeintel-auto-indexing) task.
 
-**`PRECISE_CODE_INTEL_AUTO_INDEXING_TASK_INTERVAL`**: The frequency with which to run periodic codeintel auto-indexing tasks. Default is every 10 minutes.
+**`PRECISE_CODE_INTEL_AUTO_INDEXING_TASK_INTERVAL`**: The frequency with which to run periodic codeintel auto-indexing tasks. Default is every 2 minutes.
 
 **`PRECISE_CODE_INTEL_AUTO_INDEXING_REPOSITORY_PROCESS_DELAY`**: The minimum frequency that the same repository can be considered for auto-index scheduling. Default is every 24 hours.
 
-**`PRECISE_CODE_INTEL_AUTO_INDEXING_REPOSITORY_BATCH_SIZE`**: The number of repositories to consider for auto-indexing scheduling at a time. Default is 100.
+**`PRECISE_CODE_INTEL_AUTO_INDEXING_REPOSITORY_BATCH_SIZE`**: The number of repositories to consider for auto-indexing scheduling at a time. Default is 2500.
 
 **`PRECISE_CODE_INTEL_AUTO_INDEX_MAXIMUM_REPOSITORIES_INSPECTED_PER_SECOND`**: The maximum number of repositories inspected for auto-indexing per second. Set to zero to disable limit. Default is 0.

--- a/internal/codeintel/autoindexing/background/scheduler/config.go
+++ b/internal/codeintel/autoindexing/background/scheduler/config.go
@@ -26,9 +26,9 @@ func (c *config) Load() {
 	repositoryBatchSizeName := env.ChooseFallbackVariableName("CODEINTEL_AUTOINDEXING_SCHEDULER_REPOSITORY_BATCH_SIZE", "PRECISE_CODE_INTEL_AUTO_INDEXING_REPOSITORY_BATCH_SIZE")
 	policyBatchSizeName := env.ChooseFallbackVariableName("CODEINTEL_AUTOINDEXING_SCHEDULER_POLICY_BATCH_SIZE", "PRECISE_CODE_INTEL_AUTO_INDEXING_POLICY_BATCH_SIZE")
 
-	c.SchedulerInterval = c.GetInterval(intervalName, "10m", "How frequently to run the auto-indexing scheduling routine.")
+	c.SchedulerInterval = c.GetInterval(intervalName, "2m", "How frequently to run the auto-indexing scheduling routine.")
 	c.RepositoryProcessDelay = c.GetInterval(repositoryProcessDelayName, "24h", "The minimum frequency that the same repository can be considered for auto-index scheduling.")
-	c.RepositoryBatchSize = c.GetInt(repositoryBatchSizeName, "100", "The number of repositories to consider for auto-indexing scheduling at a time.")
+	c.RepositoryBatchSize = c.GetInt(repositoryBatchSizeName, "2500", "The number of repositories to consider for auto-indexing scheduling at a time.")
 	c.PolicyBatchSize = c.GetInt(policyBatchSizeName, "100", "The number of policies to consider for auto-indexing scheduling at a time.")
 
 	c.OnDemandSchedulerInterval = c.GetInterval("CODEINTEL_AUTOINDEXING_ON_DEMAND_SCHEDULER_INTERVAL", "30s", "How frequently to run the on-demand auto-indexing scheduling routine.")


### PR DESCRIPTION
From lots of testing on Sourcegraph.com, we feel confident that these higher numbers will not cause any issues and will eventually lead to much more up to date auto indexing data.



## Test plan

Proven on dotcom. 