### PR TITLE
Migrate TreePage fetching to newer useConnection, show button to /commits after one load

### DIFF
--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -100,6 +100,7 @@ describe('Repository', () => {
                             ancestors: {
                                 nodes: [
                                     {
+                                        __typename: 'GitCommit',
                                         id: 'CommitID1',
                                         oid: '15c2290dcb37731cc4ee5a2a1c1e5a25b4c28f81',
                                         abbreviatedOID: '15c2290',
@@ -107,6 +108,7 @@ describe('Repository', () => {
                                         subject: 'update LSIF indexing CI workflow',
                                         body: null,
                                         author: {
+                                            __typename: 'Signature',
                                             person: {
                                                 avatarURL: '',
                                                 name: 'garo (they/them)',
@@ -117,6 +119,7 @@ describe('Repository', () => {
                                             date: '2020-04-29T18:40:54Z',
                                         },
                                         committer: {
+                                            __typename: 'Signature',
                                             person: {
                                                 avatarURL: '',
                                                 name: 'GitHub',
@@ -155,6 +158,7 @@ describe('Repository', () => {
                                         },
                                     },
                                     {
+                                        __typename: 'GitCommit',
                                         id: 'CommitID2',
                                         oid: '9e615b1c32cc519130575e8d10d0d0fee8a5eb6c',
                                         abbreviatedOID: '9e615b1',
@@ -162,6 +166,7 @@ describe('Repository', () => {
                                         subject: 'LSIF Indexing Campaign',
                                         body: null,
                                         author: {
+                                            __typename: 'Signature',
                                             person: {
                                                 avatarURL: '',
                                                 name: 'Sourcegraph Bot',
@@ -172,6 +177,7 @@ describe('Repository', () => {
                                             date: '2020-04-29T16:57:20Z',
                                         },
                                         committer: {
+                                            __typename: 'Signature',
                                             person: {
                                                 avatarURL: '',
                                                 name: 'Sourcegraph Bot',
@@ -206,6 +212,7 @@ describe('Repository', () => {
                                         },
                                     },
                                     {
+                                        __typename: 'GitCommit',
                                         id: 'CommitID3',
                                         oid: '96c4efab7ee28f3d1cf1d248a0139cea37368b18',
                                         abbreviatedOID: '96c4efa',
@@ -215,6 +222,7 @@ describe('Repository', () => {
                                         body:
                                             '* Produce LSIF data for each commit for fast/precise code nav\r\n\r\n* Update lsif.yml',
                                         author: {
+                                            __typename: 'Signature',
                                             person: {
                                                 avatarURL: '',
                                                 name: 'Quinn Slack',
@@ -230,6 +238,7 @@ describe('Repository', () => {
                                             date: '2019-12-22T04:34:38Z',
                                         },
                                         committer: {
+                                            __typename: 'Signature',
                                             person: {
                                                 avatarURL: '',
                                                 name: 'GitHub',

--- a/client/web/src/repo/commits/RepositoryCommitsPage.tsx
+++ b/client/web/src/repo/commits/RepositoryCommitsPage.tsx
@@ -1,13 +1,16 @@
-import React, { useEffect, useCallback } from 'react'
+import React, { useEffect, useCallback, useMemo } from 'react'
 
 import * as H from 'history'
+import { RouteComponentProps } from 'react-router'
 import { Observable, of } from 'rxjs'
 import { map } from 'rxjs/operators'
 
 import { createAggregateError } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/http-client'
+import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { RevisionSpec } from '@sourcegraph/shared/src/util/url'
-import { Heading, LoadingSpinner } from '@sourcegraph/wildcard'
+import { Code, Heading, LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { queryGraphQL } from '../../backend/graphql'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
@@ -15,7 +18,9 @@ import { FilteredConnection, FilteredConnectionQueryArguments } from '../../comp
 import { PageTitle } from '../../components/PageTitle'
 import { GitCommitFields, RepositoryFields, RepositoryGitCommitsResult, Scalars } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
+import { basename } from '../../util/path'
 import { externalLinkFieldsFragment } from '../backend'
+import { FilePathBreadcrumbs } from '../FilePathBreadcrumbs'
 
 import { GitCommitNode, GitCommitNodeProps } from './GitCommitNode'
 
@@ -76,14 +81,15 @@ const fetchGitCommits = (args: {
     revspec: string
     first?: number
     query?: string
+    filePath?: string
 }): Observable<NonNullable<RepositoryGitCommitsRepository['commit']>['ancestors']> =>
     queryGraphQL(
         gql`
-            query RepositoryGitCommits($repo: ID!, $revspec: String!, $first: Int, $query: String) {
+            query RepositoryGitCommits($repo: ID!, $revspec: String!, $first: Int, $query: String, $filePath: String) {
                 node(id: $repo) {
                     ... on Repository {
                         commit(rev: $revspec) {
-                            ancestors(first: $first, query: $query) {
+                            ancestors(first: $first, query: $query, path: $filePath) {
                                 nodes {
                                     ...GitCommitFields
                                 }
@@ -111,49 +117,102 @@ const fetchGitCommits = (args: {
         })
     )
 
-export interface RepositoryCommitsPageProps extends RevisionSpec, BreadcrumbSetters {
+export interface RepositoryCommitsPageProps
+    extends RevisionSpec,
+        BreadcrumbSetters,
+        RouteComponentProps<{
+            filePath: string | undefined
+        }>,
+        TelemetryProps {
     repo: RepositoryFields | undefined
 
     history: H.History
     location: H.Location
 }
 
-const BREADCRUMB = { key: 'commits', element: <>Commits</> }
-
-/** A page that shows a repository's commits at the current revision. */
+// A page that shows a repository's commits at the current revision.
 export const RepositoryCommitsPage: React.FunctionComponent<React.PropsWithChildren<RepositoryCommitsPageProps>> = ({
     useBreadcrumb,
     ...props
 }) => {
+    const repo = props.repo
+    const filePath = props.match.params.filePath
+
     useEffect(() => {
-        eventLogger.logViewEvent('RepositoryCommits')
+        eventLogger.logPageView('RepositoryCommits')
     }, [])
 
-    useBreadcrumb(BREADCRUMB)
+    useBreadcrumb(
+        useMemo(() => {
+            if (!filePath || !repo) {
+                return
+            }
+            return {
+                key: 'treePath',
+                className: 'flex-shrink-past-contents',
+                element: (
+                    <FilePathBreadcrumbs
+                        key="path"
+                        repoName={repo.name}
+                        revision={props.revision}
+                        filePath={filePath}
+                        isDir={true}
+                        telemetryService={props.telemetryService}
+                    />
+                ),
+            }
+        }, [filePath, repo, props.revision, props.telemetryService])
+    )
+    // We need to resolve the Commits breadcrumb at the same time as the
+    // filePath, so that the order is correct (otherwise Commits will show
+    // before the path)
+    useBreadcrumb(
+        useMemo(() => {
+            if (!repo) {
+                return
+            }
+            return { key: 'commits', element: <>Commits</> }
+        }, [repo])
+    )
 
     const queryCommits = useCallback(
         (
             args: FilteredConnectionQueryArguments
         ): Observable<NonNullable<RepositoryGitCommitsRepository['commit']>['ancestors']> => {
-            if (!props.repo?.id) {
+            if (!repo?.id) {
                 return of()
             }
 
-            return fetchGitCommits({ ...args, repo: props.repo?.id, revspec: props.revision })
+            return fetchGitCommits({ ...args, repo: repo?.id, revspec: props.revision, filePath })
         },
-        [props.repo?.id, props.revision]
+        [repo?.id, props.revision, filePath]
     )
 
-    if (!props.repo) {
+    if (!repo) {
         return <LoadingSpinner />
+    }
+
+    const getPageTitle = (): string => {
+        const repoString = displayRepoName(repo.name)
+        if (filePath) {
+            return `Commits - ${basename(filePath)} - ${repoString}`
+        }
+        return `Commits - ${repoString}`
     }
 
     return (
         <div className={styles.repositoryCommitsPage} data-testid="commits-page">
-            <PageTitle title="Commits" />
+            <PageTitle title={getPageTitle()} />
+
             <div className={styles.content}>
                 <Heading as="h2" styleAs="h1">
-                    View commits from this repository
+                    {filePath ? (
+                        <>
+                            View commits inside <Code>{basename(filePath)}</Code>
+                        </>
+                    ) : (
+                        <>View commits from this repository</>
+                    )}
                 </Heading>
                 <FilteredConnection<
                     GitCommitFields,

--- a/client/web/src/repo/commits/RepositoryCommitsPage.tsx
+++ b/client/web/src/repo/commits/RepositoryCommitsPage.tsx
@@ -121,7 +121,7 @@ export interface RepositoryCommitsPageProps
     extends RevisionSpec,
         BreadcrumbSetters,
         RouteComponentProps<{
-            filePath: string | undefined
+            filePath?: string | undefined
         }>,
         TelemetryProps {
     repo: RepositoryFields | undefined

--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -115,7 +115,7 @@ export const RepoCommits: React.FunctionComponent<
 
 const blobPath = '/-/:objectType(blob)/:filePath*'
 const treePath = '/-/:objectType(tree)/:filePath*'
-export const commitsPath = '/-/commits'
+export const commitsPath = '/-/commits/:filePath*'
 
 export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] = [
     ...[

--- a/client/web/src/repo/tree/HomeTab.tsx
+++ b/client/web/src/repo/tree/HomeTab.tsx
@@ -32,7 +32,6 @@ import {
     GitCommitFields,
     Scalars,
     TreeCommits2Result,
-    TreeCommitsResult,
     TreePageRepositoryFields,
 } from '../../graphql-operations'
 import { fetchBlob } from '../blob/backend'

--- a/client/web/src/repo/tree/HomeTab.tsx
+++ b/client/web/src/repo/tree/HomeTab.tsx
@@ -7,8 +7,8 @@ import { Observable } from 'rxjs'
 import { catchError, map, mapTo, startWith, switchMap } from 'rxjs/operators'
 
 import { ErrorMessage } from '@sourcegraph/branded/src/components/alerts'
-import { asError, ErrorLike, pluralize, encodeURIPathComponent } from '@sourcegraph/common'
-import { gql, useQuery } from '@sourcegraph/http-client'
+import { asError, ErrorLike, pluralize, encodeURIPathComponent, memoizeObservable } from '@sourcegraph/common'
+import { dataOrThrowErrors, gql, useQuery } from '@sourcegraph/http-client'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import {
     Button,
@@ -22,6 +22,7 @@ import {
     ButtonLink,
 } from '@sourcegraph/wildcard'
 
+import { queryGraphQL } from '../../backend/graphql'
 import { BatchChangesProps } from '../../batches'
 import { CodeIntelligenceProps } from '../../codeintel'
 import { FilteredConnection } from '../../components/FilteredConnection'
@@ -29,16 +30,70 @@ import {
     GetRepoBatchChangesSummaryResult,
     GetRepoBatchChangesSummaryVariables,
     GitCommitFields,
+    Scalars,
+    TreeCommits2Result,
+    TreeCommitsResult,
     TreePageRepositoryFields,
 } from '../../graphql-operations'
 import { fetchBlob } from '../blob/backend'
 import { BlobInfo } from '../blob/Blob'
 import { RenderedFile } from '../blob/RenderedFile'
-import { GitCommitNode, GitCommitNodeProps } from '../commits/GitCommitNode'
-
-import { fetchTreeCommits, TreeCommitsRepositoryCommit } from './TreePageContent'
+import { GitCommitNodeProps, GitCommitNode } from '../commits/GitCommitNode'
+import { gitCommitFragment } from '../commits/RepositoryCommitsPage'
 
 import styles from './HomeTab.module.scss'
+
+type TreeCommitsRepositoryCommit = NonNullable<
+    Extract<TreeCommits2Result['node'], { __typename: 'Repository' }>['commit']
+>
+
+const fetchTreeCommits = memoizeObservable(
+    (args: {
+        repo: Scalars['ID']
+        revspec: string
+        first?: number
+        filePath?: string
+        after?: string
+    }): Observable<TreeCommitsRepositoryCommit['ancestors']> =>
+        queryGraphQL(
+            gql`
+                query TreeCommits2($repo: ID!, $revspec: String!, $first: Int, $filePath: String, $after: String) {
+                    node(id: $repo) {
+                        __typename
+                        ... on Repository {
+                            commit(rev: $revspec) {
+                                ancestors(first: $first, path: $filePath, after: $after) {
+                                    nodes {
+                                        ...GitCommitFields
+                                    }
+                                    pageInfo {
+                                        hasNextPage
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                ${gitCommitFragment}
+            `,
+            args
+        ).pipe(
+            map(dataOrThrowErrors),
+            map(data => {
+                if (!data.node) {
+                    throw new Error('Repository not found')
+                }
+                if (data.node.__typename !== 'Repository') {
+                    throw new Error('Node is not a Repository')
+                }
+                if (!data.node.commit) {
+                    throw new Error('Commit not found')
+                }
+                return data.node.commit.ancestors
+            })
+        ),
+    args => `${args.repo}:${args.revspec}:${String(args.first)}:${String(args.filePath)}:${String(args.after)}`
+)
 
 interface Props extends SettingsCascadeProps, CodeIntelligenceProps, BatchChangesProps {
     repo: TreePageRepositoryFields

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -352,6 +352,7 @@ export const TreePage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                                             path={`${treeOrError.url}/-/commits/tab`}
                                             render={routeComponentProps => (
                                                 <RepoCommits
+                                                    filePath={filePath}
                                                     repo={repo}
                                                     revision={revision || ''}
                                                     useBreadcrumb={useBreadcrumb}

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -349,10 +349,9 @@ export const TreePage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                                             )}
                                         />
                                         <Route
-                                            path={`${treeOrError.url}/-/commits/tab`}
+                                            path={`${treeOrError.url}/-/commits/tab/:filePath*`}
                                             render={routeComponentProps => (
                                                 <RepoCommits
-                                                    filePath={filePath}
                                                     repo={repo}
                                                     revision={revision || ''}
                                                     useBreadcrumb={useBreadcrumb}

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -117,8 +117,6 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
         },
     })
 
-    console.log(connection)
-
     // We store the refetchAll callback in a ref since it will update when
     // variables or result length change and we need to call an up-to-date
     // version in the useEffect below to refetch the proper results.

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -177,8 +177,7 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
 
     const { extensionsController } = props
 
-    const showLinkToCommitsPage =
-        connection && hasNextPage && filePath === '' && connection.nodes.length > TREE_COMMITS_PER_PAGE
+    const showLinkToCommitsPage = connection && hasNextPage && connection.nodes.length > TREE_COMMITS_PER_PAGE
 
     return (
         <>
@@ -255,7 +254,9 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
                         />
                         {hasNextPage ? (
                             showLinkToCommitsPage ? (
-                                <Link to={`${tree.url}/-/commits`}>Show all commits</Link>
+                                <Link to={`${repo.url}/-/commits${filePath ? `/${filePath}` : ''}`}>
+                                    Show all commits
+                                </Link>
                             ) : (
                                 <ShowMoreButton centered={true} onClick={fetchMore} />
                             )

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -117,6 +117,8 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
         },
     })
 
+    console.log(connection)
+
     // We store the refetchAll callback in a ref since it will update when
     // variables or result length change and we need to call an up-to-date
     // version in the useEffect below to refetch the proper results.

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -16,7 +16,7 @@ import { TreeFields } from '@sourcegraph/shared/src/graphql-operations'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Button, Heading, Link, Text, useObservable } from '@sourcegraph/wildcard'
+import { Button, Heading, Link, useObservable } from '@sourcegraph/wildcard'
 
 import { getFileDecorations } from '../../backend/features'
 import { useConnection } from '../../components/FilteredConnection/hooks/useConnection'

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -1,13 +1,12 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import classNames from 'classnames'
-import { formatISO, subYears } from 'date-fns'
+import formatISO from 'date-fns/formatISO'
+import subYears from 'date-fns/subYears'
 import * as H from 'history'
-import { Observable } from 'rxjs'
-import { map } from 'rxjs/operators'
 
+import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { ContributableMenu } from '@sourcegraph/client-api'
-import { memoizeObservable, pluralize } from '@sourcegraph/common'
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
 import { ActionItem } from '@sourcegraph/shared/src/actions/ActionItem'
 import { ActionsContainer } from '@sourcegraph/shared/src/actions/ActionsContainer'
@@ -17,70 +16,53 @@ import { TreeFields } from '@sourcegraph/shared/src/graphql-operations'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Button, Heading, Text, useObservable } from '@sourcegraph/wildcard'
+import { Button, Heading, Link, Text, useObservable } from '@sourcegraph/wildcard'
 
 import { getFileDecorations } from '../../backend/features'
-import { queryGraphQL } from '../../backend/graphql'
-import { FilteredConnection } from '../../components/FilteredConnection'
-import { GitCommitFields, Scalars, TreeCommitsResult, TreePageRepositoryFields } from '../../graphql-operations'
-import { GitCommitNodeProps, GitCommitNode } from '../commits/GitCommitNode'
+import { useConnection } from '../../components/FilteredConnection/hooks/useConnection'
+import {
+    ConnectionContainer,
+    ConnectionList,
+    ConnectionLoading,
+    ConnectionSummary,
+    ShowMoreButton,
+    SummaryContainer,
+} from '../../components/FilteredConnection/ui'
+import {
+    GitCommitFields,
+    TreeCommitsResult,
+    TreeCommitsVariables,
+    TreePageRepositoryFields,
+} from '../../graphql-operations'
+import { GitCommitNode } from '../commits/GitCommitNode'
 import { gitCommitFragment } from '../commits/RepositoryCommitsPage'
 
 import { TreeEntriesSection } from './TreeEntriesSection'
 
 import styles from './TreePage.module.scss'
 
-export type TreeCommitsRepositoryCommit = NonNullable<
-    Extract<TreeCommitsResult['node'], { __typename: 'Repository' }>['commit']
->
+const TREE_COMMITS_PER_PAGE = 10
 
-export const fetchTreeCommits = memoizeObservable(
-    (args: {
-        repo: Scalars['ID']
-        revspec: string
-        first?: number
-        filePath?: string
-        after?: string
-    }): Observable<TreeCommitsRepositoryCommit['ancestors']> =>
-        queryGraphQL(
-            gql`
-                query TreeCommits($repo: ID!, $revspec: String!, $first: Int, $filePath: String, $after: String) {
-                    node(id: $repo) {
-                        __typename
-                        ... on Repository {
-                            commit(rev: $revspec) {
-                                ancestors(first: $first, path: $filePath, after: $after) {
-                                    nodes {
-                                        ...GitCommitFields
-                                    }
-                                    pageInfo {
-                                        hasNextPage
-                                    }
-                                }
-                            }
+const TREE_COMMITS_QUERY = gql`
+    query TreeCommits($repo: ID!, $revspec: String!, $first: Int, $filePath: String, $after: String) {
+        node(id: $repo) {
+            __typename
+            ... on Repository {
+                commit(rev: $revspec) {
+                    ancestors(first: $first, path: $filePath, after: $after) {
+                        nodes {
+                            ...GitCommitFields
+                        }
+                        pageInfo {
+                            hasNextPage
                         }
                     }
                 }
-                ${gitCommitFragment}
-            `,
-            args
-        ).pipe(
-            map(dataOrThrowErrors),
-            map(data => {
-                if (!data.node) {
-                    throw new Error('Repository not found')
-                }
-                if (data.node.__typename !== 'Repository') {
-                    throw new Error('Node is not a Repository')
-                }
-                if (!data.node.commit) {
-                    throw new Error('Commit not found')
-                }
-                return data.node.commit.ancestors
-            })
-        ),
-    args => `${args.repo}:${args.revspec}:${String(args.first)}:${String(args.filePath)}:${String(args.after)}`
-)
+            }
+        }
+    }
+    ${gitCommitFragment}
+`
 
 interface TreePageContentProps extends ExtensionsControllerProps, ThemeProps, TelemetryProps, PlatformContextProps {
     filePath: string
@@ -100,6 +82,58 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
     ...props
 }) => {
     const [showOlderCommits, setShowOlderCommits] = useState(false)
+    const after = useMemo(() => (showOlderCommits ? null : formatISO(subYears(Date.now(), 1))), [showOlderCommits])
+
+    const { connection, error, loading, hasNextPage, fetchMore, refetchAll } = useConnection<
+        TreeCommitsResult,
+        TreeCommitsVariables,
+        GitCommitFields
+    >({
+        query: TREE_COMMITS_QUERY,
+        variables: {
+            repo: repo.id,
+            revspec: revision || '',
+            first: TREE_COMMITS_PER_PAGE,
+            filePath,
+            after,
+        },
+        getConnection: result => {
+            const { node } = dataOrThrowErrors(result)
+
+            if (!node) {
+                return { nodes: [] }
+            }
+            if (node.__typename !== 'Repository') {
+                return { nodes: [] }
+            }
+            if (!node.commit?.ancestors) {
+                return { nodes: [] }
+            }
+
+            return node.commit.ancestors
+        },
+        options: {
+            fetchPolicy: 'cache-first',
+        },
+    })
+
+    // We store the refetchAll callback in a ref since it will update when
+    // variables or result length change and we need to call an up-to-date
+    // version in the useEffect below to refetch the proper results.
+    //
+    // TODO: See if we can make refetchAll stable
+    const refetchAllRef = useRef(refetchAll)
+    useEffect(() => {
+        refetchAllRef.current = refetchAll
+    }, [refetchAll])
+
+    useEffect(() => {
+        if (showOlderCommits && refetchAllRef.current) {
+            // Updating the variables alone is not enough to force a loading
+            // indicator to show, so we need to refetch the results.
+            refetchAllRef.current()
+        }
+    }, [showOlderCommits])
 
     const fileDecorationsByPath =
         useObservable<FileDecorationsByPath>(
@@ -116,26 +150,20 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
             )
         ) ?? {}
 
-    const queryCommits = useCallback(
-        (args: { first?: number }): Observable<TreeCommitsRepositoryCommit['ancestors']> => {
-            const after: string | undefined = showOlderCommits ? undefined : formatISO(subYears(Date.now(), 1))
-            return fetchTreeCommits({
-                ...args,
-                repo: repo.id,
-                revspec: revision || '',
-                filePath,
-                after,
-            })
-        },
-        [filePath, repo.id, revision, showOlderCommits]
-    )
+    const onShowOlderCommitsClicked = useCallback((event: React.MouseEvent): void => {
+        event.preventDefault()
+        setShowOlderCommits(true)
+    }, [])
 
-    const onShowOlderCommitsClicked = useCallback(
-        (event: React.MouseEvent): void => {
-            event.preventDefault()
-            setShowOlderCommits(true)
-        },
-        [setShowOlderCommits]
+    const showAllCommits = (
+        <Button
+            className="test-tree-page-show-all-commits"
+            onClick={onShowOlderCommitsClicked}
+            variant="secondary"
+            size="sm"
+        >
+            Show commits older than one year
+        </Button>
     )
 
     const emptyElement = showOlderCommits ? (
@@ -143,39 +171,14 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
     ) : (
         <div className="test-tree-page-no-recent-commits">
             <Text className="mb-2">No commits in this tree in the past year.</Text>
-            <Button
-                className="test-tree-page-show-all-commits"
-                onClick={onShowOlderCommitsClicked}
-                variant="secondary"
-                size="sm"
-            >
-                Show all commits
-            </Button>
-        </div>
-    )
-
-    const TotalCountSummary: React.FunctionComponent<React.PropsWithChildren<{ totalCount: number }>> = ({
-        totalCount,
-    }) => (
-        <div className="mt-2">
-            {showOlderCommits ? (
-                <>
-                    {totalCount} total {pluralize('commit', totalCount)} in this tree.
-                </>
-            ) : (
-                <>
-                    <Text className="mb-2">
-                        {totalCount} {pluralize('commit', totalCount)} in this tree in the past year.
-                    </Text>
-                    <Button onClick={onShowOlderCommitsClicked} variant="secondary" size="sm">
-                        Show all commits
-                    </Button>
-                </>
-            )}
+            {showAllCommits}
         </div>
     )
 
     const { extensionsController } = props
+
+    const showLinkToCommitsPage =
+        connection && hasNextPage && filePath === '' && connection.nodes.length > TREE_COMMITS_PER_PAGE
 
     return (
         <>
@@ -218,35 +221,49 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
                 </ActionsContainer>
             ) : null}
 
-            <div className={styles.section}>
+            <ConnectionContainer className={styles.section}>
                 <Heading as="h3" styleAs="h2">
                     Changes
                 </Heading>
-                <FilteredConnection<
-                    GitCommitFields,
-                    Pick<GitCommitNodeProps, 'className' | 'compact' | 'messageSubjectClassName' | 'wrapperElement'>
-                >
-                    location={props.location}
-                    className="mt-2"
-                    listClassName="list-group list-group-flush"
-                    noun="commit in this tree"
-                    pluralNoun="commits in this tree"
-                    queryConnection={queryCommits}
-                    nodeComponent={GitCommitNode}
-                    nodeComponentProps={{
-                        className: classNames('list-group-item', styles.gitCommitNode),
-                        messageSubjectClassName: styles.gitCommitNodeMessageSubject,
-                        compact: true,
-                        wrapperElement: 'li',
-                    }}
-                    updateOnChange={`${repo.name}:${revision}:${filePath}:${String(showOlderCommits)}`}
-                    defaultFirst={7}
-                    useURLQuery={false}
-                    hideSearch={true}
-                    emptyElement={emptyElement}
-                    totalCountSummaryComponent={TotalCountSummary}
-                />
-            </div>
+
+                {error && <ErrorAlert error={error} className="w-100 mb-0" />}
+                <ConnectionList className="list-group list-group-flush w-100">
+                    {connection?.nodes.map(node => (
+                        <GitCommitNode
+                            key={node.id}
+                            className={classNames('list-group-item', styles.gitCommitNode)}
+                            messageSubjectClassName={styles.gitCommitNodeMessageSubject}
+                            compact={true}
+                            wrapperElement="li"
+                            node={node}
+                        />
+                    ))}
+                </ConnectionList>
+                {loading && <ConnectionLoading />}
+                {connection && (
+                    <SummaryContainer centered={true}>
+                        <ConnectionSummary
+                            centered={true}
+                            first={TREE_COMMITS_PER_PAGE}
+                            connection={connection}
+                            noun={showOlderCommits ? 'commit in this tree' : 'commit in this tree in the past year'}
+                            pluralNoun={
+                                showOlderCommits ? 'commits in this tree' : 'commits in this tree in the past year'
+                            }
+                            hasNextPage={hasNextPage}
+                            emptyElement={emptyElement}
+                        />
+                        {hasNextPage ? (
+                            showLinkToCommitsPage ? (
+                                <Link to={`${tree.url}/-/commits`}>Show all commits</Link>
+                            ) : (
+                                <ShowMoreButton centered={true} onClick={fetchMore} />
+                            )
+                        ) : null}
+                        {!hasNextPage && !showOlderCommits ? showAllCommits : null}
+                    </SummaryContainer>
+                )}
+            </ConnectionContainer>
         </>
     )
 }

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -166,15 +166,6 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
         </Button>
     )
 
-    const emptyElement = showOlderCommits ? (
-        <>No commits in this tree.</>
-    ) : (
-        <div className="test-tree-page-no-recent-commits">
-            <Text className="mb-2">No commits in this tree in the past year.</Text>
-            {showAllCommits}
-        </div>
-    )
-
     const { extensionsController } = props
 
     const showLinkToCommitsPage = connection && hasNextPage && connection.nodes.length > TREE_COMMITS_PER_PAGE
@@ -245,12 +236,10 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
                             centered={true}
                             first={TREE_COMMITS_PER_PAGE}
                             connection={connection}
-                            noun={showOlderCommits ? 'commit in this tree' : 'commit in this tree in the past year'}
-                            pluralNoun={
-                                showOlderCommits ? 'commits in this tree' : 'commits in this tree in the past year'
-                            }
+                            noun={showOlderCommits ? 'commit' : 'commit in the past year'}
+                            pluralNoun={showOlderCommits ? 'commits' : 'commits in the past year'}
                             hasNextPage={hasNextPage}
-                            emptyElement={emptyElement}
+                            emptyElement={null}
                         />
                         {hasNextPage ? (
                             showLinkToCommitsPage ? (


### PR DESCRIPTION
Closes #43685

This PR updates the "Changes" section in the repo files view. We now only show at most two pages of commits in this view and, after that, will link to the commits page instead where we display more information and will be improving the pagination further:

<img width="1326" alt="Screenshot 2022-11-16 at 15 01 37" src="https://user-images.githubusercontent.com/458591/202200749-fb2733c6-ddd5-4a96-ae0e-a73264f8ea5e.png">

Since the "Changes" section was showing both for the repo root but also for sub-directories and the commits page was not, I also updated the commits page to now work for sub-directories:

<img width="1282" alt="Screenshot 2022-11-16 at 15 02 04" src="https://user-images.githubusercontent.com/458591/202200844-76014e3f-8ab3-462b-9e85-60e1b958060a.png">

Note: The commits page for sub-directories is currently only accessible via pressing the Show More button inside the Changes section. We might consider adding a dedicated link somewhere cc @AlicjaSuska 

## Test plan

Manually tested the changes: https://www.loom.com/share/64578eb9edd3484eb19cc7dbe345d14e

Made sure that the integration tests still work:

```
yarn test-integration client/web/src/integration/repository.test.ts
        ✓ loads when accessed with a repo url (4898ms)

  Visited routes:
    /github.com/sourcegraph/jsonrpc2
    /github.com/sourcegraph/jsonrpc2/-/blob/async.go
    /github.com/sourcegraph/jsonrpc2/-/commit/15c2290dcb37731cc4ee5a2a1c1e5a25b4c28f81


  1 passing (6s)

α sourcegraph (ps/tree-commits-improvements)✗
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-tree-commits-improvements.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

