### PR TITLE
Add steps on how to get the SAML metadata URL from Okta

### DIFF
--- a/doc/admin/auth/saml/okta.md
+++ b/doc/admin/auth/saml/okta.md
@@ -23,11 +23,19 @@
     - To grant access to your own user:
       - Go to the “Assignments” tab, where you should see a table of People and Groups. Click the “Assign” dropdown, and then “Assign to People”.
       - A new window should pop-up. Find your account, and click “Assign”, “Save and Go Back”, and then “Done”.
-1. You have now finished configuring the settings in Okta. Before moving to step #2, make sure you have granted access to users/groups. Also, go into the “Sign On” tab, and look for the “Identity Provider metadata” link. Copy this link to your clipboard. You will need this for step #2.
+2. You have now finished configuring the settings in Okta. Before moving to step #2, make sure you have granted access to users/groups and copy the metadata URL to your clipboard:
+   - Go into the “Sign On” tab
+   - Scroll down to the section "SAML Signing Certificates"
+   - Click the "Actions" dropdown in the active certificate and then "View IdP Metadata"
+   - Copy the URL from the new browser tab that will open. It will have the following format:
+
+   ```sh
+       https://<your tenant>.okta.com/app/<unique identitfier>/sso/saml/metadata
+   ```
 
 ## 2. Add the SAML auth provider to Sourcegraph site config
 
-[Add a SAML auth provider](./index.md#add-a-saml-provider) with `identityProviderMetadataURL` set to the URL you copied from the "Identity Provider metadata" link in the previous section. Here is an example of what your site configuration should look like:
+[Add a SAML auth provider](./index.md#add-a-saml-provider) with `identityProviderMetadataURL` set to the URL you copied from the "View IdP Metadata" link in the previous section. Here is an example of what your site configuration should look like:
 
 ```json
 {


### PR DESCRIPTION
While doing an end-to-end test for the SAML flow with Okta, I found it a little tricky to find the metadata  URL we need to copy and paste to the site config. 
I also noticed that our docs didn't have the correct instructions on how to do that  (probably, Okta had changed things on their UI), so I am updating them.

## Test plan
All tests should pass.
Checked locally that the docs are updated as expected.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
