### PR TITLE
Rethink code navigation with token cursor

### DIFF
--- a/client/shared/src/codeintel/scip.ts
+++ b/client/shared/src/codeintel/scip.ts
@@ -18,6 +18,11 @@ export interface JsonOccurrence {
 
 export class Position implements sourcegraph.Position {
     constructor(public readonly line: number, public readonly character: number) {}
+
+    public asOneBased(): Position {
+        return new Position(this.line + 1, this.character + 1)
+    }
+
     public static fromPosition(position: sourcegraph.Position): Position {
         return new Position(position.line, position.character)
     }
@@ -44,10 +49,20 @@ export class Position implements sourcegraph.Position {
         return this.character - other.character
     }
 }
+
 export class Range {
     constructor(public readonly start: Position, public readonly end: Position) {}
     public static fromNumbers(startLine: number, startCharacter: number, endLine: number, endCharacter: number): Range {
         return new Range(new Position(startLine, startCharacter), new Position(endLine, endCharacter))
+    }
+    public static fromRange(range: sourcegraph.Range): Range {
+        return new Range(Position.fromPosition(range.start), Position.fromPosition(range.end))
+    }
+    public characterDistance(position: sourcegraph.Position): number {
+        return Math.min(
+            Math.abs(position.character - this.start.character),
+            Math.abs(position.character - this.end.character)
+        )
     }
     public contains(position: sourcegraph.Position): boolean {
         return this.start.isSmallerOrEqual(position) && this.end.isGreater(position)
@@ -66,6 +81,9 @@ export class Range {
     }
     public isSingleLine(): boolean {
         return this.start.line === this.end.line
+    }
+    public asOneBased(): Range {
+        return new Range(this.start.asOneBased(), this.end.asOneBased())
     }
     public compare(other: Range): number {
         const byStart = this.start.compare(other.start)

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -316,6 +316,13 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
                             `#fuzzy-modal-result-${focusIndex} .${linkStyle}`
                         )
                         fileAnchor?.click()
+                        requestAnimationFrame(() => {
+                            const editor = document.querySelector<HTMLElement>('.cm-content')
+                            console.log({ editor })
+                            if (editor) {
+                                editor.focus()
+                            }
+                        })
                     }
                     break
                 default:

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -87,7 +87,7 @@ import { Code, useObservable } from '@sourcegraph/wildcard'
 import { getHover, getDocumentHighlights } from '../../backend/features'
 import { WebHoverOverlay } from '../../components/shared'
 import { StatusBar } from '../../extensions/components/StatusBar'
-import { BlobStencilFields, ExternalLinkFields, Scalars } from '../../graphql-operations'
+import { ExternalLinkFields, Scalars } from '../../graphql-operations'
 import { BlameHunk } from '../blame/useBlameHunks'
 import { HoverThresholdProps } from '../RepoContainer'
 
@@ -152,8 +152,6 @@ export interface BlobInfo extends AbsoluteRepoFile, ModeSpec {
 
     /** LSIF syntax-highlighting data */
     lsif?: string
-
-    stencil?: BlobStencilFields[]
 
     /** If present, the file is stored in Git LFS (large file storage). */
     lfs?: { byteSize: Scalars['BigInt'] } | null

--- a/client/web/src/repo/blob/BlobPage.module.scss
+++ b/client/web/src/repo/blob/BlobPage.module.scss
@@ -24,3 +24,16 @@
         box-shadow: var(--focus-box-shadow);
     }
 }
+
+:global(.codeintel-tooltip) {
+    position: absolute;
+}
+
+:global(.codeintel-contextmenu-item) {
+    background-color: white;
+}
+
+:global(.codeintel-contextmenu-item-action:hover) {
+    background-color: var(--color-bg-2);
+    cursor: pointer;
+}

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -64,7 +64,7 @@ import { ToggleHistoryPanel } from './actions/ToggleHistoryPanel'
 import { ToggleLineWrap } from './actions/ToggleLineWrap'
 import { ToggleRenderedFileMode } from './actions/ToggleRenderedFileMode'
 import { getModeFromURL } from './actions/utils'
-import { fetchBlob, fetchStencil } from './backend'
+import { fetchBlob } from './backend'
 import { Blob, BlobInfo } from './Blob'
 import { Blob as CodeMirrorBlob } from './CodeMirrorBlob'
 import { GoToRawAction } from './GoToRawAction'
@@ -286,24 +286,6 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
                 ),
             [repoName, revision, filePath, enableCodeMirror, mode]
         )
