### PR TITLE
monitoring/zoekt: do not manipulate targets for multiple metrics in panel

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -16519,12 +16519,12 @@ To see this dashboard, visit `/-/debug/grafana/d/zoekt/zoekt` on your Sourcegrap
 
 Sudden changes can be caused by indexing configuration changes.
 
-Additionally, a discrepancy between "assigned" and "tracked" could indicate a bug.
+Additionally, a discrepancy between "index_num_assigned" and "index_queue_cap" could indicate a bug.
 
 Legend:
-- assigned: # of repos assigned to Zoekt
-- indexed: # of repos Zoekt has indexed
-- tracked: # of repos Zoekt is aware of, including those that it has finished indexing
+- index_num_assigned: # of repos assigned to Zoekt
+- index_num_indexed: # of repos Zoekt has indexed
+- index_queue_cap: # of repos Zoekt is aware of, including those that it has finished indexing
 
 This panel has no related alerts.
 
@@ -16535,7 +16535,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100000` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(index_num_assigned)`
+Query: `sum by (__name__) ({__name__=~"index_num_assigned|index_num_indexed|index_queue_cap"})`
 
 </details>
 
@@ -16547,12 +16547,12 @@ Query: `sum(index_num_assigned)`
 
 Sudden changes can be caused by indexing configuration changes.
 
-Additionally, a discrepancy between "assigned" and "tracked" could indicate a bug.
+Additionally, a discrepancy between "index_num_assigned" and "index_queue_cap" could indicate a bug.
 
 Legend:
-- assigned: # of repos assigned to Zoekt
-- indexed: # of repos Zoekt has indexed
-- tracked: # of repos Zoekt is aware of, including those that it has finished processing
+- index_num_assigned: # of repos assigned to Zoekt
+- index_num_indexed: # of repos Zoekt has indexed
+- index_queue_cap: # of repos Zoekt is aware of, including those that it has finished processing
 
 This panel has no related alerts.
 
@@ -16563,7 +16563,7 @@ To see this panel, visit `/-/debug/grafana/d/zoekt/zoekt?viewPanel=100001` on yo
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (instance) (index_num_assigned{instance=~`${instance:regex}`})`
+Query: `sum by (__name__, instance) ({__name__=~"index_num_assigned|index_num_indexed|index_queue_cap",instance=~"${instance:regex}"})`
 
 </details>
 


### PR DESCRIPTION
Custom panel options are currently used to hijack the targets to enable multiple queries on this panel - this is not something we support. Especially with the recent changes to leverage `Query` to create allowlist metrics we collect on Cloud, doing this might mean certain metrics do not get collected in Cloud. It also seems to cause funky interactions with some manipulations we do to queries (https://github.com/sourcegraph/sourcegraph/pull/41644#issuecomment-1292230168)

Instead, panels like this should use a query on `__name__` - the legend isn't quite as nice, but a follow-up PR could add a `label_replace` to format it better:

<img width="1372" alt="image" src="https://user-images.githubusercontent.com/23356519/202796223-225ba637-3527-4aac-82c8-075ad29bfef4.png">

Doing this adds a metric to our allowlist that was previously omitted and not collected in Cloud:

```sh
$ sg monitoring metrics # in main
# ...
Found 608 metrics in use.                                                                                               
$ go run ./dev/sg monitoring metrics # on this branch
# ...
Found 609 metrics in use. 
```

Aside: in the metrics list we include this entry as `index_num_assigned|index_num_indexed|index_queue_cap`, which is fine because we use `go run ./dev/sg monitoring metrics -format regexp` for the allowlist which still ends up with a valid regexp.

For more details about centralized observability see https://github.com/sourcegraph/customer/issues/1151

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

See above. Also tested with a single instance selected:

<img width="687" alt="image" src="https://user-images.githubusercontent.com/23356519/202796426-73306858-2c75-400b-8678-fc18dd9e6bf8.png">
