### PR TITLE
extract enterprise frontend to shared package for external invocation

### DIFF
--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -1,122 +1,17 @@
-// Command frontend contains the enterprise frontend implementation.
-//
-// It wraps the open source frontend command and merely injects a few
-// proprietary things into it via e.g. blank/underscore imports in this file
-// which register side effects with the frontend package.
+// Command frontend is the enterprise frontend program.
 package main
 
 import (
-	"context"
-	"os"
-	"strconv"
-
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sourcegraph/log"
-	"go.opentelemetry.io/otel"
-
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/app"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/authz"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/batches"
-	codeintelinit "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codemonitors"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/compute"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/dotcom"
-	executor "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executorqueue"
-	licensing "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing/init"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/notebooks"
+	shared "github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/repos"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/searchcontexts"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel"
-	codeintelshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/sourcegraph/sourcegraph/internal/database"
-	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
-	"github.com/sourcegraph/sourcegraph/internal/observation"
+	shared_enterprise "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/shared"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
-	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
 func main() {
-	shared.Main(enterpriseSetupHook)
+	shared.Main(shared_enterprise.EnterpriseSetupHook)
 }
 
 func init() {
 	oobmigration.ReturnEnterpriseMigrations = true
-}
-
-type EnterpriseInitializer = func(context.Context, database.DB, codeintel.Services, conftypes.UnifiedWatchable, *enterprise.Services, *observation.Context) error
-
-var initFunctions = map[string]EnterpriseInitializer{
-	"app":            app.Init,
-	"authz":          authz.Init,
-	"batches":        batches.Init,
-	"codeintel":      codeintelinit.Init,
-	"codemonitors":   codemonitors.Init,
-	"compute":        compute.Init,
-	"dotcom":         dotcom.Init,
-	"insights":       insights.Init,
-	"licensing":      licensing.Init,
-	"notebooks":      notebooks.Init,
-	"searchcontexts": searchcontexts.Init,
-	"repos":          repos.Init,
-}
-
-func enterpriseSetupHook(db database.DB, conf conftypes.UnifiedWatchable) enterprise.Services {
-	logger := log.Scoped("enterprise", "frontend enterprise edition")
-	debug, _ := strconv.ParseBool(os.Getenv("DEBUG"))
-	if debug {
-		logger.Debug("enterprise edition")
-	}
-
-	auth.Init(logger, db)
-
-	ctx := context.Background()
-	enterpriseServices := enterprise.DefaultServices()
-
-	observationContext := &observation.Context{
-		Logger:     logger,
-		Tracer:     &trace.Tracer{TracerProvider: otel.GetTracerProvider()},
-		Registerer: prometheus.DefaultRegisterer,
-	}
-
-	codeIntelServices, err := codeintel.NewServices(codeintel.Databases{
-		DB:          db,
-		CodeIntelDB: mustInitializeCodeIntelDB(logger),
-	})
-	if err != nil {
-		logger.Fatal("failed to initialize code intelligence", log.Error(err))
-	}
-
-	for name, fn := range initFunctions {
-		if err := fn(ctx, db, codeIntelServices, conf, &enterpriseServices, observationContext); err != nil {
-			logger.Fatal("failed to initialize", log.String("name", name), log.Error(err))
-		}
-	}
-
-	// Inititalize executor last, as we require code intel and batch changes services to be
-	// already populated on the enterpriseServices object.
-	if err := executor.Init(ctx, db, conf, &enterpriseServices, observationContext); err != nil {
-		logger.Fatal("failed to initialize executor", log.Error(err))
-	}
-
-	return enterpriseServices
-}
-
-func mustInitializeCodeIntelDB(logger log.Logger) codeintelshared.CodeIntelDB {
-	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
-		return serviceConnections.CodeIntelPostgresDSN
-	})
-
-	db, err := connections.EnsureNewCodeIntelDB(dsn, "frontend", &observation.TestContext)
-	if err != nil {
-		logger.Fatal("Failed to connect to codeintel database", log.Error(err))
-	}
-
-	return codeintelshared.NewCodeIntelDB(db)
 }

