### PR TITLE
Change integration team auto-tagging owners

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -14,7 +14,7 @@ jobs:
              edit_body: true
              message: /cc {recipients}
              recipients: |
-                  team/integrations=@muratsu @jjinnii @ryankscott
+                  team/integrations=@sourcegraph/integrations
                   team/growth=@sourcegraph/growth
                   team/cloud=@sourcegraph/cloud
                   team/search-product=@lguychard


### PR DESCRIPTION
Seems like this list needed updating 🙈 

Membership for this team can be configured like this now: https://github.com/orgs/sourcegraph/teams/integrations

## Test plan

Not needed, this is just a auto-tagging change

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
