### PR TITLE
Check if time.Expiry is zero in OAuth NeedsRefresh check

### DIFF
--- a/internal/extsvc/auth/oauth_bearer.go
+++ b/internal/extsvc/auth/oauth_bearer.go
@@ -45,8 +45,8 @@ func (token *OAuthBearerToken) Refresh(ctx context.Context, cli httpcli.Doer) er
 }
 
 func (token *OAuthBearerToken) NeedsRefresh() bool {
-	// Refresh if the current time falls within the buffer period to expiry.
-	return time.Until(token.Expiry) <= time.Duration(token.NeedsRefreshBuffer)*time.Minute
+	// Refresh if the current time falls within the buffer period to expiry, and is not zero
+	return !token.Expiry.IsZero() && (time.Until(token.Expiry) <= time.Duration(token.NeedsRefreshBuffer)*time.Minute)
 }
 
 var _ Authenticator = &OAuthBearerToken{}
@@ -78,8 +78,10 @@ type OAuthBearerTokenWithSSH struct {
 	Passphrase string
 }
 
-var _ Authenticator = &OAuthBearerTokenWithSSH{}
-var _ AuthenticatorWithSSH = &OAuthBearerTokenWithSSH{}
+var (
+	_ Authenticator        = &OAuthBearerTokenWithSSH{}
+	_ AuthenticatorWithSSH = &OAuthBearerTokenWithSSH{}
+)
 
 func (token *OAuthBearerTokenWithSSH) SSHPrivateKey() (privateKey, passphrase string) {
 	return token.PrivateKey, token.Passphrase

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1517,7 +1517,9 @@ func doRequest(ctx context.Context, logger log.Logger, apiURL *url.URL, auther a
 		autherWithRefresh, ok = auther.(auth.AuthenticatorWithRefresh)
 		// Check if we should pre-emptively refresh
 		if ok && autherWithRefresh.NeedsRefresh() {
-			autherWithRefresh.Refresh(ctx, httpClient)
+			if err := autherWithRefresh.Refresh(ctx, httpClient); err != nil {
+				logger.Warn("doRequest: refreshing of the token failed", log.Error(err))
+			}
 		}
 		if err := auther.Authenticate(req); err != nil {
 			return nil, errors.Wrap(err, "authenticating request")
@@ -1541,12 +1543,12 @@ func doRequest(ctx context.Context, logger log.Logger, apiURL *url.URL, auther a
 	if autherWithRefresh != nil {
 		resp, err = oauthutil.DoRequest(ctx, httpClient, req, autherWithRefresh)
 		if err != nil {
-			return nil, errors.Wrap(err, "do request with refresh and retry")
+			return nil, errors.Wrap(err, "do request with refresh and retry failed")
 		}
 	} else {
 		resp, err = httpClient.Do(req.WithContext(ctx))
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "http request failed")
 		}
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
Closes #44207 

Adjusts the OAuth token `NeedsRefresh` check to make sure that the `token.Expiry` is not the zero time (Unix epoch), as it was erroneously signalling that the tokens required refreshing.

## Test plan

Confirmed that logs are no longer being spammed locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
