### PR TITLE
Revert "Remove user and org ID from authzQuery (#42700)"

### DIFF
--- a/internal/database/repos_perm.go
+++ b/internal/database/repos_perm.go
@@ -60,18 +60,9 @@ func AuthzQueryConds(ctx context.Context, db DB) (*sqlf.Query, error) {
 
 //nolint:unparam // unparam complains that `perms` always has same value across call-sites, but that's OK, as we only support read permissions right now.
 func authzQuery(bypassAuthz, usePermissionsUserMapping bool, authenticatedUserID int32, perms authz.Perms) *sqlf.Query {
-	if bypassAuthz {
-		// if bypassAuthz is true, we don't care about any of the checks
-		return sqlf.Sprintf(`
-(
-    -- Bypass authz
-    TRUE
-)
-`)
-	}
-
-	const unrestrictedReposSQL = `
-(
+	const queryFmtString = `(
+    %s                            -- TRUE or FALSE to indicate whether to bypass the check
+OR (
 	-- Unrestricted repos are visible to all users
 	EXISTS (
 		SELECT
@@ -80,44 +71,56 @@ func authzQuery(bypassAuthz, usePermissionsUserMapping bool, authenticatedUserID
 		AND unrestricted
 	)
 )
-`
-	unrestrictedReposQuery := sqlf.Sprintf(unrestrictedReposSQL)
-
-	const restrictedRepositoriesSQL = `
-(                             -- Restricted repositories require checking permissions
-    SELECT object_ids_ints @> INTSET(repo.id)
-    FROM user_permissions
-    WHERE
-        user_id = %s
-    AND permission = %s
-    AND object_type = 'repos'
-)
-`
-	restrictedRepositoriesQuery := sqlf.Sprintf(restrictedRepositoriesSQL, authenticatedUserID, perms.String())
-
-	conditions := []*sqlf.Query{unrestrictedReposQuery, restrictedRepositoriesQuery}
-
-	// Disregard unrestricted state when permissions user mapping is enabled
-	if !usePermissionsUserMapping {
-		const externalServiceUnrestrictedSQL = `
-(
-    NOT repo.private          -- Happy path of non-private repositories
-    OR  EXISTS (              -- Each external service defines if repositories are unrestricted
-        SELECT
-        FROM external_services AS es
-        JOIN external_service_repos AS esr ON (
-                esr.external_service_id = es.id
-            AND esr.repo_id = repo.id
-            AND es.unrestricted = TRUE
-            AND es.deleted_at IS NULL
-        )
+OR  (
+	NOT %s                        -- Disregard unrestricted state when permissions user mapping is enabled
+	AND (
+		NOT repo.private          -- Happy path of non-private repositories
+		OR  EXISTS (              -- Each external service defines if repositories are unrestricted
+			SELECT
+			FROM external_services AS es
+			JOIN external_service_repos AS esr ON (
+					esr.external_service_id = es.id
+				AND esr.repo_id = repo.id
+				AND es.unrestricted = TRUE
+				AND es.deleted_at IS NULL
+			)
+		)
 	)
 )
+OR  (                             -- Restricted repositories require checking permissions
+	(
+		SELECT object_ids_ints @> INTSET(repo.id)
+		FROM user_permissions
+		WHERE
+			user_id = %s
+		AND permission = %s
+		AND object_type = 'repos'
+	) AND EXISTS (
+		SELECT
+		FROM external_service_repos
+		WHERE repo_id = repo.id
+		AND (
+				(user_id IS NULL AND org_id IS NULL)  -- The repository was added at the instance level
+			OR  user_id = %s                          -- The authenticated user added this repository
+			OR  EXISTS (                              -- The authenticated user is a member of an organization that added this repository
+				SELECT
+				FROM org_members
+				WHERE
+					external_service_repos.org_id = org_members.org_id
+				AND org_members.user_id = %s
+			)
+		)
+	)
+)
+)
 `
-		externalServiceUnrestrictedQuery := sqlf.Sprintf(externalServiceUnrestrictedSQL)
-		conditions = append(conditions, externalServiceUnrestrictedQuery)
-	}
 
-	// Have to manually wrap the result in parenthesis so that they're evaluated together
-	return sqlf.Sprintf("(%s)", sqlf.Join(conditions, "OR"))
+	return sqlf.Sprintf(queryFmtString,
+		bypassAuthz,
+		usePermissionsUserMapping,
+		authenticatedUserID,
+		perms.String(),
+		authenticatedUserID,
+		authenticatedUserID,
+	)
 }


### PR DESCRIPTION
This reverts commit 1a72f18560de8433dd1181d6b366ba342bfa463e.

The simplified query causes a performance regression in search.


## Test plan

- N/A