### PR TITLE
batches: stop reporting transient errors when sync'ing changesets

### DIFF
--- a/enterprise/internal/batches/syncer/syncer.go
+++ b/enterprise/internal/batches/syncer/syncer.go
@@ -409,7 +409,7 @@ func (s *changesetSyncer) Run(ctx context.Context) {
 			s.metrics.syncs.WithLabelValues(labelValues...).Inc()
 
 			if err != nil {
-				s.logger.Error("Syncing changeset", log.Int64("changesetID", next.changesetID), log.Error(err))
+				s.logger.Warn("Syncing changeset", log.Int64("changesetID", next.changesetID), log.Error(err))
 				// We'll continue and remove it as it'll get retried on next schedule
 			}
 


### PR DESCRIPTION
Following up on https://sentry.io/organizations/sourcegraph/issues/3767848464/?project=6583153&referrer=slack and https://sourcegraph.slack.com/archives/C045RUZAZ9P/p1669979236027739?thread_ts=1669972400.801129&cid=C045RUZAZ9P, this small PR changes the log level at which we're logging the error.

Because it was at the `Error` level before, we were creating a report on Sentry for each time an expired toke was being used. While it _is_ an error indeed, it's not an error that should bubble up to Sentry, because it's not a bug but our code simply erroring because of incorrect user inputs that should be fixed manually (it's nicely showed at the top of a the batch change, it complains about the token being expired). 

That being said, it is possible that under the hood, we have some very real errors which are not transient that we want to report. So in that case, I think it's best that you folks take a look. Where it to be the case, we'll probably need to have a predicate to flag an error as to be reported or not. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Just a log level change, so CI. 
