### PR TITLE
Fix cache policy for search exports query

### DIFF
--- a/client/web/src/search/results/useExportSearchResultsQuery.ts
+++ b/client/web/src/search/results/useExportSearchResultsQuery.ts
@@ -167,6 +167,7 @@ export const useExportSearchResultsQuery: UseExportSearchResultsQuery = ({
                 a.remove()
                 URL.revokeObjectURL(url)
             },
+            fetchPolicy: 'no-cache',
         }
     )
 


### PR DESCRIPTION
Fixes #43222

Apparently, the default cache setup in Apollo can lead to properties being garbage collected before the onCompleted callback is invoked.

I have to investigate further to understand what exactly is going on but the symptom was that Apollo has [removed fields from the resulting objects](https://sourcegraph.slack.com/archives/C01C3NCGD40/p1666370487507549) before the search export logic was able to read those values. 

Thanks to @umpox for providing the hint regarding this having to do with the fetch policy.

## Test plan

I verified locally that exporting search results indeed works again.

https://user-images.githubusercontent.com/458591/197488032-e665fcae-1673-46d0-bf06-fc65d1b24b48.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-search-export-query.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
