### PR TITLE
monitoring: add k8s.sgdev.org dashboard for zoekt i/o metrics

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -16561,7 +16561,7 @@ Query: `sum by (container_label_io_kubernetes_pod_name) (rate(container_network_
 
 #### zoekt: data_disk_reads_sec
 
-<p class="subtitle">Data disk read request rate over 1m (per instance)</p>
+<p class="subtitle">Data disk read request rate over 2m (per instance)</p>
 
 The number of read requests that were issued to the device per second.
 
@@ -16581,7 +16581,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100800` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])`
+Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m])`
 
 </details>
 
@@ -16589,7 +16589,7 @@ Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${in
 
 #### zoekt: data_disk_writes_sec
 
-<p class="subtitle">Data disk write request rate over 1m (per instance)</p>
+<p class="subtitle">Data disk write request rate over 2m (per instance)</p>
 
 The number of write requests that were issued to the device per second.
 
@@ -16608,7 +16608,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100801` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])`
+Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m])`
 
 </details>
 
@@ -16616,7 +16616,7 @@ Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${in
 
 #### zoekt: data_disk_read_throughput
 
-<p class="subtitle">Data disk read throughput over 1m (per instance)</p>
+<p class="subtitle">Data disk read throughput over 2m (per instance)</p>
 
 The amount of data that was read from the device per second.
 
@@ -16635,7 +16635,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100810` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])`
+Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[2m])`
 
 </details>
 
@@ -16643,7 +16643,7 @@ Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${in
 
 #### zoekt: data_disk_write_throughput
 
-<p class="subtitle">Data disk write throughput over 1m (per instance)</p>
+<p class="subtitle">Data disk write throughput over 2m (per instance)</p>
 
 The amount of data that was written to the device per second.
 
@@ -16662,7 +16662,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100811` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])`
+Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[2m])`
 
 </details>
 
@@ -16670,7 +16670,7 @@ Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${in
 
 #### zoekt: data_disk_read_duration
 
-<p class="subtitle">Data disk average read duration over 1m (per instance)</p>
+<p class="subtitle">Data disk average read duration over 2m (per instance)</p>
 
 The average time for read requests issued to the device to be served. This includes the time spent
 by the requests in queue and the time spent servicing them.
@@ -16690,7 +16690,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100820` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_time_seconds_total{instance=~`node-exporter.*`}[1m])) / (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))`
+Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_time_seconds_total{instance=~`node-exporter.*`}[2m])) / (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m])))`
 
 </details>
 
@@ -16698,7 +16698,7 @@ Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${
 
 #### zoekt: data_disk_write_duration
 
-<p class="subtitle">Data disk average write duration over 1m (per instance)</p>
+<p class="subtitle">Data disk average write duration over 2m (per instance)</p>
 
 The average time for write requests issued to the device to be served. This includes the time spent
 by the requests in queue and the time spent servicing them.
@@ -16718,7 +16718,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100821` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_write_time_seconds_total{instance=~`node-exporter.*`}[1m])) / (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))`
+Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_write_time_seconds_total{instance=~`node-exporter.*`}[2m])) / (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m])))`
 
 </details>
 
@@ -16726,7 +16726,7 @@ Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${
 
 #### zoekt: data_disk_read_request_size
 
-<p class="subtitle">Data disk average read request size over 1m (per instance)</p>
+<p class="subtitle">Data disk average read request size over 2m (per instance)</p>
 
 	The average size of read requests that were issued to the device.
 
@@ -16745,7 +16745,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100830` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])) / (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))`
+Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[2m])) / (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m])))`
 
 </details>
 
@@ -16753,7 +16753,7 @@ Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${
 
 #### zoekt: data_disk_write_request_size
 
-<p class="subtitle">Data disk average write request size over 1m (per instance)</p>
+<p class="subtitle">Data disk average write request size over 2m (per instance)</p>
 
 	The average size of write requests that were issued to the device.
 
@@ -16772,7 +16772,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100831` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])) / (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))`
+Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[2m])) / (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m])))`
 
 </details>
 
@@ -16780,7 +16780,7 @@ Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${
 
 #### zoekt: data_disk_reads_merged_sec
 
-<p class="subtitle">Data disk merged read request rate over 1m (per instance)</p>
+<p class="subtitle">Data disk merged read request rate over 2m (per instance)</p>
 
 	The number of read requests merged per second that were queued to the device.
 
@@ -16799,7 +16799,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100840` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_merged_total{instance=~`node-exporter.*`}[1m])`
+Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_merged_total{instance=~`node-exporter.*`}[2m])`
 
 </details>
 
