### PR TITLE
fuzzy finder: add experimental badge to modal

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
@@ -21,16 +21,14 @@
 
 .header {
     display: flex;
-    flex-direction: row-reverse;
-    justify-content: space-between;
     align-items: center;
-    padding: 0.5rem 1rem 0; // stylelint-disable-next-line declaration-property-unit-allowed-list
+    padding: 0.5rem 1rem 0;
     margin-bottom: -1px;
     z-index: 1;
 }
 
 .divider {
-    width: 100%; // stylelint-disable-next-line declaration-property-unit-allowed-list
+    width: 100%;
     height: 1px;
     background-color: var(--border-color);
     margin-bottom: 0.5rem;
@@ -59,7 +57,6 @@
 .results {
     flex: 1;
 
-    // stylelint-disable-next-line scss/selector-no-redundant-nesting-selector
     & p {
         padding: 1rem;
     }
@@ -138,6 +135,11 @@
     flex: 1;
     font-size: 0.75rem;
     color: var(--text-muted);
+}
+
+.experimental-badge {
+    margin: -0.5rem 0.75rem 0 auto;
+    text-transform: uppercase;
 }
 
 .close-button {

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
@@ -22,13 +22,13 @@
 .header {
     display: flex;
     align-items: center;
-    padding: 0.5rem 1rem 0;
+    padding: 0.5rem 1rem 0; // stylelint-disable-next-line declaration-property-unit-allowed-list
     margin-bottom: -1px;
     z-index: 1;
 }
 
 .divider {
-    width: 100%;
+    width: 100%; // stylelint-disable-next-line declaration-property-unit-allowed-list
     height: 1px;
     background-color: var(--border-color);
     margin-bottom: 0.5rem;
@@ -57,6 +57,7 @@
 .results {
     flex: 1;
 
+    // stylelint-disable-next-line scss/selector-no-redundant-nesting-selector
     & p {
         padding: 1rem;
     }

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -32,6 +32,7 @@ import {
     TabPanels,
     TabPanel,
     TabList,
+    Badge,
 } from '@sourcegraph/wildcard'
 
 import { AggregateFuzzySearch } from '../../fuzzyFinder/AggregateFuzzySearch'
@@ -343,9 +344,6 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
         >
             <WrapperComponent className={styles.content} {...wrapperComponentProps}>
                 <div className={styles.header} data-testid="fuzzy-modal-header">
-                    <Button variant="icon" onClick={() => onClose()} aria-label="Close" className={styles.closeButton}>
-                        <Icon aria-hidden={true} svgPath={mdiClose} />
-                    </Button>
                     {showTabs ? (
                         <TabList className={styles.tabList}>
                             {tabs.entries().map(([key, tab]) => (
@@ -360,6 +358,12 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
                     ) : (
                         <H3>Find files</H3>
                     )}
+                    <Badge variant="info" className={styles.experimentalBadge}>
+                        Experimental
+                    </Badge>
+                    <Button variant="icon" onClick={onClose} aria-label="Close" className={styles.closeButton}>
+                        <Icon aria-hidden={true} svgPath={mdiClose} />
+                    </Button>
                 </div>
                 <div className={styles.divider} />
                 <Input

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -358,7 +358,12 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
                     ) : (
                         <H3>Find files</H3>
                     )}
-                    <Badge variant="info" className={styles.experimentalBadge}>
+                    <Badge
+                        variant="info"
+                        href="https://github.com/sourcegraph/sourcegraph/discussions/42874"
+                        tooltip="Provide feedback on this experimental feature"
+                        className={styles.experimentalBadge}
+                    >
                         Experimental
                     </Badge>
                     <Button variant="icon" onClick={onClose} aria-label="Close" className={styles.closeButton}>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/44765

Adds an experimental badge to the fuzzy finder modal.

I couldn't find a better place in the modal to put this badge. But I still don't know where we can put a link to the feedback page
- https://github.com/sourcegraph/sourcegraph/discussions/42874.

<img width="811" alt="Screenshot 2022-11-25 at 15 35 00" src="https://user-images.githubusercontent.com/25318659/203996823-b8ff4f12-ff59-4d18-a2a3-43d47cf624b5.png">


## Test plan
Tested manually (see screenshots)
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-fuzzy-finder-add.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
