### PR TITLE
insights: integrate error retries into new backfiller

### DIFF
--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -106,6 +106,7 @@ func (h *inProgressHandler) Handle(ctx context.Context, logger log.Logger, recor
 		log.Int("recordId", record.RecordID()),
 		log.Int("jobNumFailures", job.NumFailures),
 		log.Int("seriesId", series.ID),
+		log.String("seriesUniqueId", series.SeriesID),
 		log.Int("backfillId", backfillJob.Id),
 		log.Int("repoTotalCount", itr.TotalCount),
 		log.Float64("percentComplete", itr.PercentComplete),
@@ -160,7 +161,7 @@ func (h *inProgressHandler) Handle(ctx context.Context, logger log.Logger, recor
 	}
 
 	if itr.IsComplete() {
-		logger.Info("setting backfill to completed state", log.Int("seriesId", series.ID), log.Int("backfillId", backfillJob.Id), log.Duration("totalDuration", itr.RuntimeDuration))
+		logger.Info("setting backfill to completed state", log.Int("seriesId", series.ID), log.String("seriesUniqueId", series.SeriesID), log.Int("backfillId", backfillJob.Id), log.Duration("totalDuration", itr.RuntimeDuration))
 		err = itr.MarkComplete(ctx, h.backfillStore.Store)
 		if err != nil {
 			return err

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -127,7 +127,7 @@ func (h *inProgressHandler) Handle(ctx context.Context, logger log.Logger, recor
 
 	type nextFunc func() (api.RepoID, bool, iterator.FinishFunc)
 	itrLoop := func(nextFunc nextFunc) error {
-		for true {
+		for {
 			repoId, more, finish := nextFunc()
 			if !more {
 				break

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -130,11 +130,13 @@ func (h *inProgressHandler) Handle(ctx context.Context, logger log.Logger, recor
 				break
 			}
 
-			repo, err := h.repoStore.Get(ctx, repoId)
-			if err != nil {
-				// TODO: this repo should be marked as errored and processing should continue
-				// revisit when error handling added.
-				return err
+			repo, repoErr := h.repoStore.Get(ctx, repoId)
+			if repoErr != nil {
+				err = finish(ctx, h.backfillStore.Store, errors.Wrap(repoErr, "InProgressHandler.repoStore.Get"))
+				if err != nil {
+					return err
+				}
+				continue
 			}
 
 			logger.Debug("doing iteration work", log.Int("repo_id", int(repoId)))

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -165,7 +165,7 @@ func (h *inProgressHandler) Handle(ctx context.Context, logger log.Logger, recor
 		return errors.Wrap(err, "InProgressHandler.RetryLoop")
 	}
 
-	if itr.IsComplete() {
+	if !itr.HasMore() && !itr.HasErrors() {
 		logger.Info("setting backfill to completed state", log.Int("seriesId", series.ID), log.String("seriesUniqueId", series.SeriesID), log.Int("backfillId", backfillJob.Id), log.Duration("totalDuration", itr.RuntimeDuration))
 		err = itr.MarkComplete(ctx, h.backfillStore.Store)
 		if err != nil {

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/derision-test/glock"
-	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/log/logtest"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/pipeline"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/priority"
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	itypes "github.com/sourcegraph/sourcegraph/internal/types"
+	store2 "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -27,6 +28,17 @@ type noopBackfillRunner struct {
 }
 
 func (n *noopBackfillRunner) Run(ctx context.Context, req pipeline.BackfillRequest) error {
+	return nil
+}
+
+type errorBackfillRunner struct {
+	shouldError func(req pipeline.BackfillRequest) bool
+}
+
+func (e *errorBackfillRunner) Run(ctx context.Context, req pipeline.BackfillRequest) error {
+	if e.shouldError(req) {
+		return errors.New("fake error")
+	}
 	return nil
 }
 
@@ -178,5 +190,178 @@ func Test_PullsByPriorityGroupAge(t *testing.T) {
 	assert.Equal(t, bf2.Id, job2.backfillId)
 	assert.Equal(t, bf4.Id, job3.backfillId)
 	assert.Equal(t, bf3.Id, job4.backfillId)
+
+}
+
+func Test_BackfillWithRetry(t *testing.T) {
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t))
+	permStore := store.NewInsightPermissionStore(database.NewMockDB())
+	repos := database.NewMockRepoStore()
+	repos.GetFunc.SetDefaultReturn(&itypes.Repo{ID: 1, Name: "repo1"}, nil)
+	insightsStore := store.NewInsightStore(insightsDB)
+	seriesStore := store.New(insightsDB, permStore)
+
+	now := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := glock.NewMockClockAt(now)
+	bfs := newBackfillStoreWithClock(insightsDB, clock)
+
+	config := JobMonitorConfig{
+		InsightsDB:     insightsDB,
+		RepoStore:      repos,
+		InsightStore:   seriesStore,
+		ObsContext:     &observation.TestContext,
+		BackfillRunner: &noopBackfillRunner{},
+		CostAnalyzer:   priority.NewQueryAnalyzer(),
+	}
+	monitor := NewBackgroundJobMonitor(ctx, config)
+
+	series, err := insightsStore.CreateSeries(ctx, types.InsightSeries{
+		SeriesID:            "series1",
+		Query:               "asdf",
+		SampleIntervalUnit:  string(types.Month),
+		Repositories:        []string{"repo1", "repo2"},
+		SampleIntervalValue: 1,
+		GenerationMethod:    types.Search,
+	})
+	require.NoError(t, err)
+
+	backfill, err := bfs.NewBackfill(ctx, series)
+	require.NoError(t, err)
+	backfill, err = backfill.SetScope(ctx, bfs, []int32{1, 2}, 0)
+	require.NoError(t, err)
+	err = backfill.setState(ctx, bfs, BackfillStateProcessing)
+	require.NoError(t, err)
+
+	err = enqueueBackfill(ctx, bfs.Handle(), backfill)
+	require.NoError(t, err)
+
+	attemptCounts := make(map[int]int)
+	runner := &errorBackfillRunner{shouldError: func(req pipeline.BackfillRequest) bool {
+		val := attemptCounts[int(req.Repo.ID)]
+		attemptCounts[int(req.Repo.ID)] += 1
+		if val > 2 {
+			return false
+		}
+		return true
+	}}
+
+	dequeue, _, _ := monitor.inProgressStore.Dequeue(ctx, "test", nil)
+	handler := inProgressHandler{
+		workerStore:    monitor.newBackfillStore,
+		backfillStore:  bfs,
+		seriesReader:   insightsStore,
+		repoStore:      repos,
+		insightsStore:  seriesStore,
+		backfillRunner: runner,
+	}
+
+	// we should get an errored record here that will be retried by the overall queue
+	err = handler.Handle(ctx, logger, dequeue)
+	require.ErrorIs(t, err, incompleteBackfillErr)
+
+	completedBackfill, err := bfs.loadBackfill(ctx, backfill.Id)
+	require.NoError(t, err)
+	if completedBackfill.State != BackfillStateProcessing {
+		t.Fatal(errors.New("backfill should be state in progress"))
+	}
+
+	recordingTimes, err := seriesStore.GetInsightSeriesRecordingTimes(ctx, series.ID, nil, nil)
+	require.NoError(t, err)
+	if len(recordingTimes.RecordingTimes) == 0 {
+		t.Fatal(errors.New("recording times should have been saved after success"))
+	}
+}
+
+func Test_BackfillWithRetryAndComplete(t *testing.T) {
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t))
+	permStore := store.NewInsightPermissionStore(database.NewMockDB())
+	repos := database.NewMockRepoStore()
+	repos.GetFunc.SetDefaultReturn(&itypes.Repo{ID: 1, Name: "repo1"}, nil)
+	insightsStore := store.NewInsightStore(insightsDB)
+	seriesStore := store.New(insightsDB, permStore)
+
+	now := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := glock.NewMockClockAt(now)
+	bfs := newBackfillStoreWithClock(insightsDB, clock)
+
+	config := JobMonitorConfig{
+		InsightsDB:     insightsDB,
+		RepoStore:      repos,
+		InsightStore:   seriesStore,
+		ObsContext:     &observation.TestContext,
+		BackfillRunner: &noopBackfillRunner{},
+		CostAnalyzer:   priority.NewQueryAnalyzer(),
+	}
+	monitor := NewBackgroundJobMonitor(ctx, config)
+
+	series, err := insightsStore.CreateSeries(ctx, types.InsightSeries{
+		SeriesID:            "series1",
+		Query:               "asdf",
+		SampleIntervalUnit:  string(types.Month),
+		Repositories:        []string{"repo1", "repo2"},
+		SampleIntervalValue: 1,
+		GenerationMethod:    types.Search,
+	})
+	require.NoError(t, err)
+
+	backfill, err := bfs.NewBackfill(ctx, series)
+	require.NoError(t, err)
+	backfill, err = backfill.SetScope(ctx, bfs, []int32{1, 2}, 0)
+	require.NoError(t, err)
+	err = backfill.setState(ctx, bfs, BackfillStateProcessing)
+	require.NoError(t, err)
+
+	err = enqueueBackfill(ctx, bfs.Handle(), backfill)
+	require.NoError(t, err)
+
+	attemptCounts := make(map[int]int)
+	runner := &errorBackfillRunner{shouldError: func(req pipeline.BackfillRequest) bool {
+		val := attemptCounts[int(req.Repo.ID)]
+		attemptCounts[int(req.Repo.ID)] += 1
+		if val > 2 {
+			return false
+		}
+		return true
+	}}
+
+	dequeue, _, _ := monitor.inProgressStore.Dequeue(ctx, "test", nil)
+	handler := inProgressHandler{
+		workerStore:    monitor.newBackfillStore,
+		backfillStore:  bfs,
+		seriesReader:   insightsStore,
+		repoStore:      repos,
+		insightsStore:  seriesStore,
+		backfillRunner: runner,
+	}
+
+	// we should get an errored record here that will be retried by the overall queue
+	err = handler.Handle(ctx, logger, dequeue)
+	require.ErrorIs(t, err, incompleteBackfillErr)
+
+	updated, err := monitor.inProgressStore.MarkErrored(ctx, dequeue.RecordID(), err.Error(), store2.MarkFinalOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.True(t, updated)
+
+	// the queue won't immediately dequeue so we will just pass it back to the handler as if it was dequeued again
+	err = handler.Handle(ctx, logger, dequeue)
+	require.NoError(t, err)
+
+	completedBackfill, err := bfs.loadBackfill(ctx, backfill.Id)
+	require.NoError(t, err)
+	if completedBackfill.State != BackfillStateCompleted {
+		t.Fatal(errors.New("backfill should be state completed"))
+	}
+
+	recordingTimes, err := seriesStore.GetInsightSeriesRecordingTimes(ctx, series.ID, nil, nil)
+	require.NoError(t, err)
+	if len(recordingTimes.RecordingTimes) == 0 {
+		t.Fatal(errors.New("recording times should have been saved after success"))
+	}
 
 }

--- a/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/priority"

--- a/enterprise/internal/insights/scheduler/iterator/repo_iterator.go
+++ b/enterprise/internal/insights/scheduler/iterator/repo_iterator.go
@@ -196,6 +196,18 @@ func (p *PersistentRepoIterator) IsComplete() bool {
 	return p.PercentComplete == 1
 }
 
+func (p *PersistentRepoIterator) ErroredRepos() int {
+	return len(p.errors)
+}
+
+func (p *PersistentRepoIterator) TotalErrors() int {
+	count := 0
+	for _, iterationError := range p.errors {
+		count += iterationError.FailureCount
+	}
+	return count
+}
+
 func stampStartedAt(ctx context.Context, store *basestore.Store, itrId int, stampTime time.Time) error {
 	return store.Exec(ctx, sqlf.Sprintf("UPDATE repo_iterator SET started_at = %S WHERE Id = %S", stampTime, itrId))
 }

--- a/enterprise/internal/insights/scheduler/iterator/repo_iterator.go
+++ b/enterprise/internal/insights/scheduler/iterator/repo_iterator.go
@@ -192,6 +192,10 @@ func (p *PersistentRepoIterator) MarkComplete(ctx context.Context, store *basest
 	return nil
 }
 
+func (p *PersistentRepoIterator) IsComplete() bool {
+	return p.PercentComplete == 1
+}
+
 func stampStartedAt(ctx context.Context, store *basestore.Store, itrId int, stampTime time.Time) error {
 	return store.Exec(ctx, sqlf.Sprintf("UPDATE repo_iterator SET started_at = %S WHERE Id = %S", stampTime, itrId))
 }

--- a/enterprise/internal/insights/scheduler/iterator/repo_iterator.go
+++ b/enterprise/internal/insights/scheduler/iterator/repo_iterator.go
@@ -192,8 +192,13 @@ func (p *PersistentRepoIterator) MarkComplete(ctx context.Context, store *basest
 	return nil
 }
 
-func (p *PersistentRepoIterator) IsComplete() bool {
-	return p.PercentComplete == 1
+func (p *PersistentRepoIterator) HasMore() bool {
+	_, has := peek(p.Cursor, p.repos)
+	return has
+}
+
+func (p *PersistentRepoIterator) HasErrors() bool {
+	return len(p.errors) > 0
 }
 
 func (p *PersistentRepoIterator) ErroredRepos() int {


### PR DESCRIPTION
Integrates the retry iterator into the backfiller. This currently just uses the queue retry mechanism to start over, but future changes will build that in explicitly.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Logs from an all repo backfill where I randomly injected errors. After the job was terminally failed I removed the random error injection and retried it once more and it completed successfully, moving into the completed terminal state.

```
[         worker] INFO worker.insights-job.background workerutil/worker.go:332 Dequeued record for processing {"name": "backfill_new_backfill_worker", "id": 36}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_new_handler.go:84 newBackfillHandler called {"handle": {"recordId": 36}}
[         worker] INFO worker.insights-job.background workerutil/worker.go:332 Dequeued record for processing {"TraceId": "e11ef565eaf2e938edf17c4b9629ded4", "SpanId": "a6a417d552f5cab8", "name": "backfill_in_progress_worker", "id": 37}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:85 inProgressHandler called {"TraceId": "e11ef565eaf2e938edf17c4b9629ded4", "SpanId": "88245eb1da572e2a", "handle": {"recordId": 37}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:149 starting primary loop {"TraceId": "e11ef565eaf2e938edf17c4b9629ded4", "SpanId": "88245eb1da572e2a", "handle": {"series_id": 19, "backfill_id": 19}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "e11ef565eaf2e938edf17c4b9629ded4", "SpanId": "88245eb1da572e2a", "handle": {"repo_id": 1}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "e11ef565eaf2e938edf17c4b9629ded4", "SpanId": "88245eb1da572e2a", "handle": {"repo_id": 2}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "e11ef565eaf2e938edf17c4b9629ded4", "SpanId": "88245eb1da572e2a", "handle": {"repo_id": 3}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "e11ef565eaf2e938edf17c4b9629ded4", "SpanId": "88245eb1da572e2a", "handle": {"repo_id": 4}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "e11ef565eaf2e938edf17c4b9629ded4", "SpanId": "88245eb1da572e2a", "handle": {"repo_id": 5}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "e11ef565eaf2e938edf17c4b9629ded4", "SpanId": "88245eb1da572e2a", "handle": {"repo_id": 6}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "e11ef565eaf2e938edf17c4b9629ded4", "SpanId": "88245eb1da572e2a", "handle": {"repo_id": 7}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:154 starting retry loop {"TraceId": "e11ef565eaf2e938edf17c4b9629ded4", "SpanId": "88245eb1da572e2a", "handle": {"series_id": 19, "backfill_id": 19}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "e11ef565eaf2e938edf17c4b9629ded4", "SpanId": "88245eb1da572e2a", "handle": {"repo_id": 5}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "e11ef565eaf2e938edf17c4b9629ded4", "SpanId": "88245eb1da572e2a", "handle": {"repo_id": 1}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "e11ef565eaf2e938edf17c4b9629ded4", "SpanId": "88245eb1da572e2a", "handle": {"repo_id": 2}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "e11ef565eaf2e938edf17c4b9629ded4", "SpanId": "88245eb1da572e2a", "handle": {"repo_id": 3}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "e11ef565eaf2e938edf17c4b9629ded4", "SpanId": "88245eb1da572e2a", "handle": {"repo_id": 4}}
[         worker] WARN worker.insights-job.background.worker.Handle workerutil/worker.go:413 Marked record as errored {"TraceId": "e11ef565eaf2e938edf17c4b9629ded4", "SpanId": "88245eb1da572e2a", "error": "incomplete backfill"}
[         worker] ERROR worker.insights-job.background.worker.Handle workerutil/worker.go:386 operation.error {"TraceId": "e11ef565eaf2e938edf17c4b9629ded4", "SpanId": "88245eb1da572e2a", "count": 1, "elapsed": 14.1009395, "error": "incomplete backfill"}

[         worker] INFO worker.insights-job.background workerutil/worker.go:332 Dequeued record for processing {"TraceId": "8f4a868ba9ebec21d659510a0e2a0859", "SpanId": "7db20423e1ad2379", "name": "backfill_in_progress_worker", "id": 37}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:85 inProgressHandler called {"TraceId": "8f4a868ba9ebec21d659510a0e2a0859", "SpanId": "892fa22c2a0f5a1f", "handle": {"recordId": 37}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:149 starting primary loop {"TraceId": "8f4a868ba9ebec21d659510a0e2a0859", "SpanId": "892fa22c2a0f5a1f", "handle": {"series_id": 19, "backfill_id": 19}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:154 starting retry loop {"TraceId": "8f4a868ba9ebec21d659510a0e2a0859", "SpanId": "892fa22c2a0f5a1f", "handle": {"series_id": 19, "backfill_id": 19}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "8f4a868ba9ebec21d659510a0e2a0859", "SpanId": "892fa22c2a0f5a1f", "handle": {"repo_id": 2}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "8f4a868ba9ebec21d659510a0e2a0859", "SpanId": "892fa22c2a0f5a1f", "handle": {"repo_id": 3}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "8f4a868ba9ebec21d659510a0e2a0859", "SpanId": "892fa22c2a0f5a1f", "handle": {"repo_id": 4}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "8f4a868ba9ebec21d659510a0e2a0859", "SpanId": "892fa22c2a0f5a1f", "handle": {"repo_id": 5}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "8f4a868ba9ebec21d659510a0e2a0859", "SpanId": "892fa22c2a0f5a1f", "handle": {"repo_id": 1}}
[         worker] WARN worker.insights-job.background.worker.Handle workerutil/worker.go:413 Marked record as errored {"TraceId": "8f4a868ba9ebec21d659510a0e2a0859", "SpanId": "892fa22c2a0f5a1f", "error": "incomplete backfill"}
[         worker] ERROR worker.insights-job.background.worker.Handle workerutil/worker.go:386 operation.error {"TraceId": "8f4a868ba9ebec21d659510a0e2a0859", "SpanId": "892fa22c2a0f5a1f", "count": 1, "elapsed": 5.860580583, "error": "incomplete backfill"}

[         worker] INFO worker.insights-job.background workerutil/worker.go:332 Dequeued record for processing {"TraceId": "ad22242a87c13ead55cf808993304ad4", "SpanId": "963727364d082744", "name": "backfill_in_progress_worker", "id": 37}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:85 inProgressHandler called {"TraceId": "ad22242a87c13ead55cf808993304ad4", "SpanId": "d81c0e6113b238ca", "handle": {"recordId": 37}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:149 starting primary loop {"TraceId": "ad22242a87c13ead55cf808993304ad4", "SpanId": "d81c0e6113b238ca", "handle": {"series_id": 19, "backfill_id": 19}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:154 starting retry loop {"TraceId": "ad22242a87c13ead55cf808993304ad4", "SpanId": "d81c0e6113b238ca", "handle": {"series_id": 19, "backfill_id": 19}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "ad22242a87c13ead55cf808993304ad4", "SpanId": "d81c0e6113b238ca", "handle": {"repo_id": 4}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "ad22242a87c13ead55cf808993304ad4", "SpanId": "d81c0e6113b238ca", "handle": {"repo_id": 5}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "ad22242a87c13ead55cf808993304ad4", "SpanId": "d81c0e6113b238ca", "handle": {"repo_id": 2}}
[         worker] WARN worker.insights-job.background.worker.Handle workerutil/worker.go:413 Marked record as errored {"TraceId": "ad22242a87c13ead55cf808993304ad4", "SpanId": "d81c0e6113b238ca", "error": "incomplete backfill"}
[         worker] ERROR worker.insights-job.background.worker.Handle workerutil/worker.go:386 operation.error {"TraceId": "ad22242a87c13ead55cf808993304ad4", "SpanId": "d81c0e6113b238ca", "count": 1, "elapsed": 3.467747459, "error": "incomplete backfill"}


-------------- After manual restart (since job was terminally failed at this point) and removing forced errors ---------


[         worker] INFO worker.insights-job.background workerutil/worker.go:332 Dequeued record for processing {"TraceId": "d5bf39386e80762aba1bb4fec3033d7b", "SpanId": "65299a90a6f42e88", "name": "backfill_in_progress_worker", "id": 37}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:85 inProgressHandler called {"TraceId": "d5bf39386e80762aba1bb4fec3033d7b", "SpanId": "adde91c508feb0c6", "handle": {"recordId": 37}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:149 starting primary loop {"TraceId": "d5bf39386e80762aba1bb4fec3033d7b", "SpanId": "adde91c508feb0c6", "handle": {"series_id": 19, "backfill_id": 19}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:154 starting retry loop {"TraceId": "d5bf39386e80762aba1bb4fec3033d7b", "SpanId": "adde91c508feb0c6", "handle": {"series_id": 19, "backfill_id": 19}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "d5bf39386e80762aba1bb4fec3033d7b", "SpanId": "adde91c508feb0c6", "handle": {"repo_id": 2}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "d5bf39386e80762aba1bb4fec3033d7b", "SpanId": "adde91c508feb0c6", "handle": {"repo_id": 4}}
[         worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:133 doing iteration work {"TraceId": "d5bf39386e80762aba1bb4fec3033d7b", "SpanId": "adde91c508feb0c6", "handle": {"repo_id": 5}}

```