### PR TITLE
[release] remove step to update SelfHostedInstructions.tsx

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -496,8 +496,6 @@ cc @${config.captainGitHubUsername}
                             `find ./doc/admin/deploy/ -type f -name '*.md' -exec ${sed} -i -E 's/--version ${versionRegex}/--version ${release.version}/g' {} +`,
                             // Update fork variables in installation guides
                             `find ./doc/admin/deploy/ -type f -name '*.md' -exec ${sed} -i -E "s/DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v${versionRegex}'/DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v${release.version}'/g" {} +`,
-                            // Update sourcegraph.com frontpage
-                            `${sed} -i -E 's/sourcegraph\\/server:${versionRegex}/sourcegraph\\/server:${release.version}/g' 'client/web/src/search/home/SelfHostInstructions.tsx'`,
 
                             notPatchRelease
                                 ? `comby -in-place '{{$previousReleaseRevspec := ":[1]"}} {{$previousReleaseVersion := ":[2]"}} {{$currentReleaseRevspec := ":[3]"}} {{$currentReleaseVersion := ":[4]"}}' '{{$previousReleaseRevspec := ":[3]"}} {{$previousReleaseVersion := ":[4]"}} {{$currentReleaseRevspec := "v${release.version}"}} {{$currentReleaseVersion := "${release.major}.${release.minor}"}}' doc/_resources/templates/document.html`


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
#43295 deleted the `client/web/src/search/home/SelfHostInstructions.tsx` file. Updating this file to include the latest version of Sourcegraph is one of the steps required for creating a batch change during release. 
This PR removes the step to update that file since we don't make use of it anymore.

![CleanShot 2022-10-27 at 14 22 25@2x](https://user-images.githubusercontent.com/25608335/198283202-75b9a590-258a-4c03-a591-ac0c5d535c74.png)

## App preview:

- [Web](https://sg-web-bo-update-release-steps.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
