### PR TITLE
search contexts: rename sort by labels

### DIFF
--- a/client/web/src/enterprise/searchContexts/SearchContextsListTab.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextsListTab.tsx
@@ -107,14 +107,14 @@ export const SearchContextsListTab: React.FunctionComponent<React.PropsWithChild
             ],
         },
         {
-            label: 'Order by',
+            label: 'Sort by',
             type: 'select',
             id: 'order',
             tooltip: 'Order search contexts',
             values: [
                 {
                     value: 'spec-asc',
-                    label: 'Alphabetically A-Z',
+                    label: 'A-Z',
                     args: {
                         orderBy: SearchContextsOrderBy.SEARCH_CONTEXT_SPEC,
                         descending: false,
@@ -122,7 +122,7 @@ export const SearchContextsListTab: React.FunctionComponent<React.PropsWithChild
                 },
                 {
                     value: 'spec-desc',
-                    label: 'Alphabetically Z-A',
+                    label: 'Z-A',
                     args: {
                         orderBy: SearchContextsOrderBy.SEARCH_CONTEXT_SPEC,
                         descending: true,
@@ -130,7 +130,7 @@ export const SearchContextsListTab: React.FunctionComponent<React.PropsWithChild
                 },
                 {
                     value: 'updated-at-asc',
-                    label: 'Last update ascending',
+                    label: 'Oldest updates',
                     args: {
                         orderBy: SearchContextsOrderBy.SEARCH_CONTEXT_UPDATED_AT,
                         descending: false,
@@ -138,7 +138,7 @@ export const SearchContextsListTab: React.FunctionComponent<React.PropsWithChild
                 },
                 {
                     value: 'updated-at-desc',
-                    label: 'Last update descending',
+                    label: 'Newest updates',
                     args: {
                         orderBy: SearchContextsOrderBy.SEARCH_CONTEXT_UPDATED_AT,
                         descending: true,


### PR DESCRIPTION
Fixes #43679 
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

* Open search contexts page
* Observe renamed labels