### PR TITLE
call env.Lock() outside of shared main

### DIFF
--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 
 // Note: All frontend code should be added to shared.Main, not here. See that
@@ -15,6 +16,9 @@ func main() {
 	// Set dummy authz provider to unblock channel for checking permissions in GraphQL APIs.
 	// See https://github.com/sourcegraph/sourcegraph/issues/3847 for details.
 	authz.SetProviders(true, []authz.Provider{})
+
+	env.Lock()
+	env.HandleHelpFlag()
 
 	shared.Main(func(_ database.DB, _ conftypes.UnifiedWatchable) enterprise.Services {
 		return enterprise.DefaultServices()

--- a/cmd/frontend/shared/frontend.go
+++ b/cmd/frontend/shared/frontend.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/env"
 
 	_ "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
 )
@@ -20,7 +19,6 @@ import (
 // main package implementations such as Sourcegraph Enterprise, which import
 // proprietary/private code.
 func Main(enterpriseSetupHook func(database.DB, conftypes.UnifiedWatchable) enterprise.Services) {
-	env.Lock()
 	err := cli.Main(enterpriseSetupHook)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "fatal:", err)

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -1,8 +1,14 @@
 // gitserver is the gitserver server.
 package main // import "github.com/sourcegraph/sourcegraph/cmd/gitserver"
 
-import "github.com/sourcegraph/sourcegraph/cmd/gitserver/shared"
+import (
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/shared"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+)
 
 func main() {
+	env.Lock()
+	env.HandleHelpFlag()
+
 	shared.Main()
 }

--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -81,8 +81,6 @@ var (
 func Main() {
 	ctx := context.Background()
 
-	env.Lock()
-	env.HandleHelpFlag()
 	logging.Init()
 
 	liblog := log.Init(log.Resource{

--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -5,9 +5,13 @@ package main
 import (
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/shared"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 
 func main() {
+	env.Lock()
+	env.HandleHelpFlag()
+
 	// Set dummy authz provider to unblock channel for checking permissions in GraphQL APIs.
 	// See https://github.com/sourcegraph/sourcegraph/issues/3847 for details.
 	authz.SetProviders(true, []authz.Provider{})

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -70,8 +70,6 @@ func Main(enterpriseInit EnterpriseInit) {
 	// NOTE: Internal actor is required to have full visibility of the repo table
 	// 	(i.e. bypass repository authorization).
 	ctx := actor.WithInternalActor(context.Background())
-	env.Lock()
-	env.HandleHelpFlag()
 
 	liblog := log.Init(log.Resource{
 		Name:       env.MyName,

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -5,10 +5,14 @@ import (
 	shared "github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry"
 	shared_enterprise "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/shared"
+	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
 
 func main() {
+	env.Lock()
+	env.HandleHelpFlag()
+
 	shared.Main(shared_enterprise.EnterpriseSetupHook)
 }
 

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -22,6 +22,7 @@ import (
 	ossDB "github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
+	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
@@ -29,6 +30,9 @@ import (
 )
 
 func main() {
+	env.Lock()
+	env.HandleHelpFlag()
+
 	shared.Main(enterpriseInit)
 }
 

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -160,6 +160,10 @@ func environMap(environ []string) map[string]string {
 
 // Lock makes later calls to Get fail with a panic. Call this at the beginning of the main function.
 func Lock() {
+	if locked {
+		panic("env.Lock must be called at most once")
+	}
+
 	locked = true
 
 	sort.Slice(env, func(i, j int) bool { return env[i].name < env[j].name })


### PR DESCRIPTION
Shared main functions allow "programs" to be invoked from different entrypoints. We use this to have separate OSS and non-OSS programs for frontend, repo-updater, etc.

This updates all programs except for worker, which will take some more refactoring to make this change (because it calls `loadConfigs` in the shared main).

I would like to be able to invoke multiple shared main functions in the same program, which requires moving global/singleton things such as `env.Lock()` (which may be called at most once) outside of the shared main function.




## Test plan

No manual test plan needed. This would cause an immediate panic if it was problematic, which would be picked up in automatic tests.