### PR TITLE
codeintel: Increase compression ratio for encoded SCIP ranges

### DIFF
--- a/enterprise/internal/codeintel/shared/types/ranges.go
+++ b/enterprise/internal/codeintel/shared/types/ranges.go
@@ -138,7 +138,7 @@ func decodeRangesFromReader(r io.ByteReader) ([]int32, error) {
 // runs of zeros as a single zero followed by the length of the run. The `readVarints` function will
 // re-expand these runs of zeroes.
 func writeVarints(values []int32) []byte {
-	// Optimistic capacity; we append exactly oen or two bytes for each non-zero element in the given
+	// Optimistic capacity; we append exactly one or two bytes for each non-zero element in the given
 	// array. We assume that most of the values are small, so we try not to over-allocate here. We may
 	// resize only once in the worst case.
 	buf := make([]byte, 0, len(values))

--- a/enterprise/internal/codeintel/shared/types/ranges.go
+++ b/enterprise/internal/codeintel/shared/types/ranges.go
@@ -10,53 +10,61 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// EncodeRanges converts a sequence of integers representing a set of ranges within
-// the a text document into a string of bytes as we store them in Postgres. Each range
-// in the input must consist of four ordered components: start line, start character,
-// end line, and end character. Multiple ranges can be represented by simply appending
-// components.
+// EncodeRanges converts a sequence of integers representing a set of ranges within the a text
+// document into a string of bytes as we store them in Postgres. Each range in the input must
+// consist of four ordered components: start line, start character, end line, and end character.
+// Multiple ranges can be represented by simply appending components.
 //
-// We make the assumption that the input ranges are ordered by their start line. When
-// this is not the case, the encoding will still be correct but the delta encoding may
-// not have as large of a savings.
-func EncodeRanges(vs []int32) (buf []byte, _ error) {
-	if len(vs) == 0 {
+// We make the assumption that the input ranges are ordered by their start line. When this is not
+// the case, the encoding will still be correct but the delta encoding may not have as large of a
+// savings.
+func EncodeRanges(values []int32) (buf []byte, _ error) {
+	n := len(values)
+	if n == 0 {
 		return nil, nil
-	} else if len(vs)%4 != 0 {
-		return nil, errors.Newf("unexpected range length - have %d but expected a multiple of 4", len(vs))
+	} else if n%4 != 0 {
+		return nil, errors.Newf("unexpected range length - have %d but expected a multiple of 4", n)
 	}
 
-	// Optimistic capacity; we append exactly one or two bytes for each element in the
-	// given array. We assume that most of the delta-encoded values will be small, so
-	// we try not to over-allocate here.
-	buf = make([]byte, 0, len(vs))
+	var (
+		q1Offset = n / 4 * 0
+		q2Offset = n / 4 * 1
+		q3Offset = n / 4 * 2
+		q4Offset = n / 4 * 3
+		shuffled = make([]int32, n)
+	)
 
-	// The following outer loop causes the inner loop to execute twice. The first invocation
-	// of the loop delta-encodes all of the line numbers as a contiguous sequence. The second
-	// invocation delta-encodes the character offset numbers.
-	//
-	// The delta encoding for line numbers should be impactful as it forms a non-decreasing
-	// sequence, and multiple references to the same variable within a document are likely to
-	// present some degree of locality.
-	//
-	// Delta encoding for character numbers should be impactful as well as the average distance
-	// between character numbers should be less than the average line length in the document. The
-	// vastly common (soft) character maximums fall between 80-120, which fits into a single byte.
+	// Partition the given range quads into a the `shuffled` slice. We de-interlace each component of
+	// the ranges and "column-orient" each component (all start lines packed together, etc).
 
-	for i := 0; i <= 1; i++ {
-		for j := i; j < len(vs); j += 2 {
-			if j < 2 {
-				buf = binary.AppendVarint(buf, int64(vs[j]))
-			} else {
-				buf = binary.AppendVarint(buf, int64(vs[j]-vs[j-2]))
-			}
+	for rangeIndex, rangeOffset := 0, 0; rangeOffset < n; rangeIndex, rangeOffset = rangeIndex+1, rangeOffset+4 {
+		var (
+			startLine      = values[rangeOffset+0]
+			startCharacter = values[rangeOffset+1]
+			endLine        = values[rangeOffset+2]
+			endCharacter   = values[rangeOffset+3]
+		)
+
+		deltaEncodedStartLine := startLine
+		if rangeIndex != 0 {
+			deltaEncodedStartLine = startLine - values[(rangeIndex-1)*4]
 		}
+
+		shuffled[q1Offset+rangeIndex] = deltaEncodedStartLine         // Q1: delta-encoded start lines
+		shuffled[q2Offset+rangeIndex] = endLine - startLine           // Q2: start line/end line deltas
+		shuffled[q3Offset+rangeIndex] = startCharacter                // Q3: start character
+		shuffled[q4Offset+rangeIndex] = endCharacter - startCharacter // Q4: start character/end character deltas
 	}
 
-	return buf, nil
+	// Convert slice of ints into a packed byte slice. This will also run-length encode runs of zeros
+	// which should be extremely common the second quarter of the shuffled array, as the vast majority
+	// of occurrences will be single-lined.
+
+	return writeVarints(shuffled), nil
 }
 
-// DecodeRanges decodes the output of `EncodeRanges`, transforming the result into a SCIP range slice.
+// DecodeRanges decodes the output of `EncodeRanges`, transforming the result into a SCIP range
+// slice.
 func DecodeRanges(encoded []byte) ([]*scip.Range, error) {
 	flattenedRanges, err := DecodeFlattenedRanges(encoded)
 	if err != nil {
@@ -81,57 +89,125 @@ func DecodeFlattenedRanges(encoded []byte) ([]int32, error) {
 	return decodeRangesFromReader(bytes.NewReader(encoded))
 }
 
-// decodeRangesFromReader decodes the output of `EncodeRanges`. The given reader is assumed
-// to be non-empty.
+// decodeRangesFromReader decodes the output of `EncodeRanges`. The given reader is assumed to be
+// non-empty.
 func decodeRangesFromReader(r io.ByteReader) ([]int32, error) {
-	deltas, err := readVarints(r)
+	values, err := readVarints(r)
 	if err != nil {
 		return nil, err
 	}
 
-	n := len(deltas)
-	h := n / 2
-
+	n := len(values)
 	if n%4 != 0 {
 		return nil, errors.Newf("unexpected number of encoded deltas - have %d but expected a multiple of 4", n)
 	}
 
-	// The following loop decodes two delta-encoded sequences of integers at once. The
-	// first half of `deltas` is a sequence of start/end line number pairs; the latter
-	// half of `deltas` is a similar sequence of character number pairs.
-
-	combined := make([]int32, 0, n)
-	combined = append(
-		combined,
-		deltas[0], // first line
-		deltas[h], // first char
+	var (
+		q1Offset        = n / 4 * 0
+		q2Offset        = n / 4 * 1
+		q3Offset        = n / 4 * 2
+		q4Offset        = n / 4 * 3
+		startLine int32 = 0
+		combined        = make([]int32, 0, n)
 	)
 
-	for j := 1; j < h; j++ {
+	for i, j := 0, 0; j < n; i, j = i+1, j+4 {
+		var (
+			deltaEncodedStartLine = values[q1Offset+i]
+			lineDelta             = values[q2Offset+i]
+			startCharacter        = values[q3Offset+i]
+			characterDelta        = values[q4Offset+i]
+		)
+
+		// delta-decode start line
+		startLine += deltaEncodedStartLine
+
 		combined = append(
 			combined,
-			combined[2*j-2]+deltas[0+j], // delta decode based on last line added
-			combined[2*j-1]+deltas[h+j], // delta decode based on last char added
+			startLine,                     // start line
+			startCharacter,                // start character
+			startLine+lineDelta,           // end line
+			startCharacter+characterDelta, // end character
 		)
 	}
 
 	return combined, nil
 }
 
-// readVarints reads a slice of packed variable-length integers.
-func readVarints(r io.ByteReader) (vs []int32, _ error) {
-	for {
-		v, err := binary.ReadVarint(r)
-		if err != nil {
-			if err == io.EOF {
-				break
+// writeVarints writes each of the given values as a varint into a by buffer. This function encodes
+// runs of zeros as a single zero followed by the length of the run. The `readVarints` function will
+// re-expand these runs of zeroes.
+func writeVarints(values []int32) []byte {
+	// Optimistic capacity; we append exactly oen or two bytes for each non-zero element in the given
+	// array. We assume that most of the values are small, so we try not to over-allocate here. We may
+	// resize only once in the worst case.
+	buf := make([]byte, 0, len(values))
+
+	i := 0
+	for i < len(values) {
+		value := values[i]
+		if value == 0 {
+			runStart := i
+			for i < len(values) && values[i] == 0 {
+				i++
 			}
 
-			return nil, err
+			buf = binary.AppendVarint(buf, int64(0))
+			buf = binary.AppendVarint(buf, int64(i-runStart))
+			continue
 		}
 
-		vs = append(vs, int32(v))
+		buf = binary.AppendVarint(buf, int64(value))
+		i++
 	}
 
-	return vs, nil
+	return buf
+}
+
+// readVarints reads a sequence of varints from the given reader as encoded by `writeVarints`. When
+// a zero-value is encountered, this function expects the next varint value to be the length of a run
+// of zero values.
+//
+// The slice of values returned by this function will contain the expanded run of zeroes.
+func readVarints(r io.ByteReader) (values []int32, _ error) {
+	for {
+		if value, ok, err := readVarint32(r); err != nil {
+			return nil, err
+		} else if !ok {
+			break
+		} else if value != 0 {
+			// Regular value
+			values = append(values, value)
+			continue
+		}
+
+		// We read a zero value; read the length of the run and pad the output slice
+		count, ok, err := readVarint32(r)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, errors.New("expected length for run of zero values")
+		}
+		for ; count > 0; count-- {
+			values = append(values, 0)
+		}
+	}
+
+	return values, nil
+}
+
+// readVarint32 reads a single varint from the given reader. If the reader has no more content a
+// false-valued flag is returned.
+func readVarint32(r io.ByteReader) (int32, bool, error) {
+	value, err := binary.ReadVarint(r)
+	if err != nil {
+		if err == io.EOF {
+			return 0, false, nil
+		}
+
+		return 0, false, err
+	}
+
+	return int32(value), true, nil
 }


### PR DESCRIPTION
Change the encoding layout so that we we compress a sequence of sorted SCIP ranges to 17% of its original size (instead of the previous 25%).

## Test plan

Existing unit tests.