### PR TITLE
search: fix human string representation for metachars in query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - The Code Insights commit indexer no longer errors when fetching commits from empty repositories when sub-repo permissions are enabled. [#44558](https://github.com/sourcegraph/sourcegraph/pull/44558)
 - Unintended newline characters that could appear in diff view rendering have been fixed. [#44805](https://github.com/sourcegraph/sourcegraph/pull/44805)
+- An issue causing certain kinds of queries to behave inconsistently in Code Insights. [#44917](https://github.com/sourcegraph/sourcegraph/pull/44917)
 
 ### Removed
 

--- a/internal/search/query/printer.go
+++ b/internal/search/query/printer.go
@@ -19,7 +19,12 @@ func stringHumanPattern(nodes []Node) string {
 			if n.Annotation.Labels.IsSet(Regexp) {
 				v = fmt.Sprintf("/%s/", v)
 			}
-			if n.Annotation.Labels.IsSet(IsAlias) {
+			if _, _, ok := ScanBalancedPattern([]byte(v)); !ok && !n.Annotation.Labels.IsSet(IsAlias) && n.Annotation.Labels.IsSet(Literal) {
+				v = fmt.Sprintf(`content:%s`, strconv.Quote(v))
+				if n.Negated {
+					v = "-" + v
+				}
+			} else if n.Annotation.Labels.IsSet(IsAlias) {
 				v = fmt.Sprintf("content:%s", v)
 				if n.Negated {
 					v = "-" + v

--- a/internal/search/query/printer_test.go
+++ b/internal/search/query/printer_test.go
@@ -26,6 +26,7 @@ func TestStringHuman(t *testing.T) {
 		"-repo:modspeed -file:pogspeed Arizonan not Phoenicians",
 		"r:alias",
 		`/bo/u\gros/`,
+		`filePath.Clean( AND NOT filepath.Clean(filePath.Join("/",`,
 	}
 
 	test := func(input string) string {

--- a/internal/search/query/testdata/TestStringHuman/printer#17.golden
+++ b/internal/search/query/testdata/TestStringHuman/printer#17.golden
@@ -1,0 +1,4 @@
+{
+  "Input": "filePath.Clean( AND NOT filepath.Clean(filePath.Join(\"/\",",
+  "Result": "(content:\"filePath.Clean(\" AND -content:\"filepath.Clean(filePath.Join(\\\"/\\\",\")"
+}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/44738

A query containing special chars `(`, `)` that are unbalanced needs to be quoted/escaped when generating a human representation, because these characters can break the meaning of a well-formed query with expressions.

See also https://sourcegraph.slack.com/archives/C014ZCKMCAV/p1669114578350879

## Test plan
Added test
