### PR TITLE
Filter apply commands

### DIFF
--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
@@ -178,6 +179,10 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 	}
 
 	applyArgs := append([]string{"apply", "--cached"}, req.GitApplyArgs...)
+	if !gitdomain.IsAllowedGitCmd(logger, applyArgs) {
+		return http.StatusInternalServerError, resp
+	}
+
 	cmd = exec.CommandContext(ctx, "git", applyArgs...)
 	cmd.Dir = tmpRepoDir
 	cmd.Env = append(os.Environ(), tmpGitPathEnv, altObjectsEnv)

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1383,7 +1383,14 @@ func (s *Server) handleBatchLog(w http.ResponseWriter, r *http.Request) {
 		}
 
 		var buf bytes.Buffer
-		cmd := exec.CommandContext(ctx, "git", "log", "-n", "1", "--name-only", format, string(repoCommit.CommitID))
+
+		commitId := string(repoCommit.CommitID)
+		// make sure CommitID is not an arg
+		if commitId[0] == '-' {
+			return "", true, err
+		}
+
+		cmd := exec.CommandContext(ctx, "git", "log", "-n", "1", "--name-only", format, commitId)
 		dir.Set(cmd)
 		cmd.Stdout = &buf
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1387,7 +1387,7 @@ func (s *Server) handleBatchLog(w http.ResponseWriter, r *http.Request) {
 		commitId := string(repoCommit.CommitID)
 		// make sure CommitID is not an arg
 		if commitId[0] == '-' {
-			return "", true, err
+			return "", true, errors.New("commit ID starting with - is not allowed")
 		}
 
 		cmd := exec.CommandContext(ctx, "git", "log", "-n", "1", "--name-only", format, commitId)

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -195,9 +195,6 @@ func (c *clientImplementor) execReader(ctx context.Context, repo api.RepoName, a
 	span.SetTag("args", args)
 	defer span.Finish()
 
-	if !gitdomain.IsAllowedGitCmd(c.logger, args) {
-		return nil, errors.Errorf("command failed: %v is not a allowed git command", args)
-	}
 	cmd := c.gitCommand(repo, args...)
 	return cmd.StdoutReader(ctx)
 }

--- a/internal/gitserver/gitdomain/exec.go
+++ b/internal/gitserver/gitdomain/exec.go
@@ -35,6 +35,7 @@ var (
 		"shortlog":     {"-s", "-n", "-e", "--no-merges", "--after", "--before"},
 		"cat-file":     {},
 		"lfs":          {},
+		"apply":        {"--cached", "-p0"},
 
 		// Used in tests to simulate errors with runCommand in handleExec of gitserver.
 		"testcommand": {},


### PR DESCRIPTION
Add `git apply` commands to the filter and filter executions. More information can be found [here](https://github.com/sourcegraph/security-issues/issues/321).

## Test plan

- [x] local testing
- [x] ci tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
