### PR TITLE
ranking: Optimize dominating query

### DIFF
--- a/internal/codeintel/codenav/internal/store/store.go
+++ b/internal/codeintel/codenav/internal/store/store.go
@@ -84,12 +84,15 @@ WITH candidates AS (
 		u.id IN (
 			SELECT uvt.upload_id
 			FROM lsif_uploads_visible_at_tip uvt
-			WHERE uvt.is_default_branch
-		) AND
-		u.id NOT IN (
-			SELECT re.upload_id
-			FROM codeintel_ranking_exports re
-			WHERE re.graph_key = %s
+			WHERE
+				uvt.is_default_branch AND
+				NOT EXISTS (
+					SELECT 1
+					FROM codeintel_ranking_exports re
+					WHERE
+						re.graph_key = %s AND
+						re.upload_id = uvt.upload_id
+				)
 		) AND
 		r.deleted_at IS NULL AND
 		r.blocked IS NULL


### PR DESCRIPTION
**Before**:

```
 Limit  (cost=18762.75..22470.37 rows=200 width=54) (actual time=2114.045..2114.048 rows=0 loops=1)
   ->  Nested Loop  (cost=18762.75..702317.14 rows=36873 width=54) (actual time=2114.044..2114.047 rows=0 loops=1)
         ->  Merge Semi Join  (cost=18762.32..680597.13 rows=41702 width=16) (actual time=1796.772..2104.499 rows=4196 loops=1)
               Merge Cond: (u.id = uvt.upload_id)
               ->  Index Scan Backward using lsif_uploads_pkey on lsif_uploads u  (cost=18305.28..661024.53 rows=1554860 width=16) (actual time=372.005..1889.587 rows=426781 loops=1)
                     Filter: (NOT (hashed SubPlan 1))
                     Rows Removed by Filter: 571012
                     SubPlan 1
                       ->  Index Only Scan using codeintel_ranking_exports_graph_key_upload_id on codeintel_ranking_exports re  (cost=0.42..16877.79 rows=570825 width=4) (actual time=0.054..153.645 rows=571012 loops=1)
                             Index Cond: (graph_key = 'dotcom-test'::text)
                             Heap Fetches: 369554
               ->  Index Only Scan Backward using lsif_uploads_visible_at_tip_is_default_branch on lsif_uploads_visible_at_tip uvt  (cost=0.42..11389.88 rows=581193 width=4) (actual time=0.028..103.194 rows=585293 loops=1)
                     Heap Fetches: 81440
         ->  Index Only Scan using repo_id_idx on repo r  (cost=0.43..0.52 rows=1 width=42) (actual time=0.002..0.002 rows=0 loops=4196)
               Index Cond: (id = u.repository_id)
               Heap Fetches: 0
 Planning Time: 0.967 ms
 Execution Time: 2117.607 ms
(18 rows)
```

**After**:

```
 Limit  (cost=25909.08..25909.09 rows=1 width=54) (actual time=301.277..308.966 rows=1 loops=1)
   ->  Sort  (cost=25909.08..25909.09 rows=1 width=54) (actual time=301.276..308.964 rows=1 loops=1)
         Sort Key: u.id DESC
         Sort Method: quicksort  Memory: 25kB
         ->  Nested Loop  (cost=25906.79..25909.07 rows=1 width=54) (actual time=288.739..308.956 rows=1 loops=1)
               ->  Nested Loop  (cost=25906.36..25908.59 rows=1 width=16) (actual time=252.677..297.684 rows=4197 loops=1)
                     ->  HashAggregate  (cost=25905.93..25905.94 rows=1 width=4) (actual time=252.638..264.381 rows=14398 loops=1)
                           Group Key: uvt.upload_id
                           ->  Sort  (cost=25905.91..25905.92 rows=1 width=4) (actual time=247.191..256.008 rows=14398 loops=1)
                                 Sort Key: uvt.upload_id
                                 Sort Method: quicksort  Memory: 1059kB
                                 ->  Gather  (cost=16998.52..25905.90 rows=1 width=4) (actual time=118.266..251.853 rows=14398 loops=1)
                                       Workers Planned: 2
                                       Workers Launched: 2
                                       ->  Parallel Hash Anti Join  (cost=15998.52..24905.80 rows=1 width=4) (actual time=114.013..233.903 rows=4799 loops=3)
                                             Hash Cond: (uvt.upload_id = re.upload_id)
                                             ->  Parallel Index Only Scan using lsif_uploads_visible_at_tip_is_default_branch on lsif_uploads_visible_at_tip uvt  (cost=0.42..7999.59 rows=242164 width=4) (actual time=0.053..34.649 rows=195136 loops=3)
                                                   Heap Fetches: 81627
                                             ->  Parallel Hash  (cost=13025.05..13025.05 rows=237844 width=4) (actual time=110.652..110.653 rows=190337 loops=3)
                                                   Buckets: 1048576  Batches: 1  Memory Usage: 30592kB
                                                   ->  Parallel Seq Scan on codeintel_ranking_exports re  (cost=0.00..13025.05 rows=237844 width=4) (actual time=0.017..41.989 rows=190337 loops=3)
                                                         Filter: (graph_key = 'dotcom-test'::text)
                     ->  Index Scan using lsif_uploads_pkey on lsif_uploads u  (cost=0.43..2.65 rows=1 width=16) (actual time=0.002..0.002 rows=0 loops=14398)
                           Index Cond: (id = uvt.upload_id)
               ->  Index Only Scan using repo_id_idx on repo r  (cost=0.43..0.49 rows=1 width=42) (actual time=0.002..0.002 rows=0 loops=4197)
                     Index Cond: (id = u.repository_id)
                     Heap Fetches: 0
 Planning Time: 0.784 ms
 Execution Time: 309.062 ms
(29 rows)
```

**Intuition**: The expensive part of the query comes when the anti-join on `codeintel_ranking_exports` causes all results to fail a filter, causing a full scan of all candidate result rows. We can change the order of our clauses so that `lsif_uploads_visible_at_tip` - `codeintel_ranking_exports` causes an immediate empty result set, causing a quick return in the common case.

## Test plan

Existing unit tests.