### PR TITLE
codeintel: Improve "No such LSIFUpload" error

### DIFF
--- a/client/web/src/enterprise/codeintel/uploads/hooks/queryLisfUploadFields.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/hooks/queryLisfUploadFields.tsx
@@ -35,7 +35,7 @@ export const queryLisfUploadFields = (
         map(({ data }) => data),
         map(({ node }) => {
             if (!node || node.__typename !== 'LSIFUpload') {
-                throw new Error(
+                return new Error(
                     'No such LSIFUpload. This can happen if the upload is associated with a nonexistent commit.'
                 )
             }

--- a/client/web/src/enterprise/codeintel/uploads/hooks/queryLisfUploadFields.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/hooks/queryLisfUploadFields.tsx
@@ -35,7 +35,9 @@ export const queryLisfUploadFields = (
         map(({ data }) => data),
         map(({ node }) => {
             if (!node || node.__typename !== 'LSIFUpload') {
-                throw new Error('No such LSIFUpload')
+                throw new Error(
+                    'No such LSIFUpload. This can happen if the upload is associated with a nonexistent commit.'
+                )
             }
             return node
         })


### PR DESCRIPTION
Resolves https://github.com/sourcegraph/sourcegraph/issues/33633

<img width="1160" alt="CleanShot 2022-10-24 at 21 25 21@2x" src="https://user-images.githubusercontent.com/1387653/197675255-95d0945a-c1b8-41a2-ba16-687cf059348c.png">

This makes the app not crash and adds a little message about a common way in which this error can occur.

## Test plan

N/A

## App preview:

- [Web](https://sg-web-nonexistent-lsif-error.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
