### PR TITLE
search: go test --update

### DIFF
--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -683,14 +683,15 @@ func TestNewPlanJob(t *testing.T) {
             (repoOpts.hasKVPs[0].key . tag)
             (PARTIALREPOS
               (SEARCHERTEXTSEARCH
-                (indexed . false)))))
+                (indexed . false))))
+          (REPOSEARCH
+            (repoOpts.repoFilters.0 . foo)(repoOpts.hasKVPs[0].key . tag)
+            (repoNamePatterns . [(?i)foo])))
         (REPOSCOMPUTEEXCLUDED
           (repoOpts.hasKVPs[0].key . tag))
         (PARALLEL
           NoopJob
-          (REPOSEARCH
-            (repoOpts.repoFilters.0 . foo)(repoOpts.hasKVPs[0].key . tag)
-            (repoNamePatterns . [(?i)foo])))))))`),
+          NoopJob)))))`),
 		}, {
 			query:      `(...)`,
 			protocol:   search.Streaming,


### PR DESCRIPTION
Ran go test . --udpate. This should fix CI.  #44659 broke CI because it raced with #44694.

## Test plan
CI
