### PR TITLE
minio: Untag latest before retagging it

### DIFF
--- a/docker-images/minio/build.sh
+++ b/docker-images/minio/build.sh
@@ -6,4 +6,5 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # Retag the 2022-05-08 MinIO release
 MINIO_RELEASE="RELEASE.2022-09-17T00-09-45Z"
 docker pull minio/minio:$MINIO_RELEASE
+docker rmi "$IMAGE" || true
 docker tag minio/minio:$MINIO_RELEASE "$IMAGE"


### PR DESCRIPTION
Docker is currently running an experiment where containerd is used to pull images, which is an experimental flag in Docker for Mac for now but might become the standard. It doesn't seem to handle tagging images 100% the same way as docker does though, as it doesn't allow using an already used tag. This fixes it by untagging the image first before tagging it again. With this fix, sg start can start up just fine.

If we don't want to fix this upstream that's ok, just figured it might be good future proofing as I just played around with that new flag. Let me know what you think :)



## Test plan

Tested locally that sg start can start indeed.