### PR TITLE
worker: Add missing state index to worker tables

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -1935,6 +1935,16 @@
           "IndexDefinition": "CREATE UNIQUE INDEX batch_spec_resolution_jobs_pkey ON batch_spec_resolution_jobs USING btree (id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "batch_spec_resolution_jobs_state",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX batch_spec_resolution_jobs_state ON batch_spec_resolution_jobs USING btree (state)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [
@@ -9903,6 +9913,16 @@
           "IndexDefinition": "CREATE UNIQUE INDEX gitserver_relocator_jobs_pkey ON gitserver_relocator_jobs USING btree (id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "gitserver_relocator_jobs_state",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX gitserver_relocator_jobs_state ON gitserver_relocator_jobs USING btree (state)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": null,
@@ -11379,6 +11399,16 @@
           "IndexDefinition": "CREATE UNIQUE INDEX lsif_dependency_indexing_jobs_pkey1 ON lsif_dependency_indexing_jobs USING btree (id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "lsif_dependency_indexing_jobs_state",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX lsif_dependency_indexing_jobs_state ON lsif_dependency_indexing_jobs USING btree (state)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [
@@ -11679,6 +11709,16 @@
           "IsExclusion": false,
           "IsDeferrable": false,
           "IndexDefinition": "CREATE INDEX lsif_dependency_indexing_jobs_upload_id ON lsif_dependency_syncing_jobs USING btree (upload_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
+          "Name": "lsif_dependency_syncing_jobs_state",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX lsif_dependency_syncing_jobs_state ON lsif_dependency_syncing_jobs USING btree (state)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
         }
@@ -19488,6 +19528,16 @@
           "IsExclusion": false,
           "IsDeferrable": false,
           "IndexDefinition": "CREATE INDEX webhook_build_jobs_queued_at_idx ON webhook_build_jobs USING btree (queued_at)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
+          "Name": "webhook_build_jobs_state",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX webhook_build_jobs_state ON webhook_build_jobs USING btree (state)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
         }

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -139,6 +139,7 @@ Foreign-key constraints:
 Indexes:
     "batch_spec_resolution_jobs_pkey" PRIMARY KEY, btree (id)
     "batch_spec_resolution_jobs_batch_spec_id_unique" UNIQUE CONSTRAINT, btree (batch_spec_id)
+    "batch_spec_resolution_jobs_state" btree (state)
 Foreign-key constraints:
     "batch_spec_resolution_jobs_batch_spec_id_fkey" FOREIGN KEY (batch_spec_id) REFERENCES batch_specs(id) ON DELETE CASCADE DEFERRABLE
     "batch_spec_resolution_jobs_initiator_id_fkey" FOREIGN KEY (initiator_id) REFERENCES users(id) ON UPDATE CASCADE DEFERRABLE
@@ -1359,6 +1360,7 @@ Referenced by:
  cancel            | boolean                  |           | not null | false
 Indexes:
     "gitserver_relocator_jobs_pkey" PRIMARY KEY, btree (id)
+    "gitserver_relocator_jobs_state" btree (state)
 
 ```
 
@@ -1620,6 +1622,7 @@ A lookup table to get all the repository patterns by repository id that apply to
  cancel                | boolean                  |           | not null | false
 Indexes:
     "lsif_dependency_indexing_jobs_pkey1" PRIMARY KEY, btree (id)
+    "lsif_dependency_indexing_jobs_state" btree (state)
 Foreign-key constraints:
     "lsif_dependency_indexing_jobs_upload_id_fkey1" FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
 
@@ -1664,6 +1667,7 @@ Indexes:
 Indexes:
     "lsif_dependency_indexing_jobs_pkey" PRIMARY KEY, btree (id)
     "lsif_dependency_indexing_jobs_upload_id" btree (upload_id)
+    "lsif_dependency_syncing_jobs_state" btree (state)
 Foreign-key constraints:
     "lsif_dependency_indexing_jobs_upload_id_fkey" FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE CASCADE
 
@@ -3090,6 +3094,7 @@ Triggers:
  extsvc_id         | integer                  |           |          | 
 Indexes:
     "webhook_build_jobs_queued_at_idx" btree (queued_at)
+    "webhook_build_jobs_state" btree (state)
 
 ```
 

