### PR TITLE
txemail: add 'source' to src_email_send

### DIFF
--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -167,7 +167,7 @@ func SendUserEmailVerificationEmail(ctx context.Context, username, email, code s
 	q.Set("code", code)
 	q.Set("email", email)
 	verifyEmailPath, _ := router.Router().Get(router.VerifyEmail).URLPath()
-	return txemail.Send(ctx, txemail.Message{
+	return txemail.Send(ctx, "user_email_verification", txemail.Message{
 		To:       []string{email},
 		Template: verifyEmailTemplates,
 		Data: struct {
@@ -216,7 +216,7 @@ func (userEmails) SendUserEmailOnFieldUpdate(ctx context.Context, logger log.Log
 		return err
 	}
 
-	return txemail.Send(ctx, txemail.Message{
+	return txemail.Send(ctx, "user_account_update", txemail.Message{
 		To:       []string{email},
 		Template: updateAccountEmailTemplate,
 		Data: struct {

--- a/cmd/frontend/graphqlbackend/email_invitation.go
+++ b/cmd/frontend/graphqlbackend/email_invitation.go
@@ -68,7 +68,7 @@ func (r *schemaResolver) InviteEmailToSourcegraph(ctx context.Context, args *str
 		}
 
 		urlSignUp, _ := url.Parse("/sign-up?invitedBy=" + invitedBy.Username)
-		if err := txemail.Send(ctx, txemail.Message{
+		if err := txemail.Send(ctx, "user_invite", txemail.Message{
 			To:       []string{args.Email},
 			Template: emailTemplateEmailInvitation,
 			Data: struct {

--- a/cmd/frontend/graphqlbackend/org_invitations.go
+++ b/cmd/frontend/graphqlbackend/org_invitations.go
@@ -544,7 +544,7 @@ func sendOrgInvitationNotification(ctx context.Context, db database.DB, org *typ
 		orgName = org.Name
 	}
 
-	return txemail.Send(ctx, txemail.Message{
+	return txemail.Send(ctx, "org_invite", txemail.Message{
 		To:       []string{recipientEmail},
 		Template: emailTemplates,
 		Data: struct {

--- a/cmd/frontend/graphqlbackend/send_test_email.go
+++ b/cmd/frontend/graphqlbackend/send_test_email.go
@@ -15,7 +15,7 @@ func (r *schemaResolver) SendTestEmail(ctx context.Context, args struct{ To stri
 		return "", err
 	}
 
-	if err := txemail.Send(ctx, txemail.Message{
+	if err := txemail.Send(ctx, "test_email", txemail.Message{
 		To:       []string{args.To},
 		Template: emailTemplateTest,
 		Data:     struct{}{},

--- a/cmd/frontend/internal/auth/userpasswd/lockout.go
+++ b/cmd/frontend/internal/auth/userpasswd/lockout.go
@@ -127,7 +127,7 @@ func (s *lockoutStore) SendUnlockAccountEmail(ctx context.Context, userID int32,
 		return err
 	}
 
-	return txemail.Send(ctx, txemail.Message{
+	return txemail.Send(ctx, "account_unlock", txemail.Message{
 		To:       []string{recipientEmail},
 		Template: emailTemplates,
 		Data: struct {

--- a/cmd/frontend/internal/auth/userpasswd/reset_password.go
+++ b/cmd/frontend/internal/auth/userpasswd/reset_password.go
@@ -20,7 +20,7 @@ import (
 )
 
 func SendResetPasswordURLEmail(ctx context.Context, email, username string, resetURL *url.URL) error {
-	return txemail.Send(ctx, txemail.Message{
+	return txemail.Send(ctx, "password_reset", txemail.Message{
 		To:       []string{email},
 		Template: resetPasswordEmailTemplates,
 		Data: struct {
@@ -130,7 +130,7 @@ func HandleSetPasswordEmail(ctx context.Context, db database.DB, id int32) (stri
 	}
 
 	rus := globals.ExternalURL().ResolveReference(ru).String()
-	if err := txemail.Send(ctx, txemail.Message{
+	if err := txemail.Send(ctx, "password_set", txemail.Message{
 		To:       []string{e},
 		Template: setPasswordEmailTemplates,
 		Data: struct {

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/txemail"
+	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -90,12 +91,12 @@ func serveExternalURL(w http.ResponseWriter, _ *http.Request) error {
 }
 
 func serveSendEmail(_ http.ResponseWriter, r *http.Request) error {
-	var msg txemail.Message
+	var msg txtypes.InternalAPIMessage
 	err := json.NewDecoder(r.Body).Decode(&msg)
 	if err != nil {
 		return err
 	}
-	return txemail.Send(r.Context(), msg)
+	return txemail.Send(r.Context(), msg.Source, msg.Message)
 }
 
 // gitServiceHandler are handlers which redirect git clone requests to the

--- a/enterprise/internal/codemonitors/background/email.go
+++ b/enterprise/internal/codemonitors/background/email.go
@@ -129,7 +129,7 @@ func sendEmail(ctx context.Context, db database.DB, userID int32, template txtyp
 		}
 		return errors.Errorf("internalapi.Client.UserEmailsGetEmail for userID=%d: %w", userID, err)
 	}
-	if err := internalapi.Client.SendEmail(ctx, txtypes.Message{
+	if err := internalapi.Client.SendEmail(ctx, "code-monitor", txtypes.Message{
 		To:       []string{email},
 		Template: template,
 		Data:     data,

--- a/internal/api/internalapi/client.go
+++ b/internal/api/internalapi/client.go
@@ -50,8 +50,8 @@ func (c *internalClient) ExternalURL(ctx context.Context) (string, error) {
 }
 
 // TODO(slimsag): needs cleanup as part of upcoming configuration refactor.
-func (c *internalClient) SendEmail(ctx context.Context, message txtypes.Message) error {
-	return c.postInternal(ctx, "send-email", &message, nil)
+func (c *internalClient) SendEmail(ctx context.Context, source string, message txtypes.Message) error {
+	return c.postInternal(ctx, "send-email", &txtypes.InternalAPIMessage{}, nil)
 }
 
 // MockClientConfiguration mocks (*internalClient).Configuration.

--- a/internal/txemail/txtypes/types.go
+++ b/internal/txemail/txtypes/types.go
@@ -5,6 +5,13 @@ import (
 	texttemplate "text/template"
 )
 
+// InternalAPIMessage describes an email message to be sent via the 'internal.send-email'
+// endpoint.
+type InternalAPIMessage struct {
+	Source string
+	Message
+}
+
 // Message describes an email message to be sent.
 type Message struct {
 	FromName   string   // email "From" address proper name


### PR DESCRIPTION
Allows more granular monitoring of email delivery usage, most notably what product features are using emails.

Part of https://github.com/sourcegraph/customer/issues/1411

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI passes
