### PR TITLE
remove grafana link in annotation generation

### DIFF
--- a/enterprise/dev/ci/scripts/annotate.sh
+++ b/enterprise/dev/ci/scripts/annotate.sh
@@ -15,7 +15,7 @@ print_usage() {
 
 print_heading() {
     output="&bull; [View job output](#$BUILDKITE_JOB_ID)"
-    printf "**%s** %s %s\n\n" "$BUILDKITE_LABEL" "$output"
+    printf "**%s** %s\n\n" "$BUILDKITE_LABEL" "$output"
 }
 
 if [ $# -eq 0 ]; then

--- a/enterprise/dev/ci/scripts/annotate.sh
+++ b/enterprise/dev/ci/scripts/annotate.sh
@@ -13,29 +13,9 @@ print_usage() {
   printf "  echo \"your markdown\" | annotate.sh -m -s my-section"
 }
 
-generate_grafana_link() {
-    # -sR in the jq command below is "slurp" and "raw" tells jq to escape the json as a raw string since it will be
-    # embedded as a value in other json (aka the query we send to grafana)
-    expression="$(cat <<EOF | jq -sR .
-{app="buildkite", build="$BUILDKITE_BUILD_NUMBER", branch="main", state="failed"}
-|~ "(?i)failed|panic|FAIL \\\\|" # this is a case insensitive regular expression, feel free to unleash your regex-fu!
-EOF
-    )"
-    # On Darwin use gdate
-    begin=$(date -d '1 hour ago' "+%s")000
-    end=$(date -d 'now + 5 mins' "+%s")000
-    payload=$(printf '{"datasource":"grafanacloud-sourcegraph-logs","queries":[{"refId":"A","expr":%s}],"range":{"from":"%s","to":"%s"}}' "$expression" "$begin" "$end")
-
-    echo "https://sourcegraph.grafana.net/explore?orgId=1&left=$(echo "$payload" | jq -s -R -r @uri)"
-}
-
 print_heading() {
-    logs=""
     output="&bull; [View job output](#$BUILDKITE_JOB_ID)"
-    if [[ $BUILDKITE_BRANCH == "main" ]]; then
-        logs="&bull; [View Grafana logs]($(generate_grafana_link))"
-    fi
-    printf "**%s** %s %s\n\n" "$BUILDKITE_LABEL" "$output" "$logs"
+    printf "**%s** %s %s\n\n" "$BUILDKITE_LABEL" "$output"
 }
 
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
Remove the link that gets generated at the top of an annotation which links to grafana with a prefilled query

Part of #43934

## Test plan
Green CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
