### PR TITLE
client: remove searchParametersList in buildSearchURLQuery

### DIFF
--- a/client/search/src/helpers.ts
+++ b/client/search/src/helpers.ts
@@ -64,7 +64,6 @@ export interface SubmitSearchParameters
         | 'communitySearchContextPage'
         | 'excludedResults'
         | 'smartSearchDisabled'
-    searchParameters?: { key: string; value: string }[]
     addRecentSearch?: (query: string) => void
 }
 

--- a/client/search/src/searchQueryState.tsx
+++ b/client/search/src/searchQueryState.tsx
@@ -158,5 +158,4 @@ export interface BuildSearchQueryURLParameters {
     patternType?: SearchPatternType
     caseSensitive?: boolean
     searchContextSpec?: string
-    searchParametersList?: { key: string; value: string }[]
 }

--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -527,8 +527,7 @@ export function buildSearchURLQuery(
     query: string,
     patternType: SearchPatternType,
     caseSensitive: boolean,
-    searchContextSpec?: string,
-    searchParametersList?: { key: string; value: string }[]
+    searchContextSpec?: string
 ): string {
     const searchParameters = new URLSearchParams()
     let queryParameter = query
@@ -558,12 +557,6 @@ export function buildSearchURLQuery(
 
     if (caseParameter === 'yes') {
         searchParameters.set('case', caseParameter)
-    }
-
-    if (searchParametersList) {
-        for (const queryParameter of searchParametersList) {
-            searchParameters.set(queryParameter.key, queryParameter.value)
-        }
     }
 
     return searchParameters.toString().replace(/%2F/g, '/').replace(/%3A/g, ':')

--- a/client/web/src/search/helpers.test.tsx
+++ b/client/web/src/search/helpers.test.tsx
@@ -15,7 +15,6 @@ describe('search/helpers', () => {
                 caseSensitive: false,
                 selectedSearchContextSpec: 'global',
                 source: 'home',
-                searchParameters: undefined,
             })
             expect(history.location.search).toMatchInlineSnapshot(
                 '"?q=context:global+querystring&patternType=standard"'
@@ -30,7 +29,6 @@ describe('search/helpers', () => {
                 caseSensitive: false,
                 selectedSearchContextSpec: 'global',
                 source: 'home',
-                searchParameters: undefined,
             })
             expect(history.location.search).toMatchInlineSnapshot(
                 '"?q=context%3Aglobal+querystring&patternType=standard&trace=1"'

--- a/client/web/src/search/helpers.tsx
+++ b/client/web/src/search/helpers.tsx
@@ -24,7 +24,6 @@ export function submitSearch({
     caseSensitive,
     selectedSearchContextSpec,
     source,
-    searchParameters,
     addRecentSearch,
 }: SubmitSearchParameters): void {
     let searchQueryParameter = buildSearchURLQuery(
@@ -32,7 +31,6 @@ export function submitSearch({
         patternType,
         caseSensitive,
         selectedSearchContextSpec,
-        searchParameters
     )
 
     const existingParameters = new URLSearchParams(history.location.search)

--- a/client/web/src/stores/navbarSearchQueryState.ts
+++ b/client/web/src/stores/navbarSearchQueryState.ts
@@ -144,7 +144,6 @@ export function buildSearchURLQueryFromQueryState(parameters: BuildSearchQueryUR
         parameters.query,
         parameters.patternType ?? currentState.searchPatternType,
         parameters.caseSensitive ?? currentState.searchCaseSensitivity,
-        parameters.searchContextSpec,
-        parameters.searchParametersList
+        parameters.searchContextSpec
     )
 }


### PR DESCRIPTION
From what I can tell, this value is never set so I am removing it. 

It was suggested to use it in https://github.com/sourcegraph/sourcegraph/pull/44004 but I noticed it was never read. This means I am going to remove it, then will follow-up and introduce a parameter which make more sense for preserving.

Test Plan: CI

## App preview:

- [Web](https://sg-web-k-rm-params.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
