### PR TITLE
authz: Wrap context locally

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -54,11 +54,12 @@ func Init(
 			eiauthz.ProvidersFromConfig(ctx, cfg, extsvcStore, db)
 		problems = append(problems, conf.NewExternalServiceProblems(seriousProblems...)...)
 
+		// Validating the connection may make a cross service call, so we should use an
+		// internal actor.
+		ctx := actor.WithInternalActor(ctx)
+
 		// Add connection validation issue
 		for _, p := range providers {
-			// Validating the connection may make a cross service call, so we should use an
-			// internal actor.
-			ctx = actor.WithInternalActor(ctx)
 			for _, problem := range p.ValidateConnection(ctx) {
 				warnings = append(warnings, fmt.Sprintf("%s provider %q: %s", p.ServiceType(), p.ServiceID(), problem))
 			}


### PR DESCRIPTION
The previous code was wrapping the context multiple times in the loop
and was also writing to a variable supplied from outside the closure
which could lead to races.

## Test plan

Tested locally
