### PR TITLE
Fuzzy finder: replace fzy with fzf

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -16,7 +16,6 @@ import * as GQL from '@sourcegraph/shared/src/schema'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { parseQueryAndHash } from '@sourcegraph/shared/src/util/url'
 import { LoadingSpinner, Panel } from '@sourcegraph/wildcard'
 
@@ -28,6 +27,7 @@ import { communitySearchContextsRoutes } from './communitySearchContexts/routes'
 import { AppRouterContainer } from './components/AppRouterContainer'
 import { useBreadcrumbs } from './components/Breadcrumbs'
 import { ErrorBoundary } from './components/ErrorBoundary'
+import { LazyFuzzyFinder } from './components/fuzzyFinder/LazyFuzzyFinder'
 import { KeyboardShortcutsHelp } from './components/KeyboardShortcutsHelp/KeyboardShortcutsHelp'
 import { useScrollToLocationHash } from './components/useScrollToLocationHash'
 import { GlobalContributions } from './contributions'
@@ -65,8 +65,6 @@ import { getExperimentalFeatures } from './util/get-experimental-features'
 import { parseBrowserRepoURL } from './util/url'
 
 import styles from './Layout.module.scss'
-
-const FuzzyFinderContainer = lazyComponent(() => import('./components/fuzzyFinder/FuzzyFinder'), 'FuzzyFinderContainer')
 
 export interface LayoutProps
     extends RouteComponentProps<{}>,
