### PR TITLE
 CodeMirror blob: implement "navigate to any line on click"

### DIFF
--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -208,9 +208,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
             blameDecorationsCompartment.of(blameDecorations),
             blameVisibilityCompartment.of(blameVisibility),
             settingsCompartment.of(settings),
-            navigateToLineOnAnyClick
-                ? navigateToLineOnAnyClickExtension(location, historyRef.current, customHistoryAction)
-                : [],
+            navigateToLineOnAnyClick ? navigateToLineOnAnyClickExtension : [],
             search({
                 // useFileSearch is not a dependency because the search
                 // extension manages its own state. This is just the initial

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -222,7 +222,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         // further below. However, they are still needed here because we need to
         // set initial values when we re-initialize the editor.
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [onSelection, blobInfo, extensionsController, disableStatusBar, disableDecorations, customHistoryAction]
+        [onSelection, blobInfo, extensionsController, disableStatusBar, disableDecorations]
     )
 
     const editorRef = useRef<EditorView>()

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -208,7 +208,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
             blameDecorationsCompartment.of(blameDecorations),
             blameVisibilityCompartment.of(blameVisibility),
             settingsCompartment.of(settings),
-            navigateToLineOnAnyClick && customHistoryAction
+            navigateToLineOnAnyClick
                 ? navigateToLineOnAnyClickExtension(location, historyRef.current, customHistoryAction)
                 : [],
             search({

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -27,6 +27,7 @@ import { showBlameGutter, showGitBlameDecorations } from './codemirror/blame-dec
 import { syntaxHighlight } from './codemirror/highlight'
 import { pin, updatePin } from './codemirror/hovercard'
 import { selectableLineNumbers, SelectedLineRange, selectLines } from './codemirror/linenumbers'
+import { navigateToLineOnAnyClickExtension } from './codemirror/navigate-to-any-line-on-click'
 import { search } from './codemirror/search'
 import { sourcegraphExtensions } from './codemirror/sourcegraph-extensions'
 import { tokensAsLinks } from './codemirror/tokens-as-links'
@@ -207,6 +208,9 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
             blameDecorationsCompartment.of(blameDecorations),
             blameVisibilityCompartment.of(blameVisibility),
             settingsCompartment.of(settings),
+            navigateToLineOnAnyClick && customHistoryAction
+                ? navigateToLineOnAnyClickExtension(location, historyRef.current, customHistoryAction)
+                : [],
             search({
                 // useFileSearch is not a dependency because the search
                 // extension manages its own state. This is just the initial
@@ -220,7 +224,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         // further below. However, they are still needed here because we need to
         // set initial values when we re-initialize the editor.
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [onSelection, blobInfo, extensionsController, disableStatusBar, disableDecorations]
+        [onSelection, blobInfo, extensionsController, disableStatusBar, disableDecorations, customHistoryAction]
     )
 
     const editorRef = useRef<EditorView>()

--- a/client/web/src/repo/blob/codemirror/navigate-to-any-line-on-click.ts
+++ b/client/web/src/repo/blob/codemirror/navigate-to-any-line-on-click.ts
@@ -10,7 +10,7 @@ import { addLineRangeQueryParameter, formatSearchParameters } from '@sourcegraph
 export function navigateToLineOnAnyClickExtension(
     location: H.Location,
     history: H.History,
-    pushURL: (url: string) => void
+    pushURL?: (url: string) => void
 ): Extension {
     class LineLinkManager implements PluginValue {
         public decorations: DecorationSet = Decoration.none
@@ -54,7 +54,8 @@ export function navigateToLineOnAnyClickExtension(
                 // If it is, push the link to the history stack.
                 if (target.matches('[data-line-link]')) {
                     event.preventDefault()
-                    pushURL(target.getAttribute('href')!)
+                    const pushAction = pushURL ?? history.push
+                    pushAction(target.getAttribute('href')!)
                 }
             },
         }),

--- a/client/web/src/repo/blob/codemirror/navigate-to-any-line-on-click.ts
+++ b/client/web/src/repo/blob/codemirror/navigate-to-any-line-on-click.ts
@@ -2,6 +2,7 @@ import { Extension, RangeSetBuilder } from '@codemirror/state'
 import { Decoration, DecorationSet, EditorView, PluginValue, ViewPlugin, ViewUpdate } from '@codemirror/view'
 
 import { toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
+
 import { blobPropsFacet } from '.'
 
 class LineLinkManager implements PluginValue {

--- a/client/web/src/repo/blob/codemirror/navigate-to-any-line-on-click.ts
+++ b/client/web/src/repo/blob/codemirror/navigate-to-any-line-on-click.ts
@@ -1,63 +1,62 @@
 import { Extension, RangeSetBuilder } from '@codemirror/state'
 import { Decoration, DecorationSet, EditorView, PluginValue, ViewPlugin, ViewUpdate } from '@codemirror/view'
-import * as H from 'history'
 
-import { addLineRangeQueryParameter, formatSearchParameters } from '@sourcegraph/common'
+import { toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
+import { blobPropsFacet } from '.'
+
+class LineLinkManager implements PluginValue {
+    public decorations: DecorationSet = Decoration.none
+    constructor(view: EditorView) {
+        this.decorations = this.computeDecorations(view)
+    }
+    public update(update: ViewUpdate): void {
+        if (update.viewportChanged) {
+            this.decorations = this.computeDecorations(update.view)
+        }
+    }
+
+    private computeDecorations(view: EditorView): DecorationSet {
+        const builder = new RangeSetBuilder<Decoration>()
+        const blobInfo = view.state.facet(blobPropsFacet).blobInfo
+        for (const { from, to } of view.visibleRanges) {
+            for (let pos = from; pos < to; ) {
+                const line = view.state.doc.lineAt(pos)
+                const href = toPrettyBlobURL({
+                    ...blobInfo,
+                    position: { line: line.number, character: 0 },
+                })
+                builder.add(
+                    line.from,
+                    line.to,
+                    Decoration.mark({ tagName: 'a', attributes: { href, 'data-line-link': '' } })
+                )
+                pos = line.to + 1
+            }
+        }
+        return builder.finish()
+    }
+}
 
 // Extension that is only used in the ref panel preview pane. Wraps all lines
 // with an anchor link so that clicking on the line promotes that line from the
 // preview pane into the main blob view.
-export function navigateToLineOnAnyClickExtension(
-    location: H.Location,
-    history: H.History,
-    pushURL?: (url: string) => void
-): Extension {
-    class LineLinkManager implements PluginValue {
-        public decorations: DecorationSet = Decoration.none
-        constructor(view: EditorView) {
-            this.decorations = this.computeDecorations(view)
-        }
-        public update(update: ViewUpdate): void {
-            if (update.viewportChanged) {
-                this.decorations = this.computeDecorations(update.view)
-            }
-        }
-
-        private computeDecorations(view: EditorView): DecorationSet {
-            const builder = new RangeSetBuilder<Decoration>()
-            const startLine = view.state.doc.lineAt(view.viewport.from)
-            const endLine = view.state.doc.lineAt(view.viewport.to)
-            const parameters = new URLSearchParams(location.search)
-            parameters.delete('popover')
-            for (let lineNumber = startLine.number; lineNumber <= endLine.number; lineNumber++) {
-                const line = view.state.doc.line(lineNumber)
-                const entry: H.LocationDescriptor<unknown> = {
-                    ...location,
-                    search: formatSearchParameters(addLineRangeQueryParameter(parameters, `L${line.number}`)),
+export const navigateToLineOnAnyClickExtension: Extension = [
+    ViewPlugin.fromClass(LineLinkManager, { decorations: plugin => plugin.decorations }),
+    EditorView.domEventHandlers({
+        click(event, view) {
+            const target = event.target as HTMLElement
+            // Check to see if the clicked target is a token link.
+            // If it is, push the link to the history stack.
+            if (target.matches('[data-line-link]')) {
+                event.preventDefault()
+                const href = target.getAttribute('href')!
+                const props = view.state.facet(blobPropsFacet)
+                if (props.nav) {
+                    props.nav(href)
+                } else {
+                    props.history.push(href)
                 }
-                const url = history.createHref(entry)
-                builder.add(
-                    line.from,
-                    line.to,
-                    Decoration.mark({ tagName: 'a', attributes: { href: url, 'data-line-link': '' } })
-                )
             }
-            return builder.finish()
-        }
-    }
-    return [
-        ViewPlugin.fromClass(LineLinkManager, { decorations: plugin => plugin.decorations }),
-        EditorView.domEventHandlers({
-            click(event: MouseEvent) {
-                const target = event.target as HTMLElement
-                // Check to see if the clicked target is a token link.
-                // If it is, push the link to the history stack.
-                if (target.matches('[data-line-link]')) {
-                    event.preventDefault()
-                    const pushAction = pushURL ?? history.push
-                    pushAction(target.getAttribute('href')!)
-                }
-            },
-        }),
-    ]
-}
+        },
+    }),
+]

--- a/client/web/src/repo/blob/codemirror/navigate-to-any-line-on-click.ts
+++ b/client/web/src/repo/blob/codemirror/navigate-to-any-line-on-click.ts
@@ -1,0 +1,62 @@
+import { Extension, RangeSetBuilder } from '@codemirror/state'
+import { Decoration, DecorationSet, EditorView, PluginValue, ViewPlugin, ViewUpdate } from '@codemirror/view'
+import * as H from 'history'
+
+import { addLineRangeQueryParameter, formatSearchParameters } from '@sourcegraph/common'
+
+// Extension that is only used in the ref panel preview pane. Wraps all lines
+// with an anchor link so that clicking on the line promotes that line from the
+// preview pane into the main blob view.
+export function navigateToLineOnAnyClickExtension(
+    location: H.Location,
+    history: H.History,
+    pushURL: (url: string) => void
+): Extension {
+    class LineLinkManager implements PluginValue {
+        public decorations: DecorationSet = Decoration.none
+        constructor(view: EditorView) {
+            this.decorations = this.computeDecorations(view)
+        }
+        public update(update: ViewUpdate): void {
+            if (update.viewportChanged) {
+                this.decorations = this.computeDecorations(update.view)
+            }
+        }
+
+        private computeDecorations(view: EditorView): DecorationSet {
+            const builder = new RangeSetBuilder<Decoration>()
+            const startLine = view.state.doc.lineAt(view.viewport.from)
+            const endLine = view.state.doc.lineAt(view.viewport.to)
+            const parameters = new URLSearchParams(location.search)
+            parameters.delete('popover')
+            for (let lineNumber = startLine.number; lineNumber <= endLine.number; lineNumber++) {
+                const line = view.state.doc.line(lineNumber)
+                const entry: H.LocationDescriptor<unknown> = {
+                    ...location,
+                    search: formatSearchParameters(addLineRangeQueryParameter(parameters, `L${line.number}`)),
+                }
+                const url = history.createHref(entry)
+                builder.add(
+                    line.from,
+                    line.to,
+                    Decoration.mark({ tagName: 'a', attributes: { href: url, 'data-line-link': '' } })
+                )
+            }
+            return builder.finish()
+        }
+    }
+    return [
+        ViewPlugin.fromClass(LineLinkManager, { decorations: plugin => plugin.decorations }),
+        EditorView.domEventHandlers({
+            click(event: MouseEvent) {
+                const target = event.target as HTMLElement
+                // Check to see if the clicked target is a token link.
+                // If it is, push the link to the history stack.
+                if (target.matches('[data-line-link]')) {
+                    event.preventDefault()
+                    pushURL(target.getAttribute('href')!)
+                }
+            },
+        }),
+    ]
+}


### PR DESCRIPTION
This commits makes it possible to promote any line from the ref panel by clicking anywhere on that line in the preview pane. This feature is supported by the old blob view, this commit just closes the feature gap.

This commit implements this functionality by wrapping all lines with an anchor link. This is slightly different from the old blob view where every line registers an ad-hoc click handler.


## Test plan

Manual testing with

```
❯ SOURCEGRAPHDOTCOM_MODE=true SOURCEGRAPH_API_URL=https://sourcegraph.com sg start web-standalone
```

Make sure the `enableCodeMirrorFileView` is true. Open the ref panel and confirm that clicking on a line promotes that line to the main blob view.

![CleanShot 2022-12-02 at 15 49 09](https://user-images.githubusercontent.com/1408093/205319680-a2777099-3242-4249-95c6-37ddf8468ec5.gif)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-promote-on-any-click.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
