### PR TITLE
packages: reduce use of io.ReadAll for crate packages

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_rust_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_rust_packages.go
@@ -71,6 +71,7 @@ func (s *rustDependencySource) Download(ctx context.Context, dir string, dep rep
 	if err != nil {
 		return errors.Wrapf(err, "error downloading crate with URL '%s'", packageURL)
 	}
+	defer pkg.Close()
 
 	// TODO: we could add `.sourcegraph/repo.json` here with more information,
 	// to be used by rust analyzer

--- a/cmd/gitserver/server/vcs_syncer_rust_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_rust_packages.go
@@ -1,9 +1,9 @@
 package server
 
 import (
-	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/fs"
 
 	"github.com/sourcegraph/log"
@@ -58,8 +58,8 @@ func (rustDependencySource) ParseVersionedPackageFromConfiguration(dep string) (
 
 func (rustDependencySource) ParsePackageFromName(name reposource.PackageName) (reposource.Package, error) {
 	return reposource.ParseRustPackageFromName(name)
-
 }
+
 func (rustDependencySource) ParsePackageFromRepoName(repoName api.RepoName) (reposource.Package, error) {
 	return reposource.ParseRustPackageFromRepoName(repoName)
 }
@@ -83,8 +83,7 @@ func (s *rustDependencySource) Download(ctx context.Context, dir string, dep rep
 
 // unpackRustPackages unpacks the given rust package archive into workDir, skipping any
 // files that aren't valid or that are potentially malicious.
-func unpackRustPackage(pkg []byte, workDir string) error {
-	r := bytes.NewReader(pkg)
+func unpackRustPackage(pkg io.Reader, workDir string) error {
 	opts := unpack.Opts{
 		SkipInvalid:    true,
 		SkipDuplicates: true,
@@ -101,7 +100,7 @@ func unpackRustPackage(pkg []byte, workDir string) error {
 		},
 	}
 
-	if err := unpack.Tgz(r, workDir, opts); err != nil {
+	if err := unpack.Tgz(pkg, workDir, opts); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Continuation of https://github.com/sourcegraph/sourcegraph/pull/44497 but for rust crates

## Test plan

Unit tests and prod :trollface: 
