### PR TITLE
schema: Set max for `history.defaultPageSize`

### DIFF
--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -739,7 +739,8 @@
     "history.defaultPageSize": {
       "description": "Custom page size for the history tab. If set, the history tab will populate that number of commits the first time the history tab is opened and then double the number of commits progressively.",
       "type": "integer",
-      "minimum": 1
+      "minimum": 1,
+      "maximum": 100
     },
     "notices": {
       "description": "Custom informational messages to display to users at specific locations in the Sourcegraph user interface.\n\nUsually this setting is used in global and organization settings. If set in user settings, the message will only be displayed to that single user.",


### PR DESCRIPTION
Set a max of 100 (default behaviour) to avoid users accidentally running into performance regressions by setting a high value for this setting.

👉🏽 Suggested by customer on [Slack](https://sourcegraph.slack.com/archives/C01D50MSA7L/p1669675662900549?thread_ts=1669672729.402689&cid=C01D50MSA7L). 

Follow up on #44651.

## Test plan

Tested locally that only maximum of 100 can be set for this setting.

**Site-admin settings**
<img width="1366" alt="image" src="https://user-images.githubusercontent.com/2682729/204459101-17eaf5c5-c281-4b68-b83e-49047b197cd4.png">

**User settings**
<img width="1366" alt="image" src="https://user-images.githubusercontent.com/2682729/204459643-7853afae-a441-4165-b0a8-a4c3255ae74f.png">





<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
