### PR TITLE
executors: Remove me-central-1 until has support in Service Quotas

### DIFF
--- a/enterprise/cmd/executor/docker-mirror/aws_regions.json
+++ b/enterprise/cmd/executor/docker-mirror/aws_regions.json
@@ -18,7 +18,6 @@
   "eu-north-1",
   "ca-central-1",
   "me-south-1",
-  "me-central-1",
   "ap-east-1",
   "af-south-1"
 ]

--- a/enterprise/cmd/executor/vm-image/aws_regions.json
+++ b/enterprise/cmd/executor/vm-image/aws_regions.json
@@ -18,7 +18,6 @@
   "eu-north-1",
   "ca-central-1",
   "me-south-1",
-  "me-central-1",
   "ap-east-1",
   "af-south-1"
 ]


### PR DESCRIPTION
At the moment, `me-central-1` does not have Service Quotas support in AWS. This does not allow us to request a quota increase to our Public AMIs limit. To avoid issues, remove this region.

## Test plan

Manual validation.