@@ -289,7 +287,7 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
                 <NotepadContainer onCreateNotebook={props.onCreateNotebookFromNotepad} />
             )}
             {fuzzyFinder && (
-                <FuzzyFinderContainer
+                <LazyFuzzyFinder
                     isVisible={isFuzzyFinderVisible}
                     setIsVisible={setFuzzyFinderVisible}
                     themeState={themeStateRef}

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -16,6 +16,7 @@ import * as GQL from '@sourcegraph/shared/src/schema'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { parseQueryAndHash } from '@sourcegraph/shared/src/util/url'
 import { LoadingSpinner, Panel } from '@sourcegraph/wildcard'
 
@@ -27,7 +28,6 @@ import { communitySearchContextsRoutes } from './communitySearchContexts/routes'
 import { AppRouterContainer } from './components/AppRouterContainer'
 import { useBreadcrumbs } from './components/Breadcrumbs'
 import { ErrorBoundary } from './components/ErrorBoundary'
-import { FuzzyFinderContainer } from './components/fuzzyFinder/FuzzyFinder'
 import { KeyboardShortcutsHelp } from './components/KeyboardShortcutsHelp/KeyboardShortcutsHelp'
 import { useScrollToLocationHash } from './components/useScrollToLocationHash'
 import { GlobalContributions } from './contributions'
@@ -65,6 +65,8 @@ import { getExperimentalFeatures } from './util/get-experimental-features'
 import { parseBrowserRepoURL } from './util/url'
 
 import styles from './Layout.module.scss'
+
+const FuzzyFinderContainer = lazyComponent(() => import('./components/fuzzyFinder/FuzzyFinder'), 'FuzzyFinderContainer')
 
 export interface LayoutProps
     extends RouteComponentProps<{}>,
@@ -117,7 +119,6 @@ export interface LayoutProps
     isSourcegraphDotCom: boolean
     children?: never
 }
-
 /**
  * Syntax highlighting changes for WCAG 2.1 contrast compliance (currently behind feature flag)
  * https://github.com/sourcegraph/sourcegraph/issues/36251

--- a/client/web/src/components/fuzzyFinder/FuzzyFinderFeatureFlag.ts
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinderFeatureFlag.ts
@@ -17,6 +17,7 @@ export function getFuzzyFinderFeatureFlags(
         fuzzyFinderNavbar,
     } = getExperimentalFeatures(finalSettings)
     // Intentionally skip "Actions" when `fuzzyFinderAll` is true
+    fuzzyFinderAll = true
     fuzzyFinderRepositories = fuzzyFinderAll || fuzzyFinderRepositories
     fuzzyFinderNavbar = fuzzyFinderAll || fuzzyFinderNavbar
     fuzzyFinderSymbols = fuzzyFinderAll || fuzzyFinderSymbols

--- a/client/web/src/components/fuzzyFinder/FuzzyFinderFeatureFlag.ts
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinderFeatureFlag.ts
@@ -17,7 +17,6 @@ export function getFuzzyFinderFeatureFlags(
         fuzzyFinderNavbar,
     } = getExperimentalFeatures(finalSettings)
     // Intentionally skip "Actions" when `fuzzyFinderAll` is true
-    fuzzyFinderAll = true
     fuzzyFinderRepositories = fuzzyFinderAll || fuzzyFinderRepositories
     fuzzyFinderNavbar = fuzzyFinderAll || fuzzyFinderNavbar
     fuzzyFinderSymbols = fuzzyFinderAll || fuzzyFinderSymbols

--- a/client/web/src/components/fuzzyFinder/FuzzyFsm.ts
+++ b/client/web/src/components/fuzzyFinder/FuzzyFsm.ts
@@ -5,7 +5,7 @@ import { createUrlFunction, WordSensitiveFuzzySearch } from '../../fuzzyFinder/W
 // The default value of 80k filenames is picked from the following observations:
 // - case-insensitive search is slow but works in the torvalds/linux repo (72k files)
 // - case-insensitive search is almost unusable in the chromium/chromium repo (360k files)
-const DEFAULT_CASE_INSENSITIVE_FILE_COUNT_THRESHOLD = 80_000
+const DEFAULT_CASE_INSENSITIVE_FILE_COUNT_THRESHOLD = 100_000
 
 /**
  * The fuzzy finder modal is implemented as a state machine with the following transitions:

--- a/client/web/src/components/fuzzyFinder/LazyFuzzyFinder.tsx
+++ b/client/web/src/components/fuzzyFinder/LazyFuzzyFinder.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+
+import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
+
+import type { FuzzyFinderContainerProps } from './FuzzyFinder'
+
+const FuzzyFinderContainer = lazyComponent(() => import('./FuzzyFinder'), 'FuzzyFinderContainer')
+
+export const LazyFuzzyFinder: React.FunctionComponent<FuzzyFinderContainerProps> = props => {
+    const [isLoaded, setIsLoaded] = useState(false)
+    useEffect(() => {
+        // It's OK to always load the fuzzy finder, we just want to delay until
+        // after the initial page render. We delay the request by a small number
+        // of milliseconds to allow other useEffect-triggered GQL request to
+        // take precedence.
+        const id = setTimeout(() => setIsLoaded(true), 100)
+        return () => clearTimeout(id)
+    }, [])
+    return isLoaded ? <FuzzyFinderContainer {...props} /> : null
+}

--- a/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.ts
+++ b/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.ts
@@ -1,13 +1,9 @@
-import * as fzy from 'fzy.js'
+import { extendedMatch, Fzf } from 'fzf'
 
 import { HighlightedLinkProps, RangePosition } from '../components/fuzzyFinder/HighlightedLink'
 
 import { FuzzySearch, FuzzySearchParameters, FuzzySearchResult, SearchValue } from './FuzzySearch'
 import { createUrlFunction } from './WordSensitiveFuzzySearch'
-
-interface ScoredSearchValue extends SearchValue {
-    score: number
-}
 
 class CacheCandidate {
     constructor(public readonly query: string, public readonly candidates: SearchValue[]) {}
@@ -15,12 +11,6 @@ class CacheCandidate {
         return parameters.query.startsWith(this.query)
     }
 }
-
-// The 0.2 value was chosen by manually observing the behavior and confirming
-// that it seems to give relevant results without too much noise.
-const FZY_MINIMUM_SCORE_THRESHOLD = 0.2
-
-const FZY_EQUAL_SCORE_THRESHOLD = 0.2
 
 /**
  * FuzzySearch implementation that uses the original fzy filtering algorithm from https://github.com/jhawthorn/fzy.js
@@ -36,7 +26,6 @@ export class CaseInsensitiveFuzzySearch extends FuzzySearch {
     // last query to allow the user to quickly delete // multiple characters
     // from the query.
     private cacheCandidates: CacheCandidate[] = []
-    private spaceSeparator = new RegExp('\\s+')
 
     constructor(public readonly values: SearchValue[], private readonly createUrl: createUrlFunction) {
         super()
@@ -46,64 +35,23 @@ export class CaseInsensitiveFuzzySearch extends FuzzySearch {
     public search(parameters: FuzzySearchParameters): FuzzySearchResult {
         const cacheCandidate = this.nextCacheCandidate(parameters)
         const searchValues: SearchValue[] = cacheCandidate ? cacheCandidate.candidates : this.values
-        const isEmptyQuery = parameters.query.length === 0
-        const candidates: ScoredSearchValue[] = []
-        const candidatesWithMatch: ScoredSearchValue[] = []
-        const queryParts = parameters.query.split(this.spaceSeparator).filter(part => part.length > 0)
-        if (isEmptyQuery) {
-            // Empty query, match all values
-            candidates.push(...searchValues.map(value => ({ ...value, score: 1 })))
-        } else {
-            for (const value of searchValues) {
-                let score = 0
-                if (queryParts.length === 1 && queryParts[0] === value.text) {
-                    score = value.text.length
-                } else {
-                    for (const queryPart of queryParts) {
-                        // TODO: the query 'sourcegraph' should have a higher
-                        // score for the value 'sourcegraph/sourcegraph' instead
-                        // of 'sourcegraph/scip'. Right now, `sourcegraph/scip` scores
-                        // equally.
-                        const partScore = fzy.score(queryPart, value.text)
-                        score += partScore
-                    }
-                }
-                const noMatch = isNaN(score) || !isFinite(score)
-                if (noMatch) {
-                    continue
-                }
-                if (score > FZY_MINIMUM_SCORE_THRESHOLD) {
-                    candidates.push({ ...value, score })
-                } else {
-                    candidatesWithMatch.push({ ...value, score })
-                }
-            }
-        }
-
-        this.cacheCandidates.push(new CacheCandidate(parameters.query, [...candidates, ...candidatesWithMatch]))
-
-        const isComplete = candidates.length < parameters.maxResults
-        candidates.sort((a, b) => {
-            const byScore = b.score - a.score
-            if (byScore < FZY_EQUAL_SCORE_THRESHOLD && a.ranking && b.ranking) {
-                return b.ranking - a.ranking
-            }
-            return byScore
+        const fzf = new Fzf<SearchValue[]>(searchValues, {
+            selector: ({ text }) => text,
+            limit: parameters.maxResults,
+            match: extendedMatch,
+            tiebreakers: [(a, b) => (b.item?.ranking ?? 0) - (a.item?.ranking ?? 0)],
         })
+        const candidates = fzf.find(parameters.query)
+        // this.cacheCandidates.push(new CacheCandidate(parameters.query, [...candidates.map(({ item }) => item)]))
+        const isComplete = candidates.length < parameters.maxResults
         candidates.slice(0, parameters.maxResults)
 
         const links: HighlightedLinkProps[] = candidates.map(candidate => {
-            const offsets = new Set<number>()
-            for (const queryPart of queryParts) {
-                for (const offset of fzy.positions(queryPart, candidate.text)) {
-                    offsets.add(offset)
-                }
-            }
-            const positions = compressedRangePositions([...offsets])
+            const positions = compressedRangePositions([...candidate.positions])
             return {
-                ...candidate,
+                ...candidate.item,
                 positions,
-                url: candidate.url || this.createUrl?.(candidate.text),
+                url: candidate.item.url || this.createUrl?.(candidate.item.text),
             }
         })
         return {

--- a/package.json
+++ b/package.json
@@ -422,6 +422,7 @@
     "escape-html": "^1.0.3",
     "eventsource": "1.1.1",
     "focus-visible": "^5.2.0",
+    "fzf": "^0.5.1",
     "fzy.js": "^0.4.1",
     "got": "^11.5.2",
     "graphiql": "^1.11.5",

--- a/package.json
+++ b/package.json
@@ -423,7 +423,6 @@
     "eventsource": "1.1.1",
     "focus-visible": "^5.2.0",
     "fzf": "^0.5.1",
-    "fzy.js": "^0.4.1",
     "got": "^11.5.2",
     "graphiql": "^1.11.5",
     "highlight.js": "^10.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17738,6 +17738,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fzf@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "fzf@npm:0.5.1"
+  checksum: 5c5f56ec9fdd83c7edba58425aa3fadd587aeb9d18b013b8a0f14c80f8eef6b068249786b2e3707be9306fe877f21107f9dce5b4aabb58ee7f488de32191e62a
+  languageName: node
+  linkType: hard
+
 "fzy.js@npm:^0.4.1":
   version: 0.4.1
   resolution: "fzy.js@npm:0.4.1"
@@ -28797,6 +28804,7 @@ pvutils@latest:
     express-static-gzip: ^2.1.1
     fancy-log: ^1.3.3
     focus-visible: ^5.2.0
+    fzf: ^0.5.1
     fzy.js: ^0.4.1
     get-port: ^5.1.1
     glob: ^7.1.6

--- a/yarn.lock
+++ b/yarn.lock
@@ -17745,13 +17745,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fzy.js@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "fzy.js@npm:0.4.1"
-  checksum: 962419f11e75a07cc7dca608cd3d64045d7cbb62359ded7b8faac7fd0555bd42d9af74f905d90f84d3e8dfe3b805c55b9885b4d2cd763b4df8fa63d7e1c884ff
-  languageName: node
-  linkType: hard
-
 "gauge@npm:^3.0.0":
   version: 3.0.2
   resolution: "gauge@npm:3.0.2"
@@ -28805,7 +28798,6 @@ pvutils@latest:
     fancy-log: ^1.3.3
     focus-visible: ^5.2.0
     fzf: ^0.5.1
-    fzy.js: ^0.4.1
     get-port: ^5.1.1
     glob: ^7.1.6
     google-protobuf: 3.17.3


### PR DESCRIPTION
This PR replaces fzy.js with fzf to improve the quality of the fuzzy matcher. Thank you @tjdevries for the fzf suggestion, this change is a huge improvement!

One example where fzf improves on the results over fzy.

**Before**
Highlighted ranges didn't prioritize exact capitalized matches

<img width="513" alt="CleanShot 2022-11-02 at 16 12 29@2x" src="https://user-images.githubusercontent.com/1408093/199542874-6806b979-e190-4ec1-ae7c-3ae1dc5a1ffa.png">

**After**
<img width="490" alt="CleanShot 2022-11-02 at 16 12 45@2x" src="https://user-images.githubusercontent.com/1408093/199543063-5efdbf61-8692-493b-8bbd-b11268664518.png">


## Test plan

- Run `sg start`
- Use any special fzf syntax from https://github.com/junegunn/fzf/tree/7191ebb615f5d6ebbf51d598d8ec853a65e2274d#search-syntax
- In sg/sg, search `FuzzySearch` and validate it highlights the filenames instead of directories

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-fzf.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
