### PR TITLE
Add Code Exploration team label workflows

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -14,7 +14,6 @@ jobs:
              edit_body: true
              message: /cc {recipients}
              recipients: |
-                  team/integrations=@sourcegraph/integrations
                   team/growth=@sourcegraph/growth
                   team/cloud=@sourcegraph/cloud
                   team/search-product=@sourcegraph/search-product
@@ -23,7 +22,7 @@ jobs:
                   team/delivery=@sourcegraph/delivery
                   team/security=@dcomas
                   team/dev-experience=@jhchabran @kstretch9
-                  team/frontend-platform=@sourcegraph/frontend-platform
                   team/repo-management=@jplahn @ryphil
                   team/devops=@sourcegraph/cloud-devops
                   team/iam=@sourcegraph/iam
+                  team/code-exploration=@felixfbecker

--- a/.github/workflows/move-labled-issues-to-project.yml
+++ b/.github/workflows/move-labled-issues-to-project.yml
@@ -1,4 +1,4 @@
-name: Move labled issues to Project (Beta)
+name: Move labled issues to Project
 
 on:
   issues:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   add-to-project-beta:
-    name: Add issue to project (beta)
+    name: Add issue to project
     runs-on: ubuntu-latest
     steps:
       - name: Move team/devops or team/cloud issues
@@ -19,7 +19,7 @@ jobs:
           github-token: ${{ secrets.GH_PROJECTS_ACTION_TOKEN }}
           labeled: team/cloud
           label-operator: OR
-          
+
       - name: Move team/repo-management issues
         uses: actions/add-to-project@main
         with:
@@ -27,7 +27,15 @@ jobs:
           github-token: ${{ secrets.GH_PROJECTS_ACTION_TOKEN }}
           labeled: team/repo-management
           label-operator: OR
-          
+
+      - name: Move team/code-exploration issues
+        uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/sourcegraph/projects/297
+          github-token: ${{ secrets.GH_PROJECTS_ACTION_TOKEN }}
+          labeled: team/code-exploration
+          label-operator: OR
+
       - name: Move design issues
         uses: actions/add-to-project@main
         with:
@@ -35,7 +43,7 @@ jobs:
           github-token: ${{ secrets.GH_PROJECTS_ACTION_TOKEN }}
           labeled: design, needs-design
           label-operator: OR
-          
+
 #       - name: Move team/CHANGEME issues
 #         uses: actions/add-to-project@main
 #         with:


### PR DESCRIPTION
Adds team/code-exploration issues to our project board and sets up label notifications.
How we use the board is tbd, but want to start collecting issues.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Not required: Automation-only change
