### PR TITLE
batches: implement URL field for mounted files

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -14,6 +15,7 @@ import (
 )
 
 const workspaceFileIDKind = "BatchSpecWorkspaceFile"
+const workspaceFileURLKind = "URLBatchSpecWorkspaceFile"
 
 func marshalWorkspaceFileRandID(id string) graphql.ID {
 	return relay.MarshalID(workspaceFileIDKind, id)
@@ -21,6 +23,15 @@ func marshalWorkspaceFileRandID(id string) graphql.ID {
 
 func unmarshalWorkspaceFileRandID(id graphql.ID) (batchWorkspaceFileRandID string, err error) {
 	err = relay.UnmarshalSpec(id, &batchWorkspaceFileRandID)
+	return
+}
+
+func marshalWorkspaceFileURL(id string) graphql.ID {
+	return relay.MarshalID(workspaceFileURLKind, id)
+}
+
+func unmarshalWorkspaceFileURL(id graphql.ID) (batchWorkspaceFileURL string, err error) {
+	err = relay.UnmarshalSpec(id, &batchWorkspaceFileURL)
 	return
 }
 
@@ -101,7 +112,9 @@ func (r *batchSpecWorkspaceFileResolver) RichHTML(ctx context.Context) (string, 
 }
 
 func (r *batchSpecWorkspaceFileResolver) URL(ctx context.Context) (string, error) {
-	return "", errors.New("not implemented")
+	var u = fmt.Sprintf("%s-%s", r.file.RandID, r.batchSpecRandID)
+	url := marshalWorkspaceFileURL(u)
+	return string(url), nil
 }
 
 func (r *batchSpecWorkspaceFileResolver) CanonicalURL() string {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file.go
@@ -15,7 +15,6 @@ import (
 )
 
 const workspaceFileIDKind = "BatchSpecWorkspaceFile"
-const workspaceFileURLKind = "URLBatchSpecWorkspaceFile"
 
 func marshalWorkspaceFileRandID(id string) graphql.ID {
 	return relay.MarshalID(workspaceFileIDKind, id)
@@ -23,15 +22,6 @@ func marshalWorkspaceFileRandID(id string) graphql.ID {
 
 func unmarshalWorkspaceFileRandID(id graphql.ID) (batchWorkspaceFileRandID string, err error) {
 	err = relay.UnmarshalSpec(id, &batchWorkspaceFileRandID)
-	return
-}
-
-func marshalWorkspaceFileURL(id string) graphql.ID {
-	return relay.MarshalID(workspaceFileURLKind, id)
-}
-
-func unmarshalWorkspaceFileURL(id graphql.ID) (batchWorkspaceFileURL string, err error) {
-	err = relay.UnmarshalSpec(id, &batchWorkspaceFileURL)
 	return
 }
 
@@ -112,9 +102,7 @@ func (r *batchSpecWorkspaceFileResolver) RichHTML(ctx context.Context) (string, 
 }
 
 func (r *batchSpecWorkspaceFileResolver) URL(ctx context.Context) (string, error) {
-	var u = fmt.Sprintf("/files/batch-changes/%s/%s", r.file.RandID, r.batchSpecRandID)
-	url := marshalWorkspaceFileURL(u)
-	return string(url), nil
+	return fmt.Sprintf("/files/batch-changes/%s/%s", r.file.RandID, r.batchSpecRandID), nil
 }
 
 func (r *batchSpecWorkspaceFileResolver) CanonicalURL() string {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file.go
@@ -112,7 +112,7 @@ func (r *batchSpecWorkspaceFileResolver) RichHTML(ctx context.Context) (string, 
 }
 
 func (r *batchSpecWorkspaceFileResolver) URL(ctx context.Context) (string, error) {
-	var u = fmt.Sprintf("%s-%s", r.file.RandID, r.batchSpecRandID)
+	var u = fmt.Sprintf("/files/batch-changes/%s/%s", r.file.RandID, r.batchSpecRandID)
 	url := marshalWorkspaceFileURL(u)
 	return string(url), nil
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file_test.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -182,8 +183,7 @@ func TestBatchSpecWorkspaceFileResolver(t *testing.T) {
 				getActual: func() (interface{}, error) {
 					return resolver.URL(context.Background())
 				},
-				expected:    "",
-				expectedErr: errors.New("not implemented"),
+				expected: fmt.Sprintf("/files/batch-changes/%s/%s", file.RandID, batchSpecRandID),
 			},
 			{
 				name: "CanonicalURL",
@@ -328,8 +328,7 @@ func TestBatchSpecWorkspaceFileResolver(t *testing.T) {
 				getActual: func() (interface{}, error) {
 					return resolver.URL(context.Background())
 				},
-				expected:    "",
-				expectedErr: errors.New("not implemented"),
+				expected: fmt.Sprintf("/files/batch-changes/%s/%s", file.RandID, batchSpecRandID),
 			},
 			{
 				name: "CanonicalURL",


### PR DESCRIPTION
Closes: #44179

With both mounted files and executors using the `getPathParts` method, this method accepts two different types of IDs. 

unmarrshalled random IDs (sent via the executor)
marshalled random IDs (sent via the UI)

We can use a URL field to create URLs for batch spec workspace files and eventually change `getPathParts` to only need to accept these URLs.

Proposing to construct this URL using the file random ID and the batch spec random ID

## Test plan
no testing, just implementing a field
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
