### PR TITLE
Fix word break for repo pages

### DIFF
--- a/client/wildcard/src/components/PageHeader/Breadcrumb/Breadcrumb.tsx
+++ b/client/wildcard/src/components/PageHeader/Breadcrumb/Breadcrumb.tsx
@@ -11,7 +11,7 @@ import styles from './Breadcrumb.module.scss'
 export type BreadcrumbIcon = IconType
 export type BreadcrumbText = React.ReactNode
 
-type BreadcrumbProps = React.HTMLAttributes<HTMLSpanElement> & {
+export type BreadcrumbProps = React.HTMLAttributes<HTMLSpanElement> & {
     /** Use a valid path to render this Breadcrumb as a Link */
     to?: string
     icon?: BreadcrumbIcon

--- a/client/wildcard/src/components/PageHeader/Heading/Heading.module.scss
+++ b/client/wildcard/src/components/PageHeader/Heading/Heading.module.scss
@@ -4,4 +4,5 @@
     flex-grow: 1;
     align-items: center;
     margin: 0;
+    word-break: break-word;
 }

--- a/client/wildcard/src/components/PageHeader/PageHeader.module.scss
+++ b/client/wildcard/src/components/PageHeader/PageHeader.module.scss
@@ -28,3 +28,7 @@
     margin-top: 0.5rem;
     margin-bottom: 0;
 }
+
+.breadcrumb svg {
+    flex-shrink: 0;
+}

--- a/client/wildcard/src/components/PageHeader/PageHeader.story.tsx
+++ b/client/wildcard/src/components/PageHeader/PageHeader.story.tsx
@@ -10,6 +10,7 @@ import { Icon } from '../Icon'
 import { Link } from '../Link'
 
 import { PageHeader } from './PageHeader'
