### PR TITLE
Code Insights: Simplify code insight root page URL handling

### DIFF
--- a/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
@@ -14,11 +14,7 @@ import { HeroPage } from '../../components/HeroPage'
 
 import { CodeInsightsBackendContext } from './core'
 import { GaConfirmationModal } from './modals/GaConfirmationModal'
-import {
-    CodeInsightsRootPage,
-    CodeInsightsRootPageTab,
-    CodeInsightsRootPageURLPaths,
-} from './pages/CodeInsightsRootPage'
+import { CodeInsightsRootPage, CodeInsightsRootPageTab } from './pages/CodeInsightsRootPage'
 import { InsightsDashboardCreationPage } from './pages/dashboards/creation/InsightsDashboardCreationPage'
 import { EditDashboardPage } from './pages/dashboards/edit-dashboard/EditDashobardPage'
 import { CreationRoutes } from './pages/insights/creation/CreationRoutes'
@@ -102,14 +98,12 @@ export const CodeInsightsAppRouter = withAuthenticatedUser<CodeInsightsAppRouter
                 />
 
                 <Route
-                    path={[
-                        `${match.url}${CodeInsightsRootPageURLPaths.CodeInsights}`,
-                        `${match.url}${CodeInsightsRootPageURLPaths.GettingStarted}`,
-                    ]}
-                    render={props => (
+                    path={[`${match.url}/dashboards/:dashboardId?`, `${match.url}/about`]}
+                    render={(props: RouteComponentProps<{ dashboardId?: string }>) => (
                         <CodeInsightsRootPage
+                            dashboardId={props.match.params.dashboardId}
                             activeView={
-                                props.match.path === `${match.url}${CodeInsightsRootPageURLPaths.CodeInsights}`
+                                props.match.params.dashboardId
                                     ? CodeInsightsRootPageTab.CodeInsights
                                     : CodeInsightsRootPageTab.GettingStarted
                             }

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.module.scss
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.module.scss
@@ -1,0 +1,13 @@
+.header {
+    display: flex;
+    align-items: flex-start;
+    margin-bottom: 1rem;
+}
+
+.tabs {
+    margin-bottom: 1rem;
+}
+
+.tab-panels {
+    margin-top: 1rem;
+}

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -1,8 +1,7 @@
-import React, { Suspense } from 'react'
+import { Suspense, FC } from 'react'
 
 import { mdiPlus } from '@mdi/js'
-import { matchPath, useHistory } from 'react-router'
-import { useLocation } from 'react-router-dom'
+import { useHistory } from 'react-router'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
@@ -22,54 +21,37 @@ import {
 import { CodeInsightsIcon } from '../../../insights/Icons'
 import { CodeInsightsPage } from '../components'
 import { ALL_INSIGHTS_DASHBOARD } from '../constants'
+import { useQueryParameters } from '../hooks'
 
 import { DashboardsContentPage } from './dashboards/dashboard-page/DashboardsContentPage'
+
+import styles from './CodeInsightsRootPage.module.scss'
 
 const LazyCodeInsightsGettingStartedPage = lazyComponent(
     () => import('./landing/getting-started/CodeInsightsGettingStartedPage'),
     'CodeInsightsGettingStartedPage'
 )
 
-export enum CodeInsightsRootPageURLPaths {
-    CodeInsights = '/dashboards/:dashboardId?',
-    GettingStarted = '/about',
-}
-
 export enum CodeInsightsRootPageTab {
     CodeInsights,
     GettingStarted,
 }
 
-function useQuery(): URLSearchParams {
-    const { search } = useLocation()
-
-    return React.useMemo(() => new URLSearchParams(search), [search])
-}
-
 interface CodeInsightsRootPageProps extends TelemetryProps {
+    dashboardId?: string
     activeView: CodeInsightsRootPageTab
 }
 
-export const CodeInsightsRootPage: React.FunctionComponent<
-    React.PropsWithChildren<CodeInsightsRootPageProps>
-> = props => {
-    const { telemetryService, activeView } = props
-    const location = useLocation()
-    const query = useQuery()
+export const CodeInsightsRootPage: FC<CodeInsightsRootPageProps> = props => {
+    const { dashboardId = ALL_INSIGHTS_DASHBOARD.id, activeView, telemetryService } = props
+
     const history = useHistory()
-
-    const { params } =
-        matchPath<{ dashboardId?: string }>(location.pathname, {
-            path: `/insights${CodeInsightsRootPageURLPaths.CodeInsights}`,
-        }) ?? {}
-
-    const dashboardId = params?.dashboardId ?? ALL_INSIGHTS_DASHBOARD.id
-    const queryParameterDashboardId = query.get('dashboardId') ?? ALL_INSIGHTS_DASHBOARD.id
+    const { dashboardId: queryParamDashboardId = ALL_INSIGHTS_DASHBOARD.id } = useQueryParameters(['dashboardId'])
 
     const handleTabNavigationChange = (selectedTab: CodeInsightsRootPageTab): void => {
         switch (selectedTab) {
             case CodeInsightsRootPageTab.CodeInsights:
-                return history.push(`/insights/dashboards/${queryParameterDashboardId}`)
+                return history.push(`/insights/dashboards/${queryParamDashboardId}`)
             case CodeInsightsRootPageTab.GettingStarted:
                 return history.push(`/insights/about?dashboardId=${dashboardId}`)
         }
@@ -79,38 +61,24 @@ export const CodeInsightsRootPage: React.FunctionComponent<
         <CodeInsightsPage>
             <PageHeader
                 path={[{ icon: CodeInsightsIcon, text: 'Insights' }]}
-                actions={
-                    <>
-                        <Button
-                            as={Link}
-                            to="/insights/add-dashboard"
-                            variant="secondary"
-                            className="mr-2"
-                            aria-label="Add dashboard"
-                        >
-                            <Icon aria-hidden={true} svgPath={mdiPlus} /> Add dashboard
-                        </Button>
-                        <Button
-                            as={Link}
-                            to={`/insights/create?dashboardId=${dashboardId}`}
-                            variant="primary"
-                            onClick={() => telemetryService.log('InsightAddMoreClick')}
-                        >
-                            <Icon aria-hidden={true} svgPath={mdiPlus} /> Create insight
-                        </Button>
-                    </>
-                }
-                className="align-items-start mb-3"
+                actions={<CodeInsightHeaderActions dashboardId={dashboardId} telemetryService={telemetryService} />}
+                className={styles.header}
             />
 
-            <Tabs index={activeView} size="medium" className="mb-3" onChange={handleTabNavigationChange} lazy={true}>
+            <Tabs
+                index={activeView}
+                lazy={true}
+                size="medium"
+                className={styles.tabs}
+                onChange={handleTabNavigationChange}
+            >
                 <TabList>
                     <Tab index={CodeInsightsRootPageTab.CodeInsights}>Code Insights</Tab>
                     <Tab index={CodeInsightsRootPageTab.GettingStarted}>Getting started</Tab>
                 </TabList>
-                <TabPanels className="mt-3">
+                <TabPanels className={styles.tabPanels}>
                     <TabPanel>
-                        <DashboardsContentPage telemetryService={telemetryService} dashboardID={params?.dashboardId} />
+                        <DashboardsContentPage telemetryService={telemetryService} dashboardID={dashboardId} />
                     </TabPanel>
                     <TabPanel>
                         <Suspense fallback={<LoadingSpinner aria-label="Loading Code Insights Getting started page" />}>
@@ -120,5 +88,35 @@ export const CodeInsightsRootPage: React.FunctionComponent<
                 </TabPanels>
             </Tabs>
         </CodeInsightsPage>
+    )
+}
+
+interface CodeInsightHeaderActionsProps extends TelemetryProps {
+    dashboardId: string
+}
+
+const CodeInsightHeaderActions: FC<CodeInsightHeaderActionsProps> = props => {
+    const { dashboardId, telemetryService } = props
+
+    return (
+        <>
+            <Button
+                as={Link}
+                to="/insights/add-dashboard"
+                variant="secondary"
+                className="mr-2"
+                aria-label="Add dashboard"
+            >
+                <Icon aria-hidden={true} svgPath={mdiPlus} /> Add dashboard
+            </Button>
+            <Button
+                as={Link}
+                to={`/insights/create?dashboardId=${dashboardId}`}
+                variant="primary"
+                onClick={() => telemetryService.log('InsightAddMoreClick')}
+            >
+                <Icon aria-hidden={true} svgPath={mdiPlus} /> Create insight
+            </Button>
+        </>
     )
 }

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -43,7 +43,7 @@ interface CodeInsightsRootPageProps extends TelemetryProps {
 }
 
 export const CodeInsightsRootPage: FC<CodeInsightsRootPageProps> = props => {
-    const { dashboardId = ALL_INSIGHTS_DASHBOARD.id, activeView, telemetryService } = props
+    const { dashboardId, activeView, telemetryService } = props
 
     const history = useHistory()
     const { dashboardId: queryParamDashboardId = ALL_INSIGHTS_DASHBOARD.id } = useQueryParameters(['dashboardId'])
@@ -92,7 +92,7 @@ export const CodeInsightsRootPage: FC<CodeInsightsRootPageProps> = props => {
 }
 
 interface CodeInsightHeaderActionsProps extends TelemetryProps {
-    dashboardId: string
+    dashboardId?: string
 }
 
 const CodeInsightHeaderActions: FC<CodeInsightHeaderActionsProps> = props => {

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.tsx
@@ -14,7 +14,7 @@ import { DashboardsContent } from './components/dashboards-content/DashboardsCon
 
 export interface DashboardsContentPageProps extends TelemetryProps {
     /**
-     * Possible dashboard id. All insights on the page will be get from
+     * Possible dashboard id. All insights on the page will be got from
      * dashboard's info from the user or org settings by the dashboard id.
      * In case if id is undefined we get insights from the final
      * version of merged settings (all insights)


### PR DESCRIPTION
Preparation for https://github.com/sourcegraph/sourcegraph/issues/43561

This PR simplifies dashboard/getting started page URL handling. Previously rendered pages had to inform URL parameters by themselves. In this PR, react-router extracts URL page param. 

## Test plan
- Open the dashboard page. 
- Make sure that you can navigate between Dashboard and the getting started tab and URL changing accordingly 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-move-all-insights-dashboard.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
