### PR TITLE
Cloud CTA on all search results pages

### DIFF
--- a/client/web/src/search/results/SearchResultsInfoBar.test.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.test.tsx
@@ -28,6 +28,7 @@ const COMMON_PROPS: Omit<SearchResultsInfoBarProps, 'enableCodeMonitoring'> = {
     caseSensitive: false,
     setSidebarCollapsed: noop,
     sidebarCollapsed: false,
+    isSourcegraphDotCom: true,
 }
 
 const renderSearchResultsInfoBar = (

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -69,6 +69,8 @@ export interface SearchResultsInfoBarProps
 
     sidebarCollapsed: boolean
     setSidebarCollapsed: (collapsed: boolean) => void
+
+    isSourcegraphDotCom: boolean
 }
 
 /**
@@ -167,18 +169,20 @@ export const SearchResultsInfoBar: React.FunctionComponent<
             <div className={styles.row}>
                 {props.stats}
 
-                <CloudCtaBanner className="mb-5" variant="outlined">
-                    To search across your private repositories,{' '}
-                    <Link
-                        to="https://signup.sourcegraph.com"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        onClick={() => props.telemetryService.log('ClickedOnCloudCTA')}
-                    >
-                        try Sourcegraph Cloud
-                    </Link>
-                    .
-                </CloudCtaBanner>
+                {props.isSourcegraphDotCom && 
+                    <CloudCtaBanner className="mb-5" variant="outlined">
+                        To search across your private repositories,{' '}
+                        <Link
+                            to="https://signup.sourcegraph.com"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            onClick={() => props.telemetryService.log('ClickedOnCloudCTA')}
+                        >
+                            try Sourcegraph Cloud
+                        </Link>
+                        .
+                    </CloudCtaBanner>
+                }
 
                 <div className={styles.expander} />
 

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -169,7 +169,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<
             <div className={styles.row}>
                 {props.stats}
 
-                {props.isSourcegraphDotCom && 
+                {props.isSourcegraphDotCom && (
                     <CloudCtaBanner className="mb-5" variant="outlined">
                         To search across your private repositories,{' '}
                         <Link
@@ -182,7 +182,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<
                         </Link>
                         .
                     </CloudCtaBanner>
-                }
+                )}
 
                 <div className={styles.expander} />
 

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -12,9 +12,10 @@ import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/co
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, Icon } from '@sourcegraph/wildcard'
+import { Button, Icon, Link } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
+import { CloudCtaBanner } from '../../components/CloudCtaBanner'
 
 import {
     getCodeMonitoringCreateAction,
@@ -165,6 +166,19 @@ export const SearchResultsInfoBar: React.FunctionComponent<
         >
             <div className={styles.row}>
                 {props.stats}
+
+                <CloudCtaBanner className="mb-5" variant="outlined">
+                    To search across your private repositories,{' '}
+                    <Link
+                        to="https://signup.sourcegraph.com"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={() => props.telemetryService.log('ClickedOnCloudCTA')}
+                    >
+                        try Sourcegraph Cloud
+                    </Link>
+                    .
+                </CloudCtaBanner>
 
                 <div className={styles.expander} />
 

--- a/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
+++ b/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
@@ -12,6 +12,37 @@ exports[`SearchResultsInfoBar code monitoring feature flag disabled 1`] = `
       class="row"
     >
       <div />
+      <section
+        class="mb-5 d-flex justify-content-center outlined"
+      >
+        <svg
+          aria-hidden="true"
+          class="mdi-icon iconInline iconInlineMd mr-2 text-merged"
+          fill="currentColor"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path
+            d="M4,11V13H16L10.5,18.5L11.92,19.92L19.84,12L11.92,4.08L10.5,5.5L16,11H4Z"
+          />
+        </svg>
+        <p
+          class="my-auto"
+        >
+          To search across your private repositories, 
+          <a
+            class="anchorLink"
+            href="https://signup.sourcegraph.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            try Sourcegraph Cloud
+          </a>
+          .
+        </p>
+      </section>
       <div
         class="expander"
       />
@@ -88,6 +119,37 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
       class="row"
     >
       <div />
+      <section
+        class="mb-5 d-flex justify-content-center outlined"
+      >
+        <svg
+          aria-hidden="true"
+          class="mdi-icon iconInline iconInlineMd mr-2 text-merged"
+          fill="currentColor"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path
+            d="M4,11V13H16L10.5,18.5L11.92,19.92L19.84,12L11.92,4.08L10.5,5.5L16,11H4Z"
+          />
+        </svg>
+        <p
+          class="my-auto"
+        >
+          To search across your private repositories, 
+          <a
+            class="anchorLink"
+            href="https://signup.sourcegraph.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            try Sourcegraph Cloud
+          </a>
+          .
+        </p>
+      </section>
       <div
         class="expander"
       />
@@ -164,6 +226,37 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
       class="row"
     >
       <div />
+      <section
+        class="mb-5 d-flex justify-content-center outlined"
+      >
+        <svg
+          aria-hidden="true"
+          class="mdi-icon iconInline iconInlineMd mr-2 text-merged"
+          fill="currentColor"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path
+            d="M4,11V13H16L10.5,18.5L11.92,19.92L19.84,12L11.92,4.08L10.5,5.5L16,11H4Z"
+          />
+        </svg>
+        <p
+          class="my-auto"
+        >
+          To search across your private repositories, 
+          <a
+            class="anchorLink"
+            href="https://signup.sourcegraph.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            try Sourcegraph Cloud
+          </a>
+          .
+        </p>
+      </section>
       <div
         class="expander"
       />
@@ -240,6 +333,37 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, cannot creat
       class="row"
     >
       <div />
+      <section
+        class="mb-5 d-flex justify-content-center outlined"
+      >
+        <svg
+          aria-hidden="true"
+          class="mdi-icon iconInline iconInlineMd mr-2 text-merged"
+          fill="currentColor"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path
+            d="M4,11V13H16L10.5,18.5L11.92,19.92L19.84,12L11.92,4.08L10.5,5.5L16,11H4Z"
+          />
+        </svg>
+        <p
+          class="my-auto"
+        >
+          To search across your private repositories, 
+          <a
+            class="anchorLink"
+            href="https://signup.sourcegraph.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            try Sourcegraph Cloud
+          </a>
+          .
+        </p>
+      </section>
       <div
         class="expander"
       />
@@ -316,6 +440,37 @@ exports[`SearchResultsInfoBar unauthenticated user 1`] = `
       class="row"
     >
       <div />
+      <section
+        class="mb-5 d-flex justify-content-center outlined"
+      >
+        <svg
+          aria-hidden="true"
+          class="mdi-icon iconInline iconInlineMd mr-2 text-merged"
+          fill="currentColor"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+        >
+          <path
+            d="M4,11V13H16L10.5,18.5L11.92,19.92L19.84,12L11.92,4.08L10.5,5.5L16,11H4Z"
+          />
+        </svg>
+        <p
+          class="my-auto"
+        >
+          To search across your private repositories, 
+          <a
+            class="anchorLink"
+            href="https://signup.sourcegraph.com"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            try Sourcegraph Cloud
+          </a>
+          .
+        </p>
+      </section>
       <div
         class="expander"
       />


### PR DESCRIPTION
This closes #43902 and adds a Cloud CTA to all search results pages.

## Test plan
Ensure the Cloud CTA logs the `ClickedOnCloudCTA` event and navigates to the signup subdomain.

## App preview:

- [Web](https://sg-web-brett-search-results-cta.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
