### PR TITLE
batches: Fix missing gitserverClient in resolver

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/init.go
+++ b/enterprise/cmd/frontend/internal/batches/init.go
@@ -43,7 +43,7 @@ func Init(
 
 	// Register enterprise services.
 	gitserverClient := gitserver.NewClient(db)
-	enterpriseServices.BatchChangesResolver = resolvers.New(bstore)
+	enterpriseServices.BatchChangesResolver = resolvers.New(bstore, gitserverClient)
 	enterpriseServices.GitHubWebhook = webhooks.NewGitHubWebhook(bstore, gitserverClient)
 	enterpriseServices.BitbucketServerWebhook = webhooks.NewBitbucketServerWebhook(bstore, gitserverClient)
 	enterpriseServices.BitbucketCloudWebhook = webhooks.NewBitbucketCloudWebhook(bstore, gitserverClient)

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
@@ -195,7 +196,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 		}
 	}
 
-	s, err := newSchema(db, New(bstore))
+	s, err := newSchema(db, New(bstore, gitserver.NewMockClient()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
@@ -49,7 +49,7 @@ func TestPermissionLevels(t *testing.T) {
 	key := et.TestKey{}
 
 	bstore := store.New(db, &observation.TestContext, key)
-	sr := New(bstore)
+	sr := New(bstore, gitserver.NewMockClient())
 	s, err := newSchema(db, sr)
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -41,8 +41,8 @@ type Resolver struct {
 }
 
 // New returns a new Resolver whose store uses the given database
-func New(store *store.Store) graphqlbackend.BatchChangesResolver {
-	return &Resolver{store: store}
+func New(store *store.Store, gitserverClient gitserver.Client) graphqlbackend.BatchChangesResolver {
+	return &Resolver{store: store, gitserverClient: gitserverClient}
 }
 
 // batchChangesCreateAccess returns true if the current user has batch changes enabled for

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
@@ -46,7 +47,7 @@ func TestNullIDResilience(t *testing.T) {
 	logger := logtest.Scoped(t)
 
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
-	sr := New(store.New(db, &observation.TestContext, nil))
+	sr := New(store.New(db, &observation.TestContext, nil), gitserver.NewMockClient())
 
 	s, err := newSchema(db, sr)
 	if err != nil {


### PR DESCRIPTION
This was recently added when some mocks were refactored but we forgot to pass in the client at the root resolver, which causes panics when rendering diffs.



## Test plan

Verified diffs load again.