### PR TITLE
internal/repoupdater: Remove outdated TODO comment

### DIFF
--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -250,8 +250,6 @@ func (c *Client) SyncExternalService(ctx context.Context, externalServiceID int6
 
 	var result protocol.ExternalServiceSyncResult
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		// TODO(tsenart): Use response type for unmarshalling errors too.
-		// This needs to be done after rolling out the response type in prod.
 		return nil, errors.New(string(bs))
 	} else if len(bs) == 0 {
 		return &result, nil


### PR DESCRIPTION
We check for error in the response 262 below (now line number 260 with this edit).

Reading the sync code and stumbled upon this today.

## Test plan

N/A.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
