### PR TITLE
insights: update empty repo error handling in commit indexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed a bug where Open in Editor didn't work well with `"repositoryPathPattern" = "{nameWithOwner}"` [#43839](https://github.com/sourcegraph/sourcegraph/pull/44475)
 - The Code Insights commit indexer no longer errors when fetching commits from empty repositories when sub-repo permissions are enabled. [#44558](https://github.com/sourcegraph/sourcegraph/pull/44558)
 
-
 ### Removed
 
 - Remove the older `log.gitserver.accessLogs` site config setting. The setting is succeeded by `log.auditLog.gitserverAccess`. [#43174](https://github.com/sourcegraph/sourcegraph/pull/43174)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed a bug where path matches on files in the root directory of a repository were not highlighted. [#43275](https://github.com/sourcegraph/sourcegraph/pull/43275)
 - Fixed a bug where a search query wouldn't be validated after the query type has changed. [#43849](https://github.com/sourcegraph/sourcegraph/pull/43849)
 - Fixed a bug where Open in Editor didn't work well with `"repositoryPathPattern" = "{nameWithOwner}"` [#43839](https://github.com/sourcegraph/sourcegraph/pull/44475)
+- The Code Insights commit indexer no longer errors when fetching commits from empty repositories when sub-repo permissions are enabled. [#44558](https://github.com/sourcegraph/sourcegraph/pull/44558)
+
 
 ### Removed
 

--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -209,7 +209,7 @@ const (
 func generateEmptyRepoErrorMessage(after time.Time, until *time.Time) string {
 	fullEmptyRepoErrMessage := emptyRepoErrMessagePrefix + " --after=" + after.Format(time.RFC3339)
 	if until != nil {
-		fullEmptyRepoErrMessage += " --before=" + until.Format(time.RFC3339Nano)
+		fullEmptyRepoErrMessage += " --before=" + until.Format(time.RFC3339)
 	}
 	return fullEmptyRepoErrMessage + emptyRepoErrMessageSuffix
 }

--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -203,25 +203,27 @@ func (i *CommitIndexer) indexNextWindow(name string, id api.RepoID, windowDurati
 
 const (
 	emptyRepoErrMessagePrefix = `git command [git log --format=format:%H%x00%aN%x00%aE%x00%at%x00%cN%x00%cE%x00%ct%x00%B%x00%P%x00`
-	emptyRepoErrMessageSuffix = ` --date-order] failed (output: ""): exit status 128`
+	emptyRepoErrMessageSuffix = `] failed (output: ""): exit status 128`
 )
 
-func generateEmptyRepoErrorMessage(after time.Time, until *time.Time) string {
-	fullEmptyRepoErrMessage := emptyRepoErrMessagePrefix + " --after=" + after.Format(time.RFC3339)
+func generateEmptyRepoErrorMessage(after time.Time, until *time.Time, nameOnly bool) string {
+	fullMessage := emptyRepoErrMessagePrefix + " --after=" + after.Format(time.RFC3339)
 	if until != nil {
-		fullEmptyRepoErrMessage += " --before=" + until.Format(time.RFC3339)
+		fullMessage += " --before=" + until.Format(time.RFC3339)
 	}
-	return fullEmptyRepoErrMessage + emptyRepoErrMessageSuffix
+	fullMessage += " --date-order"
+	if nameOnly {
+		fullMessage += " --name-only"
+	}
+	return fullMessage + emptyRepoErrMessageSuffix
 }
 
-func isCommitEmptyRepoError(err error, after time.Time, until *time.Time) bool {
-	emptyRepoErrMessage := generateEmptyRepoErrorMessage(after, until)
-	unwrappedErr := err
-	for unwrappedErr != nil {
-		if strings.Contains(err.Error(), emptyRepoErrMessage) {
-			return true
-		}
-		unwrappedErr = errors.Unwrap(unwrappedErr)
+func isCommitEmptyRepoError(err error, after time.Time, until *time.Time, nameOnly bool) bool {
+	if err == nil {
+		return false
+	}
+	if strings.Contains(err.Error(), generateEmptyRepoErrorMessage(after, until, nameOnly)) {
+		return true
 	}
 	return false
 }
@@ -236,9 +238,13 @@ func getCommits(ctx context.Context, db database.DB, name api.RepoName, after ti
 		before = until.Format(time.RFC3339)
 	}
 
-	commits, err := gitserver.NewClient(db).Commits(ctx, name, gitserver.CommitsOptions{N: 0, DateOrder: true, NoEnsureRevision: true, After: after.Format(time.RFC3339), Before: before}, authz.DefaultSubRepoPermsChecker)
+	opts := gitserver.CommitsOptions{N: 0, DateOrder: true, NoEnsureRevision: true, After: after.Format(time.RFC3339), Before: before}
+	if authz.SubRepoEnabled(authz.DefaultSubRepoPermsChecker) {
+		opts.NameOnly = true
+	}
+	commits, err := gitserver.NewClient(db).Commits(ctx, name, opts, authz.DefaultSubRepoPermsChecker)
 	if err != nil {
-		if isCommitEmptyRepoError(err, after, until) {
+		if isCommitEmptyRepoError(err, after, until, opts.NameOnly) {
 			log15.Info("insights-job.background.CommitIndexer.getCommits: empty repo - updating success metadata", "repository", name)
 			err = nil
 		} else {

--- a/enterprise/internal/insights/compression/worker_test.go
+++ b/enterprise/internal/insights/compression/worker_test.go
@@ -359,17 +359,16 @@ func Test_IsEmptyRepoError(t *testing.T) {
 	t.Parallel()
 
 	defaultDate := time.Date(2022, 07, 01, 12, 12, 12, 10, time.UTC)
-	defaultError := generateEmptyRepoErrorMessage(defaultDate, nil, false)
+	defaultError := errors.New(generateEmptyRepoErrorMessagePrefix(defaultDate, nil) + emptyRepoErrMessageSuffix)
 
 	testCases := []struct {
-		err      error
-		after    time.Time
-		until    *time.Time
-		nameOnly bool
-		want     autogold.Value
+		err   error
+		after time.Time
+		until *time.Time
+		want  autogold.Value
 	}{
 		{
-			err:   errors.New(defaultError),
+			err:   defaultError,
 			after: defaultDate,
 			until: nil,
 			want:  autogold.Want("EmptyRepo", true),
@@ -393,23 +392,21 @@ func Test_IsEmptyRepoError(t *testing.T) {
 			want:  autogold.Want("NestedNotEmptyRepoError", false),
 		},
 		{
-			err:   errors.New(generateEmptyRepoErrorMessage(defaultDate, &defaultDate, false)),
+			err:   errors.New(generateEmptyRepoErrorMessagePrefix(defaultDate, &defaultDate) + emptyRepoErrMessageSuffix),
 			after: defaultDate,
 			until: &defaultDate,
 			want:  autogold.Want("EmptyRepoUntil", true),
 		},
 		{
-			err:      errors.New(generateEmptyRepoErrorMessage(defaultDate, nil, true)),
-			after:    defaultDate,
-			nameOnly: true,
-			want:     autogold.Want("EmptyRepoSubRepoPermissions", true),
+			err:   errors.New(generateEmptyRepoErrorMessagePrefix(defaultDate, nil) + emptyRepoErrMessageSuffixWithNameOnly),
+			after: defaultDate,
+			want:  autogold.Want("EmptyRepoSubRepoPermissions", true),
 		},
 		{
-			err:      errors.New(generateEmptyRepoErrorMessage(defaultDate, &defaultDate, true)),
-			after:    defaultDate,
-			until:    &defaultDate,
-			nameOnly: true,
-			want:     autogold.Want("EmptyRepoUntilSubRepoPermissions", true),
+			err:   errors.New(generateEmptyRepoErrorMessagePrefix(defaultDate, &defaultDate) + emptyRepoErrMessageSuffixWithNameOnly),
+			after: defaultDate,
+			until: &defaultDate,
+			want:  autogold.Want("EmptyRepoUntilSubRepoPermissions", true),
 		},
 		{
 			err:   errors.New("A different error"),
@@ -426,7 +423,7 @@ func Test_IsEmptyRepoError(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.want.Name(), func(t *testing.T) {
-			got := isCommitEmptyRepoError(tc.err, tc.after, tc.until, tc.nameOnly)
+			got := isCommitEmptyRepoError(tc.err, tc.after, tc.until)
 			tc.want.Equal(t, got)
 		})
 	}

--- a/enterprise/internal/insights/compression/worker_test.go
+++ b/enterprise/internal/insights/compression/worker_test.go
@@ -359,13 +359,14 @@ func Test_IsEmptyRepoError(t *testing.T) {
 	t.Parallel()
 
 	defaultDate := time.Date(2022, 07, 01, 12, 12, 12, 10, time.UTC)
-	defaultError := generateEmptyRepoErrorMessage(defaultDate, nil)
+	defaultError := generateEmptyRepoErrorMessage(defaultDate, nil, false)
 
 	testCases := []struct {
-		err   error
-		after time.Time
-		until *time.Time
-		want  autogold.Value
+		err      error
+		after    time.Time
+		until    *time.Time
+		nameOnly bool
+		want     autogold.Value
 	}{
 		{
 			err:   errors.New(defaultError),
@@ -392,10 +393,23 @@ func Test_IsEmptyRepoError(t *testing.T) {
 			want:  autogold.Want("NestedNotEmptyRepoError", false),
 		},
 		{
-			err:   errors.New(generateEmptyRepoErrorMessage(defaultDate, &defaultDate)),
+			err:   errors.New(generateEmptyRepoErrorMessage(defaultDate, &defaultDate, false)),
 			after: defaultDate,
 			until: &defaultDate,
 			want:  autogold.Want("EmptyRepoUntil", true),
+		},
+		{
+			err:      errors.New(generateEmptyRepoErrorMessage(defaultDate, nil, true)),
+			after:    defaultDate,
+			nameOnly: true,
+			want:     autogold.Want("EmptyRepoSubRepoPermissions", true),
+		},
+		{
+			err:      errors.New(generateEmptyRepoErrorMessage(defaultDate, &defaultDate, true)),
+			after:    defaultDate,
+			until:    &defaultDate,
+			nameOnly: true,
+			want:     autogold.Want("EmptyRepoUntilSubRepoPermissions", true),
 		},
 		{
 			err:   errors.New("A different error"),
@@ -412,7 +426,7 @@ func Test_IsEmptyRepoError(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.want.Name(), func(t *testing.T) {
-			got := isCommitEmptyRepoError(tc.err, tc.after, tc.until)
+			got := isCommitEmptyRepoError(tc.err, tc.after, tc.until, tc.nameOnly)
 			tc.want.Equal(t, got)
 		})
 	}

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -1885,7 +1885,11 @@ func TestRepository_Commits_options(t *testing.T) {
 		}
 		// Added for awareness if this error message changes. Insights record last repo indexing and consider empty
 		// repos a success case.
-		t.Run("empty repo", func(t *testing.T) {
+		subRepo := ""
+		if checker != nil {
+			subRepo = " sub repo enabled"
+		}
+		t.Run("empty repo"+subRepo, func(t *testing.T) {
 			repo := MakeGitRepository(t)
 			before := ""
 			after := time.Date(2022, 11, 11, 12, 10, 0, 4, time.UTC).Format(time.RFC3339)
@@ -1893,11 +1897,13 @@ func TestRepository_Commits_options(t *testing.T) {
 			if err == nil {
 				t.Error("expected error, got nil")
 			}
-			wantErrPrefix := `git command [git log --format=format:%H%x00%aN%x00%aE%x00%at%x00%cN%x00%cE%x00%ct%x00%B%x00%P%x00 --after=` + after
-			wantErrSuffix := `--date-order] failed (output: ""): exit status 128`
-			errString := err.Error()
-			if !strings.HasPrefix(errString, wantErrPrefix) || !strings.HasSuffix(errString, wantErrSuffix) {
-				t.Errorf("expected prefix and suffix [%s] [%s], got full [%s]", wantErrPrefix, wantErrSuffix, errString)
+			wantErr := `git command [git log --format=format:%H%x00%aN%x00%aE%x00%at%x00%cN%x00%cE%x00%ct%x00%B%x00%P%x00 --after=` + after + " --date-order"
+			if subRepo != "" {
+				wantErr += " --name-only"
+			}
+			wantErr += `] failed (output: ""): exit status 128`
+			if err.Error() != wantErr {
+				t.Errorf("expected:%v got:%v", wantErr, err.Error())
 			}
 		})
 	}


### PR DESCRIPTION
while running tests on scaletesting found that we were erroring on empty repos again even though it should have been fixed by #38091. turns out sub repo permissions are enabled on the env and the git command changes in those cases.

tldr; account for `--name-only` option

## Test plan

Added and updated unit tests