### PR TITLE
Turn off scheduled jobs for forks p.2

### DIFF
--- a/.github/workflows/buildchecker-history.yml
+++ b/.github/workflows/buildchecker-history.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   report:
+    if: github.repository == 'sourcegraph/sourcegraph'
     runs-on: ubuntu-latest
 
     # secrets for this workflow are configured in the 'autobuildsherrif' environment.

--- a/.github/workflows/licenses-update.yml
+++ b/.github/workflows/licenses-update.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   update:
+    if: github.repository == 'sourcegraph/sourcegraph'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   touch_sg:
+    if: github.repository == 'sourcegraph/sourcegraph'
     name: Touch sourcegraph/sg
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Continuation of #43783. Turns off workflows that sends these mails from a forked repo.

* ~~Run failed: Code Insights daily iteration board check Slack bot - main~~
* Run failed: sg-binary-release - main
* Run failed: Licenses Update - main
* Run failed: buildchecker-history - main

## Test plan

1. Fork and wait until next workday ends. There should be no message about failed job.
2. Touch `sg` code. There should be no notification about failed `Touch sourcegraph/sg ` job.
