### PR TITLE
featureflag: add per request overrides

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -29,21 +29,26 @@
 ## [2.0.2]
 
 ### Added
+
 - Added feature to specify auth headers [pull/42692](https://github.com/sourcegraph/sourcegraph/pull/42692)
 
 ### Removed
+
 - Removed tracking parameters from all shareable URLs [pull/42022](https://github.com/sourcegraph/sourcegraph/pull/42022)
 
 ### Fixed
+
 - Remove pointer cursor in the web view. [pull/41845](https://github.com/sourcegraph/sourcegraph/pull/41845)
 - Updated “Learn more” URL to link the blog post in the update notification [pull/41846](https://github.com/sourcegraph/sourcegraph/pull/41846)
 - Made the plugin compatible with versions 3.42.0 and below [pull/42105](https://github.com/sourcegraph/sourcegraph/pull/42105)
 
 ## [2.0.1]
+
 - Improve Fedora Linux compatibility: Using `BrowserUtil.browse()` rather than `Desktop.getDesktop().browse()` to open
   links in the browser.
 
 ## [2.0.0]
+
 - Added a new UI to search with Sourcegraph from inside the IDE. Open it with <kbd>Alt+S</kbd> (<kbd>⌥S</kbd> on Mac) by
   default.
 - Added a settings UI to conveniently configure the plugin
@@ -52,22 +57,27 @@
   at [https://github.com/sourcegraph/sourcegraph/tree/main/client/jetbrains](https://github.com/sourcegraph/sourcegraph/tree/main/client/jetbrains)
 
 ## [1.2.4]
+
 - Fixed an issue that prevent the latest version of the plugin to work with JetBrains 2022.1 products.
 
 ## [1.2.3]
+
 - Upgrade JetBrains IntelliJ shell to 1.3.1 and modernize the build and release pipeline.
 
 ## [1.2.2] - Minor bug fixes
+
 - It is now possible to configure the plugin per-repository using a `.idea/sourcegraph.xml` file. See the README for details.
 - Special thanks: @oliviernotteghem for contributing the new features in this release!
 - Fixed bugs where Open in Sourcegraph from the git menu does not work for repos with ssh url as their remote url
 
 ## [1.2.1] - Open Revision in Sourcegraph
+
 - Added "Open In Sourcegraph" action to VCS History and Git Log to open a revision in the Sourcegraph diff view.
 - Added "defaultBranch" configuration option that allows opening files in a specific branch on Sourcegraph.
 - Added "remoteUrlReplacements" configuration option that allow users to replace specified values in the remote url with new strings.
 
 ## [1.2.0] - Copy link to file, search in repository, per-repository configuration, bug fixes & more
+
 - The search menu entry is now no longer present when no text has been selected.
 - When on a branch that does not exist remotely, `master` will now be used instead.
 - Menu entries (Open file, etc.) are now under a Sourcegraph sub-menu.
@@ -77,14 +87,18 @@
 - Special thanks: @oliviernotteghem for contributing the new features in this release!
 
 ## [1.1.2] - Minor bug fixes around searching.
+
 - Fixed an error that occurred when trying to search with no selection.
 - The git remote used for repository detection is now `sourcegraph` and then `origin`, instead of the previously poor choice of just the first git remote.
 
 ## [1.1.1] - Fixed search shortcut
+
 - Updated the search URL to reflect a recent Sourcegraph.com change.
 
 ## [1.1.0] - Configurable Sourcegraph URL
+
 - Added support for using the plugin with on-premises Sourcegraph instances.
 
 ## [1.0.0] - Initial Release
+
 - Basic Open File & Search functionality.

--- a/client/jetbrains/CONTRIBUTING.md
+++ b/client/jetbrains/CONTRIBUTING.md
@@ -4,7 +4,6 @@ Thank you for your interest in contributing to Sourcegraph!
 The goal of this document is to provide a high-level overview of how you can contribute to the Sourcegraph JetBrains Extension.
 Please refer to our [main CONTRIBUTING](https://github.com/sourcegraph/sourcegraph/blob/main/CONTRIBUTING.md) docs for general information regarding contributing to any Sourcegraph feature.
 
-
 ## License
 
 Apache
@@ -35,8 +34,8 @@ The publishing process is based on the [intellij-platform-plugin-template](https
 ### Publishing from your local machine
 
 1. Update `pluginVersion` in `gradle.properties`
- 
-    - To create pre-release builds with the same version as a previous one, append `.{N}`. For example, `1.0.0-alpha`, then `1.0.0-alpha.1`, `1.0.0-alpha.2`, and so on.
+
+   - To create pre-release builds with the same version as a previous one, append `.{N}`. For example, `1.0.0-alpha`, then `1.0.0-alpha.1`, `1.0.0-alpha.2`, and so on.
 
 2. Describe the changes in the `[Unreleased]` section of `client/jetbrains/CHANGELOG.md` then remove any empty headers
 3. Go through

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -435,7 +435,7 @@ export interface StreamSearchOptions {
     patternType: SearchPatternType
     caseSensitive: boolean
     trace: string | undefined
-    featureOverrides: string[]
+    featureOverrides?: string[]
     searchMode?: SearchMode
     sourcegraphURL?: string
     decorationKinds?: string[]
@@ -478,7 +478,7 @@ function initiateSearchStream(
         if (trace) {
             parameters.push(['trace', trace])
         }
-        for (const v of featureOverrides) {
+        for (const v of featureOverrides || []) {
             parameters.push(['feat', v])
         }
         const parameterEncoded = parameters.map(([k, v]) => k + '=' + encodeURIComponent(v)).join('&')

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -435,6 +435,7 @@ export interface StreamSearchOptions {
     patternType: SearchPatternType
     caseSensitive: boolean
     trace: string | undefined
+    featureOverrides: string[]
     searchMode?: SearchMode
     sourcegraphURL?: string
     decorationKinds?: string[]
@@ -450,6 +451,7 @@ function initiateSearchStream(
         patternType,
         caseSensitive,
         trace,
+        featureOverrides,
         decorationKinds,
         decorationContextLines,
         searchMode = SearchMode.Precise,
@@ -475,6 +477,9 @@ function initiateSearchStream(
         ]
         if (trace) {
             parameters.push(['trace', trace])
+        }
+        for (const v of featureOverrides) {
+            parameters.push(['feat', v])
         }
         const parameterEncoded = parameters.map(([k, v]) => k + '=' + encodeURIComponent(v)).join('&')
 

--- a/client/web/src/api/ApiConsole.tsx
+++ b/client/web/src/api/ApiConsole.tsx
@@ -247,6 +247,9 @@ export class ApiConsole extends React.PureComponent<Props, State> {
         if (searchParameters.get('trace') === '1') {
             headers.set('x-sourcegraph-should-trace', 'true')
         }
+        for (const feature of searchParameters.getAll('feat')) {
+            headers.append('x-sourcegraph-override-feature', feature)
+        }
         const response = await fetch('/.api/graphql', {
             method: 'POST',
             body: JSON.stringify(graphQLParameters),

--- a/client/web/src/backend/graphql.ts
+++ b/client/web/src/backend/graphql.ts
@@ -1,5 +1,6 @@
 import { memoize } from 'lodash'
 import { Observable } from 'rxjs'
+
 import { getGraphQLClient, GraphQLResult, requestGraphQLCommon } from '@sourcegraph/http-client'
 import * as GQL from '@sourcegraph/shared/src/schema'
 

--- a/client/web/src/backend/graphql.ts
+++ b/client/web/src/backend/graphql.ts
@@ -1,15 +1,25 @@
 import { memoize } from 'lodash'
+import { Headers } from 'node-fetch'
 import { Observable } from 'rxjs'
 
 import { getGraphQLClient, GraphQLResult, requestGraphQLCommon } from '@sourcegraph/http-client'
 import * as GQL from '@sourcegraph/shared/src/schema'
 
-const getHeaders = (): { [header: string]: string } => ({
-    ...window?.context?.xhrHeaders,
-    Accept: 'application/json',
-    'Content-Type': 'application/json',
-    'X-Sourcegraph-Should-Trace': new URLSearchParams(window.location.search).get('trace') || 'false',
-})
+const getHeaders = (): Headers => {
+    const headers = new Headers({
+        ...window?.context?.xhrHeaders,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+    })
+    const searchParameters = new URLSearchParams(window.location.search)
+    if (searchParameters.get('trace') === '1') {
+        headers.set('X-Sourcegraph-Should-Trace', 'true')
+    }
+    for (const feature of searchParameters.getAll('feat')) {
+        headers.append('X-Sourcegraph-Override-Feature', feature)
+    }
+    return headers
+}
 
 /**
  * Does a GraphQL request to the Sourcegraph GraphQL API running under `/.api/graphql`

--- a/client/web/src/backend/graphql.ts
+++ b/client/web/src/backend/graphql.ts
@@ -1,7 +1,5 @@
 import { memoize } from 'lodash'
-import { Headers } from 'node-fetch'
 import { Observable } from 'rxjs'
-
 import { getGraphQLClient, GraphQLResult, requestGraphQLCommon } from '@sourcegraph/http-client'
 import * as GQL from '@sourcegraph/shared/src/schema'
 

--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -96,7 +96,6 @@ export const SearchConsolePage: React.FunctionComponent<React.PropsWithChildren<
         ],
         [searchQuery, triggerSearch, autocompletion]
     )
-
     // Fetch search results when the `q` URL query parameter changes
     const results = useObservable(
         useMemo(

--- a/client/web/src/search/helpers.tsx
+++ b/client/web/src/search/helpers.tsx
@@ -11,7 +11,7 @@ import { AGGREGATION_MODE_URL_KEY, AGGREGATION_UI_MODE_URL_KEY } from './results
  * This breaks all functionality that is built on top of URL query params and history
  * state. This list of query keys will be preserved between searches.
  */
-const PRESERVED_QUERY_PARAMETERS = ['trace', AGGREGATION_MODE_URL_KEY, AGGREGATION_UI_MODE_URL_KEY]
+const PRESERVED_QUERY_PARAMETERS = ['feat', 'trace', AGGREGATION_MODE_URL_KEY, AGGREGATION_UI_MODE_URL_KEY]
 
 /**
  * @param activation If set, records the DidSearch activation event for the new user activation
@@ -38,13 +38,16 @@ export function submitSearch({
     const existingParameters = new URLSearchParams(history.location.search)
 
     for (const key of PRESERVED_QUERY_PARAMETERS) {
-        const queryParameter = existingParameters.get(key)
-
-        if (queryParameter !== null) {
-            const parameters = new URLSearchParams(searchQueryParameter)
-            parameters.set(key, queryParameter)
-            searchQueryParameter = parameters.toString()
+        const values = existingParameters.getAll(key)
+        if (values.length === 0) {
+            continue
         }
+        const parameters = new URLSearchParams(searchQueryParameter)
+        parameters.delete(key)
+        for (const value of values) {
+            parameters.set(key, value)
+        }
+        searchQueryParameter = parameters.toString()
     }
 
     // Go to search results page

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -120,6 +120,7 @@ describe('StreamingSearchResults', () => {
             searchMode: SearchMode.Precise,
             trace: undefined,
             chunkMatches: true,
+            featureOverrides: [],
         })
     })
 

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -96,6 +96,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
     const extensionHostAPI =
         extensionsController !== null && window.context.enableLegacyExtensions ? extensionsController.extHostAPI : null
     const trace = useMemo(() => new URLSearchParams(location.search).get('trace') ?? undefined, [location.search])
+    const featureOverrides = useMemo(() => new URLSearchParams(location.search).getAll('feat') ?? [], [location.search])
 
     const options: StreamSearchOptions = useMemo(
         () => ({
@@ -103,10 +104,11 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
             patternType: patternType ?? SearchPatternType.standard,
             caseSensitive,
             trace,
+            featureOverrides,
             searchMode: patternType === SearchPatternType.lucky ? SearchMode.SmartSearch : searchMode,
             chunkMatches: true,
         }),
-        [caseSensitive, patternType, searchMode, trace]
+        [caseSensitive, patternType, searchMode, trace, featureOverrides]
     )
 
     const results = useCachedSearchResults(streamSearch, submittedURLQuery, options, extensionHostAPI, telemetryService)

--- a/internal/featureflag/middleware.go
+++ b/internal/featureflag/middleware.go
@@ -21,7 +21,16 @@ type Store interface {
 func Middleware(ffs Store, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Vary", "Cookie")
-		next.ServeHTTP(w, r.WithContext(WithFlags(r.Context(), ffs)))
+
+		store := ffs
+		if flags, ok := requestOverrides(r); ok {
+			store = &overrideStore{
+				store: ffs,
+				flags: flags,
+			}
+		}
+
+		next.ServeHTTP(w, r.WithContext(WithFlags(r.Context(), store)))
 	})
 }
 

--- a/internal/featureflag/override.go
+++ b/internal/featureflag/override.go
@@ -1,0 +1,78 @@
+package featureflag
+
+import (
+	"context"
+	"net/http"
+	"strings"
+)
+
+const (
+	overrideHeader        = "X-Sourcegraph-Override-Feature"
+	overrideQuery         = "feat"
+	overrideQueryContains = overrideQuery + "="
+)
+
+// requestWantsTrace returns true if a request is opting into tracing either
+// via our HTTP Header or our URL Query.
+func requestOverrides(r *http.Request) (flags map[string]bool, ok bool) {
+	// Prefer header over query param.
+	values := r.Header.Values(overrideHeader)
+
+	// PERF: Avoid parsing RawQuery if "feat=" is not present.
+	if len(values) == 0 && strings.Contains(r.URL.RawQuery, overrideQueryContains) {
+		values = r.URL.Query()[overrideQuery]
+	}
+
+	if len(values) == 0 {
+		return nil, false
+	}
+
+	flags = make(map[string]bool, len(values))
+	for _, k := range values {
+		// flags starting with "-" override to false
+		v := !strings.HasPrefix(k, "-")
+		k = strings.TrimPrefix(k, "-")
+		flags[k] = v
+	}
+
+	return flags, true
+}
+
+// overrideStore will override the returned feature flags in memory.
+//
+// Note: this is different to overrides in the feature flag DB, which persists
+// overrides. This is intended to override feature flags for a request.
+type overrideStore struct {
+	store Store
+	flags map[string]bool
+}
+
+func (s *overrideStore) GetUserFlags(ctx context.Context, userID int32) (map[string]bool, error) {
+	return s.override(s.store.GetUserFlags(ctx, userID))
+}
+
+func (s *overrideStore) GetAnonymousUserFlags(ctx context.Context, anonUID string) (map[string]bool, error) {
+	return s.override(s.store.GetAnonymousUserFlags(ctx, anonUID))
+}
+func (s *overrideStore) GetGlobalFeatureFlags(ctx context.Context) (map[string]bool, error) {
+	return s.override(s.store.GetGlobalFeatureFlags(ctx))
+}
+
+func (s *overrideStore) override(flags map[string]bool, err error) (map[string]bool, error) {
+	if err != nil {
+		return nil, err
+	}
+
+	// Avoid mutating flags just in case s.store returns a cached copy.
+	override := make(map[string]bool, len(flags))
+	for k, v := range flags {
+		override[k] = v
+	}
+
+	// Now apply overrides potentially adding or updating feature flags.
+	for k, v := range s.flags {
+		override[k] = v
+	}
+
+	return override, nil
+}

--- a/internal/featureflag/override_test.go
+++ b/internal/featureflag/override_test.go
@@ -1,0 +1,171 @@
+package featureflag
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func TestOverrides(t *testing.T) {
+	setupRedisTest(t)
+
+	mockStore := NewMockStore()
+	mockStore.GetUserFlagsFunc.SetDefaultHook(func(_ context.Context, uid int32) (map[string]bool, error) {
+		if uid != 123 {
+			return nil, errors.New("BOOM")
+		}
+		return map[string]bool{
+			"feat-true":  true,
+			"feat-false": false,
+			"user":       true,
+		}, nil
+	})
+	mockStore.GetAnonymousUserFlagsFunc.SetDefaultHook(func(_ context.Context, anonUID string) (map[string]bool, error) {
+		if anonUID != "123" {
+			return nil, errors.New("BOOM")
+		}
+		return map[string]bool{
+			"feat-true":  true,
+			"feat-false": false,
+			"anon":       true,
+		}, nil
+	})
+	mockStore.GetGlobalFeatureFlagsFunc.SetDefaultHook(func(_ context.Context) (map[string]bool, error) {
+		return map[string]bool{
+			"feat-true":  true,
+			"feat-false": false,
+			"global":     true,
+		}, nil
+	})
+
+	handler := Middleware(mockStore, http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(FromContext(r.Context()).flags)
+	})))
+
+	cases := []struct {
+		Name     string
+		Header   []string
+		RawQuery string
+		Want     map[string]bool
+	}{{
+		Name: "unset",
+		Want: map[string]bool{
+			"feat-true":  true,
+			"feat-false": false,
+		},
+	}, {
+		Name:   "header-true",
+		Header: []string{"feat-false"},
+		Want: map[string]bool{
+			"feat-true":  true,
+			"feat-false": true,
+		},
+	}, {
+		Name:   "header-false",
+		Header: []string{"-feat-true"},
+		Want: map[string]bool{
+			"feat-true":  false,
+			"feat-false": false,
+		},
+	}, {
+		Name:   "header-multiple",
+		Header: []string{"feat-false", "-new-false", "new-true"},
+		Want: map[string]bool{
+			"feat-true":  true,
+			"feat-false": true,
+			"new-false":  false,
+			"new-true":   true,
+		},
+	}, {
+		Name:     "query-true",
+		RawQuery: "feat=feat-false",
+		Want: map[string]bool{
+			"feat-true":  true,
+			"feat-false": true,
+		},
+	}, {
+		Name:     "query-false",
+		RawQuery: "feat=-feat-true",
+		Want: map[string]bool{
+			"feat-true":  false,
+			"feat-false": false,
+		},
+	}, {
+		Name:     "query-multiple",
+		RawQuery: "feat=feat-false&feat=-new-false&feat=new-true",
+		Want: map[string]bool{
+			"feat-true":  true,
+			"feat-false": true,
+			"new-false":  false,
+			"new-true":   true,
+		},
+	}, {
+		Name:     "prefer-header",
+		Header:   []string{"header"},
+		RawQuery: "feat=query",
+		Want: map[string]bool{
+			"feat-true":  true,
+			"feat-false": false,
+			"header":     true,
+		},
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			run := func(act *actor.Actor) map[string]bool {
+				t.Helper()
+
+				req, err := http.NewRequest(http.MethodGet, "/test?"+tc.RawQuery, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				req = req.WithContext(actor.WithActor(context.Background(), act))
+				if tc.Header != nil {
+					req.Header["X-Sourcegraph-Override-Feature"] = tc.Header
+				}
+
+				w := httptest.NewRecorder()
+				handler.ServeHTTP(w, req)
+
+				var flags map[string]bool
+				err = json.NewDecoder(w.Result().Body).Decode(&flags)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return flags
+			}
+
+			got := run(actor.FromUser(123))
+			want := flagsWithKey(tc.Want, "user")
+			if d := cmp.Diff(want, got); d != "" {
+				t.Errorf("unexpected flags for user (-want, +got):\n%s", d)
+			}
+
+			got = run(actor.FromAnonymousUser("123"))
+			want = flagsWithKey(tc.Want, "anon")
+			if d := cmp.Diff(want, got); d != "" {
+				t.Errorf("unexpected flags for anonymous (-want, +got):\n%s", d)
+			}
+
+			got = run(&actor.Actor{})
+			want = flagsWithKey(tc.Want, "global")
+			if d := cmp.Diff(want, got); d != "" {
+				t.Errorf("unexpected flags for global (-want, +got):\n%s", d)
+			}
+		})
+	}
+}
+
+func flagsWithKey(flags map[string]bool, key string) map[string]bool {
+	m := map[string]bool{key: true}
+	for k, v := range flags {
+		m[k] = v
+	}
+	return m
+}

--- a/package.json
+++ b/package.json
@@ -306,7 +306,6 @@
     "mockdate": "^3.0.2",
     "monaco-editor-webpack-plugin": "^3.1.0",
     "mz": "^2.7.0",
-    "node-fetch": "^2.6.7",
     "nyc": "^15.1.0",
     "octokit": "^2.0.7",
     "open": "^7.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28853,7 +28853,6 @@ pvutils@latest:
     monaco-yaml: ^3.2.1
     mz: ^2.7.0
     nice-ticks: ^1.0.1
-    node-fetch: ^2.6.7
     nyc: ^15.1.0
     octokit: ^2.0.7
     open: ^7.0.4


### PR DESCRIPTION
This is inspired by our ?trace=1 query parameter, except for featureflags in a request. I want to quickly toggle a feature flag to compare before and after.

I had behaviour like this at FB, except it was a more general topic called cheat codes which worked across many systems. We should probably invest in that as well, but for now this will make it quick to toggle boolean values in our codebase.

Test Plan: unit tests added and added logging of feature flags in the flag fetcher. Then visited my devserver with "?feat=hello&feat=-world" and observed hello being set and world being unset.
