### PR TITLE
authz: Update handling of directories in sub-repo filtering

### DIFF
--- a/enterprise/internal/authz/perforce/protects_test.go
+++ b/enterprise/internal/authz/perforce/protects_test.go
@@ -523,7 +523,16 @@ read    group   Dev1    *   -//-depot/-main/.../dev/foo.java
 			protects: `
 read    group   Dev1    *   //depot/main/.../*.java
 `,
-			canReadAll:    []string{"dev/bar.java", "foo.java"},
+			canReadAll:    []string{"dev/bar.java", "foo.java", "/foo.java"},
+			cannotReadAny: []string{"dev/foo.go"},
+		},
+		{
+			name:  "Root matching, multiple levels",
+			depot: "//depot/main/",
+			protects: `
+read    group   Dev1    *   //depot/main/.../.../*.java
+`,
+			canReadAll:    []string{"/foo/dev/bar.java", "foo.java", "/foo.java"},
 			cannotReadAny: []string{"dev/foo.go"},
 		},
 		{

--- a/enterprise/internal/authz/perforce/protects_test.go
+++ b/enterprise/internal/authz/perforce/protects_test.go
@@ -546,7 +546,7 @@ read    group   Dev1    *   //depot/main/...
 read    group   Dev1    *   -//depot/main/dir/...
 read    group   Dev1    *   //depot/main/dir/file.java
 `,
-			canReadAll: []string{"dir/file.java"},
+			canReadAll: []string{"dir/file.java", "dir/"},
 		},
 		{
 			// Should still be able to browse directories

--- a/enterprise/internal/authz/perforce/protects_test.go
+++ b/enterprise/internal/authz/perforce/protects_test.go
@@ -517,6 +517,46 @@ read    group   Dev1    *   -//-depot/-main/.../dev/foo.java
 			canReadAll:    []string{"dev/bar.java", "/-minus/dev/bar.java"},
 			cannotReadAny: []string{"dev/foo.java"},
 		},
+		{
+			name:  "Root matching",
+			depot: "//depot/main/",
+			protects: `
+read    group   Dev1    *   //depot/main/.../*.java
+`,
+			canReadAll:    []string{"dev/bar.java", "foo.java"},
+			cannotReadAny: []string{"dev/foo.go"},
+		},
+		{
+			// In this case, Perforce still shows the parent directory
+			name:  "Files in side directory hidden",
+			depot: "//depot/main/",
+			protects: `
+read    group   Dev1    *   //depot/main/...
+read    group   Dev1    *   -//depot/main/dir/*.java
+`,
+			canReadAll:    []string{"dir/"},
+			cannotReadAny: []string{"dir/foo.java", "dir/bar.java"},
+		},
+		{
+			// Directory excluded, but file inside included: Directory visible
+			name:  "Directory excluded",
+			depot: "//depot/main/",
+			protects: `
+read    group   Dev1    *   //depot/main/...
+read    group   Dev1    *   -//depot/main/dir/...
+read    group   Dev1    *   //depot/main/dir/file.java
+`,
+			canReadAll: []string{"dir/file.java"},
+		},
+		{
+			// Should still be able to browse directories
+			name:  "Rules start with wildcard",
+			depot: "//depot/main/",
+			protects: `
+read    group   Dev1    *   //depot/main/.../*.go
+`,
+			canReadAll: []string{"dir/file.go", "dir/"},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			logger := logtest.Scoped(t)

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -412,9 +412,9 @@ func (s *SubRepoPermsClient) EnabledForRepo(ctx context.Context, repo api.RepoNa
 	return s.permissionsGetter.RepoSupported(ctx, repo)
 }
 
-// expandDirs will return all directories above a match and a bool indicating
-// whether all directories should be matched. This can happen if we have an
-// include rule that starts with a wildcard.
+// expandDirs will return a new set of rules that will match all directories
+// above the supplied rule. As a special case, if the rule starts with a wildcard
+// we return a rule to match all directories.
 func expandDirs(rule string) []string {
 	dirs := make([]string, 0)
 

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -371,7 +371,7 @@ func (s *SubRepoPermsClient) getCompiledRules(ctx context.Context, userID int32)
 				// We should include all directories above an include rule so that we can browse
 				// to the included items.
 				if exclusion {
-					// No required for an exclude rule
+					// Not required for an exclude rule
 					continue
 				}
 

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -339,7 +339,6 @@ func (s *SubRepoPermsClient) getCompiledRules(ctx context.Context, userID int32)
 		}
 		for repo, perms := range repoPerms {
 			paths := make([]path, 0, len(perms.Paths))
-			allowAllDirs := false
 			for _, rule := range perms.Paths {
 				exclusion := strings.HasPrefix(rule, "-")
 				rule = strings.TrimPrefix(rule, "-")
@@ -375,8 +374,7 @@ func (s *SubRepoPermsClient) getCompiledRules(ctx context.Context, userID int32)
 					continue
 				}
 
-				dirs, allowAll := expandDirs(rule)
-				allowAllDirs = allowAllDirs || allowAll
+				dirs := expandDirs(rule)
 				for _, dir := range dirs {
 					g, err := glob.Compile(dir, '/')
 					if err != nil {
@@ -417,7 +415,7 @@ func (s *SubRepoPermsClient) EnabledForRepo(ctx context.Context, repo api.RepoNa
 // expandDirs will return all directories above a match and a bool indicating
 // whether all directories should be matched. This can happen if we have an
 // include rule that starts with a wildcard.
-func expandDirs(rule string) ([]string, bool) {
+func expandDirs(rule string) []string {
 	dirs := make([]string, 0)
 
 	// Make sure the rule starts with a slash
@@ -431,7 +429,7 @@ func expandDirs(rule string) ([]string, bool) {
 	// directory
 	if strings.HasPrefix(rule, "/*") {
 		dirs = append(dirs, "**/")
-		return dirs, true
+		return dirs
 	}
 
 	for {
@@ -445,7 +443,7 @@ func expandDirs(rule string) ([]string, bool) {
 		dirs = append(dirs, rule+"/")
 	}
 
-	return dirs, false
+	return dirs
 }
 
 // NewSimpleChecker is exposed for testing and allows creation of a simple

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -128,7 +128,8 @@ type cachedRules struct {
 type path struct {
 	globPath  glob.Glob
 	exclusion bool
-	original  string
+	// the original rule before it was compiled into a glob matcher
+	original string
 }
 
 type compiledRules struct {

--- a/internal/gitserver/integration_tests/tree_test.go
+++ b/internal/gitserver/integration_tests/tree_test.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -66,12 +68,11 @@ func TestReadDir_SubRepoFiltering(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if len(files) != 1 {
-		t.Fatalf("expected only one file to be returned, got %d", len(files))
-	}
-	if files[0].Name() != "file1" {
-		t.Errorf("unexpected file returned from ReadDir: %s", files[0].Name())
-	}
+
+	// Because we have a wildcard matcher we still allow directory visibility
+	assert.Len(t, files, 1)
+	assert.Equal(t, "file1", files[0].Name())
+	assert.False(t, files[0].IsDir())
 }
 
 func TestRepository_FileSystem(t *testing.T) {


### PR DESCRIPTION
We want to include all parent directories of an include match. We used
to store this in a separate structure but this would not take into
account rule order. Instead, we now insert an include rule for each
parent directory along with the rule itself into our normal rule list.

In the case of rules that begin with wildcards we can't generate a
finite list of parent directories so instead we insert a rule that
matches any directory, effectively any path ending in '/'.

This change also works around an edge case in the glob package we use
where a rule like `/**/*.java` would not match java files in the root of
the tree.

## Test plan

New tests added and all old tests pass or have been updated.