### PR TITLE
Wildcard [Popover]: Add different sizes to popover tail UI

### DIFF
--- a/client/wildcard/src/components/Popover/components/popover-tail/PopoverTail.module.scss
+++ b/client/wildcard/src/components/Popover/components/popover-tail/PopoverTail.module.scss
@@ -2,14 +2,18 @@
     position: fixed;
     top: 0;
     left: 0;
-    z-index: 1;
+    z-index: 2;
+    --tail-width: 24px;
 
-    &-triangle-path {
-        fill: var(--dropdown-bg);
-        stroke: var(--dropdown-border-color);
-        stroke-width: 12;
-        stroke-linejoin: round;
-        stroke-linecap: round;
+    width: var(--tail-width);
+    height: calc(var(--tail-width) / 2);
+
+    &--size-md {
+        --tail-width: 28px;
+    }
+
+    &--size-lg {
+        --tail-width: 36px;
     }
 
     /*
@@ -45,5 +49,24 @@
 
     &[data-side='bottom'] {
         top: 1px;
+    }
+}
+
+.tail-inner {
+    width: var(--tail-width);
+    height: var(--tail-width);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+
+    &::before {
+        content: '';
+        width: 70%;
+        height: 70%;
+        transform: translate(0%, -70%) rotate(45deg);
+
+        background-color: var(--dropdown-bg);
+        border: 1px solid var(--dropdown-border-color);
     }
 }

--- a/client/wildcard/src/components/Popover/components/popover-tail/PopoverTail.tsx
+++ b/client/wildcard/src/components/Popover/components/popover-tail/PopoverTail.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent, HTMLAttributes, useContext } from 'react'
 
+import classNames from 'classnames'
 import { createPortal } from 'react-dom'
 
 import { PopoverContext } from '../../contexts/internal-context'
@@ -7,9 +8,25 @@ import { PopoverRoot } from '../../contexts/public-context'
 
 import style from './PopoverTail.module.scss'
 
-interface PopoverTailProps extends HTMLAttributes<SVGElement> {}
+enum PopoverSize {
+    sm = 'sm',
+    md = 'md',
+    lg = 'lg',
+}
+
+const sizeClasses: Record<PopoverSize, string> = {
+    // sm is set by default (no styles are needed)
+    [PopoverSize.sm]: '',
+    [PopoverSize.md]: style.tailSizeMd,
+    [PopoverSize.lg]: style.tailSizeLg,
+}
+
+interface PopoverTailProps extends HTMLAttributes<SVGElement> {
+    size?: PopoverSize | `${PopoverSize}`
+}
 
 export const PopoverTail: FunctionComponent<PopoverTailProps> = props => {
+    const { size = PopoverSize.sm } = props
     const { setTailElement, isOpen } = useContext(PopoverContext)
     const { renderRoot } = useContext(PopoverRoot)
 
@@ -18,9 +35,9 @@ export const PopoverTail: FunctionComponent<PopoverTailProps> = props => {
     }
 
     return createPortal(
-        <svg {...props} width="17.2" height="11" viewBox="0 0 200 130" className={style.tail} ref={setTailElement}>
-            <path d="M0,0 L100,130 200,0" className={style.tailTrianglePath} />
-        </svg>,
+        <div ref={setTailElement} className={classNames(style.tail, sizeClasses[size])}>
+            <div className={style.tailInner} />
+        </div>,
         renderRoot ?? document.body
     )
 }

--- a/client/wildcard/src/components/Popover/contexts/internal-context.ts
+++ b/client/wildcard/src/components/Popover/contexts/internal-context.ts
@@ -7,11 +7,11 @@ import { PopoverOpenEvent } from '../Popover'
 export interface PopoverInternalContextData {
     isOpen: boolean
     targetElement: HTMLElement | null
-    tailElement: SVGGElement | null
+    tailElement: HTMLElement | null
     anchor?: MutableRefObject<HTMLElement | null>
     setOpen: (event: PopoverOpenEvent) => void
     setTargetElement: (element: HTMLElement | null) => void
-    setTailElement: (element: SVGGElement | null) => void
+    setTailElement: (element: HTMLElement | null) => void
 }
 
 const DEFAULT_CONTEXT_VALUE: PopoverInternalContextData = {

--- a/client/wildcard/src/components/Popover/story/Popover.story.tsx
+++ b/client/wildcard/src/components/Popover/story/Popover.story.tsx
@@ -493,7 +493,7 @@ export const WithVirtualTarget: Story = () => {
     )
 }
 
-export const WithTail: Story = () => (
+export const WithTail: Story = (args= {}) => (
     <ScrollCenterBox title="Root scroll block" className={styles.container}>
         <div className={styles.content}>
             <Popover>
@@ -513,11 +513,19 @@ export const WithTail: Story = () => (
                     </div>
                 </PopoverContent>
 
-                <PopoverTail />
+                <PopoverTail size={args.size}/>
             </Popover>
         </div>
     </ScrollCenterBox>
 )
+
+WithTail.argTypes = {
+    size: {
+        control: 'radio',
+        options: ['sm', 'md', 'lg'],
+        defaultValue: 'sm'
+    }
+}
 
 interface ScrollCenterBoxProps extends React.HTMLAttributes<HTMLDivElement> {
     title: string


### PR DESCRIPTION
## Background
Prior to this PR, we had only one version (size) of the popover tail. But different popovers require different tail sizes. For example, a tooltip requires a small tail, big popover with complex content requires a large proportional size to the popover size. 

In this PR, we add different sizes for the tooltip/popover tail.

| Small | Medium | Large |
| ------ |  ------ |  ------ | 
| <img width="987" alt="Screenshot 2022-10-22 at 11 12 45" src="https://user-images.githubusercontent.com/18492575/197344001-18e6f33f-b292-4984-9759-d35855106511.png"> | <img width="987" alt="Screenshot 2022-10-22 at 11 12 50" src="https://user-images.githubusercontent.com/18492575/197344009-30eff8b0-9e7c-4aad-a0a7-5b818ff0ce74.png"> |<img width="987" alt="Screenshot 2022-10-22 at 11 12 55" src="https://user-images.githubusercontent.com/18492575/197344030-fb8f399a-f150-486c-9374-ab451b0c62bf.png"> | 

## Test plan
- By default, we provide a small size (the same size that we used before, so it should be no visual regression in any popover that uses tail UI),
- Check that storybook story (it should have size control)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
