### PR TITLE
codeintel: Delete from scip tables on cleanup

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_delete_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_delete_test.go
@@ -22,24 +22,49 @@ func TestDeleteLsifDataByUploadIds(t *testing.T) {
 	codeIntelDB := codeintelshared.NewCodeIntelDB(dbtest.NewDB(logger, t))
 	store := New(codeIntelDB, &observation.TestContext)
 
-	for i := 0; i < 5; i++ {
-		query := sqlf.Sprintf("INSERT INTO lsif_data_metadata (dump_id, num_result_chunks) VALUES (%s, 0)", i+1)
+	t.Run("lsif", func(t *testing.T) {
+		for i := 0; i < 5; i++ {
+			query := sqlf.Sprintf("INSERT INTO lsif_data_metadata (dump_id, num_result_chunks) VALUES (%s, 0)", i+1)
 
-		if _, err := codeIntelDB.ExecContext(context.Background(), query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
-			t.Fatalf("unexpected error inserting repo: %s", err)
+			if _, err := codeIntelDB.ExecContext(context.Background(), query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+				t.Fatalf("unexpected error inserting repo: %s", err)
+			}
 		}
-	}
 
-	if err := store.DeleteLsifDataByUploadIds(context.Background(), 2, 4); err != nil {
-		t.Fatalf("unexpected error clearing bundle data: %s", err)
-	}
+		if err := store.DeleteLsifDataByUploadIds(context.Background(), 2, 4); err != nil {
+			t.Fatalf("unexpected error clearing bundle data: %s", err)
+		}
 
-	dumpIDs, err := basestore.ScanInts(codeIntelDB.QueryContext(context.Background(), "SELECT dump_id FROM lsif_data_metadata"))
-	if err != nil {
-		t.Fatalf("Unexpected error querying dump identifiers: %s", err)
-	}
+		dumpIDs, err := basestore.ScanInts(codeIntelDB.QueryContext(context.Background(), "SELECT dump_id FROM lsif_data_metadata"))
+		if err != nil {
+			t.Fatalf("Unexpected error querying dump identifiers: %s", err)
+		}
 
-	if diff := cmp.Diff([]int{1, 3, 5}, dumpIDs); diff != "" {
-		t.Errorf("unexpected dump identifiers (-want +got):\n%s", diff)
-	}
+		if diff := cmp.Diff([]int{1, 3, 5}, dumpIDs); diff != "" {
+			t.Errorf("unexpected dump identifiers (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("scip", func(t *testing.T) {
+		for i := 0; i < 5; i++ {
+			query := sqlf.Sprintf("INSERT INTO codeintel_scip_metadata (upload_id, text_document_encoding, tooL_name, tool_version, tool_arguments, protocol_version) VALUES (%s, 'utf8', '', '', '{}', 1)", i+1)
+
+			if _, err := codeIntelDB.ExecContext(context.Background(), query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+				t.Fatalf("unexpected error inserting repo: %s", err)
+			}
+		}
+
+		if err := store.DeleteLsifDataByUploadIds(context.Background(), 2, 4); err != nil {
+			t.Fatalf("unexpected error clearing bundle data: %s", err)
+		}
+
+		dumpIDs, err := basestore.ScanInts(codeIntelDB.QueryContext(context.Background(), "SELECT upload_id FROM codeintel_scip_metadata"))
+		if err != nil {
+			t.Fatalf("Unexpected error querying dump identifiers: %s", err)
+		}
+
+		if diff := cmp.Diff([]int{1, 3, 5}, dumpIDs); diff != "" {
+			t.Errorf("unexpected dump identifiers (-want +got):\n%s", diff)
+		}
+	})
 }


### PR DESCRIPTION
Delete from SCIP data tables (as well as LSIF data tables) when purging data from the codeintel-db.

## Test plan

- [x] New unit tests.