### PR TITLE
Fix repo code intel uploads page loop

### DIFF
--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexesPage.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelIndexesPage.tsx
@@ -130,6 +130,22 @@ export const CodeIntelIndexesPage: FunctionComponent<CodeIntelIndexesPageProps> 
 
     const deletes = useMemo(() => new Subject<undefined>(), [])
 
+    const queryConnection = useCallback(
+        (args: FilteredConnectionQueryArguments) => {
+            setArgs({
+                query: args.query ?? null,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+                state: (args as any).state ?? null,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+                isLatestForRepo: (args as any).isLatestForRepo ?? null,
+                repository: repo?.id ?? null,
+            })
+            setSelection(new Set())
+            return queryIndexes(args)
+        },
+        [queryIndexes, repo?.id]
+    )
+
     return (
         <div className="code-intel-indexes">
             <PageTitle title="Auto-indexing jobs" />
@@ -257,18 +273,7 @@ export const CodeIntelIndexesPage: FunctionComponent<CodeIntelIndexesPageProps> 
                         querySubject={querySubject}
                         nodeComponent={CodeIntelIndexNode}
                         nodeComponentProps={{ now, selection, onCheckboxToggle }}
-                        queryConnection={args => {
-                            setArgs({
-                                query: args.query ?? null,
-                                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-                                state: (args as any).state ?? null,
-                                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-                                isLatestForRepo: (args as any).isLatestForRepo ?? null,
-                                repository: repo?.id ?? null,
-                            })
-                            setSelection(new Set())
-                            return queryIndexes(args)
-                        }}
+                        queryConnection={queryConnection}
                         history={history}
                         location={location}
                         cursorPaging={true}

--- a/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadsPage.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/pages/CodeIntelUploadsPage.tsx
@@ -161,6 +161,22 @@ export const CodeIntelUploadsPage: FunctionComponent<React.PropsWithChildren<Cod
 
     const deletes = useMemo(() => new Subject<undefined>(), [])
 
+    const queryConnection = useCallback(
+        (args: FilteredConnectionQueryArguments) => {
+            setArgs({
+                query: args.query ?? null,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+                state: (args as any).state ?? null,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+                isLatestForRepo: (args as any).isLatestForRepo ?? null,
+                repository: repo?.id ?? null,
+            })
+            setSelection(new Set())
+            return queryLsifUploads(args)
+        },
+        [queryLsifUploads, repo?.id]
+    )
+
     return (
         <div className="code-intel-uploads">
             <PageTitle title="Code graph data uploads" />
@@ -255,18 +271,7 @@ export const CodeIntelUploadsPage: FunctionComponent<React.PropsWithChildren<Cod
                         pluralNoun="uploads"
                         nodeComponent={CodeIntelUploadNode}
                         nodeComponentProps={{ now, selection, onCheckboxToggle }}
-                        queryConnection={args => {
-                            setArgs({
-                                query: args.query ?? null,
-                                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-                                state: (args as any).state ?? null,
-                                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-                                isLatestForRepo: (args as any).isLatestForRepo ?? null,
-                                repository: repo?.id ?? null,
-                            })
-                            setSelection(new Set())
-                            return queryLsifUploads(args)
-                        }}
+                        queryConnection={queryConnection}
                         history={history}
                         location={props.location}
                         cursorPaging={true}


### PR DESCRIPTION
Fixes #43448

During the front end scale-testing audit I noticed a crash on the code intel uploads page inside the repo view. Because I was seeing this together with an empty page, I assumed that this crash would prevent the data from showing. This assumption was (thankfully?) not true though and the empty page comes from an empty backend response:

![image](https://user-images.githubusercontent.com/458591/199506908-88361bf0-9111-4269-ae53-20974f4c76d9.png)

The loop was coming from the `<FilteredConnection/>` component which is re-rendering whenever the query connection prop is being updated.
 
## Test plan

The React crash reproduced locally, I ensured that my changes fix it:

<img width="1282" alt="Screenshot 2022-11-02 at 14 48 45" src="https://user-images.githubusercontent.com/458591/199506519-ca83d25b-ffe5-4abc-a2b7-b94780c9aff5.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-code-intel-uploads-page.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
