### PR TITLE
ranking: Merge by repository name to reduce number of fragmented updates

### DIFF
--- a/internal/codeintel/ranking/internal/store/store.go
+++ b/internal/codeintel/ranking/internal/store/store.go
@@ -253,7 +253,7 @@ locked_candidates AS (
 		pr.payload
 	FROM codeintel_path_rank_inputs pr
 	WHERE pr.graph_key = %s AND NOT pr.processed
-	ORDER BY pr.id
+	ORDER BY pr.repository_name, pr.id
 	LIMIT %s
 	FOR UPDATE SKIP LOCKED
 ),
@@ -267,8 +267,7 @@ upserted AS (
 	FROM locked_candidates c
 	JOIN repo r ON r.name = c.repository_name
 	GROUP BY r.id, c.precision, c.graph_key
-	ON CONFLICT (repository_id, precision) DO UPDATE SET payload =
-	 CASE
+	ON CONFLICT (repository_id, precision) DO UPDATE SET payload = CASE
 		WHEN pr.graph_key != EXCLUDED.graph_key
 			THEN EXCLUDED.payload
 		ELSE

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -6984,6 +6984,16 @@
           "IndexDefinition": "CREATE INDEX codeintel_path_rank_graph_key_id_repository_name_processed ON codeintel_path_rank_inputs USING btree (graph_key, id, repository_name) WHERE NOT processed",
           "ConstraintType": "",
           "ConstraintDefinition": ""
+        },
+        {
+          "Name": "codeintel_path_rank_inputs_graph_key_repository_name_id_process",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX codeintel_path_rank_inputs_graph_key_repository_name_id_process ON codeintel_path_rank_inputs USING btree (graph_key, repository_name, id) WHERE NOT processed",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": null,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -896,6 +896,7 @@ Indexes:
     "codeintel_path_rank_inputs_pkey" PRIMARY KEY, btree (id)
     "codeintel_path_rank_inputs_graph_key_input_filename_reposit_key" UNIQUE CONSTRAINT, btree (graph_key, input_filename, repository_name)
     "codeintel_path_rank_graph_key_id_repository_name_processed" btree (graph_key, id, repository_name) WHERE NOT processed
+    "codeintel_path_rank_inputs_graph_key_repository_name_id_process" btree (graph_key, repository_name, id) WHERE NOT processed
 
 ```
 

--- a/migrations/frontend/1667848448_flip_index_field_order/down.sql
+++ b/migrations/frontend/1667848448_flip_index_field_order/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS codeintel_path_rank_inputs_graph_key_repository_name_id_processed;

--- a/migrations/frontend/1667848448_flip_index_field_order/metadata.yaml
+++ b/migrations/frontend/1667848448_flip_index_field_order/metadata.yaml
@@ -1,0 +1,2 @@
+name: Flip index field order
+parents: [1667433265, 1667497565, 1667500111]

--- a/migrations/frontend/1667848448_flip_index_field_order/up.sql
+++ b/migrations/frontend/1667848448_flip_index_field_order/up.sql
@@ -1,0 +1,4 @@
+-- Effectively replaces codeintel_path_rank_graph_key_id_repository_name_processed
+CREATE INDEX IF NOT EXISTS codeintel_path_rank_inputs_graph_key_repository_name_id_processed ON codeintel_path_rank_inputs(graph_key, repository_name, id)
+WHERE
+    NOT processed;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -4342,6 +4342,8 @@ CREATE UNIQUE INDEX codeintel_lockfiles_repository_id_commit_bytea_lockfile ON c
 
 CREATE INDEX codeintel_path_rank_graph_key_id_repository_name_processed ON codeintel_path_rank_inputs USING btree (graph_key, id, repository_name) WHERE (NOT processed);
 
+CREATE INDEX codeintel_path_rank_inputs_graph_key_repository_name_id_process ON codeintel_path_rank_inputs USING btree (graph_key, repository_name, id) WHERE (NOT processed);
+
 CREATE UNIQUE INDEX codeintel_path_ranks_repository_id_precision ON codeintel_path_ranks USING btree (repository_id, "precision");
 
 CREATE INDEX codeintel_path_ranks_updated_at ON codeintel_path_ranks USING btree (updated_at) INCLUDE (repository_id);


### PR DESCRIPTION
Theory: We refresh path ranks too frequently once we change the graph key to ingest a new PageRank result. If we instead group by `repository_name` (opposed to the serial id), we'll have fewer updates of the same repository, causing fewer update requests from Zoekt.

## Test plan

Will see how this affects dotcom.