### PR TITLE
Add PageSwitcher wildcard component

### DIFF
--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.module.scss
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.module.scss
@@ -1,0 +1,23 @@
+.list, .label {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 0;
+    margin-right: 0;
+    padding: 0;
+    margin-bottom: 0.625rem;
+}
+
+.list {
+    list-style: none;
+}
+
+.button {
+    min-width: 2rem;
+    padding: 0.25rem 0.5rem;
+
+    &:focus,
+    &:hover {
+        text-decoration: none;
+    }
+}

--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.module.scss
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.module.scss
@@ -21,3 +21,11 @@
         text-decoration: none;
     }
 }
+
+.nextButton, .previousButton {
+    min-width: 5.125rem;
+}
+
+.nextButton {
+    text-align: right;
+}

--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.module.scss
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.module.scss
@@ -25,7 +25,7 @@
 
 .next-button,
 .previous-button {
-    min-width: 6.25rem;
+    min-width: 4.5rem;
     display: flex;
     align-items: center;
 }

--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.module.scss
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.module.scss
@@ -1,4 +1,5 @@
-.list, .label {
+.list,
+.label {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -22,7 +23,8 @@
     }
 }
 
-.next-button, .previous-button {
+.next-button,
+.previous-button {
     min-width: 5.125rem;
 }
 

--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.module.scss
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.module.scss
@@ -25,9 +25,23 @@
 
 .next-button,
 .previous-button {
-    min-width: 5.125rem;
+    min-width: 6.25rem;
+    display: flex;
+    align-items: center;
 }
 
-.next-button {
-    text-align: right;
+.next-button-icon,
+.previous-button-icon {
+    flex-grow: 0;
+}
+
+.next-button-label,
+.previous-button-label {
+    flex-grow: 1;
+    text-align: center;
+}
+
+.first-page-button,
+.last-page-button {
+    fill: currentColor !important;
 }

--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.module.scss
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.module.scss
@@ -22,10 +22,10 @@
     }
 }
 
