### PR TITLE
authz: Rename RepoIdSupported to RepoIDSupported

### DIFF
--- a/internal/authz/mocks_temp.go
+++ b/internal/authz/mocks_temp.go
@@ -685,9 +685,9 @@ type MockSubRepoPermissionsGetter struct {
 	// GetByUserFunc is an instance of a mock function object controlling
 	// the behavior of the method GetByUser.
 	GetByUserFunc *SubRepoPermissionsGetterGetByUserFunc
-	// RepoIdSupportedFunc is an instance of a mock function object
-	// controlling the behavior of the method RepoIdSupported.
-	RepoIdSupportedFunc *SubRepoPermissionsGetterRepoIdSupportedFunc
+	// RepoIDSupportedFunc is an instance of a mock function object
+	// controlling the behavior of the method RepoIDSupported.
+	RepoIDSupportedFunc *SubRepoPermissionsGetterRepoIDSupportedFunc
 	// RepoSupportedFunc is an instance of a mock function object
 	// controlling the behavior of the method RepoSupported.
 	RepoSupportedFunc *SubRepoPermissionsGetterRepoSupportedFunc
@@ -703,7 +703,7 @@ func NewMockSubRepoPermissionsGetter() *MockSubRepoPermissionsGetter {
 				return
 			},
 		},
