### PR TITLE
batches: set x-frame-options for svgs

### DIFF
--- a/cmd/frontend/internal/app/assetsutil/handler.go
+++ b/cmd/frontend/internal/app/assetsutil/handler.go
@@ -22,6 +22,7 @@ func NewAssetHandler(mux *http.ServeMux) http.Handler {
 		// circumstances that couldn't be reproduced
 		if filepath.Ext(r.URL.Path) == ".svg" {
 			w.Header().Set("Content-Type", "image/svg+xml")
+			w.Header().Set("X-Frame-Options", "sameorigin")
 		}
 		// Required for phabricator integration, some browser extensions block
 		// unless the mime type on externally loaded JS is set


### PR DESCRIPTION
Closes #44234

Some weeks ago, the asset handler was rewritten and some SVGs that add javascript embedded in them weren't rendered in the browser. I investigated ([thankfully, this was easy due to the fact that Kelli shared some context here](https://sourcegraph.slack.com/archives/CMMTWQQ49/p1668070197980909)) the issue by spinning up two instances of Sourcegraph:

- One using `esbuild` as the web buillder
- the other making use of `webpack`

On inspection of the SVG rendered by the Batch Changes WorkspacePreview component, I realized in the request headers that the `X-FRAME-OPTIONS` header was set to `DENY` [which is the default for services within Sourcegraph](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@d6c61f5/-/blob/cmd/frontend/internal/cli/http.go?L218).
![CleanShot 2022-11-14 at 22 06 40@2x](https://user-images.githubusercontent.com/25608335/201765773-cbdf4f9c-9703-43c0-af3f-ad3b37275f1a.png).

Because of this. [the SVG inserted into the `object` tag for the LoadingSpinner doesn't get rendered](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@bo/fix-batch-spec-spinner/-/blob/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/PreviewLoadingSpinner.tsx?L1%3A1-28%3A3), instead the fallback image is rendered.

Allowing `X-FRAME-OPTIONS` for SVGs from the same origin fixed this. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Confirmed that the animation for the SVG for the[ loading spinner](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@d6c61f5/-/blob/ui/assets/img/unoptimized/batchchanges-preview-loading.svg) is now animated and rendered as document in the DOM.