### PR TITLE
suppress warning log when no tracer type is set

### DIFF
--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -131,6 +131,8 @@ func newTracer(logger log.Logger, opts *options) (opentracing.Tracer, oteltrace.
 	case Jaeger:
 		exporter, err = exporters.NewJaegerExporter()
 
+	case None:
+
 	default:
 		err = errors.Newf("unknown tracer type %q", opts.TracerType)
 	}


### PR DESCRIPTION
None is a valid tracer type that means "don't send traces", and using it should not cause a warning log "unknown tracer type" to be printed.

## Test plan

Just affects log output, no manual test plan needed.