### PR TITLE
search ui: don't submit search when toggles change in home

### DIFF
--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -277,6 +277,7 @@ describe('Search', () => {
                     await editor.focus()
                     await driver.page.keyboard.type('test')
                     await driver.page.click('.test-case-sensitivity-toggle')
+                    await driver.page.click('aria/Search[role="button"]')
                     await driver.assertWindowLocation('/search?q=context:global+test&patternType=standard&case=yes')
                 })
 

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -155,7 +155,6 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                         patternType={patternType}
                         setPatternType={setSearchPatternType}
                         setCaseSensitivity={setSearchCaseSensitivity}
-                        submitSearchOnToggle={submitSearchOnChange}
                         queryState={props.queryState}
                         onChange={props.setQueryState}
                         onSubmit={onSubmit}


### PR DESCRIPTION
When toggles (case sensitivity, regex, structural, and smart search) are changed in the homepage, the search should not be submitted.

The search is still submitted when toggles change on the search box in the navbar in other pages.

## Test plan

- Verify manually:
  - Toggles on homepage don't submit but still affect search after clicking search button
  - Toggles on other pages (eg. search results) still submit the search
- Update integration tests to press search button on homepage

## App preview:

- [Web](https://sg-web-jp-searchhometogglesdontsubmit.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
