### PR TITLE
authz: Enforce sub-repo permissions for site admins

### DIFF
--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -94,13 +94,13 @@ var _ SubRepoPermissionChecker = &SubRepoPermsClient{}
 
 // SubRepoPermissionsGetter allows getting sub repository permissions.
 type SubRepoPermissionsGetter interface {
-	// GetByUser returns the known sub repository permissions rules known for a user.
+	// GetByUser returns the sub repository permissions rules known for a user.
 	GetByUser(ctx context.Context, userID int32) (map[api.RepoName]SubRepoPermissions, error)
 
-	// RepoIDSupported returns true if repo with the given ID has sub-repo permissions
+	// RepoIDSupported returns true if repo with the given ID has sub-repo permissions.
 	RepoIDSupported(ctx context.Context, repoID api.RepoID) (bool, error)
 
-	// RepoSupported returns true if repo with the given name has sub-repo permissions
+	// RepoSupported returns true if repo with the given name has sub-repo permissions.
 	RepoSupported(ctx context.Context, repo api.RepoName) (bool, error)
 }
 
@@ -270,7 +270,7 @@ func (s *SubRepoPermsClient) FilePermissionsFunc(ctx context.Context, userID int
 	}
 
 	if s.permissionsGetter == nil {
-		return nil, errors.New("PermissionsGetter is nil")
+		return nil, errors.New("permissionsGetter is nil")
 	}
 
 	if userID == 0 {
@@ -335,8 +335,7 @@ func (s *SubRepoPermsClient) getCompiledRules(ctx context.Context, userID int32)
 			return nil, errors.Wrap(err, "fetching rules")
 		}
 		toCache := cachedRules{
-			rules:     make(map[api.RepoName]compiledRules, len(repoPerms)),
-			timestamp: time.Time{},
+			rules: make(map[api.RepoName]compiledRules, len(repoPerms)),
 		}
 		for repo, perms := range repoPerms {
 			paths := make([]path, 0, len(perms.Paths))

--- a/internal/database/sub_repo_perms_store.go
+++ b/internal/database/sub_repo_perms_store.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -142,13 +143,20 @@ WHERE repo_id = %s
 
 // GetByUser fetches all sub repo perms for a user keyed by repo.
 func (s *subRepoPermsStore) GetByUser(ctx context.Context, userID int32) (map[api.RepoName]authz.SubRepoPermissions, error) {
+	enforceForSiteAdmins := conf.Get().AuthzEnforceForSiteAdmins
+
 	q := sqlf.Sprintf(`
-SELECT r.name, paths
-FROM sub_repo_permissions
-JOIN repo r on r.id = repo_id
-WHERE user_id = %s
-  AND version = %s
-`, userID, SubRepoPermsVersion)
+	SELECT r.name, paths
+	FROM sub_repo_permissions
+	JOIN repo r on r.id = repo_id
+	JOIN users u on user_id = %s
+	WHERE user_id = %s
+	 AND version = %s
+	 -- When user is a site admin and AuthzEnforceForSiteAdmins is FALSE
+	 -- we want to return zero results. This causes us to fall back to
+	 -- repo level checks and allows access to all paths in all repos.
+	 AND NOT (u.site_admin AND NOT %b)
+	`, userID, userID, SubRepoPermsVersion, enforceForSiteAdmins)
 
 	rows, err := s.Query(ctx, q)
 	if err != nil {

--- a/internal/database/sub_repo_perms_store.go
+++ b/internal/database/sub_repo_perms_store.go
@@ -155,7 +155,7 @@ func (s *subRepoPermsStore) GetByUser(ctx context.Context, userID int32) (map[ap
 	 -- When user is a site admin and AuthzEnforceForSiteAdmins is FALSE
 	 -- we want to return zero results. This causes us to fall back to
 	 -- repo level checks and allows access to all paths in all repos.
-	 AND NOT (u.site_admin AND NOT %b)
+	 AND NOT (u.site_admin AND NOT %t)
 	`, userID, userID, SubRepoPermsVersion, enforceForSiteAdmins)
 
 	rows, err := s.Query(ctx, q)

--- a/internal/database/sub_repo_perms_store.go
+++ b/internal/database/sub_repo_perms_store.go
@@ -149,7 +149,7 @@ func (s *subRepoPermsStore) GetByUser(ctx context.Context, userID int32) (map[ap
 	SELECT r.name, paths
 	FROM sub_repo_permissions
 	JOIN repo r on r.id = repo_id
-	JOIN users u on user_id = u.id
+	JOIN users u on u.id = user_id
 	WHERE user_id = %s
 	AND version = %s
 	-- When user is a site admin and AuthzEnforceForSiteAdmins is FALSE

--- a/internal/database/sub_repo_perms_store.go
+++ b/internal/database/sub_repo_perms_store.go
@@ -149,14 +149,14 @@ func (s *subRepoPermsStore) GetByUser(ctx context.Context, userID int32) (map[ap
 	SELECT r.name, paths
 	FROM sub_repo_permissions
 	JOIN repo r on r.id = repo_id
-	JOIN users u on user_id = %s
+	JOIN users u on user_id = u.id
 	WHERE user_id = %s
-	 AND version = %s
-	 -- When user is a site admin and AuthzEnforceForSiteAdmins is FALSE
-	 -- we want to return zero results. This causes us to fall back to
-	 -- repo level checks and allows access to all paths in all repos.
-	 AND NOT (u.site_admin AND NOT %t)
-	`, userID, userID, SubRepoPermsVersion, enforceForSiteAdmins)
+	AND version = %s
+	-- When user is a site admin and AuthzEnforceForSiteAdmins is FALSE
+	-- we want to return zero results. This causes us to fall back to
+	-- repo level checks and allows access to all paths in all repos.
+	AND NOT (u.site_admin AND NOT %t)
+	`, userID, SubRepoPermsVersion, enforceForSiteAdmins)
 
 	rows, err := s.Query(ctx, q)
 	if err != nil {

--- a/internal/database/sub_repo_perms_store_test.go
+++ b/internal/database/sub_repo_perms_store_test.go
@@ -143,7 +143,7 @@ func TestSubRepoPermsGetByUser(t *testing.T) {
 	}
 
 	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{AuthzEnforceForSiteAdmins: true}})
-	defer conf.Mock(nil)
+	t.Cleanup(func() { conf.Mock(nil) })
 
 	logger := logtest.Scoped(t)
 	db := NewDB(logger, dbtest.NewDB(logger, t))

--- a/internal/database/sub_repo_perms_store_test.go
+++ b/internal/database/sub_repo_perms_store_test.go
@@ -361,7 +361,7 @@ func prepareSubRepoTestData(ctx context.Context, t *testing.T, db dbutil.DB) {
 
 	// Prepare data
 	qs := []string{
-		`INSERT INTO users(username, site_admin) VALUES ('alice', true)`,
+		`INSERT INTO users(username ) VALUES ('alice')`,
 
 		`INSERT INTO external_services(id, display_name, kind, config, namespace_user_id, last_sync_at) VALUES(1, 'GitHub #1', 'GITHUB', '{}', 1, NOW() + INTERVAL '10min')`,
 		`INSERT INTO external_services(id, display_name, kind, config, namespace_user_id, last_sync_at) VALUES(2, 'Perforce #1', 'PERFORCE', '{}', 1, NOW() + INTERVAL '10min')`,


### PR DESCRIPTION
This ensures that when we're fetching sub-repo permissions for a site admin and 
the `AuthzEnforceForSiteAdmins` is true that we don't return any rows. This is 
in line with existing logic that if no rows are found for a user we grant access. 

## Test plan 

More test cases added
Manually testing

Closes https://github.com/sourcegraph/sourcegraph/issues/44483