### PR TITLE
Add result count to search history

### DIFF
--- a/client/search-ui/src/input/SearchHistoryDropdown.module.scss
+++ b/client/search-ui/src/input/SearchHistoryDropdown.module.scss
@@ -12,6 +12,7 @@
         cursor: pointer;
         display: flex;
         justify-content: space-between;
+        align-items: baseline;
 
         &:hover {
             background-color: var(--body-bg);

--- a/client/search-ui/src/input/SearchHistoryDropdown.module.scss
+++ b/client/search-ui/src/input/SearchHistoryDropdown.module.scss
@@ -20,10 +20,6 @@
         &[aria-selected='true'] {
             background-color: var(--dropdown-link-hover-bg);
         }
-
-        > span:last-child span:last-child {
-            width: 12em;
-        }
     }
 }
 

--- a/client/search-ui/src/input/SearchHistoryDropdown.module.scss
+++ b/client/search-ui/src/input/SearchHistoryDropdown.module.scss
@@ -20,6 +20,10 @@
         &[aria-selected='true'] {
             background-color: var(--dropdown-link-hover-bg);
         }
+
+        > span:last-child span:last-child {
+            width: 12em;
+        }
     }
 }
 

--- a/client/search-ui/src/input/SearchHistoryDropdown.tsx
+++ b/client/search-ui/src/input/SearchHistoryDropdown.tsx
@@ -1,11 +1,11 @@
 import React, {
-    useState,
-    useCallback,
     KeyboardEvent,
     KeyboardEventHandler,
-    useRef,
-    MouseEventHandler,
     MouseEvent,
+    MouseEventHandler,
+    useCallback,
+    useRef,
+    useState,
 } from 'react'
 
 import { mdiClockOutline } from '@mdi/js'
@@ -17,15 +17,15 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 // eslint-disable-next-line no-restricted-imports
 import { Timestamp } from '@sourcegraph/web/src/components/time/Timestamp'
 import {
+    createRectangle,
+    Flipping,
     Icon,
     Popover,
-    PopoverTrigger,
     PopoverContent,
-    usePopoverContext,
-    Flipping,
-    Tooltip,
     PopoverOpenEvent,
-    createRectangle,
+    PopoverTrigger,
+    Tooltip,
+    usePopoverContext,
 } from '@sourcegraph/wildcard'
 
 import styles from './SearchHistoryDropdown.module.scss'
