### PR TITLE
unpack: optimize unpack.Tgz memory allocations

### DIFF
--- a/internal/unpack/bi_reader.go
+++ b/internal/unpack/bi_reader.go
@@ -5,22 +5,20 @@ import "io"
 // biReader is a specialized io.MultiReader optimized for
 // only two readers
 type biReader struct {
-	readers [2]io.Reader
-	cur     uint8
+	first  io.Reader
+	second io.Reader
 }
 
 func (mr *biReader) Read(p []byte) (n int, err error) {
-	// this local is important for bounds-check-elimination
-	cur := mr.cur
-	if cur < 2 {
-		n, err = mr.readers[cur].Read(p)
+	if mr.first != nil {
+		n, err = mr.first.Read(p)
 		if err == io.EOF {
-			mr.readers[cur] = nil
-			mr.cur++
-		}
-		if mr.cur == 1 && err == io.EOF {
 			err = nil
+			mr.first = nil
 		}
+	} else {
+		n, err = mr.second.Read(p)
 	}
+
 	return
 }

--- a/internal/unpack/bi_reader.go
+++ b/internal/unpack/bi_reader.go
@@ -1,0 +1,26 @@
+package unpack
+
+import "io"
+
+// biReader is a specialized io.MultiReader optimized for
+// only two readers
+type biReader struct {
+	readers [2]io.Reader
+	cur     uint8
+}
+
+func (mr *biReader) Read(p []byte) (n int, err error) {
+	// this local is important for bounds-check-elimination
+	cur := mr.cur
+	if cur < 2 {
+		n, err = mr.readers[cur].Read(p)
+		if err == io.EOF {
+			mr.readers[cur] = nil
+			mr.cur++
+		}
+		if mr.cur == 1 && err == io.EOF {
+			err = nil
+		}
+	}
+	return
+}

--- a/internal/unpack/unpack.go
+++ b/internal/unpack/unpack.go
@@ -96,7 +96,7 @@ func Tgz(r io.Reader, dir string, opt Opts) error {
 		return err
 	}
 
-	r = &biReader{readers: [2]io.Reader{bytes.NewReader(gzipMagicBytes[:]), r}}
+	r = &biReader{bytes.NewReader(gzipMagicBytes[:]), r}
 
 	// Some archives aren't compressed at all, despite the tgz extension.
 	// Try to untar them without gzip decompression.

--- a/internal/unpack/unpack_test.go
+++ b/internal/unpack/unpack_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestTgzFallback(t *testing.T) {
-	tar := makeTar(t, &fileInfo{path: "foo", contents: "bar", mode: 0655})
+	tar := makeTar(t, &fileInfo{path: "foo", contents: "bar", mode: 0o655})
 
 	t.Run("with-io-read-seeker", func(t *testing.T) {
 		err := Tgz(bytes.NewReader(tar), t.TempDir(), Opts{})
@@ -74,32 +74,32 @@ func TestUnpack(t *testing.T) {
 					},
 				},
 				in: []*fileInfo{
-					{path: "big", contents: "E_TOO_BIG", mode: 0655},
-					{path: "bar/baz", contents: "bar", mode: 0655},
-					{path: "bar", contents: "bar", mode: 0655},
-					{path: "foo/bar", contents: "bar", mode: 0655},
+					{path: "big", contents: "E_TOO_BIG", mode: 0o655},
+					{path: "bar/baz", contents: "bar", mode: 0o655},
+					{path: "bar", contents: "bar", mode: 0o655},
+					{path: "foo/bar", contents: "bar", mode: 0o655},
 				},
 				out: []*fileInfo{
-					{path: "bar", contents: "bar", mode: 0655, size: 3},
-					{path: "foo", mode: fs.ModeDir | 0750},
-					{path: "foo/bar", contents: "bar", mode: 0655, size: 3},
+					{path: "bar", contents: "bar", mode: 0o655, size: 3},
+					{path: "foo", mode: fs.ModeDir | 0o750},
+					{path: "foo/bar", contents: "bar", mode: 0o655, size: 3},
 				},
 			},
 			{
 				packer: p,
 				name:   "empty-dirs",
 				in: []*fileInfo{
-					{path: "foo", mode: fs.ModeDir | 0740},
+					{path: "foo", mode: fs.ModeDir | 0o740},
 				},
 				out: []*fileInfo{
-					{path: "foo", mode: fs.ModeDir | 0740},
+					{path: "foo", mode: fs.ModeDir | 0o740},
 				},
 			},
 			{
 				packer: p,
 				name:   "illegal-file-path",
 				in: []*fileInfo{
-					{path: "../../etc/passwd", contents: "foo", mode: 0655},
+					{path: "../../etc/passwd", contents: "foo", mode: 0o655},
 				},
 				err: "../../etc/passwd: illegal file path",
 			},
@@ -124,24 +124,24 @@ func TestUnpack(t *testing.T) {
 				name:   "skip-invalid",
 				opts:   Opts{SkipInvalid: true},
 				in: []*fileInfo{
-					{path: "bar", contents: "bar", mode: 0655},
-					{path: "../../etc/passwd", contents: "foo", mode: 0655},
+					{path: "bar", contents: "bar", mode: 0o655},
+					{path: "../../etc/passwd", contents: "foo", mode: 0o655},
 					{path: "passwd", contents: "../../etc/passwd", mode: fs.ModeSymlink},
 					{path: "passwd", contents: "/etc/passwd", mode: fs.ModeSymlink},
 				},
 				out: []*fileInfo{
-					{path: "bar", contents: "bar", mode: 0655, size: 3},
+					{path: "bar", contents: "bar", mode: 0o655, size: 3},
 				},
 			},
 			{
 				packer: p,
 				name:   "symbolic-link",
 				in: []*fileInfo{
-					{path: "bar", contents: "bar", mode: 0655},
+					{path: "bar", contents: "bar", mode: 0o655},
 					{path: "foo", contents: "bar", mode: fs.ModeSymlink},
 				},
 				out: []*fileInfo{
-					{path: "bar", contents: "bar", mode: 0655, size: 3},
+					{path: "bar", contents: "bar", mode: 0o655, size: 3},
 					{path: "foo", contents: "bar", mode: fs.ModeSymlink, size: 3},
 				},
 			},
@@ -150,29 +150,29 @@ func TestUnpack(t *testing.T) {
 				name:   "dir-permissions",
 				in: []*fileInfo{
 					{path: "dir", mode: fs.ModeDir},
-					{path: "dir/file1", contents: "x", mode: 0000},
-					{path: "dir/file2", contents: "x", mode: 0200},
-					{path: "dir/file3", contents: "x", mode: 0400},
-					{path: "dir/file4", contents: "x", mode: 0600},
+					{path: "dir/file1", contents: "x", mode: 0o000},
+					{path: "dir/file2", contents: "x", mode: 0o200},
+					{path: "dir/file3", contents: "x", mode: 0o400},
+					{path: "dir/file4", contents: "x", mode: 0o600},
 				},
 				out: []*fileInfo{
-					{path: "dir", mode: fs.ModeDir | 0700},
-					{path: "dir/file1", contents: "x", mode: 0600, size: 1},
-					{path: "dir/file2", contents: "x", mode: 0600, size: 1},
-					{path: "dir/file3", contents: "x", mode: 0600, size: 1},
-					{path: "dir/file4", contents: "x", mode: 0600, size: 1},
+					{path: "dir", mode: fs.ModeDir | 0o700},
+					{path: "dir/file1", contents: "x", mode: 0o600, size: 1},
+					{path: "dir/file2", contents: "x", mode: 0o600, size: 1},
+					{path: "dir/file3", contents: "x", mode: 0o600, size: 1},
+					{path: "dir/file4", contents: "x", mode: 0o600, size: 1},
 				},
 			},
 			{
 				packer: p,
 				name:   "duplicates",
 				in: []*fileInfo{
-					{path: "bar", contents: "bar", mode: 0655},
-					{path: "bar", contents: "bar", mode: 0655},
+					{path: "bar", contents: "bar", mode: 0o655},
+					{path: "bar", contents: "bar", mode: 0o655},
 				},
 				errContains: "/bar: file exists",
 				out: []*fileInfo{
-					{path: "bar", contents: "bar", mode: 0655, size: 3},
+					{path: "bar", contents: "bar", mode: 0o655, size: 3},
 				},
 			},
 			{
@@ -180,11 +180,11 @@ func TestUnpack(t *testing.T) {
 				name:   "skip-duplicates",
 				opts:   Opts{SkipDuplicates: true},
 				in: []*fileInfo{
-					{path: "bar", contents: "bar", mode: 0655},
-					{path: "bar", contents: "bar", mode: 0655},
+					{path: "bar", contents: "bar", mode: 0o655},
+					{path: "bar", contents: "bar", mode: 0o655},
 				},
 				out: []*fileInfo{
-					{path: "bar", contents: "bar", mode: 0655, size: 3},
+					{path: "bar", contents: "bar", mode: 0o655, size: 3},
 				},
 			},
 		}...)

--- a/internal/unpack/unpack_test.go
+++ b/internal/unpack/unpack_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestTgzFallback(t *testing.T) {
-	tar := makeTar(t, &fileInfo{path: "foo", contents: "bar", mode: 0o655})
+	tar := makeTar(t, &fileInfo{path: "foo", contents: "bar", mode: 0655})
 
 	t.Run("with-io-read-seeker", func(t *testing.T) {
 		err := Tgz(bytes.NewReader(tar), t.TempDir(), Opts{})
@@ -74,32 +74,32 @@ func TestUnpack(t *testing.T) {
 					},
 				},
 				in: []*fileInfo{
-					{path: "big", contents: "E_TOO_BIG", mode: 0o655},
-					{path: "bar/baz", contents: "bar", mode: 0o655},
-					{path: "bar", contents: "bar", mode: 0o655},
-					{path: "foo/bar", contents: "bar", mode: 0o655},
+					{path: "big", contents: "E_TOO_BIG", mode: 0655},
+					{path: "bar/baz", contents: "bar", mode: 0655},
+					{path: "bar", contents: "bar", mode: 0655},
+					{path: "foo/bar", contents: "bar", mode: 0655},
 				},
 				out: []*fileInfo{
-					{path: "bar", contents: "bar", mode: 0o655, size: 3},
-					{path: "foo", mode: fs.ModeDir | 0o750},
-					{path: "foo/bar", contents: "bar", mode: 0o655, size: 3},
+					{path: "bar", contents: "bar", mode: 0655, size: 3},
+					{path: "foo", mode: fs.ModeDir | 0750},
+					{path: "foo/bar", contents: "bar", mode: 0655, size: 3},
 				},
 			},
 			{
 				packer: p,
 				name:   "empty-dirs",
 				in: []*fileInfo{
-					{path: "foo", mode: fs.ModeDir | 0o740},
+					{path: "foo", mode: fs.ModeDir | 0740},
 				},
 				out: []*fileInfo{
-					{path: "foo", mode: fs.ModeDir | 0o740},
+					{path: "foo", mode: fs.ModeDir | 0740},
 				},
 			},
 			{
 				packer: p,
 				name:   "illegal-file-path",
 				in: []*fileInfo{
-					{path: "../../etc/passwd", contents: "foo", mode: 0o655},
+					{path: "../../etc/passwd", contents: "foo", mode: 0655},
 				},
 				err: "../../etc/passwd: illegal file path",
 			},
@@ -124,24 +124,24 @@ func TestUnpack(t *testing.T) {
 				name:   "skip-invalid",
 				opts:   Opts{SkipInvalid: true},
 				in: []*fileInfo{
-					{path: "bar", contents: "bar", mode: 0o655},
-					{path: "../../etc/passwd", contents: "foo", mode: 0o655},
+					{path: "bar", contents: "bar", mode: 0655},
+					{path: "../../etc/passwd", contents: "foo", mode: 0655},
 					{path: "passwd", contents: "../../etc/passwd", mode: fs.ModeSymlink},
 					{path: "passwd", contents: "/etc/passwd", mode: fs.ModeSymlink},
 				},
 				out: []*fileInfo{
-					{path: "bar", contents: "bar", mode: 0o655, size: 3},
+					{path: "bar", contents: "bar", mode: 0655, size: 3},
 				},
 			},
 			{
 				packer: p,
 				name:   "symbolic-link",
 				in: []*fileInfo{
-					{path: "bar", contents: "bar", mode: 0o655},
+					{path: "bar", contents: "bar", mode: 0655},
 					{path: "foo", contents: "bar", mode: fs.ModeSymlink},
 				},
 				out: []*fileInfo{
-					{path: "bar", contents: "bar", mode: 0o655, size: 3},
+					{path: "bar", contents: "bar", mode: 0655, size: 3},
 					{path: "foo", contents: "bar", mode: fs.ModeSymlink, size: 3},
 				},
 			},
@@ -150,29 +150,29 @@ func TestUnpack(t *testing.T) {
 				name:   "dir-permissions",
 				in: []*fileInfo{
 					{path: "dir", mode: fs.ModeDir},
-					{path: "dir/file1", contents: "x", mode: 0o000},
-					{path: "dir/file2", contents: "x", mode: 0o200},
-					{path: "dir/file3", contents: "x", mode: 0o400},
-					{path: "dir/file4", contents: "x", mode: 0o600},
+					{path: "dir/file1", contents: "x", mode: 0000},
+					{path: "dir/file2", contents: "x", mode: 0200},
+					{path: "dir/file3", contents: "x", mode: 0400},
+					{path: "dir/file4", contents: "x", mode: 0600},
 				},
 				out: []*fileInfo{
-					{path: "dir", mode: fs.ModeDir | 0o700},
-					{path: "dir/file1", contents: "x", mode: 0o600, size: 1},
-					{path: "dir/file2", contents: "x", mode: 0o600, size: 1},
-					{path: "dir/file3", contents: "x", mode: 0o600, size: 1},
-					{path: "dir/file4", contents: "x", mode: 0o600, size: 1},
+					{path: "dir", mode: fs.ModeDir | 0700},
+					{path: "dir/file1", contents: "x", mode: 0600, size: 1},
+					{path: "dir/file2", contents: "x", mode: 0600, size: 1},
+					{path: "dir/file3", contents: "x", mode: 0600, size: 1},
+					{path: "dir/file4", contents: "x", mode: 0600, size: 1},
 				},
 			},
 			{
 				packer: p,
 				name:   "duplicates",
 				in: []*fileInfo{
-					{path: "bar", contents: "bar", mode: 0o655},
-					{path: "bar", contents: "bar", mode: 0o655},
+					{path: "bar", contents: "bar", mode: 0655},
+					{path: "bar", contents: "bar", mode: 0655},
 				},
 				errContains: "/bar: file exists",
 				out: []*fileInfo{
-					{path: "bar", contents: "bar", mode: 0o655, size: 3},
+					{path: "bar", contents: "bar", mode: 0655, size: 3},
 				},
 			},
 			{
@@ -180,11 +180,11 @@ func TestUnpack(t *testing.T) {
 				name:   "skip-duplicates",
 				opts:   Opts{SkipDuplicates: true},
 				in: []*fileInfo{
-					{path: "bar", contents: "bar", mode: 0o655},
-					{path: "bar", contents: "bar", mode: 0o655},
+					{path: "bar", contents: "bar", mode: 0655},
+					{path: "bar", contents: "bar", mode: 0655},
 				},
 				out: []*fileInfo{
-					{path: "bar", contents: "bar", mode: 0o655, size: 3},
+					{path: "bar", contents: "bar", mode: 0655, size: 3},
 				},
 			},
 		}...)


### PR DESCRIPTION
In the worst case (when the `io.Reader` isnt an `io.ReadSeeker`), `unpack.Tgz` would use `io.ReadAll` on the `io.Reader` in order to fall-back to `unpack.Tar` if the file extension was incorrect (.tar.gz for something what wasnt actually gzipped).  

After https://github.com/sourcegraph/sourcegraph/pull/44497/, https://github.com/sourcegraph/sourcegraph/pull/44517/ and https://github.com/sourcegraph/sourcegraph/pull/44520, this worst will always be triggered, as http response bodies are not `io.ReadSeeker`s. This can cause excessive memory copying from `io.ReadAll`, where we could be reading a minimal amount to determine whether the file is actually gzipped or not.

Benchmark figures, where Old is the original, and New is the new (of course):
```
$ go test -benchmem -run='^$' -bench '^BenchmarkTgzFallback$' github.com/sourcegraph/sourcegraph/internal/unpack -v -count=10 -race
goos: linux
goarch: amd64
pkg: github.com/sourcegraph/sourcegraph/internal/unpack
cpu: AMD Ryzen 5 5600X 6-Core Processor             
BenchmarkTgzFallback
BenchmarkTgzFallback/Old
BenchmarkTgzFallback/Old-12                29144             43833 ns/op           14557 B/op         36 allocs/op
BenchmarkTgzFallback/Old-12                26395             45004 ns/op           14574 B/op         36 allocs/op
BenchmarkTgzFallback/Old-12                28130             45917 ns/op           14599 B/op         36 allocs/op
BenchmarkTgzFallback/Old-12                26758             46788 ns/op           14564 B/op         36 allocs/op
BenchmarkTgzFallback/Old-12                25844             45694 ns/op           14532 B/op         36 allocs/op
BenchmarkTgzFallback/Old-12                27319             45318 ns/op           14512 B/op         36 allocs/op
BenchmarkTgzFallback/Old-12                27026             46731 ns/op           14586 B/op         36 allocs/op
BenchmarkTgzFallback/Old-12                26932             47716 ns/op           14538 B/op         36 allocs/op
BenchmarkTgzFallback/Old-12                25428             45836 ns/op           14563 B/op         36 allocs/op
BenchmarkTgzFallback/Old-12                26865             41620 ns/op           14530 B/op         36 allocs/op
BenchmarkTgzFallback/New
BenchmarkTgzFallback/New-12                33439             40709 ns/op            5945 B/op         32 allocs/op
BenchmarkTgzFallback/New-12                29628             39881 ns/op            5940 B/op         31 allocs/op
BenchmarkTgzFallback/New-12                31644             39578 ns/op            5971 B/op         32 allocs/op
BenchmarkTgzFallback/New-12                29116             39691 ns/op            5957 B/op         32 allocs/op
BenchmarkTgzFallback/New-12                30648             39306 ns/op            5995 B/op         32 allocs/op
BenchmarkTgzFallback/New-12                31161             41873 ns/op            5984 B/op         32 allocs/op
BenchmarkTgzFallback/New-12                30362             41084 ns/op            5939 B/op         32 allocs/op
BenchmarkTgzFallback/New-12                30147             39431 ns/op            5999 B/op         32 allocs/op
BenchmarkTgzFallback/New-12                31102             39300 ns/op            5933 B/op         32 allocs/op
BenchmarkTgzFallback/New-12                32269             42896 ns/op            5977 B/op         32 allocs/op
```

## Test plan

Unit test, benchmark, code review, live :)
