### PR TITLE
monitoring/zoekt: have disk i/o metrics take the `max` node-exporter metric for grouping

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -16851,7 +16851,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100800` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m]))`
+Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m]))))`
 
 </details>
 
@@ -16878,7 +16878,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100801` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m]))`
+Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m]))))`
 
 </details>
 
@@ -16905,7 +16905,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100810` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[2m]))`
+Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[2m]))))`
 
 </details>
 
@@ -16932,7 +16932,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100811` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[2m]))`
+Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[2m]))))`
 
 </details>
 
@@ -16960,7 +16960,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100820` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_time_seconds_total{instance=~`node-exporter.*`}[2m]))) / (max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m]))))`
+Query: `((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left() (max by (device, nodename) (rate(node_disk_read_time_seconds_total{instance=~`node-exporter.*`}[2m]))))) / (max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m]))))))`
 
 </details>
 
@@ -16988,7 +16988,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100821` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_write_time_seconds_total{instance=~`node-exporter.*`}[2m]))) / (max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m]))))`
+Query: `((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left() (max by (device, nodename) (rate(node_disk_write_time_seconds_total{instance=~`node-exporter.*`}[2m]))))) / (max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m]))))))`
 
 </details>
 
@@ -17015,7 +17015,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100830` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[2m]))) / (max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m]))))`
+Query: `((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[2m]))))) / (max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m]))))))`
 
 </details>
 
@@ -17042,7 +17042,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100831` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[2m]))) / (max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m]))))`
+Query: `((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[2m]))))) / (max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m]))))))`
 
 </details>
 
@@ -17069,7 +17069,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100840` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_reads_merged_total{instance=~`node-exporter.*`}[2m]))`
+Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left() (max by (device, nodename) (rate(node_disk_reads_merged_total{instance=~`node-exporter.*`}[2m]))))`
 
 </details>
 
@@ -17096,7 +17096,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100841` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_writes_merged_total{instance=~`node-exporter.*`}[2m]))`
+Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left() (max by (device, nodename) (rate(node_disk_writes_merged_total{instance=~`node-exporter.*`}[2m]))))`
 
 </details>
 
@@ -17124,7 +17124,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100850` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left rate(node_disk_io_time_weighted_seconds_total{instance=~`node-exporter.*`}[2m]))`
+Query: `max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (nodename, device) group_left() (max by (device, nodename) (rate(node_disk_io_time_weighted_seconds_total{instance=~`node-exporter.*`}[2m]))))`
 
 </details>
 

--- a/monitoring/definitions/zoekt.go
+++ b/monitoring/definitions/zoekt.go
@@ -19,7 +19,7 @@ func Zoekt() *monitoring.Dashboard {
 		nodeExporterInstanceRegex = `node-exporter.*`
 	)
 
