### PR TITLE
insights: remove unneeded test that flaked

### DIFF
--- a/enterprise/internal/insights/background/limiter/search_query_test.go
+++ b/enterprise/internal/insights/background/limiter/search_query_test.go
@@ -3,8 +3,6 @@ package limiter_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background/limiter"
 )
 
@@ -16,13 +14,6 @@ func TestSearchQueryLimit(t *testing.T) {
 		if limiter1 != limiter2 {
 			t.Error("both limiters should be the same instance")
 		}
-	})
-
-	t.Run("all instances see changes", func(t *testing.T) {
-		limiter1 := limiter.SearchQueryRate()
-		limiter2 := limiter.SearchQueryRate()
-		limiter1.SetLimit(99)
-		assert.Equal(t, limiter1.Limit(), limiter2.Limit(), 99)
 	})
 
 }


### PR DESCRIPTION
Other tests confirms the limiter is a singleton so this is not needed, SetLimit is time based and caused the flake.
## Test plan
tests pass
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
