### PR TITLE
Allow users to sign out when there is only one oauth provider

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/app"
@@ -60,20 +59,6 @@ func NewMiddleware(db database.DB, serviceType, authPrefix string, isAPIHandler 
 			span.AddEvent("authenticated, proceeding to next")
 			span.Finish()
 			next.ServeHTTP(w, r)
-			return
-		}
-
-		// If there is only one auth provider configured, the single auth provider is a OAuth
-		// instance, and it's an app request, redirect to signin immediately. The user wouldn't be
-		// able to do anything else anyway; there's no point in showing them a signin screen with
-		// just a single signin option.
-		if pc := getExactlyOneOAuthProvider(); pc != nil && !isAPIHandler && pc.AuthPrefix == authPrefix && isHuman(r) {
-			span.AddEvent("redirect to singin")
-			v := make(url.Values)
-			v.Set("redirect", auth.SafeRedirectURL(r.URL.String()))
-			v.Set("pc", pc.ConfigID().ID)
-			span.Finish()
-			http.Redirect(w, r, authPrefix+"/login?"+v.Encode(), http.StatusFound)
 			return
 		}
 

--- a/enterprise/cmd/frontend/internal/auth/saml/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/middleware.go
@@ -12,7 +12,6 @@ import (
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/session"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -54,18 +53,6 @@ func authHandler(db database.DB, w http.ResponseWriter, r *http.Request, next ht
 	// If the actor is authenticated and not performing a SAML operation, then proceed to next.
 	if actor.FromContext(r.Context()).IsAuthenticated() {
 		next.ServeHTTP(w, r)
-		return
-	}
-
-	// If there is only one auth provider configured, the single auth provider is SAML, and it's an
-	// app request, redirect to signin immediately. The user wouldn't be able to do anything else
-	// anyway; there's no point in showing them a signin screen with just a single signin option.
-	if ps := providers.Providers(); len(ps) == 1 && ps[0].Config().Saml != nil && !isAPIRequest {
-		p, handled := handleGetProvider(r.Context(), w, ps[0].ConfigID().ID)
-		if handled {
-			return
-		}
-		redirectToAuthURL(w, r, p, auth.SafeRedirectURL(r.URL.String()))
 		return
 	}
 


### PR DESCRIPTION
See issue: #31192

The option to sign out when there was only one OAuth provider configured was skipped on purpose and, consequently, after clicking the SignOut link, the user would be automatically signed in.

This behavior (to be changed by this PR)  is not, officially, a bug, but:
-  it was reported that has caused issues in the past 
-  creates an annoying experience for the user, especially in the case they want to log in with a different account.


## Test plan
Manually tested the new behavior in a local instance. The tests were done with different auth providers, having only one of them configured at a time Example of a manual test:
https://user-images.githubusercontent.com/1552863/203405071-4f7e7f60-f8d4-45af-b7b7-67c7bd978dc8.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
