### PR TITLE
searcher: remove stray PathPatternsAreRegExps

### DIFF
--- a/cmd/searcher/internal/search/hybrid_test.go
+++ b/cmd/searcher/internal/search/hybrid_test.go
@@ -145,7 +145,6 @@ Hello world example in go
 		Pattern: protocol.PatternInfo{
 			Pattern:                "world",
 			IncludePatterns:        []string{"added"},
-			PathPatternsAreRegExps: true,
 		},
 		Want: `
 added.md:1:1:
@@ -155,7 +154,6 @@ hello world I am added
 		Name: "path-include",
 		Pattern: protocol.PatternInfo{
 			IncludePatterns:        []string{"^added"},
-			PathPatternsAreRegExps: true,
 		},
 		Want: `
 added.md
@@ -164,7 +162,6 @@ added.md
 		Name: "path-exclude-added",
 		Pattern: protocol.PatternInfo{
 			ExcludePattern:         "added",
-			PathPatternsAreRegExps: true,
 		},
 		Want: `
 changed.go
@@ -174,7 +171,6 @@ unchanged.md
 		Name: "path-exclude-unchanged",
 		Pattern: protocol.PatternInfo{
 			ExcludePattern:         "unchanged",
-			PathPatternsAreRegExps: true,
 		},
 		Want: `
 added.md
@@ -184,7 +180,6 @@ changed.go
 		Name: "path-all",
 		Pattern: protocol.PatternInfo{
 			IncludePatterns:        []string{"."},
-			PathPatternsAreRegExps: true,
 		},
 		Want: `
 added.md

--- a/cmd/searcher/internal/search/hybrid_test.go
+++ b/cmd/searcher/internal/search/hybrid_test.go
@@ -143,8 +143,8 @@ Hello world example in go
 	}, {
 		Name: "added",
 		Pattern: protocol.PatternInfo{
-			Pattern:                "world",
-			IncludePatterns:        []string{"added"},
+			Pattern:         "world",
+			IncludePatterns: []string{"added"},
 		},
 		Want: `
 added.md:1:1:
@@ -153,7 +153,7 @@ hello world I am added
 	}, {
 		Name: "path-include",
 		Pattern: protocol.PatternInfo{
-			IncludePatterns:        []string{"^added"},
+			IncludePatterns: []string{"^added"},
 		},
 		Want: `
 added.md
@@ -161,7 +161,7 @@ added.md
 	}, {
 		Name: "path-exclude-added",
 		Pattern: protocol.PatternInfo{
-			ExcludePattern:         "added",
+			ExcludePattern: "added",
 		},
 		Want: `
 changed.go
@@ -170,7 +170,7 @@ unchanged.md
 	}, {
 		Name: "path-exclude-unchanged",
 		Pattern: protocol.PatternInfo{
-			ExcludePattern:         "unchanged",
+			ExcludePattern: "unchanged",
 		},
 		Want: `
 added.md
@@ -179,7 +179,7 @@ changed.go
 	}, {
 		Name: "path-all",
 		Pattern: protocol.PatternInfo{
-			IncludePatterns:        []string{"."},
+			IncludePatterns: []string{"."},
 		},
 		Want: `
 added.md


### PR DESCRIPTION
PRs landed concurrently that introduced these uses as well as a PR that removed them.

Test Plan: go test ./cmd/searcher/...