### PR TITLE
batches: Don't render 404 page for preview

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
@@ -288,7 +288,10 @@ const MemoizedExecuteBatchSpecContent: React.FunctionComponent<
                         )}
                         exact={true}
                     />
-                ) : null}
+                ) : (
+                    // If the batch spec is not ready to be previewed, redirect to the spec instead.
+                    <Redirect to={`${match.url}/spec`} />
+                )}
                 <Route component={() => <HeroPage icon={MapSearchIcon} title="404: Not Found" />} key="hardcoded-key" />
             </Switch>
         </div>


### PR DESCRIPTION
If the preview is not ready yet, we would've rendered a 404 page. This is not super nice, so I decided to make it a redirect to the spec tab instead.



## Test plan

Verified the redirect works.

## App preview:

- [Web](https://sg-web-es-redirect-preview-nonono.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
