### PR TITLE
Improve render performance of file sidebar

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -45,7 +45,6 @@ interface RepoRevisionSidebarProps
     defaultBranch: string
     className: string
     history: H.History
-    location: H.Location
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean
 }
@@ -164,7 +163,6 @@ export const RepoRevisionSidebar: React.FunctionComponent<
                                         revision={props.revision}
                                         commitID={props.commitID}
                                         history={props.history}
-                                        location={props.location}
                                         scrollRootSelector=".explorer"
                                         activePath={props.filePath}
                                         activePathIsDir={props.isDir}

--- a/client/web/src/repo/RepositoryFileTreePage.tsx
+++ b/client/web/src/repo/RepositoryFileTreePage.tsx
@@ -76,20 +76,22 @@ export const RepositoryFileTreePage: React.FunctionComponent<
         return <Redirect to={url + formatHash(hashParameters)} />
     }
 
-    const repoRevisionProps = {
-        commitID: resolvedRevision?.commitID,
-        filePath,
-        globbing,
-    }
-
     return (
         <>
             <RepoRevisionSidebar
-                {...context}
-                {...repoRevisionProps}
+                className="repo-revision-container__sidebar"
+                history={context.history}
+                revision={context.revision}
+                isLightTheme={context.isLightTheme}
+                settingsCascade={context.settingsCascade}
+                telemetryService={context.telemetryService}
+                authenticatedUser={context.authenticatedUser}
+                isSourcegraphDotCom={context.isSourcegraphDotCom}
+                extensionsController={context.extensionsController}
+                commitID={resolvedRevision?.commitID}
+                filePath={filePath}
                 repoID={repo?.id}
                 repoName={repoName}
-                className="repo-revision-container__sidebar"
                 isDir={objectType === 'tree'}
                 defaultBranch={resolvedRevision?.defaultBranch || 'HEAD'}
             />
@@ -103,7 +105,9 @@ export const RepositoryFileTreePage: React.FunctionComponent<
                             <TraceSpanProvider name="BlobPage">
                                 <BlobPage
                                     {...context}
-                                    {...repoRevisionProps}
+                                    commitID={resolvedRevision?.commitID}
+                                    filePath={filePath}
+                                    globbing={globbing}
                                     repoID={repo?.id}
                                     repoName={repoName}
                                     repoUrl={repo?.url}

--- a/client/web/src/tree/ChildTreeLayer.tsx
+++ b/client/web/src/tree/ChildTreeLayer.tsx
@@ -15,7 +15,7 @@ import { TreeLayer } from './TreeLayer'
 import { TreeRootProps } from './TreeRoot'
 import { hasSingleChild, NOOP, SingleChildGitTree, TreeEntryInfo } from './util'
 
-interface ChildTreeLayerProps extends Pick<TreeRootProps, Exclude<keyof TreeRootProps, 'sizeKey'>> {
+interface ChildTreeLayerProps extends Omit<TreeRootProps, 'sizeKey'> {
     fileDecorationsByPath: FileDecorationsByPath
 
     entries: TreeEntryInfo[]
@@ -34,7 +34,6 @@ export const ChildTreeLayer: React.FunctionComponent<React.PropsWithChildren<Chi
     props: ChildTreeLayerProps
 ) => {
     const sharedProps = {
-        location: props.location,
         activePath: props.activePath,
         activeNode: props.activeNode,
         depth: props.depth + 1,
@@ -77,7 +76,6 @@ export const ChildTreeLayer: React.FunctionComponent<React.PropsWithChildren<Chi
                                                         isSingleChild: false,
                                                         submodule: null,
                                                     }}
-                                                    location={props.location}
                                                     depth={sharedProps.depth}
                                                     index={0}
                                                     isLightTheme={sharedProps.isLightTheme}

--- a/client/web/src/tree/File.tsx
+++ b/client/web/src/tree/File.tsx
@@ -6,7 +6,7 @@ import { mdiSourceRepository, mdiFileDocumentOutline } from '@mdi/js'
 import classNames from 'classnames'
 import * as H from 'history'
 import { escapeRegExp, isEqual } from 'lodash'
-import { NavLink } from 'react-router-dom'
+import { NavLink, useLocation } from 'react-router-dom'
 import { FileDecoration } from 'sourcegraph'
 
 import { gql, useQuery } from '@sourcegraph/http-client'
@@ -53,9 +53,6 @@ interface FileProps extends ThemeProps {
     customIconPath?: string
     enableMergedFileSymbolSidebar: boolean
     isGoUpTreeLink?: boolean
-
-    // For core workflow inline symbols redesign
-    location: H.Location
 }
 
 export const File: React.FunctionComponent<React.PropsWithChildren<FileProps>> = props => {
@@ -71,7 +68,6 @@ export const File: React.FunctionComponent<React.PropsWithChildren<FileProps>> =
         isLightTheme,
         depth,
         index,
-        location,
         enableMergedFileSymbolSidebar,
         customIconPath,
     } = props
@@ -176,9 +172,7 @@ export const File: React.FunctionComponent<React.PropsWithChildren<FileProps>> =
                     )}
                 </TreeLayerCell>
             </TreeRow>
