### PR TITLE
Code Insights: Fix scroll into view for the dashboard grid keyboard navigation

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/view-grid/ViewGrid.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/view-grid/ViewGrid.module.scss
@@ -16,3 +16,11 @@
         }
     }
 }
+
+.item {
+    // Hardcoded value for better scroll into view positioning
+    // top = <height of global nav bar> + <sticky code insight select height>
+    // bottom = default 2 rem padding
+    scroll-margin-top: 3.75rem;
+    scroll-margin-bottom: 2rem;
+}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/view-grid/ViewGrid.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/view-grid/ViewGrid.tsx
@@ -2,6 +2,7 @@ import React, {
     createContext,
     FC,
     forwardRef,
+    HTMLAttributes,
     PropsWithChildren,
     ReactElement,
     useCallback,
@@ -206,13 +207,13 @@ const KEY_NAVIGATION_DIRECTIONS: Partial<Record<Key, Direction>> = {
     [Key.ArrowLeft]: 'left',
 }
 
-interface ViewGridItemProps {
+interface ViewGridItemProps extends HTMLAttributes<HTMLElement> {
     id: string
     children: React.ReactElement
 }
 
 export const ViewGridItem = forwardRef<HTMLElement, ViewGridItemProps>((props, ref) => {
-    const { children, id, ...attributes } = props
+    const { children, id, className, ...attributes } = props
 
     const { gridElements, activeLayout } = useContext(GridViewContext)
     const mergedRef = useMergeRefs<HTMLElement>([ref, (children as any).ref])
@@ -242,7 +243,13 @@ export const ViewGridItem = forwardRef<HTMLElement, ViewGridItemProps>((props, r
             const nextLayoutElement = nextLayout ? gridElements.get(nextLayout.i) : null
 
             if (nextLayoutElement) {
-                nextLayoutElement.focus()
+                // Schedule focus and scroll call into the next rendering frame since
+                // in order to ensure that Safari focus and scrollIntoView will work
+                // as expected
+                requestAnimationFrame(() => {
+                    nextLayoutElement.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+                    nextLayoutElement.focus()
+                })
             }
         },
         [activeLayout, gridElements, id]
@@ -252,6 +259,7 @@ export const ViewGridItem = forwardRef<HTMLElement, ViewGridItemProps>((props, r
         return React.cloneElement(children as ReactElement, {
             ...attributes,
             ref: mergedRef,
+            className: classNames(className, styles.item),
             onKeyDown: handleKeydown,
         })
     }


### PR DESCRIPTION
## Problem 

Prior to this PR if you tried to navigate with keyboard through the code insights dashboard grid items you could see that sometimes navigation (focusing the next grid card and scrolling it into viewport) don't work as as expected. 

In this PR we fix this and fix the the scroll paddings for grid items in order to avoid visual overlapping between cards and the sticky dashboard nav header. See demos below for more context

| Before | After |
| -------- | ------- |
| <video src="https://user-images.githubusercontent.com/18492575/203689513-1a5477b2-77ba-4163-87b3-f591ced6e5db.mp4" /> | <video src="https://user-images.githubusercontent.com/18492575/203689499-29c67f6a-e9aa-4290-9697-40e908c1f810.mp4" />| 

## Test plan
- Try to navigate with arrow keys through dashboard grid items in Safari
- Make sure that you always can see the focused card 


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-grid-scroll-into-view.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
