### PR TITLE
Link migrations' README.md from migrations.md in dev docs

### DIFF
--- a/doc/dev/background-information/sql/migrations.md
+++ b/doc/dev/background-information/sql/migrations.md
@@ -12,6 +12,8 @@ Some migrations are difficult to do in a single step or idempotently. For instan
 
 The remainder of this document is formatted as a recipe book of common types of migrations. We encourage any developer to add a recipe here when a specific type of migration is under-documented.
 
+To learn the process of file changes necessary to implement a migration please refer to [the README file](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/migrations/README.md).
+
 ### Adding a non-nullable column (without a default)
 
 _On the `3.X` branch:_


### PR DESCRIPTION
When reading on [database migrations in the docs](https://docs.sourcegraph.com/dev/background-information/sql/migrations) (the page edited here). I was asking myself:

> OK, but what do I _actually do_ to implement a migration.

It took me a few minutes to find the `migrations` directory with the `README.md` in there, which is very well-written. Perhaps a link in the aforementioned dev docs page would make it easier to find?

## Test plan

Just code review of the documentation change.
