### PR TITLE
Wildcard [Charts]: Add Y/X labels for line chart data points

### DIFF
--- a/client/web/src/integration/insights/insight/insight-chart-focus.test.ts
+++ b/client/web/src/integration/insights/insight/insight-chart-focus.test.ts
@@ -75,7 +75,7 @@ describe('Code insights [Insight Card] should has a proper focus management ', (
                     await hasFocus(
                         driver,
                         `[aria-label="Line chart"] [role="listitem"]:nth-child(${lineIndex + 1}) a:nth-child(${
-                            pointIndex + 2
+                            pointIndex + 1
                         })`
                     ),
                     true,

--- a/client/wildcard/src/components/Charts/components/line-chart/LineChart.test.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/LineChart.test.tsx
@@ -5,8 +5,6 @@ import { assert, stub } from 'sinon'
 import { LineChart } from './LineChart'
 import { FLAT_SERIES } from './story/mocks'
 
-const totalSeries = FLAT_SERIES.length
-const totalDataPoints = FLAT_SERIES.reduce((acc, series) => acc + series.data.length, 0)
 const defaultArgs: RenderChartArgs = { series: FLAT_SERIES }
 
 interface RenderChartArgs {
@@ -26,13 +24,20 @@ describe('LineChart', () => {
             renderChart(defaultArgs)
 
             // Query chart series list
-            const element = screen.getByLabelText('Chart series')
+            const series = screen.getByLabelText('Chart series')
 
-            // Check number of series rendered
-            expect(within(element).getAllByRole('listitem')).toHaveLength(totalSeries)
+            // Check that series were rendered
+            const series1 = within(series).getByLabelText('A metric')
+            const series2 = within(series).getByLabelText('C metric')
+            const series3 = within(series).getByLabelText('B metric')
+            expect(series1)
+            expect(series2)
+            expect(series3)
 
             // Check number of data points rendered
-            expect(screen.getAllByRole(/(link|graphics-dataunit)/)).toHaveLength(totalDataPoints)
+            expect(within(series1).getAllByRole('listitem')).toHaveLength(FLAT_SERIES[0].data.length)
+            expect(within(series2).getAllByRole('listitem')).toHaveLength(FLAT_SERIES[1].data.length)
+            expect(within(series3).getAllByRole('listitem')).toHaveLength(FLAT_SERIES[2].data.length)
 
             // Spot check y axis labels
             expect(screen.getByLabelText(/axis tick, value: 8/i)).toBeInTheDocument()
@@ -52,9 +57,9 @@ describe('LineChart', () => {
 
             renderChart(defaultArgs)
 
-            const [firstPoint, secondPoint, thirdPoint] = screen.getAllByRole('link', {
-                name: 'Click to view data point detail',
-            })
+            // Query chart series list
+            const series = screen.getByLabelText('Chart series')
+            const [firstPoint, secondPoint, thirdPoint] = within(series).getAllByRole('listitem')
 
             // Spot checking multiple points
             // related issue https://github.com/sourcegraph/sourcegraph/issues/38304

--- a/client/wildcard/src/components/Charts/components/line-chart/components/LineDataSeries.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/components/LineDataSeries.tsx
@@ -17,7 +17,7 @@ const NULL_LINK = (): undefined => undefined
  *
  * Example: 2021 January 21 Thursday
  */
-export const formatXLabel = timeFormat('%d %B %A')
+const formatXLabel = timeFormat('%d %B %A')
 
 interface LineDataSeriesProps<D> extends SVGProps<SVGGElement> {
     id: string

--- a/client/wildcard/src/components/Charts/components/line-chart/components/LineDataSeries.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/components/LineDataSeries.tsx
@@ -3,6 +3,7 @@ import { ReactElement, SVGProps } from 'react'
 import { Group } from '@visx/group'
 import { LinePath } from '@visx/shape'
 import { ScaleLinear, ScaleTime } from 'd3-scale'
+import { timeFormat } from 'd3-time-format'
 
 import { Point } from '../types'
 import { getDatumValue, isDatumWithValidNumber, SeriesDatum } from '../utils'
@@ -10,6 +11,13 @@ import { getDatumValue, isDatumWithValidNumber, SeriesDatum } from '../utils'
 import { PointGlyph } from './PointGlyph'
 
 const NULL_LINK = (): undefined => undefined
+
+/**
+ * Returns a formatted date text for points aria labels.
+ *
+ * Example: 2021 January 21 Thursday
+ */
+export const formatXLabel = timeFormat('%d %B %A')
 
 interface LineDataSeriesProps<D> extends SVGProps<SVGGElement> {
     id: string
@@ -19,7 +27,6 @@ interface LineDataSeriesProps<D> extends SVGProps<SVGGElement> {
     color: string | undefined
     activePointId?: string
     getLinkURL?: (datum: D, index: number) => string | undefined
-
     onDatumClick: () => void
     onDatumFocus: (point: Point) => void
 }
@@ -51,34 +58,42 @@ export function LineDataSeries<D>(props: LineDataSeriesProps<D>): ReactElement {
                 strokeWidth={2}
             />
 
-            {dataset.map((datum, index) => {
-                const datumValue = getDatumValue(datum)
-                const link = getLinkURL(datum.datum, index)
-                const pointId = `${id}-${index}`
+            <Group role="list">
+                {dataset.map((datum, index) => {
+                    const datumValue = getDatumValue(datum)
+                    const link = getLinkURL(datum.datum, index)
+                    const pointId = `${id}-${index}`
+                    const formattedDate = formatXLabel(datum.x)
+                    const ariaLabel = link
+                        ? `Link point, Y value: ${datumValue}, X value: ${formattedDate}, click to view data point detail`
+                        : `Data point, Y value: ${datumValue}, X value: ${formattedDate}`
 
-                return (
-                    <PointGlyph
-                        key={pointId}
-                        tabIndex={tabIndex}
-                        top={yScale(datumValue)}
-                        left={xScale(datum.x)}
-                        active={activePointId === pointId}
-                        color={color}
-                        linkURL={link}
-                        onClick={onDatumClick}
-                        onFocus={event =>
-                            onDatumFocus({
-                                id: pointId,
-                                xValue: datum.x,
-                                yValue: datumValue,
-                                seriesId: id,
-                                linkUrl: link,
-                                node: event.target,
-                            })
-                        }
-                    />
-                )
-            })}
+                    return (
+                        <PointGlyph
+                            key={pointId}
+                            tabIndex={tabIndex}
+                            top={yScale(datumValue)}
+                            left={xScale(datum.x)}
+                            active={activePointId === pointId}
+                            color={color}
+                            linkURL={link}
+                            role="listitem"
+                            aria-label={ariaLabel}
+                            onClick={onDatumClick}
+                            onFocus={event =>
+                                onDatumFocus({
+                                    id: pointId,
+                                    xValue: datum.x,
+                                    yValue: datumValue,
+                                    seriesId: id,
+                                    linkUrl: link,
+                                    node: event.target,
+                                })
+                            }
+                        />
+                    )
+                })}
+            </Group>
         </Group>
     )
 }

--- a/client/wildcard/src/components/Charts/components/line-chart/components/PointGlyph.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/components/PointGlyph.tsx
@@ -1,4 +1,4 @@
-import React, { FocusEventHandler, MouseEventHandler } from 'react'
+import { FC, FocusEventHandler, MouseEventHandler } from 'react'
 
 import { GlyphDot } from '@visx/glyph'
 
@@ -9,6 +9,8 @@ interface PointGlyphProps {
     left: number
     color: string
     active: boolean
+    role: string
+    'aria-label': string
     linkURL?: string
     tabIndex?: number
     onClick: MouseEventHandler<Element>
@@ -16,31 +18,42 @@ interface PointGlyphProps {
     onBlur?: FocusEventHandler<Element>
 }
 
-export const PointGlyph: React.FunctionComponent<React.PropsWithChildren<PointGlyphProps>> = props => {
-    const { top, left, color, active, linkURL, tabIndex = 0, onFocus, onBlur, onClick } = props
+export const PointGlyph: FC<PointGlyphProps> = props => {
+    const {
+        top,
+        left,
+        color,
+        active,
+        role,
+        'aria-label': ariaLabel,
+        linkURL,
+        tabIndex = 0,
+        onFocus,
+        onBlur,
+        onClick,
+    } = props
 
     return (
         <MaybeLink
             to={linkURL}
             target="_blank"
             rel="noopener"
+            tabIndex={tabIndex}
+            role={role}
+            aria-label={ariaLabel}
             onClick={onClick}
             onFocus={onFocus}
             onBlur={onBlur}
-            tabIndex={tabIndex}
-            role={linkURL ? 'link' : 'graphics-dataunit'}
-            aria-label={linkURL ? 'Click to view data point detail' : 'Data point'}
         >
             <GlyphDot
-                tabIndex={linkURL ? -1 : tabIndex}
-                onFocus={onFocus}
-                onBlur={onBlur}
                 cx={left}
                 cy={top}
-                stroke={color}
-                fill="var(--body-bg)"
-                strokeWidth={active ? 3 : 2}
                 r={active ? 6 : 4}
+                fill="var(--body-bg)"
+                stroke={color}
+                strokeWidth={active ? 3 : 2}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </MaybeLink>
     )

--- a/client/wildcard/src/components/Charts/core/components/MaybeLink.tsx
+++ b/client/wildcard/src/components/Charts/core/components/MaybeLink.tsx
@@ -1,22 +1,18 @@
-import React from 'react'
+import { FC, AnchorHTMLAttributes, HTMLAttributes } from 'react'
 
 import { Link } from '../../../Link'
 
-interface MaybeLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+interface MaybeLinkProps extends AnchorHTMLAttributes<HTMLElement> {
     to?: string | void | null
 }
 
 /** Wraps the children in a link if to (link href) prop is passed. */
-export const MaybeLink: React.FunctionComponent<React.PropsWithChildren<MaybeLinkProps>> = ({
-    children,
-    to,
-    role,
-    ...props
-}) =>
-    to ? (
-        <Link {...props} to={to} role={role}>
-            {children}
-        </Link>
+export const MaybeLink: FC<MaybeLinkProps> = props => {
+    const { to, target, rel, ...attributes } = props
+
+    return to ? (
+        <Link {...attributes} to={to} target={target} rel={rel} />
     ) : (
-        <g role={role}>{children}</g>
+        <g {...(attributes as HTMLAttributes<SVGGElement>)} />
     )
+}

--- a/client/wildcard/src/components/Charts/core/components/axis/tick-formatters.ts
+++ b/client/wildcard/src/components/Charts/core/components/axis/tick-formatters.ts
@@ -22,13 +22,6 @@ export function formatYTick(number: number): string {
  */
 export const formatDateTick = timeFormat('%d %b')
 
-/**
- * Returns a formatted date text for points aria labels.
- *
- * Example: 2021 January 21 Thursday
- */
-export const formatXLabel = timeFormat('%d %B %A')
-
 const MINIMUM_NUMBER_OF_TICKS = 2
 
 export interface GetScaleTicksOptions {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/41688

## Background
This PR adds announcements for the data points on the line chart with Y/X information, also there are two different types of labels 
- Links, it pronounces that this is a link, and you can click it to see more details and Y/X values
- Common data point announces X/Y values only.  

I recorded [a quick loom](https://www.loom.com/share/bde1e64cc73d4843a9cb0005cbcb14fa) with these label demonstrations with a screen reader.

## Test plan
- Open any view with the line chart (you can run `yarn storybook:wildcard` and go to the line chart demo)
- Turn on your screen reader (I tested it with VoiceOver) 
- Reach data points series with a screen reader 
- It should announce that the series is a list 
- Pick any series it should announce that the series (line) itself is a list 
- When you navigate to the link data, it should say that this is a link and its Y/X values
- When you navigate to the common data point, it should say that this is a data point and announce its Y/X values

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-line-chart-screen-reader.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
