### PR TITLE
flake: disable 'navigates to file on symbol click for Go'

### DIFF
--- a/client/web/src/end-to-end/code-intel/repository-component.test.ts
+++ b/client/web/src/end-to-end/code-intel/repository-component.test.ts
@@ -411,12 +411,13 @@ describe('Repository component', () => {
         }
 
         const navigateToSymbolTests = [
-            {
-                name: 'navigates to file on symbol click for Go',
-                repoPath: '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d',
-                filePath: '/tree/cmd',
-                symbolPath: '/blob/cmd/go-diff/go-diff.go?L19:2-19:10',
-            },
+            // Flake, see https://github.com/sourcegraph/sourcegraph/issues/44791
+            // {
+            //     name: 'navigates to file on symbol click for Go',
+            //     repoPath: '/github.com/sourcegraph/go-diff@3f415a150aec0685cb81b73cc201e762e075006d',
+            //     filePath: '/tree/cmd',
+            //     symbolPath: '/blob/cmd/go-diff/go-diff.go?L19:2-19:10',
+            // },
             {
                 name: 'navigates to file on symbol click for Java',
                 repoPath: '/github.com/sourcegraph/java-langserver@03efbe9558acc532e88f5288b4e6cfa155c6f2dc',


### PR DESCRIPTION
See https://github.com/sourcegraph/sourcegraph/issues/44791

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Just disabled a test. 

## App preview:

- [Web](https://sg-web-jh-disable-flaky-nav-to-file-on.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
