### PR TITLE
resolve generic incomplete messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The number of commits listed in the History tab can now be customized for all users by site admins under Configuration -> Global Settings from the site admin page by using the config `history.defaultPageSize`. Individual users may also set `history.defaultPagesize` from their user settings page to override the value set under the Global Settings. [#44651](https://github.com/sourcegraph/sourcegraph/pull/44651)
 - Batch Changes: Mounted files can be accessed via the UI on the executions page. [#43180](https://github.com/sourcegraph/sourcegraph/pull/43180)
 - Added "Outbound request log" feature for site admins [#44286](https://github.com/sourcegraph/sourcegraph/pull/44286)
+- Code Insights: the data series API now provides information about incomplete datapoints during processing
 
 ### Changed
 

--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -452,9 +452,15 @@ type SearchInsightLivePreviewSeriesResolver interface {
 
 type IncompleteDatapointAlert interface {
 	ToTimeoutDatapointAlert() (TimeoutDatapointAlert, bool)
+	ToGenericIncompleteDatapointAlert() (GenericIncompleteDatapointAlert, bool)
 	Time() gqlutil.DateTime
 }
 
 type TimeoutDatapointAlert interface {
 	Time() gqlutil.DateTime
+}
+
+type GenericIncompleteDatapointAlert interface {
+	Time() gqlutil.DateTime
+	Reason() string
 }

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -174,6 +174,9 @@ type TimeoutDatapointAlert implements IncompleteDatapointAlert {
     time: DateTime!
 }
 
+"""
+Represents a terminally incomplete data point at a specific time.
+"""
 type GenericIncompleteDatapointAlert implements IncompleteDatapointAlert {
     """
     The data point that is incomplete.

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -175,7 +175,7 @@ type TimeoutDatapointAlert implements IncompleteDatapointAlert {
 }
 
 """
-Represents a terminally incomplete data point at a specific time.
+Represents a terminally incomplete data point at a specific time. Only returns alerts that do not satisfy a specific implementation.
 """
 type GenericIncompleteDatapointAlert implements IncompleteDatapointAlert {
     """

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -174,6 +174,18 @@ type TimeoutDatapointAlert implements IncompleteDatapointAlert {
     time: DateTime!
 }
 
+type GenericIncompleteDatapointAlert implements IncompleteDatapointAlert {
+    """
+    The data point that is incomplete.
+    """
+    time: DateTime!
+
+    """
+    A message describing why the datapoint was marked incomplete.
+    """
+    reason: String!
+}
+
 extend type Query {
     """
     Return dashboards visible to the authenticated user.

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -558,8 +558,6 @@ func (g *genericIncompleteDatapointAlertResolver) Time() gqlutil.DateTime {
 
 func (g *genericIncompleteDatapointAlertResolver) Reason() string {
 	switch g.point.Reason {
-	case store.ReasonTimeout:
-		return "Search timeouts during data processing caused this point to be incomplete."
 	default:
 		return "There was an issue during data processing that caused this point to be incomplete."
 	}

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -518,13 +518,10 @@ func streamingSeriesJustInTime(ctx context.Context, definition types.InsightView
 }
 
 var _ graphqlbackend.TimeoutDatapointAlert = &timeoutDatapointAlertResolver{}
-
-// var _ graphqlbackend.IncompleteDatapointAlert = &timeoutDatapointAlertResolver{}
+var _ graphqlbackend.GenericIncompleteDatapointAlert = &genericIncompleteDatapointAlertResolver{}
 var _ graphqlbackend.IncompleteDatapointAlert = &IncompleteDataPointAlertResolver{}
 
 type IncompleteDataPointAlertResolver struct {
-	// resolver any
-	// graphqlbackend.IncompleteDatapointAlert
 	point store.IncompleteDatapoint
 }
 
@@ -532,10 +529,11 @@ func (i *IncompleteDataPointAlertResolver) ToTimeoutDatapointAlert() (graphqlbac
 	if i.point.Reason == store.ReasonTimeout {
 		return &timeoutDatapointAlertResolver{point: i.point}, true
 	}
-
-	// t, ok := i.resolver.(graphqlbackend.TimeoutDatapointAlert)
-	// return t, ok
 	return nil, false
+}
+
+func (i *IncompleteDataPointAlertResolver) ToGenericIncompleteDatapointAlert() (graphqlbackend.GenericIncompleteDatapointAlert, bool) {
+	return &genericIncompleteDatapointAlertResolver{point: i.point}, true
 }
 
 func (i *IncompleteDataPointAlertResolver) Time() gqlutil.DateTime {
@@ -544,11 +542,27 @@ func (i *IncompleteDataPointAlertResolver) Time() gqlutil.DateTime {
 
 type timeoutDatapointAlertResolver struct {
 	point store.IncompleteDatapoint
-	baseInsightResolver
 }
 
 func (t *timeoutDatapointAlertResolver) Time() gqlutil.DateTime {
 	return gqlutil.DateTime{Time: t.point.Time}
+}
+
+type genericIncompleteDatapointAlertResolver struct {
+	point store.IncompleteDatapoint
+}
+
+func (g *genericIncompleteDatapointAlertResolver) Time() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: g.point.Time}
+}
+
+func (g *genericIncompleteDatapointAlertResolver) Reason() string {
+	switch g.point.Reason {
+	case store.ReasonTimeout:
+		return "Search timeouts during data processing caused this point to be incomplete."
+	default:
+		return "There was an issue during data processing that caused this point to be incomplete."
+	}
 }
 
 func (i *insightStatusResolver) IncompleteDatapoints(ctx context.Context) (resolvers []graphqlbackend.IncompleteDatapointAlert, err error) {

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -533,6 +533,10 @@ func (i *IncompleteDataPointAlertResolver) ToTimeoutDatapointAlert() (graphqlbac
 }
 
 func (i *IncompleteDataPointAlertResolver) ToGenericIncompleteDatapointAlert() (graphqlbackend.GenericIncompleteDatapointAlert, bool) {
+	switch i.point.Reason {
+	case store.ReasonTimeout:
+		return nil, false
+	}
 	return &genericIncompleteDatapointAlertResolver{point: i.point}, true
 }
 


### PR DESCRIPTION
Adds a generic incomplete datapoint resolver that will return an error message. This is going to be used to add new error types to surface to the user that won't necessarily warrant their own UI / special consideration.

cc @vovakulikov 

## Test plan
example response

``` json
{
          "id": "aW5zaWdodF92aWV3OiIySEhaSkg2emxyY29zcHFrdGgxdzdIcEw0cXIi",
          "dataSeries": [
            {
              "status": {
                "incompleteDatapoints": [
                  {
                    "__typename": "GenericIncompleteDatapointAlert",
                    "reason": "There was an issue during data processing that caused this point to be incomplete.",
                    "time": "2022-05-08T00:00:00Z"
                  },
                  {
                    "__typename": "GenericIncompleteDatapointAlert",
                    "reason": "There was an issue during data processing that caused this point to be incomplete.",
                    "time": "2022-09-08T00:00:00Z"
                  },
                  {
                    "__typename": "GenericIncompleteDatapointAlert",
                    "reason": "There was an issue during data processing that caused this point to be incomplete.",
                    "time": "2022-03-08T00:00:00Z"
                  },
                  {
                    "__typename": "GenericIncompleteDatapointAlert",
                    "reason": "There was an issue during data processing that caused this point to be incomplete.",
                    "time": "2021-03-08T00:00:00Z"
                  },
                  {
                    "__typename": "GenericIncompleteDatapointAlert",
                    "reason": "There was an issue during data processing that caused this point to be incomplete.",
                    "time": "2021-01-08T00:00:00Z"
                  },
                  {
                    "__typename": "GenericIncompleteDatapointAlert",
                    "reason": "There was an issue during data processing that caused this point to be incomplete.",
                    "time": "2022-07-08T00:00:00Z"
                  },
                  {
                    "__typename": "GenericIncompleteDatapointAlert",
                    "reason": "There was an issue during data processing that caused this point to be incomplete.",
                    "time": "2022-01-08T00:00:00Z"
                  },
                  {
                    "__typename": "GenericIncompleteDatapointAlert",
                    "reason": "There was an issue during data processing that caused this point to be incomplete.",
                    "time": "2021-07-08T00:00:00Z"
                  },
                  {
                    "__typename": "GenericIncompleteDatapointAlert",
                    "reason": "There was an issue during data processing that caused this point to be incomplete.",
                    "time": "2021-09-08T00:00:00Z"
                  },
                  {
                    "__typename": "GenericIncompleteDatapointAlert",
                    "reason": "There was an issue during data processing that caused this point to be incomplete.",
                    "time": "2022-11-08T00:00:00Z"
                  },
                  {
                    "__typename": "GenericIncompleteDatapointAlert",
                    "reason": "There was an issue during data processing that caused this point to be incomplete.",
                    "time": "2021-11-08T00:00:00Z"
                  },
                  {
                    "__typename": "GenericIncompleteDatapointAlert",
                    "reason": "There was an issue during data processing that caused this point to be incomplete.",
                    "time": "2021-05-08T00:00:00Z"
                  }
                ]
              }
            }
          ]
        },
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
