### PR TITLE
CodeMirror blob: Only select lines on main mouse button click; don't show hovercards when selecting text

### DIFF
--- a/client/web/src/integration/codemirror-blob-view.test.ts
+++ b/client/web/src/integration/codemirror-blob-view.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 
-import { ElementHandle } from 'puppeteer'
+import { ElementHandle, MouseButton } from 'puppeteer'
 import type * as sourcegraph from 'sourcegraph'
 
 import { JsonDocument, SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
@@ -177,6 +177,18 @@ describe('CodeMirror blob view', () => {
             // URL is updated
             await driver.assertWindowLocation(`${filePaths['test.ts']}?L1`)
         })
+
+        // This should also test the "back' button, but that test passed with
+        // puppeteer regardless of the implementation.
+        for (const button of ['forward', 'middle', 'right'] as MouseButton[]) {
+            it(`does not select a line on ${button} button click`, async () => {
+                await driver.page.goto(`${driver.sourcegraphBaseUrl}${filePaths['test.ts']}`)
+                await waitForView()
+
+                await driver.page.click(lineAt(1), { button })
+                await driver.page.waitForSelector(lineAt(1) + '.selected-line', { hidden: true, timeout: 5000 })
+            })
+        }
 
         it('does not select a line when clicking on content in the line', async () => {
             await driver.page.goto(`${driver.sourcegraphBaseUrl}${filePaths['test.ts']}`)


### PR DESCRIPTION
The current implementation selects lines when any mouse button is clicked which interferes with people's use of forward and back buttons.

And while I was looking at mouse events I also updated the hovercard code to not show/hide hovercards when the user moves the mouse *and* presses a mouse button (e.g. when selecting text).

## Test plan

CI and manual tests

## App preview:

- [Web](https://sg-web-fkling-cm-blob-mouse-clicks.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-iikbbeljai.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
