### PR TITLE
codeintel: remove memoization of codeintel constructors

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -124,7 +124,7 @@ func main() {
 	db := database.NewDB(logger, sqlDB)
 
 	repoStore := db.Repos()
-	dependenciesSvc := dependencies.GetService(db)
+	dependenciesSvc := dependencies.NewService(db)
 	externalServiceStore := db.ExternalServices()
 
 	err = keyring.Init(ctx)

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -166,7 +166,7 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 	var genericSourcer repos.Sourcer
 	sourcerLogger := logger.Scoped("repos.Sourcer", "repositories source")
 	db := database.NewDBWith(sourcerLogger.Scoped("db", "sourcer database"), s)
-	dependenciesService := dependencies.GetService(db)
+	dependenciesService := dependencies.NewService(db)
 	cf := httpcli.NewExternalClientFactory(httpcli.NewLoggingMiddleware(sourcerLogger))
 	genericSourcer = repos.NewSourcer(sourcerLogger, db, cf, repos.WithDependenciesService(dependenciesService))
 

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -139,7 +139,7 @@ func Main(enterpriseInit EnterpriseInit) {
 		m := repos.NewSourceMetrics()
 		m.MustRegister(prometheus.DefaultRegisterer)
 
-		src = repos.NewSourcer(sourcerLogger, db, cf, repos.WithDependenciesService(dependencies.GetService(db)), repos.ObservedSource(sourcerLogger, m))
+		src = repos.NewSourcer(sourcerLogger, db, cf, repos.WithDependenciesService(dependencies.NewService(db)), repos.ObservedSource(sourcerLogger, m))
 	}
 
 	updateScheduler := repos.NewUpdateScheduler(logger, db)
@@ -343,7 +343,7 @@ func manualPurgeHandler(db database.DB) http.HandlerFunc {
 			http.Error(w, "limit must be less than 10000", http.StatusBadRequest)
 			return
 		}
-		var perSecond = 1.0 // Default value
+		perSecond := 1.0 // Default value
 		perSecondParam := r.FormValue("perSecond")
 		if perSecondParam != "" {
 			perSecond, err = strconv.ParseFloat(perSecondParam, 64)

--- a/cmd/worker/internal/codeintel/crates_syncer.go
+++ b/cmd/worker/internal/codeintel/crates_syncer.go
@@ -35,7 +35,7 @@ func (j *cratesSyncerJob) Routines(startupCtx context.Context, logger log.Logger
 	}
 
 	gitserverClient := gitserver.NewClient(db)
-	dependenciesService := dependencies.GetService(db)
+	dependenciesService := dependencies.NewService(db)
 
 	return dependencies.CrateSyncerJob(
 		dependenciesService,

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -85,7 +85,7 @@ func enterpriseSetupHook(db database.DB, conf conftypes.UnifiedWatchable) enterp
 		Registerer: prometheus.DefaultRegisterer,
 	}
 
-	codeIntelServices, err := codeintel.GetServices(codeintel.Databases{
+	codeIntelServices, err := codeintel.NewServices(codeintel.Databases{
 		DB:          db,
 		CodeIntelDB: mustInitializeCodeIntelDB(logger),
 	})

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -99,7 +99,7 @@ func main() {
 		logger.Fatal("Failed to create sub-repo client", log.Error(err))
 	}
 
-	services, err := codeintel.GetServices(codeintel.Databases{
+	services, err := codeintel.NewServices(codeintel.Databases{
 		DB:          db,
 		CodeIntelDB: codeIntelDB,
 	})

--- a/enterprise/cmd/worker/shared/init/codeintel/services.go
+++ b/enterprise/cmd/worker/shared/init/codeintel/services.go
@@ -21,7 +21,7 @@ func InitServices() (codeintel.Services, error) {
 		return codeintel.Services{}, err
 	}
 
-	return codeintel.GetServices(codeintel.Databases{
+	return codeintel.NewServices(codeintel.Databases{
 		DB:          db,
 		CodeIntelDB: codeIntelDB,
 	})

--- a/enterprise/internal/codeintel/autoindexing/init.go
+++ b/enterprise/internal/codeintel/autoindexing/init.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/symbols"
@@ -31,13 +30,12 @@ func GetService(
 	policiesSvc PoliciesService,
 	gitserver GitserverClient,
 ) *Service {
-	svc, _ := initServiceMemo.Init(serviceDependencies{
-		db,
-		uploadSvc,
-		depsSvc,
-		policiesSvc,
-		gitserver,
-	})
+	store := store.New(db, scopedContext("store"))
+	symbolsClient := symbols.DefaultClient
+	repoUpdater := repoupdater.DefaultClient
+	inferenceSvc := inference.NewService(db)
+
+	svc := newService(store, uploadSvc, inferenceSvc, repoUpdater, gitserver, symbolsClient, scopedContext("service"))
 
 	return svc
 }
@@ -49,17 +47,6 @@ type serviceDependencies struct {
 	policiesSvc PoliciesService
 	gitserver   GitserverClient
 }
-
-var initServiceMemo = memo.NewMemoizedConstructorWithArg(func(deps serviceDependencies) (*Service, error) {
-	store := store.New(deps.db, scopedContext("store"))
-	symbolsClient := symbols.DefaultClient
-	repoUpdater := repoupdater.DefaultClient
-	inferenceSvc := inference.NewService(deps.db)
-
-	svc := newService(store, deps.uploadSvc, inferenceSvc, repoUpdater, deps.gitserver, symbolsClient, scopedContext("service"))
-
-	return svc, nil
-})
 
 func scopedContext(component string) *observation.Context {
 	return observation.ScopedContext("codeintel", "autoindexing", component)

--- a/enterprise/internal/codeintel/autoindexing/init.go
+++ b/enterprise/internal/codeintel/autoindexing/init.go
@@ -21,9 +21,7 @@ var (
 	DependencyIndexingJobWorkerStoreOptions = background.DependencyIndexingJobWorkerStoreOptions
 )
 
-// GetService creates or returns an already-initialized autoindexing service.
-// If the service is not yet initialized, it will use the provided dependencies.
-func GetService(
+func NewService(
 	db database.DB,
 	uploadSvc UploadService,
 	depsSvc DependenciesService,

--- a/enterprise/internal/codeintel/autoindexing/internal/enqueuer/observability.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/enqueuer/observability.go
@@ -3,9 +3,6 @@ package enqueuer
 import (
 	"fmt"
 
-	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -15,17 +12,17 @@ type operations struct {
 	queueIndexForPackage *observation.Operation
 }
 
-var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
-	return metrics.NewREDMetrics(
-		r,
-		"codeintel_autoindexing_enqueuer",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of method invocations."),
-	), nil
-})
+var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationContext *observation.Context) *operations {
-	m, _ := m.Init(observationContext.Registerer)
+	m := m.Get(func() *metrics.REDMetrics {
+		return metrics.NewREDMetrics(
+			observationContext.Registerer,
+			"codeintel_autoindexing_enqueuer",
+			metrics.WithLabels("op"),
+			metrics.WithCountHelp("Total number of method invocations."),
+		)
+	})
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/autoindexing/internal/enqueuer/observability.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/enqueuer/observability.go
@@ -3,6 +3,9 @@ package enqueuer
 import (
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -12,13 +15,17 @@ type operations struct {
 	queueIndexForPackage *observation.Operation
 }
 
-func newOperations(observationContext *observation.Context) *operations {
-	m := metrics.NewREDMetrics(
-		observationContext.Registerer,
+var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
+	return metrics.NewREDMetrics(
+		r,
 		"codeintel_autoindexing_enqueuer",
 		metrics.WithLabels("op"),
 		metrics.WithCountHelp("Total number of method invocations."),
-	)
+	), nil
+})
+
+func newOperations(observationContext *observation.Context) *operations {
+	m, _ := m.Init(observationContext.Registerer)
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/init.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/init.go
@@ -30,7 +30,7 @@ func NewService(db database.DB) *Service {
 	}
 
 	return newService(
-		luasandbox.GetService(),
+		luasandbox.NewService(),
 		NewDefaultGitService(nil, db),
 		ratelimit.NewInstrumentedLimiter("InferenceService", rate.NewLimiter(rate.Limit(gitserverRequestRateLimit), 1)),
 		maximumFilesWithContentCount,

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/service_test.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/service_test.go
@@ -19,7 +19,7 @@ import (
 
 func testService(t *testing.T, repositoryContents map[string]string) *Service {
 	// Real deal
-	sandboxService := luasandbox.GetService()
+	sandboxService := luasandbox.NewService()
 
 	// Fake deal
 	gitService := NewMockGitService()

--- a/enterprise/internal/codeintel/autoindexing/observability.go
+++ b/enterprise/internal/codeintel/autoindexing/observability.go
@@ -3,9 +3,6 @@ package autoindexing
 import (
 	"fmt"
 
-	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -47,17 +44,17 @@ type operations struct {
 	setRequestLanguageSupport *observation.Operation
 }
 
-var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
-	return metrics.NewREDMetrics(
-		r,
-		"codeintel_autoindexing",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of method invocations."),
-	), nil
-})
+var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationContext *observation.Context) *operations {
-	m, _ := m.Init(observationContext.Registerer)
+	m := m.Get(func() *metrics.REDMetrics {
+		return metrics.NewREDMetrics(
+			observationContext.Registerer,
+			"codeintel_autoindexing",
+			metrics.WithLabels("op"),
+			metrics.WithCountHelp("Total number of method invocations."),
+		)
+	})
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/autoindexing/observability.go
+++ b/enterprise/internal/codeintel/autoindexing/observability.go
@@ -3,6 +3,9 @@ package autoindexing
 import (
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -44,13 +47,17 @@ type operations struct {
 	setRequestLanguageSupport *observation.Operation
 }
 
-func newOperations(observationContext *observation.Context) *operations {
-	m := metrics.NewREDMetrics(
-		observationContext.Registerer,
+var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
+	return metrics.NewREDMetrics(
+		r,
 		"codeintel_autoindexing",
 		metrics.WithLabels("op"),
 		metrics.WithCountHelp("Total number of method invocations."),
-	)
+	), nil
+})
+
+func newOperations(observationContext *observation.Context) *operations {
+	m, _ := m.Init(observationContext.Registerer)
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/codenav/init.go
+++ b/enterprise/internal/codeintel/codenav/init.go
@@ -5,7 +5,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/codenav/internal/store"
 	codeintelshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
@@ -17,14 +16,16 @@ func GetService(
 	uploadSvc UploadService,
 	gitserver GitserverClient,
 ) *Service {
-	svc, _ := initServiceMemo.Init(serviceDependencies{
-		db,
-		codeIntelDB,
+	store := store.New(db, scopedContext("store"))
+	lsifStore := lsifstore.New(codeIntelDB, scopedContext("lsifstore"))
+
+	return newService(
+		store,
+		lsifStore,
 		uploadSvc,
 		gitserver,
-	})
-
-	return svc
+		scopedContext("service"),
+	)
 }
 
 type serviceDependencies struct {
@@ -33,21 +34,6 @@ type serviceDependencies struct {
 	uploadSvc   UploadService
 	gitserver   GitserverClient
 }
-
-var initServiceMemo = memo.NewMemoizedConstructorWithArg(func(deps serviceDependencies) (*Service, error) {
-	store := store.New(deps.db, scopedContext("store"))
-	lsifStore := lsifstore.New(deps.codeIntelDB, scopedContext("lsifstore"))
-
-	svc := newService(
-		store,
-		lsifStore,
-		deps.uploadSvc,
-		deps.gitserver,
-		scopedContext("service"),
-	)
-
-	return svc, nil
-})
 
 func scopedContext(component string) *observation.Context {
 	return observation.ScopedContext("codeintel", "codenav", component)

--- a/enterprise/internal/codeintel/codenav/init.go
+++ b/enterprise/internal/codeintel/codenav/init.go
@@ -8,9 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-// GetService creates or returns an already-initialized symbols service.
-// If the service is not yet initialized, it will use the provided dependencies.
-func GetService(
+func NewService(
 	db database.DB,
 	codeIntelDB codeintelshared.CodeIntelDB,
 	uploadSvc UploadService,

--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/observability.go
@@ -3,9 +3,6 @@ package lsifstore
 import (
 	"fmt"
 
-	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -27,17 +24,17 @@ type operations struct {
 	locations *observation.Operation
 }
 
-var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
-	return metrics.NewREDMetrics(
-		r,
-		"codeintel_codenav_lsifstore",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of method invocations."),
-	), nil
-})
+var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationContext *observation.Context) *operations {
-	metrics, _ := m.Init(observationContext.Registerer)
+	metrics := m.Get(func() *metrics.REDMetrics {
+		return metrics.NewREDMetrics(
+			observationContext.Registerer,
+			"codeintel_codenav_lsifstore",
+			metrics.WithLabels("op"),
+			metrics.WithCountHelp("Total number of method invocations."),
+		)
+	})
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/observability.go
@@ -3,6 +3,9 @@ package lsifstore
 import (
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -24,13 +27,17 @@ type operations struct {
 	locations *observation.Operation
 }
 
-func newOperations(observationContext *observation.Context) *operations {
-	metrics := metrics.NewREDMetrics(
-		observationContext.Registerer,
+var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
+	return metrics.NewREDMetrics(
+		r,
 		"codeintel_codenav_lsifstore",
 		metrics.WithLabels("op"),
 		metrics.WithCountHelp("Total number of method invocations."),
-	)
+	), nil
+})
+
+func newOperations(observationContext *observation.Context) *operations {
+	metrics, _ := m.Init(observationContext.Registerer)
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/codenav/internal/store/observability.go
+++ b/enterprise/internal/codeintel/codenav/internal/store/observability.go
@@ -3,6 +3,9 @@ package store
 import (
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -12,13 +15,17 @@ type operations struct {
 	noop *observation.Operation
 }
 
-func newOperations(observationContext *observation.Context) *operations {
-	metrics := metrics.NewREDMetrics(
-		observationContext.Registerer,
+var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
+	return metrics.NewREDMetrics(
+		r,
 		"codeintel_codenav_store",
 		metrics.WithLabels("op"),
 		metrics.WithCountHelp("Total number of method invocations."),
-	)
+	), nil
+})
+
+func newOperations(observationContext *observation.Context) *operations {
+	metrics, _ := m.Init(observationContext.Registerer)
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/codenav/internal/store/observability.go
+++ b/enterprise/internal/codeintel/codenav/internal/store/observability.go
@@ -3,9 +3,6 @@ package store
 import (
 	"fmt"
 
-	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -15,17 +12,17 @@ type operations struct {
 	noop *observation.Operation
 }
 
-var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
-	return metrics.NewREDMetrics(
-		r,
-		"codeintel_codenav_store",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of method invocations."),
-	), nil
-})
+var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationContext *observation.Context) *operations {
-	metrics, _ := m.Init(observationContext.Registerer)
+	metrics := m.Get(func() *metrics.REDMetrics {
+		return metrics.NewREDMetrics(
+			observationContext.Registerer,
+			"codeintel_codenav_store",
+			metrics.WithLabels("op"),
+			metrics.WithCountHelp("Total number of method invocations."),
+		)
+	})
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/codenav/observability.go
+++ b/enterprise/internal/codeintel/codenav/observability.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -23,13 +25,17 @@ type operations struct {
 	getClosestDumpsForBlob *observation.Operation
 }
 
-func newOperations(observationContext *observation.Context) *operations {
-	metrics := metrics.NewREDMetrics(
-		observationContext.Registerer,
+var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
+	return metrics.NewREDMetrics(
+		r,
 		"codeintel_codenav",
 		metrics.WithLabels("op"),
 		metrics.WithCountHelp("Total number of method invocations."),
-	)
+	), nil
+})
+
+func newOperations(observationContext *observation.Context) *operations {
+	metrics, _ := m.Init(observationContext.Registerer)
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/dependencies/init.go
+++ b/enterprise/internal/codeintel/dependencies/init.go
@@ -2,4 +2,4 @@ package dependencies
 
 import ossdependencies "github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 
-var GetService = ossdependencies.GetService
+var NewService = ossdependencies.NewService

--- a/enterprise/internal/codeintel/policies/init.go
+++ b/enterprise/internal/codeintel/policies/init.go
@@ -8,9 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-// GetService creates or returns an already-initialized policies service.
-// If the service is not yet initialized, it will use the provided dependencies.
-func GetService(
+func NewService(
 	db database.DB,
 	uploadSvc UploadService,
 	gitserver GitserverClient,

--- a/enterprise/internal/codeintel/policies/init.go
+++ b/enterprise/internal/codeintel/policies/init.go
@@ -5,7 +5,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
@@ -16,13 +15,14 @@ func GetService(
 	uploadSvc UploadService,
 	gitserver GitserverClient,
 ) *Service {
-	svc, _ := initServiceMemo.Init(serviceDependencies{
-		db,
+	store := store.New(db, scopedContext("store"))
+
+	return newService(
+		store,
 		uploadSvc,
 		gitserver,
-	})
-
-	return svc
+		scopedContext("service"),
+	)
 }
 
 type serviceDependencies struct {
@@ -30,14 +30,6 @@ type serviceDependencies struct {
 	uploadSvc UploadService
 	gitserver GitserverClient
 }
-
-var initServiceMemo = memo.NewMemoizedConstructorWithArg(func(deps serviceDependencies) (*Service, error) {
-	store := store.New(deps.db, scopedContext("store"))
-
-	svc := newService(store, deps.uploadSvc, deps.gitserver, scopedContext("service"))
-
-	return svc, nil
-})
 
 func scopedContext(component string) *observation.Context {
 	return observation.ScopedContext("codeintel", "policies", component)

--- a/enterprise/internal/codeintel/policies/internal/store/observability.go
+++ b/enterprise/internal/codeintel/policies/internal/store/observability.go
@@ -3,9 +3,6 @@ package store
 import (
 	"fmt"
 
-	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -24,17 +21,17 @@ type operations struct {
 	selectPoliciesForRepositoryMembershipUpdate *observation.Operation
 }
 
-var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
-	return metrics.NewREDMetrics(
-		r,
-		"codeintel_policies_store",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of method invocations."),
-	), nil
-})
+var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationContext *observation.Context) *operations {
-	m, _ := m.Init(observationContext.Registerer)
+	m := m.Get(func() *metrics.REDMetrics {
+		return metrics.NewREDMetrics(
+			observationContext.Registerer,
+			"codeintel_policies_store",
+			metrics.WithLabels("op"),
+			metrics.WithCountHelp("Total number of method invocations."),
+		)
+	})
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/policies/internal/store/observability.go
+++ b/enterprise/internal/codeintel/policies/internal/store/observability.go
@@ -3,6 +3,9 @@ package store
 import (
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -21,13 +24,17 @@ type operations struct {
 	selectPoliciesForRepositoryMembershipUpdate *observation.Operation
 }
 
-func newOperations(observationContext *observation.Context) *operations {
-	m := metrics.NewREDMetrics(
-		observationContext.Registerer,
+var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
+	return metrics.NewREDMetrics(
+		r,
 		"codeintel_policies_store",
 		metrics.WithLabels("op"),
 		metrics.WithCountHelp("Total number of method invocations."),
-	)
+	), nil
+})
+
+func newOperations(observationContext *observation.Context) *operations {
+	m, _ := m.Init(observationContext.Registerer)
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/policies/observability.go
+++ b/enterprise/internal/codeintel/policies/observability.go
@@ -3,9 +3,6 @@ package policies
 import (
 	"fmt"
 
-	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -28,17 +25,17 @@ type operations struct {
 	updateReposMatchingPatterns                 *observation.Operation
 }
 
-var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
-	return metrics.NewREDMetrics(
-		r,
-		"codeintel_policies",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of method invocations."),
-	), nil
-})
+var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationContext *observation.Context) *operations {
-	metrics, _ := m.Init(observationContext.Registerer)
+	metrics := m.Get(func() *metrics.REDMetrics {
+		return metrics.NewREDMetrics(
+			observationContext.Registerer,
+			"codeintel_policies",
+			metrics.WithLabels("op"),
+			metrics.WithCountHelp("Total number of method invocations."),
+		)
+	})
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/policies/observability.go
+++ b/enterprise/internal/codeintel/policies/observability.go
@@ -3,6 +3,9 @@ package policies
 import (
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -25,13 +28,17 @@ type operations struct {
 	updateReposMatchingPatterns                 *observation.Operation
 }
 
-func newOperations(observationContext *observation.Context) *operations {
-	metrics := metrics.NewREDMetrics(
-		observationContext.Registerer,
+var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
+	return metrics.NewREDMetrics(
+		r,
 		"codeintel_policies",
 		metrics.WithLabels("op"),
 		metrics.WithCountHelp("Total number of method invocations."),
-	)
+	), nil
+})
+
+func newOperations(observationContext *observation.Context) *operations {
+	metrics, _ := m.Init(observationContext.Registerer)
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/ranking/init.go
+++ b/enterprise/internal/codeintel/ranking/init.go
@@ -19,9 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/symbols"
 )
 
-// GetService creates or returns an already-initialized ranking service.
-// If the service is not yet initialized, it will use the provided dependencies.
-func GetService(
+func NewService(
 	db database.DB,
 	uploadSvc *uploads.Service,
 	gitserverClient GitserverClient,

--- a/enterprise/internal/codeintel/ranking/init.go
+++ b/enterprise/internal/codeintel/ranking/init.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/symbols"
 )
@@ -27,35 +26,6 @@ func GetService(
 	uploadSvc *uploads.Service,
 	gitserverClient GitserverClient,
 ) *Service {
-	svc, _ := initServiceMemo.Init(serviceDependencies{
-		db,
-		uploadSvc,
-		gitserverClient,
-	})
-
-	return svc
-}
-
-type serviceDependencies struct {
-	db              database.DB
-	uploadsService  *uploads.Service
-	gitserverClient GitserverClient
-}
-
-var (
-	// TODO - move these into background config
-	resultsBucketName             = env.Get("CODEINTEL_RANKING_RESULTS_BUCKET", "lsif-pagerank-experiments", "The GCS bucket.")
-	resultsGraphKey               = env.Get("CODEINTEL_RANKING_RESULTS_GRAPH_KEY", "dev", "An identifier of the graph export. Change to start a new import from the configured bucket.")
-	resultsObjectKeyPrefix        = env.Get("CODEINTEL_RANKING_RESULTS_OBJECT_KEY_PREFIX", "ranks/", "The object key prefix that holds results of the last PageRank batch job.")
-	resultsBucketCredentialsFile  = env.Get("CODEINTEL_RANKING_RESULTS_GOOGLE_APPLICATION_CREDENTIALS_FILE", "", "The path to a service account key file with access to GCS.")
-	exportObjectKeyPrefix         = env.Get("CODEINTEL_RANKING_DEVELOPMENT_EXPORT_OBJECT_KEY_PREFIX", "", "The object key prefix that should be used for development exports.")
-	developmentExportRepositories = env.Get("CODEINTEL_RANKING_DEVELOPMENT_EXPORT_REPOSITORIES", "github.com/sourcegraph/sourcegraph,github.com/sourcegraph/lsif-go", "Comma-separated list of repositories whose ranks should be exported for development.")
-
-	// Backdoor tuning for dotcom
-	mergeBatchSize = env.MustGetInt("CODEINTEL_RANKING_MERGE_BATCH_SIZE", 5000, "")
-)
-
-var initServiceMemo = memo.NewMemoizedConstructorWithArg(func(deps serviceDependencies) (*Service, error) {
 	if resultsGraphKey == "" {
 		// The codenav default
 		resultsGraphKey = "dev"
@@ -81,15 +51,35 @@ var initServiceMemo = memo.NewMemoizedConstructorWithArg(func(deps serviceDepend
 	}()
 
 	return newService(
-		store.New(deps.db, scopedContext("store")),
-		deps.uploadsService,
-		deps.gitserverClient,
+		store.New(db, scopedContext("store")),
+		uploadSvc,
+		gitserverClient,
 		symbols.DefaultClient,
 		conf.DefaultClient(),
 		resultsBucket,
 		scopedContext("service"),
-	), nil
-})
+	)
+}
+
+type serviceDependencies struct {
+	db                 database.DB
+	uploadsService     *uploads.Service
+	gitserverClient    GitserverClient
+	observationContext *observation.Context
+}
+
+var (
+	// TODO - move these into background config
+	resultsBucketName             = env.Get("CODEINTEL_RANKING_RESULTS_BUCKET", "lsif-pagerank-experiments", "The GCS bucket.")
+	resultsGraphKey               = env.Get("CODEINTEL_RANKING_RESULTS_GRAPH_KEY", "dev", "An identifier of the graph export. Change to start a new import from the configured bucket.")
+	resultsObjectKeyPrefix        = env.Get("CODEINTEL_RANKING_RESULTS_OBJECT_KEY_PREFIX", "ranks/", "The object key prefix that holds results of the last PageRank batch job.")
+	resultsBucketCredentialsFile  = env.Get("CODEINTEL_RANKING_RESULTS_GOOGLE_APPLICATION_CREDENTIALS_FILE", "", "The path to a service account key file with access to GCS.")
+	exportObjectKeyPrefix         = env.Get("CODEINTEL_RANKING_DEVELOPMENT_EXPORT_OBJECT_KEY_PREFIX", "", "The object key prefix that should be used for development exports.")
+	developmentExportRepositories = env.Get("CODEINTEL_RANKING_DEVELOPMENT_EXPORT_REPOSITORIES", "github.com/sourcegraph/sourcegraph,github.com/sourcegraph/lsif-go", "Comma-separated list of repositories whose ranks should be exported for development.")
+
+	// Backdoor tuning for dotcom
+	mergeBatchSize = env.MustGetInt("CODEINTEL_RANKING_MERGE_BATCH_SIZE", 5000, "")
+)
 
 func scopedContext(component string) *observation.Context {
 	return observation.ScopedContext("codeintel", "ranking", component)

--- a/enterprise/internal/codeintel/ranking/internal/store/observability.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/observability.go
@@ -3,6 +3,9 @@ package store
 import (
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -12,13 +15,17 @@ type operations struct {
 	insertDependencyIndexingJob *observation.Operation
 }
 
-func newOperations(observationContext *observation.Context) *operations {
-	m := metrics.NewREDMetrics(
-		observationContext.Registerer,
+var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
+	return metrics.NewREDMetrics(
+		r,
 		"codeintel_ranking_store",
 		metrics.WithLabels("op"),
 		metrics.WithCountHelp("Total number of method invocations."),
-	)
+	), nil
+})
+
+func newOperations(observationContext *observation.Context) *operations {
+	m, _ := m.Init(observationContext.Registerer)
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/ranking/internal/store/observability.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/observability.go
@@ -3,9 +3,6 @@ package store
 import (
 	"fmt"
 
-	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -15,17 +12,17 @@ type operations struct {
 	insertDependencyIndexingJob *observation.Operation
 }
 
-var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
-	return metrics.NewREDMetrics(
-		r,
-		"codeintel_ranking_store",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of method invocations."),
-	), nil
-})
+var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationContext *observation.Context) *operations {
-	m, _ := m.Init(observationContext.Registerer)
+	m := m.Get(func() *metrics.REDMetrics {
+		return metrics.NewREDMetrics(
+			observationContext.Registerer,
+			"codeintel_ranking_store",
+			metrics.WithLabels("op"),
+			metrics.WithCountHelp("Total number of method invocations."),
+		)
+	})
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/ranking/observability.go
+++ b/enterprise/internal/codeintel/ranking/observability.go
@@ -3,9 +3,6 @@ package ranking
 import (
 	"fmt"
 
-	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -17,17 +14,17 @@ type operations struct {
 	indexRepository   *observation.Operation
 }
 
-var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
-	return metrics.NewREDMetrics(
-		r,
-		"codeintel_ranking",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of method invocations."),
-	), nil
-})
+var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationContext *observation.Context) *operations {
-	m, _ := m.Init(observationContext.Registerer)
+	m := m.Get(func() *metrics.REDMetrics {
+		return metrics.NewREDMetrics(
+			observationContext.Registerer,
+			"codeintel_ranking",
+			metrics.WithLabels("op"),
+			metrics.WithCountHelp("Total number of method invocations."),
+		)
+	})
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/services.go
+++ b/enterprise/internal/codeintel/services.go
@@ -27,10 +27,7 @@ type Databases struct {
 	CodeIntelDB codeintelshared.CodeIntelDB
 }
 
-// GetServices creates or returns an already-initialized codeintel service collection.
-// If the service collection is not yet initialized, a new one will be constructed using
-// the given database handles.
-func GetServices(deps Databases) (Services, error) {
+func NewServices(deps Databases) (Services, error) {
 	db, codeIntelDB := deps.DB, deps.CodeIntelDB
 	gitserverClient := gitserver.New(db, scopedContext("gitserver"))
 

--- a/enterprise/internal/codeintel/services.go
+++ b/enterprise/internal/codeintel/services.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
@@ -31,12 +30,8 @@ type Databases struct {
 // GetServices creates or returns an already-initialized codeintel service collection.
 // If the service collection is not yet initialized, a new one will be constructed using
 // the given database handles.
-func GetServices(dbs Databases) (Services, error) {
-	return initServicesMemo.Init(dbs)
-}
-
-var initServicesMemo = memo.NewMemoizedConstructorWithArg(func(dbs Databases) (Services, error) {
-	db, codeIntelDB := dbs.DB, dbs.CodeIntelDB
+func GetServices(deps Databases) (Services, error) {
+	db, codeIntelDB := deps.DB, deps.CodeIntelDB
 	gitserverClient := gitserver.New(db, scopedContext("gitserver"))
 
 	uploadsSvc := uploads.GetService(db, codeIntelDB, gitserverClient)
@@ -54,7 +49,7 @@ var initServicesMemo = memo.NewMemoizedConstructorWithArg(func(dbs Databases) (S
 		RankingService:      rankingSvc,
 		UploadsService:      uploadsSvc,
 	}, nil
-})
+}
 
 func scopedContext(component string) *observation.Context {
 	return observation.ScopedContext("codeintel", "worker", component)

--- a/enterprise/internal/codeintel/services.go
+++ b/enterprise/internal/codeintel/services.go
@@ -34,12 +34,12 @@ func GetServices(deps Databases) (Services, error) {
 	db, codeIntelDB := deps.DB, deps.CodeIntelDB
 	gitserverClient := gitserver.New(db, scopedContext("gitserver"))
 
-	uploadsSvc := uploads.GetService(db, codeIntelDB, gitserverClient)
-	dependenciesSvc := dependencies.GetService(db)
-	policiesSvc := policies.GetService(db, uploadsSvc, gitserverClient)
-	autoIndexingSvc := autoindexing.GetService(db, uploadsSvc, dependenciesSvc, policiesSvc, gitserverClient)
-	codenavSvc := codenav.GetService(db, codeIntelDB, uploadsSvc, gitserverClient)
-	rankingSvc := ranking.GetService(db, uploadsSvc, gitserverClient)
+	uploadsSvc := uploads.NewService(db, codeIntelDB, gitserverClient)
+	dependenciesSvc := dependencies.NewService(db)
+	policiesSvc := policies.NewService(db, uploadsSvc, gitserverClient)
+	autoIndexingSvc := autoindexing.NewService(db, uploadsSvc, dependenciesSvc, policiesSvc, gitserverClient)
+	codenavSvc := codenav.NewService(db, codeIntelDB, uploadsSvc, gitserverClient)
+	rankingSvc := ranking.NewService(db, uploadsSvc, gitserverClient)
 
 	return Services{
 		AutoIndexingService: autoIndexingSvc,

--- a/enterprise/internal/codeintel/uploads/init.go
+++ b/enterprise/internal/codeintel/uploads/init.go
@@ -29,9 +29,7 @@ import (
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 )
 
-// GetService creates or returns an already-initialized uploads service.
-// If the service is not yet initialized, it will use the provided dependencies.
-func GetService(
+func NewService(
 	db database.DB,
 	codeIntelDB codeintelshared.CodeIntelDB,
 	gsc GitserverClient,
@@ -72,7 +70,7 @@ func GetService(
 		locker,
 		scopedContext("service"),
 	)
-	svc.policySvc = policies.GetService(db, svc, gsc)
+	svc.policySvc = policies.NewService(db, svc, gsc)
 
 	return svc
 }

--- a/enterprise/internal/codeintel/uploads/init.go
+++ b/enterprise/internal/codeintel/uploads/init.go
@@ -23,9 +23,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/uploadstore"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 )
 
@@ -36,35 +36,11 @@ func GetService(
 	codeIntelDB codeintelshared.CodeIntelDB,
 	gsc GitserverClient,
 ) *Service {
-	svc, _ := initServiceMemo.Init(serviceDependencies{
-		db,
-		codeIntelDB,
-		gsc,
-	})
-
-	return svc
-}
-
-type serviceDependencies struct {
-	db          database.DB
-	codeIntelDB codeintelshared.CodeIntelDB
-	gsc         GitserverClient
-}
-
-var (
-	bucketName                   = env.Get("CODEINTEL_UPLOADS_RANKING_BUCKET", "lsif-pagerank-experiments", "The GCS bucket.")
-	rankingGraphKey              = env.Get("CODEINTEL_UPLOADS_RANKING_GRAPH_KEY", "dev", "An identifier of the graph export. Change to start a new export in the configured bucket.")
-	rankingGraphBatchSize        = env.MustGetInt("CODEINTEL_UPLOADS_RANKING_GRAPH_BATCH_SIZE", 16, "How many uploads to process at once.")
-	rankingGraphDeleteBatchSize  = env.MustGetInt("CODEINTEL_UPLOADS_RANKING_GRAPH_DELETE_BATCH_SIZE", 32, "How many stale uploads to delete at once.")
-	rankingBucketCredentialsFile = env.Get("CODEINTEL_UPLOADS_RANKING_GOOGLE_APPLICATION_CREDENTIALS_FILE", "", "The path to a service account key file with access to GCS.")
-)
-
-var initServiceMemo = memo.NewMemoizedConstructorWithArg(func(deps serviceDependencies) (*Service, error) {
-	store := store.New(deps.db, scopedContext("store"))
-	repoStore := backend.NewRepos(scopedContext("repos").Logger, deps.db, gitserver.NewClient(deps.db))
-	lsifStore := lsifstore.New(deps.codeIntelDB, scopedContext("lsifstore"))
-	policyMatcher := policiesEnterprise.NewMatcher(deps.gsc, policiesEnterprise.RetentionExtractor, true, false)
-	locker := locker.NewWith(deps.db, "codeintel")
+	store := store.New(db, scopedContext("store"))
+	repoStore := backend.NewRepos(scopedContext("repos").Logger, db, gitserver.NewClient(db))
+	lsifStore := lsifstore.New(codeIntelDB, scopedContext("lsifstore"))
+	policyMatcher := policiesEnterprise.NewMatcher(gsc, policiesEnterprise.RetentionExtractor, true, false)
+	locker := locker.NewWith(db, "codeintel")
 
 	rankingBucket := func() *storage.BucketHandle {
 		if rankingBucketCredentialsFile == "" && os.Getenv("ENABLE_EXPERIMENTAL_RANKING") == "" {
@@ -89,17 +65,32 @@ var initServiceMemo = memo.NewMemoizedConstructorWithArg(func(deps serviceDepend
 		store,
 		repoStore,
 		lsifStore,
-		deps.gsc,
+		gsc,
 		rankingBucket,
 		nil, // written in circular fashion
 		policyMatcher,
 		locker,
 		scopedContext("service"),
 	)
-	svc.policySvc = policies.GetService(deps.db, svc, deps.gsc)
+	svc.policySvc = policies.GetService(db, svc, gsc)
 
-	return svc, nil
-})
+	return svc
+}
+
+type serviceDependencies struct {
+	db                 database.DB
+	codeIntelDB        codeintelshared.CodeIntelDB
+	gsc                GitserverClient
+	observationContext *observation.Context
+}
+
+var (
+	bucketName                   = env.Get("CODEINTEL_UPLOADS_RANKING_BUCKET", "lsif-pagerank-experiments", "The GCS bucket.")
+	rankingGraphKey              = env.Get("CODEINTEL_UPLOADS_RANKING_GRAPH_KEY", "dev", "An identifier of the graph export. Change to start a new export in the configured bucket.")
+	rankingGraphBatchSize        = env.MustGetInt("CODEINTEL_UPLOADS_RANKING_GRAPH_BATCH_SIZE", 16, "How many uploads to process at once.")
+	rankingGraphDeleteBatchSize  = env.MustGetInt("CODEINTEL_UPLOADS_RANKING_GRAPH_DELETE_BATCH_SIZE", 32, "How many stale uploads to delete at once.")
+	rankingBucketCredentialsFile = env.Get("CODEINTEL_UPLOADS_RANKING_GOOGLE_APPLICATION_CREDENTIALS_FILE", "", "The path to a service account key file with access to GCS.")
+)
 
 func scopedContext(component string) *observation.Context {
 	return observation.ScopedContext("codeintel", "uploads", component)
@@ -116,6 +107,9 @@ func NewUploadProcessorJob(
 	observationContext *observation.Context,
 ) goroutine.BackgroundRoutine {
 	uploadsProcessorStore := dbworkerstore.NewWithMetrics(db.Handle(), store.UploadWorkerStoreOptions, observationContext)
+
+	dbworker.InitPrometheusMetric(observationContext, uploadsProcessorStore, "codeintel", "upload", nil)
+
 	return background.NewUploadProcessorWorker(
 		uploadSvc.store,
 		uploadSvc.lsifstore,

--- a/enterprise/internal/codeintel/uploads/internal/background/metrics_expirer.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/metrics_expirer.go
@@ -14,14 +14,14 @@ type ExpirationMetrics struct {
 	NumCommitsScanned      prometheus.Counter
 }
 
-var expirationMetrics = memo.NewMemoizedConstructorWithArg(func(observationContext *observation.Context) (*ExpirationMetrics, error) {
+var expirationMetrics = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*ExpirationMetrics, error) {
 	counter := func(name, help string) prometheus.Counter {
 		counter := prometheus.NewCounter(prometheus.CounterOpts{
 			Name: name,
 			Help: help,
 		})
 
-		observationContext.Registerer.MustRegister(counter)
+		r.MustRegister(counter)
 		return counter
 	}
 
@@ -51,6 +51,6 @@ var expirationMetrics = memo.NewMemoizedConstructorWithArg(func(observationConte
 })
 
 func NewExpirationMetrics(observationContext *observation.Context) *ExpirationMetrics {
-	metrics, _ := expirationMetrics.Init(observationContext)
+	metrics, _ := expirationMetrics.Init(observationContext.Registerer)
 	return metrics
 }

--- a/enterprise/internal/codeintel/uploads/internal/background/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/observability.go
@@ -6,7 +6,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/sourcegraph/sourcegraph/internal/honey"
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -24,17 +23,17 @@ type operations struct {
 	numReconcileDeletesFromCodeIntelDB prometheus.Counter
 }
 
-var once = memo.NewMemoizedConstructorWithArg(func(observationContext *observation.Context) (*metrics.REDMetrics, error) {
-	return metrics.NewREDMetrics(
-		observationContext.Registerer,
-		"codeintel_uploads_background",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of method invocations."),
-	), nil
-})
+var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationContext *observation.Context) *operations {
-	m, _ := once.Init(observationContext)
+	m := m.Get(func() *metrics.REDMetrics {
+		return metrics.NewREDMetrics(
+			observationContext.Registerer,
+			"codeintel_uploads_background",
+			metrics.WithLabels("op"),
+			metrics.WithCountHelp("Total number of method invocations."),
+		)
+	})
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
@@ -3,9 +3,6 @@ package lsifstore
 import (
 	"fmt"
 
-	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -28,17 +25,17 @@ type operations struct {
 	writeImplementations      *observation.Operation
 }
 
-var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
-	return metrics.NewREDMetrics(
-		r,
-		"codeintel_uploads_lsifstore",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of method invocations."),
-	), nil
-})
+var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationContext *observation.Context) *operations {
-	metrics, _ := m.Init(observationContext.Registerer)
+	metrics := m.Get(func() *metrics.REDMetrics {
+		return metrics.NewREDMetrics(
+			observationContext.Registerer,
+			"codeintel_uploads_lsifstore",
+			metrics.WithLabels("op"),
+			metrics.WithCountHelp("Total number of method invocations."),
+		)
+	})
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
@@ -3,6 +3,9 @@ package lsifstore
 import (
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -25,13 +28,17 @@ type operations struct {
 	writeImplementations      *observation.Operation
 }
 
-func newOperations(observationContext *observation.Context) *operations {
-	metrics := metrics.NewREDMetrics(
-		observationContext.Registerer,
+var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
+	return metrics.NewREDMetrics(
+		r,
 		"codeintel_uploads_lsifstore",
 		metrics.WithLabels("op"),
 		metrics.WithCountHelp("Total number of method invocations."),
-	)
+	), nil
+})
+
+func newOperations(observationContext *observation.Context) *operations {
+	metrics, _ := m.Init(observationContext.Registerer)
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/uploads/internal/store/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/observability.go
@@ -3,6 +3,9 @@ package store
 import (
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -78,13 +81,17 @@ type operations struct {
 	insertDependencySyncingJob *observation.Operation
 }
 
-func newOperations(observationContext *observation.Context) *operations {
-	metrics := metrics.NewREDMetrics(
-		observationContext.Registerer,
+var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
+	return metrics.NewREDMetrics(
+		r,
 		"codeintel_uploads_store",
 		metrics.WithLabels("op"),
 		metrics.WithCountHelp("Total number of method invocations."),
-	)
+	), nil
+})
+
+func newOperations(observationContext *observation.Context) *operations {
+	metrics, _ := m.Init(observationContext.Registerer)
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/uploads/internal/store/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/observability.go
@@ -3,9 +3,6 @@ package store
 import (
 	"fmt"
 
-	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -81,17 +78,17 @@ type operations struct {
 	insertDependencySyncingJob *observation.Operation
 }
 
-var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
-	return metrics.NewREDMetrics(
-		r,
-		"codeintel_uploads_store",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of method invocations."),
-	), nil
-})
+var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationContext *observation.Context) *operations {
-	metrics, _ := m.Init(observationContext.Registerer)
+	metrics := m.Get(func() *metrics.REDMetrics {
+		return metrics.NewREDMetrics(
+			observationContext.Registerer,
+			"codeintel_uploads_store",
+			metrics.WithLabels("op"),
+			metrics.WithCountHelp("Total number of method invocations."),
+		)
+	})
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/enterprise/internal/codeintel/uploads/service.go
+++ b/enterprise/internal/codeintel/uploads/service.go
@@ -21,7 +21,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
-	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -54,9 +53,6 @@ func newService(
 	observationContext *observation.Context,
 ) *Service {
 	workerutilStore := store.WorkerutilStore(observationContext)
-
-	// TODO - move this to metric reporter?
-	dbworker.InitPrometheusMetric(observationContext, workerutilStore, "codeintel", "upload", nil)
 
 	return &Service{
 		store:           store,

--- a/internal/codeintel/dependencies/init.go
+++ b/internal/codeintel/dependencies/init.go
@@ -8,9 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-// GetService creates or returns an already-initialized dependencies service.
-// If the service is not yet initialized, it will use the provided dependencies.
-func GetService(db database.DB) *Service {
+func NewService(db database.DB) *Service {
 	return newService(store.New(db, scopedContext("store")), scopedContext("service"))
 }
 

--- a/internal/codeintel/dependencies/init.go
+++ b/internal/codeintel/dependencies/init.go
@@ -5,26 +5,18 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 // GetService creates or returns an already-initialized dependencies service.
 // If the service is not yet initialized, it will use the provided dependencies.
 func GetService(db database.DB) *Service {
-	svc, _ := initServiceMemo.Init(serviceDependencies{db})
-	return svc
+	return newService(store.New(db, scopedContext("store")), scopedContext("service"))
 }
 
 type serviceDependencies struct {
 	db database.DB
 }
-
-var initServiceMemo = memo.NewMemoizedConstructorWithArg(func(deps serviceDependencies) (*Service, error) {
-	svc := newService(store.New(deps.db, scopedContext("store")), scopedContext("service"))
-
-	return svc, nil
-})
 
 // TestService creates a new dependencies service with noop observation contexts.
 func TestService(db database.DB, gitserver GitserverClient) *Service {

--- a/internal/codeintel/dependencies/internal/store/observability.go
+++ b/internal/codeintel/dependencies/internal/store/observability.go
@@ -3,6 +3,9 @@ package store
 import (
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -22,13 +25,17 @@ type operations struct {
 	getLockfileIndex             *observation.Operation
 }
 
-func newOperations(observationContext *observation.Context) *operations {
-	metrics := metrics.NewREDMetrics(
-		observationContext.Registerer,
+var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
+	return metrics.NewREDMetrics(
+		r,
 		"codeintel_dependencies_store",
 		metrics.WithLabels("op"),
 		metrics.WithCountHelp("Total number of method invocations."),
-	)
+	), nil
+})
+
+func newOperations(observationContext *observation.Context) *operations {
+	metrics, _ := m.Init(observationContext.Registerer)
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/internal/codeintel/dependencies/internal/store/observability.go
+++ b/internal/codeintel/dependencies/internal/store/observability.go
@@ -3,9 +3,6 @@ package store
 import (
 	"fmt"
 
-	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -25,17 +22,17 @@ type operations struct {
 	getLockfileIndex             *observation.Operation
 }
 
-var m = memo.NewMemoizedConstructorWithArg(func(r prometheus.Registerer) (*metrics.REDMetrics, error) {
-	return metrics.NewREDMetrics(
-		r,
-		"codeintel_dependencies_store",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of method invocations."),
-	), nil
-})
+var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationContext *observation.Context) *operations {
-	metrics, _ := m.Init(observationContext.Registerer)
+	metrics := m.Get(func() *metrics.REDMetrics {
+		return metrics.NewREDMetrics(
+			observationContext.Registerer,
+			"codeintel_dependencies_store",
+			metrics.WithLabels("op"),
+			metrics.WithCountHelp("Total number of method invocations."),
+		)
+	})
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/internal/codeintel/dependencies/observability.go
+++ b/internal/codeintel/dependencies/observability.go
@@ -3,7 +3,6 @@ package dependencies
 import (
 	"fmt"
 
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -14,17 +13,17 @@ type operations struct {
 	deleteDependencyReposByID *observation.Operation
 }
 
-var m = memo.NewMemoizedConstructorWithArg(func(observationContext *observation.Context) (*metrics.REDMetrics, error) {
-	return metrics.NewREDMetrics(
-		observationContext.Registerer,
-		"codeintel_dependencies",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of method invocations."),
-	), nil
-})
+var m = new(metrics.SingletonREDMetrics)
 
 func newOperations(observationContext *observation.Context) *operations {
-	m, _ := m.Init(observationContext)
+	m := m.Get(func() *metrics.REDMetrics {
+		return metrics.NewREDMetrics(
+			observationContext.Registerer,
+			"codeintel_dependencies",
+			metrics.WithLabels("op"),
+			metrics.WithCountHelp("Total number of method invocations."),
+		)
+	})
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/internal/luasandbox/init.go
+++ b/internal/luasandbox/init.go
@@ -5,22 +5,16 @@ import (
 	"github.com/sourcegraph/log"
 	"go.opentelemetry.io/otel"
 
-	"github.com/sourcegraph/sourcegraph/internal/memo"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
-func GetService() *Service {
-	svc, _ := initServiceMemo.Init()
-	return svc
-}
-
-var initServiceMemo = memo.NewMemoizedConstructor(func() (*Service, error) {
+func NewService() *Service {
 	observationContext := &observation.Context{
 		Logger:     log.Scoped("luasandbox", ""),
 		Tracer:     &trace.Tracer{TracerProvider: otel.GetTracerProvider()},
 		Registerer: prometheus.DefaultRegisterer,
 	}
 
-	return newService(observationContext), nil
-})
+	return newService(observationContext)
+}

--- a/internal/luasandbox/observability.go
+++ b/internal/luasandbox/observability.go
@@ -16,13 +16,17 @@ type operations struct {
 	runScriptNamed *observation.Operation
 }
 
+var m = new(metrics.SingletonREDMetrics)
+
 func newOperations(observationContext *observation.Context) *operations {
-	metrics := metrics.NewREDMetrics(
-		observationContext.Registerer,
-		"luasandbox",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of method invocations."),
-	)
+	metrics := m.Get(func() *metrics.REDMetrics {
+		return metrics.NewREDMetrics(
+			observationContext.Registerer,
+			"luasandbox",
+			metrics.WithLabels("op"),
+			metrics.WithCountHelp("Total number of method invocations."),
+		)
+	})
 
 	op := func(name string) *observation.Operation {
 		return observationContext.Operation(observation.Op{

--- a/internal/metrics/operation.go
+++ b/internal/metrics/operation.go
@@ -143,7 +143,7 @@ func NewREDMetrics(r prometheus.Registerer, metricPrefix string, fns ...REDMetri
 }
 
 type SingletonREDMetrics struct {
-	sync.Once
+	once    sync.Once
 	metrics *REDMetrics
 }
 
@@ -151,7 +151,7 @@ type SingletonREDMetrics struct {
 // created yet, one is constructed with the given create function. This method is safe to
 // access concurrently.
 func (m *SingletonREDMetrics) Get(create func() *REDMetrics) *REDMetrics {
-	m.Do(func() {
+	m.once.Do(func() {
 		m.metrics = create()
 	})
 	return m.metrics

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -463,8 +463,6 @@ commands:
     cmd: env PATH="${PWD}/.bin:$PATH" .bin/zoekt-webserver -index "$HOME/.sourcegraph/zoekt/index-1" -pprof -rpc -listen "127.0.0.1:3071"
 
   codeintel-worker:
-    env:
-      HONEYCOMB_TEAM: 1f16a2ebfbe21dd34609b4665e4e0511
     cmd: |
       export SOURCEGRAPH_LICENSE_GENERATION_KEY=$(cat ../dev-private/enterprise/dev/test-license-generation-key.pem)
       .bin/codeintel-worker

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -463,6 +463,8 @@ commands:
     cmd: env PATH="${PWD}/.bin:$PATH" .bin/zoekt-webserver -index "$HOME/.sourcegraph/zoekt/index-1" -pprof -rpc -listen "127.0.0.1:3071"
 
   codeintel-worker:
+    env:
+      HONEYCOMB_TEAM: 1f16a2ebfbe21dd34609b4665e4e0511
     cmd: |
       export SOURCEGRAPH_LICENSE_GENERATION_KEY=$(cat ../dev-private/enterprise/dev/test-license-generation-key.pem)
       .bin/codeintel-worker


### PR DESCRIPTION
As part of https://github.com/sourcegraph/sourcegraph/pull/42765 and the wider effort, we need to not have singleton memoized codeintel domain and store constructors, as otherwise this means that the first `observation.Context` passed in to a given constructor by a given consumer would be shared between unrelated consumers, and chained loggers etc would give the wrong provenance hints.

cc @efritz I know there are some areas I havent even remotely looked at here, if you could leave a comment pointing out what areas they are (things that should be a singelton, like caches etc) :thx:

## Test plan

Ran locally to check for duplicate metrics registration (seems good)
