### PR TITLE
batches: more a11y list cleanup

### DIFF
--- a/client/web/src/enterprise/batches/BatchSpecNode.module.scss
+++ b/client/web/src/enterprise/batches/BatchSpecNode.module.scss
@@ -1,4 +1,6 @@
 .node {
+    display: contents;
+
     &__expanded-section {
         background-color: var(--body-bg);
         grid-column: 1 / -1;

--- a/client/web/src/enterprise/batches/BatchSpecNode.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecNode.tsx
@@ -44,7 +44,7 @@ export const BatchSpecNode: React.FunctionComponent<React.PropsWithChildren<Batc
     }, [isExpanded])
 
     return (
-        <>
+        <li className={styles.node}>
             <span className={styles.nodeSeparator} />
             <Button
                 variant="icon"
@@ -114,7 +114,7 @@ export const BatchSpecNode: React.FunctionComponent<React.PropsWithChildren<Batc
                     />
                 </div>
             )}
-        </>
+        </li>
     )
 }
 

--- a/client/web/src/enterprise/batches/BatchSpecsPage.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecsPage.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 import { RouteComponentProps } from 'react-router'
 
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Container, PageHeader, H5, Icon } from '@sourcegraph/wildcard'
+import { Container, PageHeader, H3, H5, Icon } from '@sourcegraph/wildcard'
 
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../../components/FilteredConnection'
 import { PageTitle } from '../../components/PageTitle'
@@ -106,7 +106,6 @@ export const BatchSpecList: React.FunctionComponent<React.PropsWithChildren<Batc
             noun="batch spec"
             pluralNoun="batch specs"
             listClassName={classNames(styles.specsGrid, 'test-batches-executions')}
-            listComponent="div"
             withCenteredSummary={true}
             headComponent={Header}
             cursorPaging={true}
@@ -119,9 +118,15 @@ export const BatchSpecList: React.FunctionComponent<React.PropsWithChildren<Batc
 const Header: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
     <>
         <span className="d-none d-md-block" />
-        <H5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">State</H5>
-        <H5 className="p-2 d-none d-md-block text-uppercase text-nowrap">Batch spec</H5>
-        <H5 className="d-none d-md-block text-uppercase text-center text-nowrap">Execution time</H5>
+        <H5 as={H3} aria-hidden={true} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
+            State
+        </H5>
+        <H5 as={H3} aria-hidden={true} className="p-2 d-none d-md-block text-uppercase text-nowrap">
+            Batch spec
+        </H5>
+        <H5 as={H3} aria-hidden={true} className="d-none d-md-block text-uppercase text-center text-nowrap">
+            Execution time
+        </H5>
     </>
 )
 

