### PR TITLE
search ui: remove extra tab stop in smart search toggle

### DIFF
--- a/client/search-ui/src/input/toggles/SmartSearchToggle.tsx
+++ b/client/search-ui/src/input/toggles/SmartSearchToggle.tsx
@@ -51,24 +51,24 @@ export const SmartSearchToggle: React.FunctionComponent<SmartSearchToggleProps> 
 
     return (
         <Popover isOpen={isPopoverOpen} onOpenChange={event => setIsPopoverOpen(event.isOpen)}>
-            <PopoverTrigger
-                as={Button}
-                className={classNames(
-                    styles.toggle,
-                    smartStyles.button,
-                    className,
-                    !!disabledRule && styles.disabled,
-                    isActive && styles.toggleActive,
-                    !interactive && styles.toggleNonInteractive
-                )}
-                variant="icon"
-                aria-checked={isActive}
-                {...interactiveProps}
-            >
-                <Tooltip content={tooltipValue} placement="bottom">
+            <Tooltip content={tooltipValue} placement="bottom">
+                <PopoverTrigger
+                    as={Button}
+                    className={classNames(
+                        styles.toggle,
+                        smartStyles.button,
+                        className,
+                        !!disabledRule && styles.disabled,
+                        isActive && styles.toggleActive,
+                        !interactive && styles.toggleNonInteractive
+                    )}
+                    variant="icon"
+                    aria-checked={isActive}
+                    {...interactiveProps}
+                >
                     <Icon aria-label={tooltipValue} svgPath={smartSearchIconSvgPath} />
-                </Tooltip>
-            </PopoverTrigger>
+                </PopoverTrigger>
+            </Tooltip>
 
             <SmartSearchToggleMenu onSelect={onSelect} isActive={isActive} closeMenu={() => setIsPopoverOpen(false)} />
         </Popover>


### PR DESCRIPTION
_Review with whitespace hidden_

The tooltip in the smart search toggle was causing an extra tab stop on the icon glyph. Move the tooltip up a level so that the tooltip trigger is the button, not the icon, which is already a tab stop.

## Test plan

Verify manually with keyboard

## App preview:

- [Web](https://sg-web-jp-smartsearchextrafocus.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
