### PR TITLE
Upgrade git version to 2.38.1 in Gitserver and Server Docker Images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+- Updated minimum required veresion of `git` to 2.38.1 in `gitserver` and `server` Docker image. This addresses: https://github.blog/2022-04-12-git-security-vulnerability-announced/ and https://lore.kernel.org/git/d1d460f6-e70f-b17f-73a5-e56d604dd9d5@github.com/. [#43615](https://github.com/sourcegraph/sourcegraph/pull/43615)
 - When a `content:` filter is used in a query, only file contents will be searched (previously any of file contents, paths, or repos were searched). However, as before, if `type:` is also set, the `content:` filter will search for results of the specified `type:`. [#43442](https://github.com/sourcegraph/sourcegraph/pull/43442)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
-- Updated minimum required veresion of `git` to 2.38.1 in `gitserver` and `server` Docker image. This addresses: https://github.blog/2022-04-12-git-security-vulnerability-announced/ and https://lore.kernel.org/git/d1d460f6-e70f-b17f-73a5-e56d604dd9d5@github.com/. [#43615](https://github.com/sourcegraph/sourcegraph/pull/43615)
+- Updated minimum required version of `git` to 2.38.1 in `gitserver` and `server` Docker image. This addresses: https://github.blog/2022-04-12-git-security-vulnerability-announced/ and https://lore.kernel.org/git/d1d460f6-e70f-b17f-73a5-e56d604dd9d5@github.com/. [#43615](https://github.com/sourcegraph/sourcegraph/pull/43615)
 - When a `content:` filter is used in a query, only file contents will be searched (previously any of file contents, paths, or repos were searched). However, as before, if `type:` is also set, the `content:` filter will search for results of the specified `type:`. [#43442](https://github.com/sourcegraph/sourcegraph/pull/43442)
 
 ### Fixed

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -37,8 +37,7 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 RUN apk add --no-cache \
-    # We require git 2.34.1 because we use git-repack with flag --write-midx.
-    # We require git 2.35.2 to fix this vulnerability:
+    # We require git 2.38+ because we need a fix for this vulnerability to be included:
     # https://github.blog/2022-04-12-git-security-vulnerability-announced/
     'git>=2.38.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main  \
     git-lfs \

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -38,7 +38,9 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 
 RUN apk add --no-cache \
     # We require git 2.34.1 because we use git-repack with flag --write-midx.
-    'git>=2.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
+    # We require git 2.35.2 to fix this vulnerability:
+    # https://github.blog/2022-04-12-git-security-vulnerability-announced/
+    'git>=2.38.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main  \
     git-lfs \
     git-p4 \
     && apk add --no-cache  \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -41,11 +41,13 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 
 RUN apk add --no-cache --verbose \
     # [NOTE: git-version-min-requirement]
-    # We require git 2.34.1 because we use git-repack with flag --write-midx.
-    'git>=2.34.1' \
+    # We require git 2.34.1 because we use git-repack with flag --write-midx. \
+    # We require git 2.35.2 to fix this vulnerability:
+    # https://github.blog/2022-04-12-git-security-vulnerability-announced/
+    'git>=2.38.1' \
     git-lfs \
     git-p4 \
-    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main  \
+    --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main  \
     # NOTE that the Postgres version we run is different
     # from our *Minimum Supported Version* which alone dictates
     # the features we can depend on. See this link for more information:

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -41,8 +41,7 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 
 RUN apk add --no-cache --verbose \
     # [NOTE: git-version-min-requirement]
-    # We require git 2.34.1 because we use git-repack with flag --write-midx. \
-    # We require git 2.35.2 to fix this vulnerability:
+    # We require git 2.35.2 because we need a fix for this vulnerability to be included:
     # https://github.blog/2022-04-12-git-security-vulnerability-announced/
     'git>=2.38.1' \
     git-lfs \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -41,7 +41,7 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 
 RUN apk add --no-cache --verbose \
     # [NOTE: git-version-min-requirement]
-    # We require git 2.35.2 because we need a fix for this vulnerability to be included:
+    # We require git 2.38+ because we need a fix for this vulnerability to be included:
     # https://github.blog/2022-04-12-git-security-vulnerability-announced/
     'git>=2.38.1' \
     git-lfs \

--- a/dev/sg/dependencies/mac.go
+++ b/dev/sg/dependencies/mac.go
@@ -36,7 +36,7 @@ var Mac = []category{
 		Checks: []*dependency{
 			{
 				Name:  "git",
-				Check: checkAction(check.Combine(check.InPath("git"), checkGitVersion(">= 2.34.1"))),
+				Check: checkAction(check.Combine(check.InPath("git"), checkGitVersion(">= 2.38.1"))),
 				Fix:   cmdFix(`brew install git`),
 			},
 			{

--- a/dev/sg/dependencies/ubuntu.go
+++ b/dev/sg/dependencies/ubuntu.go
@@ -33,7 +33,7 @@ var Ubuntu = []category{
 			},
 			{
 				Name:  "git",
-				Check: checkAction(check.Combine(check.InPath("git"), checkGitVersion(">= 2.34.1"))),
+				Check: checkAction(check.Combine(check.InPath("git"), checkGitVersion(">= 2.38.1"))),
 				Fix:   aptGetInstall("git", "sudo add-apt-repository ppa:git-core/ppa"),
 			}, {
 				Name:  "pcre",


### PR DESCRIPTION
Upgrade git to version 2.38.1

We previously had it upgraded to min 2.35.2 [here](https://github.com/sourcegraph/sourcegraph/pull/37712), but that had a bug with the git commit-graph command, so we reverted it [here](https://github.com/sourcegraph/sourcegraph/pull/39537)

The new version of git [resolves](https://lore.kernel.org/git/d1d460f6-e70f-b17f-73a5-e56d604dd9d5@github.com/) the bug above so we can safely upgrade again.

## Test plan

Just a version change, built the container locally and verified the version