### PR TITLE
Search: update docs for before/after to mention UTC

### DIFF
--- a/client/search-ui/src/results/sidebar/SearchReference.tsx
+++ b/client/search-ui/src/results/sidebar/SearchReference.tsx
@@ -78,7 +78,7 @@ const filterInfos: FilterInfo[] = [
         ...createQueryExampleFromString('"{last week}"'),
         field: FilterType.after,
         description:
-            'Only include results from diffs or commits which have a commit date after the specified time frame. To use this filter, the search query must contain `type:diff` or `type:commit`.',
+            'Only include results from diffs or commits which have a commit date after the specified time frame. Times are interpreted as UTC by default. To use this filter, the search query must contain `type:diff` or `type:commit`.',
         commonRank: 100,
         examples: ['after:"6 weeks ago"', 'after:"november 1 2019"'],
     },
@@ -103,7 +103,7 @@ To use this filter, the search query must contain \`type:diff\` or \`type:commit
         ...createQueryExampleFromString('"{last thursday}"'),
         field: FilterType.before,
         description:
-            'Only include results from diffs or commits which have a commit date before the specified time frame. To use this filter, the search query must contain `type:diff` or `type:commit`.',
+            'Only include results from diffs or commits which have a commit date before the specified time frame. Times are interpreted as UTC by default. To use this filter, the search query must contain `type:diff` or `type:commit`.',
         commonRank: 100,
         examples: ['before:"last thursday"', 'before:"november 1 2019"'],
     },

--- a/client/shared/src/search/query/filters.ts
+++ b/client/shared/src/search/query/filters.ts
@@ -184,7 +184,7 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
     Record<Exclude<FilterType, NegatableFilter>, BaseFilterDefinition> = {
     [FilterType.after]: {
         alias: 'since',
-        description: 'Commits made after a certain date',
+        description: 'Commits made after a certain date (in UTC)',
         placeholder: '"time frame"',
     },
     [FilterType.archived]: {
@@ -199,7 +199,7 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
     },
     [FilterType.before]: {
         alias: 'until',
-        description: 'Commits made before a certain date',
+        description: 'Commits made before a certain date (in UTC)',
         placeholder: '"time frame"',
     },
     [FilterType.case]: {

--- a/doc/code_search/reference/language.md
+++ b/doc/code_search/reference/language.md
@@ -740,7 +740,7 @@ ComplexDiagram(
     Terminal("quoted string", {href: "#quoted-string"})).addTo();
 </script>
 
-Include results having a commit date before the specified time frame.
+Include results having a commit date before the specified time frame. Times are interpreted as UTC by default.
 Many forms are accepted for the argument, such as:
 - `november 1 2019`
 - `1 november 2019`
@@ -772,7 +772,7 @@ ComplexDiagram(
     Terminal("quoted string", {href: "#quoted-string"})).addTo();
 </script>
 
-Include results having a commit date after the specified time frame.
+Include results having a commit date after the specified time frame. Times are interpreted as UTC by default.
 Many forms are accepted for the argument, such as:
 - `november 1 2019`
 - `1 november 2019`


### PR DESCRIPTION
I skipped the tooltip hovers because we need those to be short. 

## Test plan

N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cc-before-after-docs.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
