### PR TITLE
Update go-diff library to include fix

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -220,7 +220,7 @@ func TestRepositoryComparison(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if have, want := rawDiff, testDiff; have != want {
+			if have, want := rawDiff, testDiff+testCopyDiff; have != want {
 				t.Fatalf("rawDiff wrong. want=%q, have=%q", want, have)
 			}
 		})
@@ -279,7 +279,8 @@ func TestRepositoryComparison(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if len(nodes) != testDiffFiles {
+			// +1 for the copyDiffFile
+			if len(nodes) != testDiffFiles+1 {
 				t.Fatalf("wrong length of nodes. want=%d, have=%d", testDiffFiles, len(nodes))
 			}
 
@@ -349,8 +350,8 @@ func TestRepositoryComparison(t *testing.T) {
 		})
 
 		t.Run("Pagination", func(t *testing.T) {
-			endCursors := []string{"1", "2"}
-			totalCount := int32(testDiffFiles)
+			endCursors := []string{"1", "2", "3"}
+			totalCount := int32(testDiffFiles) + 1
 
 			tests := []struct {
 				first int32
@@ -383,6 +384,14 @@ func TestRepositoryComparison(t *testing.T) {
 					first:           1,
 					after:           endCursors[1],
 					wantNodeCount:   1,
+					wantHasNextPage: true,
+					wantEndCursor:   &endCursors[2],
+					wantTotalCount:  nil,
+				},
+				{
+					first:           1,
+					after:           endCursors[2],
+					wantNodeCount:   1,
 					wantHasNextPage: false,
 					wantEndCursor:   nil,
 					wantTotalCount:  &totalCount,
@@ -390,7 +399,7 @@ func TestRepositoryComparison(t *testing.T) {
 				{
 					first:           testDiffFiles + 1,
 					after:           "",
-					wantNodeCount:   testDiffFiles,
+					wantNodeCount:   testDiffFiles + 1,
 					wantHasNextPage: false,
 					wantEndCursor:   nil,
 					wantTotalCount:  &totalCount,

--- a/go.mod
+++ b/go.mod
@@ -129,7 +129,7 @@ require (
 	github.com/smacker/go-tree-sitter v0.0.0-20220209044044-0d3022e933c3
 	github.com/snabb/sitemap v1.0.0
 	github.com/sourcegraph/go-ctags v0.0.0-20220611154803-db463692f037
-	github.com/sourcegraph/go-diff v0.6.1
+	github.com/sourcegraph/go-diff v0.6.2-0.20221123165719-f8cd299c40f3
 	github.com/sourcegraph/go-jsonschema v0.0.0-20211011105148-2e30f7bacbe1
 	github.com/sourcegraph/go-langserver v2.0.1-0.20181108233942-4a51fa2e1238+incompatible
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d

--- a/go.sum
+++ b/go.sum
@@ -2081,8 +2081,8 @@ github.com/sourcegraph/go-ctags v0.0.0-20220611154803-db463692f037 h1:gk2cs5tfGF
 github.com/sourcegraph/go-ctags v0.0.0-20220611154803-db463692f037/go.mod h1:ZYjpRXoJrRlxjU9ZfpaUKJkk62AjhJPffN3rlw2aqxM=
 github.com/sourcegraph/go-diff v0.5.1/go.mod h1:j2dHj3m8aZgQO8lMTcTnBcXkRRRqi34cd2MNlA9u1mE=
 github.com/sourcegraph/go-diff v0.5.3/go.mod h1:v9JDtjCE4HHHCZGId75rg8gkKKa98RVjBcBGsVmMmak=
-github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=
-github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
+github.com/sourcegraph/go-diff v0.6.2-0.20221123165719-f8cd299c40f3 h1:11miag7hlORpW7ici5mL7T9PyiEsmVmf+8PFOvJ/ZrA=
+github.com/sourcegraph/go-diff v0.6.2-0.20221123165719-f8cd299c40f3/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
 github.com/sourcegraph/go-jsonschema v0.0.0-20211011105148-2e30f7bacbe1 h1:FQpHEeQlGQQVl/PZfStW5/XJifxLVym+6FhwOXd/lvo=
 github.com/sourcegraph/go-jsonschema v0.0.0-20211011105148-2e30f7bacbe1/go.mod h1:SJwWIH9fe2RW2FouXEXM4Cm4ZczlewF2xNQAL2VaU1M=
 github.com/sourcegraph/go-langserver v2.0.1-0.20181108233942-4a51fa2e1238+incompatible h1:EX1bSaIbVia2U/Pt/2Z62y8wJS4Z4iNiK5VCeUKuBx8=


### PR DESCRIPTION
See https://github.com/sourcegraph/go-diff/commit/f8cd299c40f3fb1bbccd1b4268454b1488aa3fba for more details, tl;dr this fixes empty added and deleted files on Sourcegraph rendering incorrectly in the diff view (was completely broken before)



## Test plan

Added tests to the library. 