### PR TITLE
search: activate smart search by default

### DIFF
--- a/client/search-ui/src/input/toggles/SmartSearchToggle.tsx
+++ b/client/search-ui/src/input/toggles/SmartSearchToggle.tsx
@@ -55,6 +55,7 @@ export const SmartSearchToggle: React.FunctionComponent<SmartSearchToggleProps> 
                 <PopoverTrigger
                     as={Button}
                     className={classNames(
+                        'a11y-ignore',
                         styles.toggle,
                         smartStyles.button,
                         className,

--- a/client/search-ui/src/input/toggles/Toggles.tsx
+++ b/client/search-ui/src/input/toggles/Toggles.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback } from 'react'
 
 import { mdiCodeBrackets, mdiFormatLetterCase, mdiRegex } from '@mdi/js'
 import classNames from 'classnames'
 
-import { isErrorLike, isMacPlatform } from '@sourcegraph/common'
+import { isMacPlatform } from '@sourcegraph/common'
 import {
     SearchPatternTypeProps,
     CaseSensitivityProps,
@@ -69,26 +69,12 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
         setCaseSensitivity,
         searchMode,
         setSearchMode,
-        settingsCascade,
         className,
         selectedSearchContextSpec,
         submitSearch,
         showCopyQueryButton = true,
         structuralSearchDisabled,
     } = props
-
-    const defaultPatternTypeValue = useMemo(
-        () =>
-            (settingsCascade.final &&
-                !isErrorLike(settingsCascade.final) &&
-                (settingsCascade.final['search.defaultPatternType'] as SearchPatternType)) ||
-            SearchPatternType.standard,
-        [settingsCascade.final]
-    )
-
-    const showSmartSearch = useMemo(() => defaultPatternTypeValue === SearchPatternType.lucky, [
-        defaultPatternTypeValue,
-    ])
 
     const submitOnToggle = useCallback(
         (
@@ -204,15 +190,13 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
                         />
                     )}
                 </>
-                {(showSmartSearch || showCopyQueryButton) && <div className={styles.separator} />}
-                {showSmartSearch && (
-                    <SmartSearchToggle
-                        className="test-smart-search-toggle"
-                        isActive={searchMode === SearchMode.SmartSearch}
-                        onSelect={onSelectSmartSearch}
-                        interactive={props.interactive}
-                    />
-                )}
+                <div className={styles.separator} />
+                <SmartSearchToggle
+                    className="test-smart-search-toggle"
+                    isActive={searchMode === SearchMode.SmartSearch}
+                    onSelect={onSelectSmartSearch}
+                    interactive={props.interactive}
+                />
                 {showCopyQueryButton && (
                     <CopyQueryButton
                         fullQuery={fullQuery}

--- a/client/vscode/src/webview/search-panel/SearchHomeView.tsx
+++ b/client/vscode/src/webview/search-panel/SearchHomeView.tsx
@@ -42,7 +42,7 @@ export const SearchHomeView: React.FunctionComponent<React.PropsWithChildren<Sea
     // Toggling case sensitivity or pattern type does NOT trigger a new search on home view.
     const [caseSensitive, setCaseSensitivity] = useState(false)
     const [patternType, setPatternType] = useState(SearchPatternType.standard)
-    const [searchMode, setSearchMode] = useState(SearchMode.Precise)
+    const [searchMode, setSearchMode] = useState(SearchMode.SmartSearch)
 
     const [userQueryState, setUserQueryState] = useState<QueryState>({
         query: '',
@@ -58,6 +58,7 @@ export const SearchHomeView: React.FunctionComponent<React.PropsWithChildren<Sea
             .streamSearch(userQueryState.query, {
                 caseSensitive,
                 patternType,
+                searchMode,
                 version: LATEST_VERSION,
                 trace: undefined,
             })

--- a/client/vscode/src/webview/search-panel/SearchResultsView.tsx
+++ b/client/vscode/src/webview/search-panel/SearchResultsView.tsx
@@ -148,6 +148,7 @@ export const SearchResultsView: React.FunctionComponent<React.PropsWithChildren<
                 .streamSearch(query, {
                     caseSensitive,
                     patternType,
+                    searchMode,
                     version: LATEST_VERSION,
                     trace: undefined,
                     chunkMatches: true,

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -279,18 +279,18 @@ describe('Search', () => {
                     await driver.page.click('.test-case-sensitivity-toggle')
                     await driver.page.click('aria/Search[role="button"]')
                     await driver.assertWindowLocation(
-                        '/search?q=context:global+test&patternType=standard&case=yes&sm=0'
+                        '/search?q=context:global+test&patternType=standard&case=yes&sm=1'
                     )
                 })
 
                 test('Clicking toggle turns off case sensitivity and removes case= URL parameter', async () => {
                     await driver.page.goto(
-                        driver.sourcegraphBaseUrl + '/search?q=test&patternType=standard&case=yes&sm=0'
+                        driver.sourcegraphBaseUrl + '/search?q=test&patternType=standard&case=yes&sm=1'
                     )
                     await createEditorAPI(driver, queryInputSelector)
                     await driver.page.waitForSelector('.test-case-sensitivity-toggle')
                     await driver.page.click('.test-case-sensitivity-toggle')
-                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=standard&sm=0')
+                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=standard&sm=1')
                 })
             })
         })
@@ -314,7 +314,7 @@ describe('Search', () => {
                     await driver.page.keyboard.type('test')
                     await driver.page.click('.test-structural-search-toggle')
                     await driver.page.click('aria/Search[role="button"]')
-                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=structural&sm=0')
+                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=structural&sm=1')
                 })
 
                 test('Clicking toggle turns on structural search and removes existing patternType parameter', async () => {
@@ -323,7 +323,7 @@ describe('Search', () => {
                     await editor.focus()
                     await driver.page.waitForSelector('.test-structural-search-toggle')
                     await driver.page.click('.test-structural-search-toggle')
-                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=structural&sm=0')
+                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=structural&sm=1')
                 })
 
                 test('Clicking toggle turns off structural search and reverts to default pattern type', async () => {
@@ -331,7 +331,7 @@ describe('Search', () => {
                     await createEditorAPI(driver, queryInputSelector)
                     await driver.page.waitForSelector('.test-structural-search-toggle')
                     await driver.page.click('.test-structural-search-toggle')
-                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=standard&sm=0')
+                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=standard&sm=1')
                 })
             })
         })
@@ -346,7 +346,7 @@ describe('Search', () => {
 
             await driver.page.waitForSelector('.test-search-button', { visible: true })
             await driver.page.click('.test-search-button')
-            await driver.assertWindowLocation('/search?q=context:global+test+hello&patternType=regexp&sm=0')
+            await driver.assertWindowLocation('/search?q=context:global+test+hello&patternType=regexp&sm=1')
         })
     })
 
@@ -562,7 +562,7 @@ describe('Search', () => {
                 driver.page.waitForNavigation(),
                 driver.page.click('[data-testid="search-type-submit"]'),
             ])
-            await driver.assertWindowLocation('/search?q=context:global+test+type:commit&patternType=standard&sm=0')
+            await driver.assertWindowLocation('/search?q=context:global+test+type:commit&patternType=standard&sm=1')
         })
     })
 })

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -89,6 +89,7 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                     history: props.history,
                     patternType,
                     caseSensitive,
