### PR TITLE
Implement resolver layer for executor secrets

### DIFF
--- a/cmd/frontend/graphqlbackend/executor_secret.go
+++ b/cmd/frontend/graphqlbackend/executor_secret.go
@@ -1,0 +1,136 @@
+package graphqlbackend
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func marshalExecutorSecretID(scope ExecutorSecretScope, id int64) graphql.ID {
+	return relay.MarshalID("ExecutorSecret", fmt.Sprintf("%s:%d", scope, id))
+}
+
+func unmarshalExecutorSecretID(gqlID graphql.ID) (scope ExecutorSecretScope, id int64, err error) {
+	var str string
+	if err := relay.UnmarshalSpec(gqlID, &str); err != nil {
+		return "", 0, err
+	}
+	el := strings.Split(str, ":")
+	if len(el) != 2 {
+		return "", 0, errors.New("malformed ID")
+	}
+	intID, err := strconv.Atoi(el[1])
+	if err != nil {
+		return "", 0, errors.Wrap(err, "malformed id")
+	}
+	return ExecutorSecretScope(el[0]), int64(intID), nil
+}
+
+func executorSecretByID(ctx context.Context, db database.DB, gqlID graphql.ID) (*executorSecretResolver, error) {
+	scope, id, err := unmarshalExecutorSecretID(gqlID)
+	if err != nil {
+		return nil, err
+	}
+
+	secret, err := db.ExecutorSecrets(keyring.Default().ExecutorSecretKey).GetByID(ctx, scope.ToDatabaseScope(), id)
+	if err != nil {
+		if errcode.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	// Security: Only allow access to secrets if the user has access to the namespace.
+	if err := checkNamespaceAccess(ctx, db, secret.NamespaceUserID, secret.NamespaceOrgID); err != nil {
+		return nil, err
+	}
+
+	return &executorSecretResolver{db: db, secret: secret}, nil
+}
+
+type executorSecretResolver struct {
+	db     database.DB
+	secret *database.ExecutorSecret
+}
+
+func (r *executorSecretResolver) ID() graphql.ID {
+	return marshalExecutorSecretID(ExecutorSecretScope(strings.ToUpper(r.secret.Scope)), r.secret.ID)
+}
+
+func (r *executorSecretResolver) Key() string { return r.secret.Key }
+
+func (r *executorSecretResolver) Scope() string { return strings.ToUpper(r.secret.Scope) }
+
+func (r *executorSecretResolver) Namespace(ctx context.Context) (*NamespaceResolver, error) {
+	if r.secret.NamespaceUserID != 0 {
+		n, err := UserByIDInt32(ctx, r.db, r.secret.NamespaceUserID)
+		if err != nil {
+			return nil, err
+		}
+		return &NamespaceResolver{n}, nil
+	}
+
+	if r.secret.NamespaceOrgID != 0 {
+		n, err := OrgByIDInt32(ctx, r.db, r.secret.NamespaceOrgID)
+		if err != nil {
+			return nil, err
+		}
+		return &NamespaceResolver{n}, nil
+	}
+
+	return nil, nil
+}
+
+func (r *executorSecretResolver) Creator(ctx context.Context) (*UserResolver, error) {
+	// User has been deleted.
+	if r.secret.CreatorID == 0 {
+		return nil, nil
+	}
+
+	return UserByIDInt32(ctx, r.db, r.secret.CreatorID)
+}
+
+func (r *executorSecretResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.secret.CreatedAt}
+}
+
+func (r *executorSecretResolver) UpdatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.secret.UpdatedAt}
+}
+
+type ExecutorSecretAccessLogListArgs struct {
+	First int32
+	After *string
+}
+
+func (r *executorSecretResolver) AccessLogs(args ExecutorSecretAccessLogListArgs) (*executorSecretAccessLogConnectionResolver, error) {
+	// Namespace access is already enforced when the secret resolver is used,
+	// so access to the access logs is acceptable as well.
+	limit := &database.LimitOffset{Limit: int(args.First)}
+	if args.After != nil {
+		offset, err := graphqlutil.DecodeIntCursor(args.After)
+		if err != nil {
+			return nil, err
+		}
+		limit.Offset = offset
+	}
+
+	return &executorSecretAccessLogConnectionResolver{
+		opts: database.ExecutorSecretAccessLogsListOpts{
+			LimitOffset:      limit,
+			ExecutorSecretID: r.secret.ID,
+		},
+		db: r.db,
+	}, nil
+}

--- a/cmd/frontend/graphqlbackend/executor_secret.go
+++ b/cmd/frontend/graphqlbackend/executor_secret.go
@@ -51,7 +51,7 @@ func executorSecretByID(ctx context.Context, db database.DB, gqlID graphql.ID) (
 		return nil, err
 	}
 
-	// Security: Only allow access to secrets if the user has access to the namespace.
+	// 🚨 SECURITY: Only allow access to secrets if the user has access to the namespace.
 	if err := checkNamespaceAccess(ctx, db, secret.NamespaceUserID, secret.NamespaceOrgID); err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/executor_secret_access_log.go
