### PR TITLE
Fix code insight routing (dashboardId query problem)

### DIFF
--- a/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
@@ -103,7 +103,7 @@ export const CodeInsightsAppRouter = withAuthenticatedUser<CodeInsightsAppRouter
                         <CodeInsightsRootPage
                             dashboardId={props.match.params.dashboardId}
                             activeView={
-                                props.match.params.dashboardId
+                                props.match.path === `${match.url}/dashboards/:dashboardId?`
                                     ? CodeInsightsRootPageTab.CodeInsights
                                     : CodeInsightsRootPageTab.GettingStarted
                             }

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -61,7 +61,7 @@ export const CodeInsightsRootPage: FC<CodeInsightsRootPageProps> = props => {
         <CodeInsightsPage>
             <PageHeader
                 path={[{ icon: CodeInsightsIcon, text: 'Insights' }]}
-                actions={<CodeInsightHeaderActions dashboardId={dashboardId} telemetryService={telemetryService} />}
+                actions={<CodeInsightHeaderActions dashboardId={dashboardId ?? queryParamDashboardId} telemetryService={telemetryService} />}
                 className={styles.header}
             />
 

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -61,7 +61,12 @@ export const CodeInsightsRootPage: FC<CodeInsightsRootPageProps> = props => {
         <CodeInsightsPage>
             <PageHeader
                 path={[{ icon: CodeInsightsIcon, text: 'Insights' }]}
-                actions={<CodeInsightHeaderActions dashboardId={dashboardId ?? queryParamDashboardId} telemetryService={telemetryService} />}
+                actions={
+                    <CodeInsightHeaderActions
+                        dashboardId={dashboardId ?? queryParamDashboardId}
+                        telemetryService={telemetryService}
+                    />
+                }
                 className={styles.header}
             />
 

--- a/client/web/src/enterprise/insights/pages/insights/creation/InsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/InsightCreationPage.tsx
@@ -53,7 +53,7 @@ export const InsightCreationPage: FC<InsightCreationPageProps> = props => {
     const handleInsightSuccessfulCreation = (): void => {
         if (!dashboard) {
             // Navigate to the dashboard page with new created dashboard
-            history.push('/insights/dashboards/')
+            history.push('/insights/dashboards/all')
 
             return
         }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/44999


## Background
This is a regression after https://github.com/sourcegraph/sourcegraph/pull/44970. 

The loader problem on the creation UI comes from the fact that we load the dashboard entity to attach newly created insight after. This PR fixes it, but it will be revisited when it isn't needed to use the whole dashboard entity but just its id. 


## Test plan
- Make sure that you can create insight from the all-insights dashboard (and from the personal, org or global, any non-all insights page dashboard.
- Check that you're redirected to the dashboard you came from when you created an insight 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-hot-fix-code-insight-routing.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
