### PR TITLE
JetBrains: Extract CONTRIBUTING.md from the readme

### DIFF
--- a/client/jetbrains/CONTRIBUTING.md
+++ b/client/jetbrains/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to Sourcegraph JetBrains Extension
+
+Thank you for your interest in contributing to Sourcegraph!
+The goal of this document is to provide a high-level overview of how you can contribute to the Sourcegraph JetBrains Extension.
+Please refer to our [main CONTRIBUTING](https://github.com/sourcegraph/sourcegraph/blob/main/CONTRIBUTING.md) docs for general information regarding contributing to any Sourcegraph feature.
+
+
+## License
+
+Apache
+
+## Feedback
+
+Your feedback is important to us and is greatly appreciated. Please do not hesitate to submit your ideas or suggestions about how we can improve the extension to our [JetBrains Plugin Feedback Discussion Thread](https://github.com/sourcegraph/sourcegraph/discussions/43930) on GitHub.
+
+## Issues / Bugs
+
+New issues and feature requests can be filed through our [issue tracker](https://github.com/sourcegraph/sourcegraph/issues/new?labels=team/integrations,jetbrains-ide&title=JetBrains:+&projects=Integrations%20Project%20Board) using the `jetbrains-ide` & `team/integrations` labels.
+
+## Development
+
+- Clone `https://github.com/sourcegraph/sourcegraph` (on Windows, you'll need to use WSL2)
+- Run `yarn install` in the root directory to get all dependencies
+- Run `yarn generate` in the root directory to generate graphql files
+- Go to `client/jetbrains/` and run `yarn build` to generate the JS files, or `yarn watch` to watch for changes and regenerate on the fly
+- You can test the “Find with Sourcegraph” window by running `yarn standalone` in the `client/jetbrains/` directory and opening [http://localhost:3000/](http://localhost:3000/) in your browser.
+- Run the plugin in a sandboxed IDE by running `./gradlew runIde`. This will start the platform with the versions defined in `gradle.properties`, [here](https://github.com/sourcegraph/sourcegraph/blob/main/client/jetbrains/gradle.properties#L14-L16).
+  - Note: 2021.3 or later is required for Macs with Apple Silicon chips.
+- Build a deployable plugin artifact by running `./gradlew buildPlugin`. The output file is `build/distributions/Sourcegraph.zip`.
+
+## Publishing a new version
+
+The publishing process is based on the [intellij-platform-plugin-template](https://github.com/JetBrains/intellij-platform-plugin-template).
+
+### Publishing from your local machine
+
+1. Update `pluginVersion` in `gradle.properties`
+ 
+    - To create pre-release builds with the same version as a previous one, append `.{N}`. For example, `1.0.0-alpha`, then `1.0.0-alpha.1`, `1.0.0-alpha.2`, and so on.
+
+2. Describe the changes in the `[Unreleased]` section of `client/jetbrains/CHANGELOG.md` then remove any empty headers
+3. Go through
+   the [manual test cases](https://docs.google.com/document/d/1LtYeBrSd3Q7mDxq4Qk4T3XRBSWBNux6IXRJOi2WAb6E/edit#) (
+   Sourcegraph internal doc)
+4. Make sure `runIde` is not running
+5. Commit your changes
+6. Run `PUBLISH_TOKEN=<YOUR TOKEN HERE> ./scripts/release.sh` from inside the `client/jetbrains` directory (You can [generate tokens on the JetBrains marketplace](https://plugins.jetbrains.com/author/me/tokens)).
+7. Commit changes and create PR
+
+## Enabling web view debugging
+
+Parts of this extension rely on the [JCEF](https://plugins.jetbrains.com/docs/intellij/jcef.html) web view features built into the JetBrains platform. To enable debugging tools for this view, please follow these steps:
+
+1. [Enable JetBrains internal mode](https://plugins.jetbrains.com/docs/intellij/enabling-internal.html)
+2. Open Find Actions: (<kbd>Ctrl+Shift+A</kbd> / <kbd>⌘⇧A</kbd>)
+3. Search for "Registry..." and open it
+4. Find option `ide.browser.jcef.debug.port`
+5. Change the default value to an open port (we use `9222`)
+6. Restart IDE
+7. Open the “Find with Sourcegraph” window (<kbd>Alt+A</kbd> / <kbd>⌥A</kbd>)
+8. Switch to a browser window, go to [`localhost:9222`](http://localhost:9222), and select the Sourcegraph window. Sometimes it needs some back and forth to focus the external browser with the JCEF component also focused—you may need to move the popup out of the way and click the external browser rather than using <kbd>Alt+Tab</kbd> / <kbd>⌘Tab</kbd>.

--- a/client/jetbrains/README.md
+++ b/client/jetbrains/README.md
@@ -77,13 +77,13 @@ The plugin works with all JetBrains IDEs, including:
       you may try to set up a pattern that uses the `@`, `:`, and `.git`/`.perforce` boundaries, _or_ specify a
       replacement
       pair for _each repo_ or _each depot_ you may have. If none of these solutions work for you, please raise this
-      at [support@sourcegraph.com](mailto:support@sourcegraph.com) and we'll prioritize making this more convenient.
+      at [support@sourcegraph.com](mailto:support@sourcegraph.com), and we'll prioritize making this more convenient.
 - **Globbing**: Determines whether you can specify sets of filenames with wildcard characters.
 
 ### Git remote setting
 
 By default, the plugin will use the git remote called `origin` to determine which repository on Sourcegraph corresponds
-to your local repository. If your `origin` remote doesn’t match Sourcegraph, you may instead configure a Git remote by
+to your local repository. If your `origin` remote doesn't match Sourcegraph, you may instead configure a Git remote by
 the name of `sourcegraph`. It will take priority when creating Sourcegraph links.
 
 ### Setting levels
@@ -117,7 +117,7 @@ These settings have the highest priority. You can set them in a less than intuit
    </project>
    ```
    If the file already exists, then just add the option lines next to the original ones.
-2. Reopen your project to let the IDE catch up with the changes. Now you have custom settings enabled for this project. In the future, when you have this project open and you edit your settings in the Settings UI, they will be saved to the **project-level** file.
+2. Reopen your project to let the IDE catch up with the changes. Now you have custom settings enabled for this project. In the future, when you have this project open, and you edit your settings in the Settings UI, they will be saved to the **project-level** file.
 3. To remove the project-level settings, open the XML again and remove the lines you want to set on the app level.
 
 **Storage location:** `{project root}/.idea/sourcegraph.xml`
@@ -144,7 +144,7 @@ remoteUrlReplacements = git.example.com, git-web.example.com
 
 You can configure JetBrains to set custom keymaps for Sourcegraph actions:
 
-1. Open the JetBrains preferences panel and go to to the Keymap page.
+1. Open the JetBrains preferences panel and go to the Keymap page.
 2. Filter by "sourcegraph" to see actions supplied by this plugin.
 3. Now select an option to overwrite the keymap information and supply the new bindings.
 
@@ -160,49 +160,6 @@ If you have any questions, feedback, or bug report, we appreciate if you [open a
 - Click `Plugins` in the left-hand pane, then the `Installed` tab at the top
 - Find `Sourcegraph` → Right click → `Uninstall` (or uncheck to disable)
 
-## Development
-
-- Clone `https://github.com/sourcegraph/sourcegraph` (on Windows, you'll need to use WSL2)
-- Run `yarn install` in the root directory to get all dependencies
-- Run `yarn generate` in the root directory to generate graphql files
-- Go to `client/jetbrains/` and run `yarn build` to generate the JS files, or `yarn watch` to watch for changes and regenerate on the fly
-- You can test the “Find with Sourcegraph” window by running `yarn standalone` in the `client/jetbrains/` directory and opening [http://localhost:3000/](http://localhost:3000/) in your browser.
-- Run the plugin in a sandboxed IDE by running `./gradlew runIde`. This will start the platform with the versions defined in `gradle.properties`, [here](https://github.com/sourcegraph/sourcegraph/blob/main/client/jetbrains/gradle.properties#L14-L16).
-  - Note: 2021.3 or later is required for Macs with Apple Silicon chips.
-- Build a deployable plugin artifact by running `./gradlew buildPlugin`. The output file is `build/distributions/Sourcegraph.zip`.
-
-## Publishing a new version
-
-The publishing process is based on the [intellij-platform-plugin-template](https://github.com/JetBrains/intellij-platform-plugin-template).
-
-### Publishing from your local machine
-
-1. Update `pluginVersion` in `gradle.properties`
-
-- To create pre-release builds with the same version as a previous one, append `.{N}`. For example, `1.0.0-alpha`, then `1.0.0-alpha.1`, `1.0.0-alpha.2`, and so on.
-
-2. Describe the changes in the `[Unreleased]` section of `client/jetbrains/CHANGELOG.md` then remove any empty headers
-3. Go through
-   the [manual test cases](https://docs.google.com/document/d/1LtYeBrSd3Q7mDxq4Qk4T3XRBSWBNux6IXRJOi2WAb6E/edit#) (
-   Sourcegraph internal doc)
-4. Make sure `runIde` is not running
-5. Commit your changes
-6. Run `PUBLISH_TOKEN=<YOUR TOKEN HERE> ./scripts/release.sh` from inside the `client/jetbrains` directory (You can [generate tokens on the JetBrains marketplace](https://plugins.jetbrains.com/author/me/tokens)).
-7. Commit changes and create PR
-
 ## Version History
 
 See [`CHANGELOG.md`](https://github.com/sourcegraph/sourcegraph/blob/main/client/jetbrains/CHANGELOG.md).
-
-## Enable web view debugging
-
-Parts of this extension rely on the [JCEF](https://plugins.jetbrains.com/docs/intellij/jcef.html) web view features built into the JetBrains platform. To enable debugging tools for this view, please follow these steps:
-
-1. [Enable JetBrains internal mode](https://plugins.jetbrains.com/docs/intellij/enabling-internal.html)
-2. Open Find Actions: (<kbd>Ctrl+Shift+A</kbd> / <kbd>⌘⇧A</kbd>)
-3. Search for "Registry..." and open it
-4. Find option `ide.browser.jcef.debug.port`
-5. Change the default value to an open port (we use `9222`)
-6. Restart IDE
-7. Open the “Find with Sourcegraph” window (<kbd>Alt+A</kbd> / <kbd>⌥A</kbd>)
-8. Switch to a browser window, go to [`localhost:9222`](http://localhost:9222), and select the Sourcegraph window. Sometimes it needs some back and forth to focus the external browser with the JCEF component also focused—you may need to move the popup out of the way and click the external browser rather than using <kbd>Alt+Tab</kbd> / <kbd>⌘Tab</kbd>.


### PR DESCRIPTION
I think it's more user-friendly to separate dev docs form user docs.
With our new settings description, the user docs got long enough to justify removing the dev docs from there.
I've reused some parts of the VS Code CONTRIBUTING.md, and created a new discussion (https://github.com/sourcegraph/sourcegraph/discussions/43930) for JetBrains plugin feedback which I linked in the new docs to get this aspect on par with our VS Code setup.

## Test plan

(Only docs change)