### PR TITLE
Make draft batch change explicit in database

### DIFF
--- a/client/web/src/enterprise/batches/BatchSpec.tsx
+++ b/client/web/src/enterprise/batches/BatchSpec.tsx
@@ -26,7 +26,7 @@ export const getFileName = (name: string): string => `${kebabCase(name)}.batch.y
 
 export interface BatchSpecProps extends ThemeProps {
     name: string
-    originalInput: BatchChangeFields['currentSpec']['originalInput']
+    originalInput: NonNullable<BatchChangeFields['currentSpec']>['originalInput']
     className?: string
 }
 

--- a/client/web/src/enterprise/batches/BatchSpecsPage.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecsPage.tsx
@@ -88,7 +88,6 @@ export const BatchSpecList: React.FunctionComponent<React.PropsWithChildren<Batc
                 first: args.first ?? null,
                 after: args.after ?? null,
                 includeLocallyExecutedSpecs: false,
-                excludeEmptySpecs: true,
             }
             return queryBatchSpecs(passedArguments)
         },

--- a/client/web/src/enterprise/batches/BatchSpecsPage.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecsPage.tsx
@@ -38,7 +38,7 @@ export const BatchSpecsPage: React.FunctionComponent<React.PropsWithChildren<Bat
 
 export interface BatchChangeBatchSpecListProps extends Omit<BatchSpecListProps, 'queryBatchSpecs'> {
     batchChangeID: Scalars['ID']
-    currentSpecID: Scalars['ID']
+    currentSpecID?: Scalars['ID']
     queryBatchChangeBatchSpecs?: typeof _queryBatchChangeBatchSpecs
 }
 

--- a/client/web/src/enterprise/batches/backend.ts
+++ b/client/web/src/enterprise/batches/backend.ts
@@ -17,22 +17,11 @@ export const queryBatchSpecs = ({
     first,
     after,
     includeLocallyExecutedSpecs,
-    excludeEmptySpecs,
 }: BatchSpecsVariables): Observable<BatchSpecListConnectionFields> =>
     requestGraphQL<BatchSpecsResult, BatchSpecsVariables>(
         gql`
