### PR TITLE
codeintel: Expire additional uploads via traversal

### DIFF
--- a/internal/codeintel/uploads/internal/background/iface.go
+++ b/internal/codeintel/uploads/internal/background/iface.go
@@ -32,6 +32,7 @@ type UploadService interface {
 	// Uploads
 	GetUploads(ctx context.Context, opts shared.GetUploadsOptions) (uploads []types.Upload, totalCount int, err error)
 	SoftDeleteExpiredUploads(ctx context.Context, batchSize int) (int, error)
+	SoftDeleteExpiredUploadsViaTraversal(ctx context.Context, maxTraversal int) (int, error)
 	DeleteUploadsWithoutRepository(ctx context.Context, now time.Time) (_ map[int]int, err error)
 	DeleteUploadsStuckUploading(ctx context.Context, uploadedBefore time.Time) (_ int, err error)
 	DeleteLsifDataByUploadIds(ctx context.Context, bundleIDs ...int) (err error)

--- a/internal/codeintel/uploads/internal/background/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/mocks_test.go
@@ -2081,6 +2081,10 @@ type MockUploadService struct {
 	// SoftDeleteExpiredUploadsFunc is an instance of a mock function object
 	// controlling the behavior of the method SoftDeleteExpiredUploads.
 	SoftDeleteExpiredUploadsFunc *UploadServiceSoftDeleteExpiredUploadsFunc
+	// SoftDeleteExpiredUploadsViaTraversalFunc is an instance of a mock
+	// function object controlling the behavior of the method
+	// SoftDeleteExpiredUploadsViaTraversal.
+	SoftDeleteExpiredUploadsViaTraversalFunc *UploadServiceSoftDeleteExpiredUploadsViaTraversalFunc
 	// UpdateAllDirtyCommitGraphsFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// UpdateAllDirtyCommitGraphs.
@@ -2170,6 +2174,11 @@ func NewMockUploadService() *MockUploadService {
 			},
 		},
 		SoftDeleteExpiredUploadsFunc: &UploadServiceSoftDeleteExpiredUploadsFunc{
+			defaultHook: func(context.Context, int) (r0 int, r1 error) {
+				return
+			},
+		},
+		SoftDeleteExpiredUploadsViaTraversalFunc: &UploadServiceSoftDeleteExpiredUploadsViaTraversalFunc{
 			defaultHook: func(context.Context, int) (r0 int, r1 error) {
 				return
 			},
@@ -2271,6 +2280,11 @@ func NewStrictMockUploadService() *MockUploadService {
 				panic("unexpected invocation of MockUploadService.SoftDeleteExpiredUploads")
 			},
 		},
+		SoftDeleteExpiredUploadsViaTraversalFunc: &UploadServiceSoftDeleteExpiredUploadsViaTraversalFunc{
+			defaultHook: func(context.Context, int) (int, error) {
+				panic("unexpected invocation of MockUploadService.SoftDeleteExpiredUploadsViaTraversal")
+			},
+		},
 		UpdateAllDirtyCommitGraphsFunc: &UploadServiceUpdateAllDirtyCommitGraphsFunc{
 			defaultHook: func(context.Context, time.Duration, time.Duration) error {
 				panic("unexpected invocation of MockUploadService.UpdateAllDirtyCommitGraphs")
@@ -2336,6 +2350,9 @@ func NewMockUploadServiceFrom(i UploadService) *MockUploadService {
 		},
 		SoftDeleteExpiredUploadsFunc: &UploadServiceSoftDeleteExpiredUploadsFunc{
 			defaultHook: i.SoftDeleteExpiredUploads,
+		},
+		SoftDeleteExpiredUploadsViaTraversalFunc: &UploadServiceSoftDeleteExpiredUploadsViaTraversalFunc{
+			defaultHook: i.SoftDeleteExpiredUploadsViaTraversal,
 		},
 		UpdateAllDirtyCommitGraphsFunc: &UploadServiceUpdateAllDirtyCommitGraphsFunc{
 			defaultHook: i.UpdateAllDirtyCommitGraphs,
@@ -4148,6 +4165,119 @@ func (c UploadServiceSoftDeleteExpiredUploadsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c UploadServiceSoftDeleteExpiredUploadsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// UploadServiceSoftDeleteExpiredUploadsViaTraversalFunc describes the
+// behavior when the SoftDeleteExpiredUploadsViaTraversal method of the
+// parent MockUploadService instance is invoked.
+type UploadServiceSoftDeleteExpiredUploadsViaTraversalFunc struct {
+	defaultHook func(context.Context, int) (int, error)
+	hooks       []func(context.Context, int) (int, error)
+	history     []UploadServiceSoftDeleteExpiredUploadsViaTraversalFuncCall
+	mutex       sync.Mutex
+}
+
+// SoftDeleteExpiredUploadsViaTraversal delegates to the next hook function
+// in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockUploadService) SoftDeleteExpiredUploadsViaTraversal(v0 context.Context, v1 int) (int, error) {
+	r0, r1 := m.SoftDeleteExpiredUploadsViaTraversalFunc.nextHook()(v0, v1)
+	m.SoftDeleteExpiredUploadsViaTraversalFunc.appendCall(UploadServiceSoftDeleteExpiredUploadsViaTraversalFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// SoftDeleteExpiredUploadsViaTraversal method of the parent
+// MockUploadService instance is invoked and the hook queue is empty.
+func (f *UploadServiceSoftDeleteExpiredUploadsViaTraversalFunc) SetDefaultHook(hook func(context.Context, int) (int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// SoftDeleteExpiredUploadsViaTraversal method of the parent
+// MockUploadService instance invokes the hook at the front of the queue and
+// discards it. After the queue is empty, the default hook function is
+// invoked for any future action.
+func (f *UploadServiceSoftDeleteExpiredUploadsViaTraversalFunc) PushHook(hook func(context.Context, int) (int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *UploadServiceSoftDeleteExpiredUploadsViaTraversalFunc) SetDefaultReturn(r0 int, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (int, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *UploadServiceSoftDeleteExpiredUploadsViaTraversalFunc) PushReturn(r0 int, r1 error) {
+	f.PushHook(func(context.Context, int) (int, error) {
+		return r0, r1
+	})
+}
+
+func (f *UploadServiceSoftDeleteExpiredUploadsViaTraversalFunc) nextHook() func(context.Context, int) (int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *UploadServiceSoftDeleteExpiredUploadsViaTraversalFunc) appendCall(r0 UploadServiceSoftDeleteExpiredUploadsViaTraversalFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// UploadServiceSoftDeleteExpiredUploadsViaTraversalFuncCall objects
+// describing the invocations of this function.
+func (f *UploadServiceSoftDeleteExpiredUploadsViaTraversalFunc) History() []UploadServiceSoftDeleteExpiredUploadsViaTraversalFuncCall {
+	f.mutex.Lock()
+	history := make([]UploadServiceSoftDeleteExpiredUploadsViaTraversalFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// UploadServiceSoftDeleteExpiredUploadsViaTraversalFuncCall is an object
+// that describes an invocation of method
+// SoftDeleteExpiredUploadsViaTraversal on an instance of MockUploadService.
+type UploadServiceSoftDeleteExpiredUploadsViaTraversalFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c UploadServiceSoftDeleteExpiredUploadsViaTraversalFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c UploadServiceSoftDeleteExpiredUploadsViaTraversalFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/codeintel/uploads/internal/store/observability.go
+++ b/internal/codeintel/uploads/internal/store/observability.go
@@ -33,28 +33,29 @@ type operations struct {
 	hasRepository                           *observation.Operation
 
 	// Uploads
-	getUploads                        *observation.Operation
-	getUploadByID                     *observation.Operation
-	getUploadsByIDs                   *observation.Operation
-	getVisibleUploadsMatchingMonikers *observation.Operation
-	updateUploadsVisibleToCommits     *observation.Operation
-	writeVisibleUploads               *observation.Operation
-	persistNearestUploads             *observation.Operation
-	persistNearestUploadsLinks        *observation.Operation
-	persistUploadsVisibleAtTip        *observation.Operation
-	updateUploadRetention             *observation.Operation
-	updateCommittedAt                 *observation.Operation
-	sourcedCommitsWithoutCommittedAt  *observation.Operation
-	deleteUploadsWithoutRepository    *observation.Operation
-	deleteUploadsStuckUploading       *observation.Operation
-	softDeleteExpiredUploads          *observation.Operation
-	hardDeleteUploadsByIDs            *observation.Operation
-	deleteUploadByID                  *observation.Operation
-	insertUpload                      *observation.Operation
-	addUploadPart                     *observation.Operation
-	markQueued                        *observation.Operation
-	markFailed                        *observation.Operation
-	deleteUploads                     *observation.Operation
+	getUploads                           *observation.Operation
+	getUploadByID                        *observation.Operation
+	getUploadsByIDs                      *observation.Operation
+	getVisibleUploadsMatchingMonikers    *observation.Operation
+	updateUploadsVisibleToCommits        *observation.Operation
+	writeVisibleUploads                  *observation.Operation
+	persistNearestUploads                *observation.Operation
+	persistNearestUploadsLinks           *observation.Operation
+	persistUploadsVisibleAtTip           *observation.Operation
+	updateUploadRetention                *observation.Operation
+	updateCommittedAt                    *observation.Operation
+	sourcedCommitsWithoutCommittedAt     *observation.Operation
+	deleteUploadsWithoutRepository       *observation.Operation
+	deleteUploadsStuckUploading          *observation.Operation
+	softDeleteExpiredUploadsViaTraversal *observation.Operation
+	softDeleteExpiredUploads             *observation.Operation
+	hardDeleteUploadsByIDs               *observation.Operation
+	deleteUploadByID                     *observation.Operation
+	insertUpload                         *observation.Operation
+	addUploadPart                        *observation.Operation
+	markQueued                           *observation.Operation
+	markFailed                           *observation.Operation
+	deleteUploads                        *observation.Operation
 
 	// Dumps
 	findClosestDumps                   *observation.Operation
@@ -119,24 +120,25 @@ func newOperations(observationContext *observation.Context) *operations {
 		hasRepository:                           op("HasRepository"),
 
 		// Uploads
-		getUploads:                        op("GetUploads"),
-		getUploadByID:                     op("GetUploadByID"),
-		getUploadsByIDs:                   op("GetUploadsByIDs"),
-		getVisibleUploadsMatchingMonikers: op("GetVisibleUploadsMatchingMonikers"),
-		updateUploadsVisibleToCommits:     op("UpdateUploadsVisibleToCommits"),
-		updateUploadRetention:             op("UpdateUploadRetention"),
-		updateCommittedAt:                 op("UpdateCommittedAt"),
-		sourcedCommitsWithoutCommittedAt:  op("SourcedCommitsWithoutCommittedAt"),
-		deleteUploadsStuckUploading:       op("DeleteUploadsStuckUploading"),
-		deleteUploadsWithoutRepository:    op("DeleteUploadsWithoutRepository"),
-		softDeleteExpiredUploads:          op("SoftDeleteExpiredUploads"),
-		hardDeleteUploadsByIDs:            op("HardDeleteUploadsByIDs"),
-		deleteUploadByID:                  op("DeleteUploadByID"),
-		insertUpload:                      op("InsertUpload"),
-		addUploadPart:                     op("AddUploadPart"),
-		markQueued:                        op("MarkQueued"),
-		markFailed:                        op("MarkFailed"),
-		deleteUploads:                     op("DeleteUploads"),
+		getUploads:                           op("GetUploads"),
+		getUploadByID:                        op("GetUploadByID"),
+		getUploadsByIDs:                      op("GetUploadsByIDs"),
+		getVisibleUploadsMatchingMonikers:    op("GetVisibleUploadsMatchingMonikers"),
+		updateUploadsVisibleToCommits:        op("UpdateUploadsVisibleToCommits"),
+		updateUploadRetention:                op("UpdateUploadRetention"),
+		updateCommittedAt:                    op("UpdateCommittedAt"),
+		sourcedCommitsWithoutCommittedAt:     op("SourcedCommitsWithoutCommittedAt"),
+		deleteUploadsStuckUploading:          op("DeleteUploadsStuckUploading"),
+		softDeleteExpiredUploadsViaTraversal: op("SoftDeleteExpiredUploadsViaTraversal"),
+		deleteUploadsWithoutRepository:       op("DeleteUploadsWithoutRepository"),
+		softDeleteExpiredUploads:             op("SoftDeleteExpiredUploads"),
+		hardDeleteUploadsByIDs:               op("HardDeleteUploadsByIDs"),
+		deleteUploadByID:                     op("DeleteUploadByID"),
+		insertUpload:                         op("InsertUpload"),
+		addUploadPart:                        op("AddUploadPart"),
+		markQueued:                           op("MarkQueued"),
+		markFailed:                           op("MarkFailed"),
+		deleteUploads:                        op("DeleteUploads"),
 
 		writeVisibleUploads:        op("writeVisibleUploads"),
 		persistNearestUploads:      op("persistNearestUploads"),

--- a/internal/codeintel/uploads/internal/store/store.go
+++ b/internal/codeintel/uploads/internal/store/store.go
@@ -55,6 +55,7 @@ type Store interface {
 	SourcedCommitsWithoutCommittedAt(ctx context.Context, batchSize int) ([]shared.SourcedCommits, error)
 	UpdateCommittedAt(ctx context.Context, repositoryID int, commit, commitDateString string) error
 	SoftDeleteExpiredUploads(ctx context.Context, batchSize int) (int, error)
+	SoftDeleteExpiredUploadsViaTraversal(ctx context.Context, maxTraversal int) (int, error)
 	HardDeleteUploadsByIDs(ctx context.Context, ids ...int) error
 	DeleteUploadsStuckUploading(ctx context.Context, uploadedBefore time.Time) (_ int, err error)
 	DeleteUploadsWithoutRepository(ctx context.Context, now time.Time) (_ map[int]int, err error)

--- a/internal/codeintel/uploads/internal/store/store_uploads_test.go
+++ b/internal/codeintel/uploads/internal/store/store_uploads_test.go
@@ -839,6 +839,184 @@ func TestSoftDeleteExpiredUploads(t *testing.T) {
 	}
 }
 
+func TestSoftDeleteExpiredUploadsViaTraversal(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	store := New(db, &observation.TestContext)
+
+	// The packages in this test reference each other in the following way:
+	//
+	//     [p1] ---> [p2] -> [p3]    [p8]
+	//      ^         ^       |       ^
+	//      |         |       |       |
+	//      +----+----+       |       |
+	//           |            v       v
+	// [p6] --> [p5] <------ [p4]    [p9]
+	//  ^
+	//  |
+	//  v
+	// [p7]
+	//
+	// Note that all packages except for p6 are attached to an expired upload,
+	// and each upload is _reachable_ from a non-expired upload.
+
+	insertUploads(t, db,
+		types.Upload{ID: 100, RepositoryID: 50, State: "completed"}, // Referenced by 104
+		types.Upload{ID: 101, RepositoryID: 51, State: "completed"}, // Referenced by 100, 104
+		types.Upload{ID: 102, RepositoryID: 52, State: "completed"}, // Referenced by 101
+		types.Upload{ID: 103, RepositoryID: 53, State: "completed"}, // Referenced by 102
+		types.Upload{ID: 104, RepositoryID: 54, State: "completed"}, // Referenced by 103, 105
+		types.Upload{ID: 105, RepositoryID: 55, State: "completed"}, // Referenced by 106
+		types.Upload{ID: 106, RepositoryID: 56, State: "completed"}, // Referenced by 105
+
+		// Another component
+		types.Upload{ID: 107, RepositoryID: 57, State: "completed"}, // Referenced by 108
+		types.Upload{ID: 108, RepositoryID: 58, State: "completed"}, // Referenced by 107
+	)
+	insertPackages(t, store, []shared.Package{
+		{DumpID: 100, Scheme: "test", Name: "p1", Version: "1.2.3"},
+		{DumpID: 101, Scheme: "test", Name: "p2", Version: "1.2.3"},
+		{DumpID: 102, Scheme: "test", Name: "p3", Version: "1.2.3"},
+		{DumpID: 103, Scheme: "test", Name: "p4", Version: "1.2.3"},
+		{DumpID: 104, Scheme: "test", Name: "p5", Version: "1.2.3"},
+		{DumpID: 105, Scheme: "test", Name: "p6", Version: "1.2.3"},
+		{DumpID: 106, Scheme: "test", Name: "p7", Version: "1.2.3"},
+
+		// Another component
+		{DumpID: 107, Scheme: "test", Name: "p8", Version: "1.2.3"},
+		{DumpID: 108, Scheme: "test", Name: "p9", Version: "1.2.3"},
+	})
+	insertPackageReferences(t, store, []shared.PackageReference{
+		{Package: shared.Package{DumpID: 100, Scheme: "test", Name: "p2", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 101, Scheme: "test", Name: "p3", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 102, Scheme: "test", Name: "p4", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 103, Scheme: "test", Name: "p5", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 104, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 104, Scheme: "test", Name: "p2", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 105, Scheme: "test", Name: "p5", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 106, Scheme: "test", Name: "p6", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 105, Scheme: "test", Name: "p7", Version: "1.2.3"}},
+
+		// Another component
+		{Package: shared.Package{DumpID: 107, Scheme: "test", Name: "p9", Version: "1.2.3"}},
+		{Package: shared.Package{DumpID: 108, Scheme: "test", Name: "p8", Version: "1.2.3"}},
+	})
+
+	// We'll first confirm that none of the uploads can be deleted by either of the soft delete mechanisms;
+	// once we expire the upload providing p6, the "unreferenced" method should no-op, but the traversal
+	// method should soft delete all fo them.
+
+	// expire all uploads except 105 and 109
+	if err := store.UpdateUploadRetention(context.Background(), []int{}, []int{100, 101, 102, 103, 104, 106, 107}); err != nil {
+		t.Fatalf("unexpected error marking uploads as expired: %s", err)
+	}
+	if count, err := store.SoftDeleteExpiredUploads(context.Background(), 100); err != nil {
+		t.Fatalf("unexpected error soft deleting uploads: %s", err)
+	} else if count != 0 {
+		t.Fatalf("unexpected number of uploads deleted via refcount: want=%d have=%d", 0, count)
+	}
+	for i := 0; i < 9; i++ {
+		// Initially null last_traversal_scan_at values; run once for each upload (overkill)
+		if count, err := store.SoftDeleteExpiredUploadsViaTraversal(context.Background(), 100); err != nil {
+			t.Fatalf("unexpected error soft deleting uploads: %s", err)
+		} else if count != 0 {
+			t.Fatalf("unexpected number of uploads deleted via traversal: want=%d have=%d", 0, count)
+		}
+	}
+	if count, err := store.SoftDeleteExpiredUploadsViaTraversal(context.Background(), 100); err != nil {
+		t.Fatalf("unexpected error soft deleting uploads: %s", err)
+	} else if count != 0 {
+		t.Fatalf("unexpected number of uploads deleted via traversal: want=%d have=%d", 0, count)
+	}
+
+	// Expire upload 105, making the connected component soft-deletable
+	if err := store.UpdateUploadRetention(context.Background(), []int{}, []int{105}); err != nil {
+		t.Fatalf("unexpected error marking uploads as expired: %s", err)
+	}
+	// Reset timestamps so the test is deterministics
+	if _, err := db.ExecContext(context.Background(), "UPDATE lsif_uploads SET last_traversal_scan_at = NULL"); err != nil {
+		t.Fatalf("unexpected error clearing last_traversal_scan_at: %s", err)
+	}
+	if count, err := store.SoftDeleteExpiredUploads(context.Background(), 100); err != nil {
+		t.Fatalf("unexpected error soft deleting uploads: %s", err)
+	} else if count != 0 {
+		t.Fatalf("unexpected number of uploads deleted via refcount: want=%d have=%d", 0, count)
+	}
+	// First connected component (rooted with upload 100)
+	if count, err := store.SoftDeleteExpiredUploadsViaTraversal(context.Background(), 100); err != nil {
+		t.Fatalf("unexpected error soft deleting uploads: %s", err)
+	} else if count != 7 {
+		t.Fatalf("unexpected number of uploads deleted via traversal: want=%d have=%d", 7, count)
+	}
+	// Second connected component (rooted with upload 107)
+	if count, err := store.SoftDeleteExpiredUploadsViaTraversal(context.Background(), 100); err != nil {
+		t.Fatalf("unexpected error soft deleting uploads: %s", err)
+	} else if count != 0 {
+		t.Fatalf("unexpected number of uploads deleted via traversal: want=%d have=%d", 0, count)
+	}
+
+	// Ensure records were deleted
+	expectedStates := map[int]string{
+		100: "deleting",
+		101: "deleting",
+		102: "deleting",
+		103: "deleting",
+		104: "deleting",
+		105: "deleting",
+		106: "deleting",
+		107: "completed",
+		108: "completed",
+	}
+	if states, err := getUploadStates(db, 100, 101, 102, 103, 104, 105, 106, 107, 108); err != nil {
+		t.Fatalf("unexpected error getting states: %s", err)
+	} else if diff := cmp.Diff(expectedStates, states); diff != "" {
+		t.Errorf("unexpected upload states (-want +got):\n%s", diff)
+	}
+
+	// Ensure repository was marked as dirty
+	repositoryIDs, err := store.GetDirtyRepositories(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error listing dirty repositories: %s", err)
+	}
+
+	var keys []int
+	for repositoryID := range repositoryIDs {
+		keys = append(keys, repositoryID)
+	}
+	sort.Ints(keys)
+
+	expectedKeys := []int{50, 51, 52, 53, 54, 55, 56}
+	if diff := cmp.Diff(expectedKeys, keys); diff != "" {
+		t.Errorf("unexpected dirty repositories (-want +got):\n%s", diff)
+	}
+
+	// expire uploads 107-108, making the second connected component soft-deletable
+	if err := store.UpdateUploadRetention(context.Background(), []int{}, []int{107, 108}); err != nil {
+		t.Fatalf("unexpected error marking uploads as expired: %s", err)
+	}
+	if count, err := store.SoftDeleteExpiredUploads(context.Background(), 100); err != nil {
+		t.Fatalf("unexpected error soft deleting uploads: %s", err)
+	} else if count != 0 {
+		t.Fatalf("unexpected number of uploads deleted via refcount: want=%d have=%d", 0, count)
+	}
+	if count, err := store.SoftDeleteExpiredUploadsViaTraversal(context.Background(), 100); err != nil {
+		t.Fatalf("unexpected error soft deleting uploads: %s", err)
+	} else if count != 2 {
+		t.Fatalf("unexpected number of uploads deleted via traversal: want=%d have=%d", 2, count)
+	}
+
+	// Ensure new records were deleted
+	expectedStates = map[int]string{
+		107: "deleting",
+		108: "deleting",
+	}
+	if states, err := getUploadStates(db, 107, 108); err != nil {
+		t.Fatalf("unexpected error getting states: %s", err)
+	} else if diff := cmp.Diff(expectedStates, states); diff != "" {
+		t.Errorf("unexpected upload states (-want +got):\n%s", diff)
+	}
+}
+
 func TestDeleteUploadByID(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))

--- a/internal/codeintel/uploads/mocks_test.go
+++ b/internal/codeintel/uploads/mocks_test.go
@@ -174,6 +174,10 @@ type MockStore struct {
 	// SoftDeleteExpiredUploadsFunc is an instance of a mock function object
 	// controlling the behavior of the method SoftDeleteExpiredUploads.
 	SoftDeleteExpiredUploadsFunc *StoreSoftDeleteExpiredUploadsFunc
+	// SoftDeleteExpiredUploadsViaTraversalFunc is an instance of a mock
+	// function object controlling the behavior of the method
+	// SoftDeleteExpiredUploadsViaTraversal.
+	SoftDeleteExpiredUploadsViaTraversalFunc *StoreSoftDeleteExpiredUploadsViaTraversalFunc
 	// SourcedCommitsWithoutCommittedAtFunc is an instance of a mock
 	// function object controlling the behavior of the method
 	// SourcedCommitsWithoutCommittedAt.
@@ -415,6 +419,11 @@ func NewMockStore() *MockStore {
 			},
 		},
 		SoftDeleteExpiredUploadsFunc: &StoreSoftDeleteExpiredUploadsFunc{
+			defaultHook: func(context.Context, int) (r0 int, r1 error) {
+				return
+			},
+		},
+		SoftDeleteExpiredUploadsViaTraversalFunc: &StoreSoftDeleteExpiredUploadsViaTraversalFunc{
 			defaultHook: func(context.Context, int) (r0 int, r1 error) {
 				return
 			},
@@ -681,6 +690,11 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.SoftDeleteExpiredUploads")
 			},
 		},
+		SoftDeleteExpiredUploadsViaTraversalFunc: &StoreSoftDeleteExpiredUploadsViaTraversalFunc{
+			defaultHook: func(context.Context, int) (int, error) {
+				panic("unexpected invocation of MockStore.SoftDeleteExpiredUploadsViaTraversal")
+			},
+		},
 		SourcedCommitsWithoutCommittedAtFunc: &StoreSourcedCommitsWithoutCommittedAtFunc{
 			defaultHook: func(context.Context, int) ([]shared.SourcedCommits, error) {
 				panic("unexpected invocation of MockStore.SourcedCommitsWithoutCommittedAt")
@@ -858,6 +872,9 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		SoftDeleteExpiredUploadsFunc: &StoreSoftDeleteExpiredUploadsFunc{
 			defaultHook: i.SoftDeleteExpiredUploads,
+		},
+		SoftDeleteExpiredUploadsViaTraversalFunc: &StoreSoftDeleteExpiredUploadsViaTraversalFunc{
+			defaultHook: i.SoftDeleteExpiredUploadsViaTraversal,
 		},
 		SourcedCommitsWithoutCommittedAtFunc: &StoreSourcedCommitsWithoutCommittedAtFunc{
 			defaultHook: i.SourcedCommitsWithoutCommittedAt,
@@ -5606,6 +5623,119 @@ func (c StoreSoftDeleteExpiredUploadsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreSoftDeleteExpiredUploadsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StoreSoftDeleteExpiredUploadsViaTraversalFunc describes the behavior when
+// the SoftDeleteExpiredUploadsViaTraversal method of the parent MockStore
+// instance is invoked.
+type StoreSoftDeleteExpiredUploadsViaTraversalFunc struct {
+	defaultHook func(context.Context, int) (int, error)
+	hooks       []func(context.Context, int) (int, error)
+	history     []StoreSoftDeleteExpiredUploadsViaTraversalFuncCall
+	mutex       sync.Mutex
+}
+
+// SoftDeleteExpiredUploadsViaTraversal delegates to the next hook function
+// in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockStore) SoftDeleteExpiredUploadsViaTraversal(v0 context.Context, v1 int) (int, error) {
+	r0, r1 := m.SoftDeleteExpiredUploadsViaTraversalFunc.nextHook()(v0, v1)
+	m.SoftDeleteExpiredUploadsViaTraversalFunc.appendCall(StoreSoftDeleteExpiredUploadsViaTraversalFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// SoftDeleteExpiredUploadsViaTraversal method of the parent MockStore
+// instance is invoked and the hook queue is empty.
+func (f *StoreSoftDeleteExpiredUploadsViaTraversalFunc) SetDefaultHook(hook func(context.Context, int) (int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// SoftDeleteExpiredUploadsViaTraversal method of the parent MockStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *StoreSoftDeleteExpiredUploadsViaTraversalFunc) PushHook(hook func(context.Context, int) (int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreSoftDeleteExpiredUploadsViaTraversalFunc) SetDefaultReturn(r0 int, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (int, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreSoftDeleteExpiredUploadsViaTraversalFunc) PushReturn(r0 int, r1 error) {
+	f.PushHook(func(context.Context, int) (int, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreSoftDeleteExpiredUploadsViaTraversalFunc) nextHook() func(context.Context, int) (int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreSoftDeleteExpiredUploadsViaTraversalFunc) appendCall(r0 StoreSoftDeleteExpiredUploadsViaTraversalFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// StoreSoftDeleteExpiredUploadsViaTraversalFuncCall objects describing the
+// invocations of this function.
+func (f *StoreSoftDeleteExpiredUploadsViaTraversalFunc) History() []StoreSoftDeleteExpiredUploadsViaTraversalFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreSoftDeleteExpiredUploadsViaTraversalFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreSoftDeleteExpiredUploadsViaTraversalFuncCall is an object that
+// describes an invocation of method SoftDeleteExpiredUploadsViaTraversal on
+// an instance of MockStore.
+type StoreSoftDeleteExpiredUploadsViaTraversalFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreSoftDeleteExpiredUploadsViaTraversalFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreSoftDeleteExpiredUploadsViaTraversalFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/codeintel/uploads/observability.go
+++ b/internal/codeintel/uploads/observability.go
@@ -25,19 +25,20 @@ type operations struct {
 	getRepositoriesMaxStaleAge              *observation.Operation
 
 	// Uploads
-	getUploads                        *observation.Operation
-	getUploadByID                     *observation.Operation
-	getUploadsByIDs                   *observation.Operation
-	getVisibleUploadsMatchingMonikers *observation.Operation
-	getUploadDocumentsForPath         *observation.Operation
-	updateUploadsVisibleToCommits     *observation.Operation
-	deleteUploadByID                  *observation.Operation
-	inferClosestUploads               *observation.Operation
-	deleteUploadsWithoutRepository    *observation.Operation
-	deleteUploadsStuckUploading       *observation.Operation
-	softDeleteExpiredUploads          *observation.Operation
-	hardDeleteUploadsByIDs            *observation.Operation
-	deleteLsifDataByUploadIds         *observation.Operation
+	getUploads                           *observation.Operation
+	getUploadByID                        *observation.Operation
+	getUploadsByIDs                      *observation.Operation
+	getVisibleUploadsMatchingMonikers    *observation.Operation
+	getUploadDocumentsForPath            *observation.Operation
+	updateUploadsVisibleToCommits        *observation.Operation
+	deleteUploadByID                     *observation.Operation
+	inferClosestUploads                  *observation.Operation
+	deleteUploadsWithoutRepository       *observation.Operation
+	deleteUploadsStuckUploading          *observation.Operation
+	softDeleteExpiredUploads             *observation.Operation
+	softDeleteExpiredUploadsViaTraversal *observation.Operation
+	hardDeleteUploadsByIDs               *observation.Operation
+	deleteLsifDataByUploadIds            *observation.Operation
 
 	// Dumps
 	getDumpsWithDefinitionsForMonikers *observation.Operation
@@ -88,19 +89,20 @@ func newOperations(observationContext *observation.Context) *operations {
 		getRepositoriesMaxStaleAge:              op("GetRepositoriesMaxStaleAge"),
 
 		// Uploads
-		getUploads:                        op("GetUploads"),
-		getUploadByID:                     op("GetUploadByID"),
-		getUploadsByIDs:                   op("GetUploadsByIDs"),
-		getVisibleUploadsMatchingMonikers: op("GetVisibleUploadsMatchingMonikers"),
-		getUploadDocumentsForPath:         op("GetUploadDocumentsForPath"),
-		updateUploadsVisibleToCommits:     op("UpdateUploadsVisibleToCommits"),
-		deleteUploadByID:                  op("DeleteUploadByID"),
-		inferClosestUploads:               op("InferClosestUploads"),
-		deleteUploadsWithoutRepository:    op("DeleteUploadsWithoutRepository"),
-		deleteUploadsStuckUploading:       op("DeleteUploadsStuckUploading"),
-		softDeleteExpiredUploads:          op("SoftDeleteExpiredUploads"),
-		hardDeleteUploadsByIDs:            op("HardDeleteUploadsByIDs"),
-		deleteLsifDataByUploadIds:         op("DeleteLsifDataByUploadIds"),
+		getUploads:                           op("GetUploads"),
+		getUploadByID:                        op("GetUploadByID"),
+		getUploadsByIDs:                      op("GetUploadsByIDs"),
+		getVisibleUploadsMatchingMonikers:    op("GetVisibleUploadsMatchingMonikers"),
+		getUploadDocumentsForPath:            op("GetUploadDocumentsForPath"),
+		updateUploadsVisibleToCommits:        op("UpdateUploadsVisibleToCommits"),
+		deleteUploadByID:                     op("DeleteUploadByID"),
+		inferClosestUploads:                  op("InferClosestUploads"),
+		deleteUploadsWithoutRepository:       op("DeleteUploadsWithoutRepository"),
+		deleteUploadsStuckUploading:          op("DeleteUploadsStuckUploading"),
+		softDeleteExpiredUploads:             op("SoftDeleteExpiredUploads"),
+		softDeleteExpiredUploadsViaTraversal: op("SoftDeleteExpiredUploadsViaTraversal"),
+		hardDeleteUploadsByIDs:               op("HardDeleteUploadsByIDs"),
+		deleteLsifDataByUploadIds:            op("DeleteLsifDataByUploadIds"),
 
 		// Dumps
 		getDumpsWithDefinitionsForMonikers: op("GetDumpsWithDefinitionsForMonikers"),

--- a/internal/codeintel/uploads/service.go
+++ b/internal/codeintel/uploads/service.go
@@ -444,6 +444,13 @@ func (s *Service) SoftDeleteExpiredUploads(ctx context.Context, batchSize int) (
 	return s.store.SoftDeleteExpiredUploads(ctx, batchSize)
 }
 
+func (s *Service) SoftDeleteExpiredUploadsViaTraversal(ctx context.Context, maxTraversal int) (int, error) {
+	ctx, _, endObservation := s.operations.softDeleteExpiredUploadsViaTraversal.With(ctx, nil, observation.Args{})
+	defer endObservation(1, observation.Args{})
+
+	return s.store.SoftDeleteExpiredUploadsViaTraversal(ctx, maxTraversal)
+}
+
 // BackfillCommittedAtBatch calculates the committed_at value for a batch of upload records that do not have
 // this value set. This method is used to backfill old upload records prior to this value being reliably set
 // during processing.

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -12998,6 +12998,19 @@
           "Comment": "The last time this upload was checked against data retention policies."
         },
         {
+          "Name": "last_traversal_scan_at",
+          "Index": 32,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "The last time this upload was known to be reachable by a non-expired index."
+        },
+        {
           "Name": "num_failures",
           "Index": 16,
           "TypeName": "integer",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1961,6 +1961,7 @@ Stores the retention policy of code intellience data for a repository.
  cancel                  | boolean                  |           | not null | false
  uncompressed_size       | bigint                   |           |          | 
  last_referenced_scan_at | timestamp with time zone |           |          | 
+ last_traversal_scan_at  | timestamp with time zone |           |          | 
 Indexes:
     "lsif_uploads_pkey" PRIMARY KEY, btree (id)
     "lsif_uploads_repository_id_commit_root_indexer" UNIQUE, btree (repository_id, commit, root, indexer) WHERE state = 'completed'::text
@@ -2000,6 +2001,8 @@ Stores metadata about an LSIF index uploaded by a user.
 **last_referenced_scan_at**: The last time this upload was known to be referenced by another (possibly expired) index.
 
 **last_retention_scan_at**: The last time this upload was checked against data retention policies.
+
+**last_traversal_scan_at**: The last time this upload was known to be reachable by a non-expired index.
 
 **num_parts**: The number of parts src-cli split the upload file into.
 

--- a/migrations/frontend/1666131819_add_lsif_upload_traversal_scan_timestamp/down.sql
+++ b/migrations/frontend/1666131819_add_lsif_upload_traversal_scan_timestamp/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+    lsif_uploads DROP COLUMN IF EXISTS last_traversal_scan_at;

--- a/migrations/frontend/1666131819_add_lsif_upload_traversal_scan_timestamp/metadata.yaml
+++ b/migrations/frontend/1666131819_add_lsif_upload_traversal_scan_timestamp/metadata.yaml
@@ -1,0 +1,2 @@
+name: Add lsif_upload traversal scan timestamp
+parents: [1665646849, 1665770699, 1666034720]

--- a/migrations/frontend/1666131819_add_lsif_upload_traversal_scan_timestamp/up.sql
+++ b/migrations/frontend/1666131819_add_lsif_upload_traversal_scan_timestamp/up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE
+    lsif_uploads
+ADD
+    COLUMN IF NOT EXISTS last_traversal_scan_at timestamp with time zone;
+
+COMMENT ON COLUMN lsif_uploads.last_traversal_scan_at IS 'The last time this upload was known to be reachable by a non-expired index.';

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -2374,6 +2374,7 @@ CREATE TABLE lsif_uploads (
     cancel boolean DEFAULT false NOT NULL,
     uncompressed_size bigint,
     last_referenced_scan_at timestamp with time zone,
+    last_traversal_scan_at timestamp with time zone,
     CONSTRAINT lsif_uploads_commit_valid_chars CHECK ((commit ~ '^[a-z0-9]{40}$'::text))
 );
 
@@ -2404,6 +2405,8 @@ COMMENT ON COLUMN lsif_uploads.reference_count IS 'The number of references to t
 COMMENT ON COLUMN lsif_uploads.indexer_version IS 'The version of the indexer that produced the index file. If not supplied by the user it will be pulled from the index metadata.';
 
 COMMENT ON COLUMN lsif_uploads.last_referenced_scan_at IS 'The last time this upload was known to be referenced by another (possibly expired) index.';
+
+COMMENT ON COLUMN lsif_uploads.last_traversal_scan_at IS 'The last time this upload was known to be reachable by a non-expired index.';
 
 CREATE VIEW lsif_dumps AS
  SELECT u.id,


### PR DESCRIPTION
Building off of #43015. This PR adds a new method that will do another type of data retention scan over `lsif_uploads`. The scan we updated in the linked PR only expires uploads with zero references. This PR will also expire uploads that are referenced transitively only via other expired uploads (including cycles, but not necessarily cyclic dependency graphs).

## Test plan

Updated unit tests. As with #43015, I validated on a reproduction of sourcegraph.com's scale.