### PR TITLE
Always disable user external service mode in UI

### DIFF
--- a/client/web/src/user/settings/cloud-ga.ts
+++ b/client/web/src/user/settings/cloud-ga.ts
@@ -4,7 +4,7 @@ import { UserAreaUserFields, Scalars } from '../../graphql-operations'
 type Scopes = string[] | null
 
 export interface UserProps {
-    user: Pick<UserAreaUserFields, 'id' | 'tags' | 'builtinAuth'>
+    user: Pick<UserAreaUserFields, 'id' | 'builtinAuth'>
     authenticatedUser: Pick<AuthenticatedUser, 'id' | 'tags'>
 }
 
@@ -15,12 +15,11 @@ export interface Owner {
     name?: string
 }
 
-export const externalServiceUserMode = (props: UserProps): 'disabled' | 'public' | 'all' | 'unknown' =>
-    externalServiceUserModeFromTags(props.user.tags || [])
+export const externalServiceUserMode = (): 'disabled' | 'public' | 'all' | 'unknown' => 'disabled'
 
 export const showPasswordsPage = (props: UserProps): boolean => {
     // user is signed-in with builtin Auth and External Service is not public
-    const mode = externalServiceUserMode(props)
+    const mode = externalServiceUserMode()
     return props.user.builtinAuth && (mode === 'disabled' || mode === 'unknown')
 }
 

--- a/dev/site-config.json
+++ b/dev/site-config.json
@@ -10,6 +10,5 @@
   "update.channel": "release",
   "experimentalFeatures": {},
   "disablePublicRepoRedirects": true,
-  "repoListUpdateInterval": 1,
-  "externalService.userMode": "all"
+  "repoListUpdateInterval": 1
 }


### PR DESCRIPTION
In a following PR, I want to fix a double fetch error which will be easier to fix if this is already in place. Since we don't intend to use this, it feels safe to me to remove.



## Test plan

Prayer.

## App preview:

- [Web](https://sg-web-es-rm-extsvc-user.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
