### PR TITLE
Add missing space in sr-only completion text

### DIFF
--- a/client/search-ui/src/input/extensions/completion.ts
+++ b/client/search-ui/src/input/extensions/completion.ts
@@ -570,6 +570,6 @@ function isTokenInRange(
 function voiceOverComma(): HTMLElement {
     const element = document.createElement('span')
     element.className = 'sr-only'
-    element.append(document.createTextNode(','))
+    element.append(', ')
     return element
 }


### PR DESCRIPTION
Super minor, but noticed this in Juliana's video demo. The text in VoiceOver had no space between the comma and the next word. Don't know if that actually affects pronounciation, but it looked like a bug.

Also noticed the `document.createTextNode()` was redundant as `append()` takes strings to append text nodes.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
