### PR TITLE
codeintel: Remove conflict clause

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_write.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_write.go
@@ -234,5 +234,4 @@ SELECT
 	source.implementation_ranges,
 	source.type_definition_ranges
 FROM t_codeintel_scip_symbols source
-ON CONFLICT DO NOTHING
 `


### PR DESCRIPTION
Do not expect conflicts when inserting symbols.

## Test plan

N/A.