### PR TITLE
gitserver: Add oauth2 username to GitHub clone url

### DIFF
--- a/internal/repos/clone_url.go
+++ b/internal/repos/clone_url.go
@@ -206,7 +206,7 @@ func githubCloneURL(logger log.Logger, repo *github.Repository, cfg *schema.GitH
 	if cfg.GithubAppInstallationID != "" {
 		u.User = url.UserPassword("x-access-token", cfg.Token)
 	} else {
-		u.User = url.User(cfg.Token)
+		u.User = url.UserPassword("oauth2", cfg.Token)
 	}
 	return u.String(), nil
 }


### PR DESCRIPTION
Closes #45136 

Based on this Stackoverflow thread: https://stackoverflow.com/questions/42148841/github-clone-with-oauth-access-token/66156992#66156992 it seems that GitHub fine-grained Personal Access Tokens don't work without the `oauth2` username. This PR adds the username when generating the GitHub clone URL.

This is how other code hosts work as well, for example the clone URL for GitLab uses the `oauth2` username as well: https://sourcegraph.com/github.com/sourcegraph/sourcegraph@ce477a4ad027d3dfcf74d4246d7f4c4a0eec3876/-/blob/internal/repos/clone_url.go?L216&subtree=true

I also confirmed that, with this change, the classic PATs still work.

## Test plan

Tested repository cloning with both classic PATs and fine-grained PATs after the `oauth2` username was added.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
