### PR TITLE
Revert "Fix flaky Perforce integration tests"

### DIFF
--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -23,7 +23,6 @@ type AuthzResolver interface {
 	UsersWithPendingPermissions(ctx context.Context) ([]string, error)
 	AuthorizedUsers(ctx context.Context, args *RepoAuthorizedUserArgs) (UserConnectionResolver, error)
 	BitbucketProjectPermissionJobs(ctx context.Context, args *BitbucketProjectPermissionJobsArgs) (BitbucketProjectsPermissionJobsResolver, error)
-	AuthzProviderTypes(ctx context.Context) ([]string, error)
 
 	// Helpers
 	RepositoryPermissionsInfo(ctx context.Context, repoID graphql.ID) (PermissionsInfoResolver, error)

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -132,12 +132,6 @@ extend type Query {
     usersWithPendingPermissions: [String!]!
 
     """
-    INTERNAL ONLY: Returns a list of the types of authz providers that have been configured and will be used for
-    determining which repositories the user has access to.
-    """
-    authzProviderTypes: [String!]!
-
-    """
     Returns a list of Bitbucket Project permissions sync jobs for a given set of parameters.
     """
     bitbucketProjectPermissionJobs(

--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -39,7 +39,11 @@ func TestSubRepoPermissionsPerforce(t *testing.T) {
 		}
 	})
 
+	// flaky test
+	// https://github.com/sourcegraph/sourcegraph/issues/40882
 	t.Run("cannot read hack.sh", func(t *testing.T) {
+		t.Skip("skipping because flaky")
+
 		// Should not be able to read hack.sh
 		blob, err := userClient.GitBlob(repoName, "master", "Security/hack.sh")
 		if err != nil {
@@ -55,7 +59,11 @@ func TestSubRepoPermissionsPerforce(t *testing.T) {
 		}
 	})
 
+	// flaky test
+	// https://github.com/sourcegraph/sourcegraph/issues/40883
 	t.Run("file list excludes excluded files", func(t *testing.T) {
+		t.Skip("skipping because flaky")
+
 		files, err := userClient.GitListFilenames(repoName, "master")
 		if err != nil {
 			t.Fatal(err)
@@ -328,24 +336,6 @@ func syncUserPerms(t *testing.T, userID, userName string) {
 	})
 	if err != nil {
 		t.Fatal("Waiting for user permissions to be synced:", err)
-	}
-	// Wait up to 30 seconds for Perforce to be added as an authz provider
-	err = gqltestutil.Retry(30*time.Second, func() error {
-		authzProviders, err := client.AuthzProviderTypes()
-		if err != nil {
-			t.Fatal("failed to fetch list of authz providers", err)
-		}
-		if len(authzProviders) != 0 {
-			for _, p := range authzProviders {
-				if p == "perforce" {
-					return nil
-				}
-			}
-		}
-		return gqltestutil.ErrContinueRetry
-	})
-	if err != nil {
-		t.Fatal("Waiting for authz providers to be added:", err)
 	}
 }
 

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -457,19 +457,6 @@ func (r *Resolver) AuthorizedUsers(ctx context.Context, args *graphqlbackend.Rep
 	}, nil
 }
 
-func (r *Resolver) AuthzProviderTypes(ctx context.Context) ([]string, error) {
-	// 🚨 SECURITY: Only site admins can query for authz providers.
-	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
-		return nil, err
-	}
-	_, providers := authz.GetProviders()
-	providerTypes := make([]string, 0, len(providers))
-	for _, p := range providers {
-		providerTypes = append(providerTypes, p.ServiceType())
-	}
-	return providerTypes, nil
-}
-
 var jobStatuses = map[string]bool{
 	"queued":     true,
 	"processing": true,

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -3,7 +3,6 @@ package resolvers
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -17,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/authz/github"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -920,51 +918,6 @@ func TestResolver_UsersWithPendingPermissions(t *testing.T) {
 			graphqlbackend.RunTests(t, test.gqlTests)
 		})
 	}
-}
-
-func TestResolver_AuthzProviderTypes(t *testing.T) {
-	t.Run("authenticated as non-admin", func(t *testing.T) {
-		users := database.NewStrictMockUserStore()
-		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{}, nil)
-
-		db := edb.NewStrictMockEnterpriseDB()
-		db.UsersFunc.SetDefaultReturn(users)
-
-		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := (&Resolver{db: db}).AuthzProviderTypes(ctx)
-		if want := auth.ErrMustBeSiteAdmin; err != want {
-			t.Errorf("err: want %q but got %v", want, err)
-		}
-		if result != nil {
-			t.Errorf("result: want nil but got %v", result)
-		}
-	})
-
-	t.Run("get authz provider types", func(t *testing.T) {
-		users := database.NewStrictMockUserStore()
-		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{
-			SiteAdmin: true,
-		}, nil)
-
-		db := edb.NewStrictMockEnterpriseDB()
-		db.UsersFunc.SetDefaultReturn(users)
-
-		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-
-		ghProvider := github.NewProvider("https://github.com", github.ProviderOptions{GitHubURL: mustURL(t, "https://github.com")})
-		authz.SetProviders(false, []authz.Provider{ghProvider})
-		result, err := (&Resolver{db: db}).AuthzProviderTypes(ctx)
-		assert.NoError(t, err)
-		assert.Equal(t, []string{"github"}, result)
-	})
-}
-
-func mustURL(t *testing.T, u string) *url.URL {
-	parsed, err := url.Parse(u)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return parsed
 }
 
 func TestResolver_AuthorizedUsers(t *testing.T) {

--- a/internal/gqltestutil/permissions.go
+++ b/internal/gqltestutil/permissions.go
@@ -162,20 +162,6 @@ query BitbucketProjectPermissionJobs($projectKeys: [String!], $status: String, $
 	}
 }
 
-func (c *Client) AuthzProviderTypes() ([]string, error) {
-	const query = `query { authzProviderTypes }`
-	var resp struct {
-		Data struct {
-			AuthzProviderTypes []string `json:"authzProviderTypes"`
-		} `json:"data"`
-	}
-	err := c.GraphQL("", query, nil, &resp)
-	if err != nil {
-		return nil, errors.Wrap(err, "request GraphQL")
-	}
-	return resp.Data.AuthzProviderTypes, nil
-}
-
 // UsersWithPendingPermissions returns bind IDs of users with pending permissions
 func (c *Client) UsersWithPendingPermissions() ([]string, error) {
 	const query = `


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#43696

I think this is causing flakes in E2E tests https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1667582490102689

## Test plan

N/A