### PR TITLE
Remove reference to add code hosts as a user

### DIFF
--- a/doc/admin/external_service/bitbucket_cloud.md
+++ b/doc/admin/external_service/bitbucket_cloud.md
@@ -4,14 +4,10 @@ Site admins can sync Git repositories hosted on [Bitbucket Cloud](https://bitbuc
 
 To connect Bitbucket Cloud to Sourcegraph:
 
-1. Depending on whether you are a site admin or user:
-    1. *Site admin*: Go to **Site admin > Manage code hosts > Add repositories**
-    1. *User*: Go to **Settings > Manage hosts**.
-1. Select **Bitbucket.org**.
-1. Configure the connection to Bitbucket Cloud using the action buttons above the text field. Additional fields can be added using <kbd>Cmd/Ctrl+Space</kbd> for auto-completion. See the [configuration documentation below](#configuration).
-1. Press **Add repositories**.
-
-**NOTE** That adding code hosts as a user is currently in private beta.
+1. Go to **Site admin > Manage code hosts > Add repositories**.
+2. Select **Bitbucket.org**.
+3. Configure the connection to Bitbucket Cloud using the action buttons above the text field. Additional fields can be added using <kbd>Cmd/Ctrl+Space</kbd> for auto-completion. See the [configuration documentation below](#configuration).
+4. Press **Add repositories**.
 
 ## Repository syncing
 

--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -4,12 +4,10 @@ Site admins can sync Git repositories hosted on [GitHub.com](https://github.com)
 
 To connect GitHub to Sourcegraph:
 
-1. Depending on whether you are a site admin or user:
-    1. *Site admin*: Go to **Site admin > Manage code hosts**
-    1. *User*: Go to **Settings > Manage code hosts**.
-1. Select **GitHub**.
-1. Configure the connection to GitHub using the action buttons above the text field, and additional fields can be added using <kbd>Cmd/Ctrl+Space</kbd> for auto-completion. See the [configuration documentation below](#configuration).
-1. Press **Add repositories**.
+1. Go to **Site admin > Manage code hosts**
+2. Select **GitHub**.
+3. Configure the connection to GitHub using the action buttons above the text field, and additional fields can be added using <kbd>Cmd/Ctrl+Space</kbd> for auto-completion. See the [configuration documentation below](#configuration).
+4. Press **Add repositories**.
 
 In this example, the kubernetes public repository on GitHub is added by selecting **Add a singe repository** and replacing `<owner>/<repository>` with `kubernetes/kubernetes`:
 
@@ -23,8 +21,6 @@ In this example, the kubernetes public repository on GitHub is added by selectin
   ]
 }
 ```
-
-> NOTE: Adding code hosts as a user is currently in private beta.
 
 ## Supported versions
 

--- a/doc/admin/external_service/gitlab.md
+++ b/doc/admin/external_service/gitlab.md
@@ -4,14 +4,10 @@ Site admins can sync Git repositories hosted on [GitLab](https://gitlab.com) (Gi
 
 To connect GitLab to Sourcegraph:
 
-1. Depending on whether you are a site admin or user:
-    1. *Site admin*: Go to **Site admin > Manage code hosts > Add repositories**
-    1. *User*: Go to **Settings > Manage code hosts**.
-1. Select **GitLab**.
-1. Configure the connection to GitLab using the action buttons above the text field, and additional fields can be added using <kbd>Cmd/Ctrl+Space</kbd> for auto-completion. See the [configuration documentation below](#configuration).
-1. Press **Add repositories**.
-
-**NOTE** That adding code hosts as a user is currently in private beta.
+1. Go to **Site admin > Manage code hosts > Add repositories**
+2. Select **GitLab**.
+3. Configure the connection to GitLab using the action buttons above the text field, and additional fields can be added using <kbd>Cmd/Ctrl+Space</kbd> for auto-completion. See the [configuration documentation below](#configuration).
+4. Press **Add repositories**.
 
 ## Supported versions
 

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -25,12 +25,7 @@ Adding Perforce depots as an [external code host](../external_service/index.md) 
 
 To connect Perforce to Sourcegraph:
 
-1. Depending on whether you are a site admin or user:
-   1. *Site admin*: Go to **Site admin > Manage code hosts > Add code host**
-   1. *User*: Go to **Settings > Code host connections**.
-
-        > NOTE: That adding code hosts as a user is currently in private beta.
-
+1. Go to **Site admin > Manage code hosts > Add code host**
 2. Select **Perforce**.
 3. Configure the connection to Perforce using the action buttons above the text field, and additional fields can be added using <kbd>Cmd/Ctrl+Space</kbd> for auto-completion. See the [configuration documentation below](#configuration).
 4. Click **Add repositories**.


### PR DESCRIPTION
I've just found some references in our docs to code hosts added by users. As we don't support user added code hosts anymore, I am updating the docs.

## Test plan
Manually tested locally that changes look as expected.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
