### PR TITLE
nix: migrate to Nix Flakes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,3 +28,6 @@ ignore = true
 # shfmt shouldn't format third-party script codecov.sh
 [dev/ci/codecov.sh]
 ignore = true
+
+[*.nix]
+indent_size = 2

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1659956501,
+        "narHash": "sha256-7cF2zOaTLWcxmhPBpI1ZoThUy11M1QiY5pat0OXwg3c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6f38b43c8c84c800f93465b2241156419fd4fd52",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6f38b43c8c84c800f93465b2241156419fd4fd52",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "The Sourcegraph developer environment Nix Flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=6f38b43c8c84c800f93465b2241156419fd4fd52";
+  };
+
+  outputs = { self, nixpkgs }:
+    {
+      devShells = nixpkgs.lib.genAttrs
+        [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ]
+        (system:
+          let
+            pkgs = import nixpkgs {
+              inherit system;
+              overlays = [ self.overlays.ctags ];
+            };
+          in
+          {
+            default = import ./shell.nix { inherit pkgs; };
+          }
+        );
+      # Pin a specific version of universal-ctags to the same version as in cmd/symbols/ctags-install-alpine.sh.
+      overlays.ctags = self: super: rec {
+        universal-ctags = super.universal-ctags.overrideAttrs (old: {
+          version = "5.9.20220403.0";
+          src = super.fetchFromGitHub {
+            owner = "universal-ctags";
+            repo = "ctags";
+            rev = "f95bb3497f53748c2b6afc7f298cff218103ab90";
+            sha256 = "sha256-pd89KERQj6K11Nue3YFNO+NLOJGqcMnHkeqtWvMFk38=";
+          };
+          # disable checks, else we get `make[1]: *** No rule to make target 'optlib/cmake.c'.  Stop.`
+          doCheck = false;
+          checkFlags = [ ];
+        });
+      };
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-# Experimental support for developing in nix. Please reach out to @keegan if
+# Experimental support for developing in nix. Please reach out to @keegan or @noah if
 # you encounter any issues.
 #
 # Things it does differently:
@@ -8,39 +8,14 @@
 #
 # Status: everything works on linux. Go1.17 is currently broken on
 # darwin. https://github.com/NixOS/nixpkgs/commit/9675a865c9c3eeec36c06361f7215e109925654c
-
+{ pkgs }:
 let
-  # Pin a specific version of universal-ctags to the same version as in cmd/symbols/ctags-install-alpine.sh.
-  ctags-overlay = (self: super: {
-    universal-ctags = super.universal-ctags.overrideAttrs (old: {
-      version = "5.9.20220403.0";
-      src = super.fetchFromGitHub {
-        owner = "universal-ctags";
-        repo = "ctags";
-        rev = "f95bb3497f53748c2b6afc7f298cff218103ab90";
-        sha256 = "sha256-pd89KERQj6K11Nue3YFNO+NLOJGqcMnHkeqtWvMFk38=";
-      };
-      # disable checks, else we get `make[1]: *** No rule to make target 'optlib/cmake.c'.  Stop.`
-      doCheck = false;
-      checkFlags = [ ];
-    });
-  });
-  # Pin a specific version of nixpkgs to ensure we get the same packages.
-  # To update find a recent commit to nixpkgs. To get the sha256 pass the URL to nix-prefetch-url --unpack
-  pkgs = import
-    (fetchTarball {
-      url =
-        "https://github.com/NixOS/nixpkgs/archive/5e66f427c661955f08d55f654e82bab1b1a7abc1.tar.gz";
-      sha256 = "1rhyn1hrgpsl1ydihan3xb2azz4bghghg451a49sr5vh3v6yz5sy";
-    })
-    { overlays = [ ctags-overlay ]; };
   # pkgs.universal-ctags installs the binary as "ctags", not "universal-ctags"
   # like zoekt expects.
   universal-ctags = pkgs.writeScriptBin "universal-ctags" ''
     #!${pkgs.stdenv.shell}
     exec ${pkgs.universal-ctags}/bin/ctags "$@"
   '';
-
 in
 pkgs.mkShell {
   name = "sourcegraph-dev";
@@ -79,6 +54,8 @@ pkgs.mkShell {
     (yarn.override { nodejs = nodejs-16_x; })
     nodePackages.typescript
 
+    # Rust utils for syntax-highlighter service,
+    # currently not pinned to the same versions.
     cargo
     rustc
     rustfmt
@@ -91,6 +68,7 @@ pkgs.mkShell {
     . ./dev/nix/shell-hook.sh
   '';
 
+  # Fix for using Delve https://github.com/sourcegraph/sourcegraph/pull/35885
   hardeningDisable = [ "fortify" ];
 
   # By explicitly setting this environment variable we avoid starting up


### PR DESCRIPTION
Migrates our Nix devshell to the Cool and New Nix Flakes:tm:. Going forward, `nix develop` will replace `nix-shell` to use this

## Test plan

N/A, dev-env things
