### PR TITLE
Change global nav button to "Sign up"

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -343,7 +343,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                                         size="sm"
                                         onClick={() => eventLogger.log('ClickedOnTopNavTrialButton')}
                                     >
-                                        Search your code
+                                        Sign up
                                     </ButtonLink>
                                 </div>
                             </NavAction>

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -190,7 +190,7 @@ exports[`GlobalNavbar default 1`] = `
           class="anchorLink link"
           href="https://about.sourcegraph.com"
         >
-          About
+          About 
           <span
             class="d-none d-sm-inline"
           >

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -190,7 +190,7 @@ exports[`GlobalNavbar default 1`] = `
           class="anchorLink link"
           href="https://about.sourcegraph.com"
         >
-          About 
+          About
           <span
             class="d-none d-sm-inline"
           >
@@ -213,7 +213,7 @@ exports[`GlobalNavbar default 1`] = `
             href="https://signup.sourcegraph.com/?utm_medium=inproduct&utm_source=nav&utm_campaign=inproduct-cta"
             tabindex="0"
           >
-            Search your code
+            Sign up
           </a>
         </div>
       </li>


### PR DESCRIPTION
Small change to update the global nav button to say "Sign up" instead of "Search your code."
## Test plan
Updated snapshot. 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-global-nav.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
