### PR TITLE
client: always append preserved query parameters

### DIFF
--- a/client/web/src/search/helpers.test.tsx
+++ b/client/web/src/search/helpers.test.tsx
@@ -31,7 +31,7 @@ describe('search/helpers', () => {
                 source: 'home',
             })
             expect(history.location.search).toMatchInlineSnapshot(
-                '"?q=context%3Aglobal+querystring&patternType=standard&trace=1"'
+                '"?q=context:global+querystring&patternType=standard&trace=1"'
             )
         })
     })

--- a/client/web/src/search/helpers.tsx
+++ b/client/web/src/search/helpers.tsx
@@ -14,6 +14,20 @@ import { AGGREGATION_MODE_URL_KEY, AGGREGATION_UI_MODE_URL_KEY } from './results
 const PRESERVED_QUERY_PARAMETERS = ['feat', 'trace', AGGREGATION_MODE_URL_KEY, AGGREGATION_UI_MODE_URL_KEY]
 
 /**
+ * Returns a URL query string with only the parameters in PRESERVED_QUERY_PARAMETERS.
+ */
+function preservedQuery(query: string): string {
+    const old = new URLSearchParams(query)
+    const filtered = new URLSearchParams()
+    for (const key of PRESERVED_QUERY_PARAMETERS) {
+        for (const value of old.getAll(key)) {
+            filtered.append(key, value)
+        }
+    }
+    return filtered.toString()
+}
+
+/**
  * @param activation If set, records the DidSearch activation event for the new user activation
  * flow.
  */
@@ -33,19 +47,9 @@ export function submitSearch({
         selectedSearchContextSpec,
     )
 
-    const existingParameters = new URLSearchParams(history.location.search)
-    for (const key of PRESERVED_QUERY_PARAMETERS) {
-        const values = existingParameters.getAll(key)
-        if (values.length === 0) {
-            continue
-        }
-
-        const parameters = new URLSearchParams(searchQueryParameter)
-        parameters.delete(key)
-        for (const value of values) {
-            parameters.append(key, value)
-        }
-        searchQueryParameter = parameters.toString()
+    const preserved = preservedQuery(history.location.search)
+    if (preserved !== '') {
+        searchQueryParameter = searchQueryParameter + '&' + preserved
     }
 
     // Go to search results page


### PR DESCRIPTION
This simplifies the implementation for preserving the URL parameters across search requests. Initially I adjusted the buildSearchURLQuery implementation, but this ended up being a bit ugly and would of only been used by one call site.

So instead I adjusted how we build the list of preserved parameters and just appended those. I believe this implementation is more robust and easier to understand. Additionally we won't undo the escaping we previously did if a preserved parameter is present.

Test Plan: CI

## App preview:

- [Web](https://sg-web-k-preserved-query.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
