### PR TITLE
log: Remove noisy log

### DIFF
--- a/internal/actor/http.go
+++ b/internal/actor/http.go
@@ -126,7 +126,6 @@ func HTTPMiddleware(logger log.Logger, next http.Handler) http.Handler {
 				ctx = WithActor(ctx, FromAnonymousUser(anonymousUID))
 			}
 			metricIncomingActors.WithLabelValues(metricActorTypeNone, path).Inc()
-			logger.Warn("request received without actor", log.String("path", req.URL.Path), log.String("remote", req.RemoteAddr))
 
 		// Request associated with authenticated user - add user actor to context
 		default:


### PR DESCRIPTION
Remove a noisy log that was there just to help us narrow down where
missing actors were occurring. Don't want this to confuse customers so
removing before branch cut.

## Test plan

None, just removed a log line