### PR TITLE
ranking: Expose last updated timestamps

### DIFF
--- a/internal/codeintel/ranking/internal/store/store_test.go
+++ b/internal/codeintel/ranking/internal/store/store_test.go
@@ -246,10 +246,10 @@ func TestLastUpdatedAt(t *testing.T) {
 	if _, err := db.ExecContext(ctx, `INSERT INTO repo (name) VALUES ('foo'), ('bar'), ('baz')`); err != nil {
 		t.Fatalf("failed to insert repos: %s", err)
 	}
-	if err := store.SetDocumentRanks(ctx, "foo", nil); err != nil {
+	if err := store.SetDocumentRanks(ctx, "foo", 0.25, nil); err != nil {
 		t.Fatalf("unexpected error setting document ranks: %s", err)
 	}
-	if err := store.SetDocumentRanks(ctx, "bar", nil); err != nil {
+	if err := store.SetDocumentRanks(ctx, "bar", 0.25, nil); err != nil {
 		t.Fatalf("unexpected error setting document ranks: %s", err)
 	}
 
@@ -288,10 +288,10 @@ func TestUpdatedAfter(t *testing.T) {
 	if _, err := db.ExecContext(ctx, `INSERT INTO repo (name) VALUES ('foo'), ('bar'), ('baz')`); err != nil {
 		t.Fatalf("failed to insert repos: %s", err)
 	}
-	if err := store.SetDocumentRanks(ctx, "foo", nil); err != nil {
+	if err := store.SetDocumentRanks(ctx, "foo", 0.25, nil); err != nil {
 		t.Fatalf("unexpected error setting document ranks: %s", err)
 	}
-	if err := store.SetDocumentRanks(ctx, "bar", nil); err != nil {
+	if err := store.SetDocumentRanks(ctx, "bar", 0.25, nil); err != nil {
 		t.Fatalf("unexpected error setting document ranks: %s", err)
 	}
 

--- a/internal/codeintel/ranking/internal/store/store_test.go
+++ b/internal/codeintel/ranking/internal/store/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log/logtest"
@@ -229,5 +230,90 @@ func TestBulkSetAndMergeDocumentRanks(t *testing.T) {
 	}
 	if diff := cmp.Diff(expectedRanks, allRanks); diff != "" {
 		t.Errorf("unexpected ranks (-want +got):\n%s", diff)
+	}
+}
+
+func TestLastUpdatedAt(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	store := New(db, &observation.TestContext)
+
+	if _, err := db.ExecContext(ctx, `INSERT INTO repo (name) VALUES ('foo'), ('bar'), ('baz')`); err != nil {
+		t.Fatalf("failed to insert repos: %s", err)
+	}
+	if err := store.SetDocumentRanks(ctx, "foo", nil); err != nil {
+		t.Fatalf("unexpected error setting document ranks: %s", err)
+	}
+	if err := store.SetDocumentRanks(ctx, "bar", nil); err != nil {
+		t.Fatalf("unexpected error setting document ranks: %s", err)
+	}
+
+	pairs, err := store.LastUpdatedAt(ctx, []api.RepoName{"foo", "bar", "bonk"})
+	if err != nil {
+		t.Fatalf("unexpected error getting repo last update times: %s", err)
+	}
+
+	fooUpdatedAt, ok := pairs["foo"]
+	if !ok {
+		t.Fatalf("expected 'foo' in result: %v", pairs)
+	}
+	barUpdatedAt, ok := pairs["bar"]
+	if !ok {
+		t.Fatalf("expected 'bar' in result: %v", pairs)
+	}
+	if _, ok := pairs["bonk"]; ok {
+		t.Fatalf("unexpected 'bonk' in result: %v", pairs)
+	}
+
+	if !fooUpdatedAt.Before(barUpdatedAt) {
+		t.Errorf("unexpected timestamp ordering: %v and %v", fooUpdatedAt, barUpdatedAt)
+	}
+}
+
+func TestUpdatedAfter(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	store := New(db, &observation.TestContext)
+
+	if _, err := db.ExecContext(ctx, `INSERT INTO repo (name) VALUES ('foo'), ('bar'), ('baz')`); err != nil {
+		t.Fatalf("failed to insert repos: %s", err)
+	}
+	if err := store.SetDocumentRanks(ctx, "foo", nil); err != nil {
+		t.Fatalf("unexpected error setting document ranks: %s", err)
+	}
+	if err := store.SetDocumentRanks(ctx, "bar", nil); err != nil {
+		t.Fatalf("unexpected error setting document ranks: %s", err)
+	}
+
+	// past
+	{
+		repoNames, err := store.UpdatedAfter(ctx, time.Now().Add(-time.Hour*24))
+		if err != nil {
+			t.Fatalf("unexpected error getting updated repos: %s", err)
+		}
+		if diff := cmp.Diff([]api.RepoName{"bar", "foo"}, repoNames); diff != "" {
+			t.Errorf("unexpected repository names (-want +got):\n%s", diff)
+		}
+	}
+
+	// future
+	{
+		repoNames, err := store.UpdatedAfter(ctx, time.Now().Add(time.Hour*24))
+		if err != nil {
+			t.Fatalf("unexpected error getting updated repos: %s", err)
+		}
+		if len(repoNames) != 0 {
+			t.Fatal("expected no repos")
+		}
 	}
 }

--- a/internal/codeintel/ranking/service.go
+++ b/internal/codeintel/ranking/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/sourcegraph/log"
@@ -152,6 +153,14 @@ func (s *Service) GetDocumentRanks(ctx context.Context, repoName api.RepoName) (
 	}
 
 	return ranks, nil
+}
+
+func (s *Service) LastUpdatedAt(ctx context.Context, repoNames []api.RepoName) (map[api.RepoName]time.Time, error) {
+	return s.store.LastUpdatedAt(ctx, repoNames)
+}
+
+func (s *Service) UpdatedAfter(ctx context.Context, t time.Time) ([]api.RepoName, error) {
+	return s.store.UpdatedAfter(ctx, t)
 }
 
 var testPattern = lazyregexp.New("test")

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1017,6 +1017,7 @@ func (s *repoStore) listSQL(ctx context.Context, tr *trace.Trace, opt ReposListO
 	if !opt.MinLastChanged.IsZero() {
 		conds := []*sqlf.Query{
 			sqlf.Sprintf("gr.last_changed >= %s", opt.MinLastChanged),
+			sqlf.Sprintf("EXISTS (SELECT 1 FROM codeintel_path_ranks pr WHERE pr.repository_id = repo.id AND pr.updated_at >= %s)", opt.MinLastChanged),
 			sqlf.Sprintf("COALESCE(repo.updated_at, repo.created_at) >= %s", opt.MinLastChanged),
 			sqlf.Sprintf("repo.id IN (SELECT scr.repo_id FROM search_context_repos scr LEFT JOIN search_contexts sc ON scr.search_context_id = sc.id WHERE sc.updated_at >= %s)", opt.MinLastChanged),
 		}

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -775,6 +775,17 @@ func TestRepos_List_LastChanged(t *testing.T) {
 	setGitserverRepoCloneStatus(t, db, r2.Name, types.CloneStatusCloned)
 	setGitserverRepoLastChanged(t, db, r2.Name, now)
 
+	// we create a repo that has recently had new page rank scores committed to the database
+	r3 := mustCreate(ctx, t, db, &types.Repo{Name: "ranked"})
+	setGitserverRepoCloneStatus(t, db, r3.Name, types.CloneStatusCloned)
+	setGitserverRepoLastChanged(t, db, r3.Name, now.Add(-time.Hour))
+	{
+		_, err := db.Handle().ExecContext(ctx, `INSERT INTO codeintel_path_ranks (repository_id, updated_at, payload) VALUES ($1, $2, '{}'::jsonb)`, r3.ID, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	// Our test helpers don't do updated_at, so manually doing it.
 	_, err := db.Handle().ExecContext(ctx, "update repo set updated_at = $1", now.Add(-24*time.Hour))
 	if err != nil {
@@ -782,9 +793,9 @@ func TestRepos_List_LastChanged(t *testing.T) {
 	}
 
 	// will have update_at set to now, so should be included as often as new.
-	r3 := mustCreate(ctx, t, db, &types.Repo{Name: "newMeta"})
-	setGitserverRepoCloneStatus(t, db, r3.Name, types.CloneStatusCloned)
-	setGitserverRepoLastChanged(t, db, r3.Name, now.Add(-24*time.Hour))
+	r4 := mustCreate(ctx, t, db, &types.Repo{Name: "newMeta"})
+	setGitserverRepoCloneStatus(t, db, r4.Name, types.CloneStatusCloned)
+	setGitserverRepoLastChanged(t, db, r4.Name, now.Add(-24*time.Hour))
 	_, err = db.Handle().ExecContext(ctx, "update repo set updated_at = $1 where name = 'newMeta'", now)
 	if err != nil {
 		t.Fatal(err)
@@ -792,9 +803,9 @@ func TestRepos_List_LastChanged(t *testing.T) {
 
 	// we create two search contexts, with one being updated recently only
 	// including "newSearchContext".
-	r4 := mustCreate(ctx, t, db, &types.Repo{Name: "newSearchContext"})
-	setGitserverRepoCloneStatus(t, db, r4.Name, types.CloneStatusCloned)
-	setGitserverRepoLastChanged(t, db, r4.Name, now.Add(-24*time.Hour))
+	r5 := mustCreate(ctx, t, db, &types.Repo{Name: "newSearchContext"})
+	setGitserverRepoCloneStatus(t, db, r5.Name, types.CloneStatusCloned)
+	setGitserverRepoLastChanged(t, db, r5.Name, now.Add(-24*time.Hour))
 	{
 		mkSearchContext := func(name string, opts ReposListOptions) {
 			t.Helper()
@@ -829,15 +840,15 @@ func TestRepos_List_LastChanged(t *testing.T) {
 		Want           []string
 	}{{
 		Name: "not specified",
-		Want: []string{"old", "new", "newMeta", "newSearchContext"},
+		Want: []string{"old", "new", "ranked", "newMeta", "newSearchContext"},
 	}, {
 		Name:           "old",
 		MinLastChanged: now.Add(-24 * time.Hour),
-		Want:           []string{"old", "new", "newMeta", "newSearchContext"},
+		Want:           []string{"old", "new", "ranked", "newMeta", "newSearchContext"},
 	}, {
 		Name:           "new",
 		MinLastChanged: now.Add(-time.Minute),
-		Want:           []string{"new", "newMeta", "newSearchContext"},
+		Want:           []string{"new", "ranked", "newMeta", "newSearchContext"},
 	}, {
 		Name:           "none",
 		MinLastChanged: now.Add(time.Minute),

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -780,7 +780,7 @@ func TestRepos_List_LastChanged(t *testing.T) {
 	setGitserverRepoCloneStatus(t, db, r3.Name, types.CloneStatusCloned)
 	setGitserverRepoLastChanged(t, db, r3.Name, now.Add(-time.Hour))
 	{
-		_, err := db.Handle().ExecContext(ctx, `INSERT INTO codeintel_path_ranks (repository_id, updated_at, payload) VALUES ($1, $2, '{}'::jsonb)`, r3.ID, now)
+		_, err := db.Handle().ExecContext(ctx, `INSERT INTO codeintel_path_ranks (repository_id, precision, updated_at, payload) VALUES ($1, 0, $2, '{}'::jsonb)`, r3.ID, now)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -193,6 +193,10 @@
       "Definition": "CREATE OR REPLACE FUNCTION public.soft_deleted_repository_name(name text)\n RETURNS text\n LANGUAGE plpgsql\n STRICT\nAS $function$\nBEGIN\n    RETURN 'DELETED-' || extract(epoch from transaction_timestamp()) || '-' || name;\nEND;\n$function$\n"
     },
     {
+      "Name": "update_codeintel_path_ranks_updated_at_column",
+      "Definition": "CREATE OR REPLACE FUNCTION public.update_codeintel_path_ranks_updated_at_column()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$ BEGIN\n    NEW.updated_at = NOW();\n    RETURN NEW;\nEND;\n$function$\n"
+    },
+    {
       "Name": "versions_insert_row_trigger",
       "Definition": "CREATE OR REPLACE FUNCTION public.versions_insert_row_trigger()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$\nBEGIN\n    NEW.first_version = NEW.version;\n    RETURN NEW;\nEND $function$\n"
     }
@@ -7018,6 +7022,19 @@
           "IsGenerated": "NEVER",
           "GenerationExpression": "",
           "Comment": ""
+        },
+        {
+          "Name": "updated_at",
+          "Index": 4,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": false,
+          "Default": "now()",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
         }
       ],
       "Indexes": [
@@ -7030,10 +7047,25 @@
           "IndexDefinition": "CREATE UNIQUE INDEX codeintel_path_ranks_repository_id_precision ON codeintel_path_ranks USING btree (repository_id, \"precision\")",
           "ConstraintType": "",
           "ConstraintDefinition": ""
+        },
+        {
+          "Name": "codeintel_path_ranks_updated_at",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX codeintel_path_ranks_updated_at ON codeintel_path_ranks USING btree (updated_at) INCLUDE (repository_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": null,
-      "Triggers": []
+      "Triggers": [
+        {
+          "Name": "update_codeintel_path_ranks_updated_at",
+          "Definition": "CREATE TRIGGER update_codeintel_path_ranks_updated_at BEFORE UPDATE ON codeintel_path_ranks FOR EACH ROW EXECUTE FUNCTION update_codeintel_path_ranks_updated_at_column()"
+        }
+      ]
     },
     {
       "Name": "codeintel_ranking_exports",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -903,13 +903,17 @@ Sharded inputs from Spark jobs that will subsequently be written into `codeintel
 
 # Table "public.codeintel_path_ranks"
 ```
-    Column     |       Type       | Collation | Nullable | Default 
----------------+------------------+-----------+----------+---------
- repository_id | integer          |           | not null | 
- payload       | jsonb            |           | not null | 
- precision     | double precision |           | not null | 
+    Column     |           Type           | Collation | Nullable | Default 
+---------------+--------------------------+-----------+----------+---------
+ repository_id | integer                  |           | not null | 
+ payload       | jsonb                    |           | not null | 
+ precision     | double precision         |           | not null | 
+ updated_at    | timestamp with time zone |           | not null | now()
 Indexes:
     "codeintel_path_ranks_repository_id_precision" UNIQUE, btree (repository_id, "precision")
+    "codeintel_path_ranks_updated_at" btree (updated_at) INCLUDE (repository_id)
+Triggers:
+    update_codeintel_path_ranks_updated_at BEFORE UPDATE ON codeintel_path_ranks FOR EACH ROW EXECUTE FUNCTION update_codeintel_path_ranks_updated_at_column()
 
 ```
 

--- a/migrations/frontend/1667222952_add_codeintel_ranking_timestamps/down.sql
+++ b/migrations/frontend/1667222952_add_codeintel_ranking_timestamps/down.sql
@@ -1,0 +1,4 @@
+DROP TRIGGER IF EXISTS update_codeintel_path_ranks_updated_at ON codeintel_path_ranks;
+DROP FUNCTION IF EXISTS update_codeintel_path_ranks_updated_at_column;
+DROP INDEX IF EXISTS codeintel_path_ranks_updated_at;
+ALTER TABLE codeintel_path_ranks DROP COLUMN IF EXISTS updated_at;

--- a/migrations/frontend/1667222952_add_codeintel_ranking_timestamps/metadata.yaml
+++ b/migrations/frontend/1667222952_add_codeintel_ranking_timestamps/metadata.yaml
@@ -1,0 +1,2 @@
+name: Add codeintel ranking timestamps
+parents: [1666886757, 1666904087, 1666939263]

--- a/migrations/frontend/1667222952_add_codeintel_ranking_timestamps/up.sql
+++ b/migrations/frontend/1667222952_add_codeintel_ranking_timestamps/up.sql
@@ -12,6 +12,5 @@ $$ BEGIN
 END;
 $$ language 'plpgsql';
 
-CREATE OR REPLACE TRIGGER update_codeintel_path_ranks_updated_at
-BEFORE UPDATE ON codeintel_path_ranks
-FOR EACH ROW EXECUTE PROCEDURE update_codeintel_path_ranks_updated_at_column();
+DROP TRIGGER IF EXISTS update_codeintel_path_ranks_updated_at ON codeintel_path_ranks;
+CREATE TRIGGER update_codeintel_path_ranks_updated_at BEFORE UPDATE ON codeintel_path_ranks FOR EACH ROW EXECUTE PROCEDURE update_codeintel_path_ranks_updated_at_column();

--- a/migrations/frontend/1667222952_add_codeintel_ranking_timestamps/up.sql
+++ b/migrations/frontend/1667222952_add_codeintel_ranking_timestamps/up.sql
@@ -1,0 +1,17 @@
+ALTER TABLE
+    codeintel_path_ranks
+ADD
+    COLUMN IF NOT EXISTS updated_at timestamp with time zone NOT NULL DEFAULT NOW();
+
+CREATE INDEX IF NOT EXISTS codeintel_path_ranks_updated_at ON codeintel_path_ranks(updated_at) INCLUDE (repository_id);
+
+CREATE OR REPLACE FUNCTION update_codeintel_path_ranks_updated_at_column() RETURNS TRIGGER AS
+$$ BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE OR REPLACE TRIGGER update_codeintel_path_ranks_updated_at
+BEFORE UPDATE ON codeintel_path_ranks
+FOR EACH ROW EXECUTE PROCEDURE update_codeintel_path_ranks_updated_at_column();


### PR DESCRIPTION
This PR adds timestamps to ranking results. Changes include:

- Add `updated_at` column to `codeintel_path_ranks` that updates via trigger
- Add two methods to the service/store layer for external consumers:
  - `LastUpdatedAt(repos...) -> (map[api.RepoName]time.Time, error)`
  -  `UpdatedAfter(time.Time) -> ([]api.RepoName, error)`
- Update `MinLastChanged` to return repo names if their path ranks have updated (along with gitserver, &c...)

## Test plan

Additional unit tests.