### PR TITLE
bext: fix actions container selector on GitHub

### DIFF
--- a/client/browser/src/shared/code-hosts/github/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/github/codeHost.tsx
@@ -164,7 +164,8 @@ export const createFileLineContainerToolbarMount: NonNullable<CodeView['getToolb
     mountElement.className = className
 
     // new GitHub UI
-    const container = codeViewElement.querySelector('#repos-sticky-header a[href="https://github.dev/"]')?.parentElement
+    const container = codeViewElement.querySelector('#repos-sticky-header')?.childNodes[0]?.childNodes[0]?.childNodes[1]
+        ?.childNodes[1] // we have to use this level of nesting when selecting a target container because #repos-sticky-header children don't have specific classes or ids
     if (container instanceof HTMLElement) {
         container.prepend(mountElement)
         return mountElement


### PR DESCRIPTION
Leftover from https://github.com/sourcegraph/sourcegraph/pull/44285. Fixes frong selector commited by mistake (https://github.com/sourcegraph/sourcegraph/pull/44285#discussion_r1022282259). 

## Test plan
Manually tested that file actions are rendered on GitHub mobile view.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-bext-fix-selector-on.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
