### PR TITLE
httpapi: use scoped logger for error handling

### DIFF
--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/sourcegraph/log/logtest"
+
 	apirouter "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/router"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 )
@@ -21,6 +23,7 @@ func TestGitServiceHandlers(t *testing.T) {
 		Gitserver: mockAddrForRepo{},
 	}
 	handler := jsonMiddleware(&errorHandler{
+		Logger: logtest.Scoped(t),
 		// Internal endpoints can expose sensitive errors
 		WriteErrBody: true,
 	})


### PR DESCRIPTION
Noticed in https://sourcegraph.slack.com/archives/CMBA8F926/p1667241309400239

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

checked all callsites