### PR TITLE
executors: Make src upload step in codeintel a docker step

### DIFF
--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform_test.go
@@ -1,6 +1,8 @@
 package codeintel
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -8,6 +10,7 @@ import (
 	apiclient "github.com/sourcegraph/sourcegraph/enterprise/internal/executor"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/shared/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	srccli "github.com/sourcegraph/sourcegraph/internal/src-cli"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -62,19 +65,24 @@ func TestTransformRecord(t *testing.T) {
 				Commands: []string{"-p . -author 'Test User'"},
 				Dir:      "web",
 			},
-		},
-		CliSteps: []apiclient.CliStep{
 			{
-				Key: "upload",
+				Key:   "upload",
+				Image: fmt.Sprintf("sourcegraph/src-cli:%s", srccli.MinimumVersion),
 				Commands: []string{
-					"lsif", "upload",
-					"-no-progress",
-					"-repo", "linux",
-					"-commit", "deadbeef",
-					"-root", "web",
-					"-upload-route", "/.executors/lsif/upload",
-					"-file", "dump.lsif",
-					"-associated-index-id", "42",
+					strings.Join(
+						[]string{
+							"src",
+							"lsif", "upload",
+							"-no-progress",
+							"-repo", "linux",
+							"-commit", "deadbeef",
+							"-root", "web",
+							"-upload-route", "/.executors/lsif/upload",
+							"-file", "dump.lsif",
+							"-associated-index-id", "42",
+						},
+						" ",
+					),
 				},
 				Dir: "web",
 				Env: []string{
@@ -145,19 +153,24 @@ func TestTransformRecordWithoutIndexer(t *testing.T) {
 				Commands: []string{"-p", "."},
 				Dir:      "web",
 			},
-		},
-		CliSteps: []apiclient.CliStep{
 			{
-				Key: "upload",
+				Key:   "upload",
+				Image: fmt.Sprintf("sourcegraph/src-cli:%s", srccli.MinimumVersion),
 				Commands: []string{
-					"lsif", "upload",
-					"-no-progress",
-					"-repo", "linux",
-					"-commit", "deadbeef",
-					"-root", ".",
-					"-upload-route", "/.executors/lsif/upload",
-					"-file", "other/path/lsif.dump",
-					"-associated-index-id", "42",
+					strings.Join(
+						[]string{
+							"src",
+							"lsif", "upload",
+							"-no-progress",
+							"-repo", "linux",
+							"-commit", "deadbeef",
+							"-root", ".",
+							"-upload-route", "/.executors/lsif/upload",
+							"-file", "other/path/lsif.dump",
+							"-associated-index-id", "42",
+						},
+						" ",
+					),
 				},
 				Dir: "",
 				Env: []string{

--- a/internal/codeintel/shared/resolvers/index_steps_resolver.go
+++ b/internal/codeintel/shared/resolvers/index_steps_resolver.go
@@ -69,6 +69,12 @@ func (r *indexStepsResolver) Index() IndexStepResolver {
 }
 
 func (r *indexStepsResolver) Upload() ExecutionLogEntryResolver {
+	if entry, ok := r.findExecutionLogEntry("step.docker.upload"); ok {
+		return NewExecutionLogEntryResolver(r.svc, entry)
+	}
+
+	// This is here for backwards compatibility for records that were created before
+	// src became a docker step.
 	if entry, ok := r.findExecutionLogEntry("step.src.upload"); ok {
 		return NewExecutionLogEntryResolver(r.svc, entry)
 	}

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	srccli "github.com/sourcegraph/sourcegraph/internal/src-cli"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -160,6 +161,24 @@ func ExecutorsFrontendURL() string {
 	}
 
 	return current.ExternalURL
+}
+
+func ExecutorsSrcCLIImage() string {
+	current := Get()
+	if current.ExecutorsSrcCLIImage != "" {
+		return current.ExecutorsSrcCLIImage
+	}
+
+	return "sourcegraph/src-cli"
+}
+
+func ExecutorsSrcCLIImageTag() string {
+	current := Get()
+	if current.ExecutorsSrcCLIImageTag != "" {
+		return current.ExecutorsSrcCLIImageTag
+	}
+
+	return srccli.MinimumVersion
 }
 
 func CodeIntelAutoIndexingEnabled() bool {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2084,6 +2084,10 @@ type SiteConfiguration struct {
 	ExecutorsAccessToken string `json:"executors.accessToken,omitempty"`
 	// ExecutorsFrontendURL description: The frontend URL for Sourcegraph. Only root URLs are allowed. If not set, falls back to externalURL
 	ExecutorsFrontendURL string `json:"executors.frontendURL,omitempty"`
+	// ExecutorsSrcCLIImage description: The image to use for src-cli in executors. Use this value to pull from a custom image registry.
+	ExecutorsSrcCLIImage string `json:"executors.srcCLIImage,omitempty"`
+	// ExecutorsSrcCLIImageTag description: The tag to use for the src-cli image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.
+	ExecutorsSrcCLIImageTag string `json:"executors.srcCLIImageTag,omitempty"`
 	// ExperimentalFeatures description: Experimental features to enable or disable. Features that are now enabled by default are marked as deprecated.
 	ExperimentalFeatures *ExperimentalFeatures `json:"experimentalFeatures,omitempty"`
 	ExportUsageTelemetry *ExportUsageTelemetry `json:"exportUsageTelemetry,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1126,6 +1126,16 @@
       "type": "string",
       "examples": ["https://sourcegraph.example.com"]
     },
+    "executors.srcCLIImage": {
+      "description": "The image to use for src-cli in executors. Use this value to pull from a custom image registry.",
+      "type": "string",
+      "default": "sourcegraph/src-cli"
+    },
+    "executors.srcCLIImageTag": {
+      "description": "The tag to use for the src-cli image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.",
+      "type": "string",
+      "examples": ["4.1.0"]
+    },
     "executors.accessToken": {
       "description": "The shared secret between Sourcegraph and executors.",
       "type": "string",


### PR DESCRIPTION
We want to get rid of special casing src-cli. This is the first step towards that. src-cli will still be required for batch changes for the time being but I am working on resolving that as well, but it'll be more involved. To make sure that customers using custom registries can still use this just fine, I added 2 new site settings that make this image configurable. This will also allow to ship a src hot fix to a specific customer, if src is version compatible with that backend.



## Test plan

Will test in k8s and also verified locally.