### PR TITLE
code monitors: remove sidebar

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback } from 'react'
 
 import { useHistory, useLocation } from 'react-router'
 import { of } from 'rxjs'
 
-import { Button, Container, Link, H2, H3 } from '@sourcegraph/wildcard'
+import { Container, Link, H2, H3 } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { FilteredConnection } from '../../components/FilteredConnection'
@@ -12,8 +12,6 @@ import { CodeMonitorFields, ListUserCodeMonitorsResult, ListUserCodeMonitorsVari
 import { CodeMonitorNode, CodeMonitorNodeProps } from './CodeMonitoringNode'
 import { CodeMonitoringPageProps } from './CodeMonitoringPage'
 import { CodeMonitorSignUpLink } from './CodeMonitoringSignUpLink'
-
-type CodeMonitorFilter = 'all' | 'user'
 
 interface CodeMonitorListProps
     extends Required<Pick<CodeMonitoringPageProps, 'fetchUserCodeMonitors' | 'toggleCodeMonitorEnabled'>> {
@@ -43,7 +41,6 @@ export const CodeMonitorList: React.FunctionComponent<React.PropsWithChildren<Co
 }) => {
     const location = useLocation()
     const history = useHistory()
-    const [monitorListFilter, setMonitorListFilter] = useState<CodeMonitorFilter>('all')
 
     const queryConnection = useCallback(
         (args: Partial<ListUserCodeMonitorsVariables>) => {
@@ -67,27 +64,8 @@ export const CodeMonitorList: React.FunctionComponent<React.PropsWithChildren<Co
     return (
         <>
             <div className="row mb-5">
-                <div className="d-flex flex-column col-2 mr-2">
-                    <H3 as={H2}>Filters</H3>
-                    <Button
-                        className="text-left"
-                        onClick={() => setMonitorListFilter('all')}
-                        variant={monitorListFilter === 'all' ? 'primary' : undefined}
-                    >
-                        All
-                    </Button>
-                    <Button
-                        className="text-left"
-                        onClick={() => setMonitorListFilter('user')}
-                        variant={monitorListFilter === 'user' ? 'primary' : undefined}
-                    >
-                        Your code monitors
-                    </Button>
-                </div>
                 <div className="d-flex flex-column w-100 col">
-                    <H3 className="mb-2">
-                        {`${monitorListFilter === 'all' ? 'All code monitors' : 'Your code monitors'}`}
-                    </H3>
+                    <H3 className="mb-2">Your code monitors</H3>
                     <Container className="py-3">
                         <FilteredConnection<
                             CodeMonitorFields,


### PR DESCRIPTION
The current sidebar is a currently a no-op since we only have user-owned code monitors with no sharing. We should remove it for now and add it back once we have useful filters.


## Test plan

<img width="1274" alt="image" src="https://user-images.githubusercontent.com/206864/199123933-1d3fa5d7-e3be-4a0b-8b62-ce19e82caa5d.png">

## App preview:

- [Web](https://sg-web-jp-codemonitorsremovesidebar.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
