### PR TITLE
fuzzy finder: UI improvements

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyFiles.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFiles.tsx
@@ -63,8 +63,8 @@ export const FUZZY_FILES_QUERY = gql`
 
 function fileIcon(filename: string): JSX.Element {
     return (
-        <span className="fuzzy-repos-result-icon">
-            <Icon aria-label={filename} svgPath={mdiFileDocumentOutline} className="fuzzy-repos-result-icon" />
+        <span className="mr-1">
+            <Icon aria-label={filename} svgPath={mdiFileDocumentOutline} className="mr-1" />
         </span>
     )
 }

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
@@ -10,7 +10,7 @@ import { FuzzyModal } from './FuzzyModal'
 import { useFuzzyShortcuts } from './FuzzyShortcuts'
 import { fuzzyIsActive, FuzzyTabsProps, FuzzyState, useFuzzyState, FuzzyTabKey } from './FuzzyTabs'
 
-const DEFAULT_MAX_RESULTS = 100
+const DEFAULT_MAX_RESULTS = 50
 
 export interface FuzzyFinderContainerProps
     extends TelemetryProps,
@@ -103,9 +103,7 @@ export const FuzzyFinderContainer: React.FunctionComponent<FuzzyFinderContainerP
                         />
                     ))
                 )}
-            {isVisible && (
-                <FuzzyFinder {...state} setIsVisible={bool => setIsVisible(bool)} location={props.location} />
-            )}
+            {isVisible && <FuzzyFinder {...state} setIsVisible={setIsVisible} location={props.location} />}
         </>
     )
 }

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
@@ -10,34 +10,10 @@
     padding: 0;
 }
 
-.content {
-    display: flex;
-    align-items: stretch;
-    flex-direction: column;
-    height: 100%;
-    background: transparent;
-}
-
 .header {
-    display: flex;
-    flex-direction: row-reverse;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0.5rem 1rem 0; // stylelint-disable-next-line declaration-property-unit-allowed-list
+    // stylelint-disable-next-line declaration-property-unit-allowed-list
     margin-bottom: -1px;
     z-index: 1;
-}
-
-.divider {
-    width: 100%; // stylelint-disable-next-line declaration-property-unit-allowed-list
-    height: 1px;
-    background-color: var(--border-color);
-    margin-bottom: 0.5rem;
-    z-index: 0;
-
-    &.mb-0 {
-        margin-bottom: 0;
-    }
 }
 
 .shortcut {
@@ -51,60 +27,15 @@
     box-shadow: var(--search-input-shadow);
 }
 
-.empty-results {
-    text-align: center;
-}
-
-.results {
-    flex: 1;
-
-    // stylelint-disable-next-line scss/selector-no-redundant-nesting-selector
-    & p {
-        padding: 1rem;
-    }
-
-    ul {
-        padding: 0.25rem 0;
-        margin-bottom: 0;
-    }
-
-    li {
-        padding: 0.325rem 1rem;
-        border-radius: 0;
-        display: flex;
-        align-items: center;
-
-        a {
-            max-height: initial;
-
-            span:global(.fuzzy-repos-result-icon) {
-                margin-right: 0.25rem;
-            }
-            span:global(.fuzzy-repos-star) {
-                margin-left: 0.25rem;
-            }
-
-            &:hover {
-                text-decoration: none;
-            }
-        }
-
-        &:hover {
-            background-color: var(--color-bg-2);
-        }
+.result-item {
+    &:hover {
+        background-color: var(--color-bg-2);
     }
 }
 
 .focused {
     border-radius: var(--border-radius);
     background-color: var(--color-bg-3);
-}
-
-.footer {
-    display: flex;
-    align-items: center;
-    width: 100%;
-    padding: 0 1.5rem 0.75rem 1rem;
 }
 
 .keyboard-explanation {

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
@@ -2,21 +2,18 @@
 
 .modal {
     height: 80vh;
-    // stylelint-disable-next-line declaration-property-unit-allowed-list
-    max-height: 426px;
+    max-height: 426px; // stylelint-disable-line declaration-property-unit-allowed-list
     // `!important` is required to ensure that this rule is applied in the production bundle.
     // It can be removed after addressing the following issue:
     // https://github.com/sourcegraph/sourcegraph/issues/42217
     width: 80vw !important;
-    // stylelint-disable-next-line declaration-property-unit-allowed-list
-    max-width: 900px;
+    max-width: 900px; // stylelint-disable-line declaration-property-unit-allowed-list
     background-color: var(--body-bg);
     padding: 0;
 }
 
 .header {
-    // stylelint-disable-next-line declaration-property-unit-allowed-list
-    margin-bottom: -1px;
+    margin-bottom: -1px; // stylelint-disable-line declaration-property-unit-allowed-list
     z-index: 1;
 }
 

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
@@ -2,12 +2,12 @@
 
 .modal {
     height: 80vh;
-    max-height: 426px; // stylelint-disable-line declaration-property-unit-allowed-list
+    max-height: 426px;
     // `!important` is required to ensure that this rule is applied in the production bundle.
     // It can be removed after addressing the following issue:
     // https://github.com/sourcegraph/sourcegraph/issues/42217
     width: 80vw !important;
-    max-width: 900px; // stylelint-disable-line declaration-property-unit-allowed-list
+    max-width: 900px;
     background-color: var(--body-bg);
     padding: 0;
 }

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
@@ -2,10 +2,14 @@
 
 .modal {
     height: 80vh;
+    // stylelint-disable-next-line declaration-property-unit-allowed-list
+    max-height: 426px;
     // `!important` is required to ensure that this rule is applied in the production bundle.
     // It can be removed after addressing the following issue:
     // https://github.com/sourcegraph/sourcegraph/issues/42217
     width: 80vw !important;
+    // stylelint-disable-next-line declaration-property-unit-allowed-list
+    max-width: 900px;
     background-color: var(--body-bg);
     padding: 0;
 }

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -376,12 +376,7 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
                     >
                         Experimental
                     </Badge>
-                    <Button
-                        variant="icon"
-                        onClick={() => onClose()}
-                        aria-label="Close"
-                        className={classNames('ml-auto', styles.closeButton)}
-                    >
+                    <Button variant="icon" onClick={onClose} aria-label="Close" className={styles.closeButton}>
                         <Icon aria-hidden={true} svgPath={mdiClose} />
                     </Button>
                 </div>

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -144,10 +144,7 @@ function renderFuzzyResults(
                 // decision to place the number here, as long as the number is
                 // recorded as a dependency to `renderFuzzyResults` then it
                 // should work OK.
-                <Text
-                    data-fsm-generation={props.fsmGeneration}
-                    className={classNames(styles.emptyResults, 'text-muted')}
-                >
+                <Text data-fsm-generation={props.fsmGeneration} className="p-3 text-center text-muted">
                     No matches
                 </Text>
             ),
@@ -156,14 +153,18 @@ function renderFuzzyResults(
 
     const linksToRender = props.result.links.slice(0, props.resultCount)
     const element = (
-        <ul id={FUZZY_MODAL_RESULTS} role="listbox" aria-label="Fuzzy finder results">
+        <ul id={FUZZY_MODAL_RESULTS} role="listbox" aria-label="Fuzzy finder results" className="py-1 px-0 mb-0">
             {linksToRender.map((file, fileIndex) => (
                 <li
                     id={fuzzyResultId(fileIndex)}
                     key={file.url || file.text}
                     role="option"
                     aria-selected={fileIndex === focusIndex}
-                    className={classNames(fileIndex === focusIndex && styles.focused)}
+                    className={classNames(
+                        'd-flex align-items-center py-1 px-3 rounded-0',
+                        styles.resultItem,
+                        fileIndex === focusIndex && styles.focused
+                    )}
                 >
                     <HighlightedLink {...file} onClick={mergedHandler(file.onClick, onClickItem)} />
                 </li>
@@ -341,11 +342,17 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
             onDismiss={() => onClose()}
             aria-label={tabs.underlying[activeTab].title}
         >
-            <WrapperComponent className={styles.content} {...wrapperComponentProps}>
-                <div className={styles.header} data-testid="fuzzy-modal-header">
-                    <Button variant="icon" onClick={() => onClose()} aria-label="Close" className={styles.closeButton}>
-                        <Icon aria-hidden={true} svgPath={mdiClose} />
-                    </Button>
+            <WrapperComponent
+                className="d-flex align-items-stretch flex-column h-100 bg-transparent"
+                {...wrapperComponentProps}
+            >
+                <div
+                    className={classNames(
+                        'd-flex justify-space-between align-items-center pt-2 pb-0 px-3',
+                        styles.header
+                    )}
+                    data-testid="fuzzy-modal-header"
+                >
                     {showTabs ? (
                         <TabList className={styles.tabList}>
                             {tabs.entries().map(([key, tab]) => (
@@ -360,8 +367,16 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
                     ) : (
                         <H3>Find files</H3>
                     )}
+                    <Button
+                        variant="icon"
+                        onClick={() => onClose()}
+                        aria-label="Close"
+                        className={classNames('ml-auto', styles.closeButton)}
+                    >
+                        <Icon aria-hidden={true} svgPath={mdiClose} />
+                    </Button>
                 </div>
-                <div className={styles.divider} />
+                <hr className="mt-0 mb-2 w-100" />
                 <Input
                     id="fuzzy-modal-input"
                     autoComplete="off"
@@ -396,22 +411,20 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
                         </span>
                     )}
                 </div>
-                <div className={classNames(styles.divider, 'mb-0')} />
+                <hr className="my-0 w-100" />
                 {showTabs ? (
                     <TabPanels className="flex-1 overflow-auto">
                         {tabs.entries().map(([key]) => (
-                            <TabPanel key={key} className={styles.results}>
-                                {activeTab === key && queryResult.jsxElement}
-                            </TabPanel>
+                            <TabPanel key={key}>{activeTab === key && queryResult.jsxElement}</TabPanel>
                         ))}
                     </TabPanels>
                 ) : (
-                    <div className={classNames(styles.results, 'overflow-auto')}>{queryResult.jsxElement}</div>
+                    <div className="flex-1 overflow-auto">{queryResult.jsxElement}</div>
                 )}
-                <div className={styles.divider} />
-                <div className={styles.footer}>
+                <hr className="my-0 w-100" />
+                <div className="d-flex align-items-center w-100 p-3">
                     <SearchQueryLink {...props} />
-                    <span className="ml-auto">
+                    <span className="ml-auto mr-2">
                         <ArrowKeyExplanation />
                     </span>
                 </div>

--- a/client/web/src/components/fuzzyFinder/FuzzyRepos.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyRepos.tsx
@@ -41,10 +41,10 @@ export class FuzzyRepos extends FuzzyQuery {
             return {
                 text,
                 url,
-                icon: icon ? <span className="fuzzy-repos-result-icon">{icon}</span> : undefined,
+                icon: icon ? <span className="mr-1">{icon}</span> : undefined,
                 textSuffix:
                     stars && stars > 0 && formattedRepositoryStarCount ? (
-                        <span className="fuzzy-repos-star">
+                        <span className="mr-1">
                             <SearchResultStar aria-label={`${stars} stars`} />
                             <span aria-hidden={true}>{formattedRepositoryStarCount}</span>
                         </span>

--- a/client/web/src/components/fuzzyFinder/FuzzySymbols.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzySymbols.tsx
@@ -3,7 +3,7 @@ import { FuzzyFinderSymbolsResult, FuzzyFinderSymbolsVariables } from 'src/graph
 import gql from 'tagged-template-noop'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
-import { SymbolTag } from '@sourcegraph/shared/src/symbols/SymbolTag'
+import { SymbolIcon } from '@sourcegraph/shared/src/symbols/SymbolIcon'
 
 import { getWebGraphQLClient } from '../../backend/graphql'
 import { SearchValue } from '../../fuzzyFinder/FuzzySearch'
@@ -66,7 +66,7 @@ export class FuzzySymbols extends FuzzyQuery {
         return values.map(({ text, url, symbolKind }) => ({
             text: repositoryFilter ? text.replace(repositoryText, '') : text,
             url,
-            icon: symbolKind ? <SymbolTag className="fuzzy-repos-result-icon" kind={symbolKind} /> : undefined,
+            icon: symbolKind ? <SymbolIcon kind={symbolKind} className="mr-1" /> : undefined,
         }))
     }
 

--- a/client/web/src/components/fuzzyFinder/HighlightedLink.module.scss
+++ b/client/web/src/components/fuzzyFinder/HighlightedLink.module.scss
@@ -1,12 +1,7 @@
 .link {
-    display: inline-block;
-    width: 100%;
-    height: 100%;
-    max-height: 1em;
     color: var(--text-muted);
 
     &:hover {
-        cursor: pointer;
         color: var(--text-muted);
     }
 }

--- a/client/web/src/components/fuzzyFinder/HighlightedLink.tsx
+++ b/client/web/src/components/fuzzyFinder/HighlightedLink.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react'
 
+import classNames from 'classnames'
 import { Link } from '@sourcegraph/wildcard'
 
 import styles from './HighlightedLink.module.scss'
@@ -86,7 +87,11 @@ export const HighlightedLink: React.FunctionComponent<React.PropsWithChildren<Hi
     )
 
     return (
-        <Link className={styles.link} to={url || `/commands/${props.text}`} onClick={handleClick}>
+        <Link
+            className={classNames('d-inline-block w-100 h-100 text-decoration-none', styles.link)}
+            to={url || `/commands/${props.text}`}
+            onClick={handleClick}
+        >
             {props.icon && <span>{props.icon}</span>}
             {spans}
             {url ? props.textSuffix : null}

--- a/client/web/src/components/fuzzyFinder/HighlightedLink.tsx
+++ b/client/web/src/components/fuzzyFinder/HighlightedLink.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react'
 
 import classNames from 'classnames'
+
 import { Link } from '@sourcegraph/wildcard'
 
 import styles from './HighlightedLink.module.scss'


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/43154
Closes https://github.com/sourcegraph/sourcegraph/issues/22213

1. Uses icons from the blob view symbols sidebar for the fuzzy finder symbols tab results (instead of icons from the `type:symbol` search results page). Follow-up issue to make symbols icons/tags usage consistent: https://github.com/sourcegraph/sourcegraph/issues/44946.
2. Restricts fuzzy finder modal max size.
3. Reduces the initial max results number from 100 to 50 to improve latency.
4. Refactors styles in favor of using Bootstrap utility classes instead of custom styles (docs: [1](https://docs.sourcegraph.com/dev/background-information/web/styling#host-specific-ui), [2](https://docs.sourcegraph.com/dev/background-information/web/styling#spacing)). 

| Before | After |
| -- | -- |
| <img width="3122" alt="Screenshot 2022-11-30 at 15 34 06" src="https://user-images.githubusercontent.com/25318659/204809959-eabe84d0-4d05-4216-a0da-2b7ccb8d12f3.png"> | <img width="3122" alt="Screenshot 2022-11-30 at 15 34 18" src="https://user-images.githubusercontent.com/25318659/204809971-684c5be6-a795-4983-89b3-30f9fee90ff4.png">|

## Test plan
Tested manually (see screenshots).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-fuzzy-finder-use.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

