### PR TITLE
ranking: add collectSender

### DIFF
--- a/internal/search/backend/aggregate.go
+++ b/internal/search/backend/aggregate.go
@@ -1,0 +1,145 @@
+package backend
+
+import (
+	"sync"
+	"time"
+
+	"github.com/sourcegraph/zoekt"
+	"github.com/sourcegraph/zoekt/stream"
+)
+
+// collectSender is a sender that will aggregate results. Once sending is
+// done, you call Done to return the aggregated result which are ranked.
+//
+// Note: It aggregates Progress as well, and expects that the
+// MaxPendingPriority it receives are monotonically decreasing.
+type collectSender struct {
+	aggregate          *zoekt.SearchResult
+	maxDocDisplayCount int
+}
+
+type collectOpts struct {
+	maxDocDisplayCount int
+	flushWallTime      time.Duration
+}
+
+func newCollectSender(opts *collectOpts) *collectSender {
+	return &collectSender{
+		maxDocDisplayCount: opts.maxDocDisplayCount,
+	}
+}
+
+func (c *collectSender) Send(r *zoekt.SearchResult) {
+	if c.aggregate == nil {
+		c.aggregate = &zoekt.SearchResult{
+			RepoURLs:      map[string]string{},
+			LineFragments: map[string]string{},
+		}
+	}
+
+	c.aggregate.Stats.Add(r.Stats)
+
+	if len(r.Files) > 0 {
+		c.aggregate.Files = append(c.aggregate.Files, r.Files...)
+
+		for k, v := range r.RepoURLs {
+			c.aggregate.RepoURLs[k] = v
+		}
+		for k, v := range r.LineFragments {
+			c.aggregate.LineFragments[k] = v
+		}
+	}
+
+	// The priority of our aggregate is the largest priority we collect.
+	if c.aggregate.Priority < r.Priority {
+		c.aggregate.Priority = r.Priority
+	}
+
+	// We receive monotonically decreasing values, so we update on every call.
+	c.aggregate.MaxPendingPriority = r.MaxPendingPriority
+}
+
+// Done returns the aggregated result. Before returning them the files are
+// ranked and truncated according to the input SearchOptions.
+//
+// If no results are aggregated, ok is false and the result is nil.
+func (c *collectSender) Done() (_ *zoekt.SearchResult, ok bool) {
+	if c.aggregate == nil {
+		return nil, false
+	}
+
+	agg := c.aggregate
+	c.aggregate = nil
+
+	zoekt.SortFiles(agg.Files)
+
+	if max := c.maxDocDisplayCount; max > 0 && len(agg.Files) > max {
+		agg.Files = agg.Files[:max]
+	}
+
+	return agg, true
+}
+
+// newFlushCollectSender creates a sender which will collect and rank results
+// until opts.flushWallTime. After that it will stream each result as it is
+// sent.
+func newFlushCollectSender(opts *collectOpts, sender zoekt.Sender) (zoekt.Sender, func()) {
+	// We don't need to do any collecting, so just pass back the sender to use
+	// directly.
+	if opts.flushWallTime == 0 {
+		return sender, func() {}
+	}
+
+	// We transition through 3 states
+	// 1. collectSender != nil: collect results via collectSender
+	// 2. timerFired: send collected results and mark collectSender nil
+	// 3. collectSender == nil: directly use sender
+
+	var (
+		mu            sync.Mutex
+		collectSender = newCollectSender(opts)
+		timerCancel   = make(chan struct{})
+	)
+
+	// stopCollectingAndFlush will send what we have collected and all future
+	// sends will go via sender directly.
+	stopCollectingAndFlush := func() {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if collectSender == nil {
+			return
+		}
+
+		if agg, ok := collectSender.Done(); ok {
+			sender.Send(agg)
+		}
+
+		// From now on use sender directly
+		collectSender = nil
+
+		// Stop timer goroutine if it is still running.
+		close(timerCancel)
+	}
+
+	// Wait flushWallTime to call stopCollecting.
+	go func() {
+		timer := time.NewTimer(opts.flushWallTime)
+		select {
+		case <-timerCancel:
+			timer.Stop()
+		case <-timer.C:
+			stopCollectingAndFlush()
+		}
+	}()
+
+	return stream.SenderFunc(func(event *zoekt.SearchResult) {
+		mu.Lock()
+		if collectSender != nil {
+			collectSender.Send(event)
+		} else {
+			sender.Send(event)
+		}
+		mu.Unlock()
+	}), stopCollectingAndFlush
+}

--- a/internal/search/backend/aggregate.go
+++ b/internal/search/backend/aggregate.go
@@ -62,14 +62,6 @@ func (c *collectSender) Send(r *zoekt.SearchResult) {
 		}
 	}
 
