### PR TITLE
Allow batch changes GitLab webhooks to use the webhooks top level path

### DIFF
--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -84,19 +84,19 @@ func makeNotFoundHandler(handlerName string) http.Handler {
 	})
 }
 
-type registerFunc func(webhook *webhooks.Webhook)
+type registerFunc func(webhook *webhooks.WebhookRouter)
 
 type emptyWebhookHandler struct {
 	name string
 }
 
-func (e *emptyWebhookHandler) Register(w *webhooks.Webhook) {}
+func (e *emptyWebhookHandler) Register(w *webhooks.WebhookRouter) {}
 
 func (e *emptyWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	makeNotFoundHandler(e.name)
 }
 
-func (fn registerFunc) Register(w *webhooks.Webhook) {
+func (fn registerFunc) Register(w *webhooks.WebhookRouter) {
 	fn(w)
 }
 

--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -61,8 +61,8 @@ type NewComputeStreamHandler func() http.Handler
 // DefaultServices creates a new Services value that has default implementations for all services.
 func DefaultServices() Services {
 	return Services{
-		GitHubWebhook:                   registerFunc(func(webhook *webhooks.Webhook) {}),
-        GitLabWebhook:                   &emptyWebhookHandler{name: "gitlab webhook"},
+		GitHubWebhook:                   &emptyWebhookHandler{name: "github webhook"},
+		GitLabWebhook:                   &emptyWebhookHandler{name: "gitlab webhook"},
 		BitbucketServerWebhook:          makeNotFoundHandler("bitbucket server webhook"),
 		BitbucketCloudWebhook:           makeNotFoundHandler("bitbucket cloud webhook"),
 		BatchesChangesFileGetHandler:    makeNotFoundHandler("batches file get handler"),
@@ -87,12 +87,13 @@ func makeNotFoundHandler(handlerName string) http.Handler {
 type registerFunc func(webhook *webhooks.Webhook)
 
 type emptyWebhookHandler struct {
-    name string
+	name string
 }
+
 func (e *emptyWebhookHandler) Register(w *webhooks.Webhook) {}
 
 func (e *emptyWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-    makeNotFoundHandler(e.name)
+	makeNotFoundHandler(e.name)
 }
 
 func (fn registerFunc) Register(w *webhooks.Webhook) {

--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -18,7 +18,7 @@ import (
 // enterprise frontend setup hook.
 type Services struct {
 	GitHubWebhook                   webhooks.Registerer
-	GitLabWebhook                   http.Handler
+	GitLabWebhook                   webhooks.Registerer
 	BitbucketServerWebhook          http.Handler
 	BitbucketCloudWebhook           http.Handler
 	BatchesChangesFileGetHandler    http.Handler
@@ -61,8 +61,8 @@ type NewComputeStreamHandler func() http.Handler
 // DefaultServices creates a new Services value that has default implementations for all services.
 func DefaultServices() Services {
 	return Services{
-		GitHubWebhook:                   registerFunc(func(webhook *webhooks.GitHubWebhook) {}),
-		GitLabWebhook:                   makeNotFoundHandler("gitlab webhook"),
+		GitHubWebhook:                   registerFunc(func(webhook *webhooks.Webhook) {}),
+		GitLabWebhook:                   registerFunc(func(webhook *webhooks.Webhook) {}),
 		BitbucketServerWebhook:          makeNotFoundHandler("bitbucket server webhook"),
 		BitbucketCloudWebhook:           makeNotFoundHandler("bitbucket cloud webhook"),
 		BatchesChangesFileGetHandler:    makeNotFoundHandler("batches file get handler"),
@@ -84,9 +84,9 @@ func makeNotFoundHandler(handlerName string) http.Handler {
 	})
 }
 
-type registerFunc func(webhook *webhooks.GitHubWebhook)
+type registerFunc func(webhook *webhooks.Webhook)
 
-func (fn registerFunc) Register(w *webhooks.GitHubWebhook) {
+func (fn registerFunc) Register(w *webhooks.Webhook) {
 	fn(w)
 }
 

--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -18,7 +18,7 @@ import (
 // enterprise frontend setup hook.
 type Services struct {
 	GitHubWebhook                   webhooks.Registerer
-	GitLabWebhook                   webhooks.Registerer
+	GitLabWebhook                   webhooks.RegistererHandler
 	BitbucketServerWebhook          http.Handler
 	BitbucketCloudWebhook           http.Handler
 	BatchesChangesFileGetHandler    http.Handler
@@ -62,7 +62,7 @@ type NewComputeStreamHandler func() http.Handler
 func DefaultServices() Services {
 	return Services{
 		GitHubWebhook:                   registerFunc(func(webhook *webhooks.Webhook) {}),
-		GitLabWebhook:                   registerFunc(func(webhook *webhooks.Webhook) {}),
+        GitLabWebhook:                   &emptyWebhookHandler{name: "gitlab webhook"},
 		BitbucketServerWebhook:          makeNotFoundHandler("bitbucket server webhook"),
 		BitbucketCloudWebhook:           makeNotFoundHandler("bitbucket cloud webhook"),
 		BatchesChangesFileGetHandler:    makeNotFoundHandler("batches file get handler"),
@@ -85,6 +85,15 @@ func makeNotFoundHandler(handlerName string) http.Handler {
 }
 
 type registerFunc func(webhook *webhooks.Webhook)
+
+type emptyWebhookHandler struct {
+    name string
+}
+func (e *emptyWebhookHandler) Register(w *webhooks.Webhook) {}
+
+func (e *emptyWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    makeNotFoundHandler(e.name)
+}
 
 func (fn registerFunc) Register(w *webhooks.Webhook) {
 	fn(w)

--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -86,6 +86,10 @@ func makeNotFoundHandler(handlerName string) http.Handler {
 
 type registerFunc func(webhook *webhooks.WebhookRouter)
 
+func (fn registerFunc) Register(w *webhooks.WebhookRouter) {
+	fn(w)
+}
+
 type emptyWebhookHandler struct {
 	name string
 }
@@ -94,10 +98,6 @@ func (e *emptyWebhookHandler) Register(w *webhooks.WebhookRouter) {}
 
 func (e *emptyWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	makeNotFoundHandler(e.name)
-}
-
-func (fn registerFunc) Register(w *webhooks.WebhookRouter) {
-	fn(w)
 }
 
 type ErrBatchChangesDisabledDotcom struct{}

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -93,7 +93,7 @@ func NewHandler(
 	}
 	webhookhandlers.Init(db, &wh)
 	handlers.GitHubWebhook.Register(&wh)
-    handlers.GitLabWebhook.Register(&wh)
+	handlers.GitLabWebhook.Register(&wh)
 	ghSync := repos.GitHubWebhookHandler{}
 	ghSync.Register(&wh)
 
@@ -101,7 +101,7 @@ func NewHandler(
 	// TODO: Integrate with webhookMiddleware.Logger
 	webhookHandler := webhooks.NewHandler(logger, db, &wh)
 
-    gitHubWebhook := webhooks.GitHubWebhook{Webhook: &wh}
+	gitHubWebhook := webhooks.GitHubWebhook{Webhook: &wh}
 
 	m.Get(apirouter.Webhooks).Handler(trace.Route(webhookMiddleware.Logger(webhookHandler)))
 	m.Get(apirouter.GitHubWebhooks).Handler(trace.Route(webhookMiddleware.Logger(&gitHubWebhook)))

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -42,7 +42,7 @@ import (
 
 type Handlers struct {
 	GitHubWebhook                   webhooks.Registerer
-	GitLabWebhook                   webhooks.Registerer
+	GitLabWebhook                   webhooks.RegistererHandler
 	BitbucketServerWebhook          http.Handler
 	BitbucketCloudWebhook           http.Handler
 	BatchesChangesFileGetHandler    http.Handler
@@ -88,19 +88,23 @@ func NewHandler(
 		db.WebhookLogs(keyring.Default().WebhookLogKey),
 	)
 
-	gh := webhooks.GitHubWebhook{
+	wh := webhooks.Webhook{
 		DB: db,
 	}
-	webhookhandlers.Init(db, &gh)
-	handlers.GitHubWebhook.Register(&gh)
+	webhookhandlers.Init(db, &wh)
+	handlers.GitHubWebhook.Register(&wh)
+    handlers.GitLabWebhook.Register(&wh)
 	ghSync := repos.GitHubWebhookHandler{}
-	ghSync.Register(&gh)
+	ghSync.Register(&wh)
 
 	// 🚨 SECURITY: This handler implements its own secret-based auth
-	webhookHandler := webhooks.NewHandler(logger, db, &gh)
+	// TODO: Integrate with webhookMiddleware.Logger
+	webhookHandler := webhooks.NewHandler(logger, db, &wh)
+
+    gitHubWebhook := webhooks.GitHubWebhook{Webhook: &wh}
 
 	m.Get(apirouter.Webhooks).Handler(trace.Route(webhookMiddleware.Logger(webhookHandler)))
-	m.Get(apirouter.GitHubWebhooks).Handler(trace.Route(webhookMiddleware.Logger(&gh)))
+	m.Get(apirouter.GitHubWebhooks).Handler(trace.Route(webhookMiddleware.Logger(&gitHubWebhook)))
 	m.Get(apirouter.GitLabWebhooks).Handler(trace.Route(webhookMiddleware.Logger(handlers.GitLabWebhook)))
 	m.Get(apirouter.BitbucketServerWebhooks).Handler(trace.Route(webhookMiddleware.Logger(handlers.BitbucketServerWebhook)))
 	m.Get(apirouter.BitbucketCloudWebhooks).Handler(trace.Route(webhookMiddleware.Logger(handlers.BitbucketCloudWebhook)))

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -42,7 +42,7 @@ import (
 
 type Handlers struct {
 	GitHubWebhook                   webhooks.Registerer
-	GitLabWebhook                   http.Handler
+	GitLabWebhook                   webhooks.Registerer
 	BitbucketServerWebhook          http.Handler
 	BitbucketCloudWebhook           http.Handler
 	BatchesChangesFileGetHandler    http.Handler

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -88,7 +88,7 @@ func NewHandler(
 		db.WebhookLogs(keyring.Default().WebhookLogKey),
 	)
 
-	wh := webhooks.Webhook{
+	wh := webhooks.WebhookRouter{
 		DB: db,
 	}
 	webhookhandlers.Init(db, &wh)
@@ -101,7 +101,7 @@ func NewHandler(
 	// TODO: Integrate with webhookMiddleware.Logger
 	webhookHandler := webhooks.NewHandler(logger, db, &wh)
 
-	gitHubWebhook := webhooks.GitHubWebhook{Webhook: &wh}
+	gitHubWebhook := webhooks.GitHubWebhook{WebhookRouter: &wh}
 
 	m.Get(apirouter.Webhooks).Handler(trace.Route(webhookMiddleware.Logger(webhookHandler)))
 	m.Get(apirouter.GitHubWebhooks).Handler(trace.Route(webhookMiddleware.Logger(&gitHubWebhook)))

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handlers.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handlers.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
-func Init(db database.DB, w *webhooks.Webhook) {
+func Init(db database.DB, w *webhooks.WebhookRouter) {
 	// Refer to https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads
 	// for event types
 

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handlers.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handlers.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
-func Init(db database.DB, w *webhooks.GitHubWebhook) {
+func Init(db database.DB, w *webhooks.Webhook) {
 	// Refer to https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads
 	// for event types
 

--- a/cmd/frontend/webhooks/github_webhooks.go
+++ b/cmd/frontend/webhooks/github_webhooks.go
@@ -19,7 +19,7 @@ import (
 )
 
 type GitHubWebhook struct {
-    *Webhook
+	*Webhook
 }
 
 func (h *GitHubWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/cmd/frontend/webhooks/github_webhooks.go
+++ b/cmd/frontend/webhooks/github_webhooks.go
@@ -18,7 +18,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-type GitHubWebhook Webhook
+type GitHubWebhook struct {
+    *Webhook
+}
 
 func (h *GitHubWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(r.Body)

--- a/cmd/frontend/webhooks/github_webhooks.go
+++ b/cmd/frontend/webhooks/github_webhooks.go
@@ -18,7 +18,7 @@ import (
 )
 
 type GitHubWebhook struct {
-	*Webhook
+	*WebhookRouter
 }
 
 func (h *GitHubWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/cmd/frontend/webhooks/github_webhooks_test.go
+++ b/cmd/frontend/webhooks/github_webhooks_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestGithubWebhookDispatchSuccess(t *testing.T) {
-	h := GitHubWebhook{Webhook: &Webhook{}}
+	h := GitHubWebhook{WebhookRouter: &WebhookRouter{}}
 	var called bool
 	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		called = true
@@ -43,7 +43,7 @@ func TestGithubWebhookDispatchSuccess(t *testing.T) {
 }
 
 func TestGithubWebhookDispatchNoHandler(t *testing.T) {
-	h := GitHubWebhook{Webhook: &Webhook{}}
+	h := GitHubWebhook{WebhookRouter: &WebhookRouter{}}
 	ctx := context.Background()
 	// no op
 	if err := h.Dispatch(ctx, "test-event-1", extsvc.KindGitHub, extsvc.CodeHostBaseURL{}, nil); err != nil {
@@ -53,7 +53,7 @@ func TestGithubWebhookDispatchNoHandler(t *testing.T) {
 
 func TestGithubWebhookDispatchSuccessMultiple(t *testing.T) {
 	var (
-		h      = GitHubWebhook{Webhook: &Webhook{}}
+		h      = GitHubWebhook{WebhookRouter: &WebhookRouter{}}
 		called = make(chan struct{}, 2)
 	)
 	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
@@ -76,7 +76,7 @@ func TestGithubWebhookDispatchSuccessMultiple(t *testing.T) {
 
 func TestGithubWebhookDispatchError(t *testing.T) {
 	var (
-		h      = GitHubWebhook{Webhook: &Webhook{}}
+		h      = GitHubWebhook{WebhookRouter: &WebhookRouter{}}
 		called = make(chan struct{}, 2)
 	)
 	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
@@ -152,7 +152,7 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 	}
 
 	hook := GitHubWebhook{
-		Webhook: &Webhook{
+		WebhookRouter: &WebhookRouter{
 			DB: db,
 		},
 	}

--- a/cmd/frontend/webhooks/github_webhooks_test.go
+++ b/cmd/frontend/webhooks/github_webhooks_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestGithubWebhookDispatchSuccess(t *testing.T) {
-	h := Webhook{}
+	h := GitHubWebhook{Webhook: &Webhook{}}
 	var called bool
 	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		called = true
@@ -43,7 +43,7 @@ func TestGithubWebhookDispatchSuccess(t *testing.T) {
 }
 
 func TestGithubWebhookDispatchNoHandler(t *testing.T) {
-	h := Webhook{}
+    h := GitHubWebhook{Webhook: &Webhook{}}
 	ctx := context.Background()
 	// no op
 	if err := h.Dispatch(ctx, "test-event-1", extsvc.CodeHostBaseURL{}, nil); err != nil {
@@ -53,7 +53,7 @@ func TestGithubWebhookDispatchNoHandler(t *testing.T) {
 
 func TestGithubWebhookDispatchSuccessMultiple(t *testing.T) {
 	var (
-		h      = Webhook{}
+		h      = GitHubWebhook{Webhook: &Webhook{}}
 		called = make(chan struct{}, 2)
 	)
 	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
@@ -76,7 +76,7 @@ func TestGithubWebhookDispatchSuccessMultiple(t *testing.T) {
 
 func TestGithubWebhookDispatchError(t *testing.T) {
 	var (
-		h      = Webhook{}
+        h      = GitHubWebhook{Webhook: &Webhook{}}
 		called = make(chan struct{}, 2)
 	)
 	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
@@ -151,8 +151,10 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hook := Webhook{
-		DB: db,
+	hook := GitHubWebhook{
+		Webhook: &Webhook{
+			DB: db,
+		},
 	}
 
 	var called bool

--- a/cmd/frontend/webhooks/github_webhooks_test.go
+++ b/cmd/frontend/webhooks/github_webhooks_test.go
@@ -31,7 +31,7 @@ func TestGithubWebhookDispatchSuccess(t *testing.T) {
 	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		called = true
 		return nil
-	}, "test-event-1")
+	}, extsvc.KindGitHub, "test-event-1")
 
 	ctx := context.Background()
 	if err := h.Dispatch(ctx, "test-event-1", extsvc.CodeHostBaseURL{}, nil); err != nil {
@@ -43,7 +43,7 @@ func TestGithubWebhookDispatchSuccess(t *testing.T) {
 }
 
 func TestGithubWebhookDispatchNoHandler(t *testing.T) {
-    h := GitHubWebhook{Webhook: &Webhook{}}
+	h := GitHubWebhook{Webhook: &Webhook{}}
 	ctx := context.Background()
 	// no op
 	if err := h.Dispatch(ctx, "test-event-1", extsvc.CodeHostBaseURL{}, nil); err != nil {
@@ -59,11 +59,11 @@ func TestGithubWebhookDispatchSuccessMultiple(t *testing.T) {
 	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		called <- struct{}{}
 		return nil
-	}, "test-event-1")
+	}, extsvc.KindGitHub, "test-event-1")
 	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		called <- struct{}{}
 		return nil
-	}, "test-event-1")
+	}, extsvc.KindGitHub, "test-event-1")
 
 	ctx := context.Background()
 	if err := h.Dispatch(ctx, "test-event-1", extsvc.CodeHostBaseURL{}, nil); err != nil {
@@ -76,17 +76,17 @@ func TestGithubWebhookDispatchSuccessMultiple(t *testing.T) {
 
 func TestGithubWebhookDispatchError(t *testing.T) {
 	var (
-        h      = GitHubWebhook{Webhook: &Webhook{}}
+		h      = GitHubWebhook{Webhook: &Webhook{}}
 		called = make(chan struct{}, 2)
 	)
 	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		called <- struct{}{}
 		return errors.Errorf("oh no")
-	}, "test-event-1")
+	}, extsvc.KindGitHub, "test-event-1")
 	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		called <- struct{}{}
 		return nil
-	}, "test-event-1")
+	}, extsvc.KindGitHub, "test-event-1")
 
 	ctx := context.Background()
 	if have, want := h.Dispatch(ctx, "test-event-1", extsvc.CodeHostBaseURL{}, nil), "oh no"; errString(have) != want {
@@ -168,7 +168,7 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 		}
 		called = true
 		return nil
-	}, "public")
+	}, extsvc.KindGitHub, "public")
 
 	u, err := extsvc.WebhookURL(extsvc.TypeGitHub, extSvc.ID, nil, "https://example.com/")
 	if err != nil {

--- a/cmd/frontend/webhooks/github_webhooks_test.go
+++ b/cmd/frontend/webhooks/github_webhooks_test.go
@@ -34,7 +34,7 @@ func TestGithubWebhookDispatchSuccess(t *testing.T) {
 	}, extsvc.KindGitHub, "test-event-1")
 
 	ctx := context.Background()
-	if err := h.Dispatch(ctx, "test-event-1", extsvc.CodeHostBaseURL{}, nil); err != nil {
+	if err := h.Dispatch(ctx, "test-event-1", extsvc.KindGitHub, extsvc.CodeHostBaseURL{}, nil); err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}
 	if !called {
@@ -46,7 +46,7 @@ func TestGithubWebhookDispatchNoHandler(t *testing.T) {
 	h := GitHubWebhook{Webhook: &Webhook{}}
 	ctx := context.Background()
 	// no op
-	if err := h.Dispatch(ctx, "test-event-1", extsvc.CodeHostBaseURL{}, nil); err != nil {
+	if err := h.Dispatch(ctx, "test-event-1", extsvc.KindGitHub, extsvc.CodeHostBaseURL{}, nil); err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}
 }
@@ -66,7 +66,7 @@ func TestGithubWebhookDispatchSuccessMultiple(t *testing.T) {
 	}, extsvc.KindGitHub, "test-event-1")
 
 	ctx := context.Background()
-	if err := h.Dispatch(ctx, "test-event-1", extsvc.CodeHostBaseURL{}, nil); err != nil {
+	if err := h.Dispatch(ctx, "test-event-1", extsvc.KindGitHub, extsvc.CodeHostBaseURL{}, nil); err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}
 	if len(called) != 2 {
@@ -89,7 +89,7 @@ func TestGithubWebhookDispatchError(t *testing.T) {
 	}, extsvc.KindGitHub, "test-event-1")
 
 	ctx := context.Background()
-	if have, want := h.Dispatch(ctx, "test-event-1", extsvc.CodeHostBaseURL{}, nil), "oh no"; errString(have) != want {
+	if have, want := h.Dispatch(ctx, "test-event-1", extsvc.KindGitHub, extsvc.CodeHostBaseURL{}, nil), "oh no"; errString(have) != want {
 		t.Errorf("Expected %q, got %q", want, have)
 	}
 	if len(called) != 2 {

--- a/cmd/frontend/webhooks/github_webhooks_test.go
+++ b/cmd/frontend/webhooks/github_webhooks_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestGithubWebhookDispatchSuccess(t *testing.T) {
-	h := GitHubWebhook{}
+	h := Webhook{}
 	var called bool
 	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		called = true
@@ -43,7 +43,7 @@ func TestGithubWebhookDispatchSuccess(t *testing.T) {
 }
 
 func TestGithubWebhookDispatchNoHandler(t *testing.T) {
-	h := GitHubWebhook{}
+	h := Webhook{}
 	ctx := context.Background()
 	// no op
 	if err := h.Dispatch(ctx, "test-event-1", extsvc.CodeHostBaseURL{}, nil); err != nil {
@@ -53,7 +53,7 @@ func TestGithubWebhookDispatchNoHandler(t *testing.T) {
 
 func TestGithubWebhookDispatchSuccessMultiple(t *testing.T) {
 	var (
-		h      = GitHubWebhook{}
+		h      = Webhook{}
 		called = make(chan struct{}, 2)
 	)
 	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
@@ -76,7 +76,7 @@ func TestGithubWebhookDispatchSuccessMultiple(t *testing.T) {
 
 func TestGithubWebhookDispatchError(t *testing.T) {
 	var (
-		h      = GitHubWebhook{}
+		h      = Webhook{}
 		called = make(chan struct{}, 2)
 	)
 	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
@@ -151,7 +151,7 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hook := GitHubWebhook{
+	hook := Webhook{
 		DB: db,
 	}
 

--- a/cmd/frontend/webhooks/gitlab_webhooks.go
+++ b/cmd/frontend/webhooks/gitlab_webhooks.go
@@ -1,0 +1,163 @@
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/schema"
+	"golang.org/x/sync/errgroup"
+)
+
+type GitLabWebhook Webhook
+
+var (
+	errExternalServiceNotFound     = errors.New("external service not found")
+	errExternalServiceWrongKind    = errors.New("external service is not of the expected kind")
+	errPipelineMissingMergeRequest = errors.New("pipeline event does not include a merge request")
+)
+
+func (h *GitLabWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Look up the external service.
+	extSvc, err := h.getExternalServiceFromRawID(r.Context(), r.FormValue(extsvc.IDParam))
+	if err == errExternalServiceNotFound {
+        http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	} else if err != nil {
+		http.Error(w, errors.Wrap(err, "getting external service").Error(), http.StatusInternalServerError)
+		return
+	}
+
+	SetExternalServiceID(r.Context(), extSvc.ID)
+
+    rawConfig, err := extSvc.Config.Decrypt(r.Context())
+    if err != nil {
+        log15.Error("Could not decode external service config", "error", err)
+        http.Error(w, "Invalid external service config", http.StatusInternalServerError)
+        return
+    }
+
+    config := &schema.GitLabConnection{}
+    err = json.Unmarshal([]byte(rawConfig), config)
+	if err != nil {
+		log15.Error("Could not decode external service config", "error", err)
+		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
+		return
+	}
+
+    codeHostURN, err := extsvc.NewCodeHostBaseURL(config.Url)
+	if err != nil {
+		log15.Error("Could not parse code host URL from config", "error", err)
+		http.Error(w, "Invalid code host URL", http.StatusInternalServerError)
+		return
+	}
+
+    h.HandleWebhook(w, r, codeHostURN)
+}
+
+func (h *GitLabWebhook) HandleWebhook(w http.ResponseWriter, r *http.Request, codeHostURN extsvc.CodeHostBaseURL) {
+
+	// 🚨 SECURITY: now that the shared secret has been validated, we can use an
+	// internal actor on the context.
+	ctx := actor.WithInternalActor(r.Context())
+
+	// Parse the event proper.
+	if r.Body == nil {
+		http.Error(w, "missing request body", http.StatusBadRequest)
+		return
+	}
+	payload, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, errors.Wrap(err, "reading payload").Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var eventKind struct {
+		ObjectKind string `json:"object_kind"`
+	}
+	if err := json.Unmarshal(payload, &eventKind); err != nil {
+        http.Error(w, errors.Wrap(err, "determining object kind").Error(), http.StatusInternalServerError)
+        return
+	}
+
+	event, err := webhooks.UnmarshalEvent(payload)
+	if err != nil {
+		if errors.Is(err, webhooks.ErrObjectKindUnknown) {
+			// We don't want to return a non-2XX status code and have GitLab
+			// retry the webhook, so we'll log that we don't know what to do
+			// and return 204.
+			log15.Debug("unknown object kind", "err", err)
+
+			// We don't use respond() here so that we don't log an error, since
+			// this really isn't one.
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.WriteHeader(http.StatusNoContent)
+			fmt.Fprintf(w, "%v", err)
+		} else {
+			http.Error(w, errors.Wrap(err, "unmarshalling payload").Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	// Route the request based on the event type.
+    err = h.Dispatch(ctx, eventKind.ObjectKind, codeHostURN, event)
+	if err != nil {
+		log15.Error("Error handling github webhook event", "error", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (h *GitLabWebhook) Dispatch(ctx context.Context, eventType string, codeHostURN extsvc.CodeHostBaseURL, e any) error {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	g := errgroup.Group{}
+	for _, handler := range h.handlers[extsvc.KindGitLab][eventType] {
+		// capture the handler variable within this loop
+		handler := handler
+		g.Go(func() error {
+			return handler(ctx, h.DB, codeHostURN, e)
+		})
+	}
+	return g.Wait()
+}
+
+// getExternalServiceFromRawID retrieves the external service matching the
+// given raw ID, which is usually going to be the string in the
+// externalServiceID URL parameter.
+//
+// On failure, errExternalServiceNotFound is returned if the ID doesn't match
+// any GitLab service.
+func (h *GitLabWebhook) getExternalServiceFromRawID(ctx context.Context, raw string) (*types.ExternalService, error) {
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing the raw external service ID")
+	}
+
+	es, err := h.DB.ExternalServices().List(ctx, database.ExternalServicesListOptions{
+		IDs:   []int64{id},
+		Kinds: []string{extsvc.KindGitLab},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "listing external services")
+	}
+
+	if len(es) == 0 {
+		return nil, errExternalServiceNotFound
+	} else if len(es) > 1 {
+		// This _really_ shouldn't happen, since we provided only one ID above.
+		return nil, errors.New("too many external services found")
+	}
+
+	return es[0], nil
+}

--- a/cmd/frontend/webhooks/gitlab_webhooks.go
+++ b/cmd/frontend/webhooks/gitlab_webhooks.go
@@ -14,7 +14,7 @@ import (
 )
 
 type GitLabWebhook struct {
-	*Webhook
+	*WebhookRouter
 }
 
 func (h *GitLabWebhook) HandleWebhook(w http.ResponseWriter, r *http.Request, codeHostURN extsvc.CodeHostBaseURL) {

--- a/cmd/frontend/webhooks/webhooks.go
+++ b/cmd/frontend/webhooks/webhooks.go
@@ -50,7 +50,7 @@ func (h *Webhook) Register(handler WebhookHandler, codeHostKind string, eventTyp
 // and invoking the correct handlers depending on where the webhooks
 // come from.
 func NewHandler(logger log.Logger, db database.DB, gh *Webhook) http.Handler {
-	base := mux.NewRouter().PathPrefix("/webhooks").Subrouter()
+	base := mux.NewRouter().PathPrefix("/.api/webhooks").Subrouter()
 	base.Path("/{webhook_uuid}").Methods("POST").Handler(webhookHandler(logger, db, gh))
 
 	return base

--- a/cmd/frontend/webhooks/webhooks.go
+++ b/cmd/frontend/webhooks/webhooks.go
@@ -108,10 +108,10 @@ func webhookHandler(logger log.Logger, db database.DB, wh *WebhookRouter) http.H
 
 		switch webhook.CodeHostKind {
 		case extsvc.KindGitHub:
-			handleGitHubWebHook(w, r, webhook.CodeHostURN, secret, &GitHubWebhook{WebhookRouter: wh})
+			handleGitHubWebHook(logger, w, r, webhook.CodeHostURN, secret, &GitHubWebhook{WebhookRouter: wh})
 			return
 		case extsvc.KindGitLab:
-			wh.handleGitLabWebHook(w, r, webhook.CodeHostURN, secret)
+			wh.handleGitLabWebHook(logger, w, r, webhook.CodeHostURN, secret)
 			return
 		case extsvc.KindBitbucketServer:
 			// TODO: handle Bitbucket Server secret verification

--- a/cmd/frontend/webhooks/webhooks.go
+++ b/cmd/frontend/webhooks/webhooks.go
@@ -1,10 +1,12 @@
 package webhooks
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 
 	"github.com/google/go-github/github"
 	"github.com/google/uuid"
@@ -16,13 +18,54 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
-type WebhookHandlers struct {
+type WebhookHandlers struct{}
+
+type Registerer interface {
+	Register(webhook *Webhook)
+}
+
+// Register associates a given event type(s) with the specified handler.
+// Handlers are organized into a stack and executed sequentially, so the order in
+// which they are provided is significant.
+func (h *Webhook) Register(handler WebhookHandler, codeHostKind string, eventTypes ...string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.handlers == nil {
+		h.handlers = make(map[string]map[string][]WebhookHandler)
+	}
+	for _, eventType := range eventTypes {
+		h.handlers[codeHostKind][eventType] = append(h.handlers[codeHostKind][eventType], handler)
+	}
 }
 
 // NewHandler is responsible for handling all incoming webhooks
 // and invoking the correct handlers depending on where the webhooks
 // come from.
-func NewHandler(logger log.Logger, db database.DB, gh *GitHubWebhook) http.Handler {
+func NewHandler(logger log.Logger, db database.DB, gh *Webhook) http.Handler {
+	base := mux.NewRouter().PathPrefix("/webhooks").Subrouter()
+	base.Path("/{webhook_uuid}").Methods("POST").Handler(webhookHandler(logger, db, gh))
+
+	return base
+}
+
+// WebhookHandler is a handler for a webhook event, the 'event' param could be any of the event types
+// permissible based on the event type(s) the handler was registered against. If you register a handler
+// for many event types, you should do a type switch within your handler.
+// Handlers are responsible for fetching the necessary credentials to perform their associated tasks.
+type WebhookHandler func(ctx context.Context, db database.DB, codeHostURN extsvc.CodeHostBaseURL, event any) error
+
+// Webhook is responsible for handling incoming http requests for github webhooks
+// and routing to any registered WebhookHandlers, events are routed by their event type,
+// passed in the X-Github-Event header
+type Webhook struct {
+	DB database.DB
+
+	mu sync.RWMutex
+	// Mapped by codeHostKind: webhookEvent: handlers
+	handlers map[string]map[string][]WebhookHandler
+}
+
+func webhookHandler(logger log.Logger, db database.DB, gh *Webhook) http.HandlerFunc {
 	logger = logger.Scoped("webhookHandler", "handler used to route webhooks")
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		uuidString := mux.Vars(r)["webhook_uuid"]
@@ -58,7 +101,7 @@ func NewHandler(logger log.Logger, db database.DB, gh *GitHubWebhook) http.Handl
 
 		switch webhook.CodeHostKind {
 		case extsvc.KindGitHub:
-			handleGitHubWebHook(w, r, webhook.CodeHostURN, secret, gh)
+			handleGitHubWebHook(w, r, webhook.CodeHostURN, secret, (*GitHubWebhook)(gh))
 			return
 		case extsvc.KindGitLab:
 			if secret != "" {

--- a/cmd/frontend/webhooks/webhooks.go
+++ b/cmd/frontend/webhooks/webhooks.go
@@ -16,6 +16,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
+type webhookEventHandlers map[string][]WebhookHandler
+
 // WebhookRouter is responsible for handling incoming http requests for all webhooks
 // and routing to any registered WebhookHandlers, events are routed by their code host kind
 // and event type.
@@ -24,7 +26,7 @@ type WebhookRouter struct {
 
 	mu sync.RWMutex
 	// Mapped by codeHostKind: webhookEvent: handlers
-	handlers map[string]map[string][]WebhookHandler
+	handlers map[string]webhookEventHandlers
 }
 
 type Registerer interface {
@@ -46,7 +48,7 @@ func (h *WebhookRouter) Register(handler WebhookHandler, codeHostKind string, ev
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.handlers == nil {
-		h.handlers = make(map[string]map[string][]WebhookHandler)
+		h.handlers = make(map[string]webhookEventHandlers)
 	}
 	if _, ok := h.handlers[codeHostKind]; !ok {
 		h.handlers[codeHostKind] = make(map[string][]WebhookHandler)

--- a/cmd/frontend/webhooks/webhooks_test.go
+++ b/cmd/frontend/webhooks/webhooks_test.go
@@ -60,7 +60,7 @@ func TestWebhooksHandler(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	gh := GitHubWebhook{
+	gh := Webhook{
 		DB: db,
 	}
 

--- a/cmd/frontend/webhooks/webhooks_test.go
+++ b/cmd/frontend/webhooks/webhooks_test.go
@@ -60,16 +60,14 @@ func TestWebhooksHandler(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	gh := Webhook{
-		DB: db,
-	}
+	gh := GitHubWebhook{Webhook: &Webhook{DB: db}}
 
 	webhookMiddleware := NewLogMiddleware(
 		db.WebhookLogs(keyring.Default().WebhookLogKey),
 	)
 
 	base := mux.NewRouter()
-	base.Path("/.api/webhooks/{webhook_uuid}").Methods("POST").Handler(webhookMiddleware.Logger(NewHandler(logger, db, &gh)))
+	base.Path("/.api/webhooks/{webhook_uuid}").Methods("POST").Handler(webhookMiddleware.Logger(NewHandler(logger, db, gh.Webhook)))
 	srv := httptest.NewServer(base)
 
 	t.Run("found GitLab webhook with correct secret returns unimplemented", func(t *testing.T) {

--- a/cmd/frontend/webhooks/webhooks_test.go
+++ b/cmd/frontend/webhooks/webhooks_test.go
@@ -60,14 +60,14 @@ func TestWebhooksHandler(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	gh := GitHubWebhook{Webhook: &Webhook{DB: db}}
+	gh := GitHubWebhook{WebhookRouter: &WebhookRouter{DB: db}}
 
 	webhookMiddleware := NewLogMiddleware(
 		db.WebhookLogs(keyring.Default().WebhookLogKey),
 	)
 
 	base := mux.NewRouter()
-	base.Path("/.api/webhooks/{webhook_uuid}").Methods("POST").Handler(webhookMiddleware.Logger(NewHandler(logger, db, gh.Webhook)))
+	base.Path("/.api/webhooks/{webhook_uuid}").Methods("POST").Handler(webhookMiddleware.Logger(NewHandler(logger, db, gh.WebhookRouter)))
 	srv := httptest.NewServer(base)
 
 	t.Run("found GitLab webhook with correct secret returns unimplemented", func(t *testing.T) {

--- a/cmd/frontend/webhooks/webhooks_test.go
+++ b/cmd/frontend/webhooks/webhooks_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -21,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -70,16 +72,21 @@ func TestWebhooksHandler(t *testing.T) {
 	base.Path("/.api/webhooks/{webhook_uuid}").Methods("POST").Handler(webhookMiddleware.Logger(NewHandler(logger, db, gh.WebhookRouter)))
 	srv := httptest.NewServer(base)
 
-	t.Run("found GitLab webhook with correct secret returns unimplemented", func(t *testing.T) {
+	t.Run("found GitLab webhook with correct secret returns 200", func(t *testing.T) {
 		requestURL := fmt.Sprintf("%s/.api/webhooks/%v", srv.URL, gitLabWH.UUID)
 
-		req, err := http.NewRequest("POST", requestURL, nil)
+		event := webhooks.EventCommon{
+			ObjectKind: "pipeline",
+		}
+		payload, err := json.Marshal(event)
+		require.NoError(t, err)
+		req, err := http.NewRequest("POST", requestURL, bytes.NewBuffer(payload))
 		require.NoError(t, err)
 		req.Header.Add("X-GitLab-Token", "somesecret")
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
 
-		assert.Equal(t, http.StatusNotImplemented, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
 	t.Run("not-found webhook returns 404", func(t *testing.T) {

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github.go
@@ -48,7 +48,7 @@ func NewGitHubWebhook(store *store.Store, gitserverClient gitserver.Client) *Git
 func (h *GitHubWebhook) Register(router *webhooks.Webhook) {
 	router.Register(
 		h.handleGitHubWebhook,
-        extsvc.KindGitHub,
+		extsvc.KindGitHub,
 		githubEvents...,
 	)
 }

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github.go
@@ -45,9 +45,10 @@ func NewGitHubWebhook(store *store.Store, gitserverClient gitserver.Client) *Git
 }
 
 // Register registers this webhook handler to handle events with the passed webhook router
-func (h *GitHubWebhook) Register(router *webhooks.GitHubWebhook) {
+func (h *GitHubWebhook) Register(router *webhooks.Webhook) {
 	router.Register(
 		h.handleGitHubWebhook,
+        extsvc.KindGitHub,
 		githubEvents...,
 	)
 }

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github.go
@@ -45,7 +45,7 @@ func NewGitHubWebhook(store *store.Store, gitserverClient gitserver.Client) *Git
 }
 
 // Register registers this webhook handler to handle events with the passed webhook router
-func (h *GitHubWebhook) Register(router *webhooks.Webhook) {
+func (h *GitHubWebhook) Register(router *webhooks.WebhookRouter) {
 	router.Register(
 		h.handleGitHubWebhook,
 		extsvc.KindGitHub,

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -186,11 +186,11 @@ func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 				for i := 0; i < 2; i++ {
 					for _, event := range tc.Payloads {
 						handler := webhooks.GitHubWebhook{
-							Webhook: &webhooks.Webhook{
+							WebhookRouter: &webhooks.WebhookRouter{
 								DB: db,
 							},
 						}
-						hook.Register(handler.Webhook)
+						hook.Register(handler.WebhookRouter)
 
 						u, err := extsvc.WebhookURL(extsvc.TypeGitHub, extSvc.ID, nil, "https://example.com/")
 						if err != nil {

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -185,10 +185,12 @@ func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 				// Send all events twice to ensure we are idempotent
 				for i := 0; i < 2; i++ {
 					for _, event := range tc.Payloads {
-						handler := webhooks.Webhook{
-							DB: db,
+						handler := webhooks.GitHubWebhook{
+							Webhook: &webhooks.Webhook{
+								DB: db,
+							},
 						}
-						hook.Register(&handler)
+						hook.Register(handler.Webhook)
 
 						u, err := extsvc.WebhookURL(extsvc.TypeGitHub, extSvc.ID, nil, "https://example.com/")
 						if err != nil {

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -185,7 +185,7 @@ func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 				// Send all events twice to ensure we are idempotent
 				for i := 0; i < 2; i++ {
 					for _, event := range tc.Payloads {
-						handler := webhooks.GitHubWebhook{
+						handler := webhooks.Webhook{
 							DB: db,
 						}
 						hook.Register(&handler)

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab.go
@@ -70,22 +70,22 @@ func (h *GitLabWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	fewebhooks.SetExternalServiceID(r.Context(), extSvc.ID)
 
-    rawConfig, err := extSvc.Config.Decrypt(r.Context())
-    if err != nil {
-        log15.Error("Could not decode external service config", "error", err)
-        http.Error(w, "Invalid external service config", http.StatusInternalServerError)
-        return
-    }
-
-    config := &schema.GitLabConnection{}
-    err = json.Unmarshal([]byte(rawConfig), config)
+	rawConfig, err := extSvc.Config.Decrypt(r.Context())
 	if err != nil {
 		log15.Error("Could not decode external service config", "error", err)
 		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
 		return
 	}
 
-    codeHostURN, err := extsvc.NewCodeHostBaseURL(config.Url)
+	config := &schema.GitLabConnection{}
+	err = json.Unmarshal([]byte(rawConfig), config)
+	if err != nil {
+		log15.Error("Could not decode external service config", "error", err)
+		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
+		return
+	}
+
+	codeHostURN, err := extsvc.NewCodeHostBaseURL(config.Url)
 	if err != nil {
 		log15.Error("Could not parse code host URL from config", "error", err)
 		http.Error(w, "Invalid code host URL", http.StatusInternalServerError)

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab.go
@@ -2,7 +2,9 @@ package webhooks
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -11,6 +13,7 @@ import (
 	fewebhooks "github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
@@ -22,12 +25,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-var (
-    gitlabEvents = []string{
-        "merge_request",
-        "pipeline",
-    }
-    )
+var gitlabEvents = []string{
+	"merge_request",
+	"pipeline",
+}
 
 type GitLabWebhook struct {
 	*Webhook
@@ -42,11 +43,11 @@ func NewGitLabWebhook(store *store.Store, gitserverClient gitserver.Client) *Git
 }
 
 func (h *GitLabWebhook) Register(router *fewebhooks.Webhook) {
-    router.Register(
-        h.handleEvent,
-        extsvc.KindGitLab,
-        gitlabEvents...,
-    )
+	router.Register(
+		h.handleEvent,
+		extsvc.KindGitLab,
+		gitlabEvents...,
+	)
 }
 
 var (
@@ -55,6 +56,124 @@ var (
 	errPipelineMissingMergeRequest = errors.New("pipeline event does not include a merge request")
 )
 
+// ServeHTTP implements the http.Handler interface.
+func (h *GitLabWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Look up the external service.
+	extSvc, err := h.getExternalServiceFromRawID(r.Context(), r.FormValue(extsvc.IDParam))
+	if err == errExternalServiceNotFound {
+		respond(w, http.StatusUnauthorized, err)
+		return
+	} else if err != nil {
+		respond(w, http.StatusInternalServerError, errors.Wrap(err, "getting external service"))
+		return
+	}
+
+	fewebhooks.SetExternalServiceID(r.Context(), extSvc.ID)
+
+    rawConfig, err := extSvc.Config.Decrypt(r.Context())
+    if err != nil {
+        log15.Error("Could not decode external service config", "error", err)
+        http.Error(w, "Invalid external service config", http.StatusInternalServerError)
+        return
+    }
+
+    config := &schema.GitLabConnection{}
+    err = json.Unmarshal([]byte(rawConfig), config)
+	if err != nil {
+		log15.Error("Could not decode external service config", "error", err)
+		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
+		return
+	}
+
+    codeHostURN, err := extsvc.NewCodeHostBaseURL(config.Url)
+	if err != nil {
+		log15.Error("Could not parse code host URL from config", "error", err)
+		http.Error(w, "Invalid code host URL", http.StatusInternalServerError)
+		return
+	}
+
+	// 🚨 SECURITY: Verify the shared secret against the GitLab external service
+	// configuration. If there isn't a webhook defined in the service with this
+	// secret, or the header is empty, then we return a 401 to the client.
+	if ok, err := validateGitLabSecret(r.Context(), extSvc, r.Header.Get(webhooks.TokenHeaderName)); err != nil {
+		respond(w, http.StatusInternalServerError, errors.Wrap(err, "validating the shared secret"))
+		return
+	} else if !ok {
+		respond(w, http.StatusUnauthorized, "shared secret is incorrect")
+		return
+	}
+
+	// 🚨 SECURITY: now that the shared secret has been validated, we can use an
+	// internal actor on the context.
+	ctx := actor.WithInternalActor(r.Context())
+
+	// Parse the event proper.
+	if r.Body == nil {
+		respond(w, http.StatusBadRequest, "missing request body")
+		return
+	}
+	payload, err := io.ReadAll(r.Body)
+	if err != nil {
+		respond(w, http.StatusInternalServerError, errors.Wrap(err, "reading payload"))
+		return
+	}
+
+	event, err := webhooks.UnmarshalEvent(payload)
+	if err != nil {
+		if errors.Is(err, webhooks.ErrObjectKindUnknown) {
+			// We don't want to return a non-2XX status code and have GitLab
+			// retry the webhook, so we'll log that we don't know what to do
+			// and return 204.
+			log15.Debug("unknown object kind", "err", err)
+
+			// We don't use respond() here so that we don't log an error, since
+			// this really isn't one.
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.WriteHeader(http.StatusNoContent)
+			fmt.Fprintf(w, "%v", err)
+		} else {
+			respond(w, http.StatusInternalServerError, errors.Wrap(err, "unmarshalling payload"))
+		}
+		return
+	}
+
+	// Route the request based on the event type.
+	if err := h.handleEvent(ctx, h.Store.DatabaseDB(), codeHostURN, event); err != nil {
+		respond(w, http.StatusInternalServerError, err)
+	} else {
+		respond(w, http.StatusNoContent, nil)
+	}
+}
+
+// getExternalServiceFromRawID retrieves the external service matching the
+// given raw ID, which is usually going to be the string in the
+// externalServiceID URL parameter.
+//
+// On failure, errExternalServiceNotFound is returned if the ID doesn't match
+// any GitLab service.
+func (h *GitLabWebhook) getExternalServiceFromRawID(ctx context.Context, raw string) (*types.ExternalService, error) {
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing the raw external service ID")
+	}
+
+	es, err := h.Store.ExternalServices().List(ctx, database.ExternalServicesListOptions{
+		IDs:   []int64{id},
+		Kinds: []string{extsvc.KindGitLab},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "listing external services")
+	}
+
+	if len(es) == 0 {
+		return nil, errExternalServiceNotFound
+	} else if len(es) > 1 {
+		// This _really_ shouldn't happen, since we provided only one ID above.
+		return nil, errors.New("too many external services found")
+	}
+
+	return es[0], nil
+}
 
 // handleEvent is essentially a router: it dispatches based on the event type
 // to perform whatever changeset action is appropriate for that event.
@@ -62,7 +181,7 @@ func (h *GitLabWebhook) handleEvent(ctx context.Context, db database.DB, codeHos
 	log15.Debug("GitLab webhook received", "type", fmt.Sprintf("%T", event))
 
 	if h.failHandleEvent != nil {
-        return h.failHandleEvent
+		return h.failHandleEvent
 	}
 
 	switch e := event.(type) {

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
 
+	fewebhooks "github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	bt "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
@@ -585,7 +586,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 				h.Store = store.NewWithClock(db, &observation.TestContext, nil, s.Clock())
 
 				err := h.handleEvent(ctx, db, event)
-                require.Error(t, err)
+				require.Error(t, err)
 			})
 		})
 

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	bt "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
@@ -583,12 +584,8 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 				db := database.NewDBWith(logger, basestore.NewWithHandle(&brokenDB{errors.New("foo")}))
 				h.Store = store.NewWithClock(db, &observation.TestContext, nil, s.Clock())
 
-				err := h.handleEvent(ctx, es, event)
-				if err == nil {
-					t.Error("unexpected nil error")
-				} else if want := http.StatusInternalServerError; err.code != want {
-					t.Errorf("unexpected status code: have %d; want %d", err.code, want)
-				}
+				err := h.handleEvent(ctx, db, event)
+                require.Error(t, err)
 			})
 		})
 

--- a/internal/repos/github_webhook_handler.go
+++ b/internal/repos/github_webhook_handler.go
@@ -19,7 +19,7 @@ type GitHubWebhookHandler struct {
 	logger log.Logger
 }
 
-func (g *GitHubWebhookHandler) Register(router *webhooks.Webhook) {
+func (g *GitHubWebhookHandler) Register(router *webhooks.WebhookRouter) {
 	g.logger = log.Scoped("repos.GitHubWebhookHandler", "github webhook handler")
 	router.Register(g.handleGitHubWebhook, "push")
 }

--- a/internal/repos/github_webhook_handler.go
+++ b/internal/repos/github_webhook_handler.go
@@ -19,7 +19,7 @@ type GitHubWebhookHandler struct {
 	logger log.Logger
 }
 
-func (g *GitHubWebhookHandler) Register(router *webhooks.GitHubWebhook) {
+func (g *GitHubWebhookHandler) Register(router *webhooks.Webhook) {
 	g.logger = log.Scoped("repos.GitHubWebhookHandler", "github webhook handler")
 	router.Register(g.handleGitHubWebhook, "push")
 }

--- a/internal/repos/github_webhook_handler_test.go
+++ b/internal/repos/github_webhook_handler_test.go
@@ -70,11 +70,11 @@ func TestGitHubWebhookHandle(t *testing.T) {
 
 	handler := repos.GitHubWebhookHandler{}
 	router := &webhooks.GitHubWebhook{
-		Webhook: &webhooks.Webhook{
+		WebhookRouter: &webhooks.WebhookRouter{
 			DB: db,
 		},
 	}
-	handler.Register(router.Webhook)
+	handler.Register(router.WebhookRouter)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/enqueue-repo-update", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/repos/github_webhook_handler_test.go
+++ b/internal/repos/github_webhook_handler_test.go
@@ -69,10 +69,12 @@ func TestGitHubWebhookHandle(t *testing.T) {
 	}
 
 	handler := repos.GitHubWebhookHandler{}
-	router := &webhooks.Webhook{
-		DB: db,
+	router := &webhooks.GitHubWebhook{
+		Webhook: &webhooks.Webhook{
+			DB: db,
+		},
 	}
-	handler.Register(router)
+	handler.Register(router.Webhook)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/enqueue-repo-update", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/repos/github_webhook_handler_test.go
+++ b/internal/repos/github_webhook_handler_test.go
@@ -69,7 +69,7 @@ func TestGitHubWebhookHandle(t *testing.T) {
 	}
 
 	handler := repos.GitHubWebhookHandler{}
-	router := &webhooks.GitHubWebhook{
+	router := &webhooks.Webhook{
 		DB: db,
 	}
 	handler.Register(router)


### PR DESCRIPTION
This PR tries to create a more generic structure that webhooks of different code hosts can use to register and trigger webhooks.

## Test plan

Tests updated and still passing. Have to add new ones.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
