### PR TITLE
gitserver:  Add a test for ignorePath

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -947,7 +947,7 @@ func (s *Server) ignorePath(path string) bool {
 		return false
 	}
 	base := filepath.Base(path)
-	return strings.HasPrefix(base, tempDirName) || strings.HasPrefix(base, P4HomeName)
+	return base == tempDirName || base == P4HomeName
 }
 
 func (s *Server) handleIsRepoCloneable(w http.ResponseWriter, r *http.Request) {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -947,7 +947,7 @@ func (s *Server) ignorePath(path string) bool {
 		return false
 	}
 	base := filepath.Base(path)
-	return base == tempDirName || base == P4HomeName
+	return strings.HasPrefix(base, tempDirName) || strings.HasPrefix(base, P4HomeName)
 }
 
 func (s *Server) handleIsRepoCloneable(w http.ResponseWriter, r *http.Request) {

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -1745,6 +1745,8 @@ func TestIgnorePath(t *testing.T) {
 	}{
 		{path: filepath.Join(reposDir, tempDirName), shouldIgnore: true},
 		{path: filepath.Join(reposDir, P4HomeName), shouldIgnore: true},
+		// Double check handling of trailing space
+		{path: filepath.Join(reposDir, P4HomeName+"   "), shouldIgnore: true},
 		{path: filepath.Join(reposDir, "sourcegraph/sourcegraph"), shouldIgnore: false},
 	} {
 		t.Run("", func(t *testing.T) {

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -1735,6 +1735,24 @@ func mustEncodeJSONResponse(value any) string {
 	return strings.TrimSpace(string(encoded))
 }
 
+func TestIgnorePath(t *testing.T) {
+	reposDir := "/data/repos"
+	s := Server{ReposDir: reposDir}
+
+	for _, tc := range []struct {
+		path         string
+		shouldIgnore bool
+	}{
+		{path: filepath.Join(reposDir, tempDirName), shouldIgnore: true},
+		{path: filepath.Join(reposDir, P4HomeName), shouldIgnore: true},
+		{path: filepath.Join(reposDir, "sourcegraph/sourcegraph"), shouldIgnore: false},
+	} {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, tc.shouldIgnore, s.ignorePath(tc.path))
+		})
+	}
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if !testing.Verbose() {


### PR DESCRIPTION
`filepath.Base` gives us the final part of a path and will always be a
single element so we don't need ot use `strings.HasPrefix`.

## Test plan

Added a new test