### PR TITLE
packages: reduce use of io.ReadAll for npm packages

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -48,8 +48,10 @@ type npmPackagesSyncer struct {
 	client npm.Client
 }
 
-var _ packagesSource = &npmPackagesSyncer{}
-var _ packagesDownloadSource = &npmPackagesSyncer{}
+var (
+	_ packagesSource         = &npmPackagesSyncer{}
+	_ packagesDownloadSource = &npmPackagesSyncer{}
+)
 
 func (npmPackagesSyncer) ParseVersionedPackageFromNameAndVersion(name reposource.PackageName, version string) (reposource.VersionedPackage, error) {
 	return reposource.ParseNpmVersionedPackage(string(name) + "@" + version)
@@ -62,6 +64,7 @@ func (npmPackagesSyncer) ParseVersionedPackageFromConfiguration(dep string) (rep
 func (s *npmPackagesSyncer) ParsePackageFromName(name reposource.PackageName) (reposource.Package, error) {
 	return s.ParsePackageFromRepoName(api.RepoName("npm/" + strings.TrimPrefix(string(name), "@")))
 }
+
 func (npmPackagesSyncer) ParsePackageFromRepoName(repoName api.RepoName) (reposource.Package, error) {
 	pkg, err := reposource.ParseNpmPackageFromRepoURL(repoName)
 	if err != nil {
@@ -103,6 +106,7 @@ func (s *npmPackagesSyncer) Download(ctx context.Context, dir string, dep reposo
 			return err
 		}
 	}
+
 	tgz, err := npm.FetchSources(ctx, s.client, npmDep)
 	if err != nil {
 		return errors.Wrap(err, "fetch tarball")
@@ -110,7 +114,7 @@ func (s *npmPackagesSyncer) Download(ctx context.Context, dir string, dep reposo
 	defer tgz.Close()
 
 	if err = decompressTgz(tgz, dir); err != nil {
-		return errors.Wrapf(err, "failed to decompress gzipped tarball for %s", dep)
+		return errors.Wrapf(err, "failed to decompress gzipped tarball for %s", dep.VersionedPackageSyntax())
 	}
 
 	return nil
@@ -122,6 +126,7 @@ func (s *npmPackagesSyncer) Download(ctx context.Context, dir string, dep reposo
 // dir/<blah> for the same directory 'dir', the 'dir' will be stripped.
 func decompressTgz(tgz io.Reader, destination string) error {
 	logger := log.Scoped("decompressTgz", "Decompress a tarball at tgzPath, putting the files under destination.")
+
 	err := unpack.Tgz(tgz, destination, unpack.Opts{
 		SkipInvalid: true,
 		Filter: func(path string, file fs.FileInfo) bool {
@@ -129,14 +134,12 @@ func decompressTgz(tgz io.Reader, destination string) error {
 
 			const sizeLimit = 15 * 1024 * 1024
 
-			slogger := logger.With(
-				log.String("path", file.Name()),
-				log.Int64("size", size),
-				log.Int("limit", sizeLimit),
-			)
-
 			if size >= sizeLimit {
-				slogger.Warn("skipping large file in npm package")
+				logger.With(
+					log.String("path", file.Name()),
+					log.Int64("size", size),
+					log.Int("limit", sizeLimit),
+				).Warn("skipping large file in npm package")
 				return false
 			}
 
@@ -144,7 +147,6 @@ func decompressTgz(tgz io.Reader, destination string) error {
 			return !malicious
 		},
 	})
-
 	if err != nil {
 		return err
 	}

--- a/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -97,9 +98,9 @@ func TestNpmCloneCommand(t *testing.T) {
 				},
 			},
 		},
-		Tarballs: map[string][]byte{
-			exampleNpmVersion:  tgz1,
-			exampleNpmVersion2: tgz2,
+		Tarballs: map[string]io.Reader{
+			exampleNpmVersion:  bytes.NewReader(tgz1),
+			exampleNpmVersion2: bytes.NewReader(tgz2),
 		},
 	}
 
@@ -235,7 +236,7 @@ var _ fs.FileInfo = &fileInfo{}
 
 func (info *fileInfo) Name() string       { return path.Base(info.path) }
 func (info *fileInfo) Size() int64        { return int64(len(info.contents)) }
-func (info *fileInfo) Mode() fs.FileMode  { return 0600 }
+func (info *fileInfo) Mode() fs.FileMode  { return 0o600 }
 func (info *fileInfo) ModTime() time.Time { return time.Unix(0, 0) }
 func (info *fileInfo) IsDir() bool        { return false }
 func (info *fileInfo) Sys() any           { return nil }


### PR DESCRIPTION
Continuation of https://github.com/sourcegraph/sourcegraph/pull/44497 but for npm packages

## Test plan

Unit test and prod :trollface: 
