### PR TITLE
Set name/email cookie for Cloud Trial prefill

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -197,7 +197,7 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
     }
         
     useEffect(() => {
-        if (props.authenticatedUser && !document.cookie.includes('displayName=' || 'email=')) {
+        if (props.isSourcegraphDotCom && props.authenticatedUser && !document.cookie.includes('displayName=' || 'email=')) {
             document.cookie = `displayName=${props.authenticatedUser.displayName || ''}`
             document.cookie = `email=${props.authenticatedUser.email}`
         }

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -190,9 +190,11 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
             props.authenticatedUser &&
             !document.cookie.includes('displayName=' || 'email=')
         ) {
-            const tomorrow = (new Date(Date.now()+ 86400*1000)).toUTCString()
+            const tomorrow = new Date(Date.now() + 86400 * 1000).toUTCString()
             // eslint-disable-next-line unicorn/no-document-cookie
-            document.cookie = `displayName=${props.authenticatedUser.displayName || ''}; expires=${tomorrow}; domain=.sourcegraph.com`
+            document.cookie = `displayName=${
+                props.authenticatedUser.displayName || ''
+            }; expires=${tomorrow}; domain=.sourcegraph.com`
             // eslint-disable-next-line unicorn/no-document-cookie
             document.cookie = `email=${props.authenticatedUser.email}; expires=${tomorrow}; domain=.sourcegraph.com`
         } else {

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -196,19 +196,18 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
         isMacPlatform: isMacPlatform(),
     }
 
-    const setCookie = () => {
+    useEffect(() => {
         if (
             props.isSourcegraphDotCom &&
             props.authenticatedUser &&
             !document.cookie.includes('displayName=' || 'email=')
         ) {
+            // eslint-disable-next-line unicorn/no-document-cookie
             document.cookie = `displayName=${props.authenticatedUser.displayName || ''}`
             document.cookie = `email=${props.authenticatedUser.email}`
+        } else {
+            null
         }
-    }
-
-    useEffect(() => {
-        setCookie()
     }, [props.authenticatedUser, props.isSourcegraphDotCom])
 
     return (

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -195,7 +195,7 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
         ...breadcrumbProps,
         isMacPlatform: isMacPlatform(),
     }
-    
+
     const setCookie = () => {
         if (
             props.isSourcegraphDotCom &&

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -195,9 +195,13 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
         ...breadcrumbProps,
         isMacPlatform: isMacPlatform(),
     }
-        
+
     useEffect(() => {
-        if (props.isSourcegraphDotCom && props.authenticatedUser && !document.cookie.includes('displayName=' || 'email=')) {
+        if (
+            props.isSourcegraphDotCom &&
+            props.authenticatedUser &&
+            !document.cookie.includes('displayName=' || 'email=')
+        ) {
             document.cookie = `displayName=${props.authenticatedUser.displayName || ''}`
             document.cookie = `email=${props.authenticatedUser.email}`
         }

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -183,7 +183,7 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
     // const afterTosAccepted = useCallback(() => {
     //     setTosAccepted(true)
     // }, [])
-    
+
     useEffect(() => {
         if (
             props.isSourcegraphDotCom &&

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -190,10 +190,11 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
             props.authenticatedUser &&
             !document.cookie.includes('displayName=' || 'email=')
         ) {
+            const tomorrow = (new Date(Date.now()+ 86400*1000)).toUTCString()
             // eslint-disable-next-line unicorn/no-document-cookie
-            document.cookie = `displayName=${props.authenticatedUser.displayName || ''}`
+            document.cookie = `displayName=${props.authenticatedUser.displayName || ''}; expires=${tomorrow}; domain=.sourcegraph.com`
             // eslint-disable-next-line unicorn/no-document-cookie
-            document.cookie = `email=${props.authenticatedUser.email}`
+            document.cookie = `email=${props.authenticatedUser.email}; expires=${tomorrow}; domain=.sourcegraph.com`
         } else {
             return
         }

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -195,8 +195,8 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
         ...breadcrumbProps,
         isMacPlatform: isMacPlatform(),
     }
-
-    useEffect(() => {
+    
+    const setCookie = () => {
         if (
             props.isSourcegraphDotCom &&
             props.authenticatedUser &&
@@ -205,7 +205,11 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
             document.cookie = `displayName=${props.authenticatedUser.displayName || ''}`
             document.cookie = `email=${props.authenticatedUser.email}`
         }
-    }, [])
+    }
+
+    useEffect(() => {
+        setCookie()
+    }, [props.authenticatedUser, props.isSourcegraphDotCom])
 
     return (
         <div

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useCallback, useRef, useState } from 'react'
+import React, { Suspense, useCallback, useRef, useState, useEffect } from 'react'
 
 import classNames from 'classnames'
 import { matchPath, Redirect, Route, RouteComponentProps, Switch } from 'react-router'
@@ -195,6 +195,13 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
         ...breadcrumbProps,
         isMacPlatform: isMacPlatform(),
     }
+        
+    useEffect(() => {
+        if (props.authenticatedUser && !document.cookie.includes('displayName=' || 'email=')) {
+            document.cookie = `displayName=${props.authenticatedUser.displayName || ''}`
+            document.cookie = `email=${props.authenticatedUser.email}`
+        }
+    }, [])
 
     return (
         <div

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useCallback, useRef, useState, useEffect } from 'react'
+import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react'
 
 import classNames from 'classnames'
 import { matchPath, Redirect, Route, RouteComponentProps, Switch } from 'react-router'
@@ -183,19 +183,7 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
     // const afterTosAccepted = useCallback(() => {
     //     setTosAccepted(true)
     // }, [])
-
-    // Remove trailing slash (which is never valid in any of our URLs).
-    if (props.location.pathname !== '/' && props.location.pathname.endsWith('/')) {
-        return <Redirect to={{ ...props.location, pathname: props.location.pathname.slice(0, -1) }} />
-    }
-
-    const context: LayoutRouteComponentProps<any> = {
-        ...props,
-        ...themeProps,
-        ...breadcrumbProps,
-        isMacPlatform: isMacPlatform(),
-    }
-
+    
     useEffect(() => {
         if (
             props.isSourcegraphDotCom &&
@@ -210,6 +198,18 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
             return
         }
     }, [props.authenticatedUser, props.isSourcegraphDotCom])
+
+    // Remove trailing slash (which is never valid in any of our URLs).
+    if (props.location.pathname !== '/' && props.location.pathname.endsWith('/')) {
+        return <Redirect to={{ ...props.location, pathname: props.location.pathname.slice(0, -1) }} />
+    }
+
+    const context: LayoutRouteComponentProps<any> = {
+        ...props,
+        ...themeProps,
+        ...breadcrumbProps,
+        isMacPlatform: isMacPlatform(),
+    }
 
     return (
         <div

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -197,8 +197,6 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
             }; expires=${tomorrow}; domain=.sourcegraph.com`
             // eslint-disable-next-line unicorn/no-document-cookie
             document.cookie = `email=${props.authenticatedUser.email}; expires=${tomorrow}; domain=.sourcegraph.com`
-        } else {
-            return
         }
     }, [props.authenticatedUser, props.isSourcegraphDotCom])
 

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -204,9 +204,10 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
         ) {
             // eslint-disable-next-line unicorn/no-document-cookie
             document.cookie = `displayName=${props.authenticatedUser.displayName || ''}`
+            // eslint-disable-next-line unicorn/no-document-cookie
             document.cookie = `email=${props.authenticatedUser.email}`
         } else {
-            null
+            return
         }
     }, [props.authenticatedUser, props.isSourcegraphDotCom])
 


### PR DESCRIPTION
Closes #44630, partner PR to [sourcegraph/console/#165](https://github.com/sourcegraph/console/pull/165)

[ Sourcegraph Cloud Trial use case example ]
![image](https://user-images.githubusercontent.com/59381432/204660055-83678610-0dda-478e-96e3-ed66b7809195.png)

## Changelog
- Adds a cookie for `displayName` and `email` for logged in dotcom users. (This is so that we can prefill the [Cloud Trial form](https://signup.sourcegraph.com/) to enhance the offer value & UX).

## Test plan
- This needs to be tested after merged to main, to ensure new cookie values persists across subdomains => singup.sourcegraph.com

## App preview:

- [Web](https://sg-web-becca-set-auth-cookies-for-cloud.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

