### PR TITLE
bext: remove Search on Sourcegraph buttons from GitHub search pages

### DIFF
--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 ## Unreleased
 
 - Add new GitHub UI support: [issues/44237](https://github.com/sourcegraph/sourcegraph/issues/44237), [pull/44285](https://github.com/sourcegraph/sourcegraph/pull/44285)
+- Remove 'Search on Sourcegraph' buttons from GitHub search pages: [pull/44328](https://github.com/sourcegraph/sourcegraph/pull/44328)
 
 ## Chrome 22.10.18.1144, Firefox 22.10.18.1133, Safari v1.17
 

--- a/client/browser/src/integration/github.test.ts
+++ b/client/browser/src/integration/github.test.ts
@@ -762,7 +762,9 @@ describe('GitHub', () => {
         })
     })
 
-    describe('Search pages', () => {
+    // TODO(#44327): Search on Sourcegraph buttons were removed from GitHub search pages.
+    // We need to reenable these tests if we decide to keep those buttons or delete them if we don't.
+    describe.skip('Search pages', () => {
         const sourcegraphSearchPage = 'https://sourcegraph.com/search'
 
         const pages = [

--- a/client/browser/src/shared/code-hosts/github/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/github/codeHost.tsx
@@ -426,7 +426,7 @@ export interface GithubCodeHost extends CodeHost {
         onChange: (args: { value: string; searchURL: string; resultElement: HTMLElement }) => void
     }
 
-    enhanceSearchPage: (sourcegraphURL: string) => void
+    // enhanceSearchPage: (sourcegraphURL: string) => void
 }
 
 export const isGithubCodeHost = (codeHost: CodeHost): codeHost is GithubCodeHost => codeHost.type === 'github'
@@ -678,7 +678,7 @@ export const githubCodeHost: GithubCodeHost = {
     type: 'github',
     name: checkIsGitHubEnterprise() ? 'GitHub Enterprise' : 'GitHub',
     searchEnhancement,
-    enhanceSearchPage,
+    // enhanceSearchPage,
     codeViewResolvers: [genericCodeViewResolver, fileLineContainerResolver, searchResultCodeViewResolver],
     contentViewResolvers: [markdownBodyViewResolver],
     nativeTooltipResolvers: [nativeTooltipResolver],


### PR DESCRIPTION
Removes Search on Sourcegraph buttons from GitHub search pages as they don't work as expected anymore with the new GitHub UI and search fuctionality. 

Follow-up issue: https://github.com/sourcegraph/sourcegraph/issues/44327

## Test plan
- CI passes

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-bext-disable-search.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

