### PR TITLE
Fuzzy finder: fix auto-focus bug for Firefox

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -453,7 +453,6 @@ const ScopeSelect: React.FunctionComponent<ScopeSelectProps> = ({
         isCustomStyle={true}
         id="fuzzy-scope"
         value={scope}
-        onFocus={() => focusFuzzyInput()}
         selectSize="sm"
         className={styles.fuzzyScopeSelector}
         disabled={isScopeToggleDisabled}
@@ -462,6 +461,7 @@ const ScopeSelect: React.FunctionComponent<ScopeSelectProps> = ({
                 case 'everywhere':
                 case 'repository':
                     setScope(value.target.value)
+                    focusFuzzyInput()
             }
         }}
     >


### PR DESCRIPTION
Previously, it was not possible to use the mouse to select the search scope because the text input would always get focused. Now, we only re-focus on the input after selecting an item instead of when the select gets the focus.



## Test plan

Manually tested this in Firefox, Chrome, and Safari.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-ff-disable-select-focus.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
