### PR TITLE
codeintel: Add index on SCIP table to speed up cascading deletes

### DIFF
--- a/internal/database/schema.codeintel.json
+++ b/internal/database/schema.codeintel.json
@@ -713,6 +713,16 @@
           "IndexDefinition": "CREATE UNIQUE INDEX codeintel_scip_symbols_pkey ON codeintel_scip_symbols USING btree (upload_id, symbol_name, document_lookup_id)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (upload_id, symbol_name, document_lookup_id)"
+        },
+        {
+          "Name": "codeintel_scip_symbols_document_lookup_id",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX codeintel_scip_symbols_document_lookup_id ON codeintel_scip_symbols USING btree (document_lookup_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [

--- a/internal/database/schema.codeintel.md
+++ b/internal/database/schema.codeintel.md
@@ -157,6 +157,7 @@ Global metadatadata about a single processed upload.
  type_definition_ranges | bytea   |           |          | 
 Indexes:
     "codeintel_scip_symbols_pkey" PRIMARY KEY, btree (upload_id, symbol_name, document_lookup_id)
+    "codeintel_scip_symbols_document_lookup_id" btree (document_lookup_id)
 Foreign-key constraints:
     "codeintel_scip_symbols_document_lookup_id_fk" FOREIGN KEY (document_lookup_id) REFERENCES codeintel_scip_document_lookup(id) ON DELETE CASCADE
 

--- a/migrations/codeintel/1670001463_add_missing_index_for_cascading_deletes/down.sql
+++ b/migrations/codeintel/1670001463_add_missing_index_for_cascading_deletes/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS codeintel_scip_symbols_document_lookup_id;

--- a/migrations/codeintel/1670001463_add_missing_index_for_cascading_deletes/metadata.yaml
+++ b/migrations/codeintel/1670001463_add_missing_index_for_cascading_deletes/metadata.yaml
@@ -1,0 +1,2 @@
+name: Add missing index for cascading deletes
+parents: [1669934289]

--- a/migrations/codeintel/1670001463_add_missing_index_for_cascading_deletes/up.sql
+++ b/migrations/codeintel/1670001463_add_missing_index_for_cascading_deletes/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS codeintel_scip_symbols_document_lookup_id ON codeintel_scip_symbols(document_lookup_id);

--- a/migrations/codeintel/squashed.sql
+++ b/migrations/codeintel/squashed.sql
@@ -670,6 +670,8 @@ CREATE INDEX codeintel_last_reconcile_last_reconcile_at_dump_id ON codeintel_las
 
 CREATE INDEX codeintel_scip_document_lookup_document_id ON codeintel_scip_document_lookup USING hash (document_id);
 
+CREATE INDEX codeintel_scip_symbols_document_lookup_id ON codeintel_scip_symbols USING btree (document_lookup_id);
+
 CREATE INDEX lsif_data_definitions_dump_id_schema_version ON lsif_data_definitions USING btree (dump_id, schema_version);
 
 CREATE INDEX lsif_data_definitions_schema_versions_dump_id_schema_version_bo ON lsif_data_definitions_schema_versions USING btree (dump_id, min_schema_version, max_schema_version);


### PR DESCRIPTION
Add index to lookup symbols by the field that can cause their own cascaded delete.

Thanks @Strum355 for finding this as a cause of slow batch deletes when I was looking at stuff locally.

## Test plan

N/A.