### PR TITLE
Set min height to search query example panels

### DIFF
--- a/client/web/src/search/home/QueryExamplesHomepage.module.scss
+++ b/client/web/src/search/home/QueryExamplesHomepage.module.scss
@@ -94,7 +94,8 @@
 }
 
 .tab-panel {
-    min-height: 335px;
+    // Set a minimum height so the page doesn't shift when changing tabs
+    min-height: 21rem; 
 }
 
 .pro-tip-title {

--- a/client/web/src/search/home/QueryExamplesHomepage.module.scss
+++ b/client/web/src/search/home/QueryExamplesHomepage.module.scss
@@ -93,6 +93,10 @@
     }
 }
 
+.tab-panel {
+    min-height: 335px;
+}
+
 .pro-tip-title {
     font-size: 0.75rem;
     font-weight: 700;

--- a/client/web/src/search/home/QueryExamplesHomepage.tsx
+++ b/client/web/src/search/home/QueryExamplesHomepage.tsx
@@ -115,13 +115,13 @@ export const QueryExamplesHomepage: React.FunctionComponent<QueryExamplesHomepag
                             <Tab key="Search query examples">Search query examples</Tab>
                         </TabList>
                         <TabPanels>
-                            <TabPanel>
+                            <TabPanel className={styles.tabPanel}>
                                 <QueryExamplesLayout
                                     queryColumns={exampleSyntaxColumns}
                                     onQueryExampleClick={onQueryExampleClick}
                                 />
                             </TabPanel>
-                            <TabPanel>
+                            <TabPanel className={styles.tabPanel}>
                                 <QueryExamplesLayout
                                     queryColumns={exampleQueryColumns}
                                     onQueryExampleClick={onQueryExampleClick}
@@ -191,7 +191,7 @@ export const QueryExamplesLayout: React.FunctionComponent<QueryExamplesLayout> =
 }) => (
     <div className={styles.queryExamplesSectionsColumns}>
         {queryColumns.map((column, index) => (
-            <div key={`column-${queryColumns[0][0].title}`}>
+            <div key={`column-${queryColumns[index][0].title}`}>
                 {column.map(({ title, queryExamples }) => (
                     <ExamplesSection
                         key={title}


### PR DESCRIPTION
Closes #44118. Sets a min height on new search example panels to avoid jumping UI.


https://user-images.githubusercontent.com/59381432/200929771-adc09eaa-8b19-4af9-9314-a6f7df440014.mov



## Test plan
- Test locally to display dotcom version for this UI to populate on `/search`

## App preview:

- [Web](https://sg-web-becca-search-guidance-height.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
