### PR TITLE
Fix a bug where we were showing wrong actions in the bulk actions dropdown

### DIFF
--- a/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/Table.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/Table.tsx
@@ -326,7 +326,7 @@ export function Table<T>({
             </table>
             {selectable && (
                 <div className="mt-4 d-flex justify-content-between align-items-center">
-                    <SelectionActions<T> actions={actions} position="bottom" selection={selection} />
+                    <SelectionActions<T> actions={bulkActions} position="bottom" selection={selection} />
                     {note}
                 </div>
             )}


### PR DESCRIPTION
This was only happening for the dropdown that is below the list of users, the one on the top was showing the correct list.

fixes #43411 

# Screenshot
<img width="916" alt="Screenshot 2022-10-27 at 13 24 21" src="https://user-images.githubusercontent.com/9974711/198271943-98c98743-cc10-40b7-9283-c573f7d76387.png">


## Test plan

Tested locally, everything works.

## App preview:

- [Web](https://sg-web-milan-fix-bulk-actions-dropdown.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
