### PR TITLE
Make the files sidebar correctly update based on location

### DIFF
--- a/client/web/src/repo/RepositoryFileTreePage.tsx
+++ b/client/web/src/repo/RepositoryFileTreePage.tsx
@@ -34,7 +34,7 @@ const hideRepoRevisionContent = localStorage.getItem('hideRepoRevContent')
 export const RepositoryFileTreePage: React.FunctionComponent<
     React.PropsWithChildren<RepositoryFileTreePageProps>
 > = props => {
-    const { repo, resolvedRevision, repoName, match, globbing, ...context } = props
+    const { location, repo, resolvedRevision, repoName, match, globbing, ...context } = props
 
     // The decoding depends on the pinned `history` version.
     // See https://github.com/sourcegraph/sourcegraph/issues/4408
@@ -49,12 +49,12 @@ export const RepositoryFileTreePage: React.FunctionComponent<
     const mode = getModeFromPath(filePath)
 
     // Redirect OpenGrok-style line number hashes (#123, #123-321) to query parameter (?L123, ?L123-321)
-    const hashLineNumberMatch = window.location.hash.match(/^#?(\d+)(-\d+)?$/)
+    const hashLineNumberMatch = location.hash.match(/^#?(\d+)(-\d+)?$/)
     if (objectType === 'blob' && hashLineNumberMatch) {
         const startLineNumber = parseInt(hashLineNumberMatch[1], 10)
         const endLineNumber = hashLineNumberMatch[2] ? parseInt(hashLineNumberMatch[2].slice(1), 10) : undefined
         const url = appendLineRangeQueryParameter(
-            window.location.pathname + window.location.search,
+            location.pathname + location.search,
             `L${startLineNumber}` + (endLineNumber ? `-${endLineNumber}` : '')
         )
         return <Redirect to={url} />
@@ -62,17 +62,14 @@ export const RepositoryFileTreePage: React.FunctionComponent<
 
     // For blob pages with legacy URL fragment hashes like "#L17:19-21:23$foo:bar"
     // redirect to the modern URL fragment hashes like "#L17:19-21:23&tab=foo:bar"
-    if (!hideRepoRevisionContent && objectType === 'blob' && isLegacyFragment(window.location.hash)) {
-        const parsedQuery = parseQueryAndHash(window.location.search, window.location.hash)
+    if (!hideRepoRevisionContent && objectType === 'blob' && isLegacyFragment(location.hash)) {
+        const parsedQuery = parseQueryAndHash(location.search, location.hash)
         const hashParameters = new URLSearchParams()
         if (parsedQuery.viewState) {
             hashParameters.set('tab', parsedQuery.viewState)
         }
         const range = formatLineOrPositionOrRange(parsedQuery)
-        const url = appendLineRangeQueryParameter(
-            window.location.pathname + window.location.search,
-            range ? `L${range}` : undefined
-        )
+        const url = appendLineRangeQueryParameter(location.pathname + location.search, range ? `L${range}` : undefined)
         return <Redirect to={url + formatHash(hashParameters)} />
     }
 
@@ -100,7 +97,7 @@ export const RepositoryFileTreePage: React.FunctionComponent<
                 // lowest common ancestor of Blob and the absolutely-positioned Blob status bar
                 <BlobStatusBarContainer>
                     <GettingStartedTour.Info isSourcegraphDotCom={context.isSourcegraphDotCom} className="mr-3 mb-3" />
-                    <ErrorBoundary location={context.location}>
+                    <ErrorBoundary location={location}>
                         {objectType === 'blob' ? (
                             <TraceSpanProvider name="BlobPage">
                                 <BlobPage
@@ -112,6 +109,7 @@ export const RepositoryFileTreePage: React.FunctionComponent<
                                     repoName={repoName}
                                     repoUrl={repo?.url}
                                     mode={mode}
+                                    location={location}
                                     repoHeaderContributionsLifecycleProps={
                                         context.repoHeaderContributionsLifecycleProps
                                     }

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -92,6 +92,7 @@ export const treePageRepositoryFragment = gql`
 `
 
 export const TreePage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
+    location,
     repo,
     repoName,
     commitID,

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -397,6 +397,7 @@ export const TreePage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                                                         match={match}
                                                         settingsCascade={settingsCascade}
                                                         useBreadcrumb={useBreadcrumb}
+                                                        location={location}
                                                         {...props}
                                                     />
                                                 </RepoRevisionWrapper>
@@ -412,6 +413,7 @@ export const TreePage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                                 repo={repo}
                                 revision={revision}
                                 commitID={commitID}
+                                location={location}
                                 {...props}
                             />
                         )}


### PR DESCRIPTION
Previously, navigating to a nested file with the fuzzy finder didn't update the Files sidebar. The reason this didn't happen is because the Files sidebar used `window.location` to determine the active file instead of the `location` prop. This PR fixes the issue by properly using the `location` property that already passed to the `TreePage` component.

## Test plan
Manually tested locally.

![CleanShot 2022-11-16 at 10 06 33](https://user-images.githubusercontent.com/1408093/202137263-1d924e8b-3ed3-49f3-b5bf-12b27c34d89a.gif)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-files-sidebar.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
