### PR TITLE
Update label notify for Frontend Platform Team

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -23,7 +23,7 @@ jobs:
                   team/delivery=@sourcegraph/delivery
                   team/security=@dcomas
                   team/dev-experience=@jhchabran @kstretch9
-                  team/frontend-platform=@taylorsperry @muratsu
+                  team/frontend-platform=@sourcegraph/frontend-platform
                   team/repo-management=@jplahn @ryphil
                   team/devops=@sourcegraph/cloud-devops
                   team/iam=@sourcegraph/iam


### PR DESCRIPTION
Updating this to use the team tag since the individual tags are outdated.

## Test plan

N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
