### PR TITLE
Rename `<nav>` label from "Main menu" to "Main"

### DIFF
--- a/client/web/src/nav/NavBar/NavBar.tsx
+++ b/client/web/src/nav/NavBar/NavBar.tsx
@@ -61,7 +61,7 @@ const useOnClickDetector = (
 
 export const NavBar = forwardRef(
     ({ children, logo }, reference): JSX.Element => (
-        <nav aria-label="Main Menu" className={navBarStyles.navbar} ref={reference}>
+        <nav aria-label="Main" className={navBarStyles.navbar} ref={reference}>
             <H1 className={navBarStyles.logo}>
                 <RouterLink className="d-flex align-items-center" to={PageRoutes.Search}>
                     {logo}

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`GlobalNavbar default 1`] = `
 <DocumentFragment>
   <nav
-    aria-label="Main Menu"
+    aria-label="Main"
     class="navbar"
   >
     <h1


### PR DESCRIPTION
The guidelines for `navigation` role in ARIA say:

> Redundant descriptions
> Screen readers will announce the type of role the landmark is. Because of this, you do not need to describe what the landmark is in its label. For example, a declaration of role="navigation" with an of aria-label="Primary navigation" may be announced redundantly as, "primary navigation navigation".

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav

Currently, the navigation is announced as "Main menu navigation". Not only is the role "menu" redundant in the label, it's actually wrong. "menu" is a defined term, and this is not a menu, it's a navigation landmark.

"Main" is the example given as a label for main navigation, which will result in the announcement "Main navigation", which is what we want.


## Test plan

Tested with VoiceOver
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-main-menu-nav.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
