### PR TITLE
codeintel: Share cache across requests

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/init.go
+++ b/enterprise/cmd/frontend/internal/codeintel/init.go
@@ -56,7 +56,7 @@ func Init(
 		scopedContext("autoindexing"),
 	)
 
-	codenavRootResolver := codenavgraphql.NewRootResolver(
+	codenavRootResolver, err := codenavgraphql.NewRootResolver(
 		codeIntelServices.CodenavService,
 		codeIntelServices.AutoIndexingService,
 		codeIntelServices.UploadsService,
@@ -66,6 +66,9 @@ func Init(
 		ConfigInst.HunkCacheSize,
 		scopedContext("codenav"),
 	)
+	if err != nil {
+		return err
+	}
 
 	policyRootResolver := policiesgraphql.NewRootResolver(
 		codeIntelServices.PoliciesService,

--- a/enterprise/internal/codeintel/codenav/request_state.go
+++ b/enterprise/internal/codeintel/codenav/request_state.go
@@ -36,7 +36,7 @@ func NewRequestState(
 	commit string,
 	path string,
 	maxIndexes int,
-	hunkCacheSize int,
+	hunkCache HunkCache,
 ) RequestState {
 	r := &RequestState{
 		RepositoryID: int(repo.ID),
@@ -45,7 +45,7 @@ func NewRequestState(
 	}
 	r.SetUploadsDataLoader(uploads)
 	r.SetAuthChecker(authChecker)
-	r.SetLocalGitTreeTranslator(gitclient, repo, commit, path, hunkCacheSize)
+	r.SetLocalGitTreeTranslator(gitclient, repo, commit, path, hunkCache)
 	r.SetLocalCommitCache(gitclient)
 	r.SetMaximumIndexesPerMonikerSearch(maxIndexes)
 
@@ -75,12 +75,7 @@ func (r *RequestState) SetUploadsDataLoader(uploads []types.Dump) {
 	}
 }
 
-func (r *RequestState) SetLocalGitTreeTranslator(client GitserverClient, repo *sgTypes.Repo, commit, path string, hunkCacheSize int) error {
-	hunkCache, err := NewHunkCache(hunkCacheSize)
-	if err != nil {
-		return err
-	}
-
+func (r *RequestState) SetLocalGitTreeTranslator(client GitserverClient, repo *sgTypes.Repo, commit, path string, hunkCache HunkCache) error {
 	args := &requestArgs{
 		repo:   repo,
 		commit: commit,

--- a/enterprise/internal/codeintel/codenav/service_definitions_test.go
+++ b/enterprise/internal/codeintel/codenav/service_definitions_test.go
@@ -24,6 +24,7 @@ func TestDefinitions(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitServer := codeintelgitserver.New(database.NewMockDB(), &observation.TestContext)
+	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
 	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, nil, nil, &observation.TestContext)
@@ -31,7 +32,8 @@ func TestDefinitions(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, 50)
+
+	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
 	uploads := []types.Dump{
 		{ID: 50, Commit: mockCommit, Root: "sub1/"},
 		{ID: 51, Commit: mockCommit, Root: "sub2/"},
@@ -80,6 +82,7 @@ func TestDefinitionsWithSubRepoPermissions(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitServer := codeintelgitserver.New(database.NewMockDB(), &observation.TestContext)
+	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
 	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, nil, nil, &observation.TestContext)
@@ -87,7 +90,7 @@ func TestDefinitionsWithSubRepoPermissions(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, 50)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
 	uploads := []types.Dump{
 		{ID: 50, Commit: mockCommit, Root: "sub1/"},
 		{ID: 51, Commit: mockCommit, Root: "sub2/"},
@@ -147,6 +150,7 @@ func TestDefinitionsRemote(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitServer := codeintelgitserver.New(database.NewMockDB(), &observation.TestContext)
+	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
 	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, nil, nil, &observation.TestContext)
@@ -154,7 +158,7 @@ func TestDefinitionsRemote(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockGitserverClient)
-	err := mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{ID: 42}, mockCommit, mockPath, 50)
+	err := mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{ID: 42}, mockCommit, mockPath, hunkCache)
 	if err != nil {
 		t.Fatalf("unexpected error setting local git tree translator: %s", err)
 	}
@@ -269,6 +273,7 @@ func TestDefinitionsRemoteWithSubRepoPermissions(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitServer := codeintelgitserver.New(database.NewMockDB(), &observation.TestContext)
+	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
 	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, nil, nil, &observation.TestContext)
@@ -276,7 +281,7 @@ func TestDefinitionsRemoteWithSubRepoPermissions(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{ID: 42}, mockCommit, mockPath, 50)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{ID: 42}, mockCommit, mockPath, hunkCache)
 	uploads := []types.Dump{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},

--- a/enterprise/internal/codeintel/codenav/service_diagnostics_test.go
+++ b/enterprise/internal/codeintel/codenav/service_diagnostics_test.go
@@ -24,6 +24,7 @@ func TestDiagnostics(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitServer := codeintelgitserver.New(database.NewMockDB(), &observation.TestContext)
+	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
 	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, nil, nil, &observation.TestContext)
@@ -31,7 +32,7 @@ func TestDiagnostics(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, 50)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
 	uploads := []types.Dump{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
@@ -95,6 +96,7 @@ func TestDiagnosticsWithSubRepoPermissions(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitServer := codeintelgitserver.New(database.NewMockDB(), &observation.TestContext)
+	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
 	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, nil, nil, &observation.TestContext)
@@ -102,7 +104,7 @@ func TestDiagnosticsWithSubRepoPermissions(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, 50)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
 	uploads := []types.Dump{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},

--- a/enterprise/internal/codeintel/codenav/service_hover_test.go
+++ b/enterprise/internal/codeintel/codenav/service_hover_test.go
@@ -22,6 +22,7 @@ func TestHover(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitServer := codeintelgitserver.New(database.NewMockDB(), &observation.TestContext)
+	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
 	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, nil, nil, &observation.TestContext)
@@ -29,7 +30,7 @@ func TestHover(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{ID: 42}, mockCommit, mockPath, 50)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{ID: 42}, mockCommit, mockPath, hunkCache)
 	uploads := []types.Dump{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
@@ -76,6 +77,7 @@ func TestHoverRemote(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitServer := codeintelgitserver.New(database.NewMockDB(), &observation.TestContext)
+	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
 	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, nil, nil, &observation.TestContext)
@@ -83,7 +85,7 @@ func TestHoverRemote(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{ID: 42}, mockCommit, mockPath, 50)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{ID: 42}, mockCommit, mockPath, hunkCache)
 	uploads := []types.Dump{
 		{ID: 50, Commit: "deadbeef"},
 	}

--- a/enterprise/internal/codeintel/codenav/service_implementations_test.go
+++ b/enterprise/internal/codeintel/codenav/service_implementations_test.go
@@ -24,6 +24,7 @@ func TestImplementations(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitServer := codeintelgitserver.New(database.NewMockDB(), &observation.TestContext)
+	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
 	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, nil, nil, &observation.TestContext)
@@ -31,7 +32,7 @@ func TestImplementations(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, 50)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
 
 	// Empty result set (prevents nil pointer as scanner is always non-nil)
 	mockUploadSvc.GetUploadIDsWithReferencesFunc.PushReturn([]int{}, 0, 0, nil)
@@ -87,6 +88,7 @@ func TestImplementationsWithSubRepoPermissions(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitServer := codeintelgitserver.New(database.NewMockDB(), &observation.TestContext)
+	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
 	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, nil, nil, &observation.TestContext)
@@ -94,7 +96,7 @@ func TestImplementationsWithSubRepoPermissions(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, 50)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
 
 	// Empty result set (prevents nil pointer as scanner is always non-nil)
 	mockUploadSvc.GetUploadIDsWithReferencesFunc.PushReturn([]int{}, 0, 0, nil)
@@ -162,6 +164,7 @@ func TestImplementationsRemote(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitServer := codeintelgitserver.New(database.NewMockDB(), &observation.TestContext)
+	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
 	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, nil, nil, &observation.TestContext)
@@ -169,7 +172,7 @@ func TestImplementationsRemote(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{ID: 42}, mockCommit, mockPath, 50)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{ID: 42}, mockCommit, mockPath, hunkCache)
 	uploads := []types.Dump{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
@@ -318,6 +321,7 @@ func TestImplementationsRemoteWithSubRepoPermissions(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitServer := codeintelgitserver.New(database.NewMockDB(), &observation.TestContext)
+	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
 	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, nil, nil, &observation.TestContext)
@@ -325,7 +329,7 @@ func TestImplementationsRemoteWithSubRepoPermissions(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, 50)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
 	uploads := []types.Dump{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},

--- a/enterprise/internal/codeintel/codenav/service_ranges_test.go
+++ b/enterprise/internal/codeintel/codenav/service_ranges_test.go
@@ -49,6 +49,7 @@ func TestRanges(t *testing.T) {
 		}
 		return nil, nil
 	})
+	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
 	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, nil, nil, &observation.TestContext)
@@ -56,7 +57,7 @@ func TestRanges(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, 50)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
 	uploads := []types.Dump{
 		{ID: 50, Commit: "deadbeef1", Root: "sub1/", RepositoryID: 42},
 		{ID: 51, Commit: "deadbeef1", Root: "sub2/", RepositoryID: 42},

--- a/enterprise/internal/codeintel/codenav/service_references_test.go
+++ b/enterprise/internal/codeintel/codenav/service_references_test.go
@@ -36,6 +36,7 @@ func TestReferences(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitServer := codeintelgitserver.New(database.NewMockDB(), &observation.TestContext)
+	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
 	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, nil, nil, &observation.TestContext)
@@ -43,7 +44,7 @@ func TestReferences(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, 50)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
 	uploads := []types.Dump{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
@@ -99,6 +100,7 @@ func TestReferencesWithSubRepoPermissions(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitServer := codeintelgitserver.New(database.NewMockDB(), &observation.TestContext)
+	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
 	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, nil, nil, &observation.TestContext)
@@ -106,7 +108,7 @@ func TestReferencesWithSubRepoPermissions(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, 50)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
 	uploads := []types.Dump{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
@@ -173,6 +175,7 @@ func TestReferencesRemote(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitServer := codeintelgitserver.New(database.NewMockDB(), &observation.TestContext)
+	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
 	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, nil, nil, &observation.TestContext)
@@ -180,7 +183,7 @@ func TestReferencesRemote(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, 50)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
 	uploads := []types.Dump{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
@@ -348,6 +351,7 @@ func TestReferencesRemoteWithSubRepoPermissions(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitServer := codeintelgitserver.New(database.NewMockDB(), &observation.TestContext)
+	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
 	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, nil, nil, &observation.TestContext)
@@ -355,7 +359,7 @@ func TestReferencesRemoteWithSubRepoPermissions(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, 50)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
 	uploads := []types.Dump{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},

--- a/enterprise/internal/codeintel/codenav/service_stencil_test.go
+++ b/enterprise/internal/codeintel/codenav/service_stencil_test.go
@@ -21,6 +21,7 @@ func TestStencil(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitServer := codeintelgitserver.New(database.NewMockDB(), &observation.TestContext)
+	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
 	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, nil, nil, &observation.TestContext)
@@ -28,7 +29,7 @@ func TestStencil(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, 50)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
 	uploads := []types.Dump{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
@@ -77,6 +78,7 @@ func TestStencilWithDuplicateRanges(t *testing.T) {
 	mockUploadSvc := NewMockUploadService()
 	mockGitserverClient := NewMockGitserverClient()
 	mockGitServer := codeintelgitserver.New(database.NewMockDB(), &observation.TestContext)
+	hunkCache, _ := NewHunkCache(50)
 
 	// Init service
 	svc := newService(mockStore, mockLsifStore, mockUploadSvc, mockGitserverClient, nil, nil, &observation.TestContext)
@@ -84,7 +86,7 @@ func TestStencilWithDuplicateRanges(t *testing.T) {
 	// Set up request state
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockGitserverClient)
-	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, 50)
+	mockRequestState.SetLocalGitTreeTranslator(mockGitServer, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
 	uploads := []types.Dump{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},


### PR DESCRIPTION
Move the hunk cache up to the root resolver so we only create one, rather than one on every request. Note: default size is 1000.

## Test plan

Unit tests passed!