### PR TITLE
sg: ci build: forcefully set a branch for external commits

### DIFF
--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -451,6 +451,7 @@ sg ci build docker-images-patch-notest prometheus
 				if response != "yes" {
 					return errors.New("Cancelling request.")
 				}
+				branch = fmt.Sprintf("_manually_triggered_external/%s", commit)
 			}
 
 			var rt runtype.RunType


### PR DESCRIPTION
Using `sg ci build -c $commit` when you're on the main branch, like when you're requesting a build for a PR from an external contributor, would previously end up on the `main` branch in Buildkite, even though it's actually not on the `main` branch in the repository.

This is quite scary for the random bystander and in the end, very confusing and wrong.

This change merely hotfixes the problem and the `sg ci build` command should be rewritten as we also discovered other issues such as `sg ci build main-dry-run -c $commit` will actually push the current commit and not $commit on `main-dry-run/main`, which also quite confusing.

SECURITY: this also leads to building the commit with the `main` runtype, which will push artefacts. It's fixed with this PR. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Locally tested. 