### PR TITLE
Fix tiny typo in drift_schema.go

### DIFF
--- a/internal/database/migration/cliutil/drift_schema.go
+++ b/internal/database/migration/cliutil/drift_schema.go
@@ -60,7 +60,7 @@ const migratorImageDescriptionPrefix = "/schema-descriptions"
 func LocalExpectedSchemaFactory(filename, version string) (string, descriptions.SchemaDescription, error) {
 	path, err := makeFilePath(filename, version)
 	if err != nil {
-		return "{file://{UNSUPPORTED_VERSION}", descriptions.SchemaDescription{}, err
+		return "file://{UNSUPPORTED_VERSION}", descriptions.SchemaDescription{}, err
 	}
 
 	schemaDescription, err := readSchemaFromFile(filepath.Join(migratorImageDescriptionPrefix, path))


### PR DESCRIPTION
Just ran into this while reading through code.

## Test plan

- N/A