### PR TITLE
web: reflow user and admin settings sidebars

### DIFF
--- a/client/web/src/components/Sidebar.tsx
+++ b/client/web/src/components/Sidebar.tsx
@@ -28,21 +28,27 @@ export const SidebarNavItem: React.FunctionComponent<
         className?: string
         exact?: boolean
         source?: string
+        onClick?: () => void
     }>
-> = ({ children, className, to, exact, source }) => {
+> = ({ children, className, to, exact, source, onClick }) => {
     const buttonClassNames = classNames('text-left d-flex', styles.linkInactive, className)
     const routeMatch = useRouteMatch({ path: to, exact })
 
     if (source === 'server') {
         return (
-            <ButtonLink as={AnchorLink} to={to} className={classNames(buttonClassNames, className)}>
+            <ButtonLink as={AnchorLink} to={to} className={classNames(buttonClassNames, className)} onClick={onClick}>
                 {children}
             </ButtonLink>
         )
     }
 
     return (
-        <ButtonLink to={to} className={buttonClassNames} variant={routeMatch?.isExact ? 'primary' : undefined}>
+        <ButtonLink
+            to={to}
+            className={buttonClassNames}
+            variant={routeMatch?.isExact ? 'primary' : undefined}
+            onClick={onClick}
+        >
             {children}
         </ButtonLink>
     )

--- a/client/web/src/org/settings/OrgSettingsArea.tsx
+++ b/client/web/src/org/settings/OrgSettingsArea.tsx
@@ -68,8 +68,8 @@ export const AuthenticatedOrgSettingsArea: React.FunctionComponent<
     }
 
     return (
-        <div className="d-flex">
-            <OrgSettingsSidebar items={props.sideBarItems} {...context} className="flex-0 mr-3" />
+        <div className="d-flex flex-column flex-sm-row">
+            <OrgSettingsSidebar items={props.sideBarItems} {...context} className="flex-0 mr-3 mb-4" />
             <div className="flex-1">
                 <ErrorBoundary location={props.location}>
                     <React.Suspense fallback={<LoadingSpinner className="m-2" />}>

--- a/client/web/src/org/settings/OrgSettingsSidebar.tsx
+++ b/client/web/src/org/settings/OrgSettingsSidebar.tsx
@@ -1,9 +1,10 @@
-import * as React from 'react'
+import React, { useCallback, useState } from 'react'
 
+import { mdiMenu } from '@mdi/js'
 import classNames from 'classnames'
 import { RouteComponentProps } from 'react-router-dom'
 
-import { ProductStatusBadge, ProductStatusType } from '@sourcegraph/wildcard'
+import { Button, Icon, ProductStatusBadge, ProductStatusType } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { BatchChangesProps } from '../../batches'
@@ -49,6 +50,9 @@ export const OrgSettingsSidebar: React.FunctionComponent<React.PropsWithChildren
     newMembersInviteEnabled,
     ...props
 }) => {
+    const [isMobileExpanded, setIsMobileExpanded] = useState(false)
+    const collapseMobileSidebar = useCallback((): void => setIsMobileExpanded(false), [])
+
     const siteAdminViewingOtherOrg = authenticatedUser && org.viewerCanAdminister && !org.viewerIsMember
     const context: OrgSettingsSidebarItemConditionContext = {
         batchChangesEnabled: props.batchChangesEnabled,
@@ -61,25 +65,43 @@ export const OrgSettingsSidebar: React.FunctionComponent<React.PropsWithChildren
     }
 
     return (
-        <div className={classNames(styles.orgSettingsSidebar, className)}>
-            {/* Indicate when the site admin is viewing another org's settings */}
-            {siteAdminViewingOtherOrg && (
-                <SiteAdminAlert className="sidebar__alert">
-                    Viewing settings for <strong>{org.name}</strong>
-                </SiteAdminAlert>
-            )}
-
-            <SidebarGroup>
-                <SidebarGroupHeader label="Organization" />
-                {props.items.map(
-                    ({ label, to, exact, status, condition = () => true }) =>
-                        condition(context) && (
-                            <SidebarNavItem key={label} to={match.path + to} exact={exact}>
-                                {label} {status && <ProductStatusBadge className="ml-1" status={status} />}
-                            </SidebarNavItem>
-                        )
+        <>
+            <Button className="d-sm-none align-self-start mb-3" onClick={() => setIsMobileExpanded(!isMobileExpanded)}>
+                <Icon aria-hidden={true} svgPath={mdiMenu} className="mr-2" />
+                {isMobileExpanded ? 'Hide' : 'Show'} menu
+            </Button>
+            <div
+                className={classNames(
+                    styles.orgSettingsSidebar,
+                    className,
+                    'd-sm-block',
+                    !isMobileExpanded && 'd-none'
                 )}
-            </SidebarGroup>
-        </div>
+            >
+                {/* Indicate when the site admin is viewing another org's settings */}
+                {siteAdminViewingOtherOrg && (
+                    <SiteAdminAlert className="sidebar__alert">
+                        Viewing settings for <strong>{org.name}</strong>
+                    </SiteAdminAlert>
+                )}
+
+                <SidebarGroup>
+                    <SidebarGroupHeader label="Organization" />
+                    {props.items.map(
+                        ({ label, to, exact, status, condition = () => true }) =>
+                            condition(context) && (
+                                <SidebarNavItem
+                                    key={label}
+                                    to={match.path + to}
+                                    exact={exact}
+                                    onClick={collapseMobileSidebar}
+                                >
+                                    {label} {status && <ProductStatusBadge className="ml-1" status={status} />}
+                                </SidebarNavItem>
+                            )
+                    )}
+                </SidebarGroup>
+            </div>
+        </>
     )
 }

--- a/client/web/src/site-admin/SiteAdminArea.tsx
+++ b/client/web/src/site-admin/SiteAdminArea.tsx
@@ -201,9 +201,9 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<React.PropsWithChildre
                     <PageHeader.Breadcrumb>Admin</PageHeader.Breadcrumb>
                 </PageHeader.Heading>
             </PageHeader>
-            <div className="d-flex my-3" ref={reference}>
+            <div className="d-flex my-3 flex-column flex-sm-row" ref={reference}>
                 <SiteAdminSidebar
-                    className={classNames('flex-0 mr-3', styles.sidebar)}
+                    className={classNames('flex-0 mr-3 mb-4', styles.sidebar)}
                     groups={adminSideBarGroups}
                     isSourcegraphDotCom={props.isSourcegraphDotCom}
                     batchChangesEnabled={props.batchChangesEnabled}

--- a/client/web/src/site-admin/SiteAdminSidebar.tsx
+++ b/client/web/src/site-admin/SiteAdminSidebar.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback, useState } from 'react'
 
 import { mdiMenu } from '@mdi/js'
 import classNames from 'classnames'
@@ -34,7 +34,8 @@ export const SiteAdminSidebar: React.FunctionComponent<React.PropsWithChildren<S
     groups,
     ...props
 }) => {
-    const [isMobileExpanded, setIsMobileExpanded] = React.useState(false)
+    const [isMobileExpanded, setIsMobileExpanded] = useState(false)
+    const collapseMobileSidebar = useCallback((): void => setIsMobileExpanded(false), [])
 
     return (
         <>
@@ -63,6 +64,7 @@ export const SiteAdminSidebar: React.FunctionComponent<React.PropsWithChildren<S
                                                         key={label}
                                                         source={source}
                                                         className={styles.navItem}
+                                                        onClick={collapseMobileSidebar}
                                                     >
                                                         {label}
                                                     </SidebarNavItem>
@@ -75,6 +77,7 @@ export const SiteAdminSidebar: React.FunctionComponent<React.PropsWithChildren<S
                                     <Link
                                         to={items[0].to}
                                         className="bg-2 border-0 d-flex list-group-item-action p-2 w-100"
+                                        onClick={collapseMobileSidebar}
                                     >
                                         <span>
                                             {header?.icon && (

--- a/client/web/src/site-admin/SiteAdminSidebar.tsx
+++ b/client/web/src/site-admin/SiteAdminSidebar.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 
-import { Link, Icon } from '@sourcegraph/wildcard'
+import { mdiMenu } from '@mdi/js'
+import classNames from 'classnames'
+
+import { Link, Icon, Button } from '@sourcegraph/wildcard'
 
 import { BatchChangesProps } from '../batches'
 import { SidebarGroup, SidebarCollapseItems, SidebarNavItem } from '../components/Sidebar'
@@ -30,46 +33,67 @@ export const SiteAdminSidebar: React.FunctionComponent<React.PropsWithChildren<S
     className,
     groups,
     ...props
-}) => (
-    <SidebarGroup className={className}>
-        <ul className="list-group">
-            {groups.map(
-                ({ header, items, condition = () => true }, index) =>
-                    condition(props) &&
-                    (items.length > 1 ? (
-                        <li className="p-0 list-group-item" key={index}>
-                            <SidebarCollapseItems icon={header?.icon} label={header?.label} openByDefault={true}>
-                                {items.map(
-                                    ({ label, to, source = 'client', condition = () => true }) =>
-                                        condition(props) && (
-                                            <SidebarNavItem
-                                                to={to}
-                                                exact={true}
-                                                key={label}
-                                                source={source}
-                                                className={styles.navItem}
-                                            >
-                                                {label}
-                                            </SidebarNavItem>
-                                        )
-                                )}
-                            </SidebarCollapseItems>
-                        </li>
-                    ) : (
-                        <li className="p-0 list-group-item" key={items[0].label}>
-                            <Link to={items[0].to} className="bg-2 border-0 d-flex list-group-item-action p-2 w-100">
-                                <span>
-                                    {header?.icon && (
-                                        <>
-                                            <Icon className="sidebar__icon mr-1" as={header.icon} aria-hidden={true} />{' '}
-                                        </>
-                                    )}
-                                    {items[0].label}
-                                </span>
-                            </Link>
-                        </li>
-                    ))
-            )}
-        </ul>
-    </SidebarGroup>
-)
+}) => {
+    const [isMobileExpanded, setIsMobileExpanded] = React.useState(false)
+
+    return (
+        <>
+            <Button className="d-sm-none align-self-start mb-3" onClick={() => setIsMobileExpanded(!isMobileExpanded)}>
+                <Icon aria-hidden={true} svgPath={mdiMenu} className="mr-2" />
+                {isMobileExpanded ? 'Hide' : 'Show'} menu
+            </Button>
+            <SidebarGroup className={classNames(className, 'd-sm-block', !isMobileExpanded && 'd-none')}>
+                <ul className="list-group">
+                    {groups.map(
+                        ({ header, items, condition = () => true }, index) =>
+                            condition(props) &&
+                            (items.length > 1 ? (
+                                <li className="p-0 list-group-item" key={index}>
+                                    <SidebarCollapseItems
+                                        icon={header?.icon}
+                                        label={header?.label}
+                                        openByDefault={true}
+                                    >
+                                        {items.map(
+                                            ({ label, to, source = 'client', condition = () => true }) =>
+                                                condition(props) && (
+                                                    <SidebarNavItem
+                                                        to={to}
+                                                        exact={true}
+                                                        key={label}
+                                                        source={source}
+                                                        className={styles.navItem}
+                                                    >
+                                                        {label}
+                                                    </SidebarNavItem>
+                                                )
+                                        )}
+                                    </SidebarCollapseItems>
+                                </li>
+                            ) : (
+                                <li className="p-0 list-group-item" key={items[0].label}>
+                                    <Link
+                                        to={items[0].to}
+                                        className="bg-2 border-0 d-flex list-group-item-action p-2 w-100"
+                                    >
+                                        <span>
+                                            {header?.icon && (
+                                                <>
+                                                    <Icon
+                                                        className="sidebar__icon mr-1"
+                                                        as={header.icon}
+                                                        aria-hidden={true}
+                                                    />{' '}
+                                                </>
+                                            )}
+                                            {items[0].label}
+                                        </span>
+                                    </Link>
+                                </li>
+                            ))
+                    )}
+                </ul>
+            </SidebarGroup>
+        </>
+    )
+}

