### PR TITLE
search: preserve "feat" query parameters

### DIFF
--- a/client/web/src/search/helpers.tsx
+++ b/client/web/src/search/helpers.tsx
@@ -11,7 +11,7 @@ import { AGGREGATION_MODE_URL_KEY, AGGREGATION_UI_MODE_URL_KEY } from './results
  * This breaks all functionality that is built on top of URL query params and history
  * state. This list of query keys will be preserved between searches.
  */
-const PRESERVED_QUERY_PARAMETERS = ['trace', AGGREGATION_MODE_URL_KEY, AGGREGATION_UI_MODE_URL_KEY]
+const PRESERVED_QUERY_PARAMETERS = ['feat', 'trace', AGGREGATION_MODE_URL_KEY, AGGREGATION_UI_MODE_URL_KEY]
 
 /**
  * @param activation If set, records the DidSearch activation event for the new user activation
@@ -38,13 +38,16 @@ export function submitSearch({
     const existingParameters = new URLSearchParams(history.location.search)
 
     for (const key of PRESERVED_QUERY_PARAMETERS) {
-        const queryParameter = existingParameters.get(key)
-
-        if (queryParameter !== null) {
-            const parameters = new URLSearchParams(searchQueryParameter)
-            parameters.set(key, queryParameter)
-            searchQueryParameter = parameters.toString()
+        const values = existingParameters.getAll(key)
+        if (values.length === 0) {
+            continue
         }
+        const parameters = new URLSearchParams(searchQueryParameter)
+        parameters.delete(key)
+        for (const value of values) {
+            parameters.set(key, value)
+        }
+        searchQueryParameter = parameters.toString()
     }
 
     // Go to search results page

--- a/client/web/src/search/helpers.tsx
+++ b/client/web/src/search/helpers.tsx
@@ -36,19 +36,19 @@ export function submitSearch({
     )
 
     const existingParameters = new URLSearchParams(history.location.search)
-    const parameters = new URLSearchParams(searchQueryParameter)
     for (const key of PRESERVED_QUERY_PARAMETERS) {
         const values = existingParameters.getAll(key)
         if (values.length === 0) {
             continue
         }
 
+        const parameters = new URLSearchParams(searchQueryParameter)
         parameters.delete(key)
         for (const value of values) {
             parameters.append(key, value)
         }
+        searchQueryParameter = parameters.toString()
     }
-    searchQueryParameter = parameters.toString()
 
     // Go to search results page
     const path = '/search?' + searchQueryParameter

--- a/client/web/src/search/helpers.tsx
+++ b/client/web/src/search/helpers.tsx
@@ -36,19 +36,19 @@ export function submitSearch({
     )
 
     const existingParameters = new URLSearchParams(history.location.search)
-
+    const parameters = new URLSearchParams(searchQueryParameter)
     for (const key of PRESERVED_QUERY_PARAMETERS) {
         const values = existingParameters.getAll(key)
         if (values.length === 0) {
             continue
         }
-        const parameters = new URLSearchParams(searchQueryParameter)
+
         parameters.delete(key)
         for (const value of values) {
-            parameters.set(key, value)
+            parameters.append(key, value)
         }
-        searchQueryParameter = parameters.toString()
     }
+    searchQueryParameter = parameters.toString()
 
     // Go to search results page
     const path = '/search?' + searchQueryParameter


### PR DESCRIPTION
This is a partial revert of commit
27a4880eb440c2ed8cadae3e14823cd16f319ca6. It contains the logic which keeps "feat" query parameters set in search when a user overrides it. This was not implicated in breaking E2E tests, so has been split out.

Original PR at https://github.com/sourcegraph/sourcegraph/pull/43872

Test Plan: main dry run just to make sure E2E won't break