### PR TITLE
search: turn on page rank for ranking search

### DIFF
--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -113,10 +113,11 @@ func (o *Options) ToSearch(ctx context.Context) *zoekt.SearchOptions {
 		// It is hard to think up general stats here based on limit. So
 		// instead we only run the ranking code path if the limit is
 		// reasonably small. This is fine while we experiment.
-		searchOpts.ShardMaxMatchCount = 1000
-		searchOpts.TotalMaxMatchCount = 10000
+		searchOpts.ShardMaxMatchCount = 1_000
+		searchOpts.TotalMaxMatchCount = 100_000
 		searchOpts.MaxDocDisplayCount = limit
 		searchOpts.FlushWallTime = 500 * time.Millisecond
+		searchOpts.UseDocumentRanks = true
 		return searchOpts
 	}
 


### PR DESCRIPTION
I am silly and forgot to enable page rank ranks! Additionally this tweaks how much work a zoekt can do before it flushes. I think we had a lot of poor results because in practice for a common search term we may only look in 10 repos. We now make that 100, which should still be fine w.r.t. memory use.

Test Plan: CI