-	// The priority of our aggregate is the largest priority we collect.
-	if c.aggregate.Priority < r.Priority {
-		c.aggregate.Priority = r.Priority
-	}
-
-	// We receive monotonically decreasing values, so we update on every call.
-	c.aggregate.MaxPendingPriority = r.MaxPendingPriority
-
 	c.sizeBytes += r.SizeBytes()
 }
 

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -230,6 +230,7 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 		},
 		streamer,
 	)
+	defer flushAll()
 
 	// During re-balancing a repository can appear on more than one replica.
 	var mu sync.Mutex
@@ -268,13 +269,8 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 	for i := 0; i < cap(ch); i++ {
 		errs = errors.Append(errs, <-ch)
 	}
-	if errs != nil {
-		return errs
-	}
 
-	flushAll()
-
-	return nil
+	return errs
 }
 
 func newRankingSiteConfig(siteConfig schema.SiteConfiguration) *rankingSiteConfig {

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -222,7 +222,7 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 		siteConfig.maxReorderDuration = 500 * time.Millisecond
 	}
 
-	flushCollectSender, flushAll := newFlushCollectSender(
+	streamer, flushAll := newFlushCollectSender(
 		&collectOpts{
 			maxDocDisplayCount: opts.MaxDocDisplayCount,
 			flushWallTime:      siteConfig.maxReorderDuration,
@@ -254,7 +254,7 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 				sr.Files = dedupper.Dedup(endpoint, sr.Files)
 				mu.Unlock()
 
-				flushCollectSender.Send(sr)
+				streamer.Send(sr)
 			}))
 
 			if canIgnoreError(ctx, err) {

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -228,7 +228,6 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 		},
 		streamer,
 	)
-	defer flushAll()
 
 	// During re-balancing a repository can appear on more than one replica.
 	var mu sync.Mutex
@@ -267,8 +266,13 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 	for i := 0; i < cap(ch); i++ {
 		errs = errors.Append(errs, <-ch)
 	}
+	if errs != nil {
+		return errs
+	}
 
-	return errs
+	flushAll()
+
+	return nil
 }
 
 func newRankingSiteConfig(siteConfig schema.SiteConfiguration) *rankingSiteConfig {

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -214,8 +214,10 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 	siteConfig := newRankingSiteConfig(conf.Get().SiteConfiguration)
 
 	// Hack: 500ms is a better default for this function. The original default of 0
-	// disables the flushCollectSender and offers no ranking at all. Once this
-	// function is not behind a feature flag anymore, we should update the default.
+	// disables the flushCollectSender and offers no ranking at all. For now
+	// StreamSearch and streamSearchExperimentalRanking share newRankingSiteConfig.
+	// Once this function is not behind a feature flag anymore, we should update the
+	// default.
 	if siteConfig.maxReorderDuration == 0 {
 		siteConfig.maxReorderDuration = 500 * time.Millisecond
 	}

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -215,7 +215,11 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 
 	var mu sync.Mutex
 	flushCollectSender, cancel := newFlushCollectSender(
-		&collectOpts{maxDocDisplayCount: opts.MaxDocDisplayCount, flushWallTime: siteConfig.maxReorderDuration},
+		&collectOpts{
+			maxDocDisplayCount: opts.MaxDocDisplayCount,
+			flushWallTime:      siteConfig.maxReorderDuration,
+			maxSizeBytes:       siteConfig.maxSizeBytes,
+		},
 		streamer,
 	)
 	defer cancel()

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -220,7 +220,6 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 		siteConfig.maxReorderDuration = 500 * time.Millisecond
 	}
 
-	var mu sync.Mutex
 	flushCollectSender, flushAll := newFlushCollectSender(
 		&collectOpts{
 			maxDocDisplayCount: opts.MaxDocDisplayCount,
@@ -232,6 +231,7 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 	defer flushAll()
 
 	// During re-balancing a repository can appear on more than one replica.
+	var mu sync.Mutex
 	dedupper := dedupper{}
 
 	// GobCache exists, so we only pay the cost of marshalling a query once
@@ -249,9 +249,8 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 				}
 
 				mu.Lock()
-				defer mu.Unlock()
-
 				sr.Files = dedupper.Dedup(endpoint, sr.Files)
+				mu.Unlock()
 
 				flushCollectSender.Send(sr)
 			}))


### PR DESCRIPTION
All code in this PR is behind a feature flag.

This replaces the priority queue in horizontalSearcher with the collectSender and its flushing wrapper (https://github.com/sourcegraph/zoekt/pull/438) @keegancsmith added to Zoekt.

As a consequence, with `ENABLE_EXPERIMENTAL_RANKING: true`, search results are ordered based on their match score and rank vector alone.   

## Test plan
- The code is behind a feature flag and is currently only called in local dev
- I set `ENABLE_EXPERIMENTAL_RANKING: true` for frontend and indexserver and confirmed that basic search is running as expected.
- I checked Prometheus for the newly added metric, too.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
