### PR TITLE
Revert "web: enable OpenTelemtry tracing for search results and searc…

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -29,7 +29,6 @@ import {
 import classNames from 'classnames'
 
 import { renderMarkdown } from '@sourcegraph/common'
-import { TraceSpanProvider } from '@sourcegraph/observability-client'
 import { EditorHint, QueryChangeSource, SearchPatternTypeProps } from '@sourcegraph/search'
 import { useCodeMirror, createUpdateableField } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 import { useKeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts/useKeyboardShortcut'
@@ -387,13 +386,11 @@ export const CodeMirrorQueryInput: React.FunctionComponent<
         }, [editor, externalExtensions, extensions])
 
         return (
-            <TraceSpanProvider name="CodeMirrorQueryInput">
-                <div
-                    ref={setContainer}
-                    className={classNames(styles.root, className, 'test-query-input', 'test-editor')}
-                    data-editor="codemirror6"
-                />
-            </TraceSpanProvider>
+            <div
+                ref={setContainer}
+                className={classNames(styles.root, className, 'test-query-input', 'test-editor')}
+                data-editor="codemirror6"
+            />
         )
     }
 )

--- a/client/search-ui/src/results/StreamingSearchResultsList.tsx
+++ b/client/search-ui/src/results/StreamingSearchResultsList.tsx
@@ -9,7 +9,6 @@ import { Observable } from 'rxjs'
 
 import { HoverMerged } from '@sourcegraph/client-api'
 import { Hoverifier } from '@sourcegraph/codeintellify'
-import { TraceSpanProvider } from '@sourcegraph/observability-client'
 import { SearchContextProps } from '@sourcegraph/search'
 import { CommitSearchResult, RepoSearchResult, FileSearchResult } from '@sourcegraph/search-ui'
 import { ActionItemAction } from '@sourcegraph/shared/src/actions/ActionItem'
