### PR TITLE
license: exempt SOAP user accounts

### DIFF
--- a/cmd/frontend/graphqlbackend/site_flags.go
+++ b/cmd/frontend/graphqlbackend/site_flags.go
@@ -62,7 +62,12 @@ func (r *siteResolver) FreeUsersExceeded(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	userCount, err := r.db.Users().Count(ctx, nil)
+	userCount, err := r.db.Users().Count(
+		ctx,
+		&database.UsersListOptions{
+			ExcludeSourcegraphOperators: true,
+		},
+	)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -31,7 +31,9 @@ func (r *schemaResolver) Users(ctx context.Context, args *usersArgs) (*userConne
 		return nil, err
 	}
 
-	var opt database.UsersListOptions
+	opt := database.UsersListOptions{
+		ExcludeSourcegraphOperators: true,
+	}
 	if args.Query != nil {
 		opt.Query = *args.Query
 	}

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -109,7 +109,7 @@ func hasFindRefsOccurred(ctx context.Context) (_ bool, err error) {
 
 func getTotalUsersCount(ctx context.Context, db database.DB) (_ int, err error) {
 	defer recordOperation("getTotalUsersCount")(&err)
-	return db.Users().Count(ctx, &database.UsersListOptions{ExcludeSourcegraphAdmins: true})
+	return db.Users().Count(ctx, &database.UsersListOptions{ExcludeSourcegraphOperators: true})
 }
 
 func getTotalOrgsCount(ctx context.Context, db database.DB) (_ int, err error) {

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
@@ -7,16 +7,29 @@ import (
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/sourcegraphoperator"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/cloud"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 // NewBeforeCreateUserHook returns a BeforeCreateUserHook closure with the given UsersStore
 // that determines whether new user is allowed to be created.
-func NewBeforeCreateUserHook() func(context.Context, database.DB) error {
-	return func(ctx context.Context, db database.DB) error {
+func NewBeforeCreateUserHook() func(context.Context, database.DB, *extsvc.AccountSpec) error {
+	return func(ctx context.Context, db database.DB, spec *extsvc.AccountSpec) error {
+		// Exempt user accounts that are created by the Sourcegraph Operator
+		// authentication provider.
+		//
+		// NOTE: It is important to make sure the Sourcegraph Operator authentication
+		// provider is actually enabled.
+		if spec != nil && spec.ServiceType == sourcegraphoperator.ProviderType &&
+			cloud.SiteConfig().SourcegraphOperatorAuthProviderEnabled() {
+			return nil
+		}
+
 		info, err := licensing.GetConfiguredProductLicenseInfo()
 		if err != nil {
 			return err

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
@@ -3,86 +3,106 @@ package enforcement
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/sourcegraphoperator"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/cloud"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/license"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestEnforcement_PreCreateUser(t *testing.T) {
 	expiresAt := time.Now().Add(time.Hour)
 	tests := []struct {
+		name            string
 		license         *license.Info
 		activeUserCount int
+		mockSetup       func(*testing.T)
+		spec            *extsvc.AccountSpec
 		wantErr         bool
 	}{
 		// See the impl for why we treat UserCount == 0 as unlimited.
 		{
+			name:            "unlimited",
 			license:         &license.Info{UserCount: 0, ExpiresAt: expiresAt},
 			activeUserCount: 5,
 			wantErr:         false,
 		},
 
-		// Non-true-up licenses.
 		{
+			name:            "no true-up",
 			license:         &license.Info{UserCount: 10, ExpiresAt: expiresAt},
 			activeUserCount: 0,
 			wantErr:         false,
 		},
 		{
+			name:            "no true-up and not exceeded user count",
 			license:         &license.Info{UserCount: 10, ExpiresAt: expiresAt},
 			activeUserCount: 5,
 			wantErr:         false,
 		},
 		{
-			license:         &license.Info{UserCount: 10, ExpiresAt: expiresAt},
-			activeUserCount: 9,
-			wantErr:         false,
-		},
-		{
+			name:            "no true-up and exceeding user count",
 			license:         &license.Info{UserCount: 10, ExpiresAt: expiresAt},
 			activeUserCount: 10,
 			wantErr:         true,
 		},
 		{
+			name:            "no true-up and exceeded user count",
 			license:         &license.Info{UserCount: 10, ExpiresAt: expiresAt},
 			activeUserCount: 11,
 			wantErr:         true,
 		},
-		{
-			license:         &license.Info{UserCount: 10, ExpiresAt: expiresAt},
-			activeUserCount: 12,
-			wantErr:         true,
-		},
 
-		// True-up licenses.
 		{
+			name:            "true-up and not exceeded user count",
 			license:         &license.Info{Tags: []string{licensing.TrueUpUserCountTag}, UserCount: 10, ExpiresAt: expiresAt},
 			activeUserCount: 5,
 			wantErr:         false,
 		},
 		{
+			name:            "true-up and exceeded user count",
 			license:         &license.Info{Tags: []string{licensing.TrueUpUserCountTag}, UserCount: 10, ExpiresAt: expiresAt},
 			activeUserCount: 15,
 			wantErr:         false,
 		},
 
-		// License expired
 		{
+			name:    "license expired",
 			license: &license.Info{ExpiresAt: time.Now().Add(-1 * time.Minute)},
 			wantErr: true,
 		},
+
+		{
+			name:            "exempt SOAP users",
+			license:         &license.Info{UserCount: 10, ExpiresAt: time.Now().Add(-1 * time.Minute)}, // An expired license
+			activeUserCount: 15,                                                                        // Exceeded free plan user count
+			mockSetup: func(t *testing.T) {
+				cloud.MockSiteConfig(
+					t,
+					&cloud.SchemaSiteConfig{
+						AuthProviders: &cloud.SchemaAuthProviders{
+							SourcegraphOperator: &cloud.SchemaAuthProviderSourcegraphOperator{},
+						},
+					},
+				)
+			},
+			spec: &extsvc.AccountSpec{
+				ServiceType: sourcegraphoperator.ProviderType,
+			},
+		},
 	}
 	for _, test := range tests {
-		t.Run(fmt.Sprintf("license %s with %d active users", test.license, test.activeUserCount), func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			licensing.MockGetConfiguredProductLicenseInfo = func() (*license.Info, string, error) {
 				return test.license, "test-signature", nil
 			}
@@ -94,9 +114,15 @@ func TestEnforcement_PreCreateUser(t *testing.T) {
 			db := database.NewStrictMockDB()
 			db.UsersFunc.SetDefaultReturn(users)
 
-			err := NewBeforeCreateUserHook()(context.Background(), db)
-			if gotErr := err != nil; gotErr != test.wantErr {
-				t.Errorf("got error %v, want %v", gotErr, test.wantErr)
+			if test.mockSetup != nil {
+				test.mockSetup(t)
+			}
+
+			err := NewBeforeCreateUserHook()(context.Background(), db, test.spec)
+			if test.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -154,5 +154,10 @@ type usersStore struct {
 }
 
 func (u *usersStore) Count(ctx context.Context) (int, error) {
-	return u.db.Users().Count(ctx, nil)
+	return u.db.Users().Count(
+		ctx,
+		&database.UsersListOptions{
+			ExcludeSourcegraphOperators: true,
+		},
+	)
 }

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -7,12 +7,11 @@ import (
 	"strconv"
 	"strings"
 
+	gh "github.com/google/go-github/v41/github"
 	"github.com/keegancsmith/sqlf"
 	otlog "github.com/opentracing/opentracing-go/log"
-
 	"github.com/sourcegraph/log"
 
-	gh "github.com/google/go-github/v41/github"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
@@ -260,7 +259,7 @@ func (s *userExternalAccountsStore) CreateUserAndSave(ctx context.Context, newUs
 	}
 	defer func() { err = tx.Done(err) }()
 
-	createdUser, err := UsersWith(s.logger, tx).CreateInTransaction(ctx, newUser)
+	createdUser, err := UsersWith(s.logger, tx).CreateInTransaction(ctx, newUser, &spec)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -47320,7 +47320,7 @@ func NewMockUserStore() *MockUserStore {
 			},
 		},
 		CreateInTransactionFunc: &UserStoreCreateInTransactionFunc{
-			defaultHook: func(context.Context, NewUser) (r0 *types.User, r1 error) {
+			defaultHook: func(context.Context, NewUser, *extsvc.AccountSpec) (r0 *types.User, r1 error) {
 				return
 			},
 		},
@@ -47507,7 +47507,7 @@ func NewStrictMockUserStore() *MockUserStore {
 			},
 		},
 		CreateInTransactionFunc: &UserStoreCreateInTransactionFunc{
-			defaultHook: func(context.Context, NewUser) (*types.User, error) {
+			defaultHook: func(context.Context, NewUser, *extsvc.AccountSpec) (*types.User, error) {
 				panic("unexpected invocation of MockUserStore.CreateInTransaction")
 			},
 		},
@@ -48119,24 +48119,24 @@ func (c UserStoreCreateFuncCall) Results() []interface{} {
 // CreateInTransaction method of the parent MockUserStore instance is
 // invoked.
 type UserStoreCreateInTransactionFunc struct {
-	defaultHook func(context.Context, NewUser) (*types.User, error)
-	hooks       []func(context.Context, NewUser) (*types.User, error)
+	defaultHook func(context.Context, NewUser, *extsvc.AccountSpec) (*types.User, error)
+	hooks       []func(context.Context, NewUser, *extsvc.AccountSpec) (*types.User, error)
 	history     []UserStoreCreateInTransactionFuncCall
 	mutex       sync.Mutex
 }
 
 // CreateInTransaction delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockUserStore) CreateInTransaction(v0 context.Context, v1 NewUser) (*types.User, error) {
-	r0, r1 := m.CreateInTransactionFunc.nextHook()(v0, v1)
-	m.CreateInTransactionFunc.appendCall(UserStoreCreateInTransactionFuncCall{v0, v1, r0, r1})
+func (m *MockUserStore) CreateInTransaction(v0 context.Context, v1 NewUser, v2 *extsvc.AccountSpec) (*types.User, error) {
+	r0, r1 := m.CreateInTransactionFunc.nextHook()(v0, v1, v2)
+	m.CreateInTransactionFunc.appendCall(UserStoreCreateInTransactionFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the CreateInTransaction
 // method of the parent MockUserStore instance is invoked and the hook queue
 // is empty.
-func (f *UserStoreCreateInTransactionFunc) SetDefaultHook(hook func(context.Context, NewUser) (*types.User, error)) {
+func (f *UserStoreCreateInTransactionFunc) SetDefaultHook(hook func(context.Context, NewUser, *extsvc.AccountSpec) (*types.User, error)) {
 	f.defaultHook = hook
 }
 
@@ -48144,7 +48144,7 @@ func (f *UserStoreCreateInTransactionFunc) SetDefaultHook(hook func(context.Cont
 // CreateInTransaction method of the parent MockUserStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *UserStoreCreateInTransactionFunc) PushHook(hook func(context.Context, NewUser) (*types.User, error)) {
+func (f *UserStoreCreateInTransactionFunc) PushHook(hook func(context.Context, NewUser, *extsvc.AccountSpec) (*types.User, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -48153,19 +48153,19 @@ func (f *UserStoreCreateInTransactionFunc) PushHook(hook func(context.Context, N
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *UserStoreCreateInTransactionFunc) SetDefaultReturn(r0 *types.User, r1 error) {
-	f.SetDefaultHook(func(context.Context, NewUser) (*types.User, error) {
+	f.SetDefaultHook(func(context.Context, NewUser, *extsvc.AccountSpec) (*types.User, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *UserStoreCreateInTransactionFunc) PushReturn(r0 *types.User, r1 error) {
-	f.PushHook(func(context.Context, NewUser) (*types.User, error) {
+	f.PushHook(func(context.Context, NewUser, *extsvc.AccountSpec) (*types.User, error) {
 		return r0, r1
 	})
 }
 
-func (f *UserStoreCreateInTransactionFunc) nextHook() func(context.Context, NewUser) (*types.User, error) {
+func (f *UserStoreCreateInTransactionFunc) nextHook() func(context.Context, NewUser, *extsvc.AccountSpec) (*types.User, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -48204,6 +48204,9 @@ type UserStoreCreateInTransactionFuncCall struct {
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 NewUser
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 *extsvc.AccountSpec
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *types.User
@@ -48215,7 +48218,7 @@ type UserStoreCreateInTransactionFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c UserStoreCreateInTransactionFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/cookie"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/randstring"
 	"github.com/sourcegraph/sourcegraph/internal/security"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
@@ -38,7 +39,7 @@ import (
 var (
 	// BeforeCreateUser (if set) is a hook called before creating a new user in the DB by any means
 	// (e.g., both directly via Users.Create or via ExternalAccounts.CreateUserAndSave).
-	BeforeCreateUser func(ctx context.Context, db DB) error
+	BeforeCreateUser func(ctx context.Context, db DB, spec *extsvc.AccountSpec) error
 	// AfterCreateUser (if set) is a hook called after creating a new user in the DB by any means
 	// (e.g., both directly via Users.Create or via ExternalAccounts.CreateUserAndSave).
 	// Whatever this hook mutates in database should be reflected on the `user` argument as well.
@@ -55,7 +56,7 @@ type UserStore interface {
 	CheckAndDecrementInviteQuota(context.Context, int32) (ok bool, err error)
 	Count(context.Context, *UsersListOptions) (int, error)
 	Create(context.Context, NewUser) (*types.User, error)
-	CreateInTransaction(context.Context, NewUser) (*types.User, error)
+	CreateInTransaction(context.Context, NewUser, *extsvc.AccountSpec) (*types.User, error)
 	CreatePassword(ctx context.Context, id int32, password string) error
 	CurrentUserAllowedExternalServices(context.Context) (conf.ExternalServiceMode, error)
 	Delete(context.Context, int32) error
@@ -201,7 +202,6 @@ type NewUser struct {
 
 	// TosAccepted is whether the user is created with the terms of service accepted already.
 	TosAccepted bool `json:"-"` // forbid this field being set by JSON, just in case
-
 }
 
 // Create creates a new user in the database.
@@ -227,7 +227,7 @@ func (u *userStore) Create(ctx context.Context, info NewUser) (newUser *types.Us
 		return nil, err
 	}
 	defer func() { err = tx.Done(err) }()
-	newUser, err = tx.CreateInTransaction(ctx, info)
+	newUser, err = tx.CreateInTransaction(ctx, info, nil)
 	if err == nil {
 		logAccountCreatedEvent(ctx, NewDBWith(u.logger, u), newUser, "")
 	}
@@ -242,7 +242,7 @@ func CheckPassword(pw string) error {
 // CreateInTransaction is like Create, except it is expected to be run from within a
 // transaction. It must execute in a transaction because the post-user-creation
 // hooks must run atomically with the user creation.
-func (u *userStore) CreateInTransaction(ctx context.Context, info NewUser) (newUser *types.User, err error) {
+func (u *userStore) CreateInTransaction(ctx context.Context, info NewUser, spec *extsvc.AccountSpec) (newUser *types.User, err error) {
 	if !u.InTransaction() {
 		return nil, errors.New("must run within a transaction")
 	}
@@ -294,7 +294,7 @@ func (u *userStore) CreateInTransaction(ctx context.Context, info NewUser) (newU
 
 	// Run BeforeCreateUser hook.
 	if BeforeCreateUser != nil {
-		if err := BeforeCreateUser(ctx, NewDBWith(u.logger, u.Store)); err != nil {
+		if err := BeforeCreateUser(ctx, NewDBWith(u.logger, u.Store), spec); err != nil {
 			return nil, errors.Wrap(err, "pre create user hook")
 		}
 	}
@@ -816,6 +816,8 @@ type UsersListOptions struct {
 	InactiveSince time.Time
 
 	ExcludeSourcegraphAdmins bool // filter out users with a known Sourcegraph admin username
+	// ExcludeSourcegraphOperators indicates whether to exclude Sourcegraph Operator user accounts.
+	ExcludeSourcegraphOperators bool
 
 	*LimitOffset
 }
@@ -928,6 +930,8 @@ func (*userStore) listSQL(opt UsersListOptions) (conds []*sqlf.Query) {
 	// This method of filtering is imperfect and may still incur false positives, but
 	// the two together should help prevent that in the majority of cases, and we
 	// acknowledge this risk as we would prefer to undercount rather than overcount.
+	//
+	// TODO(jchen): This hack will be removed as part of https://github.com/sourcegraph/customer/issues/1531
 	if opt.ExcludeSourcegraphAdmins {
 		conds = append(conds, sqlf.Sprintf(`
 -- The user does not...
@@ -945,7 +949,17 @@ NOT(
 			AND user_emails.email ILIKE '%%@sourcegraph.com')
 )
 `))
+	}
 
+	if opt.ExcludeSourcegraphOperators {
+		conds = append(conds, sqlf.Sprintf(`
+NOT EXISTS (
+	SELECT FROM user_external_accounts
+	WHERE
+		service_type = 'sourcegraph-operator'
+	AND user_id = u.id
+)
+`))
 	}
 	return conds
 }

--- a/internal/database/users_test.go
+++ b/internal/database/users_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/log/logtest"
 
@@ -328,6 +329,37 @@ func TestUsers_ListCount(t *testing.T) {
 	} else if len(users) > 0 {
 		t.Errorf("got %d, want empty", len(users))
 	}
+
+	// Create a Sourcegraph Operator user and should be excluded when desired
+	_, err = db.UserExternalAccounts().CreateUserAndSave(
+		ctx,
+		NewUser{
+			Username: "sourcegraph-operator-logan",
+		},
+		extsvc.AccountSpec{
+			ServiceType: "sourcegraph-operator",
+		},
+		extsvc.AccountData{},
+	)
+	require.NoError(t, err)
+	count, err := db.Users().Count(
+		ctx,
+		&UsersListOptions{
+			ExcludeSourcegraphAdmins:    true,
+			ExcludeSourcegraphOperators: true,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+	users, err := db.Users().List(
+		ctx,
+		&UsersListOptions{
+			ExcludeSourcegraphAdmins:    true,
+			ExcludeSourcegraphOperators: true,
+		},
+	)
+	require.NoError(t, err)
+	assert.Len(t, users, 0)
 }
 
 func TestUsers_Update(t *testing.T) {


### PR DESCRIPTION
This PR adds the code logic to exempt SOAP user accounts from our license user count.

I also choose to "hide" the count of SOAP user accounts from total user counts in various places in the UI because we display "Licensed user count" alongside these counts, and it would greatly confuse site admins (e.g. how do we explain their licensed user count is 10 and now at 9 but 2 of them are Sourcegraph operators, I'd prefer WYSIWYG).

## Test plan

1. Create a temporary JSON file (`site-config.json`) with the following content, the credentials can be obtained from the "Okta test instance admin" in 1Password and the "OpenID Connect (sourcegraph.test:3443)" application:
	```json
	{
	  "authProviders": {
	    "sourcegraphOperator": {
	      "issuer": "https://dev-433675.oktapreview.com",
	      "clientID": "<REDACTED>",
	      "clientSecret": "<REDACTED>",
	      "lifecycleDuration": 60
	    }
	  }
	}
	```
2. Save the "the "Okta test instance admin" in 1Password and the "OpenID Connect (sourcegraph.test:3443)" application" in 1Password to a temporary file (`singer.key`), and sign the site config:
	```sh
	go run enterprise/internal/cloud/sign_site_config.go -private-key singer.key  -site-config site-config.json
	```
3. Set the output of the above command as the value of the env var `SRC_CLOUD_SITE_CONFIG`
4. Comment out the `"licenseKey"` from the `dev-private/enterprise/dev/site-config.json`
5. Boot up the local Sourcegraph instance and try to sign in with "Sourcergaph Operators" using the same Okta account used in step 1.
6. Go to https://sourcegraph.test:3443/site-admin/license and the "X currently used" should not increase

---

Stacked on https://github.com/sourcegraph/sourcegraph/pull/43987, closes  https://github.com/sourcegraph/customer/issues/1429