### PR TITLE
graphqlbackend: add mutation to reindex repository

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_reindex.go
+++ b/cmd/frontend/graphqlbackend/repository_reindex.go
@@ -1,0 +1,80 @@
+package graphqlbackend
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// ReindexRepository will trigger Zoekt indexserver to reindex the repository.
+func (r *schemaResolver) ReindexRepository(ctx context.Context, args *struct {
+	Repository graphql.ID
+}) (*EmptyResponse, error) {
+	// 🚨 SECURITY: There is no reason why non-site-admins would need to run this operation.
+	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return nil, err
+	}
+
+	repo, err := r.repositoryByID(ctx, args.Repository)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find the Zoekt webserver hosting the index of "repo"
+	ep, err := search.Indexers().Map.Get(repo.Name())
+	if err != nil {
+		return nil, err
+	}
+
+	// We add the scheme http:// on a best-effort basis.
+	//
+	// ep doesn't have to be a valid URL. For example, locally ep can just be
+	// localhost:<port>, which would be parsed by url.Parse without error, with
+	// localhost as scheme. The reason is that the Go 1.19 scheme parser parses
+	// all valid characters [a-zA-Z][a-zA-Z0-9+-.]*) before the first ':' as
+	// scheme.
+	if !strings.HasPrefix(ep, "http://") {
+		ep = "http://" + ep
+	}
+	u, err := url.Parse(ep)
+	if err != nil {
+		return nil, err
+	}
+
+	form := url.Values{}
+	form.Add("repo", strconv.Itoa(int(repo.IDInt32())))
+
+	// <host:port>/indexerver/?headless
+	u = u.ResolveReference(&url.URL{Path: "/indexserver/", RawQuery: "headless"})
+
+	req, err := http.NewRequest("POST", u.String(), strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := httpcli.InternalClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New(string(b))
+	}
+
+	return &EmptyResponse{}, nil
+}

--- a/cmd/frontend/graphqlbackend/repository_reindex.go
+++ b/cmd/frontend/graphqlbackend/repository_reindex.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/graph-gophers/graphql-go"
+
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 )

--- a/cmd/frontend/graphqlbackend/repository_reindex.go
+++ b/cmd/frontend/graphqlbackend/repository_reindex.go
@@ -2,17 +2,10 @@ package graphqlbackend
 
 import (
 	"context"
-	"io"
-	"net/http"
-	"net/url"
-	"strconv"
-	"strings"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
-	"github.com/sourcegraph/sourcegraph/internal/search"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 )
 
 // ReindexRepository will trigger Zoekt indexserver to reindex the repository.
@@ -29,51 +22,9 @@ func (r *schemaResolver) ReindexRepository(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	// Find the Zoekt webserver hosting the index of "repo"
-	ep, err := search.Indexers().Map.Get(repo.Name())
+	err = zoekt.Reindex(ctx, repo.RepoName(), repo.IDInt32())
 	if err != nil {
 		return nil, err
-	}
-
-	// We add the scheme http:// on a best-effort basis.
-	//
-	// ep doesn't have to be a valid URL. For example, locally ep can just be
-	// localhost:<port>, which would be parsed by url.Parse without error, with
-	// localhost as scheme. The reason is that the Go 1.19 scheme parser parses
-	// all valid characters [a-zA-Z][a-zA-Z0-9+-.]*) before the first ':' as
-	// scheme.
-	if !strings.HasPrefix(ep, "http://") {
-		ep = "http://" + ep
-	}
-	u, err := url.Parse(ep)
-	if err != nil {
-		return nil, err
-	}
-
-	form := url.Values{}
-	form.Add("repo", strconv.Itoa(int(repo.IDInt32())))
-
-	// http://<host:port>/indexerver/?headless
-	u = u.ResolveReference(&url.URL{Path: "/indexserver/", RawQuery: "headless"})
-
-	req, err := http.NewRequest("POST", u.String(), strings.NewReader(form.Encode()))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := httpcli.InternalClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		b, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-		return nil, errors.New(string(b))
 	}
 
 	return &EmptyResponse{}, nil

