### PR TITLE
insights: chore: migrate logging in some background jobs and query executors

### DIFF
--- a/enterprise/internal/insights/background/data_prune.go
+++ b/enterprise/internal/insights/background/data_prune.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/inconshreveable/log15"
 	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/log"
 
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
@@ -18,14 +18,15 @@ import (
 // NewInsightsDataPrunerJob will periodically delete recorded data series that have been marked `deleted`.
 func NewInsightsDataPrunerJob(ctx context.Context, postgres database.DB, insightsdb edb.InsightsDB) goroutine.BackgroundRoutine {
 	interval := time.Minute * 60
+	logger := log.Scoped("InsightsDataPrunerJob", "")
 
 	return goroutine.NewPeriodicGoroutine(ctx, interval,
 		goroutine.NewHandlerWithErrorMessage("insights_data_prune", func(ctx context.Context) (err error) {
-			return performPurge(ctx, postgres, insightsdb, time.Now().Add(interval))
+			return performPurge(ctx, postgres, insightsdb, logger, time.Now().Add(interval))
 		}))
 }
 
-func performPurge(ctx context.Context, postgres database.DB, insightsdb edb.InsightsDB, deletedBefore time.Time) (err error) {
+func performPurge(ctx context.Context, postgres database.DB, insightsdb edb.InsightsDB, logger log.Logger, deletedBefore time.Time) (err error) {
 	insightStore := store.NewInsightStore(insightsdb)
 	timeseriesStore := store.New(insightsdb, store.NewInsightPermissionStore(postgres))
 
@@ -41,7 +42,7 @@ func performPurge(ctx context.Context, postgres database.DB, insightsdb edb.Insi
 		// the series definition will always be referencable and therefore can be re-attempted. This operation
 		// isn't across the same database currently, so there isn't a single transaction across all the
 		// tables.
-		log15.Info("pruning insight series", "seriesId", id)
+		logger.Info("pruning insight series", log.String("seriesId", id))
 		err := deleteQueuedRecords(ctx, postgres, id)
 		if err != nil {
 			return errors.Wrap(err, "deleteQueuedRecords")

--- a/enterprise/internal/insights/background/data_prune_test.go
+++ b/enterprise/internal/insights/background/data_prune_test.go
@@ -169,7 +169,7 @@ func TestPerformPurge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = performPurge(ctx, postgres, insightsDB, time.Now())
+	err = performPurge(ctx, postgres, insightsDB, logger, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/insights/background/license_check.go
+++ b/enterprise/internal/insights/background/license_check.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/log"
 
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
@@ -17,14 +17,15 @@ import (
 // NewLicenseCheckJob will periodically check for the existence of a Code Insights license and ensure the correct set of insights is frozen.
 func NewLicenseCheckJob(ctx context.Context, postgres database.DB, insightsdb edb.InsightsDB) goroutine.BackgroundRoutine {
 	interval := time.Minute * 15
+	logger := log.Scoped("LicenseCheckJob", "Check for the existence of a Code Insights license regularly")
 
 	return goroutine.NewPeriodicGoroutine(ctx, interval,
 		goroutine.NewHandlerWithErrorMessage("insights_license_check", func(ctx context.Context) (err error) {
-			return checkAndEnforceLicense(ctx, insightsdb)
+			return checkAndEnforceLicense(ctx, insightsdb, logger)
 		}))
 }
 
-func checkAndEnforceLicense(ctx context.Context, insightsdb edb.InsightsDB) (err error) {
+func checkAndEnforceLicense(ctx context.Context, insightsdb edb.InsightsDB, logger log.Logger) (err error) {
 	insightStore := store.NewInsightStore(insightsdb)
 	dashboardStore := store.NewDashboardStore(insightsdb)
 	insightTx, err := insightStore.Transact(ctx)
@@ -43,7 +44,7 @@ func checkAndEnforceLicense(ctx context.Context, insightsdb edb.InsightsDB) (err
 		return nil
 	}
 
-	log15.Info("No license found for Code Insights. Freezing insights for limited access mode", "error", licenseError.Error())
+	logger.Info("No license found for Code Insights. Freezing insights for limited access mode", log.Error(licenseError))
 
 	globalUnfrozenInsightCount, totalUnfrozenInsightCount, err := insightTx.GetUnfrozenInsightCount(ctx)
 	if err != nil {

--- a/enterprise/internal/insights/background/license_check.go
+++ b/enterprise/internal/insights/background/license_check.go
@@ -17,7 +17,7 @@ import (
 // NewLicenseCheckJob will periodically check for the existence of a Code Insights license and ensure the correct set of insights is frozen.
 func NewLicenseCheckJob(ctx context.Context, postgres database.DB, insightsdb edb.InsightsDB) goroutine.BackgroundRoutine {
 	interval := time.Minute * 15
-	logger := log.Scoped("LicenseCheckJob", "Check for the existence of a Code Insights license regularly")
+	logger := log.Scoped("CodeInsightsLicenseCheckJob", "")
 
 	return goroutine.NewPeriodicGoroutine(ctx, interval,
 		goroutine.NewHandlerWithErrorMessage("insights_license_check", func(ctx context.Context) (err error) {

--- a/enterprise/internal/insights/background/license_check_test.go
+++ b/enterprise/internal/insights/background/license_check_test.go
@@ -91,7 +91,7 @@ func TestCheckAndEnforceLicense(t *testing.T) {
 		autogold.Want("NumFrozen", numFrozen).Equal(t, 4)
 
 		setMockLicenseCheck(true)
-		err = checkAndEnforceLicense(ctx, insightsDB)
+		err = checkAndEnforceLicense(ctx, insightsDB, logger)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -110,7 +110,7 @@ func TestCheckAndEnforceLicense(t *testing.T) {
 		autogold.Want("NumFrozen", numFrozen).Equal(t, 0)
 
 		setMockLicenseCheck(false)
-		checkAndEnforceLicense(ctx, insightsDB)
+		checkAndEnforceLicense(ctx, insightsDB, logger)
 		numFrozen, err = getNumFrozenInsights()
 		if err != nil {
 			t.Fatal(err)
@@ -132,7 +132,7 @@ func TestCheckAndEnforceLicense(t *testing.T) {
 		autogold.Want("NumFrozen", numFrozen).Equal(t, 4)
 
 		setMockLicenseCheck(false)
-		checkAndEnforceLicense(ctx, insightsDB)
+		checkAndEnforceLicense(ctx, insightsDB, logger)
 		numFrozen, err = getNumFrozenInsights()
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
part of https://github.com/sourcegraph/sourcegraph/issues/39976

(had some spare time waiting for a sync response so migrating some of the less complicated ones)
 
## Test plan

Ran existing unit tests and re-built locally