### PR TITLE
Cclark/interrupt series

### DIFF
--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -224,10 +224,7 @@ func (h *inProgressHandler) doInterrupt(ctx context.Context, job *BaseJob) error
 }
 
 func (h *inProgressHandler) shouldInterrupt(duration time.Duration) bool {
-	if duration >= h.config.interruptAfter {
-		return true
-	}
-	return false
+	return duration >= h.config.interruptAfter
 }
 
 func getInterruptAfter() time.Duration {

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -75,20 +75,15 @@ func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*worker
 		Metrics:  *dbworker.NewMetrics(config.ObsContext, name),
 	})
 
+	configLogger := log.Scoped("insightsInProgressConfigWatcher", "")
 	mu := sync.Mutex{}
 	conf.Watch(func() {
-		c := conf.Get()
-		if c == nil {
-			return
-		}
-
 		mu.Lock()
 		defer mu.Unlock()
 		oldVal := task.config.interruptAfter
 		newVal := getInterruptAfter()
 		task.config.interruptAfter = newVal
-		logger := log.Scoped("insightsInProgressConfig", "")
-		logger.Info("insights backfiller interrupt time changed", log.Duration("old", oldVal), log.Duration("new", newVal))
+		configLogger.Info("insights backfiller interrupt time changed", log.Duration("old", oldVal), log.Duration("new", newVal))
 	})
 
 	return worker, resetter, workerStore

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -48,7 +48,7 @@ func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*worker
 		MaxNumRetries:     3,
 	}, config.ObsContext)
 
