### PR TITLE
ranking: introduce DocumentRankVersion

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -176,10 +176,9 @@ func NewInternalHandler(
 			return searchcontexts.RepoRevs(ctx, db, repoIDs)
 		},
 		Indexers: search.Indexers(),
+		Ranking:  codeIntelServices.RankingService,
 
 		MinLastChangedDisabled: os.Getenv("SRC_SEARCH_INDEXER_EFFICIENT_POLLING_DISABLED") != "",
-
-		codeIntelServices: codeIntelServices,
 	}
 	m.Get(apirouter.SearchConfiguration).Handler(trace.Route(handler(indexer.serveConfiguration)))
 	m.Get(apirouter.ReposIndex).Handler(trace.Route(handler(indexer.serveList)))

--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/zoekt"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	internalcodeintel "github.com/sourcegraph/sourcegraph/internal/codeintel"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -78,11 +77,16 @@ type searchIndexerServer struct {
 		Enabled() bool
 	}
 
+	// Ranking is a subset of codeintel.ranking.Service methods we use.
+	Ranking interface {
+		LastUpdatedAt(ctx context.Context, repoIDs []api.RepoID) (map[api.RepoID]time.Time, error)
+		GetRepoRank(ctx context.Context, repoName api.RepoName) (_ []float64, err error)
+		GetDocumentRanks(ctx context.Context, repoName api.RepoName) (_ map[string][]float64, err error)
+	}
+
 	// MinLastChangedDisabled is a feature flag for disabling more efficient
 	// polling by zoekt. This can be removed after v3.34 is cut (Dec 2021).
 	MinLastChangedDisabled bool
-
-	codeIntelServices internalcodeintel.Services
 }
 
 // serveConfiguration is _only_ used by the zoekt index server. Zoekt does
@@ -154,7 +158,7 @@ func (h *searchIndexerServer) serveConfiguration(w http.ResponseWriter, r *http.
 		indexedIDs = filtered
 	}
 
