### PR TITLE
Remove column information from collapsed selections and remove trailing =

### DIFF
--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -179,11 +179,16 @@ func (r *editorRequest) openFileRedirect(ctx context.Context) (string, error) {
 	u := &url.URL{Path: path.Join("/", string(repoName)+rev, "/-/blob/", of.file)}
 	q := u.Query()
 	if of.startRow == of.endRow && of.startCol == of.endCol {
-		q.Add(fmt.Sprintf("L%d:%d", of.startRow+1, of.startCol+1), "")
+		q.Add(fmt.Sprintf("L%d", of.startRow+1), "")
 	} else {
 		q.Add(fmt.Sprintf("L%d:%d-%d:%d", of.startRow+1, of.startCol+1, of.endRow+1, of.endCol+1), "")
 	}
-	u.RawQuery = q.Encode()
+	// Since the line information is added as the key as a query parameter with
+	// an empty value, the URL encoding will add an = sign followed by an empty
+	// string.
+	//
+	// Since we don't want the equal sign as it provides no value, we remove it.
+	u.RawQuery = strings.TrimSuffix(q.Encode(), "=")
 	return u.String(), nil
 }
 

--- a/cmd/frontend/internal/app/editor_test.go
+++ b/cmd/frontend/internal/app/editor_test.go
@@ -125,7 +125,7 @@ func TestEditorRedirect(t *testing.T) {
 				"end_row":    []string{"123"},
 				"end_col":    []string{"10"},
 			},
-			wantRedirectURL: "/github.com/a/b@0ad12f/-/blob/mux.go?L124%3A2-124%3A11=",
+			wantRedirectURL: "/github.com/a/b@0ad12f/-/blob/mux.go?L124%3A2-124%3A11",
 		},
 		{
 			name: "open file no selection",
@@ -137,7 +137,7 @@ func TestEditorRedirect(t *testing.T) {
 				"revision":   []string{"0ad12f"},
 				"file":       []string{"mux.go"},
 			},
-			wantRedirectURL: "/github.com/a/b@0ad12f/-/blob/mux.go?L1%3A1=", // L1:1 is expected (but could be nicer by omitting it)
+			wantRedirectURL: "/github.com/a/b@0ad12f/-/blob/mux.go?L1",
 		},
 		{
 			name: "open file in repository (Phabricator mirrored)",
@@ -151,7 +151,7 @@ func TestEditorRedirect(t *testing.T) {
 				"end_row":    []string{"123"},
 				"end_col":    []string{"10"},
 			},
-			wantRedirectURL: "/default.com/foo/bar@0ad12f/-/blob/mux.go?L124%3A2-124%3A11=",
+			wantRedirectURL: "/default.com/foo/bar@0ad12f/-/blob/mux.go?L124%3A2-124%3A11",
 		},
 		{
 			name: "open file (generic code host with repositoryPathPattern)",
@@ -165,7 +165,7 @@ func TestEditorRedirect(t *testing.T) {
 				"end_row":    []string{"123"},
 				"end_col":    []string{"10"},
 			},
-			wantRedirectURL: "/pretty/a/b@0ad12f/-/blob/mux.go?L124%3A2-124%3A11=",
+			wantRedirectURL: "/pretty/a/b@0ad12f/-/blob/mux.go?L124%3A2-124%3A11",
 		},
 		{
 			name: "open file (generic code host without repositoryPathPattern)",
@@ -179,7 +179,7 @@ func TestEditorRedirect(t *testing.T) {
 				"end_row":    []string{"123"},
 				"end_col":    []string{"10"},
 			},
-			wantRedirectURL: "/default.com/a/b@0ad12f/-/blob/mux.go?L124%3A2-124%3A11=",
+			wantRedirectURL: "/default.com/a/b@0ad12f/-/blob/mux.go?L124%3A2-124%3A11",
 		},
 		{
 			name: "open file (generic git host with slash prefix in path)",
@@ -193,7 +193,7 @@ func TestEditorRedirect(t *testing.T) {
 				"end_row":    []string{"123"},
 				"end_col":    []string{"10"},
 			},
-			wantRedirectURL: "/git.codehost.com/owner/repo@0ad12f/-/blob/mux.go?L124%3A2-124%3A11=",
+			wantRedirectURL: "/git.codehost.com/owner/repo@0ad12f/-/blob/mux.go?L124%3A2-124%3A11",
 		},
 		{
 			name: "open file (generic git host without slash prefix in path)",
@@ -207,7 +207,7 @@ func TestEditorRedirect(t *testing.T) {
 				"end_row":    []string{"123"},
 				"end_col":    []string{"10"},
 			},
-			wantRedirectURL: "/git.codehost.com/owner/repo@0ad12f/-/blob/mux.go?L124%3A2-124%3A11=",
+			wantRedirectURL: "/git.codehost.com/owner/repo@0ad12f/-/blob/mux.go?L124%3A2-124%3A11",
 		},
 		{
 			name: "search",
@@ -300,7 +300,7 @@ func TestEditorRedirect(t *testing.T) {
 				"end_row":    []string{"123"},
 				"end_col":    []string{"10"},
 			},
-			wantRedirectURL: "/github.com/a/b@0ad12f/-/blob/mux.go?L124%3A2-124%3A11=",
+			wantRedirectURL: "/github.com/a/b@0ad12f/-/blob/mux.go?L124%3A2-124%3A11",
 		},
 	}
 	errStr := func(e error) string {


### PR DESCRIPTION
Single line shared URLs had this strange characters appended `%3A1=`. This turned out to be `:1` for the column inside the selected row and an `=` sign because it was encoded as a key/value GET url parameter with an empty value.

This PR removes this part by:

- Removing column encoding if we have a collapsed selection (so when no range is selected, we don't need the column information)
- Scanning for a trailing `=` and removing it to avoid adding this unused char.

## Test plan

- Tests are passing.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
