### PR TITLE
graphqlbackend: use gitserverClient on RepositoryResolver

### DIFF
--- a/cmd/frontend/graphqlbackend/git_revision.go
+++ b/cmd/frontend/graphqlbackend/git_revision.go
@@ -16,7 +16,7 @@ type gitRevSpecExpr struct {
 func (r *gitRevSpecExpr) Expr() string { return r.expr }
 
 func (r *gitRevSpecExpr) Object(ctx context.Context) (*gitObject, error) {
-	oid, err := gitserver.NewClient(r.repo.db).ResolveRevision(ctx, r.repo.RepoName(), r.expr, gitserver.ResolveRevisionOptions{})
+	oid, err := r.repo.gitserverClient.ResolveRevision(ctx, r.repo.RepoName(), r.expr, gitserver.ResolveRevisionOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/hunk.go
+++ b/cmd/frontend/graphqlbackend/hunk.go
@@ -49,7 +49,7 @@ func (r *hunkResolver) Message() string {
 }
 
 func (r *hunkResolver) Commit(ctx context.Context) (*GitCommitResolver, error) {
-	return NewGitCommitResolver(r.db, gitserver.NewClient(r.db), r.repo, r.hunk.CommitID, nil), nil
+	return NewGitCommitResolver(r.db, r.repo.gitserverClient, r.repo, r.hunk.CommitID, nil), nil
 }
 
 func (r *hunkResolver) Filename() string {

--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -43,7 +43,6 @@ type repositoryContributorConnectionResolver struct {
 
 func (r *repositoryContributorConnectionResolver) compute(ctx context.Context) ([]*gitdomain.ContributorCount, error) {
 	r.once.Do(func() {
-		client := gitserver.NewClient(r.db)
 		var opt gitserver.ContributorOptions
 		if r.args.RevisionRange != nil {
 			opt.Range = *r.args.RevisionRange
@@ -54,7 +53,7 @@ func (r *repositoryContributorConnectionResolver) compute(ctx context.Context) (
 		if r.args.AfterDate != nil {
 			opt.After = *r.args.AfterDate
 		}
-		r.results, r.err = client.ContributorCount(ctx, r.repo.RepoName(), opt)
+		r.results, r.err = r.repo.gitserverClient.ContributorCount(ctx, r.repo.RepoName(), opt)
 	})
 	return r.results, r.err
 }

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -125,7 +125,7 @@ func (r *repositoryMirrorInfoResolver) CloneInProgress(ctx context.Context) (boo
 }
 
 func (r *repositoryMirrorInfoResolver) CloneProgress(ctx context.Context) (*string, error) {
-	progress, err := gitserver.NewClient(r.db).RepoCloneProgress(ctx, r.repository.RepoName())
+	progress, err := r.repository.gitserverClient.RepoCloneProgress(ctx, r.repository.RepoName())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This uses the gitserver.Client that is already set on the stored RepositoryResolver. However, I am unsure about this change, seems a bit ugly. It feels like we should rather be storing the client directly on the resolver / on a struct that collects dependencies.

Test Plan: go test