+import { H1, H2 } from '../Typography'
 
 const decorator: DecoratorFn = story => (
     <BrandedStory styles={webStyles}>{() => <div className="container mt-3">{story()}</div>}</BrandedStory>
@@ -24,14 +25,32 @@ const config: Meta = {
 export default config
 
 export const BasicHeader: Story = () => (
-    <PageHeader
-        path={[{ icon: mdiPuzzleOutline, text: 'Header' }]}
-        actions={
-            <Button to={`${location.pathname}/close`} className="mr-1" variant="secondary" as={Link}>
-                <Icon aria-hidden={true} svgPath={mdiMagnify} /> Button with icon
-            </Button>
-        }
-    />
+    <>
+        <H1>Page Header</H1>
+        <H2>Basic</H2>
+        <div className="mb-3">
+            <PageHeader
+                path={[{ icon: mdiPuzzleOutline, text: 'Header' }]}
+                actions={
+                    <Button to={`${location.pathname}/close`} className="mr-1" variant="secondary" as={Link}>
+                        <Icon aria-hidden={true} svgPath={mdiMagnify} /> Button with icon
+                    </Button>
+                }
+            />
+        </div>
+        <H2>Overflowing</H2>
+        <div className="mb-3">
+            <PageHeader
+                path={[
+                    {
+                        icon: mdiPuzzleOutline,
+                        text:
+                            'Call me Ishmael. Some years ago—never mind how long precisely—having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world.',
+                    },
+                ]}
+            />
+        </div>
+    </>
 )
 
 BasicHeader.storyName = 'Basic header'

--- a/client/wildcard/src/components/PageHeader/PageHeader.story.tsx
+++ b/client/wildcard/src/components/PageHeader/PageHeader.story.tsx
@@ -8,9 +8,9 @@ import { Button } from '../Button'
 import { FeedbackBadge } from '../Feedback'
 import { Icon } from '../Icon'
 import { Link } from '../Link'
+import { H1, H2 } from '../Typography'
 
 import { PageHeader } from './PageHeader'
-import { H1, H2 } from '../Typography'
 
 const decorator: DecoratorFn = story => (
     <BrandedStory styles={webStyles}>{() => <div className="container mt-3">{story()}</div>}</BrandedStory>

--- a/client/wildcard/src/components/PageHeader/PageHeader.tsx
+++ b/client/wildcard/src/components/PageHeader/PageHeader.tsx
@@ -62,7 +62,7 @@ export const PageHeader: React.FunctionComponent<React.PropsWithChildren<PageHea
     const heading = (
         <Heading as={headingElement}>
             {path.map(({ to, text, icon, ariaLabel }, index) => (
-                <Breadcrumb key={index} to={to} icon={icon} aria-label={ariaLabel}>
+                <Breadcrumb key={index} to={to} icon={icon} aria-label={ariaLabel} className={styles.breadcrumb}>
                     {text}
                 </Breadcrumb>
             ))}

--- a/client/wildcard/src/components/PageHeader/PageHeader.tsx
+++ b/client/wildcard/src/components/PageHeader/PageHeader.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 
 import { Text, HeadingElement } from '../Typography'
 
-import { Breadcrumb, BreadcrumbIcon, BreadcrumbText } from './Breadcrumb'
+import { Breadcrumb, BreadcrumbIcon, BreadcrumbProps, BreadcrumbText } from './Breadcrumb'
 import { Heading } from './Heading'
 
 import styles from './PageHeader.module.scss'
@@ -62,9 +62,9 @@ export const PageHeader: React.FunctionComponent<React.PropsWithChildren<PageHea
     const heading = (
         <Heading as={headingElement}>
             {path.map(({ to, text, icon, ariaLabel }, index) => (
-                <Breadcrumb key={index} to={to} icon={icon} aria-label={ariaLabel} className={styles.breadcrumb}>
+                <PageHeader.Breadcrumb key={index} to={to} icon={icon} aria-label={ariaLabel}>
                     {text}
-                </Breadcrumb>
+                </PageHeader.Breadcrumb>
             ))}
         </Heading>
     )
@@ -82,5 +82,8 @@ export const PageHeader: React.FunctionComponent<React.PropsWithChildren<PageHea
     )
 }
 
-PageHeader.Breadcrumb = Breadcrumb
+PageHeader.Breadcrumb = (props: BreadcrumbProps) => (
+    <Breadcrumb {...props} className={classNames(props.className, styles.breadcrumb)} />
+)
+PageHeader.Breadcrumb.displayName = 'PageHeader.Breadcrumb'
 PageHeader.Heading = Heading

--- a/client/wildcard/src/components/PageHeader/__snapshots__/PageHeader.test.tsx.snap
+++ b/client/wildcard/src/components/PageHeader/__snapshots__/PageHeader.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`PageHeader renders correctly 1`] = `
           class="h1 heading"
         >
           <span
-            class="wrapper"
+            class="wrapper breadcrumb"
           >
             <a
               class="anchorLink path"
@@ -33,7 +33,7 @@ exports[`PageHeader renders correctly 1`] = `
             </a>
           </span>
           <span
-            class="wrapper"
+            class="wrapper breadcrumb"
           >
             <a
               class="anchorLink path"
@@ -47,7 +47,7 @@ exports[`PageHeader renders correctly 1`] = `
             </a>
           </span>
           <span
-            class="wrapper"
+            class="wrapper breadcrumb"
           >
             <a
               class="anchorLink path"
@@ -61,7 +61,7 @@ exports[`PageHeader renders correctly 1`] = `
             </a>
           </span>
           <span
-            class="wrapper"
+            class="wrapper breadcrumb"
           >
             <span
               class="path"


### PR DESCRIPTION
Fixes #43687

Make sure that the header component allows long repo paths.

@AlicjaSuska: Path breadcrumbs also break very oddly in this view (they are displayed in the second line here?). What do you think of hiding some of the interim levels? e.g. if there are more than 8 directories or so, we hide some of the middle ones and just display a generic `...`? 

## Test plan

Tested locally:

<img width="1271" alt="Screenshot 2022-11-23 at 17 16 37" src="https://user-images.githubusercontent.com/458591/203792459-c9aae583-0b55-414d-95e9-6dbdc33f5eed.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-word-break-for-repo-pages.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
