### PR TITLE
docker-images: Upgrade cadvisor to 0.46.0

### DIFF
--- a/docker-images/cadvisor/Dockerfile
+++ b/docker-images/cadvisor/Dockerfile
@@ -1,5 +1,5 @@
 FROM gcr.io/cadvisor/cadvisor@sha256:9360d7421c5e9b646ea13e5ced3f8e6da80017b0144733a04b7401dd8c01a5cb
-LABEL com.sourcegraph.cadvisor.version=v0.45.0
+LABEL com.sourcegraph.cadvisor.version=v0.46.0
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"


### PR DESCRIPTION
`cadvisor` was failing for me locally on OSX + minikube with this error:

```
Failed to create a manager: could not detect clock speed from output:
```

Upgrading to `0.46.0` fixed the [issue](https://github.com/google/cadvisor/issues/3187).

## Test plan

Tested locally with new image on minikube.

Build should pass.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
