### PR TITLE
auth: refactor OIDC auth provider for code reuse

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/init.go
+++ b/enterprise/cmd/frontend/internal/auth/init.go
@@ -100,7 +100,7 @@ func ssoSignOutHandler(w http.ResponseWriter, r *http.Request) {
 		var err error
 		switch {
 		case p.Openidconnect != nil:
-			_, err = openidconnect.SignOut(w, r)
+			_, err = openidconnect.SignOut(w, r, openidconnect.SessionKey)
 		case p.Saml != nil:
 			_, err = saml.SignOut(w, r)
 		}

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/config.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/config.go
@@ -6,49 +6,54 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"net/http"
 
-	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-var mockGetProviderValue *provider
+var mockGetProviderValue *Provider
 
-// getProvider looks up the registered openidconnect auth provider with the given ID.
-func getProvider(id string) *provider {
+// getProvider looks up the registered OpenID Connect authentication provider
+// with the given ID.
+func getProvider(id string) *Provider {
 	if mockGetProviderValue != nil {
 		return mockGetProviderValue
 	}
-	p, _ := providers.GetProviderByConfigID(providers.ConfigID{Type: providerType, ID: id}).(*provider)
+	p, _ := providers.GetProviderByConfigID(
+		providers.ConfigID{
+			Type: providerType,
+			ID:   id,
+		},
+	).(*Provider)
 	return p
 }
 
-func handleGetProvider(ctx context.Context, w http.ResponseWriter, id string) (p *provider, handled bool) {
-	handled = true // safer default
-
+// GetProviderAndRefresh retrieves the authentication provider with the given
+// type and ID, and refreshes the provider.
+func GetProviderAndRefresh(ctx context.Context, id string, getProvider func(id string) *Provider) (p *Provider, safeErrMsg string, err error) {
 	p = getProvider(id)
 	if p == nil {
-		log15.Error("No OpenID Connect auth provider found with ID.", "id", id)
-		http.Error(w, "Misconfigured OpenID Connect auth provider.", http.StatusInternalServerError)
-		return nil, true
+		return nil,
+			"Misconfigured authentication provider.",
+			errors.Errorf("no authentication provider found with ID %q", id)
 	}
 	if p.config.Issuer == "" {
-		log15.Error("No issuer set for OpenID Connect auth provider (set the openidconnect auth provider's issuer property).", "id", p.ConfigID())
-		http.Error(w, "Misconfigured OpenID Connect auth provider.", http.StatusInternalServerError)
-		return nil, true
+		return nil,
+			"Misconfigured authentication provider.",
+			errors.Errorf("No issuer set for authentication provider with ID %q (set the authentication provider's issuer property).", p.ConfigID())
 	}
-	if err := p.Refresh(ctx); err != nil {
-		log15.Error("Error refreshing OpenID Connect auth provider.", "id", p.ConfigID(), "error", err)
-		http.Error(w, "Unexpected error refreshing OpenID Connect authentication provider. This may be due to an incorrect issuer URL. Check the logs for more details", http.StatusInternalServerError)
-		return nil, true
+	if err = p.Refresh(ctx); err != nil {
+		return nil,
+			"Unexpected error refreshing authentication provider. This may be due to an incorrect issuer URL. Check the logs for more details.",
+			errors.Wrapf(err, "refreshing authentication provider with ID %q", p.ConfigID())
 	}
-	return p, false
+	return p, "", nil
 }
 
 func Init() {
@@ -93,8 +98,7 @@ func getProviders() []providers.Provider {
 	}
 	ps := make([]providers.Provider, 0, len(cfgs))
 	for _, cfg := range cfgs {
-		p := &provider{config: *cfg}
-		ps = append(ps, p)
+		ps = append(ps, NewProvider(*cfg, authPrefix))
 	}
 	return ps
 }

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/config.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/config.go
@@ -25,12 +25,16 @@ func getProvider(id string) *Provider {
 	if mockGetProviderValue != nil {
 		return mockGetProviderValue
 	}
-	return providers.GetProviderByConfigID(
+	p, ok := providers.GetProviderByConfigID(
 		providers.ConfigID{
 			Type: providerType,
 			ID:   id,
 		},
 	).(*Provider)
+	if ok {
+		return p
+	}
+	return nil
 }
 
 // GetProviderAndRefresh retrieves the authentication provider with the given

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/config.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/config.go
@@ -25,17 +25,16 @@ func getProvider(id string) *Provider {
 	if mockGetProviderValue != nil {
 		return mockGetProviderValue
 	}
-	p, _ := providers.GetProviderByConfigID(
+	return providers.GetProviderByConfigID(
 		providers.ConfigID{
 			Type: providerType,
 			ID:   id,
 		},
 	).(*Provider)
-	return p
 }
 
 // GetProviderAndRefresh retrieves the authentication provider with the given
-// type and ID, and refreshes the provider.
+// type and ID, and refreshes the token used by the provider.
 func GetProviderAndRefresh(ctx context.Context, id string, getProvider func(id string) *Provider) (p *Provider, safeErrMsg string, err error) {
 	p = getProvider(id)
 	if p == nil {

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/go-oidc"
 	"github.com/gorilla/csrf"
 	"github.com/inconshreveable/log15"
 	"golang.org/x/oauth2"
@@ -18,8 +19,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/session"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-
-	"github.com/coreos/go-oidc"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 const stateCookieName = "sg-oidc-state"
@@ -94,11 +95,13 @@ func handleOpenIDConnectAuth(db database.DB, w http.ResponseWriter, r *http.Requ
 	// anything else anyway; there's no point in showing them a signin screen with just a single
 	// signin option.
 	if ps := providers.Providers(); len(ps) == 1 && ps[0].Config().Openidconnect != nil && !isAPIRequest {
-		p, handled := handleGetProvider(r.Context(), w, ps[0].ConfigID().ID)
-		if handled {
+		p, safeErrMsg, err := GetProviderAndRefresh(r.Context(), ps[0].ConfigID().ID, getProvider)
+		if err != nil {
+			log15.Error("Failed to get provider", "error", err)
+			http.Error(w, safeErrMsg, http.StatusInternalServerError)
 			return
 		}
-		redirectToAuthRequest(w, r, p, auth.SafeRedirectURL(r.URL.String()))
+		RedirectToAuthRequest(w, r, p, stateCookieName, auth.SafeRedirectURL(r.URL.String()))
 		return
 	}
 
@@ -115,128 +118,21 @@ var mockVerifyIDToken func(rawIDToken string) *oidc.IDToken
 func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch strings.TrimPrefix(r.URL.Path, authPrefix) {
-		case "/login":
-			// Endpoint that starts the Authentication Request Code Flow.
-			p, handled := handleGetProvider(r.Context(), w, r.URL.Query().Get("pc"))
-			if handled {
-				return
-			}
-			redirectToAuthRequest(w, r, p, r.URL.Query().Get("redirect"))
-			return
-
-		case "/callback":
-			// Endpoint for the OIDC Authorization Response. See http://openid.net/specs/openid-connect-core-1_0.html#AuthResponse.
-			ctx := r.Context()
-			if authError := r.URL.Query().Get("error"); authError != "" {
-				errorDesc := r.URL.Query().Get("error_description")
-				log15.Error("OpenID Connect auth provider returned error to callback.", "error", authError, "description", errorDesc)
-				http.Error(w, fmt.Sprintf("Authentication failed. Try signing in again (and clearing cookies for the current site). The authentication provider reported the following problems.\n\n%s\n\n%s", authError, errorDesc), http.StatusUnauthorized)
-				return
-			}
-
-			// Validate state parameter to prevent CSRF attacks
-			stateParam := r.URL.Query().Get("state")
-			if stateParam == "" {
-				http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site). No OpenID Connect state query parameter specified.", http.StatusBadRequest)
-				return
-			}
-			stateCookie, err := r.Cookie(stateCookieName)
-			if err == http.ErrNoCookie {
-				log15.Error("OpenID Connect auth failed: no state cookie found (possible request forgery).")
-				http.Error(w, fmt.Sprintf("Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: no OpenID Connect state cookie found (possible request forgery, or more than %s elapsed since you started the authentication process).", stateCookieTimeout), http.StatusBadRequest)
-				return
-			} else if err != nil {
-				log15.Error("OpenID Connect auth failed: could not read state cookie (possible request forgery).", "error", err)
-				http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: invalid OpenID Connect state cookie.", http.StatusInternalServerError)
-				return
-			}
-			if stateCookie.Value != stateParam {
-				log15.Error("OpenID Connect auth failed: state cookie mismatch (possible request forgery).")
-				http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: OpenID Connect state parameter did not match the expected value (possible request forgery).", http.StatusBadRequest)
-				return
-			}
-
-			// Decode state param value
-			var state authnState
-			if err := state.Decode(stateParam); err != nil {
-				log15.Error("OpenID Connect auth failed: state parameter was malformed.", "error", err)
-				http.Error(w, "Authentication failed. OpenID Connect state parameter was malformed.", http.StatusBadRequest)
-				return
-			}
-			// 🚨 SECURITY: TODO(sqs): Do we need to check state.CSRFToken?
-
-			p, handled := handleGetProvider(r.Context(), w, state.ProviderID)
-			if handled {
-				return
-			}
-			verifier := p.oidc.Verifier(&oidc.Config{ClientID: p.config.ClientID})
-
-			// Exchange the code for an access token. See http://openid.net/specs/openid-connect-core-1_0.html#TokenRequest.
-			oauth2Token, err := p.oauth2Config().Exchange(ctx, r.URL.Query().Get("code"))
+		case "/login": // Endpoint that starts the Authentication Request Code Flow.
+			p, safeErrMsg, err := GetProviderAndRefresh(r.Context(), r.URL.Query().Get("pc"), getProvider)
 			if err != nil {
-				log15.Error("OpenID Connect auth failed: failed to obtain access token from OP.", "error", err)
-				http.Error(w, "Authentication failed. Try signing in again. The error was: unable to obtain access token from issuer.", http.StatusUnauthorized)
-				return
-			}
-
-			// Extract the ID Token from the Access Token. See http://openid.net/specs/openid-connect-core-1_0.html#TokenResponse.
-			rawIDToken, ok := oauth2Token.Extra("id_token").(string)
-			if !ok {
-				log15.Error("OpenID Connect auth failed: the issuer's authorization response did not contain an ID token.")
-				http.Error(w, "Authentication failed. Try signing in again. The error was: the issuer's authorization response did not contain an ID token.", http.StatusUnauthorized)
-				return
-			}
-
-			// Parse and verify ID Token payload. See http://openid.net/specs/openid-connect-core-1_0.html#TokenResponseValidation.
-			var idToken *oidc.IDToken
-			if mockVerifyIDToken != nil {
-				idToken = mockVerifyIDToken(rawIDToken)
-			} else {
-				idToken, err = verifier.Verify(ctx, rawIDToken)
-				if err != nil {
-					log15.Error("OpenID Connect auth failed: the ID token verification failed.", "error", err)
-					http.Error(w, "Authentication failed. Try signing in again. The error was: OpenID Connect ID token could not be verified.", http.StatusUnauthorized)
-					return
-				}
-			}
-
-			// Validate the nonce. The Verify method explicitly doesn't handle nonce validation, so we do that here.
-			// We set the nonce to be the same as the state in the Authentication Request state, so we check for equality
-			// here.
-			if idToken.Nonce != stateParam {
-				log15.Error("OpenID Connect auth failed: nonce is incorrect (possible replay attach).")
-				http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: OpenID Connect nonce is incorrect (possible replay attack).", http.StatusUnauthorized)
-				return
-			}
-
-			userInfo, err := p.oidc.UserInfo(ctx, oauth2.StaticTokenSource(oauth2Token))
-			if err != nil {
-				log15.Error("Failed to get userinfo", "error", err)
-				http.Error(w, "Failed to get userinfo: "+err.Error(), http.StatusInternalServerError)
-				return
-			}
-
-			if p.config.RequireEmailDomain != "" && !strings.HasSuffix(userInfo.Email, "@"+p.config.RequireEmailDomain) {
-				log15.Error("OpenID Connect auth failed: user's email is not from allowed domain.", "userEmail", userInfo.Email, "requireEmailDomain", p.config.RequireEmailDomain)
-				http.Error(w, fmt.Sprintf("Authentication failed. Only users in %q are allowed.", p.config.RequireEmailDomain), http.StatusUnauthorized)
-				return
-			}
-
-			var claims userClaims
-			if err := userInfo.Claims(&claims); err != nil {
-				log15.Warn("OpenID Connect auth: could not parse userInfo claims.", "error", err)
-			}
-			actr, safeErrMsg, err := getOrCreateUser(ctx, db, p, idToken, userInfo, &claims)
-			if err != nil {
-				log15.Error("OpenID Connect auth failed: error looking up OpenID-authenticated user.", "error", err, "userErr", safeErrMsg)
+				log15.Error("Failed to get provider.", "error", err)
 				http.Error(w, safeErrMsg, http.StatusInternalServerError)
 				return
 			}
+			RedirectToAuthRequest(w, r, p, stateCookieName, r.URL.Query().Get("redirect"))
+			return
 
-			user, err := db.Users().GetByID(r.Context(), actr.UID)
+		case "/callback": // Endpoint for the OIDC Authorization Response, see http://openid.net/specs/openid-connect-core-1_0.html#AuthResponse.
+			result, safeErrMsg, errStatus, err := AuthCallback(db, r, stateCookieName, "", getProvider)
 			if err != nil {
-				log15.Error("OpenID Connect auth failed: error retrieving user from database.", "error", err)
-				http.Error(w, "Failed to retrieve user: "+err.Error(), http.StatusInternalServerError)
+				log15.Error("Failed to authenticate with OpenID connect.", "error", err)
+				http.Error(w, safeErrMsg, errStatus)
 				return
 			}
 
@@ -251,25 +147,20 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 			// if !idToken.Expiry.IsZero() {
 			// 	exp = time.Until(idToken.Expiry)
 			// }
-			if err := session.SetActor(w, r, actr, exp, user.CreatedAt); err != nil {
-				log15.Error("OpenID Connect auth failed: could not initiate session.", "error", err)
+			if err = session.SetActor(w, r, actor.FromUser(result.User.ID), exp, result.User.CreatedAt); err != nil {
+				log15.Error("Failed to authenticate with OpenID connect: could not initiate session.", "error", err)
 				http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: could not initiate session.", http.StatusInternalServerError)
 				return
 			}
 
-			data := sessionData{
-				ID:          p.ConfigID(),
-				AccessToken: oauth2Token.AccessToken,
-				TokenType:   oauth2Token.TokenType,
-			}
-			if err := session.SetData(w, r, sessionKey, data); err != nil {
-				// It's not fatal if this fails. It just means we won't be able to sign the user out of
-				// the OP.
+			if err = session.SetData(w, r, SessionKey, result.SessionData); err != nil {
+				// It's not fatal if this fails. It just means we won't be able to sign the user
+				// out of the OP.
 				log15.Warn("Failed to set OpenID Connect session data. The session is still secure, but Sourcegraph will be unable to revoke the user's token or redirect the user to the end-session endpoint after the user signs out of Sourcegraph.", "error", err)
 			}
 
-			// 🚨 SECURITY: Call auth.SafeRedirectURL to avoid an open-redirect vuln.
-			http.Redirect(w, r, auth.SafeRedirectURL(state.Redirect), http.StatusFound)
+			// 🚨 SECURITY: Call auth.SafeRedirectURL to avoid the open-redirect vulnerability.
+			http.Redirect(w, r, auth.SafeRedirectURL(result.Redirect), http.StatusFound)
 
 		default:
 			http.Error(w, "", http.StatusNotFound)
@@ -277,7 +168,163 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// authnState is the state parameter passed to the Authn request and returned in the Authn response callback.
+// AuthCallbackResult is the result of handling the authentication callback.
+type AuthCallbackResult struct {
+	User        *types.User // The user that is upserted and authenticated.
+	SessionData SessionData // The corresponding session data to be set for the authenticated user.
+	Redirect    string      // The redirect URL for the authenticated user.
+}
+
+// AuthCallback handles the callback in the authentication flow which validates
+// state and upserts the user and returns the result.
+//
+// In case of an error, it returns the internal error, an error message that is
+// safe to be passed back to the user, and a proper HTTP status code
+// corresponding to the error.
+func AuthCallback(db database.DB, r *http.Request, stateCookieName, usernamePrefix string, getProvider func(id string) *Provider) (result *AuthCallbackResult, safeErrMsg string, errStatus int, err error) {
+	if authError := r.URL.Query().Get("error"); authError != "" {
+		errorDesc := r.URL.Query().Get("error_description")
+		return nil,
+			fmt.Sprintf("Authentication failed. Try signing in again (and clearing cookies for the current site). The authentication provider reported the following problems.\n\n%s\n\n%s", authError, errorDesc),
+			http.StatusUnauthorized,
+			errors.Errorf("%s - %s", authError, errorDesc)
+	}
+
+	// Validate state parameter to prevent CSRF attacks
+	stateParam := r.URL.Query().Get("state")
+	if stateParam == "" {
+		desc := "Authentication failed. Try signing in again (and clearing cookies for the current site). No OpenID Connect state query parameter specified."
+		return nil,
+			desc,
+			http.StatusBadRequest,
+			errors.New(desc)
+	}
+
+	stateCookie, err := r.Cookie(stateCookieName)
+	if err == http.ErrNoCookie {
+		return nil,
+			fmt.Sprintf("Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: no state cookie found (possible request forgery, or more than %s elapsed since you started the authentication process).", stateCookieTimeout),
+			http.StatusBadRequest,
+			errors.New("no state cookie found (possible request forgery).")
+	} else if err != nil {
+		return nil,
+			"Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: invalid state cookie.",
+			http.StatusInternalServerError,
+			errors.Wrap(err, "could not read state cookie (possible request forgery)")
+	}
+	if stateCookie.Value != stateParam {
+		return nil,
+			"Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: state parameter did not match the expected value (possible request forgery).",
+			http.StatusBadRequest,
+			errors.New("state cookie mismatch (possible request forgery)")
+	}
+
+	// Decode state param value
+	var state authnState
+	if err = state.Decode(stateParam); err != nil {
+		return nil,
+			"Authentication failed. OpenID Connect state parameter was malformed.",
+			http.StatusBadRequest,
+			errors.Wrap(err, "state parameter was malformed")
+	}
+
+	p, safeErrMsg, err := GetProviderAndRefresh(r.Context(), state.ProviderID, getProvider)
+	if err != nil {
+		return nil,
+			safeErrMsg,
+			http.StatusInternalServerError,
+			errors.Wrap(err, "get provider")
+	}
+
+	// Exchange the code for an access token, see http://openid.net/specs/openid-connect-core-1_0.html#TokenRequest.
+	oauth2Token, err := p.oauth2Config().Exchange(r.Context(), r.URL.Query().Get("code"))
+	if err != nil {
+		return nil,
+			"Authentication failed. Try signing in again. The error was: unable to obtain access token from issuer.",
+			http.StatusUnauthorized,
+			errors.Wrap(err, "obtain access token from OP")
+	}
+
+	// Extract the ID Token from the Access Token, see http://openid.net/specs/openid-connect-core-1_0.html#TokenResponse.
+	rawIDToken, ok := oauth2Token.Extra("id_token").(string)
+	if !ok {
+		return nil,
+			"Authentication failed. Try signing in again. The error was: the issuer's authorization response did not contain an ID token.",
+			http.StatusUnauthorized,
+			errors.New("the issuer's authorization response did not contain an ID token")
+	}
+
+	// Parse and verify ID Token payload, see http://openid.net/specs/openid-connect-core-1_0.html#TokenResponseValidation.
+	var idToken *oidc.IDToken
+	if mockVerifyIDToken != nil {
+		idToken = mockVerifyIDToken(rawIDToken)
+	} else {
+		idToken, err = p.oidcVerifier().Verify(r.Context(), rawIDToken)
+		if err != nil {
+			return nil,
+				"Authentication failed. Try signing in again. The error was: OpenID Connect ID token could not be verified.",
+				http.StatusUnauthorized,
+				errors.Wrap(err, "verify ID token")
+		}
+	}
+
+	// Validate the nonce. The Verify method explicitly doesn't handle nonce
+	// validation, so we do that here. We set the nonce to be the same as the state
+	// in the Authentication Request state, so we check for equality here.
+	if idToken.Nonce != stateParam {
+		return nil,
+			"Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: OpenID Connect nonce is incorrect (possible replay attack).",
+			http.StatusUnauthorized,
+			errors.New("nonce is incorrect (possible replay attach)")
+	}
+
+	userInfo, err := p.oidcUserInfo(r.Context(), oauth2.StaticTokenSource(oauth2Token))
+	if err != nil {
+		return nil,
+			"Failed to get userinfo: " + err.Error(),
+			http.StatusInternalServerError,
+			errors.Wrap(err, "get user info")
+	}
+
+	if p.config.RequireEmailDomain != "" && !strings.HasSuffix(userInfo.Email, "@"+p.config.RequireEmailDomain) {
+		return nil,
+			fmt.Sprintf("Authentication failed. Only users in %q are allowed.", p.config.RequireEmailDomain),
+			http.StatusUnauthorized,
+			errors.Errorf("user's email %q is not from allowed domain %q", userInfo.Email, p.config.RequireEmailDomain)
+	}
+
+	var claims userClaims
+	if err = userInfo.Claims(&claims); err != nil {
+		log15.Warn("OpenID Connect auth: could not parse userInfo claims.", "error", err)
+	}
+	actor, safeErrMsg, err := getOrCreateUser(r.Context(), db, p, idToken, userInfo, &claims, usernamePrefix)
+	if err != nil {
+		return nil,
+			safeErrMsg,
+			http.StatusInternalServerError,
+			errors.Wrap(err, "look up authenticated user")
+	}
+
+	user, err := db.Users().GetByID(r.Context(), actor.UID)
+	if err != nil {
+		return nil,
+			"Failed to retrieve user from database",
+			http.StatusInternalServerError,
+			errors.Wrap(err, "get user by ID")
+	}
+	return &AuthCallbackResult{
+		User: user,
+		SessionData: SessionData{
+			ID:          p.ConfigID(),
+			AccessToken: oauth2Token.AccessToken,
+			TokenType:   oauth2Token.TokenType,
+		},
+		Redirect: state.Redirect,
+	}, "", 0, nil
+}
+
+// authnState is the state parameter passed to the authentication request and
+// returned to the authentication response callback.
 type authnState struct {
 	CSRFToken string `json:"csrfToken"`
 	Redirect  string `json:"redirect"`
@@ -292,7 +339,8 @@ func (s *authnState) Encode() string {
 	return base64.StdEncoding.EncodeToString(b)
 }
 
-// Decode decodes the base64-encoded JSON representation of the authn state into the receiver.
+// Decode decodes the base64-encoded JSON representation of the authn state into
+// the receiver.
 func (s *authnState) Decode(encoded string) error {
 	b, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
@@ -301,32 +349,43 @@ func (s *authnState) Decode(encoded string) error {
 	return json.Unmarshal(b, s)
 }
 
+// stateCookieTimeout defines how long the state cookie should be valid for a
+// single authentication flow.
 const stateCookieTimeout = time.Minute * 15
 
-func redirectToAuthRequest(w http.ResponseWriter, r *http.Request, p *provider, returnToURL string) {
-	// The state parameter is an opaque value used to maintain state between the original Authentication Request
-	// and the callback. We do not record any state beyond a CSRF token used to defend against CSRF attacks against the callback.
-	// We use the CSRF token created by gorilla/csrf that is used for other app endpoints as the OIDC state parameter.
+// RedirectToAuthRequest redirects the user to the authentication endpoint on the
+// external authentication provider.
+func RedirectToAuthRequest(w http.ResponseWriter, r *http.Request, p *Provider, cookieName, returnToURL string) {
+	// The state parameter is an opaque value used to maintain state between the
+	// original Authentication Request and the callback. We do not record any state
+	// beyond a CSRF token used to defend against CSRF attacks against the callback.
+	// We use the CSRF token created by gorilla/csrf that is used for other app
+	// endpoints as the OIDC state parameter.
 	//
-	// See http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest of the OIDC spec.
+	// See http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest of the
+	// OIDC spec.
 	state := (&authnState{
 		CSRFToken:  csrf.Token(r),
 		Redirect:   returnToURL,
 		ProviderID: p.ConfigID().ID,
 	}).Encode()
-	http.SetCookie(w, &http.Cookie{
-		Name:    stateCookieName,
-		Value:   state,
-		Path:    auth.AuthURLPrefix + "/", // include the OIDC redirect URI (/.auth/callback not /.auth/openidconnect/callback for BACKCOMPAT)
-		Expires: time.Now().Add(stateCookieTimeout),
-	})
+	http.SetCookie(w,
+		&http.Cookie{
+			Name:    cookieName,
+			Value:   state,
+			Path:    auth.AuthURLPrefix + "/", // Include the OIDC redirect URI (/.auth/callback not /.auth/openidconnect/callback for backwards compatibility)
+			Expires: time.Now().Add(stateCookieTimeout),
+		},
+	)
 
-	// Redirect to the OP's Authorization Endpoint for authentication. The nonce is an optional
-	// string value used to associate a Client session with an ID Token and to mitigate replay attacks.
-	// Whereas the state parameter is used in validating the Authentication Request
-	// callback, the nonce is used in validating the response to the ID Token request.
-	// We re-use the Authn request state as the nonce.
+	// Redirect to the OP's Authorization Endpoint for authentication. The nonce is
+	// an optional string value used to associate a Client session with an ID Token
+	// and to mitigate replay attacks. Whereas the state parameter is used in
+	// validating the Authentication Request callback, the nonce is used in
+	// validating the response to the ID Token request. We re-use the Authn request
+	// state as the nonce.
 	//
-	// See http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest of the OIDC spec.
+	// See http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest of the
+	// OIDC spec.
 	http.Redirect(w, r, p.oauth2Config().AuthCodeURL(state, oidc.Nonce(state)), http.StatusFound)
 }

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/middleware_test.go
@@ -119,7 +119,7 @@ func TestMiddleware(t *testing.T) {
 	defer cleanup()
 	defer licensing.TestingSkipFeatureChecks()()
 
-	mockGetProviderValue = &provider{
+	mockGetProviderValue = &Provider{
 		config: schema.OpenIDConnectAuthProvider{
 			ClientID:           testClientID,
 			ClientSecret:       "aaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -298,7 +298,7 @@ func TestMiddleware_NoOpenRedirect(t *testing.T) {
 
 	defer licensing.TestingSkipFeatureChecks()()
 
-	mockGetProviderValue = &provider{
+	mockGetProviderValue = &Provider{
 		config: schema.OpenIDConnectAuthProvider{
 			ClientID:     testClientID,
 			ClientSecret: "aaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/provider.go
@@ -21,16 +21,28 @@ import (
 
 const providerType = "openidconnect"
 
-type provider struct {
-	config schema.OpenIDConnectAuthProvider
+// Provider is the implementation of OpenID Connect authentication provider for
+// providers.Provider.
+type Provider struct {
+	config     schema.OpenIDConnectAuthProvider
+	authPrefix string
 
 	mu         sync.Mutex
 	oidc       *oidcProvider
 	refreshErr error
 }
 
+// NewProvider creates and returns a new OpenID Connect authentication provider
+// using the given config.
+func NewProvider(config schema.OpenIDConnectAuthProvider, authPrefix string) providers.Provider {
+	return &Provider{
+		config:     config,
+		authPrefix: authPrefix,
+	}
+}
+
 // ConfigID implements providers.Provider.
-func (p *provider) ConfigID() providers.ConfigID {
+func (p *Provider) ConfigID() providers.ConfigID {
 	return providers.ConfigID{
 		Type: providerType,
 		ID:   providerConfigID(&p.config),
@@ -38,25 +50,44 @@ func (p *provider) ConfigID() providers.ConfigID {
 }
 
 // Config implements providers.Provider.
-func (p *provider) Config() schema.AuthProviders {
+func (p *Provider) Config() schema.AuthProviders {
 	return schema.AuthProviders{Openidconnect: &p.config}
 }
 
 // Refresh implements providers.Provider.
-func (p *provider) Refresh(ctx context.Context) error {
+func (p *Provider) Refresh(context.Context) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.oidc, p.refreshErr = newProvider(p.config.Issuer)
+	p.oidc, p.refreshErr = newOIDCProvider(p.config.Issuer)
 	return p.refreshErr
 }
 
-func (p *provider) getCachedInfoAndError() (*providers.Info, error) {
+// oidcVerifier returns the token verifier of the underlying OIDC provider.
+func (p *Provider) oidcVerifier() *oidc.IDTokenVerifier {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.oidc.Verifier(
+		&oidc.Config{
+			ClientID: p.config.ClientID,
+		},
+	)
+}
+
+// oidcUserInfo returns the user info using the given token source from the
+// underlying OIDC provider.
+func (p *Provider) oidcUserInfo(ctx context.Context, tokenSource oauth2.TokenSource) (*oidc.UserInfo, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.oidc.UserInfo(ctx, tokenSource)
+}
+
+func (p *Provider) getCachedInfoAndError() (*providers.Info, error) {
 	info := providers.Info{
 		ServiceID:   p.config.Issuer,
 		ClientID:    p.config.ClientID,
 		DisplayName: p.config.DisplayName,
 		AuthenticationURL: (&url.URL{
-			Path:     path.Join(authPrefix, "login"),
+			Path:     path.Join(p.authPrefix, "login"),
 			RawQuery: (url.Values{"pc": []string{providerConfigID(&p.config)}}).Encode(),
 		}).String(),
 	}
@@ -76,12 +107,13 @@ func (p *provider) getCachedInfoAndError() (*providers.Info, error) {
 }
 
 // CachedInfo implements providers.Provider.
-func (p *provider) CachedInfo() *providers.Info {
+func (p *Provider) CachedInfo() *providers.Info {
 	info, _ := p.getCachedInfoAndError()
 	return info
 }
 
-func (p *provider) oauth2Config() *oauth2.Config {
+// oauth2Config constructs and returns an *oauth2.Config from the provider.
+func (p *Provider) oauth2Config() *oauth2.Config {
 	return &oauth2.Config{
 		ClientID:     p.config.ClientID,
 		ClientSecret: p.config.ClientSecret,
@@ -120,7 +152,7 @@ type providerExtraClaims struct {
 
 var mockNewProvider func(issuerURL string) (*oidcProvider, error)
 
-func newProvider(issuerURL string) (*oidcProvider, error) {
+func newOIDCProvider(issuerURL string) (*oidcProvider, error) {
 	if mockNewProvider != nil {
 		return mockNewProvider(issuerURL)
 	}
@@ -138,7 +170,7 @@ func newProvider(issuerURL string) (*oidcProvider, error) {
 }
 
 // revokeToken implements Token Revocation. See https://tools.ietf.org/html/rfc7009.
-func revokeToken(ctx context.Context, p *provider, accessToken, tokenType string) error {
+func revokeToken(ctx context.Context, p *Provider, accessToken, tokenType string) error {
 	postData := url.Values{}
 	postData.Set("token", accessToken)
 	if tokenType != "" {

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/provider.go
@@ -21,8 +21,7 @@ import (
 
 const providerType = "openidconnect"
 
-// Provider is the implementation of OpenID Connect authentication provider for
-// providers.Provider.
+// Provider is an implementation of providers.Provider for an OpenID Connect authentication.
 type Provider struct {
 	config     schema.OpenIDConnectAuthProvider
 	authPrefix string

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/provider.go
@@ -21,7 +21,8 @@ import (
 
 const providerType = "openidconnect"
 
-// Provider is an implementation of providers.Provider for an OpenID Connect authentication.
+// Provider is an implementation of providers.Provider for the OpenID Connect
+// authentication.
 type Provider struct {
 	config     schema.OpenIDConnectAuthProvider
 	authPrefix string

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/session.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/session.go
@@ -8,9 +8,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-const sessionKey = "oidc@0"
+// SessionKey is the key of the key-value pair in a user session for the OpenID
+// Connect authentication provider.
+const SessionKey = "oidc@0"
 
-type sessionData struct {
+// SessionData is the data format to be stored in a user session.
+type SessionData struct {
 	ID providers.ConfigID
 
 	// Store only the oauth2.Token fields we need, to avoid hitting the ~4096-byte session data
@@ -22,14 +25,14 @@ type sessionData struct {
 // SignOut clears OpenID Connect-related data from the session. If possible, it revokes the token
 // from the OP. If there is an end-session endpoint, it returns that for the caller to present to
 // the user.
-func SignOut(w http.ResponseWriter, r *http.Request) (endSessionEndpoint string, err error) {
+func SignOut(w http.ResponseWriter, r *http.Request, sessionKey string) (endSessionEndpoint string, err error) {
 	defer func() {
 		if err != nil {
 			_ = session.SetData(w, r, sessionKey, nil) // clear the bad data
 		}
 	}()
 
-	var data *sessionData
+	var data *SessionData
 	if err := session.GetData(r, sessionKey, &data); err != nil {
 		return "", errors.WithMessage(err, "reading OpenID Connect session data")
 	}


### PR DESCRIPTION
This PR does the required refactoring to our OpenID Connect authentication provider implementation to be able to be wrapped by the upcoming SOAP (see [RFC 750](https://docs.google.com/document/d/1Ia9sjW_KQ6BeJ28xJl3VvLIy7M9Ko7A1sBnTXkZ3W9o/edit#heading=h.trqab8y0kufp)), a OpenID Connect-based authentication provider only available for Sourcergaph Cloud.

Please see inline comments for important notes. Make sure you expand every single file!

## Test plan

Manually tested with the "Okta test instance admin" in 1Password and the "OpenID Connect (sourcegraph.test:3443)" application.

---

Part of https://github.com/sourcegraph/customer/issues/1423