### PR TITLE
insights: start calculating query cost and persisting to backfill record

### DIFF
--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/compression"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/pipeline"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/priority"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/scheduler"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -102,6 +103,7 @@ func GetBackgroundJobs(ctx context.Context, logger log.Logger, mainAppDB databas
 						Name:      "insight_backfill_new_index_repositories_analyzed",
 						Help:      "Counter of the number of repositories analyzed in the backfiller new state.",
 					}),
+				CostAnalyzer: priority.DefaultQueryAnalyzer(),
 			}
 			monitor := scheduler.NewBackgroundJobMonitor(ctx, config)
 			routines = append(routines, monitor.Routines()...)

--- a/enterprise/internal/insights/priority/analyzer.go
+++ b/enterprise/internal/insights/priority/analyzer.go
@@ -17,10 +17,14 @@ type QueryObject struct {
 	NumberOfRepositories int64
 	RepositoryByteSizes  []int64 // size of repositories in bytes, if known
 
-	Cost float64
+	cost float64
 }
 
 type CostHeuristic func(*QueryObject)
+
+func DefaultQueryAnalyzer() *QueryAnalyzer {
+	return NewQueryAnalyzer(QueryCost, RepositoriesCost)
+}
 
 func NewQueryAnalyzer(handlers ...CostHeuristic) *QueryAnalyzer {
 	return &QueryAnalyzer{
@@ -32,20 +36,20 @@ func (a *QueryAnalyzer) Cost(o *QueryObject) float64 {
 	for _, handler := range a.costHandlers {
 		handler(o)
 	}
-	if o.Cost < 0.0 {
+	if o.cost < 0.0 {
 		return 0.0
 	}
-	return o.Cost
+	return o.cost
 }
 
 func QueryCost(o *QueryObject) {
 	for _, basic := range o.Query {
 		if basic.IsStructural() {
-			o.Cost += StructuralCost
+			o.cost += StructuralCost
 		} else if basic.IsRegexp() {
-			o.Cost += RegexpCost
+			o.cost += RegexpCost
 		} else {
-			o.Cost += LiteralCost
+			o.cost += LiteralCost
 		}
 	}
 
@@ -60,40 +64,40 @@ func QueryCost(o *QueryObject) {
 		}
 	})
 	if diff {
-		o.Cost *= DiffMultiplier
+		o.cost *= DiffMultiplier
 	}
 	if commit {
-		o.Cost *= CommitMultiplier
+		o.cost *= CommitMultiplier
 	}
 
 	parameters := querybuilder.ParametersFromQueryPlan(o.Query)
 	if parameters.Index() == query.No {
-		o.Cost *= UnindexedMultiplier
+		o.cost *= UnindexedMultiplier
 	}
 	if parameters.Exists(query.FieldAuthor) {
-		o.Cost *= AuthorMultiplier
+		o.cost *= AuthorMultiplier
 	}
 	if parameters.Exists(query.FieldFile) {
-		o.Cost *= FileMultiplier
+		o.cost *= FileMultiplier
 	}
 	if parameters.Exists(query.FieldLang) {
-		o.Cost *= LangMultiplier
+		o.cost *= LangMultiplier
 	}
 
 	archived := parameters.Archived()
 	if archived != nil {
 		if *archived == query.Yes {
-			o.Cost *= YesMultiplier
+			o.cost *= YesMultiplier
 		} else if *archived == query.Only {
-			o.Cost *= OnlyMultiplier
+			o.cost *= OnlyMultiplier
 		}
 	}
 	fork := parameters.Fork()
 	if fork != nil && (*fork == query.Yes || *fork == query.Only) {
 		if *fork == query.Yes {
-			o.Cost *= YesMultiplier
+			o.cost *= YesMultiplier
 		} else if *fork == query.Only {
-			o.Cost *= OnlyMultiplier
+			o.cost *= OnlyMultiplier
 		}
 	}
 }
@@ -104,12 +108,12 @@ var (
 )
 
 func RepositoriesCost(o *QueryObject) {
-	if o.Cost <= 0.0 {
-		o.Cost = 1 // if this handler is called on its own we still want it to impact the cost.
+	if o.cost <= 0.0 {
+		o.cost = 1 // if this handler is called on its own we still want it to impact the cost.
 	}
 
 	if o.NumberOfRepositories > 10000 {
-		o.Cost *= ManyRepositoriesMultiplier
+		o.cost *= ManyRepositoriesMultiplier
 	}
 
 	var megarepo, gigarepo bool
@@ -122,8 +126,8 @@ func RepositoriesCost(o *QueryObject) {
 		}
 	}
 	if gigarepo {
-		o.Cost *= GigarepoMultiplier
+		o.cost *= GigarepoMultiplier
 	} else if megarepo {
-		o.Cost *= MegarepoMultiplier
+		o.cost *= MegarepoMultiplier
 	}
 }

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
@@ -11,6 +11,7 @@ import (
 
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/pipeline"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/priority"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/scheduler/iterator"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
@@ -48,6 +49,7 @@ func Test_MovesBackfillFromProcessingToComplete(t *testing.T) {
 		InsightStore:   seriesStore,
 		ObsContext:     &observation.TestContext,
 		BackfillRunner: &noopBackfillRunner{},
+		CostAnalyzer:   priority.NewQueryAnalyzer(),
 	}
 	monitor := NewBackgroundJobMonitor(ctx, config)
 

--- a/enterprise/internal/insights/scheduler/scheduler.go
+++ b/enterprise/internal/insights/scheduler/scheduler.go
@@ -11,6 +11,7 @@ import (
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/pipeline"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/priority"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -109,6 +110,7 @@ type JobMonitorConfig struct {
 	BackfillRunner  pipeline.Backfiller
 	ObsContext      *observation.Context
 	AllRepoIterator *discovery.AllReposIterator
+	CostAnalyzer    *priority.QueryAnalyzer
 }
 
 func NewBackgroundJobMonitor(ctx context.Context, config JobMonitorConfig) *BackgroundJobMonitor {

--- a/enterprise/internal/insights/scheduler/scheduler_test.go
+++ b/enterprise/internal/insights/scheduler/scheduler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/priority"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -26,9 +27,10 @@ func Test_MonitorStartsAndStops(t *testing.T) {
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t))
 	repos := database.NewMockRepoStore()
 	config := JobMonitorConfig{
-		InsightsDB: insightsDB,
-		RepoStore:  repos,
-		ObsContext: &observation.TestContext,
+		InsightsDB:   insightsDB,
+		RepoStore:    repos,
+		ObsContext:   &observation.TestContext,
+		CostAnalyzer: priority.NewQueryAnalyzer(),
 	}
 	routines := NewBackgroundJobMonitor(ctx, config).Routines()
 	goroutine.MonitorBackgroundRoutines(ctx, routines...)
@@ -41,9 +43,10 @@ func TestScheduler_InitialBackfill(t *testing.T) {
 	repos := database.NewMockRepoStore()
 	insightsStore := store.NewInsightStore(insightsDB)
 	config := JobMonitorConfig{
-		InsightsDB: insightsDB,
-		RepoStore:  repos,
-		ObsContext: &observation.TestContext,
+		InsightsDB:   insightsDB,
+		RepoStore:    repos,
+		ObsContext:   &observation.TestContext,
+		CostAnalyzer: priority.NewQueryAnalyzer(),
 	}
 	monitor := NewBackgroundJobMonitor(ctx, config)
 


### PR DESCRIPTION
First step towards ordering backfill runs, this starts calculating the cost of the backfill in the handler processes the "new" state.  Next step will be to use it in the ordering.

part of https://github.com/sourcegraph/sourcegraph/issues/42959

## Test plan
existing unit tests pass
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
