### PR TITLE
insights: add backfill running logic to the backfill in progress handler

### DIFF
--- a/enterprise/internal/insights/pipeline/backfill_test.go
+++ b/enterprise/internal/insights/pipeline/backfill_test.go
@@ -93,7 +93,7 @@ func TestBackfillStepsConnected(t *testing.T) {
 				return reqContext, nil
 			}
 
-			backfiller := NewBackfiller(makeTestJobGenerator(tc.numJobs), testSearchRunnerStep, countingPersister)
+			backfiller := newBackfiller(makeTestJobGenerator(tc.numJobs), testSearchRunnerStep, countingPersister)
 			got.err = backfiller.Run(context.Background(), BackfillRequest{Series: &types.InsightSeries{SeriesID: "1"}})
 			tc.want.Equal(t, got)
 		})
@@ -112,7 +112,7 @@ func (f *fakeCommitClient) RecentCommits(ctx context.Context, repoName api.RepoN
 	return f.recentCommits(ctx, repoName, target)
 }
 
-func newFakeCommitClient(first *gitdomain.Commit, recents []*gitdomain.Commit) gitCommitClient {
+func newFakeCommitClient(first *gitdomain.Commit, recents []*gitdomain.Commit) GitCommitClient {
 	return &fakeCommitClient{
 		firstCommit: func(ctx context.Context, repoName api.RepoName) (*gitdomain.Commit, error) { return first, nil },
 		recentCommits: func(ctx context.Context, repoName api.RepoName, target time.Time) ([]*gitdomain.Commit, error) {
@@ -183,7 +183,7 @@ func TestMakeSearchJobs(t *testing.T) {
 	}
 
 	testCases := []struct {
-		commitClient gitCommitClient
+		commitClient GitCommitClient
 		backfillReq  *BackfillRequest
 		workers      int
 		cancled      bool

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -1,0 +1,112 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+	log "github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/pipeline"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
+	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*workerutil.Worker, *dbworker.Resetter, dbworkerstore.Store) {
+	db := config.InsightsDB
+	backfillStore := newBackfillStore(db)
+
+	name := "backfill_in_progress_worker"
+
+	workerStore := dbworkerstore.NewWithMetrics(db.Handle(), dbworkerstore.Options{
+		Name:              fmt.Sprintf("%s_store", name),
+		TableName:         "insights_background_jobs",
+		ViewName:          "insights_jobs_backfill_in_progress",
+		ColumnExpressions: baseJobColumns,
+		Scan:              dbworkerstore.BuildWorkerScan(scanBaseJob),
+		OrderByExpression: sqlf.Sprintf("id"), // todo
+		MaxNumResets:      100,
+		StalledMaxAge:     time.Second * 30,
+	}, config.ObsContext)
+
+	task := inProgressHandler{
+		workerStore:   workerStore,
+		backfillStore: backfillStore,
+	}
+
+	worker := dbworker.NewWorker(ctx, workerStore, &task, workerutil.WorkerOptions{
+		Name:        name,
+		NumHandlers: 1,
+		Interval:    5 * time.Second,
+		Metrics:     workerutil.NewMetrics(config.ObsContext, name),
+	})
+
+	resetter := dbworker.NewResetter(log.Scoped("", ""), workerStore, dbworker.ResetterOptions{
+		Name:     fmt.Sprintf("%s_resetter", name),
+		Interval: time.Second * 20,
+		Metrics:  *dbworker.NewMetrics(config.ObsContext, name),
+	})
+
+	return worker, resetter, workerStore
+}
+
+type inProgressHandler struct {
+	workerStore    dbworkerstore.Store
+	backfillStore  *BackfillStore
+	seriesReader   SeriesReader
+	repoStore      database.RepoStore
+	backfillRunner pipeline.Backfiller
+}
+
+var _ workerutil.Handler = &inProgressHandler{}
+
+func (h *inProgressHandler) Handle(ctx context.Context, logger log.Logger, record workerutil.Record) error {
+	logger.Info("inProgressHandler called", log.Int("recordId", record.RecordID()))
+
+	job := record.(*BaseJob)
+
+	backfillJob, err := h.backfillStore.loadBackfill(ctx, job.backfillId)
+	if err != nil {
+		return errors.Wrap(err, "loadBackfill")
+	}
+	series, err := h.seriesReader.GetDataSeriesByID(ctx, backfillJob.SeriesId)
+	if err != nil {
+		return errors.Wrap(err, "GetDataSeriesByID")
+	}
+
+	itr, err := backfillJob.repoIterator(ctx, h.backfillStore)
+	if err != nil {
+		return errors.Wrap(err, "repoIterator")
+	}
+
+	for true {
+		repoId, more, finish := itr.NextWithFinish()
+		if !more {
+			break
+		}
+
+		repo, err := h.repoStore.Get(ctx, repoId)
+		if err != nil {
+			// TODO: this repo should be marked as errored and processing should continue
+			// revisit when error handling added.
+			return err
+		}
+
+		logger.Info("doing iteration work", log.Int("repo_id", int(repoId)))
+		err = h.backfillRunner.Run(ctx, pipeline.BackfillRequest{Series: series, Repo: &types.MinimalRepo{ID: repo.ID, Name: repo.Name}})
+
+		err = finish(ctx, h.backfillStore.Store, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	// todo handle errors down here after the main loop https://github.com/sourcegraph/sourcegraph/issues/42724
+
+	return nil
+}

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
@@ -66,7 +66,7 @@ func Test_MovesBackfillFromProcessingToComplete(t *testing.T) {
 	err = enqueueBackfill(ctx, bfs.Handle(), backfill)
 	require.NoError(t, err)
 
-	dequeue, found, err := monitor.inProgressStore.Dequeue(ctx, "test", nil)
+	dequeue, _, _ := monitor.inProgressStore.Dequeue(ctx, "test", nil)
 	handler := inProgressHandler{
 		workerStore:    monitor.newBackfillStore,
 		backfillStore:  bfs,
@@ -77,7 +77,7 @@ func Test_MovesBackfillFromProcessingToComplete(t *testing.T) {
 	err = handler.Handle(ctx, logger, dequeue)
 	require.NoError(t, err)
 
-	dequeue, found, err = monitor.inProgressStore.Dequeue(ctx, "test", nil)
+	_, found, err := monitor.inProgressStore.Dequeue(ctx, "test", nil)
 	require.NoError(t, err)
 	if found {
 		t.Fatal(errors.New("found record that should not be visible to the new backfill store"))

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
@@ -1,0 +1,97 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/derision-test/glock"
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/require"
+
+	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/pipeline"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/scheduler/iterator"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	itypes "github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type noopBackfillRunner struct {
+}
+
+func (n *noopBackfillRunner) Run(ctx context.Context, req pipeline.BackfillRequest) error {
+	return nil
+}
+
+func Test_MovesBackfillFromProcessingToComplete(t *testing.T) {
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t))
+	repos := database.NewMockRepoStore()
+	repos.GetFunc.SetDefaultReturn(&itypes.Repo{ID: 1, Name: "repo1"}, nil)
+	now := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := glock.NewMockClockAt(now)
+	bfs := newBackfillStoreWithClock(insightsDB, clock)
+	insightsStore := store.NewInsightStore(insightsDB)
+	config := JobMonitorConfig{
+		InsightsDB:     insightsDB,
+		RepoStore:      repos,
+		ObsContext:     &observation.TestContext,
+		BackfillRunner: &noopBackfillRunner{},
+	}
+	monitor := NewBackgroundJobMonitor(ctx, config)
+
+	series, err := insightsStore.CreateSeries(ctx, types.InsightSeries{
+		SeriesID:            "series1",
+		Query:               "asdf",
+		SampleIntervalUnit:  string(types.Month),
+		Repositories:        []string{"repo1", "repo2"},
+		SampleIntervalValue: 1,
+		GenerationMethod:    types.Search,
+	})
+	require.NoError(t, err)
+
+	backfill, err := bfs.NewBackfill(ctx, series)
+	require.NoError(t, err)
+	backfill, err = backfill.SetScope(ctx, bfs, []int32{1, 2}, 0)
+	require.NoError(t, err)
+	err = backfill.setState(ctx, bfs, BackfillStateProcessing)
+	require.NoError(t, err)
+
+	err = enqueueBackfill(ctx, bfs.Handle(), backfill)
+	require.NoError(t, err)
+
+	dequeue, found, err := monitor.inProgressStore.Dequeue(ctx, "test", nil)
+	handler := inProgressHandler{
+		workerStore:    monitor.newBackfillStore,
+		backfillStore:  bfs,
+		seriesReader:   store.NewInsightStore(insightsDB),
+		repoStore:      repos,
+		backfillRunner: &noopBackfillRunner{},
+	}
+	err = handler.Handle(ctx, logger, dequeue)
+	require.NoError(t, err)
+
+	dequeue, found, err = monitor.inProgressStore.Dequeue(ctx, "test", nil)
+	require.NoError(t, err)
+	if found {
+		t.Fatal(errors.New("found record that should not be visible to the new backfill store"))
+	}
+
+	completedBackfill, err := bfs.loadBackfill(ctx, backfill.Id)
+	require.NoError(t, err)
+	if completedBackfill.State != BackfillStateCompleted {
+		t.Fatal(errors.New("backfill should be state COMPLETED after success"))
+	}
+	completedItr, err := iterator.Load(ctx, bfs.Store, completedBackfill.repoIteratorId)
+	require.NoError(t, err)
+	if completedItr.CompletedAt.IsZero() {
+		t.Fatal(errors.New("iterator should be COMPLETED after success"))
+	}
+
+}

--- a/enterprise/internal/insights/scheduler/scheduler.go
+++ b/enterprise/internal/insights/scheduler/scheduler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/pipeline"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -100,9 +101,10 @@ type BackgroundJobMonitor struct {
 }
 
 type JobMonitorConfig struct {
-	InsightsDB edb.InsightsDB
-	RepoStore  database.RepoStore
-	ObsContext *observation.Context
+	InsightsDB     edb.InsightsDB
+	RepoStore      database.RepoStore
+	BackfillRunner pipeline.Backfiller
+	ObsContext     *observation.Context
 }
 
 func NewBackgroundJobMonitor(ctx context.Context, config JobMonitorConfig) *BackgroundJobMonitor {

--- a/enterprise/internal/insights/scheduler/scheduler.go
+++ b/enterprise/internal/insights/scheduler/scheduler.go
@@ -2,14 +2,11 @@ package scheduler
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/lib/pq"
 
 	"github.com/keegancsmith/sqlf"
-
-	"github.com/sourcegraph/log"
 
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
@@ -124,86 +121,6 @@ func (s *BackgroundJobMonitor) Routines() []goroutine.BackgroundRoutine {
 		s.newBackfillWorker,
 		s.newBackfillResetter,
 	}
-}
-
-func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*workerutil.Worker, *dbworker.Resetter, dbworkerstore.Store) {
-	db := config.InsightsDB
-	backfillStore := newBackfillStore(db)
-
-	name := "backfill_in_progress_worker"
-
-	workerStore := dbworkerstore.NewWithMetrics(db.Handle(), dbworkerstore.Options{
-		Name:              fmt.Sprintf("%s_store", name),
-		TableName:         "insights_background_jobs",
-		ViewName:          "insights_jobs_backfill_in_progress",
-		ColumnExpressions: baseJobColumns,
-		Scan:              dbworkerstore.BuildWorkerScan(scanBaseJob),
-		OrderByExpression: sqlf.Sprintf("id"), // todo
-		MaxNumResets:      100,
-		StalledMaxAge:     time.Second * 30,
-	}, config.ObsContext)
-
-	task := inProgressHandler{
-		workerStore:   workerStore,
-		backfillStore: backfillStore,
-	}
-
-	worker := dbworker.NewWorker(ctx, workerStore, &task, workerutil.WorkerOptions{
-		Name:        name,
-		NumHandlers: 1,
-		Interval:    5 * time.Second,
-		Metrics:     workerutil.NewMetrics(config.ObsContext, name),
-	})
-
-	resetter := dbworker.NewResetter(log.Scoped("BackfillInProgressResetter", ""), workerStore, dbworker.ResetterOptions{
-		Name:     fmt.Sprintf("%s_resetter", name),
-		Interval: time.Second * 20,
-		Metrics:  *dbworker.NewMetrics(config.ObsContext, name),
-	})
-
-	return worker, resetter, workerStore
-}
-
-type inProgressHandler struct {
-	workerStore   dbworkerstore.Store
-	backfillStore *BackfillStore
-}
-
-var _ workerutil.Handler = &inProgressHandler{}
-
-func (h *inProgressHandler) Handle(ctx context.Context, logger log.Logger, record workerutil.Record) error {
-	logger.Info("inProgressHandler called", log.Int("recordId", record.RecordID()))
-
-	job := record.(*BaseJob)
-
-	backfill, err := h.backfillStore.loadBackfill(ctx, job.backfillId)
-	if err != nil {
-		return errors.Wrap(err, "loadBackfill")
-	}
-
-	itr, err := backfill.repoIterator(ctx, h.backfillStore)
-	if err != nil {
-		return errors.Wrap(err, "repoIterator")
-	}
-
-	for true {
-		repoId, more, finish := itr.NextWithFinish()
-		if !more {
-			break
-		}
-
-		// todo do backfilling work
-		logger.Info("doing iteration work", log.Int("repo_id", int(repoId)))
-
-		err = finish(ctx, h.backfillStore.Store, nil)
-		if err != nil {
-			return err
-		}
-	}
-
-	// todo handle errors down here after the main loop https://github.com/sourcegraph/sourcegraph/issues/42724
-
-	return nil
 }
 
 type SeriesReader interface {


### PR DESCRIPTION
Adds the backfill running logic and all the associated dependencies into the handler that runs for the backfill `in progress` state.

I once again moved the in progress logic into a separate file because it was easier to keep track of it that way.  The logic in the `Handle` function is new.

related to https://github.com/sourcegraph/sourcegraph/issues/42887
## Test plan
Unit tests pass
Handlers changed are not yet attached to any code that runs yet.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
