### PR TITLE
Check link header to see if paginated results have a next page

### DIFF
--- a/internal/extsvc/github/testdata/vcr/ListRepositoryCollaborators_has-next-page-is-true.yaml
+++ b/internal/extsvc/github/testdata/vcr/ListRepositoryCollaborators_has-next-page-is-true.yaml
@@ -1,0 +1,75 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      - application/vnd.github.machine-man-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/repos/sourcegraph-vcr/private-repo-1/collaborators?page=1&per_page=100&affiliation=direct
+    method: GET
+  response:
+    body: '[{"id":1,"node_id":"1"},{"id":2,"node_id":"2"},{"id":3,"node_id":"3"},{"id":4,"node_id":"4"},{"id":5,"node_id":"5"},{"id":6,"node_id":"6"},{"id":7,"node_id":"7"},{"id":8,"node_id":"8"},{"id":9,"node_id":"9"},{"id":10,"node_id":"10"},{"id":11,"node_id":"11"},{"id":12,"node_id":"12"},{"id":13,"node_id":"13"},{"id":14,"node_id":"14"},{"id":15,"node_id":"15"},{"id":16,"node_id":"16"},{"id":17,"node_id":"17"},{"id":18,"node_id":"18"},{"id":19,"node_id":"19"},{"id":20,"node_id":"20"},{"id":21,"node_id":"21"},{"id":22,"node_id":"22"},{"id":23,"node_id":"23"},{"id":24,"node_id":"24"},{"id":25,"node_id":"25"},{"id":26,"node_id":"26"},{"id":27,"node_id":"27"},{"id":28,"node_id":"28"},{"id":29,"node_id":"29"},{"id":30,"node_id":"30"},{"id":31,"node_id":"31"},{"id":32,"node_id":"32"},{"id":33,"node_id":"33"},{"id":34,"node_id":"34"},{"id":35,"node_id":"35"},{"id":36,"node_id":"36"},{"id":37,"node_id":"37"},{"id":38,"node_id":"38"},{"id":39,"node_id":"39"},{"id":40,"node_id":"40"},{"id":41,"node_id":"41"},{"id":42,"node_id":"42"},{"id":43,"node_id":"43"},{"id":44,"node_id":"44"},{"id":45,"node_id":"45"},{"id":46,"node_id":"46"},{"id":47,"node_id":"47"},{"id":48,"node_id":"48"},{"id":49,"node_id":"49"},{"id":50,"node_id":"50"},{"id":51,"node_id":"51"},{"id":52,"node_id":"52"},{"id":53,"node_id":"53"},{"id":54,"node_id":"54"},{"id":55,"node_id":"55"},{"id":56,"node_id":"56"},{"id":57,"node_id":"57"},{"id":58,"node_id":"58"},{"id":59,"node_id":"59"},{"id":60,"node_id":"60"},{"id":61,"node_id":"61"},{"id":62,"node_id":"62"},{"id":63,"node_id":"63"},{"id":64,"node_id":"64"},{"id":65,"node_id":"65"},{"id":66,"node_id":"66"},{"id":67,"node_id":"67"},{"id":68,"node_id":"68"},{"id":69,"node_id":"69"},{"id":70,"node_id":"70"},{"id":71,"node_id":"71"},{"id":72,"node_id":"72"},{"id":73,"node_id":"73"},{"id":74,"node_id":"74"},{"id":75,"node_id":"75"},{"id":76,"node_id":"76"},{"id":77,"node_id":"77"},{"id":78,"node_id":"78"},{"id":79,"node_id":"79"},{"id":80,"node_id":"80"},{"id":81,"node_id":"81"},{"id":82,"node_id":"82"},{"id":83,"node_id":"83"},{"id":84,"node_id":"84"},{"id":85,"node_id":"85"},{"id":86,"node_id":"86"},{"id":87,"node_id":"87"},{"id":88,"node_id":"88"},{"id":89,"node_id":"89"},{"id":90,"node_id":"90"},{"id":91,"node_id":"91"},{"id":92,"node_id":"92"},{"id":93,"node_id":"93"},{"id":94,"node_id":"94"},{"id":95,"node_id":"95"},{"id":96,"node_id":"96"},{"id":97,"node_id":"97"},{"id":98,"node_id":"98"},{"id":99,"node_id":"99"},{"id":100,"node_id":"100"}]'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation,
+        Sunset
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 26 Aug 2021 17:04:20 GMT
+      Etag:
+      - W/"004e6fa8f639ea15fbd52f99573c2d6d2ae208032340ba0e6fa7506835be9734"
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Link:
+      - <https://api.github.com/sourcegraph-vcr/private-repo-1/collaborators?page=2&per_page=100&affiliation=direct>; rel="next", <https://api.github.com/sourcegraph-vcr/private-repo-1/collaborators?page=8&per_page=100&affiliation=direct>; rel="last"
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-Oauth-Scopes:
+      - ""
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; param=machine-man-preview;
+        format=json
+      X-Github-Request-Id:
+      - CEFE:2DE9:C643:25CAC:6127C993
+      X-Oauth-Scopes:
+      - admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
+        admin:repo_hook, delete:packages, delete_repo, gist, notifications, repo,
+        user, workflow, write:discussion, write:packages
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4974"
+      X-Ratelimit-Reset:
+      - "1630000235"
+      X-Ratelimit-Resource:
+      - core
+      X-Ratelimit-Used:
+      - "26"
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -314,11 +314,11 @@ func (c *V3Client) GetAuthenticatedUserOrgsForPage(ctx context.Context, page int
 		return orgsPage, page < len(MockGetAuthenticatedUserOrgs.PagesMock), 1, err
 	}
 
