### PR TITLE
squirrel: Suppress wrong lang errors

### DIFF
--- a/cmd/symbols/squirrel/util.go
+++ b/cmd/symbols/squirrel/util.go
@@ -425,6 +425,9 @@ func (s *SquirrelService) symbolSearchOne(ctx context.Context, repo string, comm
 		Commit: commit,
 		Path:   symbol.Path,
 	})
+	if errors.Is(err, unsupportedLanguageError) || errors.Is(err, unrecognizedFileExtensionError) {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Suppresses errors when a symbol search returns a hit in a file of an unsupported language.

See [Slack](https://sourcegraph.slack.com/archives/CHXHX7XAS/p1666646679329289).

## Test plan

Existing tests
