### PR TITLE
Add an UpdateWebhook mutation to the GraphQL resolver

### DIFF
--- a/cmd/frontend/backend/webhooks_test.go
+++ b/cmd/frontend/backend/webhooks_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/log/logtest"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -97,4 +99,58 @@ func TestCreateWebhook(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCreateUpdateDeleteWebhook(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := context.Background()
+
+	users := database.NewMockUserStore()
+	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
+	newUser := database.NewUser{Username: "testUser"}
+	createdUser, err := db.Users().Create(ctx, newUser)
+	require.NoError(t, err)
+	require.NoError(t, db.Users().SetIsSiteAdmin(ctx, createdUser.ID, true))
+
+	ctx = actor.WithActor(ctx, &actor.Actor{UID: createdUser.ID})
+
+	ws := NewWebhookService(db, keyring.Default())
+
+	// Create webhook
+	secret := "12345"
+	webhook, err := ws.CreateWebhook(ctx, "github", extsvc.KindGitHub, "https://github.com", &secret)
+	require.NoError(t, err)
+	assert.Equal(t, "github", webhook.Name)
+	assert.Equal(t, extsvc.KindGitHub, webhook.CodeHostKind)
+	assert.Equal(t, "https://github.com/", webhook.CodeHostURN.String())
+	whSecret, err := webhook.Secret.Decrypt(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, secret, whSecret)
+
+	// Update webhook
+	newSecret := "54321"
+	newName := "new name"
+	newCodeHostKind := extsvc.KindGitLab
+	newCodeHostURL := "https://gitlab.com/"
+	newWebhook, err := ws.UpdateWebhook(ctx, webhook.ID, &newName, &newCodeHostKind, &newCodeHostURL, &newSecret)
+	require.NoError(t, err)
+	// assert that it's still the same webhook
+	assert.Equal(t, webhook.ID, newWebhook.ID)
+	assert.Equal(t, webhook.UUID, newWebhook.UUID)
+	// assert values updated correctly
+	assert.Equal(t, newName, newWebhook.Name)
+	assert.Equal(t, newCodeHostKind, newWebhook.CodeHostKind)
+	assert.Equal(t, newCodeHostURL, newWebhook.CodeHostURN.String())
+	newWHSecret, err := newWebhook.Secret.Decrypt(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, newSecret, newWHSecret)
+
+	// Delete webhook
+	err = ws.DeleteWebhook(ctx, webhook.ID)
+	require.NoError(t, err)
+	// assert webhook no longer exists
+	deletedWH, err := db.Webhooks(keyring.Default().WebhookKey).GetByID(ctx, webhook.ID)
+	assert.Nil(t, deletedWH)
+	assert.Error(t, err)
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -116,7 +116,7 @@ type Mutation {
     """
     Updates a webhook with given ID. Empty fields are not updated.
     """
-    updateWebhook(id: ID!, name: String, codeHostKind: String, codeHostURN: String, secret: String): EmptyResponse!
+    updateWebhook(id: ID!, name: String, codeHostKind: String, codeHostURN: String, secret: String): Webhook!
 
     """
     Adds a external service. Only site admins may perform this mutation.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -114,6 +114,11 @@ type Mutation {
     deleteWebhook(id: ID!): EmptyResponse!
 
     """
+    Updates a webhook with given ID. Empty fields are not updated.
+    """
+    updateWebhook(id: ID!, name: String, codeHostKind: String, codeHostURN: String, secret: String): EmptyResponse!
+
+    """
     Adds a external service. Only site admins may perform this mutation.
     """
     addExternalService(input: AddExternalServiceInput!): ExternalService!

--- a/cmd/frontend/graphqlbackend/webhooks.go
+++ b/cmd/frontend/graphqlbackend/webhooks.go
@@ -50,6 +50,14 @@ type DeleteWebhookArgs struct {
 	ID graphql.ID
 }
 
+type UpdateWebhookArgs struct {
+	ID           graphql.ID
+	Name         *string
+	CodeHostKind *string
+	CodeHostURN  *string
+	Secret       *string
+}
+
 type ListWebhookArgs struct {
 	graphqlutil.ConnectionArgs
 	After *string

--- a/cmd/frontend/graphqlbackend/webhooks.go
+++ b/cmd/frontend/graphqlbackend/webhooks.go
@@ -12,7 +12,7 @@ import (
 type WebhooksResolver interface {
 	CreateWebhook(ctx context.Context, args *CreateWebhookArgs) (WebhookResolver, error)
 	DeleteWebhook(ctx context.Context, args *DeleteWebhookArgs) (*EmptyResponse, error)
-	UpdateWebhook(ctx context.Context, args *UpdateWebhookArgs) (*EmptyResponse, error)
+	UpdateWebhook(ctx context.Context, args *UpdateWebhookArgs) (WebhookResolver, error)
 	Webhooks(ctx context.Context, args *ListWebhookArgs) (WebhookConnectionResolver, error)
 
 	NodeResolvers() map[string]NodeByIDFunc

--- a/cmd/frontend/graphqlbackend/webhooks.go
+++ b/cmd/frontend/graphqlbackend/webhooks.go
@@ -12,6 +12,7 @@ import (
 type WebhooksResolver interface {
 	CreateWebhook(ctx context.Context, args *CreateWebhookArgs) (WebhookResolver, error)
 	DeleteWebhook(ctx context.Context, args *DeleteWebhookArgs) (*EmptyResponse, error)
+	UpdateWebhook(ctx context.Context, args *UpdateWebhookArgs) (*EmptyResponse, error)
 	Webhooks(ctx context.Context, args *ListWebhookArgs) (WebhookConnectionResolver, error)
 
 	NodeResolvers() map[string]NodeByIDFunc

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
@@ -63,6 +63,18 @@ func (r *webhooksResolver) DeleteWebhook(ctx context.Context, args *graphqlbacke
 	return &graphqlbackend.EmptyResponse{}, nil
 }
 
+func (r *webhooksResolver) UpdateWebhook(ctx context.Context, args *graphqlbackend.UpdateWebhookArgs) (*graphqlbackend.EmptyResponse, error) {
+	if auth.CheckCurrentUserIsSiteAdmin(ctx, r.db) != nil {
+		return nil, auth.ErrMustBeSiteAdmin
+	}
+	_, err := unmarshalWebhookID(args.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &graphqlbackend.EmptyResponse{}, nil
+}
+
 func (r *webhooksResolver) Webhooks(ctx context.Context, args *graphqlbackend.ListWebhookArgs) (graphqlbackend.WebhookConnectionResolver, error) {
 	if auth.CheckCurrentUserIsSiteAdmin(ctx, r.db) != nil {
 		return nil, auth.ErrMustBeSiteAdmin

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
@@ -49,6 +49,10 @@ func (r *webhooksResolver) CreateWebhook(ctx context.Context, args *graphqlbacke
 }
 
 func (r *webhooksResolver) DeleteWebhook(ctx context.Context, args *graphqlbackend.DeleteWebhookArgs) (*graphqlbackend.EmptyResponse, error) {
+	if auth.CheckCurrentUserIsSiteAdmin(ctx, r.db) != nil {
+		return nil, auth.ErrMustBeSiteAdmin
+	}
+
 	id, err := unmarshalWebhookID(args.ID)
 	if err != nil {
 		return nil, err
@@ -62,6 +66,10 @@ func (r *webhooksResolver) DeleteWebhook(ctx context.Context, args *graphqlbacke
 }
 
 func (r *webhooksResolver) UpdateWebhook(ctx context.Context, args *graphqlbackend.UpdateWebhookArgs) (graphqlbackend.WebhookResolver, error) {
+	if auth.CheckCurrentUserIsSiteAdmin(ctx, r.db) != nil {
+		return nil, auth.ErrMustBeSiteAdmin
+	}
+
 	whID, err := unmarshalWebhookID(args.ID)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
@@ -783,6 +783,29 @@ func TestUpdateWebhook(t *testing.T) {
 			"secret":       nil,
 		},
 	})
+
+	webhookStore.GetByIDFunc.SetDefaultReturn(nil, &database.WebhookNotFoundError{ID: 2})
+
+	graphqlbackend.RunTest(t, &graphqlbackend.Test{
+		Label:          "error for non-existent webhook",
+		Context:        ctx,
+		Schema:         gqlSchema,
+		Query:          mutateStr,
+		ExpectedResult: "null",
+		ExpectedErrors: []*errors.QueryError{
+			{
+				Message: "webhook with ID 2 not found",
+				Path:    []any{"updateWebhook"},
+			},
+		},
+		Variables: map[string]any{
+			"id":           string(id),
+			"name":         "new name",
+			"codeHostKind": nil,
+			"codeHostURN":  "https://example.github.com",
+			"secret":       nil,
+		},
+	})
 }
 
 func createGqlSchema(t *testing.T, db database.DB) *graphql.Schema {

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
@@ -794,7 +794,7 @@ func TestUpdateWebhook(t *testing.T) {
 		ExpectedResult: "null",
 		ExpectedErrors: []*errors.QueryError{
 			{
-                Message: "update webhook: webhook with ID 2 not found",
+				Message: "update webhook: webhook with ID 2 not found",
 				Path:    []any{"updateWebhook"},
 			},
 		},

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
@@ -607,7 +607,7 @@ func TestDeleteWebhook(t *testing.T) {
 		ExpectedResult: "null",
 		ExpectedErrors: []*errors.QueryError{
 			{
-				Message: "must be site admin",
+				Message: "delete webhook: must be site admin",
 				Path:    []any{"deleteWebhook"},
 			},
 		},
@@ -694,7 +694,7 @@ func TestUpdateWebhook(t *testing.T) {
 		ExpectedResult: "null",
 		ExpectedErrors: []*errors.QueryError{
 			{
-				Message: "must be site admin",
+				Message: "update webhook: must be site admin",
 				Path:    []any{"updateWebhook"},
 			},
 		},
@@ -794,7 +794,7 @@ func TestUpdateWebhook(t *testing.T) {
 		ExpectedResult: "null",
 		ExpectedErrors: []*errors.QueryError{
 			{
-				Message: "webhook with ID 2 not found",
+                Message: "update webhook: webhook with ID 2 not found",
 				Path:    []any{"updateWebhook"},
 			},
 		},

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
@@ -607,7 +607,7 @@ func TestDeleteWebhook(t *testing.T) {
 		ExpectedResult: "null",
 		ExpectedErrors: []*errors.QueryError{
 			{
-				Message: "delete webhook: must be site admin",
+				Message: "must be site admin",
 				Path:    []any{"deleteWebhook"},
 			},
 		},
@@ -694,7 +694,7 @@ func TestUpdateWebhook(t *testing.T) {
 		ExpectedResult: "null",
 		ExpectedErrors: []*errors.QueryError{
 			{
-				Message: "update webhook: must be site admin",
+				Message: "must be site admin",
 				Path:    []any{"updateWebhook"},
 			},
 		},

--- a/internal/database/webhooks.go
+++ b/internal/database/webhooks.go
@@ -265,7 +265,7 @@ func (s *webhookStore) Update(ctx context.Context, actorUID int32, newWebhook *t
 	}
 
 	q := sqlf.Sprintf(webhookUpdateQueryFmtstr,
-		newWebhook.Name, newWebhook.CodeHostURN.String(), encryptedSecret, keyID, dbutil.NullInt32Column(actorUID), newWebhook.ID,
+		newWebhook.Name, newWebhook.CodeHostURN.String(), newWebhook.CodeHostKind, encryptedSecret, keyID, dbutil.NullInt32Column(actorUID), newWebhook.ID,
 		sqlf.Join(webhookColumns, ", "))
 
 	updated, err := scanWebhook(s.QueryRow(ctx, q), s.key)
@@ -284,6 +284,7 @@ UPDATE webhooks
 SET
     name = %s,
 	code_host_urn = %s,
+    code_host_kind = %s,
 	secret = %s,
 	encryption_key_id = %s,
 	updated_at = NOW(),


### PR DESCRIPTION
Closes #44758 

Adds a GraphQL mutation resolver to update a Webhook. The webhook ID is required, all other fields are optional. Only non-null fields are updated, the rest stay the same.

## Test plan

Added tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
