### PR TITLE
status message: fix bug that caused polling to be disabled by default

### DIFF
--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -154,8 +154,7 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
 
     const { data, error } = useQuery<StatusMessagesResult>(STATUS_MESSAGES, {
         fetchPolicy: 'no-cache',
-        pollInterval:
-            props.disablePolling !== undefined && !props.disablePolling ? STATUS_MESSAGES_POLL_INTERVAL : undefined,
+        pollInterval: props.disablePolling !== true ? STATUS_MESSAGES_POLL_INTERVAL : undefined,
     })
 
     const icon: JSX.Element | null = useMemo(() => {


### PR DESCRIPTION
That one's on me. Introduced in https://github.com/sourcegraph/sourcegraph/pull/41215.

## Test plan

Manual testing

## App preview:

- [Web](https://sg-web-mrn-fix-polling-disabled-by.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-exbxawihgg.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
