### PR TITLE
[a11y] remove a11y-ignore because it is not needed

### DIFF
--- a/client/search-ui/src/input/SearchContextDropdown.tsx
+++ b/client/search-ui/src/input/SearchContextDropdown.tsx
@@ -152,11 +152,6 @@ export const SearchContextDropdown: FC<SearchContextDropdownProps> = props => {
                     </Code>
                 </PopoverTrigger>
             </Tooltip>
-            {/*
-               a11y-ignore
-               Rule: "aria-required-children" (Certain ARIA roles must contain particular children)
-               GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/34348
-             */}
             <PopoverContent
                 position={Position.bottomStart}
                 className={classNames('a11y-ignore', styles.menu)}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/34348

## Test plan

All tests should pass

## App preview:

- [Web](https://sg-web-jp-removea11yignorecontext.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
