### PR TITLE
Dotcom homepage prelim cleanup

### DIFF
--- a/client/web/src/search/home/LoggedOutHomepage.tsx
+++ b/client/web/src/search/home/LoggedOutHomepage.tsx
@@ -31,13 +31,23 @@ export const LoggedOutHomepage: React.FunctionComponent<React.PropsWithChildren<
                     telemetryService={props.telemetryService}
                     isSourcegraphDotCom={true}
                 />
+                <TipsAndTricks
+                    title="Tips and Tricks"
+                    examples={exampleTripsAndTricks}
+                    moreLink={{
+                        label: 'More search features',
+                        href: 'https://docs.sourcegraph.com/code_search/explanations/features',
+                        trackEventName: 'HomepageExampleMoreSearchFeaturesClicked',
+                    }}
+                    {...props}
+                />
+
                 <div className={styles.videoCard}>
                     <div className={classNames(styles.title, 'mb-2')}>Watch and learn</div>
                     <ModalVideo
                         id="three-ways-to-search-title"
                         title="Three ways to search"
                         src="https://www.youtube-nocookie.com/embed/XLfE2YuRwvw"
-                        showCaption={true}
                         thumbnail={{
                             src: `img/watch-and-learn-${props.isLightTheme ? 'light' : 'dark'}.png`,
                             alt: 'Watch and learn video thumbnail',
@@ -50,17 +60,6 @@ export const LoggedOutHomepage: React.FunctionComponent<React.PropsWithChildren<
                         assetsRoot={window.context?.assetsRoot || ''}
                     />
                 </div>
-
-                <TipsAndTricks
-                    title="Tips and Tricks"
-                    examples={exampleTripsAndTricks}
-                    moreLink={{
-                        label: 'More search features',
-                        href: 'https://docs.sourcegraph.com/code_search/explanations/features',
-                        trackEventName: 'HomepageExampleMoreSearchFeaturesClicked',
-                    }}
-                    {...props}
-                />
             </div>
 
             <div className={styles.heroSection}>

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -80,7 +80,7 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
                 })}
             >
                 {props.isSourcegraphDotCom && !props.authenticatedUser && <LoggedOutHomepage {...props} />}
