### PR TITLE
codeintel: Add translateRange util function

### DIFF
--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/types.go
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/types.go
@@ -1,6 +1,11 @@
 package lsifstore
 
-import "github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
+import (
+	"github.com/sourcegraph/scip/bindings/go/scip"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
+	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
+)
 
 type MarshalledDocumentData struct {
 	Ranges             []byte
@@ -18,4 +23,17 @@ type QualifiedMonikerLocations struct {
 type QualifiedDocumentData struct {
 	UploadID int
 	precise.KeyedDocumentData
+}
+
+func translateRange(r *scip.Range) types.Range {
+	return types.Range{
+		Start: types.Position{
+			Line:      int(r.Start.Line),
+			Character: int(r.Start.Character),
+		},
+		End: types.Position{
+			Line:      int(r.End.Line),
+			Character: int(r.End.Character),
+		},
+	}
 }


### PR DESCRIPTION
Add a small utility function for later use that translates a scip range into a types range (that will be used as the return value for the codenav service API).

## Test plan

N/A.