### PR TITLE
webhooks: Move handler from /webhooks to /.api/webhooks

### DIFF
--- a/cmd/frontend/auth/non_public.go
+++ b/cmd/frontend/auth/non_public.go
@@ -124,6 +124,7 @@ func AllowAnonymousRequest(req *http.Request) bool {
 
 	// Authentication is performed in the webhook handler itself.
 	for _, prefix := range []string{
+		"/.api/webhooks",
 		"/.api/github-webhooks",
 		"/.api/gitlab-webhooks",
 		"/.api/bitbucket-server-webhooks",

--- a/cmd/frontend/graphqlbackend/webhooks.go
+++ b/cmd/frontend/graphqlbackend/webhooks.go
@@ -40,7 +40,7 @@ func (r *webhookResolver) URL() (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "could not parse site config external URL")
 	}
-	externalURL.Path = fmt.Sprintf("webhooks/%v", r.hook.UUID)
+	externalURL.Path = fmt.Sprintf(".api/webhooks/%v", r.hook.UUID)
 	return externalURL.String(), nil
 }
 

--- a/cmd/frontend/graphqlbackend/webhooks_test.go
+++ b/cmd/frontend/graphqlbackend/webhooks_test.go
@@ -466,7 +466,7 @@ func TestGetWebhookWithURL(t *testing.T) {
 					"node": {
 						"id": %q,
 						"uuid": %q,
-                        "url": "%s/webhooks/%s"
+                        "url": "%s/.api/webhooks/%s"
 					}
 				}
 			`, webhookIDMarshaled, whUUID.String(), testURL, whUUID.String()),

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -90,9 +90,6 @@ func newExternalHTTPHandler(
 
 	githubAppSetupHandler := newGitHubAppSetupHandler()
 
-	// 🚨 SECURITY: This handler implements its own secret-based auth
-	webhookHandler := webhooks.NewHandler(logger, db, &gh)
-
 	// App handler (HTML pages), the call order of middleware is LIFO.
 	appHandler := app.NewHandler(db, logger, githubAppSetupHandler)
 	if hooks.PostAuthMiddleware != nil {
@@ -113,7 +110,6 @@ func newExternalHTTPHandler(
 	sm := http.NewServeMux()
 	sm.Handle("/.api/", secureHeadersMiddleware(apiHandler, crossOriginPolicyAPI))
 	sm.Handle("/.executors/", secureHeadersMiddleware(executorProxyHandler, crossOriginPolicyNever))
-	sm.Handle("/webhooks/", secureHeadersMiddleware(webhookHandler, crossOriginPolicyAPI))
 	sm.Handle("/", secureHeadersMiddleware(appHandler, crossOriginPolicyNever))
 	const urlPathPrefix = "/.assets"
 	// The asset handler should be wrapped into a middleware that enables cross-origin requests

--- a/cmd/frontend/internal/httpapi/api_test.go
+++ b/cmd/frontend/internal/httpapi/api_test.go
@@ -28,15 +28,6 @@ func newTest(t *testing.T) *httptestutil.Client {
 
 	db := database.NewMockDB()
 
-	//gh := webhooks.GitHubWebhook{
-	//	DB: db,
-	//}
-	//webhookhandlers.Init(db, &gh)
-	//enterpriseServices.GitHubWebhook.Register(&gh)
-	//
-	//ghSync := repos.GitHubWebhookHandler{}
-	//ghSync.Register(&gh)
-
 	return httptestutil.NewTest(NewHandler(db,
 		router.New(mux.NewRouter()),
 		nil,

--- a/cmd/frontend/internal/httpapi/api_test.go
+++ b/cmd/frontend/internal/httpapi/api_test.go
@@ -11,11 +11,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/router"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/webhookhandlers"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
-	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/txemail"
 )
 
@@ -30,14 +27,15 @@ func newTest(t *testing.T) *httptestutil.Client {
 	rateLimiter := graphqlbackend.NewRateLimiteWatcher(logger, rateLimitStore)
 
 	db := database.NewMockDB()
-	gh := webhooks.GitHubWebhook{
-		DB: db,
-	}
-	webhookhandlers.Init(db, &gh)
-	enterpriseServices.GitHubWebhook.Register(&gh)
 
-	ghSync := repos.GitHubWebhookHandler{}
-	ghSync.Register(&gh)
+	//gh := webhooks.GitHubWebhook{
+	//	DB: db,
+	//}
+	//webhookhandlers.Init(db, &gh)
+	//enterpriseServices.GitHubWebhook.Register(&gh)
+	//
+	//ghSync := repos.GitHubWebhookHandler{}
+	//ghSync.Register(&gh)
 
 	return httptestutil.NewTest(NewHandler(db,
 		router.New(mux.NewRouter()),
@@ -51,6 +49,5 @@ func newTest(t *testing.T) *httptestutil.Client {
 			NewCodeIntelUploadHandler: enterpriseServices.NewCodeIntelUploadHandler,
 			NewComputeStreamHandler:   enterpriseServices.NewComputeStreamHandler,
 		},
-		&gh,
 	))
 }

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -89,6 +89,11 @@ func NewHandler(
 		db.WebhookLogs(keyring.Default().WebhookLogKey),
 	)
 
+	// 🚨 SECURITY: This handler implements its own secret-based auth
+	// TODO: Integrate with webhookMiddleware.Logger
+	webhookHandler := webhooks.NewHandler(logger, db, gh)
+
+	m.Get(apirouter.Webhooks).Handler(trace.Route(webhookHandler))
 	m.Get(apirouter.GitHubWebhooks).Handler(trace.Route(webhookMiddleware.Logger(gh)))
 	m.Get(apirouter.GitLabWebhooks).Handler(trace.Route(webhookMiddleware.Logger(handlers.GitLabWebhook)))
 	m.Get(apirouter.BitbucketServerWebhooks).Handler(trace.Route(webhookMiddleware.Logger(handlers.BitbucketServerWebhook)))

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -83,7 +83,6 @@ func NewHandler(
 
 	// Set handlers for the installed routes.
 	m.Get(apirouter.RepoShield).Handler(trace.Route(handler(serveRepoShield(db))))
-
 	m.Get(apirouter.RepoRefresh).Handler(trace.Route(handler(serveRepoRefresh(db))))
 
 	webhookMiddleware := webhooks.NewLogMiddleware(

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -23,6 +23,7 @@ const (
 	RepoRefresh = "repo.refresh"
 	Telemetry   = "telemetry"
 
+	Webhooks                = "webhooks"
 	GitHubWebhooks          = "github.webhooks"
 	GitLabWebhooks          = "gitlab.webhooks"
 	BitbucketServerWebhooks = "bitbucketServer.webhooks"
@@ -56,6 +57,7 @@ func New(base *mux.Router) *mux.Router {
 
 	addRegistryRoute(base)
 	addGraphQLRoute(base)
+	base.Path("/webhooks").Methods("POST").Name(Webhooks)
 	base.Path("/github-webhooks").Methods("POST").Name(GitHubWebhooks)
 	base.Path("/gitlab-webhooks").Methods("POST").Name(GitLabWebhooks)
 	base.Path("/bitbucket-server-webhooks").Methods("POST").Name(BitbucketServerWebhooks)

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -57,7 +57,7 @@ func New(base *mux.Router) *mux.Router {
 
 	addRegistryRoute(base)
 	addGraphQLRoute(base)
-	base.Path("/webhooks").Methods("POST").Name(Webhooks)
+	base.Path("/webhooks/{webhook_uuid}").Methods("POST").Name(Webhooks)
 	base.Path("/github-webhooks").Methods("POST").Name(GitHubWebhooks)
 	base.Path("/gitlab-webhooks").Methods("POST").Name(GitLabWebhooks)
 	base.Path("/bitbucket-server-webhooks").Methods("POST").Name(BitbucketServerWebhooks)

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handlers.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handlers.go
@@ -22,5 +22,4 @@ func Init(db database.DB, w *webhooks.GitHubWebhook) {
 	w.Register(handleGitHubRepoAuthzEvent(db, authz.FetchPermsOptions{InvalidateCaches: true}), "team_add")
 	w.Register(handleGitHubUserAuthzEvent(db, authz.FetchPermsOptions{InvalidateCaches: true}), "organisation")
 	w.Register(handleGitHubUserAuthzEvent(db, authz.FetchPermsOptions{InvalidateCaches: true}), "membership")
-
 }

--- a/cmd/frontend/webhooks/webhooks.go
+++ b/cmd/frontend/webhooks/webhooks.go
@@ -23,15 +23,8 @@ type WebhookHandlers struct {
 // and invoking the correct handlers depending on where the webhooks
 // come from.
 func NewHandler(logger log.Logger, db database.DB, gh *GitHubWebhook) http.Handler {
-	base := mux.NewRouter().PathPrefix("/.api/webhooks").Subrouter()
-	base.Path("/{webhook_uuid}").Methods("POST").Handler(webhookHandler(logger, db, gh))
-
-	return base
-}
-
-func webhookHandler(logger log.Logger, db database.DB, gh *GitHubWebhook) http.HandlerFunc {
 	logger = logger.Scoped("webhookHandler", "handler used to route webhooks")
-	return func(w http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		uuidString := mux.Vars(r)["webhook_uuid"]
 		if uuidString == "" {
 			http.Error(w, "missing uuid", http.StatusBadRequest)
@@ -81,7 +74,7 @@ func webhookHandler(logger log.Logger, db database.DB, gh *GitHubWebhook) http.H
 		}
 
 		http.Error(w, fmt.Sprintf("webhooks not implemented for code host kind %q", webhook.CodeHostKind), http.StatusNotImplemented)
-	}
+	})
 }
 
 func gitlabValidatePayload(r *http.Request, secret string) ([]byte, error) {

--- a/cmd/frontend/webhooks/webhooks.go
+++ b/cmd/frontend/webhooks/webhooks.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -18,11 +19,11 @@ import (
 type WebhookHandlers struct {
 }
 
-// WebhooksHandler is responsible for handling all incoming webhooks
+// NewHandler is responsible for handling all incoming webhooks
 // and invoking the correct handlers depending on where the webhooks
 // come from.
 func NewHandler(logger log.Logger, db database.DB, gh *GitHubWebhook) http.Handler {
-	base := mux.NewRouter().PathPrefix("/webhooks").Subrouter()
+	base := mux.NewRouter().PathPrefix("/.api/webhooks").Subrouter()
 	base.Path("/{webhook_uuid}").Methods("POST").Handler(webhookHandler(logger, db, gh))
 
 	return base

--- a/cmd/frontend/webhooks/webhooks_test.go
+++ b/cmd/frontend/webhooks/webhooks_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/gorilla/mux"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -63,7 +64,9 @@ func TestWebhooksHandler(t *testing.T) {
 		DB: db,
 	}
 
-	srv := httptest.NewServer(NewHandler(logger, db, &gh))
+	base := mux.NewRouter()
+	base.Path("/.api/webhooks/{webhook_uuid}").Methods("POST").Handler(NewHandler(logger, db, &gh))
+	srv := httptest.NewServer(base)
 
 	t.Run("found GitLab webhook with correct secret returns unimplemented", func(t *testing.T) {
 		requestURL := fmt.Sprintf("%s/.api/webhooks/%v", srv.URL, gitLabWH.UUID)


### PR DESCRIPTION
Move handler to /.api/webhooks

I had to move around the routing a bit to get it to work. I couldn't get it to work with a subrouter.

## Test plan

All tests pass and I manually tested hitting the new URL locally.