### PR TITLE
Remove user added repos code from perms_syncer

### DIFF
--- a/internal/repos/mocks_temp.go
+++ b/internal/repos/mocks_temp.go
@@ -51,14 +51,6 @@ type MockStore struct {
 	// HandleFunc is an instance of a mock function object controlling the
 	// behavior of the method Handle.
 	HandleFunc *StoreHandleFunc
-	// ListExternalServicePrivateRepoIDsByUserIDFunc is an instance of a
-	// mock function object controlling the behavior of the method
-	// ListExternalServicePrivateRepoIDsByUserID.
-	ListExternalServicePrivateRepoIDsByUserIDFunc *StoreListExternalServicePrivateRepoIDsByUserIDFunc
-	// ListExternalServiceUserIDsByRepoIDFunc is an instance of a mock
-	// function object controlling the behavior of the method
-	// ListExternalServiceUserIDsByRepoID.
-	ListExternalServiceUserIDsByRepoIDFunc *StoreListExternalServiceUserIDsByRepoIDFunc
 	// ListSyncJobsFunc is an instance of a mock function object controlling
 	// the behavior of the method ListSyncJobs.
 	ListSyncJobsFunc *StoreListSyncJobsFunc
@@ -132,16 +124,6 @@ func NewMockStore() *MockStore {
 		},
 		HandleFunc: &StoreHandleFunc{
 			defaultHook: func() (r0 basestore.TransactableHandle) {
-				return
-			},
-		},
-		ListExternalServicePrivateRepoIDsByUserIDFunc: &StoreListExternalServicePrivateRepoIDsByUserIDFunc{
-			defaultHook: func(context.Context, int32) (r0 []api.RepoID, r1 error) {
-				return
-			},
-		},
-		ListExternalServiceUserIDsByRepoIDFunc: &StoreListExternalServiceUserIDsByRepoIDFunc{
-			defaultHook: func(context.Context, api.RepoID) (r0 []int32, r1 error) {
 				return
 			},
 		},
@@ -237,16 +219,6 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.Handle")
 			},
 		},
