### PR TITLE
chore: Fix pattern in .gitattributes to match mock files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,4 @@ cmd/repo-updater/repos/testdata/** linguist-generated=true
 **/Cargo.lock linguist-generated=true
 **/*.pb.go linguist-generated=true
 CHANGELOG.md merge=union
-**/mock_*_test.go linguist-generated=true
+**/mocks*_*test.go linguist-generated=true


### PR DESCRIPTION
IDK when these got renamed, but looks like .gitattribute matching broke.

## Test plan

n/a, verified manually with `fd 'mocks_test' | xargs git check-attr --all`