### PR TITLE
web: use webhook name in views.

### DIFF
--- a/client/web/src/site-admin/SiteAdminWebhookPage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookPage.story.tsx
@@ -40,7 +40,7 @@ export const SiteAdminWebhookPageStory: Story = args => {
             },
             result: {
                 data: {
-                    node: createWebhookMock(ExternalServiceKind.GITHUB, 'github.com/repo1'),
+                    node: createWebhookMock(ExternalServiceKind.GITHUB, 'https://github.com/'),
                 },
             },
             nMatches: Number.POSITIVE_INFINITY,
@@ -137,6 +137,7 @@ function createWebhookMock(kind: ExternalServiceKind, urn: string): WebhookField
         __typename: 'Webhook',
         createdAt: formatRFC3339(TIMESTAMP_MOCK),
         id: '1',
+        name: 'GitHub.com commit push webhook',
         secret: 'secret-secret',
         updatedAt: formatRFC3339(TIMESTAMP_MOCK),
         url: 'sg.com/.api/webhooks/1aa2b42c-a14c-4aaa-b756-70c82e94d3e7',

--- a/client/web/src/site-admin/SiteAdminWebhookPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookPage.tsx
@@ -53,7 +53,7 @@ export const SiteAdminWebhookPage: FC<WebhookPageProps> = props => {
                     path={[
                         { icon: mdiCog },
                         { to: '/site-admin/webhooks', text: 'Incoming webhooks' },
-                        { text: webhookData.node.codeHostURN },
+                        { text: webhookData.node.name },
                     ]}
                     byline={
                         <CreatedByAndUpdatedByInfoByline

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.story.tsx
@@ -76,11 +76,31 @@ export const FiveWebhooksFound: Story = () => (
                                 data: {
                                     webhooks: {
                                         nodes: [
-                                            createWebhookMock('Bitbucket Cloud commit webhook', ExternalServiceKind.BITBUCKETCLOUD, 'https://bitbucket.com/'),
-                                            createWebhookMock('Github.com commit webhook', ExternalServiceKind.GITHUB, 'https://github.com/'),
-                                            createWebhookMock('Github.com PR push webhook', ExternalServiceKind.GITHUB, 'https://github.com/'),
-                                            createWebhookMock('Github.com PR creation webhook', ExternalServiceKind.GITHUB, 'https://github.com/'),
-                                            createWebhookMock('Bitbucket Cloud PR webhook', ExternalServiceKind.BITBUCKETCLOUD, 'https://bitbucket.com/'),
+                                            createWebhookMock(
+                                                'Bitbucket Cloud commit webhook',
+                                                ExternalServiceKind.BITBUCKETCLOUD,
+                                                'https://bitbucket.com/'
+                                            ),
+                                            createWebhookMock(
+                                                'Github.com commit webhook',
+                                                ExternalServiceKind.GITHUB,
+                                                'https://github.com/'
+                                            ),
+                                            createWebhookMock(
+                                                'Github.com PR push webhook',
+                                                ExternalServiceKind.GITHUB,
+                                                'https://github.com/'
+                                            ),
+                                            createWebhookMock(
+                                                'Github.com PR creation webhook',
+                                                ExternalServiceKind.GITHUB,
+                                                'https://github.com/'
+                                            ),
+                                            createWebhookMock(
+                                                'Bitbucket Cloud PR webhook',
+                                                ExternalServiceKind.BITBUCKETCLOUD,
+                                                'https://bitbucket.com/'
+                                            ),
                                         ],
                                         totalCount: 5,
                                         pageInfo: {
@@ -111,7 +131,7 @@ function createWebhookMock(name: string, kind: ExternalServiceKind, urn: string)
         __typename: 'Webhook',
         createdAt: '',
         id: `webhook-${urn}`,
-        name: name,
+        name,
         secret: null,
         updatedAt: '',
         url: '',

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.story.tsx
@@ -76,17 +76,11 @@ export const FiveWebhooksFound: Story = () => (
                                 data: {
                                     webhooks: {
                                         nodes: [
-                                            createWebhookMock(
-                                                ExternalServiceKind.BITBUCKETCLOUD,
-                                                'bitbucket.com/repo1'
-                                            ),
-                                            createWebhookMock(ExternalServiceKind.GITHUB, 'github.com/repo1'),
-                                            createWebhookMock(ExternalServiceKind.GITHUB, 'github.com/repo2'),
-                                            createWebhookMock(ExternalServiceKind.GITHUB, 'github.com/repo3'),
-                                            createWebhookMock(
-                                                ExternalServiceKind.BITBUCKETCLOUD,
-                                                'bitbucket.com/repo2'
-                                            ),
+                                            createWebhookMock('Bitbucket Cloud commit webhook', ExternalServiceKind.BITBUCKETCLOUD, 'https://bitbucket.com/'),
+                                            createWebhookMock('Github.com commit webhook', ExternalServiceKind.GITHUB, 'https://github.com/'),
+                                            createWebhookMock('Github.com PR push webhook', ExternalServiceKind.GITHUB, 'https://github.com/'),
+                                            createWebhookMock('Github.com PR creation webhook', ExternalServiceKind.GITHUB, 'https://github.com/'),
+                                            createWebhookMock('Bitbucket Cloud PR webhook', ExternalServiceKind.BITBUCKETCLOUD, 'https://bitbucket.com/'),
                                         ],
                                         totalCount: 5,
                                         pageInfo: {
@@ -112,11 +106,12 @@ export const FiveWebhooksFound: Story = () => (
 
 FiveWebhooksFound.storyName = '5 webhooks found'
 
-function createWebhookMock(kind: ExternalServiceKind, urn: string): WebhookFields {
+function createWebhookMock(name: string, kind: ExternalServiceKind, urn: string): WebhookFields {
     return {
         __typename: 'Webhook',
         createdAt: '',
         id: `webhook-${urn}`,
+        name: name,
         secret: null,
         updatedAt: '',
         url: '',

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
@@ -63,6 +63,7 @@ export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChild
                         {connection?.nodes?.map(node => (
                             <WebhookNode
                                 key={node.id}
+                                name={node.name}
                                 id={node.id}
                                 codeHostKind={node.codeHostKind}
                                 codeHostURN={node.codeHostURN}

--- a/client/web/src/site-admin/WebhookInformation.story.tsx
+++ b/client/web/src/site-admin/WebhookInformation.story.tsx
@@ -26,6 +26,7 @@ function createWebhook(): WebhookFields {
         __typename: 'Webhook',
         createdAt: formatRFC3339(TIMESTAMP_MOCK),
         id: '1',
+        name: 'webhook with name',
         secret: 'secret-secret',
         updatedAt: formatRFC3339(addMinutes(TIMESTAMP_MOCK, 5)),
         url: 'sg.com/.api/webhooks/1aa2b42c-a14c-4aaa-b756-70c82e94d3e7',

--- a/client/web/src/site-admin/WebhookNode.tsx
+++ b/client/web/src/site-admin/WebhookNode.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { mdiCog, mdiDelete } from '@mdi/js'
 
-import { Button, H3, Icon, Link, Tooltip } from '@sourcegraph/wildcard'
+import { Button, H3, Icon, Link, Text, Tooltip } from '@sourcegraph/wildcard'
 
 import { defaultExternalServices } from '../components/externalServices/externalServices'
 import { ExternalServiceKind } from '../graphql-operations'
@@ -11,12 +11,14 @@ import styles from './WebhookNode.module.scss'
 
 export interface WebhookProps {
     id: string
+    name: string
     codeHostKind: ExternalServiceKind
     codeHostURN: string
 }
 
 export const WebhookNode: React.FunctionComponent<React.PropsWithChildren<WebhookProps>> = ({
     id,
+    name,
     codeHostKind,
     codeHostURN,
 }) => {
@@ -27,8 +29,13 @@ export const WebhookNode: React.FunctionComponent<React.PropsWithChildren<Webhoo
             <div className="pl-1">
                 <H3 className="pr-2">
                     {' '}
-                    <Icon inline={true} as={IconComponent} aria-label="Code host logo" className="mr-2" />
-                    <Link to={`/site-admin/webhooks/${id}`}>{codeHostURN}</Link>
+                    <Link to={`/site-admin/webhooks/${id}`}>{name}</Link>
+                    <Text className="mb-0">
+                        <small>
+                            <Icon inline={true} as={IconComponent} aria-label="Code host logo" className="mr-2" />
+                            {codeHostURN}
+                        </small>
+                    </Text>
                 </H3>
             </div>
             <div className="d-flex flex-shrink-0 ml-3">

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -919,6 +919,7 @@ const WEBHOOK_FIELDS_FRAGMENT = gql`
         id
         uuid
         url
+        name
         codeHostKind
         codeHostURN
         secret

--- a/cmd/frontend/backend/webhooks.go
+++ b/cmd/frontend/backend/webhooks.go
@@ -23,7 +23,7 @@ func NewWebhookService(db database.DB, keyRing keyring.Ring) webhookService {
 	}
 }
 
-func (ws *webhookService) CreateWebhook(ctx context.Context, codeHostKind, codeHostURN string, secretStr *string) (*types.Webhook, error) {
+func (ws *webhookService) CreateWebhook(ctx context.Context, name, codeHostKind, codeHostURN string, secretStr *string) (*types.Webhook, error) {
 	err := validateCodeHostKindAndSecret(codeHostKind, secretStr)
 	if err != nil {
 		return nil, err
@@ -32,7 +32,7 @@ func (ws *webhookService) CreateWebhook(ctx context.Context, codeHostKind, codeH
 	if secretStr != nil {
 		secret = types.NewUnencryptedSecret(*secretStr)
 	}
-	return ws.db.Webhooks(ws.keyRing.WebhookKey).Create(ctx, codeHostKind, codeHostURN, actor.FromContext(ctx).UID, secret)
+	return ws.db.Webhooks(ws.keyRing.WebhookKey).Create(ctx, name, codeHostKind, codeHostURN, actor.FromContext(ctx).UID, secret)
 }
 
 func validateCodeHostKindAndSecret(codeHostKind string, secret *string) error {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -106,7 +106,7 @@ type Mutation {
     """
     Creates a webhook for the specified code host. Only site admins may perform this mutation.
     """
-    createWebhook(codeHostKind: String!, codeHostURN: String!, secret: String): Webhook!
+    createWebhook(name: String!, codeHostKind: String!, codeHostURN: String!, secret: String): Webhook!
 
     """
     Deletes a webhook by given ID. Only site admins may perform this mutation.
@@ -7938,6 +7938,10 @@ type Webhook implements Node {
     The URL of the webhook in the instance. This is the location where we expect to receive payloads.
     """
     url: String!
+    """
+    Descriptive webhook name.
+    """
+    name: String!
     """
     The kind of code host sending payloads. (eg. GitHub, GitLab)
     """

--- a/cmd/frontend/graphqlbackend/webhooks.go
+++ b/cmd/frontend/graphqlbackend/webhooks.go
@@ -29,6 +29,7 @@ type WebhookResolver interface {
 	ID() graphql.ID
 	UUID() string
 	URL() (string, error)
+	Name() string
 	CodeHostURN() string
 	CodeHostKind() string
 	Secret(ctx context.Context) (*string, error)
@@ -39,6 +40,7 @@ type WebhookResolver interface {
 }
 
 type CreateWebhookArgs struct {
+	Name         string
 	CodeHostKind string
 	CodeHostURN  string
 	Secret       *string

--- a/cmd/frontend/webhooks/webhooks_test.go
+++ b/cmd/frontend/webhooks/webhooks_test.go
@@ -40,6 +40,7 @@ func TestWebhooksHandler(t *testing.T) {
 	dbWebhooks := db.Webhooks(keyring.Default().WebhookKey)
 	gitLabWH, err := dbWebhooks.Create(
 		context.Background(),
+		"gitLabWH",
 		extsvc.KindGitLab,
 		"http://gitlab.com",
 		u.ID,
@@ -48,6 +49,7 @@ func TestWebhooksHandler(t *testing.T) {
 
 	gitHubWH, err := dbWebhooks.Create(
 		context.Background(),
+		"gitHubWH",
 		extsvc.KindGitHub,
 		"http://github.com",
 		u.ID,
@@ -57,6 +59,7 @@ func TestWebhooksHandler(t *testing.T) {
 
 	gitHubWHNoSecret, err := dbWebhooks.Create(
 		context.Background(),
+		"gitHubWHNoSecret",
 		extsvc.KindGitHub,
 		"http://github.com",
 		u.ID,
@@ -66,6 +69,7 @@ func TestWebhooksHandler(t *testing.T) {
 
 	bbServerWH, err := dbWebhooks.Create(
 		context.Background(),
+		"bbServerWH",
 		extsvc.KindBitbucketServer,
 		"http://bitbucket.com",
 		u.ID,

--- a/dev/ci/go-backcompat/flakefiles/v4.1.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.1.0.json
@@ -15,7 +15,7 @@
     "reason": "Flakes repeatedly in CI"
   },
   {
-    "path": "github.com/sourcegraph/sourcegraph/internal/database",
+    "path": "internal/database",
     "prefix": "TestWebhookList",
     "reason": "New NOT NULL `name` column is added. The test is trying to add an entry without populating this column."
   }

--- a/dev/ci/go-backcompat/flakefiles/v4.1.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.1.0.json
@@ -16,7 +16,7 @@
   },
   {
     "path": "github.com/sourcegraph/sourcegraph/internal/database",
-    "prefix": "WebhookList",
+    "prefix": "TestWebhookList",
     "reason": "New NOT NULL `name` column is added. The test is trying to add an entry without populating this column."
   }
 ]

--- a/dev/ci/go-backcompat/flakefiles/v4.1.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.1.0.json
@@ -13,5 +13,10 @@
     "path": "github.com/sourcegraph/sourcegraph/internal/repos",
     "prefix": "EnqueueWebhookBuildJob",
     "reason": "Flakes repeatedly in CI"
+  },
+  {
+    "path": "github.com/sourcegraph/sourcegraph/internal/database",
+    "prefix": "WebhookList",
+    "reason": "New NOT NULL `name` column is added. The test is trying to add an entry without populating this column."
   }
 ]

--- a/dev/ci/go-backcompat/flakefiles/v4.1.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.1.0.json
@@ -16,7 +16,38 @@
   },
   {
     "path": "internal/database",
+    "prefix": "TestWebhookCreate",
+    "reason": "New NOT NULL `name` column is added. The test is trying to add an entry without populating this column."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestWebhookDelete",
+    "reason": "New NOT NULL `name` column is added. The test is trying to add an entry without populating this column."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestWebhookUpdate",
+    "reason": "New NOT NULL `name` column is added. The test is trying to add an entry without populating this column."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestWebhookCount",
+    "reason": "New NOT NULL `name` column is added. The test is trying to add an entry without populating this column."
+  },
+  {
+    "path": "internal/database",
     "prefix": "TestWebhookList",
+    "reason": "New NOT NULL `name` column is added. The test is trying to add an entry without populating this column."
+  },
+
+  {
+    "path": "internal/database",
+    "prefix": "TestGetByID",
+    "reason": "New NOT NULL `name` column is added. The test is trying to add an entry without populating this column."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestGetByUUID",
     "reason": "New NOT NULL `name` column is added. The test is trying to add an entry without populating this column."
   }
 ]

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
@@ -41,7 +41,7 @@ func (r *webhooksResolver) CreateWebhook(ctx context.Context, args *graphqlbacke
 		return nil, auth.ErrMustBeSiteAdmin
 	}
 	ws := backend.NewWebhookService(r.db, keyring.Default())
-	webhook, err := ws.CreateWebhook(ctx, args.CodeHostKind, args.CodeHostURN, args.Secret)
+	webhook, err := ws.CreateWebhook(ctx, args.CodeHostKind, args.CodeHostKind, args.CodeHostURN, args.Secret)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
@@ -230,6 +230,10 @@ func (r *webhookResolver) URL() (string, error) {
 	return externalURL.String(), nil
 }
 
+func (r *webhookResolver) Name() string {
+	return r.hook.Name
+}
+
 func (r *webhookResolver) CodeHostURN() string {
 	return r.hook.CodeHostURN.String()
 }

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
@@ -373,15 +373,16 @@ func TestCreateWebhook(t *testing.T) {
 	whUUID, err := uuid.NewUUID()
 	assert.NoError(t, err)
 	expectedWebhook := types.Webhook{
-		ID: 1, UUID: whUUID,
+		ID: 1, UUID: whUUID, Name: "webhookName",
 	}
 	webhookStore.CreateFunc.SetDefaultReturn(&expectedWebhook, nil)
 
 	db := database.NewMockDB()
 	db.WebhooksFunc.SetDefaultReturn(webhookStore)
 	db.UsersFunc.SetDefaultReturn(users)
-	queryStr := `mutation CreateWebhook($codeHostKind: String!, $codeHostURN: String!, $secret: String) {
-				createWebhook(codeHostKind: $codeHostKind, codeHostURN: $codeHostURN, secret: $secret) {
+	queryStr := `mutation CreateWebhook($name: String!, $codeHostKind: String!, $codeHostURN: String!, $secret: String) {
+				createWebhook(name: $name, codeHostKind: $codeHostKind, codeHostURN: $codeHostURN, secret: $secret) {
+					name
 					id
 					uuid
 				}
@@ -397,12 +398,14 @@ func TestCreateWebhook(t *testing.T) {
 			ExpectedResult: fmt.Sprintf(`
 				{
 					"createWebhook": {
+						"name": "webhookName",
 						"id": "V2ViaG9vazox",
 						"uuid": "%s"
 					}
 				}
 			`, whUUID),
 			Variables: map[string]any{
+				"name":         "webhookName",
 				"codeHostKind": "GITHUB",
 				"codeHostURN":  "https://github.com",
 			},
@@ -420,6 +423,7 @@ func TestCreateWebhook(t *testing.T) {
 				},
 			},
 			Variables: map[string]any{
+				"name":         "webhookName",
 				"codeHostKind": "InvalidKind",
 				"codeHostURN":  "https://github.com",
 			},
@@ -437,6 +441,7 @@ func TestCreateWebhook(t *testing.T) {
 				},
 			},
 			Variables: map[string]any{
+				"name":         "webhookName",
 				"codeHostKind": "BITBUCKETCLOUD",
 				"codeHostURN":  "https://bitbucket.com",
 				"secret":       "mysupersecret",
@@ -459,6 +464,7 @@ func TestCreateWebhook(t *testing.T) {
 			},
 		},
 		Variables: map[string]any{
+			"name":         "webhookName",
 			"codeHostKind": "GITHUB",
 			"codeHostURN":  "https://github.com",
 			"secret":       "mysupersecret",

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -52472,7 +52472,7 @@ func NewMockWebhookStore() *MockWebhookStore {
 			},
 		},
 		CreateFunc: &WebhookStoreCreateFunc{
-			defaultHook: func(context.Context, string, string, int32, *encryption.Encryptable) (r0 *types.Webhook, r1 error) {
+			defaultHook: func(context.Context, string, string, string, int32, *encryption.Encryptable) (r0 *types.Webhook, r1 error) {
 				return
 			},
 		},
@@ -52519,7 +52519,7 @@ func NewStrictMockWebhookStore() *MockWebhookStore {
 			},
 		},
 		CreateFunc: &WebhookStoreCreateFunc{
-			defaultHook: func(context.Context, string, string, int32, *encryption.Encryptable) (*types.Webhook, error) {
+			defaultHook: func(context.Context, string, string, string, int32, *encryption.Encryptable) (*types.Webhook, error) {
 				panic("unexpected invocation of MockWebhookStore.Create")
 			},
 		},
@@ -52698,23 +52698,23 @@ func (c WebhookStoreCountFuncCall) Results() []interface{} {
 // WebhookStoreCreateFunc describes the behavior when the Create method of
 // the parent MockWebhookStore instance is invoked.
 type WebhookStoreCreateFunc struct {
-	defaultHook func(context.Context, string, string, int32, *encryption.Encryptable) (*types.Webhook, error)
-	hooks       []func(context.Context, string, string, int32, *encryption.Encryptable) (*types.Webhook, error)
+	defaultHook func(context.Context, string, string, string, int32, *encryption.Encryptable) (*types.Webhook, error)
+	hooks       []func(context.Context, string, string, string, int32, *encryption.Encryptable) (*types.Webhook, error)
 	history     []WebhookStoreCreateFuncCall
 	mutex       sync.Mutex
 }
 
 // Create delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockWebhookStore) Create(v0 context.Context, v1 string, v2 string, v3 int32, v4 *encryption.Encryptable) (*types.Webhook, error) {
-	r0, r1 := m.CreateFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.CreateFunc.appendCall(WebhookStoreCreateFuncCall{v0, v1, v2, v3, v4, r0, r1})
+func (m *MockWebhookStore) Create(v0 context.Context, v1 string, v2 string, v3 string, v4 int32, v5 *encryption.Encryptable) (*types.Webhook, error) {
+	r0, r1 := m.CreateFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.CreateFunc.appendCall(WebhookStoreCreateFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the Create method of the
 // parent MockWebhookStore instance is invoked and the hook queue is empty.
-func (f *WebhookStoreCreateFunc) SetDefaultHook(hook func(context.Context, string, string, int32, *encryption.Encryptable) (*types.Webhook, error)) {
+func (f *WebhookStoreCreateFunc) SetDefaultHook(hook func(context.Context, string, string, string, int32, *encryption.Encryptable) (*types.Webhook, error)) {
 	f.defaultHook = hook
 }
 
@@ -52722,7 +52722,7 @@ func (f *WebhookStoreCreateFunc) SetDefaultHook(hook func(context.Context, strin
 // Create method of the parent MockWebhookStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *WebhookStoreCreateFunc) PushHook(hook func(context.Context, string, string, int32, *encryption.Encryptable) (*types.Webhook, error)) {
+func (f *WebhookStoreCreateFunc) PushHook(hook func(context.Context, string, string, string, int32, *encryption.Encryptable) (*types.Webhook, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -52731,19 +52731,19 @@ func (f *WebhookStoreCreateFunc) PushHook(hook func(context.Context, string, str
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *WebhookStoreCreateFunc) SetDefaultReturn(r0 *types.Webhook, r1 error) {
-	f.SetDefaultHook(func(context.Context, string, string, int32, *encryption.Encryptable) (*types.Webhook, error) {
+	f.SetDefaultHook(func(context.Context, string, string, string, int32, *encryption.Encryptable) (*types.Webhook, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *WebhookStoreCreateFunc) PushReturn(r0 *types.Webhook, r1 error) {
-	f.PushHook(func(context.Context, string, string, int32, *encryption.Encryptable) (*types.Webhook, error) {
+	f.PushHook(func(context.Context, string, string, string, int32, *encryption.Encryptable) (*types.Webhook, error) {
 		return r0, r1
 	})
 }
 
-func (f *WebhookStoreCreateFunc) nextHook() func(context.Context, string, string, int32, *encryption.Encryptable) (*types.Webhook, error) {
+func (f *WebhookStoreCreateFunc) nextHook() func(context.Context, string, string, string, int32, *encryption.Encryptable) (*types.Webhook, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -52787,10 +52787,13 @@ type WebhookStoreCreateFuncCall struct {
 	Arg2 string
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 int32
+	Arg3 string
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
-	Arg4 *encryption.Encryptable
+	Arg4 int32
+	// Arg5 is the value of the 6th argument passed to this method
+	// invocation.
+	Arg5 *encryption.Encryptable
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *types.Webhook
@@ -52802,7 +52805,7 @@ type WebhookStoreCreateFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c WebhookStoreCreateFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -20531,7 +20531,7 @@
           "Name": "name",
           "Index": 12,
           "TypeName": "text",
-          "IsNullable": true,
+          "IsNullable": false,
           "Default": "",
           "CharacterMaximumLength": 0,
           "IsIdentity": false,

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -20528,6 +20528,19 @@
           "Comment": ""
         },
         {
+          "Name": "name",
+          "Index": 12,
+          "TypeName": "text",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "Descriptive name of a webhook."
+        },
+        {
           "Name": "secret",
           "Index": 5,
           "TypeName": "text",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -3239,7 +3239,7 @@ Foreign-key constraints:
  uuid               | uuid                     |           | not null | gen_random_uuid()
  created_by_user_id | integer                  |           |          | 
  updated_by_user_id | integer                  |           |          | 
- name               | text                     |           |          | 
+ name               | text                     |           | not null | 
 Indexes:
     "webhooks_pkey" PRIMARY KEY, btree (id)
     "webhooks_uuid_key" UNIQUE CONSTRAINT, btree (uuid)

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -3239,6 +3239,7 @@ Foreign-key constraints:
  uuid               | uuid                     |           | not null | gen_random_uuid()
  created_by_user_id | integer                  |           |          | 
  updated_by_user_id | integer                  |           |          | 
+ name               | text                     |           |          | 
 Indexes:
     "webhooks_pkey" PRIMARY KEY, btree (id)
     "webhooks_uuid_key" UNIQUE CONSTRAINT, btree (uuid)
@@ -3257,6 +3258,8 @@ Webhooks registered in Sourcegraph instance.
 **code_host_urn**: URN of a code host. This column maps to external_service_id column of repo table.
 
 **created_by_user_id**: ID of a user, who created the webhook. If NULL, then the user does not exist (never existed or was deleted).
+
+**name**: Descriptive name of a webhook.
 
 **secret**: Secret used to decrypt webhook payload (if supported by the code host).
 

--- a/internal/database/users_test.go
+++ b/internal/database/users_test.go
@@ -647,7 +647,7 @@ func TestUsers_Delete(t *testing.T) {
 			}
 
 			// Create and update a webhook
-			webhook, err := db.Webhooks(nil).Create(ctx, extsvc.KindGitHub, testURN, user.ID, types.NewUnencryptedSecret("testSecret"))
+			webhook, err := db.Webhooks(nil).Create(ctx, "github webhook", extsvc.KindGitHub, testURN, user.ID, types.NewUnencryptedSecret("testSecret"))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/database/webhook_logs_test.go
+++ b/internal/database/webhook_logs_test.go
@@ -169,7 +169,7 @@ func TestWebhookLogStore(t *testing.T) {
 		assert.Nil(t, esStore.Upsert(ctx, es))
 
 		whStore := tx.Webhooks(keyring.Default().WebhookKey)
-		wh, err := whStore.Create(ctx, extsvc.KindGitHub, "http://github.com", 0, nil)
+		wh, err := whStore.Create(ctx, "github webhook", extsvc.KindGitHub, "http://github.com", 0, nil)
 		require.NoError(t, err)
 
 		store := tx.WebhookLogs(et.TestKey{})

--- a/internal/database/webhooks.go
+++ b/internal/database/webhooks.go
@@ -407,7 +407,7 @@ func scanWebhook(sc dbutil.Scanner, key encryption.Key) (*types.Webhook, error) 
 		&dbutil.NullString{S: &keyID},
 		&dbutil.NullInt32{N: &hook.CreatedByUserID},
 		&dbutil.NullInt32{N: &hook.UpdatedByUserID},
-		&dbutil.NullString{S: &hook.Name},
+		&hook.Name,
 	); err != nil {
 		return nil, err
 	}

--- a/internal/database/webhooks.go
+++ b/internal/database/webhooks.go
@@ -20,7 +20,7 @@ import (
 type WebhookStore interface {
 	basestore.ShareableStore
 
-	Create(ctx context.Context, kind, urn string, actorUID int32, secret *types.EncryptableSecret) (*types.Webhook, error)
+	Create(ctx context.Context, name, kind, urn string, actorUID int32, secret *types.EncryptableSecret) (*types.Webhook, error)
 	GetByID(ctx context.Context, id int32) (*types.Webhook, error)
 	GetByUUID(ctx context.Context, id uuid.UUID) (*types.Webhook, error)
 	Delete(ctx context.Context, opts DeleteWebhookOpts) error
@@ -63,7 +63,7 @@ type GetWebhookOpts WebhookOpts
 // If encryption IS enabled then the encrypted value will be stored in secret and
 // the encryption_key_id field will also be populated so that we can decrypt the
 // value later.
-func (s *webhookStore) Create(ctx context.Context, kind, urn string, actorUID int32, secret *types.EncryptableSecret) (*types.Webhook, error) {
+func (s *webhookStore) Create(ctx context.Context, name, kind, urn string, actorUID int32, secret *types.EncryptableSecret) (*types.Webhook, error) {
 	var (
 		err             error
 		encryptedSecret string
@@ -81,6 +81,7 @@ func (s *webhookStore) Create(ctx context.Context, kind, urn string, actorUID in
 	}
 
 	q := sqlf.Sprintf(webhookCreateQueryFmtstr,
+		name,
 		kind,
 		urn,
 		dbutil.NullStringColumn(encryptedSecret),
@@ -101,6 +102,7 @@ func (s *webhookStore) Create(ctx context.Context, kind, urn string, actorUID in
 const webhookCreateQueryFmtstr = `
 INSERT INTO
 	webhooks (
+        name,
 		code_host_kind,
 		code_host_urn,
 		secret,
@@ -108,6 +110,7 @@ INSERT INTO
 		created_by_user_id
 	)
 	VALUES (
+		%s,
 		%s,
 		%s,
 		%s,
@@ -128,6 +131,7 @@ var webhookColumns = []*sqlf.Query{
 	sqlf.Sprintf("encryption_key_id"),
 	sqlf.Sprintf("created_by_user_id"),
 	sqlf.Sprintf("updated_by_user_id"),
+	sqlf.Sprintf("name"),
 }
 
 const webhookGetFmtstr = `
@@ -261,7 +265,7 @@ func (s *webhookStore) Update(ctx context.Context, actorUID int32, newWebhook *t
 	}
 
 	q := sqlf.Sprintf(webhookUpdateQueryFmtstr,
-		newWebhook.CodeHostURN.String(), encryptedSecret, keyID, dbutil.NullInt32Column(actorUID), newWebhook.ID,
+		newWebhook.Name, newWebhook.CodeHostURN.String(), encryptedSecret, keyID, dbutil.NullInt32Column(actorUID), newWebhook.ID,
 		sqlf.Join(webhookColumns, ", "))
 
 	updated, err := scanWebhook(s.QueryRow(ctx, q), s.key)
@@ -278,6 +282,7 @@ func (s *webhookStore) Update(ctx context.Context, actorUID int32, newWebhook *t
 const webhookUpdateQueryFmtstr = `
 UPDATE webhooks
 SET
+    name = %s,
 	code_host_urn = %s,
 	secret = %s,
 	encryption_key_id = %s,
@@ -402,6 +407,7 @@ func scanWebhook(sc dbutil.Scanner, key encryption.Key) (*types.Webhook, error) 
 		&dbutil.NullString{S: &keyID},
 		&dbutil.NullInt32{N: &hook.CreatedByUserID},
 		&dbutil.NullInt32{N: &hook.UpdatedByUserID},
+		&dbutil.NullString{S: &hook.Name},
 	); err != nil {
 		return nil, err
 	}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1684,12 +1684,14 @@ func NewEncryptedSecret(cipher, keyID string, key encryption.Key) *EncryptableSe
 }
 
 // Webhook defines the information we need to handle incoming webhooks from a
-// code host
+// code host.
 type Webhook struct {
-	// The primary key, used for sorting and pagination
+	// The primary key, used for sorting and pagination.
 	ID int32
-	// UUID is the ID we display externally and will appear in the webhook URL
-	UUID         uuid.UUID
+	// UUID is the ID we display externally and will appear in the webhook URL.
+	UUID uuid.UUID
+	// Name is a descriptive webhook name which is shown on the UI for convenience.
+	Name         string
 	CodeHostKind string
 	CodeHostURN  extsvc.CodeHostBaseURL
 	// Secret can be in one of three states:

--- a/migrations/frontend/1669184869_add_name_to_webhooks_table/down.sql
+++ b/migrations/frontend/1669184869_add_name_to_webhooks_table/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE webhooks
+    DROP COLUMN IF EXISTS name;

--- a/migrations/frontend/1669184869_add_name_to_webhooks_table/metadata.yaml
+++ b/migrations/frontend/1669184869_add_name_to_webhooks_table/metadata.yaml
@@ -1,0 +1,2 @@
+name: add name to webhooks table
+parents: [1666398757, 1668808118]

--- a/migrations/frontend/1669184869_add_name_to_webhooks_table/up.sql
+++ b/migrations/frontend/1669184869_add_name_to_webhooks_table/up.sql
@@ -1,6 +1,5 @@
 ALTER TABLE webhooks
-    DROP COLUMN IF EXISTS name,
-    ADD COLUMN name TEXT;
+    ADD COLUMN IF NOT EXISTS name TEXT;
 
 COMMENT ON COLUMN webhooks.name IS 'Descriptive name of a webhook.';
 

--- a/migrations/frontend/1669184869_add_name_to_webhooks_table/up.sql
+++ b/migrations/frontend/1669184869_add_name_to_webhooks_table/up.sql
@@ -2,3 +2,8 @@ ALTER TABLE webhooks
     ADD COLUMN IF NOT EXISTS name TEXT;
 
 COMMENT ON COLUMN webhooks.name IS 'Descriptive name of a webhook.';
+
+UPDATE webhooks SET name = code_host_urn WHERE name IS NULL;
+
+ALTER TABLE webhooks
+    ALTER COLUMN name SET NOT NULL;

--- a/migrations/frontend/1669184869_add_name_to_webhooks_table/up.sql
+++ b/migrations/frontend/1669184869_add_name_to_webhooks_table/up.sql
@@ -1,5 +1,6 @@
 ALTER TABLE webhooks
-    ADD COLUMN IF NOT EXISTS name TEXT;
+    DROP COLUMN IF EXISTS name,
+    ADD COLUMN name TEXT;
 
 COMMENT ON COLUMN webhooks.name IS 'Descriptive name of a webhook.';
 

--- a/migrations/frontend/1669184869_add_name_to_webhooks_table/up.sql
+++ b/migrations/frontend/1669184869_add_name_to_webhooks_table/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE webhooks
+    ADD COLUMN IF NOT EXISTS name TEXT;
+
+COMMENT ON COLUMN webhooks.name IS 'Descriptive name of a webhook.';

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3694,7 +3694,7 @@ CREATE TABLE webhooks (
     uuid uuid DEFAULT gen_random_uuid() NOT NULL,
     created_by_user_id integer,
     updated_by_user_id integer,
-    name text
+    name text NOT NULL
 );
 
 COMMENT ON TABLE webhooks IS 'Webhooks registered in Sourcegraph instance.';

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3693,7 +3693,8 @@ CREATE TABLE webhooks (
     encryption_key_id text,
     uuid uuid DEFAULT gen_random_uuid() NOT NULL,
     created_by_user_id integer,
-    updated_by_user_id integer
+    updated_by_user_id integer,
+    name text
 );
 
 COMMENT ON TABLE webhooks IS 'Webhooks registered in Sourcegraph instance.';
@@ -3707,6 +3708,8 @@ COMMENT ON COLUMN webhooks.secret IS 'Secret used to decrypt webhook payload (if
 COMMENT ON COLUMN webhooks.created_by_user_id IS 'ID of a user, who created the webhook. If NULL, then the user does not exist (never existed or was deleted).';
 
 COMMENT ON COLUMN webhooks.updated_by_user_id IS 'ID of a user, who updated the webhook. If NULL, then the user does not exist (never existed or was deleted).';
+
+COMMENT ON COLUMN webhooks.name IS 'Descriptive name of a webhook.';
 
 CREATE SEQUENCE webhooks_id_seq
     AS integer


### PR DESCRIPTION
This commit includes changes in GraphQL layer and UI.

Follow up to https://github.com/sourcegraph/sourcegraph/pull/44756.

Closes https://github.com/sourcegraph/sourcegraph/issues/44757

Test plan:
Updated storybook and local sg run with visual checks.

### Changes
![image](https://user-images.githubusercontent.com/94846361/203523807-def22911-bad9-463a-927d-f8b58afa5ec5.png)

![image](https://user-images.githubusercontent.com/94846361/203523990-f78ce1b3-fc1e-45d9-a98a-d50841999361.png)
