### PR TITLE
client: set feature override header for graphql

### DIFF
--- a/client/web/src/backend/graphql.ts
+++ b/client/web/src/backend/graphql.ts
@@ -15,6 +15,10 @@ const getHeaders = (): { [header: string]: string } => {
     if (trace) {
         headers['X-Sourcegraph-Should-Trace'] = trace
     }
+    const feat = parameters.getAll('feat')
+    if (feat) {
+        headers['X-Sourcegraph-Override-Feature'] = feat.join(',')
+    }
     return headers
 }
 

--- a/client/web/src/backend/graphql.ts
+++ b/client/web/src/backend/graphql.ts
@@ -16,7 +16,7 @@ const getHeaders = (): { [header: string]: string } => {
         headers['X-Sourcegraph-Should-Trace'] = trace
     }
     const feat = parameters.getAll('feat')
-    if (feat) {
+    if (feat.length) {
         headers['X-Sourcegraph-Override-Feature'] = feat.join(',')
     }
     return headers


### PR DESCRIPTION
We already set this header in other API calls, but not yet for GraphQL calls. Multiple feature flag overrides can be specified, so we join them according to the Header spec, which is to join by comma.

Test Plan: add feature flag logging to a graphql endpoint. Visit a page in my devserver with multiple feature flags "?feat=hello&feat=world". Then ensured the logging showed flags being set.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/44061