-            {enableMergedFileSymbolSidebar && isActive && (
-                <Symbols activePath={entryInfo.path} location={location} style={offsetStyle} />
-            )}
+            {enableMergedFileSymbolSidebar && isActive && <Symbols activePath={entryInfo.path} style={offsetStyle} />}
         </>
     )
 }
@@ -230,10 +224,11 @@ export const SYMBOLS_QUERY = gql`
 `
 
 interface SymbolsProps
-    extends Pick<TreeLayerProps, 'activePath' | 'location'>,
+    extends Pick<TreeLayerProps, 'activePath'>,
         Pick<React.HTMLAttributes<HTMLDivElement>, 'style'> {}
 
-const Symbols: React.FunctionComponent<SymbolsProps> = ({ activePath, location, style }) => {
+const Symbols: React.FunctionComponent<SymbolsProps> = ({ activePath, style }) => {
+    const location = useLocation()
     const { repoID, revision } = useTreeRootContext()
     const { data, loading, error } = useQuery<InlineSymbolsResult>(SYMBOLS_QUERY, {
         variables: {

--- a/client/web/src/tree/Tree.tsx
+++ b/client/web/src/tree/Tree.tsx
@@ -23,7 +23,6 @@ import styles from './Tree.module.scss'
 
 interface Props extends AbsoluteRepo, ExtensionsControllerProps, ThemeProps, TelemetryProps {
     history: H.History
-    location: H.Location
     scrollRootSelector?: string
 
     /** The tree entry that is currently active, or '' if none (which means the root). */
@@ -326,7 +325,6 @@ export class Tree extends React.PureComponent<Props, State> {
                     activeNode={this.state.activeNode}
                     activePath={this.props.activePath}
                     depth={0}
-                    location={this.props.location}
                     repoID={this.props.repoID}
                     repoName={this.props.repoName}
                     revision={this.props.revision}

--- a/client/web/src/tree/TreeLayer.tsx
+++ b/client/web/src/tree/TreeLayer.tsx
@@ -332,7 +332,6 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                                 linkRowClick={this.linkRowClick}
                                 isActive={isActive}
                                 isSelected={isSelected}
-                                location={this.props.location}
                                 enableMergedFileSymbolSidebar={this.props.enableMergedFileSymbolSidebar}
                             />
                         )}

--- a/client/web/src/tree/TreeRoot.tsx
+++ b/client/web/src/tree/TreeRoot.tsx
@@ -1,7 +1,6 @@
 /* eslint jsx-a11y/no-noninteractive-tabindex: warn*/
 import * as React from 'react'
 
-import * as H from 'history'
 import { EMPTY, merge, of, Subject, Subscription } from 'rxjs'
 import {
     catchError,
@@ -42,7 +41,6 @@ const errorWidth = (width?: string): { width: string } => ({
 })
 
 export interface TreeRootProps extends AbsoluteRepo, ExtensionsControllerProps, ThemeProps, TelemetryProps {
-    location: H.Location
     activeNode: TreeNode
     activePath: string
     depth: number

--- a/client/web/src/tree/util.tsx
+++ b/client/web/src/tree/util.tsx
@@ -100,8 +100,7 @@ export function compareTreeProps(a: ComparisonTreeRootProps, b: ComparisonTreeRo
         a.revision === b.revision &&
         a.commitID === b.commitID &&
         a.parentPath === b.parentPath &&
-        a.isExpanded === b.isExpanded &&
-        a.location === b.location
+        a.isExpanded === b.isExpanded
     )
 }
 


### PR DESCRIPTION
> **Note**
> I'm going to merge this after the branch cut for 4.1

While working on file view hovercards I noticed that selecting lines feels "slugish" when the file sidebar shows a larger list of files. Interestingly it seems the issue is not as extreme in the production build.

Before/after video (note that when the file view receives the blue focus border is the moment when I click):


https://user-images.githubusercontent.com/179026/196010268-bec32ee8-a775-4826-9b5d-c86127b906c3.mp4

When a line is selected we update the URL and the file tree rerenders whenever the URL changes. It may look like that the issue is cause by the experimental symbols integration, but in fact the issue existed before. `location` seems to be used to determine whether to update the tree data or not, but I'm not sure whether that's actually necessary because we compare other values as well.

React profiling before and after:

<img width="733" alt="2022-10-15_23-53" src="https://user-images.githubusercontent.com/179026/196010372-4d8714f5-53ff-48bd-a325-2e35c05588b0.png">
<img width="771" alt="2022-10-15_23-51" src="https://user-images.githubusercontent.com/179026/196010373-c6e6bcb4-c0d5-4fb3-8e95-d782ccadce42.png">



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-fkling-tree-render-performance.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-rwjcdszhnr.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
