### PR TITLE
bazel: move generateGraphQlSchema.js to client/shared/dev and share code with legacy gulp build

### DIFF
--- a/client/shared/BUILD.bazel
+++ b/client/shared/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@aspect_rules_js//js:defs.bzl", "js_run_binary")
+
+js_run_binary(
+    name = "graphql_schema",
+    outs = ["src/schema.ts"],
+    args = [
+        "src/schema.ts",
+    ],
+    chdir = package_name(),
+    tool = "//client/shared/dev:generate_graphql_schema",
+)

--- a/client/shared/dev/BUILD.bazel
+++ b/client/shared/dev/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary")
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
 
 js_binary(
     name = "generate_graphql_schema",
@@ -13,14 +13,5 @@ js_binary(
         "//cmd/frontend/graphqlbackend:graphql_schema",
     ],
     entry_point = "generateGraphQlSchema.js",
-)
-
-js_run_binary(
-    name = "graphql_schema",
-    outs = ["schema.ts"],
-    args = [
-        "schema.ts",
-    ],
-    chdir = package_name(),
-    tool = ":generate_graphql_schema",
+    visibility = ["//client/shared:__pkg__"],
 )

--- a/client/shared/dev/generateGraphQlSchema.js
+++ b/client/shared/dev/generateGraphQlSchema.js
@@ -1,5 +1,3 @@
-/* eslint no-console: 0 */
-
 /**
  * Generates the TypeScript types for the GraphQL schema.
  * These are used by older code, new code should rely on the new query-specific generated types.
@@ -24,7 +22,10 @@ async function main(args) {
   }
 
   const outputFile = args[0]
+  await graphQlSchema(outputFile)
+}
 
+async function graphQlSchema(outputFile) {
   const schemaFiles = glob.sync(GRAPHQL_SCHEMA_GLOB)
   let combinedSchema = ''
   for (const schemaPath of schemaFiles) {
@@ -68,7 +69,14 @@ async function main(args) {
   await writeFile(outputFile, typings)
 }
 
-main(process.argv.slice(2)).catch(error => {
-  console.error(error)
-  process.exit(1)
-})
+// Entry point used by Bazel binary
+if (require.main === module) {
+  main(process.argv.slice(2)).catch(error => {
+    console.error(error)
+    process.exit(1)
+  })
+}
+
+module.exports = {
+  graphQlSchema,
+}

--- a/client/shared/gulpfile.js
+++ b/client/shared/gulpfile.js
@@ -2,17 +2,13 @@
 
 const path = require('path')
 
-const { generateNamespace } = require('@gql2ts/from-schema')
-const { DEFAULT_OPTIONS, DEFAULT_TYPE_MAP } = require('@gql2ts/language-typescript')
-const glob = require('glob')
-const { buildSchema, introspectionFromSchema } = require('graphql')
 const gulp = require('gulp')
 const { compile: compileJSONSchema } = require('json-schema-to-typescript')
 const { readFile, writeFile, mkdir } = require('mz/fs')
-const { format, resolveConfig } = require('prettier')
 
 const { cssModulesTypings, watchCSSModulesTypings } = require('./dev/generateCssModulesTypes')
 const { generateGraphQlOperations, ALL_DOCUMENTS_GLOB } = require('./dev/generateGraphQlOperations')
+const { graphQlSchema: _graphQlSchema } = require('./dev/generateGraphQlSchema')
 
 const GRAPHQL_SCHEMA_GLOB = path.join(__dirname, '../../cmd/frontend/graphqlbackend/*.graphql')
 
@@ -23,46 +19,7 @@ const GRAPHQL_SCHEMA_GLOB = path.join(__dirname, '../../cmd/frontend/graphqlback
  * @returns {Promise<void>}
  */
 async function graphQlSchema() {
-  const schemaFiles = glob.sync(GRAPHQL_SCHEMA_GLOB)
-  let combinedSchema = ''
-  for (const schemaPath of schemaFiles) {
-    const schemaString = await readFile(schemaPath, 'utf8')
-    combinedSchema += `\n${schemaString}`
-  }
-  const schema = buildSchema(combinedSchema)
-
-  const result = introspectionFromSchema(schema)
-
-  const formatOptions = await resolveConfig(__dirname, { config: __dirname + '/../../prettier.config.js' })
-  const typings =
-    'export type ID = string\n' +
-    'export type GitObjectID = string\n' +
-    'export type DateTime = string\n' +
-    'export type JSONCString = string\n' +
-    '\n' +
-    generateNamespace(
-      '',
-      result,
-      {
-        typeMap: {
-          ...DEFAULT_TYPE_MAP,
-          ID: 'ID',
-          GitObjectID: 'GitObjectID',
-          DateTime: 'DateTime',
-          JSONCString: 'JSONCString',
-        },
-      },
-      {
-        generateNamespace: (name, interfaces) => interfaces,
-        interfaceBuilder: (name, body) => `export ${DEFAULT_OPTIONS.interfaceBuilder(name, body)}`,
-        enumTypeBuilder: (name, values) =>
-          `export ${DEFAULT_OPTIONS.enumTypeBuilder(name, values).replace(/^const enum/, 'enum')}`,
-        typeBuilder: (name, body) => `export ${DEFAULT_OPTIONS.typeBuilder(name, body)}`,
-        wrapList: type => `${type}[]`,
-        postProcessor: code => format(code, { ...formatOptions, parser: 'typescript' }),
-      }
-    )
-  await writeFile(__dirname + '/src/schema.ts', typings)
+  await _graphQlSchema(__dirname + '/src/schema.ts')
 }
 
 /**

--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 
-package(default_visibility = ["//client/shared/src:__pkg__"])
+package(default_visibility = ["//client/shared/dev:__pkg__"])
 
 js_library(
     name = "graphql_schema",


### PR DESCRIPTION
This addresses some leftover feedback from the initial Bazel PR:
* https://github.com/sourcegraph/sourcegraph/pull/44755#discussion_r1037777635
* https://github.com/sourcegraph/sourcegraph/pull/44755#discussion_r1037789601

Generation code is now shared between the gulp file the Bazel binary. This is better if we want to avoid regressions between the two during the migration.

## Test plan

fyi @jbedard
