### PR TITLE
Add settings history.defaultPageSize

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarCommits.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarCommits.tsx
@@ -63,6 +63,7 @@ interface Props extends Partial<RevisionSpec>, FileSpec {
     history: H.History
     location: H.Location
     preferAbsoluteTimestamps: boolean
+    defaultPageSize: number
 }
 
 export const RepoRevisionSidebarCommits: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
@@ -88,7 +89,7 @@ export const RepoRevisionSidebarCommits: React.FunctionComponent<React.PropsWith
             queryConnection={queryCommits}
             nodeComponent={CommitNode}
             nodeComponentProps={{ location: props.location, preferAbsoluteTimestamps: props.preferAbsoluteTimestamps }}
-            defaultFirst={100}
+            defaultFirst={props.defaultPageSize}
             hideSearch={true}
             useURLQuery={false}
             history={props.history}

--- a/client/web/src/repo/RepoRevisionSidebarCommits.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarCommits.tsx
@@ -63,7 +63,7 @@ interface Props extends Partial<RevisionSpec>, FileSpec {
     history: H.History
     location: H.Location
     preferAbsoluteTimestamps: boolean
-    defaultPageSize: number
+    defaultPageSize?: number
 }
 
 export const RepoRevisionSidebarCommits: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
@@ -89,7 +89,7 @@ export const RepoRevisionSidebarCommits: React.FunctionComponent<React.PropsWith
             queryConnection={queryCommits}
             nodeComponent={CommitNode}
             nodeComponentProps={{ location: props.location, preferAbsoluteTimestamps: props.preferAbsoluteTimestamps }}
