### PR TITLE
ping from GH should be a valid event

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/webhooks/github.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github.go
@@ -30,6 +30,7 @@ var (
 		"status",
 		"check_suite",
 		"check_run",
+		"ping",
 	}
 )
 


### PR DESCRIPTION

## Test plan
Existing unit tests pass. verified that after this page we don't return 404 when setting up a GitHub webhook. (After setup, GH sends out a ping event to verify)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
