### PR TITLE
[language-platform]: File sidebar inconsistent in what clicking directory name does

### DIFF
--- a/client/web/src/tree/Tree.module.scss
+++ b/client/web/src/tree/Tree.module.scss
@@ -32,8 +32,8 @@
     display: flex;
     color: inherit;
     align-items: center;
-    padding-top: var(--row-vertical-spacing);
-    padding-bottom: var(--row-vertical-spacing);
+    margin-top: var(--row-vertical-spacing);
+    margin-bottom: var(--row-vertical-spacing);
     cursor: pointer;
 }
 
@@ -42,7 +42,7 @@
 }
 
 .tree-row-contents-text {
-    display: flex;
+    display: block;
     align-items: center;
     justify-content: space-between;
 }
@@ -72,6 +72,7 @@
 
     &-contents,
     &-label {
+        width: 100%;
         &:hover {
             text-decoration: none;
         }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/41726

Fix file sidebar inconsistent in what clicking directory name does.

## Test plan
Ran all the test.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

![stretch](https://media.giphy.com/media/Vx24PmwPXZWLrkxXc7/giphy.gif)

## App preview:

- [Web](https://sg-web-cesar-41726-inconsistent-sidebar.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-diosbwqzip.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

