### PR TITLE
sg: add misc toplevel command with a small helper for regexps 

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -295,6 +295,7 @@ var sg = &cli.App{
 		funkyLogoCommand,
 		analyticsCommand,
 		releaseCommand,
+		miscCommand,
 	},
 	ExitErrHandler: func(cmd *cli.Context, err error) {
 		if err == nil {

--- a/dev/sg/sg_misc.go
+++ b/dev/sg/sg_misc.go
@@ -15,7 +15,7 @@ var miscCommand = &cli.Command{
 	Subcommands: []*cli.Command{{
 		Name: "str2regex",
 		Usage: `Turn a string into a regexp that Thorsten can paste in Sourcegraph search
-strings.Split(regexp.QuoteMeta(str), " ") 👉 foo\s+:=\s+internal\.Get\(something\)`,
+foo := internal.Get(something) 👉 foo\s+:=\s+internal\.Get\(something\)`,
 		Category:  CategoryUtil,
 		UsageText: `sg misc str2regex 'Horsegraph is (very) cool'`,
 		Action: func(cmd *cli.Context) error {

--- a/dev/sg/sg_misc.go
+++ b/dev/sg/sg_misc.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+var miscCommand = &cli.Command{
+	Name:     "misc",
+	Usage:    "Misc utilities",
+	Category: CategoryUtil,
+	Subcommands: []*cli.Command{{
+		Name: "str2regex",
+		Usage: `Turn a string into a regexp that Thorsten can paste in Sourcegraph search
+strings.Split(regexp.QuoteMeta(str), " ") 👉 foo\s+:=\s+internal\.Get\(something\)`,
+		Category:  CategoryUtil,
+		UsageText: `sg misc str2regex 'Horsegraph is (very) cool'`,
+		Action: func(cmd *cli.Context) error {
+			str := strings.Join(cmd.Args().Slice(), " ")
+			words := strings.Split(regexp.QuoteMeta(str), " ")
+			fmt.Printf(strings.Join(words, `\s+`))
+			return nil
+		},
+	}},
+}

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1536,7 +1536,7 @@ Misc utilities.
 ### sg misc str2regex
 
 Turn a string into a regexp that Thorsten can paste in Sourcegraph search
-strings.Split(regexp.QuoteMeta(str), " ") 👉 foo\s+:=\s+internal\.Get\(something\).
+foo := internal.Get(something) 👉 foo\s+:=\s+internal\.Get\(something\).
 
 ```sh
 $ sg misc str2regex 'Horsegraph is (very) cool'

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1527,3 +1527,21 @@ Flags:
 * `--buildNumber, -b="<value>"`: The buildkite build number to check for CVEs
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--uri, -u="<value>"`: A reference url that contains approved CVEs. Often a link to a handbook page eg: https://handbook.sourcegraph.com/departments/security/tooling/trivy/4-2-0/.
+
+## sg misc
+
+Misc utilities.
+
+
+### sg misc str2regex
+
+Turn a string into a regexp that Thorsten can paste in Sourcegraph search
+strings.Split(regexp.QuoteMeta(str), " ") 👉 foo\s+:=\s+internal\.Get\(something\).
+
+```sh
+$ sg misc str2regex 'Horsegraph is (very) cool'
+```
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion


### PR DESCRIPTION
`foo := internal.Get(something)` 👉 `foo\s+:=\s+internal\.Get\(something\)`

```
$ sg misc str2regexp 'foo := internal.Get(something)'
foo\s+:=\s+internal\.Get\(something\)
```

@mrnugget `alias s2r="sg misc str2regexp` 😄 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Locally tested. 