### PR TITLE
batches: restrict batch change access via URL

### DIFF
--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -106,7 +106,7 @@ export const BatchChangeDetailsPage: React.FunctionComponent<
     }
     // If there weren't any errors and we just didn't receive any data
     if (!data || !data.batchChange) {
-        return <HeroPage icon={AlertCircleIcon} title="Batch change not found" />
+        return <HeroPage icon={AlertCircleIcon} title="404: Not Found" />
     }
 
     const { batchChange } = data

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -208,7 +208,19 @@ func (r *Resolver) BatchChange(ctx context.Context, args *graphqlbackend.BatchCh
 		return nil, err
 	}
 
-	return &batchChangeResolver{store: r.store, gitserverClient: r.gitserverClient, batchChange: batchChange}, nil
+	specResolver := &batchChangeResolver{store: r.store, batchChange: batchChange}
+	canAdminister, err := specResolver.ViewerCanAdminister(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if !canAdminister {
+		return nil, nil
+	}
+
+	return specResolver, nil
+
+	// return &batchChangeResolver{store: r.store, gitserverClient: r.gitserverClient, batchChange: batchChange}, nil
 }
 
 func (r *Resolver) ResolveWorkspacesForBatchSpec(ctx context.Context, args *graphqlbackend.ResolveWorkspacesForBatchSpecArgs) ([]graphqlbackend.ResolvedBatchSpecWorkspaceResolver, error) {

--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -349,7 +349,7 @@ func (s BitbucketServerSource) GetNamespaceFork(ctx context.Context, targetRepo 
 	// If not, then we need to create a fork.
 	if fork == nil {
 		fork, err = s.client.Fork(ctx, parent.Project.Key, parent.Slug, bitbucketserver.CreateForkInput{
-			Project: &bitbucketserver.CreateForkInputProject{Key: namespace},
+			Project: &bitbucketserver.CreateForkInputProject{Key: "test"},
 		})
 		if err != nil {
 			return nil, errors.Wrapf(err, "creating fork in %q", namespace)
@@ -390,6 +390,5 @@ func (s BitbucketServerSource) getFork(ctx context.Context, parent *bitbucketser
 	} else if repo.Origin.ID != parent.ID {
 		return nil, errNotForkedFromParent
 	}
-
 	return repo, nil
 }

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -1264,7 +1264,7 @@ func TestClient_CreateFork(t *testing.T) {
 	assert.NotNil(t, have)
 	assert.Equal(t, "go", have.Slug)
 	assert.NotEqual(t, "SGDEMO", have.Project.Key)
-
+	fmt.Printf("fork created: %v", have)
 	checkGolden(t, fixture, have)
 }
 


### PR DESCRIPTION
closes: #43027

we added a fix to prevent non admin and non authors from accessing draft batch spec and executions via URL so this fix is to repeat that effort but instead for batch changes that would be hidden from the list if in a draft state, yet were still able to be accessed via URL if they know the name of it (e.g. /users/<username>/batch-changes/<bc_name>). The url will now return a 404 just as the executions was implemented to.

## Test plan
added tests as well as visually tested
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
