### PR TITLE
monitoring/multi-instance: rewrite to support heights

### DIFF
--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -147,8 +147,9 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 	var generatedAssets []string
 	var err error
 	if len(opts.MultiInstanceDashboardGroupings) > 0 {
-		logger.Info("generating multi-instance")
-		generatedAssets, err = generateMultiInstance(ctx, logger, grafanaClient, grafanaFolderID, dashboards, opts)
+		l := logger.Scoped("multi-instance", "multi-instance dashboards")
+		l.Info("generating multi-instance")
+		generatedAssets, err = generateMultiInstance(ctx, l, grafanaClient, grafanaFolderID, dashboards, opts)
 	} else {
 		logger.Info("generating all")
 		generatedAssets, err = generateAll(ctx, logger, grafanaClient, grafanaFolderID, dashboards, opts)

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -281,11 +281,12 @@ func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher, folde
 				panel, err := o.renderPanel(c, panelManipulationOptions{
 					injectLabelMatchers: injectLabelMatchers,
 				}, &panelRenderOptions{
-					groupIndex: groupIndex,
-					rowIndex:   rowIndex,
-					panelIndex: panelIndex,
-					panelWidth: panelWidth,
-					offsetY:    offsetY,
+					groupIndex:  groupIndex,
+					rowIndex:    rowIndex,
+					panelIndex:  panelIndex,
+					panelWidth:  panelWidth,
+					panelHeight: 5,
+					offsetY:     offsetY,
 				})
 				if err != nil {
 					return nil, errors.Wrapf(err, "render panel for %q", o.Name)
@@ -765,10 +766,11 @@ func (o Observable) alertsCount() (count int) {
 }
 
 type panelRenderOptions struct {
-	groupIndex int
-	rowIndex   int
-	panelIndex int
-	panelWidth int
+	groupIndex  int
+	rowIndex    int
+	panelIndex  int
+	panelWidth  int
+	panelHeight int
 
 	offsetY int
 }
@@ -795,7 +797,7 @@ func (o Observable) renderPanel(c *Dashboard, manipulations panelManipulationOpt
 		panel.ID = observablePanelID(opts.groupIndex, opts.rowIndex, opts.panelIndex)
 
 		// Set positioning
-		setPanelSize(panel, opts.panelWidth, 5)
+		setPanelSize(panel, opts.panelWidth, opts.panelHeight)
 		setPanelPos(panel, opts.panelIndex*opts.panelWidth, opts.offsetY)
 	}
 

--- a/monitoring/monitoring/multi_instance.go
+++ b/monitoring/monitoring/multi_instance.go
@@ -43,12 +43,13 @@ func renderMultiInstanceDashboard(dashboards []*Dashboard, groupings []string) (
 		variableMatchers = append(variableMatchers, m)
 	}
 
-	for _, d := range dashboards {
-		var row *sdk.Row
+	var offsetY int
+	for dashboardIndex, d := range dashboards {
+		var row *sdk.Panel
 		var addDashboardRow sync.Once
-		for _, g := range d.Groups {
+		for groupIndex, g := range d.Groups {
 			for _, r := range g.Rows {
-				for _, o := range r {
+				for observableIndex, o := range r {
 					if !o.MultiInstance {
 						continue
 					}
@@ -56,22 +57,37 @@ func renderMultiInstanceDashboard(dashboards []*Dashboard, groupings []string) (
 					// Only add row if this dashboard has a multi instance panel, and only
 					// do it once per dashboard
 					addDashboardRow.Do(func() {
-						row = board.AddRow(d.Title)
-						row.ShowTitle = true
-						row.Collapse = true // avoid crazy loading times
+						row = &sdk.Panel{RowPanel: &sdk.RowPanel{}}
+						row.OfType = sdk.RowType
+						row.Type = "row"
+						row.Title = d.Title
+						row.Collapsed = true // avoid crazy loading times
+						offsetY++
+						setPanelPos(row, 0, offsetY)
+						row.Panels = []sdk.Panel{} // cannot be null
+						board.Panels = append(board.Panels, row)
 					})
 
-					// TODO make this size correctly in this context and output a valid
-					// dashboard, right now it isn't quite right
+					// Generate the panel with groupings and variables
+					offsetY++
 					panel, err := o.renderPanel(d, panelManipulationOptions{
 						injectGroupings:     groupings,
 						injectLabelMatchers: variableMatchers,
-					}, nil)
+					}, &panelRenderOptions{
+						// these indexes are only used for identification
+						groupIndex: dashboardIndex,
+						rowIndex:   groupIndex,
+						panelIndex: observableIndex,
+
+						panelWidth:  24,      // max-width
+						panelHeight: 10,      // tall dashboards!
+						offsetY:     offsetY, // total index added
+					})
 					if err != nil {
 						return nil, errors.Wrapf(err, "render panel for %q", o.Name)
 					}
 
-					row.Add(panel)
+					row.RowPanel.Panels = append(row.RowPanel.Panels, *panel)
 				}
 			}
 		}


### PR DESCRIPTION
For whatever reason the way we were writing this previously made it not possible to set the height in a way that Grafana would respect, so this PR rewrites it to mirror our other dashboard generation code and sets the multi-instance panels to be tall and big.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg start grafana`, then:

```
SRC_LOG_LEVEL=debug go run ./dev/sg monitoring generate --multi-instance-groupings=project_id --grafana.url=http://localhost:3370 --grafana.folder='Multi-Instance dashboards' -reload -no-prune
```

<img width="1354" alt="image" src="https://user-images.githubusercontent.com/23356519/205186111-d2416b45-3821-4c54-b97b-f5357ff3ad12.png">

