### PR TITLE
fix: rename thead to th for html rows

### DIFF
--- a/cmd/frontend/internal/highlight/html.go
+++ b/cmd/frontend/internal/highlight/html.go
@@ -228,7 +228,7 @@ func newHtmlRow(row int32, includeLineNumbers bool) (htmlRow, htmlCode *html.Nod
 	tr := &html.Node{Type: html.ElementNode, DataAtom: atom.Tr, Data: atom.Tr.String()}
 
 	if includeLineNumbers {
-		thLineNumber := &html.Node{Type: html.ElementNode, DataAtom: atom.Thead, Data: atom.Thead.String()}
+		thLineNumber := &html.Node{Type: html.ElementNode, DataAtom: atom.Th, Data: atom.Th.String()}
 		thLineNumber.Attr = append(thLineNumber.Attr, html.Attribute{Key: "class", Val: "line"})
 		thLineNumber.Attr = append(thLineNumber.Attr, html.Attribute{Key: "data-line", Val: fmt.Sprint(row + 1)})
 		tr.AppendChild(thLineNumber)


### PR DESCRIPTION
Fix wrong tag type for html

## Test plan

- [ ] Make sure the line numbers work now