### PR TITLE
Search result: Fix search stream memoization

### DIFF
--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -20,6 +20,7 @@ import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
+import { useDeepMemo } from '@sourcegraph/wildcard'
 
 import { SearchStreamingProps } from '..'
 import { AuthenticatedUser } from '../../auth'
@@ -97,7 +98,9 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
     const extensionHostAPI =
         extensionsController !== null && window.context.enableLegacyExtensions ? extensionsController.extHostAPI : null
     const trace = useMemo(() => new URLSearchParams(location.search).get('trace') ?? undefined, [location.search])
-    const featureOverrides = useMemo(() => new URLSearchParams(location.search).getAll('feat') ?? [], [location.search])
+    const featureOverrides = useDeepMemo(
+        useMemo(() => new URLSearchParams(location.search).getAll('feat') ?? [], [location.search])
+    )
 
     const options: StreamSearchOptions = useMemo(
         () => ({

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -99,6 +99,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
         extensionsController !== null && window.context.enableLegacyExtensions ? extensionsController.extHostAPI : null
     const trace = useMemo(() => new URLSearchParams(location.search).get('trace') ?? undefined, [location.search])
     const featureOverrides = useDeepMemo(
+        // Nested use memo here is used for avoiding extra object calculation step on each render
         useMemo(() => new URLSearchParams(location.search).getAll('feat') ?? [], [location.search])
     )
 


### PR DESCRIPTION
Original [slack thread](https://sourcegraph.slack.com/archives/CHEKCRWKV/p1668542256627789) about this problem

## Problem 

I think this PR https://github.com/sourcegraph/sourcegraph/pull/44003 or the original one https://github.com/sourcegraph/sourcegraph/pull/43872 broke the search memoisation logic around search stream data. 

- Search aggregation changes URL 
- This triggers the` featureOverride` calculation
- And because It returns a new array every time it calculates featureOverride it triggers stream cache 
- As a result, we see loading flashing between search aggregation and search stream resolves 

Sidenote: In the slack thread, @novoselrok mentioned the problem with rendering interactions, and it seemed like this was caused by SearchAggregation UI. SearchAggregation just changes the URL, and because Zuzstand observes URL in a sync way, it leads to the sync re-rendering in all Zustand store consumers that uses URL info. So I tried to update Zustand to the latest version because the 4.0 version uses useSyncExternalStore, but this didn't fix the problem, I also tried to use `startTransition` in the search aggregation UI where we set URL param, but this also didn't help. My dirty solution is just to schedule setState in the next tick with RAF or setTimeout, but I don't quite like this option. Maybe someone else has any idea about this problem. cc @fkling @limitedmage 

## Test plan
- I actually don't have a good way to reproduce this and test it. 
- Check the common flow 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-search-stream-memo.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
