### PR TITLE
web: add a command to fix js linter issues in changed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format:check": "yarn run format --write=false --check --list-different=false --loglevel=warn",
     "_lint:js": "DOCSITE_LIST=\"$(./dev/docsite.sh -config doc/docsite.json ls)\" NODE_OPTIONS=\"--max_old_space_size=16192\" eslint",
     "lint:js:changed": "yarn _lint:js $(git diff --diff-filter=d --name-only origin/main... | grep -E '\\.[tj]sx?$' | xargs)",
+    "lint:js:changed:fix": "yarn _lint:js --fix $(git diff --diff-filter=d --name-only origin/main... | grep -E '\\.[tj]sx?$' | xargs)",
     "lint:js:root": "yarn run _lint:js --quiet '*.[tj]s?(x)'",
     "lint:js:all": "DOCSITE_LIST=\"$(./dev/docsite.sh -config doc/docsite.json ls)\" dev/foreach-ts-project.sh yarn run lint:js --quiet && yarn lint:js:root",
     "_lint:css": "stylelint --quiet",


### PR DESCRIPTION
I personally used it multiple times recently, that's why I decided to add it here.

## Test plan
Ran this command locally.

## App preview:

- [Web](https://sg-web-ao-ui-add-lint-fix-cmd.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
