### PR TITLE
codeintel: Move `committed_at` out of the hot path

### DIFF
--- a/internal/codeintel/uploads/backfill.go
+++ b/internal/codeintel/uploads/backfill.go
@@ -14,9 +14,8 @@ func (s *Service) NewCommittedAtBackfiller(interval time.Duration, batchSize int
 	}))
 }
 
-// backfillCommittedAtBatch calculates the committed_at value for a batch of upload records that do not have
-// this value set. This method is used to backfill old upload records prior to this value being reliably set
-// during processing.
+// backfillCommittedAtBatch calculates the commit dates for a batch of upload records that do not have this value
+// set. This method is used to backfill old upload records prior to this value being reliably set during processing.
 func (s *Service) backfillCommittedAtBatch(ctx context.Context, batchSize int) (err error) {
 	tx, err := s.store.Transact(ctx)
 	defer func() {

--- a/internal/codeintel/uploads/internal/store/store_commits.go
+++ b/internal/codeintel/uploads/internal/store/store_commits.go
@@ -255,11 +255,11 @@ type backfillIncompleteError struct {
 }
 
 func (e backfillIncompleteError) Error() string {
-	return fmt.Sprintf("repository %d has not yet completed its backfill of column committed_at", e.repositoryID)
+	return fmt.Sprintf("repository %d has not yet completed its backfill of commit dates", e.repositoryID)
 }
 
 // GetOldestCommitDate returns the oldest commit date for all uploads for the given repository. If there are no
-// non-nil values, a false-valued flag is returned. If there are any null values, the committed_at backfill job
+// non-nil values, a false-valued flag is returned. If there are any null values, the commit date backfill job
 // has not yet completed and an error is returned to prevent downstream expiration errors being made due to
 // outdated commit graph data.
 func (s *store) GetOldestCommitDate(ctx context.Context, repositoryID int) (_ time.Time, _ bool, err error) {
@@ -284,13 +284,14 @@ func (s *store) GetOldestCommitDate(ctx context.Context, repositoryID int) (_ ti
 // having pristine database.
 const getOldestCommitDateQuery = `
 SELECT
-	committed_at
-FROM lsif_uploads
+	cd.committed_at
+FROM lsif_uploads u
+LEFT JOIN codeintel_commit_dates cd ON cd.repository_id = u.repository_id AND cd.commit_bytea = decode(u.commit, 'hex')
 WHERE
-	repository_id = %s AND
-	state = 'completed' AND
-	(committed_at != '-infinity' OR committed_at IS NULL)
-ORDER BY committed_at NULLS FIRST
+	u.repository_id = %s AND
+	u.state = 'completed' AND
+	(cd.committed_at != '-infinity' OR cd.committed_at IS NULL)
+ORDER BY cd.committed_at NULLS FIRST
 LIMIT 1
 `
 

--- a/internal/codeintel/uploads/internal/store/store_commits_test.go
+++ b/internal/codeintel/uploads/internal/store/store_commits_test.go
@@ -187,7 +187,7 @@ func TestGetOldestCommitDate(t *testing.T) {
 		types.Upload{ID: 8, State: "completed", RepositoryID: 51},
 	)
 
-	if _, err := db.ExecContext(context.Background(), "UPDATE lsif_uploads SET committed_at = '-infinity' WHERE id = 3"); err != nil {
+	if err := store.UpdateCommittedAt(context.Background(), 50, makeCommit(3), "-infinity"); err != nil {
 		t.Fatalf("unexpected error updating commit date %s", err)
 	}
 

--- a/internal/codeintel/uploads/internal/store/store_uploads.go
+++ b/internal/codeintel/uploads/internal/store/store_uploads.go
@@ -173,7 +173,7 @@ rank() OVER (
 		u.repository_id, u.indexer, u.root
 	ORDER BY
 		-- Rank each grouped upload by the associated commit date
-		u.committed_at,
+		(SELECT cd.committed_at FROM codeintel_commit_dates cd WHERE cd.repository_id = u.repository_id AND cd.commit_bytea = decode(u.commit, 'hex')) NULLS LAST,
 		-- Break ties via the unique identifier
 		u.id
 )
@@ -820,7 +820,7 @@ LIMIT %s
 `
 
 // SourcedCommitsWithoutCommittedAt returns the repository and commits of uploads that do not have an
-// associated committed_at value.
+// associated commit date value.
 func (s *store) SourcedCommitsWithoutCommittedAt(ctx context.Context, batchSize int) (_ []shared.SourcedCommits, err error) {
 	ctx, _, endObservation := s.operations.sourcedCommitsWithoutCommittedAt.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("batchSize", batchSize),
@@ -837,9 +837,10 @@ func (s *store) SourcedCommitsWithoutCommittedAt(ctx context.Context, batchSize 
 
 const sourcedCommitsWithoutCommittedAtQuery = `
 SELECT u.repository_id, r.name, u.commit
-FROM lsif_uploads u
+FROM lsif_uploads uk
 JOIN repo r ON r.id = u.repository_id
-WHERE u.state = 'completed' AND u.committed_at IS NULL
+LEFT JOIN codeintel_commit_dates cd ON cd.repository_id = u.repository_id AND cd.commit_bytea = decode(u.commit, 'hex')
+WHERE u.state = 'completed' AND cd.committed_at IS NULL
 GROUP BY u.repository_id, r.name, u.commit
 ORDER BY repository_id, commit
 LIMIT %s
@@ -853,11 +854,11 @@ func (s *store) UpdateCommittedAt(ctx context.Context, repositoryID int, commit,
 	}})
 	defer func() { endObservation(1, observation.Args{}) }()
 
-	return s.db.Exec(ctx, sqlf.Sprintf(updateCommittedAtQuery, commitDateString, repositoryID, commit))
+	return s.db.Exec(ctx, sqlf.Sprintf(updateCommittedAtQuery, repositoryID, dbutil.CommitBytea(commit), commitDateString))
 }
 
 const updateCommittedAtQuery = `
-UPDATE lsif_uploads SET committed_at = %s WHERE state = 'completed' AND repository_id = %s AND commit = %s AND committed_at IS NULL
+INSERT INTO codeintel_commit_dates(repository_id, commit_bytea, committed_at) VALUES (%s, %s, %s) ON CONFLICT DO NOTHING
 `
 
 var deltaMap = map[shared.DependencyReferenceCountUpdateType]int{

--- a/internal/codeintel/uploads/internal/store/store_uploads.go
+++ b/internal/codeintel/uploads/internal/store/store_uploads.go
@@ -837,7 +837,7 @@ func (s *store) SourcedCommitsWithoutCommittedAt(ctx context.Context, batchSize 
 
 const sourcedCommitsWithoutCommittedAtQuery = `
 SELECT u.repository_id, r.name, u.commit
-FROM lsif_uploads uk
+FROM lsif_uploads u
 JOIN repo r ON r.id = u.repository_id
 LEFT JOIN codeintel_commit_dates cd ON cd.repository_id = u.repository_id AND cd.commit_bytea = decode(u.commit, 'hex')
 WHERE u.state = 'completed' AND cd.committed_at IS NULL

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -6298,15 +6298,15 @@
         {
           "Name": "committed_at",
           "Index": 3,
-          "TypeName": "text",
-          "IsNullable": false,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": true,
           "Default": "",
           "CharacterMaximumLength": 0,
           "IsIdentity": false,
           "IdentityGeneration": "",
           "IsGenerated": "NEVER",
           "GenerationExpression": "",
-          "Comment": "The commit date string (formatted as RFC 3339; may be -infinity if unresolvable)."
+          "Comment": "The commit date (may be -infinity if unresolvable)."
         },
         {
           "Name": "repository_id",

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -6279,6 +6279,65 @@
       "Triggers": []
     },
     {
+      "Name": "codeintel_commit_dates",
+      "Comment": "Maps commits within a repository to the commit date as reported by gitserver.",
+      "Columns": [
+        {
+          "Name": "commit_bytea",
+          "Index": 2,
+          "TypeName": "bytea",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "Identifies the 40-character commit hash."
+        },
+        {
+          "Name": "committed_at",
+          "Index": 3,
+          "TypeName": "text",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "The commit date string (formatted as RFC 3339; may be -infinity if unresolvable)."
+        },
+        {
+          "Name": "repository_id",
+          "Index": 1,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "Identifies a row in the `repo` table."
+        }
+      ],
+      "Indexes": [
+        {
+          "Name": "codeintel_commit_dates_pkey",
+          "IsPrimaryKey": true,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX codeintel_commit_dates_pkey ON codeintel_commit_dates USING btree (repository_id, commit_bytea)",
+          "ConstraintType": "p",
+          "ConstraintDefinition": "PRIMARY KEY (repository_id, commit_bytea)"
+        }
+      ],
+      "Constraints": null,
+      "Triggers": []
+    },
+    {
       "Name": "codeintel_inference_scripts",
       "Comment": "Contains auto-index job inference Lua scripts as an alternative to setting via environment variables.",
       "Columns": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -754,11 +754,11 @@ Indexes:
 
 # Table "public.codeintel_commit_dates"
 ```
-    Column     |  Type   | Collation | Nullable | Default 
----------------+---------+-----------+----------+---------
- repository_id | integer |           | not null | 
- commit_bytea  | bytea   |           | not null | 
- committed_at  | text    |           | not null | 
+    Column     |           Type           | Collation | Nullable | Default 
+---------------+--------------------------+-----------+----------+---------
+ repository_id | integer                  |           | not null | 
+ commit_bytea  | bytea                    |           | not null | 
+ committed_at  | timestamp with time zone |           |          | 
 Indexes:
     "codeintel_commit_dates_pkey" PRIMARY KEY, btree (repository_id, commit_bytea)
 
@@ -768,7 +768,7 @@ Maps commits within a repository to the commit date as reported by gitserver.
 
 **commit_bytea**: Identifies the 40-character commit hash.
 
-**committed_at**: The commit date string (formatted as RFC 3339; may be -infinity if unresolvable).
+**committed_at**: The commit date (may be -infinity if unresolvable).
 
 **repository_id**: Identifies a row in the `repo` table.
 

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -752,6 +752,26 @@ Indexes:
 
 ```
 
+# Table "public.codeintel_commit_dates"
+```
+    Column     |  Type   | Collation | Nullable | Default 
+---------------+---------+-----------+----------+---------
+ repository_id | integer |           | not null | 
+ commit_bytea  | bytea   |           | not null | 
+ committed_at  | text    |           | not null | 
+Indexes:
+    "codeintel_commit_dates_pkey" PRIMARY KEY, btree (repository_id, commit_bytea)
+
+```
+
+Maps commits within a repository to the commit date as reported by gitserver.
+
+**commit_bytea**: Identifies the 40-character commit hash.
+
+**committed_at**: The commit date string (formatted as RFC 3339; may be -infinity if unresolvable).
+
+**repository_id**: Identifies a row in the `repo` table.
+
 # Table "public.codeintel_inference_scripts"
 ```
       Column      |           Type           | Collation | Nullable | Default 

--- a/migrations/frontend/1665770699_add_codeintel_commit_dates/down.sql
+++ b/migrations/frontend/1665770699_add_codeintel_commit_dates/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS codeintel_commit_dates;

--- a/migrations/frontend/1665770699_add_codeintel_commit_dates/metadata.yaml
+++ b/migrations/frontend/1665770699_add_codeintel_commit_dates/metadata.yaml
@@ -1,0 +1,2 @@
+name: Add codeintel_commit_dates
+parents: [1665420690, 1665488828, 1665524865, 1665588249]

--- a/migrations/frontend/1665770699_add_codeintel_commit_dates/up.sql
+++ b/migrations/frontend/1665770699_add_codeintel_commit_dates/up.sql
@@ -4,3 +4,11 @@ CREATE TABLE IF NOT EXISTS codeintel_commit_dates(
     committed_at text NOT NULL,
     PRIMARY KEY(repository_id, commit_bytea)
 );
+
+COMMENT ON TABLE codeintel_commit_dates IS 'Maps commits within a repository to the commit date as reported by gitserver.';
+
+COMMENT ON COLUMN codeintel_commit_dates.repository_id IS 'Identifies a row in the `repo` table.';
+
+COMMENT ON COLUMN codeintel_commit_dates.commit_bytea IS 'Identifies the 40-character commit hash.';
+
+COMMENT ON COLUMN codeintel_commit_dates.committed_at IS 'The commit date string (formatted as RFC 3339; may be -infinity if unresolvable).';

--- a/migrations/frontend/1665770699_add_codeintel_commit_dates/up.sql
+++ b/migrations/frontend/1665770699_add_codeintel_commit_dates/up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS codeintel_commit_dates(
+    repository_id integer NOT NULL,
+    commit_bytea bytea NOT NULL,
+    committed_at text NOT NULL,
+    PRIMARY KEY(repository_id, commit_bytea)
+);

--- a/migrations/frontend/1665770699_add_codeintel_commit_dates/up.sql
+++ b/migrations/frontend/1665770699_add_codeintel_commit_dates/up.sql
@@ -12,3 +12,17 @@ COMMENT ON COLUMN codeintel_commit_dates.repository_id IS 'Identifies a row in t
 COMMENT ON COLUMN codeintel_commit_dates.commit_bytea IS 'Identifies the 40-character commit hash.';
 
 COMMENT ON COLUMN codeintel_commit_dates.committed_at IS 'The commit date (may be -infinity if unresolvable).';
+
+INSERT INTO
+    codeintel_commit_dates (repository_id, commit_bytea, committed_at)
+SELECT
+    u.repository_id,
+    decode(u.commit, 'hex'),
+    MIN(u.committed_at)
+FROM
+    lsif_uploads u
+WHERE
+    u.committed_at IS NOT NULL
+GROUP BY
+    u.repository_id,
+    u.commit;

--- a/migrations/frontend/1665770699_add_codeintel_commit_dates/up.sql
+++ b/migrations/frontend/1665770699_add_codeintel_commit_dates/up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS codeintel_commit_dates(
     repository_id integer NOT NULL,
     commit_bytea bytea NOT NULL,
-    committed_at text NOT NULL,
+    committed_at timestamp with time zone,
     PRIMARY KEY(repository_id, commit_bytea)
 );
 
@@ -11,4 +11,4 @@ COMMENT ON COLUMN codeintel_commit_dates.repository_id IS 'Identifies a row in t
 
 COMMENT ON COLUMN codeintel_commit_dates.commit_bytea IS 'Identifies the 40-character commit hash.';
 
-COMMENT ON COLUMN codeintel_commit_dates.committed_at IS 'The commit date string (formatted as RFC 3339; may be -infinity if unresolvable).';
+COMMENT ON COLUMN codeintel_commit_dates.committed_at IS 'The commit date (may be -infinity if unresolvable).';

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -1466,6 +1466,20 @@ CREATE SEQUENCE codeintel_autoindex_queue_id_seq
 
 ALTER SEQUENCE codeintel_autoindex_queue_id_seq OWNED BY codeintel_autoindex_queue.id;
 
+CREATE TABLE codeintel_commit_dates (
+    repository_id integer NOT NULL,
+    commit_bytea bytea NOT NULL,
+    committed_at text NOT NULL
+);
+
+COMMENT ON TABLE codeintel_commit_dates IS 'Maps commits within a repository to the commit date as reported by gitserver.';
+
+COMMENT ON COLUMN codeintel_commit_dates.repository_id IS 'Identifies a row in the `repo` table.';
+
+COMMENT ON COLUMN codeintel_commit_dates.commit_bytea IS 'Identifies the 40-character commit hash.';
+
+COMMENT ON COLUMN codeintel_commit_dates.committed_at IS 'The commit date string (formatted as RFC 3339; may be -infinity if unresolvable).';
+
 CREATE TABLE codeintel_inference_scripts (
     insert_timestamp timestamp with time zone DEFAULT now() NOT NULL,
     script text NOT NULL
@@ -3803,6 +3817,9 @@ ALTER TABLE ONLY cm_webhooks
 
 ALTER TABLE ONLY codeintel_autoindex_queue
     ADD CONSTRAINT codeintel_autoindex_queue_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY codeintel_commit_dates
+    ADD CONSTRAINT codeintel_commit_dates_pkey PRIMARY KEY (repository_id, commit_bytea);
 
 ALTER TABLE ONLY codeintel_lockfile_references
     ADD CONSTRAINT codeintel_lockfile_references_pkey PRIMARY KEY (id);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -1469,7 +1469,7 @@ ALTER SEQUENCE codeintel_autoindex_queue_id_seq OWNED BY codeintel_autoindex_que
 CREATE TABLE codeintel_commit_dates (
     repository_id integer NOT NULL,
     commit_bytea bytea NOT NULL,
-    committed_at text NOT NULL
+    committed_at timestamp with time zone
 );
 
 COMMENT ON TABLE codeintel_commit_dates IS 'Maps commits within a repository to the commit date as reported by gitserver.';
@@ -1478,7 +1478,7 @@ COMMENT ON COLUMN codeintel_commit_dates.repository_id IS 'Identifies a row in t
 
 COMMENT ON COLUMN codeintel_commit_dates.commit_bytea IS 'Identifies the 40-character commit hash.';
 
-COMMENT ON COLUMN codeintel_commit_dates.committed_at IS 'The commit date string (formatted as RFC 3339; may be -infinity if unresolvable).';
+COMMENT ON COLUMN codeintel_commit_dates.committed_at IS 'The commit date (may be -infinity if unresolvable).';
 
 CREATE TABLE codeintel_inference_scripts (
     insert_timestamp timestamp with time zone DEFAULT now() NOT NULL,


### PR DESCRIPTION
This PR breaks the `committed_at` dates on `lsif_uploads` into a new table. Fixes #42997.

## Test plan

Tested locally, modified unit tests to match new expected behavior.