### PR TITLE
cmd/repo-updater: Remove inner-scope for handler metrics

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -216,17 +216,14 @@ func Main(enterpriseInit EnterpriseInit) {
 	addr := net.JoinHostPort(host, port)
 	logger.Info("listening", log.String("addr", addr))
 
-	var handler http.Handler
-	{
-		m := repoupdater.NewHandlerMetrics()
-		m.MustRegister(prometheus.DefaultRegisterer)
+	m := repoupdater.NewHandlerMetrics()
+	m.MustRegister(prometheus.DefaultRegisterer)
 
-		handler = repoupdater.ObservedHandler(
-			logger,
-			m,
-			otel.GetTracerProvider(),
-		)(server.Handler())
-	}
+	handler := repoupdater.ObservedHandler(
+		logger,
+		m,
+		otel.GetTracerProvider(),
+	)(server.Handler())
 
 	globals.WatchExternalURL(nil)
 


### PR DESCRIPTION
I looked at the code long and hard and couldn't figure out why it needs to be in its own scope.



## Test plan

- Tested locally that `src_http_request_duration_seconds_count` metrics are working for an endpoint in `repo-updater`

![image](https://user-images.githubusercontent.com/2682729/202341310-7969ebcf-6502-4708-acae-ebbdee4ec395.png)


- Builds pass ✅
- [main-dry-run](https://github.com/sourcegraph/sourcegraph/tree/main-dry-run/ig/scoped-handler-metrics) is ✅


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
