### PR TITLE
docs: change button cursor kind to `pointer`

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -18,7 +18,7 @@ The document content can set class names and IDs on elements (for example, Markd
     --breakpoint-md: 768px;
     --breakpoint-lg: 1024px;
     --breakpoint-xl: 1280px;
-    --breakpoint-2xl: 1536px;    
+    --breakpoint-2xl: 1536px;
     --sidebar-breakpoint-width: 800px; /* hide sidebar if narrower */
     --index-breakpoint-width: 1200px; /* show index before (not to the right) if narrower */
 
@@ -320,6 +320,7 @@ body > #sidebar #theme button {
     background-color: transparent;
     font-family: var(--base-font-family);
     font-size: 1rem;
+    cursor: pointer;
 }
 body > #sidebar #theme button:not(.active) {
     color: var(--text-muted);


### PR DESCRIPTION
While reading through the docs, I wanted to change the theme for the page and the buttons below the sidebar confused me a bit because they didn't look clickable (I thought they were disabled). This PR ensures when your mouse is hovered on the buttons, the cursor changes to a pointer.

![CleanShot 2022-11-12 at 16 23 31@2x](https://user-images.githubusercontent.com/25608335/201481165-39e90f1b-d709-42bd-8d1c-4a39d2084a39.png)


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Tested that the doc webpage is rendered fine and all buttons are rendered fine.