### PR TITLE
Fix bad link to insights docs

### DIFF
--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-description/CodeInsightsDescription.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-description/CodeInsightsDescription.tsx
@@ -35,7 +35,7 @@ export const CodeInsightsDescription: React.FunctionComponent<Props> = ({ classN
         <H3>Resources</H3>
         <ul>
             <li>
-                <Link to="/help/batch_changes" rel="noopener">
+                <Link to="/help/code_insights" rel="noopener">
                     Code Insights documentation
                 </Link>
             </li>


### PR DESCRIPTION
Correct link to insights docs
## Test plan
clicked link ensured insights docs opened.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cw-fix-link.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
