### PR TITLE
dev: Upgrade nodejs to latest LTS version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 golang 1.19.3
-nodejs 16.7.0
+nodejs 18.12.1
 # We install classic yarn with asdf, and then use yarn itself to upgrade to 3.2.3
 # This is done because there is a problem fetching yarn via asdf, instead the version is
 # specified in .yarnrc via the yarnPath.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/sourcegraph/sourcegraph"
   },
   "engines": {
-    "node": "^v16.7.0",
+    "node": "^v18.12.1",
     "yarn": "^1.22.4"
   },
   "scripts": {
@@ -348,7 +348,7 @@
     "typescript": "^4.7.2",
     "utc-version": "^2.0.2",
     "vsce": "^2.7.0",
-    "webpack": "^5.45.1",
+    "webpack": "^5.75.0",
     "webpack-bundle-analyzer": "^4.4.2",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.0.0",

--- a/shell.nix
+++ b/shell.nix
@@ -48,10 +48,10 @@ pkgs.mkShell {
     shellcheck
     golangci-lint
 
-    # Web tools. Need node 16.7 so we use unstable. Yarn should also be built
+    # Web tools. Need node 18 so we use unstable. Yarn should also be built
     # against it.
-    nodejs-16_x
-    (yarn.override { nodejs = nodejs-16_x; })
+    nodejs-18_x
+    (yarn.override { nodejs = nodejs-18_x; })
     nodePackages.typescript
 
     # Rust utils for syntax-highlighter service,

--- a/yarn.lock
+++ b/yarn.lock
@@ -22566,24 +22566,24 @@ __metadata:
   linkType: hard
 
 "loader-utils@npm:^1.0.0, loader-utils@npm:^1.1.0, loader-utils@npm:^1.2.3":
-  version: 1.4.0
-  resolution: "loader-utils@npm:1.4.0"
+  version: 1.4.2
+  resolution: "loader-utils@npm:1.4.2"
   dependencies:
     big.js: ^5.2.2
     emojis-list: ^3.0.0
     json5: ^1.0.1
-  checksum: d150b15e7a42ac47d935c8b484b79e44ff6ab4c75df7cc4cb9093350cf014ec0b17bdb60c5d6f91a37b8b218bd63b973e263c65944f58ca2573e402b9a27e717
+  checksum: eb6fb622efc0ffd1abdf68a2022f9eac62bef8ec599cf8adb75e94d1d338381780be6278534170e99edc03380a6d29bc7eb1563c89ce17c5fed3a0b17f1ad804
   languageName: node
   linkType: hard
 
 "loader-utils@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "loader-utils@npm:2.0.0"
+  version: 2.0.4
+  resolution: "loader-utils@npm:2.0.4"
   dependencies:
     big.js: ^5.2.2
     emojis-list: ^3.0.0
     json5: ^2.1.2
-  checksum: 6856423131b50b6f5f259da36f498cfd7fc3c3f8bb17777cf87fdd9159e797d4ba4288d9a96415fd8da62c2906960e88f74711dee72d03a9003bddcd0d364a51
+  checksum: a5281f5fff1eaa310ad5e1164095689443630f3411e927f95031ab4fb83b4a98f388185bb1fe949e8ab8d4247004336a625e9255c22122b815bb9a4c5d8fc3b7
   languageName: node
   linkType: hard
 
@@ -28943,7 +28943,7 @@ pvutils@latest:
     vsce: ^2.7.0
     webext-domain-permission-toggle: ^1.0.1
     webextension-polyfill: ^0.6.0
-    webpack: ^5.45.1
+    webpack: ^5.75.0
     webpack-bundle-analyzer: ^4.4.2
     webpack-cli: ^4.7.2
     webpack-dev-server: ^4.0.0
@@ -33404,8 +33404,8 @@ pvutils@latest:
   linkType: hard
 
 "webpack@npm:5":
-  version: 5.74.0
-  resolution: "webpack@npm:5.74.0"
+  version: 5.75.0
+  resolution: "webpack@npm:5.75.0"
   dependencies:
     "@types/eslint-scope": ^3.7.3
     "@types/estree": ^0.0.51
@@ -33436,7 +33436,7 @@ pvutils@latest:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 320c41369a75051b19e18c63f408b3dcc481852e992f83d311771c5ec0f05f2946385e8ebef62030cf3587f0a3d2f12779ffdb191569a966847289ba7313f946
+  checksum: 2bcc5f3c195f375944e8af2f00bf2feea39cb9fda5f763b0d1b00077f1c51783db25c94d3fae96a07dead9fa085e6ae7474417e5ab31719c9776ea5969ceb83a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
One of our dependencies was using a loader that used deprecated APIs, so I had to update that as well.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-es-try-node-18.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

