### PR TITLE
smart search ui: add delay when changing radio button before closing menu

### DIFF
--- a/client/search-ui/src/input/toggles/SmartSearchToggle.tsx
+++ b/client/search-ui/src/input/toggles/SmartSearchToggle.tsx
@@ -13,8 +13,8 @@ import {
     PopoverTrigger,
     Tooltip,
     Position,
-    H1,
     H4,
+    H2,
 } from '@sourcegraph/wildcard'
 
 import { ToggleProps } from './QueryInputToggle'
@@ -78,10 +78,16 @@ export const SmartSearchToggle: React.FunctionComponent<SmartSearchToggleProps> 
 const SmartSearchToggleMenu: React.FunctionComponent<
     Pick<SmartSearchToggleProps, 'onSelect' | 'isActive'> & { closeMenu: () => void }
 > = ({ onSelect, isActive, closeMenu }) => {
+    const [visibleIsEnabled, setVisibleIsEnabled] = useState(isActive)
+
     const onChange = useCallback(
         (value: boolean) => {
-            onSelect(value)
-            closeMenu()
+            setVisibleIsEnabled(value)
+            // Wait a tiny bit for user to see the selection change before closing the popover
+            setTimeout(() => {
+                onSelect(value)
+                closeMenu()
+            }, 100)
         },
         [onSelect, closeMenu]
     )
@@ -93,7 +99,7 @@ const SmartSearchToggleMenu: React.FunctionComponent<
             className={smartStyles.popoverWindow}
         >
             <div className="d-flex align-items-center px-3 py-2">
-                <H4 as={H1} id="smart-search-popover-header" className="m-0 flex-1">
+                <H4 as={H2} id="smart-search-popover-header" className="m-0 flex-1">
                     Smart Search
                 </H4>
                 <Button onClick={() => closeMenu()} variant="icon" aria-label="Close">
@@ -104,14 +110,14 @@ const SmartSearchToggleMenu: React.FunctionComponent<
                 value={true}
                 header="Enable"
                 description="Suggest variations of your query to find more results that may relate."
-                isChecked={isActive}
+                isChecked={visibleIsEnabled}
                 onSelect={onChange}
             />
             <RadioItem
                 value={false}
                 header="Disable"
                 description="Only show results that precisely match your query."
-                isChecked={!isActive}
+                isChecked={!visibleIsEnabled}
                 onSelect={onChange}
             />
         </PopoverContent>


### PR DESCRIPTION
Closes #43128

Adds a delay before closing. Now users can see the new radio button state before the popover closes.

Before:

https://user-images.githubusercontent.com/206864/198151989-66de7a7e-4ea5-4f22-bb2c-211241f6da4d.mp4

After:

https://user-images.githubusercontent.com/206864/198151483-bc76090c-3d9f-4ed0-9634-19338af8c98e.mp4

## Test plan

Tested with both mouse and keyboard.

## App preview:

- [Web](https://sg-web-jp-smartsearchmenufeedback.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
