### PR TITLE
fix s3proxy (blobstore) port in sg config

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -556,7 +556,7 @@ commands:
         --name=$CONTAINER \
         --cpus=1 \
         --memory=1g \
-        -p 0.0.0.0:9000:80 \
+        -p 0.0.0.0:9000:9000 \
         -e 'S3PROXY_AUTHORIZATION=none' \
         -v "$BLOBSTORE_DISK":/data \
         $IMAGE >"$BLOBSTORE_LOG_FILE" 2>&1


### PR DESCRIPTION
The blobstore Docker image specifies a container listen port of 9000 (`S3PROXY_ENDPOINT="http://0.0.0.0:9000"`), but this `docker run --publish` flag in sg.config.yaml points to a container port of 80. This commit updates sg.config.yaml to use the correct port (9000).


## Test plan

Dev only, no test plan needed.