### PR TITLE
Add note about changes to users on SAML provider

### DIFF
--- a/doc/admin/auth/saml/index.md
+++ b/doc/admin/auth/saml/index.md
@@ -78,6 +78,10 @@ The most likely error message indicating a problem is:
 Error prefetching SAML service provider metadata
 ```
 
+> NOTE: Email or NameID changes in the identity provider are not automatically reflected in Sourcegraph. Admins may manually update a users email via the admin interface at `https://example-sourcegraph.com/users/<user>/settings/emails`, or remove the user and recreate a new account. 
+>
+> Work is planned to support SCIM on SAML auth providers, which should automate this process.
+
 ### How to control user sign-up and sign-in
 
 Use the following filters to restrict how users can create accounts and sign in to your Sourcegraph instance via SAML auth provider.

--- a/doc/admin/auth/saml/index.md
+++ b/doc/admin/auth/saml/index.md
@@ -80,7 +80,7 @@ Error prefetching SAML service provider metadata
 
 > NOTE: Email or NameID changes in the identity provider are not automatically reflected in Sourcegraph. Admins may manually update a users email via the admin interface at `https://example-sourcegraph.com/users/<user>/settings/emails`, or remove the user and recreate a new account. 
 >
-> Work is planned to support SCIM on SAML auth providers, which should automate this process.
+> Work is planned to support SCIM on SAML auth providers, which should automate this process. ([tracking issue](https://github.com/sourcegraph/sourcegraph/issues/22732))
 
 ### How to control user sign-up and sign-in
 


### PR DESCRIPTION
This just adds a note suggesting admins need to manually update a users email should this change on the SAML identity provider

It'd be nice to link a tracking issue to planned work on support for SCIM on SAML auth providers



## Test plan
local test

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
