### PR TITLE
Disable flakey `EnqueueWebhookBuildJob` test

### DIFF
--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -2018,6 +2018,7 @@ func setupSyncErroredTest(ctx context.Context, s repos.Store, t *testing.T,
 }
 
 func TestEnqueueWebhookBuildJob(t *testing.T) {
+	t.Skip("Skipping flakey test")
 	store := getTestRepoStore(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
Failing on unrelated builds:
- [#1](https://buildkite.com/sourcegraph/sourcegraph/builds/184248#0184893b-0a43-4870-87dc-ad9752432651)
- [#2](https://buildkite.com/sourcegraph/sourcegraph/builds/183996#018482c7-46dc-4de4-96b8-c582a84d7c28)

## Test plan
Build is green again
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
