### PR TITLE
fix FeedbackWidget

### DIFF
--- a/cmd/frontend/graphqlbackend/survey_response.go
+++ b/cmd/frontend/graphqlbackend/survey_response.go
@@ -145,7 +145,6 @@ type HappinessFeedbackSubmissionInput struct {
 type happinessFeedbackSubmissionForHubSpot struct {
 	Email       *string `url:"email"`
 	Username    *string `url:"happiness_username"`
-	Score       int32   `url:"happiness_score"`
 	Feedback    *string `url:"happiness_feedback"`
 	CurrentPath *string `url:"happiness_current_url"`
 	IsTest      bool    `url:"happiness_is_test"`
@@ -156,12 +155,7 @@ type happinessFeedbackSubmissionForHubSpot struct {
 func (r *schemaResolver) SubmitHappinessFeedback(ctx context.Context, args *struct {
 	Input *HappinessFeedbackSubmissionInput
 }) (*EmptyResponse, error) {
-	if args.Input.Score < 1 || args.Input.Score > 4 {
-		return nil, errors.New("Score must be a value between 1 and 4")
-	}
-
 	data := happinessFeedbackSubmissionForHubSpot{
-		Score:       args.Input.Score,
 		Feedback:    args.Input.Feedback,
 		CurrentPath: args.Input.CurrentPath,
 		IsTest:      env.InsecureDev,


### PR DESCRIPTION
When I removed the score field, I forgot to remove the check for the score from the GraphQL resolver. This resulted in the feedback form failing with `Score must be a value between 1 and 4`.




## Test plan

Actually test the whole thing end-to-end. It works. (I didn't do this before to avoid spamming our feedback collection channel.)