### PR TITLE
Parallelize inference jobs

### DIFF
--- a/internal/codeintel/autoindexing/background/scheduler/config.go
+++ b/internal/codeintel/autoindexing/background/scheduler/config.go
@@ -13,6 +13,7 @@ type config struct {
 	RepositoryProcessDelay time.Duration
 	RepositoryBatchSize    int
 	PolicyBatchSize        int
+	InferenceConcurrency   int
 
 	OnDemandSchedulerInterval time.Duration
 	OnDemandBatchsize         int
@@ -30,6 +31,7 @@ func (c *config) Load() {
 	c.RepositoryProcessDelay = c.GetInterval(repositoryProcessDelayName, "24h", "The minimum frequency that the same repository can be considered for auto-index scheduling.")
 	c.RepositoryBatchSize = c.GetInt(repositoryBatchSizeName, "2500", "The number of repositories to consider for auto-indexing scheduling at a time.")
 	c.PolicyBatchSize = c.GetInt(policyBatchSizeName, "100", "The number of policies to consider for auto-indexing scheduling at a time.")
+	c.InferenceConcurrency = c.GetInt("CODEINTEL_AUTOINDEXING_INFERENCE_CONCURRENCY", "16", "The number of inference jobs running in parallel in the background scheduler.")
 
 	c.OnDemandSchedulerInterval = c.GetInterval("CODEINTEL_AUTOINDEXING_ON_DEMAND_SCHEDULER_INTERVAL", "30s", "How frequently to run the on-demand auto-indexing scheduling routine.")
 	c.OnDemandBatchsize = c.GetInt("CODEINTEL_AUTOINDEXING_ON_DEMAND_SCHEDULER_BATCH_SIZE", "100", "The number of repo/rev pairs to consider for on-demand auto-indexing scheduling at a time.")

--- a/internal/codeintel/autoindexing/background/scheduler/iface.go
+++ b/internal/codeintel/autoindexing/background/scheduler/iface.go
@@ -12,6 +12,7 @@ type AutoIndexingServiceBackgroundJobs interface {
 		repositoryProcessDelay time.Duration,
 		repositoryBatchSize int,
 		policyBatchSize int,
+		inferenceConcurrency int,
 	) goroutine.BackgroundRoutine
 
 	NewOnDemandScheduler(

--- a/internal/codeintel/autoindexing/background/scheduler/init.go
+++ b/internal/codeintel/autoindexing/background/scheduler/init.go
@@ -11,6 +11,7 @@ func NewSchedulers(backgroundJobs AutoIndexingServiceBackgroundJobs) []goroutine
 			ConfigInst.RepositoryProcessDelay,
 			ConfigInst.RepositoryBatchSize,
 			ConfigInst.PolicyBatchSize,
+			ConfigInst.InferenceConcurrency,
 		),
 
 		backgroundJobs.NewOnDemandScheduler(

--- a/internal/codeintel/autoindexing/internal/background/background_jobs.go
+++ b/internal/codeintel/autoindexing/internal/background/background_jobs.go
@@ -21,7 +21,7 @@ type BackgroundJob interface {
 	NewDependencyIndexResetter(interval time.Duration) *dbworker.Resetter
 	NewIndexResetter(interval time.Duration) *dbworker.Resetter
 	NewOnDemandScheduler(interval time.Duration, batchSize int) goroutine.BackgroundRoutine
-	NewScheduler(interval time.Duration, repositoryProcessDelay time.Duration, repositoryBatchSize int, policyBatchSize int) goroutine.BackgroundRoutine
+	NewScheduler(interval time.Duration, repositoryProcessDelay time.Duration, repositoryBatchSize int, policyBatchSize int, inferenceConcurrency int) goroutine.BackgroundRoutine
 	NewJanitor(
 		interval time.Duration,
 		minimumTimeSinceLastCheck time.Duration,


### PR DESCRIPTION
Currently, we are only inferring configs for 360k repos every 12h on dotcom. To raise this number, we want to try if it gets better if these are not fully sequentially inserted, starting with a default concurrency of 16 but added a variable to tweak it more before we settle on a final recommended value for customers.



## Test plan

It still infers locally, also relying on test suite.