### PR TITLE
Fix broken Jira and GitHub Issue links

### DIFF
--- a/doc/batch_changes/references/faq.md
+++ b/doc/batch_changes/references/faq.md
@@ -34,8 +34,8 @@ Note: If you run memory-intensive jobs, you might need to reduce the number of p
 Batch Changes does not support a declarative syntax for issues or tickets.
 However, [steps](../references/batch_spec_yaml_reference.md#steps-run) can be used to run any container. Some users have built scripts to create tickets at each apply:
 
-- [Jira tickets](https://github.com/sourcegraph/batch-change-examples/tree/main/jira-tickets)
-- [GitHub issues](https://github.com/sourcegraph/batch-change-examples/tree/main/github-issues)
+- [Jira tickets](https://github.com/sourcegraph/batch-change-examples/blob/main/ticketing-systems/jira-tickets/README.md)
+- [GitHub issues](https://github.com/sourcegraph/batch-change-examples/blob/main/ticketing-systems/github-issues/README.md)
 
 ### What happens to the preview page if the batch spec is not applied?
 Unapplied batch specs are removed from the database after 7 days.


### PR DESCRIPTION
Replaces broken links to docs for Jira and Github Issue creation, with the correct links.



## Test plan
No review required: updating docs. 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
