### PR TITLE
monitoring: add template vars to multi-instance dashboards

### DIFF
--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -345,7 +345,7 @@ func renderMultiInstanceDashboard(dashboards []*Dashboard, groupings []string) (
 	board.Time.From = "now-6h"
 	board.Time.To = "now"
 	board.SharedCrosshair = true
-	// board.Editable = false
+	board.Editable = false
 
 	var variableMatchers []*labels.Matcher
 	for _, g := range groupings {

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -345,12 +345,34 @@ func renderMultiInstanceDashboard(dashboards []*Dashboard, groupings []string) (
 	board.Time.From = "now-6h"
 	board.Time.To = "now"
 	board.SharedCrosshair = true
-	board.Editable = false
+	// board.Editable = false
 
-	// TODO generate variables
-	// board.Templating.List = append(board.Templating.List, grafanasdk.TemplateVar{
-	// 	Name: "instance", // or project, or use grouping
-	// })
+	var variableMatchers []*labels.Matcher
+	for _, g := range groupings {
+		containerVar := ContainerVariable{
+			Name:  g,
+			Label: g,
+			OptionsLabelValues: ContainerVariableOptionsLabelValues{
+				// For now we don't support any labels that aren't present on this metric.
+				Query:     "src_service_metadata",
+				LabelName: g,
+			},
+			WildcardAllValue: true,
+			Multi:            true,
+		}
+		grafanaVar, err := containerVar.toGrafanaTemplateVar(nil)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to generate template var for grouping %q", g)
+		}
+		board.Templating.List = append(board.Templating.List, grafanaVar)
+
+		// generate the matcher to inject
+		m, err := labels.NewMatcher(labels.MatchRegexp, g, fmt.Sprintf("${%s:regex}", g))
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to generate template var matcher for grouping %q", g)
+		}
+		variableMatchers = append(variableMatchers, m)
+	}
 
 	for _, d := range dashboards {
 		var row *sdk.Row
@@ -372,9 +394,8 @@ func renderMultiInstanceDashboard(dashboards []*Dashboard, groupings []string) (
 					// TODO make this size correctly in this context and output a valid
 					// dashboard, right now it isn't quite right
 					panel, err := o.renderPanel(d, panelManipulationOptions{
-						injectGroupings: groupings,
-						// TODO inject variables
-						// injectLabelMatchers: []*labels.Matcher{},
+						injectGroupings:     groupings,
+						injectLabelMatchers: variableMatchers,
 					}, nil)
 					if err != nil {
 						return nil, errors.Wrapf(err, "render panel for %q", o.Name)

--- a/monitoring/monitoring/variables.go
+++ b/monitoring/monitoring/variables.go
@@ -133,6 +133,7 @@ func (c *ContainerVariable) toGrafanaTemplateVar(injectLabelMatchers []*labels.M
 			Value: Int64Ptr(2), // Refresh on time range change
 		}
 		variable.Sort = 3
+		variable.Options = []sdk.Option{} // Cannot be null in later versions of Grafana
 
 	case len(c.Options.Options) > 0:
 		// Set the type


### PR DESCRIPTION
When using `-multi-instance-groupings`, generate template variables corresponding to each grouping label with options that reflect all possible values for that label on the "stub" metric `src_service_metadata`. This allows us to select which instances to view metrics for on multi-instance dashboards with `-multi-instance-groupings=project_id`.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
go run ./dev/sg monitoring generate -multi-instance-groupings=project_id
```

then copy `docker-images/grafana/config/provisioning/dashboards/sourcegraph/multi-instance-dashboard.json` into monitoring.sgdev.org

Show all:

<img width="281" alt="image" src="https://user-images.githubusercontent.com/23356519/204688749-bcda3c4c-f49a-4948-8659-c24279f62cb1.png">

Select a single instance:

<img width="1351" alt="image" src="https://user-images.githubusercontent.com/23356519/204688727-cc1251cf-0516-49d9-8670-31a3ecc96138.png">


Compare instances:

<img width="1360" alt="image" src="https://user-images.githubusercontent.com/23356519/204688712-c04a6062-3c08-41b5-a885-33e2fd3eaa8a.png">
