### PR TITLE
insights: add trace id to queued query record

### DIFF
--- a/enterprise/internal/insights/query/streaming/decoder.go
+++ b/enterprise/internal/insights/query/streaming/decoder.go
@@ -135,6 +135,7 @@ func newComputeMatch(repoName string, repoID int32) *ComputeMatch {
 type ComputeTabulationResult struct {
 	StreamDecoderEvents
 	RepoCounts map[string]*ComputeMatch
+	TotalCount int
 }
 
 const capturedValueMaxLength = 100
@@ -184,6 +185,7 @@ func MatchContextComputeDecoder() (client.ComputeMatchContextStreamDecoder, *Com
 						if len(value) > capturedValueMaxLength {
 							value = value[:capturedValueMaxLength]
 						}
+						ctr.TotalCount += 1
 						current.ValueCounts[value] += 1
 					}
 				}

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -11190,6 +11190,19 @@
           "Comment": ""
         },
         {
+          "Name": "trace_id",
+          "Index": 20,
+          "TypeName": "text",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
           "Name": "worker_hostname",
           "Index": 13,
           "TypeName": "text",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1548,6 +1548,7 @@ Indexes:
  persist_mode      | persistmode              |           | not null | 'record'::persistmode
  queued_at         | timestamp with time zone |           |          | now()
  cancel            | boolean                  |           | not null | false
+ trace_id          | text                     |           |          | 
 Indexes:
     "insights_query_runner_jobs_pkey" PRIMARY KEY, btree (id)
     "finished_at_insights_query_runner_jobs_idx" btree (finished_at)

--- a/internal/trace/tracer.go
+++ b/internal/trace/tracer.go
@@ -16,7 +16,7 @@ type Tracer struct {
 	TracerProvider oteltrace.TracerProvider
 }
 
-// New returns a new Trace with the specified family and title.
+// New returns a new Trace with the specified family and title. Must be closed with Finish().
 func (t Tracer) New(ctx context.Context, family, title string, tags ...Tag) (*Trace, context.Context) {
 	if t.TracerProvider == nil {
 		t.TracerProvider = otel.GetTracerProvider()

--- a/migrations/frontend/1668808118_temp_codeinsights_trace_with_query/down.sql
+++ b/migrations/frontend/1668808118_temp_codeinsights_trace_with_query/down.sql
@@ -1,2 +1,2 @@
-ALTER TABLE insights_query_runner_jobs
-    DROP COLUMN trace_id;
+ALTER TABLE IF EXISTS insights_query_runner_jobs
+    DROP COLUMN IF EXISTS trace_id;

--- a/migrations/frontend/1668808118_temp_codeinsights_trace_with_query/down.sql
+++ b/migrations/frontend/1668808118_temp_codeinsights_trace_with_query/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE insights_query_runner_jobs
+    DROP COLUMN trace_id;

--- a/migrations/frontend/1668808118_temp_codeinsights_trace_with_query/metadata.yaml
+++ b/migrations/frontend/1668808118_temp_codeinsights_trace_with_query/metadata.yaml
@@ -1,0 +1,2 @@
+name: temp_codeinsights_trace_with_query
+parents: [1668603582]

--- a/migrations/frontend/1668808118_temp_codeinsights_trace_with_query/up.sql
+++ b/migrations/frontend/1668808118_temp_codeinsights_trace_with_query/up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE insights_query_runner_jobs
-    ADD COLUMN trace_id TEXT;
+ALTER TABLE IF EXISTS insights_query_runner_jobs
+    ADD COLUMN IF NOT EXISTS trace_id TEXT;

--- a/migrations/frontend/1668808118_temp_codeinsights_trace_with_query/up.sql
+++ b/migrations/frontend/1668808118_temp_codeinsights_trace_with_query/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE insights_query_runner_jobs
+    ADD COLUMN trace_id TEXT;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -2216,7 +2216,8 @@ CREATE TABLE insights_query_runner_jobs (
     cost integer DEFAULT 500 NOT NULL,
     persist_mode persistmode DEFAULT 'record'::persistmode NOT NULL,
     queued_at timestamp with time zone DEFAULT now(),
-    cancel boolean DEFAULT false NOT NULL
+    cancel boolean DEFAULT false NOT NULL,
+    trace_id text
 );
 
 COMMENT ON TABLE insights_query_runner_jobs IS 'See [enterprise/internal/insights/background/queryrunner/worker.go:Job](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:enterprise/internal/insights/background/queryrunner/worker.go+type+Job&patternType=literal)';


### PR DESCRIPTION
To debug issues on cloud I'm adding the traceID generated (if exists) to the queued record when it starts. We can remove this if necessary in 4.3

## Test plan

Tested locally

<img width="1430" alt="image" src="https://user-images.githubusercontent.com/5090588/202815118-cbb9e02f-fd8e-4799-b0a1-a030cad5e8c9.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
