### PR TITLE
CodeMirror blob: Properly scroll selected line into view in reference panel

### DIFF
--- a/client/web/src/repo/blob/codemirror/hovercard.tsx
+++ b/client/web/src/repo/blob/codemirror/hovercard.tsx
@@ -582,25 +582,6 @@ class HovercardView implements TooltipView {
     }
 
     public mount(): void {
-        if (this.dom.parentElement) {
-            // CodeMirror doesn't provide a "destroy" function like for
-            // ViewPlugins, hence we use a mutation observer to detect the
-            // removal of the DOM container and clean up resources.
-            // (note: https://github.com/codemirror/view/pull/41 adds such a
-            // method)
-            const observer = new MutationObserver(mutations => {
-                for (const mutation of mutations) {
-                    if (mutation.type === 'childList' && Array.from(mutation.removedNodes).includes(this.dom)) {
-                        this.subscription.unsubscribe()
-                        this.root?.unmount()
-                        observer.disconnect()
-                        return
-                    }
-                }
-            })
-            observer.observe(this.dom.parentElement, { childList: true })
-        }
-
         this.nextContainer.next(this.dom)
     }
 
@@ -611,6 +592,11 @@ class HovercardView implements TooltipView {
             this.props = props
             this.nextProps.next(props)
         }
+    }
+
+    public destroy(): void {
+        this.subscription.unsubscribe()
+        this.root?.unmount()
     }
 
     private render(root: Root, { hoverOrError, actionsOrError }: HoverData, props: BlobProps, pinned: boolean): void {

--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -119,7 +119,10 @@ const lineSelectionSource = Annotation.define<'gutter'>()
 const scrollIntoView = ViewPlugin.fromClass(
     class implements PluginValue {
         private lastSelectedLines: SelectedLineRange | null = null
-        constructor(private readonly view: EditorView) {}
+        constructor(private readonly view: EditorView) {
+            this.lastSelectedLines = this.view.state.field(selectedLines)
+            this.scrollIntoView(this.lastSelectedLines)
+        }
 
         public update(update: ViewUpdate): void {
             const currentSelectedLines = update.state.field(selectedLines)
@@ -385,7 +388,7 @@ function normalizeLineRange(range: SelectedLineRange): SelectedLineRange {
  * outside of the editor viewport).
  */
 function shouldScrollIntoView(view: EditorView, range: SelectedLineRange): boolean {
-    if (!range) {
+    if (!range || !isValidLineRange(range, view.state.doc)) {
         return false
     }
 

--- a/package.json
+++ b/package.json
@@ -367,7 +367,7 @@
     "@codemirror/lint": "^6.0.0",
     "@codemirror/search": "^6.0.1",
     "@codemirror/state": "^6.1.0",
-    "@codemirror/view": "^6.0.2",
+    "@codemirror/view": "^6.4.0",
     "@lezer/highlight": "^1.0.0",
     "@mdi/js": "^6.7.96",
     "@microsoft/fetch-event-source": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2244,14 +2244,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/view@npm:^6.0.0, @codemirror/view@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "@codemirror/view@npm:6.0.2"
+"@codemirror/view@npm:^6.0.0, @codemirror/view@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "@codemirror/view@npm:6.4.0"
   dependencies:
     "@codemirror/state": ^6.0.0
     style-mod: ^4.0.0
     w3c-keyname: ^2.2.4
-  checksum: a9dbc2b97cb1aa8d88bd0cdcc9560660c89ecff93fd86b6ecdda920a6bd22b0e1ccf72c010ac743d7daf4185a03c78bafecd9860e336585bbcca0b93dde55566
+  checksum: 57ed7d9d51907f1ea549a2a158872fb7affa6cdff72e29e214f8437b7142ea2a2431ac3c780cbc0187dfff7cb5fd1055a45a887ea9b8c2a09d8430c60ebe9083
   languageName: node
   linkType: hard
 
@@ -29206,7 +29206,7 @@ pvutils@latest:
     "@codemirror/lint": ^6.0.0
     "@codemirror/search": ^6.0.1
     "@codemirror/state": ^6.1.0
-    "@codemirror/view": ^6.0.2
+    "@codemirror/view": ^6.4.0
     "@gql2ts/from-schema": ^1.10.1
     "@gql2ts/language-typescript": ^1.9.0
     "@gql2ts/types": ^1.9.0


### PR DESCRIPTION
Fixes #43427 

There have been three issues with scrolling the selected line into view:

- `shouldScrollIntoView` is potentially called when document is updated (but not the position), so it needs to guard against selecting lines outside the document range, otherwise an error is thrown.
- The selected line wasn't scrolled into view when loading opening a new file in the reference panel (tbh I don't know why it would work properly in the main view but not in the reference view, but the code was clearly incorrect).
- There seems to be a race condition between CodeMirror wrapping lines and computing whether the selected line is in view or not. I've updated `@codemirror/view` to the latest version, which contains some fixes around line wrapping with the hope that this is fixed. At least I wasn't able to reliably reproduce this issue anymore. [`@codemirror/view` changelog](https://github.com/codemirror/view/blob/main/CHANGELOG.md#603-2022-07-08) (everything >= 6.0.3).

Since I upgraded `@codemirror/view` anyway I also updated the hovercard code to make use of the `Tooltip`'s `destroy` that I added in https://github.com/codemirror/view/pull/41


## Test plan

Manual testing. Clicking different references in the reference panel scrolls the corresponding line into view.

## App preview:

- [Web](https://sg-web-fkling-43427-cm-reference-panel.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