-                {props.isSourcegraphDotCom && props.authenticatedUser && (
+                {props.isSourcegraphDotCom && props.authenticatedUser && !showEnterpriseHomePanels && (
                     <TipsAndTricks
                         title="Tips and Tricks"
                         examples={exampleTripsAndTricks}

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -21,9 +21,11 @@ import { ThemePreferenceProps } from '../../theme'
 import { HomePanels } from '../panels/HomePanels'
 
 import { LoggedOutHomepage } from './LoggedOutHomepage'
+import { exampleTripsAndTricks } from './LoggedOutHomepage.constants'
 import { QueryExamplesHomepage } from './QueryExamplesHomepage'
 import { SearchPageFooter } from './SearchPageFooter'
 import { SearchPageInput } from './SearchPageInput'
+import { TipsAndTricks } from './TipsAndTricks'
 
 import styles from './SearchPage.module.scss'
 
@@ -78,12 +80,24 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
                 })}
             >
                 {props.isSourcegraphDotCom && !props.authenticatedUser && <LoggedOutHomepage {...props} />}
+                {props.isSourcegraphDotCom && props.authenticatedUser && (
+                    <TipsAndTricks
+                        title="Tips and Tricks"
+                        examples={exampleTripsAndTricks}
+                        moreLink={{
+                            label: 'More search features',
+                            href: 'https://docs.sourcegraph.com/code_search/explanations/features',
+                            trackEventName: 'HomepageExampleMoreSearchFeaturesClicked',
+                        }}
+                        {...props}
+                    />
+                )}
 
                 {showEnterpriseHomePanels && props.authenticatedUser && (
                     <HomePanels showCollaborators={showCollaborators} {...props} />
                 )}
 
-                {(!showEnterpriseHomePanels && !props.isSourcegraphDotCom) || (props.isSourcegraphDotCom && props.authenticatedUser && !showEnterpriseHomePanels) && (
+                {!showEnterpriseHomePanels && !props.isSourcegraphDotCom && (
                     <QueryExamplesHomepage
                         selectedSearchContextSpec={props.selectedSearchContextSpec}
                         telemetryService={props.telemetryService}

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -78,12 +78,20 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
                 })}
             >
                 {props.isSourcegraphDotCom && !props.authenticatedUser && <LoggedOutHomepage {...props} />}
+                {props.isSourcegraphDotCom && props.authenticatedUser && !showEnterpriseHomePanels && (
+                    <QueryExamplesHomepage
+                        selectedSearchContextSpec={props.selectedSearchContextSpec}
+                        telemetryService={props.telemetryService}
+                        queryState={queryState}
+                        setQueryState={setQueryState}
+                    />
+                )}
 
                 {showEnterpriseHomePanels && props.authenticatedUser && (
                     <HomePanels showCollaborators={showCollaborators} {...props} />
                 )}
 
-                {!showEnterpriseHomePanels && (
+                {!showEnterpriseHomePanels && !props.isSourcegraphDotCom && (
                     <QueryExamplesHomepage
                         selectedSearchContextSpec={props.selectedSearchContextSpec}
                         telemetryService={props.telemetryService}

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -83,7 +83,7 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
                     <HomePanels showCollaborators={showCollaborators} {...props} />
                 )}
 
-                {!showEnterpriseHomePanels && !props.isSourcegraphDotCom && (
+                {!showEnterpriseHomePanels && (
                     <QueryExamplesHomepage
                         selectedSearchContextSpec={props.selectedSearchContextSpec}
                         telemetryService={props.telemetryService}

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -78,20 +78,20 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
                 })}
             >
                 {props.isSourcegraphDotCom && !props.authenticatedUser && <LoggedOutHomepage {...props} />}
-                {props.isSourcegraphDotCom && props.authenticatedUser && !showEnterpriseHomePanels && (
+                {/* {props.isSourcegraphDotCom && props.authenticatedUser && !showEnterpriseHomePanels && (
                     <QueryExamplesHomepage
                         selectedSearchContextSpec={props.selectedSearchContextSpec}
                         telemetryService={props.telemetryService}
                         queryState={queryState}
                         setQueryState={setQueryState}
                     />
-                )}
+                )} */}
 
                 {showEnterpriseHomePanels && props.authenticatedUser && (
                     <HomePanels showCollaborators={showCollaborators} {...props} />
                 )}
 
-                {!showEnterpriseHomePanels && !props.isSourcegraphDotCom && (
+                {(!showEnterpriseHomePanels && !props.isSourcegraphDotCom) || (props.isSourcegraphDotCom && props.authenticatedUser && !showEnterpriseHomePanels) && (
                     <QueryExamplesHomepage
                         selectedSearchContextSpec={props.selectedSearchContextSpec}
                         telemetryService={props.telemetryService}

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -78,14 +78,6 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
                 })}
             >
                 {props.isSourcegraphDotCom && !props.authenticatedUser && <LoggedOutHomepage {...props} />}
-                {/* {props.isSourcegraphDotCom && props.authenticatedUser && !showEnterpriseHomePanels && (
-                    <QueryExamplesHomepage
-                        selectedSearchContextSpec={props.selectedSearchContextSpec}
-                        telemetryService={props.telemetryService}
-                        queryState={queryState}
-                        setQueryState={setQueryState}
-                    />
-                )} */}
 
                 {showEnterpriseHomePanels && props.authenticatedUser && (
                     <HomePanels showCollaborators={showCollaborators} {...props} />


### PR DESCRIPTION
This PR is paving some preliminary cleanup to dotcom's homepage, closing #43246.

Preliminary search guidance is added to an auth'd users `/search` view. (The current search "tips and tricks" section from unauth'd `/search`).

## Note
Because of the complexity in S2's search examples that don't quite work for open source searches & because suggested search section is [planning to get a revamp](https://www.figma.com/file/X2BEdyugA4AvZIAXC4iEuj?node-id=4:4305#290128068), we can re-use the open source search suggestion for both unauth'd & auth'd views in #43255.

## Test plan
- Ensure all tests pass
- Ensure visiting `/search` home page logged in on dotcom (locally `SOURCEGRAPHDOTCOM_MODE=true sg start web-standalone`) shows the same search query samples on k8s and s2
- Observe no breaking changes on logged out/in state in this view for all env's

## BEFORE
unauth'd:
![image](https://user-images.githubusercontent.com/59381432/197055003-9fbe2393-4bdf-4e51-bcde-c5991396c69e.png)
auth'd:
![image](https://user-images.githubusercontent.com/59381432/197055225-1bb5c424-3f82-4914-a0a4-26d52cf388b7.png)

## NOW
unauth'd:
![image](https://user-images.githubusercontent.com/59381432/197055084-44241e6d-c7ad-4699-bc1a-5dc889b9dd7d.png)
auth'd:
![image](https://user-images.githubusercontent.com/59381432/197055262-83bf2b59-0c07-4976-9218-6c65660ccb6e.png)

## App preview:

- [Web](https://sg-web-becca-dotcom-homepage-cleanup.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-iyhnsrgmwu.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

