### PR TITLE
monitoring: add helper for creating row panels

### DIFF
--- a/monitoring/monitoring/internal/grafana/board.go
+++ b/monitoring/monitoring/internal/grafana/board.go
@@ -4,8 +4,8 @@ import (
 	"github.com/grafana-tools/sdk"
 )
 
-// Board creates a dashboard with some default configurations.
-func Board(uid, title string, labels []string) *sdk.Board {
+// NewBoard creates a dashboard with some default configurations.
+func NewBoard(uid, title string, labels []string) *sdk.Board {
 	board := sdk.NewBoard(title)
 	board.AddTags(labels...)
 	board.UID = uid
@@ -17,4 +17,23 @@ func Board(uid, title string, labels []string) *sdk.Board {
 	board.SharedCrosshair = true
 	board.Editable = false
 	return board
+}
+
+// NewRowPanel creates a row, and should be used instead of the native board.AddRow because
+// it seems to have better API support. The returned Panel should be added to a *sdk.Board,
+// and panels in this row should be added to both the returned Panel and the parent
+// *sdk.Board.
+func NewRowPanel(offsetY int, title string) *sdk.Panel {
+	row := &sdk.Panel{RowPanel: &sdk.RowPanel{}}
+	row.OfType = sdk.RowType
+	row.Type = "row"
+	row.Title = title
+	row.Panels = []sdk.Panel{} // cannot be null
+
+	// set position
+	zero := 0
+	row.GridPos.X = &zero
+	row.GridPos.Y = &offsetY
+
+	return row
 }

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -102,7 +102,7 @@ func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher, folde
 	if folder != "" {
 		uid = fmt.Sprintf("%s-%s", folder, uid)
 	}
-	board := grafana.Board(uid, c.Title, []string{"builtin"})
+	board := grafana.NewBoard(uid, c.Title, []string{"builtin"})
 
 	if !c.noAlertsDefined() {
 		alertLevelVariable := ContainerVariable{
@@ -262,14 +262,9 @@ func (c *Dashboard) renderDashboard(injectLabelMatchers []*labels.Matcher, folde
 		// Non-general groups are shown as collapsible panels.
 		var rowPanel *sdk.Panel
 		if group.Title != "General" {
-			rowPanel = &sdk.Panel{RowPanel: &sdk.RowPanel{}}
-			rowPanel.OfType = sdk.RowType
-			rowPanel.Type = "row"
-			rowPanel.Title = group.Title
 			offsetY++
-			setPanelPos(rowPanel, 0, offsetY)
+			rowPanel = grafana.NewRowPanel(offsetY, group.Title)
 			rowPanel.Collapsed = group.Hidden
-			rowPanel.Panels = []sdk.Panel{} // cannot be null
 			board.Panels = append(board.Panels, rowPanel)
 		}
 

--- a/monitoring/monitoring/multi_instance.go
+++ b/monitoring/monitoring/multi_instance.go
@@ -13,7 +13,7 @@ import (
 )
 
 func renderMultiInstanceDashboard(dashboards []*Dashboard, groupings []string) (*grafanasdk.Board, error) {
-	board := grafana.Board("multi-instance-overviews", "Multi-instance overviews",
+	board := grafana.NewBoard("multi-instance-overviews", "Multi-instance overviews",
 		[]string{"multi-instance", "generated"})
 
 	var variableMatchers []*labels.Matcher
@@ -57,14 +57,9 @@ func renderMultiInstanceDashboard(dashboards []*Dashboard, groupings []string) (
 					// Only add row if this dashboard has a multi instance panel, and only
 					// do it once per dashboard
 					addDashboardRow.Do(func() {
-						row = &sdk.Panel{RowPanel: &sdk.RowPanel{}}
-						row.OfType = sdk.RowType
-						row.Type = "row"
-						row.Title = d.Title
-						row.Collapsed = true // avoid crazy loading times
 						offsetY++
-						setPanelPos(row, 0, offsetY)
-						row.Panels = []sdk.Panel{} // cannot be null
+						row = grafana.NewRowPanel(offsetY, d.Title)
+						row.Collapsed = true // avoid crazy loading times
 						board.Panels = append(board.Panels, row)
 					})
 


### PR DESCRIPTION
Cleans up some code from https://github.com/sourcegraph/sourcegraph/pull/45038 - the usage of rows is confusing, so this tries to document how to do it "right"

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI passes, `sg run grafana` manual inspection