### PR TITLE
codeintel: Add SCIP query skeleton

### DIFF
--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_exists.go
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_exists.go
@@ -18,10 +18,14 @@ func (s *store) GetPathExists(ctx context.Context, bundleID int, path string) (_
 	}})
 	defer endObservation(1, observation.Args{})
 
-	_, exists, err := basestore.ScanFirstString(s.db.Query(ctx, sqlf.Sprintf(existsQuery, bundleID, path)))
+	exists, _, err := basestore.ScanFirstBool(s.db.Query(ctx, sqlf.Sprintf(
+		existsQuery,
+		bundleID,
+		path,
+	)))
 	return exists, err
 }
 
 const existsQuery = `
-SELECT path FROM lsif_data_documents WHERE dump_id = %s AND path = %s LIMIT 1
+SELECT 1 FROM lsif_data_documents WHERE dump_id = %s AND path = %s
 `

--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_hover.go
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_hover.go
@@ -2,6 +2,7 @@ package lsifstore
 
 import (
 	"context"
+	"errors"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
@@ -21,17 +22,25 @@ func (s *store) GetHover(ctx context.Context, bundleID int, path string, line, c
 	}})
 	defer endObservation(1, observation.Args{})
 
-	documentData, exists, err := s.scanFirstDocumentData(s.db.Query(ctx, sqlf.Sprintf(hoverDocumentQuery, bundleID, path)))
+	documentData, exists, err := s.scanFirstDocumentData(s.db.Query(ctx, sqlf.Sprintf(
+		hoverDocumentQuery,
+		bundleID,
+		path,
+	)))
 	if err != nil || !exists {
 		return "", types.Range{}, false, err
 	}
 
-	trace.Log(log.Int("numRanges", len(documentData.Document.Ranges)))
-	ranges := precise.FindRanges(documentData.Document.Ranges, line, character)
+	if documentData.SCIPData != nil {
+		return "", types.Range{}, false, errors.New("SCIP hover unimplemented")
+	}
+
+	trace.Log(log.Int("numRanges", len(documentData.LSIFData.Ranges)))
+	ranges := precise.FindRanges(documentData.LSIFData.Ranges, line, character)
 	trace.Log(log.Int("numIntersectingRanges", len(ranges)))
 
 	for _, r := range ranges {
-		if text, ok := documentData.Document.HoverResults[r.HoverResultID]; ok {
+		if text, ok := documentData.LSIFData.HoverResults[r.HoverResultID]; ok {
 			return text, newRange(r.StartLine, r.StartCharacter, r.EndLine, r.EndCharacter), true, nil
 		}
 	}
@@ -48,7 +57,8 @@ SELECT
 	hovers,
 	NULL AS monikers,
 	NULL AS packages,
-	NULL AS diagnostics
+	NULL AS diagnostics,
+	NULL AS scip_document
 FROM
 	lsif_data_documents
 WHERE

--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/types.go
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/types.go
@@ -22,7 +22,9 @@ type QualifiedMonikerLocations struct {
 
 type QualifiedDocumentData struct {
 	UploadID int
-	precise.KeyedDocumentData
+	Path     string
+	LSIFData *precise.DocumentData
+	SCIPData *scip.Document
 }
 
 func translateRange(r *scip.Range) types.Range {


### PR DESCRIPTION
Modify the codenav lsifstore package to be able to read SCIP data from codeintel-db queries. We currently have an error return on all the places where SCIP data must be consumed - these are all currently unhit as the queries return NULL for the read fields, which disables the SCIPData fields from being populated.

Pulled from #42850. In subsequent PRs we will fill out the consuming and altered query. Breaking this out as it's the uninteresting boilerplate part.

## Test plan

Existing unit tests. [main-dry-run](https://buildkite.com/sourcegraph/sourcegraph/builds/185622)
