### PR TITLE
Restore #44549 by making test more resilient and using context.Background

### DIFF
--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -173,53 +173,36 @@ func (r *schemaResolver) DeleteExternalService(ctx context.Context, args *delete
 		return nil, err
 	}
 
+	// 🚨 SECURITY: check external service access
+	if err = backend.CheckExternalServiceAccess(ctx, r.db); err != nil {
+		return nil, err
+	}
+
 	id, err := UnmarshalExternalServiceID(args.ExternalService)
 	if err != nil {
 		return nil, err
 	}
 
-	es, err := r.db.ExternalServices().GetByID(ctx, id)
+	// Load external service to make sure it exists
+	_, err = r.db.ExternalServices().GetByID(ctx, id)
 	if err != nil {
-		return nil, err
-	}
-
-	// 🚨 SECURITY: check external service access
-	if err = backend.CheckExternalServiceAccess(ctx, r.db); err != nil {
 		return nil, err
 	}
 
 	if args.Async {
 		// run deletion in the background and return right away
 		go func() {
-			if err := r.deleteExternalService(context.Background(), id, es); err != nil {
+			if err := r.db.ExternalServices().Delete(ctx, id); err != nil {
 				r.logger.Error("Background external service deletion failed", log.Error(err))
 			}
 		}()
 	} else {
-		if err = r.deleteExternalService(ctx, id, es); err != nil {
+		if err := r.db.ExternalServices().Delete(ctx, id); err != nil {
 			return nil, err
 		}
 	}
 
 	return &EmptyResponse{}, nil
-}
-
-func (r *schemaResolver) deleteExternalService(ctx context.Context, id int64, es *types.ExternalService) error {
-	if err := r.db.ExternalServices().Delete(ctx, id); err != nil {
-		return err
-	}
-	now := time.Now()
-	es.DeletedAt = now
-
-	// The user doesn't care if triggering syncing failed when deleting a
-	// service, so kick off in the background.
-	go func() {
-		if err := backend.SyncExternalService(context.Background(), r.logger, es, syncExternalServiceTimeout, r.repoupdaterClient); err != nil {
-			r.logger.Warn("Performing final sync after external service deletion", log.Error(err))
-		}
-	}()
-
-	return nil
 }
 
 type ExternalServicesArgs struct {

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -192,7 +192,7 @@ func (r *schemaResolver) DeleteExternalService(ctx context.Context, args *delete
 	if args.Async {
 		// run deletion in the background and return right away
 		go func() {
-			if err := r.db.ExternalServices().Delete(ctx, id); err != nil {
+			if err := r.db.ExternalServices().Delete(context.Background(), id); err != nil {
 				r.logger.Error("Background external service deletion failed", log.Error(err))
 			}
 		}()

--- a/dev/gqltest/external_service_test.go
+++ b/dev/gqltest/external_service_test.go
@@ -306,7 +306,7 @@ func TestExternalService_AsyncDeletion(t *testing.T) {
 	}
 
 	// This call should return not found error. Retrying for 5 seconds to wait for async deletion to finish
-	err = gqltestutil.Retry(5*time.Second, func() error {
+	err = gqltestutil.Retry(60*time.Second, func() error {
 		_, err = client.UpdateExternalService(gqltestutil.UpdateExternalServiceInput{ID: esID})
 		if err == nil {
 			return gqltestutil.ErrContinueRetry

--- a/dev/gqltest/external_service_test.go
+++ b/dev/gqltest/external_service_test.go
@@ -300,14 +300,18 @@ func TestExternalService_AsyncDeletion(t *testing.T) {
 	if err != nil && !strings.Contains(err.Error(), "/sync-external-service") {
 		t.Fatal(err)
 	}
+
 	err = client.DeleteExternalService(esID, true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// This call should return not found error. Retrying for 5 seconds to wait for async deletion to finish
-	err = gqltestutil.Retry(60*time.Second, func() error {
-		_, err = client.UpdateExternalService(gqltestutil.UpdateExternalServiceInput{ID: esID})
+	// This call should return not found error.
+	// Retrying to wait for async deletion to finish. Deletion
+	// might be blocked on the first sync of the external service still
+	// running. It cancels that syncs and waits for it to finish.
+	err = gqltestutil.Retry(30*time.Second, func() error {
+		err = client.CheckExternalService(esID)
 		if err == nil {
 			return gqltestutil.ErrContinueRetry
 		}

--- a/internal/gqltestutil/external_service.go
+++ b/internal/gqltestutil/external_service.go
@@ -93,29 +93,15 @@ mutation UpdateExternalService($input: UpdateExternalServiceInput!) {
 // This method requires the authenticated user to be a site admin.
 func (c *Client) DeleteExternalService(id string, async bool) error {
 	const query = `
-mutation DeleteExternalService($externalService: ID!) {
-	 deleteExternalService(externalService: $externalService) {
-		alwaysNil
-	}
-}
-`
-	const asyncQuery = `
 mutation DeleteExternalService($externalService: ID!, $async: Boolean!) {
-	 deleteExternalService(externalService: $externalService, async: $async) {
+	deleteExternalService(externalService: $externalService, async: $async) {
 		alwaysNil
 	}
 }
 `
-	variables := map[string]any{
-		"externalService": id,
-	}
-	q := query
-	if async {
-		q = asyncQuery
-		variables["async"] = true
-	}
+	variables := map[string]any{"externalService": id, "async": async}
 
-	err := c.GraphQL("", q, variables, nil)
+	err := c.GraphQL("", query, variables, nil)
 	if err != nil {
 		return errors.Wrap(err, "request GraphQL")
 	}

--- a/internal/gqltestutil/external_service.go
+++ b/internal/gqltestutil/external_service.go
@@ -88,6 +88,34 @@ mutation UpdateExternalService($input: UpdateExternalServiceInput!) {
 	return resp.Data.UpdateExternalService.ID, nil
 }
 
+// CheckExternalService checks whether the external service exists.
+//
+// This method requires the authenticated user to be a site admin.
+func (c *Client) CheckExternalService(id string) error {
+	const query = `
+mutation CheckExternalService($id: ID!) {
+	node(id: $input) {
+		... on ExternalService {
+			id
+		}
+	}
+}
+`
+	variables := map[string]any{"id": id}
+	var resp struct {
+		Data struct {
+			Node struct {
+				ID string `json:"id"`
+			} `json:"node"`
+		} `json:"data"`
+	}
+	err := c.GraphQL("", query, variables, &resp)
+	if err != nil {
+		return errors.Wrap(err, "request GraphQL")
+	}
+	return nil
+}
+
 // DeleteExternalService deletes the external service by given GraphQL node ID.
 //
 // This method requires the authenticated user to be a site admin.

--- a/internal/gqltestutil/external_service.go
+++ b/internal/gqltestutil/external_service.go
@@ -93,8 +93,8 @@ mutation UpdateExternalService($input: UpdateExternalServiceInput!) {
 // This method requires the authenticated user to be a site admin.
 func (c *Client) CheckExternalService(id string) error {
 	const query = `
-mutation CheckExternalService($id: ID!) {
-	node(id: $input) {
+query CheckExternalService($id: ID!) {
+	node(id: $id) {
 		... on ExternalService {
 			id
 		}


### PR DESCRIPTION
This restores  #44549 which was reverted in #44702 since it broke tests on `main`.

The fix here is to use `context.Background()` and also wait a longer time for the external service to be deleted, since we now block deletion on the sync job to be canceled. I also made the "check" a bit more clear by adding a dedicated query instead of an update-mutation that's supposed to fail.

## Test plan

- These tests here
