### PR TITLE
CodeMirror: Make search-based code intelligence keyboard navigable

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -212,7 +212,7 @@ const SearchTokenFindingReferencesList: React.FunctionComponent<
     if (!tokenResult?.searchToken) {
         return (
             <div>
-                <Text className="text-danger">Could not find hovered token.</Text>
+                <Text className="text-danger">Could not find token.</Text>
             </div>
         )
     }

--- a/client/web/src/repo/blob/codemirror/tokens-as-links.ts
+++ b/client/web/src/repo/blob/codemirror/tokens-as-links.ts
@@ -6,13 +6,13 @@ import { concatMap, debounceTime, map } from 'rxjs/operators'
 import { DeepNonNullable } from 'utility-types'
 
 import { logger, toPositionOrRangeQueryParameter } from '@sourcegraph/common'
+import { Occurrence, SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
 import { toPrettyBlobURL, UIRange } from '@sourcegraph/shared/src/util/url'
 
 import { BlobInfo } from '../Blob'
 import { DefinitionResponse, fetchDefinitionsFromRanges } from '../definitions'
 
 import { SelectedLineRange, selectedLines } from './linenumbers'
-import { Occurrence, SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
 
 interface TokenLink {
     range: UIRange

--- a/client/web/src/repo/blob/codemirror/tokens-as-links.ts
+++ b/client/web/src/repo/blob/codemirror/tokens-as-links.ts
@@ -231,7 +231,7 @@ interface TokensAsLinksConfiguration {
 }
 
 /**
- * Occurrences that are possibly interactive (i.e. they can have code intelligence)
+ * Occurrences that are possibly interactive (i.e. they can have code intelligence).
  */
 const INTERACTIVE_OCCURRENCE_KINDS = new Set([
     SyntaxKind.Identifier,

--- a/client/web/src/repo/blob/codemirror/tokens-as-links.ts
+++ b/client/web/src/repo/blob/codemirror/tokens-as-links.ts
@@ -12,6 +12,7 @@ import { BlobInfo } from '../Blob'
 import { DefinitionResponse, fetchDefinitionsFromRanges } from '../definitions'
 
 import { SelectedLineRange, selectedLines } from './linenumbers'
+import { Occurrence, SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
 
 interface TokenLink {
     range: UIRange
@@ -229,9 +230,48 @@ interface TokensAsLinksConfiguration {
     preloadGoToDefinition: boolean
 }
 
+/**
+ * Occurrences that are possibly interactive (i.e. they can have code intelligence)
+ */
+const INTERACTIVE_OCCURRENCE_KINDS = new Set([
+    SyntaxKind.Identifier,
+    SyntaxKind.IdentifierBuiltin,
+    SyntaxKind.IdentifierConstant,
+    SyntaxKind.IdentifierMutableGlobal,
+    SyntaxKind.IdentifierParameter,
+    SyntaxKind.IdentifierLocal,
+    SyntaxKind.IdentifierShadowed,
+    SyntaxKind.IdentifierModule,
+    SyntaxKind.IdentifierFunction,
+    SyntaxKind.IdentifierFunctionDefinition,
+    SyntaxKind.IdentifierMacro,
+    SyntaxKind.IdentifierMacroDefinition,
+    SyntaxKind.IdentifierType,
+    SyntaxKind.IdentifierBuiltinType,
+    SyntaxKind.IdentifierAttribute,
+])
+
+const isInteractiveOccurrence = (occurence: Occurrence): boolean => {
+    if (!occurence.kind) {
+        return false
+    }
+
+    return INTERACTIVE_OCCURRENCE_KINDS.has(occurence.kind)
+}
+
 export const tokensAsLinks = ({ history, blobInfo, preloadGoToDefinition }: TokensAsLinksConfiguration): Extension => {
+    /**
+     * Prefer precise code intelligence ranges, fall back to making certain Occurences interactive.
+     */
+    const ranges =
+        blobInfo.stencil && blobInfo.stencil.length > 0
+            ? blobInfo.stencil.map(range => range)
+            : Occurrence.fromInfo(blobInfo)
+                  .filter(isInteractiveOccurrence)
+                  .map(({ range }) => range)
+
     const referencesLinks =
-        blobInfo.stencil?.map(range => ({
+        ranges.map(range => ({
             range,
             url: `?${toPositionOrRangeQueryParameter({
                 position: { line: range.start.line + 1, character: range.start.character + 1 },


### PR DESCRIPTION
## Description

This is a basic implementation at making our code accessible for all files (not just precise code intelligence)

This PR:
- Falls back to using occurrence information to build accessible tokens.
  - These tokens navigate to the references panel, which will either display valid information about definitions/references etc OR show "Failed to find token". Ideally we would render hover overlays here but we may not have time to implement this before we begin our accessibility audit.
   
## Test plan

Tested locally with a keyboard on files with no precise code intelligence

## App preview:

- [Web](https://sg-web-tr-blob-search-accessibility.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
