### PR TITLE
executors: Implement stores for secrets

### DIFF
--- a/enterprise/internal/database/mocks_temp.go
+++ b/enterprise/internal/database/mocks_temp.go
@@ -6838,6 +6838,12 @@ type MockEnterpriseDB struct {
 	// ExecContextFunc is an instance of a mock function object controlling
 	// the behavior of the method ExecContext.
 	ExecContextFunc *EnterpriseDBExecContextFunc
+	// ExecutorSecretAccessLogsFunc is an instance of a mock function object
+	// controlling the behavior of the method ExecutorSecretAccessLogs.
+	ExecutorSecretAccessLogsFunc *EnterpriseDBExecutorSecretAccessLogsFunc
+	// ExecutorSecretsFunc is an instance of a mock function object
+	// controlling the behavior of the method ExecutorSecrets.
+	ExecutorSecretsFunc *EnterpriseDBExecutorSecretsFunc
 	// ExecutorsFunc is an instance of a mock function object controlling
 	// the behavior of the method Executors.
 	ExecutorsFunc *EnterpriseDBExecutorsFunc
@@ -6980,6 +6986,16 @@ func NewMockEnterpriseDB() *MockEnterpriseDB {
 		},
 		ExecContextFunc: &EnterpriseDBExecContextFunc{
 			defaultHook: func(context.Context, string, ...interface{}) (r0 sql.Result, r1 error) {
+				return
+			},
+		},
+		ExecutorSecretAccessLogsFunc: &EnterpriseDBExecutorSecretAccessLogsFunc{
+			defaultHook: func() (r0 database.ExecutorSecretAccessLogStore) {
+				return
+			},
+		},
+		ExecutorSecretsFunc: &EnterpriseDBExecutorSecretsFunc{
+			defaultHook: func(encryption.Key) (r0 database.ExecutorSecretStore) {
 				return
 			},
 		},
@@ -7195,6 +7211,16 @@ func NewStrictMockEnterpriseDB() *MockEnterpriseDB {
 				panic("unexpected invocation of MockEnterpriseDB.ExecContext")
 			},
 		},
