### PR TITLE
web: do not parse repoURL on the `/` page

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyTabs.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyTabs.tsx
@@ -198,10 +198,14 @@ export function useFuzzyState(props: FuzzyTabsProps, onClickItem: () => void): F
         isRepositoryRelatedPage,
         client: apolloClient,
     } = props
-    let { repoName = '', commitID = '', rawRevision = '' } = useMemo(
-        () => parseBrowserRepoURL(pathname + search + hash),
-        [pathname, search, hash]
-    )
+    let { repoName = '', commitID = '', rawRevision = '' } = useMemo(() => {
+        if (pathname !== '/') {
+            // TODO `parseBrowserRepoURL` should not be called on non-repoURL pages.
+            return parseBrowserRepoURL(pathname + search + hash)
+        }
+
+        return { repoName: '', commitID: '', rawRevision: '' }
+    }, [pathname, search, hash])
     let revision = rawRevision || commitID
     if (!isRepositoryRelatedPage) {
         repoName = ''


### PR DESCRIPTION
## Context

Adds a temporary fix to the root URL crash caused by the `FuzzyFinderContainer` component. The fix is temporary because the proper one requires understanding when it is safe to run the `useFuzzyState`. Right now, it's evaluated on every web application page, which might cause other unexpected issues. The workaround is valuable because the problem affects local DX.

<img width="1080" alt="Screenshot 2022-10-19 at 15 26 06" src="https://user-images.githubusercontent.com/3846380/196853443-18788dff-7781-46ab-9c18-8bbf62fbff49.png">

## Test plan

1. `sg start web-standalone`
2. open `https://sourcegraph.test:3443/`
3. it should redirect you to `https://sourcegraph.test:3443/seach` without errors
