### PR TITLE
FE scale audit: Implement backend paging in org membership view

### DIFF
--- a/client/web/src/integration/org.test.ts
+++ b/client/web/src/integration/org.test.ts
@@ -187,7 +187,7 @@ describe('Organizations', () => {
                     Organization: () => ({
                         organization: testOrg,
                     }),
-                    OrganizationMembers: () => ({
+                    OrganizationSettingsMembers: () => ({
                         node: {
                             __typename: 'Org',
                             viewerCanAdminister: true,
@@ -225,12 +225,17 @@ describe('Organizations', () => {
                 // Override for the fetch post-removal
                 testContext.overrideGraphQL({
                     ...graphQlResults,
-                    OrganizationMembers: () => ({
+                    OrganizationSettingsMembers: () => ({
                         node: {
+                            __typename: 'Org',
                             viewerCanAdminister: true,
                             members: {
                                 totalCount: 1,
                                 nodes: [testMember2],
+                            },
+                            pageInfo: {
+                                endCursor: null,
+                                hasNextPage: false,
                             },
                         },
                     }),

--- a/client/web/src/integration/org.test.ts
+++ b/client/web/src/integration/org.test.ts
@@ -189,10 +189,15 @@ describe('Organizations', () => {
                     }),
                     OrganizationMembers: () => ({
                         node: {
+                            __typename: 'Org',
                             viewerCanAdminister: true,
                             members: {
                                 totalCount: 2,
                                 nodes: [testMember, testMember2],
+                                pageInfo: {
+                                    endCursor: null,
+                                    hasNextPage: false,
+                                },
                             },
                         },
                     }),

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -328,7 +328,11 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                                         className="mr-1"
                                         to={
                                             '/sign-in?returnTo=' +
-                                            encodeURI(history.location.pathname + history.location.search + history.location.hash)
+                                            encodeURI(
+                                                history.location.pathname +
+                                                    history.location.search +
+                                                    history.location.hash
+                                            )
                                         }
                                         variant="secondary"
                                         outline={true}

--- a/client/web/src/org/settings/members-v1/OrgSettingsMembersPage.tsx
+++ b/client/web/src/org/settings/members-v1/OrgSettingsMembersPage.tsx
@@ -256,7 +256,6 @@ export class OrgSettingsMembersPage extends React.PureComponent<Props, State> {
                         updates={this.userUpdates}
                         history={this.props.history}
                         location={this.props.location}
-                        useURLQuery={false}
                     />
                 </Container>
             </div>
@@ -283,6 +282,7 @@ export class OrgSettingsMembersPage extends React.PureComponent<Props, State> {
                 query OrganizationSettingsMembers($id: ID!, $first: Int!, $after: String, $query: String) {
                     node(id: $id) {
                         ... on Org {
+                            __typename
                             viewerCanAdminister
                             members(query: $query, first: $first, after: $after) {
                                 nodes {
@@ -315,7 +315,7 @@ export class OrgSettingsMembersPage extends React.PureComponent<Props, State> {
                 }
                 const org = data.node
                 if (org.__typename !== 'Org') {
-                    throw new Error('Unepxected node type')
+                    throw new Error('Unexpected node type')
                 }
                 if (!org.members) {
                     this.setState({ viewerCanAdminister: false, hasOneMember: false })

--- a/client/web/src/org/settings/members-v1/OrgSettingsMembersPage.tsx
+++ b/client/web/src/org/settings/members-v1/OrgSettingsMembersPage.tsx
@@ -12,12 +12,13 @@ import { gql } from '@sourcegraph/http-client'
 import { Container, PageHeader, Button, Link, Alert } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../auth'
-import { queryGraphQL } from '../../../backend/graphql'
+import { requestGraphQL } from '../../../backend/graphql'
 import { FilteredConnection } from '../../../components/FilteredConnection'
 import { PageTitle } from '../../../components/PageTitle'
 import {
     OrgAreaOrganizationFields,
-    OrganizationMembersResult,
+    OrganizationSettingsMembersResult,
+    OrganizationSettingsMembersVariables,
     OrganizationMemberNode,
 } from '../../../graphql-operations'
 import { eventLogger } from '../../../tracking/eventLogger'
@@ -51,7 +52,7 @@ interface HasOneMember {
 
 type OrgAreaOrganization = OrgAreaOrganizationFields & HasOneMember
 
-type OrgNode = Extract<OrganizationMembersResult['node'], { __typename?: 'Org' }>
+type OrgNode = Extract<OrganizationSettingsMembersResult['node'], { __typename?: 'Org' }>
 
 interface UserNodeState {
     /** Undefined means in progress, null means done or not started. */
@@ -252,11 +253,10 @@ export class OrgSettingsMembersPage extends React.PureComponent<Props, State> {
                         queryConnection={this.fetchOrgMembers}
                         nodeComponent={UserNode}
                         nodeComponentProps={nodeProps}
-                        noShowMore={true}
-                        hideSearch={true}
                         updates={this.userUpdates}
                         history={this.props.history}
                         location={this.props.location}
+                        useURLQuery={false}
                     />
                 </Container>
             </div>
@@ -273,14 +273,18 @@ export class OrgSettingsMembersPage extends React.PureComponent<Props, State> {
 
     private onDidUpdateOrganizationMembers = (): void => this.userUpdates.next()
 
-    private fetchOrgMembers = (): Observable<OrgNode['members']> =>
-        queryGraphQL(
+    private fetchOrgMembers = (args: {
+        first?: number
+        after?: string | null
+        query?: string
+    }): Observable<OrgNode['members']> =>
+        requestGraphQL<OrganizationSettingsMembersResult, OrganizationSettingsMembersVariables>(
             gql`
-                query OrganizationMembers($id: ID!) {
+                query OrganizationSettingsMembers($id: ID!, $first: Int!, $after: String, $query: String) {
                     node(id: $id) {
                         ... on Org {
                             viewerCanAdminister
-                            members {
+                            members(query: $query, first: $first, after: $after) {
                                 nodes {
                                     ...OrganizationMemberNode
                                 }
@@ -297,14 +301,22 @@ export class OrgSettingsMembersPage extends React.PureComponent<Props, State> {
                     avatarURL
                 }
             `,
-            { id: this.props.org.id }
+            {
+                id: this.props.org.id,
+                query: args.query ?? null,
+                first: args.first ?? 2,
+                after: args.after ?? null,
+            }
         ).pipe(
             map(({ data, errors }) => {
                 if (!data || !data.node) {
                     this.setState({ viewerCanAdminister: false, hasOneMember: false })
                     throw createAggregateError(errors)
                 }
-                const org = data.node as OrgNode
+                const org = data.node
+                if (org.__typename !== 'Org') {
+                    throw new Error('Unepxected node type')
+                }
                 if (!org.members) {
                     this.setState({ viewerCanAdminister: false, hasOneMember: false })
                     throw createAggregateError(errors)

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -3,6 +3,7 @@ package graphqlbackend
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -140,28 +141,43 @@ func (o *OrgResolver) SettingsURL() *string { return strptr(o.URL() + "/settings
 
 func (o *OrgResolver) CreatedAt() gqlutil.DateTime { return gqlutil.DateTime{Time: o.org.CreatedAt} }
 
-func (o *OrgResolver) Members(ctx context.Context) (*staticUserConnectionResolver, error) {
-	// 🚨 SECURITY: Only org members can list other org members.
-	if err := auth.CheckOrgAccessOrSiteAdmin(ctx, o.db, o.org.ID); err != nil {
-		if err == auth.ErrNotAnOrgMember {
-			return nil, errors.New("must be a member of this organization to view members")
-		}
-		return nil, err
+type MembersConnectionArgs struct {
+	First *int32
+	After *string
+	Query *string
+}
+
+func (o *OrgResolver) Members(ctx context.Context, args *MembersConnectionArgs) (*userConnectionResolver, error) {
+	// For backward compatibility, the query needs to work with no pagination
+	limitOffset := &database.LimitOffset{
+		Limit: 1000,
 	}
 
-	memberships, err := o.db.OrgMembers().GetByOrgID(ctx, o.org.ID)
-	if err != nil {
-		return nil, err
+	if args.First != nil {
+		limitOffset.Limit = int(*args.First)
 	}
-	users := make([]*types.User, len(memberships))
-	for i, membership := range memberships {
-		user, err := o.db.Users().GetByID(ctx, membership.UserID)
+
+	if args.After != nil {
+		cursor, err := strconv.ParseInt(*args.After, 10, 32)
 		if err != nil {
 			return nil, err
 		}
-		users[i] = user
+		limitOffset.Offset = int(cursor)
 	}
-	return &staticUserConnectionResolver{db: o.db, users: users}, nil
+
+	query := ""
+	if args.Query != nil {
+		query = *args.Query
+	}
+
+	return &userConnectionResolver{
+		db: o.db,
+		opt: database.UsersListOptions{
+			Query:       query,
+			OrgId:       &o.org.ID,
+			LimitOffset: limitOffset,
+		},
+	}, nil
 }
 
 func (o *OrgResolver) settingsSubject() api.SettingsSubject {

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -170,6 +170,10 @@ func (o *OrgResolver) Members(ctx context.Context, args *MembersConnectionArgs) 
 		query = *args.Query
 	}
 
+	if err := checkMembersAccess(ctx, o.db, o.org.ID); err != nil {
+		return nil, err
+	}
+
 	return &userConnectionResolver{
 		db: o.db,
 		opt: database.UsersListOptions{

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -174,7 +174,7 @@ func (o *OrgResolver) Members(ctx context.Context, args *MembersConnectionArgs) 
 		db: o.db,
 		opt: database.UsersListOptions{
 			Query:       query,
-			OrgId:       &o.org.ID,
+			OrgID:       o.org.ID,
 			LimitOffset: limitOffset,
 		},
 	}, nil

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -148,6 +148,11 @@ type MembersConnectionArgs struct {
 }
 
 func (o *OrgResolver) Members(ctx context.Context, args *MembersConnectionArgs) (*userConnectionResolver, error) {
+	// 🚨 SECURITY: Only org members can list other org members.
+	if err := checkMembersAccess(ctx, o.db, o.org.ID); err != nil {
+		return nil, err
+	}
+
 	// For backward compatibility, the query needs to work with no pagination
 	limitOffset := &database.LimitOffset{
 		Limit: 1000,
@@ -168,10 +173,6 @@ func (o *OrgResolver) Members(ctx context.Context, args *MembersConnectionArgs) 
 	query := ""
 	if args.Query != nil {
 		query = *args.Query
-	}
-
-	if err := checkMembersAccess(ctx, o.db, o.org.ID); err != nil {
-		return nil, err
 	}
 
 	return &userConnectionResolver{

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -5499,7 +5499,20 @@ type Org implements Node & SettingsSubject & Namespace {
     """
     A list of users who are members of this organization.
     """
-    members: UserConnection!
+    members(
+        """
+        Number of users to return after the given cursor.
+        """
+        first: Int
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Return users whose usernames or display names match the query.
+        """
+        query: String
+    ): UserConnection!
     """
     The latest settings for the organization.
     Only organization members and site admins can access this field.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1333,6 +1333,10 @@ type Query {
         """
         first: Int
         """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
         Return users whose usernames or display names match the query.
         """
         query: String

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -144,7 +144,7 @@ func (r *userConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.Pag
 		return graphqlutil.HasNextPage(false), nil
 	}
 
-	if int(totalCount) > after {
+	if totalCount > after {
 		return graphqlutil.NextPageCursor(strconv.Itoa(after)), nil
 	}
 	return graphqlutil.HasNextPage(false), nil

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"sync"
 
@@ -183,13 +182,11 @@ func (r *userConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.Pag
 
 	// We would have had all results when no limit set
 	if r.opt.LimitOffset == nil {
-		fmt.Println("branch 1")
 		return graphqlutil.HasNextPage(false), nil
 	}
 
 	// We got less results than limit, means we've had all results
 	if after < r.opt.Limit {
-		fmt.Println("branch 2")
 		return graphqlutil.HasNextPage(false), nil
 	}
 
@@ -198,15 +195,12 @@ func (r *userConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.Pag
 	// to determine if there are more results than the limit we set.
 	totalCount, err := r.TotalCount(ctx)
 	if err != nil {
-		fmt.Println("branch 3")
 		return nil, err
 	}
 
 	if int(totalCount) > after {
-		fmt.Println("branch 4")
 		return graphqlutil.NextPageCursor(strconv.Itoa(after)), nil
 	}
-	fmt.Println("branch 5")
 	return graphqlutil.HasNextPage(false), nil
 }
 

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -103,12 +103,12 @@ func (r *userConnectionResolver) compute(ctx context.Context) ([]*types.User, in
 func (r *userConnectionResolver) Nodes(ctx context.Context) ([]*UserResolver, error) {
 	// 🚨 SECURITY: Only site admins can list users and only org members can
 	// list other org members.
-	if r.opt.OrgId == nil {
+	if r.opt.OrgID == 0 {
 		if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 			return nil, err
 		}
 	} else {
-		if err := auth.CheckOrgAccessOrSiteAdmin(ctx, r.db, *r.opt.OrgId); err != nil {
+		if err := auth.CheckOrgAccessOrSiteAdmin(ctx, r.db, r.opt.OrgID); err != nil {
 			if err == auth.ErrNotAnOrgMember {
 				return nil, errors.New("must be a member of this organization to view members")
 			}
@@ -143,12 +143,12 @@ func (r *userConnectionResolver) Nodes(ctx context.Context) ([]*UserResolver, er
 func (r *userConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
 	// 🚨 SECURITY: Only site admins can count users and only org members can
 	// count other org members.
-	if r.opt.OrgId == nil {
+	if r.opt.OrgID == 0 {
 		if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 			return 0, err
 		}
 	} else {
-		if err := auth.CheckOrgAccessOrSiteAdmin(ctx, r.db, *r.opt.OrgId); err != nil {
+		if err := auth.CheckOrgAccessOrSiteAdmin(ctx, r.db, r.opt.OrgID); err != nil {
 			if err == auth.ErrNotAnOrgMember {
 				return 0, errors.New("must be a member of this organization to view members")
 			}

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -127,7 +127,7 @@ func (r *userConnectionResolver) TotalCount(ctx context.Context) (int32, error) 
 }
 
 func (r *userConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	users, _, err := r.compute(ctx)
+	users, totalCount, err := r.compute(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -142,14 +142,6 @@ func (r *userConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.Pag
 	// We got less results than limit, means we've had all results
 	if after < r.opt.Limit {
 		return graphqlutil.HasNextPage(false), nil
-	}
-
-	// In case the number of results happens to be the same as the limit,
-	// we need another query to get accurate total count with same cursor
-	// to determine if there are more results than the limit we set.
-	totalCount, err := r.TotalCount(ctx)
-	if err != nil {
-		return nil, err
 	}
 
 	if int(totalCount) > after {

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -26,6 +26,11 @@ type usersArgs struct {
 }
 
 func (r *schemaResolver) Users(ctx context.Context, args *usersArgs) (*userConnectionResolver, error) {
+	// 🚨 SECURITY: Only site admins can see users.
+	if err := checkMembersAccess(ctx, r.db, 0); err != nil {
+		return nil, err
+	}
+
 	var opt database.UsersListOptions
 	if args.Query != nil {
 		opt.Query = *args.Query
@@ -43,10 +48,6 @@ func (r *schemaResolver) Users(ctx context.Context, args *usersArgs) (*userConne
 			return nil, err
 		}
 		opt.LimitOffset.Offset = int(cursor)
-	}
-
-	if err := checkMembersAccess(ctx, r.db, 0); err != nil {
-		return nil, err
 	}
 
 	return &userConnectionResolver{db: r.db, opt: opt, activePeriod: args.ActivePeriod}, nil

--- a/cmd/frontend/graphqlbackend/users_test.go
+++ b/cmd/frontend/graphqlbackend/users_test.go
@@ -97,6 +97,45 @@ func TestUsers_Pagination(t *testing.T) {
 			`,
 		},
 	})
+
+	users.ListFunc.SetDefaultReturn([]*types.User{
+		{Username: "user3"},
+		{Username: "user4"},
+	}, nil)
+
+	RunTests(t, []*Test{
+		{
+			Schema: mustParseGraphQLSchema(t, db),
+			Query: `
+				{
+					users(first: 2, after: "2") {
+						nodes { username }
+						totalCount
+						pageInfo { hasNextPage, endCursor }
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+					"users": {
+						"nodes": [
+							{
+								"username": "user3"
+							},
+							{
+								"username": "user4"
+							}
+						],
+						"totalCount": 4,
+						"pageInfo": {
+							"hasNextPage": false,
+							"endCursor": null
+						 }
+					}
+				}
+			`,
+		},
+	})
 }
 func TestUsers_InactiveSince(t *testing.T) {
 	if testing.Short() {

--- a/cmd/frontend/graphqlbackend/users_test.go
+++ b/cmd/frontend/graphqlbackend/users_test.go
@@ -59,6 +59,17 @@ func TestUsers_Pagination(t *testing.T) {
 		{Username: "user1"},
 		{Username: "user2"},
 	}, nil)
+	users.ListFunc.SetDefaultHook(func(ctx context.Context, opt *database.UsersListOptions) ([]*types.User, error) {
+		if opt.LimitOffset.Offset == 2 {
+			return []*types.User{
+				{Username: "user3"},
+				{Username: "user4"},
+			}, nil
+		}
+		return []*types.User{
+			{Username: "user1"},
+			{Username: "user2"}}, nil
+	})
 	users.CountFunc.SetDefaultReturn(4, nil)
 
 	db := database.NewMockDB()
@@ -96,14 +107,6 @@ func TestUsers_Pagination(t *testing.T) {
 				}
 			`,
 		},
-	})
-
-	users.ListFunc.SetDefaultReturn([]*types.User{
-		{Username: "user3"},
-		{Username: "user4"},
-	}, nil)
-
-	RunTests(t, []*Test{
 		{
 			Schema: mustParseGraphQLSchema(t, db),
 			Query: `

--- a/cmd/frontend/graphqlbackend/users_test.go
+++ b/cmd/frontend/graphqlbackend/users_test.go
@@ -55,10 +55,6 @@ func TestUsers(t *testing.T) {
 func TestUsers_Pagination(t *testing.T) {
 	users := database.NewMockUserStore()
 	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
-	users.ListFunc.SetDefaultReturn([]*types.User{
-		{Username: "user1"},
-		{Username: "user2"},
-	}, nil)
 	users.ListFunc.SetDefaultHook(func(ctx context.Context, opt *database.UsersListOptions) ([]*types.User, error) {
 		if opt.LimitOffset.Offset == 2 {
 			return []*types.User{

--- a/cmd/frontend/graphqlbackend/users_test.go
+++ b/cmd/frontend/graphqlbackend/users_test.go
@@ -2,9 +2,13 @@ package graphqlbackend
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/graph-gophers/graphql-go"
+	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -135,6 +139,183 @@ func TestUsers_Pagination(t *testing.T) {
 			`,
 		},
 	})
+}
+
+func TestUsers_Pagination_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := context.Background()
+
+	schema := mustParseGraphQLSchema(t, db)
+
+	org, err := db.Orgs().Create(ctx, "acme", nil)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	newUsers := []struct{ username string }{
+		{username: "user1"},
+		{username: "user2"},
+		{username: "user3"},
+		{username: "user4"},
+	}
+	users := make([]*types.User, len(newUsers))
+	for i, newUser := range newUsers {
+		user, err := db.Users().Create(ctx, database.NewUser{Username: newUser.username})
+		if err != nil {
+			t.Fatal(err)
+			return
+		}
+		users[i] = user
+		_, err = db.OrgMembers().Create(ctx, org.ID, user.ID)
+		if err != nil {
+			t.Fatal(err)
+			return
+		}
+	}
+
+	admin := users[0]
+	nonadmin := users[1]
+
+	tests := []usersQueryTest{
+		// no ctx
+		{
+			wantError: "not authenticated",
+		},
+		// no args
+		{
+			ctx:            actor.WithActor(ctx, actor.FromUser(admin.ID)),
+			wantUsers:      []string{"user1", "user2", "user3", "user4"},
+			wantTotalCount: 4,
+		},
+		// first: 1
+		{
+			ctx:            actor.WithActor(ctx, actor.FromUser(admin.ID)),
+			args:           "first: 1",
+			wantUsers:      []string{"user1"},
+			wantTotalCount: 4,
+		},
+		// first: 2
+		{
+			ctx:            actor.WithActor(ctx, actor.FromUser(admin.ID)),
+			args:           "first: 2",
+			wantUsers:      []string{"user1", "user2"},
+			wantTotalCount: 4,
+		},
+		// first: 2, after: 2
+		{
+			ctx:            actor.WithActor(ctx, actor.FromUser(admin.ID)),
+			args:           "first: 2, after: \"2\"",
+			wantUsers:      []string{"user3", "user4"},
+			wantTotalCount: 4,
+		},
+		// first: 1, after: 2
+		{
+			ctx:            actor.WithActor(ctx, actor.FromUser(admin.ID)),
+			args:           "first: 1, after: \"2\"",
+			wantUsers:      []string{"user3"},
+			wantTotalCount: 4,
+		},
+		// no admin
+		{
+			ctx:       actor.WithActor(ctx, actor.FromUser(nonadmin.ID)),
+			wantError: "must be site admin",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.args, func(t *testing.T) {
+			runUsersQuery(t, schema, tt)
+		})
+	}
+}
+
+type usersQueryTest struct {
+	args string
+	ctx  context.Context
+
+	wantError string
+
+	wantUsers []string
+
+	wantNoTotalCount bool
+	wantTotalCount   int
+}
+
+func runUsersQuery(t *testing.T, schema *graphql.Schema, want usersQueryTest) {
+	t.Helper()
+
+	type node struct {
+		Username string `json:"username"`
+	}
+
+	type pageInfo struct {
+		HasNextPage bool `json:"hasNextPage"`
+	}
+
+	type users struct {
+		Nodes      []node `json:"nodes"`
+		TotalCount *int   `json:"totalCount"`
+	}
+
+	type expected struct {
+		Users users `json:"users"`
+	}
+
+	nodes := make([]node, 0, len(want.wantUsers))
+	for _, username := range want.wantUsers {
+		nodes = append(nodes, node{Username: username})
+	}
+
+	ex := expected{
+		Users: users{
+			Nodes:      nodes,
+			TotalCount: &want.wantTotalCount,
+		},
+	}
+
+	if want.wantNoTotalCount {
+		ex.Users.TotalCount = nil
+	}
+
+	marshaled, err := json.Marshal(ex)
+	if err != nil {
+		t.Fatalf("failed to marshal expected repositories query result: %s", err)
+	}
+
+	var query string
+	if want.args != "" {
+		query = fmt.Sprintf(`{ users(%s) { nodes { username } totalCount } } `, want.args)
+	} else {
+		query = `{ users { nodes { username } totalCount } }`
+	}
+
+	if want.wantError != "" {
+		RunTest(t, &Test{
+			Context:        want.ctx,
+			Schema:         schema,
+			Query:          query,
+			ExpectedResult: `null`,
+			ExpectedErrors: []*gqlerrors.QueryError{
+				{
+					Message: want.wantError,
+					Path:    []any{string("users")},
+				},
+			},
+		})
+	} else {
+		RunTest(t, &Test{
+			Context:        want.ctx,
+			Schema:         schema,
+			Query:          query,
+			ExpectedResult: string(marshaled),
+		})
+	}
 }
 func TestUsers_InactiveSince(t *testing.T) {
 	if testing.Short() {

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -803,7 +803,7 @@ type UsersListOptions struct {
 	// UserIDs specifies a list of user IDs to include.
 	UserIDs []int32
 	// Only show users inside this org
-	OrgId *int32
+	OrgID int32
 
 	Tag string // only include users with this tag
 
@@ -901,8 +901,8 @@ func (*userStore) listSQL(opt UsersListOptions) (conds []*sqlf.Query) {
 			conds = append(conds, sqlf.Sprintf("u.id IN (%s)", sqlf.Join(items, ",")))
 		}
 	}
-	if opt.OrgId != nil {
-		conds = append(conds, sqlf.Sprintf(orgMembershipCond, *opt.OrgId))
+	if opt.OrgID != 0 {
+		conds = append(conds, sqlf.Sprintf(orgMembershipCond, opt.OrgID))
 	}
 	if opt.Tag != "" {
 		conds = append(conds, sqlf.Sprintf("%s::text = ANY(u.tags)", opt.Tag))

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -872,6 +872,15 @@ const listUsersInactiveCond = `
 		timestamp >= %s
 ))
 `
+const orgMembershipCond = `
+EXISTS (
+	SELECT 1
+	FROM org_members
+	WHERE
+		org_members.user_id = u.id
+		AND org_members.org_id = %d
+		AND org_members.org_id <> 0)
+`
 
 func (*userStore) listSQL(opt UsersListOptions) (conds []*sqlf.Query) {
 	conds = []*sqlf.Query{sqlf.Sprintf("TRUE")}
@@ -893,15 +902,7 @@ func (*userStore) listSQL(opt UsersListOptions) (conds []*sqlf.Query) {
 		}
 	}
 	if opt.OrgId != nil {
-		conds = append(conds, sqlf.Sprintf(`
-EXISTS (
-	SELECT 1
-	FROM org_members
-	WHERE
-		org_members.user_id = u.id
-		AND org_members.org_id = %d
-		AND org_members.org_id <> 0)
-`, *opt.OrgId))
+		conds = append(conds, sqlf.Sprintf(orgMembershipCond, *opt.OrgId))
 	}
 	if opt.Tag != "" {
 		conds = append(conds, sqlf.Sprintf("%s::text = ANY(u.tags)", opt.Tag))

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -878,8 +878,7 @@ EXISTS (
 	FROM org_members
 	WHERE
 		org_members.user_id = u.id
-		AND org_members.org_id = %d
-		AND org_members.org_id <> 0)
+		AND org_members.org_id = %d)
 `
 
 func (*userStore) listSQL(opt UsersListOptions) (conds []*sqlf.Query) {


### PR DESCRIPTION
Closes #43417 

As part of the [FE scale audit](https://docs.google.com/spreadsheets/d/1tqpi22csQJNlk7Q9JFWcFj09VbWOiFdp-Vf18qJsWHc/edit#gid=0) I've identified a few areas that lack basic server-side pagination. In this case, the org members page would not paginate at all leading to a long list if you have many members.

This is a simple fix that adds pagination based on LIMIT/OFFSET to the resolver (limit/offset was already implemented, I only had to generate the GraphQL pagination tokens correctly). I've also decided to add a search query endpoint to the members list so that it's easy to e.g. revoke access to a single user even if you have hundreds of users in the org. 

<img width="1115" alt="Screenshot 2022-10-25 at 14 42 08" src="https://user-images.githubusercontent.com/458591/197775799-af951256-de62-47ba-b506-4ed70b5dda7d.png">

To make testing easier, I've also added support for the new `after` param to the `users` root GraphQL query. This does not break existing APIs though as the field is optional and the previous "let's increase the limit with every page" logic still works.

## Test plan

- I did extensive testing in the GraphQL console
- I added a test case for a basic pagination example to the users test
- https://www.loom.com/share/ebe9da1a93ba436896705dc973b5b932

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
