### PR TITLE
codeintel: Add SCIP metadata insert method

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
@@ -9749,6 +9749,9 @@ type MockLsifStore struct {
 	// IDsWithMetaFunc is an instance of a mock function object controlling
 	// the behavior of the method IDsWithMeta.
 	IDsWithMetaFunc *LsifStoreIDsWithMetaFunc
+	// InsertMetadataFunc is an instance of a mock function object
+	// controlling the behavior of the method InsertMetadata.
+	InsertMetadataFunc *LsifStoreInsertMetadataFunc
 	// InsertSCIPDocumentFunc is an instance of a mock function object
 	// controlling the behavior of the method InsertSCIPDocument.
 	InsertSCIPDocumentFunc *LsifStoreInsertSCIPDocumentFunc
@@ -9811,6 +9814,11 @@ func NewMockLsifStore() *MockLsifStore {
 		},
 		IDsWithMetaFunc: &LsifStoreIDsWithMetaFunc{
 			defaultHook: func(context.Context, []int) (r0 []int, r1 error) {
+				return
+			},
+		},
+		InsertMetadataFunc: &LsifStoreInsertMetadataFunc{
+			defaultHook: func(context.Context, int, lsifstore.ProcessedMetadata) (r0 error) {
 				return
 			},
 		},
@@ -9906,6 +9914,11 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.IDsWithMeta")
 			},
 		},
+		InsertMetadataFunc: &LsifStoreInsertMetadataFunc{
+			defaultHook: func(context.Context, int, lsifstore.ProcessedMetadata) error {
+				panic("unexpected invocation of MockLsifStore.InsertMetadata")
+			},
+		},
 		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
 			defaultHook: func(context.Context, int, string, []byte, []byte) (int, error) {
 				panic("unexpected invocation of MockLsifStore.InsertSCIPDocument")
@@ -9989,6 +10002,9 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		},
 		IDsWithMetaFunc: &LsifStoreIDsWithMetaFunc{
 			defaultHook: i.IDsWithMeta,
+		},
+		InsertMetadataFunc: &LsifStoreInsertMetadataFunc{
+			defaultHook: i.InsertMetadata,
 		},
 		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
 			defaultHook: i.InsertSCIPDocument,
