### PR TITLE
CodeMirror blob: Improve screenreader behavior

### DIFF
--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -40,6 +40,10 @@ const staticExtensions: Extension = [
         // triggering the in-document search (see below) work when Mod-f is
         // pressed
         tabindex: '0',
+        // CodeMirror defaults to role="textbox" which does not produce the
+        // desired screenreader behavior we want for this component.
+        // See https://github.com/sourcegraph/sourcegraph/issues/43375
+        role: 'generic',
     }),
     editorHeight({ height: '100%' }),
     EditorView.theme({


### PR DESCRIPTION
Fixes #43375

This commit changes the content element's role from "textbox" to "generic" so that screenreaders don't announce the element as being a text input.

<img width="312" alt="2022-10-26_07-47" src="https://user-images.githubusercontent.com/179026/197966604-90c041a6-9284-484f-bcb5-a09ac027f117.png">


## Test plan

Manual inspection of the DOM

## App preview:

- [Web](https://sg-web-fkling-43375-cm-blob-screenreader.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
