### PR TITLE
insights: add oob migration for recording times back with fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Creating access tokens is now tracked in the security events. [#43226](https://github.com/sourcegraph/sourcegraph/pull/43226)
 - Added `codeIntelAutoIndexing.indexerMap` to site-config that allows users to update the indexers used when inferring precise code intelligence auto-indexing jobs (without having to overwrite the entire inference scripts). For example, `"codeIntelAutoIndexing.indexerMap": {"go": "my.registry/sourcegraph/lsif-go"}` will casue Go projects to use the specified container (in a alternative Docker registry). [#43199](https://github.com/sourcegraph/sourcegraph/pull/43199)
-- Code Insights data points that do not contain any results will display zero instead of being omitted from the visualization. Only applies to insight data created after 4.2. [#43166](https://github.com/sourcegraph/sourcegraph/pull/43166)
+- Code Insights data points that do not contain any results will display zero instead of being omitted from the visualization. [#43166](https://github.com/sourcegraph/sourcegraph/pull/43166), [#44165](https://github.com/sourcegraph/sourcegraph/pull/44165/)
 - Sourcegraph ships with node-exporter, a Prometheus tool that provides hardware / OS metrics that helps Sourcegraph scale your deployment. See your deployment update for more information:
   - [Kubernetes](https://docs.sourcegraph.com/admin/updates/kubernetes)
   - [Docker Compose](https://docs.sourcegraph.com/admin/updates/docker_compose)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Creating access tokens is now tracked in the security events. [#43226](https://github.com/sourcegraph/sourcegraph/pull/43226)
 - Added `codeIntelAutoIndexing.indexerMap` to site-config that allows users to update the indexers used when inferring precise code intelligence auto-indexing jobs (without having to overwrite the entire inference scripts). For example, `"codeIntelAutoIndexing.indexerMap": {"go": "my.registry/sourcegraph/lsif-go"}` will casue Go projects to use the specified container (in a alternative Docker registry). [#43199](https://github.com/sourcegraph/sourcegraph/pull/43199)
-- Code Insights data points that do not contain any results will display zero instead of being omitted from the visualization. [#43166](https://github.com/sourcegraph/sourcegraph/pull/43166), [#44165](https://github.com/sourcegraph/sourcegraph/pull/44165/)
+- Code Insights data points that do not contain any results will display zero instead of being omitted from the visualization. [#43166](https://github.com/sourcegraph/sourcegraph/pull/43166), [#44499](https://github.com/sourcegraph/sourcegraph/pull/44499/)
 - Sourcegraph ships with node-exporter, a Prometheus tool that provides hardware / OS metrics that helps Sourcegraph scale your deployment. See your deployment update for more information:
   - [Kubernetes](https://docs.sourcegraph.com/admin/updates/kubernetes)
   - [Docker Compose](https://docs.sourcegraph.com/admin/updates/docker_compose)

--- a/enterprise/internal/oobmigration/migrations/insights/migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/insights/migrator_test.go
@@ -26,7 +26,7 @@ func TestInsightsMigrator(t *testing.T) {
 	}
 
 	// We can still run this test even if a dev has disabled code insights in
-	// there env.
+	// their env.
 	t.Setenv("DISABLE_CODE_INSIGHTS", "")
 
 	ctx := context.Background()

--- a/enterprise/internal/oobmigration/migrations/insights/recording_times.go
+++ b/enterprise/internal/oobmigration/migrations/insights/recording_times.go
@@ -16,11 +16,6 @@ func calculateRecordingTimes(createdAt time.Time, lastRecordedAt time.Time, inte
 		return referenceTimes
 	}
 
-	// We don't have any missing data points for this series so just return it.
-	if len(referenceTimes) == len(existingPoints) {
-		return existingPoints
-	}
-
 	var calculatedRecordingTimes []time.Time
 	// For each reference time, we compare it to existing recording times.
 	// If the reference time is before the next existing point (i.e. no time exists there), we add it to the list.

--- a/enterprise/internal/oobmigration/migrations/insights/recording_times.go
+++ b/enterprise/internal/oobmigration/migrations/insights/recording_times.go
@@ -1,0 +1,150 @@
+package insights
+
+import (
+	"sort"
+	"time"
+)
+
+func calculateRecordingTimes(createdAt time.Time, lastRecordedAt time.Time, interval timeInterval, existingPoints []time.Time) []time.Time {
+	referenceTimes := buildRecordingTimes(12, interval, createdAt.Truncate(time.Hour*24))
+	if !lastRecordedAt.IsZero() {
+		// If we've had recordings since we need to step through them.
+		referenceTimes = append(referenceTimes, buildRecordingTimesBetween(createdAt.Truncate(time.Hour*24), lastRecordedAt, interval)[1:]...)
+	}
+
+	if len(existingPoints) == 0 {
+		return referenceTimes
+	}
+
+	// We don't have any missing data points for this series so just return it.
+	if len(referenceTimes) == len(existingPoints) {
+		return existingPoints
+	}
+
+	var calculatedRecordingTimes []time.Time
+	// For each reference time, we compare it to existing recording times.
+	// If the reference time is before the next existing point (i.e. no time exists there), we add it to the list.
+	// Else if the existing point is + half an interval close to the reference time, we add that to the list.
+	// We use + half an interval because once a recording is queued there might be a delay in stamping. It could not
+	// be stamped in the past.
+	currentPointIndex := 0
+	for _, referenceTime := range referenceTimes {
+		referenceTime := referenceTime
+		if currentPointIndex < len(existingPoints) {
+			existingTime := existingPoints[currentPointIndex]
+			intervalDuration := interval.toDuration() // precise to rough estimate of an interval's length (e.g. 1 year = 365 * 24 hours)
+			halfAnInterval := intervalDuration / 2
+			if interval.unit == hour {
+				halfAnInterval = intervalDuration / 4
+			}
+			differenceInExpectedTime := existingTime.Sub(referenceTime)
+			if differenceInExpectedTime >= 0 && differenceInExpectedTime <= halfAnInterval {
+				calculatedRecordingTimes = append(calculatedRecordingTimes, existingTime)
+				currentPointIndex++
+			} else {
+				calculatedRecordingTimes = append(calculatedRecordingTimes, referenceTime)
+				if referenceTime.After(existingTime) {
+					currentPointIndex++
+				}
+			}
+		} else {
+			calculatedRecordingTimes = append(calculatedRecordingTimes, referenceTime)
+		}
+	}
+
+	return calculatedRecordingTimes
+}
+
+type intervalUnit string
+
+const (
+	month intervalUnit = "MONTH"
+	day   intervalUnit = "DAY"
+	week  intervalUnit = "WEEK"
+	year  intervalUnit = "YEAR"
+	hour  intervalUnit = "HOUR"
+)
+
+type timeInterval struct {
+	unit  intervalUnit
+	value int
+}
+
+func (t timeInterval) toDuration() time.Duration {
+	var singleUnitDuration time.Duration
+	switch t.unit {
+	case year:
+		singleUnitDuration = time.Hour * 24 * 365
+	case month:
+		singleUnitDuration = time.Hour * 24 * 30
+	case week:
+		singleUnitDuration = time.Hour * 24 * 7
+	case day:
+		singleUnitDuration = time.Hour * 24
+	case hour:
+		singleUnitDuration = time.Hour
+	}
+	return singleUnitDuration * time.Duration(t.value)
+}
+
+func buildRecordingTimes(numPoints int, interval timeInterval, now time.Time) []time.Time {
+	current := now
+	times := make([]time.Time, 0, numPoints)
+	times = append(times, now)
+
+	for i := 0 - numPoints + 1; i < 0; i++ {
+		current = interval.stepBackwards(current)
+		times = append(times, current)
+	}
+
+	sort.Slice(times, func(i, j int) bool {
+		return times[i].Before(times[j])
+	})
+	return times
+}
+
+// buildRecordingTimesBetween builds times starting at `start` up until `end` at the given interval.
+func buildRecordingTimesBetween(start time.Time, end time.Time, interval timeInterval) []time.Time {
+	times := []time.Time{}
+
+	current := start
+	for current.Before(end) {
+		times = append(times, current)
+		current = interval.stepForwards(current)
+	}
+
+	return times
+}
+
+func (t timeInterval) stepBackwards(start time.Time) time.Time {
+	return t.step(start, backward)
+}
+
+func (t timeInterval) stepForwards(start time.Time) time.Time {
+	return t.step(start, forward)
+}
+
+type stepDirection int
+
+const (
+	forward  stepDirection = 1
+	backward stepDirection = -1
+)
+
+func (t timeInterval) step(start time.Time, direction stepDirection) time.Time {
+	switch t.unit {
+	case year:
+		return start.AddDate(int(direction)*t.value, 0, 0)
+	case month:
+		return start.AddDate(0, int(direction)*t.value, 0)
+	case week:
+		return start.AddDate(0, 0, int(direction)*7*t.value)
+	case day:
+		return start.AddDate(0, 0, int(direction)*t.value)
+	case hour:
+		return start.Add(time.Hour * time.Duration(t.value) * time.Duration(direction))
+	default:
+		// this doesn't really make sense, so return something?
+		return start.AddDate(int(direction)*t.value, 0, 0)
+	}
+}

--- a/enterprise/internal/oobmigration/migrations/insights/recording_times_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/insights/recording_times_migrator.go
@@ -1,0 +1,168 @@
+package insights
+
+import (
+	"context"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+)
+
+type recordingTimesMigrator struct {
+	store *basestore.Store
+
+	batchSize int
+}
+
+func NewRecordingTimesMigrator(store *basestore.Store, batchSize int) *recordingTimesMigrator {
+	return &recordingTimesMigrator{
+		store:     store,
+		batchSize: batchSize,
+	}
+}
+
+var _ oobmigration.Migrator = &recordingTimesMigrator{}
+
+func (m *recordingTimesMigrator) ID() int                 { return 17 }
+func (m *recordingTimesMigrator) Interval() time.Duration { return time.Second * 10 }
+
+func (m *recordingTimesMigrator) Progress(ctx context.Context, _ bool) (float64, error) {
+	if !insights.IsEnabled() {
+		return 1, nil
+	}
+	progress, _, err := basestore.ScanFirstFloat(m.store.Query(ctx, sqlf.Sprintf(`
+		SELECT
+			CASE c2.count WHEN 0 THEN 1 ELSE
+				cast(c1.count as float) / cast(c2.count as float)
+			END
+		FROM
+			(SELECT count(*) as count FROM insight_series WHERE supports_augmentation IS TRUE) c1,
+			(SELECT count(*) as count FROM insight_series) c2
+	`)))
+	return progress, err
+}
+
+func (m *recordingTimesMigrator) Up(ctx context.Context) (err error) {
+	if !insights.IsEnabled() {
+		return nil
+	}
+	tx, err := m.store.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	rows, err := tx.Query(ctx, sqlf.Sprintf(
+		"SELECT id, series_id, created_at, last_recorded_at, sample_interval_unit, sample_interval_value FROM insight_series WHERE supports_augmentation IS FALSE ORDER BY id LIMIT %s FOR UPDATE SKIP LOCKED",
+		m.batchSize,
+	))
+	if err != nil {
+		return err
+	}
+
+	series := make(map[int]seriesMetadata) // id -> metadata
+	for rows.Next() {
+		var id int
+		var seriesID string
+		var createdAt, lastRecordedAt time.Time
+		var sampleIntervalUnit string
+		var sampleIntervalValue int
+		if err := rows.Scan(
+			&id,
+			&seriesID,
+			&createdAt,
+			&lastRecordedAt,
+			&sampleIntervalUnit,
+			&sampleIntervalValue,
+		); err != nil {
+			return err
+		}
+		series[id] = seriesMetadata{
+			id:             id,
+			seriesID:       seriesID,
+			createdAt:      createdAt,
+			lastRecordedAt: lastRecordedAt,
+			interval: timeInterval{
+				unit:  intervalUnit(sampleIntervalUnit),
+				value: sampleIntervalValue,
+			},
+		}
+	}
+	if err = basestore.CloseRows(rows, err); err != nil {
+		return err
+	}
+
+	for id, metadata := range series {
+		recordingTimesRows, err := tx.Query(ctx, sqlf.Sprintf(
+			"SELECT DISTINCT time FROM series_points WHERE series_id = %s ORDER by time ASC", metadata.seriesID,
+		))
+		if err != nil {
+			return err
+		}
+		var recordingTimes []time.Time
+		for rows.Next() {
+			var record time.Time
+			if err := recordingTimesRows.Scan(&record); err != nil {
+				return err
+			}
+			recordingTimes = append(recordingTimes, record)
+		}
+		if err = basestore.CloseRows(recordingTimesRows, err); err != nil {
+			return err
+		}
+
+		calculatedTimes := calculateRecordingTimes(metadata.createdAt, metadata.lastRecordedAt, metadata.interval, recordingTimes)
+		for _, recordTime := range calculatedTimes {
+			if err := tx.Exec(ctx, sqlf.Sprintf(
+				"INSERT INTO insight_series_recording_times (insight_series_id, recording_time, snapshot) VALUES(%s, %s, false) ON CONFLICT DO NOTHING",
+				id,
+				recordTime.UTC(),
+			)); err != nil {
+				return err
+			}
+		}
+		if err := tx.Exec(ctx, sqlf.Sprintf(
+			"UPDATE insight_series SET supports_augmentation = TRUE WHERE id = %s",
+			id,
+		)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type seriesMetadata struct {
+	id             int
+	seriesID       string
+	createdAt      time.Time
+	lastRecordedAt time.Time
+	interval       timeInterval
+}
+
+func (m *recordingTimesMigrator) Down(ctx context.Context) error {
+	if !insights.IsEnabled() {
+		return nil
+	}
+	tx, err := m.store.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	if err := tx.Exec(ctx, sqlf.Sprintf(
+		`WITH deleted AS (
+			DELETE FROM insight_series_recording_times 
+			WHERE insight_series_id IN (SELECT id FROM insight_series WHERE supports_augmentation = TRUE LIMIT %s)
+            RETURNING insight_series_id
+		)
+        UPDATE insight_series SET supports_augmentation = FALSE where id IN (SELECT * from deleted)`,
+		m.batchSize,
+	)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/enterprise/internal/oobmigration/migrations/insights/recording_times_migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/insights/recording_times_migrator_test.go
@@ -1,0 +1,84 @@
+package insights
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/log/logtest"
+
+	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+)
+
+func TestRecordingTimesMigrator(t *testing.T) {
+	t.Setenv("DISABLE_CODE_INSIGHTS", "")
+
+	logger := logtest.Scoped(t)
+	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t))
+
+	insightsStore := basestore.NewWithHandle(insightsDB.Handle())
+
+	migrator := NewRecordingTimesMigrator(insightsStore, 500)
+
+	assertProgress := func(expectedProgress float64) {
+		if progress, err := migrator.Progress(context.Background(), false); err != nil {
+			t.Fatalf("unexpected error querying progress: %s", err)
+		} else if progress != expectedProgress {
+			t.Errorf("unexpected progress. want=%.2f have=%.2f", expectedProgress, progress)
+		}
+	}
+
+	assertNumberOfRecordingTimes := func(expectedCount int) {
+		query := sqlf.Sprintf(`SELECT count(*) FROM insight_series_recording_times;`)
+
+		numberOfRecordings, _, err := basestore.ScanFirstInt(migrator.store.Query(context.Background(), query))
+		if err != nil {
+			t.Fatalf("encountered error fetching recording times count: %v", err)
+		} else if expectedCount != numberOfRecordings {
+			t.Errorf("unexpected counts, want %v got %v", expectedCount, numberOfRecordings)
+		}
+	}
+
+	numSeries := 1000
+	for i := 0; i < numSeries; i++ {
+		if err := migrator.store.Exec(context.Background(), sqlf.Sprintf(
+			`INSERT INTO insight_series (series_id, query, generation_method, supports_augmentation, created_at, last_recorded_at, sample_interval_unit, sample_interval_value)
+             VALUES (%s, 'query', 'search', FALSE, %s, %s, %s, %s)`,
+			fmt.Sprintf("series-%d", i),
+			time.Date(2022, 11, 9, 12, 1, 0, 0, time.UTC),
+			time.Time{},
+			hour,
+			2,
+		)); err != nil {
+			t.Fatalf("unexpected error inserting series data: %s", err)
+		}
+	}
+
+	assertProgress(0)
+
+	if err := migrator.Up(context.Background()); err != nil {
+		t.Fatalf("unexpected error performing up migration: %s", err)
+	}
+	assertProgress(0.5)
+
+	if err := migrator.Up(context.Background()); err != nil {
+		t.Fatalf("unexpected error performing up migration: %s", err)
+	}
+	assertProgress(1)
+
+	assertNumberOfRecordingTimes(numSeries * 12)
+
+	if err := migrator.Down(context.Background()); err != nil {
+		t.Fatalf("unexpected error performing down migration: %s", err)
+	}
+	assertProgress(0.5)
+
+	if err := migrator.Down(context.Background()); err != nil {
+		t.Fatalf("unexpected error performing down migration: %s", err)
+	}
+	assertProgress(0)
+}

--- a/enterprise/internal/oobmigration/migrations/insights/recording_times_test.go
+++ b/enterprise/internal/oobmigration/migrations/insights/recording_times_test.go
@@ -1,0 +1,270 @@
+package insights
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hexops/autogold"
+)
+
+func Test_calculateRecordingTimes(t *testing.T) {
+	defaultInterval := timeInterval{
+		unit:  month,
+		value: 2,
+	}
+	createdAt := time.Date(2022, 11, 1, 0, 0, 0, 0, time.UTC)
+	defaultTimes := buildRecordingTimes(12, defaultInterval, createdAt)
+	stringDefaultTimes := []string{
+		"2021-01-01 00:00:00 +0000 UTC",
+		"2021-03-01 00:00:00 +0000 UTC",
+		"2021-05-01 00:00:00 +0000 UTC",
+		"2021-07-01 00:00:00 +0000 UTC",
+		"2021-09-01 00:00:00 +0000 UTC",
+		"2021-11-01 00:00:00 +0000 UTC",
+		"2022-01-01 00:00:00 +0000 UTC",
+		"2022-03-01 00:00:00 +0000 UTC",
+		"2022-05-01 00:00:00 +0000 UTC",
+		"2022-07-01 00:00:00 +0000 UTC",
+		"2022-09-01 00:00:00 +0000 UTC",
+		"2022-11-01 00:00:00 +0000 UTC",
+	}
+
+	stringify := func(times []time.Time) []string {
+		s := make([]string, 0, len(times))
+		for _, t := range times {
+			s = append(s, t.String())
+		}
+		return s
+	}
+	if diff := cmp.Diff(stringDefaultTimes, stringify(defaultTimes)); diff != "" {
+		t.Fatalf("test setup is tainted: got diff %v", diff)
+	}
+
+	testCases := []struct {
+		lastRecordedAt time.Time
+		interval       timeInterval
+		existingTimes  []time.Time
+		want           autogold.Value
+	}{
+		{
+			interval: defaultInterval,
+			want:     autogold.Want("no existing times returns all generated times", stringDefaultTimes),
+		},
+		{
+			interval:       defaultInterval,
+			lastRecordedAt: createdAt.AddDate(0, 5, 3),
+			want: autogold.Want("no existing times and lastRecordedAt returns generated times",
+				append(
+					stringDefaultTimes,
+					"2023-01-01 00:00:00 +0000 UTC",
+					"2023-03-01 00:00:00 +0000 UTC",
+				),
+			),
+		},
+		{
+			interval:      timeInterval{unit: week, value: 2},
+			existingTimes: []time.Time{time.Date(2022, 10, 21, 0, 0, 0, 0, time.UTC)}, // existing point within half an interval
+			want: autogold.Want("2 week intervals with existing time returns modified list", []string{
+				"2022-05-31 00:00:00 +0000 UTC",
+				"2022-06-14 00:00:00 +0000 UTC",
+				"2022-06-28 00:00:00 +0000 UTC",
+				"2022-07-12 00:00:00 +0000 UTC",
+				"2022-07-26 00:00:00 +0000 UTC",
+				"2022-08-09 00:00:00 +0000 UTC",
+				"2022-08-23 00:00:00 +0000 UTC",
+				"2022-09-06 00:00:00 +0000 UTC",
+				"2022-09-20 00:00:00 +0000 UTC",
+				"2022-10-04 00:00:00 +0000 UTC",
+				"2022-10-21 00:00:00 +0000 UTC", // this is the modified rough point
+				"2022-11-01 00:00:00 +0000 UTC",
+			}),
+		},
+		{
+			interval:      timeInterval{unit: hour, value: 2},
+			existingTimes: []time.Time{time.Date(2022, 9, 31, 03, 50, 0, 0, time.UTC), time.Date(2022, 10, 31, 18, 26, 0, 0, time.UTC)},
+			want: autogold.Want("2 hour intervals with existing time returns modified list", []string{
+				"2022-10-31 02:00:00 +0000 UTC",
+				"2022-10-31 04:00:00 +0000 UTC",
+				"2022-10-31 06:00:00 +0000 UTC",
+				"2022-10-31 08:00:00 +0000 UTC",
+				"2022-10-31 10:00:00 +0000 UTC",
+				"2022-10-31 12:00:00 +0000 UTC",
+				"2022-10-31 14:00:00 +0000 UTC",
+				"2022-10-31 16:00:00 +0000 UTC",
+				"2022-10-31 18:26:00 +0000 UTC", // this is the modified rough point
+				"2022-10-31 20:00:00 +0000 UTC",
+				"2022-10-31 22:00:00 +0000 UTC",
+				"2022-11-01 00:00:00 +0000 UTC",
+			}),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.want.Name(), func(t *testing.T) {
+			calculated := calculateRecordingTimes(createdAt, tc.lastRecordedAt, tc.interval, tc.existingTimes)
+			tc.want.Equal(t, stringify(calculated))
+		})
+	}
+}
+
+func Test_buildRecordingTimes(t *testing.T) {
+	startTime := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
+
+	buildFrameTest := func(count int, interval timeInterval, current time.Time) []string {
+		got := buildRecordingTimes(count, interval, current)
+		return convert(got)
+	}
+
+	testCases := []struct {
+		numPoints int
+		interval  timeInterval
+		startTime time.Time
+		want      autogold.Value
+	}{
+		{
+			numPoints: 1,
+			interval:  timeInterval{month, 1},
+			startTime: startTime,
+			want: autogold.Want("one point", []string{
+				"2021-12-01 00:00:00 +0000 UTC",
+			}),
+		},
+		{
+			numPoints: 2,
+			interval:  timeInterval{month, 1},
+			startTime: startTime,
+			want: autogold.Want("two points 1 month intervals", []string{
+				"2021-11-01 00:00:00 +0000 UTC",
+				"2021-12-01 00:00:00 +0000 UTC",
+			}),
+		},
+		{
+			numPoints: 6,
+			interval:  timeInterval{month, 1},
+			startTime: startTime,
+			want: autogold.Want("6 points 1 month intervals", []string{
+				"2021-07-01 00:00:00 +0000 UTC",
+				"2021-08-01 00:00:00 +0000 UTC",
+				"2021-09-01 00:00:00 +0000 UTC",
+				"2021-10-01 00:00:00 +0000 UTC",
+				"2021-11-01 00:00:00 +0000 UTC",
+				"2021-12-01 00:00:00 +0000 UTC",
+			}),
+		},
+		{
+			numPoints: 12,
+			interval:  timeInterval{week, 2},
+			startTime: startTime,
+			want: autogold.Want("12 points 2 week intervals", []string{
+				"2021-06-30 00:00:00 +0000 UTC",
+				"2021-07-14 00:00:00 +0000 UTC",
+				"2021-07-28 00:00:00 +0000 UTC",
+				"2021-08-11 00:00:00 +0000 UTC",
+				"2021-08-25 00:00:00 +0000 UTC",
+				"2021-09-08 00:00:00 +0000 UTC",
+				"2021-09-22 00:00:00 +0000 UTC",
+				"2021-10-06 00:00:00 +0000 UTC",
+				"2021-10-20 00:00:00 +0000 UTC",
+				"2021-11-03 00:00:00 +0000 UTC",
+				"2021-11-17 00:00:00 +0000 UTC",
+				"2021-12-01 00:00:00 +0000 UTC",
+			}),
+		},
+		{
+			numPoints: 6,
+			interval:  timeInterval{day, 2},
+			startTime: startTime,
+			want: autogold.Want("6 points 2 day intervals", []string{
+				"2021-11-21 00:00:00 +0000 UTC",
+				"2021-11-23 00:00:00 +0000 UTC",
+				"2021-11-25 00:00:00 +0000 UTC",
+				"2021-11-27 00:00:00 +0000 UTC",
+				"2021-11-29 00:00:00 +0000 UTC",
+				"2021-12-01 00:00:00 +0000 UTC",
+			}),
+		},
+		{
+			numPoints: 6,
+			interval:  timeInterval{hour, 2},
+			startTime: startTime,
+			want: autogold.Want("6 points 2 hour intervals", []string{
+				"2021-11-30 14:00:00 +0000 UTC",
+				"2021-11-30 16:00:00 +0000 UTC",
+				"2021-11-30 18:00:00 +0000 UTC",
+				"2021-11-30 20:00:00 +0000 UTC",
+				"2021-11-30 22:00:00 +0000 UTC",
+				"2021-12-01 00:00:00 +0000 UTC",
+			}),
+		},
+		{
+			numPoints: 6,
+			interval:  timeInterval{year, 1},
+			startTime: startTime,
+			want: autogold.Want("6 points 1 year intervals", []string{
+				"2016-12-01 00:00:00 +0000 UTC",
+				"2017-12-01 00:00:00 +0000 UTC",
+				"2018-12-01 00:00:00 +0000 UTC",
+				"2019-12-01 00:00:00 +0000 UTC",
+				"2020-12-01 00:00:00 +0000 UTC",
+				"2021-12-01 00:00:00 +0000 UTC",
+			}),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.want.Name(), func(t *testing.T) {
+			tc.want.Equal(t, buildFrameTest(tc.numPoints, tc.interval, tc.startTime))
+		})
+	}
+}
+
+func Test_buildRecordingTimesBetween(t *testing.T) {
+	fromTime := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	testCases := []struct {
+		from     time.Time
+		to       time.Time
+		interval timeInterval
+		want     autogold.Value
+	}{
+		{
+			fromTime,
+			fromTime.AddDate(0, 1, 0),
+			timeInterval{week, 1},
+			autogold.Want("one month at 1 week intervals", []string{
+				"2021-01-01 00:00:00 +0000 UTC",
+				"2021-01-08 00:00:00 +0000 UTC",
+				"2021-01-15 00:00:00 +0000 UTC",
+				"2021-01-22 00:00:00 +0000 UTC",
+				"2021-01-29 00:00:00 +0000 UTC",
+			}),
+		},
+		{
+			fromTime,
+			fromTime.AddDate(0, 6, 0),
+			timeInterval{week, 4},
+			autogold.Want("6 months at 4 week intervals", []string{
+				"2021-01-01 00:00:00 +0000 UTC",
+				"2021-01-29 00:00:00 +0000 UTC",
+				"2021-02-26 00:00:00 +0000 UTC",
+				"2021-03-26 00:00:00 +0000 UTC",
+				"2021-04-23 00:00:00 +0000 UTC",
+				"2021-05-21 00:00:00 +0000 UTC",
+				"2021-06-18 00:00:00 +0000 UTC",
+			}),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.want.Name(), func(t *testing.T) {
+			got := buildRecordingTimesBetween(tc.from, tc.to, tc.interval)
+			tc.want.Equal(t, convert(got))
+		})
+	}
+}
+
+func convert(times []time.Time) []string {
+	var got []string
+	for _, result := range times {
+		got = append(got, result.String())
+	}
+	return got
+}

--- a/enterprise/internal/oobmigration/migrations/insights/recording_times_test.go
+++ b/enterprise/internal/oobmigration/migrations/insights/recording_times_test.go
@@ -261,6 +261,39 @@ func Test_buildRecordingTimesBetween(t *testing.T) {
 	}
 }
 
+func TestBuildAndCalculate(t *testing.T) {
+	// This is a unit test based on a real insight to double-check a migration would return the desired times.
+
+	// 2022-08-04 20:10:04.573293
+	createdAt := time.Date(2022, 8, 4, 20, 10, 4, 573293, time.UTC)
+	// 2022-10-27 22:25:25.411322
+	lastRecordedAt := time.Date(2022, 10, 28, 22, 25, 25, 411322, time.UTC)
+
+	interval := timeInterval{week, 3}
+
+	existingPoints := []time.Time{
+		time.Date(2021, 12, 6, 0, 0, 0, 0, time.UTC),
+		time.Date(2022, 1, 6, 0, 0, 0, 0, time.UTC),
+		time.Date(2022, 1, 27, 0, 0, 0, 0, time.UTC),
+		time.Date(2022, 2, 17, 0, 0, 0, 0, time.UTC),
+		time.Date(2022, 3, 10, 0, 0, 0, 0, time.UTC),
+		time.Date(2022, 3, 31, 0, 0, 0, 0, time.UTC),
+		time.Date(2022, 4, 21, 0, 0, 0, 0, time.UTC),
+		time.Date(2022, 5, 12, 0, 0, 0, 0, time.UTC),
+		time.Date(2022, 6, 2, 0, 0, 0, 0, time.UTC),
+		time.Date(2022, 6, 23, 0, 0, 0, 0, time.UTC),
+		time.Date(2022, 7, 14, 0, 0, 0, 0, time.UTC),
+		time.Date(2022, 8, 4, 0, 0, 0, 0, time.UTC),
+		time.Date(2022, 8, 25, 21, 7, 55, 558154, time.UTC),
+		time.Date(2022, 9, 15, 21, 12, 38, 902339, time.UTC),
+		time.Date(2022, 9, 17, 18, 35, 8, 922635, time.UTC),
+		time.Date(2022, 10, 27, 22, 25, 30, 390084, time.UTC),
+	}
+
+	calculated := calculateRecordingTimes(createdAt, lastRecordedAt, interval, existingPoints)
+	autogold.Want("calculated matches existing", convert(existingPoints)).Equal(t, convert(calculated))
+}
+
 func convert(times []time.Time) []string {
 	var got []string
 	for _, result := range times {

--- a/enterprise/internal/oobmigration/migrations/insights/recording_times_test.go
+++ b/enterprise/internal/oobmigration/migrations/insights/recording_times_test.go
@@ -272,7 +272,7 @@ func TestBuildAndCalculate(t *testing.T) {
 	interval := timeInterval{week, 3}
 
 	existingPoints := []time.Time{
-		time.Date(2021, 12, 6, 0, 0, 0, 0, time.UTC),
+		time.Date(2021, 12, 16, 0, 0, 0, 0, time.UTC),
 		time.Date(2022, 1, 6, 0, 0, 0, 0, time.UTC),
 		time.Date(2022, 1, 27, 0, 0, 0, 0, time.UTC),
 		time.Date(2022, 2, 17, 0, 0, 0, 0, time.UTC),
@@ -286,7 +286,7 @@ func TestBuildAndCalculate(t *testing.T) {
 		time.Date(2022, 8, 4, 0, 0, 0, 0, time.UTC),
 		time.Date(2022, 8, 25, 21, 7, 55, 558154, time.UTC),
 		time.Date(2022, 9, 15, 21, 12, 38, 902339, time.UTC),
-		time.Date(2022, 9, 17, 18, 35, 8, 922635, time.UTC),
+		time.Date(2022, 10, 06, 00, 00, 00, 00, time.UTC),
 		time.Date(2022, 10, 27, 22, 25, 30, 390084, time.UTC),
 	}
 

--- a/enterprise/internal/oobmigration/migrations/register.go
+++ b/enterprise/internal/oobmigration/migrations/register.go
@@ -93,5 +93,6 @@ func registerEnterpriseMigrators(runner *oobmigration.Runner, noDelay bool, deps
 		codeintel.NewReferencesLocationsCountMigrator(deps.codeIntelStore, 1000, 0),
 		codeintel.NewDocumentColumnSplitMigrator(deps.codeIntelStore, 100, 0),
 		insights.NewMigrator(deps.store, deps.insightsStore),
+		insights.NewRecordingTimesMigrator(deps.insightsStore, 500),
 	})
 }

--- a/internal/oobmigration/oobmigrations.yaml
+++ b/internal/oobmigration/oobmigrations.yaml
@@ -88,3 +88,11 @@
   introduced_version_minor: 43
   deprecated_version_major: 4
   deprecated_version_minor: 0
+- id: 17
+  team: code-insights
+  component: codeinsights-db.insight_series
+  description: Save historical recording times for all existing insights
+  non_destructive: true
+  is_enterprise: true
+  introduced_version_major: 4
+  introduced_version_minor: 2


### PR DESCRIPTION
closes #43496 (again)

the (second) bug was that on second iteration through sql rows I iterated through `rows.Next()` rather than `recordingRows.Next()`, which meant we would _always_ reuse generated recording times rather than any existing timestamps.

## Test plan

Manually stepped through all the logic. Wrote a unit test. Manually ran the migration again on a local instance.