### PR TITLE
ranking: Remove no-longer-relevant CSV files from GCS bucket

### DIFF
--- a/internal/codeintel/codenav/init.go
+++ b/internal/codeintel/codenav/init.go
@@ -48,6 +48,7 @@ var (
 	bucketName                   = env.Get("CODEINTEL_CODENAV_RANKING_BUCKET", "lsif-pagerank-experiments", "The GCS bucket.")
 	rankingGraphKey              = env.Get("CODEINTEL_CODENAV_RANKING_GRAPH_KEY", "dev", "An identifier of the graph export. Change to start a new export in the configured bucket.")
 	rankingGraphBatchSize        = env.MustGetInt("CODEINTEL_CODENAV_RANKING_GRAPH_BATCH_SIZE", 1, "How many uploads to process at once.")
+	rankingGraphDeleteBatchSize  = env.MustGetInt("CODEINTEL_CODENAV_RANKING_GRAPH_DELETE_BATCH_SIZE", 20, "How many stale uploads to delete at once.")
 	rankingBucketCredentialsFile = env.Get("CODEINTEL_CODENAV_RANKING_GOOGLE_APPLICATION_CREDENTIALS_FILE", "", "The path to a service account key file with access to GCS.")
 )
 

--- a/internal/codeintel/codenav/internal/background/graph_serializer.go
+++ b/internal/codeintel/codenav/internal/background/graph_serializer.go
@@ -18,5 +18,13 @@ func (b *backgroundJob) NewRankingGraphSerializer(
 func (b backgroundJob) handleRankingGraphSerializer(
 	ctx context.Context,
 ) error {
-	return b.codeNavSvc.SerializeRankingGraph(ctx)
+	if err := b.codeNavSvc.SerializeRankingGraph(ctx); err != nil {
+		return err
+	}
+
+	if err := b.codeNavSvc.VacuumRankingGraph(ctx); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/codeintel/codenav/internal/background/iface.go
+++ b/internal/codeintel/codenav/internal/background/iface.go
@@ -6,4 +6,5 @@ import (
 
 type CodeNavService interface {
 	SerializeRankingGraph(ctx context.Context) error
+	VacuumRankingGraph(ctx context.Context) error
 }

--- a/internal/codeintel/codenav/internal/store/store.go
+++ b/internal/codeintel/codenav/internal/store/store.go
@@ -135,7 +135,7 @@ func (s *store) ProcessStaleExportedUplods(
 	return len(ids), nil
 }
 
-// Note: should remove the cascsade delete on codeintel_ranking_exports
+// Note: should remove the cascade delete on codeintel_ranking_exports
 // from lsif_uploads, as we'd catch it this way without abandoning data
 // in the bucket with no metadata to delete it from.
 

--- a/internal/codeintel/codenav/mocks_test.go
+++ b/internal/codeintel/codenav/mocks_test.go
@@ -33,6 +33,10 @@ type MockStore struct {
 	// GetUploadsForRankingFunc is an instance of a mock function object
 	// controlling the behavior of the method GetUploadsForRanking.
 	GetUploadsForRankingFunc *StoreGetUploadsForRankingFunc
+	// ProcessStaleExportedUplodsFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// ProcessStaleExportedUplods.
+	ProcessStaleExportedUplodsFunc *StoreProcessStaleExportedUplodsFunc
 }
 
 // NewMockStore creates a new mock of the Store interface. All methods
@@ -46,6 +50,11 @@ func NewMockStore() *MockStore {
 		},
 		GetUploadsForRankingFunc: &StoreGetUploadsForRankingFunc{
 			defaultHook: func(context.Context, string, int) (r0 []store.Upload, r1 error) {
+				return
+			},
+		},
+		ProcessStaleExportedUplodsFunc: &StoreProcessStaleExportedUplodsFunc{
+			defaultHook: func(context.Context, string, int, func(ctx context.Context, id int) error) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -66,6 +75,11 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.GetUploadsForRanking")
 			},
 		},
+		ProcessStaleExportedUplodsFunc: &StoreProcessStaleExportedUplodsFunc{
+			defaultHook: func(context.Context, string, int, func(ctx context.Context, id int) error) (int, error) {
+				panic("unexpected invocation of MockStore.ProcessStaleExportedUplods")
+			},
+		},
 	}
 }
 
@@ -78,6 +92,9 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		GetUploadsForRankingFunc: &StoreGetUploadsForRankingFunc{
 			defaultHook: i.GetUploadsForRanking,
+		},
+		ProcessStaleExportedUplodsFunc: &StoreProcessStaleExportedUplodsFunc{
+			defaultHook: i.ProcessStaleExportedUplods,
 		},
 	}
 }
