### PR TITLE
client: conditionally set X-Sourcegraph-Should-Trace

### DIFF
--- a/client/web/src/backend/graphql.ts
+++ b/client/web/src/backend/graphql.ts
@@ -4,12 +4,19 @@ import { Observable } from 'rxjs'
 import { getGraphQLClient, GraphQLResult, requestGraphQLCommon } from '@sourcegraph/http-client'
 import * as GQL from '@sourcegraph/shared/src/schema'
 
-const getHeaders = (): { [header: string]: string } => ({
-    ...window?.context?.xhrHeaders,
-    Accept: 'application/json',
-    'Content-Type': 'application/json',
-    'X-Sourcegraph-Should-Trace': new URLSearchParams(window.location.search).get('trace') || 'false',
-})
+const getHeaders = (): { [header: string]: string } => {
+    const headers: { [header: string]: string } = {
+        ...window?.context?.xhrHeaders,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+    }
+    const parameters = new URLSearchParams(window.location.search)
+    const trace = parameters.get('trace')
+    if (trace) {
+        headers['X-Sourcegraph-Should-Trace'] = trace
+    }
+    return headers
+}
 
 /**
  * Does a GraphQL request to the Sourcegraph GraphQL API running under `/.api/graphql`


### PR DESCRIPTION
Currently we always set X-Sourcegraph-Should-Trace. However, based on how the backend works, we should only be setting this if the trace parameter has been specified by the user.

Note: in other places we set this header we only set when it is specified. So only graphql had this behaviour.

Note: I pulled out the parameter construction so it can be reused. This will be used in an upcoming commit for "feat".

Alternative to https://github.com/sourcegraph/sourcegraph/pull/44006

Test Plan: main dry run to ensure we don't break E2E tests
