### PR TITLE
Revert "insights: batch insert series points (#42025)"

### DIFF
--- a/doc/dev/background-information/sql/batch_operations.md
+++ b/doc/dev/background-information/sql/batch_operations.md
@@ -7,7 +7,7 @@ If a large number of rows are being inserted into the same table, use of a [batc
 The package provides many convenience functions, but basic usage is as follows. An inserter is created with a table name and a list of column names for which values will be supplied. Then, the `Insert` method is called for each row to be inserted. It is expected that the number of values supplied to each call to `Insert` matches the number of columns supplied at construction of the inserter. On each call to `Insert`, if the current batch is full, it will be prepared and sent to the database, leaving an empty batch for future operations. A final call to `Flush` will ensure that any remaining batched rows are sent to the database.
 
 ```go
-inserter := batch.NewInserter(ctx, db, batch.MaxNumPostgresParameters, "table", "col1", "col2", "col3" /* , ... */)
+inserter := batch.NewInserter(ctx, db, "table", "col1", "col2", "col3" /* , ... */)
 
 for /* ... */ {
     if err := inserter.Insert(ctx, val1, val2, val3 /* , ... */); err != nil {
@@ -54,7 +54,7 @@ Here, we defined the temporary table with the clause `ON COMMIT DROP`, which wil
 Next, create and use a batch inserter instance just as described in the previous section, but target the newly created temporary table. Only the columns that are defined on the temporary table need to be supplied when calling the `Insert` method.
 
 ```go
-inserter := batch.NewInserter(ctx, db, batch.MaxNumPostgresParameters, "temp_table", "col3", "col4")
+inserter := batch.NewInserter(ctx, db, "temp_table", "col3", "col4")
 
 for /* ... */ {
     if err := inserter.Insert(ctx, val3, val4); err != nil {

--- a/enterprise/internal/insights/background/historical_enqueuer_test.go
+++ b/enterprise/internal/insights/background/historical_enqueuer_test.go
@@ -110,6 +110,10 @@ func testHistoricalEnqueuer(t *testing.T, p *testParams) *testResults {
 		}
 		return 0, nil
 	})
+	insightsStore.RecordSeriesPointFunc.SetDefaultHook(func(ctx context.Context, args store.RecordSeriesPointArgs) error {
+		r.operations = append(r.operations, fmt.Sprintf("recordSeriesPoint(point=%v, repoName=%v)", args.Point.String(), *args.RepoName))
+		return nil
+	})
 
 	repoStore := NewMockRepoStore()
 	repos := map[api.RepoName]*types.Repo{}

--- a/enterprise/internal/insights/store/mocks_temp.go
+++ b/enterprise/internal/insights/store/mocks_temp.go
@@ -1598,6 +1598,9 @@ type MockInterface struct {
 	// CountDataFunc is an instance of a mock function object controlling
 	// the behavior of the method CountData.
 	CountDataFunc *InterfaceCountDataFunc
+	// RecordSeriesPointFunc is an instance of a mock function object
+	// controlling the behavior of the method RecordSeriesPoint.
+	RecordSeriesPointFunc *InterfaceRecordSeriesPointFunc
 	// RecordSeriesPointsFunc is an instance of a mock function object
 	// controlling the behavior of the method RecordSeriesPoints.
 	RecordSeriesPointsFunc *InterfaceRecordSeriesPointsFunc
@@ -1612,6 +1615,11 @@ func NewMockInterface() *MockInterface {
 	return &MockInterface{
 		CountDataFunc: &InterfaceCountDataFunc{
 			defaultHook: func(context.Context, CountDataOpts) (r0 int, r1 error) {
+				return
+			},
+		},
+		RecordSeriesPointFunc: &InterfaceRecordSeriesPointFunc{
+			defaultHook: func(context.Context, RecordSeriesPointArgs) (r0 error) {
 				return
 			},
 		},
@@ -1637,6 +1645,11 @@ func NewStrictMockInterface() *MockInterface {
 				panic("unexpected invocation of MockInterface.CountData")
 			},
 		},
+		RecordSeriesPointFunc: &InterfaceRecordSeriesPointFunc{
+			defaultHook: func(context.Context, RecordSeriesPointArgs) error {
+				panic("unexpected invocation of MockInterface.RecordSeriesPoint")
+			},
+		},
 		RecordSeriesPointsFunc: &InterfaceRecordSeriesPointsFunc{
 			defaultHook: func(context.Context, []RecordSeriesPointArgs) error {
 				panic("unexpected invocation of MockInterface.RecordSeriesPoints")
@@ -1656,6 +1669,9 @@ func NewMockInterfaceFrom(i Interface) *MockInterface {
 	return &MockInterface{
 		CountDataFunc: &InterfaceCountDataFunc{
 			defaultHook: i.CountData,
+		},
+		RecordSeriesPointFunc: &InterfaceRecordSeriesPointFunc{
+			defaultHook: i.RecordSeriesPoint,
 		},
 		RecordSeriesPointsFunc: &InterfaceRecordSeriesPointsFunc{
 			defaultHook: i.RecordSeriesPoints,
@@ -1771,6 +1787,111 @@ func (c InterfaceCountDataFuncCall) Args() []interface{} {
 // invocation.
 func (c InterfaceCountDataFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// InterfaceRecordSeriesPointFunc describes the behavior when the
+// RecordSeriesPoint method of the parent MockInterface instance is invoked.
+type InterfaceRecordSeriesPointFunc struct {
+	defaultHook func(context.Context, RecordSeriesPointArgs) error
+	hooks       []func(context.Context, RecordSeriesPointArgs) error
+	history     []InterfaceRecordSeriesPointFuncCall
+	mutex       sync.Mutex
+}
+
+// RecordSeriesPoint delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockInterface) RecordSeriesPoint(v0 context.Context, v1 RecordSeriesPointArgs) error {
+	r0 := m.RecordSeriesPointFunc.nextHook()(v0, v1)
+	m.RecordSeriesPointFunc.appendCall(InterfaceRecordSeriesPointFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the RecordSeriesPoint
+// method of the parent MockInterface instance is invoked and the hook queue
+// is empty.
+func (f *InterfaceRecordSeriesPointFunc) SetDefaultHook(hook func(context.Context, RecordSeriesPointArgs) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RecordSeriesPoint method of the parent MockInterface instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *InterfaceRecordSeriesPointFunc) PushHook(hook func(context.Context, RecordSeriesPointArgs) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *InterfaceRecordSeriesPointFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, RecordSeriesPointArgs) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *InterfaceRecordSeriesPointFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, RecordSeriesPointArgs) error {
+		return r0
+	})
+}
+
+func (f *InterfaceRecordSeriesPointFunc) nextHook() func(context.Context, RecordSeriesPointArgs) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *InterfaceRecordSeriesPointFunc) appendCall(r0 InterfaceRecordSeriesPointFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of InterfaceRecordSeriesPointFuncCall objects
+// describing the invocations of this function.
+func (f *InterfaceRecordSeriesPointFunc) History() []InterfaceRecordSeriesPointFuncCall {
+	f.mutex.Lock()
+	history := make([]InterfaceRecordSeriesPointFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// InterfaceRecordSeriesPointFuncCall is an object that describes an
+// invocation of method RecordSeriesPoint on an instance of MockInterface.
+type InterfaceRecordSeriesPointFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 RecordSeriesPointArgs
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c InterfaceRecordSeriesPointFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c InterfaceRecordSeriesPointFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }
 
 // InterfaceRecordSeriesPointsFunc describes the behavior when the

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -9,13 +9,13 @@ import (
 	"time"
 
 	"github.com/RoaringBitmap/roaring"
+
 	"github.com/keegancsmith/sqlf"
 
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/batch"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -24,6 +24,7 @@ import (
 // for actual API usage.
 type Interface interface {
 	SeriesPoints(ctx context.Context, opts SeriesPointsOpts) ([]SeriesPoint, error)
+	RecordSeriesPoint(ctx context.Context, v RecordSeriesPointArgs) error
 	RecordSeriesPoints(ctx context.Context, pts []RecordSeriesPointArgs) error
 	CountData(ctx context.Context, opts CountDataOpts) (int, error)
 }
@@ -481,6 +482,66 @@ type RecordSeriesPointArgs struct {
 	PersistMode PersistMode
 }
 
+// RecordSeriesPoint records a data point for the specfied series ID (which is a unique ID for the
+// series, not a DB table primary key ID).
+func (s *Store) RecordSeriesPoint(ctx context.Context, v RecordSeriesPointArgs) (err error) {
+	// Start transaction.
+	var txStore *basestore.Store
+	txStore, err = s.Store.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = txStore.Done(err) }()
+
+	if (v.RepoName != nil && v.RepoID == nil) || (v.RepoID != nil && v.RepoName == nil) {
+		return errors.New("RepoName and RepoID must be mutually specified")
+	}
+
+	// Upsert the repository name into a separate table, so we get a small ID we can reference
+	// many times from the series_points table without storing the repo name multiple times.
+	var repoNameID *int
+	if v.RepoName != nil {
+		repoNameIDValue, ok, err := basestore.ScanFirstInt(txStore.Query(ctx, sqlf.Sprintf(upsertRepoNameFmtStr, *v.RepoName, *v.RepoName)))
+		if err != nil {
+			return errors.Wrap(err, "upserting repo name ID")
+		}
+		if !ok {
+			return errors.Wrap(err, "repo name ID not found (this should never happen)")
+		}
+		repoNameID = &repoNameIDValue
+	}
+
+	tableName, err := getTableForPersistMode(v.PersistMode)
+	if err != nil {
+		return err
+	}
+
+	q := sqlf.Sprintf(
+		recordSeriesPointFmtstr,
+		sqlf.Sprintf(tableName),
+		v.SeriesID,         // series_id
+		v.Point.Time.UTC(), // time
+		v.Point.Value,      // value
+		v.RepoID,           // repo_id
+		repoNameID,         // repo_name_id
+		repoNameID,         // original_repo_name_id
+		v.Point.Capture,
+	)
+	// Insert the actual data point.
+	return txStore.Exec(ctx, q)
+}
+
+func getTableForPersistMode(mode PersistMode) (string, error) {
+	switch mode {
+	case RecordMode:
+		return recordingTable, nil
+	case SnapshotMode:
+		return snapshotsTable, nil
+	default:
+		return "", errors.Newf("unsupported insights series point persist mode: %v", mode)
+	}
+}
+
 // RecordSeriesPoints stores multiple data points atomically.
 func (s *Store) RecordSeriesPoints(ctx context.Context, pts []RecordSeriesPointArgs) (err error) {
 	tx, err := s.Transact(ctx)
@@ -489,58 +550,12 @@ func (s *Store) RecordSeriesPoints(ctx context.Context, pts []RecordSeriesPointA
 	}
 	defer func() { err = tx.Done(err) }()
 
-	tableColumns := []string{"series_id", "time", "value", "repo_id", "repo_name_id", "original_repo_name_id", "capture"}
-
-	// In our current use cases we should only ever use one of these for one function call, but this could change.
-	inserters := map[PersistMode]*batch.Inserter{
-		RecordMode:   batch.NewInserter(ctx, tx.Handle(), recordingTable, batch.MaxNumPostgresParameters, tableColumns...),
-		SnapshotMode: batch.NewInserter(ctx, tx.Handle(), snapshotsTable, batch.MaxNumPostgresParameters, tableColumns...),
-	}
-
 	for _, pt := range pts {
-		inserter, ok := inserters[pt.PersistMode]
-		if !ok {
-			return errors.Newf("unsupported insights series point persist mode: %v", pt.PersistMode)
-		}
-
-		if (pt.RepoName != nil && pt.RepoID == nil) || (pt.RepoID != nil && pt.RepoName == nil) {
-			return errors.New("RepoName and RepoID must be mutually specified")
-		}
-
-		// Upsert the repository name into a separate table, so we get a small ID we can reference
-		// many times from the series_points table without storing the repo name multiple times.
-		var repoNameID *int
-		if pt.RepoName != nil {
-			repoNameIDValue, ok, err := basestore.ScanFirstInt(tx.Query(ctx, sqlf.Sprintf(upsertRepoNameFmtStr, *pt.RepoName, *pt.RepoName)))
-			if err != nil {
-				return errors.Wrap(err, "upserting repo name ID")
-			}
-			if !ok {
-				return errors.Wrap(err, "repo name ID not found (this should never happen)")
-			}
-			repoNameID = &repoNameIDValue
-		}
-
-		if err := inserter.Insert(
-			ctx,
-			pt.SeriesID,         // series_id
-			pt.Point.Time.UTC(), // time
-			pt.Point.Value,      // value
-			pt.RepoID,           // repo_id
-			repoNameID,          // repo_name_id
-			repoNameID,          // original_repo_name_id
-			pt.Point.Capture,    // capture
-		); err != nil {
-			return errors.Wrap(err, "Insert")
+		// this is a pretty naive implementation, this can be refactored to reduce db calls
+		if err := s.RecordSeriesPoint(ctx, pt); err != nil {
+			return err
 		}
 	}
-
-	for _, inserter := range inserters {
-		if err := inserter.Flush(ctx); err != nil {
-			return errors.Wrap(err, "Flush")
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
This reverts commit a37ff4320da5ef7a3ce5ded779d06201d91a9249.

Reverting change due to an observed increase in db cpu after switching to batch inserts. 


## Test plan
revert
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
