### PR TITLE
use chunk matches over line matches for insights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Unintended newline characters that could appear in diff view rendering have been fixed. [#44805](https://github.com/sourcegraph/sourcegraph/pull/44805)
 - Signing out doesn't immediately log the user back in when there's only one OAuth provider enabled. It now redirects the user to the Sourcegraph login page. [#44803](https://github.com/sourcegraph/sourcegraph/pull/44803)
 - An issue causing certain kinds of queries to behave inconsistently in Code Insights. [#44917](https://github.com/sourcegraph/sourcegraph/pull/44917)
-- Code Insights: fixed an issue where certain queries matching sequential whitespace characters would over count. [#44969](https://github.com/sourcegraph/sourcegraph/pull/44969)
+- Code Insights: fixed an issue where certain queries matching sequential whitespace characters would overcount. [#44969](https://github.com/sourcegraph/sourcegraph/pull/44969)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Unintended newline characters that could appear in diff view rendering have been fixed. [#44805](https://github.com/sourcegraph/sourcegraph/pull/44805)
 - Signing out doesn't immediately log the user back in when there's only one OAuth provider enabled. It now redirects the user to the Sourcegraph login page. [#44803](https://github.com/sourcegraph/sourcegraph/pull/44803)
 - An issue causing certain kinds of queries to behave inconsistently in Code Insights. [#44917](https://github.com/sourcegraph/sourcegraph/pull/44917)
+- Code Insights: fixed an issue where certain queries matching sequential whitespace characters would over count. [#44969](https://github.com/sourcegraph/sourcegraph/pull/44969)
 
 ### Removed
 

--- a/enterprise/internal/insights/query/streaming/decoder.go
+++ b/enterprise/internal/insights/query/streaming/decoder.go
@@ -80,8 +80,8 @@ func TabulationDecoder() (streamhttp.FrontendStreamDecoder, *TabulationResult) {
 				switch match := match.(type) {
 				case *streamhttp.EventContentMatch:
 					count := 0
-					for _, lineMatch := range match.LineMatches {
-						count += len(lineMatch.OffsetAndLengths)
+					for _, chunkMatch := range match.ChunkMatches {
+						count += len(chunkMatch.Ranges)
 					}
 					tr.TotalCount += count
 					addCount(match.Repository, match.RepositoryID, count)

--- a/enterprise/internal/insights/query/streaming/search.go
+++ b/enterprise/internal/insights/query/streaming/search.go
@@ -40,6 +40,10 @@ func Search(ctx context.Context, query string, patternType *string, decoder stre
 		query.Add("t", *patternType)
 		req.URL.RawQuery = query.Encode()
 	}
+	// to receive chunk matches we must set this url parameter
+	rq := req.URL.Query()
+	rq.Add("cm", "t")
+	req.URL.RawQuery = rq.Encode()
 
 	req = req.WithContext(ctx)
 	req.Header.Set("User-Agent", "code-insights-backend")


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/44965
This solves a bug where multiple whitespaces in a sequence would produce too many line matches. It seems we just missed the boat at some point when this became exposed in the API, so we would want to migrate anyway. The next step will be to retire this for the internal search client, but this solves the bug for now.


## Test plan

Here is an example insight that demonstrated the overcounting bug before and after.

<img width="847" alt="CleanShot 2022-11-30 at 15 41 16@2x" src="https://user-images.githubusercontent.com/5090588/204923834-2d49f0b5-ab74-4477-85b5-9f2b1dbfd4b0.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
