### PR TITLE
Fuzzy finder: refactor and implement Figma design

### DIFF
--- a/client/web/src/components/KeyboardShortcutsHelp/KeyboardShortcutsHelp.tsx
+++ b/client/web/src/components/KeyboardShortcutsHelp/KeyboardShortcutsHelp.tsx
@@ -100,6 +100,14 @@ interface KeybindingProps {
     keybindings: Keybinding[]
     uppercaseOrdered?: boolean
 }
+export function plaintextKeybindings(keybindings: Keybinding[]): string {
+    return keybindings
+        .map<string>(keybinding => {
+            const ordered = keybinding.ordered.map(key => key.toUpperCase())
+            return [...(keybinding.held || []), ...ordered].map(key => renderShortcutKey(key)).join('')
+        })
+        .join(' or ')
+}
 export const Keybindings: React.FunctionComponent<KeybindingProps> = ({ keybindings, uppercaseOrdered }) => (
     <>
         {keybindings.map((keybinding, index) => {

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.test.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.test.tsx
@@ -17,7 +17,7 @@ describe('FuzzyModal', () => {
             </MockedProvider>
         )
         await waitForNextApolloResponse()
-        expect(result.getByTestId('fuzzy-modal-summary')).toHaveTextContent('12 results - 14 totals')
+        expect(result.getByTestId('fuzzy-modal-summary')).toHaveTextContent('12 results out of 14 totals')
         expect(result.getByTestId('fuzzy-modal-header')).toHaveTextContent('Find files')
     })
 })

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
@@ -30,7 +30,9 @@ export const FuzzyFinderContainer: React.FunctionComponent<FuzzyFinderContainerP
     const isVisibleRef = useRef(isVisible)
     isVisibleRef.current = isVisible
     const state = useFuzzyState(props, () => setIsVisible(false))
-    const { tabs, activeTab, setActiveTab, repoRevision, toggleGlobalFiles, toggleGlobalSymbols } = state
+    const { tabs, activeTab, setActiveTab, repoRevision, isScopeToggleDisabled, toggleScope } = state
+    const isScopeToggleDisabledRef = useRef(isScopeToggleDisabled)
+    isScopeToggleDisabledRef.current = isScopeToggleDisabled
 
     // We need useRef to access the latest state inside `openFuzzyFinder` below.
     // The keyboard shortcut does not pick up changes to the callback even if we
@@ -52,14 +54,12 @@ export const FuzzyFinderContainer: React.FunctionComponent<FuzzyFinderContainerP
             if (!isVisible) {
                 setIsVisible(true)
             }
-            if (isVisible && tab === activeTab) {
+            if (!isScopeToggleDisabledRef.current && isVisible && tab === activeTab) {
                 switch (tab) {
                     case 'files':
-                        toggleGlobalFiles()
-                        break
                     case 'symbols':
-                        toggleGlobalSymbols()
-                        break
+                    case 'all':
+                        toggleScope()
                 }
             } else {
                 const newTab = tabsRef.current.focusNamedTab(tab)
@@ -68,7 +68,7 @@ export const FuzzyFinderContainer: React.FunctionComponent<FuzzyFinderContainerP
                 }
             }
         },
-        [setActiveTab, setIsVisible, toggleGlobalFiles, toggleGlobalSymbols]
+        [setActiveTab, setIsVisible, toggleScope]
     )
 
     const shortcuts = useFuzzyShortcuts(props.settingsCascade.final)
@@ -85,7 +85,7 @@ export const FuzzyFinderContainer: React.FunctionComponent<FuzzyFinderContainerP
 
     // Disable the fuzzy finder if only the 'files' tab is enabled and we're not
     // in a repository-related page.
-    if (tabs.isOnlyFilesEnabled() && !fuzzyIsActive(activeTab, repoRevision, 'files')) {
+    if (tabs.isOnlyFilesEnabled() && !fuzzyIsActive(activeTab, 'files')) {
         return null
     }
 

--- a/client/web/src/components/fuzzyFinder/FuzzyFinderFeatureFlag.ts
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinderFeatureFlag.ts
@@ -16,7 +16,7 @@ export function getFuzzyFinderFeatureFlags(
         fuzzyFinderSymbols,
         fuzzyFinderNavbar,
     } = getExperimentalFeatures(finalSettings)
-    fuzzyFinderActions = fuzzyFinderAll || fuzzyFinderActions
+    // Intentionally skip "Actions" when `fuzzyFinderAll` is true
     fuzzyFinderRepositories = fuzzyFinderAll || fuzzyFinderRepositories
     fuzzyFinderNavbar = fuzzyFinderAll || fuzzyFinderNavbar
     fuzzyFinderSymbols = fuzzyFinderAll || fuzzyFinderSymbols

--- a/client/web/src/components/fuzzyFinder/FuzzyFsm.ts
+++ b/client/web/src/components/fuzzyFinder/FuzzyFsm.ts
@@ -35,6 +35,7 @@ export interface Empty {
 }
 export interface Downloading {
     key: 'downloading'
+    downloading?: SearchIndexing
 }
 export interface Indexing {
     key: 'indexing'

--- a/client/web/src/components/fuzzyFinder/FuzzyLocalCache.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyLocalCache.tsx
@@ -9,7 +9,7 @@ import { SymbolKind } from '../../graphql-operations'
  */
 export interface PersistableQueryResult {
     text: string
-    url: string
+    url?: string
     symbolKind?: SymbolKind
 }
 

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
@@ -6,6 +6,7 @@
     // It can be removed after addressing the following issue:
     // https://github.com/sourcegraph/sourcegraph/issues/42217
     width: 80vw !important;
+    background-color: var(--body-bg);
 }
 
 .content {
@@ -18,7 +19,6 @@
 .header {
     display: flex;
     justify-content: space-between;
-    padding-bottom: 0.25rem;
     margin-bottom: 0.5rem;
     border-bottom: 1px solid var(--border-color);
 }
@@ -33,6 +33,7 @@
     text-align: left;
     list-style-type: none;
     padding: unset;
+    margin-bottom: 0;
 }
 
 .focused {
@@ -40,6 +41,9 @@
     background-color: var(--color-bg-2);
 }
 
+.bottom-summary {
+    border-top: 1px solid var(--border-color-2);
+}
 .summary {
     display: flex;
     margin-bottom: 0.5rem;
@@ -48,6 +52,9 @@
         flex-direction: column;
         gap: 0.5rem;
     }
+}
+.summary > * {
+    flex: 1;
 }
 
 .search-query {
@@ -67,16 +74,21 @@
     align-self: center;
 }
 
-.tab:hover {
-    cursor: pointer;
-}
 .tab {
-    flex: 2 1 auto;
-    padding-top: 0.5rem;
+    gap: 4px;
+}
+.right-aligned {
+    text-align: right;
 }
 .tab-centered-text {
     text-align: center;
 }
 .active-tab {
     background-color: var(--color-bg-2);
+}
+
+.fuzzy-scope-selector {
+    width: fit-content;
+    margin-left: auto;
+    margin-bottom: 0;
 }

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -1,21 +1,42 @@
-import React, { useState, useEffect, useMemo, KeyboardEvent, useLayoutEffect, useCallback } from 'react'
+import React, {
+    useState,
+    useEffect,
+    useMemo,
+    KeyboardEvent,
+    useLayoutEffect,
+    useCallback,
+    SetStateAction,
+    Dispatch,
+} from 'react'
 
 import { mdiClose } from '@mdi/js'
 import classNames from 'classnames'
 import * as H from 'history'
 
 import { pluralize } from '@sourcegraph/common'
