### PR TITLE
Wildcard [Pie chart]: Fix PieChart keyboard navigation

### DIFF
--- a/client/wildcard/src/components/Charts/components/pie-chart/PieChart.module.scss
+++ b/client/wildcard/src/components/Charts/components/pie-chart/PieChart.module.scss
@@ -2,19 +2,27 @@
     overflow: visible;
 }
 
-.link:hover {
+.link {
     text-decoration: none;
-}
 
-.arc-path {
-    &--with-link {
-        cursor: pointer;
+    &:focus .arc-path {
+        stroke-width: 3;
+        stroke: var(--primary);
+    }
+
+    &--fade {
+        opacity: 0.5;
     }
 }
 
-.link:focus .arc-path {
-    stroke-width: 3;
-    stroke: var(--primary);
-    z-index: 2;
-    position: relative;
+.arc-path {
+    //&--with-link {
+    //    cursor: pointer;
+    //}
+
+    &--fake {
+        stroke-width: 3;
+        stroke: var(--primary);
+        transform: scale(1.03);
+    }
 }

--- a/client/wildcard/src/components/Charts/components/pie-chart/PieChart.module.scss
+++ b/client/wildcard/src/components/Charts/components/pie-chart/PieChart.module.scss
@@ -16,10 +16,6 @@
 }
 
 .arc-path {
-    //&--with-link {
-    //    cursor: pointer;
-    //}
-
     &--fake {
         stroke-width: 3;
         stroke: var(--primary);

--- a/client/wildcard/src/components/Charts/components/pie-chart/components/PieArc.module.scss
+++ b/client/wildcard/src/components/Charts/components/pie-chart/components/PieArc.module.scss
@@ -1,12 +1,14 @@
-// Because @visx/annotation HTMLLabel doesn't have api for
-// passing custom CSS class to the Label component container
-// we have to get this element through CSS Cascade
-.label div {
-    background-color: var(--body-bg);
-    border: 1px solid var(--border-color);
-    padding: 0.25rem 0.5rem;
-    display: flex;
-    flex-direction: column;
+.label {
+    pointer-events: inherit !important;
+
+    // Because @visx/annotation HTMLLabel doesn't have api for
+    // passing custom CSS class to the Label component container
+    // we have to get this element through CSS Cascade
+    div {
+        background-color: var(--body-bg);
+        border: 1px solid var(--border-color);
+        padding: 0.25rem 0.5rem;
+    }
 }
 
 .label-title {

--- a/client/wildcard/src/components/Charts/components/pie-chart/components/PieArc.tsx
+++ b/client/wildcard/src/components/Charts/components/pie-chart/components/PieArc.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, SVGProps } from 'react'
 
-import { Annotation, HtmlLabel, Connector } from '@visx/annotation'
+import { Annotation, Connector, HtmlLabel } from '@visx/annotation'
 import { Group } from '@visx/group'
 import { PieArcDatum } from '@visx/shape/lib/shapes/Pie'
 import classNames from 'classnames'
@@ -36,7 +36,7 @@ export function PieArc<Datum>(props: PieArcProps<Datum>): ReactElement {
     const radius = path.outerRadius()(arc)
 
     // Pie chart operate polar system of coords but svg operates with a Cartesian coordinate system
-    // normalX and normalY they are just projections on the axes. You can thing about this code like
+    // normalX and normalY they are just projections on the axes. You can think about this code like
     // transformation polar coords to cartesian coords.
     // https://en.wikipedia.org/wiki/Polar_coordinate_system#/media/File:Polar_to_cartesian.svg
     const normalX = Math.cos(middleAngle)


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/44045
## Background 

Prior to this PR Pie chart had a logic that changed the pie arc order to visually pull focused/hoverd arc in the top visual layer. This was done in order to highlight focused/hoverd element. But this didn't work well because if we change the original elements order we change the focus order as well and it easily messes up with keyboard navigation. 

In this PR we do not change original order of pie arc elements. Instead we render additional arc element (which is hided from screen reader and focus navigation) and render it on top of all other arc elements. And therefore we have a proper focus and keyboard navigation and we still have a good visual behaviour (see the demos below) 

| Before | After |
| ------- | ------ |
| <video src="https://user-images.githubusercontent.com/18492575/201243884-252c9631-c5b3-4d46-a147-20c2d32332c6.mov" /> | <video src="https://user-images.githubusercontent.com/18492575/201243975-887ca454-c982-4d85-b0ca-4087b87be0ef.mov" /> | 

## Test plan
- Go to the PieChart storybook demo
- Try to focus any pie arc elements 
- Try to hover some other pie arch element
- Focus should stay on the same element 
- You should be able to go through all pie arc elements (no element should be skipped by focus) 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-pie-chart-keyboard.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
