### PR TITLE
observability: disable ci log upload and add disabled notice for log upload

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -27,9 +27,11 @@ if [ "$BUILDKITE_BRANCH" == "main" ]; then
     fi
   done
 
+  # Please see: https://github.com/sourcegraph/sourcegraph/issues/43934
+  echo "--- ⚠️A TEMPORARILY DISABLED: Logs will not be uploaded to Grafana. Please reach out to #dev-experiencee"
   # Non-zero exit code and not a soft fail: upload the logs.
-  echo "--- Uploading build logs: this only runs if your build has already failed, check the logs above, NOT below!"
-  ./enterprise/dev/ci/scripts/upload-build-logs.sh
+  # echo "--- Uploading build logs: this only runs if your build has already failed, check the logs above, NOT below!"
+  # ./enterprise/dev/ci/scripts/upload-build-logs.sh
 fi
 
 # upload raw annotations as artifacts if they are available for easier access


### PR DESCRIPTION
Disable upload of ci logs and print out a notice

## Test plan
[main-dry-run](https://buildkite.com/sourcegraph/sourcegraph/builds/182861)
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
