### PR TITLE
featureflag: add MemoryStore for use in testing

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -226,21 +226,12 @@ func TestRepository_DefaultBranch(t *testing.T) {
 	}
 }
 
-type mockFeatureFlagStore struct{}
-
-func (m *mockFeatureFlagStore) GetUserFlags(context.Context, int32) (map[string]bool, error) {
-	return map[string]bool{"repository-metadata": true}, nil
-}
-func (m *mockFeatureFlagStore) GetAnonymousUserFlags(context.Context, string) (map[string]bool, error) {
-	return map[string]bool{"repository-metadata": true}, nil
-}
-func (m *mockFeatureFlagStore) GetGlobalFeatureFlags(context.Context) (map[string]bool, error) {
-	return map[string]bool{"repository-metadata": true}, nil
-}
-
 func TestRepository_KVPs(t *testing.T) {
 	ctx := context.Background()
-	ctx = featureflag.WithFlags(ctx, &mockFeatureFlagStore{})
+
+	flags := map[string]bool{"repository-metadata": true}
+	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(flags, flags, flags))
+
 	logger := logtest.Scoped(t)
 	db := database.NewMockDBFrom(database.NewDB(logger, dbtest.NewDB(logger, t)))
 	users := database.NewMockUserStore()

--- a/internal/featureflag/memory_store.go
+++ b/internal/featureflag/memory_store.go
@@ -1,0 +1,41 @@
+package featureflag
+
+import "context"
+
+// NewMemoryStore returns a Store that can be used in tests. It is initialized
+// with user, anonymous user, and global feature flags.
+func NewMemoryStore(user, anonymous, global map[string]bool) Store {
+	if user == nil {
+		user = make(map[string]bool)
+	}
+	if anonymous == nil {
+		anonymous = make(map[string]bool)
+	}
+	if global == nil {
+		global = make(map[string]bool)
+	}
+
+	return &memoryStore{
+		userFlags:          user,
+		anonymousUserFlags: anonymous,
+		globalFlags:        global,
+	}
+}
+
+type memoryStore struct {
+	userFlags          map[string]bool
+	anonymousUserFlags map[string]bool
+	globalFlags        map[string]bool
+}
+
+func (m *memoryStore) GetUserFlags(context.Context, int32) (map[string]bool, error) {
+	return m.userFlags, nil
+}
+
+func (m *memoryStore) GetAnonymousUserFlags(context.Context, string) (map[string]bool, error) {
+	return m.anonymousUserFlags, nil
+}
+
+func (m *memoryStore) GetGlobalFeatureFlags(context.Context) (map[string]bool, error) {
+	return m.globalFlags, nil
+}


### PR DESCRIPTION
I need this for another PR and I think it's helpful to have an ergonomic way to initialize these flags in tests.


## Test plan

- Existing tests