### PR TITLE
Fix double status messages after error

### DIFF
--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -265,7 +265,7 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
                 variant="link"
                 aria-label={isOpen ? 'Hide status messages' : 'Show status messages'}
             >
-                {error && (
+                {error ? (
                     <Tooltip content="Sorry, we couldn’t fetch notifications!">
                         <Icon
                             aria-label="Sorry, we couldn’t fetch notifications!"
@@ -273,8 +273,9 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
                             size="md"
                         />
                     </Tooltip>
+                ) : (
+                    icon
                 )}
-                {icon}
             </PopoverTrigger>
 
             <PopoverContent position={Position.bottom} className={classNames('p-0', styles.dropdownMenu)}>


### PR DESCRIPTION
This fixes a bug where two status message items could be rendered in the navbar.

Closes https://github.com/sourcegraph/sourcegraph/issues/43693

## Test plan

Tested locally that it works correctly now.

## App preview:

- [Web](https://sg-web-es-status-navbar-double-icon.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