-		ListExternalServicePrivateRepoIDsByUserIDFunc: &StoreListExternalServicePrivateRepoIDsByUserIDFunc{
-			defaultHook: func(context.Context, int32) ([]api.RepoID, error) {
-				panic("unexpected invocation of MockStore.ListExternalServicePrivateRepoIDsByUserID")
-			},
-		},
-		ListExternalServiceUserIDsByRepoIDFunc: &StoreListExternalServiceUserIDsByRepoIDFunc{
-			defaultHook: func(context.Context, api.RepoID) ([]int32, error) {
-				panic("unexpected invocation of MockStore.ListExternalServiceUserIDsByRepoID")
-			},
-		},
 		ListSyncJobsFunc: &StoreListSyncJobsFunc{
 			defaultHook: func(context.Context) ([]SyncJob, error) {
 				panic("unexpected invocation of MockStore.ListSyncJobs")
@@ -320,12 +292,6 @@ func NewMockStoreFrom(i Store) *MockStore {
 		},
 		HandleFunc: &StoreHandleFunc{
 			defaultHook: i.Handle,
-		},
-		ListExternalServicePrivateRepoIDsByUserIDFunc: &StoreListExternalServicePrivateRepoIDsByUserIDFunc{
-			defaultHook: i.ListExternalServicePrivateRepoIDsByUserID,
-		},
-		ListExternalServiceUserIDsByRepoIDFunc: &StoreListExternalServiceUserIDsByRepoIDFunc{
-			defaultHook: i.ListExternalServiceUserIDsByRepoID,
 		},
 		ListSyncJobsFunc: &StoreListSyncJobsFunc{
 			defaultHook: i.ListSyncJobs,
@@ -1294,231 +1260,6 @@ func (c StoreHandleFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreHandleFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
-}
-
-// StoreListExternalServicePrivateRepoIDsByUserIDFunc describes the behavior
-// when the ListExternalServicePrivateRepoIDsByUserID method of the parent
-// MockStore instance is invoked.
-type StoreListExternalServicePrivateRepoIDsByUserIDFunc struct {
-	defaultHook func(context.Context, int32) ([]api.RepoID, error)
-	hooks       []func(context.Context, int32) ([]api.RepoID, error)
-	history     []StoreListExternalServicePrivateRepoIDsByUserIDFuncCall
-	mutex       sync.Mutex
-}
-
-// ListExternalServicePrivateRepoIDsByUserID delegates to the next hook
-// function in the queue and stores the parameter and result values of this
-// invocation.
-func (m *MockStore) ListExternalServicePrivateRepoIDsByUserID(v0 context.Context, v1 int32) ([]api.RepoID, error) {
-	r0, r1 := m.ListExternalServicePrivateRepoIDsByUserIDFunc.nextHook()(v0, v1)
-	m.ListExternalServicePrivateRepoIDsByUserIDFunc.appendCall(StoreListExternalServicePrivateRepoIDsByUserIDFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// ListExternalServicePrivateRepoIDsByUserID method of the parent MockStore
-// instance is invoked and the hook queue is empty.
-func (f *StoreListExternalServicePrivateRepoIDsByUserIDFunc) SetDefaultHook(hook func(context.Context, int32) ([]api.RepoID, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// ListExternalServicePrivateRepoIDsByUserID method of the parent MockStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *StoreListExternalServicePrivateRepoIDsByUserIDFunc) PushHook(hook func(context.Context, int32) ([]api.RepoID, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreListExternalServicePrivateRepoIDsByUserIDFunc) SetDefaultReturn(r0 []api.RepoID, r1 error) {
-	f.SetDefaultHook(func(context.Context, int32) ([]api.RepoID, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreListExternalServicePrivateRepoIDsByUserIDFunc) PushReturn(r0 []api.RepoID, r1 error) {
-	f.PushHook(func(context.Context, int32) ([]api.RepoID, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreListExternalServicePrivateRepoIDsByUserIDFunc) nextHook() func(context.Context, int32) ([]api.RepoID, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreListExternalServicePrivateRepoIDsByUserIDFunc) appendCall(r0 StoreListExternalServicePrivateRepoIDsByUserIDFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// StoreListExternalServicePrivateRepoIDsByUserIDFuncCall objects describing
-// the invocations of this function.
-func (f *StoreListExternalServicePrivateRepoIDsByUserIDFunc) History() []StoreListExternalServicePrivateRepoIDsByUserIDFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreListExternalServicePrivateRepoIDsByUserIDFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreListExternalServicePrivateRepoIDsByUserIDFuncCall is an object that
-// describes an invocation of method
-// ListExternalServicePrivateRepoIDsByUserID on an instance of MockStore.
-type StoreListExternalServicePrivateRepoIDsByUserIDFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int32
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []api.RepoID
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreListExternalServicePrivateRepoIDsByUserIDFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreListExternalServicePrivateRepoIDsByUserIDFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// StoreListExternalServiceUserIDsByRepoIDFunc describes the behavior when
-// the ListExternalServiceUserIDsByRepoID method of the parent MockStore
-// instance is invoked.
-type StoreListExternalServiceUserIDsByRepoIDFunc struct {
-	defaultHook func(context.Context, api.RepoID) ([]int32, error)
-	hooks       []func(context.Context, api.RepoID) ([]int32, error)
-	history     []StoreListExternalServiceUserIDsByRepoIDFuncCall
-	mutex       sync.Mutex
-}
-
-// ListExternalServiceUserIDsByRepoID delegates to the next hook function in
-// the queue and stores the parameter and result values of this invocation.
-func (m *MockStore) ListExternalServiceUserIDsByRepoID(v0 context.Context, v1 api.RepoID) ([]int32, error) {
-	r0, r1 := m.ListExternalServiceUserIDsByRepoIDFunc.nextHook()(v0, v1)
-	m.ListExternalServiceUserIDsByRepoIDFunc.appendCall(StoreListExternalServiceUserIDsByRepoIDFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// ListExternalServiceUserIDsByRepoID method of the parent MockStore
-// instance is invoked and the hook queue is empty.
-func (f *StoreListExternalServiceUserIDsByRepoIDFunc) SetDefaultHook(hook func(context.Context, api.RepoID) ([]int32, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// ListExternalServiceUserIDsByRepoID method of the parent MockStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *StoreListExternalServiceUserIDsByRepoIDFunc) PushHook(hook func(context.Context, api.RepoID) ([]int32, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreListExternalServiceUserIDsByRepoIDFunc) SetDefaultReturn(r0 []int32, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoID) ([]int32, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreListExternalServiceUserIDsByRepoIDFunc) PushReturn(r0 []int32, r1 error) {
-	f.PushHook(func(context.Context, api.RepoID) ([]int32, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreListExternalServiceUserIDsByRepoIDFunc) nextHook() func(context.Context, api.RepoID) ([]int32, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreListExternalServiceUserIDsByRepoIDFunc) appendCall(r0 StoreListExternalServiceUserIDsByRepoIDFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// StoreListExternalServiceUserIDsByRepoIDFuncCall objects describing the
-// invocations of this function.
-func (f *StoreListExternalServiceUserIDsByRepoIDFunc) History() []StoreListExternalServiceUserIDsByRepoIDFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreListExternalServiceUserIDsByRepoIDFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreListExternalServiceUserIDsByRepoIDFuncCall is an object that
-// describes an invocation of method ListExternalServiceUserIDsByRepoID on
-// an instance of MockStore.
-type StoreListExternalServiceUserIDsByRepoIDFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 api.RepoID
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []int32
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreListExternalServiceUserIDsByRepoIDFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreListExternalServiceUserIDsByRepoIDFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // StoreListSyncJobsFunc describes the behavior when the ListSyncJobs method

--- a/internal/repos/observability.go
+++ b/internal/repos/observability.go
@@ -139,22 +139,20 @@ func (o *observedSource) GetRepo(ctx context.Context, path string) (sourced *typ
 
 // StoreMetrics encapsulates the Prometheus metrics of a Store.
 type StoreMetrics struct {
-	Transact                           *metrics.REDMetrics
-	Done                               *metrics.REDMetrics
-	CreateExternalServiceRepo          *metrics.REDMetrics
-	UpdateExternalServiceRepo          *metrics.REDMetrics
-	DeleteExternalServiceRepo          *metrics.REDMetrics
-	DeleteExternalServiceReposNotIn    *metrics.REDMetrics
-	UpdateRepo                         *metrics.REDMetrics
-	UpsertRepos                        *metrics.REDMetrics
-	UpsertSources                      *metrics.REDMetrics
-	ListExternalRepoSpecs              *metrics.REDMetrics
-	ListExternalServiceUserIDsByRepoID *metrics.REDMetrics
-	ListExternalServiceRepoIDsByUserID *metrics.REDMetrics
-	GetExternalService                 *metrics.REDMetrics
-	SetClonedRepos                     *metrics.REDMetrics
-	CountNotClonedRepos                *metrics.REDMetrics
-	EnqueueSyncJobs                    *metrics.REDMetrics
+	Transact                        *metrics.REDMetrics
+	Done                            *metrics.REDMetrics
+	CreateExternalServiceRepo       *metrics.REDMetrics
+	UpdateExternalServiceRepo       *metrics.REDMetrics
+	DeleteExternalServiceRepo       *metrics.REDMetrics
+	DeleteExternalServiceReposNotIn *metrics.REDMetrics
+	UpdateRepo                      *metrics.REDMetrics
+	UpsertRepos                     *metrics.REDMetrics
+	UpsertSources                   *metrics.REDMetrics
+	ListExternalRepoSpecs           *metrics.REDMetrics
+	GetExternalService              *metrics.REDMetrics
+	SetClonedRepos                  *metrics.REDMetrics
+	CountNotClonedRepos             *metrics.REDMetrics
+	EnqueueSyncJobs                 *metrics.REDMetrics
 }
 
 // MustRegister registers all metrics in StoreMetrics in the given
@@ -164,8 +162,6 @@ func (sm StoreMetrics) MustRegister(r prometheus.Registerer) {
 		sm.Transact,
 		sm.Done,
 		sm.ListExternalRepoSpecs,
-		sm.ListExternalServiceUserIDsByRepoID,
-		sm.ListExternalServiceRepoIDsByUserID,
 		sm.CreateExternalServiceRepo,
 		sm.UpdateExternalServiceRepo,
 		sm.DeleteExternalServiceRepo,
@@ -309,34 +305,6 @@ func NewStoreMetrics() StoreMetrics {
 			Errors: prometheus.NewCounterVec(prometheus.CounterOpts{
 				Name: "src_repoupdater_store_list_external_repo_specs_errors_total",
 				Help: "Total number of errors when listing external repo specs",
-			}, []string{}),
-		},
-		ListExternalServiceUserIDsByRepoID: &metrics.REDMetrics{
-			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Name: "src_repoupdater_store_list_external_service_user_ids_by_repo_id",
-				Help: "Time spent listing external service users",
-			}, []string{}),
-			Count: prometheus.NewCounterVec(prometheus.CounterOpts{
-				Name: "src_repoupdater_store_list_external_service_user_ids_by_repo_id_total",
-				Help: "Total number of listed external service users",
-			}, []string{}),
-			Errors: prometheus.NewCounterVec(prometheus.CounterOpts{
-				Name: "src_repoupdater_store_list_external_service_user_ids_by_repo_id_errors_total",
-				Help: "Total number of errors when listing external service users",
-			}, []string{}),
-		},
-		ListExternalServiceRepoIDsByUserID: &metrics.REDMetrics{
-			Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Name: "src_repoupdater_store_list_external_service_repo_ids_by_user_id",
-				Help: "Time spent listing external service repos",
-			}, []string{}),
-			Count: prometheus.NewCounterVec(prometheus.CounterOpts{
-				Name: "src_repoupdater_store_list_external_service_repo_ids_by_user_id_total",
-				Help: "Total number of listed external service repos",
-			}, []string{}),
-			Errors: prometheus.NewCounterVec(prometheus.CounterOpts{
-				Name: "src_repoupdater_store_list_external_service_repo_ids_by_user_id_errors_total",
-				Help: "Total number of errors when listing external service repos",
 			}, []string{}),
 		},
 		GetExternalService: &metrics.REDMetrics{


### PR DESCRIPTION
Tech-debt-a-ton related work.

This code was only used while we still supported user added code on dotcom. This is no longer the case, so we can remove it and simplify. Also removed related database calls, which were not used by anything else.

So this is how it feels to be Thorsten for 2 hours 🤔 😅 

## Test plan

Tested locally by seeing if perms syncing still works (it does!).
