### PR TITLE
Add format:changed command

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "format": "prettier '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --write --list-different --config prettier.config.js",
+    "format:changed": "prettier $(git diff --diff-filter=d --name-only origin/main... | grep -E '\\.(js|json|ts|tsx|graphql|md|scss)$' | xargs) --write --list-different --config prettier.config.js",
     "format:check": "yarn run format --write=false --check --list-different=false --loglevel=warn",
     "_lint:js": "DOCSITE_LIST=\"$(./dev/docsite.sh -config doc/docsite.json ls)\" NODE_OPTIONS=\"--max_old_space_size=16192\" eslint",
     "lint:js:changed": "yarn _lint:js $(git diff --diff-filter=d --name-only origin/main... | grep -E '\\.[tj]sx?$' | xargs)",


### PR DESCRIPTION
Since we've gotten our prettier check in our PR flow, this might be useful to run prettier only on changed files (all files check seems to take quite some time at the moment)

Note: Unfortunately this diff check works only with committed changes, ideally it would be nice if we could compare staged files and committed files together. (so you don't need to commit changes in order to format them later)

## Test plan
N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
