### PR TITLE
insights: fix zero values oob migration recording time fetching

### DIFF
--- a/enterprise/internal/oobmigration/migrations/insights/recording_times.go
+++ b/enterprise/internal/oobmigration/migrations/insights/recording_times.go
@@ -16,6 +16,11 @@ func calculateRecordingTimes(createdAt time.Time, lastRecordedAt time.Time, inte
 		return referenceTimes
 	}
 
+	// We don't have any missing data points for this series so just return it.
+	if len(referenceTimes) == len(existingPoints) {
+		return existingPoints
+	}
+
 	var calculatedRecordingTimes []time.Time
 	// For each reference time, we compare it to existing recording times.
 	// If the reference time is before the next existing point (i.e. no time exists there), we add it to the list.


### PR DESCRIPTION
option 1a

the oob migration was fetching recording_times from `insight_series_recording_times` when it should have been looking at `series_points` data

## Test plan
Manually reverted the migration on local env and retriggered it up and observed it worked