### PR TITLE
misc: rm erroneous println, rm incorrect mention, quiet some logs

### DIFF
--- a/cmd/frontend/internal/app/debug.go
+++ b/cmd/frontend/internal/app/debug.go
@@ -250,7 +250,6 @@ func addNoJaegerHandler(r *mux.Router, db database.DB) {
 
 func addJaeger(r *mux.Router, db database.DB) {
 	if len(jaegerURLFromEnv) > 0 {
-		fmt.Println("Jaeger URL from env ", jaegerURLFromEnv)
 		jaegerURL, err := url.Parse(jaegerURLFromEnv)
 		if err != nil {
 			log.Printf("failed to parse JAEGER_SERVER_URL=%s: %v", jaegerURLFromEnv, err)

--- a/cmd/frontend/internal/app/otlpadapter/adapter.go
+++ b/cmd/frontend/internal/app/otlpadapter/adapter.go
@@ -90,7 +90,7 @@ func (sig *adaptedSignal) Register(ctx context.Context, logger log.Logger, r *mu
 		ErrorLog: std.NewLogger(adapterLogger, log.LevelWarn),
 	})
 
-	adapterLogger.Info("signal adapter registered")
+	adapterLogger.Debug("signal adapter registered")
 }
 
 type roundTripper struct {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -720,7 +720,7 @@ var (
 )
 
 func (s *Server) syncRepoState(gitServerAddrs gitserver.GitServerAddresses, batchSize, perSecond int, fullSync bool) error {
-	s.Logger.Info("starting syncRepoState", log.Bool("fullSync", fullSync))
+	s.Logger.Debug("starting syncRepoState", log.Bool("fullSync", fullSync))
 	addrs := gitServerAddrs.Addresses
 
 	// When fullSync is true we'll scan all repos in the database and ensure we set

--- a/internal/conf/client.go
+++ b/internal/conf/client.go
@@ -324,8 +324,13 @@ func (c *client) fetchAndUpdate(logger log.Logger) error {
 	}
 
 	if configChange.Changed {
-		logger.Info("config changed, notifying watchers",
-			log.Int("watchers", len(c.watchers)))
+		if configChange.Old == nil {
+			logger.Debug("config initialized",
+				log.Int("watchers", len(c.watchers)))
+		} else {
+			logger.Info("config changed, notifying watchers",
+				log.Int("watchers", len(c.watchers)))
+		}
 		c.notifyWatchers()
 	} else {
 		logger.Debug("no config changes detected")

--- a/internal/database/migration/runner/validate.go
+++ b/internal/database/migration/runner/validate.go
@@ -34,19 +34,19 @@ func (r *Runner) validateSchema(ctx context.Context, schemaContext schemaContext
 		log.String("schema", schemaContext.schema.Name),
 	)
 
-	logger.Info("Checked current schema state",
+	logger.Debug("Checked current schema state",
 		log.String("schema", schemaContext.schema.Name),
 		log.Ints("appliedVersions", extractIDs(byState.applied)),
 		log.Ints("pendingVersions", extractIDs(byState.pending)),
 		log.Ints("failedVersions", extractIDs(byState.failed)),
 	)
 
-	logger.Info("Checked current schema state")
+	logger.Debug("Checked current schema state")
 
 	// Quickly determine with our initial schema version if we are up to date. If so, we won't need
 	// to take an advisory lock and poll index creation status below.
 	if len(byState.pending) == 0 && len(byState.failed) == 0 && len(byState.applied) == len(definitions) {
-		logger.Info("Schema is in the expected state")
+		logger.Debug("Schema is in the expected state")
 		return nil
 	}
 

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -95,8 +95,7 @@ func init() {
 // HelpString. Calling Get with the same name twice causes a panic. Get should only be called on
 // package initialization. Calls at a later point will cause a panic if Lock was called before.
 //
-// This should be used for only *internal* environment values. User-visible configuration should be
-// added to the Config struct in the github.com/sourcegraph/sourcegraph/config package.
+// This should be used for only *internal* environment values.
 func Get(name, defaultValue, description string) string {
 	if locked {
 		panic("env.Get has to be called on package initialization")

--- a/internal/tracer/switchable_ot.go
+++ b/internal/tracer/switchable_ot.go
@@ -72,5 +72,5 @@ func (t *switchableOTTracer) set(
 	t.debug = debug
 	t.logger = logger.With(log.String("tracer", fmt.Sprintf("%T", tracer))).AddCallerSkip(1)
 
-	t.logger.Info("tracer set")
+	t.logger.Debug("tracer set")
 }


### PR DESCRIPTION
- remove erroneous fmt.Println: This appears to be a debugging aid that was accidentally left in.
- remove mention of non-existent package
- quiet some logs from info to debug: I think these are all debug-level logs and do not contain useful information outside of debugging a deep problem.

## Test plan

None needed. This only affects logging.