### PR TITLE
webhooks: move GraphQL resolver to enterprise package.

### DIFF
--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -41,6 +41,7 @@ type Services struct {
 	NotebooksResolver               graphqlbackend.NotebooksResolver
 	ComputeResolver                 graphqlbackend.ComputeResolver
 	InsightsAggregationResolver     graphqlbackend.InsightsAggregationResolver
+	WebhooksResolver                graphqlbackend.WebhooksResolver
 }
 
 // NewCodeIntelUploadHandler creates a new handler for the LSIF upload endpoint. The

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -316,23 +316,27 @@ func NewSchemaWithoutResolvers(db database.DB) (*graphql.Schema, error) {
 }
 
 func NewSchemaWithNotebooksResolver(db database.DB, notebooks NotebooksResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, nil, nil, nil, nil, notebooks, nil, nil)
+	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, nil, nil, nil, nil, notebooks, nil, nil, nil)
 }
 
 func NewSchemaWithAuthzResolver(db database.DB, authz AuthzResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, authz, nil, nil, nil, nil, nil, nil, nil)
+	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, authz, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func NewSchemaWithBatchChangesResolver(db database.DB, batchChanges BatchChangesResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(db), batchChanges, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	return NewSchema(db, gitserver.NewClient(db), batchChanges, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func NewSchemaWithCodeMonitorsResolver(db database.DB, codeMonitors CodeMonitorsResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, codeMonitors, nil, nil, nil, nil, nil, nil)
+	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, codeMonitors, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func NewSchemaWithLicenseResolver(db database.DB, license LicenseResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, nil, license, nil, nil, nil, nil, nil)
+	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, nil, license, nil, nil, nil, nil, nil, nil)
+}
+
+func NewSchemaWithWebhooksResolver(db database.DB, webhooksResolver WebhooksResolver) (*graphql.Schema, error) {
+	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, webhooksResolver)
 }
 
 func NewSchema(
@@ -349,6 +353,7 @@ func NewSchema(
 	notebooks NotebooksResolver,
 	compute ComputeResolver,
 	insightsAggregation InsightsAggregationResolver,
+	webhooksResolver WebhooksResolver,
 ) (*graphql.Schema, error) {
 	resolver := newSchemaResolver(db, gitserverClient)
 	schemas := []string{mainSchema}
@@ -444,6 +449,15 @@ func NewSchema(
 		schemas = append(schemas, insightsAggregationsSchema)
 	}
 
+	if webhooksResolver != nil {
+		EnterpriseResolvers.webhooksResolver = webhooksResolver
+		resolver.WebhooksResolver = webhooksResolver
+		// Register NodeByID handlers.
+		for kind, res := range webhooksResolver.NodeResolvers() {
+			resolver.nodeByIDFns[kind] = res
+		}
+	}
+
 	return graphql.ParseSchema(
 		strings.Join(schemas, "\n"),
 		resolver,
@@ -477,6 +491,7 @@ type schemaResolver struct {
 	SearchContextsResolver
 	NotebooksResolver
 	InsightsAggregationResolver
+	WebhooksResolver
 }
 
 // newSchemaResolver will return a new, safely instantiated schemaResolver with some
@@ -532,9 +547,6 @@ func newSchemaResolver(db database.DB, gitserverClient gitserver.Client) *schema
 		"WebhookLog": func(ctx context.Context, id graphql.ID) (Node, error) {
 			return webhookLogByID(ctx, db, id)
 		},
-		"Webhook": func(ctx context.Context, id graphql.ID) (Node, error) {
-			return webhookByID(ctx, db, id)
-		},
 		"Executor": func(ctx context.Context, id graphql.ID) (Node, error) {
 			return executorByID(ctx, db, id)
 		},
@@ -565,6 +577,7 @@ var EnterpriseResolvers = struct {
 	searchContextsResolver      SearchContextsResolver
 	notebooksResolver           NotebooksResolver
 	InsightsAggregationResolver InsightsAggregationResolver
+	webhooksResolver            WebhooksResolver
 }{}
 
 // DEPRECATED

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -312,7 +312,7 @@ func prometheusGraphQLRequestName(requestName string) string {
 }
 
 func NewSchemaWithoutResolvers(db database.DB) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func NewSchemaWithNotebooksResolver(db database.DB, notebooks NotebooksResolver) (*graphql.Schema, error) {

--- a/cmd/frontend/graphqlbackend/node.go
+++ b/cmd/frontend/graphqlbackend/node.go
@@ -275,8 +275,8 @@ func (r *NodeResolver) ToWebhookLog() (*webhookLogResolver, bool) {
 	return n, ok
 }
 
-func (r *NodeResolver) ToWebhook() (*webhookResolver, bool) {
-	n, ok := r.Node.(*webhookResolver)
+func (r *NodeResolver) ToWebhook() (WebhookResolver, bool) {
+	n, ok := r.Node.(WebhookResolver)
 	return n, ok
 }
 

--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -25,7 +25,7 @@ func mustParseGraphQLSchema(t *testing.T, db database.DB) *graphql.Schema {
 func mustParseGraphQLSchemaWithClient(t *testing.T, db database.DB, gitserverClient gitserver.Client) *graphql.Schema {
 	t.Helper()
 
-	parsedSchema, parseSchemaErr := NewSchema(db, gitserverClient, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	parsedSchema, parseSchemaErr := NewSchema(db, gitserverClient, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	if parseSchemaErr != nil {
 		t.Fatal(parseSchemaErr)
 	}

--- a/cmd/frontend/graphqlbackend/webhook_logs.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs.go
@@ -315,3 +315,12 @@ func (r *webhookLogHeaderResolver) Name() string {
 func (r *webhookLogHeaderResolver) Values() []string {
 	return r.values
 }
+
+func marshalWebhookID(id int32) graphql.ID {
+	return relay.MarshalID("Webhook", id)
+}
+
+func unmarshalWebhookID(id graphql.ID) (hookID int32, err error) {
+	err = relay.UnmarshalSpec(id, &hookID)
+	return
+}

--- a/cmd/frontend/graphqlbackend/webhooks.go
+++ b/cmd/frontend/graphqlbackend/webhooks.go
@@ -2,27 +2,29 @@ package graphqlbackend
 
 import (
 	"context"
-	"fmt"
-	"net/url"
-	"sync"
 
 	"github.com/graph-gophers/graphql-go"
-	"github.com/graph-gophers/graphql-go/relay"
-	"github.com/sourcegraph/sourcegraph/internal/errcode"
-
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
-	"github.com/sourcegraph/sourcegraph/internal/auth"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
-	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var _ WebhookResolver = &webhookResolver{}
+// WebhooksResolver is a main interface for all GraphQL operations with webhooks.
+type WebhooksResolver interface {
+	CreateWebhook(ctx context.Context, args *CreateWebhookArgs) (WebhookResolver, error)
+	DeleteWebhook(ctx context.Context, args *DeleteWebhookArgs) (*EmptyResponse, error)
+	Webhooks(ctx context.Context, args *ListWebhookArgs) (WebhookConnectionResolver, error)
 
+	NodeResolvers() map[string]NodeByIDFunc
+}
+
+// WebhookConnectionResolver is an interface for querying lists of webhooks.
+type WebhookConnectionResolver interface {
+	Nodes(ctx context.Context) ([]WebhookResolver, error)
+	TotalCount(ctx context.Context) (int32, error)
+	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
+}
+
+// WebhookResolver is an interface for querying a single webhook.
 type WebhookResolver interface {
 	ID() graphql.ID
 	UUID() string
@@ -36,285 +38,18 @@ type WebhookResolver interface {
 	UpdatedBy(ctx context.Context) (*UserResolver, error)
 }
 
-type webhookResolver struct {
-	db   database.DB
-	hook *types.Webhook
-}
-
-func (r *webhookResolver) ID() graphql.ID {
-	return marshalWebhookID(r.hook.ID)
-}
-
-func (r *webhookResolver) UUID() string {
-	return r.hook.UUID.String()
-}
-
-func (r *webhookResolver) URL() (string, error) {
-	externalURL, err := url.Parse(conf.Get().ExternalURL)
-	if err != nil {
-		return "", errors.Wrap(err, "could not parse site config external URL")
-	}
-	externalURL.Path = fmt.Sprintf(".api/webhooks/%v", r.hook.UUID)
-	return externalURL.String(), nil
-}
-
-func (r *webhookResolver) CodeHostURN() string {
-	return r.hook.CodeHostURN.String()
-}
-
-func (r *webhookResolver) CodeHostKind() string {
-	return r.hook.CodeHostKind
-}
-
-func (r *webhookResolver) Secret(ctx context.Context) (*string, error) {
-	// Secret is optional
-	if r.hook.Secret == nil {
-		return nil, nil
-	}
-	s, err := r.hook.Secret.Decrypt(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return &s, nil
-}
-
-func (r *webhookResolver) CreatedAt() gqlutil.DateTime {
-	return gqlutil.DateTime{Time: r.hook.CreatedAt}
-}
-
-func (r *webhookResolver) UpdatedAt() gqlutil.DateTime {
-	return gqlutil.DateTime{Time: r.hook.UpdatedAt}
-}
-
-func (r *webhookResolver) CreatedBy(ctx context.Context) (*UserResolver, error) {
-	if r.hook.CreatedByUserID == 0 {
-		return nil, nil
-	}
-
-	user, err := UserByIDInt32(ctx, r.db, r.hook.CreatedByUserID)
-	if errcode.IsNotFound(err) {
-		return nil, nil
-	}
-
-	return user, err
-}
-
-func (r *webhookResolver) UpdatedBy(ctx context.Context) (*UserResolver, error) {
-	if r.hook.UpdatedByUserID == 0 {
-		return nil, nil
-	}
-
-	user, err := UserByIDInt32(ctx, r.db, r.hook.UpdatedByUserID)
-	if errcode.IsNotFound(err) {
-		return nil, nil
-	}
-
-	return user, err
-}
-
-func (r *schemaResolver) Webhooks(ctx context.Context, args *webhookArgs) (*webhookConnectionResolver, error) {
-	if auth.CheckCurrentUserIsSiteAdmin(ctx, r.db) != nil {
-		return nil, auth.ErrMustBeSiteAdmin
-	}
-	opts, err := args.toWebhookListOptions()
-	if err != nil {
-		return nil, err
-	}
-	return &webhookConnectionResolver{
-		db:  r.db,
-		opt: opts,
-	}, nil
-}
-
-type webhookArgs struct {
-	graphqlutil.ConnectionArgs
-	After *string
-	Kind  *string
-}
-
-func (args *webhookArgs) toWebhookListOptions() (database.WebhookListOptions, error) {
-	opt := database.WebhookListOptions{}
-	if args.Kind != nil {
-		opt.Kind = *args.Kind
-	}
-	if args.After != nil {
-		cursor, err := UnmarshalWebhookCursor(args.After)
-		if err != nil {
-			return opt, err
-		}
-		opt.Cursor = cursor
-	} else {
-		opt.Cursor = &types.Cursor{
-			Column:    "id",
-			Direction: "next",
-		}
-	}
-	args.Set(&opt.LimitOffset)
-	return opt, nil
-}
-
-type WebhookConnectionResolver interface {
-	Nodes(ctx context.Context) ([]WebhookResolver, error)
-	TotalCount(ctx context.Context) (int32, error)
-	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
-}
-
-var _ WebhookConnectionResolver = &webhookConnectionResolver{}
-
-type webhookConnectionResolver struct {
-	db       database.DB
-	opt      database.WebhookListOptions
-	once     sync.Once
-	webhooks []*types.Webhook
-	next     int32
-	err      error
-}
-
-func (r *webhookConnectionResolver) Nodes(ctx context.Context) ([]WebhookResolver, error) {
-	webhooks, _, err := r.compute(ctx)
-	if err != nil {
-		return nil, err
-	}
-	resolvers := make([]WebhookResolver, 0, len(webhooks))
-	for _, wh := range webhooks {
-		resolvers = append(resolvers, &webhookResolver{
-			db:   r.db,
-			hook: wh,
-		})
-	}
-	return resolvers, nil
-}
-
-func (r *webhookConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
-	count, err := r.db.Webhooks(keyring.Default().WebhookLogKey).Count(ctx, r.opt)
-	if err != nil {
-		return 0, err
-	}
-	return int32(count), nil
-}
-
-func (r *webhookConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	_, next, err := r.compute(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if next == 0 {
-		return graphqlutil.HasNextPage(false), nil
-	}
-
-	return graphqlutil.NextPageCursor(MarshalWebhookCursor(
-		&types.Cursor{
-			Column:    r.opt.Cursor.Column,
-			Value:     fmt.Sprintf("%d", next),
-			Direction: r.opt.Cursor.Direction,
-		},
-	)), nil
-}
-
-func (r *webhookConnectionResolver) compute(ctx context.Context) ([]*types.Webhook, int32, error) {
-	r.once.Do(func() {
-		opts := copyOpts(r.opt)
-		if r.opt.LimitOffset != nil {
-			opts.Limit++
-		}
-		r.webhooks, r.err = r.db.Webhooks(keyring.Default().WebhookKey).List(ctx, opts)
-		if r.opt.LimitOffset != nil && opts.Limit != 0 && len(r.webhooks) == opts.Limit {
-			r.next = r.webhooks[len(r.webhooks)-1].ID
-			r.webhooks = r.webhooks[:len(r.webhooks)-1]
-		}
-	})
-	return r.webhooks, r.next, r.err
-}
-
-func copyOpts(opts database.WebhookListOptions) database.WebhookListOptions {
-	copied := database.WebhookListOptions{
-		Kind:   opts.Kind,
-		Cursor: opts.Cursor,
-	}
-	if opts.LimitOffset != nil {
-		limitOffset := database.LimitOffset{
-			Limit:  opts.Limit,
-			Offset: opts.Offset,
-		}
-		copied.LimitOffset = &limitOffset
-	}
-	return copied
-}
-
-func webhookByID(ctx context.Context, db database.DB, gqlID graphql.ID) (*webhookResolver, error) {
-	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, db); err != nil {
-		return nil, err
-	}
-
-	id, err := unmarshalWebhookID(gqlID)
-	if err != nil {
-		return nil, err
-	}
-
-	hook, err := db.Webhooks(keyring.Default().WebhookKey).GetByID(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-
-	return &webhookResolver{db: db, hook: hook}, nil
-}
-
-func marshalWebhookID(id int32) graphql.ID {
-	return relay.MarshalID("Webhook", id)
-}
-
-func unmarshalWebhookID(id graphql.ID) (hookID int32, err error) {
-	err = relay.UnmarshalSpec(id, &hookID)
-	return
-}
-
-func (r *schemaResolver) CreateWebhook(ctx context.Context, args *struct {
+type CreateWebhookArgs struct {
 	CodeHostKind string
 	CodeHostURN  string
 	Secret       *string
-}) (*webhookResolver, error) {
-	if auth.CheckCurrentUserIsSiteAdmin(ctx, r.db) != nil {
-		return nil, auth.ErrMustBeSiteAdmin
-	}
-	ws := backend.NewWebhookService(r.db, keyring.Default())
-	webhook, err := ws.CreateWebhook(ctx, args.CodeHostKind, args.CodeHostURN, args.Secret)
-	if err != nil {
-		return nil, err
-	}
-	return &webhookResolver{hook: webhook, db: r.db}, nil
 }
 
-const webhookCursorKind = "WebhookCursor"
-
-func MarshalWebhookCursor(cursor *types.Cursor) string {
-	return string(relay.MarshalID(webhookCursorKind, cursor))
+type DeleteWebhookArgs struct {
+	ID graphql.ID
 }
 
-func UnmarshalWebhookCursor(cursor *string) (*types.Cursor, error) {
-	if cursor == nil {
-		return nil, nil
-	}
-	if kind := relay.UnmarshalKind(graphql.ID(*cursor)); kind != webhookCursorKind {
-		return nil, errors.Errorf("cannot unmarshal webhook cursor type: %q", kind)
-	}
-	var spec *types.Cursor
-	if err := relay.UnmarshalSpec(graphql.ID(*cursor), &spec); err != nil {
-		return nil, err
-	}
-	return spec, nil
-}
-
-func (r *schemaResolver) DeleteWebhook(ctx context.Context, args *struct{ ID graphql.ID }) (*EmptyResponse, error) {
-	if auth.CheckCurrentUserIsSiteAdmin(ctx, r.db) != nil {
-		return nil, auth.ErrMustBeSiteAdmin
-	}
-	id, err := unmarshalWebhookID(args.ID)
-	if err != nil {
-		return nil, err
-	}
-	err = r.db.Webhooks(keyring.Default().WebhookKey).Delete(ctx, database.DeleteWebhookOpts{ID: id})
-	if err != nil {
-		return nil, errors.Wrap(err, "delete webhook")
-	}
-	return &EmptyResponse{}, nil
+type ListWebhookArgs struct {
+	graphqlutil.ConnectionArgs
+	After *string
+	Kind  *string
 }

--- a/cmd/frontend/graphqlbackend/webhooks.go
+++ b/cmd/frontend/graphqlbackend/webhooks.go
@@ -36,21 +36,6 @@ type WebhookResolver interface {
 	UpdatedBy(ctx context.Context) (*UserResolver, error)
 }
 
-var _ WebhookResolver = &webhookResolver{}
-
-type WebhookResolver interface {
-	ID() graphql.ID
-	UUID() string
-	URL() (string, error)
-	CodeHostURN() string
-	CodeHostKind() string
-	Secret(ctx context.Context) (*string, error)
-	CreatedAt() gqlutil.DateTime
-	UpdatedAt() gqlutil.DateTime
-	CreatedBy(ctx context.Context) (*UserResolver, error)
-	UpdatedBy(ctx context.Context) (*UserResolver, error)
-}
-
 type webhookResolver struct {
 	db   database.DB
 	hook *types.Webhook

--- a/cmd/frontend/graphqlbackend/webhooks.go
+++ b/cmd/frontend/graphqlbackend/webhooks.go
@@ -36,6 +36,21 @@ type WebhookResolver interface {
 	UpdatedBy(ctx context.Context) (*UserResolver, error)
 }
 
+var _ WebhookResolver = &webhookResolver{}
+
+type WebhookResolver interface {
+	ID() graphql.ID
+	UUID() string
+	URL() (string, error)
+	CodeHostURN() string
+	CodeHostKind() string
+	Secret(ctx context.Context) (*string, error)
+	CreatedAt() gqlutil.DateTime
+	UpdatedAt() gqlutil.DateTime
+	CreatedBy(ctx context.Context) (*UserResolver, error)
+	UpdatedBy(ctx context.Context) (*UserResolver, error)
+}
+
 type webhookResolver struct {
 	db   database.DB
 	hook *types.Webhook

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -290,6 +290,7 @@ func Main(enterpriseSetupHook func(db database.DB, codeIntelServices codeintel.S
 		enterprise.NotebooksResolver,
 		enterprise.ComputeResolver,
 		enterprise.InsightsAggregationResolver,
+		enterprise.WebhooksResolver,
 	)
 	if err != nil {
 		return err

--- a/enterprise/cmd/frontend/internal/repos/init.go
+++ b/enterprise/cmd/frontend/internal/repos/init.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/repos/webhooks"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/repos/webhooks/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -13,7 +14,7 @@ import (
 
 // Init initializes the given enterpriseServices with the webhook handlers for handling GitHub push events.
 func Init(
-	ctx context.Context,
+	_ context.Context,
 	db database.DB,
 	_ codeintel.Services,
 	_ conftypes.UnifiedWatchable,
@@ -21,5 +22,6 @@ func Init(
 	_ *observation.Context,
 ) error {
 	enterpriseServices.GitHubSyncWebhook = webhooks.NewGitHubWebhookHandler()
+	enterpriseServices.WebhooksResolver = resolvers.NewWebhooksResolver(db)
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
@@ -1,0 +1,312 @@
+package resolvers
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sync"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+const (
+	webhookKind       = "Webhook"
+	webhookCursorKind = "WebhookCursor"
+)
+
+var _ graphqlbackend.WebhooksResolver = &webhooksResolver{}
+
+type webhooksResolver struct {
+	db database.DB
+}
+
+func NewWebhooksResolver(db database.DB) graphqlbackend.WebhooksResolver {
+	return &webhooksResolver{db: db}
+}
+
+func (r *webhooksResolver) CreateWebhook(ctx context.Context, args *graphqlbackend.CreateWebhookArgs) (graphqlbackend.WebhookResolver, error) {
+	if auth.CheckCurrentUserIsSiteAdmin(ctx, r.db) != nil {
+		return nil, auth.ErrMustBeSiteAdmin
+	}
+	ws := backend.NewWebhookService(r.db, keyring.Default())
+	webhook, err := ws.CreateWebhook(ctx, args.CodeHostKind, args.CodeHostURN, args.Secret)
+	if err != nil {
+		return nil, err
+	}
+	return &webhookResolver{hook: webhook, db: r.db}, nil
+}
+
+func (r *webhooksResolver) DeleteWebhook(ctx context.Context, args *graphqlbackend.DeleteWebhookArgs) (*graphqlbackend.EmptyResponse, error) {
+	if auth.CheckCurrentUserIsSiteAdmin(ctx, r.db) != nil {
+		return nil, auth.ErrMustBeSiteAdmin
+	}
+	id, err := unmarshalWebhookID(args.ID)
+	if err != nil {
+		return nil, err
+	}
+	err = r.db.Webhooks(keyring.Default().WebhookKey).Delete(ctx, database.DeleteWebhookOpts{ID: id})
+	if err != nil {
+		return nil, errors.Wrap(err, "delete webhook")
+	}
+	return &graphqlbackend.EmptyResponse{}, nil
+}
+
+func (r *webhooksResolver) Webhooks(ctx context.Context, args *graphqlbackend.ListWebhookArgs) (graphqlbackend.WebhookConnectionResolver, error) {
+	if auth.CheckCurrentUserIsSiteAdmin(ctx, r.db) != nil {
+		return nil, auth.ErrMustBeSiteAdmin
+	}
+	opts, err := toWebhookListOptions(args)
+	if err != nil {
+		return nil, err
+	}
+	return &webhooksConnectionResolver{
+		db:  r.db,
+		opt: opts,
+	}, nil
+}
+
+func (r *webhooksResolver) NodeResolvers() map[string]graphqlbackend.NodeByIDFunc {
+	return map[string]graphqlbackend.NodeByIDFunc{
+		webhookKind: func(ctx context.Context, id graphql.ID) (graphqlbackend.Node, error) {
+			return webhookByID(ctx, r.db, id)
+		},
+	}
+}
+
+func webhookByID(ctx context.Context, db database.DB, gqlID graphql.ID) (*webhookResolver, error) {
+	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, db); err != nil {
+		return nil, err
+	}
+
+	id, err := unmarshalWebhookID(gqlID)
+	if err != nil {
+		return nil, err
+	}
+
+	hook, err := db.Webhooks(keyring.Default().WebhookKey).GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &webhookResolver{db: db, hook: hook}, nil
+}
+
+func toWebhookListOptions(args *graphqlbackend.ListWebhookArgs) (database.WebhookListOptions, error) {
+	opt := database.WebhookListOptions{}
+	if args.Kind != nil {
+		opt.Kind = *args.Kind
+	}
+	if args.After != nil {
+		cursor, err := UnmarshalWebhookCursor(args.After)
+		if err != nil {
+			return opt, err
+		}
+		opt.Cursor = cursor
+	} else {
+		opt.Cursor = &types.Cursor{
+			Column:    "id",
+			Direction: "next",
+		}
+	}
+	args.Set(&opt.LimitOffset)
+	return opt, nil
+}
+
+var _ graphqlbackend.WebhookConnectionResolver = &webhooksConnectionResolver{}
+
+type webhooksConnectionResolver struct {
+	db       database.DB
+	opt      database.WebhookListOptions
+	once     sync.Once
+	webhooks []*types.Webhook
+	next     int32
+	err      error
+}
+
+func (c *webhooksConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.WebhookResolver, error) {
+	webhooks, _, err := c.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resolvers := make([]graphqlbackend.WebhookResolver, 0, len(webhooks))
+	for _, wh := range webhooks {
+		resolvers = append(resolvers, &webhookResolver{
+			db:   c.db,
+			hook: wh,
+		})
+	}
+	return resolvers, nil
+}
+
+func (c *webhooksConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+	count, err := c.db.Webhooks(keyring.Default().WebhookLogKey).Count(ctx, c.opt)
+	if err != nil {
+		return 0, err
+	}
+	return int32(count), nil
+}
+
+func (c *webhooksConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	_, next, err := c.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if next == 0 {
+		return graphqlutil.HasNextPage(false), nil
+	}
+
+	return graphqlutil.NextPageCursor(MarshalWebhookCursor(
+		&types.Cursor{
+			Column:    c.opt.Cursor.Column,
+			Value:     fmt.Sprintf("%d", next),
+			Direction: c.opt.Cursor.Direction,
+		},
+	)), nil
+}
+
+func (c *webhooksConnectionResolver) compute(ctx context.Context) ([]*types.Webhook, int32, error) {
+	c.once.Do(func() {
+		opts := copyOpts(c.opt)
+		if c.opt.LimitOffset != nil {
+			opts.Limit++
+		}
+		c.webhooks, c.err = c.db.Webhooks(keyring.Default().WebhookKey).List(ctx, opts)
+		if c.opt.LimitOffset != nil && opts.Limit != 0 && len(c.webhooks) == opts.Limit {
+			c.next = c.webhooks[len(c.webhooks)-1].ID
+			c.webhooks = c.webhooks[:len(c.webhooks)-1]
+		}
+	})
+	return c.webhooks, c.next, c.err
+}
+
+func copyOpts(opts database.WebhookListOptions) database.WebhookListOptions {
+	copied := database.WebhookListOptions{
+		Kind:   opts.Kind,
+		Cursor: opts.Cursor,
+	}
+	if opts.LimitOffset != nil {
+		limitOffset := database.LimitOffset{
+			Limit:  opts.Limit,
+			Offset: opts.Offset,
+		}
+		copied.LimitOffset = &limitOffset
+	}
+	return copied
+}
+
+var _ graphqlbackend.WebhookResolver = &webhookResolver{}
+
+type webhookResolver struct {
+	db   database.DB
+	hook *types.Webhook
+}
+
+func (r *webhookResolver) ID() graphql.ID {
+	return marshalWebhookID(r.hook.ID)
+}
+
+func (r *webhookResolver) UUID() string {
+	return r.hook.UUID.String()
+}
+
+func (r *webhookResolver) URL() (string, error) {
+	externalURL, err := url.Parse(conf.Get().ExternalURL)
+	if err != nil {
+		return "", errors.Wrap(err, "could not parse site config external URL")
+	}
+	externalURL.Path = fmt.Sprintf(".api/webhooks/%v", r.hook.UUID)
+	return externalURL.String(), nil
+}
+
+func (r *webhookResolver) CodeHostURN() string {
+	return r.hook.CodeHostURN.String()
+}
+
+func (r *webhookResolver) CodeHostKind() string {
+	return r.hook.CodeHostKind
+}
+
+func (r *webhookResolver) Secret(ctx context.Context) (*string, error) {
+	// Secret is optional
+	if r.hook.Secret == nil {
+		return nil, nil
+	}
+	s, err := r.hook.Secret.Decrypt(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func (r *webhookResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.hook.CreatedAt}
+}
+
+func (r *webhookResolver) UpdatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.hook.UpdatedAt}
+}
+
+func (r *webhookResolver) CreatedBy(ctx context.Context) (*graphqlbackend.UserResolver, error) {
+	if r.hook.CreatedByUserID == 0 {
+		return nil, nil
+	}
+
+	user, err := graphqlbackend.UserByIDInt32(ctx, r.db, r.hook.CreatedByUserID)
+	if errcode.IsNotFound(err) {
+		return nil, nil
+	}
+
+	return user, err
+}
+
+func (r *webhookResolver) UpdatedBy(ctx context.Context) (*graphqlbackend.UserResolver, error) {
+	if r.hook.UpdatedByUserID == 0 {
+		return nil, nil
+	}
+
+	user, err := graphqlbackend.UserByIDInt32(ctx, r.db, r.hook.UpdatedByUserID)
+	if errcode.IsNotFound(err) {
+		return nil, nil
+	}
+
+	return user, err
+}
+
+func marshalWebhookID(id int32) graphql.ID {
+	return relay.MarshalID("Webhook", id)
+}
+
+func unmarshalWebhookID(id graphql.ID) (hookID int32, err error) {
+	err = relay.UnmarshalSpec(id, &hookID)
+	return
+}
+
+func MarshalWebhookCursor(cursor *types.Cursor) string {
+	return string(relay.MarshalID(webhookCursorKind, cursor))
+}
+
+func UnmarshalWebhookCursor(cursor *string) (*types.Cursor, error) {
+	if cursor == nil {
+		return nil, nil
+	}
+	if kind := relay.UnmarshalKind(graphql.ID(*cursor)); kind != webhookCursorKind {
+		return nil, errors.Errorf("cannot unmarshal webhook cursor type: %q", kind)
+	}
+	var spec *types.Cursor
+	if err := relay.UnmarshalSpec(graphql.ID(*cursor), &spec); err != nil {
+		return nil, err
+	}
+	return spec, nil
+}

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
@@ -1,4 +1,4 @@
-package graphqlbackend
+package resolvers
 
 import (
 	"context"
@@ -8,8 +8,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 
 	"github.com/google/uuid"
+	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -82,8 +84,8 @@ func TestListWebhooks(t *testing.T) {
 	db := database.NewMockDB()
 	db.WebhooksFunc.SetDefaultReturn(webhookStore)
 	db.UsersFunc.SetDefaultReturn(users)
-	gqlSchema := mustParseGraphQLSchema(t, db)
-	RunTests(t, []*Test{
+	gqlSchema := createGqlSchema(t, db)
+	graphqlbackend.RunTests(t, []*graphqlbackend.Test{
 		{
 			Label:   "basic",
 			Context: ctx,
@@ -259,9 +261,9 @@ func TestWebhooks_CursorPagination(t *testing.T) {
 
 	t.Run("Initial page without a cursor present", func(t *testing.T) {
 		store.ListFunc.SetDefaultReturn(mockWebhooks[0:2], nil)
-		RunTests(t, []*Test{
+		graphqlbackend.RunTests(t, []*graphqlbackend.Test{
 			{
-				Schema: mustParseGraphQLSchema(t, db),
+				Schema: createGqlSchema(t, db),
 				Query:  buildQuery(1, ""),
 				ExpectedResult: `
 				{
@@ -282,8 +284,8 @@ func TestWebhooks_CursorPagination(t *testing.T) {
 	t.Run("Second page", func(t *testing.T) {
 		store.ListFunc.SetDefaultReturn(mockWebhooks[1:], nil)
 
-		RunTest(t, &Test{
-			Schema: mustParseGraphQLSchema(t, db),
+		graphqlbackend.RunTest(t, &graphqlbackend.Test{
+			Schema: createGqlSchema(t, db),
 			Query:  buildQuery(1, "V2ViaG9va0N1cnNvcjp7IkNvbHVtbiI6ImlkIiwiVmFsdWUiOiIxIiwiRGlyZWN0aW9uIjoibmV4dCJ9"),
 			ExpectedResult: `
 				{
@@ -303,8 +305,8 @@ func TestWebhooks_CursorPagination(t *testing.T) {
 	t.Run("Initial page with no further rows to fetch", func(t *testing.T) {
 		store.ListFunc.SetDefaultReturn(mockWebhooks, nil)
 
-		RunTest(t, &Test{
-			Schema: mustParseGraphQLSchema(t, db),
+		graphqlbackend.RunTest(t, &graphqlbackend.Test{
+			Schema: createGqlSchema(t, db),
 			Query:  buildQuery(3, ""),
 			ExpectedResult: `
 				{
@@ -328,8 +330,8 @@ func TestWebhooks_CursorPagination(t *testing.T) {
 	t.Run("With no webhooks present", func(t *testing.T) {
 		store.ListFunc.SetDefaultReturn(nil, nil)
 
-		RunTest(t, &Test{
-			Schema: mustParseGraphQLSchema(t, db),
+		graphqlbackend.RunTest(t, &graphqlbackend.Test{
+			Schema: createGqlSchema(t, db),
 			Query:  buildQuery(1, ""),
 			ExpectedResult: `
 				{
@@ -347,8 +349,8 @@ func TestWebhooks_CursorPagination(t *testing.T) {
 	t.Run("With an invalid cursor provided", func(t *testing.T) {
 		store.ListFunc.SetDefaultReturn(nil, nil)
 
-		RunTest(t, &Test{
-			Schema:         mustParseGraphQLSchema(t, db),
+		graphqlbackend.RunTest(t, &graphqlbackend.Test{
+			Schema:         createGqlSchema(t, db),
 			Query:          buildQuery(1, "invalid-cursor-value"),
 			ExpectedResult: "null",
 			ExpectedErrors: []*errors.QueryError{
@@ -384,13 +386,13 @@ func TestCreateWebhook(t *testing.T) {
 					uuid
 				}
 			}`
-	schema := mustParseGraphQLSchema(t, db)
+	gqlSchema := createGqlSchema(t, db)
 
-	RunTests(t, []*Test{
+	graphqlbackend.RunTests(t, []*graphqlbackend.Test{
 		{
 			Label:   "basic",
 			Context: ctx,
-			Schema:  schema,
+			Schema:  gqlSchema,
 			Query:   queryStr,
 			ExpectedResult: fmt.Sprintf(`
 				{
@@ -408,7 +410,7 @@ func TestCreateWebhook(t *testing.T) {
 		{
 			Label:          "invalid code host",
 			Context:        ctx,
-			Schema:         schema,
+			Schema:         gqlSchema,
 			Query:          queryStr,
 			ExpectedResult: "null",
 			ExpectedErrors: []*errors.QueryError{
@@ -425,7 +427,7 @@ func TestCreateWebhook(t *testing.T) {
 		{
 			Label:          "secrets not supported for code host",
 			Context:        ctx,
-			Schema:         schema,
+			Schema:         gqlSchema,
 			Query:          queryStr,
 			ExpectedResult: "null",
 			ExpectedErrors: []*errors.QueryError{
@@ -444,10 +446,10 @@ func TestCreateWebhook(t *testing.T) {
 
 	// validate error if not site admin
 	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: false}, nil)
-	RunTest(t, &Test{
+	graphqlbackend.RunTest(t, &graphqlbackend.Test{
 		Label:          "only site admin can create webhook",
 		Context:        ctx,
-		Schema:         schema,
+		Schema:         gqlSchema,
 		Query:          queryStr,
 		ExpectedResult: "null",
 		ExpectedErrors: []*errors.QueryError{
@@ -501,9 +503,9 @@ func TestGetWebhookWithURL(t *testing.T) {
                     }
                 }
 			}`
-	gqlSchema := mustParseGraphQLSchema(t, db)
+	gqlSchema := createGqlSchema(t, db)
 
-	RunTest(t, &Test{
+	graphqlbackend.RunTest(t, &graphqlbackend.Test{
 		Label:   "basic",
 		Context: ctx,
 		Schema:  gqlSchema,
@@ -529,7 +531,7 @@ func TestGetWebhookWithURL(t *testing.T) {
 			},
 		},
 	)
-	RunTest(t, &Test{
+	graphqlbackend.RunTest(t, &graphqlbackend.Test{
 		Label:          "error if external URL invalid",
 		Context:        ctx,
 		Schema:         gqlSchema,
@@ -588,13 +590,13 @@ func TestDeleteWebhook(t *testing.T) {
 					alwaysNil
 				}
 			}`
-	schema := mustParseGraphQLSchema(t, db)
+	gqlSchema := createGqlSchema(t, db)
 
 	// validate error if not site admin
-	RunTest(t, &Test{
+	graphqlbackend.RunTest(t, &graphqlbackend.Test{
 		Label:          "only site admin can delete webhook",
 		Context:        ctx,
-		Schema:         schema,
+		Schema:         gqlSchema,
 		Query:          queryStr,
 		ExpectedResult: "null",
 		ExpectedErrors: []*errors.QueryError{
@@ -611,10 +613,10 @@ func TestDeleteWebhook(t *testing.T) {
 	// User is site admin
 	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
 
-	RunTest(t, &Test{
+	graphqlbackend.RunTest(t, &graphqlbackend.Test{
 		Label:          "database error",
 		Context:        ctx,
-		Schema:         schema,
+		Schema:         gqlSchema,
 		Query:          queryStr,
 		ExpectedResult: "null",
 		ExpectedErrors: []*errors.QueryError{
@@ -631,10 +633,10 @@ func TestDeleteWebhook(t *testing.T) {
 	// database layer behaves
 	webhookStore.DeleteFunc.SetDefaultReturn(nil)
 
-	RunTest(t, &Test{
+	graphqlbackend.RunTest(t, &graphqlbackend.Test{
 		Label:   "webhook successfully deleted",
 		Context: ctx,
-		Schema:  schema,
+		Schema:  gqlSchema,
 		Query:   queryStr,
 		ExpectedResult: `
 				{
@@ -647,4 +649,13 @@ func TestDeleteWebhook(t *testing.T) {
 			"id": string(id),
 		},
 	})
+}
+
+func createGqlSchema(t *testing.T, db database.DB) *graphql.Schema {
+	t.Helper()
+	gqlSchema, err := graphqlbackend.NewSchemaWithWebhooksResolver(db, NewWebhooksResolver(db))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return gqlSchema
 }


### PR DESCRIPTION
This PR completes https://github.com/sourcegraph/sourcegraph/issues/43656.

Moving gql resolvers under enterprise package.

Test plan:
Existing test cases should pass after refactoring.