### PR TITLE
searcher: downgrade hybrid logs to debug

### DIFF
--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -62,7 +62,7 @@ func (s *Service) hybrid(ctx context.Context, p *protocol.Request, sender matchS
 			return nil, false, err
 		}
 		if !ok {
-			logger.Warn("failed to find indexed commit")
+			logger.Debug("failed to find indexed commit")
 			recordHybridFinalState("zoekt-list-missing")
 			return nil, false, nil
 		}
@@ -96,13 +96,13 @@ func (s *Service) hybrid(ctx context.Context, p *protocol.Request, sender matchS
 			log.Int("totalLenUnindexedSearchPaths", totalLenUnindexedSearch))
 
 		if totalLenIndexedIgnore > s.MaxTotalPathsLength || totalLenUnindexedSearch > s.MaxTotalPathsLength {
-			logger.Info("not doing hybrid search due to changed file list exceeding MAX_TOTAL_PATHS_LENGTH",
+			logger.Debug("not doing hybrid search due to changed file list exceeding MAX_TOTAL_PATHS_LENGTH",
 				log.Int("MAX_TOTAL_PATHS_LENGTH", s.MaxTotalPathsLength))
 			recordHybridFinalState("diff-too-large")
 			return nil, false, nil
 		}
 
-		logger.Info("starting zoekt search")
+		logger.Debug("starting zoekt search")
 
 		ok, err = zoektSearchIgnorePaths(ctx, client, p, sender, indexed, indexedIgnore)
 		if err != nil {

--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -245,7 +245,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 			return errors.Wrap(err, "hybrid search failed")
 		}
 		if !ok {
-			s.Log.Warn("hybrid search is falling back to normal unindexed search",
+			s.Log.Debug("hybrid search is falling back to normal unindexed search",
 				log.String("repo", string(p.Repo)),
 				log.String("commit", string(p.Commit)))
 		} else {


### PR DESCRIPTION
The "failed to find indexed commit" fires often for Sourcegraph.com since it only indexes a subset of repos. Additionally in production our default log level is warn. The log levels were inflated to help understand the feature, but given we can't see them in prod nor do we want to ship with these levels, they are turned down to debug.

Test Plan: CI

Part of #37112 