### PR TITLE
Fix accessibility for QueryExamplesHomepage

### DIFF
--- a/client/web/src/search/home/QueryExamplesHomepage.module.scss
+++ b/client/web/src/search/home/QueryExamplesHomepage.module.scss
@@ -35,6 +35,8 @@
 .query-examples-section-title {
     margin-bottom: 0.75rem;
     color: var(--text-muted);
+    font-size: var(--font-size-base);
+    font-weight: 400;
 }
 
 .query-examples-sections-columns {

--- a/client/web/src/search/home/QueryExamplesHomepage.tsx
+++ b/client/web/src/search/home/QueryExamplesHomepage.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 import { EditorHint, QueryState, SearchPatternType } from '@sourcegraph/search'
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button } from '@sourcegraph/wildcard'
+import { Button, H2 } from '@sourcegraph/wildcard'
 
 import { useQueryExamples } from './useQueryExamples'
 
@@ -142,8 +142,8 @@ export const QueryExamplesSection: React.FunctionComponent<QueryExamplesSection>
     onQueryExampleClick,
 }) => (
     <div className={styles.queryExamplesSection}>
-        <div className={styles.queryExamplesSectionTitle}>{title}</div>
-        <div className={styles.queryExamplesItems}>
+        <H2 className={styles.queryExamplesSectionTitle}>{title}</H2>
+        <ul className={classNames('list-unstyled', styles.queryExamplesItems)}>
             {queryExamples
                 .filter(({ query }) => query.length > 0)
                 .map(({ id, query, helperText }) => (
@@ -155,7 +155,7 @@ export const QueryExamplesSection: React.FunctionComponent<QueryExamplesSection>
                         onClick={onQueryExampleClick}
                     />
                 ))}
-        </div>
+        </ul>
         {footer}
     </div>
 )
@@ -178,7 +178,7 @@ export const QueryExampleChip: React.FunctionComponent<QueryExampleChipProps> = 
     className,
     onClick,
 }) => (
-    <span className={classNames('d-flex align-items-center', className)}>
+    <li className={classNames('d-flex align-items-center', className)}>
         <Button type="button" className={styles.queryExampleChip} onClick={() => onClick(id, query)}>
             <SyntaxHighlightedSearchQuery query={query} searchPatternType={SearchPatternType.standard} />
         </Button>
@@ -187,5 +187,5 @@ export const QueryExampleChip: React.FunctionComponent<QueryExampleChipProps> = 
                 <small>{helperText}</small>
             </span>
         )}
-    </span>
+    </li>
 )


### PR DESCRIPTION
Fixes #43141

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

* Query examples section titles should be H2
* Query examples list should be ul with li elements

## App preview:

- [Web](https://sg-web-rn-fix-homepage-examples.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-itfaxhwxyc.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
