### PR TITLE
httpapi: simple test for SendEmail internal API handling

### DIFF
--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -90,11 +90,15 @@ func serveExternalURL(w http.ResponseWriter, _ *http.Request) error {
 	return nil
 }
 
-func serveSendEmail(_ http.ResponseWriter, r *http.Request) error {
+func decodeSendEmail(r *http.Request) (txtypes.InternalAPIMessage, error) {
 	var msg txtypes.InternalAPIMessage
-	err := json.NewDecoder(r.Body).Decode(&msg)
+	return msg, json.NewDecoder(r.Body).Decode(&msg)
+}
+
+func serveSendEmail(_ http.ResponseWriter, r *http.Request) error {
+	msg, err := decodeSendEmail(r)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "decode request")
 	}
 	return txemail.Send(r.Context(), msg.Source, msg.Message)
 }

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -9,9 +9,12 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
 
 	apirouter "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/router"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/api/internalapi"
+	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
 )
 
 func TestGitServiceHandlers(t *testing.T) {
@@ -55,4 +58,38 @@ type mockAddrForRepo struct{}
 
 func (mockAddrForRepo) AddrForRepo(_ context.Context, name api.RepoName) (string, error) {
 	return strings.ReplaceAll(string(name), "/", ".") + ".gitserver", nil
+}
+
+// newTestInternalRouter creates a minimal router for internal endpoints. You can use
+// m.Get(apirouter.FOOBAR) to mock out endpoints, and then provide the router to
+// httptest.NewServer.
+func newTestInternalRouter() *mux.Router {
+	// Magic incantation from newInternalHTTPHandler
+	sr := mux.NewRouter().PathPrefix("/.internal/").Subrouter()
+	return apirouter.NewInternal(sr)
+}
+
+func TestDecodeSendEmail(t *testing.T) {
+	m := newTestInternalRouter()
+	m.Get(apirouter.SendEmail).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		msg, err := decodeSendEmail(r)
+
+		assert.NoError(t, err)
+		assert.Equal(t, msg.Source, "testdecode")
+		assert.Contains(t, msg.To, "foobar@foobar.com")
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ts := httptest.NewServer(m)
+	t.Cleanup(ts.Close)
+
+	client := &(*internalapi.Client)
+	client.URL = ts.URL
+
+	// Do not worry about error here, run assertions in the test handler
+	err := client.SendEmail(context.Background(), "testdecode", txtypes.Message{
+		To: []string{"foobar@foobar.com"},
+	})
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
Follow-up to #43713 . Not really clear how to best test these things (doesn't seem to be a consistent pattern here) but I figured this might be good to add as a sanity check and a starting point

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

the test passes