### PR TITLE
Use unpack.go for JVM syncer

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -122,7 +122,7 @@ func (s *jvmPackagesSyncer) Download(ctx context.Context, dir string, dep reposo
 }
 
 func unzipJarFile(jarPath, destination string) (err error) {
-	logger := log.Scoped("unzipJarFile", "unzipJarFile the given jvm archive into workDir")
+	logger := log.Scoped("unzipJarFile", "unzipJarFile unpacks the given jvm archive into workDir")
 	workDir := strings.TrimSuffix(destination, string(os.PathSeparator)) + string(os.PathSeparator)
 
 	zipFile, err := os.ReadFile(jarPath)

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/internal/unpack"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
@@ -120,22 +122,40 @@ func (s *jvmPackagesSyncer) Download(ctx context.Context, dir string, dep reposo
 }
 
 func unzipJarFile(jarPath, destination string) (err error) {
-	reader, err := zip.OpenReader(jarPath)
+	logger := log.Scoped("unzipJarFile", "unzipJarFile the given jvm archive into workDir")
+	workDir := strings.TrimSuffix(destination, string(os.PathSeparator)) + string(os.PathSeparator)
+
+	zipFile, err := os.ReadFile(jarPath)
+	if err != nil {
+		errors.Wrap(err, "bad jvm package")
+	}
+
+	r := bytes.NewReader(zipFile)
+	opts := unpack.Opts{
+		SkipInvalid: true,
+		Filter: func(path string, file fs.FileInfo) bool {
+			size := file.Size()
+
+			const sizeLimit = 15 * 1024 * 1024
+			slogger := logger.With(
+				log.String("path", file.Name()),
+				log.Int64("size", size),
+				log.Float64("limit", sizeLimit),
+			)
+			if size >= sizeLimit {
+				slogger.Warn("skipping large file in JVM package")
+				return false
+			}
+
+			_, malicious := isPotentiallyMaliciousFilepathInArchive(path, workDir)
+			return !malicious
+		},
+	}
+
+	err = unpack.Zip(r, int64(len(zipFile)), workDir, opts)
+
 	if err != nil {
 		return err
-	}
-	defer reader.Close()
-	destinationDirectory := strings.TrimSuffix(destination, string(os.PathSeparator)) + string(os.PathSeparator)
-
-	for _, file := range reader.File {
-		cleanedOutputPath, isPotentiallyMalicious := isPotentiallyMaliciousFilepathInArchive(file.Name, destinationDirectory)
-		if isPotentiallyMalicious {
-			continue
-		}
-		err := copyZipFileEntry(file, cleanedOutputPath)
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -108,7 +109,7 @@ fi
 	return coursierPath.Name()
 }
 
-var maliciousPaths []string = []string{
+var maliciousPaths = []string{
 	// Absolute paths
 	"/sh", "/usr/bin/sh",
 	// Paths into .git which may trigger when git runs a hook
@@ -143,8 +144,12 @@ func TestNoMaliciousFiles(t *testing.T) {
 	assert.NotNil(t, err)
 
 	dirEntries, err := os.ReadDir(extractPath)
-	baseline := map[string]int{"lsif-java.json": 0, strings.Split(harmlessPath, string(os.PathSeparator))[0]: 0}
 	assert.Nil(t, err)
+
+	_, err = filepath.EvalSymlinks(filepath.Join(extractPath, "symlink"))
+	assert.Error(t, err)
+
+	baseline := map[string]int{"lsif-java.json": 0, strings.Split(harmlessPath, string(os.PathSeparator))[0]: 0}
 	paths := map[string]int{}
 	for _, dirEntry := range dirEntries {
 		paths[dirEntry.Name()] = 0
@@ -165,6 +170,16 @@ func createMaliciousJar(t *testing.T, name string) {
 		_, err = writer.Create(filepath)
 		assert.Nil(t, err)
 	}
+
+	os.Symlink("/etc/passwd", "symlink")
+	defer os.Remove("symlink")
+
+	fi, err := os.Lstat("symlink")
+	header, err := zip.FileInfoHeader(fi)
+	_, err = writer.CreateRaw(header)
+
+	assert.Nil(t, err)
+
 	_, err = writer.Create(harmlessPath)
 	assert.Nil(t, err)
 }

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages_test.go
@@ -174,8 +174,8 @@ func createMaliciousJar(t *testing.T, name string) {
 	os.Symlink("/etc/passwd", "symlink")
 	defer os.Remove("symlink")
 
-	fi, err := os.Lstat("symlink")
-	header, err := zip.FileInfoHeader(fi)
+	fi, _ := os.Lstat("symlink")
+	header, _ := zip.FileInfoHeader(fi)
 	_, err = writer.CreateRaw(header)
 
 	assert.Nil(t, err)

--- a/cmd/gitserver/server/vcs_syncer_python_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_python_packages.go
@@ -112,7 +112,7 @@ func unpackPythonPackage(pkg []byte, packageURL, workDir string) error {
 				log.Float64("limit", sizeLimit),
 			)
 			if size >= sizeLimit {
-				slogger.Warn("skipping large file in npm package")
+				slogger.Warn("skipping large file in python package")
 				return false
 			}
 


### PR DESCRIPTION
Using `unpack.go` for extracting JVM packages. For more information see https://github.com/sourcegraph/security-issues/issues/326.

## Test plan

- [x] ci tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
