### PR TITLE
fix(sg): Added ZDOTDIR to usershell guess

### DIFF
--- a/dev/sg/internal/usershell/usershell.go
+++ b/dev/sg/internal/usershell/usershell.go
@@ -56,7 +56,7 @@ func IsSupportedShell(ctx context.Context) bool {
 
 // GuessUserShell inspect the current environment to infer the shell the current user is running
 // and which configuration file it depends on.
-func GuessUserShell() (shellPath string, shellrc string, shell Shell, error error) {
+func GuessUserShell() (shellPath string, shellConfigPath string, shell Shell, error error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", "", "", err
@@ -71,16 +71,23 @@ func GuessUserShell() (shellPath string, shellrc string, shell Shell, error erro
 	}
 	switch {
 	case strings.Contains(shellPath, "bash"):
-		shellrc = ".bashrc"
+		shellrc := ".bashrc"
 		shell = BashShell
+		shellConfigPath = filepath.Join(home, shellrc)
 	case strings.Contains(shellPath, "zsh"):
-		shellrc = ".zshrc"
+		shellrc := ".zshrc"
 		shell = ZshShell
+		basePath, ok := os.LookupEnv("ZDOTDIR")
+		if !ok {
+			basePath = home
+		}
+		shellConfigPath = filepath.Join(basePath, shellrc)
 	case strings.Contains(shellPath, "fish"):
-		shellrc = ".config/fish/config.fish"
+		shellrc := ".config/fish/config.fish"
 		shell = FishShell
+		shellConfigPath = filepath.Join(home, shellrc)
 	}
-	return shellPath, filepath.Join(home, shellrc), shell, nil
+	return shellPath, shellConfigPath, shell, nil
 }
 
 // Context extends ctx with the UserContext of the current user.


### PR DESCRIPTION
**sg** tries to source the config(rc) file of the shell before running its checks. In case of zsh, it doesn't take into account the **ZDOTDIR** variable, and just checks in the home directory.

This PR aims to fix that

## Test Plan
Ran through the installation process after change to verify proper working