### PR TITLE
search backend: don't run global zoekt search if query contains repo:has or repo:has.tag

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -948,6 +948,12 @@ func isGlobal(op search.RepoOptions) bool {
 		return false
 	}
 
+	// Zoekt does not know about repo key-value pairs or tags, so we depend on the
+	// database to handle this filter.
+	if len(op.HasKVPs) > 0 {
+		return false
+	}
+
 	// If a search context is specified, we do not know ahead of time whether
 	// the repos in the context are indexed and we need to go through the repo
 	// resolution process.

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -642,6 +642,40 @@ func TestNewPlanJob(t *testing.T) {
           (repoOpts.hasKVPs[0].key . tag)
           (repoNamePatterns . []))))))`),
 		}, {
+			query:      `repo:has.tag(tag) foo`,
+			protocol:   search.Streaming,
+			searchType: query.SearchTypeRegex,
+			want: autogold.Want("repo has tag and foo", `
+(ALERT
+  (query . )
+  (originalQuery . )
+  (patternType . regex)
+  (TIMEOUT
+    (timeout . 20s)
+    (LIMIT
+      (limit . 500)
+      (PARALLEL
+        (SEQUENTIAL
+          (ensureUnique . false)
+          (REPOPAGER
+            (repoOpts.hasKVPs[0].key . tag)
+            (PARTIALREPOS
+              (ZOEKTREPOSUBSETTEXTSEARCH
+                (query . substr:"foo")
+                (type . text))))
+          (REPOPAGER
+            (repoOpts.hasKVPs[0].key . tag)
+            (PARTIALREPOS
+              (SEARCHERTEXTSEARCH
+                (indexed . false)))))
+        (REPOSCOMPUTEEXCLUDED
+          (repoOpts.hasKVPs[0].key . tag))
+        (PARALLEL
+          NoopJob
+          (REPOSEARCH
+            (repoOpts.repoFilters.0 . foo)(repoOpts.hasKVPs[0].key . tag)
+            (repoNamePatterns . [(?i)foo])))))))`),
+		}, {
 			query:      `(...)`,
 			protocol:   search.Streaming,
 			searchType: query.SearchTypeStructural,


### PR DESCRIPTION
Title says it pretty much, noticed this predicate didn't behave as expected.

Before:
![repo_kvps_zoektglobal_before](https://user-images.githubusercontent.com/70350613/203215660-e4b62b46-5461-4dc9-a900-8c119a2b28d9.png)

After:
![repo_kvps_zoektglobal_after](https://user-images.githubusercontent.com/70350613/203215674-080ec514-66d3-4af1-944c-fe12909a98a7.png)

## Test plan
Manually tested
Added unit test
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
