### PR TITLE
Enable prettier formatting check behind sg lint flag

### DIFF
--- a/client/jetbrains/webview/src/search/index.tsx
+++ b/client/jetbrains/webview/src/search/index.tsx
@@ -95,7 +95,10 @@ export function applyConfig(config: PluginConfig): void {
     customRequestHeaders = parseCustomRequestHeadersString(config.customRequestHeadersAsString)
     anonymousUserId = config.anonymousUserId || 'no-user-id'
     pluginVersion = config.pluginVersion
-    polyfillEventSource({ ...(accessToken ? { Authorization: `token ${accessToken}` } : {}), ...customRequestHeaders }, undefined)
+    polyfillEventSource(
+        { ...(accessToken ? { Authorization: `token ${accessToken}` } : {}), ...customRequestHeaders },
+        undefined
+    )
 }
 
 function parseCustomRequestHeadersString(headersString: string | null): Record<string, string> | null {

--- a/client/shared/src/components/ranking/PerFileResultRankingTestHelpers.ts
+++ b/client/shared/src/components/ranking/PerFileResultRankingTestHelpers.ts
@@ -487,7 +487,7 @@ export const testDataRealMatchesByZoektRanking: MatchItem[] = [
                 startLine: 24,
                 startCharacter: 8,
                 endLine: 24,
-                endCharacter: 13
+                endCharacter: 13,
             },
             {
                 startLine: 24,
@@ -750,11 +750,11 @@ export const testDataRealMatchesByZoektRanking: MatchItem[] = [
                 startCharacter: 50,
                 endLine: 60,
                 endCharacter: 55,
-            }
+            },
         ],
         content: '// Contains checks if the given error contains an error with the',
         startLine: 60,
-        endLine: 60
+        endLine: 60,
     },
     {
         highlightRanges: [
@@ -1218,7 +1218,7 @@ export const testDataRealMatchesByZoektRanking: MatchItem[] = [
         ],
         content: '// errors, you should replace it with this.',
         startLine: 42,
-        endLine: 42
+        endLine: 42,
     },
     {
         highlightRanges: [
@@ -1363,7 +1363,8 @@ export const testDataRealMultilineMatches: MatchItem[] = [
                 endCharacter: 1,
             },
         ],
-        content: '// Contains checks if the given error contains an error with the\n// message msg. If err is not a wrapped error, this will always return\n// false unless the error itself happens to match this msg.\nfunc Contains(err error, msg string) bool {\n\treturn len(GetAll(err, msg)) > 0\n}',
+        content:
+            '// Contains checks if the given error contains an error with the\n// message msg. If err is not a wrapped error, this will always return\n// false unless the error itself happens to match this msg.\nfunc Contains(err error, msg string) bool {\n\treturn len(GetAll(err, msg)) > 0\n}',
         startLine: 60,
         endLine: 65,
     },
@@ -1376,7 +1377,8 @@ export const testDataRealMultilineMatches: MatchItem[] = [
                 endCharacter: 1,
             },
         ],
-        content: '// ContainsType checks if the given error contains an error with\n// the same concrete type as v. If err is not a wrapped error, this will\n// check the err itself.\nfunc ContainsType(err error, v interface{}) bool {\n\treturn len(GetAllType(err, v)) > 0\n}',
+        content:
+            '// ContainsType checks if the given error contains an error with\n// the same concrete type as v. If err is not a wrapped error, this will\n// check the err itself.\nfunc ContainsType(err error, v interface{}) bool {\n\treturn len(GetAllType(err, v)) > 0\n}',
         startLine: 67,
         endLine: 72,
     },

--- a/client/shared/src/components/ranking/ZoektRanking.ts
+++ b/client/shared/src/components/ranking/ZoektRanking.ts
@@ -48,7 +48,7 @@ function sortHunkMatches(hunk: Hunk): void {
     })
 }
 
