### PR TITLE
search: Add screenreader only commas to query input suggestions

### DIFF
--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -146,15 +146,29 @@ export function searchQueryAutocompletion(
         // This renders the completion icon
         {
             render(completion) {
-                return createSVGIcon(
+                const icon = createSVGIcon(
                     completion.type && completion.type in typeIconMap
                         ? typeIconMap[completion.type as CompletionType]
                         : typeIconMap[SymbolKind.UNKNOWN]
                 )
+                if (completion.type && completion.type in typeIconMap) {
+                    icon.setAttribute('aria-label', completion.type)
+                }
+                return icon
             },
             // Per CodeMirror documentation, 20 is the default icon
             // position
             position: 20,
+        },
+        {
+            render: voiceOverComma,
+            // after icon
+            position: 21,
+        },
+        {
+            render: voiceOverComma,
+            // after label
+            position: 51,
         },
         {
             render(completion) {
@@ -549,4 +563,15 @@ function isTokenInRange(
     position: number
 ): boolean {
     return token.range.start <= position && token.range.end + (token.type === 'field' ? 2 : 0) >= position
+}
+
+/**
+ * Helper function for inserting voice over-only commas to improve the way the
+ * content is read.
+ */
+function voiceOverComma(): HTMLElement {
+    const element = document.createElement('span')
+    element.className = 'sr-only'
+    element.append(document.createTextNode(','))
+    return element
 }

--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -149,11 +149,9 @@ export function searchQueryAutocompletion(
                 const icon = createSVGIcon(
                     completion.type && completion.type in typeIconMap
                         ? typeIconMap[completion.type as CompletionType]
-                        : typeIconMap[SymbolKind.UNKNOWN]
+                        : typeIconMap[SymbolKind.UNKNOWN],
+                    completion.type && completion.type in typeIconMap ? completion.type : ''
                 )
-                if (completion.type && completion.type in typeIconMap) {
-                    icon.setAttribute('aria-label', completion.type)
-                }
                 return icon
             },
             // Per CodeMirror documentation, 20 is the default icon

--- a/client/shared/src/util/dom.test.ts
+++ b/client/shared/src/util/dom.test.ts
@@ -38,10 +38,10 @@ describe('createSVGIcon', () => {
     test('create SVG icon without label', () => {
         expect(createSVGIcon('M 10 10')).toMatchInlineSnapshot(`
             <svg
+              aria-hidden="true"
               viewBox="0 0 24 24"
             >
               <path
-                aria-hidden="true"
                 d="M 10 10"
               />
             </svg>
@@ -50,10 +50,10 @@ describe('createSVGIcon', () => {
     test('create SVG icon with label', () => {
         expect(createSVGIcon('M 10 10', 'open')).toMatchInlineSnapshot(`
             <svg
+              aria-label="open"
               viewBox="0 0 24 24"
             >
               <path
-                aria-label="open"
                 d="M 10 10"
               />
             </svg>
@@ -62,10 +62,10 @@ describe('createSVGIcon', () => {
     test('create SVG icon with empty label', () => {
         expect(createSVGIcon('M 10 10', '')).toMatchInlineSnapshot(`
             <svg
+              aria-hidden="true"
               viewBox="0 0 24 24"
             >
               <path
-                aria-hidden="true"
                 d="M 10 10"
               />
             </svg>

--- a/client/shared/src/util/dom.test.ts
+++ b/client/shared/src/util/dom.test.ts
@@ -35,12 +35,37 @@ describe('isInputElement', () => {
 })
 
 describe('createSVGIcon', () => {
-    test('create SVG icon', () => {
+    test('create SVG icon without label', () => {
         expect(createSVGIcon('M 10 10')).toMatchInlineSnapshot(`
             <svg
               viewBox="0 0 24 24"
             >
               <path
+                aria-hidden="true"
+                d="M 10 10"
+              />
+            </svg>
+        `)
+    })
+    test('create SVG icon with label', () => {
+        expect(createSVGIcon('M 10 10', 'open')).toMatchInlineSnapshot(`
+            <svg
+              viewBox="0 0 24 24"
+            >
+              <path
+                aria-label="open"
+                d="M 10 10"
+              />
+            </svg>
+        `)
+    })
+    test('create SVG icon with empty label', () => {
+        expect(createSVGIcon('M 10 10', '')).toMatchInlineSnapshot(`
+            <svg
+              viewBox="0 0 24 24"
+            >
+              <path
+                aria-hidden="true"
                 d="M 10 10"
               />
             </svg>

--- a/client/shared/src/util/dom.test.ts
+++ b/client/shared/src/util/dom.test.ts
@@ -38,7 +38,6 @@ describe('createSVGIcon', () => {
     test('create SVG icon', () => {
         expect(createSVGIcon('M 10 10')).toMatchInlineSnapshot(`
             <svg
-              aria-hidden="true"
               viewBox="0 0 24 24"
             >
               <path

--- a/client/shared/src/util/dom.ts
+++ b/client/shared/src/util/dom.ts
@@ -34,11 +34,10 @@ function elementIsContentEditable(element: HTMLElement): boolean {
 /**
  * Creates an SVG node. To be used together with path specs from @mdi/js
  */
-export function createSVGIcon(pathSpec: string): Node {
+export function createSVGIcon(pathSpec: string): SVGElement {
     const svgNS = 'http://www.w3.org/2000/svg'
     const svg = document.createElementNS(svgNS, 'svg')
     svg.setAttributeNS(null, 'viewBox', '0 0 24 24')
-    svg.setAttribute('aria-hidden', 'true')
 
     const path = document.createElementNS(svgNS, 'path')
     path.setAttribute('d', pathSpec)

--- a/client/shared/src/util/dom.ts
+++ b/client/shared/src/util/dom.ts
@@ -31,17 +31,24 @@ function elementIsContentEditable(element: HTMLElement): boolean {
     }
 }
 
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg'
+const HTML_NAMESPACE = 'http://www.w3.org/1999/xhtml'
+
 /**
  * Creates an SVG node. To be used together with path specs from @mdi/js
  */
-export function createSVGIcon(pathSpec: string): SVGElement {
-    const svgNS = 'http://www.w3.org/2000/svg'
-    const svg = document.createElementNS(svgNS, 'svg')
-    svg.setAttributeNS(null, 'viewBox', '0 0 24 24')
+export function createSVGIcon(pathSpec: string, ariaLabel?: string): SVGElement {
+    const svg = document.createElementNS(SVG_NAMESPACE, 'svg')
+    svg.setAttribute('viewBox', '0 0 24 24')
+    if (ariaLabel) {
+        svg.setAttributeNS(HTML_NAMESPACE, 'aria-label', ariaLabel)
+    } else {
+        svg.setAttributeNS(HTML_NAMESPACE, 'aria-hidden', 'true')
+    }
 
-    const path = document.createElementNS(svgNS, 'path')
+    const path = document.createElementNS(SVG_NAMESPACE, 'path')
     path.setAttribute('d', pathSpec)
-
     svg.append(path)
+
     return svg
 }


### PR DESCRIPTION
Fixes #43139

This commit inserts screenreader-only commas between search suggestion parts.

## Test plan

Manual inspection of DOM. 
<img width="289" alt="2022-11-07_10-19" src="https://user-images.githubusercontent.com/179026/200324692-ba5710e1-afe0-40a1-ab6c-d285e0a31f98.png">


## App preview:

- [Web](https://sg-web-fkling-43139-vo-suggestions.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
