### PR TITLE
vsce: patch release v2.2.13

### DIFF
--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -62,11 +62,6 @@
         "category": "Sourcegraph",
         "title": "Remove Repository from Sourcegraph File System",
         "icon": "$(trash)"
-      },
-      {
-        "command": "sourcegraph.auth",
-        "category": "Sourcegraph",
-        "title": "Log in to Sourcegraph"
       }
     ],
     "authentication": [
@@ -232,7 +227,6 @@
     "package": "yarn run -T ts-node ./scripts/package.ts",
     "prebuild": "yarn build-inline-extensions",
     "prewatch": "yarn build-inline-extensions",
-    "vscode:prepublish": "yarn build-inline-extensions && yarn build",
     "build-inline-extensions": "node scripts/build-inline-extensions",
     "task:gulp": "yarn run -T cross-env NODE_OPTIONS=\"--max_old_space_size=8192\" gulp",
     "build:esbuild": "NODE_ENV=development yarn task:gulp esbuild",
@@ -252,5 +246,8 @@
     "release:minor": "VSCE_RELEASE_TYPE=minor yarn run -T ts-node ./scripts/release.ts",
     "release:patch": "VSCE_RELEASE_TYPE=patch yarn run -T ts-node ./scripts/release.ts",
     "release:pre": "VSCE_RELEASE_TYPE=prerelease yarn run -T ts-node ./scripts/release.ts"
+  },
+  "devDependencies": {
+    "vsce": "^2.7.0"
   }
 }

--- a/client/vscode/scripts/package.ts
+++ b/client/vscode/scripts/package.ts
@@ -5,13 +5,14 @@ import fs from 'fs'
 const originalPackageJson = fs.readFileSync('package.json').toString()
 
 try {
+    childProcess.execSync('yarn build-inline-extensions && yarn build', { stdio: 'inherit' })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const packageJson: any = JSON.parse(originalPackageJson)
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     packageJson.name = 'sourcegraph'
     fs.writeFileSync('package.json', JSON.stringify(packageJson))
 
-    childProcess.execSync('yarn vsce package --yarn --allow-star-activation -o dist', { stdio: 'inherit' })
+    childProcess.execSync('vsce package --yarn --allow-star-activation -o dist', { stdio: 'inherit' })
 } finally {
     fs.writeFileSync('package.json', originalPackageJson)
 }

