### PR TITLE
gitserver: factor out maybeStartClone

### DIFF
--- a/cmd/gitserver/server/clone.go
+++ b/cmd/gitserver/server/clone.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"context"
+
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+)
+
+func (s *Server) maybeStartClone(ctx context.Context, logger log.Logger, repo api.RepoName) (notFound *protocol.NotFoundPayload, cloned bool) {
+	dir := s.dir(repo)
+	if repoCloned(dir) {
+		return nil, true
+	}
+
+	if conf.Get().DisableAutoGitUpdates {
+		logger.Debug("not cloning on demand as DisableAutoGitUpdates is set")
+		return &protocol.NotFoundPayload{}, false
+	}
+
+	cloneProgress, cloneInProgress := s.locker.Status(dir)
+	if cloneInProgress {
+		return &protocol.NotFoundPayload{
+			CloneInProgress: true,
+			CloneProgress:   cloneProgress,
+		}, false
+	}
+
+	cloneProgress, err := s.cloneRepo(ctx, repo, nil)
+	if err != nil {
+		logger.Debug("error starting repo clone", log.String("repo", string(repo)), log.Error(err))
+		return &protocol.NotFoundPayload{CloneInProgress: false}, false
+	}
+
+	return &protocol.NotFoundPayload{
+		CloneInProgress: true,
+		CloneProgress:   cloneProgress,
+	}, false
+}


### PR DESCRIPTION
This moves the code related to uncloned repos inside of exec into its own function. This is a non-functional change.

Motivation: I have intention to maybe reuse this code. For LFS testing I've realised I need deeper integration into gitserver due to how LFS acts with fetching missing objects on private repos.

Test Plan: go test