@@ -42,6 +42,7 @@ interface SearchHistoryDropdownProps extends TelemetryProps {
 // button and the content
 const popoverPadding = createRectangle(0, 0, 0, 2)
 
+// eslint-disable-next-line react/display-name
 export const SearchHistoryDropdown: React.FunctionComponent<SearchHistoryDropdownProps> = React.memo(
     ({ recentSearches = [], onSelect, className, telemetryService }) => {
         const [isOpen, setIsOpen] = useState(false)
@@ -149,7 +150,12 @@ const SearchHistoryEntries: React.FunctionComponent<SearchHistoryEntriesProps> =
             onClick={clickHandler}
         >
             {recentSearches.map((search, index) => (
-                <SearchHistoryEntry key={index} index={index} search={search} selected={index === selectedIndex} />
+                <SearchHistoryEntry
+                    key={`${search.timestamp}-${search.query}`}
+                    index={index}
+                    search={search}
+                    selected={index === selectedIndex}
+                />
             ))}
         </ul>
     )
@@ -163,8 +169,11 @@ const SearchHistoryEntry: React.FunctionComponent<{
     <li role="option" data-index={index} aria-selected={selected}>
         <SyntaxHighlightedSearchQuery query={search.query} tabIndex={-1} />
         <span className="ml-1 text-nowrap text-muted">
-            <span className="sr-only">,</span>
-            <Timestamp date={search.timestamp} />
+            {search.resultCount !== undefined && <span>{search.resultCount} results</span>}
+            <span className="d-inline-block text-right">
+                <span className="sr-only">,</span>
+                <Timestamp date={search.timestamp} />
+            </span>
         </span>
     </li>
 ))

--- a/client/search-ui/src/input/SearchHistoryDropdown.tsx
+++ b/client/search-ui/src/input/SearchHistoryDropdown.tsx
@@ -11,6 +11,7 @@ import React, {
 import { mdiClockOutline } from '@mdi/js'
 import classNames from 'classnames'
 
+import { pluralize } from '@sourcegraph/common/out/src'
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { RecentSearch } from '@sourcegraph/shared/src/settings/temporary/recentSearches'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -169,11 +170,9 @@ const SearchHistoryEntry: React.FunctionComponent<{
     <li role="option" data-index={index} aria-selected={selected}>
         <SyntaxHighlightedSearchQuery query={search.query} tabIndex={-1} />
         <span className="ml-1 text-nowrap text-muted">
-            {search.resultCount !== undefined && <span>{search.resultCount} results</span>}
-            <span className="d-inline-block text-right">
-                <span className="sr-only">,</span>
-                <Timestamp date={search.timestamp} />
-            </span>
+            <span className="sr-only">,</span>
+            {search.resultCount !== undefined && <span>{`${search.resultCount} results`} • </span>}
+            <Timestamp date={search.timestamp} />
         </span>
     </li>
 ))

--- a/client/search-ui/src/input/SearchHistoryDropdown.tsx
+++ b/client/search-ui/src/input/SearchHistoryDropdown.tsx
@@ -11,7 +11,7 @@ import React, {
 import { mdiClockOutline } from '@mdi/js'
 import classNames from 'classnames'
 
-import { pluralize } from '@sourcegraph/common/out/src'
+import { pluralize } from '@sourcegraph/common'
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { RecentSearch } from '@sourcegraph/shared/src/settings/temporary/recentSearches'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -171,7 +171,9 @@ const SearchHistoryEntry: React.FunctionComponent<{
         <SyntaxHighlightedSearchQuery query={search.query} tabIndex={-1} />
         <span className="ml-1 text-nowrap text-muted">
             <span className="sr-only">,</span>
-            {search.resultCount !== undefined && <span>{`${search.resultCount} results`} • </span>}
+            {search.resultCount !== undefined && (
+                <span>{`${search.resultCount} ${pluralize('result', search.resultCount)}`} • </span>
+            )}
             <Timestamp date={search.timestamp} />
         </span>
     </li>

--- a/client/search-ui/src/input/SearchHistoryDropdown.tsx
+++ b/client/search-ui/src/input/SearchHistoryDropdown.tsx
@@ -43,9 +43,8 @@ interface SearchHistoryDropdownProps extends TelemetryProps {
 // button and the content
 const popoverPadding = createRectangle(0, 0, 0, 2)
 
-// eslint-disable-next-line react/display-name
 export const SearchHistoryDropdown: React.FunctionComponent<SearchHistoryDropdownProps> = React.memo(
-    ({ recentSearches = [], onSelect, className, telemetryService }) => {
+    function SearchHistoryDropdown({ recentSearches = [], onSelect, className, telemetryService }) {
         const [isOpen, setIsOpen] = useState(false)
 
         const handlePopoverToggle = useCallback(

--- a/client/search-ui/src/input/SearchHistoryDropdown.tsx
+++ b/client/search-ui/src/input/SearchHistoryDropdown.tsx
@@ -172,7 +172,9 @@ const SearchHistoryEntry: React.FunctionComponent<{
         <span className="ml-1 text-nowrap text-muted">
             <span className="sr-only">,</span>
             {search.resultCount !== undefined && (
-                <span>{`${search.resultCount} ${pluralize('result', search.resultCount)}`} • </span>
+                <span>
+                    {`${search.resultCount}${search.limitHit ? '+' : ''} ${pluralize('result', search.resultCount)}`} •{' '}
+                </span>
             )}
             <Timestamp date={search.timestamp} />
         </span>

--- a/client/search/src/helpers.ts
+++ b/client/search/src/helpers.ts
@@ -65,7 +65,6 @@ export interface SubmitSearchParameters
         | 'excludedResults'
         | 'smartSearchDisabled'
     searchMode?: SearchMode
-    addRecentSearch?: (query: string) => void
 }
 
 export interface SubmitSearchProps {

--- a/client/shared/src/settings/temporary/recentSearches.ts
+++ b/client/shared/src/settings/temporary/recentSearches.ts
@@ -1,4 +1,5 @@
 export interface RecentSearch {
     query: string
+    resultCount: number
     timestamp: string // IEEE 8601 timestamp
 }

--- a/client/shared/src/settings/temporary/recentSearches.ts
+++ b/client/shared/src/settings/temporary/recentSearches.ts
@@ -1,5 +1,6 @@
 export interface RecentSearch {
     query: string
     resultCount: number
+    limitHit: boolean
     timestamp: string // IEEE 8601 timestamp
 }

--- a/client/web/src/search/helpers.tsx
+++ b/client/web/src/search/helpers.tsx
@@ -39,7 +39,6 @@ export function submitSearch({
     selectedSearchContextSpec,
     searchMode,
     source,
-    addRecentSearch,
 }: SubmitSearchParameters): void {
     let searchQueryParameter = buildSearchURLQuery(
         query,
@@ -66,6 +65,5 @@ export function submitSearch({
         },
         { source }
     )
-    addRecentSearch?.(queryWithContext)
     history.push(path, { ...(typeof history.location.state === 'object' ? history.location.state : null), query })
 }

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -74,7 +74,7 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
     const applySuggestionsOnEnter =
         useExperimentalFeatures(features => features.applySearchQuerySuggestionOnEnter) ?? true
 
-    const { recentSearches, addRecentSearch } = useRecentSearches()
+    const { recentSearches } = useRecentSearches()
 
     const submitSearchOnChange = useCallback(
         (parameters: Partial<SubmitSearchParameters> = {}) => {
@@ -89,20 +89,11 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                     caseSensitive,
                     searchMode,
                     selectedSearchContextSpec: props.selectedSearchContextSpec,
-                    addRecentSearch,
                     ...parameters,
                 })
             }
         },
-        [
-            props.queryState.query,
-            props.selectedSearchContextSpec,
-            props.history,
-            addRecentSearch,
-            patternType,
-            caseSensitive,
-            searchMode,
-        ]
+        [props.queryState.query, props.selectedSearchContextSpec, props.history, patternType, caseSensitive, searchMode]
     )
 
     const onSubmit = useCallback(

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -70,7 +70,7 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
     const applySuggestionsOnEnter =
         useExperimentalFeatures(features => features.applySearchQuerySuggestionOnEnter) ?? true
 
-    const { recentSearches, addRecentSearch } = useRecentSearches()
+    const { recentSearches } = useRecentSearches()
 
     const submitSearchOnChange = useCallback(
         (parameters: Partial<SubmitSearchParameters> = {}) => {
@@ -78,11 +78,10 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
                 history: props.history,
                 source: 'nav',
                 selectedSearchContextSpec: props.selectedSearchContextSpec,
-                addRecentSearch,
                 ...parameters,
             })
         },
-        [submitSearch, props.history, props.selectedSearchContextSpec, addRecentSearch]
+        [submitSearch, props.history, props.selectedSearchContextSpec]
     )
 
     const onSubmit = useCallback(

--- a/client/web/src/search/input/useRecentSearches.test.tsx
+++ b/client/web/src/search/input/useRecentSearches.test.tsx
@@ -165,7 +165,7 @@ describe('recentSearches', () => {
             `)
         })
 
-        test('adding an existing item to recent searches de-duplicates it and puts it at the top', async () => {
+        test('adding an existing item to recent searches deduplicates it and puts it at the top', async () => {
             const { queryAllByRole, getByTestId } = render(
                 <Wrapper tempSettings={buildMockTempSettings(4)} eventLogs={buildMockEventLogs(0)} />
             )

--- a/client/web/src/search/input/useRecentSearches.test.tsx
+++ b/client/web/src/search/input/useRecentSearches.test.tsx
@@ -16,6 +16,7 @@ import { SEARCH_HISTORY_EVENT_LOGS_QUERY, useRecentSearches } from './useRecentS
 export function buildMockTempSettings(items: number): RecentSearch[] {
     return Array.from({ length: items }, (_item, index) => ({
         query: `test${index}`,
+        resultCount: 555,
         timestamp: '2021-01-01T00:00:00Z',
     }))
 }

--- a/client/web/src/search/input/useRecentSearches.test.tsx
+++ b/client/web/src/search/input/useRecentSearches.test.tsx
@@ -77,7 +77,7 @@ const InnerWrapper: React.FunctionComponent<{}> = () => {
                 value={searchToAdd}
                 onInput={event => setSearchToAdd(event.currentTarget.value)}
             />
-            <button type="button" data-testid="button" onClick={() => addRecentSearch(searchToAdd)} />
+            <button type="button" data-testid="button" onClick={() => addRecentSearch(searchToAdd, 555)} />
         </>
     )
 }
@@ -164,7 +164,7 @@ describe('recentSearches', () => {
             `)
         })
 
-        test('adding an exisitng item to recent searches deduplicates it and puts it at the top', async () => {
+        test('adding an existing item to recent searches de-duplicates it and puts it at the top', async () => {
             const { queryAllByRole, getByTestId } = render(
                 <Wrapper tempSettings={buildMockTempSettings(4)} eventLogs={buildMockEventLogs(0)} />
             )

--- a/client/web/src/search/input/useRecentSearches.test.tsx
+++ b/client/web/src/search/input/useRecentSearches.test.tsx
@@ -17,6 +17,7 @@ export function buildMockTempSettings(items: number): RecentSearch[] {
     return Array.from({ length: items }, (_item, index) => ({
         query: `test${index}`,
         resultCount: 555,
+        limitHit: false,
         timestamp: '2021-01-01T00:00:00Z',
     }))
 }
@@ -77,7 +78,7 @@ const InnerWrapper: React.FunctionComponent<{}> = () => {
                 value={searchToAdd}
                 onInput={event => setSearchToAdd(event.currentTarget.value)}
             />
-            <button type="button" data-testid="button" onClick={() => addRecentSearch(searchToAdd, 555)} />
+            <button type="button" data-testid="button" onClick={() => addRecentSearch(searchToAdd, 555, false)} />
         </>
     )
 }

--- a/client/web/src/search/input/useRecentSearches.ts
+++ b/client/web/src/search/input/useRecentSearches.ts
@@ -15,7 +15,7 @@ export const SEARCH_HISTORY_EVENT_LOGS_QUERY = gql`
     query SearchHistoryEventLogsQuery($first: Int!) {
         currentUser {
             __typename
-            recentSearchLogs: eventLogs(first: $first, eventName: "SearchResultsQueried") {
+            recentSearchLogs: eventLogs(first: $first, eventName: "SearchResultsFetched") {
                 nodes {
                     argument
                     timestamp
@@ -30,7 +30,7 @@ export const SEARCH_HISTORY_EVENT_LOGS_QUERY = gql`
 // the user's recent searches from the event log.
 export function useRecentSearches(): {
     recentSearches: RecentSearch[] | undefined
-    addRecentSearch: (query: string) => void
+    addRecentSearch: (query: string, resultCount: number) => void
     state: 'loading' | 'success'
 } {
     const [recentSearches, setRecentSearches] = useTemporarySetting('search.input.recentSearches', [])
@@ -98,10 +98,10 @@ export function useRecentSearches(): {
     // If the search is being added before the list is finished loading,
     // queue it to be added after loading is complete.
     const addRecentSearch = useCallback(
-        (query: string) => {
+        (query: string, resultCount: number) => {
             const searchContext = getGlobalSearchContextFilter(query)
             if (!searchContext || omitFilter(query, searchContext.filter).trim() !== '') {
-                const recentSearch = { query, timestamp: new Date().toISOString() }
+                const recentSearch = { query, resultCount, timestamp: new Date().toISOString() }
 
                 if (state === 'success') {
                     addOrMoveRecentSearchToTop(recentSearch)
@@ -132,12 +132,20 @@ function processEventLogs(data: SearchHistoryEventLogsQueryResult): RecentSearch
     }
     const searches = data.currentUser.recentSearchLogs.nodes
         .filter(node => node.argument && node.timestamp)
-        .map(node => ({
+        .map(node => {
             // This JSON.parse is safe, silence any TS linting warnings.
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-non-null-assertion
-            query: JSON.parse(node.argument!)?.code_search?.query_data?.combined,
-            timestamp: node.timestamp,
-        }))
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-non-null-assertion
+            const argument = JSON.parse(node.argument!)
+
+            return {
+                // Similarly, these are safe
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
+                query: argument?.code_search?.query_data?.combined,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
+                resultCount: argument?.code_search?.results?.results_count,
+                timestamp: node.timestamp,
+            }
+        })
         .filter(search => search.query)
         .filter(
             // Remove duplicates
@@ -145,6 +153,5 @@ function processEventLogs(data: SearchHistoryEventLogsQueryResult): RecentSearch
             // If a search appears earlier in the list, it is a duplicate.
             (search, index, self) => index === self.findIndex(item => item.query === search.query)
         )
-
     return searches
 }

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -190,7 +190,9 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
             if (results.results.length > 0) {
                 telemetryService.log('SearchResultsNonEmpty')
             }
-            addRecentSearch(submittedURLQuery, results.progress.matchCount)
+
+            // setTimeout avoids a "Cannot update a component while rendering a different component" React error
+            setTimeout(() => addRecentSearch(submittedURLQuery, results.progress.matchCount), 0)
         } else if (results?.state === 'error') {
             telemetryService.log('SearchResultsFetchFailed', {
                 code_search: { error_message: asError(results.error).message },

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -191,18 +191,22 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
             if (results.results.length > 0) {
                 telemetryService.log('SearchResultsNonEmpty')
             }
-
-            // setTimeout avoids a "Cannot update a component while rendering a different component" React error
-            setTimeout(
-                () => addRecentSearch(submittedURLQuery, results.progress.matchCount, limitHit(results.progress)),
-                0
-            )
         } else if (results?.state === 'error') {
             telemetryService.log('SearchResultsFetchFailed', {
                 code_search: { error_message: asError(results.error).message },
             })
         }
-    }, [addRecentSearch, results, submittedURLQuery, telemetryService])
+    }, [results, submittedURLQuery, telemetryService])
+
+    useEffect(() => {
+        if (results?.state === 'complete') {
+            // Add the recent search in the next queue execution to avoid updating a React component while rendering another component.
+            setTimeout(
+                () => addRecentSearch(submittedURLQuery, results.progress.matchCount, limitHit(results.progress)),
+                0
+            )
+        }
+    }, [addRecentSearch, results, submittedURLQuery])
 
     useEffect(() => {
         if (


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/43422

Changes:
 - Added the search query to the `SearchResultsFetched` event log item.
 - Getting the search history data from the `SearchResultsFetched` items rather than `SearchResultsQueried`
 - Calling `addRecentSearch` when fetching the results in `StreamingSearchResults` rather than in the search box.
 - Added `resultCount` and `limitHit` to the `RecentSearch` interface
 - Updated the UI to add the search count data

This is how it looks:

<img width="910" alt="New search history UI" src="https://user-images.githubusercontent.com/2552265/205889634-6eba779e-1740-41f8-819b-74b431033afd.png">

Collateral fix:
- The field `code_search.results.result_count` in the `SearchResultsFetched` event log item [contained the wrong value](https://github.com/sourcegraph/sourcegraph/pull/44898/files#diff-bcede140966fa65d87915c2ff40126d4a2f79ce28f3a689fb6a888026dec5840L179): it contained the number of results that arrived from the streaming search in the first response, which is often way less than the total number of results (18 instead of 500). This now contains the real number of results.

## Test plan

- Tested if the items are displayed correctly
- Tested if new items are being added after each search.
- Tested if legacy items (not containing the two new fields) work correctly.
- Tested it with a screen reader: **it's not accessible:** the screen reader only says "list containing 20 items" but doesn't read the selected items. However, this was a pre-existing condition to my change, so this is a wontfix for this PR.

## App preview:

- [Web](https://sg-web-dv-add-result-count-to-search.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

