### PR TITLE
Blob UI: Disable return to target logic in blame popover UI

### DIFF
--- a/client/web/src/repo/blob/BlameDecoration.tsx
+++ b/client/web/src/repo/blob/BlameDecoration.tsx
@@ -153,6 +153,7 @@ export const BlameDecoration: React.FunctionComponent<{
                 targetPadding={createRectangle(0, 0, 8, 8)}
                 position={Position.topStart}
                 focusLocked={false}
+                returnTargetFocus={false}
                 onMouseEnter={resetAllTimeouts}
                 onMouseLeave={close}
                 className={styles.popoverContent}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/43335

## Background
Previously before we merged https://github.com/sourcegraph/sourcegraph/pull/43029 the PopoverContent didn't do anything with focus (didn't return it to the original target) if `focusLocked` is specified and set to `false`. In https://github.com/sourcegraph/sourcegraph/pull/43029 I changed this behaviour, and now PopoverContent exposes the `returnTargetFocus` prop to turn on/off focus preservation after Popover has been closed. 

The recursion (why we have problem in Blame annotations) is 
- Blame line (let's call it target 1) is listening to focus and showing a tooltip on the focused target (let's call this Popover1) 
- If you move the cursor (hover over another blame line, let's say target 2) or you're going through blame lines with a keyboard you focus next target (target 2), and the previous target (target 1) emits a blur which closes the Popover 1 
- Since `returnTargetFocus` by default is true the Popover 1 returns popover to the target 1
- And this is a loop, you're hovering over target 2, and we close popover 1, which closes returns focus to target 1, and we open Popover 1 

I shared my feedback about this that this blame popover should use a tooltip pattern and doesn't have any interactive element as content. And in this case, we wouldn't be needed in any focus popover-like management in this UI. 

## Test plan
- Open blob UI 
- Try to open and hover/focus blame line annotation 
- Commit message/info popover should work properly and without any freezes when you're navigating through blame line annotations

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
