### PR TITLE
insights: bin backfill costs and use to prioritize backfill runs #43757

### DIFF
--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -33,7 +33,7 @@ func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*worker
 		ViewName:          "insights_jobs_backfill_in_progress",
 		ColumnExpressions: baseJobColumns,
 		Scan:              dbworkerstore.BuildWorkerScan(scanBaseJob),
-		OrderByExpression: sqlf.Sprintf("id"), // todo
+		OrderByExpression: sqlf.Sprintf("cost_bucket, id"), // take the oldest item in the group of least work
 		MaxNumResets:      100,
 		StalledMaxAge:     time.Second * 30,
 		RetryAfter:        time.Second * 30,

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/derision-test/glock"
 	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
@@ -107,4 +108,75 @@ func Test_MovesBackfillFromProcessingToComplete(t *testing.T) {
 	if len(recordingTimes.RecordingTimes) == 0 {
 		t.Fatal(errors.New("recording times should have been saved after success"))
 	}
+}
+
+func Test_PullsByPriorityGroupAge(t *testing.T) {
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t))
+	permStore := store.NewInsightPermissionStore(database.NewMockDB())
+	repos := database.NewMockRepoStore()
+	repos.GetFunc.SetDefaultReturn(&itypes.Repo{ID: 1, Name: "repo1"}, nil)
+	insightsStore := store.NewInsightStore(insightsDB)
+	seriesStore := store.New(insightsDB, permStore)
+
+	now := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := glock.NewMockClockAt(now)
+	bfs := newBackfillStoreWithClock(insightsDB, clock)
+
+	config := JobMonitorConfig{
+		InsightsDB:     insightsDB,
+		RepoStore:      repos,
+		InsightStore:   seriesStore,
+		ObsContext:     &observation.TestContext,
+		BackfillRunner: &noopBackfillRunner{},
+		CostAnalyzer:   priority.NewQueryAnalyzer(),
+	}
+	monitor := NewBackgroundJobMonitor(ctx, config)
+
+	series, err := insightsStore.CreateSeries(ctx, types.InsightSeries{
+		SeriesID:            "series1",
+		Query:               "asdf",
+		SampleIntervalUnit:  string(types.Month),
+		Repositories:        []string{"repo1", "repo2"},
+		SampleIntervalValue: 1,
+		GenerationMethod:    types.Search,
+	})
+	require.NoError(t, err)
+
+	addBackfillToState := func(series types.InsightSeries, scope []int32, cost float64, state BackfillState) *SeriesBackfill {
+		backfill, err := bfs.NewBackfill(ctx, series)
+		require.NoError(t, err)
+		backfill, err = backfill.SetScope(ctx, bfs, scope, cost)
+		require.NoError(t, err)
+		err = backfill.setState(ctx, bfs, state)
+		require.NoError(t, err)
+
+		err = enqueueBackfill(ctx, bfs.Handle(), backfill)
+		require.NoError(t, err)
+		return backfill
+	}
+
+	bf1 := addBackfillToState(series, []int32{1, 2}, 5, BackfillStateProcessing)
+	bf2 := addBackfillToState(series, []int32{1, 2}, 3, BackfillStateProcessing)
+	bf3 := addBackfillToState(series, []int32{1, 2}, 40, BackfillStateProcessing)
+	bf4 := addBackfillToState(series, []int32{1, 2}, 10, BackfillStateProcessing)
+
+	dequeue1, _, _ := monitor.inProgressStore.Dequeue(ctx, "test1", nil)
+	job1 := dequeue1.(*BaseJob)
+	dequeue2, _, _ := monitor.inProgressStore.Dequeue(ctx, "test2", nil)
+	job2 := dequeue2.(*BaseJob)
+	dequeue3, _, _ := monitor.inProgressStore.Dequeue(ctx, "test3", nil)
+	job3 := dequeue3.(*BaseJob)
+	dequeue4, _, _ := monitor.inProgressStore.Dequeue(ctx, "test4", nil)
+	job4 := dequeue4.(*BaseJob)
+
+	// cost split is in 4 equal buckets based on 0 - max(cost)
+
+	// 1st job is bf1 it has higher cost but it's grouped in same cost and is older
+	assert.Equal(t, bf1.Id, job1.backfillId)
+	assert.Equal(t, bf2.Id, job2.backfillId)
+	assert.Equal(t, bf4.Id, job3.backfillId)
+	assert.Equal(t, bf3.Id, job4.backfillId)
+
 }

