### PR TITLE
migrator: Do not print drift error unconditionally

### DIFF
--- a/internal/database/migration/cliutil/drift_util.go
+++ b/internal/database/migration/cliutil/drift_util.go
@@ -47,7 +47,7 @@ func compareSchemaDescriptions(rawOut *output.Output, schemaName, version string
 	}
 
 	if err == nil {
-		out.WriteLine(output.Line(output.EmojiSuccess, output.StyleSuccess, "No drift detected"))
+		rawOut.WriteLine(output.Line(output.EmojiSuccess, output.StyleSuccess, "No drift detected"))
 	}
 	return err
 }


### PR DESCRIPTION
This stops the output from saying Drift detected! (when using the preambled output) when priting the success message.

## Test plan

Tested manually.