### PR TITLE
webhooks: More specific error message

### DIFF
--- a/cmd/frontend/webhooks/github_webhooks.go
+++ b/cmd/frontend/webhooks/github_webhooks.go
@@ -11,8 +11,10 @@ import (
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -37,7 +39,13 @@ func (h *GitHubWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	extSvc, err := h.getExternalService(r, body)
 	if err != nil {
 		log15.Error("Could not find valid external service for webhook", "error", err)
-		http.Error(w, "External service not found", http.StatusInternalServerError)
+
+		if errcode.IsNotFound(err) {
+			http.Error(w, "External service not found", http.StatusInternalServerError)
+			return
+		}
+
+		http.Error(w, "Error validating payload", http.StatusBadRequest)
 		return
 	}
 

--- a/cmd/frontend/webhooks/github_webhooks.go
+++ b/cmd/frontend/webhooks/github_webhooks.go
@@ -41,7 +41,7 @@ func (h *GitHubWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log15.Error("Could not find valid external service for webhook", "error", err)
 
 		if errcode.IsNotFound(err) {
-			http.Error(w, "External service not found", http.StatusInternalServerError)
+			http.Error(w, "External service not found", http.StatusNotFound)
 			return
 		}
 

--- a/cmd/frontend/webhooks/github_webhooks_test.go
+++ b/cmd/frontend/webhooks/github_webhooks_test.go
@@ -224,8 +224,8 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 			hook.ServeHTTP(rec, req)
 			resp := rec.Result()
 
-			if resp.StatusCode != http.StatusInternalServerError {
-				t.Errorf("Non 500 code: %v", resp.StatusCode)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Errorf("Non 400 code: %v", resp.StatusCode)
 			}
 
 			if called {

--- a/cmd/frontend/webhooks/github_webhooks_test.go
+++ b/cmd/frontend/webhooks/github_webhooks_test.go
@@ -110,13 +110,10 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
-
 	ctx := context.Background()
 
 	secret := "secret"
@@ -184,53 +181,47 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 		"https://example.com/.api/github-webhook",
 	}
 
+	sendRequest := func(u, secret string) *http.Response {
+		req, err := http.NewRequest("POST", u, bytes.NewReader(eventPayload))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("X-Github-Event", "public")
+		if secret != "" {
+			req.Header.Set("X-Hub-Signature", sign(t, eventPayload, []byte(secret)))
+		}
+		rec := httptest.NewRecorder()
+		hook.ServeHTTP(rec, req)
+		resp := rec.Result()
+		return resp
+	}
+
+	t.Run("missing service", func(t *testing.T) {
+		u, err := extsvc.WebhookURL(extsvc.TypeGitHub, 99, nil, "https://example.com/")
+		if err != nil {
+			t.Fatal(err)
+		}
+		called = false
+		resp := sendRequest(u, secret)
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+		assert.False(t, called)
+	})
+
 	t.Run("valid secret", func(t *testing.T) {
 		for _, u := range urls {
 			called = false
-
-			req, err := http.NewRequest("POST", u, bytes.NewReader(eventPayload))
-			if err != nil {
-				t.Fatal(err)
-			}
-			req.Header.Set("X-Github-Event", "public")
-			req.Header.Set("X-Hub-Signature", sign(t, eventPayload, []byte(secret)))
-
-			rec := httptest.NewRecorder()
-			hook.ServeHTTP(rec, req)
-			resp := rec.Result()
-
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("Non 200 code: %v", resp.StatusCode)
-			}
-
-			if !called {
-				t.Fatalf("Expected called to be true, got false (webhook handler was not called)")
-			}
+			resp := sendRequest(u, secret)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.True(t, called)
 		}
 	})
 
 	t.Run("invalid secret", func(t *testing.T) {
 		for _, u := range urls {
 			called = false
-
-			req, err := http.NewRequest("POST", u, bytes.NewReader(eventPayload))
-			if err != nil {
-				t.Fatal(err)
-			}
-			req.Header.Set("X-Github-Event", "public")
-			req.Header.Set("X-Hub-Signature", sign(t, eventPayload, []byte("not_secret")))
-
-			rec := httptest.NewRecorder()
-			hook.ServeHTTP(rec, req)
-			resp := rec.Result()
-
-			if resp.StatusCode != http.StatusBadRequest {
-				t.Errorf("Non 400 code: %v", resp.StatusCode)
-			}
-
-			if called {
-				t.Fatalf("Expected called to be false, got true (webhook handler was called)")
-			}
+			resp := sendRequest(u, "not_secret")
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			assert.False(t, called)
 		}
 	})
 
@@ -239,24 +230,9 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 		// signed and we don't need to validate it on our side
 		for _, u := range urls {
 			called = false
-
-			req, err := http.NewRequest("POST", u, bytes.NewReader(eventPayload))
-			if err != nil {
-				t.Fatal(err)
-			}
-			req.Header.Set("X-Github-Event", "public")
-
-			rec := httptest.NewRecorder()
-			hook.ServeHTTP(rec, req)
-			resp := rec.Result()
-
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("Non 200 code: %v", resp.StatusCode)
-			}
-
-			if !called {
-				t.Fatalf("Expected called to be true, got false (webhook handler was not called)")
-			}
+			resp := sendRequest(u, "")
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.True(t, called)
 		}
 	})
 }


### PR DESCRIPTION
Instead of always saying that we can't find the external service we now
also mention when we were unable to validate the payload.

## Test plan

Tests updated