### PR TITLE
batches: revert restricted batch spec access

### DIFF
--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2952,7 +2952,7 @@ type BatchSpecConnection {
 
 """
 A batch spec is an immutable description of the desired state of a batch change. To create a
-batch spec, use the createBatchSpec mutation. For security, a batch spec is only visible to viewers who can administer it.
+batch spec, use the createBatchSpec mutation.
 """
 type BatchSpec implements Node {
     """

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
@@ -487,6 +487,15 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 	want.AllCodeHosts = codeHosts
 	want.OnlyWithoutCredential = codeHosts
 	queryAndAssertBatchSpec(t, userCtx, s, apiID, want)
+
+	// PERMISSIONS: Now we view the same batch spec but as another non-admin user, for
+	// example if a user is sharing a preview link with another user. This should still
+	// work.
+	want.ViewerCanAdminister = false
+	want.ViewerCanRetry = false
+	otherUser := bt.CreateTestUser(t, db, false)
+	otherUserCtx := actor.WithActor(ctx, actor.FromUser(otherUser.ID))
+	queryAndAssertBatchSpec(t, otherUserCtx, s, apiID, want)
 }
 
 func TestBatchSpecResolver_Files(t *testing.T) {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/graph-gophers/graphql-go"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 
 	"github.com/sourcegraph/log/logtest"
 
@@ -344,16 +345,40 @@ func TestPermissionLevels(t *testing.T) {
 					wantViewerCanAdminister: true,
 				},
 				{
-					name:                    "non-site-admin viewing created-from-raw batch spec in org they belong to",
-					currentUser:             userID,
-					batchSpec:               orgBatchSpecCreatedFromRawRandID,
-					wantViewerCanAdminister: true,
+					name:        "non-site-admin viewing other's batch spec",
+					currentUser: userID,
+					batchSpec:   adminBatchSpec,
+					wantViewerCanAdminister: false,
+				},
+				{
+					name:        "non-site-admin viewing other's created-from-raw batch spec",
+					currentUser: userID,
+					batchSpec:   adminBatchSpecCreatedFromRawRandID,
+					wantViewerCanAdminister: false,
 				},
 				{
 					name:                    "non-site-admin viewing batch spec in org they belong to",
 					currentUser:             userID,
 					batchSpec:               orgBatchSpec,
 					wantViewerCanAdminister: true,
+				},
+				{
+					name:        "non-site-admin viewing batch spec in org they do not belong to",
+					currentUser: nonOrgUserID,
+					batchSpec:   orgBatchSpec,
+					wantViewerCanAdminister: false,
+				},
+				{
+					name:                    "non-site-admin viewing created-from-raw batch spec in org they belong to",
+					currentUser:             userID,
+					batchSpec:               orgBatchSpecCreatedFromRawRandID,
+					wantViewerCanAdminister: true,
+				},
+				{
+					name:        "non-site-admin viewing created-from-raw batch spec in org they do not belong to",
+					currentUser: nonOrgUserID,
+					batchSpec:   orgBatchSpecCreatedFromRawRandID,
+					wantViewerCanAdminister: false,
 				},
 			}
 
@@ -377,56 +402,6 @@ func TestPermissionLevels(t *testing.T) {
 					}
 					if have, want := res.Node.ViewerCanAdminister, tc.wantViewerCanAdminister; have != want {
 						t.Fatalf("queried batch spec's ViewerCanAdminister is wrong %t, want %t", have, want)
-					}
-				})
-			}
-		})
-
-		t.Run("NonAdminBatchSpecByID", func(t *testing.T) {
-			tests := []struct {
-				name        string
-				currentUser int32
-				batchSpec   string
-			}{
-				{
-					name:        "non-site-admin viewing other's batch spec",
-					currentUser: userID,
-					batchSpec:   adminBatchSpec,
-				},
-				{
-					name:        "non-site-admin viewing other's created-from-raw batch spec",
-					currentUser: userID,
-					batchSpec:   adminBatchSpecCreatedFromRawRandID,
-				},
-				{
-					name:        "non-site-admin viewing batch spec in org they do not belong to",
-					currentUser: nonOrgUserID,
-					batchSpec:   orgBatchSpec,
-				},
-				{
-					name:        "non-site-admin viewing created-from-raw batch spec in org they do not belong to",
-					currentUser: nonOrgUserID,
-					batchSpec:   orgBatchSpecCreatedFromRawRandID,
-				},
-			}
-
-			for _, tc := range tests {
-				t.Run(tc.name, func(t *testing.T) {
-					graphqlID := string(marshalBatchSpecRandID(tc.batchSpec))
-
-					var res struct{ Node *apitest.BatchSpec }
-
-					input := map[string]any{"batchSpec": graphqlID}
-					queryBatchSpec := `
-				  query($batchSpec: ID!) {
-				    node(id: $batchSpec) { ... on BatchSpec { id } }
-				  }`
-
-					actorCtx := actor.WithActor(ctx, actor.FromUser(tc.currentUser))
-					apitest.MustExec(actorCtx, t, s, input, &res, queryBatchSpec)
-
-					if res.Node != nil {
-						t.Fatal("queried batch spec was visible when it should not be")
 					}
 				})
 			}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
@@ -345,15 +345,15 @@ func TestPermissionLevels(t *testing.T) {
 					wantViewerCanAdminister: true,
 				},
 				{
-					name:        "non-site-admin viewing other's batch spec",
-					currentUser: userID,
-					batchSpec:   adminBatchSpec,
+					name:                    "non-site-admin viewing other's batch spec",
+					currentUser:             userID,
+					batchSpec:               adminBatchSpec,
 					wantViewerCanAdminister: false,
 				},
 				{
-					name:        "non-site-admin viewing other's created-from-raw batch spec",
-					currentUser: userID,
-					batchSpec:   adminBatchSpecCreatedFromRawRandID,
+					name:                    "non-site-admin viewing other's created-from-raw batch spec",
+					currentUser:             userID,
+					batchSpec:               adminBatchSpecCreatedFromRawRandID,
 					wantViewerCanAdminister: false,
 				},
 				{
@@ -363,9 +363,9 @@ func TestPermissionLevels(t *testing.T) {
 					wantViewerCanAdminister: true,
 				},
 				{
-					name:        "non-site-admin viewing batch spec in org they do not belong to",
-					currentUser: nonOrgUserID,
-					batchSpec:   orgBatchSpec,
+					name:                    "non-site-admin viewing batch spec in org they do not belong to",
+					currentUser:             nonOrgUserID,
+					batchSpec:               orgBatchSpec,
 					wantViewerCanAdminister: false,
 				},
 				{
@@ -375,9 +375,9 @@ func TestPermissionLevels(t *testing.T) {
 					wantViewerCanAdminister: true,
 				},
 				{
-					name:        "non-site-admin viewing created-from-raw batch spec in org they do not belong to",
-					currentUser: nonOrgUserID,
-					batchSpec:   orgBatchSpecCreatedFromRawRandID,
+					name:                    "non-site-admin viewing created-from-raw batch spec in org they do not belong to",
+					currentUser:             nonOrgUserID,
+					batchSpec:               orgBatchSpecCreatedFromRawRandID,
 					wantViewerCanAdminister: false,
 				},
 			}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/graph-gophers/graphql-go"
+
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
@@ -265,17 +266,10 @@ func (r *Resolver) batchSpecByID(ctx context.Context, id graphql.ID) (graphqlbac
 		return nil, err
 	}
 
-	specResolver := &batchSpecResolver{store: r.store, batchSpec: batchSpec}
-	canAdminister, err := specResolver.ViewerCanAdminister(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if !canAdminister {
-		return nil, nil
-	}
-
-	return specResolver, nil
+	// Everyone can see a batch spec, if they have the rand ID. The batch specs won't be
+	// enumerated to users other than their creators + admins, but they can be accessed
+	// directly if shared, e.g. to share a preview link before applying a new batch spec.
+	return &batchSpecResolver{store: r.store, batchSpec: batchSpec}, nil
 }
 
 func (r *Resolver) changesetSpecByID(ctx context.Context, id graphql.ID) (graphqlbackend.ChangesetSpecResolver, error) {


### PR DESCRIPTION
Partial revert of https://github.com/sourcegraph/sourcegraph/pull/42454 which just enables any user to get a batch spec by its (rand)id again, so as to enable intentionally sharing spec previews via the URL.

As a non-admin, I still can't see the full list of another user's batch specs, though.

I updated some of the inline code comments around this to remind us *why* we want any user to be able to access a batch spec by its id.

## Test plan

Reverted unit tests pass. Verified manually that a non-admin could:
- view all the details of a spec execution (including preview) from another user via the URL
- could only see the latest applied spec on another user's batch change details page

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
