### PR TITLE
search: Add aria-hidden to query input placeholder and set aria-placeholder

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -159,11 +159,8 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
             // extension set aria-hidden="true" on the placeholder, which is
             // what we want.
             const element = document.createElement('span')
-            element.appendChild(document.createTextNode(placeholder))
-            extensions.push(
-                placeholderExtension(element),
-                EditorView.contentAttributes.of({ 'aria-placeholder': placeholder })
-            )
+            element.append(document.createTextNode(placeholder))
+            extensions.push(placeholderExtension(element))
         }
 
         if (editorOptions?.readOnly) {

--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -155,7 +155,15 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<React.PropsWithChil
         }
 
         if (placeholder) {
-            extensions.push(placeholderExtension(placeholder))
+            // Passing a DOM element instead of a string makes the CodeMirror
+            // extension set aria-hidden="true" on the placeholder, which is
+            // what we want.
+            const element = document.createElement('span')
+            element.appendChild(document.createTextNode(placeholder))
+            extensions.push(
+                placeholderExtension(element),
+                EditorView.contentAttributes.of({ 'aria-placeholder': placeholder })
+            )
         }
 
         if (editorOptions?.readOnly) {


### PR DESCRIPTION
Fixes #43135


## Test plan

Manual DOM inspection: Placeholder element as `aria-hidden="true"` set and the input/content element has `aria-placeholder="..."` set.

## App preview:

- [Web](https://sg-web-fkling-43135-codemirror.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
