### PR TITLE
fuzzy finder: fix actions tab footer alignment

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
@@ -105,7 +105,6 @@
     display: flex;
     align-items: center;
     width: 100%;
-    justify-content: space-between;
     padding: 0 1rem 0.75rem;
 }
 
@@ -168,9 +167,6 @@
     gap: 0.5rem;
 }
 
-.right-aligned {
-    text-align: right;
-}
 .tab-centered-text {
     text-align: center;
 }

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
@@ -24,21 +24,9 @@
     flex-direction: row-reverse;
     justify-content: space-between;
     align-items: center;
-    padding: 0.5rem 1rem 0; // stylelint-disable-next-line declaration-property-unit-allowed-list
+    padding: 0.5rem 1rem 0;
     margin-bottom: -1px;
     z-index: 1;
-}
-
-.divider {
-    width: 100%; // stylelint-disable-next-line declaration-property-unit-allowed-list
-    height: 1px;
-    background-color: var(--border-color);
-    margin-bottom: 0.5rem;
-    z-index: 0;
-
-    &.mb-0 {
-        margin-bottom: 0;
-    }
 }
 
 .shortcut {
@@ -59,7 +47,6 @@
 .results {
     flex: 1;
 
-    // stylelint-disable-next-line scss/selector-no-redundant-nesting-selector
     & p {
         padding: 1rem;
     }
@@ -105,8 +92,7 @@
     display: flex;
     align-items: center;
     width: 100%;
-    justify-content: space-between;
-    padding: 0 1rem 0.75rem;
+    padding: 0.75rem 1rem;
 }
 
 .keyboard-explanation {
@@ -168,9 +154,6 @@
     gap: 0.5rem;
 }
 
-.right-aligned {
-    text-align: right;
-}
 .tab-centered-text {
     text-align: center;
 }

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
@@ -24,9 +24,21 @@
     flex-direction: row-reverse;
     justify-content: space-between;
     align-items: center;
-    padding: 0.5rem 1rem 0;
+    padding: 0.5rem 1rem 0; // stylelint-disable-next-line declaration-property-unit-allowed-list
     margin-bottom: -1px;
     z-index: 1;
+}
+
+.divider {
+    width: 100%; // stylelint-disable-next-line declaration-property-unit-allowed-list
+    height: 1px;
+    background-color: var(--border-color);
+    margin-bottom: 0.5rem;
+    z-index: 0;
+
+    &.mb-0 {
+        margin-bottom: 0;
+    }
 }
 
 .shortcut {
@@ -47,6 +59,7 @@
 .results {
     flex: 1;
 
+    // stylelint-disable-next-line scss/selector-no-redundant-nesting-selector
     & p {
         padding: 1rem;
     }
@@ -92,7 +105,8 @@
     display: flex;
     align-items: center;
     width: 100%;
-    padding: 0.75rem 1rem;
+    justify-content: space-between;
+    padding: 0 1rem 0.75rem;
 }
 
 .keyboard-explanation {
@@ -154,6 +168,9 @@
     gap: 0.5rem;
 }
 
+.right-aligned {
+    text-align: right;
+}
 .tab-centered-text {
     text-align: center;
 }

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -411,7 +411,7 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
                 <div className={styles.divider} />
                 <div className={styles.footer}>
                     <SearchQueryLink {...props} />
-                    <span className={styles.rightAligned}>
+                    <span className="ml-auto">
                         <ArrowKeyExplanation />
                     </span>
                 </div>

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -408,10 +408,10 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
                 ) : (
                     <div className={classNames(styles.results, 'overflow-auto')}>{queryResult.jsxElement}</div>
                 )}
-                <hr className="m-0" />
+                <div className={styles.divider} />
                 <div className={styles.footer}>
                     <SearchQueryLink {...props} />
-                    <span className="ml-auto">
+                    <span className={styles.rightAligned}>
                         <ArrowKeyExplanation />
                     </span>
                 </div>

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -408,10 +408,10 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
                 ) : (
                     <div className={classNames(styles.results, 'overflow-auto')}>{queryResult.jsxElement}</div>
                 )}
-                <div className={styles.divider} />
+                <hr className="m-0" />
                 <div className={styles.footer}>
                     <SearchQueryLink {...props} />
-                    <span className={styles.rightAligned}>
+                    <span className="ml-auto">
                         <ArrowKeyExplanation />
                     </span>
                 </div>


### PR DESCRIPTION
Fixes actions tab footer content alignment.
Actions tab footer had keyboard navigation hint was left-aligned while on all other tabs (all, repos, symbols, files) right-aligned.

| Tab |Before|After|
| -- | -- | -- |
| Actions |<img width="825" alt="Screenshot 2022-11-25 at 13 06 38" src="https://user-images.githubusercontent.com/25318659/203972699-a61b4232-009c-4bc3-b611-735fdf1bc1f2.png">| <img width="825" alt="Screenshot 2022-11-25 at 13 06 09" src="https://user-images.githubusercontent.com/25318659/203972691-cc2e06b6-ed81-443e-a6a8-acd123a3fa17.png">|
| Files |<img width="825" alt="Screenshot 2022-11-25 at 13 10 34" src="https://user-images.githubusercontent.com/25318659/203973344-fffd4744-605b-43a5-b99e-7bcdc6e4c4bf.png"> | No changes |





## Test plan
Tested manually (see screenshots attached).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-fuzzy-finder-fix.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
