### PR TITLE
search: show all toggles unconditionally (when smart search enabled)

### DIFF
--- a/client/search-ui/src/input/toggles/Toggles.tsx
+++ b/client/search-ui/src/input/toggles/Toggles.tsx
@@ -160,16 +160,30 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
                         },
                     ]}
                 />
-                {/* Hide regex and structural search toggles if lucky search is enabled */}
-                {(!showSmartSearch || patternType !== SearchPatternType.lucky) && (
-                    <>
+                <QueryInputToggle
+                    title="Regular expression"
+                    isActive={patternType === SearchPatternType.regexp}
+                    onToggle={toggleRegexp}
+                    iconSvgPath={mdiRegex}
+                    interactive={props.interactive}
+                    className="test-regexp-toggle"
+                    disableOn={[
+                        {
+                            condition:
+                                findFilter(navbarSearchQuery, 'patterntype', FilterKind.Subexpression) !== undefined,
+                            reason: 'Query already contains one or more patterntype subexpressions',
+                        },
+                    ]}
+                />
+                <>
+                    {!structuralSearchDisabled && (
                         <QueryInputToggle
-                            title="Regular expression"
-                            isActive={patternType === SearchPatternType.regexp}
-                            onToggle={toggleRegexp}
-                            iconSvgPath={mdiRegex}
+                            title="Structural search"
+                            className="test-structural-search-toggle"
+                            isActive={patternType === SearchPatternType.structural}
+                            onToggle={toggleStructuralSearch}
+                            iconSvgPath={mdiCodeBrackets}
                             interactive={props.interactive}
-                            className="test-regexp-toggle"
                             disableOn={[
                                 {
                                     condition:
@@ -179,26 +193,8 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
                                 },
                             ]}
                         />
-                        {!structuralSearchDisabled && (
-                            <QueryInputToggle
-                                title="Structural search"
-                                className="test-structural-search-toggle"
-                                isActive={patternType === SearchPatternType.structural}
-                                onToggle={toggleStructuralSearch}
-                                iconSvgPath={mdiCodeBrackets}
-                                interactive={props.interactive}
-                                disableOn={[
-                                    {
-                                        condition:
-                                            findFilter(navbarSearchQuery, 'patterntype', FilterKind.Subexpression) !==
-                                            undefined,
-                                        reason: 'Query already contains one or more patterntype subexpressions',
-                                    },
-                                ]}
-                            />
-                        )}
-                    </>
-                )}
+                    )}
+                </>
                 {(showSmartSearch || showCopyQueryButton) && <div className={styles.separator} />}
                 {showSmartSearch && (
                     <SmartSearchToggle


### PR DESCRIPTION
Proposal: don't hide toggles when smart search is enabled. 

Please leave a comment for discussion or approve if you agree. I think this is pretty important and removes some real friction if we plan to ship it on by default.

The reasoning is that smart search doesn't fully replace behavior of toggling any of case sensitivity/regex/structural search. It is sometimes supplemental, but not always. When it isn't supplemental, I sense we remove some agency from the user, and add indirection (they have to disable smart search to toggle these other behaviors, and sometimes it's possible that their desire for other behaviors is orthogonal to smart search).

Said another way: we want to enable smart search by default. If we do so, it shouldn't come at the cost of adding friction/indirection/extra toggle clicks when smart search is orthogonal to some existing expected behavior.

Similar and related to https://github.com/sourcegraph/sourcegraph/pull/42776

I don't think this substantially clutters the UI--we show all of the toggles when smart search is disabled. I also think there are some great opportunities with the smart search dropdown menu in future, so am comfortable with this being a permanent fixture alongside the usual search toggles.

## Test plan
Same as previous behavior, just changes whether smart search feature displays toggles (not enabled by default yet).

## App preview:

- [Web](https://sg-web-rvt-all-toggles.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

