### PR TITLE
Add p4passwd-setter script

### DIFF
--- a/dev/p4passwd-setter/README.md
+++ b/dev/p4passwd-setter/README.md
@@ -1,0 +1,15 @@
+# P4.passwd setter tool
+
+## How to use
+
+1. Install the Sourcegraph CLI tool if you don't have it – [CLI quickstart](https://docs.sourcegraph.com/cli/quickstart)
+2. Set your `SRC_ENDPOINT` environment variable to your Sourcegraph instance URL
+3. On your Sourcegraph web UI, go to `user badge` (top-right) | `Settings` | `Access tokens` and generate a token.
+4. Set your `SRC_ACCESS_TOKEN` environment variable to your access token
+5. On your Sourcegraph web UI, go to `user badge` (top-right) | `Site admin` | `Manage code hosts`, then look for your code host, click `Edit` next to it, and copy its ID from the page URL. It'll look like `RXg0YXJuZWxTZXJ3aWNlOjEzOA==`.
+6. Save the script and make it executable.
+7. Run the script: `./p4passwd-setter.sh "CODE_HOST_ID" "NEW_P4_PASSWORD"`
+
+The password will be updated for the code host and the script will give no output.
+
+If something goes wrong, you'll get an error message.

--- a/dev/p4passwd-setter/README.md
+++ b/dev/p4passwd-setter/README.md
@@ -8,7 +8,7 @@
 4. Set your `SRC_ACCESS_TOKEN` environment variable to your access token
 5. On your Sourcegraph web UI, go to `user badge` (top-right) | `Site admin` | `Manage code hosts`, then look for your code host, click `Edit` next to it, and copy its ID from the page URL. It'll look like `RXg0YXJuZWxTZXJ3aWNlOjEzOA==`.
 6. Save the script and make it executable.
-7. Run the script: `./p4passwd-setter.sh "CODE_HOST_ID" "NEW_P4_PASSWORD"`
+7. Run [the script](p4passwd-setter.sh): `./p4passwd-setter.sh "CODE_HOST_ID" "NEW_P4_PASSWORD"`
 
 The password will be updated for the code host and the script will give no output.
 

--- a/dev/p4passwd-setter/README.md
+++ b/dev/p4passwd-setter/README.md
@@ -2,13 +2,10 @@
 
 ## How to use
 
-1. Install the Sourcegraph CLI tool if you don't have it – [CLI quickstart](https://docs.sourcegraph.com/cli/quickstart)
-2. Set your `SRC_ENDPOINT` environment variable to your Sourcegraph instance URL
-3. On your Sourcegraph web UI, go to `user badge` (top-right) | `Settings` | `Access tokens` and generate a token.
-4. Set your `SRC_ACCESS_TOKEN` environment variable to your access token
-5. On your Sourcegraph web UI, go to `user badge` (top-right) | `Site admin` | `Manage code hosts`, then look for your code host, click `Edit` next to it, and copy its ID from the page URL. It'll look like `RXg0YXJuZWxTZXJ3aWNlOjEzOA==`.
-6. Save the script and make it executable.
-7. Run [the script](p4passwd-setter.sh): `./p4passwd-setter.sh "CODE_HOST_ID" "NEW_P4_PASSWORD"`
+1. Make sure you have the Sourcegraph CLI tool installed and configured – [instructions here](https://sourcegraph.com/github.com/sourcegraph/src-cli@main/-/blob/README.md)
+2. On your Sourcegraph web UI, go to `user badge` (top-right) | `Site admin` | `Manage code hosts`, then look for your code host, click `Edit` next to it, and copy its ID from the page URL. It'll look like `RXg0YXJuZWxTZXJ3aWNlOjEzOA==`.
+3. Save the script and make it executable.
+4. Run [the script](p4passwd-setter.sh): `./p4passwd-setter.sh "CODE_HOST_ID" "NEW_P4_PASSWORD"`
 
 The password will be updated for the code host and the script will give no output.
 

--- a/dev/p4passwd-setter/p4passwd-setter.sh
+++ b/dev/p4passwd-setter/p4passwd-setter.sh
@@ -29,3 +29,5 @@ if [[ $response == *"error"* ]]; then
     echo "Error: $error_message"
     exit 1
 fi
+
+echo "Password for code host updated."

--- a/dev/p4passwd-setter/p4passwd-setter.sh
+++ b/dev/p4passwd-setter/p4passwd-setter.sh
@@ -8,8 +8,9 @@ code_host_id=$1
 password=$2
 
 # Fetch and decode data
-query=("query GetCodeHostInfo{node(id:\"$code_host_id\"){...on ExternalService{config}}}")
-response=$(src api -query "${query[@]}")
+# shellcheck disable=SC2016
+query='query GetCodeHostInfo($id:ID!){node(id:$id){...on ExternalService{config}}}'
+response=$(echo "$query" | src api "id=$code_host_id")
 # If response contains "error", show error message
 if [[ $response == *"error"* ]]; then
     error_message=$(echo "$response" | jq .errors[0].message)

--- a/dev/p4passwd-setter/p4passwd-setter.sh
+++ b/dev/p4passwd-setter/p4passwd-setter.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Print each command before executing it; exit in case of an error
+set -ex
+
 # Name arguments
 code_host_id=$1
 password=$2

--- a/dev/p4passwd-setter/p4passwd-setter.sh
+++ b/dev/p4passwd-setter/p4passwd-setter.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Name arguments
+code_host_id=$1
+password=$2
+
+# Fetch and decode data
+query=("query GetCodeHostInfo{node(id:\"$code_host_id\"){...on ExternalService{config}}}")
+response=$(src api -query "${query[@]}")
+# If response contains "error", show error message
+if [[ $response == *"error"* ]]; then
+    error_message=$(echo "$response" | jq .errors[0].message)
+    echo "Error: $error_message"
+    exit 1
+fi
+
+# Get config
+json=$(echo "$response" | jq .data.node.config)
+
+# Update data
+updatedJson="${json/REDACTED/$password}"
+mutation=("mutation UpdateCodeHostPassword(\$input:UpdateExternalServiceInput!){updateExternalService(input:\$input){id}}")
+mutation_vars=("{\"input\":{\"id\":\"$code_host_id\",\"config\":$updatedJson}}")
+response=$(src api -query "${mutation[@]}" -vars "${mutation_vars[@]}")
+
+# If response contains "error", show error message
+if [[ $response == *"error"* ]]; then
+    error_message=$(echo "$response" | jq .errors[0].message)
+    echo "Error: $error_message"
+    exit 1
+fi


### PR DESCRIPTION
- Fixes https://github.com/sourcegraph/sourcegraph/issues/43125

Does what we discussed:
 - Receives two arguments: a code host ID and a password to set
 - Fetches the current config
 - Replaces the password
 - Sends the updated config
 - Handles errors and sets the exit code appropriately

This is the first Bash script I've ever written! 🎉  and I may not know some conventions/interoperability with other tools/etc, so please do a review with that in mind, @mrnugget

I think we might not merge this; we might as well just send the branch to the user. WDYT @mrnugget?

My suggested next step after a successful code review is to send a link to the docs and the script to the customer.

## Test plan

[50-sec Loom demo](https://www.loom.com/share/c1cc3a05717443b3aced2a4b424f077b) with a cool unintended vintage filter on my video

