### PR TITLE
batches: refactor log output test for TestSyncerRun

### DIFF
--- a/dev/ci/go-backcompat/flakefiles/v4.2.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.2.0.json
@@ -48,10 +48,5 @@
     "path": "enterprise/internal/batches/store",
     "prefix": "TestIntegration",
     "reason": "Added a UNIQUE constraint on batch_specs.rand_id and changeset_specs.rand_id, some tests fail because we had some duplicate Rand ID creation in tests."
-  },
-  {
-    "path": "enterprise/internal/batches/syncer",
-    "prefix": "SyncerRun/Sync_due_but_reenqueued_when_namespace_deleted",
-    "reason": "Test expectation is too narrow and is broken by new logging code"
   }
 ]

--- a/dev/ci/go-backcompat/flakefiles/v4.2.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.2.0.json
@@ -48,5 +48,10 @@
     "path": "enterprise/internal/batches/store",
     "prefix": "TestIntegration",
     "reason": "Added a UNIQUE constraint on batch_specs.rand_id and changeset_specs.rand_id, some tests fail because we had some duplicate Rand ID creation in tests."
+  },
+  {
+    "path": "enterprise/internal/batches/syncer",
+    "prefix": "SyncerRun/Sync_due_but_reenqueued_when_namespace_deleted",
+    "reason": "Test expectation is too narrow and is broken by new logging code"
   }
 ]

--- a/enterprise/internal/batches/syncer/syncer_test.go
+++ b/enterprise/internal/batches/syncer/syncer_test.go
@@ -217,8 +217,13 @@ func TestSyncerRun(t *testing.T) {
 		// ensure the deleted namespace error is logged as a debug
 		captured := export()
 		assert.Greater(t, len(captured), 0)
-		assert.Equal(t, log.LevelDebug, captured[2].Level)
-		assert.Equal(t, "SyncChangeset skipping changeset: namespace deleted", captured[2].Message)
+		var found bool
+		for _, c := range captured {
+			if c.Level == log.LevelDebug && c.Message == "SyncChangeset skipping changeset: namespace deleted" {
+				found = true
+			}
+		}
+		assert.True(t, found, "namespace deleted log was not captured")
 	})
 }
 


### PR DESCRIPTION
Closes #44947

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
It's a bit hard to test but tests seem to be passing and we don't directly access the slice index in the tests anymore, so at least it won't flake for the same reason as before (if it does flake again).