### PR TITLE
Sign Up journey UI fixes

### DIFF
--- a/client/search-ui/src/input/SearchContextDropdown.tsx
+++ b/client/search-ui/src/input/SearchContextDropdown.tsx
@@ -160,7 +160,7 @@ export const SearchContextDropdown: FC<SearchContextDropdownProps> = props => {
             </Tooltip>
             <PopoverContent
                 position={Position.bottomStart}
-                className={classNames('a11y-ignore', styles.menu)}
+                className={classNames('a11y-ignore overflow-hidden', styles.menu)}
                 data-testid="dropdown-content"
                 targetPadding={popoverPadding}
             >

--- a/client/search-ui/src/input/SearchContextMenu.module.scss
+++ b/client/search-ui/src/input/SearchContextMenu.module.scss
@@ -107,6 +107,7 @@
     }
     &-icon {
         font-size: 1.2rem;
+        max-height: 1.29rem;
     }
 }
 

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -175,7 +175,11 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
                 </PageHeader.Heading>
             </PageHeader>
             <BatchChangesListIntro isLicensed={licenseAndUsageInfo?.batchChanges || licenseAndUsageInfo?.campaigns} />
-            <BatchChangeListTabHeader selectedTab={selectedTab} setSelectedTab={setSelectedTab} isSourcegraphDotCom={isSourcegraphDotCom} />
+            <BatchChangeListTabHeader
+                selectedTab={selectedTab}
+                setSelectedTab={setSelectedTab}
+                isSourcegraphDotCom={isSourcegraphDotCom}
+            />
             {selectedTab === 'gettingStarted' && (
                 <GettingStarted isSourcegraphDotCom={isSourcegraphDotCom} className="mb-4" />
             )}

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -175,7 +175,7 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
                 </PageHeader.Heading>
             </PageHeader>
             <BatchChangesListIntro isLicensed={licenseAndUsageInfo?.batchChanges || licenseAndUsageInfo?.campaigns} />
-            <BatchChangeListTabHeader selectedTab={selectedTab} setSelectedTab={setSelectedTab} />
+            <BatchChangeListTabHeader selectedTab={selectedTab} setSelectedTab={setSelectedTab} isSourcegraphDotCom={isSourcegraphDotCom} />
             {selectedTab === 'gettingStarted' && (
                 <GettingStarted isSourcegraphDotCom={isSourcegraphDotCom} className="mb-4" />
             )}
@@ -282,8 +282,9 @@ const BatchChangeListTabHeader: React.FunctionComponent<
     React.PropsWithChildren<{
         selectedTab: SelectedTab
         setSelectedTab: (selectedTab: SelectedTab) => void
+        isSourcegraphDotCom: boolean
     }>
-> = ({ selectedTab, setSelectedTab }) => {
+> = ({ selectedTab, setSelectedTab, isSourcegraphDotCom }) => {
     const onSelectBatchChanges = useCallback<React.MouseEventHandler>(
         event => {
             event.preventDefault()
@@ -301,19 +302,21 @@ const BatchChangeListTabHeader: React.FunctionComponent<
     return (
         <nav className="overflow-auto mb-2" aria-label="Batch Changes">
             <div className="nav nav-tabs d-inline-flex d-sm-flex flex-nowrap text-nowrap" role="tablist">
-                <div className="nav-item">
-                    <Link
-                        to=""
-                        onClick={onSelectBatchChanges}
-                        className={classNames('nav-link', selectedTab === 'batchChanges' && 'active')}
-                        aria-selected={selectedTab === 'batchChanges'}
-                        role="tab"
-                    >
-                        <span className="text-content" data-tab-content="All batch changes">
-                            All batch changes
-                        </span>
-                    </Link>
-                </div>
+                {!isSourcegraphDotCom && (
+                    <div className="nav-item">
+                        <Link
+                            to=""
+                            onClick={onSelectBatchChanges}
+                            className={classNames('nav-link', selectedTab === 'batchChanges' && 'active')}
+                            aria-selected={selectedTab === 'batchChanges'}
+                            role="tab"
+                        >
+                            <span className="text-content" data-tab-content="All batch changes">
+                                All batch changes
+                            </span>
+                        </Link>
+                    </div>
+                )}
                 <div className="nav-item">
                     <Link
                         to=""

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -104,7 +104,7 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
 
     const showList = userHasCodeMonitors !== undefined && !isErrorLike(userHasCodeMonitors) && currentTab === 'list'
 
-    const showLogsTab = useExperimentalFeatures(features => features.showCodeMonitoringLogs)
+    const showLogsTab = useExperimentalFeatures(features => features.showCodeMonitoringLogs) && authenticatedUser
 
     return (
         <div className="code-monitoring-page" data-testid="code-monitoring-page">


### PR DESCRIPTION
Closes #44786 - Minor UI fixes

1) No double nested scrollable sections in context popover
![image](https://user-images.githubusercontent.com/59381432/204886138-7ad12261-3f1f-4bc9-848b-a34b5da0e8f3.png)
2) Aligns purple icon with paragraph vertical start
![image](https://user-images.githubusercontent.com/59381432/204886177-c4b9a4bc-fbcf-482d-b9c6-197a405118d9.png)
3) Hides inaccessible `Logs` tab from Code monitoring for **unauth'd users**
![image](https://user-images.githubusercontent.com/59381432/204886376-25d48783-da70-4aa7-9400-456e197ba68d.png)
4) Hides inaccessible `All batch changes` tab from Batch changes product page for **dotcom users**
![image](https://user-images.githubusercontent.com/59381432/204886565-1dc7d792-e41e-4eda-84fe-a0b612bfc7f7.png)

## Test plan
- Test for listed UI changes & no broken changes for these on other env's

## App preview:

- [Web](https://sg-web-becca-signup-journey-ui-fixes.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