--- a/client/vscode/scripts/publish.ts
+++ b/client/vscode/scripts/publish.ts
@@ -27,16 +27,17 @@ const tokens = {
 // Assume this is for testing purpose if tokens are not found
 const hasTokens = tokens.vscode !== undefined && tokens.openvsx !== undefined
 const commands = {
-    vscode_info: 'yarn vsce show sourcegraph.sourcegraph --json',
+    vscode_info: 'vsce show sourcegraph.sourcegraph --json',
     // To publish to VS Code Marketplace
-    vscode_publish: `yarn vsce publish ${isPreRelease} --pat $VSCODE_MARKETPLACE_TOKEN --yarn --allow-star-activation`,
+    vscode_publish: `vsce publish ${isPreRelease} --pat $VSCODE_MARKETPLACE_TOKEN --yarn --allow-star-activation`,
     // To package the extension without publishing
-    vscode_package: `yarn vsce package ${isPreRelease} --yarn --allow-star-activation`,
+    vscode_package: `vsce package ${isPreRelease} --yarn --allow-star-activation`,
     // To publish to the open-vsx registry
-    openvsx_publish: 'yarn npx --yes ovsx publish --yarn -p $VSCODE_OPENVSX_TOKEN',
+    openvsx_publish: 'npx --yes ovsx publish --yarn -p $VSCODE_OPENVSX_TOKEN',
 }
 // Publish the extension with the correct extension name "sourcegraph"
 try {
+    childProcess.execSync('yarn build-inline-extensions && yarn build', { stdio: 'inherit' })
     // Get the latest release version nubmer of the last release from VS Code Marketplace using the vsce cli tool
     const response = childProcess.execSync(commands.vscode_info).toString()
     /*

--- a/client/vscode/src/backend/authenticatedUser.ts
+++ b/client/vscode/src/backend/authenticatedUser.ts
@@ -49,14 +49,15 @@ export function observeAuthenticatedUser(secretStorage: vscode.SecretStorage): O
 
     function updateAuthenticatedUser(): void {
         requestGraphQLFromVSCode<CurrentAuthStateResult, CurrentAuthStateVariables>(currentAuthStateQuery, {})
-            .then(async authenticatedUserResult => {
-                if (!authenticatedUserResult.data) {
-                    await secretStorage.delete(scretTokenKey)
-                }
+            .then(authenticatedUserResult => {
                 authenticatedUsers.next(authenticatedUserResult.data ? authenticatedUserResult.data.currentUser : null)
+                if (!authenticatedUserResult.data) {
+                    throw new Error('Not an authenticated user')
+                }
             })
-            .catch(error => {
+            .catch(async error => {
                 console.error('core auth error', error)
+                await secretStorage.delete(scretTokenKey)
                 // TODO surface error?
                 authenticatedUsers.next(null)
             })

--- a/client/vscode/src/backend/authenticatedUser.ts
+++ b/client/vscode/src/backend/authenticatedUser.ts
@@ -55,9 +55,8 @@ export function observeAuthenticatedUser(secretStorage: vscode.SecretStorage): O
                     throw new Error('Not an authenticated user')
                 }
             })
-            .catch(async error => {
+            .catch(error => {
                 console.error('core auth error', error)
-                await secretStorage.delete(scretTokenKey)
                 // TODO surface error?
                 authenticatedUsers.next(null)
             })

--- a/client/vscode/src/settings/accessTokenSetting.ts
+++ b/client/vscode/src/settings/accessTokenSetting.ts
@@ -6,6 +6,19 @@ import { scretTokenKey } from '../webview/platform/AuthProvider'
 import { endpointHostnameSetting, endpointProtocolSetting } from './endpointSetting'
 import { readConfiguration } from './readConfiguration'
 
+// IMPORTANT: Call this function only once when extention is first activated
+export async function processOldToken(secretStorage: vscode.SecretStorage): Promise<void> {
+    // Process the token that lives in user configuration
+    // Move them to secrets and then remove them by setting it as undefined
+    const storageToken = await secretStorage.get(scretTokenKey)
+    const oldToken = vscode.workspace.getConfiguration().get<string>('sourcegraph.accessToken') || ''
+    if (!storageToken && oldToken.length > 8) {
+        await secretStorage.store(scretTokenKey, oldToken)
+        await removeOldAccessTokenSetting()
+    }
+    return
+}
+
 export async function accessTokenSetting(secretStorage: vscode.SecretStorage): Promise<string> {
     const currentToken = await secretStorage.get(scretTokenKey)
     return currentToken || ''

--- a/client/vscode/src/settings/accessTokenSetting.ts
+++ b/client/vscode/src/settings/accessTokenSetting.ts
@@ -11,7 +11,7 @@ export async function accessTokenSetting(secretStorage: vscode.SecretStorage): P
     return currentToken || ''
 }
 
-export async function removeAccessTokenSetting(): Promise<void> {
+export async function removeOldAccessTokenSetting(): Promise<void> {
     await readConfiguration().update('accessToken', undefined, vscode.ConfigurationTarget.Global)
     await readConfiguration().update('accessToken', undefined, vscode.ConfigurationTarget.Workspace)
     return

--- a/client/vscode/src/settings/endpointSetting.ts
+++ b/client/vscode/src/settings/endpointSetting.ts
@@ -7,9 +7,14 @@ export function endpointSetting(): string {
     return removeEndingSlash(url)
 }
 
-export async function setEndpoint(newEndpoint: string | undefined): Promise<void> {
+export async function setEndpoint(newEndpoint: string): Promise<void> {
     const newEndpointURL = newEndpoint ? removeEndingSlash(newEndpoint) : 'https://sourcegraph.com'
-    await readConfiguration().update('url', newEndpointURL, vscode.ConfigurationTarget.Global)
+    const currentEndpointHostname = new URL(endpointSetting()).hostname
+    const newEndpointHostname = new URL(newEndpointURL).hostname
+    if (currentEndpointHostname !== newEndpointHostname) {
+        await readConfiguration().update('url', newEndpointURL)
+    }
+    return
 }
 
 export function endpointHostnameSetting(): string {

--- a/client/vscode/src/settings/endpointSetting.ts
+++ b/client/vscode/src/settings/endpointSetting.ts
@@ -3,14 +3,13 @@ import * as vscode from 'vscode'
 import { readConfiguration } from './readConfiguration'
 
 export function endpointSetting(): string {
-    const url = readConfiguration().get<string>('url') || 'https://sourcegraph.com'
+    const url = vscode.workspace.getConfiguration().get<string>('sourcegraph.url') || 'https://sourcegraph.com'
     return removeEndingSlash(url)
 }
 
 export async function setEndpoint(newEndpoint: string | undefined): Promise<void> {
-    const newEndpointURL = newEndpoint ? removeEndingSlash(newEndpoint) : undefined
+    const newEndpointURL = newEndpoint ? removeEndingSlash(newEndpoint) : 'https://sourcegraph.com'
     await readConfiguration().update('url', newEndpointURL, vscode.ConfigurationTarget.Global)
-    await readConfiguration().update('url', newEndpointURL, vscode.ConfigurationTarget.Workspace)
 }
 
 export function endpointHostnameSetting(): string {
@@ -27,7 +26,7 @@ export function endpointProtocolSetting(): string {
 }
 
 export function endpointRequestHeadersSetting(): object {
-    return readConfiguration().get<object>('requestHeaders') || {}
+    return vscode.workspace.getConfiguration().get<object>('sourcegraph.requestHeaders') || {}
 }
 
 function removeEndingSlash(uri: string): string {

--- a/client/vscode/src/settings/recommendations.ts
+++ b/client/vscode/src/settings/recommendations.ts
@@ -1,6 +1,8 @@
 /**
  * Disabled due to violation of the VS Code's UX guidelines for notifications
- * To be revaluated in the future
+ * To be revaluated in the future: https://code.visualstudio.com/api/ux-guidelines/notifications
+ * This functions add Sourcegraph to workspace recommendations if haven't already
+ * eg: recommendSourcegraph(localStorageService).catch(() => {})
  */
 
 import * as vscode from 'vscode'

--- a/client/vscode/src/webview/commands.ts
+++ b/client/vscode/src/webview/commands.ts
@@ -57,19 +57,6 @@ export function registerWebviews({
         })
     )
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand('sourcegraph.auth', async (token: string, uri?: string) => {
-            // Get our PAT session.
-            await context.secrets.store(scretTokenKey, token)
-            const session = await vscode.authentication.getSession(uri || endpointSetting(), [], {
-                forceNewSession: true,
-            })
-            if (session) {
-                await vscode.window.showInformationMessage('Logged in sucessfully')
-            }
-        })
-    )
-
     // Update `EventSource` Authorization header on access token / headers change.
     // It will also be changed when the token has been changed --handled by Auth Provider
     context.subscriptions.push(

--- a/client/vscode/src/webview/sidebars/auth/AuthSidebarView.tsx
+++ b/client/vscode/src/webview/sidebars/auth/AuthSidebarView.tsx
@@ -42,6 +42,7 @@ export const AuthSidebarView: React.FunctionComponent<React.PropsWithChildren<Au
     const [hostname, setHostname] = useState(instanceHostname)
     const [accessToken, setAccessToken] = useState<string | undefined>('initial')
     const [endpointUrl, setEndpointUrl] = useState(instanceURL)
+    const sourcegraphDotCom = 'https://www.sourcegraph.com'
     const isSourcegraphDotCom = useMemo(() => {
         const hostname = new URL(instanceURL).hostname
         if (hostname === 'sourcegraph.com' || hostname === 'www.sourcegraph.com') {
@@ -90,6 +91,13 @@ export const AuthSidebarView: React.FunctionComponent<React.PropsWithChildren<Au
         setEndpointUrl(event.target.value)
     }, [])
 
+    const onInstanceTypeChange = useCallback(() => {
+        setUsePrivateInstance(!usePrivateInstance)
+        if (!usePrivateInstance) {
+            setEndpointUrl(sourcegraphDotCom)
+        }
+    }, [usePrivateInstance])
+
     const validateAccessToken: React.FormEventHandler<HTMLFormElement> = (event): void => {
         event.preventDefault()
         if (state !== 'validating' && accessToken) {
@@ -111,9 +119,10 @@ export const AuthSidebarView: React.FunctionComponent<React.PropsWithChildren<Au
                     .toPromise()
                 currentAuthStateResult
                     .then(async ({ data }) => {
-                        await extensionCoreAPI.setEndpointUri(accessToken, endpointUrl)
                         if (data?.currentUser) {
+                            await extensionCoreAPI.setEndpointUri(accessToken, endpointUrl)
                             setState('success')
+                            return
                         }
                         setState('failure')
                         return
@@ -270,7 +279,7 @@ export const AuthSidebarView: React.FunctionComponent<React.PropsWithChildren<Au
                 </Alert>
             )}
             <Text className="my-0">
-                <VSCodeLink onClick={() => setUsePrivateInstance(!usePrivateInstance)}>
+                <VSCodeLink onClick={() => onInstanceTypeChange()}>
                     {!usePrivateInstance ? 'Need to connect to a private instance?' : 'Not a private instance user?'}
                 </VSCodeLink>
             </Text>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6097,6 +6097,8 @@ __metadata:
 "@sourcegraph/vscode@workspace:client/vscode":
   version: 0.0.0-use.local
   resolution: "@sourcegraph/vscode@workspace:client/vscode"
+  dependencies:
+    vsce: ^2.7.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Follow up on https://github.com/sourcegraph/sourcegraph/pull/43060 - moving tokens from user settings to secret storage

### Update 1

The vsce package output was not working as intended in the [previous PR,]( https://github.com/sourcegraph/sourcegraph/pull/43060) so I've fixed that (users were not logged in automatically) and made some improvements in the general user experience about logging in and out (slient pop-ups when login in). 

See Loom video demo: https://www.loom.com/share/d475b8898d4c4c6eacbd4b82fe5dc698

### Update 2

[The release pipeline was also broken](https://buildkite.com/sourcegraph/sourcegraph/builds/178570#0183ed81-4bc0-4b87-9c09-704e740f77f0) which @philipp-spiess and I were able to dive into and got them to work locally at least. For example:
```sh
sourcegraph/client/vscode on  b/vsce [!] via  v16.13.2 on ☁️  (us-west-1) on ☁️  beatrix@sourcegraph.com
❯ yarn package
✔  success   Code-intel-extensions for revision "v3.41.1" are already bundled.
✔  success   Code-intel-extensions for revision "v3.41.1" are already bundled.
[13:00:14] Using gulpfile ~/Dev/sourcegraph/client/vscode/gulpfile.js
[13:00:14] Starting 'webpack'...
[13:02:38] extension:node:
  extension:node compiled in 95656 ms

extension:webworker:
  extension:webworker compiled in 95633 ms

webviews:
  WARNING in ../../node_modules/react-router-dom-v5-compat/index.js 422:15-25
  export 'Action' (imported as 'Action') was not found in 'history' (possible exports: __esModule, createBrowserHistory, createHashHistory, createLocation, createMemoryHistory, createPath, locationsAreEqual, parsePath)

  WARNING in ../../node_modules/react-router-dom-v5-compat/node_modules/react-router/index.js 12:0-74
  export 'Action' (reexported as 'NavigationType') was not found in 'history' (possible exports: __esModule, createBrowserHistory, createHashHistory, createLocation, createMemoryHistory, createPath, locationsAreEqual, parsePath)

  WARNING in ../../node_modules/react-router-dom-v5-compat/node_modules/react-router/index.js 822:21-31
  export 'Action' (imported as 'Action') was not found in 'history' (possible exports: __esModule, createBrowserHistory, createHashHistory, createLocation, createMemoryHistory, createPath, locationsAreEqual, parsePath)

  webviews compiled in 143886 ms
[13:02:38] Finished 'webpack' after 2.4 min
This extension consists of 293 files, out of which 227 are JavaScript files. For performance reasons, you should bundle your extension: https://aka.ms/vscode-bundle-extension . You should also exclude unnecessary files by adding them to your .vscodeignore: https://aka.ms/vscode-vscodeignore
 DONE  Packaged: dist/sourcegraph-2.2.13.vsix (293 files, 12.93MB)
 INFO
The latest version of vsce is 2.12.0 and you have 2.7.0.
Update it now: npm install -g vsce
``` 


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested with package output here:
[sourcegraph-2.2.13.vsix.zip](https://github.com/sourcegraph/sourcegraph/files/9824635/sourcegraph-2.2.13.vsix.zip)

Integration test is also passing:

```bash
❯ yarn test-integration
Not in BUILDKITE. No annotation will be generated in ./annotations

  VS Code extension
...
    Identifiers: {
      method: 'POST',
      body: '{"query":"\\n            query ImplementationsIntrospectionQuery {\\n             '... 182 more characters,
      url: 'https://sourcegraph.com/.api/graphql?ImplementationsIntrospectionQuery'
    }
      ✓ works (19697ms)


    1 passing (24s)
```

## App preview:

- [Web](https://sg-web-b-vsce.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-svbnpiwuim.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
