### PR TITLE
codeintel: fix autoindexing janitor metrics uninitialized

### DIFF
--- a/enterprise/cmd/worker/internal/codeintel/autoindexing_janitor.go
+++ b/enterprise/cmd/worker/internal/codeintel/autoindexing_janitor.go
@@ -43,7 +43,7 @@ func (j *autoindexingJanitorJob) Routines(startupCtx context.Context, logger log
 	gitserverClient := gitserver.New(db, observation.ScopedContext("codeintel", "janitor", "gitserver"))
 
 	return append(
-		autoindexing.NewJanitorJobs(services.AutoIndexingService, gitserverClient),
+		autoindexing.NewJanitorJobs(services.AutoIndexingService, gitserverClient, observation.ContextWithLogger(logger)),
 		autoindexing.NewResetters(db, observation.ContextWithLogger(logger))...,
 	), nil
 }

--- a/enterprise/internal/codeintel/autoindexing/init.go
+++ b/enterprise/internal/codeintel/autoindexing/init.go
@@ -76,7 +76,7 @@ func NewResetters(db database.DB, observationContext *observation.Context) []gor
 	}
 }
 
-func NewJanitorJobs(autoindexingSvc *Service, gitserver GitserverClient) []goroutine.BackgroundRoutine {
+func NewJanitorJobs(autoindexingSvc *Service, gitserver GitserverClient, observationContext *observation.Context) []goroutine.BackgroundRoutine {
 	return []goroutine.BackgroundRoutine{
 		background.NewJanitor(
 			ConfigCleanupInst.Interval,
@@ -88,6 +88,7 @@ func NewJanitorJobs(autoindexingSvc *Service, gitserver GitserverClient) []gorou
 				FailedIndexBatchSize:           ConfigCleanupInst.FailedIndexBatchSize,
 				FailedIndexMaxAge:              ConfigCleanupInst.FailedIndexMaxAge,
 			},
+			observationContext,
 		),
 	}
 }
@@ -109,7 +110,6 @@ func NewIndexSchedulers(
 				PolicyBatchSize:        ConfigIndexingInst.PolicyBatchSize,
 				InferenceConcurrency:   ConfigIndexingInst.InferenceConcurrency,
 			},
-
 			observationContext,
 		),
 


### PR DESCRIPTION
Janitor metrics were uninitialized, causing nil pointer error. This doesnt cause a worker crash and is not a severe thing to be missing (only affecting the size of `lsif_indexes` table)

## Test plan

Ran locally, no dup registering and no nil pointer
