### PR TITLE
codeintel: Draft lsifstore methods to write SCIP data

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
@@ -9749,6 +9749,9 @@ type MockLsifStore struct {
 	// IDsWithMetaFunc is an instance of a mock function object controlling
 	// the behavior of the method IDsWithMeta.
 	IDsWithMetaFunc *LsifStoreIDsWithMetaFunc
+	// InsertSCIPDocumentFunc is an instance of a mock function object
+	// controlling the behavior of the method InsertSCIPDocument.
+	InsertSCIPDocumentFunc *LsifStoreInsertSCIPDocumentFunc
 	// ReconcileCandidatesFunc is an instance of a mock function object
 	// controlling the behavior of the method ReconcileCandidates.
 	ReconcileCandidatesFunc *LsifStoreReconcileCandidatesFunc
@@ -9782,6 +9785,9 @@ type MockLsifStore struct {
 	// WriteResultChunksFunc is an instance of a mock function object
 	// controlling the behavior of the method WriteResultChunks.
 	WriteResultChunksFunc *LsifStoreWriteResultChunksFunc
+	// WriteSCIPSymbolsFunc is an instance of a mock function object
+	// controlling the behavior of the method WriteSCIPSymbols.
+	WriteSCIPSymbolsFunc *LsifStoreWriteSCIPSymbolsFunc
 }
 
 // NewMockLsifStore creates a new mock of the LsifStore interface. All
@@ -9805,6 +9811,11 @@ func NewMockLsifStore() *MockLsifStore {
 		},
 		IDsWithMetaFunc: &LsifStoreIDsWithMetaFunc{
 			defaultHook: func(context.Context, []int) (r0 []int, r1 error) {
+				return
+			},
+		},
+		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
+			defaultHook: func(context.Context, int, string, []byte, []byte) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -9863,6 +9874,11 @@ func NewMockLsifStore() *MockLsifStore {
 				return
 			},
 		},
+		WriteSCIPSymbolsFunc: &LsifStoreWriteSCIPSymbolsFunc{
+			defaultHook: func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (r0 uint32, r1 error) {
+				return
+			},
+		},
 	}
 }
 
@@ -9888,6 +9904,11 @@ func NewStrictMockLsifStore() *MockLsifStore {
 		IDsWithMetaFunc: &LsifStoreIDsWithMetaFunc{
 			defaultHook: func(context.Context, []int) ([]int, error) {
 				panic("unexpected invocation of MockLsifStore.IDsWithMeta")
+			},
+		},
+		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
+			defaultHook: func(context.Context, int, string, []byte, []byte) (int, error) {
+				panic("unexpected invocation of MockLsifStore.InsertSCIPDocument")
 			},
 		},
 		ReconcileCandidatesFunc: &LsifStoreReconcileCandidatesFunc{
@@ -9945,6 +9966,11 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.WriteResultChunks")
 			},
 		},
+		WriteSCIPSymbolsFunc: &LsifStoreWriteSCIPSymbolsFunc{
+			defaultHook: func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error) {
+				panic("unexpected invocation of MockLsifStore.WriteSCIPSymbols")
+			},
+		},
 	}
 }
 
@@ -9963,6 +9989,9 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		},
 		IDsWithMetaFunc: &LsifStoreIDsWithMetaFunc{
 			defaultHook: i.IDsWithMeta,
+		},
+		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
+			defaultHook: i.InsertSCIPDocument,
 		},
 		ReconcileCandidatesFunc: &LsifStoreReconcileCandidatesFunc{
 			defaultHook: i.ReconcileCandidates,
@@ -9996,6 +10025,9 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		},
 		WriteResultChunksFunc: &LsifStoreWriteResultChunksFunc{
 			defaultHook: i.WriteResultChunks,
+		},
+		WriteSCIPSymbolsFunc: &LsifStoreWriteSCIPSymbolsFunc{
+			defaultHook: i.WriteSCIPSymbols,
 		},
 	}
 }
