### PR TITLE
zoekt: search for 10k results in shard before ranking

### DIFF
--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -113,7 +113,7 @@ func (o *Options) ToSearch(ctx context.Context) *zoekt.SearchOptions {
 		// It is hard to think up general stats here based on limit. So
 		// instead we only run the ranking code path if the limit is
 		// reasonably small. This is fine while we experiment.
-		searchOpts.ShardMaxMatchCount = 1_000
+		searchOpts.ShardMaxMatchCount = 10_000
 		searchOpts.TotalMaxMatchCount = 100_000
 		searchOpts.MaxDocDisplayCount = limit
 		searchOpts.FlushWallTime = 500 * time.Millisecond


### PR DESCRIPTION
1k is way too low, and I believe is leading to bad results for queries like "Worker" where we can have that phrase appear over 1k times in one file (mock gen!).

In the future we may want to introduce a DocMaxMatchCount. Also this is my last PR with a manual tweak, next time I want to do this I'll introduce a way to do this via config.

Test Plan: go test