### PR TITLE
say "Sign in" instead of "Log in"

### DIFF
--- a/client/browser/src/end-to-end/bitbucket.test.ts
+++ b/client/browser/src/end-to-end/bitbucket.test.ts
@@ -137,7 +137,7 @@ describe('Sourcegraph browser extension on Bitbucket Server', () => {
         this.timeout(4 * 60 * 1000)
         driver = await createDriverForTest({ loadExtension: !TEST_NATIVE_INTEGRATION, sourcegraphBaseUrl })
         if (sourcegraphBaseUrl !== 'https://sourcegraph.com' && restConfig.testUserPassword) {
-            await driver.ensureLoggedIn({ username: 'test', password: restConfig.testUserPassword })
+            await driver.ensureSignedIn({ username: 'test', password: restConfig.testUserPassword })
         }
 
         await bitbucketLogin(driver)
@@ -152,7 +152,7 @@ describe('Sourcegraph browser extension on Bitbucket Server', () => {
 
         if (sourcegraphBaseUrl !== 'https://sourcegraph.com') {
             if (restConfig.testUserPassword) {
-                await driver.ensureLoggedIn({ username: 'test', password: restConfig.testUserPassword })
+                await driver.ensureSignedIn({ username: 'test', password: restConfig.testUserPassword })
             }
             await driver.ensureHasExternalService({
                 kind: ExternalServiceKind.BITBUCKETSERVER,

--- a/client/browser/src/end-to-end/ghe.test.ts
+++ b/client/browser/src/end-to-end/ghe.test.ts
@@ -44,7 +44,7 @@ describe('Sourcegraph browser extension on GitHub Enterprise', () => {
 
         if (sourcegraphBaseUrl !== 'https://sourcegraph.com') {
             if (restConfig.testUserPassword) {
-                await driver.ensureLoggedIn({ username: 'test', password: restConfig.testUserPassword })
+                await driver.ensureSignedIn({ username: 'test', password: restConfig.testUserPassword })
             }
             await gheLogin(driver)
             await driver.setExtensionSourcegraphUrl()

--- a/client/browser/src/end-to-end/github.test.ts
+++ b/client/browser/src/end-to-end/github.test.ts
@@ -25,7 +25,7 @@ describe('Sourcegraph browser extension on github.com', function () {
         driver = await createDriverForTest({ loadExtension: true, browser, sourcegraphBaseUrl, ...restConfig })
         if (sourcegraphBaseUrl !== 'https://sourcegraph.com') {
             if (restConfig.testUserPassword) {
-                await driver.ensureLoggedIn({ username: 'test', password: restConfig.testUserPassword })
+                await driver.ensureSignedIn({ username: 'test', password: restConfig.testUserPassword })
             }
             await driver.setExtensionSourcegraphUrl()
         }

--- a/client/browser/src/end-to-end/gitlab.test.ts
+++ b/client/browser/src/end-to-end/gitlab.test.ts
@@ -23,7 +23,7 @@ describe('Sourcegraph browser extension on Gitlab Server', () => {
 
         if (sourcegraphBaseUrl !== 'https://sourcegraph.com') {
             if (restConfig.testUserPassword) {
-                await driver.ensureLoggedIn({ username: 'test', password: restConfig.testUserPassword })
+                await driver.ensureSignedIn({ username: 'test', password: restConfig.testUserPassword })
             }
             await driver.setExtensionSourcegraphUrl()
             await driver.ensureHasExternalService({

--- a/client/browser/src/end-to-end/phabricator.test.ts
+++ b/client/browser/src/end-to-end/phabricator.test.ts
@@ -137,7 +137,7 @@ async function configureSourcegraphIntegration(driver: Driver): Promise<void> {
  */
 async function init(driver: Driver): Promise<void> {
     if (restConfig.testUserPassword) {
-        await driver.ensureLoggedIn({ username: 'test', password: restConfig.testUserPassword })
+        await driver.ensureSignedIn({ username: 'test', password: restConfig.testUserPassword })
     }
     // TODO test with a Gitolite external service
     await driver.ensureHasExternalService({

--- a/client/shared/src/testing/driver.ts
+++ b/client/shared/src/testing/driver.ts
@@ -204,7 +204,7 @@ export class Driver {
         }
     }
 
-    public async ensureLoggedIn({
+    public async ensureSignedIn({
         username,
         password,
         email,

--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -206,7 +206,7 @@ export const CloudSignUpPage: React.FunctionComponent<React.PropsWithChildren<Pr
                     <hr className={styles.separator} />
 
                     <div>
-                        Already have an account? <Link to={`/sign-in${location.search}`}>Log in</Link>
+                        Already have an account? <Link to={`/sign-in${location.search}`}>Sign in</Link>
                     </div>
                 </div>
             </div>

--- a/client/web/src/auth/VsCodeSignUpPage.tsx
+++ b/client/web/src/auth/VsCodeSignUpPage.tsx
@@ -163,7 +163,7 @@ export const VsCodeSignUpPage: React.FunctionComponent<React.PropsWithChildren<P
                     </small>
                     <hr className={styles.separator} />
                     <div>
-                        Already have an account? <Link to={`/sign-in${location.search}`}>Log in</Link>
+                        Already have an account? <Link to={`/sign-in${location.search}`}>Sign in</Link>
                     </div>
                 </div>
             </div>

--- a/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
@@ -123,7 +123,7 @@ exports[`SignUpPage renders sign up page (cloud) 1`] = `
             class="anchorLink"
             href="/sign-in"
           >
-            Log in
+            Sign in
           </a>
         </div>
       </div>

--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -563,7 +563,7 @@ const AWS_CODE_COMMIT: AddExternalServiceOptions = {
                 <li>
                     Obtain your AWS Secret Access Key and key ID:
                     <ul>
-                        <li>Log in to your AWS Management Console.</li>
+                        <li>Sign in to your AWS Management Console.</li>
                         <li>Click your username in the upper right corner of the page.</li>
                         <li>Click on "My Security Credentials".</li>
                         <li>Scroll to the section, "Access keys for CLI, SDK, & API access".</li>

--- a/client/web/src/end-to-end/utils/initEndToEndTest.ts
+++ b/client/web/src/end-to-end/utils/initEndToEndTest.ts
@@ -18,7 +18,7 @@ export async function initEndToEndTest(): Promise<Driver> {
         ...config,
     })
 
-    await driver.ensureLoggedIn({ username: 'test', password: config.testUserPassword, email: 'test@test.com' })
+    await driver.ensureSignedIn({ username: 'test', password: config.testUserPassword, email: 'test@test.com' })
     await driver.resetUserSettings()
 
     return driver

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -327,7 +327,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                                         size="sm"
                                         as={Link}
                                     >
-                                        Log in
+                                        Sign in
                                     </Button>
                                     <ButtonLink className={styles.signUp} to={buildGetStartedURL('nav')} size="sm">
                                         Get free trial

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -206,7 +206,7 @@ exports[`GlobalNavbar default 1`] = `
             class="anchorLink btn btnSecondary btnOutline btnSm mr-1"
             href="/sign-in"
           >
-            Log in
+            Sign in
           </a>
           <a
             class="anchorLink btn btnSm signUp"

--- a/client/web/src/regression/codeintel.test.ts
+++ b/client/web/src/regression/codeintel.test.ts
@@ -10,7 +10,7 @@ import { ExternalServiceKind } from '../graphql-operations'
 
 import { ensureTestExternalService, getUser, setTosAccepted, setUserSiteAdmin } from './util/api'
 import { GraphQLClient } from './util/GraphQlClient'
-import { ensureLoggedInOrCreateTestUser, getGlobalSettings } from './util/helpers'
+import { ensureSignedInOrCreateTestUser, getGlobalSettings } from './util/helpers'
 import { getTestTools } from './util/init'
 import { TestResourceManager } from './util/TestResourceManager'
 
@@ -54,7 +54,7 @@ describe('Code graph regression test suite', () => {
         outerResourceManager.add(
             'User',
             testUsername,
-            await ensureLoggedInOrCreateTestUser(driver, gqlClient, {
+            await ensureSignedInOrCreateTestUser(driver, gqlClient, {
                 username: testUsername,
                 deleteIfExists: true,
                 ...config,

--- a/client/web/src/regression/core.test.ts
+++ b/client/web/src/regression/core.test.ts
@@ -13,7 +13,7 @@ import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing
 import { getUser, setTosAccepted } from './util/api'
 import { GraphQLClient, createGraphQLClient } from './util/GraphQlClient'
 import {
-    ensureLoggedInOrCreateTestUser,
+    ensureSignedInOrCreateTestUser,
     // getGlobalSettings
 } from './util/helpers'
 import { getTestTools } from './util/init'
@@ -44,7 +44,7 @@ describe('Core functionality regression test suite', () => {
         resourceManager.add(
             'User',
             testUsername,
-            await ensureLoggedInOrCreateTestUser(driver, gqlClient, {
+            await ensureSignedInOrCreateTestUser(driver, gqlClient, {
                 username: testUsername,
                 deleteIfExists: true,
                 ...config,

--- a/client/web/src/regression/util/helpers.ts
+++ b/client/web/src/regression/util/helpers.ts
@@ -65,13 +65,13 @@ export async function ensureLoggedInOrCreateTestUser(
     if (deleteIfExists) {
         await deleteUser(gqlClient, username, false)
     } else {
-        // Attempt to log in first
+        // Attempt to sign in first
         try {
-            await driver.ensureLoggedIn({ username, password: testUserPassword })
+            await driver.ensureSignedIn({ username, password: testUserPassword })
             return userDestructor
         } catch (error) {
             logger.error(
-                `Login failed (error: ${asError(error).message}), will attempt to create user ${JSON.stringify(
+                `Signing in failed (error: ${asError(error).message}), will attempt to create user ${JSON.stringify(
                     username
                 )}`
             )
@@ -79,7 +79,7 @@ export async function ensureLoggedInOrCreateTestUser(
     }
 
     await createTestUser(driver, gqlClient, { username, testUserPassword })
-    await driver.ensureLoggedIn({ username, password: testUserPassword })
+    await driver.ensureSignedIn({ username, password: testUserPassword })
     return userDestructor
 }
 

--- a/client/web/src/regression/util/helpers.ts
+++ b/client/web/src/regression/util/helpers.ts
@@ -44,7 +44,7 @@ import { ResourceDestructor } from './TestResourceManager'
 /**
  * Create the user with the specified password. Returns a destructor that destroys the test user. Assumes basic auth.
  */
-export async function ensureLoggedInOrCreateTestUser(
+export async function ensureSignedInOrCreateTestUser(
     driver: Driver,
     gqlClient: GraphQLClient,
     {

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -331,7 +331,7 @@ End-to-end tests need to set up all backend and session state needed for the tes
 This includes signing the user in, setting up external services and syncing repositories.
 Setup should be idempotent, so that tests can be run multiple times without failure or expensive re-setups.
 Prefer using the API for setup over clicking through the UI, because it is less likely to change and faster.
-The [test driver](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/shared/src/testing/driver.ts#L129:17) has some convenience methods for common tasks, e.g. `driver.ensureExternalService()` and `driver.ensureLoggedIn()`.
+The [test driver](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/shared/src/testing/driver.ts#L129:17) has some convenience methods for common tasks, e.g. `driver.ensureExternalService()` and `driver.ensureSignedIn()`.
 
 ### Writing browser-based tests
 


### PR DESCRIPTION
In the top nav, and also in a few other places, including in test method names (just to reinforce that we prefer "sign in").

See ["sign in" in our style guide](https://handbook.sourcegraph.com/company-info-and-process/communication/content_guidelines/terminology_guidelines/#term-usage) for more information.




## Test plan

Wording change only.

## App preview:

- [Web](https://sg-web-sqs-sign-in-wording.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
