### PR TITLE
update downto instruction for `sg migration --help` 

### DIFF
--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -173,6 +173,9 @@ var (
 # Migrate local default database up all the way
 sg migration up
 
+# Migrate specific database down one migration
+sg migration downto --db codeintel --target <version>
+
 # Add new migration for specific database
 sg migration add --db codeintel 'add missing index'
 

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -173,9 +173,6 @@ var (
 # Migrate local default database up all the way
 sg migration up
 
-# Migrate specific database down one migration
-sg migration down --db codeintel
-
 # Add new migration for specific database
 sg migration add --db codeintel 'add missing index'
 

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -573,7 +573,7 @@ Modifies and runs database migrations.
 $ sg migration up
 
 # Migrate specific database down one migration
-$ sg migration down --db codeintel
+$ sg migration downto --db codeintel --target <version>
 
 # Add new migration for specific database
 $ sg migration add --db codeintel 'add missing index'


### PR DESCRIPTION
The help text for `sg migration` includes information about a subcommand `sg migration down` which doesn't exist anymore, this PR replaces that subcommand in the help text with the correct one for downgrading a migration.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Confirm everything works as normal.

| Before | After |
|--------|-------|
|  <img width="888" alt="CleanShot 2022-11-18 at 14 11 32@2x" src="https://user-images.githubusercontent.com/25608335/202713162-a3858708-0183-4db1-949d-f9e18532b712.png">      | <img width="897" alt="CleanShot 2022-11-18 at 14 13 53@2x" src="https://user-images.githubusercontent.com/25608335/202713387-1cc24988-ca11-4aa2-a532-5a9d17b569fc.png">      |