### PR TITLE
batches: improve responsiveness of list stats bar

### DIFF
--- a/client/web/src/enterprise/batches/list/BatchChangeStatsBar.module.scss
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatsBar.module.scss
@@ -1,5 +1,7 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
 .stats-bar {
-    display: flex;
+    gap: 1rem;
     padding: 1.5rem;
     background-color: var(--color-bg-1);
     border: 1px solid var(--border-color);
@@ -9,13 +11,18 @@
 }
 
 .left-side {
+    @media (--sm-breakpoint-up) {
+        flex-grow: 1;
+        margin-bottom: 0;
+    }
     display: flex;
-    width: 70%;
-    flex-direction: row;
+    margin-bottom: 1rem;
 }
 
 .right-side {
+    @media (--sm-breakpoint-up) {
+        justify-content: flex-end;
+    }
     display: flex;
-    width: 30%;
-    justify-content: flex-end;
+    flex-shrink: 0;
 }

--- a/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
@@ -41,7 +41,7 @@ export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildre
     }
 
     return (
-        <div className={classNames(styles.statsBar, 'text-muted')}>
+        <div className={classNames(styles.statsBar, 'text-muted d-block d-sm-flex')}>
             <div className={styles.leftSide}>
                 <div className="pr-4">
                     <H3 className="font-weight-bold mb-1">{data.batchChanges.totalCount}</H3>
@@ -66,13 +66,13 @@ export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildre
             <div className={styles.rightSide}>
                 <div className="pr-4 text-center">
                     <ChangesetStatusOpen
-                        className="d block d-sm-flex"
+                        className="d-flex"
                         label={<span>{data.globalChangesetsStats.open} open</span>}
                     />
                 </div>
                 <div className="text-center">
                     <ChangesetStatusClosed
-                        className="d block d-sm-flex"
+                        className="d-flex"
                         label={<span>{data.globalChangesetsStats.closed} closed</span>}
                     />
                 </div>


### PR DESCRIPTION
Noticed the cool new stats bar got a little bit "crunchy" when the screen width was sufficiently constrained. This just makes it slightly more legible.

. | Desktop | Tablet | Mobile
:-:|:-------:|:------:|:-------:
Before | No change | No change | ![Screen Shot 2022-10-17 at 5 52 24 PM](https://user-images.githubusercontent.com/8942601/196310198-d9414e45-5121-4fdf-a19d-7bfad641695a.png)
After | ![Screen Shot 2022-10-17 at 5 49 08 PM](https://user-images.githubusercontent.com/8942601/196309883-182a2403-dc71-4935-bab7-9963bc202612.png) | ![Screen Shot 2022-10-17 at 5 49 00 PM](https://user-images.githubusercontent.com/8942601/196309888-2e3edf89-fefb-4d03-91af-4d723c62fd27.png) | ![Screen Shot 2022-10-17 at 5 48 26 PM](https://user-images.githubusercontent.com/8942601/196309894-50266972-32f6-43be-98ab-c4778452154e.png)


## Test plan

Storybook coverage. Verified manually locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-stats-bar-responsiveness.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mtnxlrwyzm.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
