### PR TITLE
batches: misc a11y fixes

### DIFF
--- a/client/branded/src/components/CodeSnippet.tsx
+++ b/client/branded/src/components/CodeSnippet.tsx
@@ -31,7 +31,7 @@ export const CodeSnippet: React.FunctionComponent<React.PropsWithChildren<CodeSn
         <pre className={classNames('bg-code rounded border p-3 position-relative', className)}>
             {withCopyButton && (
                 <Button className={styles.copyButton} onClick={() => copy(code)}>
-                    <Icon className="pr-2 pt-2" svgPath={mdiContentCopy} inline={false} aria-label="Copy" />
+                    <Icon className="pr-2 pt-2" svgPath={mdiContentCopy} inline={false} aria-label="Copy snippet" />
                 </Button>
             )}
             <Code dangerouslySetInnerHTML={highlightedInput} />

--- a/client/web/src/components/DismissibleAlert/DismissibleAlert.tsx
+++ b/client/web/src/components/DismissibleAlert/DismissibleAlert.tsx
@@ -47,7 +47,7 @@ export const DismissibleAlert: React.FunctionComponent<React.PropsWithChildren<D
     return (
         <Alert data-testid={testId} className={classNames(styles.container, className)} variant={variant}>
             <div className={styles.content}>{children}</div>
-            <Button aria-label="Close alert" variant="icon" className={styles.closeButton} onClick={onDismiss}>
+            <Button aria-label="Dismiss alert" variant="icon" className={styles.closeButton} onClick={onDismiss}>
                 <Icon aria-hidden={true} svgPath={mdiClose} />
             </Button>
         </Alert>

--- a/client/web/src/components/time/Duration.tsx
+++ b/client/web/src/components/time/Duration.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useReducer } from 'react'
 
+import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 import { parseISO } from 'date-fns'
 
@@ -15,6 +16,10 @@ export interface DurationProps extends React.HTMLAttributes<HTMLDivElement> {
      * is changing (e.g. for a timer). Default is true.
      */
     stableWidth?: boolean
+    /** String to precede screen-reader readout of the duration. */
+    labelPrefix?: string
+    /** String to follow screen-reader readout of the duration. */
+    labelSuffix?: string
 }
 
 /**
@@ -26,6 +31,8 @@ export const Duration: React.FunctionComponent<React.PropsWithChildren<DurationP
     end,
     className,
     stableWidth = true,
+    labelPrefix,
+    labelSuffix,
     ...props
 }) {
     // Parse the start date.
@@ -56,8 +63,16 @@ export const Duration: React.FunctionComponent<React.PropsWithChildren<DurationP
         return undefined
     }, [end])
 
+    const label = `${labelPrefix || ''} ${hours} hours, ${minutes} minutes, and ${seconds} seconds ${
+        labelSuffix || ''
+    }`.trim()
+
     return (
-        <div className={classNames('chromatic-ignore', { [styles.stableWidth]: stableWidth }, className)} {...props}>
+        <div
+            className={classNames('chromatic-ignore', { [styles.stableWidth]: stableWidth }, className)}
+            {...props}
+            role={end === undefined ? 'timer' : undefined}
+        >
             {stableWidth && (
                 // Set the width of the parent with a filler block of full-width digits,
                 // to prevent layout shift if the time changes.
@@ -66,7 +81,8 @@ export const Duration: React.FunctionComponent<React.PropsWithChildren<DurationP
                     00:00:00
                 </span>
             )}
-            <span className={styles.duration}>
+            <VisuallyHidden>{label}</VisuallyHidden>
+            <span className={styles.duration} aria-hidden={true}>
                 {leading0(hours)}:{leading0(minutes)}:{leading0(seconds)}
             </span>
         </div>

--- a/client/web/src/enterprise/batches/BatchChangeTabs.tsx
+++ b/client/web/src/enterprise/batches/BatchChangeTabs.tsx
@@ -11,7 +11,7 @@ export const BatchChangeTabs: React.FunctionComponent<TabsProps> = props => (
 
 /** sourcegraph/wildcard `TabsList` with BC visual styling applied. */
 export const BatchChangeTabList: React.FunctionComponent<TabListProps> = props => (
-    <div className="overflow-auto mb-2">
+    <nav className="overflow-auto mb-2" aria-label="Batch Change">
         <TabList className="w-100 nav d-inline-flex d-sm-flex flex-nowrap text-nowrap" {...props} />
-    </div>
+    </nav>
 )

--- a/client/web/src/enterprise/batches/Branch.tsx
+++ b/client/web/src/enterprise/batches/Branch.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { mdiSourceFork, mdiAccountQuestion } from '@mdi/js'
+import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 
 import { Badge, Icon, BadgeProps, Tooltip } from '@sourcegraph/wildcard'
@@ -28,13 +29,13 @@ export const Branch: React.FunctionComponent<React.PropsWithChildren<BranchProps
         variant={variant !== undefined ? variant : deleted ? 'danger' : 'secondary'}
         className={classNames('text-monospace', className)}
         as={deleted ? 'del' : undefined}
-        aria-label={`${deleted ? 'Deleted ' : ''}Branch: `}
+        aria-label={deleted ? 'Deleted' : ''}
     >
         {!forkTarget || forkTarget.namespace === null ? (
             name
         ) : (
             <>
-                <Icon aria-hidden={true} className="mr-1" svgPath={mdiSourceFork} />
+                <Icon aria-label="fork" className="mr-1" svgPath={mdiSourceFork} />
                 <BranchNamespace target={forkTarget} />
                 {name}
             </>
@@ -54,8 +55,9 @@ export const BranchMerge: React.FunctionComponent<React.PropsWithChildren<Branch
     headRef,
 }) => (
     <div className="d-block d-sm-inline-block">
+        <VisuallyHidden>Request to merge commit into</VisuallyHidden>
         <Branch name={baseRef} />
-        <Icon as="span" inline={false} className="p-1" aria-label="Update with">
+        <Icon as="span" inline={false} className="p-1" aria-label="from">
             &larr;
         </Icon>
         <Branch name={headRef} forkTarget={forkTarget} />

--- a/client/web/src/enterprise/batches/DropdownButton.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { mdiChevronDown } from '@mdi/js'
-import VisuallyHidden from '@reach/visually-hidden'
+import { VisuallyHidden } from '@reach/visually-hidden'
 
 import {
     ProductStatusBadge,

--- a/client/web/src/enterprise/batches/batch-spec/TabBar.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/TabBar.module.scss
@@ -10,7 +10,6 @@
     // This prevents the active item border from being cut off, since .nav-item applies margin-bottom: -1px;
     // stylelint-disable-next-line declaration-property-unit-allowed-list
     padding-bottom: 1px;
-    flex-shrink: 0;
 }
 
 .nav-link-disabled {
@@ -37,14 +36,4 @@
         pointer-events: none;
         font-weight: 700;
     }
-}
-
-// Unset Button-y styles
-.button {
-    font-weight: unset;
-    padding: var(--nav-link-padding-y) var(--nav-link-padding-x);
-    letter-spacing: unset;
-    font-size: unset;
-    line-height: unset;
-    user-select: unset;
 }

--- a/client/web/src/enterprise/batches/batch-spec/TabBar.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/TabBar.tsx
@@ -46,7 +46,10 @@ export const TabBar: React.FunctionComponent<React.PropsWithChildren<TabBarProps
     const fullTabsConfig = useMemo<TabsConfig[]>(() => uniqBy([...tabsConfig, ...DEFAULT_TABS], 'key'), [tabsConfig])
     return (
         <nav className="overflow-auto flex-shrink-0" aria-label="Steps">
-            <ul className={classNames('nav nav-tabs d-inline-flex d-sm-flex flex-nowrap text-nowrap', className)}>
+            <ul
+                className={classNames('nav nav-tabs d-inline-flex d-sm-flex flex-nowrap text-nowrap', className)}
+                role="tablist"
+            >
                 {fullTabsConfig.map(({ key, isEnabled, handler }, index) => {
                     const tabName = getTabName(key, index)
 

--- a/client/web/src/enterprise/batches/batch-spec/TabBar.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/TabBar.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import { uniqBy, upperFirst } from 'lodash'
 import { NavLink as RouterLink } from 'react-router-dom'
 
-import { Button } from '@sourcegraph/wildcard'
+import { Link } from '@sourcegraph/wildcard'
 
 import styles from './TabBar.module.scss'
 
@@ -45,53 +45,64 @@ export const TabBar: React.FunctionComponent<React.PropsWithChildren<TabBarProps
     // uniqBy removes duplicates by taking the first item it finds with a given 'name', so we spread the defaults last
     const fullTabsConfig = useMemo<TabsConfig[]>(() => uniqBy([...tabsConfig, ...DEFAULT_TABS], 'key'), [tabsConfig])
     return (
-        <ul className={classNames('nav nav-tabs', styles.navList, className)}>
-            {fullTabsConfig.map(({ key, isEnabled, handler }, index) => {
-                const tabName = getTabName(key, index)
+        <nav className="overflow-auto flex-shrink-0" aria-label="Steps">
+            <ul className={classNames('nav nav-tabs d-inline-flex d-sm-flex flex-nowrap text-nowrap', className)}>
+                {fullTabsConfig.map(({ key, isEnabled, handler }, index) => {
+                    const tabName = getTabName(key, index)
 
-                return (
-                    <li className="nav-item" key={key}>
-                        {activeTabKey === key ? (
-                            <span aria-disabled="true" className="nav-link active">
-                                {tabName}
-                            </span>
-                        ) : !isEnabled ? (
-                            <span
-                                aria-disabled="true"
-                                className={classNames('nav-link text-muted', styles.navLinkDisabled, styles.navLink)}
-                                data-tab-content={tabName}
-                            >
-                                {tabName}
-                            </span>
-                        ) : !handler ? (
-                            <span
-                                aria-disabled="true"
-                                className={classNames('nav-link', styles.navLink)}
-                                data-tab-content={tabName}
-                            >
-                                {tabName}
-                            </span>
-                        ) : handler.type === 'link' ? (
-                            <RouterLink
-                                to={`${matchURL || ''}/${key}`}
-                                role="button"
-                                className={classNames('nav-link', styles.navLink)}
-                                data-tab-content={tabName}
-                            >
-                                {tabName}
-                            </RouterLink>
-                        ) : (
-                            <Button
-                                className={classNames('nav-link', styles.button, styles.navLink)}
-                                onClick={handler.onClick}
-                                data-tab-content={tabName}
-                            >
-                                {tabName}
-                            </Button>
-                        )}
-                    </li>
-                )
-            })}
-        </ul>
+                    return (
+                        <li className="nav-item" key={key}>
+                            {!isEnabled ? (
+                                <span
+                                    aria-disabled={true}
+                                    className={classNames(
+                                        'nav-link text-muted',
+                                        styles.navLinkDisabled,
+                                        styles.navLink
+                                    )}
+                                    role="tab"
+                                    data-tab-content={tabName}
+                                >
+                                    {tabName}
+                                </span>
+                            ) : !handler ? (
+                                <span
+                                    className={classNames('nav-link', styles.navLink, activeTabKey === key && 'active')}
+                                    role="tab"
+                                    aria-selected={activeTabKey === key}
+                                    data-tab-content={tabName}
+                                >
+                                    {tabName}
+                                </span>
+                            ) : handler.type === 'link' ? (
+                                <RouterLink
+                                    to={`${matchURL || ''}/${key}`}
+                                    className={classNames('nav-link', styles.navLink, activeTabKey === key && 'active')}
+                                    aria-selected={activeTabKey === key}
+                                    role="tab"
+                                    data-tab-content={tabName}
+                                >
+                                    {tabName}
+                                </RouterLink>
+                            ) : (
+                                <Link
+                                    to=""
+                                    className={classNames('nav-link', styles.navLink, activeTabKey === key && 'active')}
+                                    aria-selected={activeTabKey === key}
+                                    onClick={event => {
+                                        event.preventDefault()
+                                        handler.onClick()
+                                    }}
+                                    role="tab"
+                                    data-tab-content={tabName}
+                                >
+                                    {tabName}
+                                </Link>
+                            )}
+                        </li>
+                    )
+                })}
+            </ul>
+        </nav>
     )
 }

--- a/client/web/src/enterprise/batches/batch-spec/TabBar.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/TabBar.tsx
@@ -46,7 +46,7 @@ export const TabBar: React.FunctionComponent<React.PropsWithChildren<TabBarProps
     const fullTabsConfig = useMemo<TabsConfig[]>(() => uniqBy([...tabsConfig, ...DEFAULT_TABS], 'key'), [tabsConfig])
     return (
         <nav className="overflow-auto flex-shrink-0" aria-label="Steps">
-            <ul
+            <div
                 className={classNames('nav nav-tabs d-inline-flex d-sm-flex flex-nowrap text-nowrap', className)}
                 role="tablist"
             >
@@ -54,7 +54,7 @@ export const TabBar: React.FunctionComponent<React.PropsWithChildren<TabBarProps
                     const tabName = getTabName(key, index)
 
                     return (
-                        <li className="nav-item" key={key}>
+                        <div className="nav-item" key={key}>
                             {!isEnabled ? (
                                 <span
                                     aria-disabled={true}
@@ -102,10 +102,10 @@ export const TabBar: React.FunctionComponent<React.PropsWithChildren<TabBarProps
                                     {tabName}
                                 </Link>
                             )}
-                        </li>
+                        </div>
                     )
                 })}
-            </ul>
+            </div>
         </nav>
     )
 }

--- a/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
@@ -261,7 +261,7 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
             ) : (
                 <div className={styles.form}>
                     <LibraryPane name={batchChange.name} onReplaceItem={editor.handleCodeChange} />
-                    <div className={styles.editorContainer}>
+                    <div className={styles.editorContainer} role="region" aria-label="batch spec editor">
                         <H4 as={H3} className={styles.header}>
                             Batch spec
                         </H4>

--- a/client/web/src/enterprise/batches/batch-spec/edit/RunBatchSpecButton.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/RunBatchSpecButton.tsx
@@ -56,6 +56,7 @@ export const RunBatchSpecButton: React.FunctionComponent<React.PropsWithChildren
                             execute()
                             eventLogger.log('batch_change_editor:run_batch_spec:clicked')
                         }}
+                        aria-label={typeof isExecutionDisabled === 'string' ? isExecutionDisabled : undefined}
                         disabled={!!isExecutionDisabled}
                     >
                         Run batch spec

