### PR TITLE
webhooks: Allow setting nil secret on update

### DIFF
--- a/internal/database/webhooks.go
+++ b/internal/database/webhooks.go
@@ -247,6 +247,7 @@ func (s *webhookStore) Update(ctx context.Context, actorUID int32, newWebhook *t
 		encryptedSecret string
 		keyID           string
 	)
+
 	if newWebhook.Secret != nil {
 		encryptedSecret, keyID, err = newWebhook.Secret.Encrypt(ctx, s.key)
 		if err != nil || (encryptedSecret == "" && keyID == "") {
@@ -258,7 +259,11 @@ func (s *webhookStore) Update(ctx context.Context, actorUID int32, newWebhook *t
 	}
 
 	q := sqlf.Sprintf(webhookUpdateQueryFmtstr,
-		newWebhook.CodeHostURN, encryptedSecret, keyID, dbutil.NullInt32Column(actorUID), newWebhook.ID,
+		newWebhook.CodeHostURN,
+		dbutil.NullStringColumn(encryptedSecret),
+		dbutil.NullStringColumn(keyID),
+		dbutil.NullInt32Column(actorUID),
+		newWebhook.ID,
 		sqlf.Join(webhookColumns, ", "))
 
 	updated, err := scanWebhook(s.QueryRow(ctx, q), s.key)

--- a/internal/database/webhooks.go
+++ b/internal/database/webhooks.go
@@ -250,7 +250,7 @@ func (s *webhookStore) Update(ctx context.Context, actorUID int32, newWebhook *t
 
 	if newWebhook.Secret != nil {
 		encryptedSecret, keyID, err = newWebhook.Secret.Encrypt(ctx, s.key)
-		if err != nil || (encryptedSecret == "" && keyID == "") {
+		if err != nil {
 			return nil, errors.Wrap(err, "encrypting secret")
 		}
 		if encryptedSecret == "" && keyID == "" {

--- a/internal/database/webhooks_test.go
+++ b/internal/database/webhooks_test.go
@@ -247,6 +247,14 @@ func TestWebhookUpdate(t *testing.T) {
 			t.Fatalf("unexpected error updating webhook: %s", err)
 		}
 		assert.Nil(t, updated.Secret)
+
+		// Also assert that the values in the DB are nil
+		row := db.QueryRowContext(ctx, "SELECT secret, encryption_key_id FROM webhooks where id = $1", updated.ID)
+		var rawSecret string
+		var rawEncryptionKey string
+		err = row.Scan(&dbutil.NullString{S: &rawSecret}, &dbutil.NullString{S: &rawEncryptionKey})
+		assert.Empty(t, rawSecret)
+		assert.Empty(t, rawEncryptionKey)
 	})
 
 	t.Run("updating webhook that doesn't exist", func(t *testing.T) {

--- a/internal/database/webhooks_test.go
+++ b/internal/database/webhooks_test.go
@@ -253,6 +253,7 @@ func TestWebhookUpdate(t *testing.T) {
 		var rawSecret string
 		var rawEncryptionKey string
 		err = row.Scan(&dbutil.NullString{S: &rawSecret}, &dbutil.NullString{S: &rawEncryptionKey})
+		assert.NoError(t, err)
 		assert.Empty(t, rawSecret)
 		assert.Empty(t, rawEncryptionKey)
 	})

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1663,14 +1663,15 @@ type SearchContextRepositoryRevisions struct {
 
 type EncryptableSecret = encryption.Encryptable
 
-func NewEmptySecret() *EncryptableSecret {
-	return NewUnencryptedSecret("")
-}
-
+// NewUnencryptedSecret creates an EncryptableSecret that *may* be encrypted in
+// the future, but the current value has not yet been encrypted.
 func NewUnencryptedSecret(value string) *EncryptableSecret {
 	return encryption.NewUnencrypted(value)
 }
 
+// NewEncryptedSecret creates an EncryptableSecret that has come from an
+// encrypted source. In this case you need to provide the keyID and key in order
+// to be able to decrypt it.
 func NewEncryptedSecret(cipher, keyID string, key encryption.Key) *EncryptableSecret {
 	return encryption.NewEncrypted(cipher, keyID, key)
 }


### PR DESCRIPTION
Ensure that when a secret is omitted we store `null` values in the database.

## Test plan

Tests updated