-function mergeHunks(hunks: Hunk[], context: number) : void {
+function mergeHunks(hunks: Hunk[], context: number): void {
     const hunksSortedByLineNumber = hunks.slice().sort((a, b) => {
         if (a.startLine < b.startLine) {
             return -1
@@ -81,8 +81,10 @@ function mergeHunks(hunks: Hunk[], context: number) : void {
 
 function isMatchWithinGroup(group: Hunk, item: MatchItem, context: number): boolean {
     // Return true if item and group have overlapping or adjacent context
-    return (item.startLine >= group.endLine && item.startLine - group.endLine - 2 * context <= 1)
-        || (item.endLine <= group.startLine && group.startLine - item.endLine - 2 * context <= 1)
+    return (
+        (item.startLine >= group.endLine && item.startLine - group.endLine - 2 * context <= 1) ||
+        (item.endLine <= group.startLine && group.startLine - item.endLine - 2 * context <= 1)
+    )
 }
 
 function results(matches: MatchItem[], maxResults: number, context: number): RankingResult {

--- a/client/web/src/search/home/TrySourcegraphCloudSection/TrySourcegraphCloudSection.module.scss
+++ b/client/web/src/search/home/TrySourcegraphCloudSection/TrySourcegraphCloudSection.module.scss
@@ -11,7 +11,7 @@
         text-decoration: none;
 
         .trial-button {
-            background: #A305E1;
+            background: #a305e1;
             color: #ffffff;
         }
     }
@@ -40,7 +40,7 @@
 }
 
 .try-cloud {
-    color: #D0BFFF;
+    color: #d0bfff;
     font-size: 1.688rem;
     line-height: 31px;
     margin-bottom: 0.125rem;
@@ -55,7 +55,7 @@
     @media (--sm-breakpoint-up) {
         height: 1.563rem;
     }
-    
+
     span {
         display: block;
         @media (--sm-breakpoint-up) {
@@ -89,12 +89,12 @@
 
 .trial-button {
     background: #ffffff;
-    color: #A305E1;
+    color: #a305e1;
     width: 100%;
     margin-bottom: 0.5rem;
     margin-left: auto;
     &:hover {
-        background: #A305E1 !important;
+        background: #a305e1 !important;
         color: #ffffff !important;
     }
 }
@@ -107,29 +107,29 @@
     }
 }
 
-@keyframes spin_words{
-    10%{
+@keyframes spin_words {
+    10% {
         transform: translateY(-112%);
     }
-    25%{
+    25% {
         transform: translateY(-100%);
     }
-    35%{
+    35% {
         transform: translateY(-212%);
     }
-    50%{
+    50% {
         transform: translateY(-200%);
     }
-    60%{
+    60% {
         transform: translateY(-312%);
     }
-    75%{
+    75% {
         transform: translateY(-300%);
     }
-    85%{
+    85% {
         transform: translateY(-412%);
     }
-    100%{
+    100% {
         transform: translateY(-400%);
     }
 }

--- a/client/web/src/search/home/TrySourcegraphCloudSection/index.tsx
+++ b/client/web/src/search/home/TrySourcegraphCloudSection/index.tsx
@@ -42,16 +42,13 @@ export const TrySourcegraphCloudSection: FunctionComponent = () => {
                     </div>
 
                     <div className={styles.buttonContainer}>
-                        <Button
-                            variant="secondary"
-                            className={styles.trialButton}
-                        >
+                        <Button variant="secondary" className={styles.trialButton}>
                             Get free trial now
                         </Button>
                     </div>
                 </div>
             </Link>
-            
+
             <Text size="small" className={styles.selfHostedCopy}>
                 Want to deploy yourself?
                 <Link

--- a/dev/scaletesting/bulkrepocreate/README.md
+++ b/dev/scaletesting/bulkrepocreate/README.md
@@ -1,4 +1,4 @@
-# Bulkrepocreate 
+# Bulkrepocreate
 
 A CLI tool to generate blank repositories (containing a single commit with a README.md) in bulk on a given GHE instance.
 
@@ -6,9 +6,9 @@ A CLI tool to generate blank repositories (containing a single commit with a REA
 
 `go run dev/scaletesting/bulkrepocreate [flags...]`
 
-Flags: 
+Flags:
 
-- Authenticating: 
+- Authenticating:
   - `github.token`: GHE Token to create the repositories (required).
   - `github.url`: Base URL to the GHE instance (ex: `https://ghe.sgdev.org`) (required).
   - `github.org`: Existing organization to create the repositories in (required).
@@ -18,7 +18,7 @@ Flags:
   - `count`: Number of repositories to create (default: `100`).
   - `prefix`: Prefix to use when naming the repos, i.e using `foobar` as prefix will create repos named `foobar0000001`, `foobar0000002`, ... (default: `repo`)
   - `retry`: Number of times to retry pushind (can be tedious at high concurrency)
-- Resuming work: 
+- Resuming work:
   - `resume`: sqlite database name to create or resume from (default `state.db`)
 
 ## FAQ
@@ -31,6 +31,6 @@ _Creating organization on the fly requires having an GHE admin account, which is
 
 _The script will run `git push` which requires to authenticate as the user pushing the repos. Pushing over HTTPS is much simpler as it means it's not required to upload your public key on the GHE user account before running this script._
 
-> Can I `ctrl-c` the script as we have a `-resume` flag? 
+> Can I `ctrl-c` the script as we have a `-resume` flag?
 
 No. The script is made to handle errors from third parties, it's not handling anything else.

--- a/dev/scaletesting/codehostcopy/README.md
+++ b/dev/scaletesting/codehostcopy/README.md
@@ -4,13 +4,13 @@ A small tool to copy all repos from a given user on GitHub to GitLab or Bitbucke
 
 State is persisted in a SQLite database to enable to resume the copy if it was interrupted.
 
-## Usage 
+## Usage
 
 ```
 codehostcopy --config my-config.cue --state my-config.db
 ```
 
-To get an example config, you can do: 
+To get an example config, you can do:
 
 ```
 codehostcopy example > my-config.cue

--- a/dev/sg/internal/check/runner.go
+++ b/dev/sg/internal/check/runner.go
@@ -48,6 +48,8 @@ type Runner[Args any] struct {
 	Concurrency int
 	// FailFast indicates if the runner should stop upon encountering the first error.
 	FailFast bool
+	// FormatCheck indicates if the runner should check for formatting errors.
+	FormatCheck bool
 	// SuggestOnCheckFailure can be implemented to prompt the user to try certain things
 	// if a check fails. The suggestion string can be in Markdown.
 	SuggestOnCheckFailure SuggestFunc[Args]
@@ -430,7 +432,7 @@ func (r *Runner[Args]) runAllCategoryChecks(ctx context.Context, args Args) *run
 					}
 
 					// Write the terminal summary to an indented block
-					var style = output.CombineStyles(output.StyleBold, output.StyleFailure)
+					style := output.CombineStyles(output.StyleBold, output.StyleFailure)
 					block := r.Output.Block(output.Linef(output.EmojiFailure, style, check.Name))
 					block.Writef("%s\n", check.cachedCheckErr)
 					if check.cachedCheckOutput != "" {

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -73,13 +73,6 @@ var Targets = []Target{
 		},
 	},
 	{
-		Name:        "clientformatting",
-		Description: "Check client code and docs for formatting errors",
-		Checks: []*linter{
-			prettier,
-		},
-	},
-	{
 		Name:        "svg",
 		Description: "Check svg assets",
 		Enabled:     disabled("reported as unreliable"),
@@ -95,6 +88,14 @@ var Targets = []Target{
 			shellCheck,
 			bashSyntax,
 		},
+	},
+}
+
+var FormattingTarget = Target{
+	Name:        "format",
+	Description: "Check client code and docs for formatting errors",
+	Checks: []*linter{
+		prettier,
 	},
 }
 

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -75,6 +75,13 @@ var Targets = []Target{
 		},
 	},
 	{
+		Name:        "clientformatting",
+		Description: "Check client code for formatting errors",
+		Checks: []*linter{
+			prettier,
+		},
+	},
+	{
 		Name:        "svg",
 		Description: "Check svg assets",
 		Enabled:     disabled("reported as unreliable"),

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -52,7 +52,6 @@ var Targets = []Target{
 		Description: "Documentation checks",
 		Checks: []*linter{
 			runScript("Docsite lint", "dev/docsite.sh check"),
-			prettier,
 		},
 	},
 	{
@@ -71,12 +70,11 @@ var Targets = []Target{
 			inlineTemplates,
 			runScript("Yarn duplicate", "dev/check/yarn-deduplicate.sh"),
 			checkUnversionedDocsLinks(),
-			prettier,
 		},
 	},
 	{
 		Name:        "clientformatting",
-		Description: "Check client code for formatting errors",
+		Description: "Check client code and docs for formatting errors",
 		Checks: []*linter{
 			prettier,
 		},

--- a/dev/sg/linters/prettier.go
+++ b/dev/sg/linters/prettier.go
@@ -12,8 +12,7 @@ import (
 )
 
 var prettier = &linter{
-	Name:    "Prettier",
-	Enabled: disabled("Temporarily disabled to figure out unknown failure"),
+	Name: "Prettier",
 	// TODO unfortunate that we have to use 'dev/ci/yarn-run.sh'
 	Check: func(ctx context.Context, out *std.Output, args *repo.State) error {
 		return root.Run(run.Cmd(ctx, "dev/ci/yarn-run.sh format:check")).

--- a/dev/sg/linters/prettier.go
+++ b/dev/sg/linters/prettier.go
@@ -14,6 +14,9 @@ import (
 var prettier = &linter{
 	Name: "Prettier",
 	// TODO unfortunate that we have to use 'dev/ci/yarn-run.sh'
+    Enabled: func(ctx context.Context, args *repo.State) error {
+        return nil
+    },
 	Check: func(ctx context.Context, out *std.Output, args *repo.State) error {
 		return root.Run(run.Cmd(ctx, "dev/ci/yarn-run.sh format:check")).
 			Map(yarnInstallFilter()).

--- a/dev/sg/linters/prettier.go
+++ b/dev/sg/linters/prettier.go
@@ -14,9 +14,6 @@ import (
 var prettier = &linter{
 	Name: "Prettier",
 	// TODO unfortunate that we have to use 'dev/ci/yarn-run.sh'
-    Enabled: func(ctx context.Context, args *repo.State) error {
-        return nil
-    },
 	Check: func(ctx context.Context, out *std.Output, args *repo.State) error {
 		return root.Run(run.Cmd(ctx, "dev/ci/yarn-run.sh format:check")).
 			Map(yarnInstallFilter()).

--- a/dev/sg/sg_lint.go
+++ b/dev/sg/sg_lint.go
@@ -31,6 +31,13 @@ var lintFailFast = &cli.BoolFlag{
 	Value:   true,
 }
 
+var lintFormatCheck = &cli.BoolFlag{
+	Name:    "format-check",
+	Aliases: []string{"fc"},
+	Usage:   "Check file formatting and fail if changes are detected",
+	Value:   false,
+}
+
 var lintCommand = &cli.Command{
 	Name:        "lint",
 	ArgsUsage:   "[targets...]",
@@ -57,6 +64,7 @@ sg lint --help
 		generateAnnotations,
 		lintFix,
 		lintFailFast,
+		lintFormatCheck,
 	},
 	Before: func(cmd *cli.Context) error {
 		// If more than 1 target is requested, hijack subcommands by setting it to nil
@@ -103,6 +111,10 @@ sg lint --help
 			return runner.Fix(cmd.Context, repoState)
 		}
 		runner.FailFast = lintFailFast.Get(cmd)
+		runner.FormatCheck = lintFormatCheck.Get(cmd)
+        if lintFormatCheck.Get(cmd) {
+            targets = append(targets, "format")
+        }
 		std.Out.WriteNoticef("Running checks from targets: %s", strings.Join(targets, ", "))
 		return runner.Check(cmd.Context, repoState)
 	},
@@ -135,6 +147,7 @@ func (lt lintTargets) Commands() (cmds []*cli.Command) {
 					return runner.Fix(cmd.Context, repoState)
 				}
 				runner.FailFast = lintFailFast.Get(cmd)
+				runner.FormatCheck = lintFormatCheck.Get(cmd)
 				std.Out.WriteNoticef("Running checks from target: %s", target.Name)
 				return runner.Check(cmd.Context, repoState)
 			},

--- a/dev/sg/sg_lint.go
+++ b/dev/sg/sg_lint.go
@@ -88,7 +88,9 @@ sg lint --help
 			// Otherwise run requested set
 			allLintTargetsMap := make(map[string]linters.Target, len(linters.Targets))
 			for _, c := range linters.Targets {
-				allLintTargetsMap[c.Name] = c
+				if c.Name != "clientformatting" {
+					allLintTargetsMap[c.Name] = c
+				}
 			}
 			for _, t := range targets {
 				target, ok := allLintTargetsMap[t]
@@ -96,7 +98,9 @@ sg lint --help
 					std.Out.WriteFailuref("unrecognized target %q provided", t)
 					return flag.ErrHelp
 				}
-				lintTargets = append(lintTargets, target)
+				if target.Name != "clientformatting" { // only add this if format-check flag is enabled
+					lintTargets = append(lintTargets, target)
+				}
 			}
 		}
 
@@ -111,10 +115,9 @@ sg lint --help
 			return runner.Fix(cmd.Context, repoState)
 		}
 		runner.FailFast = lintFailFast.Get(cmd)
-		runner.FormatCheck = lintFormatCheck.Get(cmd)
-        if lintFormatCheck.Get(cmd) {
-            targets = append(targets, "format")
-        }
+		if lintFormatCheck.Get(cmd) {
+			targets = append(targets, "clientformatting")
+		}
 		std.Out.WriteNoticef("Running checks from targets: %s", strings.Join(targets, ", "))
 		return runner.Check(cmd.Context, repoState)
 	},

--- a/dev/sg/sg_lint.go
+++ b/dev/sg/sg_lint.go
@@ -35,7 +35,7 @@ var lintFormatCheck = &cli.BoolFlag{
 	Name:    "format-check",
 	Aliases: []string{"fc"},
 	Usage:   "Check file formatting and fail if changes are detected",
-	Value:   true,
+	Value:   false,
 }
 
 var lintCommand = &cli.Command{
@@ -82,9 +82,7 @@ sg lint --help
 			// If no args provided, run all
 			lintTargets = linters.Targets
 			for _, t := range lintTargets {
-				if t.Name != "clientformatting" { // only part of defaults if format-check flag is enabled
-					targets = append(targets, t.Name)
-				}
+				targets = append(targets, t.Name)
 			}
 		} else {
 			// Otherwise run requested set
@@ -114,7 +112,8 @@ sg lint --help
 		}
 		runner.FailFast = lintFailFast.Get(cmd)
 		if lintFormatCheck.Get(cmd) {
-			targets = append(targets, "clientformatting")
+			lintTargets = append(lintTargets, linters.FormattingTarget)
+			targets = append(targets, linters.FormattingTarget.Name)
 		}
 		std.Out.WriteNoticef("Running checks from targets: %s", strings.Join(targets, ", "))
 		return runner.Check(cmd.Context, repoState)

--- a/dev/sg/sg_lint.go
+++ b/dev/sg/sg_lint.go
@@ -82,15 +82,15 @@ sg lint --help
 			// If no args provided, run all
 			lintTargets = linters.Targets
 			for _, t := range lintTargets {
-				targets = append(targets, t.Name)
+				if t.Name != "clientformatting" { // only part of defaults if format-check flag is enabled
+					targets = append(targets, t.Name)
+				}
 			}
 		} else {
 			// Otherwise run requested set
 			allLintTargetsMap := make(map[string]linters.Target, len(linters.Targets))
 			for _, c := range linters.Targets {
-				if c.Name != "clientformatting" {
-					allLintTargetsMap[c.Name] = c
-				}
+				allLintTargetsMap[c.Name] = c
 			}
 			for _, t := range targets {
 				target, ok := allLintTargetsMap[t]
@@ -98,9 +98,7 @@ sg lint --help
 					std.Out.WriteFailuref("unrecognized target %q provided", t)
 					return flag.ErrHelp
 				}
-				if target.Name != "clientformatting" { // only add this if format-check flag is enabled
-					lintTargets = append(lintTargets, target)
-				}
+				lintTargets = append(lintTargets, target)
 			}
 		}
 

--- a/dev/sg/sg_lint.go
+++ b/dev/sg/sg_lint.go
@@ -35,7 +35,7 @@ var lintFormatCheck = &cli.BoolFlag{
 	Name:    "format-check",
 	Aliases: []string{"fc"},
 	Usage:   "Check file formatting and fail if changes are detected",
-	Value:   false,
+	Value:   true,
 }
 
 var lintCommand = &cli.Command{

--- a/dev/sg/sg_lint.go
+++ b/dev/sg/sg_lint.go
@@ -105,16 +105,17 @@ sg lint --help
 			return errors.Wrap(err, "repo.GetState")
 		}
 
+		if lintFormatCheck.Get(cmd) {
+			lintTargets = append(lintTargets, linters.FormattingTarget)
+			targets = append(targets, linters.FormattingTarget.Name)
+		}
+
 		runner := linters.NewRunner(std.Out, generateAnnotations.Get(cmd), lintTargets...)
 		if cmd.Bool("fix") {
 			std.Out.WriteNoticef("Fixing checks from targets: %s", strings.Join(targets, ", "))
 			return runner.Fix(cmd.Context, repoState)
 		}
 		runner.FailFast = lintFailFast.Get(cmd)
-		if lintFormatCheck.Get(cmd) {
-			lintTargets = append(lintTargets, linters.FormattingTarget)
-			targets = append(targets, linters.FormattingTarget.Name)
-		}
 		std.Out.WriteNoticef("Running checks from targets: %s", strings.Join(targets, ", "))
 		return runner.Check(cmd.Context, repoState)
 	},

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -109,7 +109,12 @@ func addSgLints(targets []string) func(pipeline *bk.Pipeline) {
 		cmd = cmd + "-v "
 	}
 
-	cmd = cmd + "lint -annotations -fail-fast=false " + strings.Join(targets, " ")
+	var formatCheck string
+	if os.Getenv("BUILDKITE_BRANCH") != "main" {
+		formatCheck = "-format-check=true "
+	}
+
+	cmd = cmd + "lint -annotations -fail-fast=false " + formatCheck + strings.Join(targets, " ")
 
 	return func(pipeline *bk.Pipeline) {
 		pipeline.AddStep(":pineapple::lint-roller: Run sg lint",

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -109,8 +109,18 @@ func addSgLints(targets []string) func(pipeline *bk.Pipeline) {
 		cmd = cmd + "-v "
 	}
 
+	var (
+		branch = os.Getenv("BUILDKITE_BRANCH")
+		tag    = os.Getenv("BUILDKITE_TAG")
+		// evaluates what type of pipeline run this is
+		runType = runtype.Compute(tag, branch, map[string]string{
+			"BEXT_NIGHTLY":    os.Getenv("BEXT_NIGHTLY"),
+			"RELEASE_NIGHTLY": os.Getenv("RELEASE_NIGHTLY"),
+			"VSCE_NIGHTLY":    os.Getenv("VSCE_NIGHTLY"),
+		})
+	)
 	var formatCheck string
-	if os.Getenv("BUILDKITE_BRANCH") != "main" {
+	if !runType.Is(runtype.MainBranch) {
 		formatCheck = "-format-check=true "
 	}
 


### PR DESCRIPTION
`sg` will do a `yarn run format:check` if the `--fc` or `--format-check` flag is passed.

The pipeline has also been adjusted to only pass this flag to the linter if it is NOT the `main` branch, to prevent any possible flakiness from blocking `main`, but keeping our code tidy in side branches.

## Test plan

Pipeline passes 🤞 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
