### PR TITLE
bext: ignore search pages in GitHub route change handlers

### DIFF
--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 <!-- START CHANGELOG -->
 
 ## Unreleased
+- Fix route change handlers for GitHub: [issues/44074](https://github.com/sourcegraph/sourcegraph/issues/44074), [pull/44783](https://github.com/sourcegraph/sourcegraph/pull/44783)
 
 ## Chrome 22.11.14.1520, Firefox 22.11.14.1521, Safari v1.18
 

--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 <!-- START CHANGELOG -->
 
 ## Unreleased
+
 - Fix route change handlers for GitHub: [issues/44074](https://github.com/sourcegraph/sourcegraph/issues/44074), [pull/44783](https://github.com/sourcegraph/sourcegraph/pull/44783)
 
 ## Chrome 22.11.14.1520, Firefox 22.11.14.1521, Safari v1.18

--- a/client/browser/src/shared/code-hosts/github/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/github/codeHost.tsx
@@ -435,6 +435,7 @@ const isSimpleSearchPage = (): boolean => window.location.pathname === '/search'
 const isAdvancedSearchPage = (): boolean => window.location.pathname === '/search/advanced'
 const isRepoSearchPage = (): boolean => !isSimpleSearchPage() && window.location.pathname.endsWith('/search')
 const isSearchResultsPage = (): boolean =>
+    // TODO(#44327): Do not rely on window.location.search - it may be present not only on search pages (e.g., issues, pulls, etc.).
     Boolean(new URLSearchParams(window.location.search).get('q')) && !isAdvancedSearchPage()
 const isSearchPage = (): boolean =>
     isSimpleSearchPage() || isAdvancedSearchPage() || isRepoSearchPage() || isSearchResultsPage()
@@ -694,9 +695,10 @@ export const githubCodeHost: GithubCodeHost = {
                 }
 
                 // search results page filters being applied
-                if (isSearchResultsPage()) {
-                    return document.querySelector('.codesearch-results h3')?.textContent?.trim()
-                }
+                // TODO(#44327): Uncomment or remove this depending on the outcome of the issue.
+                // if (isSearchResultsPage()) {
+                //     return document.querySelector('.codesearch-results h3')?.textContent?.trim()
+                // }
 
                 // other pages
                 return pathname


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/44074

Fixes route change handlers on GitHub.
Existing `isSearchResultsPage` definition is wrong. It relies on `window.location.search` which can be also defined for other than search pages (e.g., issues, pulls, etc.). We do not fix the definition but ignore search pages in client-side routes handling as search page enhancements have been (temporarily) disabled:
- https://github.com/sourcegraph/sourcegraph/pull/44329
- https://github.com/sourcegraph/sourcegraph/issues/44327


https://user-images.githubusercontent.com/25318659/203758189-7791ee34-1550-4065-a841-a9633b8c65fc.mov



## Test plan
- CI passes
- Tested manually (see video attached)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-bext-fix-route.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

