### PR TITLE
Scope markdown header CSS rules to the markdown block

### DIFF
--- a/client/web/src/notebooks/blocks/markdown/NotebookMarkdownBlock.module.scss
+++ b/client/web/src/notebooks/blocks/markdown/NotebookMarkdownBlock.module.scss
@@ -78,6 +78,15 @@
     code {
         border-radius: var(--border-radius);
     }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        margin-top: 1rem;
+    }
 }
 
 .heading-link {
@@ -94,13 +103,4 @@
     .is-embedded & {
         display: none;
     }
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-    margin-top: 1rem;
 }


### PR DESCRIPTION
Without prefixing a class name, the recent change of adding margin to to the header tags is appliad globally to all header elements. Whoops 🙈 

![image](https://user-images.githubusercontent.com/458591/199955479-45a12964-53f5-4f19-8067-e2675d6afe8d.png)

## Test plan

I verified that the changes work locally:

<img width="1201" alt="Screenshot 2022-11-04 at 11 47 20" src="https://user-images.githubusercontent.com/458591/199955654-a5c08635-54c7-4506-9f02-0b2abd316921.png">

This also fixes the reference panel:

<img width="703" alt="Screenshot 2022-11-04 at 11 51 59" src="https://user-images.githubusercontent.com/458591/199955731-5b5e1a0c-8bc4-472f-b7aa-526d50fef2e6.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-css-bleed.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
