### PR TITLE
Add audit logs for invalid token events

### DIFF
--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -94,6 +94,7 @@ func AccessTokenAuthMiddleware(db database.DB, logger log.Logger, next http.Hand
 						r.Context(),
 						&database.SecurityEvent{
 							Name:            database.SecurityEventAccessTokenInvalid,
+							URL:             r.URL.RequestURI(),
 							AnonymousUserID: anonymousId,
 							Source:          "BACKEND",
 							Timestamp:       time.Now(),
@@ -161,6 +162,7 @@ func AccessTokenAuthMiddleware(db database.DB, logger log.Logger, next http.Hand
 						r.Context(),
 						&database.SecurityEvent{
 							Name:      database.SecurityEventAccessTokenSubjectNotSiteAdmin,
+							URL:       r.URL.RequestURI(),
 							UserID:    uint32(subjectUserID),
 							Argument:  args,
 							Source:    "BACKEND",

--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -86,10 +86,7 @@ func AccessTokenAuthMiddleware(db database.DB, logger log.Logger, next http.Hand
 						log.Error(err),
 					)
 
-					anonymousId, anonCookieSet := cookie.AnonymousUID(r)
-					if !anonCookieSet {
-						anonymousId = "no identifier set"
-					}
+					anonymousId, _ := cookie.AnonymousUID(r)
 					db.SecurityEventLogs().LogEvent(
 						r.Context(),
 						&database.SecurityEvent{

--- a/cmd/frontend/internal/httpapi/auth_test.go
+++ b/cmd/frontend/internal/httpapi/auth_test.go
@@ -195,14 +195,22 @@ func TestAccessTokenAuthMiddleware(t *testing.T) {
 			return &types.User{ID: 456, SiteAdmin: true}, nil
 		})
 
+		securityEventLogs := database.NewMockSecurityEventLogsStore()
+		securityEventLogs.LogEventFunc.SetDefaultHook(func(ctx context.Context, se *database.SecurityEvent) {
+			if want := database.SecurityEventAccessTokenImpersonated; se.Name != want {
+				t.Errorf("got %q, want %q", se.Name, want)
+			}
+		})
+
 		db.AccessTokensFunc.SetDefaultReturn(accessTokens)
 		db.UsersFunc.SetDefaultReturn(users)
-		db.SecurityEventLogsFunc.SetDefaultReturn(database.NewMockSecurityEventLogsStore())
+		db.SecurityEventLogsFunc.SetDefaultReturn(securityEventLogs)
 
 		checkHTTPResponse(t, db, req, http.StatusOK, "user 456")
 		mockrequire.Called(t, accessTokens.LookupFunc)
 		mockrequire.Called(t, users.GetByIDFunc)
 		mockrequire.Called(t, users.GetByUsernameFunc)
+		mockrequire.Called(t, securityEventLogs.LogEventFunc)
 	})
 
 	t.Run("valid sudo token as a Sourcegraph operator", func(t *testing.T) {

--- a/cmd/frontend/internal/httpapi/auth_test.go
+++ b/cmd/frontend/internal/httpapi/auth_test.go
@@ -84,8 +84,17 @@ func TestAccessTokenAuthMiddleware(t *testing.T) {
 		accessTokens.LookupFunc.SetDefaultReturn(0, database.InvalidTokenError{})
 		db.AccessTokensFunc.SetDefaultReturn(accessTokens)
 
+		securityEventLogs := database.NewMockSecurityEventLogsStore()
+		securityEventLogs.LogEventFunc.SetDefaultHook(func(ctx context.Context, se *database.SecurityEvent) {
+			if want := database.SecurityEventAccessTokenInvalid; se.Name != want {
+				t.Errorf("got %q, want %q", se.Name, want)
+			}
+		})
+		db.SecurityEventLogsFunc.SetDefaultReturn(securityEventLogs)
+
 		checkHTTPResponse(t, db, req, http.StatusUnauthorized, "Invalid access token.\n")
 		mockrequire.Called(t, accessTokens.LookupFunc)
+		mockrequire.Called(t, securityEventLogs.LogEventFunc)
 	})
 
 	for _, headerValue := range []string{"token abcdef", `token token="abcdef"`} {
@@ -287,12 +296,21 @@ func TestAccessTokenAuthMiddleware(t *testing.T) {
 			return &types.User{ID: userID, SiteAdmin: false}, nil
 		})
 
+		securityEventLogsStore := database.NewMockSecurityEventLogsStore()
+		securityEventLogsStore.LogEventFunc.SetDefaultHook(func(_ context.Context, se *database.SecurityEvent) {
+			if want := database.SecurityEventAccessTokenSubjectNotSiteAdmin; se.Name != want {
+				t.Errorf("got %q, want %q", se.Name, want)
+			}
+		})
+
 		db.AccessTokensFunc.SetDefaultReturn(accessTokens)
 		db.UsersFunc.SetDefaultReturn(users)
+		db.SecurityEventLogsFunc.SetDefaultReturn(securityEventLogsStore)
 
 		checkHTTPResponse(t, db, req, http.StatusForbidden, "The subject user of a sudo access token must be a site admin.\n")
 		mockrequire.Called(t, accessTokens.LookupFunc)
 		mockrequire.Called(t, users.GetByIDFunc)
+		mockrequire.Called(t, securityEventLogsStore.LogEventFunc)
 	})
 
 	t.Run("valid sudo token, invalid sudo user", func(t *testing.T) {

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -18193,13 +18193,6 @@
       ],
       "Constraints": [
         {
-          "Name": "security_event_logs_check_has_user",
-          "ConstraintType": "c",
-          "RefTableName": "",
-          "IsDeferrable": false,
-          "ConstraintDefinition": "CHECK (user_id = 0 AND anonymous_user_id \u003c\u003e ''::text OR user_id \u003c\u003e 0 AND anonymous_user_id = ''::text OR user_id \u003c\u003e 0 AND anonymous_user_id \u003c\u003e ''::text)"
-        },
-        {
           "Name": "security_event_logs_check_name_not_empty",
           "ConstraintType": "c",
           "RefTableName": "",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2832,7 +2832,6 @@ Indexes:
     "security_event_logs_pkey" PRIMARY KEY, btree (id)
     "security_event_logs_timestamp" btree ("timestamp")
 Check constraints:
-    "security_event_logs_check_has_user" CHECK (user_id = 0 AND anonymous_user_id <> ''::text OR user_id <> 0 AND anonymous_user_id = ''::text OR user_id <> 0 AND anonymous_user_id <> ''::text)
     "security_event_logs_check_name_not_empty" CHECK (name <> ''::text)
     "security_event_logs_check_source_not_empty" CHECK (source <> ''::text)
     "security_event_logs_check_version_not_empty" CHECK (version <> ''::text)

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -44,10 +44,12 @@ const (
 
 	SecurityEventNameAccessGranted SecurityEventName = "AccessGranted"
 
-	SecurityEventAccessTokenCreated      SecurityEventName = "AccessTokenCreated"
-	SecurityEventAccessTokenDeleted      SecurityEventName = "AccessTokenDeleted"
-	SecurityEventAccessTokenHardDeleted  SecurityEventName = "AccessTokenHardDeleted"
-	SecurityEventAccessTokenImpersonated SecurityEventName = "AccessTokenImpersonated"
+	SecurityEventAccessTokenCreated             SecurityEventName = "AccessTokenCreated"
+	SecurityEventAccessTokenDeleted             SecurityEventName = "AccessTokenDeleted"
+	SecurityEventAccessTokenHardDeleted         SecurityEventName = "AccessTokenHardDeleted"
+	SecurityEventAccessTokenImpersonated        SecurityEventName = "AccessTokenImpersonated"
+	SecurityEventAccessTokenInvalid             SecurityEventName = "AccessTokenInvalid"
+	SecurityEventAccessTokenSubjectNotSiteAdmin SecurityEventName = "AccessTokenSubjectNotSiteAdmin"
 
 	SecurityEventGitHubAuthSucceeded SecurityEventName = "GitHubAuthSucceeded"
 	SecurityEventGitHubAuthFailed    SecurityEventName = "GitHubAuthFailed"

--- a/internal/database/security_event_logs_test.go
+++ b/internal/database/security_event_logs_test.go
@@ -34,7 +34,7 @@ func TestSecurityEventLogs_ValidInfo(t *testing.T) {
 		{
 			name:  "InvalidUser",
 			event: &SecurityEvent{Name: "test_event", URL: "http://sourcegraph.com", Source: "WEB"},
-			err:   `INSERT: ERROR: new row for relation "security_event_logs" violates check constraint "security_event_logs_check_has_user" (SQLSTATE 23514)`,
+			err:   `<nil>`,
 		},
 		{
 			name:  "EmptySource",
@@ -44,7 +44,7 @@ func TestSecurityEventLogs_ValidInfo(t *testing.T) {
 		{
 			name:  "UserAndAnonymousMissing",
 			event: &SecurityEvent{Name: "test_event", URL: "http://sourcegraph.com", Source: "WEB", UserID: 0, AnonymousUserID: ""},
-			err:   `INSERT: ERROR: new row for relation "security_event_logs" violates check constraint "security_event_logs_check_has_user" (SQLSTATE 23514)`,
+			err:   `<nil>`,
 		},
 		{
 			name:  "JustUser",
@@ -72,7 +72,7 @@ func TestSecurityEventLogs_ValidInfo(t *testing.T) {
 
 	logs := exportLogs()
 	auditLogs := filterAudit(logs)
-	assert.Equal(t, 3, len(auditLogs))
+	assert.Equal(t, 5, len(auditLogs))
 	for _, auditLog := range auditLogs {
 		assertAuditField(t, auditLog.Fields["audit"].(map[string]any))
 		assertEventField(t, auditLog.Fields["event"].(map[string]any))

--- a/migrations/frontend/1669818369_remove_user_constraints_from_security_event_logs/down.sql
+++ b/migrations/frontend/1669818369_remove_user_constraints_from_security_event_logs/down.sql
@@ -1,0 +1,3 @@
+-- Undo the changes made in the up migration
+ALTER TABLE security_event_logs ADD CONSTRAINT security_event_logs_check_has_user
+    CHECK (user_id = 0 AND anonymous_user_id <> ''::text OR user_id <> 0 AND anonymous_user_id = ''::text OR user_id <> 0 AND anonymous_user_id <> ''::text);

--- a/migrations/frontend/1669818369_remove_user_constraints_from_security_event_logs/metadata.yaml
+++ b/migrations/frontend/1669818369_remove_user_constraints_from_security_event_logs/metadata.yaml
@@ -1,0 +1,2 @@
+name: remove user constraints from security_event_logs
+parents: [1669184869]

--- a/migrations/frontend/1669818369_remove_user_constraints_from_security_event_logs/up.sql
+++ b/migrations/frontend/1669818369_remove_user_constraints_from_security_event_logs/up.sql
@@ -1,0 +1,13 @@
+-- Perform migration here.
+--
+-- See /migrations/README.md. Highlights:
+--  * Make migrations idempotent (use IF EXISTS)
+--  * Make migrations backwards-compatible (old readers/writers must continue to work)
+--  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement
+--    is defined per file, and that each such statement is NOT wrapped in a transaction.
+--    Each such migration must also declare "createIndexConcurrently: true" in their
+--    associated metadata.yaml file.
+--  * If you are modifying Postgres extensions, you must also declare "privileged: true"
+--    in the associated metadata.yaml file.
+
+ALTER TABLE security_event_logs DROP CONSTRAINT IF EXISTS security_event_logs_check_has_user;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3396,7 +3396,6 @@ CREATE TABLE security_event_logs (
     argument jsonb NOT NULL,
     version text NOT NULL,
     "timestamp" timestamp with time zone NOT NULL,
-    CONSTRAINT security_event_logs_check_has_user CHECK ((((user_id = 0) AND (anonymous_user_id <> ''::text)) OR ((user_id <> 0) AND (anonymous_user_id = ''::text)) OR ((user_id <> 0) AND (anonymous_user_id <> ''::text)))),
     CONSTRAINT security_event_logs_check_name_not_empty CHECK ((name <> ''::text)),
     CONSTRAINT security_event_logs_check_source_not_empty CHECK ((source <> ''::text)),
     CONSTRAINT security_event_logs_check_version_not_empty CHECK ((version <> ''::text))


### PR DESCRIPTION
Add audit logs for the following cases related to token-based auth:

* Invalid token is used
* Sudo access token used by user who is no longer an admin

- [ ] Need to find a solution for the case where the `sourcegraphAnonymousUid` cookie isn't set when an invalid token is used. Currently this effectively allows the user to disable database-based logging simply by removing the cookie. [e7f9ea8](https://github.com/sourcegraph/sourcegraph/commit/e7f9ea86c6a1da34c45d03dffa6db59d9481e41e#diff-cc3dcdfaa1b2810734330a8eb47a065edbcc443af9fa6aae2cde7b0e6839cd0eR90) contains a temporary workaround, but we either need to:

* remove the db constraint
* populate AnonymousUserID [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@will-michal/sudo-access-token/-/blob/internal/database/security_event_logs.go?L114) when UserID and AnonymousUserID are both zero values

This problem also affects failed sign-in attempts.

## Test plan

- [x] Unit tests
- [ ] Manual testing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
