### PR TITLE
commit page: move diff mode definition next to temp settings

### DIFF
--- a/client/shared/src/settings/temporary/TemporarySettings.ts
+++ b/client/shared/src/settings/temporary/TemporarySettings.ts
@@ -6,6 +6,7 @@ import { MultiSelectState } from '@sourcegraph/wildcard'
 
 import { BatchChangeState } from '../../graphql-operations'
 
+import { DiffMode } from './diffMode'
 import { RecentSearch } from './recentSearches'
 import { SectionID, NoResultsSectionID } from './searchSidebar'
 
@@ -49,7 +50,7 @@ export interface TemporarySettingsSchema {
     'coreWorkflowImprovements.enabled_deprecated': boolean
     'batches.minSavedPerChangeset': number
     'search.notebooks.minSavedPerView': number
-    'repo.commitPage.diffMode': 'split' | 'unified'
+    'repo.commitPage.diffMode': DiffMode
 }
 
 /**

--- a/client/shared/src/settings/temporary/diffMode.ts
+++ b/client/shared/src/settings/temporary/diffMode.ts
@@ -1,0 +1,1 @@
+export type DiffMode = 'split' | 'unified'

--- a/client/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/client/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -117,7 +117,7 @@ interface RepositoryCommitPageProps
     onDidUpdateExternalLinks: (externalLinks: ExternalLinkFields[] | undefined) => void
 }
 
-export type DiffMode = 'split' | 'unified'
+export type { DiffMode } from '@sourcegraph/shared/src/settings/temporary/diffMode'
 
 /** Displays a commit. */
 export const RepositoryCommitPage: React.FunctionComponent<RepositoryCommitPageProps> = props => {


### PR DESCRIPTION
Resolves https://github.com/sourcegraph/sourcegraph/pull/43633#discussion_r1009173410

## Test plan

No functionality change, just moving type definitions around

## App preview:

- [Web](https://sg-web-jp-diffmodedefinition.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
