### PR TITLE
searcher: use conf based connection to Zoekt

### DIFF
--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -35,9 +35,9 @@ func (s *Service) hybrid(ctx context.Context, p *protocol.Request, sender matchS
 	rootLogger := logWithTrace(ctx, s.Log).Scoped("hybrid", "experimental hybrid search").With(
 		log.String("repo", string(p.Repo)),
 		log.String("commit", string(p.Commit)),
-		log.Int("endpoints", len(p.IndexerEndpoints)))
+	)
 
-	client := getZoektClient(p.IndexerEndpoints)
+	client := s.Indexed
 
 	// There is a race condition between asking zoekt what is indexed vs
 	// actually searching since the index may update. If the index changes,

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -19,6 +19,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sourcegraph/zoekt"
 	zoektquery "github.com/sourcegraph/zoekt/query"
 
 	"github.com/sourcegraph/log"
@@ -293,7 +294,7 @@ func lookupMatcher(language string) string {
 	return ".generic"
 }
 
-func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request, sender matchSender) (err error) {
+func structuralSearchWithZoekt(ctx context.Context, indexed zoekt.Streamer, p *protocol.Request, sender matchSender) (err error) {
 	patternInfo := &search.TextPatternInfo{
 		Pattern:                      p.Pattern,
 		IsNegated:                    p.IsNegated,
@@ -315,7 +316,7 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request, sender 
 		p.Branch = "HEAD"
 	}
 	branchRepos := []zoektquery.BranchRepos{{Branch: p.Branch, Repos: roaring.BitmapOf(uint32(p.RepoID))}}
-	err = zoektSearch(ctx, patternInfo, branchRepos, time.Since, p.IndexerEndpoints, p.Repo, sender)
+	err = zoektSearch(ctx, indexed, patternInfo, branchRepos, time.Since, p.Repo, sender)
 	if err != nil {
 		return err
 	}

--- a/cmd/searcher/internal/search/zoekt_search.go
+++ b/cmd/searcher/internal/search/zoekt_search.go
@@ -7,7 +7,6 @@ import (
 	"regexp/syntax" //nolint:depguard // zoekt requires this pkg
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/sourcegraph/zoekt"
@@ -21,26 +20,6 @@ import (
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
-
-var (
-	zoektOnce   sync.Once
-	endpointMap atomicEndpoints
-	zoektClient zoekt.Streamer
-)
-
-func getZoektClient(indexerEndpoints []string) zoekt.Streamer {
-	zoektOnce.Do(func() {
-		zoektClient = backend.NewMeteredSearcher(
-			"", // no hostname means its the aggregator
-			&backend.HorizontalSearcher{
-				Map:  &endpointMap,
-				Dial: backend.ZoektDial,
-			},
-		)
-	})
-	endpointMap.Set(indexerEndpoints)
-	return zoektClient
-}
 
 func handleFilePathPatterns(query *search.TextPatternInfo) (zoektquery.Q, error) {
 	var and []zoektquery.Q
@@ -91,7 +70,7 @@ func buildQuery(args *search.TextPatternInfo, branchRepos []zoektquery.BranchRep
 // Timeouts are reported through the context, and as a special case errNoResultsInTimeout
 // is returned if no results are found in the given timeout (instead of the more common
 // case of finding partial or full results in the given timeout).
-func zoektSearch(ctx context.Context, args *search.TextPatternInfo, branchRepos []zoektquery.BranchRepos, since func(t time.Time) time.Duration, endpoints []string, repo api.RepoName, sender matchSender) (err error) {
+func zoektSearch(ctx context.Context, client zoekt.Streamer, args *search.TextPatternInfo, branchRepos []zoektquery.BranchRepos, since func(t time.Time) time.Duration, repo api.RepoName, sender matchSender) (err error) {
 	if len(branchRepos) == 0 {
 		return nil
 	}
@@ -137,7 +116,6 @@ func zoektSearch(ctx context.Context, args *search.TextPatternInfo, branchRepos 
 		}
 	}()
 
-	client := getZoektClient(endpoints)
 	err = client.StreamSearch(ctx, q, searchOpts, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
 		for _, file := range event.Files {
 			hdr := tar.Header{
@@ -165,41 +143,3 @@ func zoektSearch(ctx context.Context, args *search.TextPatternInfo, branchRepos 
 }
 
 var errNoResultsInTimeout = errors.New("no results found in specified timeout")
-
-// atomicEndpoints allows us to update the endpoints used by our zoekt client.
-type atomicEndpoints struct {
-	endpoints atomic.Value
-}
-
-func (a *atomicEndpoints) Endpoints() ([]string, error) {
-	eps := a.endpoints.Load()
-	if eps == nil {
-		return nil, errors.New("endpoints have not been set")
-	}
-	return eps.([]string), nil
-}
-
-func (a *atomicEndpoints) Set(endpoints []string) {
-	if !a.needsUpdate(endpoints) {
-		return
-	}
-	a.endpoints.Store(endpoints)
-}
-
-func (a *atomicEndpoints) needsUpdate(endpoints []string) bool {
-	old, err := a.Endpoints()
-	if err != nil {
-		return true
-	}
-	if len(old) != len(endpoints) {
-		return true
-	}
-
-	for i := range endpoints {
-		if old[i] != endpoints[i] {
-			return true
-		}
-	}
-
-	return false
-}

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/profiler"
+	sharedsearch "github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 	"github.com/sourcegraph/sourcegraph/internal/version"
@@ -184,6 +185,8 @@ func run(logger log.Logger) error {
 			ObservationContext: storeObservationContext,
 			DB:                 db,
 		},
+
+		Indexed: sharedsearch.Indexed(),
 
 		GitDiffSymbols: func(ctx context.Context, repo api.RepoName, commitA, commitB api.CommitID) ([]byte, error) {
 			// As this is an internal service call, we need an internal actor.

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -47,6 +47,8 @@ type Request struct {
 
 	// Endpoint(s) for reaching Zoekt. See description in
 	// endpoint.go:Static(...)
+	//
+	// Deprecated: no longer read, searcher uses ServiceConnections now.
 	IndexerEndpoints []string
 
 	// Whether the revision to be searched is indexed or unindexed. This matters for


### PR DESCRIPTION
Since yesterday we now can do zoekt service discovery via the conf endpoint. This means we no longer need to smuggle in the zoekt endpoints and can instead just use the same zoekt client as in frontend.

Test Plan: go test and integration tests on CI