### PR TITLE
sg: fix check for pid

### DIFF
--- a/dev/sg/internal/run/pid.go
+++ b/dev/sg/internal/run/pid.go
@@ -46,11 +46,13 @@ func PidExistsWithArgs(args []string) (int, bool, error) {
 			if err != nil {
 				return 0, true, errors.Wrapf(err, "could not check if pid %d is alive", content.Pid)
 			}
-			if !alive {
-				// Trash the pidfile and return that it's not running.
-				_ = os.Remove(match)
+			if alive {
+				return content.Pid, true, nil
 			}
-			return content.Pid, true, nil
+
+			// Trash the pidfile and return that it's not running.
+			_ = os.Remove(match)
+			return 0, false, nil
 		}
 	}
 


### PR DESCRIPTION
Previous code would detect that the process is dead *and* remove the PID file but still report to the caller that it's alive.

## Test plan

- Manual testing
