### PR TITLE
web: add formatting to Timestamp component

### DIFF
--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react'
 
 import { mdiChevronDown, mdiChevronRight } from '@mdi/js'
-import { format } from 'date-fns'
 import * as H from 'history'
 import { parse as parseJSONC } from 'jsonc-parser'
 import { Redirect, useHistory } from 'react-router'
@@ -30,6 +29,7 @@ import { FilteredConnection, FilteredConnectionQueryArguments } from '../Filtere
 import { LoaderButton } from '../LoaderButton'
 import { PageTitle } from '../PageTitle'
 import { Duration } from '../time/Duration'
+import { Timestamp, TimestampFormat } from '../time/Timestamp'
 
 import {
     useSyncExternalService,
@@ -360,7 +360,7 @@ const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJob
         ]
     }, [node])
 
-    const runningStatuses = new Set<ExternalServiceSyncJobState> ([
+    const runningStatuses = new Set<ExternalServiceSyncJobState>([
         ExternalServiceSyncJobState.QUEUED,
         ExternalServiceSyncJobState.PROCESSING,
         ExternalServiceSyncJobState.CANCELING,
@@ -387,11 +387,31 @@ const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJob
                 </div>
                 <div className="flex-shrink-1 flex-grow-0 mr-1">
                     {node.startedAt === null && 'Not started yet.'}
-                    {node.startedAt !== null && <>Started at {format(Date.parse(node.startedAt), 'HH:mm:ss')}.</>}
+                    {node.startedAt !== null && (
+                        <>
+                            Started at{' '}
+                            <Timestamp
+                                date={node.startedAt}
+                                preferAbsolute={true}
+                                timestampFormat={TimestampFormat.FULL_TIME}
+                            />
+                            .
+                        </>
+                    )}
                 </div>
                 <div className="flex-shrink-1 flex-grow-0 mr-1">
                     {node.finishedAt === null && 'Not finished yet.'}
-                    {node.finishedAt !== null && <>Finished at {format(Date.parse(node.finishedAt), 'HH:mm:ss')}.</>}
+                    {node.finishedAt !== null && (
+                        <>
+                            Finished at{' '}
+                            <Timestamp
+                                date={node.finishedAt}
+                                preferAbsolute={true}
+                                timestampFormat={TimestampFormat.FULL_TIME}
+                            />
+                            .
+                        </>
+                    )}
                 </div>
                 <div className="flex-shrink-0 flex-grow-1 mr-1">
                     {node.startedAt && (

--- a/client/web/src/components/time/Timestamp.test.tsx
+++ b/client/web/src/components/time/Timestamp.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react'
 
-import { Timestamp } from './Timestamp'
+import { Timestamp, TimestampFormat } from './Timestamp'
 
 describe('Timestamp', () => {
     test('mocked current time', () => expect(render(<Timestamp date="2006-01-02" />).asFragment()).toMatchSnapshot())
@@ -9,4 +9,6 @@ describe('Timestamp', () => {
         expect(render(<Timestamp date="2006-01-02T01:02:00Z" />).asFragment()).toMatchSnapshot())
 
     test('noAbout', () => expect(render(<Timestamp date="2006-01-02" noAbout={true} />).asFragment()).toMatchSnapshot())
+
+    test('absolute time with formatting', () => expect(render(<Timestamp date="2006-01-02T01:02:00Z" timestampFormat={TimestampFormat.FULL_TIME} preferAbsolute={true} />).asFragment()).toMatchSnapshot())
 })

--- a/client/web/src/components/time/Timestamp.tsx
+++ b/client/web/src/components/time/Timestamp.tsx
@@ -27,7 +27,9 @@ interface Props {
 }
 
 export enum TimestampFormat {
-    FULL_TIME = 'HH:mm:ss'
+    FULL_TIME = 'HH:mm:ss',
+    FULL_DATE = 'yyyy-MM-dd',
+    FULL_DATE_TIME = 'yyyy-MM-dd pp',
 }
 
 const RERENDER_INTERVAL_MSEC = 7000
@@ -42,7 +44,7 @@ export const Timestamp: React.FunctionComponent<React.PropsWithChildren<Props>> 
     strict = false,
     now = Date.now,
     preferAbsolute = false,
-    timestampFormat
+    timestampFormat,
 }) => {
     const [label, setLabel] = useState<string>(calculateLabel(date, now, strict, noAbout))
     useEffect(() => {
@@ -58,7 +60,8 @@ export const Timestamp: React.FunctionComponent<React.PropsWithChildren<Props>> 
     const tooltip = useMemo(() => {
         const parsedDate = typeof date === 'string' ? parseISO(date) : new Date(date)
         const dateHasTime = date.toString().includes('T')
-        return format(parsedDate, timestampFormat ?? `yyyy-MM-dd${dateHasTime ? ' pp' : ''}`)
+        const defaultFormat = dateHasTime ? TimestampFormat.FULL_DATE_TIME : TimestampFormat.FULL_DATE
+        return format(parsedDate, timestampFormat ?? defaultFormat)
     }, [date, timestampFormat])
 
     return (

--- a/client/web/src/components/time/Timestamp.tsx
+++ b/client/web/src/components/time/Timestamp.tsx
@@ -21,6 +21,13 @@ interface Props {
 
     /** Whether to show absolute timestamp and show relative one in tooltip */
     preferAbsolute?: boolean
+
+    /** Optional semantic timestamp format */
+    timestampFormat?: TimestampFormat
+}
+
+export enum TimestampFormat {
+    FULL_TIME = 'HH:mm:ss'
 }
 
 const RERENDER_INTERVAL_MSEC = 7000
@@ -35,6 +42,7 @@ export const Timestamp: React.FunctionComponent<React.PropsWithChildren<Props>> 
     strict = false,
     now = Date.now,
     preferAbsolute = false,
+    timestampFormat
 }) => {
     const [label, setLabel] = useState<string>(calculateLabel(date, now, strict, noAbout))
     useEffect(() => {
@@ -50,8 +58,8 @@ export const Timestamp: React.FunctionComponent<React.PropsWithChildren<Props>> 
     const tooltip = useMemo(() => {
         const parsedDate = typeof date === 'string' ? parseISO(date) : new Date(date)
         const dateHasTime = date.toString().includes('T')
-        return format(parsedDate, `yyyy-MM-dd${dateHasTime ? ' pp' : ''}`)
-    }, [date])
+        return format(parsedDate, timestampFormat ?? `yyyy-MM-dd${dateHasTime ? ' pp' : ''}`)
+    }, [date, timestampFormat])
 
     return (
         <Tooltip content={preferAbsolute ? label : tooltip}>

--- a/client/web/src/components/time/__snapshots__/Timestamp.test.tsx.snap
+++ b/client/web/src/components/time/__snapshots__/Timestamp.test.tsx.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Timestamp absolute time with formatting 1`] = `
+<DocumentFragment>
+  <span
+    class="timestamp"
+    data-state="closed"
+  >
+    01:02:00
+  </span>
+</DocumentFragment>
+`;
+
 exports[`Timestamp mocked current time 1`] = `
 <DocumentFragment>
   <span
@@ -18,6 +29,17 @@ exports[`Timestamp noAbout 1`] = `
     data-state="closed"
   >
     22 hours ago
+  </span>
+</DocumentFragment>
+`;
+
+exports[`Timestamp with full time formatting 1`] = `
+<DocumentFragment>
+  <span
+    class="timestamp"
+    data-state="closed"
+  >
+    01:02:00
   </span>
 </DocumentFragment>
 `;

--- a/client/web/src/components/time/__snapshots__/Timestamp.test.tsx.snap
+++ b/client/web/src/components/time/__snapshots__/Timestamp.test.tsx.snap
@@ -33,17 +33,6 @@ exports[`Timestamp noAbout 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Timestamp with full time formatting 1`] = `
-<DocumentFragment>
-  <span
-    class="timestamp"
-    data-state="closed"
-  >
-    01:02:00
-  </span>
-</DocumentFragment>
-`;
-
 exports[`Timestamp with time time 1`] = `
 <DocumentFragment>
   <span


### PR DESCRIPTION
Follow up to https://github.com/sourcegraph/sourcegraph/pull/43429

We have a Timestamp component which should be used instead of parsing and formatting the date if possible.

## Test plan
New jest test added. Ran sg locally to check that the dates didn't change.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ao-ui-add-format-to-timestamp.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
