### PR TITLE
RFC 740: Update `reconcileCandidates` query to reduce union size

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_reconcile.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_reconcile.go
@@ -42,19 +42,32 @@ func (s *store) ReconcileCandidates(ctx context.Context, batchSize int) (_ []int
 }
 
 func (s *store) reconcileCandidates(ctx context.Context, batchSize int, now time.Time) (_ []int, err error) {
-	return basestore.ScanInts(s.db.Query(ctx, sqlf.Sprintf(reconcileQuery, batchSize, now, now)))
+	return basestore.ScanInts(s.db.Query(ctx, sqlf.Sprintf(reconcileQuery, batchSize, batchSize, now, now)))
 }
 
 const reconcileQuery = `
-WITH candidates AS (
+WITH
+lsif_candidates AS (
 	SELECT m.dump_id
-	FROM (SELECT dump_id FROM lsif_data_metadata UNION SELECT upload_id FROM codeintel_scip_metadata) m
+	FROM lsif_data_metadata m
 	LEFT JOIN codeintel_last_reconcile lr ON lr.dump_id = m.dump_id
 	ORDER BY lr.last_reconcile_at NULLS FIRST, m.dump_id
 	LIMIT %s
+),
+scip_candidates AS (
+	SELECT m.upload_id
+	FROM codeintel_scip_metadata m
+	LEFT JOIN codeintel_last_reconcile lr ON lr.dump_id = m.upload_id
+	ORDER BY lr.last_reconcile_at NULLS FIRST, m.upload_id
+	LIMIT %s
+),
+combined_candidates AS (
+	SELECT dump_id FROM lsif_candidates
+	UNION
+	SELECT upload_id FROM scip_candidates
 )
 INSERT INTO codeintel_last_reconcile
-SELECT dump_id, %s FROM candidates
+SELECT dump_id, %s FROM combined_candidates
 ON CONFLICT (dump_id) DO UPDATE
 SET last_reconcile_at = %s
 RETURNING dump_id

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_reconcile_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_reconcile_test.go
@@ -87,7 +87,7 @@ func TestReconcileCandidates(t *testing.T) {
 	}
 
 	// Initial batch of records
-	ids, err := store.reconcileCandidates(ctx, 8, now)
+	ids, err := store.reconcileCandidates(ctx, 4, now)
 	if err != nil {
 		t.Fatalf("failed to get candidate IDs for reconciliation: %s", err)
 	}
@@ -96,28 +96,28 @@ func TestReconcileCandidates(t *testing.T) {
 		101,
 		102,
 		103,
-		104,
-		105,
 		200,
 		201,
+		202,
+		203,
 	}
 	sort.Ints(ids)
 	if diff := cmp.Diff(expectedIDs, ids); diff != "" {
 		t.Fatalf("unexpected IDs (-want +got):\n%s", diff)
 	}
 
-	// Remaining records, wrap around
-	ids, err = store.reconcileCandidates(ctx, 8, now.Add(time.Minute*1))
+	// Wraps around after exhausting first records
+	ids, err = store.reconcileCandidates(ctx, 4, now.Add(time.Minute*1))
 	if err != nil {
 		t.Fatalf("failed to get candidate IDs for reconciliation: %s", err)
 	}
 	expectedIDs = []int{
 		100,
 		101,
-		102,
-		103,
-		202,
-		203,
+		104,
+		105,
+		200,
+		201,
 		204,
 		205,
 	}
@@ -126,16 +126,16 @@ func TestReconcileCandidates(t *testing.T) {
 		t.Fatalf("unexpected IDs (-want +got):\n%s", diff)
 	}
 
-	// ...and continues to wrap
-	ids, err = store.reconcileCandidates(ctx, 4, now.Add(time.Minute*2))
+	// Continues to wrap around
+	ids, err = store.reconcileCandidates(ctx, 2, now.Add(time.Minute*2))
 	if err != nil {
 		t.Fatalf("failed to get candidate IDs for reconciliation: %s", err)
 	}
 	expectedIDs = []int{
-		104,
-		105,
-		200,
-		201,
+		102,
+		103,
+		202,
+		203,
 	}
 	sort.Ints(ids)
 	if diff := cmp.Diff(expectedIDs, ids); diff != "" {


### PR DESCRIPTION
Remove a possibly giant union so that the where conditions are guaranteed to be pushed down. This may double the batch size, but this should be a fairly cheap downstream operation.

## Test plan

Existing unit tests.