### PR TITLE
codeintel: Expose SymbolWriter in lsifstore

### DIFF
--- a/enterprise/internal/codeintel/shared/types/scip_symbols.go
+++ b/enterprise/internal/codeintel/shared/types/scip_symbols.go
@@ -1,0 +1,9 @@
+package types
+
+type InvertedRangeIndex struct {
+	SymbolName           string
+	DefinitionRanges     []int32
+	ReferenceRanges      []int32
+	ImplementationRanges []int32
+	TypeDefinitionRanges []int32
+}

--- a/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
@@ -9752,6 +9752,9 @@ type MockLsifStore struct {
 	// InsertSCIPDocumentFunc is an instance of a mock function object
 	// controlling the behavior of the method InsertSCIPDocument.
 	InsertSCIPDocumentFunc *LsifStoreInsertSCIPDocumentFunc
+	// NewSymbolWriterFunc is an instance of a mock function object
+	// controlling the behavior of the method NewSymbolWriter.
+	NewSymbolWriterFunc *LsifStoreNewSymbolWriterFunc
 	// ReconcileCandidatesFunc is an instance of a mock function object
 	// controlling the behavior of the method ReconcileCandidates.
 	ReconcileCandidatesFunc *LsifStoreReconcileCandidatesFunc
@@ -9785,9 +9788,6 @@ type MockLsifStore struct {
 	// WriteResultChunksFunc is an instance of a mock function object
 	// controlling the behavior of the method WriteResultChunks.
 	WriteResultChunksFunc *LsifStoreWriteResultChunksFunc
-	// WriteSCIPSymbolsFunc is an instance of a mock function object
-	// controlling the behavior of the method WriteSCIPSymbols.
-	WriteSCIPSymbolsFunc *LsifStoreWriteSCIPSymbolsFunc
 }
 
 // NewMockLsifStore creates a new mock of the LsifStore interface. All
@@ -9816,6 +9816,11 @@ func NewMockLsifStore() *MockLsifStore {
 		},
 		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
 			defaultHook: func(context.Context, int, string, []byte, []byte) (r0 int, r1 error) {
+				return
+			},
+		},
+		NewSymbolWriterFunc: &LsifStoreNewSymbolWriterFunc{
+			defaultHook: func(context.Context, int) (r0 lsifstore.SymbolWriter, r1 error) {
 				return
 			},
 		},
@@ -9874,11 +9879,6 @@ func NewMockLsifStore() *MockLsifStore {
 				return
 			},
 		},
-		WriteSCIPSymbolsFunc: &LsifStoreWriteSCIPSymbolsFunc{
-			defaultHook: func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (r0 uint32, r1 error) {
-				return
-			},
-		},
 	}
 }
 
@@ -9909,6 +9909,11 @@ func NewStrictMockLsifStore() *MockLsifStore {
 		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
 			defaultHook: func(context.Context, int, string, []byte, []byte) (int, error) {
 				panic("unexpected invocation of MockLsifStore.InsertSCIPDocument")
+			},
+		},
+		NewSymbolWriterFunc: &LsifStoreNewSymbolWriterFunc{
+			defaultHook: func(context.Context, int) (lsifstore.SymbolWriter, error) {
+				panic("unexpected invocation of MockLsifStore.NewSymbolWriter")
 			},
 		},
 		ReconcileCandidatesFunc: &LsifStoreReconcileCandidatesFunc{
@@ -9966,11 +9971,6 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.WriteResultChunks")
 			},
 		},
-		WriteSCIPSymbolsFunc: &LsifStoreWriteSCIPSymbolsFunc{
-			defaultHook: func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error) {
-				panic("unexpected invocation of MockLsifStore.WriteSCIPSymbols")
-			},
-		},
 	}
 }
 
@@ -9992,6 +9992,9 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		},
 		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
 			defaultHook: i.InsertSCIPDocument,
