### PR TITLE
searcher: remove PathPatternsAreRegExps

### DIFF
--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -245,9 +245,6 @@ func zoektCompile(p *protocol.PatternInfo) (zoektquery.Q, error) {
 	}
 
 	for _, pat := range p.IncludePatterns {
-		if !p.PathPatternsAreRegExps {
-			return nil, errors.New("hybrid search expects PathPatternsAreRegExps")
-		}
 		re, err := syntax.Parse(pat, syntax.Perl)
 		if err != nil {
 			return nil, err
@@ -260,9 +257,6 @@ func zoektCompile(p *protocol.PatternInfo) (zoektquery.Q, error) {
 	}
 
 	if p.ExcludePattern != "" {
-		if !p.PathPatternsAreRegExps {
-			return nil, errors.New("hybrid search expects PathPatternsAreRegExps")
-		}
 		re, err := syntax.Parse(p.ExcludePattern, syntax.Perl)
 		if err != nil {
 			return nil, err

--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -155,7 +155,6 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 		attribute.StringSlice("languages", p.Languages),
 		attribute.Bool("isWordMatch", p.IsWordMatch),
 		attribute.Bool("isCaseSensitive", p.IsCaseSensitive),
-		attribute.Bool("pathPatternsAreRegExps", p.PathPatternsAreRegExps),
 		attribute.Bool("pathPatternsAreCaseSensitive", p.PathPatternsAreCaseSensitive),
 		attribute.Int("limit", p.Limit),
 		attribute.Bool("patternMatchesContent", p.PatternMatchesContent),

--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -123,7 +123,7 @@ func compile(p *protocol.PatternInfo) (*readerGrep, error) {
 	}
 
 	pathOptions := pathmatch.CompileOptions{
-		RegExp:        p.PathPatternsAreRegExps,
+		RegExp:        true,
 		CaseSensitive: p.PathPatternsAreCaseSensitive,
 	}
 	matchPath, err := pathmatch.CompilePathPatterns(p.IncludePatterns, p.ExcludePattern, pathOptions)

--- a/cmd/searcher/internal/search/search_regex_test.go
+++ b/cmd/searcher/internal/search/search_regex_test.go
@@ -401,9 +401,8 @@ func TestPathMatches(t *testing.T) {
 	}
 
 	rg, err := compile(&protocol.PatternInfo{
-		Pattern:                "",
-		IncludePatterns:        []string{"a", "b"},
-		PathPatternsAreRegExps: true,
+		Pattern:         "",
+		IncludePatterns: []string{"a", "b"},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/searcher/internal/search/search_test.go
+++ b/cmd/searcher/internal/search/search_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/grafana/regexp"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 
@@ -125,84 +126,84 @@ main.go:6:6:
 main.go:6:6:
 	fmt.Println("Hello world")
 `},
-		{protocol.PatternInfo{Pattern: "world", IncludePatterns: []string{"*.md"}}, `
+		{protocol.PatternInfo{Pattern: "world", IncludePatterns: []string{`\.md$`}}, `
 README.md:1:1:
 # Hello World
 README.md:3:3:
 Hello world example in go
 `},
 
-		{protocol.PatternInfo{Pattern: "w", IncludePatterns: []string{"*.{md,txt}", "*.txt"}}, `
+		{protocol.PatternInfo{Pattern: "w", IncludePatterns: []string{`\.(md|txt)$`, `\.txt$`}}, `
 abc.txt:1:1:
 w
 `},
 
-		{protocol.PatternInfo{Pattern: "world", ExcludePattern: "README\\.md", PathPatternsAreRegExps: true}, `
+		{protocol.PatternInfo{Pattern: "world", ExcludePattern: "README\\.md"}, `
 main.go:6:6:
 	fmt.Println("Hello world")
 `},
-		{protocol.PatternInfo{Pattern: "world", IncludePatterns: []string{"\\.md"}, PathPatternsAreRegExps: true}, `
+		{protocol.PatternInfo{Pattern: "world", IncludePatterns: []string{"\\.md"}}, `
 README.md:1:1:
 # Hello World
 README.md:3:3:
 Hello world example in go
 `},
 
-		{protocol.PatternInfo{Pattern: "w", IncludePatterns: []string{"\\.(md|txt)", "README"}, PathPatternsAreRegExps: true}, `
+		{protocol.PatternInfo{Pattern: "w", IncludePatterns: []string{"\\.(md|txt)", "README"}}, `
 README.md:1:1:
 # Hello World
 README.md:3:3:
 Hello world example in go
 `},
 
-		{protocol.PatternInfo{Pattern: "world", IncludePatterns: []string{"*.{MD,go}"}, PathPatternsAreCaseSensitive: true}, `
+		{protocol.PatternInfo{Pattern: "world", IncludePatterns: []string{`\.(MD|go)$`}, PathPatternsAreCaseSensitive: true}, `
 main.go:6:6:
 	fmt.Println("Hello world")
 `},
-		{protocol.PatternInfo{Pattern: "world", IncludePatterns: []string{`\.(MD|go)`}, PathPatternsAreRegExps: true, PathPatternsAreCaseSensitive: true}, `
+		{protocol.PatternInfo{Pattern: "world", IncludePatterns: []string{`\.(MD|go)`}, PathPatternsAreCaseSensitive: true}, `
 main.go:6:6:
 	fmt.Println("Hello world")
 `},
 
 		{protocol.PatternInfo{Pattern: "doesnotmatch"}, ""},
-		{protocol.PatternInfo{Pattern: "", IsRegExp: false, IncludePatterns: []string{"\\.png"}, PathPatternsAreRegExps: true, PatternMatchesPath: true}, `
+		{protocol.PatternInfo{Pattern: "", IsRegExp: false, IncludePatterns: []string{"\\.png"}, PatternMatchesPath: true}, `
 milton.png
 `},
-		{protocol.PatternInfo{Pattern: "package main\n\nimport \"fmt\"", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
+		{protocol.PatternInfo{Pattern: "package main\n\nimport \"fmt\"", IsCaseSensitive: false, IsRegExp: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
 main.go:1:3:
 package main
 
 import "fmt"
 `},
-		{protocol.PatternInfo{Pattern: "package main\n\\s*import \"fmt\"", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
+		{protocol.PatternInfo{Pattern: "package main\n\\s*import \"fmt\"", IsCaseSensitive: false, IsRegExp: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
 main.go:1:3:
 package main
 
 import "fmt"
 `},
-		{protocol.PatternInfo{Pattern: "package main\n", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
+		{protocol.PatternInfo{Pattern: "package main\n", IsCaseSensitive: false, IsRegExp: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
 main.go:1:2:
 package main
 
 `},
-		{protocol.PatternInfo{Pattern: "package main\n\\s*", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
+		{protocol.PatternInfo{Pattern: "package main\n\\s*", IsCaseSensitive: false, IsRegExp: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
 main.go:1:3:
 package main
 
 import "fmt"
 `},
-		{protocol.PatternInfo{Pattern: "\nfunc", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
+		{protocol.PatternInfo{Pattern: "\nfunc", IsCaseSensitive: false, IsRegExp: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
 main.go:4:5:
 
 func main() {
 `},
-		{protocol.PatternInfo{Pattern: "\n\\s*func", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
+		{protocol.PatternInfo{Pattern: "\n\\s*func", IsCaseSensitive: false, IsRegExp: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
 main.go:3:5:
 import "fmt"
 
 func main() {
 `},
-		{protocol.PatternInfo{Pattern: "package main\n\nimport \"fmt\"\n\nfunc main\\(\\) {", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
+		{protocol.PatternInfo{Pattern: "package main\n\nimport \"fmt\"\n\nfunc main\\(\\) {", IsCaseSensitive: false, IsRegExp: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
 main.go:1:5:
 package main
 
@@ -210,7 +211,7 @@ import "fmt"
 
 func main() {
 `},
-		{protocol.PatternInfo{Pattern: "\n", IsCaseSensitive: false, IsRegExp: true, PathPatternsAreRegExps: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
+		{protocol.PatternInfo{Pattern: "\n", IsCaseSensitive: false, IsRegExp: true, PatternMatchesPath: true, PatternMatchesContent: true}, `
 README.md:1:3:
 # Hello World
 
@@ -240,7 +241,7 @@ milton.png:1:1:
 `},
 		{protocol.PatternInfo{
 			Pattern:         "filename contains regex metachars",
-			IncludePatterns: []string{"file++.plus"},
+			IncludePatterns: []string{regexp.QuoteMeta("file++.plus")},
 			IsStructuralPat: true,
 			IsRegExp:        true, // To test for a regression, imply that IsStructuralPat takes precedence.
 		}, `
@@ -410,9 +411,8 @@ func TestSearch_badrequest(t *testing.T) {
 			URL:    "u",
 			Commit: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 			PatternInfo: protocol.PatternInfo{
-				Pattern:                "test",
-				IncludePatterns:        []string{"**"},
-				PathPatternsAreRegExps: true,
+				Pattern:         "test",
+				IncludePatterns: []string{"**"},
 			},
 		},
 
@@ -422,9 +422,8 @@ func TestSearch_badrequest(t *testing.T) {
 			URL:    "u",
 			Commit: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 			PatternInfo: protocol.PatternInfo{
-				Pattern:                "test",
-				ExcludePattern:         "**",
-				PathPatternsAreRegExps: true,
+				Pattern:        "test",
+				ExcludePattern: "**",
 			},
 		},
 
@@ -434,11 +433,10 @@ func TestSearch_badrequest(t *testing.T) {
 			URL:    "u",
 			Commit: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 			PatternInfo: protocol.PatternInfo{
-				Pattern:                "fmt.Println(:[_])",
-				IsNegated:              true,
-				ExcludePattern:         "",
-				PathPatternsAreRegExps: true,
-				IsStructuralPat:        true,
+				Pattern:         "fmt.Println(:[_])",
+				IsNegated:       true,
+				ExcludePattern:  "",
+				IsStructuralPat: true,
 			},
 		},
 	}

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -93,10 +93,6 @@ type PatternInfo struct {
 	// glob or Go regexp that represents multiple such patterns ANDed together.
 	IncludePatterns []string
 
-	// IncludeExcludePatternAreRegExps indicates that ExcludePattern, IncludePattern,
-	// and IncludePatterns are regular expressions (not globs).
-	PathPatternsAreRegExps bool
-
 	// IncludeExcludePatternAreCaseSensitive indicates that ExcludePattern, IncludePattern,
 	// and IncludePatterns are case sensitive.
 	PathPatternsAreCaseSensitive bool
@@ -163,10 +159,7 @@ func (p *PatternInfo) String() string {
 		args = append(args, fmt.Sprintf("select:%s", p.Select))
 	}
 
-	path := "glob"
-	if p.PathPatternsAreRegExps {
-		path = "f"
-	}
+	path := "f"
 	if p.PathPatternsAreCaseSensitive {
 		path = "F"
 	}

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -64,7 +64,6 @@ func Search(
 			IncludePatterns:              p.IncludePatterns,
 			Languages:                    p.Languages,
 			CombyRule:                    p.CombyRule,
-			PathPatternsAreRegExps:       true,
 			Select:                       p.Select.Root(),
 			Limit:                        int(p.FileMatchLimit),
 			IsRegExp:                     p.IsRegExp,


### PR DESCRIPTION
We have hardcoded this value to true in the client for a very long time.
This PR removes the field and updates conditionals as if the field was
true. Additionally test cases based on glob fields are updated to pass
in the equivalent regex.

A follow-up PR will remove glob support from our path matcher package.

Test Plan: go test

plz-review-url: https://plz.review/review/14688