### PR TITLE
dev: cache blobstore image building in dev

### DIFF
--- a/docker-images/blobstore/build.sh
+++ b/docker-images/blobstore/build.sh
@@ -2,7 +2,14 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"
 set -ex
 
-docker build --no-cache -t "${IMAGE:-"sourcegraph/blobstore"}" . \
+# Enable image build caching via CACHE=true
+BUILD_CACHE="--no-cache"
+if [[ "$CACHE" == "true" ]]; then
+  BUILD_CACHE=""
+fi
+
+# shellcheck disable=SC2086
+docker build ${BUILD_CACHE} -t "${IMAGE:-"sourcegraph/blobstore"}" . \
   --progress=plain \
   --build-arg COMMIT_SHA \
   --build-arg DATE \


### PR DESCRIPTION
Without this, we were rebuilding the docker image every time, slowing down startup of the stack by a large order.

## Test plan

It works :+1: 