### PR TITLE
featureflag: backend add per request overrides

### DIFF
--- a/internal/featureflag/middleware.go
+++ b/internal/featureflag/middleware.go
@@ -21,7 +21,16 @@ type Store interface {
 func Middleware(ffs Store, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Vary", "Cookie")
-		next.ServeHTTP(w, r.WithContext(WithFlags(r.Context(), ffs)))
+
+		store := ffs
+		if flags, ok := requestOverrides(r); ok {
+			store = &overrideStore{
+				store: ffs,
+				flags: flags,
+			}
+		}
+
+		next.ServeHTTP(w, r.WithContext(WithFlags(r.Context(), store)))
 	})
 }
 

--- a/internal/featureflag/override.go
+++ b/internal/featureflag/override.go
@@ -1,0 +1,78 @@
+package featureflag
+
+import (
+	"context"
+	"net/http"
+	"strings"
+)
+
+const (
+	overrideHeader        = "X-Sourcegraph-Override-Feature"
+	overrideQuery         = "feat"
+	overrideQueryContains = overrideQuery + "="
+)
+
+// requestWantsTrace returns true if a request is opting into tracing either
+// via our HTTP Header or our URL Query.
+func requestOverrides(r *http.Request) (flags map[string]bool, ok bool) {
+	// Prefer header over query param.
+	values := r.Header.Values(overrideHeader)
+
+	// PERF: Avoid parsing RawQuery if "feat=" is not present.
+	if len(values) == 0 && strings.Contains(r.URL.RawQuery, overrideQueryContains) {
+		values = r.URL.Query()[overrideQuery]
+	}
+
+	if len(values) == 0 {
+		return nil, false
+	}
+
+	flags = make(map[string]bool, len(values))
+	for _, k := range values {
+		// flags starting with "-" override to false
+		v := !strings.HasPrefix(k, "-")
+		k = strings.TrimPrefix(k, "-")
+		flags[k] = v
+	}
+
+	return flags, true
+}
+
+// overrideStore will override the returned feature flags in memory.
+//
+// Note: this is different to overrides in the feature flag DB, which persists
+// overrides. This is intended to override feature flags for a request.
+type overrideStore struct {
+	store Store
+	flags map[string]bool
+}
+
+func (s *overrideStore) GetUserFlags(ctx context.Context, userID int32) (map[string]bool, error) {
+	return s.override(s.store.GetUserFlags(ctx, userID))
+}
+
+func (s *overrideStore) GetAnonymousUserFlags(ctx context.Context, anonUID string) (map[string]bool, error) {
+	return s.override(s.store.GetAnonymousUserFlags(ctx, anonUID))
+}
+func (s *overrideStore) GetGlobalFeatureFlags(ctx context.Context) (map[string]bool, error) {
+	return s.override(s.store.GetGlobalFeatureFlags(ctx))
+}
+
+func (s *overrideStore) override(flags map[string]bool, err error) (map[string]bool, error) {
+	if err != nil {
+		return nil, err
+	}
+
+	// Avoid mutating flags just in case s.store returns a cached copy.
+	override := make(map[string]bool, len(flags))
+	for k, v := range flags {
+		override[k] = v
+	}
+
+	// Now apply overrides potentially adding or updating feature flags.
+	for k, v := range s.flags {
+		override[k] = v
+	}
+
+	return override, nil
+}

