### PR TITLE
perms: Use repostore get method instead of list

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -693,16 +693,13 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 	ctx, save := s.observe(ctx, "PermsSyncer.syncRepoPerms", "")
 	defer save(requestTypeRepo, int32(repoID), &err)
 
-	rs, err := s.reposStore.RepoStore().List(ctx, database.ReposListOptions{
-		IDs: []api.RepoID{repoID},
-	})
+	repo, err := s.reposStore.RepoStore().Get(ctx, repoID)
 	if err != nil {
-		return errors.Wrap(err, "list repositories")
-	} else if len(rs) == 0 {
-		return nil
+		if errcode.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrap(err, "get repository")
 	}
-	repo := rs[0]
-
 	var userIDs []int32
 	var provider authz.Provider
 

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -656,17 +656,15 @@ func TestPermsSyncer_syncRepoPerms(t *testing.T) {
 	}
 
 	t.Run("TouchRepoPermissions is called when no authz provider", func(t *testing.T) {
-		mockRepos.ListFunc.SetDefaultReturn(
-			[]*types.Repo{
-				{
-					ID:      1,
-					Private: true,
-					ExternalRepo: api.ExternalRepoSpec{
-						ServiceID: "https://gitlab.com/",
-					},
-					Sources: map[string]*types.SourceInfo{
-						extsvc.URN(extsvc.TypeGitLab, 0): {},
-					},
+		mockRepos.GetFunc.SetDefaultReturn(
+			&types.Repo{
+				ID:      1,
+				Private: true,
+				ExternalRepo: api.ExternalRepoSpec{
+					ServiceID: "https://gitlab.com/",
+				},
+				Sources: map[string]*types.SourceInfo{
+					extsvc.URN(extsvc.TypeGitLab, 0): {},
 				},
 			},
 			nil,


### PR DESCRIPTION
This just reads a little nicer, no change in functionality here.



## Test plan

Just a small refactor, tests should catch regressions.