### PR TITLE
move legacy codeintel to enterprise

### DIFF
--- a/client/shared/src/codeintel/api.ts
+++ b/client/shared/src/codeintel/api.ts
@@ -30,9 +30,7 @@ import { languageSpecs } from './legacy-extensions/language-specs/languages'
 import { RedactingLogger } from './legacy-extensions/logging'
 import { createProviders, emptySourcegraphProviders, SourcegraphProviders } from './legacy-extensions/providers'
 
-export type QueryGraphQLFn<T> = () => Promise<T>
-
-export interface CodeIntelAPI {
+interface CodeIntelAPI {
     hasReferenceProvidersForDocument(textParameters: TextDocumentPositionParameters): Observable<boolean>
     getDefinition(textParameters: TextDocumentPositionParameters): Observable<clientType.Location[]>
     getReferences(
@@ -44,7 +42,7 @@ export interface CodeIntelAPI {
     getDocumentHighlights(textParameters: TextDocumentPositionParameters): Observable<sglegacy.DocumentHighlight[]>
 }
 
-export function newCodeIntelAPI(context: sourcegraph.CodeIntelContext): CodeIntelAPI {
+function newCodeIntelAPI(context: sourcegraph.CodeIntelContext): CodeIntelAPI {
     sourcegraph.updateCodeIntelContext(context)
     return new DefaultCodeIntelAPI()
 }

--- a/client/shared/src/codeintel/legacy-extensions/util/api.ts
+++ b/client/shared/src/codeintel/legacy-extensions/util/api.ts
@@ -575,8 +575,10 @@ export class API {
             __type: { fields: { name: string }[] }
         }
 
-        return (await queryGraphQL<IntrospectionResponse>(introspectionQuery)).__type.fields.some(
-            field => field.name === 'stencil'
+        return Boolean(
+            (await queryGraphQL<IntrospectionResponse>(introspectionQuery)).__type?.fields.some(
+                field => field.name === 'stencil'
+            )
         )
     }
 }

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -58,7 +58,6 @@ import {
     useSessionStorage,
 } from '@sourcegraph/wildcard'
 
-import { useCodeIntel } from '../enterprise/codeintel/useCodeIntel'
 import { ReferencesPanelHighlightedBlobResult, ReferencesPanelHighlightedBlobVariables } from '../graphql-operations'
 import { Blob } from '../repo/blob/Blob'
 import { Blob as CodeMirrorBlob } from '../repo/blob/CodeMirrorBlob'
@@ -73,6 +72,8 @@ import { findSearchToken } from './token'
 import { useRepoAndBlob } from './useRepoAndBlob'
 import { isDefined } from './util/helpers'
 
+import { CodeIntelligenceProps } from '.'
+
 import styles from './ReferencesPanel.module.scss'
 
 type Token = HoveredToken & RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec
@@ -84,6 +85,7 @@ interface HighlightedFileLineRangesProps {
 export interface ReferencesPanelProps
     extends SettingsCascadeProps,
         PlatformContextProps<'urlToFile' | 'requestGraphQL' | 'settings'>,
+        Pick<CodeIntelligenceProps, 'useCodeIntel'>,
         TelemetryProps,
         HoverThresholdProps,
         ExtensionsControllerProps,
@@ -157,6 +159,11 @@ export const RevisionResolvingReferencesList: React.FunctionComponent<
         return <>Nothing found</>
     }
 
+    const useCodeIntel = props.useCodeIntel
+    if (!useCodeIntel) {
+        return <>Code intelligence is not available</>
+    }
+
     const token = {
         repoName: props.repoName,
         line: props.line,
@@ -169,6 +176,7 @@ export const RevisionResolvingReferencesList: React.FunctionComponent<
     return (
         <SearchTokenFindingReferencesList
             {...props}
+            useCodeIntel={useCodeIntel}
             token={token}
             isFork={data.isFork}
             isArchived={data.isArchived}
@@ -182,6 +190,7 @@ interface ReferencesPanelPropsWithToken extends ReferencesPanelProps {
     isFork: boolean
     isArchived: boolean
     fileContent: string
+    useCodeIntel: NonNullable<ReferencesPanelProps['useCodeIntel']>
 }
 
 const SearchTokenFindingReferencesList: React.FunctionComponent<
@@ -223,7 +232,7 @@ const SearchTokenFindingReferencesList: React.FunctionComponent<
 
 const SHOW_SPINNER_DELAY_MS = 100
 
-export const ReferencesList: React.FunctionComponent<
+const ReferencesList: React.FunctionComponent<
     React.PropsWithChildren<
         ReferencesPanelPropsWithToken & {
             searchToken: string
@@ -251,7 +260,7 @@ export const ReferencesList: React.FunctionComponent<
         fetchMoreImplementations,
         fetchMoreReferencesLoading,
         fetchMoreImplementationsLoading,
-    } = useCodeIntel({
+    } = props.useCodeIntel({
         variables: {
             repository: props.token.repoName,
             commit: props.token.commitID,

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -58,6 +58,7 @@ import {
     useSessionStorage,
 } from '@sourcegraph/wildcard'
 
+import { useCodeIntel } from '../enterprise/codeintel/useCodeIntel'
 import { ReferencesPanelHighlightedBlobResult, ReferencesPanelHighlightedBlobVariables } from '../graphql-operations'
 import { Blob } from '../repo/blob/Blob'
 import { Blob as CodeMirrorBlob } from '../repo/blob/CodeMirrorBlob'
@@ -69,7 +70,6 @@ import { Location, LocationGroup, locationGroupQuality, buildRepoLocationGroups,
 import { FETCH_HIGHLIGHTED_BLOB } from './ReferencesPanelQueries'
 import { newSettingsGetter } from './settings'
 import { findSearchToken } from './token'
-import { useCodeIntel } from './useCodeIntel'
 import { useRepoAndBlob } from './useRepoAndBlob'
 import { isDefined } from './util/helpers'
 

--- a/client/web/src/codeintel/index.ts
+++ b/client/web/src/codeintel/index.ts
@@ -1,4 +1,5 @@
 import { CodeIntelligenceBadge } from './CodeIntelligenceBadge'
+import { UseCodeIntel } from './useCodeIntel'
 
 /**
  * Common props for components needing to decide whether to show Code navigation
@@ -7,4 +8,5 @@ export interface CodeIntelligenceProps {
     codeIntelligenceEnabled: boolean
     codeIntelligenceBadgeMenu?: typeof CodeIntelligenceBadge
     codeIntelligenceBadgeContent?: typeof CodeIntelligenceBadge
+    useCodeIntel?: UseCodeIntel
 }

--- a/client/web/src/codeintel/searchBased.ts
+++ b/client/web/src/codeintel/searchBased.ts
@@ -1,0 +1,31 @@
+import { Range } from '@sourcegraph/extension-api-types'
+
+export interface Result {
+    /** The name of the repository containing the result. */
+    repo: string
+
+    /** The commit containing the result. */
+    rev: string
+
+    /** The path to the result file relative to the repository root. */
+    file: string
+
+    /** The content of the file. */
+    content: string
+
+    /** The unique URL to this result. */
+
+    url: string
+
+    /** The range of the match. */
+    range: Range
+
+    /** The type of symbol, if the result came from a symbol search. */
+    symbolKind?: string
+
+    /**
+     * Whether or not the symbol is local to the containing file, if
+     * the result came from a symbol search.
+     */
+    fileLocal?: boolean
+}

--- a/client/web/src/codeintel/useCodeIntel.ts
+++ b/client/web/src/codeintel/useCodeIntel.ts
@@ -1,0 +1,53 @@
+import { ErrorLike } from '@sourcegraph/common'
+import { LanguageSpec } from '@sourcegraph/shared/src/codeintel/legacy-extensions/language-specs/language-spec'
+
+import { ConnectionQueryArguments } from '../components/FilteredConnection'
+import { UsePreciseCodeIntelForPositionVariables } from '../graphql-operations'
+
+import { Location } from './location'
+import { SettingsGetter } from './settings'
+
+export interface CodeIntelData {
+    references: {
+        endCursor: string | null
+        nodes: Location[]
+    }
+    implementations: {
+        endCursor: string | null
+        nodes: Location[]
+    }
+    definitions: {
+        endCursor: string | null
+        nodes: Location[]
+    }
+}
+
+export interface UseCodeIntelResult {
+    data?: CodeIntelData
+    error?: ErrorLike
+    loading: boolean
+
+    referencesHasNextPage: boolean
+    fetchMoreReferences: () => void
+    fetchMoreReferencesLoading: boolean
+
+    implementationsHasNextPage: boolean
+    fetchMoreImplementations: () => void
+    fetchMoreImplementationsLoading: boolean
+}
+
+export interface UseCodeIntelParameters {
+    variables: UsePreciseCodeIntelForPositionVariables & ConnectionQueryArguments
+
+    searchToken: string
+    fileContent: string
+
+    spec: LanguageSpec
+
+    isFork: boolean
+    isArchived: boolean
+
+    getSetting: SettingsGetter
+}
+
+export type UseCodeIntel = (params: UseCodeIntelParameters) => UseCodeIntelResult

--- a/client/web/src/enterprise/EnterpriseWebApp.tsx
+++ b/client/web/src/enterprise/EnterpriseWebApp.tsx
@@ -6,6 +6,7 @@ import { SourcegraphWebApp } from '../SourcegraphWebApp'
 
 import { CodeIntelligenceBadgeContent } from './codeintel/badge/components/CodeIntelligenceBadgeContent'
 import { CodeIntelligenceBadgeMenu } from './codeintel/badge/components/CodeIntelligenceBadgeMenu'
+import { useCodeIntel } from './codeintel/useCodeIntel'
 import { enterpriseExtensionAreaHeaderNavItems } from './extensions/extension/extensionAreaHeaderNavItems'
 import { enterpriseExtensionAreaRoutes } from './extensions/extension/routes'
 import { enterpriseExtensionsAreaHeaderActionButtons } from './extensions/extensionsAreaHeaderActionButtons'
@@ -55,6 +56,7 @@ export const EnterpriseWebApp: React.FunctionComponent<React.PropsWithChildren<u
         codeIntelligenceEnabled={true}
         codeIntelligenceBadgeMenu={CodeIntelligenceBadgeMenu}
         codeIntelligenceBadgeContent={CodeIntelligenceBadgeContent}
+        useCodeIntel={useCodeIntel}
         codeInsightsEnabled={true}
         batchChangesEnabled={window.context.batchChangesEnabled}
         searchContextsEnabled={true}

--- a/client/web/src/enterprise/codeintel/searchBased.ts
+++ b/client/web/src/enterprise/codeintel/searchBased.ts
@@ -6,9 +6,9 @@ import { appendLineRangeQueryParameter, toPositionOrRangeQueryParameter } from '
 import { Range } from '@sourcegraph/extension-api-types'
 import { LanguageSpec } from '@sourcegraph/shared/src/codeintel/legacy-extensions/language-specs/language-spec'
 
-import { raceWithDelayOffset } from './promise'
-import { SettingsGetter } from './settings'
-import { isDefined } from './util/helpers'
+import { raceWithDelayOffset } from '../../codeintel/promise'
+import { SettingsGetter } from '../../codeintel/settings'
+import { isDefined } from '../../codeintel/util/helpers'
 
 export function definitionQuery({
     searchToken,

--- a/client/web/src/enterprise/codeintel/searchBased.ts
+++ b/client/web/src/enterprise/codeintel/searchBased.ts
@@ -7,6 +7,7 @@ import { Range } from '@sourcegraph/extension-api-types'
 import { LanguageSpec } from '@sourcegraph/shared/src/codeintel/legacy-extensions/language-specs/language-spec'
 
 import { raceWithDelayOffset } from '../../codeintel/promise'
+import { Result } from '../../codeintel/searchBased'
 import { SettingsGetter } from '../../codeintel/settings'
 import { isDefined } from '../../codeintel/util/helpers'
 
@@ -293,36 +294,6 @@ export interface SearchSymbol {
 export interface LineMatch {
     lineNumber: number
     offsetAndLengths: [number, number][]
-}
-
-export interface Result {
-    /** The name of the repository containing the result. */
-    repo: string
-
-    /** The commit containing the result. */
-    rev: string
-
-    /** The path to the result file relative to the repository root. */
-    file: string
-
-    /** The content of the file. */
-    content: string
-
-    /** The unique URL to this result. */
-
-    url: string
-
-    /** The range of the match. */
-    range: Range
-
-    /** The type of symbol, if the result came from a symbol search. */
-    symbolKind?: string
-
-    /**
-     * Whether or not the symbol is local to the containing file, if
-     * the result came from a symbol search.
-     */
-    fileLocal?: boolean
 }
 
 /**

--- a/client/web/src/enterprise/codeintel/sort.ts
+++ b/client/web/src/enterprise/codeintel/sort.ts
@@ -1,6 +1,6 @@
 import { sortBy } from 'lodash'
 
-import { Location } from './location'
+import { Location } from '../../codeintel/location'
 
 /**
  * Sort the locations by their url field's (which is a relative path, e.g.

--- a/client/web/src/enterprise/codeintel/useCodeIntel.ts
+++ b/client/web/src/enterprise/codeintel/useCodeIntel.ts
@@ -2,9 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 
 import { QueryResult } from '@apollo/client'
 
-import { ErrorLike } from '@sourcegraph/common'
 import { dataOrThrowErrors, useLazyQuery, useQuery } from '@sourcegraph/http-client'
-import { LanguageSpec } from '@sourcegraph/shared/src/codeintel/legacy-extensions/language-specs/language-spec'
 
 import { Location, buildPreciseLocation } from '../../codeintel/location'
 import {
@@ -12,7 +10,7 @@ import {
     LOAD_ADDITIONAL_REFERENCES_QUERY,
     USE_PRECISE_CODE_INTEL_FOR_POSITION_QUERY,
 } from '../../codeintel/ReferencesPanelQueries'
-import { SettingsGetter } from '../../codeintel/settings'
+import { CodeIntelData, UseCodeIntelParameters, UseCodeIntelResult } from '../../codeintel/useCodeIntel'
 import { ConnectionQueryArguments } from '../../components/FilteredConnection'
 import { asGraphQLResult } from '../../components/FilteredConnection/utils'
 import {
@@ -26,53 +24,10 @@ import {
 
 import { useSearchBasedCodeIntel } from './useSearchBasedCodeIntel'
 
-interface CodeIntelData {
-    references: {
-        endCursor: string | null
-        nodes: Location[]
-    }
-    implementations: {
-        endCursor: string | null
-        nodes: Location[]
-    }
-    definitions: {
-        endCursor: string | null
-        nodes: Location[]
-    }
-}
-
 const EMPTY_CODE_INTEL_DATA = {
     implementations: { endCursor: null, nodes: [] },
     definitions: { endCursor: null, nodes: [] },
     references: { endCursor: null, nodes: [] },
-}
-
-export interface UseCodeIntelResult {
-    data?: CodeIntelData
-    error?: ErrorLike
-    loading: boolean
-
-    referencesHasNextPage: boolean
-    fetchMoreReferences: () => void
-    fetchMoreReferencesLoading: boolean
-
-    implementationsHasNextPage: boolean
-    fetchMoreImplementations: () => void
-    fetchMoreImplementationsLoading: boolean
-}
-
-interface UseCodeIntelParameters {
-    variables: UsePreciseCodeIntelForPositionVariables & ConnectionQueryArguments
-
-    searchToken: string
-    fileContent: string
-
-    spec: LanguageSpec
-
-    isFork: boolean
-    isArchived: boolean
-
-    getSetting: SettingsGetter
 }
 
 export const useCodeIntel = ({

--- a/client/web/src/enterprise/codeintel/useCodeIntel.ts
+++ b/client/web/src/enterprise/codeintel/useCodeIntel.ts
@@ -6,8 +6,15 @@ import { ErrorLike } from '@sourcegraph/common'
 import { dataOrThrowErrors, useLazyQuery, useQuery } from '@sourcegraph/http-client'
 import { LanguageSpec } from '@sourcegraph/shared/src/codeintel/legacy-extensions/language-specs/language-spec'
 
-import { ConnectionQueryArguments } from '../components/FilteredConnection'
-import { asGraphQLResult } from '../components/FilteredConnection/utils'
+import { Location, buildPreciseLocation } from '../../codeintel/location'
+import {
+    LOAD_ADDITIONAL_IMPLEMENTATIONS_QUERY,
+    LOAD_ADDITIONAL_REFERENCES_QUERY,
+    USE_PRECISE_CODE_INTEL_FOR_POSITION_QUERY,
+} from '../../codeintel/ReferencesPanelQueries'
+import { SettingsGetter } from '../../codeintel/settings'
+import { ConnectionQueryArguments } from '../../components/FilteredConnection'
+import { asGraphQLResult } from '../../components/FilteredConnection/utils'
 import {
     UsePreciseCodeIntelForPositionVariables,
     UsePreciseCodeIntelForPositionResult,
@@ -15,15 +22,8 @@ import {
     LoadAdditionalReferencesVariables,
     LoadAdditionalImplementationsResult,
     LoadAdditionalImplementationsVariables,
-} from '../graphql-operations'
+} from '../../graphql-operations'
 
-import { Location, buildPreciseLocation } from './location'
-import {
-    LOAD_ADDITIONAL_IMPLEMENTATIONS_QUERY,
-    LOAD_ADDITIONAL_REFERENCES_QUERY,
-    USE_PRECISE_CODE_INTEL_FOR_POSITION_QUERY,
-} from './ReferencesPanelQueries'
-import { SettingsGetter } from './settings'
 import { useSearchBasedCodeIntel } from './useSearchBasedCodeIntel'
 
 interface CodeIntelData {

--- a/client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.ts
+++ b/client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.ts
@@ -11,11 +11,13 @@ import { LanguageSpec } from '@sourcegraph/shared/src/codeintel/legacy-extension
 import { searchContext } from '@sourcegraph/shared/src/codeintel/searchContext'
 import { toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
 
-import { getWebGraphQLClient } from '../backend/graphql'
-import { CodeIntelSearch2Variables } from '../graphql-operations'
+import { getWebGraphQLClient } from '../../backend/graphql'
+import { Location, buildSearchBasedLocation, split } from '../../codeintel/location'
+import { CODE_INTEL_SEARCH_QUERY, LOCAL_CODE_INTEL_QUERY } from '../../codeintel/ReferencesPanelQueries'
+import { SettingsGetter } from '../../codeintel/settings'
+import { isDefined } from '../../codeintel/util/helpers'
+import { CodeIntelSearch2Variables } from '../../graphql-operations'
 
-import { Location, buildSearchBasedLocation, split } from './location'
-import { CODE_INTEL_SEARCH_QUERY, LOCAL_CODE_INTEL_QUERY } from './ReferencesPanelQueries'
 import {
     definitionQuery,
     isExternalPrivateSymbol,
@@ -25,9 +27,7 @@ import {
     searchResultToResults,
     searchWithFallback,
 } from './searchBased'
-import { SettingsGetter } from './settings'
 import { sortByProximity } from './sort'
-import { isDefined } from './util/helpers'
 
 type LocationHandler = (locations: Location[]) => void
 

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -56,6 +56,7 @@ export interface RepoRevisionContainerContext
         SearchStreamingProps,
         Pick<StreamingSearchResultsListProps, 'fetchHighlightedFileLineRanges'>,
         BatchChangesProps,
+        Pick<CodeIntelligenceProps, 'codeIntelligenceEnabled' | 'useCodeIntel'>,
         CodeInsightsProps {
     repo: RepositoryFields | undefined
     resolvedRevision: ResolvedRevision | undefined

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -77,7 +77,7 @@ interface BlobPageProps
         SearchStreamingProps,
         Pick<SearchContextProps, 'searchContextsEnabled'>,
         Pick<StreamingSearchResultsListProps, 'fetchHighlightedFileLineRanges'>,
-        Pick<CodeIntelligenceProps, 'codeIntelligenceEnabled'> {
+        Pick<CodeIntelligenceProps, 'codeIntelligenceEnabled' | 'useCodeIntel'> {
     location: H.Location
     history: H.History
     authenticatedUser: AuthenticatedUser | null

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -26,6 +26,7 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { AbsoluteRepoFile, ModeSpec, parseQueryAndHash, UIPositionSpec } from '@sourcegraph/shared/src/util/url'
 import { useObservable } from '@sourcegraph/wildcard'
 
+import { CodeIntelligenceProps } from '../../../codeintel'
 import { ReferencesPanelWithMemoryRouter } from '../../../codeintel/ReferencesPanel'
 import { RepoRevisionSidebarCommits } from '../../RepoRevisionSidebarCommits'
 
@@ -37,6 +38,7 @@ interface Props
         ActivationProps,
         ThemeProps,
         PlatformContextProps,
+        Pick<CodeIntelligenceProps, 'useCodeIntel'>,
         TelemetryProps {
     location: H.Location
     history: H.History
@@ -80,6 +82,7 @@ function useBlobPanelViews({
     settingsCascade,
     isLightTheme,
     platformContext,
+    useCodeIntel,
     telemetryService,
     fetchHighlightedFileLineRanges,
 }: Props): void {
@@ -269,6 +272,7 @@ function useBlobPanelViews({
                                     externalHistory={history}
                                     externalLocation={location}
                                     fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
+                                    useCodeIntel={useCodeIntel}
                                 />
                             ) : (
                                 <></>
@@ -280,16 +284,17 @@ function useBlobPanelViews({
 
             return panelDefinitions
         }, [
-            isTabbedReferencesPanelEnabled,
-            createLocationProvider,
             panelSubjectChanges,
-            preferAbsoluteTimestamps,
-            isLightTheme,
-            settingsCascade,
-            telemetryService,
-            platformContext,
+            isTabbedReferencesPanelEnabled,
             extensionsController,
+            preferAbsoluteTimestamps,
+            createLocationProvider,
+            settingsCascade,
+            platformContext,
+            isLightTheme,
+            telemetryService,
             fetchHighlightedFileLineRanges,
+            useCodeIntel,
         ])
     )
 


### PR DESCRIPTION
The search-based code intelligence is an enterprise-only feature. This change clarifies it by showing a nicer message instead of an error if it's attempted to be used in the OSS build. It also cleans up how the enabled-or-not flag is determined in code.

Also cleans up other things related to code nav when running in OSS.

## Test plan

Confirm the "unavailable" message shows up in OSS:

![cina](https://user-images.githubusercontent.com/1976/198465728-b0aab1ce-76e6-4652-93d6-3edcda226289.png)

Confirm the references panel still works in non-OSS:

![cienabled](https://user-images.githubusercontent.com/1976/198465854-42753abb-91e5-4d8b-8011-728ee1aee29e.png)

## App preview:

- [Web](https://sg-web-sqs-codeintel-enterprise.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
