### PR TITLE
Have sourcegraph-operator use its own callback endpoint

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/openidconnect/config.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/config.go
@@ -32,6 +32,7 @@ func GetProvider(id string) *Provider {
 		},
 	).(*Provider)
 	if ok {
+		p.callbackUrl = ".auth/callback"
 		return p
 	}
 	return nil
@@ -66,7 +67,6 @@ func Init() {
 	logger := log.Scoped(pkgName, "OpenID Connect config watch")
 	go func() {
 		conf.Watch(func() {
-
 			ps := getProviders()
 			if len(ps) == 0 {
 				providers.Update(pkgName, nil)
@@ -101,7 +101,7 @@ func getProviders() []providers.Provider {
 	}
 	ps := make([]providers.Provider, 0, len(cfgs))
 	for _, cfg := range cfgs {
-		ps = append(ps, NewProvider(*cfg, authPrefix))
+		ps = append(ps, NewProvider(*cfg, authPrefix, ".auth/callback"))
 	}
 	return ps
 }

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/config.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/config.go
@@ -6,9 +6,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"path"
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -32,7 +34,7 @@ func GetProvider(id string) *Provider {
 		},
 	).(*Provider)
 	if ok {
-		p.callbackUrl = ".auth/callback"
+		p.callbackUrl = path.Join(auth.AuthURLPrefix, "callback")
 		return p
 	}
 	return nil

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/config.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/config.go
@@ -103,7 +103,7 @@ func getProviders() []providers.Provider {
 	}
 	ps := make([]providers.Provider, 0, len(cfgs))
 	for _, cfg := range cfgs {
-		ps = append(ps, NewProvider(*cfg, authPrefix, ".auth/callback"))
+		ps = append(ps, NewProvider(*cfg, authPrefix, path.Join(auth.AuthURLPrefix, "callback")))
 	}
 	return ps
 }

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
-	"path"
 	"strings"
 	"time"
 
@@ -260,7 +258,7 @@ func AuthCallback(db database.DB, r *http.Request, stateCookieName, usernamePref
 	}
 
 	// Exchange the code for an access token, see http://openid.net/specs/openid-connect-core-1_0.html#TokenRequest.
-	oauth2Token, err := p.Oauth2Config(&url.URL{Path: p.callbackUrl}).Exchange(r.Context(), r.URL.Query().Get("code"))
+	oauth2Token, err := p.Oauth2Config().Exchange(r.Context(), r.URL.Query().Get("code"))
 	if err != nil {
 		return nil,
 			"Authentication failed. Try signing in again. The error was: unable to obtain access token from issuer.",
@@ -410,5 +408,5 @@ func RedirectToAuthRequest(w http.ResponseWriter, r *http.Request, p *Provider, 
 	//
 	// See http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest of the
 	// OIDC spec.
-	http.Redirect(w, r, p.Oauth2Config(&url.URL{Path: path.Join(auth.AuthURLPrefix, "callback")}).AuthCodeURL(state, oidc.Nonce(state)), http.StatusFound)
+	http.Redirect(w, r, p.Oauth2Config().AuthCodeURL(state, oidc.Nonce(state)), http.StatusFound)
 }

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -258,7 +258,7 @@ func AuthCallback(db database.DB, r *http.Request, stateCookieName, usernamePref
 	}
 
 	// Exchange the code for an access token, see http://openid.net/specs/openid-connect-core-1_0.html#TokenRequest.
-	oauth2Token, err := p.Oauth2Config().Exchange(r.Context(), r.URL.Query().Get("code"))
+	oauth2Token, err := p.oauth2Config().Exchange(r.Context(), r.URL.Query().Get("code"))
 	if err != nil {
 		return nil,
 			"Authentication failed. Try signing in again. The error was: unable to obtain access token from issuer.",
@@ -408,5 +408,5 @@ func RedirectToAuthRequest(w http.ResponseWriter, r *http.Request, p *Provider, 
 	//
 	// See http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest of the
 	// OIDC spec.
-	http.Redirect(w, r, p.Oauth2Config().AuthCodeURL(state, oidc.Nonce(state)), http.StatusFound)
+	http.Redirect(w, r, p.oauth2Config().AuthCodeURL(state, oidc.Nonce(state)), http.StatusFound)
 }

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"path"
 	"strings"
 	"time"
 
@@ -258,7 +260,7 @@ func AuthCallback(db database.DB, r *http.Request, stateCookieName, usernamePref
 	}
 
 	// Exchange the code for an access token, see http://openid.net/specs/openid-connect-core-1_0.html#TokenRequest.
-	oauth2Token, err := p.oauth2Config().Exchange(r.Context(), r.URL.Query().Get("code"))
+	oauth2Token, err := p.Oauth2Config(&url.URL{Path: p.callbackUrl}).Exchange(r.Context(), r.URL.Query().Get("code"))
 	if err != nil {
 		return nil,
 			"Authentication failed. Try signing in again. The error was: unable to obtain access token from issuer.",
@@ -408,5 +410,5 @@ func RedirectToAuthRequest(w http.ResponseWriter, r *http.Request, p *Provider, 
 	//
 	// See http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest of the
 	// OIDC spec.
-	http.Redirect(w, r, p.oauth2Config().AuthCodeURL(state, oidc.Nonce(state)), http.StatusFound)
+	http.Redirect(w, r, p.Oauth2Config(&url.URL{Path: path.Join(auth.AuthURLPrefix, "callback")}).AuthCodeURL(state, oidc.Nonce(state)), http.StatusFound)
 }

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/middleware_test.go
@@ -127,6 +127,7 @@ func TestMiddleware(t *testing.T) {
 			RequireEmailDomain: "example.com",
 			Type:               providerType,
 		},
+		callbackUrl: ".auth/callback",
 	}
 	defer func() { mockGetProviderValue = nil }()
 	providers.MockProviders = []providers.Provider{mockGetProviderValue}
@@ -320,6 +321,7 @@ func TestMiddleware_NoOpenRedirect(t *testing.T) {
 			ClientSecret: "aaaaaaaaaaaaaaaaaaaaaaaaa",
 			Type:         providerType,
 		},
+		callbackUrl: ".auth/callback",
 	}
 	defer func() { mockGetProviderValue = nil }()
 	providers.MockProviders = []providers.Provider{mockGetProviderValue}

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/provider.go
@@ -113,8 +113,8 @@ func (p *Provider) CachedInfo() *providers.Info {
 	return info
 }
 
-// Oauth2Config constructs and returns an *oauth2.Config from the provider.
-func (p *Provider) Oauth2Config() *oauth2.Config {
+// oauth2Config constructs and returns an *oauth2.Config from the provider.
+func (p *Provider) oauth2Config() *oauth2.Config {
 	return &oauth2.Config{
 		ClientID:     p.config.ClientID,
 		ClientSecret: p.config.ClientSecret,

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/provider.go
@@ -114,7 +114,7 @@ func (p *Provider) CachedInfo() *providers.Info {
 }
 
 // Oauth2Config constructs and returns an *oauth2.Config from the provider.
-func (p *Provider) Oauth2Config(redirectUrl *url.URL) *oauth2.Config {
+func (p *Provider) Oauth2Config() *oauth2.Config {
 	return &oauth2.Config{
 		ClientID:     p.config.ClientID,
 		ClientSecret: p.config.ClientSecret,
@@ -123,7 +123,7 @@ func (p *Provider) Oauth2Config(redirectUrl *url.URL) *oauth2.Config {
 		// many instances have the "/.auth/callback" value hardcoded in their external auth
 		// provider, so we can't change it easily
 		RedirectURL: globals.ExternalURL().
-			ResolveReference(redirectUrl).
+			ResolveReference(&url.URL{Path: p.callbackUrl}).
 			String(),
 
 		Endpoint: p.oidc.Endpoint(),

--- a/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/middleware.go
@@ -251,5 +251,5 @@ func RedirectToAuthRequest(w http.ResponseWriter, r *http.Request, p *openidconn
 	//
 	// See http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest of the
 	// OIDC spec.
-	http.Redirect(w, r, p.Oauth2Config(&url.URL{Path: path.Join(auth.AuthURLPrefix, internalauth.SourcegraphOperatorProviderType, "callback")}).AuthCodeURL(state, oidc.Nonce(state)), http.StatusFound)
+	http.Redirect(w, r, p.Oauth2Config().AuthCodeURL(state, oidc.Nonce(state)), http.StatusFound)
 }

--- a/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/middleware_test.go
@@ -66,7 +66,7 @@ func newOIDCIDServer(t *testing.T, code string, providerConfig *cloud.SchemaAuth
 
 		redirectURI, err := url.QueryUnescape(values.Get("redirect_uri"))
 		require.NoError(t, err)
-		require.Equal(t, "http://example.com/.auth/callback", redirectURI)
+		require.Equal(t, "http://example.com/.auth/sourcegraph-operator/callback", redirectURI)
 
 		w.Header().Set("Content-Type", "application/json")
 		err = json.NewEncoder(w).Encode(
@@ -190,7 +190,7 @@ func TestMiddleware(t *testing.T) {
 		loginURL, err := url.Parse(location)
 		require.NoError(t, err)
 		assert.Equal(t, mockProvider.config.ClientID, loginURL.Query().Get("client_id"))
-		assert.Equal(t, "http://example.com/.auth/callback", loginURL.Query().Get("redirect_uri"))
+		assert.Equal(t, "http://example.com/.auth/sourcegraph-operator/callback", loginURL.Query().Get("redirect_uri"))
 		assert.Equal(t, "code", loginURL.Query().Get("response_type"))
 		assert.Equal(t, "openid profile email", loginURL.Query().Get("scope"))
 	})
@@ -201,7 +201,7 @@ func TestMiddleware(t *testing.T) {
 			Redirect:   "/redirect",
 			ProviderID: mockProvider.ConfigID().ID,
 		}
-		urlStr := fmt.Sprintf("http://example.com/.auth/callback?code=%s&state=%s", testCode, badState.Encode())
+		urlStr := fmt.Sprintf("http://example.com/.auth/sourcegraph-operator/callback?code=%s&state=%s", testCode, badState.Encode())
 		resp := doRequest(http.MethodGet, urlStr, "", nil, false)
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
@@ -233,7 +233,7 @@ func TestMiddleware(t *testing.T) {
 			return 1, nil
 		})
 
-		urlStr := fmt.Sprintf("http://example.com/.auth/callback?code=%s&state=%s", testCode, state.Encode())
+		urlStr := fmt.Sprintf("http://example.com/.auth/sourcegraph-operator/callback?code=%s&state=%s", testCode, state.Encode())
 		cookies := []*http.Cookie{
 			{
 				Name:  stateCookieName,
@@ -267,7 +267,7 @@ func TestMiddleware(t *testing.T) {
 		}
 		defer func() { openidconnect.MockVerifyIDToken = nil }()
 
-		urlStr := fmt.Sprintf("http://example.com/.auth/callback?code=%s&state=%s", testCode, state.Encode())
+		urlStr := fmt.Sprintf("http://example.com/.auth/sourcegraph-operator/callback?code=%s&state=%s", testCode, state.Encode())
 		cookies := []*http.Cookie{
 			{
 				Name:  stateCookieName,
@@ -302,7 +302,7 @@ func TestMiddleware(t *testing.T) {
 			}, nil
 		})
 
-		urlStr := fmt.Sprintf("http://example.com/.auth/callback?code=%s&state=%s", testCode, state.Encode())
+		urlStr := fmt.Sprintf("http://example.com/.auth/sourcegraph-operator/callback?code=%s&state=%s", testCode, state.Encode())
 		cookies := []*http.Cookie{
 			{
 				Name:  stateCookieName,
@@ -343,7 +343,7 @@ func TestMiddleware(t *testing.T) {
 		}
 		defer func() { openidconnect.MockVerifyIDToken = nil }()
 
-		urlStr := fmt.Sprintf("http://example.com/.auth/callback?code=%s&state=%s", testCode, state.Encode())
+		urlStr := fmt.Sprintf("http://example.com/.auth/sourcegraph-operator/callback?code=%s&state=%s", testCode, state.Encode())
 		cookies := []*http.Cookie{
 			{
 				Name:  stateCookieName,

--- a/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/provider.go
@@ -1,8 +1,10 @@
 package sourcegraphoperator
 
 import (
+	"path"
 	"time"
 
+	feAuth "github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/openidconnect"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/cloud"
@@ -35,7 +37,7 @@ func NewProvider(config cloud.SchemaAuthProviderSourcegraphOperator) providers.P
 				Type:               auth.SourcegraphOperatorProviderType,
 			},
 			authPrefix,
-			".auth/sourcegraph-operator/callback",
+			path.Join(feAuth.AuthURLPrefix, "sourcegraph-operator", "callback"),
 		).(*openidconnect.Provider),
 	}
 }

--- a/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/provider.go
@@ -35,6 +35,7 @@ func NewProvider(config cloud.SchemaAuthProviderSourcegraphOperator) providers.P
 				Type:               auth.SourcegraphOperatorProviderType,
 			},
 			authPrefix,
+			".auth/sourcegraph-operator/callback",
 		).(*openidconnect.Provider),
 	}
 }


### PR DESCRIPTION
This attempts to fix https://github.com/sourcegraph/sourcegraph/issues/44619

This PR https://github.com/sourcegraph/sourcegraph/commit/855100cdcdf81476b8ec734dddbcec5a99d2952b introduced a complication where the Sourcegraph Operator middleware overrides the OpenID Connect middleware.

The idea is to have Sourcegraph Operator use its own dedicated endpoint instead. OpenID Connect goes through `.auth/callback` for backwards compatibility reasons, but it would preferably go through `.auth/openidconnect/callback`. Sourcegraph Operator does not need to inherit this restriction and can instead use its own callback endpoint, `.auth/sourcegraph-operator/callback`.

## Test plan

Existing tests adjusted for new callback route and pass.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
