### PR TITLE
batches: rename creating multiple changesets from experimental to beta feature

### DIFF
--- a/doc/batch_changes/how-tos/creating_multiple_changesets_in_large_repositories.md
+++ b/doc/batch_changes/how-tos/creating_multiple_changesets_in_large_repositories.md
@@ -7,7 +7,7 @@
 
 <aside class="experimental">
 <p>
-<span class="badge badge-beta">beta</span> This feature is experimental and might change or be removed in the future. We've released it as an experimental feature to provide a preview of functionality we're working on.
+<span class="badge badge-beta">beta</span>This feature is in beta and might change in the future.
 </p>
 
 <p><b>We're very much looking for input and feedback on this feature.</b> You can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>

--- a/doc/batch_changes/how-tos/creating_multiple_changesets_in_large_repositories.md
+++ b/doc/batch_changes/how-tos/creating_multiple_changesets_in_large_repositories.md
@@ -7,7 +7,7 @@
 
 <aside class="experimental">
 <p>
-<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change or be removed in the future. We've released it as an experimental feature to provide a preview of functionality we're working on.
+<span class="badge badge-beta">beta</span> This feature is experimental and might change or be removed in the future. We've released it as an experimental feature to provide a preview of functionality we're working on.
 </p>
 
 <p><b>We're very much looking for input and feedback on this feature.</b> You can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>

--- a/doc/batch_changes/how-tos/creating_multiple_changesets_in_large_repositories.md
+++ b/doc/batch_changes/how-tos/creating_multiple_changesets_in_large_repositories.md
@@ -7,8 +7,7 @@
 
 <aside class="experimental">
 <p>
-<span class="badge badge-beta">beta</span>This feature is in beta and might change in the future.
-</p>
+<span class="badge badge-beta">beta</span>This feature is in beta and might change in the future.</p>
 
 <p><b>We're very much looking for input and feedback on this feature.</b> You can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
 

--- a/doc/batch_changes/how-tos/creating_multiple_changesets_in_large_repositories.md
+++ b/doc/batch_changes/how-tos/creating_multiple_changesets_in_large_repositories.md
@@ -5,7 +5,7 @@
 .markdown-body pre.chroma { font-size: 0.75em; }
 </style>
 
-<aside class="experimental">
+<aside class="beta">
 <p>
 <span class="badge badge-beta">beta</span>This feature is in beta and might change in the future.</p>
 

--- a/doc/batch_changes/how-tos/index.md
+++ b/doc/batch_changes/how-tos/index.md
@@ -16,7 +16,7 @@ The following is a list of how-tos that show how to use [Sourcegraph Batch Chang
 - [Using file mounts with server-side execution](server_side_file_mounts.md)
 - Batch changes in monorepos
   - [Creating changesets per project in monorepos](creating_changesets_per_project_in_monorepos.md)
-  - <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](creating_multiple_changesets_in_large_repositories.md)
+  - <span class="badge badge-beta">Beta</span> [Creating multiple changesets in large repositories](creating_multiple_changesets_in_large_repositories.md)
 
 ### Administering Batch Changes
 

--- a/doc/batch_changes/index.md
+++ b/doc/batch_changes/index.md
@@ -92,7 +92,7 @@ Create a batch change by specifying a search query to get a list of repositories
 - [Using file mounts with server-side execution](how-tos/server_side_file_mounts.md)
 - Batch changes in monorepos <span class="badge badge-experimental">Experimental</span>
   - [Creating changesets per project in monorepos](how-tos/creating_changesets_per_project_in_monorepos.md)
-  - <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](how-tos/creating_multiple_changesets_in_large_repositories.md)
+  - <span class="badge badge-beta">Beta</span> [Creating multiple changesets in large repositories](how-tos/creating_multiple_changesets_in_large_repositories.md)
 
 ## Tutorials
 


### PR DESCRIPTION
closes #43194

Replace where we reference creating multiple changesets in large repositories as an experimental feature to Beta

## Test plan
docs update!
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
