### PR TITLE
ranking: Fix last-write-wins on rank merging

### DIFF
--- a/internal/codeintel/ranking/internal/store/store.go
+++ b/internal/codeintel/ranking/internal/store/store.go
@@ -267,12 +267,14 @@ upserted AS (
 	FROM locked_candidates c
 	JOIN repo r ON r.name = c.repository_name
 	GROUP BY r.id, c.precision, c.graph_key
-	ON CONFLICT (repository_id, precision) DO UPDATE SET payload = CASE
-		WHEN pr.graph_key != EXCLUDED.graph_key
-			THEN EXCLUDED.payload
-		ELSE
-			pr.payload || EXCLUDED.payload
-	END
+	ON CONFLICT (repository_id, precision) DO UPDATE SET
+		graph_key = EXCLUDED.graph_key,
+		payload   = CASE
+			WHEN pr.graph_key != EXCLUDED.graph_key
+				THEN EXCLUDED.payload
+			ELSE
+				pr.payload || EXCLUDED.payload
+		END
 	RETURNING 1
 ),
 processed AS (


### PR DESCRIPTION
This PR fixes an issue that doesn't update the graph_key on conflict. This makes it so that every merge operation overwrites the previous data instead of merging. We only want this on conflicting graph_keys, but we enter a situation where they will never align after the first change.

## Test plan

Prayer.