### PR TITLE
Fix FilteredConnection pagination race condition

### DIFF
--- a/client/web/src/components/FilteredConnection/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.tsx
@@ -438,11 +438,16 @@ export class FilteredConnection<
                     map(({ location }) => location.search),
                     distinctUntilChanged(),
                     map(searchParams => new URLSearchParams(searchParams)),
+                    map(searchParams => getFilterFromURL(searchParams, this.props.filters)),
+                    // Map is compared by reference, so by default distinctUntilChanged
+                    // will always return false for two maps. isEqual compares
+                    // them by value.
+                    distinctUntilChanged((prev, next) => isEqual(prev, next)),
                     skip(1)
                 )
-                .subscribe(searchParameters => {
+                .subscribe(newFilterValues => {
                     if (this.props.useURLQuery) {
-                        this.activeValuesChanges.next(getFilterFromURL(searchParameters, this.props.filters))
+                        this.activeValuesChanges.next(newFilterValues)
                     }
                 })
         )


### PR DESCRIPTION
When any search value changes (ie. ?visible=20), this would trigger and cause a refetch. This would refetch before the visible param is updated, so right after the request for more data finishes, this would trigger another fetch for the initial data. This fixes that by making sure that it only triggers when actually a filter value changed.

## Test plan

Verified that lists now load properly again. Also validated that what we originally fixed with this logic still works.

## App preview:

- [Web](https://sg-web-es-mrn-fix-filteredconnection.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
