### PR TITLE
use committer date instead of author date in UI

### DIFF
--- a/client/search-ui/src/components/CommitSearchResult.tsx
+++ b/client/search-ui/src/components/CommitSearchResult.tsx
@@ -60,7 +60,7 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({
                     <VisuallyHidden>,</VisuallyHidden>
                 </Code>{' '}
                 <VisuallyHidden>Commited</VisuallyHidden>
-                <Timestamp date={result.authorDate} noAbout={true} strict={true} />
+                <Timestamp date={result.committerDate} noAbout={true} strict={true} timeZone="UTC" />
             </Link>
             {result.repoStars && <div className={styles.divider} />}
         </div>

--- a/client/search/src/integration/streaming-search-mocks.ts
+++ b/client/search/src/integration/streaming-search-mocks.ts
@@ -16,6 +16,8 @@ export const diffSearchStreamEvents: SearchEvent[] = [
                 message: 'build: set up test deps and scripts\n',
                 authorName: 'Quinn Slack',
                 authorDate: '2019-10-29T20:59:15Z',
+                committerName: 'Committer Slack',
+                committerDate: '2020-10-29T20:59:15Z',
                 url:
                     '/gitlab.sgdev.org/sourcegraph/sourcegraph-lightstep/-/commit/65dba23797be9e0ce1941f92c5385a7856bc5a42',
                 repository: 'gitlab.sgdev.org/sourcegraph/sourcegraph-lightstep',
@@ -59,6 +61,8 @@ export const commitSearchStreamEvents: SearchEvent[] = [
                 message: 'add more tests, use the Sourcegraph stubs api and improve repo matching. (#13)',
                 authorName: 'Vanesa',
                 authorDate: '2019-10-29T20:59:15Z',
+                committerName: 'Committer Vanesa',
+                committerDate: '2020-10-29T20:59:15Z',
                 url:
                     '/gitlab.sgdev.org/sourcegraph/sourcegraph-sentry/-/commit/7e69ceb49adc30cb46bbe50335e1a371a0f2f6b1',
                 repository: 'gitlab.sgdev.org/sourcegraph/sourcegraph-sentry',

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -132,6 +132,8 @@ export interface CommitMatch {
     message: string
     authorName: string
     authorDate: string
+    committerName: string
+    committerDate: string
     repoStars?: number
     repoLastFetched?: string
 
@@ -200,16 +202,16 @@ export interface Skipped {
      * - display :: we hit the display limit, so we stopped sending results from the backend.
      */
     reason:
-        | 'document-match-limit'
-        | 'shard-match-limit'
-        | 'repository-limit'
-        | 'shard-timedout'
-        | 'repository-cloning'
-        | 'repository-missing'
-        | 'excluded-fork'
-        | 'excluded-archive'
-        | 'display'
-        | 'error'
+    | 'document-match-limit'
+    | 'shard-match-limit'
+    | 'repository-limit'
+    | 'shard-timedout'
+    | 'repository-cloning'
+    | 'repository-missing'
+    | 'excluded-fork'
+    | 'excluded-archive'
+    | 'display'
+    | 'error'
     /**
      * A short message. eg 1,200 timed out.
      */

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -495,18 +495,20 @@ func fromCommit(commit *result.CommitMatch, repoCache map[api.RepoID]*types.Sear
 	}
 
 	commitEvent := &streamhttp.EventCommitMatch{
-		Type:         streamhttp.CommitMatchType,
-		Label:        commit.Label(),
-		URL:          commit.URL().String(),
-		Detail:       commit.Detail(),
-		Repository:   string(commit.Repo.Name),
-		RepositoryID: int32(commit.Repo.ID),
-		OID:          string(commit.Commit.ID),
-		Message:      string(commit.Commit.Message),
-		AuthorName:   commit.Commit.Author.Name,
-		AuthorDate:   commit.Commit.Author.Date,
-		Content:      hls.Value,
-		Ranges:       ranges,
+		Type:          streamhttp.CommitMatchType,
+		Label:         commit.Label(),
+		URL:           commit.URL().String(),
+		Detail:        commit.Detail(),
+		Repository:    string(commit.Repo.Name),
+		RepositoryID:  int32(commit.Repo.ID),
+		OID:           string(commit.Commit.ID),
+		Message:       string(commit.Commit.Message),
+		AuthorName:    commit.Commit.Author.Name,
+		AuthorDate:    commit.Commit.Author.Date,
+		CommitterName: commit.Commit.Committer.Name,
+		CommitterDate: commit.Commit.Committer.Date,
+		Content:       hls.Value,
+		Ranges:        ranges,
 	}
 
 	if r, ok := repoCache[commit.Repo.ID]; ok {

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -155,6 +155,8 @@ type EventCommitMatch struct {
 	Message         string     `json:"message"`
 	AuthorName      string     `json:"authorName"`
 	AuthorDate      time.Time  `json:"authorDate"`
+	CommitterName   string     `json:"committerName"`
+	CommitterDate   time.Time  `json:"committerDate"`
 	RepoStars       int        `json:"repoStars,omitempty"`
 	RepoLastFetched *time.Time `json:"repoLastFetched,omitempty"`
 	Content         string     `json:"content"`


### PR DESCRIPTION
Commit search operates on committer date for its `before` and `after` filters, but we display the author date in the UI. We should display the date the search is operating on. Additionally, committer date tends to be more well ordered, which is less confusing when browsing commits.

This sends the committer date as part of the streamed search results and uses it instead of author date in the UI.

## Test plan

Tested that committer date shows in the hover:
<img width="235" alt="Screen Shot 2022-11-08 at 20 02 15" src="https://user-images.githubusercontent.com/12631702/200727654-80fd3d93-69de-4bda-bfe4-996358ab9ddd.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
