### PR TITLE
Don't throw fatal errors from symbols sidebar

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarSymbols.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarSymbols.tsx
@@ -145,13 +145,13 @@ export const RepoRevisionSidebarSymbols: React.FunctionComponent<
             const { node } = dataOrThrowErrors(result)
 
             if (!node) {
-                throw new Error(`Node ${repoID} not found`)
+                return { nodes: [] }
             }
             if (node.__typename !== 'Repository') {
-                throw new Error(`Node is a ${node.__typename}, not a Repository`)
+                return { nodes: [] }
             }
             if (!node.commit?.symbols?.nodes) {
-                throw new Error('Could not resolve commit symbols for repository')
+                return { nodes: [] }
             }
 
             return node.commit.symbols


### PR DESCRIPTION
Error reported by a customer https://sourcegraph.slack.com/archives/C02UM8A9M2R/p1666120081734099

The symbols sidebar should never throw fatal errors that crash the entire website.


## Test plan

N/A. We don't have a reliable reproduction.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-no-symbols.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-rlarsqspfv.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
