### PR TITLE
searcher: use ranking in hybrid search

### DIFF
--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/search"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -142,6 +143,10 @@ func zoektSearchIgnorePaths(ctx context.Context, client zoekt.Streamer, p *proto
 	opts := (&zoektutil.Options{
 		NumRepos:       1,
 		FileMatchLimit: int32(p.Limit),
+		Features: search.Features{
+			Ranking:             true,
+			RankingDampDocRanks: true,
+		},
 	}).ToSearch(ctx)
 	if deadline, ok := ctx.Deadline(); ok {
 		opts.MaxWallTime = time.Until(deadline) - 100*time.Millisecond


### PR DESCRIPTION
This enables ranking when using hybrid search. This should already be used since hybrid is currently using the batch interface against zoekt. However, in another commit we will switch to the streaming interface.

Alternatively we can marshal the features struct over the RPC. If this sounds like a good idea I'll follow-up with another commit.

Test Plan: CI

Part of https://github.com/sourcegraph/sourcegraph/issues/37112