### PR TITLE
insights: Log code insights pings errors at warn log level

### DIFF
--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -394,6 +394,8 @@ func updateBody(ctx context.Context, logger log.Logger, db database.DB) (io.Read
 	if envvar.SourcegraphDotComMode() {
 		logFunc = scopedLog.Warn
 	}
+	// Used for cases where large pings objects might otherwise fail silently.
+	logFuncError := scopedLog.Error
 
 	r := &pingRequest{
 		ClientSiteID:                  siteid.Get(),
@@ -515,7 +517,7 @@ func updateBody(ctx context.Context, logger log.Logger, db database.DB) (io.Read
 
 		r.CodeInsightsUsage, err = getAndMarshalCodeInsightsUsageJSON(ctx, db)
 		if err != nil {
-			logFunc("getAndMarshalCodeInsightsUsageJSON failed", log.Error(err))
+			logFuncError("getAndMarshalCodeInsightsUsageJSON failed", log.Error(err))
 		}
 
 		r.CodeMonitoringUsage, err = getAndMarshalCodeMonitoringUsageJSON(ctx, db)

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -395,7 +395,7 @@ func updateBody(ctx context.Context, logger log.Logger, db database.DB) (io.Read
 		logFunc = scopedLog.Warn
 	}
 	// Used for cases where large pings objects might otherwise fail silently.
-	logFuncError := scopedLog.Error
+	logFuncWarn := scopedLog.Warn
 
 	r := &pingRequest{
 		ClientSiteID:                  siteid.Get(),
@@ -517,7 +517,7 @@ func updateBody(ctx context.Context, logger log.Logger, db database.DB) (io.Read
 
 		r.CodeInsightsUsage, err = getAndMarshalCodeInsightsUsageJSON(ctx, db)
 		if err != nil {
-			logFuncError("getAndMarshalCodeInsightsUsageJSON failed", log.Error(err))
+			logFuncWarn("getAndMarshalCodeInsightsUsageJSON failed", log.Error(err))
 		}
 
 		r.CodeMonitoringUsage, err = getAndMarshalCodeMonitoringUsageJSON(ctx, db)


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/41965

## Description

I looked into a couple of different ways to solve this. At first I started down the path of logging individual errors for each of our ping objects (within `CodeInsightsUsage`,) but that breaks the pattern of how the rest of the pings work and would bypass error handling being done [higher up](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/internal/app/updatecheck/client.go?L516:8&subtree=true). And I was concerned that we might end up sending malformed data, which could potentially cause a larger issue and be more complicated to deal with.

I think the real issue is that when pings fail, it's only logged at the debug level which we don't log on `k8s` or `s2`. There could be [noise associated with certain pings](https://sourcegraph.slack.com/archives/C07KZF47K/p1665503738388769?thread_ts=1665413761.983639&cid=C07KZF47K), so I opted not to change the logging level for all of them, but added another log scope that can be used for larger pings objects that we don't expect to fail.

This can then be combined with alerts on grafana (for k8s) and gcp (for s2,) such that we'll be alerted if our pings object is failing on either of those dogfooding/testing environments. That would have solved the issue we ran into last time.

## Test plan

I found that I can cause an error in our pings by inserting a string for the `index` argument for the `GroupResultsChartBarHover` ping. So I'll do that on k8s and s2 after merging to verify that we get a log, and can also use that to set up and test the alerts.

Also easy to test locally by introducing an error and verifying that it logs it at warn level.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