--- a/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
@@ -47,7 +47,7 @@ func makeNewBackfillWorker(ctx context.Context, config JobMonitorConfig) (*worke
 		ViewName:          "insights_jobs_backfill_new",
 		ColumnExpressions: baseJobColumns,
 		Scan:              dbworkerstore.BuildWorkerScan(scanBaseJob),
-		OrderByExpression: sqlf.Sprintf("id"), // todo
+		OrderByExpression: sqlf.Sprintf("id"), // processes oldest records first
 		MaxNumResets:      100,
 		StalledMaxAge:     time.Second * 30,
 		RetryAfter:        time.Second * 30,

--- a/internal/database/schema.codeinsights.json
+++ b/internal/database/schema.codeinsights.json
@@ -2858,7 +2858,7 @@
   "Views": [
     {
       "Name": "insights_jobs_backfill_in_progress",
-      "Definition": " SELECT jobs.id,\n    jobs.state,\n    jobs.failure_message,\n    jobs.queued_at,\n    jobs.started_at,\n    jobs.finished_at,\n    jobs.process_after,\n    jobs.num_resets,\n    jobs.num_failures,\n    jobs.last_heartbeat_at,\n    jobs.execution_logs,\n    jobs.worker_hostname,\n    jobs.cancel,\n    jobs.backfill_id,\n    isb.state AS backfill_state,\n    isb.estimated_cost\n   FROM (insights_background_jobs jobs\n     JOIN insight_series_backfill isb ON ((jobs.backfill_id = isb.id)))\n  WHERE (isb.state = 'processing'::text);"
+      "Definition": " SELECT jobs.id,\n    jobs.state,\n    jobs.failure_message,\n    jobs.queued_at,\n    jobs.started_at,\n    jobs.finished_at,\n    jobs.process_after,\n    jobs.num_resets,\n    jobs.num_failures,\n    jobs.last_heartbeat_at,\n    jobs.execution_logs,\n    jobs.worker_hostname,\n    jobs.cancel,\n    jobs.backfill_id,\n    isb.state AS backfill_state,\n    isb.estimated_cost,\n    width_bucket(isb.estimated_cost, (0)::double precision, max((isb.estimated_cost + (1)::double precision)) OVER (), 4) AS cost_bucket\n   FROM (insights_background_jobs jobs\n     JOIN insight_series_backfill isb ON ((jobs.backfill_id = isb.id)))\n  WHERE (isb.state = 'processing'::text);"
     },
     {
       "Name": "insights_jobs_backfill_new",

--- a/internal/database/schema.codeinsights.md
+++ b/internal/database/schema.codeinsights.md
@@ -538,7 +538,8 @@ Stores ephemeral snapshot data of insight recordings.
     jobs.cancel,
     jobs.backfill_id,
     isb.state AS backfill_state,
-    isb.estimated_cost
+    isb.estimated_cost,
+    width_bucket(isb.estimated_cost, (0)::double precision, max((isb.estimated_cost + (1)::double precision)) OVER (), 4) AS cost_bucket
    FROM (insights_background_jobs jobs
      JOIN insight_series_backfill isb ON ((jobs.backfill_id = isb.id)))
   WHERE (isb.state = 'processing'::text);

--- a/migrations/codeinsights/1667309737_backfill_priority_groups/down.sql
+++ b/migrations/codeinsights/1667309737_backfill_priority_groups/down.sql
@@ -1,0 +1,6 @@
+-- Undo the changes made in the up migration
+CREATE OR REPLACE VIEW insights_jobs_backfill_in_progress AS
+SELECT jobs.*, isb.state AS backfill_state, isb.estimated_cost
+FROM insights_background_jobs jobs
+         JOIN insight_series_backfill isb ON jobs.backfill_id = isb.id
+WHERE isb.state = 'processing';

--- a/migrations/codeinsights/1667309737_backfill_priority_groups/down.sql
+++ b/migrations/codeinsights/1667309737_backfill_priority_groups/down.sql
@@ -1,4 +1,6 @@
 -- Undo the changes made in the up migration
+drop view if exists insights_jobs_backfill_in_progress;
+
 CREATE OR REPLACE VIEW insights_jobs_backfill_in_progress AS
 SELECT jobs.*, isb.state AS backfill_state, isb.estimated_cost
 FROM insights_background_jobs jobs

--- a/migrations/codeinsights/1667309737_backfill_priority_groups/metadata.yaml
+++ b/migrations/codeinsights/1667309737_backfill_priority_groups/metadata.yaml
@@ -1,0 +1,2 @@
+name: backfill cost groups
+parents: [1666632478]

--- a/migrations/codeinsights/1667309737_backfill_priority_groups/up.sql
+++ b/migrations/codeinsights/1667309737_backfill_priority_groups/up.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE VIEW insights_jobs_backfill_in_progress AS
+SELECT
+    jobs.*,
+    isb.state AS backfill_state,
+    isb.estimated_cost,
+    width_bucket(isb.estimated_cost, 0, max(isb.estimated_cost+1) over (), 4) cost_bucket
+FROM insights_background_jobs jobs
+         JOIN insight_series_backfill isb ON jobs.backfill_id = isb.id
+WHERE isb.state = 'processing';

--- a/migrations/codeinsights/squashed.sql
+++ b/migrations/codeinsights/squashed.sql
@@ -357,7 +357,8 @@ CREATE VIEW insights_jobs_backfill_in_progress AS
     jobs.cancel,
     jobs.backfill_id,
     isb.state AS backfill_state,
-    isb.estimated_cost
+    isb.estimated_cost,
+    width_bucket(isb.estimated_cost, (0)::double precision, max((isb.estimated_cost + (1)::double precision)) OVER (), 4) AS cost_bucket
    FROM (insights_background_jobs jobs
      JOIN insight_series_backfill isb ON ((jobs.backfill_id = isb.id)))
   WHERE (isb.state = 'processing'::text);


### PR DESCRIPTION
This updates the view used by the in progress backfill job to bin the backfill in the in progress state and uses a combination of that cost group plus how long the series has been queued to determine the order in which the are processed.

One potential issues with this approach is that a single very expensive series could skew the cost groups so much that the some typically considered expensive series end up in the lowest cost grouping. I thought this risk was worth the benefits because without binning small deviations in cost could potentially keep a series waiting for an extended period of time.

closes https://github.com/sourcegraph/sourcegraph/issues/42959

## Test plan
existing unit tests pass
added new test to confirm dequeue order
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
