### PR TITLE
web: collapse sidebar on repo settings page

### DIFF
--- a/client/web/src/repo/settings/RepoSettingsArea.tsx
+++ b/client/web/src/repo/settings/RepoSettingsArea.tsx
@@ -93,7 +93,7 @@ export const RepoSettingsArea: React.FunctionComponent<React.PropsWithChildren<P
     }
 
     return (
-        <div className={classNames('container d-flex mt-3', styles.repoSettingsArea)}>
+        <div className={classNames('container d-flex mt-3 flex-column flex-sm-row', styles.repoSettingsArea)}>
             <RepoSettingsSidebar className="flex-0 mr-3" {...props} {...context} />
             <div className="flex-bounded">
                 <Switch>

--- a/client/web/src/repo/settings/RepoSettingsArea.tsx
+++ b/client/web/src/repo/settings/RepoSettingsArea.tsx
@@ -93,7 +93,7 @@ export const RepoSettingsArea: React.FunctionComponent<React.PropsWithChildren<P
     }
 
     return (
-        <div className={classNames('container d-flex mt-3 flex-column flex-sm-row', styles.repoSettingsArea)}>
+        <div className={classNames('container d-flex mt-3 px-3 flex-column flex-sm-row', styles.repoSettingsArea)}>
             <RepoSettingsSidebar className="flex-0 mr-3" {...props} {...context} />
             <div className="flex-bounded">
                 <Switch>

--- a/client/web/src/repo/settings/RepoSettingsSidebar.tsx
+++ b/client/web/src/repo/settings/RepoSettingsSidebar.tsx
@@ -1,6 +1,10 @@
-import * as React from 'react'
+import React, { useCallback, useState } from 'react'
 
+import { mdiMenu } from '@mdi/js'
+import classNames from 'classnames'
 import { RouteComponentProps } from 'react-router-dom'
+
+import { Button, Icon } from '@sourcegraph/wildcard'
 
 import { SidebarGroupHeader, SidebarGroup, SidebarNavItem } from '../../components/Sidebar'
 import { SettingsAreaRepositoryFields } from '../../graphql-operations'
@@ -23,23 +27,39 @@ export const RepoSettingsSidebar: React.FunctionComponent<React.PropsWithChildre
     repoSettingsSidebarGroups,
     className,
     repo,
-}: Props) => (
-    <div className={className}>
-        {repoSettingsSidebarGroups.map(
-            ({ header, items, condition = () => true }, index) =>
-                condition({}) && (
-                    <SidebarGroup key={index}>
-                        {header && <SidebarGroupHeader label={header.label} />}
-                        {items.map(
-                            ({ label, to, exact, condition = () => true }) =>
-                                condition({}) && (
-                                    <SidebarNavItem to={`${repo.url}/-/settings${to}`} exact={exact} key={label}>
-                                        {label}
-                                    </SidebarNavItem>
-                                )
-                        )}
-                    </SidebarGroup>
-                )
-        )}
-    </div>
-)
+}: Props) => {
+    const [isMobileExpanded, setIsMobileExpanded] = useState(false)
+    const collapseMobileSidebar = useCallback((): void => setIsMobileExpanded(false), [])
+
+    return (
+        <>
+            <Button className="d-sm-none align-self-start mb-3" onClick={() => setIsMobileExpanded(!isMobileExpanded)}>
+                <Icon aria-hidden={true} svgPath={mdiMenu} className="mr-2" />
+                {isMobileExpanded ? 'Hide' : 'Show'} menu
+            </Button>
+            <div className={classNames(className, 'd-sm-block', !isMobileExpanded && 'd-none')}>
+                {repoSettingsSidebarGroups.map(
+                    ({ header, items, condition = () => true }, index) =>
+                        condition({}) && (
+                            <SidebarGroup key={index}>
+                                {header && <SidebarGroupHeader label={header.label} />}
+                                {items.map(
+                                    ({ label, to, exact, condition = () => true }) =>
+                                        condition({}) && (
+                                            <SidebarNavItem
+                                                to={`${repo.url}/-/settings${to}`}
+                                                exact={exact}
+                                                key={label}
+                                                onClick={collapseMobileSidebar}
+                                            >
+                                                {label}
+                                            </SidebarNavItem>
+                                        )
+                                )}
+                            </SidebarGroup>
+                        )
+                )}
+            </div>
+        </>
+    )
+}

--- a/client/web/src/repo/settings/RepoSettingsSidebar.tsx
+++ b/client/web/src/repo/settings/RepoSettingsSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useState } from 'react'
 
 import { mdiMenu } from '@mdi/js'
 import classNames from 'classnames'
@@ -10,7 +10,7 @@ import { SidebarGroupHeader, SidebarGroup, SidebarNavItem } from '../../componen
 import { SettingsAreaRepositoryFields } from '../../graphql-operations'
 import { NavGroupDescriptor } from '../../util/contributions'
 
-export interface RepoSettingsSideBarGroup extends NavGroupDescriptor {}
+export interface RepoSettingsSideBarGroup extends Omit<NavGroupDescriptor, 'condition'> {}
 
 export type RepoSettingsSideBarGroups = readonly RepoSettingsSideBarGroup[]
 
@@ -29,7 +29,6 @@ export const RepoSettingsSidebar: React.FunctionComponent<React.PropsWithChildre
     repo,
 }: Props) => {
     const [isMobileExpanded, setIsMobileExpanded] = useState(false)
-    const collapseMobileSidebar = useCallback((): void => setIsMobileExpanded(false), [])
 
     return (
         <>
@@ -38,27 +37,24 @@ export const RepoSettingsSidebar: React.FunctionComponent<React.PropsWithChildre
                 {isMobileExpanded ? 'Hide' : 'Show'} menu
             </Button>
             <div className={classNames(className, 'd-sm-block', !isMobileExpanded && 'd-none')}>
-                {repoSettingsSidebarGroups.map(
-                    ({ header, items, condition = () => true }, index) =>
-                        condition({}) && (
-                            <SidebarGroup key={index}>
-                                {header && <SidebarGroupHeader label={header.label} />}
-                                {items.map(
-                                    ({ label, to, exact, condition = () => true }) =>
-                                        condition({}) && (
-                                            <SidebarNavItem
-                                                to={`${repo.url}/-/settings${to}`}
-                                                exact={exact}
-                                                key={label}
-                                                onClick={collapseMobileSidebar}
-                                            >
-                                                {label}
-                                            </SidebarNavItem>
-                                        )
-                                )}
-                            </SidebarGroup>
-                        )
-                )}
+                {repoSettingsSidebarGroups.map(({ header, items }, index) => (
+                    <SidebarGroup key={index}>
+                        {header && <SidebarGroupHeader label={header.label} />}
+                        {items.map(
+                            ({ label, to, exact, condition = () => true }) =>
+                                condition({}) && (
+                                    <SidebarNavItem
+                                        to={`${repo.url}/-/settings${to}`}
+                                        exact={exact}
+                                        key={label}
+                                        onClick={() => setIsMobileExpanded(false)}
+                                    >
+                                        {label}
+                                    </SidebarNavItem>
+                                )
+                        )}
+                    </SidebarGroup>
+                ))}
             </div>
         </>
     )


### PR DESCRIPTION
Closes #35923
Uses same pattern as #44229
Follow-up work with #44240 to make it prettier.

## Test plan

Manually verify with Chrome devtools

![image](https://user-images.githubusercontent.com/206864/201231489-198e68f2-ed6f-4c37-a690-d23d7ceda7cf.png)

## App preview:

- [Web](https://sg-web-jp-reposettingssidebarcollapse.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
