### PR TITLE
gitserver: Simplify test

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -142,7 +142,7 @@ func main() {
 			return getRemoteURLFunc(ctx, externalServiceStore, repoStore, nil, repo)
 		},
 		GetVCSSyncer: func(ctx context.Context, repo api.RepoName) (server.VCSSyncer, error) {
-			return getVCSSyncer(ctx, externalServiceStore, repoStore, dependenciesSvc, repo)
+			return getVCSSyncer(ctx, externalServiceStore, repoStore, dependenciesSvc, repo, reposDir)
 		},
 		Hostname:                hostname.Get(),
 		DB:                      db,
@@ -441,6 +441,7 @@ func getVCSSyncer(
 	repoStore database.RepoStore,
 	depsSvc *dependencies.Service,
 	repo api.RepoName,
+	reposDir string,
 ) (server.VCSSyncer, error) {
 	// We need an internal actor in case we are trying to access a private repo. We
 	// only need access in order to find out the type of code host we're using, so

--- a/cmd/gitserver/main_test.go
+++ b/cmd/gitserver/main_test.go
@@ -144,17 +144,12 @@ func TestGetRemoteURLFunc_GitHubApp(t *testing.T) {
 }
 
 func TestGetVCSSyncer(t *testing.T) {
-	oldReposDir := reposDir
-	t.Cleanup(func() {
-		reposDir = oldReposDir
-	})
-	var err error
-	reposDir, err = os.MkdirTemp("", "TestGetVCSSyncer")
+	tempReposDir, err := os.MkdirTemp("", "TestGetVCSSyncer")
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		if err := os.RemoveAll(reposDir); err != nil {
+		if err := os.RemoveAll(tempReposDir); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -187,7 +182,7 @@ func TestGetVCSSyncer(t *testing.T) {
 		}, nil
 	})
 
-	s, err := getVCSSyncer(context.Background(), extsvcStore, repoStore, depsSvc, repo)
+	s, err := getVCSSyncer(context.Background(), extsvcStore, repoStore, depsSvc, repo, tempReposDir)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Simplify test by taking the repos directory as an argument to
`getVCSSyncer`.

Thanks @mrnugget for the idea

## Test plan

Test continues to pass
