### PR TITLE
codeintel: add zig codeintel provider

### DIFF
--- a/client/shared/src/codeintel/legacy-extensions/language-specs/languages.ts
+++ b/client/shared/src/codeintel/legacy-extensions/language-specs/languages.ts
@@ -357,11 +357,17 @@ const stratoSpec: LanguageSpec = {
     commentStyles: [cStyleComment],
 }
 
+const zigSpec: LanguageSpec = {
+    languageID: 'zig',
+    stylized: 'Zig',
+    fileExts: ['zig'],
+    commentStyles: [{ lineRegex: slashPattern }, { lineRegex: tripleSlashPattern }],
+}
+
 /**
- * The specification of languages for which search-based code intelligence
- * is supported.
+ * The specification of languages for which we register a code intelligence provider.
  *
- * The set of languages come from https://madnight.github.io/githut/#/pull_requests/2018/4.
+ * The set of languages come from https://madnight.github.io/githut/#/pull_requests/2018/4 (with additions)
  * The language names come from https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers.
  */
 export const languageSpecs: LanguageSpec[] = [
@@ -404,6 +410,7 @@ export const languageSpecs: LanguageSpec[] = [
     typescriptSpec,
     verilogSpec,
     vhdlSpec,
+    zigSpec,
 ]
 
 /**


### PR DESCRIPTION
Added zig to the list of languages for which we create providers, and updated comment on that list as its no longer true (we use that list for precise providers as well). No entry in that list = no search-based or precise codeintel

## Test plan

Tested locally using `web-standalone-http-prod`:

![image](https://user-images.githubusercontent.com/18282288/203128444-e3fc49e9-3030-4d3d-bfb7-18940d7b70f4.png)

## App preview:

- [Web](https://sg-web-nsc-zig-codeintel-suppport.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
