### PR TITLE
stop notifying batch changes team if "campaign" is mentioned

### DIFF
--- a/.github/workflows/batches-notify.yml
+++ b/.github/workflows/batches-notify.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions-ecosystem/action-create-comment@v1
-        if: (contains(github.event.issue.body, 'batch') || contains(github.event.issue.body, 'campaign')) && !contains(github.event.issue.labels.*.name, 'team/batchers')
+        if: (contains(github.event.issue.body, 'batch') && !contains(github.event.issue.labels.*.name, 'team/batchers')
         with:
           github_token: ${{ secrets.github_token }}
           body: |


### PR DESCRIPTION
Campaigns was an old name (pre-GA) for Batch Changes. It no longer makes sense to notify that team if the word "campaign" is used, especially since the Growth Marketing team will probably be using it more in issues (which is a false positive).

Fixes annoying false positives like:

![image](https://user-images.githubusercontent.com/1976/196814026-8d27a169-881e-41f4-88af-3c4555db200d.png)



## Test plan

Just a GitHub notify workflow change. No test needed.