### PR TITLE
web: add WebhookInfoLogPageHeader component.

### DIFF
--- a/client/web/src/site-admin/WebhookInfoLogPageHeader.module.scss
+++ b/client/web/src/site-admin/WebhookInfoLogPageHeader.module.scss
@@ -1,0 +1,31 @@
+.grid {
+    display: grid;
+    grid-template-columns: max-content max-content 1fr max-content;
+    column-gap: 1rem;
+    row-gap: 1rem;
+
+    > * {
+        grid-row: 1 / 2;
+    }
+}
+
+.icon {
+    fill: var(--danger) !important;
+}
+
+.icon.enabled {
+    fill: var(--light-text) !important;
+}
+
+.errors {
+    grid-column: 1 / 2;
+}
+
+.services {
+    grid-column: 2 / 3;
+}
+
+.buttons {
+    grid-column: 4 / 5;
+    align-self: end;
+}

--- a/client/web/src/site-admin/WebhookInfoLogPageHeader.story.tsx
+++ b/client/web/src/site-admin/WebhookInfoLogPageHeader.story.tsx
@@ -1,0 +1,136 @@
+import React, { useState } from 'react'
+
+import { DecoratorFn, Meta, Story } from '@storybook/react'
+
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
+import { Container } from '@sourcegraph/wildcard'
+
+import { WebStory } from '../components/WebStory'
+
+import { WebhookInfoLogPageHeader } from './WebhookInfoLogPageHeader'
+import { SelectedExternalService } from './webhooks/backend'
+import { buildHeaderMock } from './webhooks/story/fixtures'
+
+const decorator: DecoratorFn = story => (
+    <Container>
+        <div className="p-3 container">{story()}</div>
+    </Container>
+)
+
+const config: Meta = {
+    title: 'web/src/site-admin/WebhookInfoLogPageHeader',
+    parameters: {
+        chromatic: {
+            viewports: [320, 576, 978, 1440],
+        },
+    },
+    decorators: [decorator],
+    argTypes: {
+        externalServiceCount: {
+            name: 'external service count',
+            control: { type: 'number' },
+        },
+        erroredWebhookCount: {
+            name: 'errored webhook count',
+            control: { type: 'number' },
+        },
+    },
+}
+
+export default config
+
+// Create a component to handle the minimum state management required for a
+// WebhookInfoLogPageHeader.
+const WebhookInfoLogPageHeaderContainer: React.FunctionComponent<
+    React.PropsWithChildren<{
+        initialExternalService?: SelectedExternalService
+        initialOnlyErrors?: boolean
+    }>
+> = ({ initialOnlyErrors }) => {
+    const [onlyErrors, setOnlyErrors] = useState(initialOnlyErrors === true)
+
+    return <WebhookInfoLogPageHeader onlyErrors={onlyErrors} onSetOnlyErrors={setOnlyErrors} />
+}
+
+export const AllZeroes: Story = args => (
+    <WebStory>
+        {() => (
+            <MockedTestProvider mocks={buildHeaderMock(args.externalServiceCount, args.erroredWebhookCount)}>
+                <WebhookInfoLogPageHeaderContainer />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
+AllZeroes.argTypes = {
+    externalServiceCount: {
+        defaultValue: 0,
+    },
+    erroredWebhookCount: {
+        defaultValue: 0,
+    },
+}
+
+AllZeroes.storyName = 'all zeroes'
+
+export const ExternalServices: Story = args => (
+    <WebStory>
+        {() => (
+            <MockedTestProvider mocks={buildHeaderMock(args.externalServiceCount, args.erroredWebhookCount)}>
+                <WebhookInfoLogPageHeaderContainer />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
+
+ExternalServices.storyName = 'external services'
+
+ExternalServices.argTypes = {
+    externalServiceCount: {
+        defaultValue: 10,
+    },
+    erroredWebhookCount: {
+        defaultValue: 0,
+    },
+}
+
+export const ExternalServicesAndErrors: Story = args => (
+    <WebStory>
+        {() => (
+            <MockedTestProvider mocks={buildHeaderMock(args.externalServiceCount, args.erroredWebhookCount)}>
+                <WebhookInfoLogPageHeaderContainer />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
+
+ExternalServicesAndErrors.storyName = 'external services and errors'
+
+ExternalServicesAndErrors.argTypes = {
+    externalServiceCount: {
+        defaultValue: 20,
+    },
+    erroredWebhookCount: {
+        defaultValue: 500,
+    },
+}
+
+export const OnlyErrorsTurnedOn: Story = args => (
+    <WebStory>
+        {() => (
+            <MockedTestProvider mocks={buildHeaderMock(args.externalServiceCount, args.erroredWebhookCount)}>
+                <WebhookInfoLogPageHeaderContainer initialOnlyErrors={true} />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
+
+OnlyErrorsTurnedOn.storyName = 'only errors turned on'
+
+OnlyErrorsTurnedOn.argTypes = {
+    externalServiceCount: {
+        defaultValue: 20,
+    },
+    erroredWebhookCount: {
+        defaultValue: 500,
+    },
+}

--- a/client/web/src/site-admin/WebhookInfoLogPageHeader.story.tsx
+++ b/client/web/src/site-admin/WebhookInfoLogPageHeader.story.tsx
@@ -19,11 +19,6 @@ const decorator: DecoratorFn = story => (
 
 const config: Meta = {
     title: 'web/src/site-admin/WebhookInfoLogPageHeader',
-    parameters: {
-        chromatic: {
-            viewports: [320, 576, 978, 1440],
-        },
-    },
     decorators: [decorator],
     argTypes: {
         externalServiceCount: {
@@ -52,47 +47,6 @@ const WebhookInfoLogPageHeaderContainer: React.FunctionComponent<
     return <WebhookInfoLogPageHeader onlyErrors={onlyErrors} onSetOnlyErrors={setOnlyErrors} />
 }
 
-export const AllZeroes: Story = args => (
-    <WebStory>
-        {() => (
-            <MockedTestProvider mocks={buildHeaderMock(args.externalServiceCount, args.erroredWebhookCount)}>
-                <WebhookInfoLogPageHeaderContainer />
-            </MockedTestProvider>
-        )}
-    </WebStory>
-)
-AllZeroes.argTypes = {
-    externalServiceCount: {
-        defaultValue: 0,
-    },
-    erroredWebhookCount: {
-        defaultValue: 0,
-    },
-}
-
-AllZeroes.storyName = 'all zeroes'
-
-export const ExternalServices: Story = args => (
-    <WebStory>
-        {() => (
-            <MockedTestProvider mocks={buildHeaderMock(args.externalServiceCount, args.erroredWebhookCount)}>
-                <WebhookInfoLogPageHeaderContainer />
-            </MockedTestProvider>
-        )}
-    </WebStory>
-)
-
-ExternalServices.storyName = 'external services'
-
-ExternalServices.argTypes = {
-    externalServiceCount: {
-        defaultValue: 10,
-    },
-    erroredWebhookCount: {
-        defaultValue: 0,
-    },
-}
-
 export const ExternalServicesAndErrors: Story = args => (
     <WebStory>
         {() => (
@@ -106,27 +60,6 @@ export const ExternalServicesAndErrors: Story = args => (
 ExternalServicesAndErrors.storyName = 'external services and errors'
 
 ExternalServicesAndErrors.argTypes = {
-    externalServiceCount: {
-        defaultValue: 20,
-    },
-    erroredWebhookCount: {
-        defaultValue: 500,
-    },
-}
-
-export const OnlyErrorsTurnedOn: Story = args => (
-    <WebStory>
-        {() => (
-            <MockedTestProvider mocks={buildHeaderMock(args.externalServiceCount, args.erroredWebhookCount)}>
-                <WebhookInfoLogPageHeaderContainer initialOnlyErrors={true} />
-            </MockedTestProvider>
-        )}
-    </WebStory>
-)
-
-OnlyErrorsTurnedOn.storyName = 'only errors turned on'
-
-OnlyErrorsTurnedOn.argTypes = {
     externalServiceCount: {
         defaultValue: 20,
     },

--- a/client/web/src/site-admin/WebhookInfoLogPageHeader.tsx
+++ b/client/web/src/site-admin/WebhookInfoLogPageHeader.tsx
@@ -1,0 +1,58 @@
+import React, { useCallback } from 'react'
+
+import { mdiAlertCircle } from '@mdi/js'
+import classNames from 'classnames'
+
+import { useQuery } from '@sourcegraph/http-client'
+import { Button, Icon } from '@sourcegraph/wildcard'
+
+import { WebhookLogPageHeaderResult } from '../graphql-operations'
+
+import { WEBHOOK_LOG_PAGE_HEADER } from './webhooks/backend'
+import { PerformanceGauge } from './webhooks/PerformanceGauge'
+
+import styles from './WebhookInfoLogPageHeader.module.scss'
+
+export interface Props {
+    onlyErrors: boolean
+
+    onSetOnlyErrors: (onlyErrors: boolean) => void
+}
+
+export const WebhookInfoLogPageHeader: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
+    onlyErrors,
+    onSetOnlyErrors: onSetErrors,
+}) => {
+    const onErrorToggle = useCallback(() => onSetErrors(!onlyErrors), [onlyErrors, onSetErrors])
+
+    const { data } = useQuery<WebhookLogPageHeaderResult>(WEBHOOK_LOG_PAGE_HEADER, {})
+    const errorCount = data?.webhookLogs.totalCount ?? 0
+
+    return (
+        <div className={styles.grid}>
+            <div className={styles.errors}>
+                <PerformanceGauge
+                    count={data?.webhookLogs.totalCount}
+                    countClassName={errorCount > 0 ? 'text-danger' : undefined}
+                    label="recent error"
+                />
+            </div>
+            <div className={styles.services}>
+                <PerformanceGauge count={data?.externalServices.totalCount} label="external service" />
+            </div>
+            <div className={styles.buttons}>
+                <Button variant="danger" onClick={onErrorToggle} outline={!onlyErrors}>
+                    <Icon
+                        className={classNames(styles.icon, onlyErrors && styles.enabled)}
+                        aria-hidden={true}
+                        svgPath={mdiAlertCircle}
+                    />
+                    <span className="ml-1">Show errors</span>
+                </Button>
+                <Button variant="success" className="ml-2">
+                    <span className="ml-1">Send test event</span>
+                </Button>
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
Test plan:
Storybook.

This component is needed for [WebhookInfoPage](https://www.figma.com/file/ngPEwLqRVFAfXQC7lE0WLz/Webhooks?node-id=1%3A1020).

It is a header for webhook logs, inspired by [WebhookLogPageHeader](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/site-admin/webhooks/WebhookLogPageHeader.tsx?subtree=true), but I decided not to mess with existing component and create my own, because it is still different.

Part of https://github.com/sourcegraph/sourcegraph/issues/43487

## App preview:

- [Web](https://sg-web-ao-ui-webhook-info-logs-header.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
