### PR TITLE
Fix 1false badge on executions tab

### DIFF
--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -158,7 +158,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
     )
 
     const changesetCount = batchChange.changesetsStats.total - batchChange.changesetsStats.archived
-    const executionsCount = `${pendingExecutionsCount}${batchChange.batchSpecs.pageInfo.hasNextPage && '+'}`
+    const executionsCount = `${pendingExecutionsCount}${batchChange.batchSpecs.pageInfo.hasNextPage ? '+' : ''}`
 
     return (
         <BatchChangeTabs defaultIndex={defaultTabIndex} onChange={onTabChange}>


### PR DESCRIPTION
This printed as 1false instead of 1.



## Test plan

Verified no more false appears.

## App preview:

- [Web](https://sg-web-es-fix-badge-executions.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
