### PR TITLE
monitoring/frontend: mark some panels as multi-instance

### DIFF
--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -84,6 +84,8 @@ func Frontend() *monitoring.Dashboard {
 								- **Kubernetes:** Check CPU usage of zoekt-webserver in the indexed-search pod, consider increasing CPU limits in the 'indexed-search.Deployment.yaml' if regularly hitting max CPU utilization.
 								- **Docker Compose:** Check CPU usage on the Zoekt Web Server dashboard, consider increasing 'cpus:' of the zoekt-webserver container in 'docker-compose.yml' if regularly hitting max CPU utilization.
 							`,
+
+							MultiInstance: true,
 						},
 					},
 					{


### PR DESCRIPTION
These are nice, simple, single-time-series panels that could be useful for demonstrating multi-instance dashboards.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a