### PR TITLE
Search: move repository metadata behind a feature flag

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/phabricator"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
@@ -625,6 +626,10 @@ func (r *schemaResolver) AddRepoKeyValuePair(ctx context.Context, args struct {
 		return &EmptyResponse{}, err
 	}
 
+	if !featureflag.FromContext(ctx).GetBoolOr("repository-metadata", false) {
+		return nil, errors.New("'repository-metadata' feature flag is not enabled")
+	}
+
 	repoID, err := UnmarshalRepositoryID(args.Repo)
 	if err != nil {
 		return &EmptyResponse{}, nil
@@ -643,6 +648,10 @@ func (r *schemaResolver) UpdateRepoKeyValuePair(ctx context.Context, args struct
 		return &EmptyResponse{}, err
 	}
 
+	if !featureflag.FromContext(ctx).GetBoolOr("repository-metadata", false) {
+		return nil, errors.New("'repository-metadata' feature flag is not enabled")
+	}
+
 	repoID, err := UnmarshalRepositoryID(args.Repo)
 	if err != nil {
 		return &EmptyResponse{}, nil
@@ -659,6 +668,10 @@ func (r *schemaResolver) DeleteRepoKeyValuePair(ctx context.Context, args struct
 ) (*EmptyResponse, error) {
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return &EmptyResponse{}, err
+	}
+
+	if !featureflag.FromContext(ctx).GetBoolOr("repository-metadata", false) {
+		return nil, errors.New("'repository-metadata' feature flag is not enabled")
 	}
 
 	repoID, err := UnmarshalRepositoryID(args.Repo)

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -228,8 +229,21 @@ func TestRepository_DefaultBranch(t *testing.T) {
 	}
 }
 
+type mockFeatureFlagStore struct{}
+
+func (m *mockFeatureFlagStore) GetUserFlags(context.Context, int32) (map[string]bool, error) {
+	return map[string]bool{"repository-metadata": true}, nil
+}
+func (m *mockFeatureFlagStore) GetAnonymousUserFlags(context.Context, string) (map[string]bool, error) {
+	return map[string]bool{"repository-metadata": true}, nil
+}
+func (m *mockFeatureFlagStore) GetGlobalFeatureFlags(context.Context) (map[string]bool, error) {
+	return map[string]bool{"repository-metadata": true}, nil
+}
+
 func TestRepository_KVPs(t *testing.T) {
 	ctx := context.Background()
+	ctx = featureflag.WithFlags(ctx, &mockFeatureFlagStore{})
 	logger := logtest.Scoped(t)
 	db := database.NewMockDBFrom(database.NewDB(logger, dbtest.NewDB(logger, t)))
 	users := database.NewMockUserStore()

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -129,6 +129,11 @@ func addKVPs(t *testing.T, client *gqltestutil.Client) {
 		t.Fatal(err)
 	}
 
+	err = client.SetFeatureFlag("repository-metadata", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	testVal := "testval"
 	err = client.AddRepoKVP(repo1.ID, "testkey", &testVal)
 	if err != nil {

--- a/doc/admin/repo/metadata.md
+++ b/doc/admin/repo/metadata.md
@@ -1,7 +1,7 @@
 # Repository metadata
 
 <aside class="experimental">
-<span class="badge badge-experimental">Experimental</span> Tagging repositories with key/value pairs is an experimental feature in Sourcegraph 4.0. It's a <b>preview</b> of functionality we're currently exploring to make searching large numbers of repositories easier. If you have any feedback, please let us know!
+<span class="badge badge-experimental">Experimental</span> Tagging repositories with key/value pairs is an experimental feature in Sourcegraph 4.0. It's a <b>preview</b> of functionality we're currently exploring to make searching large numbers of repositories easier. To enable this feature, enable the `repository-metadata` feature flag for your org. If you have any feedback, please let us know!
 </aside>
 
 Repositories tracked by Sourcegraph can be associated with user-provided key-value pairs. Once this metadata is added, it can be used to filter searches to the subset of matching repositories.

--- a/internal/gqltestutil/repository.go
+++ b/internal/gqltestutil/repository.go
@@ -270,3 +270,19 @@ mutation AddRepoKVP($repo: ID!, $key: String!, $value: String) {
 	var resp map[string]interface{}
 	return c.GraphQL("", query, variables, &resp)
 }
+
+func (c *Client) SetFeatureFlag(name string, value bool) error {
+	const query = `
+mutation SetFeatureFlag($name: ID!, $value: Boolean!) {
+	createFeatureFlag(name: $name, value: $value) {
+		alwaysNil
+	}
+}
+`
+	variables := map[string]any{
+		"name":  name,
+		"value": value,
+	}
+	var resp map[string]interface{}
+	return c.GraphQL("", query, variables, &resp)
+}

--- a/internal/gqltestutil/repository.go
+++ b/internal/gqltestutil/repository.go
@@ -273,9 +273,9 @@ mutation AddRepoKVP($repo: ID!, $key: String!, $value: String) {
 
 func (c *Client) SetFeatureFlag(name string, value bool) error {
 	const query = `
-mutation SetFeatureFlag($name: ID!, $value: Boolean!) {
+mutation SetFeatureFlag($name: String!, $value: Boolean!) {
 	createFeatureFlag(name: $name, value: $value) {
-		alwaysNil
+		__typename
 	}
 }
 `


### PR DESCRIPTION
[Thread here](https://sourcegraph.slack.com/archives/C03L2R35ENL/p1665475173178599)

## Test plan

Tested that creating repo metadata via GraphQL returns an error without the feature flag set. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
