### PR TITLE
graphqlbackend: use injected gitserver.Client

### DIFF
--- a/cmd/frontend/graphqlbackend/git_blob.go
+++ b/cmd/frontend/graphqlbackend/git_blob.go
@@ -13,7 +13,7 @@ func (r *GitTreeEntryResolver) Blame(ctx context.Context,
 		StartLine int32
 		EndLine   int32
 	}) ([]*hunkResolver, error) {
-	hunks, err := gitserver.NewClient(r.db).BlameFile(ctx, authz.DefaultSubRepoPermsChecker, r.commit.repoResolver.RepoName(), r.Path(), &gitserver.BlameOptions{
+	hunks, err := r.gitserverClient.BlameFile(ctx, authz.DefaultSubRepoPermsChecker, r.commit.repoResolver.RepoName(), r.Path(), &gitserver.BlameOptions{
 		NewestCommit: api.CommitID(r.commit.OID()),
 		StartLine:    int(args.StartLine),
 		EndLine:      int(args.EndLine),

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -283,7 +283,7 @@ func (r *GitCommitResolver) Languages(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
-	inventory, err := backend.NewRepos(r.logger, r.db, gitserver.NewClient(r.db)).GetInventory(ctx, repo, api.CommitID(r.oid), false)
+	inventory, err := backend.NewRepos(r.logger, r.db, r.gitserverClient).GetInventory(ctx, repo, api.CommitID(r.oid), false)
 	if err != nil {
 		return nil, err
 	}
@@ -301,7 +301,7 @@ func (r *GitCommitResolver) LanguageStatistics(ctx context.Context) ([]*language
 		return nil, err
 	}
 
-	inventory, err := backend.NewRepos(r.logger, r.db, gitserver.NewClient(r.db)).GetInventory(ctx, repo, api.CommitID(r.oid), false)
+	inventory, err := backend.NewRepos(r.logger, r.db, r.gitserverClient).GetInventory(ctx, repo, api.CommitID(r.oid), false)
 	if err != nil {
 		return nil, err
 	}
@@ -340,8 +340,7 @@ func (r *GitCommitResolver) Diff(ctx context.Context, args *struct {
 	if args.Base != nil {
 		base = *args.Base
 	}
-	client := gitserver.NewClient(r.db)
-	return NewRepositoryComparison(ctx, r.db, client, r.repoResolver, &RepositoryComparisonInput{
+	return NewRepositoryComparison(ctx, r.db, r.gitserverClient, r.repoResolver, &RepositoryComparisonInput{
 		Base:         &base,
 		Head:         &oidString,
 		FetchMissing: false,

--- a/cmd/frontend/graphqlbackend/git_commits.go
+++ b/cmd/frontend/graphqlbackend/git_commits.go
@@ -80,7 +80,7 @@ func (r *gitCommitConnectionResolver) Nodes(ctx context.Context) ([]*GitCommitRe
 
 	resolvers := make([]*GitCommitResolver, len(commits))
 	for i, commit := range commits {
-		resolvers[i] = NewGitCommitResolver(r.db, gitserver.NewClient(r.db), r.repo, commit.ID, commit)
+		resolvers[i] = NewGitCommitResolver(r.db, r.gitserverClient, r.repo, commit.ID, commit)
 	}
 
 	return resolvers, nil


### PR DESCRIPTION
We had a few call sites I found in graphqlbackend which still called NewClient when the struct itself already had a client in it. I checked the construction to ensure we always passed in, but in theory there is a risk of a panic in prod here. Low likelyhood though.

Test Plan: go test