### PR TITLE
search ui: fix structural search integration tests

### DIFF
--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -309,6 +309,7 @@ describe('Search', () => {
                     await editor.focus()
                     await driver.page.keyboard.type('test')
                     await driver.page.click('.test-structural-search-toggle')
+                    await driver.page.click('aria/Search[role="button"]')
                     await driver.assertWindowLocation('/search?q=context:global+test&patternType=structural')
                 })
 


### PR DESCRIPTION
Fixes broken integration tests from https://github.com/sourcegraph/sourcegraph/pull/43762
Not sure how those tests even passed in the first place to let me merge it 🤷‍♀️

## Test plan

Verify tests pass

## App preview:

- [Web](https://sg-web-jp-fixstructuralsearchtests.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
