### PR TITLE
client previews: link to `/search` instead of `/`

### DIFF
--- a/dev/ci/render-pr-preview.sh
+++ b/dev/ci/render-pr-preview.sh
@@ -185,7 +185,7 @@ if [[ -n "${github_api_key}" && -n "${pr_number}" && "${pr_number}" != "false" ]
 
     pr_description=$(printf '%s\n\n' "${pr_description}" \
       "## App preview:" \
-      "- [Web](${pr_preview_url})" \
+      "- [Web](${pr_preview_url}/search)" \
       "Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more." |
       jq -Rs .)
 


### PR DESCRIPTION
Right now the root path on render.com previews doesn't redirect to `/search` like our normal test instances do, and the root path `/` is interpreted as a bad repo page URL:

![Screen Shot 2022-10-19 at 9 50 12 AM](https://user-images.githubusercontent.com/8942601/196754476-b425f1c8-e8f1-4c69-ad89-c16235f86da8.png)

This just updates the link appended to PR descriptions to explicitly point to `/search` instead.

## Test plan

Just a CI output change.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
