### PR TITLE
admin: change how repo sync counters are rendered.

### DIFF
--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react'
 
+import {mdiChevronDown, mdiChevronLeft} from '@mdi/js';
+import {format} from 'date-fns';
 import * as H from 'history'
 import { parse as parseJSONC } from 'jsonc-parser'
 import { Redirect, useHistory } from 'react-router'
@@ -11,7 +13,7 @@ import { hasProperty } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
 import * as GQL from '@sourcegraph/shared/src/schema'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { LoadingSpinner, H2, H3, Badge, Container } from '@sourcegraph/wildcard'
+import { Button, LoadingSpinner, H2, H3, Badge, Container, Icon } from '@sourcegraph/wildcard'
 
 import {
     ExternalServiceFields,
@@ -28,7 +30,6 @@ import { FilteredConnection, FilteredConnectionQueryArguments } from '../Filtere
 import { LoaderButton } from '../LoaderButton'
 import { PageTitle } from '../PageTitle'
 import { Duration } from '../time/Duration'
-import { Timestamp } from '../time/Timestamp'
 
 import {
     useSyncExternalService,
@@ -359,13 +360,34 @@ const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJob
         ]
     }, [node])
 
+    const [isExpanded, setIsExpanded] = useState(false)
+    const toggleIsExpanded = useCallback<React.MouseEventHandler<HTMLButtonElement>>(() => {
+        setIsExpanded(!isExpanded)
+    }, [isExpanded])
+
     return (
         <li className="list-group-item py-3">
-            <div className="d-flex align-items-center justify-content-between">
-                <div className="flex-shrink-0 mr-2">
+            <div className="d-flex justify-content-left">
+                <div className="d-flex mr-2 justify-content-left">
                     <Badge>{node.state}</Badge>
                 </div>
-                <div className="flex-shrink-0 flex-grow-1 mr-2">
+                <div className="flex-shrink-1 flex-grow-0 mr-1">
+                    {node.startedAt === null && 'Not started yet.'}
+                    {node.startedAt !== null && (
+                        <>
+                            Started at {format(Date.parse(node.startedAt), 'pp')}.
+                        </>
+                    )}
+                </div>
+                <div className="flex-shrink-1 flex-grow-0 mr-1">
+                    {node.finishedAt === null && 'Not finished yet.'}
+                    {node.finishedAt !== null && (
+                        <>
+                            Finished at {format(Date.parse(node.finishedAt), 'pp')}.
+                        </>
+                    )}
+                </div>
+                <div className="flex-shrink-0 flex-grow-1 mr-1">
                     {node.startedAt && (
                         <>
                             {node.finishedAt === null && <>Running for </>}
@@ -397,26 +419,17 @@ const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJob
                         className={styles.cancelButton}
                     />
                 )}
-                <div className="text-right flex-shrink-0">
-                    <div>
-                        {node.startedAt === null && 'Not started yet'}
-                        {node.startedAt !== null && (
-                            <>
-                                Started <Timestamp date={node.startedAt} />
-                            </>
-                        )}
-                    </div>
-                    <div>
-                        {node.finishedAt === null && 'Not finished yet'}
-                        {node.finishedAt !== null && (
-                            <>
-                                Finished <Timestamp date={node.finishedAt} />
-                            </>
-                        )}
-                    </div>
+                <div className="d-flex justify-content-right">
+                    <Button
+                        variant="icon"
+                        aria-label={isExpanded ? 'Collapse section' : 'Expand section'}
+                        onClick={toggleIsExpanded}
+                    >
+                        <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronDown : mdiChevronLeft} />
+                    </Button>
                 </div>
             </div>
-            {legends && <ValueLegendList className="mb-1" items={legends} />}
+            {isExpanded && legends && <ValueLegendList className="mb-0" items={legends} />}
             {node.failureMessage && <ErrorAlert error={node.failureMessage} className="mt-2 mb-0" />}
         </li>
     )

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react'
 
-import { mdiChevronDown, mdiChevronLeft } from '@mdi/js'
+import { mdiChevronDown, mdiChevronRight } from '@mdi/js'
 import { format } from 'date-fns'
 import * as H from 'history'
 import { parse as parseJSONC } from 'jsonc-parser'
@@ -374,6 +374,15 @@ const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJob
         <li className="list-group-item py-3">
             <div className="d-flex justify-content-left">
                 <div className="d-flex mr-2 justify-content-left">
+                    <Button
+                        variant="icon"
+                        aria-label={isExpanded ? 'Collapse section' : 'Expand section'}
+                        onClick={toggleIsExpanded}
+                    >
+                        <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronDown : mdiChevronRight} />
+                    </Button>
+                </div>
+                <div className="d-flex mr-2 justify-content-left">
                     <Badge>{node.state}</Badge>
                 </div>
                 <div className="flex-shrink-1 flex-grow-0 mr-1">
@@ -412,15 +421,6 @@ const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJob
                         className={styles.cancelButton}
                     />
                 )}
-                <div className="d-flex justify-content-right">
-                    <Button
-                        variant="icon"
-                        aria-label={isExpanded ? 'Collapse section' : 'Expand section'}
-                        onClick={toggleIsExpanded}
-                    >
-                        <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronDown : mdiChevronLeft} />
-                    </Button>
-                </div>
             </div>
             {isExpanded && legends && <ValueLegendList className="mb-0" items={legends} />}
             {node.failureMessage && <ErrorAlert error={node.failureMessage} className="mt-2 mb-0" />}

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react'
 
-import {mdiChevronDown, mdiChevronLeft} from '@mdi/js';
-import {format} from 'date-fns';
+import { mdiChevronDown, mdiChevronLeft } from '@mdi/js'
+import { format } from 'date-fns'
 import * as H from 'history'
 import { parse as parseJSONC } from 'jsonc-parser'
 import { Redirect, useHistory } from 'react-router'
