### PR TITLE
Add GTM to docs

### DIFF
--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -15,11 +15,30 @@
 			<meta name="viewport" content="width=device-width, initial-scale=1" />
 			{{block "seo" . }}{{end}}
 			{{block "head" .}}{{end}}
+            
+            <!-- Plausible -->
             <script defer data-domain="docs.sourcegraph.com" src="https://plausible.io/js/plausible.js"></script>
+            <!-- End Plausible -->
+            
+            <!-- Google Tag Manager -->
+            <script>
+                (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+                'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+                })(window,document,'script','dataLayer','GTM-TB4NLS7');
+            </script>
+            <!-- End Google Tag Manager -->
 		</head>
 
         <!-- Default to light theme if no JavaScript -->
 		<body class="theme-light">
+            <!-- Google Tag Manager (noscript) -->
+            <noscript>
+                <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TB4NLS7"
+                height="0" width="0" style="display:none;visibility:hidden"></iframe>
+            </noscript>
+            <!-- End Google Tag Manager (noscript) -->
 			<aside id="sidebar">
                 <header>
 				    <h1 id="logo"><a href="/">


### PR DESCRIPTION
This adds GTM to our docs site and closes #43365.

## Test plan
- Run `sg run docsite` and check that `window.google_tag_manager` is visible in the console