### PR TITLE
zoekt: try downgrading to 022743fd1ac0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -223,7 +223,7 @@ require (
 )
 
 require (
-	github.com/sourcegraph/zoekt v0.0.0-20221017155433-cc0ca865f592
+	github.com/sourcegraph/zoekt v0.0.0-20221010111059-022743fd1ac0
 	github.com/stretchr/objx v0.4.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2113,8 +2113,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20221017155433-cc0ca865f592 h1:I72GZIoXHps72v8QPBr5G/p6XDF/agRTr7DpkNAy2RI=
-github.com/sourcegraph/zoekt v0.0.0-20221017155433-cc0ca865f592/go.mod h1:LoDKDF/OXurd7ByCxCmND2qbor4Js1/adKyFOnMFefQ=
+github.com/sourcegraph/zoekt v0.0.0-20221010111059-022743fd1ac0 h1:b1D0x0tJIeQktPqK4zvl/vvESsCyt8ALaljWd2skos8=
+github.com/sourcegraph/zoekt v0.0.0-20221010111059-022743fd1ac0/go.mod h1:LoDKDF/OXurd7ByCxCmND2qbor4Js1/adKyFOnMFefQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
We might have a regression in dogfood's performance according to https://sourcegraph.slack.com/archives/CHEKCRWKV/p1666192832997349.

This downgrades zoekt to https://github.com/sourcegraph/zoekt/commit/022743fd1ac07e5ee0fbeb88db7324b52944cce9. 

The following commits are reverted out:

https://github.com/sourcegraph/zoekt/commit/cc0ca86 (HEAD -> main, origin/main, origin/HEAD) mountinfo: introduce namespace config option (#447)
https://github.com/sourcegraph/zoekt/commit/4f7781e merging: delete tmp code that removed duplicates (#445)
https://github.com/sourcegraph/zoekt/commit/57c3159 mountinfo_test.go: add additional test case for lvm device (#443)
https://github.com/sourcegraph/zoekt/commit/e60e03b ranking: support offline ranking (#441)
https://github.com/sourcegraph/zoekt/commit/e091ee3 monitoring: add mount_point_info Prometheus metric (#434)

Personally, I'm not sure how any of these would have caused a regression. However, these were the only commits that were introduced during the last week (and I assumed that this issue would have been observed before then).


## Test plan

CI
