### PR TITLE
ranking: set useDocumentRanks in collectSender

### DIFF
--- a/internal/search/backend/aggregate.go
+++ b/internal/search/backend/aggregate.go
@@ -30,17 +30,10 @@ type collectSender struct {
 	sizeBytes          uint64
 }
 
-type collectOpts struct {
-	maxDocDisplayCount int
-	flushWallTime      time.Duration
-	useDocumentRanks   bool
-	maxSizeBytes       int
-}
-
-func newCollectSender(opts *collectOpts) *collectSender {
+func newCollectSender(opts *zoekt.SearchOptions) *collectSender {
 	return &collectSender{
-		maxDocDisplayCount: opts.maxDocDisplayCount,
-		useDocumentRanks:   opts.useDocumentRanks,
+		maxDocDisplayCount: opts.MaxDocDisplayCount,
+		useDocumentRanks:   opts.UseDocumentRanks,
 	}
 }
 
@@ -81,7 +74,7 @@ func (c *collectSender) Done() (_ *zoekt.SearchResult, ok bool) {
 	c.aggregate = nil
 	c.sizeBytes = 0
 
-	zoekt.SortFiles(agg.Files, c.useDocumentRanks)
+	zoekt.SortFiles(agg.Files, c.useDocumentRanks, false)
 
 	if max := c.maxDocDisplayCount; max > 0 && len(agg.Files) > max {
 		agg.Files = agg.Files[:max]
@@ -93,10 +86,10 @@ func (c *collectSender) Done() (_ *zoekt.SearchResult, ok bool) {
 // newFlushCollectSender creates a sender which will collect and rank results
 // until opts.flushWallTime. After that it will stream each result as it is
 // sent.
-func newFlushCollectSender(opts *collectOpts, sender zoekt.Sender) (zoekt.Sender, func()) {
+func newFlushCollectSender(opts *zoekt.SearchOptions, maxSizeBytes int, sender zoekt.Sender) (zoekt.Sender, func()) {
 	// We don't need to do any collecting, so just pass back the sender to use
 	// directly.
-	if opts.flushWallTime == 0 {
+	if opts.FlushWallTime == 0 {
 		return sender, func() {}
 	}
 
@@ -132,7 +125,7 @@ func newFlushCollectSender(opts *collectOpts, sender zoekt.Sender) (zoekt.Sender
 
 	// Wait flushWallTime to call stopCollecting.
 	go func() {
-		timer := time.NewTimer(opts.flushWallTime)
+		timer := time.NewTimer(opts.FlushWallTime)
 		select {
 		case <-timerCancel:
 			timer.Stop()
@@ -150,7 +143,7 @@ func newFlushCollectSender(opts *collectOpts, sender zoekt.Sender) (zoekt.Sender
 
 				// Protect against too large aggregates. This should be the exception and only
 				// happen for queries yielding an extreme number of results.
-				if opts.maxSizeBytes >= 0 && collectSender.sizeBytes > uint64(opts.maxSizeBytes) {
+				if maxSizeBytes >= 0 && collectSender.sizeBytes > uint64(maxSizeBytes) {
 					stopCollectingAndFlush("max_size_reached")
 
 				}

--- a/internal/search/backend/aggregate.go
+++ b/internal/search/backend/aggregate.go
@@ -74,7 +74,7 @@ func (c *collectSender) Done() (_ *zoekt.SearchResult, ok bool) {
 	c.aggregate = nil
 	c.sizeBytes = 0
 
-	zoekt.SortFiles(agg.Files, c.useDocumentRanks, false)
+	zoekt.SortFiles(agg.Files, c.useDocumentRanks)
 
 	if max := c.maxDocDisplayCount; max > 0 && len(agg.Files) > max {
 		agg.Files = agg.Files[:max]

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -210,14 +210,7 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 
 	siteConfig := newRankingSiteConfig(conf.Get().SiteConfiguration)
 
-	streamer, flushAll := newFlushCollectSender(
-		&collectOpts{
-			maxDocDisplayCount: opts.MaxDocDisplayCount,
-			flushWallTime:      opts.FlushWallTime,
-			maxSizeBytes:       siteConfig.maxSizeBytes,
-		},
-		streamer,
-	)
+	streamer, flushAll := newFlushCollectSender(opts, siteConfig.maxSizeBytes, streamer)
 	defer flushAll()
 
 	// We give each zoekt a little less time to flush so the frontend has a


### PR DESCRIPTION
we accidentially didn't set useDocumentRanks in frontend which made us drop all ranking information at sort time.

Co-authored-by: @keegancsmith 

## Test plan
existing unit tests
