### PR TITLE
web: rename `Webhook receivers` to `Incoming webhooks`.

### DIFF
--- a/client/web/src/site-admin/SiteAdminWebhookPage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookPage.story.tsx
@@ -121,7 +121,7 @@ export const SiteAdminWebhookPageStory: Story = args => {
     )
 }
 
-SiteAdminWebhookPageStory.storyName = 'Webhook receiver'
+SiteAdminWebhookPageStory.storyName = 'Incoming webhook'
 SiteAdminWebhookPageStory.args = {
     match: {
         params: {

--- a/client/web/src/site-admin/SiteAdminWebhookPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookPage.tsx
@@ -46,13 +46,13 @@ export const SiteAdminWebhookPage: FC<WebhookPageProps> = props => {
 
     return (
         <Container>
-            <PageTitle title="Webhook receiver" />
+            <PageTitle title="Incoming webhook" />
             {webhookLoading && !webhookData && <ConnectionLoading />}
             {webhookData?.node && webhookData.node.__typename === 'Webhook' && (
                 <PageHeader
                     path={[
                         { icon: mdiCog },
-                        { to: '/site-admin/webhooks', text: 'Webhook receivers' },
+                        { to: '/site-admin/webhooks', text: 'Incoming webhooks' },
                         { text: webhookData.node.codeHostURN },
                     ]}
                     byline={

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
@@ -37,11 +37,11 @@ export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChild
     const { loading, hasNextPage, fetchMore, connection, error } = useWebhooksConnection()
     return (
         <div className="site-admin-webhooks-page">
-            <PageTitle title="Webhook receivers" />
+            <PageTitle title="Incoming webhooks" />
             <PageHeader
-                path={[{ icon: mdiCog }, { to: '/site-admin/webhooks', text: 'Webhook receivers' }]}
+                path={[{ icon: mdiCog }, { to: '/site-admin/webhooks', text: 'Incoming webhooks' }]}
                 headingElement="h2"
-                description="All configured webhooks receivers"
+                description="All configured incoming webhooks"
                 className="mb-3"
                 actions={
                     <ButtonLink className="test-create-webhook" variant="primary">
@@ -92,7 +92,7 @@ export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChild
 
 const Header: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
     <div className={styles.webhooksGrid}>
-        <H5 className="p-2 d-none d-md-block text-uppercase text-left text-nowrap">Receiver</H5>
+        <H5 className="p-2 d-none d-md-block text-uppercase text-left text-nowrap">Webhook</H5>
         <H5 className="d-none d-md-block text-uppercase text-center text-nowrap">Actions</H5>
     </div>
 )


### PR DESCRIPTION
Test plan:
Not a functional change, visual tests.

## App preview:

- [Web](https://sg-web-ao-ui-webhooks-rename-webhooks.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
