### PR TITLE
monitoring: zoekt - have disk i/o metrics use max value (by instance)

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -16851,7 +16851,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100800` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m])`
+Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m]))`
 
 </details>
 
@@ -16878,7 +16878,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100801` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m])`
+Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m]))`
 
 </details>
 
@@ -16905,7 +16905,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100810` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[2m])`
+Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[2m]))`
 
 </details>
 
@@ -16932,7 +16932,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100811` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[2m])`
+Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[2m]))`
 
 </details>
 
@@ -16960,7 +16960,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100820` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_time_seconds_total{instance=~`node-exporter.*`}[2m])) / (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m])))`
+Query: `((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_time_seconds_total{instance=~`node-exporter.*`}[2m]))) / (max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m]))))`
 
 </details>
 
@@ -16988,7 +16988,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100821` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_write_time_seconds_total{instance=~`node-exporter.*`}[2m])) / (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m])))`
+Query: `((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_write_time_seconds_total{instance=~`node-exporter.*`}[2m]))) / (max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m]))))`
 
 </details>
 
@@ -17015,7 +17015,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100830` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[2m])) / (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m])))`
+Query: `((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[2m]))) / (max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m]))))`
 
 </details>
 
@@ -17042,7 +17042,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100831` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `((zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[2m])) / (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m])))`
+Query: `((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[2m]))) / (max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m]))))`
 
 </details>
 
@@ -17069,7 +17069,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100840` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_merged_total{instance=~`node-exporter.*`}[2m])`
+Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_merged_total{instance=~`node-exporter.*`}[2m]))`
 
 </details>
 
@@ -17096,7 +17096,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100841` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_merged_total{instance=~`node-exporter.*`}[2m])`
+Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_merged_total{instance=~`node-exporter.*`}[2m]))`
 
 </details>
 
@@ -17124,7 +17124,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100850` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_io_time_weighted_seconds_total{instance=~`node-exporter.*`}[2m])`
+Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_io_time_weighted_seconds_total{instance=~`node-exporter.*`}[2m]))`
 
 </details>
 

