### PR TITLE
support skipping all sysreq checks with SRC_SKIP_REQS=all

### DIFF
--- a/internal/sysreq/sysreq.go
+++ b/internal/sysreq/sysreq.go
@@ -39,6 +39,9 @@ func (s *Status) Failed() bool { return s.Problem != "" || s.Err != nil }
 func Check(ctx context.Context, skip []string) []Status {
 	shouldSkip := func(name string) bool {
 		for _, v := range skip {
+			if v == "all" {
+				return true
+			}
 			if strings.EqualFold(name, v) {
 				return true
 			}


### PR DESCRIPTION
There was no way to skip all of them; you needed to enumerate all of the ones to skip. This was helpful to me when debugging, and it could be extremely helpful in a pinch to a customer.




## Test plan

Set SRC_SKIP_REQS=all and try running without one of those critical services. It will still try to run, as desired.