### PR TITLE
Code Insights: Fix loading insights announcements

### DIFF
--- a/client/web/src/enterprise/insights/components/views/card/InsightCard.tsx
+++ b/client/web/src/enterprise/insights/components/views/card/InsightCard.tsx
@@ -1,4 +1,12 @@
-import React, { FC, forwardRef, HTMLAttributes, ReactNode, PropsWithChildren } from 'react'
+import React, {
+    FC,
+    forwardRef,
+    HTMLAttributes,
+    ReactNode,
+    PropsWithChildren,
+    useState,
+    FocusEvent, createContext, useMemo, useContext
+} from 'react'
 
 import classNames from 'classnames'
 import { useLocation } from 'react-router-dom'
@@ -18,14 +26,46 @@ import { ErrorBoundary } from '../../../../../components/ErrorBoundary'
 
 import styles from './InsightCard.module.scss'
 
+interface CardContextData {
+    isFocused: boolean
+}
+
+const CardContext = createContext<CardContextData>({ isFocused: false })
+
 const InsightCard = forwardRef(function InsightCard(props, reference) {
-    const { title, children, className, as = 'section', ...otherProps } = props
+    const { title, children, className, as = 'section', ...attributes } = props
+
+    const [isFocused, setFocused] = useState(false)
+
+    const handleFocusCapture = (): void => {
+        if (!isFocused) {
+            setFocused(true)
+        }
+    }
+
+    const handleBlurCapture = (event: FocusEvent): void => {
+        const nextFocusTarget = event.relatedTarget as Element | null
+
+        if (!event.currentTarget.contains(nextFocusTarget)) {
+            setFocused(false)
+        }
+    }
 
     return (
-        <Card as={as} tabIndex={0} ref={reference} {...otherProps} className={classNames(className, styles.view)}>
-            <ErrorBoundary location={useLocation()} className={styles.errorBoundary}>
-                {children}
-            </ErrorBoundary>
+        <Card
+            as={as}
+            ref={reference}
+            tabIndex={0}
+            className={classNames(className, styles.view)}
+            onFocusCapture={handleFocusCapture}
+            onBlurCapture={handleBlurCapture}
+            {...attributes}
+        >
+            <CardContext.Provider value={useMemo(() => ({ isFocused }), [isFocused])}>
+                <ErrorBoundary location={useLocation()} className={styles.errorBoundary}>
+                    {children}
+                </ErrorBoundary>
+            </CardContext.Provider>
         </Card>
     )
 }) as ForwardReferenceComponent<'section'>
@@ -77,11 +117,12 @@ const InsightCardHeader = forwardRef(function InsightCardHeader(props, reference
 }) as ForwardReferenceComponent<'header', InsightCardTitleProps>
 
 const InsightCardLoading: FC<PropsWithChildren<HTMLAttributes<HTMLElement>>> = props => {
-    const { 'aria-label': ariaLabel = 'loading', children, ...attributes } = props
+    const { 'aria-label': ariaLabel = 'Insight loading', children, ...attributes } = props
+    const { isFocused } = useContext(CardContext)
 
     return (
         <InsightCardBanner {...attributes}>
-            <LoadingSpinner aria-label={ariaLabel} />
+            <LoadingSpinner aria-label={ariaLabel} aria-live={isFocused ? 'polite' : 'off'} />
             {children}
         </InsightCardBanner>
     )

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect, Suspense } from 'react'
+import React, { Suspense } from 'react'
 
 import { mdiPlus } from '@mdi/js'
 import { matchPath, useHistory } from 'react-router'
 import { useLocation } from 'react-router-dom'
 
