### PR TITLE
Add docs and changelog entry for executor secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 - A structural search diagnostic to warn users when a language filter is not set. [#43835](https://github.com/sourcegraph/sourcegraph/pull/43835)
 - GitHub/GitLab OAuth success/fail attempts are now a part of the audit log. [#43886](https://github.com/sourcegraph/sourcegraph/pull/43886)
 - When rendering a file which is backed by Git LFS, we show a page informing the file is LFS and linking to the file on the codehost. Previously we rendered the LFS pointer. [#43686](https://github.com/sourcegraph/sourcegraph/pull/43686)
+- Batch changes run server-side now support secrets. [#27926](https://github.com/sourcegraph/sourcegraph/issues/27926)
 
 ### Changed
 

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -11,27 +11,20 @@ import styles from './BatchChangesListIntro.module.scss'
 export const BatchChangesChangelogAlert: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <DismissibleAlert
         className={styles.batchChangesListIntroAlert}
-        partialStorageKey="batch-changes-list-intro-changelog-4.1"
+        partialStorageKey="batch-changes-list-intro-changelog-4.2"
     >
         <Card className={classNames(styles.batchChangesListIntroCard, 'h-100')}>
             <CardBody>
-                <H4 as={H3}>Batch Changes updates in version 4.1</H4>
+                <H4 as={H3}>Batch Changes updates in version 4.2</H4>
                 <ul className="mb-0 pl-3">
                     <li>
-                        Batch changes run on the server can now be created within{' '}
+                        Batch changes run on the server now support{' '}
                         <Link
-                            to="/help/batch_changes/how-tos/creating_a_batch_change#creating-a-batch-change-in-a-different-namespace"
+                            to="/help/batch_changes/references/batch_spec_yaml_reference.md#steps-env"
                             rel="noopener"
                             target="_blank"
                         >
-                            organizations
-                        </Link>
-                        .
-                    </li>
-                    <li>
-                        Batch changes run on the server now support{' '}
-                        <Link to="/help/batch_changes/how-tos/server_side_file_mounts" rel="noopener" target="_blank">
-                            mounting files
+                            secret values
                         </Link>
                         .
                     </li>

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -20,7 +20,7 @@ export const BatchChangesChangelogAlert: React.FunctionComponent<React.PropsWith
                     <li>
                         Batch changes run on the server now support{' '}
                         <Link
-                            to="/help/batch_changes/references/batch_spec_yaml_reference.md#steps-env"
+                            to="/help/batch_changes/references/batch_spec_yaml_reference#steps-env"
                             rel="noopener"
                             target="_blank"
                         >

--- a/doc/admin/executor_secrets.md
+++ b/doc/admin/executor_secrets.md
@@ -37,7 +37,7 @@ Org 1 secret `GITHUB_TOKEN`: Can be used by batch changes created by any org mem
 ## Creating a new secret
 
 To create a global secret, go to **Site-admin** > **Executors/Secrets** and click **Add secret**.
-To create a user secret, go to your user profile from the navbar > **Executor secrets** and click **Add secret**.
+To create a user secret, go to your user profile from the navbar > **Settings** >  **Executor secrets** and click **Add secret**.
 To create an org secret, go to the org profile from the navbar > **Executor secrets** and click **Add secret**.
 
 Then, fill in a name for the secret. This will be the name of the environment variable it will be accessible as.

--- a/doc/admin/executor_secrets.md
+++ b/doc/admin/executor_secrets.md
@@ -1,0 +1,62 @@
+# Executor secrets
+
+<style type="text/css">
+  img.executor-diagram {
+    display: block;
+    margin: 1em auto;
+    max-width: 700px;
+    margin-bottom: 0.5em;
+  }
+</style>
+
+<aside class="beta">
+<span class="badge badge-beta">Beta</span> Executors are in beta and might change in the future.
+</aside>
+
+Executor secrets can be used to define additional values to be used in Sourcegraph executors.
+
+Secret values are currently only available in server-side batch changes. Use [`step.env`](../batch_changes/references/batch_spec_yaml_reference.md#steps-env) to reference configured secrets in executions.
+
+## How secrets work
+
+Executor secrets are defined per-feature. If you want to define a secret for server-side batch changes, create a secret for that namespace. Batch Changes is currently the only namespace. Secrets are always redacted in log outputs.
+
+There are two types of secrets: 
+
+- Global secrets: These secrets are defined by an admin in the site-admin interface and will be usable by every user on the Sourcegraph instance.
+- Namespaced secrets: These secrets are set either in org or user settings and are only usable by the user or org members in their respective namespaces. If a namespaced secret has the same name as a global secret, the namespaced secret is preferred.
+
+Examples:
+
+Global secret `GITHUB_TOKEN`: Can be used by every server-side batch change
+
+User 1 secret `GITHUB_TOKEN`: Can be used by batch changes created by user 1 in their own namespace, overwrites the global secret
+
+Org 1 secret `GITHUB_TOKEN`: Can be used by batch changes created by any org member of org 1 in the org namespace, overwrites the global secret
+
+## Creating a new secret
+
+To create a global secret, go to **Site-admin** > **Executors/Secrets** and click **Add secret**.
+To create a user secret, go to your user profile from the navbar > **Executor secrets** and click **Add secret**.
+To create an org secret, go to the org profile from the navbar > **Executor secrets** and click **Add secret**.
+
+Then, fill in a name for the secret. This will be the name of the environment variable it will be accessible as.
+Next, fill in the secret value and hit **Add secret**.
+
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/batch_changes/create_executor_secret.png" class="lead-screenshot">
+
+## Rotating a secret
+
+To rotate a secret or to update the secret value, go to **Executor secrets** (see [Creating a new secret](#creating-a-new-secret)). Next to the secret you want to update or rotate click on **Update**. Fill in the new value and hit **Update secret**.
+
+> Note: When updating secrets server-side batch changes execution caches that reference the secret will be invalidated.
+
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/batch_changes/update_executor_secret.png" class="lead-screenshot">
+
+## Removing a secret
+
+To remove a secret, go to **Executor secrets** (see [Creating a new secret](#creating-a-new-secret)). Next to the secret you want to delete click on **Remove**.
+
+> Note: When removing secrets server-side batch changes execution caches that reference the secret will be invalidated.
+
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/batch_changes/remove_executor_secret.png" class="lead-screenshot">

--- a/doc/batch_changes/references/batch_spec_yaml_reference.md
+++ b/doc/batch_changes/references/batch_spec_yaml_reference.md
@@ -204,7 +204,8 @@ steps:
 In this case, `steps.env` is an array. Each array item is either:
 
 1. An object with a single property, in which case the key is used as the environment variable name and the value the value, or
-2. A string that defines an environment variable to include from the environment `src` is being run within. This is useful to define secrets that you don't want to include in the spec file, but this makes the spec dependent on your environment, means that the local execution cache will be invalidated each time the environment variable changes, and means that the batch spec file is no longer [the sole source of truth intended by the Batch Changes design](../explanations/batch_changes_design.md).
+2. For src-cli execution: A string that defines an environment variable to include from the environment `src` is being run within. This is useful to define secrets that you don't want to include in the spec file, but this makes the spec dependent on your environment, means that the local execution cache will be invalidated each time the environment variable changes, and means that the batch spec file is no longer [the sole source of truth intended by the Batch Changes design](../explanations/batch_changes_design.md).
+3. For server-side execution: A string that defines a secret value to expose as an environment variable. Follow [the guide on executor secrets](../../admin/executor_secrets.md) to set them up. The editor will suggest available secrets. This is useful to use secret values that you don't want to include in the spec file. The execution cache will be invalidated each time the secret value changes, and means that the batch spec file is no longer [the sole source of truth intended by the Batch Changes design](../explanations/batch_changes_design.md).
 
 #### Examples
 
@@ -218,7 +219,7 @@ steps:
       - MESSAGE: Hello world!
 ```
 
-This example pulls in the `USER` environment variable and uses it to construct the line that will be appended to `README.md`:
+This example pulls in the `USER` environment variable, or for server-side uses the executor secret called `USER`, and uses it to construct the line that will be appended to `README.md`:
 
 ```yaml
 steps:


### PR DESCRIPTION
This is the last bit for executor secrets. I've added a section to the YAML reference and linked to a new page that explains secret namespacing and has sections how to create, update and remove secrets.

Closes https://github.com/sourcegraph/sourcegraph/issues/27926

## Test plan

Docs.

## App preview:

- [Web](https://sg-web-es-secret-docs.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
