### PR TITLE
usagestats: Fix parens in statistics

### DIFF
--- a/internal/usagestats/ide_extensions.go
+++ b/internal/usagestats/ide_extensions.go
@@ -69,7 +69,22 @@ var ideExtensionsPeriodUsageQuery = `
 			DATE_TRUNC('week', TIMEZONE('UTC', $1::timestamp)) as current_week,
 			DATE_TRUNC('day', TIMEZONE('UTC', $1::timestamp)) as current_day
 		FROM event_logs
-		WHERE timestamp >= DATE_TRUNC('month', TIMEZONE('UTC', $1::timestamp)) AND source = 'IDEEXTENSION' OR (source = 'BACKEND' AND (name LIKE 'IDE%' OR name = 'VSCESearchSubmitted'))
+		WHERE
+			timestamp >= DATE_TRUNC('month', TIMEZONE('UTC', $1::timestamp))
+			AND
+			(
+				source = 'IDEEXTENSION'
+				OR
+				(
+					source = 'BACKEND'
+					AND
+					(
+						name LIKE 'IDE%'
+						OR
+						name = 'VSCESearchSubmitted'
+					)
+				)
+			)
 	)
 	SELECT
 		ide_kind,


### PR DESCRIPTION
The OR condition here seems wrong to me. Before it would be either events in the last month and source=IDEEXTENSION OR any other event where [...]. If this is intended let me know and I will close the PR.

This also drastically improves the queries performance, because it doesn't have to consider ALL events.

**Before:**

```
                                                                                                                    QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 GroupAggregate  (cost=4049127.99..4053381.46 rows=3615 width=128) (actual time=19382.384..19540.410 rows=3 loops=1)
   Group Key: ((event_logs.public_argument ->> 'editor'::text)), (date_trunc('month'::text, timezone('UTC'::text, now()))), (date_trunc('week'::text, timezone('UTC'::text, now()))), (date_trunc('day'::text, timezone('UTC'::text, now())))
   ->  Sort  (cost=4049127.99..4049178.94 rows=20380 width=89) (actual time=19382.098..19528.905 rows=9163 loops=1)
         Sort Key: ((event_logs.public_argument ->> 'editor'::text))
         Sort Method: quicksort  Memory: 1673kB
         ->  Gather  (cost=227497.64..4047669.30 rows=20380 width=89) (actual time=6102.731..19524.589 rows=9163 loops=1)
               Workers Planned: 2
               Workers Launched: 2
               ->  Parallel Bitmap Heap Scan on event_logs  (cost=226497.64..4044631.30 rows=8492 width=89) (actual time=6096.358..19336.929 rows=3054 loops=3)
                     Recheck Cond: (((source = 'IDEEXTENSION'::text) AND ("timestamp" >= date_trunc('month'::text, timezone('UTC'::text, now())))) OR (source = 'BACKEND'::text))
                     Filter: ((("timestamp" >= date_trunc('month'::text, timezone('UTC'::text, now()))) AND (source = 'IDEEXTENSION'::text)) OR ((source = 'BACKEND'::text) AND ((name ~~ 'IDE%'::text) OR (name = 'VSCESearchSubmitted'::text))))
                     Rows Removed by Filter: 4741352
                     Heap Blocks: exact=1055437
                     ->  BitmapOr  (cost=226497.64..226497.64 rows=13692029 width=0) (actual time=3431.338..3431.341 rows=0 loops=1)
                           ->  BitmapAnd  (cost=30847.40..30847.40 rows=5138 width=0) (actual time=591.814..591.815 rows=0 loops=1)
                                 ->  Bitmap Index Scan on event_logs_source  (cost=0.00..1106.37 rows=77334 width=0) (actual time=28.661..28.662 rows=102812 loops=1)
                                       Index Cond: (source = 'IDEEXTENSION'::text)
                                 ->  Bitmap Index Scan on event_logs_timestamp  (cost=0.00..29730.59 rows=2568909 width=0) (actual time=550.600..550.600 rows=3669539 loops=1)
                                       Index Cond: ("timestamp" >= date_trunc('month'::text, timezone('UTC'::text, now())))
                           ->  Bitmap Index Scan on event_logs_source  (cost=0.00..195645.15 rows=13686891 width=0) (actual time=2839.521..2839.522 rows=14309564 loops=1)
                                 Index Cond: (source = 'BACKEND'::text)
 Planning Time: 0.435 ms
 Execution Time: 19541.698 ms
(23 rows)
```

**After:**

```
                                                                                                                  QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 GroupAggregate  (cost=1095453.11..1096801.95 rows=2962 width=128) (actual time=5192.169..5224.053 rows=3 loops=1)
   Group Key: ((event_logs.public_argument ->> 'editor'::text)), (date_trunc('month'::text, timezone('UTC'::text, now()))), (date_trunc('week'::text, timezone('UTC'::text, now()))), (date_trunc('day'::text, timezone('UTC'::text, now())))
   ->  Sort  (cost=1095453.11..1095468.48 rows=6149 width=89) (actual time=5191.819..5212.662 rows=8959 loops=1)
         Sort Key: ((event_logs.public_argument ->> 'editor'::text))
         Sort Method: quicksort  Memory: 1644kB
         ->  Gather  (cost=227486.97..1095066.15 rows=6149 width=89) (actual time=4668.866..5208.266 rows=8959 loops=1)
               Workers Planned: 2
               Workers Launched: 2
               ->  Parallel Bitmap Heap Scan on event_logs  (cost=226486.97..1093451.25 rows=2562 width=89) (actual time=4666.480..5177.181 rows=2986 loops=3)
                     Recheck Cond: (("timestamp" >= date_trunc('month'::text, timezone('UTC'::text, now()))) AND ((source = 'IDEEXTENSION'::text) OR (source = 'BACKEND'::text)))
                     Filter: ((source = 'IDEEXTENSION'::text) OR ((source = 'BACKEND'::text) AND ((name ~~ 'IDE%'::text) OR (name = 'VSCESearchSubmitted'::text))))
                     Rows Removed by Filter: 408431
                     Heap Blocks: exact=115585
                     ->  BitmapAnd  (cost=226486.97..226486.97 rows=914446 width=0) (actual time=4502.954..4502.957 rows=0 loops=1)
                           ->  Bitmap Index Scan on event_logs_timestamp  (cost=0.00..29730.59 rows=2568909 width=0) (actual time=637.512..637.512 rows=3668593 loops=1)
                                 Index Cond: ("timestamp" >= date_trunc('month'::text, timezone('UTC'::text, now())))
                           ->  BitmapOr  (cost=196754.59..196754.59 rows=13764226 width=0) (actual time=3798.767..3798.768 rows=0 loops=1)
                                 ->  Bitmap Index Scan on event_logs_source  (cost=0.00..1106.37 rows=77334 width=0) (actual time=29.210..29.210 rows=102803 loops=1)
                                       Index Cond: (source = 'IDEEXTENSION'::text)
                                 ->  Bitmap Index Scan on event_logs_source  (cost=0.00..195645.15 rows=13686891 width=0) (actual time=3769.554..3769.555 rows=14309313 loops=1)
                                       Index Cond: (source = 'BACKEND'::text)
 Planning Time: 0.692 ms
 Execution Time: 5224.335 ms
(23 rows)
```



## Test plan

Relying on code review.