### PR TITLE
codeintel: Reconcile lsif/scip metadata similarly

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore.go
@@ -49,6 +49,10 @@ type store struct {
 }
 
 func New(db codeintelshared.CodeIntelDB, observationContext *observation.Context) LsifStore {
+	return newStore(db, observationContext)
+}
+
+func newStore(db codeintelshared.CodeIntelDB, observationContext *observation.Context) *store {
 	return &store{
 		db:         basestore.NewWithHandle(db.Handle()),
 		serializer: NewSerializer(),

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_reconcile.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_reconcile.go
@@ -50,7 +50,7 @@ WITH candidates AS (
 	SELECT m.dump_id
 	FROM (SELECT dump_id FROM lsif_data_metadata UNION SELECT upload_id FROM codeintel_scip_metadata) m
 	LEFT JOIN codeintel_last_reconcile lr ON lr.dump_id = m.dump_id
-	ORDER BY lr.last_reconcile_at DESC NULLS FIRST, m.dump_id
+	ORDER BY lr.last_reconcile_at NULLS FIRST, m.dump_id
 	LIMIT %s
 )
 INSERT INTO codeintel_last_reconcile

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_reconcile_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_reconcile_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log/logtest"
@@ -23,6 +24,10 @@ func TestIDsWithMeta(t *testing.T) {
 		INSERT INTO lsif_data_metadata (dump_id, num_result_chunks) VALUES (100, 0);
 		INSERT INTO lsif_data_metadata (dump_id, num_result_chunks) VALUES (102, 0);
 		INSERT INTO lsif_data_metadata (dump_id, num_result_chunks) VALUES (104, 0);
+
+		INSERT INTO codeintel_scip_metadata (upload_id, text_document_encoding, tool_name, tool_version, tool_arguments, protocol_version) VALUES (200, 'utf8', '', '', '{}', 1);
+		INSERT INTO codeintel_scip_metadata (upload_id, text_document_encoding, tool_name, tool_version, tool_arguments, protocol_version) VALUES (202, 'utf8', '', '', '{}', 1);
+		INSERT INTO codeintel_scip_metadata (upload_id, text_document_encoding, tool_name, tool_version, tool_arguments, protocol_version) VALUES (204, 'utf8', '', '', '{}', 1);
 	`); err != nil {
 		t.Fatalf("unexpected error setting up test: %s", err)
 	}
@@ -33,6 +38,11 @@ func TestIDsWithMeta(t *testing.T) {
 		103,
 		104, // exists
 		105,
+		200, // exists
+		201,
+		203,
+		204, // exists
+		205,
 	}
 	ids, err := store.IDsWithMeta(ctx, candidates)
 	if err != nil {
@@ -41,6 +51,8 @@ func TestIDsWithMeta(t *testing.T) {
 	expectedIDs := []int{
 		100,
 		104,
+		200,
+		204,
 	}
 	sort.Ints(ids)
 	if diff := cmp.Diff(expectedIDs, ids); diff != "" {
@@ -51,8 +63,10 @@ func TestIDsWithMeta(t *testing.T) {
 func TestReconcileCandidates(t *testing.T) {
 	logger := logtest.Scoped(t)
 	codeIntelDB := codeintelshared.NewCodeIntelDB(dbtest.NewDB(logger, t))
-	store := New(codeIntelDB, &observation.TestContext)
+	store := newStore(codeIntelDB, &observation.TestContext)
+
 	ctx := context.Background()
+	now := time.Unix(1587396557, 0).UTC()
 
 	if _, err := codeIntelDB.ExecContext(ctx, `
 		INSERT INTO lsif_data_metadata (dump_id, num_result_chunks) VALUES (100, 0);
@@ -61,12 +75,19 @@ func TestReconcileCandidates(t *testing.T) {
 		INSERT INTO lsif_data_metadata (dump_id, num_result_chunks) VALUES (103, 0);
 		INSERT INTO lsif_data_metadata (dump_id, num_result_chunks) VALUES (104, 0);
 		INSERT INTO lsif_data_metadata (dump_id, num_result_chunks) VALUES (105, 0);
+
+		INSERT INTO codeintel_scip_metadata (upload_id, text_document_encoding, tool_name, tool_version, tool_arguments, protocol_version) VALUES (200, 'utf8', '', '', '{}', 1);
+		INSERT INTO codeintel_scip_metadata (upload_id, text_document_encoding, tool_name, tool_version, tool_arguments, protocol_version) VALUES (201, 'utf8', '', '', '{}', 1);
+		INSERT INTO codeintel_scip_metadata (upload_id, text_document_encoding, tool_name, tool_version, tool_arguments, protocol_version) VALUES (202, 'utf8', '', '', '{}', 1);
+		INSERT INTO codeintel_scip_metadata (upload_id, text_document_encoding, tool_name, tool_version, tool_arguments, protocol_version) VALUES (203, 'utf8', '', '', '{}', 1);
+		INSERT INTO codeintel_scip_metadata (upload_id, text_document_encoding, tool_name, tool_version, tool_arguments, protocol_version) VALUES (204, 'utf8', '', '', '{}', 1);
+		INSERT INTO codeintel_scip_metadata (upload_id, text_document_encoding, tool_name, tool_version, tool_arguments, protocol_version) VALUES (205, 'utf8', '', '', '{}', 1);
 	`); err != nil {
 		t.Fatalf("unexpected error setting up test: %s", err)
 	}
 
 	// Initial batch of records
-	ids, err := store.ReconcileCandidates(ctx, 4)
+	ids, err := store.reconcileCandidates(ctx, 8, now)
 	if err != nil {
 		t.Fatalf("failed to get candidate IDs for reconciliation: %s", err)
 	}
@@ -75,6 +96,10 @@ func TestReconcileCandidates(t *testing.T) {
 		101,
 		102,
 		103,
+		104,
+		105,
+		200,
+		201,
 	}
 	sort.Ints(ids)
 	if diff := cmp.Diff(expectedIDs, ids); diff != "" {
@@ -82,15 +107,35 @@ func TestReconcileCandidates(t *testing.T) {
 	}
 
 	// Remaining records, wrap around
-	ids, err = store.ReconcileCandidates(ctx, 4)
+	ids, err = store.reconcileCandidates(ctx, 8, now.Add(time.Minute*1))
 	if err != nil {
 		t.Fatalf("failed to get candidate IDs for reconciliation: %s", err)
 	}
 	expectedIDs = []int{
 		100,
 		101,
+		102,
+		103,
+		202,
+		203,
+		204,
+		205,
+	}
+	sort.Ints(ids)
+	if diff := cmp.Diff(expectedIDs, ids); diff != "" {
+		t.Fatalf("unexpected IDs (-want +got):\n%s", diff)
+	}
+
+	// ...and continues to wrap
+	ids, err = store.reconcileCandidates(ctx, 4, now.Add(time.Minute*2))
+	if err != nil {
+		t.Fatalf("failed to get candidate IDs for reconciliation: %s", err)
+	}
+	expectedIDs = []int{
 		104,
 		105,
+		200,
+		201,
 	}
 	sort.Ints(ids)
 	if diff := cmp.Diff(expectedIDs, ids); diff != "" {


### PR DESCRIPTION
Read from SCIP metadata tables (as well as LSIF metadata tables) when reconciling missing data in the codeintel-db.

## Test plan

- [x] New unit tests.