### PR TITLE
[SG-42792] Migration from `shema.ts` type usage to `graphql-operations - client/web/src/enterprise/<searchContexts, user>`

### DIFF
--- a/client/search/src/backend.ts
+++ b/client/search/src/backend.ts
@@ -51,11 +51,11 @@ const searchContextFragment = gql`
         viewerCanManage
         query
         repositories {
-            ...SearchContextRepositoryRevisisonsFields
+            ...SearchContextRepositoryRevisionsFields
         }
     }
 
-    fragment SearchContextRepositoryRevisisonsFields on SearchContextRepositoryRevisions {
+    fragment SearchContextRepositoryRevisionsFields on SearchContextRepositoryRevisions {
         repository {
             name
         }

--- a/client/web/src/enterprise/searchContexts/DeleteSearchContextModal.story.tsx
+++ b/client/web/src/enterprise/searchContexts/DeleteSearchContextModal.story.tsx
@@ -2,7 +2,7 @@ import { DecoratorFn, Meta, Story } from '@storybook/react'
 import { NEVER } from 'rxjs'
 import sinon from 'sinon'
 
-import { ISearchContext } from '@sourcegraph/shared/src/schema'
+import { SearchContextFields } from '@sourcegraph/search'
 import { NOOP_PLATFORM_CONTEXT } from '@sourcegraph/shared/src/testing/searchTestHelpers'
 
 import { WebStory } from '../../components/WebStory'
@@ -12,7 +12,7 @@ import { DeleteSearchContextModal } from './DeleteSearchContextModal'
 const searchContext = {
     __typename: 'SearchContext',
     id: '1',
-} as ISearchContext
+} as SearchContextFields
 
 const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
 

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
@@ -3,11 +3,12 @@ import { subDays } from 'date-fns'
 import { NEVER, Observable, of } from 'rxjs'
 import sinon from 'sinon'
 
-import { IOrg, IRepository, ISearchContext } from '@sourcegraph/shared/src/schema'
+import { SearchContextFields } from '@sourcegraph/search'
 import { NOOP_PLATFORM_CONTEXT } from '@sourcegraph/shared/src/testing/searchTestHelpers'
 
 import { AuthenticatedUser } from '../../auth'
 import { WebStory } from '../../components/WebStory'
+import { OrgAreaOrganizationFields, RepositoryFields } from '../../graphql-operations'
 
 import { SearchContextForm } from './SearchContextForm'
 
@@ -23,7 +24,7 @@ const config: Meta = {
 
 export default config
 
-const onSubmit = (): Observable<ISearchContext> =>
+const onSubmit = (): Observable<SearchContextFields> =>
     of({
         __typename: 'SearchContext',
         id: '1',
@@ -39,7 +40,7 @@ const onSubmit = (): Observable<ISearchContext> =>
         viewerCanManage: true,
     })
 
-const searchContextToEdit: ISearchContext = {
+const searchContextToEdit: SearchContextFields = {
     __typename: 'SearchContext',
     id: '1',
     spec: 'public-ctx',
@@ -53,7 +54,7 @@ const searchContextToEdit: ISearchContext = {
         {
             __typename: 'SearchContextRepositoryRevisions',
             revisions: ['HEAD'],
-            repository: { name: 'github.com/example/example' } as IRepository,
+            repository: { name: 'github.com/example/example' } as RepositoryFields,
         },
     ],
     updatedAt: subDays(new Date(), 1).toISOString(),
@@ -75,7 +76,7 @@ const authUser: AuthenticatedUser = {
         nodes: [
             { id: '0', settingsURL: '#', name: 'ACME', displayName: 'Acme Corp' },
             { id: '1', settingsURL: '#', name: 'BETA', displayName: 'Beta Inc' },
-        ] as IOrg[],
+        ] as OrgAreaOrganizationFields[],
     },
     tags: [],
     viewerCanAdminister: true,

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
@@ -16,7 +16,6 @@ import {
     SearchPatternType,
 } from '@sourcegraph/shared/src/graphql-operations'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
-import { ISearchContextRepositoryRevisionsInput } from '@sourcegraph/shared/src/schema'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import {
@@ -138,7 +137,7 @@ type RepositoriesParseResult =
       }
     | {
           type: 'repositories'
-          repositories: ISearchContextRepositoryRevisionsInput[]
+          repositories: SearchContextRepositoryRevisionsInput[]
       }
 
 export const SearchContextForm: React.FunctionComponent<React.PropsWithChildren<SearchContextFormProps>> = props => {
@@ -234,7 +233,7 @@ export const SearchContextForm: React.FunctionComponent<React.PropsWithChildren<
                         map(repositories => {
                             const repositoryNameToID = new Map(repositories.map(({ id, name }) => [name, id]))
                             const errors: Error[] = []
-                            const validRepositories: ISearchContextRepositoryRevisionsInput[] = []
+                            const validRepositories: SearchContextRepositoryRevisionsInput[] = []
                             for (const { repository, revisions } of config) {
                                 const repositoryID = repositoryNameToID.get(repository)
                                 if (repositoryID) {

--- a/client/web/src/enterprise/searchContexts/SearchContextPage.story.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextPage.story.tsx
@@ -2,7 +2,7 @@ import { DecoratorFn, Meta, Story } from '@storybook/react'
 import { subDays } from 'date-fns'
 import { NEVER, Observable, of, throwError } from 'rxjs'
 
-import { IRepository, ISearchContext, ISearchContextRepositoryRevisions } from '@sourcegraph/shared/src/schema'
+import { SearchContextFields, SearchContextRepositoryRevisionsFields } from '@sourcegraph/search'
 import { NOOP_PLATFORM_CONTEXT } from '@sourcegraph/shared/src/testing/searchTestHelpers'
 
 import { WebStory } from '../../components/WebStory'
@@ -21,13 +21,13 @@ const config: Meta = {
 
 export default config
 
-const repositories: ISearchContextRepositoryRevisions[] = [
+const repositories: SearchContextRepositoryRevisionsFields[] = [
     {
         __typename: 'SearchContextRepositoryRevisions',
         repository: {
             __typename: 'Repository',
             name: 'github.com/example/example',
-        } as IRepository,
+        },
         revisions: ['REVISION1', 'REVISION2'],
     },
     {
@@ -35,12 +35,12 @@ const repositories: ISearchContextRepositoryRevisions[] = [
         repository: {
             __typename: 'Repository',
             name: 'github.com/example/really-really-really-really-really-really-long-name',
-        } as IRepository,
+        },
         revisions: ['REVISION3', 'LONG-LONG-LONG-LONG-LONG-LONG-LONG-LONG-REVISION'],
     },
 ]
 
-const mockContext: ISearchContext = {
+const mockContext: SearchContextFields = {
     __typename: 'SearchContext',
     id: '1',
     spec: 'public-ctx',
@@ -55,9 +55,9 @@ const mockContext: ISearchContext = {
     viewerCanManage: true,
 }
 
-const fetchPublicContext = (): Observable<ISearchContext> => of(mockContext)
+const fetchPublicContext = (): Observable<SearchContextFields> => of(mockContext)
 
-const fetchPrivateContext = (): Observable<ISearchContext> =>
+const fetchPrivateContext = (): Observable<SearchContextFields> =>
     of({
         ...mockContext,
         spec: 'private-ctx',
@@ -66,7 +66,7 @@ const fetchPrivateContext = (): Observable<ISearchContext> =>
         public: false,
     })
 
-const fetchAutoDefinedContext = (): Observable<ISearchContext> =>
+const fetchAutoDefinedContext = (): Observable<SearchContextFields> =>
     of({
         ...mockContext,
         autoDefined: true,

--- a/client/web/src/enterprise/searchContexts/SearchContextPage.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextPage.tsx
@@ -7,7 +7,7 @@ import { RouteComponentProps } from 'react-router'
 import { catchError, startWith } from 'rxjs/operators'
 
 import { asError, isErrorLike, renderMarkdown, pluralize } from '@sourcegraph/common'
-import { SearchContextProps, SearchContextRepositoryRevisisonsFields } from '@sourcegraph/search'
+import { SearchContextProps, SearchContextRepositoryRevisionsFields } from '@sourcegraph/search'
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { VirtualList } from '@sourcegraph/shared/src/components/VirtualList'
@@ -42,7 +42,7 @@ const initialRepositoriesToShow = 15
 const incrementalRepositoriesToShow = 10
 
 const SearchContextRepositories: React.FunctionComponent<
-    React.PropsWithChildren<{ repositories: SearchContextRepositoryRevisisonsFields[] }>
+    React.PropsWithChildren<{ repositories: SearchContextRepositoryRevisionsFields[] }>
 > = ({ repositories }) => {
     const [filterQuery, setFilterQuery] = useState('')
     const debouncedSetFilterQuery = useMemo(() => debounce(value => setFilterQuery(value), 250), [setFilterQuery])
@@ -71,7 +71,7 @@ const SearchContextRepositories: React.FunctionComponent<
     )
 
     const renderRepositoryRevisions = useCallback(
-        (repositoryRevisions: SearchContextRepositoryRevisisonsFields) => (
+        (repositoryRevisions: SearchContextRepositoryRevisionsFields) => (
             <div
                 key={repositoryRevisions.repository.name}
                 className={classNames(styles.searchContextPageRepoRevsRow, 'd-flex')}
@@ -120,7 +120,7 @@ const SearchContextRepositories: React.FunctionComponent<
                         <div className="w-50">Revisions</div>
                     </div>
                     <hr className="mt-2 mb-0" />
-                    <VirtualList<SearchContextRepositoryRevisisonsFields>
+                    <VirtualList<SearchContextRepositoryRevisionsFields>
                         className="mt-2"
                         itemsToShow={repositoriesToShow}
                         onShowMoreItems={onBottomHit}

--- a/client/web/src/enterprise/searchContexts/SearchContextRepositoriesFormArea.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextRepositoriesFormArea.tsx
@@ -6,7 +6,7 @@ import { useHistory } from 'react-router'
 import { Observable } from 'rxjs'
 import { delay, mergeMap, startWith, tap } from 'rxjs/operators'
 
-import { SearchContextRepositoryRevisisonsFields } from '@sourcegraph/search'
+import { SearchContextRepositoryRevisionsFields } from '@sourcegraph/search'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Button, useEventObservable, Alert, Icon } from '@sourcegraph/wildcard'
@@ -76,7 +76,7 @@ const actions: {
 ]
 
 export interface SearchContextRepositoriesFormAreaProps extends ThemeProps, TelemetryProps {
-    repositories: SearchContextRepositoryRevisisonsFields[] | undefined
+    repositories: SearchContextRepositoryRevisionsFields[] | undefined
     validateRepositories: () => Observable<Error[]>
     onChange: (config: string, isInitialValue?: boolean) => void
 }

--- a/client/web/src/enterprise/user/productSubscriptions/BackToAllSubscriptionsLink.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/BackToAllSubscriptionsLink.tsx
@@ -2,11 +2,12 @@ import React from 'react'
 
 import { mdiArrowLeft } from '@mdi/js'
 
-import * as GQL from '@sourcegraph/shared/src/schema'
 import { Button, Link, Icon } from '@sourcegraph/wildcard'
 
+import { UserAreaUserFields } from '../../../graphql-operations'
+
 export const BackToAllSubscriptionsLink: React.FunctionComponent<
-    React.PropsWithChildren<{ user: Pick<GQL.IUser, 'settingsURL'> }>
+    React.PropsWithChildren<{ user: Pick<UserAreaUserFields, 'settingsURL'> }>
 > = ({ user }) => (
     <Button to={`${user.settingsURL!}/subscriptions`} className="mb-3" variant="link" size="sm" as={Link}>
         <Icon aria-hidden={true} svgPath={mdiArrowLeft} /> All subscriptions

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.test.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.test.tsx
@@ -2,8 +2,9 @@ import { act } from '@testing-library/react'
 import { createMemoryHistory } from 'history'
 import { of } from 'rxjs'
 
-import * as GQL from '@sourcegraph/shared/src/schema'
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
+
+import { ProductSubscriptionFieldsOnSubscriptionPage } from '../../../graphql-operations'
 
 import { UserSubscriptionsProductSubscriptionPage } from './UserSubscriptionsProductSubscriptionPage'
 
@@ -15,9 +16,9 @@ describe('UserSubscriptionsProductSubscriptionPage', () => {
                 user={{ settingsURL: '/u' }}
                 match={{ isExact: true, params: { subscriptionUUID: 's' }, path: '/p', url: '/p' }}
                 _queryProductSubscription={() =>
-                    of<GQL.IProductSubscription>({
+                    of<ProductSubscriptionFieldsOnSubscriptionPage>({
                         __typename: 'ProductSubscription',
-                    } as GQL.IProductSubscription)
+                    } as ProductSubscriptionFieldsOnSubscriptionPage)
                 }
                 history={history}
             />,

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
@@ -9,11 +9,11 @@ import { catchError, map, startWith } from 'rxjs/operators'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { asError, createAggregateError, isErrorLike } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/http-client'
-import * as GQL from '@sourcegraph/shared/src/schema'
 import { LoadingSpinner, useObservable, Link, H2 } from '@sourcegraph/wildcard'
 
 import { queryGraphQL } from '../../../backend/graphql'
 import { PageTitle } from '../../../components/PageTitle'
+import { ProductSubscriptionFieldsOnSubscriptionPage, UserAreaUserFields } from '../../../graphql-operations'
 import { SiteAdminAlert } from '../../../site-admin/SiteAdminAlert'
 import { eventLogger } from '../../../tracking/eventLogger'
 
@@ -21,7 +21,7 @@ import { BackToAllSubscriptionsLink } from './BackToAllSubscriptionsLink'
 import { UserProductSubscriptionStatus } from './UserProductSubscriptionStatus'
 
 interface Props extends Pick<RouteComponentProps<{ subscriptionUUID: string }>, 'match'> {
-    user: Pick<GQL.IUser, 'settingsURL'>
+    user: Pick<UserAreaUserFields, 'settingsURL'>
 
     /** For mocking in tests only. */
     _queryProductSubscription?: typeof queryProductSubscription
@@ -94,7 +94,9 @@ export const UserSubscriptionsProductSubscriptionPage: React.FunctionComponent<R
     )
 }
 
-function queryProductSubscription(uuid: string): Observable<GQL.IProductSubscription> {
+function queryProductSubscription(
+    uuid: string
+): Observable<ProductSubscriptionFieldsOnSubscriptionPage> {
     return queryGraphQL(
         gql`
             query ProductSubscription($uuid: String!) {


### PR DESCRIPTION
## Description
Migrate typing using from `schema.ts` to `graphql-oparations`

## Success criteria

1. All imports from `schema.ts` in, the `client/web/entreprise<searchContexts, user`> folders,  are replaced with respective imports from `graphql-operations`.

## Ref
[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/42792)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-42792)

## Test Plan
- Verify that all usage of `schema.ts` types has been migrated to their equivalent typing from `graphql-oparations.ts` file in `client/web` package for the folders: `searchContexts, user`

## App preview:

- [Web](https://sg-web-contractors-sg-42792.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
