### PR TITLE
Add audit logs for invalid token events - no db migration

### DIFF
--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -94,6 +94,7 @@ func AccessTokenAuthMiddleware(db database.DB, logger log.Logger, next http.Hand
 						r.Context(),
 						&database.SecurityEvent{
 							Name:            database.SecurityEventAccessTokenInvalid,
+							URL:             r.URL.RequestURI(),
 							AnonymousUserID: anonymousId,
 							Source:          "BACKEND",
 							Timestamp:       time.Now(),
@@ -161,6 +162,7 @@ func AccessTokenAuthMiddleware(db database.DB, logger log.Logger, next http.Hand
 						r.Context(),
 						&database.SecurityEvent{
 							Name:      database.SecurityEventAccessTokenSubjectNotSiteAdmin,
+							URL:       r.URL.RequestURI(),
 							UserID:    uint32(subjectUserID),
 							Argument:  args,
 							Source:    "BACKEND",

--- a/cmd/frontend/internal/httpapi/auth_test.go
+++ b/cmd/frontend/internal/httpapi/auth_test.go
@@ -195,14 +195,22 @@ func TestAccessTokenAuthMiddleware(t *testing.T) {
 			return &types.User{ID: 456, SiteAdmin: true}, nil
 		})
 
+		securityEventLogs := database.NewMockSecurityEventLogsStore()
+		securityEventLogs.LogEventFunc.SetDefaultHook(func(ctx context.Context, se *database.SecurityEvent) {
+			if want := database.SecurityEventAccessTokenImpersonated; se.Name != want {
+				t.Errorf("got %q, want %q", se.Name, want)
+			}
+		})
+
 		db.AccessTokensFunc.SetDefaultReturn(accessTokens)
 		db.UsersFunc.SetDefaultReturn(users)
-		db.SecurityEventLogsFunc.SetDefaultReturn(database.NewMockSecurityEventLogsStore())
+		db.SecurityEventLogsFunc.SetDefaultReturn(securityEventLogs)
 
 		checkHTTPResponse(t, db, req, http.StatusOK, "user 456")
 		mockrequire.Called(t, accessTokens.LookupFunc)
 		mockrequire.Called(t, users.GetByIDFunc)
 		mockrequire.Called(t, users.GetByUsernameFunc)
+		mockrequire.Called(t, securityEventLogs.LogEventFunc)
 	})
 
 	t.Run("valid sudo token as a Sourcegraph operator", func(t *testing.T) {

--- a/cmd/frontend/internal/httpapi/auth_test.go
+++ b/cmd/frontend/internal/httpapi/auth_test.go
@@ -84,8 +84,17 @@ func TestAccessTokenAuthMiddleware(t *testing.T) {
 		accessTokens.LookupFunc.SetDefaultReturn(0, database.InvalidTokenError{})
 		db.AccessTokensFunc.SetDefaultReturn(accessTokens)
 
+		securityEventLogs := database.NewMockSecurityEventLogsStore()
+		securityEventLogs.LogEventFunc.SetDefaultHook(func(ctx context.Context, se *database.SecurityEvent) {
+			if want := database.SecurityEventAccessTokenInvalid; se.Name != want {
+				t.Errorf("got %q, want %q", se.Name, want)
+			}
+		})
+		db.SecurityEventLogsFunc.SetDefaultReturn(securityEventLogs)
+
 		checkHTTPResponse(t, db, req, http.StatusUnauthorized, "Invalid access token.\n")
 		mockrequire.Called(t, accessTokens.LookupFunc)
+		mockrequire.Called(t, securityEventLogs.LogEventFunc)
 	})
 
 	for _, headerValue := range []string{"token abcdef", `token token="abcdef"`} {
@@ -287,12 +296,21 @@ func TestAccessTokenAuthMiddleware(t *testing.T) {
 			return &types.User{ID: userID, SiteAdmin: false}, nil
 		})
 
+		securityEventLogsStore := database.NewMockSecurityEventLogsStore()
+		securityEventLogsStore.LogEventFunc.SetDefaultHook(func(_ context.Context, se *database.SecurityEvent) {
+			if want := database.SecurityEventAccessTokenSubjectNotSiteAdmin; se.Name != want {
+				t.Errorf("got %q, want %q", se.Name, want)
+			}
+		})
+
 		db.AccessTokensFunc.SetDefaultReturn(accessTokens)
 		db.UsersFunc.SetDefaultReturn(users)
+		db.SecurityEventLogsFunc.SetDefaultReturn(securityEventLogsStore)
 
 		checkHTTPResponse(t, db, req, http.StatusForbidden, "The subject user of a sudo access token must be a site admin.\n")
 		mockrequire.Called(t, accessTokens.LookupFunc)
 		mockrequire.Called(t, users.GetByIDFunc)
+		mockrequire.Called(t, securityEventLogsStore.LogEventFunc)
 	})
 
 	t.Run("valid sudo token, invalid sudo user", func(t *testing.T) {

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -44,10 +44,12 @@ const (
 
 	SecurityEventNameAccessGranted SecurityEventName = "AccessGranted"
 
-	SecurityEventAccessTokenCreated      SecurityEventName = "AccessTokenCreated"
-	SecurityEventAccessTokenDeleted      SecurityEventName = "AccessTokenDeleted"
-	SecurityEventAccessTokenHardDeleted  SecurityEventName = "AccessTokenHardDeleted"
-	SecurityEventAccessTokenImpersonated SecurityEventName = "AccessTokenImpersonated"
+	SecurityEventAccessTokenCreated             SecurityEventName = "AccessTokenCreated"
+	SecurityEventAccessTokenDeleted             SecurityEventName = "AccessTokenDeleted"
+	SecurityEventAccessTokenHardDeleted         SecurityEventName = "AccessTokenHardDeleted"
+	SecurityEventAccessTokenImpersonated        SecurityEventName = "AccessTokenImpersonated"
+	SecurityEventAccessTokenInvalid             SecurityEventName = "AccessTokenInvalid"
+	SecurityEventAccessTokenSubjectNotSiteAdmin SecurityEventName = "AccessTokenSubjectNotSiteAdmin"
 
 	SecurityEventGitHubAuthSucceeded SecurityEventName = "GitHubAuthSucceeded"
 	SecurityEventGitHubAuthFailed    SecurityEventName = "GitHubAuthFailed"


### PR DESCRIPTION
A branch off https://github.com/sourcegraph/sourcegraph/pull/44843 which does not perform a database migration.

We decided against a database migration in this PR as backcompat issues mean it would need to span two releases, and we want to iterate on audit logs faster. While it gives a cleaner result, the db migration is non-essential.

## Test plan

- [ ] Manual testing
- [ ] Unit tests