--- a/migrations/frontend/1666524436_add_missing_state_index_lsif_dependency_indexes/down.sql
+++ b/migrations/frontend/1666524436_add_missing_state_index_lsif_dependency_indexes/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS lsif_dependency_indexing_jobs_state;

--- a/migrations/frontend/1666524436_add_missing_state_index_lsif_dependency_indexes/metadata.yaml
+++ b/migrations/frontend/1666524436_add_missing_state_index_lsif_dependency_indexes/metadata.yaml
@@ -1,0 +1,3 @@
+name: Add missing state index on lsif_dependency_indexing_jobs table
+parents: [1666131819, 1666145729]
+createIndexConcurrently: true

--- a/migrations/frontend/1666524436_add_missing_state_index_lsif_dependency_indexes/up.sql
+++ b/migrations/frontend/1666524436_add_missing_state_index_lsif_dependency_indexes/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS lsif_dependency_indexing_jobs_state ON lsif_dependency_indexing_jobs (state);

--- a/migrations/frontend/1666598814_add_missing_state_index_on_lsif_dependency_syncing_jobs_table/down.sql
+++ b/migrations/frontend/1666598814_add_missing_state_index_on_lsif_dependency_syncing_jobs_table/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS lsif_dependency_syncing_jobs_state;

--- a/migrations/frontend/1666598814_add_missing_state_index_on_lsif_dependency_syncing_jobs_table/metadata.yaml
+++ b/migrations/frontend/1666598814_add_missing_state_index_on_lsif_dependency_syncing_jobs_table/metadata.yaml
@@ -1,0 +1,3 @@
+name: Add missing state index on lsif_dependency_syncing_jobs table
+parents: [1666524436]
+createIndexConcurrently: true

--- a/migrations/frontend/1666598814_add_missing_state_index_on_lsif_dependency_syncing_jobs_table/up.sql
+++ b/migrations/frontend/1666598814_add_missing_state_index_on_lsif_dependency_syncing_jobs_table/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS lsif_dependency_syncing_jobs_state ON lsif_dependency_syncing_jobs (state);

--- a/migrations/frontend/1666598828_add_missing_state_index_on_batch_spec_resolution_jobs_table/down.sql
+++ b/migrations/frontend/1666598828_add_missing_state_index_on_batch_spec_resolution_jobs_table/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS batch_spec_resolution_jobs_state;

--- a/migrations/frontend/1666598828_add_missing_state_index_on_batch_spec_resolution_jobs_table/metadata.yaml
+++ b/migrations/frontend/1666598828_add_missing_state_index_on_batch_spec_resolution_jobs_table/metadata.yaml
@@ -1,0 +1,3 @@
+name: Add missing state index on batch_spec_resolution_jobs table
+parents: [1666598814]
+createIndexConcurrently: true

--- a/migrations/frontend/1666598828_add_missing_state_index_on_batch_spec_resolution_jobs_table/up.sql
+++ b/migrations/frontend/1666598828_add_missing_state_index_on_batch_spec_resolution_jobs_table/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS batch_spec_resolution_jobs_state ON batch_spec_resolution_jobs (state);

--- a/migrations/frontend/1666598983_add_missing_state_index_on_gitserver_relocator_jobs_table/down.sql
+++ b/migrations/frontend/1666598983_add_missing_state_index_on_gitserver_relocator_jobs_table/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS gitserver_relocator_jobs_state;

--- a/migrations/frontend/1666598983_add_missing_state_index_on_gitserver_relocator_jobs_table/metadata.yaml
+++ b/migrations/frontend/1666598983_add_missing_state_index_on_gitserver_relocator_jobs_table/metadata.yaml
@@ -1,0 +1,3 @@
+name: Add missing state index on gitserver_relocator_jobs table
+parents: [1666598828]
+createIndexConcurrently: true

--- a/migrations/frontend/1666598983_add_missing_state_index_on_gitserver_relocator_jobs_table/up.sql
+++ b/migrations/frontend/1666598983_add_missing_state_index_on_gitserver_relocator_jobs_table/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS gitserver_relocator_jobs_state ON gitserver_relocator_jobs (state);

