### PR TITLE
zoekt: remove unread SearchOptions.*MaxtImportantMatch

### DIFF
--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -117,14 +117,12 @@ func searchZoekt(ctx context.Context, repoName types.MinimalRepo, commitID api.C
 	final := zoektquery.Simplify(zoektquery.NewAnd(ands...))
 	match := limitOrDefault(first) + 1
 	resp, err := search.Indexed().Search(ctx, final, &zoekt.SearchOptions{
-		Trace:                  policy.ShouldTrace(ctx),
-		MaxWallTime:            3 * time.Second,
-		ShardMaxMatchCount:     match * 25,
-		TotalMaxMatchCount:     match * 25,
-		ShardMaxImportantMatch: match * 25,
-		TotalMaxImportantMatch: match * 25,
-		MaxDocDisplayCount:     match,
-		ChunkMatches:           true,
+		Trace:              policy.ShouldTrace(ctx),
+		MaxWallTime:        3 * time.Second,
+		ShardMaxMatchCount: match * 25,
+		TotalMaxMatchCount: match * 25,
+		MaxDocDisplayCount: match,
+		ChunkMatches:       true,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -135,8 +135,6 @@ func (o *Options) ToSearch(ctx context.Context) *zoekt.SearchOptions {
 		k := o.resultCountFactor()
 		searchOpts.ShardMaxMatchCount = 100 * k
 		searchOpts.TotalMaxMatchCount = 100 * k
-		searchOpts.ShardMaxImportantMatch = 15 * k
-		searchOpts.TotalMaxImportantMatch = 25 * k
 		// Ask for 2000 more results so we have results to populate
 		// RepoStatusLimitHit.
 		searchOpts.MaxDocDisplayCount = int(o.FileMatchLimit) + 2000


### PR DESCRIPTION
These fields are deprecated and were never read.

Test Plan: go test