### PR TITLE
search frontend: warn on structural search without lang: filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Creating access tokens is now tracked in the security events. [#43226](https://github.com/sourcegraph/sourcegraph/pull/43226)
 - Added `codeIntelAutoIndexing.indexerMap` to site-config that allows users to update the indexers used when inferring precise code intelligence auto-indexing jobs (without having to overwrite the entire inference scripts). For example, `"codeIntelAutoIndexing.indexerMap": {"go": "my.registry/sourcegraph/lsif-go"}` will casue Go projects to use the specified container (in a alternative Docker registry). [#43199](https://github.com/sourcegraph/sourcegraph/pull/43199)
 - Code Insights data points that do not contain any results will display zero instead of being omitted from the visualization. Only applies to insight data created after 4.2. [#43166](https://github.com/sourcegraph/sourcegraph/pull/43166)
+- A structural search diagnostic to warn users when a language filter is not set. [#43835](https://github.com/sourcegraph/sourcegraph/pull/43835)
 
 ### Changed
 

--- a/client/shared/src/search/query/diagnostics.test.ts
+++ b/client/shared/src/search/query/diagnostics.test.ts
@@ -607,7 +607,7 @@ describe('getDiagnostics()', () => {
 
     describe('structural search and type: filter', () => {
         test('detects type: filter in structural search', () => {
-            expect(parseAndDiagnose('type:symbol test', SearchPatternType.structural)).toMatchInlineSnapshot(`
+            expect(parseAndDiagnose('type:symbol test lang:go', SearchPatternType.structural)).toMatchInlineSnapshot(`
                 [
                   {
                     "severity": "error",
@@ -619,7 +619,7 @@ describe('getDiagnostics()', () => {
                   }
                 ]
             `)
-            expect(parseAndDiagnose('type:symbol test patterntype:structural', SearchPatternType.standard))
+            expect(parseAndDiagnose('type:symbol test lang:go patterntype:structural', SearchPatternType.standard))
                 .toMatchInlineSnapshot(`
                 [
                   {
@@ -641,6 +641,23 @@ describe('getDiagnostics()', () => {
             expect(
                 parseAndDiagnose('type:symbol test patterntype:literal', SearchPatternType.structural)
             ).toMatchInlineSnapshot('[]')
+        })
+    })
+
+    describe('structural search without lang: filter', () => {
+        test('detects structural search without lang filter', () => {
+            expect(parseAndDiagnose('repo:foo bar', SearchPatternType.structural)).toMatchInlineSnapshot(`
+                [
+                  {
+                    "severity": "warning",
+                    "message": "Add a \`lang\` filter when using structural search. Structural search may miss results without a \`lang\` filter because it only guesses the language of files searched.",
+                    "range": {
+                      "start": 9,
+                      "end": 12
+                    }
+                  }
+                ]
+            `)
         })
     })
 })

--- a/client/web/src/enterprise/insights/hooks/use-api.ts
+++ b/client/web/src/enterprise/insights/hooks/use-api.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo } from 'react'
 
 import { useApolloClient } from '@apollo/client'
 


### PR DESCRIPTION
This PR adds a warning diagnostic when structural search is active but `lang:` is not set.

When structural search is active users should add a `lang:` filter so that we can pick the right parser. If `lang:` isn't set, we may fall back to a generic parser, which can "miss" results that the user would normally expect. 

More context: https://sourcegraph.slack.com/archives/C07KZF47K/p1667385583731439

## Test plan
Updated unit tests.

## App preview:

- [Web](https://sg-web-rvt-ss-lang-diag.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
