### PR TITLE
sg: do not run checks over deleted files

### DIFF
--- a/dev/sg/internal/repo/repo.go
+++ b/dev/sg/internal/repo/repo.go
@@ -99,7 +99,7 @@ func parseDiff(diffOutput string) (map[string][]DiffHunk, error) {
 
 	diffs := make(map[string][]DiffHunk)
 	for _, d := range fullDiffs {
-		if d.NewName == "" {
+		if d.NewName == "" || d.NewName == "/dev/null" {
 			continue
 		}
 


### PR DESCRIPTION
This fixes the problem encountered in this build: https://buildkite.com/sourcegraph/sourcegraph/builds/180381

`sg lint dockerfiles` ends up running `git diff main -- '**/*Dockerfile*'` and in the case of the above build the returned diff looks like this:

      diff --git a/cmd/migrator/Dockerfile b/cmd/migrator/Dockerfile
      index f27e1f91d2..f06078c7bd 100644
      --- a/cmd/migrator/Dockerfile
      +++ b/cmd/migrator/Dockerfile
      @@ -15,3 +15,4 @@ RUN apk update && apk add --no-cache \
       USER sourcegraph
       ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/migrator"]
       COPY migrator /usr/local/bin/
      +COPY schema-descriptions /schema-descriptions
      diff --git a/enterprise/cmd/migrator/Dockerfile b/enterprise/cmd/migrator/Dockerfile
      deleted file mode 100644
      index f27e1f91d2..0000000000
      --- a/enterprise/cmd/migrator/Dockerfile
      +++ /dev/null
      @@ -1,17 +0,0 @@
      -FROM sourcegraph/alpine-3.14:174825_2022-09-28_291dca5d9725@sha256:0bfed82a206a1f313b7276521375dc4d27caa45c324f99e7da0453cecbd31980
      -
      -ARG COMMIT_SHA="unknown"
      -ARG DATE="unknown"
      -ARG VERSION="unknown"
      -
      -LABEL org.opencontainers.image.revision=${COMMIT_SHA}
      -LABEL org.opencontainers.image.created=${DATE}
      -LABEL org.opencontainers.image.version=${VERSION}
      -LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
      -
      -RUN apk update && apk add --no-cache \
      -    tini
      -
      -USER sourcegraph
      -ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/migrator"]
      -COPY migrator /usr/local/bin/

Notice that the second file has been deleted. But we use that filename, `/dev/null`, and pass it to `hadolint`.

That's wrong and the commit here makes sure to skip those files.



## Test plan

- Ran `go run ./dev/sg lint dockerfiles` in this PR https://github.com/sourcegraph/sourcegraph/pull/43627 to make sure it works.
