### PR TITLE
web: enable `zone.js` on demand

### DIFF
--- a/client/web/src/monitoring/opentelemetry/initOpenTelemetry.ts
+++ b/client/web/src/monitoring/opentelemetry/initOpenTelemetry.ts
@@ -2,7 +2,7 @@
 // Don't remove the empty lines between these imports.
 import './initZones'
 
-import { ZoneContextManager } from '@opentelemetry/context-zone'
+import type { ZoneContextManager } from '@opentelemetry/context-zone'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { InstrumentationOption, registerInstrumentations } from '@opentelemetry/instrumentation'
 import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch'
@@ -51,8 +51,19 @@ export function initOpenTelemetry(): void {
             provider.addSpanProcessor(new BatchSpanProcessor(consoleExporter))
         }
 
+        /**
+         * This import enables zone.js which patches global web API modules.
+         * You can find a list of the patched modules here:
+         * https://github.com/angular/angular/blob/main/packages/zone.js/MODULE.md
+         *
+         * It's added with the `require` statement to avoid polluting stack traces in
+         * the development environment when OpenTelemetry is disabled.
+         */
+        // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+        const ZoneContextManager = require('@opentelemetry/context-zone').ZoneContextManager
+
         provider.register({
-            contextManager: new ZoneContextManager(),
+            contextManager: new ZoneContextManager() as ZoneContextManager,
         })
 
         registerInstrumentations({


### PR DESCRIPTION
## Context

This PR disables `zone.js` in environments where OpenTelemetry client observability is disabled to avoid polluting stack traces. [The Slack thread](https://sourcegraph.slack.com/archives/C01C3NCGD40/p1666371076000209?thread_ts=1666370487.507549&cid=C01C3NCGD40) for context.

## Test plan

1. `sg start web-standalone`
2. ensure that `zone.js` is not present in stack traces.

## App preview:

- [Web](https://sg-web-vb-enable-zonjs-on-demand.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
