### PR TITLE
Add default icon for non-github non-gitlab accounts in Account Security

### DIFF
--- a/client/web/src/user/settings/auth/ExternalAccountsSignIn.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccountsSignIn.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import classNames from 'classnames'
+import AccountCircleIcon from 'mdi-react/AccountCircleIcon'
 import { AuthProvider } from 'src/jscontext'
 
 import { ErrorLike } from '@sourcegraph/common'
@@ -54,7 +55,7 @@ const getNormalizedAccount = (
     const accountExternalData = account?.accountData
 
     // get external service icon and name as they will match external account
-    const { icon, title: name } = defaultExternalServices[kind]
+    const { icon, title: name } = defaultExternalServices[kind] || { icon: AccountCircleIcon, title: kind }
 
     let normalizedAccount: NormalizedMinAccount = {
         icon,


### PR DESCRIPTION
Closes #42879

Fixes a display bug that's currently present on sourcegraph.sourcegraph.com:

![image](https://user-images.githubusercontent.com/6427795/197007645-430bdb9c-59f0-4f74-b2fc-719b4b04c1f3.png)

It's now fixed and looks properly like this:

![image](https://user-images.githubusercontent.com/6427795/197007825-ab0db9f4-e769-44a3-afa9-d3752ba0f679.png)

## Test plan

Visual testing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-pjlast-42879-support-non-code.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