-		RepoIdSupportedFunc: &SubRepoPermissionsGetterRepoIdSupportedFunc{
+		RepoIDSupportedFunc: &SubRepoPermissionsGetterRepoIDSupportedFunc{
 			defaultHook: func(context.Context, api.RepoID) (r0 bool, r1 error) {
 				return
 			},
@@ -726,9 +726,9 @@ func NewStrictMockSubRepoPermissionsGetter() *MockSubRepoPermissionsGetter {
 				panic("unexpected invocation of MockSubRepoPermissionsGetter.GetByUser")
 			},
 		},
-		RepoIdSupportedFunc: &SubRepoPermissionsGetterRepoIdSupportedFunc{
+		RepoIDSupportedFunc: &SubRepoPermissionsGetterRepoIDSupportedFunc{
 			defaultHook: func(context.Context, api.RepoID) (bool, error) {
-				panic("unexpected invocation of MockSubRepoPermissionsGetter.RepoIdSupported")
+				panic("unexpected invocation of MockSubRepoPermissionsGetter.RepoIDSupported")
 			},
 		},
 		RepoSupportedFunc: &SubRepoPermissionsGetterRepoSupportedFunc{
@@ -747,8 +747,8 @@ func NewMockSubRepoPermissionsGetterFrom(i SubRepoPermissionsGetter) *MockSubRep
 		GetByUserFunc: &SubRepoPermissionsGetterGetByUserFunc{
 			defaultHook: i.GetByUser,
 		},
-		RepoIdSupportedFunc: &SubRepoPermissionsGetterRepoIdSupportedFunc{
-			defaultHook: i.RepoIdSupported,
+		RepoIDSupportedFunc: &SubRepoPermissionsGetterRepoIDSupportedFunc{
+			defaultHook: i.RepoIDSupported,
 		},
 		RepoSupportedFunc: &SubRepoPermissionsGetterRepoSupportedFunc{
 			defaultHook: i.RepoSupported,
@@ -867,37 +867,37 @@ func (c SubRepoPermissionsGetterGetByUserFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// SubRepoPermissionsGetterRepoIdSupportedFunc describes the behavior when
-// the RepoIdSupported method of the parent MockSubRepoPermissionsGetter
+// SubRepoPermissionsGetterRepoIDSupportedFunc describes the behavior when
+// the RepoIDSupported method of the parent MockSubRepoPermissionsGetter
 // instance is invoked.
-type SubRepoPermissionsGetterRepoIdSupportedFunc struct {
+type SubRepoPermissionsGetterRepoIDSupportedFunc struct {
 	defaultHook func(context.Context, api.RepoID) (bool, error)
 	hooks       []func(context.Context, api.RepoID) (bool, error)
-	history     []SubRepoPermissionsGetterRepoIdSupportedFuncCall
+	history     []SubRepoPermissionsGetterRepoIDSupportedFuncCall
 	mutex       sync.Mutex
 }
 
-// RepoIdSupported delegates to the next hook function in the queue and
+// RepoIDSupported delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockSubRepoPermissionsGetter) RepoIdSupported(v0 context.Context, v1 api.RepoID) (bool, error) {
-	r0, r1 := m.RepoIdSupportedFunc.nextHook()(v0, v1)
-	m.RepoIdSupportedFunc.appendCall(SubRepoPermissionsGetterRepoIdSupportedFuncCall{v0, v1, r0, r1})
+func (m *MockSubRepoPermissionsGetter) RepoIDSupported(v0 context.Context, v1 api.RepoID) (bool, error) {
+	r0, r1 := m.RepoIDSupportedFunc.nextHook()(v0, v1)
+	m.RepoIDSupportedFunc.appendCall(SubRepoPermissionsGetterRepoIDSupportedFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the RepoIdSupported
+// SetDefaultHook sets function that is called when the RepoIDSupported
 // method of the parent MockSubRepoPermissionsGetter instance is invoked and
 // the hook queue is empty.
-func (f *SubRepoPermissionsGetterRepoIdSupportedFunc) SetDefaultHook(hook func(context.Context, api.RepoID) (bool, error)) {
+func (f *SubRepoPermissionsGetterRepoIDSupportedFunc) SetDefaultHook(hook func(context.Context, api.RepoID) (bool, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// RepoIdSupported method of the parent MockSubRepoPermissionsGetter
+// RepoIDSupported method of the parent MockSubRepoPermissionsGetter
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *SubRepoPermissionsGetterRepoIdSupportedFunc) PushHook(hook func(context.Context, api.RepoID) (bool, error)) {
+func (f *SubRepoPermissionsGetterRepoIDSupportedFunc) PushHook(hook func(context.Context, api.RepoID) (bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -905,20 +905,20 @@ func (f *SubRepoPermissionsGetterRepoIdSupportedFunc) PushHook(hook func(context
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *SubRepoPermissionsGetterRepoIdSupportedFunc) SetDefaultReturn(r0 bool, r1 error) {
+func (f *SubRepoPermissionsGetterRepoIDSupportedFunc) SetDefaultReturn(r0 bool, r1 error) {
 	f.SetDefaultHook(func(context.Context, api.RepoID) (bool, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *SubRepoPermissionsGetterRepoIdSupportedFunc) PushReturn(r0 bool, r1 error) {
+func (f *SubRepoPermissionsGetterRepoIDSupportedFunc) PushReturn(r0 bool, r1 error) {
 	f.PushHook(func(context.Context, api.RepoID) (bool, error) {
 		return r0, r1
 	})
 }
 
-func (f *SubRepoPermissionsGetterRepoIdSupportedFunc) nextHook() func(context.Context, api.RepoID) (bool, error) {
+func (f *SubRepoPermissionsGetterRepoIDSupportedFunc) nextHook() func(context.Context, api.RepoID) (bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -931,28 +931,28 @@ func (f *SubRepoPermissionsGetterRepoIdSupportedFunc) nextHook() func(context.Co
 	return hook
 }
 
-func (f *SubRepoPermissionsGetterRepoIdSupportedFunc) appendCall(r0 SubRepoPermissionsGetterRepoIdSupportedFuncCall) {
+func (f *SubRepoPermissionsGetterRepoIDSupportedFunc) appendCall(r0 SubRepoPermissionsGetterRepoIDSupportedFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// SubRepoPermissionsGetterRepoIdSupportedFuncCall objects describing the
+// SubRepoPermissionsGetterRepoIDSupportedFuncCall objects describing the
 // invocations of this function.
-func (f *SubRepoPermissionsGetterRepoIdSupportedFunc) History() []SubRepoPermissionsGetterRepoIdSupportedFuncCall {
+func (f *SubRepoPermissionsGetterRepoIDSupportedFunc) History() []SubRepoPermissionsGetterRepoIDSupportedFuncCall {
 	f.mutex.Lock()
-	history := make([]SubRepoPermissionsGetterRepoIdSupportedFuncCall, len(f.history))
+	history := make([]SubRepoPermissionsGetterRepoIDSupportedFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// SubRepoPermissionsGetterRepoIdSupportedFuncCall is an object that
-// describes an invocation of method RepoIdSupported on an instance of
+// SubRepoPermissionsGetterRepoIDSupportedFuncCall is an object that
+// describes an invocation of method RepoIDSupported on an instance of
 // MockSubRepoPermissionsGetter.
-type SubRepoPermissionsGetterRepoIdSupportedFuncCall struct {
+type SubRepoPermissionsGetterRepoIDSupportedFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -969,13 +969,13 @@ type SubRepoPermissionsGetterRepoIdSupportedFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c SubRepoPermissionsGetterRepoIdSupportedFuncCall) Args() []interface{} {
+func (c SubRepoPermissionsGetterRepoIDSupportedFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c SubRepoPermissionsGetterRepoIdSupportedFuncCall) Results() []interface{} {
+func (c SubRepoPermissionsGetterRepoIDSupportedFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -54,7 +54,7 @@ type SubRepoPermissionChecker interface {
 	Enabled() bool
 
 	// EnabledForRepoID indicates whether sub-repo permissions are enabled for the given repoID
-	EnabledForRepoID(ctx context.Context, repoId api.RepoID) (bool, error)
+	EnabledForRepoID(ctx context.Context, repoID api.RepoID) (bool, error)
 
 	// EnabledForRepo indicates whether sub-repo permissions are enabled for the given repo
 	EnabledForRepo(ctx context.Context, repo api.RepoName) (bool, error)
@@ -82,7 +82,7 @@ func (*noopPermsChecker) Enabled() bool {
 	return false
 }
 
-func (*noopPermsChecker) EnabledForRepoID(ctx context.Context, repoId api.RepoID) (bool, error) {
+func (*noopPermsChecker) EnabledForRepoID(ctx context.Context, repoID api.RepoID) (bool, error) {
 	return false, nil
 }
 
@@ -97,8 +97,8 @@ type SubRepoPermissionsGetter interface {
 	// GetByUser returns the known sub repository permissions rules known for a user.
 	GetByUser(ctx context.Context, userID int32) (map[api.RepoName]SubRepoPermissions, error)
 
-	// RepoIdSupported returns true if repo with the given ID has sub-repo permissions
-	RepoIdSupported(ctx context.Context, repoId api.RepoID) (bool, error)
+	// RepoIDSupported returns true if repo with the given ID has sub-repo permissions
+	RepoIDSupported(ctx context.Context, repoID api.RepoID) (bool, error)
 
 	// RepoSupported returns true if repo with the given name has sub-repo permissions
 	RepoSupported(ctx context.Context, repo api.RepoName) (bool, error)
@@ -408,7 +408,7 @@ func (s *SubRepoPermsClient) Enabled() bool {
 }
 
 func (s *SubRepoPermsClient) EnabledForRepoID(ctx context.Context, id api.RepoID) (bool, error) {
-	return s.permissionsGetter.RepoIdSupported(ctx, id)
+	return s.permissionsGetter.RepoIDSupported(ctx, id)
 }
 
 func (s *SubRepoPermsClient) EnabledForRepo(ctx context.Context, repo api.RepoName) (bool, error) {
@@ -458,7 +458,7 @@ func NewSimpleChecker(repo api.RepoName, paths []string) (SubRepoPermissionCheck
 		}, nil
 	})
 	getter.RepoSupportedFunc.SetDefaultReturn(true, nil)
-	getter.RepoIdSupportedFunc.SetDefaultReturn(true, nil)
+	getter.RepoIDSupportedFunc.SetDefaultReturn(true, nil)
 	return NewSubRepoPermsClient(getter)
 }
 

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -39253,9 +39253,9 @@ type MockSubRepoPermsStore struct {
 	// GetByUserAndServiceFunc is an instance of a mock function object
 	// controlling the behavior of the method GetByUserAndService.
 	GetByUserAndServiceFunc *SubRepoPermsStoreGetByUserAndServiceFunc
-	// RepoIdSupportedFunc is an instance of a mock function object
-	// controlling the behavior of the method RepoIdSupported.
-	RepoIdSupportedFunc *SubRepoPermsStoreRepoIdSupportedFunc
+	// RepoIDSupportedFunc is an instance of a mock function object
+	// controlling the behavior of the method RepoIDSupported.
+	RepoIDSupportedFunc *SubRepoPermsStoreRepoIDSupportedFunc
 	// RepoSupportedFunc is an instance of a mock function object
 	// controlling the behavior of the method RepoSupported.
 	RepoSupportedFunc *SubRepoPermsStoreRepoSupportedFunc
@@ -39298,7 +39298,7 @@ func NewMockSubRepoPermsStore() *MockSubRepoPermsStore {
 				return
 			},
 		},
-		RepoIdSupportedFunc: &SubRepoPermsStoreRepoIdSupportedFunc{
+		RepoIDSupportedFunc: &SubRepoPermsStoreRepoIDSupportedFunc{
 			defaultHook: func(context.Context, api.RepoID) (r0 bool, r1 error) {
 				return
 			},
@@ -39356,9 +39356,9 @@ func NewStrictMockSubRepoPermsStore() *MockSubRepoPermsStore {
 				panic("unexpected invocation of MockSubRepoPermsStore.GetByUserAndService")
 			},
 		},
-		RepoIdSupportedFunc: &SubRepoPermsStoreRepoIdSupportedFunc{
+		RepoIDSupportedFunc: &SubRepoPermsStoreRepoIDSupportedFunc{
 			defaultHook: func(context.Context, api.RepoID) (bool, error) {
-				panic("unexpected invocation of MockSubRepoPermsStore.RepoIdSupported")
+				panic("unexpected invocation of MockSubRepoPermsStore.RepoIDSupported")
 			},
 		},
 		RepoSupportedFunc: &SubRepoPermsStoreRepoSupportedFunc{
@@ -39406,8 +39406,8 @@ func NewMockSubRepoPermsStoreFrom(i SubRepoPermsStore) *MockSubRepoPermsStore {
 		GetByUserAndServiceFunc: &SubRepoPermsStoreGetByUserAndServiceFunc{
 			defaultHook: i.GetByUserAndService,
 		},
-		RepoIdSupportedFunc: &SubRepoPermsStoreRepoIdSupportedFunc{
-			defaultHook: i.RepoIdSupported,
+		RepoIDSupportedFunc: &SubRepoPermsStoreRepoIDSupportedFunc{
+			defaultHook: i.RepoIDSupported,
 		},
 		RepoSupportedFunc: &SubRepoPermsStoreRepoSupportedFunc{
 			defaultHook: i.RepoSupported,
@@ -39866,37 +39866,37 @@ func (c SubRepoPermsStoreGetByUserAndServiceFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// SubRepoPermsStoreRepoIdSupportedFunc describes the behavior when the
-// RepoIdSupported method of the parent MockSubRepoPermsStore instance is
+// SubRepoPermsStoreRepoIDSupportedFunc describes the behavior when the
+// RepoIDSupported method of the parent MockSubRepoPermsStore instance is
 // invoked.
-type SubRepoPermsStoreRepoIdSupportedFunc struct {
+type SubRepoPermsStoreRepoIDSupportedFunc struct {
 	defaultHook func(context.Context, api.RepoID) (bool, error)
 	hooks       []func(context.Context, api.RepoID) (bool, error)
-	history     []SubRepoPermsStoreRepoIdSupportedFuncCall
+	history     []SubRepoPermsStoreRepoIDSupportedFuncCall
 	mutex       sync.Mutex
 }
 
-// RepoIdSupported delegates to the next hook function in the queue and
+// RepoIDSupported delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockSubRepoPermsStore) RepoIdSupported(v0 context.Context, v1 api.RepoID) (bool, error) {
-	r0, r1 := m.RepoIdSupportedFunc.nextHook()(v0, v1)
-	m.RepoIdSupportedFunc.appendCall(SubRepoPermsStoreRepoIdSupportedFuncCall{v0, v1, r0, r1})
+func (m *MockSubRepoPermsStore) RepoIDSupported(v0 context.Context, v1 api.RepoID) (bool, error) {
+	r0, r1 := m.RepoIDSupportedFunc.nextHook()(v0, v1)
+	m.RepoIDSupportedFunc.appendCall(SubRepoPermsStoreRepoIDSupportedFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the RepoIdSupported
+// SetDefaultHook sets function that is called when the RepoIDSupported
 // method of the parent MockSubRepoPermsStore instance is invoked and the
 // hook queue is empty.
-func (f *SubRepoPermsStoreRepoIdSupportedFunc) SetDefaultHook(hook func(context.Context, api.RepoID) (bool, error)) {
+func (f *SubRepoPermsStoreRepoIDSupportedFunc) SetDefaultHook(hook func(context.Context, api.RepoID) (bool, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// RepoIdSupported method of the parent MockSubRepoPermsStore instance
+// RepoIDSupported method of the parent MockSubRepoPermsStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *SubRepoPermsStoreRepoIdSupportedFunc) PushHook(hook func(context.Context, api.RepoID) (bool, error)) {
+func (f *SubRepoPermsStoreRepoIDSupportedFunc) PushHook(hook func(context.Context, api.RepoID) (bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -39904,20 +39904,20 @@ func (f *SubRepoPermsStoreRepoIdSupportedFunc) PushHook(hook func(context.Contex
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *SubRepoPermsStoreRepoIdSupportedFunc) SetDefaultReturn(r0 bool, r1 error) {
+func (f *SubRepoPermsStoreRepoIDSupportedFunc) SetDefaultReturn(r0 bool, r1 error) {
 	f.SetDefaultHook(func(context.Context, api.RepoID) (bool, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *SubRepoPermsStoreRepoIdSupportedFunc) PushReturn(r0 bool, r1 error) {
+func (f *SubRepoPermsStoreRepoIDSupportedFunc) PushReturn(r0 bool, r1 error) {
 	f.PushHook(func(context.Context, api.RepoID) (bool, error) {
 		return r0, r1
 	})
 }
 
-func (f *SubRepoPermsStoreRepoIdSupportedFunc) nextHook() func(context.Context, api.RepoID) (bool, error) {
+func (f *SubRepoPermsStoreRepoIDSupportedFunc) nextHook() func(context.Context, api.RepoID) (bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -39930,27 +39930,27 @@ func (f *SubRepoPermsStoreRepoIdSupportedFunc) nextHook() func(context.Context, 
 	return hook
 }
 
-func (f *SubRepoPermsStoreRepoIdSupportedFunc) appendCall(r0 SubRepoPermsStoreRepoIdSupportedFuncCall) {
+func (f *SubRepoPermsStoreRepoIDSupportedFunc) appendCall(r0 SubRepoPermsStoreRepoIDSupportedFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of SubRepoPermsStoreRepoIdSupportedFuncCall
+// History returns a sequence of SubRepoPermsStoreRepoIDSupportedFuncCall
 // objects describing the invocations of this function.
-func (f *SubRepoPermsStoreRepoIdSupportedFunc) History() []SubRepoPermsStoreRepoIdSupportedFuncCall {
+func (f *SubRepoPermsStoreRepoIDSupportedFunc) History() []SubRepoPermsStoreRepoIDSupportedFuncCall {
 	f.mutex.Lock()
-	history := make([]SubRepoPermsStoreRepoIdSupportedFuncCall, len(f.history))
+	history := make([]SubRepoPermsStoreRepoIDSupportedFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// SubRepoPermsStoreRepoIdSupportedFuncCall is an object that describes an
-// invocation of method RepoIdSupported on an instance of
+// SubRepoPermsStoreRepoIDSupportedFuncCall is an object that describes an
+// invocation of method RepoIDSupported on an instance of
 // MockSubRepoPermsStore.
-type SubRepoPermsStoreRepoIdSupportedFuncCall struct {
+type SubRepoPermsStoreRepoIDSupportedFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -39967,13 +39967,13 @@ type SubRepoPermsStoreRepoIdSupportedFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c SubRepoPermsStoreRepoIdSupportedFuncCall) Args() []interface{} {
+func (c SubRepoPermsStoreRepoIDSupportedFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c SubRepoPermsStoreRepoIdSupportedFuncCall) Results() []interface{} {
+func (c SubRepoPermsStoreRepoIDSupportedFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/database/sub_repo_perms_store.go
+++ b/internal/database/sub_repo_perms_store.go
@@ -39,7 +39,7 @@ type SubRepoPermsStore interface {
 	// GetByUserAndService gets the sub repo permissions for a user, but filters down
 	// to only repos that come from a specific external service.
 	GetByUserAndService(ctx context.Context, userID int32, serviceType string, serviceID string) (map[api.ExternalRepoSpec]authz.SubRepoPermissions, error)
-	RepoIDSupported(ctx context.Context, repoId api.RepoID) (bool, error)
+	RepoIDSupported(ctx context.Context, repoID api.RepoID) (bool, error)
 	RepoSupported(ctx context.Context, repo api.RepoName) (bool, error)
 }
 
@@ -210,7 +210,7 @@ WHERE user_id = %s
 
 // RepoIDSupported returns true if repo with the given ID has sub-repo permissions
 // (i.e. it is private and its type is one of the SubRepoSupportedCodeHostTypes)
-func (s *subRepoPermsStore) RepoIDSupported(ctx context.Context, repoId api.RepoID) (bool, error) {
+func (s *subRepoPermsStore) RepoIDSupported(ctx context.Context, repoID api.RepoID) (bool, error) {
 	q := sqlf.Sprintf(`
 SELECT EXISTS(
 SELECT
@@ -219,7 +219,7 @@ WHERE id = %s
 AND private = TRUE
 AND external_service_type IN (%s)
 )
-`, repoId, sqlf.Join(supportedTypesQuery, ","))
+`, repoID, sqlf.Join(supportedTypesQuery, ","))
 
 	exists, _, err := basestore.ScanFirstBool(s.Query(ctx, q))
 	if err != nil {

--- a/internal/database/sub_repo_perms_store.go
+++ b/internal/database/sub_repo_perms_store.go
@@ -39,7 +39,7 @@ type SubRepoPermsStore interface {
 	// GetByUserAndService gets the sub repo permissions for a user, but filters down
 	// to only repos that come from a specific external service.
 	GetByUserAndService(ctx context.Context, userID int32, serviceType string, serviceID string) (map[api.ExternalRepoSpec]authz.SubRepoPermissions, error)
-	RepoIdSupported(ctx context.Context, repoId api.RepoID) (bool, error)
+	RepoIDSupported(ctx context.Context, repoId api.RepoID) (bool, error)
 	RepoSupported(ctx context.Context, repo api.RepoName) (bool, error)
 }
 
@@ -208,9 +208,9 @@ WHERE user_id = %s
 	return result, nil
 }
 
-// RepoIdSupported returns true if repo with the given ID has sub-repo permissions
+// RepoIDSupported returns true if repo with the given ID has sub-repo permissions
 // (i.e. it is private and its type is one of the SubRepoSupportedCodeHostTypes)
-func (s *subRepoPermsStore) RepoIdSupported(ctx context.Context, repoId api.RepoID) (bool, error) {
+func (s *subRepoPermsStore) RepoIDSupported(ctx context.Context, repoId api.RepoID) (bool, error) {
 	q := sqlf.Sprintf(`
 SELECT EXISTS(
 SELECT

--- a/internal/database/sub_repo_perms_store_test.go
+++ b/internal/database/sub_repo_perms_store_test.go
@@ -282,7 +282,7 @@ func TestSubRepoPermsSupportedForRepoId(t *testing.T) {
 
 func testSubRepoNotSupportedForRepo(ctx context.Context, t *testing.T, s SubRepoPermsStore, repoID api.RepoID, repoName api.RepoName, errMsg string) {
 	t.Helper()
-	exists, err := s.RepoIdSupported(ctx, repoID)
+	exists, err := s.RepoIDSupported(ctx, repoID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -300,7 +300,7 @@ func testSubRepoNotSupportedForRepo(ctx context.Context, t *testing.T, s SubRepo
 
 func testSubRepoSupportedForRepo(ctx context.Context, t *testing.T, s SubRepoPermsStore, repoID api.RepoID, repoName api.RepoName, errMsg string) {
 	t.Helper()
-	exists, err := s.RepoIdSupported(ctx, repoID)
+	exists, err := s.RepoIDSupported(ctx, repoID)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
ID is more idiomatic in Go

## Test plan

Mechanical rename, tests still pass.