### PR TITLE
rockskip: Show ETA message as info instead of error

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarSymbols.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarSymbols.tsx
@@ -10,7 +10,7 @@ import { NavLink, useLocation } from 'react-router-dom'
 import { gql, dataOrThrowErrors } from '@sourcegraph/http-client'
 import { SymbolIcon } from '@sourcegraph/shared/src/symbols/SymbolIcon'
 import { RevisionSpec } from '@sourcegraph/shared/src/util/url'
-import { useDebounce } from '@sourcegraph/wildcard'
+import { Alert, useDebounce } from '@sourcegraph/wildcard'
 
 import { useConnection } from '../components/FilteredConnection/hooks/useConnection'
 import {
@@ -26,6 +26,7 @@ import { Scalars, SymbolKind, SymbolNodeFields, SymbolsResult, SymbolsVariables 
 import { parseBrowserRepoURL } from '../util/url'
 
 import styles from './RepoRevisionSidebarSymbols.module.scss'
+import { ErrorMessage } from '@sourcegraph/branded/src/components/alerts'
 
 interface SymbolNodeProps {
     node: SymbolNodeFields
@@ -196,7 +197,11 @@ export const RepoRevisionSidebarSymbols: React.FunctionComponent<
                     {query && summary}
                 </SummaryContainer>
             </div>
-            {error && <ConnectionError errors={[error.message]} compact={true} />}
+            {error && (
+                <Alert variant={error.message.includes('Estimated completion') ? 'info' : 'danger'}>
+                    <ErrorMessage error={error.message} />
+                </Alert>
+            )}
             {connection && (
                 <HierarchicalSymbols
                     symbols={connection.nodes}

--- a/client/web/src/repo/RepoRevisionSidebarSymbols.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarSymbols.tsx
@@ -7,6 +7,7 @@ import { sortBy } from 'lodash'
 import { entries, escapeRegExp, flatMap, flow, groupBy, isEqual, map } from 'lodash/fp'
 import { NavLink, useLocation } from 'react-router-dom'
 
+import { ErrorMessage } from '@sourcegraph/branded/src/components/alerts'
 import { gql, dataOrThrowErrors } from '@sourcegraph/http-client'
 import { SymbolIcon } from '@sourcegraph/shared/src/symbols/SymbolIcon'
 import { RevisionSpec } from '@sourcegraph/shared/src/util/url'
@@ -18,7 +19,6 @@ import {
     ConnectionContainer,
     ConnectionLoading,
     ConnectionSummary,
-    ConnectionError,
     SummaryContainer,
     ShowMoreButton,
 } from '../components/FilteredConnection/ui'
@@ -26,7 +26,6 @@ import { Scalars, SymbolKind, SymbolNodeFields, SymbolsResult, SymbolsVariables 
 import { parseBrowserRepoURL } from '../util/url'
 
 import styles from './RepoRevisionSidebarSymbols.module.scss'
-import { ErrorMessage } from '@sourcegraph/branded/src/components/alerts'
 
 interface SymbolNodeProps {
     node: SymbolNodeFields


### PR DESCRIPTION
- Resolves https://github.com/sourcegraph/sourcegraph/issues/43887

<img width="396" alt="CleanShot 2022-11-03 at 16 46 17@2x" src="https://user-images.githubusercontent.com/1387653/199849579-0e67078b-e354-4dfc-9bf3-6a2b8ed312d0.png">

## Test plan

Ran locally

## App preview:

- [Web](https://sg-web-rockskip-eta-info.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
