### PR TITLE
cmd/server: correct blobstore env vars / fix CI

### DIFF
--- a/cmd/server/shared/blobstore.go
+++ b/cmd/server/shared/blobstore.go
@@ -20,8 +20,6 @@ func maybeBlobstore(logger sglog.Logger) []string {
 	// blobstore env vars copied from upstream Dockerfile:
 	// https://github.com/gaul/s3proxy/blob/master/Dockerfile
 	SetDefaultEnv("LOG_LEVEL", "info")
-	SetDefaultEnv("S3PROXY_AUTHORIZATION", "aws-v2-or-v4")
-	SetDefaultEnv("S3PROXY_ENDPOINT", "http://0.0.0.0:80")
 	SetDefaultEnv("S3PROXY_IDENTITY", "local-identity")
 	SetDefaultEnv("S3PROXY_CREDENTIAL", "local-credential")
 	SetDefaultEnv("S3PROXY_VIRTUALHOST", "")


### PR DESCRIPTION
Hello - me again. The third time was not the charm, sorry - I broke CI once more.

Although I was right about the env var fixes (and I swear, I did test them against the actual image); it turned out that I had called `SetDefaultEnv` twice for these two env vars, once to set the "default" (inherited from the upstream Dockerfile) and once to set _our override_ of it. This meant that my tests using the Docker image with `-e` flags worked, but the default did not.

If `SetDefaultEnv` is called twice:

```go
SetDefaultEnv("foo", "a")
SetDefaultEnv("foo", "b")
```

Then the default value for "foo" is actually "a" not "b".

Fourth time's the charm? Helps https://github.com/sourcegraph/sourcegraph/issues/44254

## Test plan

1. Tested the exact image that CI failed with, without `-e S3PROXY_AUTHORIZATION=none -e S3PROXY_ENDPOINT=http://0.0.0.0:9000` it fails but with it passes our codeintel-qa suite.
2. Logically followed the code to identify how that could happen (`SetDefaultEnv`'s strange behavior)
