### PR TITLE
ranking: set RanksDampingFactor

### DIFF
--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -245,6 +245,7 @@ func ToFeatures(flagSet *featureflag.FlagSet, logger log.Logger) *search.Feature
 		HybridSearch:            flagSet.GetBoolOr("search-hybrid", false),
 		AbLuckySearch:           flagSet.GetBoolOr("ab-lucky-search", false),
 		Ranking:                 flagSet.GetBoolOr("search-ranking", false),
+		RankingDampDocRanks:     flagSet.GetBoolOr("search-ranking-damp-doc-ranks", false),
 		Debug:                   flagSet.GetBoolOr("search-debug", false),
 	}
 }

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -345,6 +345,10 @@ type Features struct {
 	// Debug when true will set the Debug field on FileMatches. This may grow
 	// from here. For now we treat this like a feature flag for convenience.
 	Debug bool `json:"debug"`
+
+	// RankingDampDocRanks if true will damp the influence of document
+	// ranks on the final ranking.
+	RankingDampDocRanks bool `json:"search-ranking-damp-doc-ranks"`
 }
 
 func (f *Features) String() string {

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -140,6 +140,11 @@ func (o *Options) ToSearch(ctx context.Context) *zoekt.SearchOptions {
 		// This enables the use of PageRank scores if they are available.
 		searchOpts.UseDocumentRanks = true
 
+		// This damps the impact of document ranks on the final ranking.
+		if o.Features.RankingDampDocRanks {
+			searchOpts.RanksDampingFactor = 0.5
+		}
+
 		return searchOpts
 	}
 


### PR DESCRIPTION
This damps the impact of document ranks on the final ranking.

We set the damping factor to 0.5, which increases the correlation of the final ranking to the purely score-based ranking from now 0.6 to 0.75.

![image](https://user-images.githubusercontent.com/26413131/201066749-62477173-d3e7-41f4-9734-f4eaa5946ad7.png)


## Test plan
- CI
- The change is behind a feature flag