### PR TITLE
autoindexing: Fix duplicate inserts into indexes table

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/store/store_repositories.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_repositories.go
@@ -102,7 +102,7 @@ repositories AS (
 	LIMIT %s
 )
 INSERT INTO %s (repository_id, {column_name})
-SELECT r.id, %s::timestamp FROM repositories r
+SELECT DISTINCT r.id, %s::timestamp FROM repositories r
 ON CONFLICT (repository_id) DO UPDATE
 SET {column_name} = %s
 RETURNING repository_id


### PR DESCRIPTION
Should fix the following error on dotcom:

```
│ enterprise/internal/codeintel/uploads.(*Service).GetRepositoriesForIndexScan","Body":"operation.error","Resource":{"service.name":"worker","service.version":"183026_2022-11-11_e18b2ffca276","service.instance.id":"c09c7d89-dce4-435e-af02-e276 │
│ d6022055"},"Attributes":{"table":"lsif_last_index_scan","column":"last_index_scan_at","processDelay in ms":43200000,"allowGlobalPolicies":false,"limit":2500,"now":"2022-11-12 14:43:45.047452317 +0000 UTC m=+68223.818535579","count":1,"elapse │
│ d":11.968184337,"error":"ERROR: ON CONFLICT DO UPDATE command cannot affect row a second time (SQLSTATE 21000)"}}                                                                                                                                 │
```

Seems like we're no longer doing a select from `repo JOIN ...` which ensures that the repo IDs in the `INSERT INTO SELECT` query are distinct. We no longer do the join, but use results directly from a `UNION ALL`, which can result in duplicates.

This really sloppily throws a sort/deduplication step between the limit and the insert (so it should not affect runtime). However, it may no longer return full batches of 2500 in production when duplicates are removed. We should put a bit more effort into this query to see if we can get the distinct semantics prior to the limit without blowing up runtime.

## Test plan

Existing unit tests.