+		},
+		NewSymbolWriterFunc: &LsifStoreNewSymbolWriterFunc{
+			defaultHook: i.NewSymbolWriter,
 		},
 		ReconcileCandidatesFunc: &LsifStoreReconcileCandidatesFunc{
 			defaultHook: i.ReconcileCandidates,
@@ -10025,9 +10028,6 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		},
 		WriteResultChunksFunc: &LsifStoreWriteResultChunksFunc{
 			defaultHook: i.WriteResultChunks,
-		},
-		WriteSCIPSymbolsFunc: &LsifStoreWriteSCIPSymbolsFunc{
-			defaultHook: i.WriteSCIPSymbols,
 		},
 	}
 }
@@ -10588,6 +10588,114 @@ func (c LsifStoreInsertSCIPDocumentFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c LsifStoreInsertSCIPDocumentFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// LsifStoreNewSymbolWriterFunc describes the behavior when the
+// NewSymbolWriter method of the parent MockLsifStore instance is invoked.
+type LsifStoreNewSymbolWriterFunc struct {
+	defaultHook func(context.Context, int) (lsifstore.SymbolWriter, error)
+	hooks       []func(context.Context, int) (lsifstore.SymbolWriter, error)
+	history     []LsifStoreNewSymbolWriterFuncCall
+	mutex       sync.Mutex
+}
+
+// NewSymbolWriter delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockLsifStore) NewSymbolWriter(v0 context.Context, v1 int) (lsifstore.SymbolWriter, error) {
+	r0, r1 := m.NewSymbolWriterFunc.nextHook()(v0, v1)
+	m.NewSymbolWriterFunc.appendCall(LsifStoreNewSymbolWriterFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the NewSymbolWriter
+// method of the parent MockLsifStore instance is invoked and the hook queue
+// is empty.
+func (f *LsifStoreNewSymbolWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SymbolWriter, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// NewSymbolWriter method of the parent MockLsifStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *LsifStoreNewSymbolWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SymbolWriter, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreNewSymbolWriterFunc) SetDefaultReturn(r0 lsifstore.SymbolWriter, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (lsifstore.SymbolWriter, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreNewSymbolWriterFunc) PushReturn(r0 lsifstore.SymbolWriter, r1 error) {
+	f.PushHook(func(context.Context, int) (lsifstore.SymbolWriter, error) {
+		return r0, r1
+	})
+}
+
+func (f *LsifStoreNewSymbolWriterFunc) nextHook() func(context.Context, int) (lsifstore.SymbolWriter, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreNewSymbolWriterFunc) appendCall(r0 LsifStoreNewSymbolWriterFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LsifStoreNewSymbolWriterFuncCall objects
+// describing the invocations of this function.
+func (f *LsifStoreNewSymbolWriterFunc) History() []LsifStoreNewSymbolWriterFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreNewSymbolWriterFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreNewSymbolWriterFuncCall is an object that describes an
+// invocation of method NewSymbolWriter on an instance of MockLsifStore.
+type LsifStoreNewSymbolWriterFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 lsifstore.SymbolWriter
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreNewSymbolWriterFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreNewSymbolWriterFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -11789,120 +11897,6 @@ func (c LsifStoreWriteResultChunksFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c LsifStoreWriteResultChunksFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// LsifStoreWriteSCIPSymbolsFunc describes the behavior when the
-// WriteSCIPSymbols method of the parent MockLsifStore instance is invoked.
-type LsifStoreWriteSCIPSymbolsFunc struct {
-	defaultHook func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error)
-	hooks       []func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error)
-	history     []LsifStoreWriteSCIPSymbolsFuncCall
-	mutex       sync.Mutex
-}
-
-// WriteSCIPSymbols delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockLsifStore) WriteSCIPSymbols(v0 context.Context, v1 int, v2 int, v3 []lsifstore.ProcessedSymbolData) (uint32, error) {
-	r0, r1 := m.WriteSCIPSymbolsFunc.nextHook()(v0, v1, v2, v3)
-	m.WriteSCIPSymbolsFunc.appendCall(LsifStoreWriteSCIPSymbolsFuncCall{v0, v1, v2, v3, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the WriteSCIPSymbols
-// method of the parent MockLsifStore instance is invoked and the hook queue
-// is empty.
-func (f *LsifStoreWriteSCIPSymbolsFunc) SetDefaultHook(hook func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// WriteSCIPSymbols method of the parent MockLsifStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *LsifStoreWriteSCIPSymbolsFunc) PushHook(hook func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *LsifStoreWriteSCIPSymbolsFunc) SetDefaultReturn(r0 uint32, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreWriteSCIPSymbolsFunc) PushReturn(r0 uint32, r1 error) {
-	f.PushHook(func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error) {
-		return r0, r1
-	})
-}
-
-func (f *LsifStoreWriteSCIPSymbolsFunc) nextHook() func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *LsifStoreWriteSCIPSymbolsFunc) appendCall(r0 LsifStoreWriteSCIPSymbolsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of LsifStoreWriteSCIPSymbolsFuncCall objects
-// describing the invocations of this function.
-func (f *LsifStoreWriteSCIPSymbolsFunc) History() []LsifStoreWriteSCIPSymbolsFuncCall {
-	f.mutex.Lock()
-	history := make([]LsifStoreWriteSCIPSymbolsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// LsifStoreWriteSCIPSymbolsFuncCall is an object that describes an
-// invocation of method WriteSCIPSymbols on an instance of MockLsifStore.
-type LsifStoreWriteSCIPSymbolsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 int
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 []lsifstore.ProcessedSymbolData
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 uint32
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c LsifStoreWriteSCIPSymbolsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c LsifStoreWriteSCIPSymbolsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
@@ -16,7 +16,6 @@ type operations struct {
 	scanResultChunks          *observation.Operation
 	scanLocations             *observation.Operation
 	insertSCIPDocument        *observation.Operation
-	writeSCIPSymbols          *observation.Operation
 	writeMeta                 *observation.Operation
 	writeDocuments            *observation.Operation
 	writeResultChunks         *observation.Operation
@@ -50,7 +49,6 @@ func newOperations(observationContext *observation.Context) *operations {
 		scanResultChunks:          op("ScanResultChunks"),
 		scanLocations:             op("ScanLocations"),
 		insertSCIPDocument:        op("InsertSCIPDocument"),
-		writeSCIPSymbols:          op("WriteSCIPSymbols"),
 		writeMeta:                 op("WriteMeta"),
 		writeDocuments:            op("WriteDocuments"),
 		writeResultChunks:         op("WriteResultChunks"),

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_write.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_write.go
@@ -3,40 +3,31 @@ package lsifstore
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"sync/atomic"
 
 	"github.com/keegancsmith/sqlf"
-	"github.com/opentracing/opentracing-go/log"
 	otlog "github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/batch"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
-
-type ProcessedSCIPDocument struct {
-	DocumentPath   string
-	Hash           []byte
-	RawSCIPPayload []byte
-	Symbols        []ProcessedSymbolData
-	Err            error
-}
-
-type ProcessedSymbolData struct {
-	SymbolName           string
-	DefinitionRanges     []int32
-	ReferenceRanges      []int32
-	ImplementationRanges []int32
-	TypeDefinitionRanges []int32
-}
 
 type ProcessedSCIPData struct {
 	Documents         <-chan ProcessedSCIPDocument
 	Packages          []precise.Package
 	PackageReferences []precise.PackageReference
+}
+
+type ProcessedSCIPDocument struct {
+	DocumentPath   string
+	Hash           []byte
+	RawSCIPPayload []byte
+	Symbols        []types.InvertedRangeIndex
+	Err            error
 }
 
 func (s *store) InsertSCIPDocument(ctx context.Context, uploadID int, documentPath string, hash []byte, rawSCIPPayload []byte) (_ int, err error) {
@@ -50,6 +41,7 @@ func (s *store) InsertSCIPDocument(ctx context.Context, uploadID int, documentPa
 
 	id, _, err := basestore.ScanFirstInt(s.db.Query(ctx, sqlf.Sprintf(
 		insertSCIPDocumentQuery,
+		1,
 		hash,
 		rawSCIPPayload,
 		hash,
@@ -67,7 +59,7 @@ const insertSCIPDocumentQuery = `
 WITH
 new_shared_document AS (
 	INSERT INTO codeintel_scip_documents (schema_version, payload_hash, raw_scip_payload)
-	VALUES (1, %s, %s)
+	VALUES (%s, %s, %s)
 	ON CONFLICT DO NOTHING
 	RETURNING id
 ),
@@ -81,91 +73,99 @@ SELECT %s, %s, id FROM shared_document LIMIT 1
 RETURNING id
 `
 
-func (s *store) WriteSCIPSymbols(ctx context.Context, uploadID, documentLookupID int, symbols []ProcessedSymbolData) (count uint32, err error) {
-	ctx, trace, endObservation := s.operations.writeSCIPSymbols.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
-		otlog.Int("uploadID", uploadID),
-		otlog.Int("documentLookupID", documentLookupID),
-		otlog.Int("numSymbols", len(symbols)),
-	}})
-	defer endObservation(1, observation.Args{})
-
-	tx, err := s.db.Transact(ctx)
-	if err != nil {
-		return 0, err
-	}
-	defer func() { err = tx.Done(err) }()
-
-	if err := tx.Exec(ctx, sqlf.Sprintf(writeSCIPSymbolsTemporaryTableQuery)); err != nil {
-		return 0, err
+func (s *store) NewSymbolWriter(ctx context.Context, uploadID int) (SymbolWriter, error) {
+	if !s.db.InTransaction() {
+		return nil, errors.New("WriteSCIPSymbols must be called in a transaction")
 	}
 
-	inserter := func(inserter *batch.Inserter) error {
-		for _, symbol := range symbols {
-			definitionRanges, err := types.EncodeRanges(symbol.DefinitionRanges)
-			if err != nil {
-				return err
-			}
-			referenceRanges, err := types.EncodeRanges(symbol.ReferenceRanges)
-			if err != nil {
-				return err
-			}
-			implementationRanges, err := types.EncodeRanges(symbol.ImplementationRanges)
-			if err != nil {
-				return err
-			}
-			typeDefinitionRanges, err := types.EncodeRanges(symbol.TypeDefinitionRanges)
-			if err != nil {
-				return err
-			}
+	if err := s.db.Exec(ctx, sqlf.Sprintf(writeSCIPSymbolsTemporaryTableQuery)); err != nil {
+		return nil, err
+	}
 
-			if err := inserter.Insert(
-				ctx,
-				uploadID,
-				symbol.SymbolName,
-				definitionRanges,
-				referenceRanges,
-				implementationRanges,
-				typeDefinitionRanges,
-			); err != nil {
-				return err
-			}
+	inserter := batch.NewInserter(
+		ctx,
+		s.db.Handle(),
+		"t_codeintel_scip_symbols",
+		batch.MaxNumPostgresParameters,
+		"document_lookup_id",
+		"symbol_name",
+		"definition_ranges",
+		"reference_ranges",
+		"implementation_ranges",
+		"type_definition_ranges",
+	)
 
-			atomic.AddUint32(&count, 1)
+	symbolWriter := &symbolWriter{
+		uploadID: uploadID,
+		db:       s.db,
+		inserter: inserter,
+		count:    0,
+	}
+
+	return symbolWriter, nil
+}
+
+type symbolWriter struct {
+	uploadID int
+	db       *basestore.Store
+	inserter *batch.Inserter
+	count    uint32
+}
+
+func (s *symbolWriter) WriteSCIPSymbols(ctx context.Context, documentLookupID int, symbols []types.InvertedRangeIndex) error {
+	for _, symbol := range symbols {
+		definitionRanges, err := types.EncodeRanges(symbol.DefinitionRanges)
+		if err != nil {
+			return err
+		}
+		referenceRanges, err := types.EncodeRanges(symbol.ReferenceRanges)
+		if err != nil {
+			return err
+		}
+		implementationRanges, err := types.EncodeRanges(symbol.ImplementationRanges)
+		if err != nil {
+			return err
+		}
+		typeDefinitionRanges, err := types.EncodeRanges(symbol.TypeDefinitionRanges)
+		if err != nil {
+			return err
 		}
 
-		return nil
+		if err := s.inserter.Insert(
+			ctx,
+			documentLookupID,
+			symbol.SymbolName,
+			definitionRanges,
+			referenceRanges,
+			implementationRanges,
+			typeDefinitionRanges,
+		); err != nil {
+			return err
+		}
+
+		atomic.AddUint32(&s.count, 1)
 	}
 
-	if err := withSingleThreadedBatchInserter(
-		ctx,
-		tx.Handle(),
-		"t_codeintel_scip_symbols",
-		[]string{
-			"upload_id",
-			"symbol_name",
-			"definition_ranges",
-			"reference_ranges",
-			"implementation_ranges",
-			"type_definition_ranges",
-		},
-		inserter,
-	); err != nil {
+	return nil
+
+}
+
+func (s *symbolWriter) Flush(ctx context.Context) (uint32, error) {
+	if err := s.inserter.Flush(ctx); err != nil {
 		return 0, err
 	}
-	trace.Log(log.Int("numRecords", int(count)))
 
-	err = tx.Exec(ctx, sqlf.Sprintf(writeSCIPSymbolsInsertQuery, documentLookupID, 1))
-	if err != nil {
+	if err := s.db.Exec(ctx, sqlf.Sprintf(writeSCIPSymbolsInsertQuery, s.uploadID, 1)); err != nil {
 		return 0, err
 	}
 
-	return count, nil
+	return s.count, nil
 }
 
 const writeSCIPSymbolsTemporaryTableQuery = `
 CREATE TEMPORARY TABLE t_codeintel_scip_symbols (
-	upload_id integer NOT NULL,
 	symbol_name text NOT NULL,
+	document_lookup_id integer NOT NULL,
 	definition_ranges bytea,
 	reference_ranges bytea,
 	implementation_ranges bytea,
@@ -185,9 +185,9 @@ INSERT INTO codeintel_scip_symbols (
 	type_definition_ranges
 )
 SELECT
-	source.upload_id,
-	source.symbol_name,
 	%s,
+	source.symbol_name,
+	source.document_lookup_id,
 	%s,
 	source.definition_ranges,
 	source.reference_ranges,
@@ -196,7 +196,3 @@ SELECT
 FROM t_codeintel_scip_symbols source
 ON CONFLICT DO NOTHING
 `
-
-func withSingleThreadedBatchInserter(ctx context.Context, db dbutil.DB, tableName string, columns []string, f func(inserter *batch.Inserter) error) (err error) {
-	return batch.WithInserter(ctx, db, tableName, batch.MaxNumPostgresParameters, columns, f)
-}

--- a/enterprise/internal/codeintel/uploads/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/mocks_test.go
@@ -7423,6 +7423,9 @@ type MockLsifStore struct {
 	// InsertSCIPDocumentFunc is an instance of a mock function object
 	// controlling the behavior of the method InsertSCIPDocument.
 	InsertSCIPDocumentFunc *LsifStoreInsertSCIPDocumentFunc
+	// NewSymbolWriterFunc is an instance of a mock function object
+	// controlling the behavior of the method NewSymbolWriter.
+	NewSymbolWriterFunc *LsifStoreNewSymbolWriterFunc
 	// ReconcileCandidatesFunc is an instance of a mock function object
 	// controlling the behavior of the method ReconcileCandidates.
 	ReconcileCandidatesFunc *LsifStoreReconcileCandidatesFunc
@@ -7456,9 +7459,6 @@ type MockLsifStore struct {
 	// WriteResultChunksFunc is an instance of a mock function object
 	// controlling the behavior of the method WriteResultChunks.
 	WriteResultChunksFunc *LsifStoreWriteResultChunksFunc
-	// WriteSCIPSymbolsFunc is an instance of a mock function object
-	// controlling the behavior of the method WriteSCIPSymbols.
-	WriteSCIPSymbolsFunc *LsifStoreWriteSCIPSymbolsFunc
 }
 
 // NewMockLsifStore creates a new mock of the LsifStore interface. All
@@ -7487,6 +7487,11 @@ func NewMockLsifStore() *MockLsifStore {
 		},
 		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
 			defaultHook: func(context.Context, int, string, []byte, []byte) (r0 int, r1 error) {
+				return
+			},
+		},
+		NewSymbolWriterFunc: &LsifStoreNewSymbolWriterFunc{
+			defaultHook: func(context.Context, int) (r0 lsifstore.SymbolWriter, r1 error) {
 				return
 			},
 		},
@@ -7545,11 +7550,6 @@ func NewMockLsifStore() *MockLsifStore {
 				return
 			},
 		},
-		WriteSCIPSymbolsFunc: &LsifStoreWriteSCIPSymbolsFunc{
-			defaultHook: func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (r0 uint32, r1 error) {
-				return
-			},
-		},
 	}
 }
 
@@ -7580,6 +7580,11 @@ func NewStrictMockLsifStore() *MockLsifStore {
 		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
 			defaultHook: func(context.Context, int, string, []byte, []byte) (int, error) {
 				panic("unexpected invocation of MockLsifStore.InsertSCIPDocument")
+			},
+		},
+		NewSymbolWriterFunc: &LsifStoreNewSymbolWriterFunc{
+			defaultHook: func(context.Context, int) (lsifstore.SymbolWriter, error) {
+				panic("unexpected invocation of MockLsifStore.NewSymbolWriter")
 			},
 		},
 		ReconcileCandidatesFunc: &LsifStoreReconcileCandidatesFunc{
@@ -7637,11 +7642,6 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.WriteResultChunks")
 			},
 		},
-		WriteSCIPSymbolsFunc: &LsifStoreWriteSCIPSymbolsFunc{
-			defaultHook: func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error) {
-				panic("unexpected invocation of MockLsifStore.WriteSCIPSymbols")
-			},
-		},
 	}
 }
 
@@ -7663,6 +7663,9 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		},
 		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
 			defaultHook: i.InsertSCIPDocument,
+		},
+		NewSymbolWriterFunc: &LsifStoreNewSymbolWriterFunc{
+			defaultHook: i.NewSymbolWriter,
 		},
 		ReconcileCandidatesFunc: &LsifStoreReconcileCandidatesFunc{
 			defaultHook: i.ReconcileCandidates,
@@ -7696,9 +7699,6 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		},
 		WriteResultChunksFunc: &LsifStoreWriteResultChunksFunc{
 			defaultHook: i.WriteResultChunks,
-		},
-		WriteSCIPSymbolsFunc: &LsifStoreWriteSCIPSymbolsFunc{
-			defaultHook: i.WriteSCIPSymbols,
 		},
 	}
 }
@@ -8259,6 +8259,114 @@ func (c LsifStoreInsertSCIPDocumentFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c LsifStoreInsertSCIPDocumentFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// LsifStoreNewSymbolWriterFunc describes the behavior when the
+// NewSymbolWriter method of the parent MockLsifStore instance is invoked.
+type LsifStoreNewSymbolWriterFunc struct {
+	defaultHook func(context.Context, int) (lsifstore.SymbolWriter, error)
+	hooks       []func(context.Context, int) (lsifstore.SymbolWriter, error)
+	history     []LsifStoreNewSymbolWriterFuncCall
+	mutex       sync.Mutex
+}
+
+// NewSymbolWriter delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockLsifStore) NewSymbolWriter(v0 context.Context, v1 int) (lsifstore.SymbolWriter, error) {
+	r0, r1 := m.NewSymbolWriterFunc.nextHook()(v0, v1)
+	m.NewSymbolWriterFunc.appendCall(LsifStoreNewSymbolWriterFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the NewSymbolWriter
+// method of the parent MockLsifStore instance is invoked and the hook queue
+// is empty.
+func (f *LsifStoreNewSymbolWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SymbolWriter, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// NewSymbolWriter method of the parent MockLsifStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *LsifStoreNewSymbolWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SymbolWriter, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreNewSymbolWriterFunc) SetDefaultReturn(r0 lsifstore.SymbolWriter, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (lsifstore.SymbolWriter, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreNewSymbolWriterFunc) PushReturn(r0 lsifstore.SymbolWriter, r1 error) {
+	f.PushHook(func(context.Context, int) (lsifstore.SymbolWriter, error) {
+		return r0, r1
+	})
+}
+
+func (f *LsifStoreNewSymbolWriterFunc) nextHook() func(context.Context, int) (lsifstore.SymbolWriter, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreNewSymbolWriterFunc) appendCall(r0 LsifStoreNewSymbolWriterFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LsifStoreNewSymbolWriterFuncCall objects
+// describing the invocations of this function.
+func (f *LsifStoreNewSymbolWriterFunc) History() []LsifStoreNewSymbolWriterFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreNewSymbolWriterFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreNewSymbolWriterFuncCall is an object that describes an
+// invocation of method NewSymbolWriter on an instance of MockLsifStore.
+type LsifStoreNewSymbolWriterFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 lsifstore.SymbolWriter
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreNewSymbolWriterFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreNewSymbolWriterFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -9460,120 +9568,6 @@ func (c LsifStoreWriteResultChunksFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c LsifStoreWriteResultChunksFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// LsifStoreWriteSCIPSymbolsFunc describes the behavior when the
-// WriteSCIPSymbols method of the parent MockLsifStore instance is invoked.
-type LsifStoreWriteSCIPSymbolsFunc struct {
-	defaultHook func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error)
-	hooks       []func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error)
-	history     []LsifStoreWriteSCIPSymbolsFuncCall
-	mutex       sync.Mutex
-}
-
-// WriteSCIPSymbols delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockLsifStore) WriteSCIPSymbols(v0 context.Context, v1 int, v2 int, v3 []lsifstore.ProcessedSymbolData) (uint32, error) {
-	r0, r1 := m.WriteSCIPSymbolsFunc.nextHook()(v0, v1, v2, v3)
-	m.WriteSCIPSymbolsFunc.appendCall(LsifStoreWriteSCIPSymbolsFuncCall{v0, v1, v2, v3, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the WriteSCIPSymbols
-// method of the parent MockLsifStore instance is invoked and the hook queue
-// is empty.
-func (f *LsifStoreWriteSCIPSymbolsFunc) SetDefaultHook(hook func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// WriteSCIPSymbols method of the parent MockLsifStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *LsifStoreWriteSCIPSymbolsFunc) PushHook(hook func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *LsifStoreWriteSCIPSymbolsFunc) SetDefaultReturn(r0 uint32, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreWriteSCIPSymbolsFunc) PushReturn(r0 uint32, r1 error) {
-	f.PushHook(func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error) {
-		return r0, r1
-	})
-}
-
-func (f *LsifStoreWriteSCIPSymbolsFunc) nextHook() func(context.Context, int, int, []lsifstore.ProcessedSymbolData) (uint32, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *LsifStoreWriteSCIPSymbolsFunc) appendCall(r0 LsifStoreWriteSCIPSymbolsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of LsifStoreWriteSCIPSymbolsFuncCall objects
-// describing the invocations of this function.
-func (f *LsifStoreWriteSCIPSymbolsFunc) History() []LsifStoreWriteSCIPSymbolsFuncCall {
-	f.mutex.Lock()
-	history := make([]LsifStoreWriteSCIPSymbolsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// LsifStoreWriteSCIPSymbolsFuncCall is an object that describes an
-// invocation of method WriteSCIPSymbols on an instance of MockLsifStore.
-type LsifStoreWriteSCIPSymbolsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 int
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 []lsifstore.ProcessedSymbolData
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 uint32
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c LsifStoreWriteSCIPSymbolsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c LsifStoreWriteSCIPSymbolsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 


### PR DESCRIPTION
We need to batch symbols in larger batches than documents provide. We need to expose a symbol writer that can start/flush independently from document inserts.

## Test plan

Updated unit tests.