### PR TITLE
Button: pass through disabled attribute

### DIFF
--- a/client/wildcard/src/components/Button/Button.test.tsx
+++ b/client/wildcard/src/components/Button/Button.test.tsx
@@ -14,6 +14,11 @@ describe('Button', () => {
         expect(asFragment()).toMatchSnapshot()
     })
 
+    it('renders as disabled', () => {
+        const { asFragment } = renderWithBrandedContext(<Button disabled={true}>Disabled</Button>)
+        expect(asFragment()).toMatchSnapshot()
+    })
+
     it.each(BUTTON_VARIANTS)("Renders variant '%s' correctly", variant => {
         const { asFragment } = renderWithBrandedContext(<Button variant={variant}>Hello world</Button>)
         expect(asFragment()).toMatchSnapshot()

--- a/client/wildcard/src/components/Button/Button.tsx
+++ b/client/wildcard/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, ButtonHTMLAttributes, forwardRef } from 'react'
+import { ButtonHTMLAttributes, forwardRef } from 'react'
 
 import classNames from 'classnames'
 
@@ -55,9 +55,7 @@ export const Button = forwardRef(
             size,
             outline,
             className,
-            disabled,
             display,
-            onClick,
             ...attributes
         },
         reference
@@ -66,19 +64,12 @@ export const Button = forwardRef(
 
         const brandedButtonClassname = getButtonClassName({ variant, outline, display, size })
 
-        const handleClick = (event: MouseEvent<HTMLButtonElement>): void => {
-            if (!disabled) {
-                onClick?.(event)
-            }
-        }
-
         return (
             <Component
                 ref={reference}
                 type={type}
-                aria-disabled={disabled}
+                aria-disabled={attributes.disabled}
                 className={classNames(isBranded && brandedButtonClassname, className)}
-                onClick={handleClick}
                 {...attributes}
             >
                 {children}

--- a/client/wildcard/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/client/wildcard/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -132,6 +132,19 @@ exports[`Button renders a simple button correctly 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Button renders as disabled 1`] = `
+<DocumentFragment>
+  <button
+    aria-disabled="true"
+    class="btn"
+    disabled=""
+    type="button"
+  >
+    Disabled
+  </button>
+</DocumentFragment>
+`;
+
 exports[`Button supports rendering as different elements 1`] = `
 <DocumentFragment>
   <div

--- a/client/wildcard/src/components/ButtonLink/__snapshots__/ButtonLink.test.tsx.snap
+++ b/client/wildcard/src/components/ButtonLink/__snapshots__/ButtonLink.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`<ButtonLink /> renders correctly \`disabled\` 1`] = `
   <a
     aria-disabled="true"
     class="anchorLink btn btnSecondary btnLg disabled"
+    disabled=""
     href=""
     role="button"
     tabindex="-1"


### PR DESCRIPTION
Fixes an issue in the FeedbackPrompt where clicking the `<Button disabled={true}>` would still submit the form. The button appeared disabled, but HTML forms by default submit when any non-disabled `type="submit"` button descendant is clicked. The `<Button>` had `aria-disabled={true}` but not `disabled={true}`. This bug would occur anywhere else `<Button>` is used in a form.

The new behavior seems to be ideal in all cases because it makes `<Button>` behave more like a `<button>`.




## Test plan

Submit FeedbackPrompt (in user menu) with an empty text. Nothing should happen.

## App preview:

- [Web](https://sg-web-sqs-feedback-fixes.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
