### PR TITLE
references panel: expand first repo by default

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -782,17 +782,16 @@ const LocationsList: React.FunctionComponent<React.PropsWithChildren<LocationsLi
     activeURL,
 }) => {
     const repoLocationGroups = useMemo(() => buildRepoLocationGroups(locations), [locations])
-    const openByDefault = repoLocationGroups.length === 1
 
     return (
         <>
-            {repoLocationGroups.map(group => (
+            {repoLocationGroups.map((group, index) => (
                 <CollapsibleRepoLocationGroup
                     key={group.repoName}
                     activeURL={activeURL}
                     searchToken={searchToken}
                     repoLocationGroup={group}
-                    openByDefault={openByDefault}
+                    openByDefault={index === 0}
                     isActiveLocation={isActiveLocation}
                     setActiveLocation={setActiveLocation}
                     filter={filter}

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -3,7 +3,7 @@ import React, { KeyboardEvent, MouseEvent, useCallback, useEffect, useLayoutEffe
 import { mdiArrowCollapseRight, mdiChevronDown, mdiChevronRight, mdiFilterOutline } from '@mdi/js'
 import classNames from 'classnames'
 import * as H from 'history'
-import { capitalize } from 'lodash'
+import { capitalize, uniqBy } from 'lodash'
 import { MemoryRouter, useLocation } from 'react-router'
 import { Observable, of } from 'rxjs'
 import { map } from 'rxjs/operators'
@@ -570,6 +570,12 @@ const CollapsibleLocationList: React.FunctionComponent<
     React.PropsWithChildren<CollapsibleLocationListProps>
 > = props => {
     const isOpen = props.isOpen(props.name) ?? true
+    const quantityLabel = useMemo(() => {
+        const repoNumber = uniqBy(props.locations, 'repo').length
+        return `(${props.locations.length} ${pluralize('item', props.locations.length)}${
+            repoNumber > 1 ? ` from ${repoNumber} repositories` : ''
+        } displayed${props.hasMore ? ', more available' : ''})`
+    }, [props.locations, props.hasMore])
 
     return (
         <Collapse isOpen={isOpen} onOpenChange={isOpen => props.handleOpenChange(props.name, isOpen)}>
@@ -588,7 +594,7 @@ const CollapsibleLocationList: React.FunctionComponent<
                         )}{' '}
                         <H4 className="mb-0">{capitalize(props.name)}</H4>
                         <span className={classNames('ml-2 text-muted small', styles.cardHeaderSmallText)}>
-                            ({props.locations.length} displayed{props.hasMore ? ', more available)' : ')'}
+                            {quantityLabel}
                         </span>
                     </CollapseHeader>
                 </CardHeader>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/44819

Expands first repo item by default.
Adds repo number to the results quantity label if results come from two or more different repositories. As the first repo panel is expanded by default it's obvious for users that there are results from other repos too. Thus we update the results number label to include the number of repos the results come from.

Previously repo panels had the following expanded state logic:
- if locations (results) come only from one repo, this repo panel is expanded by default
- if locations come from more than one repo, repo panels remain collapsed.
As references panel receives locations incrementally we had the case when locations from a single repo were received and thus this repo panel was expanded by default. Then we got locations from other repos, and all repo panels automatically collapsed resulting in confusing panels behavior reported in the referenced issue.

https://user-images.githubusercontent.com/25318659/204529317-9738ea99-fa7c-47d9-a6b4-bad68b95fdc8.mov

<img width="1844" alt="Screenshot 2022-11-29 at 14 28 11" src="https://user-images.githubusercontent.com/25318659/204529332-c0d5bed7-49d0-47c7-9768-34b96331ac6a.png">


## Test plan
CI checks pass.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-fix-references-panel.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
