### PR TITLE
insights: add a worker retry to new backfiller for new and inprogress states

### DIFF
--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -34,6 +34,8 @@ func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*worker
 		OrderByExpression: sqlf.Sprintf("id"), // todo
 		MaxNumResets:      100,
 		StalledMaxAge:     time.Second * 30,
+		RetryAfter:        10 * time.Second,
+		MaxNumRetries:     3,
 	}, config.ObsContext)
 
 	task := inProgressHandler{

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -34,7 +34,7 @@ func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*worker
 		OrderByExpression: sqlf.Sprintf("id"), // todo
 		MaxNumResets:      100,
 		StalledMaxAge:     time.Second * 30,
-		RetryAfter:        10 * time.Second,
+		RetryAfter:        time.Second * 30,
 		MaxNumRetries:     3,
 	}, config.ObsContext)
 

--- a/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
@@ -45,7 +45,7 @@ func makeNewBackfillWorker(ctx context.Context, config JobMonitorConfig) (*worke
 		OrderByExpression: sqlf.Sprintf("id"), // todo
 		MaxNumResets:      100,
 		StalledMaxAge:     time.Second * 30,
-		RetryAfter:        10 * time.Second,
+		RetryAfter:        time.Second * 30,
 		MaxNumRetries:     3,
 	}, config.ObsContext)
 

--- a/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
@@ -45,6 +45,8 @@ func makeNewBackfillWorker(ctx context.Context, config JobMonitorConfig) (*worke
 		OrderByExpression: sqlf.Sprintf("id"), // todo
 		MaxNumResets:      100,
 		StalledMaxAge:     time.Second * 30,
+		RetryAfter:        10 * time.Second,
+		MaxNumRetries:     3,
 	}, config.ObsContext)
 
 	task := newBackfillHandler{


### PR DESCRIPTION
Add a basic retry to new and in progress backfill workers
## Test plan
forced an error in handler and checked logs to see it was retried.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
