### PR TITLE
search contexts: allow creation of dynamic search contexts with repo:has, repo:has.tag, and repo:has.key

### DIFF
--- a/client/search-ui/src/results/sidebar/SearchReference.tsx
+++ b/client/search-ui/src/results/sidebar/SearchReference.tsx
@@ -231,6 +231,13 @@ To use this filter, the search query must contain \`type:diff\` or \`type:commit
         showSuggestions: false,
     },
     {
+        ...createQueryExampleFromString('has.key({any string})'),
+        field: FilterType.repo,
+        description: 'Search inside repositories that are associated with the given key, regardless of its value.',
+        examples: ['repo:has.key(owner)', '-repo:has.key(wip)'],
+        showSuggestions: false,
+    },
+    {
         ...createQueryExampleFromString('{revision}'),
         field: FilterType.rev,
         commonRank: 20,

--- a/client/shared/src/search/query/completion.test.ts
+++ b/client/shared/src/search/query/completion.test.ts
@@ -385,6 +385,7 @@ describe('getCompletionItems()', () => {
               "has.description(\${1}) ",
               "has.tag(\${1}) ",
               "has(\${1:key}:\${2:value}) ",
+              "has.key(\${1}) ",
               "^repo/with\\\\ a\\\\ space$ "
             ]
         `)
@@ -408,7 +409,8 @@ describe('getCompletionItems()', () => {
               "has.commit.after(\${1:1 month ago}) ",
               "has.description(\${1}) ",
               "has.tag(\${1}) ",
-              "has(\${1:key}:\${2:value}) "
+              "has(\${1:key}:\${2:value}) ",
+              "has.key(\${1}) "
             ]
         `)
     })

--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -1674,6 +1674,45 @@ describe('getMonacoTokens()', () => {
         `)
     })
 
+    test('highlight repo:has.key predicate', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:has.key(key)')))).toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 4,
+                "scopes": "metaFilterSeparator"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "metaPredicateNameAccess"
+              },
+              {
+                "startIndex": 8,
+                "scopes": "metaPredicateDot"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "metaPredicateNameAccess"
+              },
+              {
+                "startIndex": 12,
+                "scopes": "metaPredicateParenthesis"
+              },
+              {
+                "startIndex": 13,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 16,
+                "scopes": "metaPredicateParenthesis"
+              }
+            ]
+        `)
+    })
+
     test('highlight regex delimited pattern for standard search', () => {
         expect(getMonacoTokens(toSuccess(scanSearchQuery('/f.*/ x', false, SearchPatternType.standard))))
             .toMatchInlineSnapshot(`

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -1006,6 +1006,7 @@ const decoratePredicateBody = (path: string[], body: string, offset: number): De
             break
         }
         case 'has.tag':
+        case 'has.key':
             return [
                 {
                     type: 'literal',

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -176,6 +176,8 @@ const toPredicateHover = (token: MetaPredicate): string => {
             return '**Built-in predicate**. Search only inside repositories that are tagged with the given tag'
         case 'has':
             return '**Built-in predicate**. Search only inside repositories that are associated with the given key:value pair'
+        case 'has.key':
+            return '**Built-in predicate**. Search only inside repositories that are associated with the given key, regardless of its value'
     }
     return ''
 }

--- a/client/shared/src/search/query/predicates.test.ts
+++ b/client/shared/src/search/query/predicates.test.ts
@@ -60,7 +60,7 @@ describe('scanPredicate', () => {
 describe('resolveAccess', () => {
     test('resolves partial access tree', () => {
         expect(resolveAccess(['repo'], PREDICATES)).toMatchInlineSnapshot(
-            '[{"name":"contains","fields":[{"name":"file"},{"name":"path"},{"name":"content"},{"name":"commit","fields":[{"name":"after"}]}]},{"name":"has","fields":[{"name":"file"},{"name":"path"},{"name":"content"},{"name":"commit","fields":[{"name":"after"}]},{"name":"description"},{"name":"tag"}]}]'
+            '[{"name":"contains","fields":[{"name":"file"},{"name":"path"},{"name":"content"},{"name":"commit","fields":[{"name":"after"}]}]},{"name":"has","fields":[{"name":"file"},{"name":"path"},{"name":"content"},{"name":"commit","fields":[{"name":"after"}]},{"name":"description"},{"name":"tag"},{"name":"key"}]}]'
         )
     })
 

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -213,7 +213,7 @@ export const predicateCompletion = (field: string): Completion[] => {
                 label: 'has.key(...)',
                 insertText: 'has.key(${1})',
                 asSnippet: true,
-            }
+            },
         ]
     }
     return []

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -39,6 +39,7 @@ export const PREDICATES: Access[] = [
                     },
                     { name: 'description' },
                     { name: 'tag' },
+                    { name: 'key' },
                 ],
             },
         ],
