### PR TITLE
webhooks: add first version of list webhooks UI

### DIFF
--- a/client/web/src/site-admin/SiteAdminWebhooksPage.module.scss
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.module.scss
@@ -1,4 +1,4 @@
-.specs {
+.webhooks {
     &__grid {
         display: grid;
         grid-template-columns: [info] minmax(min-content, 1fr) [actions] max-content;

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.module.scss
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.module.scss
@@ -1,0 +1,7 @@
+.specs {
+    &__grid {
+        display: grid;
+        grid-template-columns: [info] minmax(min-content, 1fr) [actions] max-content;
+        align-items: center;
+    }
+}

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.story.tsx
@@ -1,0 +1,125 @@
+import { DecoratorFn, Meta, Story } from '@storybook/react'
+
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
+
+import { WebStory } from '../components/WebStory'
+
+import { SiteAdminWebhooksPage } from './SiteAdminWebhooksPage'
+import { getDocumentNode } from '@sourcegraph/http-client'
+
+import { ExternalServiceKind } from '../../../shared/src/graphql-operations'
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import * as H from 'history'
+import { WEBHOOKS } from './backend'
+import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
+import { WebhookFields } from '../graphql-operations'
+
+const decorator: DecoratorFn = Story => <Story />
+
+const config: Meta = {
+    title: 'web/src/site-admin/SiteAdminWebhooksPage',
+    decorators: [decorator],
+}
+
+export default config
+
+export const NoWebhooksFound: Story = () => (
+    <WebStory>
+        {() => (
+            <MockedTestProvider
+                link={
+                    new WildcardMockLink([
+                        {
+                            request: {
+                                query: getDocumentNode(WEBHOOKS),
+                                variables: MATCH_ANY_PARAMETERS,
+                            },
+                            result: {
+                                data: {
+                                    webhooks: {
+                                        nodes: [],
+                                        totalCount: 0,
+                                        pageInfo: {
+                                            hasNextPage: false,
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    ])
+                }
+            >
+                <SiteAdminWebhooksPage
+                    match={{} as any}
+                    history={H.createMemoryHistory()}
+                    location={{} as any}
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
+
+NoWebhooksFound.storyName = 'No webhooks found'
+
+export const FiveWebhooksFound: Story = () => (
+    <WebStory>
+        {() => (
+            <MockedTestProvider
+                link={
+                    new WildcardMockLink([
+                        {
+                            request: {
+                                query: getDocumentNode(WEBHOOKS),
+                                variables: MATCH_ANY_PARAMETERS,
+                            },
+                            result: {
+                                data: {
+                                    webhooks: {
+                                        nodes: [
+                                            createWebhookMock(
+                                                ExternalServiceKind.BITBUCKETCLOUD,
+                                                'bitbucket.com/repo1'
+                                            ),
+                                            createWebhookMock(ExternalServiceKind.GITHUB, 'github.com/repo1'),
+                                            createWebhookMock(ExternalServiceKind.GITHUB, 'github.com/repo2'),
+                                            createWebhookMock(ExternalServiceKind.GITHUB, 'github.com/repo3'),
+                                            createWebhookMock(ExternalServiceKind.BITBUCKETCLOUD, 'github.com/repo2'),
+                                        ],
+                                        totalCount: 5,
+                                        pageInfo: {
+                                            hasNextPage: false,
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    ])
+                }
+            >
+                <SiteAdminWebhooksPage
+                    match={{} as any}
+                    history={H.createMemoryHistory()}
+                    location={{} as any}
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
+
+FiveWebhooksFound.storyName = '5 webhooks found'
+
+function createWebhookMock(kind: ExternalServiceKind, urn: string): WebhookFields {
+    return {
+        __typename: 'Webhook',
+        createdAt: '',
+        id: '',
+        secret: null,
+        updatedAt: '',
+        url: '',
+        uuid: '',
+        codeHostKind: kind,
+        codeHostURN: urn,
+    }
+}

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.story.tsx
@@ -83,7 +83,7 @@ export const FiveWebhooksFound: Story = () => (
                                             createWebhookMock(ExternalServiceKind.GITHUB, 'github.com/repo1'),
                                             createWebhookMock(ExternalServiceKind.GITHUB, 'github.com/repo2'),
                                             createWebhookMock(ExternalServiceKind.GITHUB, 'github.com/repo3'),
-                                            createWebhookMock(ExternalServiceKind.BITBUCKETCLOUD, 'github.com/repo2'),
+                                            createWebhookMock(ExternalServiceKind.BITBUCKETCLOUD, 'bitbucket.com/repo2'),
                                         ],
                                         totalCount: 5,
                                         pageInfo: {
@@ -113,7 +113,7 @@ function createWebhookMock(kind: ExternalServiceKind, urn: string): WebhookField
     return {
         __typename: 'Webhook',
         createdAt: '',
-        id: '',
+        id: `webhook-${urn}`,
         secret: null,
         updatedAt: '',
         url: '',

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.story.tsx
@@ -1,18 +1,17 @@
 import { DecoratorFn, Meta, Story } from '@storybook/react'
+import * as H from 'history'
+import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
+import { getDocumentNode } from '@sourcegraph/http-client'
+import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../components/WebStory'
-
-import { SiteAdminWebhooksPage } from './SiteAdminWebhooksPage'
-import { getDocumentNode } from '@sourcegraph/http-client'
-
-import { ExternalServiceKind } from '../../../shared/src/graphql-operations'
-import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import * as H from 'history'
-import { WEBHOOKS } from './backend'
-import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 import { WebhookFields } from '../graphql-operations'
+
+import { WEBHOOKS } from './backend'
+import { SiteAdminWebhooksPage } from './SiteAdminWebhooksPage'
 
 const decorator: DecoratorFn = Story => <Story />
 

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react'
+import React, { useEffect } from 'react'
 
 import { mdiMapSearch, mdiPlus } from '@mdi/js'
 import { RouteComponentProps } from 'react-router'
@@ -26,8 +26,6 @@ export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChild
         telemetryService.logPageView('SiteAdminWebhooks')
     }, [telemetryService])
 
-    const queryConnection = useCallback(() => queryWebhooks(), [])
-
     return (
         <div className="site-admin-webhooks-page">
             <PageTitle title="Webhook receivers" />
@@ -37,11 +35,9 @@ export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChild
                 description="All configured webhooks receivers"
                 className="mb-3"
                 actions={
-                    <>
-                        <ButtonLink className="test-create-webhook" variant="primary">
-                            <Icon aria-hidden={true} svgPath={mdiPlus} /> Add webhook
-                        </ButtonLink>
-                    </>
+                    <ButtonLink className="test-create-webhook" variant="primary">
+                        <Icon aria-hidden={true} svgPath={mdiPlus} /> Add webhook
+                    </ButtonLink>
                 }
             />
 
@@ -50,12 +46,11 @@ export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChild
                     className="mb-0"
                     noun="webhook"
                     pluralNoun="webhooks"
-                    queryConnection={queryConnection}
+                    queryConnection={queryWebhooks}
                     nodeComponent={WebhookNode}
-                    nodeComponentProps={{}}
                     hideSearch={true}
                     listComponent="div"
-                    listClassName={styles.specsGrid}
+                    listClassName={styles.webhooksGrid}
                     withCenteredSummary={true}
                     noSummaryIfAllNodesVisible={true}
                     history={history}

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
@@ -1,0 +1,83 @@
+import React, { useCallback, useEffect } from 'react'
+
+import { mdiMapSearch, mdiPlus } from '@mdi/js'
+import { RouteComponentProps } from 'react-router'
+import { WebhookFields } from 'src/graphql-operations'
+
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { ButtonLink, Container, H5, Icon, PageHeader } from '@sourcegraph/wildcard'
+
+import { FilteredConnection } from '../components/FilteredConnection'
+import { PageTitle } from '../components/PageTitle'
+
+import { queryWebhooks } from './backend'
+import { WebhookNode } from './WebhookNode'
+
+import styles from './SiteAdminWebhooksPage.module.scss'
+
+interface Props extends RouteComponentProps<{}>, TelemetryProps {}
+
+export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
+    history,
+    location,
+    telemetryService,
+}) => {
+    useEffect(() => {
+        telemetryService.logPageView('SiteAdminWebhooks')
+    }, [telemetryService])
+
+    const queryConnection = useCallback(() => queryWebhooks(), [])
+
+    return (
+        <div className="site-admin-webhooks-page">
+            <PageTitle title="Webhook receivers" />
+            <PageHeader
+                path={[{ text: 'Webhook receivers' }]}
+                headingElement="h2"
+                description="All configured webhooks receivers"
+                className="mb-3"
+                actions={
+                    <>
+                        <ButtonLink className="test-create-webhook" variant="primary">
+                            <Icon aria-hidden={true} svgPath={mdiPlus} /> Add webhook
+                        </ButtonLink>
+                    </>
+                }
+            />
+
+            <Container className="mb-3">
+                <FilteredConnection<WebhookFields>
+                    className="mb-0"
+                    noun="webhook"
+                    pluralNoun="webhooks"
+                    queryConnection={queryConnection}
+                    nodeComponent={WebhookNode}
+                    nodeComponentProps={{}}
+                    hideSearch={true}
+                    listComponent="div"
+                    listClassName={styles.specsGrid}
+                    withCenteredSummary={true}
+                    noSummaryIfAllNodesVisible={true}
+                    history={history}
+                    location={location}
+                    headComponent={Header}
+                    emptyElement={<EmptyList />}
+                />
+            </Container>
+        </div>
+    )
+}
+
+const Header: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
+    <>
+        <H5 className="p-2 d-none d-md-block text-uppercase text-left text-nowrap">Receiver</H5>
+        <H5 className="d-none d-md-block text-uppercase text-center text-nowrap">Actions</H5>
+    </>
+)
+
+const EmptyList: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
+    <div className="text-muted text-center mb-3 w-100">
+        <Icon className="icon" svgPath={mdiMapSearch} inline={false} aria-hidden={true} />
+        <div className="pt-2">No webhooks have been created so far.</div>
+    </div>
+)

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
@@ -1,17 +1,12 @@
 import React, { useEffect } from 'react'
 
 import { mdiMapSearch, mdiPlus } from '@mdi/js'
+import classNames from 'classnames'
 import { RouteComponentProps } from 'react-router'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ButtonLink, Container, H5, Icon, PageHeader } from '@sourcegraph/wildcard'
 
-import { PageTitle } from '../components/PageTitle'
-
-import { queryWebhooks } from './backend'
-import { WebhookNode } from './WebhookNode'
-
-import styles from './SiteAdminWebhooksPage.module.scss'
 import {
     ConnectionContainer,
     ConnectionError,
@@ -21,7 +16,12 @@ import {
     ShowMoreButton,
     SummaryContainer,
 } from '../components/FilteredConnection/ui'
-import classNames from 'classnames'
+import { PageTitle } from '../components/PageTitle'
+
+import { useWebhooksConnection } from './backend'
+import { WebhookNode } from './WebhookNode'
+
+import styles from './SiteAdminWebhooksPage.module.scss'
 
 interface Props extends RouteComponentProps<{}>, TelemetryProps {}
 
@@ -34,7 +34,7 @@ export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChild
         telemetryService.logPageView('SiteAdminWebhooks')
     }, [telemetryService])
 
-    const { loading, hasNextPage, fetchMore, connection, error } = queryWebhooks()
+    const { loading, hasNextPage, fetchMore, connection, error } = useWebhooksConnection()
     return (
         <div className="site-admin-webhooks-page">
             <PageTitle title="Webhook receivers" />
@@ -61,7 +61,7 @@ export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChild
                         aria-label="Webhooks"
                     >
                         {connection?.nodes?.map(node => (
-                            <WebhookNode codeHostKind={node.codeHostKind} codeHostURN={node.codeHostURN} />
+                            <WebhookNode key={node.id} codeHostKind={node.codeHostKind} codeHostURN={node.codeHostURN} />
                         ))}
                     </ConnectionList>
                     {connection && (

--- a/client/web/src/site-admin/WebhookNode.module.scss
+++ b/client/web/src/site-admin/WebhookNode.module.scss
@@ -1,0 +1,8 @@
+.node {
+    &__separator {
+        // Make it full width in the current row.
+        grid-column: 1 / -1;
+        border-top: 1px solid var(--border-color-2);
+        padding-bottom: 0.3rem;
+    }
+}

--- a/client/web/src/site-admin/WebhookNode.module.scss
+++ b/client/web/src/site-admin/WebhookNode.module.scss
@@ -3,6 +3,7 @@
         // Make it full width in the current row.
         grid-column: 1 / -1;
         border-top: 1px solid var(--border-color-2);
-        padding-bottom: 0.3rem;
+        margin-top: 0.5rem;
+        padding-bottom: 0.5rem;
     }
 }

--- a/client/web/src/site-admin/WebhookNode.tsx
+++ b/client/web/src/site-admin/WebhookNode.tsx
@@ -19,34 +19,23 @@ export const WebhookNode: React.FunctionComponent<React.PropsWithChildren<Webhoo
         <>
             <span className={styles.nodeSeparator} />
             <div className="pl-1">
-                <H3 className="pr-2">{node.codeHostURN}</H3>
-                <Text className="mb-0 text-muted">
-                    <small>
-                        <Icon as={IconComponent} aria-label="Code host logo" className="mr-2" />
-                    </small>
-                </Text>
+                <H3 className="pr-2">
+                    {' '}
+                    <Icon inline={true} as={IconComponent} aria-label="Code host logo" className="mr-2" />
+                    {node.codeHostURN}
+                </H3>
             </div>
             <div className="d-flex flex-shrink-0 ml-3">
                 <div>
                     <Tooltip content="Edit webhook">
-                        <Button
-                            aria-label="Edit"
-                            className="test-edit-webhook"
-                            variant="secondary"
-                            size="sm"
-                        >
+                        <Button aria-label="Edit" className="test-edit-webhook" variant="secondary" size="sm">
                             <Icon aria-hidden={true} svgPath={mdiCog} /> Edit
                         </Button>
                     </Tooltip>
                 </div>
                 <div className="ml-1">
-                    <Tooltip content="Delete code host connection">
-                        <Button
-                            aria-label="Delete"
-                            className="test-delete-webhook"
-                            variant="danger"
-                            size="sm"
-                        >
+                    <Tooltip content="Delete webhook">
+                        <Button aria-label="Delete" className="test-delete-webhook" variant="danger" size="sm">
                             <Icon aria-hidden={true} svgPath={mdiDelete} />
                         </Button>
                     </Tooltip>

--- a/client/web/src/site-admin/WebhookNode.tsx
+++ b/client/web/src/site-admin/WebhookNode.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+
+import { mdiCog, mdiDelete } from '@mdi/js'
+
+import { Button, H3, Icon, Text, Tooltip } from '@sourcegraph/wildcard'
+
+import { defaultExternalServices } from '../components/externalServices/externalServices'
+import { WebhookFields } from '../graphql-operations'
+
+import styles from './WebhookNode.module.scss'
+
+export interface WebhookProps {
+    node: WebhookFields
+}
+
+export const WebhookNode: React.FunctionComponent<React.PropsWithChildren<WebhookProps>> = ({ node }) => {
+    const IconComponent = defaultExternalServices[node.codeHostKind].icon
+    return (
+        <>
+            <span className={styles.nodeSeparator} />
+            <div className="pl-1">
+                <H3 className="pr-2">{node.codeHostURN}</H3>
+                <Text className="mb-0 text-muted">
+                    <small>
+                        <Icon as={IconComponent} aria-label="Code host logo" className="mr-2" />
+                    </small>
+                </Text>
+            </div>
+            <div className="d-flex flex-shrink-0 ml-3">
+                <div>
+                    <Tooltip content="Edit webhook">
+                        <Button
+                            aria-label="Edit"
+                            className="test-edit-webhook"
+                            variant="secondary"
+                            size="sm"
+                        >
+                            <Icon aria-hidden={true} svgPath={mdiCog} /> Edit
+                        </Button>
+                    </Tooltip>
+                </div>
+                <div className="ml-1">
+                    <Tooltip content="Delete code host connection">
+                        <Button
+                            aria-label="Delete"
+                            className="test-delete-webhook"
+                            variant="danger"
+                            size="sm"
+                        >
+                            <Icon aria-hidden={true} svgPath={mdiDelete} />
+                        </Button>
+                    </Tooltip>
+                </div>
+            </div>
+        </>
+    )
+}

--- a/client/web/src/site-admin/WebhookNode.tsx
+++ b/client/web/src/site-admin/WebhookNode.tsx
@@ -5,16 +5,20 @@ import { mdiCog, mdiDelete } from '@mdi/js'
 import { Button, H3, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { defaultExternalServices } from '../components/externalServices/externalServices'
-import { WebhookFields } from '../graphql-operations'
+import { ExternalServiceKind } from '../graphql-operations'
 
 import styles from './WebhookNode.module.scss'
 
 export interface WebhookProps {
-    node: WebhookFields
+    codeHostKind: ExternalServiceKind
+    codeHostURN: string
 }
 
-export const WebhookNode: React.FunctionComponent<React.PropsWithChildren<WebhookProps>> = ({ node }) => {
-    const IconComponent = defaultExternalServices[node.codeHostKind].icon
+export const WebhookNode: React.FunctionComponent<React.PropsWithChildren<WebhookProps>> = ({
+    codeHostKind,
+    codeHostURN,
+}) => {
+    const IconComponent = defaultExternalServices[codeHostKind].icon
     return (
         <>
             <span className={styles.nodeSeparator} />
@@ -22,7 +26,7 @@ export const WebhookNode: React.FunctionComponent<React.PropsWithChildren<Webhoo
                 <H3 className="pr-2">
                     {' '}
                     <Icon inline={true} as={IconComponent} aria-label="Code host logo" className="mr-2" />
-                    {node.codeHostURN}
+                    {codeHostURN}
                 </H3>
             </div>
             <div className="d-flex flex-shrink-0 ml-3">

--- a/client/web/src/site-admin/WebhookNode.tsx
+++ b/client/web/src/site-admin/WebhookNode.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { mdiCog, mdiDelete } from '@mdi/js'
 
-import { Button, H3, Icon, Text, Tooltip } from '@sourcegraph/wildcard'
+import { Button, H3, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { defaultExternalServices } from '../components/externalServices/externalServices'
 import { WebhookFields } from '../graphql-operations'

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -58,6 +58,8 @@ import {
     SiteMonitoringStatisticsResult,
     SiteAdminSettingsCascadeFields,
     UserUsageStatisticsResult,
+    WebhooksListResult,
+    WebhooksListVariables,
 } from '../graphql-operations'
 import { accessTokenFragment } from '../settings/tokens/AccessTokenNode'
 
@@ -893,3 +895,38 @@ export const SITE_EXTERNAL_SERVICE_CONFIG = gql`
         }
     }
 `
+
+export const WEBHOOKS = gql`
+    fragment WebhookFields on Webhook {
+        id
+        uuid
+        url
+        codeHostKind
+        codeHostURN
+        secret
+        updatedAt
+        createdAt
+    }
+    query WebhooksList {
+        webhooks {
+            nodes {
+                ...WebhookFields
+            }
+            totalCount
+            pageInfo {
+                hasNextPage
+            }
+        }
+    }
+`
+
+export function queryWebhooks(): Observable<WebhooksListResult['webhooks']> {
+    return requestGraphQL<WebhooksListResult, WebhooksListVariables>(WEBHOOKS, {}).pipe(
+        map(({ data, errors }) => {
+            if (!data || !data.webhooks || errors) {
+                throw createAggregateError(errors)
+            }
+            return data.webhooks
+        })
+    )
+}

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -60,8 +60,10 @@ import {
     UserUsageStatisticsResult,
     WebhooksListResult,
     WebhooksListVariables,
+    WebhookFields,
 } from '../graphql-operations'
 import { accessTokenFragment } from '../settings/tokens/AccessTokenNode'
+import { useConnection, UseConnectionResult } from '../components/FilteredConnection/hooks/useConnection'
 
 /**
  * Fetches all users.
@@ -920,13 +922,13 @@ export const WEBHOOKS = gql`
     }
 `
 
-export function queryWebhooks(): Observable<WebhooksListResult['webhooks']> {
-    return requestGraphQL<WebhooksListResult, WebhooksListVariables>(WEBHOOKS, {}).pipe(
-        map(({ data, errors }) => {
-            if (!data || !data.webhooks || errors) {
-                throw createAggregateError(errors)
-            }
-            return data.webhooks
-        })
-    )
+export function queryWebhooks(): UseConnectionResult<WebhookFields> {
+    return useConnection<WebhooksListResult, WebhooksListVariables, WebhookFields>({
+        query: WEBHOOKS,
+        variables: {},
+        getConnection: result => {
+            const { webhooks } = dataOrThrowErrors(result)
+            return webhooks
+        },
+    })
 }

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -12,6 +12,7 @@ import {
 import { Settings } from '@sourcegraph/shared/src/settings/settings'
 
 import { mutateGraphQL, queryGraphQL, requestGraphQL } from '../backend/graphql'
+import { useConnection, UseConnectionResult } from '../components/FilteredConnection/hooks/useConnection'
 import {
     RepositoriesVariables,
     RepositoriesResult,
@@ -63,7 +64,6 @@ import {
     WebhookFields,
 } from '../graphql-operations'
 import { accessTokenFragment } from '../settings/tokens/AccessTokenNode'
-import { useConnection, UseConnectionResult } from '../components/FilteredConnection/hooks/useConnection'
 
 /**
  * Fetches all users.
@@ -922,8 +922,8 @@ export const WEBHOOKS = gql`
     }
 `
 
-export function queryWebhooks(): UseConnectionResult<WebhookFields> {
-    return useConnection<WebhooksListResult, WebhooksListVariables, WebhookFields>({
+export const useWebhooksConnection = (): UseConnectionResult<WebhookFields> =>
+    useConnection<WebhooksListResult, WebhooksListVariables, WebhookFields>({
         query: WEBHOOKS,
         variables: {},
         getConnection: result => {
@@ -931,4 +931,3 @@ export function queryWebhooks(): UseConnectionResult<WebhookFields> {
             return webhooks
         },
     })
-}

--- a/client/web/src/site-admin/routes.tsx
+++ b/client/web/src/site-admin/routes.tsx
@@ -94,4 +94,9 @@ export const siteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
             'SiteAdminFeatureFlagConfigurationPage'
         ),
     },
+    {
+        path: '/webhooks',
+        exact: true,
+        render: lazyComponent(() => import('./SiteAdminWebhooksPage'), 'SiteAdminWebhooksPage'),
+    },
 ]


### PR DESCRIPTION
This commits includes `site-admin/webhooks` routing to the new page without including it to site admin sidebar, listing all existing webhooks and showing a message if there are no webhooks present.

Test plan:
Local sg run and visual checks. Autotests TBD.

### Original design
https://www.figma.com/file/ngPEwLqRVFAfXQC7lE0WLz/Webhooks?node-id=0%3A1

### Notes
- No filtering and pagination are implemented because we don't expect a large number of webhooks to be shown.
- We currently don't have a "webhook name" to show, that's why webhook node's heading is a URN and instead of URN + code host type in original design I've put just a code host type icon.
- All the buttons are dummy and will be functional as soon as related features (create, view/edit, delete) are added

### Remaining things to do
- Autotests
- Design tweaks

## App preview:

- [Web](https://sg-web-ao-ui-webhooks-list-view.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
