### PR TITLE
"Log in" button should redirect to previous URL

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -328,7 +328,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                                         className="mr-1"
                                         to={
                                             '/sign-in?returnTo=' +
-                                            encodeURI(history.location.pathname + history.location.search)
+                                            encodeURI(history.location.pathname + history.location.search + history.location.hash)
                                         }
                                         variant="secondary"
                                         outline={true}


### PR DESCRIPTION
## Current behavior (bad UX):

When you click the Login button in the global nav and log in, you are redirected back to the homepage instead of the page you were on.

## New behavior

When you log in by clicking the "Log in" button in the global navbar,
![image](https://user-images.githubusercontent.com/1646931/198202748-6ad7dd64-49c7-476c-b5ba-d40f29124080.png)

Sourcegraph should remember your current URL...
![image](https://user-images.githubusercontent.com/1646931/198202807-ff616a65-e5fa-4578-8170-f4c98b8f796c.png)

...and redirect back to it after successful login:
![image](https://user-images.githubusercontent.com/1646931/198202860-16f4b8d7-f87c-42b6-9a92-727ace29eec4.png)


## App preview:

- [Web](https://sg-web-bl-sign-in-redirect.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

## Test plan

Tested locally