### PR TITLE
codeintel: Optimize repository selection for indexing query

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/store/store_repositories.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_repositories.go
@@ -51,6 +51,8 @@ func (s *store) GetRepositoriesForIndexScan(ctx context.Context, table, column s
 
 func quote(s string) *sqlf.Query { return sqlf.Sprintf(s) }
 
+// toot
+
 const getRepositoriesForIndexScanQuery = `
 WITH
 repositories_matching_policy AS (

--- a/enterprise/internal/codeintel/uploads/internal/store/store_repositories.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_repositories.go
@@ -54,48 +54,51 @@ func quote(s string) *sqlf.Query { return sqlf.Sprintf(s) }
 const getRepositoriesForIndexScanQuery = `
 WITH
 repositories_matching_policy AS ((
-	SELECT r.id FROM repo r WHERE EXISTS (
-		SELECT 1
-		FROM lsif_configuration_policies p
-		WHERE
-			p.indexing_enabled AND
-			p.repository_id IS NULL AND
-			p.repository_patterns IS NULL AND
-			%s -- completely enable or disable this query
-	)
-	ORDER BY stars DESC NULLS LAST, id
-	%s
-) UNION ALL (
-	SELECT p.repository_id AS id
-	FROM lsif_configuration_policies p
-	WHERE
-		p.indexing_enabled AND
-		p.repository_id IS NOT NULL
-) UNION ALL (
-	SELECT rpl.repo_id AS id
-	FROM lsif_configuration_policies p
-	JOIN lsif_configuration_policies_repository_pattern_lookup rpl ON rpl.policy_id = p.id
-	WHERE p.indexing_enabled
-)),
-candidate_repositories AS (
-	SELECT r.id AS id
+	SELECT r.id
 	FROM repo r
 	WHERE
 		r.deleted_at IS NULL AND
 		r.blocked IS NULL AND
-		r.id IN (SELECT id FROM repositories_matching_policy)
-),
+		EXISTS (
+			SELECT 1
+			FROM lsif_configuration_policies p
+			WHERE
+				p.indexing_enabled AND
+				p.repository_id IS NULL AND
+				p.repository_patterns IS NULL
+		) AND
+		%s -- completely enable or disable this query
+	ORDER BY stars DESC NULLS LAST, id
+	%s
+) UNION ALL (
+	SELECT r.id
+	FROM repo r
+	JOIN lsif_configuration_policies p ON p.repository_id = r.id
+	WHERE
+		r.deleted_at IS NULL AND
+		r.blocked IS NULL AND
+		p.indexing_enabled
+) UNION ALL (
+	SELECT r.id
+	FROM repo r
+	JOIN lsif_configuration_policies_repository_pattern_lookup rpl ON rpl.repo_id = r.id
+	JOIN lsif_configuration_policies p ON p.id = rpl.policy_id
+	WHERE
+		r.deleted_at IS NULL AND
+		r.blocked IS NULL AND
+		p.indexing_enabled
+)),
 repositories AS (
-	SELECT cr.id
-	FROM candidate_repositories cr
-	LEFT JOIN %s lrs ON lrs.repository_id = cr.id
+	SELECT rmp.id
+	FROM repositories_matching_policy rmp
+	LEFT JOIN %s lrs ON lrs.repository_id = rmp.id
 
 	-- Ignore records that have been checked recently. Note this condition is
 	-- true for a null {column_name} (which has never been checked).
 	WHERE (%s - lrs.{column_name} > (%s * '1 second'::interval)) IS DISTINCT FROM FALSE
 	ORDER BY
 		lrs.{column_name} NULLS FIRST,
-		cr.id -- tie breaker
+		rmp.id -- tie breaker
 	LIMIT %s
 )
 INSERT INTO %s (repository_id, {column_name})


### PR DESCRIPTION
**Before**:

