### PR TITLE
Implement noCache flag on execute endpoint

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/edit/RunBatchSpecButton.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/RunBatchSpecButton.tsx
@@ -75,8 +75,7 @@ export const RunBatchSpecButton: React.FunctionComponent<React.PropsWithChildren
 
             <PopoverContent className={styles.menuList} position={Position.bottomEnd}>
                 <H3 className="pb-2 pt-3 pl-3 pr-3 m-0">Execution options</H3>
-                {/* TODO: Once the execution mutation honors execution options, this can be removed. */}
-                <ExecutionOption moreInfo="When this batch spec is executed, it will not use cached results from any previous execution. Currently, toggling this option also requires updating the workspaces preview.">
+                <ExecutionOption moreInfo="Toggle to run workspace executions even if cache entries exist.">
                     <Checkbox
                         name="run-without-cache"
                         id="run-without-cache"

--- a/client/web/src/enterprise/batches/batch-spec/edit/useExecuteBatchSpec.ts
+++ b/client/web/src/enterprise/batches/batch-spec/edit/useExecuteBatchSpec.ts
@@ -38,9 +38,7 @@ export const useExecuteBatchSpec = (batchSpecID?: Scalars['ID'], noCache?: boole
         submitBatchSpec({
             variables: {
                 batchSpec: batchSpecID,
-                // Only set this variable to a boolean value if true, otherwise we might overwrite a previous
-                // setting set when resolving workspaces.
-                noCache: noCache === true ? true : null,
+                noCache: noCache ?? false,
             },
         })
             .then(({ data }) => {

--- a/client/web/src/enterprise/batches/batch-spec/edit/useExecuteBatchSpec.ts
+++ b/client/web/src/enterprise/batches/batch-spec/edit/useExecuteBatchSpec.ts
@@ -22,7 +22,7 @@ interface UseExecuteBatchSpecResult {
  *
  * @param batchSpecID The current batch spec ID.
  */
-export const useExecuteBatchSpec = (batchSpecID?: Scalars['ID']): UseExecuteBatchSpecResult => {
+export const useExecuteBatchSpec = (batchSpecID?: Scalars['ID'], noCache?: boolean): UseExecuteBatchSpecResult => {
     const [submitBatchSpec, { loading }] = useMutation<ExecuteBatchSpecResult, ExecuteBatchSpecVariables>(
         EXECUTE_BATCH_SPEC
     )
@@ -35,7 +35,7 @@ export const useExecuteBatchSpec = (batchSpecID?: Scalars['ID']): UseExecuteBatc
             return
         }
 
-        submitBatchSpec({ variables: { batchSpec: batchSpecID } })
+        submitBatchSpec({ variables: { batchSpec: batchSpecID, noCache: noCache ?? false } })
             .then(({ data }) => {
                 if (data?.executeBatchSpec) {
                     history.replace(
@@ -44,7 +44,7 @@ export const useExecuteBatchSpec = (batchSpecID?: Scalars['ID']): UseExecuteBatc
                 }
             })
             .catch(setExecutionError)
-    }, [submitBatchSpec, history, batchSpecID])
+    }, [submitBatchSpec, noCache, history, batchSpecID])
 
     return {
         executeBatchSpec,

--- a/client/web/src/enterprise/batches/batch-spec/edit/useExecuteBatchSpec.ts
+++ b/client/web/src/enterprise/batches/batch-spec/edit/useExecuteBatchSpec.ts
@@ -35,7 +35,14 @@ export const useExecuteBatchSpec = (batchSpecID?: Scalars['ID'], noCache?: boole
             return
         }
 
-        submitBatchSpec({ variables: { batchSpec: batchSpecID, noCache: noCache ?? false } })
+        submitBatchSpec({
+            variables: {
+                batchSpec: batchSpecID,
+                // Only set this variable to a boolean value if true, otherwise we might overwrite a previous
+                // setting set when resolving workspaces.
+                noCache: noCache === true ? true : null,
+            },
+        })
             .then(({ data }) => {
                 if (data?.executeBatchSpec) {
                     history.replace(

--- a/client/web/src/enterprise/batches/batch-spec/edit/useExecuteBatchSpec.ts
+++ b/client/web/src/enterprise/batches/batch-spec/edit/useExecuteBatchSpec.ts
@@ -38,7 +38,7 @@ export const useExecuteBatchSpec = (batchSpecID?: Scalars['ID'], noCache?: boole
         submitBatchSpec({
             variables: {
                 batchSpec: batchSpecID,
-                noCache: noCache ?? false,
+                noCache: noCache === undefined ? null : noCache,
             },
         })
             .then(({ data }) => {

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.story.tsx
@@ -346,6 +346,36 @@ export const Succeeded: Story = () => (
                             clearError: noop,
                             setFilters: noop,
                             isPreviewDisabled: false,
+                            noCache: false,
+                        },
+                    }}
+                >
+                    <WorkspacesPreview />
+                </BatchSpecContextProvider>
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
+
+export const CacheDisabled: Story = () => (
+    <WebStory>
+        {() => (
+            <MockedTestProvider link={new WildcardMockLink(UNSTARTED_WITH_CACHE_CONNECTION_MOCKS)}>
+                <BatchSpecContextProvider
+                    batchChange={mockBatchChange()}
+                    batchSpec={mockBatchSpec()}
+                    refetchBatchChange={() => Promise.resolve()}
+                    testState={{
+                        workspacesPreview: {
+                            hasPreviewed: true,
+                            resolutionState: BatchSpecWorkspaceResolutionState.COMPLETED,
+                            preview: () => Promise.resolve(),
+                            cancel: noop,
+                            isInProgress: false,
+                            clearError: noop,
+                            setFilters: noop,
+                            isPreviewDisabled: false,
+                            noCache: true,
                         },
                     }}
                 >

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
@@ -90,6 +90,7 @@ const MemoizedWorkspacesPreview: React.FunctionComponent<
         hasPreviewed,
         preview,
         isPreviewDisabled,
+        noCache: cacheDisabled,
     } = workspacesPreview
 
     const workspacesConnection = useWorkspaces(batchSpec.id, filters)
@@ -319,6 +320,7 @@ const MemoizedWorkspacesPreview: React.FunctionComponent<
                         showCached={showCached}
                         cached={cachedWorkspacesPreview}
                         isReadOnly={isReadOnly}
+                        cacheDisabled={cacheDisabled}
                     />
                     <ImportingChangesetsPreviewList
                         isStale={

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewList.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewList.tsx
@@ -52,6 +52,8 @@ interface WorkspacesPreviewListProps {
     error?: string
     /** Whether or not the items presented in the list are read-only. */
     isReadOnly?: boolean
+    /** Whether using cached results is disabled. */
+    cacheDisabled?: boolean
 }
 
 export const WorkspacesPreviewList: React.FunctionComponent<React.PropsWithChildren<WorkspacesPreviewListProps>> = ({
@@ -61,6 +63,7 @@ export const WorkspacesPreviewList: React.FunctionComponent<React.PropsWithChild
     cached,
     workspacesConnection: { connection, hasNextPage, fetchMore },
     error,
+    cacheDisabled,
     isReadOnly,
 }) => {
     const connectionOrCached = showCached && cached ? cached : connection
@@ -73,6 +76,7 @@ export const WorkspacesPreviewList: React.FunctionComponent<React.PropsWithChild
                     <WorkspacesPreviewListItem
                         key={node.id}
                         workspace={node}
+                        cacheDisabled={cacheDisabled}
                         isStale={isStale}
                         exclude={excludeRepo}
                         isReadOnly={isReadOnly}

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewListItem.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewListItem.tsx
@@ -20,11 +20,13 @@ interface WorkspacesPreviewListItemProps {
     exclude: (repo: string, branch: string) => void
     /** Whether or not the item presented should be read-only. */
     isReadOnly?: boolean
+    /** Whether using cached results is disabled. */
+    cacheDisabled?: boolean
 }
 
 export const WorkspacesPreviewListItem: React.FunctionComponent<
     React.PropsWithChildren<WorkspacesPreviewListItemProps>
-> = ({ workspace, isStale, exclude, isReadOnly = false }) => {
+> = ({ workspace, isStale, exclude, cacheDisabled, isReadOnly = false }) => {
     const [toBeExcluded, setToBeExcluded] = useState(false)
 
     const handleExclude = useCallback(() => {
@@ -41,13 +43,13 @@ export const WorkspacesPreviewListItem: React.FunctionComponent<
             return <ExcludeIcon />
         }
         if (workspace.cachedResultFound) {
-            return <CachedIcon />
+            return <CachedIcon cacheDisabled={cacheDisabled} />
         }
         if (workspace.stepCacheResultCount > 0) {
-            return <PartiallyCachedIcon count={workspace.stepCacheResultCount} />
+            return <PartiallyCachedIcon cacheDisabled={cacheDisabled} count={workspace.stepCacheResultCount} />
         }
         return undefined
-    }, [toBeExcluded, workspace.cachedResultFound, workspace.stepCacheResultCount])
+    }, [cacheDisabled, toBeExcluded, workspace.cachedResultFound, workspace.stepCacheResultCount])
 
     return (
         <ListItem className={!isReadOnly && isStale ? styles.stale : undefined}>

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/useWorkspacesPreview.ts
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/useWorkspacesPreview.ts
@@ -54,6 +54,8 @@ export interface UseWorkspacesPreviewResult {
      * on the page.
      */
     hasPreviewed: boolean
+    /** Whether or not the batch spec should be executed with the cache disabled. */
+    noCache: boolean
 }
 
 interface UseWorkspacesPreviewOptions {
@@ -159,10 +161,10 @@ export const useWorkspacesPreview = (
             > =>
                 isBatchSpecApplied
                     ? createBatchSpecFromRaw({
-                          variables: { spec: code, namespace: namespaceID, noCache, batchChange },
+                          variables: { spec: code, namespace: namespaceID, batchChange },
                       }).then(result => result.data?.createBatchSpecFromRaw)
                     : replaceBatchSpecInput({
-                          variables: { spec: code, previousSpec: currentBatchSpecID, noCache },
+                          variables: { spec: code, previousSpec: currentBatchSpecID },
                       }).then(result => result.data?.replaceBatchSpecInput)
 
             return preview()
@@ -192,7 +194,6 @@ export const useWorkspacesPreview = (
             currentBatchSpecID,
             namespaceID,
             isBatchSpecApplied,
-            noCache,
             createBatchSpecFromRaw,
             replaceBatchSpecInput,
             batchChange,
@@ -276,5 +277,6 @@ export const useWorkspacesPreview = (
         error,
         clearError: () => setError(undefined),
         hasPreviewed: hasRequestedPreview && hasPreviewed,
+        noCache,
     }
 }

--- a/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
@@ -139,7 +139,6 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
                           variables: {
                               namespace: selectedNamespace.id,
                               spec: template,
-                              noCache: false,
                               batchChange: batchChangeID,
                           },
                       }).then(() => Promise.resolve(args))

--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -84,8 +84,8 @@ export const CREATE_EMPTY_BATCH_CHANGE = gql`
 // This mutation is used to create a new batch spec when the existing batch spec attached
 // to a batch change has already been applied.
 export const CREATE_BATCH_SPEC_FROM_RAW = gql`
-    mutation CreateBatchSpecFromRaw($spec: String!, $noCache: Boolean!, $namespace: ID!, $batchChange: ID!) {
-        createBatchSpecFromRaw(batchSpec: $spec, noCache: $noCache, namespace: $namespace, batchChange: $batchChange) {
+    mutation CreateBatchSpecFromRaw($spec: String!, $namespace: ID!, $batchChange: ID!) {
+        createBatchSpecFromRaw(batchSpec: $spec, namespace: $namespace, batchChange: $batchChange) {
             id
             createdAt
             workspaceResolution {
@@ -102,8 +102,8 @@ export const CREATE_BATCH_SPEC_FROM_RAW = gql`
 // This mutation is used to update the batch spec when the existing batch spec is
 // unapplied.
 export const REPLACE_BATCH_SPEC_INPUT = gql`
-    mutation ReplaceBatchSpecInput($previousSpec: ID!, $spec: String!, $noCache: Boolean!) {
-        replaceBatchSpecInput(previousSpec: $previousSpec, batchSpec: $spec, noCache: $noCache) {
+    mutation ReplaceBatchSpecInput($previousSpec: ID!, $spec: String!) {
+        replaceBatchSpecInput(previousSpec: $previousSpec, batchSpec: $spec) {
             id
             createdAt
             workspaceResolution {

--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -61,8 +61,8 @@ export const GET_BATCH_CHANGE_TO_EDIT = gql`
 `
 
 export const EXECUTE_BATCH_SPEC = gql`
-    mutation ExecuteBatchSpec($batchSpec: ID!) {
-        executeBatchSpec(batchSpec: $batchSpec) {
+    mutation ExecuteBatchSpec($batchSpec: ID!, $noCache: Boolean) {
+        executeBatchSpec(batchSpec: $batchSpec, noCache: $noCache) {
             ...BatchSpecExecutionFields
         }
     }

--- a/client/web/src/enterprise/batches/workspaces-list/Icons.tsx
+++ b/client/web/src/enterprise/batches/workspaces-list/Icons.tsx
@@ -1,32 +1,43 @@
 import React from 'react'
 
 import { mdiContentSave, mdiContentSaveEditOutline, mdiDelete } from '@mdi/js'
+import classNames from 'classnames'
 
 import { pluralize } from '@sourcegraph/common'
 import { Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import styles from './Icons.module.scss'
 
-export const CachedIcon: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
-    <Tooltip content="A cached result was found for this workspace.">
-        <Icon
-            tabIndex={0}
-            role="tooltip"
-            aria-label="A cached result was found for this workspace."
-            svgPath={mdiContentSave}
-        />
-    </Tooltip>
-)
+export const CachedIcon: React.FunctionComponent<React.PropsWithChildren<{ cacheDisabled?: boolean }>> = ({
+    cacheDisabled,
+}) => {
+    const label = `A cached result was found for this workspace${cacheDisabled ? ', but will not be used' : ''}.`
+    return (
+        <Tooltip content={label}>
+            <Icon
+                tabIndex={0}
+                role="tooltip"
+                aria-label={label}
+                className={classNames(cacheDisabled && 'text-muted')}
+                svgPath={mdiContentSave}
+            />
+        </Tooltip>
+    )
+}
 
-export const PartiallyCachedIcon: React.FunctionComponent<React.PropsWithChildren<{ count: number }>> = ({ count }) => {
-    const label = `This workspace contains cached results for ${count} ${pluralize('step', count)}.`
+export const PartiallyCachedIcon: React.FunctionComponent<
+    React.PropsWithChildren<{ count: number; cacheDisabled?: boolean }>
+> = ({ count, cacheDisabled }) => {
+    const label = `This workspace contains cached results for ${count} ${pluralize('step', count)}${
+        cacheDisabled ? ', but will not be used' : ''
+    }.`
     return (
         <Tooltip content={label}>
             <Icon
                 aria-label={label}
                 tabIndex={0}
                 role="tooltip"
-                className={styles.partiallyCachedIcon}
+                className={classNames(styles.partiallyCachedIcon, cacheDisabled && 'text-muted')}
                 svgPath={mdiContentSaveEditOutline}
             />
         </Tooltip>

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -363,6 +363,7 @@ type BatchSpecResolver interface {
 
 	AllowIgnored() *bool
 	AllowUnsupported() *bool
+	NoCache() *bool
 
 	ViewerCanRetry(context.Context) (bool, error)
 

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -110,7 +110,7 @@ type DeleteBatchSpecArgs struct {
 
 type ExecuteBatchSpecArgs struct {
 	BatchSpec graphql.ID
-	NoCache   bool
+	NoCache   *bool
 	AutoApply bool
 }
 

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -3180,6 +3180,13 @@ type BatchSpec implements Node {
     allowUnsupported: Boolean
 
     """
+    If true, workspaces will not run with cached results.
+
+    Null, if not created through createBatchSpecFromRaw.
+    """
+    noCache: Boolean
+
+    """
     If true, viewer can retry the batch spec execution by calling
     retryBatchSpecExecution.
     """

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -1421,8 +1421,6 @@ extend type Mutation {
 
         """
         Don't use cache entries.
-
-        TODO: Not implemented yet.
         """
         noCache: Boolean = false
 
@@ -1482,8 +1480,6 @@ extend type Mutation {
 
         """
         Don't use cache entries.
-
-        TODO: Not implemented yet.
         """
         noCache: Boolean = false
     ): BatchSpec!
@@ -1524,8 +1520,6 @@ extend type Mutation {
 
         """
         Don't use cache entries.
-
-        TODO: Not implemented yet.
         """
         noCache: Boolean = false
 
@@ -1565,11 +1559,10 @@ extend type Mutation {
         """
         batchSpec: ID!
         """
-        Don't use cache entries.
-
-        TODO: Not implemented yet.
+        Don't use cache entries. If set, will overwrite the current batchSpec.NoCache
+        state.
         """
-        noCache: Boolean = false
+        noCache: Boolean
         """
         Right away set the autoApplyEnabled flag on the batch spec.
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 
 	"github.com/sourcegraph/go-diff/diff"
@@ -330,6 +331,13 @@ func (r *batchSpecResolver) AllowUnsupported() *bool {
 func (r *batchSpecResolver) AllowIgnored() *bool {
 	if r.batchSpec.CreatedFromRaw {
 		return &r.batchSpec.AllowIgnored
+	}
+	return nil
+}
+
+func (r *batchSpecResolver) NoCache() *bool {
+	if r.batchSpec.CreatedFromRaw {
+		return &r.batchSpec.NoCache
 	}
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -1662,7 +1662,8 @@ func (r *Resolver) ExecuteBatchSpec(ctx context.Context, args *graphqlbackend.Ex
 	svc := service.New(r.store)
 	batchSpec, err := svc.ExecuteBatchSpec(ctx, service.ExecuteBatchSpecOpts{
 		BatchSpecRandID: batchSpecRandID,
-		// TODO: args not yet implemented: NoCache, AutoApply
+		// TODO: args not yet implemented: AutoApply
+		NoCache: args.NoCache,
 	})
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
@@ -123,22 +123,20 @@ func transformRecord(ctx context.Context, logger log.Logger, s BatchesStore, job
 
 	// Check if we have a cache result for the workspace, if so, add it to the execution
 	// input.
-	if !batchSpec.NoCache {
-		// Find the cache entry for the _last_ step. src-cli only needs the most
-		// recent cache entry to do its work.
-		latestStepIndex := -1
-		for stepIndex := range workspace.StepCacheResults {
-			if stepIndex > latestStepIndex {
-				latestStepIndex = stepIndex
-			}
+	// Find the cache entry for the _last_ step. src-cli only needs the most
+	// recent cache entry to do its work.
+	latestStepIndex := -1
+	for stepIndex := range workspace.StepCacheResults {
+		if stepIndex > latestStepIndex {
+			latestStepIndex = stepIndex
 		}
-		if latestStepIndex != -1 {
-			cacheEntry, ok := workspace.StepCacheResult(latestStepIndex)
-			// Technically this should never be not ok, but computers.
-			if ok {
-				executionInput.CachedStepResultFound = true
-				executionInput.CachedStepResult = *cacheEntry.Value
-			}
+	}
+	if latestStepIndex != -1 {
+		cacheEntry, ok := workspace.StepCacheResult(latestStepIndex)
+		// Technically this should never be not ok, but computers.
+		if ok {
+			executionInput.CachedStepResultFound = true
+			executionInput.CachedStepResult = *cacheEntry.Value
 		}
 	}
 

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator.go
@@ -142,9 +142,6 @@ func (r *batchSpecWorkspaceCreator) process(
 
 		ws = append(ws, workspace)
 
-		if spec.NoCache {
-			continue
-		}
 		if !spec.AllowIgnored && w.Ignored {
 			continue
 		}

--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
@@ -505,7 +505,7 @@ changesetTemplate:
 		}
 	})
 
-	t.Run("caching enabled but no diff in cache entry", func(t *testing.T) {
+	t.Run("no diff in cache entry", func(t *testing.T) {
 		workspace := buildWorkspace("caching-enabled-no-diff")
 
 		batchSpec := createBatchSpec(t, false, bt.TestRawBatchSpecYAML)
@@ -547,54 +547,7 @@ changesetTemplate:
 		}
 	})
 
-	t.Run("caching disabled", func(t *testing.T) {
-		workspace := buildWorkspace("caching-disabled")
-
-		batchSpec := createBatchSpec(t, true, bt.TestRawBatchSpecYAML)
-		entry := createCacheEntry(t, batchSpec, workspace, executionResult, secretValue, nil)
-
-		resolver := &dummyWorkspaceResolver{workspaces: []*service.RepoWorkspace{workspace}}
-		job := &btypes.BatchSpecResolutionJob{BatchSpecID: batchSpec.ID}
-		if err := creator.process(userCtx, resolver.DummyBuilder, job); err != nil {
-			t.Fatalf("proces failed: %s", err)
-		}
-
-		have, _, err := s.ListBatchSpecWorkspaces(context.Background(), store.ListBatchSpecWorkspacesOpts{BatchSpecID: batchSpec.ID})
-		if err != nil {
-			t.Fatalf("listing workspaces failed: %s", err)
-		}
-
-		assertWorkspacesEqual(t, have, []*btypes.BatchSpecWorkspace{
-			{
-				RepoID:             repos[0].ID,
-				BatchSpecID:        batchSpec.ID,
-				ChangesetSpecIDs:   []int64{},
-				Branch:             "refs/heads/main",
-				Commit:             "caching-disabled",
-				FileMatches:        []string{},
-				Path:               "",
-				OnlyFetchWorkspace: true,
-				CachedResultFound:  false,
-			},
-		})
-
-		reloadedEntries, err := s.ListBatchSpecExecutionCacheEntries(context.Background(), store.ListBatchSpecExecutionCacheEntriesOpts{
-			UserID: batchSpec.UserID,
-			Keys:   []string{entry.Key},
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(reloadedEntries) != 1 {
-			t.Fatal("cache entry not found")
-		}
-		reloadedEntry := reloadedEntries[0]
-		if !reloadedEntry.LastUsedAt.IsZero() {
-			t.Fatalf("cache entry LastUsedAt updated, but should not be used: %s", reloadedEntry.LastUsedAt)
-		}
-	})
-
-	t.Run("caching enabled but workspace is ignored", func(t *testing.T) {
+	t.Run("workspace is ignored", func(t *testing.T) {
 		workspace := buildWorkspace("caching-enabled-ignored")
 		workspace.Ignored = true
 
@@ -624,7 +577,7 @@ changesetTemplate:
 		}
 	})
 
-	t.Run("caching enabled but workspace is unsupported", func(t *testing.T) {
+	t.Run("workspace is unsupported", func(t *testing.T) {
 		workspace := buildWorkspace("caching-enabled-ignored")
 		workspace.Unsupported = true
 

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -555,6 +555,7 @@ func (s *Service) ExecuteBatchSpec(ctx context.Context, opts ExecuteBatchSpecOpt
 		return nil, ErrBatchSpecResolutionErrored{resolutionJob.FailureMessage}
 
 	case btypes.BatchSpecResolutionJobStateCompleted:
+		// Continue below the switch statement.
 
 	default:
 		return nil, ErrBatchSpecResolutionIncomplete
@@ -581,6 +582,7 @@ func (s *Service) ExecuteBatchSpec(ctx context.Context, opts ExecuteBatchSpecOpt
 	if err != nil {
 		return nil, err
 	}
+
 	err = tx.MarkSkippedBatchSpecWorkspaces(ctx, batchSpec.ID)
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -1233,6 +1233,99 @@ index e5af166..d44c3fc 100644
 				t.Fatalf("wrong number of execution jobs created. want=%d, have=%d", len(rs), len(jobs))
 			}
 		})
+
+		t.Run("caching disabled", func(t *testing.T) {
+			spec := testBatchSpec(admin.ID)
+			if err := s.CreateBatchSpec(ctx, spec); err != nil {
+				t.Fatal(err)
+			}
+
+			// Simulate successful resolution.
+			job := &btypes.BatchSpecResolutionJob{
+				State:       btypes.BatchSpecResolutionJobStateCompleted,
+				BatchSpecID: spec.ID,
+				InitiatorID: admin.ID,
+			}
+
+			if err := s.CreateBatchSpecResolutionJob(ctx, job); err != nil {
+				t.Fatal(err)
+			}
+
+			cs := &btypes.ChangesetSpec{
+				Title:      "test",
+				BaseRepoID: rs[0].ID,
+			}
+			if err := s.CreateChangesetSpec(ctx, cs); err != nil {
+				t.Fatal(err)
+			}
+
+			var workspaceIDs []int64
+			for _, repo := range rs {
+				ws := &btypes.BatchSpecWorkspace{
+					BatchSpecID:       spec.ID,
+					RepoID:            repo.ID,
+					CachedResultFound: true,
+					StepCacheResults:  map[int]btypes.StepCacheResult{1: {}},
+					ChangesetSpecIDs:  []int64{cs.ID},
+				}
+				if err := s.CreateBatchSpecWorkspace(ctx, ws); err != nil {
+					t.Fatal(err)
+				}
+				workspaceIDs = append(workspaceIDs, ws.ID)
+			}
+
+			tru := true
+			// Execute BatchSpec by creating execution jobs
+			if _, err := svc.ExecuteBatchSpec(adminCtx, ExecuteBatchSpecOpts{
+				BatchSpecRandID: spec.RandID,
+				// Disable caching.
+				NoCache: &tru,
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			jobs, err := s.ListBatchSpecWorkspaceExecutionJobs(ctx, store.ListBatchSpecWorkspaceExecutionJobsOpts{
+				BatchSpecWorkspaceIDs: workspaceIDs,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(jobs) != len(rs) {
+				t.Fatalf("wrong number of execution jobs created. want=%d, have=%d", len(rs), len(jobs))
+			}
+
+			ws, _, err := s.ListBatchSpecWorkspaces(ctx, store.ListBatchSpecWorkspacesOpts{IDs: workspaceIDs})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, w := range ws {
+				if w.CachedResultFound {
+					t.Error("cached_result_found not reset")
+				}
+				if len(w.StepCacheResults) > 0 {
+					t.Error("step_cache_results not reset")
+				}
+				if len(w.ChangesetSpecIDs) > 0 {
+					t.Error("changeset_spec_ids not reset")
+				}
+			}
+
+			// Verify the changeset spec has been deleted.
+			if _, err := s.GetChangesetSpecByID(ctx, cs.ID); err == nil || err != store.ErrNoResults {
+				t.Fatal(err)
+			}
+
+			// Verify the batch spec no_cache flag has been updated.
+			reloadedSpec, err := s.GetBatchSpec(ctx, store.GetBatchSpecOpts{ID: spec.ID})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reloadedSpec.NoCache {
+				t.Error("no_cache flag on batch spec not updated")
+			}
+		})
+
 		t.Run("resolution not completed", func(t *testing.T) {
 			spec := testBatchSpec(admin.ID)
 			if err := s.CreateBatchSpec(ctx, spec); err != nil {

--- a/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs.go
+++ b/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs.go
@@ -473,59 +473,6 @@ func (s *Store) cancelBatchSpecWorkspaceExecutionJobQuery(opts CancelBatchSpecWo
 	)
 }
 
-const disableBatchSpecWorkspaceExecutionCacheQueryFmtstr = `
-WITH batch_spec AS (
-	SELECT
-		id, no_cache
-	FROM
-		batch_specs
-	WHERE
-		id = %s
-),
-candidate_batch_spec_workspaces AS (
-	SELECT
-		id, changeset_spec_ids
-	FROM
-		batch_spec_workspaces
-	WHERE
-		batch_spec_workspaces.batch_spec_id = %s
-	ORDER BY id
-),
-removable_changeset_specs AS (
-	SELECT
-		id
-	FROM
-		changeset_specs
-	WHERE
-		id IN (SELECT jsonb_object_keys(changeset_spec_ids)::bigint FROM batch_spec_workspaces)
-	ORDER BY id
-),
-removed_changeset_specs AS (
-	DELETE FROM changeset_specs
-	WHERE
-		id IN (SELECT id FROM removable_changeset_specs)
-)
-UPDATE
-	batch_spec_workspaces
-SET
-	cached_result_found = FALSE,
-	changeset_spec_ids = '{}',
-	step_cache_results = '{}'
-WHERE
-	id IN (SELECT id FROM candidate_batch_spec_workspaces)
-`
-
-// DisableBatchSpecWorkspaceExecutionCache removes caching information from workspaces prior to execution.
-func (s *Store) DisableBatchSpecWorkspaceExecutionCache(ctx context.Context, batchSpecID int64) (err error) {
-	ctx, _, endObservation := s.operations.disableBatchSpecWorkspaceExecutionCache.With(ctx, &err, observation.Args{LogFields: []log.Field{
-		log.Int("batchSpecID", int(batchSpecID)),
-	}})
-	defer endObservation(1, observation.Args{})
-
-	q := sqlf.Sprintf(disableBatchSpecWorkspaceExecutionCacheQueryFmtstr, batchSpecID, batchSpecID)
-	return s.Exec(ctx, q)
-}
-
 func ScanBatchSpecWorkspaceExecutionJob(wj *btypes.BatchSpecWorkspaceExecutionJob, s dbutil.Scanner) error {
 	var executionLogs []dbworkerstore.ExecutionLogEntry
 	var failureMessage string

--- a/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs.go
+++ b/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs.go
@@ -473,6 +473,68 @@ func (s *Store) cancelBatchSpecWorkspaceExecutionJobQuery(opts CancelBatchSpecWo
 	)
 }
 
+const disableBatchSpecWorkspaceExecutionCacheQueryFmtstr = `
+WITH batch_spec AS (
+	SELECT
+		id, no_cache
+	FROM
+		batch_specs
+	WHERE
+		id = %s
+),
+candidate_batch_spec_workspaces AS (
+	SELECT
+		id, changeset_spec_ids
+	FROM
+		batch_spec_workspaces
+	WHERE
+		batch_spec_workspaces.batch_spec_id = %s
+		AND
+		EXISTS (
+			SELECT 1
+			FROM batch_spec
+			WHERE
+				no_cache
+				OR
+				%s
+		)
+	ORDER BY id
+),
+removable_changeset_specs AS (
+	SELECT
+		id
+	FROM
+		changeset_specs
+	WHERE
+		id IN (SELECT jsonb_object_keys(changeset_spec_ids)::bigint FROM batch_spec_workspaces)
+	ORDER BY id
+),
+removed_changeset_specs AS (
+	DELETE FROM changeset_specs
+	WHERE
+		id IN (SELECT id FROM removable_changeset_specs)
+)
+UPDATE
+	batch_spec_workspaces
+SET
+	cached_result_found = FALSE,
+	changeset_spec_ids = '{}',
+	step_cache_results = '{}'
+WHERE
+	id IN (SELECT id FROM candidate_batch_spec_workspaces)
+`
+
+// DisableBatchSpecWorkspaceExecutionCache removes caching information from workspaces prior to execution.
+func (s *Store) DisableBatchSpecWorkspaceExecutionCache(ctx context.Context, batchSpecID int64, noCache bool) (err error) {
+	ctx, _, endObservation := s.operations.disableBatchSpecWorkspaceExecutionCache.With(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.Int("batchSpecID", int(batchSpecID)),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	q := sqlf.Sprintf(disableBatchSpecWorkspaceExecutionCacheQueryFmtstr, batchSpecID, batchSpecID, noCache)
+	return s.Exec(ctx, q)
+}
+
 func ScanBatchSpecWorkspaceExecutionJob(wj *btypes.BatchSpecWorkspaceExecutionJob, s dbutil.Scanner) error {
 	var executionLogs []dbworkerstore.ExecutionLogEntry
 	var failureMessage string

--- a/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs.go
+++ b/enterprise/internal/batches/store/batch_spec_workspace_execution_jobs.go
@@ -489,15 +489,6 @@ candidate_batch_spec_workspaces AS (
 		batch_spec_workspaces
 	WHERE
 		batch_spec_workspaces.batch_spec_id = %s
-		AND
-		EXISTS (
-			SELECT 1
-			FROM batch_spec
-			WHERE
-				no_cache
-				OR
-				%s
-		)
 	ORDER BY id
 ),
 removable_changeset_specs AS (
@@ -525,13 +516,13 @@ WHERE
 `
 
 // DisableBatchSpecWorkspaceExecutionCache removes caching information from workspaces prior to execution.
-func (s *Store) DisableBatchSpecWorkspaceExecutionCache(ctx context.Context, batchSpecID int64, noCache bool) (err error) {
+func (s *Store) DisableBatchSpecWorkspaceExecutionCache(ctx context.Context, batchSpecID int64) (err error) {
 	ctx, _, endObservation := s.operations.disableBatchSpecWorkspaceExecutionCache.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("batchSpecID", int(batchSpecID)),
 	}})
 	defer endObservation(1, observation.Args{})
 
-	q := sqlf.Sprintf(disableBatchSpecWorkspaceExecutionCacheQueryFmtstr, batchSpecID, batchSpecID, noCache)
+	q := sqlf.Sprintf(disableBatchSpecWorkspaceExecutionCacheQueryFmtstr, batchSpecID, batchSpecID)
 	return s.Exec(ctx, q)
 }
 

--- a/enterprise/internal/batches/store/batch_spec_workspaces.go
+++ b/enterprise/internal/batches/store/batch_spec_workspaces.go
@@ -448,6 +448,59 @@ FROM batch_spec_workspaces
 WHERE %s
 `
 
+const disableBatchSpecWorkspaceExecutionCacheQueryFmtstr = `
+WITH batch_spec AS (
+	SELECT
+		id, no_cache
+	FROM
+		batch_specs
+	WHERE
+		id = %s
+),
+candidate_batch_spec_workspaces AS (
+	SELECT
+		id, changeset_spec_ids
+	FROM
+		batch_spec_workspaces
+	WHERE
+		batch_spec_workspaces.batch_spec_id = %s
+	ORDER BY id
+),
+removable_changeset_specs AS (
+	SELECT
+		id
+	FROM
+		changeset_specs
+	WHERE
+		id IN (SELECT jsonb_object_keys(changeset_spec_ids)::bigint FROM batch_spec_workspaces)
+	ORDER BY id
+),
+removed_changeset_specs AS (
+	DELETE FROM changeset_specs
+	WHERE
+		id IN (SELECT id FROM removable_changeset_specs)
+)
+UPDATE
+	batch_spec_workspaces
+SET
+	cached_result_found = FALSE,
+	changeset_spec_ids = '{}',
+	step_cache_results = '{}'
+WHERE
+	id IN (SELECT id FROM candidate_batch_spec_workspaces)
+`
+
+// DisableBatchSpecWorkspaceExecutionCache removes caching information from workspaces prior to execution.
+func (s *Store) DisableBatchSpecWorkspaceExecutionCache(ctx context.Context, batchSpecID int64) (err error) {
+	ctx, _, endObservation := s.operations.disableBatchSpecWorkspaceExecutionCache.With(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.Int("batchSpecID", int(batchSpecID)),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	q := sqlf.Sprintf(disableBatchSpecWorkspaceExecutionCacheQueryFmtstr, batchSpecID, batchSpecID)
+	return s.Exec(ctx, q)
+}
+
 func scanBatchSpecWorkspace(wj *btypes.BatchSpecWorkspace, s dbutil.Scanner) error {
 	var stepCacheResults json.RawMessage
 

--- a/enterprise/internal/batches/store/batch_spec_workspaces_test.go
+++ b/enterprise/internal/batches/store/batch_spec_workspaces_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
+	"github.com/sourcegraph/sourcegraph/lib/batches/execution"
 )
 
 func testStoreBatchSpecWorkspaces(t *testing.T, ctx context.Context, s *Store, clock bt.Clock) {
@@ -452,5 +453,49 @@ func testStoreBatchSpecWorkspaces(t *testing.T, ctx context.Context, s *Store, c
 			require.NoError(t, err)
 			assert.Len(t, have, 1)
 		})
+	})
+
+	t.Run("DisableBatchSpecWorkspaceExecutionCache", func(t *testing.T) {
+		cs := &btypes.ChangesetSpec{}
+		require.NoError(t, s.CreateChangesetSpec(ctx, cs))
+
+		batchSpecID := int64(101010)
+		workspace := &btypes.BatchSpecWorkspace{
+			BatchSpecID:       batchSpecID,
+			RepoID:            repos[0].ID,
+			CachedResultFound: true,
+			StepCacheResults: map[int]btypes.StepCacheResult{
+				1: {
+					Key: "asdf",
+					Value: &execution.AfterStepResult{
+						StepIndex: 1,
+					},
+				},
+			},
+			ChangesetSpecIDs: []int64{cs.ID, 2, 3},
+		}
+		err := s.CreateBatchSpecWorkspace(ctx, workspace)
+		require.NoError(t, err)
+
+		require.NoError(t, s.DisableBatchSpecWorkspaceExecutionCache(ctx, batchSpecID))
+
+		want := workspace
+		want.ChangesetSpecIDs = []int64{}
+		want.StepCacheResults = map[int]btypes.StepCacheResult{}
+		want.CachedResultFound = false
+
+		have, err := s.GetBatchSpecWorkspace(ctx, GetBatchSpecWorkspaceOpts{
+			ID: workspace.ID,
+		})
+		require.NoError(t, err)
+
+		if diff := cmp.Diff(want, have); diff != "" {
+			t.Fatalf("invalid workspace state: %s", diff)
+		}
+
+		_, err = s.GetChangesetSpec(ctx, GetChangesetSpecOpts{
+			ID: cs.ID,
+		})
+		require.Error(t, err, ErrNoResults)
 	})
 }

--- a/enterprise/internal/batches/store/batch_spec_workspaces_test.go
+++ b/enterprise/internal/batches/store/batch_spec_workspaces_test.go
@@ -459,7 +459,10 @@ func testStoreBatchSpecWorkspaces(t *testing.T, ctx context.Context, s *Store, c
 		cs := &btypes.ChangesetSpec{}
 		require.NoError(t, s.CreateChangesetSpec(ctx, cs))
 
-		batchSpecID := int64(101010)
+		bc := &btypes.BatchSpec{NoCache: true, NamespaceUserID: 1}
+		require.NoError(t, s.CreateBatchSpec(ctx, bc))
+		batchSpecID := bc.ID
+
 		workspace := &btypes.BatchSpecWorkspace{
 			BatchSpecID:       batchSpecID,
 			RepoID:            repos[0].ID,

--- a/enterprise/internal/batches/store/store.go
+++ b/enterprise/internal/batches/store/store.go
@@ -271,6 +271,7 @@ type operations struct {
 	deleteBatchSpecWorkspaceExecutionJobs              *observation.Operation
 	cancelBatchSpecWorkspaceExecutionJobs              *observation.Operation
 	retryBatchSpecWorkspaceExecutionJobs               *observation.Operation
+	disableBatchSpecWorkspaceExecutionCache            *observation.Operation
 
 	createBatchSpecResolutionJob *observation.Operation
 	getBatchSpecResolutionJob    *observation.Operation
@@ -414,6 +415,7 @@ func newOperations(observationContext *observation.Context) *operations {
 			deleteBatchSpecWorkspaceExecutionJobs:              op("DeleteBatchSpecWorkspaceExecutionJobs"),
 			cancelBatchSpecWorkspaceExecutionJobs:              op("CancelBatchSpecWorkspaceExecutionJobs"),
 			retryBatchSpecWorkspaceExecutionJobs:               op("RetryBatchSpecWorkspaceExecutionJobs"),
+			disableBatchSpecWorkspaceExecutionCache:            op("DisableBatchSpecWorkspaceExecutionCache"),
 
 			createBatchSpecResolutionJob: op("CreateBatchSpecResolutionJob"),
 			getBatchSpecResolutionJob:    op("GetBatchSpecResolutionJob"),


### PR DESCRIPTION
This PR implements (finally) the no cache flag on the execute endpoint. This means that we can finally allow not refreshing the workspace preview when the checkbox is toggled. For long-running workspace resolutions (like our scaletesting) this is a gamechanger to me (maybe just me who almost always runs without cache because I test execution a lot, but hopefully also someone else 😬). 

This also changes a bit how we handle this flag as well:
We don't skip cache checking when no_cache is set anymore, so that the UI always reflects the cache status and you can simply say "don't use it" - this feels more expected to me than some checkbox that lives outside the spec that would modify the workspaces list.
So now the only thing that the workspace resolution does is setting the no_cache flag on the batch spec.
When the batch spec is executed, we check that field, or optionally overwrite it, if set in the mutation arguments.
The field on the createFromRaw,replaceInput mutations is now mostly there to forward that flag to the execute step once we have implemented `autoApply` and is not used from the UI for now.

## Test plan

Adjusted tests and made sure things work. I'd love some additional eyes on the frontend change here as the state management is _really_ complex there.