### PR TITLE
sg: add scaletesting as preset live environment

### DIFF
--- a/dev/sg/live.go
+++ b/dev/sg/live.go
@@ -24,6 +24,7 @@ var environments = []environment{
 	{Name: "s2", URL: "https://sourcegraph.sourcegraph.com"},
 	{Name: "dotcom", URL: "https://sourcegraph.com"},
 	{Name: "k8s", URL: "https://k8s.sgdev.org"},
+	{Name: "scaletesting", URL: "https://scaletesting.sgdev.org"},
 }
 
 func environmentNames() []string {

--- a/dev/sg/sg_live.go
+++ b/dev/sg/sg_live.go
@@ -21,6 +21,7 @@ var liveCommand = &cli.Command{
 sg live s2
 sg live dotcom
 sg live k8s
+sg live scaletesting
 
 # See which version is deployed on a custom environment
 sg live https://demo.sourcegraph.com

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1290,12 +1290,14 @@ Available preset environments:
 * s2
 * dotcom
 * k8s
+* scaletesting
 
 ```sh
 # See which version is deployed on a preset environment
 $ sg live s2
 $ sg live dotcom
 $ sg live k8s
+$ sg live scaletesting
 
 # See which version is deployed on a custom environment
 $ sg live https://demo.sourcegraph.com


### PR DESCRIPTION
Add scaletesting as a preset env for `sg live`

## Test plan
```
go run ./dev/sg live scaletesting
✅ Fetched deployed version
✅ Done updating list of commits

💡 Live on "scaletesting": e18d1344e0ee (built on 2022-09-23)

❗️ Deployed SHA e18d1344e0ee not found in last 20 commits on origin/main :(
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