@@ -208,6 +209,11 @@ export const predicateCompletion = (field: string): Completion[] => {
                 insertText: 'has(${1:key}:${2:value})',
                 asSnippet: true,
             },
+            {
+                label: 'has.key(...)',
+                insertText: 'has.key(${1})',
+                asSnippet: true,
+            }
         ]
     }
     return []

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -37,6 +37,7 @@ var DefaultPredicateRegistry = PredicateRegistry{
 		"has.description":       func() Predicate { return &RepoHasDescriptionPredicate{} },
 		"has.tag":               func() Predicate { return &RepoHasTagPredicate{} },
 		"has":                   func() Predicate { return &RepoHasKVPPredicate{} },
+		"has.key":               func() Predicate { return &RepoHasKeyPredicate{} },
 	},
 	FieldFile: {
 		"contains.content": func() Predicate { return &FileContainsContentPredicate{} },
@@ -299,6 +300,23 @@ func (p *RepoHasKVPPredicate) Unmarshal(params string, negated bool) (err error)
 
 func (p *RepoHasKVPPredicate) Field() string { return FieldRepo }
 func (p *RepoHasKVPPredicate) Name() string  { return "has" }
+
+type RepoHasKeyPredicate struct {
+	Key     string
+	Negated bool
+}
+
+func (p *RepoHasKeyPredicate) Unmarshal(params string, negated bool) (err error) {
+	if len(params) == 0 {
+		return errors.New("key must be non-empty")
+	}
+	p.Key = params
+	p.Negated = negated
+	return nil
+}
+
+func (p *RepoHasKeyPredicate) Field() string { return FieldRepo }
+func (p *RepoHasKeyPredicate) Name() string  { return "has.key" }
 
 /* file:contains.content(pattern) */
 

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -423,6 +423,7 @@ type RepoKVPFilter struct {
 	Key     string
 	Value   *string
 	Negated bool
+	KeyOnly bool
 }
 
 func (p Parameters) RepoHasKVPs() (res []RepoKVPFilter) {
@@ -438,6 +439,14 @@ func (p Parameters) RepoHasKVPs() (res []RepoKVPFilter) {
 		res = append(res, RepoKVPFilter{
 			Key:     pred.Key,
 			Negated: pred.Negated,
+		})
+	})
+
+	VisitTypedPredicate(toNodes(p), func(pred *RepoHasKeyPredicate) {
+		res = append(res, RepoKVPFilter{
+			Key:     pred.Key,
+			Negated: pred.Negated,
+			KeyOnly: true,
 		})
 	})
 

--- a/internal/search/query/types_test.go
+++ b/internal/search/query/types_test.go
@@ -27,3 +27,32 @@ func TestRepoHasDescription(t *testing.T) {
 
 	require.Equal(t, want, ps.RepoHasDescription())
 }
+
+func TestRepoHasKVPs(t *testing.T) {
+	ps := Parameters{
+		Parameter{
+			Field:      FieldRepo,
+			Value:      "has(key:value)",
+			Annotation: Annotation{Labels: IsPredicate},
+		},
+		Parameter{
+			Field:      FieldRepo,
+			Value:      "has.tag(tag)",
+			Annotation: Annotation{Labels: IsPredicate},
+		},
+		Parameter{
+			Field:      FieldRepo,
+			Value:      "has.key(key)",
+			Annotation: Annotation{Labels: IsPredicate},
+		},
+	}
+
+	value := "value"
+	want := []RepoKVPFilter{
+		{Key: "key", Value: &value, Negated: false, KeyOnly: false},
+		{Key: "tag", Value: nil, Negated: false, KeyOnly: false},
+		{Key: "key", Value: nil, Negated: false, KeyOnly: true},
+	}
+
+	require.Equal(t, want, ps.RepoHasKVPs())
+}

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -137,6 +137,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (_ Resolv
 			Key:     filter.Key,
 			Value:   filter.Value,
 			Negated: filter.Negated,
+			KeyOnly: filter.KeyOnly,
 		})
 	}
 

