### PR TITLE
sg: adds a command to check a release build for approved cves

### DIFF
--- a/dev/sg/internal/bk/bk.go
+++ b/dev/sg/internal/bk/bk.go
@@ -3,6 +3,7 @@ package bk
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -162,6 +163,19 @@ func (c *Client) ListArtifactsByBuildNumber(ctx context.Context, pipeline string
 	}
 
 	return artifacts, nil
+}
+
+// DownloadArtifact downloads the Buildkite artifact into the provider io.Writer
+func (c *Client) DownloadArtifact(artifact buildkite.Artifact, w io.Writer) error {
+	url := artifact.DownloadURL
+	if url == nil {
+		return errors.New("unable to download artifact, nil download url")
+	}
+	_, err := c.bk.Artifacts.DownloadArtifactByURL(*url, w)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // GetJobAnnotationByBuildNumber retrieves all annotations that are present on a build and maps them to the job ID that the

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -294,6 +294,7 @@ var sg = &cli.App{
 		installCommand,
 		funkyLogoCommand,
 		analyticsCommand,
+		releaseCommand,
 	},
 	ExitErrHandler: func(cmd *cli.Context, err error) {
 		if err == nil {

--- a/dev/sg/release.go
+++ b/dev/sg/release.go
@@ -124,12 +124,11 @@ func cveCheck(cmd *cli.Context) error {
 
 func downloadUrl(uri string, w io.Writer) (err error) {
 	std.Out.WriteLine(output.Styledf(output.StylePending, "Downloading url: %s", uri))
-	client := http.Client{}
-	resp, err := client.Get(uri)
+	resp, err := http.Get(uri)
 	if err != nil {
 		return err
 	}
-	defer func() { err = resp.Body.Close() }()
+	defer resp.Body.Close()
 
 	_, err = io.Copy(w, resp.Body)
 	if err != nil {

--- a/dev/sg/release.go
+++ b/dev/sg/release.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+
+	regexp "github.com/grafana/regexp"
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/bk"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+var releaseCommand = &cli.Command{
+	Name:     "release",
+	Usage:    "Sourcegraph release utilities",
+	Category: CategoryUtil,
+	Subcommands: []*cli.Command{{
+		Name:     "cve-check",
+		Usage:    "Check all CVEs found in a buildkite build against a set of preapproved CVEs for a release",
+		Category: CategoryUtil,
+		Action:   cveCheck,
+		Flags: []cli.Flag{
+			&buildNumberFlag,
+			&referenceUriFlag,
+		},
+		UsageText: `sg release cve-check -u https://handbook.sourcegraph.com/departments/security/tooling/trivy/4-2-0/ -b 184191`,
+	}},
+}
+
+var buildNumberFlag = cli.StringFlag{
+	Name:     "buildNumber",
+	Usage:    "The buildkite build number to check for CVEs",
+	Required: true,
+	Aliases:  []string{"b"},
+}
+
+var referenceUriFlag = cli.StringFlag{
+	Name:     "uri",
+	Usage:    "A reference url that contains approved CVEs. Often a link to a handbook page eg: https://handbook.sourcegraph.com/departments/security/tooling/trivy/4-2-0/.",
+	Required: true,
+	Aliases:  []string{"u"},
+}
+
+func cveCheck(cmd *cli.Context) error {
+	std.Out.WriteLine(output.Styledf(output.StylePending, "Checking release for approved CVEs..."))
+
+	referenceUrl := referenceUriFlag.Get(cmd)
+	number := buildNumberFlag.Get(cmd)
+
+	client, err := bk.NewClient(cmd.Context, std.Out)
+	if err != nil {
+		return errors.Wrap(err, "bk.NewClient")
+	}
+
+	artifacts, err := client.ListArtifactsByBuildNumber(cmd.Context, "sourcegraph", number)
+	if err != nil {
+		return errors.Wrap(err, "unable to list artifacts by build number")
+	}
+
+	var hbBuf bytes.Buffer
+	err = downloadUrl(referenceUrl, &hbBuf)
+	if err != nil {
+		return errors.Wrap(err, "unable to download reference uri")
+	}
+	hbPage := hbBuf.String()
+	if len(hbPage) == 0 {
+		return errors.New("provided reference uri does not have any contents")
+	}
+
+	var foundCVE []string
+	var unapprovedCVE []string
+
+	for _, artifact := range artifacts {
+		name := *artifact.Filename
+		url := *artifact.DownloadURL
+
+		pattern, err := regexp.Compile(`<\w+>(CVE.*)<\/\w+>`)
+		if err != nil {
+			return errors.Wrap(err, "failed to build regexp pattern")
+		}
+
+		if strings.HasSuffix(*artifact.Filename, "security-report.html") {
+			std.Out.WriteLine(output.Styledf(output.StylePending, "Checking security report: %s %s", name, url))
+
+			var buf bytes.Buffer
+			err = client.DownloadArtifact(artifact, &buf)
+			if err != nil {
+				return errors.Newf("failed to download security artifact %q at %s: %w", name, url, err)
+			}
+
+			matches := pattern.FindAllStringSubmatch(buf.String(), -1)
+			for _, match := range matches {
+				cve := strings.TrimSpace(match[1])
+				foundCVE = append(foundCVE, cve)
+				if !strings.Contains(hbPage, cve) {
+					unapprovedCVE = append(unapprovedCVE, cve)
+				}
+			}
+		}
+	}
+
+	// verbose := verboseFlag.Get(cmd)
+	std.Out.WriteLine(output.Styledf(output.StyleBold, "Found %d CVEs in the build", len(foundCVE)))
+	if verbose {
+		for _, s := range foundCVE {
+			std.Out.WriteLine(output.Styledf(output.StyleWarning, "%s", s))
+		}
+	}
+	if len(unapprovedCVE) > 0 {
+		std.Out.WriteLine(output.Styledf(output.StyleWarning, "Unable to match CVEs"))
+		for _, s := range unapprovedCVE {
+			std.Out.WriteLine(output.Styledf(output.StyleWarning, "%s", s))
+		}
+	} else {
+		std.Out.WriteLine(output.Styledf(output.StyleSuccess, "All CVEs approved!"))
+	}
+
+	return nil
+}
+
+func downloadUrl(uri string, w io.Writer) (err error) {
+	std.Out.WriteLine(output.Styledf(output.StylePending, "Downloading url: %s", uri))
+	client := http.Client{}
+	resp, err := client.Get(uri)
+	if err != nil {
+		return err
+	}
+	defer func() { err = resp.Body.Close() }()
+
+	_, err = io.Copy(w, resp.Body)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/dev/sg/release.go
+++ b/dev/sg/release.go
@@ -104,7 +104,6 @@ func cveCheck(cmd *cli.Context) error {
 		}
 	}
 
-	// verbose := verboseFlag.Get(cmd)
 	std.Out.WriteLine(output.Styledf(output.StyleBold, "Found %d CVEs in the build", len(foundCVE)))
 	if verbose {
 		for _, s := range foundCVE {

--- a/dev/sg/release_test.go
+++ b/dev/sg/release_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold"
+)
+
+func Test_extractCVEs(t *testing.T) {
+	tests := []struct {
+		want     autogold.Value
+		document string
+	}{
+		{want: autogold.Want("no greedy matching", []string{"CVE-2016-700"}), document: "<abc>CVE-2016-700</abc><def></def>"},
+		{want: autogold.Want("simple cve in html", []string{"CVE-2016-700"}), document: "<abc>CVE-2016-700</abc>"},
+		{want: autogold.Want("multiple td elements", []string{"CVE-2016-700", "CVE-2016-800"}), document: "<td>CVE-2016-700</td>\n<td>CVE-2016-800</td>"},
+	}
+	for _, test := range tests {
+		t.Run(test.want.Name(), func(t *testing.T) {
+			test.want.Equal(t, extractCVEs(cvePattern, test.document))
+		})
+	}
+}

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1508,3 +1508,22 @@ Flags:
 
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--raw`: view raw data
+
+## sg release
+
+Sourcegraph release utilities.
+
+
+### sg release cve-check
+
+Check all CVEs found in a buildkite build against a set of preapproved CVEs for a release.
+
+```sh
+$ sg release cve-check -u https://handbook.sourcegraph.com/departments/security/tooling/trivy/4-2-0/ -b 184191
+```
+
+Flags:
+
+* `--buildNumber, -b="<value>"`: The buildkite build number to check for CVEs
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
+* `--uri, -u="<value>"`: A reference url that contains approved CVEs. Often a link to a handbook page eg: https://handbook.sourcegraph.com/departments/security/tooling/trivy/4-2-0/.


### PR DESCRIPTION
Automates a step in the release process (at least provides some utility) to compare CVEs found in a build to a set of CVEs that have been approved by the security team.

> Cross check all reported CVEs are in the accepted list (https://handbook.sourcegraph.com/departments/security/tooling/trivy/4-2-0). Otherwise, alert @security-support in the [#release-guild](https://sourcegraph.slack.com/archives/C032Z79NZQC) channel ASAP.

The implementation is simple
1. Pull all of the HTML security artifacts generated in the release and extract any CVE strings using a regexp 
2. Download a provided URL (typically a handbook page) 
3. Check the downloaded text for any usage of the CVE strings. It's not perfect, but it should get the job done for release captains

Usage is simple:

`go run ./dev/sg release cve-check -u https://handbook.sourcegraph.com/departments/security/tooling/trivy/4-2-0 -b 184191`

```
➜  sourcegraph git:(main) ✗ go run ./dev/sg release cve-check -u https://handbook.sourcegraph.com/departments/security/tooling/trivy/4-2-0 -b 184191
Checking release for approved CVEs...
Downloading url: https://handbook.sourcegraph.com/departments/security/tooling/trivy/4-2-0
Checking security report: indexed-searcher-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e450-45be-b119-3de3a7820657/artifacts/018486f4-ddbe-4ca1-8291-369628f05522/download
Checking security report: redis_exporter-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e45e-4672-9c34-2f1b3774abb0/artifacts/018486f4-fc3e-4649-8816-18d1b0222179/download
Checking security report: node-exporter-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e456-4c67-921c-3f5e46541d05/artifacts/018486f5-01a0-4acd-b3f3-9658da6bca98/download
Checking security report: redis-cache-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e45c-4709-9c36-9db42ef597da/artifacts/018486f5-040e-4b4a-a878-539e11d6fbb9/download
Checking security report: search-indexer-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e461-4ed2-a1ca-df5fc4d1b4da/artifacts/018486f5-0868-4cdd-a02a-7dd1d2182034/download
Checking security report: cadvisor-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e448-4a19-8177-0af61753b4c9/artifacts/018486f5-0cc2-4d65-a10a-cf804938fa59/download
Checking security report: jaeger-all-in-one-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e453-4ffe-b077-1e93e9aa5310/artifacts/018486f5-23c5-4af9-b8c1-638eadc65f67/download
Checking security report: batcheshelper-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e46a-48d2-a353-22b1f983191f/artifacts/018486f5-301a-4b92-baa4-b5ab1b896a6d/download
Checking security report: postgres_exporter-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e458-49d8-a5f8-577b3afc2f26/artifacts/018486f5-3b21-4e33-93f8-ee30b9990746/download
Checking security report: redis-store-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e45d-4136-ac94-96f333a50975/artifacts/018486f5-4add-4273-876b-c002ff5b9af1/download
Checking security report: postgres-12-alpine-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e457-4884-8d24-50f53a4340c4/artifacts/018486f5-5ce4-48bd-b63a-4c9d4f4a66a7/download
Checking security report: github-proxy-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e44d-42f8-9eef-16fa8b7644b9/artifacts/018486f5-6183-4626-a652-a9d614c7fa97/download
Checking security report: jaeger-agent-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e452-45d8-86c4-0026853f106c/artifacts/018486f5-61b9-4e8a-8038-610e3cc40bcf/download
Checking security report: minio-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e454-4e44-841e-44133538e431/artifacts/018486f5-61b6-45fb-a1e8-2304e24aedcc/download
Checking security report: alpine-3.14-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e447-4c03-b832-5978635ffebd/artifacts/018486f5-6b08-4808-90c5-51bc537f4406/download
Checking security report: grafana-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e44f-4fda-a30a-00938cad9ace/artifacts/018486f5-71b4-4cd9-9d6b-ca2dc205fb4d/download
Checking security report: codeintel-db-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e44b-4e2a-b9b6-0b22156fef00/artifacts/018486f5-8c9f-4f4e-a07c-68593024e3e4/download
Checking security report: executor-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e467-43e8-922f-88cb0e0eecfc/artifacts/018486f5-a4f6-4d4e-a249-88899177be8b/download
Checking security report: codeinsights-db-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e449-4a9a-a42e-1b0bebb45b50/artifacts/018486f5-cac8-4233-906a-6d57bf55f20e/download
Checking security report: prometheus-gcp-security-report.html https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds/184191/jobs/018486f2-e45b-420b-a7e2-b46da77308d5/artifacts/018486f5-cd6d-4f00-9702-2f3af2756695/download
Found 46 CVEs in the build
All CVEs approved!

```


## Test plan

Manually tested against the current RC build

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
