### PR TITLE
Update Manifest key

### DIFF
--- a/client/browser/src/browser-extension/manifest.spec.json
+++ b/client/browser/src/browser-extension/manifest.spec.json
@@ -49,7 +49,7 @@
       "https://sourcegraph.com/*",
       "http://localhost:32773/*"
     ],
-    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvyGmcOkw4cTnhO0bgl3fQLAdv1jZp8T1ZHYI+4d8FgwwVKLYWE+pAuJ/0LrI69ibed4Nnnw5YleB1xCpI+mzB56xfXWboKp6lljevKqWJ5TpJk/Vam3kSSoZwpmJRXnzmcM3qKpL6viUhTfwGmQO6WVTsN4YCx+KWXv97IyF6yDTgd6hwFsvCZY2n1ADgurrQkE6AcJ3kK4xZ14jaHllXEdFcqwh0+Am5qLcIJ1cNo5iFD35exXsjwdQbmpt8sEk5f95pK5FEEbJFmOTguu2fOZycqIoTgoDrbbhT5k9TUogZaN5Lup0Iwh0Cv60i4C1f7IdPrxHuaYmYCfoUezXnQIDAQAB"
+    "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCl2X/axNHMbP0K/NCpMzGo/pgBSsHB2xKx6tfohORKtEv2wUMBPmkK3++kirrwYO2f8Ficyq6pjlXV8LjwPSjSw9KZj6bkDn8QNoSdCp6x9i8ZOWPw6UTQ6s54b3rGQNyvrvfD7S6LphxGEx8rNlkjpWKcrvY3+DyoFKHP/hax7wIDAQAB"
   },
   "prod": {
     "permissions": ["activeTab", "storage", "contextMenus", "https://github.com/*", "https://sourcegraph.com/*"]


### PR DESCRIPTION
This updates the [manifest `key`](https://developer.chrome.com/docs/extensions/mv3/manifest/key/) used in our Chrome extension since the value has seemingly changed.

The existing script started erroring with:

```
key field value in the manifest doesn’t match the current item.
```

To get to a new value, I followed [this Stackoverflow](https://stackoverflow.com/questions/21497781/how-to-change-chrome-packaged-app-id-or-why-do-we-need-key-field-in-the-manifest) post and read the public key from the existing extension.

I validated that the new key also resolves to the same extension ID:

![Screenshot 2022-10-18 at 13 13 03](https://user-images.githubusercontent.com/458591/196422058-72bd429f-bc18-41c4-90e6-3f13435fba52.png)


## Test plan

The script worked locally:
```
Publish Status: OK
```

A new version (`22.10.18.1144`) was created and is pending review.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-chrome-script.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qxwdcmyxxi.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
