### PR TITLE
monitoring: add stub implementation for multi-instance dashboard

### DIFF
--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1016,6 +1016,7 @@ Flags:
 * `--grafana.headers="<value>"`: Additional headers for HTTP requests to the Grafana instance
 * `--grafana.url="<value>"`: Address for the Grafana instance to reload (default: http://127.0.0.1:3370)
 * `--inject-label-matcher="<value>"`: Labels to inject into all selectors in Prometheus expressions: observable queries, dashboard template variables, etc.
+* `--multi-instance-groupings="<value>"`: [WIP] If non-empty, indicates whether or not a multi-instance dashboard should be generated with the provided labels to group on.
 * `--no-prune`: Toggles pruning of dangling generated assets through simple heuristic - should be disabled during builds.
 * `--prometheus.dir="<value>"`: Output directory for generated Prometheus assets (default: $SG_ROOT/docker-images/prometheus/config/)
 * `--prometheus.url="<value>"`: Address for the Prometheus instance to reload (default: http://127.0.0.1:9090)

--- a/monitoring/command/generate.go
+++ b/monitoring/command/generate.go
@@ -101,6 +101,11 @@ func Generate(cmdRoot string, sgRoot string) *cli.Command {
 				EnvVars: []string{"INJECT_LABEL_MATCHERS"},
 				Usage:   "Labels to inject into all selectors in Prometheus expressions: observable queries, dashboard template variables, etc.",
 			},
+			&cli.StringSliceFlag{
+				Name:    "multi-instance-groupings",
+				EnvVars: []string{"MULTI_INSTANCE_GROUPINGS"},
+				Usage:   "[WIP] If non-empty, indicates whether or not a multi-instance dashboard should be generated with the provided labels to group on.",
+			},
 		},
 		BashComplete: cliutil.CompleteOptions(func() (options []string) {
 			return definitions.Default().Names()
@@ -190,6 +195,8 @@ func Generate(cmdRoot string, sgRoot string) *cli.Command {
 					}
 					return matchers
 				}(),
+
+				MultiInstanceDashboardGroupings: c.StringSlice("multi-instance-groupings"),
 			}
 
 			// If 'all.dir' is set, override all other '*.dir' flags and ignore expansion

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -393,6 +393,8 @@ func RepoUpdater() *monitoring.Dashboard {
 							Panel:       monitoring.Panel().LegendFormat("{{type}}").Unit(monitoring.Seconds),
 							Owner:       monitoring.ObservableOwnerIAM,
 							NextSteps:   "Increase the API rate limit to [GitHub](https://docs.sourcegraph.com/admin/external_service/github#github-com-rate-limits), [GitLab](https://docs.sourcegraph.com/admin/external_service/gitlab#internal-rate-limits) or [Bitbucket Server](https://docs.sourcegraph.com/admin/external_service/bitbucket_server#internal-rate-limits).",
+
+							MultiInstance: true,
 						},
 						{
 							Name:        "perms_syncer_stale_perms",

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -8,9 +8,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/sourcegraph/log"
 
+	"github.com/grafana-tools/sdk"
 	grafanasdk "github.com/grafana-tools/sdk"
 	"github.com/prometheus/prometheus/model/labels"
 	"gopkg.in/yaml.v2"
@@ -51,6 +53,10 @@ type GenerateOptions struct {
 	// expressions - this includes dashboard template variables, observable queries,
 	// alert queries, and so on - using internal/promql.Inject(...).
 	InjectLabelMatchers []*labels.Matcher
+
+	// MultiInstanceDashboardGroupings, if non-empty, indicates whether or not a
+	// multi-instance dashboard should be generated with the provided labels to group on.
+	MultiInstanceDashboardGroupings []string
 }
 
 // Generate is the main Sourcegraph monitoring generator entrypoint.
@@ -231,6 +237,34 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 			}
 		}
 	}
