### PR TITLE
monitoring: update email panels, add multi-instance email panel

### DIFF
--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -1216,12 +1216,12 @@ Generated query for critical alert: `min((sum by(app) (up{app=~".*(frontend|sour
 
 ## frontend: email_delivery_failures
 
-<p class="subtitle">emails delivery failures every 30 minutes</p>
+<p class="subtitle">email delivery failures every 30 minutes</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 1+ emails delivery failures every 30 minutes
-- <span class="badge badge-critical">critical</span> frontend: 2+ emails delivery failures every 30 minutes
+- <span class="badge badge-warning">warning</span> frontend: 1+ email delivery failures every 30 minutes
+- <span class="badge badge-critical">critical</span> frontend: 2+ email delivery failures every 30 minutes
 
 **Next steps**
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -4110,11 +4110,11 @@ Query: `round(sum(increase(src_search_ranking_result_clicked_sum{type="commit"}[
 
 <br />
 
-### Frontend: Emails
+### Frontend: Email delivery
 
 #### frontend: email_delivery_failures
 
-<p class="subtitle">Emails delivery failures every 30 minutes</p>
+<p class="subtitle">Email delivery failures every 30 minutes</p>
 
 Refer to the [alerts reference](./alerts.md#frontend-email-delivery-failures) for 2 alerts related to this panel.
 
@@ -4131,22 +4131,43 @@ Query: `sum(increase(src_email_send{success="false"}[30m]))`
 
 <br />
 
-#### frontend: email_deliveries
+#### frontend: email_deliveries_by_source
 
-<p class="subtitle">Emails delivered per minute</p>
+<p class="subtitle">Emails successfully delivered every 5 minutes by source</p>
 
 Emails successfully delivered by source.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103101` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103110` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (source) (increase(src_email_send{success="true"}[1m]))`
+Query: `sum by (email_source) (increase(src_email_send{success="true"}[5m]))`
+
+</details>
+
+<br />
+
+#### frontend: email_deliveries_total
+
+<p class="subtitle">Total emails successfully delivered every minute</p>
+
+Total emails successfully delivered.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103111` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum (increase(src_email_send{success="true"}[5m]))`
 
 </details>
 

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -688,12 +688,12 @@ func Frontend() *monitoring.Dashboard {
 				},
 			},
 			{
-				Title:  "Emails",
+				Title:  "Email delivery",
 				Hidden: true,
 				Rows: []monitoring.Row{{
 					{
 						Name:        "email_delivery_failures",
-						Description: "emails delivery failures every 30 minutes",
+						Description: "email delivery failures every 30 minutes",
 						Query:       `sum(increase(src_email_send{success="false"}[30m]))`,
 						Panel:       monitoring.Panel().LegendFormat("failures"),
 						Warning:     monitoring.Alert().GreaterOrEqual(1),
@@ -706,19 +706,32 @@ func Frontend() *monitoring.Dashboard {
 							- Check your SMTP provider for more detailed error messages.
 						`,
 					},
+				}, {
 					{
-						Name:        "email_deliveries",
-						Description: "emails delivered per minute",
-						Query:       `sum by (source) (increase(src_email_send{success="true"}[1m]))`,
-						Panel:       monitoring.Panel().LegendFormat("{{source}}"),
+						Name:        "email_deliveries_by_source",
+						Description: "emails successfully delivered every 5 minutes by source",
+						Query:       `sum by (email_source) (increase(src_email_send{success="true"}[5m]))`,
+						Panel:       monitoring.Panel().LegendFormat("{{email_source}}"),
 						NoAlert:     true, // this is a purely informational panel
 
 						Owner:          monitoring.ObservableOwnerDevOps,
 						Interpretation: "Emails successfully delivered by source.",
 					},
+					{
+						Name:        "email_deliveries_total",
+						Description: "total emails successfully delivered every minute",
+						Query:       `sum (increase(src_email_send{success="true"}[5m]))`,
+						Panel:       monitoring.Panel().LegendFormat("count"),
+						NoAlert:     true, // this is a purely informational panel
+
+						Owner:          monitoring.ObservableOwnerDevOps,
+						Interpretation: "Total emails successfully delivered.",
+
+						// use to observe behaviour of email usage across instances
+						MultiInstance: true,
+					},
 				}},
 			},
-
 			{
 				Title:  "Sentinel queries (only on sourcegraph.com)",
 				Hidden: true,


### PR DESCRIPTION
- Fix broken deliveries by source aggregation
- Update per-source email deliveries panel to aggregate on 5m instead of 1m for readability
- Add a single-series total emails delivered to include in multi-instance dashboards

Part of https://github.com/sourcegraph/customer/issues/1411

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI, tested the fixed aggregation: https://sourcegraph.com/-/debug/grafana/explore?orgId=1&left=%5B%22now-24h%22,%22now%22,%22Prometheus%22,%7B%22expr%22:%22sum%20by(email_source)%20(increase(src_email_send%7Bsuccess%3D%5C%22true%5C%22%7D%5B5m%5D))%22,%22datasource%22:%22Prometheus%22,%22exemplar%22:true,%22requestId%22:%22Q-230e44f8-eeee-40a4-b8a2-f3a7ec4b347c-0A%22%7D%5D