### PR TITLE
JetBrains: Fix compatibility issues with 2.1.0 release

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [2.1.0]
+
+### Added
+
 - Perforce support [pull/43807](https://github.com/sourcegraph/sourcegraph/pull/43807)
 - Multi-repo project support [pull/43807](https://github.com/sourcegraph/sourcegraph/pull/43807)
 

--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -4,20 +4,6 @@
 
 ### Added
 
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
-
-## [2.1.0]
-
-### Added
-
 - Perforce support [pull/43807](https://github.com/sourcegraph/sourcegraph/pull/43807)
 - Multi-repo project support [pull/43807](https://github.com/sourcegraph/sourcegraph/pull/43807)
 

--- a/client/jetbrains/CONTRIBUTING.md
+++ b/client/jetbrains/CONTRIBUTING.md
@@ -35,8 +35,8 @@ The publishing process is based on the [intellij-platform-plugin-template](https
 
 1. Update `pluginVersion` in `gradle.properties`
 
-  - To create pre-release builds with the same version as a previous one, append `.{N}`. For example, `1.0.0-alpha`,
-    then `1.0.0-alpha.1`, `1.0.0-alpha.2`, and so on.
+- To create pre-release builds with the same version as a previous one, append `.{N}`. For example, `1.0.0-alpha`,
+  then `1.0.0-alpha.1`, `1.0.0-alpha.2`, and so on.
 
 2. Describe the changes in the `[Unreleased]` section of `client/jetbrains/CHANGELOG.md` then remove any empty headers
 3. Go through

--- a/client/jetbrains/CONTRIBUTING.md
+++ b/client/jetbrains/CONTRIBUTING.md
@@ -35,19 +35,37 @@ The publishing process is based on the [intellij-platform-plugin-template](https
 
 1. Update `pluginVersion` in `gradle.properties`
 
-   - To create pre-release builds with the same version as a previous one, append `.{N}`. For example, `1.0.0-alpha`, then `1.0.0-alpha.1`, `1.0.0-alpha.2`, and so on.
+  - To create pre-release builds with the same version as a previous one, append `.{N}`. For example, `1.0.0-alpha`,
+    then `1.0.0-alpha.1`, `1.0.0-alpha.2`, and so on.
 
 2. Describe the changes in the `[Unreleased]` section of `client/jetbrains/CHANGELOG.md` then remove any empty headers
 3. Go through
    the [manual test cases](https://docs.sourcegraph.com/integration/jetbrains/manual_testing)
 4. Make sure `runIde` is not running
 5. Commit your changes
-6. Run `PUBLISH_TOKEN=<YOUR TOKEN HERE> ./scripts/release.sh` from inside the `client/jetbrains` directory (You can [generate tokens on the JetBrains marketplace](https://plugins.jetbrains.com/author/me/tokens)).
+6. Run `PUBLISH_TOKEN=<YOUR TOKEN HERE> ./scripts/release.sh` from inside the `client/jetbrains` directory (You
+   can [generate tokens on the JetBrains marketplace](https://plugins.jetbrains.com/author/me/tokens)).
 7. Commit changes and create PR
+
+## Retrying a release
+
+It happened in the past that we had compatibility issues and the version got rejected.
+Here is what to do in this case:
+
+1. Go to the [versions](https://plugins.jetbrains.com/plugin/9682-sourcegraph/versions/) page logged in with a JetBrains
+   plugin admin account
+2. Go to the latest (failed) version, and click the Trash icon to delete it.
+3. Fix the problem in the code
+4. **Important:** Don't forget to revert the info in CHANGELOG.md to the pre-release state. Then you'll need to commit.
+5. Publish the version again
+6. (Here, of course, you'll need to commit CHANGELOG.md again)
+7. You don't need to wait for JetBrains' email—compatibility checks are visible after a few minutes on the same page.
+8. If the version is still rejected, repeat the process.
 
 ## Enabling web view debugging
 
-Parts of this extension rely on the [JCEF](https://plugins.jetbrains.com/docs/intellij/jcef.html) web view features built into the JetBrains platform. To enable debugging tools for this view, please follow these steps:
+Parts of this extension rely on the [JCEF](https://plugins.jetbrains.com/docs/intellij/jcef.html) web view features
+built into the JetBrains platform. To enable debugging tools for this view, please follow these steps:
 
 1. [Enable JetBrains internal mode](https://plugins.jetbrains.com/docs/intellij/enabling-internal.html)
 2. Open Find Actions: (<kbd>Ctrl+Shift+A</kbd> / <kbd>⌘⇧A</kbd>)

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
@@ -1,6 +1,5 @@
 package com.sourcegraph.website;
 
-import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.ApplicationManager;
@@ -26,6 +25,7 @@ import java.util.Optional;
 /**
  * JetBrains IDE action to open a selected revision in Sourcegraph.
  */
+@SuppressWarnings("MissingActionUpdateThread")
 public class OpenRevisionAction extends DumbAwareAction {
     private final Logger logger = Logger.getInstance(this.getClass());
 
@@ -87,11 +87,6 @@ public class OpenRevisionAction extends DumbAwareAction {
                 BrowserOpener.openInBrowser(project, url);
             }
         );
-    }
-
-    @Override
-    public @NotNull ActionUpdateThread getActionUpdateThread() {
-        return ActionUpdateThread.BGT;
     }
 
     @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
@@ -1,6 +1,5 @@
 package com.sourcegraph.website;
 
-import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Caret;
@@ -25,11 +24,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public abstract class SearchActionBase extends DumbAwareAction {
-    @Override
-    public @NotNull ActionUpdateThread getActionUpdateThread() {
-        return ActionUpdateThread.BGT;
-    }
-
     public void actionPerformedMode(@NotNull AnActionEvent event, @NotNull Scope scope) {
         final Project project = event.getProject();
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/SearchRepositoryAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/SearchRepositoryAction.java
@@ -4,6 +4,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import org.jetbrains.annotations.NotNull;
 
 
+@SuppressWarnings("MissingActionUpdateThread")
 public class SearchRepositoryAction extends SearchActionBase {
     @Override
     public void actionPerformed(@NotNull AnActionEvent event) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/SearchSelectionAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/SearchSelectionAction.java
@@ -3,6 +3,7 @@ package com.sourcegraph.website;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import org.jetbrains.annotations.NotNull;
 
+@SuppressWarnings("MissingActionUpdateThread")
 public class SearchSelectionAction extends SearchActionBase {
     @Override
     public void actionPerformed(@NotNull AnActionEvent event) {

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.story.tsx
@@ -83,7 +83,10 @@ export const FiveWebhooksFound: Story = () => (
                                             createWebhookMock(ExternalServiceKind.GITHUB, 'github.com/repo1'),
                                             createWebhookMock(ExternalServiceKind.GITHUB, 'github.com/repo2'),
                                             createWebhookMock(ExternalServiceKind.GITHUB, 'github.com/repo3'),
-                                            createWebhookMock(ExternalServiceKind.BITBUCKETCLOUD, 'bitbucket.com/repo2'),
+                                            createWebhookMock(
+                                                ExternalServiceKind.BITBUCKETCLOUD,
+                                                'bitbucket.com/repo2'
+                                            ),
                                         ],
                                         totalCount: 5,
                                         pageInfo: {

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
@@ -61,7 +61,11 @@ export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChild
                         aria-label="Webhooks"
                     >
                         {connection?.nodes?.map(node => (
-                            <WebhookNode key={node.id} codeHostKind={node.codeHostKind} codeHostURN={node.codeHostURN} />
+                            <WebhookNode
+                                key={node.id}
+                                codeHostKind={node.codeHostKind}
+                                codeHostURN={node.codeHostURN}
+                            />
                         ))}
                     </ConnectionList>
                     {connection && (


### PR DESCRIPTION
JetBrains' compatibility checks failed on the version that I tried to publish today.
The cause was that I was using a (threading-related) class that didn't exist in earlier IDE versions.
I wanted to keep backward compatibility, and the parts in question seemed redundant anyway (they didn't seem to do anything, and I'm handling the threading manually anyway).
So I've removed them, suppressed the related warnings at three locations, and given feedback to JetBrains that it sucks that there's no more guidance on how to handle this.
I've tried releasing again and now their CI is green. (Ahem, yellow, as it was with all our previous versions, for similar compatibility issues. But it's OK.)

## Test plan

I went through some of the manual test cases again to make sure all classes are properly loaded and threading works right.

## App preview:

- [Web](https://sg-web-dv-jetbrains-fix-compatiblity.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
