### PR TITLE
otel: update otel configs for v0.65 and filter processor

### DIFF
--- a/docker-images/opentelemetry-collector/build.sh
+++ b/docker-images/opentelemetry-collector/build.sh
@@ -3,7 +3,7 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-export OTEL_COLLECTOR_VERSION="${OTEL_COLLECTOR_VERSION:-0.54.0}"
+export OTEL_COLLECTOR_VERSION="${OTEL_COLLECTOR_VERSION:-0.64.0}"
 
 docker build -t "${IMAGE:-sourcegraph/opentelemetry-collector}" . \
   --platform linux/amd64 \

--- a/docker-images/opentelemetry-collector/build.sh
+++ b/docker-images/opentelemetry-collector/build.sh
@@ -3,7 +3,7 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-export OTEL_COLLECTOR_VERSION="${OTEL_COLLECTOR_VERSION:-0.64.0}"
+export OTEL_COLLECTOR_VERSION="${OTEL_COLLECTOR_VERSION:-0.65.0}"
 
 docker build -t "${IMAGE:-sourcegraph/opentelemetry-collector}" . \
   --platform linux/amd64 \

--- a/docker-images/opentelemetry-collector/builder.template.yaml
+++ b/docker-images/opentelemetry-collector/builder.template.yaml
@@ -16,7 +16,6 @@ exporters:
   # Contrib exporters - https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v$OTEL_COLLECTOR_VERSION"
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v$OTEL_COLLECTOR_VERSION"
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter v$OTEL_COLLECTOR_VERSION"
 
 receivers:
   # OpenTelemetry receivers - https://go.opentelemetry.io/collector/receiver

--- a/docker-images/opentelemetry-collector/builder.template.yaml
+++ b/docker-images/opentelemetry-collector/builder.template.yaml
@@ -39,3 +39,4 @@ processors:
   # Contrib extensions - https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v$OTEL_COLLECTOR_VERSION
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v$OTEL_COLLECTOR_VERSION
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v$OTEL_COLLECTOR_VERSION

--- a/docker-images/opentelemetry-collector/configs/filter.yaml
+++ b/docker-images/opentelemetry-collector/configs/filter.yaml
@@ -13,18 +13,18 @@ receivers:
 exporters:
   jaeger:
     # Default Jaeger GRPC server
-    endpoint: "$JAEGER_HOST:14250"
+    endpoint: '$JAEGER_HOST:14250'
     tls:
       insecure: true
 
 extensions:
   health_check:
-    endpoint: ":13133"
+    endpoint: ':13133'
   zpages:
-   endpoint: ":55679"
+    endpoint: ':55679'
 
 service:
-  extensions: [health_check,zpages]
+  extensions: [health_check, zpages]
   pipelines:
     traces/web-app:
       receivers: [otlp]
@@ -41,26 +41,25 @@ processors:
     expected_new_traces_per_sec: 10 # default value = 0
     # Recommended reading to understand how the policies are applied:
     # https://sourcegraph.com/github.com/open-telemetry/opentelemetry-collector-contrib@71dd19d2e59cd1f8aa9844461089d5c17efaa0ca/-/blob/processor/tailsamplingprocessor/processor.go?L214
-    policies:
-      [
-          {
-            # If a span contains `sampling_retain: true`, it will always be sampled (not dropped),
-            # regardless of the probabilistic sampling.
-            name: policy-retain,
-            type: string_attribute,
-            string_attribute: {key: sampling.retain, values: ['true']},
-          },
-          {
-            # Only keep 10% of the traces.
-            name: policy-probalistic,
-            type: probabilistic,
-            probabilistic: {sampling_percentage: 10}
-          }
-        ]
+    policies: [
+        {
+          # If a span contains `sampling_retain: true`, it will always be sampled (not dropped),
+          # regardless of the probabilistic sampling.
+          name: policy-retain,
+          type: string_attribute,
+          string_attribute: { key: sampling.retain, values: ['true'] },
+        },
+        {
+          # Only keep 10% of the traces.
+          name: policy-probalistic,
+          type: probabilistic,
+          probabilistic: { sampling_percentage: 10 },
+        },
+      ]
   filter/web-app:
     spans:
       # ONLY include traces where 'service.name' matches "web-app" and exclude ALL other traces from the pipeline
       include:
         match_type: strict
         services:
-          - "web-app"
+          - 'web-app'

--- a/docker-images/opentelemetry-collector/configs/filter.yaml
+++ b/docker-images/opentelemetry-collector/configs/filter.yaml
@@ -57,7 +57,7 @@ processors:
             probabilistic: {sampling_percentage: 10}
           }
         ]
-  filter/ui:
+  filter/web-app:
     spans:
       # ONLY include traces where 'service.name' matches "web-app" and exclude ALL other traces from the pipeline
       include:

--- a/docker-images/opentelemetry-collector/configs/filter.yaml
+++ b/docker-images/opentelemetry-collector/configs/filter.yaml
@@ -26,9 +26,9 @@ extensions:
 service:
   extensions: [health_check,zpages]
   pipelines:
-    traces:
+    traces/web-app:
       receivers: [otlp]
-      processors: [tail_sampling]
+      processors: [filter/web-app]
       exporters: [jaeger]
 
 processors:
@@ -57,3 +57,10 @@ processors:
             probabilistic: {sampling_percentage: 10}
           }
         ]
+  filter/ui:
+    spans:
+      # ONLY include traces where 'service.name' matches "web-app" and exclude ALL other traces from the pipeline
+      include:
+        match_type: regexp
+        services:
+          - "web-app"

