### PR TITLE
Search UI: display commit dates in UTC

### DIFF
--- a/client/search-ui/src/components/CommitSearchResult.tsx
+++ b/client/search-ui/src/components/CommitSearchResult.tsx
@@ -60,7 +60,7 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({
                     <VisuallyHidden>,</VisuallyHidden>
                 </Code>{' '}
                 <VisuallyHidden>Commited</VisuallyHidden>
-                <Timestamp date={result.committerDate} noAbout={true} strict={true} />
+                <Timestamp date={result.committerDate} noAbout={true} strict={true} utc={true} />
             </Link>
             {result.repoStars && <div className={styles.divider} />}
         </div>

--- a/client/search-ui/src/components/CommitSearchResult.tsx
+++ b/client/search-ui/src/components/CommitSearchResult.tsx
@@ -60,6 +60,7 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({
                     <VisuallyHidden>,</VisuallyHidden>
                 </Code>{' '}
                 <VisuallyHidden>Commited</VisuallyHidden>
+                {/* Display commit date in UTC to match behavior of before/after filters */}
                 <Timestamp date={result.committerDate} noAbout={true} strict={true} utc={true} />
             </Link>
             {result.repoStars && <div className={styles.divider} />}

--- a/client/web/src/components/time/Timestamp.tsx
+++ b/client/web/src/components/time/Timestamp.tsx
@@ -60,7 +60,6 @@ export const Timestamp: React.FunctionComponent<React.PropsWithChildren<Props>> 
         }
     }, [date, noAbout, now, strict])
 
-
     const tooltip = useMemo(() => {
         let parsedDate = typeof date === 'string' ? parseISO(date) : new Date(date)
         if (utc) {
@@ -68,7 +67,7 @@ export const Timestamp: React.FunctionComponent<React.PropsWithChildren<Props>> 
         }
         const dateHasTime = date.toString().includes('T')
         const defaultFormat = dateHasTime ? TimestampFormat.FULL_DATE_TIME : TimestampFormat.FULL_DATE
-        return format(parsedDate, timestampFormat ?? defaultFormat) + (utc ? " UTC" : "")
+        return format(parsedDate, timestampFormat ?? defaultFormat) + (utc ? ' UTC' : '')
     }, [date, timestampFormat, utc])
 
     return (

--- a/client/web/src/components/time/Timestamp.tsx
+++ b/client/web/src/components/time/Timestamp.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 
-import { parseISO, format } from 'date-fns'
+import { format, addMinutes, parseISO } from 'date-fns'
 import formatDistance from 'date-fns/formatDistance'
 import formatDistanceStrict from 'date-fns/formatDistanceStrict'
 
@@ -24,6 +24,8 @@ interface Props {
 
     /** Optional semantic timestamp format */
     timestampFormat?: TimestampFormat
+
+    utc?: boolean
 }
 
 export enum TimestampFormat {
@@ -45,6 +47,7 @@ export const Timestamp: React.FunctionComponent<React.PropsWithChildren<Props>> 
     now = Date.now,
     preferAbsolute = false,
     timestampFormat,
+    utc = false,
 }) => {
     const [label, setLabel] = useState<string>(calculateLabel(date, now, strict, noAbout))
     useEffect(() => {
@@ -57,12 +60,16 @@ export const Timestamp: React.FunctionComponent<React.PropsWithChildren<Props>> 
         }
     }, [date, noAbout, now, strict])
 
+
     const tooltip = useMemo(() => {
-        const parsedDate = typeof date === 'string' ? parseISO(date) : new Date(date)
+        let parsedDate = typeof date === 'string' ? parseISO(date) : new Date(date)
+        if (utc) {
+            parsedDate = addMinutes(parsedDate, parsedDate.getTimezoneOffset())
+        }
         const dateHasTime = date.toString().includes('T')
         const defaultFormat = dateHasTime ? TimestampFormat.FULL_DATE_TIME : TimestampFormat.FULL_DATE
-        return format(parsedDate, timestampFormat ?? defaultFormat)
-    }, [date, timestampFormat])
+        return format(parsedDate, timestampFormat ?? defaultFormat) + (utc ? " UTC" : "")
+    }, [date, timestampFormat, utc])
 
     return (
         <Tooltip content={preferAbsolute ? label : tooltip}>


### PR DESCRIPTION
The search `before:` and `after:` filters operate on UTC times, so the dates displayed to the user should also.

Stacked on #44134 

## Test plan

Manual test. 

<img width="213" alt="Screen Shot 2022-11-09 at 12 21 44" src="https://user-images.githubusercontent.com/12631702/200921988-3663637e-ab11-4370-afe3-61c853c68d41.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cc-utc-commits.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
