### PR TITLE
gitserver: Pass writeable $HOME to git p4

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -488,7 +488,7 @@ func getVCSSyncer(
 		if _, err := extractOptions(&c); err != nil {
 			return nil, err
 		}
-		p4Home := filepath.Join(reposDir, ".p4home")
+		p4Home := filepath.Join(reposDir, server.P4HomeName)
 		return &server.PerforceDepotSyncer{
 			MaxChanges:   int(c.MaxChanges),
 			Client:       c.P4Client,

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -487,10 +488,12 @@ func getVCSSyncer(
 		if _, err := extractOptions(&c); err != nil {
 			return nil, err
 		}
+		p4Home := filepath.Join(reposDir, ".p4home")
 		return &server.PerforceDepotSyncer{
 			MaxChanges:   int(c.MaxChanges),
 			Client:       c.P4Client,
 			FusionConfig: configureFusionClient(c),
+			P4Home:       p4Home,
 		}, nil
 	case extsvc.TypeJVMPackages:
 		var c schema.JVMPackagesConnection

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -64,6 +64,10 @@ import (
 // tempDirName is the name used for the temporary directory under ReposDir.
 const tempDirName = ".tmp"
 
+// P4HomeName is the name used for the directory that git p4 will use as $HOME
+// and where it will store cache data.
+const P4HomeName = ".p4home"
+
 // traceLogs is controlled via the env SRC_GITSERVER_TRACE. If true we trace
 // logs to stderr
 var traceLogs bool
@@ -919,11 +923,11 @@ func (s *Server) tempDir(prefix string) (name string, err error) {
 }
 
 func (s *Server) ignorePath(path string) bool {
-	// We ignore any path which starts with .tmp in ReposDir
+	// We ignore any path which starts with .tmp or .p4home in ReposDir
 	if filepath.Dir(path) != s.ReposDir {
 		return false
 	}
-	return strings.HasPrefix(filepath.Base(path), tempDirName)
+	return strings.HasPrefix(filepath.Base(path), tempDirName) || strings.HasPrefix(filepath.Base(path), P4HomeName)
 }
 
 func (s *Server) handleIsRepoCloneable(w http.ResponseWriter, r *http.Request) {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -927,7 +927,8 @@ func (s *Server) ignorePath(path string) bool {
 	if filepath.Dir(path) != s.ReposDir {
 		return false
 	}
-	return strings.HasPrefix(filepath.Base(path), tempDirName) || strings.HasPrefix(filepath.Base(path), P4HomeName)
+	base := filepath.Base(path)
+	return strings.HasPrefix(base, tempDirName) || strings.HasPrefix(base, P4HomeName)
 }
 
 func (s *Server) handleIsRepoCloneable(w http.ResponseWriter, r *http.Request) {

--- a/cmd/gitserver/server/vcs_syncer_perforce.go
+++ b/cmd/gitserver/server/vcs_syncer_perforce.go
@@ -178,8 +178,8 @@ func (s *PerforceDepotSyncer) p4CommandEnv(host, username, password string) []st
 	}
 
 	if s.P4Home != "" {
-		// git p4 commands write to $HOME/.gitp4-usercache.txt, we should ensure that
-		// this location is writeable.
+		// git p4 commands write to $HOME/.gitp4-usercache.txt, we should pass in a
+		// directory under our control and ensure that it is writeable.
 		env = append(env, "HOME="+s.P4Home)
 	}
 

--- a/cmd/gitserver/server/vcs_syncer_perforce.go
+++ b/cmd/gitserver/server/vcs_syncer_perforce.go
@@ -19,12 +19,16 @@ type PerforceDepotSyncer struct {
 	// MaxChanges indicates to only import at most n changes when possible.
 	MaxChanges int
 
-	// Client configures the client to use with p4 and enables use of a client spec to
-	// find the list of interesting files in p4.
+	// Client configures the client to use with p4 and enables use of a client spec
+	// to find the list of interesting files in p4.
 	Client string
 
-	// FusionConfig contains information about the experimental p4-fusion client
+	// FusionConfig contains information about the experimental p4-fusion client.
 	FusionConfig FusionConfig
+
+	// P4Home is a directory we will pass to `git p4` commands as the
+	// $HOME directory as it requires this to write cache data.
+	P4Home string
 }
 
 func (s *PerforceDepotSyncer) Type() string {
@@ -96,9 +100,6 @@ func (s *PerforceDepotSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir
 		return errors.Wrap(err, "ping with trust")
 	}
 
-	// Example: git p4 sync --max-changes 1000
-	args := append([]string{"p4", "sync"}, s.p4CommandOptions()...)
-
 	var cmd *exec.Cmd
 	if s.FusionConfig.Enabled {
 		// Example: p4-fusion --path //depot/... --user $P4USER --src clones/ --networkThreads 64 --printBatch 10 --port $P4PORT --lookAhead 2000 --retries 10 --refresh 100
@@ -120,6 +121,8 @@ func (s *PerforceDepotSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir
 			"--noColor", "true",
 		)
 	} else {
+		// Example: git p4 sync --max-changes 1000
+		args := append([]string{"p4", "sync"}, s.p4CommandOptions()...)
 		cmd = exec.CommandContext(ctx, "git", args...)
 	}
 	cmd.Env = s.p4CommandEnv(host, username, password)
@@ -169,9 +172,17 @@ func (s *PerforceDepotSyncer) p4CommandEnv(host, username, password string) []st
 		"P4USER="+username,
 		"P4PASSWD="+password,
 	)
+
 	if s.Client != "" {
 		env = append(env, "P4CLIENT="+s.Client)
 	}
+
+	if s.P4Home != "" {
+		// git p4 commands write to $HOME/.gitp4-usercache.txt, we should ensure that
+		// this location is writeable.
+		env = append(env, "HOME="+s.P4Home)
+	}
+
 	return env
 }
 

--- a/cmd/gitserver/server/vcs_syncer_perforce_test.go
+++ b/cmd/gitserver/server/vcs_syncer_perforce_test.go
@@ -2,10 +2,12 @@ package server
 
 import (
 	"os/exec"
+	"strings"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
 
 func TestDecomposePerforceRemoteURL(t *testing.T) {
@@ -137,4 +139,39 @@ func TestSpecifyCommandInErrorMessage(t *testing.T) {
 			assert.Equal(t, test.expectedMsg, actualMsg)
 		})
 	}
+}
+
+func TestP4DepotSyncer_p4CommandEnv(t *testing.T) {
+	syncer := &PerforceDepotSyncer{
+		Client: "client",
+		P4Home: "p4home",
+	}
+	vars := syncer.p4CommandEnv("host", "username", "password")
+	assertEnv := func(key, value string) {
+		var match string
+		for _, s := range vars {
+			parts := strings.SplitN(s, "=", 2)
+			if len(parts) != 2 {
+				t.Errorf("Expected 2 parts, got %d in %q", len(parts), s)
+				continue
+			}
+			if parts[0] != key {
+				continue
+			}
+			// Last match wins
+			if parts[1] == value {
+				match = parts[1]
+			}
+		}
+		if match == "" {
+			t.Errorf("No match found for %q", key)
+		} else if match != value {
+			t.Errorf("Want %q, got %q", value, match)
+		}
+	}
+	assertEnv("HOME", "p4home")
+	assertEnv("P4CLIENT", "client")
+	assertEnv("P4PORT", "host")
+	assertEnv("P4USER", "username")
+	assertEnv("P4PASSWD", "password")
 }


### PR DESCRIPTION
We need to ensure that `git p4` commands can write to $HOME as they need
to write cache data so we pass it a folder under our default data
directory.

## Test plan

Added unit tests and tested locally