### PR TITLE
webhooks: add `name` column to `webhooks` table.

### DIFF
--- a/cmd/frontend/backend/webhooks.go
+++ b/cmd/frontend/backend/webhooks.go
@@ -23,7 +23,7 @@ func NewWebhookService(db database.DB, keyRing keyring.Ring) webhookService {
 	}
 }
 
-func (ws *webhookService) CreateWebhook(ctx context.Context, codeHostKind, codeHostURN string, secretStr *string) (*types.Webhook, error) {
+func (ws *webhookService) CreateWebhook(ctx context.Context, name, codeHostKind, codeHostURN string, secretStr *string) (*types.Webhook, error) {
 	err := validateCodeHostKindAndSecret(codeHostKind, secretStr)
 	if err != nil {
 		return nil, err
@@ -32,7 +32,7 @@ func (ws *webhookService) CreateWebhook(ctx context.Context, codeHostKind, codeH
 	if secretStr != nil {
 		secret = types.NewUnencryptedSecret(*secretStr)
 	}
-	return ws.db.Webhooks(ws.keyRing.WebhookKey).Create(ctx, codeHostKind, codeHostURN, actor.FromContext(ctx).UID, secret)
+	return ws.db.Webhooks(ws.keyRing.WebhookKey).Create(ctx, name, codeHostKind, codeHostURN, actor.FromContext(ctx).UID, secret)
 }
 
 func validateCodeHostKindAndSecret(codeHostKind string, secret *string) error {

--- a/cmd/frontend/webhooks/webhooks_test.go
+++ b/cmd/frontend/webhooks/webhooks_test.go
@@ -40,6 +40,7 @@ func TestWebhooksHandler(t *testing.T) {
 	dbWebhooks := db.Webhooks(keyring.Default().WebhookKey)
 	gitLabWH, err := dbWebhooks.Create(
 		context.Background(),
+		"gitLabWH",
 		extsvc.KindGitLab,
 		"http://gitlab.com",
 		u.ID,
@@ -48,6 +49,7 @@ func TestWebhooksHandler(t *testing.T) {
 
 	gitHubWH, err := dbWebhooks.Create(
 		context.Background(),
+		"gitHubWH",
 		extsvc.KindGitHub,
 		"http://github.com",
 		u.ID,
@@ -57,6 +59,7 @@ func TestWebhooksHandler(t *testing.T) {
 
 	gitHubWHNoSecret, err := dbWebhooks.Create(
 		context.Background(),
+		"gitHubWHNoSecret",
 		extsvc.KindGitHub,
 		"http://github.com",
 		u.ID,
@@ -66,6 +69,7 @@ func TestWebhooksHandler(t *testing.T) {
 
 	bbServerWH, err := dbWebhooks.Create(
 		context.Background(),
+		"bbServerWH",
 		extsvc.KindBitbucketServer,
 		"http://bitbucket.com",
 		u.ID,

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
@@ -41,7 +41,7 @@ func (r *webhooksResolver) CreateWebhook(ctx context.Context, args *graphqlbacke
 		return nil, auth.ErrMustBeSiteAdmin
 	}
 	ws := backend.NewWebhookService(r.db, keyring.Default())
-	webhook, err := ws.CreateWebhook(ctx, args.CodeHostKind, args.CodeHostURN, args.Secret)
+	webhook, err := ws.CreateWebhook(ctx, args.CodeHostKind, args.CodeHostKind, args.CodeHostURN, args.Secret)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -52472,7 +52472,7 @@ func NewMockWebhookStore() *MockWebhookStore {
 			},
 		},
 		CreateFunc: &WebhookStoreCreateFunc{
-			defaultHook: func(context.Context, string, string, int32, *encryption.Encryptable) (r0 *types.Webhook, r1 error) {
+			defaultHook: func(context.Context, string, string, string, int32, *encryption.Encryptable) (r0 *types.Webhook, r1 error) {
 				return
 			},
 		},
@@ -52519,7 +52519,7 @@ func NewStrictMockWebhookStore() *MockWebhookStore {
 			},
 		},
 		CreateFunc: &WebhookStoreCreateFunc{
-			defaultHook: func(context.Context, string, string, int32, *encryption.Encryptable) (*types.Webhook, error) {
+			defaultHook: func(context.Context, string, string, string, int32, *encryption.Encryptable) (*types.Webhook, error) {
 				panic("unexpected invocation of MockWebhookStore.Create")
 			},
 		},
@@ -52698,23 +52698,23 @@ func (c WebhookStoreCountFuncCall) Results() []interface{} {
 // WebhookStoreCreateFunc describes the behavior when the Create method of
 // the parent MockWebhookStore instance is invoked.
 type WebhookStoreCreateFunc struct {
-	defaultHook func(context.Context, string, string, int32, *encryption.Encryptable) (*types.Webhook, error)
-	hooks       []func(context.Context, string, string, int32, *encryption.Encryptable) (*types.Webhook, error)
+	defaultHook func(context.Context, string, string, string, int32, *encryption.Encryptable) (*types.Webhook, error)
+	hooks       []func(context.Context, string, string, string, int32, *encryption.Encryptable) (*types.Webhook, error)
 	history     []WebhookStoreCreateFuncCall
 	mutex       sync.Mutex
 }
 
 // Create delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockWebhookStore) Create(v0 context.Context, v1 string, v2 string, v3 int32, v4 *encryption.Encryptable) (*types.Webhook, error) {
-	r0, r1 := m.CreateFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.CreateFunc.appendCall(WebhookStoreCreateFuncCall{v0, v1, v2, v3, v4, r0, r1})
+func (m *MockWebhookStore) Create(v0 context.Context, v1 string, v2 string, v3 string, v4 int32, v5 *encryption.Encryptable) (*types.Webhook, error) {
+	r0, r1 := m.CreateFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.CreateFunc.appendCall(WebhookStoreCreateFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the Create method of the
 // parent MockWebhookStore instance is invoked and the hook queue is empty.
-func (f *WebhookStoreCreateFunc) SetDefaultHook(hook func(context.Context, string, string, int32, *encryption.Encryptable) (*types.Webhook, error)) {
+func (f *WebhookStoreCreateFunc) SetDefaultHook(hook func(context.Context, string, string, string, int32, *encryption.Encryptable) (*types.Webhook, error)) {
 	f.defaultHook = hook
 }
 
@@ -52722,7 +52722,7 @@ func (f *WebhookStoreCreateFunc) SetDefaultHook(hook func(context.Context, strin
 // Create method of the parent MockWebhookStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *WebhookStoreCreateFunc) PushHook(hook func(context.Context, string, string, int32, *encryption.Encryptable) (*types.Webhook, error)) {
+func (f *WebhookStoreCreateFunc) PushHook(hook func(context.Context, string, string, string, int32, *encryption.Encryptable) (*types.Webhook, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -52731,19 +52731,19 @@ func (f *WebhookStoreCreateFunc) PushHook(hook func(context.Context, string, str
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *WebhookStoreCreateFunc) SetDefaultReturn(r0 *types.Webhook, r1 error) {
-	f.SetDefaultHook(func(context.Context, string, string, int32, *encryption.Encryptable) (*types.Webhook, error) {
+	f.SetDefaultHook(func(context.Context, string, string, string, int32, *encryption.Encryptable) (*types.Webhook, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *WebhookStoreCreateFunc) PushReturn(r0 *types.Webhook, r1 error) {
-	f.PushHook(func(context.Context, string, string, int32, *encryption.Encryptable) (*types.Webhook, error) {
+	f.PushHook(func(context.Context, string, string, string, int32, *encryption.Encryptable) (*types.Webhook, error) {
 		return r0, r1
 	})
 }
 
-func (f *WebhookStoreCreateFunc) nextHook() func(context.Context, string, string, int32, *encryption.Encryptable) (*types.Webhook, error) {
+func (f *WebhookStoreCreateFunc) nextHook() func(context.Context, string, string, string, int32, *encryption.Encryptable) (*types.Webhook, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -52787,10 +52787,13 @@ type WebhookStoreCreateFuncCall struct {
 	Arg2 string
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 int32
+	Arg3 string
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
-	Arg4 *encryption.Encryptable
+	Arg4 int32
+	// Arg5 is the value of the 6th argument passed to this method
+	// invocation.
+	Arg5 *encryption.Encryptable
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *types.Webhook
@@ -52802,7 +52805,7 @@ type WebhookStoreCreateFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c WebhookStoreCreateFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -20528,6 +20528,19 @@
           "Comment": ""
         },
         {
+          "Name": "name",
+          "Index": 12,
+          "TypeName": "text",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "Descriptive name of a webhook."
+        },
+        {
           "Name": "secret",
           "Index": 5,
           "TypeName": "text",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -3239,6 +3239,7 @@ Foreign-key constraints:
  uuid               | uuid                     |           | not null | gen_random_uuid()
  created_by_user_id | integer                  |           |          | 
  updated_by_user_id | integer                  |           |          | 
+ name               | text                     |           |          | 
 Indexes:
     "webhooks_pkey" PRIMARY KEY, btree (id)
     "webhooks_uuid_key" UNIQUE CONSTRAINT, btree (uuid)
@@ -3257,6 +3258,8 @@ Webhooks registered in Sourcegraph instance.
 **code_host_urn**: URN of a code host. This column maps to external_service_id column of repo table.
 
 **created_by_user_id**: ID of a user, who created the webhook. If NULL, then the user does not exist (never existed or was deleted).
+
+**name**: Descriptive name of a webhook.
 
 **secret**: Secret used to decrypt webhook payload (if supported by the code host).
 

--- a/internal/database/users_test.go
+++ b/internal/database/users_test.go
@@ -647,7 +647,7 @@ func TestUsers_Delete(t *testing.T) {
 			}
 
 			// Create and update a webhook
-			webhook, err := db.Webhooks(nil).Create(ctx, extsvc.KindGitHub, testURN, user.ID, types.NewUnencryptedSecret("testSecret"))
+			webhook, err := db.Webhooks(nil).Create(ctx, "github webhook", extsvc.KindGitHub, testURN, user.ID, types.NewUnencryptedSecret("testSecret"))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/database/webhook_logs_test.go
+++ b/internal/database/webhook_logs_test.go
@@ -169,7 +169,7 @@ func TestWebhookLogStore(t *testing.T) {
 		assert.Nil(t, esStore.Upsert(ctx, es))
 
 		whStore := tx.Webhooks(keyring.Default().WebhookKey)
-		wh, err := whStore.Create(ctx, extsvc.KindGitHub, "http://github.com", 0, nil)
+		wh, err := whStore.Create(ctx, "github webhook", extsvc.KindGitHub, "http://github.com", 0, nil)
 		require.NoError(t, err)
 
 		store := tx.WebhookLogs(et.TestKey{})

--- a/internal/database/webhooks.go
+++ b/internal/database/webhooks.go
@@ -20,7 +20,7 @@ import (
 type WebhookStore interface {
 	basestore.ShareableStore
 
-	Create(ctx context.Context, kind, urn string, actorUID int32, secret *types.EncryptableSecret) (*types.Webhook, error)
+	Create(ctx context.Context, name, kind, urn string, actorUID int32, secret *types.EncryptableSecret) (*types.Webhook, error)
 	GetByID(ctx context.Context, id int32) (*types.Webhook, error)
 	GetByUUID(ctx context.Context, id uuid.UUID) (*types.Webhook, error)
 	Delete(ctx context.Context, opts DeleteWebhookOpts) error
@@ -63,7 +63,7 @@ type GetWebhookOpts WebhookOpts
 // If encryption IS enabled then the encrypted value will be stored in secret and
 // the encryption_key_id field will also be populated so that we can decrypt the
 // value later.
-func (s *webhookStore) Create(ctx context.Context, kind, urn string, actorUID int32, secret *types.EncryptableSecret) (*types.Webhook, error) {
+func (s *webhookStore) Create(ctx context.Context, name, kind, urn string, actorUID int32, secret *types.EncryptableSecret) (*types.Webhook, error) {
 	var (
 		err             error
 		encryptedSecret string
@@ -81,6 +81,7 @@ func (s *webhookStore) Create(ctx context.Context, kind, urn string, actorUID in
 	}
 
 	q := sqlf.Sprintf(webhookCreateQueryFmtstr,
+		name,
 		kind,
 		urn,
 		dbutil.NullStringColumn(encryptedSecret),
@@ -101,6 +102,7 @@ func (s *webhookStore) Create(ctx context.Context, kind, urn string, actorUID in
 const webhookCreateQueryFmtstr = `
 INSERT INTO
 	webhooks (
+        name,
 		code_host_kind,
 		code_host_urn,
 		secret,
@@ -108,6 +110,7 @@ INSERT INTO
 		created_by_user_id
 	)
 	VALUES (
+		%s,
 		%s,
 		%s,
 		%s,
@@ -128,6 +131,7 @@ var webhookColumns = []*sqlf.Query{
 	sqlf.Sprintf("encryption_key_id"),
 	sqlf.Sprintf("created_by_user_id"),
 	sqlf.Sprintf("updated_by_user_id"),
+	sqlf.Sprintf("name"),
 }
 
 const webhookGetFmtstr = `
@@ -261,7 +265,7 @@ func (s *webhookStore) Update(ctx context.Context, actorUID int32, newWebhook *t
 	}
 
 	q := sqlf.Sprintf(webhookUpdateQueryFmtstr,
-		newWebhook.CodeHostURN.String(), encryptedSecret, keyID, dbutil.NullInt32Column(actorUID), newWebhook.ID,
+		newWebhook.Name, newWebhook.CodeHostURN.String(), encryptedSecret, keyID, dbutil.NullInt32Column(actorUID), newWebhook.ID,
 		sqlf.Join(webhookColumns, ", "))
 
 	updated, err := scanWebhook(s.QueryRow(ctx, q), s.key)
@@ -278,6 +282,7 @@ func (s *webhookStore) Update(ctx context.Context, actorUID int32, newWebhook *t
 const webhookUpdateQueryFmtstr = `
 UPDATE webhooks
 SET
+    name = %s,
 	code_host_urn = %s,
 	secret = %s,
 	encryption_key_id = %s,
@@ -402,6 +407,7 @@ func scanWebhook(sc dbutil.Scanner, key encryption.Key) (*types.Webhook, error) 
 		&dbutil.NullString{S: &keyID},
 		&dbutil.NullInt32{N: &hook.CreatedByUserID},
 		&dbutil.NullInt32{N: &hook.UpdatedByUserID},
+		&dbutil.NullString{S: &hook.Name},
 	); err != nil {
 		return nil, err
 	}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1684,12 +1684,14 @@ func NewEncryptedSecret(cipher, keyID string, key encryption.Key) *EncryptableSe
 }
 
 // Webhook defines the information we need to handle incoming webhooks from a
-// code host
+// code host.
 type Webhook struct {
-	// The primary key, used for sorting and pagination
+	// The primary key, used for sorting and pagination.
 	ID int32
-	// UUID is the ID we display externally and will appear in the webhook URL
-	UUID         uuid.UUID
+	// UUID is the ID we display externally and will appear in the webhook URL.
+	UUID uuid.UUID
+	// Name is a descriptive webhook name which is shown on the UI for convenience.
+	Name         string
 	CodeHostKind string
 	CodeHostURN  extsvc.CodeHostBaseURL
 	// Secret can be in one of three states:

--- a/migrations/frontend/1669184869_add_name_to_webhooks_table/down.sql
+++ b/migrations/frontend/1669184869_add_name_to_webhooks_table/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE webhooks
+    DROP COLUMN IF EXISTS name;

--- a/migrations/frontend/1669184869_add_name_to_webhooks_table/metadata.yaml
+++ b/migrations/frontend/1669184869_add_name_to_webhooks_table/metadata.yaml
@@ -1,0 +1,2 @@
+name: add name to webhooks table
+parents: [1666398757, 1668808118]

--- a/migrations/frontend/1669184869_add_name_to_webhooks_table/up.sql
+++ b/migrations/frontend/1669184869_add_name_to_webhooks_table/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE webhooks
+    ADD COLUMN IF NOT EXISTS name TEXT;
+
+COMMENT ON COLUMN webhooks.name IS 'Descriptive name of a webhook.';

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3693,7 +3693,8 @@ CREATE TABLE webhooks (
     encryption_key_id text,
     uuid uuid DEFAULT gen_random_uuid() NOT NULL,
     created_by_user_id integer,
-    updated_by_user_id integer
+    updated_by_user_id integer,
+    name text
 );
 
 COMMENT ON TABLE webhooks IS 'Webhooks registered in Sourcegraph instance.';
@@ -3707,6 +3708,8 @@ COMMENT ON COLUMN webhooks.secret IS 'Secret used to decrypt webhook payload (if
 COMMENT ON COLUMN webhooks.created_by_user_id IS 'ID of a user, who created the webhook. If NULL, then the user does not exist (never existed or was deleted).';
 
 COMMENT ON COLUMN webhooks.updated_by_user_id IS 'ID of a user, who updated the webhook. If NULL, then the user does not exist (never existed or was deleted).';
+
+COMMENT ON COLUMN webhooks.name IS 'Descriptive name of a webhook.';
 
 CREATE SEQUENCE webhooks_id_seq
     AS integer


### PR DESCRIPTION
This commit doesn't include changes in GraphQL layer, these will follow in the next one for the sake of keeping the commits smaller.

Test plan:
`sg migration` up-down-up, updated tests.

Closes https://github.com/sourcegraph/sourcegraph/issues/44754