### PR TITLE
remove unnecessary warning for non-HTTPS externalURL

### DIFF
--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/versions"
@@ -92,10 +91,7 @@ func init() {
 	conf.ContributeWarning(func(c conftypes.SiteConfigQuerier) (problems conf.Problems) {
 		if c.SiteConfig().ExternalURL == "" {
 			problems = append(problems, conf.NewSiteProblem("`externalURL` is required to be set for many features of Sourcegraph to work correctly."))
-		} else if deploy.Type() != deploy.Dev && strings.HasPrefix(c.SiteConfig().ExternalURL, "http://") {
-			problems = append(problems, conf.NewSiteProblem("Your connection is not private. We recommend [configuring Sourcegraph to use HTTPS/SSL](https://docs.sourcegraph.com/admin/http_https_configuration)"))
 		}
-
 		return problems
 	})
 


### PR DESCRIPTION
When the externalURL is `http://` (non-HTTPS), a warning was shown: "Your connection is not private. We recommend ...". This warning was obtrusive and annoying when you are trying Sourcegraph on localhost, haven't set up HTTPS, or are accessing Sourcegraph via a separate HTTPS proxy but haven't set up externalURL to use the HTTPS URL.

I believe this warning is security theater. Site admins should know when they need to set up HTTPS, their browser will warn them, and an https externalURL is not a guarantee of security anyway. For reference, GitLab does not display a warning when using HTTP: https://docs.gitlab.com/omnibus/settings/ssl/ ("By default, HTTPS is not enabled.").




## Test plan

Run Sourcegraph with an externalURL of http://localhost:3080 or similar. Note that there is no warning at the top of the page.