### PR TITLE
web: hide external service sync errors under collapsible element.

### DIFF
--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -440,7 +440,7 @@ const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJob
                 )}
             </div>
             {isExpanded && legends && <ValueLegendList className="mb-0" items={legends} />}
-            {node.failureMessage && <ErrorAlert error={node.failureMessage} className="mt-2 mb-0" />}
+            {isExpanded && node.failureMessage && <ErrorAlert error={node.failureMessage} className="mt-2 mb-0" />}
         </li>
     )
 }


### PR DESCRIPTION
This commit basically fixes a bug which doesn't "collapse" error message when the external service sync node is collapsed itself.

### Test plan
Local sg run and visual check.

### Error shown
<img width="924" alt="image" src="https://user-images.githubusercontent.com/94846361/200282794-a8135f44-de6a-4351-8a3b-d41539f4e123.png">


### Error collapsed
<img width="929" alt="image" src="https://user-images.githubusercontent.com/94846361/200282951-ef477932-4a37-447d-bc71-8df306d195e9.png">

## App preview:

- [Web](https://sg-web-ao-ui-hide-ext-svc-errors.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
