### PR TITLE
gitserver: Pass writeable $HOME to git p4

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -478,7 +478,13 @@ func getVCSSyncer(
 		if _, err := extractOptions(&c); err != nil {
 			return nil, err
 		}
+
 		p4Home := filepath.Join(reposDir, server.P4HomeName)
+		// Ensure the directory exists
+		if err := os.MkdirAll(p4Home, os.ModePerm); err != nil {
+			return nil, errors.Wrapf(err, "ensuring p4Home exists: %q", p4Home)
+		}
+
 		return &server.PerforceDepotSyncer{
 			MaxChanges:   int(c.MaxChanges),
 			Client:       c.P4Client,

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -477,10 +478,12 @@ func getVCSSyncer(
 		if _, err := extractOptions(&c); err != nil {
 			return nil, err
 		}
+		p4Home := filepath.Join(reposDir, server.P4HomeName)
 		return &server.PerforceDepotSyncer{
 			MaxChanges:   int(c.MaxChanges),
 			Client:       c.P4Client,
 			FusionConfig: configureFusionClient(c),
+			P4Home:       p4Home,
 		}, nil
 	case extsvc.TypeJVMPackages:
 		var c schema.JVMPackagesConnection

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -64,6 +64,10 @@ import (
 // tempDirName is the name used for the temporary directory under ReposDir.
 const tempDirName = ".tmp"
 
+// P4HomeName is the name used for the directory that git p4 will use as $HOME
+// and where it will store cache data.
+const P4HomeName = ".p4home"
+
 // traceLogs is controlled via the env SRC_GITSERVER_TRACE. If true we trace
 // logs to stderr
 var traceLogs bool
@@ -938,11 +942,12 @@ func (s *Server) tempDir(prefix string) (name string, err error) {
 }
 
 func (s *Server) ignorePath(path string) bool {
-	// We ignore any path which starts with .tmp in ReposDir
+	// We ignore any path which starts with .tmp or .p4home in ReposDir
 	if filepath.Dir(path) != s.ReposDir {
 		return false
 	}
-	return strings.HasPrefix(filepath.Base(path), tempDirName)
+	base := filepath.Base(path)
+	return strings.HasPrefix(base, tempDirName) || strings.HasPrefix(base, P4HomeName)
 }
 
 func (s *Server) handleIsRepoCloneable(w http.ResponseWriter, r *http.Request) {

--- a/cmd/gitserver/server/vcs_syncer_perforce.go
+++ b/cmd/gitserver/server/vcs_syncer_perforce.go
@@ -177,11 +177,14 @@ func (s *PerforceDepotSyncer) p4CommandEnv(host, username, password string) []st
 		env = append(env, "P4CLIENT="+s.Client)
 	}
 
-	if s.P4Home != "" {
-		// git p4 commands write to $HOME/.gitp4-usercache.txt, we should pass in a
-		// directory under our control and ensure that it is writeable.
-		env = append(env, "HOME="+s.P4Home)
-	}
+	// TODO: Temporarily comment out to confirm this is the part that is breaking
+	//  integration tests
+
+	//if s.P4Home != "" {
+	//	// git p4 commands write to $HOME/.gitp4-usercache.txt, we should pass in a
+	//	// directory under our control and ensure that it is writeable.
+	//	env = append(env, "HOME="+s.P4Home)
+	//}
 
 	return env
 }

--- a/cmd/gitserver/server/vcs_syncer_perforce.go
+++ b/cmd/gitserver/server/vcs_syncer_perforce.go
@@ -177,14 +177,11 @@ func (s *PerforceDepotSyncer) p4CommandEnv(host, username, password string) []st
 		env = append(env, "P4CLIENT="+s.Client)
 	}
 
-	// TODO: Temporarily comment out to confirm this is the part that is breaking
-	//  integration tests
-
-	//if s.P4Home != "" {
-	//	// git p4 commands write to $HOME/.gitp4-usercache.txt, we should pass in a
-	//	// directory under our control and ensure that it is writeable.
-	//	env = append(env, "HOME="+s.P4Home)
-	//}
+	if s.P4Home != "" {
+		// git p4 commands write to $HOME/.gitp4-usercache.txt, we should pass in a
+		// directory under our control and ensure that it is writeable.
+		env = append(env, "HOME="+s.P4Home)
+	}
 
 	return env
 }

--- a/cmd/gitserver/server/vcs_syncer_perforce_test.go
+++ b/cmd/gitserver/server/vcs_syncer_perforce_test.go
@@ -2,10 +2,12 @@ package server
 
 import (
 	"os/exec"
+	"strings"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
 
 func TestDecomposePerforceRemoteURL(t *testing.T) {
@@ -137,4 +139,39 @@ func TestSpecifyCommandInErrorMessage(t *testing.T) {
 			assert.Equal(t, test.expectedMsg, actualMsg)
 		})
 	}
+}
+
+func TestP4DepotSyncer_p4CommandEnv(t *testing.T) {
+	syncer := &PerforceDepotSyncer{
+		Client: "client",
+		P4Home: "p4home",
+	}
+	vars := syncer.p4CommandEnv("host", "username", "password")
+	assertEnv := func(key, value string) {
+		var match string
+		for _, s := range vars {
+			parts := strings.SplitN(s, "=", 2)
+			if len(parts) != 2 {
+				t.Errorf("Expected 2 parts, got %d in %q", len(parts), s)
+				continue
+			}
+			if parts[0] != key {
+				continue
+			}
+			// Last match wins
+			if parts[1] == value {
+				match = parts[1]
+			}
+		}
+		if match == "" {
+			t.Errorf("No match found for %q", key)
+		} else if match != value {
+			t.Errorf("Want %q, got %q", value, match)
+		}
+	}
+	assertEnv("HOME", "p4home")
+	assertEnv("P4CLIENT", "client")
+	assertEnv("P4PORT", "host")
+	assertEnv("P4USER", "username")
+	assertEnv("P4PASSWD", "password")
 }

--- a/cmd/gitserver/server/vcs_syncer_perforce_test.go
+++ b/cmd/gitserver/server/vcs_syncer_perforce_test.go
@@ -142,9 +142,6 @@ func TestSpecifyCommandInErrorMessage(t *testing.T) {
 }
 
 func TestP4DepotSyncer_p4CommandEnv(t *testing.T) {
-	// TODO: Temporary, remove skip
-	t.Skip()
-
 	syncer := &PerforceDepotSyncer{
 		Client: "client",
 		P4Home: "p4home",

--- a/cmd/gitserver/server/vcs_syncer_perforce_test.go
+++ b/cmd/gitserver/server/vcs_syncer_perforce_test.go
@@ -142,6 +142,9 @@ func TestSpecifyCommandInErrorMessage(t *testing.T) {
 }
 
 func TestP4DepotSyncer_p4CommandEnv(t *testing.T) {
+	// TODO: Temporary, remove skip
+	t.Skip()
+
 	syncer := &PerforceDepotSyncer{
 		Client: "client",
 		P4Home: "p4home",


### PR DESCRIPTION
We need to ensure that `git p4` commands can write to $HOME as they need to 
write cache data so we pass it a folder under our default data directory.

This is a followup to a previous PR that needed to be reverted since it failed
during integration tests. It appears that the issue may have been that the  
directory needs to exist before we can tell `git p4` to use it.

## Test plan

Integration tests must pass 3 times in a row.
