### PR TITLE
gqltest: Ensure fusion test is actually cloning depot

### DIFF
--- a/dev/gqltest/external_service_test.go
+++ b/dev/gqltest/external_service_test.go
@@ -179,10 +179,11 @@ func TestExternalService_Perforce(t *testing.T) {
 		},
 		{
 			name:      "p4 fusion",
-			depot:     "michelle-test",
+			depot:     "integration-test-depot",
 			useFusion: true,
-			blobPath:  "main.go",
-			wantBlob:  "package main\n\nimport \"fmt\"\nfunc main() {\n\tfmt.Println(\"hello\")\n}\n",
+			blobPath:  "path.txt",
+			wantBlob: `./
+`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	perforceRepoName = "perforce/test-perms"
+	testPermsDepot   = "test-perms"
 	aliceEmail       = "alice@perforce.sgdev.org"
 	aliceUsername    = "alice"
 )
@@ -22,7 +23,7 @@ const (
 func TestSubRepoPermissionsPerforce(t *testing.T) {
 	checkPerforceEnvironment(t)
 	enableSubRepoPermissions(t)
-	createPerforceExternalService(t, false)
+	createPerforceExternalService(t, testPermsDepot, false)
 	userClient, repoName := createTestUserAndWaitForRepo(t)
 
 	// Test cases
@@ -81,7 +82,7 @@ func TestSubRepoPermissionsPerforce(t *testing.T) {
 func TestSubRepoPermissionsSearch(t *testing.T) {
 	checkPerforceEnvironment(t)
 	enableSubRepoPermissions(t)
-	createPerforceExternalService(t, false)
+	createPerforceExternalService(t, testPermsDepot, false)
 	userClient, _ := createTestUserAndWaitForRepo(t)
 
 	err := client.WaitForReposToBeIndexed(perforceRepoName)

--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -23,7 +23,8 @@ const (
 func TestSubRepoPermissionsPerforce(t *testing.T) {
 	checkPerforceEnvironment(t)
 	enableSubRepoPermissions(t)
-	createPerforceExternalService(t, testPermsDepot, false)
+	cleanup := createPerforceExternalService(t, testPermsDepot, false)
+	t.Cleanup(cleanup)
 	userClient, repoName := createTestUserAndWaitForRepo(t)
 
 	// Test cases
@@ -82,7 +83,8 @@ func TestSubRepoPermissionsPerforce(t *testing.T) {
 func TestSubRepoPermissionsSearch(t *testing.T) {
 	checkPerforceEnvironment(t)
 	enableSubRepoPermissions(t)
-	createPerforceExternalService(t, testPermsDepot, false)
+	cleanup := createPerforceExternalService(t, testPermsDepot, false)
+	t.Cleanup(cleanup)
 	userClient, _ := createTestUserAndWaitForRepo(t)
 
 	err := client.WaitForReposToBeIndexed(perforceRepoName)


### PR DESCRIPTION
The previous tests we not testing cloning via`p4-fusion`, the following was happening:

`git p4` test runs, completes and deletes external service which then _soft_
deletes repo. `p4-fusion` can't find repo to delete since it's name has changed
so does nothing. Repo is still on disk so we end up fetching rather than
cloning. Even if that fails, we still find the repo on disk and mark the test
as passed.

To fix this we now:

* Delete the repo on disk *before* deleting the service. (Confirmed locally that the repo is removed on disk) 
* Clone a different repo in each test

The tests were also refactored to make things a little more explicit.
 
## Test plan
 
Tested many times locally, confirm that passed integration tests in CI.     

Also manually changes code locally so that the `p4-fusion` command would fail   
to confirm we were actually running it.


Part of https://github.com/sourcegraph/sourcegraph/pull/44301