### PR TITLE
graphqlbackend: make BigInt a type alias to int64

### DIFF
--- a/cmd/frontend/graphqlbackend/bigint.go
+++ b/cmd/frontend/graphqlbackend/bigint.go
@@ -8,23 +8,14 @@ import (
 )
 
 // BigInt implements the BigInt GraphQL scalar type.
-type BigInt struct{ Int int64 }
-
-// BigIntOrNil is a helper function that returns nil for int == nil and otherwise wraps int in
-// BigInt.
-func BigIntOrNil(int *int64) *BigInt {
-	if int == nil {
-		return nil
-	}
-	return &BigInt{Int: *int}
-}
+type BigInt int64
 
 func (BigInt) ImplementsGraphQLType(name string) bool {
 	return name == "BigInt"
 }
 
 func (v BigInt) MarshalJSON() ([]byte, error) {
-	return json.Marshal(strconv.FormatInt(v.Int, 10))
+	return json.Marshal(strconv.FormatInt(int64(v), 10))
 }
 
 func (v *BigInt) UnmarshalGraphQL(input any) error {
@@ -36,6 +27,6 @@ func (v *BigInt) UnmarshalGraphQL(input any) error {
 	if err != nil {
 		return err
 	}
-	*v = BigInt{Int: n}
+	*v = BigInt(n)
 	return nil
 }

--- a/cmd/frontend/graphqlbackend/lfs.go
+++ b/cmd/frontend/graphqlbackend/lfs.go
@@ -12,7 +12,7 @@ type lfsResolver struct {
 }
 
 func (l *lfsResolver) ByteSize() BigInt {
-	return BigInt{Int: l.size}
+	return BigInt(l.size)
 }
 
 var (

--- a/cmd/frontend/graphqlbackend/lfs_test.go
+++ b/cmd/frontend/graphqlbackend/lfs_test.go
@@ -8,7 +8,7 @@ func TestParseLFSPointer(t *testing.T) {
 	lfs := parseLFSPointer(`version https://git-lfs.github.com/spec/v1
 oid sha256:d4653571a605ece26e88b83cfcfa2697968ee4b8e97ecf37c9d2715e5f94f5ac
 size 902`)
-	if lfs.ByteSize().Int != 902 {
+	if lfs.ByteSize() != 902 {
 		t.Fatal("failed to correctly parse LFS pointer")
 	}
 

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -159,7 +159,11 @@ func (r *RepositoryResolver) DiskSizeBytes(ctx context.Context) (*BigInt, error)
 		return nil, err
 	}
 	repo, err := r.db.GitserverRepos().GetByID(ctx, r.IDInt32())
-	return &BigInt{Int: repo.RepoSizeBytes}, err
+	if err != nil {
+		return nil, err
+	}
+	size := BigInt(repo.RepoSizeBytes)
+	return &size, nil
 }
 
 func (r *RepositoryResolver) BatchChanges(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error) {

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -163,10 +163,10 @@ func (r *repositoryMirrorInfoResolver) UpdatedAt(ctx context.Context) (*gqlutil.
 func (r *repositoryMirrorInfoResolver) ByteSize(ctx context.Context) (BigInt, error) {
 	info, err := r.computeGitserverRepo(ctx)
 	if err != nil {
-		return BigInt{Int: 0}, err
+		return 0, err
 	}
 
-	return BigInt{Int: info.RepoSizeBytes}, err
+	return BigInt(info.RepoSizeBytes), err
 }
 
 func (r *repositoryMirrorInfoResolver) Shard(ctx context.Context) (*string, error) {

--- a/cmd/frontend/graphqlbackend/repository_stats.go
+++ b/cmd/frontend/graphqlbackend/repository_stats.go
@@ -31,9 +31,9 @@ type repositoryStatsResolver struct {
 func (r *repositoryStatsResolver) GitDirBytes(ctx context.Context) (BigInt, error) {
 	gitDirBytes, err := r.computeGitDirBytes(ctx)
 	if err != nil {
-		return BigInt{}, err
+		return 0, err
 	}
-	return BigInt{Int: gitDirBytes}, nil
+	return BigInt(gitDirBytes), nil
 
 }
 
@@ -82,9 +82,9 @@ func min(a, b int32) int32 {
 func (r *repositoryStatsResolver) IndexedLinesCount(ctx context.Context) (BigInt, error) {
 	_, indexedLinesCount, err := r.computeIndexedStats(ctx)
 	if err != nil {
-		return BigInt{}, err
+		return 0, err
 	}
-	return BigInt{Int: indexedLinesCount}, nil
+	return BigInt(indexedLinesCount), nil
 }
 
 func (r *repositoryStatsResolver) computeIndexedStats(ctx context.Context) (int32, int64, error) {

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -81,7 +81,7 @@ func (r *repositoryTextSearchIndexStatus) UpdatedAt() gqlutil.DateTime {
 }
 
 func (r *repositoryTextSearchIndexStatus) ContentByteSize() BigInt {
-	return BigInt{r.entry.Stats.ContentBytes}
+	return BigInt(r.entry.Stats.ContentBytes)
 }
 
 func (r *repositoryTextSearchIndexStatus) ContentFilesCount() int32 {
@@ -213,7 +213,7 @@ func (r *skippedIndexedResolver) Count(ctx context.Context) (BigInt, error) {
 	// with "NOT-INDEXED: <reason>"
 	expr, err := syntax.Parse("^NOT-INDEXED: ", syntax.Perl)
 	if err != nil {
-		return BigInt{}, err
+		return 0, err
 	}
 
 	q := &zoektquery.And{[]zoektquery.Q{
@@ -230,10 +230,10 @@ func (r *skippedIndexedResolver) Count(ctx context.Context) (BigInt, error) {
 			stats.Add(sr.Stats)
 		}),
 	); err != nil {
-		return BigInt{}, err
+		return 0, err
 	}
 
-	return BigInt{int64(stats.FileCount)}, nil
+	return BigInt(stats.FileCount), nil
 }
 
 func (r *skippedIndexedResolver) Query() string {


### PR DESCRIPTION
I think this improves the readability of all the callsites since we can natively use integer constants. It also avoids footguns around forgetting to use pointers/etc.

Test Plan: go test