### PR TITLE
all: include git-lfs in gitserver docker images

### DIFF
--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -39,6 +39,7 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 RUN apk add --no-cache \
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
     'git>=2.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
+    git-lfs \
     git-p4 \
     && apk add --no-cache  \
     openssh-client \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -43,6 +43,7 @@ RUN apk add --no-cache --verbose \
     # [NOTE: git-version-min-requirement]
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
     'git>=2.34.1' \
+    git-lfs \
     git-p4 \
     --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
     # NOTE that the Postgres version we run is different

--- a/shell.nix
+++ b/shell.nix
@@ -64,6 +64,7 @@ pkgs.mkShell {
 
     # Lots of our tooling and go tests rely on git et al.
     git
+    git-lfs
     parallel
     nssTools
 


### PR DESCRIPTION
We add the optional dependency git-lfs to any image gitserver may run on. This is still an experimental feature, but is a requirement when enabled.

Additionally we include it in the nix devenv since its cheap to add.

Note: git-lfs is a relatively small go binary and does not require specific versions of git. Additionally git will not automatically use it, so its presence will not change behaviour.

Test Plan: CI docker image dry run