### PR TITLE
Fix create batch change page flickering

### DIFF
--- a/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
@@ -113,7 +113,8 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
     const history = useHistory()
     const location = useLocation()
     const handleCancel = (): void => history.goBack()
-    const handleCreate = (): void => {
+    const handleCreate: React.FormEventHandler = (event): void => {
+        event.preventDefault()
         const redirectSearchParameters = new URLSearchParams(location.search)
         if (insightTitle) {
             redirectSearchParameters.set('title', insightTitle)
@@ -179,7 +180,7 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
                     label="Batch change name"
                     value={nameInput}
                     onChange={onNameChange}
-                    pattern={String(NAME_PATTERN)}
+                    pattern="^[\w.-]+$"
                     required={true}
                     status={isNameValid === undefined ? undefined : isNameValid ? 'valid' : 'error'}
                     disabled={isReadOnly}


### PR DESCRIPTION
This fixes two things that caused the page to flicker:
- The pattern was not actually the pattern but `[object Object]` so it would flash a form validation red outline briefly before it proceeds to the next page when clicking create
- The form handler caused the page to reload because it was effectively a native HTML form. This causes an unnecessary reload and flickering, and also on error reloads the page immediately and the error message is lost.

## Test plan

Verified outlined things work as intended now.

## App preview:

- [Web](https://sg-web-es-fix-config-form.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
