### PR TITLE
github clients: always collect metrics about rate limits

### DIFF
--- a/internal/extsvc/github/metrics.go
+++ b/internal/extsvc/github/metrics.go
@@ -1,0 +1,18 @@
+package github
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var githubRemainingGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	// TODO: New name?!
+	Name: "TODO_src_github_rate_limit_remaining_v2",
+	Help: "Number of calls to GitHub's API remaining before hitting the rate limit.",
+}, []string{"resource", "name"})
+
+var githubRatelimitWaitCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+	// TODO: New name?!
+	Name: "TODO_src_github_rate_limit_wait_duration_seconds",
+	Help: "The amount of time spent waiting on the rate limit",
+}, []string{"resource", "name"})

--- a/internal/extsvc/github/metrics.go
+++ b/internal/extsvc/github/metrics.go
@@ -1,8 +1,12 @@
 package github
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 )
 
 var githubRemainingGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -16,3 +20,14 @@ var githubRatelimitWaitCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "TODO_src_github_rate_limit_wait_duration_seconds",
 	Help: "The amount of time spent waiting on the rate limit",
 }, []string{"resource", "name"})
+
+func collectRateLimitMonitorMetrics(monitor *ratelimit.Monitor, resource string) {
+	monitor.SetCollector(&ratelimit.MetricsCollector{
+		Remaining: func(n float64) {
+			githubRemainingGauge.WithLabelValues(resource).Set(n)
+		},
+		WaitDuration: func(n time.Duration) {
+			githubRatelimitWaitCounter.WithLabelValues(resource).Add(n.Seconds())
+		},
+	})
+}

--- a/internal/extsvc/github/metrics.go
+++ b/internal/extsvc/github/metrics.go
@@ -22,7 +22,7 @@ var githubRatelimitWaitCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 }, []string{"resource", "name"})
 
 func collectRateLimitMonitorMetrics(monitor *ratelimit.Monitor, resource string) {
-	monitor.SetCollector(&ratelimit.MetricsCollector{
+	monitor.SetCollectorIfNotSet(&ratelimit.MetricsCollector{
 		Remaining: func(n float64) {
 			githubRemainingGauge.WithLabelValues(resource).Set(n)
 		},

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v41/github"
 
@@ -108,6 +109,15 @@ func newV3Client(logger log.Logger, urn string, apiURL *url.URL, a auth.Authenti
 
 	rl := ratelimit.DefaultRegistry.Get(urn)
 	rlm := ratelimit.DefaultMonitorRegistry.GetOrSet(apiURL.String(), tokenHash, resource, &ratelimit.Monitor{HeaderPrefix: "X-"})
+
+	rlm.SetCollector(&ratelimit.MetricsCollector{
+		Remaining: func(n float64) {
+			githubRemainingGauge.WithLabelValues(resource).Set(n)
+		},
+		WaitDuration: func(n time.Duration) {
+			githubRatelimitWaitCounter.WithLabelValues(resource).Add(n.Seconds())
+		},
+	})
 
 	return &V3Client{
 		log: logger.Scoped("github.v3", "github v3 client").

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -90,6 +90,14 @@ func NewV4Client(urn string, apiURL *url.URL, a auth.Authenticator, cli httpcli.
 
 	rl := ratelimit.DefaultRegistry.Get(urn)
 	rlm := ratelimit.DefaultMonitorRegistry.GetOrSet(apiURL.String(), tokenHash, "graphql", &ratelimit.Monitor{HeaderPrefix: "X-"})
+	rlm.SetCollector(&ratelimit.MetricsCollector{
+		Remaining: func(n float64) {
+			githubRemainingGauge.WithLabelValues("graphql").Set(n)
+		},
+		WaitDuration: func(n time.Duration) {
+			githubRatelimitWaitCounter.WithLabelValues("graphql").Add(n.Seconds())
+		},
+	})
 
 	return &V4Client{
 		log:              log.Scoped("github.v4", "github v4 client"),

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -90,14 +90,7 @@ func NewV4Client(urn string, apiURL *url.URL, a auth.Authenticator, cli httpcli.
 
 	rl := ratelimit.DefaultRegistry.Get(urn)
 	rlm := ratelimit.DefaultMonitorRegistry.GetOrSet(apiURL.String(), tokenHash, "graphql", &ratelimit.Monitor{HeaderPrefix: "X-"})
-	rlm.SetCollector(&ratelimit.MetricsCollector{
-		Remaining: func(n float64) {
-			githubRemainingGauge.WithLabelValues("graphql").Set(n)
-		},
-		WaitDuration: func(n time.Duration) {
-			githubRatelimitWaitCounter.WithLabelValues("graphql").Add(n.Seconds())
-		},
-	})
+	collectRateLimitMonitorMetrics(rlm, "graphql")
 
 	return &V4Client{
 		log:              log.Scoped("github.v4", "github v4 client"),

--- a/internal/ratelimit/monitor.go
+++ b/internal/ratelimit/monitor.go
@@ -207,6 +207,14 @@ func (c *Monitor) SetCollector(collector *MetricsCollector) {
 	c.collector = collector
 }
 
+func (c *Monitor) SetCollectorIfNotSet(collector *MetricsCollector) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.collector == nil {
+		c.collector = collector
+	}
+}
+
 func (c *Monitor) now() time.Time {
 	if c.clock != nil {
 		return c.clock()


### PR DESCRIPTION
This changes the github `Source` and clients to always collect metrics in the clients. Not just in Sources.

Tradeoff: it doesn't include the external service display name in the labels. I think that's not too bad though?

## Test plan

- N/A