--- a/enterprise/cmd/frontend/shared/shared.go
+++ b/enterprise/cmd/frontend/shared/shared.go
@@ -1,0 +1,112 @@
+// Package shared is the enterprise frontend program's shared main entrypoint.
+//
+// It lets the invoker of the OSS frontend shared entrypoint injects a few
+// proprietary things into it via e.g. blank/underscore imports in this file
+// which register side effects with the frontend package.
+package shared
+
+import (
+	"context"
+	"os"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sourcegraph/log"
+	"go.opentelemetry.io/otel"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/app"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/authz"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/batches"
+	codeintelinit "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codemonitors"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/compute"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/dotcom"
+	executor "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executorqueue"
+	licensing "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing/init"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/notebooks"
+	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/repos"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/searchcontexts"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel"
+	codeintelshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+type EnterpriseInitializer = func(context.Context, database.DB, codeintel.Services, conftypes.UnifiedWatchable, *enterprise.Services, *observation.Context) error
+
+var initFunctions = map[string]EnterpriseInitializer{
+	"app":            app.Init,
+	"authz":          authz.Init,
+	"batches":        batches.Init,
+	"codeintel":      codeintelinit.Init,
+	"codemonitors":   codemonitors.Init,
+	"compute":        compute.Init,
+	"dotcom":         dotcom.Init,
+	"insights":       insights.Init,
+	"licensing":      licensing.Init,
+	"notebooks":      notebooks.Init,
+	"searchcontexts": searchcontexts.Init,
+	"repos":          repos.Init,
+}
+
+func EnterpriseSetupHook(db database.DB, conf conftypes.UnifiedWatchable) enterprise.Services {
+	logger := log.Scoped("enterprise", "frontend enterprise edition")
+	debug, _ := strconv.ParseBool(os.Getenv("DEBUG"))
+	if debug {
+		logger.Debug("enterprise edition")
+	}
+
+	auth.Init(logger, db)
+
+	ctx := context.Background()
+	enterpriseServices := enterprise.DefaultServices()
+
+	observationContext := &observation.Context{
+		Logger:     logger,
+		Tracer:     &trace.Tracer{TracerProvider: otel.GetTracerProvider()},
+		Registerer: prometheus.DefaultRegisterer,
+	}
+
+	codeIntelServices, err := codeintel.NewServices(codeintel.Databases{
+		DB:          db,
+		CodeIntelDB: mustInitializeCodeIntelDB(logger),
+	})
+	if err != nil {
+		logger.Fatal("failed to initialize code intelligence", log.Error(err))
+	}
+
+	for name, fn := range initFunctions {
+		if err := fn(ctx, db, codeIntelServices, conf, &enterpriseServices, observationContext); err != nil {
+			logger.Fatal("failed to initialize", log.String("name", name), log.Error(err))
+		}
+	}
+
+	// Inititalize executor last, as we require code intel and batch changes services to be
+	// already populated on the enterpriseServices object.
+	if err := executor.Init(ctx, db, conf, &enterpriseServices, observationContext); err != nil {
+		logger.Fatal("failed to initialize executor", log.Error(err))
+	}
+
+	return enterpriseServices
+}
+
+func mustInitializeCodeIntelDB(logger log.Logger) codeintelshared.CodeIntelDB {
+	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
+		return serviceConnections.CodeIntelPostgresDSN
+	})
+
+	db, err := connections.EnsureNewCodeIntelDB(dsn, "frontend", &observation.TestContext)
+	if err != nil {
+		logger.Fatal("Failed to connect to codeintel database", log.Error(err))
+	}
+
+	return codeintelshared.NewCodeIntelDB(db)
+}


### PR DESCRIPTION
This is a copy-and-paste of the cmd/enterprise/frontend enterprise service constructors to a shared package so that the enterprise frontend can be invoked from a different entrypoint. There are no logic changes.

Related: https://github.com/sourcegraph/sourcegraph/pull/45112 https://github.com/sourcegraph/sourcegraph/pull/45113

## Test plan

Just a code move. No behavior change, so no manual test plan needed.