### PR TITLE
search: Fix performance of search results page when typing into query input

### DIFF
--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -9,6 +9,7 @@ import { asError } from '@sourcegraph/common'
 import { QueryUpdate, SearchContextProps, SearchMode } from '@sourcegraph/search'
 import { FetchFileParameters, StreamingProgress, StreamingSearchResultsList } from '@sourcegraph/search-ui'
 import { ActivationProps } from '@sourcegraph/shared/src/components/activation/Activation'
+import { FilePrefetcher } from '@sourcegraph/shared/src/components/PrefetchableFile'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
@@ -303,6 +304,15 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
         [caseSensitive, props, submittedURLQuery]
     )
 
+    const prefetchFile: FilePrefetcher = useCallback(
+        params =>
+            fetchBlob({
+                ...params,
+                format: prefetchBlobFormat,
+            }),
+        [prefetchBlobFormat]
+    )
+
     return (
         <div className={classNames(styles.container, sidebarCollapsed && styles.containerWithSidebarHidden)}>
             <PageTitle key="page-title" title={submittedURLQuery} />
@@ -416,12 +426,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
                             executedQuery={location.search}
                             smartSearchEnabled={smartSearchEnabled}
                             prefetchFileEnabled={prefetchFileEnabled}
-                            prefetchFile={params =>
-                                fetchBlob({
-                                    ...params,
-                                    format: prefetchBlobFormat,
-                                })
-                            }
+                            prefetchFile={prefetchFile}
                         />
                     </div>
                 </>


### PR DESCRIPTION
If many results are shown on the result page then typing into the query input can be laggy due to every search result re-rendering on every keypress (see video in PR).

In the video I'm keeping the key pressed (there is still a big delay at one point in the "after" version; as you can see there are other areas that need to be fixed).

https://user-images.githubusercontent.com/179026/198587526-88688653-73ce-484d-99ad-c284902567dc.mp4



## Test plan

Manual testing.
