### PR TITLE
[db] add index for event logs table user_id_timestamp

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -8087,6 +8087,16 @@
           "IndexDefinition": "CREATE INDEX event_logs_user_id_name ON event_logs USING btree (user_id, name)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
+        },
+        {
+          "Name": "event_logs_user_id_timestamp",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX event_logs_user_id_timestamp ON event_logs USING btree (user_id, \"timestamp\")",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1066,6 +1066,7 @@ Indexes:
     "event_logs_timestamp_at_utc" btree (date(timezone('UTC'::text, "timestamp")))
     "event_logs_user_id" btree (user_id)
     "event_logs_user_id_name" btree (user_id, name)
+    "event_logs_user_id_timestamp" btree (user_id, "timestamp")
 Check constraints:
     "event_logs_check_has_user" CHECK (user_id = 0 AND anonymous_user_id <> ''::text OR user_id <> 0 AND anonymous_user_id = ''::text OR user_id <> 0 AND anonymous_user_id <> ''::text)
     "event_logs_check_name_not_empty" CHECK (name <> ''::text)

--- a/migrations/frontend/1666886757_add_event_logs_user_id_timestamp_index/down.sql
+++ b/migrations/frontend/1666886757_add_event_logs_user_id_timestamp_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS event_logs_user_id_timestamp;

--- a/migrations/frontend/1666886757_add_event_logs_user_id_timestamp_index/metadata.yaml
+++ b/migrations/frontend/1666886757_add_event_logs_user_id_timestamp_index/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_event_logs_user_id_timestamp_index
+parents: [1664897165, 1666598990, 1666717223]

--- a/migrations/frontend/1666886757_add_event_logs_user_id_timestamp_index/metadata.yaml
+++ b/migrations/frontend/1666886757_add_event_logs_user_id_timestamp_index/metadata.yaml
@@ -1,2 +1,3 @@
 name: add_event_logs_user_id_timestamp_index
 parents: [1664897165, 1666598990, 1666717223]
+createIndexConcurrently: true

--- a/migrations/frontend/1666886757_add_event_logs_user_id_timestamp_index/up.sql
+++ b/migrations/frontend/1666886757_add_event_logs_user_id_timestamp_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS event_logs_user_id_timestamp ON event_logs(user_id, timestamp);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -4319,6 +4319,8 @@ CREATE INDEX event_logs_user_id ON event_logs USING btree (user_id);
 
 CREATE INDEX event_logs_user_id_name ON event_logs USING btree (user_id, name);
 
+CREATE INDEX event_logs_user_id_timestamp ON event_logs USING btree (user_id, "timestamp");
+
 CREATE UNIQUE INDEX executor_secrets_unique_key_global ON executor_secrets USING btree (key, scope) WHERE ((namespace_user_id IS NULL) AND (namespace_org_id IS NULL));
 
 CREATE UNIQUE INDEX executor_secrets_unique_key_namespace_org ON executor_secrets USING btree (key, namespace_org_id, scope) WHERE (namespace_org_id IS NOT NULL);


### PR DESCRIPTION
Without this index, the queries to get the last active time of a user can take an unnecessarily long time.

## Test plan

Tested locally and it seems to be working 🤞 
