### PR TITLE
Revert "web: trace search results and search query input"

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -29,6 +29,7 @@ import {
 import classNames from 'classnames'
 
 import { renderMarkdown } from '@sourcegraph/common'
+import { TraceSpanProvider } from '@sourcegraph/observability-client'
 import { EditorHint, QueryChangeSource, SearchPatternTypeProps } from '@sourcegraph/search'
 import { useCodeMirror, createUpdateableField } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 import { useKeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts/useKeyboardShortcut'
@@ -386,11 +387,13 @@ export const CodeMirrorQueryInput: React.FunctionComponent<
         }, [editor, externalExtensions, extensions])
 
         return (
-            <div
-                ref={setContainer}
-                className={classNames(styles.root, className, 'test-query-input', 'test-editor')}
-                data-editor="codemirror6"
-            />
+            <TraceSpanProvider name="CodeMirrorQueryInput">
+                <div
+                    ref={setContainer}
+                    className={classNames(styles.root, className, 'test-query-input', 'test-editor')}
+                    data-editor="codemirror6"
+                />
+            </TraceSpanProvider>
         )
     }
 )

--- a/client/search-ui/src/results/StreamingSearchResultsList.tsx
+++ b/client/search-ui/src/results/StreamingSearchResultsList.tsx
@@ -9,6 +9,7 @@ import { Observable } from 'rxjs'
 
 import { HoverMerged } from '@sourcegraph/client-api'
 import { Hoverifier } from '@sourcegraph/codeintellify'
+import { TraceSpanProvider } from '@sourcegraph/observability-client'
 import { SearchContextProps } from '@sourcegraph/search'
 import { CommitSearchResult, RepoSearchResult, FileSearchResult } from '@sourcegraph/search-ui'
 import { ActionItemAction } from '@sourcegraph/shared/src/actions/ActionItem'
