### PR TITLE
Search: remove `cursor: text` CSS class when hovering results

### DIFF
--- a/client/search-ui/src/components/CodeExcerpt.module.scss
+++ b/client/search-ui/src/components/CodeExcerpt.module.scss
@@ -25,10 +25,6 @@
         padding-left: 1rem;
     }
 
-    :global(.hl-source) {
-        cursor: text;
-    }
-
     &-error {
         width: 100%;
     }


### PR DESCRIPTION
Context https://sourcegraph.slack.com/archives/C0W2E592M/p1668578244913799

I think it's surprising that clicking with `cursor: text` opens another page. It's less surprising IMO to use `cursor: pointer` and allowing user to drag/select text.

## Test plan

Manually tested.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-remove-pointer-on-text.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
