### PR TITLE
insights: add new rate limit burst setting for search query rate

### DIFF
--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -77,7 +77,7 @@ func GetBackgroundJobs(ctx context.Context, logger log.Logger, mainAppDB databas
 			InsightStore:            insightsStore,
 			CommitClient:            discovery.NewGitCommitClient(mainAppDB),
 			SearchPlanWorkerLimit:   1,
-			SearchRunnerWorkerLimit: 12,
+			SearchRunnerWorkerLimit: 5, //TODO: move these to settings
 			SearchRateLimiter:       searchRateLimiter,
 			HistoricRateLimiter:     historicRateLimiter,
 		}

--- a/enterprise/internal/insights/background/limiter/historical.go
+++ b/enterprise/internal/insights/background/limiter/historical.go
@@ -23,7 +23,7 @@ func HistoricalWorkRate() *ratelimit.InstrumentedLimiter {
 		historicalLimiter = ratelimit.NewInstrumentedLimiter("HistoricalInsight", rate.NewLimiter(getRateLimit(), 1))
 		go conf.Watch(func() {
 			val := getRateLimit()
-			historicalLogger.Info("Updating insights/query-worker rate limit", log.Int("value", int(val)))
+			historicalLogger.Info("Updating insights/historical rate limit", log.Int("value", int(val)))
 			historicalLimiter.SetLimit(val)
 		})
 	})

--- a/enterprise/internal/insights/background/limiter/search_query.go
+++ b/enterprise/internal/insights/background/limiter/search_query.go
@@ -19,30 +19,40 @@ func SearchQueryRate() *ratelimit.InstrumentedLimiter {
 	searchOnce.Do(func() {
 		searchLogger = log.Scoped("insights.search.ratelimiter", "")
 		defaultRateLimit := rate.Limit(20.0)
-		getRateLimit := getSearchQueryRateLimit(defaultRateLimit)
-		searchLimiter = ratelimit.NewInstrumentedLimiter("QueryRunner", rate.NewLimiter(getRateLimit(), 1))
+		defaultBurst := 20
+		getRateLimit := getSearchQueryRateLimit(defaultRateLimit, defaultBurst)
+		searchLimiter = ratelimit.NewInstrumentedLimiter("QueryRunner", rate.NewLimiter(getRateLimit()))
 
 		go conf.Watch(func() {
-			val := getRateLimit()
-			searchLogger.Info("Updating insights/query-worker rate limit", log.Int("value", int(val)))
-			searchLimiter.SetLimit(val)
+			limit, burst := getRateLimit()
+			searchLogger.Info("Updating insights/query-worker ", log.Int("rate limit", int(limit)), log.Int("burst", burst))
+			searchLimiter.SetLimit(limit)
+			searchLimiter.SetBurst(burst)
 		})
 	})
 
 	return searchLimiter
 }
 
