### PR TITLE
Make OIDC provider use the HTTP external client

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/openidconnect/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/provider.go
@@ -158,7 +158,7 @@ func newOIDCProvider(issuerURL string) (*oidcProvider, error) {
 		return mockNewProvider(issuerURL)
 	}
 
-	bp, err := oidc.NewProvider(context.Background(), issuerURL)
+	bp, err := oidc.NewProvider(oidc.ClientContext(context.Background(), httpcli.ExternalClient), issuerURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The initial sign-in call with the OIDC library uses the `http.DefaultClient`. This PR sets the custom client using the oidc.ClientContext.

## Test plan

Confirmed locally that the custom cert is now being added to the login request, which it was not before.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
