### PR TITLE
Add custom jest matcher for aria-disabled state

### DIFF
--- a/client/search-ui/src/input/SearchContextDropdown.test.tsx
+++ b/client/search-ui/src/input/SearchContextDropdown.test.tsx
@@ -68,13 +68,13 @@ describe('SearchContextDropdown', () => {
 
     it('should be enabled if query is empty', () => {
         render(<SearchContextDropdown {...defaultProps} />)
-        expect(screen.getByTestId('dropdown-toggle')).toBeEnabled()
+        expect(screen.getByTestId('dropdown-toggle')).toBeAriaEnabled()
         expect(screen.getByTestId('dropdown-toggle')).toHaveAttribute('data-test-tooltip-content', '')
     })
 
     it('should be enabled if query does not contain context filter', () => {
         render(<SearchContextDropdown {...defaultProps} query="test (repo:foo or repo:python)" />)
-        expect(screen.getByTestId('dropdown-toggle')).toBeEnabled()
+        expect(screen.getByTestId('dropdown-toggle')).toBeAriaEnabled()
         expect(screen.getByTestId('dropdown-toggle')).toHaveAttribute('data-test-tooltip-content', '')
     })
 

--- a/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.test.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.test.tsx
@@ -113,7 +113,7 @@ describe('StreamingProgressSkippedPopover', () => {
         const form = screen.getByTestId('popover-form')
         const searchAgainButton = within(form).getByRole('button')
         expect(searchAgainButton).toBeInTheDocument()
-        expect(searchAgainButton).toBeDisabled()
+        expect(searchAgainButton).toBeAriaDisabled()
     })
 
     it('should enable Search Again button if at least one item is checked', () => {
@@ -217,7 +217,7 @@ describe('StreamingProgressSkippedPopover', () => {
         expect(searchAgainButton).toBeEnabled()
 
         userEvent.click(checkboxes[1])
-        expect(searchAgainButton).toBeDisabled()
+        expect(searchAgainButton).toBeAriaDisabled()
     })
 
     it('should call onSearchAgain with selected items when button is clicked', () => {

--- a/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.test.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.test.tsx
@@ -164,7 +164,7 @@ describe('StreamingProgressSkippedPopover', () => {
         const form = screen.getByTestId('popover-form')
         const searchAgainButton = within(form).getByRole('button')
         expect(searchAgainButton).toBeInTheDocument()
-        expect(searchAgainButton).toBeEnabled()
+        expect(searchAgainButton).toBeAriaEnabled()
     })
 
     it('should disable Search Again button if unchecking all items', () => {
@@ -214,7 +214,7 @@ describe('StreamingProgressSkippedPopover', () => {
 
         const form = screen.getByTestId('popover-form')
         const searchAgainButton = within(form).getByRole('button')
-        expect(searchAgainButton).toBeEnabled()
+        expect(searchAgainButton).toBeAriaEnabled()
 
         userEvent.click(checkboxes[1])
         expect(searchAgainButton).toBeAriaDisabled()

--- a/client/shared/dev/jest-matchers/setup.ts
+++ b/client/shared/dev/jest-matchers/setup.ts
@@ -1,0 +1,9 @@
+import { expect } from '@jest/globals'
+
+import { toBeAriaDisabled } from './toBeAriaDisabled'
+import { toBeAriaEnabled } from './toBeAriaEnabled'
+
+expect.extend({
+    toBeAriaEnabled,
+    toBeAriaDisabled,
+})

--- a/client/shared/dev/jest-matchers/toBeAriaDisabled.ts
+++ b/client/shared/dev/jest-matchers/toBeAriaDisabled.ts
@@ -9,7 +9,7 @@ export function toBeAriaDisabled(element: HTMLElement): { pass: boolean; message
         throw new Error('You should run this matcher over a valid html element')
     }
 
-    const pass = element.getAttribute('aria-disabled') === 'true'
+    const pass = element.getAttribute('aria-disabled') === 'true' || element.getAttribute('disabled') === 'true'
 
     const passMessage = `${matcherHint('.not.toBeAriaDisabled', 'received', '')}
         Expected element should not have an aria disabled state but received:
@@ -27,13 +27,3 @@ export function toBeAriaDisabled(element: HTMLElement): { pass: boolean; message
 }
 
 expect.extend({ toBeAriaDisabled })
-
-declare global {
-    // eslint-disable-next-line @typescript-eslint/no-namespace
-    namespace jest {
-        interface Matchers<R, T> {
-            toBeAriaDisabled(): R
-        }
-    }
-}
-

--- a/client/shared/dev/jest-matchers/toBeAriaEnabled.ts
+++ b/client/shared/dev/jest-matchers/toBeAriaEnabled.ts
@@ -1,0 +1,27 @@
+import { printReceived, matcherHint } from 'jest-matcher-utils'
+
+export function toBeAriaEnabled(element: HTMLElement): { pass: boolean; message: () => string } {
+    const isElement = element instanceof Element
+
+    if (!isElement) {
+        throw new Error('You should run this matcher over a valid html element')
+    }
+
+    const pass = element.getAttribute('aria-disabled') !== 'true' && element.getAttribute('disabled') === null
+
+    const passMessage = `${matcherHint('.not.toBeAriaDisabled', 'received', '')}
+        Expected element should have an aria disabled state but received:
+           aria-disabled: ${printReceived(element.ariaDisabled)}
+          disabled: ${printReceived(element.getAttribute('disabled'))}
+    `
+    const failMessage = `${matcherHint('.toBeArray', 'received', '')}
+        Expected element should not have an aria disabled state but received:
+          aria-disabled: ${printReceived(element.ariaDisabled)}
+          disabled: ${printReceived(element.getAttribute('disabled'))}
+    `
+
+    return {
+        pass,
+        message: () => (pass ? passMessage : failMessage),
+    }
+}

--- a/client/shared/dev/toBeAriaDisabled.ts
+++ b/client/shared/dev/toBeAriaDisabled.ts
@@ -1,0 +1,39 @@
+import { expect } from '@jest/globals'
+import { printReceived, matcherHint } from 'jest-matcher-utils'
+
+// https://github.com/testing-library/jest-dom/issues/144
+export function toBeAriaDisabled(element: HTMLElement): { pass: boolean; message: () => string } {
+    const isElement = element instanceof Element
+
+    if (!isElement) {
+        throw new Error('You should run this matcher over a valid html element')
+    }
+
+    const pass = element.getAttribute('aria-disabled') === 'true'
+
+    const passMessage = `${matcherHint('.not.toBeAriaDisabled', 'received', '')}
+        Expected element should not have an aria disabled state but received:
+          ${printReceived(element.ariaDisabled)}
+    `
+    const failMessage = `${matcherHint('.toBeArray', 'received', '')}
+        Expected element should have an aria disabled state but received:
+          ${printReceived(element.ariaDisabled)}
+    `
+
+    return {
+        pass,
+        message: () => (pass ? passMessage : failMessage),
+    }
+}
+
+expect.extend({ toBeAriaDisabled })
+
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace jest {
+        interface Matchers<R, T> {
+            toBeAriaDisabled(): R
+        }
+    }
+}
+

--- a/client/shared/src/actions/ActionItem.test.tsx
+++ b/client/shared/src/actions/ActionItem.test.tsx
@@ -185,8 +185,8 @@ describe('ActionItem', () => {
         // to result in the setState call.)
         userEvent.click(screen.getByRole('button'))
 
-        // we should wait for the button to be enabled again after got errors. Otherwise it will be flaky
-        await waitFor(() => expect(screen.getByLabelText('d')).toBeEnabled())
+        // we should wait for the button to be enabled again after got errors. Otherwise, it will be flaky
+        await waitFor(() => expect(screen.getByLabelText('d')).toBeAriaEnabled())
 
         expect(asFragment()).toMatchSnapshot()
     })

--- a/client/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
+++ b/client/shared/src/actions/__snapshots__/ActionItem.test.tsx.snap
@@ -164,7 +164,6 @@ exports[`ActionItem run command 2`] = `
 exports[`ActionItem run command with error 1`] = `
 <DocumentFragment>
   <button
-    aria-disabled="true"
     aria-label="d"
     class="test-action-item"
     type="button"

--- a/client/shared/src/globals.d.ts
+++ b/client/shared/src/globals.d.ts
@@ -27,3 +27,14 @@ declare var jsdom: import('jsdom').JSDOM
 interface Window {
     context?: any
 }
+
+declare global {
+    namespace jest {
+        interface Matchers<R, T> {
+            toBeAriaEnabled(): R
+            toBeAriaDisabled(): R
+        }
+    }
+}
+
+export {}

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
@@ -106,6 +106,6 @@ describe('CreateCodeMonitorPage', () => {
             </MockedTestProvider>
         )
         const actionButton = screen.getByTestId('form-action-toggle-email')
-        expect(actionButton).toBeDisabled()
+        expect(actionButton).toBeAriaDisabled()
     })
 })

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
@@ -161,7 +161,7 @@ describe('ManageCodeMonitorPage', () => {
 
         userEvent.type(screen.getByTestId('name-input'), 'Test code monitor updated')
 
-        expect(submitButton).toBeEnabled()
+        expect(submitButton).toBeAriaEnabled()
     })
 
     test('Cancelling after changes have been made shows confirmation prompt', () => {

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
@@ -157,7 +157,7 @@ describe('ManageCodeMonitorPage', () => {
             </MockedTestProvider>
         )
         const submitButton = screen.getByTestId('submit-monitor')
-        expect(submitButton).toBeDisabled()
+        expect(submitButton).toBeAriaDisabled()
 
         userEvent.type(screen.getByTestId('name-input'), 'Test code monitor updated')
 

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.test.tsx
@@ -63,6 +63,6 @@ describe('CodeMonitorForm', () => {
         fireEvent.click(getByTestId('form-action-toggle-email'))
         fireEvent.click(getByTestId('submit-action-email'))
 
-        expect(getByTestId('submit-monitor')).toBeEnabled()
+        expect(getByTestId('submit-monitor')).toBeAriaEnabled()
     })
 })

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.test.tsx
@@ -51,7 +51,7 @@ describe('CodeMonitorForm', () => {
         fireEvent.click(getByTestId('form-action-toggle-email'))
         fireEvent.click(getByTestId('delete-action-email'))
 
-        expect(getByTestId('submit-monitor')).toBeDisabled()
+        expect(getByTestId('submit-monitor')).toBeAriaDisabled()
     })
 
     test('Submit button enabled if one action is present', () => {

--- a/client/web/src/enterprise/code-monitoring/components/actions/ActionEditor.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/ActionEditor.test.tsx
@@ -84,7 +84,7 @@ describe('ActionEditor', () => {
         userEvent.click(getByTestId('form-action-toggle-email'))
 
         expect(queryByTestId('delete-action-email')).not.toBeInTheDocument()
-        expect(getByTestId('submit-action-email')).toBeDisabled()
+        expect(getByTestId('submit-action-email')).toBeAriaDisabled()
     })
 
     test('toggle disable when collapsed', () => {

--- a/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.test.tsx
@@ -247,7 +247,7 @@ describe('EmailAction', () => {
 
             expect(getByTestId('send-test-email')).toHaveTextContent('Send test email')
 
-            expect(getByTestId('send-test-email')).toBeEnabled()
+            expect(getByTestId('send-test-email')).toBeAriaEnabled()
 
             expect(queryByTestId('send-test-email-again')).not.toBeInTheDocument()
             expect(queryByTestId('test-email-error')).toBeInTheDocument()

--- a/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.test.tsx
@@ -190,7 +190,7 @@ describe('EmailAction', () => {
             )
 
             userEvent.click(getByTestId('form-action-toggle-email'))
-            expect(getByTestId('send-test-email')).toBeDisabled()
+            expect(getByTestId('send-test-email')).toBeAriaDisabled()
         })
 
         test('send test email, success', async () => {
@@ -217,7 +217,7 @@ describe('EmailAction', () => {
             await waitForNextApolloResponse()
 
             expect(getByTestId('send-test-email')).toHaveTextContent('Test email sent!')
-            expect(getByTestId('send-test-email')).toBeDisabled()
+            expect(getByTestId('send-test-email')).toBeAriaDisabled()
 
             expect(queryByTestId('send-test-email-again')).toBeInTheDocument()
             expect(queryByTestId('test-email-error')).not.toBeInTheDocument()

--- a/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.test.tsx
@@ -35,7 +35,7 @@ describe('SlackWebhookAction', () => {
         expect(getByTestId('submit-action-slack-webhook')).toBeAriaDisabled()
 
         userEvent.type(getByTestId('slack-webhook-url'), SLACK_URL)
-        expect(getByTestId('submit-action-slack-webhook')).toBeEnabled()
+        expect(getByTestId('submit-action-slack-webhook')).toBeAriaEnabled()
 
         userEvent.click(getByTestId('include-results-toggle-slack-webhook'))
 
@@ -69,13 +69,13 @@ describe('SlackWebhookAction', () => {
         )
 
         userEvent.click(getByTestId('form-action-toggle-slack-webhook'))
-        expect(getByTestId('submit-action-slack-webhook')).toBeEnabled()
+        expect(getByTestId('submit-action-slack-webhook')).toBeAriaEnabled()
 
         userEvent.clear(getByTestId('slack-webhook-url'))
         expect(getByTestId('submit-action-slack-webhook')).toBeAriaDisabled()
 
         userEvent.type(getByTestId('slack-webhook-url'), SLACK_URL)
-        expect(getByTestId('submit-action-slack-webhook')).toBeEnabled()
+        expect(getByTestId('submit-action-slack-webhook')).toBeAriaEnabled()
 
         userEvent.click(getByTestId('submit-action-slack-webhook'))
 
@@ -285,7 +285,7 @@ describe('SlackWebhookAction', () => {
 
             expect(getByTestId('send-test-slack-webhook')).toHaveTextContent('Send test message')
 
-            expect(getByTestId('send-test-slack-webhook')).toBeEnabled()
+            expect(getByTestId('send-test-slack-webhook')).toBeAriaEnabled()
 
             expect(queryByTestId('send-test-slack-webhook-again')).not.toBeInTheDocument()
             expect(queryByTestId('test-slack-webhook-error')).toBeInTheDocument()

--- a/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.test.tsx
@@ -32,7 +32,7 @@ describe('SlackWebhookAction', () => {
 
         userEvent.click(getByTestId('form-action-toggle-slack-webhook'))
 
-        expect(getByTestId('submit-action-slack-webhook')).toBeDisabled()
+        expect(getByTestId('submit-action-slack-webhook')).toBeAriaDisabled()
 
         userEvent.type(getByTestId('slack-webhook-url'), SLACK_URL)
         expect(getByTestId('submit-action-slack-webhook')).toBeEnabled()
@@ -72,7 +72,7 @@ describe('SlackWebhookAction', () => {
         expect(getByTestId('submit-action-slack-webhook')).toBeEnabled()
 
         userEvent.clear(getByTestId('slack-webhook-url'))
-        expect(getByTestId('submit-action-slack-webhook')).toBeDisabled()
+        expect(getByTestId('submit-action-slack-webhook')).toBeAriaDisabled()
 
         userEvent.type(getByTestId('slack-webhook-url'), SLACK_URL)
         expect(getByTestId('submit-action-slack-webhook')).toBeEnabled()
@@ -217,7 +217,7 @@ describe('SlackWebhookAction', () => {
             )
 
             userEvent.click(getByTestId('form-action-toggle-slack-webhook'))
-            expect(getByTestId('send-test-slack-webhook')).toBeDisabled()
+            expect(getByTestId('send-test-slack-webhook')).toBeAriaDisabled()
         })
 
         test('disabled if no monitor name set', () => {
@@ -228,7 +228,7 @@ describe('SlackWebhookAction', () => {
             )
 
             userEvent.click(getByTestId('form-action-toggle-slack-webhook'))
-            expect(getByTestId('send-test-slack-webhook')).toBeDisabled()
+            expect(getByTestId('send-test-slack-webhook')).toBeAriaDisabled()
         })
 
         test('send test message, success', async () => {
@@ -255,7 +255,7 @@ describe('SlackWebhookAction', () => {
             await waitForNextApolloResponse()
 
             expect(getByTestId('send-test-slack-webhook')).toHaveTextContent('Test message sent!')
-            expect(getByTestId('send-test-slack-webhook')).toBeDisabled()
+            expect(getByTestId('send-test-slack-webhook')).toBeAriaDisabled()
 
             expect(queryByTestId('send-test-slack-webhook')).toBeInTheDocument()
             expect(queryByTestId('test-email-slack-webhook')).not.toBeInTheDocument()

--- a/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.test.tsx
@@ -30,7 +30,7 @@ describe('WebhookAction', () => {
 
         userEvent.click(getByTestId('form-action-toggle-webhook'))
 
-        expect(getByTestId('submit-action-webhook')).toBeDisabled()
+        expect(getByTestId('submit-action-webhook')).toBeAriaDisabled()
 
         userEvent.type(getByTestId('webhook-url'), 'https://example.com')
         expect(getByTestId('submit-action-webhook')).toBeEnabled()
@@ -70,7 +70,7 @@ describe('WebhookAction', () => {
         expect(getByTestId('submit-action-webhook')).toBeEnabled()
 
         userEvent.clear(getByTestId('webhook-url'))
-        expect(getByTestId('submit-action-webhook')).toBeDisabled()
+        expect(getByTestId('submit-action-webhook')).toBeAriaDisabled()
 
         userEvent.type(getByTestId('webhook-url'), 'https://example2.com')
         expect(getByTestId('submit-action-webhook')).toBeEnabled()
@@ -215,7 +215,7 @@ describe('WebhookAction', () => {
             )
 
             userEvent.click(getByTestId('form-action-toggle-webhook'))
-            expect(getByTestId('send-test-webhook')).toBeDisabled()
+            expect(getByTestId('send-test-webhook')).toBeAriaDisabled()
         })
 
         test('disabled if no monitor name set', () => {
@@ -226,7 +226,7 @@ describe('WebhookAction', () => {
             )
 
             userEvent.click(getByTestId('form-action-toggle-webhook'))
-            expect(getByTestId('send-test-webhook')).toBeDisabled()
+            expect(getByTestId('send-test-webhook')).toBeAriaDisabled()
         })
 
         test('send test message, success', async () => {
@@ -253,7 +253,7 @@ describe('WebhookAction', () => {
             await waitForNextApolloResponse()
 
             expect(getByTestId('send-test-webhook')).toHaveTextContent('Test call completed!')
-            expect(getByTestId('send-test-webhook')).toBeDisabled()
+            expect(getByTestId('send-test-webhook')).toBeAriaDisabled()
 
             expect(queryByTestId('send-test-webhook')).toBeInTheDocument()
             expect(queryByTestId('test-email-webhook')).not.toBeInTheDocument()

--- a/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.test.tsx
@@ -33,7 +33,7 @@ describe('WebhookAction', () => {
         expect(getByTestId('submit-action-webhook')).toBeAriaDisabled()
 
         userEvent.type(getByTestId('webhook-url'), 'https://example.com')
-        expect(getByTestId('submit-action-webhook')).toBeEnabled()
+        expect(getByTestId('submit-action-webhook')).toBeAriaEnabled()
 
         userEvent.click(getByTestId('include-results-toggle-webhook'))
 
@@ -67,13 +67,13 @@ describe('WebhookAction', () => {
         )
 
         userEvent.click(getByTestId('form-action-toggle-webhook'))
-        expect(getByTestId('submit-action-webhook')).toBeEnabled()
+        expect(getByTestId('submit-action-webhook')).toBeAriaEnabled()
 
         userEvent.clear(getByTestId('webhook-url'))
         expect(getByTestId('submit-action-webhook')).toBeAriaDisabled()
 
         userEvent.type(getByTestId('webhook-url'), 'https://example2.com')
-        expect(getByTestId('submit-action-webhook')).toBeEnabled()
+        expect(getByTestId('submit-action-webhook')).toBeAriaEnabled()
 
         userEvent.click(getByTestId('submit-action-webhook'))
 
@@ -283,7 +283,7 @@ describe('WebhookAction', () => {
 
             expect(getByTestId('send-test-webhook')).toHaveTextContent('Call webhook with test payload')
 
-            expect(getByTestId('send-test-webhook')).toBeEnabled()
+            expect(getByTestId('send-test-webhook')).toBeAriaEnabled()
 
             expect(queryByTestId('send-test-webhook-again')).not.toBeInTheDocument()
             expect(queryByTestId('test-webhook-error')).toBeInTheDocument()

--- a/client/web/src/globals.d.ts
+++ b/client/web/src/globals.d.ts
@@ -32,6 +32,7 @@ declare module '*.yml' {
 declare global {
     namespace jest {
         interface Matchers<R, T> {
+            toBeAriaEnabled(): R
             toBeAriaDisabled(): R
         }
     }

--- a/client/web/src/globals.d.ts
+++ b/client/web/src/globals.d.ts
@@ -28,3 +28,13 @@ declare module '*.yml' {
     const ymlModule: string
     export default ymlModule
 }
+
+declare global {
+    namespace jest {
+        interface Matchers<R, T> {
+            toBeAriaDisabled(): R
+        }
+    }
+}
+
+export {}

--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -128,7 +128,7 @@ describe('Code monitoring', () => {
 
             await driver.page.waitForSelector('.test-action-button-email')
             assert.strictEqual(
-                await isElementDisabled(driver,'.test-action-button-email'),
+                await isElementDisabled(driver, '.test-action-button-email'),
                 true,
                 'Expected action button to be disabled'
             )
@@ -155,7 +155,7 @@ describe('Code monitoring', () => {
 
             await driver.page.waitForSelector('.test-action-button-email')
             assert.strictEqual(
-                await isElementDisabled(driver,'.test-action-button-email'),
+                await isElementDisabled(driver, '.test-action-button-email'),
                 true,
                 'Expected action button to be disabled'
             )
@@ -173,7 +173,7 @@ describe('Code monitoring', () => {
 
             await driver.page.waitForSelector('.test-action-button-email')
             assert.strictEqual(
-                await isElementDisabled(driver,'.test-action-button-email'),
+                await isElementDisabled(driver, '.test-action-button-email'),
                 false,
                 'Expected action button to be enabled'
             )
@@ -189,7 +189,7 @@ describe('Code monitoring', () => {
 
             await driver.page.waitForSelector('.test-submit-monitor')
             assert.strictEqual(
-                await isElementDisabled(driver,'.test-submit-monitor'),
+                await isElementDisabled(driver, '.test-submit-monitor'),
                 true,
                 'Expected submit monitor button to be disabled'
             )
@@ -211,7 +211,7 @@ describe('Code monitoring', () => {
             await driver.page.click('.test-submit-action-email')
 
             assert.strictEqual(
-                await isElementDisabled(driver,'.test-submit-monitor'),
+                await isElementDisabled(driver, '.test-submit-monitor'),
                 false,
                 'Expected submit monitor button to be enabled'
             )

--- a/client/web/src/integration/settings.test.ts
+++ b/client/web/src/integration/settings.test.ts
@@ -95,7 +95,7 @@ describe('Settings', () => {
             await driver.page.waitForSelector('.test-save-toolbar-save')
 
             assert.strictEqual(
-                await isElementDisabled(driver,'.test-save-toolbar-save'),
+                await isElementDisabled(driver, '.test-save-toolbar-save'),
                 true,
                 'Expected save button to be disabled'
             )

--- a/client/wildcard/globals.d.ts
+++ b/client/wildcard/globals.d.ts
@@ -15,6 +15,7 @@ declare var jsdom: import('jsdom').JSDOM
 declare global {
     namespace jest {
         interface Matchers<R, T> {
+            toBeAriaEnabled(): R
             toBeAriaDisabled(): R
         }
     }

--- a/client/wildcard/globals.d.ts
+++ b/client/wildcard/globals.d.ts
@@ -11,3 +11,13 @@ declare module '*.css' {
  * Set by shared/dev/jest-environment.js
  */
 declare var jsdom: import('jsdom').JSDOM
+
+declare global {
+    namespace jest {
+        interface Matchers<R, T> {
+            toBeAriaDisabled(): R
+        }
+    }
+}
+
+export {}

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.test.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.test.tsx
@@ -39,7 +39,7 @@ describe('FeedbackPrompt', () => {
             target: { value: sampleFeedback.feedback },
         })
 
-        expect(screen.getByText('Send')).toBeEnabled()
+        expect(screen.getByText('Send')).toBeAriaEnabled()
 
         userEvent.click(screen.getByText('Send'))
     }
@@ -53,7 +53,7 @@ describe('FeedbackPrompt', () => {
 
         userEvent.type(screen.getByLabelText('Send feedback to Sourcegraph'), sampleFeedback.feedback)
 
-        expect(screen.getByText('Send')).toBeEnabled()
+        expect(screen.getByText('Send')).toBeAriaEnabled()
     })
 
     test('should render submit success correctly', async () => {

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.test.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.test.tsx
@@ -49,7 +49,7 @@ describe('FeedbackPrompt', () => {
     })
 
     test('should enable/disable submit button correctly', () => {
-        expect(screen.getByText('Send')).toBeDisabled()
+        expect(screen.getByText('Send')).toBeAriaDisabled()
 
         userEvent.type(screen.getByLabelText('Send feedback to Sourcegraph'), sampleFeedback.feedback)
 

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -67,7 +67,7 @@ const config = {
     require.resolve('core-js/stable'),
     require.resolve('regenerator-runtime/runtime'),
     require.resolve('@testing-library/jest-dom'),
-    path.join(__dirname, 'client/shared/dev/toBeAriaDisabled.ts'),
+    path.join(__dirname, 'client/shared/dev/jest-matchers/setup.ts'),
   ],
   globalSetup: path.join(__dirname, 'client/shared/dev/jestGlobalSetup.js'),
 }

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -67,6 +67,7 @@ const config = {
     require.resolve('core-js/stable'),
     require.resolve('regenerator-runtime/runtime'),
     require.resolve('@testing-library/jest-dom'),
+    path.join(__dirname, 'client/shared/dev/toBeAriaDisabled.ts'),
   ],
   globalSetup: path.join(__dirname, 'client/shared/dev/jestGlobalSetup.js'),
 }


### PR DESCRIPTION
Based on https://github.com/sourcegraph/sourcegraph/pull/44384
# DO NOT MERGE THIS PR
## Problem 
In this pr https://github.com/sourcegraph/sourcegraph/pull/44384 we introduced a new disabled state for the button in order to improve the Button + Tooltip experience. In our unit tests, we have a lot of checks where we check the disabled state with the `.toBeDisabled()` matcher. This `.toBeDisabled()` checks the disabled attribute on the target, but since we start using the 'aria-disabled' attribute instead, we need to have something like the `.toBeAriaDisabled` matcher in our unit test. This PR adds this, but unfortunately, I couldn't find a way to extend jest matcher types properly. 

The current state of this PR:
- Jest tests pass with `.toBeAriaDisabled` and `.toBeAriaEnabled` matchers
- But we still have a TS error about "this matcher doesn't exist in JestMatcher interface", somehow we need to extend jest matcher globally. (global namespace override didn't work out)
- Because of this TS problem I had to updated each package where we use newly added custom matchers and add them to the `global.d.ts` files



## Test plan
- Make sure that tests with `.toBeAriaDisabled` work as expected (check aria-disabled attribute)
- Make sure that any test with `.toBeAriaDisabled` doesn't have any TypeScript problems

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-add-custom-matcher.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

