### PR TITLE
Fix queries assuming __type always returns a result

### DIFF
--- a/client/shared/src/codeintel/legacy-extensions/util/api.ts
+++ b/client/shared/src/codeintel/legacy-extensions/util/api.ts
@@ -140,10 +140,10 @@ export class API {
         `
 
         interface IntrospectionResponse {
-            __type: { fields: { name: string }[] }
+            __type?: { fields: { name: string }[] }
         }
 
-        return (await queryGraphQL<IntrospectionResponse>(introspectionQuery)).__type.fields.some(
+        return (await queryGraphQL<IntrospectionResponse>(introspectionQuery)).__type?.fields.some(
             field => field.name === 'isFork'
         )
     }
@@ -165,10 +165,10 @@ export class API {
         `
 
         interface IntrospectionResponse {
-            __type: { fields: { name: string }[] }
+            __type?: { fields: { name: string }[] }
         }
 
-        return (await queryGraphQL<IntrospectionResponse>(introspectionQuery)).__type.fields.some(
+        return (await queryGraphQL<IntrospectionResponse>(introspectionQuery)).__type?.fields.some(
             field => field.name === 'implementations'
         )
     }
@@ -191,10 +191,10 @@ export class API {
         `
 
         interface IntrospectionResponse {
-            __type: { fields: { name: string }[] }
+            __type?: { fields: { name: string }[] }
         }
 
-        return (await queryGraphQL<IntrospectionResponse>(introspectionQuery)).__type.fields.some(
+        return (await queryGraphQL<IntrospectionResponse>(introspectionQuery)).__type?.fields.some(
             field => field.name === 'localCodeIntel'
         )
     })
@@ -216,10 +216,10 @@ export class API {
         `
 
         interface IntrospectionResponse {
-            __type: { fields: { name: string }[] }
+            __type?: { fields: { name: string }[] }
         }
 
-        return (await queryGraphQL<IntrospectionResponse>(introspectionQuery)).__type.fields.some(
+        return (await queryGraphQL<IntrospectionResponse>(introspectionQuery)).__type?.fields.some(
             field => field.name === 'symbolInfo'
         )
     })
@@ -241,10 +241,10 @@ export class API {
         `
 
         interface IntrospectionResponse {
-            __type: { fields: { name: string }[] }
+            __type?: { fields: { name: string }[] }
         }
 
-        return (await queryGraphQL<IntrospectionResponse>(introspectionQuery)).__type.fields.some(
+        return (await queryGraphQL<IntrospectionResponse>(introspectionQuery)).__type?.fields.some(
             field => field.name === 'range'
         )
     })
@@ -572,7 +572,7 @@ export class API {
         `
 
         interface IntrospectionResponse {
-            __type: { fields: { name: string }[] }
+            __type?: { fields: { name: string }[] }
         }
 
         return Boolean(
@@ -747,10 +747,10 @@ const symbolInfoFlexibleToCanonical = (flexible: SymbolInfoFlexible): SymbolInfo
         range:
             'line' in flexible.definition
                 ? {
-                      line: flexible.definition.line,
-                      character: flexible.definition.character,
-                      length: flexible.definition.length,
-                  }
+                    line: flexible.definition.line,
+                    character: flexible.definition.character,
+                    length: flexible.definition.length,
+                }
                 : flexible.definition.range,
     },
     hover: flexible.hover,


### PR DESCRIPTION
Quering something like
```
{ 
__type(name:"Foo") {
  name
}
}
```
returns
```
{
  "data": {}
}
```
Not sure why it does that. I'd assume it to return `null`

Either way, the result types are wrongfully assuming to always get a type that has fields.


## Test plan

No functional changes. If the build passes everything should be fine