### PR TITLE
Fix styles for `mark` tags

### DIFF
--- a/client/branded/src/global-styles/typography.scss
+++ b/client/branded/src/global-styles/typography.scss
@@ -209,6 +209,7 @@ mark,
     // stylelint-disable-next-line declaration-property-unit-allowed-list
     padding: 0.2em;
     background-color: var(--mark-bg);
+    color: var(--body-color);
 }
 
 .lead {

--- a/client/web/src/components/fuzzyFinder/HighlightedLink.module.scss
+++ b/client/web/src/components/fuzzyFinder/HighlightedLink.module.scss
@@ -1,8 +1,3 @@
-.mark {
-    background-color: var(--mark-bg);
-    color: var(--text-muted-highlighted);
-}
-
 .link:hover {
     cursor: pointer;
 }

--- a/client/web/src/components/fuzzyFinder/HighlightedLink.tsx
+++ b/client/web/src/components/fuzzyFinder/HighlightedLink.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 
-import classNames from 'classnames'
-
-import { Link, Code } from '@sourcegraph/wildcard'
+import { Code, Link } from '@sourcegraph/wildcard'
 
 import styles from './HighlightedLink.module.scss'
 
@@ -49,7 +47,7 @@ export const HighlightedLink: React.FunctionComponent<React.PropsWithChildren<Hi
         const key = `${startOffset}-${endOffset}`
         if (kind === 'mark') {
             spans.push(
-                <mark key={key} className={classNames(styles.mark, 'px-0')}>
+                <mark key={key} className="px-0">
                     {text}
                 </mark>
             )


### PR DESCRIPTION
The default styles for the `mark` tag did not include a text color, and the default color in dark mode was rather unreadable. This was fixed for dark mode in the fuzzy finder in #43356, but that wound up reducing the text contrast in light mode and did not resolve the issue for `mark` tags shown in the References panel (which are used when highlighting filtered filename matches).

This adds a `color` property to the base `mark` styles and removes the overrides for the fuzzy finder. Both light and dark mode `mark` tags now meet WCAG AA contrast requirements:

| Light | Dark |
| - | - |
| <img width="610" alt="image" src="https://user-images.githubusercontent.com/10523985/197595144-ea740795-2202-429b-845b-27de08f52df6.png"><img width="292" alt="image" src="https://user-images.githubusercontent.com/10523985/197595171-23299883-3333-4c98-a8ef-642a90fd710a.png"> | <img width="542" alt="image" src="https://user-images.githubusercontent.com/10523985/197594912-da63cc8c-7bb2-4e17-9a20-d60a119ee0b4.png"><img width="283" alt="image" src="https://user-images.githubusercontent.com/10523985/197594963-882370b7-aca0-4ed5-a485-488db5deae8d.png"> |


## Test plan

Visual testing with app running locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-lrh-fix-mark-styles.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
