### PR TITLE
conf: Use an internal actor when fetching config

### DIFF
--- a/internal/actor/http.go
+++ b/internal/actor/http.go
@@ -125,7 +125,6 @@ func HTTPMiddleware(logger log.Logger, next http.Handler) http.Handler {
 			if anonymousUID := req.Header.Get(headerKeyActorAnonymousUID); anonymousUID != "" {
 				ctx = WithActor(ctx, FromAnonymousUser(anonymousUID))
 			}
-			logger.Error("No actor", log.String("path", req.URL.Path))
 			metricIncomingActors.WithLabelValues(metricActorTypeNone, path).Inc()
 
 		// Request associated with authenticated user - add user actor to context

--- a/internal/actor/http.go
+++ b/internal/actor/http.go
@@ -125,6 +125,7 @@ func HTTPMiddleware(logger log.Logger, next http.Handler) http.Handler {
 			if anonymousUID := req.Header.Get(headerKeyActorAnonymousUID); anonymousUID != "" {
 				ctx = WithActor(ctx, FromAnonymousUser(anonymousUID))
 			}
+			logger.Error("No actor", log.String("path", req.URL.Path))
 			metricIncomingActors.WithLabelValues(metricActorTypeNone, path).Inc()
 
 		// Request associated with authenticated user - add user actor to context

--- a/internal/conf/client.go
+++ b/internal/conf/client.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api/internalapi"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -305,7 +306,8 @@ func (c *client) continuouslyUpdate(optOnlySetByTests *continuousUpdateOptions) 
 
 func (c *client) fetchAndUpdate(logger log.Logger) error {
 	var (
-		ctx       = context.Background()
+		// We may make a cross service call here, so we need to add an internal actor.
+		ctx       = actor.WithInternalActor(context.Background())
 		newConfig conftypes.RawUnified
 		err       error
 	)


### PR DESCRIPTION
We may make a cross service call here, in which case we should be using
an internal actor.

Part of https://github.com/sourcegraph/sourcegraph/issues/28532

## Test plan

Tested locally