### PR TITLE
migrator: remove unneeded v in startup message

### DIFF
--- a/cmd/migrator/shared/main.go
+++ b/cmd/migrator/shared/main.go
@@ -88,7 +88,7 @@ func Start(logger log.Logger, registerEnterpriseMigrators registerMigratorsUsing
 		},
 	}
 
-	out.WriteLine(output.Linef(output.EmojiAsterisk, output.StyleReset, "Sourcegraph migrator v%s", version.Version()))
+	out.WriteLine(output.Linef(output.EmojiAsterisk, output.StyleReset, "Sourcegraph migrator %s", version.Version()))
 
 	args := os.Args
 	if len(args) == 1 {


### PR DESCRIPTION
The version already includes the v. Fixes:

![screenshot_2022-10-30_07 44 49@2x](https://user-images.githubusercontent.com/1185253/198866081-1c9c3448-c8b9-48ba-a247-02bae1e38c3f.png)

## Test plan

- N/A