-    )
-
-    /**
-     * Fetches stencil ranges for the current document.
-     * Used to provide keyboard navigation within the blob view.
-     */
-    const stencil = useObservable(
-        useMemo(() => {
-            if (!enableTokenKeyboardNavigation) {
-                return of(undefined)
-            }
-
-            return fetchStencil({
-                repoName,
-                revision,
-                filePath,
-            })
-        }, [enableTokenKeyboardNavigation, filePath, repoName, revision])
     )
 
     const blobInfoOrError = enableLazyBlobSyntaxHighlighting
@@ -549,7 +531,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
                     <BlobComponent
                         data-testid="repo-blob"
                         className={classNames(styles.blob, styles.border)}
-                        blobInfo={{ ...blobInfoOrError, commitID, stencil }}
+                        blobInfo={{ ...blobInfoOrError, commitID }}
                         wrapCode={wrapCode}
                         platformContext={props.platformContext}
                         extensionsController={props.extensionsController}

--- a/client/web/src/repo/blob/codemirror/context-menu.module.scss
+++ b/client/web/src/repo/blob/codemirror/context-menu.module.scss
@@ -1,0 +1,3 @@
+.clickable:hover {
+    cursor: pointer;
+}

--- a/client/web/src/repo/blob/codemirror/context-menu.ts
+++ b/client/web/src/repo/blob/codemirror/context-menu.ts
@@ -1,0 +1,721 @@
+import {
+    countColumn,
+    EditorSelection,
+    Extension,
+    Facet,
+    Line,
+    SelectionRange,
+    StateEffect,
+    StateField,
+} from '@codemirror/state'
+import { EditorView, hoverTooltip, KeyBinding, keymap, showTooltip, Tooltip, TooltipView } from '@codemirror/view'
+import { Remote } from 'comlink'
+import * as H from 'history'
+
+import { TextDocumentPositionParameters } from '@sourcegraph/client-api'
+import { renderMarkdown } from '@sourcegraph/common'
+import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
+import { FlatExtensionHostAPI } from '@sourcegraph/shared/src/api/contract'
+import { Occurrence, Position, Range } from '@sourcegraph/shared/src/codeintel/scip'
+import { parseRepoURI, toPrettyBlobURL, toURIWithPath } from '@sourcegraph/shared/src/util/url'
+
+import { BlobInfo } from '../Blob'
+
+import { HighlightIndex, syntaxHighlight } from './highlight'
+import { shouldScrollIntoView } from './linenumbers'
+import { isInteractiveOccurrence } from './tokens-as-links'
+
+import styles from './context-menu.module.scss'
+
+function occurrenceAtPosition(
+    view: EditorView,
+    position: Position
+): { occurrence: Occurrence; position: Position } | undefined {
+    const table = view.state.facet(syntaxHighlight)
+    for (
+        let index = table.lineIndex[position.line];
+        index !== undefined &&
+        index < table.occurrences.length &&
+        table.occurrences[index].range.start.line === position.line;
+        index++
+    ) {
+        const occurrence = table.occurrences[index]
+        if (occurrence.range.contains(position)) {
+            return { occurrence, position }
+        }
+    }
+    return
+}
+
+function closestOccurrence(
+    line: number,
+    table: HighlightIndex,
+    position: Position,
+    includeOccurrence?: (occurrence: Occurrence) => boolean
+): Occurrence | undefined {
+    const candidates: [Occurrence, number][] = []
+    let index = table.lineIndex[line] ?? -1
+    for (
+        ;
+        index >= 0 && index < table.occurrences.length && table.occurrences[index].range.start.line === line;
+        index++
+    ) {
+        const occurrence = table.occurrences[index]
+        if (!isInteractiveOccurrence(occurrence)) {
+            continue
+        }
+        if (includeOccurrence && !includeOccurrence(occurrence)) {
+            continue
+        }
+        candidates.push([occurrence, occurrence.range.characterDistance(position)])
+    }
+    candidates.sort(([, a], [, b]) => a - b)
+    if (candidates.length > 0) {
+        return candidates[0][0]
+    }
+    return undefined
+}
+
+function occurrenceAtEvent(
+    view: EditorView,
+    event: MouseEvent
+): { occurrence: Occurrence; position: Position; coords: Coordinates } | undefined {
+    const atEvent = positionAtEvent(view, event)
+    if (!atEvent) {
+        return
+    }
+    const { position, coords } = atEvent
+    const occurrence = occurrenceAtPosition(view, position)
+    if (!occurrence) {
+        return
+    }
+    return { ...occurrence, coords }
+}
+function goToDefinitionAtOccurrence(
+    view: EditorView,
+    blobInfo: BlobInfo,
+    history: H.History,
+    codeintel: Remote<FlatExtensionHostAPI>,
+    position: Position,
+    occurrence: Occurrence,
+    coords: Coordinates
+): Promise<() => void> {
+    const fromCache = definitionCache.get(occurrence)
+    if (fromCache) {
+        return fromCache
+    }
+    const uri = toURIWithPath(blobInfo)
+    const promise = goToDefinition(view, history, codeintel, { position, textDocument: { uri } }, coords)
+    definitionCache.set(occurrence, promise)
+    return promise
+}
+
+function goToDefinitionAtEvent(
+    view: EditorView,
+    event: MouseEvent,
+    blobInfo: BlobInfo,
+    history: H.History,
+    codeintel: Remote<FlatExtensionHostAPI>
+): Promise<() => void> {
+    const atEvent = occurrenceAtEvent(view, event)
+    if (!atEvent) {
+        return Promise.resolve(() => {})
+    }
+    const { occurrence, position, coords } = atEvent
+    return goToDefinitionAtOccurrence(view, blobInfo, history, codeintel, position, occurrence, coords)
+}
+
+function positionAtEvent(view: EditorView, event: MouseEvent): { position: Position; coords: Coordinates } | undefined {
+    const coords: Coordinates = {
+        x: event.clientX,
+        y: event.clientY,
+    }
+    const position = view.posAtCoords(coords)
+    if (position === null) {
+        return
+    }
+    event.preventDefault()
+    return { position: scipPositionAtCodemirrorPosition(view, position), coords }
+}
+
+function scipPositionAtCodemirrorPosition(view: EditorView, position: number): Position {
+    const cmLine = view.state.doc.lineAt(position)
+    const line = cmLine.number - 1
+    const character = position - cmLine.from
+    return new Position(line, character)
+}
+
+const definitionCache = new Map<Occurrence, Promise<() => void>>()
+const hoverCache = new Map<Occurrence, Promise<string>>()
+
+// HACK: we store the editor view in a global variable so that we can access it
+// from global keydown/keyup event handlers even when the editor is not focused.
+// The `keydown` handler in EditorView.domEventHandler doesn't capture events
+// when the editor is out of focus.
+let globalViewHack: EditorView | undefined
+const globalEventHandler = (event: KeyboardEvent): void => {
+    if (!globalViewHack) {
+        return
+    }
+    if (event.metaKey) {
+        globalViewHack.contentDOM.classList.add(styles.clickable)
+    } else {
+        globalViewHack.contentDOM.classList.remove(styles.clickable)
+    }
+}
+
+const scrollLineIntoView = (view: EditorView, line: Line): boolean => {
+    if (shouldScrollIntoView(view, { line: line.number })) {
+        view.dispatch({
+            effects: EditorView.scrollIntoView(line.from, { y: 'nearest' }),
+        })
+        return true
+    }
+    return false
+}
+
+export const rangeToSelection = (view: EditorView, range: Range): SelectionRange => {
+    const startLine = view.state.doc.line(range.start.line + 1)
+    const endLine = view.state.doc.line(range.end.line + 1)
+    const start = startLine.from + range.start.character
+    const end = Math.min(endLine.from + range.end.character, endLine.to)
+    return EditorSelection.range(start, end)
+}
+export const uriFacet = Facet.define<string, string>({
+    combine: props => props[0],
+})
+export const selectionsFacet = Facet.define<Map<string, Range>, Map<string, Range>>({
+    combine: props => props[0],
+})
+export const blobInfoFacet = Facet.define<BlobInfo, BlobInfo>({
+    combine: props => props[0],
+})
+
+export const selectOccurrence = (
+    codeintel: Remote<FlatExtensionHostAPI>,
+    history: H.History,
+    view: EditorView,
+    occurrence: Occurrence
+): void => {
+    const blobInfo = view.state.facet(blobInfoFacet)
+    hoverAtOccurrence(codeintel, blobInfo, occurrence).then(
+        () => {},
+        () => {}
+    )
+    const cmLine = view.state.doc.line(occurrence.range.start.line + 1)
+    const rect = view.coordsAtPos(cmLine.from + occurrence.range.start.character + 1)
+    const coords: Coordinates = rect ? { x: rect.left, y: rect.top } : { x: 0, y: 0 }
+    goToDefinitionAtOccurrence(view, blobInfo, history, codeintel, occurrence.range.start, occurrence, coords).then(
+        () => {},
+        () => {}
+    )
+    const url = toPrettyBlobURL({ ...blobInfo, range: occurrence.range.asOneBased() })
+    history.replace(url)
+    selectRange(view, occurrence.range)
+}
+export const selectRange = (view: EditorView, range: Range): void => {
+    const selection = rangeToSelection(view, range)
+    const uri = view.state.facet(uriFacet)
+    const selections = view.state.facet(selectionsFacet)
+    if (selections) {
+        selections.set(uri, range)
+    }
+    view.dispatch({ selection })
+
+    const lineAbove = view.state.doc.line(Math.min(view.state.doc.lines, range.start.line + 3))
+    if (scrollLineIntoView(view, lineAbove)) {
+        return
+    }
+    const lineBelow = view.state.doc.line(Math.max(1, range.end.line - 1))
+    scrollLineIntoView(view, lineBelow)
+}
+
+export function contextMenu(
+    codeintel: Remote<FlatExtensionHostAPI> | undefined,
+    blobInfo: BlobInfo,
+    history: H.History,
+    selections: Map<string, Range>
+): Extension {
+    if (!codeintel) {
+        return []
+    }
+    document.removeEventListener('keydown', globalEventHandler)
+    document.addEventListener('keydown', globalEventHandler)
+    document.removeEventListener('keyup', globalEventHandler)
+    document.addEventListener('keyup', globalEventHandler)
+    const setHoverEffect = StateEffect.define<Tooltip | null>()
+    const hoverField = StateField.define<Tooltip | null>({
+        create: () => null,
+        update(tooltip, transactions) {
+            for (const effect of transactions.effects) {
+                if (effect.is(setHoverEffect)) {
+                    tooltip = effect.value
+                }
+            }
+            return tooltip
+        },
+
+        provide: field => showTooltip.from(field),
+    })
+
+    const keybindings: readonly KeyBinding[] = [
+        {
+            key: 'Space',
+            run(view) {
+                const hover = view.state.field(hoverField)
+                if (hover !== null) {
+                    view.dispatch({ effects: setHoverEffect.of(null) })
+                    return true
+                }
+                const position = view.state.selection.main.from + 1
+                getHoverTooltip(codeintel, blobInfo, view, position).then(
+                    value => view.dispatch({ effects: setHoverEffect.of(value) }),
+                    () => {}
+                )
+                return true
+            },
+        },
+        {
+            key: 'Enter',
+            run(view) {
+                const position = scipPositionAtCodemirrorPosition(view, view.state.selection.main.from)
+                const atEvent = occurrenceAtPosition(view, position)
+                if (!atEvent) {
+                    return false
+                }
+                const { occurrence } = atEvent
+                const cmLine = view.state.doc.line(occurrence.range.start.line + 1)
+                const cmPos = cmLine.from + occurrence.range.start.character
+                const rect = view.coordsAtPos(cmPos)
+                const coords: Coordinates = rect ? { x: rect.left, y: rect.top } : { x: 0, y: 0 }
+                const spinner = new Spinner(coords)
+                goToDefinitionAtOccurrence(view, blobInfo, history, codeintel, position, occurrence, coords)
+                    .then(
+                        action => action(),
+                        () => {}
+                    )
+                    .finally(() => spinner.stop())
+                return true
+            },
+        },
+        {
+            key: 'Mod-ArrowRight',
+            run() {
+                history.goForward()
+                return true
+            },
+        },
+        {
+            key: 'Mod-ArrowLeft',
+            run() {
+                history.goBack()
+                return true
+            },
+        },
+        {
+            key: 'ArrowLeft',
+            run(view) {
+                view.dispatch({ effects: setHoverEffect.of(null) })
+                const position = scipPositionAtCodemirrorPosition(view, view.state.selection.main.from)
+                const table = view.state.facet(syntaxHighlight)
+                const line = position.line
+                const occurrence = closestOccurrence(line, table, position, occurrence =>
+                    occurrence.range.start.isSmaller(position)
+                )
+                if (occurrence) {
+                    selectOccurrence(codeintel, history, view, occurrence)
+                }
+                return true
+            },
+        },
+        {
+            key: 'ArrowRight',
+            run(view) {
+                view.dispatch({ effects: setHoverEffect.of(null) })
+                const position = scipPositionAtCodemirrorPosition(view, view.state.selection.main.from)
+                const table = view.state.facet(syntaxHighlight)
+                const line = position.line
+                const occurrence = closestOccurrence(line, table, position, occurrence =>
+                    occurrence.range.start.isGreater(position)
+                )
+                if (occurrence) {
+                    selectOccurrence(codeintel, history, view, occurrence)
+                }
+                return true
+            },
+        },
+        {
+            key: 'ArrowDown',
+            run(view) {
+                view.dispatch({ effects: setHoverEffect.of(null) })
+                const position = scipPositionAtCodemirrorPosition(view, view.state.selection.main.from)
+                const table = view.state.facet(syntaxHighlight)
+                for (let line = position.line + 1; line < table.lineIndex.length; line++) {
+                    const occurrence = closestOccurrence(line, table, position)
+                    if (occurrence) {
+                        selectOccurrence(codeintel, history, view, occurrence)
+                        return true
+                    }
+                }
+                return true
+            },
+        },
+        {
+            key: 'ArrowUp',
+            run(view) {
+                view.dispatch({ effects: setHoverEffect.of(null) })
+                const position = scipPositionAtCodemirrorPosition(view, view.state.selection.main.from)
+                const table = view.state.facet(syntaxHighlight)
+                for (let line = position.line - 1; line >= 0; line--) {
+                    const occurrence = closestOccurrence(line, table, position)
+                    if (occurrence) {
+                        selectOccurrence(codeintel, history, view, occurrence)
+                        return true
+                    }
+                }
+                return true
+            },
+        },
+        {
+            key: 'Escape',
+            run(view) {
+                view.dispatch({ effects: setHoverEffect.of(null) })
+                view.contentDOM.blur()
+                return true
+            },
+        },
+    ]
+    return [
+        hoverTooltip((view, position) => getHoverTooltip(codeintel, blobInfo, view, position), {
+            hoverTime: 100,
+            // Hiding the tooltip when the document changes replicates
+            // Monaco's behavior and also "feels right" because it removes
+            // "clutter" from the input.
+            hideOnChange: true,
+        }),
+        hoverField,
+        uriFacet.of(toURIWithPath(blobInfo)),
+        selectionsFacet.of(selections),
+        blobInfoFacet.of(blobInfo),
+        keymap.of(
+            keybindings.flatMap(keybinding => {
+                if (keybinding.key === 'ArrowUp') {
+                    return [keybinding, { ...keybinding, key: 'k' }]
+                }
+                if (keybinding.key === 'ArrowDown') {
+                    return [keybinding, { ...keybinding, key: 'j' }]
+                }
+                if (keybinding.key === 'ArrowLeft') {
+                    return [keybinding, { ...keybinding, key: 'h' }, { ...keybinding, key: 'Shift-Tab' }]
+                }
+                if (keybinding.key === 'ArrowRight') {
+                    return [keybinding, { ...keybinding, key: 'l' }, { ...keybinding, key: 'Tab' }]
+                }
+                return [keybinding]
+            })
+        ),
+        EditorView.domEventHandlers({
+            mouseover(event, view) {
+                globalViewHack = view
+
+                if (!codeintel) {
+                    return
+                }
+                // toggleClickableClass(view, event.metaKey)
+                goToDefinitionAtEvent(view, event, blobInfo, history, codeintel).then(
+                    () => {},
+                    () => {}
+                )
+            },
+            dblclick(event, view) {
+                if (!codeintel) {
+                    return
+                }
+                const atEvent = positionAtEvent(view, event)
+                if (!atEvent) {
+                    return
+                }
+                const {
+                    position: { line },
+                } = atEvent
+                // Select the entire line
+                selectRange(view, Range.fromNumbers(line, 0, line, Number.MAX_VALUE))
+                return true
+            },
+            click(event, view) {
+                event.preventDefault()
+                view.dispatch({ effects: setHoverEffect.of(null) })
+                const atEvent = occurrenceAtEvent(view, event)
+                if (atEvent && isInteractiveOccurrence(atEvent.occurrence)) {
+                    selectOccurrence(codeintel, history, view, atEvent.occurrence)
+                }
+                if (!event.metaKey) {
+                    return
+                }
+                const spinner = new Spinner({
+                    x: event.clientX,
+                    y: event.clientY,
+                })
+                goToDefinitionAtEvent(view, event, blobInfo, history, codeintel)
+                    .then(
+                        action => action(),
+                        () => {}
+                    )
+                    .finally(() => spinner.stop())
+            },
+            contextmenu(event, view) {
+                if (event.shiftKey) {
+                    return
+                }
+                if (!codeintel) {
+                    return
+                }
+                const atEvent = positionAtEvent(view, event)
+                if (!atEvent) {
+                    return
+                }
+                const atEvent2 = occurrenceAtEvent(view, event)
+                if (atEvent2 && isInteractiveOccurrence(atEvent2.occurrence)) {
+                    selectOccurrence(codeintel, history, view, atEvent2.occurrence)
+                }
+                const definitionAction = goToDefinitionAtEvent(view, event, blobInfo, history, codeintel)
+                const { coords } = atEvent
+                const menu = document.createElement('div')
+                const definition = document.createElement('div')
+                definition.innerHTML = 'Go to definition'
+                definition.classList.add('codeintel-contextmenu-item')
+                definition.classList.add('codeintel-contextmenu-item-action')
+
+                definition.addEventListener('click', event => {
+                    event.preventDefault()
+                    const spinner = new Spinner(coords)
+                    definitionAction
+                        .then(
+                            action => action(),
+                            () => {}
+                        )
+                        .finally(() => spinner.stop())
+                })
+                menu.append(definition)
+
+                const references = document.createElement('div')
+                references.innerHTML = 'Find references'
+                references.classList.add('codeintel-contextmenu-item')
+                references.classList.add('codeintel-contextmenu-item-action')
+                menu.append(references)
+
+                const browserMenu = document.createElement('div')
+                browserMenu.innerHTML = 'Browser context menu shift+right-click'
+                browserMenu.classList.add('codeintel-contextmenu-item')
+                menu.append(browserMenu)
+                showHackyTooltip(view, menu, coords)
+            },
+        }),
+    ]
+}
+
+interface Coordinates {
+    x: number
+    y: number
+}
+
+function showHackyTooltip(view: EditorView, element: HTMLElement, coords: Coordinates, clearTimeout?: number): void {
+    const tooltip = document.createElement('div')
+    tooltip.classList.add('codeintel-tooltip')
+    tooltip.style.left = `${coords.x}px`
+    tooltip.style.top = `${coords.y}px`
+    tooltip.append(element)
+    document.body.append(tooltip)
+    let counter = 0
+    const tooltipCloseListener = (): void => {
+        counter += 1
+        if (counter === 1) {
+            return
+        }
+        tooltip.remove()
+        document.removeEventListener('click', tooltipCloseListener)
+        document.removeEventListener('contextmenu', tooltipCloseListener)
+    }
+    document.addEventListener('contextmenu', tooltipCloseListener)
+    document.addEventListener('click', tooltipCloseListener)
+    if (clearTimeout) {
+        setTimeout(() => {
+            tooltipCloseListener()
+            tooltipCloseListener()
+        }, clearTimeout)
+    }
+    // TODO: register up/down arrows
+
+    // Measure and reposition after rendering first version
+    requestAnimationFrame(() => {
+        tooltip.style.left = `${coords.x}px`
+        tooltip.style.top = `${top}px`
+    })
+}
+
+async function goToDefinition(
+    view: EditorView,
+    history: H.History,
+    codeintel: Remote<FlatExtensionHostAPI>,
+    params: TextDocumentPositionParameters,
+    coords: Coordinates
+): Promise<() => void> {
+    const definition = await codeintel.getDefinition(params)
+
+    const result = await wrapRemoteObservable(definition).toPromise()
+    if (result.isLoading) {
+        return () => {}
+    }
+    if (result.result.length === 0) {
+        return () => {
+            const element = document.createElement('div')
+            element.textContent = 'No definition found'
+            element.style.color = 'white'
+            element.style.backgroundColor = 'deepskyblue'
+            showHackyTooltip(view, element, coords, 2000)
+        }
+    }
+    for (const location of result.result) {
+        if (location.uri === params.textDocument.uri && location.range && location.range) {
+            const requestPosition = new Position(params.position.line, params.position.character)
+            const {
+                start: { line: startLine, character: startCharacter },
+                end: { line: endLine, character: endCharacter },
+            } = location.range
+            const resultRange = Range.fromNumbers(startLine, startCharacter, endLine, endCharacter)
+            if (resultRange.contains(requestPosition)) {
+                return () => {
+                    const element = document.createElement('div')
+                    element.textContent = 'You are at the definition'
+                    element.style.color = 'white'
+                    element.style.backgroundColor = 'deepskyblue'
+                    showHackyTooltip(view, element, coords, 2000)
+                }
+            }
+        }
+    }
+    if (result.result.length === 1) {
+        const { range, uri } = result.result[0]
+        const { filePath, repoName, revision } = parseRepoURI(uri)
+        if (filePath && range) {
+            return () => {
+                const selectionRange = Range.fromNumbers(
+                    range.start.line,
+                    range.start.character,
+                    range.end.line,
+                    range.end.character
+                )
+                if (uri === params.textDocument.uri) {
+                    const atEvent = occurrenceAtPosition(view, selectionRange.start)
+                    if (atEvent) {
+                        selectOccurrence(codeintel, history, view, atEvent.occurrence)
+                    } else {
+                        selectRange(view, selectionRange)
+                    }
+                } else {
+                    const selections = view.state.facet(selectionsFacet)
+                    selections.set(uri, selectionRange)
+                    const href = toPrettyBlobURL({
+                        repoName,
+                        revision,
+                        filePath,
+                        position: { line: range.start.line + 1, character: range.start.character + 1 },
+                    })
+                    history.push(href)
+                }
+            }
+        }
+    }
+    return () => {
+        // TODO: something more useful than opening ref panel
+        const element = document.createElement('div')
+        element.textContent = 'FIXME: Multiple definitions found'
+        element.style.color = 'white'
+        element.style.backgroundColor = 'deepskyblue'
+        showHackyTooltip(view, element, coords, 2000)
+    }
+}
+
+class Spinner {
+    private spinner: HTMLElement
+    constructor(coords: Coordinates) {
+        this.spinner = document.createElement('div')
+        this.spinner.textContent = 'loading...'
+        this.spinner.style.backgroundColor = 'white'
+        this.spinner.style.position = 'fixed'
+        this.spinner.style.top = `${coords.y}px`
+        this.spinner.style.left = `${coords.x}px`
+        document.body.append(this.spinner)
+    }
+    public stop(): void {
+        this.spinner.remove()
+    }
+}
+
+async function getHoverTooltip(
+    codeintel: Remote<FlatExtensionHostAPI> | undefined,
+    blobInfo: BlobInfo,
+    view: EditorView,
+    pos: number
+): Promise<Tooltip | null> {
+    if (!codeintel) {
+        return null
+    }
+    const cmLine = view.state.doc.lineAt(pos)
+    const line = cmLine.number - 1
+    const character = countColumn(cmLine.text, 1, pos - cmLine.from) - 1
+    const atEvent = occurrenceAtPosition(view, new Position(line, character))
+    if (!atEvent) {
+        return null
+    }
+    const contents = await hoverAtOccurrence(codeintel, blobInfo, atEvent.occurrence)
+    return markdownTooltip(pos, contents)
+}
+
+function hoverAtOccurrence(
+    codeintel: Remote<FlatExtensionHostAPI>,
+    blobInfo: BlobInfo,
+    occurrence: Occurrence
+): Promise<string> {
+    const fromCache = hoverCache.get(occurrence)
+    if (fromCache) {
+        return fromCache
+    }
+    const uri = toURIWithPath(blobInfo)
+    const contents = hoverRequest(codeintel, {
+        position: { line: occurrence.range.start.line, character: occurrence.range.start.character + 1 },
+        textDocument: { uri },
+    })
+    hoverCache.set(occurrence, contents)
+    return contents
+}
+
+async function hoverRequest(
+    codeintel: Remote<FlatExtensionHostAPI>,
+    params: TextDocumentPositionParameters
+): Promise<string> {
+    const hover = await codeintel.getHover(params)
+
+    const result = await wrapRemoteObservable(hover).toPromise()
+    const contents =
+        result === undefined || result.isLoading || result.result === null || result.result.contents.length === 0
+            ? 'No hover information'
+            : result.result.contents
+                  .map(({ value }) => value)
+                  .join('\n\n----\n\n')
+                  .trimEnd()
+    return contents
+}
+
+function markdownTooltip(pos: number, contents: string): Tooltip {
+    return {
+        pos,
+        end: pos,
+        create(): TooltipView {
+            const dom = document.createElement('div')
+            const markdown = renderMarkdown(contents)
+            dom.innerHTML = markdown
+            return { dom }
+        },
+    }
+}

