### PR TITLE
insights: update benchmark setup for more scenarios for loading series points

### DIFF
--- a/enterprise/internal/insights/store/insight_store_test.go
+++ b/enterprise/internal/insights/store/insight_store_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hexops/autogold"
 	"github.com/hexops/valast"
-	"github.com/inconshreveable/log15"
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/log/logtest"
@@ -993,8 +992,6 @@ func TestCreateSeries(t *testing.T) {
 			GroupBy:              &groupByRepo,
 			SupportsAugmentation: true,
 		}
-
-		log15.Info("values", "want", want, "got", got)
 
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("unexpected result from create insight series (want/got): %s", diff)

--- a/enterprise/internal/insights/store/store_benchs_test.go
+++ b/enterprise/internal/insights/store/store_benchs_test.go
@@ -171,6 +171,16 @@ func BenchmarkLoadTimes(b *testing.B) {
 			times: 12,
 		},
 		{
+			name:  "10000 repos no capture no restrictions", // 10,000 * 12 = 120,000 samples
+			repos: 10000,
+			times: 12,
+		},
+		{
+			name:  "100000 repos no capture no restrictions", // 100,000 * 12 = 1,200,000 samples
+			repos: 100000,
+			times: 12,
+		},
+		{
 			name:    "1000 repos 100 capture no restrictions", // 1000 * 100 * 12 = 1,200,000 samples
 			repos:   1000,
 			times:   12,

--- a/enterprise/internal/insights/store/store_benchs_test.go
+++ b/enterprise/internal/insights/store/store_benchs_test.go
@@ -141,9 +141,21 @@ func BenchmarkLoadTimes(b *testing.B) {
 		times   int
 	}{
 		{
-			name:  "simple",
+			name:  "1000 repos no capture no restrictions", // 1000 * 12 = 12,000 samples
 			repos: 1000,
 			times: 12,
+		},
+		{
+			name:    "1000 repos 100 capture no restrictions", // 1000 * 100 * 12 = 1,200,000 samples
+			repos:   1000,
+			times:   12,
+			capture: 100,
+		},
+		{
+			name:    "500 repos 200 capture no restrictions", // 500 * 200 * 12 = 1,200,000 samples
+			repos:   500,
+			times:   12,
+			capture: 200,
 		},
 	}
 	for _, bm := range benchmarks {
@@ -159,7 +171,9 @@ func BenchmarkLoadTimes(b *testing.B) {
 
 		opts := SeriesPointsOpts{SeriesID: &seriesID}
 
-		b.Run("in-db-aggregate", func(b *testing.B) {
+		b.ResetTimer()
+
+		b.Run("in-db-aggregate-"+bm.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, err := store.SeriesPoints(ctx, opts)
 				if err != nil {
@@ -168,7 +182,7 @@ func BenchmarkLoadTimes(b *testing.B) {
 			}
 		})
 
-		b.Run("in-mem-aggregate", func(b *testing.B) {
+		b.Run("in-mem-aggregate-"+bm.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, err := store.LoadSeriesInMem(ctx, opts)
 				if err != nil {

--- a/enterprise/internal/insights/store/store_benchs_test.go
+++ b/enterprise/internal/insights/store/store_benchs_test.go
@@ -182,6 +182,19 @@ func BenchmarkLoadTimes(b *testing.B) {
 			times:   12,
 			capture: 200,
 		},
+		{
+			name:         "1000 repos no capture 500 restrictions",
+			repos:        1000,
+			times:        12,
+			restrictions: 500,
+		},
+		{
+			name:         "1000 repos 200 capture 500 restrictions",
+			repos:        1000,
+			times:        12,
+			capture:      200,
+			restrictions: 500,
+		},
 	}
 	for _, bm := range benchmarks {
 		logger := logtest.Scoped(b)
@@ -194,7 +207,7 @@ func BenchmarkLoadTimes(b *testing.B) {
 
 		seriesID := initializeData(ctx, store, bm.repos, bm.times, bm.capture)
 
-		opts := SeriesPointsOpts{SeriesID: &seriesID}
+		opts := SeriesPointsOpts{SeriesID: &seriesID, Excluded: generateRepoRestrictions(bm.restrictions, bm.repos)}
 
 		b.ResetTimer()
 


### PR DESCRIPTION
part of #42403 - I think it might be worth recording values on a live environment because the local go environment is much slower than testing it from an environment.

```
go test -bench=. -count 1 -run=^#
goos: darwin
goarch: arm64
pkg: github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store
BenchmarkLoadTimes/in-db-aggregate-1000_repos_no_capture_no_restrictions-10         	     145	   8376378 ns/op
BenchmarkLoadTimes/in-mem-aggregate-1000_repos_no_capture_no_restrictions-10        	     130	   9305475 ns/op
BenchmarkLoadTimes/in-db-aggregate-10000_repos_no_capture_no_restrictions-10        	       7	 161821994 ns/op
BenchmarkLoadTimes/in-mem-aggregate-10000_repos_no_capture_no_restrictions-10       	      13	  86932478 ns/op
BenchmarkLoadTimes/in-db-aggregate-100000_repos_no_capture_no_restrictions-10       	       1	1920917208 ns/op
BenchmarkLoadTimes/in-mem-aggregate-100000_repos_no_capture_no_restrictions-10      	       2	 958232375 ns/op
BenchmarkLoadTimes/in-db-aggregate-1000_repos_100_capture_no_restrictions-10        	       1	2466745250 ns/op
BenchmarkLoadTimes/in-mem-aggregate-1000_repos_100_capture_no_restrictions-10       	       1	1088576584 ns/op
BenchmarkLoadTimes/in-db-aggregate-500_repos_200_capture_no_restrictions-10         	       1	2707287791 ns/op
BenchmarkLoadTimes/in-mem-aggregate-500_repos_200_capture_no_restrictions-10        	       1	1134338541 ns/op
BenchmarkLoadTimes/in-db-aggregate-1000_repos_no_capture_500_restrictions-10        	     216	   5555030 ns/op
BenchmarkLoadTimes/in-mem-aggregate-1000_repos_no_capture_500_restrictions-10       	     165	   6861333 ns/op
BenchmarkLoadTimes/in-db-aggregate-1000_repos_200_capture_500_restrictions-10       	       1	2962200583 ns/op
BenchmarkLoadTimes/in-mem-aggregate-1000_repos_200_capture_500_restrictions-10      	       1	1411469666 ns/op
PASS
ok  	github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store	440.328s
```

some findings
* more capture vs more repos adds more complexity (e.g. 1.2m samples with 100 capture is roughly 2500ms, 1.2m samples with 200 capture is 2700ms)
* speed doesn't grow linearly with number of samples (for non-capture points), 8.4ms (12k) -> 160 ms (120k) -> 1900 ms (1.2m)
* on the whole loading in memory is faster than loading in db. this becomes more noticeable as sample size grows

## Test plan
Added and ran benchmarks (they are slow but I don't believe they're ran as part of our CI pipeline)