### PR TITLE
bext: update changelog after release

### DIFF
--- a/client/browser/CHANGELOG.md
+++ b/client/browser/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Sourcegraph [Browser Extensions](./README.md) are documen
 
 ## Unreleased
 
+## Chrome & Firefox 22.11.24.1820, Safari v1.19
+
 - Fix route change handlers for GitHub: [issues/44074](https://github.com/sourcegraph/sourcegraph/issues/44074), [pull/44783](https://github.com/sourcegraph/sourcegraph/pull/44783)
 - Fix selectors used to inject Sourcegraph code intelligence on GitHub: [issues/44759](https://github.com/sourcegraph/sourcegraph/issues/44759), [pull/44766](https://github.com/sourcegraph/sourcegraph/pull/44766)
 


### PR DESCRIPTION
Updates Sourcegraph browser extension changelog after release.

## Test plan
N/A: changelog change only
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
