### PR TITLE
codenotify: lower the notify threshold to 10

### DIFF
--- a/.github/workflows/CODENOTIFY
+++ b/.github/workflows/CODENOTIFY
@@ -1,6 +1,6 @@
 # See https://github.com/sourcegraph/codenotify for documentation.
 
-codenotify.yml @nicksnyder
+codenotify.yml @unknwon
 
 licenses-check.yml          @bobheadxi
 licenses-update.yml         @bobheadxi

--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -15,13 +15,13 @@ jobs:
       - uses: sourcegraph/codenotify@v0.6.2
         with:
           filename: 'CODENOTIFY'
-          subscriber-threshold: '15'
+          subscriber-threshold: '10'
         env:
           GITHUB_TOKEN: ${{ secrets.CODENOTIFY_GITHUB_TOKEN }}
       - uses: sourcegraph/codenotify@v0.6.2
         continue-on-error: true
         with:
           filename: 'OWNERS'
-          subscriber-threshold: '15'
+          subscriber-threshold: '10'
         env:
           GITHUB_TOKEN: ${{ secrets.CODENOTIFY_GITHUB_TOKEN }}


### PR DESCRIPTION
I think the current 15 (that I originally proposed) is still a low signal based on recent PRs I got notified.

## Test plan

n/a
