### PR TITLE
Ensure analytics cookies are always set to renew expiration timeline

### DIFF
--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -211,7 +211,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
         const redactedURL = redactSensitiveInfoFromAppURL(firstSourceURL)
 
         // Use cookies instead of localStorage so that the ID can be shared with subdomains (about.sourcegraph.com).
-        // Always set to renew expiry and migrate from localStorage
+        // Always set to renew expiry
         cookies.set(FIRST_SOURCE_URL_KEY, redactedURL, this.cookieSettings)
 
         this.firstSourceURL = firstSourceURL
@@ -226,7 +226,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
         const redactedURL = redactSensitiveInfoFromAppURL(lastSourceURL)
 
         // Use cookies instead of localStorage so that the ID can be shared with subdomains (about.sourcegraph.com).
-        // Always set to renew expiry and migrate from localStorage
+        // Always set to renew expiry
         cookies.set(LAST_SOURCE_URL_KEY, redactedURL, this.cookieSettings)
 
         this.lastSourceURL = lastSourceURL
@@ -237,8 +237,11 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
         let deviceSessionID = cookies.get(DEVICE_SESSION_ID_KEY)
         if (!deviceSessionID || deviceSessionID === '') {
             deviceSessionID = uuid.v4()
-            cookies.set(DEVICE_SESSION_ID_KEY, deviceSessionID, this.deviceSessionCookieSettings)
         }
+
+        // Use cookies instead of localStorage so that the ID can be shared with subdomains (about.sourcegraph.com).
+        // Always set to renew expiry
+        cookies.set(DEVICE_SESSION_ID_KEY, deviceSessionID, this.deviceSessionCookieSettings)
         return deviceSessionID
     }
 
@@ -308,8 +311,9 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
         if (!deviceID) {
             // If device ID does not exist, use the anonymous user ID value so these are consolidated.
             deviceID = anonymousUserID
-            cookies.set(DEVICE_ID_KEY, deviceID, this.cookieSettings)
         }
+        // Always set to renew expiry
+        cookies.set(DEVICE_ID_KEY, deviceID, this.cookieSettings)
 
         this.anonymousUserID = anonymousUserID
         this.cohortID = cohortID


### PR DESCRIPTION
I have not tested, but this is a simple change.

I believe both of these cookies _should_ always be getting set to ensure that the cookie expiration timeline is reset (I believe this is how this works—the other cookies seem to follow this pattern).

It's clear that this was the intended behavior for the `deviceSessionID`(per the comment in the `deviceSessionCookieSettings` at the top of the file). 

I'm not 100% sure however what the `deviceID` is, or if it should have this same behavior. Given it just seems to match the `anonymousUserID`, I assume it should.

## App preview:

- [Web](https://sg-web-analytics-cookies.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
