### PR TITLE
Code Insights: Fix popovers/context menus on the dashboard page

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.module.scss
@@ -40,6 +40,7 @@
     grid-area: chart;
     position: relative;
     overflow: hidden;
+    min-height: 8rem;
 
     &:hover,
     &:focus-within {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.module.scss
@@ -7,7 +7,8 @@
     }
 
     // Change the icon color on hover/focus state
-    &:hover, &[aria-expanded='true'] {
+    &:hover,
+    &[aria-expanded='true'] {
         background-color: var(--color-bg-2) !important;
     }
 

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.module.scss
@@ -7,11 +7,8 @@
     }
 
     // Change the icon color on hover/focus state
-    &:hover,
-    &:focus {
-        .filter-icon {
-            fill: var(--body-color);
-        }
+    &:hover, &[aria-expanded='true'] {
+        background-color: var(--color-bg-2) !important;
     }
 
     // Change the icon and button state with opened filter panel

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.tsx
@@ -1,16 +1,24 @@
-import React, { DOMAttributes, useRef, useState } from 'react'
+import { FC, RefObject, useRef, useState } from 'react'
 
 import { mdiFilterOutline } from '@mdi/js'
 import classNames from 'classnames'
 
-import { Button, createRectangle, Popover, PopoverContent, PopoverTrigger, Position, Icon } from '@sourcegraph/wildcard'
+import {
+    Button,
+    Icon,
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+    Position,
+    createRectangle,
+} from '@sourcegraph/wildcard'
 
 import { InsightFilters } from '../../../../../../core'
 import { FormChangeEvent, SubmissionResult } from '../../../../../form/hooks/useForm'
 import {
+    DrillDownFiltersFormValues,
     DrillDownInsightCreationForm,
     DrillDownInsightCreationFormValues,
-    DrillDownFiltersFormValues,
     DrillDownInsightFilters,
     FilterSectionVisualMode,
     hasActiveFilters,
@@ -18,21 +26,19 @@ import {
 
 import styles from './DrillDownFiltersPopover.module.scss'
 
-const POPOVER_PADDING = createRectangle(0, 0, 5, 5)
+const POPOVER_TARGET_PADDING = createRectangle(0, 0, 5, 5)
+const POPOVER_CONTAINER_PADDING = { top: 58 }
+
 interface DrillDownFiltersPopoverProps {
     isOpen: boolean
     initialFiltersValue: InsightFilters
     originalFiltersValue: InsightFilters
-    anchor: React.RefObject<HTMLElement>
+    anchor: RefObject<HTMLElement>
     onFilterChange: (filters: InsightFilters) => void
     onFilterSave: (filters: InsightFilters) => void
     onInsightCreate: (values: DrillDownInsightCreationFormValues) => SubmissionResult
     onVisibilityChange: (open: boolean) => void
 }
-
-// To prevent grid layout position change animation. Attempts to drag
-// the filter panel should not trigger react-grid-layout events.
-const handleMouseDown: DOMAttributes<HTMLElement>['onMouseDown'] = event => event.stopPropagation()
 
 export enum DrillDownFiltersStep {
     Filters = 'filters',
@@ -44,9 +50,7 @@ const STEP_STYLES = {
     [DrillDownFiltersStep.ViewCreation]: styles.popoverWithViewCreation,
 }
 
-export const DrillDownFiltersPopover: React.FunctionComponent<
-    React.PropsWithChildren<DrillDownFiltersPopoverProps>
-> = props => {
+export const DrillDownFiltersPopover: FC<DrillDownFiltersPopoverProps> = props => {
     const {
         isOpen,
         anchor,
@@ -99,11 +103,11 @@ export const DrillDownFiltersPopover: React.FunctionComponent<
             </PopoverTrigger>
 
             <PopoverContent
-                targetPadding={POPOVER_PADDING}
-                constrainToScrollParents={true}
                 position={Position.rightStart}
+                constrainToScrollParents={true}
+                targetPadding={POPOVER_TARGET_PADDING}
+                constraintPadding={POPOVER_CONTAINER_PADDING}
                 aria-label="Drill-down filters panel"
-                onMouseDown={handleMouseDown}
                 className={classNames(styles.popover, STEP_STYLES[step])}
             >
                 {step === DrillDownFiltersStep.Filters && (

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.tsx
@@ -3,15 +3,7 @@ import { FC, RefObject, useRef, useState } from 'react'
 import { mdiFilterOutline } from '@mdi/js'
 import classNames from 'classnames'
 
-import {
-    Button,
-    Icon,
-    Popover,
-    PopoverContent,
-    PopoverTrigger,
-    Position,
-    createRectangle,
-} from '@sourcegraph/wildcard'
+import { Button, Icon, Popover, PopoverContent, PopoverTrigger, Position, createRectangle } from '@sourcegraph/wildcard'
 
 import { InsightFilters } from '../../../../../../core'
 import { FormChangeEvent, SubmissionResult } from '../../../../../form/hooks/useForm'

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.module.scss
@@ -1,7 +1,8 @@
 .button {
     cursor: pointer;
 
-    &:hover, &[aria-expanded='true'] {
+    &:hover,
+    &[aria-expanded='true'] {
         background-color: var(--color-bg-2) !important;
     }
 }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.module.scss
@@ -1,5 +1,9 @@
 .button {
     cursor: pointer;
+
+    &:hover, &[aria-expanded='true'] {
+        background-color: var(--color-bg-2) !important;
+    }
 }
 
 .button-icon {
@@ -11,5 +15,5 @@
 }
 
 .item[data-reach-menu-item] {
-    text-align: right;
+    padding: 0.25rem 0.75rem;
 }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
@@ -84,7 +84,7 @@ export const InsightContextMenu: React.FunctionComponent<React.PropsWithChildren
                                 width={16}
                             />
                         </MenuButton>
-                        <MenuList position={Position.bottomEnd} data-testid={`context-menu.${insightID}`}>
+                        <MenuList position={Position.bottomStart} data-testid={`context-menu.${insightID}`}>
                             <MenuLink
                                 as={Link}
                                 data-testid="InsightContextMenuEditLink"
@@ -105,17 +105,16 @@ export const InsightContextMenu: React.FunctionComponent<React.PropsWithChildren
                             {menuPermissions.showYAxis && (
                                 <MenuItem
                                     role="menuitemcheckbox"
-                                    data-testid="InsightContextMenuEditLink"
-                                    className={classNames('d-flex align-items-center justify-content-end', styles.item)}
-                                    onSelect={onToggleZeroYAxisMin}
                                     aria-checked={zeroYAxisMin}
+                                    data-testid="InsightContextMenuEditLink"
+                                    className={styles.item}
+                                    onSelect={onToggleZeroYAxisMin}
                                 >
                                     <Checkbox
+                                        id="InsightContextMenuEditInput"
                                         aria-hidden="true"
                                         checked={zeroYAxisMin}
-                                        onChange={noop}
                                         tabIndex={-1}
-                                        id="InsightContextMenuEditInput"
                                         label={<span className="font-weight-normal">Start Y Axis at 0</span>}
                                     />
                                 </MenuItem>

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.module.scss
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.module.scss
@@ -1,5 +1,10 @@
 .trigger-button {
     padding: 0.25rem;
+    fill: var(--icon-color);
+
+    &:hover, &[aria-expanded='true'] {
+        background-color: var(--color-bg-2) !important;
+    }
 }
 
 .menu-list[data-reach-menu-items] {
@@ -12,7 +17,6 @@
     // Override default Bootstrap button style
     display: block;
     padding: 0.25rem 0.75rem;
-    text-align: right;
     width: 100%;
     border-radius: 0;
     transition: unset;

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.module.scss
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.module.scss
@@ -2,7 +2,8 @@
     padding: 0.25rem;
     fill: var(--icon-color);
 
-    &:hover, &[aria-expanded='true'] {
+    &:hover,
+    &[aria-expanded='true'] {
         background-color: var(--color-bg-2) !important;
     }
 }

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
@@ -50,12 +50,7 @@ export const DashboardMenu: React.FunctionComponent<React.PropsWithChildren<Dash
                     outline={true}
                     className={classNames(className, styles.triggerButton)}
                 >
-                    <Icon
-                        svgPath={mdiDotsVertical}
-                        height={16}
-                        width={16}
-                        aria-label="dashboard options"
-                    />
+                    <Icon svgPath={mdiDotsVertical} height={16} width={16} aria-label="dashboard options" />
                 </MenuButton>
             </Tooltip>
 

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
@@ -52,7 +52,6 @@ export const DashboardMenu: React.FunctionComponent<React.PropsWithChildren<Dash
                 >
                     <Icon
                         svgPath={mdiDotsVertical}
-                        inline={false}
                         height={16}
                         width={16}
                         aria-label="dashboard options"
@@ -60,7 +59,7 @@ export const DashboardMenu: React.FunctionComponent<React.PropsWithChildren<Dash
                 </MenuButton>
             </Tooltip>
 
-            <MenuList className={styles.menuList} position={Position.bottomEnd}>
+            <MenuList className={styles.menuList} position={Position.bottomStart}>
                 {menuPermissions.configure.display && (
                     <Tooltip content={menuPermissions.configure.tooltip} placement="right">
                         <MenuItem

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-header/DashboardHeader.module.scss
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-header/DashboardHeader.module.scss
@@ -20,6 +20,9 @@
             // stylelint-disable-next-line declaration-property-unit-allowed-list
             margin: 0 calc((100% - 100vw) / 2);
             border-bottom: 1px solid var(--border-color-2);
+            background-color: var(--body-bg);
+            height: 100%;
+            z-index: -1;
         }
     }
 }

--- a/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.tsx
+++ b/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.tsx
@@ -41,14 +41,15 @@ export const PopoverContent = forwardRef(function PopoverContent(props, referenc
         PopoverContext
     )
 
-    const targetElement = anchor?.current ?? contextTargetElement ?? propertyTargetElement
+    const targetElement = contextTargetElement ?? propertyTargetElement
+    const anchorOrTargetElement = anchor?.current ?? targetElement
     const [tooltipElement, setTooltipElement] = useState<HTMLDivElement | null>(null)
     const tooltipReferenceCallback = useCallbackRef<HTMLDivElement>(null, setTooltipElement)
     const mergeReference = useMergeRefs([tooltipReferenceCallback, reference])
 
     // Catch any outside click of the popover content element
     useOnClickOutside(mergeReference, event => {
-        if (targetElement?.contains(event.target as Node)) {
+        if (anchorOrTargetElement?.contains(event.target as Node)) {
             return
         }
 
@@ -73,7 +74,7 @@ export const PopoverContent = forwardRef(function PopoverContent(props, referenc
             {...otherProps}
             as={Component}
             ref={mergeReference}
-            target={targetElement}
+            target={anchorOrTargetElement}
             marker={tailElement}
             role={role}
             aria-modal={ariaModal}
@@ -128,7 +129,7 @@ const FloatingPanelContent: FC<PropsWithChildren<FloatingPanelContentProps>> = p
     useEffect(
         () => () => {
             if (returnTargetFocus) {
-                targetElement?.focus()
+                targetElement?.focus({ preventScroll: true })
             }
         },
         [targetElement, returnTargetFocus]


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/42753
Fixes https://github.com/sourcegraph/sourcegraph/issues/43328
Fixes https://github.com/sourcegraph/sourcegraph/issues/43329
Fixes https://github.com/sourcegraph/sourcegraph/issues/43209

## Test plan
- Check that context menus are bottom-start aligned
- Check that context menus targets have active (menu open) visual states
- Check that the context menus list is left-aligned 
- Make sure that there is no visual overlap between the header and the active card's outline (see https://github.com/sourcegraph/sourcegraph/issues/43328)
- Check that the dashboard page doesn't have a broken scroll behaviour when one of the filters panel is open (see https://github.com/sourcegraph/sourcegraph/issues/43329)
- Check that the dashboard context menu three-dot icon in the dark theme has the right colour (see https://github.com/sourcegraph/sourcegraph/issues/43209)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-improve-insight-menu-ui.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
