### PR TITLE
search: add search mode param in client

### DIFF
--- a/client/search/src/searchQueryState.tsx
+++ b/client/search/src/searchQueryState.tsx
@@ -51,6 +51,11 @@ export enum InitialParametersSource {
     URL,
 }
 
+export enum SearchMode {
+    Precise = 0,
+    SmartSearch = 1 << 0,
+}
+
 // Implemented in /web as navbar query state, /vscode as webview query state.
 export interface SearchQueryState {
     /**
@@ -73,6 +78,7 @@ export interface SearchQueryState {
     searchCaseSensitivity: boolean
     searchPatternType: SearchPatternType
     searchQueryFromURL: string
+    searchMode: SearchMode
 
     // ACTIONS
     /**

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -5,6 +5,7 @@ import { defaultIfEmpty, map, materialize, scan, switchMap } from 'rxjs/operator
 import { AggregableBadge } from 'sourcegraph'
 
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/common'
+import { SearchMode } from '@sourcegraph/search'
 
 import { SearchPatternType } from '../graphql-operations'
 import { SymbolKind } from '../schema'
@@ -434,6 +435,7 @@ export interface StreamSearchOptions {
     patternType: SearchPatternType
     caseSensitive: boolean
     trace: string | undefined
+    searchMode?: SearchMode
     sourcegraphURL?: string
     decorationKinds?: string[]
     decorationContextLines?: number
@@ -450,6 +452,7 @@ function initiateSearchStream(
         trace,
         decorationKinds,
         decorationContextLines,
+        searchMode = SearchMode.Precise,
         displayLimit = 1500,
         sourcegraphURL = '',
         chunkMatches = false,
@@ -463,6 +466,7 @@ function initiateSearchStream(
             ['q', `${query} ${caseSensitive ? 'case:yes' : ''}`],
             ['v', version],
             ['t', patternType as string],
+            ['sm', searchMode.toString()],
             ['dl', '0'],
             ['dk', (decorationKinds || ['html']).join('|')],
             ['dc', (decorationContextLines || '1').toString()],

--- a/client/vscode/src/webview/sidebars/search/SearchSidebarView.tsx
+++ b/client/vscode/src/webview/sidebars/search/SearchSidebarView.tsx
@@ -9,6 +9,7 @@ import create from 'zustand'
 import {
     InitialParametersSource,
     QueryUpdate,
+    SearchMode,
     SearchPatternType,
     SearchQueryState,
     SearchQueryStateStore,
@@ -54,6 +55,7 @@ export const SearchSidebarView: React.FunctionComponent<React.PropsWithChildren<
                     searchCaseSensitivity: false,
                     searchPatternType: SearchPatternType.standard,
                     searchQueryFromURL: '',
+                    searchMode: SearchMode.Precise,
 
                     setQueryState: queryStateUpdate => {
                         const currentSearchQueryState = get()

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -8,7 +8,7 @@ import { CompatRouter } from 'react-router-dom-v5-compat'
 import { EMPTY, NEVER, of } from 'rxjs'
 import sinon from 'sinon'
 
-import { SearchQueryStateStoreProvider } from '@sourcegraph/search'
+import { SearchMode, SearchQueryStateStoreProvider } from '@sourcegraph/search'
 import { GitRefType, SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { AggregateStreamingSearchResults, Skipped } from '@sourcegraph/shared/src/search/stream'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -117,6 +117,7 @@ describe('StreamingSearchResults', () => {
             version: 'V3',
             patternType: SearchPatternType.regexp,
             caseSensitive: true,
+            searchMode: SearchMode.Precise,
             trace: undefined,
             chunkMatches: true,
         })

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -6,7 +6,7 @@ import { useHistory } from 'react-router'
 import { Observable } from 'rxjs'
 
 import { asError } from '@sourcegraph/common'
-import { QueryUpdate, SearchContextProps } from '@sourcegraph/search'
+import { QueryUpdate, SearchContextProps, SearchMode } from '@sourcegraph/search'
 import { FetchFileParameters, StreamingProgress, StreamingSearchResultsList } from '@sourcegraph/search-ui'
 import { ActivationProps } from '@sourcegraph/shared/src/components/activation/Activation'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
@@ -106,6 +106,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
             patternType: patternType ?? SearchPatternType.standard,
             caseSensitive,
             trace,
+            searchMode: patternType === SearchPatternType.lucky ? SearchMode.SmartSearch : SearchMode.Precise,
             chunkMatches: true,
         }),
         [caseSensitive, patternType, trace]

--- a/client/web/src/stores/navbarSearchQueryState.ts
+++ b/client/web/src/stores/navbarSearchQueryState.ts
@@ -12,6 +12,7 @@ import {
     updateQuery,
     InitialParametersSource,
     SearchPatternType,
+    SearchMode,
 } from '@sourcegraph/search'
 import { Settings, SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
@@ -27,6 +28,7 @@ export const useNavbarQueryState = create<NavbarQueryState>((set, get) => ({
     queryState: { query: '' },
     searchCaseSensitivity: false,
     searchPatternType: SearchPatternType.standard,
+    searchMode: SearchMode.Precise,
     searchQueryFromURL: '',
 
     setQueryState: queryStateUpdate => {


### PR DESCRIPTION
This adds a `SearchMode` type corresponding to the URL parameter `sm`, processed by the backend to decide which search mode to run. Currently there is `Precise` and `SmartSearch`. 

The client is not yet updated to put this in the navbar state, which will happen next. Once that's done we can remove the `lucky` search pattern type and not rely on it to trigger smart search. As an intermediate step, we currently just convert `patterntype:lucky` state to -> the URL param `sm=1` on the search streaming endpoint (which the backend knows to process as smart search).

## Test plan
Updated unit test to cover the 

## App preview:

- [Web](https://sg-web-rvt-smart-search-client-param.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-qxmhanssem.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

