### PR TITLE
search: improve match grouping behavior when `by-zoekt-ranking` is enabled

### DIFF
--- a/client/shared/src/components/ranking/LineRanking.test.tsx
+++ b/client/shared/src/components/ranking/LineRanking.test.tsx
@@ -2,7 +2,7 @@ import { range } from 'lodash'
 
 import { calculateMatchGroupsSorted, mergeContext } from './LineRanking'
 import { MatchItem } from './PerFileResultRanking'
-import { testDataRealMatches } from './PerFileResultRankingTestHelpers'
+import { testDataRealMatchesByLineNumber } from './PerFileResultRankingTestHelpers'
 
 expect.addSnapshotSerializer({
     serialize: value => JSON.stringify(value, null, 2),
@@ -144,7 +144,7 @@ describe('components/FileMatchContext', () => {
         test('complex grouping', () => {
             const maxMatches = 10
             const context = 2
-            const { grouped } = calculateMatchGroupsSorted(testDataRealMatches, maxMatches, context)
+            const { grouped } = calculateMatchGroupsSorted(testDataRealMatchesByLineNumber, maxMatches, context)
             expect(grouped).toMatchInlineSnapshot(`
                 [
                   {

--- a/client/shared/src/components/ranking/PerFileResultRankingTestHelpers.ts
+++ b/client/shared/src/components/ranking/PerFileResultRankingTestHelpers.ts
@@ -446,3 +446,124 @@ export const testDataRealMatches: MatchItem[] = [
         endLine: 175,
     },
 ]
+
+// Real match data from searching a file for `if ... {...} patternType:structural`.
+export const testDataRealMultilineMatches: MatchItem[] = [
+    {
+        highlightRanges: [
+            {
+                startLine: 50,
+                startCharacter: 1,
+                endLine: 52,
+                endCharacter: 2,
+            },
+        ],
+        content: '\tif err != nil {\n\t\touterMsg = err.Error()\n\t}',
+        startLine: 50,
+        endLine: 52,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 60,
+                startCharacter: 19,
+                endLine: 65,
+                endCharacter: 1,
+            },
+        ],
+        content: '// Contains checks if the given error contains an error with the\n// message msg. If err is not a wrapped error, this will always return\n// false unless the error itself happens to match this msg.\nfunc Contains(err error, msg string) bool {\n\treturn len(GetAll(err, msg)) > 0\n}',
+        startLine: 60,
+        endLine: 65,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 67,
+                startCharacter: 23,
+                endLine: 72,
+                endCharacter: 1,
+            },
+        ],
+        content: '// ContainsType checks if the given error contains an error with\n// the same concrete type as v. If err is not a wrapped error, this will\n// check the err itself.\nfunc ContainsType(err error, v interface{}) bool {\n\treturn len(GetAllType(err, v)) > 0\n}',
+        startLine: 67,
+        endLine: 72,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 77,
+                startCharacter: 1,
+                endLine: 79,
+                endCharacter: 2,
+            },
+        ],
+        content: '\tif len(es) > 0 {\n\t\treturn es[len(es)-1]\n\t}',
+        startLine: 77,
+        endLine: 79,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 87,
+                startCharacter: 1,
+                endLine: 89,
+                endCharacter: 2,
+            },
+        ],
+        content: '\tif len(es) > 0 {\n\t\treturn es[len(es)-1]\n\t}',
+        startLine: 87,
+        endLine: 89,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 101,
+                startCharacter: 2,
+                endLine: 103,
+                endCharacter: 3,
+            },
+        ],
+        content: '\t\tif err.Error() == msg {\n\t\t\tresult = append(result, err)\n\t\t}',
+        startLine: 101,
+        endLine: 103,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 116,
+                startCharacter: 1,
+                endLine: 118,
+                endCharacter: 2,
+            },
+        ],
+        content: '\tif v != nil {\n\t\tsearch = reflect.TypeOf(v).String()\n\t}',
+        startLine: 116,
+        endLine: 118,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 121,
+                startCharacter: 2,
+                endLine: 123,
+                endCharacter: 3,
+            },
+        ],
+        content: '\t\tif err != nil {\n\t\t\tneedle = reflect.TypeOf(err).String()\n\t\t}',
+        startLine: 121,
+        endLine: 123,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 125,
+                startCharacter: 2,
+                endLine: 127,
+                endCharacter: 3,
+            },
+        ],
+        content: '\t\tif needle == search {\n\t\t\tresult = append(result, err)\n\t\t}',
+        startLine: 125,
+        endLine: 127,
+    },
+]

--- a/client/shared/src/components/ranking/PerFileResultRankingTestHelpers.ts
+++ b/client/shared/src/components/ranking/PerFileResultRankingTestHelpers.ts
@@ -1,7 +1,7 @@
 import { MatchItem } from './PerFileResultRanking'
 
-// Real match data from searching a file for `error`.
-export const testDataRealMatches: MatchItem[] = [
+// Real match data from searching a file for `error` with results returned in order of line number.
+export const testDataRealMatchesByLineNumber: MatchItem[] = [
     {
         highlightRanges: [{ startLine: 0, startCharacter: 51, endLine: 0, endCharacter: 56 }],
         content: '// Package errwrap implements methods to formalize error wrapping in Go.',
@@ -444,6 +444,898 @@ export const testDataRealMatches: MatchItem[] = [
         content: 'func (w *wrappedError) Unwrap() error {',
         startLine: 175,
         endLine: 175,
+    },
+]
+
+// Real match data from searching a file for `error` with results returned in order of Zoekt relevance ranking.
+export const testDataRealMatchesByZoektRanking: MatchItem[] = [
+    {
+        highlightRanges: [
+            {
+                startLine: 167,
+                startCharacter: 16,
+                endLine: 167,
+                endCharacter: 21,
+            },
+            {
+                startLine: 167,
+                startCharacter: 23,
+                endLine: 167,
+                endCharacter: 28,
+            },
+        ],
+        content: 'func (w *wrappedError) Error() string {',
+        startLine: 167,
+        endLine: 167,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 162,
+                startCharacter: 12,
+                endLine: 162,
+                endCharacter: 17,
+            },
+        ],
+        content: 'type wrappedError struct {',
+        startLine: 162,
+        endLine: 162,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 24,
+                startCharacter: 8,
+                endLine: 24,
+                endCharacter: 13
+            },
+            {
+                startLine: 24,
+                startCharacter: 19,
+                endLine: 24,
+                endCharacter: 24,
+            },
+        ],
+        content: '\tWrappedErrors() []error',
+        startLine: 24,
+        endLine: 24,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 171,
+                startCharacter: 16,
+                endLine: 171,
+                endCharacter: 21,
+            },
+            {
+                startLine: 171,
+                startCharacter: 30,
+                endLine: 171,
+                endCharacter: 35,
+            },
+            {
+                startLine: 171,
+                startCharacter: 41,
+                endLine: 171,
+                endCharacter: 46,
+            },
+        ],
+        content: 'func (w *wrappedError) WrappedErrors() []error {',
+        startLine: 171,
+        endLine: 171,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 0,
+                startCharacter: 51,
+                endLine: 0,
+                endCharacter: 56,
+            },
+        ],
+        content: '// Package errwrap implements methods to formalize error wrapping in Go.',
+        startLine: 0,
+        endLine: 0,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 2,
+                startCharacter: 48,
+                endLine: 2,
+                endCharacter: 53,
+            },
+        ],
+        content: '// All of the top-level functions that take an `error` are built to be able',
+        startLine: 2,
+        endLine: 2,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 3,
+                startCharacter: 15,
+                endLine: 3,
+                endCharacter: 20,
+            },
+            {
+                startLine: 3,
+                startCharacter: 39,
+                endLine: 3,
+                endCharacter: 44,
+            },
+        ],
+        content: '// to take any error, not just wrapped errors. This allows you to use errwrap',
+        startLine: 3,
+        endLine: 3,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 14,
+                startCharacter: 19,
+                endLine: 14,
+                endCharacter: 24,
+            },
+        ],
+        content: 'type WalkFunc func(error)',
+        startLine: 14,
+        endLine: 14,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 20,
+                startCharacter: 11,
+                endLine: 20,
+                endCharacter: 16,
+            },
+        ],
+        content: '// wrapped error in addition to the wrapper itself. Since all the top-level',
+        startLine: 20,
+        endLine: 20,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 27,
+                startCharacter: 53,
+                endLine: 27,
+                endCharacter: 58,
+            },
+        ],
+        content: '// Wrap defines that outer wraps inner, returning an error type that',
+        startLine: 27,
+        endLine: 27,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 31,
+                startCharacter: 34,
+                endLine: 31,
+                endCharacter: 39,
+            },
+        ],
+        content: "// This function won't modify the error message at all (the outer message",
+        startLine: 31,
+        endLine: 31,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 33,
+                startCharacter: 23,
+                endLine: 33,
+                endCharacter: 28,
+            },
+            {
+                startLine: 33,
+                startCharacter: 30,
+                endLine: 33,
+                endCharacter: 35,
+            },
+        ],
+        content: 'func Wrap(outer, inner error) error {',
+        startLine: 33,
+        endLine: 33,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 40,
+                startCharacter: 18,
+                endLine: 40,
+                endCharacter: 23,
+            },
+        ],
+        content: '// Wrapf wraps an error with a formatting message. This is similar to using',
+        startLine: 40,
+        endLine: 40,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 41,
+                startCharacter: 8,
+                endLine: 41,
+                endCharacter: 13,
+            },
+            {
+                startLine: 41,
+                startCharacter: 27,
+                endLine: 41,
+                endCharacter: 32,
+            },
+            {
+                startLine: 41,
+                startCharacter: 55,
+                endLine: 41,
+                endCharacter: 60,
+            },
+        ],
+        content: "// `fmt.Errorf` to wrap an error. If you're using `fmt.Errorf` to wrap",
+        startLine: 41,
+        endLine: 41,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 44,
+                startCharacter: 31,
+                endLine: 44,
+                endCharacter: 36,
+            },
+        ],
+        content: "// format is the format of the error message. The string '{{err}}' will",
+        startLine: 44,
+        endLine: 44,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 45,
+                startCharacter: 33,
+                endLine: 45,
+                endCharacter: 38,
+            },
+        ],
+        content: '// be replaced with the original error message.',
+        startLine: 45,
+        endLine: 45,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 48,
+                startCharacter: 30,
+                endLine: 48,
+                endCharacter: 35,
+            },
+            {
+                startLine: 48,
+                startCharacter: 37,
+                endLine: 48,
+                endCharacter: 42,
+            },
+        ],
+        content: 'func Wrapf(format string, err error) error {',
+        startLine: 48,
+        endLine: 48,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 51,
+                startCharacter: 17,
+                endLine: 51,
+                endCharacter: 22,
+            },
+        ],
+        content: '\t\touterMsg = err.Error()',
+        startLine: 51,
+        endLine: 51,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 60,
+                startCharacter: 32,
+                endLine: 60,
+                endCharacter: 37,
+            },
+            {
+                startLine: 60,
+                startCharacter: 50,
+                endLine: 60,
+                endCharacter: 55,
+            }
+        ],
+        content: '// Contains checks if the given error contains an error with the',
+        startLine: 60,
+        endLine: 60
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 61,
+                startCharacter: 40,
+                endLine: 61,
+                endCharacter: 45,
+            },
+        ],
+        content: '// message msg. If err is not a wrapped error, this will always return',
+        startLine: 61,
+        endLine: 61,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 62,
+                startCharacter: 20,
+                endLine: 62,
+                endCharacter: 25,
+            },
+        ],
+        content: '// false unless the error itself happens to match this msg',
+        startLine: 62,
+        endLine: 62,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 63,
+                startCharacter: 18,
+                endLine: 63,
+                endCharacter: 23,
+            },
+        ],
+        content: 'func Contains(err error, msg string) bool {',
+        startLine: 63,
+        endLine: 63,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 67,
+                startCharacter: 36,
+                endLine: 67,
+                endCharacter: 41,
+            },
+            {
+                startLine: 67,
+                startCharacter: 54,
+                endLine: 67,
+                endCharacter: 59,
+            },
+        ],
+        content: '// ContainsType checks if the given error contains an error with',
+        startLine: 67,
+        endLine: 67,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 68,
+                startCharacter: 56,
+                endLine: 68,
+                endCharacter: 61,
+            },
+        ],
+        content: '// the same concrete type as v. If err is not a wrapped error, this will',
+        startLine: 68,
+        endLine: 68,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 70,
+                startCharacter: 22,
+                endLine: 70,
+                endCharacter: 27,
+            },
+        ],
+        content: 'func ContainsType(err error, v interface{}) bool {',
+        startLine: 70,
+        endLine: 70,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 74,
+                startCharacter: 62,
+                endLine: 74,
+                endCharacter: 67,
+            },
+        ],
+        content: '// Get is the same as GetAll but returns the deepest matching error.',
+        startLine: 74,
+        endLine: 74,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 75,
+                startCharacter: 13,
+                endLine: 75,
+                endCharacter: 18,
+            },
+            {
+                startLine: 75,
+                startCharacter: 32,
+                endLine: 75,
+                endCharacter: 37,
+            },
+        ],
+        content: 'func Get(err error, msg string) error {',
+        startLine: 75,
+        endLine: 75,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 84,
+                startCharacter: 70,
+                endLine: 84,
+                endCharacter: 75,
+            },
+        ],
+        content: '// GetType is the same as GetAllType but returns the deepest matching error.',
+        startLine: 84,
+        endLine: 84,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 85,
+                startCharacter: 17,
+                endLine: 85,
+                endCharacter: 22,
+            },
+            {
+                startLine: 85,
+                startCharacter: 39,
+                endLine: 85,
+                endCharacter: 44,
+            },
+        ],
+        content: 'func GetType(err error, v interface{}) error {',
+        startLine: 85,
+        endLine: 85,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 96,
+                startCharacter: 12,
+                endLine: 96,
+                endCharacter: 17,
+            },
+        ],
+        content: '// matching error (the most recent wrap) is index zero, and so on.',
+        startLine: 96,
+        endLine: 96,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 97,
+                startCharacter: 16,
+                endLine: 97,
+                endCharacter: 21,
+            },
+            {
+                startLine: 97,
+                startCharacter: 37,
+                endLine: 97,
+                endCharacter: 42,
+            },
+        ],
+        content: 'func GetAll(err error, msg string) []error {',
+        startLine: 97,
+        endLine: 97,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 98,
+                startCharacter: 14,
+                endLine: 98,
+                endCharacter: 19,
+            },
+        ],
+        content: '\tvar result []error',
+        startLine: 98,
+        endLine: 98,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 100,
+                startCharacter: 20,
+                endLine: 100,
+                endCharacter: 25,
+            },
+        ],
+        content: '\tWalk(err, func(err error) {',
+        startLine: 100,
+        endLine: 100,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 101,
+                startCharacter: 9,
+                endLine: 101,
+                endCharacter: 14,
+            },
+        ],
+        content: '\t\tif err.Error() == msg {',
+        startLine: 101,
+        endLine: 101,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 112,
+                startCharacter: 20,
+                endLine: 112,
+                endCharacter: 25,
+            },
+            {
+                startLine: 112,
+                startCharacter: 44,
+                endLine: 112,
+                endCharacter: 49,
+            },
+        ],
+        content: 'func GetAllType(err error, v interface{}) []error {',
+        startLine: 112,
+        endLine: 112,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 113,
+                startCharacter: 14,
+                endLine: 113,
+                endCharacter: 19,
+            },
+        ],
+        content: '\tvar result []error',
+        startLine: 113,
+        endLine: 113,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 119,
+                startCharacter: 20,
+                endLine: 119,
+                endCharacter: 25,
+            },
+        ],
+        content: '\tWalk(err, func(err error) {',
+        startLine: 119,
+        endLine: 119,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 134,
+                startCharacter: 23,
+                endLine: 134,
+                endCharacter: 28,
+            },
+        ],
+        content: "// err isn't a wrapped error, this will be called once for err. If err",
+        startLine: 134,
+        endLine: 134,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 135,
+                startCharacter: 16,
+                endLine: 135,
+                endCharacter: 21,
+            },
+        ],
+        content: '// is a wrapped error, the callback will be called for both the wrapper',
+        startLine: 135,
+        endLine: 135,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 136,
+                startCharacter: 19,
+                endLine: 136,
+                endCharacter: 24,
+            },
+            {
+                startLine: 136,
+                startCharacter: 48,
+                endLine: 136,
+                endCharacter: 53,
+            },
+        ],
+        content: '// that implements error as well as the wrapped error itself.',
+        startLine: 136,
+        endLine: 136,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 137,
+                startCharacter: 14,
+                endLine: 137,
+                endCharacter: 19,
+            },
+        ],
+        content: 'func Walk(err error, cb WalkFunc) {',
+        startLine: 137,
+        endLine: 137,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 152,
+                startCharacter: 26,
+                endLine: 152,
+                endCharacter: 31,
+            },
+        ],
+        content: '\tcase interface{ Unwrap() error }:',
+        startLine: 152,
+        endLine: 152,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 160,
+                startCharacter: 10,
+                endLine: 160,
+                endCharacter: 15,
+            },
+            {
+                startLine: 160,
+                startCharacter: 40,
+                endLine: 160,
+                endCharacter: 45,
+            },
+        ],
+        content: '// wrappedError is an implementation of error that has both the',
+        startLine: 160,
+        endLine: 160,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 163,
+                startCharacter: 7,
+                endLine: 163,
+                endCharacter: 12,
+            },
+        ],
+        content: '\tOuter error',
+        startLine: 163,
+        endLine: 163,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 164,
+                startCharacter: 7,
+                endLine: 164,
+                endCharacter: 12,
+            },
+        ],
+        content: '\tInner error',
+        startLine: 164,
+        endLine: 164,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 168,
+                startCharacter: 16,
+                endLine: 168,
+                endCharacter: 21,
+            },
+        ],
+        content: '\treturn w.Outer.Error()',
+        startLine: 168,
+        endLine: 168,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 172,
+                startCharacter: 10,
+                endLine: 172,
+                endCharacter: 15,
+            },
+        ],
+        content: '\treturn []error{w.Outer, w.Inner}',
+        startLine: 172,
+        endLine: 172,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 175,
+                startCharacter: 16,
+                endLine: 175,
+                endCharacter: 21,
+            },
+            {
+                startLine: 175,
+                startCharacter: 32,
+                endLine: 175,
+                endCharacter: 37,
+            },
+        ],
+        content: 'func (w *wrappedError) Unwrap() error {',
+        startLine: 175,
+        endLine: 175,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 8,
+                startCharacter: 2,
+                endLine: 8,
+                endCharacter: 7,
+            },
+        ],
+        content: '\t"errors"',
+        startLine: 8,
+        endLine: 8,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 34,
+                startCharacter: 16,
+                endLine: 34,
+                endCharacter: 21,
+            },
+        ],
+        content: '\treturn &wrappedError{',
+        startLine: 34,
+        endLine: 34,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 42,
+                startCharacter: 3,
+                endLine: 42,
+                endCharacter: 8,
+            },
+        ],
+        content: '// errors, you should replace it with this.',
+        startLine: 42,
+        endLine: 42
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 47,
+                startCharacter: 23,
+                endLine: 47,
+                endCharacter: 28,
+            },
+        ],
+        content: '// Deprecated: Use fmt.Errorf()',
+        startLine: 47,
+        endLine: 47,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 54,
+                startCharacter: 10,
+                endLine: 54,
+                endCharacter: 15,
+            },
+        ],
+        content: '\touter := errors.New(strings.Replace(',
+        startLine: 54,
+        endLine: 54,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 94,
+                startCharacter: 23,
+                endLine: 94,
+                endCharacter: 28,
+            },
+        ],
+        content: '// GetAll gets all the errors that might be wrapped in err with the',
+        startLine: 94,
+        endLine: 94,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 95,
+                startCharacter: 35,
+                endLine: 95,
+                endCharacter: 40,
+            },
+        ],
+        content: '// given message. The order of the errors is such that the outermost',
+        startLine: 95,
+        endLine: 95,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 109,
+                startCharacter: 27,
+                endLine: 109,
+                endCharacter: 32,
+            },
+        ],
+        content: '// GetAllType gets all the errors that are the same type as v.',
+        startLine: 109,
+        endLine: 109,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 133,
+                startCharacter: 30,
+                endLine: 133,
+                endCharacter: 35,
+            },
+        ],
+        content: '// Walk walks all the wrapped errors in err and calls the callback. If',
+        startLine: 133,
+        endLine: 133,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 143,
+                startCharacter: 14,
+                endLine: 143,
+                endCharacter: 19,
+            },
+        ],
+        content: '\tcase *wrappedError:',
+        startLine: 143,
+        endLine: 143,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 161,
+                startCharacter: 19,
+                endLine: 161,
+                endCharacter: 24,
+            },
+        ],
+        content: '// outer and inner errors.',
+        startLine: 161,
+        endLine: 161,
+    },
+    {
+        highlightRanges: [
+            {
+                startLine: 149,
+                startCharacter: 31,
+                endLine: 149,
+                endCharacter: 36,
+            },
+        ],
+        content: '\t\tfor _, err := range e.WrappedErrors() {',
+        startLine: 149,
+        endLine: 149,
     },
 ]
 

--- a/client/shared/src/components/ranking/ZoektRanking.test.tsx
+++ b/client/shared/src/components/ranking/ZoektRanking.test.tsx
@@ -1,10 +1,14 @@
-import { testDataRealMatches, testDataRealMultilineMatches } from './PerFileResultRankingTestHelpers'
+import {
+    testDataRealMatchesByLineNumber,
+    testDataRealMatchesByZoektRanking,
+    testDataRealMultilineMatches,
+} from './PerFileResultRankingTestHelpers'
 import { ZoektRanking } from './ZoektRanking'
 
 describe('ZoektRanking', () => {
     const ranking = new ZoektRanking(5)
     test('collapsedResults, single-line matches only', () => {
-        expect(ranking.collapsedResults(testDataRealMatches, 1).grouped).toMatchInlineSnapshot(`
+        expect(ranking.collapsedResults(testDataRealMatchesByLineNumber, 1).grouped).toMatchInlineSnapshot(`
             Array [
               Object {
                 "endLine": 5,
@@ -180,6 +184,201 @@ describe('ZoektRanking', () => {
         `)
     })
 
+    test('collapsed results, single-line matches only, matches in order of zoekt relevance ranking', () => {
+        expect(ranking.collapsedResults(testDataRealMatchesByZoektRanking, 1).grouped).toMatchInlineSnapshot(`
+            Array [
+              Object {
+                "endLine": 170,
+                "matches": Array [
+                  Object {
+                    "endCharacter": 15,
+                    "endLine": 160,
+                    "startCharacter": 10,
+                    "startLine": 160,
+                  },
+                  Object {
+                    "endCharacter": 45,
+                    "endLine": 160,
+                    "startCharacter": 40,
+                    "startLine": 160,
+                  },
+                  Object {
+                    "endCharacter": 24,
+                    "endLine": 161,
+                    "startCharacter": 19,
+                    "startLine": 161,
+                  },
+                  Object {
+                    "endCharacter": 17,
+                    "endLine": 162,
+                    "startCharacter": 12,
+                    "startLine": 162,
+                  },
+                  Object {
+                    "endCharacter": 12,
+                    "endLine": 163,
+                    "startCharacter": 7,
+                    "startLine": 163,
+                  },
+                  Object {
+                    "endCharacter": 12,
+                    "endLine": 164,
+                    "startCharacter": 7,
+                    "startLine": 164,
+                  },
+                  Object {
+                    "endCharacter": 21,
+                    "endLine": 167,
+                    "startCharacter": 16,
+                    "startLine": 167,
+                  },
+                  Object {
+                    "endCharacter": 28,
+                    "endLine": 167,
+                    "startCharacter": 23,
+                    "startLine": 167,
+                  },
+                  Object {
+                    "endCharacter": 21,
+                    "endLine": 168,
+                    "startCharacter": 16,
+                    "startLine": 168,
+                  },
+                ],
+                "position": Object {
+                  "character": 11,
+                  "line": 161,
+                },
+                "startLine": 159,
+              },
+              Object {
+                "endLine": 29,
+                "matches": Array [
+                  Object {
+                    "endCharacter": 13,
+                    "endLine": 24,
+                    "startCharacter": 8,
+                    "startLine": 24,
+                  },
+                  Object {
+                    "endCharacter": 24,
+                    "endLine": 24,
+                    "startCharacter": 19,
+                    "startLine": 24,
+                  },
+                  Object {
+                    "endCharacter": 58,
+                    "endLine": 27,
+                    "startCharacter": 53,
+                    "startLine": 27,
+                  },
+                ],
+                "position": Object {
+                  "character": 9,
+                  "line": 25,
+                },
+                "startLine": 23,
+              },
+              Object {
+                "endLine": 177,
+                "matches": Array [
+                  Object {
+                    "endCharacter": 21,
+                    "endLine": 171,
+                    "startCharacter": 16,
+                    "startLine": 171,
+                  },
+                  Object {
+                    "endCharacter": 35,
+                    "endLine": 171,
+                    "startCharacter": 30,
+                    "startLine": 171,
+                  },
+                  Object {
+                    "endCharacter": 46,
+                    "endLine": 171,
+                    "startCharacter": 41,
+                    "startLine": 171,
+                  },
+                  Object {
+                    "endCharacter": 15,
+                    "endLine": 172,
+                    "startCharacter": 10,
+                    "startLine": 172,
+                  },
+                  Object {
+                    "endCharacter": 21,
+                    "endLine": 175,
+                    "startCharacter": 16,
+                    "startLine": 175,
+                  },
+                  Object {
+                    "endCharacter": 37,
+                    "endLine": 175,
+                    "startCharacter": 32,
+                    "startLine": 175,
+                  },
+                ],
+                "position": Object {
+                  "character": 17,
+                  "line": 172,
+                },
+                "startLine": 170,
+              },
+              Object {
+                "endLine": 5,
+                "matches": Array [
+                  Object {
+                    "endCharacter": 56,
+                    "endLine": 0,
+                    "startCharacter": 51,
+                    "startLine": 0,
+                  },
+                  Object {
+                    "endCharacter": 53,
+                    "endLine": 2,
+                    "startCharacter": 48,
+                    "startLine": 2,
+                  },
+                  Object {
+                    "endCharacter": 20,
+                    "endLine": 3,
+                    "startCharacter": 15,
+                    "startLine": 3,
+                  },
+                  Object {
+                    "endCharacter": 44,
+                    "endLine": 3,
+                    "startCharacter": 39,
+                    "startLine": 3,
+                  },
+                ],
+                "position": Object {
+                  "character": 52,
+                  "line": 1,
+                },
+                "startLine": 0,
+              },
+              Object {
+                "endLine": 16,
+                "matches": Array [
+                  Object {
+                    "endCharacter": 24,
+                    "endLine": 14,
+                    "startCharacter": 19,
+                    "startLine": 14,
+                  },
+                ],
+                "position": Object {
+                  "character": 20,
+                  "line": 15,
+                },
+                "startLine": 13,
+              },
+            ]
+        `)
+    })
+
     test('collapsed results, multiline matches only', () => {
         expect(ranking.collapsedResults(testDataRealMultilineMatches, 1).grouped).toMatchInlineSnapshot(`
             Array [
@@ -277,7 +476,7 @@ describe('ZoektRanking', () => {
         // reverse the data to demonstrate that zoekt-ranking does not sort the
         // results by line number, it preserves the original sort from the
         // server.
-        const dataReversed = [...testDataRealMatches].reverse().slice(0, 6)
+        const dataReversed = [...testDataRealMatchesByLineNumber].reverse().slice(0, 6)
         expect(ranking.expandedResults(dataReversed, 1).grouped).toMatchInlineSnapshot(`
             Array [
               Object {

--- a/client/shared/src/components/ranking/ZoektRanking.test.tsx
+++ b/client/shared/src/components/ranking/ZoektRanking.test.tsx
@@ -1,9 +1,9 @@
-import { testDataRealMatches } from './PerFileResultRankingTestHelpers'
+import { testDataRealMatches, testDataRealMultilineMatches } from './PerFileResultRankingTestHelpers'
 import { ZoektRanking } from './ZoektRanking'
 
 describe('ZoektRanking', () => {
     const ranking = new ZoektRanking(5)
-    test('collapsedResults', () => {
+    test('collapsedResults, single-line matches only', () => {
         expect(ranking.collapsedResults(testDataRealMatches, 1).grouped).toMatchInlineSnapshot(`
             Array [
               Object {
@@ -179,7 +179,101 @@ describe('ZoektRanking', () => {
             ]
         `)
     })
-    test('expandedResults', () => {
+
+    test('collapsed results, multiline matches only', () => {
+        expect(ranking.collapsedResults(testDataRealMultilineMatches, 1).grouped).toMatchInlineSnapshot(`
+            Array [
+              Object {
+                "endLine": 54,
+                "matches": Array [
+                  Object {
+                    "endCharacter": 2,
+                    "endLine": 52,
+                    "startCharacter": 1,
+                    "startLine": 50,
+                  },
+                ],
+                "position": Object {
+                  "character": 2,
+                  "line": 51,
+                },
+                "startLine": 49,
+              },
+              Object {
+                "endLine": 74,
+                "matches": Array [
+                  Object {
+                    "endCharacter": 1,
+                    "endLine": 65,
+                    "startCharacter": 19,
+                    "startLine": 60,
+                  },
+                  Object {
+                    "endCharacter": 1,
+                    "endLine": 72,
+                    "startCharacter": 23,
+                    "startLine": 67,
+                  },
+                ],
+                "position": Object {
+                  "character": 20,
+                  "line": 61,
+                },
+                "startLine": 59,
+              },
+              Object {
+                "endLine": 81,
+                "matches": Array [
+                  Object {
+                    "endCharacter": 2,
+                    "endLine": 79,
+                    "startCharacter": 1,
+                    "startLine": 77,
+                  },
+                ],
+                "position": Object {
+                  "character": 2,
+                  "line": 78,
+                },
+                "startLine": 76,
+              },
+              Object {
+                "endLine": 91,
+                "matches": Array [
+                  Object {
+                    "endCharacter": 2,
+                    "endLine": 89,
+                    "startCharacter": 1,
+                    "startLine": 87,
+                  },
+                ],
+                "position": Object {
+                  "character": 2,
+                  "line": 88,
+                },
+                "startLine": 86,
+              },
+              Object {
+                "endLine": 105,
+                "matches": Array [
+                  Object {
+                    "endCharacter": 3,
+                    "endLine": 103,
+                    "startCharacter": 2,
+                    "startLine": 101,
+                  },
+                ],
+                "position": Object {
+                  "character": 3,
+                  "line": 102,
+                },
+                "startLine": 100,
+              },
+            ]
+        `)
+    })
+
+    test('expandedResults, single-line matches only', () => {
         // reverse the data to demonstrate that zoekt-ranking does not sort the
         // results by line number, it preserves the original sort from the
         // server.
@@ -255,6 +349,90 @@ describe('ZoektRanking', () => {
                   "line": 165,
                 },
                 "startLine": 163,
+              },
+            ]
+        `)
+    })
+
+    test('expanded matches, multiline matches only', () => {
+        const multilineDataReversed = [...testDataRealMultilineMatches].reverse().slice(0, 6)
+        expect(ranking.expandedResults(multilineDataReversed, 1).grouped).toMatchInlineSnapshot(`
+            Array [
+              Object {
+                "endLine": 129,
+                "matches": Array [
+                  Object {
+                    "endCharacter": 2,
+                    "endLine": 118,
+                    "startCharacter": 1,
+                    "startLine": 116,
+                  },
+                  Object {
+                    "endCharacter": 3,
+                    "endLine": 123,
+                    "startCharacter": 2,
+                    "startLine": 121,
+                  },
+                  Object {
+                    "endCharacter": 3,
+                    "endLine": 127,
+                    "startCharacter": 2,
+                    "startLine": 125,
+                  },
+                ],
+                "position": Object {
+                  "character": 2,
+                  "line": 117,
+                },
+                "startLine": 115,
+              },
+              Object {
+                "endLine": 105,
+                "matches": Array [
+                  Object {
+                    "endCharacter": 3,
+                    "endLine": 103,
+                    "startCharacter": 2,
+                    "startLine": 101,
+                  },
+                ],
+                "position": Object {
+                  "character": 3,
+                  "line": 102,
+                },
+                "startLine": 100,
+              },
+              Object {
+                "endLine": 91,
+                "matches": Array [
+                  Object {
+                    "endCharacter": 2,
+                    "endLine": 89,
+                    "startCharacter": 1,
+                    "startLine": 87,
+                  },
+                ],
+                "position": Object {
+                  "character": 2,
+                  "line": 88,
+                },
+                "startLine": 86,
+              },
+              Object {
+                "endLine": 81,
+                "matches": Array [
+                  Object {
+                    "endCharacter": 2,
+                    "endLine": 79,
+                    "startCharacter": 1,
+                    "startLine": 77,
+                  },
+                ],
+                "position": Object {
+                  "character": 2,
+                  "line": 78,
+                },
+                "startLine": 76,
               },
             ]
         `)

--- a/client/shared/src/components/ranking/ZoektRanking.ts
+++ b/client/shared/src/components/ranking/ZoektRanking.ts
@@ -48,14 +48,36 @@ function sortHunkMatches(hunk: Hunk): void {
     })
 }
 
-// function sortHunks(hunks: Hunk[]): Hunk[] {
-//     hunks.sort((a, b) => {
-//        if (a.startLine < b.startLine) {
-//            return -1
-//        }
-//        if (a.startLine === b.)
-//     })
-// }
+function mergeHunks(hunks: Hunk[], context: number) : void {
+    const hunksSortedByLineNumber = hunks.slice().sort((a, b) => {
+        if (a.startLine < b.startLine) {
+            return -1
+        }
+        if (a.startLine === b.startLine) {
+            return 0
+        }
+        return 1
+    })
+
+    for (let index = 0; index < hunksSortedByLineNumber.length - 1; index++) {
+        const current = hunksSortedByLineNumber[index]
+        const next = hunksSortedByLineNumber[index + 1]
+
+        if (next.startLine - current.startLine <= context) {
+            const originalHunkIndex = hunks.indexOf(current)
+            const nextHunkIndex = hunks.indexOf(next)
+
+            if (originalHunkIndex > -1 && nextHunkIndex > -1) {
+                const originalHunk = hunks[originalHunkIndex]
+                for (const match of next.matches) {
+                    addHunkItem(originalHunk, match)
+                }
+                hunks.splice(nextHunkIndex, 1)
+                index++
+            }
+        }
+    }
+}
 
 function isMatchWithinGroup(group: Hunk, item: MatchItem, context: number): boolean {
     // Return true if item and group have overlapping or adjacent context
@@ -66,49 +88,23 @@ function isMatchWithinGroup(group: Hunk, item: MatchItem, context: number): bool
 function results(matches: MatchItem[], maxResults: number, context: number): RankingResult {
     let hunks: Hunk[] = []
     for (const match of matches) {
-        console.log('match', match)
         let isMergedWithExistingGroup = false
         for (const existingGroup of hunks) {
-            console.log('existingGroup', existingGroup)
             if (isMatchWithinGroup(existingGroup, match, context)) {
-                console.log('true')
                 addHunkItem(existingGroup, match)
                 isMergedWithExistingGroup = true
                 break
             }
-            console.log('false')
         }
         if (!isMergedWithExistingGroup) {
             const hunk = newHunk()
             addHunkItem(hunk, match)
-            console.log('newGroup', hunk)
             hunks.push(hunk)
         }
     }
 
-    // merge hunks with overlapping or adjacent line ranges
-    let hunksSortedByLineNumber = hunks.slice()
-    hunksSortedByLineNumber.sort((a, b) => {
-        if (a.startLine < b.startLine) {
-            return -1
-        }
-        if (a.startLine === b.startLine) {
-            return 0
-        }
-        return 1
-    })
-    for (let index = 0; index < hunksSortedByLineNumber.length - 1; index++) {
-        let current = hunksSortedByLineNumber[index]
-        let next = hunksSortedByLineNumber[index + 1]
-
-        if (next.startLine - current.startLine <= context) {
-
-        }
-    }
-    for (const hunk of hunks) {
-        sortHunkMatches(hunk)
-    }
-
+    // Merge hunks with overlapping or adjacent line ranges
+    mergeHunks(hunks, context)
 
     const groups: MatchGroup[] = []
     const visibleMatches: MatchItem[] = []

--- a/client/shared/src/components/ranking/ZoektRanking.ts
+++ b/client/shared/src/components/ranking/ZoektRanking.ts
@@ -48,6 +48,15 @@ function sortHunkMatches(hunk: Hunk): void {
     })
 }
 
+// function sortHunks(hunks: Hunk[]): Hunk[] {
+//     hunks.sort((a, b) => {
+//        if (a.startLine < b.startLine) {
+//            return -1
+//        }
+//        if (a.startLine === b.)
+//     })
+// }
+
 function isMatchWithinGroup(group: Hunk, item: MatchItem, context: number): boolean {
     // Return true if item and group have overlapping or adjacent context
     return (item.startLine >= group.endLine && item.startLine - group.endLine - 2 * context <= 1)
@@ -57,20 +66,50 @@ function isMatchWithinGroup(group: Hunk, item: MatchItem, context: number): bool
 function results(matches: MatchItem[], maxResults: number, context: number): RankingResult {
     let hunks: Hunk[] = []
     for (const match of matches) {
+        console.log('match', match)
         let isMergedWithExistingGroup = false
         for (const existingGroup of hunks) {
+            console.log('existingGroup', existingGroup)
             if (isMatchWithinGroup(existingGroup, match, context)) {
+                console.log('true')
                 addHunkItem(existingGroup, match)
                 isMergedWithExistingGroup = true
                 break
             }
+            console.log('false')
         }
         if (!isMergedWithExistingGroup) {
             const hunk = newHunk()
             addHunkItem(hunk, match)
+            console.log('newGroup', hunk)
             hunks.push(hunk)
         }
     }
+
+    // merge hunks with overlapping or adjacent line ranges
+    let hunksSortedByLineNumber = hunks.slice()
+    hunksSortedByLineNumber.sort((a, b) => {
+        if (a.startLine < b.startLine) {
+            return -1
+        }
+        if (a.startLine === b.startLine) {
+            return 0
+        }
+        return 1
+    })
+    for (let index = 0; index < hunksSortedByLineNumber.length - 1; index++) {
+        let current = hunksSortedByLineNumber[index]
+        let next = hunksSortedByLineNumber[index + 1]
+
+        if (next.startLine - current.startLine <= context) {
+
+        }
+    }
+    for (const hunk of hunks) {
+        sortHunkMatches(hunk)
+    }
+
+
     const groups: MatchGroup[] = []
     const visibleMatches: MatchItem[] = []
     hunks = hunks.slice(0, maxResults)

--- a/client/shared/src/components/ranking/ZoektRanking.ts
+++ b/client/shared/src/components/ranking/ZoektRanking.ts
@@ -49,10 +49,9 @@ function sortHunkMatches(hunk: Hunk): void {
 }
 
 function isMatchWithinGroup(group: Hunk, item: MatchItem, context: number): boolean {
-    return (
-        item.startLine + context + 1 >= group.startLine - context &&
-        item.endLine - context - 1 <= group.endLine + context
-    )
+    // Return true if item and group have overlapping or adjacent context
+    return (item.startLine >= group.endLine && item.startLine - group.endLine - 2 * context <= 1)
+        || (item.endLine <= group.startLine && group.startLine - item.endLine - 2 * context <= 1)
 }
 
 function results(matches: MatchItem[], maxResults: number, context: number): RankingResult {


### PR DESCRIPTION
This PR groups matches more intuitively when `experimentalFeatures.clientSearchResultRanking` is set to `by-zoekt-ranking` in settings.

Migrating the web app to request chunk matches introduced some undesirable behavior around the way match groups are merged in the search results UI when `by-zoekt-ranking` was enabled, namely that groups with adjacent or overlapping line ranges were not merged into a single group as one would expect. This PR merges such groups together into a single group.

Before:
![single_line_matchgroups_before](https://user-images.githubusercontent.com/70350613/197631555-8f31fd7d-f50f-4216-baed-92edd15d3b15.png)

![multiline_matchgroups_before](https://user-images.githubusercontent.com/70350613/197631574-ec4bb892-7424-4bb9-95e1-eae19aeba989.png)

After:
![single_line_matchgroups_merged](https://user-images.githubusercontent.com/70350613/197631626-e81bb895-ccdb-4684-9cc8-a76417f30466.png)

![multiline_matchgroups_merged](https://user-images.githubusercontent.com/70350613/197631635-104a6351-f102-4522-a304-6e74abc8c6dc.png)

## Test plan
Added new test data and unit tests
Manual testing, see screenshots above
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tl-zoekt-ranking-stuff.onrender.com)
- [Storybook](https://5f0f381c0e50750022dc6bf7-krqzqegesq.chromatic.com)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

