### PR TITLE
Code Insights: Remove polling feature flag

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/SmartInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/SmartInsight.tsx
@@ -1,11 +1,11 @@
-import React, { forwardRef, useEffect, useRef } from 'react'
+import React, { forwardRef, useEffect } from 'react'
 
 import { useMergeRefs } from 'use-callback-ref'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useSearchParameters } from '@sourcegraph/wildcard'
 
-import { Insight, isBackendInsight, isComputeInsight } from '../../../core'
+import { Insight, isBackendInsight } from '../../../core'
 
 import { BackendInsightView } from './backend-insight/BackendInsight'
 import { BuiltInInsight } from './built-in-insight/BuiltInInsight'
@@ -21,8 +21,8 @@ export interface SmartInsightProps extends TelemetryProps, React.HTMLAttributes<
  */
 export const SmartInsight = forwardRef<HTMLElement, SmartInsightProps>((props, reference) => {
     const { insight, resizing = false, telemetryService, ...otherProps } = props
-    const localReference = useRef<HTMLElement>(null)
-    const mergedReference = useMergeRefs([reference, localReference])
+
+    const mergedReference = useMergeRefs([reference])
     const search = useSearchParameters()
 
     useEffect(() => {
@@ -37,21 +37,16 @@ export const SmartInsight = forwardRef<HTMLElement, SmartInsightProps>((props, r
     if (isBackendInsight(insight)) {
         return (
             <BackendInsightView
+                ref={mergedReference}
                 insight={insight}
                 resizing={resizing}
                 telemetryService={telemetryService}
                 {...otherProps}
-                innerRef={mergedReference}
             />
         )
     }
 
-    if (isComputeInsight(insight)) {
-        // Compute-powered insight card isn't implemented yet
-        return null
-    }
-
-    // Search based extension and lang stats insight are handled by built-in fetchers
+    // Lang-stats insight is handled by built-in fetchers
     return (
         <BuiltInInsight
             insight={insight}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
@@ -243,7 +243,6 @@ const TestBackendInsight: React.FunctionComponent<React.PropsWithChildren<unknow
         style={{ width: 400, height: 400 }}
         insight={INSIGHT_CONFIGURATION_MOCK}
         telemetryService={NOOP_TELEMETRY_SERVICE}
-        innerRef={() => {}}
     />
 )
 
@@ -1223,7 +1222,6 @@ export const BackendInsightDemoCasesShowcase: Story = () => (
                 style={{ width: 400, height: 400 }}
                 insight={COMPONENT_MIGRATION_INSIGHT_CONFIGURATION}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
-                innerRef={() => {}}
             />
         </MockedTestProvider>
 
@@ -1232,7 +1230,6 @@ export const BackendInsightDemoCasesShowcase: Story = () => (
                 style={{ width: 400, height: 400 }}
                 insight={DATA_FETCHING_INSIGHT_CONFIGURATION}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
-                innerRef={() => {}}
             />
         </MockedTestProvider>
 
@@ -1241,7 +1238,6 @@ export const BackendInsightDemoCasesShowcase: Story = () => (
                 style={{ width: 400, height: 400 }}
                 insight={TERRAFORM_INSIGHT_CONFIGURATION}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
-                innerRef={() => {}}
             />
         </MockedTestProvider>
     </div>
@@ -1286,7 +1282,6 @@ export const BackendInsightVitrine: Story = () => (
                     style={{ width: 400, height: 400 }}
                     insight={{ ...INSIGHT_CONFIGURATION_MOCK, isFrozen: true }}
                     telemetryService={NOOP_TELEMETRY_SERVICE}
-                    innerRef={() => {}}
                 />
             </MockedTestProvider>
         </article>

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -1,4 +1,4 @@
-import React, { Ref, useContext, useRef, useState } from 'react'
+import { forwardRef, HTMLAttributes, useContext, useRef, useState } from 'react'
 
 import classNames from 'classnames'
 import { useMergeRefs } from 'use-callback-ref'
@@ -8,9 +8,7 @@ import { useQuery } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, useDebounce, useDeepMemo } from '@sourcegraph/wildcard'
 
-import { useFeatureFlag } from '../../../../../../featureFlags/useFeatureFlag'
 import {
-    InsightViewFiltersInput,
     SeriesDisplayOptionsInput,
     GetInsightViewResult,
     GetInsightViewVariables,
@@ -37,63 +35,50 @@ import {
 
 import styles from './BackendInsight.module.scss'
 
-interface BackendInsightProps
-    extends TelemetryProps,
-        React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> {
+interface BackendInsightProps extends TelemetryProps, HTMLAttributes<HTMLElement> {
     insight: BackendInsight
-
-    innerRef: Ref<HTMLElement>
     resizing?: boolean
 }
 
-/**
- * Renders search based insight. Fetches insight data by gql api handler.
- */
-export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren<BackendInsightProps>> = props => {
-    const { telemetryService, insight, innerRef, resizing, ...otherProps } = props
+export const BackendInsightView = forwardRef<HTMLElement, BackendInsightProps>((props, ref) => {
+    const { telemetryService, insight, resizing, children, ...otherProps } = props
 
     const { currentDashboard, dashboards } = useContext(InsightContext)
     const { createInsight, updateInsight } = useContext(CodeInsightsBackendContext)
-    // seriesToggleState is instantiated at this level to prevent the state from being
-    // deleted when the insight is scrolled out of view
+
+    const cardElementRef = useMergeRefs([ref])
+    const { wasEverVisible, isVisible } = useVisibility(cardElementRef)
+
     const seriesToggleState = useSeriesToggle()
-    const [insightData, setInsightData] = useState<BackendInsightData | undefined>()
-    const [enablePolling] = useFeatureFlag('insight-polling-enabled', true)
-    const pollingInterval = enablePolling ? insightPollingInterval(insight) : 0
-
-    // Visual line chart settings
-    const [zeroYAxisMin, setZeroYAxisMin] = useState(false)
-    const insightCardReference = useRef<HTMLDivElement>(null)
-    const mergedInsightCardReference = useMergeRefs([insightCardReference, innerRef])
-    const { wasEverVisible, isVisible } = useVisibility(insightCardReference)
-
     // Original insight filters values that are stored in setting subject with insight
     // configuration object, They are updated  whenever the user clicks update/save button
     const [originalInsightFilters, setOriginalInsightFilters] = useState(insight.filters)
-
     // Live valid filters from filter form. They are updated whenever the user is changing
     // filter value in filters fields.
     const [filters, setFilters] = useState<InsightFilters>(originalInsightFilters)
+    const [insightData, setInsightData] = useState<BackendInsightData | undefined>()
+    const [zeroYAxisMin, setZeroYAxisMin] = useState(false)
     const [isFiltersOpen, setIsFiltersOpen] = useState(false)
-    const debouncedFilters = useDebounce(useDeepMemo<InsightFilters>(filters), 500)
 
-    const filterInput: InsightViewFiltersInput = {
-        includeRepoRegex: debouncedFilters.includeRepoRegexp,
-        excludeRepoRegex: debouncedFilters.excludeRepoRegexp,
-        searchContexts: [debouncedFilters.context],
-    }
-    const seriesDisplayOptions: SeriesDisplayOptionsInput = {
-        limit: parseSeriesLimit(debouncedFilters.seriesDisplayOptions.limit),
-        sortOptions: debouncedFilters.seriesDisplayOptions.sortOptions,
-    }
+    const debouncedFilters = useDebounce(useDeepMemo<InsightFilters>(filters), 500)
 
     const { error, loading, stopPolling, startPolling } = useQuery<GetInsightViewResult, GetInsightViewVariables>(
         GET_INSIGHT_VIEW_GQL,
         {
-            variables: { id: insight.id, filters: filterInput, seriesDisplayOptions },
-            fetchPolicy: 'cache-and-network',
             skip: !wasEverVisible,
             context: { concurrentRequests: { key: 'GET_INSIGHT_VIEW' } },
+            variables: {
+                id: insight.id,
+                filters: {
+                    includeRepoRegex: debouncedFilters.includeRepoRegexp,
+                    excludeRepoRegex: debouncedFilters.excludeRepoRegexp,
+                    searchContexts: [debouncedFilters.context],
+                },
+                seriesDisplayOptions: {
+                    limit: parseSeriesLimit(debouncedFilters.seriesDisplayOptions.limit),
+                    sortOptions: debouncedFilters.seriesDisplayOptions.sortOptions,
+                }
+            },
             onCompleted: data => {
                 const parsedData = createBackendInsightData({ ...insight, filters }, data.insightViews.nodes[0])
                 seriesToggleState.setSelectedSeriesIds([])
@@ -105,18 +90,15 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
     const isFetchingHistoricalData = insightData?.isFetchingHistoricalData
     const isPolling = useRef(false)
 
-    // polling is disabled ignore all
-    if (enablePolling) {
-        // not on the screen so stop polling if we are - multiple stop calls are safe
-        if (error || !isVisible || !isFetchingHistoricalData) {
-            isPolling.current = false
-            stopPolling()
-        } else if (isFetchingHistoricalData && !isPolling.current) {
-            // we should start polling but multiple calls to startPolling reset the timer so
-            // make sure we aren't already polling.
-            isPolling.current = true
-            startPolling(pollingInterval)
-        }
+    // Not on the screen so stop polling if we are - multiple stop calls are safe
+    if (error || !isVisible || !isFetchingHistoricalData) {
+        isPolling.current = false
+        stopPolling()
+    } else if (isFetchingHistoricalData && !isPolling.current) {
+        // we should start polling but multiple calls to startPolling reset the timer so
+        // make sure we aren't already polling.
+        isPolling.current = true
+        startPolling(insightPollingInterval(insight))
     }
 
     async function handleFilterSave(filters: InsightFilters): Promise<SubmissionErrors> {
@@ -179,7 +161,7 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
     return (
         <InsightCard
             {...otherProps}
-            ref={mergedInsightCardReference}
+            ref={cardElementRef}
             data-testid={`insight-card.${insight.id}`}
             aria-label="Insight card"
             className={classNames(otherProps.className, { [styles.cardWithFilters]: isFiltersOpen })}
@@ -202,7 +184,7 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
                     <>
                         <DrillDownFiltersPopover
                             isOpen={isFiltersOpen}
-                            anchor={insightCardReference}
+                            anchor={cardElementRef}
                             initialFiltersValue={filters}
                             originalFiltersValue={originalInsightFilters}
                             onFilterChange={setFilters}
@@ -239,8 +221,8 @@ export const BackendInsightView: React.FunctionComponent<React.PropsWithChildren
             {
                 // Passing children props explicitly to render any top-level content like
                 // resize-handler from the react-grid-layout library
-                isVisible && otherProps.children
+                isVisible && children
             }
         </InsightCard>
     )
-}
+})

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -8,7 +8,6 @@ import { useQuery } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Card, CardBody, useDebounce, useDeepMemo } from '@sourcegraph/wildcard'
 
-import { useFeatureFlag } from '../../../../../../../featureFlags/useFeatureFlag'
 import {
     GetInsightViewResult,
     GetInsightViewVariables,
@@ -57,8 +56,6 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
 
     const seriesToggleState = useSeriesToggle()
     const [insightData, setInsightData] = useState<BackendInsightData | undefined>()
-    const [enablePolling] = useFeatureFlag('insight-polling-enabled', true)
-    const pollingInterval = enablePolling ? insightPollingInterval(insight) : 0
 
     // Visual line chart settings
     const [zeroYAxisMin, setZeroYAxisMin] = useState(false)
@@ -90,7 +87,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
         {
             variables: { id: insight.id, filters: filterInput, seriesDisplayOptions },
             fetchPolicy: 'cache-and-network',
-            pollInterval: pollingInterval,
+            pollInterval: insightPollingInterval(insight),
             context: { concurrentRequests: { key: 'GET_INSIGHT_VIEW' } },
             onCompleted: data => {
                 const parsedData = createBackendInsightData({ ...insight, filters }, data.insightViews.nodes[0])


### PR DESCRIPTION

Since insight polling feature has been battle tested and we haven't gotten any bad feedback about it this PR removes feature flag over this feature. 

## Test plan
- Create an insight
- Make sure that polling works for this insight correctly (insight data is keep fetching/polling until backfilling is complete)
- Make sure that CI is green

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-remove-polling-feature-flag.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
