### PR TITLE
[SG-44069] Temporary removal of the API Console's Prettify button

### DIFF
--- a/client/web/src/api/ApiConsole.tsx
+++ b/client/web/src/api/ApiConsole.tsx
@@ -168,15 +168,6 @@ export class ApiConsole extends React.PureComponent<Props, State> {
                     <GraphiQL.Logo>GraphQL API console</GraphiQL.Logo>
                     <GraphiQL.Toolbar>
                         <div className="d-flex align-items-center">
-                            {/* TODO: https://github.com/sourcegraph/sourcegraph/issues/44071 */}
-                            {/* <Button
-                                variant="secondary"
-                                title="Prettify Query (Shift-Ctrl-P)"
-                                onClick={this.handlePrettifyQuery}
-                                className={styles.toolbarButton}
-                            >
-                                Prettify
-                            </Button> */}
                             <Button
                                 variant="secondary"
                                 title="Show History"
@@ -227,12 +218,6 @@ export class ApiConsole extends React.PureComponent<Props, State> {
     private setGraphiQLRef = (reference: _graphiqlModule.default | null): void => {
         this.graphiQLRef = reference
     }
-    // private handlePrettifyQuery = (): void => {
-    //     if (!this.graphiQLRef) {
-    //         return
-    //     }
-    //     this.graphiQLRef.handlePrettifyQuery()
-    // }
     private handleToggleHistory = (): void => {
         if (!this.graphiQLRef) {
             return

--- a/client/web/src/api/ApiConsole.tsx
+++ b/client/web/src/api/ApiConsole.tsx
@@ -168,14 +168,15 @@ export class ApiConsole extends React.PureComponent<Props, State> {
                     <GraphiQL.Logo>GraphQL API console</GraphiQL.Logo>
                     <GraphiQL.Toolbar>
                         <div className="d-flex align-items-center">
-                            <Button
+                            {/* TODO: https://github.com/sourcegraph/sourcegraph/issues/44071 */}
+                            {/* <Button
                                 variant="secondary"
                                 title="Prettify Query (Shift-Ctrl-P)"
                                 onClick={this.handlePrettifyQuery}
                                 className={styles.toolbarButton}
                             >
                                 Prettify
-                            </Button>
+                            </Button> */}
                             <Button
                                 variant="secondary"
                                 title="Show History"
@@ -226,12 +227,12 @@ export class ApiConsole extends React.PureComponent<Props, State> {
     private setGraphiQLRef = (reference: _graphiqlModule.default | null): void => {
         this.graphiQLRef = reference
     }
-    private handlePrettifyQuery = (): void => {
-        if (!this.graphiQLRef) {
-            return
-        }
-        this.graphiQLRef.handlePrettifyQuery()
-    }
+    // private handlePrettifyQuery = (): void => {
+    //     if (!this.graphiQLRef) {
+    //         return
+    //     }
+    //     this.graphiQLRef.handlePrettifyQuery()
+    // }
     private handleToggleHistory = (): void => {
         if (!this.graphiQLRef) {
             return


### PR DESCRIPTION
## Description
Temporarily remove the prettify button from API console toolbar.

## Ref
[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/44069)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-44069)

## Test plan
- Visit the api console page.
- Verify that the prettify button is currently unavailable.

## App preview:

- [Web](https://sg-web-contractors-sg-44069.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
