### PR TITLE
packages: reduce use of io.ReadAll for PyPi packages

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_python_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_python_packages.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/fs"
 	"net/url"
 	"path"
@@ -75,12 +76,13 @@ func (s *pythonPackagesSyncer) Download(ctx context.Context, dir string, dep rep
 		return err
 	}
 	packageURL := pypiFile.URL
-	pkg, err := s.client.Download(ctx, packageURL)
+	pkgData, err := s.client.Download(ctx, packageURL)
 	if err != nil {
 		return errors.Wrap(err, "download")
 	}
+	defer pkgData.Close()
 
-	if err = unpackPythonPackage(pkg, packageURL, dir); err != nil {
+	if err = unpackPythonPackage(pkgData, packageURL, dir); err != nil {
 		return errors.Wrap(err, "failed to unzip python module")
 	}
 
@@ -90,7 +92,7 @@ func (s *pythonPackagesSyncer) Download(ctx context.Context, dir string, dep rep
 // unpackPythonPackages unpacks the given python package archive into workDir, skipping any
 // files that aren't valid or that are potentially malicious. It detects the kind of archive
 // and compression used with the given packageURL.
-func unpackPythonPackage(pkg []byte, packageURL, workDir string) error {
+func unpackPythonPackage(pkg io.Reader, packageURL, workDir string) error {
 	logger := log.Scoped("unpackPythonPackages", "unpackPythonPackages unpacks the given python package archive into workDir")
 	u, err := url.Parse(packageURL)
 	if err != nil {
@@ -99,20 +101,18 @@ func unpackPythonPackage(pkg []byte, packageURL, workDir string) error {
 
 	filename := path.Base(u.Path)
 
-	r := bytes.NewReader(pkg)
 	opts := unpack.Opts{
 		SkipInvalid: true,
 		Filter: func(path string, file fs.FileInfo) bool {
 			size := file.Size()
 
 			const sizeLimit = 15 * 1024 * 1024
-			slogger := logger.With(
-				log.String("path", file.Name()),
-				log.Int64("size", size),
-				log.Float64("limit", sizeLimit),
-			)
 			if size >= sizeLimit {
-				slogger.Warn("skipping large file in python package")
+				logger.With(
+					log.String("path", file.Name()),
+					log.Int64("size", size),
+					log.Float64("limit", sizeLimit),
+				).Warn("skipping large file in python package")
 				return false
 			}
 
@@ -123,11 +123,16 @@ func unpackPythonPackage(pkg []byte, packageURL, workDir string) error {
 
 	switch {
 	case strings.HasSuffix(filename, ".tar.gz"), strings.HasSuffix(filename, ".tgz"):
-		err = unpack.Tgz(r, workDir, opts)
+		err = unpack.Tgz(pkg, workDir, opts)
 	case strings.HasSuffix(filename, ".whl"), strings.HasSuffix(filename, ".zip"):
-		err = unpack.Zip(r, int64(len(pkg)), workDir, opts)
+		var pkgBytes []byte
+		pkgBytes, err = io.ReadAll(pkg)
+		if err != nil {
+			break
+		}
+		err = unpack.Zip(bytes.NewReader(pkgBytes), int64(len(pkgBytes)), workDir, opts)
 	case strings.HasSuffix(filename, ".tar"):
-		err = unpack.Tar(r, workDir, opts)
+		err = unpack.Tar(pkg, workDir, opts)
 	default:
 		return errors.Errorf("unsupported python package type %q", filename)
 	}

--- a/cmd/gitserver/server/vcs_syncer_python_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_python_packages_test.go
@@ -53,7 +53,7 @@ func TestUnpackPythonPackage_TGZ(t *testing.T) {
 		},
 	}
 
-	pkg := createTgz(t, files)
+	pkg := bytes.NewReader(createTgz(t, files))
 
 	tmp := t.TempDir()
 	if err := unpackPythonPackage(pkg, "https://some.where/pckg.tar.gz", tmp); err != nil {
@@ -126,7 +126,7 @@ func TestUnpackPythonPackage_ZIP(t *testing.T) {
 	}
 
 	tmp := t.TempDir()
-	if err := unpackPythonPackage(zipBuf.Bytes(), "https://some.where/pckg.zip", tmp); err != nil {
+	if err := unpackPythonPackage(&zipBuf, "https://some.where/pckg.zip", tmp); err != nil {
 		t.Fatal()
 	}
 
@@ -168,7 +168,7 @@ func TestUnpackPythonPackage_InvalidZip(t *testing.T) {
 		},
 	}
 
-	pkg := createTgz(t, files)
+	pkg := bytes.NewReader(createTgz(t, files))
 
 	if err := unpackPythonPackage(pkg, "https://some.where/pckg.whl", t.TempDir()); err == nil {
 		t.Fatal()
@@ -176,7 +176,7 @@ func TestUnpackPythonPackage_InvalidZip(t *testing.T) {
 }
 
 func TestUnpackPythonPackage_UnsupportedFormat(t *testing.T) {
-	if err := unpackPythonPackage([]byte{}, "https://some.where/pckg.exe", ""); err == nil {
+	if err := unpackPythonPackage(bytes.NewReader([]byte{}), "https://some.where/pckg.exe", ""); err == nil {
 		t.Fatal()
 	}
 }

--- a/internal/extsvc/pypi/client.go
+++ b/internal/extsvc/pypi/client.go
@@ -22,7 +22,6 @@
 package pypi
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -34,8 +33,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"golang.org/x/net/html"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -69,6 +69,8 @@ func (c *Client) Project(ctx context.Context, project reposource.PackageName) ([
 	if err != nil {
 		return nil, errors.Wrap(err, "PyPI")
 	}
+	defer data.Close()
+
 	return parse(data)
 }
 
@@ -183,10 +185,10 @@ type File struct {
 
 // parse parses the output of Client.Project into a list of files. Anchor tags
 // without href are ignored.
-func parse(b []byte) ([]File, error) {
+func parse(b io.Reader) ([]File, error) {
 	var files []File
 
-	z := html.NewTokenizer(bytes.NewReader(b))
+	z := html.NewTokenizer(b)
 
 	// We want to iterate over the anchor tags. Quoting from PEP503: "[The project]
 	// URL must respond with a valid HTML5 page with a single anchor element per
@@ -263,7 +265,7 @@ OUTER:
 }
 
 // Download downloads a file located at url, respecting the rate limit.
-func (c *Client) Download(ctx context.Context, url string) ([]byte, error) {
+func (c *Client) Download(ctx context.Context, url string) (io.ReadCloser, error) {
 	if err := c.limiter.Wait(ctx); err != nil {
 		return nil, err
 	}
@@ -399,7 +401,7 @@ func ToWheel(f File) (*Wheel, error) {
 	}
 }
 
-func (c *Client) get(ctx context.Context, project reposource.PackageName) (respBody []byte, err error) {
+func (c *Client) get(ctx context.Context, project reposource.PackageName) (respBody io.ReadCloser, err error) {
 	var (
 		reqURL *url.URL
 		req    *http.Request
@@ -436,24 +438,23 @@ func (c *Client) get(ctx context.Context, project reposource.PackageName) (respB
 	return respBody, err
 }
 
-func (c *Client) do(req *http.Request) ([]byte, error) {
+func (c *Client) do(req *http.Request) (io.ReadCloser, error) {
 	resp, err := c.cli.Do(req)
 	if err != nil {
 		return nil, err
 	}
 
-	defer resp.Body.Close()
-
-	bs, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
 	if resp.StatusCode != http.StatusOK {
+		defer resp.Body.Close()
+
+		bs, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, &Error{path: req.URL.Path, code: resp.StatusCode, message: fmt.Sprintf("failed to read non-200 body: %v", err)}
+		}
 		return nil, &Error{path: req.URL.Path, code: resp.StatusCode, message: string(bs)}
 	}
 
-	return bs, nil
+	return resp.Body, nil
 }
 
 type Error struct {

--- a/internal/extsvc/pypi/client_test.go
+++ b/internal/extsvc/pypi/client_test.go
@@ -57,7 +57,7 @@ func TestDownload(t *testing.T) {
 	}
 
 	tmp := t.TempDir()
-	err = unpack.Tgz(bytes.NewReader(p), tmp, unpack.Opts{})
+	err = unpack.Tgz(p, tmp, unpack.Opts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,13 +119,13 @@ func TestVersion(t *testing.T) {
 }
 
 func TestParse_empty(t *testing.T) {
-	b := []byte(`
+	b := bytes.NewReader([]byte(`
 <!DOCTYPE html>
 <html>
   <body>
   </body>
 </html>
-`)
+`))
 
 	_, err := parse(b)
 	if err != nil {
@@ -166,7 +166,7 @@ func TestParse_broken(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err := parse(buf.Bytes())
+			_, err := parse(&buf)
 			if err == nil {
 				t.Fatal("expected error")
 			}
@@ -177,7 +177,7 @@ func TestParse_broken(t *testing.T) {
 func TestParse_PEP503(t *testing.T) {
 	// There may be any other HTML elements on the API pages as long as the required
 	// anchor elements exist.
-	b := []byte(`
+	b := bytes.NewReader([]byte(`
 <!DOCTYPE html>
 <html>
   <head>
@@ -194,7 +194,7 @@ func TestParse_PEP503(t *testing.T) {
 	</div>
   </body>
 </html>
-`)
+`))
 
 	got, err := parse(b)
 	if err != nil {


### PR DESCRIPTION
@eseliger reported fetching of PyPi packages to be showing up in heap profiles. This PR attempts to address this by reducing the amount of cases where we run `io.ReadAll`, and for cases where thats run anyways (for .tar.gz, .whl and .zip files), we reduce for how long we're reading the whole response body to only the unpacking stage. 

Theres optimizations that we can make in `internal/unpack` to reduce the amount of `io.ReadAll` needed there again, which could help cut down the amount of full-reads required. Will follow up with a PR for that. Erik also reported that we do this for other package hosts as well, so more PRs to follow.

<details>
<summary>Heap Profile</summary>

![image](https://user-images.githubusercontent.com/18282288/202225584-7ac9c067-588b-4a35-b272-68b7bb9c3be0.png)

</details>

## Test plan

Unit tests pass, not user facing yet so Im ok with testing this live
