### PR TITLE
JetBrains: Improve remote branch handling

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- 
+- Now the name of the remote can contain slashes
 
 ### Changed
 
@@ -11,7 +13,9 @@
 ### Removed
 
 ### Fixed
+
 - “Open in Browser” and “Copy Link” features now open the correct branch when it exists on the remote. [pull/44735](https://github.com/sourcegraph/sourcegraph/pull/44735)
+- Fixed a bug where if the tracked branch had a different name from the local branch, the local branch name was used in the URL, incorrectly
 
 ### Security
 

--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Fixed
 
-- “Open in Browser” and “Copy Link” features now open the correct branch when it exists on the remote. [pull/44735](https://github.com/sourcegraph/sourcegraph/pull/44735)
+- “Open in Browser” and “Copy Link” features now open the correct branch when it exists on the remote. [pull/44739](https://github.com/sourcegraph/sourcegraph/pull/44739)
 - Fixed a bug where if the tracked branch had a different name from the local branch, the local branch name was used in the URL, incorrectly
 
 ### Security

--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Removed
 
 ### Fixed
+- “Open in Browser” and “Copy Link” features now open the correct branch when it exists on the remote. [pull/44735](https://github.com/sourcegraph/sourcegraph/pull/44735)
 
 ### Security
 

--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- 
+
 - Now the name of the remote can contain slashes
 
 ### Changed

--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### Added
 
-- Now the name of the remote can contain slashes
-
 ### Changed
 
 ### Deprecated
@@ -14,10 +12,18 @@
 
 ### Fixed
 
+### Security
+
+## [2.1.1]
+
+### Added
+
+- Now the name of the remote can contain slashes
+
+### Fixed
+
 - “Open in Browser” and “Copy Link” features now open the correct branch when it exists on the remote. [pull/44739](https://github.com/sourcegraph/sourcegraph/pull/44739)
 - Fixed a bug where if the tracked branch had a different name from the local branch, the local branch name was used in the URL, incorrectly
-
-### Security
 
 ## [2.1.0]
 

--- a/client/jetbrains/gradle.properties
+++ b/client/jetbrains/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup=com.sourcegraph.jetbrains
 pluginName=Sourcegraph
 # SemVer format -> https://semver.org
-pluginVersion=2.1.0
+pluginVersion=2.1.1
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 #  - 2020.2 was the first version to have JCEF enabled by default

--- a/client/jetbrains/src/main/java/com/sourcegraph/vcs/GitUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/vcs/GitUtil.java
@@ -2,6 +2,7 @@ package com.sourcegraph.vcs;
 
 import com.intellij.dvcs.repo.Repository;
 import com.intellij.openapi.project.Project;
+import git4idea.GitLocalBranch;
 import git4idea.GitRemoteBranch;
 import git4idea.repo.GitRemote;
 import git4idea.repo.GitRepository;
@@ -28,19 +29,17 @@ public class GitUtil {
         return url;
     }
 
-    /**
-     * @param branchName E.g. "main"
-     */
-    public static boolean doesRemoteBranchExist(@NotNull GitRepository repository, @NotNull String branchName) {
-        List<String> remoteBranchNames = repository.getInfo().getRemoteBranchesWithHashes()
-            .keySet().stream().map(GitRemoteBranch::getNameForLocalOperations).collect(Collectors.toList());
-        return remoteBranchNames.stream().anyMatch(name -> {
-            int firstSlashPosition = name.indexOf('/');
-            if (firstSlashPosition != -1) {
-                name = name.substring(firstSlashPosition + 1);
-            }
-            return name.equals(branchName);
-        });
+    @Nullable
+    public static String getRemoteBranchName(@NotNull GitRepository repository) {
+        GitLocalBranch localBranch = repository.getCurrentBranch();
+        if (localBranch == null) {
+            return null;
+        }
+        GitRemoteBranch remoteBranch = localBranch.findTrackedBranch(repository);
+        if (remoteBranch == null) {
+            return null;
+        }
+        return remoteBranch.getNameForRemoteOperations();
     }
 
     @Nullable

--- a/client/jetbrains/src/main/java/com/sourcegraph/vcs/GitUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/vcs/GitUtil.java
@@ -34,7 +34,13 @@ public class GitUtil {
     public static boolean doesRemoteBranchExist(@NotNull GitRepository repository, @NotNull String branchName) {
         List<String> remoteBranchNames = repository.getInfo().getRemoteBranchesWithHashes()
             .keySet().stream().map(GitRemoteBranch::getNameForLocalOperations).collect(Collectors.toList());
-        return remoteBranchNames.stream().anyMatch(name -> name.equals(branchName));
+        return remoteBranchNames.stream().anyMatch(name -> {
+            int firstSlashPosition = name.indexOf('/');
+            if (firstSlashPosition != -1) {
+                name = name.substring(firstSlashPosition + 1);
+            }
+            return name.equals(branchName);
+        });
     }
 
     @Nullable

--- a/client/jetbrains/src/main/java/com/sourcegraph/vcs/RepoInfo.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/vcs/RepoInfo.java
@@ -8,14 +8,14 @@ public class RepoInfo {
     @NotNull
     public final String remoteUrl; // E.g. "git@github.com:sourcegraph/sourcegraph.git", with replacements already applied
     @NotNull
-    public final String branchName; // E.g. "main"
+    public final String remoteBranchName; // E.g. "main"
     @NotNull
     public final String relativePath; // E.g. "/client/jetbrains/package.json"
 
-    public RepoInfo(@NotNull VCSType vcsType, @NotNull String remoteUrl, @NotNull String branchName, @NotNull String relativePath) {
+    public RepoInfo(@NotNull VCSType vcsType, @NotNull String remoteUrl, @NotNull String remoteBranchName, @NotNull String relativePath) {
         this.vcsType = vcsType;
         this.remoteUrl = remoteUrl;
-        this.branchName = branchName;
+        this.remoteBranchName = remoteBranchName;
         this.relativePath = relativePath;
     }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/FileActionBase.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/FileActionBase.java
@@ -12,8 +12,8 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.sourcegraph.common.ErrorNotification;
 import com.sourcegraph.find.PreviewContent;
 import com.sourcegraph.find.SourcegraphVirtualFile;
-import com.sourcegraph.vcs.RepoUtil;
 import com.sourcegraph.vcs.RepoInfo;
+import com.sourcegraph.vcs.RepoUtil;
 import com.sourcegraph.vcs.VCSType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -58,7 +58,7 @@ public abstract class FileActionBase extends DumbAwareAction {
                         // Our "editor" backend doesn't support Perforce, but we have all the info we need, so we'll go to the final URL directly.
                         url = URLBuilder.buildSourcegraphBlobUrl(project, repoInfo.getCodeHostUrl() + "/" + repoInfo.getRepoName(), null, repoInfo.relativePath, selectionStartPosition, selectionEndPosition);
                     } else {
-                        url = URLBuilder.buildEditorFileUrl(project, repoInfo.remoteUrl, repoInfo.branchName, repoInfo.relativePath, selectionStartPosition, selectionEndPosition);
+                        url = URLBuilder.buildEditorFileUrl(project, repoInfo.remoteUrl, repoInfo.remoteBranchName, repoInfo.relativePath, selectionStartPosition, selectionEndPosition);
                     }
                     handleFileUri(project, url);
                 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
@@ -14,8 +14,8 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.sourcegraph.common.BrowserOpener;
 import com.sourcegraph.find.SourcegraphVirtualFile;
-import com.sourcegraph.vcs.RepoUtil;
 import com.sourcegraph.vcs.RepoInfo;
+import com.sourcegraph.vcs.RepoUtil;
 import com.sourcegraph.vcs.VCSType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -49,14 +49,14 @@ public abstract class SearchActionBase extends DumbAwareAction {
                     String url;
                     RepoInfo repoInfo = RepoUtil.getRepoInfo(project, currentFile);
                     String remoteUrl = (scope == Scope.REPOSITORY) ? repoInfo.remoteUrl : null;
-                    String branchName = (scope == Scope.REPOSITORY) ? repoInfo.branchName : null;
+                    String remoteBranchName = (scope == Scope.REPOSITORY) ? repoInfo.remoteBranchName : null;
                     if (repoInfo.vcsType == VCSType.PERFORCE) {
                         // Our "editor" backend doesn't support Perforce, but we have all the info we need, so we'll go to the final URL directly.
                         String codeHostUrl = (scope == Scope.REPOSITORY) ? repoInfo.getCodeHostUrl() : null;
                         String repoName = (scope == Scope.REPOSITORY) ? repoInfo.getRepoName() : null;
                         url = URLBuilder.buildDirectSearchUrl(project, selectedText, codeHostUrl, repoName);
                     } else {
-                        url = URLBuilder.buildEditorSearchUrl(project, selectedText, remoteUrl, branchName);
+                        url = URLBuilder.buildEditorSearchUrl(project, selectedText, remoteUrl, remoteBranchName);
                     }
                     BrowserOpener.openInBrowser(project, url);
                 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/URLBuilder.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/URLBuilder.java
@@ -27,15 +27,15 @@ public class URLBuilder {
     }
 
     @NotNull
-    public static String buildEditorSearchUrl(@NotNull Project project, @NotNull String search, @Nullable String remoteUrl, @Nullable String branchName) {
+    public static String buildEditorSearchUrl(@NotNull Project project, @NotNull String search, @Nullable String remoteUrl, @Nullable String remoteBranchName) {
         String url = ConfigUtil.getSourcegraphUrl(project) + "-/editor"
             + "?" + buildVersionParams()
             + "&search=" + URLEncoder.encode(search, StandardCharsets.UTF_8);
 
         if (remoteUrl != null) {
             url += "&search_remote_url=" + URLEncoder.encode(remoteUrl, StandardCharsets.UTF_8);
-            if (branchName != null) {
-                url += "&search_branch=" + URLEncoder.encode(branchName, StandardCharsets.UTF_8);
+            if (remoteBranchName != null) {
+                url += "&search_branch=" + URLEncoder.encode(remoteBranchName, StandardCharsets.UTF_8);
             }
         }
 


### PR DESCRIPTION
- Fixes https://github.com/sourcegraph/sourcegraph/issues/44609
- Supersedes https://github.com/sourcegraph/sourcegraph/pull/44735

The problem was that `remoteBranchNames` contained names like `origin/branch-name`, which we only had the local branch name like `branch-name`.

This PR also fixes these two smaller but valid issues:
- If the branch name is not the same on the remote, then this logic didn't find it. Now it does.
- If the name of the remote (usually `origin`) contains a slash for whatever reason (it _can_ contain slashes by the spec), then this logic would fail. Now it doesn't.

## Test plan

- Tested it in [this Loom](https://www.loom.com/share/7009f01377084779977db1471602937a)
- In case of a branch that doesn't exist on the remote, it correctly opens the defalt branch
- In case of a branch that exists on the remote, it correctly openesd the branch
- I've tested it with a project that had two repos in it, so I can confirm that it also works correctly with multi-repo projects.

## App preview:

- [Web](https://sg-web-dv-jetbrains-improve-remote.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
