### PR TITLE
WIP: add hasbeenactive

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1352,6 +1352,11 @@ type Query {
         Returns users who have NOT been active since a given point in time.
         """
         inactiveSince: DateTime
+
+        """
+        Returns users that have at any point in time been active.
+        """
+        hasBeenActive: Bool
     ): UserConnection!
     """
     Looks up an organization by name.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1354,9 +1354,9 @@ type Query {
         inactiveSince: DateTime
 
         """
-        Returns users that have not been active at any point in time. 
+        Returns users that have not been active at any point in time. Has no effect if inactiveSince is unset.
         """
-        includeNeverActive: Bool
+        includeNeverActive: Boolean
     ): UserConnection!
     """
     Looks up an organization by name.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1356,7 +1356,7 @@ type Query {
         """
         Returns users that have not been active at any point in time. 
         """
-        neverActive: Bool
+        includeNeverActive: Bool
     ): UserConnection!
     """
     Looks up an organization by name.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1354,9 +1354,9 @@ type Query {
         inactiveSince: DateTime
 
         """
-        Returns users that have at any point in time been active.
+        Returns users that have not been active at any point in time. 
         """
-        hasBeenActive: Bool
+        neverActive: Bool
     ): UserConnection!
     """
     Looks up an organization by name.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1354,9 +1354,9 @@ type Query {
         inactiveSince: DateTime
 
         """
-        Returns users that have not been active at any point in time. Has no effect if inactiveSince is unset.
+        Returns users that have a null lastActiveUsage. Has no effect if inactiveSince is unset.
         """
-        includeNeverActive: Boolean
+        includeNullActive: Boolean
     ): UserConnection!
     """
     Looks up an organization by name.

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -21,6 +21,7 @@ type usersArgs struct {
 	Tag           *string
 	ActivePeriod  *string
 	InactiveSince *gqlutil.DateTime
+	HasBeenActive *bool
 }
 
 func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
@@ -33,6 +34,9 @@ func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
 	}
 	if args.InactiveSince != nil {
 		opt.InactiveSince = args.InactiveSince.Time
+	}
+	if args.HasBeenActive != nil {
+		opt.HasBeenActive = *args.HasBeenActive
 	}
 	args.ConnectionArgs.Set(&opt.LimitOffset)
 	return &userConnectionResolver{db: r.db, opt: opt, activePeriod: args.ActivePeriod}

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -17,11 +17,11 @@ import (
 
 type usersArgs struct {
 	graphqlutil.ConnectionArgs
-	Query         *string
-	Tag           *string
-	ActivePeriod  *string
-	InactiveSince *gqlutil.DateTime
-	NeverActive   *bool
+	Query              *string
+	Tag                *string
+	ActivePeriod       *string
+	InactiveSince      *gqlutil.DateTime
+	IncludeNeverActive *bool
 }
 
 func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
@@ -35,8 +35,8 @@ func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
 	if args.InactiveSince != nil {
 		opt.InactiveSince = args.InactiveSince.Time
 	}
-	if args.NeverActive != nil {
-		opt.NeverActive = *args.NeverActive
+	if args.IncludeNeverActive != nil {
+		opt.IncludeNeverActive = *args.IncludeNeverActive
 	}
 	args.ConnectionArgs.Set(&opt.LimitOffset)
 	return &userConnectionResolver{db: r.db, opt: opt, activePeriod: args.ActivePeriod}

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -21,7 +21,7 @@ type usersArgs struct {
 	Tag           *string
 	ActivePeriod  *string
 	InactiveSince *gqlutil.DateTime
-	HasBeenActive *bool
+	NeverActive   *bool
 }
 
 func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
@@ -35,8 +35,8 @@ func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
 	if args.InactiveSince != nil {
 		opt.InactiveSince = args.InactiveSince.Time
 	}
-	if args.HasBeenActive != nil {
-		opt.HasBeenActive = *args.HasBeenActive
+	if args.NeverActive != nil {
+		opt.NeverActive = *args.NeverActive
 	}
 	args.ConnectionArgs.Set(&opt.LimitOffset)
 	return &userConnectionResolver{db: r.db, opt: opt, activePeriod: args.ActivePeriod}

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -17,11 +17,11 @@ import (
 
 type usersArgs struct {
 	graphqlutil.ConnectionArgs
-	Query              *string
-	Tag                *string
-	ActivePeriod       *string
-	InactiveSince      *gqlutil.DateTime
-	IncludeNeverActive *bool
+	Query             *string
+	Tag               *string
+	ActivePeriod      *string
+	InactiveSince     *gqlutil.DateTime
+	IncludeNullActive *bool
 }
 
 func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
@@ -35,8 +35,8 @@ func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
 	if args.InactiveSince != nil {
 		opt.InactiveSince = args.InactiveSince.Time
 	}
-	if args.IncludeNeverActive != nil {
-		opt.IncludeNeverActive = *args.IncludeNeverActive
+	if args.IncludeNullActive != nil {
+		opt.IncludeNullActive = *args.IncludeNullActive
 	}
 	args.ConnectionArgs.Set(&opt.LimitOffset)
 	return &userConnectionResolver{db: r.db, opt: opt, activePeriod: args.ActivePeriod}

--- a/cmd/frontend/graphqlbackend/users_test.go
+++ b/cmd/frontend/graphqlbackend/users_test.go
@@ -214,8 +214,8 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 	ctx = actor.WithInternalActor(ctx)
 
 	query := `
-		query InactiveUsers($since: DateTime, $includeNeverActive: Bool) {
-			users(inactiveSince: $since, neverActive: $includeNeverActive) {
+		query InactiveUsers($since: DateTime, $includeNeverActive: Boolean) {
+			users(inactiveSince: $since, includeNeverActive: $includeNeverActive) {
 				nodes { username }
 				totalCount
 			}

--- a/cmd/frontend/graphqlbackend/users_test.go
+++ b/cmd/frontend/graphqlbackend/users_test.go
@@ -186,7 +186,7 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 		lastEventAt time.Time
 	}{
 		{user: database.NewUser{Username: "user-1", Password: "user-1"}, lastEventAt: daysAgo(5)},
-		{user: database.NewUser{Username: "user-2", Password: "user-2"}, lastEventAt: daysAgo(3)},
+		{user: database.NewUser{Username: "user-2", Password: "user-2"}, lastEventAt: daysAgo(4)},
 		{user: database.NewUser{Username: "user-3", Password: "user-3"}, lastEventAt: daysAgo(1)},
 		{user: database.NewUser{Username: "user-4", Password: "user-4"}, lastEventAt: daysAgo(0)},
 		{user: database.NewUser{Username: "user-5", Password: "user-5"}},
@@ -279,11 +279,10 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 			Variables: map[string]any{"since": daysAgo(3).Format(time.RFC3339Nano), "includeNeverActive": true},
 			ExpectedResult: `
 			{"users": { "nodes": [
+				{ "username": "user-1" },
 				{ "username": "user-2" },
-				{ "username": "user-3" },
-				{ "username": "user-4" },
 				{ "username": "user-5" }
-				], "totalCount": 4 }}
+				], "totalCount": 3 }}
 			`,
 		},
 		{
@@ -293,10 +292,23 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 			Variables: map[string]any{"since": daysAgo(3).Format(time.RFC3339Nano), "includeNeverActive": false},
 			ExpectedResult: `
 			{"users": { "nodes": [
+				{ "username": "user-1" },
+				{ "username": "user-2" }
+				], "totalCount": 2 }}
+			`,
+		},
+		{
+			Context:   ctx,
+			Schema:    schema,
+			Query:     query,
+			Variables: map[string]any{"since": daysAgo(0).Format(time.RFC3339Nano), "includeNeverActive": true},
+			ExpectedResult: `
+			{"users": { "nodes": [
+				{ "username": "user-1" },
 				{ "username": "user-2" },
 				{ "username": "user-3" },
-				{ "username": "user-4" }
-				], "totalCount": 3 }}
+				{ "username": "user-5" }
+				], "totalCount": 4 }}
 			`,
 		},
 	})

--- a/cmd/frontend/graphqlbackend/users_test.go
+++ b/cmd/frontend/graphqlbackend/users_test.go
@@ -164,7 +164,7 @@ func TestUsers_InactiveSince(t *testing.T) {
 	})
 }
 
-func TestUsers_IncludeNeverActive(t *testing.T) {
+func TestUsers_IncludeNullActive(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -214,8 +214,8 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 	ctx = actor.WithInternalActor(ctx)
 
 	query := `
