### PR TITLE
Signup button tracking and flow

### DIFF
--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -562,20 +562,25 @@ export function buildSearchURLQuery(
     return searchParameters.toString().replace(/%2F/g, '/').replace(/%3A/g, ':')
 }
 
-export function buildGetStartedURL(forInstances?: boolean, returnTo?: string): string {
+export function buildGetStartedURL(cloudSignup?: boolean, returnTo?: string): string {
     /**
      * Account sign-ups should be available for customer instances whereas
      * non customer instances like .com should direct users through our cloud
-     * sign-up flow.
+     * sign-up flow to prioritize trial-starts.
      */
-    const path = forInstances ? 'https://sourcegraph.com/sign-up' : 'https://signup.sourcegraph.com'
-    const url = new URL(path)
-
-    if (returnTo !== undefined) {
-        url.searchParams.set('returnTo', returnTo)
+    const path = cloudSignup ? 'https://signup.sourcegraph.com' : '/sign-up'
+    
+    if (path.includes('https')) {
+        const url = new URL(path)
+    
+        if (returnTo !== undefined) {
+            url.searchParams.set('returnTo', returnTo)
+        }
+    
+        return url.toString()
     }
 
-    return url.toString()
+    return path
 }
 
 /** The results of parsing a repo-revision string like "my/repo@my/revision". */

--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -562,9 +562,13 @@ export function buildSearchURLQuery(
     return searchParameters.toString().replace(/%2F/g, '/').replace(/%3A/g, ':')
 }
 
-export function buildGetStartedURL(forDotcom?: boolean, returnTo?: string): string {
-    // Still support directing to dotcom signup links when needed
-    const path = forDotcom ? 'https://sourcegraph.com/sign-up' : 'https://signup.sourcegraph.com'
+export function buildGetStartedURL(forInstances?: boolean, returnTo?: string): string {
+    /**
+     * Account sign-ups should be available for customer instances whereas
+     * non customer instances like .com should direct users through our cloud
+     * sign-up flow.
+     */
+    const path = forInstances ? 'https://sourcegraph.com/sign-up' : 'https://signup.sourcegraph.com'
     const url = new URL(path)
 
     if (returnTo !== undefined) {

--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -568,19 +568,20 @@ export function buildGetStartedURL(cloudSignup?: boolean, returnTo?: string): st
      * non customer instances like .com should direct users through our cloud
      * sign-up flow to prioritize trial-starts.
      */
-    const path = cloudSignup ? 'https://signup.sourcegraph.com' : '/sign-up'
+    const path = cloudSignup ? 'https://signup.sourcegraph.com' : 'https://sourcegraph.com/sign-up'
 
-    if (path.includes('https')) {
-        const url = new URL(path)
+    const url = new URL(path)
 
-        if (returnTo !== undefined) {
-            url.searchParams.set('returnTo', returnTo)
-        }
-
-        return url.toString()
+    if (returnTo !== undefined) {        
+        url.searchParams.set('returnTo', returnTo)
     }
 
-    return path
+    // Local sign-ups use relative URLs
+    if (!cloudSignup) {
+        return `${url.pathname}${url.search}`
+    }
+
+    return url.toString()
 }
 
 /** The results of parsing a repo-revision string like "my/repo@my/revision". */

--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -562,13 +562,10 @@ export function buildSearchURLQuery(
     return searchParameters.toString().replace(/%2F/g, '/').replace(/%3A/g, ':')
 }
 
-export function buildGetStartedURL(source: string, returnTo?: string, forDotcom?: boolean): string {
+export function buildGetStartedURL(forDotcom?: boolean, returnTo?: string): string {
     // Still support directing to dotcom signup links when needed
     const path = forDotcom ? 'https://sourcegraph.com/sign-up' : 'https://signup.sourcegraph.com'
     const url = new URL(path)
-    url.searchParams.set('utm_medium', 'inproduct')
-    url.searchParams.set('utm_source', source)
-    url.searchParams.set('utm_campaign', 'inproduct-cta')
 
     if (returnTo !== undefined) {
         url.searchParams.set('returnTo', returnTo)

--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -572,7 +572,7 @@ export function buildGetStartedURL(cloudSignup?: boolean, returnTo?: string): st
 
     const url = new URL(path)
 
-    if (returnTo !== undefined) {        
+    if (returnTo !== undefined) {
         url.searchParams.set('returnTo', returnTo)
     }
 

--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -569,14 +569,14 @@ export function buildGetStartedURL(cloudSignup?: boolean, returnTo?: string): st
      * sign-up flow to prioritize trial-starts.
      */
     const path = cloudSignup ? 'https://signup.sourcegraph.com' : '/sign-up'
-    
+
     if (path.includes('https')) {
         const url = new URL(path)
-    
+
         if (returnTo !== undefined) {
             url.searchParams.set('returnTo', returnTo)
         }
-    
+
         return url.toString()
     }
 

--- a/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
@@ -28,7 +28,7 @@ const CodeMonitorEmptyList: React.FunctionComponent<
                 className="my-3"
                 eventName="SignUpPLGMonitor_EmptyList"
                 text="Get started with code monitors"
-                forDotcom={false}
+                cloudSignup={true}
             />
         )}
     </div>

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
@@ -102,6 +102,7 @@ export const CodeMonitoringGettingStarted: React.FunctionComponent<
                             className={styles.createButton}
                             eventName="SignUpPLGMonitor_GettingStarted"
                             text="Get started with code monitors"
+                            cloudSignup={true}
                         />
                     )}
                 </div>
@@ -172,7 +173,7 @@ export const CodeMonitoringGettingStarted: React.FunctionComponent<
                                     className={styles.createButton}
                                     eventName="SignUpPLGMonitor_GettingStarted"
                                     text="Get started"
-                                    forDotcom={true}
+                                    cloudSignup={false}
                                 />
                             </Card>
                         </div>

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringSignUpLink.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringSignUpLink.tsx
@@ -19,7 +19,7 @@ export const CodeMonitorSignUpLink: React.FunctionComponent<
     return (
         <ButtonLink
             onClick={onClick}
-            to={buildGetStartedURL('code-monitoring', '/code-monitoring/new', forDotcom)}
+            to={buildGetStartedURL(forDotcom, '/code-monitoring/new')}
             className={className}
             variant="primary"
         >

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringSignUpLink.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringSignUpLink.tsx
@@ -10,16 +10,16 @@ export const CodeMonitorSignUpLink: React.FunctionComponent<
         className?: string
         text: string
         eventName: string
-        forDotcom?: boolean
+        cloudSignup?: boolean
     }>
-> = ({ className, text, eventName, forDotcom }) => {
+> = ({ className, text, eventName, cloudSignup }) => {
     const onClick = (): void => {
         eventLogger.log(eventName)
     }
     return (
         <ButtonLink
             onClick={onClick}
-            to={buildGetStartedURL(forDotcom, '/code-monitoring/new')}
+            to={buildGetStartedURL(cloudSignup, '/code-monitoring/new')}
             className={className}
             variant="primary"
         >

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -341,7 +341,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                                     </Button>
                                     <ButtonLink
                                         className={styles.signUp}
-                                        to={buildGetStartedURL(!isSourcegraphDotCom)}
+                                        to={buildGetStartedURL(isSourcegraphDotCom)}
                                         size="sm"
                                         onClick={() => eventLogger.log('ClickedOnTopNavTrialButton')}
                                     >

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -341,7 +341,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                                     </Button>
                                     <ButtonLink
                                         className={styles.signUp}
-                                        to={buildGetStartedURL('nav')}
+                                        to={buildGetStartedURL(!isSourcegraphDotCom)}
                                         size="sm"
                                         onClick={() => eventLogger.log('ClickedOnTopNavTrialButton')}
                                     >

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -219,7 +219,7 @@ exports[`GlobalNavbar default 1`] = `
           </a>
           <a
             class="anchorLink btn btnSm signUp"
-            href="https://signup.sourcegraph.com/?utm_medium=inproduct&utm_source=nav&utm_campaign=inproduct-cta"
+            href="https://sourcegraph.com/sign-up"
             tabindex="0"
           >
             Sign up

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -219,7 +219,7 @@ exports[`GlobalNavbar default 1`] = `
           </a>
           <a
             class="anchorLink btn btnSm signUp"
-            href="https://sourcegraph.com/sign-up"
+            href="/sign-up"
             tabindex="0"
           >
             Sign up


### PR DESCRIPTION
This closes #44421 and closes #44426.

- setting UTMs are removed from `buildGetStartedURL` to prevent overriding external source tracking and confusion in our analytics. See [thread](https://sourcegraph.slack.com/archives/C03B4EMBXL4/p1668463391535839) for details.
- our Signup button now directs .com users to signup.sourcegraph.com, whereas on customer instances, users are directed to `/sign-up` instead. See [thread](https://sourcegraph.slack.com/archives/C01N83PS4TU/p1668527126003869?thread_ts=1668443221.371069&cid=C01N83PS4TU) for details.

## Test plan
- Ensure no UTM params are added to our signup URLs
- Ensure .com users are directed to signup.sourcegraph.com and instance users are directed to `/sign-up`

## App preview:

- [Web](https://sg-web-brett-signup-for-dot-com.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
