### PR TITLE
Prevent double-fetching user before rendering UserArea

### DIFF
--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -72,7 +72,7 @@ export const CloudSignUpPage: React.FunctionComponent<React.PropsWithChildren<Pr
 
     const invitedBy = queryWithUseEmailToggled.get('invitedBy')
     const { data } = useQuery<UserAreaUserProfileResult, UserAreaUserProfileVariables>(USER_AREA_USER_PROFILE, {
-        variables: { username: invitedBy || '', siteAdmin: false },
+        variables: { username: invitedBy || '' },
         skip: !invitedBy,
     })
     const invitedByUser = data?.user

--- a/client/web/src/user/area/UserArea.tsx
+++ b/client/web/src/user/area/UserArea.tsx
@@ -45,12 +45,11 @@ export const UserAreaGQLFragment = gql`
         avatarURL
         viewerCanAdminister
         builtinAuth
-        tags @include(if: $siteAdmin)
     }
 `
 
 export const USER_AREA_USER_PROFILE = gql`
-    query UserAreaUserProfile($username: String!, $siteAdmin: Boolean!) {
+    query UserAreaUserProfile($username: String!) {
         user(username: $username) {
             ...UserAreaUserFields
         }
@@ -136,7 +135,7 @@ export const UserArea: React.FunctionComponent<React.PropsWithChildren<UserAreaP
     const { data, error, loading, previousData } = useQuery<UserAreaUserProfileResult, UserAreaUserProfileVariables>(
         USER_AREA_USER_PROFILE,
         {
-            variables: { username, siteAdmin: Boolean(props.authenticatedUser?.siteAdmin) },
+            variables: { username },
         }
     )
 
@@ -157,7 +156,11 @@ export const UserArea: React.FunctionComponent<React.PropsWithChildren<UserAreaP
     const user = data?.user ?? previousData?.user
 
     if (loading && !user) {
-        return null
+        return (
+            <div className="w-100 text-center">
+                <LoadingSpinner className="m-2" />
+            </div>
+        )
     }
 
     if (error) {


### PR DESCRIPTION
There's a race condition on slower networks where authenticatedUser would be null initially and the user area user request has to run, then the siteAdmin flag changes to true, and then it has to run again before the UI is properly rendered. I fixed it by removing the tags field, which should be unused after the PR this one is stacked on top of. 
It makes loading the page a bit faster. Also added a missing loader that caused a small blip that felt weird.

## Test plan

Verified there is no double request anymore.

## App preview:

- [Web](https://sg-web-es-no-double-fetch-user.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
