### PR TITLE
Code Insights [Forms]: Simplify error handling for use form submit handlers

### DIFF
--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
@@ -3,17 +3,15 @@ import React, { useContext, useMemo } from 'react'
 import classNames from 'classnames'
 import { useHistory } from 'react-router-dom'
 
-import { asError } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, Container, Button, LoadingSpinner, useObservable, Link, Tooltip } from '@sourcegraph/wildcard'
 
 import { LoaderButton } from '../../../../../components/LoaderButton'
 import { PageTitle } from '../../../../../components/PageTitle'
-import { CodeInsightsIcon } from '../../../components'
-import { CodeInsightsPage } from '../../../components/code-insights-page/CodeInsightsPage'
-import { FORM_ERROR, SubmissionErrors } from '../../../components/form/hooks/useForm'
+import { CodeInsightsIcon, CodeInsightsPage } from '../../../components'
+import {} from '../../../components/code-insights-page/CodeInsightsPage'
 import { CodeInsightsBackendContext } from '../../../core'
-import { useUiFeatures } from '../../../hooks/use-ui-features'
+import { useUiFeatures } from '../../../hooks'
 
 import {
     DashboardCreationFields,
@@ -35,25 +33,19 @@ export const InsightsDashboardCreationPage: React.FunctionComponent<
 
     const owners = useObservable(useMemo(() => getDashboardOwners(), [getDashboardOwners]))
 
-    const handleSubmit = async (values: DashboardCreationFields): Promise<SubmissionErrors> => {
-        try {
-            const { name, owner } = values
+    const handleSubmit = async (values: DashboardCreationFields): Promise<void> => {
+        const { name, owner } = values
 
-            if (!owner) {
-                throw new Error('You have to specify a dashboard visibility')
-            }
-
-            const createdDashboard = await createDashboard({ name, owners: [owner] }).toPromise()
-
-            telemetryService.log('CodeInsightsDashboardCreationPageSubmitClick')
-
-            // Navigate user to the dashboard page with new created dashboard
-            history.push(`/insights/dashboards/${createdDashboard.id}`)
-        } catch (error) {
-            return { [FORM_ERROR]: asError(error) }
+        if (!owner) {
+            throw new Error('You have to specify a dashboard visibility')
         }
 
-        return
+        const createdDashboard = await createDashboard({ name, owners: [owner] }).toPromise()
+
+        telemetryService.log('CodeInsightsDashboardCreationPageSubmitClick')
+
+        // Navigate user to the dashboard page with new created dashboard
+        history.push(`/insights/dashboards/${createdDashboard.id}`)
     }
 
     const handleCancel = (): void => history.goBack()

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/components/add-insight-modal/AddInsightModal.tsx
@@ -5,7 +5,7 @@ import { mdiClose } from '@mdi/js'
 import { VisuallyHidden } from '@reach/visually-hidden'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
-import { asError, isDefined } from '@sourcegraph/common'
+import { isDefined } from '@sourcegraph/common'
 import { Button, Modal, H2, Icon, LoadingSpinner } from '@sourcegraph/wildcard'
 
 import {
@@ -13,7 +13,7 @@ import {
     GetDashboardAccessibleInsightsResult,
     GetDashboardAccessibleInsightsVariables,
 } from '../../../../../../../graphql-operations'
-import { FORM_ERROR, SubmissionErrors } from '../../../../../components'
+import { SubmissionErrors } from '../../../../../components'
 import { CodeInsightsBackendContext, CustomInsightDashboard } from '../../../../../core'
 
 import {
@@ -53,19 +53,15 @@ export const AddInsightModal: FC<AddInsightModalProps> = props => {
     )
 
     const handleSubmit = async (values: AddInsightFormValues): Promise<void | SubmissionErrors> => {
-        try {
-            const { insightIds } = values
+        const { insightIds } = values
 
-            await assignInsightsToDashboard({
-                id: dashboard.id,
-                prevInsightIds: dashboardInsightIds,
-                nextInsightIds: insightIds,
-            }).toPromise()
+        await assignInsightsToDashboard({
+            id: dashboard.id,
+            prevInsightIds: dashboardInsightIds,
+            nextInsightIds: insightIds,
+        }).toPromise()
 
-            onClose()
-        } catch (error) {
-            return { [FORM_ERROR]: asError(error) }
-        }
+        onClose()
     }
 
     return (

--- a/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
@@ -4,16 +4,13 @@ import classNames from 'classnames'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import { useHistory } from 'react-router'
 
-import { asError } from '@sourcegraph/common'
 import { Badge, Button, Container, LoadingSpinner, PageHeader, useObservable, Link } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../../../auth'
 import { HeroPage } from '../../../../../components/HeroPage'
 import { LoaderButton } from '../../../../../components/LoaderButton'
 import { PageTitle } from '../../../../../components/PageTitle'
-import { CodeInsightsIcon } from '../../../components'
-import { CodeInsightsPage } from '../../../components/code-insights-page/CodeInsightsPage'
-import { FORM_ERROR, SubmissionErrors } from '../../../components/form/hooks/useForm'
+import { CodeInsightsIcon, CodeInsightsPage, SubmissionErrors } from '../../../components'
 import {
     CodeInsightsBackendContext,
     CustomInsightDashboard,
@@ -83,22 +80,17 @@ export const EditDashboardPage: React.FunctionComponent<React.PropsWithChildren<
             throw new Error('You have to specify a dashboard visibility')
         }
 
-        try {
-            const updatedDashboard = await updateDashboard({
-                id: dashboard.id,
-                nextDashboardInput: {
-                    name,
-                    owners: [owner],
-                },
-            }).toPromise()
+        const updatedDashboard = await updateDashboard({
+            id: dashboard.id,
+            nextDashboardInput: {
+                name,
+                owners: [owner],
+            },
+        }).toPromise()
 
-            history.push(`/insights/dashboards/${updatedDashboard.id}`)
-        } catch (error) {
-            return { [FORM_ERROR]: asError(error) }
-        }
-
-        return
+        history.push(`/insights/dashboards/${updatedDashboard.id}`)
     }
+
     const handleCancel = (): void => history.goBack()
 
     return (

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/CaptureGroupCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/CaptureGroupCreationPage.tsx
@@ -1,6 +1,5 @@
 import { FC, useEffect, useMemo } from 'react'
 
-import { asError } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, PageHeader, useObservable } from '@sourcegraph/wildcard'
 
@@ -44,11 +43,7 @@ export const CaptureGroupCreationPage: FC<CaptureGroupCreationPageProps> = props
     const handleSubmit = async (values: CaptureGroupFormFields): Promise<SubmissionErrors | void> => {
         const insight = getSanitizedCaptureGroupInsight(values)
 
-        try {
-            await onInsightCreateRequest({ insight })
-        } catch (error) {
-            return { [FORM_ERROR]: asError(error) }
-        }
+        await onInsightCreateRequest({ insight })
 
         setInitialFormValues(undefined)
         telemetryService.log('CodeInsightsCaptureGroupCreationPageSubmitClick')

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/ComputeInsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/ComputeInsightCreationPage.tsx
@@ -2,7 +2,6 @@ import { FunctionComponent, useCallback, useMemo } from 'react'
 
 import BarChartIcon from 'mdi-react/BarChartIcon'
 
-import { asError } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, PageHeader, Text, useLocalStorage, useObservable } from '@sourcegraph/wildcard'
 
@@ -54,26 +53,20 @@ export const ComputeInsightCreationPage: FunctionComponent<ComputeInsightCreatio
 
     const handleSubmit = useCallback(
         async (values: CreateComputeInsightFormFields): Promise<SubmissionErrors> => {
-            try {
-                const insight = getSanitizedComputeInsight(values)
+            const insight = getSanitizedComputeInsight(values)
 
-                await onInsightCreateRequest({ insight })
+            await onInsightCreateRequest({ insight })
 
-                // Clear initial values if user successfully created search insight
-                setInitialFormValues(undefined)
-                telemetryService.log('CodeInsightsComputeCreationPageSubmitClick')
-                telemetryService.log(
-                    'InsightAddition',
-                    { insightType: CodeInsightTrackType.ComputeInsight },
-                    { insightType: CodeInsightTrackType.ComputeInsight }
-                )
+            // Clear initial values if user successfully created search insight
+            setInitialFormValues(undefined)
+            telemetryService.log('CodeInsightsComputeCreationPageSubmitClick')
+            telemetryService.log(
+                'InsightAddition',
+                { insightType: CodeInsightTrackType.ComputeInsight },
+                { insightType: CodeInsightTrackType.ComputeInsight }
+            )
 
-                onSuccessfulCreation()
-            } catch (error) {
-                return { [FORM_ERROR]: asError(error) }
-            }
-
-            return
+            onSuccessfulCreation()
         },
         [onInsightCreateRequest, onSuccessfulCreation, setInitialFormValues, telemetryService]
     )

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
@@ -2,7 +2,6 @@ import { FC, useCallback, useEffect, useMemo } from 'react'
 
 import classNames from 'classnames'
 
-import { asError } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useLocalStorage, Link, PageHeader, useObservable } from '@sourcegraph/wildcard'
 
@@ -72,26 +71,20 @@ export const LangStatsInsightCreationPage: FC<LangStatsInsightCreationPageProps>
 
     const handleSubmit = useCallback<LangStatsInsightCreationContentProps['onSubmit']>(
         async values => {
-            try {
-                const insight = getSanitizedLangStatsInsight(values)
+            const insight = getSanitizedLangStatsInsight(values)
 
-                await onInsightCreateRequest({ insight })
+            await onInsightCreateRequest({ insight })
 
-                // Clear initial values if user successfully created search insight
-                setInitialFormValues(undefined)
-                telemetryService.log('CodeInsightsCodeStatsCreationPageSubmitClick')
-                telemetryService.log(
-                    'InsightAddition',
-                    { insightType: CodeInsightTrackType.LangStatsInsight },
-                    { insightType: CodeInsightTrackType.LangStatsInsight }
-                )
+            // Clear initial values if user successfully created search insight
+            setInitialFormValues(undefined)
+            telemetryService.log('CodeInsightsCodeStatsCreationPageSubmitClick')
+            telemetryService.log(
+                'InsightAddition',
+                { insightType: CodeInsightTrackType.LangStatsInsight },
+                { insightType: CodeInsightTrackType.LangStatsInsight }
+            )
 
-                onSuccessfulCreation()
-            } catch (error) {
-                return { [FORM_ERROR]: asError(error) }
-            }
-
-            return
+            onSuccessfulCreation()
         },
         [onInsightCreateRequest, onSuccessfulCreation, setInitialFormValues, telemetryService]
     )

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.tsx
@@ -1,6 +1,5 @@
 import { FC, useCallback, useEffect, useMemo } from 'react'
 
-import { asError } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, Link, PageHeader, useObservable } from '@sourcegraph/wildcard'
 
@@ -65,27 +64,21 @@ export const SearchInsightCreationPage: FC<SearchInsightCreationPageProps> = pro
 
     const handleSubmit = useCallback<SearchInsightCreationContentProps['onSubmit']>(
         async values => {
-            try {
-                const insight = getSanitizedSearchInsight(values)
+            const insight = getSanitizedSearchInsight(values)
 
-                await onInsightCreateRequest({ insight })
+            await onInsightCreateRequest({ insight })
 
-                telemetryService.log('CodeInsightsSearchBasedCreationPageSubmitClick')
-                telemetryService.log(
-                    'InsightAddition',
-                    { insightType: CodeInsightTrackType.SearchBasedInsight },
-                    { insightType: CodeInsightTrackType.SearchBasedInsight }
-                )
+            telemetryService.log('CodeInsightsSearchBasedCreationPageSubmitClick')
+            telemetryService.log(
+                'InsightAddition',
+                { insightType: CodeInsightTrackType.SearchBasedInsight },
+                { insightType: CodeInsightTrackType.SearchBasedInsight }
+            )
 
-                // Clear initial values if user successfully created search insight
-                setLocalStorageFormValues(undefined)
+            // Clear initial values if user successfully created search insight
+            setLocalStorageFormValues(undefined)
 
-                onSuccessfulCreation()
-            } catch (error) {
-                return { [FORM_ERROR]: asError(error) }
-            }
-
-            return
+            onSuccessfulCreation()
         },
         [onInsightCreateRequest, telemetryService, setLocalStorageFormValues, onSuccessfulCreation]
     )

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/hooks/use-edit-page-handlers.ts
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/hooks/use-edit-page-handlers.ts
@@ -2,10 +2,8 @@ import { useContext } from 'react'
 
 import { useHistory } from 'react-router-dom'
 
-import { asError } from '@sourcegraph/common'
-
 import { eventLogger } from '../../../../../../tracking/eventLogger'
-import { FORM_ERROR, SubmissionErrors } from '../../../../components'
+import { SubmissionErrors } from '../../../../components'
 import { ALL_INSIGHTS_DASHBOARD } from '../../../../constants'
 import { CodeInsightsBackendContext, CreationInsightInput } from '../../../../core'
 import { useQueryParameters } from '../../../../hooks'
@@ -32,22 +30,14 @@ export function useEditPageHandlers(props: { id: string | undefined }): useHandl
             return
         }
 
-        try {
-            await updateInsight({
-                insightId: id,
-                nextInsightData: newInsight,
-            }).toPromise()
+        await updateInsight({
+            insightId: id,
+            nextInsightData: newInsight,
+        }).toPromise()
 
-            const insightType = getTrackingTypeByInsightType(newInsight.type)
-
-            eventLogger.log('InsightEdit', { insightType }, { insightType })
-
-            history.push(redirectUrl)
-        } catch (error) {
-            return { [FORM_ERROR]: asError(error) }
-        }
-
-        return
+        const insightType = getTrackingTypeByInsightType(newInsight.type)
+        eventLogger.log('InsightEdit', { insightType }, { insightType })
+        history.push(redirectUrl)
     }
 
     const handleCancel = (): void => {

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -3,7 +3,6 @@ import React, { useContext, useState } from 'react'
 import classNames from 'classnames'
 import { useHistory } from 'react-router'
 
-import { asError } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Card, CardBody, useDebounce, useDeepMemo } from '@sourcegraph/wildcard'
@@ -15,14 +14,7 @@ import {
     SeriesDisplayOptionsInput,
 } from '../../../../../../../graphql-operations'
 import { useSeriesToggle } from '../../../../../../../insights/utils/use-series-toggle'
-import {
-    InsightCard,
-    InsightCardHeader,
-    InsightCardLoading,
-    FORM_ERROR,
-    FormChangeEvent,
-    SubmissionErrors,
-} from '../../../../../components'
+import { InsightCard, InsightCardHeader, InsightCardLoading, FormChangeEvent } from '../../../../../components'
 import {
     DrillDownInsightFilters,
     FilterSectionVisualMode,
@@ -118,39 +110,25 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
         }
     }
 
