### PR TITLE
allow batch changes BB cloud webhook to use top-level webhook handler

### DIFF
--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -22,7 +22,7 @@ type Services struct {
 	BatchesGitHubWebhook            webhooks.Registerer
 	BatchesGitLabWebhook            webhooks.RegistererHandler
 	BatchesBitbucketServerWebhook   webhooks.RegistererHandler
-	BatchesBitbucketCloudWebhook    http.Handler
+	BatchesBitbucketCloudWebhook    webhooks.RegistererHandler
 	BatchesChangesFileGetHandler    http.Handler
 	BatchesChangesFileExistsHandler http.Handler
 	BatchesChangesFileUploadHandler http.Handler
@@ -77,7 +77,7 @@ func DefaultServices() Services {
 		BatchesGitHubWebhook:            &emptyWebhookHandler{name: "batches github webhook"},
 		BatchesGitLabWebhook:            &emptyWebhookHandler{name: "batches gitlab webhook"},
 		BatchesBitbucketServerWebhook:   &emptyWebhookHandler{name: "batches bitbucket server webhook"},
-		BatchesBitbucketCloudWebhook:    makeNotFoundHandler("batches bitbucket cloud webhook"),
+		BatchesBitbucketCloudWebhook:    &emptyWebhookHandler{name: "batches bitbucket cloud webhook"},
 		BatchesChangesFileGetHandler:    makeNotFoundHandler("batches file get handler"),
 		BatchesChangesFileExistsHandler: makeNotFoundHandler("batches file exists handler"),
 		BatchesChangesFileUploadHandler: makeNotFoundHandler("batches file upload handler"),

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -43,7 +43,7 @@ type Handlers struct {
 	BatchesGitHubWebhook            webhooks.Registerer
 	BatchesGitLabWebhook            webhooks.RegistererHandler
 	BatchesBitbucketServerWebhook   webhooks.RegistererHandler
-	BatchesBitbucketCloudWebhook    http.Handler
+	BatchesBitbucketCloudWebhook    webhooks.RegistererHandler
 	BatchesChangesFileGetHandler    http.Handler
 	BatchesChangesFileExistsHandler http.Handler
 	BatchesChangesFileUploadHandler http.Handler
@@ -94,6 +94,7 @@ func NewHandler(
 	handlers.BatchesGitHubWebhook.Register(&wh)
 	handlers.BatchesGitLabWebhook.Register(&wh)
 	handlers.BatchesBitbucketServerWebhook.Register(&wh)
+	handlers.BatchesBitbucketCloudWebhook.Register(&wh)
 	handlers.GitHubSyncWebhook.Register(&wh)
 
 	// 🚨 SECURITY: This handler implements its own secret-based auth

--- a/cmd/frontend/webhooks/bitbucketcloud_webhooks.go
+++ b/cmd/frontend/webhooks/bitbucketcloud_webhooks.go
@@ -1,0 +1,41 @@
+package webhooks
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
+)
+
+func (wr *WebhookRouter) HandleBitbucketCloudWebhook(logger log.Logger, w http.ResponseWriter, r *http.Request, codeHostURN extsvc.CodeHostBaseURL) {
+	payload, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Error while reading request body.", http.StatusInternalServerError)
+		return
+	}
+	defer r.Body.Close()
+	ctx := actor.WithInternalActor(r.Context())
+
+	eventType := r.Header.Get("X-Event-Key")
+	e, err := bitbucketcloud.ParseWebhookEvent(eventType, payload)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Route the request based on the event type.
+	err = wr.Dispatch(ctx, eventType, extsvc.KindBitbucketCloud, codeHostURN, e)
+	if err != nil {
+		logger.Error("Error handling bitbucket cloud webhook event", log.Error(err))
+		if errcode.IsNotFound(err) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/cmd/frontend/webhooks/webhooks.go
+++ b/cmd/frontend/webhooks/webhooks.go
@@ -119,7 +119,9 @@ func webhookHandler(logger log.Logger, db database.DB, wh *WebhookRouter) http.H
 			wh.handleBitbucketServerWebhook(logger, w, r, webhook.CodeHostURN, secret)
 			return
 		case extsvc.KindBitbucketCloud:
-			// TODO: handle Bitbucket Cloud secret verification
+			// Bitbucket Cloud does not support secrets for webhooks
+			wh.HandleBitbucketCloudWebhook(logger, w, r, webhook.CodeHostURN)
+			return
 		}
 
 		http.Error(w, fmt.Sprintf("webhooks not implemented for code host kind %q", webhook.CodeHostKind), http.StatusNotImplemented)

--- a/cmd/frontend/webhooks/webhooks_test.go
+++ b/cmd/frontend/webhooks/webhooks_test.go
@@ -357,6 +357,23 @@ func TestWebhooksHandler(t *testing.T) {
 		assert.Equal(t, bbCloudWH.CodeHostURN, wh.codeHostURNReceived)
 		assert.Equal(t, &event, wh.eventReceived)
 	})
+
+	t.Run("Bitbucket Cloud returns 404 not found if webhook event type unknown", func(t *testing.T) {
+		requestURL := fmt.Sprintf("%s/.api/webhooks/%v", srv.URL, bbCloudWH.UUID)
+
+		payload := []byte(`{"body": "text"}`)
+		require.NoError(t, err)
+
+		req, err := http.NewRequest("POST", requestURL, bytes.NewBuffer(payload))
+		require.NoError(t, err)
+		req.Header.Set("X-Event-Key", "unknown_event")
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
 }
 
 type fakeWebhookHandler struct {

--- a/cmd/frontend/webhooks/webhooks_test.go
+++ b/cmd/frontend/webhooks/webhooks_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -70,6 +71,15 @@ func TestWebhooksHandler(t *testing.T) {
 		"http://bitbucket.com",
 		u.ID,
 		types.NewUnencryptedSecret("bbsecret"),
+	)
+	require.NoError(t, err)
+
+	bbCloudWH, err := dbWebhooks.Create(
+		context.Background(),
+		extsvc.KindBitbucketCloud,
+		"http://bitbucket.com",
+		u.ID,
+		types.NewUnencryptedSecret("bbcloudsecret"),
 	)
 	require.NoError(t, err)
 
@@ -311,6 +321,41 @@ func TestWebhooksHandler(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("Bitbucket Cloud returns 200", func(t *testing.T) {
+		requestURL := fmt.Sprintf("%s/.api/webhooks/%v", srv.URL, bbCloudWH.UUID)
+
+		event := bitbucketcloud.PullRequestCommentCreatedEvent{}
+		payload, err := json.Marshal(event)
+		require.NoError(t, err)
+		wh := &fakeWebhookHandler{}
+		wr.handlers = map[string]webhookEventHandlers{
+			extsvc.KindBitbucketCloud: {
+				"pullrequest:comment_created": []WebhookHandler{wh.handleEvent},
+			},
+		}
+
+		req, err := http.NewRequest("POST", requestURL, bytes.NewBuffer(payload))
+		require.NoError(t, err)
+		req.Header.Set("X-Event-Key", "pullrequest:comment_created")
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		logs, _, err := db.WebhookLogs(keyring.Default().WebhookLogKey).List(context.Background(), database.WebhookLogListOpts{
+			WebhookID: &bbCloudWH.ID,
+		})
+		assert.NoError(t, err)
+		assert.Len(t, logs, 1)
+		for _, log := range logs {
+			assert.Equal(t, bbCloudWH.ID, *log.WebhookID)
+		}
+		assert.Equal(t, bbCloudWH.CodeHostURN, wh.codeHostURNReceived)
+		assert.Equal(t, &event, wh.eventReceived)
 	})
 }
 

--- a/enterprise/cmd/frontend/internal/batches/init.go
+++ b/enterprise/cmd/frontend/internal/batches/init.go
@@ -3,6 +3,8 @@ package batches
 import (
 	"context"
 
+	sglog "github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/batches/httpapi"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/batches/resolvers"
@@ -43,11 +45,12 @@ func Init(
 
 	// Register enterprise services.
 	gitserverClient := gitserver.NewClient(db)
+	logger := sglog.Scoped("Batches", "batch changes webhooks")
 	enterpriseServices.BatchChangesResolver = resolvers.New(bstore, gitserverClient)
-	enterpriseServices.BatchesGitHubWebhook = webhooks.NewGitHubWebhook(bstore, gitserverClient)
-	enterpriseServices.BatchesBitbucketServerWebhook = webhooks.NewBitbucketServerWebhook(bstore, gitserverClient)
-	enterpriseServices.BatchesBitbucketCloudWebhook = webhooks.NewBitbucketCloudWebhook(bstore, gitserverClient)
-	enterpriseServices.BatchesGitLabWebhook = webhooks.NewGitLabWebhook(bstore, gitserverClient)
+	enterpriseServices.BatchesGitHubWebhook = webhooks.NewGitHubWebhook(bstore, gitserverClient, logger)
+	enterpriseServices.BatchesBitbucketServerWebhook = webhooks.NewBitbucketServerWebhook(bstore, gitserverClient, logger)
+	enterpriseServices.BatchesBitbucketCloudWebhook = webhooks.NewBitbucketCloudWebhook(bstore, gitserverClient, logger)
+	enterpriseServices.BatchesGitLabWebhook = webhooks.NewGitLabWebhook(bstore, gitserverClient, logger)
 
 	operations := httpapi.NewOperations(observationContext)
 	fileHandler := httpapi.NewFileHandler(db, bstore, operations)

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud.go
@@ -109,12 +109,9 @@ func (h *BitbucketCloudWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		respond(w, http.StatusInternalServerError, errors.Wrap(err, "parsing code host base url"))
 	}
-	m := h.handleEvent(ctx, h.Store.DatabaseDB(), codeHostURN, e)
-	if m != nil {
-		if errors.Is(err, bitbucketcloud.UnknownWebhookEventKey("")) {
-			return
-		}
-		respond(w, http.StatusInternalServerError, m)
+	err = h.handleEvent(ctx, h.Store.DatabaseDB(), codeHostURN, e)
+	if err != nil {
+		respond(w, http.StatusInternalServerError, err)
 	} else {
 		respond(w, http.StatusNoContent, nil)
 	}

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud_test.go
@@ -45,6 +45,7 @@ const (
 func testBitbucketCloudWebhook(db *sql.DB) func(*testing.T) {
 	return func(t *testing.T) {
 		ctx := context.Background()
+		logger := logtest.Scoped(t)
 
 		cfg := &schema.BitbucketCloudConnection{
 			WebhookSecret: "secretsecret",
@@ -56,7 +57,7 @@ func testBitbucketCloudWebhook(db *sql.DB) func(*testing.T) {
 		t.Run("ServeHTTP", func(t *testing.T) {
 			t.Run("missing external service", func(t *testing.T) {
 				store := bitbucketCloudTestSetup(t, db)
-				h := NewBitbucketCloudWebhook(store, gsClient)
+				h := NewBitbucketCloudWebhook(store, gsClient, logger)
 
 				u, err := extsvc.WebhookURL(extsvc.KindBitbucketCloud, 12345, cfg, esURL)
 				assert.Nil(t, err)
@@ -72,7 +73,7 @@ func testBitbucketCloudWebhook(db *sql.DB) func(*testing.T) {
 
 			t.Run("invalid external service", func(t *testing.T) {
 				store := bitbucketCloudTestSetup(t, db)
-				h := NewBitbucketCloudWebhook(store, gsClient)
+				h := NewBitbucketCloudWebhook(store, gsClient, logger)
 
 				u, err := extsvc.WebhookURL(extsvc.KindBitbucketCloud, 12345, cfg, esURL)
 				assert.Nil(t, err)
@@ -89,7 +90,7 @@ func testBitbucketCloudWebhook(db *sql.DB) func(*testing.T) {
 
 			t.Run("missing secret", func(t *testing.T) {
 				store := bitbucketCloudTestSetup(t, db)
-				h := NewBitbucketCloudWebhook(store, gsClient)
+				h := NewBitbucketCloudWebhook(store, gsClient, logger)
 				es := createBitbucketCloudExternalService(t, ctx, store.ExternalServices())
 
 				u, err := extsvc.WebhookURL(extsvc.KindBitbucketCloud, es.ID, cfg, esURL)
@@ -107,7 +108,7 @@ func testBitbucketCloudWebhook(db *sql.DB) func(*testing.T) {
 
 			t.Run("incorrect secret", func(t *testing.T) {
 				store := bitbucketCloudTestSetup(t, db)
-				h := NewBitbucketCloudWebhook(store, gsClient)
+				h := NewBitbucketCloudWebhook(store, gsClient, logger)
 				es := createBitbucketCloudExternalService(t, ctx, store.ExternalServices())
 
 				u, err := extsvc.WebhookURL(extsvc.KindBitbucketCloud, es.ID, cfg, esURL)
@@ -125,7 +126,7 @@ func testBitbucketCloudWebhook(db *sql.DB) func(*testing.T) {
 
 			t.Run("missing body", func(t *testing.T) {
 				store := bitbucketCloudTestSetup(t, db)
-				h := NewBitbucketCloudWebhook(store, gsClient)
+				h := NewBitbucketCloudWebhook(store, gsClient, logger)
 
 				u, err := extsvc.WebhookURL(extsvc.KindBitbucketCloud, 12345, cfg, "https://bitbucket.org/")
 				assert.Nil(t, err)
@@ -141,7 +142,7 @@ func testBitbucketCloudWebhook(db *sql.DB) func(*testing.T) {
 
 			t.Run("unreadable body", func(t *testing.T) {
 				store := bitbucketCloudTestSetup(t, db)
-				h := NewBitbucketCloudWebhook(store, gsClient)
+				h := NewBitbucketCloudWebhook(store, gsClient, logger)
 				es := createBitbucketCloudExternalService(t, ctx, store.ExternalServices())
 
 				u, err := extsvc.WebhookURL(extsvc.KindBitbucketCloud, es.ID, cfg, esURL)
@@ -158,7 +159,7 @@ func testBitbucketCloudWebhook(db *sql.DB) func(*testing.T) {
 
 			t.Run("malformed body", func(t *testing.T) {
 				store := bitbucketCloudTestSetup(t, db)
-				h := NewBitbucketCloudWebhook(store, gsClient)
+				h := NewBitbucketCloudWebhook(store, gsClient, logger)
 				es := createBitbucketCloudExternalService(t, ctx, store.ExternalServices())
 
 				u, err := extsvc.WebhookURL(extsvc.KindBitbucketCloud, es.ID, cfg, esURL)
@@ -175,7 +176,7 @@ func testBitbucketCloudWebhook(db *sql.DB) func(*testing.T) {
 
 			t.Run("invalid event key", func(t *testing.T) {
 				store := bitbucketCloudTestSetup(t, db)
-				h := NewBitbucketCloudWebhook(store, gsClient)
+				h := NewBitbucketCloudWebhook(store, gsClient, logger)
 				es := createBitbucketCloudExternalService(t, ctx, store.ExternalServices())
 
 				u, err := extsvc.WebhookURL(extsvc.KindBitbucketCloud, es.ID, cfg, esURL)
@@ -198,7 +199,7 @@ func testBitbucketCloudWebhook(db *sql.DB) func(*testing.T) {
 
 			t.Run("valid events", func(t *testing.T) {
 				store := bitbucketCloudTestSetup(t, db)
-				h := NewBitbucketCloudWebhook(store, gsClient)
+				h := NewBitbucketCloudWebhook(store, gsClient, logger)
 				es := createBitbucketCloudExternalService(t, ctx, store.ExternalServices())
 				repo := createBitbucketCloudRepo(t, ctx, store.Repos(), es)
 

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
@@ -40,6 +40,7 @@ import (
 // Run from integration_test.go
 func testBitbucketServerWebhook(db database.DB, userID int32) func(*testing.T) {
 	return func(t *testing.T) {
+		logger := logtest.Scoped(t)
 		now := timeutil.Now()
 		clock := func() time.Time { return now }
 
@@ -173,7 +174,7 @@ func testBitbucketServerWebhook(db database.DB, userID int32) func(*testing.T) {
 			}
 		}
 
-		hook := NewBitbucketServerWebhook(s, gsClient)
+		hook := NewBitbucketServerWebhook(s, gsClient, logger)
 
 		fixtureFiles, err := filepath.Glob("testdata/fixtures/webhooks/bitbucketserver/*.json")
 		if err != nil {

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 
 	gh "github.com/google/go-github/v43/github"
-	"github.com/inconshreveable/log15"
+	sglog "github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
@@ -40,8 +40,8 @@ type GitHubWebhook struct {
 	*webhook
 }
 
-func NewGitHubWebhook(store *store.Store, gitserverClient gitserver.Client) *GitHubWebhook {
-	return &GitHubWebhook{&webhook{store, gitserverClient, extsvc.TypeGitHub}}
+func NewGitHubWebhook(store *store.Store, gitserverClient gitserver.Client, logger sglog.Logger) *GitHubWebhook {
+	return &GitHubWebhook{&webhook{store, gitserverClient, logger, extsvc.TypeGitHub}}
 }
 
 // Register registers this webhook handler to handle events with the passed webhook router
@@ -81,7 +81,7 @@ func (h *GitHubWebhook) handleGitHubWebhook(ctx context.Context, db database.DB,
 }
 
 func (h *GitHubWebhook) convertEvent(ctx context.Context, codeHostURN extsvc.CodeHostBaseURL, theirs any) (prs []PR, ours keyer) {
-	log15.Debug("GitHub webhook received", "type", fmt.Sprintf("%T", theirs))
+	h.logger.Debug("GitHub webhook received", sglog.String("type", fmt.Sprintf("%T", theirs)))
 	switch e := theirs.(type) {
 	case *gh.IssueCommentEvent:
 		repo := e.GetRepo()
@@ -188,14 +188,14 @@ func (h *GitHubWebhook) convertEvent(ctx context.Context, codeHostURN extsvc.Cod
 
 		ids, err := h.Store.GetChangesetExternalIDs(ctx, spec, refs)
 		if err != nil {
-			log15.Error("Error executing GetChangesetExternalIDs", "err", err)
+			h.logger.Error("Error executing GetChangesetExternalIDs", sglog.Error(err))
 			return nil, nil
 		}
 
 		for _, id := range ids {
 			i, err := strconv.ParseInt(id, 10, 64)
 			if err != nil {
-				log15.Error("Error parsing external id", "err", err)
+				h.logger.Error("Error parsing external id", sglog.Error(err))
 				continue
 			}
 			prs = append(prs, PR{ID: i, RepoExternalID: repoExternalID})

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -167,7 +167,7 @@ func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 			t.Fatal(err)
 		}
 
-		hook := NewGitHubWebhook(s, gsClient)
+		hook := NewGitHubWebhook(s, gsClient, logtest.Scoped(t))
 
 		fixtureFiles, err := filepath.Glob("testdata/fixtures/webhooks/github/*.json")
 		if err != nil {

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/inconshreveable/log15"
+	sglog "github.com/sourcegraph/log"
 
 	fewebhooks "github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
@@ -37,8 +37,8 @@ type GitLabWebhook struct {
 	failHandleEvent error
 }
 
-func NewGitLabWebhook(store *store.Store, gitserverClient gitserver.Client) *GitLabWebhook {
-	return &GitLabWebhook{webhook: &webhook{store, gitserverClient, extsvc.TypeGitLab}}
+func NewGitLabWebhook(store *store.Store, gitserverClient gitserver.Client, logger sglog.Logger) *GitLabWebhook {
+	return &GitLabWebhook{webhook: &webhook{store, gitserverClient, logger, extsvc.TypeGitLab}}
 }
 
 func (h *GitLabWebhook) Register(router *fewebhooks.WebhookRouter) {
@@ -71,21 +71,21 @@ func (h *GitLabWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	c, err := extSvc.Configuration(r.Context())
 	if err != nil {
-		log15.Error("Could not decode external service config", "error", err)
+		h.logger.Error("Could not decode external service config", sglog.Error(err))
 		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
 		return
 	}
 
 	config, ok := c.(*schema.GitLabConnection)
 	if !ok {
-		log15.Error("Could not decode external service config")
+		h.logger.Error("Could not decode external service config")
 		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
 		return
 	}
 
 	codeHostURN, err := extsvc.NewCodeHostBaseURL(config.Url)
 	if err != nil {
-		log15.Error("Could not parse code host URL from config", "error", err)
+		h.logger.Error("Could not parse code host URL from config", sglog.Error(err))
 		http.Error(w, "Invalid code host URL", http.StatusInternalServerError)
 		return
 	}
@@ -122,7 +122,7 @@ func (h *GitLabWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// We don't want to return a non-2XX status code and have GitLab
 			// retry the webhook, so we'll log that we don't know what to do
 			// and return 204.
-			log15.Debug("unknown object kind", "err", err)
+			h.logger.Debug("unknown object kind", sglog.Error(err))
 
 			// We don't use respond() here so that we don't log an error, since
 			// this really isn't one.
@@ -176,7 +176,7 @@ func (h *GitLabWebhook) getExternalServiceFromRawID(ctx context.Context, raw str
 // handleEvent is essentially a router: it dispatches based on the event type
 // to perform whatever changeset action is appropriate for that event.
 func (h *GitLabWebhook) handleEvent(ctx context.Context, db database.DB, codeHostURN extsvc.CodeHostBaseURL, event any) error {
-	log15.Debug("GitLab webhook received", "type", fmt.Sprintf("%T", event))
+	h.logger.Debug("GitLab webhook received", sglog.String("type", fmt.Sprintf("%T", event)))
 
 	if h.failHandleEvent != nil {
 		return h.failHandleEvent
@@ -246,7 +246,7 @@ func (h *GitLabWebhook) handleEvent(ctx context.Context, db database.DB, codeHos
 
 	// We don't want to return a non-2XX status code and have GitLab retry the
 	// webhook, so we'll log that we don't know what to do and return 204.
-	log15.Debug("cannot handle GitLab webhook event of unknown type", "event", event, "type", fmt.Sprintf("%T", event))
+	h.logger.Debug("cannot handle GitLab webhook event of unknown type", sglog.String("event", fmt.Sprintf("%v", event)), sglog.String("type", fmt.Sprintf("%T", event)))
 	return nil
 }
 
@@ -280,7 +280,7 @@ func (h *GitLabWebhook) handlePipelineEvent(ctx context.Context, esID extsvc.Cod
 	// merge request; if we don't, we can't do anything useful here, and we'll
 	// just have to wait for the next scheduled sync.
 	if event.MergeRequest == nil {
-		log15.Debug("ignoring pipeline event without a merge request", "payload", event)
+		h.logger.Debug("ignoring pipeline event without a merge request", sglog.String("payload", fmt.Sprintf("%v", event)))
 		return errPipelineMissingMergeRequest
 	}
 

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab_test.go
@@ -47,7 +47,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 		t.Run("ServeHTTP", func(t *testing.T) {
 			t.Run("missing external service", func(t *testing.T) {
 				store := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, gsClient)
+				h := NewGitLabWebhook(store, gsClient, logger)
 
 				u, err := extsvc.WebhookURL(extsvc.TypeGitLab, 12345, nil, "https://example.com/")
 				if err != nil {
@@ -69,7 +69,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 
 			t.Run("invalid external service", func(t *testing.T) {
 				store := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, gsClient)
+				h := NewGitLabWebhook(store, gsClient, logger)
 
 				u, err := extsvc.WebhookURL(extsvc.TypeGitLab, 12345, nil, "https://example.com/")
 				if err != nil {
@@ -94,7 +94,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 
 			t.Run("missing secret", func(t *testing.T) {
 				store := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, gsClient)
+				h := NewGitLabWebhook(store, gsClient, logger)
 				es := createGitLabExternalService(t, ctx, store.ExternalServices())
 
 				u, err := extsvc.WebhookURL(extsvc.TypeGitLab, es.ID, nil, "https://example.com/")
@@ -119,7 +119,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 
 			t.Run("incorrect secret", func(t *testing.T) {
 				store := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, gsClient)
+				h := NewGitLabWebhook(store, gsClient, logger)
 				es := createGitLabExternalService(t, ctx, store.ExternalServices())
 
 				u, err := extsvc.WebhookURL(extsvc.TypeGitLab, es.ID, nil, "https://example.com/")
@@ -145,7 +145,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 
 			t.Run("missing body", func(t *testing.T) {
 				store := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, gsClient)
+				h := NewGitLabWebhook(store, gsClient, logger)
 				es := createGitLabExternalService(t, ctx, store.ExternalServices())
 
 				u, err := extsvc.WebhookURL(extsvc.TypeGitLab, es.ID, nil, "https://example.com/")
@@ -171,7 +171,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 
 			t.Run("unreadable body", func(t *testing.T) {
 				store := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, gsClient)
+				h := NewGitLabWebhook(store, gsClient, logger)
 				es := createGitLabExternalService(t, ctx, store.ExternalServices())
 
 				u, err := extsvc.WebhookURL(extsvc.TypeGitLab, es.ID, nil, "https://example.com/")
@@ -198,7 +198,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 
 			t.Run("malformed body", func(t *testing.T) {
 				store := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, gsClient)
+				h := NewGitLabWebhook(store, gsClient, logger)
 				es := createGitLabExternalService(t, ctx, store.ExternalServices())
 
 				u, err := extsvc.WebhookURL(extsvc.TypeGitLab, es.ID, nil, "https://example.com/")
@@ -224,7 +224,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 
 			t.Run("invalid body", func(t *testing.T) {
 				store := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, gsClient)
+				h := NewGitLabWebhook(store, gsClient, logger)
 				es := createGitLabExternalService(t, ctx, store.ExternalServices())
 
 				u, err := extsvc.WebhookURL(extsvc.TypeGitLab, es.ID, nil, "https://example.com/")
@@ -254,7 +254,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 				store := gitLabTestSetup(t, db)
 				repoStore := database.ReposWith(logger, store)
 
-				h := NewGitLabWebhook(store, gsClient)
+				h := NewGitLabWebhook(store, gsClient, logger)
 				// Force a failure
 				h.failHandleEvent = errors.New("oops")
 
@@ -296,7 +296,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 					t.Run(action, func(t *testing.T) {
 						store := gitLabTestSetup(t, db)
 						repoStore := database.ReposWith(logger, store)
-						h := NewGitLabWebhook(store, gsClient)
+						h := NewGitLabWebhook(store, gsClient, logger)
 						es := createGitLabExternalService(t, ctx, store.ExternalServices())
 						repo := createGitLabRepo(t, ctx, repoStore, es)
 						changeset := createGitLabChangeset(t, ctx, store, repo)
@@ -346,7 +346,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 					t.Run(action, func(t *testing.T) {
 						store := gitLabTestSetup(t, db)
 						repoStore := database.ReposWith(logger, store)
-						h := NewGitLabWebhook(store, gsClient)
+						h := NewGitLabWebhook(store, gsClient, logger)
 						es := createGitLabExternalService(t, ctx, store.ExternalServices())
 						repo := createGitLabRepo(t, ctx, repoStore, es)
 						changeset := createGitLabChangeset(t, ctx, store, repo)
@@ -380,7 +380,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 			t.Run("valid pipeline events", func(t *testing.T) {
 				store := gitLabTestSetup(t, db)
 				repoStore := database.ReposWith(logger, store)
-				h := NewGitLabWebhook(store, gsClient)
+				h := NewGitLabWebhook(store, gsClient, logger)
 				es := createGitLabExternalService(t, ctx, store.ExternalServices())
 				repo := createGitLabRepo(t, ctx, repoStore, es)
 				changeset := createGitLabChangeset(t, ctx, store, repo)
@@ -416,7 +416,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 			// Since these tests don't write to the database, we can just share
 			// the same database setup.
 			store := gitLabTestSetup(t, db)
-			h := NewGitLabWebhook(store, gsClient)
+			h := NewGitLabWebhook(store, gsClient, logger)
 
 			// Set up two GitLab external services.
 			a := createGitLabExternalService(t, ctx, store.ExternalServices())
@@ -489,7 +489,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 			mockDB.ExternalServicesFunc.SetDefaultReturn(externalServices)
 
 			store := gitLabTestSetup(t, db).With(mockDB)
-			h := NewGitLabWebhook(store, gsClient)
+			h := NewGitLabWebhook(store, gsClient, logger)
 
 			_, err := h.getExternalServiceFromRawID(ctx, "12345")
 			if err == nil {
@@ -500,7 +500,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 		t.Run("broken batches store", func(t *testing.T) {
 			// We can induce an error with a broken database connection.
 			s := gitLabTestSetup(t, db)
-			h := NewGitLabWebhook(s, gsClient)
+			h := NewGitLabWebhook(s, gsClient, logger)
 			db := database.NewDBWith(logger, basestore.NewWithHandle(&brokenDB{errors.New("foo")}))
 			h.Store = store.NewWithClock(db, &observation.TestContext, nil, s.Clock())
 
@@ -520,7 +520,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 
 			t.Run("unknown event type", func(t *testing.T) {
 				store := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, gsClient)
+				h := NewGitLabWebhook(store, gsClient, logger)
 				createGitLabExternalService(t, ctx, store.ExternalServices())
 
 				err := h.handleEvent(ctx, store.DatabaseDB(), gitLabURL, nil)
@@ -531,7 +531,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 
 			t.Run("error from enqueueChangesetSyncFromEvent", func(t *testing.T) {
 				store := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, gsClient)
+				h := NewGitLabWebhook(store, gsClient, logger)
 				createGitLabExternalService(t, ctx, store.ExternalServices())
 
 				// We can induce an error with an incomplete merge request
@@ -548,7 +548,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 
 			t.Run("error from handleMergeRequestStateEvent", func(t *testing.T) {
 				s := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(s, gsClient)
+				h := NewGitLabWebhook(s, gsClient, logger)
 				createGitLabExternalService(t, ctx, s.ExternalServices())
 
 				event := &webhooks.MergeRequestCloseEvent{
@@ -567,7 +567,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 
 			t.Run("error from handlePipelineEvent", func(t *testing.T) {
 				s := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(s, gsClient)
+				h := NewGitLabWebhook(s, gsClient, logger)
 				createGitLabExternalService(t, ctx, s.ExternalServices())
 
 				event := &webhooks.PipelineEvent{
@@ -588,7 +588,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 			// the same database setup.
 			store := gitLabTestSetup(t, db)
 			repoStore := database.ReposWith(logger, store)
-			h := NewGitLabWebhook(store, gsClient)
+			h := NewGitLabWebhook(store, gsClient, logger)
 			es := createGitLabExternalService(t, ctx, store.ExternalServices())
 			repo := createGitLabRepo(t, ctx, repoStore, es)
 			changeset := createGitLabChangeset(t, ctx, store, repo)
@@ -683,7 +683,7 @@ func testGitLabWebhook(db *sql.DB) func(*testing.T) {
 			// error if a transaction is started.
 			s := gitLabTestSetup(t, db)
 			store := store.NewWithClock(database.NewDBWith(logger, basestore.NewWithHandle(&noNestingTx{s.Handle()})), &observation.TestContext, nil, s.Clock())
-			h := NewGitLabWebhook(store, gsClient)
+			h := NewGitLabWebhook(store, gsClient, logger)
 
 			t.Run("missing merge request", func(t *testing.T) {
 				event := &webhooks.PipelineEvent{}

--- a/enterprise/cmd/frontend/internal/batches/webhooks/webhooks.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/webhooks.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strconv"
 
+	sglog "github.com/sourcegraph/log"
+
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/state"
@@ -24,6 +26,7 @@ import (
 type webhook struct {
 	Store           *store.Store
 	gitserverClient gitserver.Client
+	logger          sglog.Logger
 
 	// ServiceType corresponds to api.ExternalRepoSpec.ServiceType
 	// Example values: extsvc.TypeBitbucketServer, extsvc.TypeGitHub


### PR DESCRIPTION
NOTE: BB cloud does _not_ support secrets for webhooks (see [here](https://support.atlassian.com/bitbucket-cloud/docs/manage-webhooks/#Secure-webhooks)) currently in the batch changes handler, we just append the secret to the url that we provide for the webhook. I've preserved that behavior for the legacy BB cloud webhook endpoint, but I _haven't_ added it to the new top-level handler. My thinking is, we already validate the uuid in the url, so how much more security are we actually getting from the secret url param? I'm happy to add it back in (we'd need to also update the endpoints returned in the webhooks site admin to append the secret to the url for the BB cloud endpoints) but I wanted to discuss first whether we all thought it was a good approach for the top level handler. 

Also, we're getting errors surrounding the usage of `log15`, so maybe this PR is the place to figure out how to rip that out of the whole package and replace it with the correct logger? 

## Test plan
Unit tests pass, ensure BB cloud legacy/new webhooks are successfully able to be processed when running the server locally. 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
