### PR TITLE
bext: adjust to the updated GitHub UI

### DIFF
--- a/client/browser/src/shared/code-hosts/github/domFunctions.ts
+++ b/client/browser/src/shared/code-hosts/github/domFunctions.ts
@@ -60,9 +60,12 @@ const getLineNumberFromCodeElement = (codeElement: HTMLElement): number => {
  * Gets the `<td>` element for a target that contains the code
  */
 const getCodeCellFromTarget = (target: HTMLElement): HTMLTableCellElement | null => {
-    const cell = target.closest<HTMLTableCellElement>('td.blob-code')
-    // Handle rows with the [ ↕ ] button that expands collapsed unchanged lines
+    const cell =
+        target.closest<HTMLTableCellElement>('td.react-code-cell') ||
+        target.closest<HTMLTableCellElement>('td.blob-code')
+    // Handle rows with the [ ↕ ] button that expands collapsed unchanged lines TODO: CHECK IF IT STILL WORKS
     if (!cell || cell.parentElement?.classList.contains('js-expandable-line')) {
+        // TODO: update selector
         return null
     }
     return cell

--- a/client/browser/src/shared/code-hosts/github/scrape.ts
+++ b/client/browser/src/shared/code-hosts/github/scrape.ts
@@ -1,11 +1,13 @@
 import { commitIDFromPermalink } from '../../util/dom'
 
+import { getPermalinkSelector } from './util'
+
 /**
  * Get the commit ID from the permalink element on the page.
  */
 export function getCommitIDFromPermalink(): string {
     return commitIDFromPermalink({
-        selector: '.js-permalink-shortcut',
+        selector: getPermalinkSelector()!,
         hrefRegex: /^\/.*?\/.*?\/(?:blob|tree)\/([\da-f]{40})/,
     })
 }

--- a/client/browser/src/shared/code-hosts/github/util.tsx
+++ b/client/browser/src/shared/code-hosts/github/util.tsx
@@ -190,6 +190,9 @@ function getDiffResolvedRevisionFromPageSource(
     }
 }
 
+export const getPermalinkSelector = (): string | undefined =>
+    ['.ActionList-item--navActive a', 'a.js-permalink-shortcut'].find(selector => !!document.querySelector(selector))
+
 /**
  * Returns the file path for the current page. Must be on a blob or tree page.
  *
@@ -207,9 +210,10 @@ function getDiffResolvedRevisionFromPageSource(
  * TODO ideally, this should only scrape the code view itself.
  */
 export function getFilePath(): string {
-    const permalink = document.querySelector<HTMLAnchorElement>('a.js-permalink-shortcut')
+    const selector = getPermalinkSelector()
+    const permalink = document.querySelector<HTMLAnchorElement>(selector!)
     if (!permalink) {
-        throw new Error('Unable to determine the file path because no a.js-permalink-shortcut element was found.')
+        throw new Error('Unable to determine the file path because no containing file permalink was found.')
     }
     const url = new URL(permalink.href)
     // <empty>/<user>/<repo>/(blob|tree)/<commitID>/<path/to/file>
@@ -218,7 +222,7 @@ export function getFilePath(): string {
     // Check for page type because a tree page can be the repo root, so it shouldn't throw an error despite an empty path
     if (pageType !== 'tree' && path.length === 0) {
         throw new Error(
-            `Unable to determine the file path because the a.js-permalink-shortcut element's href's path was ${url.pathname} (it is expected to be of the form /<user>/<repo>/blob/<commitID>/<path/to/file>).`
+            `Unable to determine the file path because the link href attribute was ${url.pathname} (it is expected to be of the form /<user>/<repo>/blob/<commitID>/<path/to/file>).`
         )
     }
     return decodeURIComponent(path.join('/'))


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/44237

## Test plan
- CI passes
- Manually tested main browser extension functionality on GitHub and GitHub Enterprise (uses old UI)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
