### PR TITLE
verbose drift doc

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1352,6 +1352,11 @@ type Query {
         Returns users who have NOT been active since a given point in time.
         """
         inactiveSince: DateTime
+
+        """
+        Returns users that have at any point in time been active.
+        """
+        hasBeenActive: Bool
     ): UserConnection!
     """
     Looks up an organization by name.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1354,9 +1354,9 @@ type Query {
         inactiveSince: DateTime
 
         """
-        Returns users that have not been active at any point in time. 
+        Returns users that have not been active at any point in time. Has no effect if inactiveSince is unset.
         """
-        includeNeverActive: Bool
+        includeNeverActive: Boolean
     ): UserConnection!
     """
     Looks up an organization by name.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1356,7 +1356,7 @@ type Query {
         """
         Returns users that have not been active at any point in time. 
         """
-        neverActive: Bool
+        includeNeverActive: Bool
     ): UserConnection!
     """
     Looks up an organization by name.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1354,9 +1354,9 @@ type Query {
         inactiveSince: DateTime
 
         """
-        Returns users that have at any point in time been active.
+        Returns users that have not been active at any point in time. 
         """
-        hasBeenActive: Bool
+        neverActive: Bool
     ): UserConnection!
     """
     Looks up an organization by name.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1354,9 +1354,9 @@ type Query {
         inactiveSince: DateTime
 
         """
-        Returns users that have not been active at any point in time. Has no effect if inactiveSince is unset.
+        Returns users that have a null lastActiveUsage. Has no effect if inactiveSince is unset.
         """
-        includeNeverActive: Boolean
+        includeNullActive: Boolean
     ): UserConnection!
     """
     Looks up an organization by name.

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -21,6 +21,7 @@ type usersArgs struct {
 	Tag           *string
 	ActivePeriod  *string
 	InactiveSince *gqlutil.DateTime
+	HasBeenActive *bool
 }
 
 func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
@@ -33,6 +34,9 @@ func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
 	}
 	if args.InactiveSince != nil {
 		opt.InactiveSince = args.InactiveSince.Time
+	}
+	if args.HasBeenActive != nil {
+		opt.HasBeenActive = *args.HasBeenActive
 	}
 	args.ConnectionArgs.Set(&opt.LimitOffset)
 	return &userConnectionResolver{db: r.db, opt: opt, activePeriod: args.ActivePeriod}

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -17,11 +17,11 @@ import (
 
 type usersArgs struct {
 	graphqlutil.ConnectionArgs
-	Query         *string
-	Tag           *string
-	ActivePeriod  *string
-	InactiveSince *gqlutil.DateTime
-	NeverActive   *bool
+	Query              *string
+	Tag                *string
+	ActivePeriod       *string
+	InactiveSince      *gqlutil.DateTime
+	IncludeNeverActive *bool
 }
 
 func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
@@ -35,8 +35,8 @@ func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
 	if args.InactiveSince != nil {
 		opt.InactiveSince = args.InactiveSince.Time
 	}
-	if args.NeverActive != nil {
-		opt.NeverActive = *args.NeverActive
+	if args.IncludeNeverActive != nil {
+		opt.IncludeNeverActive = *args.IncludeNeverActive
 	}
 	args.ConnectionArgs.Set(&opt.LimitOffset)
 	return &userConnectionResolver{db: r.db, opt: opt, activePeriod: args.ActivePeriod}

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -21,7 +21,7 @@ type usersArgs struct {
 	Tag           *string
 	ActivePeriod  *string
 	InactiveSince *gqlutil.DateTime
-	HasBeenActive *bool
+	NeverActive   *bool
 }
 
 func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
@@ -35,8 +35,8 @@ func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
 	if args.InactiveSince != nil {
 		opt.InactiveSince = args.InactiveSince.Time
 	}
-	if args.HasBeenActive != nil {
-		opt.HasBeenActive = *args.HasBeenActive
+	if args.NeverActive != nil {
+		opt.NeverActive = *args.NeverActive
 	}
 	args.ConnectionArgs.Set(&opt.LimitOffset)
 	return &userConnectionResolver{db: r.db, opt: opt, activePeriod: args.ActivePeriod}

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -17,11 +17,11 @@ import (
 
 type usersArgs struct {
 	graphqlutil.ConnectionArgs
-	Query              *string
-	Tag                *string
-	ActivePeriod       *string
-	InactiveSince      *gqlutil.DateTime
-	IncludeNeverActive *bool
+	Query             *string
+	Tag               *string
+	ActivePeriod      *string
+	InactiveSince     *gqlutil.DateTime
+	IncludeNullActive *bool
 }
 
 func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
@@ -35,8 +35,8 @@ func (r *schemaResolver) Users(args *usersArgs) *userConnectionResolver {
 	if args.InactiveSince != nil {
 		opt.InactiveSince = args.InactiveSince.Time
 	}
-	if args.IncludeNeverActive != nil {
-		opt.IncludeNeverActive = *args.IncludeNeverActive
+	if args.IncludeNullActive != nil {
+		opt.IncludeNullActive = *args.IncludeNullActive
 	}
 	args.ConnectionArgs.Set(&opt.LimitOffset)
 	return &userConnectionResolver{db: r.db, opt: opt, activePeriod: args.ActivePeriod}

--- a/cmd/frontend/graphqlbackend/users_test.go
+++ b/cmd/frontend/graphqlbackend/users_test.go
@@ -214,8 +214,8 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 	ctx = actor.WithInternalActor(ctx)
 
 	query := `
-		query InactiveUsers($since: DateTime, $includeNeverActive: Bool) {
-			users(inactiveSince: $since, neverActive: $includeNeverActive) {
+		query InactiveUsers($since: DateTime, $includeNeverActive: Boolean) {
+			users(inactiveSince: $since, includeNeverActive: $includeNeverActive) {
 				nodes { username }
 				totalCount
 			}

--- a/cmd/frontend/graphqlbackend/users_test.go
+++ b/cmd/frontend/graphqlbackend/users_test.go
@@ -186,7 +186,7 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 		lastEventAt time.Time
 	}{
 		{user: database.NewUser{Username: "user-1", Password: "user-1"}, lastEventAt: daysAgo(5)},
-		{user: database.NewUser{Username: "user-2", Password: "user-2"}, lastEventAt: daysAgo(3)},
+		{user: database.NewUser{Username: "user-2", Password: "user-2"}, lastEventAt: daysAgo(4)},
 		{user: database.NewUser{Username: "user-3", Password: "user-3"}, lastEventAt: daysAgo(1)},
 		{user: database.NewUser{Username: "user-4", Password: "user-4"}, lastEventAt: daysAgo(0)},
 		{user: database.NewUser{Username: "user-5", Password: "user-5"}},
@@ -279,11 +279,10 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 			Variables: map[string]any{"since": daysAgo(3).Format(time.RFC3339Nano), "includeNeverActive": true},
 			ExpectedResult: `
 			{"users": { "nodes": [
+				{ "username": "user-1" },
 				{ "username": "user-2" },
-				{ "username": "user-3" },
-				{ "username": "user-4" },
 				{ "username": "user-5" }
-				], "totalCount": 4 }}
+				], "totalCount": 3 }}
 			`,
 		},
 		{
@@ -293,10 +292,23 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 			Variables: map[string]any{"since": daysAgo(3).Format(time.RFC3339Nano), "includeNeverActive": false},
 			ExpectedResult: `
 			{"users": { "nodes": [
+				{ "username": "user-1" },
+				{ "username": "user-2" }
+				], "totalCount": 2 }}
+			`,
+		},
+		{
+			Context:   ctx,
+			Schema:    schema,
+			Query:     query,
+			Variables: map[string]any{"since": daysAgo(0).Format(time.RFC3339Nano), "includeNeverActive": true},
+			ExpectedResult: `
+			{"users": { "nodes": [
+				{ "username": "user-1" },
 				{ "username": "user-2" },
 				{ "username": "user-3" },
-				{ "username": "user-4" }
-				], "totalCount": 3 }}
+				{ "username": "user-5" }
+				], "totalCount": 4 }}
 			`,
 		},
 	})

--- a/cmd/frontend/graphqlbackend/users_test.go
+++ b/cmd/frontend/graphqlbackend/users_test.go
@@ -164,7 +164,7 @@ func TestUsers_InactiveSince(t *testing.T) {
 	})
 }
 
-func TestUsers_IncludeNeverActive(t *testing.T) {
+func TestUsers_IncludeNullActive(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -214,8 +214,8 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 	ctx = actor.WithInternalActor(ctx)
 
 	query := `
