### PR TITLE
Fix VSCode extension after search components refactor

### DIFF
--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -45,7 +45,9 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
                   class="headerTitle"
                   data-testid="result-container-header"
                 >
-                  <span>
+                  <span
+                    class="d-flex align-items-center"
+                  >
                     <span
                       class="titleInner mutedRepoFileLink"
                     >
@@ -295,7 +297,9 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                   class="headerTitle"
                   data-testid="result-container-header"
                 >
-                  <span>
+                  <span
+                    class="d-flex align-items-center"
+                  >
                     <span
                       class="titleInner mutedRepoFileLink"
                     >
@@ -493,7 +497,9 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
                   class="headerTitle"
                   data-testid="result-container-header"
                 >
-                  <span>
+                  <span
+                    class="d-flex align-items-center"
+                  >
                     <span
                       class="titleInner mutedRepoFileLink"
                     >

--- a/client/search-ui/src/components/FileContentSearchResult.tsx
+++ b/client/search-ui/src/components/FileContentSearchResult.tsx
@@ -208,7 +208,7 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
 
     const title = (
         <>
-            <span>
+            <span className="d-flex align-items-center">
                 <RepoFileLink
                     repoName={result.repository}
                     repoURL={repoAtRevisionURL}

--- a/client/search-ui/src/components/FilePathSearchResult.tsx
+++ b/client/search-ui/src/components/FilePathSearchResult.tsx
@@ -32,7 +32,7 @@ export const FilePathSearchResult: React.FunctionComponent<FilePathSearchResult 
     const revisionDisplayName = getRevision(result.branches, result.commit)
 
     const title = (
-        <span>
+        <span className="d-flex align-items-center">
             <RepoFileLink
                 repoName={result.repository}
                 repoURL={repoAtRevisionURL}

--- a/client/search-ui/src/components/index.ts
+++ b/client/search-ui/src/components/index.ts
@@ -17,4 +17,5 @@ export * from './codeLinkNavigation'
 
 import FileMatchChildrenStyles from './FileMatchChildren.module.scss'
 import SearchResultStyles from './SearchResult.module.scss'
-export { SearchResultStyles, FileMatchChildrenStyles }
+import SymbolSearchResultStyles from './SymbolSearchResult.module.scss'
+export { SearchResultStyles, FileMatchChildrenStyles, SymbolSearchResultStyles }

--- a/client/vscode/webpack.config.js
+++ b/client/vscode/webpack.config.js
@@ -173,6 +173,7 @@ const webviewConfig = {
       path: require.resolve('path-browserify'),
       './RepoSearchResult': path.resolve(__dirname, 'src', 'webview', 'search-panel', 'alias', 'RepoSearchResult'),
       './CommitSearchResult': path.resolve(__dirname, 'src', 'webview', 'search-panel', 'alias', 'CommitSearchResult'),
+      './SymbolSearchResult': path.resolve(__dirname, 'src', 'webview', 'search-panel', 'alias', 'SymbolSearchResult'),
       './FileMatchChildren': path.resolve(__dirname, 'src', 'webview', 'search-panel', 'alias', 'FileMatchChildren'),
       './RepoFileLink': path.resolve(__dirname, 'src', 'webview', 'search-panel', 'alias', 'RepoFileLink'),
       '../documentation/ModalVideo': path.resolve(__dirname, 'src', 'webview', 'search-panel', 'alias', 'ModalVideo'),


### PR DESCRIPTION
Fixes VSCode extension after search components refactor in https://github.com/sourcegraph/sourcegraph/pull/43155

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

* Run the VSCode extension, make sure all search results show up and are clickable
* Run integration tests

## App preview:

- [Web](https://sg-web-rn-fix-vscode-after-search.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
