### PR TITLE
Revert "prometheus: increase scrape and evaluation intervals to 1m"

### DIFF
--- a/docker-images/prometheus/config/prometheus.yml
+++ b/docker-images/prometheus/config/prometheus.yml
@@ -1,4 +1,10 @@
-# Prometheus global config
+# Prometheus global/reference config
+#
+# Keep in sync with:
+#
+# - https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml
+# - https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/main/prometheus/prometheus.yml
+# - https://github.com/sourcegraph/deploy-sourcegraph/blob/master/base/prometheus/prometheus.ConfigMap.yaml
 global:
   scrape_interval: 30s # Scrape services for updated metrics every 30s. Default is 1m.
   evaluation_interval: 30s # Evaluate rules every 30s. Default is 1m.

--- a/docker-images/prometheus/config/prometheus.yml
+++ b/docker-images/prometheus/config/prometheus.yml
@@ -1,7 +1,7 @@
 # Prometheus global config
 global:
-  scrape_interval: 1m # Scrape services for updated metrics every 1m.
-  evaluation_interval: 1m # Evaluate rules every 1m.
+  scrape_interval: 30s # Scrape services for updated metrics every 30s. Default is 1m.
+  evaluation_interval: 30s # Evaluate rules every 30s. Default is 1m.
   # scrape_timeout is set to the global default (10s).
 
 # Alertmanager configuration


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#41872

This is technically never respected because [k8s has always had an override](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/22bed12869be633318d7b56cf3ad8f04d9b4b67b/charts/sourcegraph/templates/prometheus/prometheus.ConfigMap.yaml#L5-L7) and a similar override was recently added for docker-compose (https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/877). Additionally, it's better for metrics that sample on `1m` if we have a `30s` interval (see PR description: https://github.com/sourcegraph/sourcegraph/pull/44166).

This also adds links for reference since the relationship can be confusing (https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/877#issuecomment-1309119702)

Test plan: CI passes