### PR TITLE
[a11y] search ui: bump toggle size to 24x24px

### DIFF
--- a/client/search-ui/src/input/toggles/Toggles.module.scss
+++ b/client/search-ui/src/input/toggles/Toggles.module.scss
@@ -22,8 +22,8 @@
     justify-content: center;
     cursor: pointer;
     border-radius: 4px;
-    width: 1.375rem;
-    height: 1.375rem;
+    width: 1.5rem;
+    height: 1.5rem;
 
     &:not(:last-child) {
         margin-right: 0.125rem;


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/44226

## Test plan

Verify with visual tests

Before:
![image](https://user-images.githubusercontent.com/206864/201232319-3175401f-7ab4-4bf8-8f15-1c45e3a6c2cb.png)

After:
![image](https://user-images.githubusercontent.com/206864/201232264-f58f1af1-46b9-4388-8de8-d3aa201472cd.png)

## App preview:

- [Web](https://sg-web-jp-togglesize.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
