### PR TITLE
Render `QueryExamplesHomepage` for dotcom logged in users

### DIFF
--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -77,6 +77,7 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
                     [styles.panelsContainerWithCollaborators]: showCollaborators,
                 })}
             >
+                {props.isSourcegraphDotCom}
                 {props.isSourcegraphDotCom && !props.authenticatedUser && <LoggedOutHomepage {...props} />}
                 {showEnterpriseHomePanels && props.authenticatedUser && (
                     <HomePanels showCollaborators={showCollaborators} {...props} />

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -77,7 +77,7 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
                     [styles.panelsContainerWithCollaborators]: showCollaborators,
                 })}
             >
-                {props.isSourcegraphDotCom}
+                {!!props.isSourcegraphDotCom}
                 {props.isSourcegraphDotCom && !props.authenticatedUser && <LoggedOutHomepage {...props} />}
                 {showEnterpriseHomePanels && props.authenticatedUser && (
                     <HomePanels showCollaborators={showCollaborators} {...props} />

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -77,7 +77,6 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
                     [styles.panelsContainerWithCollaborators]: showCollaborators,
                 })}
             >
-                {props.isSourcegraphDotCom}
                 {props.isSourcegraphDotCom && !props.authenticatedUser && <LoggedOutHomepage {...props} />}
                 {showEnterpriseHomePanels && props.authenticatedUser && (
                     <HomePanels showCollaborators={showCollaborators} {...props} />

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -77,7 +77,7 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
                     [styles.panelsContainerWithCollaborators]: showCollaborators,
                 })}
             >
-                {!!props.isSourcegraphDotCom}
+                {props.isSourcegraphDotCom}
                 {props.isSourcegraphDotCom && !props.authenticatedUser && <LoggedOutHomepage {...props} />}
                 {showEnterpriseHomePanels && props.authenticatedUser && (
                     <HomePanels showCollaborators={showCollaborators} {...props} />

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -29,15 +29,15 @@ import styles from './SearchPage.module.scss'
 
 export interface SearchPageProps
     extends SettingsCascadeProps<Settings>,
-        ThemeProps,
-        ThemePreferenceProps,
-        ActivationProps,
-        TelemetryProps,
-        ExtensionsControllerProps<'extHostAPI' | 'executeCommand'>,
-        PlatformContextProps<'settings' | 'sourcegraphURL' | 'updateSettings' | 'requestGraphQL'>,
-        SearchContextInputProps,
-        HomePanelsProps,
-        CodeInsightsProps {
+    ThemeProps,
+    ThemePreferenceProps,
+    ActivationProps,
+    TelemetryProps,
+    ExtensionsControllerProps<'extHostAPI' | 'executeCommand'>,
+    PlatformContextProps<'settings' | 'sourcegraphURL' | 'updateSettings' | 'requestGraphQL'>,
+    SearchContextInputProps,
+    HomePanelsProps,
+    CodeInsightsProps {
     authenticatedUser: AuthenticatedUser | null
     location: H.Location
     history: H.History
@@ -77,13 +77,13 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
                     [styles.panelsContainerWithCollaborators]: showCollaborators,
                 })}
             >
+                {props.isSourcegraphDotCom}
                 {props.isSourcegraphDotCom && !props.authenticatedUser && <LoggedOutHomepage {...props} />}
-
                 {showEnterpriseHomePanels && props.authenticatedUser && (
                     <HomePanels showCollaborators={showCollaborators} {...props} />
                 )}
 
-                {!showEnterpriseHomePanels && !props.isSourcegraphDotCom && (
+                {!showEnterpriseHomePanels && (
                     <QueryExamplesHomepage
                         telemetryService={props.telemetryService}
                         queryState={queryState}


### PR DESCRIPTION
This PR allows dotcom logged in users to view the query samples brought in on #39987.

__ will you let us know if you see an issue in bringing this into dotcom? I'm assuming it was left out for initial rollout.

## Test plan
- Ensure all tests pass
- Ensure visiting `/search` home page logged in on dotcom shows the same search query samples on k8s and s2
- Observe no breaking changes on logged out state in this view for all env's

## App preview:

- [Web](https://sg-web-becca-dotcome-search-query-samples.onrender.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

