### PR TITLE
Make EnableLegacyExtensions a non-pointer

### DIFF
--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -190,7 +190,6 @@ func canUpdateSiteConfiguration() bool {
 	return os.Getenv("SITE_CONFIG_FILE") == "" || siteConfigAllowEdits
 }
 
-func (r *siteResolver) EnableLegacyExtensions(ctx context.Context) bool {
-	c := conf.Get()
-	return *c.ExperimentalFeatures.EnableLegacyExtensions
+func (r *siteResolver) EnableLegacyExtensions() bool {
+	return conf.ExperimentalFeatures().EnableLegacyExtensions
 }

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -247,7 +247,7 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 
 		ExperimentalFeatures: conf.ExperimentalFeatures(),
 
-		EnableLegacyExtensions: *conf.ExperimentalFeatures().EnableLegacyExtensions,
+		EnableLegacyExtensions: conf.ExperimentalFeatures().EnableLegacyExtensions,
 
 		LicenseInfo: licenseInfo,
 	}

--- a/cmd/frontend/internal/app/ui/legacy_extensions_redirects.go
+++ b/cmd/frontend/internal/app/ui/legacy_extensions_redirects.go
@@ -5,8 +5,7 @@ import (
 )
 
 func ShouldRedirectLegacyExtensionEndpoints() bool {
-	cfg := conf.Get()
-	if cfg.ExperimentalFeatures != nil && cfg.ExperimentalFeatures.EnableLegacyExtensions != nil && *cfg.ExperimentalFeatures.EnableLegacyExtensions == true {
+	if conf.ExperimentalFeatures().EnableLegacyExtensions {
 		return false
 	}
 	return true

--- a/cmd/frontend/internal/app/ui/legacy_extensions_redirects_test.go
+++ b/cmd/frontend/internal/app/ui/legacy_extensions_redirects_test.go
@@ -68,10 +68,9 @@ func TestLegacyExtensionsRedirectsWithExtensionsEnabled(t *testing.T) {
 }
 
 func enableLegacyExtensions() {
-	enableLegacyExtensionsVar := true
 	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{
 		ExperimentalFeatures: &schema.ExperimentalFeatures{
-			EnableLegacyExtensions: &enableLegacyExtensionsVar,
+			EnableLegacyExtensions: true,
 		},
 	}})
 }

--- a/cmd/frontend/registry/api/extensions_test.go
+++ b/cmd/frontend/registry/api/extensions_test.go
@@ -226,10 +226,9 @@ func strptrptr(s string) **string {
 }
 
 func enableLegacyExtensions() {
-	enableLegacyExtensionsVar := true
 	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{
 		ExperimentalFeatures: &schema.ExperimentalFeatures{
-			EnableLegacyExtensions: &enableLegacyExtensionsVar,
+			EnableLegacyExtensions: true,
 		},
 	}})
 }

--- a/cmd/frontend/registry/api/gating.go
+++ b/cmd/frontend/registry/api/gating.go
@@ -84,8 +84,7 @@ func ExtensionRegistryListAllowedExtensions() map[string]bool {
 }
 
 func ExtensionRegistryWriteEnabled() error {
-	cfg := conf.Get()
-	if cfg.ExperimentalFeatures == nil || cfg.ExperimentalFeatures.EnableLegacyExtensions == nil || *cfg.ExperimentalFeatures.EnableLegacyExtensions == false {
+	if !conf.ExperimentalFeatures().EnableLegacyExtensions {
 		return errors.Errorf("Extensions are disabled. See https://docs.sourcegraph.com/extensions/deprecation")
 	}
 

--- a/internal/conf/parse.go
+++ b/internal/conf/parse.go
@@ -20,10 +20,6 @@ func parseConfigData(data string, cfg any) error {
 		if v.ExperimentalFeatures == nil {
 			v.ExperimentalFeatures = &schema.ExperimentalFeatures{}
 		}
-
-		if v.ExperimentalFeatures.EnableLegacyExtensions == nil {
-			v.ExperimentalFeatures.EnableLegacyExtensions = func() *bool { b := false; return &b }()
-		}
 	}
 	return nil
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -620,7 +620,7 @@ type ExperimentalFeatures struct {
 	// EnableGithubInternalRepoVisibility description: Enable support for visilibity of internal Github repositories
 	EnableGithubInternalRepoVisibility bool `json:"enableGithubInternalRepoVisibility,omitempty"`
 	// EnableLegacyExtensions description: Enable the extension registry and the use of extensions (doesn't affect code intel and git extras).
-	EnableLegacyExtensions *bool `json:"enableLegacyExtensions,omitempty"`
+	EnableLegacyExtensions bool `json:"enableLegacyExtensions,omitempty"`
 	// EnablePermissionsWebhooks description: Enables webhook consumers to sync permissions from external services faster than the defaults schedule
 	EnablePermissionsWebhooks bool `json:"enablePermissionsWebhooks,omitempty"`
 	// EnablePostSignupFlow description: Enables post sign-up user flow to add code hosts and sync code

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -545,8 +545,7 @@
         "enableLegacyExtensions": {
           "description": "Enable the extension registry and the use of extensions (doesn't affect code intel and git extras).",
           "type": "boolean",
-          "default": false,
-          "!go": { "pointer": true }
+          "default": false
         },
         "insightsAlternateLoadingStrategy": {
           "description": "Use an in-memory strategy of loading Code Insights. Should only be used for benchmarking on large instances, not for customer use currently.",


### PR DESCRIPTION
This simplifies the code a little, and removes one potentially dangerous pointer destructure in jscontext.go.



## Test plan

Go test suite and compiler should find potential issues.