### PR TITLE
Update secondary rate limit avoidance docs

### DIFF
--- a/doc/admin/config/batch_changes.md
+++ b/doc/admin/config/batch_changes.md
@@ -46,9 +46,9 @@ You may encounter this error when publishing changesets to GitHub:
 >
 > Creating changeset: error in GraphQL response: was submitted too quickly
 
-In addition to their normal API rate limits, GitHub also has an internal _content creation_ limit, which is an intentional restriction on the platform to combat abuse by automated actors. At the time of writing, the specifics of this limit remain undocumented, due largely to the fact that it is dynamically determined (see [this GitHub issue](https://github.com/cli/cli/issues/4801)). However, the behavior of the limit is that it only permits a fixed number of resources to be created per minute and per hour, and exceeding this limit triggers a temporary hour-long suspension during which time no additional resources of this type can be created.
+In addition to their normal API rate limits, GitHub also has an internal _content creation_ limit (also called [secondary rate limit](https://docs.github.com/en/rest/guides/best-practices-for-integrators?apiVersion=2022-11-28#dealing-with-secondary-rate-limits)), which is an [intentional](https://github.com/cli/cli/issues/4801#issuecomment-1029207971) restriction on the platform to combat abuse by automated actors. At the time of writing, the specifics of this limit remain undocumented, due largely to the fact that it is dynamically determined (see [this GitHub issue](https://github.com/cli/cli/issues/4801)). However, the behavior of the limit is that it only permits a fixed number of resources to be created per minute and per hour, and exceeding this limit triggers a temporary hour-long suspension during which time no additional resources of this type can be created.
 
-Presently, Batch Changes does not automatically work around this limit (feature request tracked [here](https://github.com/sourcegraph/sourcegraph/issues/39847)). The current guidance if you do encounter this issue is to just to wait an hour and then try again.
+Presently, Batch Changes does not automatically work around this limit (feature request tracked [here](https://github.com/sourcegraph/sourcegraph/issues/44631). The current guidance if you do encounter this issue is to wait an hour and then try again, setting a less frequent `rolloutWindows` rate until this issue is no longer encountered.
 
 ### Rollout window object
 


### PR DESCRIPTION
This PR updates our docs a little providing more documentation links as well as a new tracking issue -- the old one was closed after adding the logging for when a secondary rate limit is encountered. The new feature request targets having a more automated solution to this issue.



## Test plan
locally tested

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
