### PR TITLE
search: remove searcher's IndexerEndpoints

### DIFF
--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -45,12 +45,6 @@ type Request struct {
 	// the fetch will still happen in the background so future requests don't have to wait.
 	FetchTimeout string
 
-	// Endpoint(s) for reaching Zoekt. See description in
-	// endpoint.go:Static(...)
-	//
-	// Deprecated: no longer read, searcher uses ServiceConnections now.
-	IndexerEndpoints []string
-
 	// Whether the revision to be searched is indexed or unindexed. This matters for
 	// structural search because it will query Zoekt for indexed structural search.
 	Indexed bool

--- a/internal/search/job/jobutil/filter_file_contains.go
+++ b/internal/search/job/jobutil/filter_file_contains.go
@@ -195,7 +195,6 @@ func (j *fileContainsFilterJob) filterCommitMatch(ctx context.Context, searcherU
 			false,
 			&patternInfo,
 			time.Hour,
-			nil,
 			search.Features{},
 			onMatch,
 		)

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -709,7 +709,6 @@ func (r *Resolver) repoHasFileContentAtCommit(ctx context.Context, repo types.Mi
 		false, // not using zoekt, don't need indexing
 		&patternInfo,
 		time.Hour,         // depend on context for timeout
-		nil,               // not using zoekt, don't need indexing
 		search.Features{}, // not using any search features
 		onMatches,
 	)

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -40,7 +40,6 @@ func Search(
 	indexed bool,
 	p *search.TextPatternInfo,
 	fetchTimeout time.Duration,
-	indexerEndpoints []string,
 	features search.Features,
 	onMatches func([]*protocol.FileMatch),
 ) (limitHit bool, err error) {
@@ -77,10 +76,9 @@ func Search(
 			PatternMatchesContent:        p.PatternMatchesContent,
 			PatternMatchesPath:           p.PatternMatchesPath,
 		},
-		Indexed:          indexed,
-		FetchTimeout:     fetchTimeout.String(),
-		IndexerEndpoints: indexerEndpoints,
-		FeatHybrid:       features.HybridSearch, // TODO(keegan) HACK because I didn't want to change the signatures to so many function calls.
+		Indexed:      indexed,
+		FetchTimeout: fetchTimeout.String(),
+		FeatHybrid:   features.HybridSearch, // TODO(keegan) HACK because I didn't want to change the signatures to so many function calls.
 	}
 
 	body, err := json.Marshal(r)

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -193,22 +193,13 @@ func (s *TextSearchJob) searchFilesInRepo(
 		return false, err
 	}
 
-	// Structural and hybrid search both speak to zoekt so need the endpoints.
-	var indexerEndpoints []string
-	if info.IsStructuralPat || s.Features.HybridSearch {
-		indexerEndpoints, err = search.Indexers().Map.Endpoints()
-		if err != nil {
-			return false, err
-		}
-	}
-
 	onMatches := func(searcherMatches []*protocol.FileMatch) {
 		stream.Send(streaming.SearchEvent{
 			Results: convertMatches(repo, commit, &rev, searcherMatches, s.PathRegexps),
 		})
 	}
 
-	return Search(ctx, searcherURLs, gitserverRepo, repo.ID, rev, commit, index, info, fetchTimeout, indexerEndpoints, s.Features, onMatches)
+	return Search(ctx, searcherURLs, gitserverRepo, repo.ID, rev, commit, index, info, fetchTimeout, s.Features, onMatches)
 }
 
 // convert converts a set of searcher matches into []result.Match


### PR DESCRIPTION
This field is no longer read, so we can remove it from the codebase.

Test Plan: go test ./internal/search/... ./cmd/searcher/...