### PR TITLE
sg: do not ask for ppa confirmation in setup

### DIFF
--- a/dev/sg/dependencies/ubuntu.go
+++ b/dev/sg/dependencies/ubuntu.go
@@ -34,7 +34,7 @@ var Ubuntu = []category{
 			{
 				Name:  "git",
 				Check: checkAction(check.Combine(check.InPath("git"), checkGitVersion(">= 2.38.1"))),
-				Fix:   aptGetInstall("git", "sudo add-apt-repository ppa:git-core/ppa"),
+				Fix:   aptGetInstall("git", "sudo add-apt-repository -y ppa:git-core/ppa"),
 			}, {
 				Name:  "pcre",
 				Check: checkAction(check.HasUbuntuLibrary("libpcre3-dev")),


### PR DESCRIPTION
This should remove the confirmation dialog when running `sg setup` on a system with outdated `git`.

```
...
Reading package lists...
 The most current stable version of Git for Ubuntu.

For release candidates, go to https://launchpad.net/~git-core/+archive/candidate .
 More info: https://launchpad.net/~git-core/+archive/ubuntu/ppa
Press [ENTER] to continue or Ctrl-c to cancel adding it.
```

## Test plan

Run this on a Ubuntu 20.04 machine where `git` is older than 2.28.1
```
sg setup --oss --fix
```
There should be no dialog awaiting confirmation for adding `git` PPA.
