### PR TITLE
codeintel: Refactor autoindexing cleanup background tasks

### DIFF
--- a/internal/codeintel/autoindexing/internal/background/iface.go
+++ b/internal/codeintel/autoindexing/internal/background/iface.go
@@ -7,7 +7,6 @@ import (
 	"github.com/grafana/regexp"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	autoindexingshared "github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	policies "github.com/sourcegraph/sourcegraph/internal/codeintel/policies/enterprise"
 	policiesshared "github.com/sourcegraph/sourcegraph/internal/codeintel/policies/shared"
@@ -53,9 +52,13 @@ type AutoIndexingService interface {
 	DeleteIndexesWithoutRepository(ctx context.Context, now time.Time) (_ map[int]int, err error)
 	ExpireFailedRecords(ctx context.Context, batchSize int, maxAge time.Duration, now time.Time) error
 
-	GetStaleSourcedCommits(ctx context.Context, minimumTimeSinceLastCheck time.Duration, limit int, now time.Time) (_ []autoindexingshared.SourcedCommits, err error)
-	UpdateSourcedCommits(ctx context.Context, repositoryID int, commit string, now time.Time) (indexesUpdated int, err error)
-	DeleteSourcedCommits(ctx context.Context, repositoryID int, commit string, maximumCommitLag time.Duration) (indexesDeleted int, err error)
+	ProcessStaleSourcedCommits(
+		ctx context.Context,
+		minimumTimeSinceLastCheck time.Duration,
+		commitResolverBatchSize int,
+		commitResolverMaximumCommitLag time.Duration,
+		shouldDelete func(ctx context.Context, repositoryID int, commit string) (bool, error),
+	) (indexesDeleted int, _ error)
 
 	ProcessRepoRevs(ctx context.Context, batchSize int) (err error)
 }

--- a/internal/codeintel/autoindexing/internal/background/job_cleanup.go
+++ b/internal/codeintel/autoindexing/internal/background/job_cleanup.go
@@ -130,7 +130,7 @@ func (b backgroundJob) handleExpiredRecords(ctx context.Context, cfg janitorConf
 func shouldDeleteUploadsForCommit(ctx context.Context, gitserverClient GitserverClient, repositoryID int, commit string) (bool, error) {
 	if _, err := gitserverClient.ResolveRevision(ctx, repositoryID, commit); err != nil {
 		if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
-			// Target condition: repository is resolvable bu the commit is not; was probably
+			// Target condition: repository is resolvable but the commit is not; was probably
 			// force-pushed away and the commit was gc'd after some time or after a re-clone
 			// in gitserver.
 			return true, nil

--- a/internal/codeintel/autoindexing/internal/background/job_cleanup.go
+++ b/internal/codeintel/autoindexing/internal/background/job_cleanup.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/shared"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -105,66 +104,20 @@ func gatherCounts(indexesCounts map[int]int) []recordCount {
 }
 
 func (b backgroundJob) handleUnknownCommit(ctx context.Context, cfg janitorConfig) (err error) {
-	staleIndexes, err := b.autoindexingSvc.GetStaleSourcedCommits(ctx, cfg.minimumTimeSinceLastCheck, cfg.commitResolverBatchSize, b.clock.Now())
+	indexesDeleted, err := b.autoindexingSvc.ProcessStaleSourcedCommits(
+		ctx,
+		cfg.minimumTimeSinceLastCheck,
+		cfg.commitResolverBatchSize,
+		cfg.commitResolverMaximumCommitLag,
+		func(ctx context.Context, repositoryID int, commit string) (bool, error) {
+			return shouldDeleteUploadsForCommit(ctx, b.gitserverClient, repositoryID, commit)
+		},
+	)
 	if err != nil {
-		return errors.Wrap(err, "indexSvc.StaleSourcedCommits")
+		return err
 	}
-
-	for _, sourcedCommits := range staleIndexes {
-		if err := b.handleSourcedCommits(ctx, sourcedCommits, cfg); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (b backgroundJob) handleSourcedCommits(ctx context.Context, sc shared.SourcedCommits, cfg janitorConfig) error {
-	for _, commit := range sc.Commits {
-		if err := b.handleCommit(ctx, sc.RepositoryID, sc.RepositoryName, commit, cfg); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (b backgroundJob) handleCommit(ctx context.Context, repositoryID int, repositoryName, commit string, cfg janitorConfig) error {
-	var shouldDelete bool
-	_, err := b.gitserverClient.ResolveRevision(ctx, repositoryID, commit)
-	if err == nil {
-		// If we have no error then the commit is resolvable and we shouldn't touch it.
-		shouldDelete = false
-	} else if gitdomain.IsRepoNotExist(err) {
-		// If we have a repository not found error, then we'll just update the timestamp
-		// of the record so we can move on to other data; we deleted records associated
-		// with deleted repositories in a separate janitor process.
-		shouldDelete = false
-	} else if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
-		// Target condition: repository is resolvable bu the commit is not; was probably
-		// force-pushed away and the commit was gc'd after some time or after a re-clone
-		// in gitserver.
-		shouldDelete = true
-	} else {
-		// unexpected error
-		return errors.Wrap(err, "git.ResolveRevision")
-	}
-
-	if shouldDelete {
-		indexesDeleted, err := b.autoindexingSvc.DeleteSourcedCommits(ctx, repositoryID, commit, cfg.commitResolverMaximumCommitLag)
-		if err != nil {
-			return errors.Wrap(err, "indexSvc.DeleteSourcedCommits")
-		}
-		if indexesDeleted > 0 {
-			// log.Debug("Deleted index records with unresolvable commits", "count", indexesDeleted)
-			b.janitorMetrics.numIndexRecordsRemoved.Add(float64(indexesDeleted))
-		}
-
-		return nil
-	}
-
-	if _, err := b.autoindexingSvc.UpdateSourcedCommits(ctx, repositoryID, commit, b.clock.Now()); err != nil {
-		return errors.Wrap(err, "indexSvc.UpdateSourcedCommits")
+	if indexesDeleted > 0 {
+		b.janitorMetrics.numIndexRecordsRemoved.Add(float64(indexesDeleted))
 	}
 
 	return nil
@@ -172,4 +125,27 @@ func (b backgroundJob) handleCommit(ctx context.Context, repositoryID int, repos
 
 func (b backgroundJob) handleExpiredRecords(ctx context.Context, cfg janitorConfig) error {
 	return b.autoindexingSvc.ExpireFailedRecords(ctx, cfg.failedIndexBatchSize, cfg.failedIndexMaxAge, b.clock.Now())
+}
+
+func shouldDeleteUploadsForCommit(ctx context.Context, gitserverClient GitserverClient, repositoryID int, commit string) (bool, error) {
+	if _, err := gitserverClient.ResolveRevision(ctx, repositoryID, commit); err != nil {
+		if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
+			// Target condition: repository is resolvable bu the commit is not; was probably
+			// force-pushed away and the commit was gc'd after some time or after a re-clone
+			// in gitserver.
+			return true, nil
+		}
+
+		if !gitdomain.IsRepoNotExist(err) {
+			// unexpected error
+			return false, errors.Wrap(err, "git.ResolveRevision")
+		}
+	}
+
+	// We hit this in one of two conditions:
+	//   - If we have no error then the commit is resolvable and we shouldn't touch it.
+	//   - If we have a repository not found error, then we'll just update the timestamp
+	//     of the record so we can move on to other data; we deleted records associated
+	//     with deleted repositories in a separate janitor process.
+	return false, nil
 }

--- a/internal/codeintel/autoindexing/internal/store/observability.go
+++ b/internal/codeintel/autoindexing/internal/store/observability.go
@@ -11,9 +11,7 @@ import (
 
 type operations struct {
 	// Commits
-	getStaleSourcedCommits *observation.Operation
-	deleteSourcedCommits   *observation.Operation
-	updateSourcedCommits   *observation.Operation
+	processStaleSourcedCommits *observation.Operation
 
 	// Indexes
 	insertIndex                    *observation.Operation
@@ -70,9 +68,7 @@ func newOperations(observationContext *observation.Context) *operations {
 
 	return &operations{
 		// Commits
-		getStaleSourcedCommits: op("StaleSourcedCommits"),
-		deleteSourcedCommits:   op("DeleteSourcedCommits"),
-		updateSourcedCommits:   op("UpdateSourcedCommits"),
+		processStaleSourcedCommits: op("ProcessStaleSourcedCommits"),
 
 		// Indexes
 		insertIndex:                    op("InsertIndex"),

--- a/internal/codeintel/autoindexing/internal/store/scan.go
+++ b/internal/codeintel/autoindexing/internal/store/scan.go
@@ -173,21 +173,6 @@ func scanSourcedCommits(rows *sql.Rows, queryErr error) (_ []shared.SourcedCommi
 	return flattened, nil
 }
 
-func scanCount(rows *sql.Rows, queryErr error) (value int, err error) {
-	if queryErr != nil {
-		return 0, queryErr
-	}
-	defer func() { err = basestore.CloseRows(rows, err) }()
-
-	for rows.Next() {
-		if err := rows.Scan(&value); err != nil {
-			return 0, err
-		}
-	}
-
-	return value, nil
-}
-
 var ScanRepoRevs = basestore.NewSliceScanner(scanRepoRev)
 
 func scanRepoRev(s dbutil.Scanner) (rr RepoRev, err error) {

--- a/internal/codeintel/autoindexing/internal/store/store.go
+++ b/internal/codeintel/autoindexing/internal/store/store.go
@@ -20,9 +20,13 @@ type Store interface {
 	Done(err error) error
 
 	// Commits
-	GetStaleSourcedCommits(ctx context.Context, minimumTimeSinceLastCheck time.Duration, limit int, now time.Time) (_ []shared.SourcedCommits, err error)
-	UpdateSourcedCommits(ctx context.Context, repositoryID int, commit string, now time.Time) (indexesUpdated int, err error)
-	DeleteSourcedCommits(ctx context.Context, repositoryID int, commit string, maximumCommitLag time.Duration) (indexesDeleted int, err error)
+	ProcessStaleSourcedCommits(
+		ctx context.Context,
+		minimumTimeSinceLastCheck time.Duration,
+		commitResolverBatchSize int,
+		commitResolverMaximumCommitLag time.Duration,
+		shouldDelete func(ctx context.Context, repositoryID int, commit string) (bool, error),
+	) (indexesDeleted int, _ error)
 
 	// Indexes
 	InsertIndexes(ctx context.Context, indexes []types.Index) (_ []types.Index, err error)

--- a/internal/codeintel/autoindexing/internal/store/store_sourced_commits.go
+++ b/internal/codeintel/autoindexing/internal/store/store_sourced_commits.go
@@ -5,53 +5,108 @@ import (
 	"time"
 
 	"github.com/keegancsmith/sqlf"
-	"github.com/opentracing/opentracing-go/log"
+	"github.com/lib/pq"
 
-	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/shared"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-// GetStaleSourcedCommits returns a set of commits attached to repositories that have been
-// least recently checked for resolvability via gitserver. We do this periodically in
-// order to determine which records in the database are unreachable by normal query
-// paths and clean up that occupied (but useless) space. The output is of this method is
-// ordered by repository ID then by commit.
-func (s *store) GetStaleSourcedCommits(ctx context.Context, minimumTimeSinceLastCheck time.Duration, limit int, now time.Time) (_ []shared.SourcedCommits, err error) {
-	ctx, trace, endObservation := s.operations.getStaleSourcedCommits.With(ctx, &err, observation.Args{})
+func (s *store) ProcessStaleSourcedCommits(
+	ctx context.Context,
+	minimumTimeSinceLastCheck time.Duration,
+	commitResolverBatchSize int,
+	commitResolverMaximumCommitLag time.Duration,
+	shouldDelete func(ctx context.Context, repositoryID int, commit string) (bool, error),
+) (int, error) {
+	return s.processStaleSourcedCommits(ctx, minimumTimeSinceLastCheck, commitResolverBatchSize, commitResolverMaximumCommitLag, shouldDelete, time.Now())
+}
+
+func (s *store) processStaleSourcedCommits(
+	ctx context.Context,
+	minimumTimeSinceLastCheck time.Duration,
+	commitResolverBatchSize int,
+	commitResolverMaximumCommitLag time.Duration,
+	shouldDelete func(ctx context.Context, repositoryID int, commit string) (bool, error),
+	now time.Time,
+) (totalDeleted int, err error) {
+	ctx, _, endObservation := s.operations.processStaleSourcedCommits.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
 	tx, err := s.db.Transact(ctx)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 	defer func() { err = tx.Done(err) }()
 
 	now = now.UTC()
 	interval := int(minimumTimeSinceLastCheck / time.Second)
 
-	candidatesSubquery := sqlf.Sprintf(candidatesSubqueryCTE, now, interval)
-	staleCommitsQuery := sqlf.Sprintf(staleIndexSourcedCommitsQuery, candidatesSubquery, limit)
-
-	sourcedCommits, err := scanSourcedCommits(tx.Query(ctx, staleCommitsQuery))
+	staleIndexes, err := scanSourcedCommits(tx.Query(ctx, sqlf.Sprintf(
+		staleIndexSourcedCommitsQuery,
+		now,
+		interval,
+		commitResolverBatchSize,
+	)))
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	numCommits := 0
-	for _, commits := range sourcedCommits {
-		numCommits += len(commits.Commits)
-	}
-	trace.Log(
-		log.Int("numRepositories", len(sourcedCommits)),
-		log.Int("numCommits", numCommits),
-	)
+	for _, sc := range staleIndexes {
+		var (
+			keep   []string
+			remove []string
+		)
 
-	return sourcedCommits, nil
+		for _, commit := range sc.Commits {
+			if ok, err := shouldDelete(ctx, sc.RepositoryID, commit); err != nil {
+				return 0, err
+			} else if ok {
+				remove = append(remove, commit)
+			} else {
+				keep = append(keep, commit)
+			}
+		}
+
+		unset, _ := tx.SetLocal(ctx, "codeintel.lsif_uploads_audit.reason", "upload associated with unknown commit")
+		defer unset(ctx)
+
+		indexesDeleted, _, err := basestore.ScanFirstInt(tx.Query(ctx, sqlf.Sprintf(
+			updateSourcedCommitsQuery,
+			sc.RepositoryID,
+			pq.Array(keep),
+			pq.Array(remove),
+			now,
+			pq.Array(keep),
+			pq.Array(remove),
+		)))
+		if err != nil {
+			return 0, err
+		}
+
+		totalDeleted += indexesDeleted
+	}
+
+	return totalDeleted, nil
 }
 
 const staleIndexSourcedCommitsQuery = `
-WITH
-	candidates AS (%s)
+WITH candidates AS (
+	SELECT
+		repository_id,
+		commit,
+		-- Keep track of the most recent update of this commit that we know about
+		-- as any earlier dates for the same repository and commit pair carry no
+		-- useful information.
+		MAX(commit_last_checked_at) as max_last_checked_at
+	FROM lsif_indexes
+	WHERE
+		-- Ignore records already marked as deleted
+		state NOT IN ('deleted', 'deleting') AND
+		-- Ignore records that have been checked recently. Note this condition is
+		-- true for a null commit_last_checked_at (which has never been checked).
+		(%s - commit_last_checked_at > (%s * '1 second'::interval)) IS DISTINCT FROM FALSE
+	GROUP BY repository_id, commit
+)
 SELECT r.id, r.name, c.commit
 FROM candidates c
 JOIN repo r ON r.id = c.repository_id
@@ -62,107 +117,32 @@ ORDER BY MIN(c.max_last_checked_at) OVER (PARTITION BY c.repository_id), c.commi
 LIMIT %s
 `
 
-const candidatesSubqueryCTE = `
-SELECT
-	repository_id,
-	commit,
-	-- Keep track of the most recent update of this commit that we know about
-	-- as any earlier dates for the same repository and commit pair carry no
-	-- useful information.
-	MAX(commit_last_checked_at) as max_last_checked_at
-FROM lsif_indexes
-WHERE
-	-- Ignore records already marked as deleted
-	state NOT IN ('deleted', 'deleting') AND
-	-- Ignore records that have been checked recently. Note this condition is
-	-- true for a null commit_last_checked_at (which has never been checked).
-	(%s - commit_last_checked_at > (%s * '1 second'::interval)) IS DISTINCT FROM FALSE
-GROUP BY repository_id, commit
-`
-
-// UpdateSourcedCommits updates the commit_last_checked_at field of each upload and index records belonging
-// to the given repository identifier and commit. This method returns the count of upload and index records
-// modified, respectively.
-func (s *store) UpdateSourcedCommits(ctx context.Context, repositoryID int, commit string, now time.Time) (indexesUpdated int, err error) {
-	ctx, trace, endObservation := s.operations.updateSourcedCommits.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.Int("repositoryID", repositoryID),
-		log.String("commit", commit),
-	}})
-	defer endObservation(1, observation.Args{})
-
-	candidateIndexesSubquery := sqlf.Sprintf(candidateIndexesCTE, repositoryID, commit)
-	updateSourcedCommitsQuery := sqlf.Sprintf(updateSourcedCommitsQuery, candidateIndexesSubquery, now)
-
-	indexesUpdated, err = scanCount(s.db.Query(ctx, updateSourcedCommitsQuery))
-	if err != nil {
-		return 0, err
-	}
-	trace.Log(log.Int("indexesUpdated", indexesUpdated))
-
-	return indexesUpdated, nil
-}
-
 const updateSourcedCommitsQuery = `
 WITH
-candidate_indexes AS (%s),
+candidate_indexes AS (
+	SELECT u.id
+	FROM lsif_indexes u
+	WHERE
+		u.repository_id = %s AND
+		(
+			u.commit = ANY(%s) OR
+			u.commit = ANY(%s)
+		)
+
+	-- Lock these rows in a deterministic order so that we don't
+	-- deadlock with other processes updating the lsif_indexes table.
+	ORDER BY u.id FOR UPDATE
+),
 update_indexes AS (
-	UPDATE lsif_indexes u
+	UPDATE lsif_indexes
 	SET commit_last_checked_at = %s
-	WHERE id IN (SELECT id FROM candidate_indexes)
+	WHERE id IN (SELECT id FROM candidate_indexes WHERE commit = ANY(%s))
 	RETURNING 1
-)
-SELECT
-	(SELECT COUNT(*) FROM update_indexes) AS num_indexes
-`
-
-const candidateIndexesCTE = `
-SELECT u.id
-FROM lsif_indexes u
-WHERE u.repository_id = %s AND u.commit = %s
-
--- Lock these rows in a deterministic order so that we don't
--- deadlock with other processes updating the lsif_indexes table.
-ORDER BY u.id FOR UPDATE
-`
-
-// DeleteSourcedCommits deletes each index records belonging to the given repository identifier
-// and commit. Indexes are hard-deleted. This method returns the count of index records modified.
-//
-// If a maximum commit lag is supplied, then any upload records in the uploading, queued, or processing states
-// younger than the provided lag will not be deleted, but its timestamp will be modified as if the sibling method
-// UpdateSourcedCommits was called instead. This configurable parameter enables support for remote code hosts
-// that are not the source of truth; if we deleted all pending records without resolvable commits introduce races
-// between the customer's Sourcegraph instance and their CI (and their CI will usually win).
-func (s *store) DeleteSourcedCommits(ctx context.Context, repositoryID int, commit string, maximumCommitLag time.Duration) (indexesDeleted int, err error) {
-	ctx, trace, endObservation := s.operations.deleteSourcedCommits.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.Int("repositoryID", repositoryID),
-		log.String("commit", commit),
-	}})
-	defer endObservation(1, observation.Args{})
-
-	unset, _ := s.db.SetLocal(ctx, "codeintel.lsif_uploads_audit.reason", "upload associated with unknown commit")
-	defer unset(ctx)
-
-	candidateIndexesSubquery := sqlf.Sprintf(candidateIndexesCTE, repositoryID, commit)
-	deleteSourcedCommitsQuery := sqlf.Sprintf(deleteSourcedCommitsQuery, candidateIndexesSubquery)
-
-	indexesDeleted, err = scanCount(s.db.Query(ctx, deleteSourcedCommitsQuery))
-	if err != nil {
-		return 0, err
-	}
-	trace.Log(log.Int("indexesDeleted", indexesDeleted))
-
-	return indexesDeleted, nil
-}
-
-const deleteSourcedCommitsQuery = `
-WITH
-candidate_indexes AS (%s),
+),
 delete_indexes AS (
-	DELETE FROM lsif_indexes u
-	WHERE id IN (SELECT id FROM candidate_indexes)
+	DELETE FROM lsif_indexes
+	WHERE id IN (SELECT id FROM candidate_indexes WHERE commit = ANY(%s))
 	RETURNING 1
 )
-SELECT
-	(SELECT COUNT(*) FROM delete_indexes) AS num_indexes_deleted
+SELECT COUNT(*) FROM delete_indexes
 `

--- a/internal/codeintel/autoindexing/mocks_test.go
+++ b/internal/codeintel/autoindexing/mocks_test.go
@@ -38,9 +38,6 @@ type MockStore struct {
 	// object controlling the behavior of the method
 	// DeleteIndexesWithoutRepository.
 	DeleteIndexesWithoutRepositoryFunc *StoreDeleteIndexesWithoutRepositoryFunc
-	// DeleteSourcedCommitsFunc is an instance of a mock function object
-	// controlling the behavior of the method DeleteSourcedCommits.
-	DeleteSourcedCommitsFunc *StoreDeleteSourcedCommitsFunc
 	// DoneFunc is an instance of a mock function object controlling the
 	// behavior of the method Done.
 	DoneFunc *StoreDoneFunc
@@ -76,9 +73,6 @@ type MockStore struct {
 	// GetRecentIndexesSummaryFunc is an instance of a mock function object
 	// controlling the behavior of the method GetRecentIndexesSummary.
 	GetRecentIndexesSummaryFunc *StoreGetRecentIndexesSummaryFunc
-	// GetStaleSourcedCommitsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetStaleSourcedCommits.
-	GetStaleSourcedCommitsFunc *StoreGetStaleSourcedCommitsFunc
 	// GetUnsafeDBFunc is an instance of a mock function object controlling
 	// the behavior of the method GetUnsafeDB.
 	GetUnsafeDBFunc *StoreGetUnsafeDBFunc
@@ -98,6 +92,10 @@ type MockStore struct {
 	// MarkRepoRevsAsProcessedFunc is an instance of a mock function object
 	// controlling the behavior of the method MarkRepoRevsAsProcessed.
 	MarkRepoRevsAsProcessedFunc *StoreMarkRepoRevsAsProcessedFunc
+	// ProcessStaleSourcedCommitsFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// ProcessStaleSourcedCommits.
+	ProcessStaleSourcedCommitsFunc *StoreProcessStaleSourcedCommitsFunc
 	// QueueRepoRevFunc is an instance of a mock function object controlling
 	// the behavior of the method QueueRepoRev.
 	QueueRepoRevFunc *StoreQueueRepoRevFunc
@@ -121,9 +119,6 @@ type MockStore struct {
 	// function object controlling the behavior of the method
 	// UpdateIndexConfigurationByRepositoryID.
 	UpdateIndexConfigurationByRepositoryIDFunc *StoreUpdateIndexConfigurationByRepositoryIDFunc
-	// UpdateSourcedCommitsFunc is an instance of a mock function object
-	// controlling the behavior of the method UpdateSourcedCommits.
-	UpdateSourcedCommitsFunc *StoreUpdateSourcedCommitsFunc
 }
 
 // NewMockStore creates a new mock of the Store interface. All methods
@@ -142,11 +137,6 @@ func NewMockStore() *MockStore {
 		},
 		DeleteIndexesWithoutRepositoryFunc: &StoreDeleteIndexesWithoutRepositoryFunc{
 			defaultHook: func(context.Context, time.Time) (r0 map[int]int, r1 error) {
-				return
-			},
-		},
-		DeleteSourcedCommitsFunc: &StoreDeleteSourcedCommitsFunc{
-			defaultHook: func(context.Context, int, string, time.Duration) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -205,11 +195,6 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		GetStaleSourcedCommitsFunc: &StoreGetStaleSourcedCommitsFunc{
-			defaultHook: func(context.Context, time.Duration, int, time.Time) (r0 []shared.SourcedCommits, r1 error) {
-				return
-			},
-		},
 		GetUnsafeDBFunc: &StoreGetUnsafeDBFunc{
 			defaultHook: func() (r0 database.DB) {
 				return
@@ -237,6 +222,11 @@ func NewMockStore() *MockStore {
 		},
 		MarkRepoRevsAsProcessedFunc: &StoreMarkRepoRevsAsProcessedFunc{
 			defaultHook: func(context.Context, []int) (r0 error) {
+				return
+			},
+		},
+		ProcessStaleSourcedCommitsFunc: &StoreProcessStaleSourcedCommitsFunc{
+			defaultHook: func(context.Context, time.Duration, int, time.Duration, func(ctx context.Context, repositoryID int, commit string) (bool, error)) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -275,11 +265,6 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		UpdateSourcedCommitsFunc: &StoreUpdateSourcedCommitsFunc{
-			defaultHook: func(context.Context, int, string, time.Time) (r0 int, r1 error) {
-				return
-			},
-		},
 	}
 }
 
@@ -300,11 +285,6 @@ func NewStrictMockStore() *MockStore {
 		DeleteIndexesWithoutRepositoryFunc: &StoreDeleteIndexesWithoutRepositoryFunc{
 			defaultHook: func(context.Context, time.Time) (map[int]int, error) {
 				panic("unexpected invocation of MockStore.DeleteIndexesWithoutRepository")
-			},
-		},
-		DeleteSourcedCommitsFunc: &StoreDeleteSourcedCommitsFunc{
-			defaultHook: func(context.Context, int, string, time.Duration) (int, error) {
-				panic("unexpected invocation of MockStore.DeleteSourcedCommits")
 			},
 		},
 		DoneFunc: &StoreDoneFunc{
@@ -362,11 +342,6 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.GetRecentIndexesSummary")
 			},
 		},
-		GetStaleSourcedCommitsFunc: &StoreGetStaleSourcedCommitsFunc{
-			defaultHook: func(context.Context, time.Duration, int, time.Time) ([]shared.SourcedCommits, error) {
-				panic("unexpected invocation of MockStore.GetStaleSourcedCommits")
-			},
-		},
 		GetUnsafeDBFunc: &StoreGetUnsafeDBFunc{
 			defaultHook: func() database.DB {
 				panic("unexpected invocation of MockStore.GetUnsafeDB")
@@ -395,6 +370,11 @@ func NewStrictMockStore() *MockStore {
 		MarkRepoRevsAsProcessedFunc: &StoreMarkRepoRevsAsProcessedFunc{
 			defaultHook: func(context.Context, []int) error {
 				panic("unexpected invocation of MockStore.MarkRepoRevsAsProcessed")
+			},
+		},
+		ProcessStaleSourcedCommitsFunc: &StoreProcessStaleSourcedCommitsFunc{
+			defaultHook: func(context.Context, time.Duration, int, time.Duration, func(ctx context.Context, repositoryID int, commit string) (bool, error)) (int, error) {
+				panic("unexpected invocation of MockStore.ProcessStaleSourcedCommits")
 			},
 		},
 		QueueRepoRevFunc: &StoreQueueRepoRevFunc{
@@ -432,11 +412,6 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.UpdateIndexConfigurationByRepositoryID")
 			},
 		},
-		UpdateSourcedCommitsFunc: &StoreUpdateSourcedCommitsFunc{
-			defaultHook: func(context.Context, int, string, time.Time) (int, error) {
-				panic("unexpected invocation of MockStore.UpdateSourcedCommits")
-			},
-		},
 	}
 }
 
@@ -452,9 +427,6 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		DeleteIndexesWithoutRepositoryFunc: &StoreDeleteIndexesWithoutRepositoryFunc{
 			defaultHook: i.DeleteIndexesWithoutRepository,
-		},
-		DeleteSourcedCommitsFunc: &StoreDeleteSourcedCommitsFunc{
-			defaultHook: i.DeleteSourcedCommits,
 		},
 		DoneFunc: &StoreDoneFunc{
 			defaultHook: i.Done,
@@ -489,9 +461,6 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
 			defaultHook: i.GetRecentIndexesSummary,
 		},
-		GetStaleSourcedCommitsFunc: &StoreGetStaleSourcedCommitsFunc{
-			defaultHook: i.GetStaleSourcedCommits,
-		},
 		GetUnsafeDBFunc: &StoreGetUnsafeDBFunc{
 			defaultHook: i.GetUnsafeDB,
 		},
@@ -509,6 +478,9 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		MarkRepoRevsAsProcessedFunc: &StoreMarkRepoRevsAsProcessedFunc{
 			defaultHook: i.MarkRepoRevsAsProcessed,
+		},
+		ProcessStaleSourcedCommitsFunc: &StoreProcessStaleSourcedCommitsFunc{
+			defaultHook: i.ProcessStaleSourcedCommits,
 		},
 		QueueRepoRevFunc: &StoreQueueRepoRevFunc{
 			defaultHook: i.QueueRepoRev,
@@ -530,9 +502,6 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		UpdateIndexConfigurationByRepositoryIDFunc: &StoreUpdateIndexConfigurationByRepositoryIDFunc{
 			defaultHook: i.UpdateIndexConfigurationByRepositoryID,
-		},
-		UpdateSourcedCommitsFunc: &StoreUpdateSourcedCommitsFunc{
-			defaultHook: i.UpdateSourcedCommits,
 		},
 	}
 }
@@ -857,120 +826,6 @@ func (c StoreDeleteIndexesWithoutRepositoryFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreDeleteIndexesWithoutRepositoryFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// StoreDeleteSourcedCommitsFunc describes the behavior when the
-// DeleteSourcedCommits method of the parent MockStore instance is invoked.
-type StoreDeleteSourcedCommitsFunc struct {
-	defaultHook func(context.Context, int, string, time.Duration) (int, error)
-	hooks       []func(context.Context, int, string, time.Duration) (int, error)
-	history     []StoreDeleteSourcedCommitsFuncCall
-	mutex       sync.Mutex
-}
-
-// DeleteSourcedCommits delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockStore) DeleteSourcedCommits(v0 context.Context, v1 int, v2 string, v3 time.Duration) (int, error) {
-	r0, r1 := m.DeleteSourcedCommitsFunc.nextHook()(v0, v1, v2, v3)
-	m.DeleteSourcedCommitsFunc.appendCall(StoreDeleteSourcedCommitsFuncCall{v0, v1, v2, v3, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the DeleteSourcedCommits
-// method of the parent MockStore instance is invoked and the hook queue is
-// empty.
-func (f *StoreDeleteSourcedCommitsFunc) SetDefaultHook(hook func(context.Context, int, string, time.Duration) (int, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// DeleteSourcedCommits method of the parent MockStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *StoreDeleteSourcedCommitsFunc) PushHook(hook func(context.Context, int, string, time.Duration) (int, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreDeleteSourcedCommitsFunc) SetDefaultReturn(r0 int, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, time.Duration) (int, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreDeleteSourcedCommitsFunc) PushReturn(r0 int, r1 error) {
-	f.PushHook(func(context.Context, int, string, time.Duration) (int, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreDeleteSourcedCommitsFunc) nextHook() func(context.Context, int, string, time.Duration) (int, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreDeleteSourcedCommitsFunc) appendCall(r0 StoreDeleteSourcedCommitsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreDeleteSourcedCommitsFuncCall objects
-// describing the invocations of this function.
-func (f *StoreDeleteSourcedCommitsFunc) History() []StoreDeleteSourcedCommitsFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreDeleteSourcedCommitsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreDeleteSourcedCommitsFuncCall is an object that describes an
-// invocation of method DeleteSourcedCommits on an instance of MockStore.
-type StoreDeleteSourcedCommitsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 time.Duration
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 int
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreDeleteSourcedCommitsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreDeleteSourcedCommitsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -2179,121 +2034,6 @@ func (c StoreGetRecentIndexesSummaryFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// StoreGetStaleSourcedCommitsFunc describes the behavior when the
-// GetStaleSourcedCommits method of the parent MockStore instance is
-// invoked.
-type StoreGetStaleSourcedCommitsFunc struct {
-	defaultHook func(context.Context, time.Duration, int, time.Time) ([]shared.SourcedCommits, error)
-	hooks       []func(context.Context, time.Duration, int, time.Time) ([]shared.SourcedCommits, error)
-	history     []StoreGetStaleSourcedCommitsFuncCall
-	mutex       sync.Mutex
-}
-
-// GetStaleSourcedCommits delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockStore) GetStaleSourcedCommits(v0 context.Context, v1 time.Duration, v2 int, v3 time.Time) ([]shared.SourcedCommits, error) {
-	r0, r1 := m.GetStaleSourcedCommitsFunc.nextHook()(v0, v1, v2, v3)
-	m.GetStaleSourcedCommitsFunc.appendCall(StoreGetStaleSourcedCommitsFuncCall{v0, v1, v2, v3, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// GetStaleSourcedCommits method of the parent MockStore instance is invoked
-// and the hook queue is empty.
-func (f *StoreGetStaleSourcedCommitsFunc) SetDefaultHook(hook func(context.Context, time.Duration, int, time.Time) ([]shared.SourcedCommits, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetStaleSourcedCommits method of the parent MockStore instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *StoreGetStaleSourcedCommitsFunc) PushHook(hook func(context.Context, time.Duration, int, time.Time) ([]shared.SourcedCommits, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetStaleSourcedCommitsFunc) SetDefaultReturn(r0 []shared.SourcedCommits, r1 error) {
-	f.SetDefaultHook(func(context.Context, time.Duration, int, time.Time) ([]shared.SourcedCommits, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetStaleSourcedCommitsFunc) PushReturn(r0 []shared.SourcedCommits, r1 error) {
-	f.PushHook(func(context.Context, time.Duration, int, time.Time) ([]shared.SourcedCommits, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreGetStaleSourcedCommitsFunc) nextHook() func(context.Context, time.Duration, int, time.Time) ([]shared.SourcedCommits, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetStaleSourcedCommitsFunc) appendCall(r0 StoreGetStaleSourcedCommitsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreGetStaleSourcedCommitsFuncCall objects
-// describing the invocations of this function.
-func (f *StoreGetStaleSourcedCommitsFunc) History() []StoreGetStaleSourcedCommitsFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetStaleSourcedCommitsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetStaleSourcedCommitsFuncCall is an object that describes an
-// invocation of method GetStaleSourcedCommits on an instance of MockStore.
-type StoreGetStaleSourcedCommitsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 time.Duration
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 int
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 time.Time
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []shared.SourcedCommits
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetStaleSourcedCommitsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetStaleSourcedCommitsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
 // StoreGetUnsafeDBFunc describes the behavior when the GetUnsafeDB method
 // of the parent MockStore instance is invoked.
 type StoreGetUnsafeDBFunc struct {
@@ -2947,6 +2687,126 @@ func (c StoreMarkRepoRevsAsProcessedFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreMarkRepoRevsAsProcessedFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
+}
+
+// StoreProcessStaleSourcedCommitsFunc describes the behavior when the
+// ProcessStaleSourcedCommits method of the parent MockStore instance is
+// invoked.
+type StoreProcessStaleSourcedCommitsFunc struct {
+	defaultHook func(context.Context, time.Duration, int, time.Duration, func(ctx context.Context, repositoryID int, commit string) (bool, error)) (int, error)
+	hooks       []func(context.Context, time.Duration, int, time.Duration, func(ctx context.Context, repositoryID int, commit string) (bool, error)) (int, error)
+	history     []StoreProcessStaleSourcedCommitsFuncCall
+	mutex       sync.Mutex
+}
+
+// ProcessStaleSourcedCommits delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockStore) ProcessStaleSourcedCommits(v0 context.Context, v1 time.Duration, v2 int, v3 time.Duration, v4 func(ctx context.Context, repositoryID int, commit string) (bool, error)) (int, error) {
+	r0, r1 := m.ProcessStaleSourcedCommitsFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.ProcessStaleSourcedCommitsFunc.appendCall(StoreProcessStaleSourcedCommitsFuncCall{v0, v1, v2, v3, v4, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// ProcessStaleSourcedCommits method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreProcessStaleSourcedCommitsFunc) SetDefaultHook(hook func(context.Context, time.Duration, int, time.Duration, func(ctx context.Context, repositoryID int, commit string) (bool, error)) (int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ProcessStaleSourcedCommits method of the parent MockStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *StoreProcessStaleSourcedCommitsFunc) PushHook(hook func(context.Context, time.Duration, int, time.Duration, func(ctx context.Context, repositoryID int, commit string) (bool, error)) (int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreProcessStaleSourcedCommitsFunc) SetDefaultReturn(r0 int, r1 error) {
+	f.SetDefaultHook(func(context.Context, time.Duration, int, time.Duration, func(ctx context.Context, repositoryID int, commit string) (bool, error)) (int, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreProcessStaleSourcedCommitsFunc) PushReturn(r0 int, r1 error) {
+	f.PushHook(func(context.Context, time.Duration, int, time.Duration, func(ctx context.Context, repositoryID int, commit string) (bool, error)) (int, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreProcessStaleSourcedCommitsFunc) nextHook() func(context.Context, time.Duration, int, time.Duration, func(ctx context.Context, repositoryID int, commit string) (bool, error)) (int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreProcessStaleSourcedCommitsFunc) appendCall(r0 StoreProcessStaleSourcedCommitsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreProcessStaleSourcedCommitsFuncCall
+// objects describing the invocations of this function.
+func (f *StoreProcessStaleSourcedCommitsFunc) History() []StoreProcessStaleSourcedCommitsFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreProcessStaleSourcedCommitsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreProcessStaleSourcedCommitsFuncCall is an object that describes an
+// invocation of method ProcessStaleSourcedCommits on an instance of
+// MockStore.
+type StoreProcessStaleSourcedCommitsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 time.Duration
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 time.Duration
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 func(ctx context.Context, repositoryID int, commit string) (bool, error)
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreProcessStaleSourcedCommitsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreProcessStaleSourcedCommitsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // StoreQueueRepoRevFunc describes the behavior when the QueueRepoRev method
@@ -3696,120 +3556,6 @@ func (c StoreUpdateIndexConfigurationByRepositoryIDFuncCall) Args() []interface{
 // invocation.
 func (c StoreUpdateIndexConfigurationByRepositoryIDFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
-}
-
-// StoreUpdateSourcedCommitsFunc describes the behavior when the
-// UpdateSourcedCommits method of the parent MockStore instance is invoked.
-type StoreUpdateSourcedCommitsFunc struct {
-	defaultHook func(context.Context, int, string, time.Time) (int, error)
-	hooks       []func(context.Context, int, string, time.Time) (int, error)
-	history     []StoreUpdateSourcedCommitsFuncCall
-	mutex       sync.Mutex
-}
-
-// UpdateSourcedCommits delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockStore) UpdateSourcedCommits(v0 context.Context, v1 int, v2 string, v3 time.Time) (int, error) {
-	r0, r1 := m.UpdateSourcedCommitsFunc.nextHook()(v0, v1, v2, v3)
-	m.UpdateSourcedCommitsFunc.appendCall(StoreUpdateSourcedCommitsFuncCall{v0, v1, v2, v3, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the UpdateSourcedCommits
-// method of the parent MockStore instance is invoked and the hook queue is
-// empty.
-func (f *StoreUpdateSourcedCommitsFunc) SetDefaultHook(hook func(context.Context, int, string, time.Time) (int, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// UpdateSourcedCommits method of the parent MockStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *StoreUpdateSourcedCommitsFunc) PushHook(hook func(context.Context, int, string, time.Time) (int, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreUpdateSourcedCommitsFunc) SetDefaultReturn(r0 int, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, time.Time) (int, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreUpdateSourcedCommitsFunc) PushReturn(r0 int, r1 error) {
-	f.PushHook(func(context.Context, int, string, time.Time) (int, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreUpdateSourcedCommitsFunc) nextHook() func(context.Context, int, string, time.Time) (int, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreUpdateSourcedCommitsFunc) appendCall(r0 StoreUpdateSourcedCommitsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreUpdateSourcedCommitsFuncCall objects
-// describing the invocations of this function.
-func (f *StoreUpdateSourcedCommitsFunc) History() []StoreUpdateSourcedCommitsFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreUpdateSourcedCommitsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreUpdateSourcedCommitsFuncCall is an object that describes an
-// invocation of method UpdateSourcedCommits on an instance of MockStore.
-type StoreUpdateSourcedCommitsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 time.Time
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 int
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreUpdateSourcedCommitsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreUpdateSourcedCommitsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // MockGitserverClient is a mock implementation of the GitserverClient

--- a/internal/codeintel/autoindexing/service.go
+++ b/internal/codeintel/autoindexing/service.go
@@ -140,25 +140,14 @@ func (s *Service) ReindexIndexes(ctx context.Context, opts shared.ReindexIndexes
 	return s.store.ReindexIndexes(ctx, opts)
 }
 
-func (s *Service) GetStaleSourcedCommits(ctx context.Context, minimumTimeSinceLastCheck time.Duration, limit int, now time.Time) (_ []shared.SourcedCommits, err error) {
-	ctx, _, endObservation := s.operations.getStaleSourcedCommits.With(ctx, &err, observation.Args{})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.GetStaleSourcedCommits(ctx, minimumTimeSinceLastCheck, limit, now)
-}
-
-func (s *Service) UpdateSourcedCommits(ctx context.Context, repositoryID int, commit string, now time.Time) (indexesUpdated int, err error) {
-	ctx, _, endObservation := s.operations.updateSourcedCommits.With(ctx, &err, observation.Args{})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.UpdateSourcedCommits(ctx, repositoryID, commit, now)
-}
-
-func (s *Service) DeleteSourcedCommits(ctx context.Context, repositoryID int, commit string, maximumCommitLag time.Duration) (indexesDeleted int, err error) {
-	ctx, _, endObservation := s.operations.deleteSourcedCommits.With(ctx, &err, observation.Args{})
-	defer endObservation(1, observation.Args{})
-
-	return s.store.DeleteSourcedCommits(ctx, repositoryID, commit, maximumCommitLag)
+func (s *Service) ProcessStaleSourcedCommits(
+	ctx context.Context,
+	minimumTimeSinceLastCheck time.Duration,
+	commitResolverBatchSize int,
+	commitResolverMaximumCommitLag time.Duration,
+	shouldDelete func(ctx context.Context, repositoryID int, commit string) (bool, error),
+) (_ int, err error) {
+	return s.store.ProcessStaleSourcedCommits(ctx, minimumTimeSinceLastCheck, commitResolverBatchSize, commitResolverMaximumCommitLag, shouldDelete)
 }
 
 func (s *Service) DeleteIndexesWithoutRepository(ctx context.Context, now time.Time) (_ map[int]int, err error) {


### PR DESCRIPTION
This PR rewrites the index-record-without-commit cleanup process from a slew of methods that proxy through the service into the store into a single method in the store that is a bit more tightly coupled with the use.

Before, we had one big "codeintel database layer" which was loosely coupled by design, but we've broken that up and can be more tightly coupled now for better understanding and control.

There are many other opportunities for similar efforts, especially in background processes. I'll be cleaning these up as I encounter them (but the invitation for others to jump in is forever).

## Test plan

Updated unit tests.