### PR TITLE
Removing line explaining Apache 2 as not relevant on vs github page

### DIFF
--- a/doc/getting-started/github-vs-sourcegraph.md
+++ b/doc/getting-started/github-vs-sourcegraph.md
@@ -719,9 +719,6 @@ GitHub is closed source, while Sourcegraph’s code is publicly available.
 
 Sourcegraph offers two versions of its product: Sourcegraph OSS (just universal code search) and Sourcegraph Enterprise (full code intelligence platform). 
 
-Sourceraph OSS is Apache 2 licensed and allows any developer to use, modify, and redistribute.
-
-
 ## Availability
 
 GitHub code search is currently available through a beta preview (you can sign up for their [waitlist](https://github.com/features/code-search-code-view/signup) to request access). The beta preview is not yet available for GitHub Enterprise. 


### PR DESCRIPTION
Removing this line for the following reasons; 

- This line isn't relevant to the comparison and is a distraction to the next point, where users can now easily spin up a trial instance and test out the product. 

- Any developers who are interested in the license know where to find it and are aware of what Apache 2 means. 

# Test Plan
- Check links
- Check content displays correctly (eg spacing as I removed a paragraph) 