--- a/client/web/src/enterprise/batches/close/BatchChangeCloseChangesetsList.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseChangesetsList.tsx
@@ -134,7 +134,7 @@ export const BatchChangeCloseChangesetsList: React.FunctionComponent<React.Props
 
     return (
         <div className="list-group position-relative" ref={nextContainerElement}>
-            <Container>
+            <Container role="region" aria-label="affected changesets">
                 <FilteredConnection<
                     ChangesetFields,
                     Omit<ChangesetCloseNodeProps, 'node'>,
@@ -159,7 +159,6 @@ export const BatchChangeCloseChangesetsList: React.FunctionComponent<React.Props
                     history={history}
                     location={location}
                     useURLQuery={true}
-                    listComponent="div"
                     listClassName={styles.batchChangeCloseChangesetsListGrid}
                     headComponent={
                         willClose ? BatchChangeCloseHeaderWillCloseChangesets : BatchChangeCloseHeaderWillKeepChangesets

--- a/client/web/src/enterprise/batches/close/BatchChangeCloseHeader.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { H2, H5 } from '@sourcegraph/wildcard'
+import { H2, H3, H5 } from '@sourcegraph/wildcard'
 
 import styles from './BatchChangeCloseHeader.module.scss'
 
@@ -13,11 +13,21 @@ export interface BatchChangeCloseHeaderProps {
 const BatchChangeCloseHeader: React.FunctionComponent<React.PropsWithChildren<BatchChangeCloseHeaderProps>> = () => (
     <>
         <span className="d-none d-md-block" />
-        <H5 className="d-none d-md-block text-uppercase text-center text-nowrap">Action</H5>
-        <H5 className="d-none d-md-block text-uppercase text-nowrap">Changeset information</H5>
-        <H5 className="d-none d-md-block text-uppercase text-center text-nowrap">Check state</H5>
-        <H5 className="d-none d-md-block text-uppercase text-center text-nowrap">Review state</H5>
-        <H5 className="d-none d-md-block text-uppercase text-center text-nowrap">Changes</H5>
+        <H5 as={H3} aria-hidden={true} className="d-none d-md-block text-uppercase text-center text-nowrap">
+            Action
+        </H5>
+        <H5 as={H3} aria-hidden={true} className="d-none d-md-block text-uppercase text-nowrap">
+            Changeset information
+        </H5>
+        <H5 as={H3} aria-hidden={true} className="d-none d-md-block text-uppercase text-center text-nowrap">
+            Check state
+        </H5>
+        <H5 as={H3} aria-hidden={true} className="d-none d-md-block text-uppercase text-center text-nowrap">
+            Review state
+        </H5>
+        <H5 as={H3} aria-hidden={true} className="d-none d-md-block text-uppercase text-center text-nowrap">
+            Changes
+        </H5>
     </>
 )
 

--- a/client/web/src/enterprise/batches/close/ChangesetCloseNode.module.scss
+++ b/client/web/src/enterprise/batches/close/ChangesetCloseNode.module.scss
@@ -1,6 +1,8 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
 .changeset-close-node {
+    display: contents;
+
     &__separator {
         // Make it full width in the current row.
         grid-column: 1 / -1;

--- a/client/web/src/enterprise/batches/close/ChangesetCloseNode.tsx
+++ b/client/web/src/enterprise/batches/close/ChangesetCloseNode.tsx
@@ -32,19 +32,13 @@ export interface ChangesetCloseNodeProps extends ThemeProps {
 export const ChangesetCloseNode: React.FunctionComponent<React.PropsWithChildren<ChangesetCloseNodeProps>> = ({
     node,
     ...props
-}) => {
-    if (node.__typename === 'ExternalChangeset') {
-        return (
-            <>
-                <span className={styles.changesetCloseNodeSeparator} />
-                <ExternalChangesetCloseNode node={node} {...props} />
-            </>
-        )
-    }
-    return (
-        <>
-            <span className={styles.changesetCloseNodeSeparator} />
+}) => (
+    <li className={styles.changesetCloseNode}>
+        <span className={styles.changesetCloseNodeSeparator} />
+        {node.__typename === 'ExternalChangeset' ? (
+            <ExternalChangesetCloseNode node={node} {...props} />
+        ) : (
             <HiddenExternalChangesetCloseNode node={node} {...props} />
-        </>
-    )
-}
+        )}
+    </li>
+)

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -187,14 +187,6 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
                                 />
                             </div>
                             {error && <ConnectionError errors={[error.message]} />}
-                            {/*
-                            The connection list is a `div` instead of a `ul` because `ul` doesn't support css grid and we need to grid
-                            to live on the wrapper as opposed to each `BatchChangeNode`.
-
-                            This is because the current grid pattern gets broken when the individual child of the `ConnectionList` component
-                            has a grid.
-                            Discussion: https://github.com/sourcegraph/sourcegraph/pull/34716#pullrequestreview-959790114
-                        */}
                             <ConnectionList
                                 className={classNames(styles.grid, isExecutionEnabled ? styles.wide : styles.narrow)}
                                 aria-label="batch changes"

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.tsx
@@ -155,7 +155,6 @@ export const PreviewList: React.FunctionComponent<React.PropsWithChildren<Props>
                 history={history}
                 location={location}
                 useURLQuery={true}
-                listComponent="ul"
                 listClassName={styles.previewListGrid}
                 headComponent={PreviewListHeader}
                 headComponentProps={{

--- a/client/web/src/enterprise/batches/repo/BatchChangeNode.module.scss
+++ b/client/web/src/enterprise/batches/repo/BatchChangeNode.module.scss
@@ -1,4 +1,6 @@
 .node {
+    display: contents;
+
     &__full-width {
         grid-column: 1 / -1;
     }

--- a/client/web/src/enterprise/batches/repo/BatchChangeNode.tsx
+++ b/client/web/src/enterprise/batches/repo/BatchChangeNode.tsx
@@ -61,7 +61,7 @@ export const BatchChangeNode: React.FunctionComponent<React.PropsWithChildren<Ba
         ) : null
 
     return (
-        <>
+        <li className={styles.node}>
             <span className={styles.nodeSeparator} />
             <div className={styles.nodeFullWidth}>
                 <div className="mt-1 mb-2 d-md-flex d-block align-items-baseline">
@@ -96,6 +96,6 @@ export const BatchChangeNode: React.FunctionComponent<React.PropsWithChildren<Ba
             ))}
             {moreChangesetsIndicator}
             <div className={styles.nodeBottomSpacer} />
-        </>
+        </li>
     )
 }

--- a/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.tsx
+++ b/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.tsx
@@ -1,10 +1,12 @@
 import React, { useMemo } from 'react'
 
+import VisuallyHidden from '@reach/visually-hidden'
 import * as H from 'history'
 
+import { pluralize } from '@sourcegraph/common'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { PageHeader, H2, useObservable, Text } from '@sourcegraph/wildcard'
+import { PageHeader, H2, useObservable, Text, H4 } from '@sourcegraph/wildcard'
 
 import { BatchChangesIcon } from '../../../batches/icons'
 import { DiffStat } from '../../../components/diff/DiffStat'
@@ -94,9 +96,37 @@ const StatsBar: React.FunctionComponent<React.PropsWithChildren<StatsBarProps>> 
 }) => (
     <div className="d-flex flex-wrap align-items-center">
         <BatchChangeStatsTotalAction count={total} />
-        <ChangesetStatusOpen className={ACTION_CLASSNAMES} label={`${(draft + open).toString()} Open`} />
-        <ChangesetStatusUnpublished className={ACTION_CLASSNAMES} label={`${unpublished} Unpublished`} />
-        <ChangesetStatusClosed className={ACTION_CLASSNAMES} label={`${closed} Closed`} />
-        <ChangesetStatusMerged className={ACTION_CLASSNAMES} label={`${merged} Merged`} />
+        <ChangesetStatusOpen
+            className={ACTION_CLASSNAMES}
+            label={
+                <H4 className="font-weight-normal text-muted m-0">
+                    {draft + open} <VisuallyHidden>{pluralize('changeset', draft + open)}</VisuallyHidden> open
+                </H4>
+            }
+        />
+        <ChangesetStatusUnpublished
+            className={ACTION_CLASSNAMES}
+            label={
+                <H4 className="font-weight-normal text-muted m-0">
+                    {unpublished} <VisuallyHidden>{pluralize('changeset', unpublished)}</VisuallyHidden> unpublished
+                </H4>
+            }
+        />
+        <ChangesetStatusClosed
+            className={ACTION_CLASSNAMES}
+            label={
+                <H4 className="font-weight-normal text-muted m-0">
+                    {closed} <VisuallyHidden>{pluralize('changeset', closed)}</VisuallyHidden> closed
+                </H4>
+            }
+        />
+        <ChangesetStatusMerged
+            className={ACTION_CLASSNAMES}
+            label={
+                <H4 className="font-weight-normal text-muted m-0">
+                    {merged} <VisuallyHidden>{pluralize('changeset', merged)}</VisuallyHidden> merged
+                </H4>
+            }
+        />
     </div>
 )

