### PR TITLE
Fix missing return err statement

### DIFF
--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -311,6 +311,7 @@ func (s *gitserverRepoStore) GetByID(ctx context.Context, id api.RepoID) (*types
 		if err == sql.ErrNoRows {
 			return nil, &errGitserverRepoNotFound{}
 		}
+		return nil, err
 	}
 	return repo, nil
 }


### PR DESCRIPTION
Found by Kalan in prod logs, we returned a nil repo from this method.

## Test plan

Traced the panic Kalan found https://sourcegraph.slack.com/archives/C04ASJKH55E/p1667951316291999?thread_ts=1667949844.239189&cid=C04ASJKH55E down to this. Relying on existing tests to catch problems.