### PR TITLE
Reroute to current page after clicking on "Sign in"

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -322,7 +322,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                                 <div>
                                     <Button
                                         className="mr-1"
-                                        to={'/sign-in?returnTo=' + window.location.pathname + window.location.search}
+                                        to={'/sign-in?returnTo=' + history.location.pathname + history.location.search}
                                         variant="secondary"
                                         outline={true}
                                         size="sm"

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -322,7 +322,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                                 <div>
                                     <Button
                                         className="mr-1"
-                                        to="/sign-in"
+                                        to={'/sign-in?returnTo=' + window.location.pathname + window.location.search}
                                         variant="secondary"
                                         outline={true}
                                         size="sm"

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -322,7 +322,10 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                                 <div>
                                     <Button
                                         className="mr-1"
-                                        to={'/sign-in?returnTo=' + history.location.pathname + history.location.search}
+                                        to={
+                                            '/sign-in?returnTo=' +
+                                            encodeURI(history.location.pathname + history.location.search)
+                                        }
                                         variant="secondary"
                                         outline={true}
                                         size="sm"

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -204,7 +204,7 @@ exports[`GlobalNavbar default 1`] = `
         <div>
           <a
             class="anchorLink btn btnSecondary btnOutline btnSm mr-1"
-            href="/sign-in"
+            href="/sign-in?returnTo=/"
           >
             Sign in
           </a>


### PR DESCRIPTION
Adds the current location's pathname and search string to the Sign in button's `returnTo` property, allowing you to click on Sign in and not lose the page you were on.

## Test plan

Tests still pass 🤞 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-pjlast-fix-reroute-after-login.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