@@ -288,6 +305,123 @@ func (c StoreGetUploadsForRankingFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreGetUploadsForRankingFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StoreProcessStaleExportedUplodsFunc describes the behavior when the
+// ProcessStaleExportedUplods method of the parent MockStore instance is
+// invoked.
+type StoreProcessStaleExportedUplodsFunc struct {
+	defaultHook func(context.Context, string, int, func(ctx context.Context, id int) error) (int, error)
+	hooks       []func(context.Context, string, int, func(ctx context.Context, id int) error) (int, error)
+	history     []StoreProcessStaleExportedUplodsFuncCall
+	mutex       sync.Mutex
+}
+
+// ProcessStaleExportedUplods delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockStore) ProcessStaleExportedUplods(v0 context.Context, v1 string, v2 int, v3 func(ctx context.Context, id int) error) (int, error) {
+	r0, r1 := m.ProcessStaleExportedUplodsFunc.nextHook()(v0, v1, v2, v3)
+	m.ProcessStaleExportedUplodsFunc.appendCall(StoreProcessStaleExportedUplodsFuncCall{v0, v1, v2, v3, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// ProcessStaleExportedUplods method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreProcessStaleExportedUplodsFunc) SetDefaultHook(hook func(context.Context, string, int, func(ctx context.Context, id int) error) (int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ProcessStaleExportedUplods method of the parent MockStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *StoreProcessStaleExportedUplodsFunc) PushHook(hook func(context.Context, string, int, func(ctx context.Context, id int) error) (int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreProcessStaleExportedUplodsFunc) SetDefaultReturn(r0 int, r1 error) {
+	f.SetDefaultHook(func(context.Context, string, int, func(ctx context.Context, id int) error) (int, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreProcessStaleExportedUplodsFunc) PushReturn(r0 int, r1 error) {
+	f.PushHook(func(context.Context, string, int, func(ctx context.Context, id int) error) (int, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreProcessStaleExportedUplodsFunc) nextHook() func(context.Context, string, int, func(ctx context.Context, id int) error) (int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreProcessStaleExportedUplodsFunc) appendCall(r0 StoreProcessStaleExportedUplodsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreProcessStaleExportedUplodsFuncCall
+// objects describing the invocations of this function.
+func (f *StoreProcessStaleExportedUplodsFunc) History() []StoreProcessStaleExportedUplodsFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreProcessStaleExportedUplodsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreProcessStaleExportedUplodsFuncCall is an object that describes an
+// invocation of method ProcessStaleExportedUplods on an instance of
+// MockStore.
+type StoreProcessStaleExportedUplodsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 func(ctx context.Context, id int) error
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreProcessStaleExportedUplodsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreProcessStaleExportedUplodsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/codeintel/codenav/observability.go
+++ b/internal/codeintel/codenav/observability.go
@@ -23,8 +23,10 @@ type operations struct {
 	getDumpsByIDs          *observation.Operation
 	getClosestDumpsForBlob *observation.Operation
 
-	numUploadsRead   prometheus.Counter
-	numBytesUploaded prometheus.Counter
+	numUploadsRead         prometheus.Counter
+	numBytesUploaded       prometheus.Counter
+	numStaleRecordsDeleted prometheus.Counter
+	numBytesDeleted        prometheus.Counter
 }
 
 func newOperations(observationContext *observation.Context) *operations {
@@ -61,6 +63,14 @@ func newOperations(observationContext *observation.Context) *operations {
 		"src_codeintel_codenav_ranking_bytes_uploaded_total",
 		"The number of bytes uploaded to GCS.",
 	)
+	numStaleRecordsDeleted := counter(
+		"src_codeintel_codenav_ranking_stale_uploads_removed_total",
+		"The number of stale upload records removed from GCS.",
+	)
+	numBytesDeleted := counter(
+		"src_codeintel_codenav_ranking_bytes_deleted_total",
+		"The number of bytes deleted from GCS.",
+	)
 
 	return &operations{
 		getReferences:          op("getReferences"),
@@ -73,8 +83,10 @@ func newOperations(observationContext *observation.Context) *operations {
 		getDumpsByIDs:          op("GetDumpsByIDs"),
 		getClosestDumpsForBlob: op("GetClosestDumpsForBlob"),
 
-		numUploadsRead:   numUploadsRead,
-		numBytesUploaded: numBytesUploaded,
+		numUploadsRead:         numUploadsRead,
+		numBytesUploaded:       numBytesUploaded,
+		numStaleRecordsDeleted: numStaleRecordsDeleted,
+		numBytesDeleted:        numBytesDeleted,
 	}
 }
 


### PR DESCRIPTION
Fixes #43772. This PR adds a background routine to remove files in the GCS export bucket when its no longer relevant to the instance's commit graph. This will provide us with an "always-up-to-date" graph split across GCS objects, and PageRank can be ran at any time using the bucket as a current snapshot.

## Test plan

Tested locally. Will add additional store tests pre-merge.