### PR TITLE
search: remove frontend lucky search a/b test logic

### DIFF
--- a/client/search-ui/src/results/StreamingSearchResultsList.tsx
+++ b/client/search-ui/src/results/StreamingSearchResultsList.tsx
@@ -97,7 +97,6 @@ export const StreamingSearchResultsList: React.FunctionComponent<
     openMatchesInNewTab,
     executedQuery,
     resultClassName,
-    smartSearchEnabled: smartSearchEnabled,
     prefetchFile,
     prefetchFileEnabled,
 }) => {
@@ -114,7 +113,6 @@ export const StreamingSearchResultsList: React.FunctionComponent<
 
             // Lucky search A/B test events on Sourcegraph.com. To be removed at latest by 12/2022.
             if (
-                smartSearchEnabled &&
                 !(
                     results?.alert?.kind === 'smart-search-additional-results' ||
                     results?.alert?.kind === 'smart-search-pure-results'
@@ -124,7 +122,6 @@ export const StreamingSearchResultsList: React.FunctionComponent<
             }
 
             if (
-                smartSearchEnabled &&
                 (results?.alert?.kind === 'smart-search-additional-results' ||
                     results?.alert?.kind === 'smart-search-pure-results') &&
                 results?.alert?.title &&
@@ -139,7 +136,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                 telemetryService.log(event)
             }
         },
-        [telemetryService, results, smartSearchEnabled]
+        [telemetryService, results]
     )
 
     const renderResult = useCallback(

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -14,7 +14,6 @@ export type FeatureFlagName =
     | 'contrast-compliant-syntax-highlighting'
     | 'admin-analytics-disabled'
     | 'admin-analytics-cache-disabled'
-    | 'ab-lucky-search' // To be removed at latest by 12/2022.
     | 'search-input-show-history'
     | 'user-management-disabled'
 

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -23,7 +23,6 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { SearchStreamingProps } from '..'
 import { AuthenticatedUser } from '../../auth'
 import { PageTitle } from '../../components/PageTitle'
-import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
 import { CodeInsightsProps } from '../../insights/types'
 import { isCodeInsightsEnabled } from '../../insights/utils/is-code-insights-enabled'
 import { fetchBlob, usePrefetchBlobFormat } from '../../repo/blob/backend'
@@ -72,8 +71,6 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
 
     const history = useHistory()
     // Feature flags
-    // Log lucky search events. To be removed at latest by 12/2022.
-    const [smartSearchEnabled] = useFeatureFlag('ab-lucky-search')
     const enableCodeMonitoring = useExperimentalFeatures(features => features.codeMonitoring ?? false)
     const showSearchContext = useExperimentalFeatures(features => features.showSearchContext ?? false)
     const prefetchFileEnabled = useExperimentalFeatures(features => features.enableSearchFilePrefetch ?? false)
@@ -187,14 +184,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
     }, [results, telemetryService])
 
     useEffect(() => {
-        if (smartSearchEnabled && results?.state === 'complete') {
-            telemetryService.log('SearchResultsFetchedAuto')
-            if (results.results.length > 0) {
-                telemetryService.log('SearchResultsNonEmptyAuto')
-            }
-        }
         if (
-            smartSearchEnabled &&
             (results?.alert?.kind === 'smart-search-additional-results' ||
                 results?.alert?.kind === 'smart-search-pure-results') &&
             results?.alert?.title &&
@@ -209,7 +199,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
                 telemetryService.log(event)
             }
         }
-    }, [results, smartSearchEnabled, telemetryService])
+    }, [results, telemetryService])
 
     // Reset expanded state when new search is started
     useEffect(() => {
@@ -414,7 +404,6 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
                             showSearchContext={showSearchContext}
                             assetsRoot={window.context?.assetsRoot || ''}
                             executedQuery={location.search}
-                            smartSearchEnabled={smartSearchEnabled}
                             prefetchFileEnabled={prefetchFileEnabled}
                             prefetchFile={params =>
                                 fetchBlob({


### PR DESCRIPTION
As in title. We keep logging events where smart search activates and users click results. I'll try tidy up the logging a bit later.

## Test plan
Not feature functionality.

## App preview:

- [Web](https://sg-web-rvt-remove-lucky-ab-test.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
