### PR TITLE
Hackily implement example of improved sidebar list items

### DIFF
--- a/client/web/src/components/Sidebar.module.scss
+++ b/client/web/src/components/Sidebar.module.scss
@@ -16,3 +16,31 @@
 .chevron {
     color: var(--icon-color);
 }
+
+.newNavItem {
+    display: block;
+    border-radius: 4px;
+    background: transparent;
+    padding: 4px 8px;
+    color: var(--body-color);
+    margin-bottom: 2px;
+
+    &:last-of-type {
+        margin-bottom: 0;
+    }
+
+    &:hover {
+        background: var(--color-bg-2);
+        text-decoration: none;
+        color: var(--body-color);
+    }
+
+    &:focus {
+        background: var(--color-bg-3);
+    }
+}
+
+.current {
+    color: var(--light-text);
+    background: var(--primary);
+}

--- a/client/web/src/components/Sidebar.module.scss
+++ b/client/web/src/components/Sidebar.module.scss
@@ -43,4 +43,9 @@
 .current {
     color: var(--light-text);
     background: var(--primary);
+
+    &:focus {
+        color: var(--light-text);
+        background: var(--primary);
+    }
 }

--- a/client/web/src/components/Sidebar.tsx
+++ b/client/web/src/components/Sidebar.tsx
@@ -7,7 +7,7 @@ import { useRouteMatch } from 'react-router-dom'
 
 import {
     AnchorLink,
-    ButtonLink,
+    ListItem,
     Icon,
     Collapse,
     CollapseHeader,
@@ -35,18 +35,47 @@ export const SidebarNavItem: React.FunctionComponent<
 
     if (source === 'server') {
         return (
-            <ButtonLink as={AnchorLink} to={to} className={classNames(buttonClassNames, className)}>
+            <ListItem as={AnchorLink} to={to} className={classNames(buttonClassNames, className)}>
                 {children}
-            </ButtonLink>
+            </ListItem>
         )
     }
 
     return (
-        <ButtonLink to={to} className={buttonClassNames} variant={routeMatch?.isExact ? 'primary' : undefined}>
+        <ListItem to={to} className={buttonClassNames} variant={routeMatch?.isExact ? 'primary' : undefined}>
             {children}
-        </ButtonLink>
+        </ListItem>
     )
 }
