### PR TITLE
search: set smart search mode bitmask value to 1

### DIFF
--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -49,7 +49,7 @@ type Mode int
 
 const (
 	Precise     Mode = 0
-	SmartSearch      = 1 << iota
+	SmartSearch      = 1 << (iota - 1)
 )
 
 type Protocol int


### PR DESCRIPTION
Previously this `1 << iota` value evaluated to `2` but the bitmask should start at `1` (same as client) and go from there.

## Test plan
Manual, not used yet.
