### PR TITLE
make dev blobstore data/log dirs writable

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -563,6 +563,7 @@ commands:
     install: |
       mkdir -p $BLOBSTORE_LOGS
       mkdir -p $BLOBSTORE_DISK
+      chmod u+rwx $BLOBSTORE_LOGS $BLOBSTORE_DISK
       CACHE=true ./docker-images/blobstore/build.sh >$BLOBSTORE_LOG_FILE 2>&1
     env:
       BLOBSTORE_DISK: $HOME/.sourcegraph-dev/data/blobstore


### PR DESCRIPTION
For me, the ~/.sourcegraph-dev/data/blobstore directory was chmod 775, which meant that the blobstore Docker container could not write to it. This caused errors:

- `failed to create bucket: operation error S3: CreateBucket, https response error StatusCode: 403` from the precise-code-intel-worker service
- `sendSimpleErrorResponse: 403 AccessDenied Forbidden` in the blobstore Docker container logs

Making these directories world-writable fixes the problem.

## Test plan

Only dev is affected, no test plan needed.