### PR TITLE
search contexts: order contexts list by default first, then starred, then others

### DIFF
--- a/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
@@ -450,11 +450,11 @@ func (r *searchContextResolver) ViewerCanManage(ctx context.Context) bool {
 }
 
 func (r *searchContextResolver) ViewerHasAsDefault(ctx context.Context) bool {
-	return searchcontexts.CurrentUserHasSearchContextAsDefault(ctx, r.db, r.sc.ID)
+	return r.sc.Default
 }
 
 func (r *searchContextResolver) ViewerHasStarred(ctx context.Context) bool {
-	return searchcontexts.CurrentUserHasStarredSearchContext(ctx, r.db, r.sc.ID)
+	return r.sc.Starred
 }
 
 func (r *searchContextResolver) Repositories(ctx context.Context) ([]graphqlbackend.SearchContextRepositoryRevisionsResolver, error) {

--- a/internal/search/searchcontexts/search_contexts.go
+++ b/internal/search/searchcontexts/search_contexts.go
@@ -592,40 +592,6 @@ func GetSearchContextSpec(searchContext *types.SearchContext) string {
 	}
 }
 
-func CurrentUserHasSearchContextAsDefault(ctx context.Context, db database.DB, searchContextID int64) bool {
-	user, err := auth.CurrentUser(ctx, db)
-	if err != nil {
-		return false
-	}
-	if user == nil {
-		return false
-	}
-
-	defaultSearchContextID, err := db.SearchContexts().GetUserDefaultSearchContextID(ctx, user.ID)
-	if err != nil {
-		return false
-	}
-
-	return defaultSearchContextID == searchContextID
-}
-
-func CurrentUserHasStarredSearchContext(ctx context.Context, db database.DB, searchContextID int64) bool {
-	user, err := auth.CurrentUser(ctx, db)
-	if err != nil {
-		return false
-	}
-	if user == nil {
-		return false
-	}
-
-	userHasStarred, err := db.SearchContexts().GetSearchContextStarForUser(ctx, user.ID, searchContextID)
-	if err != nil {
-		return false
-	}
-
-	return userHasStarred
-}
-
 func CreateSearchContextStarForCurrentUser(ctx context.Context, db database.DB, searchContext *types.SearchContext) error {
 	user, err := auth.CurrentUser(ctx, db)
 	if err != nil {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1660,6 +1660,12 @@ type SearchContext struct {
 
 	// Whether the search context is auto-defined by Sourcegraph. Auto-defined search contexts are not editable by users.
 	Autodefined bool
+
+	// Whether the search context is the default for the user. If the user hasn't explicitly set a default or is not authenticated, the global search context is used.
+	Default bool
+
+	// Whether the user has starred the context. If the user is not authenticated, this field is always false.
+	Starred bool
 }
 
 // SearchContextRepositoryRevisions is a simple wrapper for a repository and its revisions


### PR DESCRIPTION
Stacked on #44875

## Test plan

Verify search context dropdown is displayed in the right order