--- a/client/web/src/user/UserAvatar.module.scss
+++ b/client/web/src/user/UserAvatar.module.scss
@@ -1,4 +1,5 @@
 .user-avatar {
+    isolation: isolate;
     display: inline-flex;
     border-radius: 50%;
     text-transform: capitalize;

--- a/client/web/src/user/settings/UserSettingsArea.tsx
+++ b/client/web/src/user/settings/UserSettingsArea.tsx
@@ -149,11 +149,11 @@ export const AuthenticatedUserSettingsArea: React.FunctionComponent<
                     Viewing account for <strong>{user.username}</strong>
                 </SiteAdminAlert>
             )}
-            <div className="d-flex">
+            <div className="d-flex flex-column flex-sm-row">
                 <UserSettingsSidebar
                     items={sideBarItems}
                     {...context}
-                    className={classNames('flex-0 mr-3', styles.userSettingsSidebar)}
+                    className={classNames('flex-0 mr-3 mb-4', styles.userSettingsSidebar)}
                 />
                 <div className="flex-1">
                     <ErrorBoundary location={props.location}>

--- a/client/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/client/web/src/user/settings/UserSettingsSidebar.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
-import { mdiPlus } from '@mdi/js'
+import { mdiMenu, mdiPlus } from '@mdi/js'
+import classNames from 'classnames'
 import { RouteComponentProps } from 'react-router-dom'
 
 import { ProductStatusBadge, Button, Link, Icon, ProductStatusType } from '@sourcegraph/wildcard'
