### PR TITLE
Add error handling to burndown chart

### DIFF
--- a/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.story.tsx
@@ -1,12 +1,11 @@
-import { useMemo } from '@storybook/addons'
-import { Meta, Story, DecoratorFn } from '@storybook/react'
-import { addSeconds, isBefore } from 'date-fns'
-import { of } from 'rxjs'
+import { DecoratorFn, Meta, Story } from '@storybook/react'
+
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../../../components/WebStory'
-import { ChangesetCountsOverTimeFields } from '../../../graphql-operations'
 
 import { BatchChangeBurndownChart } from './BatchChangeBurndownChart'
+import { CHANGESET_COUNTS_OVER_TIME_MOCK } from './testdata'
 
 const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
 const config: Meta = {
@@ -16,169 +15,14 @@ const config: Meta = {
 
 export default config
 
-export const AllStates: Story = () => {
-    const changesetCounts = useMemo<ChangesetCountsOverTimeFields[]>(() => {
-        const timeMarks = [
-            {
-                __typename: 'ChangesetCounts',
-                date: '2019-11-13T12:00:00Z',
-                closed: 0,
-                merged: 0,
-                openApproved: 0,
-                openChangesRequested: 0,
-                openPending: 0,
-                total: 10,
-                draft: 10,
-                open: 0,
-            },
-            {
-                __typename: 'ChangesetCounts',
-                date: '2019-11-14T12:00:00Z',
-                closed: 0,
-                merged: 0,
-                openApproved: 0,
-                openChangesRequested: 0,
-                openPending: 2,
-                total: 10,
-                draft: 5,
-                open: 5,
-            },
-            {
-                __typename: 'ChangesetCounts',
-                date: '2019-11-15T12:00:00Z',
-                closed: 0,
-                merged: 1,
-                openApproved: 1,
-                openChangesRequested: 0,
-                openPending: 3,
-                total: 10,
-                draft: 0,
-                open: 8,
-            },
-            {
-                __typename: 'ChangesetCounts',
-                date: '2019-11-16T12:00:00Z',
-                closed: 1,
-                merged: 1,
-                openApproved: 1,
-                openChangesRequested: 0,
-                openPending: 3,
-                total: 10,
-                draft: 0,
-                open: 7,
-            },
-            {
-                __typename: 'ChangesetCounts',
-                date: '2019-11-17T12:00:00Z',
-                closed: 1,
-                merged: 2,
-                openApproved: 1,
-                openChangesRequested: 0,
-                openPending: 5,
-                total: 10,
-                draft: 0,
-                open: 6,
-            },
-            {
-                __typename: 'ChangesetCounts',
-                date: '2019-11-18T12:00:00Z',
-                closed: 2,
-                merged: 4,
-                openApproved: 0,
-                openChangesRequested: 2,
-                openPending: 2,
-                total: 10,
-                draft: 0,
-                open: 4,
-            },
-            {
-                __typename: 'ChangesetCounts',
-                date: '2019-11-19T12:00:00Z',
-                closed: 2,
-                merged: 4,
-                openApproved: 0,
-                openChangesRequested: 2,
-                openPending: 2,
-                total: 10,
-                draft: 0,
-                open: 4,
-            },
-            {
-                __typename: 'ChangesetCounts',
-                date: '2019-11-20T12:00:00Z',
-                closed: 2,
-                merged: 4,
-                openApproved: 0,
-                openChangesRequested: 2,
-                openPending: 2,
-                total: 10,
-                draft: 0,
-                open: 4,
-            },
-            {
-                __typename: 'ChangesetCounts',
-                date: '2019-11-21T12:00:00Z',
-                closed: 2,
-                merged: 5,
-                openApproved: 3,
-                openChangesRequested: 0,
-                openPending: 0,
-                total: 10,
-                draft: 0,
-                open: 3,
-            },
-            {
-                __typename: 'ChangesetCounts',
-                date: '2019-11-22T12:00:00Z',
-                closed: 2,
-                merged: 8,
-                openApproved: 0,
-                openChangesRequested: 0,
-                openPending: 0,
-                total: 10,
-                draft: 0,
-                open: 0,
-            },
-        ]
-        let timeMarkIndex = 0
-        return new Array(150).fill(undefined).map((value, index) => {
-            let currentMark = timeMarks[timeMarkIndex]
-            const currentDate = addSeconds(
-                new Date('2019-11-13T12:00:00Z'),
-                // 10 days of data
-                index * Math.round((10 * 24 * 60 * 60) / 150)
-            )
-            while (
-                timeMarks.length > timeMarkIndex + 1 &&
-                !isBefore(currentDate, new Date(timeMarks[timeMarkIndex + 1].date))
-            ) {
-                timeMarkIndex++
-                currentMark = timeMarks[timeMarkIndex]
-            }
-            return {
-                __typename: 'ChangesetCounts',
-                date: currentDate.toISOString(),
-                closed: currentMark.closed,
-                draft: currentMark.draft,
-                merged: currentMark.merged,
-                openApproved: currentMark.openApproved,
-                openChangesRequested: currentMark.openChangesRequested,
-                openPending: currentMark.openPending,
-                total: currentMark.total,
-            }
-        })
-    }, [])
-    return (
-        <WebStory>
-            {props => (
-                <BatchChangeBurndownChart
-                    {...props}
-                    batchChangeID="123"
-                    queryChangesetCountsOverTime={() => of(changesetCounts)}
-                />
-            )}
-        </WebStory>
-    )
-}
+export const AllStates: Story = () => (
+    <WebStory>
+        {webProps => (
+            <MockedTestProvider mocks={[CHANGESET_COUNTS_OVER_TIME_MOCK]}>
+                <BatchChangeBurndownChart {...webProps} batchChangeID="specid" />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
 
 AllStates.storyName = 'All states'

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
@@ -13,7 +13,6 @@ import { BatchChangeByNamespaceResult, BatchChangeFields, ExternalServiceKind } 
 
 import {
     queryExternalChangesetWithFileDiffs,
-    queryChangesetCountsOverTime as _queryChangesetCountsOverTime,
     queryAllChangesetIDs as _queryAllChangesetIDs,
     BATCH_CHANGE_BY_NAMESPACE,
     BULK_OPERATIONS,
@@ -26,6 +25,7 @@ import {
     BATCH_CHANGE_CHANGESETS_RESULT,
     EMPTY_BATCH_CHANGE_CHANGESETS_RESULT,
 } from './BatchChangeDetailsPage.mock'
+import { CHANGESET_COUNTS_OVER_TIME_MOCK } from './testdata'
 
 const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
 const config: Meta = {
@@ -77,70 +77,6 @@ const queryEmptyExternalChangesetWithFileDiffs: typeof queryExternalChangesetWit
             },
         },
     })
-
-const queryChangesetCountsOverTime: typeof _queryChangesetCountsOverTime = () =>
-    of([
-        {
-            date: subDays(new Date('2020-08-10'), 5).toISOString(),
-            closed: 0,
-            merged: 0,
-            openPending: 5,
-            total: 10,
-            draft: 5,
-            openChangesRequested: 0,
-            openApproved: 0,
-        },
-        {
-            date: subDays(new Date('2020-08-10'), 4).toISOString(),
-            closed: 0,
-            merged: 0,
-            openPending: 4,
-            total: 10,
-            draft: 3,
-            openChangesRequested: 0,
-            openApproved: 3,
-        },
-        {
-            date: subDays(new Date('2020-08-10'), 3).toISOString(),
-            closed: 0,
-            merged: 2,
-            openPending: 5,
-            total: 10,
-            draft: 0,
-            openChangesRequested: 0,
-            openApproved: 3,
-        },
-        {
-            date: subDays(new Date('2020-08-10'), 2).toISOString(),
-            closed: 0,
-            merged: 3,
-            openPending: 3,
-            total: 10,
-            draft: 0,
-            openChangesRequested: 1,
-            openApproved: 3,
-        },
-        {
-            date: subDays(new Date('2020-08-10'), 1).toISOString(),
-            closed: 1,
-            merged: 5,
-            openPending: 2,
-            total: 10,
-            draft: 0,
-            openChangesRequested: 0,
-            openApproved: 2,
-        },
-        {
-            date: new Date('2020-08-10').toISOString(),
-            closed: 1,
-            merged: 5,
-            openPending: 0,
-            total: 10,
-            draft: 0,
-            openChangesRequested: 0,
-            openApproved: 4,
-        },
-    ])
 
 const deleteBatchChange = () => Promise.resolve(undefined)
 
@@ -198,6 +134,7 @@ const Template: Story<{
             result: { data: { node: BATCH_CHANGE_CHANGESETS_RESULT } },
             nMatches: Number.POSITIVE_INFINITY,
         },
+        CHANGESET_COUNTS_OVER_TIME_MOCK,
     ])
 
     return (
@@ -209,7 +146,6 @@ const Template: Story<{
                         authenticatedUser={authenticatedUser}
                         namespaceID="namespace123"
                         batchChangeName="awesome-batch-change"
-                        queryChangesetCountsOverTime={queryChangesetCountsOverTime}
                         queryExternalChangesetWithFileDiffs={queryEmptyExternalChangesetWithFileDiffs}
                         deleteBatchChange={deleteBatchChange}
                         queryAllChangesetIDs={queryAllChangesetIDs}
@@ -331,7 +267,6 @@ export const EmptyChangesets: Story = args => {
                         authenticatedUser={authenticatedUser}
                         namespaceID="namespace123"
                         batchChangeName="awesome-batch-change"
-                        queryChangesetCountsOverTime={queryChangesetCountsOverTime}
                         queryExternalChangesetWithFileDiffs={queryEmptyExternalChangesetWithFileDiffs}
                         deleteBatchChange={deleteBatchChange}
                         extensionsController={{} as any}

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -21,7 +21,6 @@ import { BatchChangeBatchSpecList } from '../BatchSpecsPage'
 
 import {
     queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs,
-    queryChangesetCountsOverTime as _queryChangesetCountsOverTime,
     queryAllChangesetIDs as _queryAllChangesetIDs,
 } from './backend'
 import { BatchChangeBurndownChart } from './BatchChangeBurndownChart'
@@ -73,8 +72,6 @@ export interface BatchChangeDetailsProps
     /** For testing only. */
     queryExternalChangesetWithFileDiffs?: typeof _queryExternalChangesetWithFileDiffs
     /** For testing only. */
-    queryChangesetCountsOverTime?: typeof _queryChangesetCountsOverTime
-    /** For testing only. */
     queryAllChangesetIDs?: typeof _queryAllChangesetIDs
 }
 
@@ -90,7 +87,6 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
     platformContext,
     settingsCascade,
     initialTab = TabName.Changesets,
-    queryChangesetCountsOverTime,
     queryExternalChangesetWithFileDiffs,
     queryAllChangesetIDs,
     refetchBatchChange,
@@ -255,11 +251,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                     />
                 </TabPanel>
                 <TabPanel>
-                    <BatchChangeBurndownChart
-                        batchChangeID={batchChange.id}
-                        queryChangesetCountsOverTime={queryChangesetCountsOverTime}
-                        history={history}
-                    />
+                    <BatchChangeBurndownChart batchChangeID={batchChange.id} history={history} />
                 </TabPanel>
                 <TabPanel>
                     {shouldDisplayExecutionsTab ? (

--- a/client/web/src/enterprise/batches/detail/testdata.ts
+++ b/client/web/src/enterprise/batches/detail/testdata.ts
@@ -1,0 +1,176 @@
+import { MockedResponse } from '@apollo/client/testing'
+import { addSeconds, isBefore } from 'date-fns'
+
+import { getDocumentNode } from '@sourcegraph/http-client'
+
+import { ChangesetCountsOverTimeFields, ChangesetCountsOverTimeResult } from '../../../graphql-operations'
+
+import { CHANGESET_COUNTS_OVER_TIME } from './backend'
+
+const timeMarks = [
+    {
+        __typename: 'ChangesetCounts',
+        date: '2019-11-13T12:00:00Z',
+        closed: 0,
+        merged: 0,
+        openApproved: 0,
+        openChangesRequested: 0,
+        openPending: 0,
+        total: 10,
+        draft: 10,
+        open: 0,
+    },
+    {
+        __typename: 'ChangesetCounts',
+        date: '2019-11-14T12:00:00Z',
+        closed: 0,
+        merged: 0,
+        openApproved: 0,
+        openChangesRequested: 0,
+        openPending: 2,
+        total: 10,
+        draft: 5,
+        open: 5,
+    },
+    {
+        __typename: 'ChangesetCounts',
+        date: '2019-11-15T12:00:00Z',
+        closed: 0,
+        merged: 1,
+        openApproved: 1,
+        openChangesRequested: 0,
+        openPending: 3,
+        total: 10,
+        draft: 0,
+        open: 8,
+    },
+    {
+        __typename: 'ChangesetCounts',
+        date: '2019-11-16T12:00:00Z',
+        closed: 1,
+        merged: 1,
+        openApproved: 1,
+        openChangesRequested: 0,
+        openPending: 3,
+        total: 10,
+        draft: 0,
+        open: 7,
+    },
+    {
+        __typename: 'ChangesetCounts',
+        date: '2019-11-17T12:00:00Z',
+        closed: 1,
+        merged: 2,
+        openApproved: 1,
+        openChangesRequested: 0,
+        openPending: 5,
+        total: 10,
+        draft: 0,
+        open: 6,
+    },
+    {
+        __typename: 'ChangesetCounts',
+        date: '2019-11-18T12:00:00Z',
+        closed: 2,
+        merged: 4,
+        openApproved: 0,
+        openChangesRequested: 2,
+        openPending: 2,
+        total: 10,
+        draft: 0,
+        open: 4,
+    },
+    {
+        __typename: 'ChangesetCounts',
+        date: '2019-11-19T12:00:00Z',
+        closed: 2,
+        merged: 4,
+        openApproved: 0,
+        openChangesRequested: 2,
+        openPending: 2,
+        total: 10,
+        draft: 0,
+        open: 4,
+    },
+    {
+        __typename: 'ChangesetCounts',
+        date: '2019-11-20T12:00:00Z',
+        closed: 2,
+        merged: 4,
+        openApproved: 0,
+        openChangesRequested: 2,
+        openPending: 2,
+        total: 10,
+        draft: 0,
+        open: 4,
+    },
+    {
+        __typename: 'ChangesetCounts',
+        date: '2019-11-21T12:00:00Z',
+        closed: 2,
+        merged: 5,
+        openApproved: 3,
+        openChangesRequested: 0,
+        openPending: 0,
+        total: 10,
+        draft: 0,
+        open: 3,
+    },
+    {
+        __typename: 'ChangesetCounts',
+        date: '2019-11-22T12:00:00Z',
+        closed: 2,
+        merged: 8,
+        openApproved: 0,
+        openChangesRequested: 0,
+        openPending: 0,
+        total: 10,
+        draft: 0,
+        open: 0,
+    },
+]
+let timeMarkIndex = 0
+const changesetCounts: ChangesetCountsOverTimeFields[] = new Array(150).fill(undefined).map((value, index) => {
+    let currentMark = timeMarks[timeMarkIndex]
+    const currentDate = addSeconds(
+        new Date('2019-11-13T12:00:00Z'),
+        // 10 days of data
+        index * Math.round((10 * 24 * 60 * 60) / 150)
+    )
+    while (
+        timeMarks.length > timeMarkIndex + 1 &&
+        !isBefore(currentDate, new Date(timeMarks[timeMarkIndex + 1].date))
+    ) {
+        timeMarkIndex++
+        currentMark = timeMarks[timeMarkIndex]
+    }
+    return {
+        __typename: 'ChangesetCounts',
+        date: currentDate.toISOString(),
+        closed: currentMark.closed,
+        draft: currentMark.draft,
+        merged: currentMark.merged,
+        openApproved: currentMark.openApproved,
+        openChangesRequested: currentMark.openChangesRequested,
+        openPending: currentMark.openPending,
+        total: currentMark.total,
+    }
+})
+
+export const CHANGESET_COUNTS_OVER_TIME_MOCK: MockedResponse<ChangesetCountsOverTimeResult> = {
+    request: {
+        query: getDocumentNode(CHANGESET_COUNTS_OVER_TIME),
+        variables: {
+            includeArchived: false,
+            batchChange: 'specid',
+        },
+    },
+    result: {
+        data: {
+            node: {
+                __typename: 'BatchChange',
+                changesetCountsOverTime: changesetCounts,
+            },
+        },
+    },
+}


### PR DESCRIPTION
As I touched this, I figured I'd also do the migration to apollo.



## Test plan

Verified it still renders.

## App preview:

- [Web](https://sg-web-es-burndown-error.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
