### PR TITLE
Audit log: make severity level configurable

### DIFF
--- a/internal/audit/integration/cmd/main.go
+++ b/internal/audit/integration/cmd/main.go
@@ -8,6 +8,8 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/audit"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func main() {
@@ -35,6 +37,17 @@ func main() {
 	if err != nil {
 		os.Exit(-1)
 	}
+
+	// audit log depends on site config, but a mock is sufficient
+	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{
+		Log: &schema.Log{
+			AuditLog: &schema.AuditLog{
+				InternalTraffic: true,
+				GitserverAccess: true,
+				GraphQL:         true,
+				SeverityLevel:   "INFO",
+			}}}})
+	defer conf.Mock(nil)
 
 	for i := 0; i < logsCount; i++ {
 		audit.Log(ctx, logger, audit.Record{

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -74,6 +74,8 @@ type AuditLog struct {
 	GraphQL bool `json:"graphQL"`
 	// InternalTraffic description: Capture security events performed by the internal traffic (adds significant noise).
 	InternalTraffic bool `json:"internalTraffic"`
+	// SeverityLevel description: Severity logging level for the audit log.
+	SeverityLevel string `json:"severityLevel,omitempty"`
 }
 
 // AuthAccessTokens description: Settings for access tokens, which enable external tools to access the Sourcegraph API with the privileges of the user.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1235,6 +1235,12 @@
               "description": "Capture gitserver access logs as part of the audit log.",
               "type": "boolean",
               "default": false
+            },
+            "severityLevel": {
+              "description": "Severity logging level for the audit log.",
+              "type": "string",
+              "enum": ["DEBUG", "INFO", "WARN", "ERROR"],
+              "default": "INFO"
             }
           },
           "required": ["internalTraffic", "graphQL", "gitserverAccess"],
@@ -1242,7 +1248,8 @@
             {
               "internalTraffic": false,
               "graphQL": false,
-              "gitserverAccess": false
+              "gitserverAccess": false,
+              "securityLevel": "INFO"
             }
           ]
         }

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1249,7 +1249,7 @@
               "internalTraffic": false,
               "graphQL": false,
               "gitserverAccess": false,
-              "securityLevel": "INFO"
+              "severityLevel": "INFO"
             }
           ]
         }


### PR DESCRIPTION
## Problem

Audit logs were hard coded to the INFO level. While I think this is the best level for audit log messages (the individual entries are _informational_, not _actionable_), this is a problem for installations that use WARN+ base logging levels (they'd never see the audit logs).

## Solution

Make audit log severity level configurable. This decision will, later on, be reflected in a corresponding ADR & Docs page.

### Other options considered

Hardcode all instances to `INFO`, but the side effects of this change (mainly billing) are hard to predict.

### Usage

Corresponding site-config settings:
```
  "log": {
    "auditLog": {
      "internalTraffic": true,
      "graphQL": false,
      "gitserverAccess": true,
      "severityLevel": "INFO"
    }
  }
```

## Test plan

- automated tests (updated & new)
- screenshot from the local run (changing level from WARN to INFO)
![CleanShot 2022-10-18 at 16 28 55@2x](https://user-images.githubusercontent.com/3193149/196477633-94cbefcc-4707-4bc7-98bf-31d2a9f83b75.png)

