### PR TITLE
executor: Don't swallow errors from file.Close()

### DIFF
--- a/enterprise/cmd/executor/internal/worker/workspace/files.go
+++ b/enterprise/cmd/executor/internal/worker/workspace/files.go
@@ -127,7 +127,7 @@ func writeFiles(ctx context.Context, store store.FilesStore, workspaceFileConten
 			handle.Finalize(1)
 		}
 
-		handle.Close()
+		_ = handle.Close()
 	}()
 
 	for path, wf := range workspaceFileContentsByPath {
@@ -153,8 +153,12 @@ func writeFiles(ctx context.Context, store store.FilesStore, workspaceFileConten
 		if err != nil {
 			return err
 		}
-		defer f.Close()
+
 		if _, err = io.Copy(f, src); err != nil {
+			return errors.Append(err, f.Close())
+		}
+
+		if err = f.Close(); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
We've seen some workspace files be empty sometimes in executions. Maybe this reveals more information?

Error: 
<img width="814" alt="Screenshot 2022-11-18 at 15 12 12@2x" src="https://user-images.githubusercontent.com/19534377/202724165-9008daf9-eedf-4ba8-92b6-ceecbf1e3725.png">

## Test plan

None, will see over time if these kinds of errors we saw have more log messages now.