### PR TITLE
Search backend: add timeouts to repo status map for commit and diff search

### DIFF
--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -80,9 +80,11 @@ func (j *SearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream 
 
 		doSearch := func(args *gitprotocol.SearchRequest) error {
 			limitHit, err := clients.Gitserver.Search(ctx, args, onMatches)
+			statusMap, limitHit, err := search.HandleRepoSearchResult(repoRev.Repo.ID, repoRev.Revs, limitHit, false, err)
 			stream.Send(streaming.SearchEvent{
 				Stats: streaming.Stats{
 					IsLimitHit: limitHit,
+					Status:     statusMap,
 				},
 			})
 			return err


### PR DESCRIPTION
This updates the stream stats with the timeout results for each repo searched for commit and diff search, matching the pattern of how we do unindexed search.

Fixes #42719

## Test plan

<img width="703" alt="Screen Shot 2022-10-31 at 13 11 02" src="https://user-images.githubusercontent.com/12631702/199090390-7b12bc3f-5019-4d44-b111-805c03cc51dc.png">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
