### PR TITLE
use new HubSpot API authentication method

### DIFF
--- a/cmd/frontend/hubspot/contacts.go
+++ b/cmd/frontend/hubspot/contacts.go
@@ -16,7 +16,7 @@ import (
 //
 // http://developers.hubspot.com/docs/methods/contacts/create_or_update
 func (c *Client) CreateOrUpdateContact(email string, params *ContactProperties) (*ContactResponse, error) {
-	if c.hapiKey == "" {
+	if c.accessToken == "" {
 		return nil, errors.New("HubSpot API key must be provided.")
 	}
 	var resp ContactResponse
@@ -34,14 +34,10 @@ func (c *Client) CreateOrUpdateContact(email string, params *ContactProperties) 
 }
 
 func (c *Client) baseContactURL(email string) *url.URL {
-	q := url.Values{}
-	q.Set("hapikey", c.hapiKey)
-
 	return &url.URL{
-		Scheme:   "https",
-		Host:     "api.hubapi.com",
-		Path:     "/contacts/v1/contact/createOrUpdate/email/" + email + "/",
-		RawQuery: q.Encode(),
+		Scheme: "https",
+		Host:   "api.hubapi.com",
+		Path:   "/contacts/v1/contact/createOrUpdate/email/" + email + "/",
 	}
 }
 

--- a/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
+++ b/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
@@ -11,8 +11,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// HubSpotHAPIKey is used by some requests to access their respective API endpoints
-var HubSpotHAPIKey = env.Get("HUBSPOT_HAPI_KEY", "", "HubSpot HAPIkey for accessing certain HubSpot endpoints.")
+// HubSpotAccessToken is used by some requests to access their respective API endpoints. This access
+// token must have the following scopes:
+//
+// - crm.objects.contacts.write
+// - timeline
+// - forms
+// - crm.objects.contacts.read
+var HubSpotAccessToken = env.Get("HUBSPOT_ACCESS_TOKEN", "", "HubSpot access token for accessing certain HubSpot endpoints.")
 
 // SurveyFormID is the ID for a satisfaction (NPS) survey.
 var SurveyFormID = "ee042306-491a-4b06-bd9c-1181774dfda0"
@@ -37,14 +43,14 @@ var client *hubspot.Client
 
 // HasAPIKey returns true if a HubspotAPI key is present. A subset of requests require a HubSpot API key.
 func HasAPIKey() bool {
-	return HubSpotHAPIKey != ""
+	return HubSpotAccessToken != ""
 }
 
 func init() {
-	// The HubSpot API key will only be available in the production sourcegraph.com environment.
-	// Not having this key only restricts certain requests (e.g. GET requests to the Contacts API),
+	// The HubSpot access token will only be available in the production sourcegraph.com environment.
+	// Not having this access token only restricts certain requests (e.g. GET requests to the Contacts API),
 	// while others (e.g. POST requests to the Forms API) will still go through.
-	client = hubspot.New("2762526", HubSpotHAPIKey)
+	client = hubspot.New("2762526", HubSpotAccessToken)
 }
 
 // Client returns a hubspot client


### PR DESCRIPTION
The HubSpot API deprecated "HAPI keys" in favor of access tokens: https://developers.hubspot.com/changelog/upcoming-api-key-sunset.

This migrates our usage of the HubSpot API to use the new access tokens.

The env var HUBSPOT_HAPI_KEY is no longer used. Instead, Sourcegraph.com must specify the env var HUBSPOT_ACCESS_TOKEN.

:star:  See https://docs.google.com/document/d/1jrO003oY3tShhj_KnLvd_zCpAt1E3SFz7P0KralWizM/edit for internal steps I need help with to merge and deploy this.

This must be merged by 2022-11-30 or else it will stop working (due to HubSpot's deprecation).


## Test plan

Run `HUBSPOT_ACCESS_TOKEN=... sg start dotcom` and submit feedback. Confirm it shows up in the [HubSpot form submissions](https://app.hubspot.com/forms/2762526/417ec50b-39b4-41fa-a267-75da6f56a7cf/submissions).