### PR TITLE
insights: mark the series backfill complete

### DIFF
--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -57,14 +57,14 @@ func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*worker
 	handlerConfig := newHandlerConfig()
 
 	task := &inProgressHandler{
-		workerStore:    workerStore,
-		backfillStore:  backfillStore,
-		seriesReader:   store.NewInsightStore(db),
-		insightsStore:  config.InsightStore,
-		backfillRunner: config.BackfillRunner,
-		repoStore:      config.RepoStore,
-		clock:          glock.NewRealClock(),
-		config:         handlerConfig,
+		workerStore:        workerStore,
+		backfillStore:      backfillStore,
+		seriesReadComplete: store.NewInsightStore(db),
+		insightsStore:      config.InsightStore,
+		backfillRunner:     config.BackfillRunner,
+		repoStore:          config.RepoStore,
+		clock:              glock.NewRealClock(),
+		config:             handlerConfig,
 	}
 
 	worker := dbworker.NewWorker(ctx, workerStore, workerutil.Handler[*BaseJob](task), workerutil.WorkerOptions{
@@ -96,13 +96,13 @@ func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*worker
 }
 
 type inProgressHandler struct {
-	workerStore    dbworkerstore.Store[*BaseJob]
-	backfillStore  *BackfillStore
-	seriesReader   SeriesReader
-	repoStore      database.RepoStore
-	insightsStore  store.Interface
-	backfillRunner pipeline.Backfiller
-	config         handlerConfig
+	workerStore        dbworkerstore.Store[*BaseJob]
+	backfillStore      *BackfillStore
+	seriesReadComplete SeriesBackfillReadWrite
+	repoStore          database.RepoStore
+	insightsStore      store.Interface
+	backfillRunner     pipeline.Backfiller
+	config             handlerConfig
 
 	clock glock.Clock
 }
@@ -124,7 +124,7 @@ func (h *inProgressHandler) Handle(ctx context.Context, logger log.Logger, job *
 	if err != nil {
 		return errors.Wrap(err, "loadBackfill")
 	}
-	series, err := h.seriesReader.GetDataSeriesByID(ctx, backfillJob.SeriesId)
+	series, err := h.seriesReadComplete.GetDataSeriesByID(ctx, backfillJob.SeriesId)
 	if err != nil {
 		return errors.Wrap(err, "GetDataSeriesByID")
 	}
@@ -235,6 +235,12 @@ func (h *inProgressHandler) Handle(ctx context.Context, logger log.Logger, job *
 		if err != nil {
 			return err
 		}
+
+		err = h.seriesReadComplete.SetSeriesBackfillComplete(ctx, series.SeriesID, h.clock.Now())
+		if err != nil {
+			return err
+		}
+
 		err = backfillJob.setState(ctx, h.backfillStore, BackfillStateCompleted)
 		if err != nil {
 			return err

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -236,7 +236,7 @@ func (h *inProgressHandler) Handle(ctx context.Context, logger log.Logger, job *
 			return err
 		}
 
-		err = h.seriesReadComplete.SetSeriesBackfillComplete(ctx, series.SeriesID, h.clock.Now())
+		err = h.seriesReadComplete.SetSeriesBackfillComplete(ctx, series.SeriesID, itr.CompletedAt)
 		if err != nil {
 			return err
 		}

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -98,7 +98,7 @@ func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*worker
 type inProgressHandler struct {
 	workerStore        dbworkerstore.Store[*BaseJob]
 	backfillStore      *BackfillStore
-	seriesReadComplete SeriesBackfillReadWrite
+	seriesReadComplete SeriesReadBackfillComplete
 	repoStore          database.RepoStore
 	insightsStore      store.Interface
 	backfillRunner     pipeline.Backfiller

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
@@ -85,13 +85,13 @@ func Test_MovesBackfillFromProcessingToComplete(t *testing.T) {
 
 	dequeue, _, _ := monitor.inProgressStore.Dequeue(ctx, "test", nil)
 	handler := inProgressHandler{
-		workerStore:    monitor.newBackfillStore,
-		backfillStore:  bfs,
-		seriesReader:   insightsStore,
-		repoStore:      repos,
-		insightsStore:  seriesStore,
-		backfillRunner: &noopBackfillRunner{},
-		config:         newHandlerConfig(),
+		workerStore:        monitor.newBackfillStore,
+		backfillStore:      bfs,
+		seriesReadComplete: insightsStore,
+		repoStore:          repos,
+		insightsStore:      seriesStore,
+		backfillRunner:     &noopBackfillRunner{},
+		config:             newHandlerConfig(),
 
 		clock: clock,
 	}
@@ -240,14 +240,14 @@ func Test_BackfillWithRetry(t *testing.T) {
 
 	dequeue, _, _ := monitor.inProgressStore.Dequeue(ctx, "test", nil)
 	handler := inProgressHandler{
-		workerStore:    monitor.newBackfillStore,
-		backfillStore:  bfs,
-		seriesReader:   insightsStore,
-		repoStore:      repos,
-		insightsStore:  seriesStore,
-		backfillRunner: runner,
-		config:         newHandlerConfig(),
-		clock:          clock,
+		workerStore:        monitor.newBackfillStore,
+		backfillStore:      bfs,
+		seriesReadComplete: insightsStore,
+		repoStore:          repos,
+		insightsStore:      seriesStore,
+		backfillRunner:     runner,
+		config:             newHandlerConfig(),
+		clock:              clock,
 	}
 
 	err = handler.Handle(ctx, logger, dequeue)
@@ -318,14 +318,14 @@ func Test_BackfillWithRetryAndComplete(t *testing.T) {
 
 	dequeue, _, _ := monitor.inProgressStore.Dequeue(ctx, "test", nil)
 	handler := inProgressHandler{
-		workerStore:    monitor.newBackfillStore,
-		backfillStore:  bfs,
-		seriesReader:   insightsStore,
-		repoStore:      repos,
-		insightsStore:  seriesStore,
-		backfillRunner: runner,
-		config:         newHandlerConfig(),
-		clock:          clock,
+		workerStore:        monitor.newBackfillStore,
+		backfillStore:      bfs,
+		seriesReadComplete: insightsStore,
+		repoStore:          repos,
+		insightsStore:      seriesStore,
+		backfillRunner:     runner,
+		config:             newHandlerConfig(),
+		clock:              clock,
 	}
 
 	// we should get an errored record here that will be retried by the overall queue
@@ -394,14 +394,14 @@ func Test_BackfillWithInterrupt(t *testing.T) {
 
 	dequeue, _, _ := monitor.inProgressStore.Dequeue(ctx, "test", nil)
 	handler := inProgressHandler{
-		workerStore:    monitor.newBackfillStore,
-		backfillStore:  bfs,
-		seriesReader:   insightsStore,
-		repoStore:      repos,
-		insightsStore:  seriesStore,
-		backfillRunner: &runner,
-		config:         newHandlerConfig(),
-		clock:          clock,
+		workerStore:        monitor.newBackfillStore,
+		backfillStore:      bfs,
+		seriesReadComplete: insightsStore,
+		repoStore:          repos,
+		insightsStore:      seriesStore,
+		backfillRunner:     &runner,
+		config:             newHandlerConfig(),
+		clock:              clock,
 	}
 	handler.config.interruptAfter = time.Second * 5
 

--- a/enterprise/internal/insights/scheduler/scheduler.go
+++ b/enterprise/internal/insights/scheduler/scheduler.go
@@ -135,6 +135,15 @@ type SeriesReader interface {
 	GetDataSeriesByID(ctx context.Context, id int) (*types.InsightSeries, error)
 }
 
+type SeriesBackfillCompleteWriter interface {
+	SetSeriesBackfillComplete(ctx context.Context, seriesId string, timestamp time.Time) error
+}
+
+type SeriesBackfillReadWrite interface {
+	SeriesReader
+	SeriesBackfillCompleteWriter
+}
+
 type Scheduler struct {
 	backfillStore *BackfillStore
 }

--- a/enterprise/internal/insights/scheduler/scheduler.go
+++ b/enterprise/internal/insights/scheduler/scheduler.go
@@ -135,13 +135,13 @@ type SeriesReader interface {
 	GetDataSeriesByID(ctx context.Context, id int) (*types.InsightSeries, error)
 }
 
-type SeriesBackfillCompleteWriter interface {
+type SeriesBackfillComplete interface {
 	SetSeriesBackfillComplete(ctx context.Context, seriesId string, timestamp time.Time) error
 }
 
-type SeriesBackfillReadWrite interface {
+type SeriesReadBackfillComplete interface {
 	SeriesReader
-	SeriesBackfillCompleteWriter
+	SeriesBackfillComplete
 }
 
 type Scheduler struct {


### PR DESCRIPTION
I saw the current background process to mark the backfill complete of the series was dependent on a job existing meaning that for new backfiller records it was actually recording the time of the first snapshot completing.  

This updates the series backfill complete when the backfill finishes.  If a series were to have more than 1 backfill this method would not work anymore and we would probably need to run a background process to ensure all backfills were done.

This does not conflict with the current process because it only updates series that are not already marked completed.  The other process can be removed when we remove the v1 backfiller.

## Test plan
Create an insight - verify that backfill completed is set.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
