### PR TITLE
commit page: migrate to use apollo

### DIFF
--- a/client/web/src/integration/commit-page.test.ts
+++ b/client/web/src/integration/commit-page.test.ts
@@ -328,7 +328,7 @@ describe('RepositoryCommitPage', () => {
     afterEachSaveScreenshotIfFailed(() => driver.page)
     afterEach(() => testContext?.dispose())
 
-    it.only('Display diff in unified mode', async () => {
+    it('Display diff in unified mode', async () => {
         await driver.page.goto(`${driver.sourcegraphBaseUrl}/${repositoryName}/-/commit/${commitID}`)
         await driver.page.waitForSelector('.test-file-diff-node', { visible: true })
 

--- a/client/web/src/integration/commit-page.test.ts
+++ b/client/web/src/integration/commit-page.test.ts
@@ -1,3 +1,5 @@
+import { subDays } from 'date-fns'
+
 import {
     DiffHunkLineType,
     ExternalServiceKind,
@@ -16,6 +18,7 @@ import { percySnapshotWithVariants } from './utils'
 describe('RepositoryCommitPage', () => {
     const repositoryName = 'github.com/sourcegraph/sourcegraph'
     const commitID = '1e7bd000e78cf35c6e1be1b9f1510b4aadfaa416'
+    const commitDate = subDays(new Date(), 7).toISOString()
     const commonBlobGraphQlResults: Partial<WebGraphQlOperations & SharedGraphQlOperations> = {
         ...commonWebGraphQlResults,
         RepositoryCommit: () => ({
@@ -46,7 +49,7 @@ describe('RepositoryCommitPage', () => {
                                 displayName: 'Becca Steinbrecher',
                             },
                         },
-                        date: '2022-10-27T21:31:53Z',
+                        date: commitDate,
                     },
                     committer: {
                         __typename: 'Signature',
@@ -58,7 +61,7 @@ describe('RepositoryCommitPage', () => {
                             displayName: 'GitHub',
                             user: null,
                         },
-                        date: '2022-10-27T21:31:53Z',
+                        date: commitDate,
                     },
                     parents: [
                         {

--- a/client/web/src/integration/commit-page.test.ts
+++ b/client/web/src/integration/commit-page.test.ts
@@ -31,12 +31,15 @@ describe('RepositoryCommitPage', () => {
                     subject: 'Signup copy adjustment (#43435)',
                     body: 'Copy adjustment',
                     author: {
+                        __typename: 'Signature',
                         person: {
+                            __typename: 'Person',
                             avatarURL: null,
                             name: 'st0nebraker',
                             email: 'beccasteinbrecher@gmail.com',
                             displayName: 'Becca Steinbrecher',
                             user: {
+                                __typename: 'User',
                                 id: 'VXNlcjo1MTA5OQ==',
                                 username: 'st0nebraker',
                                 url: '/users/st0nebraker',
@@ -46,7 +49,9 @@ describe('RepositoryCommitPage', () => {
                         date: '2022-10-27T21:31:53Z',
                     },
                     committer: {
+                        __typename: 'Signature',
                         person: {
+                            __typename: 'Person',
                             avatarURL: null,
                             name: 'GitHub',
                             email: 'noreply@github.com',
@@ -57,6 +62,7 @@ describe('RepositoryCommitPage', () => {
                     },
                     parents: [
                         {
+                            __typename: 'GitCommit',
                             oid: '56ab377d94fe96c87bc8c5e26675c585f9312e64',
                             abbreviatedOID: '56ab377',
                             url:
@@ -68,12 +74,14 @@ describe('RepositoryCommitPage', () => {
                         '/github.com/sourcegraph/sourcegraph/-/commit/1e7bd000e78cf35c6e1be1b9f1510b4aadfaa416',
                     externalURLs: [
                         {
+                            __typename: 'ExternalLink',
                             url:
                                 'https://github.com/sourcegraph/sourcegraph/commit/1e7bd000e78cf35c6e1be1b9f1510b4aadfaa416',
                             serviceKind: ExternalServiceKind.GITHUB,
                         },
                     ],
                     tree: {
+                        __typename: 'GitTree',
                         canonicalURL: '/github.com/sourcegraph/sourcegraph@1e7bd000e78cf35c6e1be1b9f1510b4aadfaa416',
                     },
                 },
@@ -320,7 +328,7 @@ describe('RepositoryCommitPage', () => {
     afterEachSaveScreenshotIfFailed(() => driver.page)
     afterEach(() => testContext?.dispose())
 
-    it('Display diff in unified mode', async () => {
+    it.only('Display diff in unified mode', async () => {
         await driver.page.goto(`${driver.sourcegraphBaseUrl}/${repositoryName}/-/commit/${commitID}`)
         await driver.page.waitForSelector('.test-file-diff-node', { visible: true })
 

--- a/client/web/src/integration/graphQlResults.ts
+++ b/client/web/src/integration/graphQlResults.ts
@@ -211,4 +211,13 @@ export const commonWebGraphQlResults: Partial<
         },
         savedSearches: savedSearchesPayload(),
     }),
+    SearchHistoryEventLogsQuery: () => ({
+        currentUser: {
+            __typename: 'User',
+            recentSearchLogs: {
+                __typename: 'EventLogsConnection',
+                nodes: [],
+            },
+        },
+    }),
 }

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -281,7 +281,9 @@ describe('Repository', () => {
                             subject: 'update LSIF indexing CI workflow',
                             body: null,
                             author: {
+                                __typename: 'Signature',
                                 person: {
+                                    __typename: 'Person',
                                     avatarURL: '',
                                     name: 'garo (they/them)',
                                     email: 'gbrik@users.noreply.github.com',
@@ -291,7 +293,9 @@ describe('Repository', () => {
                                 date: '2020-04-29T18:40:54Z',
                             },
                             committer: {
+                                __typename: 'Signature',
                                 person: {
+                                    __typename: 'Person',
                                     avatarURL: '',
                                     name: 'GitHub',
                                     email: 'noreply@github.com',
@@ -302,12 +306,14 @@ describe('Repository', () => {
                             },
                             parents: [
                                 {
+                                    __typename: 'GitCommit',
                                     oid: '96c4efab7ee28f3d1cf1d248a0139cea37368b18',
                                     abbreviatedOID: '96c4efa',
                                     url:
                                         '/github.com/sourcegraph/jsonrpc2/-/commit/96c4efab7ee28f3d1cf1d248a0139cea37368b18',
                                 },
                                 {
+                                    __typename: 'GitCommit',
                                     oid: '9e615b1c32cc519130575e8d10d0d0fee8a5eb6c',
                                     abbreviatedOID: '9e615b1',
                                     url:
@@ -318,12 +324,14 @@ describe('Repository', () => {
                             canonicalURL: commitUrl,
                             externalURLs: [
                                 {
+                                    __typename: 'ExternalLink',
                                     url:
                                         'https://github.com/sourcegraph/jsonrpc2/commit/15c2290dcb37731cc4ee5a2a1c1e5a25b4c28f81',
                                     serviceKind: ExternalServiceKind.GITHUB,
                                 },
                             ],
                             tree: {
+                                __typename: 'GitTree',
                                 canonicalURL:
                                     '/github.com/sourcegraph/jsonrpc2@15c2290dcb37731cc4ee5a2a1c1e5a25b4c28f81',
                             },

--- a/client/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/client/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -55,7 +55,7 @@ const COMMIT_QUERY = gql`
             __typename
             ... on Repository {
                 commit(rev: $revspec) {
-                    __typename # necessary so that isErrorLike(x) is false when x: GitCommitFields
+                    __typename # Necessary for error handling to check if commit exists
                     ...GitCommitFields
                 }
             }

--- a/client/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/client/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -3,13 +3,13 @@ import React, { useMemo, useCallback, useEffect } from 'react'
 import classNames from 'classnames'
 import { RouteComponentProps } from 'react-router'
 import { Observable, ReplaySubject, Subject } from 'rxjs'
-import { catchError, filter, map, withLatestFrom } from 'rxjs/operators'
+import { filter, map, withLatestFrom } from 'rxjs/operators'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { HoverMerged } from '@sourcegraph/client-api'
 import { HoveredToken, createHoverifier, Hoverifier, HoverState } from '@sourcegraph/codeintellify'
-import { createAggregateError, isErrorLike, isDefined, memoizeObservable, property, asError } from '@sourcegraph/common'
-import { gql } from '@sourcegraph/http-client'
+import { isDefined, property } from '@sourcegraph/common'
+import { gql, useQuery } from '@sourcegraph/http-client'
 import { ActionItemAction } from '@sourcegraph/shared/src/actions/ActionItem'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { getHoverActions } from '@sourcegraph/shared/src/hover/actions'
@@ -31,7 +31,6 @@ import {
 import { LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
 
 import { getHover, getDocumentHighlights } from '../../backend/features'
-import { requestGraphQL } from '../../backend/graphql'
 import { FileDiffConnection } from '../../components/diff/FileDiffConnection'
 import { FileDiffNode } from '../../components/diff/FileDiffNode'
 import { FilteredConnectionQueryArguments } from '../../components/FilteredConnection'
@@ -43,7 +42,6 @@ import {
     RepositoryCommitResult,
     RepositoryCommitVariables,
     RepositoryFields,
-    Scalars,
 } from '../../graphql-operations'
 import { GitCommitNode } from '../commits/GitCommitNode'
 import { gitCommitFragment } from '../commits/RepositoryCommitsPage'
@@ -51,60 +49,20 @@ import { queryRepositoryComparisonFileDiffs, RepositoryComparisonDiff } from '..
 
 import styles from './RepositoryCommitPage.module.scss'
 
-const queryCommit = memoizeObservable(
-    (args: { repo: Scalars['ID']; revspec: string }): Observable<GitCommitFields> =>
-        requestGraphQL<RepositoryCommitResult, RepositoryCommitVariables>(
-            gql`
-                query RepositoryCommit($repo: ID!, $revspec: String!) {
-                    node(id: $repo) {
-                        __typename
-                        ... on Repository {
-                            commit(rev: $revspec) {
-                                __typename # necessary so that isErrorLike(x) is false when x: GitCommitFields
-                                ...GitCommitFields
-                            }
-                        }
-                    }
+const COMMIT_QUERY = gql`
+    query RepositoryCommit($repo: ID!, $revspec: String!) {
+        node(id: $repo) {
+            __typename
+            ... on Repository {
+                commit(rev: $revspec) {
+                    __typename # necessary so that isErrorLike(x) is false when x: GitCommitFields
+                    ...GitCommitFields
                 }
-                ${gitCommitFragment}
-            `,
-            args
-        ).pipe(
-            map(({ data, errors }) => {
-                if (!data || !data.node) {
-                    throw createAggregateError(errors)
-                }
-                if (data.node.__typename !== 'Repository') {
-                    throw new Error(`Node is a ${data.node.__typename}, not a Repository`)
-                }
-                if (!data.node.commit) {
-                    // Filter out any revision not found errors, they usually come in multiples when searching for a commit, we want to replace all of them with 1 "Commit not found" error
-                    // TODO: Figuring why should we use `errors` here since it is `undefined` in this place
-                    const errorsWithoutRevisionError = errors?.filter(
-                        (error: { message: string | string[] }) => !error.message.includes('revision not found')
-                    )
-
-                    const revisionErrorsFiltered =
-                        errors && errorsWithoutRevisionError && errorsWithoutRevisionError.length < errors?.length
-
-                    // If there are no other errors left (or there wasn't any errors to begin with throw out a Commit not found error
-                    if (!errorsWithoutRevisionError || errorsWithoutRevisionError.length === 0) {
-                        throw new Error('Commit not found')
-                    }
-
-                    // if we found at least 1 "revision nor found error" add "Commit not found" to the errors
-                    if (revisionErrorsFiltered) {
-                        throw createAggregateError([new Error('Commit not found'), ...errorsWithoutRevisionError])
-                    }
-
-                    // no "revision not found" errors, throw the other errors
-                    throw createAggregateError(errorsWithoutRevisionError)
-                }
-                return data.node.commit
-            })
-        ),
-    args => `${args.repo}:${args.revspec}`
-)
+            }
+        }
+    }
+    ${gitCommitFragment}
+`
 
 interface RepositoryCommitPageProps
     extends RouteComponentProps<{ revspec: string }>,
@@ -121,15 +79,18 @@ export type { DiffMode } from '@sourcegraph/shared/src/settings/temporary/diffMo
 
 /** Displays a commit. */
 export const RepositoryCommitPage: React.FunctionComponent<RepositoryCommitPageProps> = props => {
-    const commitOrError = useObservable(
-        useMemo(
-            () =>
-                queryCommit({ repo: props.repo.id, revspec: props.match.params.revspec }).pipe(
-                    catchError(error => [asError(error)])
-                ),
-            [props.match.params.revspec, props.repo.id]
-        )
+    const { data, error, loading } = useQuery<RepositoryCommitResult, RepositoryCommitVariables>(COMMIT_QUERY, {
+        variables: {
+            repo: props.repo.id,
+            revspec: props.match.params.revspec,
+        },
+    })
+
+    const commit = useMemo(
+        () => (data?.node && data?.node?.__typename === 'Repository' ? data?.node?.commit : undefined),
+        [data]
     )
+
     const [diffMode, setDiffMode] = useTemporarySetting('repo.commitPage.diffMode', 'unified')
 
     /** Emits whenever the ref callback for the hover element is called */
@@ -200,24 +161,25 @@ export const RepositoryCommitPage: React.FunctionComponent<RepositoryCommitPageP
     }, [props.telemetryService])
 
     useEffect(() => {
-        if (commitOrError && !isErrorLike(commitOrError)) {
-            props.onDidUpdateExternalLinks(commitOrError.externalURLs)
+        if (commit) {
+            props.onDidUpdateExternalLinks(commit.externalURLs)
         }
 
         return () => {
             props.onDidUpdateExternalLinks(undefined)
         }
-    }, [commitOrError, props])
+    }, [commit, props])
 
     const queryDiffs = useCallback(
         (args: FilteredConnectionQueryArguments): Observable<RepositoryComparisonDiff['comparison']['fileDiffs']> =>
+            // Non-null assertions here are safe because the query is only executed if the commit is defined.
             queryRepositoryComparisonFileDiffs({
                 ...args,
                 repo: props.repo.id,
-                base: commitParentOrEmpty(commitOrError as GitCommitFields),
-                head: (commitOrError as GitCommitFields).oid,
+                base: commitParentOrEmpty(commit!),
+                head: commit!.oid,
             }),
-        [commitOrError, props.repo.id]
+        [commit, props.repo.id]
     )
 
     const { extensionsController } = props
@@ -228,23 +190,17 @@ export const RepositoryCommitPage: React.FunctionComponent<RepositoryCommitPageP
             className={classNames('p-3', styles.repositoryCommitPage)}
             ref={nextRepositoryCommitPageElement}
         >
-            <PageTitle
-                title={
-                    commitOrError && !isErrorLike(commitOrError)
-                        ? commitOrError.subject
-                        : `Commit ${props.match.params.revspec}`
-                }
-            />
-            {commitOrError === undefined ? (
+            <PageTitle title={commit ? commit.subject : `Commit ${props.match.params.revspec}`} />
+            {loading ? (
                 <LoadingSpinner className="mt-2" />
-            ) : isErrorLike(commitOrError) ? (
-                <ErrorAlert className="mt-2" error={commitOrError} />
+            ) : error || !commit ? (
+                <ErrorAlert className="mt-2" error={error ?? new Error('Commit not found')} />
             ) : (
                 <>
                     <div className="border-bottom pb-2">
                         <div>
                             <GitCommitNode
-                                node={commitOrError}
+                                node={commit}
                                 expandCommitMessageBody={true}
                                 showSHAAndParentsRow={true}
                                 diffMode={diffMode}
@@ -267,14 +223,14 @@ export const RepositoryCommitPage: React.FunctionComponent<RepositoryCommitPageP
                                           base: {
                                               repoName: props.repo.name,
                                               repoID: props.repo.id,
-                                              revision: commitParentOrEmpty(commitOrError),
-                                              commitID: commitParentOrEmpty(commitOrError),
+                                              revision: commitParentOrEmpty(commit),
+                                              commitID: commitParentOrEmpty(commit),
                                           },
                                           head: {
                                               repoName: props.repo.name,
                                               repoID: props.repo.id,
-                                              revision: commitOrError.oid,
-                                              commitID: commitOrError.oid,
+                                              revision: commit.oid,
+                                              commitID: commit.oid,
                                           },
                                           hoverifier,
                                           extensionsController,
@@ -283,7 +239,7 @@ export const RepositoryCommitPage: React.FunctionComponent<RepositoryCommitPageP
                             lineNumbers: true,
                             diffMode,
                         }}
-                        updateOnChange={`${props.repo.id}:${commitOrError.oid}`}
+                        updateOnChange={`${props.repo.id}:${commit.oid}`}
                         defaultFirst={15}
                         hideSearch={true}
                         noSummaryIfAllNodesVisible={true}


### PR DESCRIPTION
Migrate the commit page to use Apollo `useQuery` instead of `requestGraphQL`

Still to do in future PR is to remove usage of `FilteredConnection` in favor of `useConnection`.

## Test plan

Verify manually and with integration tests.

## App preview:

- [Web](https://sg-web-jp-commitpageapollo.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
