### PR TITLE
Don't show publish banner for closed batch change

### DIFF
--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -169,7 +169,7 @@ export const BatchChangeDetailsPage: React.FunctionComponent<
                 className="mb-3"
             />
             <ClosedNotice closedAt={batchChange.closedAt} className="mb-3" />
-            {batchChange.viewerCanAdminister && (
+            {batchChange.closedAt === null && batchChange.viewerCanAdminister && (
                 <UnpublishedNotice
                     unpublished={batchChange.changesetsStats.unpublished}
                     total={batchChange.changesetsStats.total}


### PR DESCRIPTION
For closed batch changes, publication is not possible, so we should not show this banner.



## Test plan

Verified doesn't show.

## App preview:

- [Web](https://sg-web-es-no-publication-banner-closed.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
