### PR TITLE
search: display debug messages in search results

### DIFF
--- a/client/search-ui/src/components/FileSearchResult.tsx
+++ b/client/search-ui/src/components/FileSearchResult.tsx
@@ -221,6 +221,7 @@ export const FileSearchResult: React.FunctionComponent<React.PropsWithChildren<P
         repoName: result.repository,
         repoStars: result.repoStars,
         repoLastFetched: result.repoLastFetched,
+        rankingDebug: result.debug,
         onResultClicked: props.onSelect,
         className: props.containerClassName,
         resultsClassName: props.result.type === 'symbol' ? styles.symbols : undefined,

--- a/client/search-ui/src/components/ResultContainer.tsx
+++ b/client/search-ui/src/components/ResultContainer.tsx
@@ -99,6 +99,11 @@ export interface ResultContainerProps {
     repoLastFetched?: string
 
     /**
+     * A string sent down explaining ranking for a file when debug is enabled.
+     */
+    rankingDebug?: string
+
+    /**
      * Click event for when the result is clicked
      */
     onResultClicked?: () => void
@@ -138,6 +143,7 @@ export const ResultContainer: React.FunctionComponent<React.PropsWithChildren<Re
     description,
     repoName,
     repoStars,
+    rankingDebug,
     onResultClicked,
     className,
     resultsClassName,
@@ -202,6 +208,7 @@ export const ResultContainer: React.FunctionComponent<React.PropsWithChildren<Re
                         </span>
                     )}
                 </div>
+                {rankingDebug && <div>{rankingDebug}</div>}
                 <div className={classNames(styles.collapsibleResults, resultsClassName)}>
                     <div>{expanded ? expandedChildren : collapsedChildren}</div>
                     {collapsible && (

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -41,6 +41,7 @@ export interface PathMatch {
     repoLastFetched?: string
     branches?: string[]
     commit?: string
+    debug?: string
 }
 
 export interface ContentMatch {
@@ -55,6 +56,7 @@ export interface ContentMatch {
     lineMatches?: LineMatch[]
     chunkMatches?: ChunkMatch[]
     hunks?: DecoratedHunk[]
+    debug?: string
 }
 
 export interface DecoratedHunk {
@@ -103,6 +105,7 @@ export interface SymbolMatch {
     branches?: string[]
     commit?: string
     symbols: MatchedSymbol[]
+    debug?: string
 }
 
 export interface MatchedSymbol {


### PR DESCRIPTION
When the search-debug feature flag is enabled, we send down an extra "debug" field. This contains information on how ranks are computed. This is extremely useful to understand why we ranked results the way we did.

Right now the presentation is super ugly. But I don't know any better and this is only for consumption of search engineers.

![image](https://user-images.githubusercontent.com/187831/200004152-51c80bc9-2f6e-4b77-8803-07bd344c4114.png)

Test Plan: enabled "search-debug" feature flag on local server and observed debug information on results pages.

Co-authored-by: @stefanhengl 

## App preview:

- [Web](https://sg-web-k-debug.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
