### PR TITLE
gitserver: fix changeset publication

### DIFF
--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -110,7 +110,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 	// Temporary logging command wrapper
 	prefix := fmt.Sprintf("%d %s ", atomic.AddUint64(&patchID, 1), repo)
 	run := func(cmd *exec.Cmd, reason string) ([]byte, error) {
-		if !gitdomain.IsAllowedGitCmd(logger, cmd.Args) {
+		if !gitdomain.IsAllowedGitCmd(logger, cmd.Args[1:]) {
 			return nil, errors.New("command not on allow list")
 		}
 

--- a/internal/gitserver/gitdomain/exec.go
+++ b/internal/gitserver/gitdomain/exec.go
@@ -37,6 +37,13 @@ var (
 		"lfs":          {},
 		"apply":        {"--cached", "-p0"},
 
+		// Commands used by Batch Changes when publishing changesets.
+		"init":       {},
+		"reset":      {"-q"},
+		"commit":     {"-m"},
+		"push":       {"--force"},
+		"update-ref": {},
+
 		// Used in tests to simulate errors with runCommand in handleExec of gitserver.
 		"testcommand": {},
 		"testerror":   {},
@@ -105,10 +112,15 @@ func isAllowedDiffArg(arg string) bool {
 func isAllowedGitArg(allowedArgs []string, arg string) bool {
 	// Split the arg at the first equal sign and check the LHS against the allowlist args.
 	splitArg := strings.Split(arg, "=")[0]
+
+	// We use -- to specify the end of command options.
+	// See: https://unix.stackexchange.com/a/11382/214756.
+	if splitArg == "--" {
+		return true
+	}
+
 	for _, allowedArg := range allowedArgs {
-		// We use -- to specify the end of command options.
-		// See: https://unix.stackexchange.com/a/11382/214756.
-		if splitArg == allowedArg || splitArg == "--" {
+		if splitArg == allowedArg {
 			return true
 		}
 	}

--- a/internal/gitserver/gitdomain/exec_test.go
+++ b/internal/gitserver/gitdomain/exec_test.go
@@ -16,6 +16,14 @@ func TestIsAllowedGitCmd(t *testing.T) {
 		{"rev-parse", "83838383"},
 		{"rev-parse", "--glob=refs/heads/*"},
 		{"rev-parse", "--glob=refs/heads/*", "--exclude=refs/heads/cc/*"},
+
+		// Batch Changes.
+		{"init"},
+		{"reset", "-q", "ceed6a398bd66c090b6c24bd8251ac9255d90fb2"},
+		{"apply", "--cached", "-p0"},
+		{"commit", "-m", "An awesome commit message."},
+		{"push", "--force", "git@github.com:repo/name", "f22cfd066432e382c24f1eaa867444671e23a136:refs/heads/a-branch"},
+		{"update-ref", "--"},
 	}
 
 	logger := logtest.Scoped(t)


### PR DESCRIPTION
This PR makes two fixes to allow changesets to be published once more after the changes in #43421 broke publication. The individual commit messages include more context on each change.

Fixes #43821.

## Test plan

Tested the full publication path locally; updated the `isAllowedGitCmd` tests to cover the commands Batch Changes requires (taken from a local log and mildly anonymised).