### PR TITLE
squirrel: Lower default stack depth limit from 10k to 100

### DIFF
--- a/cmd/symbols/squirrel/service.go
+++ b/cmd/symbols/squirrel/service.go
@@ -161,7 +161,7 @@ func (squirrel *SquirrelService) getDef(ctx context.Context, node Node) (*Node, 
 	}
 }
 
-const defaultMaxSquirrelDepth = 10_000
+const defaultMaxSquirrelDepth = 100
 
 var maxSquirrelDepth = func() int {
 	maxDepth := os.Getenv("SRC_SQUIRREL_MAX_STACK_DEPTH")


### PR DESCRIPTION
10k takes ~15s to bottom out, and IMO a depth limit of 100 is plenty for 99.99% of cases. This is a continuation of https://github.com/sourcegraph/sourcegraph/pull/43259

## Test plan

N/A
