### PR TITLE
searcher: hybrid search respects PatternMatches*

### DIFF
--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -265,7 +265,8 @@ func zoektCompile(p *protocol.PatternInfo) (zoektquery.Q, error) {
 		}
 		parts = append(parts, &zoektquery.Regexp{
 			Regexp:        re,
-			Content:       true,
+			Content:       p.PatternMatchesContent,
+			FileName:      p.PatternMatchesPath,
 			CaseSensitive: !rg.ignoreCase,
 		})
 	}

--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -194,6 +194,10 @@ func zoektSearchIgnorePaths(ctx context.Context, client zoekt.Streamer, p *proto
 		}
 
 		for _, cm := range fm.ChunkMatches {
+			if cm.FileName {
+				continue
+			}
+
 			ranges := make([]protocol.Range, 0, len(cm.Ranges))
 			for _, r := range cm.Ranges {
 				ranges = append(ranges, protocol.Range{


### PR DESCRIPTION
Previously hybrid searcher assumed the patterns only matched content. However, it can match either or both contents and paths. This bug was noticed from manual testing.

Test Plan: manual testing

Part of https://github.com/sourcegraph/sourcegraph/issues/37112