### PR TITLE
[a11y] web: fix tree page reflow

### DIFF
--- a/client/web/src/components/Breadcrumbs.tsx
+++ b/client/web/src/components/Breadcrumbs.tsx
@@ -154,7 +154,7 @@ export const useBreadcrumbs = (): BreadcrumbsProps & BreadcrumbSetters => {
 export const Breadcrumbs: React.FunctionComponent<
     React.PropsWithChildren<{ breadcrumbs: BreadcrumbAtDepth[]; location: H.Location }>
 > = ({ breadcrumbs, location }) => (
-    <nav className="d-flex container-fluid flex-nowrap flex-shrink-past-contents pl-3 pr-2" aria-label="Breadcrumbs">
+    <nav className="d-flex container-fluid flex-shrink-past-contents pl-3 pr-2" aria-label="Breadcrumbs">
         {sortBy(breadcrumbs, 'depth')
             .map(({ breadcrumb }) => breadcrumb)
             .filter(isDefined)

--- a/client/web/src/repo/commits/GitCommitNode.module.scss
+++ b/client/web/src/repo/commits/GitCommitNode.module.scss
@@ -1,3 +1,5 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
 .git-commit-node {
     padding: 0.75rem 0.5rem 0.5rem;
 
@@ -5,8 +7,19 @@
         padding-top: 0.5rem;
     }
 
+    &--compact .inner-wrapper {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+
+        @media (--xs-breakpoint-down) {
+            flex-direction: column;
+            align-items: flex-start;
+        }
+    }
+
     &--compact .byline {
-        width: 25%;
+        min-width: 25%;
         flex: none;
         padding-right: 1.5rem;
         overflow: hidden;
@@ -57,6 +70,13 @@
     display: flex;
     align-items: center;
     font-size: 1rem;
+
+    @media (--xs-breakpoint-down) {
+        .git-commit-node--compact & {
+            flex-wrap: wrap;
+            max-width: 100%;
+        }
+    }
 
     &-subject {
         font-weight: 600;

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -244,7 +244,9 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
                 key={node.id}
                 className={classNames(styles.gitCommitNode, styles.gitCommitNodeCompact, className)}
             >
-                <div className="w-100 d-flex justify-content-between align-items-center flex-wrap-reverse">
+                <div
+                    className={classNames('w-100 d-flex justify-content-between align-items-center flex-wrap-reverse')}
+                >
                     {bylineElement}
                     <small className={classNames('text-muted', styles.messageTimestamp)}>
                         <Timestamp
@@ -321,7 +323,7 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
                     </>
                 ) : (
                     <div>
-                        <div className="w-100 d-flex justify-content-between align-items-center flex-wrap-reverse">
+                        <div className={styles.innerWrapper}>
                             {bylineElement}
                             {messageElement}
                             <Link to={node.canonicalURL}>{oidElement}</Link>

--- a/client/web/src/repo/tree/TreeNavigation.tsx
+++ b/client/web/src/repo/tree/TreeNavigation.tsx
@@ -25,7 +25,7 @@ export const TreeNavigation: React.FunctionComponent<React.PropsWithChildren<Tre
     codeIntelligenceEnabled,
     batchChangesEnabled,
 }) => (
-    <ButtonGroup>
+    <ButtonGroup className="flex-wrap">
         <Button to={`${tree.url}/-/commits`} variant="secondary" outline={true} as={Link}>
             <Icon aria-hidden={true} svgPath={mdiSourceCommit} /> Commits
         </Button>


### PR DESCRIPTION
Closes #35239

## Test plan

Verify at 320px width

| Before | After |
| - | - |
| <img width="375" alt="image" src="https://user-images.githubusercontent.com/206864/202050202-080ac182-77cd-4403-be78-56f1443e2924.png"> |  <img width="354" alt="image" src="https://user-images.githubusercontent.com/206864/202049443-27c17f8a-aa49-4c40-bb5b-bfc9db6e656e.png"> |
| <img width="399" alt="image" src="https://user-images.githubusercontent.com/206864/202050250-e0cec891-3024-4427-b24a-6d3017f1903b.png"> | <img width="373" alt="image" src="https://user-images.githubusercontent.com/206864/202049484-6f998c65-3158-4145-a576-ef7f77fdb739.png"> | 




## App preview:

- [Web](https://sg-web-jp-treenavwrap.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
