### PR TITLE
Bump grafana to 7.5.17

### DIFF
--- a/docker-images/grafana/Dockerfile
+++ b/docker-images/grafana/Dockerfile
@@ -11,8 +11,8 @@ RUN ls '/generated/grafana'
 # when upgrading the Grafana version, please refer to https://docs.sourcegraph.com/dev/background-information/observability/grafana#upgrading-grafana
 # DO NOT UPGRADE to AGPL Grafana without consulting Stephen+legal, Grafana >= 8.0 is AGPLv3 Licensed
 # See https://docs.google.com/document/d/1nSmz1ChL_rBvX8FAKTB-CNzgcff083sUlIpoXEz6FHE/edit#heading=h.69clsrno4211
-FROM grafana/grafana:7.5.15@sha256:8e6fe7907f8e5c5547bee5e3e8be8165144d86ad98581d6d092044aa5f805c39 as production
-LABEL com.sourcegraph.grafana.version=7.5.15
+FROM grafana/grafana:7.5.17@sha256:15abb652aa82eeb9f45589278b34ae6ef0e96f74c389cadde31831eb0b1ce228 as production
+LABEL com.sourcegraph.grafana.version=7.5.17
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"


### PR DESCRIPTION
This updates the bundled Grafana version from 7.5.15 to 7.5.17 that fixed https://github.com/grafana/grafana/issues/54535.
7.5.17 is still [Apache-licensed](https://github.com/grafana/grafana/blob/v7.5.17/LICENSE).
## Test plan

- `./docker-images/grafana/build.sh` passess locally
- also tested locally with `sg run grafana` (7.5.17 works correctly, 7.5.15 has the bug from linked issue)