### PR TITLE
codeintel: Add common/internal SCIP utilities

### DIFF
--- a/enterprise/internal/codeintel/shared/types/scip.go
+++ b/enterprise/internal/codeintel/shared/types/scip.go
@@ -1,0 +1,65 @@
+package types
+
+import (
+	"sort"
+
+	"github.com/sourcegraph/scip/bindings/go/scip"
+)
+
+// FindOccurrences filters the given occurrences and returns those that contain the position
+// constructed from line and character. The order of the output slice is "outside-in", so that
+// earlier occurrences properly enclose later occurrences.
+func FindOccurrences(occurrences []*scip.Occurrence, line, character int) []*scip.Occurrence {
+	var filtered []*scip.Occurrence
+	for _, o := range occurrences {
+		if comparePositionSCIP(scip.NewRange(o.Range), line, character) == 0 {
+			filtered = append(filtered, o)
+		}
+	}
+
+	return SortOccurrences(filtered)
+}
+
+// TODO - check ordering condition
+func SortOccurrences(occurrences []*scip.Occurrence) []*scip.Occurrence {
+	sort.Slice(occurrences, func(i, j int) bool {
+		ri := scip.NewRange(occurrences[i].Range)
+		rj := scip.NewRange(occurrences[j].Range)
+
+		return comparePositionSCIP(ri, int(rj.Start.Line), int(rj.Start.Character)) != 0
+	})
+
+	return occurrences
+}
+
+// TODO - check ordering condition
+func SortRanges(ranges []*scip.Range) []*scip.Range {
+	sort.Slice(ranges, func(i, j int) bool {
+		return comparePositionSCIP(ranges[i], int(ranges[j].Start.Line), int(ranges[j].Start.Character)) != 0
+	})
+
+	return ranges
+}
+
+// comparePositionSCIP compares the range r with the position constructed from line and character.
+// Returns -1 if the position occurs before the range, +1 if it occurs after, and 0 if the
+// position is inside of the range.
+func comparePositionSCIP(r *scip.Range, line, character int) int {
+	if line < int(r.Start.Line) {
+		return 1
+	}
+
+	if line > int(r.End.Line) {
+		return -1
+	}
+
+	if line == int(r.Start.Line) && character < int(r.Start.Character) {
+		return 1
+	}
+
+	if line == int(r.End.Line) && character >= int(r.End.Character) {
+		return -1
+	}
+
+	return 0
+}

--- a/enterprise/internal/codeintel/shared/types/scip.go
+++ b/enterprise/internal/codeintel/shared/types/scip.go
@@ -6,60 +6,123 @@ import (
 	"github.com/sourcegraph/scip/bindings/go/scip"
 )
 
