### PR TITLE
Confirm $SRC_ENDPOINT before publishing batch change

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -33,6 +33,7 @@ import {
     ensureDocker,
     changelogURL,
     ensureReleaseBranchUpToDate,
+    ensureSrcCliEndpoint,
     ensureSrcCliUpToDate,
     getLatestTag,
 } from './util'
@@ -415,6 +416,8 @@ ${trackingIssues.map(index => `- ${slackURL(index.title, index.url)}`).join('\n'
                 console.log('Docker required for batch changes')
                 process.exit(1)
             }
+            // ensure $SRC_ENDPOINT is set
+            ensureSrcCliEndpoint()
             // ensure src-cli is up to date
             await ensureSrcCliUpToDate()
             // set up batch change config
@@ -876,6 +879,7 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
         id: '_test:srccliensure',
         description: 'test srccli version',
         run: async () => {
+            ensureSrcCliEndpoint()
             await ensureSrcCliUpToDate()
         },
     },

--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -5,6 +5,8 @@ import execa from 'execa'
 import { readFile, writeFile, mkdir } from 'mz/fs'
 import fetch from 'node-fetch'
 
+const SOURCEGRAPH_RELEASE_INSTANCE_URL = 'https://k8s.sgdev.org'
+
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 export function formatDate(date: Date): string {
     return `${date.toLocaleString('en-US', {
@@ -146,6 +148,13 @@ export async function ensureSrcCliUpToDate(): Promise<void> {
             console.log('Trouble upgrading src-cli:', error)
             process.exit(1)
         }
+    }
+}
+
+export function ensureSrcCliEndpoint(): void {
+    const srcEndpoint = process.env.SRC_ENDPOINT
+    if (srcEndpoint !== SOURCEGRAPH_RELEASE_INSTANCE_URL) {
+        throw new Error('the $SRC_ENDPOINT provided doesn\'t match what is expected by the release tool')
     }
 }
 

--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -154,7 +154,8 @@ export async function ensureSrcCliUpToDate(): Promise<void> {
 export function ensureSrcCliEndpoint(): void {
     const srcEndpoint = process.env.SRC_ENDPOINT
     if (srcEndpoint !== SOURCEGRAPH_RELEASE_INSTANCE_URL) {
-        throw new Error('the $SRC_ENDPOINT provided doesn\'t match what is expected by the release tool')
+        throw new Error(`the $SRC_ENDPOINT provided doesn't match what is expected by the release tool.
+Expected $SRC_ENDPOINT to be "${SOURCEGRAPH_RELEASE_INSTANCE_URL}"`)
     }
 }
 


### PR DESCRIPTION
I ran into an issue earlier where the `SRC_ENDPOINT` was set to my local instance, this threw an error. Adding this check so release captains can quickly identify this before going far along in the release process.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Ran a dry-run test using the release tool.