### PR TITLE
monitoring: change disk metrics sampling duration to 1m

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -5568,7 +5568,7 @@ Query: `sum by (instance) (src_gitserver_search_running{instance=~`${shard:regex
 
 #### gitserver: repos_disk_reads_sec
 
-<p class="subtitle">Read request rate over 2m (per instance)</p>
+<p class="subtitle">Read request rate over 1m (per instance)</p>
 
 The number of read requests that were issued to the device per second.
 
@@ -5583,7 +5583,7 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10060
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -5591,7 +5591,7 @@ Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",ins
 
 #### gitserver: repos_disk_writes_sec
 
-<p class="subtitle">Write request rate over 2m (per instance)</p>
+<p class="subtitle">Write request rate over 1m (per instance)</p>
 
 The number of write requests that were issued to the device per second.
 
@@ -5606,7 +5606,7 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10060
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -5614,7 +5614,7 @@ Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",ins
 
 #### gitserver: repos_disk_read_throughput
 
-<p class="subtitle">Read throughput over 2m (per instance)</p>
+<p class="subtitle">Read throughput over 1m (per instance)</p>
 
 The amount of data that was read from the device per second.
 
@@ -5629,7 +5629,7 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10061
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -5637,7 +5637,7 @@ Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",ins
 
 #### gitserver: repos_disk_write_throughput
 
-<p class="subtitle">Write throughput over 2m (per instance)</p>
+<p class="subtitle">Write throughput over 1m (per instance)</p>
 
 The amount of data that was written to the device per second.
 
@@ -5652,7 +5652,7 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10061
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -5660,7 +5660,7 @@ Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",ins
 
 #### gitserver: repos_disk_read_duration
 
-<p class="subtitle">Average read duration over 2m (per instance)</p>
+<p class="subtitle">Average read duration over 1m (per instance)</p>
 
 The average time for read requests issued to the device to be served. This includes the time spent by the requests in queue and the time spent servicing them.
 
@@ -5675,7 +5675,7 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10062
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_time_seconds_total{instance=~`node-exporter.*`}[2m])))))) / ((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m])))))))`
+Query: `(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_time_seconds_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))))`
 
 </details>
 
@@ -5683,7 +5683,7 @@ Query: `(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",i
 
 #### gitserver: repos_disk_write_duration
 
-<p class="subtitle">Average write duration over 2m (per instance)</p>
+<p class="subtitle">Average write duration over 1m (per instance)</p>
 
 The average time for write requests issued to the device to be served. This includes the time spent by the requests in queue and the time spent servicing them.
 
@@ -5698,7 +5698,7 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10062
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_write_time_seconds_total{instance=~`node-exporter.*`}[2m])))))) / ((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m])))))))`
+Query: `(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_write_time_seconds_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))))`
 
 </details>
 
@@ -5706,7 +5706,7 @@ Query: `(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",i
 
 #### gitserver: repos_disk_read_request_size
 
-<p class="subtitle">Average read request size over 2m (per instance)</p>
+<p class="subtitle">Average read request size over 1m (per instance)</p>
 
 The average size of read requests that were issued to the device.
 
@@ -5721,7 +5721,7 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10063
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[2m])))))) / ((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m])))))))`
+Query: `(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))))`
 
 </details>
 
@@ -5729,7 +5729,7 @@ Query: `(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",i
 
 #### gitserver: repos_disk_write_request_size)
 
-<p class="subtitle">Average write request size over 2m (per instance)</p>
+<p class="subtitle">Average write request size over 1m (per instance)</p>
 
 The average size of write requests that were issued to the device.
 
@@ -5744,7 +5744,7 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10063
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[2m])))))) / ((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m])))))))`
+Query: `(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))))`
 
 </details>
 
@@ -5752,7 +5752,7 @@ Query: `(((max by (instance) (gitserver_mount_point_info{mount_name="reposDir",i
 
 #### gitserver: repos_disk_reads_merged_sec
 
-<p class="subtitle">Merged read request rate over 2m (per instance)</p>
+<p class="subtitle">Merged read request rate over 1m (per instance)</p>
 
 The number of read requests merged per second that were queued to the device.
 
@@ -5767,7 +5767,7 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10064
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_merged_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_merged_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -5775,7 +5775,7 @@ Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",ins
 
 #### gitserver: repos_disk_writes_merged_sec
 
-<p class="subtitle">Merged writes request rate over 2m (per instance)</p>
+<p class="subtitle">Merged writes request rate over 1m (per instance)</p>
 
 The number of write requests merged per second that were queued to the device.
 
@@ -5790,7 +5790,7 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10064
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_merged_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_merged_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -5798,7 +5798,7 @@ Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",ins
 
 #### gitserver: repos_disk_average_queue_size
 
-<p class="subtitle">Average queue size over 2m (per instance)</p>
+<p class="subtitle">Average queue size over 1m (per instance)</p>
 
 The number of I/O operations that were being queued or being serviced. See https://blog.actorsfit.com/a?ID=00200-428fa2ac-e338-4540-848c-af9a3eb1ebd2 for background (avgqu-sz).
 
@@ -5813,7 +5813,7 @@ To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=10065
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_io_time_weighted_seconds_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (gitserver_mount_point_info{mount_name="reposDir",instance=~`${shard:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_io_time_weighted_seconds_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -14244,7 +14244,7 @@ Query: `sum by(instance) (rate(searcher_service_request_total[10m]))`
 
 #### searcher: cache_disk_reads_sec
 
-<p class="subtitle">Read request rate over 2m (per instance)</p>
+<p class="subtitle">Read request rate over 1m (per instance)</p>
 
 The number of read requests that were issued to the device per second.
 
@@ -14259,7 +14259,7 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100100`
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -14267,7 +14267,7 @@ Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",inst
 
 #### searcher: cache_disk_writes_sec
 
-<p class="subtitle">Write request rate over 2m (per instance)</p>
+<p class="subtitle">Write request rate over 1m (per instance)</p>
 
 The number of write requests that were issued to the device per second.
 
@@ -14282,7 +14282,7 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100101`
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -14290,7 +14290,7 @@ Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",inst
 
 #### searcher: cache_disk_read_throughput
 
-<p class="subtitle">Read throughput over 2m (per instance)</p>
+<p class="subtitle">Read throughput over 1m (per instance)</p>
 
 The amount of data that was read from the device per second.
 
@@ -14305,7 +14305,7 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100110`
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -14313,7 +14313,7 @@ Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",inst
 
 #### searcher: cache_disk_write_throughput
 
-<p class="subtitle">Write throughput over 2m (per instance)</p>
+<p class="subtitle">Write throughput over 1m (per instance)</p>
 
 The amount of data that was written to the device per second.
 
@@ -14328,7 +14328,7 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100111`
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -14336,7 +14336,7 @@ Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",inst
 
 #### searcher: cache_disk_read_duration
 
-<p class="subtitle">Average read duration over 2m (per instance)</p>
+<p class="subtitle">Average read duration over 1m (per instance)</p>
 
 The average time for read requests issued to the device to be served. This includes the time spent by the requests in queue and the time spent servicing them.
 
@@ -14351,7 +14351,7 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100120`
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_time_seconds_total{instance=~`node-exporter.*`}[2m])))))) / ((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m])))))))`
+Query: `(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_time_seconds_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))))`
 
 </details>
 
@@ -14359,7 +14359,7 @@ Query: `(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",in
 
 #### searcher: cache_disk_write_duration
 
-<p class="subtitle">Average write duration over 2m (per instance)</p>
+<p class="subtitle">Average write duration over 1m (per instance)</p>
 
 The average time for write requests issued to the device to be served. This includes the time spent by the requests in queue and the time spent servicing them.
 
@@ -14374,7 +14374,7 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100121`
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_write_time_seconds_total{instance=~`node-exporter.*`}[2m])))))) / ((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m])))))))`
+Query: `(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_write_time_seconds_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))))`
 
 </details>
 
@@ -14382,7 +14382,7 @@ Query: `(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",in
 
 #### searcher: cache_disk_read_request_size
 
-<p class="subtitle">Average read request size over 2m (per instance)</p>
+<p class="subtitle">Average read request size over 1m (per instance)</p>
 
 The average size of read requests that were issued to the device.
 
@@ -14397,7 +14397,7 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100130`
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[2m])))))) / ((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m])))))))`
+Query: `(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))))`
 
 </details>
 
@@ -14405,7 +14405,7 @@ Query: `(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",in
 
 #### searcher: cache_disk_write_request_size)
 
-<p class="subtitle">Average write request size over 2m (per instance)</p>
+<p class="subtitle">Average write request size over 1m (per instance)</p>
 
 The average size of write requests that were issued to the device.
 
@@ -14420,7 +14420,7 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100131`
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[2m])))))) / ((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m])))))))`
+Query: `(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))))`
 
 </details>
 
@@ -14428,7 +14428,7 @@ Query: `(((max by (instance) (searcher_mount_point_info{mount_name="cacheDir",in
 
 #### searcher: cache_disk_reads_merged_sec
 
-<p class="subtitle">Merged read request rate over 2m (per instance)</p>
+<p class="subtitle">Merged read request rate over 1m (per instance)</p>
 
 The number of read requests merged per second that were queued to the device.
 
@@ -14443,7 +14443,7 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100140`
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_merged_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_merged_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -14451,7 +14451,7 @@ Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",inst
 
 #### searcher: cache_disk_writes_merged_sec
 
-<p class="subtitle">Merged writes request rate over 2m (per instance)</p>
+<p class="subtitle">Merged writes request rate over 1m (per instance)</p>
 
 The number of write requests merged per second that were queued to the device.
 
@@ -14466,7 +14466,7 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100141`
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_merged_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_merged_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -14474,7 +14474,7 @@ Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",inst
 
 #### searcher: cache_disk_average_queue_size
 
-<p class="subtitle">Average queue size over 2m (per instance)</p>
+<p class="subtitle">Average queue size over 1m (per instance)</p>
 
 The number of I/O operations that were being queued or being serviced. See https://blog.actorsfit.com/a?ID=00200-428fa2ac-e338-4540-848c-af9a3eb1ebd2 for background (avgqu-sz).
 
@@ -14489,7 +14489,7 @@ To see this panel, visit `/-/debug/grafana/d/searcher/searcher?viewPanel=100150`
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_io_time_weighted_seconds_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (searcher_mount_point_info{mount_name="cacheDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_io_time_weighted_seconds_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -17719,7 +17719,7 @@ Query: `sum by (container_label_io_kubernetes_pod_name) (rate(container_network_
 
 #### zoekt: data_disk_reads_sec
 
-<p class="subtitle">Read request rate over 2m (per instance)</p>
+<p class="subtitle">Read request rate over 1m (per instance)</p>
 
 The number of read requests that were issued to the device per second.
 
@@ -17734,7 +17734,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100800` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -17742,7 +17742,7 @@ Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="index
 
 #### zoekt: data_disk_writes_sec
 
-<p class="subtitle">Write request rate over 2m (per instance)</p>
+<p class="subtitle">Write request rate over 1m (per instance)</p>
 
 The number of write requests that were issued to the device per second.
 
@@ -17757,7 +17757,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100801` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -17765,7 +17765,7 @@ Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="index
 
 #### zoekt: data_disk_read_throughput
 
-<p class="subtitle">Read throughput over 2m (per instance)</p>
+<p class="subtitle">Read throughput over 1m (per instance)</p>
 
 The amount of data that was read from the device per second.
 
@@ -17780,7 +17780,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100810` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -17788,7 +17788,7 @@ Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="index
 
 #### zoekt: data_disk_write_throughput
 
-<p class="subtitle">Write throughput over 2m (per instance)</p>
+<p class="subtitle">Write throughput over 1m (per instance)</p>
 
 The amount of data that was written to the device per second.
 
@@ -17803,7 +17803,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100811` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -17811,7 +17811,7 @@ Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="index
 
 #### zoekt: data_disk_read_duration
 
-<p class="subtitle">Average read duration over 2m (per instance)</p>
+<p class="subtitle">Average read duration over 1m (per instance)</p>
 
 The average time for read requests issued to the device to be served. This includes the time spent by the requests in queue and the time spent servicing them.
 
@@ -17826,7 +17826,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100820` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_time_seconds_total{instance=~`node-exporter.*`}[2m])))))) / ((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m])))))))`
+Query: `(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_time_seconds_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))))`
 
 </details>
 
@@ -17834,7 +17834,7 @@ Query: `(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="ind
 
 #### zoekt: data_disk_write_duration
 
-<p class="subtitle">Average write duration over 2m (per instance)</p>
+<p class="subtitle">Average write duration over 1m (per instance)</p>
 
 The average time for write requests issued to the device to be served. This includes the time spent by the requests in queue and the time spent servicing them.
 
@@ -17849,7 +17849,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100821` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_write_time_seconds_total{instance=~`node-exporter.*`}[2m])))))) / ((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m])))))))`
+Query: `(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_write_time_seconds_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))))`
 
 </details>
 
@@ -17857,7 +17857,7 @@ Query: `(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="ind
 
 #### zoekt: data_disk_read_request_size
 
-<p class="subtitle">Average read request size over 2m (per instance)</p>
+<p class="subtitle">Average read request size over 1m (per instance)</p>
 
 The average size of read requests that were issued to the device.
 
@@ -17872,7 +17872,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100830` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[2m])))))) / ((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[2m])))))))`
+Query: `(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_read_bytes_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_completed_total{instance=~`node-exporter.*`}[1m])))))))`
 
 </details>
 
@@ -17880,7 +17880,7 @@ Query: `(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="ind
 
 #### zoekt: data_disk_write_request_size)
 
-<p class="subtitle">Average write request size over 2m (per instance)</p>
+<p class="subtitle">Average write request size over 1m (per instance)</p>
 
 The average size of write requests that were issued to the device.
 
@@ -17895,7 +17895,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100831` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[2m])))))) / ((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[2m])))))))`
+Query: `(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_written_bytes_total{instance=~`node-exporter.*`}[1m])))))) / ((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_completed_total{instance=~`node-exporter.*`}[1m])))))))`
 
 </details>
 
@@ -17903,7 +17903,7 @@ Query: `(((max by (instance) (zoekt_indexserver_mount_point_info{mount_name="ind
 
 #### zoekt: data_disk_reads_merged_sec
 
-<p class="subtitle">Merged read request rate over 2m (per instance)</p>
+<p class="subtitle">Merged read request rate over 1m (per instance)</p>
 
 The number of read requests merged per second that were queued to the device.
 
@@ -17918,7 +17918,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100840` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_merged_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_reads_merged_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -17926,7 +17926,7 @@ Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="index
 
 #### zoekt: data_disk_writes_merged_sec
 
-<p class="subtitle">Merged writes request rate over 2m (per instance)</p>
+<p class="subtitle">Merged writes request rate over 1m (per instance)</p>
 
 The number of write requests merged per second that were queued to the device.
 
@@ -17941,7 +17941,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100841` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_merged_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_writes_merged_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 
@@ -17949,7 +17949,7 @@ Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="index
 
 #### zoekt: data_disk_average_queue_size
 
-<p class="subtitle">Average queue size over 2m (per instance)</p>
+<p class="subtitle">Average queue size over 1m (per instance)</p>
 
 The number of I/O operations that were being queued or being serviced. See https://blog.actorsfit.com/a?ID=00200-428fa2ac-e338-4540-848c-af9a3eb1ebd2 for background (avgqu-sz).
 
@@ -17964,7 +17964,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100850` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_io_time_weighted_seconds_total{instance=~`node-exporter.*`}[2m])))))`
+Query: `(max by (instance) (zoekt_indexserver_mount_point_info{mount_name="indexDir",instance=~`${instance:regex}`} * on (device, nodename) group_left() (max by (device, nodename) (rate(node_disk_io_time_weighted_seconds_total{instance=~`node-exporter.*`}[1m])))))`
 
 </details>
 

--- a/monitoring/definitions/shared/diskmetrics.go
+++ b/monitoring/definitions/shared/diskmetrics.go
@@ -50,7 +50,7 @@ func NewDiskMetricsGroup(opts DiskMetricsGroupOptions, owner monitoring.Observab
 	diskStatsQuery := func(nodeExporterMetric string) string {
 		return fmt.Sprintf("(max by (instance) (%s * on (device, nodename) group_left() (%s)))",
 			fmt.Sprintf("%s{mount_name=%q,instance=~`%s`}", mountMetric, opts.MetricMountNameLabel, opts.InstanceFilterRegex),
-			fmt.Sprintf("max by (device, nodename) (rate(%s{instance=~`node-exporter.*`}[2m]))", nodeExporterMetric),
+			fmt.Sprintf("max by (device, nodename) (rate(%s{instance=~`node-exporter.*`}[1m]))", nodeExporterMetric),
 		)
 	}
 
@@ -67,7 +67,7 @@ func NewDiskMetricsGroup(opts DiskMetricsGroupOptions, owner monitoring.Observab
 			{
 				{
 					Name:        fmt.Sprintf("%s_disk_reads_sec", opts.DiskTitle),
-					Description: "read request rate over 2m (per instance)",
+					Description: "read request rate over 1m (per instance)",
 					Query:       diskStatsQuery("node_disk_reads_completed_total"),
 					NoAlert:     true,
 					Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -78,7 +78,7 @@ func NewDiskMetricsGroup(opts DiskMetricsGroupOptions, owner monitoring.Observab
 				},
 				{
 					Name:        fmt.Sprintf("%s_disk_writes_sec", opts.DiskTitle),
-					Description: "write request rate over 2m (per instance)",
+					Description: "write request rate over 1m (per instance)",
 					Query:       diskStatsQuery("node_disk_writes_completed_total"),
 					NoAlert:     true,
 					Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -91,7 +91,7 @@ func NewDiskMetricsGroup(opts DiskMetricsGroupOptions, owner monitoring.Observab
 			{
 				{
 					Name:        fmt.Sprintf("%s_disk_read_throughput", opts.DiskTitle),
-					Description: "read throughput over 2m (per instance)",
+					Description: "read throughput over 1m (per instance)",
 					Query:       diskStatsQuery("node_disk_read_bytes_total"),
 					NoAlert:     true,
 					Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -102,7 +102,7 @@ func NewDiskMetricsGroup(opts DiskMetricsGroupOptions, owner monitoring.Observab
 				},
 				{
 					Name:        fmt.Sprintf("%s_disk_write_throughput", opts.DiskTitle),
-					Description: "write throughput over 2m (per instance)",
+					Description: "write throughput over 1m (per instance)",
 					Query:       diskStatsQuery("node_disk_written_bytes_total"),
 					NoAlert:     true,
 					Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -115,7 +115,7 @@ func NewDiskMetricsGroup(opts DiskMetricsGroupOptions, owner monitoring.Observab
 			{
 				{
 					Name:        fmt.Sprintf("%s_disk_read_duration", opts.DiskTitle),
-					Description: "average read duration over 2m (per instance)",
+					Description: "average read duration over 1m (per instance)",
 
 					Query: fmt.Sprintf("((%s) / (%s))",
 						diskStatsQuery("node_disk_read_time_seconds_total"),
@@ -132,7 +132,7 @@ func NewDiskMetricsGroup(opts DiskMetricsGroupOptions, owner monitoring.Observab
 				},
 				{
 					Name:        fmt.Sprintf("%s_disk_write_duration", opts.DiskTitle),
-					Description: "average write duration over 2m (per instance)",
+					Description: "average write duration over 1m (per instance)",
 
 					Query: fmt.Sprintf("((%s) / (%s))",
 						diskStatsQuery("node_disk_write_time_seconds_total"),
@@ -151,7 +151,7 @@ func NewDiskMetricsGroup(opts DiskMetricsGroupOptions, owner monitoring.Observab
 			{
 				{
 					Name:        fmt.Sprintf("%s_disk_read_request_size", opts.DiskTitle),
-					Description: "average read request size over 2m (per instance)",
+					Description: "average read request size over 1m (per instance)",
 					Query: fmt.Sprintf("((%s) / (%s))",
 						diskStatsQuery("node_disk_read_bytes_total"),
 						diskStatsQuery("node_disk_reads_completed_total"),
@@ -165,7 +165,7 @@ func NewDiskMetricsGroup(opts DiskMetricsGroupOptions, owner monitoring.Observab
 				},
 				{
 					Name:        fmt.Sprintf("%s_disk_write_request_size)", opts.DiskTitle),
-					Description: "average write request size over 2m (per instance)",
+					Description: "average write request size over 1m (per instance)",
 					Query: fmt.Sprintf("((%s) / (%s))",
 						diskStatsQuery("node_disk_written_bytes_total"),
 						diskStatsQuery("node_disk_writes_completed_total"),
@@ -181,7 +181,7 @@ func NewDiskMetricsGroup(opts DiskMetricsGroupOptions, owner monitoring.Observab
 			{
 				{
 					Name:        fmt.Sprintf("%s_disk_reads_merged_sec", opts.DiskTitle),
-					Description: "merged read request rate over 2m (per instance)",
+					Description: "merged read request rate over 1m (per instance)",
 					Query:       diskStatsQuery("node_disk_reads_merged_total"),
 					NoAlert:     true,
 					Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -192,7 +192,7 @@ func NewDiskMetricsGroup(opts DiskMetricsGroupOptions, owner monitoring.Observab
 				},
 				{
 					Name:        fmt.Sprintf("%s_disk_writes_merged_sec", opts.DiskTitle),
-					Description: "merged writes request rate over 2m (per instance)",
+					Description: "merged writes request rate over 1m (per instance)",
 					Query:       diskStatsQuery("node_disk_writes_merged_total"),
 					NoAlert:     true,
 					Panel: monitoring.Panel().LegendFormat("{{instance}}").
@@ -206,7 +206,7 @@ func NewDiskMetricsGroup(opts DiskMetricsGroupOptions, owner monitoring.Observab
 				{
 
 					Name:        fmt.Sprintf("%s_disk_average_queue_size", opts.DiskTitle),
-					Description: "average queue size over 2m (per instance)",
+					Description: "average queue size over 1m (per instance)",
 					Query:       diskStatsQuery("node_disk_io_time_weighted_seconds_total"),
 					NoAlert:     true,
 					Panel: monitoring.Panel().LegendFormat("{{instance}}").


### PR DESCRIPTION
This change decreases the sampling duration for the disk metrics dashboards from `2m` to `1m`. 

Both [docker-compose](https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/877) and [kubernetes](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/22bed12869be633318d7b56cf3ad8f04d9b4b67b/charts/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml#L5-L7) have Prometheus scrape intervals of 30s. So, using a 1m interval allows for more accurate dashboards (following the rule of thumb of using 2x the sample rate ([Nyquist–Shannon](https://www.allaboutcircuits.com/technical-articles/nyquist-shannon-theorem-understanding-sampled-systems/))) 

## Test plan

Ran the monitoring stack using `sg start monitoring` while connected to dogfood's Prometheus instance. See this screenshot: 
<img width="1073" alt="Screen Shot 2022-11-09 at 9 39 28 AM" src="https://user-images.githubusercontent.com/9022011/200901685-6a40c625-94f7-43d1-8390-0198dd17085e.png">



