### PR TITLE
Line Chart: Paper cut fixes voice over problems in Safari

### DIFF
--- a/client/wildcard/src/components/Charts/components/line-chart/components/LineDataSeries.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/components/LineDataSeries.tsx
@@ -56,6 +56,7 @@ export function LineDataSeries<D>(props: LineDataSeriesProps<D>): ReactElement {
                 stroke={color}
                 strokeLinecap="round"
                 strokeWidth={2}
+                aria-hidden={true}
             />
 
             <Group role="list">

--- a/client/wildcard/src/components/Charts/components/line-chart/components/PointGlyph.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/components/PointGlyph.tsx
@@ -52,6 +52,7 @@ export const PointGlyph: FC<PointGlyphProps> = props => {
                 fill="var(--body-bg)"
                 stroke={color}
                 strokeWidth={active ? 3 : 2}
+                aria-hidden={true}
                 onFocus={onFocus}
                 onBlur={onBlur}
             />

--- a/client/wildcard/src/components/Charts/core/components/axis/Axis.tsx
+++ b/client/wildcard/src/components/Charts/core/components/axis/Axis.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, memo } from 'react'
+import { forwardRef, memo, useEffect } from 'react'
 
 import {
     AxisLeft as VisxAxisLeft,
@@ -9,6 +9,7 @@ import {
 } from '@visx/axis'
 import { GridRows } from '@visx/grid'
 import { Group } from '@visx/group'
+import { useMergeRefs } from 'use-callback-ref'
 
 import { Tick } from './Tick'
 import { formatYTick, getXScaleTicks, getYScaleTicks } from './tick-formatters'
@@ -92,9 +93,20 @@ export interface AxisBottomProps extends OwnSharedAxisProps {
 export const AxisBottom = memo(
     forwardRef<SVGGElement, AxisBottomProps>((props, reference) => {
         const { scale, top, left, width, tickValues, tickComponent = Tick, ...attributes } = props
+        const mergedRef = useMergeRefs([reference])
+
+        // Visx axis UI doesn't expose API to set attributes to axis line element
+        // We need to hide axis line element in Safari from screen reader to avoid
+        // extra "image" element announcement since this element is 100% decorative
+        useEffect(() => {
+            const axisGroup = mergedRef.current
+            const axisLineElement = axisGroup?.querySelector(`.${styles.axisLine}`)
+
+            axisLineElement?.setAttribute('aria-hidden', 'true')
+        }, [mergedRef])
 
         return (
-            <Group innerRef={reference} top={top} left={left} width={width} role="list" aria-label="X axis">
+            <Group innerRef={mergedRef} top={top} left={left} width={width} role="list" aria-label="X axis">
                 <VisxAsixBottom
                     {...attributes}
                     scale={scale}

--- a/client/wildcard/src/components/Charts/core/components/tooltip/Tooltip.tsx
+++ b/client/wildcard/src/components/Charts/core/components/tooltip/Tooltip.tsx
@@ -67,6 +67,9 @@ export const Tooltip: React.FunctionComponent<React.PropsWithChildren<TooltipPro
             targetPadding={TOOLTIP_PADDING}
             position={Position.rightStart}
             className={styles.tooltip}
+            // Hide Tooltip UI from screen reader otherwise Voice over in Safari will
+            // catch this element and interrupt the original chart screen reader navigation flow
+            aria-hidden={true}
             tabIndex={-1}
         >
             {children}


### PR DESCRIPTION
## Problem 

At the moment on the main line chart doesn't work really well with Voice Over in Safari. See the before demo, (axis line is announced but shouldn't be, voice over navigation just gets stuck on the series data points)

| Before | After | 
| ------- | ------- |
| <video src="https://user-images.githubusercontent.com/18492575/202928076-9aaf8224-2149-4bb6-bc16-ba3e6652ad4e.mp4" /> | <video src="https://user-images.githubusercontent.com/18492575/202928079-254a6f7e-0124-473b-a521-41ec37cf62cc.mp4" /> |


## Test plan
- Check line chart (or any code insight card) with turned on voice over in Safari.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-vo-safari-charts.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
