### PR TITLE
Code Insights: Fix code insights api memoization

### DIFF
--- a/client/web/src/enterprise/insights/hooks/use-api.ts
+++ b/client/web/src/enterprise/insights/hooks/use-api.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { useApolloClient } from '@apollo/client'
 
 import { CodeInsightsBackend, CodeInsightsGqlBackend } from '../core'
@@ -9,5 +11,5 @@ import { CodeInsightsBackend, CodeInsightsGqlBackend } from '../core'
 export function useApi(): CodeInsightsBackend {
     const apolloClient = useApolloClient()
 
-    return new CodeInsightsGqlBackend(apolloClient)
+    return useMemo(() => new CodeInsightsGqlBackend(apolloClient), [apolloClient])
 }


### PR DESCRIPTION
## Background
Prior to this PR, we assumed (wrongly) that there are no react tree updates on the very high level of code insights UI components. Because of this, we didn't add a memoisation lever over our Code Insights API class. Recreation of this class on every react tree call triggers updates all over the place in the code insight app. For example, this happens when we trigger the theme switch.

| Before | After |
| ------- | ------ |
| <video src="https://user-images.githubusercontent.com/18492575/199804253-4169accd-0f4d-45de-ae2a-75b18aa9b94d.mov" /> | <video src="https://user-images.githubusercontent.com/18492575/199804220-9680dab9-af45-418c-a3dc-2cd9bd2e6deb.mov" /> |

## Test plan
- Open the dashboard page and switch the theme 
- See that you have a different theme, but all fetch components weren't triggered

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-code-memoization.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
