### PR TITLE
authz: Simplify CheckSiteAdminOrSameUser

### DIFF
--- a/cmd/frontend/graphqlbackend/user_emails_test.go
+++ b/cmd/frontend/graphqlbackend/user_emails_test.go
@@ -152,7 +152,7 @@ func TestRemoveUserEmail(t *testing.T) {
 				setup: func() {
 					users.GetByIDFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
 				},
-				wantErr: "must be authenticated as the authorized user or as an admin (not authenticated)",
+				wantErr: "must be authenticated as the authorized user or site admin",
 			},
 			{
 				name: "another user",
@@ -166,7 +166,7 @@ func TestRemoveUserEmail(t *testing.T) {
 						return user, nil
 					})
 				},
-				wantErr: "must be authenticated as the authorized user or as an admin (must be site admin)",
+				wantErr: "must be authenticated as the authorized user or site admin",
 			},
 			{
 				name: "site admin",

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -309,7 +309,7 @@ func TestUpdateUser(t *testing.T) {
 			},
 		)
 		got := fmt.Sprintf("%v", err)
-		want := "must be authenticated as the authorized user or as an admin (must be site admin)"
+		want := "must be authenticated as the authorized user or site admin"
 		assert.Equal(t, want, got)
 		assert.Nil(t, result)
 	})
@@ -587,7 +587,7 @@ func TestUser_Organizations(t *testing.T) {
 
 	expectOrgFailure := func(t *testing.T, actorUID int32) {
 		t.Helper()
-		wantErr := "must be authenticated as the authorized user or as an admin (must be site admin)"
+		wantErr := "must be authenticated as the authorized user or site admin"
 		RunTests(t, []*Test{
 			{
 				Context: actor.WithActor(context.Background(), &actor.Actor{UID: actorUID}),

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -207,7 +207,7 @@ func TestIsAllowedToEdit(t *testing.T) {
 		}
 
 		_, err = r.UpdateCodeMonitor(ctx, args)
-		require.EqualError(t, err, "update namespace: must be authenticated as the authorized user or as an admin (must be site admin)")
+		require.EqualError(t, err, "update namespace: must be authenticated as the authorized user or site admin")
 	})
 }
 

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -1682,7 +1682,7 @@ changesetTemplate:
 				BatchChange:     batchChange.ID,
 			})
 
-			assert.Equal(t, "must be authenticated as the authorized user or as an admin (must be site admin)", err.Error())
+			assert.Equal(t, "must be authenticated as the authorized user or site admin", err.Error())
 		})
 
 		t.Run("success - without batch change ID", func(t *testing.T) {

--- a/internal/auth/site_admin.go
+++ b/internal/auth/site_admin.go
@@ -75,11 +75,7 @@ func CheckSiteAdminOrSameUser(ctx context.Context, db database.DB, subjectUserID
 	if isSiteAdminErr == nil {
 		return nil
 	}
-	_, err := db.Users().GetByID(ctx, subjectUserID)
-	if err != nil {
-		return &InsufficientAuthorizationError{fmt.Sprintf("must be authenticated as an admin (%s)", isSiteAdminErr.Error())}
-	}
-	return &InsufficientAuthorizationError{fmt.Sprintf("must be authenticated as the authorized user or as an admin (%s)", isSiteAdminErr.Error())}
+	return &InsufficientAuthorizationError{fmt.Sprintf("must be authenticated as the authorized user or site admin")}
 }
 
 // CheckSameUser returns an error if the user is not the user specified by

--- a/internal/auth/site_admin.go
+++ b/internal/auth/site_admin.go
@@ -75,7 +75,7 @@ func CheckSiteAdminOrSameUser(ctx context.Context, db database.DB, subjectUserID
 	if isSiteAdminErr == nil {
 		return nil
 	}
-	return &InsufficientAuthorizationError{fmt.Sprintf("must be authenticated as the authorized user or site admin")}
+	return &InsufficientAuthorizationError{"must be authenticated as the authorized user or site admin"}
 }
 
 // CheckSameUser returns an error if the user is not the user specified by


### PR DESCRIPTION
No need to make an extra db call to fetch the desired user as we were
only using the result of that to amend the error message slightly.

## Test plan

Tests updated