### PR TITLE
executors: Support bash syntax when available

### DIFF
--- a/enterprise/cmd/executor/internal/worker/handler_test.go
+++ b/enterprise/cmd/executor/internal/worker/handler_test.go
@@ -267,12 +267,12 @@ func TestHandle_WorkspaceFile(t *testing.T) {
 	defer dockerScriptFile1.Close()
 	dockerScriptFile1Content, err := io.ReadAll(dockerScriptFile1)
 	require.NoError(t, err)
-	assert.Equal(t, "\nset -x\n\n\ngo\nmod\ninstall\n", string(dockerScriptFile1Content))
+	assert.Equal(t, workspace.ScriptPreamble+"\n\ngo\nmod\ninstall\n", string(dockerScriptFile1Content))
 
 	dockerScriptFile2, err := os.Open(filepath.Join(testDir, ".sourcegraph-executor", "42.1_linux@deadbeef.sh"))
 	require.NoError(t, err)
 	defer dockerScriptFile2.Close()
 	dockerScriptFile2Content, err := io.ReadAll(dockerScriptFile2)
 	require.NoError(t, err)
-	assert.Equal(t, "\nset -x\n\n\nyarn\ninstall\n", string(dockerScriptFile2Content))
+	assert.Equal(t, workspace.ScriptPreamble+"\n\nyarn\ninstall\n", string(dockerScriptFile2Content))
 }

--- a/enterprise/cmd/executor/internal/worker/workspace/files.go
+++ b/enterprise/cmd/executor/internal/worker/workspace/files.go
@@ -73,7 +73,7 @@ type workspaceFile struct {
 	modifiedAt time.Time
 }
 
-// scriptPreamble contains a script that checks at runtime if bash is available.
+// ScriptPreamble contains a script that checks at runtime if bash is available.
 // If it is, we want to be using bash, to support a more natural scripting.
 // If not, then we just run with sh.
 // This works roughly like the following:
@@ -82,7 +82,7 @@ type workspaceFile struct {
 // - If so, we invoke this exact script again, but with the bash on the path, and pass an argument so that this check doesn't happen again.
 // - If not, it might be that PATH is not set correctly, but bash is still available at /bin/bash. If that's the case we do the same as above.
 // Otherwise we just continue and best effort run the script in sh.
-var scriptPreamble = `
+var ScriptPreamble = `
 # Only on the first run, check if we can upgrade to bash.
 if [ -z "$1" ]; then
   bash_path=$(which bash)
@@ -107,7 +107,7 @@ set -x
 `
 
 func buildScript(dockerStep executor.DockerStep) workspaceFile {
-	return workspaceFile{content: []byte(strings.Join(append([]string{scriptPreamble, ""}, dockerStep.Commands...), "\n") + "\n")}
+	return workspaceFile{content: []byte(strings.Join(append([]string{ScriptPreamble, ""}, dockerStep.Commands...), "\n") + "\n")}
 }
 
 func scriptNameFromJobStep(job executor.Job, i int) string {

--- a/enterprise/cmd/executor/internal/worker/workspace/files.go
+++ b/enterprise/cmd/executor/internal/worker/workspace/files.go
@@ -73,7 +73,36 @@ type workspaceFile struct {
 	modifiedAt time.Time
 }
 
+// scriptPreamble contains a script that checks at runtime if bash is available.
+// If it is, we want to be using bash, to support a more natural scripting.
+// If not, then we just run with sh.
+// This works roughly like the following:
+// - If no argument to the script is provided, this is the first run of it. We will use that later to prevent an infinite loop.
+// - Determine if a program called bash is on the path
+// - If so, we invoke this exact script again, but with the bash on the path, and pass an argument so that this check doesn't happen again.
+// - If not, it might be that PATH is not set correctly, but bash is still available at /bin/bash. If that's the case we do the same as above.
+// Otherwise we just continue and best effort run the script in sh.
 var scriptPreamble = `
+# Only on the first run, check if we can upgrade to bash.
+if [ -z "$1" ]; then
+  bash_path=$(which bash)
+  set -e
+  # Check if bash is present. If so, use bash. Otherwise just keep running with sh.
+  if [ -n "$bash_path" ]; then
+    "${bash_path}" "$0" "skip-check"
+    exit
+  else
+    # If not in the path but still exists at /bin/bash, we can use that.
+    if [ -f "/bin/bash" ]; then
+      /bin/bash "$0" "skip-check"
+      exit
+    fi
+  fi
+fi
+
+# Restore default shell behavior.
+set +e
+# From the actual script, log all commands.
 set -x
 `
 

--- a/enterprise/cmd/executor/internal/worker/workspace/files.go
+++ b/enterprise/cmd/executor/internal/worker/workspace/files.go
@@ -85,17 +85,15 @@ type workspaceFile struct {
 var ScriptPreamble = `
 # Only on the first run, check if we can upgrade to bash.
 if [ -z "$1" ]; then
-  bash_path=$(which bash)
+  bash_path=$(command -p -v bash)
   set -e
   # Check if bash is present. If so, use bash. Otherwise just keep running with sh.
   if [ -n "$bash_path" ]; then
-    "${bash_path}" "$0" "skip-check"
-    exit
+    exec "${bash_path}" "$0" skip-check
   else
     # If not in the path but still exists at /bin/bash, we can use that.
     if [ -f "/bin/bash" ]; then
-      /bin/bash "$0" "skip-check"
-      exit
+      exec /bin/bash "$0" skip-check
     fi
   fi
 fi


### PR DESCRIPTION
Executors for now ran commands as scripts in sh only, this adds support for bash as well. This is something that we supported in batch changes forever due to customer feedback. In batch changes, we used an approach where we would run the container with `/bin/bash mktemp` and then `/bin/sh mktemp` to determine which shell is available. I think this approach is actually nicer, because it
- respects the PATH setting in the container for bash
- doesn't require up to 2 additional container boots before the actual command can be run



## Test plan

Verified locally that things still work as expected and that bash detection is reliable.