### PR TITLE
search: Speed up repo list

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -10736,6 +10736,16 @@
           "ConstraintDefinition": ""
         },
         {
+          "Name": "gitserver_repos_last_changed_idx",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX gitserver_repos_last_changed_idx ON gitserver_repos USING btree (last_changed, repo_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
           "Name": "gitserver_repos_last_error_idx",
           "IsPrimaryKey": false,
           "IsUnique": false,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1473,6 +1473,7 @@ Indexes:
     "gitserver_repos_pkey" PRIMARY KEY, btree (repo_id)
     "gitserver_repos_cloned_status_idx" btree (repo_id) WHERE clone_status = 'cloned'::text
     "gitserver_repos_cloning_status_idx" btree (repo_id) WHERE clone_status = 'cloning'::text
+    "gitserver_repos_last_changed_idx" btree (last_changed, repo_id)
     "gitserver_repos_last_error_idx" btree (repo_id) WHERE last_error IS NOT NULL
     "gitserver_repos_not_cloned_status_idx" btree (repo_id) WHERE clone_status = 'not_cloned'::text
     "gitserver_repos_not_explicitly_cloned_idx" btree (repo_id) WHERE clone_status <> 'cloned'::text

--- a/migrations/frontend/1668174127_add_gitserver_repos_last_changed_idx/down.sql
+++ b/migrations/frontend/1668174127_add_gitserver_repos_last_changed_idx/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS gitserver_repos_last_changed_idx;

--- a/migrations/frontend/1668174127_add_gitserver_repos_last_changed_idx/metadata.yaml
+++ b/migrations/frontend/1668174127_add_gitserver_repos_last_changed_idx/metadata.yaml
@@ -1,0 +1,3 @@
+name: Add gitserver_repos_last_changed_idx
+parents: [1667825028, 1667952974]
+createIndexConcurrently: true

--- a/migrations/frontend/1668174127_add_gitserver_repos_last_changed_idx/up.sql
+++ b/migrations/frontend/1668174127_add_gitserver_repos_last_changed_idx/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS gitserver_repos_last_changed_idx ON gitserver_repos(last_changed, repo_id);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -4430,6 +4430,8 @@ CREATE INDEX gitserver_repos_cloned_status_idx ON gitserver_repos USING btree (r
 
 CREATE INDEX gitserver_repos_cloning_status_idx ON gitserver_repos USING btree (repo_id) WHERE (clone_status = 'cloning'::text);
 
+CREATE INDEX gitserver_repos_last_changed_idx ON gitserver_repos USING btree (last_changed, repo_id);
+
 CREATE INDEX gitserver_repos_last_error_idx ON gitserver_repos USING btree (repo_id) WHERE (last_error IS NOT NULL);
 
 CREATE INDEX gitserver_repos_not_cloned_status_idx ON gitserver_repos USING btree (repo_id) WHERE (clone_status = 'not_cloned'::text);


### PR DESCRIPTION
**Before**:

This query actually does three types of joins onto the `repo` table:

- An inner-join to the `gitserver_repos` table (only to check `last_changed`; rows are 1-1 and enforced by triggers)
- A semi-join to the `codeintel_path_ranks` table (via `EXISTS (... WHERE = id)`)
- A semi-join to the `search_context_repos` table (via `id IN (...)`)

```sql
EXPLAIN ANALYZE
SELECT
    repo.id,
    repo.name,
    repo.private
    --- , ...
FROM repo
JOIN gitserver_repos gr ON gr.repo_id = repo.id
WHERE
    repo.deleted_at IS NULL
    AND repo.blocked IS NULL
    AND (
        gr.last_changed >= NOW() - '1 day'::interval
        OR EXISTS (
            SELECT 1
            FROM codeintel_path_ranks pr
            WHERE
                pr.repository_id = repo.id
                AND pr.updated_at >= NOW() - '1 day'::interval
        )
        OR COALESCE(repo.updated_at, repo.created_at) >= NOW() - '1 day'::interval
        OR repo.id IN (
            SELECT scr.repo_id
            FROM search_context_repos scr
            LEFT JOIN search_contexts sc ON scr.search_context_id = sc.id
            WHERE
                sc.updated_at >= NOW() - '1 day'::interval
        )
    )
ORDER BY id;
```

There are a few notable properties about this query plan:

- We have a sequential scan over `gitserver_repos` table that returns ~7.4M rows.
- We have a sequential scan over the `repo` table which filters out 841k rows (of ~6.6M).
- The hash join is a large disjunction of conditions that results in ~6.6M rows being filtered (leaving only 21k for sorting).
- Each of the sub plans are efficient (good use of index scans, few heap fetches; search contexts could take a look but aren't a dominating factor)

```
QUERY PLAN
----------
 Sort  (cost=2845259.61..2863840.15 rows=7432217 width=43) (actual time=21538.469..21541.450 rows=21477 loops=1)
   Sort Key: repo.id
   Sort Method: quicksort  Memory: 2611kB
   ->  Hash Join  (cost=1055718.29..1863132.27 rows=7432217 width=43) (actual time=7418.356..21525.639 rows=21477 loops=1)
         Hash Cond: (gr.repo_id = repo.id)
         Join Filter: ((gr.last_changed >= (now() - '1 day'::interval)) OR (alternatives: SubPlan 1 or hashed SubPlan 2) OR (COALESCE(repo.updated_at, repo.created_at) >= (now() - '1 day'::interval)) OR (hashed SubPlan 3))
         Rows Removed by Join Filter: 6608001
         ->  Seq Scan on gitserver_repos gr  (cost=0.00..611340.12 rows=10105212 width=12) (actual time=0.009..2674.375 rows=7471180 loops=1)
         ->  Hash  (cost=902183.16..902183.16 rows=6596456 width=59) (actual time=7411.094..7411.108 rows=6629478 loops=1)
               Buckets: 4194304  Batches: 4  Memory Usage: 177325kB
               ->  Seq Scan on repo  (cost=0.00..902183.16 rows=6596456 width=59) (actual time=0.013..4847.639 rows=6629478 loops=1)
                     Filter: ((deleted_at IS NULL) AND (blocked IS NULL))
                     Rows Removed by Filter: 841702
         SubPlan 1
           ->  Index Scan using codeintel_path_ranks_repository_id_precision on codeintel_path_ranks pr  (cost=0.42..2.65 rows=1 width=0) (never executed)
                 Index Cond: (repository_id = repo.id)
                 Filter: (updated_at >= (now() - '1 day'::interval))
         SubPlan 2
           ->  Index Only Scan using codeintel_path_ranks_updated_at on codeintel_path_ranks pr_1  (cost=0.55..2.77 rows=1 width=4) (actual time=0.014..0.015 rows=0 loops=1)
                 Index Cond: (updated_at >= (now() - '1 day'::interval))
                 Heap Fetches: 0
         SubPlan 3
           ->  Hash Join  (cost=18.93..218.40 rows=15 width=4) (actual time=1.139..1.141 rows=0 loops=1)
                 Hash Cond: (scr.search_context_id = sc.id)
                 ->  Seq Scan on search_context_repos scr  (cost=0.00..176.57 rows=8657 width=12) (actual time=0.009..0.401 rows=3588 loops=1)
                 ->  Hash  (cost=18.92..18.92 rows=1 width=8) (actual time=0.187..0.188 rows=1 loops=1)
                       Buckets: 1024  Batches: 1  Memory Usage: 9kB
                       ->  Seq Scan on search_contexts sc  (cost=0.00..18.92 rows=1 width=8) (actual time=0.171..0.172 rows=1 loops=1)
                             Filter: (updated_at >= (now() - '1 day'::interval))
                             Rows Removed by Filter: 445
 Planning Time: 1.274 ms
 Execution Time: 21544.566 ms
(32 rows)
```

**After**:

This basically standardizes all of the joins to use the `EXISTS` syntax for uniformity. Note that we have moved the inner join on `gitserver_repos` to inside of the condition - this doesn't change the semantics of the query as `repo` and `gitserver_repos` will always be 1-1.

```sql
EXPLAIN ANALYZE
SELECT
    repo.id,
    repo.name,
    repo.private
    --- , ...
FROM repo
WHERE
    repo.deleted_at IS NULL
    AND repo.blocked IS NULL
    AND (
        EXISTS (SELECT 1 FROM gitserver_repos gr WHERE gr.repo_id = repo.id AND gr.last_changed >= NOW() - '1 day'::interval)
        OR EXISTS (
            SELECT 1
            FROM codeintel_path_ranks pr
            WHERE
                pr.repository_id = repo.id
                AND pr.updated_at >= NOW() - '1 day'::interval
        )
        OR COALESCE(repo.updated_at, repo.created_at) >= NOW() - '1 day'::interval
        OR EXISTS (
            SELECT 1
            FROM search_context_repos scr
            LEFT JOIN search_contexts sc ON scr.search_context_id = sc.id
            WHERE
                scr.repo_id = repo.id AND
                sc.updated_at >= NOW() - '1 day'::interval
        )
    )
ORDER BY id;
```

This new query shaves off a good chunk of time.

```
QUERY PLAN
----------
 Index Scan using repo_non_deleted_id_name_idx on repo  (cost=0.43..84666136.04 rows=6046751 width=43) (actual time=1081.007..14038.378 rows=21438 loops=1)
   Filter: ((blocked IS NULL) AND ((alternatives: SubPlan 1 or hashed SubPlan 2) OR (alternatives: SubPlan 3 or hashed SubPlan 4) OR (COALESCE(updated_at, created_at) >= (now() - '1 day'::interval)) OR (alternatives: SubPlan 5 or hashed SubPlan 6)))
   Rows Removed by Filter: 6608415
   SubPlan 1
     ->  Index Scan using gitserver_repos_pkey on gitserver_repos gr  (cost=0.56..2.79 rows=1 width=0) (never executed)
           Index Cond: (repo_id = repo.id)
           Filter: (last_changed >= (now() - '1 day'::interval))
   SubPlan 2
     ->  Gather  (cost=1000.00..586360.04 rows=13882 width=4) (actual time=0.520..1075.657 rows=10991 loops=1)
           Workers Planned: 2
           Workers Launched: 2
           ->  Parallel Seq Scan on gitserver_repos gr_1  (cost=0.00..583971.84 rows=5784 width=4) (actual time=0.087..1071.207 rows=3664 loops=3)
                 Filter: (last_changed >= (now() - '1 day'::interval))
                 Rows Removed by Filter: 2486731
   SubPlan 3
     ->  Index Scan using codeintel_path_ranks_repository_id_precision on codeintel_path_ranks pr  (cost=0.42..2.65 rows=1 width=0) (never executed)
           Index Cond: (repository_id = repo.id)
           Filter: (updated_at >= (now() - '1 day'::interval))
   SubPlan 4
     ->  Index Only Scan using codeintel_path_ranks_updated_at on codeintel_path_ranks pr_1  (cost=0.55..2.77 rows=1 width=4) (actual time=0.017..0.017 rows=0 loops=1)
           Index Cond: (updated_at >= (now() - '1 day'::interval))
           Heap Fetches: 0
   SubPlan 5
     ->  Nested Loop  (cost=0.56..7.23 rows=1 width=0) (never executed)
           ->  Index Only Scan using search_context_repos_unique on search_context_repos scr  (cost=0.29..2.50 rows=1 width=8) (never executed)
                 Index Cond: (repo_id = repo.id)
                 Heap Fetches: 0
           ->  Index Scan using search_contexts_pkey on search_contexts sc  (cost=0.28..2.50 rows=1 width=8) (never executed)
                 Index Cond: (id = scr.search_context_id)
                 Filter: (updated_at >= (now() - '1 day'::interval))
   SubPlan 6
     ->  Hash Join  (cost=18.93..218.40 rows=15 width=4) (actual time=1.109..1.112 rows=0 loops=1)
           Hash Cond: (scr_1.search_context_id = sc_1.id)
           ->  Seq Scan on search_context_repos scr_1  (cost=0.00..176.57 rows=8657 width=12) (actual time=0.016..0.370 rows=3588 loops=1)
           ->  Hash  (cost=18.92..18.92 rows=1 width=8) (actual time=0.194..0.195 rows=1 loops=1)
                 Buckets: 1024  Batches: 1  Memory Usage: 9kB
                 ->  Seq Scan on search_contexts sc_1  (cost=0.00..18.92 rows=1 width=8) (actual time=0.191..0.191 rows=1 loops=1)
                       Filter: (updated_at >= (now() - '1 day'::interval))
                       Rows Removed by Filter: 445
 Planning Time: 2.966 ms
 Execution Time: 14040.665 ms
(41 rows)
```

However, I still see a seq scan on `gitserver_repos` table, so I'll add an index for this condition to see how that changes the final runtime.

```
QUERY PLAN
----------
 Index Scan using repo_non_deleted_id_name_idx on repo  (cost=0.43..84649644.35 rows=6046751 width=43) (actual time=15.946..10038.577 rows=21382 loops=1)
   Filter: ((blocked IS NULL) AND ((alternatives: SubPlan 1 or hashed SubPlan 2) OR (alternatives: SubPlan 3 or hashed SubPlan 4) OR (COALESCE(updated_at, created_at) >= (now() - '1 day'::interval)) OR (alternatives: SubPlan 5 or hashed SubPlan 6)))
   Rows Removed by Filter: 6608475
   SubPlan 1
     ->  Index Scan using gitserver_repos_pkey on gitserver_repos gr  (cost=0.56..2.78 rows=1 width=0) (never executed)
           Index Cond: (repo_id = repo.id)
           Filter: (last_changed >= (now() - '1 day'::interval))
   SubPlan 2
     ->  Index Only Scan using gitserver_repos_last_changed_idx on gitserver_repos gr_1  (cost=0.44..2152.49 rows=13747 width=4) (actual time=0.016..12.235 rows=11005 loops=1)
           Index Cond: (last_changed >= (now() - '1 day'::interval))
           Heap Fetches: 6782
   SubPlan 3
     ->  Index Scan using codeintel_path_ranks_repository_id_precision on codeintel_path_ranks pr  (cost=0.42..2.65 rows=1 width=0) (never executed)
           Index Cond: (repository_id = repo.id)
           Filter: (updated_at >= (now() - '1 day'::interval))
   SubPlan 4
     ->  Index Only Scan using codeintel_path_ranks_updated_at on codeintel_path_ranks pr_1  (cost=0.55..2.77 rows=1 width=4) (actual time=0.019..0.019 rows=0 loops=1)
           Index Cond: (updated_at >= (now() - '1 day'::interval))
           Heap Fetches: 0
   SubPlan 5
     ->  Nested Loop  (cost=0.56..7.23 rows=1 width=0) (never executed)
           ->  Index Only Scan using search_context_repos_unique on search_context_repos scr  (cost=0.29..2.50 rows=1 width=8) (never executed)
                 Index Cond: (repo_id = repo.id)
                 Heap Fetches: 0
           ->  Index Scan using search_contexts_pkey on search_contexts sc  (cost=0.28..2.50 rows=1 width=8) (never executed)
                 Index Cond: (id = scr.search_context_id)
                 Filter: (updated_at >= (now() - '1 day'::interval))
   SubPlan 6
     ->  Hash Join  (cost=18.93..218.40 rows=15 width=4) (actual time=1.105..1.108 rows=0 loops=1)
           Hash Cond: (scr_1.search_context_id = sc_1.id)
           ->  Seq Scan on search_context_repos scr_1  (cost=0.00..176.57 rows=8657 width=12) (actual time=0.010..0.385 rows=3588 loops=1)
           ->  Hash  (cost=18.92..18.92 rows=1 width=8) (actual time=0.172..0.173 rows=1 loops=1)
                 Buckets: 1024  Batches: 1  Memory Usage: 9kB
                 ->  Seq Scan on search_contexts sc_1  (cost=0.00..18.92 rows=1 width=8) (actual time=0.169..0.170 rows=1 loops=1)
                       Filter: (updated_at >= (now() - '1 day'::interval))
                       Rows Removed by Filter: 445
 Planning Time: 3.519 ms
 Execution Time: 10040.349 ms
(38 rows)
```

Cool, even better savings. We no longer have a seq scan over large tables (search context queries might use some work; we double query `search_contexts` here, but that time seems negligible).

## Test plan

Ran in prod :smugcat: