### PR TITLE
web: fix error count on SiteAdminWebhookPage, remove external services count.

### DIFF
--- a/client/web/src/site-admin/SiteAdminWebhookPage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookPage.story.tsx
@@ -13,7 +13,7 @@ import { WebhookFields, WebhookLogFields } from '../graphql-operations'
 
 import { WEBHOOK_BY_ID } from './backend'
 import { SiteAdminWebhookPage } from './SiteAdminWebhookPage'
-import { WEBHOOK_LOG_PAGE_HEADER, WEBHOOK_LOGS_BY_ID } from './webhooks/backend'
+import { WEBHOOK_BY_ID_LOG_PAGE_HEADER, WEBHOOK_LOGS_BY_ID } from './webhooks/backend'
 import { BODY_JSON, BODY_PLAIN, HEADERS_JSON, HEADERS_PLAIN } from './webhooks/story/fixtures'
 
 const decorator: DecoratorFn = Story => <Story />
@@ -60,8 +60,8 @@ export const SiteAdminWebhookPageStory: Story = args => {
                 data: {
                     webhookLogs: {
                         nodes: WEBHOOK_MOCK_DATA,
-                        pageInfo: { hasNextPage: true },
-                        totalCount: 40,
+                        pageInfo: { hasNextPage: false },
+                        totalCount: 20,
                     },
                 },
             },
@@ -82,20 +82,22 @@ export const SiteAdminWebhookPageStory: Story = args => {
                 data: {
                     webhookLogs: {
                         nodes: ERRORED_WEBHOOK_MOCK_DATA,
-                        pageInfo: { hasNextPage: true },
-                        totalCount: 40,
+                        pageInfo: { hasNextPage: false },
+                        totalCount: 20,
                     },
                 },
             },
             nMatches: Number.POSITIVE_INFINITY,
         },
         {
-            request: { query: getDocumentNode(WEBHOOK_LOG_PAGE_HEADER) },
+            request: {
+                query: getDocumentNode(WEBHOOK_BY_ID_LOG_PAGE_HEADER),
+                variables: {
+                    webhookID: '1',
+                },
+            },
             result: {
                 data: {
-                    externalServices: {
-                        totalCount: 5,
-                    },
                     webhookLogs: {
                         totalCount: 13,
                     },

--- a/client/web/src/site-admin/SiteAdminWebhookPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookPage.tsx
@@ -98,7 +98,7 @@ export const SiteAdminWebhookPage: FC<WebhookPageProps> = props => {
             )}
 
             <H2>Logs</H2>
-            <WebhookInfoLogPageHeader onlyErrors={onlyErrors} onSetOnlyErrors={setOnlyErrors} />
+            <WebhookInfoLogPageHeader webhookID={id} onlyErrors={onlyErrors} onSetOnlyErrors={setOnlyErrors} />
 
             <ConnectionContainer className="mt-5">
                 {error && <ConnectionError errors={[error.message]} />}

--- a/client/web/src/site-admin/WebhookInfoLogPageHeader.module.scss
+++ b/client/web/src/site-admin/WebhookInfoLogPageHeader.module.scss
@@ -21,10 +21,6 @@
     grid-column: 1 / 2;
 }
 
-.services {
-    grid-column: 2 / 3;
-}
-
 .buttons {
     grid-column: 4 / 5;
     align-self: end;

--- a/client/web/src/site-admin/WebhookInfoLogPageHeader.tsx
+++ b/client/web/src/site-admin/WebhookInfoLogPageHeader.tsx
@@ -6,39 +6,40 @@ import classNames from 'classnames'
 import { useQuery } from '@sourcegraph/http-client'
 import { Button, Icon } from '@sourcegraph/wildcard'
 
-import { WebhookLogPageHeaderResult } from '../graphql-operations'
+import { WebhookByIDLogPageHeaderResult } from '../graphql-operations'
 
-import { WEBHOOK_LOG_PAGE_HEADER } from './webhooks/backend'
+import { WEBHOOK_BY_ID_LOG_PAGE_HEADER } from './webhooks/backend'
 import { PerformanceGauge } from './webhooks/PerformanceGauge'
 
 import styles from './WebhookInfoLogPageHeader.module.scss'
 
 export interface Props {
+    webhookID: string
     onlyErrors: boolean
 
     onSetOnlyErrors: (onlyErrors: boolean) => void
 }
 
 export const WebhookInfoLogPageHeader: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
+    webhookID,
     onlyErrors,
     onSetOnlyErrors: onSetErrors,
 }) => {
     const onErrorToggle = useCallback(() => onSetErrors(!onlyErrors), [onlyErrors, onSetErrors])
 
-    const { data } = useQuery<WebhookLogPageHeaderResult>(WEBHOOK_LOG_PAGE_HEADER, {})
+    const { data } = useQuery<WebhookByIDLogPageHeaderResult>(WEBHOOK_BY_ID_LOG_PAGE_HEADER, {
+        variables: { webhookID },
+    })
     const errorCount = data?.webhookLogs.totalCount ?? 0
 
     return (
         <div className={styles.grid}>
             <div className={styles.errors}>
                 <PerformanceGauge
-                    count={data?.webhookLogs.totalCount}
+                    count={errorCount}
                     countClassName={errorCount > 0 ? 'text-danger' : undefined}
                     label="recent error"
                 />
-            </div>
-            <div className={styles.services}>
-                <PerformanceGauge count={data?.externalServices.totalCount} label="external service" />
             </div>
             <div className={styles.buttons}>
                 <Button variant="danger" onClick={onErrorToggle} outline={!onlyErrors}>

--- a/client/web/src/site-admin/webhooks/backend.ts
+++ b/client/web/src/site-admin/webhooks/backend.ts
@@ -182,3 +182,11 @@ export const WEBHOOK_LOGS_BY_ID = gql`
         }
     }
 `
+
+export const WEBHOOK_BY_ID_LOG_PAGE_HEADER = gql`
+    query WebhookByIDLogPageHeader($webhookID: ID!) {
+        webhookLogs(webhookID: $webhookID, onlyErrors: true) {
+            totalCount
+        }
+    }
+`


### PR DESCRIPTION
## Before (s2)
<img width="926" alt="image" src="https://user-images.githubusercontent.com/94846361/203265136-ef838abd-451d-4b05-a64f-fe0930ad9ff4.png">

## After (locally, all logs)
<img width="927" alt="image" src="https://user-images.githubusercontent.com/94846361/203265288-901260a3-cbe9-4996-a553-163816a561a6.png">

## After (locally, only errors)
<img width="925" alt="image" src="https://user-images.githubusercontent.com/94846361/203265393-d4156854-62e5-4294-a179-135e85ad1636.png">

Test plan:
Storybook tests updated, local sg run with visual checks.

Closes https://github.com/sourcegraph/sourcegraph/issues/44696

## App preview:

- [Web](https://sg-web-ao-ui-webhooks-fix-error-counter.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
