### PR TITLE
otel: add collector dashboard

### DIFF
--- a/dev/prometheus/all/prometheus_targets.yml
+++ b/dev/prometheus/all/prometheus_targets.yml
@@ -63,3 +63,8 @@
   targets:
     # github proxy
     - host.docker.internal:6090
+- labels:
+    job: otel-collector
+  targets:
+    # opentelemetry collector
+    - host.docker.internal:8888

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -24437,3 +24437,32 @@ Query: `rate(src_telemetry_job_total{op="SendEvents"}[1h]) / on() group_right() 
 
 <br />
 
+## Open Telemetry Collector
+
+<p class="subtitle">Metrics about the operation of the open telemetry collector.</p>
+
+To see this dashboard, visit `/-/debug/grafana/d/otel-collector/otel-collector` on your Sourcegraph instance.
+
+### Open Telemetry Collector: Export failures
+
+#### otel-collector: otel-export-failures
+
+<p class="subtitle">Items that have failed to be exported by the exported</p>
+
+								A value above 0 indicates that the exporter has failing to export one more items to its configured endpoint
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewPanel=100000` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `rate(otelcol_exporter_enqueue_failed_log_records[5m])`
+
+</details>
+
+<br />
+

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -24445,11 +24445,11 @@ To see this dashboard, visit `/-/debug/grafana/d/otel-collector/otel-collector` 
 
 ### Open Telemetry Collector: Export failures
 
-#### otel-collector: otel-export-failures
+#### otel-collector: otel-span-receive-rate
 
-<p class="subtitle">Items that have failed to be exported by the exported</p>
+<p class="subtitle">Spans received per second</p>
 
-								A value above 0 indicates that the exporter has failing to export one more items to its configured endpoint
+								Shows the rate of spans accepted by the configured reveiver
 
 This panel has no related alerts.
 
@@ -24460,7 +24460,49 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `rate(otelcol_exporter_enqueue_failed_log_records[5m])`
+Query: `sum(rate(otelcol_receiver_accepted_spans[1m])) by (receiver)`
+
+</details>
+
+<br />
+
+#### otel-collector: otel-span-export-rate
+
+<p class="subtitle">Spans exported per second</p>
+
+								Shows the rate of spans being sent by the exporter
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewPanel=100001` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(rate(otelcol_exporter_sent_spans[1m])) by (exporter)`
+
+</details>
+
+<br />
+
+#### otel-collector: otel-span-queue-size
+
+<p class="subtitle">Exporter queue size</p>
+
+								Shows the rate of spans accepted by the configured reveiver
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewPanel=100002` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(rate(otelcol_exporter_sent_spans[1m])) by (exporter)`
 
 </details>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -24590,7 +24590,7 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `otelcol_process_cpu_seconds`
+Query: `sum(rate(otelcol_process_cpu_seconds{job=~"^.*"}[1m])) by (job)`
 
 </details>
 
@@ -24611,7 +24611,7 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `otelcol_process_cpu_seconds`
+Query: `sum(rate(otelcol_process_memory_rss{job=~"^.*"}[1m])) by (job)`
 
 </details>
 
@@ -24636,7 +24636,7 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `otelcol_process_runtime_total_alloc_bytes`
+Query: `sum(rate(otelcol_process_runtime_total_alloc_bytes{job=~"^.*"}[1m])) by (job)`
 
 </details>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -24443,7 +24443,7 @@ Query: `rate(src_telemetry_job_total{op="SendEvents"}[1h]) / on() group_right() 
 
 To see this dashboard, visit `/-/debug/grafana/d/otel-collector/otel-collector` on your Sourcegraph instance.
 
-### Open Telemetry Collector: Export failures
+### Open Telemetry Collector: Receivers
 
 #### otel-collector: otel-span-receive-rate
 
@@ -24460,17 +24460,17 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(otelcol_receiver_accepted_spans[1m])) by (receiver)`
+Query: `sum(rate(otelcol_receiver_accepted_spans{receiver=~"^.*"}[1m])) by (receiver)`
 
 </details>
 
 <br />
 
