### PR TITLE
codeintel: dont return audit-log uploads when only `state='deleted'` requested

### DIFF
--- a/internal/codeintel/uploads/internal/store/store_uploads.go
+++ b/internal/codeintel/uploads/internal/store/store_uploads.go
@@ -1951,7 +1951,7 @@ func nilTimeToString(t *time.Time) string {
 func buildGetConditionsAndCte(opts shared.GetUploadsOptions) (*sqlf.Query, []*sqlf.Query, []cteDefinition) {
 	conds := make([]*sqlf.Query, 0, 12)
 
-	allowDeletedUploads := (opts.AllowDeletedUpload && opts.State == "") || opts.State == "deleted"
+	allowDeletedUploads := opts.AllowDeletedUpload && (opts.State == "" || opts.State == "deleted")
 
 	if opts.RepositoryID != 0 {
 		conds = append(conds, sqlf.Sprintf("u.repository_id = %s", opts.RepositoryID))


### PR DESCRIPTION
Previously, `GetUploads` would return uploads synthesized from audit logs where the uploads had been hard-deleted. The resulting query is considerably slower (see query insights image below), which happens to be the kind of query that results from the upload hard-deleter. This selects uploads where `state = "deleted"` and deletes all the uploads by ID that were returned, but because of the previous behaviour, it would select a number of uploads that were technically already hard-deleted.

New behaviour does not synthesize uploads when `state = "deleted"` is requested, only when the explicit `AllowDeletedUploads` flag is set via service API or `includeDeleted` in GraphQL

![image](https://user-images.githubusercontent.com/18282288/199290901-e326cdbe-bc6d-4be2-a95c-e3f04f6578d7.png)

## Test plan

Added new unit test. No user facing change (unless someone was making sql/graphql queries with `state = "deleted"`) as this was not possible to query through the UI alone yet
