### PR TITLE
Prepare for 4.2 release

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -14,7 +14,7 @@
     "captainSlackUsername": "bolaji",
     "captainGitHubUsername": "BolajiOlajide",
     // Release versions
-    "previousRelease": "4.1.2",
+    "previousRelease": "4.1.3",
     "upcomingRelease": "4.2.0",
     "oneWorkingWeekBeforeRelease": "14 November 2022 10:00 PST",
     "threeWorkingDaysBeforeRelease": "16 November 2022 10:00 PST",

--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -11,16 +11,16 @@
 {
     // Captain information
     // To get your slack username, navigate to Profile -> More -> Account settings -> Username (at the bottom) -> Expand
-    "captainSlackUsername": "philipp.spiess",
-    "captainGitHubUsername": "philipp-spiess",
+    "captainSlackUsername": "bolaji",
+    "captainGitHubUsername": "BolajiOlajide",
     // Release versions
     "previousRelease": "4.1.2",
-    "upcomingRelease": "4.1.3",
-    "oneWorkingWeekBeforeRelease": "1 November 2022 10:00 PST",
-    "threeWorkingDaysBeforeRelease": "3 November 2022 10:00 PST",
-    "releaseDate": "8 November 2022 10:00 PST",
-    "oneWorkingDayAfterRelease": "9 November 2022 10:00 PST",
-    "oneWorkingWeekAfterRelease": "15 November 2022 10:00 PST",
+    "upcomingRelease": "4.2.0",
+    "oneWorkingWeekBeforeRelease": "14 November 2022 10:00 PST",
+    "threeWorkingDaysBeforeRelease": "16 November 2022 10:00 PST",
+    "releaseDate": "21 November 2022 10:00 PST",
+    "oneWorkingDayAfterRelease": "22 November 2022 10:00 PST",
+    "oneWorkingWeekAfterRelease": "28 November 2022 10:00 PST",
     // Channel where messages from the tooling are posted
     "slackAnnounceChannel": "eng-announce",
     // Email for preparing calendar events


### PR DESCRIPTION
Closes #44078

This basically just reverts my changes from #44073

## Test plan

release process 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-prepare-4-2-release.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
