### PR TITLE
Remove GH App linked accounts implementation

### DIFF
--- a/cmd/frontend/graphqlbackend/external_account.go
+++ b/cmd/frontend/graphqlbackend/external_account.go
@@ -72,7 +72,7 @@ func (r *externalAccountResolver) AccountData(ctx context.Context) (*JSONValue, 
 	// Therefore, the site admins and the user can view account data of GitHub and
 	// GitLab, but only site admins can view account data for all other types.
 	var err error
-	if r.account.ServiceType == extsvc.TypeGitHub || r.account.ServiceType == extsvc.TypeGitLab || r.account.ServiceType == extsvc.TypeGitHubApp {
+	if r.account.ServiceType == extsvc.TypeGitHub || r.account.ServiceType == extsvc.TypeGitLab {
 		err = auth.CheckSiteAdminOrSameUser(ctx, r.db, actor.FromContext(ctx).UID)
 	} else {
 		err = auth.CheckUserIsSiteAdmin(ctx, r.db, actor.FromContext(ctx).UID)

--- a/cmd/frontend/graphqlbackend/external_accounts.go
+++ b/cmd/frontend/graphqlbackend/external_accounts.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/graph-gophers/graphql-go"
@@ -130,29 +129,6 @@ func (r *schemaResolver) DeleteExternalAccount(ctx context.Context, args *struct
 	// 🚨 SECURITY: Only the user and site admins should be able to see a user's external accounts.
 	if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, account.UserID); err != nil {
 		return nil, err
-	}
-
-	if account.ServiceType == extsvc.TypeGitHub {
-		opts := database.ExternalAccountsListOptions{
-			ServiceType:   extsvc.TypeGitHubApp,
-			AccountIDLike: fmt.Sprintf("%%/%s", account.AccountID),
-		}
-		accts, err := r.db.UserExternalAccounts().List(ctx, opts)
-		if err != nil {
-			return nil, err
-		}
-
-		if len(accts) > 0 {
-			var acctList []int32
-			for _, acct := range accts {
-				acctList = append(acctList, acct.ID)
-			}
-
-			deleteOpts := database.ExternalAccountsDeleteOptions{IDs: acctList}
-			if err := r.db.UserExternalAccounts().Delete(ctx, deleteOpts); err != nil {
-				return nil, err
-			}
-		}
 	}
 
 	deleteOpts := database.ExternalAccountsDeleteOptions{IDs: []int32{account.ID}}

--- a/cmd/frontend/graphqlbackend/external_accounts_test.go
+++ b/cmd/frontend/graphqlbackend/external_accounts_test.go
@@ -24,40 +24,8 @@ func TestExternalAccounts_DeleteExternalAccount(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	t.Run("has github and github app accounts", func(t *testing.T) {
-		db := database.NewDB(logger, dbtest.NewDB(logger, t))
-		act := actor.Actor{UID: 1}
-		ctx := actor.WithActor(context.Background(), &act)
-		sr := newSchemaResolver(db, gitserver.NewClient(db))
 
-		spec := extsvc.AccountSpec{
-			ServiceType: extsvc.TypeGitHub,
-			ServiceID:   "xb",
-			ClientID:    "xc",
-			AccountID:   "xd",
-		}
-
-		userID, err := db.UserExternalAccounts().CreateUserAndSave(ctx, database.NewUser{Username: "u"}, spec, extsvc.AccountData{})
-		require.NoError(t, err)
-		spec.ServiceType = extsvc.TypeGitHubApp
-		spec.AccountID = "abc/xd"
-		err = db.UserExternalAccounts().Insert(ctx, userID, spec, extsvc.AccountData{})
-		require.NoError(t, err)
-
-		graphqlArgs := struct {
-			ExternalAccount graphql.ID
-		}{
-			ExternalAccount: graphql.ID(base64.URLEncoding.EncodeToString([]byte("ExternalAccount:1"))),
-		}
-		_, err = sr.DeleteExternalAccount(ctx, &graphqlArgs)
-		require.NoError(t, err)
-
-		accts, err := db.UserExternalAccounts().List(ctx, database.ExternalAccountsListOptions{UserID: 1})
-		require.NoError(t, err)
-		require.Equal(t, 0, len(accts))
-	})
-
-	t.Run("has github account but no github app accounts", func(t *testing.T) {
+	t.Run("has github account", func(t *testing.T) {
 		db := database.NewDB(logger, dbtest.NewDB(logger, t))
 		act := actor.Actor{UID: 1}
 		ctx := actor.WithActor(context.Background(), &act)
@@ -85,5 +53,4 @@ func TestExternalAccounts_DeleteExternalAccount(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 0, len(accts))
 	})
-
 }

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/session.go
@@ -127,39 +127,6 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 			CreateIfNotExist:    attempt.createIfNotExist,
 		})
 		if err == nil {
-			// Check if GitHub App access token
-			if githubsvc.IsGitHubAppAccessToken(token.AccessToken) {
-				installations, err := ghClient.GetUserInstallations(ctx)
-				if err != nil {
-					// Only log a warning, since we still want to create the user account
-					// even if we fail to get installations.
-					log15.Warn("Could not get GitHub App installations", "error", err)
-				}
-				for _, installation := range installations {
-					accountID := strconv.FormatInt(*installation.ID, 10) + "/" + strconv.FormatInt(derefInt64(ghUser.ID), 10)
-					_, _, err := auth.GetAndSaveUser(ctx, s.db, auth.GetAndSaveUserOp{
-						UserProps: database.NewUser{
-							Username:        login,
-							Email:           attempt.email,
-							EmailIsVerified: true,
-							DisplayName:     deref(ghUser.Name),
-							AvatarURL:       deref(ghUser.AvatarURL),
-						},
-						ExternalAccount: extsvc.AccountSpec{
-							ServiceType: extsvc.TypeGitHubApp,
-							ServiceID:   s.ServiceID,
-							ClientID:    s.clientID,
-							AccountID:   accountID,
-						},
-						CreateIfNotExist: attempt.createIfNotExist,
-					})
-
-					if err != nil {
-						log15.Warn("Error while saving associated user installation", "error", err)
-					}
-				}
-			}
-
 			go hubspotutil.SyncUser(attempt.email, hubspotutil.SignupEventID, &hubspot.ContactProperties{
 				AnonymousUserID: anonymousUserID,
 				FirstSourceURL:  firstSourceURL,

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -3,9 +3,7 @@ package authz
 import (
 	"container/heap"
 	"context"
-	"fmt"
 	"net/http"
-	"net/url"
 	"strconv"
 	"sync"
 	"time"
@@ -14,8 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sourcegraph/log"
-
-	gh "github.com/google/go-github/v41/github"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
@@ -28,7 +24,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
@@ -262,50 +257,6 @@ func (s *PermsSyncer) listPrivateRepoNamesBySpecs(ctx context.Context, repoSpecs
 	return repoNames, nil
 }
 
-func (s *PermsSyncer) getUserGitHubAppInstallations(ctx context.Context, acct *extsvc.Account) ([]gh.Installation, error) {
-	if acct.ServiceType != extsvc.TypeGitHub {
-		return nil, nil
-	}
-
-	_, tok, err := github.GetExternalAccountData(ctx, &acct.AccountData)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if tok == nil {
-		return nil, nil
-	}
-
-	// Not a GitHub App access token
-	if !github.IsGitHubAppAccessToken(tok.AccessToken) {
-		return nil, nil
-	}
-
-	oauthToken := &auth.OAuthBearerToken{
-		Token:              tok.AccessToken,
-		RefreshToken:       tok.RefreshToken,
-		Expiry:             tok.Expiry,
-		RefreshFunc:        database.GetAccountRefreshAndStoreOAuthTokenFunc(s.db, acct.ID, github.GetOAuthContext(acct.ServiceID)),
-		NeedsRefreshBuffer: 5,
-	}
-
-	apiURL, err := url.Parse(acct.ServiceID)
-	if err != nil {
-		return nil, err
-	}
-	apiURL, _ = github.APIRoot(apiURL)
-	ghClient := github.NewV3Client(log.Scoped("perms_syncer.github.v3", "github v3 client for perms syncer"),
-		extsvc.URNGitHubOAuth, apiURL, oauthToken, nil)
-
-	installations, err := ghClient.GetUserInstallations(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return installations, nil
-}
-
 type fetchUserPermsViaExternalAccountsResults struct {
 	repoIDs      []uint32
 	subRepoPerms map[api.ExternalRepoSpec]*authz.SubRepoPermissions
@@ -413,10 +364,6 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 	results.subRepoPerms = make(map[api.ExternalRepoSpec]*authz.SubRepoPermissions)
 
 	for _, acct := range accts {
-		if acct.ServiceType == extsvc.TypeGitHubApp {
-			continue
-		}
-
 		acctLogger := logger.With(log.Int32("acct.ID", acct.ID))
 
 		provider := byServiceID[acct.ServiceID]
@@ -430,18 +377,6 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 		}
 
 		acctLogger.Debug("update GitHub App installation access", log.Int32("accountID", acct.ID))
-
-		installations, err := s.getUserGitHubAppInstallations(ctx, acct)
-
-		// These errors aren't fatal, so we continue with the normal flow
-		// even if things go wrong.
-		if err != nil && installations != nil {
-			if err := s.db.UserExternalAccounts().UpdateGitHubAppInstallations(ctx, acct, installations); err != nil {
-				acctLogger.Warn("failed to update GitHub App installation access", log.Error(err))
-			}
-		} else if err != nil {
-			acctLogger.Warn("failed to fetch GitHub App installations", log.Error(err))
-		}
 
 		// FetchUserPerms makes API requests using a client that will deal with the token
 		// expiration and try to refresh it when necessary. If the client fails to update
@@ -459,25 +394,6 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 			if unauthorized || accountSuspended || forbidden {
 				// These are fatal errors that mean we should continue as if the account no
 				// longer has any access.
-				linkedAccts, err := s.db.UserExternalAccounts().List(ctx,
-					database.ExternalAccountsListOptions{
-						ServiceType:   extsvc.TypeGitHubApp,
-						AccountIDLike: fmt.Sprintf("%%/%s", acct.AccountID),
-					},
-				)
-				if err != nil {
-					return results, errors.Wrapf(err, "list linked accounts for %d", acct.ID)
-				}
-
-				acctIDs := make([]int32, 0, len(linkedAccts)+1)
-				acctIDs = append(acctIDs, acct.ID)
-				for _, linkedAcct := range linkedAccts {
-					acctIDs = append(acctIDs, linkedAcct.ID)
-				}
-				if err = accounts.TouchExpired(ctx, acctIDs...); err != nil {
-					return results, errors.Wrapf(err, "set expired for external account IDs %v", acctIDs)
-				}
-
 				if unauthorized {
 					acctLogger.Warn("setExternalAccountExpired, token is revoked",
 						log.Bool("unauthorized", unauthorized),
@@ -820,22 +736,6 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 			ServiceID:   provider.ServiceID(),
 			AccountIDs:  accountIDs,
 		})
-
-		if provider.ServiceType() == extsvc.TypeGitHub {
-			linkedAccountIDsToUserIDs, err := s.permsStore.GetUserIDsByExternalAccounts(ctx, &extsvc.Accounts{
-				ServiceType: extsvc.TypeGitHubApp,
-				ServiceID:   provider.ServiceID(),
-				AccountIDs:  accountIDs,
-			})
-			if err == nil {
-				for k, v := range linkedAccountIDsToUserIDs {
-					accountIDsToUserIDs[k] = v
-				}
-			} else {
-				// Only log in case of error, as there can still be valid permissions syncing.
-				logger.Warn("error fetching linked accounts", log.Error(err))
-			}
-		}
 
 		if err != nil {
 			return providerStates, errors.Wrap(err, "get user IDs by external accounts")

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -394,6 +394,10 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 			if unauthorized || accountSuspended || forbidden {
 				// These are fatal errors that mean we should continue as if the account no
 				// longer has any access.
+				if err = accounts.TouchExpired(ctx, acct.ID); err != nil {
+					return results, errors.Wrapf(err, "set expired for external account ID %v", acct.ID)
+				}
+
 				if unauthorized {
 					acctLogger.Warn("setExternalAccountExpired, token is revoked",
 						log.Bool("unauthorized", unauthorized),

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -367,12 +367,11 @@ WHERE %s`, sqlf.Join(conds, "AND"))
 
 // ExternalAccountsListOptions specifies the options for listing user external accounts.
 type ExternalAccountsListOptions struct {
-	UserID        int32
-	ServiceType   string
-	ServiceID     string
-	ClientID      string
-	AccountID     string
-	AccountIDLike string
+	UserID      int32
+	ServiceType string
+	ServiceID   string
+	ClientID    string
+	AccountID   string
 
 	// Only one of these should be set
 	ExcludeExpired bool
@@ -477,9 +476,6 @@ func (s *userExternalAccountsStore) listSQL(opt ExternalAccountsListOptions) (co
 	}
 	if opt.OnlyExpired {
 		conds = append(conds, sqlf.Sprintf("expired_at IS NOT NULL"))
-	}
-	if opt.AccountIDLike != "" {
-		conds = append(conds, sqlf.Sprintf("account_id LIKE %s", opt.AccountIDLike))
 	}
 
 	return conds

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	gh "github.com/google/go-github/v41/github"
 	"github.com/keegancsmith/sqlf"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/log"
@@ -57,8 +56,6 @@ type UserExternalAccountsStore interface {
 	// Delete will soft delete all accounts matching the options combined using AND.
 	// If options are all zero values then it does nothing.
 	Delete(ctx context.Context, opt ExternalAccountsDeleteOptions) error
-
-	UpdateGitHubAppInstallations(ctx context.Context, acct *extsvc.Account, installations []gh.Installation) error
 
 	// ExecResult performs a query without returning any rows, but includes the
 	// result of the execution.
@@ -382,54 +379,6 @@ type ExternalAccountsListOptions struct {
 	OnlyExpired    bool
 
 	*LimitOffset
-}
-
-func (s *userExternalAccountsStore) UpdateGitHubAppInstallations(ctx context.Context, acct *extsvc.Account, installations []gh.Installation) error {
-	acctInstallations, err := s.List(ctx, ExternalAccountsListOptions{
-		ServiceType:    extsvc.TypeGitHubApp,
-		AccountIDLike:  fmt.Sprintf("%%/%s", acct.AccountID),
-		ExcludeExpired: true,
-	})
-	if err != nil {
-		return err
-	}
-
-	validInstallations := []*extsvc.Account{}
-ACCTINSTALLATIONS:
-	for _, acctInstallation := range acctInstallations {
-		for _, installation := range installations {
-			installationID := strconv.FormatInt(*installation.ID, 10)
-			if acctInstallation.AccountID == fmt.Sprintf("%s/%s", installationID, acct.AccountID) {
-				validInstallations = append(validInstallations, acctInstallation)
-				continue ACCTINSTALLATIONS
-			}
-		}
-		if err = s.Delete(ctx, ExternalAccountsDeleteOptions{IDs: []int32{acctInstallation.ID}}); err != nil {
-			return err
-		}
-	}
-
-INSTALLATIONS:
-	for _, installation := range installations {
-		installationID := strconv.FormatInt(*installation.ID, 10)
-		for _, validInstallation := range validInstallations {
-			if validInstallation.AccountID == fmt.Sprintf("%s/%s", installationID, acct.AccountID) {
-				continue INSTALLATIONS
-			}
-		}
-		accountID := installationID + "/" + acct.AccountID
-		if err := s.Insert(ctx, acct.UserID, extsvc.AccountSpec{
-			ServiceType: extsvc.TypeGitHubApp,
-			ServiceID:   acct.ServiceID,
-			ClientID:    acct.ClientID,
-			AccountID:   accountID,
-		},
-			extsvc.AccountData{AuthData: nil, Data: nil},
-		); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (s *userExternalAccountsStore) List(ctx context.Context, opt ExternalAccountsListOptions) (acct []*extsvc.Account, err error) {

--- a/internal/database/external_accounts_test.go
+++ b/internal/database/external_accounts_test.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/sourcegraph/log/logtest"
 
-	gh "github.com/google/go-github/v41/github"
-
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	et "github.com/sourcegraph/sourcegraph/internal/encryption/testing"
@@ -611,61 +609,6 @@ func TestExternalAccounts_DeleteList(t *testing.T) {
 	accts, err = db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{UserID: 1})
 	require.NoError(t, err)
 	require.Equal(t, 0, len(accts))
-}
-
-func TestExternalAccounts_UpdateGitHubAppInstallations(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
-	ctx := context.Background()
-
-	spec := extsvc.AccountSpec{
-		ServiceType: "github",
-		ServiceID:   "https://github.com/",
-		ClientID:    "Iv1.efc1dc24dbdefa09",
-		AccountID:   "1234",
-	}
-
-	var installationID1 int64 = 6789
-	var installationID2 int64 = 3456
-	var installationID3 int64 = 7658
-	installations := []gh.Installation{
-		{
-			ID: &installationID1,
-		},
-		{
-			ID: &installationID2,
-		},
-		{
-			ID: &installationID3,
-		},
-	}
-
-	userID, err := db.UserExternalAccounts().CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
-	require.NoError(t, err)
-	acct, err := db.UserExternalAccounts().Get(ctx, 1)
-	require.NoError(t, err)
-	spec.ServiceType = extsvc.TypeGitHubApp
-	spec.AccountID = "9876/1234"
-	err = db.UserExternalAccounts().Insert(ctx, userID, spec, extsvc.AccountData{})
-	require.NoError(t, err)
-	spec.AccountID = "6789/1234"
-	err = db.UserExternalAccounts().Insert(ctx, userID, spec, extsvc.AccountData{})
-	require.NoError(t, err)
-
-	accts, err := db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{UserID: 1})
-	require.NoError(t, err)
-	require.Equal(t, 3, len(accts))
-
-	err = db.UserExternalAccounts().UpdateGitHubAppInstallations(ctx, acct, installations)
-	require.NoError(t, err)
-
-	accts, err = db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{UserID: 1})
-	require.NoError(t, err)
-	require.Equal(t, 4, len(accts))
 }
 
 func TestExternalAccounts_TouchExpiredList(t *testing.T) {

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	github "github.com/google/go-github/v41/github"
 	uuid "github.com/google/uuid"
 	sqlf "github.com/keegancsmith/sqlf"
 	api "github.com/sourcegraph/sourcegraph/internal/api"
@@ -44168,10 +44167,6 @@ type MockUserExternalAccountsStore struct {
 	// TransactFunc is an instance of a mock function object controlling the
 	// behavior of the method Transact.
 	TransactFunc *UserExternalAccountsStoreTransactFunc
-	// UpdateGitHubAppInstallationsFunc is an instance of a mock function
-	// object controlling the behavior of the method
-	// UpdateGitHubAppInstallations.
-	UpdateGitHubAppInstallationsFunc *UserExternalAccountsStoreUpdateGitHubAppInstallationsFunc
 	// WithFunc is an instance of a mock function object controlling the
 	// behavior of the method With.
 	WithFunc *UserExternalAccountsStoreWithFunc
@@ -44262,11 +44257,6 @@ func NewMockUserExternalAccountsStore() *MockUserExternalAccountsStore {
 		},
 		TransactFunc: &UserExternalAccountsStoreTransactFunc{
 			defaultHook: func(context.Context) (r0 UserExternalAccountsStore, r1 error) {
-				return
-			},
-		},
-		UpdateGitHubAppInstallationsFunc: &UserExternalAccountsStoreUpdateGitHubAppInstallationsFunc{
-			defaultHook: func(context.Context, *extsvc.Account, []github.Installation) (r0 error) {
 				return
 			},
 		},
@@ -44368,11 +44358,6 @@ func NewStrictMockUserExternalAccountsStore() *MockUserExternalAccountsStore {
 				panic("unexpected invocation of MockUserExternalAccountsStore.Transact")
 			},
 		},
-		UpdateGitHubAppInstallationsFunc: &UserExternalAccountsStoreUpdateGitHubAppInstallationsFunc{
-			defaultHook: func(context.Context, *extsvc.Account, []github.Installation) error {
-				panic("unexpected invocation of MockUserExternalAccountsStore.UpdateGitHubAppInstallations")
-			},
-		},
 		WithFunc: &UserExternalAccountsStoreWithFunc{
 			defaultHook: func(basestore.ShareableStore) UserExternalAccountsStore {
 				panic("unexpected invocation of MockUserExternalAccountsStore.With")
@@ -44438,9 +44423,6 @@ func NewMockUserExternalAccountsStoreFrom(i UserExternalAccountsStore) *MockUser
 		},
 		TransactFunc: &UserExternalAccountsStoreTransactFunc{
 			defaultHook: i.Transact,
-		},
-		UpdateGitHubAppInstallationsFunc: &UserExternalAccountsStoreUpdateGitHubAppInstallationsFunc{
-			defaultHook: i.UpdateGitHubAppInstallations,
 		},
 		WithFunc: &UserExternalAccountsStoreWithFunc{
 			defaultHook: i.With,
@@ -46213,120 +46195,6 @@ func (c UserExternalAccountsStoreTransactFuncCall) Args() []interface{} {
 // invocation.
 func (c UserExternalAccountsStoreTransactFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
-}
-
-// UserExternalAccountsStoreUpdateGitHubAppInstallationsFunc describes the
-// behavior when the UpdateGitHubAppInstallations method of the parent
-// MockUserExternalAccountsStore instance is invoked.
-type UserExternalAccountsStoreUpdateGitHubAppInstallationsFunc struct {
-	defaultHook func(context.Context, *extsvc.Account, []github.Installation) error
-	hooks       []func(context.Context, *extsvc.Account, []github.Installation) error
-	history     []UserExternalAccountsStoreUpdateGitHubAppInstallationsFuncCall
-	mutex       sync.Mutex
-}
-
-// UpdateGitHubAppInstallations delegates to the next hook function in the
-// queue and stores the parameter and result values of this invocation.
-func (m *MockUserExternalAccountsStore) UpdateGitHubAppInstallations(v0 context.Context, v1 *extsvc.Account, v2 []github.Installation) error {
-	r0 := m.UpdateGitHubAppInstallationsFunc.nextHook()(v0, v1, v2)
-	m.UpdateGitHubAppInstallationsFunc.appendCall(UserExternalAccountsStoreUpdateGitHubAppInstallationsFuncCall{v0, v1, v2, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the
-// UpdateGitHubAppInstallations method of the parent
-// MockUserExternalAccountsStore instance is invoked and the hook queue is
-// empty.
-func (f *UserExternalAccountsStoreUpdateGitHubAppInstallationsFunc) SetDefaultHook(hook func(context.Context, *extsvc.Account, []github.Installation) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// UpdateGitHubAppInstallations method of the parent
-// MockUserExternalAccountsStore instance invokes the hook at the front of
-// the queue and discards it. After the queue is empty, the default hook
-// function is invoked for any future action.
-func (f *UserExternalAccountsStoreUpdateGitHubAppInstallationsFunc) PushHook(hook func(context.Context, *extsvc.Account, []github.Installation) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *UserExternalAccountsStoreUpdateGitHubAppInstallationsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, *extsvc.Account, []github.Installation) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *UserExternalAccountsStoreUpdateGitHubAppInstallationsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, *extsvc.Account, []github.Installation) error {
-		return r0
-	})
-}
-
-func (f *UserExternalAccountsStoreUpdateGitHubAppInstallationsFunc) nextHook() func(context.Context, *extsvc.Account, []github.Installation) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *UserExternalAccountsStoreUpdateGitHubAppInstallationsFunc) appendCall(r0 UserExternalAccountsStoreUpdateGitHubAppInstallationsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// UserExternalAccountsStoreUpdateGitHubAppInstallationsFuncCall objects
-// describing the invocations of this function.
-func (f *UserExternalAccountsStoreUpdateGitHubAppInstallationsFunc) History() []UserExternalAccountsStoreUpdateGitHubAppInstallationsFuncCall {
-	f.mutex.Lock()
-	history := make([]UserExternalAccountsStoreUpdateGitHubAppInstallationsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// UserExternalAccountsStoreUpdateGitHubAppInstallationsFuncCall is an
-// object that describes an invocation of method
-// UpdateGitHubAppInstallations on an instance of
-// MockUserExternalAccountsStore.
-type UserExternalAccountsStoreUpdateGitHubAppInstallationsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 *extsvc.Account
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 []github.Installation
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c UserExternalAccountsStoreUpdateGitHubAppInstallationsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c UserExternalAccountsStoreUpdateGitHubAppInstallationsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
 }
 
 // UserExternalAccountsStoreWithFunc describes the behavior when the With

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -154,9 +154,6 @@ const (
 	// is the base URL to the GitHub instance (https://github.com or the GitHub Enterprise URL).
 	TypeGitHub = "github"
 
-	// TypeGitHubApp is used for GitHub App linked user external accounts.
-	TypeGitHubApp = "githubApp"
-
 	// TypeGitLab is the (api.ExternalRepoSpec).ServiceType value for GitLab projects. The ServiceID
 	// value is the base URL to the GitLab instance (https://gitlab.com or self-hosted GitLab URL).
 	TypeGitLab = "gitlab"


### PR DESCRIPTION
This PR removes the GitHub App Linked Accounts implementation. This was necessary when we were heading towards using both repo- and user-based permissions syncing, in order to ensure that repo-based permissions syncing is not giving access to repositories that the user-account token should not have access to.

However, since we want to solely use user-tokens for permissions syncing in the near future, this is no longer necessary and adds unnecessary complexity and confusion.

## Test plan

All tests still pass and tested locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
