### PR TITLE
internal/repos: Remove call to redundant s.Now()

### DIFF
--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -926,7 +926,7 @@ func (s *Syncer) observeSync(
 		syncStarted.WithLabelValues(family, owner).Inc()
 
 		now := s.Now()
-		took := s.Now().Sub(began).Seconds()
+		took := now.Sub(began).Seconds()
 
 		lastSync.WithLabelValues(family).Set(float64(now.Unix()))
 


### PR DESCRIPTION
Stumbled upon this as I was reading our monitoring code.

## Test plan

Build should pass.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
