### PR TITLE
commit page: save mode selection in temp settings instead of localStorage

### DIFF
--- a/client/shared/src/settings/temporary/TemporarySettings.ts
+++ b/client/shared/src/settings/temporary/TemporarySettings.ts
@@ -49,6 +49,7 @@ export interface TemporarySettingsSchema {
     'coreWorkflowImprovements.enabled_deprecated': boolean
     'batches.minSavedPerChangeset': number
     'search.notebooks.minSavedPerView': number
+    'repo.commitPage.diffMode': 'split' | 'unified'
 }
 
 /**

--- a/client/shared/src/settings/temporary/migrateLocalStorageToTemporarySettings.ts
+++ b/client/shared/src/settings/temporary/migrateLocalStorageToTemporarySettings.ts
@@ -8,7 +8,7 @@ import { TemporarySettingsStorage } from './TemporarySettingsStorage'
 interface Migration {
     localStorageKey: string
     temporarySettingsKey: keyof TemporarySettings
-    type: 'boolean' | 'number' | 'json'
+    type: 'boolean' | 'number' | 'string' | 'json'
     transform?: (value: any) => any
     preserve?: boolean
 }
@@ -42,12 +42,18 @@ const migrations: Migration[] = [
             value.state.tours,
         preserve: true,
     },
+    {
+        localStorageKey: 'diff-mode-visualizer',
+        temporarySettingsKey: 'repo.commitPage.diffMode',
+        type: 'string',
+    },
 ]
 
 const parse = (type: Migration['type'], localStorageValue: string | null): boolean | number | any => {
     if (localStorageValue === null) {
         return
     }
+
     if (type === 'boolean') {
         return localStorageValue === 'true'
     }
@@ -59,6 +65,11 @@ const parse = (type: Migration['type'], localStorageValue: string | null): boole
     if (type === 'json') {
         return JSON.parse(localStorageValue)
     }
+
+    if (type === 'string') {
+        return localStorageValue
+    }
+
     return
 }
 

--- a/client/shared/src/testing/driver.ts
+++ b/client/shared/src/testing/driver.ts
@@ -221,11 +221,6 @@ export class Driver {
          * 2. Redirect to /site-admin/init
          */
         await this.page.goto(this.sourcegraphBaseUrl, { waitUntil: 'networkidle0' })
-        await this.page.evaluate(() => {
-            localStorage.setItem('has-dismissed-browser-ext-toast', 'true')
-            localStorage.setItem('has-dismissed-integrations-toast', 'true')
-            localStorage.setItem('has-dismissed-survey-toast', 'true')
-        })
 
         const url = new URL(this.page.url())
 

