### PR TITLE
Code Insights: Query only timeout error for now

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/gql-backend/gql/GetInsightView.ts
+++ b/client/web/src/enterprise/insights/core/backend/gql-backend/gql/GetInsightView.ts
@@ -34,7 +34,7 @@ export const GET_INSIGHT_VIEW_GQL = gql`
             failedJobs
             isLoadingData
             incompleteDatapoints {
-                ... on IncompleteDatapointAlert {
+                ... on TimeoutDatapointAlert {
                     __typename
                     time
                 }


### PR DESCRIPTION
## Background
This fixes code insight GQL query for incomplete points. Prior to this, we query all error types (but we currently have UI only for the timeout error). Generic errors and proper UI for the timeout error will be implemented in this issue https://github.com/sourcegraph/sourcegraph/issues/44961

## Test plan
- Make sure that you can see timeout error UI only when insight has a timeout error 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-timeout-error-query.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
