### PR TITLE
bext: fix selectors for GitHub

### DIFF
--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 
 ## Unreleased
 
+- Fix selectors used to inject Sourcegraph code intelligence on GitHub: [issues/44759](https://github.com/sourcegraph/sourcegraph/issues/44759), [pull/44766](https://github.com/sourcegraph/sourcegraph/pull/44766)
+
 ## Chrome 22.11.14.1520, Firefox 22.11.14.1521, Safari v1.18
 
 - Add new GitHub UI support: [issues/44237](https://github.com/sourcegraph/sourcegraph/issues/44237), [pull/44285](https://github.com/sourcegraph/sourcegraph/pull/44285)

--- a/client/browser/src/shared/code-hosts/github/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/github/codeHost.tsx
@@ -437,6 +437,7 @@ const isSimpleSearchPage = (): boolean => window.location.pathname === '/search'
 const isAdvancedSearchPage = (): boolean => window.location.pathname === '/search/advanced'
 const isRepoSearchPage = (): boolean => !isSimpleSearchPage() && window.location.pathname.endsWith('/search')
 const isSearchResultsPage = (): boolean =>
+    // TODO(#44327): Do not rely on window.location.search - it may be present not only on search pages (e.g., issues, pulls, etc.).
     Boolean(new URLSearchParams(window.location.search).get('q')) && !isAdvancedSearchPage()
 const isSearchPage = (): boolean =>
     isSimpleSearchPage() || isAdvancedSearchPage() || isRepoSearchPage() || isSearchResultsPage()

--- a/client/browser/src/shared/code-hosts/github/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/github/codeHost.tsx
@@ -206,7 +206,7 @@ const fileLineContainerResolver: ViewResolver<CodeView> = {
             // this is not a single-file code view
             return null
         }
-        const repositoryContent = fileLineContainer.closest('.repository-content')
+        const repositoryContent = fileLineContainer.closest('.repository-content, #repo-content-turbo-frame')
         if (!repositoryContent) {
             throw new Error('Could not find repository content element')
         }
@@ -694,9 +694,10 @@ export const githubCodeHost: GithubCodeHost = {
                 }
 
                 // search results page filters being applied
-                if (isSearchResultsPage()) {
-                    return document.querySelector('.codesearch-results h3')?.textContent?.trim()
-                }
+                // TODO(#44327): Uncomment or remove this depending on the outcome of the issue.
+                // if (isSearchResultsPage()) {
+                //     return document.querySelector('.codesearch-results h3')?.textContent?.trim()
+                // }
 
                 // other pages
                 return pathname

--- a/client/browser/src/shared/code-hosts/github/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/github/codeHost.tsx
@@ -437,7 +437,6 @@ const isSimpleSearchPage = (): boolean => window.location.pathname === '/search'
 const isAdvancedSearchPage = (): boolean => window.location.pathname === '/search/advanced'
 const isRepoSearchPage = (): boolean => !isSimpleSearchPage() && window.location.pathname.endsWith('/search')
 const isSearchResultsPage = (): boolean =>
-    // TODO(#44327): Do not rely on window.location.search - it may be present not only on search pages (e.g., issues, pulls, etc.).
     Boolean(new URLSearchParams(window.location.search).get('q')) && !isAdvancedSearchPage()
 const isSearchPage = (): boolean =>
     isSimpleSearchPage() || isAdvancedSearchPage() || isRepoSearchPage() || isSearchResultsPage()
@@ -697,10 +696,9 @@ export const githubCodeHost: GithubCodeHost = {
                 }
 
                 // search results page filters being applied
-                // TODO(#44327): Uncomment or remove this depending on the outcome of the issue.
-                // if (isSearchResultsPage()) {
-                //     return document.querySelector('.codesearch-results h3')?.textContent?.trim()
-                // }
+                if (isSearchResultsPage()) {
+                    return document.querySelector('.codesearch-results h3')?.textContent?.trim()
+                }
 
                 // other pages
                 return pathname

--- a/client/browser/src/shared/code-hosts/github/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/github/codeHost.tsx
@@ -206,6 +206,8 @@ const fileLineContainerResolver: ViewResolver<CodeView> = {
             // this is not a single-file code view
             return null
         }
+
+        // selector depends on whether the page was rendered using the client-side navigation or not
         const repositoryContent = fileLineContainer.closest('.repository-content, #repo-content-turbo-frame')
         if (!repositoryContent) {
             throw new Error('Could not find repository content element')

--- a/client/browser/src/shared/code-hosts/github/util.tsx
+++ b/client/browser/src/shared/code-hosts/github/util.tsx
@@ -271,21 +271,18 @@ interface UISelectors {
     codeCell: string
     blobContainer: string
     permalink: string
-    // fileToolbarMountContainer: string
 }
 
 const oldUISelectors: UISelectors = {
     codeCell: 'td.blob-code',
     blobContainer: '.js-file-line-container',
     permalink: 'a.js-permalink-shortcut',
-    // fileToolbarMountContainer: '.file',
 }
 
 const newUISelectors: UISelectors = {
     codeCell: 'td.react-code-cell',
     blobContainer: 'react-app table',
-    permalink: '.ActionList-item--navActive a',
-    // fileToolbarMountContainer: '.file',
+    permalink: 'a.ActionList-item--navActive, .ActionList-item--navActive a',
 }
 
 /**

--- a/client/browser/src/shared/code-hosts/github/util.tsx
+++ b/client/browser/src/shared/code-hosts/github/util.tsx
@@ -282,6 +282,8 @@ const oldUISelectors: UISelectors = {
 const newUISelectors: UISelectors = {
     codeCell: 'td.react-code-cell',
     blobContainer: 'react-app table',
+
+    // the former selector is for the tree view and the latter is for the blob view
     permalink: 'a.ActionList-item--navActive, .ActionList-item--navActive a',
 }
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/44759

Fixes permalink and code container selectors for GitHub:
- permalink selector was not working for the new GitHub UI in tree view
- code container selector was not working for the not logged in user on GitHub ('old' GitHub UI).

https://user-images.githubusercontent.com/25318659/203597865-419cd3d4-a52d-483c-8038-42d0cf0b74d8.mov

## Test plan
Tested manually (videos in description).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-bext-fix-selectors.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

