### PR TITLE
insights: always sample insights query

### DIFF
--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -77,7 +77,7 @@ func GetBackgroundJobs(ctx context.Context, logger log.Logger, mainAppDB databas
 			InsightStore:            insightsStore,
 			CommitClient:            discovery.NewGitCommitClient(mainAppDB),
 			SearchPlanWorkerLimit:   1,
-			SearchRunnerWorkerLimit: 5, //TODO: move these to settings
+			SearchRunnerWorkerLimit: 5, // TODO: move these to settings
 			SearchRateLimiter:       searchRateLimiter,
 			HistoricRateLimiter:     historicRateLimiter,
 		}
@@ -160,7 +160,9 @@ func GetBackgroundQueryRunnerJob(ctx context.Context, logger log.Logger, mainApp
 // Individual insights workers may then _also_ want to register their own metrics, if desired, in
 // their NewWorker functions.
 func newWorkerMetrics(observationContext *observation.Context, workerName string) (workerutil.WorkerObservability, dbworker.ResetterMetrics) {
-	workerMetrics := workerutil.NewMetrics(observationContext, workerName+"_processor")
+	workerMetrics := workerutil.NewMetrics(observationContext, workerName+"_processor", workerutil.WithSampler(func(job workerutil.Record) bool {
+		return true
+	}))
 	resetterMetrics := dbworker.NewMetrics(observationContext, workerName)
 	return workerMetrics, *resetterMetrics
 }


### PR DESCRIPTION
Set the new internal sampler to true for insights queries while we debug this missing data issue.

## Test plan

N/A
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
