### PR TITLE
Fix empty shard ID on repos page

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -181,7 +181,11 @@ func (r *repositoryMirrorInfoResolver) Shard(ctx context.Context) (*string, erro
 		return nil, err
 	}
 
-	return &info.ShardID, err
+	if info.ShardID == "" {
+		return nil, nil
+	}
+
+	return &info.ShardID, nil
 }
 
 func (r *repositoryMirrorInfoResolver) UpdateSchedule(ctx context.Context) (*updateScheduleResolver, error) {


### PR DESCRIPTION
Previously, this resolver would not return `null` but an empty string. This fixes it so that the "Not assigned" banner is properly shown in the UI.



## Test plan

Verified the banner now shows correctly.