-	joinOnMountInfo := "zoekt_indexserver_mount_point_info{mount_name=\"indexDir\",instance=~`${instance:regex}`} * on (nodename, device) group_left"
+	joinOnMountInfo := "zoekt_indexserver_mount_point_info{mount_name=\"indexDir\",instance=~`${instance:regex}`} * on (nodename, device) group_left()"
 
 	return &monitoring.Dashboard{
 		Name:                     "zoekt",
@@ -929,7 +929,7 @@ func Zoekt() *monitoring.Dashboard {
 						{
 							Name:        "data_disk_reads_sec",
 							Description: "data disk read request rate over 2m (per instance)",
-							Query:       fmt.Sprintf("max by (instance) (%s rate(node_disk_reads_completed_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("max by (instance) (%s (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`%s`}[2m]))))", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.ReadsPerSecond).
@@ -949,7 +949,7 @@ func Zoekt() *monitoring.Dashboard {
 						{
 							Name:        "data_disk_writes_sec",
 							Description: "data disk write request rate over 2m (per instance)",
-							Query:       fmt.Sprintf("max by (instance) (%s rate(node_disk_writes_completed_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("max by (instance) (%s (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`%s`}[2m]))))", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.WritesPerSecond).
@@ -970,7 +970,7 @@ func Zoekt() *monitoring.Dashboard {
 						{
 							Name:        "data_disk_read_throughput",
 							Description: "data disk read throughput over 2m (per instance)",
-							Query:       fmt.Sprintf("max by (instance) (%s rate(node_disk_read_bytes_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("max by (instance) (%s (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`%s`}[2m]))))", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.BytesPerSecond).
@@ -989,7 +989,7 @@ func Zoekt() *monitoring.Dashboard {
 						{
 							Name:        "data_disk_write_throughput",
 							Description: "data disk write throughput over 2m (per instance)",
-							Query:       fmt.Sprintf("max by (instance) (%s rate(node_disk_written_bytes_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("max by (instance) (%s (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`%s`}[2m]))))", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.BytesPerSecond).
@@ -1012,8 +1012,8 @@ func Zoekt() *monitoring.Dashboard {
 							Description: "data disk average read duration over 2m (per instance)",
 
 							Query: fmt.Sprintf("((%s) / (%s))",
-								fmt.Sprintf("max by (instance) (%s rate(node_disk_read_time_seconds_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
-								fmt.Sprintf("max by (instance) (%s rate(node_disk_reads_completed_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("max by (instance) (%s (max by (device, nodename) (rate(node_disk_read_time_seconds_total{instance=~`%s`}[2m]))))", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("max by (instance) (%s (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`%s`}[2m]))))", joinOnMountInfo, nodeExporterInstanceRegex),
 							),
 							NoAlert: true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -1036,8 +1036,8 @@ func Zoekt() *monitoring.Dashboard {
 							Description: "data disk average write duration over 2m (per instance)",
 
 							Query: fmt.Sprintf("((%s) / (%s))",
-								fmt.Sprintf("max by (instance) (%s rate(node_disk_write_time_seconds_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
-								fmt.Sprintf("max by (instance) (%s rate(node_disk_writes_completed_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("max by (instance) (%s (max by (device, nodename) (rate(node_disk_write_time_seconds_total{instance=~`%s`}[2m]))))", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("max by (instance) (%s (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`%s`}[2m]))))", joinOnMountInfo, nodeExporterInstanceRegex),
 							),
 							NoAlert: true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -1061,8 +1061,8 @@ func Zoekt() *monitoring.Dashboard {
 							Name:        "data_disk_read_request_size",
 							Description: "data disk average read request size over 2m (per instance)",
 							Query: fmt.Sprintf("((%s) / (%s))",
-								fmt.Sprintf("max by (instance) (%s rate(node_disk_read_bytes_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
-								fmt.Sprintf("max by (instance) (%s rate(node_disk_reads_completed_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("max by (instance) (%s (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`%s`}[2m]))))", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("max by (instance) (%s (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`%s`}[2m]))))", joinOnMountInfo, nodeExporterInstanceRegex),
 							),
 							NoAlert: true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -1083,8 +1083,8 @@ func Zoekt() *monitoring.Dashboard {
 							Name:        "data_disk_write_request_size",
 							Description: "data disk average write request size over 2m (per instance)",
 							Query: fmt.Sprintf("((%s) / (%s))",
-								fmt.Sprintf("max by (instance) (%s rate(node_disk_written_bytes_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
-								fmt.Sprintf("max by (instance) (%s rate(node_disk_writes_completed_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("max by (instance) (%s (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`%s`}[2m]))))", joinOnMountInfo, nodeExporterInstanceRegex),
+								fmt.Sprintf("max by (instance) (%s (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`%s`}[2m]))))", joinOnMountInfo, nodeExporterInstanceRegex),
 							),
 							NoAlert: true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -1106,7 +1106,7 @@ func Zoekt() *monitoring.Dashboard {
 						{
 							Name:        "data_disk_reads_merged_sec",
 							Description: "data disk merged read request rate over 2m (per instance)",
-							Query:       fmt.Sprintf("max by (instance) (%s rate(node_disk_reads_merged_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("max by (instance) (%s (max by (device, nodename) (rate(node_disk_reads_merged_total{instance=~`%s`}[2m]))))", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.RequestsPerSecond).
@@ -1125,7 +1125,7 @@ func Zoekt() *monitoring.Dashboard {
 						{
 							Name:        "data_disk_writes_merged_sec",
 							Description: "data disk merged writes request rate over 2m (per instance)",
-							Query:       fmt.Sprintf("max by (instance) (%s rate(node_disk_writes_merged_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("max by (instance) (%s (max by (device, nodename) (rate(node_disk_writes_merged_total{instance=~`%s`}[2m]))))", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit(monitoring.RequestsPerSecond).
@@ -1147,7 +1147,7 @@ func Zoekt() *monitoring.Dashboard {
 
 							Name:        "data_disk_average_queue_size",
 							Description: "data disk average queue size over 2m (per instance)",
-							Query:       fmt.Sprintf("max by (instance) (%s rate(node_disk_io_time_weighted_seconds_total{instance=~`%s`}[2m]))", joinOnMountInfo, nodeExporterInstanceRegex),
+							Query:       fmt.Sprintf("max by (instance) (%s (max by (device, nodename) (rate(node_disk_io_time_weighted_seconds_total{instance=~`%s`}[2m]))))", joinOnMountInfo, nodeExporterInstanceRegex),
 							NoAlert:     true,
 							Panel: monitoring.Panel().LegendFormat("{{instance}}").
 								Unit("req").


### PR DESCRIPTION
Right now on dogfood, [zoekt's disk i/o metrics dashboards](https://k8s.sgdev.org/-/debug/grafana/d/zoekt/zoekt?orgId=1) are failing with the following error: 

<img width="1840" alt="Screen Shot 2022-10-28 at 10 11 55 AM" src="https://user-images.githubusercontent.com/9022011/198694727-0077d3fe-2d16-46a5-a09c-480b9b5077be.png">

<details>
<summary> <em>series from screen shot copied as code blocks for convenience</em> </summary>

Series 1 
```
{app=\"node-exporter\", app_kubernetes_io_component=\"node-exporter\", app_kubernetes_io_instance=\"dogfood-k8s\", deploy=\"sourcegraph\", device=\"dm-0\", instance=\"node-exporter-xzg6n\", job=\"node-exporter\", kubernetes_name=\"node-exporter\", nodename=\"gke-dogfood-containerd-node-pool-stan-64c2cd1a-vlpw\", ns=\"dogfood-k8s\", sourcegraph_resource_requires=\"no-cluster-admin\"}
```

Series 2
```
{app=\"node-exporter\", app_kubernetes_io_component=\"node-exporter\", app_kubernetes_io_instance=\"dogfood-k8s\", deploy=\"sourcegraph\", device=\"dm-0\", instance=\"node-exporter-lg7v4\", job=\"node-exporter\", kubernetes_name=\"node-exporter\", nodename=\"gke-dogfood-containerd-node-pool-stan-64c2cd1a-vlpw\", ns=\"dogfood-k8s\", sourcegraph_resource_requires=\"no-cluster-admin\"}
```

</details>



This error occurs when the right side of the join (the disk i/o metric from node-exporter) has multiple series that match a given `(nodename, device)` label pairing. `group_left` in Prometheus is a [many-to-one](https://prometheus.io/docs/prometheus/latest/querying/operators/#many-to-one-and-one-to-many-vector-matches) operator - so the join will fail when when we have these duplicate metrics.

These duplicate metrics have a chance of occurring when we perform an image-tag update for node exporter (we do continuous updates on k8s.sgdev.org). Whenever the new node-exporter image updates, there is a small window where Prometheus can scrape the node-exporter pod twice (before and after the image update) - resulting in these duplicate series. 

This PR fixes the query by adding the `max by (nodename, device)` operator to the right side of the query. In the case that there are duplicate series, the max operator will collapse them into one by picking the highest value. This operation is safe to perform on our data since:
- the frequency of image tag updates is quite low  compared to Prometheus' scrape interval (30s), at most one data point per hour would be affected
- the disk stats collected by the old and new node exporter images should be quite similar since they're reading from the same data source `/proc/diskstats`.

---

Here is a screenshot of the fixed dashboards:

<img width="1863" alt="Screen Shot 2022-10-28 at 10 31 17 AM" src="https://user-images.githubusercontent.com/9022011/198697553-ad57769b-2b2a-4a56-8ab8-60cd0aac9825.png">



## Test plan

Running `sg start monitoring` while connected to dogfood's Prometheus instance. 