The original query had the following shape, where we would select all repository_ids attached to an active indexing policy (we'd union three sets of` lsif_configuration_policies`, two relevant here, each returning some subset of results). We'd then join that to the `repo` table, kicking out anything that's deleted or blocked. We'd then order the repos by descending recency of indexing scans, and limit the first 2500.

```sql
EXPLAIN ANALYZE
WITH
repositories_matching_policy AS (
    SELECT p.repository_id AS id
    FROM lsif_configuration_policies p
    WHERE
        p.indexing_enabled AND
        p.repository_id IS NOT NULL

    UNION ALL

    SELECT rpl.repo_id AS id
    FROM lsif_configuration_policies p
    JOIN lsif_configuration_policies_repository_pattern_lookup rpl ON rpl.policy_id = p.id
    WHERE p.indexing_enabled
),
candidate_repositories AS (
    SELECT r.id AS id
    FROM repo r
    WHERE
        r.deleted_at IS NULL AND
        r.blocked IS NULL AND
        r.id IN (SELECT id FROM repositories_matching_policy)
)
SELECT cr.id
FROM candidate_repositories cr
LEFT JOIN lsif_last_index_scan lrs ON lrs.repository_id = cr.id
WHERE (NOW() - lrs.last_index_scan_at > '24 hours'::interval) IS DISTINCT FROM FALSE
ORDER BY
    lrs.last_index_scan_at NULLS FIRST,
    cr.id
LIMIT 2500;
```

This query plan returns 28M intermediate rows from the `lsif_configuration_policies_repository_pattern_lookup` table, the vast majority of which are later thrown out in the hash join filter. Our goal is to reduce the size of this intermediate result set.

```
QUERY PLAN
----------
 Limit  (cost=261291.00..261297.25 rows=2500 width=12) (actual time=21127.943..21127.962 rows=0 loops=1)
   ->  Sort  (cost=261291.00..263250.73 rows=783891 width=12) (actual time=21127.941..21127.960 rows=0 loops=1)
         Sort Key: lrs.last_index_scan_at NULLS FIRST, r.id
         Sort Method: quicksort  Memory: 25kB
         ->  Hash Left Join  (cost=208732.60..213129.87 rows=783891 width=12) (actual time=21127.932..21127.951 rows=0 loops=1)
               Hash Cond: (r.id = lrs.repository_id)
               Filter: (((now() - lrs.last_index_scan_at) > '24:00:00'::interval) IS DISTINCT FROM false)
               Rows Removed by Filter: 2842246
               ->  Nested Loop  (cost=83550.40..83832.24 rows=1567782 width=4) (actual time=3198.153..16331.139 rows=2842246 loops=1)
                     ->  HashAggregate  (cost=83549.96..83551.96 rows=200 width=4) (actual time=3198.127..4841.937 rows=2842246 loops=1)
                           Group Key: p.repository_id
                           ->  Append  (cost=0.00..79107.84 rows=1776851 width=4) (actual time=0.052..1581.737 rows=2842249 loops=1)
                                 ->  Seq Scan on lsif_configuration_policies p  (cost=0.00..9.08 rows=2 width=4) (actual time=0.052..0.054 rows=3 loops=1)
                                       Filter: (indexing_enabled AND (repository_id IS NOT NULL))
                                       Rows Removed by Filter: 5
                                 ->  Hash Join  (cost=9.14..52445.99 rows=1776849 width=4) (actual time=0.029..1278.494 rows=2842246 loops=1)
                                       Hash Cond: (rpl.policy_id = p_1.id)
                                       ->  Seq Scan on lsif_configuration_policies_repository_pattern_lookup rpl  (cost=0.00..41020.59 rows=2842959 width=8) (actual time=0.005..289.601 rows=2842246 loops=1)
                                       ->  Hash  (cost=9.08..9.08 rows=5 width=4) (actual time=0.017..0.018 rows=5 loops=1)
                                             Buckets: 1024  Batches: 1  Memory Usage: 9kB
                                             ->  Seq Scan on lsif_configuration_policies p_1  (cost=0.00..9.08 rows=5 width=4) (actual time=0.013..0.015 rows=5 loops=1)
                                                   Filter: indexing_enabled
                                                   Rows Removed by Filter: 3
                     ->  Index Only Scan using repo_id_idx on repo r  (cost=0.43..1.56 rows=1 width=4) (actual time=0.004..0.004 rows=1 loops=2842246)
                           Index Cond: (id = p.repository_id)
                           Heap Fetches: 107582
               ->  Hash  (cost=88363.20..88363.20 rows=2945520 width=12) (actual time=1461.595..1461.595 rows=2951482 loops=1)
                     Buckets: 4194304  Batches: 1  Memory Usage: 159590kB
                     ->  Seq Scan on lsif_last_index_scan lrs  (cost=0.00..88363.20 rows=2945520 width=12) (actual time=0.027..630.136 rows=2951482 loops=1)
 Planning Time: 1.030 ms
 Execution Time: 21170.969 ms
(31 rows)
```

**After**:

The change we make is rather simple: combine the top two CTEs into one. The goal here is to reduce intermediate result sets by trying to move as many conditions as early as possible. We now join directly to the `repo` table when scanning `lsif_configuration_policies` or `lsif_configuration_policies_repository_pattern_lookup`. This allows us to check for many relevant conditions related to the join at join time rather than later.

```sql
EXPLAIN ANALYZE
WITH
repositories_matching_policy AS (
    SELECT r.id
    FROM repo r
    JOIN lsif_configuration_policies p ON p.repository_id = r.id
    WHERE
        r.deleted_at IS NULL AND
        r.blocked IS NULL AND
        p.indexing_enabled

    UNION ALL

    SELECT r.id
    FROM repo r
    JOIN lsif_configuration_policies_repository_pattern_lookup rpl ON rpl.repo_id = r.id
    JOIN lsif_configuration_policies p ON p.id = rpl.policy_id
    WHERE
        r.deleted_at IS NULL AND
        r.blocked IS NULL AND
        p.indexing_enabled
)
SELECT cr.id
FROM repositories_matching_policy cr
LEFT JOIN lsif_last_index_scan lrs ON lrs.repository_id = cr.id
WHERE (NOW() - lrs.last_index_scan_at > '24 hours'::interval) IS DISTINCT FROM FALSE
ORDER BY
    lrs.last_index_scan_at NULLS FIRST,
    cr.id
LIMIT 2500;
```

I didn't have a super specific query plan in mind here - just shaking some stuff loose and see what stands out that we can take advantage of. This query is about 4x faster, but only becasue Postgres is choosing to do parallelized hash joins and appends - we are now doing two independent scans of the `repo` table and joining results.

Probably more to look into here, but this is a good improvement to ship without sinking too much time into it.

```
QUERY PLAN
----------
 Limit  (cost=292411.76..292703.44 rows=2500 width=12) (actual time=4572.243..4676.996 rows=1 loops=1)
   ->  Gather Merge  (cost=292411.76..353385.31 rows=522594 width=12) (actual time=4572.241..4676.993 rows=1 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Sort  (cost=291411.73..292064.98 rows=261297 width=12) (actual time=4562.126..4562.133 rows=0 loops=3)
               Sort Key: lrs.last_index_scan_at NULLS FIRST, r.id
               Sort Method: quicksort  Memory: 25kB
               Worker 0:  Sort Method: quicksort  Memory: 25kB
               Worker 1:  Sort Method: quicksort  Memory: 25kB
               ->  Parallel Hash Left Join  (cost=95911.15..275358.02 rows=261297 width=12) (actual time=4079.264..4562.084 rows=0 loops=3)
                     Hash Cond: (r.id = lrs.repository_id)
                     Filter: (((now() - lrs.last_index_scan_at) > '24:00:00'::interval) IS DISTINCT FROM false)
                     Rows Removed by Filter: 947417
                     ->  Parallel Append  (cost=0.43..176154.96 rows=1254225 width=4) (actual time=553.974..3155.531 rows=947417 loops=3)
                           ->  Nested Loop  (cost=0.43..13.67 rows=1 width=4) (actual time=0.136..0.160 rows=3 loops=1)
                                 ->  Seq Scan on lsif_configuration_policies p  (cost=0.00..11.02 rows=1 width=4) (actual time=0.099..0.101 rows=5 loops=1)
                                       Filter: indexing_enabled
                                       Rows Removed by Filter: 3
                                 ->  Index Only Scan using repo_id_idx on repo r  (cost=0.43..2.65 rows=1 width=4) (actual time=0.011..0.011 rows=1 loops=5)
                                       Index Cond: (id = p.repository_id)
                                       Heap Fetches: 0
                           ->  Parallel Hash Join  (cost=41550.30..157327.92 rows=522593 width=4) (actual time=830.815..3056.617 rows=947416 loops=3)
                                 Hash Cond: (r_1.id = rpl.repo_id)
                                 ->  Parallel Index Only Scan using repo_stars_desc_id_desc_idx on repo r_1  (cost=0.43..103293.62 rows=2748523 width=4) (actual time=0.027..871.066 rows=2210055 loops=3)
                                       Heap Fetches: 337895
                                 ->  Parallel Hash  (cost=34146.33..34146.33 rows=592283 width=4) (actual time=827.127..827.130 rows=947416 loops=3)
                                       Buckets: 4194304 (originally 2097152)  Batches: 1 (originally 1)  Memory Usage: 160384kB
                                       ->  Hash Join  (cost=11.03..34146.33 rows=592283 width=4) (actual time=0.114..410.114 rows=947416 loops=3)
                                             Hash Cond: (rpl.policy_id = p_1.id)
                                             ->  Parallel Seq Scan on lsif_configuration_policies_repository_pattern_lookup rpl  (cost=0.00..24436.66 rows=1184566 width=8) (actual time=0.012..94.876 rows=947416 loops=3)
                                             ->  Hash  (cost=11.02..11.02 rows=1 width=4) (actual time=0.074..0.074 rows=5 loops=3)
                                                   Buckets: 1024  Batches: 1  Memory Usage: 9kB
                                                   ->  Seq Scan on lsif_configuration_policies p_1  (cost=0.00..11.02 rows=1 width=4) (actual time=0.059..0.062 rows=5 loops=3)
                                                         Filter: indexing_enabled
                                                         Rows Removed by Filter: 3
                     ->  Parallel Hash  (cost=75353.65..75353.65 rows=1644565 width=12) (actual time=630.844..630.845 rows=983829 loops=3)
                           Buckets: 4194304  Batches: 1  Memory Usage: 171296kB
                           ->  Parallel Seq Scan on lsif_last_index_scan lrs  (cost=0.00..75353.65 rows=1644565 width=12) (actual time=0.029..202.240 rows=983829 loops=3)
 Planning Time: 1.134 ms
 Execution Time: 4677.104 ms
(40 rows)
```

## Test plan

Unit tests.