### PR TITLE
Enable use of executor secrets for SSBC

### DIFF
--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
@@ -60,7 +60,7 @@ func transformRecord(ctx context.Context, logger log.Logger, s BatchesStore, job
 	ctx = actor.WithActor(ctx, actor.FromUser(job.UserID))
 
 	// Next, we fetch all secrets that are requested for the execution.
-	rk := requiredSecrets(batchSpec.Spec)
+	rk := batchSpec.Spec.RequiredSecrets()
 	var secrets []*database.ExecutorSecret
 	if len(rk) > 0 {
 		esStore := s.DatabaseDB().ExecutorSecrets(keyring.Default().ExecutorSecretKey)
@@ -205,20 +205,4 @@ func transformRecord(ctx context.Context, logger log.Logger, s BatchesStore, job
 		},
 		RedactedValues: redactedEnvVars,
 	}, nil
-}
-
-// requiredSecrets inspects all steps for env vars used and compiles a deduplicated
-// list from those.
-func requiredSecrets(spec *batcheslib.BatchSpec) []string {
-	requiredSecretsMap := map[string]struct{}{}
-	requiredSecrets := []string{}
-	for _, step := range spec.Steps {
-		for _, v := range step.Env.OuterVars() {
-			if _, ok := requiredSecretsMap[v]; !ok {
-				requiredSecretsMap[v] = struct{}{}
-				requiredSecrets = append(requiredSecrets, v)
-			}
-		}
-	}
-	return requiredSecrets
 }

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
@@ -14,6 +14,7 @@ import (
 	apiclient "github.com/sourcegraph/sourcegraph/enterprise/internal/executor"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 	"github.com/sourcegraph/sourcegraph/lib/batches/template"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -55,8 +56,40 @@ func transformRecord(ctx context.Context, logger log.Logger, s BatchesStore, job
 	}
 
 	// 🚨 SECURITY: Set the actor on the context so we check for permissions
-	// when loading the repository.
+	// when loading the repository and getting secret values.
 	ctx = actor.WithActor(ctx, actor.FromUser(job.UserID))
+
+	// Next, we fetch all secrets that are requested for the execution.
+	rk := requiredSecrets(batchSpec.Spec)
+	var secrets []*database.ExecutorSecret
+	if len(rk) > 0 {
+		esStore := s.DatabaseDB().ExecutorSecrets(keyring.Default().ExecutorSecretKey)
+		secrets, _, err = esStore.List(ctx, database.ExecutorSecretScopeBatches, database.ExecutorSecretsListOpts{
+			NamespaceUserID: batchSpec.NamespaceUserID,
+			NamespaceOrgID:  batchSpec.NamespaceOrgID,
+			Keys:            rk,
+		})
+		if err != nil {
+			return apiclient.Job{}, err
+		}
+	}
+
+	// And build the env vars from the secrets.
+	secretEnvVars := make([]string, len(secrets))
+	redactedEnvVars := make(map[string]string, len(secrets))
+	esalStore := s.DatabaseDB().ExecutorSecretAccessLogs()
+	for i, secret := range secrets {
+		// Get the secret value. This also creates an access log entry in the
+		// name of the user.
+		val, err := secret.Value(ctx, esalStore)
+		if err != nil {
+			return apiclient.Job{}, err
+		}
+
+		secretEnvVars[i] = fmt.Sprintf("%s=%s", secret.Key, val)
+		// We redact secret values as ${{ secrets.NAME }}.
+		redactedEnvVars[val] = fmt.Sprintf("${{ secrets.%s }}", secret.Key)
+	}
 
 	repo, err := s.DatabaseDB().Repos().Get(ctx, workspace.RepoID)
 	if err != nil {
@@ -167,10 +200,25 @@ func transformRecord(ctx context.Context, logger log.Logger, s BatchesStore, job
 				Key:      "batch-exec",
 				Commands: commands,
 				Dir:      ".",
-				Env:      []string{},
+				Env:      secretEnvVars,
 			},
 		},
-		// Nothing to redact for now. We want to add secrets here once implemented.
-		RedactedValues: map[string]string{},
+		RedactedValues: redactedEnvVars,
 	}, nil
