### PR TITLE
insights: batch insert series points again

### DIFF
--- a/doc/dev/background-information/sql/batch_operations.md
+++ b/doc/dev/background-information/sql/batch_operations.md
@@ -7,7 +7,7 @@ If a large number of rows are being inserted into the same table, use of a [batc
 The package provides many convenience functions, but basic usage is as follows. An inserter is created with a table name and a list of column names for which values will be supplied. Then, the `Insert` method is called for each row to be inserted. It is expected that the number of values supplied to each call to `Insert` matches the number of columns supplied at construction of the inserter. On each call to `Insert`, if the current batch is full, it will be prepared and sent to the database, leaving an empty batch for future operations. A final call to `Flush` will ensure that any remaining batched rows are sent to the database.
 
 ```go
-inserter := batch.NewInserter(ctx, db, "table", "col1", "col2", "col3" /* , ... */)
+inserter := batch.NewInserter(ctx, db, batch.MaxNumPostgresParameters, "table", "col1", "col2", "col3" /* , ... */)
 
 for /* ... */ {
     if err := inserter.Insert(ctx, val1, val2, val3 /* , ... */); err != nil {
@@ -54,7 +54,7 @@ Here, we defined the temporary table with the clause `ON COMMIT DROP`, which wil
 Next, create and use a batch inserter instance just as described in the previous section, but target the newly created temporary table. Only the columns that are defined on the temporary table need to be supplied when calling the `Insert` method.
 
 ```go
-inserter := batch.NewInserter(ctx, db, "temp_table", "col3", "col4")
+inserter := batch.NewInserter(ctx, db, batch.MaxNumPostgresParameters, "temp_table", "col3", "col4")
 
 for /* ... */ {
     if err := inserter.Insert(ctx, val3, val4); err != nil {

--- a/enterprise/internal/insights/background/historical_enqueuer_test.go
+++ b/enterprise/internal/insights/background/historical_enqueuer_test.go
@@ -110,10 +110,6 @@ func testHistoricalEnqueuer(t *testing.T, p *testParams) *testResults {
 		}
 		return 0, nil
 	})
-	insightsStore.RecordSeriesPointFunc.SetDefaultHook(func(ctx context.Context, args store.RecordSeriesPointArgs) error {
-		r.operations = append(r.operations, fmt.Sprintf("recordSeriesPoint(point=%v, repoName=%v)", args.Point.String(), *args.RepoName))
-		return nil
-	})
 
 	repoStore := NewMockRepoStore()
 	repos := map[api.RepoName]*types.Repo{}

--- a/enterprise/internal/insights/store/mocks_temp.go
+++ b/enterprise/internal/insights/store/mocks_temp.go
@@ -1598,9 +1598,6 @@ type MockInterface struct {
 	// CountDataFunc is an instance of a mock function object controlling
 	// the behavior of the method CountData.
 	CountDataFunc *InterfaceCountDataFunc
-	// RecordSeriesPointFunc is an instance of a mock function object
-	// controlling the behavior of the method RecordSeriesPoint.
-	RecordSeriesPointFunc *InterfaceRecordSeriesPointFunc
 	// RecordSeriesPointsFunc is an instance of a mock function object
 	// controlling the behavior of the method RecordSeriesPoints.
 	RecordSeriesPointsFunc *InterfaceRecordSeriesPointsFunc
@@ -1615,11 +1612,6 @@ func NewMockInterface() *MockInterface {
 	return &MockInterface{
 		CountDataFunc: &InterfaceCountDataFunc{
 			defaultHook: func(context.Context, CountDataOpts) (r0 int, r1 error) {
-				return
-			},
-		},
-		RecordSeriesPointFunc: &InterfaceRecordSeriesPointFunc{
-			defaultHook: func(context.Context, RecordSeriesPointArgs) (r0 error) {
 				return
 			},
 		},
@@ -1645,11 +1637,6 @@ func NewStrictMockInterface() *MockInterface {
 				panic("unexpected invocation of MockInterface.CountData")
 			},
 		},
-		RecordSeriesPointFunc: &InterfaceRecordSeriesPointFunc{
-			defaultHook: func(context.Context, RecordSeriesPointArgs) error {
-				panic("unexpected invocation of MockInterface.RecordSeriesPoint")
-			},
-		},
 		RecordSeriesPointsFunc: &InterfaceRecordSeriesPointsFunc{
 			defaultHook: func(context.Context, []RecordSeriesPointArgs) error {
 				panic("unexpected invocation of MockInterface.RecordSeriesPoints")
@@ -1669,9 +1656,6 @@ func NewMockInterfaceFrom(i Interface) *MockInterface {
 	return &MockInterface{
 		CountDataFunc: &InterfaceCountDataFunc{
 			defaultHook: i.CountData,
-		},
-		RecordSeriesPointFunc: &InterfaceRecordSeriesPointFunc{
-			defaultHook: i.RecordSeriesPoint,
 		},
 		RecordSeriesPointsFunc: &InterfaceRecordSeriesPointsFunc{
 			defaultHook: i.RecordSeriesPoints,
@@ -1787,111 +1771,6 @@ func (c InterfaceCountDataFuncCall) Args() []interface{} {
 // invocation.
 func (c InterfaceCountDataFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
-}
-
-// InterfaceRecordSeriesPointFunc describes the behavior when the
-// RecordSeriesPoint method of the parent MockInterface instance is invoked.
-type InterfaceRecordSeriesPointFunc struct {
-	defaultHook func(context.Context, RecordSeriesPointArgs) error
-	hooks       []func(context.Context, RecordSeriesPointArgs) error
-	history     []InterfaceRecordSeriesPointFuncCall
-	mutex       sync.Mutex
-}
-
-// RecordSeriesPoint delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockInterface) RecordSeriesPoint(v0 context.Context, v1 RecordSeriesPointArgs) error {
-	r0 := m.RecordSeriesPointFunc.nextHook()(v0, v1)
-	m.RecordSeriesPointFunc.appendCall(InterfaceRecordSeriesPointFuncCall{v0, v1, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the RecordSeriesPoint
-// method of the parent MockInterface instance is invoked and the hook queue
-// is empty.
-func (f *InterfaceRecordSeriesPointFunc) SetDefaultHook(hook func(context.Context, RecordSeriesPointArgs) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// RecordSeriesPoint method of the parent MockInterface instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *InterfaceRecordSeriesPointFunc) PushHook(hook func(context.Context, RecordSeriesPointArgs) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *InterfaceRecordSeriesPointFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, RecordSeriesPointArgs) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *InterfaceRecordSeriesPointFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, RecordSeriesPointArgs) error {
-		return r0
-	})
-}
-
-func (f *InterfaceRecordSeriesPointFunc) nextHook() func(context.Context, RecordSeriesPointArgs) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *InterfaceRecordSeriesPointFunc) appendCall(r0 InterfaceRecordSeriesPointFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of InterfaceRecordSeriesPointFuncCall objects
-// describing the invocations of this function.
-func (f *InterfaceRecordSeriesPointFunc) History() []InterfaceRecordSeriesPointFuncCall {
-	f.mutex.Lock()
-	history := make([]InterfaceRecordSeriesPointFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// InterfaceRecordSeriesPointFuncCall is an object that describes an
-// invocation of method RecordSeriesPoint on an instance of MockInterface.
-type InterfaceRecordSeriesPointFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 RecordSeriesPointArgs
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c InterfaceRecordSeriesPointFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c InterfaceRecordSeriesPointFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
 }
 
 // InterfaceRecordSeriesPointsFunc describes the behavior when the

--- a/enterprise/internal/insights/store/store_benchs_test.go
+++ b/enterprise/internal/insights/store/store_benchs_test.go
@@ -7,13 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
-
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"k8s.io/apimachinery/pkg/util/rand"
 
-	"github.com/sourcegraph/log/logtest"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
@@ -34,12 +33,13 @@ func initializeData(ctx context.Context, store *Store, repos, times int, withCap
 
 	seriesID := rand.String(8)
 	currentTime := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+	var records []RecordSeriesPointArgs
 	for i := 0; i < times; i++ {
 		for j := 0; j < repos; j++ {
 			repoName := fmt.Sprintf("repo-%d", j)
 			id := api.RepoID(j)
 			for _, val := range cv {
-				err := store.RecordSeriesPoint(ctx, RecordSeriesPointArgs{
+				records = append(records, RecordSeriesPointArgs{
 					SeriesID: seriesID,
 					Point: SeriesPoint{
 						SeriesID: seriesID,
@@ -51,13 +51,13 @@ func initializeData(ctx context.Context, store *Store, repos, times int, withCap
 					RepoID:      &id,
 					PersistMode: RecordMode,
 				})
-				if err != nil {
-					panic(err)
-				}
 			}
 		}
 
 		currentTime = currentTime.AddDate(0, 1, 0)
+	}
+	if err := store.RecordSeriesPoints(ctx, records); err != nil {
+		panic(err)
 	}
 
 	return seriesID


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#43013

## Description

we thought an increase in db lock/cpu usage was due to this PR, however this is only happening on k8s. 

it looks like the unique index on `repo_names` is no longer being enforced. `repo_names` is now 1.3m rows, 45k are sourcegraph/sourcegraph. 

## Test plan

Revert didn't fix. s2 works with this change.