### PR TITLE
Changed the wording on the DoRequest to communicate when the request is unauthorized

### DIFF
--- a/internal/oauthutil/oauth2.go
+++ b/internal/oauthutil/oauth2.go
@@ -83,7 +83,7 @@ func DoRequest(ctx context.Context, doer httpcli.Doer, req *http.Request, auther
 			// The next request should then succeed.
 			err = autherWithRefresh.Refresh(ctx, doer)
 			if err != nil {
-				return resp, errors.Wrap(err, "refresh token")
+				return resp, errors.Wrap(err, "unauthorized request and could not refresh token")
 			}
 			continue
 		}


### PR DESCRIPTION
Previously when the Github codehost config had an expired/revoked/insufficient permissions token it had the following error message:
![image](https://user-images.githubusercontent.com/20795805/201375246-906c0c64-4648-41a3-8b72-648b6f8bcc53.png)

which made it a bit confusing to determine that the token might be expired/revoked/insufficient permissions, the updated error message mentioning the request being unauthorized should help to communicate it better .
![image](https://user-images.githubusercontent.com/20795805/201375885-3237594f-3aa5-470b-b425-408712cfa613.png)


## Test plan
Just a log change, verified locally, see attached images.