### PR TITLE
Browser extension: add Microsoft Edge build

### DIFF
--- a/client/browser/package.json
+++ b/client/browser/package.json
@@ -14,6 +14,7 @@
     "dev:no-reload": "AUTO_RELOAD=false yarn run dev",
     "dev:firefox": "if type web-ext 2>/dev/null; then yarn dev & web-ext run --source-dir ./build/firefox; else echo 'web-ext not found. Install it with: yarn global add web-ext'; exit 1; fi",
     "dev:chrome": "TARGETS=chrome yarn run dev",
+    "dev:edge": "TARGETS=edge yarn run dev",
     "dev:safari": "TARGETS=safari yarn run build",
     "prebuild": "yarn -T run generate && yarn run build-inline-extensions",
     "build": "yarn run prebuild && NODE_ENV=production NODE_OPTIONS=--max_old_space_size=8192 node -r ts-node/register scripts/build",

--- a/client/browser/scripts/build.ts
+++ b/client/browser/scripts/build.ts
@@ -10,6 +10,7 @@ import * as tasks from './tasks'
 const buildChrome = tasks.buildChrome('prod')
 const buildFirefox = tasks.buildFirefox('prod')
 const buildSafari = tasks.buildSafari('prod')
+const buildEdge = tasks.buildEdge('prod')
 
 tasks.copyAssets()
 
@@ -27,6 +28,7 @@ compiler.run(async (error, stats) => {
     signale.success('Webpack compilation done')
 
     buildChrome()
+    buildEdge()
     buildFirefox()
     if (isXcodeAvailable()) {
         buildSafari()

--- a/client/browser/scripts/development.ts
+++ b/client/browser/scripts/development.ts
@@ -13,6 +13,7 @@ const triggerReload = process.env.AUTO_RELOAD === 'false' ? noop : autoReloading
 
 const buildChrome = tasks.buildChrome('dev')
 const buildFirefox = tasks.buildFirefox('dev')
+const buildEdge = tasks.buildEdge('dev')
 
 tasks.copyAssets()
 
@@ -36,6 +37,7 @@ compiler.watch(
         signale.success('Webpack compilation done')
 
         buildChrome()
+        buildEdge()
         buildFirefox()
         tasks.copyIntegrationAssets()
         triggerReload()

--- a/client/browser/scripts/tasks.ts
+++ b/client/browser/scripts/tasks.ts
@@ -22,7 +22,7 @@ const EXTENSION_PERMISSIONS_ALL_URLS = Boolean(
 
 export type BuildEnvironment = 'dev' | 'prod'
 
-type Browser = 'firefox' | 'chrome' | 'safari'
+type Browser = 'firefox' | 'chrome' | 'safari' | 'edge'
 
 const BUILDS_DIR = 'build'
 
@@ -52,6 +52,7 @@ function ensurePaths(browser?: Browser): void {
         shelljs.mkdir('-p', `build/${browser}`)
     } else {
         shelljs.mkdir('-p', 'build/chrome')
+        shelljs.mkdir('-p', 'build/edge')
         shelljs.mkdir('-p', 'build/firefox')
         shelljs.mkdir('-p', 'build/safari')
     }
@@ -133,6 +134,7 @@ export function copyIntegrationAssets(): void {
 const BROWSER_TITLES = {
     firefox: 'Firefox',
     chrome: 'Chrome',
+    edge: 'Edge',
     safari: 'Safari',
 } as const
 
@@ -142,6 +144,7 @@ const BROWSER_TITLES = {
 const BROWSER_BUNDLE_ZIPS: Partial<Record<Browser, string>> = {
     firefox: 'firefox-bundle.xpi',
     chrome: 'chrome-bundle.zip',
+    edge: 'edge-bundle.zip',
 }
 
 /**
@@ -149,6 +152,7 @@ const BROWSER_BUNDLE_ZIPS: Partial<Record<Browser, string>> = {
  */
 const BROWSER_BLOCKLIST = {
     chrome: ['applications'] as const,
+    edge: ['applications'] as const,
     firefox: ['key'] as const,
     safari: [] as const,
 }
@@ -241,4 +245,5 @@ const buildForBrowser = curry((browser: Browser, environment: BuildEnvironment):
 
 export const buildFirefox = buildForBrowser('firefox')
 export const buildChrome = buildForBrowser('chrome')
+export const buildEdge = buildForBrowser('edge')
 export const buildSafari = buildForBrowser('safari')


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C01LZKLRF0C/p1666903698088679

Add extension build for the Microsoft Edge browser

Note: We will need to sign up for a [Microsoft Edge partner account](https://learn.microsoft.com/en-us/microsoft-edge/extensions-chromium/publish/create-dev-account#enroll-in-the-microsoft-edge-program-on-partner-center) in order to publish the extension and add it to our release CI.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

1. Run `yarn dev:edge` inside the `client/browser` directory to build the extension for edge
2. Follow the [official instruction ](https://learn.microsoft.com/en-us/microsoft-edge/extensions-chromium/getting-started/extension-sideloading)to sideload the extension pack located in the `client/browser/build/edge` path

Extension installed successfully with Edge on Mac:

![Screen Shot 2022-10-27 at 2 31 47 PM](https://user-images.githubusercontent.com/68532117/198406810-14f28449-aa84-45b5-a6c5-343412d567a8.png)

![Screen Shot 2022-10-27 at 2 25 04 PM](https://user-images.githubusercontent.com/68532117/198406769-5df28ab2-f2e8-44c3-b1c1-6466962ad059.png)

Extension installed successfully  with Edge on Windows 11:

![Screenshot_20221027_031809](https://user-images.githubusercontent.com/68532117/198408930-1dbf9f50-e3fe-4709-8fb4-067b78e1eae6.png)

## App preview:

- [Web](https://sg-web-bee-edge.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
