### PR TITLE
executors: Properly quote indexer args

### DIFF
--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kballard/go-shellquote"
+
 	apiclient "github.com/sourcegraph/sourcegraph/enterprise/internal/executor"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/shared/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -28,7 +30,7 @@ func transformRecord(index types.Index, accessToken string) (apiclient.Job, erro
 	if index.Indexer != "" {
 		dockerSteps = append(dockerSteps, apiclient.DockerStep{
 			Image:    index.Indexer,
-			Commands: append(index.LocalSteps, strings.Join(index.IndexerArgs, " ")),
+			Commands: append(index.LocalSteps, shellquote.Join(index.IndexerArgs...)),
 			Dir:      index.Root,
 			Env:      nil,
 		})

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform_test.go
@@ -23,10 +23,14 @@ func TestTransformRecord(t *testing.T) {
 				Root:     "web",
 			},
 		},
-		Root:        "web",
-		Indexer:     "lsif-node",
-		IndexerArgs: []string{"-p", "."},
-		Outfile:     "",
+		Root:    "web",
+		Indexer: "lsif-node",
+		IndexerArgs: []string{
+			"-p", ".",
+			// Verify args are properly shell quoted.
+			"-author", "Test User",
+		},
+		Outfile: "",
 	}
 	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{ExternalURL: "https://test.io"}})
 	t.Cleanup(func() {
@@ -53,7 +57,7 @@ func TestTransformRecord(t *testing.T) {
 			},
 			{
 				Image:    "lsif-node",
-				Commands: []string{"-p ."},
+				Commands: []string{"-p . -author 'Test User'"},
 				Dir:      "web",
 			},
 		},


### PR DESCRIPTION
Before, this would have become 2 separate args. See the test for details.



## Test plan

Added a test