--- a/client/web/src/enterprise/batches/batch-spec/edit/editor/EditorFeedbackPanel.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/editor/EditorFeedbackPanel.tsx
@@ -26,7 +26,11 @@ export const EditorFeedbackPanel: React.FunctionComponent<React.PropsWithChildre
     const errorHeading = errors.codeValidation ? 'Validation Errors' : 'Errors found'
 
     return (
-        <div className={classNames(styles.panel, 'rounded border bg-1 p-2 w-100 mt-2')}>
+        <div
+            className={classNames(styles.panel, 'rounded border bg-1 p-2 w-100 mt-2')}
+            role="region"
+            aria-label="editor feedback panel"
+        >
             <H4 className="text-danger text-uppercase">
                 <Icon aria-hidden={true} className="text-danger" svgPath={mdiAlertCircle} /> {errorHeading}
             </H4>

--- a/client/web/src/enterprise/batches/batch-spec/edit/library/LibraryPane.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/library/LibraryPane.tsx
@@ -156,7 +156,7 @@ export const LibraryPane: React.FunctionComponent<React.PropsWithChildren<Librar
                         <Button
                             className="p-0"
                             onClick={() => toggleCollapse(!collapsed)}
-                            aria-label={collapsed ? 'Expand' : 'Collapse'}
+                            aria-label={collapsed ? 'Expand library' : 'Collapse library'}
                         >
                             <Icon
                                 aria-hidden={true}
@@ -167,7 +167,7 @@ export const LibraryPane: React.FunctionComponent<React.PropsWithChildren<Librar
                 </div>
 
                 <animated.div style={contentStyle}>
-                    <ul className={styles.listContainer}>
+                    <ul className={styles.listContainer} aria-label="batch spec templates">
                         {LIBRARY.map(item => (
                             <li className={styles.libraryItem} key={item.name}>
                                 <Button

--- a/client/web/src/enterprise/batches/batch-spec/edit/library/LibraryPane.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/library/LibraryPane.tsx
@@ -137,7 +137,7 @@ export const LibraryPane: React.FunctionComponent<React.PropsWithChildren<Librar
     }, [selectedItem, props, updateTemplateWithQueryAndName])
 
     return (
-        <>
+        <div role="region" aria-label="batch spec template library">
             {selectedItem ? (
                 <ReplaceSpecModal
                     libraryItemName={selectedItem.name}
@@ -192,6 +192,6 @@ export const LibraryPane: React.FunctionComponent<React.PropsWithChildren<Librar
                     </Text>
                 </animated.div>
             </animated.div>
-        </>
+        </div>
     )
 }

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/ImportingChangesetsPreviewList.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/ImportingChangesetsPreviewList.tsx
@@ -37,7 +37,7 @@ export const ImportingChangesetsPreviewList: React.FunctionComponent<
         <H4 as={H3} className="align-self-start w-100 mt-4">
             Importing changesets
         </H4>
-        <ConnectionList className="list-group list-group-flush w-100">
+        <ConnectionList className="list-group list-group-flush w-100" aria-label="changesets to be imported">
             {connection?.nodes.map(node =>
                 node.__typename === 'VisibleChangesetSpec' ? (
                     <li className="w-100" key={node.id}>

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
 
 import { mdiAlert, mdiMagnify } from '@mdi/js'
+import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 import { animated, useSpring } from 'react-spring'
 
@@ -207,7 +208,7 @@ const MemoizedWorkspacesPreview: React.FunctionComponent<
                     </div>
                 )}
             </H4>
-            <animated.div style={exampleStyle} className={styles.onExample}>
+            <animated.div style={exampleStyle} className={styles.onExample} aria-hidden={!exampleOpen}>
                 <div ref={exampleReference} className="pt-2 pb-3">
                     {/* Hide the copy button while the example is closed so that it's not focusable. */}
                     <CodeSnippet
@@ -283,6 +284,9 @@ const MemoizedWorkspacesPreview: React.FunctionComponent<
             {!isReadOnly && (
                 <div className="d-flex flex-column align-items-center w-100 mb-3">
                     {error && <ErrorAlert error={error} className="w-100 mb-0" />}
+                    <VisuallyHidden role="status">
+                        {isWorkspacesPreviewInProgress ? 'Preview loading' : ''}
+                    </VisuallyHidden>
                     <div className={styles.iconContainer} aria-hidden={true}>
                         <PreviewLoadingSpinner
                             className={classNames({ [styles.hidden]: !isWorkspacesPreviewInProgress })}

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewList.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewList.tsx
@@ -68,7 +68,7 @@ export const WorkspacesPreviewList: React.FunctionComponent<React.PropsWithChild
     return (
         <ConnectionContainer className="w-100">
             {error && <ConnectionError errors={[error]} />}
-            <ConnectionList className="list-group list-group-flush w-100" aria-label="Workspace results found">
+            <ConnectionList className="list-group list-group-flush w-100" aria-label="workspace results found">
                 {connectionOrCached?.nodes?.map(node => (
                     <WorkspacesPreviewListItem
                         key={node.id}

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewPanel.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewPanel.tsx
@@ -26,7 +26,7 @@ export const WorkspacesPreviewPanel: React.FunctionComponent<React.PropsWithChil
             maxSize={0.45 * width}
             position="right"
             storageKey={WORKSPACES_PREVIEW_SIZE}
-            ariaLabel="workspaces preview sidebar"
+            ariaLabel="workspaces preview"
         >
             <div className={styles.container}>
                 <WorkspacesPreview isReadOnly={isReadOnly} />

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewPanel.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewPanel.tsx
@@ -26,7 +26,7 @@ export const WorkspacesPreviewPanel: React.FunctionComponent<React.PropsWithChil
             maxSize={0.45 * width}
             position="right"
             storageKey={WORKSPACES_PREVIEW_SIZE}
-            ariaLabel="Workspaces preview sidebar"
+            ariaLabel="workspaces preview sidebar"
         >
             <div className={styles.container}>
                 <WorkspacesPreview isReadOnly={isReadOnly} />

--- a/client/web/src/enterprise/batches/batch-spec/execute/BatchSpecStateBadge.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/BatchSpecStateBadge.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { VisuallyHidden } from '@reach/visually-hidden'
+
 import { Badge, BadgeVariantType } from '@sourcegraph/wildcard'
 
 import { BatchSpecState } from '../../../../graphql-operations'
@@ -38,8 +40,11 @@ export const BatchSpecStateBadge: React.FunctionComponent<React.PropsWithChildre
     const [variant, tooltip] = getProps(state)
 
     return (
-        <Badge className={className} variant={variant} tooltip={tooltip}>
-            {state}
-        </Badge>
+        <>
+            <VisuallyHidden role="status">{tooltip}</VisuallyHidden>
+            <Badge className={className} variant={variant} tooltip={tooltip} aria-hidden={true}>
+                {state}
+            </Badge>
+        </>
     )
 }

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 
 import { mdiProgressClock } from '@mdi/js'
+import { VisuallyHidden } from '@reach/visually-hidden'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import { Redirect, Route, RouteComponentProps, Switch } from 'react-router'
@@ -181,9 +182,16 @@ const MemoizedExecuteBatchSpecContent: React.FunctionComponent<
                         {batchSpec.source === BatchSpecSource.REMOTE ? (
                             <BatchSpecStateBadge state={batchSpec.state} />
                         ) : (
-                            <Badge variant="secondary" tooltip="This batch spec was executed with src-cli.">
-                                LOCAL
-                            </Badge>
+                            <>
+                                <VisuallyHidden>This batch spec was executed with src-cli.</VisuallyHidden>
+                                <Badge
+                                    variant="secondary"
+                                    tooltip="This batch spec was executed with src-cli."
+                                    aria-hidden={true}
+                                >
+                                    LOCAL
+                                </Badge>
+                            </>
                         )}
                     </div>
                     {batchSpec.startedAt && (

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
@@ -146,7 +146,7 @@ const MemoizedExecuteBatchSpecContent: React.FunctionComponent<
     errors,
     queryWorkspacesList,
 }) {
-    const { executionURL, workspaceResolution, source, applyURL } = batchSpec
+    const { executionURL, workspaceResolution, applyURL } = batchSpec
 
     const tabsConfig = useMemo<TabsConfig[]>(
         () => [
@@ -155,7 +155,7 @@ const MemoizedExecuteBatchSpecContent: React.FunctionComponent<
             { key: 'execution', isEnabled: true, handler: { type: 'link' } },
             { key: 'preview', isEnabled: applyURL !== null, handler: { type: 'link' } },
         ],
-        [applyURL, source]
+        [applyURL]
     )
 
     return (

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
@@ -152,7 +152,7 @@ const MemoizedExecuteBatchSpecContent: React.FunctionComponent<
         () => [
             { key: 'configuration', isEnabled: true, handler: { type: 'link' } },
             { key: 'spec', isEnabled: true, handler: { type: 'link' } },
-            { key: 'execution', isEnabled: source === BatchSpecSource.REMOTE, handler: { type: 'link' } },
+            { key: 'execution', isEnabled: true, handler: { type: 'link' } },
             { key: 'preview', isEnabled: applyURL !== null, handler: { type: 'link' } },
         ],
         [applyURL, source]

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
@@ -196,8 +196,14 @@ const MemoizedExecuteBatchSpecContent: React.FunctionComponent<
                     </div>
                     {batchSpec.startedAt && (
                         <ExecutionStat>
-                            <Icon aria-label="Duration" className={styles.durationIcon} svgPath={mdiProgressClock} />
-                            <Duration start={batchSpec.startedAt} end={batchSpec.finishedAt ?? undefined} />
+                            <Icon aria-hidden={true} className={styles.durationIcon} svgPath={mdiProgressClock} />
+                            <Duration
+                                start={batchSpec.startedAt}
+                                end={batchSpec.finishedAt ?? undefined}
+                                labelPrefix={`The batch spec ${
+                                    batchSpec.finishedAt ? 'finished executing in' : 'has been executing for'
+                                }`}
+                            />
                         </ExecutionStat>
                     )}
                     {workspaceResolution && <ExecutionStatsBar {...workspaceResolution.workspaces.stats} />}

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecutionStatsBar.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecutionStatsBar.module.scss
@@ -8,3 +8,9 @@
         height: 1.25rem;
     }
 }
+
+.label {
+    font-weight: normal;
+    font-size: 0.875rem;
+    margin: 0;
+}

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecutionStatsBar.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecutionStatsBar.tsx
@@ -1,7 +1,8 @@
 import { mdiAlertCircle, mdiCheckBold, mdiTimerSand, mdiTimelineClockOutline, mdiCircleOffOutline } from '@mdi/js'
+import { VisuallyHidden } from '@reach/visually-hidden'
 
 import { pluralize } from '@sourcegraph/common'
-import { Icon } from '@sourcegraph/wildcard'
+import { Icon, H3 } from '@sourcegraph/wildcard'
 
 import { BatchSpecWorkspaceStats } from '../../../../graphql-operations'
 
@@ -11,23 +12,33 @@ export const ExecutionStatsBar: React.FunctionComponent<React.PropsWithChildren<
     <>
         <ExecutionStat>
             <Icon aria-hidden={true} className="text-danger" svgPath={mdiAlertCircle} />
-            {stats.errored} {pluralize('error', stats.errored)}
+            <H3 className={styles.label}>
+                {stats.errored} <VisuallyHidden>workspace</VisuallyHidden> {pluralize('error', stats.errored)}
+            </H3>
         </ExecutionStat>
         <ExecutionStat>
             <Icon aria-hidden={true} className="text-success" svgPath={mdiCheckBold} />
-            {stats.completed} complete
+            <H3 className={styles.label}>
+                {stats.completed} <VisuallyHidden>{pluralize('workspace', stats.completed)}</VisuallyHidden> complete
+            </H3>
         </ExecutionStat>
         <ExecutionStat>
             <Icon aria-hidden={true} svgPath={mdiTimerSand} />
-            {stats.processing} working
+            <H3 className={styles.label}>
+                {stats.processing} <VisuallyHidden>{pluralize('workspace', stats.processing)}</VisuallyHidden> working
+            </H3>
         </ExecutionStat>
         <ExecutionStat>
             <Icon aria-hidden={true} svgPath={mdiTimelineClockOutline} />
-            {stats.queued} queued
+            <H3 className={styles.label}>
+                {stats.queued} <VisuallyHidden>{pluralize('workspace', stats.queued)}</VisuallyHidden> queued
+            </H3>
         </ExecutionStat>
         <ExecutionStat>
             <Icon aria-hidden={true} svgPath={mdiCircleOffOutline} />
-            {stats.ignored} ignored
+            <H3 className={styles.label}>
+                {stats.ignored} <VisuallyHidden>{pluralize('workspace', stats.ignored)}</VisuallyHidden> ignored
+            </H3>
         </ExecutionStat>
     </>
 )

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -160,10 +160,15 @@ const WorkspaceHeader: React.FunctionComponent<React.PropsWithChildren<Workspace
                 </Tooltip>
             )}
             {workspace.__typename === 'VisibleBatchSpecWorkspace' && workspace.path && (
-                <span className={styles.workspaceDetail}>{workspace.path}</span>
+                <span aria-label="Batch spec executed at path:" className={styles.workspaceDetail}>
+                    {workspace.path}
+                </span>
             )}
             {workspace.__typename === 'VisibleBatchSpecWorkspace' && (
-                <span className={classNames(styles.workspaceDetail, 'text-monospace')}>
+                <span
+                    aria-label="Batch spec executed on branch:"
+                    className={classNames(styles.workspaceDetail, 'text-monospace')}
+                >
                     <Icon aria-hidden={true} svgPath={mdiSourceBranch} /> {workspace.branch.displayName}
                 </span>
             )}
@@ -171,7 +176,13 @@ const WorkspaceHeader: React.FunctionComponent<React.PropsWithChildren<Workspace
                 <span className={classNames(styles.workspaceDetail, 'd-flex align-items-center')}>
                     Total time:
                     <strong className="pl-1">
-                        <Duration start={workspace.startedAt} end={workspace.finishedAt ?? undefined} />
+                        <Duration
+                            start={workspace.startedAt}
+                            end={workspace.finishedAt ?? undefined}
+                            labelPrefix={`Workspace ${
+                                workspace.finishedAt ? 'finished executing in' : 'has been executing for'
+                            }`}
+                        />
                     </strong>
                 </span>
             )}
@@ -188,7 +199,7 @@ const WorkspaceHeader: React.FunctionComponent<React.PropsWithChildren<Workspace
                 </Button>
             )}
         </div>
-        <hr className="mb-3" />
+        <hr className="mb-3" aria-hidden={true} />
     </>
 )
 
@@ -200,7 +211,7 @@ const HiddenWorkspaceDetails: React.FunctionComponent<React.PropsWithChildren<Hi
     workspace,
     deselectWorkspace,
 }) => (
-    <>
+    <div role="region" aria-label="workspace details">
         <WorkspaceHeader deselectWorkspace={deselectWorkspace} workspace={workspace} />
         <H1 className="text-center text-muted mt-5">
             <Icon aria-hidden={true} svgPath={mdiEyeOffOutline} />
@@ -208,7 +219,7 @@ const HiddenWorkspaceDetails: React.FunctionComponent<React.PropsWithChildren<Hi
         </H1>
         <Text alignment="center">This workspace is hidden due to permissions.</Text>
         <Text alignment="center">Contact the owner of this batch change for more information.</Text>
-    </>
+    </div>
 )
 
 interface VisibleWorkspaceDetailsProps extends Omit<WorkspaceDetailsProps, 'id'> {
@@ -243,7 +254,7 @@ const VisibleWorkspaceDetails: React.FunctionComponent<React.PropsWithChildren<V
     }
 
     return (
-        <>
+        <div role="region" aria-label="workspace details">
             {showTimeline && <TimelineModal node={workspace} onCancel={onDismissTimeline} />}
             <WorkspaceHeader
                 deselectWorkspace={deselectWorkspace}
@@ -301,7 +312,7 @@ const VisibleWorkspaceDetails: React.FunctionComponent<React.PropsWithChildren<V
                     {index !== workspace.steps.length - 1 && <hr className="my-2" />}
                 </React.Fragment>
             ))}
-        </>
+        </div>
     )
 }
 
@@ -393,18 +404,21 @@ const ChangesetSpecNode: React.FunctionComponent<React.PropsWithChildren<Changes
                 <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronDown : mdiChevronRight} className="mr-1" />
                 <div className={styles.collapseHeader}>
                     <Heading as="h4" styleAs="h3" className="mb-0 d-inline-block mr-2">
+                        <VisuallyHidden>Execution</VisuallyHidden>
                         <span className={styles.result}>Result</span>
                         {node.description.published !== null && (
                             <Badge className="text-uppercase ml-2">
                                 {publishBadgeLabel(node.description.published)}
                             </Badge>
-                        )}{' '}
+                        )}
                     </Heading>
                     <Icon aria-hidden={true} className="text-muted mr-1 flex-shrink-0" svgPath={mdiSourceBranch} />
+                    <VisuallyHidden>on branch</VisuallyHidden>
                     <span className={classNames('text-monospace text-muted', styles.changesetSpecBranch)}>
                         {node.description.headRef}
                     </span>
                 </div>
+                <VisuallyHidden>, generated changeset with</VisuallyHidden>
                 <DiffStat
                     {...node.description.diffStat}
                     expandedCounts={true}

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceStateIcon.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceStateIcon.tsx
@@ -39,6 +39,7 @@ export const WorkspaceStateIcon: React.FunctionComponent<React.PropsWithChildren
                             aria-label="This workspace is currently executing."
                             className={className}
                             as={LoadingSpinner}
+                            aria-live="off"
                         />
                     </span>
                 </Tooltip>

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesPanel.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesPanel.tsx
@@ -24,7 +24,7 @@ export const WorkspacesPanel: React.FunctionComponent<React.PropsWithChildren<Wo
             maxSize={0.45 * width}
             position="left"
             storageKey={WORKSPACES_LIST_SIZE}
-            ariaLabel="Execution workspaces sidebar"
+            ariaLabel="execution workspaces"
         >
             <Workspaces {...props} />
         </Panel>

--- a/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
@@ -176,14 +176,12 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
                     disabled={isReadOnly}
                 />
                 <Input
-                    autoFocus={true}
                     label="Batch change name"
                     value={nameInput}
                     onChange={onNameChange}
                     pattern={String(NAME_PATTERN)}
                     required={true}
                     status={isNameValid === undefined ? undefined : isNameValid ? 'valid' : 'error'}
-                    placeholder="My batch change name"
                     disabled={isReadOnly}
                 />
                 {!isReadOnly && (
@@ -195,14 +193,18 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
                         </span>
                     </small>
                 )}
-                <hr className="my-3" />
+                <hr className="my-3" aria-hidden={true} />
                 <strong className="d-block mb-2">
                     Visibility
                     <Tooltip content="Coming soon">
-                        <Icon aria-label="Coming soon" className="ml-1" svgPath={mdiInformationOutline} />
+                        <Icon
+                            aria-label="Private batch changes coming soon"
+                            className="ml-1"
+                            svgPath={mdiInformationOutline}
+                        />
                     </Tooltip>
                 </strong>
-                <div className="form-group mb-1">
+                <div className="form-group mb-1" aria-hidden={true}>
                     <RadioButton
                         name="visibility"
                         value="public"
@@ -213,7 +215,7 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
                         aria-label="Public"
                     />
                 </div>
-                <div className="form-group mb-0">
+                <div className="form-group mb-0" aria-hidden={true}>
                     <RadioButton
                         name="visibility"
                         value="private"
@@ -238,6 +240,7 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
                         variant="primary"
                         type="submit"
                         onClick={handleCreate}
+                        aria-label={isNameValid ? undefined : 'Batch change name is invalid'}
                         disabled={loading || nameInput === '' || !isNameValid}
                     >
                         Create

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -157,17 +157,20 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
         [history, location, shouldDisplayExecutionsTab, customShortPath]
     )
 
