### PR TITLE
worker: Fix all jobs being cancelled when heartbeat fails once

### DIFF
--- a/internal/workerutil/worker.go
+++ b/internal/workerutil/worker.go
@@ -148,6 +148,7 @@ func (w *Worker) Start() {
 				w.options.Metrics.logger.Error("Failed to refresh heartbeats",
 					log.Ints("ids", ids),
 					log.Error(err))
+				break
 			}
 			knownIDsMap := map[int]struct{}{}
 			for _, id := range knownIDs {


### PR DESCRIPTION
Any network or DB blip could've meant that all jobs get cancelled. This fixes it 

## Test plan

Tests.