### PR TITLE
featureflag: support overriding in api console

### DIFF
--- a/client/web/src/api/ApiConsole.tsx
+++ b/client/web/src/api/ApiConsole.tsx
@@ -247,6 +247,9 @@ export class ApiConsole extends React.PureComponent<Props, State> {
         if (searchParameters.get('trace') === '1') {
             headers.set('x-sourcegraph-should-trace', 'true')
         }
+        for (const feature of searchParameters.getAll('feat')) {
+            headers.append('x-sourcegraph-override-feature', feature)
+        }
         const response = await fetch('/.api/graphql', {
             method: 'POST',
             body: JSON.stringify(graphQLParameters),


### PR DESCRIPTION
This is a partial revert of commit
27a4880eb440c2ed8cadae3e14823cd16f319ca6. It shouldn't be the cause of failing E2E tests, so has been split out. This just passes on the feat query param as the correct header (like "trace") for the API Console.

Original PR at https://github.com/sourcegraph/sourcegraph/pull/43872

Test Plan: main dry run to ensure CI won't break