### PR TITLE
codeintel: Move more serializer functionality into oobmigrations

### DIFF
--- a/enterprise/internal/oobmigration/migrations/codeintel/serializer.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/serializer.go
@@ -117,6 +117,12 @@ func (s *serializer) UnmarshalLegacyDocumentData(data []byte) (document Document
 	return document, err
 }
 
+// UnmarshalResultChunkData is the inverse of MarshalResultChunkData.
+func (s *serializer) UnmarshalResultChunkData(data []byte) (resultChunk ResultChunkData, err error) {
+	err = s.decode(data, &resultChunk)
+	return resultChunk, err
+}
+
 // UnmarshalLocations is the inverse of MarshalLocations.
 func (s *serializer) UnmarshalLocations(data []byte) (locations []LocationData, err error) {
 	err = s.decode(data, &locations)

--- a/enterprise/internal/oobmigration/migrations/codeintel/types.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/types.go
@@ -59,7 +59,33 @@ type DiagnosticData struct {
 	EndCharacter   int // 0-indexed, inclusive
 }
 
-// Loocation represents a range within a particular document relative to its
+// ResultChunkData represents a row of the resultChunk table. Each row is a subset
+// of definition and reference result data in the index. Results are inserted into
+// chunks based on the hash of their identifier, thus every chunk has a roughly
+// proportional amount of data.
+type ResultChunkData struct {
+	// DocumentPaths is a mapping from document identifiers to their paths. This
+	// must be used to convert a document identifier in DocumentIDRangeIDs into
+	// a key that can be used to fetch document data.
+	DocumentPaths map[ID]string
+
+	// DocumentIDRangeIDs is a mapping from a definition or result reference
+	// identifier to the set of ranges that compose that result set. Each range
+	// is paired with the identifier of the document in which it can found.
+	DocumentIDRangeIDs map[ID][]DocumentIDRangeID
+}
+
+// DocumentIDRangeID is a pair of document and range identifiers.
+type DocumentIDRangeID struct {
+	// The identifier of the document to which the range belongs. This id is only
+	// relevant within the containing result chunk.
+	DocumentID ID
+
+	// The identifier of the range.
+	RangeID ID
+}
+
+// Location represents a range within a particular document relative to its
 // containing bundle.
 type LocationData struct {
 	URI            string


### PR DESCRIPTION
The oobmigration package that's modified here contained a "frozen" version of the serializer that was in-use. This is so the already-deprecated oobmigrations do not interfere with changes to the serializer in newer code.

As part of the LSIF -> SCIP pivot we'll need to read result chunks as well. This is moving additional behaviors from the current serializer into the frozen package for later use.

## Test plan

N/A.