### PR TITLE
search frontend: smart search toggle sets 'sm' URL param

### DIFF
--- a/client/search-ui/src/input/SearchBox.story.tsx
+++ b/client/search-ui/src/input/SearchBox.story.tsx
@@ -1,7 +1,7 @@
 import { Meta, Story } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
-import { SearchPatternType } from '@sourcegraph/search'
+import { SearchMode, SearchPatternType } from '@sourcegraph/search'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     mockFetchAutoDefinedSearchContexts,
@@ -37,6 +37,8 @@ const defaultProps: SearchBoxProps = {
     setPatternType: () => {},
     caseSensitive: false,
     setCaseSensitivity: () => {},
+    searchMode: SearchMode.Precise,
+    setSearchMode: () => {},
     searchContextsEnabled: true,
     showSearchContext: false,
     showSearchContextManagement: false,

--- a/client/search-ui/src/input/SearchBox.tsx
+++ b/client/search-ui/src/input/SearchBox.tsx
@@ -205,6 +205,8 @@ export const SearchBox: React.FunctionComponent<React.PropsWithChildren<SearchBo
                         setPatternType={props.setPatternType}
                         caseSensitive={props.caseSensitive}
                         setCaseSensitivity={props.setCaseSensitivity}
+                        searchMode={props.searchMode}
+                        setSearchMode={props.setSearchMode}
                         settingsCascade={props.settingsCascade}
                         submitSearch={props.submitSearchOnToggle}
                         navbarSearchQuery={queryState.query}

--- a/client/search-ui/src/input/toggles/Toggles.test.tsx
+++ b/client/search-ui/src/input/toggles/Toggles.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react'
 
-import { SearchPatternType } from '@sourcegraph/search'
+import { SearchMode, SearchPatternType } from '@sourcegraph/search'
 import { renderWithBrandedContext } from '@sourcegraph/shared/src/testing'
 
 import { getFullQuery, Toggles } from './Toggles'
@@ -45,6 +45,8 @@ describe('Toggles', () => {
                     setPatternType={() => undefined}
                     caseSensitive={false}
                     setCaseSensitivity={() => undefined}
+                    searchMode={SearchMode.Precise}
+                    setSearchMode={() => undefined}
                     settingsCascade={{ subjects: null, final: {} }}
                     selectedSearchContextSpec="global"
                 />
@@ -61,6 +63,8 @@ describe('Toggles', () => {
                     setPatternType={() => undefined}
                     caseSensitive={false}
                     setCaseSensitivity={() => undefined}
+                    searchMode={SearchMode.Precise}
+                    setSearchMode={() => undefined}
                     settingsCascade={{ subjects: null, final: {} }}
                     selectedSearchContextSpec="global"
                 />
@@ -76,6 +80,8 @@ describe('Toggles', () => {
                     setPatternType={() => undefined}
                     caseSensitive={false}
                     setCaseSensitivity={() => undefined}
+                    searchMode={SearchMode.Precise}
+                    setSearchMode={() => undefined}
                     settingsCascade={{ subjects: null, final: {} }}
                     selectedSearchContextSpec="global"
                 />

--- a/client/search-ui/src/input/toggles/Toggles.tsx
+++ b/client/search-ui/src/input/toggles/Toggles.tsx
@@ -11,6 +11,8 @@ import {
     SearchPatternTypeMutationProps,
     SubmitSearchProps,
     SearchPatternType,
+    SearchMode,
+    SearchModeProps,
 } from '@sourcegraph/search'
 import { findFilter, FilterKind } from '@sourcegraph/shared/src/search/query/query'
 import { appendContextFilter } from '@sourcegraph/shared/src/search/query/transformer'
@@ -26,6 +28,7 @@ export interface TogglesProps
     extends SearchPatternTypeProps,
         SearchPatternTypeMutationProps,
         CaseSensitivityProps,
+        SearchModeProps,
         SettingsCascadeProps,
         Pick<SearchContextProps, 'selectedSearchContextSpec'>,
         Partial<Pick<SubmitSearchProps, 'submitSearch'>> {
@@ -64,6 +67,8 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
         setPatternType,
         caseSensitive,
         setCaseSensitivity,
+        searchMode,
+        setSearchMode,
         settingsCascade,
         className,
         selectedSearchContextSpec,
@@ -87,15 +92,20 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
 
     const submitOnToggle = useCallback(
         (
-            args: { newPatternType: SearchPatternType } | { newCaseSensitivity: boolean } | { newPowerUser: boolean }
+            args:
+                | { newPatternType: SearchPatternType }
+                | { newCaseSensitivity: boolean }
+                | { newPowerUser: boolean }
+                | { newSearchMode: SearchMode }
         ): void => {
             submitSearch?.({
                 source: 'filter',
                 patternType: 'newPatternType' in args ? args.newPatternType : patternType,
                 caseSensitive: 'newCaseSensitivity' in args ? args.newCaseSensitivity : caseSensitive,
+                searchMode: 'newSearchMode' in args ? args.newSearchMode : searchMode,
             })
         },
-        [caseSensitive, patternType, submitSearch]
+        [caseSensitive, patternType, searchMode, submitSearch]
     )
 
     const toggleCaseSensitivity = useCallback((): void => {
@@ -122,12 +132,12 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
 
     const onSelectSmartSearch = useCallback(
         (enabled: boolean): void => {
-            const newPatternType: SearchPatternType = enabled ? SearchPatternType.lucky : SearchPatternType.standard
+            const newSearchMode: SearchMode = enabled ? SearchMode.SmartSearch : SearchMode.Precise
 
-            setPatternType(newPatternType)
-            submitOnToggle({ newPatternType })
+            setSearchMode(newSearchMode)
+            submitOnToggle({ newSearchMode })
         },
-        [setPatternType, submitOnToggle]
+        [setSearchMode, submitOnToggle]
     )
 
     const fullQuery = getFullQuery(navbarSearchQuery, selectedSearchContextSpec || '', caseSensitive, patternType)
@@ -198,17 +208,9 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
                 {showSmartSearch && (
                     <SmartSearchToggle
                         className="test-smart-search-toggle"
-                        isActive={patternType === SearchPatternType.lucky}
+                        isActive={searchMode === SearchMode.SmartSearch}
                         onSelect={onSelectSmartSearch}
                         interactive={props.interactive}
-                        disableOn={[
-                            {
-                                condition:
-                                    findFilter(navbarSearchQuery, 'patterntype', FilterKind.Subexpression) !==
-                                    undefined,
-                                reason: 'Query already contains one or more patterntype subexpressions',
-                            },
-                        ]}
                     />
                 )}
                 {showCopyQueryButton && (

--- a/client/search-ui/src/results/NoResultsPage.tsx
+++ b/client/search-ui/src/results/NoResultsPage.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect } from 'react'
 import { mdiClose, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
-import { SearchContextProps } from '@sourcegraph/search'
+import { SearchContextProps, SearchMode } from '@sourcegraph/search'
 import { SyntaxHighlightedSearchQuery, Toggles } from '@sourcegraph/search-ui'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { NoResultsSectionID as SectionID } from '@sourcegraph/shared/src/settings/temporary/searchSidebar'
@@ -95,8 +95,10 @@ const SearchInputExample: React.FunctionComponent<React.PropsWithChildren<Search
                         navbarSearchQuery={query}
                         caseSensitive={false}
                         patternType={patternType}
+                        searchMode={SearchMode.Precise}
                         setCaseSensitivity={noop}
                         setPatternType={noop}
+                        setSearchMode={noop}
                         settingsCascade={{ subjects: null, final: {} }}
                         showCopyQueryButton={false}
                         interactive={false}

--- a/client/search/src/helpers.ts
+++ b/client/search/src/helpers.ts
@@ -2,7 +2,7 @@ import * as H from 'history'
 
 import { CharacterRange } from '@sourcegraph/shared/src/search/query/token'
 
-import { CaseSensitivityProps, SearchContextProps, SearchPatternTypeProps } from '.'
+import { CaseSensitivityProps, SearchContextProps, SearchMode, SearchPatternTypeProps } from '.'
 
 export enum QueryChangeSource {
     /**
@@ -64,6 +64,7 @@ export interface SubmitSearchParameters
         | 'communitySearchContextPage'
         | 'excludedResults'
         | 'smartSearchDisabled'
+    searchMode?: SearchMode
     addRecentSearch?: (query: string) => void
 }
 

--- a/client/search/src/index.ts
+++ b/client/search/src/index.ts
@@ -15,6 +15,7 @@ import {
     isSearchContextAvailable,
 } from './backend'
 import { SearchPatternType } from './graphql-operations'
+import { SearchMode } from './searchQueryState'
 
 export * from './backend'
 export * from './searchQueryState'
@@ -34,6 +35,11 @@ export interface SearchPatternTypeMutationProps {
 export interface CaseSensitivityProps {
     caseSensitive: boolean
     setCaseSensitivity: (caseSensitive: boolean) => void
+}
+
+export interface SearchModeProps {
+    searchMode: SearchMode
+    setSearchMode: (searchMode: SearchMode) => void
 }
 
 export interface SearchContextProps {

--- a/client/search/src/searchQueryState.tsx
+++ b/client/search/src/searchQueryState.tsx
@@ -157,5 +157,6 @@ export interface BuildSearchQueryURLParameters {
     query: string
     patternType?: SearchPatternType
     caseSensitive?: boolean
+    searchMode?: SearchMode
     searchContextSpec?: string
 }

--- a/client/shared/src/util/url.test.ts
+++ b/client/shared/src/util/url.test.ts
@@ -358,63 +358,67 @@ describe('withWorkspaceRootInputRevision', () => {
 
 describe('buildSearchURLQuery', () => {
     it('builds the URL query for a regular expression search', () =>
-        expect(buildSearchURLQuery('foo', SearchPatternType.regexp, false, undefined)).toBe('q=foo&patternType=regexp'))
+        expect(buildSearchURLQuery('foo', SearchPatternType.regexp, false, undefined)).toMatchInlineSnapshot(
+            '"q=foo&patternType=regexp&sm=0"'
+        ))
     it('builds the URL query for a literal search', () =>
-        expect(buildSearchURLQuery('foo', SearchPatternType.standard, false, undefined)).toBe(
-            'q=foo&patternType=standard'
+        expect(buildSearchURLQuery('foo', SearchPatternType.standard, false, undefined)).toMatchInlineSnapshot(
+            '"q=foo&patternType=standard&sm=0"'
         ))
     it('handles an empty query', () =>
-        expect(buildSearchURLQuery('', SearchPatternType.regexp, false, undefined)).toBe('q=&patternType=regexp'))
+        expect(buildSearchURLQuery('', SearchPatternType.regexp, false, undefined)).toMatchInlineSnapshot(
+            '"q=&patternType=regexp&sm=0"'
+        ))
     it('handles characters that need encoding', () =>
-        expect(buildSearchURLQuery('foo bar%baz', SearchPatternType.regexp, false, undefined)).toBe(
-            'q=foo+bar%25baz&patternType=regexp'
+        expect(buildSearchURLQuery('foo bar%baz', SearchPatternType.regexp, false, undefined)).toMatchInlineSnapshot(
+            '"q=foo+bar%25baz&patternType=regexp&sm=0"'
         ))
     it('preserves / and : for readability', () =>
-        expect(buildSearchURLQuery('repo:foo/bar', SearchPatternType.regexp, false, undefined)).toBe(
-            'q=repo:foo/bar&patternType=regexp'
+        expect(buildSearchURLQuery('repo:foo/bar', SearchPatternType.regexp, false, undefined)).toMatchInlineSnapshot(
+            '"q=repo:foo/bar&patternType=regexp&sm=0"'
         ))
     describe('removal of patternType parameter', () => {
         it('overrides the patternType parameter at the end', () => {
-            expect(buildSearchURLQuery('foo patternType:literal', SearchPatternType.regexp, false, undefined)).toBe(
-                'q=foo&patternType=literal'
-            )
+            expect(
+                buildSearchURLQuery('foo patternType:literal', SearchPatternType.regexp, false, undefined)
+            ).toMatchInlineSnapshot('"q=foo&patternType=literal&sm=0"')
         })
         it('overrides the patternType parameter at the beginning', () => {
             expect(
                 buildSearchURLQuery('patternType:literal foo type:diff', SearchPatternType.regexp, false, undefined)
-            ).toBe('q=foo+type:diff&patternType=literal')
+            ).toMatchInlineSnapshot('"q=foo+type:diff&patternType=literal&sm=0"')
         })
         it('overrides the patternType parameter at the end with another operator', () => {
             expect(
                 buildSearchURLQuery('type:diff foo patternType:literal', SearchPatternType.regexp, false, undefined)
-            ).toBe('q=type:diff+foo&patternType=literal')
+            ).toMatchInlineSnapshot('"q=type:diff+foo&patternType=literal&sm=0"')
         })
         it('overrides the patternType parameter in the middle', () => {
             expect(
                 buildSearchURLQuery('type:diff patternType:literal foo', SearchPatternType.regexp, false, undefined)
-            ).toBe('q=type:diff+foo&patternType=literal')
+            ).toMatchInlineSnapshot('"q=type:diff+foo&patternType=literal&sm=0"')
         })
         it('overrides the patternType parameter if using a quoted value', () => {
-            expect(buildSearchURLQuery('patternType:"literal" foo', SearchPatternType.regexp, false, undefined)).toBe(
-                'q=foo&patternType=literal'
-            )
+            expect(
+                buildSearchURLQuery('patternType:"literal" foo', SearchPatternType.regexp, false, undefined)
+            ).toMatchInlineSnapshot('"q=foo&patternType=literal&sm=0"')
         })
     })
     it('builds the URL query with a case parameter if caseSensitive is true', () =>
-        expect(buildSearchURLQuery('foo', SearchPatternType.standard, true, undefined)).toBe(
-            'q=foo&patternType=standard&case=yes'
+        expect(buildSearchURLQuery('foo', SearchPatternType.standard, true, undefined)).toMatchInlineSnapshot(
+            '"q=foo&patternType=standard&case=yes&sm=0"'
         ))
     it('appends the case parameter if `case:yes` exists in the query', () =>
-        expect(buildSearchURLQuery('foo case:yes', SearchPatternType.standard, false, undefined)).toBe(
-            'q=foo&patternType=standard&case=yes'
+        expect(buildSearchURLQuery('foo case:yes', SearchPatternType.standard, false, undefined)).toMatchInlineSnapshot(
+            '"q=foo&patternType=standard&case=yes&sm=0"'
         ))
     it('removes the case parameter if using a quoted value', () =>
-        expect(buildSearchURLQuery('foo case:"yes"', SearchPatternType.standard, true, undefined)).toBe(
-            'q=foo&patternType=standard&case=yes'
-        ))
+        expect(
+            buildSearchURLQuery('foo case:"yes"', SearchPatternType.standard, true, undefined)
+        ).toMatchInlineSnapshot('"q=foo&patternType=standard&case=yes&sm=0"'))
     it('removes the case parameter case:no exists in the query and caseSensitive is true', () =>
-        expect(buildSearchURLQuery('foo case:no', SearchPatternType.standard, true, undefined)).toBe(
-            'q=foo&patternType=standard'
+        expect(buildSearchURLQuery('foo case:no', SearchPatternType.standard, true, undefined)).toMatchInlineSnapshot(
+            '"q=foo&patternType=standard&sm=0"'
         ))
 })
 

--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -9,6 +9,7 @@ import {
     toViewStateHash,
 } from '@sourcegraph/common'
 import { Position } from '@sourcegraph/extension-api-types'
+import { SearchMode } from '@sourcegraph/search'
 
 import { WorkspaceRootWithMetadata } from '../api/extension/extensionHostApi'
 import { SearchPatternType } from '../graphql-operations'
@@ -527,7 +528,9 @@ export function buildSearchURLQuery(
     query: string,
     patternType: SearchPatternType,
     caseSensitive: boolean,
-    searchContextSpec?: string
+
+    searchContextSpec?: string,
+    searchMode?: SearchMode
 ): string {
     const searchParameters = new URLSearchParams()
     let queryParameter = query
@@ -558,6 +561,8 @@ export function buildSearchURLQuery(
     if (caseParameter === 'yes') {
         searchParameters.set('case', caseParameter)
     }
+
+    searchParameters.set('sm', (searchMode || SearchMode.Precise).toString())
 
     return searchParameters.toString().replace(/%2F/g, '/').replace(/%3A/g, ':')
 }

--- a/client/vscode/src/backend/streamSearch.ts
+++ b/client/vscode/src/backend/streamSearch.ts
@@ -2,6 +2,7 @@ import { of, Subscription } from 'rxjs'
 import { map, switchMap, throttleTime } from 'rxjs/operators'
 import * as vscode from 'vscode'
 
+import { SearchMode } from '@sourcegraph/search'
 import { appendContextFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { aggregateStreamingSearch } from '@sourcegraph/shared/src/search/stream'
 
@@ -43,6 +44,7 @@ export function createStreamSearch({
                 queryState: { query },
                 searchCaseSensitivity: options.caseSensitive,
                 searchPatternType: options.patternType,
+                searchMode: options.searchMode || SearchMode.Precise,
             },
         })
         // Focus search panel if not already focused

--- a/client/vscode/src/state.ts
+++ b/client/vscode/src/state.ts
@@ -51,7 +51,10 @@ export interface ContextInvalidatedState {
 /**
  * Subset of SearchQueryState that's necessary and clone-able (`postMessage`) for the VS Code extension.
  */
-export type VSCEQueryState = Pick<SearchQueryState, 'queryState' | 'searchCaseSensitivity' | 'searchPatternType'> | null
+export type VSCEQueryState = Pick<
+    SearchQueryState,
+    'queryState' | 'searchCaseSensitivity' | 'searchPatternType' | 'searchMode'
+> | null
 
 interface CommonContext {
     authenticatedUser: AuthenticatedUser | null

--- a/client/vscode/src/webview/search-panel/SearchHomeView.tsx
+++ b/client/vscode/src/webview/search-panel/SearchHomeView.tsx
@@ -9,6 +9,7 @@ import {
     getUserSearchContextNamespaces,
     fetchAutoDefinedSearchContexts,
     QueryState,
+    SearchMode,
 } from '@sourcegraph/search'
 import { SearchBox } from '@sourcegraph/search-ui'
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
@@ -41,6 +42,7 @@ export const SearchHomeView: React.FunctionComponent<React.PropsWithChildren<Sea
     // Toggling case sensitivity or pattern type does NOT trigger a new search on home view.
     const [caseSensitive, setCaseSensitivity] = useState(false)
     const [patternType, setPatternType] = useState(SearchPatternType.standard)
+    const [searchMode, setSearchMode] = useState(SearchMode.Precise)
 
     const [userQueryState, setUserQueryState] = useState<QueryState>({
         query: '',
@@ -70,6 +72,7 @@ export const SearchHomeView: React.FunctionComponent<React.PropsWithChildren<Sea
                 queryState: { query: userQueryState.query },
                 searchCaseSensitivity: caseSensitive,
                 searchPatternType: patternType,
+                searchMode,
             })
             .catch(error => {
                 // TODO surface error to users
@@ -119,6 +122,7 @@ export const SearchHomeView: React.FunctionComponent<React.PropsWithChildren<Sea
         userQueryState.query,
         caseSensitive,
         patternType,
+        searchMode,
         instanceURL,
         context.selectedSearchContextSpec,
         platformContext.telemetryService,
@@ -168,6 +172,8 @@ export const SearchHomeView: React.FunctionComponent<React.PropsWithChildren<Sea
                         setCaseSensitivity={setCaseSensitivity}
                         patternType={patternType}
                         setPatternType={setPatternType}
+                        searchMode={searchMode}
+                        setSearchMode={setSearchMode}
                         isSourcegraphDotCom={isSourcegraphDotCom}
                         structuralSearchDisabled={false}
                         queryState={userQueryState}

--- a/client/vscode/src/webview/search-panel/SearchResultsView.tsx
+++ b/client/vscode/src/webview/search-panel/SearchResultsView.tsx
@@ -9,6 +9,7 @@ import {
     fetchAutoDefinedSearchContexts,
     getUserSearchContextNamespaces,
     QueryState,
+    SearchMode,
 } from '@sourcegraph/search'
 import { IEditor, SearchBox, StreamingProgress, StreamingSearchResultsList } from '@sourcegraph/search-ui'
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
@@ -84,6 +85,7 @@ export const SearchResultsView: React.FunctionComponent<React.PropsWithChildren<
                     queryState: newState,
                     searchCaseSensitivity: context.submittedSearchQueryState?.searchCaseSensitivity,
                     searchPatternType: context.submittedSearchQueryState?.searchPatternType,
+                    searchMode: context.submittedSearchQueryState?.searchMode,
                 })
                 .catch(error => {
                     // TODO surface error to users
@@ -94,6 +96,7 @@ export const SearchResultsView: React.FunctionComponent<React.PropsWithChildren<
             extensionCoreAPI,
             context.submittedSearchQueryState.searchCaseSensitivity,
             context.submittedSearchQueryState.searchPatternType,
+            context.submittedSearchQueryState.searchMode,
         ]
     )
 
@@ -128,12 +131,18 @@ export const SearchResultsView: React.FunctionComponent<React.PropsWithChildren<
     }, [platformContext, context.submittedSearchQueryState.queryState.query])
 
     const onSubmit = useCallback(
-        (options?: { caseSensitive?: boolean; patternType?: SearchPatternType; newQuery?: string }) => {
+        (options?: {
+            caseSensitive?: boolean
+            patternType?: SearchPatternType
+            newQuery?: string
+            searchMode?: SearchMode
+        }) => {
             const previousSearchQueryState = context.submittedSearchQueryState
 
             const query = options?.newQuery ?? userQueryState.query
             const caseSensitive = options?.caseSensitive ?? previousSearchQueryState.searchCaseSensitivity
             const patternType = options?.patternType ?? previousSearchQueryState.searchPatternType
+            const searchMode = options?.searchMode ?? previousSearchQueryState.searchMode
 
             extensionCoreAPI
                 .streamSearch(query, {
@@ -157,6 +166,7 @@ export const SearchResultsView: React.FunctionComponent<React.PropsWithChildren<
                     queryState: { query },
                     searchCaseSensitivity: caseSensitive,
                     searchPatternType: patternType,
+                    searchMode,
                 })
                 .catch(error => {
                     // TODO surface error to users
@@ -228,6 +238,13 @@ export const SearchResultsView: React.FunctionComponent<React.PropsWithChildren<
     const setPatternType = useCallback(
         (patternType: SearchPatternType) => {
             onSubmit({ patternType })
+        },
+        [onSubmit]
+    )
+
+    const setSearchMode = useCallback(
+        (searchMode: SearchMode) => {
+            onSubmit({ searchMode })
         },
         [onSubmit]
     )
@@ -317,6 +334,8 @@ export const SearchResultsView: React.FunctionComponent<React.PropsWithChildren<
                     setCaseSensitivity={setCaseSensitivity}
                     patternType={context.submittedSearchQueryState?.searchPatternType}
                     setPatternType={setPatternType}
+                    searchMode={context.submittedSearchQueryState?.searchMode}
+                    setSearchMode={setSearchMode}
                     isSourcegraphDotCom={isSourcegraphDotCom}
                     structuralSearchDisabled={false}
                     queryState={userQueryState}

--- a/client/vscode/src/webview/sidebars/search/SearchSidebarView.tsx
+++ b/client/vscode/src/webview/sidebars/search/SearchSidebarView.tsx
@@ -71,12 +71,14 @@ export const SearchSidebarView: React.FunctionComponent<React.PropsWithChildren<
                                     queryState: updatedQueryState,
                                     searchCaseSensitivity: currentSearchQueryState.searchCaseSensitivity,
                                     searchPatternType: currentSearchQueryState.searchPatternType,
+                                    searchMode: currentSearchQueryState.searchMode,
                                 },
                                 currentQueryState: {
                                     // Don't spread currentSearchQueryState as it contains un-clone-able functions.
                                     queryState: currentSearchQueryState.queryState,
                                     searchCaseSensitivity: currentSearchQueryState.searchCaseSensitivity,
                                     searchPatternType: currentSearchQueryState.searchPatternType,
+                                    searchMode: currentSearchQueryState.searchMode,
                                 },
                             })
                             .catch(error => {

--- a/client/web/src/enterprise/search/stats/__snapshots__/SearchStatsLanguages.test.tsx.snap
+++ b/client/web/src/enterprise/search/stats/__snapshots__/SearchStatsLanguages.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`SearchStatsLanguages renders 1`] = `
               <td>
                 <a
                   class=""
-                  href="/search?q=abc+lang:a&patternType=literal"
+                  href="/search?q=abc+lang:a&patternType=literal&sm=0"
                 >
                   A
                 </a>
@@ -69,7 +69,7 @@ exports[`SearchStatsLanguages renders 1`] = `
               <td>
                 <a
                   class=""
-                  href="/search?q=abc+lang:b&patternType=literal"
+                  href="/search?q=abc+lang:b&patternType=literal&sm=0"
                 >
                   B
                 </a>
@@ -85,7 +85,7 @@ exports[`SearchStatsLanguages renders 1`] = `
               <td>
                 <a
                   class=""
-                  href="/search?q=abc+lang:c&patternType=literal"
+                  href="/search?q=abc+lang:c&patternType=literal&sm=0"
                 >
                   C
                 </a>
@@ -101,7 +101,7 @@ exports[`SearchStatsLanguages renders 1`] = `
               <td>
                 <a
                   class=""
-                  href="/search?q=abc+lang:d&patternType=literal"
+                  href="/search?q=abc+lang:d&patternType=literal&sm=0"
                 >
                   D
                 </a>

--- a/client/web/src/enterprise/search/stats/__snapshots__/SearchStatsPage.test.tsx.snap
+++ b/client/web/src/enterprise/search/stats/__snapshots__/SearchStatsPage.test.tsx.snap
@@ -184,7 +184,7 @@ exports[`SearchStatsPage renders 1`] = `
                 <td>
                   <a
                     class=""
-                    href="/search?q=abc+lang:a&patternType=literal"
+                    href="/search?q=abc+lang:a&patternType=literal&sm=0"
                   >
                     A
                   </a>
@@ -200,7 +200,7 @@ exports[`SearchStatsPage renders 1`] = `
                 <td>
                   <a
                     class=""
-                    href="/search?q=abc+lang:b&patternType=literal"
+                    href="/search?q=abc+lang:b&patternType=literal&sm=0"
                   >
                     B
                   </a>
@@ -216,7 +216,7 @@ exports[`SearchStatsPage renders 1`] = `
                 <td>
                   <a
                     class=""
-                    href="/search?q=abc+lang:c&patternType=literal"
+                    href="/search?q=abc+lang:c&patternType=literal&sm=0"
                   >
                     C
                   </a>
@@ -232,7 +232,7 @@ exports[`SearchStatsPage renders 1`] = `
                 <td>
                   <a
                     class=""
-                    href="/search?q=abc+lang:d&patternType=literal"
+                    href="/search?q=abc+lang:d&patternType=literal&sm=0"
                   >
                     D
                   </a>

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -278,15 +278,19 @@ describe('Search', () => {
                     await driver.page.keyboard.type('test')
                     await driver.page.click('.test-case-sensitivity-toggle')
                     await driver.page.click('aria/Search[role="button"]')
-                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=standard&case=yes')
+                    await driver.assertWindowLocation(
+                        '/search?q=context:global+test&patternType=standard&case=yes&sm=0'
+                    )
                 })
 
                 test('Clicking toggle turns off case sensitivity and removes case= URL parameter', async () => {
-                    await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=standard&case=yes')
+                    await driver.page.goto(
+                        driver.sourcegraphBaseUrl + '/search?q=test&patternType=standard&case=yes&sm=0'
+                    )
                     await createEditorAPI(driver, queryInputSelector)
                     await driver.page.waitForSelector('.test-case-sensitivity-toggle')
                     await driver.page.click('.test-case-sensitivity-toggle')
-                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=standard')
+                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=standard&sm=0')
                 })
             })
         })
@@ -310,7 +314,7 @@ describe('Search', () => {
                     await driver.page.keyboard.type('test')
                     await driver.page.click('.test-structural-search-toggle')
                     await driver.page.click('aria/Search[role="button"]')
-                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=structural')
+                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=structural&sm=0')
                 })
 
                 test('Clicking toggle turns on structural search and removes existing patternType parameter', async () => {
@@ -319,7 +323,7 @@ describe('Search', () => {
                     await editor.focus()
                     await driver.page.waitForSelector('.test-structural-search-toggle')
                     await driver.page.click('.test-structural-search-toggle')
-                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=structural')
+                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=structural&sm=0')
                 })
 
                 test('Clicking toggle turns off structural search and reverts to default pattern type', async () => {
@@ -327,7 +331,7 @@ describe('Search', () => {
                     await createEditorAPI(driver, queryInputSelector)
                     await driver.page.waitForSelector('.test-structural-search-toggle')
                     await driver.page.click('.test-structural-search-toggle')
-                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=standard')
+                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=standard&sm=0')
                 })
             })
         })
@@ -342,7 +346,7 @@ describe('Search', () => {
 
             await driver.page.waitForSelector('.test-search-button', { visible: true })
             await driver.page.click('.test-search-button')
-            await driver.assertWindowLocation('/search?q=context:global+test+hello&patternType=regexp')
+            await driver.assertWindowLocation('/search?q=context:global+test+hello&patternType=regexp&sm=0')
         })
     })
 
@@ -558,7 +562,7 @@ describe('Search', () => {
                 driver.page.waitForNavigation(),
                 driver.page.click('[data-testid="search-type-submit"]'),
             ])
-            await driver.assertWindowLocation('/search?q=context:global+test+type:commit&patternType=standard')
+            await driver.assertWindowLocation('/search?q=context:global+test+type:commit&patternType=standard&sm=0')
         })
     })
 })

--- a/client/web/src/search/Notepad.test.tsx
+++ b/client/web/src/search/Notepad.test.tsx
@@ -121,7 +121,7 @@ describe('Notepad', () => {
 
             // Entries are in reverse order
             expect(entryLinks[0]).toHaveAttribute('href', '/test@master/-/blob/path/to/file')
-            expect(entryLinks[1]).toHaveAttribute('href', '/search?q=TODO&patternType=standard')
+            expect(entryLinks[1]).toHaveAttribute('href', '/search?q=TODO&patternType=standard&sm=0')
         })
 
         it('creates notebooks', () => {

--- a/client/web/src/search/helpers.test.tsx
+++ b/client/web/src/search/helpers.test.tsx
@@ -17,7 +17,7 @@ describe('search/helpers', () => {
                 source: 'home',
             })
             expect(history.location.search).toMatchInlineSnapshot(
-                '"?q=context:global+querystring&patternType=standard"'
+                '"?q=context:global+querystring&patternType=standard&sm=0"'
             )
         })
         test('should keep trace param when updating history', () => {
@@ -31,7 +31,7 @@ describe('search/helpers', () => {
                 source: 'home',
             })
             expect(history.location.search).toMatchInlineSnapshot(
-                '"?q=context:global+querystring&patternType=standard&trace=1"'
+                '"?q=context:global+querystring&patternType=standard&sm=0&trace=1"'
             )
         })
     })

--- a/client/web/src/search/helpers.tsx
+++ b/client/web/src/search/helpers.tsx
@@ -37,10 +37,17 @@ export function submitSearch({
     patternType,
     caseSensitive,
     selectedSearchContextSpec,
+    searchMode,
     source,
     addRecentSearch,
 }: SubmitSearchParameters): void {
-    let searchQueryParameter = buildSearchURLQuery(query, patternType, caseSensitive, selectedSearchContextSpec)
+    let searchQueryParameter = buildSearchURLQuery(
+        query,
+        patternType,
+        caseSensitive,
+        selectedSearchContextSpec,
+        searchMode
+    )
 
     const preserved = preservedQuery(history.location.search)
     if (preserved !== '') {

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -13,6 +13,7 @@ import {
     SubmitSearchParameters,
     canSubmitSearch,
     QueryState,
+    SearchModeProps,
 } from '@sourcegraph/search'
 import { SearchBox } from '@sourcegraph/search-ui'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
@@ -29,6 +30,7 @@ import {
     useNavbarQueryState,
     setSearchCaseSensitivity,
     setSearchPatternType,
+    setSearchMode,
 } from '../../stores'
 import { ThemePreferenceProps } from '../../theme'
 import { submitSearch } from '../helpers'
@@ -57,13 +59,14 @@ interface Props
 
 const queryStateSelector = (
     state: NavbarQueryState
-): Pick<CaseSensitivityProps, 'caseSensitive'> & SearchPatternTypeProps => ({
+): Pick<CaseSensitivityProps, 'caseSensitive'> & SearchPatternTypeProps & Pick<SearchModeProps, 'searchMode'> => ({
     caseSensitive: state.searchCaseSensitivity,
     patternType: state.searchPatternType,
+    searchMode: state.searchMode,
 })
 
 export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Props>> = (props: Props) => {
-    const { caseSensitive, patternType } = useNavbarQueryState(queryStateSelector, shallow)
+    const { caseSensitive, patternType, searchMode } = useNavbarQueryState(queryStateSelector, shallow)
     const showSearchContext = useExperimentalFeatures(features => features.showSearchContext ?? false)
     const showSearchContextManagement = useExperimentalFeatures(
         features => features.showSearchContextManagement ?? false
@@ -131,6 +134,8 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                             patternType={patternType}
                             setPatternType={setSearchPatternType}
                             setCaseSensitivity={setSearchCaseSensitivity}
+                            searchMode={searchMode}
+                            setSearchMode={setSearchMode}
                             queryState={props.queryState}
                             onChange={props.setQueryState}
                             onSubmit={onSubmit}

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -15,7 +15,7 @@ import { parseSearchURLQuery } from '..'
 import { AuthenticatedUser } from '../../auth'
 import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
 import { useExperimentalFeatures, useNavbarQueryState, setSearchCaseSensitivity } from '../../stores'
-import { NavbarQueryState, setSearchPatternType } from '../../stores/navbarSearchQueryState'
+import { NavbarQueryState, setSearchMode, setSearchPatternType } from '../../stores/navbarSearchQueryState'
 
 import { useRecentSearches } from './useRecentSearches'
 
@@ -40,10 +40,11 @@ const selectQueryState = ({
     submitSearch,
     searchCaseSensitivity,
     searchPatternType,
+    searchMode,
 }: NavbarQueryState): Pick<
     NavbarQueryState,
-    'queryState' | 'setQueryState' | 'submitSearch' | 'searchCaseSensitivity' | 'searchPatternType'
-> => ({ queryState, setQueryState, submitSearch, searchCaseSensitivity, searchPatternType })
+    'queryState' | 'setQueryState' | 'submitSearch' | 'searchCaseSensitivity' | 'searchPatternType' | 'searchMode'
+> => ({ queryState, setQueryState, submitSearch, searchCaseSensitivity, searchPatternType, searchMode })
 
 /**
  * The search item in the navbar
@@ -52,10 +53,16 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
     const isSearchPage = props.location.pathname === '/search' && Boolean(parseSearchURLQuery(props.location.search))
     // This uses the same logic as in Layout.tsx until we have a better solution
     // or remove the search help button
-    const { queryState, setQueryState, submitSearch, searchCaseSensitivity, searchPatternType } = useNavbarQueryState(
-        selectQueryState,
-        shallow
-    )
+
+    const {
+        queryState,
+        setQueryState,
+        submitSearch,
+        searchCaseSensitivity,
+        searchPatternType,
+        searchMode,
+    } = useNavbarQueryState(selectQueryState, shallow)
+
     const showSearchContext = useExperimentalFeatures(features => features.showSearchContext ?? false)
     const showSearchContextManagement = useExperimentalFeatures(
         features => features.showSearchContextManagement ?? false
@@ -104,6 +111,8 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
                 setCaseSensitivity={setSearchCaseSensitivity}
                 patternType={searchPatternType}
                 setPatternType={setSearchPatternType}
+                searchMode={searchMode}
+                setSearchMode={setSearchMode}
                 queryState={queryState}
                 onChange={setQueryState}
                 onSubmit={onSubmit}

--- a/client/web/src/stores/index.ts
+++ b/client/web/src/stores/index.ts
@@ -17,6 +17,7 @@ export {
     setQueryStateFromSettings,
     setSearchPatternType,
     setSearchCaseSensitivity,
+    setSearchMode,
     buildSearchURLQueryFromQueryState,
 } from './navbarSearchQueryState'
 export {

--- a/client/web/src/stores/navbarSearchQueryState.ts
+++ b/client/web/src/stores/navbarSearchQueryState.ts
@@ -44,10 +44,11 @@ export const useNavbarQueryState = create<NavbarQueryState>((set, get) => ({
             queryState: { query },
             searchCaseSensitivity: caseSensitive,
             searchPatternType: patternType,
+            searchMode: searchMode,
         } = get()
         const updatedQuery = updateQuery(query, updates)
         if (canSubmitSearch(query, parameters.selectedSearchContextSpec)) {
-            submitSearch({ ...parameters, query: updatedQuery, caseSensitive, patternType })
+            submitSearch({ ...parameters, query: updatedQuery, caseSensitive, patternType, searchMode })
         }
     },
 }))
@@ -58,6 +59,10 @@ export function setSearchPatternType(searchPatternType: SearchPatternType): void
 
 export function setSearchCaseSensitivity(searchCaseSensitivity: boolean): void {
     useNavbarQueryState.setState({ searchCaseSensitivity })
+}
+
+export function setSearchMode(searchMode: SearchMode): void {
+    useNavbarQueryState.setState({ searchMode })
 }
 
 /**
@@ -144,6 +149,7 @@ export function buildSearchURLQueryFromQueryState(parameters: BuildSearchQueryUR
         parameters.query,
         parameters.patternType ?? currentState.searchPatternType,
         parameters.caseSensitive ?? currentState.searchCaseSensitivity,
-        parameters.searchContextSpec
+        parameters.searchContextSpec,
+        parameters.searchMode ?? currentState.searchMode
     )
 }


### PR DESCRIPTION
Whoop, finally got a green PR. This propagates and sets the `SearchMode` state in the app so that we can set `sm` in the URL param.

I need to do a follow up PR that:

(1) Replaces `patterntype:lucky` so that the search mode value determines behavior only. There isn't logic yet to _not set_ `patterntype=lucky` in the URL, and we need to not set that any more. Right now there is some weird interactions when `patterntype=lucky` is set and `sm` is set.

(2) Add a default search mode setting.

I won't merge this PR until (1) is done because the intermediate state is janky. But this PR is ready to review as-is.

## Test plan
Updated unit tests

## App preview:

- [Web](https://sg-web-rvt-smart-search-default.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

