### PR TITLE
Qk/fix search toggles

### DIFF
--- a/client/search-ui/src/input/toggles/Toggles.module.scss
+++ b/client/search-ui/src/input/toggles/Toggles.module.scss
@@ -18,9 +18,12 @@
 
 .toggle {
     display: flex;
+    align-items: center;
+    justify-content: center;
     cursor: pointer;
     border-radius: 4px;
-    border: 2px solid transparent;
+    width: 22px;
+    height: 22px;
 
     &:not(:last-child) {
         margin-right: 0.125rem;

--- a/client/search-ui/src/input/toggles/Toggles.module.scss
+++ b/client/search-ui/src/input/toggles/Toggles.module.scss
@@ -75,4 +75,24 @@
             background-color: transparent;
         }
     }
+
+    &[aria-label='Case sensitivity toggle'] {
+        svg {
+            transform: scale(1.234); // Override to set precisely
+            margin-top: -1px; // Override to set precisely
+        }
+    }
+
+    &[aria-label='Regular expression toggle'] {
+        svg {
+            transform: scale(1.125); // Override to set precisely
+            margin-top: -1px; // Override to set precisely
+        }
+    }
+
+    &[aria-label='Structural search toggle'] {
+        svg {
+            transform: scale(1.125); // Override to set precisely
+        }
+    }
 }

--- a/client/search-ui/src/input/toggles/Toggles.module.scss
+++ b/client/search-ui/src/input/toggles/Toggles.module.scss
@@ -22,7 +22,9 @@
     justify-content: center;
     cursor: pointer;
     border-radius: 4px;
+    /* stylelint-disable-next-line declaration-property-unit-allowed-list */
     width: 22px;
+    /* stylelint-disable-next-line declaration-property-unit-allowed-list */
     height: 22px;
 
     &:not(:last-child) {
@@ -85,6 +87,7 @@
     &[aria-label='Regular expression toggle'] {
         svg {
             transform: scale(1.031); // Override to set precisely
+            /* stylelint-disable-next-line declaration-property-unit-allowed-list */
             margin-top: -1px; // Override to set precisely
         }
     }

--- a/client/search-ui/src/input/toggles/Toggles.module.scss
+++ b/client/search-ui/src/input/toggles/Toggles.module.scss
@@ -78,21 +78,20 @@
 
     &[aria-label='Case sensitivity toggle'] {
         svg {
-            transform: scale(1.234); // Override to set precisely
-            margin-top: -1px; // Override to set precisely
+            transform: scale(1.172); // Override to set precisely
         }
     }
 
     &[aria-label='Regular expression toggle'] {
         svg {
-            transform: scale(1.125); // Override to set precisely
+            transform: scale(1.031); // Override to set precisely
             margin-top: -1px; // Override to set precisely
         }
     }
 
     &[aria-label='Structural search toggle'] {
         svg {
-            transform: scale(1.125); // Override to set precisely
+            transform: scale(1.031); // Override to set precisely
         }
     }
 }

--- a/client/search-ui/src/input/toggles/Toggles.module.scss
+++ b/client/search-ui/src/input/toggles/Toggles.module.scss
@@ -22,10 +22,8 @@
     justify-content: center;
     cursor: pointer;
     border-radius: 4px;
-    /* stylelint-disable-next-line declaration-property-unit-allowed-list */
-    width: 22px;
-    /* stylelint-disable-next-line declaration-property-unit-allowed-list */
-    height: 22px;
+    width: 1.375rem;
+    height: 1.375rem;
 
     &:not(:last-child) {
         margin-right: 0.125rem;
@@ -77,24 +75,24 @@
             background-color: transparent;
         }
     }
+}
 
