### PR TITLE
Aggregation UI: Fix aggregation UI view mode integration test

### DIFF
--- a/client/web/src/integration/search-aggregation.test.ts
+++ b/client/web/src/integration/search-aggregation.test.ts
@@ -306,6 +306,11 @@ describe('Search aggregation', () => {
             await editor.waitForIt()
 
             await driver.page.waitForSelector('[aria-label="Bar chart content"] a')
+
+            // waitForSelector checks for dom element, but it doesn't track visual representation of the element
+            // Wait until chart is visually rendered and only then click the element, otherwise it may be possible
+            // to encounter a puppeter bug https://github.com/puppeteer/puppeteer/issues/8627
+            await delay(200)
             await driver.page.click('[aria-label="Sidebar search aggregation chart"] a')
 
             expect(await editor.getValue()).toStrictEqual('insights repo:sourcegraph/sourcegraph')
@@ -315,6 +320,12 @@ describe('Search aggregation', () => {
             await driver.page.waitForSelector(
                 '[aria-label="Expanded search aggregation chart"] [aria-label="Bar chart content"] g:nth-child(2) a'
             )
+
+            // waitForSelector checks for dom element, but it doesn't track visual representation of the element
+            // Wait until chart is visually rendered and only then click the element, otherwise it may be possible
+            // to encounter a puppeter bug https://github.com/puppeteer/puppeteer/issues/8627
+            await delay(200)
+
             await driver.page.click(
                 '[aria-label="Expanded search aggregation chart"] [aria-label="Bar chart content"] g:nth-child(2) a'
             )


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/44580

I run this "clicks on one of aggregation bars" integration tests 50 times on the main and got 1 failed time out of 49. This problem is hard to catch because this is probably a puppeteer [bug](https://github.com/puppeteer/puppeteer/issues?q=is%3Aissue+Node+is+either+not+clickable+or+not+an+HTMLElement+is%3Aclosed). In theory this problem happens when element is represented in the DOM but has 0x0 sizes. Which might be a case when we test bar chart. 

Our chart works in a way that it renders axis and bars and when measure axis sizes and sets bar chart bars coordinates and sizes. So my theory here that when we render chart we do have a elements in the dom but charts measurements are not finished and click() method of puppeteer fails with "non clickable element" error. 

In this PR we add a few delays before click just to ensure that we have visual elements before we try to click them, which should solve the problem.

## Test plan
- Make sure that CI integration test is passing with current change

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-try-to-fix-aggregation-test.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
