### PR TITLE
Cclark/refactor pings for insights

### DIFF
--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -48,24 +48,24 @@ func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB) (*types
 	loader.withOperation("weeklyUsage", weeklyUsage)
 	loader.withOperation("weeklyMetricsByInsight", weeklyMetricsByInsight)
 	loader.withOperation("weeklyFirstTimeCreators", weeklyFirstTimeCreators)
-	loader.withOperation("GetCreationViewUsage", GetCreationViewUsage)
-	loader.withOperation("GetTimeStepCounts", GetTimeStepCounts)
-	loader.withOperation("GetOrgInsightCounts", GetOrgInsightCounts)
-	loader.withOperation("GetTotalInsightCounts", GetTotalInsightCounts)
+	loader.withOperation("getCreationViewUsage", getCreationViewUsage)
+	loader.withOperation("getTimeStepCounts", getTimeStepCounts)
+	loader.withOperation("getOrgInsightCounts", getOrgInsightCounts)
+	loader.withOperation("getTotalInsightCounts", getTotalInsightCounts)
 	loader.withOperation("tabClicks", tabClicks)
-	loader.withOperation("InsightsTotalOrgsWithDashboard", InsightsTotalOrgsWithDashboard)
-	loader.withOperation("InsightsDashboardTotalCount", InsightsDashboardTotalCount)
-	loader.withOperation("GetInsightsPerDashboard", GetInsightsPerDashboard)
+	loader.withOperation("insightsTotalOrgsWithDashboard", insightsTotalOrgsWithDashboard)
+	loader.withOperation("insightsDashboardTotalCount", insightsDashboardTotalCount)
+	loader.withOperation("getInsightsPerDashboard", getInsightsPerDashboard)
 
-	loader.withOperation("GroupAggregationModeClicked", GroupAggregationModeClicked)
-	loader.withOperation("GroupAggregationModeDisabledHover", GroupAggregationModeDisabledHover)
-	loader.withOperation("GroupResultsChartBarClick", GroupResultsChartBarClick)
-	loader.withOperation("GroupResultsChartBarHover", GroupResultsChartBarHover)
-	loader.withOperation("GroupResultsExpandedViewOpen", GroupResultsExpandedViewOpen)
-	loader.withOperation("GroupResultsExpandedViewCollapse", GroupResultsExpandedViewCollapse)
-	loader.withOperation("GetBackfillTimePing", GetBackfillTimePing)
+	loader.withOperation("groupAggregationModeClicked", groupAggregationModeClicked)
+	loader.withOperation("groupAggregationModeDisabledHover", groupAggregationModeDisabledHover)
+	loader.withOperation("groupResultsChartBarClick", groupResultsChartBarClick)
+	loader.withOperation("groupResultsChartBarHover", groupResultsChartBarHover)
+	loader.withOperation("groupResultsExpandedViewOpen", groupResultsExpandedViewOpen)
+	loader.withOperation("groupResultsExpandedViewCollapse", groupResultsExpandedViewCollapse)
+	loader.withOperation("getBackfillTimePing", getBackfillTimePing)
 
-	loader.withOperation("GetGroupResultsSearchesPings", GetGroupResultsSearchesPings(
+	loader.withOperation("getGroupResultsSearchesPings", getGroupResultsSearchesPings(
 		[]types.PingName{
 			"ProactiveLimitHit",
 			"ProactiveLimitSuccess",
@@ -233,7 +233,7 @@ func GetWeeklyTabClicks(ctx context.Context, db database.DB, sql string) ([]type
 	return weeklyGetStartedTabClickByTab, nil
 }
 
-func GetTotalInsightCounts(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+func getTotalInsightCounts(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
 	store := db.EventLogs()
 	name := InsightsTotalCountPingName
 	all, err := store.ListAll(ctx, database.EventLogsListOptions{
@@ -259,7 +259,7 @@ func GetTotalInsightCounts(ctx context.Context, db database.DB, stats *types.Cod
 	return nil
 }
 
-func GetTimeStepCounts(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+func getTimeStepCounts(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
 	store := db.EventLogs()
 	name := InsightsIntervalCountsPingName
 	all, err := store.ListAll(ctx, database.EventLogsListOptions{
@@ -286,7 +286,7 @@ func GetTimeStepCounts(ctx context.Context, db database.DB, stats *types.CodeIns
 	return nil
 }
 
-func GetOrgInsightCounts(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+func getOrgInsightCounts(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
 	store := db.EventLogs()
 	name := InsightsOrgVisibleInsightsPingName
 	all, err := store.ListAll(ctx, database.EventLogsListOptions{
@@ -312,7 +312,7 @@ func GetOrgInsightCounts(ctx context.Context, db database.DB, stats *types.CodeI
 	return nil
 }
 
-func InsightsTotalOrgsWithDashboard(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+func insightsTotalOrgsWithDashboard(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
 	totalOrgsWithDashboard, err := GetIntCount(ctx, db, InsightsTotalOrgsWithDashboardPingName)
 	if err != nil {
 		return errors.Wrap(err, "GetTotalOrgsWithDashboard")
@@ -321,7 +321,7 @@ func InsightsTotalOrgsWithDashboard(ctx context.Context, db database.DB, stats *
 	return nil
 }
 
-func InsightsDashboardTotalCount(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+func insightsDashboardTotalCount(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
 	totalDashboards, err := GetIntCount(ctx, db, InsightsDashboardTotalCountPingName)
 	if err != nil {
 		return errors.Wrap(err, "GetTotalDashboards")
@@ -352,7 +352,7 @@ func GetIntCount(ctx context.Context, db database.DB, pingName string) (int32, e
 	return int32(count), nil
 }
 
-func GetCreationViewUsage(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+func getCreationViewUsage(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
 	builder := creationPagesPingBuilder(now)
 
 	results, err := builder.Sample(ctx, db)
@@ -364,7 +364,7 @@ func GetCreationViewUsage(ctx context.Context, db database.DB, stats *types.Code
 	return nil
 }
 
-func GetInsightsPerDashboard(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+func getInsightsPerDashboard(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
 	store := db.EventLogs()
 	name := InsightsPerDashboardPingName
 	all, err := store.ListAll(ctx, database.EventLogsListOptions{
@@ -415,8 +415,8 @@ func GetGroupResultsPing(ctx context.Context, db database.DB, pingName string) (
 	return groupResultsPings, nil
 }
 
-func GroupAggregationModeClicked(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
-	weeklyGroupResultsAggregationModeClicked, err := GetGroupResultsPing(ctx, db, "GroupAggregationModeClicked")
+func groupAggregationModeClicked(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+	weeklyGroupResultsAggregationModeClicked, err := GetGroupResultsPing(ctx, db, "groupAggregationModeClicked")
 	if err != nil {
 		return errors.Wrap(err, "WeeklyGroupResultsAggregationModeClicked")
 	}
@@ -424,8 +424,8 @@ func GroupAggregationModeClicked(ctx context.Context, db database.DB, stats *typ
 	return nil
 }
 
-func GroupAggregationModeDisabledHover(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
-	weeklyGroupResultsAggregationModeDisabledHover, err := GetGroupResultsPing(ctx, db, "GroupAggregationModeDisabledHover")
+func groupAggregationModeDisabledHover(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+	weeklyGroupResultsAggregationModeDisabledHover, err := GetGroupResultsPing(ctx, db, "groupAggregationModeDisabledHover")
 	if err != nil {
 		return errors.Wrap(err, "WeeklyGroupResultsAggregationModeDisabledHover")
 	}
@@ -433,33 +433,33 @@ func GroupAggregationModeDisabledHover(ctx context.Context, db database.DB, stat
 	return nil
 }
 
-func GroupResultsChartBarClick(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
-	weeklyGroupResultsChartBarClick, err := GetGroupResultsPing(ctx, db, "GroupResultsChartBarClick")
+func groupResultsChartBarClick(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+	weeklyGroupResultsChartBarClick, err := GetGroupResultsPing(ctx, db, "groupResultsChartBarClick")
 	if err != nil {
-		return errors.Wrap(err, "GroupResultsChartBarClick")
+		return errors.Wrap(err, "groupResultsChartBarClick")
 	}
 	stats.WeeklyGroupResultsChartBarClick = weeklyGroupResultsChartBarClick
 	return nil
 }
 
-func GroupResultsChartBarHover(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
-	weeklyGroupResultsChartBarHover, err := GetGroupResultsPing(ctx, db, "GroupResultsChartBarHover")
+func groupResultsChartBarHover(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+	weeklyGroupResultsChartBarHover, err := GetGroupResultsPing(ctx, db, "groupResultsChartBarHover")
 	if err != nil {
-		return errors.Wrap(err, "GroupResultsChartBarHover")
+		return errors.Wrap(err, "groupResultsChartBarHover")
 	}
 	stats.WeeklyGroupResultsChartBarHover = weeklyGroupResultsChartBarHover
 	return nil
 }
-func GroupResultsExpandedViewOpen(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
-	weeklyGroupResultsExpandedViewOpen, err := GetGroupResultsExpandedViewPing(ctx, db, "GroupResultsExpandedViewOpen")
+func groupResultsExpandedViewOpen(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+	weeklyGroupResultsExpandedViewOpen, err := GetGroupResultsExpandedViewPing(ctx, db, "groupResultsExpandedViewOpen")
 	if err != nil {
 		return errors.Wrap(err, "WeeklyGroupResultsExpandedViewOpen")
 	}
 	stats.WeeklyGroupResultsExpandedViewOpen = weeklyGroupResultsExpandedViewOpen
 	return nil
 }
-func GroupResultsExpandedViewCollapse(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
-	weeklyGroupResultsExpandedViewCollapse, err := GetGroupResultsExpandedViewPing(ctx, db, "GroupResultsExpandedViewCollapse")
+func groupResultsExpandedViewCollapse(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+	weeklyGroupResultsExpandedViewCollapse, err := GetGroupResultsExpandedViewPing(ctx, db, "groupResultsExpandedViewCollapse")
 	if err != nil {
 		return errors.Wrap(err, "WeeklyGroupResultsExpandedViewCollapse")
 	}
@@ -493,7 +493,7 @@ func GetGroupResultsExpandedViewPing(ctx context.Context, db database.DB, pingNa
 	return groupResultsExpandedViewPings, nil
 }
 
-func GetGroupResultsSearchesPings(pingNames []types.PingName) pingLoadFunc {
+func getGroupResultsSearchesPings(pingNames []types.PingName) pingLoadFunc {
 	return func(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
 		var pings []types.GroupResultSearchPing
 
@@ -530,7 +530,7 @@ func GetGroupResultsSearchesPings(pingNames []types.PingName) pingLoadFunc {
 	}
 }
 
-func GetBackfillTimePing(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+func getBackfillTimePing(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
 	store := db.EventLogs()
 	name := InsightsBackfillTimePingName
 	all, err := store.ListAll(ctx, database.EventLogsListOptions{

--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/inconshreveable/log15"
 	"github.com/lib/pq"
 
 	"github.com/sourcegraph/log"
@@ -15,160 +14,69 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-type pingLoadFunc func(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics) error
+type pingLoadFunc func(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error
 
-func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB) (*types.CodeInsightsUsageStatistics, error) {
+type pingLoader struct {
+	now        time.Time
+	operations map[string]pingLoadFunc
+}
+
+func newPingLoader(now time.Time) *pingLoader {
+	return &pingLoader{now: now, operations: make(map[string]pingLoadFunc)}
+}
+
+func (p *pingLoader) withOperation(name string, loadFunc pingLoadFunc) {
+	p.operations[name] = loadFunc
+}
+
+func (p *pingLoader) generate(ctx context.Context, db database.DB) *types.CodeInsightsUsageStatistics {
 	stats := &types.CodeInsightsUsageStatistics{}
+	logger := log.Scoped("code insights ping loader", "pings for code insights")
 
-	logger := log.Scoped("code insights pings", "pings for code insights")
-
-	loaders := make(map[string]pingLoadFunc)
-
-	loaders["weeklyUsage"] = weeklyUsage
-	loaders["weeklyMetricsByInsight"] = weeklyMetricsByInsight
-	loaders["weeklyFirstTimeCreators"] = weeklyFirstTimeCreators
-
-	for name, loadFunc := range loaders {
-		err := loadFunc(ctx, db, stats)
+	for name, loadFunc := range p.operations {
+		err := loadFunc(ctx, db, stats, p.now)
 		if err != nil {
 			logger.Error("insights pings loading error, skipping ping", log.String("name", name))
 		}
 	}
+	return stats
+}
 
-	// err := weeklyUsage(ctx, db, stats)
-	// if err != nil {
-	// 	return nil, errors.Wrap(err, "WeeklyUsage")
-	// }
+func GetCodeInsightsUsageStatistics(ctx context.Context, db database.DB) (*types.CodeInsightsUsageStatistics, error) {
+	loader := newPingLoader(timeNow())
 
-	// err = weeklyMetricsByInsight(ctx, db, stats)
-	// if err != nil {
-	// 	return nil, errors.Wrap(err, "weeklyMetricsByInsight")
-	// }
+	loader.withOperation("weeklyUsage", weeklyUsage)
+	loader.withOperation("weeklyMetricsByInsight", weeklyMetricsByInsight)
+	loader.withOperation("weeklyFirstTimeCreators", weeklyFirstTimeCreators)
+	loader.withOperation("GetCreationViewUsage", GetCreationViewUsage)
+	loader.withOperation("GetTimeStepCounts", GetTimeStepCounts)
+	loader.withOperation("GetOrgInsightCounts", GetOrgInsightCounts)
+	loader.withOperation("GetTotalInsightCounts", GetTotalInsightCounts)
+	loader.withOperation("tabClicks", tabClicks)
+	loader.withOperation("InsightsTotalOrgsWithDashboard", InsightsTotalOrgsWithDashboard)
+	loader.withOperation("InsightsDashboardTotalCount", InsightsDashboardTotalCount)
+	loader.withOperation("GetInsightsPerDashboard", GetInsightsPerDashboard)
 
-	// err = weeklyFirstTimeCreators(ctx, db, stats)
-	// if err != nil {
-	// 	return nil, errors.Wrap(err, "weeklyFirstTimeCreators")
-	// }
+	loader.withOperation("GroupAggregationModeClicked", GroupAggregationModeClicked)
+	loader.withOperation("GroupAggregationModeDisabledHover", GroupAggregationModeDisabledHover)
+	loader.withOperation("GroupResultsChartBarClick", GroupResultsChartBarClick)
+	loader.withOperation("GroupResultsChartBarHover", GroupResultsChartBarHover)
+	loader.withOperation("GroupResultsExpandedViewOpen", GroupResultsExpandedViewOpen)
+	loader.withOperation("GroupResultsExpandedViewCollapse", GroupResultsExpandedViewCollapse)
+	loader.withOperation("GetBackfillTimePing", GetBackfillTimePing)
 
-	weeklyUsage, err := GetCreationViewUsage(ctx, db, timeNow)
-	if err != nil {
-		return nil, err
-	}
-	stats.WeeklyAggregatedUsage = weeklyUsage
-
-	// These two pings are slightly more fragile than the others because they deserialize json from settings. They are
-	// also less important. So, in the case of any errors here we will not fail the entire ping for code insights.
-	timeIntervals, err := GetTimeStepCounts(ctx, db)
-	if err != nil {
-		log15.Error("code-insights/GetTimeStepCounts", "error", err)
-		return nil, nil
-	}
-	stats.InsightTimeIntervals = timeIntervals
-
-	orgVisible, err := GetOrgInsightCounts(ctx, db)
-	if err != nil {
-		log15.Error("code-insights/GetOrgInsightCounts", "error", err)
-		return nil, nil
-	}
-	stats.InsightOrgVisible = orgVisible
-
-	totalCounts, err := GetTotalInsightCounts(ctx, db)
-	if err != nil {
-		return nil, errors.Wrap(err, "GetTotalInsightCounts")
-	}
-	stats.InsightTotalCounts = totalCounts
-
-	weeklyGetStartedTabClickByTab, err := GetWeeklyTabClicks(ctx, db, getStartedTabClickSql)
-	if err != nil {
-		return nil, errors.Wrap(err, "GetWeeklyTabClicks")
-	}
-	stats.WeeklyGetStartedTabClickByTab = weeklyGetStartedTabClickByTab
-
-	weeklyGetStartedTabMoreClickByTab, err := GetWeeklyTabClicks(ctx, db, getStartedTabMoreClickSql)
-	if err != nil {
-		return nil, errors.Wrap(err, "GetWeeklyTabMoreClicks")
-	}
-	stats.WeeklyGetStartedTabMoreClickByTab = weeklyGetStartedTabMoreClickByTab
-
-	totalOrgsWithDashboard, err := GetIntCount(ctx, db, InsightsTotalOrgsWithDashboardPingName)
-	if err != nil {
-		return nil, errors.Wrap(err, "GetTotalOrgsWithDashboard")
-	}
-	stats.TotalOrgsWithDashboard = &totalOrgsWithDashboard
-
-	totalDashboards, err := GetIntCount(ctx, db, InsightsDashboardTotalCountPingName)
-	if err != nil {
-		return nil, errors.Wrap(err, "GetTotalDashboards")
-	}
-	stats.TotalDashboardCount = &totalDashboards
-
-	insightsPerDashboard, err := GetInsightsPerDashboard(ctx, db)
-	if err != nil {
-		return nil, errors.Wrap(err, "GetInsightsPerDashboard")
-	}
-	stats.InsightsPerDashboard = insightsPerDashboard
-
-	weeklyGroupResultsAggregationModeClicked, err := GetGroupResultsPing(ctx, db, "GroupAggregationModeClicked")
-	if err != nil {
-		return nil, errors.Wrap(err, "WeeklyGroupResultsAggregationModeClicked")
-	}
-	stats.WeeklyGroupResultsAggregationModeClicked = weeklyGroupResultsAggregationModeClicked
-
-	weeklyGroupResultsAggregationModeDisabledHover, err := GetGroupResultsPing(ctx, db, "GroupAggregationModeDisabledHover")
-	if err != nil {
-		return nil, errors.Wrap(err, "WeeklyGroupResultsAggregationModeDisabledHover")
-	}
-	stats.WeeklyGroupResultsAggregationModeDisabledHover = weeklyGroupResultsAggregationModeDisabledHover
-
-	weeklyGroupResultsChartBarClick, err := GetGroupResultsPing(ctx, db, "GroupResultsChartBarClick")
-	if err != nil {
-		return nil, errors.Wrap(err, "GroupResultsChartBarClick")
-	}
-	stats.WeeklyGroupResultsChartBarClick = weeklyGroupResultsChartBarClick
-
-	weeklyGroupResultsChartBarHover, err := GetGroupResultsPing(ctx, db, "GroupResultsChartBarHover")
-	if err != nil {
-		return nil, errors.Wrap(err, "GroupResultsChartBarHover")
-	}
-	stats.WeeklyGroupResultsChartBarHover = weeklyGroupResultsChartBarHover
-
-	weeklyGroupResultsExpandedViewOpen, err := GetGroupResultsExpandedViewPing(ctx, db, "GroupResultsExpandedViewOpen")
-	if err != nil {
-		return nil, errors.Wrap(err, "WeeklyGroupResultsExpandedViewOpen")
-	}
-	stats.WeeklyGroupResultsExpandedViewOpen = weeklyGroupResultsExpandedViewOpen
-
-	weeklyGroupResultsExpandedViewCollapse, err := GetGroupResultsExpandedViewPing(ctx, db, "GroupResultsExpandedViewCollapse")
-	if err != nil {
-		return nil, errors.Wrap(err, "WeeklyGroupResultsExpandedViewCollapse")
-	}
-	stats.WeeklyGroupResultsExpandedViewCollapse = weeklyGroupResultsExpandedViewCollapse
-
-	weeklyGroupResultsSearches, err := GetGroupResultsSearchesPings(
-		ctx,
-		db,
+	loader.withOperation("GetGroupResultsSearchesPings", GetGroupResultsSearchesPings(
 		[]types.PingName{
 			"ProactiveLimitHit",
 			"ProactiveLimitSuccess",
 			"ExplicitLimitHit",
 			"ExplicitLimitSuccess",
-		},
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "WeeklyGroupResultsSearches")
-	}
-	stats.WeeklyGroupResultsSearches = weeklyGroupResultsSearches
+		}))
 
-	backfillTime, err := GetBackfillTimePing(ctx, db)
-	if err != nil {
-		return nil, errors.Wrap(err, "GetBackfillTimePing")
-	}
-	stats.WeeklySeriesBackfillTime = backfillTime
-
-	return stats, nil
+	return loader.generate(ctx, db), nil
 }
 
-func weeklyUsage(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics) error {
+func weeklyUsage(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
 	const platformQuery = `
 	SELECT
 		COUNT(*) FILTER (WHERE name = 'ViewInsights')                       			AS weekly_insights_page_views,
@@ -217,7 +125,7 @@ func weeklyUsage(ctx context.Context, db database.DB, stats *types.CodeInsightsU
 	return nil
 }
 
-func weeklyMetricsByInsight(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics) error {
+func weeklyMetricsByInsight(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
 	const metricsByInsightQuery = `
 	SELECT argument ->> 'insightType'::text 					             		AS insight_type,
         COUNT(*) FILTER (WHERE name = 'InsightAddition') 		             		AS additions,
@@ -259,7 +167,7 @@ func weeklyMetricsByInsight(ctx context.Context, db database.DB, stats *types.Co
 	return nil
 }
 
-func weeklyFirstTimeCreators(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics) error {
+func weeklyFirstTimeCreators(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
 	const weeklyFirstTimeCreatorsQuery = `
 	WITH first_times AS (
 		SELECT
@@ -276,7 +184,7 @@ func weeklyFirstTimeCreators(ctx context.Context, db database.DB, stats *types.C
 	WHERE first_time > DATE_TRUNC('week', $1::timestamp);
 	`
 
-	if err := db.QueryRowContext(ctx, weeklyFirstTimeCreatorsQuery, timeNow()).Scan(
+	if err := db.QueryRowContext(ctx, weeklyFirstTimeCreatorsQuery, now).Scan(
 		&stats.WeekStart,
 		&stats.WeeklyFirstTimeInsightCreators,
 	); err != nil {
@@ -285,7 +193,25 @@ func weeklyFirstTimeCreators(ctx context.Context, db database.DB, stats *types.C
 	return nil
 }
 
+func tabClicks(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+	weeklyGetStartedTabClickByTab, err := GetWeeklyTabClicks(ctx, db, getStartedTabClickSql)
+	if err != nil {
+		return errors.Wrap(err, "GetWeeklyTabClicks")
+	}
+	stats.WeeklyGetStartedTabClickByTab = weeklyGetStartedTabClickByTab
+
+	weeklyGetStartedTabMoreClickByTab, err := GetWeeklyTabClicks(ctx, db, getStartedTabMoreClickSql)
+	if err != nil {
+		return errors.Wrap(err, "GetWeeklyTabMoreClicks")
+	}
+	stats.WeeklyGetStartedTabMoreClickByTab = weeklyGetStartedTabMoreClickByTab
+
+	return nil
+}
+
 func GetWeeklyTabClicks(ctx context.Context, db database.DB, sql string) ([]types.InsightGetStartedTabClickPing, error) {
+	// InsightsGetStartedTabClick
+	// InsightsGetStartedTabMoreClick
 	weeklyGetStartedTabClickByTab := []types.InsightGetStartedTabClickPing{}
 	rows, err := db.QueryContext(ctx, sql, timeNow())
 
@@ -307,7 +233,7 @@ func GetWeeklyTabClicks(ctx context.Context, db database.DB, sql string) ([]type
 	return weeklyGetStartedTabClickByTab, nil
 }
 
-func GetTotalInsightCounts(ctx context.Context, db database.DB) (types.InsightTotalCounts, error) {
+func GetTotalInsightCounts(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
 	store := db.EventLogs()
 	name := InsightsTotalCountPingName
 	all, err := store.ListAll(ctx, database.EventLogsListOptions{
@@ -318,21 +244,22 @@ func GetTotalInsightCounts(ctx context.Context, db database.DB) (types.InsightTo
 		EventName: &name,
 	})
 	if err != nil {
-		return types.InsightTotalCounts{}, err
+		return err
 	} else if len(all) == 0 {
-		return types.InsightTotalCounts{}, nil
+		return nil
 	}
 
 	latest := all[0]
 	var totalCounts types.InsightTotalCounts
-	err = json.Unmarshal([]byte(latest.Argument), &totalCounts)
+	err = json.Unmarshal(latest.Argument, &totalCounts)
 	if err != nil {
-		return types.InsightTotalCounts{}, errors.Wrap(err, "Unmarshal")
+		return errors.Wrap(err, "UnmarshalInsightTotalCounts")
 	}
-	return totalCounts, err
+	stats.InsightTotalCounts = totalCounts
+	return nil
 }
 
-func GetTimeStepCounts(ctx context.Context, db database.DB) ([]types.InsightTimeIntervalPing, error) {
+func GetTimeStepCounts(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
 	store := db.EventLogs()
 	name := InsightsIntervalCountsPingName
 	all, err := store.ListAll(ctx, database.EventLogsListOptions{
@@ -343,21 +270,23 @@ func GetTimeStepCounts(ctx context.Context, db database.DB) ([]types.InsightTime
 		EventName: &name,
 	})
 	if err != nil {
-		return []types.InsightTimeIntervalPing{}, err
+		return err
 	} else if len(all) == 0 {
-		return []types.InsightTimeIntervalPing{}, nil
+		return nil
 	}
 
 	latest := all[0]
 	var intervalCounts []types.InsightTimeIntervalPing
-	err = json.Unmarshal([]byte(latest.Argument), &intervalCounts)
+	err = json.Unmarshal(latest.Argument, &intervalCounts)
 	if err != nil {
-		return []types.InsightTimeIntervalPing{}, errors.Wrap(err, "Unmarshal")
+		return errors.Wrap(err, "UnmarshalInsightTimeIntervalPing")
 	}
-	return intervalCounts, nil
+
+	stats.InsightTimeIntervals = intervalCounts
+	return nil
 }
 
-func GetOrgInsightCounts(ctx context.Context, db database.DB) ([]types.OrgVisibleInsightPing, error) {
+func GetOrgInsightCounts(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
 	store := db.EventLogs()
 	name := InsightsOrgVisibleInsightsPingName
 	all, err := store.ListAll(ctx, database.EventLogsListOptions{
@@ -368,18 +297,37 @@ func GetOrgInsightCounts(ctx context.Context, db database.DB) ([]types.OrgVisibl
 		EventName: &name,
 	})
 	if err != nil {
-		return []types.OrgVisibleInsightPing{}, err
+		return err
 	} else if len(all) == 0 {
-		return []types.OrgVisibleInsightPing{}, nil
+		return nil
 	}
 
 	latest := all[0]
 	var orgVisibleInsightCounts []types.OrgVisibleInsightPing
-	err = json.Unmarshal([]byte(latest.Argument), &orgVisibleInsightCounts)
+	err = json.Unmarshal(latest.Argument, &orgVisibleInsightCounts)
 	if err != nil {
-		return []types.OrgVisibleInsightPing{}, errors.Wrap(err, "Unmarshal")
+		return errors.Wrap(err, "UnmarshalOrgVisibleInsightPing")
 	}
-	return orgVisibleInsightCounts, nil
+	stats.InsightOrgVisible = orgVisibleInsightCounts
+	return nil
+}
+
+func InsightsTotalOrgsWithDashboard(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+	totalOrgsWithDashboard, err := GetIntCount(ctx, db, InsightsTotalOrgsWithDashboardPingName)
+	if err != nil {
+		return errors.Wrap(err, "GetTotalOrgsWithDashboard")
+	}
+	stats.TotalOrgsWithDashboard = &totalOrgsWithDashboard
+	return nil
+}
+
+func InsightsDashboardTotalCount(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+	totalDashboards, err := GetIntCount(ctx, db, InsightsDashboardTotalCountPingName)
+	if err != nil {
+		return errors.Wrap(err, "GetTotalDashboards")
+	}
+	stats.TotalDashboardCount = &totalDashboards
+	return nil
 }
 
 func GetIntCount(ctx context.Context, db database.DB, pingName string) (int32, error) {
@@ -397,25 +345,26 @@ func GetIntCount(ctx context.Context, db database.DB, pingName string) (int32, e
 
 	latest := all[0]
 	var count int
-	err = json.Unmarshal([]byte(latest.Argument), &count)
+	err = json.Unmarshal(latest.Argument, &count)
 	if err != nil {
-		return 0, errors.Wrap(err, "Unmarshal")
+		return 0, errors.Wrapf(err, "Unmarshal %s", pingName)
 	}
 	return int32(count), nil
 }
 
-func GetCreationViewUsage(ctx context.Context, db database.DB, timeSupplier func() time.Time) ([]types.AggregatedPingStats, error) {
-	builder := creationPagesPingBuilder(timeSupplier)
+func GetCreationViewUsage(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+	builder := creationPagesPingBuilder(now)
 
 	results, err := builder.Sample(ctx, db)
 	if err != nil {
-		return []types.AggregatedPingStats{}, err
+		return err
 	}
+	stats.WeeklyAggregatedUsage = results
 
-	return results, nil
+	return nil
 }
 
-func GetInsightsPerDashboard(ctx context.Context, db database.DB) (types.InsightsPerDashboardPing, error) {
+func GetInsightsPerDashboard(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
 	store := db.EventLogs()
 	name := InsightsPerDashboardPingName
 	all, err := store.ListAll(ctx, database.EventLogsListOptions{
@@ -426,18 +375,19 @@ func GetInsightsPerDashboard(ctx context.Context, db database.DB) (types.Insight
 		EventName: &name,
 	})
 	if err != nil {
-		return types.InsightsPerDashboardPing{}, err
+		return err
 	} else if len(all) == 0 {
-		return types.InsightsPerDashboardPing{}, nil
+		return nil
 	}
 
 	latest := all[0]
 	var insightsPerDashboardStats types.InsightsPerDashboardPing
-	err = json.Unmarshal([]byte(latest.Argument), &insightsPerDashboardStats)
+	err = json.Unmarshal(latest.Argument, &insightsPerDashboardStats)
 	if err != nil {
-		return types.InsightsPerDashboardPing{}, errors.Wrap(err, "Unmarshal")
+		return errors.Wrap(err, "Unmarshal")
 	}
-	return insightsPerDashboardStats, nil
+	stats.InsightsPerDashboard = insightsPerDashboardStats
+	return nil
 }
 
 func GetGroupResultsPing(ctx context.Context, db database.DB, pingName string) ([]types.GroupResultPing, error) {
@@ -463,6 +413,58 @@ func GetGroupResultsPing(ctx context.Context, db database.DB, pingName string) (
 		groupResultsPings = append(groupResultsPings, groupResultsPing)
 	}
 	return groupResultsPings, nil
+}
+
+func GroupAggregationModeClicked(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+	weeklyGroupResultsAggregationModeClicked, err := GetGroupResultsPing(ctx, db, "GroupAggregationModeClicked")
+	if err != nil {
+		return errors.Wrap(err, "WeeklyGroupResultsAggregationModeClicked")
+	}
+	stats.WeeklyGroupResultsAggregationModeClicked = weeklyGroupResultsAggregationModeClicked
+	return nil
+}
+
+func GroupAggregationModeDisabledHover(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+	weeklyGroupResultsAggregationModeDisabledHover, err := GetGroupResultsPing(ctx, db, "GroupAggregationModeDisabledHover")
+	if err != nil {
+		return errors.Wrap(err, "WeeklyGroupResultsAggregationModeDisabledHover")
+	}
+	stats.WeeklyGroupResultsAggregationModeDisabledHover = weeklyGroupResultsAggregationModeDisabledHover
+	return nil
+}
+
+func GroupResultsChartBarClick(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+	weeklyGroupResultsChartBarClick, err := GetGroupResultsPing(ctx, db, "GroupResultsChartBarClick")
+	if err != nil {
+		return errors.Wrap(err, "GroupResultsChartBarClick")
+	}
+	stats.WeeklyGroupResultsChartBarClick = weeklyGroupResultsChartBarClick
+	return nil
+}
+
+func GroupResultsChartBarHover(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+	weeklyGroupResultsChartBarHover, err := GetGroupResultsPing(ctx, db, "GroupResultsChartBarHover")
+	if err != nil {
+		return errors.Wrap(err, "GroupResultsChartBarHover")
+	}
+	stats.WeeklyGroupResultsChartBarHover = weeklyGroupResultsChartBarHover
+	return nil
+}
+func GroupResultsExpandedViewOpen(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+	weeklyGroupResultsExpandedViewOpen, err := GetGroupResultsExpandedViewPing(ctx, db, "GroupResultsExpandedViewOpen")
+	if err != nil {
+		return errors.Wrap(err, "WeeklyGroupResultsExpandedViewOpen")
+	}
+	stats.WeeklyGroupResultsExpandedViewOpen = weeklyGroupResultsExpandedViewOpen
+	return nil
+}
+func GroupResultsExpandedViewCollapse(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+	weeklyGroupResultsExpandedViewCollapse, err := GetGroupResultsExpandedViewPing(ctx, db, "GroupResultsExpandedViewCollapse")
+	if err != nil {
+		return errors.Wrap(err, "WeeklyGroupResultsExpandedViewCollapse")
+	}
+	stats.WeeklyGroupResultsExpandedViewCollapse = weeklyGroupResultsExpandedViewCollapse
+	return nil
 }
 
 func GetGroupResultsExpandedViewPing(ctx context.Context, db database.DB, pingName string) ([]types.GroupResultExpandedViewPing, error) {
@@ -491,41 +493,44 @@ func GetGroupResultsExpandedViewPing(ctx context.Context, db database.DB, pingNa
 	return groupResultsExpandedViewPings, nil
 }
 
-func GetGroupResultsSearchesPings(ctx context.Context, db database.DB, pingNames []types.PingName) ([]types.GroupResultSearchPing, error) {
-	pings := []types.GroupResultSearchPing{}
+func GetGroupResultsSearchesPings(pingNames []types.PingName) pingLoadFunc {
+	return func(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
+		var pings []types.GroupResultSearchPing
 
-	for _, name := range pingNames {
-		rows, err := db.QueryContext(ctx, getGroupResultsSql, string(name), timeNow())
-		if err != nil {
-			return nil, err
-		}
-		err = func() error {
-			defer rows.Close()
-			var noop *string
-			for rows.Next() {
-				ping := types.GroupResultSearchPing{
-					Name: name,
-				}
-				if err := rows.Scan(
-					&ping.Count,
-					&ping.AggregationMode,
-					&noop,
-					&noop,
-				); err != nil {
-					return err
-				}
-				pings = append(pings, ping)
+		for _, name := range pingNames {
+			rows, err := db.QueryContext(ctx, getGroupResultsSql, string(name), timeNow())
+			if err != nil {
+				return err
 			}
-			return nil
-		}()
-		if err != nil {
-			return nil, err
+			err = func() error {
+				defer rows.Close()
+				var noop *string
+				for rows.Next() {
+					ping := types.GroupResultSearchPing{
+						Name: name,
+					}
+					if err := rows.Scan(
+						&ping.Count,
+						&ping.AggregationMode,
+						&noop,
+						&noop,
+					); err != nil {
+						return err
+					}
+					pings = append(pings, ping)
+				}
+				return nil
+			}()
+			if err != nil {
+				return err
+			}
 		}
+		stats.WeeklyGroupResultsSearches = pings
+		return nil
 	}
-	return pings, nil
 }
 
-func GetBackfillTimePing(ctx context.Context, db database.DB) ([]types.InsightsBackfillTimePing, error) {
+func GetBackfillTimePing(ctx context.Context, db database.DB, stats *types.CodeInsightsUsageStatistics, now time.Time) error {
 	store := db.EventLogs()
 	name := InsightsBackfillTimePingName
 	all, err := store.ListAll(ctx, database.EventLogsListOptions{
@@ -536,18 +541,19 @@ func GetBackfillTimePing(ctx context.Context, db database.DB) ([]types.InsightsB
 		EventName: &name,
 	})
 	if err != nil {
-		return []types.InsightsBackfillTimePing{}, err
+		return err
 	} else if len(all) == 0 {
-		return []types.InsightsBackfillTimePing{}, nil
+		return nil
 	}
 
 	latest := all[0]
 	var backfillTimePing []types.InsightsBackfillTimePing
-	err = json.Unmarshal([]byte(latest.Argument), &backfillTimePing)
+	err = json.Unmarshal(latest.Argument, &backfillTimePing)
 	if err != nil {
-		return []types.InsightsBackfillTimePing{}, errors.Wrap(err, "Unmarshal")
+		return errors.Wrap(err, "UnmarshalInsightsBackfillTimePing")
 	}
-	return backfillTimePing, nil
+	stats.WeeklySeriesBackfillTime = backfillTimePing
+	return nil
 }
 
 // WithAll adds multiple pings by name to this builder
@@ -569,7 +575,7 @@ func (b *PingQueryBuilder) Sample(ctx context.Context, db database.DB) ([]types.
 
 	query := fmt.Sprintf(templatePingQueryStr, b.timeWindow)
 
-	rows, err := db.QueryContext(ctx, query, b.getTime(), pq.Array(b.pings))
+	rows, err := db.QueryContext(ctx, query, b.now, pq.Array(b.pings))
 	if err != nil {
 		return []types.AggregatedPingStats{}, err
 	}
@@ -588,7 +594,7 @@ func (b *PingQueryBuilder) Sample(ctx context.Context, db database.DB) ([]types.
 	return results, nil
 }
 
-func creationPagesPingBuilder(timeSupplier func() time.Time) PingQueryBuilder {
+func creationPagesPingBuilder(now time.Time) PingQueryBuilder {
 	names := []types.PingName{
 		"ViewCodeInsightsCreationPage",
 		"ViewCodeInsightsSearchBasedCreationPage",
@@ -613,20 +619,20 @@ func creationPagesPingBuilder(timeSupplier func() time.Time) PingQueryBuilder {
 		"InsightsGetStartedDocsClicks",
 	}
 
-	builder := NewPingBuilder(Week, timeSupplier)
+	builder := NewPingBuilder(Week, now)
 	builder.WithAll(names)
 
 	return builder
 }
 
-func NewPingBuilder(timeWindow TimeWindow, timeSupplier func() time.Time) PingQueryBuilder {
-	return PingQueryBuilder{timeWindow: timeWindow, getTime: timeSupplier}
+func NewPingBuilder(timeWindow TimeWindow, now time.Time) PingQueryBuilder {
+	return PingQueryBuilder{timeWindow: timeWindow, now: now}
 }
 
 type PingQueryBuilder struct {
 	pings      []string
 	timeWindow TimeWindow
-	getTime    func() time.Time
+	now        time.Time
 }
 
 type TimeWindow string

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -165,7 +165,7 @@ func TestWithCreationPings(t *testing.T) {
 	}
 
 	stats := &types.CodeInsightsUsageStatistics{}
-	err = GetCreationViewUsage(ctx, db, stats, now)
+	err = getCreationViewUsage(ctx, db, stats, now)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -116,8 +117,6 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 	}
 
 	want.WeeklyAggregatedUsage = wantedWeeklyUsage
-	want.InsightTimeIntervals = []types.InsightTimeIntervalPing{}
-	want.InsightOrgVisible = []types.OrgVisibleInsightPing{}
 
 	want.WeeklyGroupResultsExpandedViewOpen = []types.GroupResultExpandedViewPing{}
 	want.WeeklyGroupResultsExpandedViewCollapse = []types.GroupResultExpandedViewPing{}
@@ -125,8 +124,6 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 	want.WeeklyGroupResultsChartBarClick = []types.GroupResultPing{}
 	want.WeeklyGroupResultsAggregationModeClicked = []types.GroupResultPing{}
 	want.WeeklyGroupResultsAggregationModeDisabledHover = []types.GroupResultPing{}
-	want.WeeklyGroupResultsSearches = []types.GroupResultSearchPing{}
-	want.WeeklySeriesBackfillTime = []types.InsightsBackfillTimePing{}
 
 	if diff := cmp.Diff(want, have); diff != "" {
 		t.Fatal(diff)
@@ -167,16 +164,15 @@ func TestWithCreationPings(t *testing.T) {
 		"ViewCodeInsightsCreationPage":              {Name: "ViewCodeInsightsCreationPage", UniqueCount: 2, TotalCount: 3},
 	}
 
-	results, err := GetCreationViewUsage(ctx, db, func() time.Time {
-		return now
-	})
+	stats := &types.CodeInsightsUsageStatistics{}
+	err = GetCreationViewUsage(ctx, db, stats, now)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// convert into map so we can reliably test for equality
 	got := make(map[types.PingName]types.AggregatedPingStats)
-	for _, v := range results {
+	for _, v := range stats.WeeklyAggregatedUsage {
 		got[v.Name] = v
 	}
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/42368

Refactored code insights pings to skip any errors during generation. To accomplish this I separated each field (where we were previously checking for errors on each field). This required a bit of refactoring here and there. Overall this code is still a mess of different styles and so on, but this at least makes it so they won't all break and will only log in the future.

## Test plan

I compared generating pings on both the head of this branch, and the most recent commit locally prior to any work `c59b95a9003a12269c75f2041cef37d7bcb1609b`. There were no differences in the revisions.

<img width="1175" alt="CleanShot 2022-11-17 at 09 33 10@2x" src="https://user-images.githubusercontent.com/5090588/202504435-b26b5c63-0fb3-4f27-81ec-56806251aba4.png">

Before:
https://gist.github.com/coury-clark/39e213c4791c94ab068f093816c00487

After: 
https://gist.github.com/coury-clark/505f81b97f185838939357053a5436f5
