### PR TITLE
remove external URL inference from nginx/http listen addresses

### DIFF
--- a/cmd/frontend/globals/globals.go
+++ b/cmd/frontend/globals/globals.go
@@ -14,14 +14,14 @@ import (
 
 var externalURLWatchers uint32
 
-var defaultexternalURL = &url.URL{
+var defaultExternalURL = &url.URL{
 	Scheme: "http",
 	Host:   "example.com",
 }
 
 var externalURL = func() atomic.Value {
 	var v atomic.Value
-	v.Store(defaultexternalURL)
+	v.Store(defaultExternalURL)
 	return v
 }()
 
@@ -35,7 +35,7 @@ func WatchExternalURL(defaultURL *url.URL) {
 	}
 
 	if defaultURL == nil {
-		defaultURL = defaultexternalURL
+		defaultURL = defaultExternalURL
 	}
 
 	conf.Watch(func() {

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -81,24 +80,6 @@ var (
 	// production browser extension ID. This is found by viewing our extension in the chrome store.
 	prodExtension = "chrome-extension://dgjhfomjieaadpoljlnidmbgkdffpack"
 )
-
-// defaultExternalURL returns the default external URL of the application.
-func defaultExternalURL(nginxAddr, httpAddr string) *url.URL {
-	addr := nginxAddr
-	if addr == "" {
-		addr = httpAddr
-	}
-
-	var hostPort string
-	if strings.HasPrefix(addr, ":") {
-		// Prepend localhost if HTTP listen addr is just a port.
-		hostPort = "127.0.0.1" + addr
-	} else {
-		hostPort = addr
-	}
-
-	return &url.URL{Scheme: "http", Host: hostPort}
-}
 
 // InitDB initializes and returns the global database connection and sets the
 // version of the frontend in our versions table.
@@ -253,7 +234,7 @@ func Main(enterpriseSetupHook func(database.DB, conftypes.UnifiedWatchable) ente
 	siteid.Init(db)
 
 	globals.WatchBranding()
-	globals.WatchExternalURL(defaultExternalURL(nginxAddr, httpAddr))
+	globals.WatchExternalURL()
 	globals.WatchPermissionsUserMapping()
 
 	goroutine.Go(func() { bg.CheckRedisCacheEvictionPolicy() })

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -222,7 +222,7 @@ func Main(enterpriseInit EnterpriseInit) {
 		otel.GetTracerProvider(),
 	)(server.Handler())
 
-	globals.WatchExternalURL(nil)
+	globals.WatchExternalURL()
 
 	debugDumpers["repos"] = updateScheduler
 	debugserverEndpoints.repoUpdaterStateEndpoint = repoUpdaterStatsHandler(debugDumpers)


### PR DESCRIPTION
If externalURL was not set in site config, the externalURL would be inferred from the listen address. This is undesirable for several reasons:

- It is a rarely used (because externalURL is almost always set) and untested code path.
- It is not guaranteed to be correct, and an incorrect value here would cause confusion.
- If the externalURL is not set, it's still possible to access the web app and change the site config to fix it.
- The inference is only possible from frontend, not repo-updater, so a default of http://example.com would be use in repo-updater. Different behavior here can lead to a bug.

If an instance relied on this behavior, then the site admin will need to add externalURL to site config. It is extremely unlikely that a real, production instance relied on this behavior because only `http://` URLs would be inferred, and it's unlikely that a real production instance would use `http://`.

## Test plan

Run Sourcegraph in dev mode with no externaLURL in site config. It is still accessible (even though it internally defaults to an externalURL of http://example.com).