### PR TITLE
insights: only save recording times data if the series supports augmentation

### DIFF
--- a/enterprise/internal/insights/background/queryrunner/search.go
+++ b/enterprise/internal/insights/background/queryrunner/search.go
@@ -233,7 +233,9 @@ func (r *workHandler) persistRecordings(ctx context.Context, job *SearchJob, ser
 		}
 		snapshot = true
 	}
-	seriesRecordingTimes.RecordingTimes = append(seriesRecordingTimes.RecordingTimes, types.RecordingTime{recordTime, snapshot})
+	if series.SupportsAugmentation {
+		seriesRecordingTimes.RecordingTimes = append(seriesRecordingTimes.RecordingTimes, types.RecordingTime{recordTime, snapshot})
+	}
 
 	// Newly queued queries should be scoped to correct repos however leaving filtering
 	// in place to ensure any older queued jobs get filtered properly. It's a noop for global insights.

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -496,6 +496,9 @@ func (s *Store) DeleteSnapshots(ctx context.Context, series *types.InsightSeries
 	if err != nil {
 		return errors.Wrapf(err, "failed to delete insights snapshots for series_id: %s", series.SeriesID)
 	}
+	if !series.SupportsAugmentation {
+		return nil
+	}
 	err = s.Exec(ctx, sqlf.Sprintf(deleteSnapshotRecordingTimeSql, series.ID))
 	if err != nil {
 		return errors.Wrapf(err, "failed to delete snapshot recording time for series_id %d", series.ID)


### PR DESCRIPTION
we don't need to store this redundant data for pre-augmentation series

## Test plan

Existing unit tests work. Manually tested that new points don't get stamped