### PR TITLE
Code Insights: Fix use insight dashboard query by id (handle virtual dashboard case)

### DIFF
--- a/client/web/src/enterprise/insights/core/hooks/use-insight-dashboards.ts
+++ b/client/web/src/enterprise/insights/core/hooks/use-insight-dashboards.ts
@@ -92,13 +92,20 @@ interface useInsightDashboardResult {
  */
 export function useInsightDashboard(props: useInsightDashboardProps): useInsightDashboardResult {
     const { id = '' } = props
+
+    const isVirtualDashboardId = id === ALL_INSIGHTS_DASHBOARD.id
     const { data, error, loading } = useQuery<InsightsDashboardsResult>(
         GET_INSIGHT_DASHBOARDS_GQL,
         {
-            fetchPolicy: 'cache-first',
-            variables: { id }
+            skip: isVirtualDashboardId,
+            variables: { id },
+            fetchPolicy: 'cache-first'
         }
     )
+
+    if (isVirtualDashboardId) {
+        return { dashboard: null, loading, error }
+    }
 
     if (data) {
         const { insightsDashboards, currentUser } = data


### PR DESCRIPTION
## Background 
At the moment, the main branch doesn't render the creation UI page if you come from the All insights dashboard. This happens because GQL Code Insight API throws an error if you pass a synthetic ID ("all" in the case of the All insights dashboard) 
```
message: "unmarshalDashboardID: unmarshalDashboardID: illegal base64 data at input byte 0"
path: ["insightsDashboards", "nodes"]
```
## Test plan
- Open the dashboard page
- Click create insight button
- Go to any insight creation UI 
- You should see actually creation UI page

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-query-dashboard-by-id.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
