### PR TITLE
Reload the reference list when codeIntel.mixPreciseAndSearchBasedReferences is changed

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -228,6 +228,8 @@ const SearchTokenFindingReferencesList: React.FunctionComponent<
 
     return (
         <ReferencesList
+            // Force the references list to recreate when the user settings
+            // change. This way we avoid showing stale results.
             key={shouldMixPreciseAndSearchBasedReferences.toString()}
             {...props}
             token={props.token}

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -213,6 +213,10 @@ const SearchTokenFindingReferencesList: React.FunctionComponent<
         blockCommentStyles: spec.commentStyles.map(style => style.block).filter(isDefined),
         identCharPattern: spec.identCharPattern,
     })
+    const shouldMixPreciseAndSearchBasedReferences: boolean = newSettingsGetter(props.settingsCascade)<boolean>(
+        'codeIntel.mixPreciseAndSearchBasedReferences',
+        false
+    )
 
     if (!tokenResult?.searchToken) {
         return (
@@ -224,6 +228,7 @@ const SearchTokenFindingReferencesList: React.FunctionComponent<
 
     return (
         <ReferencesList
+            key={shouldMixPreciseAndSearchBasedReferences.toString()}
             {...props}
             token={props.token}
             searchToken={tokenResult?.searchToken}

--- a/client/web/src/enterprise/codeintel/useCodeIntel.ts
+++ b/client/web/src/enterprise/codeintel/useCodeIntel.ts
@@ -134,7 +134,6 @@ export const useCodeIntel = ({
         variables,
         notifyOnNetworkStatusChange: false,
         fetchPolicy: 'no-cache',
-        skip: !shouldFetchPrecise,
         onCompleted: result => {
             if (shouldFetchPrecise.current) {
                 shouldFetchPrecise.current = false


### PR DESCRIPTION
Firstly, I have no idea how this worked before. 😅 I assume that there was also some unexpected remounting of the references panel happening because if you look at the [useCodeIntel](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@ps/fix-ref-panel-reload-on-mode-change/-/blob/client/web/src/enterprise/codeintel/useCodeIntel.ts?L33) implementation, the search-based results get mixed with the other results and there's no logic to re-trigger a search or anything.

Since there's quite a bit of logic already involved in `useCodeIntel` and the chances for causing a regression is pretty high, I decided to go a different route: Instead of imperatively managing the state and making sure all queries are updated, I make use of the fact that a different `key` in React will always force a remount.

By adding a key to the  `ReferencesList` based on the `shouldMixPreciseAndSearchBasedReferences` value, I force-recreate the whole React tree which in-turn will reload the references list. This way, we can be 100% certain that no stale references of data is shown when this config option changes.

## Test plan

Tested it locally:

https://user-images.githubusercontent.com/458591/200346050-e99ea754-7aab-44d9-bbc3-3f9dc3850a12.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-ref-panel-reload-on-mode.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
