### PR TITLE
docs/docker-compose Replace installation scripts with curl command

### DIFF
--- a/doc/admin/deploy/docker-compose/aws.md
+++ b/doc/admin/deploy/docker-compose/aws.md
@@ -58,76 +58,14 @@ Click **Launch Instance** from the [EC2 dashboard](https://console.aws.amazon.co
 Copy and paste the *startup script* below into the **User Data** textbox:
 
 ```bash
-#!/usr/bin/env bash
-set -euxo pipefail
-###############################################################################
-# ACTION REQUIRED: REPLACE THE URL AND REVISION WITH YOUR DEPLOYMENT REPO INFO
-###############################################################################
-# Please read the notes below the script if you are cloning a private repository
-DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
-DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v4.1.3'
-##################### NO CHANGES REQUIRED BELOW THIS LINE #####################
-DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/home/ec2-user/deploy-sourcegraph-docker'
-DOCKER_COMPOSE_VERSION='1.29.2'
-DOCKER_DAEMON_CONFIG_FILE='/etc/docker/daemon.json'
-DOCKER_DATA_ROOT='/mnt/docker-data'
-EBS_VOLUME_DEVICE_NAME='/dev/sdb'
-EBS_VOLUME_LABEL='sourcegraph'
-# Install git
-yum update -y
-yum install git -y
-# Clone the deployment repository
-git clone "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL}" "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
-cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
-git checkout "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION}"
-# Format (if unformatted) and then mount the attached volume
-device_fs=$(lsblk "${EBS_VOLUME_DEVICE_NAME}" --noheadings --output fsType)
-if [ "${device_fs}" == "" ]
-then
-  mkfs -t xfs "${EBS_VOLUME_DEVICE_NAME}"
-fi
-xfs_admin -L "${EBS_VOLUME_LABEL}" "${EBS_VOLUME_DEVICE_NAME}"
-mkdir -p "${DOCKER_DATA_ROOT}"
-mount -L "${EBS_VOLUME_LABEL}" "${DOCKER_DATA_ROOT}"
-# Mount file system by label on reboot
-echo "LABEL=${EBS_VOLUME_LABEL}  ${DOCKER_DATA_ROOT}  xfs  defaults,nofail  0  2" >> '/etc/fstab'
-umount "${DOCKER_DATA_ROOT}"
-mount -a
-# Install, configure, and enable Docker
-yum update -y
-amazon-linux-extras install docker
-systemctl enable --now docker
-sed -i -e 's/1024/262144/g' /etc/sysconfig/docker
-sed -i -e 's/4096/262144/g' /etc/sysconfig/docker
-usermod -a -G docker ec2-user
-# Install jq for scripting
-yum install -y jq
-## Initialize the config file with empty json if it doesn't exist
-if [ ! -f "${DOCKER_DAEMON_CONFIG_FILE}" ]
-then
-  mkdir -p $(dirname "${DOCKER_DAEMON_CONFIG_FILE}")
-  echo '{}' > "${DOCKER_DAEMON_CONFIG_FILE}"
-fi
-## Point Docker storage to mounted volume
-tmp_config=$(mktemp)
-trap "rm -f ${tmp_config}" EXIT
-cat "${DOCKER_DAEMON_CONFIG_FILE}" | jq --arg DATA_ROOT "${DOCKER_DATA_ROOT}" '.["data-root"]=$DATA_ROOT' > "${tmp_config}"
-cat "${tmp_config}" > "${DOCKER_DAEMON_CONFIG_FILE}"
-# Restart Docker daemon to pick up new changes
-systemctl restart --now docker
-# Install Docker Compose
-curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-chmod +x /usr/local/bin/docker-compose
-curl -L "https://raw.githubusercontent.com/docker/compose/${DOCKER_COMPOSE_VERSION}/contrib/completion/bash/docker-compose" -o /etc/bash_completion.d/docker-compose
-# Start Sourcegraph with Docker Compose
-cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"/docker-compose
-docker-compose up -d --remove-orphans
+curl -sfL https://raw.githubusercontent.com/sourcegraph/deploy-sourcegraph-docker/master/docker-compose/scripts/install-aws.sh | bash -s - v4.1.3
 ```
 
-> NOTE: If you're deploying a production instance, we recommend [forking the deployment configuration repository](./index.md#step-1-fork-the-deployment-repository) to track any customizations you make to the deployment config. If you do so, you'll want to update the *startup script* you pasted from above to refer to the clone URL and revision of your fork:
+> NOTE: If you're deploying a production instance, we recommend [forking the deployment configuration repository](./index.md#step-1-fork-the-deployment-repository) to track any customizations you make to the deployment config. If you do so, please add the git-clone URL and revision of your fork to the end of the curl command above in the following format:
+> `curl -sfL https://example.sh | bash -s - $FORK_REVISION $FORK_CLONE_URL`
 > 
-> - `DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL`: The Git clone URL of your deployment repository. If it is a private repository, please check with your code host on how to generate a URL for cloning private repository
-> - `DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION`: The revision (branch) in your fork containing the customizations, typically "release"
+> - `$FORK_CLONE_URL`: The Git clone URL of your deployment repository. If it is a private repository, please check with your code host on how to generate a URL for cloning private repository
+> - `$FORK_REVISION`: The revision (branch) in your fork containing the customizations, typically "release"
 
 ---
 

--- a/doc/admin/deploy/docker-compose/digitalocean.md
+++ b/doc/admin/deploy/docker-compose/digitalocean.md
@@ -51,77 +51,14 @@ This guide will take you through how to deploy a Sourcegraph instance to a singl
 ##### Startup script
 
 ```bash
-#!/usr/bin/env bash
-set -euxo pipefail
-###############################################################################
-# ACTION REQUIRED: REPLACE THE URL AND REVISION WITH YOUR DEPLOYMENT REPO INFO
-###############################################################################
-# Please read the notes below the script if you are cloning a private repository
-DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
-DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v4.1.3'
-##################### NO CHANGES REQUIRED BELOW THIS LINE #####################
-DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
-DOCKER_DATA_ROOT='/mnt/docker-data'
-DOCKER_COMPOSE_VERSION='1.29.2'
-DOCKER_DAEMON_CONFIG_FILE='/etc/docker/daemon.json'
-PERSISTENT_DISK_DEVICE_NAME='/dev/sda'
-# Install git
-sudo apt-get update -y
-sudo apt-get install -y git
-# Clone the deployment repository
-git clone "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL}" "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
-cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
-git checkout "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION}"
-# Format (if unformatted) and then mount the attached volume
-device_fs=$(sudo lsblk "${PERSISTENT_DISK_DEVICE_NAME}" --noheadings --output fsType)
-if [ "${device_fs}" == "" ]
-then
-    sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard "${PERSISTENT_DISK_DEVICE_NAME}"
-fi
-sudo mkdir -p "${DOCKER_DATA_ROOT}"
-sudo mount -o discard,defaults "${PERSISTENT_DISK_DEVICE_NAME}" "${DOCKER_DATA_ROOT}"
-# Mount file system by UUID on reboot
-DISK_UUID=$(sudo blkid -s UUID -o value "${PERSISTENT_DISK_DEVICE_NAME}")
-sudo echo "UUID=${DISK_UUID}  ${DOCKER_DATA_ROOT}  ext4  discard,defaults,nofail  0  2" >> '/etc/fstab'
-sudo umount "${DOCKER_DATA_ROOT}"
-sudo mount -a
-# Install, configure, and enable Docker
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-sudo apt-get update -y
-apt-cache policy docker-ce
-apt-get install -y docker-ce docker-ce-cli containerd.io
-## Enable Docker at startup
-sudo systemctl enable --now docker
-# Install jq for scripting
-sudo apt-get update -y
-sudo apt-get install -y jq
-## Initialize the config file with empty json if it doesn't exist
-if [ ! -f "${DOCKER_DAEMON_CONFIG_FILE}" ]
-then
-    mkdir -p $(dirname "${DOCKER_DAEMON_CONFIG_FILE}")
-    echo '{}' > "${DOCKER_DAEMON_CONFIG_FILE}"
-fi
-## Point Docker storage to mounted volume
-tmp_config=$(mktemp)
-trap "rm -f ${tmp_config}" EXIT
-sudo cat "${DOCKER_DAEMON_CONFIG_FILE}" | sudo jq --arg DATA_ROOT "${DOCKER_DATA_ROOT}" '.["data-root"]=$DATA_ROOT' > "${tmp_config}"
-sudo cat "${tmp_config}" > "${DOCKER_DAEMON_CONFIG_FILE}"
-## Restart Docker daemon to pick up new changes
-sudo systemctl restart --now docker
-# Install Docker Compose
-curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-chmod +x /usr/local/bin/docker-compose
-curl -L "https://raw.githubusercontent.com/docker/compose/${DOCKER_COMPOSE_VERSION}/contrib/completion/bash/docker-compose" -o /etc/bash_completion.d/docker-compose
-# Start Sourcegraph with Docker Compose
-cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"/docker-compose
-docker-compose up -d --remove-orphans
+curl -sfL https://raw.githubusercontent.com/sourcegraph/deploy-sourcegraph-docker/master/docker-compose/scripts/install-digitalocean.sh | bash -s - v4.1.3
 ```
 
-> NOTE: If you're deploying a production instance, we recommend [forking the deployment configuration repository](./index.md#step-1-fork-the-deployment-repository) to track any customizations you make to the deployment config. If you do so, you'll want to update the *startup script* you pasted from above to refer to the clone URL and revision of your fork:
+> NOTE: If you're deploying a production instance, we recommend [forking the deployment configuration repository](./index.md#step-1-fork-the-deployment-repository) to track any customizations you make to the deployment config. If you do so, please add the git-clone URL and revision of your fork to the end of the curl command above in the following format:
+> `curl -sfL https://example.sh | bash -s - $FORK_REVISION $FORK_CLONE_URL`
 > 
-> - `DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL`: The Git clone URL of your deployment repository. If it is a private repository, please check with your code host on how to generate a URL for cloning private repository
-> - `DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION`: The revision (branch) in your fork containing the customizations, typically "release"
+> - `$FORK_CLONE_URL`: The Git clone URL of your deployment repository. If it is a private repository, please check with your code host on how to generate a URL for cloning private repository
+> - `$FORK_REVISION`: The revision (branch) in your fork containing the customizations, typically "release"
 
 ---
 

--- a/doc/admin/deploy/docker-compose/google_cloud.md
+++ b/doc/admin/deploy/docker-compose/google_cloud.md
@@ -47,81 +47,14 @@ Click **Create Instance** in your [Google Cloud Compute Engine Console](https://
 ##### Startup script
 
 ```bash
-#!/usr/bin/env bash
-set -euxo pipefail
-###############################################################################
-# ACTION REQUIRED: REPLACE THE URL AND REVISION WITH YOUR DEPLOYMENT REPO INFO
-###############################################################################
-# Please read the notes below the script if you are cloning a private repository
-DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL='https://github.com/sourcegraph/deploy-sourcegraph-docker.git'
-DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION='v4.1.3'
-##################### NO CHANGES REQUIRED BELOW THIS LINE #####################
-# IMPORTANT: DO NOT MAKE ANY CHANGES FROM THIS POINT ONWARD
-DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT='/root/deploy-sourcegraph-docker'
-DOCKER_COMPOSE_VERSION='1.29.2'
-DOCKER_DAEMON_CONFIG_FILE='/etc/docker/daemon.json'
-DOCKER_DATA_ROOT='/mnt/docker-data'
-PERSISTENT_DISK_DEVICE_NAME='/dev/sdb'
-PERSISTENT_DISK_LABEL='sourcegraph'
-# Install git
-sudo apt-get update -y
-sudo apt-get install -y git
-# Clone the deployment repository
-git clone "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL}" "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
-cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"
-git checkout "${DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION}"
-# Format (if unformatted) and then mount the attached volume
-device_fs=$(sudo lsblk "${PERSISTENT_DISK_DEVICE_NAME}" --noheadings --output fsType)
-if [ "${device_fs}" == "" ] ## only format the volume if it isn't already formatted
-then
-    sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard "${PERSISTENT_DISK_DEVICE_NAME}"
-fi
-sudo e2label "${PERSISTENT_DISK_DEVICE_NAME}" "${PERSISTENT_DISK_LABEL}"
-sudo mkdir -p "${DOCKER_DATA_ROOT}"
-sudo mount -o discard,defaults "${PERSISTENT_DISK_DEVICE_NAME}" "${DOCKER_DATA_ROOT}"
-# Mount file system by label on reboot
-sudo echo "LABEL=${PERSISTENT_DISK_LABEL}  ${DOCKER_DATA_ROOT}  ext4  discard,defaults,nofail  0  2" | sudo tee -a /etc/fstab
-sudo umount "${DOCKER_DATA_ROOT}"
-sudo mount -a
-# Install, configure, and enable Docker
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo apt-get update -y
-sudo apt-get install -y software-properties-common
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-sudo apt-get update -y
-apt-cache policy docker-ce
-apt-get install -y docker-ce docker-ce-cli containerd.io
-## Enable Docker at startup
-sudo systemctl enable --now docker
-## Install jq for scripting
-sudo apt-get update -y
-sudo apt-get install -y jq
-## Initialize the config file with empty json if it doesn't exist
-if [ ! -f "${DOCKER_DAEMON_CONFIG_FILE}" ]
-then
-    mkdir -p $(dirname "${DOCKER_DAEMON_CONFIG_FILE}")
-    echo '{}' >"${DOCKER_DAEMON_CONFIG_FILE}"
-fi
-## Point Docker storage to mounted volume
-tmp_config=$(mktemp)
-trap "rm -f ${tmp_config}" EXIT
-sudo cat "${DOCKER_DAEMON_CONFIG_FILE}" | sudo jq --arg DATA_ROOT "${DOCKER_DATA_ROOT}" '.["data-root"]=$DATA_ROOT' > "${tmp_config}"
-sudo cat "${tmp_config}" > "${DOCKER_DAEMON_CONFIG_FILE}"
-## Restart Docker daemon to pick up new changes
-sudo systemctl restart --now docker
-# Install Docker Compose
-curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-chmod +x /usr/local/bin/docker-compose
-curl -L "https://raw.githubusercontent.com/docker/compose/${DOCKER_COMPOSE_VERSION}/contrib/completion/bash/docker-compose" -o /etc/bash_completion.d/docker-compose
-# Start Sourcegraph with Docker Compose
-cd "${DEPLOY_SOURCEGRAPH_DOCKER_CHECKOUT}"/docker-compose
-docker-compose up -d --remove-orphans
+curl -sfL https://raw.githubusercontent.com/sourcegraph/deploy-sourcegraph-docker/master/docker-compose/scripts/install-gcp.sh | bash -s - v4.1.3
 ```
 
-> NOTE: If you're deploying a production instance, we recommend [forking the deployment configuration repository](./index.md#step-1-fork-the-deployment-repository) to track any customizations you make to the deployment config. If you do so, you'll want to update the *startup script* you pasted from above to refer to the clone URL and revision of your fork:
+> NOTE: If you're deploying a production instance, we recommend [forking the deployment configuration repository](./index.md#step-1-fork-the-deployment-repository) to track any customizations you make to the deployment config. If you do so, please add the git-clone URL and revision of your fork to the end of the curl command above in the following format:
+> `curl -sfL https://example.sh | bash -s - $FORK_REVISION $FORK_CLONE_URL`
 > 
-> - `DEPLOY_SOURCEGRAPH_DOCKER_FORK_CLONE_URL`: The Git clone URL of your deployment repository. If it is a private repository, please check with your code host on how to generate a URL for cloning private repository
-> - `DEPLOY_SOURCEGRAPH_DOCKER_FORK_REVISION`: The revision (branch) in your fork containing the customizations, typically "release"
+> - `$FORK_CLONE_URL`: The Git clone URL of your deployment repository. If it is a private repository, please check with your code host on how to generate a URL for cloning private repository
+> - `$FORK_REVISION`: The revision (branch) in your fork containing the customizations, typically "release"
 
 ---
 

--- a/doc/admin/deploy/single-node/k3s.md
+++ b/doc/admin/deploy/single-node/k3s.md
@@ -29,13 +29,13 @@ Run the following scripts:
 This will always start Sourcegraph at the latest version.
 
 ```bash
-curl -sfL https://raw.githubusercontent.com/sourcegraph/deploy/main/install/scripts/k3s/local.sh | bash
+curl -sfL https://raw.githubusercontent.com/sourcegraph/deploy/main/install/scripts/k3s/local.sh | bash -s -
 ```
 
 To start Sourcegraph at a specific version, add version number at the end of the curl command after `-`:
 
 ```bash
-curl -sfL https://raw.githubusercontent.com/sourcegraph/deploy/main/install/scripts/k3s/local.sh | bash - v4.1.3
+curl -sfL https://raw.githubusercontent.com/sourcegraph/deploy/main/install/scripts/k3s/local.sh | bash -s - v4.1.3
 ```
 
 


### PR DESCRIPTION
Currently, the docker-compose installation scripts for each cloud provider are stored in our doc site, and it takes up half of the page, [example](https://docs.sourcegraph.com/admin/deploy/docker-compose/aws#advanced-details-user-data):
![image](https://user-images.githubusercontent.com/68532117/202029391-edebc8b4-fdb8-43c1-b2ae-c58794a55047.png)

This PR proposed to move the scripts from doc site to the [docker compose reference repo](https://github.com/sourcegraph/deploy-sourcegraph-docker), and allow users to install via curl command instead of copying a big block of text. Example:
![image](https://user-images.githubusercontent.com/68532117/202030232-3fbf1aea-49cc-4ad8-a6e9-7c2bf9dd8489.png)

Same format is currently being used in our k3s installation guide: https://docs.sourcegraph.com/admin/deploy/single-node/k3s#start-up-script

Here is the PR to move the installation scripts from doc sites to the deployment repo: https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/878


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally and in VMs.
