### PR TITLE
dotcom home page AnnouncementBlurb

### DIFF
--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -71,6 +71,7 @@ $theme-colors: (
 
     // Other root palette colors.
     --blue: #{$blue};
+    --blue-02: #c7ffff;
     --indigo: #0864c6;
     --purple: #{$purple};
     --purple-01: #e8d1ff;
@@ -108,6 +109,9 @@ $theme-colors: (
     --header-icon-color: var(--gray-05);
     --tooltip-bg: var(--gray-08);
     --text-disabled: var(--gray-06);
+    
+    // Gradients
+    --saturn-gradient: linear-gradient(90deg, var(--purple-01), var(--blue-02)) border-box;
 
     // Color for the <mark> element and highlighted/hovered tokens.
     --mark-bg-dark: rgba(217, 72, 15, 0.5);

--- a/client/web/src/search/home/AnnouncementBlurb.module.scss
+++ b/client/web/src/search/home/AnnouncementBlurb.module.scss
@@ -9,14 +9,14 @@
     position: absolute;
     z-index: 1;
     inset: 0;
-    border-radius: 5px; /*1*/
-    border: 3px solid transparent; /*2*/
-    background: linear-gradient(90deg,#e8d1ff,#c7ffff) border-box; /*3*/
-    -webkit-mask: /*4*/
+    border-radius: 5px;
+    border: 3px solid transparent;
+    background: var(--saturn-gradient);
+    -webkit-mask:
        linear-gradient(#fff 0 0) padding-box, 
        linear-gradient(#fff 0 0);
-    -webkit-mask-composite: xor; /*5'*/
-            mask-composite: exclude; /*5*/
+    -webkit-mask-composite: xor;
+            mask-composite: exclude;
 }
 
 .link {

--- a/client/web/src/search/home/AnnouncementBlurb.module.scss
+++ b/client/web/src/search/home/AnnouncementBlurb.module.scss
@@ -1,0 +1,25 @@
+.saturn-gradient-border {
+    position: relative;
+    max-width: 800px;
+    text-align: center;
+}
+
+.saturn-gradient-border::after {
+    content: "";
+    position: absolute;
+    z-index: 1;
+    inset: 0;
+    border-radius: 5px; /*1*/
+    border: 3px solid transparent; /*2*/
+    background: linear-gradient(90deg,#e8d1ff,#c7ffff) border-box; /*3*/
+    -webkit-mask: /*4*/
+       linear-gradient(#fff 0 0) padding-box, 
+       linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor; /*5'*/
+            mask-composite: exclude; /*5*/
+}
+
+.link {
+    position: relative;
+    z-index: 5;
+}

--- a/client/web/src/search/home/AnnouncementBlurb.tsx
+++ b/client/web/src/search/home/AnnouncementBlurb.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 
+import { mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
-import { Link } from '@sourcegraph/wildcard'
+import { Link, Icon } from '@sourcegraph/wildcard'
 
 import styles from './AnnouncementBlurb.module.scss'
 
@@ -18,15 +19,20 @@ interface LinkProps {
 }
 
 export const AnnouncementBlurb: React.FunctionComponent<AnnouncementBlurb> = ({ text, link, displayUntil }) => (
-    // Display only if today is not past display cut off date
-    <div className={classNames(new Date() < displayUntil ? 'd-block' : 'd-none',styles.saturnGradientBorder)}>
-        <div className="py-2 px-3">
-            {text}
-            {link && (
-                <Link to={link.link} className={classNames('ml-1', styles.link)} target="_blank" rel="noopener noreferrer">
-                    {link.text}
-                </Link>
-            )}
-        </div>
+    <div>
+        {/* Display only if today is not past display cut off date */}
+        {new Date() < displayUntil && (
+            <div className={styles.saturnGradientBorder}>
+                <div className="py-2 px-3">
+                    {text}
+                    {link && (
+                        <Link to={link.link} className={classNames('ml-1', styles.link)} target="_blank" rel="noopener noreferrer">
+                            {link.text}{' '}
+                            <Icon aria-hidden={true} svgPath={mdiOpenInNew} />
+                        </Link>
+                    )}
+                </div>
+            </div>
+        )}
     </div>
 )

--- a/client/web/src/search/home/AnnouncementBlurb.tsx
+++ b/client/web/src/search/home/AnnouncementBlurb.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+import classNames from 'classnames'
+
+import { Link } from '@sourcegraph/wildcard'
+
+import styles from './AnnouncementBlurb.module.scss'
+
+export interface AnnouncementBlurb {
+    text: string;
+    link?: LinkProps;
+    displayUntil: Date;
+}
+
+interface LinkProps {
+    text: string;
+    link: string;
+}
+
+export const AnnouncementBlurb: React.FunctionComponent<AnnouncementBlurb> = ({ text, link, displayUntil }) => (
+    // Display only if today is not past display cut off date
+    <div className={classNames(new Date() < displayUntil ? 'd-block' : 'd-none',styles.saturnGradientBorder)}>
+        <div className="py-2 px-3">
+            {text}
+            {link && (
+                <Link to={link.link} className={classNames('ml-1', styles.link)} target="_blank" rel="noopener noreferrer">
+                    {link.text}
+                </Link>
+            )}
+        </div>
+    </div>
+)

--- a/client/web/src/search/home/QueryExamplesHomepage.tsx
+++ b/client/web/src/search/home/QueryExamplesHomepage.tsx
@@ -11,6 +11,7 @@ import { Button, H2, H4, Link, Icon, Tabs, TabList, TabPanels, TabPanel, Tab } f
 
 import { eventLogger } from '../../tracking/eventLogger'
 
+import { AnnouncementBlurb } from './AnnouncementBlurb'
 import { exampleQueryColumns } from './QueryExamplesHomepage.constants'
 import { useQueryExamples, QueryExamplesSection } from './useQueryExamples'
 
@@ -135,6 +136,14 @@ export const QueryExamplesHomepage: React.FunctionComponent<QueryExamplesHomepag
                             Use Sourcegraph to search across your team's code.
                         </Link>
                     </div>
+                    <AnnouncementBlurb
+                        displayUntil={new Date('Dec 13, 2022')}
+                        text="Sourcegraph now uses PageRank to power the most relevant OSS search results."
+                        link={{
+                            text: 'Read the blog post.',
+                            link: 'https://about.sourcegraph.com/blog/new-search-ranking'
+                        }}
+                    />
                 </>
             ) : (
                 <div>


### PR DESCRIPTION
Closes #44112 - Adds announcement blurb section to .com's home page. Dynamic component with easy to change props for any non-dev to easily update copy on their own.
![image](https://user-images.githubusercontent.com/59381432/201410535-b07863b1-1ecb-4ff1-8701-fe434e456124.png)


## Test plan
- Test locally on dotcom

## App preview:

- [Web](https://sg-web-becca-homepg-announcement-section.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