+	if len(opts.MultiInstanceDashboardGroupings) > 0 {
+		board, err := renderMultiInstanceDashboard(dashboards, opts.MultiInstanceDashboardGroupings)
+		if err != nil {
+			return errors.Wrap(err, "Failed to render multi-instance dashboard")
+		}
+		if grafanaClient != nil {
+			if _, err := grafanaClient.SetDashboard(ctx, *board, grafanasdk.SetDashboardParams{
+				Overwrite: true,
+			}); err != nil {
+				return errors.Wrapf(err, "Could not reload Grafana dashboard %q", board.Title)
+			} else {
+				logger.Info("Reloaded Grafana dashboard", log.String("title", board.Title))
+			}
+		}
+		if opts.GrafanaDir != "" {
+			data, err := json.MarshalIndent(board, "", "  ")
+			if err != nil {
+				return errors.Wrapf(err, "Invalid dashboard %q", board.Title)
+			}
+			// #nosec G306  prometheus runs as nobody
+			generatedDashboard := "multi-instance-dashboard.json"
+			err = os.WriteFile(filepath.Join(opts.GrafanaDir, generatedDashboard), data, os.ModePerm)
+			if err != nil {
+				return errors.Wrapf(err, "Could not write dashboard %q to output", board.Title)
+			}
+			generatedAssets = append(generatedAssets, generatedDashboard)
+		}
+	}
 
 	// Generate additional Prometheus assets
 	if opts.PrometheusDir != "" {
@@ -300,4 +334,48 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 	}
 
 	return nil
+}
+
+func renderMultiInstanceDashboard(dashboards []*Dashboard, groupings []string) (*grafanasdk.Board, error) {
+	board := sdk.NewBoard("Multi-instance overviews")
+	board.AddTags("builtin")
+
+	// TODO generate variables
+	// board.Templating.List = append(board.Templating.List, grafanasdk.TemplateVar{
+	// 	Name: "instance", // or project, or use grouping
+	// })
+
+	for _, d := range dashboards {
+		var row *sdk.Row
+		var addDashboardRow sync.Once
+		for _, g := range d.Groups {
+			for _, r := range g.Rows {
+				for _, o := range r {
+					if !o.MultiInstance {
+						continue
+					}
+
+					// Only add row if this dashboard has a multi instance panel, and only
+					// do it once per dashboard
+					addDashboardRow.Do(func() {
+						row = board.AddRow(d.Title)
+					})
+
+					// TODO make this size correctly in this context and output a valid
+					// dashboard, right now it isn't quite right
+					panel, err := o.renderPanel(d, panelManipulationOptions{
+						injectGroupings: groupings,
+						// TODO inject variables
+						// injectLabelMatchers: []*labels.Matcher{},
+					}, nil)
+					if err != nil {
+						return nil, errors.Wrapf(err, "render panel for %q", o.Name)
+					}
+
+					row.Add(panel)
+				}
+			}
+		}
+	}
+	return board, nil
 }

--- a/monitoring/monitoring/generator_test.go
+++ b/monitoring/monitoring/generator_test.go
@@ -43,4 +43,19 @@ func TestGenerate(t *testing.T) {
 			definitions.Default()...)
 		assert.NoError(t, err)
 	})
+
+	t.Run("with inject groupings", func(t *testing.T) {
+		td := t.TempDir()
+		err := monitoring.Generate(logtest.Scoped(t),
+			monitoring.GenerateOptions{
+				DisablePrune:  true,
+				GrafanaDir:    filepath.Join(td, "grafana"),
+				PrometheusDir: filepath.Join(td, "prometheus"),
+				DocsDir:       filepath.Join(td, "docs"),
+
+				MultiInstanceDashboardGroupings: []string{"project_id"},
+			},
+			definitions.Default()...)
+		assert.NoError(t, err)
+	})
 }

--- a/monitoring/monitoring/internal/grafana/home.go
+++ b/monitoring/monitoring/internal/grafana/home.go
@@ -31,7 +31,7 @@ func Home(injectLabelMatchers []*labels.Matcher) ([]byte, error) {
 	}
 	for k, v := range vars {
 		var err error
-		vars[k], err = promql.Inject(v, injectLabelMatchers, nil)
+		vars[k], err = promql.InjectMatchers(v, injectLabelMatchers, nil)
 		if err != nil {
 			return nil, errors.Wrap(err, k)
 		}

--- a/monitoring/monitoring/internal/promql/promql_test.go
+++ b/monitoring/monitoring/internal/promql/promql_test.go
@@ -46,7 +46,7 @@ func TestValidate(t *testing.T) {
 	}
 }
 
