### PR TITLE
spike: Precise rename a symbol via batch spec

### DIFF
--- a/client/shared/src/api/contract.ts
+++ b/client/shared/src/api/contract.ts
@@ -63,6 +63,7 @@ export interface FlatExtensionHostAPI {
         id: string,
         parameters: TextDocumentPositionParameters
     ) => ProxySubscribable<MaybeLoadingResult<clientType.Location[]>>
+    renameField: (parameters: TextDocumentPositionParameters) => ProxySubscribable<MaybeLoadingResult<string>>
 
     hasReferenceProvidersForDocument: (parameters: TextDocumentPositionParameters) => ProxySubscribable<boolean>
 

--- a/client/shared/src/hover/actions.ts
+++ b/client/shared/src/hover/actions.ts
@@ -373,6 +373,16 @@ export function registerHoverContributions({
                         // eslint-disable-next-line no-template-curly-in-string
                         commandArguments: ['${goToDefinition.url}'],
                     },
+                    {
+                        id: 'batches.renameField',
+                        title: 'Rename',
+                        command: 'batches.renameField',
+                        commandArguments: [
+                            /* eslint-disable no-template-curly-in-string */
+                            '${json(hoverPosition)}',
+                            /* eslint-enable no-template-curly-in-string */
+                        ],
+                    },
                 ],
                 menus: {
                     hover: [
@@ -387,6 +397,10 @@ export function registerHoverContributions({
                             action: 'goToDefinition.preloaded',
                             when: 'goToDefinition.url',
                             disabledWhen: 'hoveredOnDefinition',
+                        },
+                        {
+                            action: 'batches.renameField',
+                            // when: 'batches.renameField.error || batches.renameField.showLoading',
                         },
                     ],
                 },
@@ -524,6 +538,24 @@ export function registerHoverContributions({
                     }
                 }
             }
+
+            subscriptions.add(
+                extensionsController.registerCommand({
+                    command: 'batches.renameField',
+                    run: async (parametersString: string) => {
+                        const parameters: TextDocumentPositionParameters & URLToFileContext = JSON.parse(
+                            parametersString
+                        )
+
+                        const result = await wrapRemoteObservable(extensionHostAPI.renameField(parameters))
+                            .pipe(first(({ isLoading, result }) => !isLoading || result !== null))
+                            .toPromise()
+
+                        alert(`generated the following spec:
+${result}`)
+                    },
+                })
+            )
 
             return Promise.all([
                 definitionContributionsPromise,

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -243,6 +243,15 @@ type BatchSpecWorkspaceStepArgs struct {
 	Index int32
 }
 
+type RenameFieldArgs struct {
+	Repository  string
+	Commit      string
+	File        string
+	Line        int32
+	Character   int32
+	Replacement string
+}
+
 type BatchChangesResolver interface {
 	//
 	// MUTATIONS
@@ -279,6 +288,8 @@ type BatchChangesResolver interface {
 	MergeChangesets(ctx context.Context, args *MergeChangesetsArgs) (BulkOperationResolver, error)
 	CloseChangesets(ctx context.Context, args *CloseChangesetsArgs) (BulkOperationResolver, error)
 	PublishChangesets(ctx context.Context, args *PublishChangesetsArgs) (BulkOperationResolver, error)
+
+	RenameField(ctx context.Context, args *RenameFieldArgs) (string, error)
 
 	// Queries
 	BatchChange(ctx context.Context, args *BatchChangeArgs) (BatchChangeResolver, error)

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -3563,3 +3563,14 @@ type BatchSpecWorkspaceFile implements File2 & Node {
         format: HighlightResponseFormat = HTML_HIGHLIGHT
     ): HighlightedFile!
 }
+
+extend type Mutation {
+    renameField(
+        repository: String!
+        commit: String!
+        file: String!
+        line: Int!
+        character: Int!
+        replacement: String!
+    ): String!
+}

--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 


### PR DESCRIPTION
I didn't really get cross repo code intel to work locally, so no idea if it can handle that, but renaming one symbol worked somewhat in that it generated a spec that felt valid.


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
