### PR TITLE
Avoid session deletion when sessionstore host can't be found

### DIFF
--- a/cmd/frontend/internal/session/session.go
+++ b/cmd/frontend/internal/session/session.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/textproto"
 	"strings"
@@ -359,7 +360,7 @@ func authenticateByCookie(logger log.Logger, db database.DB, r *http.Request, w 
 
 	var info *sessionInfo
 	if err := GetData(r, "actor", &info); err != nil {
-		if strings.Contains(err.Error(), "connect: connection refused") {
+		if errors.HasType(err, &net.OpError{}) {
 			// If fetching session info failed because of a Redis error, return empty Context
 			// without deleting the session cookie and throw an internal server error.
 			// This prevents background requests made by off-screen tabs from signing


### PR DESCRIPTION
The previous check was specific to "connection refused" errors. But it's possible that the connection fails due to other network errors too, such as "dial tcp: lookup horsegraph: no such host".

In those cases we also don't want to delete the session.

So what I did here is to make the check less specific and check for `net.OpError`. That catches both errors and more.

## Test plan

- Manual testing by logging in to local instance, turning off redis, reloading
- Manual testing by logging in to local instance, changing redis host name, checking for error on boot, confirming it's `net.OpError`