-func TestInject(t *testing.T) {
+func TestInjectMatchers(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		expression string
@@ -99,7 +99,7 @@ func TestInject(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := Inject(tc.expression, tc.matchers, tc.vars)
+			got, err := InjectMatchers(tc.expression, tc.matchers, tc.vars)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("unexpected result '%+v'", err)
 			}
@@ -166,6 +166,50 @@ func TestInjectAsAlert(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := InjectAsAlert(tc.expression, tc.matchers, tc.vars)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("unexpected result '%+v'", err)
+			} else if err != nil {
+				t.Logf("got expected error '%s'", err.Error())
+			}
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestInjectGroupings(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		expression string
+		groupings  []string
+		vars       VariableApplier
+
+		want    string
+		wantErr bool
+	}{
+		{
+			name:       "with existing by()",
+			expression: `max by (type) (src_repoupdater_perms_syncer_perms_gap_seconds)`,
+			groupings:  []string{"project_id"},
+			want:       `max by(type, project_id) (src_repoupdater_perms_syncer_perms_gap_seconds)`,
+			wantErr:    false,
+		},
+		{
+			name:       "without existing by()",
+			expression: `max(src_repoupdater_perms_syncer_perms_gap_seconds)`,
+			groupings:  []string{"project_id"},
+			want:       `max by(project_id) (src_repoupdater_perms_syncer_perms_gap_seconds)`,
+			wantErr:    false,
+		},
+		{
+			name:       "repeated and without existing by()",
+			expression: `max((max(src_codeintel_commit_graph_queued_duration_seconds_total)) >= 3600)`,
+			groupings:  []string{"project_id"},
+			want:       `max by(project_id) ((max by(project_id) (src_codeintel_commit_graph_queued_duration_seconds_total)) >= 3600)`,
+			wantErr:    false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := InjectGroupings(tc.expression, tc.groupings, tc.vars)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("unexpected result '%+v'", err)
 			} else if err != nil {

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -136,7 +136,7 @@ func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher, folde
 	}
 	if !c.noAlertsDefined() {
 		// Show alerts matching the selected alert_level (see template variable above)
-		expr, err := promql.Inject(
+		expr, err := promql.InjectMatchers(
 			fmt.Sprintf(`ALERTS{service_name=%q,level=~"$alert_level",alertstate="firing"}`, c.Name),
 			injectLabelMatchers, newVariableApplier(c.Variables))
 		if err != nil {
@@ -162,7 +162,7 @@ func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher, folde
 		// inspired by https://github.com/grafana/grafana/issues/11948#issuecomment-403841249
 		// We use `job=~.*SERVICE` because of frontend being called sourcegraph-frontend
 		// in certain environments
-		expr, err := promql.Inject(
+		expr, err := promql.InjectMatchers(
 			fmt.Sprintf(`group by(version, instance) (src_service_metadata{job=~".*%[1]s"} unless (src_service_metadata{job=~".*%[1]s"} offset 1m))`, c.Name),
 			injectLabelMatchers,
 			newVariableApplier(c.Variables))
@@ -196,7 +196,7 @@ func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher, folde
 	board.Panels = append(board.Panels, description)
 
 	if !c.noAlertsDefined() {
-		expr, err := promql.Inject(fmt.Sprintf(`label_replace(
+		expr, err := promql.InjectMatchers(fmt.Sprintf(`label_replace(
 			sum(
 				max by (level,service_name,name,description,grafana_panel_id)(alert_count{service_name="%s",name!="",level=~"$alert_level"})
 			) by (
@@ -245,7 +245,7 @@ func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher, folde
 				Show:    true,
 			},
 		}
-		alertsFiringExpr, err := promql.Inject(
+		alertsFiringExpr, err := promql.InjectMatchers(
 			fmt.Sprintf(`sum by (service_name,level,name,grafana_panel_id)(max by (level,service_name,name,description,grafana_panel_id)(alert_count{service_name="%s",name!="",level=~"$alert_level"}) >= 1)`, c.Name),
 			injectLabelMatchers,
 			newVariableApplier(c.Variables),
@@ -286,48 +286,18 @@ func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher, folde
 		for rowIndex, row := range group.Rows {
 			panelWidth := 24 / len(row)
 			offsetY++
-			for i, o := range row {
-				panelTitle := strings.ToTitle(string([]rune(o.Description)[0])) + string([]rune(o.Description)[1:])
-
-				var panel *sdk.Panel
-				switch o.Panel.panelType {
-				case PanelTypeGraph:
-					panel = sdk.NewGraph(panelTitle)
-				case PanelTypeHeatmap:
-					panel = sdk.NewHeatmap(panelTitle)
-				}
-
-				panel.ID = observablePanelID(groupIndex, rowIndex, i)
-
-				// Set positioning
-				setPanelSize(panel, panelWidth, 5)
-				setPanelPos(panel, i*panelWidth, offsetY)
-
-				// Add reference links
-				panel.Links = []sdk.Link{{
-					Title:       "Panel reference",
-					URL:         StringPtr(fmt.Sprintf("%s#%s", canonicalDashboardsDocsURL, observableDocAnchor(c, o))),
-					TargetBlank: boolPtr(true),
-				}}
-				if !o.NoAlert {
-					panel.Links = append(panel.Links, sdk.Link{
-						Title:       "Alerts reference",
-						URL:         StringPtr(fmt.Sprintf("%s#%s", canonicalAlertDocsURL, observableDocAnchor(c, o))),
-						TargetBlank: boolPtr(true),
-					})
-				}
-
-				// Build the graph panel
-				o.Panel.build(o, panel)
-
-				// Apply injected label matchers
-				for _, target := range *panel.GetTargets() {
-					var err error
-					target.Expr, err = promql.Inject(target.Expr, injectLabelMatchers, newVariableApplier(c.Variables))
-					if err != nil {
-						return nil, errors.Wrap(err, target.Query)
-					}
-					panel.SetTarget(&target)
+			for panelIndex, o := range row {
+				panel, err := o.renderPanel(c, panelManipulationOptions{
+					injectLabelMatchers: injectLabelMatchers,
+				}, &panelRenderOptions{
+					groupIndex: groupIndex,
+					rowIndex:   rowIndex,
+					panelIndex: panelIndex,
+					panelWidth: panelWidth,
+					offsetY:    offsetY,
+				})
+				if err != nil {
+					return nil, errors.Wrapf(err, "render panel for %q", o.Name)
 				}
 
 				// Attach panel to board
@@ -704,6 +674,10 @@ type Observable struct {
 	// the provided `ObservablePanel` is insufficient - see `ObservablePanelOption` for
 	// more details.
 	Panel ObservablePanel
+
+	// MultiInstance allows a panel to opt-in to a generated multi-instance overview
+	// dashboard, which is created for Sourcegraph Cloud's centralized observability.
+	MultiInstance bool
 }
 
 func (o Observable) validate(variables []ContainerVariable) error {
@@ -797,6 +771,83 @@ func (o Observable) alertsCount() (count int) {
 		count++
 	}
 	return
+}
+
+type panelRenderOptions struct {
+	groupIndex int
+	rowIndex   int
+	panelIndex int
+	panelWidth int
+
+	offsetY int
+}
+
+type panelManipulationOptions struct {
+	injectLabelMatchers []*labels.Matcher
+	injectGroupings     []string
+}
+
+func (o Observable) renderPanel(c *Dashboard, manipulations panelManipulationOptions, opts *panelRenderOptions) (*sdk.Panel, error) {
+	panelTitle := strings.ToTitle(string([]rune(o.Description)[0])) + string([]rune(o.Description)[1:])
+
+	var panel *sdk.Panel
+	switch o.Panel.panelType {
+	case PanelTypeGraph:
+		panel = sdk.NewGraph(panelTitle)
+	case PanelTypeHeatmap:
+		panel = sdk.NewHeatmap(panelTitle)
+	}
+
+	// Set attributes based on position, if available
+	if opts != nil {
+		// Generating a stable ID
+		panel.ID = observablePanelID(opts.groupIndex, opts.rowIndex, opts.panelIndex)
+
+		// Set positioning
+		setPanelSize(panel, opts.panelWidth, 5)
+		setPanelPos(panel, opts.panelIndex*opts.panelWidth, opts.offsetY)
+	}
+
+	// Add reference links
+	panel.Links = []sdk.Link{{
+		Title:       "Panel reference",
+		URL:         StringPtr(fmt.Sprintf("%s#%s", canonicalDashboardsDocsURL, observableDocAnchor(c, o))),
+		TargetBlank: boolPtr(true),
+	}}
+	if !o.NoAlert {
+		panel.Links = append(panel.Links, sdk.Link{
+			Title:       "Alerts reference",
+			URL:         StringPtr(fmt.Sprintf("%s#%s", canonicalAlertDocsURL, observableDocAnchor(c, o))),
+			TargetBlank: boolPtr(true),
+		})
+	}
+
+	// Build the graph panel
+	o.Panel.build(o, panel)
+
+	// Apply injected label matchers
+	for _, target := range *panel.GetTargets() {
+		var err error
+		target.Expr, err = promql.InjectMatchers(target.Expr, manipulations.injectLabelMatchers, newVariableApplier(c.Variables))
+		if err != nil {
+			return nil, errors.Wrap(err, target.Query)
+		}
+
+		if len(manipulations.injectGroupings) > 0 {
+			target.Expr, err = promql.InjectGroupings(target.Expr, manipulations.injectGroupings, newVariableApplier(c.Variables))
+			if err != nil {
+				return nil, errors.Wrap(err, target.Query)
+			}
+
+			for _, g := range manipulations.injectGroupings {
+				target.LegendFormat = fmt.Sprintf("%s - {{%s}}", target.LegendFormat, g)
+			}
+		}
+
+		panel.SetTarget(&target)
+	}
+
+	return panel, nil
 }
 
 // Alert provides a builder for defining alerting on an Observable.

--- a/monitoring/monitoring/prometheus.go
+++ b/monitoring/monitoring/prometheus.go
@@ -106,7 +106,7 @@ func customPrometheusRules(injectLabelMatchers []*labels.Matcher) (*promRulesFil
 
 	var injectErrors error
 	injectExpr := func(expr string) string {
-		injected, err := promql.Inject(expr, injectLabelMatchers, nil)
+		injected, err := promql.InjectMatchers(expr, injectLabelMatchers, nil)
 		if err != nil {
 			injectErrors = errors.Append(injectErrors, err)
 		}

--- a/monitoring/monitoring/variables.go
+++ b/monitoring/monitoring/variables.go
@@ -123,7 +123,7 @@ func (c *ContainerVariable) toGrafanaTemplateVar(injectLabelMatchers []*labels.M
 	switch {
 	case c.OptionsLabelValues.Query != "":
 		variable.Type = "query"
-		expr, err := promql.Inject(c.OptionsLabelValues.Query, injectLabelMatchers, nil)
+		expr, err := promql.InjectMatchers(c.OptionsLabelValues.Query, injectLabelMatchers, nil)
 		if err != nil {
 			return variable, errors.Wrap(err, "OptionsLabelValues.Query")
 		}


### PR DESCRIPTION
Lays some groundwork for generating a new dashboard of panels that aggregate metrics per-instance across multiple instances. The result will be that engineers can opt-in their panel to be included on this multi-instance dashboard with `(Observable).MultiInstance`, upon which we:

- add `project_id` (via parameterized groupings) to all aggregation expressions on the observable panel
- add `- {{project_id}}` (via parameterized groupings) to all label templates on the observable panel
- add the observable panel to a row representing the dashboard in the multi-instance dashboard

The opt-in is mainly because many dashboards do not work well when aggregated per-Cloud-instance. For example, a per-gitserver-instance will have thousands of time series when aggregated per-Cloud-instance, and similarly for other high-dimensionality. This allows us to curate a set of dashboards that give useful cross-instance signals. Eventually, we want to add template variables to allow selecting by instance.

This is very much a work-in-progress, but putting this up for merge to iterate in `main`:

- the generated dashboard does not yet work out-of-the-box (the test dashboard copy-pastes just the panel and not the entire dashboard)
- the panel has no size and defaults to very small
- the code could probably be refactored better

Part of https://github.com/sourcegraph/customer/issues/1216 / https://github.com/sourcegraph/customer/issues/1151
Co-authored with @danieldides over a hack session

Closes https://github.com/sourcegraph/customer/issues/1610

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
go run ./dev/sg monitoring generate -multi-instance-groupings=project_id
```

See `docker-images/grafana/config/provisioning/dashboards/sourcegraph/multi-instance-dashboard.json`, notably:

```json
          "targets": [
            {
              "refId": "",
              "expr": "max by(type, project_id) (src_repoupdater_perms_syncer_perms_gap_seconds)",
              "legendFormat": "{{type}} - {{project_id}}"
            }
          ],
```

https://monitoring.sgdev.org/d/2L-pTadVz/test-dashboard?orgId=1 (no screenshot included since this includes customer names - test dashboard may be deleted later)

Manually review existing dashboards look good still