### PR TITLE
gitserver: make `ReposStats` use `gitserverClient.do` for sending HTTP requests.

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -1143,23 +1143,7 @@ func (c *clientImplementor) ReposStats(ctx context.Context) (map[string]*protoco
 }
 
 func (c *clientImplementor) doReposStats(ctx context.Context, addr string) (*protocol.ReposStats, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", "http://"+addr+"/repos-stats", nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: Ideally doReposStats should use clientImplementor.do but the varying method
-	// signature prevents us from doing that.
-	//
-	// We should consolidate into a single method for creating requests so that we are
-	// setting all the required properties like headers, trace spans in a central place.
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", c.userAgent)
-
-	// Set header so that the server knows the request is from us.
-	req.Header.Set("X-Requested-With", "Sourcegraph")
-
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(ctx, "repos-stats call, no repo provided", "GET", fmt.Sprintf("http://%s/repos-stats", addr), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -1143,7 +1143,7 @@ func (c *clientImplementor) ReposStats(ctx context.Context) (map[string]*protoco
 }
 
 func (c *clientImplementor) doReposStats(ctx context.Context, addr string) (*protocol.ReposStats, error) {
-	resp, err := c.do(ctx, "repos-stats call, no repo provided", "GET", fmt.Sprintf("http://%s/repos-stats", addr), nil)
+	resp, err := c.do(ctx, "", "GET", fmt.Sprintf("http://%s/repos-stats", addr), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1222,9 +1222,8 @@ func (c *clientImplementor) httpPostWithURI(ctx context.Context, repo api.RepoNa
 	return c.do(ctx, repo, "POST", uri, b)
 }
 
-// do performs a request to a gitserver instance based on the address in the uri argument.
-//
-//nolint:unparam // unparam complains that `method` always has same value across call-sites, but that's OK
+// do performs a request to a gitserver instance based on the address in the uri
+// argument.
 func (c *clientImplementor) do(ctx context.Context, repo api.RepoName, method, uri string, payload []byte) (resp *http.Response, err error) {
 	parsedURL, err := url.ParseRequestURI(uri)
 	if err != nil {
@@ -1233,6 +1232,11 @@ func (c *clientImplementor) do(ctx context.Context, repo api.RepoName, method, u
 
 	span, ctx := ot.StartSpanFromContext(ctx, "Client.do")
 	defer func() {
+		if repo != "" {
+			span.LogKV("repo", string(repo), "method", method, "path", parsedURL.Path)
+		} else {
+			span.LogKV("method", method, "path", parsedURL.Path)
+		}
 		span.LogKV("repo", string(repo), "method", method, "path", parsedURL.Path)
 		if err != nil {
 			ext.Error.Set(span, true)

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -1224,6 +1224,9 @@ func (c *clientImplementor) httpPostWithURI(ctx context.Context, repo api.RepoNa
 
 // do performs a request to a gitserver instance based on the address in the uri
 // argument.
+//
+// Repo parameter is optional. If it is provided, then "repo" attribute is added
+// to trace span.
 func (c *clientImplementor) do(ctx context.Context, repo api.RepoName, method, uri string, payload []byte) (resp *http.Response, err error) {
 	parsedURL, err := url.ParseRequestURI(uri)
 	if err != nil {


### PR DESCRIPTION
This commit makes sending HTTP requests uniform across the gitserver client, using `gitserverClient.do` which includes all necessary headers.

Repo name which is used in `do` only for tracing purpose is passed as `repos-stats call, no repo provided` because `ReposStats` doesn't use repos, it uses gitserver instance address.

Test plan:
New unit test added.

Closes https://github.com/sourcegraph/sourcegraph/issues/43221