### PR TITLE
codeintel: Add manager to monikers/package information

### DIFF
--- a/enterprise/internal/codeintel/autoindexing/internal/background/job_dependency_indexing_scheduler.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/job_dependency_indexing_scheduler.go
@@ -148,6 +148,7 @@ func (h *dependencyIndexingSchedulerHandler) Handle(ctx context.Context, logger 
 
 		pkg := precise.Package{
 			Scheme:  packageReference.Package.Scheme,
+			Manager: packageReference.Package.Manager,
 			Name:    packageReference.Package.Name,
 			Version: packageReference.Package.Version,
 		}

--- a/enterprise/internal/codeintel/autoindexing/internal/background/job_dependency_indexing_scheduler_test.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/job_dependency_indexing_scheduler_test.go
@@ -99,6 +99,7 @@ func TestDependencyIndexingSchedulerHandler(t *testing.T) {
 		sort.Slice(packages, func(i, j int) bool {
 			for _, pair := range [][2]string{
 				{packages[i].Scheme, packages[j].Scheme},
+				{packages[i].Manager, packages[j].Manager},
 				{packages[i].Name, packages[j].Name},
 				{packages[i].Version, packages[j].Version},
 			} {
@@ -204,6 +205,7 @@ func TestDependencyIndexingSchedulerHandlerCustomer(t *testing.T) {
 		sort.Slice(packages, func(i, j int) bool {
 			for _, pair := range [][2]string{
 				{packages[i].Scheme, packages[j].Scheme},
+				{packages[i].Manager, packages[j].Manager},
 				{packages[i].Name, packages[j].Name},
 				{packages[i].Version, packages[j].Version},
 			} {

--- a/enterprise/internal/codeintel/autoindexing/internal/background/job_dependency_sync_scheduler.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/job_dependency_sync_scheduler.go
@@ -199,6 +199,7 @@ func (h *dependencySyncSchedulerHandler) Handle(ctx context.Context, logger log.
 func newPackage(pkg uploadsshared.Package) (*precise.Package, error) {
 	p := precise.Package{
 		Scheme:  pkg.Scheme,
+		Manager: pkg.Manager,
 		Name:    pkg.Name,
 		Version: pkg.Version,
 	}

--- a/enterprise/internal/codeintel/autoindexing/internal/enqueuer/enqueuer.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/enqueuer/enqueuer.go
@@ -74,6 +74,7 @@ func (s *IndexEnqueuer) QueueIndexesForPackage(ctx context.Context, pkg precise.
 	ctx, trace, endObservation := s.operations.queueIndexForPackage.With(ctx, &err, observation.Args{
 		LogFields: []otlog.Field{
 			otlog.String("scheme", pkg.Scheme),
+			otlog.String("manager", pkg.Manager),
 			otlog.String("name", pkg.Name),
 			otlog.String("version", pkg.Version),
 		},

--- a/enterprise/internal/codeintel/codenav/types.go
+++ b/enterprise/internal/codeintel/codenav/types.go
@@ -34,6 +34,7 @@ func (s *qualifiedMonikerSet) add(qualifiedMoniker precise.QualifiedMonikerData)
 		qualifiedMoniker.PackageInformationData.Name,
 		qualifiedMoniker.PackageInformationData.Version,
 		qualifiedMoniker.MonikerData.Scheme,
+		qualifiedMoniker.PackageInformationData.Manager,
 		qualifiedMoniker.MonikerData.Identifier,
 	}, ":")
 

--- a/enterprise/internal/codeintel/codenav/utils.go
+++ b/enterprise/internal/codeintel/codenav/utils.go
@@ -14,7 +14,7 @@ import (
 func monikersToString(vs []precise.QualifiedMonikerData) string {
 	strs := make([]string, 0, len(vs))
 	for _, v := range vs {
-		strs = append(strs, fmt.Sprintf("%s:%s:%s:%s", v.Kind, v.Scheme, v.Identifier, v.Version))
+		strs = append(strs, fmt.Sprintf("%s:%s:%s:%s:%s", v.Kind, v.Scheme, v.Manager, v.Identifier, v.Version))
 	}
 
 	return strings.Join(strs, ", ")

--- a/enterprise/internal/codeintel/uploads/internal/store/store_dumps.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_dumps.go
@@ -200,7 +200,7 @@ func (s *store) GetDumpsWithDefinitionsForMonikers(ctx context.Context, monikers
 
 	qs := make([]*sqlf.Query, 0, len(monikers))
 	for _, moniker := range monikers {
-		qs = append(qs, sqlf.Sprintf("(%s, %s, %s)", moniker.Scheme, moniker.Name, moniker.Version))
+		qs = append(qs, sqlf.Sprintf("(%s, %s, %s, %s)", moniker.Scheme, moniker.Manager, moniker.Name, moniker.Version))
 	}
 
 	authzConds, err := database.AuthzQueryConds(ctx, database.NewDBWith(s.logger, s.db))
@@ -234,7 +234,7 @@ ranked_uploads AS (
 	WHERE
 		-- Don't match deleted uploads
 		u.state = 'completed' AND
-		(p.scheme, p.name, p.version) IN (%s) AND
+		(p.scheme, p.manager, p.name, p.version) IN (%s) AND
 		%s -- authz conds
 ),
 canonical_uploads AS (

--- a/enterprise/internal/codeintel/uploads/internal/store/store_dumps.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_dumps.go
@@ -365,7 +365,7 @@ SELECT COUNT(*) FROM updated
 func monikersToString(vs []precise.QualifiedMonikerData) string {
 	strs := make([]string, 0, len(vs))
 	for _, v := range vs {
-		strs = append(strs, fmt.Sprintf("%s:%s:%s:%s", v.Kind, v.Scheme, v.Identifier, v.Version))
+		strs = append(strs, fmt.Sprintf("%s:%s:%s:%s:%s", v.Kind, v.Scheme, v.Manager, v.Identifier, v.Version))
 	}
 
 	return strings.Join(strs, ", ")

--- a/enterprise/internal/codeintel/uploads/internal/store/store_packages.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_packages.go
@@ -39,7 +39,7 @@ func (s *store) UpdatePackages(ctx context.Context, dumpID int, packages []preci
 		tx.Handle(),
 		"t_lsif_packages",
 		batch.MaxNumPostgresParameters,
-		[]string{"scheme", "name", "version"},
+		[]string{"scheme", "manager", "name", "version"},
 		loadPackagesChannel(packages),
 	); err != nil {
 		return err
@@ -53,14 +53,15 @@ func (s *store) UpdatePackages(ctx context.Context, dumpID int, packages []preci
 const updatePackagesTemporaryTableQuery = `
 CREATE TEMPORARY TABLE t_lsif_packages (
 	scheme text NOT NULL,
+	manager text NOT NULL,
 	name text NOT NULL,
 	version text NOT NULL
 ) ON COMMIT DROP
 `
 
 const updatePackagesInsertQuery = `
-INSERT INTO lsif_packages (dump_id, scheme, name, version)
-SELECT %s, source.scheme, source.name, source.version
+INSERT INTO lsif_packages (dump_id, scheme, manager, name, version)
+SELECT %s, source.scheme, source.manager, source.name, source.version
 FROM t_lsif_packages source
 `
 
@@ -71,7 +72,7 @@ func loadPackagesChannel(packages []precise.Package) <-chan []any {
 		defer close(ch)
 
 		for _, p := range packages {
-			ch <- []any{p.Scheme, p.Name, p.Version}
+			ch <- []any{p.Scheme, p.Manager, p.Name, p.Version}
 		}
 	}()
 

--- a/enterprise/internal/codeintel/uploads/internal/store/store_packages_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_packages_test.go
@@ -71,6 +71,7 @@ func insertPackages(t testing.TB, store Store, packages []shared.Package) {
 		if err := store.UpdatePackages(context.Background(), pkg.DumpID, []precise.Package{
 			{
 				Scheme:  pkg.Scheme,
+				Manager: pkg.Manager,
 				Name:    pkg.Name,
 				Version: pkg.Version,
 			},
@@ -87,6 +88,7 @@ func insertPackageReferences(t testing.TB, store Store, packageReferences []shar
 			{
 				Package: precise.Package{
 					Scheme:  packageReference.Scheme,
+					Manager: packageReference.Manager,
 					Name:    packageReference.Name,
 					Version: packageReference.Version,
 				},

--- a/enterprise/internal/codeintel/uploads/internal/store/store_uploads.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_uploads.go
@@ -151,10 +151,12 @@ SELECT
 	` + packageRankingQueryFragment + ` AS rank
 FROM lsif_uploads u
 JOIN lsif_packages p ON p.dump_id = u.id
-JOIN lsif_references r ON r.scheme = p.scheme
-	AND r.name = p.name
-	AND r.version = p.version
-	AND r.dump_id != p.dump_id
+JOIN lsif_references r ON
+	r.scheme = p.scheme AND
+	r.manager = p.manager AND
+	r.name = p.name AND
+	r.version = p.version AND
+	r.dump_id != p.dump_id
 WHERE
 	-- Don't match deleted uploads
 	u.state = 'completed' AND
@@ -168,7 +170,7 @@ const packageRankingQueryFragment = `
 rank() OVER (
 	PARTITION BY
 		-- Group providers of the same package together
-		p.scheme, p.name, p.version,
+		p.scheme, p.manager, p.name, p.version,
 		-- Defined by the same directory within a repository
 		u.repository_id, u.indexer, u.root
 	ORDER BY
@@ -181,10 +183,11 @@ rank() OVER (
 
 const rankedDependentCandidateCTEQuery = `
 SELECT
-	p.dump_id as pkg_id,
-	p.scheme as scheme,
-	p.name as name,
-	p.version as version,
+	p.dump_id AS pkg_id,
+	p.scheme AS scheme,
+	p.manager AS manager,
+	p.name AS name,
+	p.version AS version,
 	-- Rank each upload providing the same package from the same directory
 	-- within a repository by commit date. We'll choose the oldest commit
 	-- date as the canonical choice and ignore the uploads for younger
@@ -587,7 +590,7 @@ expired_uploads AS (
 
 -- From the set of unprotected uploads, find the set of packages they provide.
 packages_defined_by_target_uploads AS (
-	SELECT p.scheme, p.name, p.version
+	SELECT p.scheme, p.manager, p.name, p.version
 	FROM lsif_packages p
 	WHERE p.dump_id IN (SELECT id FROM expired_uploads)
 ),
@@ -602,6 +605,7 @@ ranked_uploads_providing_packages AS (
 	SELECT
 		u.id,
 		p.scheme,
+		p.manager,
 		p.name,
 		p.version,
 		-- Rank each upload providing the same package from the same directory
@@ -617,8 +621,8 @@ ranked_uploads_providing_packages AS (
 			u.id = ANY (SELECT id FROM expired_uploads) OR
 
 			-- Also select uploads that provide the same package as a target upload.
-			(p.scheme, p.name, p.version) IN (
-				SELECT p.scheme, p.name, p.version
+			(p.scheme, p.manager, p.name, p.version) IN (
+				SELECT p.scheme, p.manager, p.name, p.version
 				FROM packages_defined_by_target_uploads p
 			)
 		) AND
@@ -646,15 +650,16 @@ referenced_uploads_providing_package_canonically AS (
 			FROM lsif_references r
 			WHERE
 				r.scheme = ru.scheme AND
+				r.manager = ru.manager AND
 				r.name = ru.name AND
 				r.version = ru.version AND
 				r.dump_id != ru.id
 			)
 ),
 
--- Filter the set of our original candidate uploads to exlude the "safe" uploads found
+-- Filter the set of our original candidate uploads to exclude the "safe" uploads found
 -- above. This should include uploads that are expired and either not a canonical provider
--- of their package, or their package is unreferenced by any other uplaod. We can then lock
+-- of their package, or their package is unreferenced by any other upload. We can then lock
 -- the uploads in a deterministic order and update the state of each upload to 'deleting'.
 -- Before hard-deletion, we will clear all associated data for this upload in the codeintel-db.
 candidates AS (
@@ -757,6 +762,7 @@ root_upload_and_packages AS (
 			u.last_traversal_scan_at,
 			u.finished_at,
 			p.scheme,
+			p.manager,
 			p.name,
 			p.version,
 			` + packageRankingQueryFragment + ` AS rank
@@ -770,6 +776,7 @@ root_upload_and_packages AS (
 		FROM lsif_references r
 		WHERE
 			r.scheme = s.scheme AND
+			r.manager = s.manager AND
 			r.name = s.name AND
 			r.version = s.version AND
 			r.dump_id != s.id
@@ -781,28 +788,30 @@ root_upload_and_packages AS (
 -- Traverse the dependency graph backwards starting from our chosen root upload. The result
 -- set will include all (canonical) id and expiration status of uploads that transitively
 -- depend on chosen our root.
-transitive_dependents(id, expired, scheme, name, version) AS MATERIALIZED (
+transitive_dependents(id, expired, scheme, manager, name, version) AS MATERIALIZED (
 	(
 		-- Base case: select our root upload and its canonical packages
-		SELECT up.id, up.expired, up.scheme, up.name, up.version FROM root_upload_and_packages up
+		SELECT up.id, up.expired, up.scheme, up.manager, up.name, up.version FROM root_upload_and_packages up
 	) UNION (
 		-- Iterative case: select new (canonical) uploads that have a direct dependency of
 		-- some upload in our working set. This condition will continue to be evaluated until
 		-- it reaches a fixed point, giving us the complete connected component containing our
 		-- root upload.
 
-		SELECT s.id, s.expired, s.scheme, s.name, s.version
+		SELECT s.id, s.expired, s.scheme, s.manager, s.name, s.version
 		FROM (
 			SELECT
 				u.id,
 				u.expired,
 				p.scheme,
+				p.manager,
 				p.name,
 				p.version,
 				` + packageRankingQueryFragment + ` AS rank
 			FROM transitive_dependents d
 			JOIN lsif_references r ON
 				r.scheme = d.scheme AND
+				r.manager = d.manager AND
 				r.name = d.name AND
 				r.version = d.version AND
 				r.dump_id != d.id
@@ -1319,7 +1328,7 @@ func (s *store) GetVisibleUploadsMatchingMonikers(ctx context.Context, repositor
 
 	qs := make([]*sqlf.Query, 0, len(monikers))
 	for _, moniker := range monikers {
-		qs = append(qs, sqlf.Sprintf("(%s, %s, %s)", moniker.Scheme, moniker.Name, moniker.Version))
+		qs = append(qs, sqlf.Sprintf("(%s, %s, %s, %s)", moniker.Scheme, moniker.Manager, moniker.Name, moniker.Version))
 	}
 
 	visibleUploadsQuery := makeVisibleUploadsQuery(repositoryID, commit)
@@ -1359,13 +1368,13 @@ FROM lsif_references r
 LEFT JOIN lsif_dumps u ON u.id = r.dump_id
 JOIN repo ON repo.id = u.repository_id
 WHERE
-	(r.scheme, r.name, r.version) IN (%s) AND
+	(r.scheme, r.manager, r.name, r.version) IN (%s) AND
 	r.dump_id IN (SELECT * FROM visible_uploads) AND
 	%s -- authz conds
 `
 
 const referenceIDsQuery = referenceIDsCTEDefinitions + `
-SELECT r.dump_id, r.scheme, r.name, r.version
+SELECT r.dump_id, r.scheme, r.manager, r.name, r.version
 ` + referenceIDsBaseQuery + `
 ORDER BY dump_id
 LIMIT %s OFFSET %s
@@ -1981,8 +1990,8 @@ func buildGetConditionsAndCte(opts shared.GetUploadsOptions) (*sqlf.Query, []*sq
 		conds = append(conds, sqlf.Sprintf(`u.id IN (SELECT rd.pkg_id FROM ranked_dependencies rd WHERE rd.rank = 1)`))
 	}
 	if opts.DependentOf != 0 {
-		cteCondition := sqlf.Sprintf(`(p.scheme, p.name, p.version) IN (
-			SELECT p.scheme, p.name, p.version
+		cteCondition := sqlf.Sprintf(`(p.scheme, p.manager, p.name, p.version) IN (
+			SELECT p.scheme, p.manager, p.name, p.version
 			FROM lsif_packages p
 			WHERE p.dump_id = %s
 		)`, opts.DependentOf)
@@ -1998,10 +2007,12 @@ func buildGetConditionsAndCte(opts shared.GetUploadsOptions) (*sqlf.Query, []*sq
 		conds = append(conds, sqlf.Sprintf(`u.id IN (
 			SELECT r.dump_id
 			FROM ranked_dependents rd
-			JOIN lsif_references r ON r.scheme = rd.scheme
-				AND r.name = rd.name
-				AND r.version = rd.version
-				AND r.dump_id != rd.pkg_id
+			JOIN lsif_references r ON
+				r.scheme = rd.scheme AND
+				r.manager = rd.manager AND
+				r.name = rd.name AND
+				r.version = rd.version AND
+				r.dump_id != rd.pkg_id
 			WHERE rd.pkg_id = %s AND rd.rank = 1
 		)`, opts.DependentOf))
 	}

--- a/enterprise/internal/codeintel/uploads/shared/types.go
+++ b/enterprise/internal/codeintel/uploads/shared/types.go
@@ -81,10 +81,11 @@ type Position struct {
 	Character int
 }
 
-// Package pairs a package schem+name+version with the dump that provides it.
+// Package pairs a package scheme+manager+name+version with the dump that provides it.
 type Package struct {
 	DumpID  int
 	Scheme  string
+	Manager string
 	Name    string
 	Version string
 }
@@ -128,6 +129,7 @@ func (s *rowScanner) Next() (reference PackageReference, _ bool, _ error) {
 	if err := s.rows.Scan(
 		&reference.DumpID,
 		&reference.Scheme,
+		&reference.Manager,
 		&reference.Name,
 		&reference.Version,
 	); err != nil {

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -13257,6 +13257,19 @@
           "Comment": ""
         },
         {
+          "Name": "manager",
+          "Index": 6,
+          "TypeName": "text",
+          "IsNullable": false,
+          "Default": "''::text",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "The package manager name."
+        },
+        {
           "Name": "name",
           "Index": 3,
           "TypeName": "text",
@@ -13368,6 +13381,19 @@
           "IsGenerated": "NEVER",
           "GenerationExpression": "",
           "Comment": ""
+        },
+        {
+          "Name": "manager",
+          "Index": 7,
+          "TypeName": "text",
+          "IsNullable": false,
+          "Default": "''::text",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "The package manager name."
         },
         {
           "Name": "name",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1956,6 +1956,7 @@ Associates commits with the closest ancestor commit with usable upload data. Tog
  name    | text    |           | not null | 
  version | text    |           |          | 
  dump_id | integer |           | not null | 
+ manager | text    |           | not null | ''::text
 Indexes:
     "lsif_packages_pkey" PRIMARY KEY, btree (id)
     "lsif_packages_dump_id" btree (dump_id)
@@ -1968,6 +1969,8 @@ Foreign-key constraints:
 Associates an upload with the set of packages they provide within a given packages management scheme.
 
 **dump_id**: The identifier of the upload that provides the package.
+
+**manager**: The package manager name.
 
 **name**: The package name.
 
@@ -1984,6 +1987,7 @@ Associates an upload with the set of packages they provide within a given packag
  name    | text    |           | not null | 
  version | text    |           |          | 
  dump_id | integer |           | not null | 
+ manager | text    |           | not null | ''::text
 Indexes:
     "lsif_references_pkey" PRIMARY KEY, btree (id)
     "lsif_references_dump_id" btree (dump_id)
@@ -1996,6 +2000,8 @@ Foreign-key constraints:
 Associates an upload with the set of packages they require within a given packages management scheme.
 
 **dump_id**: The identifier of the upload that references the package.
+
+**manager**: The package manager name.
 
 **name**: The package name.
 

--- a/lib/codeintel/lsif/conversion/group.go
+++ b/lib/codeintel/lsif/conversion/group.go
@@ -102,6 +102,7 @@ func serializeDocument(state *State, documentID int) precise.DocumentData {
 			if moniker.PackageInformationID != 0 {
 				packageInformation := state.PackageInformationData[moniker.PackageInformationID]
 				document.PackageInformation[toID(moniker.PackageInformationID)] = precise.PackageInformationData{
+					Manager: "",
 					Name:    packageInformation.Name,
 					Version: packageInformation.Version,
 				}
@@ -380,6 +381,7 @@ func gatherPackages(state *State) []precise.Package {
 
 		uniques[makeKey(source.Scheme, packageInfo.Name, packageInfo.Version)] = precise.Package{
 			Scheme:  source.Scheme,
+			Manager: "",
 			Name:    packageInfo.Name,
 			Version: packageInfo.Version,
 		}
@@ -439,6 +441,7 @@ func gatherPackageReferences(state *State, packageDefinitions []precise.Package)
 		packageReferences = append(packageReferences, precise.PackageReference{
 			Package: precise.Package{
 				Scheme:  v.Scheme,
+				Manager: "",
 				Name:    v.Name,
 				Version: v.Version,
 			},

--- a/lib/codeintel/lsif/protocol/reader/unmarshal.go
+++ b/lib/codeintel/lsif/protocol/reader/unmarshal.go
@@ -353,6 +353,7 @@ func unmarshalPackageInformation(line []byte) (any, error) {
 	}
 
 	return PackageInformation{
+		Manager: "",
 		Name:    payload.Name,
 		Version: payload.Version,
 	}, nil

--- a/lib/codeintel/precise/types.go
+++ b/lib/codeintel/precise/types.go
@@ -55,6 +55,8 @@ type MonikerData struct {
 
 // PackageInformationData indicates a globally unique namespace for a moniker.
 type PackageInformationData struct {
+	Manager string // TODO
+
 	// Name of the package that contains the moniker.
 	Name string
 
@@ -215,6 +217,7 @@ type DocumentationSearchResult struct {
 // Package pairs a package name and the dump that provides it.
 type Package struct {
 	Scheme  string
+	Manager string // TODO
 	Name    string
 	Version string
 }

--- a/lib/codeintel/precise/types.go
+++ b/lib/codeintel/precise/types.go
@@ -55,7 +55,7 @@ type MonikerData struct {
 
 // PackageInformationData indicates a globally unique namespace for a moniker.
 type PackageInformationData struct {
-	Manager string // TODO
+	Manager string
 
 	// Name of the package that contains the moniker.
 	Name string
@@ -217,7 +217,7 @@ type DocumentationSearchResult struct {
 // Package pairs a package name and the dump that provides it.
 type Package struct {
 	Scheme  string
-	Manager string // TODO
+	Manager string
 	Name    string
 	Version string
 }

--- a/migrations/frontend/1669836151_add_manager_to_lsif_packagereferences/down.sql
+++ b/migrations/frontend/1669836151_add_manager_to_lsif_packagereferences/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE lsif_packages DROP COLUMN IF EXISTS manager;
+ALTER TABLE lsif_references DROP COLUMN IF EXISTS manager;

--- a/migrations/frontend/1669836151_add_manager_to_lsif_packagereferences/metadata.yaml
+++ b/migrations/frontend/1669836151_add_manager_to_lsif_packagereferences/metadata.yaml
@@ -1,0 +1,2 @@
+name: Add manager to lsif_package/references
+parents: [1668767882, 1669184869]

--- a/migrations/frontend/1669836151_add_manager_to_lsif_packagereferences/up.sql
+++ b/migrations/frontend/1669836151_add_manager_to_lsif_packagereferences/up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE lsif_packages ADD COLUMN IF NOT EXISTS manager TEXT NOT NULL DEFAULT '';
+ALTER TABLE lsif_references ADD COLUMN IF NOT EXISTS manager TEXT NOT NULL DEFAULT '';
+
+COMMENT ON COLUMN lsif_packages.manager IS 'The package manager name.';
+COMMENT ON COLUMN lsif_references.manager IS 'The package manager name.';

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -2737,7 +2737,8 @@ CREATE TABLE lsif_packages (
     scheme text NOT NULL,
     name text NOT NULL,
     version text,
-    dump_id integer NOT NULL
+    dump_id integer NOT NULL,
+    manager text DEFAULT ''::text NOT NULL
 );
 
 COMMENT ON TABLE lsif_packages IS 'Associates an upload with the set of packages they provide within a given packages management scheme.';
@@ -2749,6 +2750,8 @@ COMMENT ON COLUMN lsif_packages.name IS 'The package name.';
 COMMENT ON COLUMN lsif_packages.version IS 'The package version.';
 
 COMMENT ON COLUMN lsif_packages.dump_id IS 'The identifier of the upload that provides the package.';
+
+COMMENT ON COLUMN lsif_packages.manager IS 'The package manager name.';
 
 CREATE SEQUENCE lsif_packages_id_seq
     START WITH 1
@@ -2764,7 +2767,8 @@ CREATE TABLE lsif_references (
     scheme text NOT NULL,
     name text NOT NULL,
     version text,
-    dump_id integer NOT NULL
+    dump_id integer NOT NULL,
+    manager text DEFAULT ''::text NOT NULL
 );
 
 COMMENT ON TABLE lsif_references IS 'Associates an upload with the set of packages they require within a given packages management scheme.';
@@ -2776,6 +2780,8 @@ COMMENT ON COLUMN lsif_references.name IS 'The package name.';
 COMMENT ON COLUMN lsif_references.version IS 'The package version.';
 
 COMMENT ON COLUMN lsif_references.dump_id IS 'The identifier of the upload that references the package.';
+
+COMMENT ON COLUMN lsif_references.manager IS 'The package manager name.';
 
 CREATE SEQUENCE lsif_references_id_seq
     START WITH 1


### PR DESCRIPTION
In preparation to store the `manager` field for SCIP packages, we'll add and start to treat `manager` as a valid field in the current infrastructure. This value will remain empty for LSIF.

## Test plan

Existing unit tests.