### PR TITLE
Follow up to fix linting errors for scripts

### DIFF
--- a/cmd/frontend/internal/app/ui/app.html
+++ b/cmd/frontend/internal/app/ui/app.html
@@ -43,7 +43,7 @@
 	<script src='https://js.sentry-cdn.com/ae2f74442b154faf90b5ff0f7cd1c618.min.js' crossorigin="anonymous"></script>
 	<!-- End Sentry -->
 	<!-- Plausible -->
-	<script defer data-domain="sourcegraph.com" src="https://plausible.io/js/plausible.js"></script>
+	<script src="https://plausible.io/js/plausible.js" defer data-domain="sourcegraph.com"></script>
 	<!-- End Plausible -->
 	{{ end }}
 	<script ignore-csp>

--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -17,7 +17,7 @@
 			{{block "head" .}}{{end}}
             
             <!-- Plausible -->
-            <script defer data-domain="docs.sourcegraph.com" src="https://plausible.io/js/plausible.js"></script>
+            <script src="https://plausible.io/js/plausible.js" defer data-domain="docs.sourcegraph.com"></script>
             <!-- End Plausible -->
             
             <!-- Google Tag Manager -->


### PR DESCRIPTION
This is a follow up to #43377 and #43376 which caused buildkite to [warn](https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1666650107194459) about CSP errors in builds. ([context](https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1666653136831479?thread_ts=1666645359.249959&cid=C02FLQDD3TQ))

## Test plan
- Ensure build is successful