### PR TITLE
Wildcard: Remove nested labels from `TextArea.tsx` when there is no labels 

### DIFF
--- a/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
@@ -367,33 +367,33 @@ export const SearchContextForm: React.FunctionComponent<React.PropsWithChildren<
                     {searchContextSpecPreview}
                 </div>
                 <hr aria-hidden={true} className={classNames('my-4', styles.searchContextFormDivider)} />
-                <div>
-                    <div className="mb-2">
-                        Description <span className="text-muted">(optional)</span>
-                    </div>
-                    <TextArea
-                        className="w-100"
-                        data-testid="search-context-description-input"
-                        maxLength={MAX_DESCRIPTION_LENGTH}
-                        value={description}
-                        rows={5}
-                        onChange={event => {
-                            const value = event.target.value
-                            if (value.length <= MAX_DESCRIPTION_LENGTH) {
-                                setDescription(event.target.value)
-                            }
-                        }}
-                    />
-                    <div className="mt-1 text-muted">
-                        <small>
+                <TextArea
+                    label={
+                        <>
+                            Description <span className="text-muted">(optional)</span>
+                        </>
+                    }
+                    message={
+                        <span className="font-weight-normal">
                             <span>Markdown formatting is supported</span>
                             <span aria-hidden={true} className="px-1">
                                 &middot;
                             </span>
                             <span>{MAX_DESCRIPTION_LENGTH - description.length} characters remaining</span>
-                        </small>
-                    </div>
-                </div>
+                        </span>
+                    }
+                    className="w-100 mb-2"
+                    data-testid="search-context-description-input"
+                    maxLength={MAX_DESCRIPTION_LENGTH}
+                    value={description}
+                    rows={5}
+                    onChange={event => {
+                        const value = event.target.value
+                        if (value.length <= MAX_DESCRIPTION_LENGTH) {
+                            setDescription(event.target.value)
+                        }
+                    }}
+                />
                 <div className={classNames('mt-3', styles.searchContextFormVisibility)}>
                     <div className="mb-3">Visibility</div>
                     {visibilityRadioButtons.map((radio, index) => (

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/__snapshots__/FeedbackPrompt.test.tsx.snap
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/__snapshots__/FeedbackPrompt.test.tsx.snap
@@ -105,22 +105,20 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
   <div
     aria-modal="true"
     class="floatingPanel popover menu"
-    hidden=""
     role="dialog"
-    style="visibility: hidden;"
   >
     <div
       data-focus-guard="true"
       style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
+      tabindex="-1"
     />
     <div
       data-focus-guard="true"
       style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="1"
+      tabindex="-1"
     />
     <div
-      data-focus-lock-disabled="false"
+      data-focus-lock-disabled="disabled"
     >
       <button
         class="close"
@@ -189,7 +187,7 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
     <div
       data-focus-guard="true"
       style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
+      tabindex="-1"
     />
   </div>
 </body>

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/__snapshots__/FeedbackPrompt.test.tsx.snap
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/__snapshots__/FeedbackPrompt.test.tsx.snap
@@ -59,15 +59,11 @@ exports[`FeedbackPrompt should render correctly 1`] = `
         >
           Send feedback to Sourcegraph
         </h3>
-        <label
-          class="label label textarea"
-        >
-          <textarea
-            aria-labelledby="feedback-prompt-question"
-            class="textarea form-control resizeNone textarea"
-            rows="3"
-          />
-        </label>
+        <textarea
+          aria-labelledby="feedback-prompt-question"
+          class="form-control textarea resizeNone textarea textarea"
+          rows="3"
+        />
         <p
           class="small text-muted"
         >
@@ -109,20 +105,22 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
   <div
     aria-modal="true"
     class="floatingPanel popover menu"
+    hidden=""
     role="dialog"
+    style="visibility: hidden;"
   >
     <div
       data-focus-guard="true"
       style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="-1"
+      tabindex="0"
     />
     <div
       data-focus-guard="true"
       style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="-1"
+      tabindex="1"
     />
     <div
-      data-focus-lock-disabled="disabled"
+      data-focus-lock-disabled="false"
     >
       <button
         class="close"
@@ -151,17 +149,13 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
         >
           Send feedback to Sourcegraph
         </h3>
-        <label
-          class="label label textarea"
+        <textarea
+          aria-labelledby="feedback-prompt-question"
+          class="form-control textarea resizeNone textarea textarea"
+          rows="3"
         >
-          <textarea
-            aria-labelledby="feedback-prompt-question"
-            class="textarea form-control resizeNone textarea"
-            rows="3"
-          >
-            Lorem ipsum dolor sit amet
-          </textarea>
-        </label>
+          Lorem ipsum dolor sit amet
+        </textarea>
         <p
           class="small text-muted"
         >
@@ -195,7 +189,7 @@ exports[`FeedbackPrompt should render submit error correctly 1`] = `
     <div
       data-focus-guard="true"
       style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="-1"
+      tabindex="0"
     />
   </div>
 </body>

--- a/client/wildcard/src/components/Form/TextArea/TextArea.tsx
+++ b/client/wildcard/src/components/Form/TextArea/TextArea.tsx
@@ -52,6 +52,26 @@ export const TextArea: ForwardRefExoticComponent<TextAreaProps & RefAttributes<H
             ...otherProps
         } = props
 
+        if (!label && !message) {
+            return (
+                // eslint-disable-next-line react/forbid-elements
+                <textarea
+                    disabled={disabled}
+                    className={classNames(
+                        'form-control',
+                        styles.textarea,
+                        getValidStyle(isValid),
+                        size === 'small' && 'form-control-sm',
+                        resizeable === false && styles.resizeNone,
+                        inputClassName,
+                        className
+                    )}
+                    {...otherProps}
+                    ref={reference}
+                />
+            )
+        }
+
         return (
             <Label className={classNames(styles.label, className)}>
                 {label && <div className="mb-2">{size === 'small' ? <small>{label}</small> : label}</div>}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/41685

## Background
Prior to this PR `Textarea` component always renders Label > textarea element combination, even if label text is an empty string and there is no need for the label component. Because of this in places where we have as overrides with TextArea component like in [Code Insights repositories field](https://sourcegraph.com/-/editor?remote_url=git%40github.com%3Asourcegraph%2Fsourcegraph.git&branch=vk%2Ffix-textarea-dom-structure&file=client%2Fweb%2Fsrc%2Fenterprise%2Finsights%2Fcomponents%2Fform%2Frepositories-field%2FRepositoriesField.tsx&start_row=107&start_col=14&end_row=107&end_col=14&editor=JetBrains&version=v2.0.1) we had the following structure 


![](https://user-images.githubusercontent.com/10532611/193698836-417457f1-694c-4d10-b6f9-3041099aebab.png)

Note nested labels (which isn't correct in lights of HTML validation) it also confuses screen reader; 

This PR makes `Textarea` component to render only textarea element if there is no need for label or message UI (which is the case when we use `Textarea` as override with `as` prop)


## Test plan
- Check that code insights UI has the right (valid) DOM structure 
- Check other text area consumers

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-textarea-dom-structure.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
