### PR TITLE
fuzzy finder: make navbar button remain an experimental feature

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyFinderFeatureFlag.ts
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinderFeatureFlag.ts
@@ -16,7 +16,8 @@ export function getFuzzyFinderFeatureFlags(
         fuzzyFinderSymbols,
         fuzzyFinderNavbar,
     } = getExperimentalFeatures(finalSettings)
-    // Intentionally skip "Actions" when `fuzzyFinderAll` is true
+    // Intentionally skip fuzzyFinderActions because we don't have enough actions implemented
+    // Intentionally skip fuzzyFinderNavbar because the navbar is already too busy and we need to explore alternative solutions for the discoverability problem
     fuzzyFinderRepositories = fuzzyFinderAll || fuzzyFinderRepositories
     fuzzyFinderSymbols = fuzzyFinderAll || fuzzyFinderSymbols
     return { fuzzyFinderAll, fuzzyFinderActions, fuzzyFinderRepositories, fuzzyFinderSymbols, fuzzyFinderNavbar }

--- a/client/web/src/components/fuzzyFinder/FuzzyFinderFeatureFlag.ts
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinderFeatureFlag.ts
@@ -18,7 +18,6 @@ export function getFuzzyFinderFeatureFlags(
     } = getExperimentalFeatures(finalSettings)
     // Intentionally skip "Actions" when `fuzzyFinderAll` is true
     fuzzyFinderRepositories = fuzzyFinderAll || fuzzyFinderRepositories
-    fuzzyFinderNavbar = fuzzyFinderAll || fuzzyFinderNavbar
     fuzzyFinderSymbols = fuzzyFinderAll || fuzzyFinderSymbols
     return { fuzzyFinderAll, fuzzyFinderActions, fuzzyFinderRepositories, fuzzyFinderSymbols, fuzzyFinderNavbar }
 }


### PR DESCRIPTION
Makes fuzzy finder navbar button remain an experimental feature so that users have to explicitly enable it even if they have `fuzzyFinderAll` enabled (same as [actions](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@a2ca304f3b173dfc5c55d3572b3939d7d46633c6/-/blob/client/web/src/components/fuzzyFinder/FuzzyFinderFeatureFlag.ts?L19)).

## Test plan
Tested manually to enable fuzzy finder navbar button we need to explicitly enable `fuzzyFinderNavbar` experimental feature.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-fuzzy-finder-use.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
