### PR TITLE
admin repos view: make stats numbers clickable

### DIFF
--- a/client/web/src/components/FilteredConnection/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.tsx
@@ -430,6 +430,23 @@ export class FilteredConnection<
                     )
                 )
         )
+
+        // React to location changes.
+        this.subscriptions.add(
+            this.componentUpdates
+                .pipe(
+                    map(({ location }) => location.search),
+                    distinctUntilChanged(),
+                    map(searchParams => new URLSearchParams(searchParams)),
+                    skip(1)
+                )
+                .subscribe(searchParameters => {
+                    if (this.props.useURLQuery) {
+                        this.activeValuesChanges.next(getFilterFromURL(searchParameters, this.props.filters))
+                    }
+                })
+        )
+
         this.componentUpdates.next(this.props)
     }
 

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -189,6 +189,7 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
                 color: 'var(--body-color)',
                 position: 'right',
                 tooltip: 'The number of repositories that have not been cloned yet.',
+                filter: { name: 'status', value: 'not-cloned' },
             },
             {
                 value: data.repositoryStats.cloning,
@@ -196,6 +197,7 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
                 color: data.repositoryStats.cloning > 0 ? 'var(--success)' : 'var(--body-color)',
                 position: 'right',
                 tooltip: 'The number of repositories that are currently being cloned.',
+                filter: { name: 'status', value: 'cloning' },
             },
             {
                 value: data.repositoryStats.cloned,
@@ -203,6 +205,7 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
                 color: 'var(--body-color)',
                 position: 'right',
                 tooltip: 'The number of repositories that have been cloned.',
+                filter: { name: 'status', value: 'cloned' },
             },
             {
                 value: data.repositoryStats.indexed,
@@ -210,6 +213,7 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
                 color: 'var(--body-color)',
                 position: 'right',
                 tooltip: 'The number of repositories that have been indexed for search.',
+                filter: { name: 'status', value: 'indexed' },
             },
             {
                 value: data.repositoryStats.failedFetch,
@@ -217,6 +221,7 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
                 color: data.repositoryStats.failedFetch > 0 ? 'var(--warning)' : 'var(--body-color)',
                 position: 'right',
                 tooltip: 'The number of repositories where the last syncing attempt produced an error.',
+                filter: { name: 'status', value: 'failed-fetch' },
             },
         ]
     }, [data])

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -213,7 +213,6 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
                 color: 'var(--body-color)',
                 position: 'right',
                 tooltip: 'The number of repositories that have been indexed for search.',
-                filter: { name: 'status', value: 'indexed' },
             },
             {
                 value: data.repositoryStats.failedFetch,

--- a/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
+++ b/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
@@ -53,14 +53,25 @@ export const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({
                 )}
             </Tooltip>
             <Tooltip content={tooltip}>
-                <Text
-                    as="span"
-                    alignment="center"
-                    className={classNames(styles.textWrap, tooltip && 'cursor-pointer', 'text-muted')}
-                >
-                    {description}
-                    {tooltip && <span className={styles.linkColor}>*</span>}
-                </Text>
+                {filter ? (
+                    <Link
+                        to={`?${searchParams.toString()}`}
+                        alignment="center"
+                        className={classNames(styles.textWrap, tooltip && 'cursor-pointer', 'text-muted')}
+                    >
+                        {description}
+                        {tooltip && <span className={styles.linkColor}>*</span>}
+                    </Link>
+                ) : (
+                    <Text
+                        as="span"
+                        alignment="center"
+                        className={classNames(styles.textWrap, tooltip && 'cursor-pointer', 'text-muted')}
+                    >
+                        {description}
+                        {tooltip && <span className={styles.linkColor}>*</span>}
+                    </Text>
+                )}
             </Tooltip>
         </div>
     )

--- a/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
+++ b/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
@@ -56,7 +56,6 @@ export const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({
                 {filter ? (
                     <Link
                         to={`?${searchParams.toString()}`}
-                        alignment="center"
                         className={classNames(styles.textWrap, tooltip && 'cursor-pointer', 'text-muted')}
                     >
                         {description}

--- a/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
+++ b/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
@@ -2,8 +2,9 @@
 import React, { useMemo } from 'react'
 
 import classNames from 'classnames'
+import { useLocation } from 'react-router'
 
-import { Text, Tooltip } from '@sourcegraph/wildcard'
+import { Link, Text, Tooltip } from '@sourcegraph/wildcard'
 
 import { formatNumber } from '../utils'
 
@@ -15,6 +16,7 @@ interface ValueLegendItemProps {
     value: number | string
     tooltip?: string
     className?: string
+    filter?: { name: string; value: string }
 }
 
 export const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({
@@ -23,15 +25,32 @@ export const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({
     description,
     tooltip,
     className,
+    filter,
 }) => {
     const formattedNumber = useMemo(() => (typeof value === 'number' ? formatNumber(value) : value), [value])
     const unformattedNumber = `${value}`
+    const location = useLocation()
+
+    const searchParams = useMemo(() => {
+        const search = new URLSearchParams(location.search)
+        if (filter) {
+            search.set(filter.name, filter.value)
+        }
+        return search
+    }, [filter, location.search])
+
     return (
         <div className={classNames('d-flex flex-column align-items-center mr-4 justify-content-center', className)}>
             <Tooltip content={formattedNumber !== unformattedNumber ? unformattedNumber : undefined}>
-                <span style={{ color }} className={styles.count}>
-                    {formattedNumber}
-                </span>
+                {filter ? (
+                    <Link to={`?${searchParams.toString()}`} style={{ color }} className={styles.count}>
+                        {formattedNumber}
+                    </Link>
+                ) : (
+                    <span style={{ color }} className={styles.count}>
+                        {formattedNumber}
+                    </span>
+                )}
             </Tooltip>
             <Tooltip content={tooltip}>
                 <Text


### PR DESCRIPTION
This makes the numbers on the top of the site-admin "Repositories" page clickable, if there is a corresponding filter.

This was requested by @ryphil. 

@eseliger contributed the changes to `FilteredConnection` here.

## Demo video

https://user-images.githubusercontent.com/1185253/198313569-9e7b46c5-1888-4dab-98c8-5db6d982d582.mp4


## Test plan

- Manually tested

## App preview:

- [Web](https://sg-web-mrn-clickable-legend.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

