### PR TITLE
codeintel/search-core: disable flaky tests

### DIFF
--- a/dev/ci/go-backcompat/flakefiles/v4.1.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.1.0.json
@@ -1,0 +1,7 @@
+[
+  {
+    "path": "internal/codeintel/policies/internal/store",
+    "prefix": "TestSelectPoliciesForRepositoryMembershipUpdate",
+    "reason": "The same policies are returned but in an unexpected order."
+  }
+]

--- a/dev/ci/go-backcompat/flakefiles/v4.1.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.1.0.json
@@ -6,7 +6,7 @@
   },
   {
     "path": "internal/gitserver",
-    "prefix": "TestRepository_Branches_IncludeCommit",
+    "prefix": "TestLFSSmudge",
     "reason": "Git config seems to be borked after introduction of https://github.com/sourcegraph/sourcegraph/pull/43227"
   }
 ]

--- a/dev/ci/go-backcompat/flakefiles/v4.1.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.1.0.json
@@ -3,5 +3,10 @@
     "path": "internal/codeintel/policies/internal/store",
     "prefix": "TestSelectPoliciesForRepositoryMembershipUpdate",
     "reason": "The same policies are returned but in an unexpected order."
+  },
+  {
+    "path": "internal/gitserver",
+    "prefix": "TestRepository_Branches_IncludeCommit",
+    "reason": "Git config seems to be borked after introduction of https://github.com/sourcegraph/sourcegraph/pull/43227"
   }
 ]

--- a/internal/codeintel/policies/internal/store/store_repo_test.go
+++ b/internal/codeintel/policies/internal/store/store_repo_test.go
@@ -199,7 +199,7 @@ func TestUpdateReposMatchingPatternsOverLimit(t *testing.T) {
 }
 
 func TestSelectPoliciesForRepositoryMembershipUpdate(t *testing.T) {
-	t.Skip("Flaky due to unexpected ordering of results")
+	t.Skip("Flaky due to unexpected ordering of results: https://github.com/sourcegraph/sourcegraph/issues/43472")
 
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))

--- a/internal/codeintel/policies/internal/store/store_repo_test.go
+++ b/internal/codeintel/policies/internal/store/store_repo_test.go
@@ -199,6 +199,8 @@ func TestUpdateReposMatchingPatternsOverLimit(t *testing.T) {
 }
 
 func TestSelectPoliciesForRepositoryMembershipUpdate(t *testing.T) {
+	t.Skip("Flaky due to unexpected ordering of results")
+
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := testStoreWithoutConfigurationPolicies(t, db)

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -2764,6 +2764,8 @@ func TestRepository_Branches_BehindAheadCounts(t *testing.T) {
 }
 
 func TestRepository_Branches_IncludeCommit(t *testing.T) {
+	t.Skip("Failing, see https://github.com/sourcegraph/sourcegraph/issues/43473")
+
 	ClientMocks.LocalGitserver = true
 	t.Cleanup(func() {
 		ResetClientMocks()

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -2764,8 +2764,6 @@ func TestRepository_Branches_BehindAheadCounts(t *testing.T) {
 }
 
 func TestRepository_Branches_IncludeCommit(t *testing.T) {
-	t.Skip("Failing, see https://github.com/sourcegraph/sourcegraph/issues/43473")
-
 	ClientMocks.LocalGitserver = true
 	t.Cleanup(func() {
 		ResetClientMocks()
@@ -2826,6 +2824,8 @@ func usePermissionsForFilePermissionsFunc(m *authz.MockSubRepoPermissionChecker)
 }
 
 func TestLFSSmudge(t *testing.T) {
+	t.Skip("Failing, see https://github.com/sourcegraph/sourcegraph/issues/43473")
+
 	// TODO enforce on CI once CI has git-lfs
 	if _, err := exec.LookPath("git-lfs"); err != nil {
 		t.Skip("git-lfs not installed")

--- a/internal/search/job/jobutil/testdata/Test_computeResultTypes/plain_pattern_searches_repo_path_file_content.golden
+++ b/internal/search/job/jobutil/testdata/Test_computeResultTypes/plain_pattern_searches_repo_path_file_content.golden
@@ -1,1 +1,1 @@
-repo|file|path
+file|path|repo

--- a/internal/search/result/result_type.go
+++ b/internal/search/result/result_type.go
@@ -1,6 +1,9 @@
 package result
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 // Types represents a set of result types.
 // It's a bitset corresponding to the disjunction of types it represents.
@@ -50,5 +53,6 @@ func (r Types) String() string {
 		}
 		names = append(names, name)
 	}
+	sort.Strings(names)
 	return strings.Join(names, "|")
 }


### PR DESCRIPTION
### TestSelectPoliciesForRepositoryMembershipUpdate

Test output seems to be ordered differently but still the same members:

```shell
_bk;t=1666780251615     |     [36mstore_repo_test.go[0m[35m:257[0m[90m: unexpected configuration policy list (-want +got):

_bk;t=1666780251615     |           []int{

_bk;t=1666780251615     |         - 	101, 102, 103,

_bk;t=1666780251615     |         + 	103, 102, 101,

_bk;t=1666780251615     |           }
```

cc @sourcegraph/code-intel to re-enable when fixed

### TestLFSSmudge

Somehow git config is not set properly now

```shell
_bk;t=1666784503692[90mSTART| LFSSmudge[0m

_bk;t=1666784503692     |     [36mcommands_test.go[0m[35m:2857[0m[90m: Command "git commit -m \"lfs\"" failed. Output was:

_bk;t=1666784503692     |         

_bk;t=1666784503692     |         Author identity unknown

_bk;t=1666784503692     |         

_bk;t=1666784503692     |         *** Please tell me who you are.

_bk;t=1666784503692     |         

_bk;t=1666784503692     |         Run

_bk;t=1666784503692     |         

_bk;t=1666784503692     |           git config --global user.email "you@example.com"

_bk;t=1666784503692     |           git config --global user.name "Your Name"

_bk;t=1666784503692     |         

_bk;t=1666784503692     |         to set your account's default identity.

_bk;t=1666784503692     |         Omit --global to set the identity only in this repository.

_bk;t=1666784503692     |         

_bk;t=1666784503692     |         fatal: unable to auto-detect email address (got 'root@buildkite-agent-stateless-7830ec9b6c8446348f7561305d737ff9qjnnf.(none)')
```

## Test plan
Tests pass again
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
