### PR TITLE
sg-setup: do application-default login for glcoud

### DIFF
--- a/dev/sg/dependencies/shared.go
+++ b/dev/sg/dependencies/shared.go
@@ -286,8 +286,10 @@ func dependencyGcloud() *dependency {
 		Check: checkAction(
 			check.Combine(
 				check.InPath("gcloud"),
+				check.FileExists("~/.config/gcloud/application_default_credentials.json"),
 				// User should have logged in with a sourcegraph.com account
-				check.CommandOutputContains("gcloud auth list", "@sourcegraph.com")),
+				check.CommandOutputContains("gcloud auth list", "@sourcegraph.com"),
+			),
 		),
 		Fix: func(ctx context.Context, cio check.IO, args CheckArgs) error {
 			if cio.Input == nil {

--- a/dev/sg/dependencies/shared.go
+++ b/dev/sg/dependencies/shared.go
@@ -341,7 +341,7 @@ func dependencyGcloud() *dependency {
 				}
 			}
 
-			if err := usershell.Command(ctx, "gcloud auth login").Input(cio.Input).Run().StreamLines(cio.Write); err != nil {
+			if err := usershell.Command(ctx, "gcloud auth application-default login").Input(cio.Input).Run().StreamLines(cio.Write); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
Using `glcoud auth login` will log you in but won't set your default creds for gcloud. You can verify this by seeing if you have the file `~/.config/gcloud/application_default_credentials.json`. By doing `gcloud auth application-default login` not only will you be authenticated but your default creds will also be set.

## Test plan
1. Remove `~/.config/gcloud/application_default_credentials.json`
2. `sg setup -c` - cloud check should fail
3. `sg setup -f` - should auth with gcloud
4. `~/.config/gcloud/application_default_credentials.json` should exist
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
