### PR TITLE
Fix git blame popover styles

### DIFF
--- a/client/web/src/repo/blob/BlameDecoration.tsx
+++ b/client/web/src/repo/blob/BlameDecoration.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from 'react'
+import React, { useCallback, useEffect } from 'react'
 
 import classNames from 'classnames'
 import SourceCommitIcon from 'mdi-react/SourceCommitIcon'

--- a/client/web/src/repo/blob/BlameDecoration.tsx
+++ b/client/web/src/repo/blob/BlameDecoration.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 
 import classNames from 'classnames'
 import SourceCommitIcon from 'mdi-react/SourceCommitIcon'
@@ -181,20 +181,22 @@ export const BlameDecoration: React.FunctionComponent<{
                             {blameHunk.message}
                         </Link>
                     </div>
-                    <hr className={classNames(styles.separator, 'm-0')} />
-                    <div className={classNames('px-3', styles.block)}>
-                        {blameHunk.commit.parents.length > 0 && (
-                            <Link
-                                to={
-                                    window.location.origin +
-                                    replaceRevisionInURL(window.location.href, blameHunk.commit.parents[0].oid)
-                                }
-                                className={styles.footerLink}
-                            >
-                                View blame prior to this change
-                            </Link>
-                        )}
-                    </div>
+                    {blameHunk.commit.parents.length > 0 && (
+                        <>
+                            <hr className={classNames(styles.separator, 'm-0')} />
+                            <div className={classNames('px-3', styles.block)}>
+                                <Link
+                                    to={
+                                        window.location.origin +
+                                        replaceRevisionInURL(window.location.href, blameHunk.commit.parents[0].oid)
+                                    }
+                                    className={styles.footerLink}
+                                >
+                                    View blame prior to this change
+                                </Link>
+                            </div>
+                        </>
+                    )}
                 </div>
             </PopoverContent>
         </Popover>

--- a/client/web/src/repo/blob/BlameDecoration.tsx
+++ b/client/web/src/repo/blob/BlameDecoration.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import classNames from 'classnames'
 import SourceCommitIcon from 'mdi-react/SourceCommitIcon'


### PR DESCRIPTION
Do not render separator and empty block if no parent commit link exists.
Leftover from https://github.com/sourcegraph/sourcegraph/pull/44090.

|Before|After|
| -- | -- |
| <img width="697" alt="Screenshot 2022-11-15 at 11 47 54" src="https://user-images.githubusercontent.com/25318659/201887304-1e85b6ed-9da1-4d33-9931-b4354eda5232.png">|<img width="697" alt="Screenshot 2022-11-15 at 11 47 29" src="https://user-images.githubusercontent.com/25318659/201887242-3937e7a9-d70c-4785-b6cd-ca42ba55ab1c.png"> |

## Test plan
Tested manually.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-fix-view-previous.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
