### PR TITLE
graphqlbackend: return repo ID unmarshal error from repo KVP endpoints

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -631,7 +631,7 @@ func (r *schemaResolver) AddRepoKeyValuePair(ctx context.Context, args struct {
 
 	repoID, err := UnmarshalRepositoryID(args.Repo)
 	if err != nil {
-		return &EmptyResponse{}, nil
+		return &EmptyResponse{}, err
 	}
 
 	return &EmptyResponse{}, r.db.RepoKVPs().Create(ctx, repoID, database.KeyValuePair{Key: args.Key, Value: args.Value})
@@ -653,7 +653,7 @@ func (r *schemaResolver) UpdateRepoKeyValuePair(ctx context.Context, args struct
 
 	repoID, err := UnmarshalRepositoryID(args.Repo)
 	if err != nil {
-		return &EmptyResponse{}, nil
+		return &EmptyResponse{}, err
 	}
 
 	_, err = r.db.RepoKVPs().Update(ctx, repoID, database.KeyValuePair{Key: args.Key, Value: args.Value})
@@ -675,7 +675,7 @@ func (r *schemaResolver) DeleteRepoKeyValuePair(ctx context.Context, args struct
 
 	repoID, err := UnmarshalRepositoryID(args.Repo)
 	if err != nil {
-		return &EmptyResponse{}, nil
+		return &EmptyResponse{}, err
 	}
 
 	return &EmptyResponse{}, r.db.RepoKVPs().Delete(ctx, repoID, args.Key)


### PR DESCRIPTION
It's more helpful to the user to see that the repo ID they passed is invalid than to just get an empty response

Example request:
![Screen Shot 2022-12-01 at 3 44 40 PM](https://user-images.githubusercontent.com/70350613/205165458-ea001132-3638-4e3a-afb2-e1aedec6909a.png)

Response:
![Screen Shot 2022-12-01 at 3 44 45 PM](https://user-images.githubusercontent.com/70350613/205165466-9d26bf15-a8db-4c74-9a5d-29f90ec8198c.png)


## Test plan
Manually test
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
