### PR TITLE
app-token: skip if envvars are missing in tests

### DIFF
--- a/enterprise/dev/ci/scripts/app-token/main_test.go
+++ b/enterprise/dev/ci/scripts/app-token/main_test.go
@@ -22,14 +22,17 @@ var updateRecordings = flag.Bool("update-integration", false, "refresh integrati
 func TestGenJwtToken(t *testing.T) {
 	if os.Getenv("BUILDKITE") == "true" {
 		t.Skip("Skipping testing in CI environment")
-	} else {
-		appID := os.Getenv("GITHUB_APP_ID")
-		require.NotEmpty(t, appID, "GITHUB_APP_ID must be set.")
-		keyPath := os.Getenv("KEY_PATH")
-		require.NotEmpty(t, keyPath, "KEY_PATH must be set.")
-		_, err := genJwtToken(appID, keyPath)
-		require.NoError(t, err)
 	}
+
+	appID := os.Getenv("GITHUB_APP_ID")
+	keyPath := os.Getenv("KEY_PATH")
+
+	if appID == "" || keyPath == "" {
+		t.Skip("GITHUB_APP_ID or KEY_PATH is not set")
+	}
+
+	_, err := genJwtToken(appID, keyPath)
+	require.NoError(t, err)
 }
 
 func newTestGitHubClient(ctx context.Context, t *testing.T) (ghc *github.Client, stop func() error) {


### PR DESCRIPTION
This requirement broke being able to run go test ./... on my dev machine. I suppose if you want to keep this maybe commit bogus app id and keys to testdata.

Test Plan: go test
