### PR TITLE
Revert "About" redirect back to the product at "/search"

### DIFF
--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -74,12 +74,7 @@ function passThroughToServer(): React.ReactNode {
 export const routes: readonly LayoutRouteProps<any>[] = ([
     {
         path: PageRoutes.Index,
-        render: props =>
-            window.context.sourcegraphDotComMode && !props.authenticatedUser ? (
-                <Redirect to="https://about.sourcegraph.com" />
-            ) : (
-                <Redirect to={PageRoutes.Search} />
-            ),
+        render: () => <Redirect to={PageRoutes.Search} />,
         exact: true,
     },
     {

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -27,7 +27,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/jscontext"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/handlerutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/routevar"
-	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -310,14 +309,6 @@ func serveHome(db database.DB) handlerFunc {
 		}
 		if common == nil {
 			return nil // request was handled
-		}
-
-		if envvar.SourcegraphDotComMode() && !actor.FromContext(r.Context()).IsAuthenticated() && !strings.Contains(r.UserAgent(), "Cookiebot") {
-			// The user is not signed in and tried to access Sourcegraph.com.
-			// Redirect to about.sourcegraph.com so they see general info page.
-			// Don't redirect Cookiebot so it can scan the website without authentication.
-			http.Redirect(w, r, (&url.URL{Scheme: aboutRedirectScheme, Host: aboutRedirectHost}).String(), http.StatusTemporaryRedirect)
-			return nil
 		}
 
 		// On non-Sourcegraph.com instances, there is no separate homepage, so redirect to /search.

--- a/cmd/frontend/internal/app/ui/handlers_test.go
+++ b/cmd/frontend/internal/app/ui/handlers_test.go
@@ -64,7 +64,7 @@ func TestRedirects(t *testing.T) {
 		envvar.MockSourcegraphDotComMode(true)
 		defer envvar.MockSourcegraphDotComMode(orig) // reset
 		t.Run("root", func(t *testing.T) {
-			check(t, "/", http.StatusTemporaryRedirect, "https://about.sourcegraph.com", "Mozilla/5.0")
+			check(t, "/", http.StatusTemporaryRedirect, "/search", "Mozilla/5.0")
 		})
 	})
 


### PR DESCRIPTION
This PR reverts changes made in #35395 and removes the redirect to about.sourcegraph.com. Everyone will now be redirected to the product at `/search` when they visit sourcegraph.com.

Why is this change being made? "We" as Growth Marketing want to raise more awareness about our product and increase trial starts. We believe that devs want to tinker rather than read about us. This is a part of achieving this goal.

## Test plan
- Ensure all tests pass
- Ensure visiting the root level domain redirects you to the product at `/search`