-		query InactiveUsers($since: DateTime, $includeNeverActive: Boolean) {
-			users(inactiveSince: $since, includeNeverActive: $includeNeverActive) {
+		query InactiveUsers($since: DateTime, $includeNullActive: Boolean) {
+			users(inactiveSince: $since, includeNullActive: $includeNullActive) {
 				nodes { username }
 				totalCount
 			}
@@ -227,8 +227,8 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 			Context: ctx,
 			Schema:  schema,
 			Query:   query,
-			// This returns all users because includeNeverActive only has an effect if inactiveSince is set.
-			Variables: map[string]any{"includeNeverActive": true},
+			// This returns all users because IncludeNullActive only has an effect if inactiveSince is set.
+			Variables: map[string]any{"includeNullActive": true},
 			ExpectedResult: `
 			{"users": { "nodes": [
 				{ "username": "user-1" },
@@ -243,8 +243,8 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 			Context: ctx,
 			Schema:  schema,
 			Query:   query,
-			// This returns all users because includeNeverActive only has an effect if inactiveSince is set.
-			Variables: map[string]any{"includeNeverActive": false},
+			// This returns all users because IncludeNullActive only has an effect if inactiveSince is set.
+			Variables: map[string]any{"includeNullActive": false},
 			// Should return all users, because `inactiveSince` is not set
 			ExpectedResult: `
 			{"users": { "nodes": [
@@ -276,7 +276,7 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 			Context:   ctx,
 			Schema:    schema,
 			Query:     query,
-			Variables: map[string]any{"since": daysAgo(3).Format(time.RFC3339Nano), "includeNeverActive": true},
+			Variables: map[string]any{"since": daysAgo(3).Format(time.RFC3339Nano), "includeNullActive": true},
 			ExpectedResult: `
 			{"users": { "nodes": [
 				{ "username": "user-1" },
@@ -289,7 +289,7 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 			Context:   ctx,
 			Schema:    schema,
 			Query:     query,
-			Variables: map[string]any{"since": daysAgo(3).Format(time.RFC3339Nano), "includeNeverActive": false},
+			Variables: map[string]any{"since": daysAgo(3).Format(time.RFC3339Nano), "includeNullActive": false},
 			ExpectedResult: `
 			{"users": { "nodes": [
 				{ "username": "user-1" },
@@ -301,7 +301,7 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 			Context:   ctx,
 			Schema:    schema,
 			Query:     query,
-			Variables: map[string]any{"since": daysAgo(0).Format(time.RFC3339Nano), "includeNeverActive": true},
+			Variables: map[string]any{"since": daysAgo(0).Format(time.RFC3339Nano), "includeNullActive": true},
 			ExpectedResult: `
 			{"users": { "nodes": [
 				{ "username": "user-1" },

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -808,8 +808,8 @@ type UsersListOptions struct {
 	// InactiveSince filters out users that have had an eventlog entry with a
 	// `timestamp` greater-than-or-equal to the given timestamp.
 	InactiveSince time.Time
-	// HasBeenActive filters out users that have never had an eventlog entry if true.
-	HasBeenActive bool
+	// NeverActive filters out users that have never had an eventlog entry if true.
+	NeverActive bool
 
 	ExcludeSourcegraphAdmins bool // filter out users with a known Sourcegraph admin username
 
@@ -873,8 +873,8 @@ const listUsersInactiveCond = `
 ))
 `
 
-const listUsersHasBeenActiveCond = `
-(EXISTS (
+const listUsersNeverActiveCond = `
+(NOT EXISTS (
 	SELECT 1 FROM event_logs
 	WHERE event_logs.user_id = u.id
 ))
@@ -907,8 +907,8 @@ func (*userStore) listSQL(opt UsersListOptions) (conds []*sqlf.Query) {
 		conds = append(conds, sqlf.Sprintf(listUsersInactiveCond, opt.InactiveSince))
 	}
 
-	if opt.HasBeenActive {
-		conds = append(conds, sqlf.Sprintf(listUsersHasBeenActiveCond))
+	if opt.NeverActive {
+		conds = append(conds, sqlf.Sprintf(listUsersNeverActiveCond))
 	}
 
 	// NOTE: This is a hack which should be replaced when we have proper user types.

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -916,9 +916,9 @@ func (*userStore) listSQL(opt UsersListOptions) (conds []*sqlf.Query) {
 
 	if !opt.InactiveSince.IsZero() {
 		if opt.IncludeNeverActive {
-			conds = append(conds, sqlf.Sprintf(listUsersInactiveWithNeverActiveCond))
+			conds = append(conds, sqlf.Sprintf(listUsersInactiveWithNeverActiveCond, opt.InactiveSince))
 		} else {
-			conds = append(conds, sqlf.Sprintf(listUsersInactiveWithoutNeverActiveCond))
+			conds = append(conds, sqlf.Sprintf(listUsersInactiveWithoutNeverActiveCond, opt.InactiveSince))
 		}
 	}
 

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -808,8 +808,10 @@ type UsersListOptions struct {
 	// InactiveSince filters out users that have had an eventlog entry with a
 	// `timestamp` greater-than-or-equal to the given timestamp, excluding users who have never been active.
 	InactiveSince time.Time
-	// IncludeNeverActive includes users that have never had an eventlog entry if true.
-	IncludeNeverActive bool
+	// IncludeNullActive includes users that have no eventlog entry if true. Users may be in this state
+	// due to never having been active, or all events tagged to them having expires
+	// event_logs only persist for 93 days
+	IncludeNullActive bool
 
 	ExcludeSourcegraphAdmins bool // filter out users with a known Sourcegraph admin username
 
@@ -915,7 +917,7 @@ func (*userStore) listSQL(opt UsersListOptions) (conds []*sqlf.Query) {
 	}
 
 	if !opt.InactiveSince.IsZero() {
-		if opt.IncludeNeverActive {
+		if opt.IncludeNullActive {
 			conds = append(conds, sqlf.Sprintf(listUsersInactiveWithNeverActiveCond, opt.InactiveSince))
 		} else {
 			conds = append(conds, sqlf.Sprintf(listUsersInactiveWithoutNeverActiveCond, opt.InactiveSince))


### PR DESCRIPTION
This PR is to add a sorting flag for returning users that have a null value for `lastActiveTime` or not. This user state may be caused by a user having never been active on the Sourcegraph instance, or having not been active for 93 days (this is the length of time entries in the `event_logs` table are persisted in the database)

## Test plan
Unit Tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
