### PR TITLE
graphql: add DeleteWebhook GraphQL resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -109,6 +109,11 @@ type Mutation {
     createWebhook(codeHostKind: String!, codeHostURN: String!, secret: String): Webhook!
 
     """
+    Deletes a webhook by given ID. Only site admins may perform this mutation.
+    """
+    deleteWebhook(id: ID!): EmptyResponse!
+
+    """
     Adds a external service. Only site admins may perform this mutation.
     """
     addExternalService(input: AddExternalServiceInput!): ExternalService!

--- a/cmd/frontend/graphqlbackend/webhooks.go
+++ b/cmd/frontend/graphqlbackend/webhooks.go
@@ -137,3 +137,18 @@ func (r *schemaResolver) CreateWebhook(ctx context.Context, args *struct {
 	}
 	return &webhookResolver{hook: webhook, db: r.db}, nil
 }
+
+func (r *schemaResolver) DeleteWebhook(ctx context.Context, args *struct{ ID graphql.ID }) (*EmptyResponse, error) {
+	if auth.CheckCurrentUserIsSiteAdmin(ctx, r.db) != nil {
+		return nil, auth.ErrMustBeSiteAdmin
+	}
+	id, err := unmarshalWebhookID(args.ID)
+	if err != nil {
+		return nil, err
+	}
+	err = r.db.Webhooks(keyring.Default().WebhookKey).Delete(ctx, database.DeleteWebhookOpts{ID: id})
+	if err != nil {
+		return nil, errors.Wrap(err, "delete webhook")
+	}
+	return &EmptyResponse{}, nil
+}

--- a/cmd/frontend/graphqlbackend/webhooks_test.go
+++ b/cmd/frontend/graphqlbackend/webhooks_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/schema"
 	sgerrors "github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestCreateWebhook(t *testing.T) {


### PR DESCRIPTION
It is a "reopening" of [this PR](https://github.com/sourcegraph/sourcegraph/pull/43079)

**Main diff between the old one and this one is that resolver now accepts ID instead of UUID.**

Currently targets the branch of [this PR](https://github.com/sourcegraph/sourcegraph/pull/43081), because it contains necessary deletion code and is not yet merged.

### Test plan
New tests added.