### PR TITLE
webhooks: support deletion by both ID and UUID.

### DIFF
--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -49813,7 +49813,7 @@ func NewMockWebhookStore() *MockWebhookStore {
 			},
 		},
 		DeleteFunc: &WebhookStoreDeleteFunc{
-			defaultHook: func(context.Context, uuid.UUID) (r0 error) {
+			defaultHook: func(context.Context, DeleteWebhookOpts) (r0 error) {
 				return
 			},
 		},
@@ -49855,7 +49855,7 @@ func NewStrictMockWebhookStore() *MockWebhookStore {
 			},
 		},
 		DeleteFunc: &WebhookStoreDeleteFunc{
-			defaultHook: func(context.Context, uuid.UUID) error {
+			defaultHook: func(context.Context, DeleteWebhookOpts) error {
 				panic("unexpected invocation of MockWebhookStore.Delete")
 			},
 		},
@@ -50035,15 +50035,15 @@ func (c WebhookStoreCreateFuncCall) Results() []interface{} {
 // WebhookStoreDeleteFunc describes the behavior when the Delete method of
 // the parent MockWebhookStore instance is invoked.
 type WebhookStoreDeleteFunc struct {
-	defaultHook func(context.Context, uuid.UUID) error
-	hooks       []func(context.Context, uuid.UUID) error
+	defaultHook func(context.Context, DeleteWebhookOpts) error
+	hooks       []func(context.Context, DeleteWebhookOpts) error
 	history     []WebhookStoreDeleteFuncCall
 	mutex       sync.Mutex
 }
 
 // Delete delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockWebhookStore) Delete(v0 context.Context, v1 uuid.UUID) error {
+func (m *MockWebhookStore) Delete(v0 context.Context, v1 DeleteWebhookOpts) error {
 	r0 := m.DeleteFunc.nextHook()(v0, v1)
 	m.DeleteFunc.appendCall(WebhookStoreDeleteFuncCall{v0, v1, r0})
 	return r0
@@ -50051,7 +50051,7 @@ func (m *MockWebhookStore) Delete(v0 context.Context, v1 uuid.UUID) error {
 
 // SetDefaultHook sets function that is called when the Delete method of the
 // parent MockWebhookStore instance is invoked and the hook queue is empty.
-func (f *WebhookStoreDeleteFunc) SetDefaultHook(hook func(context.Context, uuid.UUID) error) {
+func (f *WebhookStoreDeleteFunc) SetDefaultHook(hook func(context.Context, DeleteWebhookOpts) error) {
 	f.defaultHook = hook
 }
 
@@ -50059,7 +50059,7 @@ func (f *WebhookStoreDeleteFunc) SetDefaultHook(hook func(context.Context, uuid.
 // Delete method of the parent MockWebhookStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *WebhookStoreDeleteFunc) PushHook(hook func(context.Context, uuid.UUID) error) {
+func (f *WebhookStoreDeleteFunc) PushHook(hook func(context.Context, DeleteWebhookOpts) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -50068,19 +50068,19 @@ func (f *WebhookStoreDeleteFunc) PushHook(hook func(context.Context, uuid.UUID) 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *WebhookStoreDeleteFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, uuid.UUID) error {
+	f.SetDefaultHook(func(context.Context, DeleteWebhookOpts) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *WebhookStoreDeleteFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, uuid.UUID) error {
+	f.PushHook(func(context.Context, DeleteWebhookOpts) error {
 		return r0
 	})
 }
 
-func (f *WebhookStoreDeleteFunc) nextHook() func(context.Context, uuid.UUID) error {
+func (f *WebhookStoreDeleteFunc) nextHook() func(context.Context, DeleteWebhookOpts) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -50118,7 +50118,7 @@ type WebhookStoreDeleteFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 uuid.UUID
+	Arg1 DeleteWebhookOpts
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error

--- a/internal/database/webhooks.go
+++ b/internal/database/webhooks.go
@@ -179,25 +179,27 @@ type DeleteWebhookOpts struct {
 	UUID uuid.UUID
 }
 
-func NewDeleteWebhookOptsWithID(ID int32) DeleteWebhookOpts {
-	return DeleteWebhookOpts{ID: ID}
+func NewDeleteWebhookOptsWithID(id int32) DeleteWebhookOpts {
+	return DeleteWebhookOpts{ID: id}
 }
 
-func NewDeleteWebhookOptsWithUUID(UUID uuid.UUID) DeleteWebhookOpts {
-	return DeleteWebhookOpts{UUID: UUID}
+func NewDeleteWebhookOptsWithUUID(uuid uuid.UUID) DeleteWebhookOpts {
+	return DeleteWebhookOpts{UUID: uuid}
 }
 
-// Delete the webhook with given options. Either ID or UUID can be provided.
+// Delete the webhook with given options.
+//
+// Either ID or UUID can be provided.
 //
 // No error is returned if both ID and UUID are provided, ID is used in this
-// case. Error is returned when the webhook is not
-// found or something went wrong during an SQL query.
+// case. Error is returned when the webhook is not found or something went wrong
+// during an SQL query.
 func (s *webhookStore) Delete(ctx context.Context, opts DeleteWebhookOpts) error {
 	var query *sqlf.Query
 	if opts.ID > 0 {
 		query = sqlf.Sprintf(webhookDeleteByIDQueryFmtstr, opts.ID)
 	} else if opts.UUID == uuid.Nil {
-		return errors.New("Neither ID not UUID is provided to delete the webhook")
+		return errors.New("neither ID or UUID were provided to delete the webhook")
 	} else {
 		query = sqlf.Sprintf(webhookDeleteByUUIDQueryFmtstr, opts.UUID)
 	}
@@ -224,10 +226,10 @@ type WebhookNotFoundError struct {
 }
 
 func (w *WebhookNotFoundError) Error() string {
-	if w.UUID != uuid.Nil {
-		return fmt.Sprintf("webhook with UUID %s not found", w.UUID)
-	} else {
+	if w.ID > 0 {
 		return fmt.Sprintf("webhook with ID %d not found", w.ID)
+	} else {
+		return fmt.Sprintf("webhook with UUID %s not found", w.UUID)
 	}
 }
 

--- a/internal/database/webhooks.go
+++ b/internal/database/webhooks.go
@@ -201,15 +201,14 @@ func (s *webhookStore) Delete(ctx context.Context, opts DeleteWebhookOpts) error
 	return nil
 }
 
-func buildDeletePredicate(opts DeleteWebhookOpts) (predicate *sqlf.Query, err error) {
+func buildDeletePredicate(opts DeleteWebhookOpts) (*sqlf.Query, error) {
 	if opts.ID > 0 {
-		predicate = sqlf.Sprintf("ID = %d", opts.ID)
-	} else if opts.UUID == uuid.Nil {
-		err = errors.New("neither ID or UUID were provided to delete the webhook")
-	} else {
-		predicate = sqlf.Sprintf("UUID = %s", opts.UUID)
+		return sqlf.Sprintf("ID = %d", opts.ID), nil
 	}
-	return
+	if opts.UUID == uuid.Nil {
+		return nil, errors.New("neither ID or UUID were provided to delete the webhook")
+	}
+	return sqlf.Sprintf("UUID = %s", opts.UUID), nil
 }
 
 // WebhookNotFoundError occurs when a webhook is not found.

--- a/internal/database/webhooks_test.go
+++ b/internal/database/webhooks_test.go
@@ -161,7 +161,7 @@ func TestWebhookDelete(t *testing.T) {
 
 	// Test that delete with empty options returns an error
 	err = store.Delete(ctx, DeleteWebhookOpts{})
-	assert.EqualError(t, err, "Neither ID not UUID is provided to delete the webhook")
+	assert.EqualError(t, err, "neither ID or UUID were provided to delete the webhook")
 
 	// Creating something to be deleted
 	createdWebhook1 := createWebhook(ctx, t, store)

--- a/internal/database/webhooks_test.go
+++ b/internal/database/webhooks_test.go
@@ -143,21 +143,39 @@ func TestWebhookDelete(t *testing.T) {
 	db := NewDB(logger, dbtest.NewDB(logger, t))
 	store := db.Webhooks(nil)
 
-	// Test that delete with wrong ID returns an error
+	// Test that delete with wrong UUID returns an error
 	nonExistentUUID := uuid.New()
-	err := store.Delete(ctx, nonExistentUUID)
+	err := store.Delete(ctx, NewDeleteWebhookOptsWithUUID(nonExistentUUID))
 	if !errors.HasType(err, &WebhookNotFoundError{}) {
 		t.Fatalf("want WebhookNotFoundError, got: %s", err)
 	}
 	assert.EqualError(t, err, fmt.Sprintf("failed to delete webhook: webhook with UUID %s not found", nonExistentUUID))
 
-	// Test that delete with right ID deletes the webhook
-	createdWebhook, err := store.Create(ctx, extsvc.KindGitHub, "https://github.com", 0, types.NewUnencryptedSecret("very secret (not)"))
-	assert.NoError(t, err)
-	err = store.Delete(ctx, createdWebhook.UUID)
+	// Test that delete with wrong ID returns an error
+	nonExistentID := int32(123)
+	err = store.Delete(ctx, NewDeleteWebhookOptsWithID(nonExistentID))
+	if !errors.HasType(err, &WebhookNotFoundError{}) {
+		t.Fatalf("want WebhookNotFoundError, got: %s", err)
+	}
+	assert.EqualError(t, err, fmt.Sprintf("failed to delete webhook: webhook with ID %d not found", nonExistentID))
+
+	// Test that delete with empty options returns an error
+	err = store.Delete(ctx, DeleteWebhookOpts{})
+	assert.EqualError(t, err, "Neither ID not UUID is provided to delete the webhook")
+
+	// Creating something to be deleted
+	createdWebhook1 := createWebhook(ctx, t, store)
+	createdWebhook2 := createWebhook(ctx, t, store)
+
+	// Test that delete with right UUID deletes the webhook
+	err = store.Delete(ctx, NewDeleteWebhookOptsWithUUID(createdWebhook1.UUID))
 	assert.NoError(t, err)
 
-	exists, _, err := basestore.ScanFirstBool(db.QueryContext(ctx, "SELECT EXISTS(SELECT 1 FROM webhooks WHERE uuid=$1)", createdWebhook.UUID))
+	// Test that delete with both ID and UUID deletes the webhook by ID
+	err = store.Delete(ctx, DeleteWebhookOpts{UUID: uuid.New(), ID: createdWebhook2.ID})
+	assert.NoError(t, err)
+
+	exists, _, err := basestore.ScanFirstBool(db.QueryContext(ctx, "SELECT EXISTS(SELECT 1 FROM webhooks WHERE id IN ($1, $2))", createdWebhook1.ID, createdWebhook2.ID))
 	assert.NoError(t, err)
 	assert.False(t, exists)
 }

--- a/internal/database/webhooks_test.go
+++ b/internal/database/webhooks_test.go
@@ -145,7 +145,7 @@ func TestWebhookDelete(t *testing.T) {
 
 	// Test that delete with wrong UUID returns an error
 	nonExistentUUID := uuid.New()
-	err := store.Delete(ctx, NewDeleteWebhookOptsWithUUID(nonExistentUUID))
+	err := store.Delete(ctx, DeleteWebhookOpts{UUID: nonExistentUUID})
 	if !errors.HasType(err, &WebhookNotFoundError{}) {
 		t.Fatalf("want WebhookNotFoundError, got: %s", err)
 	}
@@ -153,7 +153,7 @@ func TestWebhookDelete(t *testing.T) {
 
 	// Test that delete with wrong ID returns an error
 	nonExistentID := int32(123)
-	err = store.Delete(ctx, NewDeleteWebhookOptsWithID(nonExistentID))
+	err = store.Delete(ctx, DeleteWebhookOpts{ID: nonExistentID})
 	if !errors.HasType(err, &WebhookNotFoundError{}) {
 		t.Fatalf("want WebhookNotFoundError, got: %s", err)
 	}
@@ -168,7 +168,7 @@ func TestWebhookDelete(t *testing.T) {
 	createdWebhook2 := createWebhook(ctx, t, store)
 
 	// Test that delete with right UUID deletes the webhook
-	err = store.Delete(ctx, NewDeleteWebhookOptsWithUUID(createdWebhook1.UUID))
+	err = store.Delete(ctx, DeleteWebhookOpts{UUID: createdWebhook1.UUID})
 	assert.NoError(t, err)
 
 	// Test that delete with both ID and UUID deletes the webhook by ID


### PR DESCRIPTION
Test plan:
Database tests updated.

Closes https://github.com/sourcegraph/sourcegraph/issues/43080

This PR is needed to revive https://github.com/sourcegraph/sourcegraph/pull/43079 