+                    searchMode,
                     selectedSearchContextSpec: props.selectedSearchContextSpec,
                     addRecentSearch,
                     ...parameters,
@@ -102,6 +103,7 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
             addRecentSearch,
             patternType,
             caseSensitive,
+            searchMode,
         ]
     )
 

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -117,7 +117,7 @@ describe('StreamingSearchResults', () => {
             version: 'V3',
             patternType: SearchPatternType.regexp,
             caseSensitive: true,
-            searchMode: SearchMode.Precise,
+            searchMode: SearchMode.SmartSearch,
             trace: undefined,
             chunkMatches: true,
             featureOverrides: [],

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -6,7 +6,7 @@ import { useHistory } from 'react-router'
 import { Observable } from 'rxjs'
 
 import { asError } from '@sourcegraph/common'
-import { QueryUpdate, SearchContextProps, SearchMode } from '@sourcegraph/search'
+import { QueryUpdate, SearchContextProps } from '@sourcegraph/search'
 import { StreamingProgress, StreamingSearchResultsList } from '@sourcegraph/search-ui'
 import { FetchFileParameters } from '@sourcegraph/shared/src/backend/file'
 import { FilePrefetcher } from '@sourcegraph/shared/src/components/PrefetchableFile'
@@ -106,7 +106,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
             caseSensitive,
             trace,
             featureOverrides,
-            searchMode: patternType === SearchPatternType.lucky ? SearchMode.SmartSearch : searchMode,
+            searchMode,
             chunkMatches: true,
         }),
         [caseSensitive, patternType, searchMode, trace, featureOverrides]

--- a/client/web/src/stores/navbarSearchQueryState.ts
+++ b/client/web/src/stores/navbarSearchQueryState.ts
@@ -19,7 +19,11 @@ import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 
 import { ParsedSearchURL } from '../search'
 import { submitSearch } from '../search/helpers'
-import { defaultCaseSensitiveFromSettings, defaultPatternTypeFromSettings } from '../util/settings'
+import {
+    defaultCaseSensitiveFromSettings,
+    defaultPatternTypeFromSettings,
+    defaultSearchModeFromSettings,
+} from '../util/settings'
 
 export interface NavbarQueryState extends SearchQueryState {}
 
