### PR TITLE
Doc update: Sourcegraph Cloud does not support SSH URLs

### DIFF
--- a/doc/admin/external_service/other.md
+++ b/doc/admin/external_service/other.md
@@ -11,6 +11,8 @@ To connect generic Git host to Sourcegraph:
 
 ## Constructing the `url` for SSH access
 
+>NOTE: Repository access over SSH is not yet supported on [Sourcegraph Cloud](../../cloud/index.md).
+
 If your code host serves git repositories over SSH (e.g. Gerrit), make sure your Sourcegraph instance can connect to your code host over SSH:
 
 ```

--- a/doc/admin/repo/auth.md
+++ b/doc/admin/repo/auth.md
@@ -10,6 +10,8 @@ Then, follow the directions below depending on your deployment type:
 - [Sourcegraph with Kubernetes](../deploy/kubernetes/index.md): See [Configure repository cloning via SSH](../deploy/kubernetes/configure.md#configure-repository-cloning-via-ssh).
 - [Single-container Sourcegraph](../deploy/docker-single-container/index.md): See [the single-container git configuration guide](../deploy/docker-single-container/index.md#git-configuration-and-authentication).
 
+>NOTE: Repository access over SSH is not yet supported on [Sourcegraph Cloud](../../cloud/index.md).
+
 ## Troubleshooting
 
 ### What should be included in my config file?

--- a/doc/dev/how-to/sync_repositories_from_gitolite_sgdev_org.md
+++ b/doc/dev/how-to/sync_repositories_from_gitolite_sgdev_org.md
@@ -1,5 +1,7 @@
 # Sync repositories from gitolite.sgdev.org
 
+>NOTE: SSH key configuration is not yet available on [Sourcegraph Cloud](../../cloud/index.md).
+
 1. Create `~/.ssh/gitolite_ssh_key` and paste in the [private key stored in 1Password](https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&v=dnrhbauihkhjs5ag6vszsme45a&i=i5bm6syw45w2c33cvfrrlt4fhu&h=team-sourcegraph.1password.com)
 1. Run `chmod 400 ~/.ssh/gitolite_ssh_key` to give it correct permissions
 1. Create `~/.ssh/gitolite_ssh_key.pub` and paste in the *public* key stored in same 1Password entry


### PR DESCRIPTION
Following [this discussion](https://sourcegraph.slack.com/archives/C03JR7S7KRP/p1666960490729939) in Slack, we thought it might be worth mentioning this in the docs for now.

## Test plan

Just a doc update

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
