### PR TITLE
Fix focus management with label and contenteditable inputs

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -122,7 +122,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<
     placeholder,
     editorOptions,
     ariaLabel = 'Search query',
-
+    ariaLabelledby,
     // CodeMirror implementation specific options
     applySuggestionsOnEnter = false,
     searchHistory,
@@ -178,6 +178,10 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<
             autocompletion,
         ]
 
+        if (ariaLabelledby) {
+            extensions.push(EditorView.contentAttributes.of({ 'aria-labelledby': ariaLabelledby }))
+        }
+
         if (preventNewLine) {
             // NOTE: If a submit handler is assigned to the query input then the pressing
             // enter won't insert a line break anyway. In that case, this extensions ensures
@@ -218,6 +222,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<
         return extensions
     }, [
         ariaLabel,
+        ariaLabelledby,
         autocompletion,
         placeholder,
         preventNewLine,

--- a/client/search-ui/src/input/QueryInput.ts
+++ b/client/search-ui/src/input/QueryInput.ts
@@ -41,4 +41,5 @@ export interface QueryInputProps
     placeholder?: string
 
     ariaLabel?: string
+    ariaLabelledby?: string
 }

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.tsx
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.tsx
@@ -71,6 +71,7 @@ export const MonacoField = forwardRef<HTMLInputElement, MonacoFieldProps>((props
         autoFocus,
         placeholder,
         patternType = SearchPatternType.regexp,
+        'aria-labelledby': ariaLabelledby,
     } = props
 
     const { renderedWithinFocusContainer } = useContext(MonacoFieldContext)
@@ -90,6 +91,7 @@ export const MonacoField = forwardRef<HTMLInputElement, MonacoFieldProps>((props
 
     return (
         <LazyMonacoQueryInput
+            ariaLabelledby={ariaLabelledby}
             editorComponent={editorComponent}
             queryState={{ query: value, changeSource: QueryChangeSource.userInput }}
             isLightTheme={enhancedThemePreference === ThemePreference.Light}

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGoupCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGoupCreationForm.tsx
@@ -127,7 +127,7 @@ export const CaptureGroupCreationForm: FC<CaptureGroupCreationFormProps> = props
                 }
             >
                 <Card className="p-3">
-                    <Label className="w-100">
+                    <Label className="w-100" id="capture-group-query-label">
                         <div className="mb-2">Search query</div>
 
                         <small className={classNames('mb-3', 'text-muted', 'd-block', 'font-weight-normal')}>
@@ -148,6 +148,7 @@ export const CaptureGroupCreationForm: FC<CaptureGroupCreationFormProps> = props
                             required={true}
                             repositories={repositories.input.value}
                             placeholder="Example: file:\.pom$ <java\.version>(.*)</java\.version>"
+                            aria-labelledby="capture-group-query-label"
                             {...getDefaultInputProps(query)}
                         />
                     </Label>

--- a/client/wildcard/src/components/Typography/Label/Label.tsx
+++ b/client/wildcard/src/components/Typography/Label/Label.tsx
@@ -45,9 +45,10 @@ export const Label = React.forwardRef((props, reference) => {
             return
         }
 
-        const inputElements = mergedRef.current?.querySelectorAll('input') ?? []
+        const labelableElements =
+            mergedRef.current?.querySelectorAll('input, keygen, meter, output, progress, select, textarea') ?? []
 
-        if (inputElements.length === 0) {
+        if (labelableElements.length === 0) {
             const contendEditableElement = mergedRef.current?.querySelector<HTMLElement>('[contenteditable="true"]')
 
             if (contendEditableElement) {

--- a/client/wildcard/src/components/Typography/Label/Label.tsx
+++ b/client/wildcard/src/components/Typography/Label/Label.tsx
@@ -45,19 +45,12 @@ export const Label = React.forwardRef((props, reference) => {
             return
         }
 
-        const labelableElements =
-            mergedRef.current?.querySelectorAll('input, keygen, meter, output, progress, select, textarea') ?? []
+        const labelableElement = mergedRef.current?.querySelector<HTMLElement>(
+            'input, keygen, meter, output, progress, select, textarea, [contenteditable="true"]'
+        )
 
-        if (labelableElements.length === 0) {
-            const contendEditableElement = mergedRef.current?.querySelector<HTMLElement>('[contenteditable="true"]')
-
-            if (contendEditableElement) {
-                // If there is content editable element focus it instead and prevent default behavior
-                // We need to prevent default behavior because by default labels focuses any interactive elements
-                // such buttons, in order to preserve focus on the content editable element we stop this behavior
-                event.preventDefault()
-                contendEditableElement.focus()
-            }
+        if (labelableElement) {
+            labelableElement.focus()
         }
 
         onClick?.(event)

--- a/client/wildcard/src/components/Typography/Label/Label.tsx
+++ b/client/wildcard/src/components/Typography/Label/Label.tsx
@@ -47,7 +47,7 @@ export const Label = React.forwardRef((props, reference) => {
 
         // Extend labelable elements set with contenteditable elements
         const labelableElement = mergedRef.current?.querySelector<HTMLElement>(
-            'input, keygen, meter, output, progress, select, textarea, [contenteditable="true"]'
+            'input, keygen, meter, output, progress, select, textarea, [contenteditable=""], [contenteditable="true"]'
         )
 
         if (labelableElement) {

--- a/client/wildcard/src/components/Typography/Label/Label.tsx
+++ b/client/wildcard/src/components/Typography/Label/Label.tsx
@@ -32,11 +32,11 @@ export const Label = React.forwardRef((props, reference) => {
 
     const mergedRef = useMergeRefs([reference])
 
-    // Listen clicks on label elements in order to improve click-to-focus logic
-    // over contenteditable="true". Be default label element native behavior (click to focus first input element)
+    // Listen all clicks on the label element in order to improve click-to-focus logic
+    // for contenteditable="true". By default, label element's native behavior (click to focus a first input element)
     // doesn't work with content editable element.
     // Since we use content editable inputs (codemirror search box input) and labels together in some
-    // consumers we support this behavior manually for content editable elements
+    // consumers we need to support this behavior manually for content editable elements.
     const handleClick = (event: MouseEvent<HTMLLabelElement>): void => {
         const htmlForAttribute = mergedRef.current?.getAttribute('htmlFor')
 
@@ -45,6 +45,7 @@ export const Label = React.forwardRef((props, reference) => {
             return
         }
 
+        // Extend labelable elements set with contenteditable elements
         const labelableElement = mergedRef.current?.querySelector<HTMLElement>(
             'input, keygen, meter, output, progress, select, textarea, [contenteditable="true"]'
         )

--- a/client/wildcard/src/components/Typography/Label/Label.tsx
+++ b/client/wildcard/src/components/Typography/Label/Label.tsx
@@ -15,6 +15,13 @@ interface LabelProps extends React.HTMLAttributes<HTMLLabelElement>, TypographyP
     isUppercase?: boolean
 }
 
+/**
+ * Wildcard implementation of the label element.
+ *
+ * Use this Label component for non-standard form controls such as contenteditable inputs.
+ * Make sure you connect the input element and label with an aria-labelledby attribute.
+ * Otherwise, label native behaviour click-to-focus won't work.
+ */
 export const Label = React.forwardRef((props, reference) => {
     const {
         children,
@@ -45,15 +52,9 @@ export const Label = React.forwardRef((props, reference) => {
             return
         }
 
-        // Extend labelable elements set with contenteditable elements
-        const labelableElement = mergedRef.current?.querySelector<HTMLElement>(
-            'input, keygen, meter, output, progress, select, textarea, [contenteditable=""], [contenteditable="true"]'
-        )
-
-        if (labelableElement) {
-            labelableElement.focus()
-        }
-
+        // Resolve label's labellable control with aria-labelledby
+        // See https://github.com/sourcegraph/sourcegraph/pull/44676#pullrequestreview-1188749383
+        document.querySelector<HTMLElement>(`[aria-labelledby="${event.currentTarget.id}"]`)?.focus()
         onClick?.(event)
     }
 

--- a/client/wildcard/src/components/Typography/Label/Label.tsx
+++ b/client/wildcard/src/components/Typography/Label/Label.tsx
@@ -38,6 +38,13 @@ export const Label = React.forwardRef((props, reference) => {
     // Since we use content editable inputs (codemirror search box input) and labels together in some
     // consumers we support this behavior manually for content editable elements
     const handleClick = (event: MouseEvent<HTMLLabelElement>): void => {
+        const htmlForAttribute = mergedRef.current?.getAttribute('htmlFor')
+
+        if (htmlForAttribute) {
+            onClick?.(event)
+            return
+        }
+
         const inputElements = mergedRef.current?.querySelectorAll('input') ?? []
 
         if (inputElements.length === 0) {

--- a/client/wildcard/src/components/Typography/Label/Label.tsx
+++ b/client/wildcard/src/components/Typography/Label/Label.tsx
@@ -32,11 +32,11 @@ export const Label = React.forwardRef((props, reference) => {
 
     const mergedRef = useMergeRefs([reference])
 
-    // Listen all clicks on the label element in order to improve click-to-focus logic
-    // for contenteditable="true". By default, label element's native behavior (click to focus a first input element)
-    // doesn't work with content editable element.
-    // Since we use content editable inputs (codemirror search box input) and labels together in some
-    // consumers we need to support this behavior manually for content editable elements.
+    // Listen to all clicks on the label element in order to improve click-to-focus logic
+    // for contenteditable="true". By default, label element's native behavior (click to focus the first input element)
+    // doesn't work with contenteditable elements.
+    // Since we use contenteditable inputs (the CodeMirror search box) and labels together in some
+    // consumers, we need to support this behavior manually for contenteditable elements.
     const handleClick = (event: MouseEvent<HTMLLabelElement>): void => {
         const htmlForAttribute = mergedRef.current?.getAttribute('htmlFor')
 

--- a/client/wildcard/src/components/Typography/Label/Label.tsx
+++ b/client/wildcard/src/components/Typography/Label/Label.tsx
@@ -38,9 +38,9 @@ export const Label = React.forwardRef((props, reference) => {
     // Since we use contenteditable inputs (the CodeMirror search box) and labels together in some
     // consumers, we need to support this behavior manually for contenteditable elements.
     const handleClick = (event: MouseEvent<HTMLLabelElement>): void => {
-        const htmlForAttribute = mergedRef.current?.getAttribute('htmlFor')
+        const forAttribute = mergedRef.current?.getAttribute('for')
 
-        if (htmlForAttribute) {
+        if (forAttribute) {
             onClick?.(event)
             return
         }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/44674

## Context
All HTML label elements have default native behaviour that clicks on them lead to the focusing the any labelable elements within the label element or to focus on the labelable element that is specified with `htmlFor` attribute on the label. 

By labelable spec means
>**labelable**
Elements that can be associated with `<label>` elements. Contains  `<button>`, `<input>`, `<keygen>`, `<meter>`, `<output>`, `<progress>`, `<select>`, and `<textarea>`.

## Problem 
If you take a look at the original issue https://github.com/sourcegraph/sourcegraph/issues/44674 you can noticed that we have the following structure there

```tsx
<label>
   <SearchQueryField (which is content editable)
   <button>Hello</button>
</label>
```

So since content editable isn't a labelable element label skips it and focus button instead (which is labelable element) 

## The fix
In this PR we extend label component behaviour with content editable elements support by listening all label clicks and check label children by content editable elements appearance. It's important to say that we just extend the default behaviour all labelable should works as expected. 

## Test plan
- Check that focus work correctly in the capture group creation UI form (check the query field input
- Check that all wildcard controls that use Label component internally (Input, Checkbox, Radio, TextArea) work correctly with focus management 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-contenteditable-label-focus.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
