### PR TITLE
Improve DB pressure on gitserver rollout

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -780,61 +780,72 @@ func (s *Server) syncRepoState(gitServerAddrs gitserver.GitServerAddresses, batc
 	options := database.IterateRepoGitserverStatusOptions{
 		// We also want to include deleted repos as they may still be cloned on disk
 		IncludeDeleted: true,
+		BatchSize:      batchSize,
 	}
 	if !fullSync {
 		options.OnlyWithoutShard = true
 	}
-	err := store.IterateRepoGitserverStatus(ctx, options, func(repo types.RepoGitserverStatus) error {
-		repoSyncStateCounter.WithLabelValues("check").Inc()
-
-		// We may have a deleted repo, we need to extract the original name both to
-		// ensure that the shard check is correct and also so that we can find the
-		// directory.
-		repo.Name = api.UndeletedRepoName(repo.Name)
-
-		// Ensure we're only dealing with repos we are responsible for.
-		addr, err := s.addrForRepo(ctx, repo.Name, gitServerAddrs)
+	for {
+		repos, nextRepo, err := store.IterateRepoGitserverStatus(ctx, options)
 		if err != nil {
 			return err
 		}
-		if !s.hostnameMatch(addr) {
-			repoSyncStateCounter.WithLabelValues("other_shard").Inc()
-			return nil
+		for _, repo := range repos {
+			repoSyncStateCounter.WithLabelValues("check").Inc()
+
+			// We may have a deleted repo, we need to extract the original name both to
+			// ensure that the shard check is correct and also so that we can find the
+			// directory.
+			repo.Name = api.UndeletedRepoName(repo.Name)
+
+			// Ensure we're only dealing with repos we are responsible for.
+			addr, err := s.addrForRepo(ctx, repo.Name, gitServerAddrs)
+			if err != nil {
+				return err
+			}
+			if !s.hostnameMatch(addr) {
+				repoSyncStateCounter.WithLabelValues("other_shard").Inc()
+				continue
+			}
+			repoSyncStateCounter.WithLabelValues("this_shard").Inc()
+
+			dir := s.dir(repo.Name)
+			cloned := repoCloned(dir)
+			_, cloning := s.locker.Status(dir)
+
+			var shouldUpdate bool
+			if repo.ShardID != s.Hostname {
+				repo.ShardID = s.Hostname
+				shouldUpdate = true
+			}
+			cloneStatus := cloneStatus(cloned, cloning)
+			if repo.CloneStatus != cloneStatus {
+				repo.CloneStatus = cloneStatus
+				shouldUpdate = true
+			}
+
+			if !shouldUpdate {
+				continue
+			}
+
+			batch = append(batch, repo.GitserverRepo)
+
+			if len(batch) >= batchSize {
+				writeBatch()
+			}
 		}
-		repoSyncStateCounter.WithLabelValues("this_shard").Inc()
 
-		dir := s.dir(repo.Name)
-		cloned := repoCloned(dir)
-		_, cloning := s.locker.Status(dir)
-
-		var shouldUpdate bool
-		if repo.ShardID != s.Hostname {
-			repo.ShardID = s.Hostname
-			shouldUpdate = true
-		}
-		cloneStatus := cloneStatus(cloned, cloning)
-		if repo.CloneStatus != cloneStatus {
-			repo.CloneStatus = cloneStatus
-			shouldUpdate = true
+		if nextRepo == 0 {
+			break
 		}
 
-		if !shouldUpdate {
-			return nil
-		}
-
-		batch = append(batch, repo.GitserverRepo)
-
-		if len(batch) >= batchSize {
-			writeBatch()
-		}
-
-		return nil
-	})
+		options.NextCursor = nextRepo
+	}
 
 	// Attempt final write
 	writeBatch()
 
-	return err
+	return nil
 }
 
 // Stop cancels the running background jobs and returns when done.

--- a/cmd/repo-updater/shared/main_test.go
+++ b/cmd/repo-updater/shared/main_test.go
@@ -15,8 +15,8 @@ import (
 func Test_manualPurgeHandler(t *testing.T) {
 	db := database.NewMockDB()
 	gsr := database.NewMockGitserverRepoStore()
-	gsr.IterateRepoGitserverStatusFunc.SetDefaultHook(func(ctx context.Context, options database.IterateRepoGitserverStatusOptions, f func(repo types.RepoGitserverStatus) error) error {
-		return nil
+	gsr.IterateRepoGitserverStatusFunc.SetDefaultHook(func(ctx context.Context, irgso database.IterateRepoGitserverStatusOptions) ([]types.RepoGitserverStatus, int, error) {
+		return []types.RepoGitserverStatus{}, 0, nil
 	})
 	db.GitserverReposFunc.SetDefaultReturn(gsr)
 

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -28,8 +28,8 @@ type GitserverRepoStore interface {
 	// IterateRepoGitserverStatus iterates over the status of all repos by joining
 	// our repo and gitserver_repos table. It is impossible for us not to have a
 	// corresponding row in gitserver_repos because of the trigger on repos table.
-	// repoFn will be called once for each row. If it returns an error we'll abort iteration.
-	IterateRepoGitserverStatus(ctx context.Context, options IterateRepoGitserverStatusOptions, repoFn func(repo types.RepoGitserverStatus) error) error
+	// Use cursors and limit batch size to paginate through the full set.
+	IterateRepoGitserverStatus(ctx context.Context, options IterateRepoGitserverStatusOptions) (rs []types.RepoGitserverStatus, nextCursor int, err error)
 	GetByID(ctx context.Context, id api.RepoID) (*types.GitserverRepo, error)
 	GetByName(ctx context.Context, name api.RepoName) (*types.GitserverRepo, error)
 	GetByNames(ctx context.Context, names ...api.RepoName) (map[api.RepoName]*types.GitserverRepo, error)
@@ -237,13 +237,11 @@ type IterateRepoGitserverStatusOptions struct {
 	// If true, also include deleted repos. Note that their repo name will start with
 	// 'DELETED-'
 	IncludeDeleted bool
+	BatchSize      int
+	NextCursor     int
 }
 
-func (s *gitserverRepoStore) IterateRepoGitserverStatus(ctx context.Context, options IterateRepoGitserverStatusOptions, repoFn func(repo types.RepoGitserverStatus) error) (err error) {
-	if repoFn == nil {
-		return errors.New("nil repoFn")
-	}
-
+func (s *gitserverRepoStore) IterateRepoGitserverStatus(ctx context.Context, options IterateRepoGitserverStatusOptions) (rs []types.RepoGitserverStatus, nextCursor int, err error) {
 	preds := []*sqlf.Query{}
 
 	if !options.IncludeDeleted {
@@ -254,39 +252,48 @@ func (s *gitserverRepoStore) IterateRepoGitserverStatus(ctx context.Context, opt
 		preds = append(preds, sqlf.Sprintf("gr.shard_id = ''"))
 	}
 
+	if options.NextCursor > 0 {
+		preds = append(preds, sqlf.Sprintf("gr.repo_id > %s", options.NextCursor))
+	}
+
 	if len(preds) == 0 {
 		preds = append(preds, sqlf.Sprintf("TRUE"))
 	}
 
-	q := sqlf.Sprintf(iterateRepoGitserverQuery, sqlf.Join(preds, "AND"))
+	var limitOffset *LimitOffset
+	if options.BatchSize > 0 {
+		limitOffset = &LimitOffset{Limit: options.BatchSize}
+	}
+
+	q := sqlf.Sprintf(iterateRepoGitserverQuery, sqlf.Join(preds, "AND"), limitOffset.SQL())
 
 	rows, err := s.Query(ctx, q)
 	if err != nil {
-		return errors.Wrap(err, "fetching gitserver status")
+		return rs, nextCursor, errors.Wrap(err, "fetching gitserver status")
 	}
 	defer func() {
 		err = basestore.CloseRows(rows, err)
 	}()
 
+	rs = make([]types.RepoGitserverStatus, 0, options.BatchSize)
+
 	for rows.Next() {
 		gr, name, err := scanGitserverRepo(rows)
 		if err != nil {
-			return errors.Wrap(err, "scanning row")
+			return rs, nextCursor, errors.Wrap(err, "scanning row")
 		}
+
+		nextCursor = int(gr.RepoID)
 
 		rgs := types.RepoGitserverStatus{
 			ID:            gr.RepoID,
 			Name:          name,
 			GitserverRepo: gr,
 		}
-
-		if err := repoFn(rgs); err != nil {
-			// Abort
-			return errors.Wrap(err, "calling repoFn")
-		}
+		rs = append(rs, rgs)
 	}
 
-	return nil
+	return rs, nextCursor, nil
 }
 
 const iterateRepoGitserverQuery = `
@@ -303,6 +310,8 @@ SELECT
 FROM gitserver_repos gr
 JOIN repo ON gr.repo_id = repo.id
 WHERE %s
+ORDER BY repo_id ASC
+%s
 `
 
 func (s *gitserverRepoStore) GetByID(ctx context.Context, id api.RepoID) (*types.GitserverRepo, error) {

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -22847,7 +22847,7 @@ func NewMockGitserverRepoStore() *MockGitserverRepoStore {
 			},
 		},
 		IterateRepoGitserverStatusFunc: &GitserverRepoStoreIterateRepoGitserverStatusFunc{
-			defaultHook: func(context.Context, IterateRepoGitserverStatusOptions, func(repo types.RepoGitserverStatus) error) (r0 error) {
+			defaultHook: func(context.Context, IterateRepoGitserverStatusOptions) (r0 []types.RepoGitserverStatus, r1 int, r2 error) {
 				return
 			},
 		},
@@ -22935,7 +22935,7 @@ func NewStrictMockGitserverRepoStore() *MockGitserverRepoStore {
 			},
 		},
 		IterateRepoGitserverStatusFunc: &GitserverRepoStoreIterateRepoGitserverStatusFunc{
-			defaultHook: func(context.Context, IterateRepoGitserverStatusOptions, func(repo types.RepoGitserverStatus) error) error {
+			defaultHook: func(context.Context, IterateRepoGitserverStatusOptions) ([]types.RepoGitserverStatus, int, error) {
 				panic("unexpected invocation of MockGitserverRepoStore.IterateRepoGitserverStatus")
 			},
 		},
@@ -23595,24 +23595,24 @@ func (c GitserverRepoStoreIteratePurgeableReposFuncCall) Results() []interface{}
 // when the IterateRepoGitserverStatus method of the parent
 // MockGitserverRepoStore instance is invoked.
 type GitserverRepoStoreIterateRepoGitserverStatusFunc struct {
-	defaultHook func(context.Context, IterateRepoGitserverStatusOptions, func(repo types.RepoGitserverStatus) error) error
-	hooks       []func(context.Context, IterateRepoGitserverStatusOptions, func(repo types.RepoGitserverStatus) error) error
+	defaultHook func(context.Context, IterateRepoGitserverStatusOptions) ([]types.RepoGitserverStatus, int, error)
+	hooks       []func(context.Context, IterateRepoGitserverStatusOptions) ([]types.RepoGitserverStatus, int, error)
 	history     []GitserverRepoStoreIterateRepoGitserverStatusFuncCall
 	mutex       sync.Mutex
 }
 
 // IterateRepoGitserverStatus delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockGitserverRepoStore) IterateRepoGitserverStatus(v0 context.Context, v1 IterateRepoGitserverStatusOptions, v2 func(repo types.RepoGitserverStatus) error) error {
-	r0 := m.IterateRepoGitserverStatusFunc.nextHook()(v0, v1, v2)
-	m.IterateRepoGitserverStatusFunc.appendCall(GitserverRepoStoreIterateRepoGitserverStatusFuncCall{v0, v1, v2, r0})
-	return r0
+func (m *MockGitserverRepoStore) IterateRepoGitserverStatus(v0 context.Context, v1 IterateRepoGitserverStatusOptions) ([]types.RepoGitserverStatus, int, error) {
+	r0, r1, r2 := m.IterateRepoGitserverStatusFunc.nextHook()(v0, v1)
+	m.IterateRepoGitserverStatusFunc.appendCall(GitserverRepoStoreIterateRepoGitserverStatusFuncCall{v0, v1, r0, r1, r2})
+	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the
 // IterateRepoGitserverStatus method of the parent MockGitserverRepoStore
 // instance is invoked and the hook queue is empty.
-func (f *GitserverRepoStoreIterateRepoGitserverStatusFunc) SetDefaultHook(hook func(context.Context, IterateRepoGitserverStatusOptions, func(repo types.RepoGitserverStatus) error) error) {
+func (f *GitserverRepoStoreIterateRepoGitserverStatusFunc) SetDefaultHook(hook func(context.Context, IterateRepoGitserverStatusOptions) ([]types.RepoGitserverStatus, int, error)) {
 	f.defaultHook = hook
 }
 
@@ -23621,7 +23621,7 @@ func (f *GitserverRepoStoreIterateRepoGitserverStatusFunc) SetDefaultHook(hook f
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *GitserverRepoStoreIterateRepoGitserverStatusFunc) PushHook(hook func(context.Context, IterateRepoGitserverStatusOptions, func(repo types.RepoGitserverStatus) error) error) {
+func (f *GitserverRepoStoreIterateRepoGitserverStatusFunc) PushHook(hook func(context.Context, IterateRepoGitserverStatusOptions) ([]types.RepoGitserverStatus, int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -23629,20 +23629,20 @@ func (f *GitserverRepoStoreIterateRepoGitserverStatusFunc) PushHook(hook func(co
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *GitserverRepoStoreIterateRepoGitserverStatusFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, IterateRepoGitserverStatusOptions, func(repo types.RepoGitserverStatus) error) error {
-		return r0
+func (f *GitserverRepoStoreIterateRepoGitserverStatusFunc) SetDefaultReturn(r0 []types.RepoGitserverStatus, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, IterateRepoGitserverStatusOptions) ([]types.RepoGitserverStatus, int, error) {
+		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *GitserverRepoStoreIterateRepoGitserverStatusFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, IterateRepoGitserverStatusOptions, func(repo types.RepoGitserverStatus) error) error {
-		return r0
+func (f *GitserverRepoStoreIterateRepoGitserverStatusFunc) PushReturn(r0 []types.RepoGitserverStatus, r1 int, r2 error) {
+	f.PushHook(func(context.Context, IterateRepoGitserverStatusOptions) ([]types.RepoGitserverStatus, int, error) {
+		return r0, r1, r2
 	})
 }
 
-func (f *GitserverRepoStoreIterateRepoGitserverStatusFunc) nextHook() func(context.Context, IterateRepoGitserverStatusOptions, func(repo types.RepoGitserverStatus) error) error {
+func (f *GitserverRepoStoreIterateRepoGitserverStatusFunc) nextHook() func(context.Context, IterateRepoGitserverStatusOptions) ([]types.RepoGitserverStatus, int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -23683,24 +23683,27 @@ type GitserverRepoStoreIterateRepoGitserverStatusFuncCall struct {
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 IterateRepoGitserverStatusOptions
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 func(repo types.RepoGitserverStatus) error
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 error
+	Result0 []types.RepoGitserverStatus
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 int
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
 }
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c GitserverRepoStoreIterateRepoGitserverStatusFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GitserverRepoStoreIterateRepoGitserverStatusFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // GitserverRepoStoreIterateWithNonemptyLastErrorFunc describes the behavior


### PR DESCRIPTION
When gitserver rolls out, it has to run `IterateRepoGitserverStatus` on every shard once. Since the iteration handler runs while we still fetch rows from the DB, the total query duration of that is about 11 minutes on average on dotcom. (The query keeps running as rows are consumed by gitserver). 

This causes a MASSIVE load spike despite only run 10 times, it will be by far the worst offending query for the full 1h window. This can also cause issues with migrations rolling out during the gitserver rollout (so likely when migrator also rolls out). 
![Screenshot 2022-11-10 at 15 30 33@2x](https://user-images.githubusercontent.com/19534377/201119380-e745933a-a30f-4755-a019-e8fd920a6b10.png)

This PR fixes this issue by doing the following:
- We fetch the repo status in batches, and scan all the rows as fast as possible and return after. The lock and db conn are freed up at this point,
- Then we iterate over the small result set
- And use a cursor to fetch the next page of repos to iterate over

I ran a few of these queries against our big prod db and they all resolve in sub-milliseconds.

This should be no behavioral change overall at all, except that it has to run more smaller queries compared to one gigantic one. This should even out the load better. Since we order by ID ASC, this should not ever miss any records.

## Test plan

Adjusted test suite and made sure things pass locally.