@@ -373,19 +373,11 @@ const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJob
                 </div>
                 <div className="flex-shrink-1 flex-grow-0 mr-1">
                     {node.startedAt === null && 'Not started yet.'}
-                    {node.startedAt !== null && (
-                        <>
-                            Started at {format(Date.parse(node.startedAt), 'pp')}.
-                        </>
-                    )}
+                    {node.startedAt !== null && <>Started at {format(Date.parse(node.startedAt), 'pp')}.</>}
                 </div>
                 <div className="flex-shrink-1 flex-grow-0 mr-1">
                     {node.finishedAt === null && 'Not finished yet.'}
-                    {node.finishedAt !== null && (
-                        <>
-                            Finished at {format(Date.parse(node.finishedAt), 'pp')}.
-                        </>
-                    )}
+                    {node.finishedAt !== null && <>Finished at {format(Date.parse(node.finishedAt), 'pp')}.</>}
                 </div>
                 <div className="flex-shrink-0 flex-grow-1 mr-1">
                     {node.startedAt && (

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -360,7 +360,12 @@ const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJob
         ]
     }, [node])
 
-    const [isExpanded, setIsExpanded] = useState(false)
+    let runningStatuses = [
+        ExternalServiceSyncJobState.QUEUED,
+        ExternalServiceSyncJobState.PROCESSING,
+        ExternalServiceSyncJobState.CANCELING,
+    ]
+    const [isExpanded, setIsExpanded] = useState(runningStatuses.includes(node.state))
     const toggleIsExpanded = useCallback<React.MouseEventHandler<HTMLButtonElement>>(() => {
         setIsExpanded(!isExpanded)
     }, [isExpanded])
@@ -373,11 +378,11 @@ const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJob
                 </div>
                 <div className="flex-shrink-1 flex-grow-0 mr-1">
                     {node.startedAt === null && 'Not started yet.'}
-                    {node.startedAt !== null && <>Started at {format(Date.parse(node.startedAt), 'pp')}.</>}
+                    {node.startedAt !== null && <>Started at {format(Date.parse(node.startedAt), 'HH:mm:ss')}.</>}
                 </div>
                 <div className="flex-shrink-1 flex-grow-0 mr-1">
                     {node.finishedAt === null && 'Not finished yet.'}
-                    {node.finishedAt !== null && <>Finished at {format(Date.parse(node.finishedAt), 'pp')}.</>}
+                    {node.finishedAt !== null && <>Finished at {format(Date.parse(node.finishedAt), 'HH:mm:ss')}.</>}
                 </div>
                 <div className="flex-shrink-0 flex-grow-1 mr-1">
                     {node.startedAt && (
@@ -394,11 +399,7 @@ const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJob
                         </>
                     )}
                 </div>
-                {[
-                    ExternalServiceSyncJobState.QUEUED,
-                    ExternalServiceSyncJobState.PROCESSING,
-                    ExternalServiceSyncJobState.CANCELING,
-                ].includes(node.state) && (
+                {runningStatuses.includes(node.state) && (
                     <LoaderButton
                         label="Cancel"
                         alwaysShowLabel={true}

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -360,12 +360,12 @@ const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJob
         ]
     }, [node])
 
-    let runningStatuses = [
+    const runningStatuses = new Set<ExternalServiceSyncJobState> ([
         ExternalServiceSyncJobState.QUEUED,
         ExternalServiceSyncJobState.PROCESSING,
         ExternalServiceSyncJobState.CANCELING,
-    ]
-    const [isExpanded, setIsExpanded] = useState(runningStatuses.includes(node.state))
+    ])
+    const [isExpanded, setIsExpanded] = useState(runningStatuses.has(node.state))
     const toggleIsExpanded = useCallback<React.MouseEventHandler<HTMLButtonElement>>(() => {
         setIsExpanded(!isExpanded)
     }, [isExpanded])
@@ -399,7 +399,7 @@ const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJob
                         </>
                     )}
                 </div>
-                {runningStatuses.includes(node.state) && (
+                {runningStatuses.has(node.state) && (
                     <LoaderButton
                         label="Cancel"
                         alwaysShowLabel={true}


### PR DESCRIPTION
This commit makes start and finish times absolute (not relative as they used to be), moves them in one line and hides the numbers behind collapse button.

### Before
<img width="1166" alt="image" src="https://user-images.githubusercontent.com/94846361/197825977-196d2bac-e6d1-42c7-b4cd-ea7386d227de.png">

### After
<img width="1142" alt="image" src="https://user-images.githubusercontent.com/94846361/197826391-b5b567c3-9aff-4476-96cb-6642c9c5e28d.png">

### Updates from Oct 27 (chevron icon moved from right to left, auto-expand queued/progress nodes)
<img width="913" alt="image" src="https://user-images.githubusercontent.com/94846361/198234923-762b37f5-f22e-4698-8d58-e71cad8dd75f.png">

## What is not implemented
According to [revised design](https://www.figma.com/file/Rt6HoQEOG5seIvOGUCLpmi/Quick-Fix-Repo-Sync-Queue?node-id=0%3A1) sizes of statistics numbers should be smaller, but I haven't found a simple way of changing the size of [ValueLegendItem](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/site-admin/analytics/components/ValueLegendList.tsx?L20&subtree=true).
My hunch is that `className` should include some size-tweaking css statements, but I haven't learned the spells yet.

Closes https://github.com/sourcegraph/sourcegraph/issues/43084

### Test plan
TBD

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ao-ext-svc-sync-job-view-design.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
