### PR TITLE
log15 migration: executor migrate log15 usage to sglog

### DIFF
--- a/enterprise/cmd/executor/internal/run/run.go
+++ b/enterprise/cmd/executor/internal/run/run.go
@@ -26,9 +26,11 @@ func RunRun(cliCtx *cli.Context, logger log.Logger, cfg *config.Config) error {
 		return err
 	}
 
+	logger = log.Scoped("service", "executor service")
+
 	// Initialize tracing/metrics
 	observationContext := &observation.Context{
-		Logger:     log.Scoped("service", "executor service"),
+		Logger:     logger,
 		Tracer:     &trace.Tracer{TracerProvider: otel.GetTracerProvider()},
 		Registerer: prometheus.DefaultRegisterer,
 	}
@@ -86,7 +88,7 @@ func RunRun(cliCtx *cli.Context, logger log.Logger, cfg *config.Config) error {
 
 	nameSet := janitor.NewNameSet()
 	ctx, cancel := context.WithCancel(cliCtx.Context)
-	worker, err := worker.NewWorker(nameSet, opts, observationContext)
+	worker, err := worker.NewWorker(logger, nameSet, opts, observationContext)
 	if err != nil {
 		cancel()
 		return err

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/log"
 	"go.opentelemetry.io/otel"
 	oteltracesdk "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/trace"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"go.uber.org/automaxprocs/maxprocs"
 
@@ -137,7 +136,7 @@ func newTracer(logger log.Logger, opts *options) (opentracing.Tracer, oteltrace.
 	}
 
 	if err != nil || exporter == nil {
-		return opentracing.NoopTracer{}, trace.NewNoopTracerProvider(), nil, err
+		return opentracing.NoopTracer{}, oteltrace.NewNoopTracerProvider(), nil, err
 	}
 	return newOTelBridgeTracer(logger, exporter, opts.resource, opts.debug)
 }


### PR DESCRIPTION
While digging around for tracing things I decided to do some procasta-work and migrate this file.
## Test plan
Unit tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
