### PR TITLE
Support binary patches

### DIFF
--- a/cmd/frontend/graphqlbackend/preview_repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/preview_repository_comparison_test.go
@@ -38,7 +38,7 @@ Line 9
 Line 10
 `
 
-	const testDiff = `diff --git INSTALL.md INSTALL.md
+	var testDiff = []byte(`diff --git INSTALL.md INSTALL.md
 index e5af166..d44c3fc 100644
 --- INSTALL.md
 +++ INSTALL.md
@@ -94,7 +94,8 @@ index 9bd8209..d2acfa9 100644
  Line 9
  Line 10
 +Another line
-`
+`)
+
 	wantBaseRef := "refs/heads/master"
 	wantHeadRevision := api.CommitID("b69072d5f687b31b9f6ae3ceafdc24c259c4b9ec")
 	mockBackendCommits(t, api.CommitID(wantBaseRef), wantHeadRevision)

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -535,7 +535,7 @@ func (r *schemaResolver) ResolvePhabricatorDiff(ctx context.Context, args *struc
 		Repo:       api.RepoName(args.RepoName),
 		BaseCommit: api.CommitID(args.BaseRev),
 		TargetRef:  targetRef,
-		Patch:      patch,
+		Patch:      []byte(patch),
 		CommitInfo: protocol.PatchCommitInfo{
 			AuthorName:  info.AuthorName,
 			AuthorEmail: info.AuthorEmail,

--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -188,7 +189,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 	cmd = exec.CommandContext(ctx, "git", applyArgs...)
 	cmd.Dir = tmpRepoDir
 	cmd.Env = append(os.Environ(), tmpGitPathEnv, altObjectsEnv)
-	cmd.Stdin = strings.NewReader(req.Patch)
+	cmd.Stdin = bytes.NewReader(req.Patch)
 
 	if out, err := run(cmd, "applying patch"); err != nil {
 		logger.Error("Failed to apply patch", log.String("output", string(out)))

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -497,6 +497,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/delete", trace.WithRouteName("delete", s.handleRepoDelete))
 	mux.HandleFunc("/repo-update", trace.WithRouteName("repo-update", s.handleRepoUpdate))
 	mux.HandleFunc("/repo-clone", trace.WithRouteName("repo-clone", s.handleRepoClone))
+	mux.HandleFunc("/create-commit-from-patch-binary", trace.WithRouteName("create-commit-from-patch-binary", s.handleCreateCommitFromPatchBinary))
 	mux.HandleFunc("/create-commit-from-patch", trace.WithRouteName("create-commit-from-patch", s.handleCreateCommitFromPatch))
 	mux.HandleFunc("/ping", trace.WithRouteName("ping", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/enterprise/cmd/batcheshelper/post.go
+++ b/enterprise/cmd/batcheshelper/post.go
@@ -51,7 +51,7 @@ func execPost(ctx context.Context, stepIdx int, executionInput batcheslib.Worksp
 	}
 
 	// Render the step outputs.
-	changes, err := git.ChangesInDiff([]byte(previousResult.Diff))
+	changes, err := git.ChangesInDiff(previousResult.Diff)
 	if err != nil {
 		return errors.Wrap(err, "failed to get changes in diff")
 	}

--- a/enterprise/cmd/batcheshelper/post.go
+++ b/enterprise/cmd/batcheshelper/post.go
@@ -41,10 +41,11 @@ func execPost(ctx context.Context, stepIdx int, executionInput batcheslib.Worksp
 
 	// Build the step result.
 	stepResult := execution.AfterStepResult{
+		Version:   2,
 		Stdout:    string(stdout),
 		Stderr:    string(stderr),
 		StepIndex: stepIdx,
-		Diff:      string(diff),
+		Diff:      diff,
 		// Those will be set below.
 		Outputs: make(map[string]interface{}),
 	}

--- a/enterprise/cmd/batcheshelper/pre.go
+++ b/enterprise/cmd/batcheshelper/pre.go
@@ -26,7 +26,7 @@ func execPre(ctx context.Context, stepIdx int, executionInput batcheslib.Workspa
 
 	step := executionInput.Steps[stepIdx]
 
-	changes, err := git.ChangesInDiff([]byte(previousResult.Diff))
+	changes, err := git.ChangesInDiff(previousResult.Diff)
 	if err != nil {
 		return errors.Wrap(err, "failed to compute changes")
 	}

--- a/enterprise/cmd/executor/internal/apiclient/queue/client.go
+++ b/enterprise/cmd/executor/internal/apiclient/queue/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/apiclient"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/executor"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -81,6 +82,7 @@ func (c *Client) Dequeue(ctx context.Context, queueName string, job *executor.Jo
 	defer endObservation(1, observation.Args{})
 
 	req, err := c.client.NewJSONRequest(http.MethodPost, fmt.Sprintf("%s/dequeue", queueName), executor.DequeueRequest{
+		Version:      version.Version(),
 		ExecutorName: c.options.ExecutorName,
 		NumCPUs:      c.options.ResourceOptions.NumCPUs,
 		Memory:       c.options.ResourceOptions.Memory,

--- a/enterprise/cmd/executor/internal/apiclient/queue/client_test.go
+++ b/enterprise/cmd/executor/internal/apiclient/queue/client_test.go
@@ -27,7 +27,7 @@ func TestDequeue(t *testing.T) {
 		expectedPath:     "/.executors/queue/test_queue/dequeue",
 		expectedUsername: "test",
 		expectedToken:    "hunter2",
-		expectedPayload:  `{"executorName": "deadbeef"}`,
+		expectedPayload:  `{"executorName": "deadbeef", "version": "0.0.0-dev"}`,
 		responseStatus:   http.StatusOK,
 		responsePayload:  `{"id": 42}`,
 	}
@@ -53,7 +53,7 @@ func TestDequeueNoRecord(t *testing.T) {
 		expectedPath:     "/.executors/queue/test_queue/dequeue",
 		expectedUsername: "test",
 		expectedToken:    "hunter2",
-		expectedPayload:  `{"executorName": "deadbeef"}`,
+		expectedPayload:  `{"executorName": "deadbeef", "version": "0.0.0-dev"}`,
 		responseStatus:   http.StatusNoContent,
 		responsePayload:  ``,
 	}
@@ -75,7 +75,7 @@ func TestDequeueBadResponse(t *testing.T) {
 		expectedPath:     "/.executors/queue/test_queue/dequeue",
 		expectedUsername: "test",
 		expectedToken:    "hunter2",
-		expectedPayload:  `{"executorName": "deadbeef"}`,
+		expectedPayload:  `{"executorName": "deadbeef", "version": "0.0.0-dev"}`,
 		responseStatus:   http.StatusInternalServerError,
 		responsePayload:  ``,
 	}

--- a/enterprise/cmd/executor/internal/apiclient/queue/client_test.go
+++ b/enterprise/cmd/executor/internal/apiclient/queue/client_test.go
@@ -27,7 +27,7 @@ func TestDequeue(t *testing.T) {
 		expectedPath:     "/.executors/queue/test_queue/dequeue",
 		expectedUsername: "test",
 		expectedToken:    "hunter2",
-		expectedPayload:  `{"executorName": "deadbeef", "version": "0.0.0-dev"}`,
+		expectedPayload:  `{"executorName": "deadbeef", "version": "0.0.0+dev"}`,
 		responseStatus:   http.StatusOK,
 		responsePayload:  `{"id": 42}`,
 	}
@@ -53,7 +53,7 @@ func TestDequeueNoRecord(t *testing.T) {
 		expectedPath:     "/.executors/queue/test_queue/dequeue",
 		expectedUsername: "test",
 		expectedToken:    "hunter2",
-		expectedPayload:  `{"executorName": "deadbeef", "version": "0.0.0-dev"}`,
+		expectedPayload:  `{"executorName": "deadbeef", "version": "0.0.0+dev"}`,
 		responseStatus:   http.StatusNoContent,
 		responsePayload:  ``,
 	}
@@ -75,7 +75,7 @@ func TestDequeueBadResponse(t *testing.T) {
 		expectedPath:     "/.executors/queue/test_queue/dequeue",
 		expectedUsername: "test",
 		expectedToken:    "hunter2",
-		expectedPayload:  `{"executorName": "deadbeef", "version": "0.0.0-dev"}`,
+		expectedPayload:  `{"executorName": "deadbeef", "version": "0.0.0+dev"}`,
 		responseStatus:   http.StatusInternalServerError,
 		responsePayload:  ``,
 	}

--- a/enterprise/cmd/executor/internal/worker/handler_test.go
+++ b/enterprise/cmd/executor/internal/worker/handler_test.go
@@ -39,7 +39,7 @@ func TestHandle(t *testing.T) {
 		Commit:         "deadbeef",
 		RepositoryName: "linux",
 		VirtualMachineFiles: map[string]executor.VirtualMachineFile{
-			"test.txt": {Content: "<file payload>"},
+			"test.txt": {Content: []byte("<file payload>")},
 		},
 		DockerSteps: []executor.DockerStep{
 			{
@@ -148,7 +148,7 @@ func TestHandle_WorkspaceFile(t *testing.T) {
 		Commit:         "deadbeef",
 		RepositoryName: "linux",
 		VirtualMachineFiles: map[string]executor.VirtualMachineFile{
-			"test.txt":  {Content: "<file payload>"},
+			"test.txt":  {Content: []byte("<file payload>")},
 			"script.sh": {Bucket: "batch-changes", Key: "123/abc", ModifiedAt: virtualFileModifiedAt},
 		},
 		DockerSteps: []executor.DockerStep{

--- a/enterprise/cmd/executor/internal/worker/workspace/files.go
+++ b/enterprise/cmd/executor/internal/worker/workspace/files.go
@@ -43,7 +43,7 @@ func prepareScripts(
 		}
 		// Either write raw content that has already been provided or retrieve it from the store.
 		workspaceFilesByPath[path] = workspaceFile{
-			content:    []byte(machineFile.Content),
+			content:    machineFile.Content,
 			bucket:     machineFile.Bucket,
 			key:        machineFile.Key,
 			modifiedAt: machineFile.ModifiedAt,

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
@@ -161,8 +161,8 @@ func (r *batchSpecWorkspaceStepV1Resolver) Diff(ctx context.Context) (graphqlbac
 	if r.CachedResultFound() {
 		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(r.store.DatabaseDB()), r.repo, r.baseRev, r.cachedResult.Diff)
 	}
-	if r.stepInfo.Diff != nil {
-		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(r.store.DatabaseDB()), r.repo, r.baseRev, *r.stepInfo.Diff)
+	if r.stepInfo.DiffFound {
+		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(r.store.DatabaseDB()), r.repo, r.baseRev, r.stepInfo.Diff)
 	}
 	return nil, nil
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
@@ -455,7 +455,7 @@ func (r *changesetResolver) Diff(ctx context.Context) (graphqlbackend.Repository
 			r.gitserverClient,
 			r.repoResolver,
 			desc.BaseRev,
-			string(desc.Diff),
+			desc.Diff,
 		)
 	}
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
@@ -178,14 +178,14 @@ func (r *changesetDescriptionResolver) DiffStat() *graphqlbackend.DiffStat {
 }
 
 func (r *changesetDescriptionResolver) Diff(ctx context.Context) (graphqlbackend.PreviewRepositoryComparisonResolver, error) {
-	return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(r.store.DatabaseDB()), r.repoResolver, r.spec.BaseRev, string(r.spec.Diff))
+	return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(r.store.DatabaseDB()), r.repoResolver, r.spec.BaseRev, r.spec.Diff)
 }
 
 func (r *changesetDescriptionResolver) Commits() []graphqlbackend.GitCommitDescriptionResolver {
 	return []graphqlbackend.GitCommitDescriptionResolver{&gitCommitDescriptionResolver{
 		store:       r.store,
 		message:     r.spec.CommitMessage,
-		diff:        string(r.spec.Diff),
+		diff:        r.spec.Diff,
 		authorName:  r.spec.CommitAuthorName,
 		authorEmail: r.spec.CommitAuthorEmail,
 	}}
@@ -196,7 +196,7 @@ var _ graphqlbackend.GitCommitDescriptionResolver = &gitCommitDescriptionResolve
 type gitCommitDescriptionResolver struct {
 	store       *store.Store
 	message     string
-	diff        string
+	diff        []byte
 	authorName  string
 	authorEmail string
 }
@@ -221,7 +221,7 @@ func (r *gitCommitDescriptionResolver) Body() *string {
 	}
 	return &body
 }
-func (r *gitCommitDescriptionResolver) Diff() string { return r.diff }
+func (r *gitCommitDescriptionResolver) Diff() string { return string(r.diff) }
 
 type forkTargetResolver struct {
 	changesetSpec *btypes.ChangesetSpec

--- a/enterprise/cmd/frontend/internal/executorqueue/handler/handler.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/handler/handler.go
@@ -86,7 +86,7 @@ func (h *handler[T]) dequeue(ctx context.Context, metadata executorMetadata) (_ 
 	version2Supported := false
 	if metadata.Version != "" {
 		var err error
-		version2Supported, err = api.CheckSourcegraphVersion(metadata.Version, "4.4.0-0", "2022-11-24")
+		version2Supported, err = api.CheckSourcegraphVersion(metadata.Version, "4.3.0-0", "2022-11-24")
 		if err != nil {
 			return apiclient.Job{}, false, err
 		}

--- a/enterprise/cmd/frontend/internal/executorqueue/handler/handler_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/handler/handler_test.go
@@ -30,7 +30,7 @@ func TestDequeue(t *testing.T) {
 
 	store := workerstoremocks.NewMockStore[testRecord]()
 	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42, Payload: "secret"}, true, nil)
-	recordTransformer := func(ctx context.Context, tr testRecord, _ ResourceMetadata) (apiclient.Job, error) {
+	recordTransformer := func(ctx context.Context, _ string, tr testRecord, _ ResourceMetadata) (apiclient.Job, error) {
 		if tr.Payload != "secret" {
 			t.Errorf("unexpected payload. want=%q have=%q", "secret", tr.Payload)
 		}
@@ -76,7 +76,7 @@ func TestDequeueNoRecord(t *testing.T) {
 func TestAddExecutionLogEntry(t *testing.T) {
 	store := workerstoremocks.NewMockStore[testRecord]()
 	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42}, true, nil)
-	recordTransformer := func(ctx context.Context, record testRecord, _ ResourceMetadata) (apiclient.Job, error) {
+	recordTransformer := func(ctx context.Context, _ string, record testRecord, _ ResourceMetadata) (apiclient.Job, error) {
 		return apiclient.Job{ID: 42}, nil
 	}
 	fakeEntryID := 99
@@ -138,7 +138,7 @@ func TestAddExecutionLogEntryUnknownJob(t *testing.T) {
 func TestUpdateExecutionLogEntry(t *testing.T) {
 	store := workerstoremocks.NewMockStore[testRecord]()
 	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42}, true, nil)
-	recordTransformer := func(ctx context.Context, record testRecord, _ ResourceMetadata) (apiclient.Job, error) {
+	recordTransformer := func(ctx context.Context, _ string, record testRecord, _ ResourceMetadata) (apiclient.Job, error) {
 		return apiclient.Job{ID: 42}, nil
 	}
 
@@ -199,7 +199,7 @@ func TestMarkComplete(t *testing.T) {
 	store := workerstoremocks.NewMockStore[testRecord]()
 	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42}, true, nil)
 	store.MarkCompleteFunc.SetDefaultReturn(true, nil)
-	recordTransformer := func(ctx context.Context, record testRecord, _ ResourceMetadata) (apiclient.Job, error) {
+	recordTransformer := func(ctx context.Context, _ string, record testRecord, _ ResourceMetadata) (apiclient.Job, error) {
 		return apiclient.Job{ID: 42}, nil
 	}
 
@@ -258,7 +258,7 @@ func TestMarkErrored(t *testing.T) {
 	store := workerstoremocks.NewMockStore[testRecord]()
 	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42}, true, nil)
 	store.MarkErroredFunc.SetDefaultReturn(true, nil)
-	recordTransformer := func(ctx context.Context, record testRecord, _ ResourceMetadata) (apiclient.Job, error) {
+	recordTransformer := func(ctx context.Context, _ string, record testRecord, _ ResourceMetadata) (apiclient.Job, error) {
 		return apiclient.Job{ID: 42}, nil
 	}
 
@@ -320,7 +320,7 @@ func TestMarkFailed(t *testing.T) {
 	store := workerstoremocks.NewMockStore[testRecord]()
 	store.DequeueFunc.SetDefaultReturn(testRecord{ID: 42}, true, nil)
 	store.MarkFailedFunc.SetDefaultReturn(true, nil)
-	recordTransformer := func(ctx context.Context, record testRecord, _ ResourceMetadata) (apiclient.Job, error) {
+	recordTransformer := func(ctx context.Context, _ string, record testRecord, _ ResourceMetadata) (apiclient.Job, error) {
 		return apiclient.Job{ID: 42}, nil
 	}
 
@@ -380,7 +380,7 @@ func TestMarkFailedStoreError(t *testing.T) {
 
 func TestHeartbeat(t *testing.T) {
 	s := workerstoremocks.NewMockStore[testRecord]()
-	recordTransformer := func(ctx context.Context, record testRecord, _ ResourceMetadata) (apiclient.Job, error) {
+	recordTransformer := func(ctx context.Context, _ string, record testRecord, _ ResourceMetadata) (apiclient.Job, error) {
 		return apiclient.Job{ID: record.RecordID()}, nil
 	}
 	testKnownID := 10

--- a/enterprise/cmd/frontend/internal/executorqueue/handler/routes.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/handler/routes.go
@@ -52,7 +52,8 @@ func (h *handler[T]) handleDequeue(w http.ResponseWriter, r *http.Request) {
 
 	h.wrapHandler(w, r, &payload, func() (int, any, error) {
 		job, dequeued, err := h.dequeue(r.Context(), executorMetadata{
-			Name: payload.ExecutorName,
+			Name:    payload.ExecutorName,
+			Version: payload.Version,
 			Resources: ResourceMetadata{
 				NumCPUs:   payload.NumCPUs,
 				Memory:    payload.Memory,

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/queue.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/queue.go
@@ -15,9 +15,9 @@ import (
 
 func QueueOptions(db database.DB, _ func() string, observationContext *observation.Context) handler.QueueOptions[*btypes.BatchSpecWorkspaceExecutionJob] {
 	logger := log.Scoped("executor-queue.batches", "The executor queue handlers for the batches queue")
-	recordTransformer := func(ctx context.Context, record *btypes.BatchSpecWorkspaceExecutionJob, _ handler.ResourceMetadata) (apiclient.Job, error) {
+	recordTransformer := func(ctx context.Context, version string, record *btypes.BatchSpecWorkspaceExecutionJob, _ handler.ResourceMetadata) (apiclient.Job, error) {
 		batchesStore := store.New(db, observationContext, nil)
-		return transformRecord(ctx, logger, batchesStore, record)
+		return transformRecord(ctx, logger, batchesStore, record, version)
 	}
 
 	store := store.NewBatchSpecWorkspaceExecutionWorkerStore(db.Handle(), observationContext)

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
@@ -149,7 +149,7 @@ func transformRecord(ctx context.Context, logger log.Logger, s BatchesStore, job
 	}
 	files := map[string]apiclient.VirtualMachineFile{
 		srcInputPath: {
-			Content: string(marshaledInput),
+			Content: marshaledInput,
 		},
 	}
 
@@ -197,7 +197,7 @@ func transformRecord(ctx context.Context, logger log.Logger, s BatchesStore, job
 		if executionInput.CachedStepResultFound {
 			cacheEntry := executionInput.CachedStepResult
 			// Apply the diff if necessary.
-			if cacheEntry.Diff != "" {
+			if len(cacheEntry.Diff) > 0 {
 				dockerSteps = append(dockerSteps, apiclient.DockerStep{
 					Key: "apply-diff",
 					Dir: srcRepoDir,
@@ -219,7 +219,7 @@ func transformRecord(ctx context.Context, logger log.Logger, s BatchesStore, job
 			}
 			// Write the step result for the last cached step.
 			files[fmt.Sprintf("step%d.json", cacheEntry.StepIndex)] = apiclient.VirtualMachineFile{
-				Content: string(val),
+				Content: val,
 			}
 		}
 
@@ -293,6 +293,7 @@ func transformRecord(ctx context.Context, logger log.Logger, s BatchesStore, job
 			// Tell src to store tmp files inside the workspace. Src currently
 			// runs on the host and we don't want pollution outside of the workspace.
 			"-tmp", srcTempDir,
+			"-binaryDiffs", "true",
 		}
 		// Only add the workspaceFiles flag if there are files to mount. This helps with backwards compatibility.
 		if len(workspaceFiles) > 0 {

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
@@ -296,7 +296,7 @@ func transformRecord(ctx context.Context, logger log.Logger, s BatchesStore, job
 			"-tmp", srcTempDir,
 		}
 
-		ok, err := api.CheckSourcegraphVersion(version, ">= 4.3.0-0", "2022-11-24")
+		ok, err := api.CheckSourcegraphVersion(version, ">= 4.3.0-0", "2022-11-29")
 		if err != nil {
 			return apiclient.Job{}, err
 		}

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
@@ -90,7 +90,7 @@ steps:
 			1: {
 				Key: "testcachekey",
 				Value: &execution.AfterStepResult{
-					Diff: "123",
+					Diff: []byte("123"),
 				},
 			},
 		},
@@ -131,12 +131,12 @@ steps:
 	}
 
 	t.Run("with cache entry", func(t *testing.T) {
-		job, err := transformRecord(context.Background(), logtest.Scoped(t), store, workspaceExecutionJob)
+		job, err := transformRecord(context.Background(), logtest.Scoped(t), store, workspaceExecutionJob, "0.0.0-dev")
 		if err != nil {
 			t.Fatalf("unexpected error transforming record: %s", err)
 		}
 
-		marshaledInput, err := json.Marshal(wantInput(true, execution.AfterStepResult{Diff: "123"}))
+		marshaledInput, err := json.Marshal(wantInput(true, execution.AfterStepResult{Diff: []byte("123")}))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -149,7 +149,7 @@ steps:
 			ShallowClone:        true,
 			SparseCheckout:      []string{"a/b/c/*"},
 			VirtualMachineFiles: map[string]apiclient.VirtualMachineFile{
-				"input.json": {Content: string(marshaledInput)},
+				"input.json": {Content: marshaledInput},
 			},
 			CliSteps: []apiclient.CliStep{
 				{
@@ -186,7 +186,7 @@ steps:
 		// Set the no cache flag on the batch spec.
 		batchSpec.NoCache = true
 
-		job, err := transformRecord(context.Background(), logtest.Scoped(t), store, workspaceExecutionJob)
+		job, err := transformRecord(context.Background(), logtest.Scoped(t), store, workspaceExecutionJob, "0.0.0-dev")
 		if err != nil {
 			t.Fatalf("unexpected error transforming record: %s", err)
 		}
@@ -204,7 +204,7 @@ steps:
 			ShallowClone:        true,
 			SparseCheckout:      []string{"a/b/c/*"},
 			VirtualMachineFiles: map[string]apiclient.VirtualMachineFile{
-				"input.json": {Content: string(marshaledInput)},
+				"input.json": {Content: marshaledInput},
 			},
 			CliSteps: []apiclient.CliStep{
 				{
@@ -259,7 +259,7 @@ steps:
 			nil,
 		)
 
-		job, err := transformRecord(context.Background(), logtest.Scoped(t), store, workspaceExecutionJob)
+		job, err := transformRecord(context.Background(), logtest.Scoped(t), store, workspaceExecutionJob, "0.0.0-dev")
 		if err != nil {
 			t.Fatalf("unexpected error transforming record: %s", err)
 		}
@@ -277,7 +277,7 @@ steps:
 			ShallowClone:        true,
 			SparseCheckout:      []string{"a/b/c/*"},
 			VirtualMachineFiles: map[string]apiclient.VirtualMachineFile{
-				"input.json":                        {Content: string(marshaledInput)},
+				"input.json":                        {Content: marshaledInput},
 				"workspace-files/foo/bar/script.sh": {Bucket: "batch-changes", Key: "abc/xyz", ModifiedAt: workspaceFileModifiedAt},
 			},
 			CliSteps: []apiclient.CliStep{

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/queue.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/queue.go
@@ -13,7 +13,7 @@ import (
 )
 
 func QueueOptions(db database.DB, accessToken func() string, observationContext *observation.Context) handler.QueueOptions[types.Index] {
-	recordTransformer := func(ctx context.Context, record types.Index, resourceMetadata handler.ResourceMetadata) (apiclient.Job, error) {
+	recordTransformer := func(ctx context.Context, _ string, record types.Index, resourceMetadata handler.ResourceMetadata) (apiclient.Job, error) {
 		return transformRecord(record, resourceMetadata, accessToken())
 	}
 

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
@@ -278,7 +278,7 @@ func (r *batchSpecWorkspaceCreator) process(
 
 		workspace.dbWorkspace.CachedResultFound = true
 
-		rawSpecs, err := cache.ChangesetSpecsFromCache(spec.Spec, workspace.repo, *res.Value, workspace.dbWorkspace.Path)
+		rawSpecs, err := cache.ChangesetSpecsFromCache(spec.Spec, workspace.repo, *res.Value, workspace.dbWorkspace.Path, true)
 		if err != nil {
 			return err
 		}

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
@@ -331,7 +331,7 @@ func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 		}
 
 		haveDiff := changesetSpec.Diff
-		if !bytes.Equal(haveDiff, []byte(testDiff)) {
+		if !bytes.Equal(haveDiff, testDiff) {
 			t.Fatalf("changeset spec built from cache has wrong diff: %s", haveDiff)
 		}
 
@@ -727,7 +727,7 @@ changesetTemplate:
 		}
 
 		haveDiff := changesetSpec.Diff
-		if !bytes.Equal(haveDiff, []byte(testDiff)) {
+		if !bytes.Equal(haveDiff, testDiff) {
 			t.Fatalf("changeset spec built from cache has wrong diff: %s", haveDiff)
 		}
 
@@ -825,7 +825,7 @@ changesetTemplate:
 		}
 
 		haveDiff := changesetSpec.Diff
-		if !bytes.Equal(haveDiff, []byte(testDiff)) {
+		if !bytes.Equal(haveDiff, testDiff) {
 			t.Fatalf("changeset spec built from cache has wrong diff: %s", haveDiff)
 		}
 

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
@@ -511,7 +511,7 @@ changesetTemplate:
 		batchSpec := createBatchSpec(t, false, bt.TestRawBatchSpecYAML)
 
 		resultWithoutDiff := *executionResult
-		resultWithoutDiff.Diff = ""
+		resultWithoutDiff.Diff = []byte("")
 
 		entry := createCacheEntry(t, batchSpec, workspace, &resultWithoutDiff, secretValue, nil)
 
@@ -1058,7 +1058,7 @@ func (d *dummyWorkspaceResolver) ResolveWorkspacesForBatchSpec(context.Context, 
 	return d.workspaces, d.err
 }
 
-const testDiff = `diff README.md README.md
+var testDiff = []byte(`diff README.md README.md
 index 671e50a..851b23a 100644
 --- README.md
 +++ README.md
@@ -1075,7 +1075,7 @@ index 6f8b5d9..17400bc 100644
 -example.com
 +sourcegraph.com
  never-touch-the-mouse.com
-`
+`)
 
 func assertWorkspacesEqual(t *testing.T, have, want []*btypes.BatchSpecWorkspace) {
 	t.Helper()

--- a/enterprise/internal/batches/reconciler/executor.go
+++ b/enterprise/internal/batches/reconciler/executor.go
@@ -617,7 +617,8 @@ func handleArchivedRepo(
 func buildCommitOpts(repo *types.Repo, spec *btypes.ChangesetSpec, pushOpts *protocol.PushConfig) (opts protocol.CreateCommitFromPatchRequest, err error) {
 	// IMPORTANT: We add a trailing newline here, otherwise `git apply`
 	// will fail with "corrupt patch at line <N>" where N is the last line.
-	patch := append(spec.Diff, []byte("\n")...)
+	patch := append([]byte{}, spec.Diff...)
+	patch = append(patch, []byte("\n")...)
 	opts = protocol.CreateCommitFromPatchRequest{
 		Repo:       repo.Name,
 		BaseCommit: api.CommitID(spec.BaseRev),

--- a/enterprise/internal/batches/reconciler/executor.go
+++ b/enterprise/internal/batches/reconciler/executor.go
@@ -615,13 +615,14 @@ func handleArchivedRepo(
 }
 
 func buildCommitOpts(repo *types.Repo, spec *btypes.ChangesetSpec, pushOpts *protocol.PushConfig) (opts protocol.CreateCommitFromPatchRequest, err error) {
+	// IMPORTANT: We add a trailing newline here, otherwise `git apply`
+	// will fail with "corrupt patch at line <N>" where N is the last line.
+	patch := append(spec.Diff, []byte("\n")...)
 	opts = protocol.CreateCommitFromPatchRequest{
 		Repo:       repo.Name,
 		BaseCommit: api.CommitID(spec.BaseRev),
-		// IMPORTANT: We add a trailing newline here, otherwise `git apply`
-		// will fail with "corrupt patch at line <N>" where N is the last line.
-		Patch:     string(spec.Diff) + "\n",
-		TargetRef: spec.HeadRef,
+		Patch:      patch,
+		TargetRef:  spec.HeadRef,
 
 		// CAUTION: `UniqueRef` means that we'll push to a generated branch if it
 		// already exists.

--- a/enterprise/internal/batches/reconciler/executor_test.go
+++ b/enterprise/internal/batches/reconciler/executor_test.go
@@ -8,9 +8,10 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 
 	"github.com/sourcegraph/log/logtest"
 
@@ -1040,7 +1041,7 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 				HeadRef:    "refs/heads/my-branch",
 				Typ:        btypes.ChangesetSpecTypeBranch,
 				Published:  true,
-				CommitDiff: "testdiff",
+				CommitDiff: []byte("testdiff"),
 			})
 
 			fakeSource := &stesting.FakeChangesetSource{Svc: tt.extSvc, CurrentAuthenticator: tt.credential}

--- a/enterprise/internal/batches/reconciler/plan_test.go
+++ b/enterprise/internal/batches/reconciler/plan_test.go
@@ -231,8 +231,8 @@ func TestDetermineReconcilerPlan(t *testing.T) {
 		},
 		{
 			name:         "commit diff changed on published changeset",
-			previousSpec: &bt.TestSpecOpts{Published: true, CommitDiff: "testDiff"},
-			currentSpec:  &bt.TestSpecOpts{Published: true, CommitDiff: "newTestDiff"},
+			previousSpec: &bt.TestSpecOpts{Published: true, CommitDiff: []byte("testDiff")},
+			currentSpec:  &bt.TestSpecOpts{Published: true, CommitDiff: []byte("newTestDiff")},
 			changeset: bt.TestChangesetOpts{
 				PublicationState: btypes.ChangesetPublicationStatePublished,
 			},
@@ -257,8 +257,8 @@ func TestDetermineReconcilerPlan(t *testing.T) {
 		},
 		{
 			name:         "commit diff changed on merge changeset",
-			previousSpec: &bt.TestSpecOpts{Published: true, CommitDiff: "testDiff"},
-			currentSpec:  &bt.TestSpecOpts{Published: true, CommitDiff: "newTestDiff"},
+			previousSpec: &bt.TestSpecOpts{Published: true, CommitDiff: []byte("testDiff")},
+			currentSpec:  &bt.TestSpecOpts{Published: true, CommitDiff: []byte("newTestDiff")},
 			changeset: bt.TestChangesetOpts{
 				PublicationState: btypes.ChangesetPublicationStatePublished,
 				ExternalState:    btypes.ChangesetExternalStateMerged,

--- a/enterprise/internal/batches/reconciler/reconciler_test.go
+++ b/enterprise/internal/batches/reconciler/reconciler_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/log/logtest"
+
 	stesting "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources/testing"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	bt "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
@@ -72,7 +73,7 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 
 				Title:         "old title",
 				Body:          "old body",
-				CommitDiff:    "old diff",
+				CommitDiff:    []byte("old diff"),
 				CommitMessage: "old message",
 			},
 

--- a/enterprise/internal/batches/store/worker_workspace_execution.go
+++ b/enterprise/internal/batches/store/worker_workspace_execution.go
@@ -222,6 +222,7 @@ func (s *batchSpecWorkspaceExecutionWorkerStore) MarkComplete(ctx context.Contex
 		},
 		latestStepResult.Value,
 		workspace.Path,
+		true,
 	)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to build changeset specs from cache")

--- a/enterprise/internal/batches/store/worker_workspace_execution_test.go
+++ b/enterprise/internal/batches/store/worker_workspace_execution_test.go
@@ -192,7 +192,7 @@ stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.
 			if err := json.Unmarshal([]byte(entry.Value), &cachedExecutionResult); err != nil {
 				t.Fatal(err)
 			}
-			if cachedExecutionResult.Diff == "" {
+			if len(cachedExecutionResult.Diff) == 0 {
 				t.Fatalf("wrong diff extracted")
 			}
 		}
@@ -341,7 +341,7 @@ stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.
 			if err := json.Unmarshal([]byte(entry.Value), &cachedExecutionResult); err != nil {
 				t.Fatal(err)
 			}
-			if cachedExecutionResult.Diff == "" {
+			if len(cachedExecutionResult.Diff) == 0 {
 				t.Fatalf("wrong diff extracted")
 			}
 		}

--- a/enterprise/internal/batches/testing/changeset_spec.go
+++ b/enterprise/internal/batches/testing/changeset_spec.go
@@ -32,7 +32,7 @@ type TestSpecOpts struct {
 	Title             string
 	Body              string
 	CommitMessage     string
-	CommitDiff        string
+	CommitDiff        []byte
 	CommitAuthorEmail string
 	CommitAuthorName  string
 
@@ -69,7 +69,7 @@ func BuildChangesetSpec(t *testing.T, opts TestSpecOpts) *btypes.ChangesetSpec {
 		Title:             opts.Title,
 		Body:              opts.Body,
 		CommitMessage:     opts.CommitMessage,
-		Diff:              []byte(opts.CommitDiff),
+		Diff:              opts.CommitDiff,
 		CommitAuthorEmail: opts.CommitAuthorEmail,
 		CommitAuthorName:  opts.CommitAuthorName,
 		DiffStatAdded:     TestChangsetSpecDiffStat.Added,

--- a/enterprise/internal/batches/testing/specs.go
+++ b/enterprise/internal/batches/testing/specs.go
@@ -80,7 +80,8 @@ func BuildRawBatchSpecWithImportChangesets(t *testing.T, imports []batcheslib.Im
 var ChangesetSpecDiffStat = &diff.Stat{Added: 3, Deleted: 3}
 
 const ChangesetSpecAuthorEmail = "mary@example.com"
-const ChangesetSpecDiff = `diff --git INSTALL.md INSTALL.md
+
+var ChangesetSpecDiff = []byte(`diff --git INSTALL.md INSTALL.md
 index e5af166..d44c3fc 100644
 --- INSTALL.md
 +++ INSTALL.md
@@ -98,7 +99,7 @@ index e5af166..d44c3fc 100644
 +Foobar Line 8
  Line 9
  Line 10
-`
+`)
 
 var baseChangesetSpecGitBranch = batcheslib.ChangesetSpec{
 	BaseRef: "refs/heads/master",
@@ -111,6 +112,7 @@ var baseChangesetSpecGitBranch = batcheslib.ChangesetSpec{
 
 	Commits: []batcheslib.GitCommitDescription{
 		{
+			Version:     2,
 			Message:     "git commit message\n\nand some more content in a second paragraph.",
 			Diff:        ChangesetSpecDiff,
 			AuthorName:  "Mary McButtons",

--- a/enterprise/internal/batches/types/changeset_spec.go
+++ b/enterprise/internal/batches/types/changeset_spec.go
@@ -65,7 +65,7 @@ func NewChangesetSpecFromSpec(spec *batcheslib.ChangesetSpec) (*ChangesetSpec, e
 			return nil, err
 		}
 		c.Type = ChangesetSpecTypeBranch
-		c.Diff = []byte(diff)
+		c.Diff = diff
 		c.HeadRef = spec.HeadRef
 		c.BaseRev = spec.BaseRev
 		c.BaseRef = spec.BaseRef

--- a/enterprise/internal/batches/types/step_info.go
+++ b/enterprise/internal/batches/types/step_info.go
@@ -42,7 +42,8 @@ type StepInfo struct {
 	FinishedAt      time.Time
 	Environment     map[string]string
 	OutputVariables map[string]any
-	Diff            *string
+	DiffFound       bool
+	Diff            []byte
 	ExitCode        *int
 }
 
@@ -95,7 +96,8 @@ func ParseLogLines(entry workerutil.ExecutionLogEntry, lines []*batcheslib.LogEv
 							outputs = map[string]any{}
 						}
 						si.OutputVariables = outputs
-						si.Diff = &m.Diff
+						si.Diff = m.Diff
+						si.DiffFound = true
 					}
 				})
 			} else if l.Status == batcheslib.LogEventStatusStarted {

--- a/enterprise/internal/batches/types/step_info_test.go
+++ b/enterprise/internal/batches/types/step_info_test.go
@@ -138,7 +138,7 @@ func TestParseLogLines(t *testing.T) {
 	time3 := timeutil.Now().Add(-5 * 60 * time.Second)
 	zero := 0
 	nonZero := 1
-	diff := `all-must-change`
+	diff := []byte(`all-must-change`)
 
 	tcs := []struct {
 		name  string
@@ -364,7 +364,8 @@ func TestParseLogLines(t *testing.T) {
 					Environment:     make(map[string]string),
 					OutputVariables: map[string]any{"test": 1},
 					ExitCode:        &zero,
-					Diff:            &diff,
+					Diff:            diff,
+					DiffFound:       true,
 				},
 			},
 		},
@@ -461,7 +462,8 @@ func TestParseLogLines(t *testing.T) {
 					OutputVariables: map[string]any{"test": 1},
 					OutputLines:     []string{"stdout: log1", "stdout: log2", "stderr: log3"},
 					ExitCode:        &zero,
-					Diff:            &diff,
+					Diff:            diff,
+					DiffFound:       true,
 				},
 				2: {
 					StartedAt:   time1,

--- a/enterprise/internal/executor/client_types.go
+++ b/enterprise/internal/executor/client_types.go
@@ -12,7 +12,7 @@ type Job struct {
 	// Version is used to version the shape of the Job payload, so that older
 	// executors can still talk to Sourcegraph. The dequeue endpoint takes an
 	// executor version to determine which maximum version said executor supports.
-	Version int `json:"version"`
+	Version int `json:"version,omitempty"`
 
 	// ID is the unique identifier of a job within the source queue. Note
 	// that different queues can share identifiers.
@@ -62,7 +62,7 @@ type Job struct {
 	RedactedValues map[string]string `json:"redactedValues"`
 }
 
-func (j *Job) MarshalJSON() ([]byte, error) {
+func (j Job) MarshalJSON() ([]byte, error) {
 	if j.Version == 2 {
 		v2 := v2Job{
 			Version:             j.Version,
@@ -161,11 +161,11 @@ func (j *Job) UnmarshalJSON(data []byte) error {
 }
 
 type versionJob struct {
-	Version int `json:"version"`
+	Version int `json:"version,omitempty"`
 }
 
 type v2Job struct {
-	Version             int                             `json:"version"`
+	Version             int                             `json:"version,omitempty"`
 	ID                  int                             `json:"id"`
 	RepositoryName      string                          `json:"repositoryName"`
 	RepositoryDirectory string                          `json:"repositoryDirectory"`
@@ -232,7 +232,7 @@ func (j Job) RecordID() int {
 type DockerStep struct {
 	// Key is a unique identifier of the step. It can be used to retrieve the
 	// associated log entry.
-	Key string `json:"key"`
+	Key string `json:"key,omitempty"`
 
 	// Image specifies the docker image.
 	Image string `json:"image"`
@@ -250,7 +250,7 @@ type DockerStep struct {
 type CliStep struct {
 	// Key is a unique identifier of the step. It can be used to retrieve the
 	// associated log entry.
-	Key string `json:"key"`
+	Key string `json:"key,omitempty"`
 
 	// Commands specifies the arguments supplied to the src command.
 	Commands []string `json:"command"`

--- a/enterprise/internal/executor/client_types_test.go
+++ b/enterprise/internal/executor/client_types_test.go
@@ -65,7 +65,7 @@ func TestJob_UnmarshalJSON(t *testing.T) {
 				SparseCheckout:      []string{"a", "b", "c"},
 				VirtualMachineFiles: map[string]executor.VirtualMachineFile{
 					"script1.sh": {
-						Content: "hello",
+						Content: []byte("hello"),
 					},
 					"script2.py": {
 						Bucket:     "my-bucket",
@@ -131,7 +131,7 @@ func TestJob_UnmarshalJSON(t *testing.T) {
 				SparseCheckout:      []string{"a", "b", "c"},
 				VirtualMachineFiles: map[string]executor.VirtualMachineFile{
 					"script1.sh": {
-						Content: "hello",
+						Content: []byte("hello"),
 					},
 				},
 				DockerSteps: []executor.DockerStep{

--- a/enterprise/internal/executor/client_types_test.go
+++ b/enterprise/internal/executor/client_types_test.go
@@ -1,4 +1,4 @@
-package executor_test
+package executor
 
 import (
 	"encoding/json"
@@ -7,9 +7,175 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
-
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/executor"
 )
+
+func TestJob_MarshalJSON(t *testing.T) {
+	modAt, err := time.Parse(time.RFC3339, "2022-10-07T18:55:45.831031-06:00")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		input    Job
+		expected string
+	}{
+		{
+			name: "4.3",
+			input: Job{
+				Version:             2,
+				ID:                  1,
+				RepositoryName:      "my-repo",
+				RepositoryDirectory: "foo/bar",
+				Commit:              "xyz",
+				FetchTags:           true,
+				ShallowClone:        true,
+				SparseCheckout:      []string{"a", "b", "c"},
+				VirtualMachineFiles: map[string]VirtualMachineFile{
+					"script1.sh": {
+						Content: []byte("hello"),
+					},
+					"script2.py": {
+						Bucket:     "my-bucket",
+						Key:        "file/key",
+						ModifiedAt: modAt,
+					},
+				},
+				DockerSteps: []DockerStep{
+					{
+						Image:    "my-image",
+						Commands: []string{"run"},
+						Dir:      "faz/baz",
+						Env:      []string{"FOO=BAR"},
+					},
+				},
+				CliSteps: []CliStep{
+					{
+						Commands: []string{"x", "y", "z"},
+						Dir:      "raz/daz",
+						Env:      []string{"BAZ=FAZ"},
+					},
+				},
+				RedactedValues: map[string]string{
+					"password": "foo",
+				},
+			},
+			expected: `{
+		"version": 2,
+		"id": 1,
+		"repositoryName": "my-repo",
+		"repositoryDirectory": "foo/bar",
+		"commit": "xyz",
+		"fetchTags": true,
+		"shallowClone": true,
+		"sparseCheckout": ["a", "b", "c"],
+		"files": {
+			"script1.sh": {
+				"content": "aGVsbG8=",
+				"modifiedAt": "0001-01-01T00:00:00Z"
+			},
+			"script2.py": {
+				"bucket": "my-bucket",
+				"key": "file/key",
+				"modifiedAt": "2022-10-07T18:55:45.831031-06:00"
+			}
+		},
+		"dockerSteps": [{
+			"image": "my-image",
+			"commands": ["run"],
+			"dir": "faz/baz",
+			"env": ["FOO=BAR"]
+		}],
+		"cliSteps": [{
+			"command": ["x", "y", "z"],
+			"dir": "raz/daz",
+			"env": ["BAZ=FAZ"]
+		}],
+		"redactedValues": {
+			"password": "foo"
+		}
+	}`,
+		},
+		{
+			name: "4.2",
+			input: Job{
+				ID:                  1,
+				RepositoryName:      "my-repo",
+				RepositoryDirectory: "foo/bar",
+				Commit:              "xyz",
+				FetchTags:           true,
+				ShallowClone:        true,
+				SparseCheckout:      []string{"a", "b", "c"},
+				VirtualMachineFiles: map[string]VirtualMachineFile{
+					"script1.sh": {
+						Content: []byte("hello"),
+					},
+				},
+				DockerSteps: []DockerStep{
+					{
+						Image:    "my-image",
+						Commands: []string{"run"},
+						Dir:      "faz/baz",
+						Env:      []string{"FOO=BAR"},
+					},
+				},
+				CliSteps: []CliStep{
+					{
+						Commands: []string{"x", "y", "z"},
+						Dir:      "raz/daz",
+						Env:      []string{"BAZ=FAZ"},
+					},
+				},
+				RedactedValues: map[string]string{
+					"password": "foo",
+				},
+			},
+			expected: `{
+		"id": 1,
+		"repositoryName": "my-repo",
+		"repositoryDirectory": "foo/bar",
+		"commit": "xyz",
+		"fetchTags": true,
+		"shallowClone": true,
+		"sparseCheckout": ["a", "b", "c"],
+		"files": {
+			"script1.sh": {
+				"content": "hello",
+				"modifiedAt": "0001-01-01T00:00:00Z"
+			}
+		},
+		"dockerSteps": [{
+			"image": "my-image",
+			"commands": ["run"],
+			"dir": "faz/baz",
+			"env": ["FOO=BAR"]
+		}],
+		"cliSteps": [{
+			"command": ["x", "y", "z"],
+			"dir": "raz/daz",
+			"env": ["BAZ=FAZ"]
+		}],
+		"redactedValues": {
+			"password": "foo"
+		}
+	}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := json.Marshal(test.input)
+			require.NoError(t, err)
+			var actualMap, expectedMap map[string]any
+			if err := json.Unmarshal(actual, &actualMap); err != nil {
+				t.Fatal(err)
+			}
+			if err := json.Unmarshal([]byte(test.expected), &expectedMap); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(expectedMap, actualMap); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
 
 func TestJob_UnmarshalJSON(t *testing.T) {
 	modAt, err := time.Parse(time.RFC3339, "2022-10-07T18:55:45.831031-06:00")
@@ -18,11 +184,12 @@ func TestJob_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
-		expected executor.Job
+		expected Job
 	}{
 		{
-			name: "4.1",
+			name: "4.3",
 			input: `{
+	"version": 2,
 	"id": 1,
 	"repositoryName": "my-repo",
 	"repositoryDirectory": "foo/bar",
@@ -32,7 +199,7 @@ func TestJob_UnmarshalJSON(t *testing.T) {
 	"sparseCheckout": ["a", "b", "c"],
 	"files": {
 		"script1.sh": {
-			"content": "hello"
+			"content": "aGVsbG8="
 		},
 		"script2.py": {
 			"bucket": "my-bucket",
@@ -55,7 +222,8 @@ func TestJob_UnmarshalJSON(t *testing.T) {
 		"password": "foo"
 	}
 }`,
-			expected: executor.Job{
+			expected: Job{
+				Version:             2,
 				ID:                  1,
 				RepositoryName:      "my-repo",
 				RepositoryDirectory: "foo/bar",
@@ -63,7 +231,7 @@ func TestJob_UnmarshalJSON(t *testing.T) {
 				FetchTags:           true,
 				ShallowClone:        true,
 				SparseCheckout:      []string{"a", "b", "c"},
-				VirtualMachineFiles: map[string]executor.VirtualMachineFile{
+				VirtualMachineFiles: map[string]VirtualMachineFile{
 					"script1.sh": {
 						Content: []byte("hello"),
 					},
@@ -73,7 +241,7 @@ func TestJob_UnmarshalJSON(t *testing.T) {
 						ModifiedAt: modAt,
 					},
 				},
-				DockerSteps: []executor.DockerStep{
+				DockerSteps: []DockerStep{
 					{
 						Image:    "my-image",
 						Commands: []string{"run"},
@@ -81,7 +249,7 @@ func TestJob_UnmarshalJSON(t *testing.T) {
 						Env:      []string{"FOO=BAR"},
 					},
 				},
-				CliSteps: []executor.CliStep{
+				CliSteps: []CliStep{
 					{
 						Commands: []string{"x", "y", "z"},
 						Dir:      "raz/daz",
@@ -94,7 +262,7 @@ func TestJob_UnmarshalJSON(t *testing.T) {
 			},
 		},
 		{
-			name: "4.0",
+			name: "4.2",
 			input: `{
 	"id": 1,
 	"repositoryName": "my-repo",
@@ -104,7 +272,9 @@ func TestJob_UnmarshalJSON(t *testing.T) {
 	"shallowClone": true,
 	"sparseCheckout": ["a", "b", "c"],
 	"files": {
-		"script1.sh": "hello"
+		"script1.sh": {
+			"content": "hello"
+		}
 	},
 	"dockerSteps": [{
 		"image": "my-image",
@@ -121,7 +291,7 @@ func TestJob_UnmarshalJSON(t *testing.T) {
 		"password": "foo"
 	}
 }`,
-			expected: executor.Job{
+			expected: Job{
 				ID:                  1,
 				RepositoryName:      "my-repo",
 				RepositoryDirectory: "foo/bar",
@@ -129,12 +299,12 @@ func TestJob_UnmarshalJSON(t *testing.T) {
 				FetchTags:           true,
 				ShallowClone:        true,
 				SparseCheckout:      []string{"a", "b", "c"},
-				VirtualMachineFiles: map[string]executor.VirtualMachineFile{
+				VirtualMachineFiles: map[string]VirtualMachineFile{
 					"script1.sh": {
 						Content: []byte("hello"),
 					},
 				},
-				DockerSteps: []executor.DockerStep{
+				DockerSteps: []DockerStep{
 					{
 						Image:    "my-image",
 						Commands: []string{"run"},
@@ -142,7 +312,7 @@ func TestJob_UnmarshalJSON(t *testing.T) {
 						Env:      []string{"FOO=BAR"},
 					},
 				},
-				CliSteps: []executor.CliStep{
+				CliSteps: []CliStep{
 					{
 						Commands: []string{"x", "y", "z"},
 						Dir:      "raz/daz",
@@ -157,7 +327,7 @@ func TestJob_UnmarshalJSON(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			var actual executor.Job
+			var actual Job
 			err := json.Unmarshal([]byte(test.input), &actual)
 			require.NoError(t, err)
 			if diff := cmp.Diff(test.expected, actual); diff != "" {

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -1282,7 +1282,12 @@ func (c *clientImplementor) do(ctx context.Context, repo api.RepoName, method, u
 }
 
 func (c *clientImplementor) CreateCommitFromPatch(ctx context.Context, req protocol.CreateCommitFromPatchRequest) (string, error) {
-	resp, err := c.httpPost(ctx, req.Repo, "create-commit-from-patch", req)
+	resp, err := c.httpPost(ctx, req.Repo, "create-commit-from-patch-binary", req)
+	// If gitserver doesn't speak the binary endpoint yet, we fall back to the old one.
+	if resp.StatusCode == http.StatusNotFound {
+		resp.Body.Close()
+		resp, err = c.httpPost(ctx, req.Repo, "create-commit-from-patch", req)
+	}
 	if err != nil {
 		return "", err
 	}

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -1283,9 +1283,11 @@ func (c *clientImplementor) do(ctx context.Context, repo api.RepoName, method, u
 
 func (c *clientImplementor) CreateCommitFromPatch(ctx context.Context, req protocol.CreateCommitFromPatchRequest) (string, error) {
 	resp, err := c.httpPost(ctx, req.Repo, "create-commit-from-patch-binary", req)
+	if err != nil {
+		return "", err
+	}
 	// If gitserver doesn't speak the binary endpoint yet, we fall back to the old one.
 	if resp.StatusCode == http.StatusNotFound {
-		resp.Body.Close()
 		resp, err = c.httpPost(ctx, req.Repo, "create-commit-from-patch", protocol.V1CreateCommitFromPatchRequest{
 			Repo:         req.Repo,
 			BaseCommit:   req.BaseCommit,
@@ -1296,9 +1298,9 @@ func (c *clientImplementor) CreateCommitFromPatch(ctx context.Context, req proto
 			Push:         req.Push,
 			GitApplyArgs: req.GitApplyArgs,
 		})
-	}
-	if err != nil {
-		return "", err
+		if err != nil {
+			return "", err
+		}
 	}
 	defer resp.Body.Close()
 

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -1286,7 +1286,16 @@ func (c *clientImplementor) CreateCommitFromPatch(ctx context.Context, req proto
 	// If gitserver doesn't speak the binary endpoint yet, we fall back to the old one.
 	if resp.StatusCode == http.StatusNotFound {
 		resp.Body.Close()
-		resp, err = c.httpPost(ctx, req.Repo, "create-commit-from-patch", req)
+		resp, err = c.httpPost(ctx, req.Repo, "create-commit-from-patch", protocol.V1CreateCommitFromPatchRequest{
+			Repo:         req.Repo,
+			BaseCommit:   req.BaseCommit,
+			Patch:        string(req.Patch),
+			TargetRef:    req.TargetRef,
+			UniqueRef:    req.UniqueRef,
+			CommitInfo:   req.CommitInfo,
+			Push:         req.Push,
+			GitApplyArgs: req.GitApplyArgs,
+		})
 	}
 	if err != nil {
 		return "", err

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -1286,6 +1286,7 @@ func (c *clientImplementor) CreateCommitFromPatch(ctx context.Context, req proto
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 	// If gitserver doesn't speak the binary endpoint yet, we fall back to the old one.
 	if resp.StatusCode == http.StatusNotFound {
 		resp.Body.Close()
@@ -1302,8 +1303,8 @@ func (c *clientImplementor) CreateCommitFromPatch(ctx context.Context, req proto
 		if err != nil {
 			return "", err
 		}
+		defer resp.Body.Close()
 	}
-	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -1288,6 +1288,7 @@ func (c *clientImplementor) CreateCommitFromPatch(ctx context.Context, req proto
 	}
 	// If gitserver doesn't speak the binary endpoint yet, we fall back to the old one.
 	if resp.StatusCode == http.StatusNotFound {
+		resp.Body.Close()
 		resp, err = c.httpPost(ctx, req.Repo, "create-commit-from-patch", protocol.V1CreateCommitFromPatchRequest{
 			Repo:         req.Repo,
 			BaseCommit:   req.BaseCommit,

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -254,7 +254,7 @@ type CreateCommitFromPatchRequest struct {
 	// BaseCommit is the revision that the staging area object is based on
 	BaseCommit api.CommitID
 	// Patch is the diff contents to be used to create the staging area revision
-	Patch string
+	Patch []byte
 	// TargetRef is the ref that will be created for this patch
 	TargetRef string
 	// If set to true and the TargetRef already exists, an unique number will be appended to the end (ie TargetRef-{#}). The generated ref will be returned.

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -269,6 +269,29 @@ type CreateCommitFromPatchRequest struct {
 	GitApplyArgs []string
 }
 
+// V1CreateCommitFromPatchRequest is the request information needed for creating
+// the simulated staging area git object for a repo.
+type V1CreateCommitFromPatchRequest struct {
+	// Repo is the repository to get information about.
+	Repo api.RepoName
+	// BaseCommit is the revision that the staging area object is based on
+	BaseCommit api.CommitID
+	// Patch is the diff contents to be used to create the staging area revision
+	Patch string
+	// TargetRef is the ref that will be created for this patch
+	TargetRef string
+	// If set to true and the TargetRef already exists, an unique number will be appended to the end (ie TargetRef-{#}). The generated ref will be returned.
+	UniqueRef bool
+	// CommitInfo is the information that will be used when creating the commit from a patch
+	CommitInfo PatchCommitInfo
+	// Push specifies whether the target ref will be pushed to the code host: if
+	// nil, no push will be attempted, if non-nil, a push will be attempted.
+	Push *PushConfig
+	// GitApplyArgs are the arguments that will be passed to `git apply` along
+	// with `--cached`.
+	GitApplyArgs []string
+}
+
 // PatchCommitInfo will be used for commit information when creating a commit from a patch
 type PatchCommitInfo struct {
 	Message        string

--- a/lib/api/version_check.go
+++ b/lib/api/version_check.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"github.com/grafana/regexp"
+
+	"github.com/Masterminds/semver"
+)
+
+// NOTE: A version with a prerelease suffix (e.g. the "-rc.3" of "3.35.1-rc.3") is not
+// considered by semver to satisfy a constraint without a prerelease suffix, regardless of
+// whether or not the major/minor/patch version is greater than or equal to that of the
+// constraint.
+//
+// For example, the version "3.35.1-rc.3" is not considered to satisfy the constraint ">=
+// 3.23.0". This is likely not the expected outcome. However, the same version IS
+// considered to satisfy the constraint "3.23.0-0". Thus, it is recommended to pass a
+// constraint with a minimum prerelease version suffix attached if comparisons to
+// prerelease versions are ever expected. See
+// https://github.com/Masterminds/semver#working-with-prerelease-versions for more.
+func CheckSourcegraphVersion(version, constraint, minDate string) (bool, error) {
+	if version == "dev" || version == "0.0.0+dev" {
+		return true, nil
+	}
+
+	// Since we don't actually care about the abbreviated commit hash at the end of the
+	// version string, we match on 7 or more characters. Currently, the Sourcegraph version
+	// is expected to return 12:
+	// https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/dev/ci/internal/ci/config.go?L96.
+	buildDate := regexp.MustCompile(`^\d+_(\d{4}-\d{2}-\d{2})_[a-z0-9]{7,}$`)
+	matches := buildDate.FindStringSubmatch(version)
+	if len(matches) > 1 {
+		return matches[1] >= minDate, nil
+	}
+
+	c, err := semver.NewConstraint(constraint)
+	if err != nil {
+		return false, nil
+	}
+
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return false, err
+	}
+
+	return c.Check(v), nil
+}

--- a/lib/api/version_check_test.go
+++ b/lib/api/version_check_test.go
@@ -1,0 +1,107 @@
+package api
+
+import "testing"
+
+func TestCheckSourcegraphVersion(t *testing.T) {
+	for _, tc := range []struct {
+		currentVersion, constraint, minDate string
+		expected                            bool
+	}{
+		{
+			currentVersion: "3.12.6",
+			constraint:     ">= 3.12.6",
+			minDate:        "2020-01-19",
+			expected:       true,
+		},
+		{
+			currentVersion: "3.12.6-rc.1",
+			constraint:     ">= 3.12.6-0",
+			minDate:        "2020-01-19",
+			expected:       true,
+		},
+		{
+			currentVersion: "3.12.6-rc.3",
+			constraint:     ">= 3.10.6-0",
+			minDate:        "2020-01-19",
+			expected:       true,
+		},
+		{
+			currentVersion: "3.12.6",
+			constraint:     ">= 3.13",
+			minDate:        "2020-01-19",
+			expected:       false,
+		},
+		{
+			currentVersion: "3.13.0",
+			constraint:     ">= 3.13",
+			minDate:        "2020-01-19",
+			expected:       true,
+		},
+		{
+			currentVersion: "dev",
+			constraint:     ">= 3.13",
+			minDate:        "2020-01-19",
+			expected:       true,
+		},
+		{
+			currentVersion: "0.0.0+dev",
+			constraint:     ">= 3.13",
+			minDate:        "2020-01-19",
+			expected:       true,
+		},
+		// 7-character abbreviated hash
+		{
+			currentVersion: "54959_2020-01-29_9258595",
+			minDate:        "2020-01-19",
+			constraint:     ">= 999.13",
+			expected:       true,
+		},
+		{
+			currentVersion: "54959_2020-01-29_9258595",
+			minDate:        "2020-01-30",
+			constraint:     ">= 999.13",
+			expected:       false,
+		},
+		{
+			currentVersion: "54959_2020-01-29_9258595",
+			minDate:        "2020-01-29",
+			constraint:     ">= 0.0",
+			expected:       true,
+		},
+		// 12-character abbreviated hash
+		{
+			currentVersion: "54959_2020-01-29_925859585436",
+			minDate:        "2020-01-19",
+			constraint:     ">= 999.13",
+			expected:       true,
+		},
+		{
+			currentVersion: "54959_2020-01-29_925859585436",
+			minDate:        "2020-01-30",
+			constraint:     ">= 999.13",
+			expected:       false,
+		},
+		{
+			currentVersion: "54959_2020-01-29_925859585436",
+			minDate:        "2020-01-29",
+			constraint:     ">= 0.0",
+			expected:       true,
+		},
+		// Full 40-character hash, just for fun
+		{
+			currentVersion: "54959_2020-01-29_7db7d396346284fd0f8f79f130f38b16fb1d3d70",
+			minDate:        "2020-01-29",
+			constraint:     ">= 0.0",
+			expected:       true,
+		},
+	} {
+		actual, err := CheckSourcegraphVersion(tc.currentVersion, tc.constraint, tc.minDate)
+		if err != nil {
+			t.Errorf("err: %s", err)
+		}
+
+		if actual != tc.expected {
+			t.Errorf("wrong result. want=%t, got=%t (version=%q, constraint=%q)", tc.expected, actual, tc.currentVersion, tc.constraint)
+		}
+	}
+}

--- a/lib/batches/changeset_spec.go
+++ b/lib/batches/changeset_spec.go
@@ -127,7 +127,7 @@ type GitCommitDescription struct {
 	AuthorEmail string `json:"authorEmail,omitempty"`
 }
 
-func (a *GitCommitDescription) MarshalJSON() ([]byte, error) {
+func (a GitCommitDescription) MarshalJSON() ([]byte, error) {
 	if a.Version == 2 {
 		return json.Marshal(v2GitCommitDescription{
 			Version:     a.Version,

--- a/lib/batches/changeset_spec.go
+++ b/lib/batches/changeset_spec.go
@@ -129,13 +129,7 @@ type GitCommitDescription struct {
 
 func (a GitCommitDescription) MarshalJSON() ([]byte, error) {
 	if a.Version == 2 {
-		return json.Marshal(v2GitCommitDescription{
-			Version:     a.Version,
-			Message:     a.Message,
-			Diff:        a.Diff,
-			AuthorName:  a.AuthorName,
-			AuthorEmail: a.AuthorEmail,
-		})
+		return json.Marshal(v2GitCommitDescription(a))
 	}
 	return json.Marshal(v1GitCommitDescription{
 		Message:     a.Message,

--- a/lib/batches/changeset_spec.go
+++ b/lib/batches/changeset_spec.go
@@ -120,6 +120,72 @@ func (c *ChangesetSpec) MarshalJSON() ([]byte, error) {
 }
 
 type GitCommitDescription struct {
+	Version     int    `json:"version,omitempty"`
+	Message     string `json:"message,omitempty"`
+	Diff        []byte `json:"diff,omitempty"`
+	AuthorName  string `json:"authorName,omitempty"`
+	AuthorEmail string `json:"authorEmail,omitempty"`
+}
+
+func (a *GitCommitDescription) MarshalJSON() ([]byte, error) {
+	if a.Version == 2 {
+		return json.Marshal(v2GitCommitDescription{
+			Version:     a.Version,
+			Message:     a.Message,
+			Diff:        a.Diff,
+			AuthorName:  a.AuthorName,
+			AuthorEmail: a.AuthorEmail,
+		})
+	}
+	return json.Marshal(v1GitCommitDescription{
+		Message:     a.Message,
+		Diff:        string(a.Diff),
+		AuthorName:  a.AuthorName,
+		AuthorEmail: a.AuthorEmail,
+	})
+}
+
+func (a *GitCommitDescription) UnmarshalJSON(data []byte) error {
+	var version versionGitCommitDescription
+	if err := json.Unmarshal(data, &version); err != nil {
+		return err
+	}
+	if version.Version == 2 {
+		var v2 v2GitCommitDescription
+		if err := json.Unmarshal(data, &v2); err != nil {
+			return err
+		}
+		a.Version = v2.Version
+		a.Message = v2.Message
+		a.Diff = v2.Diff
+		a.AuthorName = v2.AuthorName
+		a.AuthorEmail = v2.AuthorEmail
+		return nil
+	}
+	var v1 v1GitCommitDescription
+	if err := json.Unmarshal(data, &v1); err != nil {
+		return err
+	}
+	a.Message = v1.Message
+	a.Diff = []byte(v1.Diff)
+	a.AuthorName = v1.AuthorName
+	a.AuthorEmail = v1.AuthorEmail
+	return nil
+}
+
+type versionGitCommitDescription struct {
+	Version int `json:"version,omitempty"`
+}
+
+type v2GitCommitDescription struct {
+	Version     int    `json:"version,omitempty"`
+	Message     string `json:"message,omitempty"`
+	Diff        []byte `json:"diff,omitempty"`
+	AuthorName  string `json:"authorName,omitempty"`
+	AuthorEmail string `json:"authorEmail,omitempty"`
+}
+
+type v1GitCommitDescription struct {
 	Message     string `json:"message,omitempty"`
 	Diff        string `json:"diff,omitempty"`
 	AuthorName  string `json:"authorName,omitempty"`
@@ -166,9 +232,9 @@ var ErrNoCommits = errors.New("changeset description doesn't contain commit desc
 //
 // We currently only support a single commit in Commits. Once we support more,
 // this method will need to be revisited.
-func (d *ChangesetSpec) Diff() (string, error) {
+func (d *ChangesetSpec) Diff() ([]byte, error) {
 	if len(d.Commits) == 0 {
-		return "", ErrNoCommits
+		return nil, ErrNoCommits
 	}
 	return d.Commits[0].Diff, nil
 }

--- a/lib/batches/changeset_specs.go
+++ b/lib/batches/changeset_specs.go
@@ -238,7 +238,7 @@ func validateGroups(repoName, defaultBranch string, groups []Group) error {
 }
 
 func groupFileDiffs(completeDiff []byte, defaultBranch string, groups []Group) (map[string][]byte, error) {
-	fileDiffs, err := diff.ParseMultiFileDiff([]byte(completeDiff))
+	fileDiffs, err := diff.ParseMultiFileDiff(completeDiff)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/batches/changeset_specs.go
+++ b/lib/batches/changeset_specs.go
@@ -37,7 +37,7 @@ type ChangesetSpecInput struct {
 	Result execution.AfterStepResult
 }
 
-func BuildChangesetSpecs(input *ChangesetSpecInput) ([]*ChangesetSpec, error) {
+func BuildChangesetSpecs(input *ChangesetSpecInput, binaryDiffs bool) ([]*ChangesetSpec, error) {
 	tmplCtx := &template.ChangesetTemplateContext{
 		BatchChangeAttributes: *input.BatchChangeAttributes,
 		Steps: template.StepsContext{
@@ -94,10 +94,15 @@ func BuildChangesetSpecs(input *ChangesetSpecInput) ([]*ChangesetSpec, error) {
 		return nil, err
 	}
 
-	newSpec := func(branch, diff string) (*ChangesetSpec, error) {
+	newSpec := func(branch string, diff []byte) (*ChangesetSpec, error) {
 		var published any = nil
 		if input.Template.Published != nil {
 			published = input.Template.Published.ValueWithSuffix(input.Repository.Name, branch)
+		}
+
+		version := 1
+		if binaryDiffs {
+			version = 2
 		}
 
 		return &ChangesetSpec{
@@ -111,6 +116,7 @@ func BuildChangesetSpecs(input *ChangesetSpecInput) ([]*ChangesetSpec, error) {
 			Body:    body,
 			Commits: []GitCommitDescription{
 				{
+					Version:     version,
 					Message:     message,
 					AuthorName:  authorName,
 					AuthorEmail: authorEmail,
@@ -231,7 +237,7 @@ func validateGroups(repoName, defaultBranch string, groups []Group) error {
 	return nil
 }
 
-func groupFileDiffs(completeDiff, defaultBranch string, groups []Group) (map[string]string, error) {
+func groupFileDiffs(completeDiff []byte, defaultBranch string, groups []Group) (map[string][]byte, error) {
 	fileDiffs, err := diff.ParseMultiFileDiff([]byte(completeDiff))
 	if err != nil {
 		return nil, err
@@ -282,13 +288,13 @@ func groupFileDiffs(completeDiff, defaultBranch string, groups []Group) (map[str
 		byBranch[branch] = append(byBranch[branch], f)
 	}
 
-	finalDiffsByBranch := make(map[string]string, len(byBranch))
+	finalDiffsByBranch := make(map[string][]byte, len(byBranch))
 	for branch, diffs := range byBranch {
 		printed, err := diff.PrintMultiFileDiff(diffs)
 		if err != nil {
 			return nil, errors.Wrap(err, "printing multi file diff failed")
 		}
-		finalDiffsByBranch[branch] = string(printed)
+		finalDiffsByBranch[branch] = printed
 	}
 	return finalDiffsByBranch, nil
 }

--- a/lib/batches/changeset_specs_test.go
+++ b/lib/batches/changeset_specs_test.go
@@ -26,6 +26,7 @@ func TestCreateChangesetSpecs(t *testing.T) {
 		Body:  "The body",
 		Commits: []GitCommitDescription{
 			{
+				Version:     2,
 				Message:     "git commit message",
 				Diff:        []byte("cool diff"),
 				AuthorName:  "Sourcegraph",
@@ -200,16 +201,16 @@ index 0000000..1bd79fb
 		diff          string
 		defaultBranch string
 		groups        []Group
-		want          map[string]string
+		want          map[string][]byte
 	}{
 		{
 			diff: allDiffs,
 			groups: []Group{
 				{Directory: "1/2/3", Branch: "everything-in-3"},
 			},
-			want: map[string]string{
-				"my-default-branch": diff1 + diff2,
-				"everything-in-3":   diff3,
+			want: map[string][]byte{
+				"my-default-branch": []byte(diff1 + diff2),
+				"everything-in-3":   []byte(diff3),
 			},
 		},
 		{
@@ -217,9 +218,9 @@ index 0000000..1bd79fb
 			groups: []Group{
 				{Directory: "1/2", Branch: "everything-in-2-and-3"},
 			},
-			want: map[string]string{
-				"my-default-branch":     diff1,
-				"everything-in-2-and-3": diff2 + diff3,
+			want: map[string][]byte{
+				"my-default-branch":     []byte(diff1),
+				"everything-in-2-and-3": []byte(diff2 + diff3),
 			},
 		},
 		{
@@ -227,9 +228,9 @@ index 0000000..1bd79fb
 			groups: []Group{
 				{Directory: "1", Branch: "everything-in-1-and-2-and-3"},
 			},
-			want: map[string]string{
-				"my-default-branch":           "",
-				"everything-in-1-and-2-and-3": diff1 + diff2 + diff3,
+			want: map[string][]byte{
+				"my-default-branch":           nil,
+				"everything-in-1-and-2-and-3": []byte(diff1 + diff2 + diff3),
 			},
 		},
 		{
@@ -240,11 +241,11 @@ index 0000000..1bd79fb
 				{Directory: "1/2", Branch: "only-in-2"},
 				{Directory: "1/2/3", Branch: "only-in-3"},
 			},
-			want: map[string]string{
-				"my-default-branch": "",
-				"only-in-3":         diff3,
-				"only-in-2":         diff2,
-				"only-in-1":         diff1,
+			want: map[string][]byte{
+				"my-default-branch": nil,
+				"only-in-3":         []byte(diff3),
+				"only-in-2":         []byte(diff2),
+				"only-in-1":         []byte(diff1),
 			},
 		},
 		{
@@ -255,9 +256,9 @@ index 0000000..1bd79fb
 				{Directory: "1/2", Branch: "only-in-2"},
 				{Directory: "1", Branch: "only-in-1"},
 			},
-			want: map[string]string{
-				"my-default-branch": "",
-				"only-in-1":         diff1 + diff2 + diff3,
+			want: map[string][]byte{
+				"my-default-branch": nil,
+				"only-in-1":         []byte(diff1 + diff2 + diff3),
 			},
 		},
 		{
@@ -265,8 +266,8 @@ index 0000000..1bd79fb
 			groups: []Group{
 				{Directory: "", Branch: "everything"},
 			},
-			want: map[string]string{
-				"my-default-branch": diff1 + diff2 + diff3,
+			want: map[string][]byte{
+				"my-default-branch": []byte(diff1 + diff2 + diff3),
 			},
 		},
 	}

--- a/lib/batches/changeset_specs_test.go
+++ b/lib/batches/changeset_specs_test.go
@@ -27,7 +27,7 @@ func TestCreateChangesetSpecs(t *testing.T) {
 		Commits: []GitCommitDescription{
 			{
 				Message:     "git commit message",
-				Diff:        "cool diff",
+				Diff:        []byte("cool diff"),
 				AuthorName:  "Sourcegraph",
 				AuthorEmail: "batch-changes@sourcegraph.com",
 			},
@@ -71,7 +71,7 @@ func TestCreateChangesetSpecs(t *testing.T) {
 		},
 
 		Result: execution.AfterStepResult{
-			Diff: "cool diff",
+			Diff: []byte("cool diff"),
 			ChangedFiles: git.Changes{
 				Modified: []string{"README.md"},
 			},
@@ -148,7 +148,7 @@ func TestCreateChangesetSpecs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			have, err := BuildChangesetSpecs(tt.input)
+			have, err := BuildChangesetSpecs(tt.input, true)
 			if err != nil {
 				if tt.wantErr != "" {
 					if err.Error() != tt.wantErr {
@@ -272,7 +272,7 @@ index 0000000..1bd79fb
 	}
 
 	for _, tc := range tests {
-		have, err := groupFileDiffs(tc.diff, defaultBranch, tc.groups)
+		have, err := groupFileDiffs([]byte(tc.diff), defaultBranch, tc.groups)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}

--- a/lib/batches/execution/cache/cache.go
+++ b/lib/batches/execution/cache/cache.go
@@ -151,7 +151,7 @@ func KeyForWorkspace(batchChangeAttributes *template.BatchChangeAttributes, r ba
 }
 
 // ChangesetSpecsFromCache takes the execution.Result and generates all changeset specs from it.
-func ChangesetSpecsFromCache(spec *batches.BatchSpec, r batches.Repository, result execution.AfterStepResult, path string) ([]*batches.ChangesetSpec, error) {
+func ChangesetSpecsFromCache(spec *batches.BatchSpec, r batches.Repository, result execution.AfterStepResult, path string, binaryDiffs bool) ([]*batches.ChangesetSpec, error) {
 	if len(result.Diff) == 0 {
 		return []*batches.ChangesetSpec{}, nil
 	}
@@ -170,5 +170,5 @@ func ChangesetSpecsFromCache(spec *batches.BatchSpec, r batches.Repository, resu
 		Path:             path,
 	}
 
-	return batches.BuildChangesetSpecs(input)
+	return batches.BuildChangesetSpecs(input, binaryDiffs)
 }

--- a/lib/batches/execution/cache/cache.go
+++ b/lib/batches/execution/cache/cache.go
@@ -152,7 +152,7 @@ func KeyForWorkspace(batchChangeAttributes *template.BatchChangeAttributes, r ba
 
 // ChangesetSpecsFromCache takes the execution.Result and generates all changeset specs from it.
 func ChangesetSpecsFromCache(spec *batches.BatchSpec, r batches.Repository, result execution.AfterStepResult, path string) ([]*batches.ChangesetSpec, error) {
-	if result.Diff == "" {
+	if len(result.Diff) == 0 {
 		return []*batches.ChangesetSpec{}, nil
 	}
 

--- a/lib/batches/execution/results.go
+++ b/lib/batches/execution/results.go
@@ -24,7 +24,7 @@ type AfterStepResult struct {
 	Outputs map[string]any `json:"outputs"`
 }
 
-func (a *AfterStepResult) MarshalJSON() ([]byte, error) {
+func (a AfterStepResult) MarshalJSON() ([]byte, error) {
 	if a.Version == 2 {
 		return json.Marshal(v2AfterStepResult{
 			Version:      a.Version,

--- a/lib/batches/execution/results.go
+++ b/lib/batches/execution/results.go
@@ -26,15 +26,7 @@ type AfterStepResult struct {
 
 func (a AfterStepResult) MarshalJSON() ([]byte, error) {
 	if a.Version == 2 {
-		return json.Marshal(v2AfterStepResult{
-			Version:      a.Version,
-			ChangedFiles: a.ChangedFiles,
-			Stdout:       a.Stdout,
-			Stderr:       a.Stderr,
-			StepIndex:    a.StepIndex,
-			Diff:         a.Diff,
-			Outputs:      a.Outputs,
-		})
+		return json.Marshal(v2AfterStepResult(a))
 	}
 	return json.Marshal(v1AfterStepResult{
 		ChangedFiles: a.ChangedFiles,

--- a/lib/batches/execution/results.go
+++ b/lib/batches/execution/results.go
@@ -1,10 +1,15 @@
 package execution
 
-import "github.com/sourcegraph/sourcegraph/lib/batches/git"
+import (
+	"encoding/json"
+
+	"github.com/sourcegraph/sourcegraph/lib/batches/git"
+)
 
 // AfterStepResult is the execution result after executing a step with the given
 // index in Steps.
 type AfterStepResult struct {
+	Version int `json:"version"`
 	// Files are the changes made to Files by the step.
 	ChangedFiles git.Changes `json:"changedFiles"`
 	// Stdout is the output produced by the step on standard out.
@@ -14,7 +19,84 @@ type AfterStepResult struct {
 	// StepIndex is the index of the step in the list of steps.
 	StepIndex int `json:"stepIndex"`
 	// Diff is the cumulative `git diff` after executing the Step.
-	Diff string `json:"diff"`
+	Diff []byte `json:"diff"`
 	// Outputs is a copy of the Outputs after executing the Step.
 	Outputs map[string]any `json:"outputs"`
+}
+
+func (a *AfterStepResult) MarshalJSON() ([]byte, error) {
+	if a.Version == 2 {
+		return json.Marshal(v2AfterStepResult{
+			Version:      a.Version,
+			ChangedFiles: a.ChangedFiles,
+			Stdout:       a.Stdout,
+			Stderr:       a.Stderr,
+			StepIndex:    a.StepIndex,
+			Diff:         a.Diff,
+			Outputs:      a.Outputs,
+		})
+	}
+	return json.Marshal(v1AfterStepResult{
+		ChangedFiles: a.ChangedFiles,
+		Stdout:       a.Stdout,
+		Stderr:       a.Stderr,
+		StepIndex:    a.StepIndex,
+		Diff:         string(a.Diff),
+		Outputs:      a.Outputs,
+	})
+}
+
+func (a *AfterStepResult) UnmarshalJSON(data []byte) error {
+	var version versionAfterStepResult
+	if err := json.Unmarshal(data, &version); err != nil {
+		return err
+	}
+	if version.Version == 2 {
+		var v2 v2AfterStepResult
+		if err := json.Unmarshal(data, &v2); err != nil {
+			return err
+		}
+		a.Version = v2.Version
+		a.ChangedFiles = v2.ChangedFiles
+		a.Stdout = v2.Stdout
+		a.Stderr = v2.Stderr
+		a.StepIndex = v2.StepIndex
+		a.Diff = v2.Diff
+		a.Outputs = v2.Outputs
+		return nil
+	}
+	var v1 v1AfterStepResult
+	if err := json.Unmarshal(data, &v1); err != nil {
+		return err
+	}
+	a.ChangedFiles = v1.ChangedFiles
+	a.Stdout = v1.Stdout
+	a.Stderr = v1.Stderr
+	a.StepIndex = v1.StepIndex
+	a.Diff = []byte(v1.Diff)
+	a.Outputs = v1.Outputs
+	return nil
+}
+
+type versionAfterStepResult struct {
+	Version int `json:"version"`
+}
+
+type v2AfterStepResult struct {
+	Version      int            `json:"version"`
+	ChangedFiles git.Changes    `json:"changedFiles"`
+	Stdout       string         `json:"stdout"`
+	Stderr       string         `json:"stderr"`
+	StepIndex    int            `json:"stepIndex"`
+	Diff         []byte         `json:"diff"`
+	Outputs      map[string]any `json:"outputs"`
+}
+
+type v1AfterStepResult struct {
+	ChangedFiles git.Changes    `json:"changedFiles"`
+	Stdout       string         `json:"stdout"`
+	Stderr       string         `json:"stderr"`
+	StepIndex    int            `json:"stepIndex"`
+	Diff         string         `json:"diff"`
+	Outputs      map[string]any `json:"outputs"`
 }

--- a/lib/batches/json_logs.go
+++ b/lib/batches/json_logs.go
@@ -226,7 +226,7 @@ type TaskStepMetadata struct {
 	Error    string
 }
 
-func (m *TaskStepMetadata) MarshalJSON() ([]byte, error) {
+func (m TaskStepMetadata) MarshalJSON() ([]byte, error) {
 	if m.Version == 2 {
 		return json.Marshal(v2TaskStepMetadata{
 			Version:   2,

--- a/lib/batches/json_logs.go
+++ b/lib/batches/json_logs.go
@@ -210,19 +210,115 @@ type TaskPreparingStepMetadata struct {
 }
 
 type TaskStepMetadata struct {
-	TaskID string `json:"taskID,omitempty"`
-	Step   int    `json:"step,omitempty"`
+	Version int
+	TaskID  string
+	Step    int
 
+	RunScript string
+	Env       map[string]string
+
+	Out string
+
+	Diff    []byte
+	Outputs map[string]any
+
+	ExitCode int
+	Error    string
+}
+
+func (m *TaskStepMetadata) MarshalJSON() ([]byte, error) {
+	if m.Version == 2 {
+		return json.Marshal(v2TaskStepMetadata{
+			Version:   2,
+			TaskID:    m.TaskID,
+			Step:      m.Step,
+			RunScript: m.RunScript,
+			Env:       m.Env,
+			Out:       m.Out,
+			Diff:      m.Diff,
+			Outputs:   m.Outputs,
+			ExitCode:  m.ExitCode,
+			Error:     m.Error,
+		})
+	}
+	return json.Marshal(v1TaskStepMetadata{
+		TaskID:    m.TaskID,
+		Step:      m.Step,
+		RunScript: m.RunScript,
+		Env:       m.Env,
+		Out:       m.Out,
+		Diff:      string(m.Diff),
+		Outputs:   m.Outputs,
+		ExitCode:  m.ExitCode,
+		Error:     m.Error,
+	})
+}
+
+func (m *TaskStepMetadata) UnmarshalJSON(data []byte) error {
+	var version versionTaskStepMetadata
+	if err := json.Unmarshal(data, &version); err != nil {
+		return err
+	}
+	if version.Version == 2 {
+		var v2 v2TaskStepMetadata
+		if err := json.Unmarshal(data, &v2); err != nil {
+			return err
+		}
+		m.Version = v2.Version
+		m.TaskID = v2.TaskID
+		m.Step = v2.Step
+		m.RunScript = v2.RunScript
+		m.Env = v2.Env
+		m.Out = v2.Out
+		m.Diff = v2.Diff
+		m.Outputs = v2.Outputs
+		m.ExitCode = v2.ExitCode
+		m.Error = v2.Error
+		return nil
+	}
+	var v1 v1TaskStepMetadata
+	if err := json.Unmarshal(data, &v1); err != nil {
+		return errors.Wrap(err, string(data))
+	}
+	m.TaskID = v1.TaskID
+	m.Step = v1.Step
+	m.RunScript = v1.RunScript
+	m.Env = v1.Env
+	m.Out = v1.Out
+	m.Diff = []byte(v1.Diff)
+	m.Outputs = v1.Outputs
+	m.ExitCode = v1.ExitCode
+	m.Error = v1.Error
+	return nil
+}
+
+type versionTaskStepMetadata struct {
+	Version int `json:"version,omitempty"`
+}
+
+type v2TaskStepMetadata struct {
+	Version   int               `json:"version,omitempty"`
+	TaskID    string            `json:"taskID,omitempty"`
+	Step      int               `json:"step,omitempty"`
 	RunScript string            `json:"runScript,omitempty"`
 	Env       map[string]string `json:"env,omitempty"`
+	Out       string            `json:"out,omitempty"`
+	Diff      []byte            `json:"diff,omitempty"`
+	Outputs   map[string]any    `json:"outputs,omitempty"`
+	ExitCode  int               `json:"exitCode,omitempty"`
+	Error     string            `json:"error,omitempty"`
+}
 
-	Out string `json:"out,omitempty"`
-
-	Diff    string         `json:"diff,omitempty"`
-	Outputs map[string]any `json:"outputs,omitempty"`
-
-	ExitCode int    `json:"exitCode,omitempty"`
-	Error    string `json:"error,omitempty"`
+type v1TaskStepMetadata struct {
+	TaskID    string            `json:"taskID,omitempty"`
+	Step      int               `json:"step,omitempty"`
+	RunScript string            `json:"runScript,omitempty"`
+	Env       map[string]string `json:"env,omitempty"`
+	Out       string            `json:"out,omitempty"`
+	Diff      string            `json:"diff,omitempty"`
+	Outputs   map[string]any    `json:"outputs,omitempty"`
+	ExitCode  int               `json:"exitCode,omitempty"`
+	Error     string            `json:"error,omitempty"`
 }
 
 type CacheAfterStepResultMetadata struct {

--- a/lib/batches/schema/changeset_spec_stringdata.go
+++ b/lib/batches/schema/changeset_spec_stringdata.go
@@ -14,7 +14,7 @@ const ChangesetSpecJSON = `{
       "type": "object",
       "properties": {
         "version": {
-          "type": "number",
+          "type": "integer",
           "description": "A field for versioning the payload."
         },
         "baseRepository": {
@@ -36,7 +36,7 @@ const ChangesetSpecJSON = `{
       "type": "object",
       "properties": {
         "version": {
-          "type": "number",
+          "type": "integer",
           "description": "A field for versioning the payload."
         },
         "baseRepository": {
@@ -81,7 +81,7 @@ const ChangesetSpecJSON = `{
             "required": ["message", "diff", "authorName", "authorEmail"],
             "properties": {
               "version": {
-                "type": "number",
+                "type": "integer",
                 "description": "A field for versioning the payload."
               },
               "message": {

--- a/lib/batches/schema/changeset_spec_stringdata.go
+++ b/lib/batches/schema/changeset_spec_stringdata.go
@@ -13,6 +13,10 @@ const ChangesetSpecJSON = `{
       "title": "ExistingChangesetSpec",
       "type": "object",
       "properties": {
+        "version": {
+          "type": "number",
+          "description": "A field for versioning the payload."
+        },
         "baseRepository": {
           "type": "string",
           "description": "The GraphQL ID of the repository that contains the existing changeset on the code host.",
@@ -31,6 +35,10 @@ const ChangesetSpecJSON = `{
       "title": "BranchChangesetSpec",
       "type": "object",
       "properties": {
+        "version": {
+          "type": "number",
+          "description": "A field for versioning the payload."
+        },
         "baseRepository": {
           "type": "string",
           "description": "The GraphQL ID of the repository that this changeset spec is proposing to change.",
@@ -72,6 +80,10 @@ const ChangesetSpecJSON = `{
             "additionalProperties": false,
             "required": ["message", "diff", "authorName", "authorEmail"],
             "properties": {
+              "version": {
+                "type": "number",
+                "description": "A field for versioning the payload."
+              },
               "message": {
                 "type": "string",
                 "description": "The Git commit message."

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -3,6 +3,7 @@ module github.com/sourcegraph/sourcegraph/lib
 go 1.19
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/charmbracelet/glamour v0.5.0
 	github.com/cockroachdb/errors v1.9.0
 	github.com/derision-test/go-mockgen v1.3.7

--- a/lib/go.sum
+++ b/lib/go.sum
@@ -9,6 +9,8 @@ github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mo
 github.com/CloudyKit/jet/v3 v3.0.0/go.mod h1:HKQPgSJmdK8hdoAbKUUWajkHyHo4RaU5rMdUywE7VMo=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7/go.mod h1:6E6s8o2AE4KhCrqr6GRJjdC/gNfTdxkIXvuGZZda2VM=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=

--- a/schema/changeset_spec.schema.json
+++ b/schema/changeset_spec.schema.json
@@ -8,6 +8,10 @@
       "title": "ExistingChangesetSpec",
       "type": "object",
       "properties": {
+        "version": {
+          "type": "number",
+          "description": "A field for versioning the payload."
+        },
         "baseRepository": {
           "type": "string",
           "description": "The GraphQL ID of the repository that contains the existing changeset on the code host.",
@@ -26,6 +30,10 @@
       "title": "BranchChangesetSpec",
       "type": "object",
       "properties": {
+        "version": {
+          "type": "number",
+          "description": "A field for versioning the payload."
+        },
         "baseRepository": {
           "type": "string",
           "description": "The GraphQL ID of the repository that this changeset spec is proposing to change.",
@@ -67,6 +75,10 @@
             "additionalProperties": false,
             "required": ["message", "diff", "authorName", "authorEmail"],
             "properties": {
+              "version": {
+                "type": "number",
+                "description": "A field for versioning the payload."
+              },
               "message": {
                 "type": "string",
                 "description": "The Git commit message."

--- a/schema/changeset_spec.schema.json
+++ b/schema/changeset_spec.schema.json
@@ -9,7 +9,7 @@
       "type": "object",
       "properties": {
         "version": {
-          "type": "number",
+          "type": "integer",
           "description": "A field for versioning the payload."
         },
         "baseRepository": {
@@ -31,7 +31,7 @@
       "type": "object",
       "properties": {
         "version": {
-          "type": "number",
+          "type": "integer",
           "description": "A field for versioning the payload."
         },
         "baseRepository": {
@@ -76,7 +76,7 @@
             "required": ["message", "diff", "authorName", "authorEmail"],
             "properties": {
               "version": {
-                "type": "number",
+                "type": "integer",
                 "description": "A field for versioning the payload."
               },
               "message": {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -398,6 +398,8 @@ type BranchChangesetSpec struct {
 	Published interface{} `json:"published,omitempty"`
 	// Title description: The title of the changeset on the code host.
 	Title string `json:"title"`
+	// Version description: A field for versioning the payload.
+	Version float64 `json:"version,omitempty"`
 }
 type BrandAssets struct {
 	// Logo description: The URL to the image used on the homepage. This will replace the Sourcegraph logo on the homepage. Maximum width: 320px. We recommend using the following file formats: SVG, PNG
@@ -593,6 +595,8 @@ type ExistingChangesetSpec struct {
 	BaseRepository string `json:"baseRepository"`
 	// ExternalID description: The ID that uniquely identifies the existing changeset on the code host
 	ExternalID string `json:"externalID"`
+	// Version description: A field for versioning the payload.
+	Version float64 `json:"version,omitempty"`
 }
 
 // ExpandedGitCommitDescription description: The Git commit to create with the changes.
@@ -767,6 +771,8 @@ type GitCommitDescription struct {
 	Diff string `json:"diff"`
 	// Message description: The Git commit message.
 	Message string `json:"message"`
+	// Version description: A field for versioning the payload.
+	Version float64 `json:"version,omitempty"`
 }
 
 // GitHubApp description: The config options for Sourcegraph GitHub App.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -399,7 +399,7 @@ type BranchChangesetSpec struct {
 	// Title description: The title of the changeset on the code host.
 	Title string `json:"title"`
 	// Version description: A field for versioning the payload.
-	Version float64 `json:"version,omitempty"`
+	Version int `json:"version,omitempty"`
 }
 type BrandAssets struct {
 	// Logo description: The URL to the image used on the homepage. This will replace the Sourcegraph logo on the homepage. Maximum width: 320px. We recommend using the following file formats: SVG, PNG
@@ -596,7 +596,7 @@ type ExistingChangesetSpec struct {
 	// ExternalID description: The ID that uniquely identifies the existing changeset on the code host
 	ExternalID string `json:"externalID"`
 	// Version description: A field for versioning the payload.
-	Version float64 `json:"version,omitempty"`
+	Version int `json:"version,omitempty"`
 }
 
 // ExpandedGitCommitDescription description: The Git commit to create with the changes.
@@ -772,7 +772,7 @@ type GitCommitDescription struct {
 	// Message description: The Git commit message.
 	Message string `json:"message"`
 	// Version description: A field for versioning the payload.
-	Version float64 `json:"version,omitempty"`
+	Version int `json:"version,omitempty"`
 }
 
 // GitHubApp description: The config options for Sourcegraph GitHub App.


### PR DESCRIPTION
Patches can contain non UTF-8 characters (who knew). Since we JSON-encode the patch as a string field, we lose that encoding over the wire to Sourcegraph from src-cli and also when we interact with executors. This PR adds support for a byte slice encoded (so base64 over the wire) mode from Sourcegraph 4.4 onwards, which retains original encoding.
Executors also now support binary files for VirtualMachineFiles. The most of this diff is restoring backwards compatibility with old src-cli and executors, the main change is `string -> []byte`. 

Closes https://github.com/sourcegraph/sourcegraph/issues/44743

## Test plan

Validated that the corresponding src-cli version still works with older Sourcegraph backends (then without this fix), and with a current Sourcegraph backend where this fixes patches with non UTF-8. Tested with src-cli execution and SSBC.
I've put a bunch of effort into testing this, but would appreciate someone else taking a stab at this.