### PR TITLE
Revert "symbols: Hierarchical symbol sidebar"

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarSymbols.module.scss
+++ b/client/web/src/repo/RepoRevisionSidebarSymbols.module.scss
@@ -56,8 +56,3 @@
     top: 0;
     background-color: var(--body-bg);
 }
-
-.hierarchical-symbols-container {
-    list-style-type: none;
-    padding-left: 0;
-}


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#43637

Need to update the e2e tests.

## App preview:

- [Web](https://sg-web-revert-43637-hierarchical-symbols.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

## Test plan

Revert