### PR TITLE
PermsSyncer: report exact state of each provider in each job

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/integration_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/integration_test.go
@@ -146,6 +146,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 				ProviderID:   "https://github.com/",
 				ProviderType: "github",
 				State:        "SUCCESS",
+				Message:      "FetchRepoPerms",
 			}}, providerStates)
 
 			p := &authz.UserPermissions{
@@ -231,6 +232,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 				ProviderID:   "https://github.com/",
 				ProviderType: "github",
 				State:        "SUCCESS",
+				Message:      "FetchRepoPerms",
 			}}, providerStates)
 
 			p := &authz.UserPermissions{
@@ -257,6 +259,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 				ProviderID:   "https://github.com/",
 				ProviderType: "github",
 				State:        "SUCCESS",
+				Message:      "FetchRepoPerms",
 			}}, providerStates)
 
 			err = permsStore.LoadUserPermissions(ctx, p)
@@ -348,6 +351,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 				ProviderID:   "https://github.com/",
 				ProviderType: "github",
 				State:        "SUCCESS",
+				Message:      "FetchUserPerms",
 			}}, providerStates)
 
 			p := &authz.UserPermissions{
@@ -436,6 +440,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 				ProviderID:   "https://github.com/",
 				ProviderType: "github",
 				State:        "SUCCESS",
+				Message:      "FetchUserPerms",
 			}}, providerStates)
 
 			p := &authz.UserPermissions{
@@ -462,6 +467,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 				ProviderID:   "https://github.com/",
 				ProviderType: "github",
 				State:        "SUCCESS",
+				Message:      "FetchUserPerms",
 			}}, providerStates)
 
 			err = permsStore.LoadUserPermissions(ctx, p)

--- a/enterprise/cmd/repo-updater/internal/authz/integration_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/regexp"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/log/logtest"
 
@@ -137,10 +138,15 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			permsStore := edb.Perms(logger, testDB, timeutil.Now)
 			syncer := NewPermsSyncer(logger, testDB, reposStore, permsStore, timeutil.Now, nil)
 
