### PR TITLE
Manually trap web-ext return code to avoid throwing when uploading to the Mozilla store

### DIFF
--- a/client/browser/scripts/release-firefox.sh
+++ b/client/browser/scripts/release-firefox.sh
@@ -8,8 +8,22 @@ rm -rf build/web-ext
 mkdir -p build/web-ext
 
 # Sign the bundle
-yarn add web-ext
-yarn web-ext sign --source-dir ./build/firefox --artifacts-dir ./build/web-ext --api-key "$FIREFOX_AMO_ISSUER" --api-secret "$FIREFOX_AMO_SECRET"
+#
+# Due to an limitation of the web-ext package, we can not rely on the exit
+# status to know if the status was successful.
+#
+# c.f. https://github.com/mozilla/web-ext/issues/804
+set +e
+tmp="$(mktemp)"
+ok="Your add-on has been submitted for review."
+yarn dlx web-ext sign --source-dir ./build/firefox --artifacts-dir ./build/web-ext --api-key "$FIREFOX_AMO_ISSUER" --api-secret "$FIREFOX_AMO_SECRET" |
+  sed -n "s/\($ok\).*$/\0/;1,/$ok/p" |
+  tee "$tmp"
+error=${PIPESTATUS[0]}
+if ! grep -q "$ok" "$tmp" && [ "$error" = 1 ]; then
+  exit "$error"
+fi
+set -e
 
 # Upload to gcp and make it public
 pushd build/web-ext


### PR DESCRIPTION
Currently, whenever we publish a new browser extension version to the Mozilla store, the script fails even though the upload succeeds. This causes noise in our CI system and confusion amongst engineers.

This "fixes" this based on best practices from [this thread](https://github.com/mozilla/web-ext/issues/804) (we can't adopt the `web-ext-submit` script but this is applying a similar pattern directly in our bash script). 

## Test plan

Exit propagation works: 
<img width="1174" alt="Screenshot 2022-11-14 at 20 14 11" src="https://user-images.githubusercontent.com/458591/201745905-49c47a39-65a1-40b8-9507-7a95e93ec037.png">

The rest we have to try and see the next time we publish an extension?

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-ff-sign.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
