### PR TITLE
searcher: handle context errors in hybrid

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -14249,9 +14249,10 @@ Query: `sum by(instance) (rate(searcher_service_request_total[10m]))`
 This graph should be empty unless you enable the feature flag "search-hybrid".
 
 This graph should mostly be "success". The next most common state should be
-"diff-too-large", which happens if the commit is too far from the indexed
-commit. Otherwise other state should be rare and likely are a sign for further
-investigation.
+"search-canceled" which happens when result limits are hit or the user starts
+a new search. Finally the next most common should be "diff-too-large", which
+happens if the commit is too far from the indexed commit. Otherwise other
+state should be rare and likely are a sign for further investigation.
 
 Note: On sourcegraph.com "zoekt-list-missing" is also common due to it
 indexing a subset of repositories. Otherwise every other state should occur

--- a/monitoring/definitions/searcher.go
+++ b/monitoring/definitions/searcher.go
@@ -65,9 +65,10 @@ func Searcher() *monitoring.Dashboard {
 This graph should be empty unless you enable the feature flag "search-hybrid".
 
 This graph should mostly be "success". The next most common state should be
-"diff-too-large", which happens if the commit is too far from the indexed
-commit. Otherwise other state should be rare and likely are a sign for further
-investigation.
+"search-canceled" which happens when result limits are hit or the user starts
+a new search. Finally the next most common should be "diff-too-large", which
+happens if the commit is too far from the indexed commit. Otherwise other
+state should be rare and likely are a sign for further investigation.
 
 Note: On sourcegraph.com "zoekt-list-missing" is also common due to it
 indexing a subset of repositories. Otherwise every other state should occur


### PR DESCRIPTION
We have a fair number of errors in hybrid search, but they all seem to be context canceled. This happens because in the frontend we spin up many searcher requests (per repo) and then cancel the RPC once we hit a limit. Additionally searcher itself will cancel after we hit a limit.

Test Plan: CI and then will monitor graphs in production. I expect zoekt-search-error to go to zero always.

Part of https://github.com/sourcegraph/sourcegraph/issues/37112