-            defaultFirst={props.defaultPageSize}
+            defaultFirst={props.defaultPageSize || 100}
             hideSearch={true}
             useURLQuery={false}
             history={props.history}

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -309,6 +309,8 @@ function defaultPageSizeFromSettings(settingsCascade: SettingsCascadeOrError<Set
     if (settingsCascade.final && !isErrorLike(settingsCascade.final)) {
         return settingsCascade.final['history.defaultPageSize'] as number
     }
+
+    return undefined
 }
 
 /**

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -305,12 +305,10 @@ function preferAbsoluteTimestampsFromSettings(settingsCascade: SettingsCascadeOr
     return false
 }
 
-function defaultPageSizeFromSettings(settingsCascade: SettingsCascadeOrError<Settings>): number {
+function defaultPageSizeFromSettings(settingsCascade: SettingsCascadeOrError<Settings>): number | undefined {
     if (settingsCascade.final && !isErrorLike(settingsCascade.final)) {
-        return settingsCascade.final['history.defautlPageSize'] as number
+        return settingsCascade.final['history.defaultPageSize'] as number
     }
-
-    return 100
 }
 
 /**

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -103,6 +103,7 @@ function useBlobPanelViews({
 
     const maxPanelResults = maxPanelResultsFromSettings(settingsCascade)
     const preferAbsoluteTimestamps = preferAbsoluteTimestampsFromSettings(settingsCascade)
+    const defaultPageSize = defaultPageSizeFromSettings(settingsCascade)
     const isTabbedReferencesPanelEnabled =
         !isErrorLike(settingsCascade.final) &&
         settingsCascade.final !== null &&
@@ -192,6 +193,7 @@ function useBlobPanelViews({
                                     history={history}
                                     location={location}
                                     preferAbsoluteTimestamps={preferAbsoluteTimestamps}
+                                    defaultPageSize={defaultPageSize}
                                 />
                             ),
                         }))
@@ -275,6 +277,7 @@ function useBlobPanelViews({
             isTabbedReferencesPanelEnabled,
             extensionsController,
             preferAbsoluteTimestamps,
+            defaultPageSize,
             createLocationProvider,
             settingsCascade,
             platformContext,
@@ -300,6 +303,14 @@ function preferAbsoluteTimestampsFromSettings(settingsCascade: SettingsCascadeOr
         return settingsCascade.final['history.preferAbsoluteTimestamps'] as boolean
     }
     return false
+}
+
+function defaultPageSizeFromSettings(settingsCascade: SettingsCascadeOrError<Settings>): number {
+    if (settingsCascade.final && !isErrorLike(settingsCascade.final)) {
+        return settingsCascade.final['history.defautlPageSize'] as number
+    }
+
+    return 100
 }
 
 /**

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1787,6 +1787,8 @@ type Settings struct {
 	ExtensionsActiveLoggers []string `json:"extensions.activeLoggers,omitempty"`
 	// FileSidebarVisibleByDefault description: Whether the sidebar on the repo view should be open by default.
 	FileSidebarVisibleByDefault bool `json:"fileSidebarVisibleByDefault,omitempty"`
+	// HistoryDefaultPageSize description: Custom page size for the history tab. If set, the history tab will populate that number of commits at a time. If not set, it will populate 100 commits at a time.
+	HistoryDefaultPageSize int `json:"history.defaultPageSize,omitempty"`
 	// HistoryPreferAbsoluteTimestamps description: Show absolute timestamps in the history panel and only show relative timestamps (e.g.: "5 days ago") in tooltip when hovering.
 	HistoryPreferAbsoluteTimestamps bool `json:"history.preferAbsoluteTimestamps,omitempty"`
 	// Insights description: EXPERIMENTAL: Code Insights

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1787,7 +1787,7 @@ type Settings struct {
 	ExtensionsActiveLoggers []string `json:"extensions.activeLoggers,omitempty"`
 	// FileSidebarVisibleByDefault description: Whether the sidebar on the repo view should be open by default.
 	FileSidebarVisibleByDefault bool `json:"fileSidebarVisibleByDefault,omitempty"`
-	// HistoryDefaultPageSize description: Custom page size for the history tab. If set, the history tab will populate that number of commits at a time. If not set, it will populate 100 commits at a time.
+	// HistoryDefaultPageSize description: Custom page size for the history tab. If set, the history tab will populate that number of commits the first time the history tab is opened and then double the number of commits progressively.
 	HistoryDefaultPageSize int `json:"history.defaultPageSize,omitempty"`
 	// HistoryPreferAbsoluteTimestamps description: Show absolute timestamps in the history panel and only show relative timestamps (e.g.: "5 days ago") in tooltip when hovering.
 	HistoryPreferAbsoluteTimestamps bool `json:"history.preferAbsoluteTimestamps,omitempty"`

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -736,6 +736,12 @@
       "type": "boolean",
       "default": false
     },
+    "history.defaultPageSize": {
+      "description": "Custom page size for the history tab. If set, the history tab will populate that number of commits at a time. If not set, it will populate 100 commits at a time.",
+      "type": "integer",
+      "default": 100,
+      "minimum": 1
+    },
     "notices": {
       "description": "Custom informational messages to display to users at specific locations in the Sourcegraph user interface.\n\nUsually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that single user.",
       "type": "array",

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -737,9 +737,8 @@
       "default": false
     },
     "history.defaultPageSize": {
-      "description": "Custom page size for the history tab. If set, the history tab will populate that number of commits at a time. If not set, it will populate 100 commits at a time.",
+      "description": "Custom page size for the history tab. If set, the history tab will populate that number of commits the first time the history tab is opened and then double the number of commits progressively.",
       "type": "integer",
-      "default": 100,
       "minimum": 1
     },
     "notices": {


### PR DESCRIPTION
Fixed #44431.

https://user-images.githubusercontent.com/2682729/203026948-93dd8be7-b1ca-4172-834a-164fa3f1f62d.mp4

**Note about returning 2x the responses on clicking the `Show more` button:**

- This is the existing behaviour and unchanged
- Initially we load say 5 commits
- Next time it fetched 10 commits, so visually it looks like 5 commits were fetched (the API doesn't support pagination yet)
- Then it fetches 20 commits which is why visually it looks like 10 new commits were fetched and thus the doubling of the commits from this point on


## Test plan

Tested functionality locally.
Builds (should) pass.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
