### PR TITLE
Bump security events cleanup policy from 7 to 30 days.

### DIFF
--- a/cmd/frontend/internal/bg/delete_old_event_logs_in_postgres.go
+++ b/cmd/frontend/internal/bg/delete_old_event_logs_in_postgres.go
@@ -26,11 +26,11 @@ func DeleteOldEventLogsInPostgres(ctx context.Context, db database.DB) {
 
 func DeleteOldSecurityEventLogsInPostgres(ctx context.Context, db database.DB) {
 	for {
-		// We choose 7 days as the interval to ensure that we have at least the last week's worth of
+		// We choose 30 days as the interval to ensure that we have at least the last month's worth of
 		// logs at all times.
 		_, err := db.ExecContext(
 			ctx,
-			`DELETE FROM security_event_logs WHERE "timestamp" < now() - interval '7' day`,
+			`DELETE FROM security_event_logs WHERE "timestamp" < now() - interval '30' day`,
 		)
 		if err != nil {
 			log15.Error("deleting expired rows from security_event_logs table", "error", err)


### PR DESCRIPTION
## Description

`security_event_logs` table is auto-cleaned regularly. We're bumping this interval **from 7 to 30 days**.

### Historical context

This period has been [notably shortened](https://github.com/sourcegraph/sourcegraph/pull/25159/files) as a part of the design for the multi-tenant cloud. We assumed that the table would need to hold data for many customers at once, which isn't a necessary limitation for the single-tenant design anymore.

### Reasoning

No external system or actor has been periodically reading data from the table until we introduced the audit logs recently. The only known case was admins querying the table manually. Since the security event logs are now an essential part of the audit logs, it makes sense to bump this period to give our customers a more meaningful minimal audit period.

### Related data

**S2**
```
pgsql=> SELECT count(*) FROM security_event_logs;
 count  
--------
 329238
(1 row)

pgsql=> SELECT pg_size_pretty( pg_total_relation_size('security_event_logs') );
 pg_size_pretty 
----------------
 525 MB
(1 row)
```

**Large Cloud instance**
```
pgsql=> SELECT count(*) FROM security_event_logs;
  count  
---------
 3927526
(1 row)

pgsql=> SELECT pg_size_pretty( pg_total_relation_size('security_event_logs') );
 pg_size_pretty 
----------------
 1728 MB
(1 row)
```

**Largest Cloud instance**
```
pgsql=> SELECT count(*) FROM security_event_logs;
  count  
---------
 9738677
(1 row)

pgsql=> SELECT pg_size_pretty( pg_total_relation_size('security_event_logs') );
 pg_size_pretty 
----------------
 9794 MB
(1 row)
```

## Test plan

- manual research to verify that this policy makes sense
