### PR TITLE
codeintel: Add partial index to `lsif_uploads_visible_at_tip`

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -14312,6 +14312,16 @@
       ],
       "Indexes": [
         {
+          "Name": "lsif_uploads_visible_at_tip_is_default_branch",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX lsif_uploads_visible_at_tip_is_default_branch ON lsif_uploads_visible_at_tip USING btree (upload_id) WHERE is_default_branch",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
           "Name": "lsif_uploads_visible_at_tip_repository_id_upload_id",
           "IsPrimaryKey": false,
           "IsUnique": false,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2171,6 +2171,7 @@ A less hot-path reference count for upload records.
  branch_or_tag_name | text    |           | not null | ''::text
  is_default_branch  | boolean |           | not null | false
 Indexes:
+    "lsif_uploads_visible_at_tip_is_default_branch" btree (upload_id) WHERE is_default_branch
     "lsif_uploads_visible_at_tip_repository_id_upload_id" btree (repository_id, upload_id)
 
 ```

--- a/migrations/frontend/1667313173_add_index_to_lsif_uploads_visible_at_tip/down.sql
+++ b/migrations/frontend/1667313173_add_index_to_lsif_uploads_visible_at_tip/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS lsif_uploads_visible_at_tip_is_default_branch;

--- a/migrations/frontend/1667313173_add_index_to_lsif_uploads_visible_at_tip/metadata.yaml
+++ b/migrations/frontend/1667313173_add_index_to_lsif_uploads_visible_at_tip/metadata.yaml
@@ -1,0 +1,2 @@
+name: Add index to lsif_uploads_visible_at_tip
+parents: [1667259203]

--- a/migrations/frontend/1667313173_add_index_to_lsif_uploads_visible_at_tip/up.sql
+++ b/migrations/frontend/1667313173_add_index_to_lsif_uploads_visible_at_tip/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS lsif_uploads_visible_at_tip_is_default_branch ON lsif_uploads_visible_at_tip(upload_id)
+WHERE
+    is_default_branch;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -4482,6 +4482,8 @@ CREATE INDEX lsif_uploads_state ON lsif_uploads USING btree (state);
 
 CREATE INDEX lsif_uploads_uploaded_at ON lsif_uploads USING btree (uploaded_at);
 
+CREATE INDEX lsif_uploads_visible_at_tip_is_default_branch ON lsif_uploads_visible_at_tip USING btree (upload_id) WHERE is_default_branch;
+
 CREATE INDEX lsif_uploads_visible_at_tip_repository_id_upload_id ON lsif_uploads_visible_at_tip USING btree (repository_id, upload_id);
 
 CREATE INDEX notebook_stars_user_id_idx ON notebook_stars USING btree (user_id);


### PR DESCRIPTION
Query insights shows a dominating query that does a seq scan over this table. This doesn't help a lot but it's slow hanging fruit.

## Test plan

Existing pipeline