+
+/**
+ * Hacky temporary item of `SideBarGroup`.
+ */
+
+export const SidebarNewNavItem: React.FunctionComponent<React.PropsWithChildren<{
+    to: string,
+    className?: string,
+    exact?: boolean,
+    source?: string
+}>
+    > = ({ children, className, to, exact, source }) => {
+    const routeMatch = useRouteMatch({ path: to, exact })
+
+    if (source === 'server') {
+        return (
+            <AnchorLink to={to} className={classNames(styles.newNavItem, { [styles.current]: routeMatch?.isExact }, className)}>
+                {children}
+            </AnchorLink>
+        )
+    }
+
+    return (
+        <AnchorLink to={to} className={classNames(styles.newNavItem, { [styles.current]: routeMatch?.isExact }, className)}>
+            {children}
+        </AnchorLink>
+    )
+}
+
 /**
  *
  * Header of a `SideBarGroup`
@@ -110,7 +139,7 @@ interface SidebarGroupProps {
 }
 
 /**
- * A box of items in the side bar. Use `SideBarGroupHeader` as children.
+ * A box of items in the sidebar. Use `SideBarGroupHeader` as children.
  */
 export const SidebarGroup: React.FunctionComponent<React.PropsWithChildren<SidebarGroupProps>> = ({
     children,

--- a/client/web/src/components/Sidebar.tsx
+++ b/client/web/src/components/Sidebar.tsx
@@ -6,8 +6,8 @@ import kebabCase from 'lodash/kebabCase'
 import { useRouteMatch } from 'react-router-dom'
 
 import {
+    Link,
     AnchorLink,
-    ListItem,
     Icon,
     Collapse,
     CollapseHeader,
@@ -63,16 +63,16 @@ export const SidebarNewNavItem: React.FunctionComponent<React.PropsWithChildren<
 
     if (source === 'server') {
         return (
-            <AnchorLink to={to} className={classNames(styles.newNavItem, { [styles.current]: routeMatch?.isExact }, className)}>
+            <Link to={to} className={classNames(styles.newNavItem, { [styles.current]: routeMatch?.isExact }, className)}>
                 {children}
-            </AnchorLink>
+            </Link>
         )
     }
 
     return (
-        <AnchorLink to={to} className={classNames(styles.newNavItem, { [styles.current]: routeMatch?.isExact }, className)}>
+        <Link to={to} className={classNames(styles.newNavItem, { [styles.current]: routeMatch?.isExact }, className)}>
             {children}
-        </AnchorLink>
+        </Link>
     )
 }
 

--- a/client/web/src/user/settings/UserSettingsArea.module.scss
+++ b/client/web/src/user/settings/UserSettingsArea.module.scss
@@ -1,3 +1,5 @@
 .user-settings-sidebar {
     width: 12.5rem;
 }
+
+

--- a/client/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/client/web/src/user/settings/UserSettingsSidebar.tsx
@@ -7,7 +7,7 @@ import { ProductStatusBadge, Button, Link, Icon, ProductStatusType } from '@sour
 
 import { AuthenticatedUser } from '../../auth'
 import { BatchChangesProps } from '../../batches'
-import { SidebarGroup, SidebarGroupHeader, SidebarNavItem } from '../../components/Sidebar'
+import { SidebarGroup, SidebarGroupHeader, SidebarNewNavItem } from '../../components/Sidebar'
 import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
 import { UserSettingsAreaUserFields } from '../../graphql-operations'
 import { OrgAvatar } from '../../org/OrgAvatar'
@@ -68,9 +68,9 @@ export const UserSettingsSidebar: React.FunctionComponent<
                 {props.items.map(
                     ({ label, to, exact, status, condition = () => true }) =>
                         condition(context) && (
-                            <SidebarNavItem key={label} to={props.match.path + to} exact={exact}>
+                            <SidebarNewNavItem key={label} to={props.match.path + to} exact={exact}>
                                 {label} {status && <ProductStatusBadge className="ml-1" status={status} />}
-                            </SidebarNavItem>
+                            </SidebarNewNavItem>
                         )
                 )}
             </SidebarGroup>
@@ -78,20 +78,20 @@ export const UserSettingsSidebar: React.FunctionComponent<
                 <SidebarGroup>
                     <SidebarGroupHeader label="Your organizations" />
                     {props.user.organizations.nodes.map(org => (
-                        <SidebarNavItem
+                        <SidebarNewNavItem
                             key={org.id}
                             to={`/organizations/${org.name}/settings`}
                             className="text-truncate text-nowrap align-items-center"
                         >
                             <OrgAvatar org={org.name} className="d-inline-flex mr-1" /> {org.name}
-                        </SidebarNavItem>
+                        </SidebarNewNavItem>
                     ))}
                     {!siteAdminViewingOtherUser &&
                         (window.context.sourcegraphDotComMode &&
                         !props.authenticatedUser?.tags?.includes('CreateOrg') ? (
-                            <SidebarNavItem to={`${props.match.path}/about-organizations`}>
+                            <SidebarNewNavItem to={`${props.match.path}/about-organizations`}>
                                 About organizations
-                            </SidebarNavItem>
+                            </SidebarNewNavItem>
                         ) : (
                             <div className={styles.newOrgBtnWrapper}>
                                 <Button to="/organizations/new" variant="secondary" outline={true} size="sm" as={Link}>
@@ -103,8 +103,8 @@ export const UserSettingsSidebar: React.FunctionComponent<
             )}
             <SidebarGroup>
                 <SidebarGroupHeader label="Other actions" />
-                {!siteAdminViewingOtherUser && <SidebarNavItem to="/api/console">API console</SidebarNavItem>}
-                {props.authenticatedUser.siteAdmin && <SidebarNavItem to="/site-admin">Site admin</SidebarNavItem>}
+                {!siteAdminViewingOtherUser && <SidebarNewNavItem to="/api/console">API console</SidebarNewNavItem>}
+                {props.authenticatedUser.siteAdmin && <SidebarNewNavItem to="/site-admin">Site admin</SidebarNewNavItem>}
             </SidebarGroup>
             <div>Version: {window.context.version}</div>
         </div>


### PR DESCRIPTION
This is not really a real PR. I wanted to experiment with hacking together an update to the settings sidebar list items in relation to #22117, while also doing a bit of dogfooding with IntelliJ. This "works" in that it updates the user settings sidebar to match the intended design, as shown in this screenshot:

<img width="866" alt="CleanShot 2022-10-18 at 14 21 26@2x" src="https://user-images.githubusercontent.com/6304497/196427918-cf4074bf-a636-4446-b082-29ea17af4a76.png">

But, it's a hack, not a sustainable better-than-I-found-it solution. As it turns out, the user settings sidebar is pretty tightly integrated with a bunch of components that lead to these list items. I was hoping to just introduce a new Wildcard component for the list items here that could be used for both user and admin sidebars, but whoa: it's not that simple. There's nested components pretty far along, and it's not as easy as swapping out Wildcard components for a new component or similar and calling it a day.

**What I've found along the way:**

- The Wildcard component for the [Nav List Items](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/%E2%9C%B3%EF%B8%8F-Wildcard-Design-System?node-id=3734%3A115) wasn't implemented as such. Instead, sidebar items all use `Button` components. There's no quick fix to the issues in #22117 so long as they use the `Button` component.
- UserSettingsSidebar uses the non-Wildcard `Sidebar` component, which is used in many places.
- Adding the Nav List Item component from the Wildcard design spec and getting it into the settings sidebars isn't a quick fix, and will take some refactoring.

**What from here?**

I'm looking for some advice here, honestly. This is something we need to address for the user settings and the admin settings sidebars, especially as we look ahead to things like customization. We have a design spec ready to go between the [settings sidebar unification](https://www.figma.com/file/459B4a8704zFuwqKPA8joL/Settings-sidebar-unification?node-id=1614%3A1992) and the original [Nav List Items](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/%E2%9C%B3%EF%B8%8F-Wildcard-Design-System?node-id=3734%3A115) from Wildcard.

## Test plan

Run `sg start` and navigate to user settings.