### PR TITLE
graphql: Add helper to build schema without resolvers

### DIFF
--- a/cmd/frontend/graphqlbackend/executor_secrets_test.go
+++ b/cmd/frontend/graphqlbackend/executor_secrets_test.go
@@ -573,7 +573,7 @@ func TestExecutorSecretsIntegration(t *testing.T) {
 		t.Fatal("invalid number of access logs found in DB")
 	}
 
-	s, err := NewSchema(db, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s, err := NewSchemaWithoutResolvers(db)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -311,6 +311,10 @@ func prometheusGraphQLRequestName(requestName string) string {
 	return "other"
 }
 
+func NewSchemaWithoutResolvers(db database.DB) (*graphql.Schema, error) {
+	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+}
+
 func NewSchemaWithNotebooksResolver(db database.DB, notebooks NotebooksResolver) (*graphql.Schema, error) {
 	return NewSchema(db, gitserver.NewClient(db), nil, nil, nil, nil, nil, nil, nil, nil, notebooks, nil, nil)
 }


### PR DESCRIPTION
Another chain of `nil`s gone

## Test plan

- N/A