### PR TITLE
[fix] access token curl example url generation allowed malformed URLs

### DIFF
--- a/client/web/src/settings/tokens/AccessTokenCreatedAlert.tsx
+++ b/client/web/src/settings/tokens/AccessTokenCreatedAlert.tsx
@@ -42,5 +42,5 @@ function curlExampleCommand(tokenSecret: string, isSudoToken: boolean): string {
     return `curl \\
   -H 'Authorization: ${credentials}' \\
   -d '{"query":"query { currentUser { username } }"}' \\
-  ${window.context.externalURL}/.api/graphql`
+  ${new URL('/.api/graphql', window.context.externalURL).href}`
 }


### PR DESCRIPTION
Fixed by using the builtin new URL(path, base) constructor https://developer.mozilla.org/en-US/docs/Web/API/URL/URL

Fixes #43123
- #43123

# Screenshot
<img width="557" alt="Screenshot 2022-10-28 at 13 30 15" src="https://user-images.githubusercontent.com/9974711/198577863-81a19c67-a2bd-4dc1-bfc7-2b91b081640b.png">

Works ™️  even after my changes

## Test plan

Tested locally in the browser

## App preview:

- [Web](https://sg-web-milan-fix-access-token-curl.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
