### PR TITLE
Limit number of orgs in user nav menu

### DIFF
--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -71,6 +71,7 @@ export const UserNavItem: React.FunctionComponent<React.PropsWithChildren<UserNa
     // Target ID for tooltip
     const targetID = 'target-user-avatar'
     const keyboardShortcutSwitchTheme = useKeyboardShortcut('switchTheme')
+    const organizations = props.authenticatedUser.organizations.nodes
 
     return (
         <>
@@ -145,15 +146,20 @@ export const UserNavItem: React.FunctionComponent<React.PropsWithChildren<UserNa
                                     </div>
                                 )}
                             </div>
-                            {props.authenticatedUser.organizations.nodes.length > 0 && (
+                            {organizations.length > 0 && (
                                 <>
                                     <MenuDivider className={styles.dropdownDivider} />
                                     <MenuHeader className={styles.dropdownHeader}>Your organizations</MenuHeader>
-                                    {props.authenticatedUser.organizations.nodes.map(org => (
+                                    {organizations.slice(0, 5).map(org => (
                                         <MenuLink as={Link} key={org.id} to={org.settingsURL || org.url}>
                                             {org.displayName || org.name}
                                         </MenuLink>
                                     ))}
+                                    {organizations.length > 5 && (
+                                        <MenuLink as={Link} to={props.authenticatedUser.settingsURL!}>
+                                            Show all organizations
+                                        </MenuLink>
+                                    )}
                                 </>
                             )}
                             <MenuDivider className={styles.dropdownDivider} />

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -27,6 +27,7 @@ import { UserAvatar } from '../user/UserAvatar'
 
 import styles from './UserNavItem.module.scss'
 
+const MAX_VISIBLE_ORGS = 5
 export interface UserNavItemProps extends ThemeProps, ThemePreferenceProps {
     authenticatedUser: Pick<
         AuthenticatedUser,
@@ -150,12 +151,12 @@ export const UserNavItem: React.FunctionComponent<React.PropsWithChildren<UserNa
                                 <>
                                     <MenuDivider className={styles.dropdownDivider} />
                                     <MenuHeader className={styles.dropdownHeader}>Your organizations</MenuHeader>
-                                    {organizations.slice(0, 5).map(org => (
+                                    {organizations.slice(0, MAX_VISIBLE_ORGS).map(org => (
                                         <MenuLink as={Link} key={org.id} to={org.settingsURL || org.url}>
                                             {org.displayName || org.name}
                                         </MenuLink>
                                     ))}
-                                    {organizations.length > 5 && (
+                                    {organizations.length > MAX_VISIBLE_ORGS && (
                                         <MenuLink as={Link} to={props.authenticatedUser.settingsURL!}>
                                             Show all organizations
                                         </MenuLink>


### PR DESCRIPTION
Fixes #43669

One of the considerations with organizations is that a user can be part of multiple. Since some companies might use orgs to map access control settings, [we believe](https://sourcegraph.slack.com/archives/C07KZF47K/p1666274516248379) that it is realistic that a user is part of many orgs (think tens of them, probably not more).

The nav bar menu is a place where this is particularly noticable:

![image](https://user-images.githubusercontent.com/458591/201165020-37f28446-3fb4-4289-a6f8-3f6351be073b.png)

This PR limits the number of orgs shown in this list to 5. If a user is part of more then 5 orgs, we link to the user settings where all orgs will be listed.

Since we don't expect more than tens of orgs per user, I think we can leave the GraphQL query as-is and fetch all org ids for now. Changing the query would be breaking a lot of places that depend on the `user.organization` collection.


## Test plan

<img width="391" alt="Screenshot 2022-11-10 at 18 24 20" src="https://user-images.githubusercontent.com/458591/201165193-d6d64041-ff6a-40a7-801b-e10ea35f7f37.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-limit-number-of-orgs-in-menu.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
