### PR TITLE
insights: fix troubleshooting docs that refer to deprecated api

### DIFF
--- a/doc/code_insights/references/common_reasons_code_insights_may_not_match_search_results.md
+++ b/doc/code_insights/references/common_reasons_code_insights_may_not_match_search_results.md
@@ -28,14 +28,10 @@ Currently, a data series' most recent datapoint defaults to the end of the prior
 
 If your code insight is very large, it is possible that a few (\<1% in 100+ manual tests over 26,000 repositories) repositories failed to return match counts due to timing out while searching. To check this, you can run the following GraphQL query in the Sourcegraph GraphQL API: 
 ```graphql
-{
-  insights(ids: ["INSIGHT_ID"]) {
-    totalCount
+query{
+  insightViews(id: "INSIGHT_ID") {
     nodes {
-      id
-      title
-      description
-      series{
+      dataSeries {
         label
         status {
           pendingJobs
@@ -43,17 +39,16 @@ If your code insight is very large, it is possible that a few (\<1% in 100+ manu
           failedJobs
         }
         dirtyMetadata {
-          time
           count
           reason
+          time
         }
       }
-      id
     }
   }
 }
 ```
 
-where `INSIGHT_ID` can be found in the URL of the "edit" page for the insight (selectable from the three-dot dropdown on the insight) after `...edit/`. For example, `https://sourcegraph.yourdomain.com/insights/edit/searchInsights.insight.TestInsightTitleHere?dashboardId=all` contains the `INSIGHT_ID` of `searchInsights.insight.TestInsightTitleHere`. 
+where `INSIGHT_ID` can be found in the URL of the "edit" page for the insight (selectable from the three-dot dropdown on the insight) after `...edit/`. For example, `https://sourcegraph.yourdomain.com/insights/edit/searchInsights.insight.TestInsightTitleHere?dashboardId=all` contains the `INSIGHT_ID` of `searchInsights.insight.TestInsightTitleHere`.  The `INSIGHT_ID` can also be found in the url of the single insight view found by clicking on the title of the insight. The ID will be in the url, for example, `https://sourcegraph.yourdomain.com/insights/insight/{INSIGHT_ID}`
 
 If there are `failedJobs`, there may be timeouts or similar issues affecting your insight. 


### PR DESCRIPTION
Updates troubleshooting query in docs.
## Test plan
docs only
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
