### PR TITLE
search input: Reduce "flicker" of query suggestions

### DIFF
--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -304,6 +304,7 @@ export function createDefaultSuggestionSources(
                 return {
                     from,
                     options: FILTER_SUGGESTIONS,
+                    validFor: /^-?[a-z]+$/i,
                 }
             }),
             // Show static filter value suggestions
@@ -353,6 +354,11 @@ export function createDefaultSuggestionSources(
                                 boost: index * -1,
                             }
                         }),
+                    // validFor should not be set when the filter has dynamic
+                    // suggestions, otherwise static suggestions won't be
+                    // removed from the list (because we also disable
+                    // filtering above)
+                    validFor: hasDynamicSuggestions ? undefined : /^[a-z.():]+$/i,
                 }
             }),
 

--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -358,7 +358,7 @@ export function createDefaultSuggestionSources(
                     // suggestions, otherwise static suggestions won't be
                     // removed from the list (because we also disable
                     // filtering above)
-                    validFor: hasDynamicSuggestions ? undefined : /^[a-z.():]+$/i,
+                    validFor: hasDynamicSuggestions ? undefined : /^[().:a-z]+$/i,
                 }
             }),
 

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -168,8 +168,8 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                         structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch === 'disabled'}
                         applySuggestionsOnEnter={applySuggestionsOnEnter}
                         suggestionSources={suggestionSources}
-                        defaultSuggestionsShowWhenEmpty={false}
-                        showSuggestionsOnFocus={true}
+                        defaultSuggestionsShowWhenEmpty={!showSearchHistory}
+                        showSuggestionsOnFocus={showSearchHistory}
                     />
                 </div>
                 <Notices className="my-3" location="home" settingsCascade={props.settingsCascade} />


### PR DESCRIPTION
Addresses https://github.com/sourcegraph/sourcegraph/issues/40072

This commit makes use of CodeMirror's `validFor` option to reduce the "flickering" of search suggestions. If set, then CodeMirror doesn't query the source anymore as long as the `{from, to}` range matches the provided regular expression.

I've only enabled this for filter names and filers with static values because it's not clear how filters with both static and dynamic values should work in this regard.


https://user-images.githubusercontent.com/179026/196680563-94227013-968d-414f-a0be-46857dfec3f0.mp4




## Test plan

Open search input and enter query.

## App preview:

- [Web](https://sg-web-fkling-search-suggestions.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-mzyehtulrt.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