--- a/client/web/src/integration/commit-page.test.ts
+++ b/client/web/src/integration/commit-page.test.ts
@@ -14,22 +14,8 @@ import { commonWebGraphQlResults } from './graphQlResults'
 import { percySnapshotWithVariants } from './utils'
 
 describe('RepositoryCommitPage', () => {
-    let driver: Driver
-    before(async () => {
-        driver = await createDriverForTest()
-    })
-    after(() => driver?.close())
-    let testContext: WebIntegrationTestContext
-    beforeEach(async function () {
-        testContext = await createWebIntegrationTestContext({
-            driver,
-            currentTest: this.currentTest!,
-            directory: __dirname,
-        })
-    })
-    afterEachSaveScreenshotIfFailed(() => driver.page)
-    afterEach(() => testContext?.dispose())
-
+    const repositoryName = 'github.com/sourcegraph/sourcegraph'
+    const commitID = '1e7bd000e78cf35c6e1be1b9f1510b4aadfaa416'
     const commonBlobGraphQlResults: Partial<WebGraphQlOperations & SharedGraphQlOperations> = {
         ...commonWebGraphQlResults,
         RepositoryCommit: () => ({
@@ -317,12 +303,22 @@ describe('RepositoryCommitPage', () => {
         }),
     }
 
-    beforeEach(() => {
+    let driver: Driver
+    before(async () => {
+        driver = await createDriverForTest()
+    })
+    after(() => driver?.close())
+    let testContext: WebIntegrationTestContext
+    beforeEach(async function () {
+        testContext = await createWebIntegrationTestContext({
+            driver,
+            currentTest: this.currentTest!,
+            directory: __dirname,
+        })
         testContext.overrideGraphQL(commonBlobGraphQlResults)
     })
-
-    const repositoryName = 'github.com/sourcegraph/sourcegraph'
-    const commitID = '1e7bd000e78cf35c6e1be1b9f1510b4aadfaa416'
+    afterEachSaveScreenshotIfFailed(() => driver.page)
+    afterEach(() => testContext?.dispose())
 
     it('Display diff in unified mode', async () => {
         await driver.page.goto(`${driver.sourcegraphBaseUrl}/${repositoryName}/-/commit/${commitID}`)
@@ -336,8 +332,10 @@ describe('RepositoryCommitPage', () => {
         await driver.page.goto(`${driver.sourcegraphBaseUrl}/${repositoryName}/-/commit/${commitID}`)
         await driver.page.waitForSelector('.test-file-diff-node', { visible: true })
 
-        const splitRadioButton = await driver.page.$('aria/Split[role="radio"]')
-        await driver.page.evaluate(element => element.click(), splitRadioButton)
+        await testContext.waitForGraphQLRequest(async () => {
+            const splitRadioButton = await driver.page.$('aria/Split[role="radio"]')
+            await driver.page.evaluate(element => element.click(), splitRadioButton)
+        }, 'EditTemporarySettings')
 
         await driver.page.waitForSelector('[data-split-mode="split"]', { visible: true })
 

--- a/client/web/src/integration/commit-page.test.ts
+++ b/client/web/src/integration/commit-page.test.ts
@@ -332,10 +332,8 @@ describe('RepositoryCommitPage', () => {
         await driver.page.goto(`${driver.sourcegraphBaseUrl}/${repositoryName}/-/commit/${commitID}`)
         await driver.page.waitForSelector('.test-file-diff-node', { visible: true })
 
-        await testContext.waitForGraphQLRequest(async () => {
-            const splitRadioButton = await driver.page.$('aria/Split[role="radio"]')
-            await driver.page.evaluate(element => element.click(), splitRadioButton)
-        }, 'EditTemporarySettings')
+        const splitRadioButton = await driver.page.$('aria/Split[role="radio"]')
+        await driver.page.evaluate(element => element.click(), splitRadioButton)
 
         await driver.page.waitForSelector('[data-split-mode="split"]', { visible: true })
 

--- a/client/web/src/integration/context.ts
+++ b/client/web/src/integration/context.ts
@@ -6,6 +6,7 @@ import html from 'tagged-template-noop'
 import { SearchGraphQlOperations } from '@sourcegraph/search'
 import { SharedGraphQlOperations } from '@sourcegraph/shared/src/graphql-operations'
 import { SearchEvent } from '@sourcegraph/shared/src/search/stream'
+import { TemporarySettings } from '@sourcegraph/shared/src/settings/temporary/TemporarySettings'
 import { getConfig } from '@sourcegraph/shared/src/testing/config'
 import {
     createSharedIntegrationTestContext,
@@ -19,6 +20,7 @@ import { SourcegraphContext } from '../jscontext'
 import { isHotReloadEnabled } from './environment'
 import { commonWebGraphQlResults } from './graphQlResults'
 import { createJsContext } from './jscontext'
+import { TemporarySettingsContext } from './temporarySettingsContext'
 
 export interface WebIntegrationTestContext
     extends IntegrationTestContext<
@@ -36,6 +38,11 @@ export interface WebIntegrationTestContext
      * @param overrides The array of events to return.
      */
     overrideSearchStreamEvents: (overrides: SearchEvent[]) => void
+
+    /**
+     * Configures initial values for temporary settings.
+     */
+    overrideInitialTemporarySettings: (overrides: TemporarySettings) => void
 }
 
 const rootDirectory = path.resolve(__dirname, '..', '..', '..', '..')
@@ -72,6 +79,9 @@ export const createWebIntegrationTestContext = async ({
 
     sharedTestContext.overrideGraphQL(commonWebGraphQlResults)
     let jsContext = createJsContext({ sourcegraphBaseUrl: driver.sourcegraphBaseUrl })
+
+    const tempSettings = new TemporarySettingsContext()
+    sharedTestContext.overrideGraphQL(tempSettings.getGraphQLOverrides())
 
     if (!config.disableAppAssetsMocking) {
         // On CI, we don't use `react-fast-refresh`, so we don't need the runtime bundle.
@@ -125,6 +135,9 @@ export const createWebIntegrationTestContext = async ({
         },
         overrideSearchStreamEvents: overrides => {
             searchStreamEventOverrides = overrides
+        },
+        overrideInitialTemporarySettings: overrides => {
+            tempSettings.overrideInitialTemporarySettings(overrides)
         },
     }
 }

--- a/client/web/src/integration/graphQlResults.ts
+++ b/client/web/src/integration/graphQlResults.ts
@@ -201,21 +201,6 @@ export const commonWebGraphQlResults: Partial<
     OrgFeatureFlagOverrides: () => ({
         organizationFeatureFlagOverrides: [],
     }),
-    GetTemporarySettings: () => ({
-        temporarySettings: {
-            __typename: 'TemporarySettings',
-            contents: JSON.stringify({
-                'user.daysActiveCount': 1,
-                'user.lastDayActive': new Date().toDateString(),
-                'search.usedNonGlobalContext': true,
-            }),
-        },
-    }),
-    EditTemporarySettings: () => ({
-        editTemporarySettings: {
-            alwaysNil: null,
-        },
-    }),
     HomePanelsQuery: () => ({
         node: {
             __typename: 'User',

--- a/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
+++ b/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
@@ -44,22 +44,14 @@ export interface OverrideGraphQLExtensionsProps {
 export function overrideInsightsGraphQLApi(props: OverrideGraphQLExtensionsProps): void {
     const { testContext, overrides = {} } = props
 
+    // Mock temporary settings cause code insights beta modal UI relies on this handler to show/hide
+    // modal UI on all code insights related pages.
+    testContext.overrideInitialTemporarySettings({
+        'insights.freeGaAccepted': true,
+        'insights.wasMainPageOpen': true,
+    })
     testContext.overrideGraphQL({
         ...commonWebGraphQlResults,
-        // Mock temporary settings cause code insights beta modal UI relies on this handler to show/hide
-        // modal UI on all code insights related pages.
-        GetTemporarySettings: () => ({
-            temporarySettings: {
-                __typename: 'TemporarySettings',
-                contents: JSON.stringify({
-                    'user.daysActiveCount': 1,
-                    'user.lastDayActive': new Date().toDateString(),
-                    'search.usedNonGlobalContext': true,
-                    'insights.freeGaAccepted': true,
-                    'insights.wasMainPageOpen': true,
-                }),
-            },
-        }),
         // Mock insight config query
         GetInsights: () => ({
             __typename: 'Query',

--- a/client/web/src/integration/notebook.test.ts
+++ b/client/web/src/integration/notebook.test.ts
@@ -176,17 +176,6 @@ const commonSearchGraphQLResults: Partial<WebGraphQlOperations & SharedGraphQlOp
     ...commonWebGraphQlResults,
     ...highlightFileResult,
     ...viewerSettings,
-    GetTemporarySettings: () => ({
-        temporarySettings: {
-            __typename: 'TemporarySettings',
-            contents: JSON.stringify({
-                'user.daysActiveCount': 1,
-                'user.lastDayActive': new Date().toDateString(),
-                'search.usedNonGlobalContext': true,
-                'search.notebooks.gettingStartedTabSeen': true,
-            }),
-        },
-    }),
     ResolveRepoRev: () => createResolveRepoRevisionResult('/github.com/sourcegraph/sourcegraph'),
     FetchNotebook: ({ id }) => ({
         node: notebookFixture(id, 'Notebook Title', [
@@ -221,6 +210,9 @@ describe('Search Notebook', () => {
         })
         testContext.overrideGraphQL(commonSearchGraphQLResults)
         testContext.overrideSearchStreamEvents(mixedSearchStreamEvents)
+        testContext.overrideInitialTemporarySettings({
+            'search.notebooks.gettingStartedTabSeen': true,
+        })
     })
     afterEachSaveScreenshotIfFailed(() => driver.page)
     afterEach(() => testContext?.dispose())

--- a/client/web/src/integration/temporarySettingsContext.ts
+++ b/client/web/src/integration/temporarySettingsContext.ts
@@ -1,0 +1,52 @@
+import {
+    EditTemporarySettingsResult,
+    GetTemporarySettingsResult,
+    SharedGraphQlOperations,
+} from '@sourcegraph/shared/src/graphql-operations'
+import { TemporarySettings } from '@sourcegraph/shared/src/settings/temporary/TemporarySettings'
+
+const defaultSettings: TemporarySettings = {
+    'user.daysActiveCount': 1,
+    'user.lastDayActive': new Date().toDateString(),
+    'npsSurvey.hasTemporarilyDismissed': true,
+}
+
+export class TemporarySettingsContext {
+    private settings: TemporarySettings
+
+    constructor() {
+        this.settings = defaultSettings
+    }
+
+    public overrideInitialTemporarySettings(overrides: TemporarySettings): void {
+        this.settings = { ...this.settings, ...overrides }
+    }
+
+    public getGraphQLOverrides(): Pick<SharedGraphQlOperations, 'GetTemporarySettings' | 'EditTemporarySettings'> {
+        return {
+            GetTemporarySettings: () => this.getTemporarySettings(),
+            EditTemporarySettings: params => this.editTemporarySettings(params.contents),
+        }
+    }
+
+    private getTemporarySettings(): GetTemporarySettingsResult {
+        return {
+            temporarySettings: {
+                __typename: 'TemporarySettings',
+                contents: JSON.stringify(this.settings),
+            },
+        }
+    }
+
+    private editTemporarySettings(contents: string): EditTemporarySettingsResult {
+        // This parsing is safe in integration tests
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        this.settings = { ...this.settings, ...JSON.parse(contents) }
+
+        return {
+            editTemporarySettings: {
+                alwaysNil: null,
+            },
+        }
+    }
+}

--- a/client/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/client/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -18,6 +18,7 @@ import { getModeFromPath } from '@sourcegraph/shared/src/languages'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import * as GQL from '@sourcegraph/shared/src/schema'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import {
@@ -28,7 +29,7 @@ import {
     RevisionSpec,
     UIPositionSpec,
 } from '@sourcegraph/shared/src/util/url'
-import { LoadingSpinner, useLocalStorage, useObservable } from '@sourcegraph/wildcard'
+import { LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
 
 import { getHover, getDocumentHighlights } from '../../backend/features'
 import { requestGraphQL } from '../../backend/graphql'
@@ -119,8 +120,6 @@ interface RepositoryCommitPageProps
 
 export type DiffMode = 'split' | 'unified'
 
-const DIFF_MODE_VISUALIZER = 'diff-mode-visualizer'
-
 /** Displays a commit. */
 export const RepositoryCommitPage: React.FunctionComponent<RepositoryCommitPageProps> = props => {
     const commitOrError = useObservable(
@@ -132,7 +131,7 @@ export const RepositoryCommitPage: React.FunctionComponent<RepositoryCommitPageP
             [props.match.params.revspec, props.repo.id]
         )
     )
-    const [diffMode, setDiffMode] = useLocalStorage<DiffMode>(DIFF_MODE_VISUALIZER, 'unified')
+    const [diffMode, setDiffMode] = useTemporarySetting('repo.commitPage.diffMode', 'unified')
 
     /** Emits whenever the ref callback for the hover element is called */
     const hoverOverlayElements = useMemo(() => new Subject<HTMLElement | null>(), [])


### PR DESCRIPTION
Move the diff mode selection (unified & split) from localStorage to temporary settings. This way, logged in users will have the setting roamed if they log into a different browser.

![image](https://user-images.githubusercontent.com/206864/198748488-6e11cb73-4462-47fe-b3e2-9aeac9b341c4.png)


## Test plan

- Tested using an existing user migrates the setting from localStorage to temporary settings
- Tested that changing the setting one browser is reflected in another

## App preview:

- [Web](https://sg-web-jp-diffmodetempsettings.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
