### PR TITLE
fix prometheus Dockerfile build

### DIFF
--- a/docker-images/prometheus/Dockerfile
+++ b/docker-images/prometheus/Dockerfile
@@ -77,7 +77,6 @@ COPY ./alertmanager.sh /alertmanager.sh
 
 # Copy config
 COPY --from=monitoring_builder /generated/prometheus/* /sg_config_prometheus/
-COPY config/*_rules.yml /sg_config_prometheus/
 COPY config/prometheus.yml /sg_config_prometheus/
 COPY config/alertmanager.yml /sg_config_prometheus/
 


### PR DESCRIPTION
This `COPY` line fails the Prometheus Docker build, because there haven't been any `*_rules.yml` files since aa05d0bd2497d0e5f6a02e27f0edc3410817f950 and 834da914c860bc0bb30cb7a3a7e5e2b8061f6951.

## Test plan

Verified in dev environment