@@ -10471,6 +10487,114 @@ func (c LsifStoreIDsWithMetaFuncCall) Args() []interface{} {
 // invocation.
 func (c LsifStoreIDsWithMetaFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// LsifStoreInsertMetadataFunc describes the behavior when the
+// InsertMetadata method of the parent MockLsifStore instance is invoked.
+type LsifStoreInsertMetadataFunc struct {
+	defaultHook func(context.Context, int, lsifstore.ProcessedMetadata) error
+	hooks       []func(context.Context, int, lsifstore.ProcessedMetadata) error
+	history     []LsifStoreInsertMetadataFuncCall
+	mutex       sync.Mutex
+}
+
+// InsertMetadata delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockLsifStore) InsertMetadata(v0 context.Context, v1 int, v2 lsifstore.ProcessedMetadata) error {
+	r0 := m.InsertMetadataFunc.nextHook()(v0, v1, v2)
+	m.InsertMetadataFunc.appendCall(LsifStoreInsertMetadataFuncCall{v0, v1, v2, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the InsertMetadata
+// method of the parent MockLsifStore instance is invoked and the hook queue
+// is empty.
+func (f *LsifStoreInsertMetadataFunc) SetDefaultHook(hook func(context.Context, int, lsifstore.ProcessedMetadata) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// InsertMetadata method of the parent MockLsifStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *LsifStoreInsertMetadataFunc) PushHook(hook func(context.Context, int, lsifstore.ProcessedMetadata) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreInsertMetadataFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int, lsifstore.ProcessedMetadata) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreInsertMetadataFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int, lsifstore.ProcessedMetadata) error {
+		return r0
+	})
+}
+
+func (f *LsifStoreInsertMetadataFunc) nextHook() func(context.Context, int, lsifstore.ProcessedMetadata) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreInsertMetadataFunc) appendCall(r0 LsifStoreInsertMetadataFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LsifStoreInsertMetadataFuncCall objects
+// describing the invocations of this function.
+func (f *LsifStoreInsertMetadataFunc) History() []LsifStoreInsertMetadataFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreInsertMetadataFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreInsertMetadataFuncCall is an object that describes an invocation
+// of method InsertMetadata on an instance of MockLsifStore.
+type LsifStoreInsertMetadataFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 lsifstore.ProcessedMetadata
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreInsertMetadataFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreInsertMetadataFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }
 
 // LsifStoreInsertSCIPDocumentFunc describes the behavior when the

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore.go
@@ -17,6 +17,7 @@ type LsifStore interface {
 	GetUploadDocumentsForPath(ctx context.Context, bundleID int, pathPattern string) ([]string, int, error)
 	DeleteLsifDataByUploadIds(ctx context.Context, bundleIDs ...int) (err error)
 
+	InsertMetadata(ctx context.Context, uploadID int, meta ProcessedMetadata) error
 	NewSymbolWriter(ctx context.Context, uploadID int) (SymbolWriter, error)
 	InsertSCIPDocument(ctx context.Context, uploadID int, documentPath string, hash []byte, rawSCIPPayload []byte) (int, error)
 

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
@@ -15,6 +15,7 @@ type operations struct {
 	scanDocuments             *observation.Operation
 	scanResultChunks          *observation.Operation
 	scanLocations             *observation.Operation
+	insertMetadata            *observation.Operation
 	insertSCIPDocument        *observation.Operation
 	writeMeta                 *observation.Operation
 	writeDocuments            *observation.Operation
@@ -48,6 +49,7 @@ func newOperations(observationContext *observation.Context) *operations {
 		scanDocuments:             op("ScanDocuments"),
 		scanResultChunks:          op("ScanResultChunks"),
 		scanLocations:             op("ScanLocations"),
+		insertMetadata:            op("InsertMetadata"),
 		insertSCIPDocument:        op("InsertSCIPDocument"),
 		writeMeta:                 op("WriteMeta"),
 		writeDocuments:            op("WriteDocuments"),

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_write_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_write_test.go
@@ -13,6 +13,23 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
+func TestInsertMetadata(t *testing.T) {
+	logger := logtest.Scoped(t)
+	codeIntelDB := codeintelshared.NewCodeIntelDB(dbtest.NewDB(logger, t))
+	store := New(codeIntelDB, &observation.TestContext)
+	ctx := context.Background()
+
+	if err := store.InsertMetadata(ctx, 42, ProcessedMetadata{
+		TextDocumentEncoding: "UTF8",
+		ToolName:             "scip-test",
+		ToolVersion:          "0.1.0",
+		ToolArguments:        []string{"-p", "src"},
+		ProtocolVersion:      1,
+	}); err != nil {
+		t.Fatalf("failed to insert metadata: %s", err)
+	}
+}
+
 func TestInsertSCIPDocument(t *testing.T) {
 	logger := logtest.Scoped(t)
 	codeIntelDB := codeintelshared.NewCodeIntelDB(dbtest.NewDB(logger, t))

--- a/enterprise/internal/codeintel/uploads/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/mocks_test.go
@@ -7420,6 +7420,9 @@ type MockLsifStore struct {
 	// IDsWithMetaFunc is an instance of a mock function object controlling
 	// the behavior of the method IDsWithMeta.
 	IDsWithMetaFunc *LsifStoreIDsWithMetaFunc
+	// InsertMetadataFunc is an instance of a mock function object
+	// controlling the behavior of the method InsertMetadata.
+	InsertMetadataFunc *LsifStoreInsertMetadataFunc
 	// InsertSCIPDocumentFunc is an instance of a mock function object
 	// controlling the behavior of the method InsertSCIPDocument.
 	InsertSCIPDocumentFunc *LsifStoreInsertSCIPDocumentFunc
@@ -7482,6 +7485,11 @@ func NewMockLsifStore() *MockLsifStore {
 		},
 		IDsWithMetaFunc: &LsifStoreIDsWithMetaFunc{
 			defaultHook: func(context.Context, []int) (r0 []int, r1 error) {
+				return
+			},
+		},
+		InsertMetadataFunc: &LsifStoreInsertMetadataFunc{
+			defaultHook: func(context.Context, int, lsifstore.ProcessedMetadata) (r0 error) {
 				return
 			},
 		},
@@ -7577,6 +7585,11 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.IDsWithMeta")
 			},
 		},
+		InsertMetadataFunc: &LsifStoreInsertMetadataFunc{
+			defaultHook: func(context.Context, int, lsifstore.ProcessedMetadata) error {
+				panic("unexpected invocation of MockLsifStore.InsertMetadata")
+			},
+		},
 		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
 			defaultHook: func(context.Context, int, string, []byte, []byte) (int, error) {
 				panic("unexpected invocation of MockLsifStore.InsertSCIPDocument")
@@ -7660,6 +7673,9 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		},
 		IDsWithMetaFunc: &LsifStoreIDsWithMetaFunc{
 			defaultHook: i.IDsWithMeta,
+		},
+		InsertMetadataFunc: &LsifStoreInsertMetadataFunc{
+			defaultHook: i.InsertMetadata,
 		},
 		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
 			defaultHook: i.InsertSCIPDocument,
@@ -8142,6 +8158,114 @@ func (c LsifStoreIDsWithMetaFuncCall) Args() []interface{} {
 // invocation.
 func (c LsifStoreIDsWithMetaFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// LsifStoreInsertMetadataFunc describes the behavior when the
+// InsertMetadata method of the parent MockLsifStore instance is invoked.
+type LsifStoreInsertMetadataFunc struct {
+	defaultHook func(context.Context, int, lsifstore.ProcessedMetadata) error
+	hooks       []func(context.Context, int, lsifstore.ProcessedMetadata) error
+	history     []LsifStoreInsertMetadataFuncCall
+	mutex       sync.Mutex
+}
+
+// InsertMetadata delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockLsifStore) InsertMetadata(v0 context.Context, v1 int, v2 lsifstore.ProcessedMetadata) error {
+	r0 := m.InsertMetadataFunc.nextHook()(v0, v1, v2)
+	m.InsertMetadataFunc.appendCall(LsifStoreInsertMetadataFuncCall{v0, v1, v2, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the InsertMetadata
+// method of the parent MockLsifStore instance is invoked and the hook queue
+// is empty.
+func (f *LsifStoreInsertMetadataFunc) SetDefaultHook(hook func(context.Context, int, lsifstore.ProcessedMetadata) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// InsertMetadata method of the parent MockLsifStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *LsifStoreInsertMetadataFunc) PushHook(hook func(context.Context, int, lsifstore.ProcessedMetadata) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreInsertMetadataFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int, lsifstore.ProcessedMetadata) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreInsertMetadataFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int, lsifstore.ProcessedMetadata) error {
+		return r0
+	})
+}
+
+func (f *LsifStoreInsertMetadataFunc) nextHook() func(context.Context, int, lsifstore.ProcessedMetadata) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreInsertMetadataFunc) appendCall(r0 LsifStoreInsertMetadataFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LsifStoreInsertMetadataFuncCall objects
+// describing the invocations of this function.
+func (f *LsifStoreInsertMetadataFunc) History() []LsifStoreInsertMetadataFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreInsertMetadataFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreInsertMetadataFuncCall is an object that describes an invocation
+// of method InsertMetadata on an instance of MockLsifStore.
+type LsifStoreInsertMetadataFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 lsifstore.ProcessedMetadata
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreInsertMetadataFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreInsertMetadataFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }
 
 // LsifStoreInsertSCIPDocumentFunc describes the behavior when the


### PR DESCRIPTION
Add a method to insert SCIP metadata into the codeintel-db.

## Test plan

New unit tests.