### PR TITLE
Fix request error in Heartbeat fallback logic

### DIFF
--- a/internal/workerutil/idset.go
+++ b/internal/workerutil/idset.go
@@ -33,7 +33,7 @@ func (i *IDSet) Add(id int, cancel context.CancelFunc) bool {
 // Remove invokes the cancel function associated with the given identifier
 // in the set and removes the identifier from the set. If the identifier is
 // not a member of the set, then no action is performed.
-func (i *IDSet) Remove(id int) {
+func (i *IDSet) Remove(id int) bool {
 	i.Lock()
 	cancel, ok := i.ids[id]
 	delete(i.ids, id)
@@ -42,6 +42,8 @@ func (i *IDSet) Remove(id int) {
 	if ok {
 		cancel()
 	}
+
+	return ok
 }
 
 // Remove invokes the cancel function associated with the given identifier

--- a/internal/workerutil/worker.go
+++ b/internal/workerutil/worker.go
@@ -158,9 +158,10 @@ func (w *Worker) Start() {
 
 			for _, id := range ids {
 				if _, ok := knownIDsMap[id]; !ok {
-					w.options.Metrics.logger.Error("Removed unknown job from running set",
-						log.Int("id", id))
-					w.runningIDSet.Remove(id)
+					if w.runningIDSet.Remove(id) {
+						w.options.Metrics.logger.Error("Removed unknown job from running set",
+							log.Int("id", id))
+					}
 				}
 			}
 


### PR DESCRIPTION
Redoing the same request object apparently causes cloudflare errors? No idea. Also it seems to have caused some infinite memory growth. This seems to fix it, reproduced it locally and now it doesn't happen anymore. Also fixed a race condition in the "Removed unknown job from running set" reporting where
- Jobs {1, 2} are running
- A heartbeat request for {1, 2} is made
- Job 1 is finished via MarkComplete
- Job 1 is marked as finalized in DB
- The heartbeat request query runs, only finds Job 2 is running
- The response only contains {2}
- The worker reports it lost job 1
- This fixes is by validating that the job was still in the running set, otherwise it didn't actually remove or cancel a job and shouldn't log that either, to avoid confusion



## Test plan

Tried locally against scaletesting that I no longer see 400 errors.