### PR TITLE
Have dedicated CodeHostBaseURL type

### DIFF
--- a/cmd/frontend/backend/webhooks_test.go
+++ b/cmd/frontend/backend/webhooks_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -31,7 +32,8 @@ func TestCreateWebhook(t *testing.T) {
 
 	ws := NewWebhookService(db, keyring.Default())
 
-	ghURN := "https://github.com"
+	ghURN, err := extsvc.NewCodeHostBaseURL("https://github.com")
+	require.NoError(t, err)
 	testSecret := "mysecret"
 	tests := []struct {
 		label        string
@@ -44,7 +46,7 @@ func TestCreateWebhook(t *testing.T) {
 		{
 			label:        "basic",
 			codeHostKind: extsvc.KindGitHub,
-			codeHostURN:  ghURN,
+			codeHostURN:  ghURN.String(),
 			secret:       &testSecret,
 			expected: types.Webhook{
 				ID:              1,
@@ -58,7 +60,7 @@ func TestCreateWebhook(t *testing.T) {
 		{
 			label:        "invalid code host",
 			codeHostKind: "InvalidKind",
-			codeHostURN:  ghURN,
+			codeHostURN:  ghURN.String(),
 			expectedErr:  errors.New("webhooks are not supported for code host kind InvalidKind"),
 		},
 		{

--- a/cmd/frontend/graphqlbackend/webhooks.go
+++ b/cmd/frontend/graphqlbackend/webhooks.go
@@ -44,7 +44,7 @@ func (r *webhookResolver) URL() (string, error) {
 }
 
 func (r *webhookResolver) CodeHostURN() string {
-	return r.hook.CodeHostURN
+	return r.hook.CodeHostURN.String()
 }
 
 func (r *webhookResolver) CodeHostKind() string {

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
@@ -13,16 +13,16 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // handleGithubRepoAuthzEvent handles any github event containing a repository field, and enqueues the contained
 // repo for permissions synchronisation.
-func handleGitHubRepoAuthzEvent(db database.DB, opts authz.FetchPermsOptions) func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
-	return func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
+func handleGitHubRepoAuthzEvent(db database.DB, opts authz.FetchPermsOptions) func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
+	return func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		if !conf.ExperimentalFeatures().EnablePermissionsWebhooks {
 			return nil
 		}

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
@@ -15,13 +15,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // handleGithubRepoAuthzEvent handles any github event containing a repository field, and enqueues the contained
 // repo for permissions synchronisation.
-func handleGitHubRepoAuthzEvent(db database.DB, opts authz.FetchPermsOptions) func(ctx context.Context, db database.DB, urn string, payload any) error {
-	return func(ctx context.Context, db database.DB, urn string, payload any) error {
+func handleGitHubRepoAuthzEvent(db database.DB, opts authz.FetchPermsOptions) func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
+	return func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
 		if !conf.ExperimentalFeatures().EnablePermissionsWebhooks {
 			return nil
 		}

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
@@ -13,13 +13,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // handleGitHubUserAuthzEvent handles a github webhook for the events described in webhookhandlers/handlers.go
 // extracting a user from the github event and scheduling it for a perms update in repo-updater
-func handleGitHubUserAuthzEvent(db database.DB, opts authz.FetchPermsOptions) func(ctx context.Context, db database.DB, urn string, payload any) error {
-	return func(ctx context.Context, db database.DB, urn string, payload any) error {
+func handleGitHubUserAuthzEvent(db database.DB, opts authz.FetchPermsOptions) func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
+	return func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
 		if !conf.ExperimentalFeatures().EnablePermissionsWebhooks {
 			return nil
 		}

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
@@ -11,16 +11,16 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // handleGitHubUserAuthzEvent handles a github webhook for the events described in webhookhandlers/handlers.go
 // extracting a user from the github event and scheduling it for a perms update in repo-updater
-func handleGitHubUserAuthzEvent(db database.DB, opts authz.FetchPermsOptions) func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
-	return func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
+func handleGitHubUserAuthzEvent(db database.DB, opts authz.FetchPermsOptions) func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
+	return func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		if !conf.ExperimentalFeatures().EnablePermissionsWebhooks {
 			return nil
 		}

--- a/cmd/frontend/webhooks/github_webhooks.go
+++ b/cmd/frontend/webhooks/github_webhooks.go
@@ -74,7 +74,7 @@ func (h *GitHubWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	codeHostURN, err := types.ParseCodeHostURN(config.Url)
+	codeHostURN, err := types.NewCodeHostURN(config.Url)
 	if err != nil {
 		log15.Error("Could not parse code host URL from config", "error", err)
 		http.Error(w, "Invalid code host URL", http.StatusInternalServerError)

--- a/cmd/frontend/webhooks/github_webhooks.go
+++ b/cmd/frontend/webhooks/github_webhooks.go
@@ -28,7 +28,7 @@ type Registerer interface {
 // permissible based on the event type(s) the handler was registered against. If you register a handler
 // for many event types, you should do a type switch within your handler.
 // Handlers are responsible for fetching the necessary credentials to perform their associated tasks.
-type WebhookHandler func(ctx context.Context, db database.DB, codeHostURN types.CodeHostURN, event any) error
+type WebhookHandler func(ctx context.Context, db database.DB, codeHostURN extsvc.CodeHostBaseURL, event any) error
 
 // GitHubWebhook is responsible for handling incoming http requests for github webhooks
 // and routing to any registered WebhookHandlers, events are routed by their event type,
@@ -74,7 +74,7 @@ func (h *GitHubWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	codeHostURN, err := types.NewCodeHostURN(config.Url)
+	codeHostURN, err := extsvc.NewCodeHostBaseURL(config.Url)
 	if err != nil {
 		log15.Error("Could not parse code host URL from config", "error", err)
 		http.Error(w, "Invalid code host URL", http.StatusInternalServerError)
@@ -84,7 +84,7 @@ func (h *GitHubWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.HandleWebhook(w, r, codeHostURN, body)
 }
 
-func (h *GitHubWebhook) HandleWebhook(w http.ResponseWriter, r *http.Request, codeHostURN types.CodeHostURN, requestBody []byte) {
+func (h *GitHubWebhook) HandleWebhook(w http.ResponseWriter, r *http.Request, codeHostURN extsvc.CodeHostBaseURL, requestBody []byte) {
 	// 🚨 SECURITY: now that the payload and shared secret have been validated,
 	// we can use an internal actor on the context.
 	ctx := actor.WithInternalActor(r.Context())
@@ -109,7 +109,7 @@ func (h *GitHubWebhook) HandleWebhook(w http.ResponseWriter, r *http.Request, co
 
 // Dispatch accepts an event for a particular event type and dispatches it
 // to the appropriate stack of handlers, if any are configured.
-func (h *GitHubWebhook) Dispatch(ctx context.Context, eventType string, codeHostURN types.CodeHostURN, e any) error {
+func (h *GitHubWebhook) Dispatch(ctx context.Context, eventType string, codeHostURN extsvc.CodeHostBaseURL, e any) error {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	g := errgroup.Group{}

--- a/cmd/frontend/webhooks/github_webhooks.go
+++ b/cmd/frontend/webhooks/github_webhooks.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"net/url"
 	"strconv"
 	"sync"
 
@@ -29,7 +28,7 @@ type Registerer interface {
 // permissible based on the event type(s) the handler was registered against. If you register a handler
 // for many event types, you should do a type switch within your handler.
 // Handlers are responsible for fetching the necessary credentials to perform their associated tasks.
-type WebhookHandler func(ctx context.Context, db database.DB, codeHostURN string, event any) error
+type WebhookHandler func(ctx context.Context, db database.DB, codeHostURN types.CodeHostURN, event any) error
 
 // GitHubWebhook is responsible for handling incoming http requests for github webhooks
 // and routing to any registered WebhookHandlers, events are routed by their event type,
@@ -75,17 +74,17 @@ func (h *GitHubWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	url, err := url.Parse(config.Url)
+	codeHostURN, err := types.ParseCodeHostURN(config.Url)
 	if err != nil {
 		log15.Error("Could not parse code host URL from config", "error", err)
 		http.Error(w, "Invalid code host URL", http.StatusInternalServerError)
 		return
 	}
 
-	h.HandleWebhook(w, r, extsvc.NormalizeBaseURL(url).String(), body)
+	h.HandleWebhook(w, r, codeHostURN, body)
 }
 
-func (h *GitHubWebhook) HandleWebhook(w http.ResponseWriter, r *http.Request, codeHostURN string, requestBody []byte) {
+func (h *GitHubWebhook) HandleWebhook(w http.ResponseWriter, r *http.Request, codeHostURN types.CodeHostURN, requestBody []byte) {
 	// 🚨 SECURITY: now that the payload and shared secret have been validated,
 	// we can use an internal actor on the context.
 	ctx := actor.WithInternalActor(r.Context())
@@ -110,7 +109,7 @@ func (h *GitHubWebhook) HandleWebhook(w http.ResponseWriter, r *http.Request, co
 
 // Dispatch accepts an event for a particular event type and dispatches it
 // to the appropriate stack of handlers, if any are configured.
-func (h *GitHubWebhook) Dispatch(ctx context.Context, eventType string, codeHostURN string, e any) error {
+func (h *GitHubWebhook) Dispatch(ctx context.Context, eventType string, codeHostURN types.CodeHostURN, e any) error {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	g := errgroup.Group{}

--- a/cmd/frontend/webhooks/github_webhooks_test.go
+++ b/cmd/frontend/webhooks/github_webhooks_test.go
@@ -26,13 +26,13 @@ import (
 func TestGithubWebhookDispatchSuccess(t *testing.T) {
 	h := GitHubWebhook{}
 	var called bool
-	h.Register(func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
+	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		called = true
 		return nil
 	}, "test-event-1")
 
 	ctx := context.Background()
-	if err := h.Dispatch(ctx, "test-event-1", types.CodeHostURN{}, nil); err != nil {
+	if err := h.Dispatch(ctx, "test-event-1", extsvc.CodeHostBaseURL{}, nil); err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}
 	if !called {
@@ -44,7 +44,7 @@ func TestGithubWebhookDispatchNoHandler(t *testing.T) {
 	h := GitHubWebhook{}
 	ctx := context.Background()
 	// no op
-	if err := h.Dispatch(ctx, "test-event-1", types.CodeHostURN{}, nil); err != nil {
+	if err := h.Dispatch(ctx, "test-event-1", extsvc.CodeHostBaseURL{}, nil); err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}
 }
@@ -54,17 +54,17 @@ func TestGithubWebhookDispatchSuccessMultiple(t *testing.T) {
 		h      = GitHubWebhook{}
 		called = make(chan struct{}, 2)
 	)
-	h.Register(func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
+	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		called <- struct{}{}
 		return nil
 	}, "test-event-1")
-	h.Register(func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
+	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		called <- struct{}{}
 		return nil
 	}, "test-event-1")
 
 	ctx := context.Background()
-	if err := h.Dispatch(ctx, "test-event-1", types.CodeHostURN{}, nil); err != nil {
+	if err := h.Dispatch(ctx, "test-event-1", extsvc.CodeHostBaseURL{}, nil); err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}
 	if len(called) != 2 {
@@ -77,17 +77,17 @@ func TestGithubWebhookDispatchError(t *testing.T) {
 		h      = GitHubWebhook{}
 		called = make(chan struct{}, 2)
 	)
-	h.Register(func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
+	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		called <- struct{}{}
 		return errors.Errorf("oh no")
 	}, "test-event-1")
-	h.Register(func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
+	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		called <- struct{}{}
 		return nil
 	}, "test-event-1")
 
 	ctx := context.Background()
-	if have, want := h.Dispatch(ctx, "test-event-1", types.CodeHostURN{}, nil), "oh no"; errString(have) != want {
+	if have, want := h.Dispatch(ctx, "test-event-1", extsvc.CodeHostBaseURL{}, nil), "oh no"; errString(have) != want {
 		t.Errorf("Expected %q, got %q", want, have)
 	}
 	if len(called) != 2 {
@@ -138,7 +138,7 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 	}
 
 	var called bool
-	hook.Register(func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
+	hook.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		evt, ok := payload.(*gh.PublicEvent)
 		if !ok {
 			t.Errorf("Expected *gh.PublicEvent event, got %T", payload)

--- a/cmd/frontend/webhooks/github_webhooks_test.go
+++ b/cmd/frontend/webhooks/github_webhooks_test.go
@@ -26,13 +26,13 @@ import (
 func TestGithubWebhookDispatchSuccess(t *testing.T) {
 	h := GitHubWebhook{}
 	var called bool
-	h.Register(func(ctx context.Context, db database.DB, urn string, payload any) error {
+	h.Register(func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
 		called = true
 		return nil
 	}, "test-event-1")
 
 	ctx := context.Background()
-	if err := h.Dispatch(ctx, "test-event-1", "", nil); err != nil {
+	if err := h.Dispatch(ctx, "test-event-1", types.CodeHostURN{}, nil); err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}
 	if !called {
@@ -44,7 +44,7 @@ func TestGithubWebhookDispatchNoHandler(t *testing.T) {
 	h := GitHubWebhook{}
 	ctx := context.Background()
 	// no op
-	if err := h.Dispatch(ctx, "test-event-1", "", nil); err != nil {
+	if err := h.Dispatch(ctx, "test-event-1", types.CodeHostURN{}, nil); err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}
 }
@@ -54,17 +54,17 @@ func TestGithubWebhookDispatchSuccessMultiple(t *testing.T) {
 		h      = GitHubWebhook{}
 		called = make(chan struct{}, 2)
 	)
-	h.Register(func(ctx context.Context, db database.DB, urn string, payload any) error {
+	h.Register(func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
 		called <- struct{}{}
 		return nil
 	}, "test-event-1")
-	h.Register(func(ctx context.Context, db database.DB, urn string, payload any) error {
+	h.Register(func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
 		called <- struct{}{}
 		return nil
 	}, "test-event-1")
 
 	ctx := context.Background()
-	if err := h.Dispatch(ctx, "test-event-1", "", nil); err != nil {
+	if err := h.Dispatch(ctx, "test-event-1", types.CodeHostURN{}, nil); err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}
 	if len(called) != 2 {
@@ -77,17 +77,17 @@ func TestGithubWebhookDispatchError(t *testing.T) {
 		h      = GitHubWebhook{}
 		called = make(chan struct{}, 2)
 	)
-	h.Register(func(ctx context.Context, db database.DB, urn string, payload any) error {
+	h.Register(func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
 		called <- struct{}{}
 		return errors.Errorf("oh no")
 	}, "test-event-1")
-	h.Register(func(ctx context.Context, db database.DB, urn string, payload any) error {
+	h.Register(func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
 		called <- struct{}{}
 		return nil
 	}, "test-event-1")
 
 	ctx := context.Background()
-	if have, want := h.Dispatch(ctx, "test-event-1", "", nil), "oh no"; errString(have) != want {
+	if have, want := h.Dispatch(ctx, "test-event-1", types.CodeHostURN{}, nil), "oh no"; errString(have) != want {
 		t.Errorf("Expected %q, got %q", want, have)
 	}
 	if len(called) != 2 {
@@ -138,7 +138,7 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 	}
 
 	var called bool
-	hook.Register(func(ctx context.Context, db database.DB, urn string, payload any) error {
+	hook.Register(func(ctx context.Context, db database.DB, urn types.CodeHostURN, payload any) error {
 		evt, ok := payload.(*gh.PublicEvent)
 		if !ok {
 			t.Errorf("Expected *gh.PublicEvent event, got %T", payload)

--- a/cmd/frontend/webhooks/webhooks.go
+++ b/cmd/frontend/webhooks/webhooks.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 type WebhookHandlers struct {
@@ -99,7 +98,7 @@ func gitlabValidatePayload(r *http.Request, secret string) ([]byte, error) {
 	return body, nil
 }
 
-func handleGitHubWebHook(w http.ResponseWriter, r *http.Request, urn types.CodeHostURN, secret string, gh *GitHubWebhook) {
+func handleGitHubWebHook(w http.ResponseWriter, r *http.Request, urn extsvc.CodeHostBaseURL, secret string, gh *GitHubWebhook) {
 	if secret == "" {
 		payload, err := io.ReadAll(r.Body)
 		if err != nil {

--- a/cmd/frontend/webhooks/webhooks.go
+++ b/cmd/frontend/webhooks/webhooks.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 type WebhookHandlers struct {
@@ -98,7 +99,7 @@ func gitlabValidatePayload(r *http.Request, secret string) ([]byte, error) {
 	return body, nil
 }
 
-func handleGitHubWebHook(w http.ResponseWriter, r *http.Request, urn string, secret string, gh *GitHubWebhook) {
+func handleGitHubWebHook(w http.ResponseWriter, r *http.Request, urn types.CodeHostURN, secret string, gh *GitHubWebhook) {
 	if secret == "" {
 		payload, err := io.ReadAll(r.Body)
 		if err != nil {

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud.go
@@ -134,7 +134,7 @@ func (h *BitbucketCloudWebhook) parseEvent(r *http.Request) (interface{}, *types
 	return e, extSvc, nil
 }
 
-func (h *BitbucketCloudWebhook) convertEvent(ctx context.Context, theirs interface{}, externalServiceID string) ([]PR, keyer, error) {
+func (h *BitbucketCloudWebhook) convertEvent(ctx context.Context, theirs interface{}, externalServiceID types.CodeHostURN) ([]PR, keyer, error) {
 	switch e := theirs.(type) {
 	case *bitbucketcloud.PullRequestApprovedEvent:
 		return bitbucketCloudPullRequestEventPRs(&e.PullRequestEvent), e, nil
@@ -178,7 +178,7 @@ func bitbucketCloudPullRequestEventPRs(e *bitbucketcloud.PullRequestEvent) []PR 
 
 func bitbucketCloudRepoCommitStatusEventPRs(
 	ctx context.Context, bstore *store.Store,
-	e *bitbucketcloud.RepoCommitStatusEvent, externalServiceID string,
+	e *bitbucketcloud.RepoCommitStatusEvent, externalServiceID types.CodeHostURN,
 ) ([]PR, error) {
 	// Bitbucket Cloud repo commit statuses only include the commit hash they
 	// relate to, not the branch or PR, so we have to go look up the relevant
@@ -190,7 +190,7 @@ func bitbucketCloudRepoCommitStatusEventPRs(
 			{
 				ID:          e.Repository.UUID,
 				ServiceType: extsvc.TypeBitbucketCloud,
-				ServiceID:   externalServiceID,
+				ServiceID:   externalServiceID.String(),
 			},
 		},
 	})

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud.go
@@ -134,7 +134,7 @@ func (h *BitbucketCloudWebhook) parseEvent(r *http.Request) (interface{}, *types
 	return e, extSvc, nil
 }
 
-func (h *BitbucketCloudWebhook) convertEvent(ctx context.Context, theirs interface{}, externalServiceID types.CodeHostURN) ([]PR, keyer, error) {
+func (h *BitbucketCloudWebhook) convertEvent(ctx context.Context, theirs interface{}, externalServiceID extsvc.CodeHostBaseURL) ([]PR, keyer, error) {
 	switch e := theirs.(type) {
 	case *bitbucketcloud.PullRequestApprovedEvent:
 		return bitbucketCloudPullRequestEventPRs(&e.PullRequestEvent), e, nil
@@ -178,7 +178,7 @@ func bitbucketCloudPullRequestEventPRs(e *bitbucketcloud.PullRequestEvent) []PR 
 
 func bitbucketCloudRepoCommitStatusEventPRs(
 	ctx context.Context, bstore *store.Store,
-	e *bitbucketcloud.RepoCommitStatusEvent, externalServiceID types.CodeHostURN,
+	e *bitbucketcloud.RepoCommitStatusEvent, externalServiceID extsvc.CodeHostBaseURL,
 ) ([]PR, error) {
 	// Bitbucket Cloud repo commit statuses only include the commit hash they
 	// relate to, not the branch or PR, so we have to go look up the relevant

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -54,7 +55,7 @@ func (h *GitHubWebhook) Register(router *webhooks.GitHubWebhook) {
 
 // handleGithubWebhook is the entry point for webhooks from the webhook router, see the events
 // it's registered to handle in GitHubWebhook.Register
-func (h *GitHubWebhook) handleGitHubWebhook(ctx context.Context, db database.DB, codeHostURN string, payload any) error {
+func (h *GitHubWebhook) handleGitHubWebhook(ctx context.Context, db database.DB, codeHostURN types.CodeHostURN, payload any) error {
 	var m error
 
 	prs, ev := h.convertEvent(ctx, codeHostURN, payload)
@@ -79,7 +80,7 @@ func (h *GitHubWebhook) handleGitHubWebhook(ctx context.Context, db database.DB,
 	return m
 }
 
-func (h *GitHubWebhook) convertEvent(ctx context.Context, codeHostURN string, theirs any) (prs []PR, ours keyer) {
+func (h *GitHubWebhook) convertEvent(ctx context.Context, codeHostURN types.CodeHostURN, theirs any) (prs []PR, ours keyer) {
 	log15.Debug("GitHub webhook received", "type", fmt.Sprintf("%T", theirs))
 	switch e := theirs.(type) {
 	case *gh.IssueCommentEvent:
@@ -181,7 +182,7 @@ func (h *GitHubWebhook) convertEvent(ctx context.Context, codeHostURN string, th
 
 		spec := api.ExternalRepoSpec{
 			ID:          repoExternalID,
-			ServiceID:   codeHostURN,
+			ServiceID:   codeHostURN.String(),
 			ServiceType: extsvc.TypeGitHub,
 		}
 

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -55,7 +54,7 @@ func (h *GitHubWebhook) Register(router *webhooks.GitHubWebhook) {
 
 // handleGithubWebhook is the entry point for webhooks from the webhook router, see the events
 // it's registered to handle in GitHubWebhook.Register
-func (h *GitHubWebhook) handleGitHubWebhook(ctx context.Context, db database.DB, codeHostURN types.CodeHostURN, payload any) error {
+func (h *GitHubWebhook) handleGitHubWebhook(ctx context.Context, db database.DB, codeHostURN extsvc.CodeHostBaseURL, payload any) error {
 	var m error
 
 	prs, ev := h.convertEvent(ctx, codeHostURN, payload)
@@ -80,7 +79,7 @@ func (h *GitHubWebhook) handleGitHubWebhook(ctx context.Context, db database.DB,
 	return m
 }
 
-func (h *GitHubWebhook) convertEvent(ctx context.Context, codeHostURN types.CodeHostURN, theirs any) (prs []PR, ours keyer) {
+func (h *GitHubWebhook) convertEvent(ctx context.Context, codeHostURN extsvc.CodeHostBaseURL, theirs any) (prs []PR, ours keyer) {
 	log15.Debug("GitHub webhook received", "type", fmt.Sprintf("%T", theirs))
 	switch e := theirs.(type) {
 	case *gh.IssueCommentEvent:

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	gh "github.com/google/go-github/v43/github"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/log/logtest"
 
@@ -246,8 +247,9 @@ func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 			// unexpected input.
 			n := 10156
 			action := "this is a bad action"
-
-			if err := hook.handleGitHubWebhook(ctx, db, "github.com", &gh.PullRequestEvent{
+			u, err := types.ParseCodeHostURN("github.com")
+			require.NoError(t, err)
+			if err := hook.handleGitHubWebhook(ctx, db, u, &gh.PullRequestEvent{
 				Number: &n,
 				Repo: &gh.Repository{
 					NodeID: &githubRepo.ExternalRepo.ID,

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -247,7 +247,7 @@ func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 			// unexpected input.
 			n := 10156
 			action := "this is a bad action"
-			u, err := types.NewCodeHostURN("github.com")
+			u, err := extsvc.NewCodeHostBaseURL("github.com")
 			require.NoError(t, err)
 			if err := hook.handleGitHubWebhook(ctx, db, u, &gh.PullRequestEvent{
 				Number: &n,

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -247,7 +247,7 @@ func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 			// unexpected input.
 			n := 10156
 			action := "this is a bad action"
-			u, err := types.ParseCodeHostURN("github.com")
+			u, err := types.NewCodeHostURN("github.com")
 			require.NoError(t, err)
 			if err := hook.handleGitHubWebhook(ctx, db, u, &gh.PullRequestEvent{
 				Number: &n,

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab.go
@@ -227,7 +227,7 @@ func (h *GitLabWebhook) handleEvent(ctx context.Context, extSvc *types.ExternalS
 	return nil
 }
 
-func (h *GitLabWebhook) enqueueChangesetSyncFromEvent(ctx context.Context, esID string, event *webhooks.MergeRequestEventCommon) error {
+func (h *GitLabWebhook) enqueueChangesetSyncFromEvent(ctx context.Context, esID types.CodeHostURN, event *webhooks.MergeRequestEventCommon) error {
 	// We need to get our changeset ID for this to work. To get _there_, we need
 	// the repo ID, and then we can use the merge request IID to match the
 	// external ID.
@@ -249,7 +249,7 @@ func (h *GitLabWebhook) enqueueChangesetSyncFromEvent(ctx context.Context, esID 
 	return nil
 }
 
-func (h *GitLabWebhook) handlePipelineEvent(ctx context.Context, esID string, event *webhooks.PipelineEvent) error {
+func (h *GitLabWebhook) handlePipelineEvent(ctx context.Context, esID types.CodeHostURN, event *webhooks.PipelineEvent) error {
 	// Pipeline webhook payloads don't include the merge request very reliably:
 	// for example, re-running a pipeline from the GitLab UI will result in no
 	// merge request field, even when that pipeline was attached to a merge

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab.go
@@ -227,7 +227,7 @@ func (h *GitLabWebhook) handleEvent(ctx context.Context, extSvc *types.ExternalS
 	return nil
 }
 
-func (h *GitLabWebhook) enqueueChangesetSyncFromEvent(ctx context.Context, esID types.CodeHostURN, event *webhooks.MergeRequestEventCommon) error {
+func (h *GitLabWebhook) enqueueChangesetSyncFromEvent(ctx context.Context, esID extsvc.CodeHostBaseURL, event *webhooks.MergeRequestEventCommon) error {
 	// We need to get our changeset ID for this to work. To get _there_, we need
 	// the repo ID, and then we can use the merge request IID to match the
 	// external ID.
@@ -249,7 +249,7 @@ func (h *GitLabWebhook) enqueueChangesetSyncFromEvent(ctx context.Context, esID 
 	return nil
 }
 
-func (h *GitLabWebhook) handlePipelineEvent(ctx context.Context, esID types.CodeHostURN, event *webhooks.PipelineEvent) error {
+func (h *GitLabWebhook) handlePipelineEvent(ctx context.Context, esID extsvc.CodeHostBaseURL, event *webhooks.PipelineEvent) error {
 	// Pipeline webhook payloads don't include the merge request very reliably:
 	// for example, re-running a pipeline from the GitLab UI will result in no
 	// merge request field, even when that pipeline was attached to a merge

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
@@ -697,7 +697,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 			t.Run("missing merge request", func(t *testing.T) {
 				event := &webhooks.PipelineEvent{}
 
-				if have := h.handlePipelineEvent(ctx, "ignored", event); have != errPipelineMissingMergeRequest {
+				if have := h.handlePipelineEvent(ctx, types.CodeHostURN{}, event); have != errPipelineMissingMergeRequest {
 					t.Errorf("unexpected error: have %+v; want %+v", have, errPipelineMissingMergeRequest)
 				}
 			})
@@ -707,7 +707,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 					MergeRequest: &gitlab.MergeRequest{},
 				}
 
-				if err := h.handlePipelineEvent(ctx, "ignored", event); err == nil || err == errPipelineMissingMergeRequest {
+				if err := h.handlePipelineEvent(ctx, types.CodeHostURN{}, event); err == nil || err == errPipelineMissingMergeRequest {
 					t.Errorf("unexpected error: %+v", err)
 				}
 			})

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
@@ -697,7 +697,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 			t.Run("missing merge request", func(t *testing.T) {
 				event := &webhooks.PipelineEvent{}
 
-				if have := h.handlePipelineEvent(ctx, types.CodeHostURN{}, event); have != errPipelineMissingMergeRequest {
+				if have := h.handlePipelineEvent(ctx, extsvc.CodeHostBaseURL{}, event); have != errPipelineMissingMergeRequest {
 					t.Errorf("unexpected error: have %+v; want %+v", have, errPipelineMissingMergeRequest)
 				}
 			})
@@ -707,7 +707,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 					MergeRequest: &gitlab.MergeRequest{},
 				}
 
-				if err := h.handlePipelineEvent(ctx, types.CodeHostURN{}, event); err == nil || err == errPipelineMissingMergeRequest {
+				if err := h.handlePipelineEvent(ctx, extsvc.CodeHostBaseURL{}, event); err == nil || err == errPipelineMissingMergeRequest {
 					t.Errorf("unexpected error: %+v", err)
 				}
 			})

--- a/enterprise/cmd/frontend/internal/batches/webhooks/webhooks.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/webhooks.go
@@ -81,7 +81,7 @@ func extractExternalServiceID(ctx context.Context, extSvc *types.ExternalService
 		return types.CodeHostURN{}, errors.New("could not determine service id")
 	}
 
-	return types.ParseCodeHostURN(serviceID)
+	return types.NewCodeHostURN(serviceID)
 }
 
 type keyer interface {

--- a/internal/database/webhooks.go
+++ b/internal/database/webhooks.go
@@ -361,7 +361,7 @@ func scanWebhook(sc dbutil.Scanner, key encryption.Key) (*types.Webhook, error) 
 	// If both keyID and rawSecret are empty then we didn't set a secret and we leave
 	// hook.Secret as nil
 
-	codeHostURN, err := types.ParseCodeHostURN(urnString)
+	codeHostURN, err := types.NewCodeHostURN(urnString)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/webhooks.go
+++ b/internal/database/webhooks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -335,12 +336,12 @@ func scanWebhook(sc dbutil.Scanner, key encryption.Key) (*types.Webhook, error) 
 		rawSecret string
 	)
 
-	var urnString string
+	var codeHostURL string
 	if err := sc.Scan(
 		&hook.ID,
 		&hook.UUID,
 		&hook.CodeHostKind,
-		&urnString,
+		&codeHostURL,
 		&dbutil.NullString{S: &rawSecret},
 		&hook.CreatedAt,
 		&hook.UpdatedAt,
@@ -361,7 +362,7 @@ func scanWebhook(sc dbutil.Scanner, key encryption.Key) (*types.Webhook, error) 
 	// If both keyID and rawSecret are empty then we didn't set a secret and we leave
 	// hook.Secret as nil
 
-	codeHostURN, err := types.NewCodeHostURN(urnString)
+	codeHostURN, err := extsvc.NewCodeHostBaseURL(codeHostURL)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/webhooks_test.go
+++ b/internal/database/webhooks_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -38,7 +39,7 @@ func TestWebhookCreate(t *testing.T) {
 			}
 
 			kind := extsvc.KindGitHub
-			urn := "https://github.com"
+			urn := "https://github.com/"
 			encryptedSecret := types.NewUnencryptedSecret(testSecret)
 
 			created, err := store.Create(ctx, kind, urn, 0, encryptedSecret)
@@ -48,7 +49,7 @@ func TestWebhookCreate(t *testing.T) {
 			assert.NotZero(t, created.ID)
 			assert.NotZero(t, created.UUID)
 			assert.Equal(t, kind, created.CodeHostKind)
-			assert.Equal(t, urn, created.CodeHostURN)
+			assert.Equal(t, urn, created.CodeHostURN.String())
 			assert.Equal(t, int32(0), created.CreatedByUserID)
 			assert.NotZero(t, created.CreatedAt)
 			assert.NotZero(t, created.UpdatedAt)
@@ -77,7 +78,7 @@ func TestWebhookCreate(t *testing.T) {
 		store := db.Webhooks(et.ByteaTestKey{})
 
 		kind := extsvc.KindGitHub
-		urn := "https://github.com"
+		urn := "https://github.com/"
 
 		created, err := store.Create(ctx, kind, urn, 0, nil)
 		assert.NoError(t, err)
@@ -87,7 +88,7 @@ func TestWebhookCreate(t *testing.T) {
 		assert.NotZero(t, created.UUID)
 		assert.NoError(t, err)
 		assert.Equal(t, kind, created.CodeHostKind)
-		assert.Equal(t, urn, created.CodeHostURN)
+		assert.Equal(t, urn, created.CodeHostURN.String())
 		assert.Equal(t, int32(0), created.CreatedByUserID)
 		assert.NotZero(t, created.CreatedAt)
 		assert.NotZero(t, created.UpdatedAt)
@@ -187,7 +188,8 @@ func TestWebhookUpdate(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := NewDB(logger, dbtest.NewDB(logger, t))
 
-	const newCodeHostURN = "https://new.github.com"
+	newCodeHostURN, err := types.ParseCodeHostURN("https://new.github.com")
+	require.NoError(t, err)
 	const updatedSecret = "my new secret"
 
 	t.Run("updating w/ unencrypted secret", func(t *testing.T) {
@@ -203,7 +205,7 @@ func TestWebhookUpdate(t *testing.T) {
 		assert.Equal(t, created.ID, updated.ID)
 		assert.Equal(t, created.UUID, updated.UUID)
 		assert.Equal(t, created.CodeHostKind, updated.CodeHostKind)
-		assert.Equal(t, newCodeHostURN, updated.CodeHostURN)
+		assert.Equal(t, newCodeHostURN.String(), updated.CodeHostURN.String())
 		assert.NotZero(t, created.CreatedAt, updated.CreatedAt)
 		assert.NotZero(t, created.UpdatedAt)
 		assert.Greater(t, updated.UpdatedAt, created.UpdatedAt)
@@ -222,7 +224,7 @@ func TestWebhookUpdate(t *testing.T) {
 		assert.Equal(t, created.ID, updated.ID)
 		assert.Equal(t, created.UUID, updated.UUID)
 		assert.Equal(t, created.CodeHostKind, updated.CodeHostKind)
-		assert.Equal(t, newCodeHostURN, updated.CodeHostURN)
+		assert.Equal(t, newCodeHostURN.String(), updated.CodeHostURN.String())
 		assert.NotZero(t, created.CreatedAt, updated.CreatedAt)
 		assert.NotZero(t, created.UpdatedAt)
 		assert.Greater(t, updated.UpdatedAt, created.UpdatedAt)
@@ -365,7 +367,7 @@ func TestGetByID(t *testing.T) {
 	assert.Equal(t, webhook.UUID, createdWebhook.UUID)
 	assert.Equal(t, webhook.Secret, createdWebhook.Secret)
 	assert.Equal(t, webhook.CodeHostKind, createdWebhook.CodeHostKind)
-	assert.Equal(t, webhook.CodeHostURN, createdWebhook.CodeHostURN)
+	assert.Equal(t, webhook.CodeHostURN.String(), createdWebhook.CodeHostURN.String())
 	assert.Equal(t, webhook.CreatedAt, createdWebhook.CreatedAt)
 	assert.Equal(t, webhook.UpdatedAt, createdWebhook.UpdatedAt)
 }
@@ -395,7 +397,7 @@ func TestGetByUUID(t *testing.T) {
 	assert.Equal(t, webhook.UUID, createdWebhook.UUID)
 	assert.Equal(t, webhook.Secret, createdWebhook.Secret)
 	assert.Equal(t, webhook.CodeHostKind, createdWebhook.CodeHostKind)
-	assert.Equal(t, webhook.CodeHostURN, createdWebhook.CodeHostURN)
+	assert.Equal(t, webhook.CodeHostURN.String(), createdWebhook.CodeHostURN.String())
 	assert.Equal(t, webhook.CreatedAt, createdWebhook.CreatedAt)
 	assert.Equal(t, webhook.UpdatedAt, createdWebhook.UpdatedAt)
 }

--- a/internal/database/webhooks_test.go
+++ b/internal/database/webhooks_test.go
@@ -188,7 +188,7 @@ func TestWebhookUpdate(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := NewDB(logger, dbtest.NewDB(logger, t))
 
-	newCodeHostURN, err := types.ParseCodeHostURN("https://new.github.com")
+	newCodeHostURN, err := types.NewCodeHostURN("https://new.github.com")
 	require.NoError(t, err)
 	const updatedSecret = "my new secret"
 

--- a/internal/database/webhooks_test.go
+++ b/internal/database/webhooks_test.go
@@ -39,17 +39,17 @@ func TestWebhookCreate(t *testing.T) {
 			}
 
 			kind := extsvc.KindGitHub
-			urn := "https://github.com/"
+			codeHostURL := "https://github.com/"
 			encryptedSecret := types.NewUnencryptedSecret(testSecret)
 
-			created, err := store.Create(ctx, kind, urn, 0, encryptedSecret)
+			created, err := store.Create(ctx, kind, codeHostURL, 0, encryptedSecret)
 			assert.NoError(t, err)
 
 			// Check that the calculated fields were correctly calculated.
 			assert.NotZero(t, created.ID)
 			assert.NotZero(t, created.UUID)
 			assert.Equal(t, kind, created.CodeHostKind)
-			assert.Equal(t, urn, created.CodeHostURN.String())
+			assert.Equal(t, codeHostURL, created.CodeHostURN.String())
 			assert.Equal(t, int32(0), created.CreatedByUserID)
 			assert.NotZero(t, created.CreatedAt)
 			assert.NotZero(t, created.UpdatedAt)
@@ -78,9 +78,9 @@ func TestWebhookCreate(t *testing.T) {
 		store := db.Webhooks(et.ByteaTestKey{})
 
 		kind := extsvc.KindGitHub
-		urn := "https://github.com/"
+		codeHostURL := "https://github.com/"
 
-		created, err := store.Create(ctx, kind, urn, 0, nil)
+		created, err := store.Create(ctx, kind, codeHostURL, 0, nil)
 		assert.NoError(t, err)
 
 		// Check that the calculated fields were correctly calculated.
@@ -88,7 +88,7 @@ func TestWebhookCreate(t *testing.T) {
 		assert.NotZero(t, created.UUID)
 		assert.NoError(t, err)
 		assert.Equal(t, kind, created.CodeHostKind)
-		assert.Equal(t, urn, created.CodeHostURN.String())
+		assert.Equal(t, codeHostURL, created.CodeHostURN.String())
 		assert.Equal(t, int32(0), created.CreatedByUserID)
 		assert.NotZero(t, created.CreatedAt)
 		assert.NotZero(t, created.UpdatedAt)
@@ -188,7 +188,7 @@ func TestWebhookUpdate(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := NewDB(logger, dbtest.NewDB(logger, t))
 
-	newCodeHostURN, err := types.NewCodeHostURN("https://new.github.com")
+	newCodeHostURN, err := extsvc.NewCodeHostBaseURL("https://new.github.com")
 	require.NoError(t, err)
 	const updatedSecret = "my new secret"
 

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -794,7 +794,7 @@ func NewCodeHostBaseURL(baseURL string) (CodeHostBaseURL, error) {
 	return CodeHostBaseURL{baseURL: NormalizeBaseURL(codeHostURL).String()}, nil
 }
 
-// String returns the stored, noramlized code host URN as a string.
+// String returns the stored, normalized code host URN as a string.
 func (c CodeHostBaseURL) String() string {
 	return c.baseURL
 }

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -772,3 +772,29 @@ func uniqueCodeHostIdentifier(kind string, cfg any) (string, error) {
 
 	return NormalizeBaseURL(u).String(), nil
 }
+
+// CodeHostBaseURL is an identifier for a unique code host in the form
+// of its host URL.
+// To create a new CodeHostBaseURL, use NewCodeHostURN.
+// e.g. NewCodeHostURN("https://github.com")
+// To use the string value again, use codeHostURN.String()
+type CodeHostBaseURL struct {
+	baseURL string
+}
+
+// NewCodeHostBaseURL takes a code host URL string, normalizes it,
+// and returns a CodeHostURN. If the string is required, use the
+// .String() method on the CodeHostURN.
+func NewCodeHostBaseURL(baseURL string) (CodeHostBaseURL, error) {
+	codeHostURL, err := url.Parse(baseURL)
+	if err != nil {
+		return CodeHostBaseURL{}, err
+	}
+
+	return CodeHostBaseURL{baseURL: NormalizeBaseURL(codeHostURL).String()}, nil
+}
+
+// String returns the stored, noramlized code host URN as a string.
+func (c CodeHostBaseURL) String() string {
+	return c.baseURL
+}

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -388,5 +389,20 @@ func TestWebhookURL(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, externalURL+"/.api/bitbucket-cloud-webhooks?externalServiceID=42&secret=foo+bar", have)
 		})
+	})
+}
+
+func TestCodeHostURN(t *testing.T) {
+	t.Run("normalize URL", func(t *testing.T) {
+		const url = "https://github.com"
+		urn, err := NewCodeHostBaseURL(url)
+		require.NoError(t, err)
+
+		assert.Equal(t, "https://github.com/", urn.String())
+	})
+
+	t.Run(`empty CodeHostURN.String() returns ""`, func(t *testing.T) {
+		urn := CodeHostBaseURL{}
+		assert.Equal(t, "", urn.String())
 	})
 }

--- a/internal/repos/github_webhook_handler.go
+++ b/internal/repos/github_webhook_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -23,7 +24,7 @@ func (g *GitHubWebhookHandler) Register(router *webhooks.GitHubWebhook) {
 	router.Register(g.handleGitHubWebhook, "push")
 }
 
-func (g *GitHubWebhookHandler) handleGitHubWebhook(ctx context.Context, _ database.DB, _ string, payload any) error {
+func (g *GitHubWebhookHandler) handleGitHubWebhook(ctx context.Context, _ database.DB, _ types.CodeHostURN, payload any) error {
 	event, ok := payload.(*gh.PushEvent)
 	if !ok {
 		return errors.Newf("expected GitHub.PushEvent, got %T", payload)

--- a/internal/repos/github_webhook_handler.go
+++ b/internal/repos/github_webhook_handler.go
@@ -10,8 +10,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -24,7 +24,7 @@ func (g *GitHubWebhookHandler) Register(router *webhooks.GitHubWebhook) {
 	router.Register(g.handleGitHubWebhook, "push")
 }
 
-func (g *GitHubWebhookHandler) handleGitHubWebhook(ctx context.Context, _ database.DB, _ types.CodeHostURN, payload any) error {
+func (g *GitHubWebhookHandler) handleGitHubWebhook(ctx context.Context, _ database.DB, _ extsvc.CodeHostBaseURL, payload any) error {
 	event, ok := payload.(*gh.PushEvent)
 	if !ok {
 		return errors.Newf("expected GitHub.PushEvent, got %T", payload)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/url"
 	"reflect"
 	"sort"
 	"strings"
@@ -1684,7 +1685,7 @@ type Webhook struct {
 	// UUID is the ID we display externally and will appear in the webhook URL
 	UUID         uuid.UUID
 	CodeHostKind string
-	CodeHostURN  string
+	CodeHostURN  CodeHostURN
 	// Secret can be in one of three states:
 	//
 	// 1. nil, no secret provided.
@@ -1699,4 +1700,31 @@ type Webhook struct {
 	UpdatedAt       time.Time
 	CreatedByUserID int32
 	UpdatedByUserID int32
+}
+
+// CodeHostURN is an identifier for a unique code host in the form
+// of its host URL.
+type CodeHostURN struct {
+	url *url.URL
+}
+
+// ParseCodeHostURN takes a code host URL string, normalizes it,
+// and returns a CodeHostURN. If the string is required, use the
+// .String() method on the CodeHostURN.
+func ParseCodeHostURN(urnString string) (CodeHostURN, error) {
+	url, err := url.Parse(urnString)
+	if err != nil {
+		return CodeHostURN{}, err
+	}
+
+	return CodeHostURN{url: extsvc.NormalizeBaseURL(url)}, nil
+}
+
+// String returns the stored, noramlized code host URN as a string.
+func (c CodeHostURN) String() string {
+	if c.url != nil {
+		return c.url.String()
+	}
+
+	return ""
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1704,6 +1704,9 @@ type Webhook struct {
 
 // CodeHostURN is an identifier for a unique code host in the form
 // of its host URL.
+// To create a new CodeHostURN, use NewCodeHostURN.
+// e.g. NewCodeHostURN("https://github.com")
+// To use the string value again, use codeHostURN.String()
 type CodeHostURN struct {
 	urlString string
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1708,10 +1708,10 @@ type CodeHostURN struct {
 	urlString string
 }
 
-// ParseCodeHostURN takes a code host URL string, normalizes it,
+// NewCodeHostURN takes a code host URL string, normalizes it,
 // and returns a CodeHostURN. If the string is required, use the
 // .String() method on the CodeHostURN.
-func ParseCodeHostURN(urnString string) (CodeHostURN, error) {
+func NewCodeHostURN(urnString string) (CodeHostURN, error) {
 	url, err := url.Parse(urnString)
 	if err != nil {
 		return CodeHostURN{}, err

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1705,7 +1705,7 @@ type Webhook struct {
 // CodeHostURN is an identifier for a unique code host in the form
 // of its host URL.
 type CodeHostURN struct {
-	url *url.URL
+	urlString string
 }
 
 // ParseCodeHostURN takes a code host URL string, normalizes it,
@@ -1717,14 +1717,10 @@ func ParseCodeHostURN(urnString string) (CodeHostURN, error) {
 		return CodeHostURN{}, err
 	}
 
-	return CodeHostURN{url: extsvc.NormalizeBaseURL(url)}, nil
+	return CodeHostURN{urlString: extsvc.NormalizeBaseURL(url).String()}, nil
 }
 
 // String returns the stored, noramlized code host URN as a string.
 func (c CodeHostURN) String() string {
-	if c.url != nil {
-		return c.url.String()
-	}
-
-	return ""
+	return c.urlString
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"net/url"
 	"reflect"
 	"sort"
 	"strings"
@@ -1685,7 +1684,7 @@ type Webhook struct {
 	// UUID is the ID we display externally and will appear in the webhook URL
 	UUID         uuid.UUID
 	CodeHostKind string
-	CodeHostURN  CodeHostURN
+	CodeHostURN  extsvc.CodeHostBaseURL
 	// Secret can be in one of three states:
 	//
 	// 1. nil, no secret provided.
@@ -1700,30 +1699,4 @@ type Webhook struct {
 	UpdatedAt       time.Time
 	CreatedByUserID int32
 	UpdatedByUserID int32
-}
-
-// CodeHostURN is an identifier for a unique code host in the form
-// of its host URL.
-// To create a new CodeHostURN, use NewCodeHostURN.
-// e.g. NewCodeHostURN("https://github.com")
-// To use the string value again, use codeHostURN.String()
-type CodeHostURN struct {
-	urlString string
-}
-
-// NewCodeHostURN takes a code host URL string, normalizes it,
-// and returns a CodeHostURN. If the string is required, use the
-// .String() method on the CodeHostURN.
-func NewCodeHostURN(urnString string) (CodeHostURN, error) {
-	url, err := url.Parse(urnString)
-	if err != nil {
-		return CodeHostURN{}, err
-	}
-
-	return CodeHostURN{urlString: extsvc.NormalizeBaseURL(url).String()}, nil
-}
-
-// String returns the stored, noramlized code host URN as a string.
-func (c CodeHostURN) String() string {
-	return c.urlString
 }

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -3,9 +3,6 @@ package types
 import (
 	"reflect"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestExternalServiceFields will fail if a new field is added to
@@ -19,19 +16,4 @@ func TestExternalServiceFields(t *testing.T) {
 	if wantFieldCount != v.NumField() {
 		t.Fatalf("Expected %d fields, got %d. See comments in failing test", wantFieldCount, v.NumField())
 	}
-}
-
-func TestCodeHostURN(t *testing.T) {
-	t.Run("normalize URL", func(t *testing.T) {
-		const url = "https://github.com"
-		urn, err := NewCodeHostURN(url)
-		require.NoError(t, err)
-
-		assert.Equal(t, "https://github.com/", urn.String())
-	})
-
-	t.Run(`empty CodeHostURN.String() returns ""`, func(t *testing.T) {
-		urn := CodeHostURN{}
-		assert.Equal(t, "", urn.String())
-	})
 }

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -24,7 +24,7 @@ func TestExternalServiceFields(t *testing.T) {
 func TestCodeHostURN(t *testing.T) {
 	t.Run("normalize URL", func(t *testing.T) {
 		const url = "https://github.com"
-		urn, err := ParseCodeHostURN(url)
+		urn, err := NewCodeHostURN(url)
 		require.NoError(t, err)
 
 		assert.Equal(t, "https://github.com/", urn.String())

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -3,6 +3,9 @@ package types
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestExternalServiceFields will fail if a new field is added to
@@ -16,4 +19,19 @@ func TestExternalServiceFields(t *testing.T) {
 	if wantFieldCount != v.NumField() {
 		t.Fatalf("Expected %d fields, got %d. See comments in failing test", wantFieldCount, v.NumField())
 	}
+}
+
+func TestCodeHostURN(t *testing.T) {
+	t.Run("normalize URL", func(t *testing.T) {
+		const url = "https://github.com"
+		urn, err := ParseCodeHostURN(url)
+		require.NoError(t, err)
+
+		assert.Equal(t, "https://github.com/", urn.String())
+	})
+
+	t.Run(`empty CodeHostURN.String() returns ""`, func(t *testing.T) {
+		urn := CodeHostURN{}
+		assert.Equal(t, "", urn.String())
+	})
 }


### PR DESCRIPTION
Idea to have a dedicated CodeHostURN type. It's a struct with a single internal field, with a `.String()` method to get it out again.

Doing it like this allows us to enforce normalization without other code trying to shortcut it.

## Test plan

Existing tests past, unit tests added for CodeHostURN type.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
