### PR TITLE
Fix TestEnqueueWebhookBuildJob by not running in parallel with other

### DIFF
--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -2018,7 +2018,6 @@ func setupSyncErroredTest(ctx context.Context, s repos.Store, t *testing.T,
 }
 
 func TestEnqueueWebhookBuildJob(t *testing.T) {
-	t.Parallel()
 	store := getTestRepoStore(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
See failure here: https://buildkite.com/sourcegraph/sourcegraph/builds/180025#018418fb-0d93-49a2-adf9-a7d62667f290

I suspect this test became flaky with #42973. Before that PR the test was _not_ run in parallel with the other tests in `TestIngegration`.

But since they were then pulled out, all the tests that ran sequentially are now being run together, concurrently.

This one here modifies a global mock, `conf.Mock`, so it's unsafe it in parallel with other tests.

## Test plan

- Ran tests locally
