### PR TITLE
chore: Add .lua to editorconfig.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ indent_size = 4
 [*.go]
 indent_style = tab
 
-[{*.js,*.jsx,*.json,*.yml,*.yaml,*.md,.babelrc,.stylelintrc}]
+[{*.lua,*.js,*.jsx,*.json,*.yml,*.yaml,*.md,.babelrc,.stylelintrc}]
 indent_size = 2
 
 [*.md]


### PR DESCRIPTION
We have some Lua code in the autoindexing inference logic, it uses 2 spaces.

## Test plan

n/a