+		ExecutorSecretAccessLogsFunc: &EnterpriseDBExecutorSecretAccessLogsFunc{
+			defaultHook: func() database.ExecutorSecretAccessLogStore {
+				panic("unexpected invocation of MockEnterpriseDB.ExecutorSecretAccessLogs")
+			},
+		},
+		ExecutorSecretsFunc: &EnterpriseDBExecutorSecretsFunc{
+			defaultHook: func(encryption.Key) database.ExecutorSecretStore {
+				panic("unexpected invocation of MockEnterpriseDB.ExecutorSecrets")
+			},
+		},
 		ExecutorsFunc: &EnterpriseDBExecutorsFunc{
 			defaultHook: func() database.ExecutorStore {
 				panic("unexpected invocation of MockEnterpriseDB.Executors")
@@ -7391,6 +7417,12 @@ func NewMockEnterpriseDBFrom(i EnterpriseDB) *MockEnterpriseDB {
 		},
 		ExecContextFunc: &EnterpriseDBExecContextFunc{
 			defaultHook: i.ExecContext,
+		},
+		ExecutorSecretAccessLogsFunc: &EnterpriseDBExecutorSecretAccessLogsFunc{
+			defaultHook: i.ExecutorSecretAccessLogs,
+		},
+		ExecutorSecretsFunc: &EnterpriseDBExecutorSecretsFunc{
+			defaultHook: i.ExecutorSecrets,
 		},
 		ExecutorsFunc: &EnterpriseDBExecutorsFunc{
 			defaultHook: i.Executors,
@@ -8307,6 +8339,212 @@ func (c EnterpriseDBExecContextFuncCall) Args() []interface{} {
 // invocation.
 func (c EnterpriseDBExecContextFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// EnterpriseDBExecutorSecretAccessLogsFunc describes the behavior when the
+// ExecutorSecretAccessLogs method of the parent MockEnterpriseDB instance
+// is invoked.
+type EnterpriseDBExecutorSecretAccessLogsFunc struct {
+	defaultHook func() database.ExecutorSecretAccessLogStore
+	hooks       []func() database.ExecutorSecretAccessLogStore
+	history     []EnterpriseDBExecutorSecretAccessLogsFuncCall
+	mutex       sync.Mutex
+}
+
+// ExecutorSecretAccessLogs delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockEnterpriseDB) ExecutorSecretAccessLogs() database.ExecutorSecretAccessLogStore {
+	r0 := m.ExecutorSecretAccessLogsFunc.nextHook()()
+	m.ExecutorSecretAccessLogsFunc.appendCall(EnterpriseDBExecutorSecretAccessLogsFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// ExecutorSecretAccessLogs method of the parent MockEnterpriseDB instance
+// is invoked and the hook queue is empty.
+func (f *EnterpriseDBExecutorSecretAccessLogsFunc) SetDefaultHook(hook func() database.ExecutorSecretAccessLogStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ExecutorSecretAccessLogs method of the parent MockEnterpriseDB instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *EnterpriseDBExecutorSecretAccessLogsFunc) PushHook(hook func() database.ExecutorSecretAccessLogStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *EnterpriseDBExecutorSecretAccessLogsFunc) SetDefaultReturn(r0 database.ExecutorSecretAccessLogStore) {
+	f.SetDefaultHook(func() database.ExecutorSecretAccessLogStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *EnterpriseDBExecutorSecretAccessLogsFunc) PushReturn(r0 database.ExecutorSecretAccessLogStore) {
+	f.PushHook(func() database.ExecutorSecretAccessLogStore {
+		return r0
+	})
+}
+
+func (f *EnterpriseDBExecutorSecretAccessLogsFunc) nextHook() func() database.ExecutorSecretAccessLogStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *EnterpriseDBExecutorSecretAccessLogsFunc) appendCall(r0 EnterpriseDBExecutorSecretAccessLogsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// EnterpriseDBExecutorSecretAccessLogsFuncCall objects describing the
+// invocations of this function.
+func (f *EnterpriseDBExecutorSecretAccessLogsFunc) History() []EnterpriseDBExecutorSecretAccessLogsFuncCall {
+	f.mutex.Lock()
+	history := make([]EnterpriseDBExecutorSecretAccessLogsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// EnterpriseDBExecutorSecretAccessLogsFuncCall is an object that describes
+// an invocation of method ExecutorSecretAccessLogs on an instance of
+// MockEnterpriseDB.
+type EnterpriseDBExecutorSecretAccessLogsFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 database.ExecutorSecretAccessLogStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c EnterpriseDBExecutorSecretAccessLogsFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c EnterpriseDBExecutorSecretAccessLogsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// EnterpriseDBExecutorSecretsFunc describes the behavior when the
+// ExecutorSecrets method of the parent MockEnterpriseDB instance is
+// invoked.
+type EnterpriseDBExecutorSecretsFunc struct {
+	defaultHook func(encryption.Key) database.ExecutorSecretStore
+	hooks       []func(encryption.Key) database.ExecutorSecretStore
+	history     []EnterpriseDBExecutorSecretsFuncCall
+	mutex       sync.Mutex
+}
+
+// ExecutorSecrets delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockEnterpriseDB) ExecutorSecrets(v0 encryption.Key) database.ExecutorSecretStore {
+	r0 := m.ExecutorSecretsFunc.nextHook()(v0)
+	m.ExecutorSecretsFunc.appendCall(EnterpriseDBExecutorSecretsFuncCall{v0, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the ExecutorSecrets
+// method of the parent MockEnterpriseDB instance is invoked and the hook
+// queue is empty.
+func (f *EnterpriseDBExecutorSecretsFunc) SetDefaultHook(hook func(encryption.Key) database.ExecutorSecretStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ExecutorSecrets method of the parent MockEnterpriseDB instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *EnterpriseDBExecutorSecretsFunc) PushHook(hook func(encryption.Key) database.ExecutorSecretStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *EnterpriseDBExecutorSecretsFunc) SetDefaultReturn(r0 database.ExecutorSecretStore) {
+	f.SetDefaultHook(func(encryption.Key) database.ExecutorSecretStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *EnterpriseDBExecutorSecretsFunc) PushReturn(r0 database.ExecutorSecretStore) {
+	f.PushHook(func(encryption.Key) database.ExecutorSecretStore {
+		return r0
+	})
+}
+
+func (f *EnterpriseDBExecutorSecretsFunc) nextHook() func(encryption.Key) database.ExecutorSecretStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *EnterpriseDBExecutorSecretsFunc) appendCall(r0 EnterpriseDBExecutorSecretsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of EnterpriseDBExecutorSecretsFuncCall objects
+// describing the invocations of this function.
+func (f *EnterpriseDBExecutorSecretsFunc) History() []EnterpriseDBExecutorSecretsFuncCall {
+	f.mutex.Lock()
+	history := make([]EnterpriseDBExecutorSecretsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// EnterpriseDBExecutorSecretsFuncCall is an object that describes an
+// invocation of method ExecutorSecrets on an instance of MockEnterpriseDB.
+type EnterpriseDBExecutorSecretsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 encryption.Key
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 database.ExecutorSecretStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c EnterpriseDBExecutorSecretsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c EnterpriseDBExecutorSecretsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }
 
 // EnterpriseDBExecutorsFunc describes the behavior when the Executors

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -53,6 +53,8 @@ type DB interface {
 	Webhooks(encryption.Key) WebhookStore
 	RepoStatistics() RepoStatisticsStore
 	Executors() ExecutorStore
+	ExecutorSecrets(encryption.Key) ExecutorSecretStore
+	ExecutorSecretAccessLogs() ExecutorSecretAccessLogStore
 
 	Transact(context.Context) (DB, error)
 	Done(error) error
@@ -229,4 +231,12 @@ func (d *db) RepoStatistics() RepoStatisticsStore {
 
 func (d *db) Executors() ExecutorStore {
 	return ExecutorsWith(d.Store)
+}
+
+func (d *db) ExecutorSecrets(key encryption.Key) ExecutorSecretStore {
+	return ExecutorSecretsWith(d.logger, d.Store, key)
+}
+
+func (d *db) ExecutorSecretAccessLogs() ExecutorSecretAccessLogStore {
+	return ExecutorSecretAccessLogsWith(d.Store)
 }

--- a/internal/database/encryption_tables.go
+++ b/internal/database/encryption_tables.go
@@ -26,6 +26,7 @@ var EncryptionConfigs = []EncryptionConfig{
 	userCredentialsEncryptionConfig,
 	batchChangesSiteCredentialsEncryptionConfig,
 	webhooklogsEncryptionConfig,
+	executorSecretsEncryptionConfig,
 }
 
 var externalServicesEncryptionConfig = EncryptionConfig{
@@ -77,6 +78,17 @@ var webhooklogsEncryptionConfig = EncryptionConfig{
 	EncryptedFieldNames: []string{"request", "response"},
 	Scan:                basestore.NewMapScanner(scanEncryptedStringPair),
 	Key:                 func() encryption.Key { return keyring.Default().WebhookLogKey },
+	Limit:               5,
+}
+
+var executorSecretsEncryptionConfig = EncryptionConfig{
+	TableName:           "executor_secrets",
+	IDFieldName:         "id",
+	KeyIDFieldName:      "encryption_key_id",
+	EncryptedFieldNames: []string{"value"},
+	UpdateAsBytes:       true,
+	Scan:                basestore.NewMapScanner(scanEncryptedBytea),
+	Key:                 func() encryption.Key { return keyring.Default().ExecutorSecretKey },
 	Limit:               5,
 }
 

--- a/internal/database/executor_secret_access_logs.go
+++ b/internal/database/executor_secret_access_logs.go
@@ -1,0 +1,257 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+)
+
+// ExecutorSecret represents a row in the `executor_secret_access_logs` table.
+type ExecutorSecretAccessLog struct {
+	ID               int64
+	ExecutorSecretID int64
+	UserID           int32
+
+	CreatedAt time.Time
+}
+
+// ExecutorSecretAccessLogNotFoundErr is returned when a log cannot be found.
+type ExecutorSecretAccessLogNotFoundErr struct {
+	id int64
+}
+
+func (err ExecutorSecretAccessLogNotFoundErr) Error() string {
+	return fmt.Sprintf("executor secret access log not found: id=%d", err.id)
+}
+
+func (ExecutorSecretAccessLogNotFoundErr) NotFound() bool {
+	return true
+}
+
+// ExecutorSecretAccessLogStore provides access to the `executor_secret_access_logs` table.
+type ExecutorSecretAccessLogStore interface {
+	basestore.ShareableStore
+	With(basestore.ShareableStore) ExecutorSecretAccessLogStore
+	Transact(context.Context) (ExecutorSecretAccessLogStore, error)
+
+	// Create inserts the given ExecutorSecretAccessLog into the database.
+	Create(ctx context.Context, log *ExecutorSecretAccessLog) error
+	// GetByID returns the executor secret access log matching the given ID, or
+	// ExecutorSecretAccessLogNotFoundErr if no such record exists.
+	GetByID(ctx context.Context, id int64) (*ExecutorSecretAccessLog, error)
+	// List returns all logs matching the given options.
+	List(context.Context, ExecutorSecretAccessLogsListOpts) ([]*ExecutorSecretAccessLog, int, error)
+	// Count counts all logs matching the given options.
+	Count(context.Context, ExecutorSecretAccessLogsListOpts) (int, error)
+}
+
+// ExecutorSecretAccessLogsListOpts provide the options when listing secret access
+// logs.
+type ExecutorSecretAccessLogsListOpts struct {
+	*LimitOffset
+
+	// ExecutorSecretID filters the access records by the given secret id.
+	ExecutorSecretID int64
+}
+
+func (opts ExecutorSecretAccessLogsListOpts) sqlConds(ctx context.Context) (*sqlf.Query, error) {
+	preds := []*sqlf.Query{}
+
+	if opts.ExecutorSecretID != 0 {
+		preds = append(preds, sqlf.Sprintf("executor_secret_id = %s", opts.ExecutorSecretID))
+	}
+
+	if len(preds) == 0 {
+		preds = append(preds, sqlf.Sprintf("TRUE"))
+	}
+
+	return sqlf.Join(preds, "\n AND "), nil
+}
+
+// limitSQL overrides LimitOffset.SQL() to give a LIMIT clause with one extra value
+// so we can populate the next cursor.
+func (opts *ExecutorSecretAccessLogsListOpts) limitSQL() *sqlf.Query {
+	if opts.LimitOffset == nil || opts.Limit == 0 {
+		return &sqlf.Query{}
+	}
+
+	return (&LimitOffset{Limit: opts.Limit + 1, Offset: opts.Offset}).SQL()
+}
+
+type executorSecretAccessLogStore struct {
+	*basestore.Store
+}
+
+// ExecutorSecretAccessLogsWith instantiates and returns a new ExecutorSecretAccessLogStore using the other store handle.
+func ExecutorSecretAccessLogsWith(other basestore.ShareableStore) ExecutorSecretAccessLogStore {
+	return &executorSecretAccessLogStore{
+		Store: basestore.NewWithHandle(other.Handle()),
+	}
+}
+
+func (s *executorSecretAccessLogStore) With(other basestore.ShareableStore) ExecutorSecretAccessLogStore {
+	return &executorSecretAccessLogStore{
+		Store: s.Store.With(other),
+	}
+}
+
+func (s *executorSecretAccessLogStore) Transact(ctx context.Context) (ExecutorSecretAccessLogStore, error) {
+	txBase, err := s.Store.Transact(ctx)
+	return &executorSecretAccessLogStore{
+		Store: txBase,
+	}, err
+}
+
+func (s *executorSecretAccessLogStore) Create(ctx context.Context, log *ExecutorSecretAccessLog) error {
+	// Set the current actor as the creator.
+	if log.UserID == 0 {
+		log.UserID = actor.FromContext(ctx).UID
+	}
+
+	q := sqlf.Sprintf(
+		executorSecretAccessLogCreateQueryFmtstr,
+		log.ExecutorSecretID,
+		log.UserID,
+		sqlf.Join(executorSecretAccessLogsColumns, ", "),
+	)
+
+	row := s.QueryRow(ctx, q)
+	if err := scanExecutorSecretAccessLog(log, row); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *executorSecretAccessLogStore) GetByID(ctx context.Context, id int64) (*ExecutorSecretAccessLog, error) {
+	q := sqlf.Sprintf(
+		"SELECT %s FROM executor_secret_access_logs WHERE id = %s",
+		sqlf.Join(executorSecretAccessLogsColumns, ", "),
+		id,
+	)
+
+	log := ExecutorSecretAccessLog{}
+	row := s.QueryRow(ctx, q)
+	if err := scanExecutorSecretAccessLog(&log, row); err == sql.ErrNoRows {
+		return nil, ExecutorSecretAccessLogNotFoundErr{id: id}
+	} else if err != nil {
+		return nil, err
+	}
+
+	return &log, nil
+}
+
+func (s *executorSecretAccessLogStore) List(ctx context.Context, opts ExecutorSecretAccessLogsListOpts) ([]*ExecutorSecretAccessLog, int, error) {
+	conds, err := opts.sqlConds(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	q := sqlf.Sprintf(
+		executorSecretAccessLogsListQueryFmtstr,
+		sqlf.Join(executorSecretAccessLogsColumns, ", "),
+		conds,
+		opts.limitSQL(),
+	)
+
+	rows, err := s.Query(ctx, q)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	var logs []*ExecutorSecretAccessLog
+	for rows.Next() {
+		log := ExecutorSecretAccessLog{}
+		if err := scanExecutorSecretAccessLog(&log, rows); err != nil {
+			return nil, 0, err
+		}
+		logs = append(logs, &log)
+	}
+
+	// Check if there were more results than the limit: if so, then we need to
+	// set the return cursor and lop off the extra log that we retrieved.
+	next := 0
+	if opts.LimitOffset != nil && opts.Limit != 0 && len(logs) == opts.Limit+1 {
+		next = opts.Offset + opts.Limit
+		logs = logs[:len(logs)-1]
+	}
+
+	return logs, next, nil
+}
+
+func (s *executorSecretAccessLogStore) Count(ctx context.Context, opts ExecutorSecretAccessLogsListOpts) (int, error) {
+	conds, err := opts.sqlConds(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	q := sqlf.Sprintf(
+		executorSecretAccessLogsCountQueryFmtstr,
+		conds,
+	)
+
+	totalCount, _, err := basestore.ScanFirstInt(s.Query(ctx, q))
+	if err != nil {
+		return 0, err
+	}
+
+	return totalCount, nil
+}
+
+// executorSecretAccessLogsColumns are the columns that must be selected by
+// executor_secret_access_logs queries in order to use scanExecutorSecretAccessLog().
+var executorSecretAccessLogsColumns = []*sqlf.Query{
+	sqlf.Sprintf("id"),
+	sqlf.Sprintf("executor_secret_id"),
+	sqlf.Sprintf("user_id"),
+	sqlf.Sprintf("created_at"),
+}
+
+const executorSecretAccessLogsListQueryFmtstr = `
+SELECT %s
+FROM executor_secret_access_logs
+WHERE %s
+ORDER BY created_at DESC
+%s  -- LIMIT clause
+`
+
+const executorSecretAccessLogsCountQueryFmtstr = `
+SELECT COUNT(*)
+FROM executor_secret_access_logs
+WHERE %s
+`
+
+const executorSecretAccessLogCreateQueryFmtstr = `
+INSERT INTO
+	executor_secret_access_logs (
+		executor_secret_id,
+		user_id,
+		created_at
+	)
+	VALUES (
+		%s,
+		%s,
+		NOW()
+	)
+	RETURNING %s
+`
+
+// scanExecutorSecretAccessLog scans an ExecutorSecretAccessLog from the given scanner
+// into the given ExecutorSecretAccessLog.
+func scanExecutorSecretAccessLog(log *ExecutorSecretAccessLog, s interface {
+	Scan(...any) error
+}) error {
+	return s.Scan(
+		&log.ID,
+		&log.ExecutorSecretID,
+		&log.UserID,
+		&log.CreatedAt,
+	)
+}

--- a/internal/database/executor_secret_access_logs.go
+++ b/internal/database/executor_secret_access_logs.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 )
 
-// ExecutorSecret represents a row in the `executor_secret_access_logs` table.
+// ExecutorSecretAccessLog represents a row in the `executor_secret_access_logs` table.
 type ExecutorSecretAccessLog struct {
 	ID               int64
 	ExecutorSecretID int64

--- a/internal/database/executor_secret_access_logs_test.go
+++ b/internal/database/executor_secret_access_logs_test.go
@@ -1,0 +1,163 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/log/logtest"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func TestExecutorSecretAccessLogs_Create(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.NoOp(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	user, err := db.Users().Create(ctx, NewUser{Username: "johndoe"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret := &ExecutorSecret{
+		Key:       "GH_TOKEN",
+		CreatorID: user.ID,
+	}
+	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(actor.WithInternalActor(ctx), ExecutorSecretScopeBatches, secret, "sosecret"); err != nil {
+		t.Fatal(err)
+	}
+	store := db.ExecutorSecretAccessLogs()
+
+	t.Run("Create", func(t *testing.T) {
+		log := &ExecutorSecretAccessLog{
+			ExecutorSecretID: secret.ID,
+			UserID:           user.ID,
+		}
+		if err := store.Create(ctx, log); err != nil {
+			t.Fatal(err)
+		}
+		if log.CreatedAt.IsZero() {
+			t.Fatal("created_at time not set")
+		}
+
+		t.Run("uses actor user if user ID is not set", func(t *testing.T) {
+			log := &ExecutorSecretAccessLog{
+				ExecutorSecretID: secret.ID,
+			}
+			if err := store.Create(actor.WithActor(ctx, actor.FromUser(user.ID)), log); err != nil {
+				t.Fatal(err)
+			}
+			if log.UserID != user.ID {
+				t.Fatal("wrong user_id set on access log record")
+			}
+		})
+	})
+}
+
+func TestExecutorSecretAccessLogs_GetListCount(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.NoOp(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	user, err := db.Users().Create(ctx, NewUser{Username: "johndoe"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret1 := &ExecutorSecret{
+		Key:       "GH_TOKEN",
+		CreatorID: user.ID,
+	}
+	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(actor.WithInternalActor(ctx), ExecutorSecretScopeBatches, secret1, "sosecret"); err != nil {
+		t.Fatal(err)
+	}
+	secret2 := &ExecutorSecret{
+		Key:       "NPM_TOKEN",
+		CreatorID: user.ID,
+	}
+	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(actor.WithInternalActor(ctx), ExecutorSecretScopeBatches, secret2, "sosecret"); err != nil {
+		t.Fatal(err)
+	}
+	store := db.ExecutorSecretAccessLogs()
+
+	// Create a bunch of logs. 2 for secret1 and 1 for secret2.
+	createLog := func(secret *ExecutorSecret) *ExecutorSecretAccessLog {
+		log := &ExecutorSecretAccessLog{
+			ExecutorSecretID: secret.ID,
+			UserID:           user.ID,
+		}
+		if err := store.Create(ctx, log); err != nil {
+			t.Fatal(err)
+		}
+		return log
+	}
+
+	secret1Log1 := createLog(secret1)
+	secret1Log2 := createLog(secret1)
+	secret2Log1 := createLog(secret2)
+
+	t.Run("GetByID", func(t *testing.T) {
+		log, err := store.GetByID(ctx, secret1Log1.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(log, secret1Log1); diff != "" {
+			t.Fatal(diff)
+		}
+
+		t.Run("not found", func(t *testing.T) {
+			_, err := store.GetByID(ctx, secret2Log1.ID+1000)
+			if err == nil {
+				t.Fatal("unexpected nil error")
+			}
+			if !errors.As(err, &ExecutorSecretAccessLogNotFoundErr{}) {
+				t.Fatal("wrong error returned")
+			}
+		})
+	})
+
+	t.Run("ListCount", func(t *testing.T) {
+		t.Run("All", func(t *testing.T) {
+			opts := ExecutorSecretAccessLogsListOpts{}
+			logs, _, err := store.List(ctx, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			count, err := store.Count(ctx, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if have, want := count, len(logs); have != want {
+				t.Fatalf("invalid count returned: %d", have)
+			}
+			if diff := cmp.Diff([]*ExecutorSecretAccessLog{secret2Log1, secret1Log2, secret1Log1}, logs); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+		t.Run("For given secret", func(t *testing.T) {
+			opts := ExecutorSecretAccessLogsListOpts{ExecutorSecretID: secret1.ID}
+			logs, _, err := store.List(ctx, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			count, err := store.Count(ctx, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if have, want := count, len(logs); have != want {
+				t.Fatalf("invalid count returned: %d", have)
+			}
+			if diff := cmp.Diff([]*ExecutorSecretAccessLog{secret1Log2, secret1Log1}, logs); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	})
+}
+
+func TestExecutorSecretAccessLogNotFoundError(t *testing.T) {
+	err := ExecutorSecretAccessLogNotFoundErr{}
+	if have := errcode.IsNotFound(err); !have {
+		t.Error("TestExecutorSecretAccessLogNotFoundErr does not say it represents a not found error")
+	}
+}

--- a/internal/database/executor_secrets.go
+++ b/internal/database/executor_secrets.go
@@ -244,7 +244,7 @@ func (s *executorSecretStore) Update(ctx context.Context, scope ExecutorSecretSc
 
 	q := sqlf.Sprintf(
 		executorSecretUpdateQueryFmtstr,
-		[]byte(encryptedValue),
+		encryptedValue,
 		keyID,
 		secret.UpdatedAt,
 		secret.ID,

--- a/internal/database/executor_secrets.go
+++ b/internal/database/executor_secrets.go
@@ -579,6 +579,13 @@ func executorSecretsAuthzQueryConds(ctx context.Context) (*sqlf.Query, error) {
 const executorSecretsAuthzQueryCondsFmtstr = `
 (
 	(
+		-- the secret is a global secret
+		executor_secrets.namespace_user_id IS NULL
+		AND
+		executor_secrets.namespace_org_id IS NULL
+	)
+	OR
+	(
 		-- user is the same as the actor
 		executor_secrets.namespace_user_id = %s
 	)

--- a/internal/database/executor_secrets.go
+++ b/internal/database/executor_secrets.go
@@ -179,7 +179,13 @@ func (s *executorSecretStore) Transact(ctx context.Context) (ExecutorSecretStore
 	}, err
 }
 
+var ErrEmptyExecutorSecret = errors.New("empty executor secret is not allowed")
+
 func (s *executorSecretStore) Create(ctx context.Context, scope ExecutorSecretScope, secret *ExecutorSecret, value string) error {
+	if len(value) == 0 {
+		return ErrEmptyExecutorSecret
+	}
+
 	// SECURITY: check that the current user is authorized to create a secret for the given namespace.
 	if err := ensureActorHasNamespaceWriteAccess(ctx, NewDBWith(s.logger, s), secret); err != nil {
 		return err
@@ -216,6 +222,10 @@ func (s *executorSecretStore) Create(ctx context.Context, scope ExecutorSecretSc
 }
 
 func (s *executorSecretStore) Update(ctx context.Context, scope ExecutorSecretScope, secret *ExecutorSecret, value string) error {
+	if len(value) == 0 {
+		return ErrEmptyExecutorSecret
+	}
+
 	// SECURITY: check that the current user is authorized to update a secret in the given namespace.
 	if err := ensureActorHasNamespaceWriteAccess(ctx, NewDBWith(s.logger, s), secret); err != nil {
 		return err

--- a/internal/database/executor_secrets.go
+++ b/internal/database/executor_secrets.go
@@ -1,0 +1,576 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/lib/pq"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// ExecutorSecret represents a row in the `executor_secrets` table.
+type ExecutorSecret struct {
+	ID              int64
+	Key             string
+	Scope           string
+	CreatorID       int32
+	NamespaceUserID int32
+	NamespaceOrgID  int32
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+
+	// unexported so that there's no direct access. Use `Value` to access it
+	// which will generate the access log entries as well.
+	encryptedValue *encryption.Encryptable
+}
+
+// Value decrypts the contained value and logs an access log event. Calling Value
+// multiple times will not require another decryption call, but will create an
+// additional access log entry.
+func (e ExecutorSecret) Value(ctx context.Context, s ExecutorSecretAccessLogStore) (string, error) {
+	if err := s.Create(ctx, &ExecutorSecretAccessLog{
+		// user is set automatically from the context actor.
+		ExecutorSecretID: e.ID,
+	}); err != nil {
+		return "", errors.Wrap(err, "creating secret access log entry")
+	}
+	return e.encryptedValue.Decrypt(ctx)
+}
+
+type ExecutorSecretScope string
+
+const (
+	ExecutorSecretScopeBatches = "batches"
+)
+
+// ExecutorSecretNotFoundErr is returned when a secret cannot be found.
+type ExecutorSecretNotFoundErr struct {
+	id int64
+}
+
+func (err ExecutorSecretNotFoundErr) Error() string {
+	return fmt.Sprintf("executor secret not found: id=%d", err.id)
+}
+
+func (ExecutorSecretNotFoundErr) NotFound() bool {
+	return true
+}
+
+// ExecutorSecretStore provides access to the `executor_secrets` table.
+type ExecutorSecretStore interface {
+	basestore.ShareableStore
+	With(basestore.ShareableStore) ExecutorSecretStore
+	Transact(context.Context) (ExecutorSecretStore, error)
+
+	// Create inserts the given ExecutorSecret into the database.
+	Create(ctx context.Context, scope ExecutorSecretScope, secret *ExecutorSecret, value string) error
+	// Update updates a secret in the database. If the secret cannot be found,
+	// an error is returned.
+	Update(ctx context.Context, scope ExecutorSecretScope, secret *ExecutorSecret, value string) error
+	// Delete deletes the given executor secret.
+	Delete(ctx context.Context, scope ExecutorSecretScope, id int64) error
+	// GetByID returns the executor secret matching the given ID, or
+	// ExecutorSecretNotFoundErr if no such secret exists.
+	GetByID(ctx context.Context, scope ExecutorSecretScope, id int64) (*ExecutorSecret, error)
+	// List returns all secrets matching the given options.
+	List(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) ([]*ExecutorSecret, int, error)
+	// Count counts all secrets matching the given options.
+	Count(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) (int, error)
+}
+
+// ExecutorSecretsListOpts provide the options when listing secrets. If no namespace
+// scoping is provided, only global credentials are returned (no namespace set).
+type ExecutorSecretsListOpts struct {
+	*LimitOffset
+
+	// Keys, if set limits the returned secrets to the list of provided keys.
+	Keys []string
+
+	// NamespaceUserID, when set, returns secrets accessible in the user namespace.
+	// These may include global secrets.
+	NamespaceUserID int32
+	// NamespaceOrgID, when set, returns secrets accessible in the user namespace.
+	// These may include global secrets.
+	NamespaceOrgID int32
+}
+
+func (opts ExecutorSecretsListOpts) sqlConds(ctx context.Context) (*sqlf.Query, error) {
+	authz, err := executorSecretsAuthzQueryConds(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	globalSecret := sqlf.Sprintf("namespace_user_id IS NULL AND namespace_org_id IS NULL")
+
+	preds := []*sqlf.Query{authz}
+
+	if opts.NamespaceOrgID != 0 {
+		preds = append(preds, sqlf.Sprintf("(namespace_org_id = %s OR (%s))", opts.NamespaceOrgID, globalSecret))
+	} else if opts.NamespaceUserID != 0 {
+		preds = append(preds, sqlf.Sprintf("(namespace_user_id = %s OR (%s))", opts.NamespaceUserID, globalSecret))
+	} else {
+		preds = append(preds, globalSecret)
+	}
+
+	if len(opts.Keys) > 0 {
+		preds = append(preds, sqlf.Sprintf("key = ANY(%s)", pq.Array(opts.Keys)))
+	}
+
+	return sqlf.Join(preds, "\n AND "), nil
+}
+
+// limitSQL overrides LimitOffset.SQL() to give a LIMIT clause with one extra value
+// so we can populate the next cursor.
+func (opts *ExecutorSecretsListOpts) limitSQL() *sqlf.Query {
+	if opts.LimitOffset == nil || opts.Limit == 0 {
+		return &sqlf.Query{}
+	}
+
+	return (&LimitOffset{Limit: opts.Limit + 1, Offset: opts.Offset}).SQL()
+}
+
+type executorSecretStore struct {
+	logger log.Logger
+	*basestore.Store
+	key encryption.Key
+}
+
+// ExecutorSecretsWith instantiates and returns a new ExecutorSecretStore using the other store handle.
+func ExecutorSecretsWith(logger log.Logger, other basestore.ShareableStore, key encryption.Key) ExecutorSecretStore {
+	return &executorSecretStore{
+		logger: logger,
+		Store:  basestore.NewWithHandle(other.Handle()),
+		key:    key,
+	}
+}
+
+func (s *executorSecretStore) With(other basestore.ShareableStore) ExecutorSecretStore {
+	return &executorSecretStore{
+		logger: s.logger,
+		Store:  s.Store.With(other),
+		key:    s.key,
+	}
+}
+
+func (s *executorSecretStore) Transact(ctx context.Context) (ExecutorSecretStore, error) {
+	txBase, err := s.Store.Transact(ctx)
+	return &executorSecretStore{
+		logger: s.logger,
+		Store:  txBase,
+		key:    s.key,
+	}, err
+}
+
+func (s *executorSecretStore) Create(ctx context.Context, scope ExecutorSecretScope, secret *ExecutorSecret, value string) error {
+	// SECURITY: check that the current user is authorized to create a secret for the given namespace.
+	if err := ensureActorHasNamespaceAccess(ctx, NewDBWith(s.logger, s), secret); err != nil {
+		return err
+	}
+
+	// Set the current actor as the secret creator if not set.
+	if secret.CreatorID == 0 {
+		secret.CreatorID = actor.FromContext(ctx).UID
+	}
+
+	encryptedValue, keyID, err := encryptExecutorSecret(ctx, s.key, value)
+	if err != nil {
+		return err
+	}
+
+	q := sqlf.Sprintf(
+		executorSecretCreateQueryFmtstr,
+		scope,
+		secret.Key,
+		encryptedValue, // N.B.: is already a []byte
+		keyID,
+		dbutil.NewNullInt(int(secret.NamespaceUserID)),
+		dbutil.NewNullInt(int(secret.NamespaceOrgID)),
+		secret.CreatorID,
+		sqlf.Join(executorSecretsColumns, ", "),
+	)
+
+	row := s.QueryRow(ctx, q)
+	if err := scanExecutorSecret(secret, s.key, row); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *executorSecretStore) Update(ctx context.Context, scope ExecutorSecretScope, secret *ExecutorSecret, value string) error {
+	// SECURITY: check that the current user is authorized to create a secret for the given namespace.
+	if err := ensureActorHasNamespaceAccess(ctx, NewDBWith(s.logger, s), secret); err != nil {
+		return err
+	}
+
+	secret.UpdatedAt = timeutil.Now()
+	encryptedValue, keyID, err := encryptExecutorSecret(ctx, s.key, value)
+	if err != nil {
+		return err
+	}
+
+	authz, err := executorSecretsAuthzQueryConds(ctx)
+	if err != nil {
+		return err
+	}
+
+	q := sqlf.Sprintf(
+		executorSecretUpdateQueryFmtstr,
+		[]byte(encryptedValue),
+		keyID,
+		secret.UpdatedAt,
+		secret.ID,
+		scope,
+		authz,
+		sqlf.Join(executorSecretsColumns, ", "),
+	)
+
+	row := s.QueryRow(ctx, q)
+	if err := scanExecutorSecret(secret, s.key, row); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *executorSecretStore) Delete(ctx context.Context, scope ExecutorSecretScope, id int64) error {
+	authz, err := executorSecretsAuthzQueryConds(ctx)
+	if err != nil {
+		return err
+	}
+
+	q := sqlf.Sprintf("DELETE FROM executor_secrets WHERE id = %s AND scope = %s AND %s", id, scope, authz)
+	res, err := s.ExecResult(ctx, q)
+	if err != nil {
+		return err
+	}
+
+	if rows, err := res.RowsAffected(); err != nil {
+		return err
+	} else if rows == 0 {
+		return ExecutorSecretNotFoundErr{id: id}
+	}
+
+	return nil
+}
+
+func (s *executorSecretStore) GetByID(ctx context.Context, scope ExecutorSecretScope, id int64) (*ExecutorSecret, error) {
+	authz, err := executorSecretsAuthzQueryConds(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	q := sqlf.Sprintf(
+		"SELECT %s FROM executor_secrets WHERE id = %s AND %s",
+		sqlf.Join(executorSecretsColumns, ", "),
+		id,
+		authz,
+	)
+
+	secret := ExecutorSecret{}
+	row := s.QueryRow(ctx, q)
+	if err := scanExecutorSecret(&secret, s.key, row); err == sql.ErrNoRows {
+		return nil, ExecutorSecretNotFoundErr{id: id}
+	} else if err != nil {
+		return nil, err
+	}
+
+	return &secret, nil
+}
+
+func (s *executorSecretStore) List(ctx context.Context, scope ExecutorSecretScope, opts ExecutorSecretsListOpts) ([]*ExecutorSecret, int, error) {
+	conds, err := opts.sqlConds(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	q := sqlf.Sprintf(
+		executorSecretsListQueryFmtstr,
+		sqlf.Join(executorSecretsColumns, ", "),
+		sqlf.Join(executorSecretsColumns, ", "),
+		conds,
+		opts.limitSQL(),
+	)
+
+	rows, err := s.Query(ctx, q)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	var secrets []*ExecutorSecret
+	for rows.Next() {
+		secret := ExecutorSecret{}
+		if err := scanExecutorSecret(&secret, s.key, rows); err != nil {
+			return nil, 0, err
+		}
+		secrets = append(secrets, &secret)
+	}
+
+	// Check if there were more results than the limit: if so, then we need to
+	// set the return cursor and lop off the extra secret that we retrieved.
+	next := 0
+	if opts.LimitOffset != nil && opts.Limit != 0 && len(secrets) == opts.Limit+1 {
+		next = opts.Offset + opts.Limit
+		secrets = secrets[:len(secrets)-1]
+	}
+
+	return secrets, next, nil
+}
+
+func (s *executorSecretStore) Count(ctx context.Context, scope ExecutorSecretScope, opts ExecutorSecretsListOpts) (int, error) {
+	conds, err := opts.sqlConds(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	q := sqlf.Sprintf(
+		executorSecretsCountQueryFmtstr,
+		conds,
+	)
+
+	totalCount, _, err := basestore.ScanFirstInt(s.Query(ctx, q))
+	if err != nil {
+		return 0, err
+	}
+
+	return totalCount, nil
+}
+
+// executorSecretsColumns are the columns that must be selected by
+// executor_secrets queries in order to use scanExecutorSecret().
+var executorSecretsColumns = []*sqlf.Query{
+	sqlf.Sprintf("id"),
+	sqlf.Sprintf("scope"),
+	sqlf.Sprintf("key"),
+	sqlf.Sprintf("value"),
+	sqlf.Sprintf("encryption_key_id"),
+	sqlf.Sprintf("namespace_user_id"),
+	sqlf.Sprintf("namespace_org_id"),
+	sqlf.Sprintf("creator_id"),
+	sqlf.Sprintf("created_at"),
+	sqlf.Sprintf("updated_at"),
+}
+
+const executorSecretsListQueryFmtstr = `
+SELECT %s
+FROM (
+	SELECT
+		%s,
+		RANK() OVER(
+			PARTITION BY key
+			ORDER BY
+				namespace_user_id NULLS LAST,
+				namespace_org_id NULLS LAST
+		)
+	FROM executor_secrets
+	WHERE %s
+) executor_secrets
+WHERE
+	executor_secrets.rank = 1
+ORDER BY key ASC
+%s  -- LIMIT clause
+`
+
+const executorSecretsCountQueryFmtstr = `
+SELECT COUNT(*)
+FROM (
+	SELECT
+		RANK() OVER(
+			PARTITION BY key
+			ORDER BY
+				namespace_user_id NULLS LAST,
+				namespace_org_id NULLS LAST
+		)
+	FROM executor_secrets
+	WHERE %s
+) executor_secrets
+WHERE
+	executor_secrets.rank = 1
+`
+
+const executorSecretCreateQueryFmtstr = `
+INSERT INTO
+	executor_secrets (
+		scope,
+		key,
+		value,
+		encryption_key_id,
+		namespace_user_id,
+		namespace_org_id,
+		creator_id,
+		created_at,
+		updated_at
+	)
+	VALUES (
+		%s,
+		%s,
+		%s,
+		%s,
+		%s,
+		%s,
+		%s,
+		NOW(),
+		NOW()
+	)
+	RETURNING %s
+`
+
+const executorSecretUpdateQueryFmtstr = `
+UPDATE executor_secrets
+SET
+	value = %s,
+	encryption_key_id = %s,
+	updated_at = %s
+WHERE
+	id = %s AND
+	scope = %s AND
+	%s -- authz query conds
+RETURNING %s
+`
+
+// scanExecutorSecret scans a secret from the given scanner into the given
+// ExecutorSecret.
+func scanExecutorSecret(secret *ExecutorSecret, key encryption.Key, s interface {
+	Scan(...any) error
+}) error {
+	var (
+		value []byte
+		keyID string
+	)
+
+	if err := s.Scan(
+		&secret.ID,
+		&secret.Scope,
+		&secret.Key,
+		&value,
+		&dbutil.NullString{S: &keyID},
+		&dbutil.NullInt32{N: &secret.NamespaceUserID},
+		&dbutil.NullInt32{N: &secret.NamespaceOrgID},
+		&dbutil.NullInt32{N: &secret.CreatorID},
+		&secret.CreatedAt,
+		&secret.UpdatedAt,
+	); err != nil {
+		return err
+	}
+
+	secret.encryptedValue = NewEncryptedCredential(string(value), keyID, key)
+	return nil
+}
+
+func ensureActorHasNamespaceAccess(ctx context.Context, db DB, secret *ExecutorSecret) error {
+	a := actor.FromContext(ctx)
+	if a.IsInternal() {
+		return nil
+	}
+	if !a.IsAuthenticated() {
+		return errors.New("not logged in")
+	}
+
+	// TODO: This should use the helpers from the auth package, but that package
+	// today depends on the database package, so that would be an import cycle.
+	if secret.NamespaceOrgID != 0 {
+		// Check if the current user is org member.
+		resp, err := db.OrgMembers().GetByOrgIDAndUserID(ctx, secret.NamespaceOrgID, a.UID)
+		if err != nil {
+			if !errcode.IsNotFound(err) {
+				return err
+			}
+			// Not found case: Fall through and eventually end up down at the site-admin
+			// check.
+		}
+		// If membership is found, the user may pass.
+		if resp != nil {
+			return nil
+		}
+	} else if secret.NamespaceUserID != 0 {
+		// If the actor is the same user as the namespace user, pass. Otherwise
+		// fall through and check if they're site-admin.
+		if a.UID == secret.NamespaceUserID {
+			return nil
+		}
+	}
+
+	// Check user is site admin.
+	user, err := db.Users().GetByID(ctx, a.UID)
+	if err != nil {
+		return err
+	}
+	if user == nil || !user.SiteAdmin {
+		return errors.New("not site-admin")
+	}
+	return nil
+}
+
+// executorSecretsAuthzQueryConds generates authz query conditions for checking
+// access to the secret at the database level.
+// Internal actors will always pass.
+func executorSecretsAuthzQueryConds(ctx context.Context) (*sqlf.Query, error) {
+	a := actor.FromContext(ctx)
+	if a.IsInternal() {
+		return sqlf.Sprintf("(TRUE)"), nil
+	}
+
+	return sqlf.Sprintf(
+		executorSecretsAuthzQueryCondsFmtstr,
+		a.UID,
+		a.UID,
+		a.UID,
+	), nil
+}
+
+// executorSecretsAuthzQueryCondsFmtstr contains the SQL used to determine if a user
+// has access to the given secret value. It is used in every query to ensure that
+// the store never returns secrets that are not meant to be seen by them.
+const executorSecretsAuthzQueryCondsFmtstr = `
+(
+	(
+		-- user is the same as the actor
+		executor_secrets.namespace_user_id = %s
+	)
+	OR
+	(
+		-- actor is part of the org
+		executor_secrets.namespace_org_id IS NOT NULL
+		AND
+		EXISTS (
+			SELECT 1
+			FROM orgs
+			JOIN org_members ON org_members.org_id = orgs.id
+			WHERE org_members.user_id = %s
+		)
+	)
+	OR
+	(
+		-- actor is site admin
+		EXISTS (
+			SELECT 1
+			FROM users
+			WHERE site_admin = TRUE AND id = %s  -- actor user ID
+		)
+	)
+)
+`
+
+// encryptExecutorSecret encrypts the given raw secret value if encryption is enabled
+// and returns the encrypted data and the associated encryption key ID.
+func encryptExecutorSecret(ctx context.Context, key encryption.Key, raw string) ([]byte, string, error) {
+	if len(raw) == 0 {
+		return nil, "", errors.New("got empty secret")
+	}
+	data, keyID, err := encryption.MaybeEncrypt(ctx, key, raw)
+	return []byte(data), keyID, err
+}

--- a/internal/database/executor_secrets.go
+++ b/internal/database/executor_secrets.go
@@ -74,6 +74,8 @@ type ExecutorSecretStore interface {
 	basestore.ShareableStore
 	With(basestore.ShareableStore) ExecutorSecretStore
 	Transact(context.Context) (ExecutorSecretStore, error)
+	Done(err error) error
+	ExecResult(ctx context.Context, query *sqlf.Query) (sql.Result, error)
 
 	// Create inserts the given ExecutorSecret into the database.
 	Create(ctx context.Context, scope ExecutorSecretScope, secret *ExecutorSecret, value string) error
@@ -107,7 +109,7 @@ type ExecutorSecretsListOpts struct {
 	NamespaceOrgID int32
 }
 
-func (opts ExecutorSecretsListOpts) sqlConds(ctx context.Context) (*sqlf.Query, error) {
+func (opts ExecutorSecretsListOpts) sqlConds(ctx context.Context, scope ExecutorSecretScope) (*sqlf.Query, error) {
 	authz, err := executorSecretsAuthzQueryConds(ctx)
 	if err != nil {
 		return nil, err
@@ -115,7 +117,10 @@ func (opts ExecutorSecretsListOpts) sqlConds(ctx context.Context) (*sqlf.Query, 
 
 	globalSecret := sqlf.Sprintf("namespace_user_id IS NULL AND namespace_org_id IS NULL")
 
-	preds := []*sqlf.Query{authz}
+	preds := []*sqlf.Query{
+		authz,
+		sqlf.Sprintf("scope = %s", scope),
+	}
 
 	if opts.NamespaceOrgID != 0 {
 		preds = append(preds, sqlf.Sprintf("(namespace_org_id = %s OR (%s))", opts.NamespaceOrgID, globalSecret))
@@ -176,7 +181,7 @@ func (s *executorSecretStore) Transact(ctx context.Context) (ExecutorSecretStore
 
 func (s *executorSecretStore) Create(ctx context.Context, scope ExecutorSecretScope, secret *ExecutorSecret, value string) error {
 	// SECURITY: check that the current user is authorized to create a secret for the given namespace.
-	if err := ensureActorHasNamespaceAccess(ctx, NewDBWith(s.logger, s), secret); err != nil {
+	if err := ensureActorHasNamespaceWriteAccess(ctx, NewDBWith(s.logger, s), secret); err != nil {
 		return err
 	}
 
@@ -211,8 +216,8 @@ func (s *executorSecretStore) Create(ctx context.Context, scope ExecutorSecretSc
 }
 
 func (s *executorSecretStore) Update(ctx context.Context, scope ExecutorSecretScope, secret *ExecutorSecret, value string) error {
-	// SECURITY: check that the current user is authorized to create a secret for the given namespace.
-	if err := ensureActorHasNamespaceAccess(ctx, NewDBWith(s.logger, s), secret); err != nil {
+	// SECURITY: check that the current user is authorized to update a secret in the given namespace.
+	if err := ensureActorHasNamespaceWriteAccess(ctx, NewDBWith(s.logger, s), secret); err != nil {
 		return err
 	}
 
@@ -247,13 +252,37 @@ func (s *executorSecretStore) Update(ctx context.Context, scope ExecutorSecretSc
 }
 
 func (s *executorSecretStore) Delete(ctx context.Context, scope ExecutorSecretScope, id int64) error {
+	// Grab the secret and make sure that namespace write access from the actor
+	// is acceptable.
+	var tx ExecutorSecretStore
+	if s.InTransaction() {
+		tx = s
+	} else {
+		var err error
+		tx, err = s.Transact(ctx)
+		if err != nil {
+			return err
+		}
+		defer func() { err = tx.Done(err) }()
+	}
+
+	secret, err := tx.GetByID(ctx, scope, id)
+	if err != nil {
+		return err
+	}
+
+	// SECURITY: check that the current user is authorized to delete a secret in the given namespace.
+	if err := ensureActorHasNamespaceWriteAccess(ctx, NewDBWith(s.logger, tx), secret); err != nil {
+		return err
+	}
+
 	authz, err := executorSecretsAuthzQueryConds(ctx)
 	if err != nil {
 		return err
 	}
 
 	q := sqlf.Sprintf("DELETE FROM executor_secrets WHERE id = %s AND scope = %s AND %s", id, scope, authz)
-	res, err := s.ExecResult(ctx, q)
+	res, err := tx.ExecResult(ctx, q)
 	if err != nil {
 		return err
 	}
@@ -292,7 +321,7 @@ func (s *executorSecretStore) GetByID(ctx context.Context, scope ExecutorSecretS
 }
 
 func (s *executorSecretStore) List(ctx context.Context, scope ExecutorSecretScope, opts ExecutorSecretsListOpts) ([]*ExecutorSecret, int, error) {
-	conds, err := opts.sqlConds(ctx)
+	conds, err := opts.sqlConds(ctx, scope)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -332,7 +361,7 @@ func (s *executorSecretStore) List(ctx context.Context, scope ExecutorSecretScop
 }
 
 func (s *executorSecretStore) Count(ctx context.Context, scope ExecutorSecretScope, opts ExecutorSecretsListOpts) (int, error) {
-	conds, err := opts.sqlConds(ctx)
+	conds, err := opts.sqlConds(ctx, scope)
 	if err != nil {
 		return 0, err
 	}
@@ -471,7 +500,7 @@ func scanExecutorSecret(secret *ExecutorSecret, key encryption.Key, s interface 
 	return nil
 }
 
-func ensureActorHasNamespaceAccess(ctx context.Context, db DB, secret *ExecutorSecret) error {
+func ensureActorHasNamespaceWriteAccess(ctx context.Context, db DB, secret *ExecutorSecret) error {
 	a := actor.FromContext(ctx)
 	if a.IsInternal() {
 		return nil
@@ -496,6 +525,8 @@ func ensureActorHasNamespaceAccess(ctx context.Context, db DB, secret *ExecutorS
 		if resp != nil {
 			return nil
 		}
+		// Not a member case: Fall through and eventually end up down at the site-admin
+		// check.
 	} else if secret.NamespaceUserID != 0 {
 		// If the actor is the same user as the namespace user, pass. Otherwise
 		// fall through and check if they're site-admin.

--- a/internal/database/executor_secrets_test.go
+++ b/internal/database/executor_secrets_test.go
@@ -185,6 +185,11 @@ func TestExecutorSecrets_CreateUpdateDelete(t *testing.T) {
 				t.Fatal("unexpected non-nil error")
 			}
 		})
+		t.Run("empty secret is forbidden", func(t *testing.T) {
+			if err := store.Create(ctx, ExecutorSecretScopeBatches, secret, ""); err == nil {
+				t.Fatal("unexpected non-nil error")
+			}
+		})
 		if err := store.Create(ctx, ExecutorSecretScopeBatches, secret, secretVal); err != nil {
 			t.Fatal(err)
 		}
@@ -214,6 +219,12 @@ func TestExecutorSecrets_CreateUpdateDelete(t *testing.T) {
 
 			t.Run("non-admin user cannot update global secret", func(t *testing.T) {
 				if err := store.Update(userCtx, ExecutorSecretScopeBatches, secret, newSecretValue); err == nil {
+					t.Fatal("unexpected non-nil error")
+				}
+			})
+
+			t.Run("empty secret is forbidden", func(t *testing.T) {
+				if err := store.Update(ctx, ExecutorSecretScopeBatches, secret, ""); err == nil {
 					t.Fatal("unexpected non-nil error")
 				}
 			})

--- a/internal/database/executor_secrets_test.go
+++ b/internal/database/executor_secrets_test.go
@@ -1,0 +1,391 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func TestEnsureActorHasNamespaceWriteAccess(t *testing.T) {
+	userID := int32(1)
+	adminID := int32(2)
+	orgID := int32(1)
+
+	db := NewMockDB()
+	us := NewMockUserStore()
+	us.GetByIDFunc.SetDefaultHook(func(ctx context.Context, i int32) (*types.User, error) {
+		if i == userID {
+			return &types.User{
+				SiteAdmin: false,
+			}, nil
+		}
+		if i == adminID {
+			return &types.User{
+				SiteAdmin: true,
+			}, nil
+		}
+		return nil, errors.New("not found")
+	})
+	db.UsersFunc.SetDefaultReturn(us)
+	om := NewMockOrgMemberStore()
+	om.GetByOrgIDAndUserIDFunc.SetDefaultHook(func(ctx context.Context, oid, uid int32) (*types.OrgMembership, error) {
+		if uid == userID && oid == orgID {
+			// Is a member.
+			return &types.OrgMembership{}, nil
+		}
+		return nil, nil
+	})
+	db.OrgMembersFunc.SetDefaultReturn(om)
+
+	internalCtx := actor.WithInternalActor(context.Background())
+	userCtx := actor.WithActor(context.Background(), actor.FromUser(userID))
+	adminCtx := actor.WithActor(context.Background(), actor.FromUser(adminID))
+	unauthedCtx := context.Background()
+
+	tts := []struct {
+		name            string
+		namespaceOrgID  int32
+		namespaceUserID int32
+		ctx             context.Context
+		wantErr         bool
+	}{
+		{
+			name:    "unauthed actor accessing global secret",
+			ctx:     unauthedCtx,
+			wantErr: true,
+		},
+		{
+			name:            "unauthed actor accessing user secret",
+			namespaceUserID: userID,
+			ctx:             unauthedCtx,
+			wantErr:         true,
+		},
+		{
+			name:           "unauthed actor accessing org secret",
+			namespaceOrgID: orgID,
+			ctx:            unauthedCtx,
+			wantErr:        true,
+		},
+		{
+			name:    "internal actor accessing global secret",
+			ctx:     internalCtx,
+			wantErr: false,
+		},
+		{
+			name:            "internal actor accessing user secret",
+			namespaceUserID: userID,
+			ctx:             internalCtx,
+			wantErr:         false,
+		},
+		{
+			name:           "internal actor accessing org secret",
+			namespaceOrgID: orgID,
+			ctx:            internalCtx,
+			wantErr:        false,
+		},
+		{
+			name:    "site admin accessing global secret",
+			ctx:     adminCtx,
+			wantErr: false,
+		},
+		{
+			name:            "site admin accessing user secret",
+			namespaceUserID: userID,
+			ctx:             adminCtx,
+			wantErr:         false,
+		},
+		{
+			name:           "site admin accessing org secret",
+			namespaceOrgID: orgID,
+			ctx:            adminCtx,
+			wantErr:        false,
+		},
+		{
+			name:    "user accessing global secret",
+			ctx:     userCtx,
+			wantErr: true,
+		},
+		{
+			name:            "user accessing user secret",
+			namespaceUserID: userID,
+			ctx:             userCtx,
+			wantErr:         false,
+		},
+		{
+			name:            "user accessing user secret of other user",
+			namespaceUserID: userID + 1,
+			ctx:             userCtx,
+			wantErr:         true,
+		},
+		{
+			name:           "user accessing org secret",
+			namespaceOrgID: orgID,
+			ctx:            userCtx,
+			wantErr:        false,
+		},
+		{
+			name:           "user accessing org secret where not member",
+			namespaceOrgID: orgID + 1,
+			ctx:            userCtx,
+			wantErr:        true,
+		},
+	}
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			secret := &ExecutorSecret{}
+			if tt.namespaceOrgID != 0 {
+				secret.NamespaceOrgID = tt.namespaceOrgID
+			}
+			if tt.namespaceUserID != 0 {
+				secret.NamespaceUserID = tt.namespaceUserID
+			}
+			err := ensureActorHasNamespaceWriteAccess(tt.ctx, db, secret)
+			if have, want := err != nil, tt.wantErr; have != want {
+				t.Fatalf("unexpected err state: have=%t want=%t", have, want)
+			}
+		})
+	}
+}
+
+func TestExecutorSecrets_CreateUpdateDelete(t *testing.T) {
+	// Use an internal actor for most of these tests, namespace access is already properly
+	// tested further down separately.
+	ctx := actor.WithInternalActor(context.Background())
+	logger := logtest.NoOp(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	user, err := db.Users().Create(ctx, NewUser{Username: "johndoe"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Users().SetIsSiteAdmin(ctx, user.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	org, err := db.Orgs().Create(ctx, "the-org", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	userCtx := actor.WithActor(context.Background(), actor.FromUser(user.ID))
+	store := db.ExecutorSecrets(&encryption.NoopKey{})
+	secretVal := "sosecret"
+	t.Run("global secret", func(t *testing.T) {
+		secret := &ExecutorSecret{
+			Key:       "GH_TOKEN",
+			CreatorID: user.ID,
+		}
+		t.Run("non-admin user cannot create global secret", func(t *testing.T) {
+			if err := store.Create(userCtx, ExecutorSecretScopeBatches, secret, secretVal); err == nil {
+				t.Fatal("unexpected non-nil error")
+			}
+		})
+		if err := store.Create(ctx, ExecutorSecretScopeBatches, secret, secretVal); err != nil {
+			t.Fatal(err)
+		}
+		if val, err := secret.Value(ctx, NewMockExecutorSecretAccessLogStore()); err != nil {
+			t.Fatal(err)
+		} else if val != secretVal {
+			t.Fatalf("stored value does not match passed secret have=%q want=%q", val, secretVal)
+		}
+		if have, want := secret.Scope, ExecutorSecretScopeBatches; have != want {
+			t.Fatalf("invalid scope stored: have=%q want=%q", have, want)
+		}
+		if have, want := secret.CreatorID, user.ID; have != want {
+			t.Fatalf("invalid creator ID stored: have=%q want=%q", have, want)
+		}
+		t.Run("duplicate keys are forbidden", func(t *testing.T) {
+			secret := &ExecutorSecret{
+				Key:       "GH_TOKEN",
+				CreatorID: user.ID,
+			}
+			err := store.Create(ctx, ExecutorSecretScopeBatches, secret, secretVal)
+			if err == nil {
+				t.Fatal("no error for duplicate key")
+			}
+		})
+		t.Run("update", func(t *testing.T) {
+			newSecretValue := "evenmoresecret"
+
+			t.Run("non-admin user cannot update global secret", func(t *testing.T) {
+				if err := store.Update(userCtx, ExecutorSecretScopeBatches, secret, newSecretValue); err == nil {
+					t.Fatal("unexpected non-nil error")
+				}
+			})
+
+			if err := store.Update(ctx, ExecutorSecretScopeBatches, secret, newSecretValue); err != nil {
+				t.Fatal(err)
+			}
+			if val, err := secret.Value(ctx, NewMockExecutorSecretAccessLogStore()); err != nil {
+				t.Fatal(err)
+			} else if val != newSecretValue {
+				t.Fatalf("stored value does not match passed secret have=%q want=%q", val, newSecretValue)
+			}
+		})
+		t.Run("delete", func(t *testing.T) {
+			t.Run("non-admin user cannot delete global secret", func(t *testing.T) {
+				if err := store.Delete(userCtx, ExecutorSecretScopeBatches, secret.ID); err == nil {
+					t.Fatal("unexpected non-nil error")
+				}
+			})
+
+			if err := store.Delete(ctx, ExecutorSecretScopeBatches, secret.ID); err != nil {
+				t.Fatal(err)
+			}
+			_, err = store.GetByID(ctx, ExecutorSecretScopeBatches, secret.ID)
+			if err == nil {
+				t.Fatal("secret not deleted")
+			}
+			esnfe := &ExecutorSecretNotFoundErr{}
+			if !errors.As(err, esnfe) {
+				t.Fatal("invalid error returned, expected not found")
+			}
+		})
+	})
+	t.Run("user secret", func(t *testing.T) {
+		secret := &ExecutorSecret{
+			Key:             "GH_TOKEN",
+			NamespaceUserID: user.ID,
+			CreatorID:       user.ID,
+		}
+		if err := store.Create(ctx, ExecutorSecretScopeBatches, secret, secretVal); err != nil {
+			t.Fatal(err)
+		}
+		if val, err := secret.Value(ctx, NewMockExecutorSecretAccessLogStore()); err != nil {
+			t.Fatal(err)
+		} else if val != secretVal {
+			t.Fatalf("stored value does not match passed secret have=%q want=%q", val, secretVal)
+		}
+		if have, want := secret.Scope, ExecutorSecretScopeBatches; have != want {
+			t.Fatalf("invalid scope stored: have=%q want=%q", have, want)
+		}
+		if have, want := secret.CreatorID, user.ID; have != want {
+			t.Fatalf("invalid creator ID stored: have=%q want=%q", have, want)
+		}
+		if have, want := secret.NamespaceUserID, user.ID; have != want {
+			t.Fatalf("invalid namespace user ID stored: have=%q want=%q", have, want)
+		}
+		t.Run("duplicate keys are forbidden", func(t *testing.T) {
+			secret := &ExecutorSecret{
+				Key:             "GH_TOKEN",
+				NamespaceUserID: user.ID,
+				CreatorID:       user.ID,
+			}
+			err := store.Create(ctx, ExecutorSecretScopeBatches, secret, secretVal)
+			if err == nil {
+				t.Fatal("no error for duplicate key")
+			}
+		})
+		t.Run("update", func(t *testing.T) {
+			newSecretValue := "evenmoresecret"
+			if err := store.Update(ctx, ExecutorSecretScopeBatches, secret, newSecretValue); err != nil {
+				t.Fatal(err)
+			}
+			if val, err := secret.Value(ctx, NewMockExecutorSecretAccessLogStore()); err != nil {
+				t.Fatal(err)
+			} else if val != newSecretValue {
+				t.Fatalf("stored value does not match passed secret have=%q want=%q", val, newSecretValue)
+			}
+		})
+		t.Run("delete", func(t *testing.T) {
+			if err := store.Delete(ctx, ExecutorSecretScopeBatches, secret.ID); err != nil {
+				t.Fatal(err)
+			}
+			_, err = store.GetByID(ctx, ExecutorSecretScopeBatches, secret.ID)
+			if err == nil {
+				t.Fatal("secret not deleted")
+			}
+			esnfe := &ExecutorSecretNotFoundErr{}
+			if !errors.As(err, esnfe) {
+				t.Fatal("invalid error returned, expected not found")
+			}
+		})
+	})
+	t.Run("org secret", func(t *testing.T) {
+		secret := &ExecutorSecret{
+			Key:            "GH_TOKEN",
+			NamespaceOrgID: org.ID,
+			CreatorID:      user.ID,
+		}
+		if err := store.Create(ctx, ExecutorSecretScopeBatches, secret, secretVal); err != nil {
+			t.Fatal(err)
+		}
+		if val, err := secret.Value(ctx, NewMockExecutorSecretAccessLogStore()); err != nil {
+			t.Fatal(err)
+		} else if val != secretVal {
+			t.Fatalf("stored value does not match passed secret have=%q want=%q", val, secretVal)
+		}
+		if have, want := secret.Scope, ExecutorSecretScopeBatches; have != want {
+			t.Fatalf("invalid scope stored: have=%q want=%q", have, want)
+		}
+		if have, want := secret.CreatorID, user.ID; have != want {
+			t.Fatalf("invalid creator ID stored: have=%q want=%q", have, want)
+		}
+		if have, want := secret.NamespaceOrgID, org.ID; have != want {
+			t.Fatalf("invalid namespace org ID stored: have=%q want=%q", have, want)
+		}
+		t.Run("duplicate keys are forbidden", func(t *testing.T) {
+			secret := &ExecutorSecret{
+				Key:            "GH_TOKEN",
+				NamespaceOrgID: org.ID,
+				CreatorID:      user.ID,
+			}
+			err := store.Create(ctx, ExecutorSecretScopeBatches, secret, secretVal)
+			if err == nil {
+				t.Fatal("no error for duplicate key")
+			}
+		})
+		t.Run("update", func(t *testing.T) {
+			newSecretValue := "evenmoresecret"
+			if err := store.Update(ctx, ExecutorSecretScopeBatches, secret, newSecretValue); err != nil {
+				t.Fatal(err)
+			}
+			if val, err := secret.Value(ctx, NewMockExecutorSecretAccessLogStore()); err != nil {
+				t.Fatal(err)
+			} else if val != newSecretValue {
+				t.Fatalf("stored value does not match passed secret have=%q want=%q", val, newSecretValue)
+			}
+		})
+		t.Run("delete", func(t *testing.T) {
+			if err := store.Delete(ctx, ExecutorSecretScopeBatches, secret.ID); err != nil {
+				t.Fatal(err)
+			}
+			_, err = store.GetByID(ctx, ExecutorSecretScopeBatches, secret.ID)
+			if err == nil {
+				t.Fatal("secret not deleted")
+			}
+			esnfe := &ExecutorSecretNotFoundErr{}
+			if !errors.As(err, esnfe) {
+				t.Fatal("invalid error returned, expected not found")
+			}
+		})
+	})
+}
+
+func TestExecutorSecretNotFoundError(t *testing.T) {
+	err := ExecutorSecretNotFoundErr{}
+	if have := errcode.IsNotFound(err); !have {
+		t.Error("ExecutorSecretNotFoundErr does not say it represents a not found error")
+	}
+}
+
+func TestExecutorSecret_Value(t *testing.T) {
+	secretVal := "sosecret"
+	esal := NewMockExecutorSecretAccessLogStore()
+	secret := &ExecutorSecret{encryptedValue: NewUnencryptedCredential([]byte(secretVal))}
+	val, err := secret.Value(context.Background(), esal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val != secretVal {
+		t.Fatalf("invalid secret value returned: want=%q have=%q", secretVal, val)
+	}
+	if len(esal.CreateFunc.History()) != 1 {
+		t.Fatal("no access log entry created")
+	}
+}

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -14050,6 +14050,12 @@ type MockExecutorSecretStore struct {
 	// DeleteFunc is an instance of a mock function object controlling the
 	// behavior of the method Delete.
 	DeleteFunc *ExecutorSecretStoreDeleteFunc
+	// DoneFunc is an instance of a mock function object controlling the
+	// behavior of the method Done.
+	DoneFunc *ExecutorSecretStoreDoneFunc
+	// ExecResultFunc is an instance of a mock function object controlling
+	// the behavior of the method ExecResult.
+	ExecResultFunc *ExecutorSecretStoreExecResultFunc
 	// GetByIDFunc is an instance of a mock function object controlling the
 	// behavior of the method GetByID.
 	GetByIDFunc *ExecutorSecretStoreGetByIDFunc
@@ -14087,6 +14093,16 @@ func NewMockExecutorSecretStore() *MockExecutorSecretStore {
 		},
 		DeleteFunc: &ExecutorSecretStoreDeleteFunc{
 			defaultHook: func(context.Context, ExecutorSecretScope, int64) (r0 error) {
+				return
+			},
+		},
+		DoneFunc: &ExecutorSecretStoreDoneFunc{
+			defaultHook: func(error) (r0 error) {
+				return
+			},
+		},
+		ExecResultFunc: &ExecutorSecretStoreExecResultFunc{
+			defaultHook: func(context.Context, *sqlf.Query) (r0 sql.Result, r1 error) {
 				return
 			},
 		},
@@ -14143,6 +14159,16 @@ func NewStrictMockExecutorSecretStore() *MockExecutorSecretStore {
 				panic("unexpected invocation of MockExecutorSecretStore.Delete")
 			},
 		},
+		DoneFunc: &ExecutorSecretStoreDoneFunc{
+			defaultHook: func(error) error {
+				panic("unexpected invocation of MockExecutorSecretStore.Done")
+			},
+		},
+		ExecResultFunc: &ExecutorSecretStoreExecResultFunc{
+			defaultHook: func(context.Context, *sqlf.Query) (sql.Result, error) {
+				panic("unexpected invocation of MockExecutorSecretStore.ExecResult")
+			},
+		},
 		GetByIDFunc: &ExecutorSecretStoreGetByIDFunc{
 			defaultHook: func(context.Context, ExecutorSecretScope, int64) (*ExecutorSecret, error) {
 				panic("unexpected invocation of MockExecutorSecretStore.GetByID")
@@ -14189,6 +14215,12 @@ func NewMockExecutorSecretStoreFrom(i ExecutorSecretStore) *MockExecutorSecretSt
 		},
 		DeleteFunc: &ExecutorSecretStoreDeleteFunc{
 			defaultHook: i.Delete,
+		},
+		DoneFunc: &ExecutorSecretStoreDoneFunc{
+			defaultHook: i.Done,
+		},
+		ExecResultFunc: &ExecutorSecretStoreExecResultFunc{
+			defaultHook: i.ExecResult,
 		},
 		GetByIDFunc: &ExecutorSecretStoreGetByIDFunc{
 			defaultHook: i.GetByID,
@@ -14539,6 +14571,218 @@ func (c ExecutorSecretStoreDeleteFuncCall) Args() []interface{} {
 // invocation.
 func (c ExecutorSecretStoreDeleteFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
+}
+
+// ExecutorSecretStoreDoneFunc describes the behavior when the Done method
+// of the parent MockExecutorSecretStore instance is invoked.
+type ExecutorSecretStoreDoneFunc struct {
+	defaultHook func(error) error
+	hooks       []func(error) error
+	history     []ExecutorSecretStoreDoneFuncCall
+	mutex       sync.Mutex
+}
+
+// Done delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockExecutorSecretStore) Done(v0 error) error {
+	r0 := m.DoneFunc.nextHook()(v0)
+	m.DoneFunc.appendCall(ExecutorSecretStoreDoneFuncCall{v0, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the Done method of the
+// parent MockExecutorSecretStore instance is invoked and the hook queue is
+// empty.
+func (f *ExecutorSecretStoreDoneFunc) SetDefaultHook(hook func(error) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Done method of the parent MockExecutorSecretStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *ExecutorSecretStoreDoneFunc) PushHook(hook func(error) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretStoreDoneFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(error) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretStoreDoneFunc) PushReturn(r0 error) {
+	f.PushHook(func(error) error {
+		return r0
+	})
+}
+
+func (f *ExecutorSecretStoreDoneFunc) nextHook() func(error) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretStoreDoneFunc) appendCall(r0 ExecutorSecretStoreDoneFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExecutorSecretStoreDoneFuncCall objects
+// describing the invocations of this function.
+func (f *ExecutorSecretStoreDoneFunc) History() []ExecutorSecretStoreDoneFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretStoreDoneFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretStoreDoneFuncCall is an object that describes an invocation
+// of method Done on an instance of MockExecutorSecretStore.
+type ExecutorSecretStoreDoneFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 error
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretStoreDoneFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretStoreDoneFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// ExecutorSecretStoreExecResultFunc describes the behavior when the
+// ExecResult method of the parent MockExecutorSecretStore instance is
+// invoked.
+type ExecutorSecretStoreExecResultFunc struct {
+	defaultHook func(context.Context, *sqlf.Query) (sql.Result, error)
+	hooks       []func(context.Context, *sqlf.Query) (sql.Result, error)
+	history     []ExecutorSecretStoreExecResultFuncCall
+	mutex       sync.Mutex
+}
+
+// ExecResult delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockExecutorSecretStore) ExecResult(v0 context.Context, v1 *sqlf.Query) (sql.Result, error) {
+	r0, r1 := m.ExecResultFunc.nextHook()(v0, v1)
+	m.ExecResultFunc.appendCall(ExecutorSecretStoreExecResultFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the ExecResult method of
+// the parent MockExecutorSecretStore instance is invoked and the hook queue
+// is empty.
+func (f *ExecutorSecretStoreExecResultFunc) SetDefaultHook(hook func(context.Context, *sqlf.Query) (sql.Result, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ExecResult method of the parent MockExecutorSecretStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *ExecutorSecretStoreExecResultFunc) PushHook(hook func(context.Context, *sqlf.Query) (sql.Result, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretStoreExecResultFunc) SetDefaultReturn(r0 sql.Result, r1 error) {
+	f.SetDefaultHook(func(context.Context, *sqlf.Query) (sql.Result, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretStoreExecResultFunc) PushReturn(r0 sql.Result, r1 error) {
+	f.PushHook(func(context.Context, *sqlf.Query) (sql.Result, error) {
+		return r0, r1
+	})
+}
+
+func (f *ExecutorSecretStoreExecResultFunc) nextHook() func(context.Context, *sqlf.Query) (sql.Result, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretStoreExecResultFunc) appendCall(r0 ExecutorSecretStoreExecResultFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExecutorSecretStoreExecResultFuncCall
+// objects describing the invocations of this function.
+func (f *ExecutorSecretStoreExecResultFunc) History() []ExecutorSecretStoreExecResultFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretStoreExecResultFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretStoreExecResultFuncCall is an object that describes an
+// invocation of method ExecResult on an instance of
+// MockExecutorSecretStore.
+type ExecutorSecretStoreExecResultFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 *sqlf.Query
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 sql.Result
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretStoreExecResultFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretStoreExecResultFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // ExecutorSecretStoreGetByIDFunc describes the behavior when the GetByID

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -3641,6 +3641,12 @@ type MockDB struct {
 	// ExecContextFunc is an instance of a mock function object controlling
 	// the behavior of the method ExecContext.
 	ExecContextFunc *DBExecContextFunc
+	// ExecutorSecretAccessLogsFunc is an instance of a mock function object
+	// controlling the behavior of the method ExecutorSecretAccessLogs.
+	ExecutorSecretAccessLogsFunc *DBExecutorSecretAccessLogsFunc
+	// ExecutorSecretsFunc is an instance of a mock function object
+	// controlling the behavior of the method ExecutorSecrets.
+	ExecutorSecretsFunc *DBExecutorSecretsFunc
 	// ExecutorsFunc is an instance of a mock function object controlling
 	// the behavior of the method Executors.
 	ExecutorsFunc *DBExecutorsFunc
@@ -3775,6 +3781,16 @@ func NewMockDB() *MockDB {
 		},
 		ExecContextFunc: &DBExecContextFunc{
 			defaultHook: func(context.Context, string, ...interface{}) (r0 sql.Result, r1 error) {
+				return
+			},
+		},
+		ExecutorSecretAccessLogsFunc: &DBExecutorSecretAccessLogsFunc{
+			defaultHook: func() (r0 ExecutorSecretAccessLogStore) {
+				return
+			},
+		},
+		ExecutorSecretsFunc: &DBExecutorSecretsFunc{
+			defaultHook: func(encryption.Key) (r0 ExecutorSecretStore) {
 				return
 			},
 		},
@@ -3980,6 +3996,16 @@ func NewStrictMockDB() *MockDB {
 				panic("unexpected invocation of MockDB.ExecContext")
 			},
 		},
+		ExecutorSecretAccessLogsFunc: &DBExecutorSecretAccessLogsFunc{
+			defaultHook: func() ExecutorSecretAccessLogStore {
+				panic("unexpected invocation of MockDB.ExecutorSecretAccessLogs")
+			},
+		},
+		ExecutorSecretsFunc: &DBExecutorSecretsFunc{
+			defaultHook: func(encryption.Key) ExecutorSecretStore {
+				panic("unexpected invocation of MockDB.ExecutorSecrets")
+			},
+		},
 		ExecutorsFunc: &DBExecutorsFunc{
 			defaultHook: func() ExecutorStore {
 				panic("unexpected invocation of MockDB.Executors")
@@ -4167,6 +4193,12 @@ func NewMockDBFrom(i DB) *MockDB {
 		},
 		ExecContextFunc: &DBExecContextFunc{
 			defaultHook: i.ExecContext,
+		},
+		ExecutorSecretAccessLogsFunc: &DBExecutorSecretAccessLogsFunc{
+			defaultHook: i.ExecutorSecretAccessLogs,
+		},
+		ExecutorSecretsFunc: &DBExecutorSecretsFunc{
+			defaultHook: i.ExecutorSecrets,
 		},
 		ExecutorsFunc: &DBExecutorsFunc{
 			defaultHook: i.Executors,
@@ -4976,6 +5008,207 @@ func (c DBExecContextFuncCall) Args() []interface{} {
 // invocation.
 func (c DBExecContextFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// DBExecutorSecretAccessLogsFunc describes the behavior when the
+// ExecutorSecretAccessLogs method of the parent MockDB instance is invoked.
+type DBExecutorSecretAccessLogsFunc struct {
+	defaultHook func() ExecutorSecretAccessLogStore
+	hooks       []func() ExecutorSecretAccessLogStore
+	history     []DBExecutorSecretAccessLogsFuncCall
+	mutex       sync.Mutex
+}
+
+// ExecutorSecretAccessLogs delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockDB) ExecutorSecretAccessLogs() ExecutorSecretAccessLogStore {
+	r0 := m.ExecutorSecretAccessLogsFunc.nextHook()()
+	m.ExecutorSecretAccessLogsFunc.appendCall(DBExecutorSecretAccessLogsFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// ExecutorSecretAccessLogs method of the parent MockDB instance is invoked
+// and the hook queue is empty.
+func (f *DBExecutorSecretAccessLogsFunc) SetDefaultHook(hook func() ExecutorSecretAccessLogStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ExecutorSecretAccessLogs method of the parent MockDB instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *DBExecutorSecretAccessLogsFunc) PushHook(hook func() ExecutorSecretAccessLogStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *DBExecutorSecretAccessLogsFunc) SetDefaultReturn(r0 ExecutorSecretAccessLogStore) {
+	f.SetDefaultHook(func() ExecutorSecretAccessLogStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *DBExecutorSecretAccessLogsFunc) PushReturn(r0 ExecutorSecretAccessLogStore) {
+	f.PushHook(func() ExecutorSecretAccessLogStore {
+		return r0
+	})
+}
+
+func (f *DBExecutorSecretAccessLogsFunc) nextHook() func() ExecutorSecretAccessLogStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBExecutorSecretAccessLogsFunc) appendCall(r0 DBExecutorSecretAccessLogsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBExecutorSecretAccessLogsFuncCall objects
+// describing the invocations of this function.
+func (f *DBExecutorSecretAccessLogsFunc) History() []DBExecutorSecretAccessLogsFuncCall {
+	f.mutex.Lock()
+	history := make([]DBExecutorSecretAccessLogsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBExecutorSecretAccessLogsFuncCall is an object that describes an
+// invocation of method ExecutorSecretAccessLogs on an instance of MockDB.
+type DBExecutorSecretAccessLogsFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 ExecutorSecretAccessLogStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DBExecutorSecretAccessLogsFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBExecutorSecretAccessLogsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// DBExecutorSecretsFunc describes the behavior when the ExecutorSecrets
+// method of the parent MockDB instance is invoked.
+type DBExecutorSecretsFunc struct {
+	defaultHook func(encryption.Key) ExecutorSecretStore
+	hooks       []func(encryption.Key) ExecutorSecretStore
+	history     []DBExecutorSecretsFuncCall
+	mutex       sync.Mutex
+}
+
+// ExecutorSecrets delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockDB) ExecutorSecrets(v0 encryption.Key) ExecutorSecretStore {
+	r0 := m.ExecutorSecretsFunc.nextHook()(v0)
+	m.ExecutorSecretsFunc.appendCall(DBExecutorSecretsFuncCall{v0, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the ExecutorSecrets
+// method of the parent MockDB instance is invoked and the hook queue is
+// empty.
+func (f *DBExecutorSecretsFunc) SetDefaultHook(hook func(encryption.Key) ExecutorSecretStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ExecutorSecrets method of the parent MockDB instance invokes the hook at
+// the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *DBExecutorSecretsFunc) PushHook(hook func(encryption.Key) ExecutorSecretStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *DBExecutorSecretsFunc) SetDefaultReturn(r0 ExecutorSecretStore) {
+	f.SetDefaultHook(func(encryption.Key) ExecutorSecretStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *DBExecutorSecretsFunc) PushReturn(r0 ExecutorSecretStore) {
+	f.PushHook(func(encryption.Key) ExecutorSecretStore {
+		return r0
+	})
+}
+
+func (f *DBExecutorSecretsFunc) nextHook() func(encryption.Key) ExecutorSecretStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBExecutorSecretsFunc) appendCall(r0 DBExecutorSecretsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBExecutorSecretsFuncCall objects
+// describing the invocations of this function.
+func (f *DBExecutorSecretsFunc) History() []DBExecutorSecretsFuncCall {
+	f.mutex.Lock()
+	history := make([]DBExecutorSecretsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBExecutorSecretsFuncCall is an object that describes an invocation of
+// method ExecutorSecrets on an instance of MockDB.
+type DBExecutorSecretsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 encryption.Key
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 ExecutorSecretStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DBExecutorSecretsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBExecutorSecretsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }
 
 // DBExecutorsFunc describes the behavior when the Executors method of the
@@ -12897,6 +13130,2056 @@ func (c EventLogStoreWithFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c EventLogStoreWithFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// MockExecutorSecretAccessLogStore is a mock implementation of the
+// ExecutorSecretAccessLogStore interface (from the package
+// github.com/sourcegraph/sourcegraph/internal/database) used for unit
+// testing.
+type MockExecutorSecretAccessLogStore struct {
+	// CountFunc is an instance of a mock function object controlling the
+	// behavior of the method Count.
+	CountFunc *ExecutorSecretAccessLogStoreCountFunc
+	// CreateFunc is an instance of a mock function object controlling the
+	// behavior of the method Create.
+	CreateFunc *ExecutorSecretAccessLogStoreCreateFunc
+	// GetByIDFunc is an instance of a mock function object controlling the
+	// behavior of the method GetByID.
+	GetByIDFunc *ExecutorSecretAccessLogStoreGetByIDFunc
+	// HandleFunc is an instance of a mock function object controlling the
+	// behavior of the method Handle.
+	HandleFunc *ExecutorSecretAccessLogStoreHandleFunc
+	// ListFunc is an instance of a mock function object controlling the
+	// behavior of the method List.
+	ListFunc *ExecutorSecretAccessLogStoreListFunc
+	// TransactFunc is an instance of a mock function object controlling the
+	// behavior of the method Transact.
+	TransactFunc *ExecutorSecretAccessLogStoreTransactFunc
+	// WithFunc is an instance of a mock function object controlling the
+	// behavior of the method With.
+	WithFunc *ExecutorSecretAccessLogStoreWithFunc
+}
+
+// NewMockExecutorSecretAccessLogStore creates a new mock of the
+// ExecutorSecretAccessLogStore interface. All methods return zero values
+// for all results, unless overwritten.
+func NewMockExecutorSecretAccessLogStore() *MockExecutorSecretAccessLogStore {
+	return &MockExecutorSecretAccessLogStore{
+		CountFunc: &ExecutorSecretAccessLogStoreCountFunc{
+			defaultHook: func(context.Context, ExecutorSecretAccessLogsListOpts) (r0 int, r1 error) {
+				return
+			},
+		},
+		CreateFunc: &ExecutorSecretAccessLogStoreCreateFunc{
+			defaultHook: func(context.Context, *ExecutorSecretAccessLog) (r0 error) {
+				return
+			},
+		},
+		GetByIDFunc: &ExecutorSecretAccessLogStoreGetByIDFunc{
+			defaultHook: func(context.Context, int64) (r0 *ExecutorSecretAccessLog, r1 error) {
+				return
+			},
+		},
+		HandleFunc: &ExecutorSecretAccessLogStoreHandleFunc{
+			defaultHook: func() (r0 basestore.TransactableHandle) {
+				return
+			},
+		},
+		ListFunc: &ExecutorSecretAccessLogStoreListFunc{
+			defaultHook: func(context.Context, ExecutorSecretAccessLogsListOpts) (r0 []*ExecutorSecretAccessLog, r1 int, r2 error) {
+				return
+			},
+		},
+		TransactFunc: &ExecutorSecretAccessLogStoreTransactFunc{
+			defaultHook: func(context.Context) (r0 ExecutorSecretAccessLogStore, r1 error) {
+				return
+			},
+		},
+		WithFunc: &ExecutorSecretAccessLogStoreWithFunc{
+			defaultHook: func(basestore.ShareableStore) (r0 ExecutorSecretAccessLogStore) {
+				return
+			},
+		},
+	}
+}
+
+// NewStrictMockExecutorSecretAccessLogStore creates a new mock of the
+// ExecutorSecretAccessLogStore interface. All methods panic on invocation,
+// unless overwritten.
+func NewStrictMockExecutorSecretAccessLogStore() *MockExecutorSecretAccessLogStore {
+	return &MockExecutorSecretAccessLogStore{
+		CountFunc: &ExecutorSecretAccessLogStoreCountFunc{
+			defaultHook: func(context.Context, ExecutorSecretAccessLogsListOpts) (int, error) {
+				panic("unexpected invocation of MockExecutorSecretAccessLogStore.Count")
+			},
+		},
+		CreateFunc: &ExecutorSecretAccessLogStoreCreateFunc{
+			defaultHook: func(context.Context, *ExecutorSecretAccessLog) error {
+				panic("unexpected invocation of MockExecutorSecretAccessLogStore.Create")
+			},
+		},
+		GetByIDFunc: &ExecutorSecretAccessLogStoreGetByIDFunc{
+			defaultHook: func(context.Context, int64) (*ExecutorSecretAccessLog, error) {
+				panic("unexpected invocation of MockExecutorSecretAccessLogStore.GetByID")
+			},
+		},
+		HandleFunc: &ExecutorSecretAccessLogStoreHandleFunc{
+			defaultHook: func() basestore.TransactableHandle {
+				panic("unexpected invocation of MockExecutorSecretAccessLogStore.Handle")
+			},
+		},
+		ListFunc: &ExecutorSecretAccessLogStoreListFunc{
+			defaultHook: func(context.Context, ExecutorSecretAccessLogsListOpts) ([]*ExecutorSecretAccessLog, int, error) {
+				panic("unexpected invocation of MockExecutorSecretAccessLogStore.List")
+			},
+		},
+		TransactFunc: &ExecutorSecretAccessLogStoreTransactFunc{
+			defaultHook: func(context.Context) (ExecutorSecretAccessLogStore, error) {
+				panic("unexpected invocation of MockExecutorSecretAccessLogStore.Transact")
+			},
+		},
+		WithFunc: &ExecutorSecretAccessLogStoreWithFunc{
+			defaultHook: func(basestore.ShareableStore) ExecutorSecretAccessLogStore {
+				panic("unexpected invocation of MockExecutorSecretAccessLogStore.With")
+			},
+		},
+	}
+}
+
+// NewMockExecutorSecretAccessLogStoreFrom creates a new mock of the
+// MockExecutorSecretAccessLogStore interface. All methods delegate to the
+// given implementation, unless overwritten.
+func NewMockExecutorSecretAccessLogStoreFrom(i ExecutorSecretAccessLogStore) *MockExecutorSecretAccessLogStore {
+	return &MockExecutorSecretAccessLogStore{
+		CountFunc: &ExecutorSecretAccessLogStoreCountFunc{
+			defaultHook: i.Count,
+		},
+		CreateFunc: &ExecutorSecretAccessLogStoreCreateFunc{
+			defaultHook: i.Create,
+		},
+		GetByIDFunc: &ExecutorSecretAccessLogStoreGetByIDFunc{
+			defaultHook: i.GetByID,
+		},
+		HandleFunc: &ExecutorSecretAccessLogStoreHandleFunc{
+			defaultHook: i.Handle,
+		},
+		ListFunc: &ExecutorSecretAccessLogStoreListFunc{
+			defaultHook: i.List,
+		},
+		TransactFunc: &ExecutorSecretAccessLogStoreTransactFunc{
+			defaultHook: i.Transact,
+		},
+		WithFunc: &ExecutorSecretAccessLogStoreWithFunc{
+			defaultHook: i.With,
+		},
+	}
+}
+
+// ExecutorSecretAccessLogStoreCountFunc describes the behavior when the
+// Count method of the parent MockExecutorSecretAccessLogStore instance is
+// invoked.
+type ExecutorSecretAccessLogStoreCountFunc struct {
+	defaultHook func(context.Context, ExecutorSecretAccessLogsListOpts) (int, error)
+	hooks       []func(context.Context, ExecutorSecretAccessLogsListOpts) (int, error)
+	history     []ExecutorSecretAccessLogStoreCountFuncCall
+	mutex       sync.Mutex
+}
+
+// Count delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockExecutorSecretAccessLogStore) Count(v0 context.Context, v1 ExecutorSecretAccessLogsListOpts) (int, error) {
+	r0, r1 := m.CountFunc.nextHook()(v0, v1)
+	m.CountFunc.appendCall(ExecutorSecretAccessLogStoreCountFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the Count method of the
+// parent MockExecutorSecretAccessLogStore instance is invoked and the hook
+// queue is empty.
+func (f *ExecutorSecretAccessLogStoreCountFunc) SetDefaultHook(hook func(context.Context, ExecutorSecretAccessLogsListOpts) (int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Count method of the parent MockExecutorSecretAccessLogStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *ExecutorSecretAccessLogStoreCountFunc) PushHook(hook func(context.Context, ExecutorSecretAccessLogsListOpts) (int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretAccessLogStoreCountFunc) SetDefaultReturn(r0 int, r1 error) {
+	f.SetDefaultHook(func(context.Context, ExecutorSecretAccessLogsListOpts) (int, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretAccessLogStoreCountFunc) PushReturn(r0 int, r1 error) {
+	f.PushHook(func(context.Context, ExecutorSecretAccessLogsListOpts) (int, error) {
+		return r0, r1
+	})
+}
+
+func (f *ExecutorSecretAccessLogStoreCountFunc) nextHook() func(context.Context, ExecutorSecretAccessLogsListOpts) (int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretAccessLogStoreCountFunc) appendCall(r0 ExecutorSecretAccessLogStoreCountFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExecutorSecretAccessLogStoreCountFuncCall
+// objects describing the invocations of this function.
+func (f *ExecutorSecretAccessLogStoreCountFunc) History() []ExecutorSecretAccessLogStoreCountFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretAccessLogStoreCountFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretAccessLogStoreCountFuncCall is an object that describes an
+// invocation of method Count on an instance of
+// MockExecutorSecretAccessLogStore.
+type ExecutorSecretAccessLogStoreCountFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 ExecutorSecretAccessLogsListOpts
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretAccessLogStoreCountFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretAccessLogStoreCountFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// ExecutorSecretAccessLogStoreCreateFunc describes the behavior when the
+// Create method of the parent MockExecutorSecretAccessLogStore instance is
+// invoked.
+type ExecutorSecretAccessLogStoreCreateFunc struct {
+	defaultHook func(context.Context, *ExecutorSecretAccessLog) error
+	hooks       []func(context.Context, *ExecutorSecretAccessLog) error
+	history     []ExecutorSecretAccessLogStoreCreateFuncCall
+	mutex       sync.Mutex
+}
+
+// Create delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockExecutorSecretAccessLogStore) Create(v0 context.Context, v1 *ExecutorSecretAccessLog) error {
+	r0 := m.CreateFunc.nextHook()(v0, v1)
+	m.CreateFunc.appendCall(ExecutorSecretAccessLogStoreCreateFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the Create method of the
+// parent MockExecutorSecretAccessLogStore instance is invoked and the hook
+// queue is empty.
+func (f *ExecutorSecretAccessLogStoreCreateFunc) SetDefaultHook(hook func(context.Context, *ExecutorSecretAccessLog) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Create method of the parent MockExecutorSecretAccessLogStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *ExecutorSecretAccessLogStoreCreateFunc) PushHook(hook func(context.Context, *ExecutorSecretAccessLog) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretAccessLogStoreCreateFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, *ExecutorSecretAccessLog) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretAccessLogStoreCreateFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, *ExecutorSecretAccessLog) error {
+		return r0
+	})
+}
+
+func (f *ExecutorSecretAccessLogStoreCreateFunc) nextHook() func(context.Context, *ExecutorSecretAccessLog) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretAccessLogStoreCreateFunc) appendCall(r0 ExecutorSecretAccessLogStoreCreateFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExecutorSecretAccessLogStoreCreateFuncCall
+// objects describing the invocations of this function.
+func (f *ExecutorSecretAccessLogStoreCreateFunc) History() []ExecutorSecretAccessLogStoreCreateFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretAccessLogStoreCreateFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretAccessLogStoreCreateFuncCall is an object that describes an
+// invocation of method Create on an instance of
+// MockExecutorSecretAccessLogStore.
+type ExecutorSecretAccessLogStoreCreateFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 *ExecutorSecretAccessLog
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretAccessLogStoreCreateFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretAccessLogStoreCreateFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// ExecutorSecretAccessLogStoreGetByIDFunc describes the behavior when the
+// GetByID method of the parent MockExecutorSecretAccessLogStore instance is
+// invoked.
+type ExecutorSecretAccessLogStoreGetByIDFunc struct {
+	defaultHook func(context.Context, int64) (*ExecutorSecretAccessLog, error)
+	hooks       []func(context.Context, int64) (*ExecutorSecretAccessLog, error)
+	history     []ExecutorSecretAccessLogStoreGetByIDFuncCall
+	mutex       sync.Mutex
+}
+
+// GetByID delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockExecutorSecretAccessLogStore) GetByID(v0 context.Context, v1 int64) (*ExecutorSecretAccessLog, error) {
+	r0, r1 := m.GetByIDFunc.nextHook()(v0, v1)
+	m.GetByIDFunc.appendCall(ExecutorSecretAccessLogStoreGetByIDFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the GetByID method of
+// the parent MockExecutorSecretAccessLogStore instance is invoked and the
+// hook queue is empty.
+func (f *ExecutorSecretAccessLogStoreGetByIDFunc) SetDefaultHook(hook func(context.Context, int64) (*ExecutorSecretAccessLog, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetByID method of the parent MockExecutorSecretAccessLogStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *ExecutorSecretAccessLogStoreGetByIDFunc) PushHook(hook func(context.Context, int64) (*ExecutorSecretAccessLog, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretAccessLogStoreGetByIDFunc) SetDefaultReturn(r0 *ExecutorSecretAccessLog, r1 error) {
+	f.SetDefaultHook(func(context.Context, int64) (*ExecutorSecretAccessLog, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretAccessLogStoreGetByIDFunc) PushReturn(r0 *ExecutorSecretAccessLog, r1 error) {
+	f.PushHook(func(context.Context, int64) (*ExecutorSecretAccessLog, error) {
+		return r0, r1
+	})
+}
+
+func (f *ExecutorSecretAccessLogStoreGetByIDFunc) nextHook() func(context.Context, int64) (*ExecutorSecretAccessLog, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretAccessLogStoreGetByIDFunc) appendCall(r0 ExecutorSecretAccessLogStoreGetByIDFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExecutorSecretAccessLogStoreGetByIDFuncCall
+// objects describing the invocations of this function.
+func (f *ExecutorSecretAccessLogStoreGetByIDFunc) History() []ExecutorSecretAccessLogStoreGetByIDFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretAccessLogStoreGetByIDFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretAccessLogStoreGetByIDFuncCall is an object that describes
+// an invocation of method GetByID on an instance of
+// MockExecutorSecretAccessLogStore.
+type ExecutorSecretAccessLogStoreGetByIDFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int64
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *ExecutorSecretAccessLog
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretAccessLogStoreGetByIDFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretAccessLogStoreGetByIDFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// ExecutorSecretAccessLogStoreHandleFunc describes the behavior when the
+// Handle method of the parent MockExecutorSecretAccessLogStore instance is
+// invoked.
+type ExecutorSecretAccessLogStoreHandleFunc struct {
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
+	history     []ExecutorSecretAccessLogStoreHandleFuncCall
+	mutex       sync.Mutex
+}
+
+// Handle delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockExecutorSecretAccessLogStore) Handle() basestore.TransactableHandle {
+	r0 := m.HandleFunc.nextHook()()
+	m.HandleFunc.appendCall(ExecutorSecretAccessLogStoreHandleFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the Handle method of the
+// parent MockExecutorSecretAccessLogStore instance is invoked and the hook
+// queue is empty.
+func (f *ExecutorSecretAccessLogStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Handle method of the parent MockExecutorSecretAccessLogStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *ExecutorSecretAccessLogStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretAccessLogStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretAccessLogStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
+		return r0
+	})
+}
+
+func (f *ExecutorSecretAccessLogStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretAccessLogStoreHandleFunc) appendCall(r0 ExecutorSecretAccessLogStoreHandleFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExecutorSecretAccessLogStoreHandleFuncCall
+// objects describing the invocations of this function.
+func (f *ExecutorSecretAccessLogStoreHandleFunc) History() []ExecutorSecretAccessLogStoreHandleFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretAccessLogStoreHandleFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretAccessLogStoreHandleFuncCall is an object that describes an
+// invocation of method Handle on an instance of
+// MockExecutorSecretAccessLogStore.
+type ExecutorSecretAccessLogStoreHandleFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 basestore.TransactableHandle
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretAccessLogStoreHandleFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretAccessLogStoreHandleFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// ExecutorSecretAccessLogStoreListFunc describes the behavior when the List
+// method of the parent MockExecutorSecretAccessLogStore instance is
+// invoked.
+type ExecutorSecretAccessLogStoreListFunc struct {
+	defaultHook func(context.Context, ExecutorSecretAccessLogsListOpts) ([]*ExecutorSecretAccessLog, int, error)
+	hooks       []func(context.Context, ExecutorSecretAccessLogsListOpts) ([]*ExecutorSecretAccessLog, int, error)
+	history     []ExecutorSecretAccessLogStoreListFuncCall
+	mutex       sync.Mutex
+}
+
+// List delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockExecutorSecretAccessLogStore) List(v0 context.Context, v1 ExecutorSecretAccessLogsListOpts) ([]*ExecutorSecretAccessLog, int, error) {
+	r0, r1, r2 := m.ListFunc.nextHook()(v0, v1)
+	m.ListFunc.appendCall(ExecutorSecretAccessLogStoreListFuncCall{v0, v1, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the List method of the
+// parent MockExecutorSecretAccessLogStore instance is invoked and the hook
+// queue is empty.
+func (f *ExecutorSecretAccessLogStoreListFunc) SetDefaultHook(hook func(context.Context, ExecutorSecretAccessLogsListOpts) ([]*ExecutorSecretAccessLog, int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// List method of the parent MockExecutorSecretAccessLogStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *ExecutorSecretAccessLogStoreListFunc) PushHook(hook func(context.Context, ExecutorSecretAccessLogsListOpts) ([]*ExecutorSecretAccessLog, int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretAccessLogStoreListFunc) SetDefaultReturn(r0 []*ExecutorSecretAccessLog, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, ExecutorSecretAccessLogsListOpts) ([]*ExecutorSecretAccessLog, int, error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretAccessLogStoreListFunc) PushReturn(r0 []*ExecutorSecretAccessLog, r1 int, r2 error) {
+	f.PushHook(func(context.Context, ExecutorSecretAccessLogsListOpts) ([]*ExecutorSecretAccessLog, int, error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *ExecutorSecretAccessLogStoreListFunc) nextHook() func(context.Context, ExecutorSecretAccessLogsListOpts) ([]*ExecutorSecretAccessLog, int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretAccessLogStoreListFunc) appendCall(r0 ExecutorSecretAccessLogStoreListFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExecutorSecretAccessLogStoreListFuncCall
+// objects describing the invocations of this function.
+func (f *ExecutorSecretAccessLogStoreListFunc) History() []ExecutorSecretAccessLogStoreListFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretAccessLogStoreListFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretAccessLogStoreListFuncCall is an object that describes an
+// invocation of method List on an instance of
+// MockExecutorSecretAccessLogStore.
+type ExecutorSecretAccessLogStoreListFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 ExecutorSecretAccessLogsListOpts
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []*ExecutorSecretAccessLog
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 int
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretAccessLogStoreListFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretAccessLogStoreListFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
+// ExecutorSecretAccessLogStoreTransactFunc describes the behavior when the
+// Transact method of the parent MockExecutorSecretAccessLogStore instance
+// is invoked.
+type ExecutorSecretAccessLogStoreTransactFunc struct {
+	defaultHook func(context.Context) (ExecutorSecretAccessLogStore, error)
+	hooks       []func(context.Context) (ExecutorSecretAccessLogStore, error)
+	history     []ExecutorSecretAccessLogStoreTransactFuncCall
+	mutex       sync.Mutex
+}
+
+// Transact delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockExecutorSecretAccessLogStore) Transact(v0 context.Context) (ExecutorSecretAccessLogStore, error) {
+	r0, r1 := m.TransactFunc.nextHook()(v0)
+	m.TransactFunc.appendCall(ExecutorSecretAccessLogStoreTransactFuncCall{v0, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the Transact method of
+// the parent MockExecutorSecretAccessLogStore instance is invoked and the
+// hook queue is empty.
+func (f *ExecutorSecretAccessLogStoreTransactFunc) SetDefaultHook(hook func(context.Context) (ExecutorSecretAccessLogStore, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Transact method of the parent MockExecutorSecretAccessLogStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *ExecutorSecretAccessLogStoreTransactFunc) PushHook(hook func(context.Context) (ExecutorSecretAccessLogStore, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretAccessLogStoreTransactFunc) SetDefaultReturn(r0 ExecutorSecretAccessLogStore, r1 error) {
+	f.SetDefaultHook(func(context.Context) (ExecutorSecretAccessLogStore, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretAccessLogStoreTransactFunc) PushReturn(r0 ExecutorSecretAccessLogStore, r1 error) {
+	f.PushHook(func(context.Context) (ExecutorSecretAccessLogStore, error) {
+		return r0, r1
+	})
+}
+
+func (f *ExecutorSecretAccessLogStoreTransactFunc) nextHook() func(context.Context) (ExecutorSecretAccessLogStore, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretAccessLogStoreTransactFunc) appendCall(r0 ExecutorSecretAccessLogStoreTransactFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// ExecutorSecretAccessLogStoreTransactFuncCall objects describing the
+// invocations of this function.
+func (f *ExecutorSecretAccessLogStoreTransactFunc) History() []ExecutorSecretAccessLogStoreTransactFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretAccessLogStoreTransactFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretAccessLogStoreTransactFuncCall is an object that describes
+// an invocation of method Transact on an instance of
+// MockExecutorSecretAccessLogStore.
+type ExecutorSecretAccessLogStoreTransactFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 ExecutorSecretAccessLogStore
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretAccessLogStoreTransactFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretAccessLogStoreTransactFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// ExecutorSecretAccessLogStoreWithFunc describes the behavior when the With
+// method of the parent MockExecutorSecretAccessLogStore instance is
+// invoked.
+type ExecutorSecretAccessLogStoreWithFunc struct {
+	defaultHook func(basestore.ShareableStore) ExecutorSecretAccessLogStore
+	hooks       []func(basestore.ShareableStore) ExecutorSecretAccessLogStore
+	history     []ExecutorSecretAccessLogStoreWithFuncCall
+	mutex       sync.Mutex
+}
+
+// With delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockExecutorSecretAccessLogStore) With(v0 basestore.ShareableStore) ExecutorSecretAccessLogStore {
+	r0 := m.WithFunc.nextHook()(v0)
+	m.WithFunc.appendCall(ExecutorSecretAccessLogStoreWithFuncCall{v0, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the With method of the
+// parent MockExecutorSecretAccessLogStore instance is invoked and the hook
+// queue is empty.
+func (f *ExecutorSecretAccessLogStoreWithFunc) SetDefaultHook(hook func(basestore.ShareableStore) ExecutorSecretAccessLogStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// With method of the parent MockExecutorSecretAccessLogStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *ExecutorSecretAccessLogStoreWithFunc) PushHook(hook func(basestore.ShareableStore) ExecutorSecretAccessLogStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretAccessLogStoreWithFunc) SetDefaultReturn(r0 ExecutorSecretAccessLogStore) {
+	f.SetDefaultHook(func(basestore.ShareableStore) ExecutorSecretAccessLogStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretAccessLogStoreWithFunc) PushReturn(r0 ExecutorSecretAccessLogStore) {
+	f.PushHook(func(basestore.ShareableStore) ExecutorSecretAccessLogStore {
+		return r0
+	})
+}
+
+func (f *ExecutorSecretAccessLogStoreWithFunc) nextHook() func(basestore.ShareableStore) ExecutorSecretAccessLogStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretAccessLogStoreWithFunc) appendCall(r0 ExecutorSecretAccessLogStoreWithFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExecutorSecretAccessLogStoreWithFuncCall
+// objects describing the invocations of this function.
+func (f *ExecutorSecretAccessLogStoreWithFunc) History() []ExecutorSecretAccessLogStoreWithFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretAccessLogStoreWithFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretAccessLogStoreWithFuncCall is an object that describes an
+// invocation of method With on an instance of
+// MockExecutorSecretAccessLogStore.
+type ExecutorSecretAccessLogStoreWithFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 basestore.ShareableStore
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 ExecutorSecretAccessLogStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretAccessLogStoreWithFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretAccessLogStoreWithFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// MockExecutorSecretStore is a mock implementation of the
+// ExecutorSecretStore interface (from the package
+// github.com/sourcegraph/sourcegraph/internal/database) used for unit
+// testing.
+type MockExecutorSecretStore struct {
+	// CountFunc is an instance of a mock function object controlling the
+	// behavior of the method Count.
+	CountFunc *ExecutorSecretStoreCountFunc
+	// CreateFunc is an instance of a mock function object controlling the
+	// behavior of the method Create.
+	CreateFunc *ExecutorSecretStoreCreateFunc
+	// DeleteFunc is an instance of a mock function object controlling the
+	// behavior of the method Delete.
+	DeleteFunc *ExecutorSecretStoreDeleteFunc
+	// GetByIDFunc is an instance of a mock function object controlling the
+	// behavior of the method GetByID.
+	GetByIDFunc *ExecutorSecretStoreGetByIDFunc
+	// HandleFunc is an instance of a mock function object controlling the
+	// behavior of the method Handle.
+	HandleFunc *ExecutorSecretStoreHandleFunc
+	// ListFunc is an instance of a mock function object controlling the
+	// behavior of the method List.
+	ListFunc *ExecutorSecretStoreListFunc
+	// TransactFunc is an instance of a mock function object controlling the
+	// behavior of the method Transact.
+	TransactFunc *ExecutorSecretStoreTransactFunc
+	// UpdateFunc is an instance of a mock function object controlling the
+	// behavior of the method Update.
+	UpdateFunc *ExecutorSecretStoreUpdateFunc
+	// WithFunc is an instance of a mock function object controlling the
+	// behavior of the method With.
+	WithFunc *ExecutorSecretStoreWithFunc
+}
+
+// NewMockExecutorSecretStore creates a new mock of the ExecutorSecretStore
+// interface. All methods return zero values for all results, unless
+// overwritten.
+func NewMockExecutorSecretStore() *MockExecutorSecretStore {
+	return &MockExecutorSecretStore{
+		CountFunc: &ExecutorSecretStoreCountFunc{
+			defaultHook: func(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) (r0 int, r1 error) {
+				return
+			},
+		},
+		CreateFunc: &ExecutorSecretStoreCreateFunc{
+			defaultHook: func(context.Context, ExecutorSecretScope, *ExecutorSecret, string) (r0 error) {
+				return
+			},
+		},
+		DeleteFunc: &ExecutorSecretStoreDeleteFunc{
+			defaultHook: func(context.Context, ExecutorSecretScope, int64) (r0 error) {
+				return
+			},
+		},
+		GetByIDFunc: &ExecutorSecretStoreGetByIDFunc{
+			defaultHook: func(context.Context, ExecutorSecretScope, int64) (r0 *ExecutorSecret, r1 error) {
+				return
+			},
+		},
+		HandleFunc: &ExecutorSecretStoreHandleFunc{
+			defaultHook: func() (r0 basestore.TransactableHandle) {
+				return
+			},
+		},
+		ListFunc: &ExecutorSecretStoreListFunc{
+			defaultHook: func(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) (r0 []*ExecutorSecret, r1 int, r2 error) {
+				return
+			},
+		},
+		TransactFunc: &ExecutorSecretStoreTransactFunc{
+			defaultHook: func(context.Context) (r0 ExecutorSecretStore, r1 error) {
+				return
+			},
+		},
+		UpdateFunc: &ExecutorSecretStoreUpdateFunc{
+			defaultHook: func(context.Context, ExecutorSecretScope, *ExecutorSecret, string) (r0 error) {
+				return
+			},
+		},
+		WithFunc: &ExecutorSecretStoreWithFunc{
+			defaultHook: func(basestore.ShareableStore) (r0 ExecutorSecretStore) {
+				return
+			},
+		},
+	}
+}
+
+// NewStrictMockExecutorSecretStore creates a new mock of the
+// ExecutorSecretStore interface. All methods panic on invocation, unless
+// overwritten.
+func NewStrictMockExecutorSecretStore() *MockExecutorSecretStore {
+	return &MockExecutorSecretStore{
+		CountFunc: &ExecutorSecretStoreCountFunc{
+			defaultHook: func(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) (int, error) {
+				panic("unexpected invocation of MockExecutorSecretStore.Count")
+			},
+		},
+		CreateFunc: &ExecutorSecretStoreCreateFunc{
+			defaultHook: func(context.Context, ExecutorSecretScope, *ExecutorSecret, string) error {
+				panic("unexpected invocation of MockExecutorSecretStore.Create")
+			},
+		},
+		DeleteFunc: &ExecutorSecretStoreDeleteFunc{
+			defaultHook: func(context.Context, ExecutorSecretScope, int64) error {
+				panic("unexpected invocation of MockExecutorSecretStore.Delete")
+			},
+		},
+		GetByIDFunc: &ExecutorSecretStoreGetByIDFunc{
+			defaultHook: func(context.Context, ExecutorSecretScope, int64) (*ExecutorSecret, error) {
+				panic("unexpected invocation of MockExecutorSecretStore.GetByID")
+			},
+		},
+		HandleFunc: &ExecutorSecretStoreHandleFunc{
+			defaultHook: func() basestore.TransactableHandle {
+				panic("unexpected invocation of MockExecutorSecretStore.Handle")
+			},
+		},
+		ListFunc: &ExecutorSecretStoreListFunc{
+			defaultHook: func(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) ([]*ExecutorSecret, int, error) {
+				panic("unexpected invocation of MockExecutorSecretStore.List")
+			},
+		},
+		TransactFunc: &ExecutorSecretStoreTransactFunc{
+			defaultHook: func(context.Context) (ExecutorSecretStore, error) {
+				panic("unexpected invocation of MockExecutorSecretStore.Transact")
+			},
+		},
+		UpdateFunc: &ExecutorSecretStoreUpdateFunc{
+			defaultHook: func(context.Context, ExecutorSecretScope, *ExecutorSecret, string) error {
+				panic("unexpected invocation of MockExecutorSecretStore.Update")
+			},
+		},
+		WithFunc: &ExecutorSecretStoreWithFunc{
+			defaultHook: func(basestore.ShareableStore) ExecutorSecretStore {
+				panic("unexpected invocation of MockExecutorSecretStore.With")
+			},
+		},
+	}
+}
+
+// NewMockExecutorSecretStoreFrom creates a new mock of the
+// MockExecutorSecretStore interface. All methods delegate to the given
+// implementation, unless overwritten.
+func NewMockExecutorSecretStoreFrom(i ExecutorSecretStore) *MockExecutorSecretStore {
+	return &MockExecutorSecretStore{
+		CountFunc: &ExecutorSecretStoreCountFunc{
+			defaultHook: i.Count,
+		},
+		CreateFunc: &ExecutorSecretStoreCreateFunc{
+			defaultHook: i.Create,
+		},
+		DeleteFunc: &ExecutorSecretStoreDeleteFunc{
+			defaultHook: i.Delete,
+		},
+		GetByIDFunc: &ExecutorSecretStoreGetByIDFunc{
+			defaultHook: i.GetByID,
+		},
+		HandleFunc: &ExecutorSecretStoreHandleFunc{
+			defaultHook: i.Handle,
+		},
+		ListFunc: &ExecutorSecretStoreListFunc{
+			defaultHook: i.List,
+		},
+		TransactFunc: &ExecutorSecretStoreTransactFunc{
+			defaultHook: i.Transact,
+		},
+		UpdateFunc: &ExecutorSecretStoreUpdateFunc{
+			defaultHook: i.Update,
+		},
+		WithFunc: &ExecutorSecretStoreWithFunc{
+			defaultHook: i.With,
+		},
+	}
+}
+
+// ExecutorSecretStoreCountFunc describes the behavior when the Count method
+// of the parent MockExecutorSecretStore instance is invoked.
+type ExecutorSecretStoreCountFunc struct {
+	defaultHook func(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) (int, error)
+	hooks       []func(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) (int, error)
+	history     []ExecutorSecretStoreCountFuncCall
+	mutex       sync.Mutex
+}
+
+// Count delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockExecutorSecretStore) Count(v0 context.Context, v1 ExecutorSecretScope, v2 ExecutorSecretsListOpts) (int, error) {
+	r0, r1 := m.CountFunc.nextHook()(v0, v1, v2)
+	m.CountFunc.appendCall(ExecutorSecretStoreCountFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the Count method of the
+// parent MockExecutorSecretStore instance is invoked and the hook queue is
+// empty.
+func (f *ExecutorSecretStoreCountFunc) SetDefaultHook(hook func(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) (int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Count method of the parent MockExecutorSecretStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *ExecutorSecretStoreCountFunc) PushHook(hook func(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) (int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretStoreCountFunc) SetDefaultReturn(r0 int, r1 error) {
+	f.SetDefaultHook(func(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) (int, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretStoreCountFunc) PushReturn(r0 int, r1 error) {
+	f.PushHook(func(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) (int, error) {
+		return r0, r1
+	})
+}
+
+func (f *ExecutorSecretStoreCountFunc) nextHook() func(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) (int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretStoreCountFunc) appendCall(r0 ExecutorSecretStoreCountFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExecutorSecretStoreCountFuncCall objects
+// describing the invocations of this function.
+func (f *ExecutorSecretStoreCountFunc) History() []ExecutorSecretStoreCountFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretStoreCountFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretStoreCountFuncCall is an object that describes an
+// invocation of method Count on an instance of MockExecutorSecretStore.
+type ExecutorSecretStoreCountFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 ExecutorSecretScope
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 ExecutorSecretsListOpts
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretStoreCountFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretStoreCountFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// ExecutorSecretStoreCreateFunc describes the behavior when the Create
+// method of the parent MockExecutorSecretStore instance is invoked.
+type ExecutorSecretStoreCreateFunc struct {
+	defaultHook func(context.Context, ExecutorSecretScope, *ExecutorSecret, string) error
+	hooks       []func(context.Context, ExecutorSecretScope, *ExecutorSecret, string) error
+	history     []ExecutorSecretStoreCreateFuncCall
+	mutex       sync.Mutex
+}
+
+// Create delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockExecutorSecretStore) Create(v0 context.Context, v1 ExecutorSecretScope, v2 *ExecutorSecret, v3 string) error {
+	r0 := m.CreateFunc.nextHook()(v0, v1, v2, v3)
+	m.CreateFunc.appendCall(ExecutorSecretStoreCreateFuncCall{v0, v1, v2, v3, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the Create method of the
+// parent MockExecutorSecretStore instance is invoked and the hook queue is
+// empty.
+func (f *ExecutorSecretStoreCreateFunc) SetDefaultHook(hook func(context.Context, ExecutorSecretScope, *ExecutorSecret, string) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Create method of the parent MockExecutorSecretStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *ExecutorSecretStoreCreateFunc) PushHook(hook func(context.Context, ExecutorSecretScope, *ExecutorSecret, string) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretStoreCreateFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, ExecutorSecretScope, *ExecutorSecret, string) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretStoreCreateFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, ExecutorSecretScope, *ExecutorSecret, string) error {
+		return r0
+	})
+}
+
+func (f *ExecutorSecretStoreCreateFunc) nextHook() func(context.Context, ExecutorSecretScope, *ExecutorSecret, string) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretStoreCreateFunc) appendCall(r0 ExecutorSecretStoreCreateFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExecutorSecretStoreCreateFuncCall objects
+// describing the invocations of this function.
+func (f *ExecutorSecretStoreCreateFunc) History() []ExecutorSecretStoreCreateFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretStoreCreateFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretStoreCreateFuncCall is an object that describes an
+// invocation of method Create on an instance of MockExecutorSecretStore.
+type ExecutorSecretStoreCreateFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 ExecutorSecretScope
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 *ExecutorSecret
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretStoreCreateFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretStoreCreateFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// ExecutorSecretStoreDeleteFunc describes the behavior when the Delete
+// method of the parent MockExecutorSecretStore instance is invoked.
+type ExecutorSecretStoreDeleteFunc struct {
+	defaultHook func(context.Context, ExecutorSecretScope, int64) error
+	hooks       []func(context.Context, ExecutorSecretScope, int64) error
+	history     []ExecutorSecretStoreDeleteFuncCall
+	mutex       sync.Mutex
+}
+
+// Delete delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockExecutorSecretStore) Delete(v0 context.Context, v1 ExecutorSecretScope, v2 int64) error {
+	r0 := m.DeleteFunc.nextHook()(v0, v1, v2)
+	m.DeleteFunc.appendCall(ExecutorSecretStoreDeleteFuncCall{v0, v1, v2, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the Delete method of the
+// parent MockExecutorSecretStore instance is invoked and the hook queue is
+// empty.
+func (f *ExecutorSecretStoreDeleteFunc) SetDefaultHook(hook func(context.Context, ExecutorSecretScope, int64) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Delete method of the parent MockExecutorSecretStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *ExecutorSecretStoreDeleteFunc) PushHook(hook func(context.Context, ExecutorSecretScope, int64) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretStoreDeleteFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, ExecutorSecretScope, int64) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretStoreDeleteFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, ExecutorSecretScope, int64) error {
+		return r0
+	})
+}
+
+func (f *ExecutorSecretStoreDeleteFunc) nextHook() func(context.Context, ExecutorSecretScope, int64) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretStoreDeleteFunc) appendCall(r0 ExecutorSecretStoreDeleteFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExecutorSecretStoreDeleteFuncCall objects
+// describing the invocations of this function.
+func (f *ExecutorSecretStoreDeleteFunc) History() []ExecutorSecretStoreDeleteFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretStoreDeleteFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretStoreDeleteFuncCall is an object that describes an
+// invocation of method Delete on an instance of MockExecutorSecretStore.
+type ExecutorSecretStoreDeleteFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 ExecutorSecretScope
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int64
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretStoreDeleteFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretStoreDeleteFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// ExecutorSecretStoreGetByIDFunc describes the behavior when the GetByID
+// method of the parent MockExecutorSecretStore instance is invoked.
+type ExecutorSecretStoreGetByIDFunc struct {
+	defaultHook func(context.Context, ExecutorSecretScope, int64) (*ExecutorSecret, error)
+	hooks       []func(context.Context, ExecutorSecretScope, int64) (*ExecutorSecret, error)
+	history     []ExecutorSecretStoreGetByIDFuncCall
+	mutex       sync.Mutex
+}
+
+// GetByID delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockExecutorSecretStore) GetByID(v0 context.Context, v1 ExecutorSecretScope, v2 int64) (*ExecutorSecret, error) {
+	r0, r1 := m.GetByIDFunc.nextHook()(v0, v1, v2)
+	m.GetByIDFunc.appendCall(ExecutorSecretStoreGetByIDFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the GetByID method of
+// the parent MockExecutorSecretStore instance is invoked and the hook queue
+// is empty.
+func (f *ExecutorSecretStoreGetByIDFunc) SetDefaultHook(hook func(context.Context, ExecutorSecretScope, int64) (*ExecutorSecret, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetByID method of the parent MockExecutorSecretStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *ExecutorSecretStoreGetByIDFunc) PushHook(hook func(context.Context, ExecutorSecretScope, int64) (*ExecutorSecret, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretStoreGetByIDFunc) SetDefaultReturn(r0 *ExecutorSecret, r1 error) {
+	f.SetDefaultHook(func(context.Context, ExecutorSecretScope, int64) (*ExecutorSecret, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretStoreGetByIDFunc) PushReturn(r0 *ExecutorSecret, r1 error) {
+	f.PushHook(func(context.Context, ExecutorSecretScope, int64) (*ExecutorSecret, error) {
+		return r0, r1
+	})
+}
+
+func (f *ExecutorSecretStoreGetByIDFunc) nextHook() func(context.Context, ExecutorSecretScope, int64) (*ExecutorSecret, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretStoreGetByIDFunc) appendCall(r0 ExecutorSecretStoreGetByIDFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExecutorSecretStoreGetByIDFuncCall objects
+// describing the invocations of this function.
+func (f *ExecutorSecretStoreGetByIDFunc) History() []ExecutorSecretStoreGetByIDFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretStoreGetByIDFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretStoreGetByIDFuncCall is an object that describes an
+// invocation of method GetByID on an instance of MockExecutorSecretStore.
+type ExecutorSecretStoreGetByIDFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 ExecutorSecretScope
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int64
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *ExecutorSecret
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretStoreGetByIDFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretStoreGetByIDFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// ExecutorSecretStoreHandleFunc describes the behavior when the Handle
+// method of the parent MockExecutorSecretStore instance is invoked.
+type ExecutorSecretStoreHandleFunc struct {
+	defaultHook func() basestore.TransactableHandle
+	hooks       []func() basestore.TransactableHandle
+	history     []ExecutorSecretStoreHandleFuncCall
+	mutex       sync.Mutex
+}
+
+// Handle delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockExecutorSecretStore) Handle() basestore.TransactableHandle {
+	r0 := m.HandleFunc.nextHook()()
+	m.HandleFunc.appendCall(ExecutorSecretStoreHandleFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the Handle method of the
+// parent MockExecutorSecretStore instance is invoked and the hook queue is
+// empty.
+func (f *ExecutorSecretStoreHandleFunc) SetDefaultHook(hook func() basestore.TransactableHandle) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Handle method of the parent MockExecutorSecretStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *ExecutorSecretStoreHandleFunc) PushHook(hook func() basestore.TransactableHandle) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretStoreHandleFunc) SetDefaultReturn(r0 basestore.TransactableHandle) {
+	f.SetDefaultHook(func() basestore.TransactableHandle {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretStoreHandleFunc) PushReturn(r0 basestore.TransactableHandle) {
+	f.PushHook(func() basestore.TransactableHandle {
+		return r0
+	})
+}
+
+func (f *ExecutorSecretStoreHandleFunc) nextHook() func() basestore.TransactableHandle {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretStoreHandleFunc) appendCall(r0 ExecutorSecretStoreHandleFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExecutorSecretStoreHandleFuncCall objects
+// describing the invocations of this function.
+func (f *ExecutorSecretStoreHandleFunc) History() []ExecutorSecretStoreHandleFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretStoreHandleFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretStoreHandleFuncCall is an object that describes an
+// invocation of method Handle on an instance of MockExecutorSecretStore.
+type ExecutorSecretStoreHandleFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 basestore.TransactableHandle
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretStoreHandleFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretStoreHandleFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// ExecutorSecretStoreListFunc describes the behavior when the List method
+// of the parent MockExecutorSecretStore instance is invoked.
+type ExecutorSecretStoreListFunc struct {
+	defaultHook func(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) ([]*ExecutorSecret, int, error)
+	hooks       []func(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) ([]*ExecutorSecret, int, error)
+	history     []ExecutorSecretStoreListFuncCall
+	mutex       sync.Mutex
+}
+
+// List delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockExecutorSecretStore) List(v0 context.Context, v1 ExecutorSecretScope, v2 ExecutorSecretsListOpts) ([]*ExecutorSecret, int, error) {
+	r0, r1, r2 := m.ListFunc.nextHook()(v0, v1, v2)
+	m.ListFunc.appendCall(ExecutorSecretStoreListFuncCall{v0, v1, v2, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the List method of the
+// parent MockExecutorSecretStore instance is invoked and the hook queue is
+// empty.
+func (f *ExecutorSecretStoreListFunc) SetDefaultHook(hook func(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) ([]*ExecutorSecret, int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// List method of the parent MockExecutorSecretStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *ExecutorSecretStoreListFunc) PushHook(hook func(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) ([]*ExecutorSecret, int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretStoreListFunc) SetDefaultReturn(r0 []*ExecutorSecret, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) ([]*ExecutorSecret, int, error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretStoreListFunc) PushReturn(r0 []*ExecutorSecret, r1 int, r2 error) {
+	f.PushHook(func(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) ([]*ExecutorSecret, int, error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *ExecutorSecretStoreListFunc) nextHook() func(context.Context, ExecutorSecretScope, ExecutorSecretsListOpts) ([]*ExecutorSecret, int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretStoreListFunc) appendCall(r0 ExecutorSecretStoreListFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExecutorSecretStoreListFuncCall objects
+// describing the invocations of this function.
+func (f *ExecutorSecretStoreListFunc) History() []ExecutorSecretStoreListFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretStoreListFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretStoreListFuncCall is an object that describes an invocation
+// of method List on an instance of MockExecutorSecretStore.
+type ExecutorSecretStoreListFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 ExecutorSecretScope
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 ExecutorSecretsListOpts
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []*ExecutorSecret
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 int
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretStoreListFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretStoreListFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
+// ExecutorSecretStoreTransactFunc describes the behavior when the Transact
+// method of the parent MockExecutorSecretStore instance is invoked.
+type ExecutorSecretStoreTransactFunc struct {
+	defaultHook func(context.Context) (ExecutorSecretStore, error)
+	hooks       []func(context.Context) (ExecutorSecretStore, error)
+	history     []ExecutorSecretStoreTransactFuncCall
+	mutex       sync.Mutex
+}
+
+// Transact delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockExecutorSecretStore) Transact(v0 context.Context) (ExecutorSecretStore, error) {
+	r0, r1 := m.TransactFunc.nextHook()(v0)
+	m.TransactFunc.appendCall(ExecutorSecretStoreTransactFuncCall{v0, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the Transact method of
+// the parent MockExecutorSecretStore instance is invoked and the hook queue
+// is empty.
+func (f *ExecutorSecretStoreTransactFunc) SetDefaultHook(hook func(context.Context) (ExecutorSecretStore, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Transact method of the parent MockExecutorSecretStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *ExecutorSecretStoreTransactFunc) PushHook(hook func(context.Context) (ExecutorSecretStore, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretStoreTransactFunc) SetDefaultReturn(r0 ExecutorSecretStore, r1 error) {
+	f.SetDefaultHook(func(context.Context) (ExecutorSecretStore, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretStoreTransactFunc) PushReturn(r0 ExecutorSecretStore, r1 error) {
+	f.PushHook(func(context.Context) (ExecutorSecretStore, error) {
+		return r0, r1
+	})
+}
+
+func (f *ExecutorSecretStoreTransactFunc) nextHook() func(context.Context) (ExecutorSecretStore, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretStoreTransactFunc) appendCall(r0 ExecutorSecretStoreTransactFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExecutorSecretStoreTransactFuncCall objects
+// describing the invocations of this function.
+func (f *ExecutorSecretStoreTransactFunc) History() []ExecutorSecretStoreTransactFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretStoreTransactFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretStoreTransactFuncCall is an object that describes an
+// invocation of method Transact on an instance of MockExecutorSecretStore.
+type ExecutorSecretStoreTransactFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 ExecutorSecretStore
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretStoreTransactFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretStoreTransactFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// ExecutorSecretStoreUpdateFunc describes the behavior when the Update
+// method of the parent MockExecutorSecretStore instance is invoked.
+type ExecutorSecretStoreUpdateFunc struct {
+	defaultHook func(context.Context, ExecutorSecretScope, *ExecutorSecret, string) error
+	hooks       []func(context.Context, ExecutorSecretScope, *ExecutorSecret, string) error
+	history     []ExecutorSecretStoreUpdateFuncCall
+	mutex       sync.Mutex
+}
+
+// Update delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockExecutorSecretStore) Update(v0 context.Context, v1 ExecutorSecretScope, v2 *ExecutorSecret, v3 string) error {
+	r0 := m.UpdateFunc.nextHook()(v0, v1, v2, v3)
+	m.UpdateFunc.appendCall(ExecutorSecretStoreUpdateFuncCall{v0, v1, v2, v3, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the Update method of the
+// parent MockExecutorSecretStore instance is invoked and the hook queue is
+// empty.
+func (f *ExecutorSecretStoreUpdateFunc) SetDefaultHook(hook func(context.Context, ExecutorSecretScope, *ExecutorSecret, string) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Update method of the parent MockExecutorSecretStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *ExecutorSecretStoreUpdateFunc) PushHook(hook func(context.Context, ExecutorSecretScope, *ExecutorSecret, string) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretStoreUpdateFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, ExecutorSecretScope, *ExecutorSecret, string) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretStoreUpdateFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, ExecutorSecretScope, *ExecutorSecret, string) error {
+		return r0
+	})
+}
+
+func (f *ExecutorSecretStoreUpdateFunc) nextHook() func(context.Context, ExecutorSecretScope, *ExecutorSecret, string) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretStoreUpdateFunc) appendCall(r0 ExecutorSecretStoreUpdateFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExecutorSecretStoreUpdateFuncCall objects
+// describing the invocations of this function.
+func (f *ExecutorSecretStoreUpdateFunc) History() []ExecutorSecretStoreUpdateFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretStoreUpdateFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretStoreUpdateFuncCall is an object that describes an
+// invocation of method Update on an instance of MockExecutorSecretStore.
+type ExecutorSecretStoreUpdateFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 ExecutorSecretScope
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 *ExecutorSecret
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretStoreUpdateFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretStoreUpdateFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// ExecutorSecretStoreWithFunc describes the behavior when the With method
+// of the parent MockExecutorSecretStore instance is invoked.
+type ExecutorSecretStoreWithFunc struct {
+	defaultHook func(basestore.ShareableStore) ExecutorSecretStore
+	hooks       []func(basestore.ShareableStore) ExecutorSecretStore
+	history     []ExecutorSecretStoreWithFuncCall
+	mutex       sync.Mutex
+}
+
+// With delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockExecutorSecretStore) With(v0 basestore.ShareableStore) ExecutorSecretStore {
+	r0 := m.WithFunc.nextHook()(v0)
+	m.WithFunc.appendCall(ExecutorSecretStoreWithFuncCall{v0, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the With method of the
+// parent MockExecutorSecretStore instance is invoked and the hook queue is
+// empty.
+func (f *ExecutorSecretStoreWithFunc) SetDefaultHook(hook func(basestore.ShareableStore) ExecutorSecretStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// With method of the parent MockExecutorSecretStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *ExecutorSecretStoreWithFunc) PushHook(hook func(basestore.ShareableStore) ExecutorSecretStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ExecutorSecretStoreWithFunc) SetDefaultReturn(r0 ExecutorSecretStore) {
+	f.SetDefaultHook(func(basestore.ShareableStore) ExecutorSecretStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ExecutorSecretStoreWithFunc) PushReturn(r0 ExecutorSecretStore) {
+	f.PushHook(func(basestore.ShareableStore) ExecutorSecretStore {
+		return r0
+	})
+}
+
+func (f *ExecutorSecretStoreWithFunc) nextHook() func(basestore.ShareableStore) ExecutorSecretStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ExecutorSecretStoreWithFunc) appendCall(r0 ExecutorSecretStoreWithFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ExecutorSecretStoreWithFuncCall objects
+// describing the invocations of this function.
+func (f *ExecutorSecretStoreWithFunc) History() []ExecutorSecretStoreWithFuncCall {
+	f.mutex.Lock()
+	history := make([]ExecutorSecretStoreWithFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ExecutorSecretStoreWithFuncCall is an object that describes an invocation
+// of method With on an instance of MockExecutorSecretStore.
+type ExecutorSecretStoreWithFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 basestore.ShareableStore
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 ExecutorSecretStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ExecutorSecretStoreWithFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ExecutorSecretStoreWithFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -8562,12 +8562,22 @@
           "ConstraintDefinition": ""
         },
         {
-          "Name": "executor_secrets_unique_key_namespace",
+          "Name": "executor_secrets_unique_key_namespace_org",
           "IsPrimaryKey": false,
           "IsUnique": true,
           "IsExclusion": false,
           "IsDeferrable": false,
-          "IndexDefinition": "CREATE UNIQUE INDEX executor_secrets_unique_key_namespace ON executor_secrets USING btree (key, namespace_user_id, namespace_org_id, scope)",
+          "IndexDefinition": "CREATE UNIQUE INDEX executor_secrets_unique_key_namespace_org ON executor_secrets USING btree (key, namespace_org_id, scope) WHERE namespace_org_id IS NOT NULL",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
+          "Name": "executor_secrets_unique_key_namespace_user",
+          "IsPrimaryKey": false,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX executor_secrets_unique_key_namespace_user ON executor_secrets USING btree (key, namespace_user_id, scope) WHERE namespace_user_id IS NOT NULL",
           "ConstraintType": "",
           "ConstraintDefinition": ""
         }

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -501,6 +501,24 @@
       "CycleOption": "NO"
     },
     {
+      "Name": "executor_secret_access_logs_id_seq",
+      "TypeName": "integer",
+      "StartValue": 1,
+      "MinimumValue": 1,
+      "MaximumValue": 2147483647,
+      "Increment": 1,
+      "CycleOption": "NO"
+    },
+    {
+      "Name": "executor_secrets_id_seq",
+      "TypeName": "integer",
+      "StartValue": 1,
+      "MinimumValue": 1,
+      "MaximumValue": 2147483647,
+      "Increment": 1,
+      "CycleOption": "NO"
+    },
+    {
       "Name": "explicit_permissions_bitbucket_projects_jobs_id_seq",
       "TypeName": "integer",
       "StartValue": 1,
@@ -8298,6 +8316,285 @@
         }
       ],
       "Constraints": null,
+      "Triggers": []
+    },
+    {
+      "Name": "executor_secret_access_logs",
+      "Comment": "",
+      "Columns": [
+        {
+          "Name": "created_at",
+          "Index": 4,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": false,
+          "Default": "now()",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "executor_secret_id",
+          "Index": 2,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "id",
+          "Index": 1,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "nextval('executor_secret_access_logs_id_seq'::regclass)",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "user_id",
+          "Index": 3,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        }
+      ],
+      "Indexes": [
+        {
+          "Name": "executor_secret_access_logs_pkey",
+          "IsPrimaryKey": true,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX executor_secret_access_logs_pkey ON executor_secret_access_logs USING btree (id)",
+          "ConstraintType": "p",
+          "ConstraintDefinition": "PRIMARY KEY (id)"
+        }
+      ],
+      "Constraints": [
+        {
+          "Name": "executor_secret_access_logs_executor_secret_id_fkey",
+          "ConstraintType": "f",
+          "RefTableName": "executor_secrets",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "FOREIGN KEY (executor_secret_id) REFERENCES executor_secrets(id) ON DELETE CASCADE"
+        },
+        {
+          "Name": "executor_secret_access_logs_user_id_fkey",
+          "ConstraintType": "f",
+          "RefTableName": "users",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"
+        }
+      ],
+      "Triggers": []
+    },
+    {
+      "Name": "executor_secrets",
+      "Comment": "",
+      "Columns": [
+        {
+          "Name": "created_at",
+          "Index": 8,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": false,
+          "Default": "now()",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "creator_id",
+          "Index": 10,
+          "TypeName": "integer",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "NULL, if the user has been deleted."
+        },
+        {
+          "Name": "encryption_key_id",
+          "Index": 5,
+          "TypeName": "text",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "id",
+          "Index": 1,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "nextval('executor_secrets_id_seq'::regclass)",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "key",
+          "Index": 2,
+          "TypeName": "text",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "namespace_org_id",
+          "Index": 7,
+          "TypeName": "integer",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "namespace_user_id",
+          "Index": 6,
+          "TypeName": "integer",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "scope",
+          "Index": 4,
+          "TypeName": "text",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "updated_at",
+          "Index": 9,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": false,
+          "Default": "now()",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "value",
+          "Index": 3,
+          "TypeName": "bytea",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        }
+      ],
+      "Indexes": [
+        {
+          "Name": "executor_secrets_pkey",
+          "IsPrimaryKey": true,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX executor_secrets_pkey ON executor_secrets USING btree (id)",
+          "ConstraintType": "p",
+          "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "executor_secrets_unique_key_global",
+          "IsPrimaryKey": false,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX executor_secrets_unique_key_global ON executor_secrets USING btree (key, scope) WHERE namespace_user_id IS NULL AND namespace_org_id IS NULL",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
+          "Name": "executor_secrets_unique_key_namespace",
+          "IsPrimaryKey": false,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX executor_secrets_unique_key_namespace ON executor_secrets USING btree (key, namespace_user_id, namespace_org_id, scope)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        }
+      ],
+      "Constraints": [
+        {
+          "Name": "executor_secrets_creator_id_fkey",
+          "ConstraintType": "f",
+          "RefTableName": "users",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "FOREIGN KEY (creator_id) REFERENCES users(id) ON DELETE SET NULL"
+        },
+        {
+          "Name": "executor_secrets_namespace_org_id_fkey",
+          "ConstraintType": "f",
+          "RefTableName": "orgs",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE"
+        },
+        {
+          "Name": "executor_secrets_namespace_user_id_fkey",
+          "ConstraintType": "f",
+          "RefTableName": "users",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE"
+        }
+      ],
       "Triggers": []
     },
     {

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1135,6 +1135,51 @@ Tracks the most recent activity of executors attached to this Sourcegraph instan
 
 **src_cli_version**: The version of src-cli used by the executor.
 
+# Table "public.executor_secret_access_logs"
+```
+       Column       |           Type           | Collation | Nullable |                         Default                         
+--------------------+--------------------------+-----------+----------+---------------------------------------------------------
+ id                 | integer                  |           | not null | nextval('executor_secret_access_logs_id_seq'::regclass)
+ executor_secret_id | integer                  |           | not null | 
+ user_id            | integer                  |           | not null | 
+ created_at         | timestamp with time zone |           | not null | now()
+Indexes:
+    "executor_secret_access_logs_pkey" PRIMARY KEY, btree (id)
+Foreign-key constraints:
+    "executor_secret_access_logs_executor_secret_id_fkey" FOREIGN KEY (executor_secret_id) REFERENCES executor_secrets(id) ON DELETE CASCADE
+    "executor_secret_access_logs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+
+```
+
+# Table "public.executor_secrets"
+```
+      Column       |           Type           | Collation | Nullable |                   Default                    
+-------------------+--------------------------+-----------+----------+----------------------------------------------
+ id                | integer                  |           | not null | nextval('executor_secrets_id_seq'::regclass)
+ key               | text                     |           | not null | 
+ value             | bytea                    |           | not null | 
+ scope             | text                     |           | not null | 
+ encryption_key_id | text                     |           |          | 
+ namespace_user_id | integer                  |           |          | 
+ namespace_org_id  | integer                  |           |          | 
+ created_at        | timestamp with time zone |           | not null | now()
+ updated_at        | timestamp with time zone |           | not null | now()
+ creator_id        | integer                  |           |          | 
+Indexes:
+    "executor_secrets_pkey" PRIMARY KEY, btree (id)
+    "executor_secrets_unique_key_global" UNIQUE, btree (key, scope) WHERE namespace_user_id IS NULL AND namespace_org_id IS NULL
+    "executor_secrets_unique_key_namespace" UNIQUE, btree (key, namespace_user_id, namespace_org_id, scope)
+Foreign-key constraints:
+    "executor_secrets_creator_id_fkey" FOREIGN KEY (creator_id) REFERENCES users(id) ON DELETE SET NULL
+    "executor_secrets_namespace_org_id_fkey" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE
+    "executor_secrets_namespace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE
+Referenced by:
+    TABLE "executor_secret_access_logs" CONSTRAINT "executor_secret_access_logs_executor_secret_id_fkey" FOREIGN KEY (executor_secret_id) REFERENCES executor_secrets(id) ON DELETE CASCADE
+
+```
+
+**creator_id**: NULL, if the user has been deleted.
+
 # Table "public.explicit_permissions_bitbucket_projects_jobs"
 ```
        Column        |           Type           | Collation | Nullable |                                 Default                                  
@@ -2266,6 +2311,7 @@ Referenced by:
     TABLE "batch_changes" CONSTRAINT "batch_changes_namespace_org_id_fkey" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE DEFERRABLE
     TABLE "cm_monitors" CONSTRAINT "cm_monitors_org_id_fk" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE
     TABLE "cm_recipients" CONSTRAINT "cm_recipients_org_id_fk" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE
+    TABLE "executor_secrets" CONSTRAINT "executor_secrets_namespace_org_id_fkey" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE
     TABLE "external_service_repos" CONSTRAINT "external_service_repos_org_id_fkey" FOREIGN KEY (org_id) REFERENCES orgs(id) ON DELETE CASCADE
     TABLE "external_services" CONSTRAINT "external_services_namespace_org_id_fkey" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE DEFERRABLE
     TABLE "feature_flag_overrides" CONSTRAINT "feature_flag_overrides_namespace_org_id_fkey" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE
@@ -3018,6 +3064,9 @@ Referenced by:
     TABLE "discussion_comments" CONSTRAINT "discussion_comments_author_user_id_fkey" FOREIGN KEY (author_user_id) REFERENCES users(id) ON DELETE RESTRICT
     TABLE "discussion_mail_reply_tokens" CONSTRAINT "discussion_mail_reply_tokens_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE RESTRICT
     TABLE "discussion_threads" CONSTRAINT "discussion_threads_author_user_id_fkey" FOREIGN KEY (author_user_id) REFERENCES users(id) ON DELETE RESTRICT
+    TABLE "executor_secret_access_logs" CONSTRAINT "executor_secret_access_logs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    TABLE "executor_secrets" CONSTRAINT "executor_secrets_creator_id_fkey" FOREIGN KEY (creator_id) REFERENCES users(id) ON DELETE SET NULL
+    TABLE "executor_secrets" CONSTRAINT "executor_secrets_namespace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE
     TABLE "external_service_repos" CONSTRAINT "external_service_repos_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
     TABLE "external_services" CONSTRAINT "external_services_namepspace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
     TABLE "feature_flag_overrides" CONSTRAINT "feature_flag_overrides_namespace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1168,7 +1168,8 @@ Foreign-key constraints:
 Indexes:
     "executor_secrets_pkey" PRIMARY KEY, btree (id)
     "executor_secrets_unique_key_global" UNIQUE, btree (key, scope) WHERE namespace_user_id IS NULL AND namespace_org_id IS NULL
-    "executor_secrets_unique_key_namespace" UNIQUE, btree (key, namespace_user_id, namespace_org_id, scope)
+    "executor_secrets_unique_key_namespace_org" UNIQUE, btree (key, namespace_org_id, scope) WHERE namespace_org_id IS NOT NULL
+    "executor_secrets_unique_key_namespace_user" UNIQUE, btree (key, namespace_user_id, scope) WHERE namespace_user_id IS NOT NULL
 Foreign-key constraints:
     "executor_secrets_creator_id_fkey" FOREIGN KEY (creator_id) REFERENCES users(id) ON DELETE SET NULL
     "executor_secrets_namespace_org_id_fkey" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE

--- a/internal/encryption/keyring/ring.go
+++ b/internal/encryption/keyring/ring.go
@@ -120,6 +120,13 @@ func NewRing(ctx context.Context, keyConfig *schema.EncryptionKeys) (*Ring, erro
 		}
 	}
 
+	if keyConfig.ExecutorSecretKey != nil {
+		r.ExecutorSecretKey, err = NewKey(ctx, keyConfig.ExecutorSecretKey, keyConfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &r, nil
 }
 
@@ -129,6 +136,7 @@ type Ring struct {
 	UserExternalAccountKey    encryption.Key
 	WebhookKey                encryption.Key
 	WebhookLogKey             encryption.Key
+	ExecutorSecretKey         encryption.Key
 }
 
 func NewKey(ctx context.Context, k *schema.EncryptionKey, config *schema.EncryptionKeys) (encryption.Key, error) {

--- a/migrations/frontend/1664897165_executor_secrets/down.sql
+++ b/migrations/frontend/1664897165_executor_secrets/down.sql
@@ -1,2 +1,2 @@
-DROP TABLE IF EXISTS executor_secrets;
 DROP TABLE IF EXISTS executor_secret_access_logs;
+DROP TABLE IF EXISTS executor_secrets;

--- a/migrations/frontend/1664897165_executor_secrets/down.sql
+++ b/migrations/frontend/1664897165_executor_secrets/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS executor_secrets;
+DROP TABLE IF EXISTS executor_secret_access_logs;

--- a/migrations/frontend/1664897165_executor_secrets/metadata.yaml
+++ b/migrations/frontend/1664897165_executor_secrets/metadata.yaml
@@ -1,0 +1,2 @@
+name: executor_secrets
+parents: [1664300936, 1663665519, 1663871069]

--- a/migrations/frontend/1664897165_executor_secrets/up.sql
+++ b/migrations/frontend/1664897165_executor_secrets/up.sql
@@ -14,7 +14,8 @@ CREATE TABLE IF NOT EXISTS executor_secrets (
 COMMENT ON COLUMN executor_secrets.creator_id IS 'NULL, if the user has been deleted.';
 
 -- Enforce uniqueness of the key in a given namespace.
-CREATE UNIQUE INDEX executor_secrets_unique_key_namespace ON executor_secrets (key, namespace_user_id, namespace_org_id, scope);
+CREATE UNIQUE INDEX executor_secrets_unique_key_namespace_user ON executor_secrets (key, namespace_user_id, scope) WHERE namespace_user_id IS NOT NULL;
+CREATE UNIQUE INDEX executor_secrets_unique_key_namespace_org ON executor_secrets (key, namespace_org_id, scope) WHERE namespace_org_id IS NOT NULL;
 -- Enforce uniqueness of the key in the global namespace. NULL is a fun type :)
 CREATE UNIQUE INDEX executor_secrets_unique_key_global ON executor_secrets(key, scope) WHERE namespace_user_id IS NULL AND namespace_org_id IS NULL;
 

--- a/migrations/frontend/1664897165_executor_secrets/up.sql
+++ b/migrations/frontend/1664897165_executor_secrets/up.sql
@@ -14,10 +14,10 @@ CREATE TABLE IF NOT EXISTS executor_secrets (
 COMMENT ON COLUMN executor_secrets.creator_id IS 'NULL, if the user has been deleted.';
 
 -- Enforce uniqueness of the key in a given namespace.
-CREATE UNIQUE INDEX executor_secrets_unique_key_namespace_user ON executor_secrets (key, namespace_user_id, scope) WHERE namespace_user_id IS NOT NULL;
-CREATE UNIQUE INDEX executor_secrets_unique_key_namespace_org ON executor_secrets (key, namespace_org_id, scope) WHERE namespace_org_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS executor_secrets_unique_key_namespace_user ON executor_secrets (key, namespace_user_id, scope) WHERE namespace_user_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS executor_secrets_unique_key_namespace_org ON executor_secrets (key, namespace_org_id, scope) WHERE namespace_org_id IS NOT NULL;
 -- Enforce uniqueness of the key in the global namespace. NULL is a fun type :)
-CREATE UNIQUE INDEX executor_secrets_unique_key_global ON executor_secrets(key, scope) WHERE namespace_user_id IS NULL AND namespace_org_id IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS executor_secrets_unique_key_global ON executor_secrets(key, scope) WHERE namespace_user_id IS NULL AND namespace_org_id IS NULL;
 
 CREATE TABLE IF NOT EXISTS executor_secret_access_logs (
     id SERIAL PRIMARY KEY,

--- a/migrations/frontend/1664897165_executor_secrets/up.sql
+++ b/migrations/frontend/1664897165_executor_secrets/up.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS executor_secrets (
+    id SERIAL PRIMARY KEY,
+    key text NOT NULL,
+    value bytea NOT NULL,
+    scope text NOT NULL,
+    encryption_key_id text,
+    namespace_user_id integer REFERENCES users(id) ON DELETE CASCADE,
+    namespace_org_id integer REFERENCES orgs(id) ON DELETE CASCADE,
+    created_at timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at timestamp with time zone NOT NULL DEFAULT NOW(),
+    creator_id integer REFERENCES users(id) ON DELETE SET NULL
+);
+
+COMMENT ON COLUMN executor_secrets.creator_id IS 'NULL, if the user has been deleted.';
+
+-- Enforce uniqueness of the key in a given namespace.
+CREATE UNIQUE INDEX executor_secrets_unique_key_namespace ON executor_secrets (key, namespace_user_id, namespace_org_id, scope);
+-- Enforce uniqueness of the key in the global namespace. NULL is a fun type :)
+CREATE UNIQUE INDEX executor_secrets_unique_key_global ON executor_secrets(key, scope) WHERE namespace_user_id IS NULL AND namespace_org_id IS NULL;
+
+CREATE TABLE IF NOT EXISTS executor_secret_access_logs (
+    id SERIAL PRIMARY KEY,
+    executor_secret_id integer NOT NULL REFERENCES executor_secrets(id) ON DELETE CASCADE,
+    user_id integer NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at timestamp with time zone NOT NULL DEFAULT NOW()
+);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -1828,6 +1828,48 @@ CREATE SEQUENCE executor_heartbeats_id_seq
 
 ALTER SEQUENCE executor_heartbeats_id_seq OWNED BY executor_heartbeats.id;
 
+CREATE TABLE executor_secret_access_logs (
+    id integer NOT NULL,
+    executor_secret_id integer NOT NULL,
+    user_id integer NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE SEQUENCE executor_secret_access_logs_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE executor_secret_access_logs_id_seq OWNED BY executor_secret_access_logs.id;
+
+CREATE TABLE executor_secrets (
+    id integer NOT NULL,
+    key text NOT NULL,
+    value bytea NOT NULL,
+    scope text NOT NULL,
+    encryption_key_id text,
+    namespace_user_id integer,
+    namespace_org_id integer,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    creator_id integer
+);
+
+COMMENT ON COLUMN executor_secrets.creator_id IS 'NULL, if the user has been deleted.';
+
+CREATE SEQUENCE executor_secrets_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE executor_secrets_id_seq OWNED BY executor_secrets.id;
+
 CREATE TABLE explicit_permissions_bitbucket_projects_jobs (
     id integer NOT NULL,
     state text DEFAULT 'queued'::text,
@@ -3674,6 +3716,10 @@ ALTER TABLE ONLY event_logs_scrape_state ALTER COLUMN id SET DEFAULT nextval('ev
 
 ALTER TABLE ONLY executor_heartbeats ALTER COLUMN id SET DEFAULT nextval('executor_heartbeats_id_seq'::regclass);
 
+ALTER TABLE ONLY executor_secret_access_logs ALTER COLUMN id SET DEFAULT nextval('executor_secret_access_logs_id_seq'::regclass);
+
+ALTER TABLE ONLY executor_secrets ALTER COLUMN id SET DEFAULT nextval('executor_secrets_id_seq'::regclass);
+
 ALTER TABLE ONLY explicit_permissions_bitbucket_projects_jobs ALTER COLUMN id SET DEFAULT nextval('explicit_permissions_bitbucket_projects_jobs_id_seq'::regclass);
 
 ALTER TABLE ONLY external_services ALTER COLUMN id SET DEFAULT nextval('external_services_id_seq'::regclass);
@@ -3883,6 +3929,12 @@ ALTER TABLE ONLY executor_heartbeats
 
 ALTER TABLE ONLY executor_heartbeats
     ADD CONSTRAINT executor_heartbeats_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY executor_secret_access_logs
+    ADD CONSTRAINT executor_secret_access_logs_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY executor_secrets
+    ADD CONSTRAINT executor_secrets_pkey PRIMARY KEY (id);
 
 ALTER TABLE ONLY explicit_permissions_bitbucket_projects_jobs
     ADD CONSTRAINT explicit_permissions_bitbucket_projects_jobs_pkey PRIMARY KEY (id);
@@ -4229,6 +4281,10 @@ CREATE INDEX event_logs_timestamp ON event_logs USING btree ("timestamp");
 CREATE INDEX event_logs_timestamp_at_utc ON event_logs USING btree (date(timezone('UTC'::text, "timestamp")));
 
 CREATE INDEX event_logs_user_id ON event_logs USING btree (user_id);
+
+CREATE UNIQUE INDEX executor_secrets_unique_key_global ON executor_secrets USING btree (key, scope) WHERE ((namespace_user_id IS NULL) AND (namespace_org_id IS NULL));
+
+CREATE UNIQUE INDEX executor_secrets_unique_key_namespace ON executor_secrets USING btree (key, namespace_user_id, namespace_org_id, scope);
 
 CREATE INDEX explicit_permissions_bitbucket_projects_jobs_project_key_extern ON explicit_permissions_bitbucket_projects_jobs USING btree (project_key, external_service_id, state);
 
@@ -4668,6 +4724,21 @@ ALTER TABLE ONLY discussion_threads_target_repo
 
 ALTER TABLE ONLY discussion_threads_target_repo
     ADD CONSTRAINT discussion_threads_target_repo_thread_id_fkey FOREIGN KEY (thread_id) REFERENCES discussion_threads(id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY executor_secret_access_logs
+    ADD CONSTRAINT executor_secret_access_logs_executor_secret_id_fkey FOREIGN KEY (executor_secret_id) REFERENCES executor_secrets(id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY executor_secret_access_logs
+    ADD CONSTRAINT executor_secret_access_logs_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY executor_secrets
+    ADD CONSTRAINT executor_secrets_creator_id_fkey FOREIGN KEY (creator_id) REFERENCES users(id) ON DELETE SET NULL;
+
+ALTER TABLE ONLY executor_secrets
+    ADD CONSTRAINT executor_secrets_namespace_org_id_fkey FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY executor_secrets
+    ADD CONSTRAINT executor_secrets_namespace_user_id_fkey FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE;
 
 ALTER TABLE ONLY external_service_repos
     ADD CONSTRAINT external_service_repos_external_service_id_fkey FOREIGN KEY (external_service_id) REFERENCES external_services(id) ON DELETE CASCADE DEFERRABLE;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -4284,7 +4284,9 @@ CREATE INDEX event_logs_user_id ON event_logs USING btree (user_id);
 
 CREATE UNIQUE INDEX executor_secrets_unique_key_global ON executor_secrets USING btree (key, scope) WHERE ((namespace_user_id IS NULL) AND (namespace_org_id IS NULL));
 
-CREATE UNIQUE INDEX executor_secrets_unique_key_namespace ON executor_secrets USING btree (key, namespace_user_id, namespace_org_id, scope);
+CREATE UNIQUE INDEX executor_secrets_unique_key_namespace_org ON executor_secrets USING btree (key, namespace_org_id, scope) WHERE (namespace_org_id IS NOT NULL);
+
+CREATE UNIQUE INDEX executor_secrets_unique_key_namespace_user ON executor_secrets USING btree (key, namespace_user_id, scope) WHERE (namespace_user_id IS NOT NULL);
 
 CREATE INDEX explicit_permissions_bitbucket_projects_jobs_project_key_extern ON explicit_permissions_bitbucket_projects_jobs USING btree (project_key, external_service_id, state);
 

--- a/mockgen.temp.yaml
+++ b/mockgen.temp.yaml
@@ -106,6 +106,8 @@
     - WebhookStore
     - WebhookLogStore
     - ExecutorStore
+    - ExecutorSecretStore
+    - ExecutorSecretAccessLogStore
 - filename: internal/gitserver/mocks_temp.go
   path: github.com/sourcegraph/sourcegraph/internal/gitserver
   interfaces:

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -536,6 +536,7 @@ type EncryptionKeys struct {
 	CacheSize int `json:"cacheSize,omitempty"`
 	// EnableCache description: enable LRU cache for decryption APIs
 	EnableCache            bool           `json:"enableCache,omitempty"`
+	ExecutorSecretKey      *EncryptionKey `json:"executorSecretKey,omitempty"`
 	ExternalServiceKey     *EncryptionKey `json:"externalServiceKey,omitempty"`
 	UserExternalAccountKey *EncryptionKey `json:"userExternalAccountKey,omitempty"`
 	WebhookKey             *EncryptionKey `json:"webhookKey,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1748,6 +1748,9 @@
         },
         "webhookKey": {
           "$ref": "#/definitions/EncryptionKey"
+        },
+        "executorSecretKey": {
+          "$ref": "#/definitions/EncryptionKey"
         }
       }
     },


### PR DESCRIPTION
This PR is the first of a series of PRs to implement secrets in executors. It introduces 2 new stores that together form one unit:
- ExecutorSecrets: A store that holds all defined executor secrets and access to those, plus encryption
- ExecutorSecretAccessLogs: A store that holds all access log events, these are created automatically when the secret value of the secret is ever read

The secrets store uses both namespace checking in-app for nice error messages and additionally does authz on the SQL layer, so that never a secret is returned to a user that they're not supposed to see.

In the next PR, these stores will be used to implement a resolver layer to expose basic CRUD functionality for these.


## Test plan

Wrote extensive test suite, and validated that these stores make sense in the grand scheme of things. This is pulled out of a giant draft PR.