### PR TITLE
Open in Editor: Use line numbers to open the right line of the file

### DIFF
--- a/client/web/src/open-in-editor/build-url.test.ts
+++ b/client/web/src/open-in-editor/build-url.test.ts
@@ -80,34 +80,34 @@ describe('buildRepoBaseNameAndPath tests', () => {
 })
 
 describe('buildEditorUrl tests', () => {
-    const defaultRange = { start: { line: 43, character: 0 }, end: { line: 43, character: 0 } }
+    const defaultPosition = { line: 43, character: 0 }
     const defaultPath = 'sourcegraph/.gitignore'
     const baseUrl = 'https://sourcegraph.com'
     describe('happy paths', () => {
         it('builds the correct URL for some basic settings and VS Code', () => {
-            const url = buildEditorUrl(defaultPath, defaultRange, buildSettings(), baseUrl)
+            const url = buildEditorUrl(defaultPath, defaultPosition, buildSettings(), baseUrl)
             expect(url.toString()).toBe('vscode://file/home/user/projects/sourcegraph/.gitignore:43:0')
         })
 
         it('builds the correct URL for some basic settings and IDEA', () => {
-            const url = buildEditorUrl(defaultPath, defaultRange, buildSettings({ editorIds: ['idea'] }), baseUrl)
+            const url = buildEditorUrl(defaultPath, defaultPosition, buildSettings({ editorIds: ['idea'] }), baseUrl)
             expect(url.toString()).toBe('idea://open?file=/home/user/projects/sourcegraph/.gitignore&line=43&column=0')
         })
 
         it('builds the correct URL for some basic settings and Atom', () => {
-            const url = buildEditorUrl(defaultPath, defaultRange, buildSettings({ editorIds: ['atom'] }), baseUrl)
+            const url = buildEditorUrl(defaultPath, defaultPosition, buildSettings({ editorIds: ['atom'] }), baseUrl)
             expect(url.toString()).toBe(
                 'atom://core/open/file?filename=/home/user/projects/sourcegraph/.gitignore:43:0'
             )
         })
 
         it('builds the correct URL for some basic settings and Sublime', () => {
-            const url = buildEditorUrl(defaultPath, defaultRange, buildSettings({ editorIds: ['sublime'] }), baseUrl)
+            const url = buildEditorUrl(defaultPath, defaultPosition, buildSettings({ editorIds: ['sublime'] }), baseUrl)
             expect(url.toString()).toBe('subl://open?url=/home/user/projects/sourcegraph/.gitignore&line=43&column=0')
         })
 
         it('builds the correct URL for some basic settings and PyCharm', () => {
-            const url = buildEditorUrl(defaultPath, defaultRange, buildSettings({ editorIds: ['pycharm'] }), baseUrl)
+            const url = buildEditorUrl(defaultPath, defaultPosition, buildSettings({ editorIds: ['pycharm'] }), baseUrl)
             expect(url.toString()).toBe(
                 'pycharm://open?file=/home/user/projects/sourcegraph/.gitignore&line=43&column=0'
             )
@@ -118,7 +118,7 @@ describe('buildEditorUrl tests', () => {
             Object.defineProperty(navigator, 'userAgent', { value: 'MacOS', writable: true })
             const url = buildEditorUrl(
                 defaultPath,
-                defaultRange,
+                defaultPosition,
                 buildSettings({
                     editorIds: ['goland'],
                     'projectPaths.default': '/home/user/projects',
@@ -135,7 +135,7 @@ describe('buildEditorUrl tests', () => {
         it('performs replacements', () => {
             const url = buildEditorUrl(
                 defaultPath,
-                defaultRange,
+                defaultPosition,
                 buildSettings({ replacements: { projects: 'new-projects' } }),
                 baseUrl
             )
@@ -145,7 +145,7 @@ describe('buildEditorUrl tests', () => {
         it('forces JetBrains built-in server', () => {
             const url = buildEditorUrl(
                 defaultPath,
-                defaultRange,
+                defaultPosition,
                 buildSettings({
                     editorIds: ['goland'],
                     'jetbrains.forceApi': 'builtInServer',
@@ -160,7 +160,7 @@ describe('buildEditorUrl tests', () => {
         it('handles UNC paths for VS Code', () => {
             const url = buildEditorUrl(
                 defaultPath,
-                defaultRange,
+                defaultPosition,
                 buildSettings({
                     'projectPaths.default': '/server/projects',
                     'vscode.isProjectPathUNCPath': true,
@@ -173,7 +173,7 @@ describe('buildEditorUrl tests', () => {
         it('handles Windows paths for VS Code', () => {
             const url = buildEditorUrl(
                 defaultPath,
-                defaultRange,
+                defaultPosition,
                 buildSettings({ 'projectPaths.default': 'C:\\Projects' }),
                 baseUrl
             )
@@ -188,7 +188,7 @@ describe('buildEditorUrl tests', () => {
         it('can use insiders build of VS Code', () => {
             const url = buildEditorUrl(
                 defaultPath,
-                defaultRange,
+                defaultPosition,
                 buildSettings({ 'vscode.useInsiders': true }),
                 baseUrl
             )
@@ -198,7 +198,7 @@ describe('buildEditorUrl tests', () => {
         it('can use SSH with VS Code', () => {
             const url = buildEditorUrl(
                 defaultPath,
-                defaultRange,
+                defaultPosition,
                 buildSettings({
                     'vscode.useSSH': true,
                     'vscode.remoteHostForSSH': '127.0.0.1',
@@ -213,7 +213,7 @@ describe('buildEditorUrl tests', () => {
         it('can use SSH with VS Code Insiders', () => {
             const url = buildEditorUrl(
                 defaultPath,
-                defaultRange,
+                defaultPosition,
                 buildSettings({
                     'vscode.useInsiders': true,
                     'vscode.useSSH': true,
@@ -229,7 +229,7 @@ describe('buildEditorUrl tests', () => {
         it('can use a custom URL pattern', () => {
             const url = buildEditorUrl(
                 defaultPath,
-                defaultRange,
+                defaultPosition,
                 buildSettings({
                     editorIds: ['custom'],
                     'custom.urlPattern': 'idea://test?file=%file&line=%line&column=%col',
@@ -243,13 +243,13 @@ describe('buildEditorUrl tests', () => {
     describe('unhappy paths', () => {
         it('recognizes missing editor settings', () => {
             expect(() => {
-                buildEditorUrl(defaultPath, defaultRange, undefined, baseUrl)
+                buildEditorUrl(defaultPath, defaultPosition, undefined, baseUrl)
             }).toThrow()
         })
 
         it('recognizes missing project path', () => {
             expect(() => {
-                buildEditorUrl(defaultPath, defaultRange, { editorIds: ['vscode'] }, baseUrl)
+                buildEditorUrl(defaultPath, defaultPosition, { editorIds: ['vscode'] }, baseUrl)
             }).toThrow()
         })
 
@@ -257,7 +257,7 @@ describe('buildEditorUrl tests', () => {
             expect(() => {
                 buildEditorUrl(
                     defaultPath,
-                    defaultRange,
+                    defaultPosition,
                     buildSettings({ 'projectPaths.default': '../projects' }),
                     baseUrl
                 )
@@ -266,7 +266,7 @@ describe('buildEditorUrl tests', () => {
 
         it('recognizes missing editor ID', () => {
             expect(() => {
-                buildEditorUrl(defaultPath, defaultRange, { 'projectPaths.default': '/home/user/projects' }, baseUrl)
+                buildEditorUrl(defaultPath, defaultPosition, { 'projectPaths.default': '/home/user/projects' }, baseUrl)
             }).toThrow()
         })
 
@@ -274,7 +274,7 @@ describe('buildEditorUrl tests', () => {
             expect(() => {
                 buildEditorUrl(
                     defaultPath,
-                    defaultRange,
+                    defaultPosition,
                     buildSettings({
                         editorIds: ['custom'],
                         'projectPaths.default': '/home/user/projects',
@@ -286,19 +286,19 @@ describe('buildEditorUrl tests', () => {
 
         it('recognizes missing editor settings', () => {
             expect(() => {
-                buildEditorUrl(defaultPath, defaultRange, { editorIds: ['vscode'] }, baseUrl)
+                buildEditorUrl(defaultPath, defaultPosition, { editorIds: ['vscode'] }, baseUrl)
             }).toThrow()
         })
 
         it('recognizes missing SSH remote setting if vscode SSH mode is enabled', () => {
             expect(() => {
-                buildEditorUrl(defaultPath, defaultRange, buildSettings({ 'vscode.useSSH': true }), baseUrl)
+                buildEditorUrl(defaultPath, defaultPosition, buildSettings({ 'vscode.useSSH': true }), baseUrl)
             }).toThrow()
         })
 
         it('builds the right "Learn more" URL', () => {
             expect(() => {
-                buildEditorUrl(defaultPath, defaultRange, { editorIds: ['vscode'] }, baseUrl)
+                buildEditorUrl(defaultPath, defaultPosition, { editorIds: ['vscode'] }, baseUrl)
             }).toThrow(/https:\/\/docs\.sourcegraph\.com\/integration\/open_in_editor/)
         })
     })

--- a/client/web/src/open-in-editor/build-url.ts
+++ b/client/web/src/open-in-editor/build-url.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
 
-import type { UIRangeSpec } from '@sourcegraph/shared/src/util/url'
+import type { UIPositionSpec } from '@sourcegraph/shared/src/util/url'
 
 import { ExternalServiceKind } from '../graphql-operations'
 
@@ -29,7 +29,7 @@ export function buildRepoBaseNameAndPath(
 
 export function buildEditorUrl(
     repoBaseNameAndPath: string,
-    range: UIRangeSpec['range'] | undefined,
+    position: UIPositionSpec['position'] | undefined,
     editorSettings: EditorSettings | undefined,
     sourcegraphBaseUrl: string,
     editorIndex = 0
@@ -49,7 +49,7 @@ export function buildEditorUrl(
             : ''
 
     const absolutePath = path.join(projectPath, repoBaseNameAndPath)
-    const { line, column } = range ? { line: range.start.line, column: range.start.character } : { line: 1, column: 1 }
+    const { line, column } = position ? { line: position.line, column: position.character } : { line: 1, column: 1 }
     const url = urlPattern
         .replace('%file', pathPrefix + absolutePath)
         .replace('%line', `${line}`)

--- a/client/web/src/open-in-editor/useOpenCurrentUrlInEditor.ts
+++ b/client/web/src/open-in-editor/useOpenCurrentUrlInEditor.ts
@@ -1,7 +1,5 @@
 import { useCallback } from 'react'
 
-import { useLocation } from 'react-router'
-
 import { parseBrowserRepoURL } from '../util/url'
 
 import { buildEditorUrl, buildRepoBaseNameAndPath } from './build-url'
@@ -15,16 +13,15 @@ export const useOpenCurrentUrlInEditor = (): ((
     externalServiceType: string | undefined,
     sourcegraphURL: string,
     editorIndex?: number
-) => void) => {
-    const location = useLocation()
-    return useCallback(
+) => void) =>
+    useCallback(
         (
             editorSettings: EditorSettings | undefined,
             externalServiceType: string | undefined,
             sourcegraphURL: string,
             editorIndex = 0
         ) => {
-            const { repoName, filePath, range } = parseBrowserRepoURL(location.pathname)
+            const { repoName, filePath, range } = parseBrowserRepoURL(window.location.href)
             const url = buildEditorUrl(
                 buildRepoBaseNameAndPath(repoName, externalServiceType, filePath),
                 range,
@@ -36,4 +33,3 @@ export const useOpenCurrentUrlInEditor = (): ((
         },
         [location.pathname]
     )
-}

--- a/client/web/src/open-in-editor/useOpenCurrentUrlInEditor.ts
+++ b/client/web/src/open-in-editor/useOpenCurrentUrlInEditor.ts
@@ -21,15 +21,16 @@ export const useOpenCurrentUrlInEditor = (): ((
             sourcegraphURL: string,
             editorIndex = 0
         ) => {
-            const { repoName, filePath, range } = parseBrowserRepoURL(window.location.href)
+            const { repoName, filePath, position, range } = parseBrowserRepoURL(window.location.href)
+            const start = position || range?.start
             const url = buildEditorUrl(
                 buildRepoBaseNameAndPath(repoName, externalServiceType, filePath),
-                range,
+                start,
                 editorSettings,
                 sourcegraphURL,
                 editorIndex
             )
             window.open(url.toString(), '_blank')
         },
-        [location.pathname]
+        []
     )


### PR DESCRIPTION
We had two issues:
1. We didn't _pass_ the needed information (the search query part of the URL) to the URL builder logic, so it had no chance to use it 😄 
2. We didn't use the returned `position` information, just `range`, so if only a single line was selected, it wouldn't have used the returned position info.

Fixed both and now it works fine for me.

## Test plan

Half-minute Loom demo: https://www.loom.com/share/d77cb2b773af46a4aa9156feec1b6796

## App preview:

- [Web](https://sg-web-dv-fix-open-in-editor-line-numbers.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