+}
+
+// requiredSecrets inspects all steps for env vars used and compiles a deduplicated
+// list from those.
+func requiredSecrets(spec *batcheslib.BatchSpec) []string {
+	requiredSecretsMap := map[string]struct{}{}
+	requiredSecrets := []string{}
+	for _, step := range spec.Steps {
+		for _, v := range step.Env.OuterVars() {
+			if _, ok := requiredSecretsMap[v]; !ok {
+				requiredSecretsMap[v] = struct{}{}
+				requiredSecrets = append(requiredSecrets, v)
+			}
+		}
+	}
+	return requiredSecrets
 }

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
@@ -60,7 +60,7 @@ func transformRecord(ctx context.Context, logger log.Logger, s BatchesStore, job
 	ctx = actor.WithActor(ctx, actor.FromUser(job.UserID))
 
 	// Next, we fetch all secrets that are requested for the execution.
-	rk := batchSpec.Spec.RequiredSecrets()
+	rk := batchSpec.Spec.RequiredEnvVars()
 	var secrets []*database.ExecutorSecret
 	if len(rk) > 0 {
 		esStore := s.DatabaseDB().ExecutorSecrets(keyring.Default().ExecutorSecretKey)

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
@@ -79,7 +79,7 @@ func (r *batchSpecWorkspaceCreator) process(
 	}
 
 	// Next, we fetch all secrets that are requested by the spec.
-	rk := spec.Spec.RequiredSecrets()
+	rk := spec.Spec.RequiredEnvVars()
 	var secrets []*database.ExecutorSecret
 	if len(rk) > 0 {
 		userCtx := actor.WithActor(ctx, actor.FromUser(spec.UserID))

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
@@ -82,9 +82,8 @@ func (r *batchSpecWorkspaceCreator) process(
 	rk := spec.Spec.RequiredEnvVars()
 	var secrets []*database.ExecutorSecret
 	if len(rk) > 0 {
-		userCtx := actor.WithActor(ctx, actor.FromUser(spec.UserID))
 		esStore := r.store.DatabaseDB().ExecutorSecrets(keyring.Default().ExecutorSecretKey)
-		secrets, _, err = esStore.List(userCtx, database.ExecutorSecretScopeBatches, database.ExecutorSecretsListOpts{
+		secrets, _, err = esStore.List(ctx, database.ExecutorSecretScopeBatches, database.ExecutorSecretsListOpts{
 			NamespaceUserID: spec.NamespaceUserID,
 			NamespaceOrgID:  spec.NamespaceOrgID,
 			Keys:            rk,

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
@@ -247,6 +247,7 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 				FileMatches: workspace.FileMatches,
 			},
 			workspace.Path,
+			[]string{},
 			workspace.OnlyFetchWorkspace,
 			batchSpec.Spec.Steps,
 			result.StepIndex,

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
@@ -3,6 +3,7 @@ package workers
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	bt "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
@@ -175,9 +177,22 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 
-	repos, _ := bt.CreateTestRepos(t, context.Background(), db, 1)
+	ctx := context.Background()
+
+	repos, _ := bt.CreateTestRepos(t, ctx, db, 1)
 
 	user := bt.CreateTestUser(t, db, true)
+	userCtx := actor.WithActor(ctx, actor.FromUser(user.ID))
+
+	secret := &database.ExecutorSecret{
+		Key:       "FOO",
+		CreatorID: user.ID,
+	}
+	secretValue := "sosecret"
+	err := db.ExecutorSecrets(nil).Create(userCtx, database.ExecutorSecretScopeBatches, secret, secretValue)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
@@ -231,7 +246,7 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 		}
 	}
 
-	createCacheEntry := func(t *testing.T, batchSpec *btypes.BatchSpec, workspace *service.RepoWorkspace, result *execution.AfterStepResult, mounts []*btypes.BatchSpecWorkspaceFile) *btypes.BatchSpecExecutionCacheEntry {
+	createCacheEntry := func(t *testing.T, batchSpec *btypes.BatchSpec, workspace *service.RepoWorkspace, result *execution.AfterStepResult, envVarValue string, mounts []*btypes.BatchSpecWorkspaceFile) *btypes.BatchSpecExecutionCacheEntry {
 		t.Helper()
 
 		key := cache.KeyForWorkspace(
@@ -247,7 +262,7 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 				FileMatches: workspace.FileMatches,
 			},
 			workspace.Path,
-			[]string{},
+			[]string{fmt.Sprintf("FOO=%s", envVarValue)},
 			workspace.OnlyFetchWorkspace,
 			batchSpec.Spec.Steps,
 			result.StepIndex,
@@ -272,11 +287,11 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 		workspace := buildWorkspace("caching-enabled")
 
 		batchSpec := createBatchSpec(t, false, bt.TestRawBatchSpecYAML)
-		entry := createCacheEntry(t, batchSpec, workspace, executionResult, nil)
+		entry := createCacheEntry(t, batchSpec, workspace, executionResult, secretValue, nil)
 
 		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
 		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
-		if err := creator.process(context.Background(), resolver.DummyBuilder, job); err != nil {
+		if err := creator.process(userCtx, resolver.DummyBuilder, job); err != nil {
 			t.Fatalf("proces failed: %s", err)
 		}
 
@@ -336,6 +351,53 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 		}
 	})
 
+	t.Run("secret value changed", func(t *testing.T) {
+		workspace := buildWorkspace("secret-value-changed")
+
+		batchSpec := createBatchSpec(t, false, bt.TestRawBatchSpecYAML)
+		entry := createCacheEntry(t, batchSpec, workspace, executionResult, "not the secret value", nil)
+
+		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
+		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
+		if err := creator.process(userCtx, resolver.DummyBuilder, job); err != nil {
+			t.Fatalf("proces failed: %s", err)
+		}
+
+		have, _, err := s.ListBatchSpecWorkspaces(context.Background(), store.ListBatchSpecWorkspacesOpts{BatchSpecID: batchSpec.ID})
+		if err != nil {
+			t.Fatalf("listing workspaces failed: %s", err)
+		}
+
+		assertWorkspacesEqual(t, have, []*btypes.BatchSpecWorkspace{
+			{
+				RepoID:             repos[0].ID,
+				BatchSpecID:        batchSpec.ID,
+				ChangesetSpecIDs:   []int64{},
+				Branch:             "refs/heads/main",
+				Commit:             "secret-value-changed",
+				FileMatches:        []string{},
+				Path:               "",
+				OnlyFetchWorkspace: true,
+				CachedResultFound:  false,
+			},
+		})
+
+		reloadedEntries, err := s.ListBatchSpecExecutionCacheEntries(context.Background(), store.ListBatchSpecExecutionCacheEntriesOpts{
+			UserID: batchSpec.UserID,
+			Keys:   []string{entry.Key},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(reloadedEntries) != 1 {
+			t.Fatal("cache entry not found")
+		}
+		reloadedEntry := reloadedEntries[0]
+		if !reloadedEntry.LastUsedAt.Equal(entry.LastUsedAt) {
+			t.Fatalf("cache entry LastUsedAt updated. want=%s, have=%s", entry.LastUsedAt, reloadedEntry.LastUsedAt)
+		}
+	})
+
 	t.Run("only step is statically skipped", func(t *testing.T) {
 		workspace := buildWorkspace("no-step-after-eval")
 
@@ -359,7 +421,7 @@ changesetTemplate:
 
 		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
 		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
-		if err := creator.process(context.Background(), resolver.DummyBuilder, job); err != nil {
+		if err := creator.process(userCtx, resolver.DummyBuilder, job); err != nil {
 			t.Fatalf("proces failed: %s", err)
 		}
 
@@ -414,7 +476,7 @@ changesetTemplate:
 
 		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
 		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
-		if err := creator.process(context.Background(), resolver.DummyBuilder, job); err != nil {
+		if err := creator.process(userCtx, resolver.DummyBuilder, job); err != nil {
 			t.Fatalf("proces failed: %s", err)
 		}
 
@@ -451,11 +513,11 @@ changesetTemplate:
 		resultWithoutDiff := *executionResult
 		resultWithoutDiff.Diff = ""
 
-		entry := createCacheEntry(t, batchSpec, workspace, &resultWithoutDiff, nil)
+		entry := createCacheEntry(t, batchSpec, workspace, &resultWithoutDiff, secretValue, nil)
 
 		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
 		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
-		if err := creator.process(context.Background(), resolver.DummyBuilder, job); err != nil {
+		if err := creator.process(userCtx, resolver.DummyBuilder, job); err != nil {
 			t.Fatalf("proces failed: %s", err)
 		}
 
@@ -489,11 +551,11 @@ changesetTemplate:
 		workspace := buildWorkspace("caching-disabled")
 
 		batchSpec := createBatchSpec(t, true, bt.TestRawBatchSpecYAML)
-		entry := createCacheEntry(t, batchSpec, workspace, executionResult, nil)
+		entry := createCacheEntry(t, batchSpec, workspace, executionResult, secretValue, nil)
 
 		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
 		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
-		if err := creator.process(context.Background(), resolver.DummyBuilder, job); err != nil {
+		if err := creator.process(userCtx, resolver.DummyBuilder, job); err != nil {
 			t.Fatalf("proces failed: %s", err)
 		}
 
@@ -538,11 +600,11 @@ changesetTemplate:
 
 		batchSpec := createBatchSpec(t, false, bt.TestRawBatchSpecYAML)
 
-		entry := createCacheEntry(t, batchSpec, workspace, executionResult, nil)
+		entry := createCacheEntry(t, batchSpec, workspace, executionResult, secretValue, nil)
 
 		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
 		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
-		if err := creator.process(context.Background(), resolver.DummyBuilder, job); err != nil {
+		if err := creator.process(userCtx, resolver.DummyBuilder, job); err != nil {
 			t.Fatalf("proces failed: %s", err)
 		}
 
@@ -568,11 +630,11 @@ changesetTemplate:
 
 		batchSpec := createBatchSpec(t, false, bt.TestRawBatchSpecYAML)
 
-		entry := createCacheEntry(t, batchSpec, workspace, executionResult, nil)
+		entry := createCacheEntry(t, batchSpec, workspace, executionResult, secretValue, nil)
 
 		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
 		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
-		if err := creator.process(context.Background(), resolver.DummyBuilder, job); err != nil {
+		if err := creator.process(userCtx, resolver.DummyBuilder, job); err != nil {
 			t.Fatalf("proces failed: %s", err)
 		}
 
@@ -621,11 +683,11 @@ changesetTemplate:
 		batchSpec := createBatchSpec(t, false, rawSpec)
 		mounts := []*btypes.BatchSpecWorkspaceFile{{BatchSpecID: batchSpec.ID, FileName: "hello.txt", Content: []byte("hello!"), Size: 6, ModifiedAt: time.Now().UTC()}}
 		createBatchSpecMounts(t, mounts)
-		entry := createCacheEntry(t, batchSpec, workspace, executionResult, mounts)
+		entry := createCacheEntry(t, batchSpec, workspace, executionResult, secretValue, mounts)
 
 		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
 		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
-		if err := creator.process(context.Background(), resolver.DummyBuilder, job); err != nil {
+		if err := creator.process(userCtx, resolver.DummyBuilder, job); err != nil {
 			t.Fatalf("proces failed: %s", err)
 		}
 
@@ -719,11 +781,11 @@ changesetTemplate:
 			{BatchSpecID: batchSpec.ID, FileName: "world.txt", Content: []byte("hello!"), Size: 6, ModifiedAt: time.Now().UTC()},
 		}
 		createBatchSpecMounts(t, mounts)
-		entry := createCacheEntry(t, batchSpec, workspace, executionResult, mounts)
+		entry := createCacheEntry(t, batchSpec, workspace, executionResult, secretValue, mounts)
 
 		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
 		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
-		if err := creator.process(context.Background(), resolver.DummyBuilder, job); err != nil {
+		if err := creator.process(userCtx, resolver.DummyBuilder, job); err != nil {
 			t.Fatalf("proces failed: %s", err)
 		}
 
@@ -897,6 +959,88 @@ importChangesets:
 
 	if diff := cmp.Diff(want, have); diff != "" {
 		t.Fatal(diff)
+	}
+}
+
+func TestBatchSpecWorkspaceCreatorProcess_Secrets(t *testing.T) {
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+
+	user := bt.CreateTestUser(t, db, true)
+	userCtx := actor.WithActor(ctx, actor.FromUser(user.ID))
+
+	repos, _ := bt.CreateTestRepos(t, ctx, db, 4)
+
+	s := store.New(db, &observation.TestContext, nil)
+
+	secret := &database.ExecutorSecret{
+		Key:       "FOO",
+		CreatorID: user.ID,
+	}
+	err := db.ExecutorSecrets(nil).Create(userCtx, database.ExecutorSecretScopeBatches, secret, "sosecret")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	batchSpec, err := btypes.NewBatchSpecFromRaw(bt.TestRawBatchSpecYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	batchSpec.UserID = user.ID
+	batchSpec.NamespaceUserID = user.ID
+	if err := s.CreateBatchSpec(ctx, batchSpec); err != nil {
+		t.Fatal(err)
+	}
+
+	job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
+
+	resolver := &dummyWorkspaceResolver{
+		workspaces: []*service.RepoWorkspace{
+			{
+				RepoRevision: &service.RepoRevision{
+					Repo:        repos[0],
+					Branch:      "refs/heads/main",
+					Commit:      "d34db33f",
+					FileMatches: []string{},
+				},
+				Path:               "",
+				OnlyFetchWorkspace: true,
+			},
+		},
+	}
+
+	creator := &batchSpecWorkspaceCreator{store: s, logger: logtest.Scoped(t)}
+	if err := creator.process(userCtx, resolver.DummyBuilder, job); err != nil {
+		t.Fatalf("proces failed: %s", err)
+	}
+
+	have, _, err := s.ListBatchSpecWorkspaces(ctx, store.ListBatchSpecWorkspacesOpts{BatchSpecID: batchSpec.ID})
+	if err != nil {
+		t.Fatalf("listing workspaces failed: %s", err)
+	}
+
+	want := []*btypes.BatchSpecWorkspace{
+		{
+			RepoID:             repos[0].ID,
+			BatchSpecID:        batchSpec.ID,
+			ChangesetSpecIDs:   []int64{},
+			Branch:             "refs/heads/main",
+			Commit:             "d34db33f",
+			FileMatches:        []string{},
+			Path:               "",
+			OnlyFetchWorkspace: true,
+		},
+	}
+
+	assertWorkspacesEqual(t, have, want)
+
+	c, err := db.ExecutorSecretAccessLogs().Count(ctx, database.ExecutorSecretAccessLogsListOpts{ExecutorSecretID: secret.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if have, want := c, 1; have != want {
+		t.Fatalf("invalid number of access logs created: have=%d want=%d", have, want)
 	}
 }
 

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -477,18 +477,6 @@ type createBatchSpecForExecutionOpts struct {
 // transaction, possibly creating ChangesetSpecs if the spec contains
 // importChangesets statements, and finally creating a BatchSpecResolutionJob.
 func (s *Service) createBatchSpecForExecution(ctx context.Context, tx *store.Store, opts createBatchSpecForExecutionOpts) error {
-	// The global env is always mocked to be empty for executors, so we just
-	// want to throw a validation error here for now.
-	var errs error
-	for i, step := range opts.spec.Spec.Steps {
-		if !step.Env.IsStatic() {
-			errs = errors.Append(errs, batcheslib.NewValidationError(errors.Errorf("step %d includes one or more dynamic environment variables, which are unsupported in this Sourcegraph version", i+1)))
-		}
-	}
-	if errs != nil {
-		return errs
-	}
-
 	opts.spec.CreatedFromRaw = true
 	opts.spec.AllowIgnored = opts.allowIgnored
 	opts.spec.AllowUnsupported = opts.allowUnsupported

--- a/enterprise/internal/batches/testing/specs.go
+++ b/enterprise/internal/batches/testing/specs.go
@@ -22,9 +22,10 @@ const TestRawBatchSpec = `{
     {
       "run": "echo 'foobar'",
       "container": "alpine",
-      "env": {
-        "PATH": "/work/foobar:$PATH"
-      }
+      "env": [
+		{ "PATH": "/work/foobar:$PATH" },
+		"FOO"
+	  ]
     }
   ],
   "changesetTemplate": {

--- a/enterprise/internal/batches/testing/specs.go
+++ b/enterprise/internal/batches/testing/specs.go
@@ -48,7 +48,8 @@ steps:
 - run: echo 'foobar'
   container: alpine
   env:
-    PATH: "/work/foobar:$PATH"
+    - PATH: "/work/foobar:$PATH"
+    - FOO
 changesetTemplate:
   title: Hello World
   body: My first batch change!

--- a/internal/database/executor_secrets.go
+++ b/internal/database/executor_secrets.go
@@ -627,3 +627,10 @@ func encryptExecutorSecret(ctx context.Context, key encryption.Key, raw string) 
 	data, keyID, err := encryption.MaybeEncrypt(ctx, key, raw)
 	return []byte(data), keyID, err
 }
+
+// NewMockExecutorSecret can be used in tests to create an executor secret with a
+// set inner value. DO NOT USE THIS OUTSIDE OF TESTS.
+func NewMockExecutorSecret(s *ExecutorSecret, v string) *ExecutorSecret {
+	s.encryptedValue = NewUnencryptedCredential([]byte(v))
+	return s
+}

--- a/internal/database/executor_secrets.go
+++ b/internal/database/executor_secrets.go
@@ -179,11 +179,16 @@ func (s *executorSecretStore) Transact(ctx context.Context) (ExecutorSecretStore
 	}, err
 }
 
-var ErrEmptyExecutorSecret = errors.New("empty executor secret is not allowed")
+var ErrEmptyExecutorSecretKey = errors.New("empty executor secret key is not allowed")
+var ErrEmptyExecutorSecretValue = errors.New("empty executor secret value is not allowed")
 
 func (s *executorSecretStore) Create(ctx context.Context, scope ExecutorSecretScope, secret *ExecutorSecret, value string) error {
+	if len(secret.Key) == 0 {
+		return ErrEmptyExecutorSecretKey
+	}
+
 	if len(value) == 0 {
-		return ErrEmptyExecutorSecret
+		return ErrEmptyExecutorSecretValue
 	}
 
 	// SECURITY: check that the current user is authorized to create a secret for the given namespace.
@@ -223,7 +228,7 @@ func (s *executorSecretStore) Create(ctx context.Context, scope ExecutorSecretSc
 
 func (s *executorSecretStore) Update(ctx context.Context, scope ExecutorSecretScope, secret *ExecutorSecret, value string) error {
 	if len(value) == 0 {
-		return ErrEmptyExecutorSecret
+		return ErrEmptyExecutorSecretValue
 	}
 
 	// SECURITY: check that the current user is authorized to update a secret in the given namespace.

--- a/lib/batches/batch_spec.go
+++ b/lib/batches/batch_spec.go
@@ -244,3 +244,19 @@ func SkippedStepsForRepo(spec *BatchSpec, repoName string, fileMatches []string)
 
 	return skipped, nil
 }
+
+// RequiredSecrets inspects all steps for outer environment variables used and
+// compiles a deduplicated list from those.
+func (s *BatchSpec) RequiredSecrets() []string {
+	requiredSecretsMap := map[string]struct{}{}
+	requiredSecrets := []string{}
+	for _, step := range s.Steps {
+		for _, v := range step.Env.OuterVars() {
+			if _, ok := requiredSecretsMap[v]; !ok {
+				requiredSecretsMap[v] = struct{}{}
+				requiredSecrets = append(requiredSecrets, v)
+			}
+		}
+	}
+	return requiredSecrets
+}

--- a/lib/batches/batch_spec.go
+++ b/lib/batches/batch_spec.go
@@ -245,18 +245,18 @@ func SkippedStepsForRepo(spec *BatchSpec, repoName string, fileMatches []string)
 	return skipped, nil
 }
 
-// RequiredSecrets inspects all steps for outer environment variables used and
+// RequiredEnvVars inspects all steps for outer environment variables used and
 // compiles a deduplicated list from those.
-func (s *BatchSpec) RequiredSecrets() []string {
-	requiredSecretsMap := map[string]struct{}{}
-	requiredSecrets := []string{}
+func (s *BatchSpec) RequiredEnvVars() []string {
+	requiredMap := map[string]struct{}{}
+	required := []string{}
 	for _, step := range s.Steps {
 		for _, v := range step.Env.OuterVars() {
-			if _, ok := requiredSecretsMap[v]; !ok {
-				requiredSecretsMap[v] = struct{}{}
-				requiredSecrets = append(requiredSecrets, v)
+			if _, ok := requiredMap[v]; !ok {
+				requiredMap[v] = struct{}{}
+				required = append(required, v)
 			}
 		}
 	}
-	return requiredSecrets
+	return required
 }

--- a/lib/batches/batch_spec_test.go
+++ b/lib/batches/batch_spec_test.go
@@ -379,7 +379,7 @@ func (s sortableInt32) Less(i, j int) bool { return s[i] < s[j] }
 
 func (s sortableInt32) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
-func TestBatchSpec_RequiredSecrets(t *testing.T) {
+func TestBatchSpec_RequiredEnvVars(t *testing.T) {
 	for name, tc := range map[string]struct {
 		in   string
 		want []string
@@ -407,7 +407,7 @@ func TestBatchSpec_RequiredSecrets(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			have := spec.RequiredSecrets()
+			have := spec.RequiredEnvVars()
 
 			if diff := cmp.Diff(have, tc.want); diff != "" {
 				t.Errorf("unexpected value: have=%q want=%q", have, tc.want)

--- a/lib/batches/batch_spec_test.go
+++ b/lib/batches/batch_spec_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
 )
 
 func TestParseBatchSpec(t *testing.T) {
@@ -377,3 +378,40 @@ func (s sortableInt32) Len() int { return len(s) }
 func (s sortableInt32) Less(i, j int) bool { return s[i] < s[j] }
 
 func (s sortableInt32) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+func TestBatchSpec_RequiredSecrets(t *testing.T) {
+	for name, tc := range map[string]struct {
+		in   string
+		want []string
+	}{
+		"no steps": {
+			in:   `steps:`,
+			want: []string{},
+		},
+		"no env vars": {
+			in:   `steps: [run: asdf]`,
+			want: []string{},
+		},
+		"static variable": {
+			in:   `steps: [{run: asdf, env: [a: b]}]`,
+			want: []string{},
+		},
+		"dynamic variable": {
+			in:   `steps: [{run: asdf, env: [a]}]`,
+			want: []string{"a"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var spec BatchSpec
+			err := yaml.Unmarshal([]byte(tc.in), &spec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			have := spec.RequiredSecrets()
+
+			if diff := cmp.Diff(have, tc.want); diff != "" {
+				t.Errorf("unexpected value: have=%q want=%q", have, tc.want)
+			}
+		})
+	}
+}

--- a/lib/batches/env/env.go
+++ b/lib/batches/env/env.go
@@ -107,6 +107,18 @@ func (e Environment) IsStatic() bool {
 	return true
 }
 
+// OuterVars returns the list of environment variables that depend on any
+// environment variable defined in the global env.
+func (e Environment) OuterVars() []string {
+	outer := []string{}
+	for _, v := range e.vars {
+		if v.value == nil {
+			outer = append(outer, v.name)
+		}
+	}
+	return outer
+}
+
 // Resolve resolves the environment, using values from the given outer
 // environment to fill in environment values as needed. If an environment
 // variable doesn't exist in the outer environment, then an empty string will be

--- a/lib/batches/env/env_test.go
+++ b/lib/batches/env/env_test.go
@@ -255,3 +255,37 @@ func TestEnvironment_Resolve(t *testing.T) {
 		}
 	})
 }
+
+func TestEnvironment_OuterVars(t *testing.T) {
+	for name, tc := range map[string]struct {
+		in   Environment
+		want []string
+	}{
+		"no variables": {
+			in:   Environment{},
+			want: []string{},
+		},
+		"static variables": {
+			in: Environment{vars: []variable{
+				{name: "foo", value: stringPtr("bar")},
+				{name: "quux", value: stringPtr("baz")},
+			}},
+			want: []string{},
+		},
+		"dynamic variables and static mixed": {
+			in: Environment{vars: []variable{
+				{name: "foo", value: stringPtr("bar")},
+				{name: "quux", value: nil},
+			}},
+			want: []string{"quux"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			have := tc.in.OuterVars()
+
+			if diff := cmp.Diff(have, tc.want); diff != "" {
+				t.Errorf("unexpected value: have=%q want=%q", have, tc.want)
+			}
+		})
+	}
+}

--- a/lib/batches/execution/cache/cache.go
+++ b/lib/batches/execution/cache/cache.go
@@ -135,13 +135,14 @@ func (key CacheKey) Slug() string {
 	return SlugForRepo(key.Repository.Name, key.Repository.BaseRev)
 }
 
-func KeyForWorkspace(batchChangeAttributes *template.BatchChangeAttributes, r batches.Repository, path string, onlyFetchWorkspace bool, steps []batches.Step, stepIndex int, retriever MetadataRetriever) Keyer {
+func KeyForWorkspace(batchChangeAttributes *template.BatchChangeAttributes, r batches.Repository, path string, globalEnv []string, onlyFetchWorkspace bool, steps []batches.Step, stepIndex int, retriever MetadataRetriever) Keyer {
 	sort.Strings(r.FileMatches)
 
 	return CacheKey{
 		Repository:            r,
 		Path:                  path,
 		OnlyFetchWorkspace:    onlyFetchWorkspace,
+		GlobalEnv:             globalEnv,
 		Steps:                 steps,
 		BatchChangeAttributes: batchChangeAttributes,
 		StepIndex:             stepIndex,


### PR DESCRIPTION
This PR makes use of the generic executor secrets infrastructure in SSBC! We will now read the secret values for resolving workspaces and when spawning an executor job, to make sure that everything is set as required and that the cache keys are properly calculated so that a secret value change would invalidate the cache.

For this to have any effect, src-cli will need to be bumped to a new version. It will not break existing executions though so this is safe to merge.

## Test plan

Added a bunch of tests.