### PR TITLE
searcher: use zoektquery.NewFileNameSet for hybrid search

### DIFF
--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/grafana/regexp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sourcegraph/log"
@@ -153,7 +152,7 @@ func zoektSearchIgnorePaths(ctx context.Context, client zoekt.Streamer, p *proto
 	q := zoektquery.Simplify(zoektquery.NewAnd(
 		zoektquery.NewSingleBranchesRepos("HEAD", uint32(p.RepoID)),
 		qText,
-		zoektIgnorePaths(ignoredPaths),
+		&zoektquery.Not{Child: zoektquery.NewFileNameSet(ignoredPaths...)},
 	))
 
 	opts := (&zoektutil.Options{
@@ -313,20 +312,7 @@ func zoektIgnorePaths(paths []string) zoektquery.Q {
 		return &zoektquery.Const{Value: true}
 	}
 
-	parts := make([]zoektquery.Q, 0, len(paths))
-	for _, p := range paths {
-		re, err := syntax.Parse("^"+regexp.QuoteMeta(p)+"$", syntax.Perl)
-		if err != nil {
-			panic("failed to regex compile escaped literal: " + err.Error())
-		}
-		parts = append(parts, &zoektquery.Regexp{
-			Regexp:        re,
-			FileName:      true,
-			CaseSensitive: true,
-		})
-	}
-
-	return &zoektquery.Not{Child: zoektquery.NewOr(parts...)}
+	return &zoektquery.Not{Child: zoektquery.NewFileNameSet(paths...)}
 }
 
 // zoektIndexedCommit returns the default indexed commit for a repository.

--- a/go.mod
+++ b/go.mod
@@ -229,7 +229,7 @@ require (
 )
 
 require (
-	github.com/sourcegraph/zoekt v0.0.0-20221117134003-f876be0ded78
+	github.com/sourcegraph/zoekt v0.0.0-20221121125711-20baf3ac44b3
 	github.com/stretchr/objx v0.5.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2115,8 +2115,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20221117134003-f876be0ded78 h1:vI1SXaFhQ0X5mkaQyspvasP/WsrphgaRslu7XBnZbOc=
-github.com/sourcegraph/zoekt v0.0.0-20221117134003-f876be0ded78/go.mod h1:3yRHgwrcLzDQewuFoCQTFSLUgLjljPr1cN/971Z2Uec=
+github.com/sourcegraph/zoekt v0.0.0-20221121125711-20baf3ac44b3 h1:VsnRSuBGngMou3euDuzA+/wRCKQKfyrpLqsA5+9JdnU=
+github.com/sourcegraph/zoekt v0.0.0-20221121125711-20baf3ac44b3/go.mod h1:3yRHgwrcLzDQewuFoCQTFSLUgLjljPr1cN/971Z2Uec=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
This is an optimized way to send a list of exact paths to search. Note we can also remove the special case of no paths thanks to zoekt.Simplify doiing constant folding on empty FileNameSets to false.

Test Plan: go test