### PR TITLE
Navigate to blame prior to selected change without page reload

### DIFF
--- a/client/web/src/repo/blob/BlameColumn.tsx
+++ b/client/web/src/repo/blob/BlameColumn.tsx
@@ -1,5 +1,6 @@
 import React, { useLayoutEffect } from 'react'
 
+import { History } from 'history'
 import ReactDOM from 'react-dom'
 import { ReplaySubject } from 'rxjs'
 
@@ -13,6 +14,7 @@ interface BlameColumnProps {
     isBlameVisible?: boolean
     blameHunks?: BlameHunk[]
     codeViewElements: ReplaySubject<HTMLElement | null>
+    history: History
 }
 
 const getRowByLine = (line: number): HTMLTableRowElement | null | undefined =>
@@ -23,7 +25,7 @@ const getRowByLine = (line: number): HTMLTableRowElement | null | undefined =>
 const selectRow = (line: number): void => getRowByLine(line)?.classList.add('highlighted')
 const deselectRow = (line: number): void => getRowByLine(line)?.classList.remove('highlighted')
 
-export const BlameColumn = React.memo<BlameColumnProps>(({ isBlameVisible, codeViewElements, blameHunks }) => {
+export const BlameColumn = React.memo<BlameColumnProps>(({ isBlameVisible, codeViewElements, blameHunks, history }) => {
     /**
      * Array to store the DOM element and the blame hunk to render in it.
      * As blame decorations are displayed in the column view, we need to add a corresponding
@@ -122,6 +124,7 @@ export const BlameColumn = React.memo<BlameColumnProps>(({ isBlameVisible, codeV
                     <BlameDecoration
                         line={index + 1}
                         blameHunk={blameHunk}
+                        history={history}
                         onSelect={selectRow}
                         onDeselect={deselectRow}
                     />,

--- a/client/web/src/repo/blob/BlameDecoration.tsx
+++ b/client/web/src/repo/blob/BlameDecoration.tsx
@@ -130,7 +130,7 @@ export const BlameDecoration: React.FunctionComponent<{
     ])
 
     // Prevent hitting the backend (full page reloads) for links that stay inside the app.
-    const onClick = useMemo(() => createLinkClickHandler(history), [history])
+    const handleParentCommitLinkClick = useMemo(() => createLinkClickHandler(history), [history])
 
     if (!blameHunk) {
         return null
@@ -196,7 +196,7 @@ export const BlameDecoration: React.FunctionComponent<{
                                         window.location.origin +
                                         replaceRevisionInURL(window.location.href, blameHunk.commit.parents[0].oid)
                                     }
-                                    onClick={onClick}
+                                    onClick={handleParentCommitLinkClick}
                                     className={styles.footerLink}
                                 >
                                     View blame prior to this change

--- a/client/web/src/repo/blob/BlameDecoration.tsx
+++ b/client/web/src/repo/blob/BlameDecoration.tsx
@@ -1,9 +1,11 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 
 import classNames from 'classnames'
+import { History } from 'history'
 import SourceCommitIcon from 'mdi-react/SourceCommitIcon'
 import { BehaviorSubject } from 'rxjs'
 
+import { createLinkClickHandler } from '@sourcegraph/shared/src/components/utils/linkClickHandler'
 import {
     createRectangle,
     Icon,
@@ -105,9 +107,10 @@ const usePopover = ({
 export const BlameDecoration: React.FunctionComponent<{
     line: number // 1-based line number
     blameHunk?: BlameHunk
+    history: History
     onSelect?: (line: number) => void
     onDeselect?: (line: number) => void
-}> = ({ line, blameHunk, onSelect, onDeselect }) => {
+}> = ({ line, blameHunk, history, onSelect, onDeselect }) => {
     const id = line?.toString() || ''
     const onOpen = useCallback(() => {
         onSelect?.(line)
@@ -125,6 +128,9 @@ export const BlameDecoration: React.FunctionComponent<{
         close,
         open,
     ])
+
+    // Prevent hitting the backend (full page reloads) for links that stay inside the app.
+    const onClick = useMemo(() => createLinkClickHandler(history), [history])
 
     if (!blameHunk) {
         return null
@@ -189,6 +195,7 @@ export const BlameDecoration: React.FunctionComponent<{
                                     window.location.origin +
                                     replaceRevisionInURL(window.location.href, blameHunk.commit.parents[0].oid)
                                 }
+                                onClick={onClick}
                                 className={styles.footerLink}
                             >
                                 View blame prior to this change

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -891,6 +891,7 @@ export const Blob: React.FunctionComponent<React.PropsWithChildren<BlobProps>> =
                     isBlameVisible={props.isBlameVisible}
                     blameHunks={props.blameHunks}
                     codeViewElements={codeViewElements}
+                    history={props.history}
                 />
 
                 {groupedDecorations &&

--- a/client/web/src/repo/blob/codemirror/blame-decorations.tsx
+++ b/client/web/src/repo/blob/codemirror/blame-decorations.tsx
@@ -5,6 +5,7 @@
  */
 import { Facet, RangeSet } from '@codemirror/state'
 import { Decoration, EditorView, gutter, gutterLineClass, GutterMarker } from '@codemirror/view'
+import { History } from 'history'
 import { isEqual } from 'lodash'
 import { createRoot, Root } from 'react-dom/client'
 
@@ -12,6 +13,8 @@ import { createUpdateableField } from '@sourcegraph/shared/src/components/CodeMi
 
 import { BlameHunk } from '../../blame/useBlameHunks'
 import { BlameDecoration } from '../BlameDecoration'
+
+import { blobPropsFacet } from '.'
 
 import blameColumnStyles from '../BlameColumn.module.scss'
 
@@ -53,6 +56,7 @@ const longestColumnDecorations = (hunks?: BlameHunk[]): BlameHunk | undefined =>
 class BlameDecoratorMarker extends GutterMarker {
     private container: HTMLElement | null = null
     private reactRoot: Root | null = null
+    private state: { history: History }
 
     constructor(
         public view: EditorView,
@@ -60,6 +64,7 @@ class BlameDecoratorMarker extends GutterMarker {
         private isSpacer: boolean = false
     ) {
         super()
+        this.state = { history: this.view.state.facet(blobPropsFacet).history }
     }
 
     /* eslint-disable-next-line id-length*/
@@ -79,6 +84,7 @@ class BlameDecoratorMarker extends GutterMarker {
                      */
                     line={this.isSpacer ? 0 : this.hunk?.startLine ?? 0}
                     blameHunk={this.hunk}
+                    history={this.state.history}
                     onSelect={this.selectRow}
                     onDeselect={this.deselectRow}
                 />


### PR DESCRIPTION
Intercept 'View blame prior to this change' links clicks to avoid page reloads.
See [this thread](https://github.com/sourcegraph/sourcegraph/pull/44090#discussion_r1021482132) for implementation details.
Lefover from https://github.com/sourcegraph/sourcegraph/pull/44090.

**Monaco**

https://user-images.githubusercontent.com/25318659/201898433-57eb5d3e-8f9f-4d01-9530-a402e84fc1a5.mov

**CodeMirror**

https://user-images.githubusercontent.com/25318659/201898203-4a608449-437b-46b8-9e84-7414b54ad2cb.mov

## Test plan
Tested manually (see videos attached).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-fix-prior-blame-nav.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

