### PR TITLE
Tweak git blame paddings

### DIFF
--- a/client/web/src/repo/blob/BlameDecoration.tsx
+++ b/client/web/src/repo/blob/BlameDecoration.tsx
@@ -150,7 +150,7 @@ export const BlameDecoration: React.FunctionComponent<{
             </PopoverTrigger>
 
             <PopoverContent
-                targetPadding={createRectangle(0, 0, 8, 8)}
+                constraintPadding={createRectangle(150, 0, 0, 0)}
                 position={Position.topStart}
                 focusLocked={false}
                 returnTargetFocus={false}


### PR DESCRIPTION
Closes #43690

Tweak the git blame paddings to unblock mouse interactions with above lines.

## Test plan

<img width="526" alt="Screenshot 2022-11-02 at 14 10 38" src="https://user-images.githubusercontent.com/458591/199498258-328f3121-8a05-46e1-b1fb-b80c6a547e5f.png">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-tweak-git-blame-paddings.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

