### PR TITLE
ci: use golang 1.19.3 image in builder for symbols

### DIFF
--- a/cmd/symbols/Dockerfile
+++ b/cmd/symbols/Dockerfile
@@ -6,7 +6,7 @@ USER root
 COPY cmd/symbols/ctags-install-alpine.sh /ctags-install-alpine.sh
 RUN /ctags-install-alpine.sh
 
-FROM golang:1.18.1-alpine@sha256:42d35674864fbb577594b60b84ddfba1be52b4d4298c961b46ba95e9fb4712e8 AS symbols-build
+FROM golang:1.19.3-alpine@sha256:27a9653759f44afd08c94418307a26d2db9cf78af12933200bc2ca63c4844316 AS symbols-build
 # hadolint ignore=DL3002
 USER root
 


### PR DESCRIPTION
with the upgrade to 1.19.3 we've ugraded our dev environments to 1.19.3 but some of our docker images are using 1.18.1 ... which I forgot to update 😮‍💨 

PR to following which updates the rest of our images where applicable

## Test plan
[green main-dry-run](https://buildkite.com/sourcegraph/sourcegraph/builds/185732)
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
