### PR TITLE
JetBrains: Add manual testing page, clean up IDE extension docs a bit

### DIFF
--- a/client/jetbrains/CONTRIBUTING.md
+++ b/client/jetbrains/CONTRIBUTING.md
@@ -40,8 +40,7 @@ The publishing process is based on the [intellij-platform-plugin-template](https
 
 2. Describe the changes in the `[Unreleased]` section of `client/jetbrains/CHANGELOG.md` then remove any empty headers
 3. Go through
-   the [manual test cases](https://docs.google.com/document/d/1LtYeBrSd3Q7mDxq4Qk4T3XRBSWBNux6IXRJOi2WAb6E/edit#) (
-   Sourcegraph internal doc)
+   the [manual test cases](https://docs.sourcegraph.com/integration/jetbrains/manual_testing)
 4. Make sure `runIde` is not running
 5. Commit your changes
 6. Run `PUBLISH_TOKEN=<YOUR TOKEN HERE> ./scripts/release.sh` from inside the `client/jetbrains` directory (You can [generate tokens on the JetBrains marketplace](https://plugins.jetbrains.com/author/me/tokens)).

--- a/doc/integration/index.md
+++ b/doc/integration/index.md
@@ -2,27 +2,28 @@
 
 Sourcegraph integrates with your other tools to help you search, navigate, and review your code.
 
+- [GraphQL API](../api/graphql/index.md): create custom tools using Sourcegraph data
 - [Browser extension](browser_extension/index.md): go-to-definitions and hovers in your code host and code reviews
 - Code hosts
-  - [GitHub](github.md)
-  - [GitLab](gitlab.md)
-  - [Bitbucket Cloud](bitbucket_cloud.md)
-  - [Bitbucket Server / Bitbucket Data Center](bitbucket_server.md)
-<!--  - [Phabricator](phabricator.md) -->
-<!--  - [AWS CodeCommit](aws_codecommit.md) -->
-<!--  - [Gitolite](gitolite.md) -->
-  - [JVM dependencies](jvm.md)
-  - [npm dependencies](npm.md)
-  - [Python dependencies](python.md)
-  - [Go dependencies](go.md)
-  - [Ruby dependencies](ruby.md)
-  - [Other Git repository hosts](../admin/external_service/other.md)
-  - [Editor plugins](editor.md): jump to Sourcegraph from your editor
-    - [Open in Editor](open_in_editor.md): jump to your editor from Sourcegraph
-    - [Search shortcuts](browser_extension/how-tos/browser_search_engine.md): quickly search from your browser
-  - Launcher extensions
-    - [Sourcegraph for Raycast](https://www.raycast.com/bobheadxi/sourcegraph) (unofficial): search code, browse
-      notebooks, and manage batch changes from the Raycast launcher
-- [GraphQL API](../api/graphql/index.md): create custom tools using Sourcegraph data
+    - [GitHub](github.md)
+    - [GitLab](gitlab.md)
+    - [Bitbucket Cloud](bitbucket_cloud.md)
+    - [Bitbucket Server / Bitbucket Data Center](bitbucket_server.md)
+    - [JVM dependencies](jvm.md)
+    - [npm dependencies](npm.md)
+    - [Python dependencies](python.md)
+    - [Go dependencies](go.md)
+    - [Ruby dependencies](ruby.md)
+    - [Other Git repository hosts](../admin/external_service/other.md)
+    - [Editor plugins](editor.md): jump to Sourcegraph from your editor
+        - [Open in Editor](open_in_editor.md): jump to your editor from Sourcegraph
+        - [Search shortcuts](browser_extension/how-tos/browser_search_engine.md): quickly search from your browser
+    - Launcher extensions
+        - [Sourcegraph for Raycast](https://www.raycast.com/bobheadxi/sourcegraph) (unofficial): search code, browse
+        notebooks, and manage batch changes from the Raycast launcher
+- IDE Extensions
+    - [JetBrains](jetbrains/index.md)
+        - [Manual testing](jetbrains/manual_testing.md)
+    - [VS Code](vscode/index.md)
 
 ![GitHub pull request integration](https://storage.googleapis.com/sourcegraph-assets/code-graph/docs/github-pr.png)

--- a/doc/integration/jetbrains/index.md
+++ b/doc/integration/jetbrains/index.md
@@ -1,0 +1,5 @@
+# JetBrains plugin
+
+- See user docs at [client/jetbrains/README.md](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/client/jetbrains/README.md)
+- See dev docs at [client/jetbrains/CONTRIBUTING.md](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/client/jetbrains/CONTRIBUTING.md)
+- [Manual test cases](manual_testing.md)

--- a/doc/integration/jetbrains/manual_testing.md
+++ b/doc/integration/jetbrains/manual_testing.md
@@ -1,0 +1,146 @@
+# JetBrains plugin manual test cases
+
+## Overview
+
+All these test scripts are written in a way so that humans can perform it, but also an E2E testing tool can run it eventually.
+
+Each of these test cases should be run either right after starting the IDE and opening a project, _or_ after closing and reopening a project, to make sure we have a clean state.
+
+### Test case format anatomy
+
+* The numbered items are the steps to perform in order.
+* The indented bullets are assertions.
+
+### Performing a test manually
+
+If a red error notification appears at the bottom right of the IDE, that means we have a problem.
+
+Same if any of the assertions fail.
+
+If there is a problem, we should either investigate right away (typically, if a developer does the manual testing), or create an issue with the error message / specifying which test case failed, and any additional helpful context.
+
+## Test cases
+
+### Website-related features
+
+#### Preparation
+
+**Perforce** testing is slightly tricky because we don’t currently have a lot of Perforce code hosts added to any of our Sourcegraph instances. Try this:
+
+* Use [https://cse-k8s.sgdev.org/](https://cse-k8s.sgdev.org/) as your Sourcegraph URL
+* Generate an access token for yourself for CSE-K8S (admin user in 1Password), set that
+* Set up a Perforce client
+* Set `perforce.sgdev.org:1666` for the port. User is “admin”, password is in 1Password.
+* Make sure your connection work, and _actually connect_ in P4V (connection didn’t work without this step  in IntelliJ for me)
+* Create a workspace for yourself (delete an old one if you bump into the 20-workspace limit), and include the `test-large-depot` depot
+* In the JetBrains plugin settings, set the replacement string to `perforce.sgdev.org:,perforce.beatrix.com:app/,.perforce,/patch/core.perforce`.
+* At this point, your files should open properly in your browser.
+
+#### Search Selection and Open/Copy features
+
+1. Open a project with a file that’s under Git version control
+2. Right click on editor | Sourcegraph | Search Selection on Sourcegraph Web
+    * Make sure it searches the current selection in all repos
+3. Right click on editor | Sourcegraph | Search Selection in Repository on Sourcegraph Web
+    * Make sure it searches the current selection in the current repo
+4. Right click on editor | Sourcegraph | Open Selection in Sourcegraph Web
+    * Make sure it opens the right file on the web
+5. Copy Sourcegraph File Link
+    * Make sure it copies the right URL (should be good if the previous point worked because they share the logic.)
+6. Repeat it with a Perforce repo.
+
+#### “Open Revision Diff in Sourcegraph Web”
+
+1. Open a project that has files under Git version control
+2. Open Version Control (⌘9) | Log
+3. Right click on a commit and choose Open Revision Diff in Sourcegraph Web
+4. Make sure the right page opens on the Sourcegraph instance set up in the plugin settings
+5. (Would be cool to also test this each time with a project that has files from multiple repositories.)
+6. Repeat the process with a project that has files under Perforce version control.
+
+### Find with Sourcegraph
+
+#### Popup opens, loads, and closes
+
+Why: To make sure the popup is discoverable and generally works
+
+1. Press the shortcut for the popup
+    * The popup should become active
+    * The popup should be in the “loading” state
+2. Wait until the “loading” state is gone
+    * It should not take more than ~five seconds
+3. Close the popup with ESC
+    * The popup should become hidden
+4. Open “Find Action” (⌘⇧A) and search for “open sourcegraph search view” and select the first result
+    * The popup should become active
+    * The popup should not be in the “loading” state
+5. Click the header of the IDE main window
+    * The popup should become hidden
+6. In the main menu, choose Edit | Find | Find on Sourcegraph…
+    * The popup should become active
+
+#### Browser doesn’t disappear after a few opens
+
+Why: After opening and closing the "Find on Sourcegraph" popup four-five times on Mac, the browser disappears if _circumstances are not right_. This bug should be fixed, but it may reappear if we mess something up.
+
+1. Open popup with the shortcut
+    * The popup should become active
+2. Wait until the “loading” state is gone
+3. Close the popup with ESC
+4. Open popup with the shortcut
+    * The popup should become active, and the browser should be visible
+5. Repeat 3–4 at least five times.
+
+#### Search results are displayed and navigation works
+
+Why: To make sure that the most basic functionality of the popup works
+
+1. Open the popup with the shortcut
+2. Wait for the browser content to load
+3. Type “repo:^github\.com/sourcegraph/sourcegraph file:index.ts”
+    * It should type into the input box
+    * The content should be exactly the same as what was typed
+4. Press Enter
+5. Wait for the search results and preview to load
+    * The result list and the preview box should populate
+6. Press `↓` key
+7. Wait for the search results and preview to load
+    * The preview should be different from the previous one
+8. Press `⌥Enter`
+    * The popup should close
+    * A new editor tab should open
+    * The content of the new tab should be the same as the last preview
+9. Open the popup with the shortcut
+10. Press ⌘A, type “repo:^github\.com/sourcegraph/sourcegraph” and press Enter
+11. Wait for the search results to load
+    * The result list should update
+    * The preview state should be “No preview available”
+12. Press ⌥Enter
+    * The popup should close
+    * A browser should open (if automated: an “open browser” trigger should be sent)
+
+#### Server connection success/failure is recognized
+
+This test needs a valid access token that can be generated at https://sourcegraph.com/users/{username}/settings/tokens
+
+* Open Settings with `⌘`,
+* Go to Tools | Sourcegraph
+* Set the URL to “[https://sourcegraph.com](https://sourcegraph.com)”
+* Set the access token to a valid one
+    * Press Enter to save settings
+* Open the popup with the shortcut
+* Wait for the browser content to load.
+    * The search box should be visible
+* Close the popup with ESC
+* Open Settings with ⌘,
+* Type “TEST” after the end of the valid access token.
+* Press Enter to save settings
+* Open the popup with the shortcut
+    * The search box should not be visible, an error message should appear
+    * The preview should be saying “No preview available”
+* Close the popup with ESC
+* Open Settings with ⌘,
+* Remove “TEST” to again have the valid access token.
+* Press Enter to save settings
+* Open the popup with the shortcut
+    * The search box should be visible again.

--- a/doc/integration/vscode/index.md
+++ b/doc/integration/vscode/index.md
@@ -1,0 +1,4 @@
+# VS Code extension
+
+- See user docs at [client/vscode/README.md](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/client/vscode/README.md)
+- See dev docs at [client/vscode/CONTRIBUTING.md](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/client/vscode/CONTRIBUTING.md)


### PR DESCRIPTION
- Moved the manual tests from our private [doc](https://docs.google.com/document/d/1LtYeBrSd3Q7mDxq4Qk4T3XRBSWBNux6IXRJOi2WAb6E/edit#heading=h.zdm5em366pex) to a new page.
  - Made sure there was no sensitive data in the doc.
- Created page stubs for our VS Code and JetBrains extensions. They didn't exist in the docs. I just linked to the readmes and "contribute" files to make those docs a bit more discoverable.
- Fixed the tabulation. This is a weird one because our [Prettier config sets](https://share.cleanshot.com/u9F6FQ) Markdown tab widths to `2`, but our Docs site engine doesn't work well with tab widths of `2`. ([live version is broken](https://share.cleanshot.com/EHjBZb), [my updated version looks good](https://share.cleanshot.com/vbUzpT)). This might be worth raising with the team to collect input and maybe change our Prettier config.

## Test plan

- Only docs change
- I've tested all the links and the pages, everything seemed fine to me.