### PR TITLE
codeintel: add zig to (other) list of languages

### DIFF
--- a/client/shared/src/languages.ts
+++ b/client/shared/src/languages.ts
@@ -565,6 +565,9 @@ function getModeFromExtension(extension: string): string | undefined {
         case 'zcml':
             return 'xml'
 
+        case 'zig':
+            return 'zig'
+
         // YAML
         case 'yml':
         case 'yaml':


### PR DESCRIPTION
Fixes the bug reported on Discord for scip-zig uploads, by adding zig to the _other_ list of languages we have on the web client
![image](https://user-images.githubusercontent.com/18282288/203361140-cee8d2e6-74df-41a2-9c24-3ae84570bf16.png)


## Test plan

Ran locally
