### PR TITLE
web: reflow branches page

### DIFF
--- a/client/web/src/repo/GitReference.module.scss
+++ b/client/web/src/repo/GitReference.module.scss
@@ -15,6 +15,7 @@
 
 .git-ref-node-link {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
     color: inherit;

--- a/client/web/src/repo/GitReference.tsx
+++ b/client/web/src/repo/GitReference.tsx
@@ -71,18 +71,18 @@ export const GitReferenceNode: React.FunctionComponent<React.PropsWithChildren<G
                 data-testid="git-ref-node"
                 aria-label={ariaLabel}
             >
-                <span className="d-flex align-items-center">
+                <span className="d-flex flex-wrap align-items-center">
                     {ReferenceIcon && <Icon className="mr-1" as={ReferenceIcon} aria-hidden={true} />}
                     {/*
                     a11y-ignore
                     Rule: "color-contrast" (Elements must have sufficient color contrast)
                     GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/33343
                 */}
-                    <Badge className="a11y-ignore px-1 py-0" as="code">
+                    <Badge className="a11y-ignore px-1 py-0 mr-2 text-break text-wrap text-justify" as="code">
                         {node.displayName}
                     </Badge>
                     {mostRecentSig && (
-                        <small className="pl-2">
+                        <small>
                             Updated <Timestamp date={mostRecentSig.date} />{' '}
                             {mostRecentSig.person && <>by {mostRecentSig.person.displayName}</>}
                         </small>

--- a/client/web/src/repo/branches/RepositoryBranchesArea.tsx
+++ b/client/web/src/repo/branches/RepositoryBranchesArea.tsx
@@ -48,7 +48,7 @@ export const RepositoryBranchesArea: React.FunctionComponent<React.PropsWithChil
     useBreadcrumb(useMemo(() => ({ key: 'branches', element: 'Branches' }), []))
 
     return (
-        <div className="repository-branches-area container">
+        <div className="repository-branches-area container px-3">
             <RepositoryBranchesNavbar className="my-3" repo={repo.name} />
             <Switch>
                 <Route

--- a/client/web/src/repo/branches/RepositoryBranchesOverviewPage.tsx
+++ b/client/web/src/repo/branches/RepositoryBranchesOverviewPage.tsx
@@ -154,13 +154,15 @@ export class RepositoryBranchesOverviewPage extends React.PureComponent<Props, S
                                         />
                                     ))}
                                     {this.state.dataOrError.hasMoreActiveBranches && (
-                                        <Link
-                                            className="list-group-item list-group-item-action py-2 d-flex"
-                                            to={`/${this.props.repo.name}/-/branches/all`}
-                                        >
-                                            View more branches
-                                            <Icon aria-hidden={true} svgPath={mdiChevronRight} />
-                                        </Link>
+                                        <li className="list-group-item list-group-item-action">
+                                            <Link
+                                                className="py-2 d-flex align-items-center"
+                                                to={`/${this.props.repo.name}/-/branches/all`}
+                                            >
+                                                View more branches
+                                                <Icon aria-hidden={true} svgPath={mdiChevronRight} />
+                                            </Link>
+                                        </li>
                                     )}
                                 </ul>
                             </Card>


### PR DESCRIPTION
Closes #35462
Also fixes small alignment issue and use of a non-li inside a ul

## Test plan

Verify visually

Before:
![image](https://user-images.githubusercontent.com/206864/201235804-e121476f-e06c-4f22-9095-5da1a6cba07b.png)

After:
![image](https://user-images.githubusercontent.com/206864/201235686-c4b4bea2-fc4c-430d-bda1-ea75e009242b.png)

## App preview:

- [Web](https://sg-web-jp-branchespagereflow.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
