### PR TITLE
ranking: remove feature flag

### DIFF
--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -160,8 +160,7 @@ func zoektSearchIgnorePaths(ctx context.Context, client zoekt.Streamer, p *proto
 		NumRepos:       1,
 		FileMatchLimit: int32(p.Limit),
 		Features: search.Features{
-			Ranking:             true,
-			RankingDampDocRanks: true,
+			Ranking: true,
 		},
 	}).ToSearch(ctx)
 	if deadline, ok := ctx.Deadline(); ok {

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -292,7 +292,6 @@ func ToFeatures(flagSet *featureflag.FlagSet, logger log.Logger) *search.Feature
 		HybridSearch:            flagSet.GetBoolOr("search-hybrid", false),
 		AbLuckySearch:           flagSet.GetBoolOr("ab-lucky-search", false),
 		Ranking:                 flagSet.GetBoolOr("search-ranking", false),
-		RankingDampDocRanks:     flagSet.GetBoolOr("search-ranking-damp-doc-ranks", false),
 		Debug:                   flagSet.GetBoolOr("search-debug", false),
 	}
 }

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -347,10 +347,6 @@ type Features struct {
 	// Debug when true will set the Debug field on FileMatches. This may grow
 	// from here. For now we treat this like a feature flag for convenience.
 	Debug bool `json:"debug"`
-
-	// RankingDampDocRanks if true will damp the influence of document
-	// ranks on the final ranking.
-	RankingDampDocRanks bool `json:"search-ranking-damp-doc-ranks"`
 }
 
 func (f *Features) String() string {

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -141,9 +141,7 @@ func (o *Options) ToSearch(ctx context.Context) *zoekt.SearchOptions {
 		searchOpts.UseDocumentRanks = true
 
 		// This damps the impact of document ranks on the final ranking.
-		if o.Features.RankingDampDocRanks {
-			searchOpts.RanksDampingFactor = 0.5
-		}
+		searchOpts.RanksDampingFactor = 0.5
 
 		return searchOpts
 	}


### PR DESCRIPTION
We remove the feature flag search-ranking-damp-doc-ranks. We set searchOpts.RanksDampingFactor=0.5 always, because manual testing showed good results for this value. Once we have a proper cost function we can experiment with other values.

Note: This code is still behind the feature flag for ranking.

## Test plan
- The code has been live for the Sourcegraph org for about a week now
- CI
 