### PR TITLE
Inc 153 advisement doc

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1352,6 +1352,11 @@ type Query {
         Returns users who have NOT been active since a given point in time.
         """
         inactiveSince: DateTime
+
+        """
+        Returns users that have at any point in time been active.
+        """
+        hasBeenActive: Bool
     ): UserConnection!
     """
     Looks up an organization by name.

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -21,6 +21,7 @@ type usersArgs struct {
 	Tag           *string
 	ActivePeriod  *string
 	InactiveSince *gqlutil.DateTime
+	HasBeenActive *bool
 }
 
 func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
@@ -33,6 +34,9 @@ func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
 	}
 	if args.InactiveSince != nil {
 		opt.InactiveSince = args.InactiveSince.Time
+	}
+	if args.HasBeenActive != nil {
+		opt.HasBeenActive = *args.HasBeenActive
 	}
 	args.ConnectionArgs.Set(&opt.LimitOffset)
 	return &userConnectionResolver{db: r.db, opt: opt, activePeriod: args.ActivePeriod}

--- a/doc/admin/how-to/index.md
+++ b/doc/admin/how-to/index.md
@@ -25,3 +25,4 @@
 - [How to address common monorepo problems](monorepo-issues.md)
 - [How to Set a password for Redis using a ConfigMap](redis_configmap.md)
 - [How to import a set of internal repositories to Sourcegraph](internal_github_repos.md)
+- [How to address index corruption from postgres-14](postgres-14-index-corruption.md)

--- a/doc/admin/how-to/postgres-14-index-corruption.md
+++ b/doc/admin/how-to/postgres-14-index-corruption.md
@@ -1,0 +1,46 @@
+# How to identify and resolve index corruption in Postgres v14.0 - v14.3
+
+A bug has ben identified in PostgreSQL 14.0-14.3 that can cause database index corruption in indexes created concurrently. Sourcegraph [utilizes](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+CREATE+INDEX+AND+CONCURRENTLY&patternType=standard) concurrent index creation, and if you are on these versions, you may experience slow queries or database corruption. To learn more about this bug see postgres's [out-of-cycle release announcment](https://www.postgresql.org/message-id/165473835807.573551.1512237163040609764%40wrigleys.postgresql.org) or [migops article](https://www.migops.com/blog/important-postgresql-14-update-to-avoid-silent-corruption-of-indexes/) on the subject.
+
+## Identify your database version
+To identify which version of Sourcegraph you are running in a default Sourcegraph deployment. You can access your database via the `docker` or `kubectl` cli tools and run the following command:
+```
+SELECT version();
+```
+> NOTE: You can refer to the following instructions for accessing databases on your deployment type: [Docker Compose](../deploy/docker-compose/index.md#access-the-database), [Kubernetes](../deploy/kubernetes/operations.md#access-the-database).
+
+You may also check for index corruption in your database using the `amcheck` by running the following query in your database
+```
+create extension amcheck;
+
+select bt_index_parent_check(c.oid, true), c.relname, c.relpages
+from pg_index i
+join pg_opclass op ON i.indclass[0] = op.oid
+join pg_am am ON op.opcmethod = am.oid
+join pg_class c ON i.indexrelid = c.oid
+join pg_namespace n ON c.relnamespace = n.oid
+where am.amname = 'btree'
+-- Don't check temp tables, which may be from another session:
+and c.relpersistence != 't'
+-- Function may throw an error when this is omitted:
+and i.indisready AND i.indisvalid;
+```
+This query will return error if there are corrupted indexes. 
+
+## Resolve
+If you are impacted, you can remediate this by upgrading to a newer version of Postgres (14.4+) and running the following commands in your database
+
+Determine database name:
+```
+SELECT current_database();
+```
+```
+REINDEX DATABASE <dbname>;
+```
+*You may want to use the amcheck query above to verify the reindex has resolved index corruption.*
+
+### Upgrading your database
+
+In default Sourcegraph deployments internal PostgreSQL instances are used and may be upgraded via the [pg_upgrade](https://www.postgresql.org/docs/11/pgupgrade.html). For external databases consult your service providers documentation. For a deeper look at database upgrade operations please consult our [PostgreSQL documentation](https://docs.sourcegraph.com/admin/postgres#upgrading-postgresql).
+
+If you have any questions, please reach out to support on Slack or email support@sourcegraph.com.


### PR DESCRIPTION

Hey all this doc is intended to be linked in official comms to be sent out relating to `inc-153-postgres-14-can-cause-index-corruption` ([context](https://sourcegraph.slack.com/archives/CU93UDUBV/p1666861659779429))

I've linked to previous documentation on upgrading postgres in a Sourcegraph deployment and it'd be good to validate that those linked docs still make sense. 

I've also borrowed our old `amcheck` from https://docs.sourcegraph.com/admin/how-to/rebuild-corrupt-postgres-indexes
It looks like linked articles are suggesting use of a newer `pg_amcheck` tool which is available in version 14, but whose use I haven't validated. 

Generally give this a good look over and please suggest any relevant fixes or clarifications -- we need to get this out expediently so feel free to amend and merge without my  consultation. 

## Test plan
doc update

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
