### PR TITLE
accesslog: use log.Field instead of map for meta

### DIFF
--- a/cmd/gitserver/server/commands.go
+++ b/cmd/gitserver/server/commands.go
@@ -21,9 +21,7 @@ func handleGetObject(logger log.Logger, getObject gitdomain.GetObjectFunc) func(
 		}
 
 		// Log which actor is accessing the repo.
-		accesslog.Record(r.Context(), string(req.Repo), map[string]string{
-			"objectname": req.ObjectName,
-		})
+		accesslog.Record(r.Context(), string(req.Repo), log.String("objectname", req.ObjectName))
 
 		obj, err := getObject(r.Context(), req.Repo, req.ObjectName)
 		if err != nil {

--- a/cmd/gitserver/server/gitservice.go
+++ b/cmd/gitserver/server/gitservice.go
@@ -90,10 +90,10 @@ func (s *Server) gitServiceHandler() *gitservice.Handler {
 			metricServiceRunning.WithLabelValues(svc).Inc()
 
 			// Log which which actor is accessing the repo.
-			accesslog.Record(ctx, repo, map[string]string{
-				"svc":      svc,
-				"protocol": protocol,
-			})
+			accesslog.Record(ctx, repo,
+				log.String("svc", svc),
+				log.String("protocol", protocol),
+			)
 
 			return func(err error) {
 				errLabel := strconv.FormatBool(err != nil)

--- a/cmd/gitserver/server/internal/accesslog/accesslog.go
+++ b/cmd/gitserver/server/internal/accesslog/accesslog.go
@@ -18,13 +18,13 @@ type contextKey struct{}
 
 type paramsContext struct {
 	repo     string
-	metadata map[string]string
+	metadata []log.Field
 }
 
 // Record updates a mutable unexported field stored in the context,
 // making it available for Middleware to log at the end of the middleware
 // chain.
-func Record(ctx context.Context, repo string, meta map[string]string) {
+func Record(ctx context.Context, repo string, meta ...log.Field) {
 	pc := fromContext(ctx)
 	if pc == nil {
 		return
@@ -86,12 +86,7 @@ func (a *accessLogger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if paramsCtx != nil {
-		params := []log.Field{
-			log.String("repo", paramsCtx.repo),
-		}
-		for k, v := range paramsCtx.metadata {
-			params = append(params, log.String(k, v))
-		}
+		params := append([]log.Field{log.String("repo", paramsCtx.repo)}, paramsCtx.metadata...)
 		fields = append(fields, log.Object("params", params...))
 	} else {
 		fields = append(fields, log.String("params", "nil"))

--- a/cmd/gitserver/server/internal/accesslog/accesslog_test.go
+++ b/cmd/gitserver/server/internal/accesslog/accesslog_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,9 +21,9 @@ func TestRecord(t *testing.T) {
 		ctx := context.Background()
 		ctx = withContext(ctx, &paramsContext{})
 
-		meta := map[string]string{"cmd": "git", "args": "grep foo"}
+		meta := []log.Field{log.String("cmd", "git"), log.String("args", "grep foo")}
 
-		Record(ctx, "github.com/foo/bar", meta)
+		Record(ctx, "github.com/foo/bar", meta...)
 
 		pc := fromContext(ctx)
 		require.NotNil(t, pc)
@@ -33,9 +34,9 @@ func TestRecord(t *testing.T) {
 	t.Run("OK not initialized context", func(t *testing.T) {
 		ctx := context.Background()
 
-		meta := map[string]string{"cmd": "git", "args": "grep foo"}
+		meta := []log.Field{log.String("cmd", "git"), log.String("args", "grep foo")}
 
-		Record(ctx, "github.com/foo/bar", meta)
+		Record(ctx, "github.com/foo/bar", meta...)
 		pc := fromContext(ctx)
 		assert.Nil(t, pc)
 	})
@@ -65,8 +66,7 @@ func TestHTTPMiddleware(t *testing.T) {
 	t.Run("OK for access log setting", func(t *testing.T) {
 		logger, exportLogs := logtest.Captured(t)
 		h := HTTPMiddleware(logger, &accessLogConf{}, func(w http.ResponseWriter, r *http.Request) {
-			meta := map[string]string{"cmd": "git", "args": "grep foo"}
-			Record(r.Context(), "github.com/foo/bar", meta)
+			Record(r.Context(), "github.com/foo/bar", log.String("cmd", "git"), log.String("args", "grep foo"))
 		})
 
 		rec := httptest.NewRecorder()
@@ -115,8 +115,7 @@ func TestHTTPMiddleware(t *testing.T) {
 		cfg := &accessLogConf{disabled: true}
 		var handled bool
 		h := HTTPMiddleware(logger, cfg, func(w http.ResponseWriter, r *http.Request) {
-			meta := map[string]string{"cmd": "git", "args": "grep foo"}
-			Record(r.Context(), "github.com/foo/bar", meta)
+			Record(r.Context(), "github.com/foo/bar", log.String("cmd", "git"), log.String("args", "grep foo"))
 			handled = true
 		})
 		rec := httptest.NewRecorder()

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1086,11 +1086,11 @@ func (s *Server) handleArchive(w http.ResponseWriter, r *http.Request) {
 	)
 
 	// Log which which actor is accessing the repo.
-	accesslog.Record(r.Context(), repo, map[string]string{
-		"treeish": treeish,
-		"format":  format,
-		"path":    strings.Join(pathspecs, ","),
-	})
+	accesslog.Record(r.Context(), repo,
+		log.String("treeish", treeish),
+		log.String("format", format),
+		log.Strings("path", pathspecs),
+	)
 
 	if err := checkSpecArgSafety(treeish); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
@@ -1523,10 +1523,10 @@ func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
 		cmd = req.Args[0]
 		args = args[1:]
 	}
-	accesslog.Record(r.Context(), string(req.Repo), map[string]string{
-		"cmd":  cmd,
-		"args": strings.Join(args, " "),
-	})
+	accesslog.Record(r.Context(), string(req.Repo),
+		log.String("cmd", cmd),
+		log.Strings("args", args),
+	)
 
 	s.exec(w, r, &req)
 }
@@ -1768,11 +1768,11 @@ func (s *Server) handleP4Exec(w http.ResponseWriter, r *http.Request) {
 	//
 	// p4-exec is currently only used for fetching user based permissions information
 	// so, we don't have a repo name.
-	accesslog.Record(r.Context(), "<no-repo>", map[string]string{
-		"p4user": req.P4User,
-		"p4port": req.P4Port,
-		"args":   strings.Join(req.Args, " "),
-	})
+	accesslog.Record(r.Context(), "<no-repo>",
+		log.String("p4user", req.P4User),
+		log.String("p4port", req.P4Port),
+		log.Strings("args", req.Args),
+	)
 
 	// Make sure credentials are valid before heavier operation
 	err := p4pingWithTrust(r.Context(), req.P4Port, req.P4User, req.P4Passwd)


### PR DESCRIPTION
This has better memory usage, natively supports slices, does less work if disabled and is the final target for our logs anyways. As log becomes more deeply embedded in our codebase, I imagine this will be the more convenient field to use in logs, traces and accesslog.

Test Plan: go test