### PR TITLE
Update CodeMirrorQueryInput.tsx

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -776,11 +776,11 @@ function getTokensTooltipInformation(
                 break
             case 'keyword':
                 switch (token.kind) {
-                    case KeywordKind.Or:
+                    case KeywordKind.And:
                         values.push('Find results which match both the left and the right expression.')
                         range = token.range
                         break
-                    case KeywordKind.And:
+                    case KeywordKind.Or:
                         values.push('Find results which match the left or the right expression.')
                         range = token.range
                         break


### PR DESCRIPTION
Fix: Hover tooltips for AND and OR operators were reversed



## Test plan
CI, manual inspection

## App preview:

- [Web](https://sg-web-j-tooltip.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
