### PR TITLE
CodeMirror: Fix focusing selected lines

### DIFF
--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -34,7 +34,10 @@ const MOUSE_MAIN_BUTTON = 0
  */
 export type SelectedLineRange = { line: number; endLine?: number } | null
 
-const selectedLineDecoration = Decoration.line({ class: 'selected-line', attributes: { tabIndex: '-1' } })
+const selectedLineDecoration = Decoration.line({
+    class: 'selected-line',
+    attributes: { tabIndex: '-1', 'data-line-focusable': '' },
+})
 const selectedLineGutterMarker = new (class extends GutterMarker {
     public elementClass = 'selected-line'
 })()

--- a/client/web/src/repo/blob/codemirror/tokens-as-links.ts
+++ b/client/web/src/repo/blob/codemirror/tokens-as-links.ts
@@ -39,19 +39,20 @@ const focusSelectedLine = ViewPlugin.fromClass(
                 const line = this.view.state.doc.line(selection.line)
 
                 if (line) {
-                    const closestNode = this.view.domAtPos(line.from).node
+                    window.requestAnimationFrame(() => {
+                        const closestNode = this.view.domAtPos(line.from).node
 
-                    // Loosely find closest element. Note: This is usually only be `closestNode` if the line is empty.
-                    const closestElement = closestNode instanceof HTMLElement ? closestNode : closestNode.parentElement
-                    const target = closestElement?.hasAttribute('data-line-focusable')
-                        ? closestElement
-                        : closestElement?.closest<HTMLElement>('[data-line-focusable]')
+                        // Loosely find closest element.
+                        // Note: This is usually only be `closestNode` if the line is empty.
+                        const closestElement =
+                            closestNode instanceof HTMLElement ? closestNode : closestNode.parentElement
 
-                    if (target) {
-                        window.requestAnimationFrame(() => {
-                            target.focus()
-                        })
-                    }
+                        const target = closestElement?.hasAttribute('data-line-focusable')
+                            ? closestElement
+                            : closestElement?.closest<HTMLElement>('[data-line-focusable]')
+
+                        target?.focus()
+                    })
                 }
             }
         }

--- a/client/web/src/repo/blob/codemirror/tokens-as-links.ts
+++ b/client/web/src/repo/blob/codemirror/tokens-as-links.ts
@@ -39,11 +39,19 @@ const focusSelectedLine = ViewPlugin.fromClass(
                 const line = this.view.state.doc.line(selection.line)
 
                 if (line) {
-                    window.requestAnimationFrame(() => {
-                        const element = this.view.domAtPos(line.from).node.parentElement
-                        const lineElement = element?.closest<HTMLElement>('[data-line-focusable]')
-                        lineElement?.focus()
-                    })
+                    const closestNode = this.view.domAtPos(line.from).node
+
+                    // Loosely find closest element. Note: This is usually only be `closestNode` if the line is empty.
+                    const closestElement = closestNode instanceof HTMLElement ? closestNode : closestNode.parentElement
+                    const target = closestElement?.hasAttribute('data-line-focusable')
+                        ? closestElement
+                        : closestElement?.closest<HTMLElement>('[data-line-focusable]')
+
+                    if (target) {
+                        window.requestAnimationFrame(() => {
+                            target.focus()
+                        })
+                    }
                 }
             }
         }

--- a/client/web/src/repo/blob/codemirror/tokens-as-links.ts
+++ b/client/web/src/repo/blob/codemirror/tokens-as-links.ts
@@ -40,8 +40,9 @@ const focusSelectedLine = ViewPlugin.fromClass(
 
                 if (line) {
                     window.requestAnimationFrame(() => {
-                        const element = this.view.domAtPos(line.from).node as HTMLElement
-                        element.focus()
+                        const element = this.view.domAtPos(line.from).node.parentElement
+                        const lineElement = element?.closest<HTMLElement>('[data-line-focusable]')
+                        lineElement?.focus()
                     })
                 }
             }


### PR DESCRIPTION
## Description

When we upgraded `@codemirror/view` the automatic line focusing broke. We can no longer rely on using the line position to get the line element as in 6.2.1 (https://github.com/codemirror/view/commit/75f0740e0df657f513ec8567ca4ffbea66551dba) `domAtPos` changed to bias towards entering nodes. We now need to find the nearest `cm-line`.

## Test plan

Tested locally
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-tr-fix-selected-focus.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
