### PR TITLE
Fix finding the branch name

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/vcs/GitUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/vcs/GitUtil.java
@@ -34,7 +34,13 @@ public class GitUtil {
     public static boolean doesRemoteBranchExist(@NotNull GitRepository repository, @NotNull String branchName) {
         List<String> remoteBranchNames = repository.getInfo().getRemoteBranchesWithHashes()
             .keySet().stream().map(GitRemoteBranch::getNameForLocalOperations).collect(Collectors.toList());
-        return remoteBranchNames.stream().anyMatch(name -> name.equals(branchName));
+        return remoteBranchNames.stream().anyMatch(name -> {
+            int firstSlashPosition = name.indexOf('/');
+            if (firstSlashPosition != -1) {
+                name = name.substring(firstSlashPosition + 1);
+            }
+            return name.equals(branchName);
+        });
     }
 
     @Nullable


### PR DESCRIPTION
- Fixes https://github.com/sourcegraph/sourcegraph/issues/44609

The problem was that `remoteBranchNames` contained names like `origin/branch-name`, which we only had the local branch name like `branch-name`.

Caveats:
 - If the branch name is not the same on the remote, then this logic won't find it. But this was always the case with our plugin. Now that we use the built-in VCS, this could probably be improved, but I didn't want to do that in this PR.
 - If the name of the remote (usually `origin`) contains a slash for whatever reason, then this logic will fail. But it was likely the same for our old solution.

## Test plan

I've tested it locally, just forgot to make a Loom about it:
- It correctly listed the names of the remote branches (I've debugged it with the Java debugger)
- In the case of a branch that didn't exist on the remote, it correctly opened `main`
- In the case of a branch that existed on the remote, it correctly opened the branch
- I've tested it with a project that had two repos in it, so I can confirm that it also works correctly with multi-repo projects.