-func getSearchQueryRateLimit(defaultValue rate.Limit) func() rate.Limit {
-	return func() rate.Limit {
-		val := conf.Get().InsightsQueryWorkerRateLimit
+func getSearchQueryRateLimit(defaultRate rate.Limit, defaultBurst int) func() (rate.Limit, int) {
+	return func() (rate.Limit, int) {
+		limit := conf.Get().InsightsQueryWorkerRateLimit
+		burst := conf.Get().InsightsQueryWorkerRateLimitBurst
 
-		var result rate.Limit
-		if val == nil {
-			result = defaultValue
+		var rateLimit rate.Limit
+		if limit == nil {
+			rateLimit = defaultRate
 		} else {
-			result = rate.Limit(*val)
+			rateLimit = rate.Limit(*limit)
 		}
 
-		return result
+		var burstLimit int
+		if burst == nil {
+			burstLimit = defaultBurst
+		} else {
+			burstLimit = *burst
+		}
+
+		return rateLimit, burstLimit
 	}
 }

--- a/enterprise/internal/insights/background/limiter/search_query.go
+++ b/enterprise/internal/insights/background/limiter/search_query.go
@@ -46,13 +46,10 @@ func getSearchQueryRateLimit(defaultRate rate.Limit, defaultBurst int) func() (r
 			rateLimit = rate.Limit(*limit)
 		}
 
-		var burstLimit int
-		if burst == nil {
-			burstLimit = defaultBurst
-		} else {
-			burstLimit = *burst
+		if burst <= 0 {
+			burst = defaultBurst
 		}
 
-		return rateLimit, burstLimit
+		return rateLimit, burst
 	}
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2157,7 +2157,7 @@ type SiteConfiguration struct {
 	// InsightsQueryWorkerRateLimit description: Maximum number of Code Insights queries initiated per second on a worker node.
 	InsightsQueryWorkerRateLimit *float64 `json:"insights.query.worker.rateLimit,omitempty"`
 	// InsightsQueryWorkerRateLimitBurst description: The allowed burst rate for the Code Insights queries per second rate limiter.
-	InsightsQueryWorkerRateLimitBurst *int `json:"insights.query.worker.rateLimitBurst,omitempty"`
+	InsightsQueryWorkerRateLimitBurst int `json:"insights.query.worker.rateLimitBurst,omitempty"`
 	// InsightsSearchGraphql description: DEPRECATED: Force GraphQL mode for insights searches. This will overwrite the default streaming behavior and force search clients to use the GraphQL API
 	InsightsSearchGraphql *bool `json:"insights.search.graphql,omitempty"`
 	// LicenseKey description: The license key associated with a Sourcegraph product subscription, which is necessary to activate Sourcegraph Enterprise functionality. To obtain this value, contact Sourcegraph to purchase a subscription. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2156,6 +2156,8 @@ type SiteConfiguration struct {
 	InsightsQueryWorkerConcurrency int `json:"insights.query.worker.concurrency,omitempty"`
 	// InsightsQueryWorkerRateLimit description: Maximum number of Code Insights queries initiated per second on a worker node.
 	InsightsQueryWorkerRateLimit *float64 `json:"insights.query.worker.rateLimit,omitempty"`
+	// InsightsQueryWorkerRateLimitBurst description: The allowed burst rate for the Code Insights queries per second rate limiter.
+	InsightsQueryWorkerRateLimitBurst *int `json:"insights.query.worker.rateLimitBurst,omitempty"`
 	// InsightsSearchGraphql description: DEPRECATED: Force GraphQL mode for insights searches. This will overwrite the default streaming behavior and force search clients to use the GraphQL API
 	InsightsSearchGraphql *bool `json:"insights.search.graphql,omitempty"`
 	// LicenseKey description: The license key associated with a Sourcegraph product subscription, which is necessary to activate Sourcegraph Enterprise functionality. To obtain this value, contact Sourcegraph to purchase a subscription. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1437,8 +1437,16 @@
       "description": "Maximum number of Code Insights queries initiated per second on a worker node.",
       "type": "number",
       "group": "CodeInsights",
-      "default": 2,
+      "default": 20,
       "examples": [10.0, 0.5],
+      "!go": { "pointer": true }
+    },
+    "insights.query.worker.rateLimitBurst": {
+      "description": "The allowed burst rate for the Code Insights queries per second rate limiter.",
+      "type": "integer",
+      "group": "CodeInsights",
+      "default": 20,
+      "examples": [10, 20],
       "!go": { "pointer": true }
     },
     "insights.compute.graphql": {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1446,8 +1446,7 @@
       "type": "integer",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [10, 20],
-      "!go": { "pointer": true }
+      "examples": [10, 20]
     },
     "insights.compute.graphql": {
       "description": "DEPRECATED: Force GraphQL mode for insights compute searches. This will overwrite the default streaming behavior and force search clients to use the GraphQL API",


### PR DESCRIPTION
Adds a new setting to configure burst rate for insights searches.  Also lowered concurrency of search jobs, will move that to a setting in the future
## Test plan
Backfilled an insight and noted time it took
Updated settings and lowered burst to 1 and backfilled again - noted time was double

captured logs with burst 20
```
[         worker] WARN insightsBackfiller pipeline/backfill.go:268 done waiting {"wait time": "16.75µs"}
[         worker] WARN insightsBackfiller pipeline/backfill.go:268 done waiting {"wait time": "18.459µs"}
[         worker] WARN insightsBackfiller pipeline/backfill.go:268 done waiting {"wait time": "15.292µs"}
[         worker] WARN insightsBackfiller pipeline/backfill.go:268 done waiting {"wait time": "14.416µs"}
[         worker] WARN insightsBackfiller pipeline/backfill.go:268 done waiting {"wait time": "16.167µs"}
[         worker] WARN insightsBackfiller pipeline/backfill.go:268 done waiting {"wait time": "15.25µs"}
```
Captured logs with burst 1
```
[         worker] WARN insightsBackfiller pipeline/backfill.go:268 done waiting {"wait time": "200.999792ms"}
[         worker] WARN insightsBackfiller pipeline/backfill.go:268 done waiting {"wait time": "241.729583ms"}
[         worker] WARN insightsBackfiller pipeline/backfill.go:268 done waiting {"wait time": "243.792291ms"}
[         worker] WARN insightsBackfiller pipeline/backfill.go:268 done waiting {"wait time": "243.50275ms"}
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
