### PR TITLE
Remove buildkite.message from buildevent_file to prevent garbage data in traces

### DIFF
--- a/enterprise/dev/ci/scripts/buildevent_file
+++ b/enterprise/dev/ci/scripts/buildevent_file
@@ -1,7 +1,6 @@
 buildkite.step.key="$BUILDKITE_STEP_KEY"
 buildkite.step.id="$BUILDKITE_STEP_ID"
 buildkite.label="$BUILDKITE_LABEL"
-buildkite.message="$BUILDKITE_MESSAGE"
 buildkite.build.url="$BUILDKITE_BUILD_URL"
 buildkite.build.id="$BUILDKITE_BUILD_ID"
 buildkite.build.author="$BUILDKITE_BUILD_AUTHOR"


### PR DESCRIPTION
Fix #43977 in which we're getting garbage fields being attached to traces uploaded from CI to the `buildevents` dataset in Honeycomb.

The apparent reason is the `buildkite.message` field. This fix removes the field from `buildevents` traces.

**Explanation:**

The `buildkite.message` field is expected to be a double-quoted string when it's written from the `BUILDKITE_MESSAGE` env var to the `.buildevent_file` file. The `.buildevent_file` file is supposed contain key-value definitions of the fields to be attached to the trace. But double quotes aren't being escaped when the `BUILDKITE_MESSAGE` variable gets substituted by `envsubst` so the set of fields in `buildevent_file` gets parsed incorrectly, and it produces a bunch of bad key-value pairs from the contents of the commit message.

**Rationale** for removing `buildkite.message` (instead of fixing the variable substitution instead):

- Removal of the field is the most straightforward fix
- The field's value is not useful for filtering/grouping the traces (it's the full text of the commit message/PR description)
- The build ID and the commit ID are included in the trace so they can be used to look up the message if it's relevant.
- Fixing the escaping would introduce some complexity because we use `envsubst` to substitute the variable and that command doesn't have a way of substituting with escaping (in plain bash we could use `${BUILDKITE_MESSAGE@Q}` to quote the value

## Test plan

Check that `buildkite.message` is no longer sent in traces