-.nextButton, .previousButton {
+.next-button, .previous-button {
     min-width: 5.125rem;
 }
 
-.nextButton {
+.next-button {
     text-align: right;
 }

--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.story.tsx
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.story.tsx
@@ -63,3 +63,10 @@ Simple.argTypes = {
         defaultValue: 'pages',
     },
 }
+
+Simple.parameters = {
+    chromatic: {
+        enableDarkMode: true,
+        disableSnapshot: false,
+    },
+}

--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.story.tsx
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.story.tsx
@@ -16,6 +16,17 @@ const config: Meta = {
     title: 'wildcard/PageSwitcher',
     component: PageSwitcher,
     decorators: [decorator],
+    parameters: {
+        component: PageSwitcher,
+        design: [
+            {
+                type: 'figma',
+                name: 'Figma',
+                url:
+                    'https://www.figma.com/file/LZoW17Fy6eqOfnxjxIRB7d/%F0%9F%93%91-Pagination-Experiments?t=0QPBSel9sN03v8us-1',
+            },
+        ],
+    },
 }
 
 export default config

--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.story.tsx
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.story.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react'
+
+import { DecoratorFn, Meta, Story } from '@storybook/react'
+
+import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
+import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
+import { Text } from '@sourcegraph/wildcard'
+
+import { PageSwitcher } from './PageSwitcher'
+
+const decorator: DecoratorFn = story => (
+    <BrandedStory styles={webStyles}>{() => <div className="container mt-3">{story()}</div>}</BrandedStory>
+)
+
+const config: Meta = {
+    title: 'wildcard/PageSwitcher',
+    component: PageSwitcher,
+    decorators: [decorator],
+}
+
+export default config
+
+export const Simple: Story = (args = {}) => {
+    const totalPages = args.totalCount
+
+    const [page, setPage] = useState(1)
+
+    const goToNextPage = () => setPage(page => (page < totalPages ? page + 1 : page))
+    const goToPreviousPage = () => setPage(page => (page > 1 ? page - 1 : page))
+    const goToFirstPage = () => setPage(1)
+    const goToLastPage = () => setPage(totalPages)
+
+    const hasNextPage = page < totalPages
+    const hasPreviousPage = page > 1
+
+    return (
+        <div>
+            <Text alignment="center">
+                Showing page {page} of {totalPages}
+            </Text>
+            <PageSwitcher
+                totalLabel={args.totalLabel}
+                totalCount={args.totalCount}
+                goToNextPage={goToNextPage}
+                goToPreviousPage={goToPreviousPage}
+                goToFirstPage={goToFirstPage}
+                goToLastPage={goToLastPage}
+                hasNextPage={hasNextPage}
+                hasPreviousPage={hasPreviousPage}
+            />
+        </div>
+    )
+}
+Simple.argTypes = {
+    totalCount: {
+        name: 'totalCount',
+        control: { type: 'number' },
+        defaultValue: 5,
+    },
+    totalLabel: {
+        name: 'totalLabel',
+        control: { type: 'string' },
+        defaultValue: 'pages',
+    },
+}

--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.test.tsx
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.test.tsx
@@ -1,4 +1,4 @@
-import { render, RenderResult, cleanup, fireEvent } from '@testing-library/react'
+import { render, RenderResult, cleanup } from '@testing-library/react'
 import sinon from 'sinon'
 
 import { PageSwitcher, PageSwitcherProps } from './PageSwitcher'

--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.test.tsx
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.test.tsx
@@ -1,0 +1,41 @@
+import { render, RenderResult, cleanup, fireEvent } from '@testing-library/react'
+import sinon from 'sinon'
+
+import { PageSwitcher, PageSwitcherProps } from './PageSwitcher'
+
+describe('PageSwitcher', () => {
+    let queries: RenderResult
+    const renderWithProps = (props: PageSwitcherProps): RenderResult => render(<PageSwitcher {...props} />)
+
+    const goToNextPage = sinon.spy()
+    const goToPreviousPage = sinon.spy()
+    const goToFirstPage = sinon.spy()
+    const goToLastPage = sinon.spy()
+
+    beforeEach(() => {
+        goToNextPage.resetHistory()
+        goToPreviousPage.resetHistory()
+        goToFirstPage.resetHistory()
+        goToLastPage.resetHistory()
+    })
+    afterEach(cleanup)
+
+    describe('Simple pagination', () => {
+        beforeEach(() => {
+            queries = renderWithProps({
+                totalLabel: 'elements',
+                totalCount: 10,
+                goToNextPage,
+                goToPreviousPage,
+                goToFirstPage,
+                goToLastPage,
+                hasNextPage: true,
+                hasPreviousPage: false,
+            })
+        })
+
+        it('will render four buttons', () => {
+            expect(queries.getAllByRole('button')).toHaveLength(4)
+        })
+    })
+})

--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.test.tsx
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.test.tsx
@@ -1,10 +1,11 @@
-import { render, RenderResult, cleanup } from '@testing-library/react'
+import { render, RenderResult, cleanup, fireEvent } from '@testing-library/react'
 import sinon from 'sinon'
+
+import { assertAriaDisabled, assertAriaEnabled } from '@sourcegraph/shared/dev/aria-asserts'
 
 import { PageSwitcher, PageSwitcherProps } from './PageSwitcher'
 
 describe('PageSwitcher', () => {
-    let queries: RenderResult
     const renderWithProps = (props: PageSwitcherProps): RenderResult => render(<PageSwitcher {...props} />)
 
     const goToNextPage = sinon.spy()
@@ -12,30 +13,129 @@ describe('PageSwitcher', () => {
     const goToFirstPage = sinon.spy()
     const goToLastPage = sinon.spy()
 
+    let defaultProps: PageSwitcherProps
+
     beforeEach(() => {
         goToNextPage.resetHistory()
         goToPreviousPage.resetHistory()
         goToFirstPage.resetHistory()
         goToLastPage.resetHistory()
+
+        defaultProps = {
+            totalLabel: 'elements',
+            totalCount: 10,
+            goToNextPage,
+            goToPreviousPage,
+            goToFirstPage,
+            goToLastPage,
+            hasNextPage: true,
+            hasPreviousPage: true,
+        }
     })
     afterEach(cleanup)
 
-    describe('Simple pagination', () => {
-        beforeEach(() => {
-            queries = renderWithProps({
-                totalLabel: 'elements',
-                totalCount: 10,
-                goToNextPage,
-                goToPreviousPage,
-                goToFirstPage,
-                goToLastPage,
-                hasNextPage: true,
-                hasPreviousPage: false,
-            })
-        })
+    it('renders the go to first page button', () => {
+        const queries = renderWithProps(defaultProps)
+        const goToFirstPageButton = queries.getByRole('button', { name: 'Go to first page' })
+        expect(goToFirstPageButton).toBeInTheDocument()
+        assertAriaEnabled(goToFirstPageButton)
+        fireEvent.click(goToFirstPageButton)
+        sinon.assert.calledOnce(goToFirstPage)
+    })
 
-        it('will render four buttons', () => {
-            expect(queries.getAllByRole('button')).toHaveLength(4)
-        })
+    it('renders the go to next page button', () => {
+        const queries = renderWithProps(defaultProps)
+        const goToNextPageButton = queries.getByRole('button', { name: 'Go to next page' })
+        expect(goToNextPageButton).toBeInTheDocument()
+        assertAriaEnabled(goToNextPageButton)
+        fireEvent.click(goToNextPageButton)
+        sinon.assert.calledOnce(goToNextPage)
+    })
+
+    it('renders the go to previous page button', () => {
+        const queries = renderWithProps(defaultProps)
+        const goToPreviousPageButton = queries.getByRole('button', { name: 'Go to previous page' })
+        expect(goToPreviousPageButton).toBeInTheDocument()
+        assertAriaEnabled(goToPreviousPageButton)
+        fireEvent.click(goToPreviousPageButton)
+        sinon.assert.calledOnce(goToPreviousPage)
+    })
+
+    it('renders the go to last page button', () => {
+        const queries = renderWithProps(defaultProps)
+        const goToLastPageButton = queries.getByRole('button', { name: 'Go to last page' })
+        expect(goToLastPageButton).toBeInTheDocument()
+        assertAriaEnabled(goToLastPageButton)
+        fireEvent.click(goToLastPageButton)
+        sinon.assert.calledOnce(goToLastPage)
+    })
+
+    it('disables the go to first page and go to previous page button when it has no previous page', () => {
+        const queries = renderWithProps({ ...defaultProps, hasPreviousPage: false })
+        const goToFirstPageButton = queries.getByRole('button', { name: 'Go to first page' })
+        const goToPreviousPageButton = queries.getByRole('button', { name: 'Go to previous page' })
+        expect(goToFirstPageButton).toBeInTheDocument()
+        expect(goToPreviousPageButton).toBeInTheDocument()
+        assertAriaDisabled(goToFirstPageButton)
+        assertAriaDisabled(goToPreviousPageButton)
+        fireEvent.click(goToFirstPageButton)
+        fireEvent.click(goToPreviousPageButton)
+        sinon.assert.notCalled(goToFirstPage)
+        sinon.assert.notCalled(goToPreviousPage)
+    })
+
+    it('disables the go to last page and go to next page button when it has no next page', () => {
+        const queries = renderWithProps({ ...defaultProps, hasNextPage: false })
+        const goToLastPageButton = queries.getByRole('button', { name: 'Go to last page' })
+        const goToNextPageButton = queries.getByRole('button', { name: 'Go to next page' })
+        expect(goToLastPageButton).toBeInTheDocument()
+        expect(goToNextPageButton).toBeInTheDocument()
+        assertAriaDisabled(goToLastPageButton)
+        assertAriaDisabled(goToNextPageButton)
+        fireEvent.click(goToLastPageButton)
+        fireEvent.click(goToNextPageButton)
+        sinon.assert.notCalled(goToLastPage)
+        sinon.assert.notCalled(goToNextPage)
+    })
+
+    it('renders label with total count', () => {
+        const queries = renderWithProps(defaultProps)
+        expect(queries.container.textContent!).toContain('Total elements: 10')
+    })
+
+    it("doesn't render the label when it's not set", () => {
+        const queries = renderWithProps({ ...defaultProps, totalLabel: undefined })
+        expect(queries.container.textContent!).not.toContain('Total')
+    })
+
+    it('renders disabled buttons and no label while loading', () => {
+        const queries = renderWithProps({ ...defaultProps, hasPreviousPage: null, hasNextPage: null, totalCount: null })
+
+        const goToFirstPageButton = queries.getByRole('button', { name: 'Go to first page' })
+        const goToPreviousPageButton = queries.getByRole('button', { name: 'Go to previous page' })
+        const goToNextPageButton = queries.getByRole('button', { name: 'Go to next page' })
+        const goToLastPageButton = queries.getByRole('button', { name: 'Go to last page' })
+
+        expect(goToFirstPageButton).toBeInTheDocument()
+        expect(goToPreviousPageButton).toBeInTheDocument()
+        expect(goToNextPageButton).toBeInTheDocument()
+        expect(goToLastPageButton).toBeInTheDocument()
+
+        assertAriaDisabled(goToFirstPageButton)
+        assertAriaDisabled(goToPreviousPageButton)
+        assertAriaDisabled(goToNextPageButton)
+        assertAriaDisabled(goToLastPageButton)
+
+        fireEvent.click(goToFirstPageButton)
+        fireEvent.click(goToPreviousPageButton)
+        fireEvent.click(goToNextPageButton)
+        fireEvent.click(goToLastPageButton)
+
+        sinon.assert.notCalled(goToFirstPage)
+        sinon.assert.notCalled(goToPreviousPage)
+        sinon.assert.notCalled(goToNextPage)
+        sinon.assert.notCalled(goToLastPage)
+
+        expect(queries.container.textContent!).not.toContain('Total')
     })
 })

--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.tsx
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.tsx
@@ -64,7 +64,7 @@ export const PageSwitcher: React.FunctionComponent<React.PropsWithChildren<PageS
                 </li>
                 <li>
                     <Button
-                        className={classNames(styles.button, 'mx-1')}
+                        className={classNames(styles.button, styles.previousButton, 'mx-1')}
                         aria-label="Go to previous page"
                         variant="secondary"
                         outline={true}
@@ -77,7 +77,7 @@ export const PageSwitcher: React.FunctionComponent<React.PropsWithChildren<PageS
                 </li>
                 <li>
                     <Button
-                        className={classNames(styles.button, 'mx-1')}
+                        className={classNames(styles.button, styles.nextButton, 'mx-1')}
                         aria-label="Go to next page"
                         variant="secondary"
                         outline={true}

--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.tsx
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.tsx
@@ -58,7 +58,7 @@ export const PageSwitcher: React.FunctionComponent<React.PropsWithChildren<PageS
                             disabled={hasPreviousPage !== null ? !hasPreviousPage : true}
                             onClick={goToFirstPage}
                         >
-                            <Icon aria-hidden={true} as={PageFirstIcon} />
+                            <Icon aria-hidden={true} as={PageFirstIcon} className={styles.firstPageButton} />
                         </Button>
                     </Tooltip>
                 </li>
@@ -71,8 +71,12 @@ export const PageSwitcher: React.FunctionComponent<React.PropsWithChildren<PageS
                         disabled={hasPreviousPage !== null ? !hasPreviousPage : true}
                         onClick={goToPreviousPage}
                     >
-                        <Icon aria-hidden={true} as={ChevronLeftIcon} className="mr-1" />
-                        Previous
+                        <Icon
+                            aria-hidden={true}
+                            as={ChevronLeftIcon}
+                            className={classNames('mr-1', styles.previousButtonIcon)}
+                        />
+                        <span className={styles.previousButtonLabel}>Previous</span>
                     </Button>
                 </li>
                 <li>
@@ -84,8 +88,12 @@ export const PageSwitcher: React.FunctionComponent<React.PropsWithChildren<PageS
                         disabled={hasNextPage !== null ? !hasNextPage : true}
                         onClick={goToNextPage}
                     >
-                        Next
-                        <Icon aria-hidden={true} as={ChevronRightIcon} className="ml-1" />
+                        <span className={styles.nextButtonLabel}>Next</span>
+                        <Icon
+                            aria-hidden={true}
+                            as={ChevronRightIcon}
+                            className={classNames('ml-1', styles.nextButtonIcon)}
+                        />
                     </Button>
                 </li>
                 <li>
@@ -98,14 +106,14 @@ export const PageSwitcher: React.FunctionComponent<React.PropsWithChildren<PageS
                             disabled={hasNextPage !== null ? !hasNextPage : true}
                             onClick={goToLastPage}
                         >
-                            <Icon aria-hidden={true} as={PageLastIcon} />
+                            <Icon aria-hidden={true} as={PageLastIcon} className={styles.lastPageButton} />
                         </Button>
                     </Tooltip>
                 </li>
             </ul>
             {totalCount !== null && totalLabel !== undefined ? (
                 <div className={styles.label}>
-                    <Text className="text-muted">
+                    <Text className="text-muted" size="small">
                         Total{' '}
                         <Text weight="bold" as="strong">
                             {totalLabel}

--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.tsx
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.tsx
@@ -1,0 +1,119 @@
+import React from 'react'
+
+import classNames from 'classnames'
+import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'
+import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
+import PageFirstIcon from 'mdi-react/PageFirstIcon'
+import PageLastIcon from 'mdi-react/PageLastIcon'
+
+import { Button } from '../Button'
+import { Icon } from '../Icon'
+import { Tooltip } from '../Tooltip'
+import { Text } from '../Typography'
+
+import styles from './PageSwitcher.module.scss'
+
+export interface PageSwitcherProps {
+    totalLabel?: string
+    totalCount: null | number
+    hasNextPage: null | boolean
+    hasPreviousPage: null | boolean
+    goToNextPage: () => void
+    goToPreviousPage: () => void
+    goToFirstPage: () => void
+    goToLastPage: () => void
+    className?: string
+}
+
+/**
+ * PageSwitcher is used to render pagination control for a cursor-based
+ * pagination.
+ *
+ * It works best together with the `usePageSwitcherPagination` hook and
+ * is our recommended way of implementing pagination.
+ */
+export const PageSwitcher: React.FunctionComponent<React.PropsWithChildren<PageSwitcherProps>> = props => {
+    const {
+        className,
+        totalLabel,
+        totalCount,
+        goToFirstPage,
+        goToPreviousPage,
+        goToNextPage,
+        goToLastPage,
+        hasPreviousPage,
+        hasNextPage,
+    } = props
+
+    return (
+        <nav className={className}>
+            <ul className={styles.list}>
+                <li>
+                    <Tooltip content="First page">
+                        <Button
+                            aria-label="Go to first page"
+                            className={classNames(styles.button, 'mx-3')}
+                            variant="secondary"
+                            outline={true}
+                            disabled={hasPreviousPage !== null ? !hasPreviousPage : true}
+                            onClick={goToFirstPage}
+                        >
+                            <Icon aria-hidden={true} as={PageFirstIcon} />
+                        </Button>
+                    </Tooltip>
+                </li>
+                <li>
+                    <Button
+                        className={classNames(styles.button, 'mx-1')}
+                        aria-label="Go to previous page"
+                        variant="secondary"
+                        outline={true}
+                        disabled={hasPreviousPage !== null ? !hasPreviousPage : true}
+                        onClick={goToPreviousPage}
+                    >
+                        <Icon aria-hidden={true} as={ChevronLeftIcon} className="mr-1" />
+                        Previous
+                    </Button>
+                </li>
+                <li>
+                    <Button
+                        className={classNames(styles.button, 'mx-1')}
+                        aria-label="Go to next page"
+                        variant="secondary"
+                        outline={true}
+                        disabled={hasNextPage !== null ? !hasNextPage : true}
+                        onClick={goToNextPage}
+                    >
+                        Next
+                        <Icon aria-hidden={true} as={ChevronRightIcon} className="ml-1" />
+                    </Button>
+                </li>
+                <li>
+                    <Tooltip content="Last page">
+                        <Button
+                            aria-label="Go to last page"
+                            className={classNames(styles.button, 'mx-3')}
+                            variant="secondary"
+                            outline={true}
+                            disabled={hasNextPage !== null ? !hasNextPage : true}
+                            onClick={goToLastPage}
+                        >
+                            <Icon aria-hidden={true} as={PageLastIcon} />
+                        </Button>
+                    </Tooltip>
+                </li>
+            </ul>
+            {totalCount !== null && totalLabel !== undefined ? (
+                <div className={styles.label}>
+                    <Text className="text-muted">
+                        Total{' '}
+                        <Text weight="bold" as="strong">
+                            {totalLabel}
+                        </Text>
+                        : {totalCount}
+                    </Text>
+                </div>
+            ) : null}
+        </nav>
+    )
+}

--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.tsx
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.tsx
@@ -76,7 +76,7 @@ export const PageSwitcher: React.FunctionComponent<React.PropsWithChildren<PageS
                             as={ChevronLeftIcon}
                             className={classNames('mr-1', styles.previousButtonIcon)}
                         />
-                        <span className={styles.previousButtonLabel}>Previous</span>
+                        <span className={styles.previousButtonLabel}>Prev</span>
                     </Button>
                 </li>
                 <li>

--- a/client/wildcard/src/components/PageSwitcher/index.tsx
+++ b/client/wildcard/src/components/PageSwitcher/index.tsx
@@ -1,0 +1,1 @@
+export * from './PageSwitcher'


### PR DESCRIPTION
Part of #44706

This adds a new `<PageSwitcher />` (I’m open to better name suggestions, this one is derived from the proposal to call the hook `usePageSwitcherPagination`) component to the set of Wildcard components:

<img width="291" alt="Screenshot 2022-11-23 at 14 33 05" src="https://user-images.githubusercontent.com/458591/203559559-68dd6df4-87c3-4e9c-8b1e-e50607060d83.png">

Figma: https://www.figma.com/file/LZoW17Fy6eqOfnxjxIRB7d/%F0%9F%93%91-Pagination-Experiments?t=0QPBSel9sN03v8us-1

## Test plan

- https://5f0f381c0e50750022dc6bf7-dvghpbfanb.chromatic.com/?path=/story/wildcard-pageswitcher--simple
- I added some simple unit tests to test the behavior

## App preview:

- [Web](https://sg-web-ps-add-page-switcher-wildcard.onrender.com/search)
- [Storybook](https://5f0f381c0e50750022dc6bf7-dvghpbfanb.chromatic.com/?path=/story/wildcard-pageswitcher--simple)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
