### PR TITLE
Outbound requests: Fix keyword display

### DIFF
--- a/client/web/src/site-admin/SiteAdminOutboundRequestsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOutboundRequestsPage.tsx
@@ -172,7 +172,7 @@ export const SiteAdminOutboundRequestsPage: React.FunctionComponent<
                     <>
                         <Text>Outbound request logging is currently disabled.</Text>
                         <Text>
-                            Set `outboundRequestLogLimit` to a non-zero value in your{' '}
+                            Set <Code>outboundRequestLogLimit</Code> to a non-zero value in your{' '}
                             <Link to="/site-admin/configuration">site config</Link> to enable it.
                         </Text>
                     </>


### PR DESCRIPTION
@mrnugget found a mistake on the empty state of the page: a keyword was not correctly formatted:

![image](https://user-images.githubusercontent.com/2552265/204839763-302aedf0-3b06-4f25-9177-066ea99cfb21.png)

## Test plan

Looks like this now:

<img width="975" alt="CleanShot 2022-11-30 at 16 28 47@2x" src="https://user-images.githubusercontent.com/2552265/204839520-9613312e-3ca5-45f4-a592-d11ce3c0ff8b.png">

## App preview:

- [Web](https://sg-web-dv-outbound-requests-fix-keyword.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
