### PR TITLE
lib/cliutil: help is rendering empty text

### DIFF
--- a/lib/cliutil/docgen/default.go
+++ b/lib/cliutil/docgen/default.go
@@ -8,7 +8,12 @@ import (
 
 // Default renders help text for the app using urfave/cli's default help format.
 func Default(app *cli.App) (string, error) {
+	tpl := app.CustomAppHelpTemplate
+	if tpl == "" {
+		tpl = cli.AppHelpTemplate
+	}
+
 	var w bytes.Buffer
-	cli.HelpPrinterCustom(&w, app.CustomAppHelpTemplate, app, nil)
+	cli.HelpPrinterCustom(&w, tpl, app, nil)
 	return w.String(), nil
 }


### PR DESCRIPTION
upstream also have similar handling

https://github.com/urfave/cli/blob/d219eb19efe8099cd128ac55e2101cdffa43cef8/help.go#L121-L140

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

it works in `mi2`

```
go run ./cmd/mi2 help                                                                                       16:07:54
NAME:
   mi2 - mi2 is a tool for managing Managed Instances V2

USAGE:
   mi2  command [command options] [arguments...]
...
```