### PR TITLE
Scope a new logger in NewGitCommitResolver

### DIFF
--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -68,7 +68,14 @@ type GitCommitResolver struct {
 // commit will be loaded lazily as needed by the resolver. Pass in a commit when
 // you have batch-loaded a bunch of them and already have them at hand.
 func NewGitCommitResolver(db database.DB, gsClient gitserver.Client, repo *RepositoryResolver, id api.CommitID, commit *gitdomain.Commit) *GitCommitResolver {
+	var commitId = GitObjectID(id)
+	var repoName = repo.RepoName()
+
 	return &GitCommitResolver{
+		logger: log.Scoped("gitCommitResolver", "resolve a specific commit").
+			With(log.Object("commit",
+				log.String("repo", string(repoName)),
+				log.String("commitId", string(commitId)))),
 		db:              db,
 		gitserverClient: gsClient,
 		repoResolver:    repo,


### PR DESCRIPTION
GH Issue [44033](https://github.com/sourcegraph/sourcegraph/issues/44033)

`NewGitCommitResolver` returns a resolver with a nil logger. Once the query is submitted for language per the example provided in the GH issue 44033, the panic results from attempt to scope a new logger from the `GitCommitResolver's` logger member.

## Test plan

Manual testing