### PR TITLE
[a11y] notepad: screen reader fixes

### DIFF
--- a/client/web/src/search/Notepad.module.scss
+++ b/client/web/src/search/Notepad.module.scss
@@ -35,7 +35,7 @@
         margin: 0;
     }
 
-    ul {
+    ol {
         padding: 0;
         margin: 0;
         list-style: none;

--- a/client/web/src/search/Notepad.tsx
+++ b/client/web/src/search/Notepad.tsx
@@ -38,11 +38,11 @@ import {
     SearchEntry,
     NotepadEntry,
     removeFromNotepad,
-    removeAllNotepadEntries,
     NotepadEntryInput,
     addNotepadEntry,
     setEntryAnnotation,
     NotepadEntryID,
+    removeAllNotepadEntries,
 } from '../stores/notepad'
 
 import styles from './Notepad.module.scss'
@@ -336,6 +336,22 @@ export const Notepad: React.FunctionComponent<React.PropsWithChildren<NotepadPro
         }
     }, [confirmRemoveAll])
 
+    // Focus the remove all button when the remove all confirmation box is hidden.
+    // If the remove all button is now diabled (because there are no entries left),
+    // focus the top-level notepad button.
+    const removeAllButton = useRef<HTMLButtonElement>(null)
+    const rootButton = useRef<HTMLButtonElement>(null)
+    const onRemoveAllClosed = useCallback((removeAll: boolean) => {
+        setConfirmRemoveAll(false)
+
+        if (removeAll) {
+            removeAllNotepadEntries()
+            rootButton.current?.focus()
+        } else {
+            removeAllButton.current?.focus()
+        }
+    }, [])
+
     return (
         <aside
             className={classNames(styles.root, className, { [styles.open]: open })}
@@ -349,6 +365,7 @@ export const Notepad: React.FunctionComponent<React.PropsWithChildren<NotepadPro
                 aria-controls={NOTEPAD_ID}
                 aria-expanded="true"
                 id={`${NOTEPAD_ID}-button`}
+                ref={rootButton}
             >
                 <span>
                     <NotepadIcon />
@@ -415,23 +432,17 @@ export const Notepad: React.FunctionComponent<React.PropsWithChildren<NotepadPro
                         })}
                     </ol>
                     {confirmRemoveAll && (
-                        <div className="p-2">
+                        <div className="p-2" role="alert">
                             <Text>Are you sure you want to delete all entries?</Text>
                             <div className="d-flex justify-content-between">
                                 <Button
                                     variant="secondary"
-                                    onClick={() => setConfirmRemoveAll(false)}
+                                    onClick={() => onRemoveAllClosed(false)}
                                     ref={cancelRemoveAll}
                                 >
                                     Cancel
                                 </Button>
-                                <Button
-                                    variant="danger"
-                                    onClick={() => {
-                                        removeAllNotepadEntries()
-                                        setConfirmRemoveAll(false)
-                                    }}
-                                >
+                                <Button variant="danger" onClick={() => onRemoveAllClosed(true)}>
                                     Yes, delete
                                 </Button>
                             </div>
@@ -465,6 +476,7 @@ export const Notepad: React.FunctionComponent<React.PropsWithChildren<NotepadPro
                             className="text-muted"
                             disabled={entries.length === 0}
                             onClick={() => setConfirmRemoveAll(true)}
+                            ref={removeAllButton}
                         >
                             <Icon aria-hidden={true} svgPath={mdiDelete} />
                         </Button>

--- a/client/web/src/search/Notepad.tsx
+++ b/client/web/src/search/Notepad.tsx
@@ -372,14 +372,25 @@ export const Notepad: React.FunctionComponent<React.PropsWithChildren<NotepadPro
                     <H3 className="p-2">
                         Notes <small>({reversedEntries.length})</small>
                     </H3>
-                    <ul role="listbox" aria-multiselectable={true} onKeyDown={handleKey} tabIndex={0}>
+
+                    {/* This should be a role="listbox" and the entries should be role="option", but that doesn't work with the
+                        design because of the nested buttons. Leave this as a normal list with some interaction (arrow keys, etc)
+                        so that screen readers can navigate the nested controls.
+                    */}
+                    {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+                    <ol
+                        onKeyDown={handleKey}
+                        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+                        tabIndex={0}
+                        aria-label="Notepad entries. Use arrow keys to move selection. Use shift key to select multiple items."
+                    >
                         {reversedEntries.map((entry, index) => {
                             const selected = selectedEntries.includes(index)
                             return (
+                                // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
                                 <li
                                     key={entry.id}
                                     data-notepad-entry-index={index}
-                                    role="option"
                                     onClick={event => toggleSelectedEntry(index, event)}
                                     onKeyDown={event => {
                                         if (document.activeElement === event.currentTarget && event.key === ' ') {
@@ -387,22 +398,22 @@ export const Notepad: React.FunctionComponent<React.PropsWithChildren<NotepadPro
                                             toggleSelectedEntry(index, event)
                                         }
                                     }}
-                                    aria-selected={selected}
-                                    aria-label={getLabel(entry)}
                                     onMouseDown={preventTextSelection}
+                                    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
                                     tabIndex={0}
+                                    aria-label={getLabel(entry, selected)}
                                 >
                                     <NotepadEntryComponent
                                         entry={entry}
                                         focus={hasNewEntry && index === 0}
                                         selected={selected}
-                                        onDelete={selected ? deleteSelectedEntries : deleteEntry}
+                                        onDelete={deleteEntry}
                                         index={index}
                                     />
                                 </li>
                             )
                         })}
-                    </ul>
+                    </ol>
                     {confirmRemoveAll && (
                         <div className="p-2">
                             <Text>Are you sure you want to delete all entries?</Text>
@@ -578,8 +589,6 @@ const NotepadEntryComponent: React.FunctionComponent<React.PropsWithChildren<Not
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selected])
 
-    const deletionLabel = selected ? 'Remove all selected notes' : 'Remove note'
-
     const toggleAnnotationInput = useCallback(
         (show: boolean) => {
             setShowAnnotationInput(show)
@@ -594,6 +603,7 @@ const NotepadEntryComponent: React.FunctionComponent<React.PropsWithChildren<Not
     return (
         <div className={classNames(styles.entry, { [styles.selected]: selected })}>
             <div className="d-flex">
+                <span className="sr-only">{selected ? 'Selected, ' : ''}</span>
                 <span className="flex-shrink-0 text-muted mr-1">{icon}</span>
                 <span className="flex-1">
                     <Link
@@ -617,8 +627,8 @@ const NotepadEntryComponent: React.FunctionComponent<React.PropsWithChildren<Not
                         <Icon aria-hidden={true} svgPath={mdiTextBox} />
                     </Button>
                     <Button
-                        aria-label={deletionLabel}
-                        title={deletionLabel}
+                        aria-label="Remove entry"
+                        title="Remove entry"
                         variant="icon"
                         className="ml-1 text-muted"
                         onClick={event => {
@@ -682,7 +692,12 @@ function getUIComponentsForEntry(
             }
         case 'file':
             return {
-                icon: <Icon aria-label="File" svgPath={entry.lineRange ? mdiCodeBrackets : mdiFileDocumentOutline} />,
+                icon: (
+                    <Icon
+                        aria-label={entry.lineRange ? 'Line range' : 'File'}
+                        svgPath={entry.lineRange ? mdiCodeBrackets : mdiFileDocumentOutline}
+                    />
+                ),
                 title: (
                     <span title={entry.path}>
                         {fileName(entry.path)}
@@ -704,15 +719,16 @@ function getUIComponentsForEntry(
     }
 }
 
-function getLabel(entry: NotepadEntry): string {
+function getLabel(entry: NotepadEntry, selected: boolean): string {
+    const selectedText = selected ? 'Selected, ' : ''
     switch (entry.type) {
         case 'search':
-            return `search: ${toSearchQuery(entry)}`
+            return `${selectedText}search: ${toSearchQuery(entry)}`
         case 'file':
             if (entry.lineRange) {
-                return `line range: ${fileName(entry.path)}${formatLineRange(entry.lineRange)}`
+                return `${selectedText}line range: ${fileName(entry.path)}${formatLineRange(entry.lineRange)}`
             }
-            return `file: ${fileName(entry.path)}`
+            return `${selectedText}file: ${fileName(entry.path)}`
     }
 }
 

--- a/client/web/src/search/Notepad.tsx
+++ b/client/web/src/search/Notepad.tsx
@@ -337,7 +337,7 @@ export const Notepad: React.FunctionComponent<React.PropsWithChildren<NotepadPro
     }, [confirmRemoveAll])
 
     // Focus the remove all button when the remove all confirmation box is hidden.
-    // If the remove all button is now diabled (because there are no entries left),
+    // If the remove all button is now disabled (because there are no entries left),
     // focus the top-level notepad button.
     const removeAllButton = useRef<HTMLButtonElement>(null)
     const rootButton = useRef<HTMLButtonElement>(null)

--- a/client/web/src/search/Notepad.tsx
+++ b/client/web/src/search/Notepad.tsx
@@ -33,16 +33,16 @@ import { Button, Link, TextArea, Icon, H2, H3, Text, createLinkUrl, useMatchMedi
 
 import { BlockInput } from '../notebooks'
 import {
-    useNotepadState,
+    addNotepadEntry,
+    NotepadEntry,
+    NotepadEntryID,
+    NotepadEntryInput,
+    removeAllNotepadEntries,
+    removeFromNotepad,
     restorePreviousSession,
     SearchEntry,
-    NotepadEntry,
-    removeFromNotepad,
-    NotepadEntryInput,
-    addNotepadEntry,
     setEntryAnnotation,
-    NotepadEntryID,
-    removeAllNotepadEntries,
+    useNotepadState,
 } from '../stores/notepad'
 
 import styles from './Notepad.module.scss'

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "watch-web": "yarn workspace @sourcegraph/web run watch",
     "generate": "gulp generate",
     "watch-generate": "gulp watchGenerate",
-    "test": "jest --testPathIgnorePatterns end-to-end regression integration storybook \"/out/.*test.js\"",
+    "test": "jest --testPathIgnorePatterns end-to-end regression integration storybook \"/out/.*test.js\" \"/out/.*test.d.ts\"",
     "_test-integration": "TS_NODE_PROJECT=client/web/src/integration/tsconfig.json mocha --parallel=${CI:-\"false\"} --retries=1 --jobs=2",
     "test-integration": "yarn _test-integration \"./client/web/src/integration/**/*.test.ts\"",
     "test-integration:debug": "BROWSER=chrome KEEP_BROWSER=true DEVTOOLS=true DISABLE_APP_ASSETS_MOCKING=true WINDOW_WIDTH=1920 WINDOW_HEIGHT=1080 yarn _test-integration --retries=0 --jobs=1",


### PR DESCRIPTION
Closes #36510

- Notepad's "delete all" confirmation is now read and focus is managed correctly when closing it.
- Notepad no longer uses the "listbox/option" roles for the list. Even though these roles makes sense, because of the nested buttons, this is not supported (you cannot have nested interactive roles; the screen reader will ignore the nested ones). I added some extra `sr-only` text and labels to tell users how the component works. I also changed the list from `ul` to `ol` since it is more semantic (the notepad items have an order to them that matters).
- Also changed the delete button inside a notepad entry to only delete that entry, instead of all selected entries, since I think this didn't make sense. (Maybe the delete button on the bottom should delete only selected entries instead of everything?)

https://user-images.githubusercontent.com/206864/196499407-1c580c8b-4cb6-4e44-8c88-2e5f8dc86d7b.mp4


## Test plan

- Updated existing unit tests 
- Manually tested

## App preview:

- [Web](https://sg-web-jp-notepadscreenreader.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-wssnzsdqgt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
