### PR TITLE
txemail: alias duplicated type

### DIFF
--- a/internal/txemail/txemail.go
+++ b/internal/txemail/txemail.go
@@ -19,17 +19,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// Message describes an email message to be sent.
-type Message struct {
-	FromName   string   // email "From" address proper name
-	To         []string // email "To" recipients
-	ReplyTo    *string  // optional "ReplyTo" address
-	MessageID  *string  // optional "Message-ID" header
-	References []string // optional "References" header list
-
-	Template txtypes.Templates // unparsed subject/body templates
-	Data     any               // template data
-}
+// Message describes an email message to be sent, aliased in this package for convenience.
+type Message = txtypes.Message
 
 var emailSendCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "src_email_send",


### PR DESCRIPTION
txemail.Message and txtypes.Message are exactly the same - we alias the latter in the former for convenience.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI passes
