### PR TITLE
executors: Validate worker hostname field is not empty

### DIFF
--- a/enterprise/cmd/frontend/internal/executorqueue/handler/handler.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/handler/handler.go
@@ -77,6 +77,10 @@ func (h *handler[T]) Name() string { return h.QueueOptions.Name }
 // the job record and the locking transaction. If no job is available for processing,
 // a false-valued flag is returned.
 func (h *handler[T]) dequeue(ctx context.Context, metadata executorMetadata) (_ apiclient.Job, dequeued bool, _ error) {
+	if err := validateWorkerHostname(metadata.Name); err != nil {
+		return apiclient.Job{}, false, err
+	}
+
 	// executorName is supposed to be unique.
 	record, dequeued, err := h.Store.Dequeue(ctx, metadata.Name, nil)
 	if err != nil {
@@ -103,6 +107,10 @@ func (h *handler[T]) dequeue(ctx context.Context, metadata executorMetadata) (_ 
 
 // addExecutionLogEntry calls AddExecutionLogEntry for the given job.
 func (h *handler[T]) addExecutionLogEntry(ctx context.Context, executorName string, jobID int, entry workerutil.ExecutionLogEntry) (entryID int, err error) {
+	if err := validateWorkerHostname(executorName); err != nil {
+		return 0, err
+	}
+
 	entryID, err = h.Store.AddExecutionLogEntry(ctx, jobID, entry, store.ExecutionLogEntryOptions{
 		// We pass the WorkerHostname, so the store enforces the record to be owned by this executor. When
 		// the previous executor didn't report heartbeats anymore, but is still alive and reporting logs,
@@ -119,6 +127,10 @@ func (h *handler[T]) addExecutionLogEntry(ctx context.Context, executorName stri
 
 // updateExecutionLogEntry calls UpdateExecutionLogEntry for the given job and entry.
 func (h *handler[T]) updateExecutionLogEntry(ctx context.Context, executorName string, jobID int, entryID int, entry workerutil.ExecutionLogEntry) error {
+	if err := validateWorkerHostname(executorName); err != nil {
+		return err
+	}
+
 	err := h.Store.UpdateExecutionLogEntry(ctx, jobID, entryID, entry, store.ExecutionLogEntryOptions{
 		// We pass the WorkerHostname, so the store enforces the record to be owned by this executor. When
 		// the previous executor didn't report heartbeats anymore, but is still alive and reporting logs,
@@ -135,6 +147,10 @@ func (h *handler[T]) updateExecutionLogEntry(ctx context.Context, executorName s
 
 // markComplete calls MarkComplete for the given job.
 func (h *handler[T]) markComplete(ctx context.Context, executorName string, jobID int) error {
+	if err := validateWorkerHostname(executorName); err != nil {
+		return err
+	}
+
 	ok, err := h.Store.MarkComplete(ctx, jobID, store.MarkFinalOptions{
 		// We pass the WorkerHostname, so the store enforces the record to be owned by this executor. When
 		// the previous executor didn't report heartbeats anymore, but is still alive and reporting state,
@@ -152,6 +168,10 @@ func (h *handler[T]) markComplete(ctx context.Context, executorName string, jobI
 
 // markErrored calls MarkErrored for the given job.
 func (h *handler[T]) markErrored(ctx context.Context, executorName string, jobID int, errorMessage string) error {
+	if err := validateWorkerHostname(executorName); err != nil {
+		return err
+	}
+
 	ok, err := h.Store.MarkErrored(ctx, jobID, errorMessage, store.MarkFinalOptions{
 		// We pass the WorkerHostname, so the store enforces the record to be owned by this executor. When
 		// the previous executor didn't report heartbeats anymore, but is still alive and reporting state,
@@ -169,6 +189,10 @@ func (h *handler[T]) markErrored(ctx context.Context, executorName string, jobID
 
 // markFailed calls MarkFailed for the given job.
 func (h *handler[T]) markFailed(ctx context.Context, executorName string, jobID int, errorMessage string) error {
+	if err := validateWorkerHostname(executorName); err != nil {
+		return err
+	}
+
 	ok, err := h.Store.MarkFailed(ctx, jobID, errorMessage, store.MarkFinalOptions{
 		// We pass the WorkerHostname, so the store enforces the record to be owned by this executor. When
 		// the previous executor didn't report heartbeats anymore, but is still alive and reporting state,
@@ -186,6 +210,10 @@ func (h *handler[T]) markFailed(ctx context.Context, executorName string, jobID 
 
 // heartbeat calls Heartbeat for the given jobs.
 func (h *handler[T]) heartbeat(ctx context.Context, executor types.Executor, ids []int) (knownIDs, cancelIDs []int, err error) {
+	if err := validateWorkerHostname(executor.Hostname); err != nil {
+		return nil, nil, err
+	}
+
 	logger := log.Scoped("heartbeat", "Write this heartbeat to the database")
 
 	// Write this heartbeat to the database so that we can populate the UI with recent executor activity.
@@ -206,6 +234,9 @@ func (h *handler[T]) heartbeat(ctx context.Context, executor types.Executor, ids
 // to be canceled.
 // This endpoint is deprecated and should be removed in Sourcegraph 4.4.
 func (h *handler[T]) canceled(ctx context.Context, executorName string, knownIDs []int) (canceledIDs []int, err error) {
+	if err := validateWorkerHostname(executorName); err != nil {
+		return nil, err
+	}
 	// The Heartbeat method now handles both heartbeats and cancellation. For backcompat,
 	// we fall back to this method.
 	_, canceledIDs, err = h.Store.Heartbeat(ctx, knownIDs, store.HeartbeatOptions{
@@ -215,4 +246,14 @@ func (h *handler[T]) canceled(ctx context.Context, executorName string, knownIDs
 		WorkerHostname: executorName,
 	})
 	return canceledIDs, errors.Wrap(err, "dbworkerstore.CanceledJobs")
+}
+
+// validateWorkerHostname validates the WorkerHostname field sent for all the endpoints.
+// We don't allow empty hostnames, as it would bypass the hostname verification, which
+// could lead to stray workers updating records they no longer own.
+func validateWorkerHostname(hostname string) error {
+	if hostname == "" {
+		return errors.New("worker hostname cannot be empty")
+	}
+	return nil
 }


### PR DESCRIPTION
We don't want to allow empty hostnames, as it would bypass the hostname verification, which could lead to stray workers updating records they no longer own. This is not a security measure, just making sure we don't race for the same record across resets.



## Test plan

Verified things still work.