### PR TITLE
auth: hide SOAP sign-in option by default

### DIFF
--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -52,18 +52,21 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
         provider => provider.isBuiltin
     )
 
-    const showSourcegraphOperatorLogin = function (provider: AuthProvider): boolean {
+    const shouldShowProvider = function (provider: AuthProvider): boolean {
+        // Hide the legacy OIDC sign-in by default if the hiding feature flag is turned on.
         if (provider.serviceType === 'openidconnect' && provider.displayName === 'Sourcegraph Employee') {
             return !isOperatorHidingEnabled || new URLSearchParams(location.search).has('sourcegraph-operator')
         }
 
+        // Hide the Sourcegraph Operator authentication provider by default because it is
+        // not useful to customer users and may even cause confusion.
         if (provider.serviceType === 'sourcegraph-operator') {
             return new URLSearchParams(location.search).has('sourcegraph-operator')
         }
         return true
     }
 
-    const thirdPartyAuthProviders = nonBuiltinAuthProviders.filter(provider => showSourcegraphOperatorLogin(provider))
+    const thirdPartyAuthProviders = nonBuiltinAuthProviders.filter(provider => shouldShowProvider(provider))
 
     const body =
         !builtInAuthProvider && thirdPartyAuthProviders.length === 0 ? (


### PR DESCRIPTION
This PR makes the SOAP sign-in option to be hidden by default, and Sourcegraph operators can append "?sourcegraph-operator" to the URL to see it.

Default:

![CleanShot 2022-11-29 at 13 44 43@2x](https://user-images.githubusercontent.com/2946214/204448669-31674240-003e-4e09-932c-e86de7f700b9.png)

Append "?sourcegraph-operator":

![CleanShot 2022-11-29 at 13 45 06@2x](https://user-images.githubusercontent.com/2946214/204448728-13c8e18d-bc4c-4932-ad76-d6c73ae0ceac.png)


## Test plan

1. Create a temporary JSON file (`site-config.json`) with the following content, the credentials can be obtained from the "Okta test instance admin" in 1Password and the "OpenID Connect (sourcegraph.test:3443)" application:
	```json
	{
	  "authProviders": {
	    "sourcegraphOperator": {
	      "issuer": "https://dev-433675.oktapreview.com",
	      "clientID": "<REDACTED>",
	      "clientSecret": "<REDACTED>",
	      "lifecycleDuration": 60
	    }
	  }
	}
	```
3. Save the "Sourcegraph Cloud site config singer key" in 1Password to a temporary file (`singer.key`), and use it to sign the site config:
	```sh
	go run enterprise/internal/cloud/sign_site_config.go -private-key singer.key  -site-config site-config.json
	```
4. Set the output of the above command as the value of the env var `SRC_CLOUD_SITE_CONFIG`
5. Comment out the `"licenseKey"` from the `dev-private/enterprise/dev/site-config.json`
6. Boot up the local Sourcegraph instance and try to sign in with "Sourcergaph Operators" using the same Okta account used in step 1.
7. Append "?sourcegraph-operator" to the URL to see the SOAP sign-in option.

---

Closes  https://github.com/sourcegraph/customer/issues/1634


## App preview:

- [Web](https://sg-web-jc-soap-11-hide-soap-signin.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
