### PR TITLE
go.mod: bump zoekt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -228,7 +228,7 @@ require (
 )
 
 require (
-	github.com/sourcegraph/zoekt v0.0.0-20221102142945-42b609c769a8
+	github.com/sourcegraph/zoekt v0.0.0-20221103094912-9eb454fb3c74
 	github.com/stretchr/objx v0.4.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2118,8 +2118,6 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20221102142945-42b609c769a8 h1:GbtSr/KkxJyL0rx1OSX3hVhxxGh6Fj9l6RBxJiA28wA=
-github.com/sourcegraph/zoekt v0.0.0-20221102142945-42b609c769a8/go.mod h1:jieuX0Y1il24xoxONSDhkbDtXB/8cf1ZC5bbJVGtVRI=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/go.sum
+++ b/go.sum
@@ -2118,6 +2118,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
+github.com/sourcegraph/zoekt v0.0.0-20221103094912-9eb454fb3c74 h1:Q0RXiMQRSGQYVKf+UxsuOKzlu3cNZnfsACJtYOeDhqc=
+github.com/sourcegraph/zoekt v0.0.0-20221103094912-9eb454fb3c74/go.mod h1:jieuX0Y1il24xoxONSDhkbDtXB/8cf1ZC5bbJVGtVRI=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
9eb454f disable shellcheck for pipefail
52deedb Only set FileMatch.Ranks if UseDocumentRanks is true cf7fece ranking: boost Go interfaces
9ed8b09 run ranking inside of shard
325f843 docker: fix ctags build behind http proxy
a4728c3 GetEnv time duration
42b609c ranking: boost cpp matches based on kind
ea05daa Send index status to Sourcegraph once repo is indexed
fb9c22b indexserver: backoff repo if failing repeatedly

## Test plan
Zoekt-CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