@@ -143,80 +142,66 @@ export const StreamingSearchResultsList: React.FunctionComponent<
 
     const renderResult = useCallback(
         (result: SearchMatch, index: number): JSX.Element => {
-            function renderResultContent(): JSX.Element {
-                switch (result.type) {
-                    case 'content':
-                    case 'path':
-                    case 'symbol':
-                        return (
-                            <PrefetchableFile
-                                isPrefetchEnabled={prefetchFileEnabled}
-                                prefetch={prefetchFile}
-                                filePath={result.path}
-                                revision={getRevision(result.branches, result.commit)}
-                                repoName={result.repository}
-                                // PrefetchableFile adds an extra wrapper, so we lift the <li> up and match the ResultContainer styles.
-                                // Better approach would be to use `as` to avoid wrapping, but that requires a larger refactor of the
-                                // child components than is worth doing right now for this experimental feature
-                                className={resultContainerStyles.resultContainer}
-                                as="li"
-                            >
-                                <FileSearchResult
-                                    index={index}
-                                    location={location}
-                                    telemetryService={telemetryService}
-                                    icon={getFileMatchIcon(result)}
-                                    result={result}
-                                    onSelect={() => logSearchResultClicked(index, 'fileMatch')}
-                                    expanded={false}
-                                    showAllMatches={false}
-                                    allExpanded={allExpanded}
-                                    fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
-                                    repoDisplayName={displayRepoName(result.repository)}
-                                    settingsCascade={settingsCascade}
-                                    extensionsController={extensionsController}
-                                    hoverifier={hoverifier}
-                                    openInNewTab={openMatchesInNewTab}
-                                    containerClassName={resultClassName}
-                                />
-                            </PrefetchableFile>
-                        )
-                    case 'commit':
-                        return (
-                            <CommitSearchResult
+            switch (result.type) {
+                case 'content':
+                case 'path':
+                case 'symbol':
+                    return (
+                        <PrefetchableFile
+                            isPrefetchEnabled={prefetchFileEnabled}
+                            prefetch={prefetchFile}
+                            filePath={result.path}
+                            revision={getRevision(result.branches, result.commit)}
+                            repoName={result.repository}
+                            // PrefetchableFile adds an extra wrapper, so we lift the <li> up and match the ResultContainer styles.
+                            // Better approach would be to use `as` to avoid wrapping, but that requires a larger refactor of the
+                            // child components than is worth doing right now for this experimental feature
+                            className={resultContainerStyles.resultContainer}
+                            as="li"
+                        >
+                            <FileSearchResult
                                 index={index}
+                                location={location}
+                                telemetryService={telemetryService}
+                                icon={getFileMatchIcon(result)}
                                 result={result}
-                                platformContext={platformContext}
-                                onSelect={() => logSearchResultClicked(index, 'commit')}
+                                onSelect={() => logSearchResultClicked(index, 'fileMatch')}
+                                expanded={false}
+                                showAllMatches={false}
+                                allExpanded={allExpanded}
+                                fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
+                                repoDisplayName={displayRepoName(result.repository)}
+                                settingsCascade={settingsCascade}
+                                extensionsController={extensionsController}
+                                hoverifier={hoverifier}
                                 openInNewTab={openMatchesInNewTab}
                                 containerClassName={resultClassName}
-                                as="li"
                             />
-                        )
-                    case 'repo':
-                        return (
-                            <RepoSearchResult
-                                index={index}
-                                result={result}
-                                onSelect={() => logSearchResultClicked(index, 'repo')}
-                                containerClassName={resultClassName}
-                                as="li"
-                            />
-                        )
-                }
+                        </PrefetchableFile>
+                    )
+                case 'commit':
+                    return (
+                        <CommitSearchResult
+                            index={index}
+                            result={result}
+                            platformContext={platformContext}
+                            onSelect={() => logSearchResultClicked(index, 'commit')}
+                            openInNewTab={openMatchesInNewTab}
+                            containerClassName={resultClassName}
+                            as="li"
+                        />
+                    )
+                case 'repo':
+                    return (
+                        <RepoSearchResult
+                            index={index}
+                            result={result}
+                            onSelect={() => logSearchResultClicked(index, 'repo')}
+                            containerClassName={resultClassName}
+                            as="li"
+                        />
+                    )
             }
-
-            return (
-                <TraceSpanProvider
-                    name="StreamingSearchResultsListItem"
-                    attributes={{
-                        type: result.type,
-                        index,
-                    }}
-                >
-                    {renderResultContent()}
-                </TraceSpanProvider>
-            )
         },
         [
             prefetchFileEnabled,

--- a/client/web/src/search/SearchPageWrapper.tsx
+++ b/client/web/src/search/SearchPageWrapper.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 
 import { useLocation } from 'react-router'
 
-import { TraceSpanProvider } from '@sourcegraph/observability-client'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { LayoutRouteComponentProps } from '../routes'
@@ -22,13 +21,5 @@ export const SearchPageWrapper: React.FunctionComponent<
     const location = useLocation()
     const hasSearchQuery = parseSearchURLQuery(location.search)
 
-    return hasSearchQuery ? (
-        <TraceSpanProvider name="StreamingSearchResults">
-            <StreamingSearchResults {...props} />
-        </TraceSpanProvider>
-    ) : (
-        <TraceSpanProvider name="SearchPage">
-            <SearchPage {...props} />
-        </TraceSpanProvider>
-    )
+    return hasSearchQuery ? <StreamingSearchResults {...props} /> : <SearchPage {...props} />
 }

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -5,7 +5,6 @@ import { NavbarQueryState } from 'src/stores/navbarSearchQueryState'
 import shallow from 'zustand/shallow'
 
 import { Form } from '@sourcegraph/branded/src/components/Form'
-import { TraceSpanProvider } from '@sourcegraph/observability-client'
 import {
     SearchContextInputProps,
     CaseSensitivityProps,
@@ -121,30 +120,26 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
         <div className="d-flex flex-row flex-shrink-past-contents">
             <Form className="flex-grow-1 flex-shrink-past-contents" onSubmit={onSubmit}>
                 <div data-search-page-input-container={true} className={styles.inputContainer}>
-                    <TraceSpanProvider name="SearchBox">
-                        <SearchBox
-                            {...props}
-                            editorComponent={editorComponent}
-                            showSearchContext={showSearchContext}
-                            showSearchContextManagement={showSearchContextManagement}
-                            caseSensitive={caseSensitive}
-                            patternType={patternType}
-                            setPatternType={setSearchPatternType}
-                            setCaseSensitivity={setSearchCaseSensitivity}
-                            queryState={props.queryState}
-                            onChange={props.setQueryState}
-                            onSubmit={onSubmit}
-                            autoFocus={!showSearchHistory && !isTouchOnlyDevice && props.autoFocus !== false}
-                            isExternalServicesUserModeAll={window.context.externalServicesUserMode === 'all'}
-                            structuralSearchDisabled={
-                                window.context?.experimentalFeatures?.structuralSearch === 'disabled'
-                            }
-                            applySuggestionsOnEnter={applySuggestionsOnEnter}
-                            showCopyQueryButton={!showSearchHistory}
-                            showSearchHistory={showSearchHistory}
-                            recentSearches={recentSearches}
-                        />
-                    </TraceSpanProvider>
+                    <SearchBox
+                        {...props}
+                        editorComponent={editorComponent}
+                        showSearchContext={showSearchContext}
+                        showSearchContextManagement={showSearchContextManagement}
+                        caseSensitive={caseSensitive}
+                        patternType={patternType}
+                        setPatternType={setSearchPatternType}
+                        setCaseSensitivity={setSearchCaseSensitivity}
+                        queryState={props.queryState}
+                        onChange={props.setQueryState}
+                        onSubmit={onSubmit}
+                        autoFocus={!showSearchHistory && !isTouchOnlyDevice && props.autoFocus !== false}
+                        isExternalServicesUserModeAll={window.context.externalServicesUserMode === 'all'}
+                        structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch === 'disabled'}
+                        applySuggestionsOnEnter={applySuggestionsOnEnter}
+                        showCopyQueryButton={!showSearchHistory}
+                        showSearchHistory={showSearchHistory}
+                        recentSearches={recentSearches}
+                    />
                 </div>
                 <Notices className="my-3" location="home" settingsCascade={props.settingsCascade} />
             </Form>


### PR DESCRIPTION
…h query input (#43997)"

This reverts commit ee8e8abf72cd53179df546497cf3fcda6cc99d08.

This is the first PR that broke E2E and QA in CI, I am not sure how this breaks it, but reverting to see if that fixes it.

cc @valerybugakov 

## Test plan

Revert, looking at the code this seems safe.

## App preview:

- [Web](https://sg-web-es-revert-broken-ci.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
