### PR TITLE
log: stop capturing ctx cancellation in sec events store

### DIFF
--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -143,6 +143,10 @@ func (s *securityEventLogsStore) LogEventList(ctx context.Context, events []*Sec
 			names[i] = string(e.Name)
 		}
 		j, _ := json.Marshal(&events)
-		trace.Logger(ctx, s.logger).Error(strings.Join(names, ","), log.String("events", string(j)), log.Error(err))
+		if errors.Is(err, context.Canceled) {
+			trace.Logger(ctx, s.logger).Warn(strings.Join(names, ","), log.String("events", string(j)), log.Error(err))
+		} else {
+			trace.Logger(ctx, s.logger).Error(strings.Join(names, ","), log.String("events", string(j)), log.Error(err))
+		}
 	}
 }


### PR DESCRIPTION
This PR silences these errors: https://sentry.io/organizations/sourcegraph/issues/3665218062/?project=6583153&query=is%3Aunresolved

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally. 