### PR TITLE
Revert "Do not run useless final sync for deleted external service (#44549)"

### DIFF
--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
+	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -173,36 +174,53 @@ func (r *schemaResolver) DeleteExternalService(ctx context.Context, args *delete
 		return nil, err
 	}
 
-	// 🚨 SECURITY: check external service access
-	if err = backend.CheckExternalServiceAccess(ctx, r.db); err != nil {
-		return nil, err
-	}
-
 	id, err := UnmarshalExternalServiceID(args.ExternalService)
 	if err != nil {
 		return nil, err
 	}
 
-	// Load external service to make sure it exists
-	_, err = r.db.ExternalServices().GetByID(ctx, id)
+	es, err := r.db.ExternalServices().GetByID(ctx, id)
 	if err != nil {
+		return nil, err
+	}
+
+	// 🚨 SECURITY: check external service access
+	if err = backend.CheckExternalServiceAccess(ctx, r.db); err != nil {
 		return nil, err
 	}
 
 	if args.Async {
 		// run deletion in the background and return right away
 		go func() {
-			if err := r.db.ExternalServices().Delete(ctx, id); err != nil {
-				r.logger.Error("Background external service deletion failed", log.Error(err))
+			if err := r.deleteExternalService(context.Background(), id, es); err != nil {
+				log15.Error("Background external service deletion failed", "err", err)
 			}
 		}()
 	} else {
-		if err := r.db.ExternalServices().Delete(ctx, id); err != nil {
+		if err = r.deleteExternalService(ctx, id, es); err != nil {
 			return nil, err
 		}
 	}
 
 	return &EmptyResponse{}, nil
+}
+
+func (r *schemaResolver) deleteExternalService(ctx context.Context, id int64, es *types.ExternalService) error {
+	if err := r.db.ExternalServices().Delete(ctx, id); err != nil {
+		return err
+	}
+	now := time.Now()
+	es.DeletedAt = now
+
+	// The user doesn't care if triggering syncing failed when deleting a
+	// service, so kick off in the background.
+	go func() {
+		if err := backend.SyncExternalService(context.Background(), r.logger, es, syncExternalServiceTimeout, r.repoupdaterClient); err != nil {
+			log15.Warn("Performing final sync after external service deletion", "err", err)
+		}
+	}()
+
+	return nil
 }
 
 type ExternalServicesArgs struct {

--- a/internal/gqltestutil/external_service.go
+++ b/internal/gqltestutil/external_service.go
@@ -93,15 +93,29 @@ mutation UpdateExternalService($input: UpdateExternalServiceInput!) {
 // This method requires the authenticated user to be a site admin.
 func (c *Client) DeleteExternalService(id string, async bool) error {
 	const query = `
-mutation DeleteExternalService($externalService: ID!, $async: Boolean!) {
-	deleteExternalService(externalService: $externalService, async: $async) {
+mutation DeleteExternalService($externalService: ID!) {
+	 deleteExternalService(externalService: $externalService) {
 		alwaysNil
 	}
 }
 `
-	variables := map[string]any{"externalService": id, "async": async}
+	const asyncQuery = `
+mutation DeleteExternalService($externalService: ID!, $async: Boolean!) {
+	 deleteExternalService(externalService: $externalService, async: $async) {
+		alwaysNil
+	}
+}
+`
+	variables := map[string]any{
+		"externalService": id,
+	}
+	q := query
+	if async {
+		q = asyncQuery
+		variables["async"] = true
+	}
 
-	err := c.GraphQL("", query, variables, nil)
+	err := c.GraphQL("", q, variables, nil)
 	if err != nil {
 		return errors.Wrap(err, "request GraphQL")
 	}


### PR DESCRIPTION
This reverts commit b1dbc12a7631a5285e016ecb197f04d77a3d8275.

It broke backend integration tests: https://buildkite.com/sourcegraph/sourcegraph/builds/184661#01849f2d-62f7-4eea-afc9-91300f862ad6

## Test plan

- N/A
