### PR TITLE
Revert "internal/extsvc/github: Log error from token.refreshFunc (#43998)

### DIFF
--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1517,9 +1517,7 @@ func doRequest(ctx context.Context, logger log.Logger, apiURL *url.URL, auther a
 		autherWithRefresh, ok = auther.(auth.AuthenticatorWithRefresh)
 		// Check if we should pre-emptively refresh
 		if ok && autherWithRefresh.NeedsRefresh() {
-			if err := autherWithRefresh.Refresh(ctx, httpClient); err != nil {
-				logger.Warn("doRequest: failed to refresh token", log.Error(err))
-			}
+			autherWithRefresh.Refresh(ctx, httpClient)
 		}
 		if err := auther.Authenticate(req); err != nil {
 			return nil, errors.Wrap(err, "authenticating request")
@@ -1548,7 +1546,7 @@ func doRequest(ctx context.Context, logger log.Logger, apiURL *url.URL, auther a
 	} else {
 		resp, err = httpClient.Do(req.WithContext(ctx))
 		if err != nil {
-			return nil, errors.Wrap(err, "http request failed")
+			return nil, err
 		}
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
This reverts commit 5a7e96ad1925408e167d93aca165eed358a5214b from https://github.com/sourcegraph/sourcegraph/pull/43998

Why?

It causes a lot of log spam locally, even though everything's working fine:

```
[   repo-updater] WARN provider.github.v3.github.v3 github/common.go:1521 doRequest: failed to refresh token {"urn": "extsvc:github:1", "resource": "rest", "error": "no refresh token available"}
[   repo-updater] WARN provider.github.v3.github.v3 github/common.go:1521 doRequest: failed to refresh token {"urn": "extsvc:github:1", "resource": "rest", "error": "no refresh token available"}
[   repo-updater] WARN provider.github.v3.github.v3 github/common.go:1521 doRequest: failed to refresh token {"urn": "extsvc:github:1", "resource": "rest", "error": "no refresh token available"}
[   repo-updater] WARN provider.github.v3.github.v3 github/common.go:1521 doRequest: failed to refresh token {"urn": "extsvc:github:1", "resource": "rest", "error": "no refresh token available"}
[   repo-updater] WARN provider.github.v3.github.v3 github/common.go:1521 doRequest: failed to refresh token {"urn": "extsvc:github:1", "resource": "rest", "error": "no refresh token available"}
[   repo-updater] WARN provider.github.v3.github.v3 github/common.go:1521 doRequest: failed to refresh token {"urn": "extsvc:github:1", "resource": "rest", "error": "no refresh token available"}
[   repo-updater] WARN provider.github.v3.github.v3 github/common.go:1521 doRequest: failed to refresh token {"urn": "extsvc:github:1", "resource": "rest", "error": "no refresh token available"}
[   repo-updater] WARN provider.github.v3.github.v3 github/common.go:1521 doRequest: failed to refresh token {"urn": "extsvc:github:1", "resource": "rest", "error": "no refresh token available"}
```

We should take a closer look at this once @pjlast is back (or if someone else from @sourcegraph/iam has capacity to look at it), but for now I want to avoid this slipping into the release branch on Tuesday.

## Test plan

- N/A