--- a/internal/featureflag/override_test.go
+++ b/internal/featureflag/override_test.go
@@ -1,0 +1,171 @@
+package featureflag
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func TestOverrides(t *testing.T) {
+	setupRedisTest(t)
+
+	mockStore := NewMockStore()
+	mockStore.GetUserFlagsFunc.SetDefaultHook(func(_ context.Context, uid int32) (map[string]bool, error) {
+		if uid != 123 {
+			return nil, errors.New("BOOM")
+		}
+		return map[string]bool{
+			"feat-true":  true,
+			"feat-false": false,
+			"user":       true,
+		}, nil
+	})
+	mockStore.GetAnonymousUserFlagsFunc.SetDefaultHook(func(_ context.Context, anonUID string) (map[string]bool, error) {
+		if anonUID != "123" {
+			return nil, errors.New("BOOM")
+		}
+		return map[string]bool{
+			"feat-true":  true,
+			"feat-false": false,
+			"anon":       true,
+		}, nil
+	})
+	mockStore.GetGlobalFeatureFlagsFunc.SetDefaultHook(func(_ context.Context) (map[string]bool, error) {
+		return map[string]bool{
+			"feat-true":  true,
+			"feat-false": false,
+			"global":     true,
+		}, nil
+	})
+
+	handler := Middleware(mockStore, http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(FromContext(r.Context()).flags)
+	})))
+
+	cases := []struct {
+		Name     string
+		Header   []string
+		RawQuery string
+		Want     map[string]bool
+	}{{
+		Name: "unset",
+		Want: map[string]bool{
+			"feat-true":  true,
+			"feat-false": false,
+		},
+	}, {
+		Name:   "header-true",
+		Header: []string{"feat-false"},
+		Want: map[string]bool{
+			"feat-true":  true,
+			"feat-false": true,
+		},
+	}, {
+		Name:   "header-false",
+		Header: []string{"-feat-true"},
+		Want: map[string]bool{
+			"feat-true":  false,
+			"feat-false": false,
+		},
+	}, {
+		Name:   "header-multiple",
+		Header: []string{"feat-false", "-new-false", "new-true"},
+		Want: map[string]bool{
+			"feat-true":  true,
+			"feat-false": true,
+			"new-false":  false,
+			"new-true":   true,
+		},
+	}, {
+		Name:     "query-true",
+		RawQuery: "feat=feat-false",
+		Want: map[string]bool{
+			"feat-true":  true,
+			"feat-false": true,
+		},
+	}, {
+		Name:     "query-false",
+		RawQuery: "feat=-feat-true",
+		Want: map[string]bool{
+			"feat-true":  false,
+			"feat-false": false,
+		},
+	}, {
+		Name:     "query-multiple",
+		RawQuery: "feat=feat-false&feat=-new-false&feat=new-true",
+		Want: map[string]bool{
+			"feat-true":  true,
+			"feat-false": true,
+			"new-false":  false,
+			"new-true":   true,
+		},
+	}, {
+		Name:     "prefer-header",
+		Header:   []string{"header"},
+		RawQuery: "feat=query",
+		Want: map[string]bool{
+			"feat-true":  true,
+			"feat-false": false,
+			"header":     true,
+		},
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			run := func(act *actor.Actor) map[string]bool {
+				t.Helper()
+
+				req, err := http.NewRequest(http.MethodGet, "/test?"+tc.RawQuery, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				req = req.WithContext(actor.WithActor(context.Background(), act))
+				if tc.Header != nil {
+					req.Header["X-Sourcegraph-Override-Feature"] = tc.Header
+				}
+
+				w := httptest.NewRecorder()
+				handler.ServeHTTP(w, req)
+
+				var flags map[string]bool
+				err = json.NewDecoder(w.Result().Body).Decode(&flags)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return flags
+			}
+
+			got := run(actor.FromUser(123))
+			want := flagsWithKey(tc.Want, "user")
+			if d := cmp.Diff(want, got); d != "" {
+				t.Errorf("unexpected flags for user (-want, +got):\n%s", d)
+			}
+
+			got = run(actor.FromAnonymousUser("123"))
+			want = flagsWithKey(tc.Want, "anon")
+			if d := cmp.Diff(want, got); d != "" {
+				t.Errorf("unexpected flags for anonymous (-want, +got):\n%s", d)
+			}
+
+			got = run(&actor.Actor{})
+			want = flagsWithKey(tc.Want, "global")
+			if d := cmp.Diff(want, got); d != "" {
+				t.Errorf("unexpected flags for global (-want, +got):\n%s", d)
+			}
+		})
+	}
+}
+
+func flagsWithKey(flags map[string]bool, key string) map[string]bool {
+	m := map[string]bool{key: true}
+	for k, v := range flags {
+		m[k] = v
+	}
+	return m
+}


### PR DESCRIPTION
This is a partial revert of commit
27a4880eb440c2ed8cadae3e14823cd16f319ca6. It just adds back the backend bit which was not implicated in breaking E2E tests.

Original PR at https://github.com/sourcegraph/sourcegraph/pull/43872

Test Plan: main dry run to ensure CI won't break