### PR TITLE
Remove gsutil copying during Firefox publishing

### DIFF
--- a/client/browser/scripts/release-firefox.sh
+++ b/client/browser/scripts/release-firefox.sh
@@ -23,20 +23,3 @@ error=${PIPESTATUS[0]}
 if ! grep -q "$ok" "$tmp" && [ "$error" = 1 ]; then
   exit "$error"
 fi
-set -e
-
-# Upload to gcp and make it public
-pushd build/web-ext
-for filename in *; do
-  gsutil cp "$filename" "gs://sourcegraph-for-firefox/$filename"
-  gsutil cp "$filename" "gs://sourcegraph-for-firefox/latest.xpi"
-  gsutil -m acl set -R -a public-read "gs://sourcegraph-for-firefox/$filename"
-  gsutil -m acl set -R -a public-read "gs://sourcegraph-for-firefox/latest.xpi"
-done
-popd
-
-export TS_NODE_COMPILER_OPTIONS="{\"module\":\"commonjs\"}"
-
-gsutil ls gs://sourcegraph-for-firefox | xargs yarn ts-node scripts/build-updates-manifest.ts
-gsutil cp src/browser-extension/updates.manifest.json gs://sourcegraph-for-firefox/updates.json
-gsutil -m acl set -R -a public-read gs://sourcegraph-for-firefox/updates.json

--- a/doc/dev/how-to/releasing_browser_extensions.md
+++ b/doc/dev/how-to/releasing_browser_extensions.md
@@ -6,9 +6,7 @@ This page contains information about releasing browser extensions for different 
 Deployment to the Chrome web store happen automatically in CI when the `bext/release` branch is updated.
 
 ## Firefox
-The release process for Firefox is currently semi-automated.
-
-When the `bext/release` branch is updated, our build pipeline will trigger a build for the Firefox extension (take a note of the commit sha, we'll need it later). The build will trigger [this](https://github.com/sourcegraph/sourcegraph/blob/main/client/browser/scripts/release-ff.sh) script which will create a bundle, sign it and upload it to the [Google Cloud Storage](https://console.cloud.google.com/storage/browser/sourcegraph-for-firefox). Once the bundle is created, we upload it to the Mozilla Add-on page. Once the bundle is uploaded, we need to upload the source code as well. On your local copy, navigate to `sourcegraph/client/browser/scripts/create-source-zip.js` and modify the `commitId` variable (use the sha from earlier). Once the variable is modified, run this script. It will generate a `sourcegraph.zip` in the folder. Upload this zip to the Mozilla Add-on page and wait for approval.
+Deployment to the Mozilla store happen automatically in CI when the `bext/release` branch is updated.
 
 ## Safari
 The release process for Safari is currently not automated.


### PR DESCRIPTION
Follow up to #4380

Alright, so [it seems like](https://buildkite.com/sourcegraph/sourcegraph/builds/185192#0184aacb-122a-4b05-8dba-eb5e1b9910b7/152-308) my changes from #4380 have worked but now that the script continues after the `web-ext` upload, we now execute code that was dead for a long time which still fails the build. 

I’m pretty sure this workflow is not needed anymore:

- We now have full automation in place, so we don't need to manually store the extension somewhere.
- [Google Cloud UI](https://console.cloud.google.com/storage/browser/sourcegraph-for-firefox;tab=objects?prefix=&forceOnObjectsSortingFiltering=false) shows the last automated push happened in April 2019 (I wanted to make a joke based on the date but damn I forgot everything that happened before Covid)

```bash
Applying config file: ./package.json
--
  | Building web extension from /root/buildkite/build/sourcegraph/client/browser/build/firefox
  | Validating add-on [............................................................]
  | Validation results: https://addons.mozilla.org/en-US/developers/upload/<hash>
  | Signing add-on [...............................................................]
  | Your add-on has been submitted for review. It passed validation but could not be automatically signed because this is a listed add-on.
  | + error=1
  | + grep -q 'Your add-on has been submitted for review.' /tmp/tmp.CWpRdVTWgs
  | + set -e
  | + pushd build/web-ext
  | ~/buildkite/build/sourcegraph/client/browser/build/web-ext ~/buildkite/build/sourcegraph/client/browser
  | + for filename in *
  | + gsutil cp '*' 'gs://sourcegraph-for-firefox/*'
  | CommandException: Destination (gs://sourcegraph-for-firefox/*) must match exactly 1 URL
  | Error: exit status 1
  | 🚨 Error: The command exited with status 1
```

## Test plan

Deleting dead code.


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-clean-up-firefox-script.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
