### PR TITLE
Add endpoint to fetch webhooks by ID or UUID

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1642,6 +1642,20 @@ type Query {
         """
         kind: ExternalServiceKind
     ): WebhookConnection!
+
+    """
+    Looks up a webhook by id or uuid.
+    """
+    webhook(
+        """
+        The webhook ID. Provide either ID or UUID, not both.
+        """
+        id: ID
+        """
+        The webhook UUID. Provide either UUID or ID, not both.
+        """
+        uuid: String
+    ): Webhook
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1645,6 +1645,8 @@ type Query {
 
     """
     Looks up a webhook by id or uuid.
+
+    Only site admins may access webhooks.
     """
     webhook(
         """

--- a/cmd/frontend/graphqlbackend/webhooks_test.go
+++ b/cmd/frontend/graphqlbackend/webhooks_test.go
@@ -146,8 +146,14 @@ func TestGetWebhook(t *testing.T) {
                     uuid
                 }
     }`
-	errorQueryStr := `query GetWebhook($uuid: String, $id: ID) {
+	errorBothQueryStr := `query GetWebhook($uuid: String, $id: ID) {
                 webhook(uuid: $uuid, id: $id) {
+                    id
+                    uuid
+                }
+    }`
+	errorNoneQueryStr := `query GetWebhook {
+                webhook {
                     id
                     uuid
                 }
@@ -193,17 +199,30 @@ func TestGetWebhook(t *testing.T) {
 			Label:          "error with both ID and UUID",
 			Context:        ctx,
 			Schema:         schema,
-			Query:          errorQueryStr,
+			Query:          errorBothQueryStr,
 			ExpectedResult: `{"webhook": null}`,
 			ExpectedErrors: []*errors.QueryError{
 				{
-					Message: "either 1 of ID or UUID must be provided, but not both",
+					Message: "either one of ID or UUID must be provided, but not both",
 					Path:    []any{"webhook"},
 				},
 			},
 			Variables: map[string]any{
 				"id":   "V2ViaG9vazox",
 				"uuid": whUUID.String(),
+			},
+		},
+		{
+			Label:          "error with neither ID or UUID",
+			Context:        ctx,
+			Schema:         schema,
+			Query:          errorNoneQueryStr,
+			ExpectedResult: `{"webhook": null}`,
+			ExpectedErrors: []*errors.QueryError{
+				{
+					Message: "either one of ID or UUID must be provided, but not both",
+					Path:    []any{"webhook"},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
Solves #42806 

Adds a GraphQL endpoint to fetch webhooks by ID or UUID, but not both.

## Test plan

Unit tests added.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
