### PR TITLE
search: Add user whitelist option for search sanitization

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -195,19 +195,20 @@ func NewBasicJob(inputs *search.Inputs, b query.Basic) (job.Job, error) {
 		}
 	}
 
-	{
-		// Apply search result sanitize rules post-filter
-		var sanitizePatterns []*regexp.Regexp
-		c := conf.Get()
-		if c.ExperimentalFeatures != nil && c.ExperimentalFeatures.SearchSanitizePatterns != nil {
-			for _, val := range c.ExperimentalFeatures.SearchSanitizePatterns {
-				if re, err := regexp.Compile(val); err == nil {
-					sanitizePatterns = append(sanitizePatterns, re)
+	{ // Apply search result sanitization post-filter if enabled
+		if inputs.SanitizeSearch {
+			var sanitizePatterns []*regexp.Regexp
+			c := conf.Get()
+			if c.ExperimentalFeatures != nil && c.ExperimentalFeatures.SearchSanitization != nil {
+				for _, val := range c.ExperimentalFeatures.SearchSanitization.SanitizePatterns {
+					if re, err := regexp.Compile(val); err == nil {
+						sanitizePatterns = append(sanitizePatterns, re)
+					}
 				}
 			}
-		}
-		if len(sanitizePatterns) > 0 {
-			basicJob = NewSanitizeJob(sanitizePatterns, basicJob)
+			if len(sanitizePatterns) > 0 {
+				basicJob = NewSanitizeJob(sanitizePatterns, basicJob)
+			}
 		}
 	}
 

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -196,19 +196,8 @@ func NewBasicJob(inputs *search.Inputs, b query.Basic) (job.Job, error) {
 	}
 
 	{ // Apply search result sanitization post-filter if enabled
-		if inputs.SanitizeSearch {
-			var sanitizePatterns []*regexp.Regexp
-			c := conf.Get()
-			if c.ExperimentalFeatures != nil && c.ExperimentalFeatures.SearchSanitization != nil {
-				for _, val := range c.ExperimentalFeatures.SearchSanitization.SanitizePatterns {
-					if re, err := regexp.Compile(val); err == nil {
-						sanitizePatterns = append(sanitizePatterns, re)
-					}
-				}
-			}
-			if len(sanitizePatterns) > 0 {
-				basicJob = NewSanitizeJob(sanitizePatterns, basicJob)
-			}
+		if len(inputs.SanitizeSearchPatterns) > 0 {
+			basicJob = NewSanitizeJob(inputs.SanitizeSearchPatterns, basicJob)
 		}
 	}
 

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -30,6 +30,7 @@ type Inputs struct {
 	OnSourcegraphDotCom bool
 	Features            *Features
 	Protocol            Protocol
+	SanitizeSearch      bool
 }
 
 // MaxResults computes the limit for the query.

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/grafana/regexp"
 	otlog "github.com/opentracing/opentracing-go/log"
-	zoektquery "github.com/sourcegraph/zoekt/query"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
@@ -17,20 +17,21 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
+	zoektquery "github.com/sourcegraph/zoekt/query"
 )
 
 // Inputs contains fields we set before kicking off search.
 type Inputs struct {
-	Plan                query.Plan // the comprehensive query plan
-	Query               query.Q    // the current basic query being evaluated, one part of query.Plan
-	OriginalQuery       string     // the raw string of the original search query
-	SearchMode          Mode
-	PatternType         query.SearchType
-	UserSettings        *schema.Settings
-	OnSourcegraphDotCom bool
-	Features            *Features
-	Protocol            Protocol
-	SanitizeSearch      bool
+	Plan                   query.Plan // the comprehensive query plan
+	Query                  query.Q    // the current basic query being evaluated, one part of query.Plan
+	OriginalQuery          string     // the raw string of the original search query
+	SearchMode             Mode
+	PatternType            query.SearchType
+	UserSettings           *schema.Settings
+	OnSourcegraphDotCom    bool
+	Features               *Features
+	Protocol               Protocol
+	SanitizeSearchPatterns []*regexp.Regexp
 }
 
 // MaxResults computes the limit for the query.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1711,7 +1711,7 @@ type SearchLimits struct {
 type SearchSanitization struct {
 	// OrgName description: Optionally specify the name of an organization within this Sourcegraph instance containing users whose searches should not be sanitized. Admins: ensure that ALL members of this org are trusted users. If no org exists with the given name then there will be no effect. If no org name is specified then all non-admin users will have their searches sanitized if this feature is enabled.
 	OrgName string `json:"orgName,omitempty"`
-	// SanitizePatterns description: An array of regular expressions representing matched content that should be omitted from search result events. This does not prevent users from accessing file contents through other means if they have read access. Values added to this array must be valid Go regular expressions. By default, site admins will not have their search results sanitized.
+	// SanitizePatterns description: An array of regular expressions representing matched content that should be omitted from search result events. This does not prevent users from accessing file contents through other means if they have read access. Values added to this array must be valid Go regular expressions. Site admins will not have their search results sanitized.
 	SanitizePatterns []string `json:"sanitizePatterns,omitempty"`
 }
 type SearchSavedQueries struct {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -673,8 +673,8 @@ type ExperimentalFeatures struct {
 	SearchIndexQueryContexts bool `json:"search.index.query.contexts,omitempty"`
 	// SearchIndexRevisions description: An array of objects describing rules for extra revisions (branch, ref, tag, commit sha, etc) to be indexed for all repositories that match them. We always index the default branch ("HEAD") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.
 	SearchIndexRevisions []*SearchIndexRevisionsRule `json:"search.index.revisions,omitempty"`
-	// SearchSanitizePatterns description: A list of regular expressions representing matched content that should be omitted from search result events. This does not prevent users from accessing file contents through other means if they have read access. A pattern that is not a valid Go regular expression will have no effect.
-	SearchSanitizePatterns []string `json:"search.sanitize.patterns,omitempty"`
+	// SearchSanitization description: Allows site admins to specify a list of regular expressions representing matched content that should be omitted from search results. Also allows admins to specify the name of an organization within their Sourcegraph instance whose members are trusted and will not have their search results sanitized. Enable this feature by adding at least one valid regular expression to the value of the `sanitizePatterns` field on this object. By default, site admins will not have their searches sanitized.
+	SearchSanitization *SearchSanitization `json:"search.sanitization,omitempty"`
 	// SearchMultipleRevisionsPerRepository description: DEPRECATED. Always on. Will be removed in 3.19.
 	SearchMultipleRevisionsPerRepository *bool `json:"searchMultipleRevisionsPerRepository,omitempty"`
 	// StructuralSearch description: Enables structural search.
@@ -1705,6 +1705,14 @@ type SearchLimits struct {
 	MaxRepos int `json:"maxRepos,omitempty"`
 	// MaxTimeoutSeconds description: The maximum value for "timeout:" that search will respect. "timeout:" values larger than maxTimeoutSeconds are capped at maxTimeoutSeconds. Note: You need to ensure your load balancer / reverse proxy in front of Sourcegraph won't timeout the request for larger values. Note: Too many large rearch requests may harm Soucregraph for other users. Defaults to 1 minute.
 	MaxTimeoutSeconds int `json:"maxTimeoutSeconds,omitempty"`
+}
+
+// SearchSanitization description: Allows site admins to specify a list of regular expressions representing matched content that should be omitted from search results. Also allows admins to specify the name of an organization within their Sourcegraph instance whose members are trusted and will not have their search results sanitized. Enable this feature by adding at least one valid regular expression to the value of the `sanitizePatterns` field on this object. By default, site admins will not have their searches sanitized.
+type SearchSanitization struct {
+	// OrgName description: Optionally specify the name of an organization within this Sourcegraph instance containing users whose searches should not be sanitized. Admins: ensure that ALL members of this org are trusted users. If no org exists with the given name then there will be no effect. If no org name is specified then all non-admin users will have their searches sanitized if this feature is enabled.
+	OrgName string `json:"orgName,omitempty"`
+	// SanitizePatterns description: An array of regular expressions representing matched content that should be omitted from search result events. This does not prevent users from accessing file contents through other means if they have read access. Values added to this array must be valid Go regular expressions. By default, site admins will not have their search results sanitized.
+	SanitizePatterns []string `json:"sanitizePatterns,omitempty"`
 }
 type SearchSavedQueries struct {
 	// Description description: Description of this saved query

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -673,7 +673,7 @@ type ExperimentalFeatures struct {
 	SearchIndexQueryContexts bool `json:"search.index.query.contexts,omitempty"`
 	// SearchIndexRevisions description: An array of objects describing rules for extra revisions (branch, ref, tag, commit sha, etc) to be indexed for all repositories that match them. We always index the default branch ("HEAD") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.
 	SearchIndexRevisions []*SearchIndexRevisionsRule `json:"search.index.revisions,omitempty"`
-	// SearchSanitization description: Allows site admins to specify a list of regular expressions representing matched content that should be omitted from search results. Also allows admins to specify the name of an organization within their Sourcegraph instance whose members are trusted and will not have their search results sanitized. Enable this feature by adding at least one valid regular expression to the value of the `sanitizePatterns` field on this object. By default, site admins will not have their searches sanitized.
+	// SearchSanitization description: Allows site admins to specify a list of regular expressions representing matched content that should be omitted from search results. Also allows admins to specify the name of an organization within their Sourcegraph instance whose members are trusted and will not have their search results sanitized. Enable this feature by adding at least one valid regular expression to the value of the `sanitizePatterns` field on this object. Site admins will not have their searches sanitized.
 	SearchSanitization *SearchSanitization `json:"search.sanitization,omitempty"`
 	// SearchMultipleRevisionsPerRepository description: DEPRECATED. Always on. Will be removed in 3.19.
 	SearchMultipleRevisionsPerRepository *bool `json:"searchMultipleRevisionsPerRepository,omitempty"`
@@ -1707,7 +1707,7 @@ type SearchLimits struct {
 	MaxTimeoutSeconds int `json:"maxTimeoutSeconds,omitempty"`
 }
 
-// SearchSanitization description: Allows site admins to specify a list of regular expressions representing matched content that should be omitted from search results. Also allows admins to specify the name of an organization within their Sourcegraph instance whose members are trusted and will not have their search results sanitized. Enable this feature by adding at least one valid regular expression to the value of the `sanitizePatterns` field on this object. By default, site admins will not have their searches sanitized.
+// SearchSanitization description: Allows site admins to specify a list of regular expressions representing matched content that should be omitted from search results. Also allows admins to specify the name of an organization within their Sourcegraph instance whose members are trusted and will not have their search results sanitized. Enable this feature by adding at least one valid regular expression to the value of the `sanitizePatterns` field on this object. Site admins will not have their searches sanitized.
 type SearchSanitization struct {
 	// OrgName description: Optionally specify the name of an organization within this Sourcegraph instance containing users whose searches should not be sanitized. Admins: ensure that ALL members of this org are trusted users. If no org exists with the given name then there will be no effect. If no org name is specified then all non-admin users will have their searches sanitized if this feature is enabled.
 	OrgName string `json:"orgName,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -519,12 +519,22 @@
             }
           }
         },
-        "search.sanitize.patterns": {
-          "description": "A list of regular expressions representing matched content that should be omitted from search result events. This does not prevent users from accessing file contents through other means if they have read access. A pattern that is not a valid Go regular expression will have no effect.",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "format": "regex"
+        "search.sanitization": {
+          "description": "Allows site admins to specify a list of regular expressions representing matched content that should be omitted from search results. Also allows admins to specify the name of an organization within their Sourcegraph instance whose members are trusted and will not have their search results sanitized. Enable this feature by adding at least one valid regular expression to the value of the `sanitizePatterns` field on this object. By default, site admins will not have their searches sanitized.",
+          "type": "object",
+          "properties": {
+            "sanitizePatterns": {
+              "description": "An array of regular expressions representing matched content that should be omitted from search result events. This does not prevent users from accessing file contents through other means if they have read access. Values added to this array must be valid Go regular expressions. By default, site admins will not have their search results sanitized.",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "regex"
+              }
+            },
+            "orgName": {
+              "description": "Optionally specify the name of an organization within this Sourcegraph instance containing users whose searches should not be sanitized. Admins: ensure that ALL members of this org are trusted users. If no org exists with the given name then there will be no effect. If no org name is specified then all non-admin users will have their searches sanitized if this feature is enabled.",
+              "type": "string"
+            }
           }
         },
         "enableGithubInternalRepoVisibility": {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -524,7 +524,7 @@
           "type": "object",
           "properties": {
             "sanitizePatterns": {
-              "description": "An array of regular expressions representing matched content that should be omitted from search result events. This does not prevent users from accessing file contents through other means if they have read access. Values added to this array must be valid Go regular expressions. By default, site admins will not have their search results sanitized.",
+              "description": "An array of regular expressions representing matched content that should be omitted from search result events. This does not prevent users from accessing file contents through other means if they have read access. Values added to this array must be valid Go regular expressions. Site admins will not have their search results sanitized.",
               "type": "array",
               "items": {
                 "type": "string",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -520,7 +520,7 @@
           }
         },
         "search.sanitization": {
-          "description": "Allows site admins to specify a list of regular expressions representing matched content that should be omitted from search results. Also allows admins to specify the name of an organization within their Sourcegraph instance whose members are trusted and will not have their search results sanitized. Enable this feature by adding at least one valid regular expression to the value of the `sanitizePatterns` field on this object. By default, site admins will not have their searches sanitized.",
+          "description": "Allows site admins to specify a list of regular expressions representing matched content that should be omitted from search results. Also allows admins to specify the name of an organization within their Sourcegraph instance whose members are trusted and will not have their search results sanitized. Enable this feature by adding at least one valid regular expression to the value of the `sanitizePatterns` field on this object. Site admins will not have their searches sanitized.",
           "type": "object",
           "properties": {
             "sanitizePatterns": {


### PR DESCRIPTION
This PR modifies the experimental search sanitization feature (introduced in https://github.com/sourcegraph/sourcegraph/pull/44154) in site config to add an additional property, `orgName`, which gives site admins the ability to specify an organization within their Sourcegraph instance whose users should not have their search results sanitized. This way, admins can whitelist certain trusted non-admin users. This was a specific customer request in response to the initial prototype. 

Also, this PR disables search sanitization by default for site admins.

We check the current user's role and org membership during the `Plan` step to decide whether sanitization should occur. If the given org name doesn't exist, then there will be no effect (sanitization will be active for all non-admin users). 


## Test plan
Added unit tests for checking whether to run sanitization
Manual testing
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
