### PR TITLE
searcher: return early for foundResults

### DIFF
--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -218,21 +218,23 @@ func zoektSearchIgnorePaths(ctx context.Context, client zoekt.Streamer, p *proto
 		return false, err
 	}
 
-	// we have no matches, so we don't know if we searched the correct commit.
-	if !foundResults {
-		newIndexed, ok, err := zoektIndexedCommit(ctx, client, p.Repo)
-		if err != nil {
-			return false, errors.Wrap(err, "failed to double check indexed commit")
-		}
-		if !ok {
-			// let the retry logic handle the call to zoektIndexedCommit again
-			return false, nil
-		}
-		retry := newIndexed != indexed
-		return !retry, nil
+	// We found results and we got past wrongCommit, so we know what we have
+	// streamed back is correct.
+	if foundResults {
+		return true, nil
 	}
 
-	return true, nil
+	// we have no matches, so we don't know if we searched the correct commit
+	newIndexed, ok, err := zoektIndexedCommit(ctx, client, p.Repo)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to double check indexed commit")
+	}
+	if !ok {
+		// let the retry logic handle the call to zoektIndexedCommit again
+		return false, nil
+	}
+	retry := newIndexed != indexed
+	return !retry, nil
 }
 
 // zoektCompile builds a text search zoekt query for p.


### PR DESCRIPTION
This is a minor code improvement which makes a later change more
readable.

Test Plan: go test

plz-review-url: https://plz.review/review/15467