### PR TITLE
Use internal actor for more cross service calls

### DIFF
--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -156,7 +156,7 @@ func run(logger log.Logger) error {
 		Store: &search.Store{
 			FetchTar: func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
 				// We pass in a nil sub-repo permissions checker and an internal actor here since
-				// searcher needs access to all data in the archive
+				// searcher needs access to all data in the archive.
 				ctx = actor.WithInternalActor(ctx)
 				return git.ArchiveReader(ctx, nil, repo, gitserver.ArchiveOptions{
 					Treeish: string(commit),
@@ -169,7 +169,7 @@ func run(logger log.Logger) error {
 					pathspecs[i] = gitdomain.PathspecLiteral(p)
 				}
 				// We pass in a nil sub-repo permissions checker and an internal actor here since
-				// searcher needs access to all data in the archive
+				// searcher needs access to all data in the archive.
 				ctx = actor.WithInternalActor(ctx)
 				return git.ArchiveReader(ctx, nil, repo, gitserver.ArchiveOptions{
 					Treeish:   string(commit),
@@ -186,7 +186,7 @@ func run(logger log.Logger) error {
 		},
 
 		GitDiffSymbols: func(ctx context.Context, repo api.RepoName, commitA, commitB api.CommitID) ([]byte, error) {
-			// As this is an internal service call, we need an internal actor
+			// As this is an internal service call, we need an internal actor.
 			ctx = actor.WithInternalActor(ctx)
 			return git.DiffSymbols(ctx, repo, commitA, commitB)
 		},

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -155,8 +155,9 @@ func run(logger log.Logger) error {
 	service := &search.Service{
 		Store: &search.Store{
 			FetchTar: func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
-				// We pass in a nil sub-repo permissions checker here since searcher needs access
-				// to all data in the archive
+				// We pass in a nil sub-repo permissions checker and an internal actor here since
+				// searcher needs access to all data in the archive
+				ctx = actor.WithInternalActor(ctx)
 				return git.ArchiveReader(ctx, nil, repo, gitserver.ArchiveOptions{
 					Treeish: string(commit),
 					Format:  gitserver.ArchiveFormatTar,
@@ -167,8 +168,9 @@ func run(logger log.Logger) error {
 				for i, p := range paths {
 					pathspecs[i] = gitdomain.PathspecLiteral(p)
 				}
-				// We pass in a nil sub-repo permissions checker here since searcher needs access
-				// to all data in the archive
+				// We pass in a nil sub-repo permissions checker and an internal actor here since
+				// searcher needs access to all data in the archive
+				ctx = actor.WithInternalActor(ctx)
 				return git.ArchiveReader(ctx, nil, repo, gitserver.ArchiveOptions{
 					Treeish:   string(commit),
 					Format:    gitserver.ArchiveFormatTar,
@@ -183,7 +185,11 @@ func run(logger log.Logger) error {
 			DB:                 db,
 		},
 
-		GitDiffSymbols:      git.DiffSymbols,
+		GitDiffSymbols: func(ctx context.Context, repo api.RepoName, commitA, commitB api.CommitID) ([]byte, error) {
+			// As this is an internal service all, we need an internal actor
+			ctx = actor.WithInternalActor(ctx)
+			return git.DiffSymbols(ctx, repo, commitA, commitB)
+		},
 		MaxTotalPathsLength: maxTotalPathsLength,
 
 		Log: logger,

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -186,7 +186,7 @@ func run(logger log.Logger) error {
 		},
 
 		GitDiffSymbols: func(ctx context.Context, repo api.RepoName, commitA, commitB api.CommitID) ([]byte, error) {
-			// As this is an internal service all, we need an internal actor
+			// As this is an internal service call, we need an internal actor
 			ctx = actor.WithInternalActor(ctx)
 			return git.DiffSymbols(ctx, repo, commitA, commitB)
 		},


### PR DESCRIPTION
searcher: Use internal actor when calling out to gitserver
insights: Use internal actor when requesting commits from gitserver

Part of https://github.com/sourcegraph/sourcegraph/issues/28532

## Test plan

All tests still pass and no functional changes made
