### PR TITLE
rockskip: Search last indexed commit

### DIFF
--- a/enterprise/cmd/symbols/main.go
+++ b/enterprise/cmd/symbols/main.go
@@ -100,7 +100,7 @@ func SetupRockskip(observationContext *observation.Context, gitserverClient symb
 	createParser := func() (ctags.Parser, error) {
 		return symbolsParser.SpawnCtags(log.Scoped("parser", "ctags parser"), config.Ctags)
 	}
-	server, err := rockskip.NewService(codeintelDB, gitserverClient, repositoryFetcher, createParser, config.MaxConcurrentlyIndexing, config.MaxRepos, config.LogQueries, config.IndexRequestsQueueSize, config.SymbolsCacheSize, config.PathSymbolsCacheSize)
+	server, err := rockskip.NewService(codeintelDB, gitserverClient, repositoryFetcher, createParser, config.MaxConcurrentlyIndexing, config.MaxRepos, config.LogQueries, config.IndexRequestsQueueSize, config.SymbolsCacheSize, config.PathSymbolsCacheSize, config.SearchLastIndexedCommit)
 	if err != nil {
 		return nil, nil, nil, config.Ctags.Command, err
 	}
@@ -117,6 +117,7 @@ type RockskipConfig struct {
 	MaxConcurrentlyIndexing int
 	SymbolsCacheSize        int
 	PathSymbolsCacheSize    int
+	SearchLastIndexedCommit bool
 }
 
 func LoadRockskipConfig(baseConfig env.BaseConfig) RockskipConfig {
@@ -129,6 +130,7 @@ func LoadRockskipConfig(baseConfig env.BaseConfig) RockskipConfig {
 		MaxConcurrentlyIndexing: baseConfig.GetInt("MAX_CONCURRENTLY_INDEXING", "4", "maximum number of repositories being indexed at a time (also limits ctags processes)"),
 		SymbolsCacheSize:        baseConfig.GetInt("SYMBOLS_CACHE_SIZE", "100000", "how many tuples of (path, symbol name, int ID) to cache in memory"),
 		PathSymbolsCacheSize:    baseConfig.GetInt("PATH_SYMBOLS_CACHE_SIZE", "10000", "how many sets of symbols for files to cache in memory"),
+		SearchLastIndexedCommit: baseConfig.GetBool("SEARCH_LAST_INDEXED_COMMIT", "false", "falls back to searching the most recently indexed commit if the requested commit is not indexed"),
 	}
 }
 

--- a/enterprise/internal/rockskip/server_test.go
+++ b/enterprise/internal/rockskip/server_test.go
@@ -114,7 +114,7 @@ func TestIndex(t *testing.T) {
 
 	createParser := func() (ctags.Parser, error) { return mockParser{}, nil }
 
-	service, err := NewService(db, git, newMockRepositoryFetcher(git), createParser, 1, 1, false, 1, 1, 1)
+	service, err := NewService(db, git, newMockRepositoryFetcher(git), createParser, 1, 1, false, 1, 1, 1, false)
 	fatalIfError(err, "NewService")
 
 	verifyBlobs := func() {


### PR DESCRIPTION
- Resolves https://github.com/sourcegraph/sourcegraph/issues/43889

This searches the last commit if the current commit has not been indexed yet, sacrificing correctness of results for speed. Enabled via:

```
env SEARCH_LAST_INDEXED_COMMIT=true ...
```

## Test plan

Ran locally