### PR TITLE
Fuzzy finder: with filename first

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyFiles.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFiles.tsx
@@ -95,10 +95,7 @@ export async function loadFilesFSM(
 
 export function newFuzzyFSM(filenames: string[], createUrl: createUrlFunction): FuzzyFSM {
     return newFuzzyFSMFromValues(
-        filenames.map(text => ({
-            text,
-            icon: fileIcon(text),
-        })),
+        filenames.map(text => newSearchValue(text)),
         createUrl
     )
 }
@@ -133,10 +130,7 @@ export class FuzzyRepoFiles {
             },
         })
         const filenames = response.data.repository?.commit?.fileNames || []
-        const values: SearchValue[] = filenames.map(text => ({
-            text,
-            icon: fileIcon(text),
-        }))
+        const values: SearchValue[] = filenames.map(text => newSearchValue(text))
         this.updateFSM(newFuzzyFSMFromValues(values, this.createURL))
         this.loopIndexing()
         return values
@@ -176,11 +170,7 @@ export class FuzzyFiles extends FuzzyQuery {
     }
 
     /* override */ protected searchValues(): SearchValue[] {
-        return [...this.queryResults.values()].map(({ text, url }) => ({
-            text,
-            url,
-            icon: fileIcon(text),
-        }))
+        return [...this.queryResults.values()].map(({ text, url }) => newSearchValue(text, url))
     }
 
     /* override */ protected rawQuery(query: string): string {
@@ -205,5 +195,16 @@ export class FuzzyFiles extends FuzzyQuery {
             }
         }
         return queryResults
+    }
+}
+
+function newSearchValue(text: string, url?: string): SearchValue {
+    const slashIndex = text.lastIndexOf('/')
+    const rotationOffset = slashIndex < 0 ? undefined : text.length - slashIndex - 1
+    return {
+        text,
+        rotationOffset,
+        url,
+        icon: fileIcon(text),
     }
 }

--- a/client/web/src/components/fuzzyFinder/HighlightedLink.module.scss
+++ b/client/web/src/components/fuzzyFinder/HighlightedLink.module.scss
@@ -13,3 +13,8 @@
     height: 100%;
     max-height: 1em;
 }
+
+.muted-section {
+    color: var(--text-muted) !important;
+    margin-left: 0.5rem;
+}

--- a/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.test.ts
+++ b/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.test.ts
@@ -14,7 +14,7 @@ function fuzzyMatches(query: string, values: string[]): string[] {
     }
 
     const results = fuzzy.search({ query, maxResults: 100 })
-    return results.links.map(link => link.text)
+    return results.links.flatMap(({ sections }) => sections).map(section => section.text)
 }
 
 function checkFuzzyMatches(name: string, query: string, inputs: string[], expected: string[]): void {

--- a/client/web/src/fuzzyFinder/FuzzySearch.ts
+++ b/client/web/src/fuzzyFinder/FuzzySearch.ts
@@ -19,7 +19,9 @@ export enum SearchIconKind {
 
 export interface SearchValue {
     text: string
+    rotationOffset?: number
     ranking?: number
+    textSuffix?: JSX.Element
     url?: string
     icon?: JSX.Element
     onClick?: () => void


### PR DESCRIPTION
Previously, the full file path was listed making it sometimes difficult to find the filename since could disappear behind the horizontal scroll for long filenames (esp. common when searching globally).

Now, the filename is displayed first and the directory is displayed after. This was somewhat tricky to implement because we want to allow the user to query the full path (directory+filename).

**After**
<img width="764" alt="CleanShot 2022-10-29 at 12 10 35@2x" src="https://user-images.githubusercontent.com/1408093/198830634-be82c1ae-98bd-45ff-87e2-329fd6f2e7c8.png">

**Before**
<img width="708" alt="CleanShot 2022-10-29 at 12 11 02@2x" src="https://user-images.githubusercontent.com/1408093/198830660-9cd96d07-533c-4403-98a8-18dc1ef00a1a.png">


## Test plan

See updated storybook tests, which have Chromatic UI tests.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-fuzzy-filename.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
