### PR TITLE
release: support `$ONE_WORKING_WEEK_BEFORE_RELEASE` and fix Slack link format

### DIFF
--- a/dev/release/src/github.ts
+++ b/dev/release/src/github.ts
@@ -88,6 +88,10 @@ interface IssueTemplateArguments {
      */
     version: semver.SemVer
     /**
+     * Available as `$ONE_WORKING_WEEK_BEFORE_RELEASE`
+     */
+    oneWorkingWeekBeforeRelease: Date
+    /**
      * Available as `$ONE_WORKING_DAY_BEFORE_RELEASE`
      */
     threeWorkingDaysBeforeRelease: Date
@@ -139,7 +143,13 @@ function dateMarkdown(date: Date, name: string): string {
 async function execTemplate(
     octokit: Octokit,
     template: IssueTemplate,
-    { version, threeWorkingDaysBeforeRelease, releaseDate, oneWorkingDayAfterRelease }: IssueTemplateArguments
+    {
+        version,
+        oneWorkingWeekBeforeRelease,
+        threeWorkingDaysBeforeRelease,
+        releaseDate,
+        oneWorkingDayAfterRelease,
+    }: IssueTemplateArguments
 ): Promise<string> {
     console.log(`Preparing issue from ${JSON.stringify(template)}`)
     const name = releaseName(version)
@@ -148,6 +158,10 @@ async function execTemplate(
         .replace(/\$MAJOR/g, version.major.toString())
         .replace(/\$MINOR/g, version.minor.toString())
         .replace(/\$PATCH/g, version.patch.toString())
+        .replace(
+            /\$ONE_WORKING_WEEK_BEFORE_RELEASE/g,
+            dateMarkdown(oneWorkingWeekBeforeRelease, `One working week before ${name} release`)
+        )
         .replace(
             /\$THREE_WORKING_DAY_BEFORE_RELEASE/g,
             dateMarkdown(threeWorkingDaysBeforeRelease, `Three working days before ${name} release`)
@@ -175,6 +189,7 @@ export async function ensureTrackingIssues({
     version,
     assignees,
     releaseDate,
+    oneWorkingWeekBeforeRelease,
     threeWorkingDaysBeforeRelease,
     oneWorkingDayAfterRelease,
     dryRun,
@@ -182,6 +197,7 @@ export async function ensureTrackingIssues({
     version: semver.SemVer
     assignees: string[]
     releaseDate: Date
+    oneWorkingWeekBeforeRelease: Date
     threeWorkingDaysBeforeRelease: Date
     oneWorkingDayAfterRelease: Date
     dryRun: boolean
@@ -218,6 +234,7 @@ export async function ensureTrackingIssues({
         const body = await execTemplate(octokit, template, {
             version,
             releaseDate,
+            oneWorkingWeekBeforeRelease,
             threeWorkingDaysBeforeRelease,
             oneWorkingDayAfterRelease,
         })

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -184,6 +184,7 @@ const steps: Step[] = [
             const {
                 releaseDate,
                 captainGitHubUsername,
+                oneWorkingWeekBeforeRelease,
                 threeWorkingDaysBeforeRelease,
                 oneWorkingDayAfterRelease,
                 captainSlackUsername,
@@ -198,6 +199,7 @@ const steps: Step[] = [
                 version: release,
                 assignees: [captainGitHubUsername],
                 releaseDate: date,
+                oneWorkingWeekBeforeRelease: new Date(oneWorkingWeekBeforeRelease),
                 threeWorkingDaysBeforeRelease: new Date(threeWorkingDaysBeforeRelease),
                 oneWorkingDayAfterRelease: new Date(oneWorkingDayAfterRelease),
                 dryRun: dryRun.trackingIssues || false,
@@ -319,9 +321,9 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
             let message: string
             // notify cs team on patch release cut
             if (release.patch !== 0) {
-                message = `:mega: *${release.version} branch has been cut cc: @cs`
+                message = `:mega: *${release.version}* branch has been cut cc: @cs`
             } else {
-                message = `:mega: *${release.version} branch has been cut.`
+                message = `:mega: *${release.version}* branch has been cut.`
             }
             try {
                 // Create and push new release branch from changelog commit
@@ -347,7 +349,7 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
             }
             const latestTag = (await getLatestTag('sourcegraph', 'sourcegraph')).toString()
             const latestBuildURL = `https://buildkite.com/sourcegraph/sourcegraph/builds?branch=${latestTag}`
-            const latestBuildMessage = `Latest release build: ${latestTag}. See the build status [here](${latestBuildURL}) `
+            const latestBuildMessage = `Latest release build: ${latestTag}. See the build status on <${latestBuildURL}|Buildkite>`
             const blockingQuery = 'is:open org:sourcegraph label:release-blocker'
             const blockingIssues = await listIssues(githubClient, blockingQuery)
             const blockingIssuesURL = `https://github.com/issues?q=${encodeURIComponent(blockingQuery)}`


### PR DESCRIPTION


## Test plan

It's for release tooling.

## App preview:

- [Web](https://sg-web-jc-dev-release.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
