### PR TITLE
ci/prettier: update prettier, and fix single target lint

### DIFF
--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -67,9 +67,13 @@ export const SearchPage: React.FunctionComponent<React.PropsWithChildren<SearchP
             <BrandLogo className={styles.logo} isLightTheme={props.isLightTheme} variant="logo" />
             {props.isSourcegraphDotCom && (
                 <div className="d-flex flex-row">
-                    <div className={classNames('text-muted text-center mt-3 mr-2 pr-2 border-right')}>Search millions of open source repositories</div>
+                    <div className={classNames('text-muted text-center mt-3 mr-2 pr-2 border-right')}>
+                        Search millions of open source repositories
+                    </div>
                     <div className="mt-3">
-                        <Link to="https://signup.sourcegraph.com/" onClick={() => eventLogger.log('ClickedOnCloudCTA')}>Search private code</Link>
+                        <Link to="https://signup.sourcegraph.com/" onClick={() => eventLogger.log('ClickedOnCloudCTA')}>
+                            Search private code
+                        </Link>
                     </div>
                 </div>
             )}

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -89,9 +89,10 @@ var Targets = []Target{
 			bashSyntax,
 		},
 	},
+	Formatting,
 }
 
-var FormattingTarget = Target{
+var Formatting = Target{
 	Name:        "format",
 	Description: "Check client code and docs for formatting errors",
 	Checks: []*linter{

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -89,7 +89,6 @@ var Targets = []Target{
 			bashSyntax,
 		},
 	},
-	Formatting,
 }
 
 var Formatting = Target{

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -89,6 +89,7 @@ var Targets = []Target{
 			bashSyntax,
 		},
 	},
+	Formatting,
 }
 
 var Formatting = Target{

--- a/dev/sg/sg_lint.go
+++ b/dev/sg/sg_lint.go
@@ -80,8 +80,8 @@ sg lint --help
 
 		if len(targets) == 0 {
 			// If no args provided, run all
-			for _, t := range linters.Targets {
-				lintTargets = append(lintTargets, t)
+			lintTargets = linters.Targets
+			for _, t := range lintTargets {
 				targets = append(targets, t.Name)
 			}
 

--- a/dev/sg/sg_lint.go
+++ b/dev/sg/sg_lint.go
@@ -151,7 +151,7 @@ func (lt lintTargets) Commands() (cmds []*cli.Command) {
 
 				lintTargets := []linters.Target{target}
 				// Always add the format check, unless specified otherwise!
-				if !lintNoFormatCheck.Get(cmd) {
+				if !lintNoFormatCheck.Get(cmd) && target.Name != linters.Formatting.Name {
 					lintTargets = append(lintTargets, linters.Formatting)
 				}
 

--- a/dev/sg/sg_lint.go
+++ b/dev/sg/sg_lint.go
@@ -31,10 +31,10 @@ var lintFailFast = &cli.BoolFlag{
 	Value:   true,
 }
 
-var lintNoFormatCheck = &cli.BoolFlag{
-	Name:    "no-format-check",
-	Aliases: []string{"nfc"},
-	Usage:   "Don't check file formatting",
+var lintSkipFormatCheck = &cli.BoolFlag{
+	Name:    "skip-format-check",
+	Aliases: []string{"sfc"},
+	Usage:   "Skip file formatting check",
 	Value:   false,
 }
 
@@ -64,7 +64,7 @@ sg lint --help
 		generateAnnotations,
 		lintFix,
 		lintFailFast,
-		lintNoFormatCheck,
+		lintSkipFormatCheck,
 	},
 	Before: func(cmd *cli.Context) error {
 		// If more than 1 target is requested, hijack subcommands by setting it to nil
@@ -81,7 +81,7 @@ sg lint --help
 		if len(targets) == 0 {
 			// If no args provided, run all
 			for _, t := range linters.Targets {
-				if lintNoFormatCheck.Get(cmd) {
+				if lintSkipFormatCheck.Get(cmd) {
 					continue
 				}
 
@@ -110,8 +110,8 @@ sg lint --help
 				lintTargets = append(lintTargets, target)
 			}
 
-			// If we haven't added the format target already, add it! Unless specified otherwise
-			if !lintNoFormatCheck.Get(cmd) && !hasFormatTarget {
+			// If we haven't added the format target already, add it! Unless we must skip it
+			if !lintSkipFormatCheck.Get(cmd) && !hasFormatTarget {
 				lintTargets = append(lintTargets, linters.Formatting)
 				targets = append(targets, linters.Formatting.Name)
 
@@ -157,8 +157,8 @@ func (lt lintTargets) Commands() (cmds []*cli.Command) {
 
 				lintTargets := []linters.Target{target}
 				targets := []string{target.Name}
-				// Always add the format check, unless specified otherwise!
-				if !lintNoFormatCheck.Get(cmd) && target.Name != linters.Formatting.Name {
+				// Always add the format check, unless we must skip it!
+				if !lintSkipFormatCheck.Get(cmd) && target.Name != linters.Formatting.Name {
 					lintTargets = append(lintTargets, linters.Formatting)
 					targets = append(targets, linters.Formatting.Name)
 

--- a/dev/sg/sg_lint.go
+++ b/dev/sg/sg_lint.go
@@ -80,14 +80,15 @@ sg lint --help
 
 		if len(targets) == 0 {
 			// If no args provided, run all
-			lintTargets = linters.Targets
-			for _, t := range lintTargets {
+			for _, t := range linters.Targets {
+				// skip adding the formatting check
 				if lintNoFormatCheck.Get(cmd) && t.Name == linters.Formatting.Name {
-					// don't add the format check if it is disabled
 					continue
 				}
+				lintTargets = append(lintTargets, t)
 				targets = append(targets, t.Name)
 			}
+
 		} else {
 			// Otherwise run requested set
 			allLintTargetsMap := make(map[string]linters.Target, len(linters.Targets))

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -387,7 +387,7 @@ Flags:
 * `--fail-fast, --ff`: Exit immediately if an issue is encountered (not available with '-fix')
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--fix, -f`: Try to fix any lint issues
-* `--no-format-check, --nfc`: Don't check file formatting
+* `--skip-format-check, --sfc`: Skip file formatting check
 
 ### sg lint urls
 
@@ -446,6 +446,15 @@ Flags:
 ### sg lint shell
 
 Check shell code for linting errors, formatting, etc.
+
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
+
+### sg lint format
+
+Check client code and docs for formatting errors.
 
 
 Flags:

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -122,7 +122,7 @@ func addSgLints(targets []string) func(pipeline *bk.Pipeline) {
 
 	formatCheck := ""
 	if runType.Is(runtype.MainBranch) || runType.Is(runtype.MainDryRun) {
-		formatCheck = "--no-format-check "
+		formatCheck = "--skip-format-check "
 	}
 
 	cmd = cmd + "lint -annotations -fail-fast=false " + formatCheck + strings.Join(targets, " ")

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "yarn": "^1.22.4"
   },
   "scripts": {
-    "format": "prettier '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --list-different --config prettier.config.js --write",
+    "format": "prettier  '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --list-different --config prettier.config.js --write",
     "format:changed": "prettier $(git diff --diff-filter=d --name-only origin/main... && git ls-files --other --modified --exclude-standard | grep -E '\\.(js|json|ts|tsx|graphql|md|scss)$' | xargs) --write --list-different --config prettier.config.js",
     "format:check": "prettier '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --list-different  --config prettier.config.js --write=false",
     "_lint:js": "DOCSITE_LIST=\"$(./dev/docsite.sh -config doc/docsite.json ls)\" NODE_OPTIONS=\"--max_old_space_size=16192\" eslint",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "format": "prettier  '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --list-different --config prettier.config.js --write",
     "format:changed": "prettier $(git diff --diff-filter=d --name-only origin/main... && git ls-files --other --modified --exclude-standard | grep -E '\\.(js|json|ts|tsx|graphql|md|scss)$' | xargs) --write --list-different --config prettier.config.js",
-    "format:check": "prettier '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --list-different  --config prettier.config.js --write=false",
+    "format:check": "prettier '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --config prettier.config.js --check --write=false",
     "_lint:js": "DOCSITE_LIST=\"$(./dev/docsite.sh -config doc/docsite.json ls)\" NODE_OPTIONS=\"--max_old_space_size=16192\" eslint",
     "lint:js:changed": "yarn _lint:js $(git diff --diff-filter=d --name-only origin/main... | grep -E '\\.[tj]sx?$' | xargs)",
     "lint:js:root": "yarn run _lint:js --quiet '*.[tj]s?(x)'",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "yarn": "^1.22.4"
   },
   "scripts": {
-    "format": "prettier  '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --list-different --config prettier.config.js --write",
+    "format": "prettier '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --list-different --config prettier.config.js --write",
     "format:changed": "prettier $(git diff --diff-filter=d --name-only origin/main... && git ls-files --other --modified --exclude-standard | grep -E '\\.(js|json|ts|tsx|graphql|md|scss)$' | xargs) --write --list-different --config prettier.config.js",
     "format:check": "prettier '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --config prettier.config.js --check --write=false",
     "_lint:js": "DOCSITE_LIST=\"$(./dev/docsite.sh -config doc/docsite.json ls)\" NODE_OPTIONS=\"--max_old_space_size=16192\" eslint",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "yarn": "^1.22.4"
   },
   "scripts": {
-    "format": "prettier '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --write --list-different --config prettier.config.js",
+    "format": "prettier '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --list-different --config prettier.config.js --write",
     "format:changed": "prettier $(git diff --diff-filter=d --name-only origin/main... && git ls-files --other --modified --exclude-standard | grep -E '\\.(js|json|ts|tsx|graphql|md|scss)$' | xargs) --write --list-different --config prettier.config.js",
-    "format:check": "yarn run format --write=false --check --list-different=false --loglevel=warn",
+    "format:check": "prettier '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --list-different  --config prettier.config.js --write=false",
     "_lint:js": "DOCSITE_LIST=\"$(./dev/docsite.sh -config doc/docsite.json ls)\" NODE_OPTIONS=\"--max_old_space_size=16192\" eslint",
     "lint:js:changed": "yarn _lint:js $(git diff --diff-filter=d --name-only origin/main... | grep -E '\\.[tj]sx?$' | xargs)",
     "lint:js:root": "yarn run _lint:js --quiet '*.[tj]s?(x)'",
@@ -318,7 +318,7 @@
     "postcss-focus-visible": "^5.0.0",
     "postcss-loader": "^6.1.1",
     "postcss-modules": "^4.2.2",
-    "prettier": "2.2.1",
+    "prettier": "2.7.1",
     "process": "^0.11.10",
     "protoc-gen-ts": "0.8.1",
     "puppeteer": "^13.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28875,7 +28875,7 @@ pvutils@latest:
     postcss-inset: ^1.0.0
     postcss-loader: ^6.1.1
     postcss-modules: ^4.2.2
-    prettier: 2.2.1
+    prettier: 2.7.1
     pretty-bytes: ^5.3.0
     process: ^0.11.10
     prop-types: ^15.7.2


### PR DESCRIPTION
Lint formatting failures have been sneaking into main and it's due to a special case in a PR when the formatting check was not applied.

## When format lint is applied
In the primary lint action, the formatting lint is always added unless you specify `--no-format-check`.
The primary lint action is executed when:
* When you specify no lint targets
* Specify **more than one** lint target

## When format lint is **NOT** applied
The `sg lint` command as a special case in its `Before`, where it checks how many targets there are, then deciding whether the primary action should handle the targets (targets > 1) or if it is a single target, let the subcommand action handle it.
The subcommand action didn't add the formatting lint, _so if your PR diff only touched one "category" like Client, then the formatting lint will **not run** as in this [PR run](https://buildkite.com/sourcegraph/sourcegraph/builds/183015#018467fc-b9c2-4890-b97e-8abcc90cd709)_.

## Test plan
1. `sg lint`
```
go run ./dev/sg lint
👉 Running checks from targets: urls, go, docs, dockerfiles, client, svg, shell, format
│
├── 1. urls         Done!                                                                                                                                                                                                      3s
├── 2. go           Running checks...                                                                                                                                                                                          5s
├── 3. docs         Running checks...                                                                                                                                                                                          5s
├── 4. dockerfiles  Running checks...                                                                                                                                                                                          5s
├── 5. client       Running checks...                                                                                                                                                                                          5s
├── 6. svg          Category skipped: disabled: reported as unreliable                                                                                                                                                         0s
├── 7. shell        Running checks...                                                                                                                                                                                          5s
└── 8. format       Running checks... 
```
3. `sg lint client`
```
go run ./dev/sg lint client
👉 Running checks from target: client

│
├── 1. client  Running checks...                                                                                                                                                                                               2s
└── 2. format  Running checks... 
```
5. `sg lint client docs`
```
go run ./dev/sg lint client docs
👉 Running checks from targets: client, docs, format
│
├── 1. client  Done!                                                                                                                                                                                                           7s
├── 2. docs    Done!                                                                                                                                                                                                          26s
└── 3. format  Running checks... 
```
6. `sg lint --no-format-check`
```
go run ./dev/sg lint --no-format-check
👉 Running checks from targets: urls, go, docs, dockerfiles, client, svg, shell
⠋  Running checks  
│
├── 1. urls         Running checks...                                                                                                                                                                                          2s
├── 2. go           Running checks...                                                                                                                                                                                          2s
├── 3. docs         Running checks...                                                                                                                                                                                          2s
├── 4. dockerfiles  Running checks...                                                                                                                                                                                          2s
├── 5. client       Running checks...                                                                                                                                                                                          2s
├── 6. svg          Category skipped: disabled: reported as unreliable                                                                                                                                                         0s
└── 7. shell        Running checks...
```
8. `sg lint --no-format-check client`
```
go run ./dev/sg lint --no-format-check client
👉 Running checks from target: client
✅ 1. client (3s)

👌 Everything looks good! Happy hacking!
```

You can also see it now picks up a format error that sneaked into main on _https://buildkite.com/sourcegraph/sourcegraph/builds/183251_

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-wb-prettier-check.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
