### PR TITLE
migrator: validate -version in drift command

### DIFF
--- a/internal/database/migration/cliutil/drift.go
+++ b/internal/database/migration/cliutil/drift.go
@@ -2,10 +2,12 @@ package cliutil
 
 import (
 	"context"
+	"strings"
 
 	"github.com/urfave/cli/v2"
 
 	descriptions "github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
@@ -34,6 +36,16 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, 
 
 		if (version == "" && file == "") || (version != "" && file != "") {
 			return errors.New("must supply exactly one of -version or -file")
+		}
+
+		if version != "" {
+			if !strings.HasPrefix(version, "v") {
+				return errors.New("bad format for -version. -version must start with 'v'. example: v4.1.2")
+			}
+			_, _, ok := oobmigration.MustNewVersionAndPatchFromString(version)
+			if !ok {
+				return errors.New("bad format for -version. -version must contain major.minor.patch. example: v4.1.2")
+			}
 		}
 
 		if file != "" {

--- a/internal/oobmigration/version.go
+++ b/internal/oobmigration/version.go
@@ -50,6 +50,26 @@ func NewVersionAndPatchFromString(v string) (Version, int, bool) {
 	return NewVersion(major, minor), patch, true
 }
 
+// MustNewVersionAndPatchFromString parses the major, minor and patch version
+// from the given string. It's similar to NewVersionAndPatchFromString but
+// returns a false-valued flag if no patch version was given.
+func MustNewVersionAndPatchFromString(v string) (Version, int, bool) {
+	matches := versionPattern.FindStringSubmatch(v)
+	if len(matches) < 4 {
+		return Version{}, 0, false
+	}
+
+	if matches[1] == "" || matches[2] == "" || matches[3] == "" {
+		return Version{}, 0, false
+	}
+
+	major, _ := strconv.Atoi(matches[1])
+	minor, _ := strconv.Atoi(matches[2])
+	patch, _ := strconv.Atoi(matches[3])
+
+	return NewVersion(major, minor), patch, true
+}
+
 func (v Version) String() string {
 	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
 }


### PR DESCRIPTION
Customer ran into the problem of trying to run `migrator drift` with `-version=3.34` instead of `-version=v3.34.2`.

WDYT @efritz?

## Test plan

- Tested manually:
```
$ go run . drift -version=v4.1 -db=frontend
✱ Sourcegraph migrator 0.0.0+dev
{"SeverityText":"FATAL","Timestamp":1667231329899023000,"InstrumentationScope":"migrator","Caller":"migrator/main.go:27","Function":"main.main","Body":"bad format for -version. -version must contain major.minor.patch. example: v4.1.2","Resource":{"service.name":"migrator","service.version":"0.0.0+dev","service.instance.id":"8d8cd711-063c-40ca-9ff0-63dc2ad7baf3"},"Attributes":{}}
exit status 1

$ go run . drift -version=4.1.0 -db=frontend
✱ Sourcegraph migrator 0.0.0+dev
{"SeverityText":"FATAL","Timestamp":1667231339496352000,"InstrumentationScope":"migrator","Caller":"migrator/main.go:27","Function":"main.main","Body":"bad format for -version. -version must start with 'v'. example: v4.1.2","Resource":{"service.name":"migrator","service.version":"0.0.0+dev","service.instance.id":"0b0317f7-158e-4fb5-88c1-babbf0286488"},"Attributes":{}}
exit status 1

$ go run . drift -version=v4.1.0 -db=frontend
✱ Sourcegraph migrator 0.0.0+dev
ℹ️ Locating schema description
✅ Schema found at github://sourcegraph/sourcegraph/v4.1.0/internal/database/schema.json.
[...]
```