### PR TITLE
[language-platform] Update warning message look and add link to docs

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/components/IndexSettings.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/IndexSettings.tsx
@@ -72,7 +72,7 @@ export const IndexingSettings: FunctionComponent<React.PropsWithChildren<Indexin
                             constrained policy targeting an explicit set of repositories to enable this policy.{' '}
                             <Link
                                 className={styles.autoindexingLink}
-                                to="https://docs.sourcegraph.com/code_intelligence/how-to/enable_auto_indexing#configure-auto-indexing-policies"
+                                to="/help/code_intelligence/how-to/enable_auto_indexing#configure-auto-indexing-policies"
                             >
                                 See autoindexing docs.
                             </Link>

--- a/client/web/src/enterprise/codeintel/configuration/components/IndexSettings.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/IndexSettings.tsx
@@ -72,7 +72,9 @@ export const IndexingSettings: FunctionComponent<React.PropsWithChildren<Indexin
                             constrained policy targeting an explicit set of repositories to enable this policy.{' '}
                             <Link
                                 className={styles.autoindexingLink}
-                                to="/help/code_intelligence/how-to/enable_auto_indexing#configure-auto-indexing-policies"
+                                to="/help/code_navigation/how-to/enable_auto_indexing#configure-auto-indexing-policies"
+                                target="_blank"
+                                rel="noopener noreferrer"
                             >
                                 See autoindexing docs.
                             </Link>

--- a/client/web/src/enterprise/codeintel/configuration/components/IndexSettings.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/IndexSettings.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react'
 
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
-import { Alert, Label, H3 } from '@sourcegraph/wildcard'
+import { Alert, Link, Label, H3 } from '@sourcegraph/wildcard'
 
 import { RadioButtons } from '../../../../components/RadioButtons'
 import { CodeIntelligenceConfigurationPolicyFields, GitObjectType } from '../../../../graphql-operations'
@@ -67,9 +67,15 @@ export const IndexingSettings: FunctionComponent<React.PropsWithChildren<Indexin
                     repo === undefined &&
                     (policy.repositoryPatterns || []).length === 0 &&
                     policy.indexingEnabled && (
-                        <Alert variant="danger">
+                        <Alert variant="warning" className={styles.alertBox}>
                             This Sourcegraph instance has disabled global policies for auto-indexing. Create a more
-                            constrained policy targeting an explicit set of repositories to enable this policy.
+                            constrained policy targeting an explicit set of repositories to enable this policy.{' '}
+                            <Link
+                                className={styles.autoindexingLink}
+                                to="https://docs.sourcegraph.com/code_intelligence/how-to/enable_auto_indexing#configure-auto-indexing-policies"
+                            >
+                                See autoindexing docs.
+                            </Link>
                         </Alert>
                     )}
 

--- a/client/web/src/enterprise/codeintel/configuration/components/RetentionSettings.module.scss
+++ b/client/web/src/enterprise/codeintel/configuration/components/RetentionSettings.module.scss
@@ -12,3 +12,11 @@
 .label {
     display: block;
 }
+
+.autoindexing-link {
+    text-decoration: underline;
+}
+
+.alert-box {
+    margin-top: 1rem;
+}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/36120

Update autoindexing policy section's warning message look and add link to docs.

<img width="1033" alt="CleanShot 2022-10-20 at 08 51 16@2x" src="https://user-images.githubusercontent.com/6225160/196982848-f4c89a56-1714-4a2f-a118-8c378c5a93b2.png">


## Test plan
Ran all the test.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

![quick f](https://media.giphy.com/media/l2JefhuLRZWPnxF1m/giphy.gif)

## App preview:

- [Web](https://sg-web-cesar-36120-update-message-ux.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
