### PR TITLE
search: record zoekt backend being down as a crash

### DIFF
--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -268,6 +268,9 @@ func TestIgnoreDownEndpoints(t *testing.T) {
 	if len(sr.Files) == 0 {
 		t.Fatal("Search: expected results")
 	}
+	if sr.Crashes != 3 {
+		t.Fatalf("Search: expected 3 crashes to be recorded, got %d", sr.Crashes)
+	}
 
 	rle, err := searcher.List(context.Background(), nil, nil)
 	if err != nil {
@@ -275,6 +278,9 @@ func TestIgnoreDownEndpoints(t *testing.T) {
 	}
 	if len(rle.Repos) == 0 {
 		t.Fatal("List: expected results")
+	}
+	if rle.Crashes != 3 {
+		t.Fatalf("List: expected 3 crashes to be recorded, got %d", rle.Crashes)
 	}
 
 	// now test we do return errors if they occur


### PR DESCRIPTION
This will allow us to track in our observability how often we do a
search which doesn't run on all instances. Additionally this will be
used for a "strict" mode search which fails if any Zoekts are down. This
is intended to be used by code insights.

Test Plan: Updated unit tests

plz-review-url: https://plz.review/review/15452