+    const changesetCount = batchChange.changesetsStats.total - batchChange.changesetsStats.archived
+    const executionsCount = `${pendingExecutionsCount}${batchChange.batchSpecs.pageInfo.hasNextPage && '+'}`
+
     return (
         <BatchChangeTabs defaultIndex={defaultTabIndex} onChange={onTabChange}>
             <BatchChangeTabList>
-                <Tab>
+                <Tab aria-label={`Changesets (${changesetCount} total)`}>
                     <span>
                         <Icon aria-hidden={true} className="text-muted mr-2" svgPath={mdiSourceBranch} />
                         <span className="text-content" data-tab-content="Changesets">
                             Changesets
                         </span>
                         <Badge variant="secondary" pill={true} className="ml-2">
-                            {batchChange.changesetsStats.total - batchChange.changesetsStats.archived}
+                            {changesetCount}
                         </Badge>
                     </span>
                 </Tab>
@@ -180,7 +183,11 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                     </span>
                 </Tab>
                 {shouldDisplayExecutionsTab ? (
-                    <Tab>
+                    <Tab
+                        aria-label={`Executions${
+                            pendingExecutionsCount > 0 ? ' (' + executionsCount + 'total active)' : ''
+                        }`}
+                    >
                         <span>
                             <Icon aria-hidden={true} className="text-muted mr-2" svgPath={mdiFileDocument} />
                             <span className="text-content" data-tab-content="Executions">
@@ -188,7 +195,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                             </span>
                             {pendingExecutionsCount > 0 && (
                                 <Badge variant="warning" pill={true} className="ml-2">
-                                    {pendingExecutionsCount} {batchChange.batchSpecs.pageInfo.hasNextPage && <>+</>}
+                                    {executionsCount}
                                 </Badge>
                             )}
                         </span>
@@ -203,7 +210,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                         </span>
                     </Tab>
                 )}
-                <Tab>
+                <Tab aria-label={`Archived (${batchChange.changesetsStats.archived} total)`}>
                     <span>
                         <Icon aria-hidden={true} className="text-muted mr-2" svgPath={mdiArchive} />
                         <span className="text-content" data-tab-content="Archived">
@@ -214,7 +221,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                         </Badge>
                     </span>
                 </Tab>
-                <Tab>
+                <Tab aria-label={`Bulk operations (${batchChange.bulkOperations.totalCount} total)`}>
                     <span>
                         <Icon aria-hidden={true} className="text-muted mr-2" svgPath={mdiMonitorStar} />
                         <span className="text-content" data-tab-content="Bulk operations">

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
@@ -65,7 +65,7 @@ export const BatchChangeStatsCard: React.FunctionComponent<React.PropsWithChildr
                         />
                     </Heading>{' '}
                     <span className={classNames(styles.batchChangeStatsCardCompleteness, 'lead text-nowrap')}>
-                        {formatDisplayPercent(percentComplete)} complete
+                        {`${formatDisplayPercent(percentComplete)} complete`}
                     </span>
                 </div>
                 <div className={classNames(styles.batchChangeStatsCardDivider, 'd-none d-md-block mx-3')} />

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
@@ -6,7 +6,7 @@ import CheckCircleOutlineIcon from 'mdi-react/CheckCircleOutlineIcon'
 import ProgressCheckIcon from 'mdi-react/ProgressCheckIcon'
 
 import { pluralize } from '@sourcegraph/common'
-import { Badge, Icon, Heading, H4 } from '@sourcegraph/wildcard'
+import { Badge, Icon, Heading, H3, H4 } from '@sourcegraph/wildcard'
 
 import { DiffStatStack } from '../../../components/diff/DiffStat'
 import { BatchChangeFields } from '../../../graphql-operations'
@@ -135,6 +135,7 @@ export const BatchChangeStatsTotalAction: React.FunctionComponent<React.PropsWit
     count,
 }) => (
     <H4
+        as={H3}
         className={classNames(
             styles.batchChangeStatsCardStat,
             'font-weight-normal m-0 flex-grow-0 pr-2 text-truncate text-nowrap d-flex flex-column align-items-center justify-content-center'

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
@@ -75,7 +75,8 @@ export const BatchChangeStatsCard: React.FunctionComponent<React.PropsWithChildr
                     <ChangesetStatusUnpublished
                         label={
                             <H4 className="font-weight-normal text-muted m-0">
-                                {stats.unpublished} <VisuallyHidden>changesets</VisuallyHidden> unpublished
+                                {stats.unpublished}{' '}
+                                <VisuallyHidden>{pluralize('changeset', stats.unpublished)}</VisuallyHidden> unpublished
                             </H4>
                         }
                         className={classNames(styles.batchChangeStatsCardStat, 'd-flex flex-grow-0 px-2 text-truncate')}
@@ -83,7 +84,8 @@ export const BatchChangeStatsCard: React.FunctionComponent<React.PropsWithChildr
                     <ChangesetStatusDraft
                         label={
                             <H4 className="font-weight-normal text-muted m-0">
-                                {stats.draft} <VisuallyHidden>changesets</VisuallyHidden> draft
+                                {stats.draft} <VisuallyHidden>{pluralize('changeset', stats.draft)}</VisuallyHidden>{' '}
+                                draft
                             </H4>
                         }
                         className={classNames(styles.batchChangeStatsCardStat, 'd-flex flex-grow-0 px-2 text-truncate')}
@@ -91,7 +93,7 @@ export const BatchChangeStatsCard: React.FunctionComponent<React.PropsWithChildr
                     <ChangesetStatusOpen
                         label={
                             <H4 className="font-weight-normal text-muted m-0">
-                                {stats.open} <VisuallyHidden>changesets</VisuallyHidden> open
+                                {stats.open} <VisuallyHidden>{pluralize('changeset', stats.open)}</VisuallyHidden> open
                             </H4>
                         }
                         className={classNames(styles.batchChangeStatsCardStat, 'd-flex flex-grow-0 px-2 text-truncate')}
@@ -99,7 +101,8 @@ export const BatchChangeStatsCard: React.FunctionComponent<React.PropsWithChildr
                     <ChangesetStatusClosed
                         label={
                             <H4 className="font-weight-normal text-muted m-0">
-                                {stats.closed} <VisuallyHidden>changesets</VisuallyHidden> closed
+                                {stats.closed} <VisuallyHidden>{pluralize('changeset', stats.closed)}</VisuallyHidden>{' '}
+                                closed
                             </H4>
                         }
                         className={classNames(styles.batchChangeStatsCardStat, 'd-flex flex-grow-0 px-2 text-truncate')}
@@ -107,7 +110,8 @@ export const BatchChangeStatsCard: React.FunctionComponent<React.PropsWithChildr
                     <ChangesetStatusMerged
                         label={
                             <H4 className="font-weight-normal text-muted m-0">
-                                {stats.merged} <VisuallyHidden>changesets</VisuallyHidden> merged
+                                {stats.merged} <VisuallyHidden>{pluralize('changeset', stats.merged)}</VisuallyHidden>{' '}
+                                merged
                             </H4>
                         }
                         className={classNames(styles.batchChangeStatsCardStat, 'd-flex flex-grow-0 pl-2 text-truncate')}
@@ -115,7 +119,8 @@ export const BatchChangeStatsCard: React.FunctionComponent<React.PropsWithChildr
                     <ChangesetStatusArchived
                         label={
                             <H4 className="font-weight-normal text-muted m-0">
-                                {stats.archived} <VisuallyHidden>changesets</VisuallyHidden> archived
+                                {stats.archived}{' '}
+                                <VisuallyHidden>{pluralize('changeset', stats.archived)}</VisuallyHidden> archived
                             </H4>
                         }
                         className={classNames(styles.batchChangeStatsCardStat, 'd-flex flex-grow-0 pl-2 text-truncate')}

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 
+import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 import CheckCircleOutlineIcon from 'mdi-react/CheckCircleOutlineIcon'
 import ProgressCheckIcon from 'mdi-react/ProgressCheckIcon'
 
 import { pluralize } from '@sourcegraph/common'
-import { Badge, Icon, H2, Heading } from '@sourcegraph/wildcard'
+import { Badge, Icon, Heading, H4 } from '@sourcegraph/wildcard'
 
 import { DiffStatStack } from '../../../components/diff/DiffStat'
 import { BatchChangeFields } from '../../../graphql-operations'
@@ -45,24 +46,22 @@ export const BatchChangeStatsCard: React.FunctionComponent<React.PropsWithChildr
     return (
         <div className={classNames(className)}>
             <div className="d-flex flex-wrap align-items-center flex-grow-1">
-                <H2 className="m-0">
-                    {/*
-                        a11y-ignore
-                        Rule: "color-contrast" (Elements must have sufficient color contrast)
-                        GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/33343
-                    */}
-                    <BatchChangeStatePill
-                        state={batchChange.state}
-                        className={classNames('a11y-ignore', styles.batchChangeStatsCardStateBadge)}
-                    />
-                </H2>
+                {/*
+                    a11y-ignore
+                    Rule: "color-contrast" (Elements must have sufficient color contrast)
+                    GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/33343
+                */}
+                <BatchChangeStatePill
+                    state={batchChange.state}
+                    className={classNames('a11y-ignore', styles.batchChangeStatsCardStateBadge)}
+                />
                 <div className={classNames(styles.batchChangeStatsCardDivider, 'mx-3')} />
-                <div className="d-flex align-items-center">
-                    <Heading as="h3" styleAs="h1" className="d-inline mb-0" aria-label="Batch Change Status">
+                <div className="d-flex align-items-center" role="status">
+                    <Heading as="h3" styleAs="h1" className="d-inline mb-0" aria-hidden="true">
                         <Icon
                             className={classNames('mr-2', isCompleted ? 'text-success' : 'text-muted')}
                             as={BatchChangeStatusIcon}
-                            aria-label="Batch Change Status Icon"
+                            aria-hidden={true}
                         />
                     </Heading>{' '}
                     <span className={classNames(styles.batchChangeStatsCardCompleteness, 'lead text-nowrap')}>
@@ -74,27 +73,51 @@ export const BatchChangeStatsCard: React.FunctionComponent<React.PropsWithChildr
                 <div className="d-flex flex-wrap justify-content-end flex-grow-1">
                     <BatchChangeStatsTotalAction count={stats.total} />
                     <ChangesetStatusUnpublished
-                        label={<span className="text-muted">{stats.unpublished} Unpublished</span>}
+                        label={
+                            <H4 className="font-weight-normal text-muted m-0">
+                                {stats.unpublished} <VisuallyHidden>changesets</VisuallyHidden> unpublished
+                            </H4>
+                        }
                         className={classNames(styles.batchChangeStatsCardStat, 'd-flex flex-grow-0 px-2 text-truncate')}
                     />
                     <ChangesetStatusDraft
-                        label={<span className="text-muted">{stats.draft} Draft</span>}
+                        label={
+                            <H4 className="font-weight-normal text-muted m-0">
+                                {stats.draft} <VisuallyHidden>changesets</VisuallyHidden> draft
+                            </H4>
+                        }
                         className={classNames(styles.batchChangeStatsCardStat, 'd-flex flex-grow-0 px-2 text-truncate')}
                     />
                     <ChangesetStatusOpen
-                        label={<span className="text-muted">{stats.open} Open</span>}
+                        label={
+                            <H4 className="font-weight-normal text-muted m-0">
+                                {stats.open} <VisuallyHidden>changesets</VisuallyHidden> open
+                            </H4>
+                        }
                         className={classNames(styles.batchChangeStatsCardStat, 'd-flex flex-grow-0 px-2 text-truncate')}
                     />
                     <ChangesetStatusClosed
-                        label={<span className="text-muted">{stats.closed} Closed</span>}
+                        label={
+                            <H4 className="font-weight-normal text-muted m-0">
+                                {stats.closed} <VisuallyHidden>changesets</VisuallyHidden> closed
+                            </H4>
+                        }
                         className={classNames(styles.batchChangeStatsCardStat, 'd-flex flex-grow-0 px-2 text-truncate')}
                     />
                     <ChangesetStatusMerged
-                        label={<span className="text-muted">{stats.merged} Merged</span>}
+                        label={
+                            <H4 className="font-weight-normal text-muted m-0">
+                                {stats.merged} <VisuallyHidden>changesets</VisuallyHidden> merged
+                            </H4>
+                        }
                         className={classNames(styles.batchChangeStatsCardStat, 'd-flex flex-grow-0 pl-2 text-truncate')}
                     />
                     <ChangesetStatusArchived
-                        label={<span className="text-muted">{stats.archived} Archived</span>}
+                        label={
+                            <H4 className="font-weight-normal text-muted m-0">
+                                {stats.archived} <VisuallyHidden>changesets</VisuallyHidden> archived
+                            </H4>
+                        }
                         className={classNames(styles.batchChangeStatsCardStat, 'd-flex flex-grow-0 pl-2 text-truncate')}
                     />
                 </div>
@@ -106,17 +129,18 @@ export const BatchChangeStatsCard: React.FunctionComponent<React.PropsWithChildr
 export const BatchChangeStatsTotalAction: React.FunctionComponent<React.PropsWithChildren<{ count: number }>> = ({
     count,
 }) => (
-    <div
+    <H4
         className={classNames(
             styles.batchChangeStatsCardStat,
-            'm-0 flex-grow-0 pr-2 text-truncate text-nowrap d-flex flex-column align-items-center justify-content-center'
+            'font-weight-normal m-0 flex-grow-0 pr-2 text-truncate text-nowrap d-flex flex-column align-items-center justify-content-center'
         )}
+        aria-label={`${count} total ${pluralize('changeset', count)}`}
     >
         <span className={styles.batchChangeStatsCardChangesetsPill}>
             <Badge variant="secondary" pill={true}>
                 {count}
             </Badge>
         </span>
-        <span className="text-muted">{pluralize('Changeset', count)}</span>
-    </div>
+        <span className="text-muted">{pluralize('changeset', count)}</span>
+    </H4>
 )

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.tsx
@@ -56,7 +56,7 @@ export const BatchChangeStatsCard: React.FunctionComponent<React.PropsWithChildr
                     className={classNames('a11y-ignore', styles.batchChangeStatsCardStateBadge)}
                 />
                 <div className={classNames(styles.batchChangeStatsCardDivider, 'mx-3')} />
-                <div className="d-flex align-items-center" role="status">
+                <div className="d-flex align-items-center">
                     <Heading as="h3" styleAs="h1" className="d-inline mb-0" aria-hidden="true">
                         <Icon
                             className={classNames('mr-2', isCompleted ? 'text-success' : 'text-muted')}

--- a/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
@@ -40,7 +40,7 @@ export const BulkOperationsTab: React.FunctionComponent<React.PropsWithChildren<
         <Container>
             <ConnectionContainer>
                 {error && <ConnectionError errors={[error.message]} />}
-                <ConnectionList className="list-group list-group-flush">
+                <ConnectionList className="list-group list-group-flush" aria-label="bulk operations">
                     {connection?.nodes?.map(node => (
                         <BulkOperationNode key={node.id} node={node} />
                     ))}

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -280,7 +280,7 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<React.PropsWithChildren
             <div className="list-group position-relative" ref={nextContainerElement}>
                 <ConnectionContainer>
                     {error && <ConnectionError errors={[error.message]} />}
-                    <ConnectionList className={styles.batchChangeChangesetsGrid}>
+                    <ConnectionList className={styles.batchChangeChangesetsGrid} aria-label="changesets">
                         {connection?.nodes?.length ? (
                             <BatchChangeChangesetsHeader
                                 allSelected={showSelectRow && areAllVisibleSelected()}

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -280,7 +280,7 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<React.PropsWithChildren
             <div className="list-group position-relative" ref={nextContainerElement}>
                 <ConnectionContainer>
                     {error && <ConnectionError errors={[error.message]} />}
-                    <ConnectionList as="div" className={styles.batchChangeChangesetsGrid}>
+                    <ConnectionList className={styles.batchChangeChangesetsGrid}>
                         {connection?.nodes?.length ? (
                             <BatchChangeChangesetsHeader
                                 allSelected={showSelectRow && areAllVisibleSelected()}

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesetsHeader.module.scss
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesetsHeader.module.scss
@@ -1,0 +1,3 @@
+.list-item {
+    display: contents;
+}

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesetsHeader.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesetsHeader.tsx
@@ -32,19 +32,19 @@ export const BatchChangeChangesetsHeader: React.FunctionComponent<
                 }
             />
         )}
-        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
+        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap" aria-hidden={true}>
             Status
         </H5>
-        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-nowrap">
+        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-nowrap" aria-hidden={true}>
             Changeset information
         </H5>
-        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
+        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap" aria-hidden={true}>
             Check state
         </H5>
-        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
+        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap" aria-hidden={true}>
             Review state
         </H5>
-        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
+        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap" aria-hidden={true}>
             Changes
         </H5>
     </>

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesetsHeader.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesetsHeader.tsx
@@ -4,6 +4,8 @@ import { H3, H5 } from '@sourcegraph/wildcard'
 
 import { InputTooltip } from '../../../../components/InputTooltip'
 
+import styles from './BatchChangeChangesetsHeader.module.scss'
+
 export interface BatchChangeChangesetsHeaderProps {
     allSelected?: boolean
     toggleSelectAll?: () => void
@@ -13,7 +15,7 @@ export interface BatchChangeChangesetsHeaderProps {
 export const BatchChangeChangesetsHeader: React.FunctionComponent<
     React.PropsWithChildren<BatchChangeChangesetsHeaderProps>
 > = ({ allSelected, toggleSelectAll, disabled }) => (
-    <>
+    <li className={styles.listItem}>
         <span className="d-none d-md-block" />
         {toggleSelectAll && (
             // eslint-disable-next-line no-restricted-syntax
@@ -47,5 +49,5 @@ export const BatchChangeChangesetsHeader: React.FunctionComponent<
         <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap" aria-hidden={true}>
             Changes
         </H5>
-    </>
+    </li>
 )

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetCheckStatusCell.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetCheckStatusCell.tsx
@@ -34,10 +34,12 @@ export const ChangesetCheckStatusPending: React.FunctionComponent<React.PropsWit
             className
         )}
     >
-        <Tooltip content="Check state is pending">
-            <Icon svgPath={mdiTimerSand} aria-label="Check state is pending" inline={false} />
+        <Tooltip content="Some checks are still pending">
+            <Icon svgPath={mdiTimerSand} aria-label="Some checks are still pending" inline={false} />
         </Tooltip>
-        <span className="text-muted">Pending</span>
+        <span aria-hidden={true} className="text-muted">
+            Pending
+        </span>
     </div>
 )
 export const ChangesetCheckStatusPassed: React.FunctionComponent<React.PropsWithChildren<{ className?: string }>> = ({
@@ -49,10 +51,12 @@ export const ChangesetCheckStatusPassed: React.FunctionComponent<React.PropsWith
             className
         )}
     >
-        <Tooltip content="All checks complete">
-            <Icon svgPath={mdiCheckCircle} aria-label="All checks complete" inline={false} />
+        <Tooltip content="All checks succeeded">
+            <Icon svgPath={mdiCheckCircle} aria-label="All checks succeeded" inline={false} />
         </Tooltip>
-        <span className="text-muted">Passed</span>
+        <span aria-hidden={true} className="text-muted">
+            Passed
+        </span>
     </div>
 )
 export const ChangesetCheckStatusFailed: React.FunctionComponent<React.PropsWithChildren<{ className?: string }>> = ({
@@ -67,6 +71,8 @@ export const ChangesetCheckStatusFailed: React.FunctionComponent<React.PropsWith
         <Tooltip content="Some checks failed">
             <Icon svgPath={mdiCloseCircle} aria-label="Some checks failed" inline={false} />
         </Tooltip>
-        <span className="text-muted">Failed</span>
+        <span aria-hidden={true} className="text-muted">
+            Failed
+        </span>
     </div>
 )

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetFilterRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetFilterRow.tsx
@@ -98,6 +98,7 @@ export const ChangesetFilterRow: React.FunctionComponent<React.PropsWithChildren
                             ref={searchElement}
                             defaultValue={search}
                             placeholder="Search title and repository name"
+                            aria-label="Search title and repository name"
                         />
                     </Form>
                 </div>

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetLastSynced.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetLastSynced.tsx
@@ -81,7 +81,7 @@ export const ChangesetLastSynced: React.FunctionComponent<React.PropsWithChildre
                     </span>
                 </Tooltip>
             ) : (
-                <>Last synced {formatDistance(parseISO(changeset.updatedAt), _now ?? new Date())} ago.</>
+                <>{`Last synced ${formatDistance(parseISO(changeset.updatedAt), _now ?? new Date())} ago.`}</>
             )}{' '}
             {isErrorLike(lastUpdatedAt) && (
                 <Tooltip content={lastUpdatedAt.message}>

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetNode.module.scss
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetNode.module.scss
@@ -1,6 +1,8 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
 .changeset-node {
+    display: contents;
+
     &__separator {
         // Make it full width in the current row.
         grid-column: 1 / -1;

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetNode.tsx
@@ -45,12 +45,12 @@ export const ChangesetNode: React.FunctionComponent<React.PropsWithChildren<Chan
     separator = <span className={styles.changesetNodeSeparator} />,
     ...props
 }) => (
-    <>
+    <li className={styles.changesetNode}>
         {separator}
         {node.__typename === 'ExternalChangeset' ? (
             <ExternalChangesetNode node={node} {...props} />
         ) : (
             <HiddenExternalChangesetNode node={node} {...props} />
         )}
-    </>
+    </li>
 )

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetReviewStatusCell.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetReviewStatusCell.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { mdiTimerSand, mdiGateArrowRight, mdiCommentOutline, mdiDelta, mdiCheckCircle } from '@mdi/js'
 import classNames from 'classnames'
 
-import { Icon } from '@sourcegraph/wildcard'
+import { Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { ExternalChangesetFields, ChangesetReviewState } from '../../../../graphql-operations'
 
@@ -38,8 +38,12 @@ export const ChangesetReviewStatusPending: React.FunctionComponent<React.PropsWi
             className
         )}
     >
-        <Icon svgPath={mdiTimerSand} inline={false} aria-hidden={true} />
-        <span className="text-muted">Pending</span>
+        <Tooltip content="A review for this changeset is still pending">
+            <Icon svgPath={mdiTimerSand} aria-label="A review for this changeset is still pending" inline={false} />
+        </Tooltip>
+        <span aria-hidden={true} className="text-muted">
+            Pending
+        </span>
     </div>
 )
 export const ChangesetReviewStatusDismissed: React.FunctionComponent<
@@ -51,8 +55,10 @@ export const ChangesetReviewStatusDismissed: React.FunctionComponent<
             className
         )}
     >
-        <Icon svgPath={mdiGateArrowRight} inline={false} aria-hidden={true} />
-        <span className="text-muted">Dismissed</span>
+        <Icon svgPath={mdiGateArrowRight} aria-label="This changeset's review has been dismissed" inline={false} />
+        <span aria-hidden={true} className="text-muted">
+            Dismissed
+        </span>
     </div>
 )
 export const ChangesetReviewStatusCommented: React.FunctionComponent<
@@ -64,8 +70,16 @@ export const ChangesetReviewStatusCommented: React.FunctionComponent<
             className
         )}
     >
