### PR TITLE
Wildcard [Chart]: Fix shutter appearance in the ScrollBox component

### DIFF
--- a/client/wildcard/src/components/Charts/core/components/scroll-box/ScrollBox.module.scss
+++ b/client/wildcard/src/components/Charts/core/components/scroll-box/ScrollBox.module.scss
@@ -2,55 +2,38 @@
     position: relative;
     padding: 0;
 
-    &--with-scroll {
-        overflow: auto;
+    &::before,
+    &::after {
+        content: '';
+        display: block;
+        position: absolute;
+        width: 100%;
+        height: 2rem;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
     }
 
-    &--with-top-fader {
-        .fader--top {
-            opacity: 1;
-        }
+    &::before {
+        top: 0;
+        background: linear-gradient(0deg, rgba(249, 250, 251, 0) 0%, var(--color-bg-1) 100%);
     }
 
-    &--with-bottom-fader {
-        .fader--bottom {
-            opacity: 1;
-        }
+    &::after {
+        bottom: 0;
+        background: linear-gradient(180deg, rgba(249, 250, 251, 0) 0%, var(--color-bg-1) 100%);
+    }
+
+    &--with-top-fader::before {
+        opacity: 1;
+    }
+
+    &--with-bottom-fader::after {
+        opacity: 1;
     }
 }
 
-.fader {
-    display: block;
-    position: sticky;
-    z-index: 1;
-    height: 0;
-    width: 100%;
-    opacity: 0;
-    pointer-events: none;
-
-    &--top {
-        top: 0;
-
-        &::before {
-            content: '';
-            display: block;
-            position: absolute;
-            width: 100%;
-            height: 3rem;
-            background: linear-gradient(0deg, rgba(249, 250, 251, 0) 0%, var(--color-bg-1) 100%);
-        }
-    }
-
-    &--bottom {
-        top: calc(100% - 3rem);
-
-        &::before {
-            content: '';
-            display: block;
-            position: absolute;
-            width: 100%;
-            height: 3rem;
-            background: linear-gradient(180deg, rgba(249, 250, 251, 0) 0%, var(--color-bg-1) 100%);
-        }
-    }
+.scroll-container {
+    overflow-x: auto;
+    height: 100%;
 }

--- a/client/wildcard/src/components/Charts/core/components/scroll-box/ScrollBox.story.tsx
+++ b/client/wildcard/src/components/Charts/core/components/scroll-box/ScrollBox.story.tsx
@@ -15,7 +15,7 @@ export default {
 } as Meta
 
 export const ScrollBoxDemo = () => (
-    <ScrollBox style={{ height: 400, width: 200 }}>
+    <ScrollBox style={{ height: 400, width: 200, border: '1px solid var(--border-color)' }}>
         Sorokin's works, bright and striking examples of underground culture, were banned during the Soviet period. His
         first publication in the USSR appeared in November 1989, when the Riga-based Latvian magazine Rodnik (Spring)
         presented a group of Sorokin's stories. Soon after, his stories appeared in Russian literary miscellanies and

--- a/client/wildcard/src/components/Charts/core/components/scroll-box/ScrollBox.tsx
+++ b/client/wildcard/src/components/Charts/core/components/scroll-box/ScrollBox.tsx
@@ -1,44 +1,10 @@
-import { FunctionComponent, HTMLAttributes, useEffect, useState } from 'react'
+import { FunctionComponent, HTMLAttributes, useRef } from 'react'
 
 import classNames from 'classnames'
 
-import { isFirefox, observeResize } from '@sourcegraph/common'
+import { useElementObscuredArea } from '../../../../../hooks'
 
 import styles from './ScrollBox.module.scss'
-
-/**
- * Mutates element (adds/removes css classes) based on scroll height and client height.
- */
-function addShutterElementsToTarget(parentElement: HTMLDivElement, scrollElement: HTMLDivElement): void {
-    const { scrollTop, scrollHeight, offsetHeight } = scrollElement
-
-    if (scrollTop === 0) {
-        parentElement.classList.remove(styles.rootWithTopFader)
-    } else {
-        parentElement.classList.add(styles.rootWithTopFader)
-    }
-
-    if (offsetHeight + scrollTop === scrollHeight) {
-        parentElement.classList.remove(styles.rootWithBottomFader)
-    } else {
-        parentElement.classList.add(styles.rootWithBottomFader)
-    }
-}
-
-function hasElementScroll(target: HTMLElement): boolean {
-    target.style.overflow = 'scroll'
-
-    const hasScroll = isFirefox()
-        ? // For some reason in Firefox it's possible to get a wrong scrollHeight with 1% ~ 1px
-          // static error. To avoid this "fake" scroll we take into calculation a static error
-          // value which equals to 1% of scrollable container height.
-          target.scrollHeight > Math.round(target.clientHeight + target.clientHeight / 100)
-        : target.scrollHeight > target.clientHeight
-
-    target.style.overflow = ''
-
-    return hasScroll
-}
 
 interface ScrollBoxProps extends HTMLAttributes<HTMLDivElement> {
     className?: string
@@ -47,62 +13,19 @@ interface ScrollBoxProps extends HTMLAttributes<HTMLDivElement> {
 export const ScrollBox: FunctionComponent<ScrollBoxProps> = props => {
     const { children, className, ...otherProps } = props
 
-    const [parentElement, setParentElement] = useState<HTMLDivElement | null>()
-    const [hasScroll, setHasScroll] = useState(false)
+    const scrollRef = useRef<HTMLDivElement>(null)
+    const obscuredArea = useElementObscuredArea(scrollRef)
 
-    useEffect(() => {
-        if (!parentElement) {
-            return
-        }
-
-        function onScroll(event: Event): void {
-            if (!event.target || !parentElement) {
-                return
-            }
-
-            addShutterElementsToTarget(parentElement, event.target as HTMLDivElement)
-
-            event.stopPropagation()
-            event.preventDefault()
-        }
-
-        parentElement.addEventListener('scroll', onScroll)
-
-        const resizeSubscription = observeResize(parentElement).subscribe(entry => {
-            if (!entry) {
-                return
-            }
-
-            const target = entry.target as HTMLElement
-
-            // Delay overflow content measurements while browser renders
-            // parent content
-            requestAnimationFrame(() => {
-                setHasScroll(hasElementScroll(target))
-                addShutterElementsToTarget(parentElement, parentElement)
-            })
-        })
-
-        return () => {
-            parentElement.removeEventListener('scroll', onScroll)
-            resizeSubscription.unsubscribe()
-        }
-    }, [parentElement])
+    const shutterClasses = [
+        obscuredArea.top > 0 ? styles.rootWithTopFader : undefined,
+        obscuredArea.bottom > 0 ? styles.rootWithBottomFader : undefined,
+    ]
 
     return (
-        <div
-            {...otherProps}
-            ref={setParentElement}
-            className={classNames(styles.root, className, { [styles.rootWithScroll]: hasScroll })}
-        >
-            {hasScroll && (
-                <>
-                    <div className={classNames(styles.fader, styles.faderTop)} />
-                    <div className={classNames(styles.fader, styles.faderBottom)} />
-                </>
-            )}
-
-            {children}
+        <div {...otherProps} className={classNames(styles.root, className, ...shutterClasses)}>
+            <div ref={scrollRef} className={styles.scrollContainer}>
+                {children}
+            </div>
         </div>
     )
 }

--- a/client/wildcard/src/hooks/useElementObscuredArea.ts
+++ b/client/wildcard/src/hooks/useElementObscuredArea.ts
@@ -3,8 +3,10 @@ import React from 'react'
 import { throttle } from 'lodash'
 
 interface ElementObscuredArea {
-    left: number
+    top: number
     right: number
+    bottom: number
+    left: number
 }
 
 const SCROLL_THROTTLE_WAIT = 50
@@ -16,8 +18,10 @@ export function useElementObscuredArea<T extends HTMLElement>(
     elementReference: React.MutableRefObject<T | null>
 ): ElementObscuredArea {
     const [obscured, setObscured] = React.useState<ElementObscuredArea>({
-        left: 0,
+        top: 0,
         right: 0,
+        bottom: 0,
+        left: 0,
     })
 
     const calculate = React.useMemo(
@@ -27,8 +31,10 @@ export function useElementObscuredArea<T extends HTMLElement>(
                     const element = elementReference?.current
                     if (element) {
                         setObscured({
-                            left: element.scrollLeft,
+                            top: element.scrollTop,
                             right: element.scrollWidth - element.clientWidth - element.scrollLeft,
+                            bottom: element.scrollHeight - element.clientHeight - element.scrollTop,
+                            left: element.scrollLeft,
                         })
                     }
                 },


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/39139

## Test plan
- Check that `ScrollBox` UI in the storybook works properly (shutters appear and hide based on scroll position) 
- Check that `ScrollBox` works properly on the dashboard page insight card (aside legend block for insights that have more than 3 series)
- Check both scenarios in Chrome and Safari (since we had problems with Chrome and Safari before)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
