### PR TITLE
Update minimum recommended version for src-cli

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "4.0.2"
+const MinimumVersion = "4.1.0"


### PR DESCRIPTION
This version isn't released yet but [will be by tomorrow](https://github.com/sourcegraph/src-cli/pull/865).

## Test plan

Just a constant change.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
