### PR TITLE
ranking: Upsert document ranks

### DIFF
--- a/internal/codeintel/ranking/internal/store/store_test.go
+++ b/internal/codeintel/ranking/internal/store/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -56,5 +57,52 @@ func TestGetStarRank(t *testing.T) {
 		if stars != testCase.expected {
 			t.Errorf("unexpected rank. want=%.2f have=%.2f", testCase.expected, stars)
 		}
+	}
+}
+
+func TestDocumentRanks(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	store := New(db, &observation.TestContext)
+	repoName := api.RepoName("foo")
+
+	if _, err := db.ExecContext(ctx, `INSERT INTO repo (name, stars) VALUES ('foo', 1000)`); err != nil {
+		t.Fatalf("failed to insert repos: %s", err)
+	}
+
+	if err := store.SetDocumentRanks(ctx, repoName, map[string][]float64{
+		"cmd/main.go":        {1, 2, 3},
+		"internal/secret.go": {2, 3, 4},
+		"internal/util.go":   {3, 4, 5},
+		"README.md":          {4, 5, 6},
+	}); err != nil {
+		t.Fatalf("unexpected error setting document ranks: %s", err)
+	}
+	if err := store.SetDocumentRanks(ctx, repoName, map[string][]float64{
+		"cmd/args.go":        {7, 8, 9}, //new
+		"internal/secret.go": {6, 7, 8}, // edited
+		"internal/util.go":   {5, 6, 7}, // edited
+	}); err != nil {
+		t.Fatalf("unexpected error setting document ranks: %s", err)
+	}
+
+	ranks, _, err := store.GetDocumentRanks(ctx, repoName)
+	if err != nil {
+		t.Fatalf("unexpected error setting document ranks: %s", err)
+	}
+	expectedRanks := map[string][]float64{
+		"cmd/main.go":        {1, 2, 3},
+		"README.md":          {4, 5, 6},
+		"cmd/args.go":        {7, 8, 9},
+		"internal/secret.go": {6, 7, 8},
+		"internal/util.go":   {5, 6, 7},
+	}
+	if diff := cmp.Diff(expectedRanks, ranks); diff != "" {
+		t.Errorf("unexpected ranks (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
Update the `SetDocumentRanks` store method to combine all path ranks (taking the newer ones on conflict). This will eventually allow us more efficiently upsert batches of page rank results into the database.

## Test plan

New unit tests. This method is currently feature flagged off in all non-dev environments.