### PR TITLE
[a11y] Improved accessibility when showing/hiding history panel

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, useCallback, useRef, useState } from 'react'
 
 import classNames from 'classnames'
-import { Redirect, Route, RouteComponentProps, Switch, matchPath } from 'react-router'
+import { matchPath, Redirect, Route, RouteComponentProps, Switch } from 'react-router'
 import { Observable } from 'rxjs'
 
 import { TabbedPanelContent } from '@sourcegraph/branded/src/components/panel/TabbedPanelContent'
@@ -51,9 +51,9 @@ import { RepoHeaderActionButton } from './repo/RepoHeader'
 import type { RepoRevisionContainerRoute } from './repo/RepoRevisionContainer'
 import type { RepoSettingsAreaRoute } from './repo/settings/RepoSettingsArea'
 import type { RepoSettingsSideBarGroup } from './repo/settings/RepoSettingsSidebar'
-import type { LayoutRouteProps, LayoutRouteComponentProps } from './routes'
-import { PageRoutes, EnterprisePageRoutes } from './routes.constants'
-import { parseSearchURLQuery, HomePanelsProps, SearchStreamingProps } from './search'
+import type { LayoutRouteComponentProps, LayoutRouteProps } from './routes'
+import { EnterprisePageRoutes, PageRoutes } from './routes.constants'
+import { HomePanelsProps, parseSearchURLQuery, SearchStreamingProps } from './search'
 import { NotepadContainer } from './search/Notepad'
 import type { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import type { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
@@ -280,6 +280,7 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
                         defaultSize={350}
                         storageKey="panel-size"
                         ariaLabel="References panel"
+                        id="references-panel"
                     >
                         <TabbedPanelContent
                             {...props}

--- a/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
@@ -3,8 +3,8 @@ import * as React from 'react'
 import * as H from 'history'
 
 import { Connection } from './ConnectionType'
-import { ConnectionList, ShowMoreButton, SummaryContainer, ConnectionSummary } from './ui'
-import { hasID, hasNextPage, hasDisplayName } from './utils'
+import { ConnectionList, ConnectionSummary, ShowMoreButton, SummaryContainer } from './ui'
+import { hasDisplayName, hasID, hasNextPage } from './utils'
 
 /**
  * Props for the FilteredConnection component's result nodes and associated summary/pagination controls.
@@ -83,7 +83,7 @@ export interface ConnectionNodesDisplayProps {
 
     withCenteredSummary?: boolean
 
-    /** A function that generates an aria label given a node display name */
+    /** A function that generates an aria label given a node display name. */
     ariaLabelFunction?: (displayName: string) => string
 }
 

--- a/client/web/src/components/FilteredConnection/ui/ConnectionContainer.tsx
+++ b/client/web/src/components/FilteredConnection/ui/ConnectionContainer.tsx
@@ -7,6 +7,7 @@ import styles from './ConnectionContainer.module.scss'
 interface ConnectionContainerProps {
     className?: string
     compact?: boolean
+    ariaLive?: 'polite' | 'off'
 }
 
 /**
@@ -18,10 +19,12 @@ export const ConnectionContainer: React.FunctionComponent<React.PropsWithChildre
     children,
     className,
     compact,
+    ariaLive,
 }) => (
     <div
         data-testid="filtered-connection"
         className={classNames(styles.normal, !compact && styles.noncompact, className)}
+        aria-live={ariaLive}
     >
         {children}
     </div>

--- a/client/web/src/repo/RepoRevisionSidebarCommits.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarCommits.tsx
@@ -8,8 +8,8 @@ import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 
 import { createInvalidGraphQLQueryResponseError, dataOrThrowErrors, gql } from '@sourcegraph/http-client'
-import { RevisionSpec, FileSpec } from '@sourcegraph/shared/src/util/url'
-import { Link, Icon } from '@sourcegraph/wildcard'
+import { FileSpec, RevisionSpec } from '@sourcegraph/shared/src/util/url'
+import { Icon, Link } from '@sourcegraph/wildcard'
 
 import { requestGraphQL } from '../backend/graphql'
 import { FilteredConnection } from '../components/FilteredConnection'
@@ -79,6 +79,7 @@ export const RepoRevisionSidebarCommits: React.FunctionComponent<React.PropsWith
             CommitAncestorsConnectionFields
         >
             className="list-group list-group-flush"
+            ariaLive="polite"
             listClassName={styles.list}
             summaryClassName={styles.summary}
             loaderClassName={styles.loader}

--- a/client/web/src/repo/blob/actions/ToggleHistoryPanel.tsx
+++ b/client/web/src/repo/blob/actions/ToggleHistoryPanel.tsx
@@ -85,18 +85,25 @@ export class ToggleHistoryPanel extends React.PureComponent<
 
     public render(): JSX.Element | null {
         const visible = ToggleHistoryPanel.isVisible(this.props.location)
+        const message = `${visible ? 'Hide' : 'Show'} history (Alt+H/Opt+H)`
 
         if (this.props.actionType === 'dropdown') {
             return (
                 <RepoHeaderActionMenuItem file={true} onSelect={this.onClick}>
                     <Icon aria-hidden={true} svgPath={mdiHistory} />
-                    <span>{visible ? 'Hide' : 'Show'} history (Alt+H/Opt+H)</span>
+                    <span>{message}</span>
                 </RepoHeaderActionMenuItem>
             )
         }
         return (
-            <Tooltip content={`${visible ? 'Hide' : 'Show'} history (Alt+H/Opt+H)`}>
-                <RepoHeaderActionButtonLink aria-label={visible ? 'Hide' : 'Show'} file={false} onSelect={this.onClick}>
+            <Tooltip content={message}>
+                <RepoHeaderActionButtonLink
+                    aria-label={message}
+                    aria-controls="references-panel"
+                    aria-expanded={visible}
+                    file={false}
+                    onSelect={this.onClick}
+                >
                     <Icon aria-hidden={true} svgPath={mdiHistory} />
                 </RepoHeaderActionButtonLink>
             </Tooltip>

--- a/client/wildcard/src/components/Panel/Panel.tsx
+++ b/client/wildcard/src/components/Panel/Panel.tsx
@@ -20,6 +20,7 @@ export interface PanelProps extends Omit<UseResizablePanelParameters, 'panelRef'
      */
     handleClassName?: string
     className?: string
+    id?: string
     ariaLabel: string
 }
 


### PR DESCRIPTION
Closes #35924. I think it's a valid fix for that issue as presented, in that the screen reader properly announces that the state was changed and responds to the new history content loading in. Separately, I think we can address how to update the focus after the panel opens. I didn't see a "quick wins" to easily move focus into the history panel after it opens, so I'll need to spend some more time on it. Happy to hear suggestions if anyone has any ideas on this!

There is now screen reader support for the show/hide history action:

https://user-images.githubusercontent.com/10523985/202039793-25623494-c023-4e9e-9095-02354c16b632.mov

This was resolved by:

- Adding [`aria-controls`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls) along with `aria-expanded` properties to the button that toggles showing/hiding, which properly describes the relationship between the button and panel
- Adding `aria-live` to the element that wraps the nodes in a `FilteredConnection` component, which is used to notify the screen reader of updates to the list of nodes

## Test plan

Tested with locally running app and verified that:
1. When toggling this button via VoiceOver controls, the screen reader should properly announce a change to the state of the button/panel (collapsed or expanded).
2. After the panel is opened (expanded), the screen reader should announcing the loading state, followed by the history entries after they have finished loading.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-lrh-a11y-history-panel-toggle.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