@@ -10438,6 +10470,124 @@ func (c LsifStoreIDsWithMetaFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c LsifStoreIDsWithMetaFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// LsifStoreInsertSCIPDocumentFunc describes the behavior when the
+// InsertSCIPDocument method of the parent MockLsifStore instance is
+// invoked.
+type LsifStoreInsertSCIPDocumentFunc struct {
+	defaultHook func(context.Context, int, string, []byte, []byte) (int, error)
+	hooks       []func(context.Context, int, string, []byte, []byte) (int, error)
+	history     []LsifStoreInsertSCIPDocumentFuncCall
+	mutex       sync.Mutex
+}
+
+// InsertSCIPDocument delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockLsifStore) InsertSCIPDocument(v0 context.Context, v1 int, v2 string, v3 []byte, v4 []byte) (int, error) {
+	r0, r1 := m.InsertSCIPDocumentFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.InsertSCIPDocumentFunc.appendCall(LsifStoreInsertSCIPDocumentFuncCall{v0, v1, v2, v3, v4, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the InsertSCIPDocument
+// method of the parent MockLsifStore instance is invoked and the hook queue
+// is empty.
+func (f *LsifStoreInsertSCIPDocumentFunc) SetDefaultHook(hook func(context.Context, int, string, []byte, []byte) (int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// InsertSCIPDocument method of the parent MockLsifStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *LsifStoreInsertSCIPDocumentFunc) PushHook(hook func(context.Context, int, string, []byte, []byte) (int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreInsertSCIPDocumentFunc) SetDefaultReturn(r0 int, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, []byte, []byte) (int, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreInsertSCIPDocumentFunc) PushReturn(r0 int, r1 error) {
+	f.PushHook(func(context.Context, int, string, []byte, []byte) (int, error) {
+		return r0, r1
+	})
+}
+
+func (f *LsifStoreInsertSCIPDocumentFunc) nextHook() func(context.Context, int, string, []byte, []byte) (int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreInsertSCIPDocumentFunc) appendCall(r0 LsifStoreInsertSCIPDocumentFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LsifStoreInsertSCIPDocumentFuncCall objects
+// describing the invocations of this function.
+func (f *LsifStoreInsertSCIPDocumentFunc) History() []LsifStoreInsertSCIPDocumentFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreInsertSCIPDocumentFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreInsertSCIPDocumentFuncCall is an object that describes an
+// invocation of method InsertSCIPDocument on an instance of MockLsifStore.
+type LsifStoreInsertSCIPDocumentFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 []byte
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 []byte
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreInsertSCIPDocumentFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreInsertSCIPDocumentFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -11639,6 +11789,120 @@ func (c LsifStoreWriteResultChunksFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c LsifStoreWriteResultChunksFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// LsifStoreWriteSCIPSymbolsFunc describes the behavior when the
+// WriteSCIPSymbols method of the parent MockLsifStore instance is invoked.
+type LsifStoreWriteSCIPSymbolsFunc struct {
+	defaultHook func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error)
+	hooks       []func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error)
+	history     []LsifStoreWriteSCIPSymbolsFuncCall
+	mutex       sync.Mutex
+}
+
+// WriteSCIPSymbols delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockLsifStore) WriteSCIPSymbols(v0 context.Context, v1 int, v2 int, v3 []lsifstore.ProcessedSymbolData) (uint32, error) {
+	r0, r1 := m.WriteSCIPSymbolsFunc.nextHook()(v0, v1, v2, v3)
+	m.WriteSCIPSymbolsFunc.appendCall(LsifStoreWriteSCIPSymbolsFuncCall{v0, v1, v2, v3, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the WriteSCIPSymbols
+// method of the parent MockLsifStore instance is invoked and the hook queue
+// is empty.
+func (f *LsifStoreWriteSCIPSymbolsFunc) SetDefaultHook(hook func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WriteSCIPSymbols method of the parent MockLsifStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *LsifStoreWriteSCIPSymbolsFunc) PushHook(hook func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreWriteSCIPSymbolsFunc) SetDefaultReturn(r0 uint32, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreWriteSCIPSymbolsFunc) PushReturn(r0 uint32, r1 error) {
+	f.PushHook(func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error) {
+		return r0, r1
+	})
+}
+
+func (f *LsifStoreWriteSCIPSymbolsFunc) nextHook() func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreWriteSCIPSymbolsFunc) appendCall(r0 LsifStoreWriteSCIPSymbolsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LsifStoreWriteSCIPSymbolsFuncCall objects
+// describing the invocations of this function.
+func (f *LsifStoreWriteSCIPSymbolsFunc) History() []LsifStoreWriteSCIPSymbolsFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreWriteSCIPSymbolsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreWriteSCIPSymbolsFuncCall is an object that describes an
+// invocation of method WriteSCIPSymbols on an instance of MockLsifStore.
+type LsifStoreWriteSCIPSymbolsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 []lsifstore.ProcessedSymbolData
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 uint32
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreWriteSCIPSymbolsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreWriteSCIPSymbolsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore.go
@@ -16,6 +16,9 @@ type LsifStore interface {
 	GetUploadDocumentsForPath(ctx context.Context, bundleID int, pathPattern string) ([]string, int, error)
 	DeleteLsifDataByUploadIds(ctx context.Context, bundleIDs ...int) (err error)
 
+	InsertSCIPDocument(ctx context.Context, uploadID int, documentPath string, hash []byte, rawSCIPPayload []byte) (int, error)
+	WriteSCIPSymbols(ctx context.Context, uploadID, documentLookupID int, symbols []ProcessedSymbolData) (uint32, error)
+
 	WriteMeta(ctx context.Context, bundleID int, meta precise.MetaData) error
 	WriteDocuments(ctx context.Context, bundleID int, documents chan precise.KeyedDocumentData) (count uint32, err error)
 	WriteResultChunks(ctx context.Context, bundleID int, resultChunks chan precise.IndexedResultChunkData) (count uint32, err error)

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
@@ -15,6 +15,8 @@ type operations struct {
 	scanDocuments             *observation.Operation
 	scanResultChunks          *observation.Operation
 	scanLocations             *observation.Operation
+	insertSCIPDocument        *observation.Operation
+	writeSCIPSymbols          *observation.Operation
 	writeMeta                 *observation.Operation
 	writeDocuments            *observation.Operation
 	writeResultChunks         *observation.Operation
@@ -47,6 +49,8 @@ func newOperations(observationContext *observation.Context) *operations {
 		scanDocuments:             op("ScanDocuments"),
 		scanResultChunks:          op("ScanResultChunks"),
 		scanLocations:             op("ScanLocations"),
+		insertSCIPDocument:        op("InsertSCIPDocument"),
+		writeSCIPSymbols:          op("WriteSCIPSymbols"),
 		writeMeta:                 op("WriteMeta"),
 		writeDocuments:            op("WriteDocuments"),
 		writeResultChunks:         op("WriteResultChunks"),

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_write.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_write.go
@@ -1,0 +1,202 @@
+package lsifstore
+
+import (
+	"context"
+	"encoding/base64"
+	"sync/atomic"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/opentracing/opentracing-go/log"
+	otlog "github.com/opentracing/opentracing-go/log"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/batch"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
+)
+
+type ProcessedSCIPDocument struct {
+	DocumentPath   string
+	Hash           []byte
+	RawSCIPPayload []byte
+	Symbols        []ProcessedSymbolData
+	Err            error
+}
+
+type ProcessedSymbolData struct {
+	SymbolName           string
+	DefinitionRanges     []int32
+	ReferenceRanges      []int32
+	ImplementationRanges []int32
+	TypeDefinitionRanges []int32
+}
+
+type ProcessedSCIPData struct {
+	Documents         <-chan ProcessedSCIPDocument
+	Packages          []precise.Package
+	PackageReferences []precise.PackageReference
+}
+
+func (s *store) InsertSCIPDocument(ctx context.Context, uploadID int, documentPath string, hash []byte, rawSCIPPayload []byte) (_ int, err error) {
+	ctx, _, endObservation := s.operations.insertSCIPDocument.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
+		otlog.Int("uploadID", uploadID),
+		otlog.String("documentPath", documentPath),
+		otlog.String("hash", base64.StdEncoding.EncodeToString(hash)),
+		otlog.Int("rawSCIPPayloadLen", len(rawSCIPPayload)),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	id, _, err := basestore.ScanFirstInt(s.db.Query(ctx, sqlf.Sprintf(
+		insertSCIPDocumentQuery,
+		hash,
+		rawSCIPPayload,
+		hash,
+		uploadID,
+		documentPath,
+	)))
+	if err != nil {
+		return 0, err
+	}
+
+	return id, nil
+}
+
+const insertSCIPDocumentQuery = `
+WITH
+new_shared_document AS (
+	INSERT INTO codeintel_scip_documents (schema_version, payload_hash, raw_scip_payload)
+	VALUES (1, %s, %s)
+	ON CONFLICT DO NOTHING
+	RETURNING id
+),
+shared_document AS (
+	SELECT id FROM new_shared_document
+	UNION ALL
+	SELECT id FROM codeintel_scip_documents WHERE payload_hash = %s
+)
+INSERT INTO codeintel_scip_document_lookup (upload_id, document_path, document_id)
+SELECT %s, %s, id FROM shared_document LIMIT 1
+RETURNING id
+`
+
+func (s *store) WriteSCIPSymbols(ctx context.Context, uploadID, documentLookupID int, symbols []ProcessedSymbolData) (count uint32, err error) {
+	ctx, trace, endObservation := s.operations.writeSCIPSymbols.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
+		otlog.Int("uploadID", uploadID),
+		otlog.Int("documentLookupID", documentLookupID),
+		otlog.Int("numSymbols", len(symbols)),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	tx, err := s.db.Transact(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	if err := tx.Exec(ctx, sqlf.Sprintf(writeSCIPSymbolsTemporaryTableQuery)); err != nil {
+		return 0, err
+	}
+
+	inserter := func(inserter *batch.Inserter) error {
+		for _, symbol := range symbols {
+			definitionRanges, err := types.EncodeRanges(symbol.DefinitionRanges)
+			if err != nil {
+				return err
+			}
+			referenceRanges, err := types.EncodeRanges(symbol.ReferenceRanges)
+			if err != nil {
+				return err
+			}
+			implementationRanges, err := types.EncodeRanges(symbol.ImplementationRanges)
+			if err != nil {
+				return err
+			}
+			typeDefinitionRanges, err := types.EncodeRanges(symbol.TypeDefinitionRanges)
+			if err != nil {
+				return err
+			}
+
+			if err := inserter.Insert(
+				ctx,
+				uploadID,
+				symbol.SymbolName,
+				definitionRanges,
+				referenceRanges,
+				implementationRanges,
+				typeDefinitionRanges,
+			); err != nil {
+				return err
+			}
+
+			atomic.AddUint32(&count, 1)
+		}
+
+		return nil
+	}
+
+	if err := withSingleThreadedBatchInserter(
+		ctx,
+		tx.Handle(),
+		"t_codeintel_scip_symbols",
+		[]string{
+			"upload_id",
+			"symbol_name",
+			"definition_ranges",
+			"reference_ranges",
+			"implementation_ranges",
+			"type_definition_ranges",
+		},
+		inserter,
+	); err != nil {
+		return 0, err
+	}
+	trace.Log(log.Int("numRecords", int(count)))
+
+	err = tx.Exec(ctx, sqlf.Sprintf(writeSCIPSymbolsInsertQuery, documentLookupID, 1))
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+const writeSCIPSymbolsTemporaryTableQuery = `
+CREATE TEMPORARY TABLE t_codeintel_scip_symbols (
+	upload_id integer NOT NULL,
+	symbol_name text NOT NULL,
+	definition_ranges bytea,
+	reference_ranges bytea,
+	implementation_ranges bytea,
+	type_definition_ranges bytea
+) ON COMMIT DROP
+`
+
+const writeSCIPSymbolsInsertQuery = `
+INSERT INTO codeintel_scip_symbols (
+	upload_id,
+	symbol_name,
+	document_lookup_id,
+	schema_version,
+	definition_ranges,
+	reference_ranges,
+	implementation_ranges,
+	type_definition_ranges
+)
+SELECT
+	source.upload_id,
+	source.symbol_name,
+	%s,
+	%s,
+	source.definition_ranges,
+	source.reference_ranges,
+	source.implementation_ranges,
+	source.type_definition_ranges
+FROM t_codeintel_scip_symbols source
+ON CONFLICT DO NOTHING
+`
+
+func withSingleThreadedBatchInserter(ctx context.Context, db dbutil.DB, tableName string, columns []string, f func(inserter *batch.Inserter) error) (err error) {
+	return batch.WithInserter(ctx, db, tableName, batch.MaxNumPostgresParameters, columns, f)
+}

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_write_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_write_test.go
@@ -1,0 +1,126 @@
+package lsifstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+
+	codeintelshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+func TestInsertSCIPDocument(t *testing.T) {
+	logger := logtest.Scoped(t)
+	codeIntelDB := codeintelshared.NewCodeIntelDB(dbtest.NewDB(logger, t))
+	store := New(codeIntelDB, &observation.TestContext)
+	ctx := context.Background()
+
+	if _, err := store.InsertSCIPDocument(
+		ctx,
+		24,
+		"internal/util.go",
+		[]byte("deadbeef"),
+		[]byte("lorem ipsum dolor sit amet"),
+	); err != nil {
+		t.Fatalf("failed to write SCIP document: %s", err)
+	}
+
+	if _, err := store.InsertSCIPDocument(
+		ctx,
+		25,
+		"internal/util.go",
+		[]byte("deadbeef"),
+		[]byte("lorem ipsum dolor sit amet"),
+	); err != nil {
+		t.Fatalf("failed to write SCIP document: %s", err)
+	}
+
+	if _, err := store.InsertSCIPDocument(
+		ctx,
+		25,
+		"internal/util_test.go",
+		[]byte("cafebabe"),
+		[]byte("consectetur adipiscing elit, sed do eiusmod"),
+	); err != nil {
+		t.Fatalf("failed to write SCIP document: %s", err)
+	}
+
+	count, _, err := basestore.ScanFirstInt(codeIntelDB.Handle().QueryContext(ctx, `SELECT COUNT(*) FROM codeintel_scip_documents`))
+	if err != nil {
+		t.Fatalf("failed to query number of SCIP documents: %s", err)
+	} else if expected := 2; count != expected {
+		t.Fatalf("unexpected number of documents. want=%d have=%d", expected, count)
+	}
+}
+
+func TestWriteSCIPSymbols(t *testing.T) {
+	logger := logtest.Scoped(t)
+	codeIntelDB := codeintelshared.NewCodeIntelDB(dbtest.NewDB(logger, t))
+	store := New(codeIntelDB, &observation.TestContext)
+	ctx := context.Background()
+
+	uploadID := 24
+
+	documentLookupID, err := store.InsertSCIPDocument(
+		ctx,
+		uploadID,
+		"internal/util.go",
+		[]byte("deadbeef"),
+		[]byte("lorem ipsum dolor sit amet"),
+	)
+	if err != nil {
+		t.Fatalf("failed to write SCIP document: %s", err)
+	}
+
+	symbols := []ProcessedSymbolData{
+		{
+			SymbolName: "foo.bar.ident",
+			DefinitionRanges: []int32{
+				3, 25, 3, 30,
+			},
+			ReferenceRanges: []int32{
+				4, 25, 4, 30,
+				5, 10, 5, 15,
+				5, 25, 5, 30,
+				6, 16, 6, 21,
+			},
+		},
+		{
+			SymbolName: "bar.baz.longerName",
+			ReferenceRanges: []int32{
+				100, 10, 100, 20,
+				101, 15, 101, 25,
+				103, 16, 103, 26,
+				103, 31, 103, 41,
+				103, 55, 103, 65,
+				151, 10, 151, 20,
+				152, 15, 152, 25,
+				154, 25, 154, 35,
+				154, 50, 154, 60,
+			},
+			ImplementationRanges: []int32{
+				342, 5, 342, 15,
+				364, 5, 364, 15,
+			},
+		},
+		{
+			SymbolName: "baz.bonk.quux",
+			DefinitionRanges: []int32{
+				251, 24, 251, 30,
+			},
+			TypeDefinitionRanges: []int32{
+				151, 14, 151, 20,
+			},
+		},
+	}
+	n, err := store.WriteSCIPSymbols(ctx, uploadID, documentLookupID, symbols)
+	if err != nil {
+		t.Fatalf("failed to write SCIP symbols: %s", err)
+	}
+	if expected := uint32(3); n != expected {
+		t.Fatalf("unexpected number of symbols inserted. want=%d have=%d", expected, n)
+	}
+}

--- a/enterprise/internal/codeintel/uploads/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/mocks_test.go
@@ -7420,6 +7420,9 @@ type MockLsifStore struct {
 	// IDsWithMetaFunc is an instance of a mock function object controlling
 	// the behavior of the method IDsWithMeta.
 	IDsWithMetaFunc *LsifStoreIDsWithMetaFunc
+	// InsertSCIPDocumentFunc is an instance of a mock function object
+	// controlling the behavior of the method InsertSCIPDocument.
+	InsertSCIPDocumentFunc *LsifStoreInsertSCIPDocumentFunc
 	// ReconcileCandidatesFunc is an instance of a mock function object
 	// controlling the behavior of the method ReconcileCandidates.
 	ReconcileCandidatesFunc *LsifStoreReconcileCandidatesFunc
@@ -7435,24 +7438,9 @@ type MockLsifStore struct {
 	// TransactFunc is an instance of a mock function object controlling the
 	// behavior of the method Transact.
 	TransactFunc *LsifStoreTransactFunc
-	// WriteDefinitionsFunc is an instance of a mock function object
-	// controlling the behavior of the method WriteDefinitions.
-	WriteDefinitionsFunc *LsifStoreWriteDefinitionsFunc
-	// WriteDocumentsFunc is an instance of a mock function object
-	// controlling the behavior of the method WriteDocuments.
-	WriteDocumentsFunc *LsifStoreWriteDocumentsFunc
-	// WriteImplementationsFunc is an instance of a mock function object
-	// controlling the behavior of the method WriteImplementations.
-	WriteImplementationsFunc *LsifStoreWriteImplementationsFunc
-	// WriteMetaFunc is an instance of a mock function object controlling
-	// the behavior of the method WriteMeta.
-	WriteMetaFunc *LsifStoreWriteMetaFunc
-	// WriteReferencesFunc is an instance of a mock function object
-	// controlling the behavior of the method WriteReferences.
-	WriteReferencesFunc *LsifStoreWriteReferencesFunc
-	// WriteResultChunksFunc is an instance of a mock function object
-	// controlling the behavior of the method WriteResultChunks.
-	WriteResultChunksFunc *LsifStoreWriteResultChunksFunc
+	// WriteSCIPSymbolsFunc is an instance of a mock function object
+	// controlling the behavior of the method WriteSCIPSymbols.
+	WriteSCIPSymbolsFunc *LsifStoreWriteSCIPSymbolsFunc
 }
 
 // NewMockLsifStore creates a new mock of the LsifStore interface. All
@@ -7476,6 +7464,11 @@ func NewMockLsifStore() *MockLsifStore {
 		},
 		IDsWithMetaFunc: &LsifStoreIDsWithMetaFunc{
 			defaultHook: func(context.Context, []int) (r0 []int, r1 error) {
+				return
+			},
+		},
+		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
+			defaultHook: func(context.Context, int, string, []byte, []byte) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -7504,33 +7497,8 @@ func NewMockLsifStore() *MockLsifStore {
 				return
 			},
 		},
-		WriteDefinitionsFunc: &LsifStoreWriteDefinitionsFunc{
-			defaultHook: func(context.Context, int, chan precise.MonikerLocations) (r0 uint32, r1 error) {
-				return
-			},
-		},
-		WriteDocumentsFunc: &LsifStoreWriteDocumentsFunc{
-			defaultHook: func(context.Context, int, chan precise.KeyedDocumentData) (r0 uint32, r1 error) {
-				return
-			},
-		},
-		WriteImplementationsFunc: &LsifStoreWriteImplementationsFunc{
-			defaultHook: func(context.Context, int, chan precise.MonikerLocations) (r0 uint32, r1 error) {
-				return
-			},
-		},
-		WriteMetaFunc: &LsifStoreWriteMetaFunc{
-			defaultHook: func(context.Context, int, precise.MetaData) (r0 error) {
-				return
-			},
-		},
-		WriteReferencesFunc: &LsifStoreWriteReferencesFunc{
-			defaultHook: func(context.Context, int, chan precise.MonikerLocations) (r0 uint32, r1 error) {
-				return
-			},
-		},
-		WriteResultChunksFunc: &LsifStoreWriteResultChunksFunc{
-			defaultHook: func(context.Context, int, chan precise.IndexedResultChunkData) (r0 uint32, r1 error) {
+		WriteSCIPSymbolsFunc: &LsifStoreWriteSCIPSymbolsFunc{
+			defaultHook: func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (r0 uint32, r1 error) {
 				return
 			},
 		},
@@ -7561,6 +7529,11 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.IDsWithMeta")
 			},
 		},
+		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
+			defaultHook: func(context.Context, int, string, []byte, []byte) (int, error) {
+				panic("unexpected invocation of MockLsifStore.InsertSCIPDocument")
+			},
+		},
 		ReconcileCandidatesFunc: &LsifStoreReconcileCandidatesFunc{
 			defaultHook: func(context.Context, int) ([]int, error) {
 				panic("unexpected invocation of MockLsifStore.ReconcileCandidates")
@@ -7586,34 +7559,9 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.Transact")
 			},
 		},
-		WriteDefinitionsFunc: &LsifStoreWriteDefinitionsFunc{
-			defaultHook: func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
-				panic("unexpected invocation of MockLsifStore.WriteDefinitions")
-			},
-		},
-		WriteDocumentsFunc: &LsifStoreWriteDocumentsFunc{
-			defaultHook: func(context.Context, int, chan precise.KeyedDocumentData) (uint32, error) {
-				panic("unexpected invocation of MockLsifStore.WriteDocuments")
-			},
-		},
-		WriteImplementationsFunc: &LsifStoreWriteImplementationsFunc{
-			defaultHook: func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
-				panic("unexpected invocation of MockLsifStore.WriteImplementations")
-			},
-		},
-		WriteMetaFunc: &LsifStoreWriteMetaFunc{
-			defaultHook: func(context.Context, int, precise.MetaData) error {
-				panic("unexpected invocation of MockLsifStore.WriteMeta")
-			},
-		},
-		WriteReferencesFunc: &LsifStoreWriteReferencesFunc{
-			defaultHook: func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
-				panic("unexpected invocation of MockLsifStore.WriteReferences")
-			},
-		},
-		WriteResultChunksFunc: &LsifStoreWriteResultChunksFunc{
-			defaultHook: func(context.Context, int, chan precise.IndexedResultChunkData) (uint32, error) {
-				panic("unexpected invocation of MockLsifStore.WriteResultChunks")
+		WriteSCIPSymbolsFunc: &LsifStoreWriteSCIPSymbolsFunc{
+			defaultHook: func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error) {
+				panic("unexpected invocation of MockLsifStore.WriteSCIPSymbols")
 			},
 		},
 	}
@@ -7635,6 +7583,9 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		IDsWithMetaFunc: &LsifStoreIDsWithMetaFunc{
 			defaultHook: i.IDsWithMeta,
 		},
+		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
+			defaultHook: i.InsertSCIPDocument,
+		},
 		ReconcileCandidatesFunc: &LsifStoreReconcileCandidatesFunc{
 			defaultHook: i.ReconcileCandidates,
 		},
@@ -7650,23 +7601,8 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		TransactFunc: &LsifStoreTransactFunc{
 			defaultHook: i.Transact,
 		},
-		WriteDefinitionsFunc: &LsifStoreWriteDefinitionsFunc{
-			defaultHook: i.WriteDefinitions,
-		},
-		WriteDocumentsFunc: &LsifStoreWriteDocumentsFunc{
-			defaultHook: i.WriteDocuments,
-		},
-		WriteImplementationsFunc: &LsifStoreWriteImplementationsFunc{
-			defaultHook: i.WriteImplementations,
-		},
-		WriteMetaFunc: &LsifStoreWriteMetaFunc{
-			defaultHook: i.WriteMeta,
-		},
-		WriteReferencesFunc: &LsifStoreWriteReferencesFunc{
-			defaultHook: i.WriteReferences,
-		},
-		WriteResultChunksFunc: &LsifStoreWriteResultChunksFunc{
-			defaultHook: i.WriteResultChunks,
+		WriteSCIPSymbolsFunc: &LsifStoreWriteSCIPSymbolsFunc{
+			defaultHook: i.WriteSCIPSymbols,
 		},
 	}
 }
@@ -8109,6 +8045,124 @@ func (c LsifStoreIDsWithMetaFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c LsifStoreIDsWithMetaFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// LsifStoreInsertSCIPDocumentFunc describes the behavior when the
+// InsertSCIPDocument method of the parent MockLsifStore instance is
+// invoked.
+type LsifStoreInsertSCIPDocumentFunc struct {
+	defaultHook func(context.Context, int, string, []byte, []byte) (int, error)
+	hooks       []func(context.Context, int, string, []byte, []byte) (int, error)
+	history     []LsifStoreInsertSCIPDocumentFuncCall
+	mutex       sync.Mutex
+}
+
+// InsertSCIPDocument delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockLsifStore) InsertSCIPDocument(v0 context.Context, v1 int, v2 string, v3 []byte, v4 []byte) (int, error) {
+	r0, r1 := m.InsertSCIPDocumentFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.InsertSCIPDocumentFunc.appendCall(LsifStoreInsertSCIPDocumentFuncCall{v0, v1, v2, v3, v4, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the InsertSCIPDocument
+// method of the parent MockLsifStore instance is invoked and the hook queue
+// is empty.
+func (f *LsifStoreInsertSCIPDocumentFunc) SetDefaultHook(hook func(context.Context, int, string, []byte, []byte) (int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// InsertSCIPDocument method of the parent MockLsifStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *LsifStoreInsertSCIPDocumentFunc) PushHook(hook func(context.Context, int, string, []byte, []byte) (int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreInsertSCIPDocumentFunc) SetDefaultReturn(r0 int, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, []byte, []byte) (int, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreInsertSCIPDocumentFunc) PushReturn(r0 int, r1 error) {
+	f.PushHook(func(context.Context, int, string, []byte, []byte) (int, error) {
+		return r0, r1
+	})
+}
+
+func (f *LsifStoreInsertSCIPDocumentFunc) nextHook() func(context.Context, int, string, []byte, []byte) (int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreInsertSCIPDocumentFunc) appendCall(r0 LsifStoreInsertSCIPDocumentFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LsifStoreInsertSCIPDocumentFuncCall objects
+// describing the invocations of this function.
+func (f *LsifStoreInsertSCIPDocumentFunc) History() []LsifStoreInsertSCIPDocumentFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreInsertSCIPDocumentFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreInsertSCIPDocumentFuncCall is an object that describes an
+// invocation of method InsertSCIPDocument on an instance of MockLsifStore.
+type LsifStoreInsertSCIPDocumentFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 []byte
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 []byte
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreInsertSCIPDocumentFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreInsertSCIPDocumentFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -8649,35 +8703,35 @@ func (c LsifStoreTransactFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// LsifStoreWriteDefinitionsFunc describes the behavior when the
-// WriteDefinitions method of the parent MockLsifStore instance is invoked.
-type LsifStoreWriteDefinitionsFunc struct {
-	defaultHook func(context.Context, int, chan precise.MonikerLocations) (uint32, error)
-	hooks       []func(context.Context, int, chan precise.MonikerLocations) (uint32, error)
-	history     []LsifStoreWriteDefinitionsFuncCall
+// LsifStoreWriteSCIPSymbolsFunc describes the behavior when the
+// WriteSCIPSymbols method of the parent MockLsifStore instance is invoked.
+type LsifStoreWriteSCIPSymbolsFunc struct {
+	defaultHook func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error)
+	hooks       []func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error)
+	history     []LsifStoreWriteSCIPSymbolsFuncCall
 	mutex       sync.Mutex
 }
 
-// WriteDefinitions delegates to the next hook function in the queue and
+// WriteSCIPSymbols delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockLsifStore) WriteDefinitions(v0 context.Context, v1 int, v2 chan precise.MonikerLocations) (uint32, error) {
-	r0, r1 := m.WriteDefinitionsFunc.nextHook()(v0, v1, v2)
-	m.WriteDefinitionsFunc.appendCall(LsifStoreWriteDefinitionsFuncCall{v0, v1, v2, r0, r1})
+func (m *MockLsifStore) WriteSCIPSymbols(v0 context.Context, v1 int, v2 int, v3 []lsifstore.ProcessedSymbolData) (uint32, error) {
+	r0, r1 := m.WriteSCIPSymbolsFunc.nextHook()(v0, v1, v2, v3)
+	m.WriteSCIPSymbolsFunc.appendCall(LsifStoreWriteSCIPSymbolsFuncCall{v0, v1, v2, v3, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the WriteDefinitions
+// SetDefaultHook sets function that is called when the WriteSCIPSymbols
 // method of the parent MockLsifStore instance is invoked and the hook queue
 // is empty.
-func (f *LsifStoreWriteDefinitionsFunc) SetDefaultHook(hook func(context.Context, int, chan precise.MonikerLocations) (uint32, error)) {
+func (f *LsifStoreWriteSCIPSymbolsFunc) SetDefaultHook(hook func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// WriteDefinitions method of the parent MockLsifStore instance invokes the
+// WriteSCIPSymbols method of the parent MockLsifStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *LsifStoreWriteDefinitionsFunc) PushHook(hook func(context.Context, int, chan precise.MonikerLocations) (uint32, error)) {
+func (f *LsifStoreWriteSCIPSymbolsFunc) PushHook(hook func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -8685,20 +8739,20 @@ func (f *LsifStoreWriteDefinitionsFunc) PushHook(hook func(context.Context, int,
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *LsifStoreWriteDefinitionsFunc) SetDefaultReturn(r0 uint32, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
+func (f *LsifStoreWriteSCIPSymbolsFunc) SetDefaultReturn(r0 uint32, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreWriteDefinitionsFunc) PushReturn(r0 uint32, r1 error) {
-	f.PushHook(func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
+func (f *LsifStoreWriteSCIPSymbolsFunc) PushReturn(r0 uint32, r1 error) {
+	f.PushHook(func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error) {
 		return r0, r1
 	})
 }
 
-func (f *LsifStoreWriteDefinitionsFunc) nextHook() func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
+func (f *LsifStoreWriteSCIPSymbolsFunc) nextHook() func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -8711,26 +8765,26 @@ func (f *LsifStoreWriteDefinitionsFunc) nextHook() func(context.Context, int, ch
 	return hook
 }
 
-func (f *LsifStoreWriteDefinitionsFunc) appendCall(r0 LsifStoreWriteDefinitionsFuncCall) {
+func (f *LsifStoreWriteSCIPSymbolsFunc) appendCall(r0 LsifStoreWriteSCIPSymbolsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of LsifStoreWriteDefinitionsFuncCall objects
+// History returns a sequence of LsifStoreWriteSCIPSymbolsFuncCall objects
 // describing the invocations of this function.
-func (f *LsifStoreWriteDefinitionsFunc) History() []LsifStoreWriteDefinitionsFuncCall {
+func (f *LsifStoreWriteSCIPSymbolsFunc) History() []LsifStoreWriteSCIPSymbolsFuncCall {
 	f.mutex.Lock()
-	history := make([]LsifStoreWriteDefinitionsFuncCall, len(f.history))
+	history := make([]LsifStoreWriteSCIPSymbolsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// LsifStoreWriteDefinitionsFuncCall is an object that describes an
-// invocation of method WriteDefinitions on an instance of MockLsifStore.
-type LsifStoreWriteDefinitionsFuncCall struct {
+// LsifStoreWriteSCIPSymbolsFuncCall is an object that describes an
+// invocation of method WriteSCIPSymbols on an instance of MockLsifStore.
+type LsifStoreWriteSCIPSymbolsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -8739,7 +8793,10 @@ type LsifStoreWriteDefinitionsFuncCall struct {
 	Arg1 int
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 chan precise.MonikerLocations
+	Arg2 int
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 []lsifstore.ProcessedSymbolData
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 uint32
@@ -8750,566 +8807,13 @@ type LsifStoreWriteDefinitionsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LsifStoreWriteDefinitionsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c LsifStoreWriteSCIPSymbolsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LsifStoreWriteDefinitionsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// LsifStoreWriteDocumentsFunc describes the behavior when the
-// WriteDocuments method of the parent MockLsifStore instance is invoked.
-type LsifStoreWriteDocumentsFunc struct {
-	defaultHook func(context.Context, int, chan precise.KeyedDocumentData) (uint32, error)
-	hooks       []func(context.Context, int, chan precise.KeyedDocumentData) (uint32, error)
-	history     []LsifStoreWriteDocumentsFuncCall
-	mutex       sync.Mutex
-}
-
-// WriteDocuments delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockLsifStore) WriteDocuments(v0 context.Context, v1 int, v2 chan precise.KeyedDocumentData) (uint32, error) {
-	r0, r1 := m.WriteDocumentsFunc.nextHook()(v0, v1, v2)
-	m.WriteDocumentsFunc.appendCall(LsifStoreWriteDocumentsFuncCall{v0, v1, v2, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the WriteDocuments
-// method of the parent MockLsifStore instance is invoked and the hook queue
-// is empty.
-func (f *LsifStoreWriteDocumentsFunc) SetDefaultHook(hook func(context.Context, int, chan precise.KeyedDocumentData) (uint32, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// WriteDocuments method of the parent MockLsifStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *LsifStoreWriteDocumentsFunc) PushHook(hook func(context.Context, int, chan precise.KeyedDocumentData) (uint32, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *LsifStoreWriteDocumentsFunc) SetDefaultReturn(r0 uint32, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, chan precise.KeyedDocumentData) (uint32, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreWriteDocumentsFunc) PushReturn(r0 uint32, r1 error) {
-	f.PushHook(func(context.Context, int, chan precise.KeyedDocumentData) (uint32, error) {
-		return r0, r1
-	})
-}
-
-func (f *LsifStoreWriteDocumentsFunc) nextHook() func(context.Context, int, chan precise.KeyedDocumentData) (uint32, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *LsifStoreWriteDocumentsFunc) appendCall(r0 LsifStoreWriteDocumentsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of LsifStoreWriteDocumentsFuncCall objects
-// describing the invocations of this function.
-func (f *LsifStoreWriteDocumentsFunc) History() []LsifStoreWriteDocumentsFuncCall {
-	f.mutex.Lock()
-	history := make([]LsifStoreWriteDocumentsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// LsifStoreWriteDocumentsFuncCall is an object that describes an invocation
-// of method WriteDocuments on an instance of MockLsifStore.
-type LsifStoreWriteDocumentsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 chan precise.KeyedDocumentData
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 uint32
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c LsifStoreWriteDocumentsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c LsifStoreWriteDocumentsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// LsifStoreWriteImplementationsFunc describes the behavior when the
-// WriteImplementations method of the parent MockLsifStore instance is
-// invoked.
-type LsifStoreWriteImplementationsFunc struct {
-	defaultHook func(context.Context, int, chan precise.MonikerLocations) (uint32, error)
-	hooks       []func(context.Context, int, chan precise.MonikerLocations) (uint32, error)
-	history     []LsifStoreWriteImplementationsFuncCall
-	mutex       sync.Mutex
-}
-
-// WriteImplementations delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockLsifStore) WriteImplementations(v0 context.Context, v1 int, v2 chan precise.MonikerLocations) (uint32, error) {
-	r0, r1 := m.WriteImplementationsFunc.nextHook()(v0, v1, v2)
-	m.WriteImplementationsFunc.appendCall(LsifStoreWriteImplementationsFuncCall{v0, v1, v2, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the WriteImplementations
-// method of the parent MockLsifStore instance is invoked and the hook queue
-// is empty.
-func (f *LsifStoreWriteImplementationsFunc) SetDefaultHook(hook func(context.Context, int, chan precise.MonikerLocations) (uint32, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// WriteImplementations method of the parent MockLsifStore instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *LsifStoreWriteImplementationsFunc) PushHook(hook func(context.Context, int, chan precise.MonikerLocations) (uint32, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *LsifStoreWriteImplementationsFunc) SetDefaultReturn(r0 uint32, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreWriteImplementationsFunc) PushReturn(r0 uint32, r1 error) {
-	f.PushHook(func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
-		return r0, r1
-	})
-}
-
-func (f *LsifStoreWriteImplementationsFunc) nextHook() func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *LsifStoreWriteImplementationsFunc) appendCall(r0 LsifStoreWriteImplementationsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of LsifStoreWriteImplementationsFuncCall
-// objects describing the invocations of this function.
-func (f *LsifStoreWriteImplementationsFunc) History() []LsifStoreWriteImplementationsFuncCall {
-	f.mutex.Lock()
-	history := make([]LsifStoreWriteImplementationsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// LsifStoreWriteImplementationsFuncCall is an object that describes an
-// invocation of method WriteImplementations on an instance of
-// MockLsifStore.
-type LsifStoreWriteImplementationsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 chan precise.MonikerLocations
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 uint32
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c LsifStoreWriteImplementationsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c LsifStoreWriteImplementationsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// LsifStoreWriteMetaFunc describes the behavior when the WriteMeta method
-// of the parent MockLsifStore instance is invoked.
-type LsifStoreWriteMetaFunc struct {
-	defaultHook func(context.Context, int, precise.MetaData) error
-	hooks       []func(context.Context, int, precise.MetaData) error
-	history     []LsifStoreWriteMetaFuncCall
-	mutex       sync.Mutex
-}
-
-// WriteMeta delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockLsifStore) WriteMeta(v0 context.Context, v1 int, v2 precise.MetaData) error {
-	r0 := m.WriteMetaFunc.nextHook()(v0, v1, v2)
-	m.WriteMetaFunc.appendCall(LsifStoreWriteMetaFuncCall{v0, v1, v2, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the WriteMeta method of
-// the parent MockLsifStore instance is invoked and the hook queue is empty.
-func (f *LsifStoreWriteMetaFunc) SetDefaultHook(hook func(context.Context, int, precise.MetaData) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// WriteMeta method of the parent MockLsifStore instance invokes the hook at
-// the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *LsifStoreWriteMetaFunc) PushHook(hook func(context.Context, int, precise.MetaData) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *LsifStoreWriteMetaFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int, precise.MetaData) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreWriteMetaFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int, precise.MetaData) error {
-		return r0
-	})
-}
-
-func (f *LsifStoreWriteMetaFunc) nextHook() func(context.Context, int, precise.MetaData) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *LsifStoreWriteMetaFunc) appendCall(r0 LsifStoreWriteMetaFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of LsifStoreWriteMetaFuncCall objects
-// describing the invocations of this function.
-func (f *LsifStoreWriteMetaFunc) History() []LsifStoreWriteMetaFuncCall {
-	f.mutex.Lock()
-	history := make([]LsifStoreWriteMetaFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// LsifStoreWriteMetaFuncCall is an object that describes an invocation of
-// method WriteMeta on an instance of MockLsifStore.
-type LsifStoreWriteMetaFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 precise.MetaData
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c LsifStoreWriteMetaFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c LsifStoreWriteMetaFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
-}
-
-// LsifStoreWriteReferencesFunc describes the behavior when the
-// WriteReferences method of the parent MockLsifStore instance is invoked.
-type LsifStoreWriteReferencesFunc struct {
-	defaultHook func(context.Context, int, chan precise.MonikerLocations) (uint32, error)
-	hooks       []func(context.Context, int, chan precise.MonikerLocations) (uint32, error)
-	history     []LsifStoreWriteReferencesFuncCall
-	mutex       sync.Mutex
-}
-
-// WriteReferences delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockLsifStore) WriteReferences(v0 context.Context, v1 int, v2 chan precise.MonikerLocations) (uint32, error) {
-	r0, r1 := m.WriteReferencesFunc.nextHook()(v0, v1, v2)
-	m.WriteReferencesFunc.appendCall(LsifStoreWriteReferencesFuncCall{v0, v1, v2, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the WriteReferences
-// method of the parent MockLsifStore instance is invoked and the hook queue
-// is empty.
-func (f *LsifStoreWriteReferencesFunc) SetDefaultHook(hook func(context.Context, int, chan precise.MonikerLocations) (uint32, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// WriteReferences method of the parent MockLsifStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *LsifStoreWriteReferencesFunc) PushHook(hook func(context.Context, int, chan precise.MonikerLocations) (uint32, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *LsifStoreWriteReferencesFunc) SetDefaultReturn(r0 uint32, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreWriteReferencesFunc) PushReturn(r0 uint32, r1 error) {
-	f.PushHook(func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
-		return r0, r1
-	})
-}
-
-func (f *LsifStoreWriteReferencesFunc) nextHook() func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *LsifStoreWriteReferencesFunc) appendCall(r0 LsifStoreWriteReferencesFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of LsifStoreWriteReferencesFuncCall objects
-// describing the invocations of this function.
-func (f *LsifStoreWriteReferencesFunc) History() []LsifStoreWriteReferencesFuncCall {
-	f.mutex.Lock()
-	history := make([]LsifStoreWriteReferencesFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// LsifStoreWriteReferencesFuncCall is an object that describes an
-// invocation of method WriteReferences on an instance of MockLsifStore.
-type LsifStoreWriteReferencesFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 chan precise.MonikerLocations
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 uint32
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c LsifStoreWriteReferencesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c LsifStoreWriteReferencesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// LsifStoreWriteResultChunksFunc describes the behavior when the
-// WriteResultChunks method of the parent MockLsifStore instance is invoked.
-type LsifStoreWriteResultChunksFunc struct {
-	defaultHook func(context.Context, int, chan precise.IndexedResultChunkData) (uint32, error)
-	hooks       []func(context.Context, int, chan precise.IndexedResultChunkData) (uint32, error)
-	history     []LsifStoreWriteResultChunksFuncCall
-	mutex       sync.Mutex
-}
-
-// WriteResultChunks delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockLsifStore) WriteResultChunks(v0 context.Context, v1 int, v2 chan precise.IndexedResultChunkData) (uint32, error) {
-	r0, r1 := m.WriteResultChunksFunc.nextHook()(v0, v1, v2)
-	m.WriteResultChunksFunc.appendCall(LsifStoreWriteResultChunksFuncCall{v0, v1, v2, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the WriteResultChunks
-// method of the parent MockLsifStore instance is invoked and the hook queue
-// is empty.
-func (f *LsifStoreWriteResultChunksFunc) SetDefaultHook(hook func(context.Context, int, chan precise.IndexedResultChunkData) (uint32, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// WriteResultChunks method of the parent MockLsifStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *LsifStoreWriteResultChunksFunc) PushHook(hook func(context.Context, int, chan precise.IndexedResultChunkData) (uint32, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *LsifStoreWriteResultChunksFunc) SetDefaultReturn(r0 uint32, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, chan precise.IndexedResultChunkData) (uint32, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreWriteResultChunksFunc) PushReturn(r0 uint32, r1 error) {
-	f.PushHook(func(context.Context, int, chan precise.IndexedResultChunkData) (uint32, error) {
-		return r0, r1
-	})
-}
-
-func (f *LsifStoreWriteResultChunksFunc) nextHook() func(context.Context, int, chan precise.IndexedResultChunkData) (uint32, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *LsifStoreWriteResultChunksFunc) appendCall(r0 LsifStoreWriteResultChunksFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of LsifStoreWriteResultChunksFuncCall objects
-// describing the invocations of this function.
-func (f *LsifStoreWriteResultChunksFunc) History() []LsifStoreWriteResultChunksFuncCall {
-	f.mutex.Lock()
-	history := make([]LsifStoreWriteResultChunksFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// LsifStoreWriteResultChunksFuncCall is an object that describes an
-// invocation of method WriteResultChunks on an instance of MockLsifStore.
-type LsifStoreWriteResultChunksFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 chan precise.IndexedResultChunkData
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 uint32
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c LsifStoreWriteResultChunksFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c LsifStoreWriteResultChunksFuncCall) Results() []interface{} {
+func (c LsifStoreWriteSCIPSymbolsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/internal/codeintel/uploads/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/mocks_test.go
@@ -7438,6 +7438,24 @@ type MockLsifStore struct {
 	// TransactFunc is an instance of a mock function object controlling the
 	// behavior of the method Transact.
 	TransactFunc *LsifStoreTransactFunc
+	// WriteDefinitionsFunc is an instance of a mock function object
+	// controlling the behavior of the method WriteDefinitions.
+	WriteDefinitionsFunc *LsifStoreWriteDefinitionsFunc
+	// WriteDocumentsFunc is an instance of a mock function object
+	// controlling the behavior of the method WriteDocuments.
+	WriteDocumentsFunc *LsifStoreWriteDocumentsFunc
+	// WriteImplementationsFunc is an instance of a mock function object
+	// controlling the behavior of the method WriteImplementations.
+	WriteImplementationsFunc *LsifStoreWriteImplementationsFunc
+	// WriteMetaFunc is an instance of a mock function object controlling
+	// the behavior of the method WriteMeta.
+	WriteMetaFunc *LsifStoreWriteMetaFunc
+	// WriteReferencesFunc is an instance of a mock function object
+	// controlling the behavior of the method WriteReferences.
+	WriteReferencesFunc *LsifStoreWriteReferencesFunc
+	// WriteResultChunksFunc is an instance of a mock function object
+	// controlling the behavior of the method WriteResultChunks.
+	WriteResultChunksFunc *LsifStoreWriteResultChunksFunc
 	// WriteSCIPSymbolsFunc is an instance of a mock function object
 	// controlling the behavior of the method WriteSCIPSymbols.
 	WriteSCIPSymbolsFunc *LsifStoreWriteSCIPSymbolsFunc
@@ -7494,6 +7512,36 @@ func NewMockLsifStore() *MockLsifStore {
 		},
 		TransactFunc: &LsifStoreTransactFunc{
 			defaultHook: func(context.Context) (r0 lsifstore.LsifStore, r1 error) {
+				return
+			},
+		},
+		WriteDefinitionsFunc: &LsifStoreWriteDefinitionsFunc{
+			defaultHook: func(context.Context, int, chan precise.MonikerLocations) (r0 uint32, r1 error) {
+				return
+			},
+		},
+		WriteDocumentsFunc: &LsifStoreWriteDocumentsFunc{
+			defaultHook: func(context.Context, int, chan precise.KeyedDocumentData) (r0 uint32, r1 error) {
+				return
+			},
+		},
+		WriteImplementationsFunc: &LsifStoreWriteImplementationsFunc{
+			defaultHook: func(context.Context, int, chan precise.MonikerLocations) (r0 uint32, r1 error) {
+				return
+			},
+		},
+		WriteMetaFunc: &LsifStoreWriteMetaFunc{
+			defaultHook: func(context.Context, int, precise.MetaData) (r0 error) {
+				return
+			},
+		},
+		WriteReferencesFunc: &LsifStoreWriteReferencesFunc{
+			defaultHook: func(context.Context, int, chan precise.MonikerLocations) (r0 uint32, r1 error) {
+				return
+			},
+		},
+		WriteResultChunksFunc: &LsifStoreWriteResultChunksFunc{
+			defaultHook: func(context.Context, int, chan precise.IndexedResultChunkData) (r0 uint32, r1 error) {
 				return
 			},
 		},
@@ -7559,6 +7607,36 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.Transact")
 			},
 		},
+		WriteDefinitionsFunc: &LsifStoreWriteDefinitionsFunc{
+			defaultHook: func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
+				panic("unexpected invocation of MockLsifStore.WriteDefinitions")
+			},
+		},
+		WriteDocumentsFunc: &LsifStoreWriteDocumentsFunc{
+			defaultHook: func(context.Context, int, chan precise.KeyedDocumentData) (uint32, error) {
+				panic("unexpected invocation of MockLsifStore.WriteDocuments")
+			},
+		},
+		WriteImplementationsFunc: &LsifStoreWriteImplementationsFunc{
+			defaultHook: func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
+				panic("unexpected invocation of MockLsifStore.WriteImplementations")
+			},
+		},
+		WriteMetaFunc: &LsifStoreWriteMetaFunc{
+			defaultHook: func(context.Context, int, precise.MetaData) error {
+				panic("unexpected invocation of MockLsifStore.WriteMeta")
+			},
+		},
+		WriteReferencesFunc: &LsifStoreWriteReferencesFunc{
+			defaultHook: func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
+				panic("unexpected invocation of MockLsifStore.WriteReferences")
+			},
+		},
+		WriteResultChunksFunc: &LsifStoreWriteResultChunksFunc{
+			defaultHook: func(context.Context, int, chan precise.IndexedResultChunkData) (uint32, error) {
+				panic("unexpected invocation of MockLsifStore.WriteResultChunks")
+			},
+		},
 		WriteSCIPSymbolsFunc: &LsifStoreWriteSCIPSymbolsFunc{
 			defaultHook: func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error) {
 				panic("unexpected invocation of MockLsifStore.WriteSCIPSymbols")
@@ -7600,6 +7678,24 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		},
 		TransactFunc: &LsifStoreTransactFunc{
 			defaultHook: i.Transact,
+		},
+		WriteDefinitionsFunc: &LsifStoreWriteDefinitionsFunc{
+			defaultHook: i.WriteDefinitions,
+		},
+		WriteDocumentsFunc: &LsifStoreWriteDocumentsFunc{
+			defaultHook: i.WriteDocuments,
+		},
+		WriteImplementationsFunc: &LsifStoreWriteImplementationsFunc{
+			defaultHook: i.WriteImplementations,
+		},
+		WriteMetaFunc: &LsifStoreWriteMetaFunc{
+			defaultHook: i.WriteMeta,
+		},
+		WriteReferencesFunc: &LsifStoreWriteReferencesFunc{
+			defaultHook: i.WriteReferences,
+		},
+		WriteResultChunksFunc: &LsifStoreWriteResultChunksFunc{
+			defaultHook: i.WriteResultChunks,
 		},
 		WriteSCIPSymbolsFunc: &LsifStoreWriteSCIPSymbolsFunc{
 			defaultHook: i.WriteSCIPSymbols,
@@ -8700,6 +8796,670 @@ func (c LsifStoreTransactFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c LsifStoreTransactFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// LsifStoreWriteDefinitionsFunc describes the behavior when the
+// WriteDefinitions method of the parent MockLsifStore instance is invoked.
+type LsifStoreWriteDefinitionsFunc struct {
+	defaultHook func(context.Context, int, chan precise.MonikerLocations) (uint32, error)
+	hooks       []func(context.Context, int, chan precise.MonikerLocations) (uint32, error)
+	history     []LsifStoreWriteDefinitionsFuncCall
+	mutex       sync.Mutex
+}
+
+// WriteDefinitions delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockLsifStore) WriteDefinitions(v0 context.Context, v1 int, v2 chan precise.MonikerLocations) (uint32, error) {
+	r0, r1 := m.WriteDefinitionsFunc.nextHook()(v0, v1, v2)
+	m.WriteDefinitionsFunc.appendCall(LsifStoreWriteDefinitionsFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the WriteDefinitions
+// method of the parent MockLsifStore instance is invoked and the hook queue
+// is empty.
+func (f *LsifStoreWriteDefinitionsFunc) SetDefaultHook(hook func(context.Context, int, chan precise.MonikerLocations) (uint32, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WriteDefinitions method of the parent MockLsifStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *LsifStoreWriteDefinitionsFunc) PushHook(hook func(context.Context, int, chan precise.MonikerLocations) (uint32, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreWriteDefinitionsFunc) SetDefaultReturn(r0 uint32, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreWriteDefinitionsFunc) PushReturn(r0 uint32, r1 error) {
+	f.PushHook(func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
+		return r0, r1
+	})
+}
+
+func (f *LsifStoreWriteDefinitionsFunc) nextHook() func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreWriteDefinitionsFunc) appendCall(r0 LsifStoreWriteDefinitionsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LsifStoreWriteDefinitionsFuncCall objects
+// describing the invocations of this function.
+func (f *LsifStoreWriteDefinitionsFunc) History() []LsifStoreWriteDefinitionsFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreWriteDefinitionsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreWriteDefinitionsFuncCall is an object that describes an
+// invocation of method WriteDefinitions on an instance of MockLsifStore.
+type LsifStoreWriteDefinitionsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 chan precise.MonikerLocations
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 uint32
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreWriteDefinitionsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreWriteDefinitionsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// LsifStoreWriteDocumentsFunc describes the behavior when the
+// WriteDocuments method of the parent MockLsifStore instance is invoked.
+type LsifStoreWriteDocumentsFunc struct {
+	defaultHook func(context.Context, int, chan precise.KeyedDocumentData) (uint32, error)
+	hooks       []func(context.Context, int, chan precise.KeyedDocumentData) (uint32, error)
+	history     []LsifStoreWriteDocumentsFuncCall
+	mutex       sync.Mutex
+}
+
+// WriteDocuments delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockLsifStore) WriteDocuments(v0 context.Context, v1 int, v2 chan precise.KeyedDocumentData) (uint32, error) {
+	r0, r1 := m.WriteDocumentsFunc.nextHook()(v0, v1, v2)
+	m.WriteDocumentsFunc.appendCall(LsifStoreWriteDocumentsFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the WriteDocuments
+// method of the parent MockLsifStore instance is invoked and the hook queue
+// is empty.
+func (f *LsifStoreWriteDocumentsFunc) SetDefaultHook(hook func(context.Context, int, chan precise.KeyedDocumentData) (uint32, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WriteDocuments method of the parent MockLsifStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *LsifStoreWriteDocumentsFunc) PushHook(hook func(context.Context, int, chan precise.KeyedDocumentData) (uint32, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreWriteDocumentsFunc) SetDefaultReturn(r0 uint32, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, chan precise.KeyedDocumentData) (uint32, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreWriteDocumentsFunc) PushReturn(r0 uint32, r1 error) {
+	f.PushHook(func(context.Context, int, chan precise.KeyedDocumentData) (uint32, error) {
+		return r0, r1
+	})
+}
+
+func (f *LsifStoreWriteDocumentsFunc) nextHook() func(context.Context, int, chan precise.KeyedDocumentData) (uint32, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreWriteDocumentsFunc) appendCall(r0 LsifStoreWriteDocumentsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LsifStoreWriteDocumentsFuncCall objects
+// describing the invocations of this function.
+func (f *LsifStoreWriteDocumentsFunc) History() []LsifStoreWriteDocumentsFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreWriteDocumentsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreWriteDocumentsFuncCall is an object that describes an invocation
+// of method WriteDocuments on an instance of MockLsifStore.
+type LsifStoreWriteDocumentsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 chan precise.KeyedDocumentData
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 uint32
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreWriteDocumentsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreWriteDocumentsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// LsifStoreWriteImplementationsFunc describes the behavior when the
+// WriteImplementations method of the parent MockLsifStore instance is
+// invoked.
+type LsifStoreWriteImplementationsFunc struct {
+	defaultHook func(context.Context, int, chan precise.MonikerLocations) (uint32, error)
+	hooks       []func(context.Context, int, chan precise.MonikerLocations) (uint32, error)
+	history     []LsifStoreWriteImplementationsFuncCall
+	mutex       sync.Mutex
+}
+
+// WriteImplementations delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockLsifStore) WriteImplementations(v0 context.Context, v1 int, v2 chan precise.MonikerLocations) (uint32, error) {
+	r0, r1 := m.WriteImplementationsFunc.nextHook()(v0, v1, v2)
+	m.WriteImplementationsFunc.appendCall(LsifStoreWriteImplementationsFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the WriteImplementations
+// method of the parent MockLsifStore instance is invoked and the hook queue
+// is empty.
+func (f *LsifStoreWriteImplementationsFunc) SetDefaultHook(hook func(context.Context, int, chan precise.MonikerLocations) (uint32, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WriteImplementations method of the parent MockLsifStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *LsifStoreWriteImplementationsFunc) PushHook(hook func(context.Context, int, chan precise.MonikerLocations) (uint32, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreWriteImplementationsFunc) SetDefaultReturn(r0 uint32, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreWriteImplementationsFunc) PushReturn(r0 uint32, r1 error) {
+	f.PushHook(func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
+		return r0, r1
+	})
+}
+
+func (f *LsifStoreWriteImplementationsFunc) nextHook() func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreWriteImplementationsFunc) appendCall(r0 LsifStoreWriteImplementationsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LsifStoreWriteImplementationsFuncCall
+// objects describing the invocations of this function.
+func (f *LsifStoreWriteImplementationsFunc) History() []LsifStoreWriteImplementationsFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreWriteImplementationsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreWriteImplementationsFuncCall is an object that describes an
+// invocation of method WriteImplementations on an instance of
+// MockLsifStore.
+type LsifStoreWriteImplementationsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 chan precise.MonikerLocations
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 uint32
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreWriteImplementationsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreWriteImplementationsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// LsifStoreWriteMetaFunc describes the behavior when the WriteMeta method
+// of the parent MockLsifStore instance is invoked.
+type LsifStoreWriteMetaFunc struct {
+	defaultHook func(context.Context, int, precise.MetaData) error
+	hooks       []func(context.Context, int, precise.MetaData) error
+	history     []LsifStoreWriteMetaFuncCall
+	mutex       sync.Mutex
+}
+
+// WriteMeta delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockLsifStore) WriteMeta(v0 context.Context, v1 int, v2 precise.MetaData) error {
+	r0 := m.WriteMetaFunc.nextHook()(v0, v1, v2)
+	m.WriteMetaFunc.appendCall(LsifStoreWriteMetaFuncCall{v0, v1, v2, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the WriteMeta method of
+// the parent MockLsifStore instance is invoked and the hook queue is empty.
+func (f *LsifStoreWriteMetaFunc) SetDefaultHook(hook func(context.Context, int, precise.MetaData) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WriteMeta method of the parent MockLsifStore instance invokes the hook at
+// the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *LsifStoreWriteMetaFunc) PushHook(hook func(context.Context, int, precise.MetaData) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreWriteMetaFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int, precise.MetaData) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreWriteMetaFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int, precise.MetaData) error {
+		return r0
+	})
+}
+
+func (f *LsifStoreWriteMetaFunc) nextHook() func(context.Context, int, precise.MetaData) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreWriteMetaFunc) appendCall(r0 LsifStoreWriteMetaFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LsifStoreWriteMetaFuncCall objects
+// describing the invocations of this function.
+func (f *LsifStoreWriteMetaFunc) History() []LsifStoreWriteMetaFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreWriteMetaFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreWriteMetaFuncCall is an object that describes an invocation of
+// method WriteMeta on an instance of MockLsifStore.
+type LsifStoreWriteMetaFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 precise.MetaData
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreWriteMetaFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreWriteMetaFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// LsifStoreWriteReferencesFunc describes the behavior when the
+// WriteReferences method of the parent MockLsifStore instance is invoked.
+type LsifStoreWriteReferencesFunc struct {
+	defaultHook func(context.Context, int, chan precise.MonikerLocations) (uint32, error)
+	hooks       []func(context.Context, int, chan precise.MonikerLocations) (uint32, error)
+	history     []LsifStoreWriteReferencesFuncCall
+	mutex       sync.Mutex
+}
+
+// WriteReferences delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockLsifStore) WriteReferences(v0 context.Context, v1 int, v2 chan precise.MonikerLocations) (uint32, error) {
+	r0, r1 := m.WriteReferencesFunc.nextHook()(v0, v1, v2)
+	m.WriteReferencesFunc.appendCall(LsifStoreWriteReferencesFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the WriteReferences
+// method of the parent MockLsifStore instance is invoked and the hook queue
+// is empty.
+func (f *LsifStoreWriteReferencesFunc) SetDefaultHook(hook func(context.Context, int, chan precise.MonikerLocations) (uint32, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WriteReferences method of the parent MockLsifStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *LsifStoreWriteReferencesFunc) PushHook(hook func(context.Context, int, chan precise.MonikerLocations) (uint32, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreWriteReferencesFunc) SetDefaultReturn(r0 uint32, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreWriteReferencesFunc) PushReturn(r0 uint32, r1 error) {
+	f.PushHook(func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
+		return r0, r1
+	})
+}
+
+func (f *LsifStoreWriteReferencesFunc) nextHook() func(context.Context, int, chan precise.MonikerLocations) (uint32, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreWriteReferencesFunc) appendCall(r0 LsifStoreWriteReferencesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LsifStoreWriteReferencesFuncCall objects
+// describing the invocations of this function.
+func (f *LsifStoreWriteReferencesFunc) History() []LsifStoreWriteReferencesFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreWriteReferencesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreWriteReferencesFuncCall is an object that describes an
+// invocation of method WriteReferences on an instance of MockLsifStore.
+type LsifStoreWriteReferencesFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 chan precise.MonikerLocations
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 uint32
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreWriteReferencesFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreWriteReferencesFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// LsifStoreWriteResultChunksFunc describes the behavior when the
+// WriteResultChunks method of the parent MockLsifStore instance is invoked.
+type LsifStoreWriteResultChunksFunc struct {
+	defaultHook func(context.Context, int, chan precise.IndexedResultChunkData) (uint32, error)
+	hooks       []func(context.Context, int, chan precise.IndexedResultChunkData) (uint32, error)
+	history     []LsifStoreWriteResultChunksFuncCall
+	mutex       sync.Mutex
+}
+
+// WriteResultChunks delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockLsifStore) WriteResultChunks(v0 context.Context, v1 int, v2 chan precise.IndexedResultChunkData) (uint32, error) {
+	r0, r1 := m.WriteResultChunksFunc.nextHook()(v0, v1, v2)
+	m.WriteResultChunksFunc.appendCall(LsifStoreWriteResultChunksFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the WriteResultChunks
+// method of the parent MockLsifStore instance is invoked and the hook queue
+// is empty.
+func (f *LsifStoreWriteResultChunksFunc) SetDefaultHook(hook func(context.Context, int, chan precise.IndexedResultChunkData) (uint32, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WriteResultChunks method of the parent MockLsifStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *LsifStoreWriteResultChunksFunc) PushHook(hook func(context.Context, int, chan precise.IndexedResultChunkData) (uint32, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreWriteResultChunksFunc) SetDefaultReturn(r0 uint32, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, chan precise.IndexedResultChunkData) (uint32, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreWriteResultChunksFunc) PushReturn(r0 uint32, r1 error) {
+	f.PushHook(func(context.Context, int, chan precise.IndexedResultChunkData) (uint32, error) {
+		return r0, r1
+	})
+}
+
+func (f *LsifStoreWriteResultChunksFunc) nextHook() func(context.Context, int, chan precise.IndexedResultChunkData) (uint32, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreWriteResultChunksFunc) appendCall(r0 LsifStoreWriteResultChunksFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LsifStoreWriteResultChunksFuncCall objects
+// describing the invocations of this function.
+func (f *LsifStoreWriteResultChunksFunc) History() []LsifStoreWriteResultChunksFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreWriteResultChunksFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreWriteResultChunksFuncCall is an object that describes an
+// invocation of method WriteResultChunks on an instance of MockLsifStore.
+type LsifStoreWriteResultChunksFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 chan precise.IndexedResultChunkData
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 uint32
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreWriteResultChunksFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreWriteResultChunksFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 


### PR DESCRIPTION
This PR pulls from #42850 the behavior that writes to Postgres correlated SCIP data.

## Test plan

New unit tests.