@@ -41,6 +42,8 @@ export interface UserSettingsSidebarProps
 export const UserSettingsSidebar: React.FunctionComponent<
     React.PropsWithChildren<UserSettingsSidebarProps>
 > = props => {
+    const [isMobileExpanded, setIsMobileExpanded] = React.useState(false)
+
     if (!props.authenticatedUser) {
         return null
     }
@@ -57,51 +60,63 @@ export const UserSettingsSidebar: React.FunctionComponent<
     }
 
     return (
-        <div className={props.className}>
-            <SidebarGroup>
-                <SidebarGroupHeader label="Account" />
-                {props.items.map(
-                    ({ label, to, exact, status, condition = () => true }) =>
-                        condition(context) && (
-                            <SidebarNavItem key={label} to={props.match.path + to} exact={exact}>
-                                {label} {status && <ProductStatusBadge className="ml-1" status={status} />}
-                            </SidebarNavItem>
-                        )
-                )}
-            </SidebarGroup>
-            {(props.user.organizations.nodes.length > 0 || !siteAdminViewingOtherUser) && (
+        <>
+            <Button className="d-sm-none align-self-start mb-3" onClick={() => setIsMobileExpanded(!isMobileExpanded)}>
+                <Icon aria-hidden={true} svgPath={mdiMenu} className="mr-2" />
+                {isMobileExpanded ? 'Hide' : 'Show'} menu
+            </Button>
+            <div className={classNames(props.className, 'd-sm-block', !isMobileExpanded && 'd-none')}>
                 <SidebarGroup>
-                    <SidebarGroupHeader label="Your organizations" />
-                    {props.user.organizations.nodes.map(org => (
-                        <SidebarNavItem
-                            key={org.id}
-                            to={`/organizations/${org.name}/settings`}
-                            className="text-truncate text-nowrap align-items-center"
-                        >
-                            <OrgAvatar org={org.name} className="d-inline-flex mr-1" /> {org.name}
-                        </SidebarNavItem>
-                    ))}
-                    {!siteAdminViewingOtherUser &&
-                        (window.context.sourcegraphDotComMode &&
-                        !props.authenticatedUser?.tags?.includes('CreateOrg') ? (
-                            <SidebarNavItem to={`${props.match.path}/about-organizations`}>
-                                About organizations
-                            </SidebarNavItem>
-                        ) : (
-                            <div className={styles.newOrgBtnWrapper}>
-                                <Button to="/organizations/new" variant="secondary" outline={true} size="sm" as={Link}>
-                                    <Icon aria-hidden={true} svgPath={mdiPlus} /> New organization
-                                </Button>
-                            </div>
-                        ))}
+                    <SidebarGroupHeader label="Account" />
+                    {props.items.map(
+                        ({ label, to, exact, status, condition = () => true }) =>
+                            condition(context) && (
+                                <SidebarNavItem key={label} to={props.match.path + to} exact={exact}>
+                                    {label} {status && <ProductStatusBadge className="ml-1" status={status} />}
+                                </SidebarNavItem>
+                            )
+                    )}
                 </SidebarGroup>
-            )}
-            <SidebarGroup>
-                <SidebarGroupHeader label="Other actions" />
-                {!siteAdminViewingOtherUser && <SidebarNavItem to="/api/console">API console</SidebarNavItem>}
-                {props.authenticatedUser.siteAdmin && <SidebarNavItem to="/site-admin">Site admin</SidebarNavItem>}
-            </SidebarGroup>
-            <div>Version: {window.context.version}</div>
-        </div>
+                {(props.user.organizations.nodes.length > 0 || !siteAdminViewingOtherUser) && (
+                    <SidebarGroup>
+                        <SidebarGroupHeader label="Your organizations" />
+                        {props.user.organizations.nodes.map(org => (
+                            <SidebarNavItem
+                                key={org.id}
+                                to={`/organizations/${org.name}/settings`}
+                                className="text-truncate text-nowrap align-items-center"
+                            >
+                                <OrgAvatar org={org.name} className="d-inline-flex mr-1" /> {org.name}
+                            </SidebarNavItem>
+                        ))}
+                        {!siteAdminViewingOtherUser &&
+                            (window.context.sourcegraphDotComMode &&
+                            !props.authenticatedUser?.tags?.includes('CreateOrg') ? (
+                                <SidebarNavItem to={`${props.match.path}/about-organizations`}>
+                                    About organizations
+                                </SidebarNavItem>
+                            ) : (
+                                <div className={styles.newOrgBtnWrapper}>
+                                    <Button
+                                        to="/organizations/new"
+                                        variant="secondary"
+                                        outline={true}
+                                        size="sm"
+                                        as={Link}
+                                    >
+                                        <Icon aria-hidden={true} svgPath={mdiPlus} /> New organization
+                                    </Button>
+                                </div>
+                            ))}
+                    </SidebarGroup>
+                )}
+                <SidebarGroup>
+                    <SidebarGroupHeader label="Other actions" />
+                    {!siteAdminViewingOtherUser && <SidebarNavItem to="/api/console">API console</SidebarNavItem>}
+                    {props.authenticatedUser.siteAdmin && <SidebarNavItem to="/site-admin">Site admin</SidebarNavItem>}
+                </SidebarGroup>
+                <div>Version: {window.context.version}</div>
+            </div>
+        </>
     )
 }

