### PR TITLE
Fixup systemd configuration for executor service

### DIFF
--- a/doc/admin/deploy_executors_binary.md
+++ b/doc/admin/deploy_executors_binary.md
@@ -156,10 +156,11 @@ To make sure that the executor runs post-boot of the machine, you might want to 
 cat <<EOF >/etc/systemd/system/executor.service
 [Unit]
 Description=Sourcegraph executor
+After=docker.service
+BindsTo=docker.service
 
 [Service]
 ExecStart=/usr/local/bin/executor
-Requires=docker
 Restart=on-failure
 EnvironmentFile=/etc/systemd/system/executor.env
 Environment=HOME="%h"

--- a/enterprise/cmd/executor/vm-image/install.sh
+++ b/enterprise/cmd/executor/vm-image/install.sh
@@ -99,11 +99,12 @@ function install_executor() {
   cat <<EOF >/etc/systemd/system/executor.service
 [Unit]
 Description=User code executor
+After=docker.service
+BindsTo=docker.service
 
 [Service]
 ExecStart=/usr/local/bin/executor
 ExecStopPost=/shutdown_executor.sh
-Requires=docker
 Restart=on-failure
 EnvironmentFile=/etc/systemd/system/executor.env
 Environment=HOME="%h"


### PR DESCRIPTION
Apparently this has to live under unit. I also re-read the documentation and figured a combination of After and BindsTo might be more what we want.

## Test plan

Saw an error message on an executor saying Requires is not a known property. Indeed so, it belongs in the Unit section. 