### PR TITLE
monitoring/multi-instance: set UID on dashboard

### DIFF
--- a/monitoring/monitoring/multi_instance.go
+++ b/monitoring/monitoring/multi_instance.go
@@ -13,8 +13,8 @@ import (
 
 func renderMultiInstanceDashboard(dashboards []*Dashboard, groupings []string) (*grafanasdk.Board, error) {
 	board := sdk.NewBoard("Multi-instance overviews")
-	board.AddTags("builtin")
-
+	board.UID = "multi-instance-overviews"
+	board.ID = 0
 	board.Timezone = "utc"
 	board.Timepicker.RefreshIntervals = []string{"5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"}
 	board.Time.From = "now-6h"

--- a/monitoring/monitoring/multi_instance.go
+++ b/monitoring/monitoring/multi_instance.go
@@ -13,6 +13,7 @@ import (
 
 func renderMultiInstanceDashboard(dashboards []*Dashboard, groupings []string) (*grafanasdk.Board, error) {
 	board := sdk.NewBoard("Multi-instance overviews")
+	board.AddTags("multi-instance", "generated")
 	board.UID = "multi-instance-overviews"
 	board.ID = 0
 	board.Timezone = "utc"


### PR DESCRIPTION
Previously, you would get an error like this when attempting to reload the multi-instance dashboard, rather than loading it from disk:

```
generate: Could not reload Grafana dashboard "Multi-instance overviews": HTTP error 400: returns Cannot save provisioned dashboard
```

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg start grafana`, then:

```
SRC_LOG_LEVEL=debug sg monitoring generate --multi-instance-groupings=project_id --grafana.url=http://localhost:3370 --grafana.folder='Multi-Instance dashboards'
```