### PR TITLE
Code Insights: Improve keyboard navigation over chart legends

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.module.scss
@@ -77,7 +77,11 @@
 }
 
 .legend-list-item {
-    word-break: break-all;
+    // Reset wildcard button styles
+    padding: 0;
+    margin: 0;
+    font-weight: normal;
+    font-size: inherit;
 
     &.clickable {
         cursor: pointer;

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
@@ -1,10 +1,10 @@
-import React, { FC, useMemo } from 'react'
+import React, { FC, MouseEvent, useMemo } from 'react'
 
 import { ParentSize } from '@visx/responsive'
 import classNames from 'classnames'
 import useResizeObserver from 'use-resize-observer'
 
-import { BarChart, ScrollBox, LegendList, LegendItem, Series } from '@sourcegraph/wildcard'
+import { BarChart, ScrollBox, LegendList, LegendItem, Series, Button } from '@sourcegraph/wildcard'
 
 import { UseSeriesToggleReturn } from '../../../../../../../../insights/utils/use-series-toggle'
 import { BackendInsightData, InsightContent } from '../../../../../../core'
@@ -13,10 +13,6 @@ import { SeriesBasedChartTypes, SeriesChart } from '../../../../../views'
 import { BackendAlertOverlay } from '../backend-insight-alerts/BackendInsightAlerts'
 
 import styles from './BackendInsightChart.module.scss'
-
-function getLineColor(series: Series<any>): string {
-    return series.color ?? 'var(--gray-07)'
-}
 
 /**
  * If width of the chart is less than this var width value we should put the legend
@@ -54,7 +50,6 @@ interface BackendInsightChartProps<Datum> extends BackendInsightData {
 export function BackendInsightChart<Datum>(props: BackendInsightChartProps<Datum>): React.ReactElement {
     const { locked, isFetchingHistoricalData, data, zeroYAxisMin, className, onDatumClick, seriesToggleState } = props
     const { ref, width = 0 } = useResizeObserver()
-    const { setHoveredId } = seriesToggleState
 
     const isEmptyDataset = useMemo(() => hasNoData(data), [data])
 
@@ -111,7 +106,7 @@ export function BackendInsightChart<Datum>(props: BackendInsightChartProps<Datum
                     </ParentSize>
 
                     {isSeriesLikeInsight && (
-                        <ScrollBox className={styles.legendListContainer} onMouseLeave={() => setHoveredId(undefined)}>
+                        <ScrollBox className={styles.legendListContainer}>
                             <SeriesLegends series={data.content.series} seriesToggleState={seriesToggleState} />
                         </ScrollBox>
                     )}
@@ -151,27 +146,37 @@ const SeriesLegends: FC<SeriesLegendsProps> = props => {
 
     const { setHoveredId, isSeriesSelected, isSeriesHovered, toggle } = seriesToggleState
 
+    const isInteractive = series.length > 1
+
     return (
-        <LegendList className={styles.legendList}>
+        <LegendList
+            as={isInteractive ? 'div' : 'ul'}
+            role="list"
+            className={styles.legendList}
+            // prevent accidental dragging events
+            onMouseDown={(event: MouseEvent<HTMLElement>) => event.stopPropagation()}
+        >
             {series.map(item => (
                 <LegendItem
                     key={item.id as string}
-                    color={getLineColor(item)}
+                    as={isInteractive ? Button : 'li'}
+                    role={isInteractive ? 'checkbox listitem' : 'listitem'}
+                    aria-checked={isSeriesSelected(`${item.id}`)}
                     name={item.name}
-                    selected={isSeriesSelected(`${item.id}`)}
                     hovered={isSeriesHovered(`${item.id}`)}
-                    className={classNames(styles.legendListItem, {
-                        [styles.clickable]: series.length > 1,
-                    })}
+                    selected={isSeriesSelected(`${item.id}`)}
+                    color={item.color}
+                    className={styles.legendListItem}
+                    onMouseEnter={() => setHoveredId(`${item.id}`)}
+                    onMouseLeave={() => setHoveredId(undefined)}
+                    onFocus={() => setHoveredId(`${item.id}`)}
+                    onBlur={() => setHoveredId(undefined)}
                     onClick={() =>
                         toggle(
                             `${item.id}`,
                             series.map(series => `${series.id}`)
                         )
                     }
-                    onMouseEnter={() => setHoveredId(`${item.id}`)}
-                    // prevent accidental dragging events
-                    onMouseDown={event => event.stopPropagation()}
                 />
             ))}
         </LegendList>

--- a/client/wildcard/src/components/Charts/components/line-chart/components/legend-list/LegendList.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/components/legend-list/LegendList.tsx
@@ -1,46 +1,56 @@
-import React, { LiHTMLAttributes } from 'react'
+import { forwardRef } from 'react'
 
 import classNames from 'classnames'
 
+import { ForwardReferenceComponent } from '@sourcegraph/wildcard'
+
 import styles from './LegendList.module.scss'
 
-interface LegendListProps extends React.HTMLAttributes<HTMLUListElement> {
-    className?: string
-}
-
-export const LegendList: React.FunctionComponent<React.PropsWithChildren<LegendListProps>> = props => {
-    const { className, ...attributes } = props
+export const LegendList = forwardRef(function LegendList(props, ref) {
+    const { as: Component = 'ul', 'aria-label': ariaLabel = 'Chart legend', className, ...attributes } = props
 
     return (
-        <ul {...attributes} className={classNames(styles.legendList, className)}>
-            {props.children}
-        </ul>
-    )
-}
-
-interface LegendItemProps extends LiHTMLAttributes<HTMLLIElement> {
-    name: string
-    color?: string
-    selected?: boolean
-    hovered?: boolean
-}
-
-export const LegendItem: React.FunctionComponent<React.PropsWithChildren<LegendItemProps>> = ({
-    color = 'var(--gray-07)',
-    name,
-    selected = true,
-    hovered,
-    className,
-    children,
-    ...attributes
-}) => (
-    <li {...attributes} className={classNames({ 'text-muted': !selected && !hovered }, styles.legendItem, className)}>
-        <span
-            aria-hidden={true}
-            /* eslint-disable-next-line react/forbid-dom-props */
-            style={{ backgroundColor: selected || hovered ? color : undefined }}
-            className={classNames([styles.legendMark, { [styles.unselected]: !selected }])}
+        <Component
+            {...attributes}
+            ref={ref}
+            aria-label={ariaLabel}
+            className={classNames(styles.legendList, className)}
         />
-        {children || name}
-    </li>
-)
+    )
+}) as ForwardReferenceComponent<'ul'>
+
+interface LegendItemProps {
+    name: string
+    hovered?: boolean
+    selected?: boolean
+    color?: string
+}
+
+export const LegendItem = forwardRef(function LegendItem(props, ref) {
+    const {
+        name,
+        hovered,
+        selected = true,
+        color = 'var(--gray-07)',
+        className,
+        children,
+        as: Component = 'li',
+        ...attributes
+    } = props
+
+    return (
+        <Component
+            {...attributes}
+            ref={ref}
+            className={classNames(styles.legendItem, className, { 'text-muted': !selected && !hovered })}
+        >
+            <span
+                aria-hidden={true}
+                /* eslint-disable-next-line react/forbid-dom-props */
+                style={{ backgroundColor: selected || hovered ? color : undefined }}
+                className={classNames([styles.legendMark, { [styles.unselected]: !selected }])}
+            />
+            {children || name}
+        </Component>
+    )
+}) as ForwardReferenceComponent<'li', LegendItemProps>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/44055

## Background
This PR extend legend list UI in order to make legend item UI interactive for keyboard and screen reader (focusable, accessible for keyboard navigation and iteration and with proper aria labels and roles).

Prior to this PR we always render `li` items for the chart legend items and implement all cursor styles /click short cuts right in consumer. In this PR legend items become open for extending and therefore we can replace `li` element with any interactive component (as button) in consumer. So we don't need to care about all button-like behaviour in consumer and can just reuse wildcard button component for legend list item component.

I recorder a quick demo of how it works with this PR changes https://www.loom.com/share/2d9f4ae3d8844c1ea135f121bb12ef36

## Test plan
- Go to the code insights dashboard page and try to interact with legend items with keyboard and screen reader
- Make sure that all short cuts work properly
- Make sure that screen reader announcements are correct 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
