### PR TITLE
Add steps on what to do when a user email changes on the IdP side

### DIFF
--- a/doc/admin/auth/saml/index.md
+++ b/doc/admin/auth/saml/index.md
@@ -152,6 +152,21 @@ Use the following filters to restrict how users can create accounts and sign in 
 
 See [SAML troubleshooting](#troubleshooting) for more tips.
 
+### Updating user emails
+
+Whe SAML authentication is enabled and a user email registered on the IdP is changed, Sourcegraph doesn’t apply that change on its side. In consequence, site admins have to update the user email.
+To do that, go to the site Admin area > Users page and:
+
+- click the username whose email needs to be updated to see their account
+- in the left menu, click "Emails"
+- add the new email address that matches the one registered in the IdP and mark it as verified (you can also send a verification link to the user)
+- in the "Primary email address" section, select the new verified email and click Save
+- the new email should now have the "Verified" and "Primary" labels
+- remove the old email by clicking the "Remove" link besides it
+
+Depending on the IdP configuration, there can be a case when users will continue to log in successfully to Sourcegraph despite the email mismatch (for example, when there's a match between the username or NameID).
+But we still recommend site-admin to follow the steps above to avoid having a mismatch between a user IdP email and their Sourcegraph account email.
+
 ## Troubleshooting
 
 ### Enable logging in Sourcegraph containers

--- a/doc/admin/auth/saml/index.md
+++ b/doc/admin/auth/saml/index.md
@@ -154,18 +154,18 @@ See [SAML troubleshooting](#troubleshooting) for more tips.
 
 ### Updating user emails
 
-Whe SAML authentication is enabled and a user email registered on the IdP is changed, Sourcegraph doesn’t apply that change on its side. In consequence, site admins have to update the user email.
-To do that, go to the site Admin area > Users page and:
+Whe SAML authentication is enabled and a user email registered on the IdP is updated, Sourcegraph doesn’t apply that change on its side. In consequence, site admins have to update the user email.
+To do that, go to the "Site admin" area, navigate to the "Users" page and:
 
-- click the username whose email needs to be updated to see their account
+- click the username whose email needs to be updated
 - in the left menu, click "Emails"
 - add the new email address that matches the one registered in the IdP and mark it as verified (you can also send a verification link to the user)
-- in the "Primary email address" section, select the new verified email and click Save
+- in the "Primary email address" section, select the new verified email and click "Save"
 - the new email should now have the "Verified" and "Primary" labels
 - remove the old email by clicking the "Remove" link besides it
 
 Depending on the IdP configuration, there can be a case when users will continue to log in successfully to Sourcegraph despite the email mismatch (for example, when there's a match between the username or NameID).
-But we still recommend site-admin to follow the steps above to avoid having a mismatch between a user IdP email and their Sourcegraph account email.
+But we still recommend site-admin to follow the steps above to avoid having different emails in the IdP and in Sourcegraph.
 
 ## Troubleshooting
 

--- a/doc/admin/auth/saml/index.md
+++ b/doc/admin/auth/saml/index.md
@@ -154,7 +154,8 @@ See [SAML troubleshooting](#troubleshooting) for more tips.
 
 ### Updating user emails
 
-Whe SAML authentication is enabled and a user email registered on the IdP is updated, Sourcegraph doesn’t apply that change on its side. In consequence, site admins have to update the user email.
+Whe SAML authentication is enabled and a user email registered on the IdP is updated, Sourcegraph doesn’t apply that change on its side. In consequence, site admins have to update the user email to make sure they
+can continue signing in to Sourcegraph.
 To do that, go to the "Site admin" area, navigate to the "Users" page and:
 
 - click the username whose email needs to be updated


### PR DESCRIPTION

This PR updates the SAML section in our docs to inform site admins what to do if a user email is changed on the Identity Provider. 

Currently, we don't apply that type of change in Sourcegraph, so there will be a mismatch between the user email stored in SG and the user email stored in the IdP. More: depending on the IdP configuration, users can continue signing in to SG or won't be able to sign in until a site admin updates their emails.


## Test plan
All tests should pass.
Checked the new changes in a local instance.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
