### PR TITLE
Verbose schema drift doc

### DIFF
--- a/doc/admin/how-to/manual_database_migrations.md
+++ b/doc/admin/how-to/manual_database_migrations.md
@@ -266,7 +266,7 @@ Run the following commands in the root of your `deploy-sourcegraph` fork.
 
 First, modify the `migrator` manifest to update two fields: the `spec.template.spec.containers[0].args` field, which selects the target operation, and the `spec.template.spec.containers[0].image` field, which controls the version of the migrator binary (and, consequently, the set of embedded migration definitions).
 
-The following example uses `yq`, but these values can also be updated manually in thee `configure/migrator/migrator.Job.yaml` file.
+The following example uses `yq`, but these values may also be updated manually by opening the `configure/migrator/migrator.Job.yaml` file in an editor of your choice and editing the `image` and `args` key value pairs.
 
 ```bash
 export MIGRATOR_SOURCEGRAPH_VERSION="..."
@@ -281,6 +281,14 @@ yq eval -i \
 yq eval -i \
   '.spec.template.spec.containers[0].args = ["add", "quoted", "arguments"]' \
   configure/migrator/migrator.Job.yaml
+```
+
+The above `yq` commands alter the `configure/migrator/migrator.Job.yaml` file. For example producing the following key pairs:
+```yaml
+image: "index.docker.io/sourcegraph/migrator:4.1.3@sha256:0dc6543f0a755e46d962ba572d501559915716fa55beb3aa644a52f081fcd57e"
+```
+```yaml
+args: ["upgrade", "--from=3.40.2", "--to=4.1.2"]
 ```
 
 Next, apply the job and wait for it to complete.

--- a/doc/admin/how-to/manual_database_migrations.md
+++ b/doc/admin/how-to/manual_database_migrations.md
@@ -41,11 +41,12 @@ upgrade \
 **Notes**:
 
 - Successive invocations of this command will re-attempt the last failed or attempted (but incomplete) migration. This command run as if the `-ignore-single-{dirty,pending}-log` flags supplied by the commands `up`, `upto`, and `downto` were enabled.
+- This command checks that the schema of the database is in the correct state for the current version, if schema drift is detected it must be resolved before completing the upgrade. [Learn more here.](./schema-drift.md).
 - Successive invocations of this command may *cause* database drift when partial progress is made. When making a subsequent upgrade attempt, invoke this command with `-skip-drift-check` ignore the failing startup check.
 
 ### drift
 
-The `drift` command describes the current (live) database schema and compares it against the expected schema at the given version. The output of this command will include all relevant schema differences that could affect application correctness and performance. When schema drift is detected, a diff of the expected and actual Postgres object definitions will be shown, along with instructions on how to manually resolve the disparity.
+The `drift` command describes the current (live) database schema and compares it against the expected schema at the given version. The output of this command will include all relevant schema differences that could affect application correctness and performance. When schema drift is detected, a diff of the expected and actual Postgres object definitions will be shown, along with instructions on how to manually resolve the disparity. [Learn more here.](./schema-drift.md)
 
 ```
 drift \
@@ -53,11 +54,10 @@ drift \
     [-version=<version>] \
     [-file=<path to description file>]
 ```
-> Note: the drig `-version` argument requires the version to be specified with the `v` prefix, for example `-version=v3.40.2`
 
 **Required arguments**:
 
-- `-db`: The target schema to inspect.
+- `-db`: The target schema to inspect. *Ex: frontend, codeintel, codeinsights*
 
 **Mutually exclusive arguments**:
 
@@ -266,7 +266,7 @@ Run the following commands in the root of your `deploy-sourcegraph` fork.
 
 First, modify the `migrator` manifest to update two fields: the `spec.template.spec.containers[0].args` field, which selects the target operation, and the `spec.template.spec.containers[0].image` field, which controls the version of the migrator binary (and, consequently, the set of embedded migration definitions).
 