-#### otel-collector: otel-span-export-rate
+#### otel-collector: otel-span-refused
 
-<p class="subtitle">Spans exported per second</p>
+<p class="subtitle">Spans that the receiver refused</p>
 
-								Shows the rate of spans being sent by the exporter
+								Shows the rate of spans accepted by the configured reveiver
 
 This panel has no related alerts.
 
@@ -24481,7 +24481,51 @@ To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewP
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(otelcol_exporter_sent_spans[1m])) by (exporter)`
+Query: `sum(rate(otelcol_receiver_refused_spans{receiver=~"^.*.*"}[1m])) by (receiver)`
+
+</details>
+
+<br />
+
+### Open Telemetry Collector: Exporters
+
+#### otel-collector: otel-span-export-rate
+
+<p class="subtitle">Spans exported per second</p>
+
+								Shows the rate of spans being sent by the exporter
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewPanel=100100` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(rate(otelcol_exporter_sent_spans{exporter=~"^.*"}[1m])) by (exporter)`
+
+</details>
+
+<br />
+
+#### otel-collector: otel-span-failed-send-size
+
+<p class="subtitle">Spans that the exporter failed to send</p>
+
+								Shows the rate of spans failed to be sent by the configured reveiver. A number higher than 0 for a long period can indicate a problem with the exporter configuration or with the service that is being exported too
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewPanel=100101` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(rate(otelcol_exporter_send_failed_spans{exporter=~"^.*"}[1m])) by (exporter)`
 
 </details>
 
@@ -24489,20 +24533,110 @@ Query: `sum(rate(otelcol_exporter_sent_spans[1m])) by (exporter)`
 
 #### otel-collector: otel-span-queue-size
 
-<p class="subtitle">Exporter queue size</p>
+<p class="subtitle">Spans pending to be sent</p>
 
-								Shows the rate of spans accepted by the configured reveiver
+								Indicates the amount of spans that are in the queue to be sent (exported). A high queue count might indicate a high volume of spans or a problem with the receiving service
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewPanel=100002` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewPanel=100102` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
 
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(rate(otelcol_exporter_sent_spans[1m])) by (exporter)`
+Query: `sum(rate(otelcol_exporter_queue_size{exporter=~"^.*"}[1m])) by (exporter)`
+
+</details>
+
+<br />
+
+#### otel-collector: otel-span-queue-capacity
+
+<p class="subtitle">Spans max items that can be pending to be sent</p>
+
+								Indicates the amount of spans that are in the queue to be sent (exported). A high queue count might indicate a high volume of spans or a problem with the receiving service
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewPanel=100103` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(rate(otelcol_exporter_queue_capacity{exporter=~"^.*"}[1m])) by (exporter)`
+
+</details>
+
+<br />
+
+### Open Telemetry Collector: Collector resource usage
+
+#### otel-collector: otel-cpu-usage
+
+<p class="subtitle">Cpu usuge of the collector</p>
+
+								Shows the rate of spans accepted by the configured reveiver
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewPanel=100200` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `otelcol_process_cpu_seconds`
+
+</details>
+
+<br />
+
+#### otel-collector: otel-memory-rss
+
+<p class="subtitle">Memory allocated to the otel collector</p>
+
+								Shows the rate of spans accepted by the configured reveiver
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewPanel=100201` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `otelcol_process_cpu_seconds`
+
+</details>
+
+<br />
+
+#### otel-collector: otel-memory-usage
+
+<p class="subtitle">Total memory usage</p>
+
+								Shows how much memory is being used by the otel collector.
+
+								* High memory usage might indicate thad the configured pipeline is keeping a lot of spans in memory for processing
+								* Spans failing to be sent and the exporter is configured to retry
+								* A high bacth count by using a batch processor
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/otel-collector/otel-collector?viewPanel=100202` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Cloud DevOps team](https://handbook.sourcegraph.com/departments/engineering/teams/devops).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `otelcol_process_runtime_total_alloc_bytes`
 
 </details>
 

--- a/docker-images/opentelemetry-collector/configs/jaeger.yaml
+++ b/docker-images/opentelemetry-collector/configs/jaeger.yaml
@@ -24,6 +24,9 @@ extensions:
     endpoint: ":55679"
 
 service:
+  telemetry:
+    metrics:
+      address: ":8888"
   extensions: [health_check,zpages]
   pipelines:
     traces:

--- a/monitoring/definitions/dashboards.go
+++ b/monitoring/definitions/dashboards.go
@@ -31,6 +31,7 @@ func Default() Dashboards {
 		CodeIntelRanking(),
 		CodeIntelUploads(),
 		Telemetry(),
+		OtelCollector(),
 	}
 }
 

--- a/monitoring/definitions/otel_collector.go
+++ b/monitoring/definitions/otel_collector.go
@@ -19,7 +19,7 @@ func OtelCollector() *monitoring.Dashboard {
 						{
 							Name:        "otel-span-receive-rate",
 							Description: "spans received per second",
-							Panel:       monitoring.Panel().Unit(monitoring.Number).LegendFormat("receiver"),
+							Panel:       monitoring.Panel().Unit(monitoring.Number).LegendFormat("receiver: {{receiver}}"),
 							Owner:       monitoring.ObservableOwnerDevOps,
 							Query:       "sum(rate(otelcol_receiver_accepted_spans{receiver=~\"^.*\"}[1m])) by (receiver)",
 							NoAlert:     true,
@@ -29,7 +29,7 @@ func OtelCollector() *monitoring.Dashboard {
 						{
 							Name:        "otel-span-refused",
 							Description: "spans that the receiver refused",
-							Panel:       monitoring.Panel().Unit(monitoring.Number).LegendFormat("receiver=%s"),
+							Panel:       monitoring.Panel().Unit(monitoring.Number).LegendFormat("receiver: {{receiver}}"),
 							Owner:       monitoring.ObservableOwnerDevOps,
 							Query:       "sum(rate(otelcol_receiver_refused_spans{receiver=~\"^.*.*\"}[1m])) by (receiver)",
 							NoAlert:     true,
@@ -47,7 +47,7 @@ func OtelCollector() *monitoring.Dashboard {
 						{
 							Name:        "otel-span-export-rate",
 							Description: "spans exported per second",
-							Panel:       monitoring.Panel().Unit(monitoring.Number).LegendFormat("exporter=%s"),
+							Panel:       monitoring.Panel().Unit(monitoring.Number).LegendFormat("exporter: {{exporter}}"),
 							Owner:       monitoring.ObservableOwnerDevOps,
 							Query:       "sum(rate(otelcol_exporter_sent_spans{exporter=~\"^.*\"}[1m])) by (exporter)",
 							NoAlert:     true,
@@ -57,7 +57,7 @@ func OtelCollector() *monitoring.Dashboard {
 						{
 							Name:        "otel-span-failed-send-size",
 							Description: "spans that the exporter failed to send",
-							Panel:       monitoring.Panel().Unit(monitoring.Number).LegendFormat("exporter=%s"),
+							Panel:       monitoring.Panel().Unit(monitoring.Number).LegendFormat("exporter: {{exporter}}"),
 							Owner:       monitoring.ObservableOwnerDevOps,
 							Query:       "sum(rate(otelcol_exporter_send_failed_spans{exporter=~\"^.*\"}[1m])) by (exporter)",
 							NoAlert:     true,
@@ -67,7 +67,7 @@ func OtelCollector() *monitoring.Dashboard {
 						{
 							Name:        "otel-span-queue-size",
 							Description: "spans pending to be sent",
-							Panel:       monitoring.Panel().Unit(monitoring.Number).LegendFormat("exporter=%s"),
+							Panel:       monitoring.Panel().Unit(monitoring.Number).LegendFormat("exporter: {{exporter}}"),
 							Owner:       monitoring.ObservableOwnerDevOps,
 							Query:       "sum(rate(otelcol_exporter_queue_size{exporter=~\"^.*\"}[1m])) by (exporter)",
 							NoAlert:     true,
@@ -77,7 +77,7 @@ func OtelCollector() *monitoring.Dashboard {
 						{
 							Name:        "otel-span-queue-capacity",
 							Description: "spans max items that can be pending to be sent",
-							Panel:       monitoring.Panel().Unit(monitoring.Number),
+							Panel:       monitoring.Panel().Unit(monitoring.Number).LegendFormat("exporter: {{exporter}}"),
 							Owner:       monitoring.ObservableOwnerDevOps,
 							Query:       "sum(rate(otelcol_exporter_queue_capacity{exporter=~\"^.*\"}[1m])) by (exporter)",
 							NoAlert:     true,
@@ -95,9 +95,9 @@ func OtelCollector() *monitoring.Dashboard {
 						{
 							Name:        "otel-cpu-usage",
 							Description: "cpu usuge of the collector",
-							Panel:       monitoring.Panel().Unit(monitoring.Seconds),
+							Panel:       monitoring.Panel().Unit(monitoring.Seconds).LegendFormat("{{job}}"),
 							Owner:       monitoring.ObservableOwnerDevOps,
-							Query:       "otelcol_process_cpu_seconds",
+							Query:       "sum(rate(otelcol_process_cpu_seconds{job=~\"^.*\"}[1m])) by (job)",
 							NoAlert:     true,
 							Interpretation: `
 								Shows the rate of spans accepted by the configured reveiver`,
@@ -105,9 +105,9 @@ func OtelCollector() *monitoring.Dashboard {
 						{
 							Name:        "otel-memory-rss",
 							Description: "memory allocated to the otel collector",
-							Panel:       monitoring.Panel().Unit(monitoring.Bytes),
+							Panel:       monitoring.Panel().Unit(monitoring.Bytes).LegendFormat("{{job}}"),
 							Owner:       monitoring.ObservableOwnerDevOps,
-							Query:       "otelcol_process_cpu_seconds",
+							Query:       "sum(rate(otelcol_process_memory_rss{job=~\"^.*\"}[1m])) by (job)",
 							NoAlert:     true,
 							Interpretation: `
 								Shows the rate of spans accepted by the configured reveiver`,
@@ -115,9 +115,9 @@ func OtelCollector() *monitoring.Dashboard {
 						{
 							Name:        "otel-memory-usage",
 							Description: "total memory usage",
-							Panel:       monitoring.Panel().Unit(monitoring.Bytes).LegendFormat("process_memory")
+							Panel:       monitoring.Panel().Unit(monitoring.Bytes).LegendFormat("{{job}}"),
 							Owner:       monitoring.ObservableOwnerDevOps,
-							Query:       "rate(otelcol_process_runtime_total_alloc_bytes{job=\"^.*\"})[1m])",
+							Query:       "sum(rate(otelcol_process_runtime_total_alloc_bytes{job=~\"^.*\"}[1m])) by (job)",
 							NoAlert:     true,
 							Interpretation: `
 								Shows how much memory is being used by the otel collector.

