### PR TITLE
ranking: Optimize sloppy query

### DIFF
--- a/enterprise/internal/codeintel/ranking/internal/store/store_test.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/store_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -162,6 +163,7 @@ func TestBulkSetAndMergeDocumentRanks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error checking if filename inputs exist: %s", err)
 	}
+	sort.Strings(filenames)
 	expectedFilenames := []string{
 		"f-07.csv",
 		"f-08.csv",


### PR DESCRIPTION
This PR optimizes an expensive query by prompting semi-join instead of a full scan for very few distinct values. Some comments along with queries/query plans below.

**Before**:

```sql
SELECT DISTINCT pr.input_filename
FROM codeintel_path_rank_inputs pr
WHERE
	pr.graph_key = $1 AND
	pr.input_filename = ANY ($2)
ORDER BY pr.input_filename;
```

The original query wants to return each of the input filenames with a representative row in `codeintel_path_rank_inputs`.

```
QUERY PLAN
----------
 Sort  (cost=1108366.59..1108367.59 rows=400 width=101) (actual time=13202.281..13202.294 rows=200 loops=1)
   Sort Key: input_filename
   Sort Method: quicksort  Memory: 53kB
   ->  HashAggregate  (cost=1108345.30..1108349.30 rows=400 width=101) (actual time=13198.732..13198.773 rows=200 loops=1)
         Group Key: input_filename
         ->  Index Only Scan using codeintel_path_rank_inputs_graph_key_input_filename_reposit_key on codeintel_path_rank_inputs pr  (cost=0.81..1093039.95 rows=6122139 width=101) (actual time=0.949..10414.699 rows=10453542 loops=1)
               Index Cond: ((graph_key = 'dotcom-test-2022-11-07-02'::text) AND (input_filename = ANY ('...'::text[])))
               Heap Fetches: 7860112
 Planning Time: 1.090 ms
 Execution Time: 13202.408 ms
(10 rows)
```

You can see that this starts by identifying all of the rows matching the graph key and one of the input filenames. Once these are found, we create a hash table of input filenames (the `DISTINCT`) and order them. This intermediate result set has 10,453,542 rows on DotCom.

We can see that Postgres is performing the `DISTINCT` too late. What we want to do instead is to express that we don't need _every_ row matching those conditions in the intermediate result.

**After**:

```sql
SELECT v.input_filename FROM unnest($2::text[]) AS v(input_filename)
WHERE EXISTS (
	SELECT 1 
	FROM codeintel_path_rank_inputs pr
	WHERE
		pr.graph_key = $1 AND
		pr.input_filename = v.input_filename
)
ORDER BY v.input_filename;
```

This new query simply returns its input array, but filters out the inputs that do not have a representative row in the correlated subquery. This happens to perform `n` index scans over the table (stopping at the first result). The result is a huge reduction in the number of heap pages fetched as we don't care to collect the remaining rows.

```
QUERY PLAN
----------
 Sort  (cost=207.62..207.87 rows=100 width=32) (actual time=9.920..9.932 rows=200 loops=1)
   Sort Key: v.input_filename
   Sort Method: quicksort  Memory: 53kB
   ->  Nested Loop Semi Join  (cost=0.81..204.29 rows=100 width=32) (actual time=0.094..9.407 rows=200 loops=1)
         ->  Function Scan on unnest v  (cost=0.00..2.00 rows=200 width=32) (actual time=0.033..0.059 rows=200 loops=1)
         ->  Index Only Scan using codeintel_path_rank_inputs_graph_key_input_filename_reposit_key on codeintel_path_rank_inputs pr  (cost=0.81..5070.62 rows=26139 width=101) (actual time=0.046..0.046 rows=1 loops=200)
               Index Cond: ((graph_key = 'dotcom-test-2022-11-07-02'::text) AND (input_filename = v.input_filename))
               Heap Fetches: 47
 Planning Time: 0.196 ms
 Execution Time: 9.981 ms
(10 rows)
```

## Test plan

Existing unit tests.