### PR TITLE
pathmatch: only support regex

### DIFF
--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -123,7 +123,6 @@ func compile(p *protocol.PatternInfo) (*readerGrep, error) {
 	}
 
 	pathOptions := pathmatch.CompileOptions{
-		RegExp:        true,
 		CaseSensitive: p.PathPatternsAreCaseSensitive,
 	}
 	matchPath, err := pathmatch.CompilePathPatterns(p.IncludePatterns, p.ExcludePattern, pathOptions)

--- a/cmd/searcher/internal/search/search_regex_test.go
+++ b/cmd/searcher/internal/search/search_regex_test.go
@@ -441,7 +441,7 @@ func init() {
 }
 
 func TestRegexSearch(t *testing.T) {
-	match, err := pathmatch.CompilePathPatterns([]string{`a\.go`}, `README\.md`, pathmatch.CompileOptions{RegExp: true})
+	match, err := pathmatch.CompilePathPatterns([]string{`a\.go`}, `README\.md`, pathmatch.CompileOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pathmatch/pathmatch_test.go
+++ b/internal/pathmatch/pathmatch_test.go
@@ -38,7 +38,7 @@ func TestCompilePattern(t *testing.T) {
 }
 
 func TestCompilePathPatterns(t *testing.T) {
-	match, err := CompilePathPatterns([]string{`main\.go`, `m`}, `README\.md`, CompileOptions{RegExp: true})
+	match, err := CompilePathPatterns([]string{`main\.go`, `m`}, `README\.md`, CompileOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
We only ever use the regex functionality, so update the package to only
support regex inputs.

Test Plan: go test

plz-review-url: https://plz.review/review/14689