### PR TITLE
executors: Fix env vars with spaces

### DIFF
--- a/enterprise/cmd/executor/internal/command/docker.go
+++ b/enterprise/cmd/executor/internal/command/docker.go
@@ -38,8 +38,7 @@ func formatRawOrDockerCommand(spec CommandSpec, dir string, options Options) com
 			dockerResourceFlags(options.ResourceOptions),
 			dockerVolumeFlags(hostDir),
 			dockerWorkingdirectoryFlags(spec.Dir),
-			// If the env vars will be part of the command line args, we need to quote them
-			dockerEnvFlags(quoteEnv(spec.Env)),
+			dockerEnvFlags(spec.Env),
 			dockerEntrypointFlags(),
 			spec.Image,
 			filepath.Join("/data", ScriptsPath, spec.ScriptPath),

--- a/enterprise/cmd/executor/internal/command/docker_test.go
+++ b/enterprise/cmd/executor/internal/command/docker_test.go
@@ -60,7 +60,9 @@ func TestFormatRawOrDockerCommandDockerScript(t *testing.T) {
 			"-v", "/proj/src:/data",
 			"-w", "/data/subdir",
 			"-e", "TEST=true",
-			"-e", `CONTAINS_WHITESPACE="yes it does"`,
+			// Note: This does NOT need to be quoted, as exec.Command
+			// properly passes each string in this slice as a separate argument.
+			"-e", `CONTAINS_WHITESPACE=yes it does`,
 			"--entrypoint",
 			"/bin/sh",
 			"alpine:latest",

--- a/enterprise/cmd/executor/internal/command/firecracker_test.go
+++ b/enterprise/cmd/executor/internal/command/firecracker_test.go
@@ -16,7 +16,7 @@ func TestFormatFirecrackerCommandRaw(t *testing.T) {
 	actual := formatFirecrackerCommand(
 		CommandSpec{
 			Command: []string{"ls", "-a"},
-			Dir:     "subdir",
+			Dir:     "sub dir",
 			Env: []string{
 				`TEST=true`,
 				`CONTAINS_WHITESPACE=yes it does`,
@@ -30,7 +30,7 @@ func TestFormatFirecrackerCommandRaw(t *testing.T) {
 	expected := command{
 		Command: []string{
 			"ignite", "exec", "deadbeef", "--",
-			`cd /work/subdir && TEST=true CONTAINS_WHITESPACE="yes it does" ls -a`,
+			`cd '/work/sub dir' && TEST=true CONTAINS_WHITESPACE='yes it does' ls -a`,
 		},
 	}
 	if diff := cmp.Diff(expected, actual, commandComparer); diff != "" {
@@ -43,7 +43,7 @@ func TestFormatFirecrackerCommandDockerScript(t *testing.T) {
 		CommandSpec{
 			Image:      "alpine:latest",
 			ScriptPath: "myscript.sh",
-			Dir:        "subdir",
+			Dir:        "sub dir",
 			Env: []string{
 				`TEST=true`,
 				`CONTAINS_WHITESPACE=yes it does`,
@@ -67,15 +67,16 @@ func TestFormatFirecrackerCommandDockerScript(t *testing.T) {
 				"--cpus", "4",
 				"--memory", "20G",
 				"-v", "/work:/data",
-				"-w", "/data/subdir",
+				"-w", "'/data/sub dir'",
 				"-e", "TEST=true",
-				"-e", `'CONTAINS_WHITESPACE="yes it does"'`,
+				"-e", `'CONTAINS_WHITESPACE=yes it does'`,
 				"--entrypoint /bin/sh",
 				"alpine:latest",
 				"/data/.sourcegraph-executor/myscript.sh",
 			}, " "),
 		},
 	}
+
 	if diff := cmp.Diff(expected, actual, commandComparer); diff != "" {
 		t.Errorf("unexpected command (-want +got):\n%s", diff)
 	}

--- a/enterprise/cmd/executor/internal/command/util.go
+++ b/enterprise/cmd/executor/internal/command/util.go
@@ -3,6 +3,8 @@ package command
 import (
 	"fmt"
 	"strings"
+
+	"github.com/kballard/go-shellquote"
 )
 
 // flatten combines string values and (non-recursive) string slice values
@@ -31,17 +33,13 @@ func intersperse(flag string, values []string) []string {
 	return interspersed
 }
 
-// quoteEnv returns a slice of env vars in which env vars that contain a whitespace have been quoted
+// quoteEnv returns a slice of env vars in which the values are properly shell quoted.
 func quoteEnv(env []string) []string {
 	quotedEnv := make([]string, len(env))
 
 	for i, e := range env {
-		if strings.Contains(e, " ") {
-			elems := strings.SplitN(e, "=", 2)
-			quotedEnv[i] = fmt.Sprintf(`%s=%q`, elems[0], elems[1])
-		} else {
-			quotedEnv[i] = e
-		}
+		elems := strings.SplitN(e, "=", 2)
+		quotedEnv[i] = fmt.Sprintf("%s=%s", elems[0], shellquote.Join(elems[1]))
 	}
 
 	return quotedEnv

--- a/enterprise/cmd/executor/internal/command/util_test.go
+++ b/enterprise/cmd/executor/internal/command/util_test.go
@@ -51,7 +51,7 @@ func TestQuoteEnv(t *testing.T) {
 		},
 		{
 			in:   []string{"FOO=bar foo bar"},
-			want: []string{`FOO="bar foo bar"`},
+			want: []string{`FOO='bar foo bar'`},
 		},
 
 		{
@@ -60,15 +60,15 @@ func TestQuoteEnv(t *testing.T) {
 		},
 		{
 			in:   []string{"HOME=compute r", "FOO=bar foo bar"},
-			want: []string{`HOME="compute r"`, `FOO="bar foo bar"`},
+			want: []string{`HOME='compute r'`, `FOO='bar foo bar'`},
 		},
 		{
 			in:   []string{"FOO=bar -e 31337=H4XX0R"},
-			want: []string{`FOO="bar -e 31337=H4XX0R"`},
+			want: []string{`FOO='bar -e 31337=H4XX0R'`},
 		},
 		{
 			in:   []string{`FOO=bar -e "shell-h4xx0r"`},
-			want: []string{`FOO="bar -e \"shell-h4xx0r\""`},
+			want: []string{`FOO='bar -e "shell-h4xx0r"'`},
 		},
 	}
 


### PR DESCRIPTION
When we introduced quoting for env vars, we went a bit too far and actually broke env vars with spaces for docker commands that don't run in firecracker. When we quote the env vars in the docker layer, they will be literally quoted in the value that docker receives, because we use exec.Command there and it handles the arg splitting already. For firecracker, we actually make the command a shell script that we run so there we have to encode it right.

## Test plan

Will test executor image on k8s.