### PR TITLE
allow batch changes BB server webhook to use top-level webhook handler

### DIFF
--- a/cmd/frontend/backend/webhooks.go
+++ b/cmd/frontend/backend/webhooks.go
@@ -37,9 +37,9 @@ func (ws *webhookService) CreateWebhook(ctx context.Context, codeHostKind, codeH
 
 func validateCodeHostKindAndSecret(codeHostKind string, secret *string) error {
 	switch codeHostKind {
-	case extsvc.KindGitHub, extsvc.KindGitLab:
+	case extsvc.KindGitHub, extsvc.KindGitLab, extsvc.KindBitbucketServer:
 		return nil
-	case extsvc.KindBitbucketCloud, extsvc.KindBitbucketServer:
+	case extsvc.KindBitbucketCloud:
 		if secret != nil {
 			return errors.Newf("webhooks do not support secrets for code host kind %s", codeHostKind)
 		}

--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -76,7 +76,7 @@ func DefaultServices() Services {
 		GitHubSyncWebhook:               &emptyWebhookHandler{name: "github sync webhook"},
 		BatchesGitHubWebhook:            &emptyWebhookHandler{name: "batches github webhook"},
 		BatchesGitLabWebhook:            &emptyWebhookHandler{name: "batches gitlab webhook"},
-		BatchesBitbucketServerWebhook:   &emptyWebhookHandler{"batches bitbucket server webhook"},
+		BatchesBitbucketServerWebhook:   &emptyWebhookHandler{name: "batches bitbucket server webhook"},
 		BatchesBitbucketCloudWebhook:    makeNotFoundHandler("batches bitbucket cloud webhook"),
 		BatchesChangesFileGetHandler:    makeNotFoundHandler("batches file get handler"),
 		BatchesChangesFileExistsHandler: makeNotFoundHandler("batches file exists handler"),

--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -21,7 +21,7 @@ type Services struct {
 	// Batch Changes Services
 	BatchesGitHubWebhook            webhooks.Registerer
 	BatchesGitLabWebhook            webhooks.RegistererHandler
-	BatchesBitbucketServerWebhook   http.Handler
+	BatchesBitbucketServerWebhook   webhooks.RegistererHandler
 	BatchesBitbucketCloudWebhook    http.Handler
 	BatchesChangesFileGetHandler    http.Handler
 	BatchesChangesFileExistsHandler http.Handler
@@ -76,7 +76,7 @@ func DefaultServices() Services {
 		GitHubSyncWebhook:               &emptyWebhookHandler{name: "github sync webhook"},
 		BatchesGitHubWebhook:            &emptyWebhookHandler{name: "batches github webhook"},
 		BatchesGitLabWebhook:            &emptyWebhookHandler{name: "batches gitlab webhook"},
-		BatchesBitbucketServerWebhook:   makeNotFoundHandler("batches bitbucket server webhook"),
+		BatchesBitbucketServerWebhook:   &emptyWebhookHandler{"batches bitbucket server webhook"},
 		BatchesBitbucketCloudWebhook:    makeNotFoundHandler("batches bitbucket cloud webhook"),
 		BatchesChangesFileGetHandler:    makeNotFoundHandler("batches file get handler"),
 		BatchesChangesFileExistsHandler: makeNotFoundHandler("batches file exists handler"),

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -42,7 +42,7 @@ type Handlers struct {
 	GitHubSyncWebhook               webhooks.Registerer
 	BatchesGitHubWebhook            webhooks.Registerer
 	BatchesGitLabWebhook            webhooks.RegistererHandler
-	BatchesBitbucketServerWebhook   http.Handler
+	BatchesBitbucketServerWebhook   webhooks.RegistererHandler
 	BatchesBitbucketCloudWebhook    http.Handler
 	BatchesChangesFileGetHandler    http.Handler
 	BatchesChangesFileExistsHandler http.Handler
@@ -93,6 +93,7 @@ func NewHandler(
 	webhookhandlers.Init(&wh)
 	handlers.BatchesGitHubWebhook.Register(&wh)
 	handlers.BatchesGitLabWebhook.Register(&wh)
+	handlers.BatchesBitbucketServerWebhook.Register(&wh)
 	handlers.GitHubSyncWebhook.Register(&wh)
 
 	// 🚨 SECURITY: This handler implements its own secret-based auth

--- a/cmd/frontend/webhooks/bitbucketserver_webhooks.go
+++ b/cmd/frontend/webhooks/bitbucketserver_webhooks.go
@@ -6,13 +6,12 @@ import (
 
 	gh "github.com/google/go-github/v43/github"
 
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
-
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func (h *WebhookRouter) HandleBitBucketServerWebhook(logger log.Logger, w http.ResponseWriter, r *http.Request, codeHostURN extsvc.CodeHostBaseURL, payload []byte) {

--- a/cmd/frontend/webhooks/bitbucketserver_webhooks.go
+++ b/cmd/frontend/webhooks/bitbucketserver_webhooks.go
@@ -52,6 +52,7 @@ func (wr *WebhookRouter) handleBitbucketServerWebhook(logger log.Logger, w http.
 		http.Error(w, "Error while reading request body.", http.StatusInternalServerError)
 		return
 	}
+	defer r.Body.Close()
 	if secret == "" {
 		wr.HandleBitBucketServerWebhook(logger, w, r, urn, payload)
 		return

--- a/cmd/frontend/webhooks/bitbucketserver_webhooks.go
+++ b/cmd/frontend/webhooks/bitbucketserver_webhooks.go
@@ -1,0 +1,69 @@
+package webhooks
+
+import (
+	"io"
+	"net/http"
+
+	gh "github.com/google/go-github/v43/github"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+)
+
+func (h *WebhookRouter) HandleBitBucketServerWebhook(logger log.Logger, w http.ResponseWriter, r *http.Request, codeHostURN extsvc.CodeHostBaseURL, payload []byte) {
+	// 🚨 SECURITY: now that the shared secret has been validated, we can use an
+	// internal actor on the context.
+	ctx := actor.WithInternalActor(r.Context())
+	e, eventType, err := h.parseEvent(r, payload)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Route the request based on the event type.
+	err = h.Dispatch(ctx, eventType, extsvc.KindBitbucketServer, codeHostURN, e)
+	if err != nil {
+		logger.Error("Error handling bitbucket server webhook event", log.Error(err))
+		switch err.(type) {
+		case eventTypeNotFoundError:
+			http.Error(w, err.Error(), http.StatusNotFound)
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+}
+
+func (h *WebhookRouter) parseEvent(r *http.Request, payload []byte) (any, string, error) {
+	eventType := bitbucketserver.WebhookEventType(r)
+	e, err := bitbucketserver.ParseWebhookEvent(eventType, payload)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "parsing webhook")
+	}
+	return e, eventType, nil
+}
+
+func (h *WebhookRouter) handleBitbucketServerWebhook(logger log.Logger, w http.ResponseWriter, r *http.Request, urn extsvc.CodeHostBaseURL, secret string) {
+	payload, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Error while reading request body.", http.StatusInternalServerError)
+		return
+	}
+	if secret == "" {
+		h.HandleBitBucketServerWebhook(logger, w, r, urn, payload)
+		return
+	}
+
+	sig := r.Header.Get("X-Hub-Signature")
+	if err := gh.ValidateSignature(sig, payload, []byte(secret)); err != nil {
+		http.Error(w, "Could not validate payload with secret.", http.StatusBadRequest)
+		return
+	}
+
+	h.HandleBitBucketServerWebhook(logger, w, r, urn, payload)
+}

--- a/cmd/frontend/webhooks/github_webhooks.go
+++ b/cmd/frontend/webhooks/github_webhooks.go
@@ -93,13 +93,11 @@ func (h *GitHubWebhook) HandleWebhook(logger log.Logger, w http.ResponseWriter, 
 	err = h.Dispatch(ctx, eventType, extsvc.KindGitHub, codeHostURN, e)
 	if err != nil {
 		logger.Error("Error handling github webhook event", log.Error(err))
-		switch err.(type) {
-		case eventTypeNotFoundError:
+		if errcode.IsNotFound(err) {
 			http.Error(w, err.Error(), http.StatusNotFound)
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
-		return
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
 

--- a/cmd/frontend/webhooks/gitlab_webhooks.go
+++ b/cmd/frontend/webhooks/gitlab_webhooks.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func (h *WebhookRouter) HandleGitLabWebhook(logger log.Logger, w http.ResponseWriter, r *http.Request, codeHostURN extsvc.CodeHostBaseURL, payload []byte) {
+func (wr *WebhookRouter) HandleGitLabWebhook(logger log.Logger, w http.ResponseWriter, r *http.Request, codeHostURN extsvc.CodeHostBaseURL, payload []byte) {
 	// 🚨 SECURITY: now that the shared secret has been validated, we can use an
 	// internal actor on the context.
 	ctx := actor.WithInternalActor(r.Context())
@@ -48,7 +48,7 @@ func (h *WebhookRouter) HandleGitLabWebhook(logger log.Logger, w http.ResponseWr
 	}
 
 	// Route the request based on the event type.
-	err = h.Dispatch(ctx, eventKind.ObjectKind, extsvc.KindGitLab, codeHostURN, event)
+	err = wr.Dispatch(ctx, eventKind.ObjectKind, extsvc.KindGitLab, codeHostURN, event)
 	if err != nil {
 		logger.Error("Error handling gitlab webhook event", log.Error(err))
 		if errcode.IsNotFound(err) {
@@ -74,7 +74,7 @@ func gitlabValidatePayload(r *http.Request, secret string) ([]byte, error) {
 	return body, nil
 }
 
-func (h *WebhookRouter) handleGitLabWebHook(logger log.Logger, w http.ResponseWriter, r *http.Request, urn extsvc.CodeHostBaseURL, secret string) {
+func (wr *WebhookRouter) handleGitLabWebHook(logger log.Logger, w http.ResponseWriter, r *http.Request, urn extsvc.CodeHostBaseURL, secret string) {
 	if secret == "" {
 		payload, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -82,7 +82,7 @@ func (h *WebhookRouter) handleGitLabWebHook(logger log.Logger, w http.ResponseWr
 			return
 		}
 
-		h.HandleGitLabWebhook(logger, w, r, urn, payload)
+		wr.HandleGitLabWebhook(logger, w, r, urn, payload)
 		return
 	}
 
@@ -92,5 +92,5 @@ func (h *WebhookRouter) handleGitLabWebHook(logger log.Logger, w http.ResponseWr
 		return
 	}
 
-	h.HandleGitLabWebhook(logger, w, r, urn, payload)
+	wr.HandleGitLabWebhook(logger, w, r, urn, payload)
 }

--- a/cmd/frontend/webhooks/gitlab_webhooks.go
+++ b/cmd/frontend/webhooks/gitlab_webhooks.go
@@ -81,6 +81,7 @@ func (wr *WebhookRouter) handleGitLabWebHook(logger log.Logger, w http.ResponseW
 			http.Error(w, "Error while reading request body.", http.StatusInternalServerError)
 			return
 		}
+		defer r.Body.Close()
 
 		wr.HandleGitLabWebhook(logger, w, r, urn, payload)
 		return

--- a/cmd/frontend/webhooks/webhooks.go
+++ b/cmd/frontend/webhooks/webhooks.go
@@ -44,17 +44,17 @@ type RegistererHandler interface {
 // Register associates a given event type(s) with the specified handler.
 // Handlers are organized into a stack and executed sequentially, so the order in
 // which they are provided is significant.
-func (h *WebhookRouter) Register(handler WebhookHandler, codeHostKind string, eventTypes ...string) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	if h.handlers == nil {
-		h.handlers = make(map[string]webhookEventHandlers)
+func (wr *WebhookRouter) Register(handler WebhookHandler, codeHostKind string, eventTypes ...string) {
+	wr.mu.Lock()
+	defer wr.mu.Unlock()
+	if wr.handlers == nil {
+		wr.handlers = make(map[string]webhookEventHandlers)
 	}
-	if _, ok := h.handlers[codeHostKind]; !ok {
-		h.handlers[codeHostKind] = make(map[string][]WebhookHandler)
+	if _, ok := wr.handlers[codeHostKind]; !ok {
+		wr.handlers[codeHostKind] = make(map[string][]WebhookHandler)
 	}
 	for _, eventType := range eventTypes {
-		h.handlers[codeHostKind][eventType] = append(h.handlers[codeHostKind][eventType], handler)
+		wr.handlers[codeHostKind][eventType] = append(wr.handlers[codeHostKind][eventType], handler)
 	}
 }
 
@@ -128,18 +128,18 @@ func webhookHandler(logger log.Logger, db database.DB, wh *WebhookRouter) http.H
 
 // Dispatch accepts an event for a particular event type and dispatches it
 // to the appropriate stack of handlers, if any are configured.
-func (h *WebhookRouter) Dispatch(ctx context.Context, eventType string, codeHostKind string, codeHostURN extsvc.CodeHostBaseURL, e any) error {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
+func (wr *WebhookRouter) Dispatch(ctx context.Context, eventType string, codeHostKind string, codeHostURN extsvc.CodeHostBaseURL, e any) error {
+	wr.mu.RLock()
+	defer wr.mu.RUnlock()
 	g := errgroup.Group{}
-	if _, ok := h.handlers[codeHostKind][eventType]; !ok {
+	if _, ok := wr.handlers[codeHostKind][eventType]; !ok {
 		return eventTypeNotFoundError{eventType: eventType, codeHostKind: codeHostKind}
 	}
-	for _, handler := range h.handlers[codeHostKind][eventType] {
+	for _, handler := range wr.handlers[codeHostKind][eventType] {
 		// capture the handler variable within this loop
 		handler := handler
 		g.Go(func() error {
-			return handler(ctx, h.DB, codeHostURN, e)
+			return handler(ctx, wr.DB, codeHostURN, e)
 		})
 	}
 	return g.Wait()

--- a/cmd/frontend/webhooks/webhooks.go
+++ b/cmd/frontend/webhooks/webhooks.go
@@ -150,6 +150,10 @@ type eventTypeNotFoundError struct {
 	codeHostKind string
 }
 
+func (e eventTypeNotFoundError) NotFound() bool {
+	return true
+}
+
 func (e eventTypeNotFoundError) Error() string {
 	return fmt.Sprintf("event type %s not supported for code host kind %s", e.eventType, e.codeHostKind)
 }

--- a/cmd/frontend/webhooks/webhooks.go
+++ b/cmd/frontend/webhooks/webhooks.go
@@ -116,7 +116,8 @@ func webhookHandler(logger log.Logger, db database.DB, wh *WebhookRouter) http.H
 			wh.handleGitLabWebHook(logger, w, r, webhook.CodeHostURN, secret)
 			return
 		case extsvc.KindBitbucketServer:
-			// TODO: handle Bitbucket Server secret verification
+			wh.handleBitbucketServerWebhook(logger, w, r, webhook.CodeHostURN, secret)
+			return
 		case extsvc.KindBitbucketCloud:
 			// TODO: handle Bitbucket Cloud secret verification
 		}

--- a/cmd/frontend/webhooks/webhooks_test.go
+++ b/cmd/frontend/webhooks/webhooks_test.go
@@ -179,6 +179,8 @@ func TestWebhooksHandler(t *testing.T) {
 		h.Write(payload)
 		res := h.Sum(nil)
 
+		wr.handlers = map[string]webhookEventHandlers{}
+
 		req, err := http.NewRequest("POST", requestURL, bytes.NewBuffer(payload))
 		require.NoError(t, err)
 		req.Header.Set("X-Hub-Signature", "sha1="+hex.EncodeToString(res))
@@ -195,6 +197,12 @@ func TestWebhooksHandler(t *testing.T) {
 		requestURL := fmt.Sprintf("%s/.api/webhooks/%v", srv.URL, gitHubWHNoSecret.UUID)
 
 		payload := []byte(`{"body": "text"}`)
+
+		wr.handlers = map[string]webhookEventHandlers{
+			extsvc.KindGitHub: {
+				"member": []WebhookHandler{fakeWebhookHandler},
+			},
+		}
 
 		req, err := http.NewRequest("POST", requestURL, bytes.NewBuffer(payload))
 		require.NoError(t, err)

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver.go
@@ -59,19 +59,19 @@ func (h *BitbucketServerWebhook) handleEvent(ctx context.Context, db database.DB
 
 	prs, ev := h.convertEvent(event)
 
-	var m error
+	var err error
 	for _, pr := range prs {
 		if pr == (PR{}) {
 			log15.Warn("Dropping Bitbucket Server webhook event", "type", fmt.Sprintf("%T", event))
 			continue
 		}
 
-		err := h.upsertChangesetEvent(ctx, codeHostURN, pr, ev)
-		if err != nil {
-			m = errors.Append(m, err)
+		eventError := h.upsertChangesetEvent(ctx, codeHostURN, pr, ev)
+		if eventError != nil {
+			err = errors.Append(err, eventError)
 		}
 	}
-	return m
+	return err
 }
 
 func (h *BitbucketServerWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver.go
@@ -53,8 +53,8 @@ func (h *BitbucketServerWebhook) Register(router *fewebhooks.WebhookRouter) {
 }
 
 func (h *BitbucketServerWebhook) handleEvent(ctx context.Context, db database.DB, codeHostURN extsvc.CodeHostBaseURL, event any) error {
-	// 🚨 SECURITY: now that the shared secret has been validated, we can use an
-	// internal actor on the context.
+	// 🚨 SECURITY: If we've made it here, then the secret for the Bitbucket Server webhook has been validated, so we can use
+	// an internal actor on the context.
 	ctx = actor.WithInternalActor(ctx)
 
 	prs, ev := h.convertEvent(event)

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver.go
@@ -1,6 +1,7 @@
 package webhooks
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,6 +22,18 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
+var bitbucketServerEvents = []string{
+	"ping",
+	"repo:build_status",
+	"pr:activity:status",
+	"pr:activity:event",
+	"pr:activity:rescope",
+	"pr:activity:merge",
+	"pr:activity:comment",
+	"pr:activity:reviewers",
+	"pr:participant:status",
+}
+
 type BitbucketServerWebhook struct {
 	*Webhook
 }
@@ -29,6 +42,36 @@ func NewBitbucketServerWebhook(store *store.Store, gitserverClient gitserver.Cli
 	return &BitbucketServerWebhook{
 		Webhook: &Webhook{store, gitserverClient, extsvc.TypeBitbucketServer},
 	}
+}
+
+func (h *BitbucketServerWebhook) Register(router *fewebhooks.WebhookRouter) {
+	router.Register(
+		h.handleEvent,
+		extsvc.KindBitbucketServer,
+		bitbucketServerEvents...,
+	)
+}
+
+func (h *BitbucketServerWebhook) handleEvent(ctx context.Context, db database.DB, codeHostURN extsvc.CodeHostBaseURL, event any) error {
+	// 🚨 SECURITY: now that the shared secret has been validated, we can use an
+	// internal actor on the context.
+	ctx = actor.WithInternalActor(ctx)
+
+	prs, ev := h.convertEvent(event)
+
+	var m error
+	for _, pr := range prs {
+		if pr == (PR{}) {
+			log15.Warn("Dropping Bitbucket Server webhook event", "type", fmt.Sprintf("%T", event))
+			continue
+		}
+
+		err := h.upsertChangesetEvent(ctx, codeHostURN, pr, ev)
+		if err != nil {
+			m = errors.Append(m, err)
+		}
+	}
+	return m
 }
 
 func (h *BitbucketServerWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -44,26 +87,25 @@ func (h *BitbucketServerWebhook) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	// internal actor on the context.
 	ctx := actor.WithInternalActor(r.Context())
 
-	externalServiceID, err := extractExternalServiceID(ctx, extSvc)
+	c, err := extSvc.Configuration(r.Context())
 	if err != nil {
-		respond(w, http.StatusInternalServerError, err)
+		log15.Error("Could not decode external service config", "error", err)
+		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
 		return
 	}
 
-	prs, ev := h.convertEvent(e)
-
-	var m error
-	for _, pr := range prs {
-		if pr == (PR{}) {
-			log15.Warn("Dropping Bitbucket Server webhook event", "type", fmt.Sprintf("%T", e))
-			continue
-		}
-
-		err := h.upsertChangesetEvent(ctx, externalServiceID, pr, ev)
-		if err != nil {
-			m = errors.Append(m, err)
-		}
+	config, ok := c.(*schema.BitbucketServerConnection)
+	if !ok {
+		log15.Error("Could not decode external service config")
+		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
+		return
 	}
+
+	codeHostURN, err := extsvc.NewCodeHostBaseURL(config.Url)
+	if err != nil {
+		respond(w, http.StatusInternalServerError, errors.Wrap(err, "parsing code host base url"))
+	}
+	m := h.handleEvent(ctx, h.Store.DatabaseDB(), codeHostURN, e)
 	if m != nil {
 		respond(w, http.StatusInternalServerError, m)
 	}


### PR DESCRIPTION
Decided to do BB server first, then BB cloud will be in a second PR (both felt like too much for one).

## Test plan
Validated via unit tests, but I still need to do a full manual validation locally using ngrok (i.e. set up some BB server webhooks and validate that the original behavior still works, as well as using the new top level handler). Update: just validated that we can still successfully consume these events via the legacy handler as well as the new top-level handler 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
