### PR TITLE
Search: do not highlight paths when selecting content

### DIFF
--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -102,6 +102,7 @@ func (fm *FileMatch) Select(selectPath filter.SelectPath) Match {
 		// Only return file match if line matches exist
 		if len(fm.ChunkMatches) > 0 {
 			fm.Symbols = nil
+			fm.PathMatches = nil
 			return fm
 		}
 		return nil

--- a/internal/search/result/match_test.go
+++ b/internal/search/result/match_test.go
@@ -15,26 +15,38 @@ import (
 
 func TestSelect(t *testing.T) {
 	t.Run("FileMatch", func(t *testing.T) {
-		data := &FileMatch{
-			Symbols: []*SymbolMatch{
-				{Symbol: Symbol{Name: "a()", Kind: "func"}},
-				{Symbol: Symbol{Name: "b()", Kind: "function"}},
-				{Symbol: Symbol{Name: "var c", Kind: "variable"}},
-			},
-		}
-
-		test := func(input string) string {
-			selectPath, _ := filter.SelectPathFromString(input)
-			symbols := data.Select(selectPath).(*FileMatch).Symbols
-			var values []string
-			for _, s := range symbols {
-				values = append(values, s.Symbol.Name+":"+s.Symbol.Kind)
+		t.Run("symbols", func(t *testing.T) {
+			data := &FileMatch{
+				Symbols: []*SymbolMatch{
+					{Symbol: Symbol{Name: "a()", Kind: "func"}},
+					{Symbol: Symbol{Name: "b()", Kind: "function"}},
+					{Symbol: Symbol{Name: "var c", Kind: "variable"}},
+				},
 			}
-			return strings.Join(values, ", ")
-		}
 
-		autogold.Want("filter any symbol", "a():func, b():function, var c:variable").Equal(t, test("symbol"))
-		autogold.Want("filter symbol kind variable", "var c:variable").Equal(t, test("symbol.variable"))
+			test := func(input string) string {
+				selectPath, _ := filter.SelectPathFromString(input)
+				symbols := data.Select(selectPath).(*FileMatch).Symbols
+				var values []string
+				for _, s := range symbols {
+					values = append(values, s.Symbol.Name+":"+s.Symbol.Kind)
+				}
+				return strings.Join(values, ", ")
+			}
+
+			autogold.Want("filter any symbol", "a():func, b():function, var c:variable").Equal(t, test("symbol"))
+			autogold.Want("filter symbol kind variable", "var c:variable").Equal(t, test("symbol.variable"))
+		})
+
+		t.Run("path match", func(t *testing.T) {
+			fm := &FileMatch{
+				PathMatches:  []Range{{}},
+				ChunkMatches: []ChunkMatch{{}},
+			}
+
+			selected := fm.Select([]string{filter.Content})
+			require.Empty(t, selected.(*FileMatch).PathMatches)
+		})
 	})
 
 	t.Run("CommitMatch", func(t *testing.T) {


### PR DESCRIPTION
This updates our select:content logic to remove any path match ranges since select:content indicates that the user is only interested in the content part of the search results.

## Test plan

Unit test and manual test

<img width="1040" alt="Screen Shot 2022-11-03 at 12 55 27" src="https://user-images.githubusercontent.com/12631702/199809978-a0f5a0de-b15b-40e6-bc2c-4dc085dad850.png">
