### PR TITLE
batches: add unique constraint {batch, changeset}_spec rand ids

### DIFF
--- a/dev/ci/go-backcompat/flakefiles/v4.1.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.1.0.json
@@ -49,5 +49,10 @@
     "path": "internal/database",
     "prefix": "TestGetByUUID",
     "reason": "New NOT NULL `name` column is added. The test is trying to add an entry without populating this column."
+  },
+  {
+    "path": "enterprise/internal/batches/store",
+    "prefix": "TestIntegration",
+    "reason": "Added a UNIQUE constraint on batch_specs.rand_id and changeset_specs.rand_id, some tests fail because we had some duplicate Rand ID creation in tests."
   }
 ]

--- a/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs_test.go
+++ b/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs_test.go
@@ -3,7 +3,6 @@ package store
 import (
 	"context"
 	"fmt"
-	"github.com/google/uuid"
 	"strconv"
 	"testing"
 
@@ -526,7 +525,6 @@ func testStoreBatchSpecWorkspaceExecutionJobs(t *testing.T, ctx context.Context,
 			cachedResultWorkspace := &btypes.BatchSpecWorkspace{CachedResultFound: true}
 
 			batchSpec := &btypes.BatchSpec{}
-			batchSpec.RandID = uuid.NewString()
 
 			createBatchSpec(t, batchSpec)
 			createWorkspaces(t, batchSpec, normalWorkspace, ignoredWorkspace, unsupportedWorkspace, cachedResultWorkspace)
@@ -538,7 +536,6 @@ func testStoreBatchSpecWorkspaceExecutionJobs(t *testing.T, ctx context.Context,
 			ignoredWorkspace := &btypes.BatchSpecWorkspace{Ignored: true}
 
 			batchSpec := &btypes.BatchSpec{AllowIgnored: true}
-			batchSpec.RandID = uuid.NewString()
 
 			createBatchSpec(t, batchSpec)
 			createWorkspaces(t, batchSpec, normalWorkspace, ignoredWorkspace)
@@ -562,7 +559,6 @@ func testStoreBatchSpecWorkspaceExecutionJobs(t *testing.T, ctx context.Context,
 			unsupportedWorkspace := &btypes.BatchSpecWorkspace{Unsupported: true}
 
 			batchSpec := &btypes.BatchSpec{AllowUnsupported: true, AllowIgnored: true}
-			batchSpec.RandID = uuid.NewString()
 
 			createBatchSpec(t, batchSpec)
 			createWorkspaces(t, batchSpec, normalWorkspace, ignoredWorkspace, unsupportedWorkspace)

--- a/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs_test.go
+++ b/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
 	"strconv"
 	"testing"
 
@@ -475,11 +476,6 @@ func testStoreBatchSpecWorkspaceExecutionJobs(t *testing.T, ctx context.Context,
 		createWorkspaces := func(t *testing.T, batchSpec *btypes.BatchSpec, workspaces ...*btypes.BatchSpecWorkspace) {
 			t.Helper()
 
-			batchSpec.NamespaceUserID = 1
-			if err := s.CreateBatchSpec(ctx, batchSpec); err != nil {
-				t.Fatal(err)
-			}
-
 			for i, workspace := range workspaces {
 				workspace.BatchSpecID = batchSpec.ID
 				workspace.RepoID = 1
@@ -530,6 +526,7 @@ func testStoreBatchSpecWorkspaceExecutionJobs(t *testing.T, ctx context.Context,
 			cachedResultWorkspace := &btypes.BatchSpecWorkspace{CachedResultFound: true}
 
 			batchSpec := &btypes.BatchSpec{}
+			batchSpec.RandID = uuid.NewString()
 
 			createBatchSpec(t, batchSpec)
 			createWorkspaces(t, batchSpec, normalWorkspace, ignoredWorkspace, unsupportedWorkspace, cachedResultWorkspace)
@@ -541,6 +538,7 @@ func testStoreBatchSpecWorkspaceExecutionJobs(t *testing.T, ctx context.Context,
 			ignoredWorkspace := &btypes.BatchSpecWorkspace{Ignored: true}
 
 			batchSpec := &btypes.BatchSpec{AllowIgnored: true}
+			batchSpec.RandID = uuid.NewString()
 
 			createBatchSpec(t, batchSpec)
 			createWorkspaces(t, batchSpec, normalWorkspace, ignoredWorkspace)
@@ -564,6 +562,7 @@ func testStoreBatchSpecWorkspaceExecutionJobs(t *testing.T, ctx context.Context,
 			unsupportedWorkspace := &btypes.BatchSpecWorkspace{Unsupported: true}
 
 			batchSpec := &btypes.BatchSpec{AllowUnsupported: true, AllowIgnored: true}
+			batchSpec.RandID = uuid.NewString()
 
 			createBatchSpec(t, batchSpec)
 			createWorkspaces(t, batchSpec, normalWorkspace, ignoredWorkspace, unsupportedWorkspace)

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -3014,6 +3014,16 @@
           "ConstraintDefinition": "PRIMARY KEY (id)"
         },
         {
+          "Name": "batch_specs_unique_rand_id",
+          "IsPrimaryKey": false,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX batch_specs_unique_rand_id ON batch_specs USING btree (rand_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
           "Name": "batch_specs_rand_id",
           "IsPrimaryKey": false,
           "IsUnique": false,

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -3867,6 +3867,16 @@
           "ConstraintDefinition": "PRIMARY KEY (id)"
         },
         {
+          "Name": "changeset_specs_unique_rand_id",
+          "IsPrimaryKey": false,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX changeset_specs_unique_rand_id ON changeset_specs USING btree (rand_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
           "Name": "changeset_specs_batch_spec_id",
           "IsPrimaryKey": false,
           "IsUnique": false,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -270,6 +270,7 @@ Referenced by:
  batch_change_id   | bigint                   |           |          | 
 Indexes:
     "batch_specs_pkey" PRIMARY KEY, btree (id)
+    "batch_specs_unique_rand_id" UNIQUE, btree (rand_id)
     "batch_specs_rand_id" btree (rand_id)
 Check constraints:
     "batch_specs_has_1_namespace" CHECK ((namespace_user_id IS NULL) <> (namespace_org_id IS NULL))

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -376,6 +376,7 @@ Foreign-key constraints:
  type                | text                     |           | not null | 
 Indexes:
     "changeset_specs_pkey" PRIMARY KEY, btree (id)
+    "changeset_specs_unique_rand_id" UNIQUE, btree (rand_id)
     "changeset_specs_batch_spec_id" btree (batch_spec_id)
     "changeset_specs_created_at" btree (created_at)
     "changeset_specs_external_id" btree (external_id)

--- a/migrations/frontend/1668707631_add_unique_constraint_batch_specs_rand_id/down.sql
+++ b/migrations/frontend/1668707631_add_unique_constraint_batch_specs_rand_id/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS batch_specs_unique_rand_id;

--- a/migrations/frontend/1668707631_add_unique_constraint_batch_specs_rand_id/metadata.yaml
+++ b/migrations/frontend/1668707631_add_unique_constraint_batch_specs_rand_id/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_unique_constraint_batch_specs_rand_id
+parents: [1668603582]

--- a/migrations/frontend/1668707631_add_unique_constraint_batch_specs_rand_id/up.sql
+++ b/migrations/frontend/1668707631_add_unique_constraint_batch_specs_rand_id/up.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX
+    IF NOT EXISTS batch_specs_unique_rand_id ON batch_specs (rand_id);

--- a/migrations/frontend/1668767882_add_unique_constraint_changeset_specs_rand_id/down.sql
+++ b/migrations/frontend/1668767882_add_unique_constraint_changeset_specs_rand_id/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS changeset_specs_unique_rand_id;

--- a/migrations/frontend/1668767882_add_unique_constraint_changeset_specs_rand_id/metadata.yaml
+++ b/migrations/frontend/1668767882_add_unique_constraint_changeset_specs_rand_id/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_unique_constraint_changeset_specs_rand_id
+parents: [1668707631]

--- a/migrations/frontend/1668767882_add_unique_constraint_changeset_specs_rand_id/up.sql
+++ b/migrations/frontend/1668767882_add_unique_constraint_changeset_specs_rand_id/up.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX
+    IF NOT EXISTS changeset_specs_unique_rand_id ON changeset_specs (rand_id);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -4304,6 +4304,8 @@ CREATE INDEX changeset_specs_rand_id ON changeset_specs USING btree (rand_id);
 
 CREATE INDEX changeset_specs_title ON changeset_specs USING btree (title);
 
+CREATE UNIQUE INDEX changeset_specs_unique_rand_id ON changeset_specs USING btree (rand_id);
+
 CREATE INDEX changesets_batch_change_ids ON changesets USING gin (batch_change_ids);
 
 CREATE INDEX changesets_bitbucket_cloud_metadata_source_commit_idx ON changesets USING btree (((((metadata -> 'source'::text) -> 'commit'::text) ->> 'hash'::text)));

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -4286,6 +4286,8 @@ CREATE INDEX batch_spec_workspaces_id_batch_spec_id ON batch_spec_workspaces USI
 
 CREATE INDEX batch_specs_rand_id ON batch_specs USING btree (rand_id);
 
+CREATE UNIQUE INDEX batch_specs_unique_rand_id ON batch_specs USING btree (rand_id);
+
 CREATE INDEX changeset_jobs_bulk_group_idx ON changeset_jobs USING btree (bulk_group);
 
 CREATE INDEX changeset_jobs_state_idx ON changeset_jobs USING btree (state);


### PR DESCRIPTION
Closes #16721

This PR adds a unique constraint on the `rand_id` column in the following tables:

* `batch_specs`
* `changeset_specs`

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Confirm `sg migrations up` works fine and applies the relevant migrations.
Also confirm `sg migrations downto` works fine as well.