### PR TITLE
sg: pass parameters from bootstrap.sh

### DIFF
--- a/dev/sg/bootstrap.sh
+++ b/dev/sg/bootstrap.sh
@@ -58,8 +58,8 @@ main() {
     exit 1
   fi
 
-  printf '%s\n' 'running sg install' 1>&2
-  "$_file" install </dev/tty
+  printf 'running "%s %s"\n' 'sg install' "$@" 1>&2
+  "$_file" install "$@" </dev/tty
 }
 
 get_architecture() {

--- a/dev/sg/bootstrap.sh
+++ b/dev/sg/bootstrap.sh
@@ -59,7 +59,7 @@ main() {
   fi
 
   printf 'running "%s %s"\n' 'sg install' "$*" 1>&2
-  "$_file" install $* </dev/tty
+  "$_file" install "$*" </dev/tty
 }
 
 get_architecture() {

--- a/dev/sg/bootstrap.sh
+++ b/dev/sg/bootstrap.sh
@@ -58,8 +58,8 @@ main() {
     exit 1
   fi
 
-  printf 'running "%s %s"\n' 'sg install' "$@" 1>&2
-  "$_file" install "$@" </dev/tty
+  printf 'running "%s %s"\n' 'sg install' "$*" 1>&2
+  "$_file" install $* </dev/tty
 }
 
 get_architecture() {


### PR DESCRIPTION
To help with unattended installs, like in Gitpod.

## Test plan

Ensure that parameters are passed to `sg install` when running bootstrap script from terminal.

    ./bootstrap.sh -f

Ensure that parameters are passed when piping the script to shell.

    cat ./bootstrap.sh | sh -s -- -f -p

   