### PR TITLE
Add security events for access token deletions

### DIFF
--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -43,7 +43,9 @@ const (
 
 	SecurityEventNameAccessGranted SecurityEventName = "AccessGranted"
 
-	SecurityEventAccessTokenCreated SecurityEventName = "AccessTokenCreated"
+	SecurityEventAccessTokenCreated     SecurityEventName = "AccessTokenCreated"
+	SecurityEventAccessTokenDeleted     SecurityEventName = "AccessTokenDeleted"
+	SecurityEventAccessTokenHardDeleted SecurityEventName = "AccessTokenHardDeleted"
 )
 
 // SecurityEvent contains information needed for logging a security-relevant event.


### PR DESCRIPTION

## Test plan

- [x] New unit tests
- [x] Manual testing locally - tested `/.api/graphql?DeleteAccessToken` with `byID` and `byToken`

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
