### PR TITLE
Adds migration to remove `repo_status` from `gitserver_repos`

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -10665,19 +10665,6 @@
           "Comment": ""
         },
         {
-          "Name": "repo_status",
-          "Index": 9,
-          "TypeName": "text",
-          "IsNullable": true,
-          "Default": "",
-          "CharacterMaximumLength": 0,
-          "IsIdentity": false,
-          "IdentityGeneration": "",
-          "IsGenerated": "NEVER",
-          "GenerationExpression": "",
-          "Comment": ""
-        },
-        {
           "Name": "shard_id",
           "Index": 3,
           "TypeName": "text",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1468,7 +1468,6 @@ Indexes:
  last_fetched    | timestamp with time zone |           | not null | now()
  last_changed    | timestamp with time zone |           | not null | now()
  repo_size_bytes | bigint                   |           |          | 
- repo_status     | text                     |           |          | 
 Indexes:
     "gitserver_repos_pkey" PRIMARY KEY, btree (repo_id)
     "gitserver_repos_cloned_status_idx" btree (repo_id) WHERE clone_status = 'cloned'::text

--- a/migrations/frontend/1668184279_remove_git_status_column_from_gitserver_repos_table/down.sql
+++ b/migrations/frontend/1668184279_remove_git_status_column_from_gitserver_repos_table/down.sql
@@ -1,0 +1,3 @@
+-- Undo the changes made in the up migration
+ALTER TABLE gitserver_repos
+ADD repo_status text;

--- a/migrations/frontend/1668184279_remove_git_status_column_from_gitserver_repos_table/down.sql
+++ b/migrations/frontend/1668184279_remove_git_status_column_from_gitserver_repos_table/down.sql
@@ -1,3 +1,3 @@
 -- Undo the changes made in the up migration
 ALTER TABLE gitserver_repos
-ADD repo_status text;
+ADD COLUMN IF NOT EXISTS repo_status text;

--- a/migrations/frontend/1668184279_remove_git_status_column_from_gitserver_repos_table/metadata.yaml
+++ b/migrations/frontend/1668184279_remove_git_status_column_from_gitserver_repos_table/metadata.yaml
@@ -1,0 +1,2 @@
+name: remove git_status column from gitserver_repos table
+parents: [1668174127]

--- a/migrations/frontend/1668184279_remove_git_status_column_from_gitserver_repos_table/up.sql
+++ b/migrations/frontend/1668184279_remove_git_status_column_from_gitserver_repos_table/up.sql
@@ -1,0 +1,14 @@
+-- Perform migration here.
+--
+-- See /migrations/README.md. Highlights:
+--  * Make migrations idempotent (use IF EXISTS)
+--  * Make migrations backwards-compatible (old readers/writers must continue to work)
+--  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement
+--    is defined per file, and that each such statement is NOT wrapped in a transaction.
+--    Each such migration must also declare "createIndexConcurrently: true" in their
+--    associated metadata.yaml file.
+--  * If you are modifying Postgres extensions, you must also declare "privileged: true"
+--    in the associated metadata.yaml file.
+
+ALTER TABLE gitserver_repos
+DROP COLUMN repo_status;

--- a/migrations/frontend/1668184279_remove_git_status_column_from_gitserver_repos_table/up.sql
+++ b/migrations/frontend/1668184279_remove_git_status_column_from_gitserver_repos_table/up.sql
@@ -10,5 +10,4 @@
 --  * If you are modifying Postgres extensions, you must also declare "privileged: true"
 --    in the associated metadata.yaml file.
 
-ALTER TABLE gitserver_repos
-DROP COLUMN repo_status;
+ALTER TABLE gitserver_repos DROP COLUMN IF EXISTS repo_status;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -2168,8 +2168,7 @@ CREATE TABLE gitserver_repos (
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     last_fetched timestamp with time zone DEFAULT now() NOT NULL,
     last_changed timestamp with time zone DEFAULT now() NOT NULL,
-    repo_size_bytes bigint,
-    repo_status text
+    repo_size_bytes bigint
 );
 
 CREATE TABLE gitserver_repos_statistics (


### PR DESCRIPTION
- Reference issue here: https://github.com/sourcegraph/sourcegraph/issues/44009



## Test plan
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
- Tested both `up` and `down` migrations manually.
- Added code host, triggered resync of code host and resync of repos. No errors.