### PR TITLE
Fix metrics scanning when no rows

### DIFF
--- a/cmd/worker/internal/gitserver/servermetrics.go
+++ b/cmd/worker/internal/gitserver/servermetrics.go
@@ -45,7 +45,7 @@ func (j *metricsJob) Routines(startupCtx context.Context, logger log.Logger) ([]
 		defer cancel()
 
 		var count int64
-		err := db.QueryRowContext(ctx, `SELECT SUM(failed_fetch) FROM gitserver_repos_statistics`).Scan(&count)
+		err := db.QueryRowContext(ctx, `SELECT COALESCE(SUM(failed_fetch), 0) FROM gitserver_repos_statistics`).Scan(&count)
 		if err != nil {
 			j.Logger.Error("failed to count repository errors", log.Error(err))
 			return 0
@@ -62,7 +62,7 @@ func (j *metricsJob) Routines(startupCtx context.Context, logger log.Logger) ([]
 		defer cancel()
 
 		var count int64
-		err := db.QueryRowContext(ctx, `SELECT SUM(total) FROM repo_statistics`).Scan(&count)
+		err := db.QueryRowContext(ctx, `SELECT COALESCE(SUM(total), 0) FROM repo_statistics`).Scan(&count)
 		if err != nil {
 			j.Logger.Error("failed to count repositories", log.Error(err))
 			return 0

--- a/internal/repos/metrics.go
+++ b/internal/repos/metrics.go
@@ -252,7 +252,7 @@ where last_fetched < now() - interval '8 hours'
 	}, func() float64 {
 		count, err := scanCount(`
 SELECT
-	SUM(cloned)
+	COALESCE(SUM(cloned), 0)
 FROM
 	repo_statistics
 `)


### PR DESCRIPTION
When no rows exist, or only NULLs are present, these could return NULL which cannot be scanned into an int. This fixes it. Reported here https://sourcegraph.slack.com/archives/C07KZF47K/p1668140073339829



## Test plan

Manually ran to see they work 