### PR TITLE
SyncExternalService fails fast if code host does not seem available

### DIFF
--- a/internal/repos/awscodecommit.go
+++ b/internal/repos/awscodecommit.go
@@ -112,6 +112,13 @@ func newAWSCodeCommitSource(svc *types.ExternalService, c *schema.AWSCodeCommitC
 	return s, nil
 }
 
+// IsAvailable at this point assumes availability and relies on errors returned
+// from the subsequent calls. This is going to be expanded as part of issue #44683
+// to actually only return true if the source can serve requests.
+func (s *AWSCodeCommitSource) IsAvailable(ctx context.Context) bool {
+	return true
+}
+
 // ListRepos returns all AWS Code Commit repositories accessible to all
 // connections configured in Sourcegraph via the external services
 // configuration.

--- a/internal/repos/bitbucketcloud.go
+++ b/internal/repos/bitbucketcloud.go
@@ -80,6 +80,13 @@ func newBitbucketCloudSource(logger log.Logger, svc *types.ExternalService, c *s
 	}, nil
 }
 
+// IsAvailable at this point assumes availability and relies on errors returned
+// from the subsequent calls. This is going to be expanded as part of issue #44683
+// to actually only return true if the source can serve requests.
+func (s BitbucketCloudSource) IsAvailable(ctx context.Context) bool {
+	return true
+}
+
 // ListRepos returns all Bitbucket Cloud repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
 func (s BitbucketCloudSource) ListRepos(ctx context.Context, results chan SourceResult) {

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -89,6 +89,13 @@ func newBitbucketServerSource(logger log.Logger, svc *types.ExternalService, c *
 	}, nil
 }
 
+// IsAvailable at this point assumes availability and relies on errors returned
+// from the subsequent calls. This is going to be expanded as part of issue #44683
+// to actually only return true if the source can serve requests.
+func (s BitbucketServerSource) IsAvailable(ctx context.Context) bool {
+	return true
+}
+
 // ListRepos returns all BitbucketServer repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
 func (s BitbucketServerSource) ListRepos(ctx context.Context, results chan SourceResult) {

--- a/internal/repos/gerrit.go
+++ b/internal/repos/gerrit.go
@@ -59,6 +59,13 @@ func NewGerritSource(ctx context.Context, svc *types.ExternalService, cf *httpcl
 	}, nil
 }
 