--- a/client/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/client/web/src/user/settings/UserSettingsSidebar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, { useState, useCallback } from 'react'
 
 import { mdiMenu, mdiPlus } from '@mdi/js'
 import classNames from 'classnames'
@@ -42,7 +42,8 @@ export interface UserSettingsSidebarProps
 export const UserSettingsSidebar: React.FunctionComponent<
     React.PropsWithChildren<UserSettingsSidebarProps>
 > = props => {
-    const [isMobileExpanded, setIsMobileExpanded] = React.useState(false)
+    const [isMobileExpanded, setIsMobileExpanded] = useState(false)
+    const collapseMobileSidebar = useCallback((): void => setIsMobileExpanded(false), [])
 
     if (!props.authenticatedUser) {
         return null
@@ -71,7 +72,12 @@ export const UserSettingsSidebar: React.FunctionComponent<
                     {props.items.map(
                         ({ label, to, exact, status, condition = () => true }) =>
                             condition(context) && (
-                                <SidebarNavItem key={label} to={props.match.path + to} exact={exact}>
+                                <SidebarNavItem
+                                    key={label}
+                                    to={props.match.path + to}
+                                    exact={exact}
+                                    onClick={collapseMobileSidebar}
+                                >
                                     {label} {status && <ProductStatusBadge className="ml-1" status={status} />}
                                 </SidebarNavItem>
                             )
@@ -85,6 +91,7 @@ export const UserSettingsSidebar: React.FunctionComponent<
                                 key={org.id}
                                 to={`/organizations/${org.name}/settings`}
                                 className="text-truncate text-nowrap align-items-center"
+                                onClick={collapseMobileSidebar}
                             >
                                 <OrgAvatar org={org.name} className="d-inline-flex mr-1" /> {org.name}
                             </SidebarNavItem>
@@ -92,7 +99,10 @@ export const UserSettingsSidebar: React.FunctionComponent<
                         {!siteAdminViewingOtherUser &&
                             (window.context.sourcegraphDotComMode &&
                             !props.authenticatedUser?.tags?.includes('CreateOrg') ? (
-                                <SidebarNavItem to={`${props.match.path}/about-organizations`}>
+                                <SidebarNavItem
+                                    to={`${props.match.path}/about-organizations`}
+                                    onClick={collapseMobileSidebar}
+                                >
                                     About organizations
                                 </SidebarNavItem>
                             ) : (
@@ -103,6 +113,7 @@ export const UserSettingsSidebar: React.FunctionComponent<
                                         outline={true}
                                         size="sm"
                                         as={Link}
+                                        onClick={collapseMobileSidebar}
                                     >
                                         <Icon aria-hidden={true} svgPath={mdiPlus} /> New organization
                                     </Button>
@@ -112,8 +123,16 @@ export const UserSettingsSidebar: React.FunctionComponent<
                 )}
                 <SidebarGroup>
                     <SidebarGroupHeader label="Other actions" />
-                    {!siteAdminViewingOtherUser && <SidebarNavItem to="/api/console">API console</SidebarNavItem>}
-                    {props.authenticatedUser.siteAdmin && <SidebarNavItem to="/site-admin">Site admin</SidebarNavItem>}
+                    {!siteAdminViewingOtherUser && (
+                        <SidebarNavItem to="/api/console" onClick={collapseMobileSidebar}>
+                            API console
+                        </SidebarNavItem>
+                    )}
+                    {props.authenticatedUser.siteAdmin && (
+                        <SidebarNavItem to="/site-admin" onClick={collapseMobileSidebar}>
+                            Site admin
+                        </SidebarNavItem>
+                    )}
                 </SidebarGroup>
                 <div>Version: {window.context.version}</div>
             </div>


### PR DESCRIPTION
Adds a hamburger menu to user settings and admin pages in XS sizes. Not the prettiest but it works. 

Closes https://github.com/sourcegraph/sourcegraph/issues/35706
Closes https://github.com/sourcegraph/sourcegraph/issues/35867

## Test plan

Manually verify using Chrome responsive devtool

https://user-images.githubusercontent.com/206864/201186810-29bf2a69-5262-4cb1-959d-c34641d73281.mp4

https://user-images.githubusercontent.com/206864/201188261-3b801f29-1fdf-48d5-86ba-cc859181c958.mp4


## App preview:

- [Web](https://sg-web-jp-settingsreflow.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

