### PR TITLE
webhooks: Remove TODO

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -98,7 +98,6 @@ func NewHandler(
 	ghSync.Register(&gh)
 
 	// 🚨 SECURITY: This handler implements its own secret-based auth
-	// TODO: Integrate with webhookMiddleware.Logger
 	webhookHandler := webhooks.NewHandler(logger, db, &gh)
 
 	m.Get(apirouter.Webhooks).Handler(trace.Route(webhookMiddleware.Logger(webhookHandler)))


### PR DESCRIPTION
We've already done this, notice that we wrap `webhookHandler` with `webhookMiddleware.Logger`.



## Test plan

Only removed a comment, no tests required.