-			err = syncer.syncRepoPerms(ctx, repo.ID, false, authz.FetchPermsOptions{})
+			providerStates, err := syncer.syncRepoPerms(ctx, repo.ID, false, authz.FetchPermsOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
+			assert.Equal(t, []providerState{{
+				ProviderID:   "https://github.com/",
+				ProviderType: "github",
+				State:        "SUCCESS",
+			}}, providerStates)
 
 			p := &authz.UserPermissions{
 				UserID: userID,
@@ -217,10 +223,15 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			permsStore := edb.Perms(logger, testDB, timeutil.Now)
 			syncer := NewPermsSyncer(logger, testDB, reposStore, permsStore, timeutil.Now, nil)
 
-			err = syncer.syncRepoPerms(ctx, repo.ID, false, authz.FetchPermsOptions{})
+			providerStates, err := syncer.syncRepoPerms(ctx, repo.ID, false, authz.FetchPermsOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
+			assert.Equal(t, []providerState{{
+				ProviderID:   "https://github.com/",
+				ProviderType: "github",
+				State:        "SUCCESS",
+			}}, providerStates)
 
 			p := &authz.UserPermissions{
 				UserID: userID,
@@ -238,10 +249,16 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			}
 
 			// sync again and check
-			err = syncer.syncRepoPerms(ctx, repo.ID, false, authz.FetchPermsOptions{})
+			providerStates, err = syncer.syncRepoPerms(ctx, repo.ID, false, authz.FetchPermsOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
+			assert.Equal(t, []providerState{{
+				ProviderID:   "https://github.com/",
+				ProviderType: "github",
+				State:        "SUCCESS",
+			}}, providerStates)
+
 			err = permsStore.LoadUserPermissions(ctx, p)
 			if err != nil {
 				t.Fatal(err)
@@ -323,10 +340,15 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			permsStore := edb.Perms(logger, testDB, timeutil.Now)
 			syncer := NewPermsSyncer(logger, testDB, reposStore, permsStore, timeutil.Now, nil)
 
-			err = syncer.syncUserPerms(ctx, userID, false, authz.FetchPermsOptions{})
+			providerStates, err := syncer.syncUserPerms(ctx, userID, false, authz.FetchPermsOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
+			assert.Equal(t, []providerState{{
+				ProviderID:   "https://github.com/",
+				ProviderType: "github",
+				State:        "SUCCESS",
+			}}, providerStates)
 
 			p := &authz.UserPermissions{
 				UserID: userID,
@@ -406,10 +428,15 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			permsStore := edb.Perms(logger, testDB, timeutil.Now)
 			syncer := NewPermsSyncer(logger, testDB, reposStore, permsStore, timeutil.Now, nil)
 
-			err = syncer.syncUserPerms(ctx, userID, false, authz.FetchPermsOptions{})
+			providerStates, err := syncer.syncUserPerms(ctx, userID, false, authz.FetchPermsOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
+			assert.Equal(t, []providerState{{
+				ProviderID:   "https://github.com/",
+				ProviderType: "github",
+				State:        "SUCCESS",
+			}}, providerStates)
 
 			p := &authz.UserPermissions{
 				UserID: userID,
@@ -427,10 +454,16 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 			}
 
 			// sync again and check
-			err = syncer.syncUserPerms(ctx, userID, false, authz.FetchPermsOptions{})
+			providerStates, err = syncer.syncUserPerms(ctx, userID, false, authz.FetchPermsOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
+			assert.Equal(t, []providerState{{
+				ProviderID:   "https://github.com/",
+				ProviderType: "github",
+				State:        "SUCCESS",
+			}}, providerStates)
+
 			err = permsStore.LoadUserPermissions(ctx, p)
 			if err != nil {
 				t.Fatal(err)

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -301,9 +301,33 @@ func (s *PermsSyncer) getUserGitHubAppInstallations(ctx context.Context, acct *e
 	return installations, nil
 }
 
+// providerState describes the state of a provider during a permissions sync.
+type providerState struct {
+	ProviderID   string
+	ProviderType string
+
+	// One of "ERROR" or "SUCCESS"
+	State   string
+	Message string
+}
+
+type providerStatesSet []providerState
+
+// ErroredProviders returns the list of providers that had error responses.
+func (ps providerStatesSet) ErroredProviders() (providers []string) {
+	for _, p := range ps {
+		if p.State == "ERROR" {
+			providers = append(providers, fmt.Sprintf("%s:%s", p.ProviderType, p.ProviderID))
+		}
+	}
+	return
+}
+
 type fetchUserPermsViaExternalAccountsResults struct {
 	repoIDs      []uint32
 	subRepoPerms map[api.ExternalRepoSpec]*authz.SubRepoPermissions
+
+	providerStates providerStatesSet
 }
 
 // fetchUserPermsViaExternalAccounts uses external accounts (aka. login
@@ -381,6 +405,12 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 		acct, err := provider.FetchAccount(ctx, user, accts, emails)
 		if err != nil {
 			providerLogger.Error("could not fetch account from authz provider", log.Error(err))
+			results.providerStates = append(results.providerStates, providerState{
+				ProviderID:   provider.ServiceID(),
+				ProviderType: provider.ServiceType(),
+				State:        "ERROR",
+				Message:      fmt.Sprintf("could not fetch account: %s", err.Error()),
+			})
 			continue
 		}
 
@@ -442,6 +472,12 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 		extPerms, err := provider.FetchUserPerms(ctx, acct, fetchOpts)
 		if err != nil {
 			acctLogger.Debug("fetching user permissions", log.Error(err))
+			results.providerStates = append(results.providerStates, providerState{
+				ProviderID:   provider.ServiceID(),
+				ProviderType: provider.ServiceType(),
+				State:        "ERROR",
+				Message:      fmt.Sprintf("could not fetch user permissions: %s", err.Error()),
+			})
 
 			unauthorized := errcode.IsUnauthorized(err)
 			forbidden := errcode.IsForbidden(err)
@@ -527,6 +563,12 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 			}
 			acctLogger.Warn("proceedWithPartialResults", log.Error(err))
 		} else {
+			results.providerStates = append(results.providerStates, providerState{
+				ProviderID:   provider.ServiceID(),
+				ProviderType: provider.ServiceType(),
+				State:        "SUCCESS",
+			})
+
 			err = accounts.TouchLastValid(ctx, acct.ID)
 			if err != nil {
 				return results, errors.Wrapf(err, "set last valid for external account %d", acct.ID)
@@ -617,14 +659,14 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 
 // syncUserPerms processes permissions syncing request in user-centric way. When `noPerms` is true,
 // the method will use partial results to update permissions tables even when error occurs.
-func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms bool, fetchOpts authz.FetchPermsOptions) (err error) {
+func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms bool, fetchOpts authz.FetchPermsOptions) (providerStates []providerState, err error) {
 	logger := s.logger.Scoped("syncUserPerms", "processes permissions sync request in user-centric way").With(log.Int32("userID", userID))
 	ctx, save := s.observe(ctx, "PermsSyncer.syncUserPerms", "")
 	defer save(requestTypeUser, userID, &err)
 
 	user, err := s.db.Users().GetByID(ctx, userID)
 	if err != nil {
-		return errors.Wrap(err, "get user")
+		return providerStates, errors.Wrap(err, "get user")
 	}
 
 	// We call this when there are errors communicating with external services so
@@ -636,9 +678,10 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 	}
 
 	results, err := s.fetchUserPermsViaExternalAccounts(ctx, user, noPerms, fetchOpts)
+	providerStates = results.providerStates
 	if err != nil {
 		tryTouchUserPerms()
-		return errors.Wrap(err, "fetch user permissions via external accounts")
+		return providerStates, errors.Wrap(err, "fetch user permissions via external accounts")
 	}
 
 	// fetch current permissions from database
@@ -666,7 +709,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 	srp := s.db.SubRepoPerms()
 	for spec, perm := range results.subRepoPerms {
 		if err := srp.UpsertWithSpec(ctx, user.ID, spec, *perm); err != nil {
-			return errors.Wrapf(err, "upserting sub repo perms %v for user %d", spec, user.ID)
+			return providerStates, errors.Wrapf(err, "upserting sub repo perms %v for user %d", spec, user.ID)
 		}
 	}
 
@@ -682,7 +725,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 
 	err = s.permsStore.SetUserPermissions(ctx, p)
 	if err != nil {
-		return errors.Wrap(err, "set user permissions")
+		return providerStates, errors.Wrap(err, "set user permissions")
 	}
 
 	logger.Debug("synced",
@@ -700,22 +743,22 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 		metricsPermsFirstSyncDelay.WithLabelValues("user", string(p.UserID)).Set(p.SyncedAt.Sub(user.CreatedAt).Seconds())
 	}
 
-	return nil
+	return providerStates, nil
 }
 
 // syncRepoPerms processes permissions syncing request in repository-centric way.
 // When `noPerms` is true, the method will use partial results to update permissions
 // tables even when error occurs.
-func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPerms bool, fetchOpts authz.FetchPermsOptions) (err error) {
+func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPerms bool, fetchOpts authz.FetchPermsOptions) (providerStates []providerState, err error) {
 	ctx, save := s.observe(ctx, "PermsSyncer.syncRepoPerms", "")
 	defer save(requestTypeRepo, int32(repoID), &err)
 
 	repo, err := s.reposStore.RepoStore().Get(ctx, repoID)
 	if err != nil {
 		if errcode.IsNotFound(err) {
-			return nil
+			return providerStates, nil
 		}
-		return errors.Wrap(err, "get repository")
+		return providerStates, errors.Wrap(err, "get repository")
 	}
 	var provider authz.Provider
 
@@ -748,14 +791,14 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		// We have no authz provider configured for the repository.
 		// However, we need to upsert the dummy record in order to
 		// prevent scheduler keep scheduling this repository.
-		return errors.Wrap(s.permsStore.TouchRepoPermissions(ctx, int32(repoID)), "touch repository permissions")
+		return providerStates, errors.Wrap(s.permsStore.TouchRepoPermissions(ctx, int32(repoID)), "touch repository permissions")
 	}
 
 	pendingAccountIDsSet := make(map[string]struct{})
 	accountIDsToUserIDs := make(map[string]int32) // Account ID -> User ID
 
 	if err := s.waitForRateLimit(ctx, provider.URN(), 1, "repo"); err != nil {
-		return errors.Wrap(err, "wait for rate limiter")
+		return providerStates, errors.Wrap(err, "wait for rate limiter")
 	}
 
 	extAccountIDs, err := provider.FetchRepoPerms(ctx, &extsvc.Repository{
@@ -773,7 +816,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 			log.Error(err),
 			log.String("suggestion", "GitHub access token user may only have read access to the repository, but needs write for permissions"),
 		)
-		return errors.Wrap(s.permsStore.TouchRepoPermissions(ctx, int32(repoID)), "touch repository permissions")
+		return providerStates, errors.Wrap(s.permsStore.TouchRepoPermissions(ctx, int32(repoID)), "touch repository permissions")
 	}
 
 	// Skip repo if unimplemented
@@ -786,13 +829,13 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 			logger.Warn("error touching permissions for unimplemented authz provider", log.Error(err))
 		}
 
-		return nil
+		return providerStates, nil
 	}
 
 	if err != nil {
 		// Process partial results if this is an initial fetch.
 		if !noPerms {
-			return errors.Wrap(err, "fetch repository permissions")
+			return providerStates, errors.Wrap(err, "fetch repository permissions")
 		}
 		logger.Warn("proceedWithPartialResults", log.Error(err))
 	}
@@ -827,7 +870,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		}
 
 		if err != nil {
-			return errors.Wrap(err, "get user IDs by external accounts")
+			return providerStates, errors.Wrap(err, "get user IDs by external accounts")
 		}
 
 		// Set up the set of all account IDs that need to be bound to permissions
@@ -871,12 +914,12 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 
 	txs, err := s.permsStore.Transact(ctx)
 	if err != nil {
-		return errors.Wrap(err, "start transaction")
+		return providerStates, errors.Wrap(err, "start transaction")
 	}
 	defer func() { err = txs.Done(err) }()
 
 	if err = txs.SetRepoPermissions(ctx, p); err != nil {
-		return errors.Wrap(err, "set repository permissions")
+		return providerStates, errors.Wrap(err, "set repository permissions")
 	}
 	regularCount := len(p.UserIDs)
 
@@ -886,7 +929,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		AccountIDs:  pendingAccountIDs,
 	}
 	if err = txs.SetRepoPendingPermissions(ctx, accounts, p); err != nil {
-		return errors.Wrap(err, "set repository pending permissions")
+		return providerStates, errors.Wrap(err, "set repository pending permissions")
 	}
 	pendingCount := len(p.UserIDs)
 
@@ -906,7 +949,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		metricsPermsFirstSyncDelay.WithLabelValues("repo", string(p.RepoID)).Set(p.SyncedAt.Sub(repo.CreatedAt).Seconds())
 	}
 
-	return nil
+	return providerStates, nil
 }
 
 // waitForRateLimit blocks until rate limit permits n events to happen. It returns
@@ -936,16 +979,16 @@ func (s *PermsSyncer) waitForRateLimit(ctx context.Context, urn string, n int, s
 func (s *PermsSyncer) syncPerms(ctx context.Context, logger log.Logger, syncGroups map[requestType]group.ContextGroup, request *syncRequest) {
 	defer s.queue.remove(request.Type, request.ID, true)
 
-	var runSync func() error
+	var runSync func() (providerStatesSet, error)
 	switch request.Type {
 	case requestTypeUser:
-		runSync = func() error {
+		runSync = func() (providerStatesSet, error) {
 			// Ensure the job field is recorded when monitoring external API calls
 			ctx = metrics.ContextWithTask(ctx, "SyncUserPerms")
 			return s.syncUserPerms(ctx, request.ID, request.NoPerms, request.Options)
 		}
 	case requestTypeRepo:
-		runSync = func() error {
+		runSync = func() (providerStatesSet, error) {
 			// Ensure the job field is recorded when monitoring external API calls
 			ctx = metrics.ContextWithTask(ctx, "SyncRepoPerms")
 			return s.syncRepoPerms(ctx, api.RepoID(request.ID), request.NoPerms, request.Options)
@@ -961,13 +1004,14 @@ func (s *PermsSyncer) syncPerms(ctx context.Context, logger log.Logger, syncGrou
 			metricsConcurrentSyncs.WithLabelValues(request.Type.String()).Inc()
 			defer metricsConcurrentSyncs.WithLabelValues(request.Type.String()).Dec()
 
-			err := runSync()
+			providerStates, err := runSync()
 			if err != nil {
 				logger.Error("failed to sync permissions",
 					log.Object("request",
 						log.Int("type", int(request.Type)),
 						log.Int32("id", request.ID),
 					),
+					log.Strings("erroredProviders", providerStates.ErroredProviders()),
 					log.Error(err),
 				)
 

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -183,6 +183,7 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 		ProviderID:   "https://gitlab.com/",
 		ProviderType: "gitlab",
 		State:        "SUCCESS",
+		Message:      "FetchUserPerms",
 	}}, providers)
 }
 
@@ -337,7 +338,7 @@ func TestPermsSyncer_syncUserPermsTemporaryProviderError(t *testing.T) {
 		ProviderID:   "https://gitlab.com/",
 		ProviderType: "gitlab",
 		State:        "ERROR",
-		Message:      "could not fetch user permissions: context deadline exceeded",
+		Message:      "FetchUserPerms: context deadline exceeded",
 	}}, providers)
 }
 

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -924,7 +924,7 @@ func TestPermsSyncer_syncPerms(t *testing.T) {
 		s := NewPermsSyncer(logtest.Scoped(t), nil, nil, nil, nil, nil)
 		s.queue.Push(request)
 
-		s.syncPerms(context.Background(), logtest.NoOp(t), nil, request)
+		s.syncPerms(context.Background(), nil, request)
 		assert.Equal(t, 0, s.queue.Len())
 	})
 
@@ -978,11 +978,11 @@ func TestPermsSyncer_syncPerms(t *testing.T) {
 		started := make(chan struct{}, 2)
 		go func() {
 			started <- struct{}{}
-			s.syncPerms(ctx, logtest.NoOp(t), syncGroups, request1)
+			s.syncPerms(ctx, syncGroups, request1)
 		}()
 		go func() {
 			started <- struct{}{}
-			s.syncPerms(ctx, logtest.NoOp(t), syncGroups, request2)
+			s.syncPerms(ctx, syncGroups, request2)
 		}()
 
 		getOrFail := func(c <-chan struct{}) (failed bool) {

--- a/enterprise/cmd/repo-updater/internal/authz/provider_state.go
+++ b/enterprise/cmd/repo-updater/internal/authz/provider_state.go
@@ -1,0 +1,46 @@
+package authz
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/log"
+)
+
+// providerState describes the state of a provider during a permissions sync.
+type providerState struct {
+	ProviderID   string
+	ProviderType string
+
+	// One of "ERROR" or "SUCCESS"
+	State   string
+	Message string
+}
+
+type providerStatesSet []providerState
+
+// SummaryField generates a single log field that summarizes the state of all providers.
+func (ps providerStatesSet) SummaryField() log.Field {
+	var (
+		errored   []log.Field
+		succeeded []log.Field
+	)
+	for _, p := range ps {
+		key := fmt.Sprintf("%s:%s", p.ProviderType, p.ProviderID)
+		// first add errored providers to fields
+		switch p.State {
+		case "ERROR":
+			errored = append(errored, log.String(
+				key,
+				p.Message,
+			))
+		case "SUCCESS":
+			succeeded = append(errored, log.String(
+				key,
+				p.Message,
+			))
+		}
+	}
+	return log.Object("providers",
+		log.Object("state.error", errored...),
+		log.Object("state.success", succeeded...))
+}

--- a/enterprise/cmd/repo-updater/internal/authz/provider_state.go
+++ b/enterprise/cmd/repo-updater/internal/authz/provider_state.go
@@ -46,7 +46,6 @@ func (ps providerStatesSet) SummaryField() log.Field {
 	)
 	for _, p := range ps {
 		key := fmt.Sprintf("%s:%s", p.ProviderType, p.ProviderID)
-		// first add errored providers to fields
 		switch p.State {
 		case "ERROR":
 			errored = append(errored, log.String(

--- a/enterprise/cmd/repo-updater/internal/authz/provider_state.go
+++ b/enterprise/cmd/repo-updater/internal/authz/provider_state.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 )
 
 // providerState describes the state of a provider during a permissions sync.
@@ -14,6 +16,24 @@ type providerState struct {
 	// One of "ERROR" or "SUCCESS"
 	State   string
 	Message string
+}
+
+func newProviderState(provider authz.Provider, err error, action string) providerState {
+	if err != nil {
+		return providerState{
+			ProviderID:   provider.ServiceID(),
+			ProviderType: provider.ServiceType(),
+			State:        "ERROR",
+			Message:      fmt.Sprintf("%s: %s", action, err.Error()),
+		}
+	} else {
+		return providerState{
+			ProviderID:   provider.ServiceID(),
+			ProviderType: provider.ServiceType(),
+			State:        "SUCCESS",
+			Message:      action,
+		}
+	}
 }
 
 type providerStatesSet []providerState


### PR DESCRIPTION
Right now there are three ways to try and determine if an authz/authorization provider is happy, each with caveats:

- through metrics and logs exported by each individual provider implementation. This is very inconsistent, up to each implementation, and difficult to programmatically assess
- through `PermsSyncer` job results, which only reports the overall state of a sync job run in a single `error`. It sometimes doesn't report any error from the provider at all, swallowing the provider's error with special handling
- through `PermsSyncer` metrics and logs. This gets us ~almost there, but is difficult to programmatically assess, requires infrastructure access, and requires knowledge of how `PermsSyncer` is implemented.

This makes assessing the health of authz difficult when:

- attempting to validate a particular authz provider is behaving correctly - e.g. when restoring from a backup, we want to be able to select a particular provider to ensure permissions sync jobs are correctly involving the provider and succeeding
- hypothetically, when multiple authz providers are configured

This change propagates the "real" state of each individual provider from the various `runSync` implementations, so that we can see the state of each provider involved in a permissions sync job. As a simple proof-of-concept, I've added a log field that lists the providers that failed when a job fails, and added some assertions to a few tests to demonstrate what the output looks like.

On top of this, we can then implement a cache that tracks recent permission sync job outcomes: #44258, which can then open the door to allowing us to render these results via the GraphQL API, similarly to the external service sync status API.

Part of https://github.com/sourcegraph/customer/issues/1534
Stacked on https://github.com/sourcegraph/sourcegraph/pull/44251

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Updated unit and integration tests pass