### PR TITLE
graphqlbackend: create gitserver client outside of loop

### DIFF
--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -170,7 +170,7 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 			}
 		}
 
-		client := gitserver.NewClient(r.db)
+		reposClient := backend.NewRepos(r.logger, r.db, gitserver.NewClient(r.db))
 		for {
 			// Cursor-based pagination requires that we fetch limit+1 records, so
 			// that we know whether or not there's an additional page (or more)
@@ -179,7 +179,7 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 			if opt2.LimitOffset != nil {
 				opt2.LimitOffset.Limit++
 			}
-			repos, err := backend.NewRepos(r.logger, r.db, client).List(ctx, opt2)
+			repos, err := reposClient.List(ctx, opt2)
 			if err != nil {
 				r.err = err
 				return

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -170,6 +170,7 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 			}
 		}
 
+		client := gitserver.NewClient(r.db)
 		for {
 			// Cursor-based pagination requires that we fetch limit+1 records, so
 			// that we know whether or not there's an additional page (or more)
@@ -178,7 +179,7 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 			if opt2.LimitOffset != nil {
 				opt2.LimitOffset.Limit++
 			}
-			repos, err := backend.NewRepos(r.logger, r.db, gitserver.NewClient(r.db)).List(ctx, opt2)
+			repos, err := backend.NewRepos(r.logger, r.db, client).List(ctx, opt2)
 			if err != nil {
 				r.err = err
 				return
@@ -222,12 +223,13 @@ func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*Repository
 		return nil, err
 	}
 	resolvers := make([]*RepositoryResolver, 0, len(repos))
+	client := gitserver.NewClient(r.db)
 	for i, repo := range repos {
 		if r.opt.LimitOffset != nil && i == r.opt.Limit {
 			break
 		}
 
-		resolvers = append(resolvers, NewRepositoryResolver(r.db, gitserver.NewClient(r.db), repo))
+		resolvers = append(resolvers, NewRepositoryResolver(r.db, client, repo))
 	}
 	return resolvers, nil
 }

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -520,6 +520,7 @@ func (r *UserResolver) PublicRepositories(ctx context.Context) ([]*RepositoryRes
 	if err != nil {
 		return nil, err
 	}
+	gsClient := gitserver.NewClient(r.db)
 	var out []*RepositoryResolver
 	for _, repo := range repos {
 		out = append(out, &RepositoryResolver{
@@ -529,7 +530,7 @@ func (r *UserResolver) PublicRepositories(ctx context.Context) ([]*RepositoryRes
 				Name: api.RepoName(repo.RepoURI),
 			},
 			db:              r.db,
-			gitserverClient: gitserver.NewClient(r.db),
+			gitserverClient: gsClient,
 			innerRepo: &types.Repo{
 				ID: repo.RepoID,
 			},


### PR DESCRIPTION
Minor change which creates the client outside of the connection loop, such that each repository resolver doesn't get a new client. Ideally we should be injecting the client, but this is the smaller change for now.

Test Plan: go test