### PR TITLE
Search: Fix search tip tooltip layout and active state

### DIFF
--- a/client/search-ui/src/input/SearchButton.module.scss
+++ b/client/search-ui/src/input/SearchButton.module.scss
@@ -12,3 +12,7 @@
         border-radius: var(--border-radius);
     }
 }
+
+.help-button {
+    margin-left: 0.25rem;
+}

--- a/client/search-ui/src/input/SearchButton.tsx
+++ b/client/search-ui/src/input/SearchButton.tsx
@@ -38,7 +38,11 @@ export const SearchButton: React.FunctionComponent<React.PropsWithChildren<Props
             <Icon aria-hidden="true" svgPath={mdiMagnify} />
         </Button>
         {!hideHelpButton && (
-            <SearchHelpDropdownButton isSourcegraphDotCom={isSourcegraphDotCom} telemetryService={telemetryService} />
+            <SearchHelpDropdownButton
+                isSourcegraphDotCom={isSourcegraphDotCom}
+                className={styles.helpButton}
+                telemetryService={telemetryService}
+            />
         )}
     </div>
 )

--- a/client/search-ui/src/input/SearchHelpDropdownButton.module.scss
+++ b/client/search-ui/src/input/SearchHelpDropdownButton.module.scss
@@ -1,5 +1,12 @@
 .trigger-button {
+    padding: 0.375rem;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+
+    &[aria-expanded='true'],
     &:hover {
+        background-color: var(--color-bg-2);
         color: var(--link-color);
     }
 }
@@ -7,4 +14,5 @@
 .content {
     min-width: 10rem;
     max-width: 14.8rem;
+    padding-top: 0.25rem;
 }

--- a/client/search-ui/src/input/SearchHelpDropdownButton.tsx
+++ b/client/search-ui/src/input/SearchHelpDropdownButton.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import { useCallback, FC } from 'react'
 
 import { mdiHelpCircleOutline, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
@@ -7,6 +7,7 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import {
     PopoverTrigger,
     PopoverContent,
+    PopoverTail,
     Popover,
     Button,
     Position,
@@ -22,30 +23,30 @@ import styles from './SearchHelpDropdownButton.module.scss'
 
 interface SearchHelpDropdownButtonProps extends TelemetryProps {
     isSourcegraphDotCom?: boolean
+    className?: string
 }
 
 /**
  * A dropdown button that shows a menu with reference documentation for Sourcegraph search query
  * syntax.
  */
-export const SearchHelpDropdownButton: React.FunctionComponent<
-    React.PropsWithChildren<SearchHelpDropdownButtonProps>
-> = ({ isSourcegraphDotCom, telemetryService }) => {
-    const [isOpen, setIsOpen] = useState(false)
-    const toggleIsOpen = useCallback(() => setIsOpen(!isOpen), [isOpen])
+export const SearchHelpDropdownButton: FC<SearchHelpDropdownButtonProps> = props => {
+    const { isSourcegraphDotCom, className, telemetryService } = props
+
     const onQueryDocumentationLinkClicked = useCallback(() => {
         telemetryService.log('SearchHelpDropdownQueryDocsLinkClicked')
-        toggleIsOpen()
-    }, [toggleIsOpen, telemetryService])
+    }, [telemetryService])
+
     const documentationUrlPrefix = isSourcegraphDotCom ? 'https://docs.sourcegraph.com' : '/help'
 
     return (
-        <Popover isOpen={isOpen} onOpenChange={event => setIsOpen(event.isOpen)}>
+        <Popover>
             <PopoverTrigger
                 as={Button}
                 variant="link"
-                className={classNames('px-2 d-flex align-items-center cursor-pointer', styles.triggerButton)}
                 aria-label="Quick help for search"
+                className={classNames(className, styles.triggerButton)}
+                onClick={onQueryDocumentationLinkClicked}
             >
                 <Icon
                     aria-hidden={true}
@@ -53,7 +54,8 @@ export const SearchHelpDropdownButton: React.FunctionComponent<
                     svgPath={mdiHelpCircleOutline}
                 />
             </PopoverTrigger>
-            <PopoverContent position={Position.bottomEnd} className={classNames('pb-0', styles.content)}>
+
+            <PopoverContent position={Position.bottom} className={styles.content}>
                 <MenuHeader>
                     <strong>Search reference</strong>
                 </MenuHeader>
@@ -130,6 +132,7 @@ export const SearchHelpDropdownButton: React.FunctionComponent<
                     <Icon aria-hidden={true} className="small" svgPath={mdiOpenInNew} /> All search keywords
                 </MenuText>
             </PopoverContent>
+            <PopoverTail />
         </Popover>
     )
 }

--- a/client/web/src/nav/__snapshots__/StatusMessagesNavItem.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/StatusMessagesNavItem.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`StatusMessagesNavItem all messages 1`] = `
 <DocumentFragment>
   <button
+    aria-expanded="false"
     aria-label="Show status messages"
     class="btn btnLink nav-link py-0 px-0 percy-hide chromatic-ignore"
     type="button"
@@ -13,6 +14,7 @@ exports[`StatusMessagesNavItem all messages 1`] = `
 exports[`StatusMessagesNavItem no messages 1`] = `
 <DocumentFragment>
   <button
+    aria-expanded="false"
     aria-label="Show status messages"
     class="btn btnLink nav-link py-0 px-0 percy-hide chromatic-ignore"
     type="button"

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/__snapshots__/FeedbackPrompt.test.tsx.snap
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/__snapshots__/FeedbackPrompt.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`FeedbackPrompt should render correctly 1`] = `
 <body>
   <div>
     <button
+      aria-expanded="true"
       aria-label="Feedback"
       class=""
       type="button"
@@ -275,6 +276,7 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
 <body>
   <div>
     <button
+      aria-expanded="true"
       aria-label="Feedback"
       class=""
       type="button"
@@ -563,6 +565,7 @@ exports[`FeedbackPrompt should render submit success correctly 1`] = `
 <body>
   <div>
     <button
+      aria-expanded="true"
       aria-label="Feedback"
       class=""
       type="button"

--- a/client/wildcard/src/components/Popover/components/PopoverTrigger.tsx
+++ b/client/wildcard/src/components/Popover/components/PopoverTrigger.tsx
@@ -24,7 +24,7 @@ export const PopoverTrigger = forwardRef(function PopoverTrigger(props, referenc
     }
 
     return (
-        <Component ref={mergedReference} onClick={handleClick} {...otherProps}>
+        <Component ref={mergedReference} aria-expanded={isOpen} onClick={handleClick} {...otherProps}>
             {typeof children === 'function' ? children(isOpen) : children}
         </Component>
     )


### PR DESCRIPTION

This PR fixes the layout for the tips tooltip UI and enforces a11y aria-expanded attributes for any popover target (it helps with screen readers' announcements and allows consumers to use this state in CSS for applying active states over the target). 

It also adds arrow (tail) UI to the tooltip because prior to this PR, it wasn't clear to which target this tooltip is visually attached.

| Before  | After |
| ------------- | ------------- |
| <img width="340" alt="Screenshot 2022-10-14 at 18 49 41" src="https://user-images.githubusercontent.com/18492575/195949346-77e82657-c64c-4950-8c9a-397cec3fff90.png"> | <img width="338" alt="Screenshot 2022-10-14 at 18 49 31" src="https://user-images.githubusercontent.com/18492575/195949326-9b40a125-e169-4613-90da-379238f17155.png"> |

## Test plan
- Make sure that the tips UI tooltip looks properly on the home and blob view pages 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-search-tips-tooltip.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-hqbmxbjizl.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