+++ b/cmd/frontend/graphqlbackend/executor_secret_access_log.go
@@ -66,7 +66,7 @@ func (r *executorSecretAccessLogResolver) ID() graphql.ID {
 
 func (r *executorSecretAccessLogResolver) ExecutorSecret(ctx context.Context) (*executorSecretResolver, error) {
 	// TODO: Where to get the scope from..
-	return executorSecretByID(ctx, r.db, marshalExecutorSecretID(r.log.ExecutorSecretID))
+	return executorSecretByID(ctx, r.db, marshalExecutorSecretID(ExecutorSecretScopeBatches, r.log.ExecutorSecretID))
 }
 
 func (r *executorSecretAccessLogResolver) User(ctx context.Context) (*UserResolver, error) {

--- a/cmd/frontend/graphqlbackend/executor_secret_access_log.go
+++ b/cmd/frontend/graphqlbackend/executor_secret_access_log.go
@@ -1,0 +1,92 @@
+package graphqlbackend
+
+import (
+	"context"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func marshalExecutorSecretAccessLogID(id int64) graphql.ID {
+	return relay.MarshalID("ExecutorSecretAccessLog", id)
+}
+
+func unmarshalExecutorSecretAccessLogID(gqlID graphql.ID) (id int64, err error) {
+	err = relay.UnmarshalSpec(gqlID, &id)
+	return
+}
+
+func executorSecretAccessLogByID(ctx context.Context, db database.DB, gqlID graphql.ID) (*executorSecretAccessLogResolver, error) {
+	id, err := unmarshalExecutorSecretAccessLogID(gqlID)
+	if err != nil {
+		return nil, err
+	}
+
+	l, err := db.ExecutorSecretAccessLogs().GetByID(ctx, id)
+	if err != nil {
+		if errcode.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	// TODO: How to get scope.
+	secret, err := db.ExecutorSecrets(keyring.Default().ExecutorSecretKey).GetByID(ctx, database.ExecutorSecretScopeBatches, l.ExecutorSecretID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Security: Only allow access if the user has access to the namespace.
+	if err := checkNamespaceAccess(ctx, db, secret.NamespaceUserID, secret.NamespaceOrgID); err != nil {
+		return nil, err
+	}
+
+	return &executorSecretAccessLogResolver{db: db, log: l}, nil
+}
+
+type executorSecretAccessLogResolver struct {
+	db  database.DB
+	log *database.ExecutorSecretAccessLog
+
+	// If true, the user has been preloaded. It can still be null (if deleted),
+	// so this flag signifies that.
+	attemptPreloadedUser bool
+	preloadedUser        *types.User
+}
+
+func (r *executorSecretAccessLogResolver) ID() graphql.ID {
+	return marshalExecutorSecretAccessLogID(r.log.ID)
+}
+
+func (r *executorSecretAccessLogResolver) ExecutorSecret(ctx context.Context) (*executorSecretResolver, error) {
+	// TODO: Where to get the scope from..
+	return executorSecretByID(ctx, r.db, marshalExecutorSecretID(r.log.ExecutorSecretID))
+}
+
+func (r *executorSecretAccessLogResolver) User(ctx context.Context) (*UserResolver, error) {
+	if r.attemptPreloadedUser {
+		if r.preloadedUser == nil {
+			return nil, nil
+		}
+		return NewUserResolver(r.db, r.preloadedUser), nil
+	}
+
+	u, err := UserByIDInt32(ctx, r.db, r.log.UserID)
+	if err != nil {
+		if errcode.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return u, nil
+}
+
+func (r *executorSecretAccessLogResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.log.CreatedAt}
+}

--- a/cmd/frontend/graphqlbackend/executor_secret_access_log.go
+++ b/cmd/frontend/graphqlbackend/executor_secret_access_log.go
@@ -42,7 +42,7 @@ func executorSecretAccessLogByID(ctx context.Context, db database.DB, gqlID grap
 		return nil, err
 	}
 
-	// Security: Only allow access if the user has access to the namespace.
+	// 🚨 SECURITY: Only allow access if the user has access to the namespace.
 	if err := checkNamespaceAccess(ctx, db, secret.NamespaceUserID, secret.NamespaceOrgID); err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/executor_secret_access_logs_connection.go
+++ b/cmd/frontend/graphqlbackend/executor_secret_access_logs_connection.go
@@ -68,7 +68,10 @@ func (r *executorSecretAccessLogConnectionResolver) PageInfo(ctx context.Context
 func (r *executorSecretAccessLogConnectionResolver) compute(ctx context.Context) (_ []*database.ExecutorSecretAccessLog, _ []*types.User, next int, err error) {
 	r.computeOnce.Do(func() {
 		r.logs, r.next, r.err = r.db.ExecutorSecretAccessLogs().List(ctx, r.opts)
-		if r.err != nil && len(r.logs) > 0 {
+		if r.err != nil {
+			return
+		}
+		if len(r.logs) > 0 {
 			userIDMap := make(map[int32]struct{})
 			userIDs := []int32{}
 			for _, log := range r.logs {

--- a/cmd/frontend/graphqlbackend/executor_secret_access_logs_connection.go
+++ b/cmd/frontend/graphqlbackend/executor_secret_access_logs_connection.go
@@ -1,0 +1,84 @@
+package graphqlbackend
+
+import (
+	"context"
+	"sync"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+type executorSecretAccessLogConnectionResolver struct {
+	db   database.DB
+	opts database.ExecutorSecretAccessLogsListOpts
+
+	computeOnce sync.Once
+	logs        []*database.ExecutorSecretAccessLog
+	users       []*types.User
+	next        int
+	err         error
+}
+
+func (r *executorSecretAccessLogConnectionResolver) Nodes(ctx context.Context) ([]*executorSecretAccessLogResolver, error) {
+	logs, users, _, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	userMap := make(map[int32]*types.User)
+	for _, u := range users {
+		userMap[u.ID] = u
+	}
+
+	resolvers := make([]*executorSecretAccessLogResolver, 0, len(logs))
+	for _, log := range logs {
+		r := &executorSecretAccessLogResolver{
+			db:                   r.db,
+			log:                  log,
+			attemptPreloadedUser: true,
+		}
+		if user, ok := userMap[log.UserID]; ok {
+			r.preloadedUser = user
+		}
+		resolvers = append(resolvers, r)
+	}
+
+	return resolvers, nil
+}
+
+func (r *executorSecretAccessLogConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+	totalCount, err := r.db.ExecutorSecretAccessLogs().Count(ctx, r.opts)
+	return int32(totalCount), err
+}
+
+func (r *executorSecretAccessLogConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	_, _, next, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if next != 0 {
+		n := int32(next)
+		return graphqlutil.EncodeIntCursor(&n), nil
+	}
+	return graphqlutil.HasNextPage(false), nil
+}
+
+func (r *executorSecretAccessLogConnectionResolver) compute(ctx context.Context) (_ []*database.ExecutorSecretAccessLog, _ []*types.User, next int, err error) {
+	r.computeOnce.Do(func() {
+		r.logs, r.next, r.err = r.db.ExecutorSecretAccessLogs().List(ctx, r.opts)
+		if r.err != nil && len(r.logs) > 0 {
+			userIDMap := make(map[int32]struct{})
+			userIDs := []int32{}
+			for _, log := range r.logs {
+				if _, ok := userIDMap[log.UserID]; !ok {
+					userIDMap[log.UserID] = struct{}{}
+					userIDs = append(userIDs, log.UserID)
+				}
+			}
+			r.users, r.err = r.db.Users().List(ctx, &database.UsersListOptions{UserIDs: userIDs})
+		}
+	})
+	return r.logs, r.users, r.next, r.err
+}

--- a/cmd/frontend/graphqlbackend/executor_secret_connection.go
+++ b/cmd/frontend/graphqlbackend/executor_secret_connection.go
@@ -1,0 +1,63 @@
+package graphqlbackend
+
+import (
+	"context"
+	"sync"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
+)
+
+type executorSecretConnectionResolver struct {
+	db    database.DB
+	scope ExecutorSecretScope
+	opts  database.ExecutorSecretsListOpts
+
+	computeOnce sync.Once
+	secrets     []*database.ExecutorSecret
+	next        int
+	err         error
+}
+
+func (r *executorSecretConnectionResolver) Nodes(ctx context.Context) ([]*executorSecretResolver, error) {
+	secrets, _, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	resolvers := make([]*executorSecretResolver, 0, len(secrets))
+	for _, secret := range secrets {
+		resolvers = append(resolvers, &executorSecretResolver{db: r.db, secret: secret})
+	}
+
+	return resolvers, nil
+}
+
+func (r *executorSecretConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+	store := r.db.ExecutorSecrets(keyring.Default().ExecutorSecretKey)
+	totalCount, err := store.Count(ctx, r.scope.ToDatabaseScope(), r.opts)
+	return int32(totalCount), err
+}
+
+func (r *executorSecretConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	_, next, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if next != 0 {
+		n := int32(next)
+		return graphqlutil.EncodeIntCursor(&n), nil
+	}
+	return graphqlutil.HasNextPage(false), nil
+}
+
+func (r *executorSecretConnectionResolver) compute(ctx context.Context) ([]*database.ExecutorSecret, int, error) {
+	r.computeOnce.Do(func() {
+		store := r.db.ExecutorSecrets(keyring.Default().ExecutorSecretKey)
+
+		r.secrets, r.next, r.err = store.List(ctx, r.scope.ToDatabaseScope(), r.opts)
+	})
+	return r.secrets, r.next, r.err
+}

--- a/cmd/frontend/graphqlbackend/executor_secrets.go
+++ b/cmd/frontend/graphqlbackend/executor_secrets.go
@@ -1,0 +1,261 @@
+package graphqlbackend
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/graph-gophers/graphql-go"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var executorSecretKeyPattern = regexp.MustCompile("^[A-Z][A-Z|0-9|_]*$")
+
+type ExecutorSecretScope string
+
+const (
+	ExecutorSecretScopeBatches ExecutorSecretScope = "BATCHES"
+)
+
+func (s ExecutorSecretScope) ToDatabaseScope() database.ExecutorSecretScope {
+	return database.ExecutorSecretScope(strings.ToLower(string(s)))
+}
+
+type CreateExecutorSecretArgs struct {
+	Key       string
+	Value     string
+	Scope     ExecutorSecretScope
+	Namespace *graphql.ID
+}
+
+func (r *schemaResolver) CreateExecutorSecret(ctx context.Context, args CreateExecutorSecretArgs) (*executorSecretResolver, error) {
+	var userID, orgID int32
+	if args.Namespace != nil {
+		if err := UnmarshalNamespaceID(*args.Namespace, &userID, &orgID); err != nil {
+			return nil, err
+		}
+	}
+
+	a := actor.FromContext(ctx)
+	if !a.IsAuthenticated() {
+		return nil, auth.ErrNotAuthenticated
+	}
+
+	// Security: Check namespace access.
+	if err := checkNamespaceAccess(ctx, r.db, userID, orgID); err != nil {
+		return nil, err
+	}
+
+	store := r.db.ExecutorSecrets(keyring.Default().ExecutorSecretKey)
+
+	if len(args.Key) == 0 {
+		return nil, errors.New("key cannot be empty string")
+	}
+
+	if !executorSecretKeyPattern.Match([]byte(args.Key)) {
+		return nil, errors.New("invalid key format, should be a valid env var name")
+	}
+
+	secret := &database.ExecutorSecret{
+		Key:             args.Key,
+		CreatorID:       a.UID,
+		NamespaceUserID: userID,
+		NamespaceOrgID:  orgID,
+	}
+	if err := store.Create(ctx, args.Scope.ToDatabaseScope(), secret, args.Value); err != nil {
+		return nil, err
+	}
+
+	return &executorSecretResolver{db: r.db, secret: secret}, nil
+}
+
+type UpdateExecutorSecretArgs struct {
+	ID    graphql.ID
+	Scope ExecutorSecretScope
+	Value string
+}
+
+func (r *schemaResolver) UpdateExecutorSecret(ctx context.Context, args UpdateExecutorSecretArgs) (_ *executorSecretResolver, err error) {
+	scope, id, err := unmarshalExecutorSecretID(args.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	a := actor.FromContext(ctx)
+	if !a.IsAuthenticated() {
+		return nil, auth.ErrNotAuthenticated
+	}
+
+	if scope != args.Scope {
+		return nil, errors.New("scope mismatch")
+	}
+
+	store := r.db.ExecutorSecrets(keyring.Default().ExecutorSecretKey)
+
+	tx, err := store.Transact(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	secret, err := tx.GetByID(ctx, args.Scope.ToDatabaseScope(), id)
+	if err != nil {
+		return nil, err
+	}
+
+	// Security: Check namespace access.
+	if err := checkNamespaceAccess(ctx, r.db, secret.NamespaceUserID, secret.NamespaceOrgID); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Update(ctx, args.Scope.ToDatabaseScope(), secret, args.Value); err != nil {
+		return nil, err
+	}
+
+	return &executorSecretResolver{db: r.db, secret: secret}, nil
+}
+
+type DeleteExecutorSecretArgs struct {
+	ID    graphql.ID
+	Scope ExecutorSecretScope
+}
+
+func (r *schemaResolver) DeleteExecutorSecret(ctx context.Context, args DeleteExecutorSecretArgs) (_ *EmptyResponse, err error) {
+	scope, id, err := unmarshalExecutorSecretID(args.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	a := actor.FromContext(ctx)
+	if !a.IsAuthenticated() {
+		return nil, auth.ErrNotAuthenticated
+	}
+
+	if scope != args.Scope {
+		return nil, errors.New("scope mismatch")
+	}
+
+	store := r.db.ExecutorSecrets(keyring.Default().ExecutorSecretKey)
+
+	tx, err := store.Transact(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	secret, err := tx.GetByID(ctx, args.Scope.ToDatabaseScope(), id)
+	if err != nil {
+		return nil, err
+	}
+
+	// Security: Check namespace access.
+	if err := checkNamespaceAccess(ctx, r.db, secret.NamespaceUserID, secret.NamespaceOrgID); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Delete(ctx, args.Scope.ToDatabaseScope(), id); err != nil {
+		return nil, err
+	}
+
+	return &EmptyResponse{}, nil
+}
+
+type ExecutorSecretsListArgs struct {
+	Scope ExecutorSecretScope
+	First int32
+	After *string
+}
+
+func (o ExecutorSecretsListArgs) LimitOffset() (*database.LimitOffset, error) {
+	limit := &database.LimitOffset{Limit: int(o.First)}
+	if o.After != nil {
+		offset, err := graphqlutil.DecodeIntCursor(o.After)
+		if err != nil {
+			return nil, err
+		}
+		limit.Offset = offset
+	}
+	return limit, nil
+}
+
+// ExecutorSecrets returns the global executor secrets.
+func (r *schemaResolver) ExecutorSecrets(ctx context.Context, args ExecutorSecretsListArgs) (*executorSecretConnectionResolver, error) {
+	// Security: Only allow access to list global secrets if the user is admin.
+	if err := checkNamespaceAccess(ctx, r.db, 0, 0); err != nil {
+		return nil, err
+	}
+
+	limit, err := args.LimitOffset()
+	if err != nil {
+		return nil, err
+	}
+	return &executorSecretConnectionResolver{
+		db:    r.db,
+		scope: args.Scope,
+		opts: database.ExecutorSecretsListOpts{
+			LimitOffset:     limit,
+			NamespaceUserID: 0,
+			NamespaceOrgID:  0,
+		},
+	}, nil
+}
+
+func (r *UserResolver) ExecutorSecrets(ctx context.Context, args ExecutorSecretsListArgs) (*executorSecretConnectionResolver, error) {
+	// Security: Only allow access to list secrets if the user has access to the namespace.
+	if err := checkNamespaceAccess(ctx, r.db, r.user.ID, 0); err != nil {
+		return nil, err
+	}
+
+	limit, err := args.LimitOffset()
+	if err != nil {
+		return nil, err
+	}
+	return &executorSecretConnectionResolver{
+		db:    r.db,
+		scope: args.Scope,
+		opts: database.ExecutorSecretsListOpts{
+			LimitOffset:     limit,
+			NamespaceUserID: r.user.ID,
+			NamespaceOrgID:  0,
+		},
+	}, nil
+}
+
+func (r *OrgResolver) ExecutorSecrets(ctx context.Context, args ExecutorSecretsListArgs) (*executorSecretConnectionResolver, error) {
+	// Security: Only allow access to list secrets if the user has access to the namespace.
+	if err := checkNamespaceAccess(ctx, r.db, 0, r.org.ID); err != nil {
+		return nil, err
+	}
+
+	limit, err := args.LimitOffset()
+	if err != nil {
+		return nil, err
+	}
+
+	return &executorSecretConnectionResolver{
+		db:    r.db,
+		scope: args.Scope,
+		opts: database.ExecutorSecretsListOpts{
+			LimitOffset:     limit,
+			NamespaceUserID: 0,
+			NamespaceOrgID:  r.org.ID,
+		},
+	}, nil
+}
+
+func checkNamespaceAccess(ctx context.Context, db database.DB, namespaceUserID, namespaceOrgID int32) error {
+	if namespaceUserID != 0 {
+		return auth.CheckSiteAdminOrSameUser(ctx, db, namespaceUserID)
+	}
+	if namespaceOrgID != 0 {
+		return auth.CheckOrgAccessOrSiteAdmin(ctx, db, namespaceOrgID)
+	}
+
+	return auth.CheckCurrentUserIsSiteAdmin(ctx, db)
+}

--- a/cmd/frontend/graphqlbackend/executor_secrets.go
+++ b/cmd/frontend/graphqlbackend/executor_secrets.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var executorSecretKeyPattern = regexp.MustCompile("^[A-Z][A-Z|0-9|_]*$")
+var executorSecretKeyPattern = regexp.MustCompile("^[A-Z][A-Z0-9_]*$")
 
 type ExecutorSecretScope string
 
@@ -47,7 +47,7 @@ func (r *schemaResolver) CreateExecutorSecret(ctx context.Context, args CreateEx
 		return nil, auth.ErrNotAuthenticated
 	}
 
-	// Security: Check namespace access.
+	// 🚨 SECURITY: Check namespace access.
 	if err := checkNamespaceAccess(ctx, r.db, userID, orgID); err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func (r *schemaResolver) UpdateExecutorSecret(ctx context.Context, args UpdateEx
 		return nil, err
 	}
 
-	// Security: Check namespace access.
+	// 🚨 SECURITY: Check namespace access.
 	if err := checkNamespaceAccess(ctx, r.db, secret.NamespaceUserID, secret.NamespaceOrgID); err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (r *schemaResolver) DeleteExecutorSecret(ctx context.Context, args DeleteEx
 		return nil, err
 	}
 
-	// Security: Check namespace access.
+	// 🚨 SECURITY: Check namespace access.
 	if err := checkNamespaceAccess(ctx, r.db, secret.NamespaceUserID, secret.NamespaceOrgID); err != nil {
 		return nil, err
 	}
@@ -194,7 +194,7 @@ func (o ExecutorSecretsListArgs) LimitOffset() (*database.LimitOffset, error) {
 
 // ExecutorSecrets returns the global executor secrets.
 func (r *schemaResolver) ExecutorSecrets(ctx context.Context, args ExecutorSecretsListArgs) (*executorSecretConnectionResolver, error) {
-	// Security: Only allow access to list global secrets if the user is admin.
+	// 🚨 SECURITY: Only allow access to list global secrets if the user is admin.
 	// This is not terribly bad, since the secrets are also part of the user's namespace
 	// secrets, but this endpoint is useless to non-admins.
 	if err := checkNamespaceAccess(ctx, r.db, 0, 0); err != nil {
@@ -218,7 +218,7 @@ func (r *schemaResolver) ExecutorSecrets(ctx context.Context, args ExecutorSecre
 }
 
 func (r *UserResolver) ExecutorSecrets(ctx context.Context, args ExecutorSecretsListArgs) (*executorSecretConnectionResolver, error) {
-	// Security: Only allow access to list secrets if the user has access to the namespace.
+	// 🚨 SECURITY: Only allow access to list secrets if the user has access to the namespace.
 	if err := checkNamespaceAccess(ctx, r.db, r.user.ID, 0); err != nil {
 		return nil, err
 	}
@@ -239,7 +239,7 @@ func (r *UserResolver) ExecutorSecrets(ctx context.Context, args ExecutorSecrets
 }
 
 func (r *OrgResolver) ExecutorSecrets(ctx context.Context, args ExecutorSecretsListArgs) (*executorSecretConnectionResolver, error) {
-	// Security: Only allow access to list secrets if the user has access to the namespace.
+	// 🚨 SECURITY: Only allow access to list secrets if the user has access to the namespace.
 	if err := checkNamespaceAccess(ctx, r.db, 0, r.org.ID); err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/executor_secrets_test.go
+++ b/cmd/frontend/graphqlbackend/executor_secrets_test.go
@@ -2,9 +2,13 @@ package graphqlbackend
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/log/logtest"
 
@@ -499,4 +503,265 @@ func TestOrgResolver_ExecutorSecrets(t *testing.T) {
 	if tc != 2 {
 		t.Fatalf("invalid totalcount returned: %d", len(nodes))
 	}
+}
+
+func TestExecutorSecretsIntegration(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := context.Background()
+
+	user, err := db.Users().Create(ctx, database.NewUser{Username: "test-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Users().SetIsSiteAdmin(ctx, user.ID, true); err != nil {
+		t.Fatal(err)
+	}
+
+	org, err := db.Orgs().Create(ctx, "super-org", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.OrgMembers().Create(ctx, org.ID, user.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	userCtx := actor.WithActor(ctx, actor.FromUser(user.ID))
+
+	secret1 := &database.ExecutorSecret{
+		Key:       "ASDF",
+		Scope:     database.ExecutorSecretScopeBatches,
+		CreatorID: user.ID,
+	}
+	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(userCtx, database.ExecutorSecretScopeBatches, secret1, "1234"); err != nil {
+		t.Fatal(err)
+	}
+	secret2 := &database.ExecutorSecret{
+		Key:             "ASDF",
+		Scope:           database.ExecutorSecretScopeBatches,
+		CreatorID:       user.ID,
+		NamespaceUserID: user.ID,
+	}
+	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(userCtx, database.ExecutorSecretScopeBatches, secret2, "1234"); err != nil {
+		t.Fatal(err)
+	}
+	secret3 := &database.ExecutorSecret{
+		Key:             "FOOBAR",
+		Scope:           database.ExecutorSecretScopeBatches,
+		NamespaceUserID: user.ID,
+	}
+	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(userCtx, database.ExecutorSecretScopeBatches, secret3, "1234"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read secret2 twice.
+	for i := 0; i < 2; i++ {
+		_, err := secret2.Value(userCtx, db.ExecutorSecretAccessLogs())
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	als, _, err := db.ExecutorSecretAccessLogs().List(ctx, database.ExecutorSecretAccessLogsListOpts{ExecutorSecretID: secret2.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(als) != 2 {
+		t.Fatal("invalid number of access logs found in DB")
+	}
+
+	s, err := NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := s.Exec(userCtx, fmt.Sprintf(`
+query ExecutorSecretsIntegrationTest {
+	node(id: %q) {
+		__typename
+		... on User {
+			executorSecrets(scope: BATCHES, first: 10) {
+				totalCount
+				pageInfo { hasNextPage endCursor }
+				nodes {
+					id
+					key
+					scope
+					namespace {
+						id
+					}
+					creator {
+						id
+					}
+					createdAt
+					updatedAt
+					accessLogs(first: 2) {
+						totalCount
+						pageInfo { hasNextPage endCursor }
+						nodes {
+							id
+							executorSecret {
+								id
+							}
+							user {
+								id
+							}
+							createdAt
+						}
+					}
+				}
+			}
+		}
+	}
+}
+	`, MarshalUserID(user.ID)), "ExecutorSecretsIntegrationTest", nil)
+	if len(resp.Errors) > 0 {
+		t.Fatal(resp.Errors)
+	}
+	data := &executorSecretsIntegrationTestResponse{}
+	if err := json.Unmarshal(resp.Data, data); err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(data, &executorSecretsIntegrationTestResponse{
+		Node: executorSecretsIntegrationTestResponseNode{
+			Typename: "User",
+			ExecutorSecrets: executorSecretsIntegrationTestResponseExecutorSecrets{
+				TotalCount: 2,
+				PageInfo: executorSecretsIntegrationTestResponsePageInfo{
+					HasNextPage: false,
+					EndCursor:   "",
+				},
+				Nodes: []executorSecretsIntegrationTestResponseSecretNode{
+					{
+						ID:    marshalExecutorSecretID(ExecutorSecretScope(strings.ToUpper(secret2.Scope)), secret2.ID),
+						Key:   "ASDF",
+						Scope: string(ExecutorSecretScopeBatches),
+						Namespace: executorSecretsIntegrationTestResponseNamespace{
+							ID: MarshalUserID(user.ID),
+						},
+						Creator: executorSecretsIntegrationTestResponseCreator{
+							ID: MarshalUserID(user.ID),
+						},
+						CreatedAt: secret2.CreatedAt.Format(time.RFC3339),
+						UpdatedAt: secret2.UpdatedAt.Format(time.RFC3339),
+						AccessLogs: executorSecretsIntegrationTestResponseAccessLogs{
+							TotalCount: 2,
+							PageInfo: executorSecretsIntegrationTestResponsePageInfo{
+								HasNextPage: false,
+								EndCursor:   "",
+							},
+							Nodes: []executorSecretsIntegrationTestResponseAccessLogNode{
+								{
+									ID: marshalExecutorSecretAccessLogID(als[0].ID),
+									ExecutorSecret: executorSecretsIntegrationTestResponseAccessLogExecutorSecret{
+										ID: marshalExecutorSecretID(ExecutorSecretScope(strings.ToUpper(secret2.Scope)), secret2.ID),
+									},
+									User: executorSecretsIntegrationTestResponseAccessLogUser{
+										ID: MarshalUserID(user.ID),
+									},
+									CreatedAt: als[0].CreatedAt.Format(time.RFC3339),
+								},
+								{
+									ID: marshalExecutorSecretAccessLogID(als[1].ID),
+									ExecutorSecret: executorSecretsIntegrationTestResponseAccessLogExecutorSecret{
+										ID: marshalExecutorSecretID(ExecutorSecretScope(strings.ToUpper(secret2.Scope)), secret2.ID),
+									},
+									User: executorSecretsIntegrationTestResponseAccessLogUser{
+										ID: MarshalUserID(user.ID),
+									},
+									CreatedAt: als[1].CreatedAt.Format(time.RFC3339),
+								},
+							},
+						},
+					},
+					{
+						ID:    marshalExecutorSecretID(ExecutorSecretScope(strings.ToUpper(secret3.Scope)), secret3.ID),
+						Key:   "FOOBAR",
+						Scope: string(ExecutorSecretScopeBatches),
+						Namespace: executorSecretsIntegrationTestResponseNamespace{
+							ID: MarshalUserID(user.ID),
+						},
+						Creator: executorSecretsIntegrationTestResponseCreator{
+							ID: MarshalUserID(user.ID),
+						},
+						CreatedAt: secret3.CreatedAt.Format(time.RFC3339),
+						UpdatedAt: secret3.UpdatedAt.Format(time.RFC3339),
+						AccessLogs: executorSecretsIntegrationTestResponseAccessLogs{
+							TotalCount: 0,
+							PageInfo: executorSecretsIntegrationTestResponsePageInfo{
+								HasNextPage: false,
+								EndCursor:   "",
+							},
+							Nodes: []executorSecretsIntegrationTestResponseAccessLogNode{},
+						},
+					},
+				},
+			},
+		},
+	}); diff != "" {
+		t.Fatalf("invalid response: %s", diff)
+	}
+}
+
+type executorSecretsIntegrationTestResponse struct {
+	Node executorSecretsIntegrationTestResponseNode `json:"node"`
+}
+
+type executorSecretsIntegrationTestResponseNode struct {
+	Typename        string                                                `json:"__typename"`
+	ExecutorSecrets executorSecretsIntegrationTestResponseExecutorSecrets `json:"executorSecrets"`
+}
+
+type executorSecretsIntegrationTestResponseExecutorSecrets struct {
+	TotalCount int32                                              `json:"totalCount"`
+	PageInfo   executorSecretsIntegrationTestResponsePageInfo     `json:"pageInfo"`
+	Nodes      []executorSecretsIntegrationTestResponseSecretNode `json:"nodes"`
+}
+
+type executorSecretsIntegrationTestResponsePageInfo struct {
+	HasNextPage bool   `json:"hasNextPage"`
+	EndCursor   string `json:"endCursor"`
+}
+
+type executorSecretsIntegrationTestResponseSecretNode struct {
+	ID         graphql.ID                                       `json:"id"`
+	Key        string                                           `json:"key"`
+	Scope      string                                           `json:"scope"`
+	Namespace  executorSecretsIntegrationTestResponseNamespace  `json:"namespace"`
+	Creator    executorSecretsIntegrationTestResponseCreator    `json:"creator"`
+	CreatedAt  string                                           `json:"createdAt"`
+	UpdatedAt  string                                           `json:"updatedAt"`
+	AccessLogs executorSecretsIntegrationTestResponseAccessLogs `json:"accessLogs"`
+}
+
+type executorSecretsIntegrationTestResponseNamespace struct {
+	ID graphql.ID `json:"id"`
+}
+
+type executorSecretsIntegrationTestResponseCreator struct {
+	ID graphql.ID `json:"id"`
+}
+
+type executorSecretsIntegrationTestResponseAccessLogs struct {
+	TotalCount int32                                                 `json:"totalCount"`
+	PageInfo   executorSecretsIntegrationTestResponsePageInfo        `json:"pageInfo"`
+	Nodes      []executorSecretsIntegrationTestResponseAccessLogNode `json:"nodes"`
+}
+
+type executorSecretsIntegrationTestResponseAccessLogNode struct {
+	ID             graphql.ID                                                    `json:"id"`
+	ExecutorSecret executorSecretsIntegrationTestResponseAccessLogExecutorSecret `json:"executorSecret"`
+	User           executorSecretsIntegrationTestResponseAccessLogUser           `json:"user"`
+	CreatedAt      string                                                        `json:"createdAt"`
+}
+
+type executorSecretsIntegrationTestResponseAccessLogExecutorSecret struct {
+	ID graphql.ID `json:"id"`
+}
+
+type executorSecretsIntegrationTestResponseAccessLogUser struct {
+	ID graphql.ID `json:"id"`
 }

--- a/cmd/frontend/graphqlbackend/executor_secrets_test.go
+++ b/cmd/frontend/graphqlbackend/executor_secrets_test.go
@@ -472,6 +472,7 @@ func TestOrgResolver_ExecutorSecrets(t *testing.T) {
 	secret3 := &database.ExecutorSecret{
 		Key:            "FOOBAR",
 		Scope:          database.ExecutorSecretScopeBatches,
+		CreatorID:      user.ID,
 		NamespaceOrgID: user.ID,
 	}
 	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(internalCtx, database.ExecutorSecretScopeBatches, secret3, "1234"); err != nil {

--- a/cmd/frontend/graphqlbackend/executor_secrets_test.go
+++ b/cmd/frontend/graphqlbackend/executor_secrets_test.go
@@ -1,0 +1,502 @@
+package graphqlbackend
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/sourcegraph/log/logtest"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func TestSchemaResolver_CreateExecutorSecret(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	r := &schemaResolver{logger: logger, db: db}
+	ctx := context.Background()
+
+	user, err := db.Users().Create(ctx, database.NewUser{Username: "test-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Users().SetIsSiteAdmin(ctx, user.ID, true); err != nil {
+		t.Fatal(err)
+	}
+
+	gqlIDPtr := func(id graphql.ID) *graphql.ID { return &id }
+
+	tts := []struct {
+		name    string
+		args    CreateExecutorSecretArgs
+		actor   *actor.Actor
+		wantErr error
+	}{
+		{
+			name: "Empty key",
+			args: CreateExecutorSecretArgs{
+				// Empty key
+				Key:   "",
+				Scope: ExecutorSecretScopeBatches,
+			},
+			actor:   actor.FromUser(user.ID),
+			wantErr: errors.New("key cannot be empty string"),
+		},
+		{
+			name: "Invalid key",
+			args: CreateExecutorSecretArgs{
+				Key:   "1GitH-UbT0ken",
+				Scope: ExecutorSecretScopeBatches,
+			},
+			actor:   actor.FromUser(user.ID),
+			wantErr: errors.New("invalid key format, should be a valid env var name"),
+		},
+		{
+			name: "Empty value",
+			args: CreateExecutorSecretArgs{
+				Key: "GITHUB_TOKEN",
+				// Empty value
+				Value: "",
+				Scope: ExecutorSecretScopeBatches,
+			},
+			actor:   actor.FromUser(user.ID),
+			wantErr: errors.New("value cannot be empty string"),
+		},
+		{
+			name: "Create global secret",
+			args: CreateExecutorSecretArgs{
+				Key:   "GITHUB_TOKEN",
+				Value: "1234",
+				Scope: ExecutorSecretScopeBatches,
+			},
+			actor: actor.FromUser(user.ID),
+		},
+		{
+			name: "Create user secret",
+			args: CreateExecutorSecretArgs{
+				Key:       "GITHUB_TOKEN",
+				Value:     "1234",
+				Scope:     ExecutorSecretScopeBatches,
+				Namespace: gqlIDPtr(MarshalUserID(user.ID)),
+			},
+			actor: actor.FromUser(user.ID),
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.actor != nil {
+				ctx = actor.WithActor(ctx, tt.actor)
+			}
+			_, err := r.CreateExecutorSecret(ctx, tt.args)
+			if (err != nil) != (tt.wantErr != nil) {
+				t.Fatalf("invalid error returned: have=%v want=%v", err, tt.wantErr)
+			}
+			if err != nil {
+				if have, want := err.Error(), tt.wantErr.Error(); have != want {
+					t.Fatalf("invalid error returned: have=%v want=%v", have, want)
+				}
+			}
+		})
+	}
+}
+
+func TestSchemaResolver_UpdateExecutorSecret(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	r := &schemaResolver{logger: logger, db: db}
+	ctx := context.Background()
+	internalCtx := actor.WithInternalActor(ctx)
+
+	user, err := db.Users().Create(ctx, database.NewUser{Username: "test-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Users().SetIsSiteAdmin(ctx, user.ID, true); err != nil {
+		t.Fatal(err)
+	}
+
+	globalSecret := &database.ExecutorSecret{
+		Key:       "ASDF",
+		Scope:     database.ExecutorSecretScopeBatches,
+		CreatorID: user.ID,
+	}
+	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(internalCtx, database.ExecutorSecretScopeBatches, globalSecret, "1234"); err != nil {
+		t.Fatal(err)
+	}
+
+	userSecret := &database.ExecutorSecret{
+		Key:             "ASDF",
+		Scope:           database.ExecutorSecretScopeBatches,
+		CreatorID:       user.ID,
+		NamespaceUserID: user.ID,
+	}
+	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(internalCtx, database.ExecutorSecretScopeBatches, userSecret, "1234"); err != nil {
+		t.Fatal(err)
+	}
+
+	tts := []struct {
+		name    string
+		args    UpdateExecutorSecretArgs
+		actor   *actor.Actor
+		wantErr error
+	}{
+		{
+			name: "Empty value",
+			args: UpdateExecutorSecretArgs{
+				ID: marshalExecutorSecretID(ExecutorSecretScope(strings.ToUpper(globalSecret.Scope)), globalSecret.ID),
+				// Empty value
+				Value: "",
+				Scope: ExecutorSecretScopeBatches,
+			},
+			actor:   actor.FromUser(user.ID),
+			wantErr: errors.New("value cannot be empty string"),
+		},
+		{
+			name: "Update global secret",
+			args: UpdateExecutorSecretArgs{
+				ID:    marshalExecutorSecretID(ExecutorSecretScope(strings.ToUpper(globalSecret.Scope)), globalSecret.ID),
+				Value: "1234",
+				Scope: ExecutorSecretScopeBatches,
+			},
+			actor: actor.FromUser(user.ID),
+		},
+		{
+			name: "Update user secret",
+			args: UpdateExecutorSecretArgs{
+				ID:    marshalExecutorSecretID(ExecutorSecretScope(strings.ToUpper(userSecret.Scope)), userSecret.ID),
+				Value: "1234",
+				Scope: ExecutorSecretScopeBatches,
+			},
+			actor: actor.FromUser(user.ID),
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.actor != nil {
+				ctx = actor.WithActor(ctx, tt.actor)
+			}
+			_, err := r.UpdateExecutorSecret(ctx, tt.args)
+			if (err != nil) != (tt.wantErr != nil) {
+				t.Fatalf("invalid error returned: have=%v want=%v", err, tt.wantErr)
+			}
+			if err != nil {
+				if have, want := err.Error(), tt.wantErr.Error(); have != want {
+					t.Fatalf("invalid error returned: have=%v want=%v", have, want)
+				}
+			}
+		})
+	}
+}
+
+func TestSchemaResolver_DeleteExecutorSecret(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	r := &schemaResolver{logger: logger, db: db}
+	ctx := context.Background()
+	internalCtx := actor.WithInternalActor(ctx)
+
+	user, err := db.Users().Create(ctx, database.NewUser{Username: "test-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Users().SetIsSiteAdmin(ctx, user.ID, true); err != nil {
+		t.Fatal(err)
+	}
+
+	globalSecret := &database.ExecutorSecret{
+		Key:       "ASDF",
+		Scope:     database.ExecutorSecretScopeBatches,
+		CreatorID: user.ID,
+	}
+	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(internalCtx, database.ExecutorSecretScopeBatches, globalSecret, "1234"); err != nil {
+		t.Fatal(err)
+	}
+
+	userSecret := &database.ExecutorSecret{
+		Key:             "ASDF",
+		Scope:           database.ExecutorSecretScopeBatches,
+		CreatorID:       user.ID,
+		NamespaceUserID: user.ID,
+	}
+	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(internalCtx, database.ExecutorSecretScopeBatches, userSecret, "1234"); err != nil {
+		t.Fatal(err)
+	}
+
+	tts := []struct {
+		name    string
+		args    DeleteExecutorSecretArgs
+		actor   *actor.Actor
+		wantErr error
+	}{
+		{
+			name: "Delete global secret",
+			args: DeleteExecutorSecretArgs{
+				ID:    marshalExecutorSecretID(ExecutorSecretScope(strings.ToUpper(globalSecret.Scope)), globalSecret.ID),
+				Scope: ExecutorSecretScopeBatches,
+			},
+			actor: actor.FromUser(user.ID),
+		},
+		{
+			name: "Delete user secret",
+			args: DeleteExecutorSecretArgs{
+				ID:    marshalExecutorSecretID(ExecutorSecretScope(strings.ToUpper(userSecret.Scope)), userSecret.ID),
+				Scope: ExecutorSecretScopeBatches,
+			},
+			actor: actor.FromUser(user.ID),
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.actor != nil {
+				ctx = actor.WithActor(ctx, tt.actor)
+			}
+			_, err := r.DeleteExecutorSecret(ctx, tt.args)
+			if (err != nil) != (tt.wantErr != nil) {
+				t.Fatalf("invalid error returned: have=%v want=%v", err, tt.wantErr)
+			}
+			if err != nil {
+				if have, want := err.Error(), tt.wantErr.Error(); have != want {
+					t.Fatalf("invalid error returned: have=%v want=%v", have, want)
+				}
+			}
+		})
+	}
+}
+
+func TestSchemaResolver_ExecutorSecrets(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	r := &schemaResolver{logger: logger, db: db}
+	ctx := context.Background()
+	internalCtx := actor.WithInternalActor(ctx)
+
+	user, err := db.Users().Create(ctx, database.NewUser{Username: "test-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Users().SetIsSiteAdmin(ctx, user.ID, true); err != nil {
+		t.Fatal(err)
+	}
+
+	userCtx := actor.WithActor(ctx, actor.FromUser(user.ID))
+
+	secret1 := &database.ExecutorSecret{
+		Key:       "ASDF",
+		Scope:     database.ExecutorSecretScopeBatches,
+		CreatorID: user.ID,
+	}
+	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(internalCtx, database.ExecutorSecretScopeBatches, secret1, "1234"); err != nil {
+		t.Fatal(err)
+	}
+	secret2 := &database.ExecutorSecret{
+		Key:             "ASDF",
+		Scope:           database.ExecutorSecretScopeBatches,
+		CreatorID:       user.ID,
+		NamespaceUserID: user.ID,
+	}
+	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(internalCtx, database.ExecutorSecretScopeBatches, secret2, "1234"); err != nil {
+		t.Fatal(err)
+	}
+	secret3 := &database.ExecutorSecret{
+		Key:       "FOOBAR",
+		Scope:     database.ExecutorSecretScopeBatches,
+		CreatorID: user.ID,
+	}
+	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(internalCtx, database.ExecutorSecretScopeBatches, secret3, "1234"); err != nil {
+		t.Fatal(err)
+	}
+
+	ls, err := r.ExecutorSecrets(userCtx, ExecutorSecretsListArgs{
+		Scope: ExecutorSecretScopeBatches,
+		First: 50,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nodes, err := ls.Nodes(userCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Expect only global secrets to be returned.
+	if len(nodes) != 2 {
+		t.Fatalf("invalid count of nodes returned: %d", len(nodes))
+	}
+
+	tc, err := ls.TotalCount(userCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tc != 2 {
+		t.Fatalf("invalid totalcount returned: %d", len(nodes))
+	}
+}
+
+func TestUserResolver_ExecutorSecrets(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := context.Background()
+	internalCtx := actor.WithInternalActor(ctx)
+
+	user, err := db.Users().Create(ctx, database.NewUser{Username: "test-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Users().SetIsSiteAdmin(ctx, user.ID, true); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := UserByIDInt32(ctx, db, user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	userCtx := actor.WithActor(ctx, actor.FromUser(user.ID))
+
+	secret1 := &database.ExecutorSecret{
+		Key:       "ASDF",
+		Scope:     database.ExecutorSecretScopeBatches,
+		CreatorID: user.ID,
+	}
+	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(internalCtx, database.ExecutorSecretScopeBatches, secret1, "1234"); err != nil {
+		t.Fatal(err)
+	}
+	secret2 := &database.ExecutorSecret{
+		Key:             "ASDF",
+		Scope:           database.ExecutorSecretScopeBatches,
+		CreatorID:       user.ID,
+		NamespaceUserID: user.ID,
+	}
+	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(internalCtx, database.ExecutorSecretScopeBatches, secret2, "1234"); err != nil {
+		t.Fatal(err)
+	}
+	secret3 := &database.ExecutorSecret{
+		Key:       "FOOBAR",
+		Scope:     database.ExecutorSecretScopeBatches,
+		CreatorID: user.ID,
+	}
+	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(internalCtx, database.ExecutorSecretScopeBatches, secret3, "1234"); err != nil {
+		t.Fatal(err)
+	}
+
+	ls, err := r.ExecutorSecrets(userCtx, ExecutorSecretsListArgs{
+		Scope: ExecutorSecretScopeBatches,
+		First: 50,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nodes, err := ls.Nodes(userCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Expect user and global secrets, but ASDF is overwritten by user, so only 2 here.
+	if len(nodes) != 2 {
+		t.Fatalf("invalid count of nodes returned: %d", len(nodes))
+	}
+
+	tc, err := ls.TotalCount(userCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tc != 2 {
+		t.Fatalf("invalid totalcount returned: %d", len(nodes))
+	}
+}
+
+func TestOrgResolver_ExecutorSecrets(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := context.Background()
+	internalCtx := actor.WithInternalActor(ctx)
+
+	user, err := db.Users().Create(ctx, database.NewUser{Username: "test-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Users().SetIsSiteAdmin(ctx, user.ID, true); err != nil {
+		t.Fatal(err)
+	}
+
+	org, err := db.Orgs().Create(ctx, "super-org", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.OrgMembers().Create(ctx, org.ID, user.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := OrgByIDInt32(ctx, db, org.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	userCtx := actor.WithActor(ctx, actor.FromUser(user.ID))
+
+	secret1 := &database.ExecutorSecret{
+		Key:       "ASDF",
+		Scope:     database.ExecutorSecretScopeBatches,
+		CreatorID: user.ID,
+	}
+	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(internalCtx, database.ExecutorSecretScopeBatches, secret1, "1234"); err != nil {
+		t.Fatal(err)
+	}
+	secret2 := &database.ExecutorSecret{
+		Key:             "ASDF",
+		Scope:           database.ExecutorSecretScopeBatches,
+		CreatorID:       user.ID,
+		NamespaceUserID: user.ID,
+	}
+	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(internalCtx, database.ExecutorSecretScopeBatches, secret2, "1234"); err != nil {
+		t.Fatal(err)
+	}
+	secret3 := &database.ExecutorSecret{
+		Key:            "FOOBAR",
+		Scope:          database.ExecutorSecretScopeBatches,
+		NamespaceOrgID: user.ID,
+	}
+	if err := db.ExecutorSecrets(&encryption.NoopKey{}).Create(internalCtx, database.ExecutorSecretScopeBatches, secret3, "1234"); err != nil {
+		t.Fatal(err)
+	}
+
+	ls, err := r.ExecutorSecrets(userCtx, ExecutorSecretsListArgs{
+		Scope: ExecutorSecretScopeBatches,
+		First: 50,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nodes, err := ls.Nodes(userCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Expect org and global secrets.
+	if len(nodes) != 2 {
+		t.Fatalf("invalid count of nodes returned: %d", len(nodes))
+	}
+
+	tc, err := ls.TotalCount(userCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tc != 2 {
+		t.Fatalf("invalid totalcount returned: %d", len(nodes))
+	}
+}

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -537,6 +537,12 @@ func newSchemaResolver(db database.DB, gitserverClient gitserver.Client) *schema
 		"ExternalServiceSyncJob": func(ctx context.Context, id graphql.ID) (Node, error) {
 			return externalServiceSyncJobByID(ctx, db, id)
 		},
+		"ExecutorSecret": func(ctx context.Context, id graphql.ID) (Node, error) {
+			return executorSecretByID(ctx, db, id)
+		},
+		"ExecutorSecretAccessLog": func(ctx context.Context, id graphql.ID) (Node, error) {
+			return executorSecretAccessLogByID(ctx, db, id)
+		},
 	}
 	return r
 }

--- a/cmd/frontend/graphqlbackend/node.go
+++ b/cmd/frontend/graphqlbackend/node.go
@@ -285,6 +285,16 @@ func (r *NodeResolver) ToExecutor() (*ExecutorResolver, bool) {
 	return n, ok
 }
 
+func (r *NodeResolver) ToExecutorSecret() (*executorSecretResolver, bool) {
+	n, ok := r.Node.(*executorSecretResolver)
+	return n, ok
+}
+
+func (r *NodeResolver) ToExecutorSecretAccessLog() (*executorSecretAccessLogResolver, bool) {
+	n, ok := r.Node.(*executorSecretAccessLogResolver)
+	return n, ok
+}
+
 func (r *NodeResolver) ToExternalServiceSyncJob() (*externalServiceSyncJobResolver, bool) {
 	n, ok := r.Node.(*externalServiceSyncJobResolver)
 	return n, ok

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1669,7 +1669,7 @@ type ExecutorSecret implements Node {
     id: ID!
     """
     The key under which the secret is available. Secrets are usually exposed
-    as environment variables under this key.
+    as environment variables named using this key.
     Recommended format: uppercase letters, numbers and underscores.
     """
     key: String!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1650,6 +1650,254 @@ type Query {
 }
 
 """
+Enum of the possible scopes for executor secrets.
+"""
+enum ExecutorSecretScope {
+    """
+    The secret is meant to be used with Batch Changes execution.
+    """
+    BATCHES
+}
+
+"""
+A secret to be used in executor jobs.
+"""
+type ExecutorSecret implements Node {
+    """
+    The unique identifier of the secret.
+    """
+    id: ID!
+    """
+    The key under which the secret is available. Secrets are usually exposed
+    as environment variables under this key.
+    Recommended format: uppercase letters, numbers and underscores.
+    """
+    key: String!
+    """
+    The scope of this secret. The secret will only be usable for jobs in this
+    particular scope.
+    """
+    scope: ExecutorSecretScope!
+    """
+    The namespace this secret belongs to. Null, if a global secret.
+    Global secrets are available to every execution.
+    """
+    namespace: Namespace
+    """
+    The creator of the secret. Null, if the creator has been deleted.
+    """
+    creator: User
+    """
+    The date and time this secret has been created.
+    """
+    createdAt: DateTime!
+    """
+    The date and time this secret has been last updated.
+    """
+    updatedAt: DateTime!
+    """
+    The list of access events to this secret. Every time the secret value is
+    decoded and used, one of these entries is created.
+    """
+    accessLogs(
+        """
+        Only return N records.
+        """
+        first: Int = 50
+        """
+        Opaque cursor for pagination.
+        """
+        after: String
+    ): ExecutorSecretAccessLogConnection!
+}
+
+"""
+A list of executor secrets.
+"""
+type ExecutorSecretConnection {
+    """
+    A list of executor secrets.
+    """
+    nodes: [ExecutorSecret!]!
+
+    """
+    The total number of records in this result set.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+A list of executor secret access logs.
+"""
+type ExecutorSecretAccessLogConnection {
+    """
+    A list of access logs.
+    """
+    nodes: [ExecutorSecretAccessLog!]!
+
+    """
+    The total number of records in this result set.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+An access log entry for an executor secret.
+These are created every time the secret value is decoded.
+"""
+type ExecutorSecretAccessLog implements Node {
+    """
+    The unique identifier of the log entry.
+    """
+    id: ID!
+    """
+    The secret that this log entry belongs to.
+    """
+    executorSecret: ExecutorSecret!
+    """
+    The user in which name the secret has been used.
+    """
+    user: User!
+    """
+    The date and time when the secret has been used.
+    """
+    createdAt: DateTime!
+}
+
+extend type Query {
+    """
+    The list of all globally available executor secrets.
+    """
+    executorSecrets(
+        """
+        The scope for which secrets shall be returned.
+        """
+        scope: ExecutorSecretScope!
+        """
+        Only return N records.
+        """
+        first: Int = 50
+        """
+        Opaque cursor for pagination.
+        """
+        after: String
+    ): ExecutorSecretConnection!
+}
+
+extend type User {
+    """
+    The list of all available executor secrets for execution in this users namespace.
+    """
+    executorSecrets(
+        """
+        The scope for which secrets shall be returned.
+        """
+        scope: ExecutorSecretScope!
+        """
+        Only return N records.
+        """
+        first: Int = 50
+        """
+        Opaque cursor for pagination.
+        """
+        after: String
+    ): ExecutorSecretConnection!
+}
+
+extend type Org {
+    """
+    The list of all available executor secrets for execution in this orgs namespace.
+    """
+    executorSecrets(
+        """
+        The scope for which secrets shall be returned.
+        """
+        scope: ExecutorSecretScope!
+        """
+        Only return N records.
+        """
+        first: Int = 50
+        """
+        Opaque cursor for pagination.
+        """
+        after: String
+    ): ExecutorSecretConnection!
+}
+
+extend type Mutation {
+    """
+    Create a new executor secret.
+    See argument descriptions for more details.
+    """
+    createExecutorSecret(
+        """
+        The scope for which the secret is usable.
+        """
+        scope: ExecutorSecretScope!
+        """
+        The key under which the secret is known. For executions, this is the name
+        of the environment variable this secret will be accessible under.
+        It is therefore advised that key only contains uppercase letters, numbers
+        and underscores.
+        """
+        key: String!
+        """
+        The secret value.
+        """
+        value: String!
+        """
+        The namespace this secret is for. If not set, a global secret is created
+        that is accessible by all users.
+        Creating a global secret requires site-admin permissions.
+        Creating a namespaced secret requires write-access to the namespace.
+        """
+        namespace: ID
+    ): ExecutorSecret!
+
+    """
+    Update the value of an existing executor secret.
+    """
+    updateExecutorSecret(
+        """
+        The scope of the secret.
+        """
+        scope: ExecutorSecretScope!
+        """
+        The idenitifier of the secret that shall be updated.
+        """
+        id: ID!
+        """
+        The new secret value.
+        """
+        value: String!
+    ): ExecutorSecret!
+
+    """
+    Deletes the given executor secret.
+    """
+    deleteExecutorSecret(
+        """
+        The scope of the secret.
+        """
+        scope: ExecutorSecretScope!
+        """
+        The idenitifier of the secret that shall be deleted.
+        """
+        id: ID!
+    ): EmptyResponse
+}
+
+"""
 A feature flag is either a static boolean feature flag or a rollout feature flag
 """
 union FeatureFlag = FeatureFlagBoolean | FeatureFlagRollout


### PR DESCRIPTION
This PR builds on top of the new executor secret stores. It implements the resolver layer needed to implement the UI parts that are used to manage secrets.

## Test plan

Wrote test suite, wrote the UI before to validate this schema makes sense, but It'll be a separate PR.