### PR TITLE
search: make `repo:has(key:)` valid syntax

### DIFF
--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -288,7 +288,7 @@ type RepoHasKVPPredicate struct {
 
 func (p *RepoHasKVPPredicate) Unmarshal(params string, negated bool) (err error) {
 	split := strings.Split(params, ":")
-	if len(split) != 2 || len(split[0]) == 0 || len(split[1]) == 0 {
+	if len(split) != 2 || len(split[0]) == 0 {
 		return errors.New("expected params in the form of key:value")
 	}
 	p.Key = split[0]

--- a/internal/search/query/predicate_test.go
+++ b/internal/search/query/predicate_test.go
@@ -124,3 +124,49 @@ func TestRepoHasDescriptionPredicate(t *testing.T) {
 		}
 	})
 }
+
+func TestRepoHasKVPPredicate(t *testing.T) {
+	t.Run("Unmarshal", func(t *testing.T) {
+		type test struct {
+			name     string
+			params   string
+			expected *RepoHasKVPPredicate
+		}
+
+		valid := []test{
+			{`key:value`, `key:value`, &RepoHasKVPPredicate{Key: "key", Value: "value", Negated: false}},
+			{`empty string value`, `key:`, &RepoHasKVPPredicate{Key: "key", Value: "", Negated: false}},
+		}
+
+		for _, tc := range valid {
+			t.Run(tc.name, func(t *testing.T) {
+				p := &RepoHasKVPPredicate{}
+				err := p.Unmarshal(tc.params, false)
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+
+				if !reflect.DeepEqual(tc.expected, p) {
+					t.Fatalf("expected %#v, got %#v", tc.expected, p)
+				}
+			})
+		}
+
+		invalid := []test{
+			{`empty`, ``, nil},
+			{`no key`, `:value`, nil},
+			{`no key or value`, `:`, nil},
+			{`invalid syntax`, `key-value`, nil},
+		}
+
+		for _, tc := range invalid {
+			t.Run(tc.name, func(t *testing.T) {
+				p := &RepoHasKVPPredicate{}
+				err := p.Unmarshal(tc.params, false)
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
If no value is specified in the predicate argument then it will filter to repos with a matching key and an empty string as the value, i.e. we'll attempt to match whatever comes after the `:` against the `value` column in the KVPs table. 

This is distinct from `repo:has.tag(key)` which will filter to repos with a matching key and a null value.

Context: https://sourcegraph.slack.com/archives/C020S8AT3LN/p1669595389698639

## Test plan
Manually test
Unit test
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
