### PR TITLE
ranking: Move concurrency down a few levels

### DIFF
--- a/enterprise/internal/codeintel/codenav/background/ranking/iface.go
+++ b/enterprise/internal/codeintel/codenav/background/ranking/iface.go
@@ -8,6 +8,7 @@ import (
 
 type CodeNavServiceBackgroundJobs interface {
 	NewRankingGraphSerializer(
+		numRankingRoutines int,
 		interval time.Duration,
 	) goroutine.BackgroundRoutine
 }

--- a/enterprise/internal/codeintel/codenav/background/ranking/init.go
+++ b/enterprise/internal/codeintel/codenav/background/ranking/init.go
@@ -4,10 +4,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 )
 
-func NewGraphSerializers(backgroundJobs CodeNavServiceBackgroundJobs) (routines []goroutine.BackgroundRoutine) {
-	for i := 0; i < ConfigInst.NumRankingRoutines; i++ {
-		routines = append(routines, backgroundJobs.NewRankingGraphSerializer(ConfigInst.RankingInterval))
+func NewGraphSerializers(backgroundJobs CodeNavServiceBackgroundJobs) []goroutine.BackgroundRoutine {
+	return []goroutine.BackgroundRoutine{
+		backgroundJobs.NewRankingGraphSerializer(ConfigInst.NumRankingRoutines, ConfigInst.RankingInterval),
 	}
-
-	return routines
 }

--- a/enterprise/internal/codeintel/codenav/init.go
+++ b/enterprise/internal/codeintel/codenav/init.go
@@ -47,8 +47,8 @@ type serviceDependencies struct {
 var (
 	bucketName                   = env.Get("CODEINTEL_CODENAV_RANKING_BUCKET", "lsif-pagerank-experiments", "The GCS bucket.")
 	rankingGraphKey              = env.Get("CODEINTEL_CODENAV_RANKING_GRAPH_KEY", "dev", "An identifier of the graph export. Change to start a new export in the configured bucket.")
-	rankingGraphBatchSize        = env.MustGetInt("CODEINTEL_CODENAV_RANKING_GRAPH_BATCH_SIZE", 1, "How many uploads to process at once.")
-	rankingGraphDeleteBatchSize  = env.MustGetInt("CODEINTEL_CODENAV_RANKING_GRAPH_DELETE_BATCH_SIZE", 20, "How many stale uploads to delete at once.")
+	rankingGraphBatchSize        = env.MustGetInt("CODEINTEL_CODENAV_RANKING_GRAPH_BATCH_SIZE", 16, "How many uploads to process at once.")
+	rankingGraphDeleteBatchSize  = env.MustGetInt("CODEINTEL_CODENAV_RANKING_GRAPH_DELETE_BATCH_SIZE", 32, "How many stale uploads to delete at once.")
 	rankingBucketCredentialsFile = env.Get("CODEINTEL_CODENAV_RANKING_GOOGLE_APPLICATION_CREDENTIALS_FILE", "", "The path to a service account key file with access to GCS.")
 )
 

--- a/enterprise/internal/codeintel/codenav/internal/background/background_jobs.go
+++ b/enterprise/internal/codeintel/codenav/internal/background/background_jobs.go
@@ -8,7 +8,7 @@ import (
 )
 
 type BackgroundJob interface {
-	NewRankingGraphSerializer(interval time.Duration) goroutine.BackgroundRoutine
+	NewRankingGraphSerializer(numRankingRoutines int, interval time.Duration) goroutine.BackgroundRoutine
 	SetService(service CodeNavService)
 }
 

--- a/enterprise/internal/codeintel/codenav/internal/background/graph_serializer.go
+++ b/enterprise/internal/codeintel/codenav/internal/background/graph_serializer.go
@@ -8,17 +8,19 @@ import (
 )
 
 func (b *backgroundJob) NewRankingGraphSerializer(
+	numRankingRoutines int,
 	interval time.Duration,
 ) goroutine.BackgroundRoutine {
 	return goroutine.NewPeriodicGoroutineWithMetrics(context.Background(), interval, goroutine.HandlerFunc(func(ctx context.Context) error {
-		return b.handleRankingGraphSerializer(ctx)
+		return b.handleRankingGraphSerializer(ctx, numRankingRoutines)
 	}), b.operations.handleRankingGraphSerializer)
 }
 
 func (b backgroundJob) handleRankingGraphSerializer(
 	ctx context.Context,
+	numRankingRoutines int,
 ) error {
-	if err := b.codeNavSvc.SerializeRankingGraph(ctx); err != nil {
+	if err := b.codeNavSvc.SerializeRankingGraph(ctx, numRankingRoutines); err != nil {
 		return err
 	}
 

--- a/enterprise/internal/codeintel/codenav/internal/background/iface.go
+++ b/enterprise/internal/codeintel/codenav/internal/background/iface.go
@@ -5,6 +5,6 @@ import (
 )
 
 type CodeNavService interface {
-	SerializeRankingGraph(ctx context.Context) error
+	SerializeRankingGraph(ctx context.Context, numRankingRoutines int) error
 	VacuumRankingGraph(ctx context.Context) error
 }


### PR DESCRIPTION
Do not create 4x the background routines that run both indexing and cleanup of the intel graph export. This PR ensures that we only have one instance, running 4x (still configurable) processed goroutines.

This should reduce the frequency that we are invoking these queries (and they are currently dominating DotCom query insights).

## Test plan

My 👀 