-import { KeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts'
 import { KEYBOARD_SHORTCUTS } from '@sourcegraph/shared/src/keyboardShortcuts/keyboardShortcuts'
-import { Button, Modal, Icon, H3, Text, Input, useSessionStorage, Code, Link, Checkbox } from '@sourcegraph/wildcard'
+import {
+    Button,
+    Modal,
+    Icon,
+    Text,
+    Input,
+    useSessionStorage,
+    Code,
+    Link,
+    Tabs,
+    Tab,
+    LoadingSpinner,
+    Select,
+    H3,
+} from '@sourcegraph/wildcard'
 
 import { AggregateFuzzySearch } from '../../fuzzyFinder/AggregateFuzzySearch'
 import { FuzzySearch, FuzzySearchResult } from '../../fuzzyFinder/FuzzySearch'
 import { mergedHandler } from '../../fuzzyFinder/WordSensitiveFuzzySearch'
 import { Keybindings } from '../KeyboardShortcutsHelp/KeyboardShortcutsHelp'
 
-import { FuzzyRepoRevision } from './FuzzyRepoRevision'
-import { fuzzyErrors, FuzzyState, fuzzyIsActive, FuzzyTabs, FuzzyTabKey } from './FuzzyTabs'
+import { fuzzyErrors, FuzzyState, FuzzyTabs, FuzzyTabKey, FuzzyScope } from './FuzzyTabs'
 import { HighlightedLink, linkStyle } from './HighlightedLink'
 
 import styles from './FuzzyModal.module.scss'
@@ -44,6 +65,7 @@ function cleanupOldLocalStorage(): void {
 
 interface RenderProps {
     query: string
+    renderCount: number
     result: FuzzySearchResult
     resultCount: number
     isComplete: boolean
@@ -53,21 +75,25 @@ interface QueryResult extends RenderProps {
     jsxElement: JSX.Element
 }
 
-function newFuzzySearch(activeTab: FuzzyTabKey, repoRevision: FuzzyRepoRevision, tabs: FuzzyTabs): FuzzySearch {
+function newFuzzySearch(query: string, activeTab: FuzzyTabKey, scope: FuzzyScope, tabs: FuzzyTabs): FuzzySearch {
     const searches: FuzzySearch[] = []
-    for (const [key, tab] of tabs.entries()) {
-        if (!fuzzyIsActive(activeTab, repoRevision, key)) {
+    for (const tab of tabs.fsms) {
+        if (!tab.isActive(activeTab, scope)) {
             continue
         }
-        if (!tab.fsm) {
-            continue
-        }
-        switch (tab.fsm.key) {
+        tab.onQuery?.(query) // trigger downloads
+        const fsm = tab.fsm()
+        switch (fsm.key) {
+            case 'downloading':
+                if (fsm.downloading?.partialFuzzy) {
+                    searches.push(fsm.downloading.partialFuzzy)
+                }
+                break
             case 'indexing':
-                searches.push(tab.fsm.indexing.partialFuzzy)
+                searches.push(fsm.indexing.partialFuzzy)
                 break
             case 'ready':
-                searches.push(tab.fsm.fuzzy)
+                searches.push(fsm.fuzzy)
         }
     }
     if (searches.length === 1) {
@@ -79,28 +105,45 @@ function newFuzzySearch(activeTab: FuzzyTabKey, repoRevision: FuzzyRepoRevision,
 function fuzzySearch(
     query: string,
     activeTab: FuzzyTabKey,
-    repoRevision: FuzzyRepoRevision,
+    scope: FuzzyScope,
     maxResults: number,
-    tabs: FuzzyTabs
+    tabs: FuzzyTabs,
+    renderCount: number
 ): RenderProps {
-    const search = newFuzzySearch(activeTab, repoRevision, tabs)
+    const search = newFuzzySearch(query, activeTab, scope, tabs)
     const start = window.performance.now()
     const result = search.search({ query, maxResults })
     result.elapsedMilliseconds = window.performance.now() - start
     return {
         result,
         query,
+        renderCount,
         resultCount: Math.min(maxResults, result.links.length),
         isComplete: result.isComplete,
         totalFileCount: search.totalFileCount,
     }
 }
 
-function renderFuzzyResults(props: RenderProps, focusIndex: number, onClickItem: () => void): QueryResult {
+function renderFuzzyResults(
+    props: RenderProps,
+    focusIndex: number,
+    maxResults: number,
+    initialMaxResults: number,
+    setMaxResults: Dispatch<SetStateAction<number>>,
+    onClickItem: () => void
+): QueryResult {
     if (props.result.links.length === 0) {
         return {
             ...props,
-            jsxElement: <Text>No matches for '{props.query}'</Text>,
+            jsxElement: (
+                // renderCount does not serve any purpose but to trigger
+                // re-renders when background data changes.  We use renderCount
+                // in this component just to ensure that updates to this state
+                // propagate all the way to the computation of QueryResult.
+                <Text data-render-count={props.renderCount} className={styles.results}>
+                    No matches for '{props.query}'
+                </Text>
+            ),
         }
     }
 
@@ -118,6 +161,15 @@ function renderFuzzyResults(props: RenderProps, focusIndex: number, onClickItem:
                     <HighlightedLink {...file} onClick={mergedHandler(file.onClick, onClickItem)} />
                 </li>
             ))}
+            {!props.isComplete && (
+                <Button
+                    className={styles.showMore}
+                    onClick={() => setMaxResults(maxResults + initialMaxResults)}
+                    variant="secondary"
+                >
+                    Show more
+                </Button>
+            )}
         </ul>
     )
     return {
@@ -131,6 +183,7 @@ function emptyResults(element: JSX.Element): QueryResult {
         query: '',
         result: { isComplete: true, links: [] },
         resultCount: 0,
+        renderCount: 0,
         isComplete: true,
         totalFileCount: 0,
         jsxElement: element,
@@ -144,13 +197,18 @@ function emptyResults(element: JSX.Element): QueryResult {
  */
 export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyModalProps>> = props => {
     const {
+        initialMaxResults,
         onClose,
         onClickItem,
+        renderCount,
         query,
         setQuery,
+        tabs,
+        isScopeToggleDisabled,
+        setScope,
+        scope,
         activeTab,
         setActiveTab,
-        repoRevision,
         repoRevision: { repositoryName, revision },
     } = props
     // The "focus index" is the index of the file result that the user has
@@ -167,27 +225,41 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
     // repositories, a generic query like "src" may return thousands of results
     // making DOM rendering slow.  The user can increase this number by clicking
     // on a button at the bottom of the result list.
-    const [maxResults, setMaxResults] = useState(props.initialMaxResults)
+    const [maxResults, setMaxResults] = useState(initialMaxResults)
 
     // Stage 1: compute fuzzy results. Most importantly, this stage does not
     // depend on `focusIndex` so that we avoid re-running the fuzzy finder
     // whenever the user presses up/down to cycle through the results.
     const fuzzySearchResult = useMemo<RenderProps>(
-        () => fuzzySearch(query, activeTab, repoRevision, maxResults, props.tabs),
-        [maxResults, query, activeTab, repoRevision, props.tabs]
+        () => fuzzySearch(query, activeTab, scope, maxResults, tabs, renderCount),
+        [renderCount, maxResults, query, activeTab, scope, tabs]
     )
 
     // Stage 2: render results from the fuzzy matcher.
     const queryResult = useMemo<QueryResult>(() => {
-        if (props.tabs.isDownloading()) {
-            return emptyResults(<Text>Downloading...</Text>)
-        }
-        const fsmErrors = fuzzyErrors(props.tabs, activeTab, repoRevision)
+        const fsmErrors = fuzzyErrors(tabs, activeTab, scope)
         if (fsmErrors.length > 0) {
             return emptyResults(<Text>Error: {JSON.stringify(fsmErrors)}</Text>)
         }
-        return renderFuzzyResults(fuzzySearchResult, focusIndex, onClickItem)
-    }, [activeTab, repoRevision, fuzzySearchResult, focusIndex, onClickItem, props.tabs])
+        return renderFuzzyResults(
+            fuzzySearchResult,
+            focusIndex,
+            maxResults,
+            initialMaxResults,
+            setMaxResults,
+            onClickItem
+        )
+    }, [
+        activeTab,
+        scope,
+        fuzzySearchResult,
+        focusIndex,
+        maxResults,
+        initialMaxResults,
+        setMaxResults,
+        onClickItem,
+        tabs,
+    ])
 
     // Sets the new "focus index" so that it's rounded by the number of
     // displayed filenames.  Cycles so that the user can press-hold the down
@@ -249,50 +321,38 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
                     }
                     break
                 case event.key === 'Tab':
-                    if (props.tabs.isOnlyFilesEnabled()) {
+                    if (tabs.isOnlyFilesEnabled()) {
                         break
                     }
                     event.preventDefault()
-                    setActiveTab(props.tabs.focusTabWithIncrement(activeTab, event.shiftKey ? -1 : 1))
+                    setActiveTab(tabs.focusTabWithIncrement(activeTab, event.shiftKey ? -1 : 1))
                 default:
             }
         },
-        [activeTab, setActiveTab, props, onClose, queryResult, focusIndex, setRoundedFocusIndex]
+        [activeTab, setActiveTab, onClose, queryResult, focusIndex, setRoundedFocusIndex, tabs]
     )
 
     return (
         <Modal position="center" className={styles.modal} onDismiss={() => onClose()} aria-label="Fuzzy finder">
             <div className={styles.content}>
                 <div className={styles.header} data-testid="fuzzy-modal-header">
-                    {props.tabs.entries().map(([key, tab]) => (
-                        <div
-                            key={tab.title}
-                            className={classNames(
-                                'mb-0',
-                                styles.tab,
-                                styles.tab,
-                                !props.tabs.isOnlyFilesEnabled() ? styles.tabCenteredText : '',
-                                !props.tabs.isOnlyFilesEnabled() && activeTab === key ? styles.activeTab : ''
-                            )}
+                    {tabs.isOnlyFilesEnabled() ? (
+                        <H3>Files</H3>
+                    ) : (
+                        <Tabs
+                            size="large"
+                            index={tabs.activeIndex(activeTab)}
+                            onFocus={() => focusFuzzyInput()}
+                            onChange={index => setActiveTab(tabs.focusTab(index))}
                         >
-                            <H3
-                                role="link"
-                                onClick={() => {
-                                    const input = document.querySelector<HTMLInputElement>('#fuzzy-modal-input')
-                                    if (input) {
-                                        const nextActiveTab = props.tabs.focusNamedTab(key)
-                                        if (nextActiveTab) {
-                                            setActiveTab(nextActiveTab)
-                                            input.focus()
-                                        }
-                                    }
-                                }}
-                            >
-                                {props.tabs.isOnlyFilesEnabled() ? 'Find files' : tab.title}
-                                {!props.tabs.isOnlyFilesEnabled() && tab?.shortcut}
-                            </H3>
-                        </div>
-                    ))}
+                            {tabs.entries().map(([key, tab]) => (
+                                <Tab key={key} className={styles.tab}>
+                                    {tab.title}
+                                    {tab?.plaintextShortcut && ' ' + tab.plaintextShortcut}
+                                </Tab>
+                            ))}
+                        </Tabs>
+                    )}
                     <Button variant="icon" onClick={() => onClose()} aria-label="Close">
                         <Icon className={styles.closeIcon} aria-hidden={true} svgPath={mdiClose} />
                     </Button>
@@ -306,7 +366,7 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
                     aria-autocomplete="list"
                     aria-controls={FUZZY_MODAL_RESULTS}
                     aria-owns={FUZZY_MODAL_RESULTS}
-                    aria-expanded={props.tabs.isDownloading()}
+                    aria-expanded={tabs.isDownloading(activeTab, scope)}
                     aria-activedescendant={fuzzyResultId(focusIndex)}
                     onFocus={input => input.target.select()}
                     className={styles.input}
@@ -319,19 +379,25 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
                     onKeyDown={onInputKeyDown}
                 />
                 <div className={styles.summary}>
-                    <FuzzyResultsSummary tabs={props.tabs} queryResult={queryResult} />
+                    <FuzzyResultsSummary activeTab={activeTab} scope={scope} tabs={tabs} queryResult={queryResult} />
+                    {!tabs.isOnlyFilesEnabled() && (
+                        <span className={classNames(styles.fuzzyScopeSelector)}>
+                            <ScopeSelect
+                                activeTab={activeTab}
+                                scope={scope}
+                                isScopeToggleDisabled={isScopeToggleDisabled}
+                                setScope={setScope}
+                            />
+                        </span>
+                    )}
                 </div>
-                {!props.tabs.isOnlyFilesEnabled() && <div className={styles.summary}>{searchQuery(props)}</div>}
                 {queryResult.jsxElement}
-                {!queryResult.isComplete && (
-                    <Button
-                        className={styles.showMore}
-                        onClick={() => setMaxResults(maxResults + props.initialMaxResults)}
-                        variant="secondary"
-                    >
-                        Show more
-                    </Button>
-                )}
+                <div className={classNames(styles.summary, styles.bottomSummary)}>
+                    <SearchQueryLink {...props} />
+                    <span className={styles.rightAligned}>
+                        <ArrowKeyExplanation />
+                    </span>
+                </div>
             </div>
         </Modal>
     )
@@ -341,114 +407,157 @@ function plural(what: string, count: number, isComplete: boolean): string {
     return `${count.toLocaleString()}${isComplete ? '' : '+'} ${pluralize(what, count)}`
 }
 
-function searchQueryLink(
-    what: string,
-    query: string,
-    onClick: () => void,
-    shortcut?: KeyboardShortcut,
-    isToggleEnabled?: boolean,
-    isToggleDisabled?: boolean,
-    onClickToggle?: () => void
-): JSX.Element {
-    const searchParams = new URLSearchParams()
-    searchParams.set('q', query)
-    const url = `/search?${searchParams.toString()}`
-    return (
-        <span className={styles.searchQuery}>
-            <Code>
-                <Link to={url} onClick={onClick}>
-                    {query}
-                </Link>{' '}
-            </Code>
-            {what && (
-                <Checkbox
-                    id={`fuzzy-query-${what}`}
-                    checked={isToggleEnabled}
-                    disabled={isToggleDisabled}
-                    label="Search everywhere"
-                    onClick={onClickToggle}
-                />
-            )}
-            {what && shortcut?.keybindings && (
-                <Keybindings uppercaseOrdered={true} keybindings={shortcut.keybindings} />
-            )}
-        </span>
-    )
+const ArrowKeyExplanation: React.FunctionComponent = () => (
+    <i className="text-muted">
+        Press <kbd>↑</kbd>
+        <kbd>↓</kbd> to navigate through results
+    </i>
+)
+
+interface ScopeSelectProps {
+    activeTab: FuzzyTabKey
+    scope: FuzzyScope
+    setScope: Dispatch<SetStateAction<FuzzyScope>>
+    isScopeToggleDisabled: boolean
 }
 
-function repoFilter(state: FuzzyState): string {
-    const isGlobal = !state.repoRevision.repositoryName
-    const revision = state.repoRevision.revision ? `@${state.repoRevision.revision}` : ''
-    return isGlobal ? '' : `repo:${state.repoRevision.repositoryName}${revision} `
-}
-
-function searchQuery(state: FuzzyState): JSX.Element {
-    switch (state.activeTab) {
-        case 'symbols':
-            return searchQueryLink(
-                'symbols',
-                `${state.isGlobalSymbols ? '' : repoFilter(state)}type:symbol ${state.query}`,
-                state.onClickItem,
-                KEYBOARD_SHORTCUTS.fuzzyFinderSymbols,
-                !state.repoRevision.repositoryName || state.isGlobalSymbols,
-                !state.repoRevision.repositoryName,
-                state.toggleGlobalSymbols
-            )
+const ToggleShortcut: React.FunctionComponent<{ activeTab: FuzzyTabKey }> = ({ activeTab }) => {
+    switch (activeTab) {
+        case 'all':
+            return <Keybindings uppercaseOrdered={true} keybindings={KEYBOARD_SHORTCUTS.fuzzyFinder.keybindings} />
         case 'files':
-            return searchQueryLink(
-                'files',
-                `${state.isGlobalFiles ? '' : repoFilter(state)}type:path ${state.query}`,
-                state.onClickItem,
-                KEYBOARD_SHORTCUTS.fuzzyFinderFiles,
-                !state.repoRevision.repositoryName || state.isGlobalFiles,
-                !state.repoRevision.repositoryName,
-                state.toggleGlobalFiles
+            return <Keybindings uppercaseOrdered={true} keybindings={KEYBOARD_SHORTCUTS.fuzzyFinderFiles.keybindings} />
+        case 'symbols':
+            return (
+                <Keybindings uppercaseOrdered={true} keybindings={KEYBOARD_SHORTCUTS.fuzzyFinderSymbols.keybindings} />
             )
-        case 'repos':
-            return searchQueryLink('', `type:repo ${state.query}`, state.onClickItem)
         default:
             return <></>
     }
 }
 
+const ScopeSelect: React.FunctionComponent<ScopeSelectProps> = ({
+    activeTab,
+    scope,
+    setScope,
+    isScopeToggleDisabled,
+}) => (
+    <Select
+        label=""
+        isCustomStyle={true}
+        id="fuzzy-scope"
+        value={scope}
+        onFocus={() => focusFuzzyInput()}
+        selectSize="sm"
+        className={styles.fuzzyScopeSelector}
+        disabled={isScopeToggleDisabled}
+        onChange={value => {
+            switch (value.target.value) {
+                case 'everywhere':
+                case 'repository':
+                    setScope(value.target.value)
+            }
+        }}
+    >
+        <option value="everywhere">
+            <ToggleShortcut activeTab={activeTab} /> Search everywhere
+        </option>
+        <option value="repository">
+            <ToggleShortcut activeTab={activeTab} /> Search in this repository
+        </option>
+    </Select>
+)
+
+const SearchQueryLink: React.FunctionComponent<FuzzyState> = props => {
+    const { onClickItem, scope } = props
+    const searchQueryLink = useCallback(
+        (query: string): JSX.Element => {
+            const searchParams = new URLSearchParams()
+            searchParams.set('q', query)
+            const url = `/search?${searchParams.toString()}`
+            return (
+                <Code>
+                    <Link to={url} onClick={onClickItem}>
+                        {query}
+                    </Link>{' '}
+                </Code>
+            )
+        },
+        [onClickItem]
+    )
+    const isScopeEverywhere = scope === 'everywhere'
+    switch (props.activeTab) {
+        case 'symbols':
+            return searchQueryLink(`type:symbol ${props.query}${isScopeEverywhere ? '' : repoFilter(props)}`)
+        case 'files':
+            return searchQueryLink(`type:path ${props.query}${isScopeEverywhere ? '' : repoFilter(props)}`)
+        case 'repos':
+            return searchQueryLink(`type:repo ${props.query}`)
+        case 'all':
+            return searchQueryLink(`${props.query}${isScopeEverywhere ? '' : repoFilter(props)}`)
+        default:
+            return <></>
+    }
+}
+
+function repoFilter(state: FuzzyState): string {
+    const isGlobal = !state.repoRevision.repositoryName
+    const revision = state.repoRevision.revision ? `@${state.repoRevision.revision}` : ''
+    return isGlobal ? '' : ` repo:${state.repoRevision.repositoryName}${revision}`
+}
+
 interface FuzzyResultsSummaryProps {
+    activeTab: FuzzyTabKey
+    scope: FuzzyScope
     tabs: FuzzyTabs
     queryResult: QueryResult
 }
 
 const FuzzyResultsSummary: React.FunctionComponent<React.PropsWithChildren<FuzzyResultsSummaryProps>> = ({
+    activeTab,
+    scope,
     tabs,
     queryResult,
-}) => (
-    <>
-        <span data-testid="fuzzy-modal-summary" className={styles.resultCount}>
-            {plural('result', queryResult.resultCount, queryResult.isComplete)} - {indexingProgressBar(tabs)}{' '}
-            {plural('total', queryResult.totalFileCount, true)}
-        </span>
-        <i className="text-muted">
-            <kbd>↑</kbd> and <kbd>↓</kbd> arrow keys browse. <kbd>⏎</kbd> selects.
-        </i>
-    </>
-)
-
-function indexingProgressBar(tabs: FuzzyTabs): JSX.Element {
+}) => {
     let indexedFiles = 0
     let totalFiles = 0
-    for (const [, tab] of tabs.entries()) {
-        if (!tab.fsm) {
+    const downloadingTabs: string[] = []
+    for (const tab of tabs.fsms) {
+        if (!tab.isActive(activeTab, scope)) {
             continue
         }
-        if (tab.fsm.key === 'indexing') {
-            indexedFiles += tab.fsm.indexing.indexedFileCount
-            totalFiles += tab.fsm.indexing.totalFileCount
+        const fsm = tab.fsm()
+        if (fsm.key === 'downloading') {
+            downloadingTabs.push(tab.key)
+        }
+        if (fsm.key === 'indexing') {
+            indexedFiles += fsm.indexing.indexedFileCount
+            totalFiles += fsm.indexing.totalFileCount
         }
     }
-    if (indexedFiles === 0 && totalFiles === 0) {
+    return (
+        <>
+            <span data-testid="fuzzy-modal-summary" className={styles.resultCount}>
+                {plural('result', queryResult.resultCount, queryResult.isComplete)} out of{' '}
+                {plural('total', queryResult.totalFileCount, true)}
+                <ProgressBar value={indexedFiles} max={totalFiles} />
+                {downloadingTabs.length > 0 && <LoadingSpinner />}
+            </span>
+        </>
+    )
+}
+
+interface ProgressBarProps {
+    value: number
+    max: number
+}
+const ProgressBar: React.FunctionComponent<ProgressBarProps> = ({ value, max }) => {
+    if (max === 0) {
         return <></>
     }
-    const percentage = Math.round((indexedFiles / totalFiles) * 100)
+    const percentage = Math.round((value / max) * 100)
     return (
-        <progress value={indexedFiles} max={totalFiles}>
+        <progress value={value} max={max}>
             {percentage}%
         </progress>
     )
@@ -456,4 +565,10 @@ function indexingProgressBar(tabs: FuzzyTabs): JSX.Element {
 
 function fuzzyResultId(id: number): string {
     return `fuzzy-modal-result-${id}`
+}
+
+function focusFuzzyInput(): void {
+    // Redirect the focus to the fuzzy search bar
+    const input = document.querySelector<HTMLInputElement>('#fuzzy-modal-input')
+    input?.focus()
 }

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -337,7 +337,7 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
             <div className={styles.content}>
                 <div className={styles.header} data-testid="fuzzy-modal-header">
                     {tabs.isOnlyFilesEnabled() ? (
-                        <H3>Files</H3>
+                        <H3>Find files</H3>
                     ) : (
                         <Tabs
                             size="large"

--- a/client/web/src/components/fuzzyFinder/FuzzyRepos.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyRepos.tsx
@@ -29,7 +29,7 @@ export class FuzzyRepos extends FuzzyQuery {
     }
 
     /* override */ protected rawQuery(query: string): string {
-        return `type:repo count:10 ${query.replace('/', '.*/.*')}`
+        return `type:repo count:100 ${query.replace('/', '.*/.*')}`
     }
 
     /* override */ protected searchValues(): SearchValue[] {

--- a/client/web/src/components/fuzzyFinder/FuzzySymbols.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzySymbols.tsx
@@ -48,7 +48,7 @@ export class FuzzySymbols extends FuzzyQuery {
         private readonly client: ApolloClient<object> | undefined,
         onNamesChanged: () => void,
         private readonly repoRevision: React.MutableRefObject<FuzzyRepoRevision>,
-        private readonly isGlobalSymbolsRef: React.MutableRefObject<boolean>
+        private readonly isGlobalSymbols: boolean
     ) {
         // Symbol results should not be cached because stale symbol data is complicated to evict/invalidate.
         super(onNamesChanged, emptyFuzzyCache)
@@ -56,7 +56,7 @@ export class FuzzySymbols extends FuzzyQuery {
 
     /* override */ protected searchValues(): SearchValue[] {
         const repositoryName = this.repoRevision.current.repositoryName
-        const repositoryFilter = repositoryName && !this.isGlobalSymbolsRef.current ? '/' + repositoryName : ''
+        const repositoryFilter = repositoryName && !this.isGlobalSymbols ? '/' + repositoryName : ''
         let values = [...this.queryResults.values()]
         if (repositoryFilter) {
             values = values.filter(({ url }) => url?.startsWith(repositoryFilter))
@@ -71,10 +71,8 @@ export class FuzzySymbols extends FuzzyQuery {
     }
 
     /* override */ protected rawQuery(query: string): string {
-        const repoFilter = this.isGlobalSymbolsRef.current
-            ? ''
-            : fuzzyRepoRevisionSearchFilter(this.repoRevision.current)
-        return `${repoFilter}type:symbol count:10 ${query}`
+        const repoFilter = this.isGlobalSymbols ? '' : fuzzyRepoRevisionSearchFilter(this.repoRevision.current)
+        return `${repoFilter}type:symbol count:100 ${query}`
     }
 
     /* override */ protected async handleRawQueryPromise(query: string): Promise<PersistableQueryResult[]> {

--- a/client/web/src/components/fuzzyFinder/FuzzyTabs.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyTabs.tsx
@@ -8,12 +8,11 @@ import { Settings, SettingsCascadeOrError } from '@sourcegraph/shared/src/settin
 import { toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
 import { useSessionStorage } from '@sourcegraph/wildcard'
 
-import { SearchIndexing } from '../../fuzzyFinder/FuzzySearch'
 import { parseBrowserRepoURL } from '../../util/url'
-import { Keybindings } from '../KeyboardShortcutsHelp/KeyboardShortcutsHelp'
+import { Keybindings, plaintextKeybindings } from '../KeyboardShortcutsHelp/KeyboardShortcutsHelp'
 
-import { createActionsFSM, getAllFuzzyActions, FuzzyActionProps } from './FuzzyActions'
-import { FuzzyFiles, loadFilesFSM } from './FuzzyFiles'
+import { createActionsFSM, FuzzyActionProps, getAllFuzzyActions } from './FuzzyActions'
+import { FuzzyFiles, FuzzyRepoFiles } from './FuzzyFiles'
 import { getFuzzyFinderFeatureFlags } from './FuzzyFinderFeatureFlag'
 import { FuzzyFSM } from './FuzzyFsm'
 import { FuzzyRepoRevision } from './FuzzyRepoRevision'
@@ -25,38 +24,43 @@ class Tab {
         public readonly title: string,
         public readonly isEnabled: boolean,
         public readonly shortcut?: JSX.Element,
-        public readonly fsm?: FuzzyFSM
+        public readonly plaintextShortcut?: string
     ) {}
-    public withFSM(fsm: FuzzyFSM): Tab {
-        return new Tab(this.title, this.isEnabled, this.shortcut, fsm)
-    }
+    // public withFSM(fsm: FuzzyFSM): Tab {
+    //     return new Tab(this.title, this.isEnabled, this.shortcut, this.plaintextShortcut, fsm)
+    // }
 }
 
 const defaultTabs: Tabs = {
     all: new Tab(
         'All',
         true,
-        <Keybindings uppercaseOrdered={true} keybindings={KEYBOARD_SHORTCUTS.fuzzyFinder.keybindings} />
+        <Keybindings uppercaseOrdered={true} keybindings={KEYBOARD_SHORTCUTS.fuzzyFinder.keybindings} />,
+        plaintextKeybindings(KEYBOARD_SHORTCUTS.fuzzyFinder.keybindings)
     ),
     actions: new Tab(
         'Actions',
         true,
-        <Keybindings uppercaseOrdered={true} keybindings={KEYBOARD_SHORTCUTS.fuzzyFinderActions.keybindings} />
+        <Keybindings uppercaseOrdered={true} keybindings={KEYBOARD_SHORTCUTS.fuzzyFinderActions.keybindings} />,
+        plaintextKeybindings(KEYBOARD_SHORTCUTS.fuzzyFinderActions.keybindings)
     ),
     repos: new Tab(
         'Repos',
         true,
-        <Keybindings uppercaseOrdered={true} keybindings={KEYBOARD_SHORTCUTS.fuzzyFinderRepos.keybindings} />
+        <Keybindings uppercaseOrdered={true} keybindings={KEYBOARD_SHORTCUTS.fuzzyFinderRepos.keybindings} />,
+        plaintextKeybindings(KEYBOARD_SHORTCUTS.fuzzyFinderRepos.keybindings)
     ),
     symbols: new Tab(
         'Symbols',
         true,
-        <Keybindings uppercaseOrdered={true} keybindings={KEYBOARD_SHORTCUTS.fuzzyFinderSymbols.keybindings} />
+        <Keybindings uppercaseOrdered={true} keybindings={KEYBOARD_SHORTCUTS.fuzzyFinderSymbols.keybindings} />,
+        plaintextKeybindings(KEYBOARD_SHORTCUTS.fuzzyFinderSymbols.keybindings)
     ),
     files: new Tab(
         'Files',
         true,
-        <Keybindings uppercaseOrdered={true} keybindings={KEYBOARD_SHORTCUTS.fuzzyFinderFiles.keybindings} />
+        <Keybindings uppercaseOrdered={true} keybindings={KEYBOARD_SHORTCUTS.fuzzyFinderFiles.keybindings} />,
+        plaintextKeybindings(KEYBOARD_SHORTCUTS.fuzzyFinderFiles.keybindings)
     ),
     lines: new Tab('Lines', true),
 }
@@ -74,6 +78,22 @@ interface Tabs {
 
 export type FuzzyTabKey = keyof Tabs
 
+export type FuzzyScope = 'everywhere' | 'repository'
+
+export class FuzzyTabFSM {
+    constructor(
+        public readonly key: FuzzyTabKey,
+        public readonly scope: FuzzyScope | 'always',
+        public readonly fsm: () => FuzzyFSM,
+        public readonly onQuery?: (query: string) => void
+    ) {}
+    public isActive(activeTab: FuzzyTabKey, scope: FuzzyScope): boolean {
+        const isScopeMatch = this.scope === 'always' || this.scope === scope
+        const isTabMatch = activeTab === 'all' || this.key === activeTab
+        return isScopeMatch && isTabMatch
+    }
+}
+
 export interface FuzzyState {
     activeTab: FuzzyTabKey
     setActiveTab: Dispatch<SetStateAction<FuzzyTabKey>>
@@ -81,38 +101,39 @@ export interface FuzzyState {
     setQuery: Dispatch<SetStateAction<string>>
     repoRevision: FuzzyRepoRevision
     tabs: FuzzyTabs
+    setScope: Dispatch<SetStateAction<FuzzyScope>>
+    isScopeToggleDisabled: boolean
+    scope: FuzzyScope
+    renderCount: number // hidden number to trigger re-render
+    toggleScope: () => void
     onClickItem: () => void
-    isGlobalFiles: boolean
-    toggleGlobalFiles: () => void
-    isGlobalSymbols: boolean
-    toggleGlobalSymbols: () => void
 }
 
-export function fuzzyIsActive(activeTab: FuzzyTabKey, repoRevision: FuzzyRepoRevision, tab: FuzzyTabKey): boolean {
+export function fuzzyIsActive(activeTab: FuzzyTabKey, tab: FuzzyTabKey): boolean {
     return activeTab === 'all' || tab === activeTab
 }
 
-export function fuzzyErrors(tabs: FuzzyTabs, activeTab: FuzzyTabKey, repoRevision: FuzzyRepoRevision): string[] {
+export function fuzzyErrors(tabs: FuzzyTabs, activeTab: FuzzyTabKey, scope: FuzzyScope): string[] {
     const result: string[] = []
-    for (const [key, tab] of tabs.entries()) {
-        if (!fuzzyIsActive(activeTab, repoRevision, key)) {
+    for (const tab of tabs.fsms) {
+        if (!tab.isActive(activeTab, scope)) {
             continue
         }
-        if (!tab.fsm) {
-            continue
-        }
-        if (tab.fsm.key === 'failed') {
-            result.push(tab.fsm.errorMessage)
+        const fsm = tab.fsm()
+        if (fsm.key === 'failed') {
+            result.push(fsm.errorMessage)
         }
     }
     return result
 }
 
 export class FuzzyTabs {
-    constructor(public readonly underlying: Tabs) {}
+    constructor(public readonly underlying: Tabs, public readonly fsms: FuzzyTabFSM[]) {}
+    public activeIndex(activeTab: FuzzyTabKey): number {
+        return this.entries().findIndex(([key]) => activeTab === key)
+    }
     public focusTabWithIncrement(activeTab: FuzzyTabKey, increment: number): FuzzyTabKey {
-        const activeIndex = this.entries().findIndex(([key]) => activeTab === key)
-        const nextIndex = activeIndex + increment
+        const nextIndex = this.activeIndex(activeTab) + increment
         return this.focusTab(nextIndex)
     }
     public focusNamedTab(tab: FuzzyTabKey): FuzzyTabKey | undefined {
@@ -134,9 +155,9 @@ export class FuzzyTabs {
         }
         return result
     }
-    public withTabs(newTabs: Partial<Tabs>): FuzzyTabs {
-        return new FuzzyTabs({ ...this.underlying, ...newTabs })
-    }
+    // public withTabs(newTabs: Partial<Tabs>): FuzzyTabs {
+    //     return new FuzzyTabs({ ...this.underlying, ...newTabs })
+    // }
     public all(): Tab[] {
         return Object.values(this.underlying).filter(tab => (tab as Tab).isEnabled)
     }
@@ -144,9 +165,8 @@ export class FuzzyTabs {
         const [[tab], ...rest] = this.entries()
         return rest.length === 0 && tab === 'files'
     }
-    public isDownloading(): boolean {
-        const downloadingFSM = this.all().find(tab => tab.fsm && tab.fsm.key === 'downloading')
-        return downloadingFSM !== undefined
+    public isDownloading(activeTab: FuzzyTabKey, scope: FuzzyScope): boolean {
+        return this.fsms.find(tab => tab.isActive(activeTab, scope) && tab.fsm().key === 'downloading') !== undefined
     }
     public isAllDisabled(): boolean {
         return this.all().length === 0
@@ -155,14 +175,11 @@ export class FuzzyTabs {
 
 export function defaultFuzzyState(): FuzzyState {
     let query = ''
+    let scope: FuzzyScope = 'repository'
     let activeTab: FuzzyTabKey = 'all'
     return {
         query,
         onClickItem: () => {},
-        isGlobalFiles: false,
-        toggleGlobalFiles: () => {},
-        isGlobalSymbols: false,
-        toggleGlobalSymbols: () => {},
         setQuery: newQuery => {
             if (typeof newQuery === 'function') {
                 query = newQuery(query)
@@ -179,7 +196,20 @@ export function defaultFuzzyState(): FuzzyState {
             }
         },
         repoRevision: { repositoryName: '', revision: '' },
-        tabs: new FuzzyTabs(defaultTabs),
+        tabs: new FuzzyTabs(defaultTabs, []),
+        renderCount: 0,
+        scope,
+        isScopeToggleDisabled: false,
+        setScope: newScope => {
+            if (typeof newScope === 'function') {
+                scope = newScope(scope)
+            } else {
+                scope = newScope
+            }
+        },
+        toggleScope: () => {
+            scope = scope === 'repository' ? 'everywhere' : 'repository'
+        },
     }
 }
 export interface FuzzyTabsProps extends FuzzyActionProps {
@@ -193,6 +223,7 @@ export interface FuzzyTabsProps extends FuzzyActionProps {
 
 export function useFuzzyState(props: FuzzyTabsProps, onClickItem: () => void): FuzzyState {
     const {
+        themeState,
         isVisible,
         location: { pathname, search, hash },
         isRepositoryRelatedPage,
@@ -223,18 +254,6 @@ export function useFuzzyState(props: FuzzyTabsProps, onClickItem: () => void): F
         fuzzyFinderSymbols,
     } = getFuzzyFinderFeatureFlags(props.settingsCascade.final)
 
-    const [globalFilesToggleCount, setGlobalFilesToggleCount] = useState(0)
-    const toggleGlobalFiles = useMemo(() => () => setGlobalFilesToggleCount(old => old + 1), [
-        setGlobalFilesToggleCount,
-    ])
-    const isGlobalFilesRef = useRef(false)
-    isGlobalFilesRef.current = globalFilesToggleCount % 2 === 1
-    const [isGlobalSymbols, setGlobalSymbols] = useState(false)
-    const toggleGlobalSymbols = useMemo(() => () => setGlobalSymbols(old => !old), [setGlobalSymbols])
-    const isGlobalSymbolsRef = useRef(isGlobalSymbols)
-    isGlobalSymbolsRef.current = isGlobalSymbols
-    const localFilesRef = useRef<FuzzyFSM | null>(null)
-
     // NOTE: the query is cached in session storage to mimic the file pickers in
     // IntelliJ (by default) and VS Code (when "Workbench > Quick Open >
     // Preserve Input" is enabled).
@@ -243,157 +262,23 @@ export function useFuzzyState(props: FuzzyTabsProps, onClickItem: () => void): F
     queryRef.current = query
     const [activeTab, setActiveTab] = useState<FuzzyTabKey>('all')
 
+    const [scope, setScope] = useState<FuzzyScope>('repository')
+    const toggleScope = useCallback(() => setScope(old => (old === 'repository' ? 'everywhere' : 'repository')), [
+        setScope,
+    ])
+    const isScopeToggleDisabled = activeTab === 'repos' || activeTab === 'actions' || !isRepositoryRelatedPage
+
     useEffect(() => {
-        setGlobalSymbols(false)
-        setGlobalFilesToggleCount(0)
-    }, [isVisible, activeTab, setGlobalFilesToggleCount, setGlobalSymbols])
+        setScope(isScopeToggleDisabled ? 'everywhere' : 'repository')
+    }, [isVisible, setScope, isScopeToggleDisabled])
 
-    const fuzzyState: Omit<FuzzyState, 'tabs'> = useMemo(
-        () => ({
-            onClickItem,
-            query,
-            setQuery,
-            activeTab,
-            setActiveTab,
-            repoRevision,
-            isGlobalFiles: globalFilesToggleCount % 2 === 1,
-            isGlobalSymbols,
-            toggleGlobalFiles,
-            toggleGlobalSymbols,
-        }),
-        [
-            onClickItem,
-            query,
-            setQuery,
-            activeTab,
-            repoRevision,
-            globalFilesToggleCount,
-            isGlobalSymbols,
-            toggleGlobalFiles,
-            toggleGlobalSymbols,
-        ]
-    )
-    const fuzzyStateRef = useRef(fuzzyState)
-    fuzzyStateRef.current = fuzzyState
+    const [renderCount, setRenderCount] = useState(0)
+    const triggerRender: () => void = useCallback(() => setRenderCount(old => old + 1), [setRenderCount])
 
-    const [tabs, setTabs] = useState<FuzzyTabs>(
-        () =>
-            new FuzzyTabs({
-                all: fuzzyFinderAll ? defaultTabs.all : hiddenKind,
-                actions: fuzzyFinderActions
-                    ? defaultTabs.actions.withFSM(createActionsFSM(getAllFuzzyActions(props)))
-                    : hiddenKind,
-                repos: fuzzyFinderRepositories ? defaultTabs.repos : hiddenKind,
-                symbols: fuzzyFinderSymbols ? defaultTabs.symbols : hiddenKind,
-                files: defaultTabs.files,
-                lines: hiddenKind,
-            })
-    )
+    // defaultTabs.actions.fsm = createActionsFSM(getAllFuzzyActions(props))
 
     const repoRevisionRef = useRef<FuzzyRepoRevision>({ repositoryName: '', revision: '' })
     repoRevisionRef.current = { repositoryName: repoName, revision }
-
-    const tabsRef = useRef(tabs)
-    tabsRef.current = tabs
-    const [globalFilesNameChangeCount, setGlobalFilesNameChangeCount] = useState(0)
-    const globalFilesRef = useRef<FuzzyFiles | null>(null)
-    if (globalFilesRef.current === null) {
-        globalFilesRef.current = new FuzzyFiles(
-            apolloClient,
-            () => setGlobalFilesNameChangeCount(oldCount => oldCount + 1),
-            repoRevisionRef,
-            isGlobalFilesRef
-        )
-    }
-
-    const [repositoryNameChangeCount, setRepositoryNameChangeCount] = useState(0)
-    const repositoriesRef = useRef<FuzzyRepos | null>(null)
-    if (fuzzyFinderRepositories && repositoriesRef.current === null) {
-        repositoriesRef.current = new FuzzyRepos(apolloClient, () =>
-            setRepositoryNameChangeCount(oldCount => oldCount + 1)
-        )
-    }
-    const hasDeletedStaleRepositories = useRef(false)
-    if (isVisible && !hasDeletedStaleRepositories.current) {
-        hasDeletedStaleRepositories.current = true
-        repositoriesRef.current?.removeStaleResults().then(
-            () => {},
-            () => {}
-        )
-    }
-
-    const [symbolsNameCount, setSymbolNameCount] = useState(0)
-    const symbolsRef = useRef<FuzzySymbols | null>(null)
-    if (fuzzyFinderSymbols && symbolsRef.current === null) {
-        symbolsRef.current = new FuzzySymbols(
-            apolloClient,
-            () => setSymbolNameCount(oldCount => oldCount + 1),
-            repoRevisionRef,
-            isGlobalSymbolsRef
-        )
-    }
-
-    useEffect(() => {
-        for (const [key, value] of tabs.entries()) {
-            if (!value.fsm) {
-                continue
-            }
-            if (value.fsm.key === 'indexing' && !value.fsm.indexing.isIndexing()) {
-                continueIndexing(value.fsm.indexing)
-                    .then(next => {
-                        const updatedTabs: Partial<Tabs> = {}
-                        updatedTabs[key] = value.withFSM(next)
-                        setTabs(tabsRef.current.withTabs(updatedTabs))
-                    })
-                    // eslint-disable-next-line no-console
-                    .catch(error => console.error(`failed to index fuzzy tab ${key}`, error))
-            }
-        }
-    }, [tabs])
-
-    useEffect(() => {
-        if (!isVisible) {
-            return
-        }
-        if (!fuzzyFinderSymbols) {
-            return
-        }
-        const isSymbolActive = fuzzyIsActive(activeTab, repoRevision, 'symbols')
-        if (!isSymbolActive) {
-            return
-        }
-        const symbols = symbolsRef.current
-        if (!symbols) {
-            return
-        }
-        setTabs(
-            tabsRef.current.withTabs({
-                symbols: tabsRef.current.underlying.symbols.withFSM(symbols.fuzzyFSM(query)),
-            })
-        )
-    }, [isGlobalSymbols, isVisible, activeTab, repoRevision, query, symbolsNameCount, fuzzyFinderSymbols])
-
-    useEffect(() => {
-        if (!isVisible) {
-            return
-        }
-        if (!fuzzyFinderRepositories) {
-            return
-        }
-        const isRepoActive = fuzzyIsActive(activeTab, repoRevision, 'repos')
-        if (!isRepoActive) {
-            return
-        }
-        const repositories = repositoriesRef.current
-        if (!repositories) {
-            return
-        }
-        setTabs(
-            tabsRef.current.withTabs({
-                repos: tabsRef.current.underlying.repos.withFSM(repositories.fuzzyFSM(query)),
-            })
-        )
-    }, [isVisible, activeTab, repoRevision, query, repositoryNameChangeCount, fuzzyFinderRepositories])
 
     const createURL = useCallback(
         (filename: string): string =>
@@ -404,69 +289,113 @@ export function useFuzzyState(props: FuzzyTabsProps, onClickItem: () => void): F
             }),
         [revision, repoName]
     )
+    // Actions
+    const actions = useMemo<FuzzyTabFSM>(() => {
+        const fsm = createActionsFSM(getAllFuzzyActions({ themeState }))
+        return new FuzzyTabFSM('actions', 'always', () => fsm)
+    }, [themeState])
 
-    const setFilesFSM = useCallback(
-        (fsm: FuzzyFSM) => {
-            setTabs(
-                tabsRef.current.withTabs({
-                    files: tabsRef.current.underlying.files.withFSM(fsm),
-                })
-            )
-        },
-        [setTabs]
-    )
-
-    useEffect(() => {
-        if (!isVisible) {
-            return
-        }
-        if (!repoRevision.repositoryName) {
-            return
-        }
-        setFilesFSM({ key: 'downloading' })
-        loadFilesFSM(apolloClient, repoRevision, createURL).then(
-            fsm => {
-                setFilesFSM(fsm)
-                localFilesRef.current = fsm
-            },
-            () => {}
+    // Repos
+    const repos = useMemo<FuzzyTabFSM>(() => {
+        const fsm = new FuzzyRepos(apolloClient, triggerRender)
+        return new FuzzyTabFSM(
+            'repos',
+            'everywhere',
+            () => fsm.fuzzyFSM(),
+            query => fsm.handleQuery(query)
         )
-    }, [isVisible, repoRevision, apolloClient, createURL, setFilesFSM])
+    }, [apolloClient, triggerRender])
 
-    useEffect(() => {
-        if (!isVisible) {
-            return
-        }
-        if (repoRevision.repositoryName) {
-            return
-        }
-        if (!globalFilesRef.current) {
-            return
-        }
-        setFilesFSM(globalFilesRef.current.fuzzyFSM(query))
-    }, [query, globalFilesNameChangeCount, isVisible, repoRevision, setFilesFSM])
+    // Symbols
+    const localSymbols = useMemo<FuzzyTabFSM>(() => {
+        const fsm = new FuzzySymbols(apolloClient, triggerRender, repoRevisionRef, false)
+        return new FuzzyTabFSM(
+            'symbols',
+            'repository',
+            () => fsm.fuzzyFSM(),
+            query => fsm.handleQuery(query)
+        )
+    }, [apolloClient, triggerRender])
+    const globalSymbols = useMemo<FuzzyTabFSM>(() => {
+        const fsm = new FuzzySymbols(apolloClient, triggerRender, repoRevisionRef, true)
+        return new FuzzyTabFSM(
+            'symbols',
+            'everywhere',
+            () => fsm.fuzzyFSM(),
+            query => fsm.handleQuery(query)
+        )
+    }, [apolloClient, triggerRender])
 
-    useEffect(() => {
-        if (globalFilesToggleCount === 0) {
-            return
-        }
-        if (isGlobalFilesRef.current && globalFilesRef.current) {
-            setFilesFSM(globalFilesRef.current.fuzzyFSM(queryRef.current))
-        } else if (!isGlobalFilesRef.current && localFilesRef.current && repoRevisionRef.current.repositoryName) {
-            setFilesFSM(localFilesRef.current)
-        }
-    }, [globalFilesToggleCount, setFilesFSM])
+    // Files
+    const localFiles = useMemo<FuzzyTabFSM>(() => {
+        const fsm = new FuzzyRepoFiles(apolloClient, createURL, triggerRender, repoRevisionRef.current)
+        return new FuzzyTabFSM(
+            'files',
+            'repository',
+            () => fsm.fuzzyFSM(),
+            () => fsm.handleQuery()
+        )
+    }, [apolloClient, triggerRender, createURL])
+    const globalFiles = useMemo<FuzzyTabFSM>(() => {
+        const fsm = new FuzzyFiles(apolloClient, triggerRender, repoRevisionRef)
+        return new FuzzyTabFSM(
+            'files',
+            'everywhere',
+            () => fsm.fuzzyFSM(),
+            query => fsm.handleQuery(query)
+        )
+    }, [apolloClient, triggerRender])
 
-    return { ...fuzzyState, tabs }
-}
+    const tabs = useMemo(() => {
+        const tabs: FuzzyTabFSM[] = []
+        if (fuzzyFinderActions) {
+            tabs.push(actions)
+        }
+        if (fuzzyFinderRepositories) {
+            tabs.push(repos)
+        }
+        if (fuzzyFinderSymbols) {
+            tabs.push(globalSymbols)
+            tabs.push(localSymbols)
+        }
+        tabs.push(localFiles)
+        tabs.push(globalFiles)
+        return new FuzzyTabs(
+            {
+                all: fuzzyFinderAll ? defaultTabs.all : hiddenKind,
+                actions: fuzzyFinderActions ? defaultTabs.actions : hiddenKind,
+                repos: fuzzyFinderRepositories ? defaultTabs.repos : hiddenKind,
+                symbols: fuzzyFinderSymbols ? defaultTabs.symbols : hiddenKind,
+                files: defaultTabs.files,
+                lines: hiddenKind,
+            },
+            tabs
+        )
+    }, [
+        fuzzyFinderAll,
+        fuzzyFinderActions,
+        fuzzyFinderRepositories,
+        fuzzyFinderSymbols,
+        actions,
+        repos,
+        globalFiles,
+        localFiles,
+        globalSymbols,
+        localSymbols,
+    ])
 
-async function continueIndexing(indexing: SearchIndexing): Promise<FuzzyFSM> {
-    const next = await indexing.continueIndexing()
-    if (next.key === 'indexing') {
-        return { key: 'indexing', indexing: next }
-    }
     return {
-        key: 'ready',
-        fuzzy: next.value,
+        onClickItem,
+        query,
+        setQuery,
+        activeTab,
+        setActiveTab,
+        repoRevision,
+        renderCount,
+        scope,
+        toggleScope,
+        setScope,
+        isScopeToggleDisabled,
+        tabs,
     }
 }


### PR DESCRIPTION
This is the first step towards implementing the design from https://www.figma.com/file/E0vD9UduSp2liVyDb7dplw/Fuzzy-finder-UI-improvements?node-id=1714%3A3559

While working on the code, I was increasingly unhappy with the convoluted state management inside `useFuzzyState`, which has caused app freezes (infinite loops between cyclic hooks).

The new state management inside `useFuzzyState` is significantly simpler to reason about and it should be much easier to add new functionality to this new codestructure.

The "Actions" tab is no longer enabled with `fuzzyFinderAll` since I suspect it will take a long time until we can make it GA (need at least a few dozen actions to make it GA-ready).

## Test plan

See the CI go green. To test the changes manually

- `sg start`
- Use keyboard shortcuts to open fuzzy finder
- Type in some query and make sure the fuzzy results are as expected
- Reload the page and make sure the query is preserved and the same results are rendered
- Use tab/shift-tab to cycle between fuzzy tabs
- Use mouse to click on different fuzzy tabs
- Use keyboard shortcut to toggle "search everywhere" and "Search within repo" when focusing on the all/files/symbols fuzzy tabs.
- Use mouse to select "search everywhere" and "search within repo"


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-fuzzy-v3.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
