### PR TITLE
Fuzzy finder: fix bug with missing results

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
@@ -69,7 +69,7 @@
         a {
             max-height: initial;
 
-            span:first-of-type {
+            span:global(.fuzzy-repos-result-icon) {
                 margin-right: 0.25rem;
             }
             span:global(.fuzzy-repos-star) {

--- a/client/web/src/components/fuzzyFinder/FuzzyRepos.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyRepos.tsx
@@ -36,11 +36,12 @@ export class FuzzyRepos extends FuzzyQuery {
     /* override */ protected searchValues(): SearchValue[] {
         return [...this.queryResults.values()].map(({ text, url, stars }) => {
             const formattedRepositoryStarCount = formatRepositoryStarCount(stars)
+            const icon = <CodeHostIcon repoName={text} />
 
             return {
                 text,
                 url,
-                icon: <CodeHostIcon repoName={text} /> || undefined,
+                icon: icon ? <span className="fuzzy-repos-result-icon">{icon}</span> : undefined,
                 textSuffix:
                     stars && stars > 0 && formattedRepositoryStarCount ? (
                         <span className="fuzzy-repos-star">

--- a/client/web/src/components/fuzzyFinder/FuzzySymbols.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzySymbols.tsx
@@ -66,7 +66,7 @@ export class FuzzySymbols extends FuzzyQuery {
         return values.map(({ text, url, symbolKind }) => ({
             text: repositoryFilter ? text.replace(repositoryText, '') : text,
             url,
-            icon: symbolKind ? <SymbolTag kind={symbolKind} /> : undefined,
+            icon: symbolKind ? <SymbolTag className="fuzzy-repos-result-icon" kind={symbolKind} /> : undefined,
         }))
     }
 

--- a/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.test.ts
+++ b/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.test.ts
@@ -5,6 +5,14 @@ function fuzzyMatches(query: string, values: string[]): string[] {
         values.map(value => ({ text: value })),
         undefined
     )
+
+    // Reproduce a real-world scenario where the user types one character at a
+    // time.  CaseInsensitiveFuzzySearch has an internal cache that may contain
+    // bugs that don't reproduce when it only gets one `search()` request.
+    for (let index = 1; index < query.length; index++) {
+        fuzzy.search({ query: query.slice(0, index), maxResults: 100 })
+    }
+
     const results = fuzzy.search({ query, maxResults: 100 })
     return results.links.map(link => link.text)
 }
@@ -30,4 +38,10 @@ describe('case-insensitive fuzzy search', () => {
         ['batches/executor.go']
     )
     checkFuzzyMatches('exact-match', 'src/hello.ts', ['src/hello.ts', 'ignore.me'], ['src/hello.ts'])
+
+    // Buggy cache test. Previously, the cached list of candidates only included
+    // results that had a fuzzy score above 0.2 causing the 'a' query to filter
+    // out a lot of strings containing the character 'a' because their score was
+    // below 0.2.
+    checkFuzzyMatches('buggy-cache', 'attr', ['.gitattributes', 'aaa24'], ['.gitattributes'])
 })


### PR DESCRIPTION
`CaseInsensitiveFuzzySearch` had a buggy cache implementation causing normal queries like `attr` to not match files like `.attr`. The problem was only reproducible by typing out `attr` one character at a time, it didn't reproduce in the test suite (which only triggered one query for the final string `attr`).

This commit fixes the bug and updates the testing infrastructure to mirror the behavior of a normal user by querying each individual prefix substring first.

## Test plan

See new test case.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-filename-first.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
