### PR TITLE
insights: Fix backfill ping for large values

### DIFF
--- a/enterprise/internal/insights/background/pings/insights_ping_aggregators.go
+++ b/enterprise/internal/insights/background/pings/insights_ping_aggregators.go
@@ -290,9 +290,9 @@ const backfillTimeQuery = `
 SELECT
 	COALESCE(CARDINALITY(repositories),0) = 0 AS allRepos,
 	COUNT(*),
-	ROUND(EXTRACT(EPOCH FROM COALESCE(PERCENTILE_CONT(0.99) WITHIN GROUP( ORDER BY backfill_completed_at - backfill_queued_at), '0'))) AS p99_seconds,
-	ROUND(EXTRACT(EPOCH FROM COALESCE(PERCENTILE_CONT(0.90) WITHIN GROUP (ORDER BY backfill_completed_at - backfill_queued_at), '0'))) AS p90_seconds,
-	ROUND(EXTRACT(EPOCH FROM COALESCE(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY backfill_completed_at - backfill_queued_at), '0'))) AS p50_seconds
+	ROUND(EXTRACT(EPOCH FROM COALESCE(PERCENTILE_CONT(0.99) WITHIN GROUP( ORDER BY backfill_completed_at - backfill_queued_at), '0')))::INT AS p99_seconds,
+	ROUND(EXTRACT(EPOCH FROM COALESCE(PERCENTILE_CONT(0.90) WITHIN GROUP (ORDER BY backfill_completed_at - backfill_queued_at), '0')))::INT AS p90_seconds,
+	ROUND(EXTRACT(EPOCH FROM COALESCE(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY backfill_completed_at - backfill_queued_at), '0')))::INT AS p50_seconds
 FROM insight_series
 WHERE backfill_completed_at > ($1::timestamp - interval '7 days')
 GROUP BY allRepos;


### PR DESCRIPTION
## Description

For large enough values, a float format was being used and resulting in errors such as:
```
sql: Scan error on column index 2, name "p99_seconds": converting driver.Value type float64 ("1.3603816e+07") to a int: invalid syntax
```
Casting to an int seems to fix it.

## Test plan

Test with a series that took a month to backfill. Before this fix it shows an error and does not write the object to the `event_log` table. After the fix it should work.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
