### PR TITLE
allow running in dotcom mode w/o ranking to silence log spam

### DIFF
--- a/internal/codeintel/codenav/ranking.go
+++ b/internal/codeintel/codenav/ranking.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sourcegraph/log"
 	"google.golang.org/api/iterator"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -22,7 +21,7 @@ import (
 func (s *Service) SerializeRankingGraph(
 	ctx context.Context,
 ) error {
-	if !envvar.SourcegraphDotComMode() && os.Getenv("ENABLE_EXPERIMENTAL_RANKING") == "" {
+	if os.Getenv("ENABLE_EXPERIMENTAL_RANKING") == "" {
 		return nil
 	}
 	if s.rankingBucket == nil {
@@ -63,7 +62,7 @@ func (s *Service) SerializeRankingGraph(
 func (s *Service) VacuumRankingGraph(
 	ctx context.Context,
 ) error {
-	if !envvar.SourcegraphDotComMode() && os.Getenv("ENABLE_EXPERIMENTAL_RANKING") == "" {
+	if os.Getenv("ENABLE_EXPERIMENTAL_RANKING") == "" {
 		return nil
 	}
 	if s.rankingBucket == nil {


### PR DESCRIPTION
Without this change, running `sg start dotcom` to run in Sourcegraph.com mode results in log spam `No ranking bucket is configured` several times per second.

Experimental ranking can still be enabled by setting the env var `ENABLE_EXPERIMENTAL_RANKING` to anything nonempty.




## Test plan

Run `sg start dotcom` and notice no logspam.