### PR TITLE
searcher: only skip comby tests if binary missing

### DIFF
--- a/cmd/searcher/internal/search/search_structural_test.go
+++ b/cmd/searcher/internal/search/search_structural_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -727,6 +728,9 @@ func maybeSkipComby(t *testing.T) {
 	t.Helper()
 	if os.Getenv("CI") != "" {
 		return
+	}
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		t.Skip("Skipping due to limitations in comby and M1")
 	}
 	if _, err := exec.LookPath("comby"); err != nil {
 		t.Skipf("skipping comby test when not on CI: %v", err)

--- a/cmd/searcher/internal/search/search_structural_test.go
+++ b/cmd/searcher/internal/search/search_structural_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -19,10 +20,7 @@ import (
 )
 
 func TestMatcherLookupByLanguage(t *testing.T) {
-	// If we are not on CI skip the test.
-	if os.Getenv("CI") == "" {
-		t.Skip("Not on CI, skipping comby-dependent test")
-	}
+	maybeSkipComby(t)
 
 	input := map[string]string{
 		"file_without_extension": `
@@ -93,10 +91,7 @@ func foo(go string) {}
 }
 
 func TestMatcherLookupByExtension(t *testing.T) {
-	// If we are not on CI skip the test.
-	if os.Getenv("CI") == "" {
-		t.Skip("Not on CI, skipping comby-dependent test")
-	}
+	maybeSkipComby(t)
 
 	t.Parallel()
 
@@ -188,10 +183,7 @@ func foo(go.txt) {}
 // Tests that structural search correctly infers the Go matcher from the .go
 // file extension.
 func TestInferredMatcher(t *testing.T) {
-	// If we are not on CI skip the test.
-	if os.Getenv("CI") == "" {
-		t.Skip("Not on CI, skipping comby-dependent test")
-	}
+	maybeSkipComby(t)
 
 	input := map[string]string{
 		"main.go": `
@@ -288,10 +280,7 @@ func TestRecordMetrics(t *testing.T) {
 // instead (currently) expects a list of patterns that represent a set of file
 // paths to search.
 func TestIncludePatterns(t *testing.T) {
-	// If we are not on CI skip the test.
-	if os.Getenv("CI") == "" {
-		t.Skip("Not on CI, skipping comby-dependent test")
-	}
+	maybeSkipComby(t)
 
 	input := map[string]string{
 		"a/b/c":         "",
@@ -340,10 +329,7 @@ func TestIncludePatterns(t *testing.T) {
 }
 
 func TestRule(t *testing.T) {
-	// If we are not on CI skip the test.
-	if os.Getenv("CI") == "" {
-		t.Skip("Not on CI, skipping comby-dependent test")
-	}
+	maybeSkipComby(t)
 
 	input := map[string]string{
 		"file.go": "func foo(success) {} func bar(fail) {}",
@@ -388,10 +374,7 @@ func TestRule(t *testing.T) {
 }
 
 func TestStructuralLimits(t *testing.T) {
-	// If we are not on CI skip the test.
-	if os.Getenv("CI") == "" {
-		t.Skip("Not on CI, skipping comby-dependent test")
-	}
+	maybeSkipComby(t)
 
 	input := map[string]string{
 		"test1.go": `
@@ -445,10 +428,7 @@ func bar() {
 }
 
 func TestMatchCountForMultilineMatches(t *testing.T) {
-	// If we are not on CI skip the test.
-	if os.Getenv("CI") == "" {
-		t.Skip("Not on CI, skipping comby-dependent test")
-	}
+	maybeSkipComby(t)
 
 	input := map[string]string{
 		"main.go": `
@@ -491,10 +471,7 @@ func bar() {
 }
 
 func TestMultilineMatches(t *testing.T) {
-	// If we are not on CI skip the test.
-	if os.Getenv("CI") == "" {
-		t.Skip("Not on CI, skipping comby-dependent test")
-	}
+	maybeSkipComby(t)
 
 	input := map[string]string{
 		"main.go": `
@@ -688,10 +665,7 @@ func Test_chunkRanges(t *testing.T) {
 }
 
 func TestTarInput(t *testing.T) {
-	// If we are not on CI skip the test.
-	if os.Getenv("CI") == "" {
-		t.Skip("Not on CI, skipping comby-dependent test")
-	}
+	maybeSkipComby(t)
 
 	input := map[string]string{
 		"main.go": `
@@ -747,4 +721,14 @@ func bar() {
 		}}
 		require.Equal(t, expected, matches)
 	})
+}
+
+func maybeSkipComby(t *testing.T) {
+	t.Helper()
+	if os.Getenv("CI") != "" {
+		return
+	}
+	if _, err := exec.LookPath("comby"); err != nil {
+		t.Skipf("skipping comby test when not on CI: %v", err)
+	}
 }

--- a/cmd/searcher/internal/search/search_test.go
+++ b/cmd/searcher/internal/search/search_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -335,6 +336,9 @@ func maybeSkipComby(t *testing.T) {
 	t.Helper()
 	if os.Getenv("CI") != "" {
 		return
+	}
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		t.Skip("Skipping due to limitations in comby and M1")
 	}
 	if _, err := exec.LookPath("comby"); err != nil {
 		t.Skipf("skipping comby test when not on CI: %v", err)

--- a/cmd/searcher/internal/search/search_test.go
+++ b/cmd/searcher/internal/search/search_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
@@ -298,8 +299,8 @@ abc.txt
 
 	for i, test := range cases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			if test.arg.IsStructuralPat && os.Getenv("CI") == "" {
-				t.Skip("skipping comby test when not on CI")
+			if test.arg.IsStructuralPat {
+				maybeSkipComby(t)
 			}
 
 			req := protocol.Request{
@@ -327,6 +328,16 @@ abc.txt
 				t.Fatalf("%s unexpected response:\n%s", test.arg.String(), d)
 			}
 		})
+	}
+}
+
+func maybeSkipComby(t *testing.T) {
+	t.Helper()
+	if os.Getenv("CI") != "" {
+		return
+	}
+	if _, err := exec.LookPath("comby"); err != nil {
+		t.Skipf("skipping comby test when not on CI: %v", err)
 	}
 }
 


### PR DESCRIPTION
This bit me on a recent PR where the comby tests did not run locally and I only noticed on CI. However, I locally have comby so can run these tests just fine.

Test Plan: go test on my dev machine and CI