### PR TITLE
Remove lock around external service sync and delete

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -188,6 +188,7 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	logger.Warn("going into handleExternalServiceValidate")
 	statusCode, resp := handleExternalServiceValidate(ctx, logger, es, genericSrc)
 	if statusCode > 0 {
 		s.respond(w, statusCode, resp)
@@ -265,6 +266,8 @@ func handleExternalServiceValidate(ctx context.Context, logger log.Logger, es *t
 
 func externalServiceValidate(ctx context.Context, es *types.ExternalService, src repos.Source) error {
 	if !es.DeletedAt.IsZero() {
+
+		fmt.Println("early exit because it's deleted")
 		// We don't need to check deleted services.
 		return nil
 	}

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/locker"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
@@ -508,6 +507,8 @@ func (s *Syncer) SyncExternalService(
 	logger := s.Logger.With(log.Int64("externalServiceID", externalServiceID))
 	logger.Info("syncing external service")
 
+	logger.Warn("SyncExternalService")
+
 	// Ensure the job field is recorded when monitoring external API calls
 	ctx = metrics.ContextWithTask(ctx, "SyncExternalService")
 
@@ -519,39 +520,40 @@ func (s *Syncer) SyncExternalService(
 	// want to hold a lock on the external_services table for too long.
 	svc, err = s.Store.ExternalServiceStore().GetByID(ctx, externalServiceID)
 	if err != nil {
+		logger.Warn("could not find ext svc", log.Int64("extsvcid", externalServiceID))
 		return errors.Wrap(err, "fetching external services")
 	}
 
 	// We take an advisory lock here and also when deleting an external service to
 	// ensure that they can't happen at the same time.
-	lock := locker.NewWith(s.Store, "external_service")
+	// lock := locker.NewWith(s.Store, "external_service")
 
-	var locked bool
-	var unlock locker.UnlockFunc
-	// We need both code paths here since our production code doesn't use a
-	// transaction but most of our tests DO run in transactions in order to make
-	// rolling back test state easier.
-	if s.Store.Handle().InTransaction() {
-		locked, err = lock.LockInTransaction(ctx, locker.StringKey(fmt.Sprintf("%d", svc.ID)), false)
-		if err != nil {
-			return errors.Wrap(err, "getting advisory lock")
-		}
-		if !locked {
-			return errors.Errorf("could not get advisory lock for service %d", svc.ID)
-		}
-	} else {
-		// We're NOT in a transaction
-		locked, unlock, err = lock.Lock(ctx, locker.StringKey(fmt.Sprintf("%d", svc.ID)), false)
-		if err != nil {
-			return errors.Wrap(err, "getting advisory lock")
-		}
-		if !locked {
-			return errors.Errorf("could not get advisory lock for service %d", svc.ID)
-		}
-		defer func() {
-			err = unlock(err)
-		}()
-	}
+	// var locked bool
+	// var unlock locker.UnlockFunc
+	// // We need both code paths here since our production code doesn't use a
+	// // transaction but most of our tests DO run in transactions in order to make
+	// // rolling back test state easier.
+	// if s.Store.Handle().InTransaction() {
+	// 	locked, err = lock.LockInTransaction(ctx, locker.StringKey(fmt.Sprintf("%d", svc.ID)), false)
+	// 	if err != nil {
+	// 		return errors.Wrap(err, "getting advisory lock")
+	// 	}
+	// 	if !locked {
+	// 		return errors.Errorf("could not get advisory lock for service %d", svc.ID)
+	// 	}
+	// } else {
+	// 	// We're NOT in a transaction
+	// 	locked, unlock, err = lock.Lock(ctx, locker.StringKey(fmt.Sprintf("%d", svc.ID)), false)
+	// 	if err != nil {
+	// 		return errors.Wrap(err, "getting advisory lock")
+	// 	}
+	// 	if !locked {
+	// 		return errors.Errorf("could not get advisory lock for service %d", svc.ID)
+	// 	}
+	// 	defer func() {
+	// 		err = unlock(err)
+	// 	}()
+	// }
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -566,9 +568,7 @@ func (s *Syncer) SyncExternalService(
 		svc.NextSyncAt = now.Add(interval)
 		svc.LastSyncAt = now
 
-		// We use context.Background() here because we want this update to
-		// succeed even if the job has been canceled.
-		if err := s.Store.ExternalServiceStore().Upsert(context.Background(), svc); err != nil {
+		if err := s.Store.ExternalServiceStore().Upsert(ctx, svc); err != nil {
 			// We only want to log this error, not return it
 			logger.Error("upserting external service", log.Error(err))
 		}
@@ -601,6 +601,14 @@ func (s *Syncer) SyncExternalService(
 	results := make(chan SourceResult)
 	go func() {
 		s.Logger.Debug("listing repos asynchronously")
+		for i := 0; i < 100; i++ {
+			if ctx.Err() != nil {
+				s.Logger.Warn("sleep done cause context is canceled", log.Int("i", i))
+				break
+			}
+			s.Logger.Warn("sleeping for one second", log.Int("i", i))
+			time.Sleep(1 * time.Second)
+		}
 		src.ListRepos(ctx, results)
 		close(results)
 	}()
@@ -623,7 +631,9 @@ func (s *Syncer) SyncExternalService(
 	var syncProgress SyncProgress
 	// Record the final progress state
 	defer func() {
-		if err := progressRecorder(ctx, syncProgress, true); err != nil {
+		// Use a different context here so that we make sure to record progress
+		// even if context has been canceled
+		if err := progressRecorder(context.Background(), syncProgress, true); err != nil {
 			logger.Error("recording final sync progress", log.Error(err))
 		}
 	}()


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/44146 by removing the lock and replacing it with the following mechanisms:

1. When deleting an external service, we load the external service from the database with `FOR UPDATE` to lock that single row.
2. Once we have that row, we cancel all currently running sync jobs and wait until they're canceled.
3. To avoid new sync jobs being enqueued _while the deletion is in progress_ we also try to load the external service with `FOR UPDATE` and then don't create a sync job if we can't load it.

So, in practical terms:

1. Deleting an external service while sync is going on: might take ~10s until the job is canceled. Then the external service is deleted.
2. Triggering a sync while external service is being deleted: blocks for a few seconds until deletion is done, then fails with "not found".

## TODOs

- [ ] Write/modify tests

## Test plan

- Lots of manual testing
