### PR TITLE
blobstore: use port 9000 by default

### DIFF
--- a/cmd/server/shared/blobstore.go
+++ b/cmd/server/shared/blobstore.go
@@ -21,14 +21,13 @@ func maybeBlobstore(logger sglog.Logger) []string {
 	// Note: SetDefaultEnv should be called only once for the same env var, so
 	// ensure these do not conflict with the default list set below.
 	dataDir := filepath.Join(os.Getenv("DATA_DIR"), "blobstore")
-	SetDefaultEnv("S3PROXY_ENDPOINT", "http://0.0.0.0:9000")
 	SetDefaultEnv("JCLOUDS_FILESYSTEM_BASEDIR", dataDir)
 
 	// Default blobstore env vars copied from the Dockerfile
 	// https://github.com/sourcegraph/sourcegraph/blob/main/docker-images/blobstore/Dockerfile
 	SetDefaultEnv("LOG_LEVEL", "info")
 	SetDefaultEnv("S3PROXY_AUTHORIZATION", "none")
-	// SetDefaultEnv("S3PROXY_ENDPOINT", "http://0.0.0.0:80") // overridden above; here for equality with Dockerfile
+	SetDefaultEnv("S3PROXY_ENDPOINT", "http://0.0.0.0:9000")
 	SetDefaultEnv("S3PROXY_IDENTITY", "local-identity")
 	SetDefaultEnv("S3PROXY_CREDENTIAL", "local-credential")
 	SetDefaultEnv("S3PROXY_VIRTUALHOST", "")

--- a/docker-images/blobstore/Dockerfile
+++ b/docker-images/blobstore/Dockerfile
@@ -35,7 +35,7 @@ COPY --from=builder /opt/s3proxy /opt/s3proxy
 ENV \
     LOG_LEVEL="info" \
     S3PROXY_AUTHORIZATION="none" \
-    S3PROXY_ENDPOINT="http://0.0.0.0:80" \
+    S3PROXY_ENDPOINT="http://0.0.0.0:9000" \
     S3PROXY_IDENTITY="local-identity" \
     S3PROXY_CREDENTIAL="local-credential" \
     S3PROXY_VIRTUALHOST="" \
@@ -59,7 +59,7 @@ ENV \
     JCLOUDS_KEYSTONE_PROJECT_DOMAIN_NAME="" \
     JCLOUDS_FILESYSTEM_BASEDIR="/data"
 
-EXPOSE 80
+EXPOSE 9000
 USER sourcegraph
 WORKDIR /opt/s3proxy
 ENTRYPOINT ["/sbin/tini", "--", "/opt/s3proxy/run-docker-container.sh"]


### PR DESCRIPTION
All deployments will have blobstore serve on port 9000, so default to this in the Dockerfile so it doesn't need to be configured everywhere.

Helps https://github.com/sourcegraph/sourcegraph/issues/44254

## Test plan

existing tests + `sg ci build main-dry-run` to confirm I don't break `main` again by accident