-The following example uses `yq`, but these values may also be updated manually by opening the `configure/migrator/migrator.Job.yaml` file in an editor of your choice and editing the `image` and `args` key value pairs.
+The following example uses `yq`, but these values can also be updated manually in thee `configure/migrator/migrator.Job.yaml` file.
 
 ```bash
 export MIGRATOR_SOURCEGRAPH_VERSION="..."
@@ -281,14 +281,6 @@ yq eval -i \
 yq eval -i \
   '.spec.template.spec.containers[0].args = ["add", "quoted", "arguments"]' \
   configure/migrator/migrator.Job.yaml
-```
-
-The corresponding changes the `configure/migrator/migrator.Job.yaml` file would look something like this:
-```yaml
-image: "index.docker.io/sourcegraph/migrator:4.1.3@sha256:0dc6543f0a755e46d962ba572d501559915716fa55beb3aa644a52f081fcd57e"
-```
-```yaml
-args: ["upgrade", "--from=3.40.2", "--to=4.1.2"]
 ```
 
 Next, apply the job and wait for it to complete.

--- a/doc/admin/how-to/schema-drift.md
+++ b/doc/admin/how-to/schema-drift.md
@@ -1,0 +1,60 @@
+# How to use `migrator` operation `drift`
+
+During an upgrade you may run into the following message.
+
+```
+* Sourcegraph migrator v4.1.3
+❌ Schema drift detected for frontend
+💡 Before continuing with this operation, run the migrator's drift command and follow instructions to repair the schema. See https://docs.sourcegraph.com/admin/how-to/manual_database_migrations#drift for additional instructions.
+```
+
+This error indicates that `migrator` has detected some difference between the state of the schema in your database and the expected schema for the database in the `-from` or current version of your Sourcegraph instance.
+
+When the schema [drift](./manual_database_migrations.md#drift) command is run you'll see a set of diffs representing the areas where your instance schema has diverged from the expected state as well as the SQL operations to fix these examples of drift. For example:
+
+```
+❌ Missing index "external_service_repos"."external_service_repos_repo_id_external_service_id_unique"
+💡 Suggested action: define the index.
+
+ALTER TABLE external_service_repos ADD CONSTRAINT
+external_service_repos_repo_id_external_service_id_unique UNIQUE
+(repo_id, external_service_id);
+```
+
+```
+❌ Unexpected properties of column "batch_spec_resolution_jobs"."batch_spec_id"
+
+schemas.ColumnDescription{
+  	Name:                   "batch_spec_id",
+  	Index:                  -1,
+  	TypeName:               "integer",
+- 	IsNullable:             false,
++ 	IsNullable:             true,
+  	Default:                "",
+  	CharacterMaximumLength: 0,
+  	... // 5 identical fields
+  }
+
+💡 Suggested action: change the column nullability constraint.
+
+ALTER TABLE batch_spec_resolution_jobs ALTER COLUMN
+batch_spec_id SET NOT NULL;
+```
+
+To correct these errors in the database run the suggested SQL queries via `psql` in internal databases, or via the tools provided by your cloud database provider. 
+
+*docker example*
+```
+docker exec -it pgsql psql -U sg -c 'ALTER TABLE external_service_repos ADD CONSTRAINT external_service_repos_repo_id_external_service_id_unique UNIQUE (repo_id, external_service_id);'
+```
+*kubernetes example*
+```
+kubectl -n ns-sourcegraph exec -it pgsql -- psql -U sg -c 'ALTER TABLE external_service_repos ADD CONSTRAINT external_service_repos_repo_id_external_service_id_unique UNIQUE (repo_id, external_service_id);'
+```
+
+Then check the database again with the `drift` command and proceed with your multiversion upgrade.
+
+> Note: It is possible for the drift command to detect diffs which will not prevent prevent upgrades.
+
+If migrator drift suggests SQL queries which don't make sense please report to support@sourcegraph.com or open an issue in the [`sourcegraph/sourcegraph`](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=&template=bug_report.md&title=) repo.
+

--- a/doc/admin/how-to/schema-drift.md
+++ b/doc/admin/how-to/schema-drift.md
@@ -54,7 +54,7 @@ kubectl -n ns-sourcegraph exec -it pgsql -- psql -U sg -c 'ALTER TABLE external_
 
 Then check the database again with the `drift` command and proceed with your multiversion upgrade.
 
-> Note: It is possible for the drift command to detect diffs which will not prevent prevent upgrades.
+> Note: It is possible for the drift command to detect diffs which will not prevent upgrades.
 
 If migrator drift suggests SQL queries which don't make sense please report to support@sourcegraph.com or open an issue in the [`sourcegraph/sourcegraph`](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=&template=bug_report.md&title=) repo.
 


### PR DESCRIPTION
Round 2 without the commits from that other branch: https://github.com/sourcegraph/sourcegraph/pull/45053

This PR adds a verbose description of the `drift` command with examples of output. The drift commands output can be confusing to admins, this doc attempts to make the expected actions explicit to admins

Reviewers please pay special attention to the note at the end of `schema-drift.md` -- running through operations on a test instance while writing this doc I observed that a variety of diffs in my schema for fields nullability were reported by `drift` but not blocking --

```
[ec2-user@ip-172-31-18-10 ~]$ docker run   --rm -e PGHOST='pgsql'   -e PGPORT='5432'   -e PGUSER='sg'   -e PGPASSWORD='sg'   -e PGDATABASE='sg'   -e PGSSLMODE='disable'   -e CODEINTEL_PGHOST='codeintel-db'   -e CODEINTEL_PGPORT='5432'   -e CODEINTEL_PGUSER='sg'   -e CODEINTEL_PGPASSWORD='sg'   -e CODEINTEL_PGDATABASE='sg'   -e CODEINTEL_PGSSLMODE='disable'   -e CODEINSIGHTS_PGHOST='codeinsights-db'   -e CODEINSIGHTS_PGPORT='5432'   -e CODEINSIGHTS_PGUSER='postgres'   -e CODEINSIGHTS_PGPASSWORD='password'   -e CODEINSIGHTS_PGDATABASE='postgres'   -e CODEINSIGHTS_PGSSLMODE='disable'   --network=docker-compose_sourcegraph   sourcegraph/migrator:$MIGRATOR_SOURCEGRAPH_VERSION
❗️ An error was returned when detecting the terminal size and capabilities:

   GetWinsize: inappropriate ioctl for device

   Execution will continue, but please report this, along with your operating
   system, terminal, and any other details, to:
     https://github.com/sourcegraph/sourcegraph/issues/new

✱ Sourcegraph migrator v4.1.3
✅ Schema(s) are up-to-date!
[ec2-user@ip-172-31-18-10 ~]$ docker run   --rm -e PGHOST='pgsql'   -e PGPORT='5432'   -e PGUSER='sg'   -e PGPASSWORD='sg'   -e PGDATABASE='sg'   -e PGSSLMODE='disable'   -e CODEINTEL_PGHOST='codeintel-db'   -e CODEINTEL_PGPORT='5432'   -e CODEINTEL_PGUSER='sg'   -e CODEINTEL_PGPASSWORD='sg'   -e CODEINTEL_PGDATABASE='sg'   -e CODEINTEL_PGSSLMODE='disable'   -e CODEINSIGHTS_PGHOST='codeinsights-db'   -e CODEINSIGHTS_PGPORT='5432'   -e CODEINSIGHTS_PGUSER='postgres'   -e CODEINSIGHTS_PGPASSWORD='password'   -e CODEINSIGHTS_PGDATABASE='postgres'   -e CODEINSIGHTS_PGSSLMODE='disable'   --network=docker-compose_sourcegraph   sourcegraph/migrator:$MIGRATOR_SOURCEGRAPH_VERSION "drift" "-db=frontend" "-version=v4.1.3"
❗️ An error was returned when detecting the terminal size and capabilities:

   GetWinsize: inappropriate ioctl for device

   Execution will continue, but please report this, along with your operating
   system, terminal, and any other details, to:
     https://github.com/sourcegraph/sourcegraph/issues/new

✱ Sourcegraph migrator v4.1.3
❌ Unexpected properties of column "batch_spec_resolution_jobs"."batch_spec_id"

schemas.ColumnDescription{
  	Name:                   "batch_spec_id",
  	Index:                  -1,
  	TypeName:               "integer",
- 	IsNullable:             false,
+ 	IsNullable:             true,
  	Default:                "",
  	CharacterMaximumLength: 0,
  	... // 5 identical fields
  }

💡 Suggested action: change the column nullability constraint.

ALTER TABLE batch_spec_resolution_jobs ALTER COLUMN
batch_spec_id SET NOT NULL;
```

In retrospect I'm actually thinking the `["up", "-db", "all"]` command to the migrator doesnt actually check the schemas and we may not have noticed this drift in the instance since we dont usually use multiversion upgrades on this instance. 


## Test plan
locally tested

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