--- a/monitoring/definitions/zoekt.go
+++ b/monitoring/definitions/zoekt.go
@@ -929,7 +929,7 @@ func Zoekt() *monitoring.Dashboard {
 						{
 							Name:        "data_disk_reads_sec",
 							Description: "data disk read request rate over 2m (per instance)",
-							Query:       fmt.Sprintf("%s rate(node_disk_reads_completed_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("max by (instance) (%s rate(node_disk_reads_completed_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.ReadsPerSecond).
@@ -949,7 +949,7 @@ func Zoekt() *monitoring.Dashboard {
 						{
 							Name:        "data_disk_writes_sec",
 							Description: "data disk write request rate over 2m (per instance)",
-							Query:       fmt.Sprintf("%s rate(node_disk_writes_completed_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("max by (instance) (%s rate(node_disk_writes_completed_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.WritesPerSecond).
@@ -970,7 +970,7 @@ func Zoekt() *monitoring.Dashboard {
 						{
 							Name:        "data_disk_read_throughput",
 							Description: "data disk read throughput over 2m (per instance)",
-							Query:       fmt.Sprintf("%s rate(node_disk_read_bytes_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("max by (instance) (%s rate(node_disk_read_bytes_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.BytesPerSecond).
@@ -989,7 +989,7 @@ func Zoekt() *monitoring.Dashboard {
 						{
 							Name:        "data_disk_write_throughput",
 							Description: "data disk write throughput over 2m (per instance)",
-							Query:       fmt.Sprintf("%s rate(node_disk_written_bytes_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("max by (instance) (%s rate(node_disk_written_bytes_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.BytesPerSecond).
@@ -1012,8 +1012,8 @@ func Zoekt() *monitoring.Dashboard {
 							Description: "data disk average read duration over 2m (per instance)",
 
 							Query: fmt.Sprintf("((%s) / (%s))",
-								fmt.Sprintf("%s rate(node_disk_read_time_seconds_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
-								fmt.Sprintf("%s rate(node_disk_reads_completed_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("max by (instance) (%s rate(node_disk_read_time_seconds_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("max by (instance) (%s rate(node_disk_reads_completed_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
 							),
 							NoAlert: true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -1036,8 +1036,8 @@ func Zoekt() *monitoring.Dashboard {
 							Description: "data disk average write duration over 2m (per instance)",
 
 							Query: fmt.Sprintf("((%s) / (%s))",
-								fmt.Sprintf("%s rate(node_disk_write_time_seconds_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
-								fmt.Sprintf("%s rate(node_disk_writes_completed_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("max by (instance) (%s rate(node_disk_write_time_seconds_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("max by (instance) (%s rate(node_disk_writes_completed_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
 							),
 							NoAlert: true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -1061,8 +1061,8 @@ func Zoekt() *monitoring.Dashboard {
 							Name:        "data_disk_read_request_size",
 							Description: "data disk average read request size over 2m (per instance)",
 							Query: fmt.Sprintf("((%s) / (%s))",
-								fmt.Sprintf("%s rate(node_disk_read_bytes_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
-								fmt.Sprintf("%s rate(node_disk_reads_completed_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("max by (instance) (%s rate(node_disk_read_bytes_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("max by (instance) (%s rate(node_disk_reads_completed_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
 							),
 							NoAlert: true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -1083,8 +1083,8 @@ func Zoekt() *monitoring.Dashboard {
 							Name:        "data_disk_write_request_size",
 							Description: "data disk average write request size over 2m (per instance)",
 							Query: fmt.Sprintf("((%s) / (%s))",
-								fmt.Sprintf("%s rate(node_disk_written_bytes_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
-								fmt.Sprintf("%s rate(node_disk_writes_completed_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("max by (instance) (%s rate(node_disk_written_bytes_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("max by (instance) (%s rate(node_disk_writes_completed_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
 							),
 							NoAlert: true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -1106,7 +1106,7 @@ func Zoekt() *monitoring.Dashboard {
 						{
 							Name:        "data_disk_reads_merged_sec",
 							Description: "data disk merged read request rate over 2m (per instance)",
-							Query:       fmt.Sprintf("%s rate(node_disk_reads_merged_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("max by (instance) (%s rate(node_disk_reads_merged_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.RequestsPerSecond).
@@ -1125,7 +1125,7 @@ func Zoekt() *monitoring.Dashboard {
 						{
 							Name:        "data_disk_writes_merged_sec",
 							Description: "data disk merged writes request rate over 2m (per instance)",
-							Query:       fmt.Sprintf("%s rate(node_disk_writes_merged_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("max by (instance) (%s rate(node_disk_writes_merged_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.RequestsPerSecond).
@@ -1147,7 +1147,7 @@ func Zoekt() *monitoring.Dashboard {
 
 							Name:        "data_disk_average_queue_size",
 							Description: "data disk average queue size over 2m (per instance)",
-							Query:       fmt.Sprintf("%s rate(node_disk_io_time_weighted_seconds_total{instance=~`%s`}[2m])", joinOnMountInfo, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("max by (instance) (%s rate(node_disk_io_time_weighted_seconds_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit("req").


### PR DESCRIPTION
Right now on k8s.sgdev.org, zoekt's disk i/o metrics can have two different colored time series for the same "instance". See that there are multiple entries for "instance 0" in the following screenshot. :

![Screen Shot 2022-10-24 at 8 47 01 AM](https://user-images.githubusercontent.com/9022011/197570305-5ac5cc56-452e-4e75-88e2-eda53f6f6332.png)


This can occur when a zoekt instance is rescheduled onto a different node that has its disk attached under a different device name. (look at the labels in the time series in the following screenshot)

![Screen Shot 2022-10-24 at 8 47 47 AM](https://user-images.githubusercontent.com/9022011/197570894-49c85e30-c15c-4687-888d-1b63822ff5b9.png)

---

This PR resolves this issue by adjusting the disk i/o queries to only display the `max by (instance)` of all the distinct time series that are fed into it. Using `max` doesn't swallow any data here: a pod can only be scheduled on a single node at any given time. Once a pod is rescheduled, all of it's disk i/o metrics from the old node / device will no longer have any observations - only the new node / device will generate new observations. 

Here is a screenshot of what the new dashboards look like (from the same time interval). Note that "instance 0" now only has one entry on all of the dashboards.

![Screen Shot 2022-10-24 at 8 48 42 AM](https://user-images.githubusercontent.com/9022011/197571829-13afa0df-bc2b-4612-a1d9-d29470e698ea.png)

## Test plan

Used `sg start monitoring` while connected to k8s.sgdev.org's Prometheus instance.
