### PR TITLE
search: add search mode param to app URL

### DIFF
--- a/client/web/src/search/index.test.ts
+++ b/client/web/src/search/index.test.ts
@@ -3,6 +3,7 @@ import { of, Subscription, Observable } from 'rxjs'
 import { first, startWith, tap, last } from 'rxjs/operators'
 
 import { resetAllMemoizationCaches } from '@sourcegraph/common'
+import { SearchMode } from '@sourcegraph/search'
 
 import { SearchPatternType } from '../graphql-operations'
 import { observeLocation } from '../util/location'
@@ -22,6 +23,7 @@ describe('search/index', () => {
             query: 'TEST repo:sourcegraph/sourcegraph',
             patternType: SearchPatternType.standard,
             caseSensitive: true,
+            searchMode: SearchMode.Precise,
         })
 
         expect(
@@ -30,6 +32,7 @@ describe('search/index', () => {
             query: 'TEST repo:sourcegraph/sourcegraph',
             patternType: SearchPatternType.standard,
             caseSensitive: false,
+            searchMode: SearchMode.Precise,
         })
 
         expect(
@@ -38,12 +41,14 @@ describe('search/index', () => {
             query: 'TEST repo:sourcegraph/sourcegraph',
             patternType: SearchPatternType.regexp,
             caseSensitive: true,
+            searchMode: SearchMode.Precise,
         })
 
         expect(parseSearchURL('q=TEST+repo:sourcegraph/sourcegraph+case:yes&patternType=standard')).toStrictEqual({
             query: 'TEST repo:sourcegraph/sourcegraph',
             patternType: SearchPatternType.standard,
             caseSensitive: true,
+            searchMode: SearchMode.Precise,
         })
 
         expect(
@@ -54,12 +59,14 @@ describe('search/index', () => {
             query: 'TEST repo:sourcegraph/sourcegraph',
             patternType: SearchPatternType.regexp,
             caseSensitive: false,
+            searchMode: SearchMode.Precise,
         })
 
         expect(parseSearchURL('q=TEST+repo:sourcegraph/sourcegraph&patternType=standard')).toStrictEqual({
             query: 'TEST repo:sourcegraph/sourcegraph',
             patternType: SearchPatternType.standard,
             caseSensitive: false,
+            searchMode: SearchMode.Precise,
         })
     })
 
@@ -72,6 +79,7 @@ describe('search/index', () => {
             query: 'TEST repo:sourcegraph/sourcegraph case:yes',
             patternType: SearchPatternType.standard,
             caseSensitive: true,
+            searchMode: SearchMode.Precise,
         })
 
         expect(
@@ -82,6 +90,7 @@ describe('search/index', () => {
             query: 'TEST repo:sourcegraph/sourcegraph',
             patternType: SearchPatternType.standard,
             caseSensitive: false,
+            searchMode: SearchMode.Precise,
         })
 
         expect(
@@ -92,6 +101,7 @@ describe('search/index', () => {
             query: 'TEST repo:sourcegraph/sourcegraph case:yes',
             patternType: SearchPatternType.regexp,
             caseSensitive: true,
+            searchMode: SearchMode.Precise,
         })
 
         expect(
@@ -102,6 +112,7 @@ describe('search/index', () => {
             query: 'TEST repo:sourcegraph/sourcegraph case:yes',
             patternType: SearchPatternType.standard,
             caseSensitive: true,
+            searchMode: SearchMode.Precise,
         })
 
         expect(
@@ -113,6 +124,7 @@ describe('search/index', () => {
             query: 'TEST repo:sourcegraph/sourcegraph',
             patternType: SearchPatternType.regexp,
             caseSensitive: false,
+            searchMode: SearchMode.Precise,
         })
 
         expect(
@@ -121,6 +133,7 @@ describe('search/index', () => {
             query: 'TEST repo:sourcegraph/sourcegraph',
             patternType: SearchPatternType.standard,
             caseSensitive: false,
+            searchMode: SearchMode.Precise,
         })
     })
 
@@ -129,18 +142,21 @@ describe('search/index', () => {
             query: 'content:"/a literal pattern/"',
             patternType: SearchPatternType.standard,
             caseSensitive: false,
+            searchMode: SearchMode.Precise,
         })
 
         expect(parseSearchURL('q=not /a literal pattern/&patternType=literal')).toStrictEqual({
             query: 'not content:"/a literal pattern/"',
             patternType: SearchPatternType.standard,
             caseSensitive: false,
+            searchMode: SearchMode.Precise,
         })
 
         expect(parseSearchURL('q=un.*touched&patternType=literal')).toStrictEqual({
             query: 'un.*touched',
             patternType: SearchPatternType.standard,
             caseSensitive: false,
+            searchMode: SearchMode.Precise,
         })
     })
 })

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -84,6 +84,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
     // Global state
     const caseSensitive = useNavbarQueryState(state => state.searchCaseSensitivity)
     const patternType = useNavbarQueryState(state => state.searchPatternType)
