### PR TITLE
Code Insights: Fix insight card UI for compute insight (bar chart) layout

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-alerts/BackendInsightAlerts.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-alerts/BackendInsightAlerts.module.scss
@@ -1,5 +1,8 @@
 .alert-container {
-    position: relative;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
 
     :global(.theme-dark) & {
         background: linear-gradient(180deg, rgba(25, 27, 37, 0.6) 0%, #191b25 51.56%, rgba(25, 27, 37, 0.6) 100%);
@@ -8,18 +11,6 @@
     :global(.theme-light) & {
         background: linear-gradient(180deg, rgba(255, 255, 255, 0.7) 0%, #ffffff 51.04%, rgba(255, 255, 255, 0.8) 100%);
     }
-}
-
-.alert-content {
-    position: absolute;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
 }
 
 .icon {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-alerts/BackendInsightAlerts.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-alerts/BackendInsightAlerts.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { FC } from 'react'
 
 import classNames from 'classnames'
 import ProgressWrench from 'mdi-react/ProgressWrenchIcon'
@@ -17,9 +17,7 @@ interface BackendAlertOverLayProps {
     className?: string
 }
 
-export const BackendAlertOverlay: React.FunctionComponent<
-    React.PropsWithChildren<BackendAlertOverLayProps>
-> = props => {
+export const BackendAlertOverlay: FC<BackendAlertOverLayProps> = props => {
     const { isFetchingHistoricalData, hasNoData, className } = props
 
     if (isFetchingHistoricalData) {
@@ -58,11 +56,9 @@ const AlertOverlay: React.FunctionComponent<React.PropsWithChildren<AlertOverlay
 
     return (
         <div className={classNames(className, styles.alertContainer)}>
-            <div className={styles.alertContent}>
-                {icon && <div className={styles.icon}>{icon}</div>}
-                <H4 className={styles.title}>{title}</H4>
-                <small className={styles.description}>{description}</small>
-            </div>
+            {icon && <div className={styles.icon}>{icon}</div>}
+            <H4 className={styles.title}>{title}</H4>
+            <small className={styles.description}>{description}</small>
         </div>
     )
 }
@@ -71,9 +67,7 @@ interface BackendInsightErrorAlertProps {
     error: ErrorLike
 }
 
-export const BackendInsightErrorAlert: React.FunctionComponent<
-    React.PropsWithChildren<BackendInsightErrorAlertProps>
-> = props =>
+export const BackendInsightErrorAlert: FC<BackendInsightErrorAlertProps> = props =>
     props.error instanceof InsightInProcessError ? (
         <Alert variant="info">{props.error.message}</Alert>
     ) : (

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.module.scss
@@ -3,7 +3,7 @@
     min-height: 0;
     position: relative;
     display: grid;
-    gap: 0.75rem;
+    grid-template-areas: 'chart';
 
     // Hack for generating a proper scoped css nested class
     // see https://css-tricks.com/using-sass-control-scope-bem-naming/
@@ -14,6 +14,7 @@
         grid-template-areas:
             'chart'
             'legend';
+        gap: 0.75rem;
 
         // Chart section can grow and take all space if we don't have any legends
         // Legends section can grow until the chart section is bigger than 12rem.


### PR DESCRIPTION
## Context
This PR fixes insight card layout for the case when we have just one chart block without legend block. Prior to this PR card with just one chart block had a slightly shifted layout (because of the grid gap CSS rule, this rule forces the chart block to have small size measurements errors during first render, which produced strange enter animation see the video below). 

| Before | After |
| -------- | -------- |
| <video src="https://user-images.githubusercontent.com/18492575/204687807-21385eb7-1e72-4045-a2cf-ed7ad3a652ef.mov" /> | <video src="https://user-images.githubusercontent.com/18492575/204687814-a478a1b4-2603-48b5-8924-12e29aa3f735.mov" /> |

 
## Test plan
- Make sure that chart grid card layout looks as expected on the dashboard page

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-bar-chart-insight-card.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
