### PR TITLE
rename batches-specific webhooks for clarity

### DIFF
--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -17,9 +17,9 @@ import (
 // Services is a bag of HTTP handlers and factory functions that are registered by the
 // enterprise frontend setup hook.
 type Services struct {
-	GitHubWebhook                   webhooks.Registerer
 	GitHubSyncWebhook               webhooks.Registerer
-	GitLabWebhook                   webhooks.RegistererHandler
+	GitHubBatchesWebhook            webhooks.Registerer
+	GitLabBatchesWebhook            webhooks.RegistererHandler
 	BitbucketServerWebhook          http.Handler
 	BitbucketCloudWebhook           http.Handler
 	BatchesChangesFileGetHandler    http.Handler
@@ -62,8 +62,8 @@ type NewComputeStreamHandler func() http.Handler
 // DefaultServices creates a new Services value that has default implementations for all services.
 func DefaultServices() Services {
 	return Services{
-		GitHubWebhook:                   &emptyWebhookHandler{name: "github webhook"},
-		GitLabWebhook:                   &emptyWebhookHandler{name: "gitlab webhook"},
+		GitHubBatchesWebhook:            &emptyWebhookHandler{name: "github batches webhook"},
+		GitLabBatchesWebhook:            &emptyWebhookHandler{name: "gitlab batches webhook"},
 		GitHubSyncWebhook:               &emptyWebhookHandler{name: "github sync webhook"},
 		BitbucketServerWebhook:          makeNotFoundHandler("bitbucket server webhook"),
 		BitbucketCloudWebhook:           makeNotFoundHandler("bitbucket cloud webhook"),

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -340,8 +340,8 @@ func makeExternalAPI(db database.DB, schema *graphql.Schema, enterprise enterpri
 		schema,
 		rateLimiter,
 		&httpapi.Handlers{
-			GitHubWebhook:                   enterprise.GitHubWebhook,
-			GitLabWebhook:                   enterprise.GitLabWebhook,
+			GitHubBatchesWebhook:            enterprise.GitHubBatchesWebhook,
+			GitLabBatchesWebhook:            enterprise.GitLabBatchesWebhook,
 			GitHubSyncWebhook:               enterprise.GitHubSyncWebhook,
 			BitbucketServerWebhook:          enterprise.BitbucketServerWebhook,
 			BitbucketCloudWebhook:           enterprise.BitbucketCloudWebhook,

--- a/cmd/frontend/internal/httpapi/api_test.go
+++ b/cmd/frontend/internal/httpapi/api_test.go
@@ -33,8 +33,8 @@ func newTest(t *testing.T) *httptestutil.Client {
 		nil,
 		rateLimiter,
 		&Handlers{
-			GitHubWebhook:             enterpriseServices.GitHubWebhook,
-			GitLabWebhook:             enterpriseServices.GitLabWebhook,
+			GitHubBatchesWebhook:      enterpriseServices.GitHubBatchesWebhook,
+			GitLabBatchesWebhook:      enterpriseServices.GitLabBatchesWebhook,
 			GitHubSyncWebhook:         enterpriseServices.GitHubSyncWebhook,
 			BitbucketServerWebhook:    enterpriseServices.BitbucketServerWebhook,
 			BitbucketCloudWebhook:     enterpriseServices.BitbucketCloudWebhook,

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -40,9 +40,9 @@ import (
 )
 
 type Handlers struct {
-	GitHubWebhook                   webhooks.Registerer
 	GitHubSyncWebhook               webhooks.Registerer
-	GitLabWebhook                   webhooks.RegistererHandler
+	GitHubBatchesWebhook            webhooks.Registerer
+	GitLabBatchesWebhook            webhooks.RegistererHandler
 	BitbucketServerWebhook          http.Handler
 	BitbucketCloudWebhook           http.Handler
 	BatchesChangesFileGetHandler    http.Handler
@@ -92,8 +92,8 @@ func NewHandler(
 		DB: db,
 	}
 	webhookhandlers.Init(db, &wh)
-	handlers.GitHubWebhook.Register(&wh)
-	handlers.GitLabWebhook.Register(&wh)
+	handlers.GitHubBatchesWebhook.Register(&wh)
+	handlers.GitLabBatchesWebhook.Register(&wh)
 	handlers.GitHubSyncWebhook.Register(&wh)
 
 	// 🚨 SECURITY: This handler implements its own secret-based auth
@@ -104,7 +104,7 @@ func NewHandler(
 
 	m.Get(apirouter.Webhooks).Handler(trace.Route(webhookMiddleware.Logger(webhookHandler)))
 	m.Get(apirouter.GitHubWebhooks).Handler(trace.Route(webhookMiddleware.Logger(&gitHubWebhook)))
-	m.Get(apirouter.GitLabWebhooks).Handler(trace.Route(webhookMiddleware.Logger(handlers.GitLabWebhook)))
+	m.Get(apirouter.GitLabWebhooks).Handler(trace.Route(webhookMiddleware.Logger(handlers.GitLabBatchesWebhook)))
 	m.Get(apirouter.BitbucketServerWebhooks).Handler(trace.Route(webhookMiddleware.Logger(handlers.BitbucketServerWebhook)))
 	m.Get(apirouter.BitbucketCloudWebhooks).Handler(trace.Route(webhookMiddleware.Logger(handlers.BitbucketCloudWebhook)))
 	m.Get(apirouter.BatchesFileGet).Handler(trace.Route(handlers.BatchesChangesFileGetHandler))

--- a/enterprise/cmd/frontend/internal/batches/init.go
+++ b/enterprise/cmd/frontend/internal/batches/init.go
@@ -44,10 +44,10 @@ func Init(
 	// Register enterprise services.
 	gitserverClient := gitserver.NewClient(db)
 	enterpriseServices.BatchChangesResolver = resolvers.New(bstore, gitserverClient)
-	enterpriseServices.GitHubWebhook = webhooks.NewGitHubWebhook(bstore, gitserverClient)
+	enterpriseServices.GitHubBatchesWebhook = webhooks.NewGitHubWebhook(bstore, gitserverClient)
 	enterpriseServices.BitbucketServerWebhook = webhooks.NewBitbucketServerWebhook(bstore, gitserverClient)
 	enterpriseServices.BitbucketCloudWebhook = webhooks.NewBitbucketCloudWebhook(bstore, gitserverClient)
-	enterpriseServices.GitLabWebhook = webhooks.NewGitLabWebhook(bstore, gitserverClient)
+	enterpriseServices.GitLabBatchesWebhook = webhooks.NewGitLabWebhook(bstore, gitserverClient)
 
 	operations := httpapi.NewOperations(observationContext)
 	fileHandler := httpapi.NewFileHandler(db, bstore, operations)


### PR DESCRIPTION
Context: I found it confusing that these are generically named as Github/Gitlab Webhooks, when they are particular to batch changes and initialized within the batch changes-specific enterprise package. Hopefully this will clear it up a bit. Open to other ideas/suggestions of course :) 
## Test plan
existing unit tests pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
