### PR TITLE
Use faster way to compute cloned repos metric

### DIFF
--- a/internal/repos/metrics.go
+++ b/internal/repos/metrics.go
@@ -251,11 +251,10 @@ where last_fetched < now() - interval '8 hours'
 		Help: "The number of deleted repos that are still cloned on disk",
 	}, func() float64 {
 		count, err := scanCount(`
-select count(*) from
-gitserver_repos
-where clone_status = 'cloned'
-and exists
-  (select from repo where id = repo_id and (deleted_at is not null or blocked is not null))
+SELECT
+	SUM(cloned)
+FROM
+	repo_statistics
 `)
 		if err != nil {
 			logger.Error("Failed to count purgeable repos", log.Error(err))


### PR DESCRIPTION
The previous query can be replaced by this statistics query. It reflects the exact same value. The previous query was the 6th worst query on dotcom.

## Test plan

Verified the new query works and talked to Thorsten if this is a correct replacement.