### PR TITLE
search: fix smart search dropdown checkbox when disabling from dialog

### DIFF
--- a/client/search-ui/src/input/toggles/SmartSearchToggle.tsx
+++ b/client/search-ui/src/input/toggles/SmartSearchToggle.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { mdiClose, mdiRadioboxBlank, mdiRadioboxMarked } from '@mdi/js'
 import classNames from 'classnames'
@@ -79,6 +79,9 @@ const SmartSearchToggleMenu: React.FunctionComponent<
     Pick<SmartSearchToggleProps, 'onSelect' | 'isActive'> & { closeMenu: () => void }
 > = ({ onSelect, isActive, closeMenu }) => {
     const [visibleIsEnabled, setVisibleIsEnabled] = useState(isActive)
+    useEffect(() => {
+        setVisibleIsEnabled(isActive)
+    }, [isActive])
 
     const onChange = useCallback(
         (value: boolean) => {


### PR DESCRIPTION
The dropdown state would check the "Enabled" box when smart search is disabled from the dialog. Bug:

https://user-images.githubusercontent.com/888624/201037477-a65e8dd5-7ec7-4a20-8f20-4965cbe7540a.mp4


After investigating it turns out this is because the variable state to pick which box to select isn't updated in tandem with the source state `isActive`. Now it does, with the `useEffect` addition

## Test plan
manually tested UI change

## App preview:

- [Web](https://sg-web-rvt-fix-selected-checkbox-ss.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
