### PR TITLE
accept HEAD request on index route for VSCode extension verification

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -311,6 +311,11 @@ func serveHome(db database.DB) handlerFunc {
 			return nil // request was handled
 		}
 
+		if r.Method == "HEAD" && envvar.SourcegraphDotComMode() {
+			w.WriteHeader(http.StatusOK)
+			return nil
+		}
+
 		// On non-Sourcegraph.com instances, there is no separate homepage, so redirect to /search.
 		r.URL.Path = "/search"
 		http.Redirect(w, r, r.URL.String(), http.StatusTemporaryRedirect)

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -311,8 +311,12 @@ func serveHome(db database.DB) handlerFunc {
 			return nil // request was handled
 		}
 
-		if r.Method == "HEAD" && envvar.SourcegraphDotComMode() {
-			w.WriteHeader(http.StatusOK)
+		if r.Method == "HEAD" {
+			if envvar.SourcegraphDotComMode() {
+				w.WriteHeader(http.StatusOK)
+				return nil
+			}
+			w.WriteHeader(http.StatusMethodNotAllowed)
 			return nil
 		}
 

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -311,7 +311,7 @@ func serveHome(db database.DB) handlerFunc {
 			return nil // request was handled
 		}
 
-		// we only allow HEAD requests on Sourcegraph.com -
+		// we only allow HEAD requests on sourcegraph.com.
 		if r.Method == "HEAD" {
 			w.WriteHeader(http.StatusOK)
 			return nil

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -311,12 +311,9 @@ func serveHome(db database.DB) handlerFunc {
 			return nil // request was handled
 		}
 
+		// we only allow HEAD requests on Sourcegraph.com -
 		if r.Method == "HEAD" {
-			if envvar.SourcegraphDotComMode() {
-				w.WriteHeader(http.StatusOK)
-				return nil
-			}
-			w.WriteHeader(http.StatusMethodNotAllowed)
+			w.WriteHeader(http.StatusOK)
 			return nil
 		}
 

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -130,7 +130,7 @@ func newRouter() *mux.Router {
 	r.StrictSlash(true)
 
 	// Top-level routes.
-	r.Path("/").Methods("GET").Name(routeHome)
+	r.Path("/").Methods("GET", "HEAD").Name(routeHome)
 	r.PathPrefix("/threads").Methods("GET").Name(routeThreads)
 	r.Path("/search").Methods("GET").Name(routeSearch)
 	r.Path("/search/badge").Methods("GET").Name(routeSearchBadge)

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -129,8 +129,13 @@ func newRouter() *mux.Router {
 	r := mux.NewRouter()
 	r.StrictSlash(true)
 
+	homeRouteMethods := []string{"GET"}
+	if envvar.SourcegraphDotComMode() {
+		homeRouteMethods = append(homeRouteMethods, "HEAD")
+	}
+
 	// Top-level routes.
-	r.Path("/").Methods("GET", "HEAD").Name(routeHome)
+	r.Path("/").Methods(homeRouteMethods...).Name(routeHome)
 	r.PathPrefix("/threads").Methods("GET").Name(routeThreads)
 	r.Path("/search").Methods("GET").Name(routeSearch)
 	r.Path("/search/badge").Methods("GET").Name(routeSearchBadge)


### PR DESCRIPTION
Confirmed that `curl -I https://sourcegraph.test:3443` returns a 200. This makes a HEAD request to the root route.

[Slack Context](https://sourcegraph.slack.com/archives/C02UC4WUX1Q/p1668800409417249)

One of the requirements for verifying our VSCode extension is that our domain must be able to serve an HTTP 200 status response to a HEAD request.

This PR adds the functionality for the index route to return 200 to a HEAD request.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
![CleanShot 2022-11-18 at 23 05 39@2x](https://user-images.githubusercontent.com/25608335/202810974-b19c9e60-50e7-4047-8849-0281a6d5e934.png)

<img width="905" alt="CleanShot 2022-11-18 at 23 06 34@2x" src="https://user-images.githubusercontent.com/25608335/202811046-270af67f-a693-43d3-acf9-a365708330a7.png">
