### PR TITLE
gitserver: add support to set stdin for exec endpoint

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1586,6 +1586,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 				ev.AddField("ensure_revision_status", ensureRevisionStatus)
 				ev.AddField("client", r.UserAgent())
 				ev.AddField("duration_ms", duration.Milliseconds())
+				ev.AddField("stdin_size", len(req.Stdin))
 				ev.AddField("stdout_size", stdoutN)
 				ev.AddField("stderr_size", stderrN)
 				ev.AddField("exit_status", exitStatus)
@@ -1708,6 +1709,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 	dir.Set(cmd)
 	cmd.Stdout = stdoutW
 	cmd.Stderr = stderrW
+	cmd.Stdin = bytes.NewReader(req.Stdin)
 
 	exitStatus, execErr = runCommand(ctx, cmd)
 

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -614,6 +614,7 @@ func (c *RemoteGitCommand) sendExec(ctx context.Context) (_ io.ReadCloser, _ htt
 		Repo:           repoName,
 		EnsureRevision: c.EnsureRevision(),
 		Args:           c.args[1:],
+		Stdin:          c.stdin,
 		NoTimeout:      c.noTimeout,
 	}
 	resp, err := c.execFn(ctx, repoName, "exec", req)

--- a/internal/gitserver/gitdomain/exec.go
+++ b/internal/gitserver/gitdomain/exec.go
@@ -38,6 +38,8 @@ var (
 		// Used in tests to simulate errors with runCommand in handleExec of gitserver.
 		"testcommand": {},
 		"testerror":   {},
+		"testecho":    {},
+		"testcat":     {},
 	}
 
 	// `git log`, `git show`, `git diff`, etc., share a large common set of allowed args.

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -96,6 +96,7 @@ type ExecRequest struct {
 
 	EnsureRevision string      `json:"ensureRevision"`
 	Args           []string    `json:"args"`
+	Stdin          []byte      `json:"stdin,omitempty"`
 	Opt            *RemoteOpts `json:"opt"`
 	NoTimeout      bool        `json:"noTimeout"`
 }


### PR DESCRIPTION
To interact with git-lfs we need to be able to send input to stdin. The
input is small and static (an lfs-pointer), so to support this we add a
field to the exec request.

Alternatively I started adding a dedicated serveGitLFS endpoint.
However, by making the client code construct the exec requests we get to
piggy back of much better testability and observability.

Test Plan: added tests

plz-review-url: https://plz.review/review/13315