### PR TITLE
Help Please: web: use Headers type for graphql getHeaders

### DIFF
--- a/client/web/src/backend/graphql.ts
+++ b/client/web/src/backend/graphql.ts
@@ -4,12 +4,18 @@ import { Observable } from 'rxjs'
 import { getGraphQLClient, GraphQLResult, requestGraphQLCommon } from '@sourcegraph/http-client'
 import * as GQL from '@sourcegraph/shared/src/schema'
 
-const getHeaders = (): { [header: string]: string } => ({
-    ...window?.context?.xhrHeaders,
-    Accept: 'application/json',
-    'Content-Type': 'application/json',
-    'X-Sourcegraph-Should-Trace': new URLSearchParams(window.location.search).get('trace') || 'false',
-})
+const getHeaders = (): Headers => {
+    const headers = new Headers({
+        ...window?.context?.xhrHeaders,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+    })
+    const searchParameters = new URLSearchParams(window.location.search)
+    if (searchParameters.get('trace') === '1') {
+        headers.set('X-Sourcegraph-Should-Trace', 'true')
+    }
+    return headers
+}
 
 /**
  * Does a GraphQL request to the Sourcegraph GraphQL API running under `/.api/graphql`


### PR DESCRIPTION
This change is to make it possible to use "Headers.append" so we can set multiple values for a single header. According to the type documentation and the typescript compiler this should work.

However, in practice this breaks the E2E tests. Every graphql seems to fail with 401 Unauthorized. This makes me suspect that somehow doing "...window?.context?.xhrHeaders" into the construct of Headers is working incorrectly.

For more context, this is what I want to add in:

```typescript
  for (const feature of searchParameters.getAll('feat')) {
    headers.append('X-Sourcegraph-Override-Feature', feature)
  }
```

Alternatively I could probably not use Header and just encode the values for the header myself. But I'm interested why this is not working.

Original PR at https://github.com/sourcegraph/sourcegraph/pull/43872

Test Plan: main dry run which passes (to exercise E2E tests)