### PR TITLE
zoekt: set -indexserver_proxy for webserver

### DIFF
--- a/cmd/server/shared/zoekt.go
+++ b/cmd/server/shared/zoekt.go
@@ -23,6 +23,6 @@ func maybeZoektProcFile() []string {
 
 	return []string{
 		fmt.Sprintf("zoekt-indexserver: env GOGC=25 HOSTNAME=%s zoekt-sourcegraph-indexserver -sourcegraph_url http://%s -index %s -interval 1m -listen 127.0.0.1:6072 -cpu_fraction 0.25", defaultHost, frontendInternalHost, indexDir),
-		fmt.Sprintf("zoekt-webserver: env GOGC=25 zoekt-webserver -rpc -pprof -listen %s -index %s", defaultHost, indexDir),
+		fmt.Sprintf("zoekt-webserver: env GOGC=25 zoekt-webserver -rpc -pprof -indexserver_proxy -listen %s -index %s", defaultHost, indexDir),
 	}
 }

--- a/dev/zoekt/wrapper
+++ b/dev/zoekt/wrapper
@@ -31,7 +31,7 @@ indexserver)
     ;;
 
 webserver)
-    exec env JAEGER_DISABLED=false zoekt-webserver -index "$index" -pprof -rpc -listen ":$webport"
+    exec env JAEGER_DISABLED=false zoekt-webserver -index "$index" -pprof -rpc -indexserver_proxy -listen ":$webport"
     ;;
 
 *)

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -455,11 +455,11 @@ commands:
 
   zoekt-web-0:
     <<: *zoekt_webserver_template
-    cmd: env PATH="${PWD}/.bin:$PATH" .bin/zoekt-webserver -index "$HOME/.sourcegraph/zoekt/index-0" -pprof -rpc -listen "127.0.0.1:3070"
+    cmd: env PATH="${PWD}/.bin:$PATH" .bin/zoekt-webserver -index "$HOME/.sourcegraph/zoekt/index-0" -pprof -rpc -indexserver_proxy -listen "127.0.0.1:3070"
 
   zoekt-web-1:
     <<: *zoekt_webserver_template
-    cmd: env PATH="${PWD}/.bin:$PATH" .bin/zoekt-webserver -index "$HOME/.sourcegraph/zoekt/index-1" -pprof -rpc -listen "127.0.0.1:3071"
+    cmd: env PATH="${PWD}/.bin:$PATH" .bin/zoekt-webserver -index "$HOME/.sourcegraph/zoekt/index-1" -pprof -rpc -indexserver_proxy -listen "127.0.0.1:3071"
 
   codeintel-worker:
     cmd: |


### PR DESCRIPTION
Relates to https://github.com/sourcegraph/zoekt/pull/487

We set the new flag -indexerver_proxy for local dev and server.

## Test plan
- Ran `sg start` and confirmed that Zoekt webserver was started with the flag `-indexserver_proxy`
