### PR TITLE
event_logs: instrument SOAP-related event logs

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -32,6 +32,7 @@ import (
 	sgtrace "github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/usagestats"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -43,11 +44,13 @@ var (
 	}, []string{"type", "field", "error", "source", "request_name"})
 )
 
-type prometheusTracer struct {
+type requestTracer struct {
+	DB     database.DB
 	tracer trace.OpenTracingTracer
+	logger sglog.Logger
 }
 
-func (t *prometheusTracer) TraceQuery(ctx context.Context, queryString string, operationName string, variables map[string]any, varTypes map[string]*introspection.Type) (context.Context, trace.TraceQueryFinishFunc) {
+func (t *requestTracer) TraceQuery(ctx context.Context, queryString string, operationName string, variables map[string]any, varTypes map[string]*introspection.Type) (context.Context, trace.TraceQueryFinishFunc) {
 	start := time.Now()
 	var finish trace.TraceQueryFinishFunc
 	if policy.ShouldTrace(ctx) {
@@ -62,6 +65,48 @@ func (t *prometheusTracer) TraceQuery(ctx context.Context, queryString string, o
 	a := actor.FromContext(ctx)
 	if a.IsAuthenticated() {
 		currentUserID = a.UID
+	}
+
+	// 🚨 SECURITY: We want to log every single operation the Sourcegraph operator
+	// has done on the instance, so we need to do additional logging here. Sometimes
+	// we would end up having logging twice for the same operation (here and the web
+	// app), but we would not want to risk missing logging operations. Also in the
+	// future, we expect audit logging of Sourcegraph operators to live outside the
+	// instance, which makes this pattern less of a concern in terms of redundancy.
+	if a.SourcegraphOperator {
+		const eventName = "SourcegraphOperatorGraphQLRequest"
+		args, err := json.Marshal(map[string]any{
+			"queryString": queryString,
+			"variables":   variables,
+		})
+		if err != nil {
+			t.logger.Error(
+				"failed to marshal JSON for event log argument",
+				sglog.String("eventName", eventName),
+				sglog.Error(err),
+			)
+		}
+
+		// NOTE: It is important to propagate the correct context that carries the
+		// information of the actor, especially whether the actor is a Sourcegraph
+		// operator or not.
+		err = usagestats.LogEvent(
+			ctx,
+			t.DB,
+			usagestats.Event{
+				EventName: eventName,
+				UserID:    a.UID,
+				Argument:  args,
+				Source:    "BACKEND",
+			},
+		)
+		if err != nil {
+			t.logger.Error(
+				"failed to log event",
+				sglog.String("eventName", eventName),
+				sglog.Error(err),
+			)
+		}
 	}
 
 	// Requests made by our JS frontend and other internal things will have a concrete name attached to the
@@ -96,7 +141,7 @@ VARIABLES
 	}
 }
 
-func (prometheusTracer) TraceField(ctx context.Context, label, typeName, fieldName string, trivial bool, args map[string]any) (context.Context, trace.TraceFieldFinishFunc) {
+func (requestTracer) TraceField(ctx context.Context, label, typeName, fieldName string, trivial bool, args map[string]any) (context.Context, trace.TraceFieldFinishFunc) {
 	// We don't call into t.OpenTracingTracer.TraceField since it generates too many spans which is really hard to read.
 	start := time.Now()
 	return ctx, func(err *gqlerrors.QueryError) {
@@ -111,7 +156,7 @@ func (prometheusTracer) TraceField(ctx context.Context, label, typeName, fieldNa
 	}
 }
 
-func (t prometheusTracer) TraceValidation(ctx context.Context) trace.TraceValidationFinishFunc {
+func (t requestTracer) TraceValidation(ctx context.Context) trace.TraceValidationFinishFunc {
 	var finish trace.TraceValidationFinishFunc
 	if policy.ShouldTrace(ctx) {
 		finish = t.tracer.TraceValidation(ctx)
@@ -458,10 +503,14 @@ func NewSchema(
 		}
 	}
 
+	logger := sglog.Scoped("GraphQL", "general GraphQL logging")
 	return graphql.ParseSchema(
 		strings.Join(schemas, "\n"),
 		resolver,
-		graphql.Tracer(&prometheusTracer{}),
+		graphql.Tracer(&requestTracer{
+			DB:     db,
+			logger: logger,
+		}),
 		graphql.UseStringDescriptions(),
 	)
 }

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -117,7 +117,7 @@ func TestSearch(t *testing.T) {
 			gsClient.ResolveRevisionFunc.SetDefaultHook(tc.repoRevsMock)
 
 			sr := newSchemaResolver(db, gsClient)
-			schema, err := graphql.ParseSchema(mainSchema, sr, graphql.Tracer(&prometheusTracer{}))
+			schema, err := graphql.ParseSchema(mainSchema, sr, graphql.Tracer(&requestTracer{}))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -63,7 +63,7 @@ func newExternalHTTPHandler(
 	// 🚨 SECURITY: The HTTP API should not accept cookies as authentication, except from trusted
 	// origins, to avoid CSRF attacks. See session.CookieMiddlewareWithCSRFSafety for details.
 	apiHandler = session.CookieMiddlewareWithCSRFSafety(logger, db, apiHandler, corsAllowHeader, isTrustedOrigin) // API accepts cookies with special header
-	apiHandler = internalhttpapi.AccessTokenAuthMiddleware(db, apiHandler)                                        // API accepts access tokens
+	apiHandler = internalhttpapi.AccessTokenAuthMiddleware(db, logger, apiHandler)                                // API accepts access tokens
 	apiHandler = requestclient.HTTPMiddleware(apiHandler)
 	apiHandler = gziphandler.GzipHandler(apiHandler)
 	if envvar.SourcegraphDotComMode() {
@@ -85,8 +85,8 @@ func newExternalHTTPHandler(
 	appHandler = actor.AnonymousUIDMiddleware(appHandler)
 	appHandler = authMiddlewares.App(appHandler) // 🚨 SECURITY: auth middleware
 	appHandler = middleware.OpenGraphMetadataMiddleware(db.FeatureFlags(), appHandler)
-	appHandler = session.CookieMiddleware(logger, db, appHandler)          // app accepts cookies
-	appHandler = internalhttpapi.AccessTokenAuthMiddleware(db, appHandler) // app accepts access tokens
+	appHandler = session.CookieMiddleware(logger, db, appHandler)                  // app accepts cookies
+	appHandler = internalhttpapi.AccessTokenAuthMiddleware(db, logger, appHandler) // app accepts access tokens
 	appHandler = requestclient.HTTPMiddleware(appHandler)
 	if envvar.SourcegraphDotComMode() {
 		appHandler = deviceid.Middleware(appHandler)

--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -1,9 +1,11 @@
 package httpapi
 
 import (
+	"encoding/json"
 	"net/http"
+	"time"
 
-	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
@@ -16,7 +18,8 @@ import (
 
 // AccessTokenAuthMiddleware authenticates the user based on the
 // token query parameter or the "Authorization" header.
-func AccessTokenAuthMiddleware(db database.DB, next http.Handler) http.Handler {
+func AccessTokenAuthMiddleware(db database.DB, logger log.Logger, next http.Handler) http.Handler {
+	logger = logger.Scoped("accessTokenAuth", "Access token authentication middleware")
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Vary", "Authorization")
 
@@ -38,7 +41,11 @@ func AccessTokenAuthMiddleware(db database.DB, next http.Handler) http.Handler {
 			if err != nil {
 				if authz.IsUnrecognizedScheme(err) {
 					// Ignore Authorization headers that we don't handle.
-					log15.Warn("Ignoring unrecognized Authorization header.", "err", err, "value", headerValue)
+					logger.Warn(
+						"ignoring unrecognized Authorization header",
+						log.String("value", headerValue),
+						log.Error(err),
+					)
 					next.ServeHTTP(w, r)
 					return
 				}
@@ -46,7 +53,7 @@ func AccessTokenAuthMiddleware(db database.DB, next http.Handler) http.Handler {
 				// Report errors on malformed Authorization headers for schemes we do handle, to
 				// make it clear to the client that their request is not proceeding with their
 				// supplied credentials.
-				log15.Error("Invalid Authorization header.", "err", err)
+				logger.Error("invalid Authorization header", log.Error(err))
 				http.Error(w, "Invalid Authorization header.", http.StatusUnauthorized)
 				return
 			}
@@ -72,15 +79,42 @@ func AccessTokenAuthMiddleware(db database.DB, next http.Handler) http.Handler {
 			subjectUserID, err := db.AccessTokens().Lookup(r.Context(), token, requiredScope)
 			if err != nil {
 				if err == database.ErrAccessTokenNotFound || errors.HasType(err, database.InvalidTokenError{}) {
-					log15.Error("AccessTokenAuthMiddleware.invalidAccessToken", "token", token, "error", err)
+					logger.Error(
+						"invalid access token",
+						log.String("token", token),
+						log.Error(err),
+					)
 					http.Error(w, "Invalid access token.", http.StatusUnauthorized)
 					return
 				}
 
-				log15.Error("AccessTokenAuthMiddleware.lookingUpAccessToken.", "token", token, "error", err)
+				logger.Error(
+					"failed to look up access token",
+					log.String("token", token),
+					log.Error(err),
+				)
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
+
+			// FIXME: Can we find a way to do this only for SOAP users?
+			soapCount, err := db.UserExternalAccounts().Count(
+				r.Context(),
+				database.ExternalAccountsListOptions{
+					UserID:      subjectUserID,
+					ServiceType: auth.SourcegraphOperatorProviderType,
+				},
+			)
+			if err != nil {
+				logger.Error(
+					"failed to list user external accounts",
+					log.Int32("subjectUserID", subjectUserID),
+					log.Error(err),
+				)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			sourcegraphOperator := soapCount > 0
 
 			// Determine the actor's user ID.
 			var actorUserID int32
@@ -90,7 +124,11 @@ func AccessTokenAuthMiddleware(db database.DB, next http.Handler) http.Handler {
 				// 🚨 SECURITY: Confirm that the sudo token's subject is still a site admin, to
 				// prevent users from retaining site admin privileges after being demoted.
 				if err := auth.CheckUserIsSiteAdmin(r.Context(), db, subjectUserID); err != nil {
-					log15.Error("Sudo access token's subject is not a site admin.", "subjectUserID", subjectUserID, "err", err)
+					logger.Error(
+						"sudo access token's subject is not a site admin",
+						log.Int32("subjectUserID", subjectUserID),
+						log.Error(err),
+					)
 					http.Error(w, "The subject user of a sudo access token must be a site admin.", http.StatusForbidden)
 					return
 				}
@@ -99,7 +137,11 @@ func AccessTokenAuthMiddleware(db database.DB, next http.Handler) http.Handler {
 				// the necessary scope in the Lookup call above.
 				user, err := db.Users().GetByUsername(r.Context(), sudoUser)
 				if err != nil {
-					log15.Error("Invalid username used with sudo access token.", "sudoUser", sudoUser, "err", err)
+					logger.Error(
+						"invalid username used with sudo access token",
+						log.String("sudoUser", sudoUser),
+						log.Error(err),
+					)
 					var message string
 					if errcode.IsNotFound(err) {
 						message = "Unable to sudo to nonexistent user."
@@ -110,10 +152,53 @@ func AccessTokenAuthMiddleware(db database.DB, next http.Handler) http.Handler {
 					return
 				}
 				actorUserID = user.ID
-				log15.Debug("HTTP request used sudo token.", "requestURI", r.URL.RequestURI(), "tokenSubjectUserID", subjectUserID, "actorUserID", actorUserID, "actorUsername", user.Username)
+				logger.Debug(
+					"HTTP request used sudo token",
+					log.String("requestURI", r.URL.RequestURI()),
+					log.Int32("tokenSubjectUserID", subjectUserID),
+					log.Int32("actorUserID", actorUserID),
+					log.String("actorUsername", user.Username),
+				)
+
+				args, err := json.Marshal(map[string]any{
+					"sudo_user_id": actorUserID,
+				})
+				if err != nil {
+					logger.Error(
+						"failed to marshal JSON for security event log argument",
+						log.String("eventName", string(database.SecurityEventAccessTokenImpersonated)),
+						log.String("sudoUser", sudoUser),
+						log.Error(err),
+					)
+					// OK to continue, we still want the security event log to be created
+				}
+				db.SecurityEventLogs().LogEvent(
+					actor.WithActor(
+						r.Context(),
+						&actor.Actor{
+							UID:                 subjectUserID,
+							SourcegraphOperator: sourcegraphOperator,
+						},
+					),
+					&database.SecurityEvent{
+						Name:      database.SecurityEventAccessTokenImpersonated,
+						UserID:    uint32(subjectUserID),
+						Argument:  args,
+						Source:    "BACKEND",
+						Timestamp: time.Now(),
+					},
+				)
 			}
 
-			r = r.WithContext(actor.WithActor(r.Context(), &actor.Actor{UID: actorUserID}))
+			r = r.WithContext(
+				actor.WithActor(
+					r.Context(),
+					&actor.Actor{
+						UID:                 actorUserID,
+						SourcegraphOperator: sourcegraphOperator,
+					},
+				),
+			)
 		}
 
 		next.ServeHTTP(w, r)

--- a/enterprise/cmd/frontend/internal/auth/init.go
+++ b/enterprise/cmd/frontend/internal/auth/init.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/saml"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/sourcegraphoperator"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
+	internalauth "github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 )
@@ -112,7 +113,7 @@ func ssoSignOutHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if p := sourcegraphoperator.GetOIDCProvider(sourcegraphoperator.ProviderType); p != nil {
+	if p := sourcegraphoperator.GetOIDCProvider(internalauth.SourcegraphOperatorProviderType); p != nil {
 		_, err := openidconnect.SignOut(
 			w,
 			r,

--- a/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/config.go
+++ b/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/openidconnect"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/cloud"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 )
@@ -18,7 +19,7 @@ import (
 func GetOIDCProvider(id string) *openidconnect.Provider {
 	p, ok := providers.GetProviderByConfigID(
 		providers.ConfigID{
-			Type: ProviderType,
+			Type: auth.SourcegraphOperatorProviderType,
 			ID:   id,
 		},
 	).(*provider)
@@ -37,13 +38,13 @@ func Init() {
 	conf.ContributeValidator(validateConfig)
 
 	p := NewProvider(*cloudSiteConfig.AuthProviders.SourcegraphOperator)
-	logger := log.Scoped(ProviderType, "Sourcegraph Operator config watch")
+	logger := log.Scoped(auth.SourcegraphOperatorProviderType, "Sourcegraph Operator config watch")
 	go func() {
 		if err := p.Refresh(context.Background()); err != nil {
 			logger.Error("failed to fetch Sourcegraph Operator service provider metadata", log.Error(err))
 		}
 	}()
-	providers.Update(ProviderType, []providers.Provider{p})
+	providers.Update(auth.SourcegraphOperatorProviderType, []providers.Provider{p})
 }
 
 func validateConfig(c conftypes.SiteConfigQuerier) (problems conf.Problems) {

--- a/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/middleware.go
@@ -1,6 +1,7 @@
 package sourcegraphoperator
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 	"time"
@@ -12,12 +13,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/session"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/openidconnect"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	internalauth "github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // All Sourcegraph Operator endpoints are under this path prefix.
-const authPrefix = auth.AuthURLPrefix + "/" + ProviderType
+const authPrefix = auth.AuthURLPrefix + "/" + internalauth.SourcegraphOperatorProviderType
 
 // Middleware is middleware for Sourcegraph Operator authentication, adding
 // endpoints under the auth path prefix ("/.auth") to enable the login flow and
@@ -66,7 +68,7 @@ const (
 )
 
 func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
-	logger := log.Scoped(ProviderType+".authHandler", "Sourcegraph Operator authentication handler")
+	logger := log.Scoped(internalauth.SourcegraphOperatorProviderType+".authHandler", "Sourcegraph Operator authentication handler")
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch strings.TrimPrefix(r.URL.Path, authPrefix) {
 		case "/login": // Endpoint that starts the Authentication Request Code Flow.
@@ -89,12 +91,15 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 
 			p, ok := providers.GetProviderByConfigID(
 				providers.ConfigID{
-					Type: ProviderType,
-					ID:   ProviderType,
+					Type: internalauth.SourcegraphOperatorProviderType,
+					ID:   internalauth.SourcegraphOperatorProviderType,
 				},
 			).(*provider)
 			if !ok {
-				logger.Error("failed to get Sourcegraph Operator authentication provider", log.Error(errors.Errorf("no authentication provider found with ID %q", ProviderType)))
+				logger.Error(
+					"failed to get Sourcegraph Operator authentication provider",
+					log.Error(errors.Errorf("no authentication provider found with ID %q", internalauth.SourcegraphOperatorProviderType)),
+				)
 				http.Error(w, "Misconfigured authentication provider.", http.StatusInternalServerError)
 				return
 			}
@@ -118,7 +123,7 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 			// If the "sourcegraph-operator" is the only external account associated with the
 			// user, that means the user is a pure Sourcegraph Operator which should have
 			// designated and aggressive session expiry.
-			if len(extAccts) == 1 && extAccts[0].ServiceType == ProviderType {
+			if len(extAccts) == 1 && extAccts[0].ServiceType == internalauth.SourcegraphOperatorProviderType {
 				// The user session will only live at most for the remaining duration from the
 				// "users.created_at" compared to the current time.
 				//
@@ -130,15 +135,40 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 				//       the second session only lives for 50 minutes.
 				expiry = time.Until(result.User.CreatedAt.Add(p.lifecycleDuration()))
 				if expiry <= 0 {
+					// Let's do a proactive hard delete since the background worker hasn't caught up
+
+					// Help exclude Sourcegraph operator related events from analytics
+					ctx := actor.WithActor(
+						r.Context(),
+						&actor.Actor{
+							SourcegraphOperator: true,
+						},
+					)
+					err = db.Users().HardDelete(ctx, result.User.ID)
+					if err != nil {
+						logger.Error("failed to proactively clean up the expire user account", log.Error(err))
+					}
+
 					http.Error(w, "The retrieved user account lifecycle has already expired, please re-authenticate.", http.StatusUnauthorized)
 					return
 				}
 			}
-			if err = session.SetActor(w, r, actor.FromUser(result.User.ID), expiry, result.User.CreatedAt); err != nil {
+
+			act := &actor.Actor{
+				UID:                 result.User.ID,
+				SourcegraphOperator: true,
+			}
+			err = session.SetActor(w, r, act, expiry, result.User.CreatedAt)
+			if err != nil {
 				logger.Error("failed to authenticate with Sourcegraph Operator", log.Error(errors.Wrap(err, "initiate session")))
 				http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: could not initiate session.", http.StatusInternalServerError)
 				return
 			}
+
+			// NOTE: It is important to wrap the request context with the correct actor and
+			// use it onwards to be able to mark all generated event logs with
+			// `"sourcegraph_operator": true`.
+			ctx := actor.WithActor(r.Context(), act)
 
 			if err = session.SetData(w, r, SessionKey, result.SessionData); err != nil {
 				// It's not fatal if this fails. It just means we won't be able to sign the user
@@ -148,10 +178,31 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 					log.String("message", "The session is still secure, but Sourcegraph will be unable to revoke the user's token or redirect the user to the end-session endpoint after the user signs out of Sourcegraph."),
 					log.Error(err),
 				)
+			} else {
+				args, err := json.Marshal(map[string]any{
+					"session_expiry_seconds": int64(expiry.Seconds()),
+				})
+				if err != nil {
+					logger.Error(
+						"failed to marshal JSON for security event log argument",
+						log.String("eventName", string(database.SecurityEventNameSignInSucceeded)),
+						log.Error(err),
+					)
+				}
+				db.SecurityEventLogs().LogEvent(
+					ctx,
+					&database.SecurityEvent{
+						Name:      database.SecurityEventNameSignInSucceeded,
+						UserID:    uint32(act.UID),
+						Argument:  args,
+						Source:    "BACKEND",
+						Timestamp: time.Now(),
+					},
+				)
 			}
 
 			if !result.User.SiteAdmin {
-				err = db.Users().SetIsSiteAdmin(r.Context(), result.User.ID, true)
+				err = db.Users().SetIsSiteAdmin(ctx, result.User.ID, true)
 				if err != nil {
 					logger.Error("failed to update Sourcegraph Operator as site admin", log.Error(err))
 					http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: could not set as site admin.", http.StatusInternalServerError)

--- a/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/provider.go
@@ -6,12 +6,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/openidconnect"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/cloud"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
-
-// ProviderType is the unique identifier of the Sourcegraph Operator
-// authentication provider.
-const ProviderType = "sourcegraph-operator"
 
 // provider is an implementation of providers.Provider for the Sourcegraph
 // Operator authentication.
@@ -31,11 +28,11 @@ func NewProvider(config cloud.SchemaAuthProviderSourcegraphOperator) providers.P
 				AllowSignup:        &allowSignUp,
 				ClientID:           config.ClientID,
 				ClientSecret:       config.ClientSecret,
-				ConfigID:           ProviderType,
+				ConfigID:           auth.SourcegraphOperatorProviderType,
 				DisplayName:        "Sourcegraph Operators",
 				Issuer:             config.Issuer,
 				RequireEmailDomain: "sourcegraph.com",
-				Type:               ProviderType,
+				Type:               auth.SourcegraphOperatorProviderType,
 			},
 			authPrefix,
 		).(*openidconnect.Provider),
@@ -50,7 +47,7 @@ func (p *provider) Config() schema.AuthProviders {
 	// non-Sourcegraph employees.
 	return schema.AuthProviders{
 		Openidconnect: &schema.OpenIDConnectAuthProvider{
-			ConfigID: ProviderType,
+			ConfigID: auth.SourcegraphOperatorProviderType,
 		},
 	}
 }

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
@@ -7,9 +7,9 @@ import (
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/sourcegraphoperator"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/cloud"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -25,7 +25,7 @@ func NewBeforeCreateUserHook() func(context.Context, database.DB, *extsvc.Accoun
 		//
 		// NOTE: It is important to make sure the Sourcegraph Operator authentication
 		// provider is actually enabled.
-		if spec != nil && spec.ServiceType == sourcegraphoperator.ProviderType &&
+		if spec != nil && spec.ServiceType == auth.SourcegraphOperatorProviderType &&
 			cloud.SiteConfig().SourcegraphOperatorAuthProviderEnabled() {
 			return nil
 		}

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/sourcegraphoperator"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/cloud"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/license"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -97,7 +97,7 @@ func TestEnforcement_PreCreateUser(t *testing.T) {
 				)
 			},
 			spec: &extsvc.AccountSpec{
-				ServiceType: sourcegraphoperator.ProviderType,
+				ServiceType: auth.SourcegraphOperatorProviderType,
 			},
 		},
 	}

--- a/enterprise/cmd/frontend/worker/auth/sourcegraph_operator_cleaner_test.go
+++ b/enterprise/cmd/frontend/worker/auth/sourcegraph_operator_cleaner_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/sourcegraphoperator"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/cloud"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -33,7 +33,7 @@ func TestSourcegraphOperatorCleanHandler(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	logger := logtest.Scoped(t)
+	logger := logtest.NoOp(t)
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	handler := sourcegraphOperatorCleanHandler{
 		db:                db,
@@ -64,7 +64,7 @@ func TestSourcegraphOperatorCleanHandler(t *testing.T) {
 			Username: "morgan",
 		},
 		extsvc.AccountSpec{
-			ServiceType: sourcegraphoperator.ProviderType,
+			ServiceType: auth.SourcegraphOperatorProviderType,
 			ServiceID:   "https://sourcegraph.com",
 			ClientID:    "soap",
 			AccountID:   "morgan",
@@ -93,7 +93,7 @@ func TestSourcegraphOperatorCleanHandler(t *testing.T) {
 			Username: "jordan",
 		},
 		extsvc.AccountSpec{
-			ServiceType: sourcegraphoperator.ProviderType,
+			ServiceType: auth.SourcegraphOperatorProviderType,
 			ServiceID:   "https://sourcegraph.com",
 			ClientID:    "soap",
 			AccountID:   "jordan",
@@ -108,7 +108,7 @@ func TestSourcegraphOperatorCleanHandler(t *testing.T) {
 			Username: "riley",
 		},
 		extsvc.AccountSpec{
-			ServiceType: sourcegraphoperator.ProviderType,
+			ServiceType: auth.SourcegraphOperatorProviderType,
 			ServiceID:   "https://sourcegraph.com",
 			ClientID:    "soap",
 			AccountID:   "riley",

--- a/internal/actor/actor.go
+++ b/internal/actor/actor.go
@@ -36,6 +36,9 @@ type Actor struct {
 	// not tied to a specific user).
 	Internal bool `json:",omitempty"`
 
+	// SourcegraphOperator indicates whether the actor is a Sourcegraph operator user account.
+	SourcegraphOperator bool `json:",omitempty"`
+
 	// FromSessionCookie is whether a session cookie was used to authenticate the actor. It is used
 	// to selectively display a logout link. (If the actor wasn't authenticated with a session
 	// cookie, logout would be ineffective.)

--- a/internal/auth/const.go
+++ b/internal/auth/const.go
@@ -1,0 +1,5 @@
+package auth
+
+// SourcegraphOperatorProviderType is the unique identifier of the Sourcegraph
+// Operator authentication provider.
+const SourcegraphOperatorProviderType = "sourcegraph-operator"

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -9,8 +9,10 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/audit"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -42,9 +44,10 @@ const (
 
 	SecurityEventNameAccessGranted SecurityEventName = "AccessGranted"
 
-	SecurityEventAccessTokenCreated     SecurityEventName = "AccessTokenCreated"
-	SecurityEventAccessTokenDeleted     SecurityEventName = "AccessTokenDeleted"
-	SecurityEventAccessTokenHardDeleted SecurityEventName = "AccessTokenHardDeleted"
+	SecurityEventAccessTokenCreated      SecurityEventName = "AccessTokenCreated"
+	SecurityEventAccessTokenDeleted      SecurityEventName = "AccessTokenDeleted"
+	SecurityEventAccessTokenHardDeleted  SecurityEventName = "AccessTokenHardDeleted"
+	SecurityEventAccessTokenImpersonated SecurityEventName = "AccessTokenImpersonated"
 
 	SecurityEventGitHubAuthSucceeded SecurityEventName = "GitHubAuthSucceeded"
 	SecurityEventGitHubAuthFailed    SecurityEventName = "GitHubAuthFailed"
@@ -104,8 +107,22 @@ func (s *securityEventLogsStore) Insert(ctx context.Context, event *SecurityEven
 }
 
 func (s *securityEventLogsStore) InsertList(ctx context.Context, events []*SecurityEvent) error {
+	actor := actor.FromContext(ctx)
 	vals := make([]*sqlf.Query, len(events))
 	for index, event := range events {
+		// Add an attribution for Sourcegraph operator to be distinguished in our analytics pipelines
+		if actor.SourcegraphOperator {
+			result, err := jsonc.Edit(
+				event.marshalArgumentAsJSON(),
+				true,
+				"sourcegraph_operator",
+			)
+			event.Argument = json.RawMessage(result)
+			if err != nil {
+				return errors.Wrap(err, `edit "argument" for Sourcegraph operator`)
+			}
+		}
+
 		vals[index] = sqlf.Sprintf(`(%s, %s, %s, %s, %s, %s, %s, %s)`,
 			event.Name,
 			event.URL,


### PR DESCRIPTION
This PR adds instruments for SOAP-related event logs, including:

1. All GraphQL requests (both the cookie or access token authenticated) are logged for SOAP users.
2. All event logs and security event logs are attributed with `"sourcegraph_operator": true` in the `public_argument` and `argument` columns respectively.

Below are the captures of event logs that we want in both `event_logs` and `security_event_logs` tables:

<img width="1067" alt="CleanShot 2022-11-16 at 19 35 26@2x" src="https://user-images.githubusercontent.com/2946214/202170282-d688ff32-fa49-4e48-805b-c8ddf1a6fdb0.png">

<img width="711" alt="CleanShot 2022-11-16 at 19 34 55@2x" src="https://user-images.githubusercontent.com/2946214/202170209-5af04f85-f791-4891-a35a-d651077e843d.png">


## Test plan

1. Create a temporary JSON file (`site-config.json`) with the following content, the credentials can be obtained from the "Okta test instance admin" in 1Password and the "OpenID Connect (sourcegraph.test:3443)" application:
	```json
	{
	  "authProviders": {
	    "sourcegraphOperator": {
	      "issuer": "https://dev-433675.oktapreview.com",
	      "clientID": "<REDACTED>",
	      "clientSecret": "<REDACTED>",
	      "lifecycleDuration": 60
	    }
	  }
	}
	```
3. Save the "Sourcegraph Cloud site config singer key" in 1Password to a temporary file (`singer.key`), and use it to sign the site config:
	```sh
	go run enterprise/internal/cloud/sign_site_config.go -private-key singer.key  -site-config site-config.json
	```
4. Set the output of the above command as the value of the env var `SRC_CLOUD_SITE_CONFIG`
5. Comment out the `"licenseKey"` from the `dev-private/enterprise/dev/site-config.json`
6. Boot up the local Sourcegraph instance and try to sign in with "Sourcergaph Operators" using the same Okta account used in step 1.
7. Entries generated in `event_logs` and `security_event_logs` are attributed with `"sourcegraph_operator": true` in `public_argument` and `argument` columns respectively.

---

~~Stacked on https://github.com/sourcegraph/sourcegraph/pull/44200,~~ closes  https://github.com/sourcegraph/customer/issues/1428