-	handlerConfig := handlerConfig{interruptAfter: getInterruptAfter()}
+	handlerConfig := newHandlerConfig()
 
 	task := &inProgressHandler{
 		workerStore:    workerStore,
@@ -103,6 +103,10 @@ type inProgressHandler struct {
 
 type handlerConfig struct {
 	interruptAfter time.Duration
+}
+
+func newHandlerConfig() handlerConfig {
+	return handlerConfig{interruptAfter: getInterruptAfter()}
 }
 
 var _ workerutil.Handler = &inProgressHandler{}

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
@@ -94,6 +94,9 @@ func Test_MovesBackfillFromProcessingToComplete(t *testing.T) {
 		repoStore:      repos,
 		insightsStore:  seriesStore,
 		backfillRunner: &noopBackfillRunner{},
+		config:         newHandlerConfig(),
+
+		clock: clock,
 	}
 	err = handler.Handle(ctx, logger, dequeue)
 	require.NoError(t, err)
@@ -249,6 +252,8 @@ func Test_BackfillWithRetry(t *testing.T) {
 		repoStore:      repos,
 		insightsStore:  seriesStore,
 		backfillRunner: runner,
+		config:         newHandlerConfig(),
+		clock:          clock,
 	}
 
 	// we should get an errored record here that will be retried by the overall queue
@@ -324,6 +329,8 @@ func Test_BackfillWithRetryAndComplete(t *testing.T) {
 		repoStore:      repos,
 		insightsStore:  seriesStore,
 		backfillRunner: runner,
+		config:         newHandlerConfig(),
+		clock:          clock,
 	}
 
 	// we should get an errored record here that will be retried by the overall queue

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	itypes "github.com/sourcegraph/sourcegraph/internal/types"
@@ -31,15 +32,12 @@ func (n *noopBackfillRunner) Run(ctx context.Context, req pipeline.BackfillReque
 	return nil
 }
 
-type errorBackfillRunner struct {
-	shouldError func(req pipeline.BackfillRequest) bool
+type delegateBackfillRunner struct {
+	doSomething func(ctx context.Context, req pipeline.BackfillRequest) error
 }
 
-func (e *errorBackfillRunner) Run(ctx context.Context, req pipeline.BackfillRequest) error {
-	if e.shouldError(req) {
-		return errors.New("fake error")
-	}
-	return nil
+func (e *delegateBackfillRunner) Run(ctx context.Context, req pipeline.BackfillRequest) error {
+	return e.doSomething(ctx, req)
 }
 
 func Test_MovesBackfillFromProcessingToComplete(t *testing.T) {
@@ -235,14 +233,16 @@ func Test_BackfillWithRetry(t *testing.T) {
 	require.NoError(t, err)
 
 	attemptCounts := make(map[int]int)
-	runner := &errorBackfillRunner{shouldError: func(req pipeline.BackfillRequest) bool {
-		val := attemptCounts[int(req.Repo.ID)]
-		attemptCounts[int(req.Repo.ID)] += 1
-		if val > 2 {
-			return false
-		}
-		return true
-	}}
+	runner := &delegateBackfillRunner{
+		doSomething: func(ctx context.Context, req pipeline.BackfillRequest) error {
+			val := attemptCounts[int(req.Repo.ID)]
+			attemptCounts[int(req.Repo.ID)] += 1
+			if val > 2 {
+				return nil
+			}
+			return errors.New("fake error")
+		},
+	}
 
 	dequeue, _, _ := monitor.inProgressStore.Dequeue(ctx, "test", nil)
 	handler := inProgressHandler{
@@ -312,14 +312,16 @@ func Test_BackfillWithRetryAndComplete(t *testing.T) {
 	require.NoError(t, err)
 
 	attemptCounts := make(map[int]int)
-	runner := &errorBackfillRunner{shouldError: func(req pipeline.BackfillRequest) bool {
-		val := attemptCounts[int(req.Repo.ID)]
-		attemptCounts[int(req.Repo.ID)] += 1
-		if val > 2 {
-			return false
-		}
-		return true
-	}}
+	runner := &delegateBackfillRunner{
+		doSomething: func(ctx context.Context, req pipeline.BackfillRequest) error {
+			val := attemptCounts[int(req.Repo.ID)]
+			attemptCounts[int(req.Repo.ID)] += 1
+			if val > 2 {
+				return nil
+			}
+			return errors.New("fake error")
+		},
+	}
 
 	dequeue, _, _ := monitor.inProgressStore.Dequeue(ctx, "test", nil)
 	handler := inProgressHandler{
@@ -342,6 +344,91 @@ func Test_BackfillWithRetryAndComplete(t *testing.T) {
 		t.Fatal(err)
 	}
 	require.True(t, updated)
+
+	// the queue won't immediately dequeue so we will just pass it back to the handler as if it was dequeued again
+	err = handler.Handle(ctx, logger, dequeue)
+	require.NoError(t, err)
+
+	completedBackfill, err := bfs.loadBackfill(ctx, backfill.Id)
+	require.NoError(t, err)
+	if completedBackfill.State != BackfillStateCompleted {
+		t.Fatal(errors.New("backfill should be state completed"))
+	}
+}
+
+func Test_BackfillWithInterrupt(t *testing.T) {
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t))
+	permStore := store.NewInsightPermissionStore(database.NewMockDB())
+	repos := database.NewMockRepoStore()
+	repos.GetFunc.SetDefaultReturn(&itypes.Repo{ID: 1, Name: "repo1"}, nil)
+	insightsStore := store.NewInsightStore(insightsDB)
+	seriesStore := store.New(insightsDB, permStore)
+
+	now := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := glock.NewMockClockAt(now)
+	bfs := newBackfillStoreWithClock(insightsDB, clock)
+
+	config := JobMonitorConfig{
+		InsightsDB:     insightsDB,
+		RepoStore:      repos,
+		InsightStore:   seriesStore,
+		ObsContext:     &observation.TestContext,
+		BackfillRunner: &noopBackfillRunner{},
+		CostAnalyzer:   priority.NewQueryAnalyzer(),
+	}
+	monitor := NewBackgroundJobMonitor(ctx, config)
+
+	series, err := insightsStore.CreateSeries(ctx, types.InsightSeries{
+		SeriesID:            "series1",
+		Query:               "asdf",
+		SampleIntervalUnit:  string(types.Month),
+		Repositories:        []string{"repo1", "repo2"},
+		SampleIntervalValue: 1,
+		GenerationMethod:    types.Search,
+	})
+	require.NoError(t, err)
+
+	backfill, err := bfs.NewBackfill(ctx, series)
+	require.NoError(t, err)
+	backfill, err = backfill.SetScope(ctx, bfs, []int32{1, 2}, 0)
+	require.NoError(t, err)
+	err = backfill.setState(ctx, bfs, BackfillStateProcessing)
+	require.NoError(t, err)
+
+	err = enqueueBackfill(ctx, bfs.Handle(), backfill)
+	require.NoError(t, err)
+
+	runner := delegateBackfillRunner{doSomething: func(ctx context.Context, req pipeline.BackfillRequest) error {
+		clock.Advance(time.Second * 6) // this will cause an interrupt on each iteration with a 5 second interrupt
+		return nil
+	}}
+
+	dequeue, _, _ := monitor.inProgressStore.Dequeue(ctx, "test", nil)
+	handler := inProgressHandler{
+		workerStore:    monitor.newBackfillStore,
+		backfillStore:  bfs,
+		seriesReader:   insightsStore,
+		repoStore:      repos,
+		insightsStore:  seriesStore,
+		backfillRunner: &runner,
+		config:         newHandlerConfig(),
+		clock:          clock,
+	}
+	handler.config.interruptAfter = time.Second * 5
+
+	// we should get an errored record here that will be retried by the overall queue
+	err = handler.Handle(ctx, logger, dequeue)
+	require.NoError(t, err)
+
+	// we will check that it was interrupted by verifying the backfill has progress, but is not completed yet
+	reloaded, err := bfs.loadBackfill(ctx, backfill.Id)
+	require.NoError(t, err)
+	require.Equal(t, BackfillStateProcessing, reloaded.State)
+	itr, err := iterator.LoadWithClock(ctx, basestore.NewWithHandle(insightsDB.Handle()), reloaded.repoIteratorId, clock)
+	require.NoError(t, err)
+	require.Greater(t, itr.PercentComplete, float64(0))
 
 	// the queue won't immediately dequeue so we will just pass it back to the handler as if it was dequeued again
 	err = handler.Handle(ctx, logger, dequeue)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2134,17 +2134,19 @@ type SiteConfiguration struct {
 	InsightsAggregationsBufferSize int `json:"insights.aggregations.bufferSize,omitempty"`
 	// InsightsAggregationsProactiveResultLimit description: The maximum number of results a proactive search aggregation can accept before stopping
 	InsightsAggregationsProactiveResultLimit int `json:"insights.aggregations.proactiveResultLimit,omitempty"`
+	// InsightsBackfillInterruptAfter description: Set the number of seconds an insight series will spend backfilling before being interrupted. Series are interrupted to prevent long running insights from exhausting all of the available workers. Interrupted series will be placed back in the queue and retried based on their priority.
+	InsightsBackfillInterruptAfter int `json:"insights.backfill.interruptAfter,omitempty"`
 	// InsightsCommitIndexerInterval description: The interval (in minutes) at which the insights commit indexer will check for new commits.
 	InsightsCommitIndexerInterval int `json:"insights.commit.indexer.interval,omitempty"`
 	// InsightsCommitIndexerWindowDuration description: The number of days of commits the insights commit indexer will pull during each request (0 is no limit).
 	InsightsCommitIndexerWindowDuration int `json:"insights.commit.indexer.windowDuration,omitempty"`
 	// InsightsComputeGraphql description: DEPRECATED: Force GraphQL mode for insights compute searches. This will overwrite the default streaming behavior and force search clients to use the GraphQL API
 	InsightsComputeGraphql *bool `json:"insights.compute.graphql,omitempty"`
-	// InsightsHistoricalFrameLength description: (debug) duration of historical insights timeframes, one point per repository will be recorded in each timeframe.
+	// InsightsHistoricalFrameLength description: DEPRECATED: (debug) duration of historical insights timeframes, one point per repository will be recorded in each timeframe.
 	InsightsHistoricalFrameLength string `json:"insights.historical.frameLength,omitempty"`
-	// InsightsHistoricalFrames description: (debug) number of historical insights timeframes to populate
+	// InsightsHistoricalFrames description: DEPRECATED: (debug) number of historical insights timeframes to populate
 	InsightsHistoricalFrames int `json:"insights.historical.frames,omitempty"`
-	// InsightsHistoricalSpeedFactor description: (debug) Speed factor for building historical insights data. A value like 1.5 indicates approximately to use 1.5x as much repo-updater and gitserver resources.
+	// InsightsHistoricalSpeedFactor description: DEPRECATED: (debug) Speed factor for building historical insights data. A value like 1.5 indicates approximately to use 1.5x as much repo-updater and gitserver resources.
 	InsightsHistoricalSpeedFactor *float64 `json:"insights.historical.speedFactor,omitempty"`
 	// InsightsHistoricalWorkerRateLimit description: Maximum number of historical Code Insights data frames that may be analyzed per second.
 	InsightsHistoricalWorkerRateLimit *float64 `json:"insights.historical.worker.rateLimit,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1397,19 +1397,19 @@
       "examples": [["10000"]]
     },
     "insights.historical.frames": {
-      "description": "(debug) number of historical insights timeframes to populate",
+      "description": "DEPRECATED: (debug) number of historical insights timeframes to populate",
       "type": "integer",
       "group": "Debug",
       "examples": [["6"]]
     },
     "insights.historical.frameLength": {
-      "description": "(debug) duration of historical insights timeframes, one point per repository will be recorded in each timeframe.",
+      "description": "DEPRECATED: (debug) duration of historical insights timeframes, one point per repository will be recorded in each timeframe.",
       "type": "string",
       "group": "Debug",
       "examples": ["30d"]
     },
     "insights.historical.speedFactor": {
-      "description": "(debug) Speed factor for building historical insights data. A value like 1.5 indicates approximately to use 1.5x as much repo-updater and gitserver resources.",
+      "description": "DEPRECATED: (debug) Speed factor for building historical insights data. A value like 1.5 indicates approximately to use 1.5x as much repo-updater and gitserver resources.",
       "!go": { "pointer": true },
       "type": "number",
       "group": "Debug",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1396,6 +1396,12 @@
       "group": "Debug",
       "examples": [["10000"]]
     },
+    "insights.backfill.interruptAfter": {
+      "description": "Set the number of seconds an insight series will spend backfilling before being interrupted. Series are interrupted to prevent long running insights from exhausting all of the available workers. Interrupted series will be placed back in the queue and retried based on their priority.",
+      "type": "integer",
+      "group": "CodeInsights",
+      "default": 60
+    },
     "insights.historical.frames": {
       "description": "DEPRECATED: (debug) number of historical insights timeframes to populate",
       "type": "integer",


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/42958

Adds an interrupt timeout for backfilling series. This will soft interrupt (will only stop on the next repo iteration and will not stop work in progress) and requeue the work. The timeout can be controlled by a site setting.

## Test plan

Example logs from a backfill after setting interrupt to 1 second

```
[worker] INFO insightsInProgressConfig scheduler/backfill_state_inprogress_handler.go:91 insights backfiller interrupt time changed {"old": "1m0s", "new": "1s"}

[worker] INFO worker.insights-job.background workerutil/worker.go:332 Dequeued record for processing {"name": "backfill_new_backfill_worker", "id": 54}
[worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_new_handler.go:87 newBackfillHandler called {"handle": {"recordId": 54}}

[worker] INFO worker.insights-job.background workerutil/worker.go:332 Dequeued record for processing {"TraceId": "1507c6af59be2f940bbbff2b977228fb", "SpanId": "b3200057526cb73e", "name": "backfill_in_progress_worker", "id": 55}
[worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:142 insights backfill progress handler loaded {"TraceId": "1507c6af59be2f940bbbff2b977228fb", "SpanId": "348d6211457eff48", "handle": {"recordId": 55, "jobNumFailures": 0, "seriesId": 28, "seriesUniqueId": "2H5iewq61VCgq8WldCvHxoejsLz", "backfillId": 28, "repoTotalCount": 7, "percentComplete": 0, "erroredRepos": 0, "totalErrors": 0}}
[worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:192 interrupted insight series backfill {"TraceId": "1507c6af59be2f940bbbff2b977228fb", "SpanId": "348d6211457eff48", "handle": {"seriesId": 28, "seriesUniqueId": "2H5iewq61VCgq8WldCvHxoejsLz", "backfillId": 28}}

[worker] INFO worker.insights-job.background workerutil/worker.go:332 Dequeued record for processing {"TraceId": "7b29be109b6ff6ab0157d07af130e6ad", "SpanId": "80b08293581a263e", "name": "backfill_in_progress_worker", "id": 55}
[worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:142 insights backfill progress handler loaded {"TraceId": "7b29be109b6ff6ab0157d07af130e6ad", "SpanId": "65dcf7dfe278e163", "handle": {"recordId": 55, "jobNumFailures": 0, "seriesId": 28, "seriesUniqueId": "2H5iewq61VCgq8WldCvHxoejsLz", "backfillId": 28, "repoTotalCount": 7, "percentComplete": 0.14285714285714285, "erroredRepos": 0, "totalErrors": 0}}
[worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:192 interrupted insight series backfill {"TraceId": "7b29be109b6ff6ab0157d07af130e6ad", "SpanId": "65dcf7dfe278e163", "handle": {"seriesId": 28, "seriesUniqueId": "2H5iewq61VCgq8WldCvHxoejsLz", "backfillId": 28}}

[worker] INFO worker.insights-job.background workerutil/worker.go:332 Dequeued record for processing {"TraceId": "5572f622f4cbb7b8e32230c17f3ba83b", "SpanId": "9373170badba3673", "name": "backfill_in_progress_worker", "id": 55}
[worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:142 insights backfill progress handler loaded {"TraceId": "5572f622f4cbb7b8e32230c17f3ba83b", "SpanId": "fcceeb6547f5b8ed", "handle": {"recordId": 55, "jobNumFailures": 0, "seriesId": 28, "seriesUniqueId": "2H5iewq61VCgq8WldCvHxoejsLz", "backfillId": 28, "repoTotalCount": 7, "percentComplete": 0.2857142857142857, "erroredRepos": 0, "totalErrors": 0}}
[worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:192 interrupted insight series backfill {"TraceId": "5572f622f4cbb7b8e32230c17f3ba83b", "SpanId": "fcceeb6547f5b8ed", "handle": {"seriesId": 28, "seriesUniqueId": "2H5iewq61VCgq8WldCvHxoejsLz", "backfillId": 28}}

[worker] INFO worker.insights-job.background workerutil/worker.go:332 Dequeued record for processing {"name": "backfill_in_progress_worker", "id": 55}
[worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:142 insights backfill progress handler loaded {"handle": {"recordId": 55, "jobNumFailures": 0, "seriesId": 28, "seriesUniqueId": "2H5iewq61VCgq8WldCvHxoejsLz", "backfillId": 28, "repoTotalCount": 7, "percentComplete": 0.42857142857142855, "erroredRepos": 0, "totalErrors": 0}}
[worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:192 interrupted insight series backfill {"handle": {"seriesId": 28, "seriesUniqueId": "2H5iewq61VCgq8WldCvHxoejsLz", "backfillId": 28}}

[worker] INFO worker.insights-job.background workerutil/worker.go:332 Dequeued record for processing {"TraceId": "aec90f1d6b52c786310ac836cfcfb467", "SpanId": "bba15371be5cfc6a", "name": "backfill_in_progress_worker", "id": 55}
[worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:142 insights backfill progress handler loaded {"TraceId": "aec90f1d6b52c786310ac836cfcfb467", "SpanId": "5e1cbc84201d541f", "handle": {"recordId": 55, "jobNumFailures": 0, "seriesId": 28, "seriesUniqueId": "2H5iewq61VCgq8WldCvHxoejsLz", "backfillId": 28, "repoTotalCount": 7, "percentComplete": 0.5714285714285714, "erroredRepos": 0, "totalErrors": 0}}
[worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:192 interrupted insight series backfill {"TraceId": "aec90f1d6b52c786310ac836cfcfb467", "SpanId": "5e1cbc84201d541f", "handle": {"seriesId": 28, "seriesUniqueId": "2H5iewq61VCgq8WldCvHxoejsLz", "backfillId": 28}}

[worker] INFO worker.insights-job.background workerutil/worker.go:332 Dequeued record for processing {"TraceId": "2289f96960ea6a4e68c66ea73fb89bb2", "SpanId": "e4599aef6903a0b9", "name": "backfill_in_progress_worker", "id": 55}
[worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:142 insights backfill progress handler loaded {"TraceId": "2289f96960ea6a4e68c66ea73fb89bb2", "SpanId": "ac4a58bcbdf29d7e", "handle": {"recordId": 55, "jobNumFailures": 0, "seriesId": 28, "seriesUniqueId": "2H5iewq61VCgq8WldCvHxoejsLz", "backfillId": 28, "repoTotalCount": 7, "percentComplete": 0.7142857142857143, "erroredRepos": 0, "totalErrors": 0}}
[worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:192 interrupted insight series backfill {"TraceId": "2289f96960ea6a4e68c66ea73fb89bb2", "SpanId": "ac4a58bcbdf29d7e", "handle": {"seriesId": 28, "seriesUniqueId": "2H5iewq61VCgq8WldCvHxoejsLz", "backfillId": 28}}

[worker] INFO worker.insights-job.background workerutil/worker.go:332 Dequeued record for processing {"name": "backfill_in_progress_worker", "id": 55}
[worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:142 insights backfill progress handler loaded {"handle": {"recordId": 55, "jobNumFailures": 0, "seriesId": 28, "seriesUniqueId": "2H5iewq61VCgq8WldCvHxoejsLz", "backfillId": 28, "repoTotalCount": 7, "percentComplete": 0.8571428571428571, "erroredRepos": 0, "totalErrors": 0}}
[worker] INFO worker.insights-job.background.worker.Handle scheduler/backfill_state_inprogress_handler.go:205 setting backfill to completed state {"handle": {"seriesId": 28, "seriesUniqueId": "2H5iewq61VCgq8WldCvHxoejsLz", "backfillId": 28, "totalDuration": "8.565626042s"}}

```