### PR TITLE
otelsql: mute less useful spans

### DIFF
--- a/internal/database/dbconn/open.go
+++ b/internal/database/dbconn/open.go
@@ -226,6 +226,9 @@ func open(cfg *pgx.ConnConfig) (*sql.DB, error) {
 		otelsql.WithSQLCommenter(true),
 		otelsql.WithSpanOptions(otelsql.SpanOptions{
 			OmitConnResetSession: true,
+			OmitConnPrepare:      true,
+			OmitRows:             true,
+			OmitConnectorConnect: true,
 			ArgumentOptions: otelsql.ArgumentOptions{
 				EnableAttributes: true,
 				Skip: func(ctx context.Context, query string, args []any) bool {


### PR DESCRIPTION
This mutes the less useful otelsql spans, reducing the number of total spans. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

After: 

<img width="2170" alt="CleanShot 2022-11-24 at 18 00 53@2x" src="https://user-images.githubusercontent.com/10151/203836491-00572ec8-04c8-420a-929c-49cb60c5ab18.png">
