### PR TITLE
api: Use internal actor in internal api client

### DIFF
--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -112,7 +112,7 @@ func (h *searchIndexerServer) serveConfiguration(w http.ResponseWriter, r *http.
 	}
 
 	if len(indexedIDs) == 0 {
-		http.Error(w, "atleast one repoID required", http.StatusBadRequest)
+		http.Error(w, "at least one repoID required", http.StatusBadRequest)
 		return nil
 	}
 

--- a/internal/conf/client.go
+++ b/internal/conf/client.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api/internalapi"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -306,8 +305,7 @@ func (c *client) continuouslyUpdate(optOnlySetByTests *continuousUpdateOptions) 
 
 func (c *client) fetchAndUpdate(logger log.Logger) error {
 	var (
-		// We may make a cross service call here, so we need to add an internal actor.
-		ctx       = actor.WithInternalActor(context.Background())
+		ctx       = context.Background()
 		newConfig conftypes.RawUnified
 		err       error
 	)

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -175,7 +175,7 @@ func NewInternalClientFactory(subsystem string, middleware ...Middleware) *Facto
 	)
 }
 
-// InternalDoer is a shared client for external communication. This is a
+// InternalDoer is a shared client for internal communication. This is a
 // convenience for existing uses of http.DefaultClient.
 var InternalDoer, _ = InternalClientFactory.Doer()
 

--- a/internal/usagestats/repositories.go
+++ b/internal/usagestats/repositories.go
@@ -3,6 +3,7 @@ package usagestats
 import (
 	"context"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -37,7 +38,8 @@ type Repositories struct {
 func GetRepositories(ctx context.Context, db database.DB) (*Repositories, error) {
 	var total Repositories
 
-	stats, err := gitserver.NewClient(db).ReposStats(ctx)
+	// Since this hits gitserver, we should use an internal actor.
+	stats, err := gitserver.NewClient(db).ReposStats(actor.WithInternalActor(ctx))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is a more robust follow to a [previous PR](https://github.com/sourcegraph/sourcegraph/pull/43161).

We now ensure that all outgoing requests to our internal api via our internal client
include an internal actor if no actor was already provided.

Part of https://github.com/sourcegraph/sourcegraph/issues/28532

And for those following along, I'm trying to get [this dashboard](https://sourcegraph.sourcegraph.com/-/debug/grafana/explore?orgId=1&left=%5B%22now-12h%22,%22now%22,%22Prometheus%22,%7B%22exemplar%22:true,%22expr%22:%22sum%20by(actor_type,%20app,%20path)%20(rate(src_actors_incoming_requests%7Bactor_type%3D%5C%22none%5C%22%7D%5B5m%5D))%22,%22requestId%22:%22Q-0481ae16-4c20-469e-8ce2-3863a2378e50-0A%22%7D%5D) to as close to zero as possible.

## Test plan

Tested locally