### PR TITLE
batches: update docs, in-app changelog for 4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Batch changes run on the server can now be created within organisations. [#36536](https://github.com/sourcegraph/sourcegraph/issues/36536)
 - GraphQL request logs are now compliant with the audit logging format. The old GraphQl logging based on `LOG_ALL_GRAPHQL_REQUESTS` env var is now deprecated and scheduled for removal. [#42550](https://github.com/sourcegraph/sourcegraph/pull/42550)
 - Mounting files now works when running batch changes server side. [#31792](https://github.com/sourcegraph/sourcegraph/issues/31792)
+- Added mini dashboard of total batch change metrics to the top of the batch changes list page. [#42046](https://github.com/sourcegraph/sourcegraph/pull/42046)
 
 ### Changed
 
@@ -38,6 +39,7 @@ All notable changes to Sourcegraph are documented in this file.
 - When updating the site configuration, the provided Last ID is now used to prevent race conditions when simultaneous config updates occur. [#42691](https://github.com/sourcegraph/sourcegraph/pull/42691)
 - When multiple auth providers of the same external service type is set up, there are now separate entries in the user's Account Security settings. [#42865](https://github.com/sourcegraph/sourcegraph/pull/42865)
 - Fixed a bug with GitHub code hosts that did not label archived repos correctly when using the "public" repositoryQuery keyword.
+- Fixed a bug where a non-admin user could view another user’s batch spec executions individually via URL. [#42454](https://github.com/sourcegraph/sourcegraph/pull/42454)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,6 @@ All notable changes to Sourcegraph are documented in this file.
 - When updating the site configuration, the provided Last ID is now used to prevent race conditions when simultaneous config updates occur. [#42691](https://github.com/sourcegraph/sourcegraph/pull/42691)
 - When multiple auth providers of the same external service type is set up, there are now separate entries in the user's Account Security settings. [#42865](https://github.com/sourcegraph/sourcegraph/pull/42865)
 - Fixed a bug with GitHub code hosts that did not label archived repos correctly when using the "public" repositoryQuery keyword.
-- Fixed a bug where a non-admin user could view another user’s batch spec executions individually via URL. [#42454](https://github.com/sourcegraph/sourcegraph/pull/42454)
 
 ### Removed
 

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -30,11 +30,7 @@ export const BatchChangesChangelogAlert: React.FunctionComponent<React.PropsWith
                     </li>
                     <li>
                         Batch changes run on the server now support{' '}
-                        <Link
-                            to="/help/batch_changes/references/batch_spec_yaml_reference#steps-mount"
-                            rel="noopener"
-                            target="_blank"
-                        >
+                        <Link to="/help/batch_changes/how-tos/server_side_file_mounts" rel="noopener" target="_blank">
                             mounting files
                         </Link>
                         .

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { CardBody, Card, H3, H4 } from '@sourcegraph/wildcard'
+import { CardBody, Card, H3, H4, Link } from '@sourcegraph/wildcard'
 
 import { DismissibleAlert } from '../../../components/DismissibleAlert'
 
@@ -11,15 +11,33 @@ import styles from './BatchChangesListIntro.module.scss'
 export const BatchChangesChangelogAlert: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <DismissibleAlert
         className={styles.batchChangesListIntroAlert}
-        partialStorageKey="batch-changes-list-intro-changelog-4.0"
+        partialStorageKey="batch-changes-list-intro-changelog-4.1"
     >
         <Card className={classNames(styles.batchChangesListIntroCard, 'h-100')}>
             <CardBody>
-                <H4 as={H3}>Batch Changes updates in version 4.0</H4>
+                <H4 as={H3}>Batch Changes updates in version 4.1</H4>
                 <ul className="mb-0 pl-3">
                     <li>
-                        Code host connection tokens are no longer supported as a fallback method for syncing changesets
-                        in Batch Changes.
+                        Batch changes run on the server can now be created within{' '}
+                        <Link
+                            to="/help/batch_changes/how-tos/creating_a_batch_change#creating-a-batch-change-in-a-different-namespace"
+                            rel="noopener"
+                            target="_blank"
+                        >
+                            organizations
+                        </Link>
+                        .
+                    </li>
+                    <li>
+                        Batch changes run on the server now support{' '}
+                        <Link
+                            to="/help/batch_changes/references/batch_spec_yaml_reference#steps-mount"
+                            rel="noopener"
+                            target="_blank"
+                        >
+                            mounting files
+                        </Link>
+                        .
                     </li>
                 </ul>
             </CardBody>

--- a/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
@@ -6,6 +6,8 @@ import { CardBody, Card, Link, H4, Text } from '@sourcegraph/wildcard'
 
 import { SourcegraphIcon } from '../../../auth/icons'
 
+import { BatchChangesChangelogAlert } from './BatchChangesChangelogAlert'
+
 import styles from './BatchChangesListIntro.module.scss'
 
 export interface BatchChangesListIntroProps {
@@ -15,15 +17,26 @@ export interface BatchChangesListIntroProps {
 export const BatchChangesListIntro: React.FunctionComponent<React.PropsWithChildren<BatchChangesListIntroProps>> = ({
     isLicensed,
 }) => {
-    if (isLicensed === undefined || isLicensed === true) {
+    if (isLicensed === undefined) {
         return null
     }
 
     return (
         <div className="row">
-            <div className="col-12 mb-3">
-                <BatchChangesUnlicensedAlert />
-            </div>
+            {isLicensed === true ? (
+                <div className="col-12">
+                    <BatchChangesChangelogAlert />
+                </div>
+            ) : (
+                <>
+                    <div className="col-12 col-md-6 mb-3">
+                        <BatchChangesUnlicensedAlert />
+                    </div>
+                    <div className="col-12 col-md-6 mb-3">
+                        <BatchChangesChangelogAlert />
+                    </div>
+                </>
+            )}
         </div>
     )
 }

--- a/doc/batch_changes/how-tos/creating_a_batch_change.md
+++ b/doc/batch_changes/how-tos/creating_a_batch_change.md
@@ -4,6 +4,13 @@ Batch changes are created by writing a [batch spec](../references/batch_spec_yam
 
 Batch changes can also be used on [multiple projects within a monorepo](./creating_changesets_per_project_in_monorepos.md) by using the `workspaces` key in your batch spec.
 
+There are two paths to creating a batch change:
+
+- On your local machine, with the [Sourcegraph CLI](https://github.com/sourcegraph/src-cli)
+- Remotely, with [server-side execution](../explanations/server_side)
+
+Many concepts are shared between the two paths. However, this guide will walk you through creating a batch change the first way, on your local machine.
+
 ## Requirements
 
 - Sourcegraph instance with repositories in it. See the "[Quickstart](../../index.md#quick-install)" guide on how to setup a Sourcegraph instance.
@@ -91,3 +98,9 @@ By default, batch changes will use your username on Sourcegraph as your namespac
 ```
 src batch preview -f your_batch_spec.batch.yaml -namespace USERNAME_OR_ORG
 ```
+
+When creating a batch change server-side using the UI, you can select the namespace for the batch change to belong to at the time that you're creating it.
+
+### Administration
+
+Once a batch change is open, any Sourcegraph user can view it. However, the namespace determines who has the ability to administer it, such as editing or deleting it. When a batch change is created in a user namespace, only that user (and site admins) can administer it. When a batch change is created in an organization namespace, all members of that organization (and site admins) can administer it.

--- a/doc/batch_changes/how-tos/index.md
+++ b/doc/batch_changes/how-tos/index.md
@@ -13,6 +13,7 @@ The following is a list of how-tos that show how to use [Sourcegraph Batch Chang
 - [Changeset yaml formatting errors](yaml_changeset_errors.md)
 - [Opting out of Batch Changes](opting_out_of_batch_changes.md)
 - [Bulk operations on changesets](bulk_operations_on_changesets.md)
+- <span class="badge badge-experimental">Experimental</span> [Using file mounts in server-side](server_side_file_mounts.md)
 - Batch changes in monorepos
   - [Creating changesets per project in monorepos](creating_changesets_per_project_in_monorepos.md)
   - <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](creating_multiple_changesets_in_large_repositories.md)

--- a/doc/batch_changes/how-tos/index.md
+++ b/doc/batch_changes/how-tos/index.md
@@ -13,7 +13,7 @@ The following is a list of how-tos that show how to use [Sourcegraph Batch Chang
 - [Changeset yaml formatting errors](yaml_changeset_errors.md)
 - [Opting out of Batch Changes](opting_out_of_batch_changes.md)
 - [Bulk operations on changesets](bulk_operations_on_changesets.md)
-- <span class="badge badge-experimental">Experimental</span> [Using file mounts in server-side](server_side_file_mounts.md)
+- <span class="badge badge-experimental">Experimental</span> [Using file mounts with server-side execution](server_side_file_mounts.md)
 - Batch changes in monorepos
   - [Creating changesets per project in monorepos](creating_changesets_per_project_in_monorepos.md)
   - <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](creating_multiple_changesets_in_large_repositories.md)

--- a/doc/batch_changes/how-tos/server_side_file_mounts.md
+++ b/doc/batch_changes/how-tos/server_side_file_mounts.md
@@ -1,4 +1,4 @@
-# Using file mounts in server-side
+# Using file mounts with server-side execution
 
 <aside class="experimental">
 <p>
@@ -7,10 +7,10 @@
 
 <p><b>We're very much looking for input and feedback on this feature.</b> You can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
 
-<p>It's available in Sourcegraph 4.1 with <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 4.0.1 and later.</p>
+<p>This feature is available in Sourcegraph 4.1 with <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 4.0.1 and later.</p>
 </aside>
 
-> NOTE: Running a server-side execution with file [`mounts`](../references/batch_spec_yaml_reference.md#steps-mount) are
+> NOTE: Running a batch spec [server-side](../explanations/server_side.md) with file mounts is
 > currently only supported with <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a>.
 
 File [`mounts`](../references/batch_spec_yaml_reference.md#steps-mount) are a powerful way to run custom files without
@@ -65,15 +65,15 @@ changesetTemplate:
   published: false # Do not publish any changes to the code hosts yet
 ```
 
-<sub>NOTE: when running mounting files, ensure the appropriate `container` is used.</sub>
-
-Based on the above `mountpoint`, the Python script should live besides the batch spec.
+In this example, the Python script should live besides the batch spec file, as indicated by the `path`:
 
 ```text
 .
 ├── batch-spec.yml
 └── hello_appender.py
 ```
+
+Note that a `container` appropriate for the mounted file has also been chosen for this step.
 
 ## Running server-side
 

--- a/doc/batch_changes/how-tos/server_side_file_mounts.md
+++ b/doc/batch_changes/how-tos/server_side_file_mounts.md
@@ -1,0 +1,87 @@
+# Using file mounts in server-side
+
+<aside class="experimental">
+<p>
+<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change or be removed in the future. We've released it as an experimental feature to provide a preview of functionality we're working on.
+</p>
+
+<p><b>We're very much looking for input and feedback on this feature.</b> You can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
+
+<p>It's available in Sourcegraph 4.1 with <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 4.0.1 and later.</p>
+</aside>
+
+> NOTE: Running a server-side execution with file [`mounts`](../references/batch_spec_yaml_reference.md#steps-mount) are
+> currently only supported with <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a>.
+
+File [`mounts`](../references/batch_spec_yaml_reference.md#steps-mount) are a powerful way to run custom files without
+directly embedding the files in your batch spec.
+
+## Writing a batch spec
+
+In the following example, you have a Python script that appends "Hello World" to all `README.md` files.
+
+```python
+#!/usr/bin/env python3
+import os.path
+
+
+def main():
+  if os.path.exists('README.md'):
+    with open('README.md', 'a') as f:
+      f.write('\nHello World')
+
+
+if __name__ == "__main__":
+  main()
+```
+
+To use the Python script in your batch change, mount the script in a `step` using
+the [`mounts`](../references/batch_spec_yaml_reference.md#steps-mount) field. The following is an example of mounting
+the above Python script in a `step`.
+
+```yaml
+name: hello-world
+description: Add Hello World to READMEs
+
+# Find all repositories that contain a README.md file.
+on:
+  - repositoriesMatchingQuery: file:README.md
+
+# In each repository, run this command. Each repository's resulting diff is captured.
+steps:
+  - run: python /tmp/hello_appender.py
+    container: python:latest
+    mount:
+      - path: ./hello_appender.py
+        mountpoint: /tmp/hello_appender.py
+
+# Describe the changeset (e.g., GitHub pull request) you want for each repository.
+changesetTemplate:
+  title: Hello World
+  body: My first batch change!
+  branch: hello-world # Push the commit to this branch.
+  commit:
+    message: Append Hello World to all README.md files
+  published: false # Do not publish any changes to the code hosts yet
+```
+
+<sub>NOTE: when running mounting files, ensure the appropriate `container` is used.</sub>
+
+Based on the above `mountpoint`, the Python script should live besides the batch spec.
+
+```text
+.
+├── batch-spec.yml
+└── hello_appender.py
+```
+
+## Running server-side
+
+After writing the batch spec, use the <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI (`src`)</a>
+command [`remote`](../../cli/references/batch/remote.md) to execute the batch spec server-side.
+
+```shell
+src batch remote -f batch-spec.yml
+```
+
+Once successful, `src` provides a URL to the execution of the batch change.

--- a/doc/batch_changes/index.md
+++ b/doc/batch_changes/index.md
@@ -89,7 +89,7 @@ Create a batch change by specifying a search query to get a list of repositories
 - [Handling errored changesets](how-tos/handling_errored_changesets.md)
 - [Opting out of batch changes](how-tos/opting_out_of_batch_changes.md)
 - [Bulk operations on changesets](how-tos/bulk_operations_on_changesets.md)
-- <span class="badge badge-experimental">Experimental</span> [Using file mounts in server-side](how-tos/server_side_file_mounts.md)
+- <span class="badge badge-experimental">Experimental</span> [Using file mounts with server-side execution](how-tos/server_side_file_mounts.md)
 - Batch changes in monorepos <span class="badge badge-experimental">Experimental</span>
   - [Creating changesets per project in monorepos](how-tos/creating_changesets_per_project_in_monorepos.md)
   - <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](how-tos/creating_multiple_changesets_in_large_repositories.md)

--- a/doc/batch_changes/index.md
+++ b/doc/batch_changes/index.md
@@ -89,6 +89,7 @@ Create a batch change by specifying a search query to get a list of repositories
 - [Handling errored changesets](how-tos/handling_errored_changesets.md)
 - [Opting out of batch changes](how-tos/opting_out_of_batch_changes.md)
 - [Bulk operations on changesets](how-tos/bulk_operations_on_changesets.md)
+- <span class="badge badge-experimental">Experimental</span> [Using file mounts in server-side](how-tos/server_side_file_mounts.md)
 - Batch changes in monorepos <span class="badge badge-experimental">Experimental</span>
   - [Creating changesets per project in monorepos](how-tos/creating_changesets_per_project_in_monorepos.md)
   - <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](how-tos/creating_multiple_changesets_in_large_repositories.md)

--- a/doc/batch_changes/references/batch_spec_yaml_reference.md
+++ b/doc/batch_changes/references/batch_spec_yaml_reference.md
@@ -433,6 +433,8 @@ path is absolute or relative, the path must be within the same directory as the 
 spec directory is considered the "working directory"). If the batch spec is provided using standard input, the current 
 directory is used as the working directory.
 
+Individual files are restricted to a max size of 10MB. Do not include any sensitive information in files being uploaded.
+
 ### Examples
 
 ```yaml


### PR DESCRIPTION
- Updates items for in-app changelog for 4.1
- Restore visibility of in-app changelog
- Clarifies docs for "creating a batch change" in two ways:
  1. That this doc is focused on creating batch changes with src-cli
  2. How the namespace affects administration controls over a batch change
- @Piszmog - adds a new guide for using remote file mounts with src-cli
- @adeola-ak - adds CHANGELOG items for issues completed this release that we forgot to put in earlier

## Test plan

Manually verified changelog appearance + links:

https://user-images.githubusercontent.com/8942601/196264233-2b4c9721-a7bd-4b44-8230-2e6f5dcea6e7.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-4-1-batches-changelog.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qvoeftmcsh.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
