### PR TITLE
codeintel: Fix unique inserts for `codeintel_commit_dates`

### DIFF
--- a/migrations/frontend/1665770699_add_codeintel_commit_dates/up.sql
+++ b/migrations/frontend/1665770699_add_codeintel_commit_dates/up.sql
@@ -25,4 +25,5 @@ WHERE
     u.committed_at IS NOT NULL
 GROUP BY
     u.repository_id,
-    u.commit;
+    u.commit
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
This fixes a migration that can't be ran twice.

## Test plan

It broke b4 now it don't.