+    const searchMode = useNavbarQueryState(state => state.searchMode)
     const liveQuery = useNavbarQueryState(state => state.queryState.query)
     const submittedURLQuery = useNavbarQueryState(state => state.searchQueryFromURL)
     const setQueryState = useNavbarQueryState(state => state.setQueryState)
@@ -106,10 +107,10 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
             patternType: patternType ?? SearchPatternType.standard,
             caseSensitive,
             trace,
-            searchMode: patternType === SearchPatternType.lucky ? SearchMode.SmartSearch : SearchMode.Precise,
+            searchMode: patternType === SearchPatternType.lucky ? SearchMode.SmartSearch : searchMode,
             chunkMatches: true,
         }),
-        [caseSensitive, patternType, trace]
+        [caseSensitive, patternType, searchMode, trace]
     )
 
     const results = useCachedSearchResults(streamSearch, submittedURLQuery, options, extensionHostAPI, telemetryService)

--- a/client/web/src/stores/navbarSearchQueryState.ts
+++ b/client/web/src/stores/navbarSearchQueryState.ts
@@ -76,7 +76,12 @@ export function setQueryStateFromURL(parsedSearchURL: ParsedSearchURL, query = p
     const newState: Partial<
         Pick<
             NavbarQueryState,
-            'queryState' | 'searchPatternType' | 'searchCaseSensitivity' | 'searchQueryFromURL' | 'parametersSource'
+            | 'queryState'
+            | 'searchPatternType'
+            | 'searchCaseSensitivity'
+            | 'searchQueryFromURL'
+            | 'parametersSource'
+            | 'searchMode'
         >
     > = {}
 
@@ -89,6 +94,7 @@ export function setQueryStateFromURL(parsedSearchURL: ParsedSearchURL, query = p
         }
         newState.queryState = { query }
         newState.searchQueryFromURL = parsedSearchURL.query
+        newState.searchMode = parsedSearchURL.searchMode
     }
 
     // The way Zustand is designed makes it difficult to build up a partial new


### PR DESCRIPTION
This allows our app to recognize the `sm` (search mode) URL param, parse it, and propagate it to enable smart search requests to the backend.

Currently we don't set `sm` in the URL yet, so this change doesn't affect any existing behavior yet. It just means that when `sm=0` vs `sm=1` is set, then our app parses these values and sets `searchMode` in internal app state.

In next PRs I will introduce a setting to enable search mode and [parse here](https://github.com/sourcegraph/sourcegraph/pull/43581/files#diff-5d9811fc675ac3aef136b5e996d2598f5f90386b541ee676dcabfed33feeee4aR108), and explicitly setting URL `sm` param based on search mode. Just trying to break up changes because the state is all over the web app.


## Test plan
Updated tests

## App preview:

- [Web](https://sg-web-rvt-search-mode-url.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

