### PR TITLE
codeintel: Fix deadlocks in deletion queries

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_delete.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_delete.go
@@ -7,31 +7,15 @@ import (
 	"strings"
 
 	"github.com/keegancsmith/sqlf"
+	"github.com/lib/pq"
 	otlog "github.com/opentracing/opentracing-go/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-var tableNames = map[string]string{
-	"lsif_data_metadata":                        "dump_id",
-	"lsif_data_documents":                       "dump_id",
-	"lsif_data_documents_schema_versions":       "dump_id",
-	"lsif_data_result_chunks":                   "dump_id",
-	"lsif_data_definitions":                     "dump_id",
-	"lsif_data_definitions_schema_versions":     "dump_id",
-	"lsif_data_references":                      "dump_id",
-	"lsif_data_references_schema_versions":      "dump_id",
-	"lsif_data_implementations":                 "dump_id",
-	"lsif_data_implementations_schema_versions": "dump_id",
-	"codeintel_last_reconcile":                  "dump_id",
-	"codeintel_scip_metadata":                   "upload_id",
-	"codeintel_scip_document_lookup":            "upload_id",
-	"codeintel_scip_symbols":                    "upload_id",
-}
-
 // DeleteLsifDataByUploadIds deletes LSIF data by UploadIds from the lsif database.
 func (s *store) DeleteLsifDataByUploadIds(ctx context.Context, bundleIDs ...int) (err error) {
-	ctx, trace, endObservation := s.operations.deleteLsifDataByUploadIds.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
+	ctx, _, endObservation := s.operations.deleteLsifDataByUploadIds.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
 		otlog.Int("numBundleIDs", len(bundleIDs)),
 		otlog.String("bundleIDs", intsToString(bundleIDs)),
 	}})
@@ -41,16 +25,42 @@ func (s *store) DeleteLsifDataByUploadIds(ctx context.Context, bundleIDs ...int)
 		return nil
 	}
 
-	// Ensure ids are sorted so that we take row locks during the
-	// DELETE query in a determinstic order. This should prevent
-	// deadlocks with other queries that mass update the same table.
-	sort.Ints(bundleIDs)
-
-	var ids []*sqlf.Query
-	for _, bundleID := range bundleIDs {
-		ids = append(ids, sqlf.Sprintf("%d", bundleID))
+	if err := s.deleteLSIFData(ctx, bundleIDs); err != nil {
+		return err
 	}
 
+	if err := s.deleteSCIPData(ctx, bundleIDs); err != nil {
+		return err
+	}
+
+	if err := s.db.Exec(ctx, sqlf.Sprintf(deleteLastReconcileQuery, pq.Array(bundleIDs))); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+const deleteLastReconcileQuery = `
+WITH locked_rows AS (
+	SELECT dump_id
+	FROM codeintel_last_reconcile
+	WHERE dump_id = ANY(%s)
+	ORDER BY dump_id
+	FOR UPDATE
+)
+DELETE FROM codeintel_last_reconcile WHERE dump_id IN (SELECT dump_id FROM locked_rows)
+`
+
+var lsifDataTables = []string{
+	"lsif_data_metadata",
+	"lsif_data_documents",
+	"lsif_data_result_chunks",
+	"lsif_data_definitions",
+	"lsif_data_references",
+	"lsif_data_implementations",
+}
+
+func (s *store) deleteLSIFData(ctx context.Context, uploadIDs []int) error {
 	tx, err := s.db.Transact(ctx)
 	if err != nil {
 		return err
@@ -59,20 +69,65 @@ func (s *store) DeleteLsifDataByUploadIds(ctx context.Context, bundleIDs ...int)
 		err = tx.Done(err)
 	}()
 
-	for tableName, fieldName := range tableNames {
-		trace.Log(otlog.String("tableName", tableName))
+	// Ensure ids are sorted so that we take row locks during the DELETE query
+	// in a deterministic order. This should prevent deadlocks with other queries
+	// that mass update the same table.
+	sort.Ints(uploadIDs)
 
-		query := sqlf.Sprintf(deleteQuery, sqlf.Sprintf(tableName), sqlf.Sprintf(fieldName), sqlf.Join(ids, ","))
+	for _, tableName := range lsifDataTables {
+		query := sqlf.Sprintf(`DELETE FROM %s WHERE dump_id = ANY(%s)`, sqlf.Sprintf(tableName), pq.Array(uploadIDs))
 		if err := tx.Exec(ctx, query); err != nil {
 			return err
 		}
+
 	}
 
 	return nil
 }
 
-const deleteQuery = `
-DELETE FROM %s WHERE %s IN (%s)
+func (s *store) deleteSCIPData(ctx context.Context, uploadIDs []int) error {
+	tx, err := s.db.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = tx.Done(err)
+	}()
+
+	if err := tx.Exec(ctx, sqlf.Sprintf(deleteSCIPDocumentLookupQuery, pq.Array(uploadIDs))); err != nil {
+		return err
+	}
+	if err := tx.Exec(ctx, sqlf.Sprintf(deleteSCIPMetadataQuery, pq.Array(uploadIDs))); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+const deleteSCIPMetadataQuery = `
+ WITH
+ locked_metadata AS (
+ 	SELECT id
+ 	FROM codeintel_scip_metadata
+ 	WHERE upload_id = ANY(%s)
+ 	ORDER BY id
+ 	FOR UPDATE
+ )
+DELETE FROM codeintel_scip_metadata
+WHERE id IN (SELECT id FROM locked_metadata)
+`
+
+const deleteSCIPDocumentLookupQuery = `
+WITH
+locked_document_lookup AS (
+	SELECT id
+	FROM codeintel_scip_document_lookup
+	WHERE upload_id = ANY(%s)
+	ORDER BY id
+	FOR UPDATE
+)
+DELETE FROM codeintel_scip_document_lookup
+WHERE id IN (SELECT id FROM locked_document_lookup)
 `
 
 func intsToString(vs []int) string {


### PR DESCRIPTION
I've noticed some deadlock conditions when iterating over these items in a map. I've split them out to be very consistent and deterministically ordered for deletions.

## Test plan

Existing unit tests, tested by hand locally.