### PR TITLE
featureflag: allow specify multiple overrides in single param

### DIFF
--- a/internal/featureflag/override.go
+++ b/internal/featureflag/override.go
@@ -27,6 +27,11 @@ func requestOverrides(r *http.Request) (flags map[string]bool, ok bool) {
 		return nil, false
 	}
 
+	// We use this to make it convenient to specify multiple feature flag
+	// overrides in many different ways. eg a user doesn't have to do multiple
+	// &feat= query params, instead they could separate by space and comma.
+	values = flatMapValues(values)
+
 	flags = make(map[string]bool, len(values))
 	for _, k := range values {
 		// flags starting with "-" override to false
@@ -75,4 +80,16 @@ func (s *overrideStore) override(flags map[string]bool, err error) (map[string]b
 	}
 
 	return override, nil
+}
+
+// flatMapValues splits each string in vs by space and commas, then returns
+// the flattened result.
+func flatMapValues(vs []string) []string {
+	var flattened []string
+	for _, v := range vs {
+		flattened = append(flattened, strings.FieldsFunc(v, func(r rune) bool {
+			return r == ' ' || r == ','
+		})...)
+	}
+	return flattened
 }

--- a/internal/featureflag/override_test.go
+++ b/internal/featureflag/override_test.go
@@ -114,6 +114,26 @@ func TestOverrides(t *testing.T) {
 			"feat-false": false,
 			"header":     true,
 		},
+	}, {
+		Name:   "header-flat-map-values",
+		Header: []string{"  feat-false", "-new-false,new-true", " a b,c,  d "},
+		Want: map[string]bool{
+			"feat-true":  true,
+			"feat-false": true,
+			"new-false":  false,
+			"new-true":   true,
+			"a":          true,
+			"b":          true,
+			"c":          true,
+			"d":          true,
+		},
+	}, {
+		Name:     "empty-param",
+		RawQuery: "feat=",
+		Want: map[string]bool{
+			"feat-true":  true,
+			"feat-false": false,
+		},
 	}}
 
 	for _, tc := range cases {


### PR DESCRIPTION
We use this to make it convenient to specify multiple feature flag overrides in many different ways. eg a user doesn't have to do multiple &feat= query params, instead they could separate by space and comma.

Additionally I couldn't find a nice way for the GraphQL client code in our web code send multiple HTTP Headers with the same key. So now they join them by ",".

Test Plan: added tests