### PR TITLE
usagestats: exclude SOAP activities

### DIFF
--- a/internal/adminanalytics/utils.go
+++ b/internal/adminanalytics/utils.go
@@ -138,7 +138,7 @@ func getDefaultConds(ctx context.Context, db database.DB, cache bool) ([]*sqlf.Q
 	conds := []*sqlf.Query{
 		sqlf.Sprintf("anonymous_user_id <> 'backend'"),
 		sqlf.Sprintf("name NOT IN (%s)", sqlf.Join(nonActiveUserEvents, ", ")),
-		sqlf.Sprintf(`NOT public_argument @> '{"sourcegraph_operator": true}'`), // Exclude Sourcegraph Operator user accounts
+		sqlf.Sprintf(fmt.Sprintf(`NOT public_argument @> '{"%s": true}'`, database.EventLogsSourcegraphOperatorKey)), // Exclude Sourcegraph Operator user accounts
 	}
 
 	sgEmpUserIds, err := getSgEmpUserIDs(ctx, db, cache)

--- a/internal/adminanalytics/utils.go
+++ b/internal/adminanalytics/utils.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/eventlogger"
 )
@@ -137,6 +138,7 @@ func getDefaultConds(ctx context.Context, db database.DB, cache bool) ([]*sqlf.Q
 	conds := []*sqlf.Query{
 		sqlf.Sprintf("anonymous_user_id <> 'backend'"),
 		sqlf.Sprintf("name NOT IN (%s)", sqlf.Join(nonActiveUserEvents, ", ")),
+		sqlf.Sprintf(`NOT public_argument @> '{"sourcegraph_operator": true}'`), // Exclude Sourcegraph Operator user accounts
 	}
 
 	sgEmpUserIds, err := getSgEmpUserIDs(ctx, db, cache)

--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -477,6 +477,9 @@ type CommonUsageOptions struct {
 	// are mostly actions taken by signed-out users.
 	ExcludeNonActiveUsers bool
 	// Exclude Sourcegraph (employee) admins.
+	//
+	// Deprecated: Use ExcludeSourcegraphOperators instead. If you have to use this,
+	// then set both fields with the same value at the same time.
 	ExcludeSourcegraphAdmins bool
 	// ExcludeSourcegraphOperators indicates whether to exclude Sourcegraph Operator
 	// user accounts.

--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -200,6 +200,8 @@ func (l *eventLogStore) Insert(ctx context.Context, e *Event) error {
 	return l.BulkInsert(ctx, []*Event{e})
 }
 
+const EventLogsSourcegraphOperatorKey = "sourcegraph_operator"
+
 func (l *eventLogStore) BulkInsert(ctx context.Context, events []*Event) error {
 	coalesce := func(v json.RawMessage) json.RawMessage {
 		if v != nil {
@@ -231,7 +233,7 @@ func (l *eventLogStore) BulkInsert(ctx context.Context, events []*Event) error {
 			result, err := jsonc.Edit(
 				string(publicArgument),
 				true,
-				"sourcegraph_operator",
+				EventLogsSourcegraphOperatorKey,
 			)
 			publicArgument = json.RawMessage(result)
 			if err != nil {
@@ -601,7 +603,7 @@ OR NOT(
 		}
 
 		if opt.ExcludeSourcegraphOperators {
-			conds = append(conds, sqlf.Sprintf(`NOT event_logs.public_argument @> '{"sourcegraph_operator": true}'`))
+			conds = append(conds, sqlf.Sprintf(fmt.Sprintf(`NOT event_logs.public_argument @> '{"%s": true}'`, EventLogsSourcegraphOperatorKey)))
 		}
 	}
 	return conds

--- a/internal/database/event_logs_test.go
+++ b/internal/database/event_logs_test.go
@@ -233,11 +233,12 @@ func TestEventLogs_SiteUsageMultiplePeriods(t *testing.T) {
 	secondDay := startDate.Add(time.Hour * 24)
 	thirdDay := startDate.Add(time.Hour * 24 * 2)
 
+	soPublicArgument := json.RawMessage(fmt.Sprintf(`{"%s": true}`, EventLogsSourcegraphOperatorKey))
 	events := []*Event{
 		makeTestEvent(&Event{UserID: uint32(sgAdmin.ID), Timestamp: startDate}),
 		makeTestEvent(&Event{UserID: uint32(sgAdmin.ID), Timestamp: startDate}),
-		makeTestEvent(&Event{UserID: uint32(soLoganID), Timestamp: startDate, PublicArgument: json.RawMessage(`{"sourcegraph_operator": true}`)}),
-		makeTestEvent(&Event{UserID: uint32(soLoganID), Timestamp: startDate, PublicArgument: json.RawMessage(`{"sourcegraph_operator": true}`)}),
+		makeTestEvent(&Event{UserID: uint32(soLoganID), Timestamp: startDate, PublicArgument: soPublicArgument}),
+		makeTestEvent(&Event{UserID: uint32(soLoganID), Timestamp: startDate, PublicArgument: soPublicArgument}),
 		makeTestEvent(&Event{UserID: uint32(user1.ID), Timestamp: startDate}),
 		makeTestEvent(&Event{UserID: uint32(user1.ID), Timestamp: startDate}),
 
@@ -245,8 +246,8 @@ func TestEventLogs_SiteUsageMultiplePeriods(t *testing.T) {
 		makeTestEvent(&Event{UserID: uint32(user1.ID), Timestamp: secondDay}),
 		makeTestEvent(&Event{UserID: uint32(user2.ID), Timestamp: secondDay}),
 		makeTestEvent(&Event{UserID: uint32(sgAdmin.ID), Timestamp: secondDay}),
-		makeTestEvent(&Event{UserID: uint32(soLoganID), Timestamp: secondDay, PublicArgument: json.RawMessage(`{"sourcegraph_operator": true}`)}),
-		makeTestEvent(&Event{UserID: uint32(soLoganID), Timestamp: secondDay, PublicArgument: json.RawMessage(`{"sourcegraph_operator": true}`)}),
+		makeTestEvent(&Event{UserID: uint32(soLoganID), Timestamp: secondDay, PublicArgument: soPublicArgument}),
+		makeTestEvent(&Event{UserID: uint32(soLoganID), Timestamp: secondDay, PublicArgument: soPublicArgument}),
 
 		makeTestEvent(&Event{UserID: uint32(user1.ID), Timestamp: thirdDay}),
 		makeTestEvent(&Event{UserID: uint32(user2.ID), Timestamp: thirdDay}),
@@ -524,7 +525,7 @@ func TestEventLogs_SiteUsage_ExcludeSourcegraphAdmins(t *testing.T) {
 						}
 
 						if userID == uint32(soLoganID) {
-							e.PublicArgument = json.RawMessage(`{"sourcegraph_operator": true}`)
+							e.PublicArgument = json.RawMessage(fmt.Sprintf(`{"%s": true}`, EventLogsSourcegraphOperatorKey))
 						}
 
 						err := db.EventLogs().Insert(ctx, e)

--- a/internal/database/event_logs_test.go
+++ b/internal/database/event_logs_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/version"
@@ -200,31 +202,31 @@ func TestEventLogs_SiteUsageMultiplePeriods(t *testing.T) {
 	db := NewDB(logger, dbtest.NewDB(logger, t))
 	ctx := context.Background()
 
-	// Several of the events will belong to a Sourcegraph employee admin user
+	// Several of the events will belong to Sourcegraph employee admin user and Sourcegraph Operator user account
 	sgAdmin, err := db.Users().Create(ctx, NewUser{Username: "sourcegraph-admin"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := db.UserEmails().Add(ctx, sgAdmin.ID, "admin@sourcegraph.com", nil); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	err = db.UserEmails().Add(ctx, sgAdmin.ID, "admin@sourcegraph.com", nil)
+	require.NoError(t, err)
+	soLoganID, err := db.UserExternalAccounts().CreateUserAndSave(
+		ctx,
+		NewUser{
+			Username: "sourcegraph-operator-logan",
+		},
+		extsvc.AccountSpec{
+			ServiceType: "sourcegraph-operator",
+		},
+		extsvc.AccountData{},
+	)
+	require.NoError(t, err)
 
 	user1, err := db.Users().Create(ctx, NewUser{Username: "a"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	user2, err := db.Users().Create(ctx, NewUser{Username: "b"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	user3, err := db.Users().Create(ctx, NewUser{Username: "c"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	user4, err := db.Users().Create(ctx, NewUser{Username: "d"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	now := time.Now()
 	startDate, _ := calcStartDate(now, Daily, 3)
@@ -234,6 +236,8 @@ func TestEventLogs_SiteUsageMultiplePeriods(t *testing.T) {
 	events := []*Event{
 		makeTestEvent(&Event{UserID: uint32(sgAdmin.ID), Timestamp: startDate}),
 		makeTestEvent(&Event{UserID: uint32(sgAdmin.ID), Timestamp: startDate}),
+		makeTestEvent(&Event{UserID: uint32(soLoganID), Timestamp: startDate, PublicArgument: json.RawMessage(`{"sourcegraph_operator": true}`)}),
+		makeTestEvent(&Event{UserID: uint32(soLoganID), Timestamp: startDate, PublicArgument: json.RawMessage(`{"sourcegraph_operator": true}`)}),
 		makeTestEvent(&Event{UserID: uint32(user1.ID), Timestamp: startDate}),
 		makeTestEvent(&Event{UserID: uint32(user1.ID), Timestamp: startDate}),
 
@@ -241,32 +245,26 @@ func TestEventLogs_SiteUsageMultiplePeriods(t *testing.T) {
 		makeTestEvent(&Event{UserID: uint32(user1.ID), Timestamp: secondDay}),
 		makeTestEvent(&Event{UserID: uint32(user2.ID), Timestamp: secondDay}),
 		makeTestEvent(&Event{UserID: uint32(sgAdmin.ID), Timestamp: secondDay}),
+		makeTestEvent(&Event{UserID: uint32(soLoganID), Timestamp: secondDay, PublicArgument: json.RawMessage(`{"sourcegraph_operator": true}`)}),
+		makeTestEvent(&Event{UserID: uint32(soLoganID), Timestamp: secondDay, PublicArgument: json.RawMessage(`{"sourcegraph_operator": true}`)}),
 
 		makeTestEvent(&Event{UserID: uint32(user1.ID), Timestamp: thirdDay}),
 		makeTestEvent(&Event{UserID: uint32(user2.ID), Timestamp: thirdDay}),
 		makeTestEvent(&Event{UserID: uint32(user3.ID), Timestamp: thirdDay}),
 		makeTestEvent(&Event{UserID: uint32(user4.ID), Timestamp: thirdDay}),
 	}
-
-	for _, e := range events {
-		if err := db.EventLogs().Insert(ctx, e); err != nil {
-			t.Fatal(err)
-		}
-	}
+	err = db.EventLogs().BulkInsert(ctx, events)
+	require.NoError(t, err)
 
 	values, err := db.EventLogs().SiteUsageMultiplePeriods(ctx, now, 3, 0, 0, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	assertUsageValue(t, values.DAUs[0], startDate.Add(time.Hour*24*2), 4, 4, 0, 0)
-	assertUsageValue(t, values.DAUs[1], startDate.Add(time.Hour*24), 3, 3, 0, 0)
-	assertUsageValue(t, values.DAUs[2], startDate, 2, 2, 0, 0)
+	assertUsageValue(t, values.DAUs[1], startDate.Add(time.Hour*24), 4, 4, 0, 0)
+	assertUsageValue(t, values.DAUs[2], startDate, 3, 3, 0, 0)
 
-	values, err = db.EventLogs().SiteUsageMultiplePeriods(ctx, now, 3, 0, 0, &CountUniqueUsersOptions{CommonUsageOptions{ExcludeSourcegraphAdmins: true}, nil})
-	if err != nil {
-		t.Fatal(err)
-	}
+	values, err = db.EventLogs().SiteUsageMultiplePeriods(ctx, now, 3, 0, 0, &CountUniqueUsersOptions{CommonUsageOptions{ExcludeSourcegraphAdmins: true, ExcludeSourcegraphOperators: true}, nil})
+	require.NoError(t, err)
 
 	assertUsageValue(t, values.DAUs[0], startDate.Add(time.Hour*24*2), 4, 4, 0, 0)
 	assertUsageValue(t, values.DAUs[1], startDate.Add(time.Hour*24), 2, 2, 0, 0)
@@ -454,26 +452,30 @@ func TestEventLogs_SiteUsage_ExcludeSourcegraphAdmins(t *testing.T) {
 	// time that falls too near the edge of a week.
 	now := time.Unix(1589581800, 0).UTC()
 
-	// Several of the events will belong to a Sourcegraph employee admin user
+	// Several of the events will belong to Sourcegraph employee admin user and Sourcegraph Operator user account
 	sgAdmin, err := db.Users().Create(ctx, NewUser{Username: "sourcegraph-admin"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := db.UserEmails().Add(ctx, sgAdmin.ID, "admin@sourcegraph.com", nil); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	err = db.UserEmails().Add(ctx, sgAdmin.ID, "admin@sourcegraph.com", nil)
+	require.NoError(t, err)
+	soLoganID, err := db.UserExternalAccounts().CreateUserAndSave(
+		ctx,
+		NewUser{
+			Username: "sourcegraph-operator-logan",
+		},
+		extsvc.AccountSpec{
+			ServiceType: "sourcegraph-operator",
+		},
+		extsvc.AccountData{},
+	)
+	require.NoError(t, err)
 
 	user1, err := db.Users().Create(ctx, NewUser{Username: "a"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	user2, err := db.Users().Create(ctx, NewUser{Username: "b"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	days := map[time.Time]struct {
-		users   []uint32
+		userIDs []uint32
 		names   []string
 		sources []string
 	}{
@@ -483,9 +485,19 @@ func TestEventLogs_SiteUsage_ExcludeSourcegraphAdmins(t *testing.T) {
 			[]string{"ViewSiteAdminX"},
 			[]string{"test", "CODEHOSTINTEGRATION"},
 		},
+		now.Add(-time.Hour): {
+			[]uint32{uint32(soLoganID)},
+			[]string{"ViewSiteAdminX"},
+			[]string{"test", "CODEHOSTINTEGRATION"},
+		},
 		// This week
 		now.Add(-time.Hour * 24 * 3): {
 			[]uint32{uint32(sgAdmin.ID), uint32(user1.ID)},
+			[]string{"ViewRepository", "ViewTree"},
+			[]string{"test", "CODEHOSTINTEGRATION"},
+		},
+		now.Add(-time.Hour * 24 * 4): {
+			[]uint32{uint32(soLoganID), uint32(user1.ID)},
 			[]string{"ViewRepository", "ViewTree"},
 			[]string{"test", "CODEHOSTINTEGRATION"},
 		},
@@ -498,12 +510,12 @@ func TestEventLogs_SiteUsage_ExcludeSourcegraphAdmins(t *testing.T) {
 	}
 
 	for day, data := range days {
-		for _, user := range data.users {
+		for _, userID := range data.userIDs {
 			for _, name := range data.names {
 				for _, source := range data.sources {
 					for i := 0; i < 5; i++ {
 						e := &Event{
-							UserID: user,
+							UserID: userID,
 							Name:   name,
 							URL:    "http://sourcegraph.com",
 							Source: source,
@@ -511,9 +523,12 @@ func TestEventLogs_SiteUsage_ExcludeSourcegraphAdmins(t *testing.T) {
 							Timestamp: day.Add(time.Minute * time.Duration(rand.Intn(60)-30)),
 						}
 
-						if err := db.EventLogs().Insert(ctx, e); err != nil {
-							t.Fatal(err)
+						if userID == uint32(soLoganID) {
+							e.PublicArgument = json.RawMessage(`{"sourcegraph_operator": true}`)
 						}
+
+						err := db.EventLogs().Insert(ctx, e)
+						require.NoError(t, err)
 					}
 				}
 			}
@@ -522,32 +537,26 @@ func TestEventLogs_SiteUsage_ExcludeSourcegraphAdmins(t *testing.T) {
 
 	el := &eventLogStore{Store: basestore.NewWithHandle(db.Handle())}
 	summary, err := el.siteUsageCurrentPeriods(ctx, now, &SiteUsageOptions{CommonUsageOptions{ExcludeSourcegraphAdmins: false}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	expectedSummary := types.SiteUsageSummary{
 		Month:                   time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC),
 		Week:                    now.Truncate(time.Hour * 24).Add(-time.Hour * 24 * 5), // the previous Sunday
 		Day:                     now.Truncate(time.Hour * 24),
-		UniquesMonth:            3,
-		UniquesWeek:             2,
-		UniquesDay:              1,
-		RegisteredUniquesMonth:  3,
-		RegisteredUniquesWeek:   2,
-		RegisteredUniquesDay:    1,
-		IntegrationUniquesMonth: 3,
-		IntegrationUniquesWeek:  2,
-		IntegrationUniquesDay:   1,
+		UniquesMonth:            4,
+		UniquesWeek:             3,
+		UniquesDay:              2,
+		RegisteredUniquesMonth:  4,
+		RegisteredUniquesWeek:   3,
+		RegisteredUniquesDay:    2,
+		IntegrationUniquesMonth: 4,
+		IntegrationUniquesWeek:  3,
+		IntegrationUniquesDay:   2,
 	}
-	if diff := cmp.Diff(expectedSummary, summary); diff != "" {
-		t.Fatal(diff)
-	}
+	assert.Equal(t, expectedSummary, summary)
 
-	summary, err = el.siteUsageCurrentPeriods(ctx, now, &SiteUsageOptions{CommonUsageOptions{ExcludeSourcegraphAdmins: true}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	summary, err = el.siteUsageCurrentPeriods(ctx, now, &SiteUsageOptions{CommonUsageOptions{ExcludeSourcegraphAdmins: true, ExcludeSourcegraphOperators: true}})
+	require.NoError(t, err)
 
 	expectedSummary = types.SiteUsageSummary{
 		Month:                   time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC),
@@ -563,9 +572,7 @@ func TestEventLogs_SiteUsage_ExcludeSourcegraphAdmins(t *testing.T) {
 		IntegrationUniquesWeek:  1,
 		IntegrationUniquesDay:   0,
 	}
-	if diff := cmp.Diff(expectedSummary, summary); diff != "" {
-		t.Fatal(diff)
-	}
+	assert.Equal(t, expectedSummary, summary)
 }
 
 func TestEventLogs_codeIntelligenceWeeklyUsersCount(t *testing.T) {
@@ -1435,20 +1442,22 @@ func makeTestEvent(e *Event) *Event {
 }
 
 func assertUsageValue(t *testing.T, v *types.SiteActivityPeriod, start time.Time, userCount, registeredUserCount, anonymousUserCount, integrationUserCount int) {
+	t.Helper()
+
 	if v.StartTime != start {
-		t.Errorf("got Start %q, want %q", v.StartTime, start)
+		t.Errorf("got StartTime %q, want %q", v.StartTime, start)
 	}
 	if int(v.UserCount) != userCount {
-		t.Errorf("got Count %d, want %d", v.UserCount, userCount)
+		t.Errorf("got UserCount %d, want %d", v.UserCount, userCount)
 	}
 	if int(v.RegisteredUserCount) != registeredUserCount {
-		t.Errorf("got Count %d, want %d", v.RegisteredUserCount, registeredUserCount)
+		t.Errorf("got RegisteredUserCount %d, want %d", v.RegisteredUserCount, registeredUserCount)
 	}
 	if int(v.AnonymousUserCount) != anonymousUserCount {
-		t.Errorf("got Count %d, want %d", v.AnonymousUserCount, anonymousUserCount)
+		t.Errorf("got AnonymousUserCount %d, want %d", v.AnonymousUserCount, anonymousUserCount)
 	}
 	if int(v.IntegrationUserCount) != integrationUserCount {
-		t.Errorf("got Count %d, want %d", v.IntegrationUserCount, integrationUserCount)
+		t.Errorf("got IntegrationUserCount %d, want %d", v.IntegrationUserCount, integrationUserCount)
 	}
 }
 

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -118,7 +118,7 @@ func (s *securityEventLogsStore) InsertList(ctx context.Context, events []*Secur
 			result, err := jsonc.Edit(
 				event.marshalArgumentAsJSON(),
 				true,
-				"sourcegraph_operator",
+				EventLogsSourcegraphOperatorKey,
 			)
 			event.Argument = json.RawMessage(result)
 			if err != nil {

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -813,7 +813,11 @@ type UsersListOptions struct {
 	// `timestamp` greater-than-or-equal to the given timestamp.
 	InactiveSince time.Time
 
-	ExcludeSourcegraphAdmins bool // filter out users with a known Sourcegraph admin username
+	// Filter out users with a known Sourcegraph admin username
+	//
+	// Deprecated: Use ExcludeSourcegraphOperators instead. If you have to use this,
+	// then set both fields with the same value at the same time.
+	ExcludeSourcegraphAdmins bool
 	// ExcludeSourcegraphOperators indicates whether to exclude Sourcegraph Operator
 	// user accounts.
 	ExcludeSourcegraphOperators bool

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -814,7 +814,8 @@ type UsersListOptions struct {
 	InactiveSince time.Time
 
 	ExcludeSourcegraphAdmins bool // filter out users with a known Sourcegraph admin username
-	// ExcludeSourcegraphOperators indicates whether to exclude Sourcegraph Operator user accounts.
+	// ExcludeSourcegraphOperators indicates whether to exclude Sourcegraph Operator
+	// user accounts.
 	ExcludeSourcegraphOperators bool
 
 	*LimitOffset

--- a/internal/usagestats/usage_stats.go
+++ b/internal/usagestats/usage_stats.go
@@ -152,7 +152,16 @@ func GetByUserID(ctx context.Context, db database.DB, userID int32) (*types.User
 func GetUsersActiveTodayCount(ctx context.Context, db database.DB) (int, error) {
 	now := timeNow().UTC()
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
-	return db.EventLogs().CountUniqueUsersAll(ctx, today, today.AddDate(0, 0, 1), &database.CountUniqueUsersOptions{CommonUsageOptions: database.CommonUsageOptions{ExcludeSystemUsers: true, ExcludeSourcegraphAdmins: true}})
+	return db.EventLogs().CountUniqueUsersAll(
+		ctx,
+		today,
+		today.AddDate(0, 0, 1),
+		&database.CountUniqueUsersOptions{CommonUsageOptions: database.CommonUsageOptions{
+			ExcludeSystemUsers:          true,
+			ExcludeSourcegraphAdmins:    true,
+			ExcludeSourcegraphOperators: true,
+		}},
+	)
 }
 
 // ListRegisteredUsersToday returns a list of the registered users that were active today.
@@ -224,9 +233,10 @@ func activeUsers(ctx context.Context, db database.DB, dayPeriods, weekPeriods, m
 
 	return db.EventLogs().SiteUsageMultiplePeriods(ctx, timeNow().UTC(), dayPeriods, weekPeriods, monthPeriods, &database.CountUniqueUsersOptions{
 		CommonUsageOptions: database.CommonUsageOptions{
-			ExcludeSystemUsers:       true,
-			ExcludeNonActiveUsers:    true,
-			ExcludeSourcegraphAdmins: true,
+			ExcludeSystemUsers:          true,
+			ExcludeNonActiveUsers:       true,
+			ExcludeSourcegraphAdmins:    true,
+			ExcludeSourcegraphOperators: true,
 		},
 	})
 }

--- a/internal/users/stats.go
+++ b/internal/users/stats.go
@@ -130,6 +130,16 @@ func (s *UsersStats) makeQueryParameters() ([]*sqlf.Query, error) {
 			conds = append(conds, sqlf.Sprintf("events_count >= %s", *s.Filters.EventsCount.Gte))
 		}
 	}
+
+	// Exclude Sourcegraph Operator user accounts
+	conds = append(conds, sqlf.Sprintf(`
+NOT EXISTS (
+	SELECT FROM user_external_accounts
+	WHERE
+		service_type = 'sourcegraph-operator'
+	AND user_id = aggregated_stats.id
+)
+`))
 	return conds, nil
 }
 


### PR DESCRIPTION
This PR makes our usage stats to exclude all activities generated by SOAP user accounts, which affects both **Site admin > Analytics > Users** and **Site admin > Pings** pages.

## Test plan

1. Create a temporary JSON file (`site-config.json`) with the following content, the credentials can be obtained from the "Okta test instance admin" in 1Password and the "OpenID Connect (sourcegraph.test:3443)" application:
	```json
	{
	  "authProviders": {
	    "sourcegraphOperator": {
	      "issuer": "https://dev-433675.oktapreview.com",
	      "clientID": "<REDACTED>",
	      "clientSecret": "<REDACTED>",
	      "lifecycleDuration": 60
	    }
	  }
	}
	```
3. Save the "Sourcegraph Cloud site config singer key" in 1Password to a temporary file (`singer.key`), and use it to sign the site config:
	```sh
	go run enterprise/internal/cloud/sign_site_config.go -private-key singer.key  -site-config site-config.json
	```
4. Set the output of the above command as the value of the env var `SRC_CLOUD_SITE_CONFIG`
5. Comment out the `"licenseKey"` from the `dev-private/enterprise/dev/site-config.json`
6. Boot up the local Sourcegraph instance and try to sign in with "Sourcergaph Operators" using the same Okta account used in step 1.
7. The usage stats in **Site admin > Analytics > Users** and **Site admin > Pings** does not increase.

---

Closes  https://github.com/sourcegraph/customer/issues/1430

