### PR TITLE
searcher: simplify pathMatch implementation

### DIFF
--- a/cmd/searcher/internal/search/pathmatch.go
+++ b/cmd/searcher/internal/search/pathmatch.go
@@ -1,169 +1,69 @@
 package search
 
 import (
-	"bytes"
-	"fmt"
+	"strings"
 
 	"github.com/grafana/regexp"
 )
 
-// PathMatcher reports whether the path was matched.
-type PathMatcher interface {
-	MatchPath(path string) bool
-
-	// String returns the source text used to compile the PatchMatcher.
-	String() string
+type pathMatcher struct {
+	Include []*regexp.Regexp
+	Exclude *regexp.Regexp
 }
 
-type pathMatcherFunc struct {
-	matcher func(path string) bool
-	pattern string
-}
-
-func (f *pathMatcherFunc) MatchPath(path string) bool { return f.matcher(path) }
-
-func (f *pathMatcherFunc) String() string {
-	return f.pattern
-}
-
-// regexpMatcher is a PathMatcher backed by a regexp.
-type regexpMatcher regexp.Regexp
-
-func (m *regexpMatcher) MatchPath(path string) bool {
-	return (*regexp.Regexp)(m).MatchString(path)
-}
-
-func (m *regexpMatcher) String() string {
-	return fmt.Sprintf("re:%s", (*regexp.Regexp)(m).String())
-}
-
-// CompileOptions specifies options about the patterns to compile.
-type CompileOptions struct {
-	CaseSensitive bool // whether the patterns are case sensitive
-}
-
-// CompilePattern compiles pattern into a PathMatcher func.
-func CompilePattern(pattern string, options CompileOptions) (PathMatcher, error) {
-	// Respect the CaseSensitive option. However, if the pattern already contains
-	// (?i:...), then don't clear that 'i' flag (because we assume that behavior
-	// is desirable in more cases).
-	if !options.CaseSensitive {
-		pattern = "(?i:" + pattern + ")"
-	}
-	p, err := regexp.Compile(pattern)
-	if err != nil {
-		return nil, err
-	}
-	return (*regexpMatcher)(p), nil
-}
-
-// pathMatcherAnd is a PathMatcher that matches a path iff all of the
-// underlying matchers match the path.
-type pathMatcherAnd []PathMatcher
-
-func (pm pathMatcherAnd) MatchPath(path string) bool {
-	for _, m := range pm {
-		if !m.MatchPath(path) {
+func (pm *pathMatcher) MatchPath(path string) bool {
+	for _, re := range pm.Include {
+		if !re.MatchString(path) {
 			return false
 		}
 	}
-	return true
+	return pm.Exclude == nil || !pm.Exclude.MatchString(path)
 }
 
-func (pm pathMatcherAnd) String() string {
-	var b bytes.Buffer
-	b.WriteString("li:")
-	for i, m := range pm {
-		b.WriteString(m.String())
-		if i != len(pm)-1 {
-			b.WriteString(", ")
-		}
+func (pm *pathMatcher) String() string {
+	var parts []string
+	for _, re := range pm.Include {
+		parts = append(parts, re.String())
 	}
-	return b.String()
+	if pm.Exclude != nil {
+		parts = append(parts, "!"+pm.Exclude.String())
+	}
+	return strings.Join(parts, " ")
 }
 
-// CompilePatterns compiles the patterns into a PathMatcher func that matches
-// a path iff all patterns match the path.
-func CompilePatterns(patterns []string, options CompileOptions) (PathMatcher, error) {
-	matchers := make([]PathMatcher, len(patterns))
-	for i, pattern := range patterns {
-		matcher, err := CompilePattern(pattern, options)
-		if err != nil {
-			return nil, err
-		}
-		matchers[i] = matcher
-	}
-
-	if len(matchers) == 1 {
-		return matchers[0], nil
-	}
-
-	return pathMatcherAnd(matchers), nil
-}
-
-// pathMatcherIncludeExclude is a PathMatcher that matches a path iff it matches
-// the include matcher AND it does not match the exclude matcher.
-type pathMatcherIncludeExclude struct {
-	include PathMatcher
-	exclude PathMatcher
-}
-
-func (pm pathMatcherIncludeExclude) MatchPath(path string) bool {
-	include := pm.include == nil || pm.include.MatchPath(path)
-	if !include {
-		return false
-	}
-
-	exclude := pm.exclude != nil && pm.exclude.MatchPath(path)
-	return !exclude
-}
-
-func (pm pathMatcherIncludeExclude) String() string {
-	if pm.include != nil && pm.exclude != nil {
-		return fmt.Sprintf("%s !%s", pm.include.String(), pm.exclude.String())
-	}
-	if pm.include != nil {
-		return pm.include.String()
-	}
-	return "!" + pm.exclude.String()
-}
-
-// CompilePathPatterns returns a PathMatcher func that matches a path iff:
+// compilePathPatterns returns a pathMatcher that matches a path iff:
 //
 // * all of the includePatterns match the path; AND
 // * the excludePattern does NOT match the path.
-//
-// This is the most common behavior for include/exclude paths in a search interface.
-func CompilePathPatterns(includePatterns []string, excludePattern string, options CompileOptions) (PathMatcher, error) {
-	var include PathMatcher
-	if len(includePatterns) > 0 {
-		var err error
-		include, err = CompilePatterns(includePatterns, options)
-		if err != nil {
-			return nil, err
+func compilePathPatterns(includePatterns []string, excludePattern string, caseSensitive bool) (*pathMatcher, error) {
+	// set err once if non-nil. This simplifies our many calls to compile.
+	var err error
+	compile := func(p string) *regexp.Regexp {
+		if !caseSensitive {
+			// Respect the CaseSensitive option. However, if the pattern already contains
+			// (?i:...), then don't clear that 'i' flag (because we assume that behavior
+			// is desirable in more cases).
+			p = "(?i:" + p + ")"
 		}
+		re, innerErr := regexp.Compile(p)
+		if innerErr != nil {
+			err = innerErr
+		}
+		return re
 	}
 
-	var exclude PathMatcher
+	var include []*regexp.Regexp
+	for _, p := range includePatterns {
+		include = append(include, compile(p))
+	}
+
+	var exclude *regexp.Regexp
 	if excludePattern != "" {
-		var err error
-		exclude, err = CompilePattern(excludePattern, options)
-		if err != nil {
-			return nil, err
-		}
+		exclude = compile(excludePattern)
 	}
 
-	if include == nil && exclude == nil {
-		return &pathMatcherFunc{
-			matcher: func(path string) bool { return true },
-			pattern: "noop",
-		}, nil
-	}
-	if exclude == nil {
-		return include, nil
-	}
-	return pathMatcherIncludeExclude{
-		include: include,
-		exclude: exclude,
-	}, nil
+	return &pathMatcher{
+		Include: include,
+		Exclude: exclude,
+	}, err
 }

--- a/cmd/searcher/internal/search/pathmatch_test.go
+++ b/cmd/searcher/internal/search/pathmatch_test.go
@@ -2,43 +2,8 @@ package search
 
 import "testing"
 
-func TestCompilePattern(t *testing.T) {
-	tests := []struct {
-		pattern string
-		options CompileOptions
-		want    map[string]bool
-		wantErr bool
-	}{
-		{
-			pattern: `README.md`,
-			options: CompileOptions{},
-			want: map[string]bool{
-				"README.md": true,
-				"main.go":   false,
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.pattern, func(t *testing.T) {
-			match, err := CompilePattern(test.pattern, test.options)
-			if (err != nil) != test.wantErr {
-				t.Errorf("got error %v, want %v", err, test.wantErr)
-			}
-			if err != nil {
-				return
-			}
-			for path, want := range test.want {
-				got := match.MatchPath(path)
-				if got != want {
-					t.Errorf("path %q: got %v, want %v", path, got, want)
-				}
-			}
-		})
-	}
-}
-
 func TestCompilePathPatterns(t *testing.T) {
-	match, err := CompilePathPatterns([]string{`main\.go`, `m`}, `README\.md`, CompileOptions{})
+	match, err := compilePathPatterns([]string{`main\.go`, `m`}, `README\.md`, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -53,7 +53,7 @@ type readerGrep struct {
 
 	// matchPath is compiled from the include/exclude path patterns and reports
 	// whether a file path matches (and should be searched).
-	matchPath PathMatcher
+	matchPath *pathMatcher
 
 	// literalSubstring is used to test if a file is worth considering for
 	// matches. literalSubstring is guaranteed to appear in any match found by
@@ -121,10 +121,7 @@ func compile(p *protocol.PatternInfo) (*readerGrep, error) {
 		}
 	}
 
-	pathOptions := CompileOptions{
-		CaseSensitive: p.PathPatternsAreCaseSensitive,
-	}
-	matchPath, err := CompilePathPatterns(p.IncludePatterns, p.ExcludePattern, pathOptions)
+	matchPath, err := compilePathPatterns(p.IncludePatterns, p.ExcludePattern, p.PathPatternsAreCaseSensitive)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/searcher/internal/search/search_regex_test.go
+++ b/cmd/searcher/internal/search/search_regex_test.go
@@ -440,7 +440,7 @@ func init() {
 }
 
 func TestRegexSearch(t *testing.T) {
-	match, err := CompilePathPatterns([]string{`a\.go`}, `README\.md`, CompileOptions{})
+	match, err := compilePathPatterns([]string{`a\.go`}, `README\.md`, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This had a lot of machinery going on for something that just returned
true if you matches a slice of regexes. In the past we could swap out
the matcher, but now we don't.

Test Plan: go test

plz-review-url: https://plz.review/review/14691