### PR TITLE
Fix spacings for global bar left items

### DIFF
--- a/client/web/src/nav/GlobalNavbar.module.scss
+++ b/client/web/src/nav/GlobalNavbar.module.scss
@@ -21,7 +21,6 @@
 
 .feedback-trigger {
     border: 1px solid var(--border-color);
-    margin: 0 0.375rem;
     white-space: normal;
 
     &:hover {

--- a/client/web/src/nav/NavBar/NavAction.module.scss
+++ b/client/web/src/nav/NavBar/NavAction.module.scss
@@ -8,38 +8,15 @@
     margin: 0 0 0 auto;
     padding: 0;
     height: 100%;
-    &:first-child {
-        margin-left: 0;
-    }
-    &:last-child {
-        margin-right: 0;
+    gap: 1rem;
+
+    @media (--xs-breakpoint-down) {
+        gap: 0.5rem;
     }
 }
 
 .action {
     display: flex;
     align-items: center;
-    margin: 0 0.5rem;
     padding: 0;
-    height: 100%;
-    &:first-of-type {
-        margin-left: 0;
-    }
-    &:last-of-type {
-        margin-right: 0;
-    }
-    @media (--xs-breakpoint-down) {
-        margin: 0 0.25rem;
-    }
-}
-
-// Global rule is necessary because the elements used as action items are handling margin/padding as part of their own styles.
-:is(.action) :global(.nav-link),
-:is(.action) :global(.btn-link) {
-    margin: 0;
-    padding: 0;
-    color: var(--icon-color);
-    &:hover {
-        color: var(--body-color);
-    }
 }


### PR DESCRIPTION
| Before | After |
| ------- | -------| 
| <img width="376" alt="Screenshot 2022-10-30 at 17 24 50" src="https://user-images.githubusercontent.com/18492575/198900074-7d0bfa57-c394-453d-a257-d1b36c6a4ec6.png"> | <img width="367" alt="Screenshot 2022-10-30 at 17 24 42" src="https://user-images.githubusercontent.com/18492575/198900084-9080d79b-0112-4e75-8470-144ba3bba8f2.png"> |

Previously feedback button had strange inner margin in addition to outer nav item spacing. In this PR we remove this inner spacing and remove old styles over nav bar action items.

## Test plan
- Check that signed in actions look correct.
- Make sure that signed out actions/links visually look correct. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-nav-bar-spacings.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
