### PR TITLE
graphqlbackend: add permissionsSyncJobs query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - When rendering a file which is backed by Git LFS, we show a page informing the file is LFS and linking to the file on the codehost. Previously we rendered the LFS pointer. [#43686](https://github.com/sourcegraph/sourcegraph/pull/43686)
 - Batch changes run server-side now support secrets. [#27926](https://github.com/sourcegraph/sourcegraph/issues/27926)
 - OIDC success/fail login attempts are now a part of the audit log. [#44467](https://github.com/sourcegraph/sourcegraph/pull/44467)
-- A new experimental endpoint, `permissionsSyncJobs`, that lists the states of recently completed permissions sync jobs and the state of each provider. [#44387](https://github.com/sourcegraph/sourcegraph/pull/44387)
+- A new experimental GraphQL query, `permissionsSyncJobs`, that lists the states of recently completed permissions sync jobs and the state of each provider. [#44387](https://github.com/sourcegraph/sourcegraph/pull/44387)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - When rendering a file which is backed by Git LFS, we show a page informing the file is LFS and linking to the file on the codehost. Previously we rendered the LFS pointer. [#43686](https://github.com/sourcegraph/sourcegraph/pull/43686)
 - Batch changes run server-side now support secrets. [#27926](https://github.com/sourcegraph/sourcegraph/issues/27926)
 - OIDC success/fail login attempts are now a part of the audit log. [#44467](https://github.com/sourcegraph/sourcegraph/pull/44467)
+- A new experimental endpoint, `permissionsSyncJobs`, that lists the states of recently completed permissions sync jobs and the state of each provider. [#44387](https://github.com/sourcegraph/sourcegraph/pull/44387)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - When rendering a file which is backed by Git LFS, we show a page informing the file is LFS and linking to the file on the codehost. Previously we rendered the LFS pointer. [#43686](https://github.com/sourcegraph/sourcegraph/pull/43686)
 - Batch changes run server-side now support secrets. [#27926](https://github.com/sourcegraph/sourcegraph/issues/27926)
 - OIDC success/fail login attempts are now a part of the audit log. [#44467](https://github.com/sourcegraph/sourcegraph/pull/44467)
-- A new experimental GraphQL query, `permissionsSyncJobs`, that lists the states of recently completed permissions sync jobs and the state of each provider. [#44387](https://github.com/sourcegraph/sourcegraph/pull/44387)
+- A new experimental GraphQL query, `permissionsSyncJobs`, that lists the states of recently completed permissions sync jobs and the state of each provider. The TTL of entries retrained can be configured with `authz.syncJobsRecordsTTL`. [#44387](https://github.com/sourcegraph/sourcegraph/pull/44387), [#44258](https://github.com/sourcegraph/sourcegraph/pull/44258)
 
 ### Changed
 

--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -24,7 +25,7 @@ type AuthzResolver interface {
 	AuthorizedUsers(ctx context.Context, args *RepoAuthorizedUserArgs) (UserConnectionResolver, error)
 	BitbucketProjectPermissionJobs(ctx context.Context, args *BitbucketProjectPermissionJobsArgs) (BitbucketProjectsPermissionJobsResolver, error)
 	AuthzProviderTypes(ctx context.Context) ([]string, error)
-	PermissionsSyncJobs(ctx context.Context, args *PermissionsSyncJobsArgs) (PermissionsSyncJobsResolver, error)
+	PermissionsSyncJobs(ctx context.Context, args *PermissionsSyncJobsArgs) (PermissionsSyncJobsConnection, error)
 
 	// Helpers
 	RepositoryPermissionsInfo(ctx context.Context, repoID graphql.ID) (PermissionsInfoResolver, error)
@@ -124,16 +125,18 @@ type PermissionsSyncJobsArgs struct {
 	First  *int32
 }
 
-type PermissionsSyncJobsResolver interface {
-	Nodes() ([]PermissionsSyncJobResolver, error)
+type PermissionsSyncJobsConnection interface {
+	Nodes() []PermissionsSyncJob
+	TotalCount() int32
+	PageInfo() *graphqlutil.PageInfo
 }
 
-type PermissionsSyncJobResolver interface {
+type PermissionsSyncJob interface {
 	Type() string
 	ID() int32
 	Status() string
 	Message() string
-	CompletedAt() gqlutil.DateTime
+	CompletedAt() *gqlutil.DateTime
 
 	Providers() ([]PermissionsProviderStatus, error)
 }

--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -126,22 +126,23 @@ type PermissionsSyncJobsArgs struct {
 }
 
 type PermissionsSyncJobsConnection interface {
-	Nodes() []PermissionsSyncJob
+	Nodes() []PermissionsSyncJobResolver
 	TotalCount() int32
 	PageInfo() *graphqlutil.PageInfo
 }
 
-type PermissionsSyncJob interface {
+type PermissionsSyncJobResolver interface {
+	ID() graphql.ID
+	RequestID() int32
 	Type() string
-	ID() int32
 	Status() string
 	Message() string
 	CompletedAt() *gqlutil.DateTime
 
-	Providers() ([]PermissionsProviderStatus, error)
+	Providers() ([]PermissionsProviderStateResolver, error)
 }
 
-type PermissionsProviderStatus interface {
+type PermissionsProviderStateResolver interface {
 	Type() string
 	ID() string
 	Status() string

--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -121,7 +121,7 @@ type PermissionsInfoResolver interface {
 
 type PermissionsSyncJobsArgs struct {
 	Status *string
-	Count  *int32
+	First  *int32
 }
 
 type PermissionsSyncJobsResolver interface {

--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -30,6 +30,9 @@ type AuthzResolver interface {
 	// Helpers
 	RepositoryPermissionsInfo(ctx context.Context, repoID graphql.ID) (PermissionsInfoResolver, error)
 	UserPermissionsInfo(ctx context.Context, userID graphql.ID) (PermissionsInfoResolver, error)
+
+	// Node types
+	NodeResolvers() map[string]NodeByIDFunc
 }
 
 type RepositoryIDArgs struct {
@@ -122,7 +125,7 @@ type PermissionsInfoResolver interface {
 
 type PermissionsSyncJobsArgs struct {
 	Status *string
-	First  *int32
+	First  int32
 }
 
 type PermissionsSyncJobsConnection interface {
@@ -132,7 +135,8 @@ type PermissionsSyncJobsConnection interface {
 }
 
 type PermissionsSyncJobResolver interface {
-	ID() graphql.ID
+	Node
+
 	JobID() int32
 	Type() string
 	Status() string

--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -24,6 +24,7 @@ type AuthzResolver interface {
 	AuthorizedUsers(ctx context.Context, args *RepoAuthorizedUserArgs) (UserConnectionResolver, error)
 	BitbucketProjectPermissionJobs(ctx context.Context, args *BitbucketProjectPermissionJobsArgs) (BitbucketProjectsPermissionJobsResolver, error)
 	AuthzProviderTypes(ctx context.Context) ([]string, error)
+	PermissionsSyncJobs(ctx context.Context, args *PermissionsSyncJobsArgs) (PermissionsSyncJobsResolver, error)
 
 	// Helpers
 	RepositoryPermissionsInfo(ctx context.Context, repoID graphql.ID) (PermissionsInfoResolver, error)
@@ -116,4 +117,30 @@ type PermissionsInfoResolver interface {
 	SyncedAt() *gqlutil.DateTime
 	UpdatedAt() gqlutil.DateTime
 	Unrestricted() bool
+}
+
+type PermissionsSyncJobsArgs struct {
+	Status *string
+	Count  *int32
+}
+
+type PermissionsSyncJobsResolver interface {
+	Nodes() ([]PermissionsSyncJobResolver, error)
+}
+
+type PermissionsSyncJobResolver interface {
+	Type() string
+	ID() int32
+	Status() string
+	Message() string
+	CompletedAt() gqlutil.DateTime
+
+	Providers() ([]PermissionsProviderStatus, error)
+}
+
+type PermissionsProviderStatus interface {
+	Type() string
+	ID() string
+	Status() string
+	Message() string
 }

--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -133,7 +133,7 @@ type PermissionsSyncJobsConnection interface {
 
 type PermissionsSyncJobResolver interface {
 	ID() graphql.ID
-	RequestID() int32
+	JobID() int32
 	Type() string
 	Status() string
 	Message() string

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -312,6 +312,9 @@ input FetchPermissionsOptions {
     invalidateCaches: Boolean
 }
 
+"""
+Permission sync jobs.
+"""
 type PermissionsSyncJobs {
     """
     Permission sync jobs.
@@ -319,11 +322,17 @@ type PermissionsSyncJobs {
     nodes: [PermissionsSyncJob!]!
 }
 
+"""
+Status types of permissions sync jobs.
+"""
 enum PermissionsSyncJobStatus {
     ERROR
     SUCCESS
 }
 
+"""
+State of a permission sync job.
+"""
 type PermissionsSyncJob {
     """
     Type of the sync job.
@@ -351,6 +360,9 @@ type PermissionsSyncJob {
     providers: [PermissionsProviderStatus!]!
 }
 
+"""
+State of a permissions provider during a sync job.
+"""
 type PermissionsProviderStatus {
     """
     Type of the provider.

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -150,7 +150,7 @@ extend type Query {
         """
         Number of jobs returned. Maximum number of returned jobs is 500. Up to 100 jobs are returned by default.
         """
-        count: Int
+        first: Int
     ): PermissionsSyncJobs
 
     """

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -138,6 +138,22 @@ extend type Query {
     authzProviderTypes: [String!]!
 
     """
+    EXPERIMENTAL: Returns a list of recent permissions sync jobs for a given set of parameters.
+
+    This endpoint currently only reports recently completed sync jobs, with an expiry configurable by 'authz.syncJobsRecordsTTL'.
+    """
+    permissionsSyncJobs(
+        """
+        Only returns jobs with this status.
+        """
+        status: PermissionsSyncJobStatus
+        """
+        Number of jobs returned. Maximum number of returned jobs is 500. Up to 100 jobs are returned by default.
+        """
+        count: Int
+    ): PermissionsSyncJobs
+
+    """
     Returns a list of Bitbucket Project permissions sync jobs for a given set of parameters.
     """
     bitbucketProjectPermissionJobs(
@@ -294,6 +310,64 @@ input FetchPermissionsOptions {
     sync should be invalidated.
     """
     invalidateCaches: Boolean
+}
+
+type PermissionsSyncJobs {
+    """
+    Permission sync jobs.
+    """
+    nodes: [PermissionsSyncJob!]!
+}
+
+enum PermissionsSyncJobStatus {
+    ERROR
+    SUCCESS
+}
+
+type PermissionsSyncJob {
+    """
+    Type of the sync job.
+    """
+    type: String!
+    """
+    ID of the entity targeted in this sync job.
+    """
+    id: Int!
+    """
+    Completion time of the sync job.
+    """
+    completedAt: DateTime!
+    """
+    Status of the sync job.
+    """
+    status: PermissionsSyncJobStatus!
+    """
+    Message describing the status of the sync job.
+    """
+    message: String!
+    """
+    Per-provider statuses.
+    """
+    providers: [PermissionsProviderStatus!]!
+}
+
+type PermissionsProviderStatus {
+    """
+    Type of the provider.
+    """
+    type: String!
+    """
+    ID representing the provider.
+    """
+    id: String!
+    """
+    Type of the sync job.
+    """
+    status: PermissionsSyncJobStatus!
+    """
+    Message describing the status of the sync job.
+    """
+    message: String!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -359,7 +359,8 @@ type PermissionsSyncJob {
     """
     status: PermissionsSyncJobStatus!
     """
-    Message describing the status of the sync job.
+    Message describing the status of the sync job - for example, the contents of any
+    errors.
     """
     message: String!
     """
@@ -385,7 +386,8 @@ type PermissionsProviderStatus {
     """
     status: PermissionsSyncJobStatus!
     """
-    Message describing the status of the sync job.
+    Message describing the status of the provider during a sync job - for example, the
+    contents of any errors and during which operation they occured.
     """
     message: String!
 }

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -341,15 +341,19 @@ enum PermissionsSyncJobStatus {
 """
 State of a permission sync job.
 """
-type PermissionsSyncJob {
+type PermissionsSyncJob implements Node {
+    """
+    Unique node ID.
+    """
+    id: ID!
     """
     Type of the sync job.
     """
     type: String!
     """
-    ID of the entity targeted in this sync job.
+    ID of the entity in the original request for a sync job.
     """
-    id: Int!
+    requestID: Int!
     """
     Completion time of the sync job.
     """
@@ -364,15 +368,23 @@ type PermissionsSyncJob {
     """
     message: String!
     """
-    Per-provider statuses.
+    Per-provider states.
     """
-    providers: [PermissionsProviderStatus!]!
+    providers: [PermissionsProviderState!]!
+}
+
+"""
+Status types of permissions providers.
+"""
+enum PermissionsProviderStatus {
+    ERROR
+    SUCCESS
 }
 
 """
 State of a permissions provider during a sync job.
 """
-type PermissionsProviderStatus {
+type PermissionsProviderState {
     """
     Type of the provider.
     """
@@ -384,7 +396,7 @@ type PermissionsProviderStatus {
     """
     Type of the sync job.
     """
-    status: PermissionsSyncJobStatus!
+    status: PermissionsProviderStatus!
     """
     Message describing the status of the provider during a sync job - for example, the
     contents of any errors and during which operation they occured.

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -151,7 +151,7 @@ extend type Query {
         Number of jobs returned. Maximum number of returned jobs is 500. Up to 100 jobs are returned by default.
         """
         first: Int
-    ): PermissionsSyncJobs
+    ): PermissionsSyncJobsConnection
 
     """
     Returns a list of Bitbucket Project permissions sync jobs for a given set of parameters.
@@ -315,11 +315,19 @@ input FetchPermissionsOptions {
 """
 Permission sync jobs.
 """
-type PermissionsSyncJobs {
+type PermissionsSyncJobsConnection {
     """
     Permission sync jobs.
     """
     nodes: [PermissionsSyncJob!]!
+    """
+    The total number of jobs in the connection.
+    """
+    totalCount: Int!
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
 }
 
 """
@@ -345,7 +353,7 @@ type PermissionsSyncJob {
     """
     Completion time of the sync job.
     """
-    completedAt: DateTime!
+    completedAt: DateTime
     """
     Status of the sync job.
     """

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -351,9 +351,9 @@ type PermissionsSyncJob implements Node {
     """
     type: String!
     """
-    ID of the entity in the original request for a sync job.
+    ID of the entity worked on in this sync job.
     """
-    requestID: Int!
+    jobID: Int!
     """
     Completion time of the sync job.
     """

--- a/cmd/frontend/graphqlbackend/authz.graphql
+++ b/cmd/frontend/graphqlbackend/authz.graphql
@@ -150,8 +150,8 @@ extend type Query {
         """
         Number of jobs returned. Maximum number of returned jobs is 500. Up to 100 jobs are returned by default.
         """
-        first: Int
-    ): PermissionsSyncJobsConnection
+        first: Int = 100
+    ): PermissionsSyncJobsConnection!
 
     """
     Returns a list of Bitbucket Project permissions sync jobs for a given set of parameters.

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -388,6 +388,9 @@ func NewSchema(
 		EnterpriseResolvers.authzResolver = authz
 		resolver.AuthzResolver = authz
 		schemas = append(schemas, authzSchema)
+		for kind, res := range authz.NodeResolvers() {
+			resolver.nodeByIDFns[kind] = res
+		}
 	}
 
 	if codeMonitors != nil {

--- a/cmd/frontend/graphqlbackend/node.go
+++ b/cmd/frontend/graphqlbackend/node.go
@@ -303,3 +303,8 @@ func (r *NodeResolver) ToBatchSpecWorkspaceFile() (BatchWorkspaceFileResolver, b
 	n, ok := r.Node.(BatchWorkspaceFileResolver)
 	return n, ok
 }
+
+func (r *NodeResolver) ToPermissionsSyncJob() (PermissionsSyncJobResolver, bool) {
+	n, ok := r.Node.(PermissionsSyncJobResolver)
+	return n, ok
+}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
@@ -31,8 +31,8 @@ type permissionsSyncJobResolver struct{ s syncjobs.Status }
 var _ graphqlbackend.PermissionsSyncJobResolver = permissionsSyncJobResolver{}
 
 func (j permissionsSyncJobResolver) ID() graphql.ID {
-	// Use eventTime because RequestID can repeat
-	return relay.MarshalID("EventTime", j.s.Completed)
+	// Use eventTime because job ID can repeat
+	return relay.MarshalID("PermissionsSyncJob", j.s.Completed)
 }
 
 func (j permissionsSyncJobResolver) JobID() int32 { return j.s.JobID }

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
@@ -1,6 +1,9 @@
 package resolvers
 
 import (
+	"context"
+	"time"
+
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 
@@ -8,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/authz/syncjobs"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type permissionsSyncJobsConnection struct {
@@ -30,23 +34,38 @@ type permissionsSyncJobResolver struct{ s syncjobs.Status }
 
 var _ graphqlbackend.PermissionsSyncJobResolver = permissionsSyncJobResolver{}
 
+const permissionsSyncJobKind = "PermissionsSyncJob"
+
+func getPermissionsSyncJobByIDFunc(r *Resolver) graphqlbackend.NodeByIDFunc {
+	return func(ctx context.Context, id graphql.ID) (graphqlbackend.Node, error) {
+		if kind := relay.UnmarshalKind(id); kind != permissionsSyncJobKind {
+			return nil, errors.Errorf("expected graphql ID to have kind %q; got %q", permissionsSyncJobKind, kind)
+		}
+		var unixNano int64
+		err := relay.UnmarshalSpec(id, &unixNano)
+		if err != nil {
+			return nil, errors.Wrap(err, "unmarshal ID")
+		}
+		status, err := r.syncJobsRecords.Get(time.Unix(0, unixNano))
+		if err != nil {
+			return nil, errors.Wrap(err, "node with ID not found - it may have expired")
+		}
+		return &permissionsSyncJobResolver{*status}, nil
+	}
+}
+
 func (j permissionsSyncJobResolver) ID() graphql.ID {
-	// Use eventTime because job ID can repeat
-	return relay.MarshalID("PermissionsSyncJob", j.s.Completed)
+	// Use event time because job ID can repeat
+	return relay.MarshalID(permissionsSyncJobKind, j.s.Completed.UnixNano())
 }
 
 func (j permissionsSyncJobResolver) JobID() int32 { return j.s.JobID }
-
 func (j permissionsSyncJobResolver) Type() string { return j.s.JobType }
-
 func (j permissionsSyncJobResolver) CompletedAt() *gqlutil.DateTime {
 	return &gqlutil.DateTime{Time: j.s.Completed}
 }
-
-func (j permissionsSyncJobResolver) Status() string { return j.s.Status }
-
+func (j permissionsSyncJobResolver) Status() string  { return j.s.Status }
 func (j permissionsSyncJobResolver) Message() string { return j.s.Message }
-
 func (j permissionsSyncJobResolver) Providers() (providers []graphqlbackend.PermissionsProviderStateResolver, err error) {
 	for _, p := range j.s.Providers {
 		providers = append(providers, permissionsProviderStatusResolver{ProviderStatus: p})
@@ -58,10 +77,7 @@ type permissionsProviderStatusResolver struct{ syncjobs.ProviderStatus }
 
 var _ graphqlbackend.PermissionsProviderStateResolver = permissionsProviderStatusResolver{}
 
-func (p permissionsProviderStatusResolver) ID() string { return p.ProviderID }
-
-func (p permissionsProviderStatusResolver) Type() string { return p.ProviderType }
-
-func (p permissionsProviderStatusResolver) Status() string { return p.ProviderStatus.Status }
-
+func (p permissionsProviderStatusResolver) ID() string      { return p.ProviderID }
+func (p permissionsProviderStatusResolver) Type() string    { return p.ProviderType }
+func (p permissionsProviderStatusResolver) Status() string  { return p.ProviderStatus.Status }
 func (p permissionsProviderStatusResolver) Message() string { return p.ProviderStatus.Message }

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
@@ -35,9 +35,9 @@ func (j permissionsSyncJobResolver) ID() graphql.ID {
 	return relay.MarshalID("EventTime", j.s.Completed)
 }
 
-func (j permissionsSyncJobResolver) RequestID() int32 { return j.s.RequestID }
+func (j permissionsSyncJobResolver) JobID() int32 { return j.s.JobID }
 
-func (j permissionsSyncJobResolver) Type() string { return j.s.RequestType }
+func (j permissionsSyncJobResolver) Type() string { return j.s.JobType }
 
 func (j permissionsSyncJobResolver) CompletedAt() *gqlutil.DateTime {
 	return &gqlutil.DateTime{Time: j.s.Completed}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
@@ -2,30 +2,37 @@ package resolvers
 
 import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/authz/syncjobs"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
-type permissionsSyncJobsResolver struct {
-	jobs []graphqlbackend.PermissionsSyncJobResolver
+type permissionsSyncJobsConnection struct {
+	jobs []graphqlbackend.PermissionsSyncJob
 }
 
-var _ graphqlbackend.PermissionsSyncJobsResolver = &permissionsSyncJobsResolver{}
+var _ graphqlbackend.PermissionsSyncJobsConnection = &permissionsSyncJobsConnection{}
 
-func (r *permissionsSyncJobsResolver) Nodes() ([]graphqlbackend.PermissionsSyncJobResolver, error) {
-	return r.jobs, nil
+func (r *permissionsSyncJobsConnection) Nodes() []graphqlbackend.PermissionsSyncJob {
+	return r.jobs
+}
+
+// We don't yet support pagination, but we have the fields for future-compat
+func (r *permissionsSyncJobsConnection) TotalCount() int32 { return int32(len(r.jobs)) }
+func (r *permissionsSyncJobsConnection) PageInfo() *graphqlutil.PageInfo {
+	return graphqlutil.HasNextPage(false)
 }
 
 type permissionsSyncJobResolver struct{ s syncjobs.Status }
 
-var _ graphqlbackend.PermissionsSyncJobResolver = permissionsSyncJobResolver{}
+var _ graphqlbackend.PermissionsSyncJob = permissionsSyncJobResolver{}
 
 func (j permissionsSyncJobResolver) ID() int32 { return j.s.RequestID }
 
 func (j permissionsSyncJobResolver) Type() string { return j.s.RequestType }
 
-func (j permissionsSyncJobResolver) CompletedAt() gqlutil.DateTime {
-	return gqlutil.DateTime{Time: j.s.Completed}
+func (j permissionsSyncJobResolver) CompletedAt() *gqlutil.DateTime {
+	return &gqlutil.DateTime{Time: j.s.Completed}
 }
 
 func (j permissionsSyncJobResolver) Status() string { return j.s.Status }

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
@@ -1,0 +1,52 @@
+package resolvers
+
+import (
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/authz/syncjobs"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
+)
+
+type permissionsSyncJobsResolver struct {
+	jobs []graphqlbackend.PermissionsSyncJobResolver
+}
+
+var _ graphqlbackend.PermissionsSyncJobsResolver = &permissionsSyncJobsResolver{}
+
+func (r *permissionsSyncJobsResolver) Nodes() ([]graphqlbackend.PermissionsSyncJobResolver, error) {
+	return r.jobs, nil
+}
+
+type permissionsSyncJobResolver struct{ s syncjobs.Status }
+
+var _ graphqlbackend.PermissionsSyncJobResolver = permissionsSyncJobResolver{}
+
+func (j permissionsSyncJobResolver) ID() int32 { return j.s.RequestID }
+
+func (j permissionsSyncJobResolver) Type() string { return j.s.RequestType }
+
+func (j permissionsSyncJobResolver) CompletedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: j.s.Completed}
+}
+
+func (j permissionsSyncJobResolver) Status() string { return j.s.Status }
+
+func (j permissionsSyncJobResolver) Message() string { return j.s.Message }
+
+func (j permissionsSyncJobResolver) Providers() (providers []graphqlbackend.PermissionsProviderStatus, err error) {
+	for _, p := range j.s.Providers {
+		providers = append(providers, permissionsProviderStatusResolver{ProviderStatus: p})
+	}
+	return
+}
+
+type permissionsProviderStatusResolver struct{ syncjobs.ProviderStatus }
+
+var _ graphqlbackend.PermissionsProviderStatus = permissionsProviderStatusResolver{}
+
+func (p permissionsProviderStatusResolver) ID() string { return p.ProviderID }
+
+func (p permissionsProviderStatusResolver) Type() string { return p.ProviderType }
+
+func (p permissionsProviderStatusResolver) Status() string { return p.ProviderStatus.Status }
+
+func (p permissionsProviderStatusResolver) Message() string { return p.ProviderStatus.Message }

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
@@ -1,6 +1,9 @@
 package resolvers
 
 import (
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/authz/syncjobs"
@@ -8,12 +11,12 @@ import (
 )
 
 type permissionsSyncJobsConnection struct {
-	jobs []graphqlbackend.PermissionsSyncJob
+	jobs []graphqlbackend.PermissionsSyncJobResolver
 }
 
 var _ graphqlbackend.PermissionsSyncJobsConnection = &permissionsSyncJobsConnection{}
 
-func (r *permissionsSyncJobsConnection) Nodes() []graphqlbackend.PermissionsSyncJob {
+func (r *permissionsSyncJobsConnection) Nodes() []graphqlbackend.PermissionsSyncJobResolver {
 	return r.jobs
 }
 
@@ -25,9 +28,14 @@ func (r *permissionsSyncJobsConnection) PageInfo() *graphqlutil.PageInfo {
 
 type permissionsSyncJobResolver struct{ s syncjobs.Status }
 
-var _ graphqlbackend.PermissionsSyncJob = permissionsSyncJobResolver{}
+var _ graphqlbackend.PermissionsSyncJobResolver = permissionsSyncJobResolver{}
 
-func (j permissionsSyncJobResolver) ID() int32 { return j.s.RequestID }
+func (j permissionsSyncJobResolver) ID() graphql.ID {
+	// Use eventTime because RequestID can repeat
+	return relay.MarshalID("EventTime", j.s.Completed)
+}
+
+func (j permissionsSyncJobResolver) RequestID() int32 { return j.s.RequestID }
 
 func (j permissionsSyncJobResolver) Type() string { return j.s.RequestType }
 
@@ -39,7 +47,7 @@ func (j permissionsSyncJobResolver) Status() string { return j.s.Status }
 
 func (j permissionsSyncJobResolver) Message() string { return j.s.Message }
 
-func (j permissionsSyncJobResolver) Providers() (providers []graphqlbackend.PermissionsProviderStatus, err error) {
+func (j permissionsSyncJobResolver) Providers() (providers []graphqlbackend.PermissionsProviderStateResolver, err error) {
 	for _, p := range j.s.Providers {
 		providers = append(providers, permissionsProviderStatusResolver{ProviderStatus: p})
 	}
@@ -48,7 +56,7 @@ func (j permissionsSyncJobResolver) Providers() (providers []graphqlbackend.Perm
 
 type permissionsProviderStatusResolver struct{ syncjobs.ProviderStatus }
 
-var _ graphqlbackend.PermissionsProviderStatus = permissionsProviderStatusResolver{}
+var _ graphqlbackend.PermissionsProviderStateResolver = permissionsProviderStatusResolver{}
 
 func (p permissionsProviderStatusResolver) ID() string { return p.ProviderID }
 

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -633,8 +633,8 @@ func (r *Resolver) PermissionsSyncJobs(ctx context.Context, args *graphqlbackend
 	}
 
 	count := 100
-	if args.Count != nil {
-		count = int(*args.Count)
+	if args.First != nil {
+		count = int(*args.First)
 		if count > 500 {
 			count = 500
 		}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -626,7 +626,7 @@ func (r *Resolver) UserPermissionsInfo(ctx context.Context, id graphql.ID) (grap
 	}, nil
 }
 
-func (r *Resolver) PermissionsSyncJobs(ctx context.Context, args *graphqlbackend.PermissionsSyncJobsArgs) (graphqlbackend.PermissionsSyncJobsResolver, error) {
+func (r *Resolver) PermissionsSyncJobs(ctx context.Context, args *graphqlbackend.PermissionsSyncJobsArgs) (graphqlbackend.PermissionsSyncJobsConnection, error) {
 	// 🚨 SECURITY: Only site admins can query sync jobs records.
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
@@ -645,10 +645,12 @@ func (r *Resolver) PermissionsSyncJobs(ctx context.Context, args *graphqlbackend
 		return nil, err
 	}
 
-	jobs := &permissionsSyncJobsResolver{
-		jobs: make([]graphqlbackend.PermissionsSyncJobResolver, 0, len(records)),
+	jobs := &permissionsSyncJobsConnection{
+		jobs: make([]graphqlbackend.PermissionsSyncJob, 0, len(records)),
 	}
 	for _, j := range records {
+		// If status is not provided, add all - otherwise, check if the job's status
+		// matches the argument status.
 		if args.Status == nil {
 			jobs.jobs = append(jobs.jobs, permissionsSyncJobResolver{j})
 		} else if j.Status == *args.Status {

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -646,7 +646,7 @@ func (r *Resolver) PermissionsSyncJobs(ctx context.Context, args *graphqlbackend
 	}
 
 	jobs := &permissionsSyncJobsConnection{
-		jobs: make([]graphqlbackend.PermissionsSyncJob, 0, len(records)),
+		jobs: make([]graphqlbackend.PermissionsSyncJobResolver, 0, len(records)),
 	}
 	for _, j := range records {
 		// If status is not provided, add all - otherwise, check if the job's status

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -1707,10 +1707,10 @@ func TestResolverPermissionsSyncJobs(t *testing.T) {
 					db:                edb.NewEnterpriseDB(db),
 					repoupdaterClient: repoupdater.DefaultClient,
 					syncJobsRecords: mockRecordsReader{{
-						RequestID:   3,
-						RequestType: "repo",
-						Status:      "SUCCESS",
-						Message:     "nice",
+						JobID:   3,
+						JobType: "repo",
+						Status:  "SUCCESS",
+						Message: "nice",
 						Providers: []syncjobs.ProviderStatus{{
 							ProviderID:   "https://github.com",
 							ProviderType: "github",
@@ -1732,7 +1732,7 @@ query {
 	pageInfo { hasNextPage }
     nodes {
 		id
-		requestID
+		jobID
 		type
 		status
 		message
@@ -1753,7 +1753,7 @@ query {
 		"nodes": [
 			{
 				"id": "RXZlbnRUaW1lOiIwMDAxLTAxLTAxVDAwOjAwOjAwWiI=",
-				"requestID": 3,
+				"jobID": 3,
 				"type": "repo",
 				"status": "SUCCESS",
 				"message": "nice",

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -1727,7 +1727,7 @@ func TestResolverPermissionsSyncJobs(t *testing.T) {
 			}(),
 			Query: `
 query {
-  permissionsSyncJobs(count:1) {
+  permissionsSyncJobs(first:1) {
     nodes {
 		id
 		type

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -1728,6 +1728,8 @@ func TestResolverPermissionsSyncJobs(t *testing.T) {
 			Query: `
 query {
   permissionsSyncJobs(first:1) {
+	totalCount
+	pageInfo { hasNextPage }
     nodes {
 		id
 		type
@@ -1763,7 +1765,11 @@ query {
 					}
 				]
 			}
-		]
+		],
+		"pageInfo": {
+			"hasNextPage": false
+		},
+		"totalCount": 1
 	}
 }`,
 		}})

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -1732,6 +1732,7 @@ query {
 	pageInfo { hasNextPage }
     nodes {
 		id
+		requestID
 		type
 		status
 		message
@@ -1751,7 +1752,8 @@ query {
 	"permissionsSyncJobs": {
 		"nodes": [
 			{
-				"id": 3,
+				"id": "RXZlbnRUaW1lOiIwMDAxLTAxLTAxVDAwOjAwOjAwWiI=",
+				"requestID": 3,
 				"type": "repo",
 				"status": "SUCCESS",
 				"message": "nice",

--- a/enterprise/internal/authz/syncjobs/mocks_test.go
+++ b/enterprise/internal/authz/syncjobs/mocks_test.go
@@ -1,0 +1,33 @@
+package syncjobs
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+type confWatcher struct {
+	update func()
+	conf   schema.SiteConfiguration
+}
+
+func (c *confWatcher) Watch(fn func())                      { c.update = fn }
+func (c *confWatcher) SiteConfig() schema.SiteConfiguration { return c.conf }
+
+type memCache map[string]string
+
+func (m memCache) Set(k string, v []byte) { m[k] = string(v) }
+
+func (m memCache) ListKeys(context.Context) (keys []string, err error) {
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return
+}
+
+func (m memCache) GetMulti(keys ...string) (vals [][]byte) {
+	for _, k := range keys {
+		vals = append(vals, []byte(m[k]))
+	}
+	return
+}

--- a/enterprise/internal/authz/syncjobs/records_reader.go
+++ b/enterprise/internal/authz/syncjobs/records_reader.go
@@ -1,0 +1,55 @@
+package syncjobs
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+
+	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type recordsReader struct {
+	// readOnlyCache is a replaceable abstraction over rcache.Cache.
+	readOnlyCache interface {
+		ListKeys(ctx context.Context) ([]string, error)
+		GetMulti(keys ...string) [][]byte
+	}
+}
+
+func NewRecordsReader() *recordsReader {
+	return &recordsReader{
+		readOnlyCache: rcache.New(syncJobsRecordsPrefix),
+	}
+}
+
+// Get retrieves the first n records, with the most recent records first.
+func (r *recordsReader) Get(ctx context.Context, first int) ([]Status, error) {
+	keys, err := r.readOnlyCache.ListKeys(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "list jobs")
+	}
+
+	// keys are timestamps
+	sort.Strings(keys)
+
+	switch {
+	case first <= 0:
+		return []Status{}, nil
+	case first < len(keys):
+		keys = keys[:first]
+	}
+
+	// get values
+	vals := r.readOnlyCache.GetMulti(keys...)
+	records := make([]Status, 0, len(vals))
+	for _, v := range vals {
+		var j Status
+		if err := json.Unmarshal(v, &j); err != nil {
+			continue // discard
+		}
+		records = append(records, j)
+	}
+
+	return records, nil
+}

--- a/enterprise/internal/authz/syncjobs/records_reader_test.go
+++ b/enterprise/internal/authz/syncjobs/records_reader_test.go
@@ -34,8 +34,8 @@ func TestSyncJobRecordsRead(t *testing.T) {
 	r.readOnlyCache = c
 
 	t.Run("read limited", func(t *testing.T) {
-		results, err := r.Get(context.Background(), 1)
-		assert.Nil(t, err)
+		results, err := r.GetAll(context.Background(), 1)
+		assert.NoError(t, err)
 		assert.Len(t, results, 1)
 
 		first := results[0]
@@ -45,8 +45,8 @@ func TestSyncJobRecordsRead(t *testing.T) {
 	})
 
 	t.Run("read all", func(t *testing.T) {
-		results, err := r.Get(context.Background(), 10)
-		assert.Nil(t, err)
+		results, err := r.GetAll(context.Background(), 10)
+		assert.NoError(t, err)
 		assert.Len(t, results, 3)
 
 		// Assert sorted
@@ -55,6 +55,12 @@ func TestSyncJobRecordsRead(t *testing.T) {
 		third := results[2]
 		assert.True(t, first.Completed.Before(second.Completed))
 		assert.True(t, second.Completed.Before(third.Completed))
+
+		t.Run("read single", func(t *testing.T) {
+			s, err := r.Get(second.Completed)
+			assert.NoError(t, err)
+			assert.Equal(t, second, *s)
+		})
 	})
 
 }

--- a/enterprise/internal/authz/syncjobs/records_reader_test.go
+++ b/enterprise/internal/authz/syncjobs/records_reader_test.go
@@ -1,0 +1,60 @@
+package syncjobs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func TestSyncJobRecordsRead(t *testing.T) {
+	c := memCache{}
+
+	// Write multiple records
+	s := NewRecordsStore(logtest.Scoped(t))
+	s.cache = c
+	s.Record("repo", 12, []ProviderStatus{{
+		ProviderID:   "https://github.com",
+		ProviderType: "github",
+	}}, errors.New("oh no"))
+	s.Record("repo", 15, []ProviderStatus{{
+		ProviderID:   "https://github.com",
+		ProviderType: "github",
+	}}, nil)
+	s.Record("user", 6, []ProviderStatus{{
+		ProviderID:   "https://github.com",
+		ProviderType: "github",
+	}}, nil)
+
+	// set up reader
+	r := NewRecordsReader()
+	r.readOnlyCache = c
+
+	t.Run("read limited", func(t *testing.T) {
+		results, err := r.Get(context.Background(), 1)
+		assert.Nil(t, err)
+		assert.Len(t, results, 1)
+
+		first := results[0]
+		assert.Equal(t, "repo", first.RequestType)
+		assert.Equal(t, int32(12), first.RequestID)
+		assert.Len(t, first.Providers, 1)
+	})
+
+	t.Run("read all", func(t *testing.T) {
+		results, err := r.Get(context.Background(), 10)
+		assert.Nil(t, err)
+		assert.Len(t, results, 3)
+
+		// Assert sorted
+		first := results[0]
+		second := results[1]
+		third := results[2]
+		assert.True(t, first.Completed.Before(second.Completed))
+		assert.True(t, second.Completed.Before(third.Completed))
+	})
+
+}

--- a/enterprise/internal/authz/syncjobs/records_reader_test.go
+++ b/enterprise/internal/authz/syncjobs/records_reader_test.go
@@ -39,8 +39,8 @@ func TestSyncJobRecordsRead(t *testing.T) {
 		assert.Len(t, results, 1)
 
 		first := results[0]
-		assert.Equal(t, "repo", first.RequestType)
-		assert.Equal(t, int32(12), first.RequestID)
+		assert.Equal(t, "repo", first.JobType)
+		assert.Equal(t, int32(12), first.JobID)
 		assert.Len(t, first.Providers, 1)
 	})
 

--- a/enterprise/internal/authz/syncjobs/records_store.go
+++ b/enterprise/internal/authz/syncjobs/records_store.go
@@ -90,5 +90,5 @@ func (r *RecordsStore) Record(jobType string, jobID int32, providerStates []Prov
 	}
 
 	// Key by timestamp for sorting
-	r.cache.Set(strconv.FormatInt(record.Completed.UnixNano(), 10), val)
+	r.cache.Set(strconv.FormatInt(record.Completed.UTC().UnixNano(), 10), val)
 }

--- a/enterprise/internal/authz/syncjobs/records_store.go
+++ b/enterprise/internal/authz/syncjobs/records_store.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 )
 
+// keep in sync with consumer in enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
 const syncJobsRecordsPrefix = "authz/sync-job-records"
 
 // default documented in site.schema.json

--- a/enterprise/internal/authz/syncjobs/records_store_test.go
+++ b/enterprise/internal/authz/syncjobs/records_store_test.go
@@ -13,14 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-type confWatcher struct {
-	update func()
-	conf   schema.SiteConfiguration
-}
-
-func (c *confWatcher) Watch(fn func())                      { c.update = fn }
-func (c *confWatcher) SiteConfig() schema.SiteConfiguration { return c.conf }
-
 func TestSyncJobsRecordsStoreWatch(t *testing.T) {
 	s := NewRecordsStore(logtest.Scoped(t))
 
@@ -42,10 +34,6 @@ func TestSyncJobsRecordsStoreWatch(t *testing.T) {
 	// assert updated
 	assert.Equal(t, 5*time.Minute, s.cache.(*rcache.Cache).TTL())
 }
-
-type memCache map[string]string
-
-func (m memCache) Set(k string, v []byte) { m[k] = string(v) }
 
 func TestSyncJobRecordsRecord(t *testing.T) {
 	mockTime, err := time.Parse(time.RFC1123, time.RFC1123)

--- a/internal/rcache/rcache.go
+++ b/internal/rcache/rcache.go
@@ -1,8 +1,10 @@
 package rcache
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // dataVersion is used for releases that change type structure for
@@ -178,6 +181,48 @@ func (r *Cache) Delete(key string) {
 	if err != nil {
 		log15.Warn("failed to execute redis command", "cmd", "DEL", "error", err)
 	}
+}
+
+// ListKeys lists all keys associated with this cache. Use with care if you have long
+// TTLs or no TTL configured.
+func (r *Cache) ListKeys(ctx context.Context) ([]string, error) {
+	c, err := pool.GetContext(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "get redis conn")
+	}
+	defer c.Close()
+
+	var allKeys []string
+	cursor := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return allKeys, ctx.Err()
+		default:
+		}
+
+		res, err := redis.Values(
+			c.Do("SCAN", cursor,
+				"MATCH", r.rkeyPrefix()+"*",
+				"COUNT", 100),
+		)
+		if err != nil {
+			return allKeys, errors.Wrap(err, "redis scan")
+		}
+
+		cursor, _ = redis.Int(res[0], nil)
+		keys, _ := redis.Strings(res[1], nil)
+		for i, k := range keys {
+			keys[i] = strings.TrimPrefix(k, r.rkeyPrefix())
+		}
+
+		allKeys = append(allKeys, keys...)
+
+		if cursor == 0 {
+			break
+		}
+	}
+	return allKeys, nil
 }
 
 // rkeyPrefix generates the actual key prefix we use on redis.

--- a/internal/rcache/rcache_test.go
+++ b/internal/rcache/rcache_test.go
@@ -1,6 +1,7 @@
 package rcache
 
 import (
+	"context"
 	"reflect"
 	"strconv"
 	"testing"
@@ -200,6 +201,23 @@ func TestCache_Increase(t *testing.T) {
 		_, ok = c.Get("a")
 		return !ok
 	}, 5*time.Second, 50*time.Millisecond, "rcache.increase did not respect expiration")
+}
+
+func TestCache_ListKeys(t *testing.T) {
+	SetupForTest(t)
+
+	c := NewWithTTL("some_prefix:", 1)
+	c.SetMulti(
+		[2]string{"foobar", "123"},
+		[2]string{"bazbar", "456"},
+		[2]string{"barfoo", "234"},
+	)
+
+	keys, err := c.ListKeys(context.Background())
+	assert.NoError(t, err)
+	for _, k := range []string{"foobar", "bazbar", "barfoo"} {
+		assert.Contains(t, keys, k)
+	}
 }
 
 func bytes(s ...string) [][]byte {


### PR DESCRIPTION
Adds a new `permissionsSyncJobs` that returns the most recent outcomes of permissions sync jobs, with per-provider details included. This will be used to validate permissions syncing is starting correctly and the desired providers are being involved and in a healthy state.

We don't implement pagination since the endpoint is intended as a stream of recent events and retention is low (see https://github.com/sourcegraph/sourcegraph/pull/44258), but the endpoint schema is set up so that it can be extended to support pagination in the future.

Closes https://github.com/sourcegraph/customer/issues/1534
Stacked on https://github.com/sourcegraph/sourcegraph/pull/44258

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Add a GitHub code host with `"authorization": {}`, and add a private repo to the list

Wait a few minutes

<img width="1697" alt="image" src="https://user-images.githubusercontent.com/23356519/202055449-f4b8cb7d-0279-4b57-98f6-14963166ee0d.png">

Remove the token:

<img width="1241" alt="image" src="https://user-images.githubusercontent.com/23356519/202257053-aaa765f4-b24b-40a9-b6fe-1c362a8dd169.png">

Get by ID:

<img width="1239" alt="image" src="https://user-images.githubusercontent.com/23356519/202257697-bffe4130-7ed9-4c3b-b60e-43d1297469e8.png">