-	_, err = c.get(ctx, fmt.Sprintf("/user/orgs?per_page=100&page=%d", page), &orgs)
+	responseState, err := c.get(ctx, fmt.Sprintf("/user/orgs?per_page=100&page=%d", page), &orgs)
 	if err != nil {
 		return
 	}
-	return orgs, len(orgs) > 0, 1, err
+	return orgs, responseHasNextPage(*responseState), 1, err
 }
 
 // OrgDetailsAndMembership is a results container for the results from the API calls made
@@ -393,7 +393,7 @@ func (c *V3Client) GetAuthenticatedUserTeams(ctx context.Context, page int) (
 	}
 
 	var restTeams []*restTeam
-	_, err = c.get(ctx, fmt.Sprintf("/user/teams?per_page=100&page=%d", page), &restTeams)
+	responseState, err := c.get(ctx, fmt.Sprintf("/user/teams?per_page=100&page=%d", page), &restTeams)
 	if err != nil {
 		return
 	}
@@ -403,7 +403,7 @@ func (c *V3Client) GetAuthenticatedUserTeams(ctx context.Context, page int) (
 		teams[i] = t.convert()
 	}
 
-	return teams, len(teams) > 0, 1, err
+	return teams, responseHasNextPage(*responseState), 1, err
 }
 
 var MockGetAuthenticatedOAuthScopes func(ctx context.Context) ([]string, error)
@@ -436,11 +436,11 @@ func (c *V3Client) ListRepositoryCollaborators(ctx context.Context, owner, repo 
 	if len(affiliation) > 0 {
 		path = fmt.Sprintf("%s&affiliation=%s", path, affiliation)
 	}
-	_, err := c.get(ctx, path, &users)
+	responseState, err := c.get(ctx, path, &users)
 	if err != nil {
 		return nil, false, err
 	}
-	return users, len(users) > 0, nil
+	return users, responseHasNextPage(*responseState), nil
 }
 
 // ListRepositoryTeams lists GitHub teams that has access to the repository.
