### PR TITLE
[a11y] diff page: mode buttons should be radio buttons

### DIFF
--- a/client/web/src/repo/commit/DiffModeSelector.module.scss
+++ b/client/web/src/repo/commit/DiffModeSelector.module.scss
@@ -1,0 +1,5 @@
+.button {
+    &:focus-within {
+        box-shadow: var(--focus-box-shadow);
+    }
+}

--- a/client/web/src/repo/commit/DiffModeSelector.tsx
+++ b/client/web/src/repo/commit/DiffModeSelector.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 
-import { Button, ButtonGroup } from '@sourcegraph/wildcard'
+import { Button, ButtonGroup, Input } from '@sourcegraph/wildcard'
 
 import { DiffMode } from './RepositoryCommitPage'
+
+import styles from './DiffModeSelector.module.scss'
 
 interface DiffModeSelectorProps {
     className?: string
@@ -11,7 +13,7 @@ interface DiffModeSelectorProps {
     diffMode: DiffMode
 }
 
-export const DiffModeSelector: React.FunctionComponent<React.PropsWithChildren<DiffModeSelectorProps>> = ({
+export const DiffModeSelector: React.FunctionComponent<DiffModeSelectorProps> = ({
     className,
     diffMode,
     onHandleDiffMode,
@@ -20,19 +22,37 @@ export const DiffModeSelector: React.FunctionComponent<React.PropsWithChildren<D
     <div className={className}>
         <ButtonGroup>
             <Button
-                onClick={() => onHandleDiffMode('unified')}
                 size={small ? 'sm' : undefined}
                 variant="secondary"
                 outline={diffMode !== 'unified'}
+                as="label"
+                className={styles.button}
             >
+                <Input
+                    type="radio"
+                    name="diff-mode"
+                    value="unified"
+                    checked={diffMode === 'unified'}
+                    onChange={event => onHandleDiffMode(event.target.value as DiffMode)}
+                    className="sr-only"
+                />
                 Unified
             </Button>
             <Button
-                onClick={() => onHandleDiffMode('split')}
                 size={small ? 'sm' : undefined}
                 variant="secondary"
                 outline={diffMode !== 'split'}
+                as="label"
+                className={styles.button}
             >
+                <Input
+                    type="radio"
+                    name="diff-mode"
+                    value="split"
+                    checked={diffMode === 'split'}
+                    onChange={event => onHandleDiffMode(event.target.value as DiffMode)}
+                    className="sr-only"
+                />
                 Split
             </Button>
         </ButtonGroup>


### PR DESCRIPTION
The diff mode selection buttons should be radio buttons. Before, screen readers were not able to know which one was selected. With this change, they follow the convention for radio buttons: tab focuses the radio group and arrow keys can be used to toggle within the possible options. There are no visual changes here; the radio inputs are hidden to non-keyboard users.

![image](https://user-images.githubusercontent.com/206864/198746402-321fd6e2-0806-463c-b96a-389b4daeb11e.png)

## Test plan

Verified with VoiceOver and keyboard usage.

## App preview:

- [Web](https://sg-web-jp-diffmoderadio.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