--- a/docker-images/opentelemetry-collector/configs/filter.yaml
+++ b/docker-images/opentelemetry-collector/configs/filter.yaml
@@ -61,6 +61,6 @@ processors:
     spans:
       # ONLY include traces where 'service.name' matches "web-app" and exclude ALL other traces from the pipeline
       include:
-        match_type: regexp
+        match_type: strict
         services:
           - "web-app"

--- a/docker-images/opentelemetry-collector/configs/honeycomb.yaml
+++ b/docker-images/opentelemetry-collector/configs/honeycomb.yaml
@@ -22,9 +22,9 @@ exporters:
 
 extensions:
   health_check:
-    port: 13133
+    endpoint: ":13133"
   zpages:
-   endpoint: "localhost:55679"
+   endpoint: ":55679"
 
 service:
   extensions: [health_check,zpages]

--- a/docker-images/opentelemetry-collector/configs/honeycomb.yaml
+++ b/docker-images/opentelemetry-collector/configs/honeycomb.yaml
@@ -18,17 +18,38 @@ exporters:
     endpoint: "api.honeycomb.io:443"
     headers:
       "x-honeycomb-team": "$HONEYCOMB_API_KEY"
-      "x-honeycomb-dataset": "$HONEYCOMB_DATASET"
+  otlp/webapp:
+    endpoint: "api.honeycomb.io:443"
+    headers:
+      "x-honeycomb-team": "$HONEYCOMB_API_KEY_WEBAPP"
+
+processors:
+  filter/webapp:
+    spans:
+      include:
+        match_type: strict
+        services:
+          - web-app
+  filter/exc-webapp:
+      spans:
+        exclude:
+          match_type: strict
+          services:
+            - web-app
 
 extensions:
   health_check:
-    endpoint: ":13133"
   zpages:
-   endpoint: ":55679"
+    endpoint: ":55679"
 
 service:
   extensions: [health_check,zpages]
   pipelines:
-    traces:
+    traces/webapp:
       receivers: [otlp]
+      processors: [filter/webapp]
+      exporters: [otlp/webapp]
+    traces/all:
+      receivers: [otlp]
+      processors: [filter/exc-webapp]
       exporters: [otlp]

--- a/docker-images/opentelemetry-collector/configs/honeycomb.yaml
+++ b/docker-images/opentelemetry-collector/configs/honeycomb.yaml
@@ -24,13 +24,13 @@ exporters:
       "x-honeycomb-team": "$HONEYCOMB_API_KEY_WEBAPP"
 
 processors:
-  filter/webapp:
+  filter/webapp: # You can include certain traces
     spans:
       include:
         match_type: strict
         services:
           - web-app
-  filter/exc-webapp:
+  filter/exc-webapp: # You can exclude certain traces
       spans:
         exclude:
           match_type: strict
@@ -45,11 +45,11 @@ extensions:
 service:
   extensions: [health_check,zpages]
   pipelines:
-    traces/webapp:
+    traces/webapp: # Only traces for the service web-app will be allowed through this pipeline
       receivers: [otlp]
       processors: [filter/webapp]
       exporters: [otlp/webapp]
-    traces/all:
+    traces/all: # All traces except web-app is allowed through the pipeline
       receivers: [otlp]
       processors: [filter/exc-webapp]
       exporters: [otlp]

--- a/docker-images/opentelemetry-collector/configs/jaeger.yaml
+++ b/docker-images/opentelemetry-collector/configs/jaeger.yaml
@@ -19,9 +19,9 @@ exporters:
 
 extensions:
   health_check:
-    port: 13133
+    endpoint: ":13133"
   zpages:
-   endpoint: ":55679"
+    endpoint: ":55679"
 
 service:
   extensions: [health_check,zpages]

--- a/docker-images/opentelemetry-collector/configs/logging.yaml
+++ b/docker-images/opentelemetry-collector/configs/logging.yaml
@@ -17,9 +17,9 @@ exporters:
 
 extensions:
   health_check:
-    port: 13133
+    endpoint: ":13133"
   zpages:
-   endpoint: "localhost:55679"
+   endpoint: ":55679"
 
 service:
   extensions: [health_check,zpages]


### PR DESCRIPTION
* Update otel-collector to 0.65.0
* Add filterprocessor

### Breaking changes by using 0.65
* removed `lokiexporter` since it isn't used and doesn't compile with the custom distro builder
* `healthz` extension cannot use `port` anymore and must use `endpoint`

### Filterprocessor
Using `filterprocessor` we can direct certain spans to certain exporters in a pipeline. In the following example, all traces will go to googlecloud, **and** additionally, traces for the "web-app" service will go to honeycomb

```yaml
services:
  pipelines:
    traces/general:
         receivers: [oltp]
         processors: [tail_sampling]
         exporters: [googlecloud]
    traces/web-app:
         receivers: [oltp]
         processors: [filter/web-app]
         exporters: [honeycomb]


processors:
   filter/web-app:
      spans:
          include:
             match_type: strict
             services:
             - "web-app"
```

- [ ] update cloud
    - https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/213
- [ ] update dogfood
- [ ] update s2
   - https://github.com/sourcegraph/deploy-sourcegraph-managed/pull/2249
- [ ] update managed
   - https://github.com/sourcegraph/deploy-sourcegraph-managed/pull/2249
- [ ] update docker
   - https://github.com/sourcegraph/deploy-sourcegraph-docker/pull/879/files
- [ ] update helm
   - https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/213
## Test plan
1. `sg start otel` with the `config/filter.yaml` config
2. `sg start iam` do a trace with `&trace=1`
3.  Check in jaeger that we ONLY have traces for "web-app"
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
