### PR TITLE
perforce: Provide internal actor when validating connection

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -46,7 +46,6 @@ func Init(
 	}
 
 	extsvcStore := db.ExternalServices()
-
 	// TODO(nsc): use c
 	// Report any authz provider problems in external configs.
 	conf.ContributeWarning(func(cfg conftypes.SiteConfigQuerier) (problems conf.Problems) {
@@ -56,6 +55,9 @@ func Init(
 
 		// Add connection validation issue
 		for _, p := range providers {
+			// Validating the connection may make a cross service call, so we should use an
+			// internal actor.
+			ctx = actor.WithInternalActor(ctx)
 			for _, problem := range p.ValidateConnection(ctx) {
 				warnings = append(warnings, fmt.Sprintf("%s provider %q: %s", p.ServiceType(), p.ServiceID(), problem))
 			}

--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -46,6 +46,7 @@ func Init(
 	}
 
 	extsvcStore := db.ExternalServices()
+
 	// TODO(nsc): use c
 	// Report any authz provider problems in external configs.
 	conf.ContributeWarning(func(cfg conftypes.SiteConfigQuerier) (problems conf.Problems) {

--- a/enterprise/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/internal/authz/bitbucketserver/provider.go
@@ -48,7 +48,7 @@ func NewProvider(cli *bitbucketserver.Client, urn string, pluginPerm bool) *Prov
 	}
 }
 
-// Validate validates that the Provider has access to the Bitbucket Server API
+// ValidateConnection validates that the Provider has access to the Bitbucket Server API
 // with the OAuth credentials it was configured with.
 func (p *Provider) ValidateConnection(ctx context.Context) []string {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)

--- a/enterprise/internal/authz/perforce/perforce.go
+++ b/enterprise/internal/authz/perforce/perforce.go
@@ -379,9 +379,9 @@ func (p *Provider) URN() string {
 	return p.urn
 }
 
-func (p *Provider) ValidateConnection(_ context.Context) (problems []string) {
+func (p *Provider) ValidateConnection(ctx context.Context) (problems []string) {
 	// Validate the user has "super" access with "-u" option, see https://www.perforce.com/perforce/r12.1/manuals/cmdref/protects.html
-	rc, _, err := p.p4Execer.P4Exec(context.Background(), p.host, p.user, p.password, "protects", "-u", p.user)
+	rc, _, err := p.p4Execer.P4Exec(ctx, p.host, p.user, p.password, "protects", "-u", p.user)
 	if err == nil {
 		_ = rc.Close()
 		return nil


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/28532

## Test plan

Testing locally, confirmed we no longer log that we received a request without an actor