### PR TITLE
Downs/backend add event device session

### DIFF
--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -250,7 +250,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
             deviceID = anonymousUserID
             cookies.set(DEVICE_ID_KEY, deviceID, this.cookieSettings)
         }
-        return this.deviceID
+        return deviceID
     }
 
     // Insert ID is used to deduplicate events in Amplitude.

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -245,6 +245,11 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
     // Device ID is a require field for Amplitude events.
     // https://developers.amplitude.com/docs/http-api-v2
     public getDeviceID(): string {
+        let deviceID = cookies.get(DEVICE_ID_KEY)
+        if (!deviceID || deviceID === '') {
+            deviceID = anonymousUserID
+            cookies.set(DEVICE_ID_KEY, deviceID, this.cookieSettings)
+        }
         return this.deviceID
     }
 
@@ -308,8 +313,8 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
         if (!deviceID || deviceID === '') {
             // If device ID does not exist, use the anonymous user ID value so these are consolidated.
             deviceID = anonymousUserID
-            cookies.set(DEVICE_ID_KEY, deviceID, this.cookieSettings)
         }
+        cookies.set(DEVICE_ID_KEY, deviceID, this.cookieSettings)
 
         this.anonymousUserID = anonymousUserID
         this.cohortID = cohortID

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -316,9 +316,16 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
             cookies.set(DEVICE_ID_KEY, deviceID, this.cookieSettings)
         }
 
+        let deviceSessionID = cookies.get(DEVICE_SESSION_ID_KEY)
+        if (!deviceSessionID || deviceSessionID === '') {
+            deviceSessionID = uuid.v4()
+            cookies.set(DEVICE_SESSION_ID_KEY, deviceSessionID, this.deviceSessionCookieSettings)
+        }
+
         this.anonymousUserID = anonymousUserID
         this.cohortID = cohortID
         this.deviceID = deviceID
+        this.deviceSessionID = deviceSessionID
     }
 
     public addEventLogListener(callback: (eventName: string) => void): () => void {

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -305,7 +305,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
         }
 
         let deviceID = cookies.get(DEVICE_ID_KEY)
-        if (!deviceID) {
+        if (!deviceID || deviceID === '') {
             // If device ID does not exist, use the anonymous user ID value so these are consolidated.
             deviceID = anonymousUserID
             cookies.set(DEVICE_ID_KEY, deviceID, this.cookieSettings)

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -313,8 +313,8 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
         if (!deviceID || deviceID === '') {
             // If device ID does not exist, use the anonymous user ID value so these are consolidated.
             deviceID = anonymousUserID
+            cookies.set(DEVICE_ID_KEY, deviceID, this.cookieSettings)
         }
-        cookies.set(DEVICE_ID_KEY, deviceID, this.cookieSettings)
 
         this.anonymousUserID = anonymousUserID
         this.cohortID = cohortID


### PR DESCRIPTION
Since we construct the deviceID as an empty string, it may fail to initialize with the rest of the parameters. Checking for an empty string insures we set the device id to the anonymous user id when the device id isn't available. When getDeviceID is called, we previously would return an empty string if not initialized, this will now return the anonymous user id.

## Test plan

Visual

## App preview:

- [Web](https://sg-web-downs-backend-add-event-device.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
