### PR TITLE
featureflag: support overriding in streaming search

### DIFF
--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -438,6 +438,7 @@ export interface StreamSearchOptions {
     patternType: SearchPatternType
     caseSensitive: boolean
     trace: string | undefined
+    featureOverrides?: string[]
     searchMode?: SearchMode
     sourcegraphURL?: string
     decorationKinds?: string[]
@@ -453,6 +454,7 @@ function initiateSearchStream(
         patternType,
         caseSensitive,
         trace,
+        featureOverrides,
         decorationKinds,
         decorationContextLines,
         searchMode = SearchMode.Precise,
@@ -478,6 +480,9 @@ function initiateSearchStream(
         ]
         if (trace) {
             parameters.push(['trace', trace])
+        }
+        for (const v of featureOverrides || []) {
+            parameters.push(['feat', v])
         }
         const parameterEncoded = parameters.map(([k, v]) => k + '=' + encodeURIComponent(v)).join('&')
 

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -120,6 +120,7 @@ describe('StreamingSearchResults', () => {
             searchMode: SearchMode.Precise,
             trace: undefined,
             chunkMatches: true,
+            featureOverrides: [],
         })
     })
 

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -96,6 +96,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
     const extensionHostAPI =
         extensionsController !== null && window.context.enableLegacyExtensions ? extensionsController.extHostAPI : null
     const trace = useMemo(() => new URLSearchParams(location.search).get('trace') ?? undefined, [location.search])
+    const featureOverrides = useMemo(() => new URLSearchParams(location.search).getAll('feat') ?? [], [location.search])
 
     const options: StreamSearchOptions = useMemo(
         () => ({
@@ -103,10 +104,11 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
             patternType: patternType ?? SearchPatternType.standard,
             caseSensitive,
             trace,
+            featureOverrides,
             searchMode: patternType === SearchPatternType.lucky ? SearchMode.SmartSearch : searchMode,
             chunkMatches: true,
         }),
-        [caseSensitive, patternType, searchMode, trace]
+        [caseSensitive, patternType, searchMode, trace, featureOverrides]
     )
 
     const results = useCachedSearchResults(streamSearch, submittedURLQuery, options, extensionHostAPI, telemetryService)


### PR DESCRIPTION
This is a partial revert of commit
27a4880eb440c2ed8cadae3e14823cd16f319ca6. It adds back support for streaming search to set the feature flag override query parameter. This was not implicated in breaking E2E tests.

Original PR at https://github.com/sourcegraph/sourcegraph/pull/43872

Test Plan: main dry run to ensure CI won't break