+// IsAvailable at this point assumes availability and relies on errors returned
+// from the subsequent calls. This is going to be expanded as part of issue #44683
+// to actually only return true if the source can serve requests.
+func (s *GerritSource) IsAvailable(ctx context.Context) bool {
+	return true
+}
+
 // ListRepos returns all Gerrit repositories configured with this GerritSource's config.
 func (s *GerritSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	args := gerrit.ListProjectsArgs{

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -283,6 +283,13 @@ func (s *GitHubSource) Version(ctx context.Context) (string, error) {
 	return s.v3Client.GetVersion(ctx)
 }
 
+// IsAvailable at this point assumes availability and relies on errors returned
+// from the subsequent calls. This is going to be expanded as part of issue #44683
+// to actually only return true if the source can serve requests.
+func (s *GitHubSource) IsAvailable(ctx context.Context) bool {
+	return true
+}
+
 // ListRepos returns all Github repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
 func (s *GitHubSource) ListRepos(ctx context.Context, results chan SourceResult) {

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -162,6 +162,13 @@ func (s GitLabSource) ValidateAuthenticator(ctx context.Context) error {
 	return s.client.ValidateToken(ctx)
 }
 
+// IsAvailable at this point assumes availability and relies on errors returned
+// from the subsequent calls. This is going to be expanded as part of issue #44683
+// to actually only return true if the source can serve requests.
+func (s GitLabSource) IsAvailable(ctx context.Context) bool {
+	return true
+}
+
 // ListRepos returns all GitLab repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
 func (s GitLabSource) ListRepos(ctx context.Context, results chan SourceResult) {

--- a/internal/repos/gitolite.go
+++ b/internal/repos/gitolite.go
@@ -70,6 +70,13 @@ func NewGitoliteSource(ctx context.Context, svc *types.ExternalService, cf *http
 	}, nil
 }
 
+// IsAvailable at this point assumes availability and relies on errors returned
+// from the subsequent calls. This is going to be expanded as part of issue #44683
+// to actually only return true if the source can serve requests.
+func (s *GitoliteSource) IsAvailable(ctx context.Context) bool {
+	return true
+}
+
 // ListRepos returns all Gitolite repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
 func (s *GitoliteSource) ListRepos(ctx context.Context, results chan SourceResult) {

--- a/internal/repos/other.go
+++ b/internal/repos/other.go
@@ -7,8 +7,10 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -58,6 +60,15 @@ func NewOtherSource(ctx context.Context, svc *types.ExternalService, cf *httpcli
 	}
 
 	return &OtherSource{svc: svc, conn: &c, client: cli, logger: logger}, nil
+}
+
+var defaultPing time.Duration = time.Second * 10
+
+// IsAvailable at this point assumes availability and relies on errors returned
+// from the subsequent calls. This is going to be expanded as part of issue #44683
+// to actually only return true if the source can serve requests.
+func (s OtherSource) IsAvailable(ctx context.Context) bool {
+	return true
 }
 
 // ListRepos returns all Other repositories accessible to all connections configured

--- a/internal/repos/packages.go
+++ b/internal/repos/packages.go
@@ -46,6 +46,13 @@ type packagesDownloadSource interface {
 
 var _ Source = &PackagesSource{}
 
+// IsAvailable at this point assumes availability and relies on errors returned
+// from the subsequent calls. This is going to be expanded as part of issue #44683
+// to actually only return true if the source can serve requests.
+func (s *PackagesSource) IsAvailable(ctx context.Context) bool {
+	return true
+}
+
 func (s *PackagesSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	deps, err := s.configDependencies(s.configDeps)
 	if err != nil {

--- a/internal/repos/pagure.go
+++ b/internal/repos/pagure.go
@@ -59,6 +59,13 @@ func NewPagureSource(ctx context.Context, svc *types.ExternalService, cf *httpcl
 	}, nil
 }
 
+// IsAvailable at this point assumes availability and relies on errors returned
+// from the subsequent calls. This is going to be expanded as part of issue #44683
+// to actually only return true if the source can serve requests.
+func (s *PagureSource) IsAvailable(ctx context.Context) bool {
+	return true
+}
+
 // ListRepos returns all Pagure repositories configured with this PagureSource's config.
 func (s *PagureSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	args := pagure.ListProjectsArgs{

--- a/internal/repos/perforce.go
+++ b/internal/repos/perforce.go
@@ -43,6 +43,13 @@ func newPerforceSource(svc *types.ExternalService, c *schema.PerforceConnection)
 	}, nil
 }
 
+// IsAvailable at this point assumes availability and relies on errors returned
+// from the subsequent calls. This is going to be expanded as part of issue #44683
+// to actually only return true if the source can serve requests.
+func (s PerforceSource) IsAvailable(ctx context.Context) bool {
+	return true
+}
+
 // ListRepos returns all Perforce depots accessible to all connections
 // configured in Sourcegraph via the external services configuration.
 func (s PerforceSource) ListRepos(ctx context.Context, results chan SourceResult) {

--- a/internal/repos/phabricator.go
+++ b/internal/repos/phabricator.go
@@ -45,6 +45,13 @@ func NewPhabricatorSource(ctx context.Context, logger log.Logger, svc *types.Ext
 	return &PhabricatorSource{logger: logger, svc: svc, conn: &c, cf: cf}, nil
 }
 
+// IsAvailable at this point assumes availability and relies on errors returned
+// from the subsequent calls. This is going to be expanded as part of issue #44683
+// to actually only return true if the source can serve requests.
+func (s *PhabricatorSource) IsAvailable(ctx context.Context) bool {
+	return true
+}
+
 // ListRepos returns all Phabricator repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
 func (s *PhabricatorSource) ListRepos(ctx context.Context, results chan SourceResult) {

--- a/internal/repos/sources.go
+++ b/internal/repos/sources.go
@@ -91,6 +91,9 @@ type Source interface {
 	// ListRepos sends all the repos a source yields over the passed in channel
 	// as SourceResults
 	ListRepos(context.Context, chan SourceResult)
+	// IsAvailable returns true if there is evidence that the Source can
+	// be reached and serve requests.
+	IsAvailable(context.Context) bool
 	// ExternalServices returns the ExternalServices for the Source.
 	ExternalServices() types.ExternalServices
 }

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -559,6 +559,10 @@ func (s *Syncer) SyncExternalService(
 		return err
 	}
 
+	if !src.IsAvailable(ctx) {
+		return errors.New("code host does not seem to be available")
+	}
+
 	results := make(chan SourceResult)
 	go func() {
 		src.ListRepos(ctx, results)

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -611,6 +611,16 @@ func TestSyncerSync(t *testing.T) {
 				svcs: []*types.ExternalService{tc.svc},
 				err:  "<nil>",
 			},
+			testCase{
+				name: string(tc.repo.Name) + "/code host unavailable",
+				sourcer: repos.NewFakeSourcer(nil,
+					repos.NewFakeSource(nil, nil, nil).Unavailable(),
+				),
+				store: store,
+				now: clock.Now,
+				svcs: []*types.ExternalService{tc.svc},
+				err:  "does not seem to be available",
+			},
 		)
 	}
 

--- a/internal/repos/testing.go
+++ b/internal/repos/testing.go
@@ -22,9 +22,10 @@ func NewFakeSourcer(err error, src Source) Sourcer {
 
 // FakeSource is a fake implementation of Source to be used in tests.
 type FakeSource struct {
-	svc   *types.ExternalService
-	repos []*types.Repo
-	err   error
+	svc         *types.ExternalService
+	repos       []*types.Repo
+	err         error
+	unavailable bool
 
 	// ListRepos will send on this channel if it's not nil and wait on the channel
 	// again before quitting. This can help with testing certain concurrent situation
@@ -42,6 +43,15 @@ func NewFakeSource(svc *types.ExternalService, err error, rs ...*types.Repo) *Fa
 func (s *FakeSource) InitLockChan() chan struct{} {
 	s.lockChan = make(chan struct{})
 	return s.lockChan
+}
+
+func (s *FakeSource) Unavailable() *FakeSource {
+	s.unavailable = true
+	return s
+}
+
+func (s *FakeSource) IsAvailable(ctx context.Context) bool {
+	return !s.unavailable
 }
 
 // ListRepos returns the Repos that FakeSource was instantiated with


### PR DESCRIPTION
This pull request introduces the availability surfacing method to `Source` and invokes it within `SyncExternalService` to allow better error messaging in case of unavailable code host.

Subsequent pull requests will introduce actual availability checks for different code hosts.

## Test plan

Extend existing syncer unit tests.
