### PR TITLE
batches: Create page replaces history

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/TabBar.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/TabBar.tsx
@@ -8,7 +8,7 @@ import { Link } from '@sourcegraph/wildcard'
 
 import styles from './TabBar.module.scss'
 
-export const TAB_KEYS = ['configuration', 'spec', 'execution', 'preview'] as const
+export const TAB_KEYS = ['configuration', 'edit', 'execution', 'preview'] as const
 export type TabKey = typeof TAB_KEYS[number]
 
 export interface TabsConfig {
@@ -19,13 +19,13 @@ export interface TabsConfig {
 
 const DEFAULT_TABS: TabsConfig[] = [
     { key: 'configuration', isEnabled: false },
-    { key: 'spec', isEnabled: false },
+    { key: 'edit', isEnabled: false },
     { key: 'execution', isEnabled: false },
     { key: 'preview', isEnabled: false },
 ]
 
 const getTabName = (key: TabKey, index: number): string => {
-    const lowerCaseName = key === 'spec' ? 'batch spec' : key
+    const lowerCaseName = key === 'edit' ? 'batch spec' : key
     return `${index + 1}. ${upperFirst(lowerCaseName)}`
 }
 

--- a/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react'
 
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
-import { useHistory } from 'react-router'
+import { Route, Router, Switch, useHistory } from 'react-router'
 
 import { useQuery } from '@sourcegraph/http-client'
 import { Settings, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
@@ -130,23 +130,20 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
     const { insightTitle } = useInsightTemplates(settingsCascade)
     const { searchQuery } = useSearchTemplate()
 
-    const [activeTabKey, setActiveTabKey] = useState<TabKey>('spec')
     const tabsConfig = useMemo<TabsConfig[]>(
         () => [
             {
                 key: 'configuration',
                 isEnabled: true,
                 handler: {
-                    type: 'button',
-                    onClick: () => setActiveTabKey('configuration'),
+                    type: 'link',
                 },
             },
             {
-                key: 'spec',
+                key: 'edit',
                 isEnabled: true,
                 handler: {
-                    type: 'button',
-                    onClick: () => setActiveTabKey('spec'),
+                    type: 'link',
                 },
             },
         ],
@@ -256,30 +253,43 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
             </div>
             <TabBar activeTabKey={activeTabKey} tabsConfig={tabsConfig} />
 
-            {activeTabKey === 'configuration' ? (
-                <ConfigurationForm isReadOnly={true} batchChange={batchChange} settingsCascade={settingsCascade} />
-            ) : (
-                <div className={styles.form}>
-                    <LibraryPane name={batchChange.name} onReplaceItem={editor.handleCodeChange} />
-                    <div className={styles.editorContainer} role="region" aria-label="batch spec editor">
-                        <H4 as={H3} className={styles.header}>
-                            Batch spec
-                        </H4>
-                        {executionAlert}
-                        <MonacoBatchSpecEditor
-                            autoFocus={true}
-                            batchChangeNamespace={batchChange.namespace}
-                            batchChangeName={batchChange.name}
-                            className={styles.editor}
-                            isLightTheme={isLightTheme}
-                            value={editor.code}
-                            onChange={editor.handleCodeChange}
+            <Switch>
+                <Route
+                    path={`${match.url}/configuration`}
+                    render={() => (
+                        <ConfigurationForm
+                            isReadOnly={true}
+                            batchChange={batchChange}
+                            settingsCascade={settingsCascade}
                         />
-                        <EditorFeedbackPanel errors={errors} />
-                    </div>
-                    <WorkspacesPreviewPanel />
-                </div>
-            )}
+                    )}
+                />
+                <Route
+                    path={`${match.url}/edit`}
+                    render={() => (
+                        <div className={styles.form}>
+                            <LibraryPane name={batchChange.name} onReplaceItem={editor.handleCodeChange} />
+                            <div className={styles.editorContainer} role="region" aria-label="batch spec editor">
+                                <H4 as={H3} className={styles.header}>
+                                    Batch spec
+                                </H4>
+                                {executionAlert}
+                                <MonacoBatchSpecEditor
+                                    autoFocus={true}
+                                    batchChangeNamespace={batchChange.namespace}
+                                    batchChangeName={batchChange.name}
+                                    className={styles.editor}
+                                    isLightTheme={isLightTheme}
+                                    value={editor.code}
+                                    onChange={editor.handleCodeChange}
+                                />
+                                <EditorFeedbackPanel errors={errors} />
+                            </div>
+                            <WorkspacesPreviewPanel />
+                        </div>
+                    )}
+                />
+            </Switch>
 
             {isDownloadSpecModalOpen ? (
                 <DownloadSpecModal

--- a/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
@@ -144,11 +144,12 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
                       }).then(() => Promise.resolve(args))
                     : Promise.resolve(args)
             })
-            .then(({ data }) =>
-                data
-                    ? history.push(`${data.createEmptyBatchChange.url}/edit${serializedRedirectSearchParameters}`)
-                    : noop()
-            )
+            .then(({ data }) => {
+                if (data) {
+                    history.replace(`${data.createEmptyBatchChange.url}/spec${serializedRedirectSearchParameters}`)
+                    history.push(`${data.createEmptyBatchChange.url}/edit${serializedRedirectSearchParameters}`)
+                }
+            })
             // We destructure and surface the error from `useMutation` instead.
             .catch(noop)
     }

--- a/client/web/src/enterprise/organizations/routes.tsx
+++ b/client/web/src/enterprise/organizations/routes.tsx
@@ -39,7 +39,7 @@ export const enterpriseOrganizationAreaRoutes: readonly OrgAreaRoute[] = [
         fullPage: true,
     },
     {
-        path: '/batch-changes/:batchChangeName/edit',
+        path: '/batch-changes/:batchChangeName/(spec|edit)',
         render: ({ match, ...props }: OrgAreaRouteContext & RouteComponentProps<{ batchChangeName: string }>) => (
             <EditBatchSpecPage
                 {...props}

--- a/client/web/src/enterprise/user/routes.tsx
+++ b/client/web/src/enterprise/user/routes.tsx
@@ -53,7 +53,7 @@ export const enterpriseUserAreaRoutes: readonly UserAreaRoute[] = [
         fullPage: true,
     },
     {
-        path: '/batch-changes/:batchChangeName/edit',
+        path: '/batch-changes/:batchChangeName/(spec|edit)',
         render: ({ match, ...props }: UserAreaRouteContext & RouteComponentProps<{ batchChangeName: string }>) => (
             <EditBatchSpecPage
                 {...props}


### PR DESCRIPTION
Instead of pushing to the history, we should replace it with the spec stage and then replace it to navigate to the edit step. This feels more natural to me than going back in history and coming back to the create page, since the create page is really just "step 1" of the process and morphs into that step 1.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-es-edit-page-routing.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

