### PR TITLE
monitoring: fix multi-instance generator

### DIFF
--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -340,6 +340,13 @@ func renderMultiInstanceDashboard(dashboards []*Dashboard, groupings []string) (
 	board := sdk.NewBoard("Multi-instance overviews")
 	board.AddTags("builtin")
 
+	board.Timezone = "utc"
+	board.Timepicker.RefreshIntervals = []string{"5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"}
+	board.Time.From = "now-6h"
+	board.Time.To = "now"
+	board.SharedCrosshair = true
+	board.Editable = false
+
 	// TODO generate variables
 	// board.Templating.List = append(board.Templating.List, grafanasdk.TemplateVar{
 	// 	Name: "instance", // or project, or use grouping
@@ -359,6 +366,7 @@ func renderMultiInstanceDashboard(dashboards []*Dashboard, groupings []string) (
 					// do it once per dashboard
 					addDashboardRow.Do(func() {
 						row = board.AddRow(d.Title)
+						row.ShowTitle = true
 					})
 
 					// TODO make this size correctly in this context and output a valid


### PR DESCRIPTION
Correctly render the dashboards and the row headers for multi-instance dashboards.

# Test Plan

Start a local grafana instance:
```
sg run grafana
```
Generate the dashboards locally:
```
go run ./dev/sg monitoring generate -multi-instance-groupings=project_id
```

And then inspect `docker-images/grafana/config/provisioning/dashboards/sourcegraph/multi-instance-dashboard.json`. Copy the JSON and import it at the local grafana at`http://localhost:3370`. It should import correctly and not raise errors.

<img width="770" alt="Screen Shot 2022-11-29 at 17 23 31" src="https://user-images.githubusercontent.com/8784265/204684540-7f436b60-4f9b-4466-86d7-9a389626440d.png">
