### PR TITLE
zoekt: add ranks and rrf scores to debug string 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -228,7 +228,7 @@ require (
 )
 
 require (
-	github.com/sourcegraph/zoekt v0.0.0-20221103094912-9eb454fb3c74
+	github.com/sourcegraph/zoekt v0.0.0-20221104165739-12648c98a5dd
 	github.com/stretchr/objx v0.4.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2118,8 +2118,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20221103094912-9eb454fb3c74 h1:Q0RXiMQRSGQYVKf+UxsuOKzlu3cNZnfsACJtYOeDhqc=
-github.com/sourcegraph/zoekt v0.0.0-20221103094912-9eb454fb3c74/go.mod h1:jieuX0Y1il24xoxONSDhkbDtXB/8cf1ZC5bbJVGtVRI=
+github.com/sourcegraph/zoekt v0.0.0-20221104165739-12648c98a5dd h1:SMYEzoPn0q26GMEZ8YK9S0cn/mvTjXga0OHS2U+w1GA=
+github.com/sourcegraph/zoekt v0.0.0-20221104165739-12648c98a5dd/go.mod h1:jieuX0Y1il24xoxONSDhkbDtXB/8cf1ZC5bbJVGtVRI=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/internal/search/backend/aggregate.go
+++ b/internal/search/backend/aggregate.go
@@ -24,16 +24,14 @@ var (
 // Note: It aggregates Progress as well, and expects that the
 // MaxPendingPriority it receives are monotonically decreasing.
 type collectSender struct {
-	aggregate          *zoekt.SearchResult
-	maxDocDisplayCount int
-	useDocumentRanks   bool
-	sizeBytes          uint64
+	aggregate *zoekt.SearchResult
+	opts      *zoekt.SearchOptions
+	sizeBytes uint64
 }
 
 func newCollectSender(opts *zoekt.SearchOptions) *collectSender {
 	return &collectSender{
-		maxDocDisplayCount: opts.MaxDocDisplayCount,
-		useDocumentRanks:   opts.UseDocumentRanks,
+		opts: opts,
 	}
 }
 
@@ -74,9 +72,9 @@ func (c *collectSender) Done() (_ *zoekt.SearchResult, ok bool) {
 	c.aggregate = nil
 	c.sizeBytes = 0
 
-	zoekt.SortFiles(agg.Files, c.useDocumentRanks)
+	zoekt.SortFiles(agg.Files, c.opts)
 
-	if max := c.maxDocDisplayCount; max > 0 && len(agg.Files) > max {
+	if max := c.opts.MaxDocDisplayCount; max > 0 && len(agg.Files) > max {
 		agg.Files = agg.Files[:max]
 	}
 

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -2,7 +2,6 @@ package zoekt
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -402,9 +401,6 @@ func sendMatches(event *zoekt.SearchResult, pathRegexps []*regexp.Regexp, getRep
 				},
 			}
 			if debug := file.Debug; debug != "" {
-				if len(file.Ranks) > 0 {
-					debug = fmt.Sprintf("%s ranks=%v", debug, file.Ranks)
-				}
 				fm.Debug = &debug
 			}
 			matches = append(matches, &fm)


### PR DESCRIPTION
This updates zoekt to have better debug messages for scoring. We needed to adjust some uses of the APIs here as well as remove some additional adding we did to the API.

Test Plan: CI