### PR TITLE
internal/repos: Add debug logs

### DIFF
--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -967,12 +967,12 @@ func (s *GitHubSource) fetchAllRepositoriesInBatches(ctx context.Context, result
 		for _, r := range repos {
 			if err := ctx.Err(); err != nil {
 				results <- &githubResult{err: err}
-				s.logger.Debug("context error", log.String("repo", fmt.Sprintf("%v", r)))
+				s.logger.Debug("context error", log.String("repo", fmt.Sprintf("%+v", r)))
 				return err
 			}
 
 			results <- &githubResult{repo: r}
-			s.logger.Debug("sent repo to result", log.String("repo", fmt.Sprintf("%v", r)))
+			s.logger.Debug("sent repo to result", log.String("repo", fmt.Sprintf("%+v", r)))
 		}
 	}
 

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -570,14 +570,12 @@ func (s *GitHubSource) listRepos(ctx context.Context, repos []string, results ch
 	for i := len(repos) - 1; i >= 0; i-- {
 		nameWithOwner := repos[i]
 		if err := ctx.Err(); err != nil {
-			s.logger.Debug("context error", log.String("nameWithOwner", nameWithOwner))
-			results <- &githubResult{err: err}
+			results <- &githubResult{err: errors.Wrap(err, "context error for repository: namewithOwner="+nameWithOwner)}
 			return
 		}
 
 		owner, name, err := github.SplitRepositoryNameWithOwner(nameWithOwner)
 		if err != nil {
-			s.logger.Debug("invalid repository", log.String("nameWithOwner", nameWithOwner))
 			results <- &githubResult{err: errors.New("Invalid GitHub repository: nameWithOwner=" + nameWithOwner)}
 			return
 		}

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -570,13 +570,13 @@ func (s *GitHubSource) listRepos(ctx context.Context, repos []string, results ch
 	for i := len(repos) - 1; i >= 0; i-- {
 		nameWithOwner := repos[i]
 		if err := ctx.Err(); err != nil {
-			results <- &githubResult{err: errors.Wrap(err, "context error for repository: namewithOwner="+nameWithOwner)}
+			results <- &githubResult{err: errors.Wrapf(err, "context error for repository: namewithOwner=%s", nameWithOwner)}
 			return
 		}
 
 		owner, name, err := github.SplitRepositoryNameWithOwner(nameWithOwner)
 		if err != nil {
-			results <- &githubResult{err: errors.New("Invalid GitHub repository: nameWithOwner=" + nameWithOwner)}
+			results <- &githubResult{err: errors.Newf("Invalid GitHub repository: nameWithOwner=%s", nameWithOwner)}
 			return
 		}
 		var repo *github.Repository

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -964,8 +964,11 @@ func (s *GitHubSource) fetchAllRepositoriesInBatches(ctx context.Context, result
 		s.logger.Debug("github sync: GetReposByNameWithOwner", log.Strings("repos", batch))
 		for _, r := range repos {
 			if err := ctx.Err(); err != nil {
+				if r != nil {
+					err = errors.Wrapf(err, "context error for repository: %s", r.NameWithOwner)
+				}
+
 				results <- &githubResult{err: err}
-				s.logger.Debug("context error", log.String("repo", fmt.Sprintf("%+v", r)))
 				return err
 			}
 

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -299,10 +299,10 @@ func (s *GitHubSource) ListRepos(ctx context.Context, results chan SourceResult)
 			continue
 		}
 
-		s.logger.Debug("unfiltered", log.String("repo", fmt.Sprintf("%v", res.repo.NameWithOwner)))
+		s.logger.Debug("unfiltered", log.String("repo", res.repo.NameWithOwner))
 		if !seen[res.repo.DatabaseID] && !s.excludes(res.repo) {
 			results <- SourceResult{Source: s, Repo: s.makeRepo(res.repo)}
-			s.logger.Debug("sent to result", log.String("repo", fmt.Sprintf("%v", res.repo.NameWithOwner)))
+			s.logger.Debug("sent to result", log.String("repo", res.repo.NameWithOwner))
 			seen[res.repo.DatabaseID] = true
 		}
 	}

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -37,6 +37,7 @@ func RunScheduler(ctx context.Context, logger log.Logger, scheduler *UpdateSched
 	)
 
 	conf.Watch(func() {
+		logger.Debug("RunScheduler: watching config")
 		c := conf.Get()
 
 		want := schedulerConfig{
@@ -48,9 +49,10 @@ func RunScheduler(ctx context.Context, logger log.Logger, scheduler *UpdateSched
 			return
 		}
 
+		logger.Debug("RunScheduler: config changed")
 		if stop != nil {
 			stop()
-			logger.Info("stopped previous scheduler")
+			logger.Info("RunScheduler: stopped previous scheduler")
 		}
 
 		// We setup a separate sub-context so that we can reuse the original
@@ -66,7 +68,7 @@ func RunScheduler(ctx context.Context, logger log.Logger, scheduler *UpdateSched
 		}
 
 		logger.Debug(
-			"started configured scheduler",
+			"RunScheduler: started configured scheduler",
 			log.String("version", "new"),
 			log.Bool("auto-git-updates", want.autoGitUpdatesEnabled),
 		)

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -36,8 +36,10 @@ func RunScheduler(ctx context.Context, logger log.Logger, scheduler *UpdateSched
 		stop context.CancelFunc
 	)
 
+	logger.Scoped("RunScheduler", "git fetch scheduler")
+
 	conf.Watch(func() {
-		logger.Debug("RunScheduler: watching config")
+		logger.Debug("watching config")
 		c := conf.Get()
 
 		want := schedulerConfig{
@@ -49,10 +51,10 @@ func RunScheduler(ctx context.Context, logger log.Logger, scheduler *UpdateSched
 			return
 		}
 
-		logger.Debug("RunScheduler: config changed")
+		logger.Debug("config changed")
 		if stop != nil {
 			stop()
-			logger.Info("RunScheduler: stopped previous scheduler")
+			logger.Info("stopped previous scheduler")
 		}
 
 		// We setup a separate sub-context so that we can reuse the original
@@ -68,7 +70,7 @@ func RunScheduler(ctx context.Context, logger log.Logger, scheduler *UpdateSched
 		}
 
 		logger.Debug(
-			"RunScheduler: started configured scheduler",
+			"started configured scheduler",
 			log.String("version", "new"),
 			log.Bool("auto-git-updates", want.autoGitUpdatesEnabled),
 		)

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -36,7 +36,7 @@ func RunScheduler(ctx context.Context, logger log.Logger, scheduler *UpdateSched
 		stop context.CancelFunc
 	)
 
-	logger.Scoped("RunScheduler", "git fetch scheduler")
+	logger = logger.Scoped("RunScheduler", "git fetch scheduler")
 
 	conf.Watch(func() {
 		logger.Debug("watching config")

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -39,7 +39,6 @@ func RunScheduler(ctx context.Context, logger log.Logger, scheduler *UpdateSched
 	logger = logger.Scoped("RunScheduler", "git fetch scheduler")
 
 	conf.Watch(func() {
-		logger.Debug("watching config")
 		c := conf.Get()
 
 		want := schedulerConfig{

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -307,8 +307,7 @@ func (s *Syncer) SyncRepo(ctx context.Context, name api.RepoName, background boo
 
 	repo, err = s.Store.RepoStore().GetByName(ctx, name)
 	if err != nil && !errcode.IsNotFound(err) {
-		logger.Debug("repo not found in DB, skipping")
-		return nil, err
+		return nil, errors.Wrapf(err, "GetByName failed for %q", name)
 	}
 
 	codehost := extsvc.CodeHostOf(name, extsvc.PublicCodeHosts...)

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -783,7 +783,7 @@ func (s *Syncer) sync(ctx context.Context, svc *types.ExternalService, sourced *
 		if s.Synced != nil && d.Len() > 0 {
 			select {
 			case <-ctx.Done():
-				s.Logger.Debug("context done")
+				s.Logger.Debug("sync context done")
 			case s.Synced <- d:
 				s.Logger.Debug("diff synced")
 			}

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -299,11 +299,15 @@ func (rm ReposModified) ReposModified(modified types.RepoModified) types.Repos {
 // sync in the background vs block and call s.syncRepo synchronously.
 func (s *Syncer) SyncRepo(ctx context.Context, name api.RepoName, background bool) (repo *types.Repo, err error) {
 	logger := s.Logger.With(log.String("name", string(name)), log.Bool("background", background))
+
+	logger.Debug("SyncRepo started")
+
 	tr, ctx := trace.New(ctx, "Syncer.SyncRepo", string(name))
 	defer tr.Finish()
 
 	repo, err = s.Store.RepoStore().GetByName(ctx, name)
 	if err != nil && !errcode.IsNotFound(err) {
+		logger.Debug("repo not foundin DB, skipping")
 		return nil, err
 	}
 
@@ -312,30 +316,36 @@ func (s *Syncer) SyncRepo(ctx context.Context, name api.RepoName, background boo
 		if repo != nil {
 			return repo, nil
 		}
+
+		logger.Debug("no associated code host found, skipping")
 		return nil, &database.RepoNotFoundErr{Name: name}
 	}
 
 	if repo != nil {
 		// Only public repos can be individually synced on sourcegraph.com
 		if repo.Private {
+			logger.Debug("repo is private, skipping")
 			return nil, &database.RepoNotFoundErr{Name: name}
 		}
 		// Don't sync the repo if it's been updated in the past 1 minute.
 		if s.Now().Sub(repo.UpdatedAt) < time.Minute {
+			logger.Debug("repo updated recently, skipping")
 			return repo, nil
 		}
 	}
 
 	if background && repo != nil {
+		logger.Debug("starting background sync in goroutine")
 		go func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			defer cancel()
 
 			// We don't care about the return value here, but we still want to ensure that
 			// only one is in flight at a time.
-			_, err, shared := s.syncGroup.Do(string(name), func() (any, error) {
+			updatedRepo, err, shared := s.syncGroup.Do(string(name), func() (any, error) {
 				return s.syncRepo(ctx, codehost, name, repo)
 			})
+			logger.Debug("syncGroup completed", log.String("updatedRepo", fmt.Sprintf("%v", updatedRepo.(*types.Repo))))
 			if err != nil {
 				logger.Error("SyncRepo", log.Error(err), log.Bool("shared", shared))
 			}
@@ -343,6 +353,7 @@ func (s *Syncer) SyncRepo(ctx context.Context, name api.RepoName, background boo
 		return repo, nil
 	}
 
+	logger.Debug("starting foreground sync")
 	updatedRepo, err, shared := s.syncGroup.Do(string(name), func() (any, error) {
 		return s.syncRepo(ctx, codehost, name, repo)
 	})
@@ -388,7 +399,7 @@ func (s *Syncer) syncRepo(
 
 	src, err := s.Sourcer(ctx, svc)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to retrieve Sourcer")
 	}
 
 	rg, ok := src.(RepoGetter)
@@ -403,6 +414,7 @@ func (s *Syncer) syncRepo(
 
 	if stored != nil {
 		defer func() {
+			s.Logger.Debug("deferred deletable repo check")
 			if isDeleteableRepoError(err) {
 				err2 := s.Store.DeleteExternalServiceRepo(ctx, svc, stored.ID)
 				if err2 != nil {
@@ -414,6 +426,7 @@ func (s *Syncer) syncRepo(
 						log.Error(err2),
 					)
 				}
+				s.Logger.Debug("external service repo deleted", log.Int32("stored.ID", int32(stored.ID)))
 				s.notifyDeleted(ctx, stored.ID)
 			}
 		}()
@@ -421,10 +434,11 @@ func (s *Syncer) syncRepo(
 
 	repo, err = rg.GetRepo(ctx, path)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to get repo: %q")
 	}
 
 	if repo.Private {
+		s.Logger.Debug("repo is private, skipping")
 		return nil, &database.RepoNotFoundErr{Name: name}
 	}
 
@@ -582,11 +596,12 @@ func (s *Syncer) SyncExternalService(
 
 	src, err := s.Sourcer(ctx, svc)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get sourcer")
 	}
 
 	results := make(chan SourceResult)
 	go func() {
+		s.Logger.Debug("listing repos asynchronously")
 		src.ListRepos(ctx, results)
 		close(results)
 	}()
@@ -617,6 +632,8 @@ func (s *Syncer) SyncExternalService(
 	// Insert or update repos as they are sourced. Keep track of what was seen so we
 	// can remove anything else at the end.
 	for res := range results {
+		logger.Debug("received result", log.String("repo", string(res.Repo.Name)))
+
 		if err := progressRecorder(ctx, syncProgress, false); err != nil {
 			logger.Warn("recording sync progress", log.Error(err))
 		}
@@ -756,15 +773,20 @@ func (s *Syncer) sync(ctx context.Context, svc *types.ExternalService, sourced *
 		observeDiff(d)
 		// We must commit the transaction before publishing to s.Synced
 		// so that gitserver finds the repo in the database.
+
+		s.Logger.Debug("syncer: committing transaction")
 		err = tx.Done(err)
 		if err != nil {
+			s.Logger.Warn("failed to commit transaction", log.Error(err))
 			return
 		}
 
 		if s.Synced != nil && d.Len() > 0 {
 			select {
 			case <-ctx.Done():
+				s.Logger.Debug("syncer: context done")
 			case s.Synced <- d:
+				s.Logger.Debug("syncer: context done")
 			}
 		}
 	}()
@@ -782,6 +804,8 @@ func (s *Syncer) sync(ctx context.Context, svc *types.ExternalService, sourced *
 
 	switch len(stored) {
 	case 2: // Existing repo with a naming conflict
+		s.Logger.Debug("syncer: naming conflict")
+
 		// Pick this sourced repo to own the name by deleting the other repo. If it still exists, it'll have a different
 		// name when we source it from the same code host, and it will be re-created.
 		var conflicting, existing *types.Repo
@@ -801,8 +825,10 @@ func (s *Syncer) sync(ctx context.Context, svc *types.ExternalService, sourced *
 		// We fallthrough to the next case after removing the conflicting repo in order to update
 		// the winner (i.e. existing). This works because we mutate stored to contain it, which the case expects.
 		stored = types.Repos{existing}
+		s.Logger.Debug("syncer: retrieved stored repo, falling through", log.String("stored", fmt.Sprintf("%v", stored)))
 		fallthrough
 	case 1: // Existing repo, update.
+		s.Logger.Debug("syncer: exisitng repo")
 		modified := stored[0].Update(sourced)
 		if modified == types.RepoUnmodified {
 			d.Unmodified = append(d.Unmodified, stored[0])
@@ -815,16 +841,20 @@ func (s *Syncer) sync(ctx context.Context, svc *types.ExternalService, sourced *
 
 		*sourced = *stored[0]
 		d.Modified = append(d.Modified, RepoModified{Repo: stored[0], Modified: modified})
+		s.Logger.Debug("syncer: appended to modified repos")
 	case 0: // New repo, create.
+		s.Logger.Debug("syncer: new repo")
 		if err = tx.CreateExternalServiceRepo(ctx, svc, sourced); err != nil {
 			return Diff{}, errors.Wrap(err, "syncer: failed to create external service repo")
 		}
 
 		d.Added = append(d.Added, sourced)
+		s.Logger.Debug("syncer: appended to added repos")
 	default: // Impossible since we have two separate unique constraints on name and external repo spec
 		panic("unreachable")
 	}
 
+	s.Logger.Debug("syncer: completed")
 	return d, nil
 }
 

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -434,7 +434,7 @@ func (s *Syncer) syncRepo(
 
 	repo, err = rg.GetRepo(ctx, path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get repo: %q")
+		return nil, errors.Wrapf(err, "failed to get repo with path: %q", path)
 	}
 
 	if repo.Private {

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -307,7 +307,7 @@ func (s *Syncer) SyncRepo(ctx context.Context, name api.RepoName, background boo
 
 	repo, err = s.Store.RepoStore().GetByName(ctx, name)
 	if err != nil && !errcode.IsNotFound(err) {
-		logger.Debug("repo not foundin DB, skipping")
+		logger.Debug("repo not found in DB, skipping")
 		return nil, err
 	}
 

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -425,7 +425,7 @@ func (s *Syncer) syncRepo(
 						log.Error(err2),
 					)
 				}
-				s.Logger.Debug("external service repo deleted", log.Int32("stored.ID", int32(stored.ID)))
+				s.Logger.Debug("external service repo deleted", log.Int32("deleted ID", int32(stored.ID)))
 				s.notifyDeleted(ctx, stored.ID)
 			}
 		}()

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -632,7 +632,7 @@ func (s *Syncer) SyncExternalService(
 	// Insert or update repos as they are sourced. Keep track of what was seen so we
 	// can remove anything else at the end.
 	for res := range results {
-		logger.Debug("received result", log.String("repo", string(res.Repo.Name)))
+		logger.Debug("received result", log.String("repo", fmt.Sprintf("%v", res)))
 
 		if err := progressRecorder(ctx, syncProgress, false); err != nil {
 			logger.Warn("recording sync progress", log.Error(err))

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -596,7 +596,7 @@ func (s *Syncer) SyncExternalService(
 
 	src, err := s.Sourcer(ctx, svc)
 	if err != nil {
-		return errors.Wrap(err, "failed to get sourcer")
+		return err
 	}
 
 	results := make(chan SourceResult)


### PR DESCRIPTION
Also wrap errors in some places.

This is to aid in debugging a curious case of few missing repos in https://github.com/sourcegraph/customer/issues/1487. 



## Test plan

Only logging and error wrapping. No functional change.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