-	rankingLastUpdatedAt, err := h.codeIntelServices.RankingService.LastUpdatedAt(ctx, indexedIDs)
+	rankingLastUpdatedAt, err := h.Ranking.LastUpdatedAt(ctx, indexedIDs)
 	if err != nil {
 		h.logger.Warn("failed to get ranking last updated timestamps, falling back to no rankingx",
 			log.Int("repos", len(indexedIDs)),
@@ -293,11 +297,11 @@ var metricGetVersion = promauto.NewCounter(prometheus.CounterOpts{
 })
 
 func (h *searchIndexerServer) serveRepoRank(w http.ResponseWriter, r *http.Request) error {
-	return serveRank(h.codeIntelServices.RankingService.GetRepoRank, w, r)
+	return serveRank(h.Ranking.GetRepoRank, w, r)
 }
 
 func (h *searchIndexerServer) serveDocumentRanks(w http.ResponseWriter, r *http.Request) error {
-	return serveRank(h.codeIntelServices.RankingService.GetDocumentRanks, w, r)
+	return serveRank(h.Ranking.GetDocumentRanks, w, r)
 }
 
 func serveRank[T []float64 | map[string][]float64](

--- a/cmd/frontend/internal/httpapi/search_test.go
+++ b/cmd/frontend/internal/httpapi/search_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log/logtest"
@@ -45,6 +46,7 @@ func TestServeConfiguration(t *testing.T) {
 		SearchContextsRepoRevs: func(ctx context.Context, repoIDs []api.RepoID) (map[api.RepoID][]string, error) {
 			return map[api.RepoID][]string{6: {"a", "b"}}, nil
 		},
+		Ranking: &fakeRankingService{},
 	}
 
 	data := url.Values{
@@ -226,6 +228,18 @@ func (f *fakeRepoStore) StreamMinimalRepos(ctx context.Context, opt database.Rep
 	}
 
 	return nil
+}
+
+type fakeRankingService struct{}
+
+func (*fakeRankingService) LastUpdatedAt(ctx context.Context, repoIDs []api.RepoID) (map[api.RepoID]time.Time, error) {
+	return map[api.RepoID]time.Time{}, nil
+}
+func (*fakeRankingService) GetRepoRank(ctx context.Context, repoName api.RepoName) (_ []float64, err error) {
+	return nil, nil
+}
+func (*fakeRankingService) GetDocumentRanks(ctx context.Context, repoName api.RepoName) (_ map[string][]float64, err error) {
+	return nil, nil
 }
 
 // suffixIndexers mocks Indexers. ReposSubset will return all repoNames with

--- a/internal/codeintel/ranking/internal/store/store_test.go
+++ b/internal/codeintel/ranking/internal/store/store_test.go
@@ -243,7 +243,9 @@ func TestLastUpdatedAt(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := New(db, &observation.TestContext)
 
-	if _, err := db.ExecContext(ctx, `INSERT INTO repo (name) VALUES ('foo'), ('bar'), ('baz')`); err != nil {
+	idFoo := api.RepoID(1)
+	idBar := api.RepoID(2)
+	if _, err := db.ExecContext(ctx, `INSERT INTO repo (id, name) VALUES (1, 'foo'), (2, 'bar'), (3, 'baz')`); err != nil {
 		t.Fatalf("failed to insert repos: %s", err)
 	}
 	if err := store.SetDocumentRanks(ctx, "foo", 0.25, nil); err != nil {
@@ -253,20 +255,20 @@ func TestLastUpdatedAt(t *testing.T) {
 		t.Fatalf("unexpected error setting document ranks: %s", err)
 	}
 
-	pairs, err := store.LastUpdatedAt(ctx, []api.RepoName{"foo", "bar", "bonk"})
+	pairs, err := store.LastUpdatedAt(ctx, []api.RepoID{idFoo, idBar})
 	if err != nil {
 		t.Fatalf("unexpected error getting repo last update times: %s", err)
 	}
 
-	fooUpdatedAt, ok := pairs["foo"]
+	fooUpdatedAt, ok := pairs[idFoo]
 	if !ok {
 		t.Fatalf("expected 'foo' in result: %v", pairs)
 	}
-	barUpdatedAt, ok := pairs["bar"]
+	barUpdatedAt, ok := pairs[idBar]
 	if !ok {
 		t.Fatalf("expected 'bar' in result: %v", pairs)
 	}
-	if _, ok := pairs["bonk"]; ok {
+	if _, ok := pairs[999]; ok {
 		t.Fatalf("unexpected 'bonk' in result: %v", pairs)
 	}
 

--- a/internal/codeintel/ranking/mocks_test.go
+++ b/internal/codeintel/ranking/mocks_test.go
@@ -98,7 +98,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		LastUpdatedAtFunc: &StoreLastUpdatedAtFunc{
-			defaultHook: func(context.Context, []api.RepoName) (r0 map[api.RepoName]time.Time, r1 error) {
+			defaultHook: func(context.Context, []api.RepoID) (r0 map[api.RepoID]time.Time, r1 error) {
 				return
 			},
 		},
@@ -160,7 +160,7 @@ func NewStrictMockStore() *MockStore {
 			},
 		},
 		LastUpdatedAtFunc: &StoreLastUpdatedAtFunc{
-			defaultHook: func(context.Context, []api.RepoName) (map[api.RepoName]time.Time, error) {
+			defaultHook: func(context.Context, []api.RepoID) (map[api.RepoID]time.Time, error) {
 				panic("unexpected invocation of MockStore.LastUpdatedAt")
 			},
 		},
@@ -878,15 +878,15 @@ func (c StoreHasInputFilenameFuncCall) Results() []interface{} {
 // StoreLastUpdatedAtFunc describes the behavior when the LastUpdatedAt
 // method of the parent MockStore instance is invoked.
 type StoreLastUpdatedAtFunc struct {
-	defaultHook func(context.Context, []api.RepoName) (map[api.RepoName]time.Time, error)
-	hooks       []func(context.Context, []api.RepoName) (map[api.RepoName]time.Time, error)
+	defaultHook func(context.Context, []api.RepoID) (map[api.RepoID]time.Time, error)
+	hooks       []func(context.Context, []api.RepoID) (map[api.RepoID]time.Time, error)
 	history     []StoreLastUpdatedAtFuncCall
 	mutex       sync.Mutex
 }
 
 // LastUpdatedAt delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockStore) LastUpdatedAt(v0 context.Context, v1 []api.RepoName) (map[api.RepoName]time.Time, error) {
+func (m *MockStore) LastUpdatedAt(v0 context.Context, v1 []api.RepoID) (map[api.RepoID]time.Time, error) {
 	r0, r1 := m.LastUpdatedAtFunc.nextHook()(v0, v1)
 	m.LastUpdatedAtFunc.appendCall(StoreLastUpdatedAtFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -894,7 +894,7 @@ func (m *MockStore) LastUpdatedAt(v0 context.Context, v1 []api.RepoName) (map[ap
 
 // SetDefaultHook sets function that is called when the LastUpdatedAt method
 // of the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreLastUpdatedAtFunc) SetDefaultHook(hook func(context.Context, []api.RepoName) (map[api.RepoName]time.Time, error)) {
+func (f *StoreLastUpdatedAtFunc) SetDefaultHook(hook func(context.Context, []api.RepoID) (map[api.RepoID]time.Time, error)) {
 	f.defaultHook = hook
 }
 
@@ -902,7 +902,7 @@ func (f *StoreLastUpdatedAtFunc) SetDefaultHook(hook func(context.Context, []api
 // LastUpdatedAt method of the parent MockStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *StoreLastUpdatedAtFunc) PushHook(hook func(context.Context, []api.RepoName) (map[api.RepoName]time.Time, error)) {
+func (f *StoreLastUpdatedAtFunc) PushHook(hook func(context.Context, []api.RepoID) (map[api.RepoID]time.Time, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -910,20 +910,20 @@ func (f *StoreLastUpdatedAtFunc) PushHook(hook func(context.Context, []api.RepoN
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreLastUpdatedAtFunc) SetDefaultReturn(r0 map[api.RepoName]time.Time, r1 error) {
-	f.SetDefaultHook(func(context.Context, []api.RepoName) (map[api.RepoName]time.Time, error) {
+func (f *StoreLastUpdatedAtFunc) SetDefaultReturn(r0 map[api.RepoID]time.Time, r1 error) {
+	f.SetDefaultHook(func(context.Context, []api.RepoID) (map[api.RepoID]time.Time, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreLastUpdatedAtFunc) PushReturn(r0 map[api.RepoName]time.Time, r1 error) {
-	f.PushHook(func(context.Context, []api.RepoName) (map[api.RepoName]time.Time, error) {
+func (f *StoreLastUpdatedAtFunc) PushReturn(r0 map[api.RepoID]time.Time, r1 error) {
+	f.PushHook(func(context.Context, []api.RepoID) (map[api.RepoID]time.Time, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreLastUpdatedAtFunc) nextHook() func(context.Context, []api.RepoName) (map[api.RepoName]time.Time, error) {
+func (f *StoreLastUpdatedAtFunc) nextHook() func(context.Context, []api.RepoID) (map[api.RepoID]time.Time, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -961,10 +961,10 @@ type StoreLastUpdatedAtFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 []api.RepoName
+	Arg1 []api.RepoID
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 map[api.RepoName]time.Time
+	Result0 map[api.RepoID]time.Time
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/internal/codeintel/ranking/service.go
+++ b/internal/codeintel/ranking/service.go
@@ -155,8 +155,8 @@ func (s *Service) GetDocumentRanks(ctx context.Context, repoName api.RepoName) (
 	return ranks, nil
 }
 
-func (s *Service) LastUpdatedAt(ctx context.Context, repoNames []api.RepoName) (map[api.RepoName]time.Time, error) {
-	return s.store.LastUpdatedAt(ctx, repoNames)
+func (s *Service) LastUpdatedAt(ctx context.Context, repoIDs []api.RepoID) (map[api.RepoID]time.Time, error) {
+	return s.store.LastUpdatedAt(ctx, repoIDs)
 }
 
 func (s *Service) UpdatedAfter(ctx context.Context, t time.Time) ([]api.RepoName, error) {

--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -48,6 +48,11 @@ type zoektIndexOptions struct {
 	// Priority indicates ranking in results, higher first.
 	Priority float64 `json:",omitempty"`
 
+	// DocumentRanksVersion when non-empty will lead to indexing using offline
+	// ranking. When the string changes this will also cause us to re-index
+	// with new ranks.
+	DocumentRanksVersion string `json:",omitempty"`
+
 	// Error if non-empty indicates the request failed for the repo.
 	Error string `json:",omitempty"`
 }
@@ -67,6 +72,11 @@ type RepoIndexOptions struct {
 
 	// Priority indicates ranking in results, higher first.
 	Priority float64
+
+	// DocumentRanksVersion when non-empty will lead to indexing using offline
+	// ranking. When the string changes this will also cause us to re-index
+	// with new ranks.
+	DocumentRanksVersion string
 
 	// Fork is true if the repository is a fork.
 	Fork bool
@@ -134,6 +144,8 @@ func getIndexOptions(
 		Archived:   opts.Archived,
 		LargeFiles: c.SearchLargeFiles,
 		Symbols:    getBoolPtr(c.SearchIndexSymbolsEnabled, true),
+
+		DocumentRanksVersion: opts.DocumentRanksVersion,
 	}
 
 	// Set of branch names. Always index HEAD

--- a/internal/search/backend/index_options_test.go
+++ b/internal/search/backend/index_options_test.go
@@ -22,6 +22,7 @@ func TestGetIndexOptions(t *testing.T) {
 		PUBLIC
 		FORK
 		ARCHIVED
+		RANKED
 	)
 
 	name := func(repo int32) string {
@@ -208,6 +209,19 @@ func TestGetIndexOptions(t *testing.T) {
 			},
 			Priority: 10,
 		},
+	}, {
+		name: "with rank",
+		conf: schema.SiteConfiguration{},
+		repo: RANKED,
+		want: zoektIndexOptions{
+			RepoID:  8,
+			Name:    "repo-08",
+			Symbols: true,
+			Branches: []zoekt.RepositoryBranch{
+				{Name: "HEAD", Version: "!HEAD"},
+			},
+			DocumentRanksVersion: "ranked",
+		},
 	}}
 
 	{
@@ -241,6 +255,10 @@ func TestGetIndexOptions(t *testing.T) {
 		if repo == PRIORITY {
 			priority = 10
 		}
+		var documentRanksVersion string
+		if repo == RANKED {
+			documentRanksVersion = "ranked"
+		}
 		return &RepoIndexOptions{
 			RepoID:   repo,
 			Name:     name(repo),
@@ -251,6 +269,8 @@ func TestGetIndexOptions(t *testing.T) {
 			GetVersion: func(branch string) (string, error) {
 				return "!" + branch, nil
 			},
+
+			DocumentRanksVersion: documentRanksVersion,
 		}, nil
 	}
 


### PR DESCRIPTION
This field allows us to indicate when the ranks have changed, which forces us to re-index. This field is currently the updated at timestamp which will change as we update ranks for a repository.

This commit is paired with a change in Zoekt (https://github.com/sourcegraph/zoekt/pull/460) that reads this field when set. Now when ranking is enabled in frontend it will be enabled in zoekt. So when this PR lands (with the zoekt one) we will start to store the page ranks in zoekt for use at query time. However, using those ranks fully is still behind a feature flag for query time.

Note: I adjusted the API for LastUpdatedAt to be more convenient. We have a slice of repo IDs rather than repo names. Luckily this also leads to a more minimal SQL query.

Test Plan: Mostly relied on existing unit tests and unit/manual testing within the Zoekt repo. Otherwise this is behind an envvar feature flag for sourcegraph.com