@@ -450,7 +450,7 @@ func (c *V3Client) ListRepositoryCollaborators(ctx context.Context, owner, repo 
 func (c *V3Client) ListRepositoryTeams(ctx context.Context, owner, repo string, page int) (teams []*Team, hasNextPage bool, _ error) {
 	path := fmt.Sprintf("/repos/%s/%s/teams?page=%d&per_page=100", owner, repo, page)
 	var restTeams []*restTeam
-	_, err := c.get(ctx, path, &restTeams)
+	responseState, err := c.get(ctx, path, &restTeams)
 	if err != nil {
 		return nil, false, err
 	}
@@ -458,7 +458,7 @@ func (c *V3Client) ListRepositoryTeams(ctx context.Context, owner, repo string, 
 	for i, t := range restTeams {
 		teams[i] = t.convert()
 	}
-	return teams, len(teams) > 0, nil
+	return teams, responseHasNextPage(*responseState), nil
 }
 
 // GetRepository gets a repository from GitHub by owner and repository name.
@@ -523,11 +523,11 @@ func (c *V3Client) ListOrganizationMembers(ctx context.Context, owner string, pa
 	if adminsOnly {
 		path += "&role=admin"
 	}
-	_, err := c.get(ctx, path, &users)
+	responseState, err := c.get(ctx, path, &users)
 	if err != nil {
 		return nil, false, err
 	}
-	return users, len(users) > 0, nil
+	return users, responseHasNextPage(*responseState), nil
 }
 
 // ListTeamMembers retrieves collaborators in the given team.
@@ -537,11 +537,11 @@ func (c *V3Client) ListOrganizationMembers(ctx context.Context, owner string, pa
 // be for page 1).
 func (c *V3Client) ListTeamMembers(ctx context.Context, owner, team string, page int) (users []*Collaborator, hasNextPage bool, _ error) {
 	path := fmt.Sprintf("/orgs/%s/teams/%s/members?page=%d&per_page=100", owner, team, page)
-	_, err := c.get(ctx, path, &users)
+	responseState, err := c.get(ctx, path, &users)
 	if err != nil {
 		return nil, false, err
 	}
-	return users, len(users) > 0, nil
+	return users, responseHasNextPage(*responseState), nil
 }
 
 // getPublicRepositories returns a page of public repositories that were created
@@ -549,7 +549,7 @@ func (c *V3Client) ListTeamMembers(ctx context.Context, owner, team string, page
 // An empty sinceRepoID returns the first page of results.
 // This is only intended to be called for GitHub Enterprise, so no rate limit information is returned.
 // https://developer.github.com/v3/repos/#list-all-public-repositories
-func (c *V3Client) getPublicRepositories(ctx context.Context, sinceRepoID int64) ([]*Repository, error) {
+func (c *V3Client) getPublicRepositories(ctx context.Context, sinceRepoID int64) ([]*Repository, bool, error) {
 	path := "repositories"
 	if sinceRepoID > 0 {
 		path += "?per_page=100&since=" + strconv.FormatInt(sinceRepoID, 10)
@@ -557,12 +557,8 @@ func (c *V3Client) getPublicRepositories(ctx context.Context, sinceRepoID int64)
 	return c.listRepositories(ctx, path)
 }
 
-func (c *V3Client) ListPublicRepositories(ctx context.Context, sinceRepoID int64) ([]*Repository, error) {
-	repos, err := c.getPublicRepositories(ctx, sinceRepoID)
-	if err != nil {
-		return nil, err
-	}
-	return repos, nil
+func (c *V3Client) ListPublicRepositories(ctx context.Context, sinceRepoID int64) ([]*Repository, bool, error) {
+	return c.getPublicRepositories(ctx, sinceRepoID)
 }
 
 // ListAffiliatedRepositories lists GitHub repositories affiliated with the client token.
@@ -584,9 +580,9 @@ func (c *V3Client) ListAffiliatedRepositories(ctx context.Context, visibility Vi
 		}
 		path = fmt.Sprintf("%s&affiliation=%s", path, strings.Join(affilationsStrings, ","))
 	}
-	repos, err = c.listRepositories(ctx, path)
+	repos, hasNextPage, err = c.listRepositories(ctx, path)
 
-	return repos, len(repos) > 0, 1, err
+	return repos, hasNextPage, 1, err
 }
 
 // ListOrgRepositories lists GitHub repositories from the specified organization.
@@ -594,8 +590,8 @@ func (c *V3Client) ListAffiliatedRepositories(ctx context.Context, visibility Vi
 // Pages are 1-indexed (so the first call should be for page 1).
 func (c *V3Client) ListOrgRepositories(ctx context.Context, org string, page int, repoType string) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
 	path := fmt.Sprintf("orgs/%s/repos?sort=created&page=%d&per_page=100&type=%s", org, page, repoType)
-	repos, err = c.listRepositories(ctx, path)
-	return repos, len(repos) > 0, 1, err
+	repos, hasNextPage, err = c.listRepositories(ctx, path)
+	return repos, hasNextPage, 1, err
 }
 
 // ListTeamRepositories lists GitHub repositories from the specified team.
@@ -603,16 +599,16 @@ func (c *V3Client) ListOrgRepositories(ctx context.Context, org string, page int
 // page is the page of results to return. Pages are 1-indexed (so the first call should be for page 1).
 func (c *V3Client) ListTeamRepositories(ctx context.Context, org, team string, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
 	path := fmt.Sprintf("orgs/%s/teams/%s/repos?page=%d&per_page=100", org, team, page)
-	repos, err = c.listRepositories(ctx, path)
-	return repos, len(repos) > 0, 1, err
+	repos, hasNextPage, err = c.listRepositories(ctx, path)
+	return repos, hasNextPage, 1, err
 }
 
 // ListUserRepositories lists GitHub repositories from the specified user.
 // Pages are 1-indexed (so the first call should be for page 1)
 func (c *V3Client) ListUserRepositories(ctx context.Context, user string, page int) (repos []*Repository, hasNextPage bool, rateLimitCost int, err error) {
 	path := fmt.Sprintf("users/%s/repos?sort=created&type=owner&page=%d&per_page=100", user, page)
-	repos, err = c.listRepositories(ctx, path)
-	return repos, len(repos) > 0, 1, err
+	repos, hasNextPage, err = c.listRepositories(ctx, path)
+	return repos, hasNextPage, 1, err
 }
 
 func (c *V3Client) ListRepositoriesForSearch(ctx context.Context, searchString string, page int) (RepositoryListPage, error) {
@@ -673,14 +669,15 @@ func (c *V3Client) ListInstallationRepositories(ctx context.Context, page int) (
 	}
 	var resp response
 	path := fmt.Sprintf("installation/repositories?page=%d&per_page=100", page)
-	if _, err = c.get(ctx, path, &resp); err != nil {
+	responseState, err := c.get(ctx, path, &resp)
+	if err != nil {
 		return nil, false, 1, err
 	}
 	repos = make([]*Repository, 0, len(resp.Repositories))
 	for _, restRepo := range resp.Repositories {
 		repos = append(repos, convertRestRepo(restRepo))
 	}
-	return repos, len(repos) > 0, 1, nil
+	return repos, responseHasNextPage(*responseState), 1, nil
 }
 
 // listRepositories is a generic method that unmarshalls the given JSON HTTP
@@ -690,25 +687,17 @@ func (c *V3Client) ListInstallationRepositories(ctx context.Context, page int) (
 // - /users/:user/repos
 // - /orgs/:org/repos
 // - /user/repos
-func (c *V3Client) listRepositories(ctx context.Context, requestURI string) ([]*Repository, error) {
+func (c *V3Client) listRepositories(ctx context.Context, requestURI string) ([]*Repository, bool, error) {
 	var restRepos []restRepository
-	if res, err := c.get(ctx, requestURI, &restRepos); err != nil {
-		if res != nil {
-			link := res.headers.Get("Link")
-			// If we've reached beyond the last page then GitHub API returns 404 with link to
-			// the first page, but does NOT contain link to the next page. link to the next
-			// page is typically included in 200 response Link header
-			if res.statusCode == http.StatusNotFound && strings.Contains(link, `rel="first"`) && !strings.Contains(link, `rel="next"`) {
-				return []*Repository{}, nil
-			}
-		}
-		return nil, err
+	res, err := c.get(ctx, requestURI, &restRepos)
+	if err != nil {
+		return nil, false, err
 	}
 	repos := make([]*Repository, 0, len(restRepos))
 	for _, restRepo := range restRepos {
 		repos = append(repos, convertRestRepo(restRepo))
 	}
-	return repos, nil
+	return repos, responseHasNextPage(*res), nil
 }
 
 // Fork forks the given repository. If org is given, then the repository will
@@ -913,4 +902,11 @@ func webhookURLBuilderWithID(repoName string, hookID int) (string, error) {
 		return fmt.Sprintf("https://api.github.com/repos%s/hooks/%d", u.Path, hookID), nil
 	}
 	return fmt.Sprintf("https://%s/api/v3/repos%s/hooks/%d", u.Host, u.Path, hookID), nil
+}
+
+// responseHasNextPage checks if the Link header of the response contains a
+// URL tagged with rel="next".
+// If this header is not present, it also means there is only one page.
+func responseHasNextPage(responseState httpResponseState) bool {
+	return strings.Contains(responseState.headers.Get("Link"), "rel=\"next\"")
 }

--- a/internal/extsvc/github/v3_test.go
+++ b/internal/extsvc/github/v3_test.go
@@ -174,11 +174,12 @@ func Test_GetAuthenticatedOAuthScopes(t *testing.T) {
 // for GITHUB_TOKEN, which can be found in 1Password.
 func TestListRepositoryCollaborators(t *testing.T) {
 	tests := []struct {
-		name        string
-		owner       string
-		repo        string
-		affiliation CollaboratorAffiliation
-		wantUsers   []*Collaborator
+		name            string
+		owner           string
+		repo            string
+		affiliation     CollaboratorAffiliation
+		wantUsers       []*Collaborator
+		wantHasNextPage bool
 	}{
 		{
 			name:  "public repo",
@@ -190,6 +191,7 @@ func TestListRepositoryCollaborators(t *testing.T) {
 					DatabaseID: 63290851,
 				},
 			},
+			wantHasNextPage: false,
 		},
 		{
 			name:  "private repo",
@@ -210,6 +212,7 @@ func TestListRepositoryCollaborators(t *testing.T) {
 					DatabaseID: 89494884,
 				},
 			},
+			wantHasNextPage: false,
 		},
 		{
 			name:        "direct collaborator outside collaborator",
@@ -222,6 +225,7 @@ func TestListRepositoryCollaborators(t *testing.T) {
 					DatabaseID: 66464926,
 				},
 			},
+			wantHasNextPage: false,
 		},
 		{
 			name:        "direct collaborator repo owner",
@@ -234,6 +238,15 @@ func TestListRepositoryCollaborators(t *testing.T) {
 					DatabaseID: 63290851,
 				},
 			},
+			wantHasNextPage: false,
+		},
+		{
+			name:            "has next page is true",
+			owner:           "sourcegraph-vcr",
+			repo:            "private-repo-1",
+			affiliation:     AffiliationDirect,
+			wantUsers:       nil,
+			wantHasNextPage: true,
 		},
 	}
 	for _, test := range tests {
@@ -241,13 +254,19 @@ func TestListRepositoryCollaborators(t *testing.T) {
 			client, save := newV3TestClient(t, "ListRepositoryCollaborators_"+test.name)
 			defer save()
 
-			users, _, err := client.ListRepositoryCollaborators(context.Background(), test.owner, test.repo, 1, test.affiliation)
+			users, hasNextPage, err := client.ListRepositoryCollaborators(context.Background(), test.owner, test.repo, 1, test.affiliation)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if diff := cmp.Diff(test.wantUsers, users); diff != "" {
-				t.Fatalf("Users mismatch (-want +got):\n%s", diff)
+			if test.wantUsers != nil {
+				if diff := cmp.Diff(test.wantUsers, users); diff != "" {
+					t.Fatalf("Users mismatch (-want +got):\n%s", diff)
+				}
+			}
+
+			if diff := cmp.Diff(test.wantHasNextPage, hasNextPage); diff != "" {
+				t.Fatalf("HasNextPage mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -481,7 +500,6 @@ func TestGetRepository(t *testing.T) {
 			if remaining2 < remaining {
 				t.Fatalf("expected cached repsonse, but API quota used")
 			}
-
 		})
 	})
 
@@ -497,7 +515,6 @@ func TestGetRepository(t *testing.T) {
 			t.Error("repo != nil")
 		}
 	})
-
 }
 
 // ListOrganizations is primarily used for GitHub Enterprise clients. As a result we test against
@@ -792,7 +809,6 @@ func TestClient_ListRepositoriesForSearch(t *testing.T) {
 
 	rcache.SetupForTest(t)
 	reposPage, err := cli.ListRepositoriesForSearch(context.Background(), "org:sourcegraph-vcr-repos", 1)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -806,7 +822,6 @@ func TestClient_ListRepositoriesForSearch(t *testing.T) {
 		update("ListRepositoriesForSearch"),
 		reposPage.Repos,
 	)
-
 }
 
 func TestClient_ListRepositoriesForSearch_incomplete(t *testing.T) {

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -639,12 +639,12 @@ func (s *GitHubSource) listPublic(ctx context.Context, results chan *githubResul
 			return
 		}
 
-		repos, err := s.v3Client.ListPublicRepositories(ctx, sinceRepoID)
+		repos, hasNextPage, err := s.v3Client.ListPublicRepositories(ctx, sinceRepoID)
 		if err != nil {
 			results <- &githubResult{err: errors.Wrapf(err, "failed to list public repositories: sinceRepoID=%d", sinceRepoID)}
 			return
 		}
-		if len(repos) == 0 {
+		if !hasNextPage {
 			return
 		}
 		s.logger.Debug("github sync public", log.Int("repos", len(repos)), log.Error(err))


### PR DESCRIPTION
Original PR by @mrnugget : https://github.com/sourcegraph/sourcegraph/pull/44950

Changes all paginated GitHub requests to check the link header for a next page and use that to determine whether or not there is a next page, instead of comparing result lengths.

## Test plan

Additional test added by @kopancek that contains a link header

Also did a manual check on every endpoint used in `v3.go` to confirm that the link header is returned for paginated results.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