-    &[aria-label='Case sensitivity toggle'] {
-        svg {
-            transform: scale(1.172); // Override to set precisely
-        }
+.case-sensitivity-toggle {
+    svg {
+        transform: scale(1.172); // Override to set precisely
     }
+}
 
-    &[aria-label='Regular expression toggle'] {
-        svg {
-            transform: scale(1.031); // Override to set precisely
-            /* stylelint-disable-next-line declaration-property-unit-allowed-list */
-            margin-top: -1px; // Override to set precisely
-        }
+.regular-expression-toggle {
+    svg {
+        transform: scale(1.031); // Override to set precisely
+        /* stylelint-disable-next-line declaration-property-unit-allowed-list */
+        margin-top: -1px; // Override to set precisely
     }
+}
 
-    &[aria-label='Structural search toggle'] {
-        svg {
-            transform: scale(1.031); // Override to set precisely
-        }
+.structural-search-toggle {
+    svg {
+        transform: scale(1.031); // Override to set precisely
     }
 }

--- a/client/search-ui/src/input/toggles/Toggles.tsx
+++ b/client/search-ui/src/input/toggles/Toggles.tsx
@@ -141,7 +141,7 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
                     onToggle={toggleCaseSensitivity}
                     iconSvgPath={mdiFormatLetterCase}
                     interactive={props.interactive}
-                    className="test-case-sensitivity-toggle"
+                    className={`test-case-sensitivity-toggle ${styles.caseSensitivityToggle}`}
                     disableOn={[
                         {
                             condition: findFilter(navbarSearchQuery, 'case', FilterKind.Subexpression) !== undefined,
@@ -165,7 +165,7 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
                     onToggle={toggleRegexp}
                     iconSvgPath={mdiRegex}
                     interactive={props.interactive}
-                    className="test-regexp-toggle"
+                    className={`test-regexp-toggle ${styles.regularExpressionToggle}`}
                     disableOn={[
                         {
                             condition:
@@ -178,7 +178,7 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
                     {!structuralSearchDisabled && (
                         <QueryInputToggle
                             title="Structural search"
-                            className="test-structural-search-toggle"
+                            className={`test-structural-search-toggle ${styles.structuralSearchToggle}`}
                             isActive={patternType === SearchPatternType.structural}
                             onToggle={toggleStructuralSearch}
                             iconSvgPath={mdiCodeBrackets}

--- a/client/search-ui/src/input/toggles/__snapshots__/Toggles.test.tsx.snap
+++ b/client/search-ui/src/input/toggles/__snapshots__/Toggles.test.tsx.snap
@@ -6,7 +6,7 @@ Array [
     aria-checked="false"
     aria-disabled="true"
     aria-label="Case sensitivity toggle"
-    class="btn btnIcon toggle test-case-sensitivity-toggle disabled"
+    class="btn btnIcon toggle test-case-sensitivity-toggle caseSensitivityToggle disabled"
     role="checkbox"
     tabindex="0"
   >
@@ -33,7 +33,7 @@ Array [
     aria-checked="false"
     aria-disabled="true"
     aria-label="Case sensitivity toggle"
-    class="btn btnIcon toggle test-case-sensitivity-toggle disabled"
+    class="btn btnIcon toggle test-case-sensitivity-toggle caseSensitivityToggle disabled"
     role="checkbox"
     tabindex="0"
   >
@@ -60,7 +60,7 @@ Array [
     aria-checked="false"
     aria-disabled="true"
     aria-label="Regular expression toggle"
-    class="btn btnIcon toggle test-regexp-toggle disabled"
+    class="btn btnIcon toggle test-regexp-toggle regularExpressionToggle disabled"
     role="checkbox"
     tabindex="0"
   >


### PR DESCRIPTION
The search toggles in the search input today are shown at a slightly different size than intended in the Wildcard design system. This discrepancy is at both the container and icon level. The result is toggles that are both visually mismatched with the rest of the search input, and a slightly undersized target area for the cursor on both toggles.

Part of the problem is that we're using mdi icons, which aren't scaled as intended for these specific elements. To fine-tune these icons, I've ~used CSS `transforms` targeting toggles using their aria-label element `&[aria-label='Structural search toggle']`. This particular element seems the most consistent/reliable, as the class names on the toggles appears related to test cases and isn't consistent in format. Happy to change this to a better way as needed.~ added new css module styles for each specific toggle.

## Test plan

- Start locally and interact with toggles in search input.

## App preview:

- [Web](https://sg-web-qk-fix-search-toggles.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
