### PR TITLE
docs: Fix GitLab webhooks link

### DIFF
--- a/doc/admin/external_service/gitlab.md
+++ b/doc/admin/external_service/gitlab.md
@@ -102,7 +102,7 @@ We are actively collaborating with GitLab to improve our integration (e.g. the [
 | [`GET /projects/:id/repository/tree`](https://docs.gitlab.com/ee/api/repositories.html#list-repository-tree) | `api` or `read_api` | If using GitLab OAuth and repository permissions, used to verify a given user has access to the file contents of a repository within a project (i.e. does not merely have `Guest` permissions). |
 | Batch Changes requests | `api` or `read_api`, `read_repository`, `write_repository` | [Batch Changes](../../batch_changes/index.md) require write access to push commits and create, update and close merge requests on GitLab repositories. See "[Code host interactions in batch changes](../../batch_changes/explanations/permissions_in_batch_changes.md#code-host-interactions-in-batch-changes)" for details. |
 
-## Webhooks
+## Webhook setup
 
 The `webhooks` setting allows specifying the webhook secrets necessary to authenticate incoming webhook requests to `/.api/gitlab-webhooks`.
 

--- a/doc/admin/external_service/gitlab.md
+++ b/doc/admin/external_service/gitlab.md
@@ -120,9 +120,7 @@ To set up webhooks:
 1. Add the `"webhooks"` property to the configuration (you can generate a secret with `openssl rand -hex 32`):<br /> `"webhooks": [{"secret": "verylongrandomsecret"}]`
 1. Click **Update repositories**.
 1. Copy the webhook URL displayed below the **Update repositories** button.
-1. Set up webhook on your GitLab instance, you have two options:
-   1. System wide webhooks (recommended): On GitLab, go to **Main menu > Admin > System hooks**. ([Details here](https://docs.gitlab.com/ee/administration/system_hooks.html#create-a-system-hook))
-   1. Per project webhooks: On GitLab, go to your project, and then **Settings > Webhooks** (or **Settings > Integration** on older GitLab versions that don't have the **Webhooks** option).
+1. On GitLab, go to your project, and then **Settings > Webhooks** (or **Settings > Integration** on older GitLab versions that don't have the **Webhooks** option).
 1. Fill in the webhook form:
    * **URL**: the URL you copied above from Sourcegraph.
    * **Secret token**: the secret token you configured Sourcegraph to use above.

--- a/doc/admin/external_service/gitlab.md
+++ b/doc/admin/external_service/gitlab.md
@@ -120,7 +120,9 @@ To set up webhooks:
 1. Add the `"webhooks"` property to the configuration (you can generate a secret with `openssl rand -hex 32`):<br /> `"webhooks": [{"secret": "verylongrandomsecret"}]`
 1. Click **Update repositories**.
 1. Copy the webhook URL displayed below the **Update repositories** button.
-1. On GitLab, go to your project, and then **Settings > Webhooks** (or **Settings > Integration** on older GitLab versions that don't have the **Webhooks** option).
+1. Set up webhook on your GitLab instance, you have two options:
+   1. System wide webhooks (recommended): On GitLab, go to **Main menu > Admin > System hooks**. ([Details here](https://docs.gitlab.com/ee/administration/system_hooks.html#create-a-system-hook))
+   1. Per project webhooks: On GitLab, go to your project, and then **Settings > Webhooks** (or **Settings > Integration** on older GitLab versions that don't have the **Webhooks** option).
 1. Fill in the webhook form:
    * **URL**: the URL you copied above from Sourcegraph.
    * **Secret token**: the secret token you configured Sourcegraph to use above.

--- a/doc/batch_changes/how-tos/site_admin_configuration.md
+++ b/doc/batch_changes/how-tos/site_admin_configuration.md
@@ -19,10 +19,10 @@
         <a href="../../admin/external_service/github#webhooks">GitHub</a>
       </li>
       <li>
-        <a href="../../admin/external_service/bitbucket_server#webhooks-setup">Bitbucket Server / Bitbucket Data Center</a>
+        <a href="../../admin/external_service/bitbucket_server#webhooks">Bitbucket Server / Bitbucket Data Center</a>
       </li>
       <li>
-        <a href="../../admin/external_service/gitlab#webhooks">GitLab</a>
+        <a href="../../admin/external_service/gitlab#webhook-setup">GitLab</a>
       </li>
       <li>
         <a href="../../admin/external_service/bitbucket_cloud#webhooks">Bitbucket Cloud</a>

--- a/doc/batch_changes/how-tos/site_admin_configuration.md
+++ b/doc/batch_changes/how-tos/site_admin_configuration.md
@@ -19,7 +19,7 @@
         <a href="../../admin/external_service/github#webhooks">GitHub</a>
       </li>
       <li>
-        <a href="../../admin/external_service/bitbucket_server#webhooks">Bitbucket Server / Bitbucket Data Center</a>
+        <a href="../../admin/external_service/bitbucket_server#webhooks-setup">Bitbucket Server / Bitbucket Data Center</a>
       </li>
       <li>
         <a href="../../admin/external_service/gitlab#webhooks">GitLab</a>


### PR DESCRIPTION
The #webhooks link is broken because of some generated links from config. Instead, renamed the section
to "Webhook setup" to avoid the conflict.

## Test plan 

Doc only change
