### PR TITLE
Web: Fix decorated tokens keys

### DIFF
--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -1217,33 +1217,33 @@ export function toDecoration(query: string, token: DecoratedToken): Decoration {
         case 'metaStructural':
             return {
                 value: token.value,
-                key: token.range.start,
+                key: token.range.start + token.range.end,
                 className,
             }
         case 'openingParen':
             return {
                 value: '(',
-                key: token.range.start,
+                key: token.range.start + token.range.end,
                 className,
             }
         case 'closingParen':
             return {
                 value: ')',
-                key: token.range.start,
+                key: token.range.start + token.range.end,
                 className,
             }
 
         case 'metaFilterSeparator':
             return {
                 value: ':',
-                key: token.range.start,
+                key: token.range.start + token.range.end,
                 className,
             }
         case 'metaRepoRevisionSeparator':
         case 'metaContextPrefix':
             return {
                 value: '@',
-                key: token.range.start,
+                key: token.range.start + token.range.end,
                 className,
             }
 
@@ -1262,14 +1262,14 @@ export function toDecoration(query: string, token: DecoratedToken): Decoration {
             }
             return {
                 value,
-                key: token.range.start,
+                key: token.range.start + token.range.end,
                 className,
             }
         }
     }
     return {
         value: query.slice(token.range.start, token.range.end),
-        key: token.range.start,
+        key: token.range.start + token.range.end,
         className,
     }
 }


### PR DESCRIPTION
It turend out that it's possible that `decoratedToken.ts` may generate non unique values for syntax highlighted `span` parts. (and because of this we have a react warning in the dev tools)

<img width="1117" alt="Screenshot 2022-11-02 at 18 38 46" src="https://user-images.githubusercontent.com/18492575/199607898-27f5c9a8-374e-435b-884c-d3531154cfb5.png">

## Test plan
- Make sure that there is no console warning about keys if page has `SyntaxHighlightedSearchQuery` component. For example Code Insights getting started page 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-decorated-token-keys.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
