### PR TITLE
codeintel: drop ignore-engines in typescript inference

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/lang_typescript_test.go
+++ b/internal/codeintel/autoindexing/internal/inference/lang_typescript_test.go
@@ -45,7 +45,7 @@ func TestTypeScriptGenerator(t *testing.T) {
 						{
 							Root:     "",
 							Image:    expectedIndexerImage,
-							Commands: []string{"yarn --ignore-engines --ignore-scripts"},
+							Commands: []string{"yarn --ignore-scripts"},
 						},
 					},
 					LocalSteps:  []string{`if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi`},
@@ -143,7 +143,7 @@ func TestTypeScriptGenerator(t *testing.T) {
 						{
 							Root:     "foo/bar",
 							Image:    expectedIndexerImage,
-							Commands: []string{"yarn --ignore-engines"},
+							Commands: []string{"yarn"},
 						},
 					},
 					LocalSteps:  []string{`if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi`},
@@ -162,7 +162,7 @@ func TestTypeScriptGenerator(t *testing.T) {
 						{
 							Root:     "foo/bar",
 							Image:    expectedIndexerImage,
-							Commands: []string{"yarn --ignore-engines"},
+							Commands: []string{"yarn"},
 						},
 						{
 							Root:     "foo/bar/bonk",
@@ -205,7 +205,7 @@ func TestTypeScriptGenerator(t *testing.T) {
 						{
 							Root:     "",
 							Image:    expectedIndexerImage,
-							Commands: []string{"yarn --ignore-engines"},
+							Commands: []string{"yarn"},
 						},
 					},
 					LocalSteps:  []string{`if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi`},

--- a/internal/codeintel/autoindexing/internal/inference/lua/typescript.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/typescript.lua
@@ -83,7 +83,7 @@ local infer_typescript_job = function(api, tsconfig_path, should_infer_config)
 				if contents_by_path[path.join(reverse_ancestors[i], "package.json")] then
 					local install_command = ""
 					if is_yarn or util.contains(paths, path.join(reverse_ancestors[i], "yarn.lock")) then
-						install_command = "yarn --ignore-engines"
+						install_command = "yarn"
 					else
 						install_command = "npm install"
 					end


### PR DESCRIPTION
Sister PR to https://github.com/sourcegraph/scip-typescript/pull/197, so Im not gonna duplicate the text :slightly_smiling_face: 

## Test plan

See test plan in https://github.com/sourcegraph/scip-typescript/pull/197
