### PR TITLE
Remove useless status messages tests

### DIFF
--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -122,43 +122,6 @@ func TestStatusMessages(t *testing.T) {
 			},
 		},
 		{
-			name:        "site-admin: subset cloned",
-			repos:       []*types.Repo{{Name: "foobar"}, {Name: "barfoo"}},
-			cloneStatus: map[string]types.CloneStatus{"foobar": types.CloneStatusCloned},
-			res: []StatusMessage{
-				{
-					Cloning: &CloningProgress{
-						Message: "1 repository enqueued for cloning.",
-					},
-				},
-			},
-		},
-		{
-			name:  "site-admin: more cloned than stored",
-			repos: []*types.Repo{{Name: "foobar"}},
-			cloneStatus: map[string]types.CloneStatus{
-				"foobar": types.CloneStatusCloned,
-				"barfoo": types.CloneStatusCloned,
-			},
-			res: nil,
-		},
-		{
-			name:  "site-admin: cloned different than stored",
-			repos: []*types.Repo{{Name: "foobar"}, {Name: "barfoo"}},
-			cloneStatus: map[string]types.CloneStatus{
-				"one":   types.CloneStatusCloned,
-				"two":   types.CloneStatusCloned,
-				"three": types.CloneStatusCloned,
-			},
-			res: []StatusMessage{
-				{
-					Cloning: &CloningProgress{
-						Message: "2 repositories enqueued for cloning.",
-					},
-				},
-			},
-		},
-		{
 			name:  "site-admin: one repo failed to sync",
 			repos: []*types.Repo{{Name: "foobar"}, {Name: "barfoo"}},
 			cloneStatus: map[string]types.CloneStatus{


### PR DESCRIPTION
The tests are useless because they don't test anything. If a repository is in `cloneStatus` but not in `repos` in the test then the clones status write will be skipped.

And since that kind of setup doesn't have an effect the tests become duplicates from other tests and are thus useless.

## Test plan

- These are the tests