-            query BatchSpecs(
-                $first: Int
-                $after: String
-                $includeLocallyExecutedSpecs: Boolean
-                $excludeEmptySpecs: Boolean
-            ) {
-                batchSpecs(
-                    first: $first
-                    after: $after
-                    includeLocallyExecutedSpecs: $includeLocallyExecutedSpecs
-                    excludeEmptySpecs: $excludeEmptySpecs
-                ) {
+            query BatchSpecs($first: Int, $after: String, $includeLocallyExecutedSpecs: Boolean) {
+                batchSpecs(first: $first, after: $after, includeLocallyExecutedSpecs: $includeLocallyExecutedSpecs) {
                     ...BatchSpecListConnectionFields
                 }
             }
@@ -43,7 +32,6 @@ export const queryBatchSpecs = ({
             first,
             after,
             includeLocallyExecutedSpecs,
-            excludeEmptySpecs,
         }
     ).pipe(
         map(dataOrThrowErrors),
@@ -56,7 +44,6 @@ export const queryBatchChangeBatchSpecs =
         first,
         after,
         includeLocallyExecutedSpecs,
-        excludeEmptySpecs,
     }: Omit<BatchChangeBatchSpecsVariables, 'id'>): Observable<BatchSpecListConnectionFields> =>
         requestGraphQL<BatchChangeBatchSpecsResult, BatchChangeBatchSpecsVariables>(
             gql`
@@ -65,7 +52,6 @@ export const queryBatchChangeBatchSpecs =
                     $first: Int
                     $after: String
                     $includeLocallyExecutedSpecs: Boolean
-                    $excludeEmptySpecs: Boolean
                 ) {
                     node(id: $id) {
                         __typename
@@ -74,7 +60,6 @@ export const queryBatchChangeBatchSpecs =
                                 first: $first
                                 after: $after
                                 includeLocallyExecutedSpecs: $includeLocallyExecutedSpecs
-                                excludeEmptySpecs: $excludeEmptySpecs
                             ) {
                                 ...BatchSpecListConnectionFields
                             }
@@ -89,7 +74,6 @@ export const queryBatchChangeBatchSpecs =
                 first,
                 after,
                 includeLocallyExecutedSpecs,
-                excludeEmptySpecs,
             }
         ).pipe(
             map(dataOrThrowErrors),

--- a/client/web/src/enterprise/batches/batch-spec/BatchSpecContext.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/BatchSpecContext.tsx
@@ -119,7 +119,7 @@ export const BatchSpecContextProvider = <BatchSpecFields extends MinimalBatchSpe
     const { currentSpec } = batchChange
 
     // TODO: This should probably just be a field on GraphQL.
-    const isBatchSpecApplied = useMemo(() => currentSpec.id === batchSpec.id, [currentSpec.id, batchSpec.id])
+    const isBatchSpecApplied = useMemo(() => currentSpec?.id === batchSpec.id, [currentSpec, batchSpec.id])
 
     const editor = useBatchSpecCode(batchSpec.originalInput, batchChange.name)
     const { handleCodeChange, isValid, isServerStale: isServerBatchSpecYAMLStale } = editor

--- a/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
+++ b/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
@@ -57,7 +57,7 @@ export const mockBatchChange = (batchChange?: Partial<EditBatchChangeFields>): E
 
 export const mockBatchSpec = (
     batchSpec?: Partial<EditBatchChangeFields['currentSpec']>
-): EditBatchChangeFields['currentSpec'] => ({
+): NonNullable<EditBatchChangeFields['currentSpec']> => ({
     __typename: 'BatchSpec',
     id: '1',
     state: BatchSpecState.PENDING,

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
@@ -152,7 +152,7 @@ const Template: Story<{
     isClosed?: boolean
 }> = ({ url, supersedingBatchSpec, currentBatchSpec, viewerCanAdminister, isClosed }) => {
     const batchChange: BatchChangeFields = useMemo(() => {
-        const currentSpec = currentBatchSpec ?? MOCK_BATCH_CHANGE.currentSpec
+        const currentSpec = currentBatchSpec ?? MOCK_BATCH_CHANGE.currentSpec!
 
         return {
             ...MOCK_BATCH_CHANGE,
@@ -282,7 +282,7 @@ export const UnpublishableBatchSpec = Template.bind({})
 UnpublishableBatchSpec.args = {
     url: '/users/alice/batch-changes/awesome-batch-change',
     currentBatchSpec: {
-        ...MOCK_BATCH_CHANGE.currentSpec,
+        ...MOCK_BATCH_CHANGE.currentSpec!,
         viewerBatchChangesCodeHosts: {
             __typename: 'BatchChangesCodeHostConnection',
             totalCount: 1,

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -147,13 +147,13 @@ export const BatchChangeDetailsPage: React.FunctionComponent<
                 </PageHeader.Heading>
             </PageHeader>
             <BulkOperationsAlerts location={location} bulkOperations={batchChange.activeBulkOperations} />
-            {batchChange.viewerCanAdminister && (
+            {batchChange.currentSpec && batchChange.viewerCanAdminister && (
                 <MissingCredentialsAlert
                     authenticatedUser={authenticatedUser}
                     viewerBatchChangesCodeHosts={batchChange.currentSpec.viewerBatchChangesCodeHosts}
                 />
             )}
-            {batchChange.viewerCanAdminister && (
+            {batchChange.currentSpec && batchChange.viewerCanAdminister && (
                 <SupersedingBatchSpecAlert spec={batchChange.currentSpec.supersedingBatchSpec} />
             )}
             <ActiveExecutionNotice

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -170,7 +170,12 @@ export const BatchChangeDetailsPage: React.FunctionComponent<
                 />
             )}
             <ChangesetsArchivedNotice history={history} location={location} />
-            <WebhookAlert batchChange={batchChange} />
+            {batchChange.currentSpec && (
+                <WebhookAlert
+                    batchChangeID={batchChange.id}
+                    codeHostsWithoutWebhooks={batchChange.currentSpec.codeHostsWithoutWebhooks}
+                />
+            )}
             <BatchChangeStatsCard batchChange={batchChange} className="mb-3" />
             <Description description={batchChange.description} />
             <BatchChangeDetailsTabs batchChange={batchChange} refetchBatchChange={refetch} {...props} />

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -274,7 +274,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                                 isLightTheme={isLightTheme}
                             />
                         </Container>
-                    ) : (
+                    ) : batchChange.currentSpec ? (
                         <>
                             <div className="d-flex flex-wrap justify-content-between align-items-baseline mb-2 test-batches-spec">
                                 <BatchSpecMeta
@@ -285,11 +285,13 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                                 <BatchSpecDownloadButton
                                     name={batchChange.name}
                                     isLightTheme={isLightTheme}
-                                    originalInput={batchChange.currentSpec!.originalInput}
+                                    originalInput={batchChange.currentSpec.originalInput}
                                 />
                             </div>
-                            <BatchSpecInfo spec={batchChange.currentSpec!} isLightTheme={isLightTheme} />
+                            <BatchSpecInfo spec={batchChange.currentSpec} isLightTheme={isLightTheme} />
                         </>
+                    ) : (
+                        <>No spec yet</>
                     )}
                 </TabPanel>
                 <TabPanel>

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -13,7 +13,7 @@ import { Badge, Container, Icon, Tab, TabPanel, TabPanels } from '@sourcegraph/w
 
 import { isBatchChangesExecutionEnabled } from '../../../batches'
 import { resetFilteredConnectionURLQuery } from '../../../components/FilteredConnection'
-import { BatchSpecState, BatchChangeFields, BatchSpecSource } from '../../../graphql-operations'
+import { BatchSpecState, BatchChangeFields, BatchSpecSource, BatchChangeState } from '../../../graphql-operations'
 import { BatchChangeTabList, BatchChangeTabs } from '../BatchChangeTabs'
 import { BatchSpecDownloadButton, BatchSpecMeta } from '../BatchSpec'
 import { BatchSpecInfo } from '../BatchSpecNode'
@@ -106,9 +106,11 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
         [batchChange.batchSpecs.nodes]
     )
 
-    const isBatchSpecLocallyCreated = batchChange.currentSpec.source === BatchSpecSource.LOCAL
+    const isBatchSpecLocallyCreated = batchChange.currentSpec?.source === BatchSpecSource.LOCAL
     const shouldDisplayExecutionsTab =
-        isExecutionEnabled && !isBatchSpecLocallyCreated && batchChange.viewerCanAdminister
+        isExecutionEnabled &&
+        (!isBatchSpecLocallyCreated || batchChange.state === BatchChangeState.DRAFT) &&
+        batchChange.viewerCanAdminister
 
     // We track the current tab in a URL parameter so that tabs are easy to navigate to
     // and share.
@@ -268,7 +270,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                                 history={history}
                                 location={location}
                                 batchChangeID={batchChange.id}
-                                currentSpecID={batchChange.currentSpec.id}
+                                currentSpecID={batchChange.currentSpec?.id}
                                 isLightTheme={isLightTheme}
                             />
                         </Container>
@@ -283,10 +285,10 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
                                 <BatchSpecDownloadButton
                                     name={batchChange.name}
                                     isLightTheme={isLightTheme}
-                                    originalInput={batchChange.currentSpec.originalInput}
+                                    originalInput={batchChange.currentSpec!.originalInput}
                                 />
                             </div>
-                            <BatchSpecInfo spec={batchChange.currentSpec} isLightTheme={isLightTheme} />
+                            <BatchSpecInfo spec={batchChange.currentSpec!} isLightTheme={isLightTheme} />
                         </>
                     )}
                 </TabPanel>

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -13,7 +13,7 @@ import { Badge, Container, Icon, Tab, TabPanel, TabPanels } from '@sourcegraph/w
 
 import { isBatchChangesExecutionEnabled } from '../../../batches'
 import { resetFilteredConnectionURLQuery } from '../../../components/FilteredConnection'
-import { BatchSpecState, BatchChangeFields, BatchSpecSource, BatchChangeState } from '../../../graphql-operations'
+import { BatchSpecState, BatchChangeFields, BatchSpecSource } from '../../../graphql-operations'
 import { BatchChangeTabList, BatchChangeTabs } from '../BatchChangeTabs'
 import { BatchSpecDownloadButton, BatchSpecMeta } from '../BatchSpec'
 import { BatchSpecInfo } from '../BatchSpecNode'

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -108,9 +108,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<React.PropsWithChil
 
     const isBatchSpecLocallyCreated = batchChange.currentSpec?.source === BatchSpecSource.LOCAL
     const shouldDisplayExecutionsTab =
-        isExecutionEnabled &&
-        (!isBatchSpecLocallyCreated || batchChange.state === BatchChangeState.DRAFT) &&
-        batchChange.viewerCanAdminister
+        isExecutionEnabled && !isBatchSpecLocallyCreated && batchChange.viewerCanAdminister
 
     // We track the current tab in a URL parameter so that tabs are easy to navigate to
     // and share.

--- a/client/web/src/enterprise/batches/detail/WebhookAlert.story.tsx
+++ b/client/web/src/enterprise/batches/detail/WebhookAlert.story.tsx
@@ -3,7 +3,6 @@ import { Meta, Story, DecoratorFn } from '@storybook/react'
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
 
 import { WebStory } from '../../../components/WebStory'
-import { BatchSpecSource } from '../../../graphql-operations'
 
 import { WebhookAlert } from './WebhookAlert'
 
@@ -18,61 +17,51 @@ export default config
 
 const id = new Date().toString()
 
-const currentSpec = {
-    id: 'specID1',
-    originalInput: '',
-    supersedingBatchSpec: null,
-    source: BatchSpecSource.REMOTE,
-    viewerBatchChangesCodeHosts: {
-        totalCount: 0,
-        nodes: [],
-    },
-    files: null,
-    description: {
-        __typename: 'BatchChangeDescription' as const,
-        name: 'spec with ID 1',
-    },
-}
-
-const batchChange = (totalCount: number, hasNextPage: boolean) => ({
-    id,
-    currentSpec: {
-        ...currentSpec,
-        codeHostsWithoutWebhooks: {
-            nodes: [
-                {
-                    externalServiceKind: 'GITHUB' as ExternalServiceKind,
-                    externalServiceURL: 'https://github.com/',
-                },
-                {
-                    externalServiceKind: 'GITLAB' as ExternalServiceKind,
-                    externalServiceURL: 'https://gitlab.com/',
-                },
-                {
-                    externalServiceKind: 'BITBUCKETSERVER' as ExternalServiceKind,
-                    externalServiceURL: 'https://bitbucket.org/',
-                },
-            ],
-            pageInfo: { hasNextPage },
-            totalCount,
+const codeHostsWithoutWebhooks = (totalCount: number, hasNextPage: boolean) => ({
+    nodes: [
+        {
+            externalServiceKind: 'GITHUB' as ExternalServiceKind,
+            externalServiceURL: 'https://github.com/',
         },
-    },
+        {
+            externalServiceKind: 'GITLAB' as ExternalServiceKind,
+            externalServiceURL: 'https://gitlab.com/',
+        },
+        {
+            externalServiceKind: 'BITBUCKETSERVER' as ExternalServiceKind,
+            externalServiceURL: 'https://bitbucket.org/',
+        },
+    ],
+    pageInfo: { hasNextPage },
+    totalCount,
 })
 
 export const SiteAdmin: Story = () => (
-    <WebStory>{() => <WebhookAlert batchChange={batchChange(3, false)} isSiteAdmin={true} />}</WebStory>
+    <WebStory>
+        {() => (
+            <WebhookAlert
+                batchChangeID={id}
+                codeHostsWithoutWebhooks={codeHostsWithoutWebhooks(3, false)}
+                isSiteAdmin={true}
+            />
+        )}
+    </WebStory>
 )
 
 SiteAdmin.storyName = 'Site admin'
 
 export const RegularUser: Story = () => (
-    <WebStory>{() => <WebhookAlert batchChange={batchChange(3, false)} />}</WebStory>
+    <WebStory>
+        {() => <WebhookAlert batchChangeID={id} codeHostsWithoutWebhooks={codeHostsWithoutWebhooks(3, false)} />}
+    </WebStory>
 )
 
 RegularUser.storyName = 'Regular user'
 
 export const RegularUserWithMoreThanThreeCodeHosts: Story = () => (
-    <WebStory>{() => <WebhookAlert batchChange={batchChange(4, true)} />}</WebStory>
+    <WebStory>
+        {() => <WebhookAlert batchChangeID={id} codeHostsWithoutWebhooks={codeHostsWithoutWebhooks(4, true)} />}
+    </WebStory>
 )
 
 RegularUserWithMoreThanThreeCodeHosts.storyName = 'Regular user with more than three code hosts'
@@ -81,16 +70,11 @@ export const AllCodeHostsHaveWebhooks: Story = () => (
     <WebStory>
         {() => (
             <WebhookAlert
-                batchChange={{
-                    id,
-                    currentSpec: {
-                        ...currentSpec,
-                        codeHostsWithoutWebhooks: {
-                            nodes: [],
-                            pageInfo: { hasNextPage: false },
-                            totalCount: 0,
-                        },
-                    },
+                batchChangeID={id}
+                codeHostsWithoutWebhooks={{
+                    nodes: [],
+                    pageInfo: { hasNextPage: false },
+                    totalCount: 0,
                 }}
             />
         )}

--- a/client/web/src/enterprise/batches/detail/WebhookAlert.tsx
+++ b/client/web/src/enterprise/batches/detail/WebhookAlert.tsx
@@ -13,22 +13,19 @@ import { CodeHost } from '../CodeHost'
 import styles from './WebhookAlert.module.scss'
 
 export interface Props {
-    batchChange: Pick<BatchChangeFields, 'id' | 'currentSpec'>
+    batchChangeID: BatchChangeFields['id']
+    codeHostsWithoutWebhooks: NonNullable<BatchChangeFields['currentSpec']>['codeHostsWithoutWebhooks']
 
     // isSiteAdmin is only here for storybook purposes.
     isSiteAdmin?: boolean
 }
 
 export const WebhookAlert: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
-    batchChange: {
-        id,
-        currentSpec: {
-            codeHostsWithoutWebhooks: {
-                nodes,
-                pageInfo: { hasNextPage },
-                totalCount,
-            },
-        },
+    batchChangeID: id,
+    codeHostsWithoutWebhooks: {
+        nodes,
+        pageInfo: { hasNextPage },
+        totalCount,
     },
     isSiteAdmin,
 }) => {

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.tsx
@@ -104,7 +104,7 @@ export const BatchChangeNode: React.FunctionComponent<React.PropsWithChildren<Ba
             case BatchSpecState.COMPLETED:
                 // If it hasn't been applied, we take you to the preview page. Otherwise,
                 // we just take you to the details page.
-                return node.currentSpec.id === latestExecution.id
+                return node.currentSpec?.id === latestExecution.id
                     ? node.url
                     : `${node.url}/executions/${latestExecution.id}/preview`
             default:
@@ -119,7 +119,7 @@ export const BatchChangeNode: React.FunctionComponent<React.PropsWithChildren<Ba
                 <BatchChangeStatePill
                     state={node.state}
                     latestExecutionState={node.batchSpecs.nodes[0]?.state}
-                    currentSpecID={node.currentSpec.id}
+                    currentSpecID={node.currentSpec?.id}
                     latestSpecID={latestExecution?.id}
                     className={styles.batchChangeNodePill}
                 />

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2579,6 +2579,7 @@ type BatchChange implements Node {
     """
     The user who last updated the batch change by applying a spec to this batch change.
     If the batch change hasn't been updated, the lastApplier is the initialApplier, or null if the user was deleted.
+    Also null, if the batch change is a draft.
     """
     lastApplier: User
 
@@ -2689,10 +2690,9 @@ type BatchChange implements Node {
     diffStat: DiffStat!
 
     """
-    The last batch spec applied to this batch change, or an "empty" spec if the batch
-    change has never had a spec applied.
+    The last batch spec applied to this batch change, or null if the batch change has never had a spec applied. (ie. is draft)
     """
-    currentSpec: BatchSpec!
+    currentSpec: BatchSpec
 
     """
     The bulk operations that have been run over this batch change.

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -1852,7 +1852,7 @@ extend type Query {
         """
         Exclude the empty batch specs that are initially created and applied to draft batch changes.
         """
-        excludeEmptySpecs: Boolean @deprecated(reason: "Not required anymore, these specs don't exist anymore")
+        excludeEmptySpecs: Boolean @deprecated(reason: "No longer required, as these specs don't exist anymore")
     ): BatchSpecConnection!
 
     """
@@ -2734,7 +2734,7 @@ type BatchChange implements Node {
         """
         Exclude the empty batch specs that are initially created and applied to draft batch changes.
         """
-        excludeEmptySpecs: Boolean @deprecated(reason: "Not required anymore, these specs don't exist anymore")
+        excludeEmptySpecs: Boolean @deprecated(reason: "No longer required, as these specs don't exist anymore")
     ): BatchSpecConnection!
 }
 

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -1852,7 +1852,7 @@ extend type Query {
         """
         Exclude the empty batch specs that are initially created and applied to draft batch changes.
         """
-        excludeEmptySpecs: Boolean
+        excludeEmptySpecs: Boolean @deprecated(reason: "Not required anymore, these specs don't exist anymore")
     ): BatchSpecConnection!
 
     """
@@ -2734,7 +2734,7 @@ type BatchChange implements Node {
         """
         Exclude the empty batch specs that are initially created and applied to draft batch changes.
         """
-        excludeEmptySpecs: Boolean
+        excludeEmptySpecs: Boolean @deprecated(reason: "Not required anymore, these specs don't exist anymore")
     ): BatchSpecConnection!
 }
 

--- a/dev/ci/go-backcompat/flakefiles/v4.2.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.2.0.json
@@ -56,17 +56,12 @@
   },
   {
     "path": "enterprise/cmd/frontend/internal/batches/webhooks",
-    "prefix": "WebhooksIntegration/WebhooksIntegration/GitHubWebhook",
-    "reason": "Test was having incomplete data, fails now that constraints are in place"
-  },
-  {
-    "path": "enterprise/cmd/frontend/internal/batches/webhooks",
-    "prefix": "WebhooksIntegration/WebhooksIntegration/BitbucketServerWebhook",
+    "prefix": "WebhooksIntegration",
     "reason": "Test was having incomplete data, fails now that constraints are in place"
   },
   {
     "path": "enterprise/cmd/frontend/internal/batches/resolvers",
-    "prefix": "ChangesetApplyPreviewResolverWithPublicationStates/already_published_changeset",
+    "prefix": "ChangesetApplyPreviewResolverWithPublicationStates",
     "reason": "Test was having incomplete data, fails now that constraints are in place"
   },
   {
@@ -76,7 +71,7 @@
   },
   {
     "path": "enterprise/cmd/frontend/internal/batches/resolvers",
-    "prefix": "RepositoryPermissions/BatchChange_and_changesets",
+    "prefix": "RepositoryPermissions",
     "reason": "Test was having incomplete data, fails now that constraints are in place"
   }
 ]

--- a/dev/ci/go-backcompat/flakefiles/v4.2.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.2.0.json
@@ -56,12 +56,17 @@
   },
   {
     "path": "enterprise/cmd/frontend/internal/batches/webhooks",
-    "prefix": "WebhooksIntegration",
+    "prefix": "WebhooksIntegration/WebhooksIntegration/GitHubWebhook",
+    "reason": "Test was having incomplete data, fails now that constraints are in place"
+  },
+  {
+    "path": "enterprise/cmd/frontend/internal/batches/webhooks",
+    "prefix": "WebhooksIntegration/WebhooksIntegration/BitbucketServerWebhook",
     "reason": "Test was having incomplete data, fails now that constraints are in place"
   },
   {
     "path": "enterprise/cmd/frontend/internal/batches/resolvers",
-    "prefix": "ChangesetApplyPreviewResolverWithPublicationStates",
+    "prefix": "ChangesetApplyPreviewResolverWithPublicationStates/already_published_changeset",
     "reason": "Test was having incomplete data, fails now that constraints are in place"
   },
   {
@@ -71,7 +76,7 @@
   },
   {
     "path": "enterprise/cmd/frontend/internal/batches/resolvers",
-    "prefix": "RepositoryPermissions",
+    "prefix": "RepositoryPermissions/BatchChange_and_changesets",
     "reason": "Test was having incomplete data, fails now that constraints are in place"
   }
 ]

--- a/dev/ci/go-backcompat/flakefiles/v4.2.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.2.0.json
@@ -53,5 +53,25 @@
     "path": "enterprise/internal/batches/syncer",
     "prefix": "SyncerRun/Sync_due_but_reenqueued_when_namespace_deleted",
     "reason": "Test expectation is too narrow and is broken by new logging code"
+  },
+  {
+    "path": "enterprise/cmd/frontend/internal/batches/webhooks",
+    "prefix": "WebhooksIntegration",
+    "reason": "Test was having incomplete data, fails now that constraints are in place"
+  },
+  {
+    "path": "enterprise/cmd/frontend/internal/batches/resolvers",
+    "prefix": "ChangesetApplyPreviewResolverWithPublicationStates",
+    "reason": "Test was having incomplete data, fails now that constraints are in place"
+  },
+  {
+    "path": "enterprise/cmd/frontend/internal/batches/resolvers",
+    "prefix": "ChangesetCountsOverTimeIntegration",
+    "reason": "Test was having incomplete data, fails now that constraints are in place"
+  },
+  {
+    "path": "enterprise/cmd/frontend/internal/batches/resolvers",
+    "prefix": "RepositoryPermissions",
+    "reason": "Test was having incomplete data, fails now that constraints are in place"
   }
 ]

--- a/dev/ci/go-backcompat/flakefiles/v4.2.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.2.0.json
@@ -56,22 +56,22 @@
   },
   {
     "path": "enterprise/cmd/frontend/internal/batches/webhooks",
-    "prefix": "WebhooksIntegration",
+    "prefix": "TestWebhooksIntegration",
     "reason": "Test was having incomplete data, fails now that constraints are in place"
   },
   {
     "path": "enterprise/cmd/frontend/internal/batches/resolvers",
-    "prefix": "ChangesetApplyPreviewResolverWithPublicationStates",
+    "prefix": "TestChangesetApplyPreviewResolverWithPublicationStates",
     "reason": "Test was having incomplete data, fails now that constraints are in place"
   },
   {
     "path": "enterprise/cmd/frontend/internal/batches/resolvers",
-    "prefix": "ChangesetCountsOverTimeIntegration",
+    "prefix": "TestChangesetCountsOverTimeIntegration",
     "reason": "Test was having incomplete data, fails now that constraints are in place"
   },
   {
     "path": "enterprise/cmd/frontend/internal/batches/resolvers",
-    "prefix": "RepositoryPermissions",
+    "prefix": "TestRepositoryPermissions",
     "reason": "Test was having incomplete data, fails now that constraints are in place"
   }
 ]

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
@@ -329,10 +329,6 @@ func (r *batchChangeResolver) BatchSpecs(
 		opts.IncludeLocallyExecutedSpecs = *args.IncludeLocallyExecutedSpecs
 	}
 
-	if args.ExcludeEmptySpecs != nil {
-		opts.ExcludeEmptySpecs = *args.ExcludeEmptySpecs
-	}
-
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.store.DatabaseDB()); err != nil {
 		opts.ExcludeCreatedFromRawNotOwnedByUser = actor.FromContext(ctx).UID
 	}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -35,10 +36,6 @@ type batchChangeResolver struct {
 	namespaceOnce sync.Once
 	namespace     graphqlbackend.NamespaceResolver
 	namespaceErr  error
-
-	batchSpecOnce sync.Once
-	batchSpec     *btypes.BatchSpec
-	batchSpecErr  error
 
 	canAdministerOnce sync.Once
 	canAdminister     bool
@@ -157,16 +154,6 @@ func (r *batchChangeResolver) computeNamespace(ctx context.Context) (graphqlback
 	return r.namespace, r.namespaceErr
 }
 
-func (r *batchChangeResolver) computeBatchSpec(ctx context.Context) (*btypes.BatchSpec, error) {
-	r.batchSpecOnce.Do(func() {
-		r.batchSpec, r.batchSpecErr = r.store.GetBatchSpec(ctx, store.GetBatchSpecOpts{
-			ID: r.batchChange.BatchSpecID,
-		})
-	})
-
-	return r.batchSpec, r.batchSpecErr
-}
-
 func (r *batchChangeResolver) CreatedAt() gqlutil.DateTime {
 	return gqlutil.DateTime{Time: r.batchChange.CreatedAt}
 }
@@ -277,9 +264,13 @@ func (r *batchChangeResolver) DiffStat(ctx context.Context) (*graphqlbackend.Dif
 }
 
 func (r *batchChangeResolver) CurrentSpec(ctx context.Context) (graphqlbackend.BatchSpecResolver, error) {
-	batchSpec, err := r.computeBatchSpec(ctx)
+	batchSpec, err := r.store.GetBatchSpec(ctx, store.GetBatchSpecOpts{
+		ID: r.batchChange.BatchSpecID,
+	})
 	if err != nil {
-		// This spec should always exist, so fail hard on not found errors as well.
+		if err == store.ErrNoResults {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_connection_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_change_connection_test.go
@@ -186,7 +186,7 @@ func TestBatchChangesListing(t *testing.T) {
 	userID := bt.CreateTestUser(t, db, false).ID
 	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
 
-	orgID := bt.CreateTestOrg(t, db, "org").ID
+	orgID := bt.CreateTestOrg(t, db, "org", userID).ID
 
 	store := store.New(db, &observation.TestContext, nil)
 
@@ -200,7 +200,9 @@ func TestBatchChangesListing(t *testing.T) {
 		t.Helper()
 
 		spec.UserID = userID
-		spec.NamespaceUserID = userID
+		if spec.NamespaceOrgID == 0 {
+			spec.NamespaceUserID = userID
+		}
 		if err := store.CreateBatchSpec(ctx, spec); err != nil {
 			t.Fatal(err)
 		}
@@ -218,6 +220,7 @@ func TestBatchChangesListing(t *testing.T) {
 		spec := &btypes.BatchSpec{}
 		createBatchSpec(t, spec)
 
+		// Create an open batch change.
 		batchChange := &btypes.BatchChange{
 			Name:            "batch-change-1",
 			NamespaceUserID: userID,
@@ -239,7 +242,7 @@ func TestBatchChangesListing(t *testing.T) {
 			BatchChanges: apitest.BatchChangeConnection{
 				TotalCount: 1,
 				Nodes: []apitest.BatchChange{
-					{ID: string(marshalBatchChangeID(batchChange.ID))},
+					{ID: string(marshalBatchChangeID(batchChange.ID)), State: "OPEN"},
 				},
 			},
 		}
@@ -255,7 +258,6 @@ func TestBatchChangesListing(t *testing.T) {
 		batchChange2 := &btypes.BatchChange{
 			Name:            "batch-change-2",
 			NamespaceUserID: userID,
-			BatchSpecID:     spec2.ID,
 		}
 		createBatchChange(t, batchChange2)
 
@@ -267,8 +269,8 @@ func TestBatchChangesListing(t *testing.T) {
 			BatchChanges: apitest.BatchChangeConnection{
 				TotalCount: 2,
 				Nodes: []apitest.BatchChange{
-					{ID: string(marshalBatchChangeID(batchChange2.ID))},
-					{ID: string(marshalBatchChangeID(batchChange.ID))},
+					{ID: string(marshalBatchChangeID(batchChange2.ID)), State: "DRAFT"},
+					{ID: string(marshalBatchChangeID(batchChange.ID)), State: "OPEN"},
 				},
 			},
 		}
@@ -299,7 +301,9 @@ func TestBatchChangesListing(t *testing.T) {
 	})
 
 	t.Run("listing an orgs batch changes", func(t *testing.T) {
-		spec := &btypes.BatchSpec{}
+		spec := &btypes.BatchSpec{
+			NamespaceOrgID: orgID,
+		}
 		createBatchSpec(t, spec)
 
 		batchChange := &btypes.BatchChange{
@@ -323,7 +327,7 @@ func TestBatchChangesListing(t *testing.T) {
 			BatchChanges: apitest.BatchChangeConnection{
 				TotalCount: 1,
 				Nodes: []apitest.BatchChange{
-					{ID: string(marshalBatchChangeID(batchChange.ID))},
+					{ID: string(marshalBatchChangeID(batchChange.ID)), State: "OPEN"},
 				},
 			},
 		}
@@ -332,18 +336,18 @@ func TestBatchChangesListing(t *testing.T) {
 			t.Fatalf("wrong batch change response (-want +got):\n%s", diff)
 		}
 
-		spec2 := &btypes.BatchSpec{UserID: userID}
-		createBatchSpec(t, spec2)
-
 		// This batch change has never been applied -- it is a draft.
 		batchChange2 := &btypes.BatchChange{
 			Name:           "batch-change-2",
 			NamespaceOrgID: orgID,
-			BatchSpecID:    spec2.ID,
+			CreatorID:      userID,
 		}
 		createBatchChange(t, batchChange2)
 
-		// DRAFTS CASE 1: USERS CAN VIEW THEIR OWN DRAFTS.
+		spec2 := &btypes.BatchSpec{UserID: userID, BatchChangeID: batchChange2.ID}
+		createBatchSpec(t, spec2)
+
+		// DRAFTS CASE 1: USERS CAN VIEW DRAFTS IN ORGS THEY'RE PART OF.
 		apitest.MustExec(actorCtx, t, s, input, &response, listNamespacesBatchChanges)
 
 		wantBoth := apitest.Org{
@@ -351,8 +355,8 @@ func TestBatchChangesListing(t *testing.T) {
 			BatchChanges: apitest.BatchChangeConnection{
 				TotalCount: 2,
 				Nodes: []apitest.BatchChange{
-					{ID: string(marshalBatchChangeID(batchChange2.ID))},
-					{ID: string(marshalBatchChangeID(batchChange.ID))},
+					{ID: string(marshalBatchChangeID(batchChange2.ID)), State: "DRAFT"},
+					{ID: string(marshalBatchChangeID(batchChange.ID)), State: "OPEN"},
 				},
 			},
 		}
@@ -371,7 +375,7 @@ func TestBatchChangesListing(t *testing.T) {
 			t.Fatalf("wrong batch change response (-want +got):\n%s", diff)
 		}
 
-		// DRAFTS CASE 3: NON-ADMIN USERS CANNOT VIEW OTHER USERS' DRAFTS.
+		// DRAFTS CASE 3: NON-ADMIN USERS CANNOT VIEW DRAFTS IN ORGS THEY'RE NOT PART OF.
 		otherUserID := bt.CreateTestUser(t, db, false).ID
 		otherActorCtx := actor.WithActor(ctx, actor.FromUser(otherUserID))
 
@@ -392,6 +396,7 @@ query($node: ID!) {
         totalCount
         nodes {
           id
+          state
         }
       }
     }
@@ -402,6 +407,7 @@ query($node: ID!) {
         totalCount
         nodes {
           id
+          state
         }
       }
     }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_connection.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_connection.go
@@ -41,7 +41,6 @@ func (r *batchSpecConnectionResolver) TotalCount(ctx context.Context) (int32, er
 		BatchChangeID:                       r.opts.BatchChangeID,
 		ExcludeCreatedFromRawNotOwnedByUser: r.opts.ExcludeCreatedFromRawNotOwnedByUser,
 		IncludeLocallyExecutedSpecs:         r.opts.IncludeLocallyExecutedSpecs,
-		ExcludeEmptySpecs:                   r.opts.ExcludeEmptySpecs,
 	})
 	return int32(count), err
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_test.go
@@ -349,7 +349,7 @@ func TestChangesetApplyPreviewResolverWithPublicationStates(t *testing.T) {
 		// The set up on this is pretty similar to the previous test case, but
 		// with the extra step of then modifying the relevant changeset to make
 		// it look like it's been published.
-		createdFx := newApplyPreviewTestFixture(t, ctx, bstore, userID, repo.ID, "already published")
+		createdFx := newApplyPreviewTestFixture(t, ctx, bstore, userID, repo.ID, "already-published")
 
 		// Apply the batch spec so we have an existing batch change.
 		svc := service.New(bstore)
@@ -376,7 +376,7 @@ func TestChangesetApplyPreviewResolverWithPublicationStates(t *testing.T) {
 		}
 
 		// Now we need a fresh batch spec.
-		newFx := newApplyPreviewTestFixture(t, ctx, bstore, userID, repo.ID, "already published")
+		newFx := newApplyPreviewTestFixture(t, ctx, bstore, userID, repo.ID, "already-published")
 
 		// We need to modify the changeset spec to not have a published field.
 		newFx.specPublished.Published = batches.PublishedValue{Val: nil}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
@@ -151,7 +151,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 	}
 
 	batchChange := &btypes.BatchChange{
-		Name:            "Test batch change",
+		Name:            "Test-batch-change",
 		Description:     "Testing changeset counts",
 		CreatorID:       userID,
 		NamespaceUserID: userID,

--- a/enterprise/cmd/frontend/internal/batches/resolvers/errors.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/errors.go
@@ -36,6 +36,16 @@ func (e ErrBatchChangesDisabledForUser) Extensions() map[string]any {
 	return map[string]any{"code": "ErrBatchChangesDisabledForUser"}
 }
 
+type ErrBatchChangeInvalidName struct{ error }
+
+func (e ErrBatchChangeInvalidName) Error() string {
+	return "The batch change name can only contain word characters, dots and dashes."
+}
+
+func (e ErrBatchChangeInvalidName) Extensions() map[string]any {
+	return map[string]any{"code": "ErrBatchChangeInvalidName"}
+}
+
 // ErrBatchChangesUnlicensed wraps an underlying licensing.featureNotActivatedError
 // to add an error code.
 type ErrBatchChangesUnlicensed struct{ error }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/permissions_test.go
@@ -1424,7 +1424,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		}
 
 		batchChange := &btypes.BatchChange{
-			Name:            "my batch change",
+			Name:            "my-batch-change",
 			CreatorID:       userID,
 			NamespaceUserID: userID,
 			LastApplierID:   userID,

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -1514,10 +1514,6 @@ func (r *Resolver) BatchSpecs(ctx context.Context, args *graphqlbackend.ListBatc
 		opts.IncludeLocallyExecutedSpecs = *args.IncludeLocallyExecutedSpecs
 	}
 
-	if args.ExcludeEmptySpecs != nil {
-		opts.ExcludeEmptySpecs = *args.ExcludeEmptySpecs
-	}
-
 	// 🚨 SECURITY: If the user is not an admin, we don't want to include
 	// BatchSpecs that were created with CreateBatchSpecFromRaw and not owned
 	// by the user

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -1554,8 +1554,11 @@ func (r *Resolver) CreateEmptyBatchChange(ctx context.Context, args *graphqlback
 		NamespaceOrgID:  oid,
 		Name:            args.Name,
 	})
-
 	if err != nil {
+		// Render pretty error.
+		if err == store.ErrInvalidBatchChangeName {
+			return nil, ErrBatchChangeInvalidName{}
+		}
 		return nil, err
 	}
 

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver_test.go
@@ -121,7 +121,7 @@ func testBitbucketServerWebhook(db database.DB, userID int32) func(*testing.T) {
 		}
 
 		batchChange := &btypes.BatchChange{
-			Name:            "Test batch change",
+			Name:            "Test-batch-change",
 			Description:     "Testing THE WEBHOOKS",
 			CreatorID:       userID,
 			NamespaceUserID: userID,

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -116,7 +116,7 @@ func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 		}
 
 		batchChange := &btypes.BatchChange{
-			Name:            "Test batch changes",
+			Name:            "Test-batch-changes",
 			Description:     "Testing THE WEBHOOKS",
 			CreatorID:       userID,
 			NamespaceUserID: userID,

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go/log"
-	"gopkg.in/yaml.v2"
 
 	sglog "github.com/sourcegraph/log"
 
@@ -27,7 +26,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 	"github.com/sourcegraph/sourcegraph/lib/batches/template"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -170,61 +168,30 @@ func (s *Service) CreateEmptyBatchChange(ctx context.Context, opts CreateEmptyBa
 		return nil, err
 	}
 
-	// Construct and parse the batch spec YAML of just the provided name to validate the
-	// pattern of the name is okay
-	rawSpec, err := yaml.Marshal(struct {
-		Name string `yaml:"name"`
-	}{Name: opts.Name})
-	if err != nil {
-		return nil, errors.Wrap(err, "marshalling name")
-	}
-	// TODO: Should name require a minimum length?
-	spec, err := batcheslib.ParseBatchSpec(rawSpec)
-	if err != nil {
-		return nil, err
-	}
-
-	actor := actor.FromContext(ctx)
-	// Actor is guaranteed to be set here, because CheckNamespaceAccess above enforces it.
-
-	batchSpec := &btypes.BatchSpec{
-		RawSpec:         string(rawSpec),
-		Spec:            spec,
-		NamespaceUserID: opts.NamespaceUserID,
-		NamespaceOrgID:  opts.NamespaceOrgID,
-		UserID:          actor.UID,
-		CreatedFromRaw:  true,
-	}
-
 	// The combination of name + namespace must be unique
 	// TODO: Should name be case-insensitive unique? i.e. should "foo" and "Foo"
 	// be considered unique?
-	batchChange, err = s.GetBatchChangeMatchingBatchSpec(ctx, batchSpec)
-	if err != nil {
+	batchChange, err = s.store.GetBatchChange(ctx, store.GetBatchChangeOpts{
+		NamespaceUserID: opts.NamespaceUserID,
+		NamespaceOrgID:  opts.NamespaceOrgID,
+		Name:            opts.Name,
+	})
+	if err != nil && err != store.ErrNoResults {
 		return nil, err
-	}
-	if batchChange != nil {
+	} else if batchChange != nil {
 		return nil, ErrNameNotUnique
 	}
 
-	tx, err := s.store.Transact(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { err = tx.Done(err) }()
-
-	if err := tx.CreateBatchSpec(ctx, batchSpec); err != nil {
-		return nil, err
-	}
+	actor := actor.FromContext(ctx)
 
 	batchChange = &btypes.BatchChange{
 		Name:            opts.Name,
 		NamespaceUserID: opts.NamespaceUserID,
 		NamespaceOrgID:  opts.NamespaceOrgID,
-		BatchSpecID:     batchSpec.ID,
 		CreatorID:       actor.UID,
+		// Note: No batch spec id, meaning it's a draft batch change.
 	}
-	if err := tx.CreateBatchChange(ctx, batchChange); err != nil {
+	if err := s.store.CreateBatchChange(ctx, batchChange); err != nil {
 		return nil, err
 	}
 
@@ -249,56 +216,17 @@ func (s *Service) UpsertEmptyBatchChange(ctx context.Context, opts UpsertEmptyBa
 		return nil, err
 	}
 
-	// Construct and parse the batch spec YAML of just the provided name to validate the
-	// pattern of the name is okay
-	rawSpec, err := yaml.Marshal(struct {
-		Name string `yaml:"name"`
-	}{Name: opts.Name})
-	if err != nil {
-		return nil, errors.Wrap(err, "marshalling name")
-	}
-
-	spec, err := batcheslib.ParseBatchSpec(rawSpec)
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = template.ValidateBatchSpecTemplate(string(rawSpec))
-	if err != nil {
-		return nil, err
-	}
-
-	actor := actor.FromContext(ctx)
 	// Actor is guaranteed to be set here, because CheckNamespaceAccess above enforces it.
-
-	batchSpec := &btypes.BatchSpec{
-		RawSpec:         string(rawSpec),
-		Spec:            spec,
-		NamespaceUserID: opts.NamespaceUserID,
-		NamespaceOrgID:  opts.NamespaceOrgID,
-		UserID:          actor.UID,
-		CreatedFromRaw:  true,
-	}
-
-	tx, err := s.store.Transact(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { err = tx.Done(err) }()
-
-	if err := tx.CreateBatchSpec(ctx, batchSpec); err != nil {
-		return nil, err
-	}
+	actor := actor.FromContext(ctx)
 
 	batchChange := &btypes.BatchChange{
 		Name:            opts.Name,
 		NamespaceUserID: opts.NamespaceUserID,
 		NamespaceOrgID:  opts.NamespaceOrgID,
-		BatchSpecID:     batchSpec.ID,
 		CreatorID:       actor.UID,
 	}
 
-	err = tx.UpsertBatchChange(ctx, batchChange)
+	err = s.store.UpsertBatchChange(ctx, batchChange)
 
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -157,7 +157,7 @@ type CreateEmptyBatchChangeOpts struct {
 	Name string
 }
 
-// CreateEmptyBatchChange creates a new batch change with an empty batch spec. It enforces
+// CreateEmptyBatchChange creates a new batch change without an applied spec. It enforces
 // namespace permissions of the caller and validates that the combination of name +
 // namespace is unique.
 func (s *Service) CreateEmptyBatchChange(ctx context.Context, opts CreateEmptyBatchChangeOpts) (batchChange *btypes.BatchChange, err error) {
@@ -168,7 +168,7 @@ func (s *Service) CreateEmptyBatchChange(ctx context.Context, opts CreateEmptyBa
 		return nil, err
 	}
 
-	// The combination of name + namespace must be unique
+	// The combination of name + namespace must be unique.
 	// TODO: Should name be case-insensitive unique? i.e. should "foo" and "Foo"
 	// be considered unique?
 	batchChange, err = s.store.GetBatchChange(ctx, store.GetBatchChangeOpts{

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -2138,14 +2138,14 @@ changesetTemplate:
 		})
 
 		t.Run("batch spec associated with draft batch change", func(t *testing.T) {
-			spec := testBatchSpec(admin.ID)
-			if err := s.CreateBatchSpec(ctx, spec); err != nil {
+			batchChange := testDraftBatchChange(admin.ID)
+			if err := s.CreateBatchChange(ctx, batchChange); err != nil {
 				t.Fatal(err)
 			}
 
-			// Associate with draft batch change
-			batchChange := testDraftBatchChange(spec.UserID, spec)
-			if err := s.CreateBatchChange(ctx, batchChange); err != nil {
+			spec := testBatchSpec(admin.ID)
+			spec.BatchChangeID = batchChange.ID
+			if err := s.CreateBatchSpec(ctx, spec); err != nil {
 				t.Fatal(err)
 			}
 
@@ -2437,14 +2437,14 @@ changesetTemplate:
 		})
 
 		t.Run("batch spec associated with draft batch change", func(t *testing.T) {
-			spec := testBatchSpec(admin.ID)
-			if err := s.CreateBatchSpec(ctx, spec); err != nil {
+			batchChange := testDraftBatchChange(admin.ID)
+			if err := s.CreateBatchChange(ctx, batchChange); err != nil {
 				t.Fatal(err)
 			}
 
-			// Associate with draft batch change
-			batchChange := testDraftBatchChange(spec.UserID, spec)
-			if err := s.CreateBatchChange(ctx, batchChange); err != nil {
+			spec := testBatchSpec(admin.ID)
+			spec.BatchChangeID = batchChange.ID
+			if err := s.CreateBatchSpec(ctx, spec); err != nil {
 				t.Fatal(err)
 			}
 
@@ -3040,8 +3040,8 @@ func testBatchChange(user int32, spec *btypes.BatchSpec) *btypes.BatchChange {
 	return c
 }
 
-func testDraftBatchChange(user int32, spec *btypes.BatchSpec) *btypes.BatchChange {
-	bc := testBatchChange(user, spec)
+func testDraftBatchChange(user int32) *btypes.BatchChange {
+	bc := testBatchChange(user, &btypes.BatchSpec{})
 	bc.LastAppliedAt = time.Time{}
 	bc.CreatorID = 0
 	bc.LastApplierID = 0

--- a/enterprise/internal/batches/store/batch_changes.go
+++ b/enterprise/internal/batches/store/batch_changes.go
@@ -134,7 +134,6 @@ func (s *Store) upsertBatchChangeQuery(c *btypes.BatchChange) *sqlf.Query {
 		c.CreatedAt,
 		c.UpdatedAt,
 		dbutil.NullTimeColumn(c.ClosedAt),
-		// TODO: Why is this in here twice
 		dbutil.NullInt64Column(c.BatchSpecID),
 		sqlf.Join(batchChangeColumns, ", "),
 	)

--- a/enterprise/internal/batches/store/batch_changes.go
+++ b/enterprise/internal/batches/store/batch_changes.go
@@ -337,8 +337,8 @@ func countBatchChangesQuery(opts *CountBatchChangesOpts, repoAuthzConds *sqlf.Qu
 			preds = append(preds, sqlf.Sprintf("batch_changes.batch_spec_id IS NOT NULL"))
 		}
 		// For batch changes filtered by org namespace, or not filtered by namespace at
-		// all, if I can't see other users' drafts, filter out unapplied (draft) batch
-		// changes except those that I authored the batch spec of from this list.
+		// all, I can't see other users' drafts, so filter out unapplied (draft) batch
+		// changes except those that I created from this list.
 	} else if opts.ExcludeDraftsNotOwnedByUserID != 0 {
 		cond := sqlf.Sprintf(`(
 	batch_changes.batch_spec_id IS NOT NULL
@@ -664,8 +664,8 @@ func listBatchChangesQuery(opts *ListBatchChangesOpts, repoAuthzConds *sqlf.Quer
 			preds = append(preds, sqlf.Sprintf("batch_changes.batch_spec_id IS NOT NULL"))
 		}
 		// For batch changes filtered by org namespace, or not filtered by namespace at
-		// all, if I can't see other users' drafts, filter out unapplied (draft) batch
-		// changes except those that I authored from this list.
+		// all, I can't see other users' drafts, so filter out unapplied (draft) batch
+		// changes except those that I created from this list.
 	} else if opts.ExcludeDraftsNotOwnedByUserID != 0 {
 		cond := sqlf.Sprintf(`(
 	batch_changes.batch_spec_id IS NOT NULL

--- a/enterprise/internal/batches/store/batch_specs.go
+++ b/enterprise/internal/batches/store/batch_specs.go
@@ -186,7 +186,6 @@ type CountBatchSpecsOpts struct {
 
 	ExcludeCreatedFromRawNotOwnedByUser int32
 	IncludeLocallyExecutedSpecs         bool
-	ExcludeEmptySpecs                   bool
 }
 
 // CountBatchSpecs returns the number of code mods in the database.
@@ -228,11 +227,6 @@ ON
 
 	if !opts.IncludeLocallyExecutedSpecs {
 		preds = append(preds, sqlf.Sprintf("batch_specs.created_from_raw IS TRUE"))
-	}
-
-	if opts.ExcludeEmptySpecs {
-		// An empty batch spec's YAML only contains the name, so we filter to batch specs that have at least one key other than "name"
-		preds = append(preds, sqlf.Sprintf("(EXISTS (SELECT * FROM jsonb_object_keys(batch_specs.spec) AS t (k) WHERE t.k NOT LIKE 'name'))"))
 	}
 
 	if len(preds) == 0 {
@@ -387,7 +381,6 @@ type ListBatchSpecsOpts struct {
 
 	ExcludeCreatedFromRawNotOwnedByUser int32
 	IncludeLocallyExecutedSpecs         bool
-	ExcludeEmptySpecs                   bool
 }
 
 // ListBatchSpecs lists BatchSpecs with the given filters.
@@ -445,11 +438,6 @@ ON
 
 	if !opts.IncludeLocallyExecutedSpecs {
 		preds = append(preds, sqlf.Sprintf("batch_specs.created_from_raw IS TRUE"))
-	}
-
-	if opts.ExcludeEmptySpecs {
-		// An empty batch spec's YAML only contains the name, so we filter to batch specs that have at least one key other than "name"
-		preds = append(preds, sqlf.Sprintf("(EXISTS (SELECT * FROM jsonb_object_keys(batch_specs.spec) AS t (k) WHERE t.k NOT LIKE 'name'))"))
 	}
 
 	if opts.NewestFirst {

--- a/enterprise/internal/batches/store/batch_specs_test.go
+++ b/enterprise/internal/batches/store/batch_specs_test.go
@@ -140,20 +140,6 @@ func testStoreBatchSpecs(t *testing.T, ctx context.Context, s *Store, clock bt.C
 			}
 		})
 
-		t.Run("ExcludeEmptySpecs", func(t *testing.T) {
-			count, err := s.CountBatchSpecs(ctx, CountBatchSpecsOpts{
-				ExcludeEmptySpecs:           true,
-				IncludeLocallyExecutedSpecs: true,
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if have, want := count, len(batchSpecs)-1; have != want {
-				t.Fatalf("have count: %d, want: %d", have, want)
-			}
-		})
-
 		t.Run("ExcludeCreatedFromRawNotOwnedByUser", func(t *testing.T) {
 			for _, spec := range batchSpecs {
 				if spec.CreatedFromRaw {
@@ -387,26 +373,6 @@ func testStoreBatchSpecs(t *testing.T, ctx context.Context, s *Store, clock bt.C
 			}
 
 			if diff := cmp.Diff(have, batchSpecs); diff != "" {
-				t.Fatalf("opts: %+v, diff: %s", opts, diff)
-			}
-		})
-
-		t.Run("ExcludeEmptySpecs", func(t *testing.T) {
-			opts := ListBatchSpecsOpts{
-				ExcludeEmptySpecs:           true,
-				IncludeLocallyExecutedSpecs: true,
-			}
-			have, _, err := s.ListBatchSpecs(ctx, opts)
-			if err != nil {
-				t.Fatal(err)
-			}
-			// The third batch spec is the empty one
-			want := make([]*btypes.BatchSpec, 0, 4)
-			want = append(want, batchSpecs[0])
-			want = append(want, batchSpecs[1])
-			want = append(want, batchSpecs[3])
-
-			if diff := cmp.Diff(have, want); diff != "" {
 				t.Fatalf("opts: %+v, diff: %s", opts, diff)
 			}
 		})

--- a/enterprise/internal/batches/store/changeset_specs_test.go
+++ b/enterprise/internal/batches/store/changeset_specs_test.go
@@ -570,7 +570,7 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, clock 
 
 			if tc.batchSpecApplied {
 				batchChange := &btypes.BatchChange{
-					Name:            fmt.Sprintf("batch change for spec %d", batchSpec.ID),
+					Name:            fmt.Sprintf("batch-change-for-spec-%d", batchSpec.ID),
 					BatchSpecID:     batchSpec.ID,
 					CreatorID:       batchSpec.UserID,
 					NamespaceUserID: batchSpec.NamespaceUserID,

--- a/enterprise/internal/batches/types/batch_change.go
+++ b/enterprise/internal/batches/types/batch_change.go
@@ -47,7 +47,7 @@ func (c *BatchChange) Closed() bool { return !c.ClosedAt.IsZero() }
 // IsDraft returns true when the BatchChange is a draft ("shallow") Batch
 // Change, i.e. it's associated with a BatchSpec but it hasn't been applied
 // yet.
-func (c *BatchChange) IsDraft() bool { return c.LastAppliedAt.IsZero() }
+func (c *BatchChange) IsDraft() bool { return c.BatchSpecID == 0 }
 
 // ToGraphQL returns the GraphQL representation of the state.
 func (s BatchChangeState) ToGraphQL() string { return strings.ToUpper(string(s)) }

--- a/enterprise/internal/batches/types/batch_change.go
+++ b/enterprise/internal/batches/types/batch_change.go
@@ -44,9 +44,8 @@ func (c *BatchChange) Clone() *BatchChange {
 // Closed returns true when the ClosedAt timestamp has been set.
 func (c *BatchChange) Closed() bool { return !c.ClosedAt.IsZero() }
 
-// IsDraft returns true when the BatchChange is a draft ("shallow") Batch
-// Change, i.e. it's associated with a BatchSpec but it hasn't been applied
-// yet.
+// IsDraft returns true when the BatchChange is a draft batch change, i.e. has no
+// applied batch spec yet.
 func (c *BatchChange) IsDraft() bool { return c.BatchSpecID == 0 }
 
 // ToGraphQL returns the GraphQL representation of the state.

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -1228,7 +1228,7 @@
           "Name": "batch_spec_id",
           "Index": 10,
           "TypeName": "bigint",
-          "IsNullable": false,
+          "IsNullable": true,
           "Default": "",
           "CharacterMaximumLength": 0,
           "IsIdentity": false,
@@ -1434,6 +1434,13 @@
         }
       ],
       "Constraints": [
+        {
+          "Name": "batch_change_name_is_valid",
+          "ConstraintType": "c",
+          "RefTableName": "",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "CHECK (name ~ '^[\\w.-]+$'::text)"
+        },
         {
           "Name": "batch_changes_batch_spec_id_fkey",
           "ConstraintType": "f",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -51,7 +51,7 @@ Foreign-key constraints:
  created_at        | timestamp with time zone |           | not null | now()
  updated_at        | timestamp with time zone |           | not null | now()
  closed_at         | timestamp with time zone |           |          | 
- batch_spec_id     | bigint                   |           | not null | 
+ batch_spec_id     | bigint                   |           |          | 
  last_applier_id   | bigint                   |           |          | 
  last_applied_at   | timestamp with time zone |           |          | 
 Indexes:
@@ -61,6 +61,7 @@ Indexes:
     "batch_changes_namespace_org_id" btree (namespace_org_id)
     "batch_changes_namespace_user_id" btree (namespace_user_id)
 Check constraints:
+    "batch_change_name_is_valid" CHECK (name ~ '^[\w.-]+$'::text)
     "batch_changes_has_1_namespace" CHECK ((namespace_user_id IS NULL) <> (namespace_org_id IS NULL))
     "batch_changes_name_not_blank" CHECK (name <> ''::text)
 Foreign-key constraints:

--- a/migrations/frontend/1669576792_make_batch_spec_of_batch_change_nullable/down.sql
+++ b/migrations/frontend/1669576792_make_batch_spec_of_batch_change_nullable/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE batch_changes ALTER COLUMN batch_spec_id SET NOT NULL;

--- a/migrations/frontend/1669576792_make_batch_spec_of_batch_change_nullable/metadata.yaml
+++ b/migrations/frontend/1669576792_make_batch_spec_of_batch_change_nullable/metadata.yaml
@@ -1,0 +1,2 @@
+name: Make batch spec of batch change nullable
+parents: [1669184869]

--- a/migrations/frontend/1669576792_make_batch_spec_of_batch_change_nullable/up.sql
+++ b/migrations/frontend/1669576792_make_batch_spec_of_batch_change_nullable/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE batch_changes ALTER COLUMN batch_spec_id DROP NOT NULL;

--- a/migrations/frontend/1669576792_make_batch_spec_of_batch_change_nullable/up.sql
+++ b/migrations/frontend/1669576792_make_batch_spec_of_batch_change_nullable/up.sql
@@ -1,1 +1,4 @@
+-- Delete existing empty batch specs.
+DELETE FROM batch_specs WHERE id IN (SELECT batch_spec_id FROM batch_changes WHERE batch_spec_id IS NOT NULL AND last_applied_at IS NULL);
+
 ALTER TABLE batch_changes ALTER COLUMN batch_spec_id DROP NOT NULL;

--- a/migrations/frontend/1669645608_make_batch_change_name_pattern/down.sql
+++ b/migrations/frontend/1669645608_make_batch_change_name_pattern/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE batch_changes DROP CONSTRAINT IF EXISTS batch_change_name_is_valid;

--- a/migrations/frontend/1669645608_make_batch_change_name_pattern/metadata.yaml
+++ b/migrations/frontend/1669645608_make_batch_change_name_pattern/metadata.yaml
@@ -1,0 +1,2 @@
+name: Make batch change name pattern
+parents: [1669576792]

--- a/migrations/frontend/1669645608_make_batch_change_name_pattern/up.sql
+++ b/migrations/frontend/1669645608_make_batch_change_name_pattern/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE batch_changes DROP CONSTRAINT IF EXISTS batch_change_name_is_valid;
+ALTER TABLE batch_changes ADD CONSTRAINT batch_change_name_is_valid CHECK (name ~ '^[\w.-]+$');

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -821,9 +821,10 @@ CREATE TABLE batch_changes (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     closed_at timestamp with time zone,
-    batch_spec_id bigint NOT NULL,
+    batch_spec_id bigint,
     last_applier_id bigint,
     last_applied_at timestamp with time zone,
+    CONSTRAINT batch_change_name_is_valid CHECK ((name ~ '^[\w.-]+$'::text)),
     CONSTRAINT batch_changes_has_1_namespace CHECK (((namespace_user_id IS NULL) <> (namespace_org_id IS NULL))),
     CONSTRAINT batch_changes_name_not_blank CHECK ((name <> ''::text))
 );


### PR DESCRIPTION
Instead of looking at last_applied_at, we should just make it nullable. This also solves the weird "empty batch spec" appearing in the executions list.



## Test plan

Adjusted test suites and manually went through workflows, would appreciate an extra set of eyes. Also won't merge this before branch cut.