### PR TITLE
[dotcom] Add validation to subscription path param

### DIFF
--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.test.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.test.tsx
@@ -14,7 +14,12 @@ describe('UserSubscriptionsProductSubscriptionPage', () => {
         const component = renderWithBrandedContext(
             <UserSubscriptionsProductSubscriptionPage
                 user={{ settingsURL: '/u' }}
-                match={{ isExact: true, params: { subscriptionUUID: 's' }, path: '/p', url: '/p' }}
+                match={{
+                    isExact: true,
+                    params: { subscriptionUUID: '43002662-f627-4550-9af6-d621d2a878de' },
+                    path: '/p',
+                    url: '/p',
+                }}
                 _queryProductSubscription={() =>
                     of<ProductSubscriptionFieldsOnSubscriptionPage>({
                         __typename: 'ProductSubscription',

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
@@ -5,6 +5,7 @@ import * as H from 'history'
 import { RouteComponentProps } from 'react-router'
 import { Observable } from 'rxjs'
 import { catchError, map, startWith } from 'rxjs/operators'
+import { validate as validateUUID } from 'uuid'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { asError, createAggregateError, isErrorLike } from '@sourcegraph/common'
@@ -42,6 +43,9 @@ export const UserSubscriptionsProductSubscriptionPage: React.FunctionComponent<R
 }) => {
     useEffect(() => eventLogger.logViewEvent('UserSubscriptionsProductSubscription'), [])
 
+    const isValidUUID = validateUUID(subscriptionUUID)
+    const validationError = !isValidUUID && new Error('Subscription ID is not a valid UUID')
+
     /**
      * The product subscription, or loading, or an error.
      */
@@ -74,8 +78,8 @@ export const UserSubscriptionsProductSubscriptionPage: React.FunctionComponent<R
             </div>
             {productSubscription === LOADING ? (
                 <LoadingSpinner />
-            ) : isErrorLike(productSubscription) ? (
-                <ErrorAlert className="my-2" error={productSubscription} />
+            ) : !isValidUUID || isErrorLike(productSubscription) ? (
+                <ErrorAlert className="my-2" error={validationError || productSubscription} />
             ) : (
                 <>
                     <H2>Subscription {productSubscription.name}</H2>


### PR DESCRIPTION
- Fixes #39837

Changed the behavior to actually validate the path param in React code. That way we do not send bogus requests to graphql API and it does not need to fail in Postgres on invalid UUID check.

Originally I wanted to check the path param with react router, but apparently [they removed that functionality in v6](https://reactrouter.com/en/main/upgrading/v5) and I did not want to risk adding functionality that might break if we ever upgrade from v5.

> If you were using any of path-to-regexp's more advanced syntax, you'll have to remove it and simplify your route paths. If you were using the RegExp syntax to do URL param validation (e.g. to ensure an id is all numeric characters) please know that we plan to add some more advanced param validation in v6 at some point. For now, you'll need to move that logic to the component the route renders, and let it branch its rendered tree after you parse the params.

# Screenshots

## Before
<img width="914" alt="Screenshot 2022-11-14 at 17 45 11" src="https://user-images.githubusercontent.com/9974711/201723229-1f24a70a-b6a6-4b79-ba54-32b5c8825b15.png">

## After
<img width="679" alt="Screenshot 2022-11-14 at 18 10 15" src="https://user-images.githubusercontent.com/9974711/201723269-8f22be94-0a8a-45a0-ace8-c4e05c6e3064.png">


## Test plan

Tested locally manually. IMO no need to add a unit test.

## App preview:

- [Web](https://sg-web-milan-fix-new-subscription-error.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
