### PR TITLE
dx: create a cli similar to sg (playground for DX)

### DIFF
--- a/dev/dx/main.go
+++ b/dev/dx/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/lib/output"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	BuildCommit = "dev"
+	stdOut      *output.Output
+)
+
+func main() {
+	if err := dx.RunContext(context.Background(), os.Args); err != nil {
+		// We want to prefer an already-initialized std.Out no matter what happens,
+		// because that can be configured (e.g. with '--disable-output-detection'). Only
+		// if something went horribly wrong and std.Out is not yet initialized should we
+		// attempt an initialization here.
+		if stdOut == nil {
+			stdOut = output.NewOutput(os.Stdout, output.OutputOpts{})
+		}
+		// Do not treat error message as a format string
+		log.Fatal(err)
+	}
+}
+
+var dx = &cli.App{
+	Usage:       "The internal CLI used by the DevX team",
+	Description: "TODO",
+	Version:     BuildCommit,
+	Compiled:    time.Now(),
+	Commands:    []*cli.Command{scaletestingCommand},
+}
+
+var scaletestingCommand = &cli.Command{
+	Name:      "scaletesting",
+	Aliases:   []string{"sct"},
+	UsageText: "TODO",
+	Subcommands: []*cli.Command{
+		{
+			Name:        "dev",
+			Description: "TODO",
+			Subcommands: []*cli.Command{
+				// TODO: add a command to shutdown the machine and one to turn it on.
+				{
+					Name:        "ssh",
+					Description: "SSH to the devbox",
+					Action: func(cmd *cli.Context) error {
+						args := []string{
+							"-c",
+							`gcloud compute ssh --zone "us-central1-a" "devx" --project "sourcegraph-scaletesting" --tunnel-through-iap`,
+						}
+
+						c := exec.CommandContext(cmd.Context, os.Getenv("SHELL"), args...)
+						c.Stdin = os.Stdin
+						c.Stdout = os.Stdout
+						c.Stderr = os.Stderr
+
+						if err := c.Run(); err != nil {
+							return err
+						}
+						return nil
+					},
+				},
+			},
+		},
+	},
+}


### PR DESCRIPTION
Creates an additional command, `dx` which the DevX team uses as a playground to script and add commands without having to think too much about design and can host crude hacks before merging those in `sg`.

Right now, it only supports `dx sct dev ssh` which ssh you into our devxbox that we use to run long-lived scripts (typically to generate 200k repos for example). 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally. As long as you have the `gcloud` cli and the proper credentials, it works. 