### PR TITLE
Remove IncludePrivate option from ListIndexableRepos

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -551,8 +551,7 @@ func syncScheduler(ctx context.Context, logger log.Logger, sched *repos.UpdateSc
 			// Fetch ALL indexable repos that are NOT cloned so that we can add them to the
 			// scheduler
 			opts := database.ListIndexableReposOptions{
-				CloneStatus:    types.CloneStatusNotCloned,
-				IncludePrivate: true,
+				CloneStatus: types.CloneStatusNotCloned,
 			}
 			indexable, err := baseRepoStore.ListIndexableRepos(ctx, opts)
 			if err != nil {

--- a/internal/database/dbcache/cached_indexable_repos.go
+++ b/internal/database/dbcache/cached_indexable_repos.go
@@ -105,8 +105,7 @@ func (s *IndexableReposLister) refreshCache(ctx context.Context) ([]types.Minima
 
 	opts := database.ListIndexableReposOptions{
 		// Zoekt can only index a repo which has been cloned.
-		CloneStatus:    types.CloneStatusCloned,
-		IncludePrivate: true,
+		CloneStatus: types.CloneStatusCloned,
 	}
 	repos, err := s.store.ListIndexableRepos(ctx, opts)
 	if err != nil {

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1170,9 +1170,6 @@ type ListIndexableReposOptions struct {
 	// status.
 	CloneStatus types.CloneStatus
 
-	// IncludePrivate when true will include user added private repos.
-	IncludePrivate bool
-
 	*LimitOffset
 }
 
@@ -1200,10 +1197,6 @@ func (s *repoStore) ListIndexableRepos(ctx context.Context, opts ListIndexableRe
 		where = append(where, sqlf.Sprintf(
 			"gr.clone_status = %s", opts.CloneStatus,
 		))
-	}
-
-	if !opts.IncludePrivate {
-		where = append(where, sqlf.Sprintf("NOT repo.private"))
 	}
 
 	if len(where) == 0 {

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -2781,17 +2781,12 @@ func TestListIndexableRepos(t *testing.T) {
 	}{
 		{
 			name: "no opts",
-			want: []api.RepoID{2, 1}, // No private repos returned by default
+			want: []api.RepoID{2, 1, 3},
 		},
 		{
 			name: "only uncloned",
 			opts: ListIndexableReposOptions{CloneStatus: types.CloneStatusNotCloned},
 			want: []api.RepoID{1},
-		},
-		{
-			name: "include private",
-			opts: ListIndexableReposOptions{IncludePrivate: true},
-			want: []api.RepoID{2, 1, 3},
 		},
 		{
 			name: "limit 1",


### PR DESCRIPTION
The code that called `ListIndexableRepos` that wanted `IncludePrivate: false` has been removed by now. We don't have user-added repos anymore and `IncludePrivate` is always `true` (except in tests).

## Test plan

- Existing tests