### PR TITLE
CodeMirror blob: Request hover data and document highlights based on lsif/scip data

### DIFF
--- a/client/web/src/lsif/html.ts
+++ b/client/web/src/lsif/html.ts
@@ -2,6 +2,8 @@ import escape from 'escape-html'
 
 import { DocumentInfo, Occurrence, SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
 
+import { toCSSClassName } from './utils'
+
 class HtmlBuilder {
     public readonly buffer: string[] = []
     public plaintext(value: string): void {
@@ -59,9 +61,9 @@ function closeLine(html: HtmlBuilder): void {
 
 function highlightSlice(html: HtmlBuilder, kind: SyntaxKind | undefined, slice: string): void {
     if (kind) {
-        const kindName = SyntaxKind[kind]
-        if (kindName) {
-            html.span(`class="hl-typed-${kindName}"`, slice)
+        const className = toCSSClassName(kind)
+        if (className) {
+            html.span(`class="${className}"`, slice)
             return
         }
     }

--- a/client/web/src/lsif/utils.ts
+++ b/client/web/src/lsif/utils.ts
@@ -1,0 +1,11 @@
+import { SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
+
+/**
+ * Returns the corresponding CSS class name for the provided syntax kind.
+ * Returns an empty string if the provided kind does not exist (which could
+ * happen since this data usually comes from the server).
+ */
+export function toCSSClassName(kind: SyntaxKind): string {
+    const kindName = SyntaxKind[kind]
+    return kindName ? `hl-typed-${kindName}` : ''
+}

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -24,7 +24,7 @@ import { useExperimentalFeatures } from '../../stores'
 import { BlobInfo, BlobProps, updateBrowserHistoryIfChanged } from './Blob'
 import { blobPropsFacet } from './codemirror'
 import { showBlameGutter, showGitBlameDecorations } from './codemirror/blame-decorations'
-import { syntaxHighlight } from './codemirror/highlight'
+import { lsifData } from './codemirror/highlight'
 import { pin, updatePin } from './codemirror/hovercard'
 import { selectableLineNumbers, SelectedLineRange, selectLines } from './codemirror/linenumbers'
 import { search } from './codemirror/search'
@@ -192,7 +192,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
                       preloadGoToDefinition,
                   })
                 : [],
-            syntaxHighlight.of(blobInfo),
+            lsifData.of(blobInfo),
             pin.init(() => (hasPin ? position : null)),
             extensionsController !== null && !navigateToLineOnAnyClick
                 ? sourcegraphExtensions({

--- a/client/web/src/repo/blob/codemirror/highlight.ts
+++ b/client/web/src/repo/blob/codemirror/highlight.ts
@@ -6,24 +6,14 @@ import { Occurrence, SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
 
 import { BlobInfo } from '../Blob'
 
-import { positionToOffset } from './utils'
-
-/**
- * This data structure combines the syntax highlighting data received from the
- * server with a lineIndex map (implemented as array), for fast lookup by line
- * number, with minimal additional impact on memory (e.g. garbage collection).
- */
-interface HighlightIndex {
-    occurrences: Occurrence[]
-    lineIndex: (number | undefined)[]
-}
+import { positionToOffset, OccurrenceIndex } from './utils'
 
 /**
  * Parses JSON-encoded SCIP syntax highlighting data and creates a line index.
  * NOTE: This assumes that the data is sorted and does not contain overlapping
  * ranges.
  */
-function createHighlightTable(info: BlobInfo): HighlightIndex {
+function createHighlightTable(info: BlobInfo): OccurrenceIndex {
     const lineIndex: (number | undefined)[] = []
 
     if (!info.lsif) {
@@ -80,7 +70,7 @@ class SyntaxHighlightManager implements PluginValue {
             const fromLine = view.state.doc.lineAt(from)
             const toLine = view.state.doc.lineAt(to)
 
-            const { occurrences, lineIndex } = view.state.facet(syntaxHighlight)
+            const { occurrences, lineIndex } = view.state.facet(lsifData)
 
             // Find index of first relevant token
             let startIndex: number | undefined
@@ -147,7 +137,7 @@ class SyntaxHighlightManager implements PluginValue {
  * Facet for providing syntax highlighting information from a {@link BlobInfo}
  * object.
  */
-export const syntaxHighlight = Facet.define<BlobInfo, HighlightIndex>({
+export const lsifData = Facet.define<BlobInfo, OccurrenceIndex>({
     static: true,
     compareInput: (blobInfoA, blobInfoB) => blobInfoA.lsif === blobInfoB.lsif,
     combine: blobInfos =>

--- a/client/web/src/repo/blob/codemirror/highlight.ts
+++ b/client/web/src/repo/blob/codemirror/highlight.ts
@@ -4,6 +4,7 @@ import { Decoration, DecorationSet, EditorView, PluginValue, ViewPlugin, ViewUpd
 import { logger } from '@sourcegraph/common'
 import { Occurrence, SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
 
+import { toCSSClassName } from '../../../lsif/utils'
 import { BlobInfo } from '../Blob'
 
 import { positionToOffset, OccurrenceIndex } from './utils'
@@ -121,7 +122,7 @@ class SyntaxHighlightManager implements PluginValue {
                     const decoration =
                         this.decorationCache[occurrence.kind] ||
                         (this.decorationCache[occurrence.kind] = Decoration.mark({
-                            class: `hl-typed-${SyntaxKind[occurrence.kind]}`,
+                            class: toCSSClassName(occurrence.kind),
                         }))
                     builder.add(from, to, decoration)
                 }

--- a/client/web/src/repo/blob/codemirror/hovercard.tsx
+++ b/client/web/src/repo/blob/codemirror/hovercard.tsx
@@ -64,7 +64,6 @@ import {
     LineOrPositionOrRange,
     toPositionOrRangeQueryParameter,
 } from '@sourcegraph/common'
-import { SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
 import { createUpdateableField } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 import { UIPositionSpec, UIRangeSpec } from '@sourcegraph/shared/src/util/url'
 
@@ -87,6 +86,7 @@ import {
     zeroToOneBasedPosition,
     findLsifOccurenceAt,
     HOVER_DEBOUNCE_TIME,
+    isInteractiveOccurrence,
 } from './utils'
 
 import { blobPropsFacet } from './index'
@@ -733,11 +733,6 @@ const hoverdataCache = ViewPlugin.fromClass(
 )
 
 /**
- * Syntax kinds for which we don't want to request hover data.
- */
-const syntaxKindBlockList = new Set([SyntaxKind.Comment, SyntaxKind.IdentifierKeyword, SyntaxKind.IdentifierOperator])
-
-/**
  * Helper operator for requesting hover information and creating a {@link Hovercard}
  * object.
  */
@@ -756,7 +751,7 @@ function tokenRangeToHovercard(
                 const validOccurenceAtPosition = findLsifOccurenceAt(
                     view.state.facet(lsifData),
                     { line: lineCharacterRange.start.line - 1, character: lineCharacterRange.start.character - 1 },
-                    occurence => !occurence?.kind || !syntaxKindBlockList.has(occurence.kind)
+                    occurence => isInteractiveOccurrence(occurence)
                 )
                 if (!validOccurenceAtPosition) {
                     return of(null)

--- a/client/web/src/repo/blob/codemirror/hovercard.tsx
+++ b/client/web/src/repo/blob/codemirror/hovercard.tsx
@@ -311,7 +311,7 @@ const pinManager = ViewPlugin.fromClass(
             this.subscription = this.nextPin
                 .pipe(
                     map(pin => {
-                        if (!pin || !pin.line || !pin.character) {
+                        if (pin?.line === undefined || pin?.character === undefined) {
                             return null
                         }
 

--- a/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
+++ b/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
@@ -34,7 +34,7 @@ import { BlobInfo, BlobProps } from '../Blob'
 
 import { documentHighlightsSource } from './document-highlights'
 import { showTextDocumentDecorations } from './extensions-decorations'
-import { hovercardSource } from './hovercard'
+import { hoverDataSource } from './hovercard'
 import { SelectedLineRange, selectedLines } from './linenumbers'
 import { Container } from './react-interop'
 
@@ -259,11 +259,11 @@ class SelectionManager implements PluginValue {
 //
 
 /**
- * hovercardDataSource uses the {@link hovercardSource} facet to provide a
+ * hovercardDataSource uses the {@link hoverDataSource} facet to provide a
  * callback function for querying the extension API for hover data.
  */
 function hovercardDataSource(context: Observable<Context>): Extension {
-    return hovercardSource.of(
+    return hoverDataSource.of(
         (
             view: EditorView,
             position: UIPositionSpec['position']

--- a/client/web/src/repo/blob/codemirror/tokens-as-links.ts
+++ b/client/web/src/repo/blob/codemirror/tokens-as-links.ts
@@ -6,13 +6,14 @@ import { concatMap, debounceTime, map } from 'rxjs/operators'
 import { DeepNonNullable } from 'utility-types'
 
 import { logger, toPositionOrRangeQueryParameter } from '@sourcegraph/common'
-import { Occurrence, SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
+import { Occurrence } from '@sourcegraph/shared/src/codeintel/scip'
 import { toPrettyBlobURL, UIRange } from '@sourcegraph/shared/src/util/url'
 
 import { BlobInfo } from '../Blob'
 import { DefinitionResponse, fetchDefinitionsFromRanges } from '../definitions'
 
 import { SelectedLineRange, selectedLines } from './linenumbers'
+import { isInteractiveOccurrence } from './utils'
 
 interface TokenLink {
     range: UIRange
@@ -242,35 +243,6 @@ interface TokensAsLinksConfiguration {
     history: History
     blobInfo: BlobInfo
     preloadGoToDefinition: boolean
-}
-
-/**
- * Occurrences that are possibly interactive (i.e. they can have code intelligence).
- */
-const INTERACTIVE_OCCURRENCE_KINDS = new Set([
-    SyntaxKind.Identifier,
-    SyntaxKind.IdentifierBuiltin,
-    SyntaxKind.IdentifierConstant,
-    SyntaxKind.IdentifierMutableGlobal,
-    SyntaxKind.IdentifierParameter,
-    SyntaxKind.IdentifierLocal,
-    SyntaxKind.IdentifierShadowed,
-    SyntaxKind.IdentifierModule,
-    SyntaxKind.IdentifierFunction,
-    SyntaxKind.IdentifierFunctionDefinition,
-    SyntaxKind.IdentifierMacro,
-    SyntaxKind.IdentifierMacroDefinition,
-    SyntaxKind.IdentifierType,
-    SyntaxKind.IdentifierBuiltinType,
-    SyntaxKind.IdentifierAttribute,
-])
-
-const isInteractiveOccurrence = (occurence: Occurrence): boolean => {
-    if (!occurence.kind) {
-        return false
-    }
-
-    return INTERACTIVE_OCCURRENCE_KINDS.has(occurence.kind)
 }
 
 export const tokensAsLinks = ({ history, blobInfo, preloadGoToDefinition }: TokensAsLinksConfiguration): Extension => {

--- a/client/web/src/repo/blob/codemirror/utils.ts
+++ b/client/web/src/repo/blob/codemirror/utils.ts
@@ -2,7 +2,7 @@ import { Line, Text } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
 
 import { Position } from '@sourcegraph/extension-api-types'
-import { Occurrence } from '@sourcegraph/shared/src/codeintel/scip'
+import { Occurrence, SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
 import { UIPositionSpec, UIRangeSpec } from '@sourcegraph/shared/src/util/url'
 
 /**
@@ -238,4 +238,33 @@ export function findLsifOccurenceAt(
     }
 
     return null
+}
+
+/**
+ * Occurrences that are possibly interactive (i.e. they can have code intelligence).
+ */
+const INTERACTIVE_OCCURRENCE_KINDS = new Set([
+    SyntaxKind.Identifier,
+    SyntaxKind.IdentifierBuiltin,
+    SyntaxKind.IdentifierConstant,
+    SyntaxKind.IdentifierMutableGlobal,
+    SyntaxKind.IdentifierParameter,
+    SyntaxKind.IdentifierLocal,
+    SyntaxKind.IdentifierShadowed,
+    SyntaxKind.IdentifierModule,
+    SyntaxKind.IdentifierFunction,
+    SyntaxKind.IdentifierFunctionDefinition,
+    SyntaxKind.IdentifierMacro,
+    SyntaxKind.IdentifierMacroDefinition,
+    SyntaxKind.IdentifierType,
+    SyntaxKind.IdentifierBuiltinType,
+    SyntaxKind.IdentifierAttribute,
+])
+
+export const isInteractiveOccurrence = (occurence: Occurrence): boolean => {
+    if (!occurence.kind) {
+        return false
+    }
+
+    return INTERACTIVE_OCCURRENCE_KINDS.has(occurence.kind)
 }


### PR DESCRIPTION
This updates the hovercard and document highlights implementation to only request data for a position when we know that an "eligible" token is at that position.

Note that this will still _not_ show "No hover information available" reliably because this state needs some design love.

## Test plan

Hovered of tokens and verified that no requests are made for comments and keywords.

## App preview:

- [Web](https://sg-web-fkling-cm-blob-use-scip-data.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
