### PR TITLE
codeintel: Do not ignore deleted uploads when reconciling

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/background/job_reconciler.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_reconciler.go
@@ -91,13 +91,13 @@ func (j reconcilerJob) handleReconcileFromCodeintelDB(ctx context.Context, batch
 
 	j.operations.numReconcileScansFromCodeIntelDB.Add(float64(len(ids)))
 
-	dumps, err := j.store.GetDumpsByIDs(ctx, ids)
+	uploads, err := j.store.GetUploadsByIDsAllowDeleted(ctx, ids...)
 	if err != nil {
 		return err
 	}
 
 	found := map[int]struct{}{}
-	for _, dump := range dumps {
+	for _, dump := range uploads {
 		found[dump.ID] = struct{}{}
 	}
 

--- a/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
@@ -2457,6 +2457,10 @@ type MockStore struct {
 	// GetUploadsByIDsFunc is an instance of a mock function object
 	// controlling the behavior of the method GetUploadsByIDs.
 	GetUploadsByIDsFunc *StoreGetUploadsByIDsFunc
+	// GetUploadsByIDsAllowDeletedFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// GetUploadsByIDsAllowDeleted.
+	GetUploadsByIDsAllowDeletedFunc *StoreGetUploadsByIDsAllowDeletedFunc
 	// GetUploadsForRankingFunc is an instance of a mock function object
 	// controlling the behavior of the method GetUploadsForRanking.
 	GetUploadsForRankingFunc *StoreGetUploadsForRankingFunc
@@ -2686,6 +2690,11 @@ func NewMockStore() *MockStore {
 			},
 		},
 		GetUploadsByIDsFunc: &StoreGetUploadsByIDsFunc{
+			defaultHook: func(context.Context, ...int) (r0 []types.Upload, r1 error) {
+				return
+			},
+		},
+		GetUploadsByIDsAllowDeletedFunc: &StoreGetUploadsByIDsAllowDeletedFunc{
 			defaultHook: func(context.Context, ...int) (r0 []types.Upload, r1 error) {
 				return
 			},
@@ -2972,6 +2981,11 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.GetUploadsByIDs")
 			},
 		},
+		GetUploadsByIDsAllowDeletedFunc: &StoreGetUploadsByIDsAllowDeletedFunc{
+			defaultHook: func(context.Context, ...int) ([]types.Upload, error) {
+				panic("unexpected invocation of MockStore.GetUploadsByIDsAllowDeleted")
+			},
+		},
 		GetUploadsForRankingFunc: &StoreGetUploadsForRankingFunc{
 			defaultHook: func(context.Context, string, string, int) ([]store.ExportedUpload, error) {
 				panic("unexpected invocation of MockStore.GetUploadsForRanking")
@@ -3199,6 +3213,9 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		GetUploadsByIDsFunc: &StoreGetUploadsByIDsFunc{
 			defaultHook: i.GetUploadsByIDs,
+		},
+		GetUploadsByIDsAllowDeletedFunc: &StoreGetUploadsByIDsAllowDeletedFunc{
+			defaultHook: i.GetUploadsByIDsAllowDeleted,
 		},
 		GetUploadsForRankingFunc: &StoreGetUploadsForRankingFunc{
 			defaultHook: i.GetUploadsForRanking,
@@ -6337,6 +6354,124 @@ func (c StoreGetUploadsByIDsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreGetUploadsByIDsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StoreGetUploadsByIDsAllowDeletedFunc describes the behavior when the
+// GetUploadsByIDsAllowDeleted method of the parent MockStore instance is
+// invoked.
+type StoreGetUploadsByIDsAllowDeletedFunc struct {
+	defaultHook func(context.Context, ...int) ([]types.Upload, error)
+	hooks       []func(context.Context, ...int) ([]types.Upload, error)
+	history     []StoreGetUploadsByIDsAllowDeletedFuncCall
+	mutex       sync.Mutex
+}
+
+// GetUploadsByIDsAllowDeleted delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockStore) GetUploadsByIDsAllowDeleted(v0 context.Context, v1 ...int) ([]types.Upload, error) {
+	r0, r1 := m.GetUploadsByIDsAllowDeletedFunc.nextHook()(v0, v1...)
+	m.GetUploadsByIDsAllowDeletedFunc.appendCall(StoreGetUploadsByIDsAllowDeletedFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetUploadsByIDsAllowDeleted method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreGetUploadsByIDsAllowDeletedFunc) SetDefaultHook(hook func(context.Context, ...int) ([]types.Upload, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetUploadsByIDsAllowDeleted method of the parent MockStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *StoreGetUploadsByIDsAllowDeletedFunc) PushHook(hook func(context.Context, ...int) ([]types.Upload, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreGetUploadsByIDsAllowDeletedFunc) SetDefaultReturn(r0 []types.Upload, r1 error) {
+	f.SetDefaultHook(func(context.Context, ...int) ([]types.Upload, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreGetUploadsByIDsAllowDeletedFunc) PushReturn(r0 []types.Upload, r1 error) {
+	f.PushHook(func(context.Context, ...int) ([]types.Upload, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetUploadsByIDsAllowDeletedFunc) nextHook() func(context.Context, ...int) ([]types.Upload, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetUploadsByIDsAllowDeletedFunc) appendCall(r0 StoreGetUploadsByIDsAllowDeletedFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreGetUploadsByIDsAllowDeletedFuncCall
+// objects describing the invocations of this function.
+func (f *StoreGetUploadsByIDsAllowDeletedFunc) History() []StoreGetUploadsByIDsAllowDeletedFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetUploadsByIDsAllowDeletedFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetUploadsByIDsAllowDeletedFuncCall is an object that describes an
+// invocation of method GetUploadsByIDsAllowDeleted on an instance of
+// MockStore.
+type StoreGetUploadsByIDsAllowDeletedFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is a slice containing the values of the variadic arguments
+	// passed to this method invocation.
+	Arg1 []int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []types.Upload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation. The variadic slice argument is flattened in this array such
+// that one positional argument and three variadic arguments would result in
+// a slice of four, not two.
+func (c StoreGetUploadsByIDsAllowDeletedFuncCall) Args() []interface{} {
+	trailing := []interface{}{}
+	for _, val := range c.Arg1 {
+		trailing = append(trailing, val)
+	}
+
+	return append([]interface{}{c.Arg0}, trailing...)
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetUploadsByIDsAllowDeletedFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/internal/codeintel/uploads/internal/store/store.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store.go
@@ -46,6 +46,7 @@ type Store interface {
 	GetUploads(ctx context.Context, opts shared.GetUploadsOptions) (_ []types.Upload, _ int, err error)
 	GetUploadByID(ctx context.Context, id int) (_ types.Upload, _ bool, err error)
 	GetUploadsByIDs(ctx context.Context, ids ...int) (_ []types.Upload, err error)
+	GetUploadsByIDsAllowDeleted(ctx context.Context, ids ...int) (_ []types.Upload, err error)
 	GetUploadIDsWithReferences(ctx context.Context, orderedMonikers []precise.QualifiedMonikerData, ignoreIDs []int, repositoryID int, commit string, limit int, offset int, trace observation.TraceLogger) (ids []int, recordsScanned int, totalCount int, err error)
 	GetVisibleUploadsMatchingMonikers(ctx context.Context, repositoryID int, commit string, orderedMonikers []precise.QualifiedMonikerData, limit, offset int) (_ shared.PackageReferenceScanner, _ int, err error)
 	GetRecentUploadsSummary(ctx context.Context, repositoryID int) (upload []shared.UploadsWithRepositoryNamespace, err error)

--- a/enterprise/internal/codeintel/uploads/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/mocks_test.go
@@ -128,6 +128,10 @@ type MockStore struct {
 	// GetUploadsByIDsFunc is an instance of a mock function object
 	// controlling the behavior of the method GetUploadsByIDs.
 	GetUploadsByIDsFunc *StoreGetUploadsByIDsFunc
+	// GetUploadsByIDsAllowDeletedFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// GetUploadsByIDsAllowDeleted.
+	GetUploadsByIDsAllowDeletedFunc *StoreGetUploadsByIDsAllowDeletedFunc
 	// GetUploadsForRankingFunc is an instance of a mock function object
 	// controlling the behavior of the method GetUploadsForRanking.
 	GetUploadsForRankingFunc *StoreGetUploadsForRankingFunc
@@ -357,6 +361,11 @@ func NewMockStore() *MockStore {
 			},
 		},
 		GetUploadsByIDsFunc: &StoreGetUploadsByIDsFunc{
+			defaultHook: func(context.Context, ...int) (r0 []types.Upload, r1 error) {
+				return
+			},
+		},
+		GetUploadsByIDsAllowDeletedFunc: &StoreGetUploadsByIDsAllowDeletedFunc{
 			defaultHook: func(context.Context, ...int) (r0 []types.Upload, r1 error) {
 				return
 			},
@@ -643,6 +652,11 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.GetUploadsByIDs")
 			},
 		},
+		GetUploadsByIDsAllowDeletedFunc: &StoreGetUploadsByIDsAllowDeletedFunc{
+			defaultHook: func(context.Context, ...int) ([]types.Upload, error) {
+				panic("unexpected invocation of MockStore.GetUploadsByIDsAllowDeleted")
+			},
+		},
 		GetUploadsForRankingFunc: &StoreGetUploadsForRankingFunc{
 			defaultHook: func(context.Context, string, string, int) ([]store.ExportedUpload, error) {
 				panic("unexpected invocation of MockStore.GetUploadsForRanking")
@@ -870,6 +884,9 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		GetUploadsByIDsFunc: &StoreGetUploadsByIDsFunc{
 			defaultHook: i.GetUploadsByIDs,
+		},
+		GetUploadsByIDsAllowDeletedFunc: &StoreGetUploadsByIDsAllowDeletedFunc{
+			defaultHook: i.GetUploadsByIDsAllowDeleted,
 		},
 		GetUploadsForRankingFunc: &StoreGetUploadsForRankingFunc{
 			defaultHook: i.GetUploadsForRanking,
@@ -4008,6 +4025,124 @@ func (c StoreGetUploadsByIDsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreGetUploadsByIDsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StoreGetUploadsByIDsAllowDeletedFunc describes the behavior when the
+// GetUploadsByIDsAllowDeleted method of the parent MockStore instance is
+// invoked.
+type StoreGetUploadsByIDsAllowDeletedFunc struct {
+	defaultHook func(context.Context, ...int) ([]types.Upload, error)
+	hooks       []func(context.Context, ...int) ([]types.Upload, error)
+	history     []StoreGetUploadsByIDsAllowDeletedFuncCall
+	mutex       sync.Mutex
+}
+
+// GetUploadsByIDsAllowDeleted delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockStore) GetUploadsByIDsAllowDeleted(v0 context.Context, v1 ...int) ([]types.Upload, error) {
+	r0, r1 := m.GetUploadsByIDsAllowDeletedFunc.nextHook()(v0, v1...)
+	m.GetUploadsByIDsAllowDeletedFunc.appendCall(StoreGetUploadsByIDsAllowDeletedFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetUploadsByIDsAllowDeleted method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreGetUploadsByIDsAllowDeletedFunc) SetDefaultHook(hook func(context.Context, ...int) ([]types.Upload, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetUploadsByIDsAllowDeleted method of the parent MockStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *StoreGetUploadsByIDsAllowDeletedFunc) PushHook(hook func(context.Context, ...int) ([]types.Upload, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreGetUploadsByIDsAllowDeletedFunc) SetDefaultReturn(r0 []types.Upload, r1 error) {
+	f.SetDefaultHook(func(context.Context, ...int) ([]types.Upload, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreGetUploadsByIDsAllowDeletedFunc) PushReturn(r0 []types.Upload, r1 error) {
+	f.PushHook(func(context.Context, ...int) ([]types.Upload, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetUploadsByIDsAllowDeletedFunc) nextHook() func(context.Context, ...int) ([]types.Upload, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetUploadsByIDsAllowDeletedFunc) appendCall(r0 StoreGetUploadsByIDsAllowDeletedFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreGetUploadsByIDsAllowDeletedFuncCall
+// objects describing the invocations of this function.
+func (f *StoreGetUploadsByIDsAllowDeletedFunc) History() []StoreGetUploadsByIDsAllowDeletedFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetUploadsByIDsAllowDeletedFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetUploadsByIDsAllowDeletedFuncCall is an object that describes an
+// invocation of method GetUploadsByIDsAllowDeleted on an instance of
+// MockStore.
+type StoreGetUploadsByIDsAllowDeletedFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is a slice containing the values of the variadic arguments
+	// passed to this method invocation.
+	Arg1 []int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []types.Upload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation. The variadic slice argument is flattened in this array such
+// that one positional argument and three variadic arguments would result in
+// a slice of four, not two.
+func (c StoreGetUploadsByIDsAllowDeletedFuncCall) Args() []interface{} {
+	trailing := []interface{}{}
+	for _, val := range c.Arg1 {
+		trailing = append(trailing, val)
+	}
+
+	return append([]interface{}{c.Arg0}, trailing...)
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetUploadsByIDsAllowDeletedFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 


### PR DESCRIPTION
We don't want to filter out upload records when reconciling data between the two databases. This causes additional contention when the same batch is deleted from two different worker routines.

We now only delete truly abandoned data, not just data that's in the period between being marked as deletable and the hard deletion routine running.

## Test plan

Tested by hand.