-        <Icon svgPath={mdiCommentOutline} inline={false} aria-hidden={true} />
-        <span className="text-muted">Commented</span>
+        <Tooltip content="Comments have been left on this changeset by a reviewer">
+            <Icon
+                svgPath={mdiCommentOutline}
+                aria-label="Comments have been left on this changeset by a reviewer"
+                inline={false}
+            />
+        </Tooltip>
+        <span aria-hidden={true} className="text-muted">
+            Commented
+        </span>
     </div>
 )
 export const ChangesetReviewStatusChangesRequested: React.FunctionComponent<
@@ -77,8 +91,10 @@ export const ChangesetReviewStatusChangesRequested: React.FunctionComponent<
             className
         )}
     >
-        <Icon svgPath={mdiDelta} inline={false} aria-hidden={true} />
-        <span className="text-muted">Changes requested</span>
+        <Icon svgPath={mdiDelta} aria-label="Changes have been requested by a reviewer" inline={false} />
+        <span aria-hidden={true} className="text-muted">
+            Changes requested
+        </span>
     </div>
 )
 export const ChangesetReviewStatusApproved: React.FunctionComponent<
@@ -90,7 +106,11 @@ export const ChangesetReviewStatusApproved: React.FunctionComponent<
             className
         )}
     >
-        <Icon svgPath={mdiCheckCircle} inline={false} aria-hidden={true} />
-        <span className="text-muted">Approved</span>
+        <Tooltip content="This changeset has been approved by a reviewer">
+            <Icon svgPath={mdiCheckCircle} aria-label="This changeset has been approved by a reviewer" inline={false} />
+        </Tooltip>
+        <span aria-hidden={true} className="text-muted">
+            Approved
+        </span>
     </div>
 )

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusCell.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusCell.tsx
@@ -11,6 +11,7 @@ import {
     mdiArchive,
     mdiLock,
 } from '@mdi/js'
+import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 
 import { Tooltip, Icon } from '@sourcegraph/wildcard'
@@ -23,40 +24,48 @@ export interface ChangesetStatusCellProps {
     className?: string
     id?: Scalars['ID']
     state: ChangesetFields['state']
+    role?: React.AriaRole
 }
 
 export const ChangesetStatusCell: React.FunctionComponent<React.PropsWithChildren<ChangesetStatusCellProps>> = ({
     id,
     state,
     className = 'd-flex',
+    role,
 }) => {
     switch (state) {
         case ChangesetState.FAILED:
-            return <ChangesetStatusError className={className} />
+            return <ChangesetStatusError className={className} role={role} />
         case ChangesetState.RETRYING:
-            return <ChangesetStatusRetrying className={className} />
+            return <ChangesetStatusRetrying className={className} role={role} />
         case ChangesetState.SCHEDULED:
-            return <ChangesetStatusScheduled className={className} id={id} />
+            return <ChangesetStatusScheduled className={className} role={role} id={id} />
         case ChangesetState.PROCESSING:
-            return <ChangesetStatusProcessing className={className} />
+            return <ChangesetStatusProcessing className={className} role={role} />
         case ChangesetState.UNPUBLISHED:
-            return <ChangesetStatusUnpublished className={className} />
+            return <ChangesetStatusUnpublished className={className} role={role} />
         case ChangesetState.OPEN:
-            return <ChangesetStatusOpen className={className} />
+            return <ChangesetStatusOpen className={className} role={role} />
         case ChangesetState.DRAFT:
-            return <ChangesetStatusDraft className={className} />
+            return <ChangesetStatusDraft className={className} role={role} />
         case ChangesetState.CLOSED:
-            return <ChangesetStatusClosed className={className} />
+            return <ChangesetStatusClosed className={className} role={role} />
         case ChangesetState.MERGED:
-            return <ChangesetStatusMerged className={className} />
+            return <ChangesetStatusMerged className={className} role={role} />
         case ChangesetState.READONLY:
-            return <ChangesetStatusReadOnly className={className} />
+            return <ChangesetStatusReadOnly className={className} role={role} />
         case ChangesetState.DELETED:
-            return <ChangesetStatusDeleted className={className} />
+            return <ChangesetStatusDeleted className={className} role={role} />
     }
 }
 
 const iconClassNames = 'm-0 text-nowrap flex-column align-items-center justify-content-center'
+
+const StatusLabel: React.FunctionComponent<{ status: string; className?: string }> = ({ status, className }) => (
+    <span className={className}>
+        <VisuallyHidden>Status:</VisuallyHidden> {status}
+    </span>
+)
 
 interface ChangesetStatusIconProps extends React.HTMLAttributes<HTMLDivElement> {
     label?: React.ReactNode
@@ -64,7 +73,7 @@ interface ChangesetStatusIconProps extends React.HTMLAttributes<HTMLDivElement> 
 }
 
 export const ChangesetStatusUnpublished: React.FunctionComponent<React.PropsWithChildren<ChangesetStatusIconProps>> = ({
-    label = <span>Unpublished</span>,
+    label = <StatusLabel status="Unpublished" />,
     className,
     ...props
 }) => (
@@ -74,7 +83,7 @@ export const ChangesetStatusUnpublished: React.FunctionComponent<React.PropsWith
     </div>
 )
 export const ChangesetStatusClosed: React.FunctionComponent<React.PropsWithChildren<ChangesetStatusIconProps>> = ({
-    label = <span>Closed</span>,
+    label = <StatusLabel status="Closed" />,
     className,
     ...props
 }) => (
@@ -84,7 +93,7 @@ export const ChangesetStatusClosed: React.FunctionComponent<React.PropsWithChild
     </div>
 )
 export const ChangesetStatusMerged: React.FunctionComponent<React.PropsWithChildren<ChangesetStatusIconProps>> = ({
-    label = <span>Merged</span>,
+    label = <StatusLabel status="Merged" />,
     className,
     ...props
 }) => (
@@ -94,7 +103,7 @@ export const ChangesetStatusMerged: React.FunctionComponent<React.PropsWithChild
     </div>
 )
 export const ChangesetStatusOpen: React.FunctionComponent<React.PropsWithChildren<ChangesetStatusIconProps>> = ({
-    label = <span>Open</span>,
+    label = <StatusLabel status="Open" />,
     className,
     ...props
 }) => (
@@ -104,7 +113,7 @@ export const ChangesetStatusOpen: React.FunctionComponent<React.PropsWithChildre
     </div>
 )
 export const ChangesetStatusDraft: React.FunctionComponent<React.PropsWithChildren<ChangesetStatusIconProps>> = ({
-    label = <span>Draft</span>,
+    label = <StatusLabel status="Draft" />,
     className,
     ...props
 }) => (
@@ -114,7 +123,7 @@ export const ChangesetStatusDraft: React.FunctionComponent<React.PropsWithChildr
     </div>
 )
 export const ChangesetStatusDeleted: React.FunctionComponent<React.PropsWithChildren<ChangesetStatusIconProps>> = ({
-    label = <span>Deleted</span>,
+    label = <StatusLabel status="Deleted" />,
     className,
     ...props
 }) => (
@@ -124,7 +133,7 @@ export const ChangesetStatusDeleted: React.FunctionComponent<React.PropsWithChil
     </div>
 )
 export const ChangesetStatusError: React.FunctionComponent<React.PropsWithChildren<ChangesetStatusIconProps>> = ({
-    label = <span className="text-danger">Failed</span>,
+    label = <StatusLabel className="text-danger" status="Failed" />,
     className,
     ...props
 }) => (
@@ -134,7 +143,7 @@ export const ChangesetStatusError: React.FunctionComponent<React.PropsWithChildr
     </div>
 )
 export const ChangesetStatusRetrying: React.FunctionComponent<React.PropsWithChildren<ChangesetStatusIconProps>> = ({
-    label = <span>Retrying</span>,
+    label = <StatusLabel status="Retrying" />,
     className,
     ...props
 }) => (
@@ -145,7 +154,7 @@ export const ChangesetStatusRetrying: React.FunctionComponent<React.PropsWithChi
 )
 
 export const ChangesetStatusProcessing: React.FunctionComponent<React.PropsWithChildren<ChangesetStatusIconProps>> = ({
-    label = <span>Processing</span>,
+    label = <StatusLabel status="Processing" />,
     className,
     ...props
 }) => (
@@ -156,7 +165,7 @@ export const ChangesetStatusProcessing: React.FunctionComponent<React.PropsWithC
 )
 
 export const ChangesetStatusArchived: React.FunctionComponent<React.PropsWithChildren<ChangesetStatusIconProps>> = ({
-    label = <span>Archived</span>,
+    label = <StatusLabel status="Archived" />,
     className,
     ...props
 }) => (
@@ -167,7 +176,7 @@ export const ChangesetStatusArchived: React.FunctionComponent<React.PropsWithChi
 )
 
 export const ChangesetStatusReadOnly: React.FunctionComponent<React.PropsWithChildren<ChangesetStatusIconProps>> = ({
-    label = <span>Read-only</span>,
+    label = <StatusLabel status="Read-only" />,
     className,
     ...props
 }) => (

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusScheduled.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusScheduled.tsx
@@ -42,12 +42,14 @@ interface Props {
     id: Scalars['ID']
     label: JSX.Element
     className?: string
+    role?: React.AriaRole
 }
 
 const DynamicChangesetStatusScheduled: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     id,
     label,
     className,
+    role,
 }) => {
     // Calculating the estimate is just expensive enough that we don't want to
     // do it for every changeset. (If we did, we'd just request the field when
@@ -87,7 +89,12 @@ const DynamicChangesetStatusScheduled: React.FunctionComponent<React.PropsWithCh
 
     return (
         <Tooltip content={tooltip}>
-            <div className={classNames(iconClassNames, className)} onMouseOver={onMouseOver} onFocus={onMouseOver}>
+            <div
+                className={classNames(iconClassNames, className)}
+                onMouseOver={onMouseOver}
+                onFocus={onMouseOver}
+                role={role}
+            >
                 <Icon svgPath={mdiTimerOutline} inline={false} aria-hidden={true} />
                 {label}
             </div>
@@ -98,7 +105,7 @@ const DynamicChangesetStatusScheduled: React.FunctionComponent<React.PropsWithCh
 const StaticChangesetStatusScheduled: React.FunctionComponent<
     React.PropsWithChildren<Pick<Props, 'label' | 'className'>>
 > = ({ label, className }) => (
-    <div className={classNames(iconClassNames, className)}>
+    <div className={classNames(iconClassNames, className)} role={role}>
         <Icon svgPath={mdiTimerOutline} inline={false} aria-hidden={true} />
         {label}
     </div>
@@ -108,15 +115,16 @@ export const ChangesetStatusScheduled: React.FunctionComponent<React.PropsWithCh
     id,
     label = <span>Scheduled</span>,
     className,
+    role,
 }) => (
     // If there's no ID (for example, when previewing a batch change), then no
     // dynamic behaviour is required, and we can just return a static icon and
     // label. Otherwise, we need the whole dynamic shebang.
     <>
         {id ? (
-            <DynamicChangesetStatusScheduled id={id} label={label} className={className} />
+            <DynamicChangesetStatusScheduled id={id} label={label} className={className} role={role} />
         ) : (
-            <StaticChangesetStatusScheduled label={label} className={className} />
+            <StaticChangesetStatusScheduled label={label} className={className} role={role} />
         )}
     </>
 )

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusScheduled.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusScheduled.tsx
@@ -103,8 +103,8 @@ const DynamicChangesetStatusScheduled: React.FunctionComponent<React.PropsWithCh
 }
 
 const StaticChangesetStatusScheduled: React.FunctionComponent<
-    React.PropsWithChildren<Pick<Props, 'label' | 'className'>>
-> = ({ label, className }) => (
+    React.PropsWithChildren<Pick<Props, 'label' | 'className' | 'role'>>
+> = ({ label, className, role }) => (
     <div className={classNames(iconClassNames, className)} role={role}>
         <Icon svgPath={mdiTimerOutline} inline={false} aria-hidden={true} />
         {label}

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react'
 
 import { mdiChevronDown, mdiChevronRight, mdiSync } from '@mdi/js'
+import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 import * as H from 'history'
 
@@ -133,9 +134,21 @@ export const ExternalChangesetNode: React.FunctionComponent<React.PropsWithChild
                     (node.checkState || node.reviewState || node.diffStat) && 'p-2'
                 )}
             >
-                {node.checkState && <ChangesetCheckStatusCell checkState={node.checkState} className="mr-3" />}
-                {node.reviewState && <ChangesetReviewStatusCell reviewState={node.reviewState} className="mr-3" />}
-                {node.diffStat && <DiffStatStack {...node.diffStat} />}
+                {node.checkState ? (
+                    <ChangesetCheckStatusCell checkState={node.checkState} className="mr-3" />
+                ) : (
+                    <VisuallyHidden>No check state available</VisuallyHidden>
+                )}
+                {node.reviewState ? (
+                    <ChangesetReviewStatusCell reviewState={node.reviewState} className="mr-3" />
+                ) : (
+                    <VisuallyHidden>No review state available</VisuallyHidden>
+                )}
+                {node.diffStat ? (
+                    <DiffStatStack {...node.diffStat} />
+                ) : (
+                    <VisuallyHidden>No diff available</VisuallyHidden>
+                )}
             </div>
             <span
                 className={classNames(
@@ -143,7 +156,11 @@ export const ExternalChangesetNode: React.FunctionComponent<React.PropsWithChild
                     node.checkState && 'p-2'
                 )}
             >
-                {node.checkState && <ChangesetCheckStatusCell checkState={node.checkState} />}
+                {node.checkState ? (
+                    <ChangesetCheckStatusCell checkState={node.checkState} />
+                ) : (
+                    <VisuallyHidden>No check state available</VisuallyHidden>
+                )}
             </span>
             <span
                 className={classNames(
@@ -151,7 +168,11 @@ export const ExternalChangesetNode: React.FunctionComponent<React.PropsWithChild
                     node.reviewState && 'p-2'
                 )}
             >
-                {node.reviewState && <ChangesetReviewStatusCell reviewState={node.reviewState} />}
+                {node.reviewState ? (
+                    <ChangesetReviewStatusCell reviewState={node.reviewState} />
+                ) : (
+                    <VisuallyHidden>No review state available</VisuallyHidden>
+                )}
             </span>
             <div
                 className={classNames(
@@ -159,7 +180,11 @@ export const ExternalChangesetNode: React.FunctionComponent<React.PropsWithChild
                     node.diffStat && 'p-2'
                 )}
             >
-                {node.diffStat && <DiffStatStack {...node.diffStat} />}
+                {node.diffStat ? (
+                    <DiffStatStack {...node.diffStat} />
+                ) : (
+                    <VisuallyHidden>No diff available</VisuallyHidden>
+                )}
             </div>
             {/* The button for expanding the information used on xs devices. */}
             <Button

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
@@ -115,6 +115,7 @@ export const ExternalChangesetNode: React.FunctionComponent<React.PropsWithChild
             <ChangesetStatusCell
                 id={node.id}
                 state={node.state}
