### PR TITLE
[SG-43132]: Default search context read letter-by-letter

### DIFF
--- a/client/search-ui/src/input/SearchContextMenu.test.tsx
+++ b/client/search-ui/src/input/SearchContextMenu.test.tsx
@@ -159,8 +159,8 @@ describe('SearchContextMenu', () => {
 
         const items = screen.getAllByTestId('search-context-menu-item')
         expect(items.length).toBe(2)
-        expect(items[0]).toHaveTextContent('@username Your repositories on Sourcegraph')
-        expect(items[1]).toHaveTextContent('@username/test-version-1.5 Only code in version 1.5')
+        expect(items[0]).toHaveTextContent('@username, Your repositories on Sourcegraph')
+        expect(items[1]).toHaveTextContent('@username/test-version-1.5, Only code in version 1.5')
 
         expect(items).toMatchSnapshot()
     })
@@ -224,6 +224,6 @@ describe('SearchContextMenu', () => {
 
         const items = screen.getAllByTestId('search-context-menu-item')
         // With no auto-defined contexts, the first context should be a user-defined context
-        expect(items[0]).toHaveTextContent('@username/test-version-1.5 Only code in version 1.5')
+        expect(items[0]).toHaveTextContent('@username/test-version-1.5, Only code in version 1.5')
     })
 })

--- a/client/search-ui/src/input/SearchContextMenu.tsx
+++ b/client/search-ui/src/input/SearchContextMenu.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useEffect, FormEvent, useMemo, useState, FC } from 'react'
 
 import { mdiClose } from '@mdi/js'
+import VisuallyHidden from '@reach/visually-hidden'
 import classNames from 'classnames'
 import { BehaviorSubject, combineLatest, of, timer } from 'rxjs'
 import { catchError, debounce, switchMap, tap } from 'rxjs/operators'
@@ -289,14 +290,18 @@ export const SearchContextMenuItem: FC<SearchContextMenuItemProps> = props => {
                 <small data-testid="search-context-menu-item-name" className={styles.itemName}>
                     <ComboboxOptionText />
                 </small>
-            </Tooltip>{' '}
+            </Tooltip>
+            {descriptionOrQuery && <VisuallyHidden>,</VisuallyHidden>}{' '}
             <Tooltip content={descriptionOrQuery}>
                 <small className={styles.itemDescription}>{descriptionOrQuery}</small>
             </Tooltip>
             {isDefault && (
-                <Badge variant="secondary" className={classNames('text-uppercase', styles.itemDefault)}>
-                    Default
-                </Badge>
+                <>
+                    <VisuallyHidden>,</VisuallyHidden>
+                    <Badge variant="secondary" className={classNames('text-uppercase', styles.itemDefault)}>
+                        Default
+                    </Badge>
+                </>
             )}
         </ComboboxOption>
     )

--- a/client/search-ui/src/input/__snapshots__/SearchContextMenu.test.tsx.snap
+++ b/client/search-ui/src/input/__snapshots__/SearchContextMenu.test.tsx.snap
@@ -36,6 +36,11 @@ Array [
         name
       </span>
     </small>
+    <span
+      style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+    >
+      ,
+    </span>
      
     <small
       class="itemDescription"
@@ -78,6 +83,11 @@ Array [
         name/test-version-1.5
       </span>
     </small>
+    <span
+      style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+    >
+      ,
+    </span>
      
     <small
       class="itemDescription"


### PR DESCRIPTION
## Description
The badge for the default search context in the search context dropdown is being read letter-by-letter (D-E-F-A-U-L-T) instead of as a single word.

<img width="534" alt="image" src="https://user-images.githubusercontent.com/206864/196555579-8ee55656-61c2-440b-a9cc-515bf5d15e79.png">

## Success Criteria
It should be read as a single word.

## Ref
[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/43132)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-43132)

## Test Plan
1. Run the web app on this branch
2. Using the screen reader, navigate through the search context dropdown items
3. Verify that the `DEFAULT` text is read as a word and not a bunch of alphabets
4. Verify that there is a pause between words when the screen reader reads `context name`, `description`, `default status` as mentioned in #43134

## Demo

### Existing
https://user-images.githubusercontent.com/45232708/196698224-11c6a0aa-ff7c-49f4-b970-988022ef242c.mov



### New
https://user-images.githubusercontent.com/45232708/196695316-6839935c-b7ee-452b-bfec-b390739bc76e.mov


## App preview:

- [Web](https://sg-web-contractors-sg-43132.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