--- a/client/web/src/repo/blob/codemirror/highlight.ts
+++ b/client/web/src/repo/blob/codemirror/highlight.ts
@@ -13,7 +13,7 @@ import { positionToOffset } from './utils'
  * server with a lineIndex map (implemented as array), for fast lookup by line
  * number, with minimal additional impact on memory (e.g. garbage collection).
  */
-interface HighlightIndex {
+export interface HighlightIndex {
     occurrences: Occurrence[]
     lineIndex: (number | undefined)[]
 }
@@ -23,7 +23,7 @@ interface HighlightIndex {
  * NOTE: This assumes that the data is sorted and does not contain overlapping
  * ranges.
  */
-function createHighlightTable(info: BlobInfo): HighlightIndex {
+export function createHighlightTable(info: BlobInfo): HighlightIndex {
     const lineIndex: (number | undefined)[] = []
 
     if (!info.lsif) {

--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -390,7 +390,7 @@ function normalizeLineRange(range: SelectedLineRange): SelectedLineRange {
  * of *rendered* lines, not just *visible* lines (some lines are rendered
  * outside of the editor viewport).
  */
-function shouldScrollIntoView(view: EditorView, range: SelectedLineRange): boolean {
+export function shouldScrollIntoView(view: EditorView, range: SelectedLineRange): boolean {
     if (!range || !isValidLineRange(range, view.state.doc)) {
         return false
     }


### PR DESCRIPTION
Previously, the token cursor feature flag used HTML href links for go to definition. This commit changes the behavior of the feature flag to use CodeMirror selections instead along with several other big changes:

* Cmd+Click for Go to definition
* Enter for Go to definition
* Space for Show popover
* Right-click menu for Go to definition and Find references
* Up/Down/Right/Left arrow to move the selection to the next token

Demo https://www.loom.com/share/a0fa53badd4d419081dcfd1a2fbc7e4e

Please give it a try and let us know what you think.


## Test plan

To test it manually with a local build:

```
SOURCEGRAPH_API_URL=https://sourcegraph.com sg start web-standalone
```

Update the user setting `"codeIntel.blobKeyboardNavigation": "token"`. The setting name will likely get renamed and moved under experimental options. This PR doesn't introduce a new feature flag yet, it replaces the behavior of this flag for now.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-definition-button.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

