### PR TITLE
monitoring: do not manually set dashboard versions

### DIFF
--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -339,7 +339,6 @@ func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher, folde
 			}
 		}
 	}
-
 	return board, nil
 }
 

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -2,7 +2,6 @@ package monitoring
 
 import (
 	"fmt"
-	"math/rand"
 	"regexp"
 	"strconv"
 	"strings"
@@ -105,7 +104,6 @@ func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher, folde
 	}
 
 	board := sdk.NewBoard(c.Title)
-	board.Version = uint(rand.Uint32())
 	board.UID = uid
 	board.ID = 0
 	board.Timezone = "utc"
@@ -341,6 +339,7 @@ func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher, folde
 			}
 		}
 	}
+
 	return board, nil
 }
 


### PR DESCRIPTION
Explicitly setting the dashboard version should not be required as Grafana will increment the dashboard version automatically.

When using a Postgres database for Grafana (by default Grafana uses sqlite), Grafana stores the `version` and `parent_version` fields as an `int4`. This code had the potential to generate version numbers that exceeded the allowable range of that data type causing Grafana to throw a server error:
```
grafana logger=context userId=3 orgId=1 uname=mi-github@sourcegraph-secrets.iam.gserviceaccount.com t=2022-11-14T23:22:08.29936165Z level=error msg="Failed to save dashboard" error="saving dashboard failed: pq: value \"3633878605\" is out of range for type integer"
```

This is blocking the [centralized observability](https://github.com/sourcegraph/customer/issues/1151) efforts for the Cloud platform.


## Test plan

1. Checkout this branch
2. Start grafana locally with `sg run grafana` from the root of the repo (requires docker)
3. Exec into the container: `docker exec -it --user root grafana bash`
4. Install sqlite tooling in the containerE: `docker exec -it --user root grafana bash`
5. Open the database: `cd /var/lib/grafana` and `sqlite3 grafana.db`. Verify the tables show with `.tables`.
6. Note initial state:
```
sqlite> SELECT id, parent_version, version FROM dashboard_version;
1|0|1
2|0|1
3|0|1
4|0|1
5|0|1
6|0|1
7|0|1
8|0|1
9|0|1
10|0|1
11|0|1
12|0|1
13|0|1
14|0|1
15|1|1
16|0|1
17|0|1
18|0|1
19|0|1
20|0|1
21|0|1
22|0|1
```
7. Generate new dashboards:
```
go run ./dev/sg monitoring generate \
	--reload \
	--grafana.dir="/tmp/grafana" \
	--prometheus.dir="" \
	--prometheus.url="" \
	--docs.dir="/tmp/docs" \
	--grafana.url=http://127.0.0.1:3370
```
8. Re-execute SQL query and note that the `version` field has been incremented for each dashboard and they now reference the previous version as a `parent_version`:
```
sqlite> SELECT id, parent_version, version FROM dashboard_version;
1|0|1
2|0|1
3|0|1
4|0|1
5|0|1
6|0|1
7|0|1
8|0|1
9|0|1
10|0|1
11|0|1
12|0|1
13|0|1
14|0|1
15|1|1
16|0|1
17|0|1
18|0|1
19|0|1
20|0|1
21|0|1
22|0|1
23|1|2
24|1|2
25|1|2
26|1|2
27|1|2
28|1|2
29|1|2
30|1|2
31|1|2
32|1|2
33|1|2
34|1|2
35|1|2
36|1|2
37|1|2
38|1|2
39|1|2
40|1|2
41|1|2
42|1|2
43|1|2
44|1|2
```