### PR TITLE
codeintel: Fix illegal SQL query in `IsQueuedRootIndexer`

### DIFF
--- a/internal/codeintel/autoindexing/internal/store/store_indexes.go
+++ b/internal/codeintel/autoindexing/internal/store/store_indexes.go
@@ -615,7 +615,7 @@ WHERE
 	repository_id  = %s AND
 	commit         = %s AND
 	root           = %s AND
-	indexer        = %s AND
+	indexer        = %s
 ORDER BY queued_at DESC
 LIMIT 1
 `


### PR DESCRIPTION
Fixed extraneous AND in SQL query that is causing auto-indexing to fail on dotcom.

## Test plan

New unit tests.