### PR TITLE
Properly center BatchChangeStatsBar

### DIFF
--- a/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
@@ -45,19 +45,19 @@ export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildre
         <div className={classNames(styles.statsBar, 'text-muted d-block d-sm-flex')}>
             <div className={styles.leftSide}>
                 <div className="pr-4">
-                    <H3 className="font-weight-bold">
+                    <H3 className="font-weight-bold mb-0">
                         <span className="d-block mb-1">{data.batchChanges.totalCount}</span>
                         <span className={styles.statLabel}>Batch changes</span>
                     </H3>
                 </div>
                 <div className="pr-4">
-                    <H3 className="font-weight-bold">
+                    <H3 className="font-weight-bold mb-0">
                         <span className="d-block mb-1">{data.globalChangesetsStats.merged}</span>
                         <span className={styles.statLabel}>Changesets merged</span>
                     </H3>
                 </div>
                 <div className="pr-4">
-                    <H3 className="font-weight-bold">
+                    <H3 className="font-weight-bold mb-0">
                         <span className="d-block mb-1">
                             {Math.round((data.globalChangesetsStats.merged * minSavedPerChangeset) / 60).toFixed(2)}
                         </span>


### PR DESCRIPTION
With the headings having some margin at the bottom, the items wouldn't be perfectly centered. This fixes it.

## Test plan

Verified things are centered now.

## App preview:

- [Web](https://sg-web-es-centered-stats-bar.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
