### PR TITLE
batches: disable workspaces preview when server-side execution is not enabled

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.story.tsx
@@ -1,5 +1,5 @@
 import { DecoratorFn, Meta, Story } from '@storybook/react'
-import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
+import { MATCH_ANY_PARAMETERS, WildcardMockedResponse, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import {
@@ -11,6 +11,8 @@ import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../../../../components/WebStory'
 import { GET_BATCH_CHANGE_TO_EDIT } from '../../create/backend'
+import { GET_LICENSE_AND_USAGE_INFO } from '../../list/backend'
+import { getLicenseAndUsageInfoResult } from '../../list/testData'
 import {
     ACTIVE_EXECUTORS_MOCK,
     mockBatchChange,
@@ -61,6 +63,15 @@ const SETTINGS_CASCADE = {
     ],
 }
 
+const LICENSED: WildcardMockedResponse = {
+    request: {
+        query: getDocumentNode(GET_LICENSE_AND_USAGE_INFO),
+        variables: MATCH_ANY_PARAMETERS,
+    },
+    result: { data: getLicenseAndUsageInfoResult(true) },
+    nMatches: Number.POSITIVE_INFINITY,
+}
+
 const FIRST_TIME_MOCKS = new WildcardMockLink([
     {
         request: {
@@ -82,6 +93,7 @@ const FIRST_TIME_MOCKS = new WildcardMockLink([
         },
         nMatches: Number.POSITIVE_INFINITY,
     },
+    LICENSED,
     ACTIVE_EXECUTORS_MOCK,
     ...UNSTARTED_CONNECTION_MOCKS,
 ])
@@ -129,6 +141,7 @@ const MULTIPLE_SPEC_MOCKS = new WildcardMockLink([
         },
         nMatches: Number.POSITIVE_INFINITY,
     },
+    LICENSED,
     ACTIVE_EXECUTORS_MOCK,
     ...UNSTARTED_WITH_CACHE_CONNECTION_MOCKS,
 ])
@@ -161,6 +174,7 @@ const NOT_FOUND_MOCKS = new WildcardMockLink([
         result: { data: { batchChange: null } },
         nMatches: Number.POSITIVE_INFINITY,
     },
+    LICENSED,
     ACTIVE_EXECUTORS_MOCK,
     ...UNSTARTED_CONNECTION_MOCKS,
 ])
@@ -191,6 +205,7 @@ const INVALID_SPEC_MOCKS = new WildcardMockLink([
         result: { data: { batchChange: mockBatchChange() } },
         nMatches: Number.POSITIVE_INFINITY,
     },
+    LICENSED,
     ACTIVE_EXECUTORS_MOCK,
     ...UNSTARTED_CONNECTION_MOCKS,
 ])
@@ -225,6 +240,7 @@ const NO_EXECUTORS_MOCKS = new WildcardMockLink([
         result: { data: { batchChange: mockBatchChange({ name: 'hello-world' }) } },
         nMatches: Number.POSITIVE_INFINITY,
     },
+    LICENSED,
     NO_ACTIVE_EXECUTORS_MOCK,
     ...UNSTARTED_CONNECTION_MOCKS,
 ])

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.module.scss
@@ -119,3 +119,17 @@
         display: none;
     }
 }
+
+.no-executors-warning-icon {
+    margin-top: 1rem;
+    color: var(--icon-muted);
+}
+
+.modal-link {
+    font-size: 1em;
+    padding: 0;
+    border: 0;
+    margin: 0;
+    font-weight: normal;
+    font-style: italic;
+}

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
@@ -69,16 +69,18 @@ export const WorkspacesPreview: React.FunctionComponent<React.PropsWithChildren<
     // Check for active executors to tell if we are able to run batch changes server-side.
     const { data } = useQuery<CheckExecutorsAccessTokenResult, CheckExecutorsAccessTokenVariables>(EXECUTORS, {})
 
-    return data?.areExecutorsConfigured ? (
-        <MemoizedWorkspacesPreview
-            batchSpec={batchSpec}
-            editor={editor}
-            workspacesPreview={workspacesPreview}
-            isReadOnly={isReadOnly}
-        />
-    ) : (
-        <NoExecutorsWarning />
-    )
+    return data ? (
+        data.areExecutorsConfigured ? (
+            <MemoizedWorkspacesPreview
+                batchSpec={batchSpec}
+                editor={editor}
+                workspacesPreview={workspacesPreview}
+                isReadOnly={isReadOnly}
+            />
+        ) : (
+            <NoExecutorsWarning />
+        )
+    ) : null
 }
 
 type MemoizedWorkspacesPreviewProps = WorkspacesPreviewProps &


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/43924, pending any design adjustment from Daniel.

Uses the `areExecutorsConfigured` query to disable the workspaces preview when server-side execution isn't enabled, as without executors the preview button literally doesn't do anything. 🤦‍♀️

<img src="https://user-images.githubusercontent.com/8942601/199866970-37ca6798-f1d4-423e-8df3-3a1be5ad1932.png" width="500"> 

While adding and updating storybooks, I noticed we had some missing mocks for the license and usage info request, so I fixed that up.

## Test plan

Manually tested, added and updated storybook stories.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-disable-preview-if-no-ssbc.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