--- a/internal/search/searchcontexts/search_contexts.go
+++ b/internal/search/searchcontexts/search_contexts.go
@@ -207,9 +207,12 @@ func validateSearchContextQuery(contextQuery string) error {
 		switch field {
 		case query.FieldRepo:
 			if a.Labels.IsSet(query.IsPredicate) {
-				errs = errors.Append(errs,
-					errors.Errorf("unsupported repo field predicate in search context query: %q", value))
-				return
+				predName, _ := query.ParseAsPredicate(value)
+				if predName != "has" && predName != "has.tag" && predName != "has.key" {
+					errs = errors.Append(errs,
+						errors.Errorf("unsupported repo field predicate in search context query: %q", value))
+					return
+				}
 			}
 
 			repoRegex, revs := search.ParseRepositoryRevisions(value)

--- a/internal/search/searchcontexts/search_contexts.go
+++ b/internal/search/searchcontexts/search_contexts.go
@@ -213,6 +213,7 @@ func validateSearchContextQuery(contextQuery string) error {
 						errors.Errorf("unsupported repo field predicate in search context query: %q", value))
 					return
 				}
+				return
 			}
 
 			repoRegex, revs := search.ParseRepositoryRevisions(value)

--- a/internal/search/searchcontexts/search_contexts_test.go
+++ b/internal/search/searchcontexts/search_contexts_test.go
@@ -470,6 +470,27 @@ func TestCreatingSearchContexts(t *testing.T) {
 			},
 			wantErr: fmt.Sprintf("revision %q exceeds maximum allowed length (255)", tooLongRevision),
 		},
+		{
+			name:          "can create search context with repo:has query",
+			searchContext: &types.SearchContext{Name: "repo_has_kvp", Query: "repo:has(key:value)"},
+			userID:        user1.ID,
+		},
+		{
+			name:          "can create search context with repo:has.tag query",
+			searchContext: &types.SearchContext{Name: "repo_has_tag", Query: "repo:has.tag(tag)"},
+			userID:        user1.ID,
+		},
+		{
+			name:          "can create search context with repo:has.key query",
+			searchContext: &types.SearchContext{Name: "repo_has_key", Query: "repo:has.key(key)"},
+			userID:        user1.ID,
+		},
+		{
+			name:          "cannot create search context with unsupported repo field predicate in query",
+			searchContext: &types.SearchContext{Name: "unsupported_repo_predicate", Query: "repo:has.content(foo)"},
+			userID:        user1.ID,
+			wantErr:       fmt.Sprintf("unsupported repo field predicate in search context query: %q", "has.content(foo)"),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Stacked on #44873

Addresses #43958

Allow the use of `repo:has`, `repo:has.tag` and `repo:has.key` in query-based search contexts. This way, users can create a search context like `repo:has.tag(my-team-name)` once to encompass all current and future repos that are tagged with "my-team-name".


## Test plan
Manually test
Added unit tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