--- a/cmd/frontend/graphqlbackend/repository_reindex.go
+++ b/cmd/frontend/graphqlbackend/repository_reindex.go
@@ -53,7 +53,7 @@ func (r *schemaResolver) ReindexRepository(ctx context.Context, args *struct {
 	form := url.Values{}
 	form.Add("repo", strconv.Itoa(int(repo.IDInt32())))
 
-	// <host:port>/indexerver/?headless
+	// http://<host:port>/indexerver/?headless
 	u = u.ResolveReference(&url.URL{Path: "/indexserver/", RawQuery: "headless"})
 
 	req, err := http.NewRequest("POST", u.String(), strings.NewReader(form.Encode()))

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -155,6 +155,17 @@ type Mutation {
         repository: ID!
     ): EmptyResponse!
     """
+    Force Zoekt to reindex the repository right now. Reindexing occurs
+    automatically, so this should not normally be needed.
+    """
+    reindexRepository(
+        """
+        The repository to index
+        """
+        repository: ID!
+    ): EmptyResponse!
+
+    """
     Creates a new user account.
 
     Only site admins may perform this mutation.

--- a/dev/authtest/site_admin_test.go
+++ b/dev/authtest/site_admin_test.go
@@ -92,6 +92,15 @@ mutation {
 	}
 }`,
 			}, {
+				name: "reindexRepository",
+				query: `
+mutation {
+	reindexRepository(repository: "UmVwb3NpdG9yeTox") {
+		alwaysNil
+	}
+}`,
+			},
+			{
 				name: "updateMirrorRepository",
 				query: `
 mutation {

--- a/internal/search/zoekt/reindex.go
+++ b/internal/search/zoekt/reindex.go
@@ -14,22 +14,16 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// Reindex forces a reindex of the repo with id by the indexserver that is
-// determined based on name.
+// Reindex forces indexserver to reindex the repo immediately.
 func Reindex(ctx context.Context, name api.RepoName, id api.RepoID) error {
-	// Find the Zoekt webserver hosting the index of the repo with "name"
+	// Find the Zoekt webserver hosting the index of the repo.
 	ep, err := search.Indexers().Map.Get(string(name))
 	if err != nil {
 		return err
 	}
 
-	// We add the scheme http:// on a best-effort basis.
-	//
-	// ep doesn't have to be a valid URL. For example, locally ep can just be
-	// localhost:<port>, which would be parsed by url.Parse without error, with
-	// localhost as scheme. The reason is that the Go 1.19 scheme parser parses
-	// all valid characters [a-zA-Z][a-zA-Z0-9+-.]*) before the first ':' as
-	// scheme.
+	// We add http:// on a best-effort basis, because it is not guaranteed that
+	// ep is a valid URL.
 	if !strings.HasPrefix(ep, "http://") {
 		ep = "http://" + ep
 	}

--- a/internal/search/zoekt/reindex.go
+++ b/internal/search/zoekt/reindex.go
@@ -1,0 +1,68 @@
+package zoekt
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// Reindex forces a reindex of the repo with id by the indexserver that is
+// determined based on name.
+func Reindex(ctx context.Context, name api.RepoName, id api.RepoID) error {
+	// Find the Zoekt webserver hosting the index of the repo with "name"
+	ep, err := search.Indexers().Map.Get(string(name))
+	if err != nil {
+		return err
+	}
+
+	// We add the scheme http:// on a best-effort basis.
+	//
+	// ep doesn't have to be a valid URL. For example, locally ep can just be
+	// localhost:<port>, which would be parsed by url.Parse without error, with
+	// localhost as scheme. The reason is that the Go 1.19 scheme parser parses
+	// all valid characters [a-zA-Z][a-zA-Z0-9+-.]*) before the first ':' as
+	// scheme.
+	if !strings.HasPrefix(ep, "http://") {
+		ep = "http://" + ep
+	}
+	u, err := url.Parse(ep)
+	if err != nil {
+		return err
+	}
+
+	form := url.Values{}
+	form.Add("repo", strconv.Itoa(int(id)))
+
+	// http://<host:port>/indexerver/?headless
+	u = u.ResolveReference(&url.URL{Path: "/indexserver/", RawQuery: "headless"})
+
+	req, err := http.NewRequestWithContext(ctx, "POST", u.String(), strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := httpcli.InternalClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return errors.New(string(b))
+	}
+
+	return nil
+}


### PR DESCRIPTION
This adds a new mutation that lets us trigger a reindex from frontend. The end goal is to add a reindex button, calling this mutation, to the index status page.

## Test plan
- ammended unit test for site-admin only mutations
- manual testing: triggered mutation from API Console and confirmed that the mutation forced a reindex for zoekt-web-0 and zoekt-web-1 depending on the repository. 

