### PR TITLE
[language-platform]: fixing NewPreciseCodeIntelSupportResolver panic

### DIFF
--- a/internal/codeintel/autoindexing/transport/graphql/precise_based_support_resolver.go
+++ b/internal/codeintel/autoindexing/transport/graphql/precise_based_support_resolver.go
@@ -27,7 +27,7 @@ type preciseCodeIntelSupportResolver struct {
 func NewPreciseCodeIntelSupportResolver(filepath string) PreciseSupportResolver {
 	indexers := types.LanguageToIndexer[path.Ext(filepath)]
 
-	resolvers := make([]types.CodeIntelIndexerResolver, len(indexers))
+	resolvers := make([]types.CodeIntelIndexerResolver, 0, len(indexers))
 	for _, indexer := range indexers {
 		resolvers = append(resolvers, types.NewCodeIntelIndexerResolverFrom(indexer))
 	}


### PR DESCRIPTION
Fixing panic in `NewPreciseCodeIntelSupportResolver` by initializing slice with zero values.

## Test plan
Ran all the tests.

![oh](https://media.giphy.com/media/WrNfErHio7ZAc/giphy.gif)
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