+                role="status"
                 className={classNames(
                     styles.externalChangesetNodeState,
                     'p-2 align-self-stretch text-muted d-block d-sm-flex'

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
@@ -116,7 +116,6 @@ export const ExternalChangesetNode: React.FunctionComponent<React.PropsWithChild
             <ChangesetStatusCell
                 id={node.id}
                 state={node.state}
-                role="status"
                 className={classNames(
                     styles.externalChangesetNodeState,
                     'p-2 align-self-stretch text-muted d-block d-sm-flex'

--- a/client/web/src/enterprise/batches/detail/changesets/HiddenExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/HiddenExternalChangesetNode.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 
 import { InputTooltip } from '../../../../components/InputTooltip'
@@ -27,6 +28,7 @@ export const HiddenExternalChangesetNode: React.FunctionComponent<
                 checked={false}
                 disabled={true}
                 tooltip="You do not have permission to perform a bulk operation on this changeset"
+                aria-label="You do not have permission to perform a bulk operation on this changeset"
                 placement="right"
             />
         </div>
@@ -39,7 +41,9 @@ export const HiddenExternalChangesetNode: React.FunctionComponent<
             node={node}
             className={classNames(styles.hiddenExternalChangesetNodeInformation, 'p-2')}
         />
-        <span className="d-none d-sm-block" />
+        <span className="d-none d-sm-block">
+            <VisuallyHidden>Check state, review state, and diff unavailable</VisuallyHidden>
+        </span>
         <span className="d-none d-sm-block" />
         <span className="d-none d-sm-block" />
     </>

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -299,7 +299,8 @@ const BatchChangeListTabHeader: React.FunctionComponent<
                         to=""
                         onClick={onSelectBatchChanges}
                         className={classNames('nav-link', selectedTab === 'batchChanges' && 'active')}
-                        role="button"
+                        aria-selected={selectedTab === 'batchChanges'}
+                        role="tab"
                     >
                         <span className="text-content" data-tab-content="All batch changes">
                             All batch changes
@@ -314,7 +315,8 @@ const BatchChangeListTabHeader: React.FunctionComponent<
                             eventLogger.log('batch_change_homepage:getting_started:clicked')
                         }}
                         className={classNames('nav-link', selectedTab === 'gettingStarted' && 'active')}
-                        role="button"
+                        aria-selected={selectedTab === 'gettingStarted'}
+                        role="tab"
                         data-testid="test-getting-started-btn"
                     >
                         <span className="text-content" data-tab-content="Getting started">

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -172,8 +172,10 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
                             <div className={styles.filtersRow}>
                                 {typeof currentTotalCount === 'number' && typeof lastTotalCount === 'number' && (
                                     <H3 className="align-self-end flex-1">
-                                        {lastTotalCount} of {currentTotalCount}{' '}
-                                        {pluralize('batch change', currentTotalCount)}
+                                        {`${lastTotalCount} of ${currentTotalCount} ${pluralize(
+                                            'batch change',
+                                            currentTotalCount
+                                        )}`}
                                     </H3>
                                 )}
 

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -292,7 +292,7 @@ const BatchChangeListTabHeader: React.FunctionComponent<
         [setSelectedTab]
     )
     return (
-        <div className="overflow-auto mb-2">
+        <nav className="overflow-auto mb-2" aria-label="Batch Changes">
             <ul className="nav nav-tabs d-inline-flex d-sm-flex flex-nowrap text-nowrap">
                 <li className="nav-item">
                     <Link
@@ -323,6 +323,6 @@ const BatchChangeListTabHeader: React.FunctionComponent<
                     </Link>
                 </li>
             </ul>
-        </div>
+        </nav>
     )
 }

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -194,8 +194,8 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
                             Discussion: https://github.com/sourcegraph/sourcegraph/pull/34716#pullrequestreview-959790114
                         */}
                             <ConnectionList
-                                as="div"
                                 className={classNames(styles.grid, isExecutionEnabled ? styles.wide : styles.narrow)}
