### PR TITLE
search: Force linting pass when query parsing changes due to external triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Fixed a bug where path matches on files in the root directory of a repository were not highlighted. [#43275](https://github.com/sourcegraph/sourcegraph/pull/43275)
+- Fixed a bug where a search query wouldn't be validated after the query type has changed. [#43849](https://github.com/sourcegraph/sourcegraph/pull/43849)
 
 ### Removed
 

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { closeCompletion, startCompletion } from '@codemirror/autocomplete'
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
-import { Diagnostic as CMDiagnostic, linter } from '@codemirror/lint'
+import { Diagnostic as CMDiagnostic, linter, LintSource } from '@codemirror/lint'
 import {
     EditorSelection,
     Extension,
@@ -322,7 +322,7 @@ export const CodeMirrorQueryInput: React.FunctionComponent<
                     history(),
                     themeExtension.of(EditorView.darkTheme.of(isLightTheme === false)),
                     parseInputAsQuery({ patternType, interpretComments }),
-                    queryDiagnostic,
+                    queryDiagnostic(),
                     // The precedence of these extensions needs to be decreased
                     // explicitly, otherwise the diagnostic indicators will be
                     // hidden behind the highlight background color
@@ -762,38 +762,58 @@ function getTokensTooltipInformation(
     return { tokensAtCursor, range, value: values.join('') }
 }
 
-// Hooks query diagnostics into the editor.
-// The facet stores the diagnostics data which is used by the text decoration
-// and the tooltip extensions.
-const queryDiagnostic: Extension = [
-    linter(
-        view => {
-            const query = view.state.facet(queryTokens)
-            return query.tokens.length > 0 ? getDiagnostics(query.tokens, query.patternType).map(toCMDiagnostic) : []
-        },
-        {
-            delay: 200,
-        }
-    ),
-    EditorView.theme({
-        '.cm-diagnosticText': {
-            display: 'block',
-        },
-        '.cm-diagnosticAction': {
-            color: 'var(--body-color)',
-            borderColor: 'var(--secondary)',
-            backgroundColor: 'var(--secondary)',
-            borderRadius: 'var(--border-radius)',
-            padding: 'var(--btn-padding-y-sm) .5rem',
-            fontSize: 'calc(min(0.75rem, 0.9166666667em))',
-            lineHeight: '1rem',
-            margin: '0.5rem 0 0 0',
-        },
-        '.cm-diagnosticAction + .cm-diagnosticAction': {
-            marginLeft: '1rem',
-        },
-    }),
-]
+/**
+ * Sets up client side query validation.
+ */
+function queryDiagnostic(): Extension {
+    // The setup is a bit "strange" because @codemirror/lint only triggers
+    // linting when the document changes. But in our case the linting rules
+    // change depending on the query "type" (regexp, structural, ...). Changing
+    // the query type does not involve changing the document and to linting
+    // wouldn't be triggered. To work around this we explictly reconfigure the
+    // linter via a compartment when the parsed query changes but the document
+    // hadsn't change. This queues a new linting pass.
+    // See
+    // - https://discuss.codemirror.net/t/can-we-manually-force-linting-even-if-the-document-hasnt-changed/3570/2
+    // - https://github.com/sourcegraph/sourcegraph/issues/43836
+    //
+    const source: LintSource = view => {
+        const query = view.state.facet(queryTokens)
+        return query.tokens.length > 0 ? getDiagnostics(query.tokens, query.patternType).map(toCMDiagnostic) : []
+    }
+    const config = {
+        delay: 200,
+    }
+
+    const linterCompartment = new Compartment()
+
+    return [
+        linterCompartment.of(linter(source, config)),
+        EditorView.updateListener.of(update => {
+            if (update.state.facet(queryTokens) !== update.startState.facet(queryTokens) && !update.docChanged) {
+                update.view.dispatch({ effects: linterCompartment.reconfigure(linter(source, config)) })
+            }
+        }),
+        EditorView.theme({
+            '.cm-diagnosticText': {
+                display: 'block',
+            },
+            '.cm-diagnosticAction': {
+                color: 'var(--body-color)',
+                borderColor: 'var(--secondary)',
+                backgroundColor: 'var(--secondary)',
+                borderRadius: 'var(--border-radius)',
+                padding: 'var(--btn-padding-y-sm) .5rem',
+                fontSize: 'calc(min(0.75rem, 0.9166666667em))',
+                lineHeight: '1rem',
+                margin: '0.5rem 0 0 0',
+            },
+            '.cm-diagnosticAction + .cm-diagnosticAction': {
+                marginLeft: '1rem',
+            },
+        }),
+    ]
+}
 
 function renderMarkdownNode(message: string): Element {
     const div = document.createElement('div')


### PR DESCRIPTION
Fixes #43836

This updates the CodeMirror query input to lint the input when the query parsing configuration has changed.



## Test plan

Manually tested the uses cases mentioned in the issue.

## App preview:

- [Web](https://sg-web-fkling-43836-query-diagnostics.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
