### PR TITLE
insights: add initial logic for backfill analyze step

### DIFF
--- a/enterprise/internal/insights/discovery/series_repo_iterator.go
+++ b/enterprise/internal/insights/discovery/series_repo_iterator.go
@@ -1,0 +1,32 @@
+package discovery
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+)
+
+type seriesRepoIterator struct {
+	allRepoIterator *AllReposIterator
+	repoStore       RepoStore
+}
+
+type SeriesRepoIterator interface {
+	SeriesRepoIterator(ctx context.Context, series *types.InsightSeries) (RepoIterator, error)
+}
+
+func (s *seriesRepoIterator) SeriesRepoIterator(ctx context.Context, series *types.InsightSeries) (RepoIterator, error) {
+	switch len(series.Repositories) {
+	case 0:
+		return s.allRepoIterator, nil
+	default:
+		return NewScopedRepoIterator(ctx, series.Repositories, s.repoStore)
+	}
+}
+
+func NewSeriesRepoIterator(allReposIterator *AllReposIterator, repoStore RepoStore) SeriesRepoIterator {
+	return &seriesRepoIterator{
+		allRepoIterator: allReposIterator,
+		repoStore:       repoStore,
+	}
+}

--- a/enterprise/internal/insights/discovery/series_repo_iterator.go
+++ b/enterprise/internal/insights/discovery/series_repo_iterator.go
@@ -12,10 +12,10 @@ type seriesRepoIterator struct {
 }
 
 type SeriesRepoIterator interface {
-	SeriesRepoIterator(ctx context.Context, series *types.InsightSeries) (RepoIterator, error)
+	ForSeries(ctx context.Context, series *types.InsightSeries) (RepoIterator, error)
 }
 
