### PR TITLE
Aggregation: Add aggregation data pings again

### DIFF
--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
@@ -53,6 +53,7 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
         caseSensitive,
         proactive: true,
         extendedTimeout,
+        telemetryService,
     })
 
     const handleCollapseClick = (): void => {

--- a/client/web/src/search/results/components/aggregation/pings.ts
+++ b/client/web/src/search/results/components/aggregation/pings.ts
@@ -13,4 +13,10 @@ export enum GroupResultsPing {
     ExpandFullViewPanel = 'GroupResultsExpandedViewOpen',
     CollapseFullViewPanel = 'GroupResultsExpandedViewCollapse',
     InfoIconHover = 'GroupResultsInfoIconHover',
+
+    // Proactive
+    ProactiveLimitHit = 'ProactiveLimitHit',
+    ProactiveLimitSuccess = 'ProactiveLimitSuccess',
+    ExplicitLimitHit = 'ExplicitLimitHit',
+    ExplicitLimitSuccess = 'ExplicitLimitSuccess',
 }

--- a/client/web/src/search/results/sidebar/SearchAggregations.tsx
+++ b/client/web/src/search/results/sidebar/SearchAggregations.tsx
@@ -58,6 +58,7 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
         proactive,
         caseSensitive,
         extendedTimeout,
+        telemetryService,
     })
 
     // When query is updated reset extendedTimeout as per business rules
@@ -156,3 +157,5 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
         </article>
     )
 })
+
+SearchAggregations.displayName = 'SearchAggregations'

--- a/doc/dev/background-information/insights/code_insights_pings.md
+++ b/doc/dev/background-information/insights/code_insights_pings.md
@@ -423,3 +423,15 @@ https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegrap
   - [WeeklyGroupResultsChartBarClick](https://sourcegraph.com/search?q=context:%40sourcegraph/all+GroupResultsChartBarClick&patternType=regexp)
   - [WeeklyGroupResultsChartBarHover](https://sourcegraph.com/search?q=context:%40sourcegraph/all+GroupResultsChartBarHover&patternType=regexp)
 - **Version added:** 4.0 ([#40977](https://github.com/sourcegraph/sourcegraph/pull/40977))
+
+### Search mode (proactive/extended) success rate
+
+**Type:** FE event
+
+**Intended purpose:** To track the number of aggregation searches that succeed or hit limit in either a proactive or extended search. 
+
+**Functional implementation:** These pings fire a telemetry event when an aggregation search completes or times out.
+
+- Aggregation: weekly
+- Event Code: [WeeklyGroupResultsSearches](https://sourcegraph.com/search?q=context:%40sourcegraph/all+WeeklyGroupResultsSearches&patternType=lucky)
+- **Version added:** 4.1 ([#42554](https://github.com/sourcegraph/sourcegraph/pull/42554))

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1458,6 +1458,7 @@ type CodeInsightsUsageStatistics struct {
 	WeeklyGroupResultsChartBarClick                []GroupResultPing
 	WeeklyGroupResultsAggregationModeClicked       []GroupResultPing
 	WeeklyGroupResultsAggregationModeDisabledHover []GroupResultPing
+	WeeklyGroupResultsSearches                     []GroupResultSearchPing
 	WeeklySeriesBackfillTime                       []InsightsBackfillTimePing
 }
 
@@ -1469,6 +1470,12 @@ type GroupResultPing struct {
 }
 
 type GroupResultExpandedViewPing struct {
+	AggregationMode *string
+	Count           *int32
+}
+
+type GroupResultSearchPing struct {
+	Name            PingName
 	AggregationMode *string
 	Count           *int32
 }

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -126,6 +125,7 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 	want.WeeklyGroupResultsChartBarClick = []types.GroupResultPing{}
 	want.WeeklyGroupResultsAggregationModeClicked = []types.GroupResultPing{}
 	want.WeeklyGroupResultsAggregationModeDisabledHover = []types.GroupResultPing{}
+	want.WeeklyGroupResultsSearches = []types.GroupResultSearchPing{}
 	want.WeeklySeriesBackfillTime = []types.InsightsBackfillTimePing{}
 
 	if diff := cmp.Diff(want, have); diff != "" {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/41033

## Test plan
- Run aggregation that is resolved automatically (check that you see the `ProactiveLimitSuccess` event with a non-nullable value in the mode field)
- Run aggregation that is a timeout when you open the search result page (check that you see `ProactiveLimitHit` event with non-nullable value in the mode field) and you see the "Run aggregation" button
- Run query that timeout at the beginning but with extended timeout is resolved (check that you see the `ProactiveLimitHit` first and then after clicking on the "Run aggregation" and when data is resolved, you see the `ExplicitLimitSuccess` event)
- Run query that failed with timeout even with extended timeout - check that you see `ExplicitLimitHit` event in the network tab

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
