### PR TITLE
[language-platform] Making search bar in symbols panel sticky

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarSymbols.module.scss
+++ b/client/web/src/repo/RepoRevisionSidebarSymbols.module.scss
@@ -50,3 +50,9 @@
 .container-name {
     margin-left: 0.5rem;
 }
+
+.form-container {
+    position: sticky;
+    top: 0;
+    background-color: var(--body-bg);
+}

--- a/client/web/src/repo/RepoRevisionSidebarSymbols.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarSymbols.tsx
@@ -186,16 +186,18 @@ export const RepoRevisionSidebarSymbols: React.FunctionComponent<
 
     return (
         <ConnectionContainer className={classNames('h-100', styles.repoRevisionSidebarSymbols)} compact={true}>
-            <ConnectionForm
-                inputValue={searchValue}
-                onInputChange={event => setSearchValue(event.target.value)}
-                inputPlaceholder="Search symbols..."
-                compact={true}
-                formClassName={styles.form}
-            />
-            <SummaryContainer compact={true} className={styles.summaryContainer}>
-                {query && summary}
-            </SummaryContainer>
+            <div className={styles.formContainer}>
+                <ConnectionForm
+                    inputValue={searchValue}
+                    onInputChange={event => setSearchValue(event.target.value)}
+                    inputPlaceholder="Search symbols..."
+                    compact={true}
+                    formClassName={styles.form}
+                />
+                <SummaryContainer compact={true} className={styles.summaryContainer}>
+                    {query && summary}
+                </SummaryContainer>
+            </div>
             {error && <ConnectionError errors={[error.message]} compact={true} />}
             {connection && (
                 <ConnectionList compact={true}>


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/33127
Making search bar in symbols panel sticky.

https://user-images.githubusercontent.com/6225160/197248995-4adc9d2a-7380-4194-bb1a-8f1ce7d0ec6b.mov


## Test plan
Ran all the test.




<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

![sticky](https://media.giphy.com/media/C6TUZ559o8hAA/giphy.gif)

## App preview:

- [Web](https://sg-web-cesar-33127-make-search-bar-sticky.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
