### PR TITLE
gitserver: Improve handling of failed commit errors

### DIFF
--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -192,7 +192,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 
 	if out, err := run(cmd, "applying patch"); err != nil {
 		logger.Error("Failed to apply patch", log.String("output", string(out)))
-		return http.StatusInternalServerError, resp
+		return http.StatusBadRequest, resp
 	}
 
 	message := req.CommitInfo.Message

--- a/enterprise/internal/batches/reconciler/executor.go
+++ b/enterprise/internal/batches/reconciler/executor.go
@@ -565,7 +565,8 @@ func (e *executor) pushCommit(ctx context.Context, opts protocol.CreateCommitFro
 	if err != nil {
 		var e *protocol.CreateCommitFromPatchError
 		if errors.As(err, &e) {
-			// Make patch does not apply error a fatal error, retries won't help here.
+			// Make "patch does not apply" errors a fatal error. Retrying the changeset
+			// rollout won't help here and just causes noise.
 			if strings.Contains(e.CombinedOutput, "patch does not apply") {
 				return errcode.MakeNonRetryable(pushCommitError{e})
 			}

--- a/enterprise/internal/batches/reconciler/executor.go
+++ b/enterprise/internal/batches/reconciler/executor.go
@@ -565,6 +565,10 @@ func (e *executor) pushCommit(ctx context.Context, opts protocol.CreateCommitFro
 	if err != nil {
 		var e *protocol.CreateCommitFromPatchError
 		if errors.As(err, &e) {
+			// Make patch does not apply error a fatal error, retries won't help here.
+			if strings.Contains(e.CombinedOutput, "patch does not apply") {
+				return errcode.MakeNonRetryable(pushCommitError{e})
+			}
 			return pushCommitError{e}
 		}
 		return err

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -25,9 +25,10 @@ import (
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 
 	sglog "github.com/sourcegraph/log"
 
@@ -1282,22 +1283,13 @@ func (c *clientImplementor) CreateCommitFromPatch(ctx context.Context, req proto
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		c.logger.Warn("reading gitserver create-commit-from-patch response", sglog.Error(err))
-		return "", &url.Error{
-			URL: resp.Request.URL.String(),
-			Op:  "CreateCommitFromPatch",
-			Err: errors.Errorf("CreateCommitFromPatch: http status %d, %s", resp.Status, readResponseBody(resp.Body)),
-		}
-	}
-
 	var res protocol.CreateCommitFromPatchResponse
 	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
 		c.logger.Warn("decoding gitserver create-commit-from-patch response", sglog.Error(err))
 		return "", &url.Error{
 			URL: resp.Request.URL.String(),
 			Op:  "CreateCommitFromPatch",
-			Err: errors.Errorf("CreateCommitFromPatch: http status %d, %v", resp.StatusCode, err),
+			Err: errors.Errorf("CreateCommitFromPatch: http status %d, %s", resp.StatusCode, readResponseBody(resp.Body)),
 		}
 	}
 

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -552,7 +552,7 @@ func NewRetryPolicy(max int) rehttp.RetryFn {
 			return true
 		}
 
-		if status == 0 || status == 429 || (status >= 500 && status != 501) {
+		if status == 0 || status == http.StatusTooManyRequests || (status >= http.StatusInternalServerError && status != http.StatusNotImplemented) {
 			return true
 		}
 

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -552,7 +552,7 @@ func NewRetryPolicy(max int) rehttp.RetryFn {
 			return true
 		}
 
-		if status == 0 || status == http.StatusTooManyRequests || (status >= http.StatusInternalServerError && status != http.StatusNotImplemented) {
+		if status == 0 || status == http.StatusTooManyRequests || (status >= 500 && status != http.StatusNotImplemented) {
 			return true
 		}
 


### PR DESCRIPTION
This PR improves how we handle failed to apply patch errors by doing the following:
- Make it a 4xx error so that we don't retry this request through the internalClient
- Make a patch does not apply a fatal error so that the dbworker doesn't retry it
- Actually return the well formatted CreateCommitFromPatch from the client



## Test plan

Verified errors now show up nicer and we don't retry failed patch errors.