--- a/client/web/src/enterprise/batches/repo/RepoBatchChanges.tsx
+++ b/client/web/src/enterprise/batches/repo/RepoBatchChanges.tsx
@@ -4,7 +4,7 @@ import * as H from 'history'
 import { map } from 'rxjs/operators'
 
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Container, H5 } from '@sourcegraph/wildcard'
+import { Container, H3, H5 } from '@sourcegraph/wildcard'
 
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../../../components/FilteredConnection'
 import { RepoBatchChange, RepositoryFields } from '../../../graphql-operations'
@@ -55,7 +55,7 @@ export const RepoBatchChanges: React.FunctionComponent<React.PropsWithChildren<P
     )
 
     return (
-        <Container>
+        <Container role="region" aria-label="batch changes">
             <FilteredConnection<RepoBatchChange, Omit<BatchChangeNodeProps, 'node'>>
                 history={history}
                 location={location}
@@ -72,7 +72,6 @@ export const RepoBatchChanges: React.FunctionComponent<React.PropsWithChildren<P
                 defaultFirst={15}
                 noun="batch change"
                 pluralNoun="batch changes"
-                listComponent="div"
                 listClassName={styles.batchChangesGrid}
                 withCenteredSummary={true}
                 headComponent={RepoBatchChangesHeader}
@@ -89,10 +88,20 @@ export const RepoBatchChangesHeader: React.FunctionComponent<React.PropsWithChil
         {/* Empty filler elements for the spaces in the grid that don't need headers */}
         <span />
         <span />
-        <H5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Status</H5>
-        <H5 className="p-2 d-none d-md-block text-uppercase text-nowrap">Changeset information</H5>
-        <H5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Check state</H5>
-        <H5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Review state</H5>
-        <H5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Changes</H5>
+        <H5 as={H3} aria-hidden={true} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
+            Status
+        </H5>
+        <H5 as={H3} aria-hidden={true} className="p-2 d-none d-md-block text-uppercase text-nowrap">
+            Changeset information
+        </H5>
+        <H5 as={H3} aria-hidden={true} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
+            Check state
+        </H5>
+        <H5 as={H3} aria-hidden={true} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
+            Review state
+        </H5>
+        <H5 as={H3} aria-hidden={true} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">
+            Changes
+        </H5>
     </>
 )


### PR DESCRIPTION
Some "leftovers" that didn't make it into https://github.com/sourcegraph/sourcegraph/pull/44263. These screens aren't currently covered by the third party auditor's testing scope, so I didn't include them in my re-audit last week. However, that doesn't mean they shouldn't receive the same attention eventually. 🙂 This PR:
- Updates the remaining grid lists to use proper semantic elements
- Updates the remaining lists to not announce their headers (and to not skip heading levels)
- Adds additional landmark regions for the pages with these lists
- Updates screen readout for stats on the repo batch changes page
- Removes an outdated comment and an unnecessary prop value

## Test plan

Local testing with screen reader + Storybook stories.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-a11y-cleanup.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
