### PR TITLE
Add URL resolving Webhook GraphQL query

### DIFF
--- a/cmd/frontend/graphqlbackend/webhooks.go
+++ b/cmd/frontend/graphqlbackend/webhooks.go
@@ -2,6 +2,8 @@ package graphqlbackend
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -9,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -33,8 +36,13 @@ func (r *webhookResolver) UUID() string {
 }
 
 func (r *webhookResolver) URL() string {
-	// TODO: Combine external URL and UUID
-	return "TODO"
+	externalURL, err := url.Parse(conf.Get().ExternalURL)
+	if err != nil {
+		// The external URL in the site config should never be invalid
+		return ""
+	}
+	externalURL.Path = fmt.Sprintf("webhooks/%s", r.hook.UUID.String())
+	return externalURL.String()
 }
 
 func (r *webhookResolver) CodeHostURN() string {

--- a/cmd/frontend/graphqlbackend/webhooks.go
+++ b/cmd/frontend/graphqlbackend/webhooks.go
@@ -35,14 +35,13 @@ func (r *webhookResolver) UUID() string {
 	return r.hook.UUID.String()
 }
 
-func (r *webhookResolver) URL() string {
+func (r *webhookResolver) URL() (string, error) {
 	externalURL, err := url.Parse(conf.Get().ExternalURL)
 	if err != nil {
-		// The external URL in the site config should never be invalid
-		return ""
+		return "", errors.Wrap(err, "could not parse site config external URL")
 	}
-	externalURL.Path = fmt.Sprintf("webhooks/%s", r.hook.UUID.String())
-	return externalURL.String()
+	externalURL.Path = fmt.Sprintf("webhooks/%v", r.hook.UUID)
+	return externalURL.String(), nil
 }
 
 func (r *webhookResolver) CodeHostURN() string {


### PR DESCRIPTION
Solves #43053 

Builds the webhook external URL using the site config's external URL and the webhook's UUID.

## Test plan

Added unit test

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
