### PR TITLE
otel: update version to 0.66

### DIFF
--- a/docker-images/opentelemetry-collector/build.sh
+++ b/docker-images/opentelemetry-collector/build.sh
@@ -3,7 +3,7 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-export OTEL_COLLECTOR_VERSION="${OTEL_COLLECTOR_VERSION:-0.65.0}"
+export OTEL_COLLECTOR_VERSION="${OTEL_COLLECTOR_VERSION:-0.66.0}"
 
 docker build -t "${IMAGE:-sourcegraph/opentelemetry-collector}" . \
   --platform linux/amd64 \


### PR DESCRIPTION
v0.65 got revoked or superseded by 0.66

- https://github.com/open-telemetry/opentelemetry-collector/issues/6604
## Test plan
Built locally and main-dry-run
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
