### PR TITLE
Fix popover/tooltip tail UI styles based on tail css variables

### DIFF
--- a/client/wildcard/src/components/Popover/components/popover-tail/PopoverTail.module.scss
+++ b/client/wildcard/src/components/Popover/components/popover-tail/PopoverTail.module.scss
@@ -1,16 +1,17 @@
+:root {
+    --tail-width: 24px;
+    --tail-background: var(--dropdown-bg);
+    --tail-border: 1px solid var(--dropdown-border-color);
+}
+
 .tail {
     position: fixed;
     top: 0;
     left: 0;
-    overflow: hidden;
-    pointer-events: none;
-
-    --tail-width: 24px;
-    --tail-background: var(--dropdown-bg);
-    --tail-border: 1px solid var(--dropdown-border-color);
-
     width: var(--tail-width);
     height: calc(var(--tail-width) / 2);
+    overflow: hidden;
+    pointer-events: none;
 
     &--size-sm {
         --tail-width: 16px;

--- a/client/wildcard/src/components/Popover/components/popover-tail/PopoverTail.module.scss
+++ b/client/wildcard/src/components/Popover/components/popover-tail/PopoverTail.module.scss
@@ -1,8 +1,3 @@
-:root {
-    --tail-width: 24px;
-    --tail-background: var(--dropdown-bg);
-    --tail-border: 1px solid var(--dropdown-border-color);
-}
 
 .tail {
     position: fixed;
@@ -15,6 +10,10 @@
 
     &--size-sm {
         --tail-width: 16px;
+    }
+
+    &--size-md {
+        --tail-width: 24px;
     }
 
     &--size-lg {
@@ -71,7 +70,7 @@
         height: 70%;
         transform: translate(0%, -70%) rotate(45deg);
 
-        background-color: var(--tail-background);
-        border: var(--tail-border);
+        background-color: var(--tail-background, var(--dropdown-bg));
+        border: var(--tail-border, 1px solid var(--dropdown-border-color));
     }
 }

--- a/client/wildcard/src/components/Popover/components/popover-tail/PopoverTail.tsx
+++ b/client/wildcard/src/components/Popover/components/popover-tail/PopoverTail.tsx
@@ -18,6 +18,7 @@ enum PopoverSize {
 
 const sizeClasses: Partial<Record<PopoverSize, string>> = {
     [PopoverSize.sm]: style.tailSizeSm,
+    [PopoverSize.md]: style.tailSizeMd,
     [PopoverSize.lg]: style.tailSizeLg,
 }
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/43707

| Before | After | 
| ------- | ------ |
| <img width="246" alt="Screenshot 2022-10-31 at 14 23 35" src="https://user-images.githubusercontent.com/18492575/199078416-1a476541-c79e-4e1b-924c-56154a118a4b.png"> | <img width="240" alt="Screenshot 2022-10-31 at 14 58 23" src="https://user-images.githubusercontent.com/18492575/199078456-3aef0da5-d1d4-468e-9dfd-84d3b4758537.png"> |

## Test plan
- Make sure that production build has correctly visual appearance of tooltip and its tail UI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-tooltip-tail-styles.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
