### PR TITLE
search: collect and flush ranking

### DIFF
--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -6,9 +6,7 @@ import (
 	"fmt"
 	"math"
 	"net"
-	"os"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -68,12 +66,11 @@ type HorizontalSearcher struct {
 	clients map[string]zoekt.Streamer // addr -> client
 }
 
-var rankingEnabled, _ = strconv.ParseBool(os.Getenv("ENABLE_EXPERIMENTAL_RANKING"))
-
 // StreamSearch does a search which merges the stream from every endpoint in Map, reordering results to produce a sorted stream.
 func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, streamer zoekt.Sender) error {
-
-	if rankingEnabled {
+	// We check for nil opts for convenience in tests. Must fix once we rely
+	// on this.
+	if opts != nil && opts.FlushWallTime > 0 {
 		return s.streamSearchExperimentalRanking(ctx, q, opts, streamer)
 	}
 
@@ -213,24 +210,20 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 
 	siteConfig := newRankingSiteConfig(conf.Get().SiteConfiguration)
 
-	// Hack: 500ms is a better default for this function. The original default of 0
-	// disables the flushCollectSender and offers no ranking at all. For now
-	// StreamSearch and streamSearchExperimentalRanking share newRankingSiteConfig.
-	// Once this function is not behind a feature flag anymore, we should update the
-	// default.
-	if siteConfig.maxReorderDuration == 0 {
-		siteConfig.maxReorderDuration = 500 * time.Millisecond
-	}
-
 	streamer, flushAll := newFlushCollectSender(
 		&collectOpts{
 			maxDocDisplayCount: opts.MaxDocDisplayCount,
-			flushWallTime:      siteConfig.maxReorderDuration,
+			flushWallTime:      opts.FlushWallTime,
 			maxSizeBytes:       siteConfig.maxSizeBytes,
 		},
 		streamer,
 	)
 	defer flushAll()
+
+	// We give each zoekt a little less time to flush so the frontend has a
+	// chance to collect them before flushing.
+	childOpts := *opts
+	childOpts.FlushWallTime -= childOpts.FlushWallTime / 5
 
 	// During re-balancing a repository can appear on more than one replica.
 	var mu sync.Mutex
@@ -244,7 +237,7 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 	ch := make(chan error, len(clients))
 	for endpoint, c := range clients {
 		go func(endpoint string, c zoekt.Streamer) {
-			err := c.StreamSearch(ctx, q, opts, stream.SenderFunc(func(sr *zoekt.SearchResult) {
+			err := c.StreamSearch(ctx, q, &childOpts, stream.SenderFunc(func(sr *zoekt.SearchResult) {
 				// This shouldn't happen, but skip event if sr is nil.
 				if sr == nil {
 					return

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -244,6 +244,7 @@ func ToFeatures(flagSet *featureflag.FlagSet, logger log.Logger) *search.Feature
 		ContentBasedLangFilters: flagSet.GetBoolOr("search-content-based-lang-detection", false),
 		HybridSearch:            flagSet.GetBoolOr("search-hybrid", false),
 		AbLuckySearch:           flagSet.GetBoolOr("ab-lucky-search", false),
+		Ranking:                 flagSet.GetBoolOr("search-ranking", false),
 	}
 }
 

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -728,6 +728,7 @@ func (b *jobBuilder) newZoektGlobalSearch(typ search.IndexedRequestType) (job.Jo
 		Typ:            typ,
 		FileMatchLimit: b.fileMatchLimit,
 		Select:         b.selector,
+		Features:       *b.features,
 	}
 
 	switch typ {
@@ -760,6 +761,7 @@ func (b *jobBuilder) newZoektSearch(typ search.IndexedRequestType) (job.Job, err
 			Query:          zoektQuery,
 			FileMatchLimit: b.fileMatchLimit,
 			Select:         b.selector,
+			Features:       *b.features,
 		}, nil
 	case search.TextRequest:
 		return &zoekt.RepoSubsetTextSearchJob{
@@ -768,6 +770,7 @@ func (b *jobBuilder) newZoektSearch(typ search.IndexedRequestType) (job.Job, err
 			Typ:               typ,
 			FileMatchLimit:    b.fileMatchLimit,
 			Select:            b.selector,
+			Features:          *b.features,
 		}, nil
 	}
 	return nil, errors.Errorf("attempt to create unrecognized zoekt search with value %v", typ)

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -165,6 +165,9 @@ type ZoektParameters struct {
 	Typ            IndexedRequestType
 	FileMatchLimit int32
 	Select         filter.SelectPath
+
+	// Features are feature flags that can affect behaviour of searcher.
+	Features Features
 }
 
 // SearcherParameters the inputs for a search fulfilled by the Searcher service
@@ -334,6 +337,10 @@ type Features struct {
 	// When true lucky search runs by default. Adding for A/B testing in
 	// 08/2022. To be removed at latest by 12/2022.
 	AbLuckySearch bool `json:"ab-lucky-search"`
+
+	// Ranking when true will use a our new #ranking signals and code paths
+	// for ranking results from Zoekt.
+	Ranking bool `json:"ranking"`
 }
 
 func (f *Features) String() string {

--- a/internal/search/zoekt/symbol_search.go
+++ b/internal/search/zoekt/symbol_search.go
@@ -19,6 +19,7 @@ type SymbolSearchJob struct {
 	Query          zoektquery.Q
 	FileMatchLimit int32
 	Select         filter.SelectPath
+	Features       search.Features
 	Since          func(time.Time) time.Duration `json:"-"` // since if non-nil will be used instead of time.Since. For tests
 }
 
@@ -42,7 +43,7 @@ func (z *SymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClients, s
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	err = zoektSearch(ctx, z.Repos, z.Query, nil, search.SymbolRequest, clients.Zoekt, z.FileMatchLimit, z.Select, since, stream)
+	err = zoektSearch(ctx, z.Repos, z.Query, nil, search.SymbolRequest, clients.Zoekt, z.FileMatchLimit, z.Select, z.Features, since, stream)
 	if err != nil {
 		tr.LogFields(log.Error(err))
 		// Only record error if we haven't timed out.


### PR DESCRIPTION
This is our new experimental ranking path which overcomes the limits of bucketing by stars. It is feature flagged behind "search-ranking", so can be turned on per user. It relies on the recently shipped FlushWallTime feature in zoekt.

When turned on we will effectively wait 500ms to collect candidate results. We will then rank and truncate those results based on combining Zoekts query ranking and our new #ranking work.

Note: This is all experimental #ranking work so right now we hardcode a bunch of assumptions into the code. As we gain emperical understanding we will introduce ways to tune / more sophisticated mechanisms to pick values like FlushWallTime. We have some prometheus metrics to understand if FlushWallTime needs tuning.

Test Plan: Minimal functional changes unless feature flag is turned on. So intend to rely on unit tests to ensure we didn't break existing code paths. Otherwise for now will ne relying on manual validation (which will be comparing searches).