### PR TITLE
batches: fetch orgs when selecting a namespace

### DIFF
--- a/client/shared/src/auth.ts
+++ b/client/shared/src/auth.ts
@@ -18,6 +18,7 @@ export const currentAuthStateQuery = gql`
             settingsURL
             organizations {
                 nodes {
+                    __typename
                     id
                     name
                     displayName

--- a/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.story.tsx
@@ -9,6 +9,7 @@ import {
 } from '@sourcegraph/shared/src/settings/settings'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
+import { AuthenticatedUser } from '../../../../auth'
 import { WebStory } from '../../../../components/WebStory'
 import { GET_BATCH_CHANGE_TO_EDIT } from '../../create/backend'
 import {
@@ -86,6 +87,23 @@ const FIRST_TIME_MOCKS = new WildcardMockLink([
     ...UNSTARTED_CONNECTION_MOCKS,
 ])
 
+const MOCK_ORGANIZATION = {
+    __typename: 'Org',
+    name: 'acme-corp',
+    displayName: 'ACME Corporation',
+    id: 'acme-corp-id',
+}
+
+const mockAuthenticatedUser = {
+    __typename: 'User',
+    username: 'alice',
+    displayName: 'alice',
+    id: 'b',
+    organizations: {
+        nodes: [MOCK_ORGANIZATION],
+    },
+} as AuthenticatedUser
+
 export const EditFirstTime: Story = () => (
     <WebStory>
         {props => (
@@ -97,6 +115,7 @@ export const EditFirstTime: Story = () => (
                         namespace: 'test1234',
                     }}
                     settingsCascade={SETTINGS_CASCADE}
+                    authenticatedUser={mockAuthenticatedUser}
                 />
             </MockedTestProvider>
         )}
@@ -144,6 +163,7 @@ export const EditLatestBatchSpec: Story = () => (
                         namespace: 'test1234',
                     }}
                     settingsCascade={SETTINGS_CASCADE}
+                    authenticatedUser={mockAuthenticatedUser}
                 />
             </MockedTestProvider>
         )}
@@ -176,6 +196,7 @@ export const BatchChangeNotFound: Story = () => (
                         namespace: 'test1234',
                     }}
                     settingsCascade={SETTINGS_CASCADE}
+                    authenticatedUser={mockAuthenticatedUser}
                 />
             </MockedTestProvider>
         )}
@@ -208,6 +229,7 @@ export const InvalidBatchSpec: Story = () => (
                         namespace: 'test1234',
                     }}
                     settingsCascade={SETTINGS_CASCADE}
+                    authenticatedUser={mockAuthenticatedUser}
                 />
             </MockedTestProvider>
         )}
@@ -240,6 +262,7 @@ export const ExecutorsNotActive: Story = () => (
                         namespace: 'test1234',
                     }}
                     settingsCascade={SETTINGS_CASCADE}
+                    authenticatedUser={mockAuthenticatedUser}
                 />
             </MockedTestProvider>
         )}

--- a/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
@@ -128,7 +128,7 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
     batchSpec,
     editor,
     errors,
-    authenticatedUser
+    authenticatedUser,
 }) {
     const history = useHistory()
 

--- a/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
@@ -9,6 +9,7 @@ import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Button, Icon, LoadingSpinner, H3, H4, Alert } from '@sourcegraph/wildcard'
 
+import { AuthenticatedUser } from '../../../../auth'
 import { HeroPage } from '../../../../components/HeroPage'
 import {
     CheckExecutorsAccessTokenResult,
@@ -42,6 +43,7 @@ import layoutStyles from '../Layout.module.scss'
 import styles from './EditBatchSpecPage.module.scss'
 
 export interface EditBatchSpecPageProps extends SettingsCascadeProps<Settings>, ThemeProps {
+    authenticatedUser: AuthenticatedUser | null
     batchChange: { name: string; namespace: Scalars['ID'] }
 }
 
@@ -94,7 +96,9 @@ export const EditBatchSpecPage: React.FunctionComponent<React.PropsWithChildren<
     )
 }
 
-interface EditBatchSpecPageContentProps extends SettingsCascadeProps<Settings>, ThemeProps {}
+interface EditBatchSpecPageContentProps extends SettingsCascadeProps<Settings>, ThemeProps {
+    authenticatedUser: AuthenticatedUser | null
+}
 
 const EditBatchSpecPageContent: React.FunctionComponent<
     React.PropsWithChildren<EditBatchSpecPageContentProps>
@@ -124,6 +128,7 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
     batchSpec,
     editor,
     errors,
+    authenticatedUser
 }) {
     const history = useHistory()
 
@@ -257,7 +262,7 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
             <TabBar activeTabKey={activeTabKey} tabsConfig={tabsConfig} />
 
             {activeTabKey === 'configuration' ? (
-                <ConfigurationForm isReadOnly={true} batchChange={batchChange} />
+                <ConfigurationForm isReadOnly={true} batchChange={batchChange} authenticatedUser={authenticatedUser} />
             ) : (
                 <div className={styles.form}>
                     <LibraryPane name={batchChange.name} onReplaceItem={editor.handleCodeChange} />

--- a/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.tsx
@@ -257,7 +257,7 @@ const MemoizedEditBatchSpecPageContent: React.FunctionComponent<
             <TabBar activeTabKey={activeTabKey} tabsConfig={tabsConfig} />
 
             {activeTabKey === 'configuration' ? (
-                <ConfigurationForm isReadOnly={true} batchChange={batchChange} settingsCascade={settingsCascade} />
+                <ConfigurationForm isReadOnly={true} batchChange={batchChange} />
             ) : (
                 <div className={styles.form}>
                     <LibraryPane name={batchChange.name} onReplaceItem={editor.handleCodeChange} />

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.story.tsx
@@ -5,13 +5,9 @@ import { of } from 'rxjs'
 import { MATCH_ANY_PARAMETERS, MockedResponses, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
-import {
-    EMPTY_SETTINGS_CASCADE,
-    SettingsOrgSubject,
-    SettingsUserSubject,
-} from '@sourcegraph/shared/src/settings/settings'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
+import { AuthenticatedUser } from '../../../../auth'
 import { WebStory } from '../../../../components/WebStory'
 import {
     BatchSpecExecutionFields,
@@ -20,7 +16,6 @@ import {
     BatchSpecWorkspaceState,
     VisibleBatchSpecWorkspaceFields,
 } from '../../../../graphql-operations'
-import { mockAuthenticatedUser } from '../../../code-monitoring/testing/util'
 import { GET_BATCH_CHANGE_TO_EDIT, WORKSPACE_RESOLUTION_STATUS } from '../../create/backend'
 import {
     COMPLETED_BATCH_SPEC,
@@ -60,29 +55,22 @@ const config: Meta = {
 
 export default config
 
-const FIXTURE_ORG: SettingsOrgSubject = {
+const MOCK_ORGANIZATION = {
     __typename: 'Org',
-    name: 'sourcegraph',
-    displayName: 'Sourcegraph',
-    id: 'a',
-    viewerCanAdminister: true,
+    name: 'acme-corp',
+    displayName: 'ACME Corporation',
+    id: 'acme-corp-id',
 }
 
-const FIXTURE_USER: SettingsUserSubject = {
+const mockAuthenticatedUser = {
     __typename: 'User',
     username: 'alice',
     displayName: 'alice',
     id: 'b',
-    viewerCanAdminister: true,
-}
-
-const SETTINGS_CASCADE = {
-    ...EMPTY_SETTINGS_CASCADE,
-    subjects: [
-        { subject: FIXTURE_ORG, settings: { a: 1 }, lastID: 1 },
-        { subject: FIXTURE_USER, settings: { b: 2 }, lastID: 2 },
-    ],
-}
+    organizations: {
+        nodes: [MOCK_ORGANIZATION],
+    },
+} as AuthenticatedUser
 
 const COMMON_MOCKS: MockedResponses = [
     {
@@ -139,7 +127,6 @@ export const Executing: Story = () => (
                     batchSpecID="spec1234"
                     batchChange={{ name: 'my-batch-change', namespace: 'user1234' }}
                     authenticatedUser={mockAuthenticatedUser}
-                    settingsCascade={SETTINGS_CASCADE}
                     queryWorkspacesList={buildWorkspacesQuery()}
                 />
             </MockedTestProvider>
@@ -193,7 +180,6 @@ export const ExecuteWithAWorkspaceSelected: Story = () => (
                         batchSpecID="spec1234"
                         batchChange={{ name: 'my-batch-change', namespace: 'user1234' }}
                         authenticatedUser={mockAuthenticatedUser}
-                        settingsCascade={SETTINGS_CASCADE}
                         match={{
                             isExact: false,
                             params: { batchChangeName: 'my-batch-change', batchSpecID: 'spec1234' },
@@ -221,7 +207,6 @@ export const Completed: Story = () => (
                     batchSpecID="spec1234"
                     batchChange={{ name: 'my-batch-change', namespace: 'user1234' }}
                     authenticatedUser={mockAuthenticatedUser}
-                    settingsCascade={SETTINGS_CASCADE}
                     queryWorkspacesList={buildWorkspacesQuery({ state: BatchSpecWorkspaceState.COMPLETED })}
                 />
             </MockedTestProvider>
@@ -240,7 +225,6 @@ export const CompletedWithErrors: Story = () => (
                     batchSpecID="spec1234"
                     batchChange={{ name: 'my-batch-change', namespace: 'user1234' }}
                     authenticatedUser={mockAuthenticatedUser}
-                    settingsCascade={SETTINGS_CASCADE}
                     queryWorkspacesList={buildWorkspacesQuery({ state: BatchSpecWorkspaceState.FAILED })}
                 />
             </MockedTestProvider>
@@ -261,7 +245,6 @@ export const LocallyExecutedSpec: Story = () => (
                     batchSpecID="spec1234"
                     batchChange={{ name: 'my-local-batch-change', namespace: 'user1234' }}
                     authenticatedUser={mockAuthenticatedUser}
-                    settingsCascade={SETTINGS_CASCADE}
                 />
             </MockedTestProvider>
         )}

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
@@ -10,7 +10,6 @@ import { ErrorMessage } from '@sourcegraph/branded/src/components/alerts'
 import { useQuery } from '@sourcegraph/http-client'
 import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
-import { Settings, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Badge, Icon, LoadingSpinner } from '@sourcegraph/wildcard'
@@ -47,8 +46,7 @@ import layoutStyles from '../Layout.module.scss'
 import styles from './ExecuteBatchSpecPage.module.scss'
 
 export interface AuthenticatedExecuteBatchSpecPageProps
-    extends SettingsCascadeProps<Settings>,
-        ThemeProps,
+    extends ThemeProps,
         TelemetryProps,
         RouteComponentProps<{}> {
     batchChange: { name: string; namespace: Scalars['ID'] }
@@ -112,8 +110,7 @@ export const AuthenticatedExecuteBatchSpecPage: React.FunctionComponent<
 }
 
 interface ExecuteBatchSpecPageContentProps
-    extends SettingsCascadeProps<Settings>,
-        ThemeProps,
+    extends ThemeProps,
         TelemetryProps,
         RouteComponentProps<{}> {
     authenticatedUser: AuthenticatedUser
@@ -138,7 +135,6 @@ const MemoizedExecuteBatchSpecContent: React.FunctionComponent<
 > = React.memo(function MemoizedExecuteBatchSpecContent({
     isLightTheme,
     match,
-    settingsCascade,
     telemetryService,
     authenticatedUser,
     batchChange,
@@ -223,7 +219,7 @@ const MemoizedExecuteBatchSpecContent: React.FunctionComponent<
                     render={() => (
                         <>
                             <TabBar activeTabKey="configuration" tabsConfig={tabsConfig} matchURL={executionURL} />
-                            <ConfigurationForm isReadOnly={true} batchChange={batchChange} />
+                            <ConfigurationForm isReadOnly={true} batchChange={batchChange} authenticatedUser={authenticatedUser} />
                         </>
                     )}
                     exact={true}

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
@@ -45,10 +45,7 @@ import { ExecutionWorkspaces } from './workspaces/ExecutionWorkspaces'
 import layoutStyles from '../Layout.module.scss'
 import styles from './ExecuteBatchSpecPage.module.scss'
 
-export interface AuthenticatedExecuteBatchSpecPageProps
-    extends ThemeProps,
-        TelemetryProps,
-        RouteComponentProps<{}> {
+export interface AuthenticatedExecuteBatchSpecPageProps extends ThemeProps, TelemetryProps, RouteComponentProps<{}> {
     batchChange: { name: string; namespace: Scalars['ID'] }
     batchSpecID: Scalars['ID']
     authenticatedUser: AuthenticatedUser
@@ -109,10 +106,7 @@ export const AuthenticatedExecuteBatchSpecPage: React.FunctionComponent<
     )
 }
 
-interface ExecuteBatchSpecPageContentProps
-    extends ThemeProps,
-        TelemetryProps,
-        RouteComponentProps<{}> {
+interface ExecuteBatchSpecPageContentProps extends ThemeProps, TelemetryProps, RouteComponentProps<{}> {
     authenticatedUser: AuthenticatedUser
     queryWorkspacesList?: typeof _queryWorkspacesList
 }
@@ -219,7 +213,11 @@ const MemoizedExecuteBatchSpecContent: React.FunctionComponent<
                     render={() => (
                         <>
                             <TabBar activeTabKey="configuration" tabsConfig={tabsConfig} matchURL={executionURL} />
-                            <ConfigurationForm isReadOnly={true} batchChange={batchChange} authenticatedUser={authenticatedUser} />
+                            <ConfigurationForm
+                                isReadOnly={true}
+                                batchChange={batchChange}
+                                authenticatedUser={authenticatedUser}
+                            />
                         </>
                     )}
                     exact={true}

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
@@ -223,11 +223,7 @@ const MemoizedExecuteBatchSpecContent: React.FunctionComponent<
                     render={() => (
                         <>
                             <TabBar activeTabKey="configuration" tabsConfig={tabsConfig} matchURL={executionURL} />
-                            <ConfigurationForm
-                                isReadOnly={true}
-                                batchChange={batchChange}
-                                settingsCascade={settingsCascade}
-                            />
+                            <ConfigurationForm isReadOnly={true} batchChange={batchChange} />
                         </>
                     )}
                     exact={true}

--- a/client/web/src/enterprise/batches/create/ConfigurationForm.story.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.story.tsx
@@ -13,6 +13,7 @@ import { WebStory } from '../../../components/WebStory'
 import { GET_LICENSE_AND_USAGE_INFO } from '../list/backend'
 import { getLicenseAndUsageInfoResult } from '../list/testData'
 
+import { GET_ORGANIZATIONS } from './backend'
 import { ConfigurationForm } from './ConfigurationForm'
 
 const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
@@ -53,11 +54,29 @@ const SETTINGS_CASCADE = {
     ],
 }
 
+const MOCK_ORGANIZATION = {
+    __typename: 'Org',
+    name: 'acme-corp',
+    displayName: 'ACME Corporation',
+    id: 'acme-corp-id',
+    viewerCanAdminister: true,
+}
+
 const buildMocks = (isLicensed = true, hasBatchChanges = true) =>
     new WildcardMockLink([
         {
             request: { query: getDocumentNode(GET_LICENSE_AND_USAGE_INFO), variables: MATCH_ANY_PARAMETERS },
             result: { data: getLicenseAndUsageInfoResult(isLicensed, hasBatchChanges) },
+            nMatches: Number.POSITIVE_INFINITY,
+        },
+        {
+            request: { query: getDocumentNode(GET_ORGANIZATIONS), variables: MATCH_ANY_PARAMETERS },
+            result: { data: {
+                organizations: {
+                    totalCount: 1,
+                    nodes: [MOCK_ORGANIZATION]
+                }
+            } },
             nMatches: Number.POSITIVE_INFINITY,
         },
     ])
@@ -73,6 +92,18 @@ export const NewBatchChange: Story = () => (
 )
 
 NewBatchChange.storyName = 'New batch change'
+
+export const NewOrgBatchChange: Story = () => (
+    <WebStory>
+        {props => (
+            <MockedTestProvider link={buildMocks()}>
+                <ConfigurationForm {...props} settingsCascade={SETTINGS_CASCADE} initialNamespaceID={MOCK_ORGANIZATION.id} />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
+
+NewOrgBatchChange.storyName = 'New batch change with new Org'
 
 export const ExistingBatchChange: Story = () => (
     <WebStory>

--- a/client/web/src/enterprise/batches/create/ConfigurationForm.story.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.story.tsx
@@ -71,12 +71,14 @@ const buildMocks = (isLicensed = true, hasBatchChanges = true) =>
         },
         {
             request: { query: getDocumentNode(GET_ORGANIZATIONS), variables: MATCH_ANY_PARAMETERS },
-            result: { data: {
-                organizations: {
-                    totalCount: 1,
-                    nodes: [MOCK_ORGANIZATION]
-                }
-            } },
+            result: {
+                data: {
+                    organizations: {
+                        totalCount: 1,
+                        nodes: [MOCK_ORGANIZATION],
+                    },
+                },
+            },
             nMatches: Number.POSITIVE_INFINITY,
         },
     ])
@@ -97,7 +99,11 @@ export const NewOrgBatchChange: Story = () => (
     <WebStory>
         {props => (
             <MockedTestProvider link={buildMocks()}>
-                <ConfigurationForm {...props} settingsCascade={SETTINGS_CASCADE} initialNamespaceID={MOCK_ORGANIZATION.id} />
+                <ConfigurationForm
+                    {...props}
+                    settingsCascade={SETTINGS_CASCADE}
+                    initialNamespaceID={MOCK_ORGANIZATION.id}
+                />
             </MockedTestProvider>
         )}
     </WebStory>

--- a/client/web/src/enterprise/batches/create/ConfigurationForm.story.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.story.tsx
@@ -67,7 +67,11 @@ export const NewOrgBatchChange: Story = () => (
     <WebStory>
         {props => (
             <MockedTestProvider link={buildMocks()}>
-                <ConfigurationForm {...props} initialNamespaceID={MOCK_ORGANIZATION.id} authenticatedUser={mockAuthenticatedUser} />
+                <ConfigurationForm
+                    {...props}
+                    initialNamespaceID={MOCK_ORGANIZATION.id}
+                    authenticatedUser={mockAuthenticatedUser}
+                />
             </MockedTestProvider>
         )}
     </WebStory>

--- a/client/web/src/enterprise/batches/create/ConfigurationForm.story.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.story.tsx
@@ -87,7 +87,7 @@ export const NewBatchChange: Story = () => (
     <WebStory>
         {props => (
             <MockedTestProvider link={buildMocks()}>
-                <ConfigurationForm {...props} settingsCascade={SETTINGS_CASCADE} />
+                <ConfigurationForm {...props} />
             </MockedTestProvider>
         )}
     </WebStory>
@@ -99,11 +99,7 @@ export const NewOrgBatchChange: Story = () => (
     <WebStory>
         {props => (
             <MockedTestProvider link={buildMocks()}>
-                <ConfigurationForm
-                    {...props}
-                    settingsCascade={SETTINGS_CASCADE}
-                    initialNamespaceID={MOCK_ORGANIZATION.id}
-                />
+                <ConfigurationForm {...props} initialNamespaceID={MOCK_ORGANIZATION.id} />
             </MockedTestProvider>
         )}
     </WebStory>
@@ -117,7 +113,6 @@ export const ExistingBatchChange: Story = () => (
             <MockedTestProvider link={buildMocks()}>
                 <ConfigurationForm
                     {...props}
-                    settingsCascade={SETTINGS_CASCADE}
                     isReadOnly={true}
                     batchChange={{
                         name: 'My existing batch change',
@@ -144,7 +139,6 @@ export const LicenseAlert: Story = () => (
             <MockedTestProvider link={buildMocks(false)}>
                 <ConfigurationForm
                     {...props}
-                    settingsCascade={SETTINGS_CASCADE}
                     isReadOnly={true}
                     batchChange={{
                         name: 'My existing batch change',

--- a/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
@@ -8,10 +8,7 @@ import { useHistory, useLocation } from 'react-router'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { useMutation } from '@sourcegraph/http-client'
-import {
-    SettingsOrgSubject,
-    SettingsUserSubject,
-} from '@sourcegraph/shared/src/settings/settings'
+import { SettingsOrgSubject, SettingsUserSubject } from '@sourcegraph/shared/src/settings/settings'
 import { Alert, Button, Container, Icon, Input, LoadingSpinner, RadioButton, Tooltip } from '@sourcegraph/wildcard'
 
 import {

--- a/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 
 import { mdiInformationOutline, mdiLock } from '@mdi/js'
 import classNames from 'classnames'
@@ -87,18 +87,22 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
         CreateBatchSpecFromRawVariables
     >(CREATE_BATCH_SPEC_FROM_RAW)
 
-    const loading = batchChangeLoading || batchSpecLoading
-    const error = batchChangeError || batchSpecError
-
-    const { namespaces, defaultSelectedNamespace } = useNamespaces(
+    const { namespaces, defaultSelectedNamespace, loading: namespaceLoading, error: namespaceError } = useNamespaces(
         settingsCascade,
         batchChange?.namespace.id || initialNamespaceID
     )
+
+    const loading = batchChangeLoading || batchSpecLoading || namespaceLoading
+    const error = batchChangeError || batchSpecError || namespaceError
 
     // The namespace selected for creating the new batch change under.
     const [selectedNamespace, setSelectedNamespace] = useState<
         Pick<SettingsUserSubject, 'id'> | Pick<SettingsOrgSubject, 'id'>
     >(defaultSelectedNamespace)
+
+    useEffect(() => {
+        setSelectedNamespace(defaultSelectedNamespace)
+    }, [defaultSelectedNamespace])
 
     const [nameInput, setNameInput] = useState(batchChange?.name || '')
     const [isNameValid, setIsNameValid] = useState<boolean>()

--- a/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
@@ -100,6 +100,7 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
         Pick<SettingsUserSubject, 'id'> | Pick<SettingsOrgSubject, 'id'>
     >(defaultSelectedNamespace)
 
+    // This updates the defaultSelectedNamespace after the graphql query in the `useNamespace` hook is done.
     useEffect(() => {
         setSelectedNamespace(defaultSelectedNamespace)
     }, [defaultSelectedNamespace])

--- a/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
@@ -92,7 +92,9 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
         batchChange?.namespace.id || initialNamespaceID
     )
 
-    const loading = batchChangeLoading || batchSpecLoading
+    // When creating a batch change we want to disable the `Create` button, to avoid user's clicking
+    // on it again.
+    const isButtonDisabled = batchChangeLoading || batchSpecLoading
     const error = batchChangeError || batchSpecError || namespaceError
 
     // The namespace selected for creating the new batch change under.
@@ -250,7 +252,7 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
                         type="submit"
                         onClick={handleCreate}
                         aria-label={isNameValid ? undefined : 'Batch change name is invalid'}
-                        disabled={loading || nameInput === '' || !isNameValid}
+                        disabled={isButtonDisabled || nameInput === '' || !isNameValid}
                     >
                         Create
                     </Button>

--- a/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
@@ -8,9 +8,7 @@ import { useHistory, useLocation } from 'react-router'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { useMutation } from '@sourcegraph/http-client'
-import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import {
-    SettingsCascadeProps,
     SettingsOrgSubject,
     SettingsUserSubject,
 } from '@sourcegraph/shared/src/settings/settings'
@@ -35,7 +33,7 @@ import styles from './ConfigurationForm.module.scss'
 /* Regex pattern for a valid batch change name. Needs to match what's defined in the BatchSpec JSON schema. */
 const NAME_PATTERN = /^[\w.-]+$/
 
-type ConfigurationFormProps = SettingsCascadeProps<Settings> & {
+type ConfigurationFormProps = {
     /**
      * When set, apply a template to the batch spec before redirecting to the edit page.
      */
@@ -48,30 +46,29 @@ type ConfigurationFormProps = SettingsCascadeProps<Settings> & {
      */
     initialNamespaceID?: Scalars['ID']
 } & (
-        | // Either the form is editable and we may not have a batch change yet, or the form is
-        // read-only and we definitely already have a batch change.
-        {
-              /**
-               * Whether or not to display the configuration form in read-only mode, i.e. to view
-               * for an existing batch change.
-               */
-              isReadOnly?: false
-              /** The existing batch change to use to pre-populate the form. */
-              batchChange?: Pick<BatchChangeFields, 'name' | 'namespace'>
-          }
-        | {
-              /**
-               * Whether or not to display the configuration form in read-only mode, i.e. to view
-               * for an existing batch change.
-               */
-              isReadOnly: true
-              /** The existing batch change to use to pre-populate the form. */
-              batchChange: Pick<BatchChangeFields, 'name' | 'namespace'>
-          }
-    )
+    | // Either the form is editable and we may not have a batch change yet, or the form is
+    // read-only and we definitely already have a batch change.
+    {
+          /**
+           * Whether or not to display the configuration form in read-only mode, i.e. to view
+           * for an existing batch change.
+           */
+          isReadOnly?: false
+          /** The existing batch change to use to pre-populate the form. */
+          batchChange?: Pick<BatchChangeFields, 'name' | 'namespace'>
+      }
+    | {
+          /**
+           * Whether or not to display the configuration form in read-only mode, i.e. to view
+           * for an existing batch change.
+           */
+          isReadOnly: true
+          /** The existing batch change to use to pre-populate the form. */
+          batchChange: Pick<BatchChangeFields, 'name' | 'namespace'>
+      }
+)
 
 export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<ConfigurationFormProps>> = ({
-    settingsCascade,
     isReadOnly,
     batchChange,
     renderTemplate,
@@ -88,7 +85,6 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
     >(CREATE_BATCH_SPEC_FROM_RAW)
 
     const { namespaces, defaultSelectedNamespace, loading: namespaceLoading, error: namespaceError } = useNamespaces(
-        settingsCascade,
         batchChange?.namespace.id || initialNamespaceID
     )
 

--- a/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
@@ -14,7 +14,7 @@ import {
     SettingsOrgSubject,
     SettingsUserSubject,
 } from '@sourcegraph/shared/src/settings/settings'
-import { Alert, Button, Container, Icon, Input, RadioButton, Tooltip } from '@sourcegraph/wildcard'
+import { Alert, Button, Container, Icon, Input, LoadingSpinner, RadioButton, Tooltip } from '@sourcegraph/wildcard'
 
 import {
     BatchChangeFields,
@@ -92,7 +92,7 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
         batchChange?.namespace.id || initialNamespaceID
     )
 
-    const loading = batchChangeLoading || batchSpecLoading || namespaceLoading
+    const loading = batchChangeLoading || batchSpecLoading
     const error = batchChangeError || batchSpecError || namespaceError
 
     // The namespace selected for creating the new batch change under.
@@ -155,6 +155,10 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
             )
             // We destructure and surface the error from `useMutation` instead.
             .catch(noop)
+    }
+
+    if (namespaceLoading) {
+        return <LoadingSpinner />
     }
 
     return (

--- a/client/web/src/enterprise/batches/create/CreateBatchChangePage.story.tsx
+++ b/client/web/src/enterprise/batches/create/CreateBatchChangePage.story.tsx
@@ -6,6 +6,7 @@ import {
     SettingsUserSubject,
 } from '@sourcegraph/shared/src/settings/settings'
 
+import { AuthenticatedUser } from '../../../auth'
 import { WebStory } from '../../../components/WebStory'
 
 import { CreateBatchChangePage } from './CreateBatchChangePage'
@@ -28,12 +29,30 @@ const config: Meta = {
 
 export default config
 
+const MOCK_ORGANIZATION = {
+    __typename: 'Org',
+    name: 'acme-corp',
+    displayName: 'ACME Corporation',
+    id: 'acme-corp-id',
+}
+
+const mockAuthenticatedUser = {
+    __typename: 'User',
+    username: 'alice',
+    displayName: 'alice',
+    id: 'b',
+    organizations: {
+        nodes: [MOCK_ORGANIZATION],
+    },
+} as AuthenticatedUser
+
 export const ExperimentalExecutionDisabled: Story = () => (
     <WebStory>
         {props => (
             <CreateBatchChangePage
                 {...props}
                 headingElement="h1"
+                authenticatedUser={mockAuthenticatedUser}
                 settingsCascade={{
                     ...EMPTY_SETTINGS_CASCADE,
                     final: { experimentalFeatures: { batchChangesExecution: false } },
@@ -67,6 +86,7 @@ export const ExperimentalExecutionEnabled: Story = () => (
             <CreateBatchChangePage
                 {...props}
                 headingElement="h1"
+                authenticatedUser={mockAuthenticatedUser}
                 settingsCascade={{
                     ...EMPTY_SETTINGS_CASCADE,
                     subjects: [
@@ -87,7 +107,8 @@ export const ExperimentalExecutionEnabledFromOrgNamespace: Story = () => (
             <CreateBatchChangePage
                 {...props}
                 headingElement="h1"
-                initialNamespaceID="a"
+                initialNamespaceID={MOCK_ORGANIZATION.id}
+                authenticatedUser={mockAuthenticatedUser}
                 settingsCascade={{
                     ...EMPTY_SETTINGS_CASCADE,
                     final: {
@@ -111,7 +132,8 @@ export const ExperimentalExecutionEnabledFromUserNamespace: Story = () => (
             <CreateBatchChangePage
                 {...props}
                 headingElement="h1"
-                initialNamespaceID="b"
+                initialNamespaceID={mockAuthenticatedUser.id}
+                authenticatedUser={mockAuthenticatedUser}
                 settingsCascade={{
                     ...EMPTY_SETTINGS_CASCADE,
                     final: {

--- a/client/web/src/enterprise/batches/create/CreateBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateBatchChangePage.tsx
@@ -5,6 +5,7 @@ import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { Link, PageHeader } from '@sourcegraph/wildcard'
 
+import { AuthenticatedUser } from '../../../auth'
 import { isBatchChangesExecutionEnabled } from '../../../batches'
 import { BatchChangesIcon } from '../../../batches/icons'
 import { Page } from '../../../components/Page'
@@ -23,6 +24,7 @@ import { useSearchTemplate } from './useSearchTemplate'
 import layoutStyles from '../batch-spec/Layout.module.scss'
 
 export interface CreateBatchChangePageProps extends SettingsCascadeProps<Settings>, ThemeProps {
+    authenticatedUser: AuthenticatedUser | null
     // TODO: This can go away once we only have the new SSBC create page
     headingElement: 'h1' | 'h2'
     initialNamespaceID?: Scalars['ID']
@@ -63,7 +65,7 @@ const TABS_CONFIG: TabsConfig[] = [{ key: 'configuration', isEnabled: true }]
 
 const NewBatchChangePageContent: React.FunctionComponent<
     React.PropsWithChildren<Omit<CreateBatchChangePageProps, 'headingElement'>>
-> = ({ settingsCascade, initialNamespaceID }) => {
+> = ({ settingsCascade, initialNamespaceID, authenticatedUser }) => {
     const { renderTemplate: insightRenderTemplate, insightTitle } = useInsightTemplates(settingsCascade)
     const { renderTemplate: searchRenderTemplate, searchQuery } = useSearchTemplate()
     return (
@@ -76,6 +78,7 @@ const NewBatchChangePageContent: React.FunctionComponent<
             </div>
             <TabBar activeTabKey="configuration" tabsConfig={TABS_CONFIG} />
             <ConfigurationForm
+                authenticatedUser={authenticatedUser}
                 // the insight render template takes precendence over the search query render
                 renderTemplate={insightRenderTemplate || searchRenderTemplate}
                 insightTitle={insightTitle}

--- a/client/web/src/enterprise/batches/create/CreateBatchChangePage.tsx
+++ b/client/web/src/enterprise/batches/create/CreateBatchChangePage.tsx
@@ -79,7 +79,6 @@ const NewBatchChangePageContent: React.FunctionComponent<
                 // the insight render template takes precendence over the search query render
                 renderTemplate={insightRenderTemplate || searchRenderTemplate}
                 insightTitle={insightTitle}
-                settingsCascade={settingsCascade}
                 initialNamespaceID={initialNamespaceID}
             />
         </div>

--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -2,6 +2,21 @@ import { gql } from '@sourcegraph/http-client'
 
 import { batchSpecExecutionFieldsFragment } from '../batch-spec/execute/backend'
 
+export const GET_ORGANIZATIONS = gql`
+    query GetOrganizations {
+        organizations {
+            totalCount
+            nodes {
+                id
+                __typename
+                viewerCanAdminister
+                displayName
+                name
+            }
+        }
+    }
+`
+
 export const GET_BATCH_CHANGE_TO_EDIT = gql`
     query GetBatchChangeToEdit($namespace: ID!, $name: String!) {
         batchChange(namespace: $namespace, name: $name) {

--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -2,32 +2,6 @@ import { gql } from '@sourcegraph/http-client'
 
 import { batchSpecExecutionFieldsFragment } from '../batch-spec/execute/backend'
 
-export const GET_USER_ORGANIZATIONS = gql`
-    query GetUserOrganizations($userId: ID!) {
-        node(id: $userId) {
-            ...GetUserOrganizationsFields
-        }
-    }
-
-    fragment GetUserOrganizationsFields on User {
-        __typename
-        id
-        displayName
-        username
-        viewerCanAdminister
-
-        organizations {
-            nodes {
-                __typename
-                id
-                viewerCanAdminister
-                displayName
-                name
-            }
-        }
-    }
-`
-
 export const GET_BATCH_CHANGE_TO_EDIT = gql`
     query GetBatchChangeToEdit($namespace: ID!, $name: String!) {
         batchChange(namespace: $namespace, name: $name) {

--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -5,7 +5,6 @@ import { batchSpecExecutionFieldsFragment } from '../batch-spec/execute/backend'
 export const GET_ORGANIZATIONS = gql`
     query GetOrganizations {
         organizations {
-            totalCount
             nodes {
                 id
                 __typename

--- a/client/web/src/enterprise/batches/create/backend.ts
+++ b/client/web/src/enterprise/batches/create/backend.ts
@@ -2,12 +2,24 @@ import { gql } from '@sourcegraph/http-client'
 
 import { batchSpecExecutionFieldsFragment } from '../batch-spec/execute/backend'
 
-export const GET_ORGANIZATIONS = gql`
-    query GetOrganizations {
+export const GET_USER_ORGANIZATIONS = gql`
+    query GetUserOrganizations($userId: ID!) {
+        node(id: $userId) {
+            ...GetUserOrganizationsFields
+        }
+    }
+
+    fragment GetUserOrganizationsFields on User {
+        __typename
+        id
+        displayName
+        username
+        viewerCanAdminister
+
         organizations {
             nodes {
-                id
                 __typename
+                id
                 viewerCanAdminister
                 displayName
                 name

--- a/client/web/src/enterprise/batches/create/useNamespaces.ts
+++ b/client/web/src/enterprise/batches/create/useNamespaces.ts
@@ -14,7 +14,7 @@ import {
 
 import { Scalars, GetOrganizationsResult, GetOrganizationsVariables } from '../../../graphql-operations'
 
-import { GET_ORGANIZATIONS, } from './backend'
+import { GET_ORGANIZATIONS } from './backend'
 
 export interface UseNamespacesResult {
     userNamespace: SettingsUserSubject
@@ -56,18 +56,15 @@ export const useNamespaces = (
     }
 
     const { loading, data, error } = useQuery<GetOrganizationsResult, GetOrganizationsVariables>(GET_ORGANIZATIONS, {
-        fetchPolicy: 'cache-and-network'
+        fetchPolicy: 'cache-and-network',
     })
 
-    const organizationNamespaces: SettingsOrgSubject[] = useMemo(
-        () => {
-            if (!loading && data?.organizations) {
-                return data.organizations.nodes
-            }
-            return []
-        },
-        [data, loading]
-    )
+    const organizationNamespaces: SettingsOrgSubject[] = useMemo(() => {
+        if (!loading && data?.organizations) {
+            return data.organizations.nodes
+        }
+        return []
+    }, [data, loading])
 
     const namespaces: (SettingsUserSubject | SettingsOrgSubject)[] = useMemo(
         () => [userNamespace, ...organizationNamespaces],

--- a/client/web/src/enterprise/batches/create/useNamespaces.ts
+++ b/client/web/src/enterprise/batches/create/useNamespaces.ts
@@ -32,13 +32,16 @@ export const useNamespaces = (initialNamespaceID?: Scalars['ID']): UseNamespaces
         throw new Error('No user found')
     }
 
-    const localUserNamespace = useMemo(() => ({
-        __typename: user.__typename,
-        id: user.id,
-        username: user?.username,
-        displayName: user.displayName,
-        viewerCanAdminister: user.viewerCanAdminister
-    }), [user])
+    const localUserNamespace = useMemo(
+        () => ({
+            __typename: user.__typename,
+            id: user.id,
+            username: user?.username,
+            displayName: user.displayName,
+            viewerCanAdminister: user.viewerCanAdminister,
+        }),
+        [user]
+    )
 
     const { loading, data, error } = useQuery<GetUserOrganizationsResult, GetUserOrganizationsVariables>(
         GET_USER_ORGANIZATIONS,

--- a/client/web/src/enterprise/batches/create/useNamespaces.ts
+++ b/client/web/src/enterprise/batches/create/useNamespaces.ts
@@ -1,82 +1,43 @@
 import { useMemo } from 'react'
 
-import { ApolloError } from '@apollo/client'
-
-import { useQuery } from '@sourcegraph/http-client'
 import { SettingsOrgSubject, SettingsUserSubject } from '@sourcegraph/shared/src/settings/settings'
-import { useObservable } from '@sourcegraph/wildcard'
 
-import { authenticatedUser } from '../../../auth'
-import { Scalars, GetUserOrganizationsResult, GetUserOrganizationsVariables } from '../../../graphql-operations'
+import { AuthenticatedUser } from '../../../auth'
+import { Scalars } from '../../../graphql-operations'
 
-import { GET_USER_ORGANIZATIONS } from './backend'
+type UserNamespace = Omit<SettingsUserSubject, 'viewerCanAdminister'>
+type OrgNamespace = Omit<SettingsOrgSubject, 'viewerCanAdminister'>
 
 export interface UseNamespacesResult {
-    userNamespace: SettingsUserSubject
-    namespaces: (SettingsUserSubject | SettingsOrgSubject)[]
-    defaultSelectedNamespace: SettingsUserSubject | SettingsOrgSubject
-    loading: boolean
-    error: ApolloError | undefined
+    userNamespace: UserNamespace
+    namespaces: (UserNamespace | OrgNamespace)[]
+    defaultSelectedNamespace: UserNamespace | OrgNamespace
 }
 
 /**
  * Custom hook to extract namespaces from the provided `settingsCascade` and determine the
  * appropriate default namespace to select for the user.
  *
- * @param initialNamespaceID The id of the initial namespace to select.
+ * @param authenticatedUser     The currently signed-in user
+ * @param initialNamespaceID    The id of the initial namespace to select.
  */
-export const useNamespaces = (initialNamespaceID?: Scalars['ID']): UseNamespacesResult => {
-    const user = useObservable(authenticatedUser)
-
-    if (!user) {
+export const useNamespaces = (
+    authenticatedUser: AuthenticatedUser | null,
+    initialNamespaceID?: Scalars['ID']
+): UseNamespacesResult => {
+    if (!authenticatedUser) {
         throw new Error('No user found')
     }
 
-    const localUserNamespace = useMemo(
-        () => ({
-            __typename: user.__typename,
-            id: user.id,
-            username: user?.username,
-            displayName: user.displayName,
-            viewerCanAdminister: user.viewerCanAdminister,
-        }),
-        [user]
-    )
+    const { organizations, ...userDetails } = authenticatedUser
 
-    const { loading, data, error } = useQuery<GetUserOrganizationsResult, GetUserOrganizationsVariables>(
-        GET_USER_ORGANIZATIONS,
-        {
-            variables: {
-                userId: user.id,
-            },
-            fetchPolicy: 'cache-and-network',
-        }
-    )
+    const organizationNamespaces = organizations.nodes
+    const userNamespace = userDetails
 
-    if (data?.node?.__typename !== 'User') {
-        throw new Error('No user found')
-    }
-
-    const userNamespace: SettingsUserSubject = useMemo(() => {
-        const userData = data?.node
-        if (!loading && userData?.__typename === 'User') {
-            return userData
-        }
-        return localUserNamespace
-    }, [data, loading, localUserNamespace])
-
-    const organizationNamespaces: SettingsOrgSubject[] = useMemo(() => {
-        const userData = data?.node
-        if (!loading && userData?.__typename === 'User') {
-            return userData.organizations.nodes
-        }
-        return []
-    }, [data, loading])
-
-    const namespaces: (SettingsUserSubject | SettingsOrgSubject)[] = useMemo(
-        () => [userNamespace, ...organizationNamespaces],
-        [userNamespace, organizationNamespaces]
-    )
+    const namespaces = useMemo(() => [userNamespace, ...organizationNamespaces], [
+        userNamespace,
+        organizationNamespaces,
+    ])
 
     // The default namespace selected from the dropdown should match whatever the initial
     // namespace was, or else default to the user's namespace.
@@ -91,7 +52,5 @@ export const useNamespaces = (initialNamespaceID?: Scalars['ID']): UseNamespaces
         userNamespace,
         namespaces,
         defaultSelectedNamespace,
-        loading,
-        error,
     }
 }

--- a/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
+++ b/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
@@ -80,7 +80,7 @@ export const GlobalBatchChangesArea: React.FunctionComponent<React.PropsWithChil
             </Route>
             {!isSourcegraphDotCom && (
                 <Route path={`${match.url}/create`} exact={true}>
-                    <CreateBatchChangePage headingElement="h1" {...props} />
+                    <CreateBatchChangePage headingElement="h1" {...props} authenticatedUser={authenticatedUser} />
                 </Route>
             )}
             <Route component={NotFoundPage} key="hardcoded-key" />

--- a/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
+++ b/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
@@ -80,13 +80,21 @@ export const GlobalBatchChangesArea: React.FunctionComponent<React.PropsWithChil
             </Route>
             {!isSourcegraphDotCom && (
                 <Route path={`${match.url}/create`} exact={true}>
-                    <CreateBatchChangePage headingElement="h1" {...props} authenticatedUser={authenticatedUser} />
+                    <AuthenticatedCreateBatchChangePage
+                        {...props}
+                        headingElement="h1"
+                        authenticatedUser={authenticatedUser}
+                    />
                 </Route>
             )}
             <Route component={NotFoundPage} key="hardcoded-key" />
         </Switch>
     </div>
 )
+
+const AuthenticatedCreateBatchChangePage = withAuthenticatedUser<
+    CreateBatchChangePageProps & { authenticatedUser: AuthenticatedUser }
+>(props => <CreateBatchChangePage {...props} authenticatedUser={props.authenticatedUser} />)
 
 const NotFoundPage: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <HeroPage icon={MapSearchIcon} title="404: Not Found" />

--- a/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
+++ b/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
@@ -90,6 +90,7 @@ export function overrideInsightsGraphQLApi(props: OverrideGraphQLExtensionsProps
                 organizations: {
                     nodes: [
                         {
+                            __typename: 'Org',
                             name: 'test organization',
                             displayName: 'Test organization',
                             id: 'Org_test_id',

--- a/client/web/src/nav/UserNavItem.story.tsx
+++ b/client/web/src/nav/UserNavItem.story.tsx
@@ -50,6 +50,7 @@ const authenticatedUser: UserNavItemProps['authenticatedUser'] = {
     organizations: {
         nodes: [
             {
+                __typename: 'Org',
                 id: '0',
                 name: 'acme',
                 displayName: 'Acme Corp',
@@ -57,6 +58,7 @@ const authenticatedUser: UserNavItemProps['authenticatedUser'] = {
                 settingsURL: '/organizations/acme/settings',
             },
             {
+                __typename: 'Org',
                 id: '1',
                 name: 'beta',
                 displayName: 'Beta Inc',

--- a/client/web/src/nav/UserNavItem.test.tsx
+++ b/client/web/src/nav/UserNavItem.test.tsx
@@ -31,6 +31,7 @@ describe('UserNavItem', () => {
         organizations: {
             nodes: [
                 {
+                    __typename: 'Org',
                     id: '0',
                     name: 'acme',
                     displayName: 'Acme Corp',
@@ -38,6 +39,7 @@ describe('UserNavItem', () => {
                     settingsURL: '/organizations/acme/settings',
                 },
                 {
+                    __typename: 'Org',
                     id: '1',
                     name: 'beta',
                     displayName: 'Beta Inc',


### PR DESCRIPTION
Closes #44708

![CleanShot 2022-12-02 at 16 19 09](https://user-images.githubusercontent.com/25608335/205326647-5d8a2e3d-fd5e-48ba-8627-7e38a9e1b9f0.gif)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Steps to reproduce:

* Create a new org
* Land on the org page
* Click on batch changes
* Click create
* The org namespace should be selected by default (previously it wasn't)

## App preview:

- [Web](https://sg-web-bo-fix-namespace-selector-new-org.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
