### PR TITLE
ranking: hoist top scoring match

### DIFF
--- a/internal/search/backend/aggregate.go
+++ b/internal/search/backend/aggregate.go
@@ -78,7 +78,35 @@ func (c *collectSender) Done() (_ *zoekt.SearchResult, ok bool) {
 		agg.Files = agg.Files[:max]
 	}
 
+	hoistMaxScore(agg.Files, 10)
+
 	return agg, true
+}
+
+// hoistMaxScore swaps the top scoring result within fm[:n] to the top.
+func hoistMaxScore(fm []zoekt.FileMatch, n int) {
+	if n > len(fm) {
+		n = len(fm)
+	}
+
+	var max float64
+	pos := 0
+	for i := 0; i < n; i++ {
+		if fm[i].Score > max {
+			max = fm[i].Score
+			pos = i
+		}
+	}
+
+	if pos > 0 {
+		prev := fm[0]
+		fm[0] = fm[pos]
+		for i := 1; i <= pos; i++ {
+			this := fm[i]
+			fm[i] = prev
+			prev = this
+		}
+	}
 }
 
 // newFlushCollectSender creates a sender which will collect and rank results

--- a/internal/search/backend/aggregate.go
+++ b/internal/search/backend/aggregate.go
@@ -89,23 +89,16 @@ func hoistMaxScore(fm []zoekt.FileMatch, n int) {
 		n = len(fm)
 	}
 
-	var max float64
-	pos := 0
-	for i := 0; i < n; i++ {
-		if fm[i].Score > max {
-			max = fm[i].Score
-			pos = i
+	maxIdx := 0
+	for i := 1; i < n; i++ {
+		if fm[i].Score > fm[maxIdx].Score {
+			maxIdx = i
 		}
 	}
 
-	if pos > 0 {
-		prev := fm[0]
-		fm[0] = fm[pos]
-		for i := 1; i <= pos; i++ {
-			this := fm[i]
-			fm[i] = prev
-			prev = this
-		}
+	for maxIdx > 0 {
+		fm[maxIdx-1], fm[maxIdx] = fm[maxIdx], fm[maxIdx-1]
+		maxIdx--
 	}
 }
 

--- a/internal/search/backend/aggregate_test.go
+++ b/internal/search/backend/aggregate_test.go
@@ -1,0 +1,82 @@
+package backend
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/zoekt"
+)
+
+func TestHoistTopScore(t *testing.T) {
+	cases := []struct {
+		inputScore []float64
+		wantScore  []float64
+		n          int
+	}{
+		{
+			inputScore: []float64{1, 2, 33, 99, 5, 6},
+			wantScore:  []float64{99, 1, 2, 33, 5, 6},
+			n:          5,
+		},
+		{
+			inputScore: []float64{99, 1, 2, 3, 5, 6},
+			wantScore:  []float64{99, 1, 2, 3, 5, 6},
+			n:          5,
+		},
+		{
+			inputScore: []float64{1, 99, 2, 3, 5, 6},
+			wantScore:  []float64{99, 1, 2, 3, 5, 6},
+			n:          5,
+		},
+
+		{
+			inputScore: []float64{1, 2, 3, 5, 6, 99},
+			wantScore:  []float64{6, 1, 2, 3, 5, 99},
+			n:          5,
+		},
+		{
+			inputScore: []float64{1, 99, 2},
+			wantScore:  []float64{99, 1, 2},
+			n:          5,
+		},
+		{
+			inputScore: []float64{1, 99, 2},
+			wantScore:  []float64{1, 99, 2},
+			n:          1,
+		},
+
+		{
+			inputScore: []float64{1, 99, 2},
+			wantScore:  []float64{1, 99, 2},
+			n:          0,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run("", func(t *testing.T) {
+			fileMatches := mkFileMatch(tt.inputScore)
+			hoistMaxScore(fileMatches, tt.n)
+
+			haveScore := []float64{}
+			for _, fm := range fileMatches {
+				haveScore = append(haveScore, fm.Score)
+			}
+
+			if d := cmp.Diff(tt.wantScore, haveScore); d != "" {
+				t.Fatalf("-want, +got:\n%s", d)
+			}
+		})
+	}
+
+	hoistMaxScore(nil, 5)
+	hoistMaxScore([]zoekt.FileMatch{}, 5)
+}
+
+func mkFileMatch(scores []float64) []zoekt.FileMatch {
+	fm := make([]zoekt.FileMatch, 0, len(scores))
+	for _, score := range scores {
+		fm = append(fm, zoekt.FileMatch{Score: score})
+	}
+
+	return fm
+}


### PR DESCRIPTION
This lifts the top scoring match within the top 10 matches returned by Zoekt to the top.

Motivation:
Our ranking algorithm will usually produce a good balance of high scores and high document ranks IE producing good matches within relevant documents.  However, we have noticed that a near perfect document rank can outperform high scores yielding sometimes poor matches within highly relevant documents as top result. This change makes sure we always show the top scoring result first.

## Test plan
- new unit test