+                                aria-label="Batch changes"
                             >
                                 {connection?.nodes?.map(node => (
                                     <BatchChangeNode

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -197,7 +197,7 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
                         */}
                             <ConnectionList
                                 className={classNames(styles.grid, isExecutionEnabled ? styles.wide : styles.narrow)}
-                                aria-label="Batch changes"
+                                aria-label="batch changes"
                             >
                                 {connection?.nodes?.map(node => (
                                     <BatchChangeNode

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -293,8 +293,8 @@ const BatchChangeListTabHeader: React.FunctionComponent<
     )
     return (
         <nav className="overflow-auto mb-2" aria-label="Batch Changes">
-            <ul className="nav nav-tabs d-inline-flex d-sm-flex flex-nowrap text-nowrap" role="tablist">
-                <li className="nav-item">
+            <div className="nav nav-tabs d-inline-flex d-sm-flex flex-nowrap text-nowrap" role="tablist">
+                <div className="nav-item">
                     <Link
                         to=""
                         onClick={onSelectBatchChanges}
@@ -306,8 +306,8 @@ const BatchChangeListTabHeader: React.FunctionComponent<
                             All batch changes
                         </span>
                     </Link>
-                </li>
-                <li className="nav-item">
+                </div>
+                <div className="nav-item">
                     <Link
                         to=""
                         onClick={event => {
@@ -323,8 +323,8 @@ const BatchChangeListTabHeader: React.FunctionComponent<
                             Getting started
                         </span>
                     </Link>
-                </li>
-            </ul>
+                </div>
+            </div>
         </nav>
     )
 }

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -293,7 +293,7 @@ const BatchChangeListTabHeader: React.FunctionComponent<
     )
     return (
         <nav className="overflow-auto mb-2" aria-label="Batch Changes">
-            <ul className="nav nav-tabs d-inline-flex d-sm-flex flex-nowrap text-nowrap">
+            <ul className="nav nav-tabs d-inline-flex d-sm-flex flex-nowrap text-nowrap" role="tablist">
                 <li className="nav-item">
                     <Link
                         to=""

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.module.scss
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.module.scss
@@ -1,6 +1,8 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
 .batch-change-node {
+    display: contents;
+
     // Old state badge
     &__badge {
         justify-self: center;

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
@@ -1,9 +1,9 @@
 import React, { useMemo } from 'react'
 
-import VisuallyHidden from '@reach/visually-hidden'
+import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 
-import { renderMarkdown } from '@sourcegraph/common'
+import { pluralize, renderMarkdown } from '@sourcegraph/common'
 import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { Badge, Link, H3, H4 } from '@sourcegraph/wildcard'
 
@@ -164,7 +164,9 @@ export const BatchChangeNode: React.FunctionComponent<React.PropsWithChildren<Ba
                         className="d-block d-sm-flex"
                         label={
                             <H4 className="font-weight-normal text-muted m-0">
-                                {node.changesetsStats.open} <VisuallyHidden>changesets</VisuallyHidden> open
+                                {node.changesetsStats.open}{' '}
+                                <VisuallyHidden>{pluralize('changeset', node.changesetsStats.open)}</VisuallyHidden>{' '}
+                                open
                             </H4>
                         }
                     />
@@ -172,7 +174,9 @@ export const BatchChangeNode: React.FunctionComponent<React.PropsWithChildren<Ba
                         className="d-block d-sm-flex text-center"
                         label={
                             <H4 className="font-weight-normal text-muted m-0">
-                                {node.changesetsStats.closed} <VisuallyHidden>changesets</VisuallyHidden> closed
+                                {node.changesetsStats.closed}{' '}
+                                <VisuallyHidden>{pluralize('changeset', node.changesetsStats.closed)}</VisuallyHidden>{' '}
+                                closed
                             </H4>
                         }
                     />
@@ -180,7 +184,9 @@ export const BatchChangeNode: React.FunctionComponent<React.PropsWithChildren<Ba
                         className="d-block d-sm-flex"
                         label={
                             <H4 className="font-weight-normal text-muted m-0">
-                                {node.changesetsStats.merged} <VisuallyHidden>changesets</VisuallyHidden> merged
+                                {node.changesetsStats.merged}{' '}
+                                <VisuallyHidden>{pluralize('changeset', node.changesetsStats.merged)}</VisuallyHidden>{' '}
+                                merged
                             </H4>
                         }
                     />

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
@@ -112,7 +112,7 @@ export const BatchChangeNode: React.FunctionComponent<React.PropsWithChildren<Ba
     }, [isExecutionEnabled, node.url, node.state, node.currentSpec, latestExecution])
 
     return (
-        <>
+        <li className={styles.batchChangeNode}>
             <span className={styles.batchChangeNodeSeparator} />
             {isExecutionEnabled ? (
                 <BatchChangeStatePill
@@ -197,6 +197,6 @@ export const BatchChangeNode: React.FunctionComponent<React.PropsWithChildren<Ba
                     />
                 </>
             )}
-        </>
+        </li>
     )
 }

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
@@ -1,10 +1,11 @@
 import React, { useMemo } from 'react'
 
+import VisuallyHidden from '@reach/visually-hidden'
 import classNames from 'classnames'
 
 import { renderMarkdown } from '@sourcegraph/common'
 import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
-import { Badge, Link, H3 } from '@sourcegraph/wildcard'
+import { Badge, Link, H3, H4 } from '@sourcegraph/wildcard'
 
 import { Timestamp } from '../../../components/time/Timestamp'
 import {
@@ -161,38 +162,26 @@ export const BatchChangeNode: React.FunctionComponent<React.PropsWithChildren<Ba
                 <>
                     <ChangesetStatusOpen
                         className="d-block d-sm-flex"
-                        aria-labelledby={`changesets-open-label-${node.id}`}
-                        role="group"
                         label={
-                            <span
-                                className="text-muted"
-                                id={`changesets-open-label-${node.id}`}
-                                aria-hidden={true}
-                            >{`${node.changesetsStats.open} open`}</span>
+                            <H4 className="font-weight-normal text-muted m-0">
+                                {node.changesetsStats.open} <VisuallyHidden>changesets</VisuallyHidden> open
+                            </H4>
                         }
                     />
                     <ChangesetStatusClosed
                         className="d-block d-sm-flex text-center"
-                        aria-labelledby={`changesets-closed-label-${node.id}`}
-                        role="group"
                         label={
-                            <span
-                                className="text-muted"
-                                aria-hidden={true}
-                                id={`changesets-closed-label-${node.id}`}
-                            >{`${node.changesetsStats.closed} closed`}</span>
+                            <H4 className="font-weight-normal text-muted m-0">
+                                {node.changesetsStats.closed} <VisuallyHidden>changesets</VisuallyHidden> closed
+                            </H4>
                         }
                     />
                     <ChangesetStatusMerged
                         className="d-block d-sm-flex"
-                        aria-labelledby={`changesets-merged-label-${node.id}`}
-                        role="group"
                         label={
-                            <span
-                                className="text-muted"
-                                id={`changesets-merged-label-${node.id}`}
-                                aria-hidden={true}
-                            >{`${node.changesetsStats.merged} merged`}</span>
+                            <H4 className="font-weight-normal text-muted m-0">
+                                {node.changesetsStats.merged} <VisuallyHidden>changesets</VisuallyHidden> merged
+                            </H4>
                         }
                     />
                 </>

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react'
 
-import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 
 import { pluralize, renderMarkdown } from '@sourcegraph/common'
@@ -163,30 +162,42 @@ export const BatchChangeNode: React.FunctionComponent<React.PropsWithChildren<Ba
                     <ChangesetStatusOpen
                         className="d-block d-sm-flex"
                         label={
-                            <H4 className="font-weight-normal text-muted m-0">
-                                {node.changesetsStats.open}{' '}
-                                <VisuallyHidden>{pluralize('changeset', node.changesetsStats.open)}</VisuallyHidden>{' '}
-                                open
+                            <H4
+                                className="font-weight-normal text-muted m-0"
+                                aria-label={`${node.changesetsStats.open} ${pluralize(
+                                    'changeset',
+                                    node.changesetsStats.open
+                                )} open`}
+                            >
+                                {`${node.changesetsStats.open} open`}
                             </H4>
                         }
                     />
                     <ChangesetStatusClosed
                         className="d-block d-sm-flex text-center"
                         label={
-                            <H4 className="font-weight-normal text-muted m-0">
-                                {node.changesetsStats.closed}{' '}
-                                <VisuallyHidden>{pluralize('changeset', node.changesetsStats.closed)}</VisuallyHidden>{' '}
-                                closed
+                            <H4
+                                className="font-weight-normal text-muted m-0"
+                                aria-label={`${node.changesetsStats.closed} ${pluralize(
+                                    'changeset',
+                                    node.changesetsStats.closed
+                                )} closed`}
+                            >
+                                {`${node.changesetsStats.closed} closed`}
                             </H4>
                         }
                     />
                     <ChangesetStatusMerged
                         className="d-block d-sm-flex"
                         label={
-                            <H4 className="font-weight-normal text-muted m-0">
-                                {node.changesetsStats.merged}{' '}
-                                <VisuallyHidden>{pluralize('changeset', node.changesetsStats.merged)}</VisuallyHidden>{' '}
-                                merged
+                            <H4
+                                className="font-weight-normal text-muted m-0"
+                                aria-label={`${node.changesetsStats.merged} ${pluralize(
+                                    'changeset',
+                                    node.changesetsStats.merged
+                                )} merged`}
+                            >
+                                {`${node.changesetsStats.merged} merged`}
                             </H4>
                         }
                     />

--- a/client/web/src/enterprise/batches/list/BatchChangeStatePill.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatePill.tsx
@@ -57,7 +57,6 @@ export const BatchChangeStatePill: React.FunctionComponent<React.PropsWithChildr
 
     return (
         <div
-            role="status"
             className={classNames(styles.pillGroup, className, {
                 [styles.open]: state === BatchChangeState.OPEN,
                 [styles.draft]: state === BatchChangeState.DRAFT,

--- a/client/web/src/enterprise/batches/list/BatchChangeStatePill.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatePill.tsx
@@ -106,6 +106,11 @@ const ExecutionStatePill: React.FunctionComponent<
             return (
                 <Badge
                     variant="warning"
+                    aria-label={`This batch change has a new spec ${
+                        latestExecutionState === BatchSpecState.QUEUED
+                            ? 'queued for execution'
+                            : 'in the process of executing'
+                    }.`}
                     tooltip={`This batch change has a new spec ${
                         latestExecutionState === BatchSpecState.QUEUED
                             ? 'queued for execution'
@@ -113,16 +118,7 @@ const ExecutionStatePill: React.FunctionComponent<
                     }.`}
                     className={styles.executionPill}
                 >
-                    <Icon
-                        className={styles.executionIcon}
-                        svgPath={mdiHistory}
-                        inline={false}
-                        aria-label={`This batch change has a new spec ${
-                            latestExecutionState === BatchSpecState.QUEUED
-                                ? 'queued for execution'
-                                : 'in the process of executing'
-                        }.`}
-                    />
+                    <Icon className={styles.executionIcon} svgPath={mdiHistory} inline={false} aria-hidden={true} />
                 </Badge>
             )
 
@@ -130,6 +126,7 @@ const ExecutionStatePill: React.FunctionComponent<
             return (
                 <Badge
                     variant="primary"
+                    aria-label="This batch change has a newer batch spec execution that is ready to be applied."
                     tooltip="This batch change has a newer batch spec execution that is ready to be applied."
                     className={styles.executionPill}
                 >
@@ -141,6 +138,7 @@ const ExecutionStatePill: React.FunctionComponent<
             return (
                 <Badge
                     variant="danger"
+                    aria-label="The latest batch spec execution for this batch change failed."
                     tooltip="The latest batch spec execution for this batch change failed."
                     className={styles.executionPill}
                 >

--- a/client/web/src/enterprise/batches/list/BatchChangeStatePill.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatePill.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react'
 
 import { mdiHistory } from '@mdi/js'
-import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 
 import { Badge, Icon } from '@sourcegraph/wildcard'
@@ -62,8 +61,8 @@ export const BatchChangeStatePill: React.FunctionComponent<React.PropsWithChildr
                 [styles.draft]: state === BatchChangeState.DRAFT,
                 [styles.closed]: state === BatchChangeState.CLOSED,
             })}
+            aria-label={`${state.toLowerCase()} batch change`}
         >
-            <VisuallyHidden>{state} status</VisuallyHidden>
             <StatePill state={state} />
             {executionStatePill}
         </div>

--- a/client/web/src/enterprise/batches/list/BatchChangeStatePill.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatePill.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 
 import { mdiHistory } from '@mdi/js'
+import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 
 import { Badge, Icon } from '@sourcegraph/wildcard'
@@ -56,14 +57,14 @@ export const BatchChangeStatePill: React.FunctionComponent<React.PropsWithChildr
 
     return (
         <div
-            role="group"
+            role="status"
             className={classNames(styles.pillGroup, className, {
                 [styles.open]: state === BatchChangeState.OPEN,
                 [styles.draft]: state === BatchChangeState.DRAFT,
                 [styles.closed]: state === BatchChangeState.CLOSED,
             })}
-            aria-label={`${state} status`}
         >
+            <VisuallyHidden>{state} status</VisuallyHidden>
             <StatePill state={state} />
             {executionStatePill}
         </div>

--- a/client/web/src/enterprise/batches/list/BatchChangeStatsBar.module.scss
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatsBar.module.scss
@@ -26,3 +26,8 @@
     display: flex;
     flex-shrink: 0;
 }
+
+.stat-label {
+    font-weight: normal;
+    font-size: 0.875rem;
+}

--- a/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
@@ -44,36 +44,48 @@ export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildre
         <div className={classNames(styles.statsBar, 'text-muted d-block d-sm-flex')}>
             <div className={styles.leftSide}>
                 <div className="pr-4">
-                    <H3 className="font-weight-bold mb-1">{data.batchChanges.totalCount}</H3>
-                    <span>Batch changes</span>
-                </div>
-                <div className="pr-4">
-                    <H3 className="font-weight-bold mb-1">{data.globalChangesetsStats.merged}</H3>
-                    <span>Changesets merged</span>
-                </div>
-                <div className="pr-4">
-                    <H3 className="font-weight-bold mb-1">
-                        {Math.round((data.globalChangesetsStats.merged * minSavedPerChangeset) / 60).toFixed(2)}
+                    <H3 className="font-weight-bold">
+                        <span className="d-block mb-1">{data.batchChanges.totalCount}</span>
+                        <span className={styles.statLabel}>Batch changes</span>
                     </H3>
-                    <span>
-                        Hours saved
+                </div>
+                <div className="pr-4">
+                    <H3 className="font-weight-bold">
+                        <span className="d-block mb-1">{data.globalChangesetsStats.merged}</span>
+                        <span className={styles.statLabel}>Changesets merged</span>
+                    </H3>
+                </div>
+                <div className="pr-4">
+                    <H3 className="font-weight-bold">
+                        <span className="d-block mb-1">
+                            {Math.round((data.globalChangesetsStats.merged * minSavedPerChangeset) / 60).toFixed(2)}
+                        </span>
+                        <span className={styles.statLabel}>Hours saved</span>
                         <Tooltip content="Based on multiplier per changeset defined by site admin">
-                            <Icon aria-label="More info" svgPath={mdiInformationOutline} className="ml-1" />
+                            <Icon
+                                aria-label="Based on multiplier per changeset defined by site admin"
+                                svgPath={mdiInformationOutline}
+                                className="ml-1"
+                            />
                         </Tooltip>
-                    </span>
+                    </H3>
                 </div>
             </div>
             <div className={styles.rightSide}>
                 <div className="pr-4 text-center">
                     <ChangesetStatusOpen
                         className="d-flex"
-                        label={<span>{data.globalChangesetsStats.open} open</span>}
+                        aria-label={`${data.globalChangesetsStats.open} total changesets open`}
+                        role="group"
+                        label={<span aria-hidden={true}>{data.globalChangesetsStats.open} open</span>}
                     />
                 </div>
                 <div className="text-center">
                     <ChangesetStatusClosed
                         className="d-flex"
-                        label={<span>{data.globalChangesetsStats.closed} closed</span>}
+                        aria-label={`${data.globalChangesetsStats.closed} total changesets closed`}
+                        role="group"
+                        label={<span aria-hidden={true}>{data.globalChangesetsStats.closed} closed</span>}
                     />
                 </div>
             </div>

--- a/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { mdiInformationOutline } from '@mdi/js'
-import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 
 import { useQuery } from '@sourcegraph/http-client'
@@ -15,6 +14,7 @@ import { ChangesetStatusClosed, ChangesetStatusOpen } from '../detail/changesets
 import { GLOBAL_CHANGESETS_STATS } from './backend'
 
 import styles from './BatchChangeStatsBar.module.scss'
+import { pluralize } from '@sourcegraph/common'
 
 interface BatchChangeStatsBarProps {
     className?: string
@@ -77,8 +77,14 @@ export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildre
                     <ChangesetStatusOpen
                         className="d-flex"
                         label={
-                            <H4 className="font-weight-normal m-0">
-                                {data.globalChangesetsStats.open} <VisuallyHidden>total changesets</VisuallyHidden> open
+                            <H4
+                                className="font-weight-normal m-0"
+                                aria-label={`${data.globalChangesetsStats.open} total ${pluralize(
+                                    'changeset',
+                                    data.globalChangesetsStats.open
+                                )} open`}
+                            >
+                                {data.globalChangesetsStats.open} open
                             </H4>
                         }
                     />
@@ -87,9 +93,14 @@ export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildre
                     <ChangesetStatusClosed
                         className="d-flex"
                         label={
-                            <H4 className="font-weight-normal m-0">
-                                {data.globalChangesetsStats.closed} <VisuallyHidden>total changesets</VisuallyHidden>{' '}
-                                closed
+                            <H4
+                                className="font-weight-normal m-0"
+                                aria-label={`${data.globalChangesetsStats.closed} total ${pluralize(
+                                    'changeset',
+                                    data.globalChangesetsStats.closed
+                                )} closed`}
+                            >
+                                {data.globalChangesetsStats.closed} closed
                             </H4>
                         }
                     />

--- a/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 
 import { mdiInformationOutline } from '@mdi/js'
+import VisuallyHidden from '@reach/visually-hidden'
 import classNames from 'classnames'
 
 import { useQuery } from '@sourcegraph/http-client'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
-import { H3, Icon, LoadingSpinner, Tooltip } from '@sourcegraph/wildcard'
+import { H3, H4, Icon, LoadingSpinner, Tooltip } from '@sourcegraph/wildcard'
 
 import { GlobalChangesetsStatsResult, GlobalChangesetsStatsVariables } from '../../../graphql-operations'
 import { DEFAULT_MINS_SAVED_PER_CHANGESET } from '../../../site-admin/analytics/AnalyticsBatchChangesPage'
@@ -75,17 +76,22 @@ export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildre
                 <div className="pr-4 text-center">
                     <ChangesetStatusOpen
                         className="d-flex"
-                        aria-label={`${data.globalChangesetsStats.open} total changesets open`}
-                        role="group"
-                        label={<span aria-hidden={true}>{data.globalChangesetsStats.open} open</span>}
+                        label={
+                            <H4 className="font-weight-normal m-0">
+                                {data.globalChangesetsStats.open} <VisuallyHidden>total changesets</VisuallyHidden> open
+                            </H4>
+                        }
                     />
                 </div>
                 <div className="text-center">
                     <ChangesetStatusClosed
                         className="d-flex"
-                        aria-label={`${data.globalChangesetsStats.closed} total changesets closed`}
-                        role="group"
-                        label={<span aria-hidden={true}>{data.globalChangesetsStats.closed} closed</span>}
+                        label={
+                            <H4 className="font-weight-normal m-0">
+                                {data.globalChangesetsStats.closed} <VisuallyHidden>total changesets</VisuallyHidden>{' '}
+                                closed
+                            </H4>
+                        }
                     />
                 </div>
             </div>

--- a/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { mdiInformationOutline } from '@mdi/js'
-import VisuallyHidden from '@reach/visually-hidden'
+import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 
 import { useQuery } from '@sourcegraph/http-client'

--- a/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { mdiInformationOutline } from '@mdi/js'
 import classNames from 'classnames'
 
+import { pluralize } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { H3, H4, Icon, LoadingSpinner, Tooltip } from '@sourcegraph/wildcard'
@@ -14,7 +15,6 @@ import { ChangesetStatusClosed, ChangesetStatusOpen } from '../detail/changesets
 import { GLOBAL_CHANGESETS_STATS } from './backend'
 
 import styles from './BatchChangeStatsBar.module.scss'
-import { pluralize } from '@sourcegraph/common'
 
 interface BatchChangeStatsBarProps {
     className?: string

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewStatsBar.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewStatsBar.tsx
@@ -4,7 +4,7 @@ import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 
 import { pluralize } from '@sourcegraph/common'
-import { Badge, H2, H4, useObservable } from '@sourcegraph/wildcard'
+import { Badge, H2, H3, H4, useObservable } from '@sourcegraph/wildcard'
 
 import { DiffStatStack } from '../../../components/diff/DiffStat'
 import { ApplyPreviewStatsFields, DiffStatFields, Scalars } from '../../../graphql-operations'
@@ -109,7 +109,11 @@ export const PreviewStatsAdded: React.FunctionComponent<React.PropsWithChildren<
             </span>
             <span className={styles.previewStatsAddedLine}>&nbsp;</span>
         </div>
-        <H4 className="font-weight-normal mt-1 mb-0" aria-label={`${count} ${pluralize('changeset', count)} added`}>
+        <H4
+            as={H3}
+            className="font-weight-normal mt-1 mb-0"
+            aria-label={`${count} ${pluralize('changeset', count)} added`}
+        >
             {`${count} added`}
         </H4>
     </div>
@@ -130,7 +134,11 @@ export const PreviewStatsModified: React.FunctionComponent<React.PropsWithChildr
             </span>
             <span className={styles.previewStatsModifiedLine}>&nbsp;</span>
         </div>
-        <H4 className="font-weight-normal mt-1 mb-0" aria-label={`${count} ${pluralize('changeset', count)} modified`}>
+        <H4
+            as={H3}
+            className="font-weight-normal mt-1 mb-0"
+            aria-label={`${count} ${pluralize('changeset', count)} modified`}
+        >
             {`${count} modified`}
         </H4>
     </div>
@@ -149,7 +157,11 @@ export const PreviewStatsRemoved: React.FunctionComponent<React.PropsWithChildre
             </span>
             <span className={styles.previewStatsRemovedLine}>&nbsp;</span>
         </div>
-        <H4 className="font-weight-normal mt-1 mb-0" aria-label={`${count} ${pluralize('changeset', count)} removed`}>
+        <H4
+            as={H3}
+            className="font-weight-normal mt-1 mb-0"
+            aria-label={`${count} ${pluralize('changeset', count)} removed`}
+        >
             {`${count} removed`}
         </H4>
     </div>

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewStatsBar.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewStatsBar.tsx
@@ -13,14 +13,14 @@ import { queryApplyPreviewStats as _queryApplyPreviewStats } from './backend'
 import { BatchChangePreviewContext } from './BatchChangePreviewContext'
 import { ChangesetAddedIcon, ChangesetModifiedIcon, ChangesetRemovedIcon } from './icons'
 import {
-    PreviewActionArchive,
-    PreviewActionClose,
-    PreviewActionImport,
-    PreviewActionPublish,
-    PreviewActionReattach,
-    PreviewActionReopen,
-    PreviewActionUndraft,
-    PreviewActionUpdate,
+    PreviewArchiveStat,
+    PreviewCloseStat,
+    PreviewImportStat,
+    PreviewPublishStat,
+    PreviewReattachStat,
+    PreviewReopenStat,
+    PreviewUndraftStat,
+    PreviewUpdateStat,
 } from './list/PreviewActions'
 
 import styles from './BatchChangePreviewStatsBar.module.scss'
@@ -85,17 +85,14 @@ export const BatchChangePreviewStatsBar: React.FunctionComponent<
             <div className={classNames(styles.batchChangePreviewStatsBarHorizontalDivider, 'd-block d-md-none my-3')} />
             <div className={classNames(styles.batchChangePreviewStatsBarDivider, 'd-none d-md-block ml-3 mr-2')} />
             <div className={classNames(styles.batchChangePreviewStatsBarStates, 'd-flex justify-content-end')}>
-                <PreviewActionReopen className={actionClassNames} label={`${stats.reopen} Reopen`} />
-                <PreviewActionClose className={actionClassNames} label={`${stats.reopen} Close`} />
-                <PreviewActionUpdate className={actionClassNames} label={`${stats.update} Update`} />
-                <PreviewActionUndraft className={actionClassNames} label={`${stats.undraft} Undraft`} />
-                <PreviewActionPublish
-                    className={actionClassNames}
-                    label={`${stats.publish + stats.publishDraft} Publish`}
-                />
-                <PreviewActionImport className={actionClassNames} label={`${stats.import} Import`} />
-                <PreviewActionArchive className={actionClassNames} label={`${stats.archive} Archive`} />
-                <PreviewActionReattach className={actionClassNames} label={`${stats.reattach} Reattach`} />
+                <PreviewReopenStat className={actionClassNames} count={stats.reopen} />
+                <PreviewCloseStat className={actionClassNames} count={stats.close} />
+                <PreviewUpdateStat className={actionClassNames} count={stats.update} />
+                <PreviewUndraftStat className={actionClassNames} count={stats.undraft} />
+                <PreviewPublishStat className={actionClassNames} count={stats.publish} />
+                <PreviewImportStat className={actionClassNames} count={stats.import} />
+                <PreviewArchiveStat className={actionClassNames} count={stats.archive} />
+                <PreviewReattachStat className={actionClassNames} count={stats.reattach} />
             </div>
         </div>
     )

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewStatsBar.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewStatsBar.tsx
@@ -1,8 +1,10 @@
 import React, { useContext, useMemo } from 'react'
 
+import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 
-import { Badge, H2, useObservable } from '@sourcegraph/wildcard'
+import { pluralize } from '@sourcegraph/common'
+import { Badge, H2, H4, useObservable } from '@sourcegraph/wildcard'
 
 import { DiffStatStack } from '../../../components/diff/DiffStat'
 import { ApplyPreviewStatsFields, DiffStatFields, Scalars } from '../../../graphql-operations'
@@ -59,7 +61,10 @@ export const BatchChangePreviewStatsBar: React.FunctionComponent<
     return (
         <div className="d-flex flex-wrap mb-3 align-items-center">
             <H2 className="m-0 align-self-center">
-                <Badge variant="info" className="text-uppercase mb-0">
+                <VisuallyHidden>
+                    This is a preview of the changesets generated from executing the batch spec.
+                </VisuallyHidden>
+                <Badge variant="info" className="text-uppercase mb-0" aria-hidden={true}>
                     Preview
                 </Badge>
             </H2>
@@ -72,8 +77,6 @@ export const BatchChangePreviewStatsBar: React.FunctionComponent<
                     styles.batchChangePreviewStatsBarMetrics,
                     'flex-grow-1 d-flex justify-content-end'
                 )}
-                aria-label="Preview Stats"
-                role="note"
             >
                 <PreviewStatsAdded count={stats.added} />
                 <PreviewStatsRemoved count={stats.removed} />
@@ -109,7 +112,9 @@ export const PreviewStatsAdded: React.FunctionComponent<React.PropsWithChildren<
             </span>
             <span className={styles.previewStatsAddedLine}>&nbsp;</span>
         </div>
-        {count} Added
+        <H4 className="font-weight-normal mt-1 mb-0" aria-label={`${count} ${pluralize('changeset', count)} added`}>
+            {`${count} added`}
+        </H4>
     </div>
 )
 export const PreviewStatsModified: React.FunctionComponent<React.PropsWithChildren<{ count: number }>> = ({
@@ -128,7 +133,9 @@ export const PreviewStatsModified: React.FunctionComponent<React.PropsWithChildr
             </span>
             <span className={styles.previewStatsModifiedLine}>&nbsp;</span>
         </div>
-        {count} Modified
+        <H4 className="font-weight-normal mt-1 mb-0" aria-label={`${count} ${pluralize('changeset', count)} modified`}>
+            {`${count} modified`}
+        </H4>
     </div>
 )
 export const PreviewStatsRemoved: React.FunctionComponent<React.PropsWithChildren<{ count: number }>> = ({ count }) => (
@@ -145,6 +152,8 @@ export const PreviewStatsRemoved: React.FunctionComponent<React.PropsWithChildre
             </span>
             <span className={styles.previewStatsRemovedLine}>&nbsp;</span>
         </div>
-        {count} Removed
+        <H4 className="font-weight-normal mt-1 mb-0" aria-label={`${count} ${pluralize('changeset', count)} removed`}>
+            {`${count} removed`}
+        </H4>
     </div>
 )

--- a/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.tsx
+++ b/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.tsx
@@ -80,7 +80,7 @@ export const CreateUpdateBatchChangeAlert: React.FunctionComponent<
 
     return (
         <>
-            <Alert className="mb-3 d-block d-md-flex align-items-center body-lead" variant="info">
+            <Alert className="mb-3 d-block d-md-flex align-items-center body-lead" variant="info" aria-live="off">
                 <div className={classNames(styles.createUpdateBatchChangeAlertCopy, 'flex-grow-1 mr-3')}>
                     {batchChange ? (
                         <>

--- a/client/web/src/enterprise/batches/preview/list/ChangesetApplyPreviewNode.module.scss
+++ b/client/web/src/enterprise/batches/preview/list/ChangesetApplyPreviewNode.module.scss
@@ -1,6 +1,8 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
 .changeset-apply-preview-node {
+    display: contents;
+
     &__separator {
         // Make it full width in the current row.
         grid-column: 1 / -1;

--- a/client/web/src/enterprise/batches/preview/list/ChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/ChangesetApplyPreviewNode.tsx
@@ -31,24 +31,18 @@ export interface ChangesetApplyPreviewNodeProps extends ThemeProps {
 
 export const ChangesetApplyPreviewNode: React.FunctionComponent<
     React.PropsWithChildren<ChangesetApplyPreviewNodeProps>
-> = ({ node, queryChangesetSpecFileDiffs, expandChangesetDescriptions, ...props }) => {
-    if (node.__typename === 'HiddenChangesetApplyPreview') {
-        return (
-            <>
-                <span className={styles.changesetApplyPreviewNodeSeparator} />
-                <HiddenChangesetApplyPreviewNode node={node} />
-            </>
-        )
-    }
-    return (
-        <>
-            <span className={styles.changesetApplyPreviewNodeSeparator} />
+> = ({ node, queryChangesetSpecFileDiffs, expandChangesetDescriptions, ...props }) => (
+    <li className={styles.changesetApplyPreviewNode}>
+        <span className={styles.changesetApplyPreviewNodeSeparator} />
+        {node.__typename === 'HiddenChangesetApplyPreview' ? (
+            <HiddenChangesetApplyPreviewNode node={node} />
+        ) : (
             <VisibleChangesetApplyPreviewNode
                 node={node}
                 {...props}
                 queryChangesetSpecFileDiffs={queryChangesetSpecFileDiffs}
                 expandChangesetDescriptions={expandChangesetDescriptions}
             />
-        </>
-    )
-}
+        )}
+    </li>
+)

--- a/client/web/src/enterprise/batches/preview/list/PreviewActions.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewActions.tsx
@@ -17,7 +17,7 @@ import {
 import classNames from 'classnames'
 
 import { pluralize } from '@sourcegraph/common'
-import { H4, Icon, Tooltip } from '@sourcegraph/wildcard'
+import { H3, H4, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { ChangesetApplyPreviewFields, ChangesetSpecOperation } from '../../../../graphql-operations'
 
@@ -109,6 +109,7 @@ export const PreviewPublishStat: React.FunctionComponent<
     <div className={classNames(className, iconClassNames)}>
         <Icon aria-hidden={true} svgPath={mdiUpload} />
         <H4
+            as={H3}
             className="font-weight-normal text-muted m-0"
             aria-label={`${count} ${pluralize('changeset', count)} will be published`}
         >
@@ -149,6 +150,7 @@ export const PreviewImportStat: React.FunctionComponent<
     <div className={classNames(className, iconClassNames)}>
         <Icon aria-hidden={true} svgPath={mdiImport} />
         <H4
+            as={H3}
             className="font-weight-normal text-muted m-0"
             aria-label={`${count} ${pluralize('changeset', count)} will be imported`}
         >
@@ -178,6 +180,7 @@ export const PreviewCloseStat: React.FunctionComponent<
     <div className={classNames(className, iconClassNames, 'text-danger')}>
         <Icon aria-hidden={true} svgPath={mdiCloseCircleOutline} />
         <H4
+            as={H3}
             className="font-weight-normal text-muted m-0"
             aria-label={`${count} ${pluralize('changeset', count)} will be closed`}
         >
@@ -222,6 +225,7 @@ export const PreviewReopenStat: React.FunctionComponent<
     <div className={classNames(className, iconClassNames, 'text-success')}>
         <Icon aria-hidden={true} svgPath={mdiSourceBranchRefresh} />
         <H4
+            as={H3}
             className="font-weight-normal text-muted m-0"
             aria-label={`${count} ${pluralize('changeset', count)} will be reopened`}
         >
@@ -251,6 +255,7 @@ export const PreviewUndraftStat: React.FunctionComponent<
     <div className={classNames(className, iconClassNames, 'text-success')}>
         <Icon aria-hidden={true} svgPath={mdiSourceBranchCheck} />
         <H4
+            as={H3}
             className="font-weight-normal text-muted m-0"
             aria-label={`${count} ${pluralize('changeset', count)} will be promoted from ${pluralize('draft', count)}`}
         >
@@ -280,6 +285,7 @@ export const PreviewUpdateStat: React.FunctionComponent<
     <div className={classNames(className, iconClassNames)}>
         <Icon aria-hidden={true} svgPath={mdiSourceBranchSync} />
         <H4
+            as={H3}
             className="font-weight-normal text-muted m-0"
             aria-label={`${count} ${pluralize('changeset', count)} will be updated`}
         >
@@ -339,6 +345,7 @@ export const PreviewArchiveStat: React.FunctionComponent<
     <div className={classNames(className, iconClassNames)}>
         <Icon aria-hidden={true} svgPath={mdiArchive} />
         <H4
+            as={H3}
             className="font-weight-normal text-muted m-0"
             aria-label={`${count} ${pluralize('changeset', count)} will be archived`}
         >
@@ -368,6 +375,7 @@ export const PreviewReattachStat: React.FunctionComponent<
     <div className={classNames(className, iconClassNames)}>
         <Icon aria-hidden={true} svgPath={mdiPaperclip} />
         <H4
+            as={H3}
             className="font-weight-normal text-muted m-0"
             aria-label={`${count} ${pluralize('changeset', count)} will be re-added`}
         >

--- a/client/web/src/enterprise/batches/preview/list/PreviewActions.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewActions.tsx
@@ -124,13 +124,13 @@ export const PreviewActionPublish: React.FunctionComponent<React.PropsWithChildr
         <Tooltip content="This changeset will be published to its code host">
             <Icon aria-label="This changeset will be published to its code host" className="mr-1" svgPath={mdiUpload} />
         </Tooltip>
-        <span>Publish</span>
+        <span aria-hidden={true}>Publish</span>
     </div>
 )
 
-export const PreviewActionPublishDraft: React.FunctionComponent<
-    React.PropsWithChildren<{ label?: string; className?: string }>
-> = ({ label = 'Publish draft', className }) => (
+export const PreviewActionPublishDraft: React.FunctionComponent<React.PropsWithChildren<{ className?: string }>> = ({
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <Tooltip content="This changeset will be published as a draft to its code host">
             <Icon
@@ -139,7 +139,7 @@ export const PreviewActionPublishDraft: React.FunctionComponent<
                 svgPath={mdiUpload}
             />
         </Tooltip>
-        <span>{label}</span>
+        <span aria-hidden={true}>Publish draft</span>
     </div>
 )
 
@@ -157,9 +157,9 @@ export const PreviewImportStat: React.FunctionComponent<
     </div>
 )
 
-export const PreviewActionImport: React.FunctionComponent<
-    React.PropsWithChildren<{ label?: string; className?: string }>
-> = ({ label = 'Import', className }) => (
+export const PreviewActionImport: React.FunctionComponent<React.PropsWithChildren<{ className?: string }>> = ({
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <Tooltip content="This changeset will be imported and tracked in this batch change">
             <Icon
@@ -168,7 +168,7 @@ export const PreviewActionImport: React.FunctionComponent<
                 svgPath={mdiImport}
             />
         </Tooltip>
-        <span>{label}</span>
+        <span aria-hidden={true}>Import</span>
     </div>
 )
 
@@ -186,9 +186,9 @@ export const PreviewCloseStat: React.FunctionComponent<
     </div>
 )
 
-export const PreviewActionClose: React.FunctionComponent<
-    React.PropsWithChildren<{ label?: string; className?: string }>
-> = ({ label = 'Close', className }) => (
+export const PreviewActionClose: React.FunctionComponent<React.PropsWithChildren<{ className?: string }>> = ({
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <Tooltip content="This changeset will be closed on the code host">
             <Icon
@@ -197,13 +197,13 @@ export const PreviewActionClose: React.FunctionComponent<
                 svgPath={mdiCloseCircleOutline}
             />
         </Tooltip>
-        <span>{label}</span>
+        <span aria-hidden={true}>Close</span>
     </div>
 )
 
-export const PreviewActionDetach: React.FunctionComponent<
-    React.PropsWithChildren<{ label?: string; className?: string }>
-> = ({ label = 'Detach', className }) => (
+export const PreviewActionDetach: React.FunctionComponent<React.PropsWithChildren<{ className?: string }>> = ({
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <Tooltip content="This changeset will be removed from the batch change">
             <Icon
@@ -212,7 +212,7 @@ export const PreviewActionDetach: React.FunctionComponent<
                 svgPath={mdiDelete}
             />
         </Tooltip>
-        <span>{label}</span>
+        <span aria-hidden={true}>Detach</span>
     </div>
 )
 
@@ -230,9 +230,9 @@ export const PreviewReopenStat: React.FunctionComponent<
     </div>
 )
 
-export const PreviewActionReopen: React.FunctionComponent<
-    React.PropsWithChildren<{ label?: string; className?: string }>
-> = ({ label = 'Reopen', className }) => (
+export const PreviewActionReopen: React.FunctionComponent<React.PropsWithChildren<{ className?: string }>> = ({
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <Tooltip content="This changeset will be reopened on the code host">
             <Icon
@@ -241,7 +241,7 @@ export const PreviewActionReopen: React.FunctionComponent<
                 svgPath={mdiSourceBranchRefresh}
             />
         </Tooltip>
-        <span>{label}</span>
+        <span aria-hidden={true}>Reopen</span>
     </div>
 )
 
@@ -259,9 +259,9 @@ export const PreviewUndraftStat: React.FunctionComponent<
     </div>
 )
 
-export const PreviewActionUndraft: React.FunctionComponent<
-    React.PropsWithChildren<{ label?: string; className?: string }>
-> = ({ label = 'Undraft', className }) => (
+export const PreviewActionUndraft: React.FunctionComponent<React.PropsWithChildren<{ className?: string }>> = ({
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <Tooltip content="This changeset will be marked as ready for review on the code host">
             <Icon
@@ -270,7 +270,7 @@ export const PreviewActionUndraft: React.FunctionComponent<
                 svgPath={mdiSourceBranchCheck}
             />
         </Tooltip>
-        <span>{label}</span>
+        <span aria-hidden={true}>Undraft</span>
     </div>
 )
 
@@ -288,9 +288,9 @@ export const PreviewUpdateStat: React.FunctionComponent<
     </div>
 )
 
-export const PreviewActionUpdate: React.FunctionComponent<
-    React.PropsWithChildren<{ label?: string; className?: string }>
-> = ({ label = 'Update', className }) => (
+export const PreviewActionUpdate: React.FunctionComponent<React.PropsWithChildren<{ className?: string }>> = ({
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <Tooltip content="This changeset will be updated on the code host">
             <Icon
@@ -299,13 +299,13 @@ export const PreviewActionUpdate: React.FunctionComponent<
                 svgPath={mdiSourceBranchSync}
             />
         </Tooltip>
-        <span>{label}</span>
+        <span aria-hidden={true}>Update</span>
     </div>
 )
 
-export const PreviewActionPush: React.FunctionComponent<
-    React.PropsWithChildren<{ label?: string; className?: string }>
-> = ({ label = 'Push', className }) => (
+export const PreviewActionPush: React.FunctionComponent<React.PropsWithChildren<{ className?: string }>> = ({
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <Tooltip content="A new commit will be pushed to the code host">
             <Icon
@@ -314,7 +314,7 @@ export const PreviewActionPush: React.FunctionComponent<
                 svgPath={mdiUploadNetwork}
             />
         </Tooltip>
-        <span>{label}</span>
+        <span aria-hidden={true}>Push</span>
     </div>
 )
 
@@ -329,7 +329,7 @@ export const PreviewActionUnknown: React.FunctionComponent<
                 svgPath={mdiBeakerQuestion}
             />
         </Tooltip>
-        <span>Unknown</span>
+        <span aria-hidden={true}>Unknown</span>
     </div>
 )
 
@@ -347,9 +347,9 @@ export const PreviewArchiveStat: React.FunctionComponent<
     </div>
 )
 
-export const PreviewActionArchive: React.FunctionComponent<
-    React.PropsWithChildren<{ label?: string; className?: string }>
-> = ({ label = 'Archive', className }) => (
+export const PreviewActionArchive: React.FunctionComponent<React.PropsWithChildren<{ className?: string }>> = ({
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <Tooltip content="This changeset will be kept and marked as archived in this batch change">
             <Icon
@@ -358,7 +358,7 @@ export const PreviewActionArchive: React.FunctionComponent<
                 svgPath={mdiArchive}
             />
         </Tooltip>
-        <span>{label}</span>
+        <span aria-hidden={true}>Archive</span>
     </div>
 )
 
@@ -376,9 +376,9 @@ export const PreviewReattachStat: React.FunctionComponent<
     </div>
 )
 
-export const PreviewActionReattach: React.FunctionComponent<
-    React.PropsWithChildren<{ label?: string; className?: string }>
-> = ({ label = 'Reattach', className }) => (
+export const PreviewActionReattach: React.FunctionComponent<React.PropsWithChildren<{ className?: string }>> = ({
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <Tooltip content="This changeset will be re-added to the batch change">
             <Icon
@@ -387,7 +387,7 @@ export const PreviewActionReattach: React.FunctionComponent<
                 svgPath={mdiPaperclip}
             />
         </Tooltip>
-        <span>{label}</span>
+        <span aria-hidden={true}>Reattach</span>
     </div>
 )
 
@@ -403,9 +403,13 @@ export const PreviewActionNoAction: React.FunctionComponent<
     React.PropsWithChildren<{ className?: string; reason?: string }>
 > = ({ className, reason }) => (
     <div className={classNames(className, iconClassNames, 'text-muted')}>
-        <Tooltip content={reason}>
-            <Icon aria-label={reason ?? ''} className="mr-1" svgPath={mdiCheckboxBlankCircleOutline} />
+        <Tooltip content={reason ?? 'The state of this changeset will not change.'}>
+            <Icon
+                aria-label={reason ?? 'The state of this changeset will not change'}
+                className="mr-1"
+                svgPath={mdiCheckboxBlankCircleOutline}
+            />
         </Tooltip>
-        <span>No action</span>
+        <span aria-hidden={true}>No action</span>
     </div>
 )

--- a/client/web/src/enterprise/batches/preview/list/PreviewActions.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewActions.tsx
@@ -16,7 +16,8 @@ import {
 } from '@mdi/js'
 import classNames from 'classnames'
 
-import { Icon, Tooltip } from '@sourcegraph/wildcard'
+import { pluralize } from '@sourcegraph/common'
+import { H4, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { ChangesetApplyPreviewFields, ChangesetSpecOperation } from '../../../../graphql-operations'
 
@@ -102,14 +103,28 @@ const PreviewAction: React.FunctionComponent<React.PropsWithChildren<PreviewActi
 
 const iconClassNames = 'm-0 text-nowrap'
 
-export const PreviewActionPublish: React.FunctionComponent<
-    React.PropsWithChildren<{ label?: string; className?: string }>
-> = ({ label = 'Publish', className }) => (
+export const PreviewPublishStat: React.FunctionComponent<
+    React.PropsWithChildren<{ count: number; className?: string }>
+> = ({ count, className }) => (
+    <div className={classNames(className, iconClassNames)}>
+        <Icon aria-hidden={true} svgPath={mdiUpload} />
+        <H4
+            className="font-weight-normal text-muted m-0"
+            aria-label={`${count} ${pluralize('changeset', count)} will be published`}
+        >
+            {count} publish
+        </H4>
+    </div>
+)
+
+export const PreviewActionPublish: React.FunctionComponent<React.PropsWithChildren<{ className?: string }>> = ({
+    className,
+}) => (
     <div className={classNames(className, iconClassNames)}>
         <Tooltip content="This changeset will be published to its code host">
             <Icon aria-label="This changeset will be published to its code host" className="mr-1" svgPath={mdiUpload} />
         </Tooltip>
-        <span>{label}</span>
+        <span>Publish</span>
     </div>
 )
 
@@ -128,6 +143,20 @@ export const PreviewActionPublishDraft: React.FunctionComponent<
     </div>
 )
 
+export const PreviewImportStat: React.FunctionComponent<
+    React.PropsWithChildren<{ count: number; className?: string }>
+> = ({ count, className }) => (
+    <div className={classNames(className, iconClassNames)}>
+        <Icon aria-hidden={true} svgPath={mdiImport} />
+        <H4
+            className="font-weight-normal text-muted m-0"
+            aria-label={`${count} ${pluralize('changeset', count)} will be imported`}
+        >
+            {count} import
+        </H4>
+    </div>
+)
+
 export const PreviewActionImport: React.FunctionComponent<
     React.PropsWithChildren<{ label?: string; className?: string }>
 > = ({ label = 'Import', className }) => (
@@ -140,6 +169,20 @@ export const PreviewActionImport: React.FunctionComponent<
             />
         </Tooltip>
         <span>{label}</span>
+    </div>
+)
+
+export const PreviewCloseStat: React.FunctionComponent<
+    React.PropsWithChildren<{ count: number; className?: string }>
+> = ({ count, className }) => (
+    <div className={classNames(className, iconClassNames, 'text-danger')}>
+        <Icon aria-hidden={true} svgPath={mdiCloseCircleOutline} />
+        <H4
+            className="font-weight-normal text-muted m-0"
+            aria-label={`${count} ${pluralize('changeset', count)} will be closed`}
+        >
+            {count} close
+        </H4>
     </div>
 )
 
@@ -173,6 +216,20 @@ export const PreviewActionDetach: React.FunctionComponent<
     </div>
 )
 
+export const PreviewReopenStat: React.FunctionComponent<
+    React.PropsWithChildren<{ count: number; className?: string }>
+> = ({ count, className }) => (
+    <div className={classNames(className, iconClassNames, 'text-success')}>
+        <Icon aria-hidden={true} svgPath={mdiSourceBranchRefresh} />
+        <H4
+            className="font-weight-normal text-muted m-0"
+            aria-label={`${count} ${pluralize('changeset', count)} will be reopened`}
+        >
+            {count} reopen
+        </H4>
+    </div>
+)
+
 export const PreviewActionReopen: React.FunctionComponent<
     React.PropsWithChildren<{ label?: string; className?: string }>
 > = ({ label = 'Reopen', className }) => (
@@ -188,6 +245,20 @@ export const PreviewActionReopen: React.FunctionComponent<
     </div>
 )
 
+export const PreviewUndraftStat: React.FunctionComponent<
+    React.PropsWithChildren<{ count: number; className?: string }>
+> = ({ count, className }) => (
+    <div className={classNames(className, iconClassNames, 'text-success')}>
+        <Icon aria-hidden={true} svgPath={mdiSourceBranchCheck} />
+        <H4
+            className="font-weight-normal text-muted m-0"
+            aria-label={`${count} ${pluralize('changeset', count)} will be promoted from ${pluralize('draft', count)}`}
+        >
+            {count} undraft
+        </H4>
+    </div>
+)
+
 export const PreviewActionUndraft: React.FunctionComponent<
     React.PropsWithChildren<{ label?: string; className?: string }>
 > = ({ label = 'Undraft', className }) => (
@@ -200,6 +271,20 @@ export const PreviewActionUndraft: React.FunctionComponent<
             />
         </Tooltip>
         <span>{label}</span>
+    </div>
+)
+
+export const PreviewUpdateStat: React.FunctionComponent<
+    React.PropsWithChildren<{ count: number; className?: string }>
+> = ({ count, className }) => (
+    <div className={classNames(className, iconClassNames)}>
+        <Icon aria-hidden={true} svgPath={mdiSourceBranchSync} />
+        <H4
+            className="font-weight-normal text-muted m-0"
+            aria-label={`${count} ${pluralize('changeset', count)} will be updated`}
+        >
+            {count} update
+        </H4>
     </div>
 )
 
@@ -248,6 +333,20 @@ export const PreviewActionUnknown: React.FunctionComponent<
     </div>
 )
 
+export const PreviewArchiveStat: React.FunctionComponent<
+    React.PropsWithChildren<{ count: number; className?: string }>
+> = ({ count, className }) => (
+    <div className={classNames(className, iconClassNames)}>
+        <Icon aria-hidden={true} svgPath={mdiArchive} />
+        <H4
+            className="font-weight-normal text-muted m-0"
+            aria-label={`${count} ${pluralize('changeset', count)} will be archived`}
+        >
+            {count} archive
+        </H4>
+    </div>
+)
+
 export const PreviewActionArchive: React.FunctionComponent<
     React.PropsWithChildren<{ label?: string; className?: string }>
 > = ({ label = 'Archive', className }) => (
@@ -260,6 +359,20 @@ export const PreviewActionArchive: React.FunctionComponent<
             />
         </Tooltip>
         <span>{label}</span>
+    </div>
+)
+
+export const PreviewReattachStat: React.FunctionComponent<
+    React.PropsWithChildren<{ count: number; className?: string }>
+> = ({ count, className }) => (
+    <div className={classNames(className, iconClassNames)}>
+        <Icon aria-hidden={true} svgPath={mdiPaperclip} />
+        <H4
+            className="font-weight-normal text-muted m-0"
+            aria-label={`${count} ${pluralize('changeset', count)} will be re-added`}
+        >
+            {count} reattach
+        </H4>
     </div>
 )
 

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
@@ -121,7 +121,7 @@ export const PreviewList: React.FunctionComponent<React.PropsWithChildren<Props>
     const showSelectRow = selected === 'all' || selected.size > 0
 
     return (
-        <Container>
+        <Container role="region" aria-label="preview changesets">
             {showSelectRow && queryArguments ? (
                 <PreviewSelectRow
                     queryPublishableChangesetSpecIDs={queryPublishableChangesetSpecIDs}

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
@@ -155,7 +155,7 @@ export const PreviewList: React.FunctionComponent<React.PropsWithChildren<Props>
                 history={history}
                 location={location}
                 useURLQuery={true}
-                listComponent="div"
+                listComponent="ul"
                 listClassName={styles.previewListGrid}
                 headComponent={PreviewListHeader}
                 headComponentProps={{

--- a/client/web/src/enterprise/batches/preview/list/PreviewListHeader.module.scss
+++ b/client/web/src/enterprise/batches/preview/list/PreviewListHeader.module.scss
@@ -1,0 +1,3 @@
+.list-item {
+    display: contents;
+}

--- a/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
@@ -4,6 +4,8 @@ import { H3, H5 } from '@sourcegraph/wildcard'
 
 import { InputTooltip } from '../../../../components/InputTooltip'
 
+import styles from './PreviewListHeader.module.scss'
+
 export interface PreviewListHeaderProps {
     allSelected?: boolean
     toggleSelectAll?: () => void
@@ -13,7 +15,7 @@ export const PreviewListHeader: React.FunctionComponent<React.PropsWithChildren<
     allSelected,
     toggleSelectAll,
 }) => (
-    <>
+    <li className={styles.listItem}>
         <span className="p-2 d-none d-sm-block" />
         {toggleSelectAll && (
             <div className="d-flex p-2 align-items-center">
@@ -47,5 +49,5 @@ export const PreviewListHeader: React.FunctionComponent<React.PropsWithChildren<
         <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-center text-nowrap" aria-hidden={true}>
             Change state
         </H5>
-    </>
+    </li>
 )

--- a/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
@@ -29,22 +29,22 @@ export const PreviewListHeader: React.FunctionComponent<React.PropsWithChildren<
                 <span className="pl-2 d-block d-sm-none">Select all</span>
             </div>
         )}
-        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-center">
+        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-center" aria-hidden={true}>
             Current state
         </H5>
-        <H5 as={H3} className="d-none d-sm-block text-uppercase text-center">
+        <H5 as={H3} className="d-none d-sm-block text-uppercase text-center" aria-hidden={true}>
             +<br />-
         </H5>
-        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-nowrap">
+        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-nowrap" aria-hidden={true}>
             Actions
         </H5>
-        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-nowrap">
+        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-nowrap" aria-hidden={true}>
             Changeset information
         </H5>
-        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-center text-nowrap">
+        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-center text-nowrap" aria-hidden={true}>
             Commit changes
         </H5>
-        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-center text-nowrap">
+        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-center text-nowrap" aria-hidden={true}>
             Change state
         </H5>
     </>

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -141,10 +141,15 @@ export const VisibleChangesetApplyPreviewNode: React.FunctionComponent<
                             'd-flex justify-content-center align-items-center flex-column mx-1'
                         )}
                     >
-                        <Tooltip content="The diff changed">
-                            <Icon aria-label="The diff changed" svgPath={mdiFileDocumentEditOutline} />
+                        <Tooltip content="The diff for this changeset has been updated">
+                            <Icon
+                                aria-label="The diff for this changeset has been updated"
+                                svgPath={mdiFileDocumentEditOutline}
+                            />
                         </Tooltip>
-                        <span className="text-nowrap">Diff</span>
+                        <span className="text-nowrap" aria-hidden={true}>
+                            Diff
+                        </span>
                     </div>
                 )}
                 {(node.delta.authorNameChanged || node.delta.authorEmailChanged) && (

--- a/client/web/src/enterprise/batches/settings/CheckButton.tsx
+++ b/client/web/src/enterprise/batches/settings/CheckButton.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { mdiCheck, mdiClose } from '@mdi/js'
 
-import { Button, LoadingSpinner, Icon } from '@sourcegraph/wildcard'
+import { Button, LoadingSpinner, Icon, Alert } from '@sourcegraph/wildcard'
 
 export interface CheckButtonProps {
     label: string
@@ -35,16 +35,16 @@ export const CheckButton: React.FunctionComponent<React.PropsWithChildren<CheckB
     }
     if (successMessage && !failedMessage) {
         return (
-            <div className="text-success">
-                <Icon svgPath={mdiCheck} inline={false} aria-label="Success" /> {successMessage}
-            </div>
+            <Alert className="text-success">
+                <Icon svgPath={mdiCheck} inline={false} aria-hidden={true} /> {successMessage}
+            </Alert>
         )
     }
     if (failedMessage) {
         return (
-            <div className="text-danger">
-                <Icon svgPath={mdiClose} inline={false} aria-label="Failed" /> {failedMessage}
-            </div>
+            <Alert className="text-danger">
+                <Icon svgPath={mdiClose} inline={false} aria-hidden={true} /> {failedMessage}
+            </Alert>
         )
     }
     throw new Error('unreachable check button state')

--- a/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
@@ -53,7 +53,7 @@ const CodeHostConnections: React.FunctionComponent<React.PropsWithChildren<CodeH
             <ConnectionContainer className="mb-3">
                 {error && <ConnectionError errors={[error.message]} />}
                 {loading && !connection && <ConnectionLoading />}
-                <ConnectionList as="ul" className="list-group" aria-label="Code hosts">
+                <ConnectionList as="ul" className="list-group" aria-label="code hosts">
                     {connection?.nodes?.map(node => (
                         <CodeHostConnectionNode
                             key={node.externalServiceURL}

--- a/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
+++ b/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
@@ -34,10 +34,9 @@ export const Descriptor = <Workspace extends WorkspaceBaseFields>({
         <div className="flex-1">
             <H4 className={styles.name}>{workspace?.repository.name ?? 'Workspace in hidden repository'}</H4>
             {workspace && workspace.path !== '' && workspace.path !== '/' ? (
-                <>
-                    {/* <VisuallyHidden>Workspace path: </VisuallyHidden> */}
-                    <span className={styles.path}>{workspace?.path}</span>
-                </>
+                <span aria-label="Workspace path:" className={styles.path}>
+                    {workspace?.path}
+                </span>
             ) : null}
             {workspace && (
                 <div className={classNames(styles.workspaceDetails, 'text-monospace')}>
@@ -60,10 +59,7 @@ export const Descriptor = <Workspace extends WorkspaceBaseFields>({
                         </Badge>
                     )}
                     <Icon aria-hidden={true} className="mr-1" svgPath={mdiSourceBranch} />
-                    <small>
-                        {/* <VisuallyHidden>Workspace branch: </VisuallyHidden> */}
-                        {workspace.branch.displayName}
-                    </small>
+                    <small aria-label="Workspace branch:">{workspace.branch.displayName}</small>
                 </div>
             )}
         </div>

--- a/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
+++ b/client/web/src/enterprise/batches/workspaces-list/Descriptor.tsx
@@ -34,7 +34,7 @@ export const Descriptor = <Workspace extends WorkspaceBaseFields>({
         <div className="flex-1">
             <H4 className={styles.name}>{workspace?.repository.name ?? 'Workspace in hidden repository'}</H4>
             {workspace && workspace.path !== '' && workspace.path !== '/' ? (
-                <span aria-label="Workspace path:" className={styles.path}>
+                <span aria-label={`Workspace path: ${workspace?.path}`} className={styles.path}>
                     {workspace?.path}
                 </span>
             ) : null}
@@ -59,7 +59,9 @@ export const Descriptor = <Workspace extends WorkspaceBaseFields>({
                         </Badge>
                     )}
                     <Icon aria-hidden={true} className="mr-1" svgPath={mdiSourceBranch} />
-                    <small aria-label="Workspace branch:">{workspace.branch.displayName}</small>
+                    <small aria-label={`Workspace branch: ${workspace.branch.displayName}`}>
+                        {workspace.branch.displayName}
+                    </small>
                 </div>
             )}
         </div>

--- a/client/web/src/global/__snapshots__/Notices.test.tsx.snap
+++ b/client/web/src/global/__snapshots__/Notices.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`Notices shows notices for location 1`] = `
         </div>
       </div>
       <button
-        aria-label="Close alert"
+        aria-label="Dismiss alert"
         class="btn btnIcon closeButton"
         type="button"
       >

--- a/client/web/src/org/area/OrgHeader.tsx
+++ b/client/web/src/org/area/OrgHeader.tsx
@@ -77,7 +77,7 @@ export const OrgHeader: React.FunctionComponent<React.PropsWithChildren<Props>> 
                                 </PageHeader.Breadcrumb>
                             </PageHeader.Heading>
                         </PageHeader>
-                        <div className="d-flex align-items-end justify-content-between">
+                        <nav className="d-flex align-items-end justify-content-between" aria-label="Org">
                             <ul className="nav nav-tabs w-100">
                                 {navItems.map(
                                     ({
@@ -127,7 +127,7 @@ export const OrgHeader: React.FunctionComponent<React.PropsWithChildren<Props>> 
                                     </Button>
                                 </div>
                             )}
-                        </div>
+                        </nav>
                     </>
                 )}
             </div>

--- a/client/web/src/site/__snapshots__/LicenseExpirationAlert.test.tsx.snap
+++ b/client/web/src/site/__snapshots__/LicenseExpirationAlert.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`LicenseExpirationAlert expired 1`] = `
       </a>
     </div>
     <button
-      aria-label="Close alert"
+      aria-label="Dismiss alert"
       class="btn btnIcon closeButton"
       type="button"
     >
@@ -90,7 +90,7 @@ exports[`LicenseExpirationAlert expiring soon 1`] = `
       </a>
     </div>
     <button
-      aria-label="Close alert"
+      aria-label="Dismiss alert"
       class="btn btnIcon closeButton"
       type="button"
     >

--- a/client/web/src/user/area/UserAreaHeader.tsx
+++ b/client/web/src/user/area/UserAreaHeader.tsx
@@ -63,7 +63,7 @@ export const UserAreaHeader: React.FunctionComponent<React.PropsWithChildren<Pro
                         <PageHeader.Breadcrumb icon={path.icon}>{path.text}</PageHeader.Breadcrumb>
                     </PageHeader.Heading>
                 </PageHeader>
-                <div className="d-flex align-items-end justify-content-between">
+                <nav className="d-flex align-items-end justify-content-between" aria-label="User">
                     <ul className="nav nav-tabs w-100">
                         {navItems.map(
                             ({ to, label, exact, icon: ItemIcon, condition = () => true }) =>
@@ -86,7 +86,7 @@ export const UserAreaHeader: React.FunctionComponent<React.PropsWithChildren<Pro
                                 )
                         )}
                     </ul>
-                </div>
+                </nav>
             </div>
         </div>
     )

--- a/client/wildcard/src/components/Badge/ProductStatusBadge.tsx
+++ b/client/wildcard/src/components/Badge/ProductStatusBadge.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 
 import { BadgeProps, Badge } from './Badge'
@@ -59,15 +60,26 @@ export const ProductStatusBadge: React.FunctionComponent<React.PropsWithChildren
 
     if ('linkToDocs' in props) {
         return (
-            <Badge href={STATUS_LINK_MAPPING[props.status]} variant={variant} className={className}>
-                {props.status}
-            </Badge>
+            <>
+                <VisuallyHidden>{`This feature is currently in ${props.status}`}</VisuallyHidden>
+                <Badge
+                    href={STATUS_LINK_MAPPING[props.status]}
+                    variant={variant}
+                    className={className}
+                    aria-hidden={true}
+                >
+                    {props.status}
+                </Badge>
+            </>
         )
     }
 
     return (
-        <Badge {...props} variant={variant} className={className}>
-            {props.status}
-        </Badge>
+        <>
+            <VisuallyHidden>{`This feature is currently in ${props.status}`}</VisuallyHidden>
+            <Badge {...props} variant={variant} className={className} aria-hidden={true}>
+                {props.status}
+            </Badge>
+        </>
     )
 }

--- a/client/wildcard/src/components/Badge/ProductStatusBadge.tsx
+++ b/client/wildcard/src/components/Badge/ProductStatusBadge.tsx
@@ -57,11 +57,23 @@ export type ProductStatusBadgeProps = BaseProductStatusBadgeProps | PossibleLink
 export const ProductStatusBadge: React.FunctionComponent<React.PropsWithChildren<ProductStatusBadgeProps>> = props => {
     const variant = STATUS_VARIANT_MAPPING[props.status]
     const className = classNames(styles.productStatusBadge, props.className)
+    const label =
+        props.status === 'beta'
+            ? 'This feature is currently in beta'
+            : props.status === 'prototype'
+            ? 'This feature is a prototype'
+            : props.status === 'experimental'
+            ? 'This feature is experimental'
+            : props.status === 'wip'
+            ? 'This feature is a work in progress'
+            : props.status === 'new'
+            ? 'This feature is new'
+            : ''
 
     if ('linkToDocs' in props) {
         return (
             <>
-                <VisuallyHidden>{`This feature is currently in ${props.status}`}</VisuallyHidden>
+                <VisuallyHidden>{label}</VisuallyHidden>
                 <Badge
                     href={STATUS_LINK_MAPPING[props.status]}
                     variant={variant}

--- a/client/wildcard/src/components/Container/Container.tsx
+++ b/client/wildcard/src/components/Container/Container.tsx
@@ -4,11 +4,17 @@ import classNames from 'classnames'
 
 import styles from './Container.module.scss'
 
-interface Props {
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
     className?: string
 }
 
 /** A container wrapper. Used for grouping content together. */
-export const Container: React.FunctionComponent<React.PropsWithChildren<Props>> = ({ children, className }) => (
-    <div className={classNames(styles.container, className)}>{children}</div>
+export const Container: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
+    children,
+    className,
+    ...props
+}) => (
+    <div className={classNames(styles.container, className)} {...props}>
+        {children}
+    </div>
 )

--- a/client/wildcard/src/components/Feedback/FeedbackBadge/FeedbackBadge.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackBadge/FeedbackBadge.tsx
@@ -23,11 +23,10 @@ interface FeedbackBadgeProps extends BaseProductStatusBadgeProps {
 export const FeedbackBadge: React.FunctionComponent<React.PropsWithChildren<FeedbackBadgeProps>> = ({
     className,
     status,
-    tooltip,
     feedback: { mailto, text },
 }) => (
     <div className={classNames(styles.feedbackBadge, className)}>
-        <ProductStatusBadge tooltip={tooltip} status={status} className={styles.productStatusBadge} />
+        <ProductStatusBadge status={status} className={styles.productStatusBadge} />
         <Link to={`mailto:${mailto}`} className={styles.anchor} target="_blank" rel="noopener noreferrer">
             {text || 'Share feedback'}
         </Link>

--- a/client/wildcard/src/components/Feedback/FeedbackBadge/__snapshots__/FeedbackBadge.test.tsx.snap
+++ b/client/wildcard/src/components/Feedback/FeedbackBadge/__snapshots__/FeedbackBadge.test.tsx.snap
@@ -5,6 +5,12 @@ exports[`FeedbackBadge Renders status 'beta' correctly 1`] = `
   class="feedbackBadge"
 >
   <span
+    style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+  >
+    This feature is currently in beta
+  </span>
+  <span
+    aria-hidden="true"
     class="productStatusBadge productStatusBadge"
     status="beta"
   >
@@ -26,6 +32,12 @@ exports[`FeedbackBadge Renders status 'experimental' correctly 1`] = `
   class="feedbackBadge"
 >
   <span
+    style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+  >
+    This feature is currently in experimental
+  </span>
+  <span
+    aria-hidden="true"
     class="productStatusBadge productStatusBadge"
     status="experimental"
   >
@@ -47,6 +59,12 @@ exports[`FeedbackBadge Renders status 'new' correctly 1`] = `
   class="feedbackBadge"
 >
   <span
+    style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+  >
+    This feature is currently in new
+  </span>
+  <span
+    aria-hidden="true"
     class="productStatusBadge productStatusBadge"
     status="new"
   >
@@ -68,6 +86,12 @@ exports[`FeedbackBadge Renders status 'prototype' correctly 1`] = `
   class="feedbackBadge"
 >
   <span
+    style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+  >
+    This feature is currently in prototype
+  </span>
+  <span
+    aria-hidden="true"
     class="productStatusBadge productStatusBadge"
     status="prototype"
   >
@@ -89,6 +113,12 @@ exports[`FeedbackBadge Renders status 'wip' correctly 1`] = `
   class="feedbackBadge"
 >
   <span
+    style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+  >
+    This feature is currently in wip
+  </span>
+  <span
+    aria-hidden="true"
     class="productStatusBadge productStatusBadge"
     status="wip"
   >
@@ -110,6 +140,12 @@ exports[`FeedbackBadge renders a FeedbackBadge 1`] = `
   class="feedbackBadge"
 >
   <span
+    style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+  >
+    This feature is currently in new
+  </span>
+  <span
+    aria-hidden="true"
     class="productStatusBadge productStatusBadge"
     status="new"
   >


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/35009, https://github.com/sourcegraph/sourcegraph/issues/34484, and https://github.com/sourcegraph/sourcegraph/issues/39360.

While conducting screen reader audits for the core batch changes user journeys, I hit lots of paper cuts and saw many small opportunities for improvement. This is result of fixing those issues. 

Journeys covered:
- Adding user credentials for batch changes
- Navigating the batch changes list
- Understanding the state of a batch change
- Navigating the changesets list
- Creating a new batch change (server-side flow)
- Using the batch spec editor library
- Using the batch spec editor workspaces preview
- Monitoring an active batch spec execution and viewing workspace details
- Understanding the preview and applying a new spec 

You can find recordings of these journeys [here](https://www.loom.com/looms/folders/Screenreader-journey-recordings-b5730fa3307547a99ba6d0aaf3a7d139).

I initially tried to split this into multiple PRs for each journey, but for certain journeys there was lots of overlap, and I didn't want to end up with 9 stacked PRs, so apologies in advance for the large-ish diff.

---

### Notes

Not every batch change user journey that we initially audited has been included in the final testing scope for the external auditor. To name a few:
- Performing bulk operations
- Editing and re-executing an existing batch change
- Essentially all of the admin flows

I believe it's important that we re-audit and improve these journeys as well. However, since these 9 are the ones we want ready for the external auditors, I have not done anything to those other flows.

Additionally, the burndown chart is apparently _is_ included in the test coverage. 🙃 Considering we've put exactly 0 resources into the burndown chart in the 1.5 years I've been a part of this team and have talked about how it was effectively a PoC that just never got any incremental improvements, I'm not planning to fix the burndown chart up at all for the audit. This means it will be reported for violations, considering the chart is not screenreader-friendly. I think we can live with this.

## Test plan

Final recordings for each journey were taken after these changes were applied. I tried my best to manually test for visual regressions with Storybook where applicable. There are a handful of intended visual differences (mostly capitalization and a couple spacing changes), but I'll be monitoring for any unexpected Chromatic diffs once CI runs. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-misc-a11y-fixes.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
