### PR TITLE
Code Insights: Fix dashboard select suggestion panel min width

### DIFF
--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/DashboardSelect.module.scss
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-select/DashboardSelect.module.scss
@@ -3,6 +3,7 @@
     align-items: center;
     background-color: var(--input-bg);
     font-weight: normal;
+    max-width: 22rem;
 
     &--text {
         display: flex;
@@ -43,6 +44,7 @@
     flex-direction: column;
     height: 100%;
     max-width: 25rem;
+    min-width: 22rem;
 
     &-unchanged {
         [data-user-value] {

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.module.scss
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.module.scss
@@ -1,9 +1,6 @@
 .dashboard-select {
-    // This max-width value is synced with max width of dropdown panel
-    // of the dropdown component.
-    max-width: 22.75rem;
-    flex-grow: 1;
-    flex-shrink: 1;
+    margin-right: 0.5rem;
+    flex: 1;
 }
 
 .dashboard-select-label {

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
@@ -99,7 +99,7 @@ export const DashboardsContent: React.FunctionComponent<React.PropsWithChildren<
                 <DashboardSelect
                     dashboard={currentDashboard}
                     dashboards={dashboards}
-                    className={classNames(styles.dashboardSelect, 'mr-2')}
+                    className={styles.dashboardSelect}
                     onSelect={handleDashboardSelect}
                 />
 


### PR DESCRIPTION

Since the new dashboard select has a dynamic popover panel size, we should enforce min/max widths for the dashboard suggestion panel in order to avoid weirdly narrow suggestion panel 

| Before | After |
| ------- | ------- |
| <img width="585" alt="Screenshot 2022-11-01 at 12 22 46" src="https://user-images.githubusercontent.com/18492575/199270481-ac0783c3-9c16-4276-8005-597b95c5fd40.png"> | <img width="647" alt="Screenshot 2022-11-01 at 12 23 01" src="https://user-images.githubusercontent.com/18492575/199270629-20e0b2c9-8396-43cf-bcb6-7af3b0537354.png"> |

## Test plan
- Make sure that the dashboard UI select suggestion panel has min width value

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-min-width-dashboard-select.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
