### PR TITLE
[a11y] Set user profile horizontal divider as hidden for screen readers

### DIFF
--- a/client/web/src/user/settings/profile/EditUserProfileForm.tsx
+++ b/client/web/src/user/settings/profile/EditUserProfileForm.tsx
@@ -99,7 +99,7 @@ export const EditUserProfileForm: React.FunctionComponent<React.PropsWithChildre
                 )}
                 {after && (
                     <>
-                        <hr className="my-4" />
+                        <hr className="my-4" aria-hidden={true} />
                         {after}
                     </>
                 )}


### PR DESCRIPTION

## Test plan

Added just one attribute for accessibility reasons. Tested locally when recording voiceover videos:

https://user-images.githubusercontent.com/9974711/201086355-eab26c8d-e2f6-49e4-abeb-aa97895d29a7.mp4



## App preview:

- [Web](https://sg-web-milan-a11y-fixes.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
