### PR TITLE
Render `QueryExamplesHomepage` for dotcom logged in users

### DIFF
--- a/client/web/src/search/home/LoggedOutHomepage.tsx
+++ b/client/web/src/search/home/LoggedOutHomepage.tsx
@@ -31,13 +31,23 @@ export const LoggedOutHomepage: React.FunctionComponent<React.PropsWithChildren<
                     telemetryService={props.telemetryService}
                     isSourcegraphDotCom={true}
                 />
+                <TipsAndTricks
+                    title="Tips and Tricks"
+                    examples={exampleTripsAndTricks}
+                    moreLink={{
+                        label: 'More search features',
+                        href: 'https://docs.sourcegraph.com/code_search/explanations/features',
+                        trackEventName: 'HomepageExampleMoreSearchFeaturesClicked',
+                    }}
+                    {...props}
+                />
+
                 <div className={styles.videoCard}>
                     <div className={classNames(styles.title, 'mb-2')}>Watch and learn</div>
                     <ModalVideo
                         id="three-ways-to-search-title"
                         title="Three ways to search"
                         src="https://www.youtube-nocookie.com/embed/XLfE2YuRwvw"
-                        showCaption={true}
                         thumbnail={{
                             src: `img/watch-and-learn-${props.isLightTheme ? 'light' : 'dark'}.png`,
                             alt: 'Watch and learn video thumbnail',
@@ -50,17 +60,6 @@ export const LoggedOutHomepage: React.FunctionComponent<React.PropsWithChildren<
                         assetsRoot={window.context?.assetsRoot || ''}
                     />
                 </div>
-
-                <TipsAndTricks
-                    title="Tips and Tricks"
-                    examples={exampleTripsAndTricks}
-                    moreLink={{
-                        label: 'More search features',
-                        href: 'https://docs.sourcegraph.com/code_search/explanations/features',
-                        trackEventName: 'HomepageExampleMoreSearchFeaturesClicked',
-                    }}
-                    {...props}
-                />
             </div>
 
             <div className={styles.heroSection}>

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -21,9 +21,11 @@ import { ThemePreferenceProps } from '../../theme'
 import { HomePanels } from '../panels/HomePanels'
 
 import { LoggedOutHomepage } from './LoggedOutHomepage'
+import { exampleTripsAndTricks } from './LoggedOutHomepage.constants'
 import { QueryExamplesHomepage } from './QueryExamplesHomepage'
 import { SearchPageFooter } from './SearchPageFooter'
 import { SearchPageInput } from './SearchPageInput'
+import { TipsAndTricks } from './TipsAndTricks'
 
 import styles from './SearchPage.module.scss'
 
@@ -78,12 +80,24 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
                 })}
             >
                 {props.isSourcegraphDotCom && !props.authenticatedUser && <LoggedOutHomepage {...props} />}
+                {props.isSourcegraphDotCom && props.authenticatedUser && (
+                    <TipsAndTricks
+                        title="Tips and Tricks"
+                        examples={exampleTripsAndTricks}
+                        moreLink={{
+                            label: 'More search features',
+                            href: 'https://docs.sourcegraph.com/code_search/explanations/features',
+                            trackEventName: 'HomepageExampleMoreSearchFeaturesClicked',
+                        }}
+                        {...props}
+                    />
+                )}
 
                 {showEnterpriseHomePanels && props.authenticatedUser && (
                     <HomePanels showCollaborators={showCollaborators} {...props} />
                 )}
 
