### PR TITLE
search: introduce Debug field and feature flag

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -413,6 +413,10 @@ func fromContentMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.Sear
 		contentEvent.RepoLastFetched = r.LastFetched
 	}
 
+	if fm.Debug != nil {
+		contentEvent.Debug = *fm.Debug
+	}
+
 	return contentEvent
 }
 

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -245,6 +245,7 @@ func ToFeatures(flagSet *featureflag.FlagSet, logger log.Logger) *search.Feature
 		HybridSearch:            flagSet.GetBoolOr("search-hybrid", false),
 		AbLuckySearch:           flagSet.GetBoolOr("ab-lucky-search", false),
 		Ranking:                 flagSet.GetBoolOr("search-ranking", false),
+		Debug:                   flagSet.GetBoolOr("search-debug", false),
 	}
 }
 

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -48,6 +48,12 @@ type FileMatch struct {
 	PathMatches  []Range
 
 	LimitHit bool
+
+	// Debug is optionally set with a debug message explaining the result.
+	//
+	// Note: this is a pointer since usually this is unset. Pointer is 8 bytes
+	// vs an empty string which is 16 bytes.
+	Debug *string `json:"-"`
 }
 
 func (fm *FileMatch) RepoName() types.MinimalRepo {

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -30,6 +30,7 @@ type EventContentMatch struct {
 	Hunks           []DecoratedHunk  `json:"hunks"`
 	LineMatches     []EventLineMatch `json:"lineMatches,omitempty"`
 	ChunkMatches    []ChunkMatch     `json:"chunkMatches,omitempty"`
+	Debug           string           `json:"debug,omitempty"`
 }
 
 func (e *EventContentMatch) eventMatch() {}

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -341,6 +341,10 @@ type Features struct {
 	// Ranking when true will use a our new #ranking signals and code paths
 	// for ranking results from Zoekt.
 	Ranking bool `json:"ranking"`
+
+	// Debug when true will set the Debug field on FileMatches. This may grow
+	// from here. For now we treat this like a feature flag for convenience.
+	Debug bool `json:"debug"`
 }
 
 func (f *Features) String() string {

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -400,6 +400,9 @@ func sendMatches(event *zoekt.SearchResult, pathRegexps []*regexp.Regexp, getRep
 					Path:     file.FileName,
 				},
 			}
+			if debug := file.Debug; debug != "" {
+				fm.Debug = &debug
+			}
 			matches = append(matches, &fm)
 		}
 	}

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -109,6 +109,10 @@ func (o *Options) ToSearch(ctx context.Context) *zoekt.SearchOptions {
 		ChunkMatches: true,
 	}
 
+	if o.Features.Debug {
+		searchOpts.DebugScore = true
+	}
+
 	if limit := int(o.FileMatchLimit); o.Features.Ranking && limit < 1000 {
 		// It is hard to think up general stats here based on limit. So
 		// instead we only run the ranking code path if the limit is


### PR DESCRIPTION
This feature flag allows us to set DebugScore on zoekt.SearchOptions. This will help us understand ranking in the frontend. Right now we only pass Debug back on FileMatch (and not on individual chunk matches), but this will already greatly help us. In future PRs we can work on showing this information in the frontend and allowing this to be set outside of feature flags.

This is an abuse of the Feature flag struct. However, it is very convenient for now and is a relatively clean use of it.

The debug field on FileMatch makes the struct grow from 152 bytes to 160 bytes.

I'll first follow up by getting src-cli to print this debug info.

Test Plan: set the feature flag then curl streaming search endpoint and see debug messages.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
