### PR TITLE
Normalize draft to "draft"

### DIFF
--- a/migrations/frontend/1663871069_changeset_specs_null_published/up.sql
+++ b/migrations/frontend/1663871069_changeset_specs_null_published/up.sql
@@ -2,6 +2,10 @@ UPDATE changeset_specs
 SET published = NULL
 WHERE published = 'null';
 
+UPDATE changeset_specs
+SET published = '"draft"'
+WHERE published = 'draft';
+
 ALTER TABLE changeset_specs
     DROP CONSTRAINT IF EXISTS changeset_specs_published_valid_values,
     ADD CONSTRAINT changeset_specs_published_valid_values CHECK (published = 'true' OR published = 'false' OR


### PR DESCRIPTION
Ensure any `draft` values are `"draft"`

## Test plan

Functional testing.