@@ -142,66 +143,80 @@ export const StreamingSearchResultsList: React.FunctionComponent<
 
     const renderResult = useCallback(
         (result: SearchMatch, index: number): JSX.Element => {
-            switch (result.type) {
-                case 'content':
-                case 'path':
-                case 'symbol':
-                    return (
-                        <PrefetchableFile
-                            isPrefetchEnabled={prefetchFileEnabled}
-                            prefetch={prefetchFile}
-                            filePath={result.path}
-                            revision={getRevision(result.branches, result.commit)}
-                            repoName={result.repository}
-                            // PrefetchableFile adds an extra wrapper, so we lift the <li> up and match the ResultContainer styles.
-                            // Better approach would be to use `as` to avoid wrapping, but that requires a larger refactor of the
-                            // child components than is worth doing right now for this experimental feature
-                            className={resultContainerStyles.resultContainer}
-                            as="li"
-                        >
-                            <FileSearchResult
+            function renderResultContent(): JSX.Element {
+                switch (result.type) {
+                    case 'content':
+                    case 'path':
+                    case 'symbol':
+                        return (
+                            <PrefetchableFile
+                                isPrefetchEnabled={prefetchFileEnabled}
+                                prefetch={prefetchFile}
+                                filePath={result.path}
+                                revision={getRevision(result.branches, result.commit)}
+                                repoName={result.repository}
+                                // PrefetchableFile adds an extra wrapper, so we lift the <li> up and match the ResultContainer styles.
+                                // Better approach would be to use `as` to avoid wrapping, but that requires a larger refactor of the
+                                // child components than is worth doing right now for this experimental feature
+                                className={resultContainerStyles.resultContainer}
+                                as="li"
+                            >
+                                <FileSearchResult
+                                    index={index}
+                                    location={location}
+                                    telemetryService={telemetryService}
+                                    icon={getFileMatchIcon(result)}
+                                    result={result}
+                                    onSelect={() => logSearchResultClicked(index, 'fileMatch')}
+                                    expanded={false}
+                                    showAllMatches={false}
+                                    allExpanded={allExpanded}
+                                    fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
+                                    repoDisplayName={displayRepoName(result.repository)}
+                                    settingsCascade={settingsCascade}
+                                    extensionsController={extensionsController}
+                                    hoverifier={hoverifier}
+                                    openInNewTab={openMatchesInNewTab}
+                                    containerClassName={resultClassName}
+                                />
+                            </PrefetchableFile>
+                        )
+                    case 'commit':
+                        return (
+                            <CommitSearchResult
                                 index={index}
-                                location={location}
-                                telemetryService={telemetryService}
-                                icon={getFileMatchIcon(result)}
                                 result={result}
-                                onSelect={() => logSearchResultClicked(index, 'fileMatch')}
-                                expanded={false}
-                                showAllMatches={false}
-                                allExpanded={allExpanded}
-                                fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
-                                repoDisplayName={displayRepoName(result.repository)}
-                                settingsCascade={settingsCascade}
-                                extensionsController={extensionsController}
-                                hoverifier={hoverifier}
+                                platformContext={platformContext}
+                                onSelect={() => logSearchResultClicked(index, 'commit')}
                                 openInNewTab={openMatchesInNewTab}
                                 containerClassName={resultClassName}
+                                as="li"
                             />
-                        </PrefetchableFile>
-                    )
-                case 'commit':
-                    return (
-                        <CommitSearchResult
-                            index={index}
-                            result={result}
-                            platformContext={platformContext}
-                            onSelect={() => logSearchResultClicked(index, 'commit')}
-                            openInNewTab={openMatchesInNewTab}
-                            containerClassName={resultClassName}
-                            as="li"
-                        />
-                    )
-                case 'repo':
-                    return (
-                        <RepoSearchResult
-                            index={index}
-                            result={result}
-                            onSelect={() => logSearchResultClicked(index, 'repo')}
-                            containerClassName={resultClassName}
-                            as="li"
-                        />
-                    )
+                        )
+                    case 'repo':
+                        return (
+                            <RepoSearchResult
+                                index={index}
+                                result={result}
+                                onSelect={() => logSearchResultClicked(index, 'repo')}
+                                containerClassName={resultClassName}
+                                as="li"
+                            />
+                        )
+                }
             }
+
+            return (
+                <TraceSpanProvider
+                    name="StreamingSearchResultsListItem"
+                    attributes={{
+                        type: result.type,
+                        index,
+                    }}
+                >
+                    {renderResultContent()}
+                </TraceSpanProvider>
+            )
         },
         [
             prefetchFileEnabled,

--- a/client/web/src/search/SearchPageWrapper.tsx
+++ b/client/web/src/search/SearchPageWrapper.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { useLocation } from 'react-router'
 
+import { TraceSpanProvider } from '@sourcegraph/observability-client'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { LayoutRouteComponentProps } from '../routes'
@@ -21,5 +22,13 @@ export const SearchPageWrapper: React.FunctionComponent<
     const location = useLocation()
     const hasSearchQuery = parseSearchURLQuery(location.search)
 
-    return hasSearchQuery ? <StreamingSearchResults {...props} /> : <SearchPage {...props} />
+    return hasSearchQuery ? (
+        <TraceSpanProvider name="StreamingSearchResults">
+            <StreamingSearchResults {...props} />
+        </TraceSpanProvider>
+    ) : (
+        <TraceSpanProvider name="SearchPage">
+            <SearchPage {...props} />
+        </TraceSpanProvider>
+    )
 }

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -5,6 +5,7 @@ import { NavbarQueryState } from 'src/stores/navbarSearchQueryState'
 import shallow from 'zustand/shallow'
 
 import { Form } from '@sourcegraph/branded/src/components/Form'
+import { TraceSpanProvider } from '@sourcegraph/observability-client'
 import {
     SearchContextInputProps,
     CaseSensitivityProps,
@@ -120,26 +121,30 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
         <div className="d-flex flex-row flex-shrink-past-contents">
             <Form className="flex-grow-1 flex-shrink-past-contents" onSubmit={onSubmit}>
                 <div data-search-page-input-container={true} className={styles.inputContainer}>
-                    <SearchBox
-                        {...props}
-                        editorComponent={editorComponent}
-                        showSearchContext={showSearchContext}
-                        showSearchContextManagement={showSearchContextManagement}
-                        caseSensitive={caseSensitive}
-                        patternType={patternType}
-                        setPatternType={setSearchPatternType}
-                        setCaseSensitivity={setSearchCaseSensitivity}
-                        queryState={props.queryState}
-                        onChange={props.setQueryState}
-                        onSubmit={onSubmit}
-                        autoFocus={!showSearchHistory && !isTouchOnlyDevice && props.autoFocus !== false}
-                        isExternalServicesUserModeAll={window.context.externalServicesUserMode === 'all'}
-                        structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch === 'disabled'}
-                        applySuggestionsOnEnter={applySuggestionsOnEnter}
-                        showCopyQueryButton={!showSearchHistory}
-                        showSearchHistory={showSearchHistory}
-                        recentSearches={recentSearches}
-                    />
+                    <TraceSpanProvider name="SearchBox">
+                        <SearchBox
+                            {...props}
+                            editorComponent={editorComponent}
+                            showSearchContext={showSearchContext}
+                            showSearchContextManagement={showSearchContextManagement}
+                            caseSensitive={caseSensitive}
+                            patternType={patternType}
+                            setPatternType={setSearchPatternType}
+                            setCaseSensitivity={setSearchCaseSensitivity}
+                            queryState={props.queryState}
+                            onChange={props.setQueryState}
+                            onSubmit={onSubmit}
+                            autoFocus={!showSearchHistory && !isTouchOnlyDevice && props.autoFocus !== false}
+                            isExternalServicesUserModeAll={window.context.externalServicesUserMode === 'all'}
+                            structuralSearchDisabled={
+                                window.context?.experimentalFeatures?.structuralSearch === 'disabled'
+                            }
+                            applySuggestionsOnEnter={applySuggestionsOnEnter}
+                            showCopyQueryButton={!showSearchHistory}
+                            showSearchHistory={showSearchHistory}
+                            recentSearches={recentSearches}
+                        />
+                    </TraceSpanProvider>
                 </div>
                 <Notices className="my-3" location="home" settingsCascade={props.settingsCascade} />
             </Form>

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -76,6 +76,12 @@ const styleLoader = IS_DEVELOPMENT ? 'style-loader' : MiniCssExtractPlugin.loade
 
 const extensionHostWorker = /main\.worker\.ts$/
 
+// Used to ensure that we include all initial chunks into the Webpack manifest.
+const initialChunkNames = {
+  react: 'react',
+  opentelemetry: 'opentelemetry',
+}
+
 /** @type {import('webpack').Configuration} */
 const config = {
   context: __dirname, // needed when running `gulp webpackDevServer` from the root dir
@@ -101,14 +107,14 @@ const config = {
     minimizer: [getTerserPlugin(), new CssMinimizerWebpackPlugin()],
     splitChunks: {
       cacheGroups: {
-        react: {
+        [initialChunkNames.react]: {
           test: /[/\\]node_modules[/\\](react|react-dom)[/\\]/,
-          name: 'react',
+          name: initialChunkNames.react,
           chunks: 'all',
         },
-        opentelemetry: {
+        [initialChunkNames.opentelemetry]: {
           test: /[/\\]node_modules[/\\](@opentelemetry)[/\\]/,
-          name: 'opentelemetry',
+          name: initialChunkNames.opentelemetry,
           chunks: 'all',
         },
       },
@@ -163,7 +169,8 @@ const config = {
         writeToFileEmit: true,
         fileName: 'webpack.manifest.json',
         // Only output files that are required to run the application.
-        filter: ({ isInitial, name }) => isInitial || name?.includes('react'),
+        filter: ({ isInitial, name }) =>
+          isInitial || Object.values(initialChunkNames).some(initialChunkName => name?.includes(initialChunkName)),
       }),
     ...(WEBPACK_SERVE_INDEX ? getHTMLWebpackPlugins() : []),
     WEBPACK_BUNDLE_ANALYZER && getStatoscopePlugin(WEBPACK_STATS_NAME),


### PR DESCRIPTION
## Context

Revert [the revert](https://github.com/sourcegraph/sourcegraph/pull/44320) of [the initial PR](https://github.com/sourcegraph/sourcegraph/pull/43997).

The issue was similar to the one we already bumped into a while ago with [the initial React chunk](https://github.com/sourcegraph/sourcegraph/pull/30834). The OpenTelemtry chunk wasn't added to the generated Webpack manifest. [This commit](https://github.com/sourcegraph/sourcegraph/pull/44322/commits/1ddd5618e545bfbb8143f02b4748744c0d625f91) now fixes this.

## Test plan

[The main-dry-run build](https://buildkite.com/sourcegraph/sourcegraph/builds/183131) is green. 

## App preview:

- [Web](https://sg-web-vb-revert-revert-components.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
