### PR TITLE
fix: remove circular references in build-config package

### DIFF
--- a/client/build-config/src/esbuild/monacoPlugin.ts
+++ b/client/build-config/src/esbuild/monacoPlugin.ts
@@ -6,9 +6,8 @@ import { EditorFeature, featuresArr } from 'monaco-editor-webpack-plugin/out/fea
 // eslint-disable-next-line no-restricted-imports
 import { EditorLanguage, languagesArr } from 'monaco-editor-webpack-plugin/out/languages'
 
-import { MONACO_LANGUAGES_AND_FEATURES } from '@sourcegraph/build-config'
-
 import { ROOT_PATH } from '../paths'
+import { MONACO_LANGUAGES_AND_FEATURES } from '../webpack/monaco-editor'
 
 const monacoModulePath = (modulePath: string): string =>
     require.resolve(path.join('monaco-editor/esm', modulePath), {

--- a/client/build-config/src/esbuild/workerPlugin.ts
+++ b/client/build-config/src/esbuild/workerPlugin.ts
@@ -2,7 +2,7 @@ import path from 'path'
 
 import * as esbuild from 'esbuild'
 
-import { packageResolutionPlugin, RXJS_RESOLUTIONS } from '@sourcegraph/build-config'
+import { packageResolutionPlugin, RXJS_RESOLUTIONS } from './packageResolutionPlugin'
 
 async function buildWorker(
     workerPath: string,


### PR DESCRIPTION
Circular references in bazel are not possible. I think importing within a package is normally relative and these can be changed.

## Test plan

The build being green is enough.

@kormide @jhchabran 