### PR TITLE
{blobstore, uploadstore}: general cleanup

### DIFF
--- a/cmd/server/shared/blobstore.go
+++ b/cmd/server/shared/blobstore.go
@@ -17,9 +17,18 @@ func maybeBlobstore(logger sglog.Logger) []string {
 	SetDefaultEnv("PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT", "http://127.0.0.1:9000")
 	SetDefaultEnv("PRECISE_CODE_INTEL_UPLOAD_BACKEND", "blobstore")
 
-	// blobstore env vars copied from upstream Dockerfile:
-	// https://github.com/gaul/s3proxy/blob/master/Dockerfile
+	// cmd/server-specific blobstore env vars
+	// Note: SetDefaultEnv should be called only once for the same env var, so
+	// ensure these do not conflict with the default list set below.
+	dataDir := filepath.Join(os.Getenv("DATA_DIR"), "blobstore")
+	SetDefaultEnv("S3PROXY_ENDPOINT", "http://0.0.0.0:9000")
+	SetDefaultEnv("JCLOUDS_FILESYSTEM_BASEDIR", dataDir)
+
+	// Default blobstore env vars copied from the Dockerfile
+	// https://github.com/sourcegraph/sourcegraph/blob/main/docker-images/blobstore/Dockerfile
 	SetDefaultEnv("LOG_LEVEL", "info")
+	SetDefaultEnv("S3PROXY_AUTHORIZATION", "none")
+	// SetDefaultEnv("S3PROXY_ENDPOINT", "http://0.0.0.0:80") // overridden above; here for equality with Dockerfile
 	SetDefaultEnv("S3PROXY_IDENTITY", "local-identity")
 	SetDefaultEnv("S3PROXY_CREDENTIAL", "local-credential")
 	SetDefaultEnv("S3PROXY_VIRTUALHOST", "")
@@ -41,12 +50,9 @@ func maybeBlobstore(logger sglog.Logger) []string {
 	SetDefaultEnv("JCLOUDS_KEYSTONE_VERSION", "")
 	SetDefaultEnv("JCLOUDS_KEYSTONE_SCOPE", "")
 	SetDefaultEnv("JCLOUDS_KEYSTONE_PROJECT_DOMAIN_NAME", "")
+	// SetDefaultEnv("JCLOUDS_FILESYSTEM_BASEDIR", dataDir) // overridden above; here for equality with Dockerfile
 
 	// Configure blobstore service
-	dataDir := filepath.Join(os.Getenv("DATA_DIR"), "blobstore")
-	SetDefaultEnv("JCLOUDS_FILESYSTEM_BASEDIR", dataDir)
-	SetDefaultEnv("S3PROXY_AUTHORIZATION", "none")
-	SetDefaultEnv("S3PROXY_ENDPOINT", "http://0.0.0.0:9000")
 	procline := `blobstore: /opt/s3proxy/run-docker-container.sh >> /var/opt/sourcegraph/blobstore.log 2>&1`
 	return []string{procline}
 }

--- a/docker-images/blobstore/Dockerfile
+++ b/docker-images/blobstore/Dockerfile
@@ -34,7 +34,7 @@ COPY --from=builder /opt/s3proxy /opt/s3proxy
 
 ENV \
     LOG_LEVEL="info" \
-    S3PROXY_AUTHORIZATION="aws-v2-or-v4" \
+    S3PROXY_AUTHORIZATION="none" \
     S3PROXY_ENDPOINT="http://0.0.0.0:80" \
     S3PROXY_IDENTITY="local-identity" \
     S3PROXY_CREDENTIAL="local-credential" \

--- a/internal/uploadstore/gcs_api.go
+++ b/internal/uploadstore/gcs_api.go
@@ -15,7 +15,6 @@ type gcsAPI interface {
 type gcsBucketHandle interface {
 	Attrs(ctx context.Context) (*storage.BucketAttrs, error)
 	Create(ctx context.Context, projectID string, attrs *storage.BucketAttrs) error
-	Update(ctx context.Context, attrs storage.BucketAttrsToUpdate) error
 	Object(name string) gcsObjectHandle
 	Objects(ctx context.Context, q *storage.Query) gcsObjectIterator
 }
@@ -62,11 +61,6 @@ func (s *bucketHandleShim) Attrs(ctx context.Context) (*storage.BucketAttrs, err
 
 func (s *bucketHandleShim) Create(ctx context.Context, projectID string, attrs *storage.BucketAttrs) error {
 	return s.handle.Create(ctx, projectID, attrs)
-}
-
-func (s *bucketHandleShim) Update(ctx context.Context, attrs storage.BucketAttrsToUpdate) error {
-	_, err := s.handle.Update(ctx, attrs)
-	return err
 }
 
 func (s *bucketHandleShim) Object(name string) gcsObjectHandle {

--- a/internal/uploadstore/gcs_client.go
+++ b/internal/uploadstore/gcs_client.go
@@ -75,10 +75,6 @@ func (s *gcsStore) Init(ctx context.Context) error {
 		return errors.Wrap(err, "failed to get bucket attributes")
 	}
 
-	if err := s.update(ctx, bucket); err != nil {
-		return errors.Wrap(err, "failed to update bucket attributes")
-	}
-
 	return nil
 }
 
@@ -195,32 +191,7 @@ func (s *gcsStore) ExpireObjects(ctx context.Context, prefix string, maxAge time
 }
 
 func (s *gcsStore) create(ctx context.Context, bucket gcsBucketHandle) error {
-	return bucket.Create(ctx, s.config.ProjectID, &storage.BucketAttrs{
-		Lifecycle: s.lifecycle(),
-	})
-}
-
-func (s *gcsStore) update(ctx context.Context, bucket gcsBucketHandle) error {
-	lifecycle := s.lifecycle()
-
-	return bucket.Update(ctx, storage.BucketAttrsToUpdate{
-		Lifecycle: &lifecycle,
-	})
-}
-
-func (s *gcsStore) lifecycle() storage.Lifecycle {
-	return storage.Lifecycle{
-		Rules: []storage.LifecycleRule{
-			{
-				Action: storage.LifecycleAction{
-					Type: "Delete",
-				},
-				Condition: storage.LifecycleCondition{
-					AgeInDays: int64(s.ttl / (time.Hour * 24)),
-				},
-			},
-		},
-	}
+	return bucket.Create(ctx, s.config.ProjectID, nil)
 }
 
 func (s *gcsStore) deleteSources(ctx context.Context, bucket gcsBucketHandle, sources []string) error {

--- a/internal/uploadstore/gcs_client_test.go
+++ b/internal/uploadstore/gcs_client_test.go
@@ -34,9 +34,6 @@ func TestGCSInit(t *testing.T) {
 	} else if value := calls[0].Arg1; value != "pid" {
 		t.Errorf("unexpected projectId argument. want=%s have=%s", "pid", value)
 	}
-	if calls := bucketHandle.UpdateFunc.History(); len(calls) != 0 {
-		t.Fatalf("unexpected number of Update calls. want=%d have=%d", 0, len(calls))
-	}
 }
 
 func TestGCSInitBucketExists(t *testing.T) {
@@ -58,9 +55,6 @@ func TestGCSInitBucketExists(t *testing.T) {
 	if calls := bucketHandle.CreateFunc.History(); len(calls) != 0 {
 		t.Fatalf("unexpected number of Create calls. want=%d have=%d", 0, len(calls))
 	}
-	if calls := bucketHandle.UpdateFunc.History(); len(calls) != 1 {
-		t.Fatalf("unexpected number of Update calls. want=%d have=%d", 1, len(calls))
-	}
 }
 
 func TestGCSUnmanagedInit(t *testing.T) {
@@ -76,9 +70,6 @@ func TestGCSUnmanagedInit(t *testing.T) {
 
 	if calls := gcsClient.BucketFunc.History(); len(calls) != 0 {
 		t.Fatalf("unexpected number of Bucket calls. want=%d have=%d", 0, len(calls))
-	}
-	if calls := bucketHandle.UpdateFunc.History(); len(calls) != 0 {
-		t.Fatalf("unexpected number of Update calls. want=%d have=%d", 0, len(calls))
 	}
 	if calls := bucketHandle.CreateFunc.History(); len(calls) != 0 {
 		t.Fatalf("unexpected number of Create calls. want=%d have=%d", 0, len(calls))
@@ -246,16 +237,6 @@ func TestGCSDelete(t *testing.T) {
 
 	if calls := objectHandle.DeleteFunc.History(); len(calls) != 1 {
 		t.Fatalf("unexpected number of Delete calls. want=%d have=%d", 1, len(calls))
-	}
-}
-
-func TestGCSLifecycle(t *testing.T) {
-	client := rawGCSClient(nil, true)
-
-	if lifecycle := client.lifecycle(); len(lifecycle.Rules) != 1 {
-		t.Fatalf("unexpected lifecycle rules")
-	} else if value := lifecycle.Rules[0].Condition.AgeInDays; value != 3 {
-		t.Errorf("unexpected expiration days. want=%d have=%d", 3, value)
 	}
 }
 

--- a/internal/uploadstore/mocks_test.go
+++ b/internal/uploadstore/mocks_test.go
@@ -1533,10 +1533,6 @@ type MockS3API struct {
 	// object controlling the behavior of the method
 	// NewListObjectsV2Paginator.
 	NewListObjectsV2PaginatorFunc *S3APINewListObjectsV2PaginatorFunc
-	// PutBucketLifecycleConfigurationFunc is an instance of a mock function
-	// object controlling the behavior of the method
-	// PutBucketLifecycleConfiguration.
-	PutBucketLifecycleConfigurationFunc *S3APIPutBucketLifecycleConfigurationFunc
 	// UploadPartCopyFunc is an instance of a mock function object
 	// controlling the behavior of the method UploadPartCopy.
 	UploadPartCopyFunc *S3APIUploadPartCopyFunc
@@ -1588,11 +1584,6 @@ func NewMockS3API() *MockS3API {
 		},
 		NewListObjectsV2PaginatorFunc: &S3APINewListObjectsV2PaginatorFunc{
 			defaultHook: func(*s3.ListObjectsV2Input) (r0 *s3.ListObjectsV2Paginator) {
-				return
-			},
-		},
-		PutBucketLifecycleConfigurationFunc: &S3APIPutBucketLifecycleConfigurationFunc{
-			defaultHook: func(context.Context, *s3.PutBucketLifecycleConfigurationInput) (r0 *s3.PutBucketLifecycleConfigurationOutput, r1 error) {
 				return
 			},
 		},
@@ -1653,11 +1644,6 @@ func NewStrictMockS3API() *MockS3API {
 				panic("unexpected invocation of MockS3API.NewListObjectsV2Paginator")
 			},
 		},
-		PutBucketLifecycleConfigurationFunc: &S3APIPutBucketLifecycleConfigurationFunc{
-			defaultHook: func(context.Context, *s3.PutBucketLifecycleConfigurationInput) (*s3.PutBucketLifecycleConfigurationOutput, error) {
-				panic("unexpected invocation of MockS3API.PutBucketLifecycleConfiguration")
-			},
-		},
 		UploadPartCopyFunc: &S3APIUploadPartCopyFunc{
 			defaultHook: func(context.Context, *s3.UploadPartCopyInput) (*s3.UploadPartCopyOutput, error) {
 				panic("unexpected invocation of MockS3API.UploadPartCopy")
@@ -1679,7 +1665,6 @@ type surrogateMockS3API interface {
 	GetObject(context.Context, *s3.GetObjectInput) (*s3.GetObjectOutput, error)
 	HeadObject(context.Context, *s3.HeadObjectInput) (*s3.HeadObjectOutput, error)
 	NewListObjectsV2Paginator(*s3.ListObjectsV2Input) *s3.ListObjectsV2Paginator
-	PutBucketLifecycleConfiguration(context.Context, *s3.PutBucketLifecycleConfigurationInput) (*s3.PutBucketLifecycleConfigurationOutput, error)
 	UploadPartCopy(context.Context, *s3.UploadPartCopyInput) (*s3.UploadPartCopyOutput, error)
 }
 
@@ -1713,9 +1698,6 @@ func NewMockS3APIFrom(i surrogateMockS3API) *MockS3API {
 		},
 		NewListObjectsV2PaginatorFunc: &S3APINewListObjectsV2PaginatorFunc{
 			defaultHook: i.NewListObjectsV2Paginator,
-		},
-		PutBucketLifecycleConfigurationFunc: &S3APIPutBucketLifecycleConfigurationFunc{
-			defaultHook: i.PutBucketLifecycleConfiguration,
 		},
 		UploadPartCopyFunc: &S3APIUploadPartCopyFunc{
 			defaultHook: i.UploadPartCopy,
@@ -2695,118 +2677,6 @@ func (c S3APINewListObjectsV2PaginatorFuncCall) Args() []interface{} {
 // invocation.
 func (c S3APINewListObjectsV2PaginatorFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
-}
-
-// S3APIPutBucketLifecycleConfigurationFunc describes the behavior when the
-// PutBucketLifecycleConfiguration method of the parent MockS3API instance
-// is invoked.
-type S3APIPutBucketLifecycleConfigurationFunc struct {
-	defaultHook func(context.Context, *s3.PutBucketLifecycleConfigurationInput) (*s3.PutBucketLifecycleConfigurationOutput, error)
-	hooks       []func(context.Context, *s3.PutBucketLifecycleConfigurationInput) (*s3.PutBucketLifecycleConfigurationOutput, error)
-	history     []S3APIPutBucketLifecycleConfigurationFuncCall
-	mutex       sync.Mutex
-}
-
-// PutBucketLifecycleConfiguration delegates to the next hook function in
-// the queue and stores the parameter and result values of this invocation.
-func (m *MockS3API) PutBucketLifecycleConfiguration(v0 context.Context, v1 *s3.PutBucketLifecycleConfigurationInput) (*s3.PutBucketLifecycleConfigurationOutput, error) {
-	r0, r1 := m.PutBucketLifecycleConfigurationFunc.nextHook()(v0, v1)
-	m.PutBucketLifecycleConfigurationFunc.appendCall(S3APIPutBucketLifecycleConfigurationFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// PutBucketLifecycleConfiguration method of the parent MockS3API instance
-// is invoked and the hook queue is empty.
-func (f *S3APIPutBucketLifecycleConfigurationFunc) SetDefaultHook(hook func(context.Context, *s3.PutBucketLifecycleConfigurationInput) (*s3.PutBucketLifecycleConfigurationOutput, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// PutBucketLifecycleConfiguration method of the parent MockS3API instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *S3APIPutBucketLifecycleConfigurationFunc) PushHook(hook func(context.Context, *s3.PutBucketLifecycleConfigurationInput) (*s3.PutBucketLifecycleConfigurationOutput, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *S3APIPutBucketLifecycleConfigurationFunc) SetDefaultReturn(r0 *s3.PutBucketLifecycleConfigurationOutput, r1 error) {
-	f.SetDefaultHook(func(context.Context, *s3.PutBucketLifecycleConfigurationInput) (*s3.PutBucketLifecycleConfigurationOutput, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *S3APIPutBucketLifecycleConfigurationFunc) PushReturn(r0 *s3.PutBucketLifecycleConfigurationOutput, r1 error) {
-	f.PushHook(func(context.Context, *s3.PutBucketLifecycleConfigurationInput) (*s3.PutBucketLifecycleConfigurationOutput, error) {
-		return r0, r1
-	})
-}
-
-func (f *S3APIPutBucketLifecycleConfigurationFunc) nextHook() func(context.Context, *s3.PutBucketLifecycleConfigurationInput) (*s3.PutBucketLifecycleConfigurationOutput, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *S3APIPutBucketLifecycleConfigurationFunc) appendCall(r0 S3APIPutBucketLifecycleConfigurationFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// S3APIPutBucketLifecycleConfigurationFuncCall objects describing the
-// invocations of this function.
-func (f *S3APIPutBucketLifecycleConfigurationFunc) History() []S3APIPutBucketLifecycleConfigurationFuncCall {
-	f.mutex.Lock()
-	history := make([]S3APIPutBucketLifecycleConfigurationFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// S3APIPutBucketLifecycleConfigurationFuncCall is an object that describes
-// an invocation of method PutBucketLifecycleConfiguration on an instance of
-// MockS3API.
-type S3APIPutBucketLifecycleConfigurationFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 *s3.PutBucketLifecycleConfigurationInput
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 *s3.PutBucketLifecycleConfigurationOutput
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c S3APIPutBucketLifecycleConfigurationFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c S3APIPutBucketLifecycleConfigurationFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // S3APIUploadPartCopyFunc describes the behavior when the UploadPartCopy

--- a/internal/uploadstore/mocks_test.go
+++ b/internal/uploadstore/mocks_test.go
@@ -183,9 +183,6 @@ type MockGcsBucketHandle struct {
 	// ObjectsFunc is an instance of a mock function object controlling the
 	// behavior of the method Objects.
 	ObjectsFunc *GcsBucketHandleObjectsFunc
-	// UpdateFunc is an instance of a mock function object controlling the
-	// behavior of the method Update.
-	UpdateFunc *GcsBucketHandleUpdateFunc
 }
 
 // NewMockGcsBucketHandle creates a new mock of the gcsBucketHandle
@@ -210,11 +207,6 @@ func NewMockGcsBucketHandle() *MockGcsBucketHandle {
 		},
 		ObjectsFunc: &GcsBucketHandleObjectsFunc{
 			defaultHook: func(context.Context, *storage.Query) (r0 gcsObjectIterator) {
-				return
-			},
-		},
-		UpdateFunc: &GcsBucketHandleUpdateFunc{
-			defaultHook: func(context.Context, storage.BucketAttrsToUpdate) (r0 error) {
 				return
 			},
 		},
@@ -245,11 +237,6 @@ func NewStrictMockGcsBucketHandle() *MockGcsBucketHandle {
 				panic("unexpected invocation of MockGcsBucketHandle.Objects")
 			},
 		},
-		UpdateFunc: &GcsBucketHandleUpdateFunc{
-			defaultHook: func(context.Context, storage.BucketAttrsToUpdate) error {
-				panic("unexpected invocation of MockGcsBucketHandle.Update")
-			},
-		},
 	}
 }
 
@@ -262,7 +249,6 @@ type surrogateMockGcsBucketHandle interface {
 	Create(context.Context, string, *storage.BucketAttrs) error
 	Object(string) gcsObjectHandle
 	Objects(context.Context, *storage.Query) gcsObjectIterator
-	Update(context.Context, storage.BucketAttrsToUpdate) error
 }
 
 // NewMockGcsBucketHandleFrom creates a new mock of the MockGcsBucketHandle
@@ -281,9 +267,6 @@ func NewMockGcsBucketHandleFrom(i surrogateMockGcsBucketHandle) *MockGcsBucketHa
 		},
 		ObjectsFunc: &GcsBucketHandleObjectsFunc{
 			defaultHook: i.Objects,
-		},
-		UpdateFunc: &GcsBucketHandleUpdateFunc{
-			defaultHook: i.Update,
 		},
 	}
 }
@@ -705,111 +688,6 @@ func (c GcsBucketHandleObjectsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GcsBucketHandleObjectsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
-}
-
-// GcsBucketHandleUpdateFunc describes the behavior when the Update method
-// of the parent MockGcsBucketHandle instance is invoked.
-type GcsBucketHandleUpdateFunc struct {
-	defaultHook func(context.Context, storage.BucketAttrsToUpdate) error
-	hooks       []func(context.Context, storage.BucketAttrsToUpdate) error
-	history     []GcsBucketHandleUpdateFuncCall
-	mutex       sync.Mutex
-}
-
-// Update delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockGcsBucketHandle) Update(v0 context.Context, v1 storage.BucketAttrsToUpdate) error {
-	r0 := m.UpdateFunc.nextHook()(v0, v1)
-	m.UpdateFunc.appendCall(GcsBucketHandleUpdateFuncCall{v0, v1, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the Update method of the
-// parent MockGcsBucketHandle instance is invoked and the hook queue is
-// empty.
-func (f *GcsBucketHandleUpdateFunc) SetDefaultHook(hook func(context.Context, storage.BucketAttrsToUpdate) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// Update method of the parent MockGcsBucketHandle instance invokes the hook
-// at the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *GcsBucketHandleUpdateFunc) PushHook(hook func(context.Context, storage.BucketAttrsToUpdate) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *GcsBucketHandleUpdateFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, storage.BucketAttrsToUpdate) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *GcsBucketHandleUpdateFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, storage.BucketAttrsToUpdate) error {
-		return r0
-	})
-}
-
-func (f *GcsBucketHandleUpdateFunc) nextHook() func(context.Context, storage.BucketAttrsToUpdate) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *GcsBucketHandleUpdateFunc) appendCall(r0 GcsBucketHandleUpdateFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of GcsBucketHandleUpdateFuncCall objects
-// describing the invocations of this function.
-func (f *GcsBucketHandleUpdateFunc) History() []GcsBucketHandleUpdateFuncCall {
-	f.mutex.Lock()
-	history := make([]GcsBucketHandleUpdateFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// GcsBucketHandleUpdateFuncCall is an object that describes an invocation
-// of method Update on an instance of MockGcsBucketHandle.
-type GcsBucketHandleUpdateFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 storage.BucketAttrsToUpdate
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c GcsBucketHandleUpdateFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c GcsBucketHandleUpdateFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/uploadstore/s3_api.go
+++ b/internal/uploadstore/s3_api.go
@@ -16,7 +16,6 @@ type s3API interface {
 	UploadPartCopy(ctx context.Context, input *s3.UploadPartCopyInput) (*s3.UploadPartCopyOutput, error)
 	CompleteMultipartUpload(ctx context.Context, input *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error)
 	CreateBucket(ctx context.Context, input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error)
-	PutBucketLifecycleConfiguration(ctx context.Context, input *s3.PutBucketLifecycleConfigurationInput) (*s3.PutBucketLifecycleConfigurationOutput, error)
 	DeleteObjects(ctx context.Context, params *s3.DeleteObjectsInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error)
 	NewListObjectsV2Paginator(input *s3.ListObjectsV2Input) *s3.ListObjectsV2Paginator
 }
@@ -37,10 +36,6 @@ var (
 
 func (s *s3APIShim) CreateBucket(ctx context.Context, input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
 	return s.Client.CreateBucket(ctx, input)
-}
-
-func (s *s3APIShim) PutBucketLifecycleConfiguration(ctx context.Context, input *s3.PutBucketLifecycleConfigurationInput) (*s3.PutBucketLifecycleConfigurationOutput, error) {
-	return s.Client.PutBucketLifecycleConfiguration(ctx, input)
 }
 
 func (s *s3APIShim) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {

--- a/internal/uploadstore/s3_client.go
+++ b/internal/uploadstore/s3_client.go
@@ -28,8 +28,6 @@ type s3Store struct {
 	manageBucket                 bool
 	client                       s3API
 	uploader                     s3Uploader
-	bucketLifecycleConfiguration *s3types.BucketLifecycleConfiguration
-	canConfigureLifecycle        bool
 	operations                   *Operations
 }
 
@@ -54,19 +52,16 @@ func newS3FromConfig(ctx context.Context, config Config, operations *Operations)
 	s3Client := s3.NewFromConfig(cfg, s3ClientOptions(config.S3))
 	api := &s3APIShim{s3Client}
 	uploader := &s3UploaderShim{manager.NewUploader(s3Client)}
-	lifecycleConfiguration, canConfigureLifecycle := s3BucketLifecycleConfiguration(config.Backend, config.TTL)
-	return newS3WithClients(api, uploader, config.Bucket, config.ManageBucket, lifecycleConfiguration, canConfigureLifecycle, operations), nil
+	return newS3WithClients(api, uploader, config.Bucket, config.ManageBucket, operations), nil
 }
 
-func newS3WithClients(client s3API, uploader s3Uploader, bucket string, manageBucket bool, lifecycleConfiguration *s3types.BucketLifecycleConfiguration, canConfigureLifecycle bool, operations *Operations) *s3Store {
+func newS3WithClients(client s3API, uploader s3Uploader, bucket string, manageBucket bool, operations *Operations) *s3Store {
 	return &s3Store{
 		bucket:                       bucket,
 		manageBucket:                 manageBucket,
 		client:                       client,
 		uploader:                     uploader,
 		operations:                   operations,
-		bucketLifecycleConfiguration: lifecycleConfiguration,
-		canConfigureLifecycle:        canConfigureLifecycle,
 	}
 }
 
@@ -77,10 +72,6 @@ func (s *s3Store) Init(ctx context.Context) error {
 
 	if err := s.create(ctx); err != nil {
 		return errors.Wrap(err, "failed to create bucket")
-	}
-
-	if err := s.update(ctx); err != nil {
-		return errors.Wrap(err, "failed to update bucket attributes")
 	}
 
 	return nil
@@ -340,20 +331,6 @@ func (s *s3Store) create(ctx context.Context) error {
 	return err
 }
 
-func (s *s3Store) update(ctx context.Context) error {
-	// TODO(blobstore): remove lifecycle configuration entirely and rely just on our
-	// built-in expiration. See https://github.com/sourcegraph/sourcegraph/pull/44255#discussion_r1036336557
-	if !s.canConfigureLifecycle {
-		return nil
-	}
-	configureRequest := &s3.PutBucketLifecycleConfigurationInput{
-		Bucket:                 aws.String(s.bucket),
-		LifecycleConfiguration: s.bucketLifecycleConfiguration,
-	}
-	_, err := s.client.PutBucketLifecycleConfiguration(ctx, configureRequest)
-	return err
-}
-
 func (s *s3Store) deleteSources(ctx context.Context, bucket string, sources []string) error {
 	return goroutine.RunWorkersOverStrings(sources, func(index int, source string) error {
 		if _, err := s.client.DeleteObject(ctx, &s3.DeleteObjectInput{
@@ -416,33 +393,4 @@ func writeToPipe(fn func(w io.Writer) error) io.Reader {
 
 func isConnectionResetError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "read: connection reset by peer")
-}
-
-func s3BucketLifecycleConfiguration(backend string, ttl time.Duration) (*s3types.BucketLifecycleConfiguration, bool) {
-	if backend == "blobstore" {
-		// blobstore backend does not support configuration of lifecycle rules.
-		return nil, false
-	}
-	days := int32(ttl / (time.Hour * 24))
-
-	rules := []s3types.LifecycleRule{
-		{
-			ID:         aws.String("Expiration Rule"),
-			Status:     s3types.ExpirationStatusEnabled,
-			Filter:     &s3types.LifecycleRuleFilterMemberPrefix{Value: ""},
-			Expiration: &s3types.LifecycleExpiration{Days: days},
-		},
-	}
-
-	// TODO(blobstore): remove minio support
-	// This rule doesn't work on minio, so we have to skip it there.
-	if backend != "minio" {
-		rules = append(rules, s3types.LifecycleRule{
-			ID:                             aws.String("Abort Incomplete Multipart Upload Rule"),
-			Status:                         s3types.ExpirationStatusEnabled,
-			Filter:                         &s3types.LifecycleRuleFilterMemberPrefix{Value: ""},
-			AbortIncompleteMultipartUpload: &s3types.AbortIncompleteMultipartUpload{DaysAfterInitiation: days},
-		})
-	}
-	return &s3types.BucketLifecycleConfiguration{Rules: rules}, true
 }

--- a/internal/uploadstore/s3_client.go
+++ b/internal/uploadstore/s3_client.go
@@ -24,11 +24,11 @@ import (
 )
 
 type s3Store struct {
-	bucket                       string
-	manageBucket                 bool
-	client                       s3API
-	uploader                     s3Uploader
-	operations                   *Operations
+	bucket       string
+	manageBucket bool
+	client       s3API
+	uploader     s3Uploader
+	operations   *Operations
 }
 
 var _ Store = &s3Store{}
@@ -57,11 +57,11 @@ func newS3FromConfig(ctx context.Context, config Config, operations *Operations)
 
 func newS3WithClients(client s3API, uploader s3Uploader, bucket string, manageBucket bool, operations *Operations) *s3Store {
 	return &s3Store{
-		bucket:                       bucket,
-		manageBucket:                 manageBucket,
-		client:                       client,
-		uploader:                     uploader,
-		operations:                   operations,
+		bucket:       bucket,
+		manageBucket: manageBucket,
+		client:       client,
+		uploader:     uploader,
+		operations:   operations,
 	}
 }
 

--- a/internal/uploadstore/s3_client_test.go
+++ b/internal/uploadstore/s3_client_test.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -54,7 +53,7 @@ func TestS3InitBucketExists(t *testing.T) {
 
 func TestS3UnmanagedInit(t *testing.T) {
 	s3Client := NewMockS3API()
-	client := newS3WithClients(s3Client, nil, "test-bucket", false, nil, true, NewOperations(&observation.TestContext, "test", "brittleStore"))
+	client := newS3WithClients(s3Client, nil, "test-bucket", false, NewOperations(&observation.TestContext, "test", "brittleStore"))
 	if err := client.Init(context.Background()); err != nil {
 		t.Fatalf("unexpected error initializing client: %s", err)
 	}
@@ -70,7 +69,7 @@ func TestS3Get(t *testing.T) {
 		Body: io.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))),
 	}, nil)
 
-	client := newS3WithClients(s3Client, nil, "test-bucket", false, nil, true, NewOperations(&observation.TestContext, "test", "brittleStore"))
+	client := newS3WithClients(s3Client, nil, "test-bucket", false, NewOperations(&observation.TestContext, "test", "brittleStore"))
 	rc, err := client.Get(context.Background(), "test-key")
 	if err != nil {
 		t.Fatalf("unexpected error getting key: %s", err)
@@ -122,7 +121,7 @@ func TestS3GetTransientErrors(t *testing.T) {
 	}
 
 	s3Client := fullContentsS3API()
-	client := newS3WithClients(s3Client, nil, "test-bucket", false, nil, true, NewOperations(&observation.TestContext, "test", "brittleStore"))
+	client := newS3WithClients(s3Client, nil, "test-bucket", false, NewOperations(&observation.TestContext, "test", "brittleStore"))
 	rc, err := client.Get(context.Background(), "test-key")
 	if err != nil {
 		t.Fatalf("unexpected error getting key: %s", err)
@@ -151,7 +150,7 @@ func TestS3GetReadNothingLoop(t *testing.T) {
 	}
 
 	s3Client := fullContentsS3API()
-	client := newS3WithClients(s3Client, nil, "test-bucket", false, nil, true, NewOperations(&observation.TestContext, "test", "brittleStore"))
+	client := newS3WithClients(s3Client, nil, "test-bucket", false, NewOperations(&observation.TestContext, "test", "brittleStore"))
 	rc, err := client.Get(context.Background(), "test-key")
 	if err != nil {
 		t.Fatalf("unexpected error getting key: %s", err)
@@ -369,5 +368,5 @@ func testS3Client(client s3API, uploader s3Uploader) Store {
 }
 
 func rawS3Client(client s3API, uploader s3Uploader) *s3Store {
-	return newS3WithClients(client, uploader, "test-bucket", true, nil, true, NewOperations(&observation.TestContext, "test", "brittleStore"))
+	return newS3WithClients(client, uploader, "test-bucket", true, NewOperations(&observation.TestContext, "test", "brittleStore"))
 }

--- a/internal/uploadstore/s3_client_test.go
+++ b/internal/uploadstore/s3_client_test.go
@@ -32,12 +32,6 @@ func TestS3Init(t *testing.T) {
 	} else if value := *calls[0].Arg1.Bucket; value != "test-bucket" {
 		t.Errorf("unexpected bucket argument. want=%s have=%s", "test-bucket", value)
 	}
-
-	if calls := s3Client.PutBucketLifecycleConfigurationFunc.History(); len(calls) != 1 {
-		t.Fatalf("unexpected number of PutBucketLifecycleConfiguration calls. want=%d have=%d", 1, len(calls))
-	} else if value := *calls[0].Arg1.Bucket; value != "test-bucket" {
-		t.Errorf("unexpected bucket argument. want=%s have=%s", "test-bucket", value)
-	}
 }
 
 func TestS3InitBucketExists(t *testing.T) {
@@ -55,12 +49,6 @@ func TestS3InitBucketExists(t *testing.T) {
 		} else if value := *calls[0].Arg1.Bucket; value != "test-bucket" {
 			t.Errorf("unexpected bucket argument. want=%s have=%s", "test-bucket", value)
 		}
-
-		if calls := s3Client.PutBucketLifecycleConfigurationFunc.History(); len(calls) != 1 {
-			t.Fatalf("unexpected number of PutBucketLifecycleConfiguration calls. want=%d have=%d", 1, len(calls))
-		} else if value := *calls[0].Arg1.Bucket; value != "test-bucket" {
-			t.Errorf("unexpected bucket argument. want=%s have=%s", "test-bucket", value)
-		}
 	}
 }
 
@@ -73,9 +61,6 @@ func TestS3UnmanagedInit(t *testing.T) {
 
 	if calls := s3Client.CreateBucketFunc.History(); len(calls) != 0 {
 		t.Fatalf("unexpected number of CreateBucket calls. want=%d have=%d", 0, len(calls))
-	}
-	if calls := s3Client.PutBucketLifecycleConfigurationFunc.History(); len(calls) != 0 {
-		t.Fatalf("unexpected number of PutBucketLifecycleConfiguration calls. want=%d have=%d", 0, len(calls))
 	}
 }
 
@@ -376,32 +361,6 @@ func TestS3Delete(t *testing.T) {
 		t.Errorf("unexpected bucket argument. want=%s have=%s", "test-bucket", value)
 	} else if value := *calls[0].Arg1.Key; value != "test-key" {
 		t.Errorf("unexpected key argument. want=%s have=%s", "test-key", value)
-	}
-}
-
-func TestS3BucketLifecycleConfiguration(t *testing.T) {
-	if lifecycle, ok := s3BucketLifecycleConfiguration("s3", time.Hour*24*3); lifecycle == nil || len(lifecycle.Rules) != 2 || !ok {
-		t.Fatalf("unexpected lifecycle rules")
-	} else {
-		var objectExpiration int32
-		for _, rule := range lifecycle.Rules {
-			if rule.Expiration != nil {
-				objectExpiration = rule.Expiration.Days
-			}
-		}
-		if objectExpiration != 3 {
-			t.Errorf("unexpected ttl for object expiration. want=%d have=%d", 3, objectExpiration)
-		}
-
-		var multipartExpiration int32
-		for _, rule := range lifecycle.Rules {
-			if rule.AbortIncompleteMultipartUpload != nil {
-				multipartExpiration = rule.AbortIncompleteMultipartUpload.DaysAfterInitiation
-			}
-		}
-		if multipartExpiration != 3 {
-			t.Errorf("unexpected ttl for multipart upload expiration. want=%d have=%d", 3, multipartExpiration)
-		}
 	}
 }
 


### PR DESCRIPTION
* All our deployment methods will specify `S3PROXY_AUTHORIZATION=none`, so bake that into the Docker image.
* Refactor `cmd/server` env var overrides + default values to avoid subtle issues like #45037 in the future.
* Removed lifecycle configuration from `uploadstore`, instead relying just on our own builtin background worker to expire objects.

## Test plan

existing tests + `sg ci build main-dry-run` to confirm I don't break `main` again by accident