--- a/migrations/frontend/1666598987_add_missing_state_index_on_webhook_build_jobs_table/down.sql
+++ b/migrations/frontend/1666598987_add_missing_state_index_on_webhook_build_jobs_table/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS webhook_build_jobs_state;

--- a/migrations/frontend/1666598987_add_missing_state_index_on_webhook_build_jobs_table/metadata.yaml
+++ b/migrations/frontend/1666598987_add_missing_state_index_on_webhook_build_jobs_table/metadata.yaml
@@ -1,0 +1,3 @@
+name: Add missing state index on webhook_build_jobs table
+parents: [1666598983]
+createIndexConcurrently: true

--- a/migrations/frontend/1666598987_add_missing_state_index_on_webhook_build_jobs_table/up.sql
+++ b/migrations/frontend/1666598987_add_missing_state_index_on_webhook_build_jobs_table/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS webhook_build_jobs_state ON webhook_build_jobs (state);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -4122,6 +4122,8 @@ CREATE UNIQUE INDEX batch_changes_unique_org_id ON batch_changes USING btree (na
 
 CREATE UNIQUE INDEX batch_changes_unique_user_id ON batch_changes USING btree (name, namespace_user_id) WHERE (namespace_user_id IS NOT NULL);
 
+CREATE INDEX batch_spec_resolution_jobs_state ON batch_spec_resolution_jobs USING btree (state);
+
 CREATE INDEX batch_spec_workspace_execution_jobs_batch_spec_workspace_id ON batch_spec_workspace_execution_jobs USING btree (batch_spec_workspace_id);
 
 CREATE INDEX batch_spec_workspace_execution_jobs_cancel ON batch_spec_workspace_execution_jobs USING btree (cancel);
@@ -4264,6 +4266,8 @@ CREATE INDEX feature_flag_overrides_user_id ON feature_flag_overrides USING btre
 
 CREATE INDEX finished_at_insights_query_runner_jobs_idx ON insights_query_runner_jobs USING btree (finished_at);
 
+CREATE INDEX gitserver_relocator_jobs_state ON gitserver_relocator_jobs USING btree (state);
+
 CREATE INDEX gitserver_repos_cloned_status_idx ON gitserver_repos USING btree (repo_id) WHERE (clone_status = 'cloned'::text);
 
 CREATE INDEX gitserver_repos_cloning_status_idx ON gitserver_repos USING btree (repo_id) WHERE (clone_status = 'cloning'::text);
@@ -4290,7 +4294,11 @@ CREATE UNIQUE INDEX kind_cloud_default ON external_services USING btree (kind, c
 
 CREATE INDEX lsif_configuration_policies_repository_id ON lsif_configuration_policies USING btree (repository_id);
 
+CREATE INDEX lsif_dependency_indexing_jobs_state ON lsif_dependency_indexing_jobs USING btree (state);
+
 CREATE INDEX lsif_dependency_indexing_jobs_upload_id ON lsif_dependency_syncing_jobs USING btree (upload_id);
+
+CREATE INDEX lsif_dependency_syncing_jobs_state ON lsif_dependency_syncing_jobs USING btree (state);
 
 CREATE INDEX lsif_indexes_commit_last_checked_at ON lsif_indexes USING btree (commit_last_checked_at) WHERE (state <> 'deleted'::text);
 
@@ -4433,6 +4441,8 @@ CREATE INDEX users_created_at_idx ON users USING btree (created_at);
 CREATE UNIQUE INDEX users_username ON users USING btree (username) WHERE (deleted_at IS NULL);
 
 CREATE INDEX webhook_build_jobs_queued_at_idx ON webhook_build_jobs USING btree (queued_at);
+
+CREATE INDEX webhook_build_jobs_state ON webhook_build_jobs USING btree (state);
 
 CREATE INDEX webhook_logs_external_service_id_idx ON webhook_logs USING btree (external_service_id);
 


### PR DESCRIPTION
Some tables were lacking an index on the state table, which is generally advised nowadays.

In the case of lsif_dependency_indexing_jobs_state, this brings down the dequeue query from 200ms to 19ms.

## Test plan

Just adding indexes. Tested that this does any good (see above).