### PR TITLE
search ui: don't render lang section in sidebar if there is only one item

### DIFF
--- a/client/search-ui/src/results/sidebar/SearchFilterSection.test.tsx
+++ b/client/search-ui/src/results/sidebar/SearchFilterSection.test.tsx
@@ -27,6 +27,7 @@ describe('SearchSidebarSection', () => {
             </SearchFilterSection>
         )
 
+        expect(screen.getByRole('article')).toBeInTheDocument()
         expect(screen.getAllByTestId('filter-link')).toHaveLength(9)
         expect(screen.getByTestId('sidebar-section-search-box')).toBeInTheDocument()
     })
@@ -85,6 +86,18 @@ describe('SearchSidebarSection', () => {
         )
 
         expect(screen.getAllByTestId('filter-link')).toHaveLength(9)
+        expect(screen.queryByTestId('sidebar-section-search-box')).not.toBeInTheDocument()
+    })
+
+    it('should not render based on minItems', () => {
+        render(
+            <SearchFilterSection sectionId="id" header="Dynamic filters" minItems={2}>
+                {getDynamicFilterLinks([filters[2]], ['file', 'lang', 'utility'], onFilterChosen)}
+            </SearchFilterSection>
+        )
+
+        expect(screen.queryByRole('article')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('filter-link')).not.toBeInTheDocument()
         expect(screen.queryByTestId('sidebar-section-search-box')).not.toBeInTheDocument()
     })
 })

--- a/client/search-ui/src/results/sidebar/SearchFilterSection.tsx
+++ b/client/search-ui/src/results/sidebar/SearchFilterSection.tsx
@@ -22,9 +22,9 @@ export interface SearchFilterSectionProps {
     forcedRender?: boolean
 
     /**
-     * Minimal number of items to render the filter section.
-     * This prop is used for repositories filter section: when we have only
-     * one repo, the repo filter section shouldn't be rendered.
+     * Minimal number of items to render the filter section. Defaults to 1.
+     * This prop is set to 2 for repositories and languages filter sections:
+     * when we have only one repo or language, the section shouldn't be rendered.
      */
     minItems?: number
 
@@ -73,7 +73,7 @@ export const SearchFilterSection: FC<SearchFilterSectionProps> = memo(props => {
         forcedRender = true,
         onToggle,
         startCollapsed,
-        minItems = 0,
+        minItems = 1,
     } = props
 
     const { ariaLabel = '', noResultText = defaultNoResult, clearSearchOnChange = children } = searchOptions ?? {}
@@ -97,7 +97,7 @@ export const SearchFilterSection: FC<SearchFilterSectionProps> = memo(props => {
         // items (usually it's FilterLink components)
     } else if (Array.isArray(children)) {
         // Sometimes we don't need to render filter section with just one item (example - repositories filter section)
-        visible = children.length > minItems
+        visible = children.length >= minItems
 
         // We don't need to have a search UI if we're dealing with only one item
         searchVisible = searchVisible && children.length > 1

--- a/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
+++ b/client/web/src/search/results/sidebar/SearchFiltersSidebar.tsx
@@ -135,7 +135,7 @@ export const SearchFiltersSidebar: FC<PropsWithChildren<SearchFiltersSidebarProp
                 })}
             </SearchSidebarSection>
 
-            <SearchSidebarSection sectionId={SectionID.LANGUAGES} header="Languages">
+            <SearchSidebarSection sectionId={SectionID.LANGUAGES} header="Languages" minItems={2}>
                 {getDynamicFilterLinks(filters, ['lang'], onDynamicFilterClicked, label => `Search ${label} files`)}
             </SearchSidebarSection>
 
@@ -143,7 +143,7 @@ export const SearchFiltersSidebar: FC<PropsWithChildren<SearchFiltersSidebarProp
                 sectionId={SectionID.REPOSITORIES}
                 header="Repositories"
                 searchOptions={{ ariaLabel: 'Find repositories', noResultText: getRepoFilterNoResultText }}
-                minItems={1}
+                minItems={2}
             >
                 {getRepoFilterLinks(repoFilters, onDynamicFilterClicked)}
             </SearchSidebarSection>


### PR DESCRIPTION
Don't render lang section in sidebar if there is only one item (from [Slack suggestion](https://sourcegraph.slack.com/archives/C020S8AT3LN/p1666872001968379)).

Also fixes the semantics of `minItems` to actually mean the minimum number of items to render (instead of the maximum number of items to not render).

## Test plan

- Adds unit tests

## App preview:

- [Web](https://sg-web-jp-langminitems.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
