### PR TITLE
Update slow graphql logging code to the new logger

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -14,10 +13,9 @@ import (
 	"github.com/graph-gophers/graphql-go/introspection"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/graph-gophers/graphql-go/trace"
-	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	sglog "github.com/sourcegraph/log"
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -47,7 +45,7 @@ var (
 type requestTracer struct {
 	DB     database.DB
 	tracer trace.OpenTracingTracer
-	logger sglog.Logger
+	logger log.Logger
 }
 
 func (t *requestTracer) TraceQuery(ctx context.Context, queryString string, operationName string, variables map[string]any, varTypes map[string]*introspection.Type) (context.Context, trace.TraceQueryFinishFunc) {
@@ -82,8 +80,8 @@ func (t *requestTracer) TraceQuery(ctx context.Context, queryString string, oper
 		if err != nil {
 			t.logger.Error(
 				"failed to marshal JSON for event log argument",
-				sglog.String("eventName", eventName),
-				sglog.Error(err),
+				log.String("eventName", eventName),
+				log.Error(err),
 			)
 		}
 
@@ -103,8 +101,8 @@ func (t *requestTracer) TraceQuery(ctx context.Context, queryString string, oper
 		if err != nil {
 			t.logger.Error(
 				"failed to log event",
-				sglog.String("eventName", eventName),
-				sglog.Error(err),
+				log.String("eventName", eventName),
+				log.Error(err),
 			)
 		}
 	}
@@ -123,19 +121,33 @@ func (t *requestTracer) TraceQuery(ctx context.Context, queryString string, oper
 		}
 		d := time.Since(start)
 		if v := conf.Get().ObservabilityLogSlowGraphQLRequests; v != 0 && d.Milliseconds() > int64(v) {
-			encodedVariables, _ := json.Marshal(variables)
-			log15.Warn("slow GraphQL request", "time", d, "name", requestName, "userID", currentUserID, "source", requestSource, "error", err, "variables", string(encodedVariables))
+			variablesFields := make([]log.Field, 0, len(variables))
+			for k, v := range variables {
+				enc, _ := json.Marshal(v)
+				variablesFields = append(variablesFields, log.String(k, string(enc)))
+			}
+			t.logger.Warn(
+				"slow GraphQL request",
+				log.Duration("duration", d),
+				log.Int32("user_id", currentUserID),
+				log.String("request_name", requestName),
+				log.String("source", string(requestSource)),
+				log.Object("variables", variablesFields...),
+			)
 			if requestName == "unknown" {
-				log.Printf(`logging complete query for slow GraphQL request above time=%v name=%s userID=%d source=%s error=%v:
-QUERY
------
-%s
-
-VARIABLES
----------
-%s
-
-`, d, requestName, currentUserID, requestSource, err, queryString, encodedVariables)
+				errFields := make([]string, 0, len(err))
+				for _, e := range err {
+					errFields = append(errFields, e.Error())
+				}
+				t.logger.Info(
+					"slow unknown GraphQL request",
+					log.Duration("duration", d),
+					log.Int32("user_id", currentUserID),
+					log.Strings("errors", errFields),
+					log.String("query", queryString),
+					log.String("source", string(requestSource)),
+					log.Object("variables", variablesFields...),
+				)
 			}
 		}
 	}
@@ -506,7 +518,7 @@ func NewSchema(
 		}
 	}
 
-	logger := sglog.Scoped("GraphQL", "general GraphQL logging")
+	logger := log.Scoped("GraphQL", "general GraphQL logging")
 	return graphql.ParseSchema(
 		strings.Join(schemas, "\n"),
 		resolver,
@@ -524,7 +536,7 @@ func NewSchema(
 //
 // schemaResolver must be instantiated using newSchemaResolver.
 type schemaResolver struct {
-	logger            sglog.Logger
+	logger            log.Logger
 	db                database.DB
 	gitserverClient   gitserver.Client
 	repoupdaterClient *repoupdater.Client
@@ -550,7 +562,7 @@ type schemaResolver struct {
 // defaults. It does not implement any sub-resolvers.
 func newSchemaResolver(db database.DB, gitserverClient gitserver.Client) *schemaResolver {
 	r := &schemaResolver{
-		logger:            sglog.Scoped("schemaResolver", "GraphQL schema resolver"),
+		logger:            log.Scoped("schemaResolver", "GraphQL schema resolver"),
 		db:                db,
 		gitserverClient:   gitserverClient,
 		repoupdaterClient: repoupdater.DefaultClient,

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -121,18 +121,14 @@ func (t *requestTracer) TraceQuery(ctx context.Context, queryString string, oper
 		}
 		d := time.Since(start)
 		if v := conf.Get().ObservabilityLogSlowGraphQLRequests; v != 0 && d.Milliseconds() > int64(v) {
-			variablesFields := make([]log.Field, 0, len(variables))
-			for k, v := range variables {
-				enc, _ := json.Marshal(v)
-				variablesFields = append(variablesFields, log.String(k, string(enc)))
-			}
+			enc, _ := json.Marshal(variables)
 			t.logger.Warn(
 				"slow GraphQL request",
 				log.Duration("duration", d),
 				log.Int32("user_id", currentUserID),
 				log.String("request_name", requestName),
 				log.String("source", string(requestSource)),
-				log.Object("variables", variablesFields...),
+				log.String("variables", string(enc)),
 			)
 			if requestName == "unknown" {
 				errFields := make([]string, 0, len(err))
@@ -146,7 +142,7 @@ func (t *requestTracer) TraceQuery(ctx context.Context, queryString string, oper
 					log.Strings("errors", errFields),
 					log.String("query", queryString),
 					log.String("source", string(requestSource)),
-					log.Object("variables", variablesFields...),
+					log.String("variables", string(enc)),
 				)
 			}
 		}


### PR DESCRIPTION
After working with a customer to parse these logs, it was obvious that having to write regexps to properly parse this should be fixed. 

The new code simply uses the new structured logger, making the output much easier to parse. 

```
WARN GraphQL graphqlbackend/graphqlbackend.go:125 slow GraphQL request {"duration": "13.599625ms", "user_id": 1, "request_name": "EvaluateFeatureFlag", "source": "browser", "variables": "{\"flagName\":\"contrast-compliant-syntax-highlighting\"}"}
```

Because we strongly discourage blindly dumping objects in the logs, there is no primitive available for that purpose in `sourcegraph/log`. Therefore, in this special case, it's just being dumped as JSON. 

It's still annoying to parse because not all GraphQL requests name the repo variable the same way, so this still requires so ad-hoc tricks to extract. 

Coincidentally, this removes the last bit of `log15` from that file. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Locally tested. 