### PR TITLE
Cloud CTA variants

### DIFF
--- a/client/web/src/components/CloudCtaBanner.module.scss
+++ b/client/web/src/components/CloudCtaBanner.module.scss
@@ -1,4 +1,11 @@
-.container-outline {
+.filled {
+    background-color: var(--primary-4);
+    border-radius: var(--border-radius);
+    margin: 1rem 0;
+    padding: 0.313rem 1.125rem;
+}
+
+.outlined {
     background-color: var(--color-bg-1);
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius);
@@ -6,9 +13,8 @@
     padding: 0.25rem 0.5rem;
 }
 
-.primary-bg {
-    background-color: var(--primary-4);
-    border-radius: var(--border-radius);
-    margin: 1rem 0;
-    padding: 0.5rem;
+.underlined {
+    background: linear-gradient(to left, var(--blue) 0%, var(--purple) 100%) left bottom no-repeat;
+    background-size: 100% 1px;
+    padding-bottom: 0.5rem;
 }

--- a/client/web/src/components/CloudCtaBanner.module.scss
+++ b/client/web/src/components/CloudCtaBanner.module.scss
@@ -16,5 +16,5 @@
 .underlined {
     background: linear-gradient(to left, var(--blue) 0%, var(--purple) 100%) left bottom no-repeat;
     background-size: 100% 1px;
-    padding-bottom: 0.5rem;
+    padding: 0.375rem 0.5rem;
 }

--- a/client/web/src/components/CloudCtaBanner.tsx
+++ b/client/web/src/components/CloudCtaBanner.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { FunctionComponent, ReactNode } from 'react'
 
 import { mdiArrowRight } from '@mdi/js'
 import classNames from 'classnames'
@@ -7,19 +7,24 @@ import { Icon, Text } from '@sourcegraph/wildcard'
 
 import styles from './CloudCtaBanner.module.scss'
 
-export const CloudCtaBanner: React.FunctionComponent<
-    React.PropsWithChildren<{ outlined?: boolean; className?: string; children: React.ReactNode }>
-> = ({ outlined = false, className, children }) => (
-    <section
-        className={classNames(
-            outlined ? styles.containerOutline : styles.primaryBg,
-            className,
-            'd-flex justify-content-center'
-        )}
-    >
-        <Icon className="mr-2 text-merged" size={outlined ? 'sm' : 'md'} aria-hidden={true} svgPath={mdiArrowRight} />
+export interface CloudCtaBanner {
+    variant?: 'filled' | 'outlined' | 'underlined' | string | undefined
+    small?: boolean
+    className?: string
+    children: ReactNode
+}
 
-        <Text size={outlined ? 'small' : 'base'} className="my-auto">
+export const CloudCtaBanner: FunctionComponent<CloudCtaBanner> = ({ variant, small, className, children }) => (
+    <section
+        className={classNames(className, 'd-flex justify-content-center', {
+            [styles.filled]: variant === 'filled',
+            [styles.outlined]: variant === 'outlined',
+            [styles.underlined]: variant === 'underlined',
+        })}
+    >
+        <Icon className="mr-2 text-merged" size={small ? 'sm' : 'md'} aria-hidden={true} svgPath={mdiArrowRight} />
+
+        <Text size={small ? 'small' : 'base'} className="my-auto">
             {children}
         </Text>
     </section>

--- a/client/web/src/enterprise/batches/list/GettingStarted.tsx
+++ b/client/web/src/enterprise/batches/list/GettingStarted.tsx
@@ -74,7 +74,7 @@ export const GettingStarted: React.FunctionComponent<React.PropsWithChildren<Get
             </div>
         </Container>
         {isSourcegraphDotCom ? (
-            <CloudCtaBanner>
+            <CloudCtaBanner variant="filled">
                 To automate changes across your team's private repos,{' '}
                 <Link
                     to="https://signup.sourcegraph.com/?p=batch"

--- a/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
@@ -62,7 +62,7 @@ export const CodeMonitorList: React.FunctionComponent<React.PropsWithChildren<Co
                     <div className="d-flex align-items-center justify-content-between">
                         <H3 className="mb-2">Your code monitors</H3>
                         {isSourcegraphDotCom && (
-                            <CloudCtaBanner outlined={true}>
+                            <CloudCtaBanner variant="outlined" small={true}>
                                 To monitor changes across your private repos,{' '}
                                 <Link
                                     to="https://signup.sourcegraph.com/?p=monitoring"

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
@@ -102,7 +102,7 @@ export const CodeMonitoringGettingStarted: React.FunctionComponent<
             </Card>
 
             {isSourcegraphDotCom && (
-                <CloudCtaBanner>
+                <CloudCtaBanner variant="filled">
                     To monitor changes across your team's private repositories,{' '}
                     <Link
                         to="https://signup.sourcegraph.com/?p=monitoring"

--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.tsx
@@ -76,7 +76,7 @@ export const CodeInsightsDotComGetStarted: React.FunctionComponent<
                         <CodeInsightsDescription className={styles.heroDescriptionBlock} />
                     </Card>
 
-                    <CloudCtaBanner>
+                    <CloudCtaBanner variant="filled">
                         To track Insights across your team's private repos,{' '}
                         <Link
                             to="https://signup.sourcegraph.com/?p=insights"

--- a/client/web/src/notebooks/listPage/NotebooksGettingStartedTab.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksGettingStartedTab.tsx
@@ -121,7 +121,7 @@ export const NotebooksGettingStartedTab: React.FunctionComponent<
             </Container>
 
             {isSourcegraphDotCom && (
-                <CloudCtaBanner>
+                <CloudCtaBanner variant="filled">
                     To create Notebooks across your team's private repositories,{' '}
                     <Link
                         to="https://signup.sourcegraph.com/?p=notebooks"

--- a/client/web/src/notebooks/listPage/NotebooksListPage.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPage.tsx
@@ -290,7 +290,7 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
                         ))}
 
                         {selectedTab === 'notebooks' && isSourcegraphDotCom && (
-                            <CloudCtaBanner outlined={true} className="ml-sm-auto mt-md-0 mt-3">
+                            <CloudCtaBanner variant="outlined" small={true} className="ml-sm-auto mt-md-0 mt-3">
                                 To create Notebooks across your private repositories,{' '}
                                 <Link
                                     to="https://signup.sourcegraph.com/?p=notebooks"

--- a/client/web/src/search/home/QueryExamplesHomepage.module.scss
+++ b/client/web/src/search/home/QueryExamplesHomepage.module.scss
@@ -58,7 +58,7 @@
 }
 
 .query-examples-items {
-    > * {
+    >* {
         margin-bottom: 0.25rem;
 
         &:last-child {
@@ -88,6 +88,7 @@
 
 .tab-header {
     border: none !important;
+
     @media (--lg-breakpoint-up) {
         justify-content: center !important;
     }
@@ -96,12 +97,4 @@
 .tab-panel {
     // Set a minimum height so the page doesn't shift when changing tabs
     min-height: 21rem;
-}
-
-.pro-tip-title {
-    font-size: 0.75rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    border-right: 1px solid var(--border-color);
-    min-width: 60px;
 }

--- a/client/web/src/search/home/QueryExamplesHomepage.module.scss
+++ b/client/web/src/search/home/QueryExamplesHomepage.module.scss
@@ -58,7 +58,7 @@
 }
 
 .query-examples-items {
-    >* {
+    > * {
         margin-bottom: 0.25rem;
 
         &:last-child {

--- a/client/web/src/search/home/QueryExamplesHomepage.tsx
+++ b/client/web/src/search/home/QueryExamplesHomepage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useState, useEffect } from 'react'
 
 import { mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
@@ -7,9 +7,9 @@ import { useHistory } from 'react-router'
 import { EditorHint, QueryState, SearchPatternType } from '@sourcegraph/search'
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, H2, H4, Link, Icon, Tabs, TabList, TabPanels, TabPanel, Tab } from '@sourcegraph/wildcard'
+import { Button, H2, Link, Icon, Tabs, TabList, TabPanels, TabPanel, Tab } from '@sourcegraph/wildcard'
 
-import { eventLogger } from '../../tracking/eventLogger'
+import { CloudCtaBanner } from '../../components/CloudCtaBanner'
 
 import { exampleQueryColumns } from './QueryExamplesHomepage.constants'
 import { useQueryExamples, QueryExamplesSection } from './useQueryExamples'
@@ -105,10 +105,41 @@ export const QueryExamplesHomepage: React.FunctionComponent<QueryExamplesHomepag
         ]
     )
 
+    const [cloudCtaVariant, setCloudCtaVariant] = useState<CloudCtaBanner['variant'] | string>('filled')
+    useEffect(() => {
+        const searchParams = new URL(window.location.href).searchParams
+        const uxParam = searchParams.get('cta')
+        const allowedVariants: { [key: string]: string | undefined } = {
+            a: 'filled',
+            b: 'underlined',
+            c: undefined,
+            d: 'outlined',
+        }
+
+        if (uxParam && Object.keys(allowedVariants).includes(uxParam)) {
+            setCloudCtaVariant(allowedVariants[uxParam])
+        }
+    }, [])
+
     return (
         <div>
             {isSourcegraphDotCom ? (
                 <>
+                    <div className="d-table mx-auto">
+                        <CloudCtaBanner className="mb-5" variant={cloudCtaVariant}>
+                            To search across your private repositories,{' '}
+                            <Link
+                                to="https://signup.sourcegraph.com"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                onClick={() => telemetryService.log('ClickedOnCloudCTA')}
+                            >
+                                try Sourcegraph Cloud
+                            </Link>
+                            .
+                        </CloudCtaBanner>
+                    </div>
+
                     <Tabs size="medium" onChange={handleTabChange}>
                         <TabList wrapperClassName={classNames('mb-4', styles.tabHeader)}>
                             <Tab key="Code search basics">Code search basics</Tab>
@@ -129,17 +160,6 @@ export const QueryExamplesHomepage: React.FunctionComponent<QueryExamplesHomepag
                             </TabPanel>
                         </TabPanels>
                     </Tabs>
-                    <div className="d-flex align-items-baseline justify-content-lg-center my-5">
-                        <H4 className={classNames('mr-2 mb-0 pr-2', styles.proTipTitle)}>Pro Tip</H4>
-                        <Link
-                            to="https://signup.sourcegraph.com/"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            onClick={() => eventLogger.log('ClickedOnCloudCTA')}
-                        >
-                            Use Sourcegraph to search across your team's code.
-                        </Link>
-                    </div>
                 </>
             ) : (
                 <div>

--- a/client/web/src/search/home/QueryExamplesHomepage.tsx
+++ b/client/web/src/search/home/QueryExamplesHomepage.tsx
@@ -112,8 +112,8 @@ export const QueryExamplesHomepage: React.FunctionComponent<QueryExamplesHomepag
         const allowedVariants: { [key: string]: string | undefined } = {
             a: 'filled',
             b: 'underlined',
-            c: undefined,
-            d: 'outlined',
+            c: 'outlined',
+            d: undefined,
         }
 
         if (uxParam && Object.keys(allowedVariants).includes(uxParam)) {

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -150,7 +150,7 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                         />
                     </TraceSpanProvider>
                 </div>
-                <Notices className="my-3" location="home" settingsCascade={props.settingsCascade} />
+                <Notices className="my-3 text-center" location="home" settingsCascade={props.settingsCascade} />
             </Form>
         </div>
     )


### PR DESCRIPTION
This closes #44770 and modifies our `CloudCtaBanner` component with flexible props.

Variants for UX testing are listed in this [Figma](https://www.figma.com/file/qdUtoveMtn2wI8eaysE1De/UX%3A-Cleaning-up-noise-below-the-search-bar-on-dotcom?node-id=169%3A2790&t=jr4on1XLBuP1Rt9J-0).

- `?cta=a` = filled (also used as the default since this replaces our "Pro Tip" CTA)
- `?cta=b` = underlined
- `?cta=c` = outlined
- `?cta=d` = undefined (no additional styling)

## Changelog
- CloudCtaBanner:
  - `small` prop was added for conditional small text
  - `variant` prop was added to change styling
- centre-aligned the notice on the homepage

## Test plan
- Ensure our CloudCtaBanner renders and looks good on other pages where it's being used
- Test the search param to render the 4 different variants (ie: `?cta=b`)

## App preview:

- [Web](https://sg-web-brett-homepage-cta.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

