### PR TITLE
Add index on event_logs(user_id, name)

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -8077,6 +8077,16 @@
           "IndexDefinition": "CREATE INDEX event_logs_user_id ON event_logs USING btree (user_id)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
+        },
+        {
+          "Name": "event_logs_user_id_name",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX event_logs_user_id_name ON event_logs USING btree (user_id, name)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1065,6 +1065,7 @@ Indexes:
     "event_logs_timestamp" btree ("timestamp")
     "event_logs_timestamp_at_utc" btree (date(timezone('UTC'::text, "timestamp")))
     "event_logs_user_id" btree (user_id)
+    "event_logs_user_id_name" btree (user_id, name)
 Check constraints:
     "event_logs_check_has_user" CHECK (user_id = 0 AND anonymous_user_id <> ''::text OR user_id <> 0 AND anonymous_user_id = ''::text OR user_id <> 0 AND anonymous_user_id <> ''::text)
     "event_logs_check_name_not_empty" CHECK (name <> ''::text)

--- a/migrations/frontend/1666939263_add_index_on_event_logs_user_id_name/down.sql
+++ b/migrations/frontend/1666939263_add_index_on_event_logs_user_id_name/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS event_logs_user_id_name;

--- a/migrations/frontend/1666939263_add_index_on_event_logs_user_id_name/metadata.yaml
+++ b/migrations/frontend/1666939263_add_index_on_event_logs_user_id_name/metadata.yaml
@@ -1,0 +1,3 @@
+name: add_index_on_event_logs_user_id_name
+parents: [1664897165, 1666344635, 1666598990, 1666717223]
+createIndexConcurrently: true

--- a/migrations/frontend/1666939263_add_index_on_event_logs_user_id_name/up.sql
+++ b/migrations/frontend/1666939263_add_index_on_event_logs_user_id_name/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS event_logs_user_id_name ON event_logs (user_id, name);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -4317,6 +4317,8 @@ CREATE INDEX event_logs_timestamp_at_utc ON event_logs USING btree (date(timezon
 
 CREATE INDEX event_logs_user_id ON event_logs USING btree (user_id);
 
+CREATE INDEX event_logs_user_id_name ON event_logs USING btree (user_id, name);
+
 CREATE UNIQUE INDEX executor_secrets_unique_key_global ON executor_secrets USING btree (key, scope) WHERE ((namespace_user_id IS NULL) AND (namespace_org_id IS NULL));
 
 CREATE UNIQUE INDEX executor_secrets_unique_key_namespace_org ON executor_secrets USING btree (key, namespace_org_id, scope) WHERE (namespace_org_id IS NOT NULL);


### PR DESCRIPTION
Customers report dramatic performance decrease after switching to 4.0.1.

This adds an index that makes the large number of

    select max(timestamp) from event_logs where user_id = $1 and name = $2

queries that customers are seeing faster.

It doesn't explain why the queries are now appearing, though. Investigating.

## Test plan

- N/A