-import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import {
@@ -51,9 +50,7 @@ interface CodeInsightsRootPageProps extends TelemetryProps {
     activeView: CodeInsightsRootPageTab
 }
 
-export const CodeInsightsRootPage: React.FunctionComponent<
-    React.PropsWithChildren<CodeInsightsRootPageProps>
-> = props => {
+export const CodeInsightsRootPage: React.FunctionComponent<CodeInsightsRootPageProps> = props => {
     const { telemetryService, activeView } = props
     const location = useLocation()
     const query = useQuery()
@@ -63,8 +60,6 @@ export const CodeInsightsRootPage: React.FunctionComponent<
         matchPath<{ dashboardId?: string }>(location.pathname, {
             path: `/insights${CodeInsightsRootPageURLPaths.CodeInsights}`,
         }) ?? {}
-
-    const [hasInsightPageBeenViewed, markMainPageAsViewed] = useTemporarySetting('insights.wasMainPageOpen', false)
 
     const dashboardId = params?.dashboardId ?? ALL_INSIGHTS_DASHBOARD.id
     const queryParameterDashboardId = query.get('dashboardId') ?? ALL_INSIGHTS_DASHBOARD.id
@@ -77,12 +72,6 @@ export const CodeInsightsRootPage: React.FunctionComponent<
                 return history.push(`/insights/about?dashboardId=${dashboardId}`)
         }
     }
-
-    useEffect(() => {
-        if (hasInsightPageBeenViewed === false) {
-            markMainPageAsViewed(true)
-        }
-    }, [hasInsightPageBeenViewed, markMainPageAsViewed])
 
     return (
         <CodeInsightsPage>
@@ -122,7 +111,7 @@ export const CodeInsightsRootPage: React.FunctionComponent<
                         <DashboardsContentPage telemetryService={telemetryService} dashboardID={params?.dashboardId} />
                     </TabPanel>
                     <TabPanel>
-                        <Suspense fallback={<LoadingSpinner />}>
+                        <Suspense fallback={<LoadingSpinner aria-label='Loading Code Insights Getting started page' />}>
                             <LazyCodeInsightsGettingStartedPage telemetryService={telemetryService} />
                         </Suspense>
                     </TabPanel>

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.tsx
@@ -27,11 +27,10 @@ export const DashboardsContentPage: FC<DashboardsContentPageProps> = props => {
     const { url } = useRouteMatch()
 
     const { dashboards, loading } = useInsightDashboards()
-
-    const currentDashboard = useMemo(() => dashboards?.find(dashboard => dashboard.id === dashboardID), [
-        dashboardID,
-        dashboards,
-    ])
+    const currentDashboard = useMemo(
+        () => dashboards?.find(dashboard => dashboard.id === dashboardID),
+        [dashboardID, dashboards]
+    )
 
     if (!dashboardID) {
         // In case if url doesn't have a dashboard id we should fall back on
@@ -42,7 +41,7 @@ export const DashboardsContentPage: FC<DashboardsContentPageProps> = props => {
     if (loading || !dashboards) {
         return (
             <div data-testid="loading-spinner">
-                <LoadingSpinner inline={false} />
+                <LoadingSpinner aria-live='off' inline={false} />
             </div>
         )
     }

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboard-menu/DashboardMenu.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { mdiDotsVertical } from '@mdi/js'
 import classNames from 'classnames'
+import { noop } from 'lodash';
 
 import {
     Button,
@@ -28,15 +29,14 @@ export enum DashboardMenuAction {
 }
 
 export interface DashboardMenuProps {
-    innerRef: React.Ref<HTMLButtonElement>
     dashboard?: InsightDashboard
-    onSelect?: (action: DashboardMenuAction) => void
     tooltipText?: string
     className?: string
+    onSelect?: (action: DashboardMenuAction) => void
 }
 
 export const DashboardMenu: React.FunctionComponent<React.PropsWithChildren<DashboardMenuProps>> = props => {
-    const { innerRef, dashboard, onSelect = () => {}, tooltipText, className } = props
+    const { dashboard, tooltipText, className, onSelect = noop } = props
 
     const { dashboard: dashboardPermission } = useUiFeatures()
     const menuPermissions = dashboardPermission.getContextActionsPermissions(dashboard)
@@ -45,7 +45,6 @@ export const DashboardMenu: React.FunctionComponent<React.PropsWithChildren<Dash
         <Menu>
             <Tooltip content={tooltipText} placement="right">
                 <MenuButton
-                    ref={innerRef}
                     variant="icon"
                     outline={true}
                     className={classNames(className, styles.triggerButton)}

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/DashboardsContent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import classNames from 'classnames'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
@@ -45,7 +45,6 @@ export const DashboardsContent: React.FunctionComponent<React.PropsWithChildren<
     const [isDeleteDashboardActive, setDeleteDashboardActive] = useState<boolean>(false)
 
     const [copyURL, isCopied] = useCopyURLHandler()
-    const menuReference = useRef<HTMLButtonElement | null>(null)
 
     useEffect(() => {
         telemetryService.logViewEvent('Insights')
@@ -72,14 +71,6 @@ export const DashboardsContent: React.FunctionComponent<React.PropsWithChildren<
             }
             case DashboardMenuAction.CopyLink: {
                 copyURL()
-
-                // Re-trigger trigger tooltip event catching logic to activate
-                // copied tooltip appearance
-                requestAnimationFrame(() => {
-                    menuReference.current?.blur()
-                    menuReference.current?.focus()
-                })
-
                 return
             }
         }
@@ -104,11 +95,10 @@ export const DashboardsContent: React.FunctionComponent<React.PropsWithChildren<
                 />
 
                 <DashboardMenu
-                    innerRef={menuReference}
-                    tooltipText={isCopied ? 'Copied!' : undefined}
                     dashboard={currentDashboard}
-                    onSelect={handleSelect}
+                    tooltipText={isCopied ? 'Copied!' : undefined}
                     className="mr-auto"
+                    onSelect={handleSelect}
                 />
 
                 <Tooltip content={addRemovePermissions.tooltip} placement="bottom">

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
@@ -35,7 +35,7 @@ export const DashboardInsights: React.FunctionComponent<React.PropsWithChildren<
     const insightContextValue = useMemo(() => ({ currentDashboard, dashboards }), [currentDashboard, dashboards])
 
     if (insights === undefined) {
-        return <LoadingSpinner inline={false} />
+        return <LoadingSpinner aria-hidden={true} inline={false} />
     }
 
     return (


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/41684

## Background
Prior to this PR, we had a bunch of sync-blocking "loading" announcements on the dashboard page. This happened because all insight cards contain `<LoadingSpinner />`, which renders the spinner with `aria-live='polite'`. When we render many insights, we have a bunch of loading loading loading ... announcements. 

So in order to solve this and still have loading announcements in this PR, we enable insight card loading announcements only when we have a focus on or inside the card. In all other case we disable loading spinner announcements with `aria-live="off"`.

Also, in this PR, we turn off a few high-level loading spinners that we use as a fallback for the dashboard page loading. 

## Test plan
- Turn on voice-over and go to the dashboard page
- There should be no loading announcements until you focus the insight card and this insight is still loading. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-loading-insights.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
