### PR TITLE
Add changeset ID to error log

### DIFF
--- a/enterprise/internal/batches/syncer/syncer.go
+++ b/enterprise/internal/batches/syncer/syncer.go
@@ -409,7 +409,7 @@ func (s *changesetSyncer) Run(ctx context.Context) {
 			s.metrics.syncs.WithLabelValues(labelValues...).Inc()
 
 			if err != nil {
-				s.logger.Error("Syncing changeset", log.Error(err))
+				s.logger.Error("Syncing changeset", log.Int64("changeset ID", next.changesetID), log.Error(err))
 				// We'll continue and remove it as it'll get retried on next schedule
 			}
 

--- a/enterprise/internal/batches/syncer/syncer.go
+++ b/enterprise/internal/batches/syncer/syncer.go
@@ -409,7 +409,7 @@ func (s *changesetSyncer) Run(ctx context.Context) {
 			s.metrics.syncs.WithLabelValues(labelValues...).Inc()
 
 			if err != nil {
-				s.logger.Error("Syncing changeset", log.Int64("changeset ID", next.changesetID), log.Error(err))
+				s.logger.Error("Syncing changeset", log.Int64("changesetID", next.changesetID), log.Error(err))
 				// We'll continue and remove it as it'll get retried on next schedule
 			}
 


### PR DESCRIPTION
Simple change to add a changeset ID to the error log, so that it can be debugged when a changeset sync fails. This is to debug a failing case on S2 that keeps popping up: https://sourcegraph.slack.com/archives/C045RUZAZ9P/p1669638261971009
But highlights the bigger issue that we don't have enough information to do something when a failure occurs.

## Test plan

Tests should pass, only a logging change.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
