### PR TITLE
docs: add simple information for redis-cache

### DIFF
--- a/doc/dev/how-to/add_caching.md
+++ b/doc/dev/how-to/add_caching.md
@@ -11,7 +11,7 @@ Sourcegraph is backed by two Redis caches, `redis-cache` and `redis-store`.
 Engineers are welcome to cache data as they see fit.
 
 The cache instances are instantiated in [`internal/redispool`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/redispool/redispool.go).
-You can use the [redis-cache helpers](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/internal/rcache/rcache.go) to read and write data to and from `redis-cache`, which you are also welcome to add to.
+You can use the [`rcache` package](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/internal/rcache/rcache.go) to read and write data to and from `redis-cache`, which you are also welcome to add to.
 
 ## Troubleshooting local redis access
 

--- a/doc/dev/how-to/add_caching.md
+++ b/doc/dev/how-to/add_caching.md
@@ -1,2 +1,44 @@
 # How to add caching
 
+## Background
+
+Sourcegraph is backed by two Redis caches, `redis-cache` and `redis-store`. 
+
+`redis-cache` should be favored as the two instances are [to be consolidated into one](https://docs.sourcegraph.com/dev/adr/1657287546-consolidate-redis-store-and-redis-cache-in-a-single-instance).
+
+## Usage
+
+Engineers are welcome to cache data as they see fit.
+
+The cache instances are instantiated in [`internal/redispool`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/redispool/redispool.go).
+You can use the [redis-cache helpers](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/internal/rcache/rcache.go) to read and write data to and from `redis-cache`, which you are also welcome to add to.
+
+## Troubleshooting local redis access
+
+A simple way to test your caching locally is through the `redis-cli`. You can install it using `brew` if you do not have it:
+
+```shell
+brew install redis 
+```
+
+You might run into the following error with `sg` after installing:
+
+```
+❌ Start Redis
+   failed to write to Redis at 127.0.0.1:6379: MISCONF Redis is configured to save RDB snapshots, but it's currently unable to persist to disk. Commands that may modify the data set are disabled, because this instance is configured to report errors during writes if RDB snapshotting fails (stop-writes-on-bgsave-error option). Please check the Redis logs for details about the RDB error.
+```
+
+Potential solutions for this are:
+
+1. Restarting Redis (e.g. `brew services restart redis`)
+2. Changing the config to stop writes:
+
+```shell
+redis-cli 
+> config set stop-writes-on-bgsave-error no
+> exit
+```
+
+## Helpful links
+
+* [Redis commands](https://redis.io/commands/)

--- a/doc/dev/how-to/add_caching.md
+++ b/doc/dev/how-to/add_caching.md
@@ -4,7 +4,7 @@
 
 Sourcegraph is backed by two Redis caches, `redis-cache` and `redis-store`. 
 
-`redis-cache` should be favored as the two instances are [to be consolidated into one](https://docs.sourcegraph.com/dev/adr/1657287546-consolidate-redis-store-and-redis-cache-in-a-single-instance).
+`redis-cache` should be favored as the two instances are [to be consolidated into one](../adr/1657287546-consolidate-redis-store-and-redis-cache-in-a-single-instance).
 
 ## Usage
 

--- a/doc/dev/how-to/add_caching.md
+++ b/doc/dev/how-to/add_caching.md
@@ -1,0 +1,2 @@
+# How to add caching
+

--- a/doc/dev/how-to/add_caching.md
+++ b/doc/dev/how-to/add_caching.md
@@ -4,7 +4,7 @@
 
 Sourcegraph is backed by two Redis caches, `redis-cache` and `redis-store`. 
 
-`redis-cache` should be favored as the two instances are [to be consolidated into one](../adr/1657287546-consolidate-redis-store-and-redis-cache-in-a-single-instance).
+`redis-cache` should be favored as the two instances are [to be consolidated into one](../adr/1657287546-consolidate-redis-store-and-redis-cache-in-a-single-instance.md).
 
 ## Usage
 

--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -156,6 +156,7 @@ Guides to help with troubleshooting, configuring test instances, debugging, and 
 
 - [How to add support for a language](how-to/add_support_for_a_language.md)
 - [How to use feature flags](how-to/use_feature_flags.md)
+- [How to add caching](how-to/add_caching.md)
 
 ### Observability
 


### PR DESCRIPTION
closes #42578 

this is rudimentary information but a nicer landing page to find when searching our docs than having no information on how redis is used. 

## Test plan

Validated visually using `sg run docsite`