### PR TITLE
[SG-43130] Clicking the copy query button should maintain focus on the copy button

### DIFF
--- a/client/search-ui/src/input/toggles/CopyQueryButton.tsx
+++ b/client/search-ui/src/input/toggles/CopyQueryButton.tsx
@@ -31,9 +31,13 @@ export const CopyQueryButton: React.FunctionComponent<React.PropsWithChildren<Pr
 
     const [nextClick, copied] = useEventObservable(
         useCallback(
-            (clicks: Observable<React.MouseEvent>) =>
+            (clicks: Observable<React.MouseEvent<HTMLButtonElement>>) =>
                 clicks.pipe(
                     tap(copyFullQuery),
+                    tap(event => {
+                        event.preventDefault()
+                        event.currentTarget.focus()
+                    }),
                     switchMapTo(merge(of(true), of(false).pipe(delay(2000)))),
                     startWith(false)
                 ),

--- a/client/search-ui/src/input/toggles/CopyQueryButton.tsx
+++ b/client/search-ui/src/input/toggles/CopyQueryButton.tsx
@@ -34,6 +34,8 @@ export const CopyQueryButton: React.FunctionComponent<React.PropsWithChildren<Pr
             (clicks: Observable<React.MouseEvent<HTMLButtonElement>>) =>
                 clicks.pipe(
                     tap(copyFullQuery),
+                    // There is an issue in copyFullQuery where the focus 
+                    // is removed from the button; this patches it.
                     tap(event => {
                         event.preventDefault()
                         event.currentTarget.focus()


### PR DESCRIPTION
### Description
When using keyboard or mouse, after activating the copy query button on the right of the search box, focus is changed to the search box. The focus will not be changed now.

### Success Criteria
The focus should stay on the copy button.

### Ref
[Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/43130)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-43130)

<img width="886" alt="image" src="https://user-images.githubusercontent.com/206864/196552673-bab63e9f-6108-48ff-ac14-de6252fc4e30.png">

### Loom Video
[Video](https://www.loom.com/share/b5ab6f60f019469ea1a6148dc67878da)

### Test Plan
Go to localhost:3080/search
Use keyboard for navigation
When foucs is at `Copy Query Button` icon click enter
The focus should remain in the `Copy Query Button` icon

## App preview:

- [Web](https://sg-web-contractors-sg-43130.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