-		query InactiveUsers($since: DateTime, $includeNeverActive: Boolean) {
-			users(inactiveSince: $since, includeNeverActive: $includeNeverActive) {
+		query InactiveUsers($since: DateTime, $includeNullActive: Boolean) {
+			users(inactiveSince: $since, includeNullActive: $includeNullActive) {
 				nodes { username }
 				totalCount
 			}
@@ -227,8 +227,8 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 			Context: ctx,
 			Schema:  schema,
 			Query:   query,
-			// This returns all users because includeNeverActive only has an effect if inactiveSince is set.
-			Variables: map[string]any{"includeNeverActive": true},
+			// This returns all users because IncludeNullActive only has an effect if inactiveSince is set.
+			Variables: map[string]any{"includeNullActive": true},
 			ExpectedResult: `
 			{"users": { "nodes": [
 				{ "username": "user-1" },
@@ -243,8 +243,8 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 			Context: ctx,
 			Schema:  schema,
 			Query:   query,
-			// This returns all users because includeNeverActive only has an effect if inactiveSince is set.
-			Variables: map[string]any{"includeNeverActive": false},
+			// This returns all users because IncludeNullActive only has an effect if inactiveSince is set.
+			Variables: map[string]any{"includeNullActive": false},
 			// Should return all users, because `inactiveSince` is not set
 			ExpectedResult: `
 			{"users": { "nodes": [
@@ -276,7 +276,7 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 			Context:   ctx,
 			Schema:    schema,
 			Query:     query,
-			Variables: map[string]any{"since": daysAgo(3).Format(time.RFC3339Nano), "includeNeverActive": true},
+			Variables: map[string]any{"since": daysAgo(3).Format(time.RFC3339Nano), "includeNullActive": true},
 			ExpectedResult: `
 			{"users": { "nodes": [
 				{ "username": "user-1" },
@@ -289,7 +289,7 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 			Context:   ctx,
 			Schema:    schema,
 			Query:     query,
-			Variables: map[string]any{"since": daysAgo(3).Format(time.RFC3339Nano), "includeNeverActive": false},
+			Variables: map[string]any{"since": daysAgo(3).Format(time.RFC3339Nano), "includeNullActive": false},
 			ExpectedResult: `
 			{"users": { "nodes": [
 				{ "username": "user-1" },
@@ -301,7 +301,7 @@ func TestUsers_IncludeNeverActive(t *testing.T) {
 			Context:   ctx,
 			Schema:    schema,
 			Query:     query,
-			Variables: map[string]any{"since": daysAgo(0).Format(time.RFC3339Nano), "includeNeverActive": true},
+			Variables: map[string]any{"since": daysAgo(0).Format(time.RFC3339Nano), "includeNullActive": true},
 			ExpectedResult: `
 			{"users": { "nodes": [
 				{ "username": "user-1" },

--- a/doc/admin/how-to/manual_database_migrations.md
+++ b/doc/admin/how-to/manual_database_migrations.md
@@ -41,11 +41,12 @@ upgrade \
 **Notes**:
 
 - Successive invocations of this command will re-attempt the last failed or attempted (but incomplete) migration. This command run as if the `-ignore-single-{dirty,pending}-log` flags supplied by the commands `up`, `upto`, and `downto` were enabled.
+- This command checks that the schema of the database is in the correct state for the current version, if schema drift is detected it must be resolved before completing the upgrade. [Learn more here.](./schema-drift.md).
 - Successive invocations of this command may *cause* database drift when partial progress is made. When making a subsequent upgrade attempt, invoke this command with `-skip-drift-check` ignore the failing startup check.
 
 ### drift
 
-The `drift` command describes the current (live) database schema and compares it against the expected schema at the given version. The output of this command will include all relevant schema differences that could affect application correctness and performance. When schema drift is detected, a diff of the expected and actual Postgres object definitions will be shown, along with instructions on how to manually resolve the disparity.
+The `drift` command describes the current (live) database schema and compares it against the expected schema at the given version. The output of this command will include all relevant schema differences that could affect application correctness and performance. When schema drift is detected, a diff of the expected and actual Postgres object definitions will be shown, along with instructions on how to manually resolve the disparity. [Learn more here.](./schema-drift.md)
 
 ```
 drift \
@@ -56,7 +57,7 @@ drift \
 
 **Required arguments**:
 
-- `-db`: The target schema to inspect.
+- `-db`: The target schema to inspect. *Ex: frontend, codeintel, codeinsights*
 
 **Mutually exclusive arguments**:
 

--- a/doc/admin/how-to/schema-drift.md
+++ b/doc/admin/how-to/schema-drift.md
@@ -1,0 +1,61 @@
+# How to use `migrator` operation `drift`
+
+During an upgrade you may run into the following message.
+
+```
+* Sourcegraph migrator v4.1.3
+❌ Schema drift detected for frontend
+💡 Before continuing with this operation, run the migrator's drift command and follow instructions to repair the schema. See https://docs.sourcegraph.com/admin/how-to/manual_database_migrations#drift for additional instructions.
+```
+
+This error indicates that `migrator` has detected some difference between the state of the schema in your database and the expected schema for the database in the `-from` or current version of your Sourcegraph instance.
+
+When the schema [drift](./manual_database_migrations.md#drift) command is run you'll see a set of diffs representing the areas where your instance schema has diverged from the expected state as well as the SQL operations to fix these examples of drift. For example:
+
+```
+❌ Missing index "external_service_repos"."external_service_repos_repo_id_external_service_id_unique"
+💡 Suggested action: define the index.
+
+ALTER TABLE external_service_repos ADD CONSTRAINT
+external_service_repos_repo_id_external_service_id_unique UNIQUE
+(repo_id, external_service_id);
+```
+
+```
+❌ Unexpected properties of column "batch_spec_resolution_jobs"."batch_spec_id"
+
+schemas.ColumnDescription{
+  	Name:                   "batch_spec_id",
+  	Index:                  -1,
+  	TypeName:               "integer",
+- 	IsNullable:             false,
++ 	IsNullable:             true,
+  	Default:                "",
+  	CharacterMaximumLength: 0,
+  	... // 5 identical fields
+  }
+
+💡 Suggested action: change the column nullability constraint.
+
+ALTER TABLE batch_spec_resolution_jobs ALTER COLUMN
+batch_spec_id SET NOT NULL;
+```
+
+To correct these errors in the database run the suggested SQL queries via `psql` in internal databases, or via the tools provided by your cloud database provider. 
+
+*docker example*
+```
+docker exec -it pgsql psql -U sg -c 'ALTER TABLE external_service_repos ADD CONSTRAINT external_service_repos_repo_id_external_service_id_unique UNIQUE (repo_id, external_service_id);'
+```
+*kubernetes example*
+```
+kubectl -n ns-sourcegraph exec -it pgsql -- psql -U sg -c 'ALTER TABLE external_service_repos ADD CONSTRAINT external_service_repos_repo_id_external_service_id_unique UNIQUE (repo_id, external_service_id);'
+```
+
+Then check the database again with the `drift` command and proceed with your multiversion upgrade.
+
+> Note: It is possible for the drift command to detect diffs which will not prevent prevent upgrades.
+
+If migrator drift suggests SQL queries which don't make sense please report to support@sourcegraph.com or open an issue in the [`sourcegraph/sourcegraph`](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=&template=bug_report.md&title=) repo.
+
+

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -808,8 +808,8 @@ type UsersListOptions struct {
 	// InactiveSince filters out users that have had an eventlog entry with a
 	// `timestamp` greater-than-or-equal to the given timestamp.
 	InactiveSince time.Time
-	// HasBeenActive filters out users that have never had an eventlog entry if true.
-	HasBeenActive bool
+	// NeverActive filters out users that have never had an eventlog entry if true.
+	NeverActive bool
 
 	ExcludeSourcegraphAdmins bool // filter out users with a known Sourcegraph admin username
 
@@ -873,8 +873,8 @@ const listUsersInactiveCond = `
 ))
 `
 
-const listUsersHasBeenActiveCond = `
-(EXISTS (
+const listUsersNeverActiveCond = `
+(NOT EXISTS (
 	SELECT 1 FROM event_logs
 	WHERE event_logs.user_id = u.id
 ))
@@ -907,8 +907,8 @@ func (*userStore) listSQL(opt UsersListOptions) (conds []*sqlf.Query) {
 		conds = append(conds, sqlf.Sprintf(listUsersInactiveCond, opt.InactiveSince))
 	}
 
-	if opt.HasBeenActive {
-		conds = append(conds, sqlf.Sprintf(listUsersHasBeenActiveCond))
+	if opt.NeverActive {
+		conds = append(conds, sqlf.Sprintf(listUsersNeverActiveCond))
 	}
 
 	// NOTE: This is a hack which should be replaced when we have proper user types.

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -916,9 +916,9 @@ func (*userStore) listSQL(opt UsersListOptions) (conds []*sqlf.Query) {
 
 	if !opt.InactiveSince.IsZero() {
 		if opt.IncludeNeverActive {
-			conds = append(conds, sqlf.Sprintf(listUsersInactiveWithNeverActiveCond))
+			conds = append(conds, sqlf.Sprintf(listUsersInactiveWithNeverActiveCond, opt.InactiveSince))
 		} else {
-			conds = append(conds, sqlf.Sprintf(listUsersInactiveWithoutNeverActiveCond))
+			conds = append(conds, sqlf.Sprintf(listUsersInactiveWithoutNeverActiveCond, opt.InactiveSince))
 		}
 	}
 

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -808,8 +808,10 @@ type UsersListOptions struct {
 	// InactiveSince filters out users that have had an eventlog entry with a
 	// `timestamp` greater-than-or-equal to the given timestamp, excluding users who have never been active.
 	InactiveSince time.Time
-	// IncludeNeverActive includes users that have never had an eventlog entry if true.
-	IncludeNeverActive bool
+	// IncludeNullActive includes users that have no eventlog entry if true. Users may be in this state
+	// due to never having been active, or all events tagged to them having expires
+	// event_logs only persist for 93 days
+	IncludeNullActive bool
 
 	ExcludeSourcegraphAdmins bool // filter out users with a known Sourcegraph admin username
 
@@ -915,7 +917,7 @@ func (*userStore) listSQL(opt UsersListOptions) (conds []*sqlf.Query) {
 	}
 
 	if !opt.InactiveSince.IsZero() {
-		if opt.IncludeNeverActive {
+		if opt.IncludeNullActive {
 			conds = append(conds, sqlf.Sprintf(listUsersInactiveWithNeverActiveCond, opt.InactiveSince))
 		} else {
 			conds = append(conds, sqlf.Sprintf(listUsersInactiveWithoutNeverActiveCond, opt.InactiveSince))


### PR DESCRIPTION
This PR adds a verbose description of the `drift` command with examples of output. The drift commands output can be confusing to admins, this doc attempts to make the expected actions explicit to admins

Reviewers please pay special attention to the note at the end of `schema-drift.md` -- running through operations on a test instance while writing this doc I observed that a variety of diffs in my schema for fields nullability were reported by `drift` but not blocking --

```
[ec2-user@ip-172-31-18-10 ~]$ docker run   --rm -e PGHOST='pgsql'   -e PGPORT='5432'   -e PGUSER='sg'   -e PGPASSWORD='sg'   -e PGDATABASE='sg'   -e PGSSLMODE='disable'   -e CODEINTEL_PGHOST='codeintel-db'   -e CODEINTEL_PGPORT='5432'   -e CODEINTEL_PGUSER='sg'   -e CODEINTEL_PGPASSWORD='sg'   -e CODEINTEL_PGDATABASE='sg'   -e CODEINTEL_PGSSLMODE='disable'   -e CODEINSIGHTS_PGHOST='codeinsights-db'   -e CODEINSIGHTS_PGPORT='5432'   -e CODEINSIGHTS_PGUSER='postgres'   -e CODEINSIGHTS_PGPASSWORD='password'   -e CODEINSIGHTS_PGDATABASE='postgres'   -e CODEINSIGHTS_PGSSLMODE='disable'   --network=docker-compose_sourcegraph   sourcegraph/migrator:$MIGRATOR_SOURCEGRAPH_VERSION
❗️ An error was returned when detecting the terminal size and capabilities:

   GetWinsize: inappropriate ioctl for device

   Execution will continue, but please report this, along with your operating
   system, terminal, and any other details, to:
     https://github.com/sourcegraph/sourcegraph/issues/new

✱ Sourcegraph migrator v4.1.3
✅ Schema(s) are up-to-date!
[ec2-user@ip-172-31-18-10 ~]$ docker run   --rm -e PGHOST='pgsql'   -e PGPORT='5432'   -e PGUSER='sg'   -e PGPASSWORD='sg'   -e PGDATABASE='sg'   -e PGSSLMODE='disable'   -e CODEINTEL_PGHOST='codeintel-db'   -e CODEINTEL_PGPORT='5432'   -e CODEINTEL_PGUSER='sg'   -e CODEINTEL_PGPASSWORD='sg'   -e CODEINTEL_PGDATABASE='sg'   -e CODEINTEL_PGSSLMODE='disable'   -e CODEINSIGHTS_PGHOST='codeinsights-db'   -e CODEINSIGHTS_PGPORT='5432'   -e CODEINSIGHTS_PGUSER='postgres'   -e CODEINSIGHTS_PGPASSWORD='password'   -e CODEINSIGHTS_PGDATABASE='postgres'   -e CODEINSIGHTS_PGSSLMODE='disable'   --network=docker-compose_sourcegraph   sourcegraph/migrator:$MIGRATOR_SOURCEGRAPH_VERSION "drift" "-db=frontend" "-version=v4.1.3"
❗️ An error was returned when detecting the terminal size and capabilities:

   GetWinsize: inappropriate ioctl for device

   Execution will continue, but please report this, along with your operating
   system, terminal, and any other details, to:
     https://github.com/sourcegraph/sourcegraph/issues/new

✱ Sourcegraph migrator v4.1.3
❌ Unexpected properties of column "batch_spec_resolution_jobs"."batch_spec_id"

schemas.ColumnDescription{
  	Name:                   "batch_spec_id",
  	Index:                  -1,
  	TypeName:               "integer",
- 	IsNullable:             false,
+ 	IsNullable:             true,
  	Default:                "",
  	CharacterMaximumLength: 0,
  	... // 5 identical fields
  }

💡 Suggested action: change the column nullability constraint.

ALTER TABLE batch_spec_resolution_jobs ALTER COLUMN
batch_spec_id SET NOT NULL;
```

In retrospect I'm actually thinking the `["up", "-db", "all"]` command to the migrator doesnt actually check the schemas and we may not have noticed this drift in the instance since we dont usually use multiversion upgrades on this instance. 

## Test plan
local test

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
