### PR TITLE
[a11y] web: disable spinning logo if users prefer reduced motion

### DIFF
--- a/client/web/src/components/branding/BrandLogo.module.scss
+++ b/client/web/src/components/branding/BrandLogo.module.scss
@@ -1,6 +1,5 @@
 .brand-logo--spin {
     &:hover {
-        animation: spin 0.5s ease-in-out 1;
         @keyframes spin {
             50% {
                 transform: rotate(180deg) scale(1.2);
@@ -8,6 +7,10 @@
             100% {
                 transform: rotate(180deg) scale(1);
             }
+        }
+
+        @media (prefers-reduced-motion: no-preference) {
+            animation: spin 0.5s ease-in-out 1;
         }
     }
 }


### PR DESCRIPTION
The logo on the global navbar shouldn't spin if users have `prefer-reduced-motion` (or rather, only enable if this is not set; this is a fallback for older browsers that don't support this media query so they are accessible by default).

## Test plan

Enable reduced motion on OS settings (on macOS, System Settings > Accessibility > Display > Reduce motion). The logo should not spin when checked, and should spin as usual when unchecked.

<img width="667" alt="image" src="https://user-images.githubusercontent.com/206864/197296764-4ab17a88-78ea-45c2-bb10-67b36b604fe7.png">

## App preview:

- [Web](https://sg-web-jp-a11yspinlogo.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

