### PR TITLE
web: parameterize Webpack `devtool` for local development

### DIFF
--- a/client/web/dev/utils/environment-config.ts
+++ b/client/web/dev/utils/environment-config.ts
@@ -35,10 +35,12 @@ export const ENVIRONMENT_CONFIG = {
     WEBPACK_BUNDLE_ANALYZER: getEnvironmentBoolean('WEBPACK_BUNDLE_ANALYZER'),
     // The name used to generate Statoscope JSON stats and HTML report in the `/ui/assets` folder.
     WEBPACK_STATS_NAME: process.env.WEBPACK_STATS_NAME,
-    // Allow overriding default Webpack naming behavior for debugging
+    // Allow overriding default Webpack naming behavior for debugging.
     WEBPACK_USE_NAMED_CHUNKS: getEnvironmentBoolean('WEBPACK_USE_NAMED_CHUNKS'),
-
+    // Enables the plugin that write Webpack stats to disk.
     WEBPACK_EXPORT_STATS_FILENAME: process.env.WEBPACK_EXPORT_STATS_FILENAME,
+    // Allow to adjust https://webpack.js.org/configuration/devtool/ in the dev environment.
+    WEBPACK_DEVELOPMENT_DEVTOOL: process.env.WEBPACK_DEVELOPMENT_DEVTOOL || 'eval-cheap-module-source-map',
 
     // The commit SHA the client bundle was built with.
     COMMIT_SHA: process.env.COMMIT_SHA,

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -46,6 +46,7 @@ const {
   WEBPACK_SERVE_INDEX,
   WEBPACK_STATS_NAME,
   WEBPACK_USE_NAMED_CHUNKS,
+  WEBPACK_DEVELOPMENT_DEVTOOL,
   SENTRY_UPLOAD_SOURCE_MAPS,
   COMMIT_SHA,
   VERSION,
@@ -143,7 +144,7 @@ const config = {
     globalObject: 'self',
     pathinfo: false,
   },
-  devtool: IS_PRODUCTION ? 'source-map' : 'eval-cheap-module-source-map',
+  devtool: IS_PRODUCTION ? 'source-map' : WEBPACK_DEVELOPMENT_DEVTOOL,
   plugins: [
     new webpack.DefinePlugin({
       'process.env': mapValues(RUNTIME_ENV_VARIABLES, JSON.stringify),


### PR DESCRIPTION
## Context

This PR enables [custom `devtool` values](https://webpack.js.org/configuration/devtool/) in the development environment via the new env `WEBPACK_DEVELOPMENT_DEVTOOL` variable. 

Use-case: I always prefer to use `eval` because it consistently allows setting breakpoints everywhere in the code, so I can now make it my default `devtool` via `sg.config.overwrite.yaml`.

## Test plan

1. `WEBPACK_DEVELOPMENT_DEVTOOL=eval sg start web-standalone`
2. See the updated sourcemaps format in the browser.

## App preview:

- [Web](https://sg-web-vb-parameterize-webpack-devtool.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