@@ -16807,7 +16807,7 @@ Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${in
 
 #### zoekt: data_disk_writes_merged_sec
 
-<p class="subtitle">Data disk merged writes request rate over 1m (per instance)</p>
+<p class="subtitle">Data disk merged writes request rate over 2m (per instance)</p>
 
 	The number of write requests merged per second that were queued to the device.
 
@@ -16826,7 +16826,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100841` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_merged_total{instance=~`node-exporter.*`}[1m])`
+Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_merged_total{instance=~`node-exporter.*`}[2m])`
 
 </details>
 
@@ -16834,7 +16834,7 @@ Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${in
 
 #### zoekt: data_disk_average_queue_size
 
-<p class="subtitle">Data disk average queue size over 1m (per instance)</p>
+<p class="subtitle">Data disk average queue size over 2m (per instance)</p>
 
 							The number of I/O operations that were being queued or being serviced. See
 							https://blog.actorsfit.com/a?ID=00200-428fa2ac-e338-4540-848c-af9a3eb1ebd2 for background (avgqu-sz).
@@ -16854,7 +16854,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100850` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_io_time_weighted_seconds_total{instance=~`node-exporter.*`}[1m])`
+Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_io_time_weighted_seconds_total{instance=~`node-exporter.*`}[2m])`
 
 </details>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -16557,6 +16557,309 @@ Query: `sum by (container_label_io_kubernetes_pod_name) (rate(container_network_
 
 <br />
 
+### Zoekt: Disk I/O metrics (only available on Sourcegraph internal instances)
+
+#### zoekt: data_disk_reads_sec
+
+<p class="subtitle">Data disk read request rate over 1m (per instance)</p>
+
+The number of read requests that were issued to the device per second.
+
+
+Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+These statistics are best interpreted as the load experienced by the device Zoekt is
+using, not the load Zoekt is solely responsible for causing.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100800` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])`
+
+</details>
+
+<br />
+
+#### zoekt: data_disk_writes_sec
+
+<p class="subtitle">Data disk write request rate over 1m (per instance)</p>
+
+The number of write requests that were issued to the device per second.
+
+Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+These statistics are best interpreted as the load experienced by the device Zoekt is
+using, not the load Zoekt is solely responsible for causing.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100801` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])`
+
+</details>
+
+<br />
+
+#### zoekt: data_disk_read_throughput
+
+<p class="subtitle">Data disk read throughput over 1m (per instance)</p>
+
+The amount of data that was read from the device per second.
+
+Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+These statistics are best interpreted as the load experienced by the device Zoekt is
+using, not the load Zoekt is solely responsible for causing.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100810` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])`
+
+</details>
+
+<br />
+
+#### zoekt: data_disk_write_throughput
+
+<p class="subtitle">Data disk write throughput over 1m (per instance)</p>
+
+The amount of data that was written to the device per second.
+
+Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+These statistics are best interpreted as the load experienced by the device Zoekt is
+using, not the load Zoekt is solely responsible for causing.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100811` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])`
+
+</details>
+
+<br />
+
+#### zoekt: data_disk_read_duration
+
+<p class="subtitle">Data disk average read duration over 1m (per instance)</p>
+
+The average time for read requests issued to the device to be served. This includes the time spent
+by the requests in queue and the time spent servicing them.
+
+Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+These statistics are best interpreted as the load experienced by the device Zoekt is
+using, not the load Zoekt is solely responsible for causing.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100820` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_time_seconds_total{instance=~`node-exporter.*`}[1m])) / (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))`
+
+</details>
+
+<br />
+
+#### zoekt: data_disk_write_duration
+
+<p class="subtitle">Data disk average write duration over 1m (per instance)</p>
+
+The average time for write requests issued to the device to be served. This includes the time spent
+by the requests in queue and the time spent servicing them.
+
+Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+These statistics are best interpreted as the load experienced by the device Zoekt is
+using, not the load Zoekt is solely responsible for causing.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100821` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_write_time_seconds_total{instance=~`node-exporter.*`}[1m])) / (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))`
+
+</details>
+
+<br />
+
+#### zoekt: data_disk_read_request_size
+
+<p class="subtitle">Data disk average read request size over 1m (per instance)</p>
+
+	The average size of read requests that were issued to the device.
+
+	Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+	as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+	These statistics are best interpreted as the load experienced by the device Zoekt is
+	using, not the load Zoekt is solely responsible for causing.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100830` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])) / (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))`
+
+</details>
+
+<br />
+
+#### zoekt: data_disk_write_request_size
+
+<p class="subtitle">Data disk average write request size over 1m (per instance)</p>
+
+	The average size of write requests that were issued to the device.
+
+	Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+	as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+	These statistics are best interpreted as the load experienced by the device Zoekt is
+	using, not the load Zoekt is solely responsible for causing.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100831` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])) / (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))`
+
+</details>
+
+<br />
+
+#### zoekt: data_disk_reads_merged_sec
+
+<p class="subtitle">Data disk merged read request rate over 1m (per instance)</p>
+
+	The number of read requests merged per second that were queued to the device.
+
+	Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+	as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+	These statistics are best interpreted as the load experienced by the device Zoekt is
+	using, not the load Zoekt is solely responsible for causing.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100840` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_merged_total{instance=~`node-exporter.*`}[1m])`
+
+</details>
+
+<br />
+
+#### zoekt: data_disk_writes_merged_sec
+
+<p class="subtitle">Data disk merged writes request rate over 1m (per instance)</p>
+
+	The number of write requests merged per second that were queued to the device.
+
+	Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+	as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+	These statistics are best interpreted as the load experienced by the device Zoekt is
+	using, not the load Zoekt is solely responsible for causing.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100841` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_merged_total{instance=~`node-exporter.*`}[1m])`
+
+</details>
+
+<br />
+
+#### zoekt: data_disk_average_queue_size
+
+<p class="subtitle">Data disk average queue size over 1m (per instance)</p>
+
+							The number of I/O operations that were being queued or being serviced. See
+							https://blog.actorsfit.com/a?ID=00200-428fa2ac-e338-4540-848c-af9a3eb1ebd2 for background (avgqu-sz).
+
+							Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+							as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+							These statistics are best interpreted as the load experienced by the device Zoekt is
+							using, not the load Zoekt is solely responsible for causing.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100850` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_io_time_weighted_seconds_total{instance=~`node-exporter.*`}[1m])`
+
+</details>
+
+<br />
+
 ### Zoekt: [zoekt-indexserver] Container monitoring (not available on server)
 
 #### zoekt: container_missing
@@ -16575,7 +16878,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100800` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100900` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
@@ -16594,7 +16897,7 @@ Query: `count by(name) ((time() - container_last_seen{name=~"^zoekt-indexserver.
 
 Refer to the [alerts reference](./alerts.md#zoekt-container-cpu-usage) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100801` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100901` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
@@ -16613,7 +16916,7 @@ Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-indexserver.
 
 Refer to the [alerts reference](./alerts.md#zoekt-container-memory-usage) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100802` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100902` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
@@ -16635,7 +16938,7 @@ When extremely high, this can indicate a resource usage problem, or can cause pr
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100803` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100903` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
@@ -16666,7 +16969,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100900` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101000` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
@@ -16685,7 +16988,7 @@ Query: `count by(name) ((time() - container_last_seen{name=~"^zoekt-webserver.*"
 
 Refer to the [alerts reference](./alerts.md#zoekt-container-cpu-usage) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100901` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101001` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
@@ -16704,7 +17007,7 @@ Query: `cadvisor_container_cpu_usage_percentage_total{name=~"^zoekt-webserver.*"
 
 Refer to the [alerts reference](./alerts.md#zoekt-container-memory-usage) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100902` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101002` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
@@ -16726,7 +17029,7 @@ When extremely high, this can indicate a resource usage problem, or can cause pr
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100903` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101003` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
@@ -16747,7 +17050,7 @@ Query: `sum by(name) (rate(container_fs_reads_total{name=~"^zoekt-webserver.*"}[
 
 Refer to the [alerts reference](./alerts.md#zoekt-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101000` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101100` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
@@ -16766,7 +17069,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 Refer to the [alerts reference](./alerts.md#zoekt-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101001` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101101` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
@@ -16785,7 +17088,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^z
 
 Refer to the [alerts reference](./alerts.md#zoekt-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101010` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101110` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
@@ -16804,7 +17107,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^zoek
 
 Refer to the [alerts reference](./alerts.md#zoekt-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101011` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101111` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
@@ -16826,7 +17129,7 @@ When it occurs frequently, it is an indicator of underprovisioning.
 
 Refer to the [alerts reference](./alerts.md#zoekt-container-oomkill-events-total) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101012` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101112` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
@@ -16847,7 +17150,7 @@ Query: `max by (name) (container_oom_events_total{name=~"^zoekt-indexserver.*"})
 
 Refer to the [alerts reference](./alerts.md#zoekt-provisioning-container-cpu-usage-long-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101100` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101200` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
@@ -16866,7 +17169,7 @@ Query: `quantile_over_time(0.9, cadvisor_container_cpu_usage_percentage_total{na
 
 Refer to the [alerts reference](./alerts.md#zoekt-provisioning-container-memory-usage-long-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101101` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101201` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
@@ -16885,7 +17188,7 @@ Query: `max_over_time(cadvisor_container_memory_usage_percentage_total{name=~"^z
 
 Refer to the [alerts reference](./alerts.md#zoekt-provisioning-container-cpu-usage-short-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101110` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101210` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
@@ -16904,7 +17207,7 @@ Query: `max_over_time(cadvisor_container_cpu_usage_percentage_total{name=~"^zoek
 
 Refer to the [alerts reference](./alerts.md#zoekt-provisioning-container-memory-usage-short-term) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101111` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101211` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
@@ -16926,7 +17229,7 @@ When it occurs frequently, it is an indicator of underprovisioning.
 
 Refer to the [alerts reference](./alerts.md#zoekt-container-oomkill-events-total) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101112` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101212` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 
@@ -16947,7 +17250,7 @@ Query: `max by (name) (container_oom_events_total{name=~"^zoekt-webserver.*"})`
 
 Refer to the [alerts reference](./alerts.md#zoekt-pods-available-percentage) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101200` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=101300` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Search Core team](https://handbook.sourcegraph.com/departments/engineering/teams/search/core).*</sub>
 

--- a/monitoring/definitions/zoekt.go
+++ b/monitoring/definitions/zoekt.go
@@ -929,8 +929,8 @@ func Zoekt() *monitoring.Dashboard {
 					{
 						{
 							Name:        "data_disk_reads_sec",
-							Description: "data disk read request rate over 1m (per instance)",
-							Query:       fmt.Sprintf("%s rate(node_disk_reads_completed_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
+							Description: "data disk read request rate over 2m (per instance)",
+							Query:       fmt.Sprintf("%s rate(node_disk_reads_completed_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.ReadsPerSecond).
@@ -949,8 +949,8 @@ func Zoekt() *monitoring.Dashboard {
 						},
 						{
 							Name:        "data_disk_writes_sec",
-							Description: "data disk write request rate over 1m (per instance)",
-							Query:       fmt.Sprintf("%s rate(node_disk_writes_completed_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
+							Description: "data disk write request rate over 2m (per instance)",
+							Query:       fmt.Sprintf("%s rate(node_disk_writes_completed_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.WritesPerSecond).
@@ -970,8 +970,8 @@ func Zoekt() *monitoring.Dashboard {
 					{
 						{
 							Name:        "data_disk_read_throughput",
-							Description: "data disk read throughput over 1m (per instance)",
-							Query:       fmt.Sprintf("%s rate(node_disk_read_bytes_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
+							Description: "data disk read throughput over 2m (per instance)",
+							Query:       fmt.Sprintf("%s rate(node_disk_read_bytes_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.BytesPerSecond).
@@ -989,8 +989,8 @@ func Zoekt() *monitoring.Dashboard {
 						},
 						{
 							Name:        "data_disk_write_throughput",
-							Description: "data disk write throughput over 1m (per instance)",
-							Query:       fmt.Sprintf("%s rate(node_disk_written_bytes_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
+							Description: "data disk write throughput over 2m (per instance)",
+							Query:       fmt.Sprintf("%s rate(node_disk_written_bytes_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.BytesPerSecond).
@@ -1010,11 +1010,11 @@ func Zoekt() *monitoring.Dashboard {
 					{
 						{
 							Name:        "data_disk_read_duration",
-							Description: "data disk average read duration over 1m (per instance)",
+							Description: "data disk average read duration over 2m (per instance)",
 
 							Query: fmt.Sprintf("((%s) / (%s))",
-								fmt.Sprintf("%s rate(node_disk_read_time_seconds_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
-								fmt.Sprintf("%s rate(node_disk_reads_completed_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("%s rate(node_disk_read_time_seconds_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("%s rate(node_disk_reads_completed_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							),
 							NoAlert: true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -1034,11 +1034,11 @@ func Zoekt() *monitoring.Dashboard {
 						},
 						{
 							Name:        "data_disk_write_duration",
-							Description: "data disk average write duration over 1m (per instance)",
+							Description: "data disk average write duration over 2m (per instance)",
 
 							Query: fmt.Sprintf("((%s) / (%s))",
-								fmt.Sprintf("%s rate(node_disk_write_time_seconds_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
-								fmt.Sprintf("%s rate(node_disk_writes_completed_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("%s rate(node_disk_write_time_seconds_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("%s rate(node_disk_writes_completed_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							),
 							NoAlert: true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -1060,10 +1060,10 @@ func Zoekt() *monitoring.Dashboard {
 					{
 						{
 							Name:        "data_disk_read_request_size",
-							Description: "data disk average read request size over 1m (per instance)",
+							Description: "data disk average read request size over 2m (per instance)",
 							Query: fmt.Sprintf("((%s) / (%s))",
-								fmt.Sprintf("%s rate(node_disk_read_bytes_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
-								fmt.Sprintf("%s rate(node_disk_reads_completed_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("%s rate(node_disk_read_bytes_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("%s rate(node_disk_reads_completed_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							),
 							NoAlert: true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -1082,10 +1082,10 @@ func Zoekt() *monitoring.Dashboard {
 						},
 						{
 							Name:        "data_disk_write_request_size",
-							Description: "data disk average write request size over 1m (per instance)",
+							Description: "data disk average write request size over 2m (per instance)",
 							Query: fmt.Sprintf("((%s) / (%s))",
-								fmt.Sprintf("%s rate(node_disk_written_bytes_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
-								fmt.Sprintf("%s rate(node_disk_writes_completed_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("%s rate(node_disk_written_bytes_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("%s rate(node_disk_writes_completed_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							),
 							NoAlert: true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -1106,8 +1106,8 @@ func Zoekt() *monitoring.Dashboard {
 					{
 						{
 							Name:        "data_disk_reads_merged_sec",
-							Description: "data disk merged read request rate over 1m (per instance)",
-							Query:       fmt.Sprintf("%s rate(node_disk_reads_merged_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
+							Description: "data disk merged read request rate over 2m (per instance)",
+							Query:       fmt.Sprintf("%s rate(node_disk_reads_merged_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.RequestsPerSecond).
@@ -1125,8 +1125,8 @@ func Zoekt() *monitoring.Dashboard {
 						},
 						{
 							Name:        "data_disk_writes_merged_sec",
-							Description: "data disk merged writes request rate over 1m (per instance)",
-							Query:       fmt.Sprintf("%s rate(node_disk_writes_merged_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
+							Description: "data disk merged writes request rate over 2m (per instance)",
+							Query:       fmt.Sprintf("%s rate(node_disk_writes_merged_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.RequestsPerSecond).
@@ -1147,8 +1147,8 @@ func Zoekt() *monitoring.Dashboard {
 						{
 
 							Name:        "data_disk_average_queue_size",
-							Description: "data disk average queue size over 1m (per instance)",
-							Query:       fmt.Sprintf("%s rate(node_disk_io_time_weighted_seconds_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
+							Description: "data disk average queue size over 2m (per instance)",
+							Query:       fmt.Sprintf("%s rate(node_disk_io_time_weighted_seconds_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit("req").

--- a/monitoring/definitions/zoekt.go
+++ b/monitoring/definitions/zoekt.go
@@ -15,6 +15,9 @@ func Zoekt() *monitoring.Dashboard {
 		indexServerContainerName = "zoekt-indexserver"
 		webserverContainerName   = "zoekt-webserver"
 		bundledContainerName     = "indexed-search"
+
+		mountInfoDataDir          = "indexDir"
+		nodeExporterInstanceRegex = `node-exporter.*`
 	)
 
 	return &monitoring.Dashboard{
@@ -913,6 +916,252 @@ func Zoekt() *monitoring.Dashboard {
 								With(monitoring.PanelOptions.LegendOnRight()),
 							Owner:          monitoring.ObservableOwnerSearchCore,
 							Interpretation: "An increase in errors while receiving could indicate a networking issue.",
+						},
+					},
+				},
+			},
+			{
+				Title:  "Disk I/O metrics (only available on Sourcegraph internal instances)",
+				Hidden: true,
+				Rows: []monitoring.Row{
+					{
+						{
+							Name:        "data_disk_reads_sec",
+							Description: "data disk read request rate over 1m (per instance)",
+							Query:       fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+							NoAlert:     true,
+							Panel: monitoring.Panel().LegendFormat("{{instance}}").
+								Unit(monitoring.ReadsPerSecond).
+								With(monitoring.PanelOptions.LegendOnRight()),
+							Owner: monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								The number of read requests that were issued to the device per second.
+
+
+								Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+								as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+								These statistics are best interpreted as the load experienced by the device Zoekt is
+								using, not the load Zoekt is solely responsible for causing.
+							`,
+						},
+						{
+							Name:        "data_disk_writes_sec",
+							Description: "data disk write request rate over 1m (per instance)",
+							Query:       fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+							NoAlert:     true,
+							Panel: monitoring.Panel().LegendFormat("{{instance}}").
+								Unit(monitoring.WritesPerSecond).
+								With(monitoring.PanelOptions.LegendOnRight()),
+							Owner: monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								The number of write requests that were issued to the device per second.
+
+								Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+								as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+								These statistics are best interpreted as the load experienced by the device Zoekt is
+								using, not the load Zoekt is solely responsible for causing.
+							`,
+						},
+					},
+					{
+						{
+							Name:        "data_disk_read_throughput",
+							Description: "data disk read throughput over 1m (per instance)",
+							Query:       fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_bytes_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+							NoAlert:     true,
+							Panel: monitoring.Panel().LegendFormat("{{instance}}").
+								Unit(monitoring.BytesPerSecond).
+								With(monitoring.PanelOptions.LegendOnRight()),
+							Owner: monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								The amount of data that was read from the device per second.
+
+								Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+								as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+								These statistics are best interpreted as the load experienced by the device Zoekt is
+								using, not the load Zoekt is solely responsible for causing.
+							`,
+						},
+						{
+							Name:        "data_disk_write_throughput",
+							Description: "data disk write throughput over 1m (per instance)",
+							Query:       fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_written_bytes_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+							NoAlert:     true,
+							Panel: monitoring.Panel().LegendFormat("{{instance}}").
+								Unit(monitoring.BytesPerSecond).
+								With(monitoring.PanelOptions.LegendOnRight()),
+							Owner: monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								The amount of data that was written to the device per second.
+
+								Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+								as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+								These statistics are best interpreted as the load experienced by the device Zoekt is
+								using, not the load Zoekt is solely responsible for causing.
+							`,
+						},
+					},
+					{
+						{
+							Name:        "data_disk_read_duration",
+							Description: "data disk average read duration over 1m (per instance)",
+
+							Query: fmt.Sprintf("((%s) / (%s))",
+								fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_time_seconds_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+								fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+							),
+							NoAlert: true,
+							Panel: monitoring.Panel().LegendFormat("{{instance}}").
+								Unit(monitoring.Seconds).
+								With(monitoring.PanelOptions.LegendOnRight()),
+							Owner: monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								The average time for read requests issued to the device to be served. This includes the time spent
+								by the requests in queue and the time spent servicing them.
+
+								Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+								as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+								These statistics are best interpreted as the load experienced by the device Zoekt is
+								using, not the load Zoekt is solely responsible for causing.
+							`,
+						},
+						{
+							Name:        "data_disk_write_duration",
+							Description: "data disk average write duration over 1m (per instance)",
+
+							Query: fmt.Sprintf("((%s) / (%s))",
+								fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_write_time_seconds_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+								fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+							),
+							NoAlert: true,
+							Panel: monitoring.Panel().LegendFormat("{{instance}}").
+								Unit(monitoring.Seconds).
+								With(monitoring.PanelOptions.LegendOnRight()),
+							Owner: monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								The average time for write requests issued to the device to be served. This includes the time spent
+								by the requests in queue and the time spent servicing them.
+
+								Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+								as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+								These statistics are best interpreted as the load experienced by the device Zoekt is
+								using, not the load Zoekt is solely responsible for causing.
+							`,
+						},
+					},
+					{
+						{
+							Name:        "data_disk_read_request_size",
+							Description: "data disk average read request size over 1m (per instance)",
+							Query: fmt.Sprintf("((%s) / (%s))",
+								fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_bytes_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+								fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+							),
+							NoAlert: true,
+							Panel: monitoring.Panel().LegendFormat("{{instance}}").
+								Unit(monitoring.Bytes).
+								With(monitoring.PanelOptions.LegendOnRight()),
+							Owner: monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								The average size of read requests that were issued to the device.
+
+								Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+								as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+								These statistics are best interpreted as the load experienced by the device Zoekt is
+								using, not the load Zoekt is solely responsible for causing.
+						`,
+						},
+						{
+							Name:        "data_disk_write_request_size",
+							Description: "data disk average write request size over 1m (per instance)",
+							Query: fmt.Sprintf("((%s) / (%s))",
+								fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_written_bytes_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+								fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+							),
+							NoAlert: true,
+							Panel: monitoring.Panel().LegendFormat("{{instance}}").
+								Unit(monitoring.Bytes).
+								With(monitoring.PanelOptions.LegendOnRight()),
+							Owner: monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								The average size of write requests that were issued to the device.
+
+								Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+								as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+								These statistics are best interpreted as the load experienced by the device Zoekt is
+								using, not the load Zoekt is solely responsible for causing.
+						`,
+						},
+					},
+					{
+						{
+							Name:        "data_disk_reads_merged_sec",
+							Description: "data disk merged read request rate over 1m (per instance)",
+							Query:       fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_merged_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+							NoAlert:     true,
+							Panel: monitoring.Panel().LegendFormat("{{instance}}").
+								Unit(monitoring.RequestsPerSecond).
+								With(monitoring.PanelOptions.LegendOnRight()),
+							Owner: monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								The number of read requests merged per second that were queued to the device.
+
+								Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+								as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+								These statistics are best interpreted as the load experienced by the device Zoekt is
+								using, not the load Zoekt is solely responsible for causing.
+						`,
+						},
+						{
+							Name:        "data_disk_writes_merged_sec",
+							Description: "data disk merged writes request rate over 1m (per instance)",
+							Query:       fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_merged_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+							NoAlert:     true,
+							Panel: monitoring.Panel().LegendFormat("{{instance}}").
+								Unit(monitoring.RequestsPerSecond).
+								With(monitoring.PanelOptions.LegendOnRight()),
+							Owner: monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								The number of write requests merged per second that were queued to the device.
+
+								Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+								as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+								These statistics are best interpreted as the load experienced by the device Zoekt is
+								using, not the load Zoekt is solely responsible for causing.
+						`,
+						},
+					},
+					{
+						{
+
+							Name:        "data_disk_average_queue_size",
+							Description: "data disk average queue size over 1m (per instance)",
+							Query:       fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_io_time_weighted_seconds_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+							NoAlert:     true,
+							Panel: monitoring.Panel().LegendFormat("{{instance}}").
+								Unit("req").
+								With(monitoring.PanelOptions.LegendOnRight()),
+							Owner: monitoring.ObservableOwnerSearchCore,
+							Interpretation: `
+								The number of I/O operations that were being queued or being serviced. See
+								https://blog.actorsfit.com/a?ID=00200-428fa2ac-e338-4540-848c-af9a3eb1ebd2 for background (avgqu-sz).
+
+								Note: Disk statistics are per _device_, not per _service_. In certain environments (such
+								as common docker-compose setups), Zoekt could be one of _many services_ using this disk.
+
+								These statistics are best interpreted as the load experienced by the device Zoekt is
+								using, not the load Zoekt is solely responsible for causing.
+`,
 						},
 					},
 				},

--- a/monitoring/definitions/zoekt.go
+++ b/monitoring/definitions/zoekt.go
@@ -20,6 +20,8 @@ func Zoekt() *monitoring.Dashboard {
 		nodeExporterInstanceRegex = `node-exporter.*`
 	)
 
+	joinOnMountInfo := "zoekt_indexserver_mount_point_info{mount_name=\"indexDir\",instance=~`${instance:regex}`} * on (nodename, device) group_left"
+
 	return &monitoring.Dashboard{
 		Name:                     "zoekt",
 		Title:                    "Zoekt",
@@ -928,7 +930,7 @@ func Zoekt() *monitoring.Dashboard {
 						{
 							Name:        "data_disk_reads_sec",
 							Description: "data disk read request rate over 1m (per instance)",
-							Query:       fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("%s rate(node_disk_reads_completed_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.ReadsPerSecond).
@@ -948,7 +950,7 @@ func Zoekt() *monitoring.Dashboard {
 						{
 							Name:        "data_disk_writes_sec",
 							Description: "data disk write request rate over 1m (per instance)",
-							Query:       fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("%s rate(node_disk_writes_completed_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.WritesPerSecond).
@@ -969,7 +971,7 @@ func Zoekt() *monitoring.Dashboard {
 						{
 							Name:        "data_disk_read_throughput",
 							Description: "data disk read throughput over 1m (per instance)",
-							Query:       fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_bytes_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("%s rate(node_disk_read_bytes_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.BytesPerSecond).
@@ -988,7 +990,7 @@ func Zoekt() *monitoring.Dashboard {
 						{
 							Name:        "data_disk_write_throughput",
 							Description: "data disk write throughput over 1m (per instance)",
-							Query:       fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_written_bytes_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("%s rate(node_disk_written_bytes_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.BytesPerSecond).
@@ -1011,8 +1013,8 @@ func Zoekt() *monitoring.Dashboard {
 							Description: "data disk average read duration over 1m (per instance)",
 
 							Query: fmt.Sprintf("((%s) / (%s))",
-								fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_time_seconds_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
-								fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+								fmt.Sprintf("%s rate(node_disk_read_time_seconds_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("%s rate(node_disk_reads_completed_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							),
 							NoAlert: true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -1035,8 +1037,8 @@ func Zoekt() *monitoring.Dashboard {
 							Description: "data disk average write duration over 1m (per instance)",
 
 							Query: fmt.Sprintf("((%s) / (%s))",
-								fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_write_time_seconds_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
-								fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+								fmt.Sprintf("%s rate(node_disk_write_time_seconds_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("%s rate(node_disk_writes_completed_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							),
 							NoAlert: true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -1060,8 +1062,8 @@ func Zoekt() *monitoring.Dashboard {
 							Name:        "data_disk_read_request_size",
 							Description: "data disk average read request size over 1m (per instance)",
 							Query: fmt.Sprintf("((%s) / (%s))",
-								fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_bytes_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
-								fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+								fmt.Sprintf("%s rate(node_disk_read_bytes_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("%s rate(node_disk_reads_completed_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							),
 							NoAlert: true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -1082,8 +1084,8 @@ func Zoekt() *monitoring.Dashboard {
 							Name:        "data_disk_write_request_size",
 							Description: "data disk average write request size over 1m (per instance)",
 							Query: fmt.Sprintf("((%s) / (%s))",
-								fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_written_bytes_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
-								fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+								fmt.Sprintf("%s rate(node_disk_written_bytes_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("%s rate(node_disk_writes_completed_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							),
 							NoAlert: true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -1105,7 +1107,7 @@ func Zoekt() *monitoring.Dashboard {
 						{
 							Name:        "data_disk_reads_merged_sec",
 							Description: "data disk merged read request rate over 1m (per instance)",
-							Query:       fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_merged_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("%s rate(node_disk_reads_merged_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.RequestsPerSecond).
@@ -1124,7 +1126,7 @@ func Zoekt() *monitoring.Dashboard {
 						{
 							Name:        "data_disk_writes_merged_sec",
 							Description: "data disk merged writes request rate over 1m (per instance)",
-							Query:       fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_merged_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("%s rate(node_disk_writes_merged_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.RequestsPerSecond).
@@ -1146,7 +1148,7 @@ func Zoekt() *monitoring.Dashboard {
 
 							Name:        "data_disk_average_queue_size",
 							Description: "data disk average queue size over 1m (per instance)",
-							Query:       fmt.Sprintf("zoekt_indexserver_mount_point_info{mount_name=%q,instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_io_time_weighted_seconds_total{instance=~`%s`}[1m])", mountInfoDataDir, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("%s rate(node_disk_io_time_weighted_seconds_total{instance=~`%s`}[1m])", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit("req").

--- a/monitoring/definitions/zoekt.go
+++ b/monitoring/definitions/zoekt.go
@@ -16,7 +16,6 @@ func Zoekt() *monitoring.Dashboard {
 		webserverContainerName   = "zoekt-webserver"
 		bundledContainerName     = "indexed-search"
 
-		mountInfoDataDir          = "indexDir"
 		nodeExporterInstanceRegex = `node-exporter.*`
 	)
 


### PR DESCRIPTION
Builds on: https://github.com/sourcegraph/zoekt/pull/434, https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s/pull/5350

This PR adds a new set of dashboards that expose disk i/o metrics for the data disk attached to the zoekt-replicas. 

For now, these dashboards will only work on k8s.sgdev.org. This functionality requires disk metrics collected by [node-exporter](https://github.com/prometheus/node_exporter), which is currently only [deployed on k8s.sgdev.org ](https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s/pull/5350). As such, this dashboard group is hidden by default. 

In the long-run, I'll look into:

- shipping node-exporter alongside our other services, which will allow more instances beside k8s.sgdev.org to use these dashboards 
- extracting this functionality (alongside the disk discovery functionality built in https://github.com/sourcegraph/zoekt/pull/434) as a general utility that would allow other Sourcegraph services to expose metrics about their own disks. 

Note: These disk metrics are device-centric, **not** service centric. In certain environments (such as the typical docker-compose setup), Zoekt could be one of _many services_ using a particular disk. These statistics are best interpreted as the **load experienced by the device Zoekt is using**, not the **load Zoekt is solely responsible for causing**.

## screenshot (using Prometheus data from k8s.sgdev.org)

![screencapture-localhost-3370-debug-grafana-d-zoekt-zoekt-2022-10-17-13_54_33](https://user-images.githubusercontent.com/9022011/196281562-b17e635e-8aa1-44b8-9fc6-a4618a2647cc.png)

## Test plan

Ran `sg start monitoring` while connected to k8s.sgdev.org's Prometheus instance.
