### PR TITLE
src-expose feature: ignore files in source directory

### DIFF
--- a/dev/src-expose/examples/example.yaml
+++ b/dev/src-expose/examples/example.yaml
@@ -7,7 +7,7 @@ destination: /data/git-repos
 # before is a command run before sync. before is run from root.
 before: p4 sync
 # dirmode defines what behaviour to use if Dir is missing.
-# 
+#
 #  - fail (default)
 #  - ignore
 #  - remove_dest
@@ -28,4 +28,12 @@ dirs:
   # destination is relative to top-level destination (/data/git-repos). By
   # default it is the same as dir.
   destination: ./nested-project
+  ignore:
+    - "**/.git/*"
+    - "**/.svn/*"
+    - "**/.hg/*"
+    - "**/.idea/*"
+    - "**/target/*"
+    - "**/build/*"
+    - "**/.DS_Store"
 - dir: ./other-project


### PR DESCRIPTION
By default, `src-expose` will sync and serve all content in a source directory.
When using `src-expose` on local repositories from other SCM tools, like Subversion, the SCM local database and control files should be ignored to avoid Sourcegraph indexing those files. For most setups, build and dependency directories should be ignored also.

Add to the config definition an `ignore` property on `dir` that is a list of `gitignore` patterns identifying items in the source directory to exclude from the sync and serve.

When using the `ignore` list, there is no need to create a `.gitignore` file in the source directory, as shown in the `example.yaml` configuration file.

The `ignore` list is written to the file `$GIT_DIR/info/exclude`, where `$GIT_DIR` is the `.git` dir in the destination directory, so the source directory is not touched.

See the `git` documentation about the `$GIT_DIR/info/exclude` file
and `gitignore` patterns: https://git-scm.com/docs/gitignore



## Test plan

All commands should be compatible with Linux, macOS and WSL terminals.
May need to adjust paths for the local environment.

### Setup

#### Create a sample directory structure to expose
```
mkdir -p ~/Downloads/testrepos/repoi
cat >~/Downloads/testrepos/repoi/hello.c <<EOF
#include <stdio.h>
int main() {
  puts("hello, world!");
  return 0;
}
EOF
cat >~/Downloads/testrepos/repoi/goodbye.c <<EOF
#include <stdio.h>
int main() {
  puts("goodbye, world!");
  return 0;
}
EOF
```
#### Create two config files to use for before and after tests
```
cat >~/Downloads/testrepos/before.yaml <<EOF
dirs:
- dir: ${HOME}/Downloads/testrepos/repoi
  destination: repoi
EOF
cat >~/Downloads/testrepos/after.yaml <<EOF
dirs:
- dir: ${HOME}/Downloads/testrepos/repoi
  destination: repoi
  ignore:
  - "goodbye.c"
EOF
```
### Before
Displays the behavior without the `ignore` list in the config file
#### Run `src-expose` using the `before.yaml` config file
```
src-expose --config ~/Downloads/testrepos/before.yaml
```
The output should show both source files being synced
```
>  2 files changed, 10 insertions(+)
>  create mode 100644 goodbye.c
>  create mode 100644 hello.c
```
### After
Displays the behavior when using the `ignore` list in the config file
#### Delete the synced directory
```
rm -rf ~/.sourcegraph/src-expose-repos/repoi
```
#### Run `src-expose` using the `after.yaml` config file
```
src-expose --config ~/Downloads/testrepos/after.yaml
```
The output should show only the `hello.c` file, since `goodbye.c` is being ignored
```
>  1 file changed, 5 insertions(+)
>  create mode 100644 hello.c
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
