### PR TITLE
Omit sensitive query parameters when logging auth errors.

### DIFF
--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -196,10 +196,17 @@ func HTTPMiddleware(logger log.Logger, next http.Handler, siteConfig conftypes.S
 
 		if m.Code >= minCode || m.Duration >= minDuration {
 			fields := make([]log.Field, 0, 10)
+
+			var url string
+			if strings.Contains(r.URL.Path, ".auth") {
+				url = r.URL.Path // omit sensitive query params
+			} else {
+				url = r.URL.String()
+			}
 			fields = append(fields,
 				log.String("route_name", fullRouteTitle),
 				log.String("method", r.Method),
-				log.String("url", truncate(r.URL.String(), 100)),
+				log.String("url", truncate(url, 100)),
 				log.Int("code", m.Code),
 				log.Duration("duration", m.Duration),
 				log.Bool("shouldTrace", policy.ShouldTrace(ctx)),


### PR DESCRIPTION
Omit sensitive query parameters when logging auth errors.

## Test plan

See before & after shots.

**Before**
![error_params](https://user-images.githubusercontent.com/3193149/199824061-2ce9cb24-bd3b-4c4e-b94f-6a7613bb3162.png)

**After**
<img width="1703" alt="error_noparams" src="https://user-images.githubusercontent.com/3193149/199824092-8f9b52a0-2361-4f7f-b7ce-99de48137008.png">
