### PR TITLE
bash: unquote bash var expansion in bootstrap script

### DIFF
--- a/dev/sg/bootstrap.sh
+++ b/dev/sg/bootstrap.sh
@@ -59,7 +59,7 @@ main() {
   fi
 
   printf 'running "%s %s"\n' 'sg install' "$*" 1>&2
-  "$_file" install "$*" </dev/tty
+  "$_file" install $* </dev/tty
 }
 
 get_architecture() {

--- a/dev/sg/bootstrap.sh
+++ b/dev/sg/bootstrap.sh
@@ -59,6 +59,7 @@ main() {
   fi
 
   printf 'running "%s %s"\n' 'sg install' "$*" 1>&2
+  # shellcheck disable=SC2048,SC2086
   "$_file" install $* </dev/tty
 }
 


### PR DESCRIPTION
In #43628 I added quotes around `$*` since the shellcheck linter pointed it out. But it turns out that breaks the script as the parameters are then expaned _within_ the quotes instead of passing it as separate args to the command.

Thanks to @abitrolly for testing it again and checking it ❤️ 
## Test plan
* ran `sg lint shell` locally
* added `set -x` to bootstrap script and executed `./dev/sg/bootstrap.sh -a -b`
```
+ printf 'running "%s %s"\n' 'sg install' '-a -b'
running "sg install -a -b"
+ /var/folders/1r/5z42n9p52zv8rfp93gxc1vfr0000gn/T/tmp.RxohMPrX/sg install -a -b
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
