### PR TITLE
ranking: Speed up dominating SQL query

### DIFF
--- a/internal/codeintel/codenav/internal/store/store.go
+++ b/internal/codeintel/codenav/internal/store/store.go
@@ -157,19 +157,12 @@ SELECT
 	re.id,
 	re.object_prefix
 FROM codeintel_ranking_exports re
-LEFT JOIN lsif_uploads u ON u.id = re.upload_id
-LEFT JOIN repo r ON r.id = u.repository_id
 WHERE
-	re.graph_key = %s AND NOT (
-		u.id IN (
-			SELECT uvt.upload_id
-			FROM lsif_uploads_visible_at_tip uvt
-			WHERE uvt.is_default_branch
-		) AND
-		r.id IS NOT NULL AND
-		r.deleted_at IS NULL AND
-		r.blocked IS NULL
-	)
+	re.graph_key = %s AND (re.upload_id IS NULL OR re.upload_id NOT IN (
+		SELECT uvt.upload_id
+		FROM lsif_uploads_visible_at_tip uvt
+		WHERE uvt.is_default_branch
+	))
 ORDER BY re.upload_id DESC
 LIMIT %s
 FOR UPDATE OF re SKIP LOCKED


### PR DESCRIPTION
**Before:**

```
 Limit  (cost=24966.36..25876.45 rows=200 width=35) (actual time=3612.726..4748.743 rows=1 loops=1)
   ->  Nested Loop Left Join  (cost=24966.36..1464621.51 rows=316379 width=35) (actual time=3612.725..4748.741 rows=1 loops=1)
         Filter: ((NOT (hashed SubPlan 1)) OR (r.id IS NULL) OR (r.deleted_at IS NOT NULL) OR (r.blocked IS NOT NULL))
         Rows Removed by Filter: 570892
         ->  Nested Loop Left Join  (cost=0.85..751247.51 rows=570825 width=43) (actual time=0.036..1843.294 rows=570893 loops=1)
               ->  Index Scan Backward using codeintel_ranking_exports_graph_key_upload_id on codeintel_ranking_exports re  (cost=0.42..22904.99 rows=570825 width=35) (actual time=0.024..191.804 rows=570893 loops=1)
                     Index Cond: (graph_key = 'dotcom-test'::text)
               ->  Index Scan using lsif_uploads_pkey on lsif_uploads u  (cost=0.42..1.28 rows=1 width=8) (actual time=0.002..0.002 rows=1 loops=570893)
                     Index Cond: (id = re.upload_id)
         ->  Index Scan using repo_pkey on repo r  (cost=0.43..1.19 rows=1 width=75) (actual time=0.003..0.003 rows=1 loops=570893)
               Index Cond: (id = u.repository_id)
         SubPlan 1
           ->  Index Only Scan using lsif_uploads_visible_at_tip_is_default_branch on lsif_uploads_visible_at_tip uvt  (cost=0.42..23491.75 rows=589332 width=4) (actual time=0.027..285.127 rows=585296 loops=1)
                 Heap Fetches: 572775
 Planning Time: 0.662 ms
 Execution Time: 4751.078 ms
```

**After**:

```
Limit  (cost=24965.51..24982.56 rows=200 width=35) (actual time=914.510..914.512 rows=0 loops=1)
   ->  Index Scan Backward using codeintel_ranking_exports_graph_key_upload_id on codeintel_ranking_exports re  (cost=24965.51..49298.24 rows=285412 width=35) (actual time=914.509..914.510 rows=0 loops=1)
         Index Cond: (graph_key = 'dotcom-test'::text)
         Filter: ((upload_id IS NULL) OR (NOT (hashed SubPlan 1)))
         Rows Removed by Filter: 570928
         SubPlan 1
           ->  Index Only Scan using lsif_uploads_visible_at_tip_is_default_branch on lsif_uploads_visible_at_tip uvt  (cost=0.42..23491.75 rows=589332 width=4) (actual time=0.026..314.697 rows=585331 loops=1)
                 Heap Fetches: 573005
 Planning Time: 0.156 ms
 Execution Time: 917.291 ms
```

**Insight**: We do not need to check _all_ conditions, as they will eventually decay into one: no row in the `lsif_uploads_visible_at_tip` table. The deletion of an index or a repo will eventually force the commit graph to be updated, allowing us to check on the end result instead of being immediately reactive in this cleanup process.

## Test plan

Tested on dotcom db, updated unit tests.