-// FindOccurrences filters the given occurrences and returns those that contain the position
-// constructed from line and character. The order of the output slice is "outside-in", so that
-// earlier occurrences properly enclose later occurrences.
-func FindOccurrences(occurrences []*scip.Occurrence, line, character int) []*scip.Occurrence {
+// FindOccurrences filters the given slice of occurrences and returns those that contain the position
+// represented by line and character. The order of the output slice is "inside-out", so that earlier
+// occurrences are properly enclosed by later occurrences.
+func FindOccurrences(occurrences []*scip.Occurrence, targetLine, targetCharacter int32) []*scip.Occurrence {
 	var filtered []*scip.Occurrence
 	for _, o := range occurrences {
-		if comparePositionSCIP(scip.NewRange(o.Range), line, character) == 0 {
+		if compareRanges(o.Range, targetLine, targetCharacter) == 0 {
 			filtered = append(filtered, o)
 		}
 	}
 
-	return SortOccurrences(filtered)
+	sort.Slice(filtered, func(i, j int) bool {
+		// Ordered so that the least precise (largest) range comes first
+		return compareRanges(filtered[i].Range, filtered[j].Range...) > 0
+	})
+
+	return filtered
 }
 
-// TODO - check ordering condition
+// SortOccurrences sorts the given occurrence slice (in-place) and returns it (for convenience).
+// Occurrences sorted in ascending order of their range's starting position, where enclosing ranges
+// come before the enclosed.
 func SortOccurrences(occurrences []*scip.Occurrence) []*scip.Occurrence {
 	sort.Slice(occurrences, func(i, j int) bool {
-		ri := scip.NewRange(occurrences[i].Range)
-		rj := scip.NewRange(occurrences[j].Range)
-
-		return comparePositionSCIP(ri, int(rj.Start.Line), int(rj.Start.Character)) != 0
+		return compareRanges(occurrences[i].Range, occurrences[j].Range...) <= 0
 	})
 
 	return occurrences
 }
 
-// TODO - check ordering condition
+// SortRanges sorts the given range slice (in-place) and returns it (for convenience). Ranges are
+// sorted in ascending order of starting position, where enclosing ranges come before the enclosed.
 func SortRanges(ranges []*scip.Range) []*scip.Range {
 	sort.Slice(ranges, func(i, j int) bool {
-		return comparePositionSCIP(ranges[i], int(ranges[j].Start.Line), int(ranges[j].Start.Character)) != 0
+		return comparePositionToRange(
+			ranges[i].Start.Line,
+			ranges[i].Start.Character,
+			ranges[i].End.Line,
+			ranges[i].End.Character,
+			ranges[j].Start.Line,
+			ranges[j].Start.Character,
+		) <= 0
 	})
 
 	return ranges
 }
 
-// comparePositionSCIP compares the range r with the position constructed from line and character.
-// Returns -1 if the position occurs before the range, +1 if it occurs after, and 0 if the
-// position is inside of the range.
-func comparePositionSCIP(r *scip.Range, line, character int) int {
-	if line < int(r.Start.Line) {
+// compareRanges compares the order of the leading edge of the two ranges. This method returns
+//
+// - -1 if the leading edge of r2 occurs before r1,
+// - +1 if the leading edge of r2 occurs after r1, and
+// - +0 if the leading edge of r2 is enclosed by r1.
+//
+// Note that ranges are half-closed intervals, so a match on the leading end of the range will
+// be considered enclosed, but a match on the trailing edge will not.
+func compareRanges(r1 []int32, r2 ...int32) int {
+	startLine, startCharacter, endLine, endCharacter := unpackRange(r1)
+
+	return comparePositionToRange(
+		startLine,
+		startCharacter,
+		endLine,
+		endCharacter,
+		r2[0],
+		r2[1],
+	)
+}
+
+// unpackRange unpacks the raw SCIP range into a four-element range bound. This function
+// duplicates some of the logic in the SCIP repository, but we're dealing heavily with raw
+// encoded proto messages in the database layer here as well, and we'd like to avoid boxing
+// into a scip.Range unnecessarily.
+func unpackRange(r []int32) (int32, int32, int32, int32) {
+	if len(r) == 3 {
+		return r[0], r[1], r[0], r[2]
+	}
+
+	return r[0], r[1], r[2], r[3]
+}
+
+// comparePositionToRange compares the given target position represented by line and character
+// against the four-element range bound. This method returns
+//
+// - -1 if the position occurs before the range,
+// - +1 if the position occurs after the range, and
+// - +0 if the position is enclosed by the range.
+//
+// Note that ranges are half-closed intervals, so a match on the leading end of the range will
+// be considered enclosed, but a match on the trailing edge will not.
+func comparePositionToRange(
+	startLine int32,
+	startCharacter int32,
+	endLine int32,
+	endCharacter int32,
+	targetLine int32,
+	targetCharacter int32,
+) int {
+	// line before range
+	if targetLine < startLine {
 		return 1
 	}
 
-	if line > int(r.End.Line) {
+	// line after range
+	if targetLine > endLine {
 		return -1
 	}
 
-	if line == int(r.Start.Line) && character < int(r.Start.Character) {
+	// on first line, character before start of range
+	if targetLine == startLine && targetCharacter < startCharacter {
 		return 1
 	}
 
-	if line == int(r.End.Line) && character >= int(r.End.Character) {
+	// on last line; character after end of range
+	if targetLine == endLine && targetCharacter >= endCharacter {
 		return -1
 	}
 
+	// enclosed by range
 	return 0
 }

--- a/enterprise/internal/codeintel/shared/types/scip_test.go
+++ b/enterprise/internal/codeintel/shared/types/scip_test.go
@@ -1,0 +1,54 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/scip/bindings/go/scip"
+)
+
+func TestFindOccurrences(t *testing.T) {
+	occurrences := []*scip.Occurrence{
+		{Range: []int32{0, 3, 4, 5}},
+		{Range: []int32{1, 3, 3, 5}},
+		{Range: []int32{2, 3, 5}},
+		{Range: []int32{5, 3, 5}},
+		{Range: []int32{6, 3, 5}},
+	}
+
+	var matchingRanges [][]int32
+	for _, occurrence := range FindOccurrences(occurrences, 2, 4) {
+		matchingRanges = append(matchingRanges, occurrence.Range)
+	}
+
+	expected := [][]int32{
+		occurrences[2].Range,
+		occurrences[1].Range,
+		occurrences[0].Range,
+	}
+	if diff := cmp.Diff(expected, matchingRanges); diff != "" {
+		t.Errorf("unexpected FindOccurrences result (-want +got):\n%s", diff)
+	}
+}
+
+func TestComparePositionSCIP(t *testing.T) {
+	testCases := []struct {
+		line      int
+		character int
+		expected  int
+	}{
+		{5, 11, 0},
+		{5, 12, 0},
+		{5, 13, -1},
+		{4, 12, +1},
+		{5, 10, +1},
+		{5, 14, -1},
+		{6, 12, -1},
+	}
+
+	for _, testCase := range testCases {
+		if cmp := comparePositionSCIP(scip.NewRange([]int32{5, 11, 13}), testCase.line, testCase.character); cmp != testCase.expected {
+			t.Errorf("unexpected ComparePositionSCIP result for %d:%d. want=%d have=%d", testCase.line, testCase.character, testCase.expected, cmp)
+		}
+	}
+}

--- a/enterprise/internal/codeintel/shared/types/scip_test.go
+++ b/enterprise/internal/codeintel/shared/types/scip_test.go
@@ -31,10 +31,103 @@ func TestFindOccurrences(t *testing.T) {
 	}
 }
 
-func TestComparePositionSCIP(t *testing.T) {
+func TestSortOccurrences(t *testing.T) {
+	occurrences := []*scip.Occurrence{
+		{Range: []int32{2, 3, 5}},       // rank 2
+		{Range: []int32{11, 10, 12}},    // rank 10
+		{Range: []int32{6, 3, 5}},       // rank 4
+		{Range: []int32{10, 4, 8}},      // rank 6
+		{Range: []int32{10, 10, 12}},    // rank 7
+		{Range: []int32{0, 3, 4, 5}},    // rank 0
+		{Range: []int32{12, 1, 13, 12}}, // rank 11
+		{Range: []int32{11, 1, 3}},      // rank 8
+		{Range: []int32{5, 3, 5}},       // rank 3
+		{Range: []int32{10, 1, 3}},      // rank 5
+		{Range: []int32{12, 10, 13, 3}}, // rank 13
+		{Range: []int32{11, 4, 8}},      // rank 9
+		{Range: []int32{12, 4, 13, 8}},  // rank 12
+		{Range: []int32{1, 3, 3, 5}},    // rank 1
+	}
+	unsorted := make([]*scip.Occurrence, len(occurrences))
+	copy(unsorted, occurrences)
+
+	ranges := [][]int32{}
+	for _, r := range SortOccurrences(unsorted) {
+		ranges = append(ranges, r.Range)
+	}
+
+	expected := [][]int32{
+		occurrences[5].Range,
+		occurrences[13].Range,
+		occurrences[0].Range,
+		occurrences[8].Range,
+		occurrences[2].Range,
+		occurrences[9].Range,
+		occurrences[3].Range,
+		occurrences[4].Range,
+		occurrences[7].Range,
+		occurrences[11].Range,
+		occurrences[1].Range,
+		occurrences[6].Range,
+		occurrences[12].Range,
+		occurrences[10].Range,
+	}
+	if diff := cmp.Diff(expected, ranges); diff != "" {
+		t.Errorf("unexpected occurrence order (-want +got):\n%s", diff)
+	}
+}
+
+func TestSortRanges(t *testing.T) {
+	occurrences := []*scip.Range{
+		scip.NewRange([]int32{2, 3, 5}),       // rank 2
+		scip.NewRange([]int32{11, 10, 12}),    // rank 10
+		scip.NewRange([]int32{6, 3, 5}),       // rank 4
+		scip.NewRange([]int32{10, 4, 8}),      // rank 6
+		scip.NewRange([]int32{10, 10, 12}),    // rank 7
+		scip.NewRange([]int32{0, 3, 4, 5}),    // rank 0
+		scip.NewRange([]int32{12, 1, 13, 12}), // rank 11
+		scip.NewRange([]int32{11, 1, 3}),      // rank 8
+		scip.NewRange([]int32{5, 3, 5}),       // rank 3
+		scip.NewRange([]int32{10, 1, 3}),      // rank 5
+		scip.NewRange([]int32{12, 10, 13, 3}), // rank 13
+		scip.NewRange([]int32{11, 4, 8}),      // rank 9
+		scip.NewRange([]int32{12, 4, 13, 8}),  // rank 12
+		scip.NewRange([]int32{1, 3, 3, 5}),    // rank 1
+	}
+	unsorted := make([]*scip.Range, len(occurrences))
+	copy(unsorted, occurrences)
+
+	ranges := [][]int32{}
+	for _, r := range SortRanges(unsorted) {
+		ranges = append(ranges, r.SCIPRange())
+	}
+
+	// TODO - better data
+	expected := [][]int32{
+		occurrences[5].SCIPRange(),
+		occurrences[13].SCIPRange(),
+		occurrences[0].SCIPRange(),
+		occurrences[8].SCIPRange(),
+		occurrences[2].SCIPRange(),
+		occurrences[9].SCIPRange(),
+		occurrences[3].SCIPRange(),
+		occurrences[4].SCIPRange(),
+		occurrences[7].SCIPRange(),
+		occurrences[11].SCIPRange(),
+		occurrences[1].SCIPRange(),
+		occurrences[6].SCIPRange(),
+		occurrences[12].SCIPRange(),
+		occurrences[10].SCIPRange(),
+	}
+	if diff := cmp.Diff(expected, ranges); diff != "" {
+		t.Errorf("unexpected occurrence order (-want +got):\n%s", diff)
+	}
+}
+
+func TestComparePositionToRange(t *testing.T) {
 	testCases := []struct {
-		line      int
-		character int
+		line      int32
+		character int32
 		expected  int
 	}{
 		{5, 11, 0},
@@ -47,7 +140,7 @@ func TestComparePositionSCIP(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		if cmp := comparePositionSCIP(scip.NewRange([]int32{5, 11, 13}), testCase.line, testCase.character); cmp != testCase.expected {
+		if cmp := comparePositionToRange(5, 11, 5, 13, testCase.line, testCase.character); cmp != testCase.expected {
 			t.Errorf("unexpected ComparePositionSCIP result for %d:%d. want=%d have=%d", testCase.line, testCase.character, testCase.expected, cmp)
 		}
 	}


### PR DESCRIPTION
This PR adds a SCIP-typed version of `FindRanges` and `CompareRanges` used by the codenav service.

## Test plan

Additional unit tests.