### PR TITLE
gitserver: add command LFSSmudge

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -411,6 +411,11 @@ type Client interface {
 	// LsFiles returns the output of `git ls-files`
 	LsFiles(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, pathspecs ...gitdomain.Pathspec) ([]string, error)
 
+	// LFSSmudge returns a reader of the contents from LFS of the LFS pointer
+	// at path. If the path is not an LFS pointer, the file contents from git
+	// are returned instead.
+	LFSSmudge(ctx context.Context, repo api.RepoName, commit api.CommitID, path string, checker authz.SubRepoPermissionChecker) (io.ReadCloser, error)
+
 	// GetCommits returns a git commit object describing each of the given repository and commit pairs. This
 	// function returns a slice of the same size as the input slice. Values in the output slice may be nil if
 	// their associated repository or commit are unresolvable.

--- a/internal/gitserver/git_command.go
+++ b/internal/gitserver/git_command.go
@@ -154,7 +154,7 @@ func (l *LocalGitCommand) EnsureRevision() string { return l.ensureRevision }
 func (l *LocalGitCommand) SetStdin(b []byte) { l.stdin = b }
 
 func (l *LocalGitCommand) StdoutReader(ctx context.Context) (io.ReadCloser, error) {
-	output, err := l.CombinedOutput(ctx)
+	output, err := l.Output(ctx)
 	return io.NopCloser(bytes.NewReader(output)), err
 }
 

--- a/internal/gitserver/gitdomain/exec.go
+++ b/internal/gitserver/gitdomain/exec.go
@@ -34,6 +34,7 @@ var (
 		"show-ref":     {"--heads"},
 		"shortlog":     {"-s", "-n", "-e", "--no-merges", "--after", "--before"},
 		"cat-file":     {},
+		"lfs":          {},
 
 		// Used in tests to simulate errors with runCommand in handleExec of gitserver.
 		"testcommand": {},

--- a/internal/gitserver/test_utils.go
+++ b/internal/gitserver/test_utils.go
@@ -55,6 +55,22 @@ func MakeGitRepository(t *testing.T, cmds ...string) api.RepoName {
 	return repo
 }
 
+// MakeBareGitRepository calls initGitRepository to create a new Git
+// repository and returns a handle to a bare clone of it.
+func MakeBareGitRepository(t *testing.T, cmds ...string) api.RepoName {
+	t.Helper()
+	dir := InitGitRepository(t, cmds...)
+	repo := api.RepoName(filepath.Base(dir) + "-bare")
+	bareDir := filepath.Join(filepath.Dir(dir), string(repo), ".git")
+	if err := os.Mkdir(filepath.Dir(bareDir), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := exec.Command("git", "clone", "--bare", dir, bareDir).Output(); err != nil {
+		t.Fatal(err)
+	}
+	return repo
+}
+
 // InitGitRepository initializes a new Git repository and runs commands in a new
 // temporary directory (returned as dir).
 // It also sets ClientMocks.LocalGitCommandReposDir for successful run of local git commands.


### PR DESCRIPTION
This adds a new command which will run the contents of files through git-lfs-smudge. Smudge is the terminology used by git filters for converting a file from what is stored in git into what you want in your working copy. So what this command will do is fetch the file from LFS.

If the file is not an LFS pointer, git-lfs-smudge ignores it and passes it on. We use the same behaviour in our implementation, but we bypass needing to pass the large file as stdin to gitserver.

We needed to fix LocalGitCommand.StdoutReader since previously it was returning combined output (instead of stdout). We also add a utility which ensures we run against bare clones since this is important to test for git-lfs.

Note: this is still missing other pieces before it can be used properly. In particular we need infrastructure to monitor and prune the LFS cache as well as including git-lfs binary in our images. Additionally I need to test more how authorization works in filling the LFS cache, which means we may need to change this implementation up a bit.

Test Plan: added a test

Part of #42903 