### PR TITLE
flakefile for EnqueueWebhookBuildJob

### DIFF
--- a/dev/ci/go-backcompat/flakefiles/v4.1.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.1.0.json
@@ -8,5 +8,10 @@
     "path": "internal/gitserver",
     "prefix": "TestLFSSmudge",
     "reason": "Git config seems to be borked after introduction of https://github.com/sourcegraph/sourcegraph/pull/43227"
+  },
+  {
+    "path": "github.com/sourcegraph/sourcegraph/internal/repos",
+    "prefix": "EnqueueWebhookBuildJob",
+    "reason": "Flakes repeatedly in CI"
   }
 ]


### PR DESCRIPTION
This test has been flaking for quite a while 

<img width="1397" alt="image" src="https://user-images.githubusercontent.com/5090588/202749036-ec3fb379-db5d-4ae1-b181-7d7ef25ff855.png">


## Test plan

N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
