### PR TITLE
schema: fix repoPurgeWorker.*Minutes spellings

### DIFF
--- a/internal/repos/purge.go
+++ b/internal/repos/purge.go
@@ -37,20 +37,20 @@ func RunRepositoryPurgeWorker(ctx context.Context, logger log.Logger, db databas
 		if purgeConfig == nil {
 			purgeConfig = &schema.RepoPurgeWorker{
 				// Defaults - align with documentation
-				IntervalMintues:   15,
-				DeletedTTLMintues: 60,
+				IntervalMinutes:   15,
+				DeletedTTLMinutes: 60,
 			}
-		} else if purgeConfig.IntervalMintues <= 0 {
+		} else if purgeConfig.IntervalMinutes <= 0 {
 			logger.Debug("purge worker disabled via site config",
-				log.Int("repoPurgeWorker.interval", purgeConfig.IntervalMintues))
+				log.Int("repoPurgeWorker.interval", purgeConfig.IntervalMinutes))
 			randSleep(15*time.Minute, 1*time.Minute)
 			continue
 		}
 
-		deletedBefore := time.Now().Add(-time.Duration(purgeConfig.DeletedTTLMintues) * time.Minute)
+		deletedBefore := time.Now().Add(-time.Duration(purgeConfig.DeletedTTLMinutes) * time.Minute)
 		purgeLogger := logger.With(log.Time("deletedBefore", deletedBefore))
 
-		timeToNextPurge := time.Duration(purgeConfig.IntervalMintues) * time.Minute
+		timeToNextPurge := time.Duration(purgeConfig.IntervalMinutes) * time.Minute
 		purgeLogger.Debug("running repository purge",
 			log.Duration("timeToNextPurge", timeToNextPurge))
 		if err := purge(ctx, purgeLogger, db, database.IteratePurgableReposOptions{

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1576,10 +1576,10 @@ type Ranking struct {
 
 // RepoPurgeWorker description: Configuration for repository purge worker.
 type RepoPurgeWorker struct {
-	// DeletedTTLMintues description: Repository TTL in minutes after deletion before it becomes eligible to be purged. A migration or admin could accidentally remove all or a significant number of repositories - recloning all of them is slow, so a TTL acts as a grace period so that admins can recover from accidental deletions
-	DeletedTTLMintues int `json:"deletedTTLMintues,omitempty"`
-	// IntervalMintues description: Interval in minutes at which to run purge jobs. Set to 0 to disable.
-	IntervalMintues int `json:"intervalMintues,omitempty"`
+	// DeletedTTLMinutes description: Repository TTL in minutes after deletion before it becomes eligible to be purged. A migration or admin could accidentally remove all or a significant number of repositories - recloning all of them is slow, so a TTL acts as a grace period so that admins can recover from accidental deletions
+	DeletedTTLMinutes int `json:"deletedTTLMinutes,omitempty"`
+	// IntervalMinutes description: Interval in minutes at which to run purge jobs. Set to 0 to disable.
+	IntervalMinutes int `json:"intervalMinutes,omitempty"`
 }
 type Repos struct {
 	// Callsign description: The unique Phabricator identifier for the repository, like 'MUX'.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -922,13 +922,13 @@
         "deletedTTL": 60
       },
       "properties": {
-        "intervalMintues": {
+        "intervalMinutes": {
           "type": "integer",
           "description": "Interval in minutes at which to run purge jobs. Set to 0 to disable.",
           "default": "15",
           "minimum": 0
         },
-        "deletedTTLMintues": {
+        "deletedTTLMinutes": {
           "type": "integer",
           "description": "Repository TTL in minutes after deletion before it becomes eligible to be purged. A migration or admin could accidentally remove all or a significant number of repositories - recloning all of them is slow, so a TTL acts as a grace period so that admins can recover from accidental deletions",
           "default": "60",


### PR DESCRIPTION
fix some bad speeling from https://github.com/sourcegraph/sourcegraph/pull/44753#discussion_r1031178717

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI, checked my dictionary