-    const handleFilterSave = async (filters: InsightFilters): Promise<SubmissionErrors> => {
-        try {
-            await updateInsight({ insightId: insight.id, nextInsightData: { ...insight, filters } }).toPromise()
-            setOriginalInsightFilters(filters)
-            telemetryService.log('CodeInsightsSearchBasedFilterUpdating')
-        } catch (error) {
-            return { [FORM_ERROR]: asError(error) }
-        }
-
-        return
+    const handleFilterSave = async (filters: InsightFilters): Promise<void> => {
+        await updateInsight({ insightId: insight.id, nextInsightData: { ...insight, filters } }).toPromise()
+        setOriginalInsightFilters(filters)
+        telemetryService.log('CodeInsightsSearchBasedFilterUpdating')
     }
 
-    const handleInsightFilterCreation = async (
-        values: DrillDownInsightCreationFormValues
-    ): Promise<SubmissionErrors> => {
-        try {
-            await createInsight({
-                insight: {
-                    ...insight,
-                    title: values.insightName,
-                    filters,
-                },
-                dashboard: null,
-            }).toPromise()
+    const handleInsightFilterCreation = async (values: DrillDownInsightCreationFormValues): Promise<void> => {
+        await createInsight({
+            insight: {
+                ...insight,
+                title: values.insightName,
+                filters,
+            },
+            dashboard: null,
+        }).toPromise()
 
-            setOriginalInsightFilters(filters)
-            history.push(`/insights/dashboard/${ALL_INSIGHTS_DASHBOARD.id}`)
-            telemetryService.log('CodeInsightsSearchBasedFilterInsightCreation')
-        } catch (error) {
-            return { [FORM_ERROR]: asError(error) }
-        }
-
-        return
+        setOriginalInsightFilters(filters)
+        history.push(`/insights/dashboard/${ALL_INSIGHTS_DASHBOARD.id}`)
+        telemetryService.log('CodeInsightsSearchBasedFilterInsightCreation')
     }
 
     return (


### PR DESCRIPTION
Prior to this PR we had to care about form submit error always on the consumer level. This PR simplifies error handling by providing default error handling on the hook `use-form` level.

## Test plan
- Ideally we need to check all places where we have async submit operations (create insight, edit insight, create/edit dashboard, delete/remove insights) but since most of them are tested via integration test you can check just some of them 
- Make sure that CI is passing 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-utilize-use-form-submit-errors.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