-func (s *seriesRepoIterator) SeriesRepoIterator(ctx context.Context, series *types.InsightSeries) (RepoIterator, error) {
+func (s *seriesRepoIterator) ForSeries(ctx context.Context, series *types.InsightSeries) (RepoIterator, error) {
 	switch len(series.Repositories) {
 	case 0:
 		return s.allRepoIterator, nil

--- a/enterprise/internal/insights/scheduler/backfill.go
+++ b/enterprise/internal/insights/scheduler/backfill.go
@@ -27,12 +27,12 @@ func newBackfillStoreWithClock(edb edb.InsightsDB, clock glock.Clock) *BackfillS
 }
 
 func (s *BackfillStore) With(other basestore.ShareableStore) *BackfillStore {
-	return &BackfillStore{Store: s.Store.With(other)}
+	return &BackfillStore{Store: s.Store.With(other), clock: s.clock}
 }
 
 func (s *BackfillStore) Transact(ctx context.Context) (*BackfillStore, error) {
 	txBase, err := s.Store.Transact(ctx)
-	return &BackfillStore{Store: txBase}, err
+	return &BackfillStore{Store: txBase, clock: s.clock}, err
 }
 
 type SeriesBackfill struct {

--- a/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
@@ -29,7 +29,7 @@ type newBackfillHandler struct {
 	costAnalyzer  priority.QueryAnalyzer
 }
 
-// makeNewBackfillWorker Makes a new Worker, Resetter and store to handle the Queue of Backfill jobs that are in the state of "New"
+// makeNewBackfillWorker makes a new Worker, Resetter and Store to handle the queue of Backfill jobs that are in the state of "New"
 func makeNewBackfillWorker(ctx context.Context, config JobMonitorConfig) (*workerutil.Worker, *dbworker.Resetter, dbworkerstore.Store) {
 	insightsDB := config.InsightsDB
 	backfillStore := newBackfillStore(insightsDB)

--- a/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
@@ -61,7 +61,7 @@ func makeNewBackfillWorker(ctx context.Context, config JobMonitorConfig) (*worke
 		Metrics:     workerutil.NewMetrics(config.ObsContext, name),
 	})
 
-	resetter := dbworker.NewResetter(log.Scoped("", ""), workerStore, dbworker.ResetterOptions{
+	resetter := dbworker.NewResetter(log.Scoped("BackfillNewResetter", ""), workerStore, dbworker.ResetterOptions{
 		Name:     fmt.Sprintf("%s_resetter", name),
 		Interval: time.Second * 20,
 		Metrics:  *dbworker.NewMetrics(config.ObsContext, name),

--- a/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/keegancsmith/sqlf"
-	log "github.com/sourcegraph/log"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/priority"

--- a/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
@@ -1,0 +1,133 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+	log "github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/priority"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
+	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// newBackfillHandler - Handles backfill that are in the "new" state
+// The new state is the initial state post creation of a series.  This handler is responsible only for determining the work
+// that needs to be completed to backfill this series.  It then requeues the backfill record to perform the acutal backfill work.
+type newBackfillHandler struct {
+	workerStore   dbworkerstore.Store
+	backfillStore *BackfillStore
+	seriesReader  SeriesReader
+	repoIterator  discovery.SeriesRepoIterator
+	costAnalyzer  priority.QueryAnalyzer
+}
+
+// makeNewBackfillWorker Makes a new Worker, Resetter and store to handle the Queue of Backfill jobs that are in the state of "New"
+func makeNewBackfillWorker(ctx context.Context, config JobMonitorConfig) (*workerutil.Worker, *dbworker.Resetter, dbworkerstore.Store) {
+	insightsDB := config.InsightsDB
+	backfillStore := newBackfillStore(insightsDB)
+
+	name := "backfill_new_backfill_worker"
+
+	workerStore := dbworkerstore.NewWithMetrics(insightsDB.Handle(), dbworkerstore.Options{
+		Name:              fmt.Sprintf("%s_store", name),
+		TableName:         "insights_background_jobs",
+		ViewName:          "insights_jobs_backfill_new",
+		ColumnExpressions: baseJobColumns,
+		Scan:              dbworkerstore.BuildWorkerScan(scanBaseJob),
+		OrderByExpression: sqlf.Sprintf("id"), // todo
+		MaxNumResets:      100,
+		StalledMaxAge:     time.Second * 30,
+	}, config.ObsContext)
+
+	task := newBackfillHandler{
+		workerStore:   workerStore,
+		backfillStore: backfillStore,
+		seriesReader:  store.NewInsightStore(insightsDB),
+		repoIterator:  discovery.NewSeriesRepoIterator(nil, config.RepoStore), //TODO add in a real all repos iterator
+	}
+
+	worker := dbworker.NewWorker(ctx, workerStore, &task, workerutil.WorkerOptions{
+		Name:        name,
+		NumHandlers: 1,
+		Interval:    5 * time.Second,
+		Metrics:     workerutil.NewMetrics(config.ObsContext, name),
+	})
+
+	resetter := dbworker.NewResetter(log.Scoped("", ""), workerStore, dbworker.ResetterOptions{
+		Name:     fmt.Sprintf("%s_resetter", name),
+		Interval: time.Second * 20,
+		Metrics:  *dbworker.NewMetrics(config.ObsContext, name),
+	})
+
+	return worker, resetter, workerStore
+}
+
+var _ workerutil.Handler = &newBackfillHandler{}
+
+func (h *newBackfillHandler) Handle(ctx context.Context, logger log.Logger, record workerutil.Record) (err error) {
+	logger.Info("newBackfillHandler called", log.Int("recordId", record.RecordID()))
+	job, ok := record.(*BaseJob)
+	if !ok {
+		return errors.New("invalid job received")
+	}
+	// setup transactions
+	queueTx, err := h.workerStore.Handle().Transact(ctx)
+	if err != nil {
+		return err
+	}
+	backfillTx, err := h.backfillStore.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		queueTx.Done(err)
+		backfillTx.Done(err)
+	}()
+
+	// load backfill and series
+	backfill, err := backfillTx.loadBackfill(ctx, job.backfillId)
+	if err != nil {
+		return errors.Wrap(err, "loadBackfill")
+	}
+	series, err := h.seriesReader.GetDataSeriesByID(ctx, backfill.SeriesId)
+	if err != nil {
+		return errors.Wrap(err, "GetDataSeriesByID")
+	}
+
+	// set backfill repo scope
+	repoIds := []int32{}
+	reposIterator, err := h.repoIterator.SeriesRepoIterator(ctx, series)
+	if err != nil {
+		return errors.Wrap(err, "repoIterator.SeriesRepoIterator")
+	}
+	err = reposIterator.ForEach(ctx, func(repoName string, id api.RepoID) error {
+		repoIds = append(repoIds, int32(id))
+		return nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "reposIterator.ForEach")
+	}
+
+	//TODO: use query costing
+	backfill, err = backfill.SetScope(ctx, backfillTx, repoIds, 0)
+	if err != nil {
+		return errors.Wrap(err, "backfill.SetScope")
+	}
+
+	// update series state
+	err = backfill.setState(ctx, backfillTx, BackfillStateProcessing)
+	if err != nil {
+		return errors.Wrap(err, "backfill.setState")
+	}
+
+	// enqueue backfill for next step in processing
+	return enqueueBackfill(ctx, queueTx, backfill)
+}

--- a/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
@@ -20,7 +20,7 @@ import (
 
 // newBackfillHandler - Handles backfill that are in the "new" state
 // The new state is the initial state post creation of a series.  This handler is responsible only for determining the work
-// that needs to be completed to backfill this series.  It then requeues the backfill record to perform the acutal backfill work.
+// that needs to be completed to backfill this series.  It then requeues the backfill record into "processing" to perform the actual backfill work.
 type newBackfillHandler struct {
 	workerStore   dbworkerstore.Store
 	backfillStore *BackfillStore

--- a/enterprise/internal/insights/scheduler/backfill_state_new_handler_test.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_new_handler_test.go
@@ -2,43 +2,33 @@ package scheduler
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
+	"github.com/derision-test/glock"
+	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
 
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
-
-	"github.com/sourcegraph/log/logtest"
+	itypes "github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func Test_MonitorStartsAndStops(t *testing.T) {
-	logger := logtest.Scoped(t)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
-	defer cancel()
-	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t))
-	repos := database.NewMockRepoStore()
-	config := JobMonitorConfig{
-		InsightsDB: insightsDB,
-		RepoStore:  repos,
-		ObsContext: &observation.TestContext,
-	}
-	routines := NewBackgroundJobMonitor(ctx, config).Routines()
-	goroutine.MonitorBackgroundRoutines(ctx, routines...)
-}
-
-func TestScheduler_InitialBackfill(t *testing.T) {
+func Test_MovesBackfillFromNewToProcessing(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t))
 	repos := database.NewMockRepoStore()
+	repos.ListFunc.SetDefaultReturn([]*itypes.Repo{{ID: 1, Name: "repo1"}, {ID: 2, Name: "repo2"}}, nil)
+	now := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := glock.NewMockClockAt(now)
+	bfs := newBackfillStoreWithClock(insightsDB, clock)
 	insightsStore := store.NewInsightStore(insightsDB)
 	config := JobMonitorConfig{
 		InsightsDB: insightsDB,
@@ -51,16 +41,36 @@ func TestScheduler_InitialBackfill(t *testing.T) {
 		SeriesID:            "series1",
 		Query:               "asdf",
 		SampleIntervalUnit:  string(types.Month),
+		Repositories:        []string{"repo1", "repo2"},
 		SampleIntervalValue: 1,
 		GenerationMethod:    types.Search,
 	})
 	require.NoError(t, err)
 
-	scheduler := NewScheduler(insightsDB)
-	backfill, err := scheduler.InitialBackfill(ctx, series)
+	backfill, err := bfs.NewBackfill(ctx, series)
+	require.NoError(t, err)
+
+	err = enqueueBackfill(ctx, bfs.Handle(), backfill)
 	require.NoError(t, err)
 
 	dequeue, found, err := monitor.newBackfillStore.Dequeue(ctx, "test", nil)
+	handler := newBackfillHandler{
+		workerStore:   monitor.newBackfillStore,
+		backfillStore: bfs,
+		seriesReader:  store.NewInsightStore(insightsDB),
+		repoIterator:  discovery.NewSeriesRepoIterator(nil, repos),
+	}
+	err = handler.Handle(ctx, logger, dequeue)
+	require.NoError(t, err)
+
+	dequeue, found, err = monitor.newBackfillStore.Dequeue(ctx, "test", nil)
+	require.NoError(t, err)
+	if found {
+		t.Fatal(errors.New("found record that should not be visible to the new backfill store"))
+	}
+
+	// now ensure the in progress handler _can_ pick it up
+	dequeue, found, err = monitor.inProgressStore.Dequeue(ctx, "test", nil)
 	require.NoError(t, err)
 	if !found {
 		t.Fatal(errors.New("no queued record found"))

--- a/enterprise/internal/insights/scheduler/scheduler.go
+++ b/enterprise/internal/insights/scheduler/scheduler.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 
-        "github.com/sourcegraph/log"
+	"github.com/sourcegraph/log"
 
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"

--- a/enterprise/internal/insights/scheduler/scheduler.go
+++ b/enterprise/internal/insights/scheduler/scheduler.go
@@ -155,7 +155,7 @@ func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*worker
 		Metrics:     workerutil.NewMetrics(config.ObsContext, name),
 	})
 
-	resetter := dbworker.NewResetter(log.Scoped("", ""), workerStore, dbworker.ResetterOptions{
+	resetter := dbworker.NewResetter(log.Scoped("BackfillInProgressResetter", ""), workerStore, dbworker.ResetterOptions{
 		Name:     fmt.Sprintf("%s_resetter", name),
 		Interval: time.Second * 20,
 		Metrics:  *dbworker.NewMetrics(config.ObsContext, name),

--- a/enterprise/internal/insights/scheduler/scheduler.go
+++ b/enterprise/internal/insights/scheduler/scheduler.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 
-	log "github.com/sourcegraph/log"
+        "github.com/sourcegraph/log"
 
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"

--- a/enterprise/internal/insights/scheduler/scheduler_test.go
+++ b/enterprise/internal/insights/scheduler/scheduler_test.go
@@ -28,7 +28,12 @@ func Test_MonitorStartsAndStops(t *testing.T) {
 	defer cancel()
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t))
 	repos := database.NewMockRepoStore()
-	routines := NewBackgroundJobMonitor(ctx, insightsDB, repos, &observation.TestContext).Routines()
+	config := JobMonitorConfig{
+		InsightsDB: insightsDB,
+		RepoStore:  repos,
+		ObsContext: &observation.TestContext,
+	}
+	routines := NewBackgroundJobMonitor(ctx, config).Routines()
 	goroutine.MonitorBackgroundRoutines(ctx, routines...)
 }
 
@@ -42,7 +47,12 @@ func Test_MovesBackfillFromNewToProcessing(t *testing.T) {
 	clock := glock.NewMockClockAt(now)
 	bfs := newBackfillStoreWithClock(insightsDB, clock)
 	insightsStore := store.NewInsightStore(insightsDB)
-	monitor := NewBackgroundJobMonitor(ctx, insightsDB, repos, &observation.TestContext)
+	config := JobMonitorConfig{
+		InsightsDB: insightsDB,
+		RepoStore:  repos,
+		ObsContext: &observation.TestContext,
+	}
+	monitor := NewBackgroundJobMonitor(ctx, config)
 
 	series, err := insightsStore.CreateSeries(ctx, types.InsightSeries{
 		SeriesID:            "series1",
@@ -92,7 +102,12 @@ func TestScheduler_InitialBackfill(t *testing.T) {
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t))
 	repos := database.NewMockRepoStore()
 	insightsStore := store.NewInsightStore(insightsDB)
-	monitor := NewBackgroundJobMonitor(ctx, insightsDB, repos, &observation.TestContext)
+	config := JobMonitorConfig{
+		InsightsDB: insightsDB,
+		RepoStore:  repos,
+		ObsContext: &observation.TestContext,
+	}
+	monitor := NewBackgroundJobMonitor(ctx, config)
 
 	series, err := insightsStore.CreateSeries(ctx, types.InsightSeries{
 		SeriesID:            "series1",


### PR DESCRIPTION
Fills in the logic for the backfill "new" state handler logic.  This step is triggered from the queue when backfill jobs are in the "new" state.  It picks up the backfill record and figures out which repos it will run over, and estimated cost (currently 0) and then re-queues the backfill to start processing.

I also picked up the "new" worker logic and moved it into it's own file because it was getting difficult to reason about what belonged to what as they are all named similar.  

Created a new config object to get passed in because the number of dependencies is increase and will continue to grow in the next PR.

Also creates a new type of Repo iterator which takes a `InsightSeries` and returns an iterator that is appropriate for it, when we add strat scoped insights this should be updated with the 3rd type of iterator.  

closes https://github.com/sourcegraph/sourcegraph/issues/42890
## Test plan
unit tests
not attached to live code yet.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
