### PR TITLE
internal/database: Order by ID only if no order by args are present

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -793,8 +793,7 @@ func (s *repoStore) List(ctx context.Context, opt ReposListOptions) (results []*
 		tr.Finish()
 	}()
 
-	// always having ID in ORDER BY helps Postgres create a more performant query plan
-	if len(opt.OrderBy) == 0 || (len(opt.OrderBy) == 1 && opt.OrderBy[0].Field != RepoListID) {
+	if len(opt.OrderBy) == 0 {
 		opt.OrderBy = append(opt.OrderBy, RepoListSort{Field: RepoListID})
 	}
 


### PR DESCRIPTION
Previously, we made a change to _always_ order by ID in this PR: https://github.com/sourcegraph/sourcegraph/pull/27026

As a result we would order across multiple dimensions if an existing ORDER BY clause was already being used.

The reasoning back then was to speed up the query which would take >30 seconds on dotcom. It turns out we are back at square one after about a year. On further investigation, the change back then made sense because we used to have a clause to filter against `external_service_repos.org_id` in the "queryConds" (search in example query in linked PR above). However, we have since stopped the usage of this column for filtering repos.

As a result, now that the set of repos is not filtered down by one specific org_id, the resulting set is huge on dotcom and the sorting across two dimensions (name, id) ends up taking ~7s on its own. Additionally it no longer uses the indexes on name as a result.

But sorting by just name takes <150ms with the same query as it is now able to use the repo_name_unique index instead of a sequential scan.

The performance gain is huge for every query that already uses an `ORDER BY` clause for listing repos. Example (~280ms vs 30s) of this can be seen with the following GraphQL query on dotcom. ([link](https://sourcegraph.com/api/console?trace=1#%7B%22query%22%3A%22%7B%5Cn%20%20repositories(first%3A%201)%20%7B%5Cn%20%20%20%20nodes%20%7B%5Cn%20%20%20%20%20%20name%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%22%2C%22variables%22%3A%22%22%7D)):

Alternatively, you may check out the [trace](https://sourcegraph.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22grafanacloud-traces%22,%22queries%22:%5B%7B%22query%22:%2298cc6c0448c3011c9b677485852d2f3c%22,%22queryType%22:%22traceId%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D) of this query on dotcom (expand scroll all the way to the bottom to see the query taking ~26 secs)

```
query {
  repositories(first: 1) {
    nodes {
      name
    }
  }
}
```

### The slow query

![image](https://user-images.githubusercontent.com/2682729/198999477-a8b10c76-0bdb-4610-8028-a8416077a50a.png)

### The fast query

![image](https://user-images.githubusercontent.com/2682729/198999780-c6980cdb-9e49-4858-9241-395ab877b8a8.png)



## Test plan

Tested query against dotcom DB with only `ORDER BY name` and the query completes in ~280 ms.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
