### PR TITLE
Fuzzy finder: add star-based repo ranking

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.mocks.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.mocks.tsx
@@ -88,7 +88,7 @@ export const FUZZY_REPOS_MOCK: MockedResponse<FuzzyFinderRepoResult> = {
         data: {
             search: {
                 results: {
-                    repositories: [{ name: 'github.com/sourcegraph/sourcegraph' }],
+                    repositories: [{ name: 'github.com/sourcegraph/sourcegraph', stars: 1234 }],
                 },
             },
         },

--- a/client/web/src/components/fuzzyFinder/FuzzyLocalCache.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyLocalCache.tsx
@@ -11,6 +11,7 @@ export interface PersistableQueryResult {
     text: string
     url?: string
     symbolKind?: SymbolKind
+    stars?: number
 }
 
 export interface FuzzyLocalCache {

--- a/client/web/src/components/fuzzyFinder/FuzzyRepos.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyRepos.tsx
@@ -3,7 +3,6 @@ import gql from 'tagged-template-noop'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { CodeHostIcon, formatRepositoryStarCount, SearchResultStar } from '@sourcegraph/search-ui'
-import { Text } from '@sourcegraph/wildcard'
 
 import { getWebGraphQLClient } from '../../backend/graphql'
 import { SearchValue } from '../../fuzzyFinder/FuzzySearch'

--- a/client/web/src/components/fuzzyFinder/FuzzyRepos.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyRepos.tsx
@@ -2,7 +2,8 @@ import { ApolloClient } from '@apollo/client'
 import gql from 'tagged-template-noop'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
-import { CodeHostIcon } from '@sourcegraph/search-ui'
+import { CodeHostIcon, formatRepositoryStarCount, SearchResultStar } from '@sourcegraph/search-ui'
+import { Text } from '@sourcegraph/wildcard'
 
 import { getWebGraphQLClient } from '../../backend/graphql'
 import { SearchValue } from '../../fuzzyFinder/FuzzySearch'
@@ -17,6 +18,7 @@ export const FUZZY_REPOS_QUERY = gql`
             results {
                 repositories {
                     name
+                    stars
                 }
             }
         }
@@ -33,11 +35,23 @@ export class FuzzyRepos extends FuzzyQuery {
     }
 
     /* override */ protected searchValues(): SearchValue[] {
-        return [...this.queryResults.values()].map(({ text, url }) => ({
-            text,
-            url,
-            icon: <CodeHostIcon repoName={text} /> || undefined,
-        }))
+        return [...this.queryResults.values()].map(({ text, url, stars }) => {
+            const formattedRepositoryStarCount = formatRepositoryStarCount(stars)
+
+            return {
+                text,
+                url,
+                icon: <CodeHostIcon repoName={text} /> || undefined,
+                textSuffix:
+                    stars && stars > 0 && formattedRepositoryStarCount ? (
+                        <span>
+                            <SearchResultStar aria-label={`${stars} stars`} />
+                            <span aria-hidden={true}>{formattedRepositoryStarCount}</span>
+                        </span>
+                    ) : undefined,
+                ranking: stars,
+            }
+        })
     }
     /* override */ protected async handleRawQueryPromise(query: string): Promise<PersistableQueryResult[]> {
         const client = this.client || (await getWebGraphQLClient())
@@ -46,16 +60,17 @@ export class FuzzyRepos extends FuzzyQuery {
             variables: { query },
         })
         const repositories = response.data?.search?.results?.repositories || []
-        // const repositories = await Promise.resolve([{ name: 'a' }])
-        return repositories?.map(({ name }) => ({
+        const queryResults: PersistableQueryResult[] = repositories?.map(({ name, stars }) => ({
             text: name,
             url: `/${name}`,
+            stars,
         }))
+        return queryResults
     }
 
     private async staleResults(values: PersistableQueryResult[]): Promise<PersistableQueryResult[]> {
         const actualRepos = await this.handleRawQueryPromise(`type:repo (${values.map(({ text }) => text).join('|')})`)
         const isActualRepoName = new Set([...actualRepos.map(({ text }) => text)])
-        return values.filter(({ text }) => !isActualRepoName.has(text))
+        return values.filter(({ text, stars }) => !isActualRepoName.has(text) || stars === undefined)
     }
 }

--- a/client/web/src/components/fuzzyFinder/HighlightedLink.tsx
+++ b/client/web/src/components/fuzzyFinder/HighlightedLink.tsx
@@ -19,6 +19,7 @@ export interface HighlightedLinkProps {
     positions: RangePosition[]
     url?: string
     icon?: JSX.Element
+    textSuffix?: JSX.Element
     onClick?: () => void
 }
 
@@ -80,6 +81,7 @@ export const HighlightedLink: React.FunctionComponent<React.PropsWithChildren<Hi
             <Link key="link" tabIndex={-1} className={styles.link} to={props.url} onClick={props.onClick}>
                 {props.icon && <span key="icon">{props.icon}</span>}
                 {spans}
+                {props.textSuffix}
             </Link>
         </Code>
     ) : (

--- a/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.ts
+++ b/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.ts
@@ -75,7 +75,13 @@ export class CaseInsensitiveFuzzySearch extends FuzzySearch {
         this.cacheCandidates.push(new CacheCandidate(parameters.query, [...candidates]))
 
         const isComplete = candidates.length < parameters.maxResults
-        candidates.sort((a, b) => b.score - a.score)
+        candidates.sort((a, b) => {
+            const byScore = b.score - a.score
+            if (byScore < 1 && a.ranking && b.ranking) {
+                return b.ranking - a.ranking
+            }
+            return byScore
+        })
         candidates.slice(0, parameters.maxResults)
 
         const links: HighlightedLinkProps[] = candidates.map(candidate => {

--- a/client/web/src/fuzzyFinder/FuzzySearch.ts
+++ b/client/web/src/fuzzyFinder/FuzzySearch.ts
@@ -19,6 +19,7 @@ export enum SearchIconKind {
 
 export interface SearchValue {
     text: string
+    ranking?: number
     url?: string
     icon?: JSX.Element
     onClick?: () => void


### PR DESCRIPTION
Previously, the repos tab used exclusively text-based ranking, which meant that queries like "sourcegraph" would often give irrelevant results at the top since so many repos have similar text-based ranking. This commit updates the ranking to use repo stars as a tie-breaker for text-based ranking.

Followup from https://sourcegraph.slack.com/archives/C03CSAER9LK/p1666342383541329

## Test plan

Run `SOURCEGRAPH_API_URL=https://sourcegraph.com sg start web-standalone` and type queries that trigger the new star-based ranking. For example,

- ruby
- react
- sourcegraph
- microsoft

![CleanShot 2022-10-21 at 11 48 27](https://user-images.githubusercontent.com/1408093/197168839-76057723-d126-4852-9c93-2195b806dc8d.png)
![CleanShot 2022-10-21 at 11 49 15](https://user-images.githubusercontent.com/1408093/197168847-ca3a90d1-24c3-4420-a08a-975afcaccfcb.png)
![CleanShot 2022-10-21 at 11 49 06](https://user-images.githubusercontent.com/1408093/197168851-065b8fb6-dd4f-4bd8-a506-9967a1a8805f.png)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-fuzzy-repo-stars.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
