### PR TITLE
[language-platform] make parent directory while scrolling in file explorer

### DIFF
--- a/client/web/src/tree/Directory.tsx
+++ b/client/web/src/tree/Directory.tsx
@@ -51,6 +51,7 @@ export const Directory: React.FunctionComponent<React.PropsWithChildren<Director
         isActive={props.isActive}
         isSelected={props.isSelected}
         isExpanded={props.isExpanded}
+        depth={props.depth}
     >
         <TreeLayerCell className="test-sidebar-file-decorable">
             <TreeLayerRowContents data-tree-is-directory="true" data-tree-path={props.entryInfo.path} isNew={true}>

--- a/client/web/src/tree/Tree.module.scss
+++ b/client/web/src/tree/Tree.module.scss
@@ -45,7 +45,7 @@
     display: block;
     align-items: center;
     justify-content: space-between;
-    padding: 0 0 0 5px;
+    padding: 0 0 0 0.35rem;
 }
 
 .row {

--- a/client/web/src/tree/Tree.module.scss
+++ b/client/web/src/tree/Tree.module.scss
@@ -45,6 +45,7 @@
     display: block;
     align-items: center;
     justify-content: space-between;
+    padding: 0 0 0 5px;
 }
 
 .row {
@@ -68,6 +69,16 @@
         width: 100%;
         background-color: var(--color-bg-3);
         color: var(--body-color);
+    }
+
+    &--expanded {
+        position: sticky;
+        top: 1px;
+        background-color: var(--color-bg-2);
+
+        &:hover {
+            background-color: var(--color-bg-3);
+        }
     }
 
     &-contents,

--- a/client/web/src/tree/Tree.module.scss
+++ b/client/web/src/tree/Tree.module.scss
@@ -73,7 +73,7 @@
 
     &--expanded {
         position: sticky;
-        top: 1px;
+        top: 0;
         background-color: var(--color-bg-2);
 
         &:hover {

--- a/client/web/src/tree/components/TreeRow.tsx
+++ b/client/web/src/tree/components/TreeRow.tsx
@@ -4,10 +4,13 @@ import classNames from 'classnames'
 
 import styles from '../Tree.module.scss'
 
+const MAX_DIRECTORY_DEPTH = 100
+
 type TreeRowProps = HTMLAttributes<HTMLTableRowElement> & {
     isActive?: boolean
     isSelected?: boolean
     isExpanded?: boolean
+    depth?: number
 }
 
 export const TreeRow: React.FunctionComponent<React.PropsWithChildren<TreeRowProps>> = ({
@@ -16,14 +19,23 @@ export const TreeRow: React.FunctionComponent<React.PropsWithChildren<TreeRowPro
     isExpanded,
     className,
     children,
+    depth = 0,
     ...rest
 }) => (
     <tr
-        className={classNames(styles.row, isActive && styles.rowActive, isSelected && styles.rowSelected, className)}
+        className={classNames(
+            styles.row,
+            isActive && styles.rowActive,
+            isSelected && styles.rowSelected,
+            isExpanded && styles.rowExpanded,
+            className
+        )}
         data-testid="tree-row"
         data-tree-row-active={isActive}
         data-tree-row-selected={isSelected}
         data-tree-row-expanded={isExpanded}
+        // eslint-disable-next-line react/forbid-dom-props
+        style={{ top: `${depth * 2}em`, zIndex: MAX_DIRECTORY_DEPTH > depth ? MAX_DIRECTORY_DEPTH - depth : 'inherit' }}
         {...rest}
     >
         {children}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/33129

Pin current directory and ancestors in file explorer


https://user-images.githubusercontent.com/6225160/197837916-4c892648-215d-4781-b4ff-ca364f2b966c.mov



## Test plan
Ran all the test.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

![sticky](https://media.giphy.com/media/kNdYrCO6yOKeM66bIU/giphy.gif)

## App preview:

- [Web](https://sg-web-cesar-33129-sticky-directory.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

