### PR TITLE
search contexts: fix dropdown size regression

### DIFF
--- a/client/search-ui/src/input/SearchContextMenu.module.scss
+++ b/client/search-ui/src/input/SearchContextMenu.module.scss
@@ -1,7 +1,8 @@
 .container {
     display: flex;
     flex-direction: column;
-    max-width: 31rem;
+    width: 31rem;
+    max-width: 100%;
 }
 
 .header {


### PR DESCRIPTION
Fixes a small regression from #44434 where the search context dropdown would shrink to fit its contents, causing the size to change while loading, searching, etc.

## Test plan

Storybook tests

## App preview:

- [Web](https://sg-web-jp-fixcontextdropdownsize.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