@@ -28,7 +32,7 @@ export const useNavbarQueryState = create<NavbarQueryState>((set, get) => ({
     queryState: { query: '' },
     searchCaseSensitivity: false,
     searchPatternType: SearchPatternType.standard,
-    searchMode: SearchMode.Precise,
+    searchMode: SearchMode.SmartSearch,
     searchQueryFromURL: '',
 
     setQueryState: queryStateUpdate => {
@@ -116,7 +120,7 @@ export function setQueryStateFromSettings(settings: SettingsCascadeOrError<Setti
     }
 
     const newState: Partial<
-        Pick<NavbarQueryState, 'searchPatternType' | 'searchCaseSensitivity' | 'parametersSource'>
+        Pick<NavbarQueryState, 'searchPatternType' | 'searchCaseSensitivity' | 'parametersSource' | 'searchMode'>
     > = {
         parametersSource: InitialParametersSource.USER_SETTINGS,
     }
@@ -124,6 +128,11 @@ export function setQueryStateFromSettings(settings: SettingsCascadeOrError<Setti
     const caseSensitive = defaultCaseSensitiveFromSettings(settings)
     if (caseSensitive !== undefined) {
         newState.searchCaseSensitivity = caseSensitive
+    }
+
+    const searchMode = defaultSearchModeFromSettings(settings)
+    if (searchMode !== undefined) {
+        newState.searchMode = searchMode
     }
 
     const searchPatternType = defaultPatternTypeFromSettings(settings)

--- a/client/web/src/util/settings.ts
+++ b/client/web/src/util/settings.ts
@@ -1,4 +1,5 @@
 import { isErrorLike } from '@sourcegraph/common'
+import { SearchMode } from '@sourcegraph/search'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { SettingsCascadeOrError, SettingsSubjectCommonFields } from '@sourcegraph/shared/src/settings/settings'
 
@@ -24,6 +25,20 @@ export function viewerSubjectFromSettings(
         return cascade.subjects[0].subject
     }
     return siteSubjectNoAdmin()
+}
+
+/**
+ * Returns the user-configured default search mode or undefined if not
+ * configured by the user.
+ */
+export function defaultSearchModeFromSettings(settingsCascade: SettingsCascadeOrError): SearchMode | undefined {
+    switch (getFromSettings(settingsCascade, 'search.defaultMode')) {
+        case 'precise':
+            return SearchMode.Precise
+        case 'smart':
+            return SearchMode.SmartSearch
+    }
+    return undefined
 }
 
 /**

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1816,6 +1816,8 @@ type Settings struct {
 	SearchContextLines int `json:"search.contextLines,omitempty"`
 	// SearchDefaultCaseSensitive description: Whether query patterns are treated case sensitively. Patterns are case insensitive by default.
 	SearchDefaultCaseSensitive bool `json:"search.defaultCaseSensitive,omitempty"`
+	// SearchDefaultMode description: Defines default properties for search behavior. The default is `smart`, which provides query assistance that automatically runs alternative queries when appropriate. When `precise`, search behavior strictly searches for the precise meaning of the query.
+	SearchDefaultMode string `json:"search.defaultMode,omitempty"`
 	// SearchDefaultPatternType description: The default pattern type that search queries will be intepreted as. `lucky` is an experimental mode that will interpret the query in multiple ways.
 	SearchDefaultPatternType string `json:"search.defaultPatternType,omitempty"`
 	// SearchGlobbing description: REMOVED. Previously an experimental setting to interpret file and repo patterns as glob syntax.

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -681,6 +681,11 @@
       "minimum": 0,
       "default": 1
     },
+    "search.defaultMode": {
+      "description": "Defines default properties for search behavior. The default is `smart`, which provides query assistance that automatically runs alternative queries when appropriate. When `precise`, search behavior strictly searches for the precise meaning of the query.",
+      "type": "string",
+      "pattern": "precise|smart"
+    },
     "search.defaultPatternType": {
       "description": "The default pattern type that search queries will be intepreted as. `lucky` is an experimental mode that will interpret the query in multiple ways.",
       "type": "string",


### PR DESCRIPTION
This activates the smart search feature by default (the toggle always shows up). It also adds a setting where the default toggle state can be set by `search.defaultMode`.

See inline comments for more details.

After this PR I will update changelog and continue testing/refining things.

Extra notes, about VSCode extension:

After some manual testing, I think it makes sense to keep the smart search toggle in VScode, which is what this PR does. Because:

1) It works as expected and consistent with web app behavior (this because the streaming search endpoint sees the smart search value)

2) It is _really_ ugly and messy to try and introduce a setting/bool to not display certain toggle buttons when in VSCode mode and not worth the tradeoff IMO. We would effectively have a need for divergent UIs. If we really want to disable smart search for VSCode we should first do the work that completely separates it, and it's UI (`Toggles`, `SearchBox`) from the web app. That does not seem like the desired approach, we want to keep webapp and VSCode components consistent.

3) There are two cons to the tradeoff. The main one is that the VSCode extension doesn't display the alerts/info box (it doesn't appear to display any server side alerts). I think this is a gap in the extension that we should address swiftly. I wasn't aware of it being absent before, so this is already a divergence that really seems like something we should support in VSCode. Second, there isn't a direct URL that corresponds to the web app (at least, I'm not sure there is a web URL can copy from the VSCode environment). But at least, now if a user had smart search toggled in VSCode, and sees results, they can get the same behavior in the webapp as well. That can also be mitigated with a "open in browser" if that doesn't exist already.

## Test plan
Existing tests + manual testing

## App preview:

- [Web](https://sg-web-rvt-smart-search-default-xyz.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

