### PR TITLE
Open in Editor: Add filter for short URL patterns + test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Fixed a bug where path matches on files in the root directory of a repository were not highlighted. [#43275](https://github.com/sourcegraph/sourcegraph/pull/43275)
 - Fixed a bug where a search query wouldn't be validated after the query type has changed. [#43849](https://github.com/sourcegraph/sourcegraph/pull/43849)
+- Fixed a bug where Open in Editor didn't work well with `"repositoryPathPattern" = "{nameWithOwner}"` [#43839](https://github.com/sourcegraph/sourcegraph/pull/44475)
 
 ### Removed
 

--- a/client/web/src/open-in-editor/build-url.test.ts
+++ b/client/web/src/open-in-editor/build-url.test.ts
@@ -13,6 +13,15 @@ function buildSettings(props: EditorSettings = {}): EditorSettings {
 }
 
 describe('buildRepoBaseNameAndPath tests', () => {
+    it('builds the correct string for "repositoryPathPattern": "{nameWithOwner}" config', () => {
+        const url = 'https://sourcegraph.com/sourcegraph/sourcegraph/-/blob/tsconfig.json'
+        const { repoName, filePath } = parseBrowserRepoURL(url)
+
+        const result = buildRepoBaseNameAndPath(repoName, ExternalServiceKind.GITHUB, filePath)
+
+        expect(result).toEqual('sourcegraph/tsconfig.json')
+    })
+
     it('builds the correct string for GitHub URLs', () => {
         const url = 'https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/tsconfig.json'
         const { repoName, filePath } = parseBrowserRepoURL(url)

--- a/client/web/src/open-in-editor/build-url.ts
+++ b/client/web/src/open-in-editor/build-url.ts
@@ -21,9 +21,10 @@ export function buildRepoBaseNameAndPath(
     externalServiceType: string | undefined,
     filePath: string | undefined
 ): string {
-    const bareRepoNamePieces = repoName
-        .split('/')
-        .slice(serviceTypesWithOwnerInUrl.has((externalServiceType || '').toLowerCase()) ? 2 : 1)
+    const pathPieces = repoName.split('/')
+    const shouldCutOffTwoPieces =
+        pathPieces.length > 2 && serviceTypesWithOwnerInUrl.has((externalServiceType || '').toLowerCase())
+    const bareRepoNamePieces = pathPieces.slice(shouldCutOffTwoPieces ? 2 : 1)
     return path.join(...bareRepoNamePieces, ...(filePath ? [filePath] : []))
 }
 


### PR DESCRIPTION
- Fixes https://github.com/sourcegraph/sourcegraph/issues/43839

I've done some digging, and I don't see a truly elegant solution that I could deliver before tomorrow's branch cut.
The solution in this PR is not elegant, but it solves the current customer issue, and I find it unlikely that it'd break other cases.

My findings:
- The `repositoryPathPattern` is **not available** on the front end (for a reason).
    - Only the modified repo URLs are available, that is, the results of applying the `repositoryPathPattern` on the original URLs.
    - `repositoryPathPattern` is a part of the code host connection settings (The config visible at `/site-admin/external-services/{id}`), and the whole thing is not accessible to the front end. This is expected because this raw information should probably be available for admins.
    - Without `repositoryPathPattern`, we can't reliably determine how many pieces we should cut off from the URL.
- We could move the logic to the back end, and have the back end return an alternative path made for Open in Editor. This would probably involve introducing a new setting to the code host connection config (for each code host type), to set the number of pieces to cut off explicitly. Then the front-end logic would have no logic; it'd just use the URL provided.
  - I'm not confident that this would be a user-friendly solution; it's a bit too many settings, and I'm still wondering whether the cutoff point could be reliably calculated on the back end.

## Test plan

I've added a new test that covers this case; the old test and the new one are all passing, so I think this should be fine.

## App preview:

- [Web](https://sg-web-dv-open-in-editor-respect.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
