### PR TITLE
codeintel: fix broken link to precise codenav docs

### DIFF
--- a/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsCodeIntelPage/index.tsx
@@ -355,7 +355,7 @@ export const AnalyticsCodeIntelPage: React.FunctionComponent<RouteComponentProps
                                 <b>{repos.preciseCodeIntelCount}</b> of your <b>{repos.count}</b> repositories have
                                 precise code navigation.{' '}
                                 <AnchorLink
-                                    to="/help/code_navigation/explanations/precise_code_intelligence"
+                                    to="/help/code_navigation/explanations/precise_code_navigation"
                                     target="_blank"
                                 >
                                     Learn how to improve precise code navigation coverage.


### PR DESCRIPTION
Link was broken, reported by @kevin-quigley 

Occurred here https://github.com/sourcegraph/sourcegraph/pull/40729

## Test plan

Tested locally :+1: 

## App preview:

- [Web](https://sg-web-nsc-codeintel-doclink-fix.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

