### PR TITLE
Wildcard [Button]: Fix disabled button state

### DIFF
--- a/client/wildcard/src/components/Button/Button.tsx
+++ b/client/wildcard/src/components/Button/Button.tsx
@@ -67,13 +67,15 @@ export const Button = forwardRef(
         const brandedButtonClassname = getButtonClassName({ variant, outline, display, size })
 
         const handleClick = (event: MouseEvent<HTMLButtonElement>): void => {
-            if (!disabled) {
+            if (disabled) {
                 // Prevent any native button element behaviour, such as submit
                 // functionality if the button is used within form elements without
-                // type attribute
+                // type attribute (or with explicitly set "submit" type.
                 event.preventDefault()
-                onClick?.(event)
+                return
             }
+
+            onClick?.(event)
         }
 
         return (

--- a/client/wildcard/src/components/Button/Button.tsx
+++ b/client/wildcard/src/components/Button/Button.tsx
@@ -68,6 +68,10 @@ export const Button = forwardRef(
 
         const handleClick = (event: MouseEvent<HTMLButtonElement>): void => {
             if (!disabled) {
+                // Prevent any native button element behaviour, such as submit
+                // functionality if the button is used within form elements without
+                // type attribute
+                event.preventDefault()
                 onClick?.(event)
             }
         }


### PR DESCRIPTION
Closes the problem, which is described in this PR https://github.com/sourcegraph/sourcegraph/pull/44837

This PR adds `event.preventDefault()` to the custom button click handler in order to stop any native behaviour if the button is disabled (has aria-disabled true and not-clickable). See [this comment](https://github.com/sourcegraph/sourcegraph/pull/44837#issuecomment-1328062550) for more details.

## Test plan
- Open the user profile menu 
- Click feedback item
- Try to submit the form with empty feedback textarea 
- You should see that you can't submit the form if you have no value in the textbox

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-disabled-form-button-state.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
