### PR TITLE
Add docs cta to no results page

### DIFF
--- a/client/search-ui/src/results/StreamingSearchResultsFooter.tsx
+++ b/client/search-ui/src/results/StreamingSearchResultsFooter.tsx
@@ -4,7 +4,8 @@ import classNames from 'classnames'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { AggregateStreamingSearchResults } from '@sourcegraph/shared/src/search/stream'
-import { Alert, LoadingSpinner, Code, Text } from '@sourcegraph/wildcard'
+import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { Alert, LoadingSpinner, Code, Text, Link } from '@sourcegraph/wildcard'
 
 import { StreamingProgressCount } from './progress/StreamingProgressCount'
 
@@ -14,8 +15,9 @@ export const StreamingSearchResultFooter: React.FunctionComponent<
     React.PropsWithChildren<{
         results?: AggregateStreamingSearchResults
         children?: React.ReactChild | React.ReactChild[]
+        telemetryService: TelemetryService
     }>
-> = ({ results, children }) => (
+> = ({ results, children, telemetryService }) => (
     <div className={classNames(styles.contentCentered, 'd-flex flex-column align-items-center')}>
         {(!results || results?.state === 'loading') && (
             <div className="text-center my-4" data-testid="loading-container">
@@ -37,7 +39,16 @@ export const StreamingSearchResultFooter: React.FunctionComponent<
                     <Text className="m-0">
                         <strong>No results matched your query</strong>
                         <br />
-                        Use the tips below to improve your query.
+                        Learn more about how to search{' '}
+                        <Link
+                            to="https://docs.sourcegraph.com/code_search/explanations/features"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            onClick={() => telemetryService.log('ClickedOnDocs')}
+                        >
+                            in our docs
+                        </Link>
+                        , or use the tips below to improve your query.
                     </Text>
                 </Alert>
             </div>

--- a/client/search-ui/src/results/StreamingSearchResultsList.tsx
+++ b/client/search-ui/src/results/StreamingSearchResultsList.tsx
@@ -274,7 +274,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
             />
 
             {itemsToShow >= resultsNumber && (
-                <StreamingSearchResultFooter results={results}>
+                <StreamingSearchResultFooter results={results} telemetryService={telemetryService}>
                     <>
                         {results?.state === 'complete' && resultsNumber === 0 && (
                             <NoResultsPage


### PR DESCRIPTION
This is progress towards #43899 which adds a doc link to the alert banner. Further recommendations and brainstorming for improvements of this page are still in flight ([design](https://www.figma.com/file/UuxnX1GteK9xjehqAb2dPP/UX%3A-Clean-up-'No-results'-page?t=TvzM5phB1cHGAvNh-0), [UX research](https://docs.google.com/document/d/1pceWxExHNI3ckmY62AtbLE367YMSoxpi2mMO6IJLrFo/edit#heading=h.g0gjwch98szj)).

## Test plan
Ensure the link goes to the docs and the `ClickedOnDocs` cta event is called in our event logger.

## App preview:

- [Web](https://sg-web-brett-no-results-cta.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
