### PR TITLE
Fix code intel repo meta caching by also caching inflight requests

### DIFF
--- a/client/shared/src/codeintel/legacy-extensions/util/api.ts
+++ b/client/shared/src/codeintel/legacy-extensions/util/api.ts
@@ -57,8 +57,13 @@ export interface RepoMeta {
 }
 
 export class API {
-    /** Small never-evict map from repo names to their meta. */
-    private cachedMetas = new Map<string, RepoMeta>()
+    /**
+     * Small never-evict map from repo names to a promise of their meta.
+     *
+     * We store a promise so that we can cache two requests to the same repo
+     * before the request resolves
+     */
+    private cachedMetaRequests = new Map<string, Promise<RepoMeta>>()
 
     /**
      * Retrieves the name and fork/archive status of a repository. This method
@@ -67,49 +72,55 @@ export class API {
      * @param name The repository's name.
      */
     public async resolveRepo(name: string): Promise<RepoMeta> {
-        const cachedMeta = this.cachedMetas.get(name)
-        if (cachedMeta !== undefined) {
-            return cachedMeta
+        const cachedMetaRequest = this.cachedMetaRequests.get(name)
+        if (cachedMetaRequest !== undefined) {
+            return cachedMetaRequest
         }
 
-        const queryWithFork = gql`
-            query LegacyResolveRepo($name: String!) {
-                repository(name: $name) {
-                    id
-                    name
-                    isFork
-                    isArchived
+        const metaRequest = (async (name: string): Promise<RepoMeta> => {
+            const queryWithFork = gql`
+                query LegacyResolveRepo($name: String!) {
+                    repository(name: $name) {
+                        id
+                        name
+                        isFork
+                        isArchived
+                    }
+                }
+            `
+
+            const queryWithoutFork = gql`
+                query LegacyResolveRepo2($name: String!) {
+                    repository(name: $name) {
+                        name
+                    }
+                }
+            `
+
+            interface Response {
+                repository: {
+                    id: string
+                    name: string
+                    isFork?: boolean
+                    isArchived?: boolean
                 }
             }
-        `
 
-        const queryWithoutFork = gql`
-            query LegacyResolveRepo2($name: String!) {
-                repository(name: $name) {
-                    name
-                }
+            const data = await queryGraphQL<Response>((await this.hasForkField()) ? queryWithFork : queryWithoutFork, {
+                name,
+            })
+
+            // Assume repo is not a fork/archived for older instances
+            return {
+                isFork: false,
+                isArchived: false,
+                ...data.repository,
+                id: graphqlIdToRepoId(data.repository.id),
             }
-        `
+        })(name)
+        this.cachedMetaRequests.set(name, metaRequest)
 
-        interface Response {
-            repository: {
-                id: string
-                name: string
-                isFork?: boolean
-                isArchived?: boolean
-            }
-        }
-
-        const data = await queryGraphQL<Response>((await this.hasForkField()) ? queryWithFork : queryWithoutFork, {
-            name,
-        })
-
-        // Assume repo is not a fork/archived for older instances
-        const meta = { isFork: false, isArchived: false, ...data.repository, id: graphqlIdToRepoId(data.repository.id) }
-
-        this.cachedMetas.set(name, meta)
-
-        return meta
+        return metaRequest
     }
 
     /**


### PR DESCRIPTION
The caching logic for code intel repo metadata was failing in the case when `resolveRepo()` was called multiple times before the first request responds. 

To fix this, we're now caching the whole promise instead so that we only need to initialise the requests once and can return the same promise for any sub-sequent call. 

IIRC, resolved promises only hold a promise to the resolved value and nothing else, so this should not impact memory overhead.

c.f. https://sourcegraph.slack.com/archives/C01C3NCGD40/p1666107750133859

## Test plan

### Before

(Check out the second reload where I got it to make **11!!** request for the same repo)


https://user-images.githubusercontent.com/458591/196946642-f9027f24-b888-4c81-9be6-c6dd3435e8b7.mov

### After


https://user-images.githubusercontent.com/458591/196946913-1634fd4a-8fa3-442b-b332-db2f088df025.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
