### PR TITLE
docs/deploy update GCE images links,

### DIFF
--- a/doc/admin/deploy/machine-images/aws-ami.md
+++ b/doc/admin/deploy/machine-images/aws-ami.md
@@ -14,6 +14,27 @@ Following these docs will provision the following resources:
 - A root EBS volume with 50GB of storage
 - An additional EBS volume with 500GB of storage for storing code and search indices
 
+### Instance size chart
+
+Select an AMI according and instance type to the number of users and repositories you have using this table. If you fall between two sizes, choose the larger of the two.
+
+For example, if you have 8,000 users with 80,000 repositories, your instance size would be **L**. If you have 1,000 users with 80,000 repositories, you should still go with size **M**.
+
+|                  | **XS**     | **S**       | **M**       | **L**       | **XL**      |
+|------------------|------------|-------------|-------------|-------------|-------------|
+| **Users**        | _<=_ 500   | _<=_ 1,000  | _<=_ 5,000  | _<=_ 10,000 | _<=_ 20,000 |
+| **Repositories** | _<=_ 5,000 | _<=_ 10,000 | _<=_ 50,000 | _<=_ 100,000| _<=_ 250,000|
+| **Recommended Type**  |                                               m6a.2xlarge                                                |                     m6a.4xlarge                      |                     m6a.8xlarge                      |                                              m6a.12xlarge                                               |                                               m6a.24xlarge                                               |
+| **Minimum Type**      |                                               m6a.2xlarge                                                |                     m6a.2xlarge                      |                     m6a.4xlarge                      |                                               m6a.8xlarge                                               |                                               m6a.12xlarge                                               |
+| **AMIs List** | [size-XS AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-XS) | [size-S AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-S) | [size-M AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-M) | [size-L AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-L) | [size-XL AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-XL) |
+
+Click [here](https://github.com/sourcegraph/deploy#amazon-ec2-amis) to see the completed list of AMI IDs published in each region.
+
+<span class="badge badge-critical">IMPORTANT</span> The default AMI user name is **ec2-user**.
+
+> NOTE: AMIs are optimized for the specific set of resources provided by the instance type, please ensure you use the correct AMI for the associated EC2 instance type. You can [resize your EC2 instance anytime](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-resize.html), but your Sourcegraph AMI must match accordingly. If needed, follow the [upgrade steps](#upgrade) to switch to the correct AMI image that is optimized for your EC2 instance type.
+
+
 ---
 
 ## Deploy Sourcegraph
@@ -41,26 +62,6 @@ Once the instance has started, please allow ~5 minutes for Sourcegraph to initia
 To configure SSL, and lock down the instance from the public internet, see the [networking](#networking) section.
 
 > NOTE: If you cannot access the Sourcegraph homepage after 10 minutes, please try reboot your instance.
-
-### Instance size chart
-
-Select an AMI according and instance type to the number of users and repositories you have using this table. If you fall between two sizes, choose the larger of the two.
-
-For example, if you have 8,000 users with 80,000 repositories, your instance size would be **L**. If you have 1,000 users with 80,000 repositories, you should still go with size **M**.
-
-|                  | **XS**     | **S**       | **M**       | **L**       | **XL**      |
-|------------------|------------|-------------|-------------|-------------|-------------|
-| **Users**        | _<=_ 500   | _<=_ 1,000  | _<=_ 5,000  | _<=_ 10,000 | _<=_ 20,000 |
-| **Repositories** | _<=_ 5,000 | _<=_ 10,000 | _<=_ 50,000 | _<=_ 100,000| _<=_ 250,000|
-| **Recommended Type**  |                                               m6a.2xlarge                                                |                     m6a.4xlarge                      |                     m6a.8xlarge                      |                                              m6a.12xlarge                                               |                                               m6a.24xlarge                                               |
-| **Minimum Type**      |                                               m6a.2xlarge                                                |                     m6a.2xlarge                      |                     m6a.4xlarge                      |                                               m6a.8xlarge                                               |                                               m6a.12xlarge                                               |
-| **AMIs List** | [size-XS AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-XS) | [size-S AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-S) | [size-M AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-M) | [size-L AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-L) | [size-XL AMIs](https://console.aws.amazon.com/ec2/v2/home#Images:visibility=public-images;imageName=Sourcegraph-XL) |
-
-Click [here](https://github.com/sourcegraph/deploy#amazon-ec2-amis) to see the completed list of AMI IDs published in each region.
-
-<span class="badge badge-critical">IMPORTANT</span> The default AMI user name is **ec2-user**.
-
-> NOTE: AMIs are optimized for the specific set of resources provided by the instance type, please ensure you use the correct AMI for the associated EC2 instance type. You can [resize your EC2 instance anytime](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-resize.html), but your Sourcegraph AMI must match accordingly. If needed, follow the [upgrade steps](#upgrade) to switch to the correct AMI image that is optimized for your EC2 instance type.
 
 ---
 

--- a/doc/admin/deploy/machine-images/gce.md
+++ b/doc/admin/deploy/machine-images/gce.md
@@ -16,6 +16,23 @@ Following these docs will provision the following resources:
 
 > WARNING: Connection to the internet is required to pull Docker images at first launch.
 
+## Instance size chart
+
+Select a deployment image and machine type according to the number of users and repositories you have using this table.
+
+If you fall between two sizes, choose the larger of the two. For example, if you have 8,000 users with 80,000 repositories, your instance size would be **L**. If you have 1,000 users with 80,000 repositories, you should still go with size **M**.
+
+|                  | **XS**     | **S**       | **M**       | **L**       | **XL**      |
+|------------------|------------|-------------|-------------|-------------|-------------|
+| **Users**        | _<=_ 500   | _<=_ 1,000  | _<=_ 5,000  | _<=_ 10,000 | _<=_ 20,000 |
+| **Repositories** | _<=_ 5,000 | _<=_ 10,000 | _<=_ 50,000 | _<=_ 100,000| _<=_ 250,000|
+| **Series**       | N2         | N2          | N2          | N2          | N2          |
+| **Recommended**  | standard-8 | standard-16 | standard-32 | standard-48 | standard-96 |
+| **Minimum**      | standard-8 | standard-8  | standard-16 | standard-32 | standard-64 |
+| **Lastest Version Links**   | [download](https://storage.googleapis.com/sourcegraph-images/latest/Sourcegraph-XS.tar.gz) | [download](https://storage.googleapis.com/sourcegraph-images/latest/Sourcegraph-S.tar.gz) | [download](https://storage.googleapis.com/sourcegraph-images/latest/Sourcegraph-M.tar.gz) | [download](https://storage.googleapis.com/sourcegraph-images/latest/Sourcegraph-L.tar.gz) | [download](https://storage.googleapis.com/sourcegraph-images/latest/Sourcegraph-XL.tar.gz) |
+
+> NOTE: Sourcegraph GCE images are optimized for the specific set of resources provided by the machine type, please ensure you use the correct GCE image for the associated GCE machine type. You can [resize your machine type anytime](https://cloud.google.com/compute/docs/instances/changing-machine-type-of-stopped-instance), but your Sourcegraph GCE image must match accordingly. If needed, follow the [upgrade steps](#upgrade) to switch to the correct GCE image that is optimized for your machine type.
+
 ---
 
 ## Deploy Sourcegraph
@@ -24,7 +41,7 @@ Following these docs will provision the following resources:
 
 <img class="screenshot" src="./assets/gcp-bucket.png"/>
 
-1. In the [instance size chart](#instance-size-chart) below, download the image (`tar.gz`) file that matches your deployment size
+1. Download the image (`tar.gz`) file that matches your deployment size from the [instance size chart](#instance-size-chart)
 2. Navigate to [Google Cloud Storage](https://console.cloud.google.com/storage) and select a project where you will store the image and deploy the instance in
 3. **Upload** the `tar.gz` file to a bucket (create one if needed)
 4. Copy the **URL**
@@ -78,27 +95,6 @@ Your can also switch users in the terminal with the command below:
 ```bash
 $ sudo su sourcegraph
 ```
-
----
-
-## Instance size chart
-
-Select a deployment image and machine type according to the number of users and repositories you have using this table.
-
-If you fall between two sizes, choose the larger of the two. For example, if you have 8,000 users with 80,000 repositories, your instance size would be **L**. If you have 1,000 users with 80,000 repositories, you should still go with size **M**.
-
-|                  | **XS**     | **S**       | **M**       | **L**       | **XL**      |
-|------------------|------------|-------------|-------------|-------------|-------------|
-| **Users**        | _<=_ 500   | _<=_ 1,000  | _<=_ 5,000  | _<=_ 10,000 | _<=_ 20,000 |
-| **Repositories** | _<=_ 5,000 | _<=_ 10,000 | _<=_ 50,000 | _<=_ 100,000| _<=_ 250,000|
-| **Series**       | N2         | N2          | N2          | N2          | N2          |
-| **Recommended**  | standard-8 | standard-16 | standard-32 | standard-48 | standard-96 |
-| **Minimum**      | standard-8 | standard-8  | standard-16 | standard-32 | standard-64 |
-| **Lastest Version Links**   | [download](https://storage.googleapis.com/sourcegraph-images/latest/Soucegraph-XS.tar.gz) | [download](https://storage.googleapis.com/sourcegraph-images/latest/Soucegraph-S.tar.gz) | [download](https://storage.googleapis.com/sourcegraph-images/latest/Soucegraph-M.tar.gz) | [download](https://storage.googleapis.com/sourcegraph-images/latest/Soucegraph-L.tar.gz) | [download](https://storage.googleapis.com/sourcegraph-images/latest/Soucegraph-XL.tar.gz) |
-
-File Size: ~<2GB
-
-> NOTE: Sourcegraph GCE images are optimized for the specific set of resources provided by the machine type, please ensure you use the correct GCE image for the associated GCE machine type. You can [resize your machine type anytime](https://cloud.google.com/compute/docs/instances/changing-machine-type-of-stopped-instance), but your Sourcegraph GCE image must match accordingly. If needed, follow the [upgrade steps](#upgrade) to switch to the correct GCE image that is optimized for your machine type.
 
 ---
 


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C02E4HE42BX/p1666818011010539

Current GCE download links are broken due to missing `r` in file name `Sourcegraph`. 

This PR:
- Update broken links with the correct links
- Move instance size charts to top for better user flow

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

![image](https://user-images.githubusercontent.com/68532117/198149523-ccc73404-ad5a-4302-acd4-1bef26d591ae.png)

Tested locally to confirm the links are valid:
![image](https://user-images.githubusercontent.com/68532117/198149582-2781759d-cd08-4f1d-bcbf-362db46f58c8.png)