-                {(!showEnterpriseHomePanels && !props.isSourcegraphDotCom) || (props.isSourcegraphDotCom && props.authenticatedUser && !showEnterpriseHomePanels) && (
+                {!showEnterpriseHomePanels && !props.isSourcegraphDotCom && (
                     <QueryExamplesHomepage
                         selectedSearchContextSpec={props.selectedSearchContextSpec}
                         telemetryService={props.telemetryService}

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -78,12 +78,20 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
                 })}
             >
                 {props.isSourcegraphDotCom && !props.authenticatedUser && <LoggedOutHomepage {...props} />}
+                {props.isSourcegraphDotCom && props.authenticatedUser && !showEnterpriseHomePanels && (
+                    <QueryExamplesHomepage
+                        selectedSearchContextSpec={props.selectedSearchContextSpec}
+                        telemetryService={props.telemetryService}
+                        queryState={queryState}
+                        setQueryState={setQueryState}
+                    />
+                )}
 
                 {showEnterpriseHomePanels && props.authenticatedUser && (
                     <HomePanels showCollaborators={showCollaborators} {...props} />
                 )}
 
-                {!showEnterpriseHomePanels && (
+                {!showEnterpriseHomePanels && !props.isSourcegraphDotCom && (
                     <QueryExamplesHomepage
                         selectedSearchContextSpec={props.selectedSearchContextSpec}
                         telemetryService={props.telemetryService}

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -83,7 +83,7 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
                     <HomePanels showCollaborators={showCollaborators} {...props} />
                 )}
 
-                {!showEnterpriseHomePanels && !props.isSourcegraphDotCom && (
+                {!showEnterpriseHomePanels && (
                     <QueryExamplesHomepage
                         selectedSearchContextSpec={props.selectedSearchContextSpec}
                         telemetryService={props.telemetryService}

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -78,20 +78,20 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
                 })}
             >
                 {props.isSourcegraphDotCom && !props.authenticatedUser && <LoggedOutHomepage {...props} />}
-                {props.isSourcegraphDotCom && props.authenticatedUser && !showEnterpriseHomePanels && (
+                {/* {props.isSourcegraphDotCom && props.authenticatedUser && !showEnterpriseHomePanels && (
                     <QueryExamplesHomepage
                         selectedSearchContextSpec={props.selectedSearchContextSpec}
                         telemetryService={props.telemetryService}
                         queryState={queryState}
                         setQueryState={setQueryState}
                     />
-                )}
+                )} */}
 
                 {showEnterpriseHomePanels && props.authenticatedUser && (
                     <HomePanels showCollaborators={showCollaborators} {...props} />
                 )}
 
-                {!showEnterpriseHomePanels && !props.isSourcegraphDotCom && (
+                {(!showEnterpriseHomePanels && !props.isSourcegraphDotCom) || (props.isSourcegraphDotCom && props.authenticatedUser && !showEnterpriseHomePanels) && (
                     <QueryExamplesHomepage
                         selectedSearchContextSpec={props.selectedSearchContextSpec}
                         telemetryService={props.telemetryService}

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -78,14 +78,6 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
                 })}
             >
                 {props.isSourcegraphDotCom && !props.authenticatedUser && <LoggedOutHomepage {...props} />}
-                {/* {props.isSourcegraphDotCom && props.authenticatedUser && !showEnterpriseHomePanels && (
-                    <QueryExamplesHomepage
-                        selectedSearchContextSpec={props.selectedSearchContextSpec}
-                        telemetryService={props.telemetryService}
-                        queryState={queryState}
-                        setQueryState={setQueryState}
-                    />
-                )} */}
 
                 {showEnterpriseHomePanels && props.authenticatedUser && (
                     <HomePanels showCollaborators={showCollaborators} {...props} />


### PR DESCRIPTION
This PR allows dotcom logged in users to view the query samples brought in on #39987.
(From [Growth Marketing projects](https://docs.google.com/document/d/1i1w83_gkzYueLpaIuaYPOHMj0_TYPI4KU87Krdn_iV8/edit#heading=h.nqkc8q1w72oe) kickoff)

@novoselrok  will you let us know if you see an issue in bringing this into dotcom? I'm assuming it was left out for initial rollout.

## Test plan
- Ensure all tests pass
- Ensure visiting `/search` home page logged in on dotcom (locally `SOURCEGRAPHDOTCOM_MODE=true sg start web-standalone`) shows the same search query samples on k8s and s2
- Observe no breaking changes on logged out/in state in this view for all env's

## Data plan
- [pending] - Find Amplitude metrics (if any) around these existing query samples & watch for changes after they're brought into dotcom

## App preview:
- [Web](https://sg-web-becca-dotcom-search-query-samples.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-uafpjfvouy.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

