### PR TITLE
search ui: highlight path matches for files in root directory

### DIFF
--- a/client/search-ui/src/components/RepoFileLink.tsx
+++ b/client/search-ui/src/components/RepoFileLink.tsx
@@ -46,7 +46,7 @@ export const RepoFileLink: React.FunctionComponent<React.PropsWithChildren<Props
     )
 
     useEffect((): void => {
-        if (containerElement.current && pathMatchRanges && fileBase && fileName) {
+        if (containerElement.current && pathMatchRanges && fileName) {
             for (const range of pathMatchRanges) {
                 highlightNode(
                     containerElement.current as HTMLElement,
@@ -55,7 +55,7 @@ export const RepoFileLink: React.FunctionComponent<React.PropsWithChildren<Props
                 )
             }
         }
-    }, [pathMatchRanges, fileBase, fileName, containerElement])
+    }, [pathMatchRanges, fileName, containerElement])
 
     return repoFileLink()
 }


### PR DESCRIPTION
Fixes a bug where path matches on files in the root directory of a repository were not highlighted. 
`fileBase` is empty for file paths in the root directory and so the `if` condition in `useEffect()` would evaluate to false and highlighting would not happen.

## Test plan
Manual testing

Before:
![file_highlight_fix_before](https://user-images.githubusercontent.com/70350613/197096809-cbd77bc5-25e9-4236-bceb-667e412730bd.png)

After:
![file_highlight_fix_after](https://user-images.githubusercontent.com/70350613/197096821-ca1cdb4b-f30b-4474-b775-1fc64d021075.png)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tl-filename-highlight-fix.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-iqpahbpfpc.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
