### PR TITLE
[a11y] search ui: fix color contrast for show/hide matches button

### DIFF
--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -208,6 +208,7 @@ $theme-colors: (
     --modal-bg: #{rgba($gray-04, 0.5)};
     --sidebar-bg: var(--color-bg-1);
     --sidebar-border-color: var(--border-color-2);
+    --collapse-results-color: var(--gray-08);
 }
 
 .theme-dark {
@@ -300,6 +301,7 @@ $theme-colors: (
     --modal-bg: #{rgba($gray-08, 0.5)};
     --sidebar-bg: var(--black);
     --sidebar-border-color: var(--color-bg-2);
+    --collapse-results-color: var(--gray-05);
 }
 
 // Additional colors global colors.

--- a/client/search-ui/src/components/ResultContainer.module.scss
+++ b/client/search-ui/src/components/ResultContainer.module.scss
@@ -64,7 +64,7 @@
     background-color: var(--border-color);
     border-bottom-left-radius: var(--border-radius);
     border-bottom-right-radius: var(--border-radius);
-    color: var(--text-muted);
+    color: var(--collapse-results-color);
 
     // When expanded, stick collapse button to the bottom of the
     // screen if there are enough search results to cause scrolling.


### PR DESCRIPTION
Closes #43145

Before:

![image](https://user-images.githubusercontent.com/206864/198750710-b5dfd9e1-1212-4ddc-9abb-aae4a4fa6ff0.png)
![image](https://user-images.githubusercontent.com/206864/198750691-1ee0ce2a-fa5f-4130-86f4-3b879bd7ed63.png)

After:

![image](https://user-images.githubusercontent.com/206864/198750674-3513cd48-cd64-47e8-8523-7f9620524287.png)
![image](https://user-images.githubusercontent.com/206864/198750681-81481261-d715-4a3f-8e06-b9c83b78ccca.png)



## Test plan

Verify color contrast using Chrome dev tools

## App preview:

- [Web](https://sg-web-jp-collapsecolor.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
