### PR TITLE
Revert "ranking: send repo rank to zoekt"

### DIFF
--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"strconv"
 	"time"
 
@@ -22,7 +21,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -177,30 +175,7 @@ func (h *searchIndexerServer) serveConfiguration(w http.ResponseWriter, r *http.
 			return string(commitID), err
 		}
 
-		var priority float64
-
-		// We have to enable experimental ranking either for all or none of the repos.
-		// We cannot mix star-based priorities [0, inf] with ranks [0, 1], because in
-		// Zoekt, shards are sorted and searched based on their priority, and the rank
-		// and star-count are in principle not comparable.
-		if rankingEnabled, _ := strconv.ParseBool(os.Getenv("ENABLE_EXPERIMENTAL_RANKING")); rankingEnabled {
-			rankVec, err := h.codeIntelServices.RankingService.GetRepoRank(ctx, repo.Name)
-			if err != nil {
-				return nil, errors.Wrapf(err, "serveConfiguration: error getting repo rank")
-			}
-			// Hack: we take the first non-zero rank as priority. This is fine for now
-			// because, unlike documents, repos don't have categorical ranks like
-			// "generated" or "test" (yet). In the future we can persist the full ranking
-			// vector in the Zoekt shard.
-			for _, r := range rankVec {
-				if r > 0 {
-					priority = r
-					break
-				}
-			}
-		} else {
-			priority = float64(repo.Stars) + repoRankFromConfig(siteConfig, string(repo.Name))
-		}
+		priority := float64(repo.Stars) + repoRankFromConfig(siteConfig, string(repo.Name))
 
 		return &searchbackend.RepoIndexOptions{
 			Name:       string(repo.Name),


### PR DESCRIPTION
This reverts commit 5c56a7d8274eac61c36ebdca3a5ffde777781dfb.

This piece of code is too distributive to enable it on a large, live instance. Let's remove it and keep searching in order of decending star count for now.



## Test plan
The code path we remove here wasn't yet active.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
