### PR TITLE
docker-images(postgres_exporter): upgrade to v0.11.1

### DIFF
--- a/docker-images/postgres_exporter/Dockerfile
+++ b/docker-images/postgres_exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM prometheuscommunity/postgres-exporter:v0.9.0@sha256:9100e51f477827840e06638f7ebec111799eece916c603fac2d2369bfbc9f507 as postgres_exporter
+FROM prometheuscommunity/postgres-exporter:v0.11.1@sha256:a7f8f66064b95c2b08dce9a0aaafe78c6639b7546d472fab649e9e7480be0454 as postgres_exporter
 FROM sourcegraph/alpine-3.14:180512_2022-10-31_84d1e240bb40@sha256:179ad53ab463ebc804f93de967113739fa73efc2cea6d9c53a9106be45f79d5e
 # hadolint ignore=DL3048
 LABEL com.sourcegraph.postgres_exporter.version=v0.9.0


### PR DESCRIPTION
there is no breaking change that could affect us

I want to use the `-include-databases` flag https://github.com/sourcegraph/deploy-sourcegraph-managed/pull/2273/files#diff-4662fb8a50bdbb28d9025f6e723876b0706c0d0798ab76bfba873963f288674cR75-R81

also why not run the latest?

TODO

- [x] check trivy report and confirm no added vulnerability
  - confirmed there are vuln present, however, they're all accepted https://handbook.sourcegraph.com/departments/security/tooling/trivy/4-2-0/ here

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

it's deployed on `rctest`, and I can confirm I am still seeing metrics. at a glance, there is no broken dashboard
