### PR TITLE
graphql: add support for filtering webhook logs by webhook ID.

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1585,7 +1585,7 @@ type Query {
         """
         Only include webhook logs of given webhook ID.
         """
-        webhookID: Int
+        webhookID: ID
     ): WebhookLogConnection!
 
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1581,6 +1581,11 @@ type Query {
         Only include webhook logs on or before this time.
         """
         until: DateTime
+
+        """
+        Only include webhook logs of given webhook ID.
+        """
+        webhookID: Int
     ): WebhookLogConnection!
 
     """

--- a/cmd/frontend/graphqlbackend/webhook_logs.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs.go
@@ -30,6 +30,7 @@ type webhookLogsArgs struct {
 	OnlyErrors *bool
 	Since      *time.Time
 	Until      *time.Time
+	WebhookID  *int32
 }
 
 // webhookLogsExternalServiceID is used to represent an external service ID,
@@ -79,6 +80,12 @@ func (args *webhookLogsArgs) toListOpts(externalServiceID webhookLogsExternalSer
 
 	if args.OnlyErrors != nil && *args.OnlyErrors {
 		opts.OnlyErrors = true
+	}
+
+	// Both nil and "-1" webhook IDs should be resolved to nil WebhookID
+	// WebhookLogListOpts option
+	if args.WebhookID != nil && *args.WebhookID != -1 {
+		opts.WebhookID = args.WebhookID
 	}
 
 	return opts, nil

--- a/cmd/frontend/graphqlbackend/webhook_logs.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs.go
@@ -30,7 +30,7 @@ type webhookLogsArgs struct {
 	OnlyErrors *bool
 	Since      *time.Time
 	Until      *time.Time
-	WebhookID  *int32
+	WebhookID  *graphql.ID
 }
 
 // webhookLogsExternalServiceID is used to represent an external service ID,
@@ -84,8 +84,15 @@ func (args *webhookLogsArgs) toListOpts(externalServiceID webhookLogsExternalSer
 
 	// Both nil and "-1" webhook IDs should be resolved to nil WebhookID
 	// WebhookLogListOpts option
-	if args.WebhookID != nil && *args.WebhookID != -1 {
-		opts.WebhookID = args.WebhookID
+	if args.WebhookID != nil {
+		id, err := unmarshalWebhookID(*args.WebhookID)
+		if err != nil {
+			return opts, errors.Wrap(err, "unmarshalling webhook ID")
+		}
+
+		if id != -1 {
+			opts.WebhookID = &id
+		}
 	}
 
 	return opts, nil

--- a/cmd/frontend/graphqlbackend/webhook_logs.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs.go
@@ -90,7 +90,7 @@ func (args *webhookLogsArgs) toListOpts(externalServiceID webhookLogsExternalSer
 			return opts, errors.Wrap(err, "unmarshalling webhook ID")
 		}
 
-		if id != -1 {
+		if id > 0 {
 			opts.WebhookID = &id
 		}
 	}

--- a/cmd/frontend/graphqlbackend/webhook_logs_test.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs_test.go
@@ -301,56 +301,22 @@ func TestListWebhookLogs(t *testing.T) {
 	ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 	webhookLogsStore := database.NewMockWebhookLogStore()
 	webhookLogs := []*types.WebhookLog{
-		{
-			ID:         1,
-			WebhookID:  int32Ptr(1),
-			StatusCode: 200,
-		},
-		{
-			ID:         2,
-			WebhookID:  int32Ptr(1),
-			StatusCode: 500,
-		},
-		{
-			ID:         3,
-			WebhookID:  int32Ptr(1),
-			StatusCode: 200,
-		},
-		{
-			ID:         4,
-			WebhookID:  int32Ptr(2),
-			StatusCode: 200,
-		},
-		{
-			ID:         5,
-			WebhookID:  int32Ptr(2),
-			StatusCode: 200,
-		},
-		{
-			ID:         6,
-			WebhookID:  int32Ptr(2),
-			StatusCode: 200,
-		},
-		{
-			ID:         7,
-			WebhookID:  int32Ptr(3),
-			StatusCode: 500,
-		},
-		{
-			ID:         8,
-			WebhookID:  int32Ptr(3),
-			StatusCode: 500,
-		},
+		{ID: 1, WebhookID: int32Ptr(1), StatusCode: 200},
+		{ID: 2, WebhookID: int32Ptr(1), StatusCode: 500},
+		{ID: 3, WebhookID: int32Ptr(1), StatusCode: 200},
+		{ID: 4, WebhookID: int32Ptr(2), StatusCode: 200},
+		{ID: 5, WebhookID: int32Ptr(2), StatusCode: 200},
+		{ID: 6, WebhookID: int32Ptr(2), StatusCode: 200},
+		{ID: 7, WebhookID: int32Ptr(3), StatusCode: 500},
+		{ID: 8, WebhookID: int32Ptr(3), StatusCode: 500},
 	}
 	webhookLogsStore.ListFunc.SetDefaultHook(func(_ context.Context, options database.WebhookLogListOpts) ([]*types.WebhookLog, int64, error) {
-		var filteredWebhookLogs []*types.WebhookLog
-		for _, wl := range webhookLogs {
-			filteredWebhookLogs = append(filteredWebhookLogs, wl)
-		}
+		var logs []*types.WebhookLog
+		logs = append(logs, webhookLogs...)
 
 		filter := func(items []*types.WebhookLog, predicate func(log *types.WebhookLog) bool) []*types.WebhookLog {
 			var filtered []*types.WebhookLog
-			for _, wl := range filteredWebhookLogs {
+			for _, wl := range items {
 				if predicate(wl) {
 					filtered = append(filtered, wl)
 				}
@@ -359,8 +325,8 @@ func TestListWebhookLogs(t *testing.T) {
 		}
 
 		if options.WebhookID != nil {
-			filteredWebhookLogs = filter(
-				filteredWebhookLogs,
+			logs = filter(
+				logs,
 				func(wl *types.WebhookLog) bool {
 					return *wl.WebhookID == *options.WebhookID
 				},
@@ -368,15 +334,15 @@ func TestListWebhookLogs(t *testing.T) {
 		}
 
 		if options.OnlyErrors {
-			filteredWebhookLogs = filter(
-				filteredWebhookLogs,
+			logs = filter(
+				logs,
 				func(wl *types.WebhookLog) bool {
 					return wl.StatusCode < 100 || wl.StatusCode > 399
 				},
 			)
 		}
 
-		return filteredWebhookLogs, int64(len(filteredWebhookLogs)), nil
+		return logs, int64(len(logs)), nil
 	})
 
 	webhookLogsStore.CountFunc.SetDefaultHook(func(ctx context.Context, opts database.WebhookLogListOpts) (int64, error) {

--- a/cmd/frontend/graphqlbackend/webhooks_test.go
+++ b/cmd/frontend/graphqlbackend/webhooks_test.go
@@ -69,12 +69,12 @@ func TestListWebhooks(t *testing.T) {
 	db := database.NewMockDB()
 	db.WebhooksFunc.SetDefaultReturn(webhookStore)
 	db.UsersFunc.SetDefaultReturn(users)
-	schema := mustParseGraphQLSchema(t, db)
+	gqlSchema := mustParseGraphQLSchema(t, db)
 	RunTests(t, []*Test{
 		{
 			Label:   "basic",
 			Context: ctx,
-			Schema:  schema,
+			Schema:  gqlSchema,
 			Query: `
 				{
 					webhooks {
@@ -99,7 +99,7 @@ func TestListWebhooks(t *testing.T) {
 		{
 			Label:   "specify first",
 			Context: ctx,
-			Schema:  schema,
+			Schema:  gqlSchema,
 			Query: `query Webhooks($first: Int!) {
 						webhooks(first: $first) {
 							nodes { id }
@@ -124,7 +124,7 @@ func TestListWebhooks(t *testing.T) {
 		{
 			Label:   "specify kind",
 			Context: ctx,
-			Schema:  schema,
+			Schema:  gqlSchema,
 			Query: `query Webhooks($kind: ExternalServiceKind) {
 						webhooks(kind: $kind) {
 							nodes { id }
@@ -150,7 +150,7 @@ func TestListWebhooks(t *testing.T) {
 		{
 			Label:   "specify cursor",
 			Context: ctx,
-			Schema:  schema,
+			Schema:  gqlSchema,
 			Query: `query Webhooks($first: Int!, $after: String!) {
 						webhooks(first: $first, after: $after) {
 							nodes { id }


### PR DESCRIPTION
Test plan:
New GraphQL tests added, existing tests updated.

Closes https://github.com/sourcegraph/sourcegraph/issues/44001