### PR TITLE
Search backend: escape spaces in diff file names

### DIFF
--- a/internal/gitserver/search/diff_format.go
+++ b/internal/gitserver/search/diff_format.go
@@ -36,6 +36,8 @@ func FormatDiff(rawDiff []*diff.FileDiff, highlights map[int]MatchedFileDiff) (s
 		fileCount++
 
 		ranges = append(ranges, fdh.OldFile.Add(loc)...)
+		// NOTE(@camdencheek): this does not correctly update the highlight ranges of files with spaces in the name.
+		// Doing so would require a smarter replacer.
 		escaped := escaper.Replace(fileDiff.OrigName)
 		buf.WriteString(escaped)
 		buf.WriteByte(' ')

--- a/internal/gitserver/search/diff_format.go
+++ b/internal/gitserver/search/diff_format.go
@@ -17,6 +17,8 @@ const (
 	maxFiles          = 5
 )
 
+var escaper = strings.NewReplacer(" ", `\ `)
+
 func FormatDiff(rawDiff []*diff.FileDiff, highlights map[int]MatchedFileDiff) (string, result.Ranges) {
 	var buf strings.Builder
 	var loc result.Location
@@ -34,13 +36,14 @@ func FormatDiff(rawDiff []*diff.FileDiff, highlights map[int]MatchedFileDiff) (s
 		fileCount++
 
 		ranges = append(ranges, fdh.OldFile.Add(loc)...)
-		buf.WriteString(fileDiff.OrigName)
+		escaped := escaper.Replace(fileDiff.OrigName)
+		buf.WriteString(escaped)
 		buf.WriteByte(' ')
 		loc.Offset = buf.Len()
-		loc.Column = len(fileDiff.OrigName) + len(" ")
+		loc.Column = len(escaped) + len(" ")
 
 		ranges = append(ranges, fdh.NewFile.Add(loc)...)
-		buf.WriteString(fileDiff.NewName)
+		buf.WriteString(escaper.Replace(fileDiff.NewName))
 		buf.WriteByte('\n')
 		loc.Offset = buf.Len()
 		loc.Line++

--- a/internal/gitserver/search/diff_format_test.go
+++ b/internal/gitserver/search/diff_format_test.go
@@ -44,8 +44,8 @@ index dbace57d5f..53357b4971 100644
 		require.Equal(t, expectedFormatted, formatted)
 
 		expectedRanges := result.Ranges{{
-			Start: result.Location{Offset: 142, Line: 3, Column: 1},
-			End:   result.Location{Offset: 148, Line: 3, Column: 7},
+			Start: result.Location{Offset: 167, Line: 3, Column: 1},
+			End:   result.Location{Offset: 173, Line: 3, Column: 7},
 		}}
 		require.Equal(t, expectedRanges, ranges)
 	})

--- a/internal/gitserver/search/diff_format_test.go
+++ b/internal/gitserver/search/diff_format_test.go
@@ -14,8 +14,8 @@ func TestDiffFormat(t *testing.T) {
 	t.Run("last line matches", func(t *testing.T) {
 		rawDiff := `diff --git a/.mailmap b/.mailmap
 index dbace57d5f..53357b4971 100644
---- .mailmap
-+++ .mailmap
+--- file with spaces
++++ new file with spaces
 @@ -59,3 +59,4 @@ Unknown <u@gogs.io> 无闻 <u@gogs.io>
  Renovate Bot <bot@renovateapp.com> renovate[bot] <renovate[bot]@users.noreply.github.com>
  Matt King <kingy895@gmail.com> Matthew King <kingy895@gmail.com>
@@ -36,7 +36,7 @@ index dbace57d5f..53357b4971 100644
 		}
 
 		formatted, ranges := FormatDiff(parsedDiff, highlights)
-		expectedFormatted := `.mailmap .mailmap
+		expectedFormatted := `file\ with\ spaces new\ file\ with\ spaces
 @@ -60,1 +60,2 @@ Unknown <u@gogs.io> 无闻 <u@gogs.io>
  Matt King <kingy895@gmail.com> Matthew King <kingy895@gmail.com>
 +Camden Cheek <camden@sourcegraph.com> Camden Cheek <camden@ccheek.com>
@@ -48,6 +48,5 @@ index dbace57d5f..53357b4971 100644
 			End:   result.Location{Offset: 148, Line: 3, Column: 7},
 		}}
 		require.Equal(t, expectedRanges, ranges)
-
 	})
 }

--- a/internal/search/result/commit_diff.go
+++ b/internal/search/result/commit_diff.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -116,9 +117,9 @@ func (cm *CommitDiffMatch) searchResultMarker() {}
 func FormatDiffFiles(res []DiffFile) string {
 	var buf strings.Builder
 	for _, diffFile := range res {
-		buf.WriteString(diffFile.OrigName)
+		buf.WriteString(escaper.Replace(diffFile.OrigName))
 		buf.WriteByte(' ')
-		buf.WriteString(diffFile.NewName)
+		buf.WriteString(escaper.Replace(diffFile.NewName))
 		buf.WriteByte('\n')
 		for _, hunk := range diffFile.Hunks {
 			fmt.Fprintf(&buf, "@@ -%d,%d +%d,%d @@", hunk.OldStart, hunk.OldCount, hunk.NewStart, hunk.NewCount)
@@ -135,6 +136,9 @@ func FormatDiffFiles(res []DiffFile) string {
 	}
 	return buf.String()
 }
+
+var escaper = strings.NewReplacer(" ", `\ `)
+var unescaper = strings.NewReplacer(`\ `, " ")
 
 func ParseDiffString(diff string) (res []DiffFile, err error) {
 	const (
@@ -193,13 +197,14 @@ func ParseDiffString(diff string) (res []DiffFile, err error) {
 }
 
 var errInvalidDiff = errors.New("invalid diff format")
+var splitRegex = lazyregexp.New(`(.*[^\\]) (.*)`)
 
 func splitDiffFiles(fileLine string) (oldFile, newFile string, err error) {
-	split := strings.Fields(fileLine)
-	if len(split) != 2 {
+	match := splitRegex.FindStringSubmatch(fileLine)
+	if len(match) == 0 {
 		return "", "", errInvalidDiff
 	}
-	return split[0], split[1], nil
+	return unescaper.Replace(match[1]), unescaper.Replace(match[2]), nil
 }
 
 var headerRegex = regexp.MustCompile(`@@ -(\d+),(\d+) \+(\d+),(\d+) @@\ ?(.*)`)

--- a/internal/search/result/commit_json_test.go
+++ b/internal/search/result/commit_json_test.go
@@ -42,10 +42,13 @@ func TestCommitMatchMarshaling(t *testing.T) {
 				MatchedRanges: Ranges{{Start: Location{Offset: 0, Line: 0, Column: 0}, End: Location{Offset: 3, Line: 0, Column: 3}}},
 			},
 			DiffPreview: &MatchedString{
-				Content:       "/dev/null drinks/coffee.md",
+				Content:       `drinks/coffee\ with\ milk.md drinks/coffee.md`,
 				MatchedRanges: Ranges{{Start: Location{Offset: 17, Line: 0, Column: 17}, End: Location{Offset: 23, Line: 0, Column: 23}}},
 			},
-			Diff:          func() []DiffFile { dfs, _ := ParseDiffString("/dev/null drinks/coffee.md"); return dfs }(),
+			Diff: func() []DiffFile {
+				dfs, _ := ParseDiffString(`drinks/coffee\ with\ milk.md drinks/coffee.md`)
+				return dfs
+			}(),
 			ModifiedFiles: []string{"drinks/coffee.md", "drinks/tea.md"},
 		}
 


### PR DESCRIPTION
When parsing formatted diffs, we split file names on whitespace. However, file names can contain whitespace, which makes the file delimiting ambiguous.

This escapes spaces in the formatted diff so that we can unambiguously parse the file names.

## Test plan

Updated tests to exercise files with spaces in the name. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
