### PR TITLE
blobstore: build s3proxy from source ourselves; use our base alpine image

### DIFF
--- a/docker-images/blobstore/Dockerfile
+++ b/docker-images/blobstore/Dockerfile
@@ -1,10 +1,15 @@
 # Build s3proxy from source
 # hadolint ignore=DL3022
 FROM maven:3.8.6-openjdk-11-slim AS builder
-RUN apt-get update -y && apt-get install -y git
+
+# hadolint ignore=DL3008,DL3009
+RUN add-apt-repository ppa:git-core/ppa && \
+  apt-get update && \
+  apt-get install -y --no-install-recommends git
+
 RUN git clone https://github.com/sourcegraph/s3proxy
-RUN cd s3proxy/ && \
-    mvn package -DskipTests && \
+WORKDIR s3proxy
+RUN mvn package -DskipTests && \
     mv target/ /opt/s3proxy && \
     cp src/main/resources/run-docker-container.sh /opt/s3proxy
 

--- a/docker-images/blobstore/Dockerfile
+++ b/docker-images/blobstore/Dockerfile
@@ -6,8 +6,8 @@ FROM maven:3.8.6-openjdk-11-slim AS builder
 RUN apt-get update && \
   apt-get install -y --no-install-recommends git
 
-RUN git clone https://github.com/sourcegraph/s3proxy
-WORKDIR s3proxy
+RUN git clone https://github.com/sourcegraph/s3proxy /build
+WORKDIR /build
 RUN mvn package -DskipTests && \
     mv target/ /opt/s3proxy && \
     cp src/main/resources/run-docker-container.sh /opt/s3proxy

--- a/docker-images/blobstore/Dockerfile
+++ b/docker-images/blobstore/Dockerfile
@@ -3,8 +3,7 @@
 FROM maven:3.8.6-openjdk-11-slim AS builder
 
 # hadolint ignore=DL3008,DL3009
-RUN add-apt-repository ppa:git-core/ppa && \
-  apt-get update && \
+RUN apt-get update && \
   apt-get install -y --no-install-recommends git
 
 RUN git clone https://github.com/sourcegraph/s3proxy

--- a/docker-images/blobstore/Dockerfile
+++ b/docker-images/blobstore/Dockerfile
@@ -1,0 +1,60 @@
+# Build s3proxy from source
+# hadolint ignore=DL3022
+FROM maven:3.8.6-openjdk-11-slim AS builder
+RUN apt-get update -y && apt-get install -y git
+RUN git clone https://github.com/sourcegraph/s3proxy
+RUN cd s3proxy/ && \
+    mvn package -DskipTests && \
+    mv target/ /opt/s3proxy && \
+    cp src/main/resources/run-docker-container.sh /opt/s3proxy
+
+# Build our final Alpine-based image
+FROM sourcegraph/alpine-3.14:180512_2022-10-31_84d1e240bb40@sha256:179ad53ab463ebc804f93de967113739fa73efc2cea6d9c53a9106be45f79d5e
+
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL org.opencontainers.image.url=https://sourcegraph.com/
+LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph/
+LABEL org.opencontainers.image.documentation=https://docs.sourcegraph.com/
+LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
+
+RUN apk update && apk add --no-cache \
+    openjdk11
+
+COPY --from=builder /opt/s3proxy /opt/s3proxy
+
+ENV \
+    LOG_LEVEL="info" \
+    S3PROXY_AUTHORIZATION="aws-v2-or-v4" \
+    S3PROXY_ENDPOINT="http://0.0.0.0:80" \
+    S3PROXY_IDENTITY="local-identity" \
+    S3PROXY_CREDENTIAL="local-credential" \
+    S3PROXY_VIRTUALHOST="" \
+    S3PROXY_CORS_ALLOW_ALL="false" \
+    S3PROXY_CORS_ALLOW_ORIGINS="" \
+    S3PROXY_CORS_ALLOW_METHODS="" \
+    S3PROXY_CORS_ALLOW_HEADERS="" \
+    S3PROXY_IGNORE_UNKNOWN_HEADERS="false" \
+    S3PROXY_ENCRYPTED_BLOBSTORE="" \
+    S3PROXY_ENCRYPTED_BLOBSTORE_PASSWORD="" \
+    S3PROXY_ENCRYPTED_BLOBSTORE_SALT="" \
+    JCLOUDS_PROVIDER="filesystem" \
+    JCLOUDS_ENDPOINT="" \
+    JCLOUDS_REGION="" \
+    JCLOUDS_REGIONS="us-east-1" \
+    JCLOUDS_IDENTITY="remote-identity" \
+    JCLOUDS_CREDENTIAL="remote-credential" \
+    JCLOUDS_KEYSTONE_VERSION="" \
+    JCLOUDS_KEYSTONE_SCOPE="" \
+    JCLOUDS_KEYSTONE_PROJECT_DOMAIN_NAME="" \
+    JCLOUDS_FILESYSTEM_BASEDIR="/data"
+
+EXPOSE 80
+USER sourcegraph
+WORKDIR /opt/s3proxy
+ENTRYPOINT ["/sbin/tini", "--", "/opt/s3proxy/run-docker-container.sh"]

--- a/docker-images/blobstore/build.sh
+++ b/docker-images/blobstore/build.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-
-set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
+set -ex
 
-# Retag the release
-S3PROXY_RELEASE="sha-ba0fd6d"
-docker pull andrewgaul/s3proxy:$S3PROXY_RELEASE
-docker rmi "$IMAGE" || true
-docker tag andrewgaul/s3proxy:$S3PROXY_RELEASE "$IMAGE"
+docker build --no-cache -t "${IMAGE:-"sourcegraph/blobstore"}" . \
+  --progress=plain \
+  --build-arg COMMIT_SHA \
+  --build-arg DATE \
+  --build-arg VERSION

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -559,7 +559,7 @@ commands:
         -p 0.0.0.0:9000:80 \
         -e 'S3PROXY_AUTHORIZATION=none' \
         -v "$BLOBSTORE_DISK":/data \
-        $IMAGE server /data >"$BLOBSTORE_LOG_FILE" 2>&1
+        $IMAGE >"$BLOBSTORE_LOG_FILE" 2>&1
     install: |
       mkdir -p $BLOBSTORE_LOGS
       mkdir -p $BLOBSTORE_DISK


### PR DESCRIPTION
* We now maintain a fork of the s3proxy repo here: https://github.com/sourcegraph/s3proxy (no actual changes, just for source control on our side.)
* We now build s3proxy from source in the Dockerfile using Maven.
* `sourcegraph/blobstore` is now based on our base Alpine image, so we get all our normal goodies (tini init, proper UID/GID, etc.)

Helps #44254

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>

## Test plan

Manually ensured the new image runs as expected.