--- a/monitoring/definitions/otel_collector.go
+++ b/monitoring/definitions/otel_collector.go
@@ -1,0 +1,43 @@
+package definitions
+
+import "github.com/sourcegraph/sourcegraph/monitoring/monitoring"
+
+func OtelCollector() *monitoring.Dashboard {
+	containerName := "otel-collector"
+
+	return &monitoring.Dashboard{
+		Name:        containerName,
+		Title:       "Open Telemetry Collector",
+		Description: "Metrics about the operation of the open telemetry collector.",
+		Groups: []monitoring.Group{
+			{
+				Title:  "Export failures",
+				Hidden: false,
+				Rows: []monitoring.Row{
+					{
+						{
+							Name:        "otel-span-receive-rate",
+							Description: "Spans received per second",
+							Panel:       monitoring.Panel().Unit(monitoring.Number),
+							Owner:       monitoring.ObservableOwnerDevOps,
+							Query:       "sum(rate(otelcol_receiver_accepted_spans[1m])) by (receiver)",
+							NoAlert:     true,
+							Interpretation: `
+								Shows the rate of spans accepted by the configured reveiver`,
+						},
+						{
+							Name:        "otel-span-export-rate",
+							Description: "Spans exported per second",
+							Panel:       monitoring.Panel().Unit(monitoring.Number),
+							Owner:       monitoring.ObservableOwnerDevOps,
+							Query:       "sum(rate(otelcol_exporter_accepted_spans[1m])) by (receiver)",
+							NoAlert:     true,
+							Interpretation: `
+								Shows the rate of spans accepted by the configured reveiver`,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/monitoring/definitions/otel_collector.go
+++ b/monitoring/definitions/otel_collector.go
@@ -15,9 +15,10 @@ func OtelCollector() *monitoring.Dashboard {
 				Hidden: false,
 				Rows: []monitoring.Row{
 					{
+						// TODO(burmudar): look into adding a Guage as a Panel type
 						{
 							Name:        "otel-span-receive-rate",
-							Description: "Spans received per second",
+							Description: "spans received per second",
 							Panel:       monitoring.Panel().Unit(monitoring.Number),
 							Owner:       monitoring.ObservableOwnerDevOps,
 							Query:       "sum(rate(otelcol_receiver_accepted_spans[1m])) by (receiver)",
@@ -27,10 +28,20 @@ func OtelCollector() *monitoring.Dashboard {
 						},
 						{
 							Name:        "otel-span-export-rate",
-							Description: "Spans exported per second",
+							Description: "spans exported per second",
 							Panel:       monitoring.Panel().Unit(monitoring.Number),
 							Owner:       monitoring.ObservableOwnerDevOps,
-							Query:       "sum(rate(otelcol_exporter_accepted_spans[1m])) by (receiver)",
+							Query:       "sum(rate(otelcol_exporter_sent_spans[1m])) by (exporter)",
+							NoAlert:     true,
+							Interpretation: `
+								Shows the rate of spans being sent by the exporter`,
+						},
+						{
+							Name:        "otel-span-failed-send",
+							Description: "spans that the exporter failed to send size",
+							Panel:       monitoring.Panel().Unit(monitoring.Number),
+							Owner:       monitoring.ObservableOwnerDevOps,
+							Query:       "sum(otelcol_exporter_send_failed_spans[1m])) by (exporter)",
 							NoAlert:     true,
 							Interpretation: `
 								Shows the rate of spans accepted by the configured reveiver`,

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -743,6 +743,7 @@ commands:
       docker container rm otel-collector
       docker run --rm --name=otel-collector $DOCKER_NET $DOCKER_ARGS \
         -p 4317:4317 -p 4318:4318 -p 55679:55679 -p 55670:55670 \
+        -p 8888:8888 \
         -e JAEGER_HOST=$JAEGER_HOST \
         -e HONEYCOMB_API_KEY=$HONEYCOMB_API_KEY \
         -e HONEYCOMB_DATASET=$HONEYCOMB_DATASET \


### PR DESCRIPTION
The otel collector (when configured) exposes a metrics endpoint that can be scraped by prometheus. This adds a dash board to track metrics of traces and general performance of the collector

![Screenshot 2022-12-01 at 20 40 20](https://user-images.githubusercontent.com/1001709/205133947-6e56f5dd-9881-408c-b694-9905b07a2050.png)

@bobheadxi Any suggestions here would be immensely appreciated 🙏🏼 

Closes #43946
## Test plan
1. `sg start monitoring` and navigate to `/-/debug/grafana`and select `Open Telementry dashboard`
2. Do a search with tracing 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
