### PR TITLE
remove old, rarely used, and broken search.index.enabled:false site config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Removed
 
 - Removed legacy GraphQL field `dirtyMetadata` on an insight series. `insightViewDebug` can be used as an alternative. [#44416](https://github.com/sourcegraph/sourcegraph/pull/44416)
+- Removed `search.index.enabled` site configuration setting. Search indexing is now always enabled.
 
 ## 4.2.0
 

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -210,10 +210,6 @@ func (s *repos) ListIndexable(ctx context.Context) (repos []types.MinimalRepo, e
 		return s.cache.List(ctx)
 	}
 
-	if !conf.SearchIndexEnabled() {
-		return []types.MinimalRepo{}, nil
-	}
-
 	return s.store.ListMinimalRepos(ctx, database.ReposListOptions{
 		OnlyCloned: true,
 	})

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -147,15 +146,11 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 		}
 
 		var indexed *zoekt.RepoList
-		searchIndexEnabled := conf.SearchIndexEnabled()
 		isIndexed := func(id api.RepoID) bool {
-			if !searchIndexEnabled {
-				return true // do not need index
-			}
 			_, ok := indexed.Minimal[uint32(id)]
 			return ok
 		}
-		if searchIndexEnabled && (!r.indexed || !r.notIndexed) {
+		if !r.indexed || !r.notIndexed {
 			listCtx, cancel := context.WithTimeout(ctx, time.Minute)
 			defer cancel()
 			var err error

--- a/cmd/frontend/graphqlbackend/repository_stats.go
+++ b/cmd/frontend/graphqlbackend/repository_stats.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/internal/auth"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -89,23 +88,13 @@ func (r *repositoryStatsResolver) IndexedLinesCount(ctx context.Context) (BigInt
 
 func (r *repositoryStatsResolver) computeIndexedStats(ctx context.Context) (int32, int64, error) {
 	r.indexedStatsOnce.Do(func() {
-		var (
-			indexedRepos     int32
-			indexedLineCount int64
-		)
-
-		if conf.SearchIndexEnabled() {
-			repos, err := search.ListAllIndexed(ctx)
-			if err != nil {
-				r.indexedStatsErr = err
-				return
-			}
-			indexedRepos = int32(len(repos.Minimal))
-			indexedLineCount = int64(repos.Stats.DefaultBranchNewLinesCount) + int64(repos.Stats.OtherBranchesNewLinesCount)
+		repos, err := search.ListAllIndexed(ctx)
+		if err != nil {
+			r.indexedStatsErr = err
+			return
 		}
-
-		r.indexedRepos = indexedRepos
-		r.indexedLinesCount = indexedLineCount
+		r.indexedRepos = int32(len(repos.Minimal))
+		r.indexedLinesCount = int64(repos.Stats.DefaultBranchNewLinesCount) + int64(repos.Stats.OtherBranchesNewLinesCount)
 	})
 
 	return r.indexedRepos, r.indexedLinesCount, r.indexedStatsErr

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -12,17 +12,12 @@ import (
 	zoektquery "github.com/sourcegraph/zoekt/query"
 	"github.com/sourcegraph/zoekt/stream"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 )
 
 func (r *RepositoryResolver) TextSearchIndex() *repositoryTextSearchIndexResolver {
-	if !conf.SearchIndexEnabled() {
-		return nil
-	}
-
 	return &repositoryTextSearchIndexResolver{
 		repo:   r,
 		client: search.Indexed(),

--- a/cmd/worker/internal/zoektrepos/zoektrepos.go
+++ b/cmd/worker/internal/zoektrepos/zoektrepos.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
@@ -54,11 +53,6 @@ var _ goroutine.Handler = &handler{}
 var _ goroutine.ErrorHandler = &handler{}
 
 func (h *handler) Handle(ctx context.Context) error {
-	if !conf.SearchIndexEnabled() {
-		h.logger.Debug("Search indexing is disabled. Skipping update of index statuses.")
-		return nil
-	}
-
 	indexed, err := search.ListAllIndexed(ctx)
 	if err != nil {
 		return err

--- a/doc/admin/config/site_config.md
+++ b/doc/admin/config/site_config.md
@@ -92,7 +92,5 @@ You can check the container logs to see if you have made any typos or mistakes i
 			"allowSignup": false
 		}
 	],
-
-	"search.index.enabled": true
 }
 ```

--- a/doc/admin/search.md
+++ b/doc/admin/search.md
@@ -4,11 +4,11 @@ See "[Code search overview](../code_search/index.md)" for general information ab
 
 ## Indexed search
 
-Sourcegraph can index the code on the default branch of each repository. This speeds up searches that hit many repositories at once. Not all files in a repository branch are indexed, we skip files that are [larger than 1 MB](../code_search/explanations/search_details.md) and binary files. To view which files are skipped during indexing, visit the repository settings page and click on indexing.
+Sourcegraph indexes the code on the default branch of each repository. This speeds up searches that hit many repositories at once. Not all files in a repository branch are indexed, we skip files that are [larger than 1 MB](../code_search/explanations/search_details.md) and binary files. To view which files are skipped during indexing, visit the repository settings page and click on indexing.
 
 For large deployments we recommend horizontally scaling indexed search. You can do this by [adjusting the number of replicas](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/configure.md#configure-indexed-search-replica-count). Sourcegraph shards repository indexes across replicas. When the replica count changes Sourcegraph will slowly rebalance indexes to ensure availability of existing indexes.
 
-Indexed search increases the memory and storage requirements for Sourcegraph. The resource requirements vary considerably based on the text contents of your repositories, but a good estimate is that the node should have enough memory to hold the entire text contents of the default branch of each repository. To disable indexed search when running Sourcegraph on a single node, set the `search.index.enabled` [site configuration](config/site_config.md) property to `false`.
+The resource requirements for indexed search vary considerably based on the text contents of your repositories, but a good estimate is that the node should have enough memory to hold the entire text contents of the default branch of each repository.
 
 ### Scaling considerations
 

--- a/doc/admin/troubleshooting.md
+++ b/doc/admin/troubleshooting.md
@@ -133,7 +133,6 @@ If you can get repository results when you explicitly include `repo:{your reposi
 
 - The repository is a fork repository (excluded from search results by default) and `fork:yes` is not specified in the search query.
 - The repository is an archived repository (excluded from search results by default) and `archived:yes` is not specified in the search query.
-- Your site config file does not include `"search.index.enabled": true`. It should be included, and you should set it to true; if it's false, it means Sourcegraph won't index anything and will only search in real-time.
 - There is an issue indexing the repository: check the logs of repo-updater and/or search-indexer.
 - The search index is unavailable for some reason: try the search query `repo:<the_repository> index:only`. If it returns no results, the repository has not been indexed.
 

--- a/enterprise/internal/insights/discovery/all_repos_iterator.go
+++ b/enterprise/internal/insights/discovery/all_repos_iterator.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -113,13 +112,9 @@ func (a *AllReposIterator) cachedRepoStoreList(ctx context.Context, page databas
 		return cacheEntry.results, nil
 	}
 
-	var repos []*types.Repo
-	if conf.SearchIndexEnabled() {
-		var err error
-		repos, err = a.RepoStore.List(ctx, database.ReposListOptions{LimitOffset: &page})
-		if err != nil {
-			return nil, err
-		}
+	repos, err := a.RepoStore.List(ctx, database.ReposListOptions{LimitOffset: &page})
+	if err != nil {
+		return nil, err
 	}
 
 	a.cachedPageRequests[page] = cachedPageRequest{

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -128,15 +128,6 @@ func UpdateChannel() string {
 	return channel
 }
 
-// SearchIndexEnabled returns true if sourcegraph should index all
-// repositories for text search.
-func SearchIndexEnabled() bool {
-	if v := Get().SearchIndexEnabled; v != nil {
-		return *v
-	}
-	return true // always on by default in all deployment types, see confdefaults.go
-}
-
 func BatchChangesEnabled() bool {
 	if enabled := Get().BatchChangesEnabled; enabled != nil {
 		return *enabled

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -1,7 +1,6 @@
 package conf
 
 import (
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -9,74 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf/confdefaults"
-	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-
 	"github.com/sourcegraph/sourcegraph/schema"
 )
-
-func TestSearchIndexEnabled(t *testing.T) {
-	tests := []struct {
-		name string
-		sc   *Unified
-		env  []string
-		want any
-	}{{
-		name: "SearchIndex defaults to true in docker",
-		sc:   &Unified{},
-		env:  []string{"DEPLOY_TYPE=docker-container"},
-		want: true,
-	}, {
-		name: "SearchIndex defaults to true in k8s",
-		sc:   &Unified{},
-		env:  []string{"DEPLOY_TYPE=k8s"},
-		want: true,
-	}, {
-		name: "SearchIndex enabled",
-		sc:   &Unified{SiteConfiguration: schema.SiteConfiguration{SearchIndexEnabled: boolPtr(true)}},
-		env:  []string{"DEPLOY_TYPE=docker-container"},
-		want: true,
-	}, {
-		name: "SearchIndex disabled",
-		sc:   &Unified{SiteConfiguration: schema.SiteConfiguration{SearchIndexEnabled: boolPtr(false)}},
-		env:  []string{"DEPLOY_TYPE=docker-container"},
-		want: false,
-	}}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			for _, e := range test.env {
-				cleanup := setenv(t, e)
-				defer cleanup()
-			}
-			Mock(test.sc)
-			got := SearchIndexEnabled()
-			if got != test.want {
-				t.Fatalf("SearchIndexEnabled() = %v, want %v", got, test.want)
-			}
-		})
-	}
-
-	defaults := map[string]conftypes.RawUnified{
-		"Kubernetes":      confdefaults.KubernetesOrDockerComposeOrPureDocker,
-		"Default":         confdefaults.Default,
-		"DevAndTesting":   confdefaults.DevAndTesting,
-		"DockerContainer": confdefaults.DockerContainer,
-	}
-	for dStr, d := range defaults {
-		test := fmt.Sprintf("for %s defaults", dStr)
-		t.Run(test, func(t *testing.T) {
-			cfg, err := ParseConfig(d)
-			if err != nil {
-				t.Fatal(err)
-			}
-			Mock(cfg)
-			defer Mock(nil)
-			if !SearchIndexEnabled() {
-				t.Errorf("search indexing should be enabled by default for Docker deployments")
-			}
-		})
-	}
-}
 
 func TestAuthPasswordResetLinkDuration(t *testing.T) {
 	tests := []struct {

--- a/internal/conf/confdefaults/confdefaults.go
+++ b/internal/conf/confdefaults/confdefaults.go
@@ -25,8 +25,6 @@ var DevAndTesting = conftypes.RawUnified{
 			"allowSignup": true
 		}
 	],
-
-	"search.index.enabled": true
 }`,
 }
 
@@ -46,7 +44,6 @@ var DockerContainer = conftypes.RawUnified{
 	],
 
 	"disablePublicRepoRedirects": true,
-	"search.index.enabled": true
 }`,
 }
 
@@ -71,8 +68,6 @@ var KubernetesOrDockerComposeOrPureDocker = conftypes.RawUnified{
 			"allowSignup": false
 		}
 	],
-
-	"search.index.enabled": true
 }`,
 }
 

--- a/internal/search/env.go
+++ b/internal/search/env.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/search/backend"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 var (
@@ -28,8 +27,6 @@ var (
 	indexedDialer     backend.ZoektDialer
 )
 
-var ErrIndexDisabled = errors.New("indexed search has been disabled")
-
 func SearcherURLs() *endpoint.Map {
 	searcherURLsOnce.Do(func() {
 		searcherURLs = endpoint.ConfBased(func(conns conftypes.ServiceConnections) []string {
@@ -40,10 +37,6 @@ func SearcherURLs() *endpoint.Map {
 }
 
 func Indexed() zoekt.Streamer {
-	if !conf.SearchIndexEnabled() {
-		return &backend.FakeSearcher{SearchError: ErrIndexDisabled, ListError: ErrIndexDisabled}
-	}
-
 	indexedSearchOnce.Do(func() {
 		indexedSearch = backend.NewCachedSearcher(conf.Get().ServiceConnections().ZoektListTTL, backend.NewMeteredSearcher(
 			"", // no hostname means its the aggregator
@@ -58,8 +51,7 @@ func Indexed() zoekt.Streamer {
 	return indexedSearch
 }
 
-// ListAllIndexed lists all indexed repositories with `Minimal: true`. If
-// indexed search is disabled it returns ErrIndexDisabled.
+// ListAllIndexed lists all indexed repositories with `Minimal: true`.
 func ListAllIndexed(ctx context.Context) (*zoekt.RepoList, error) {
 	q := &query.Const{Value: true}
 	opts := &zoekt.ListOptions{Minimal: true}

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
@@ -29,9 +28,6 @@ const DefaultSymbolLimit = 100
 // repository at a specific commit. If it has it returns the branch name (for
 // use when querying zoekt). Otherwise an empty string is returned.
 func indexedSymbolsBranch(ctx context.Context, repo *types.MinimalRepo, commit string) string {
-	if !conf.SearchIndexEnabled() {
-		return ""
-	}
 	z := search.Indexed()
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second)

--- a/internal/usagestats/repositories.go
+++ b/internal/usagestats/repositories.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -47,10 +46,6 @@ func GetRepositories(ctx context.Context, db database.DB) (*Repositories, error)
 		// In the rare case we haven't yet computed the stat (UpdatedAt ==
 		// 0), we undercount the size.
 		total.GitDirBytes += uint64(stat.GitDirBytes)
-	}
-
-	if !conf.SearchIndexEnabled() {
-		return &total, nil
 	}
 
 	repos, err := search.ListAllIndexed(ctx)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2238,8 +2238,6 @@ type SiteConfiguration struct {
 	RepoListUpdateInterval int `json:"repoListUpdateInterval,omitempty"`
 	// RepoPurgeWorker description: Configuration for repository purge worker.
 	RepoPurgeWorker *RepoPurgeWorker `json:"repoPurgeWorker,omitempty"`
-	// SearchIndexEnabled description: Whether indexed search is enabled. If : unset Sourcegraph detects the environment to decide if indexed search is enabled. Indexed search is RAM heavy, and is disabled by default in the single docker image. All other environments will have it enabled by default. The size of all your repository working copies is the amount of additional RAM required.
-	SearchIndexEnabled *bool `json:"search.index.enabled,omitempty"`
 	// SearchIndexSymbolsEnabled description: Whether indexed symbol search is enabled. This is contingent on the indexed search configuration, and is true by default for instances with indexed search enabled. Enabling this will cause every repository to re-index, which is a time consuming (several hours) operation. Additionally, it requires more storage and ram to accommodate the added symbols information in the search index.
 	SearchIndexSymbolsEnabled *bool `json:"search.index.symbols.enabled,omitempty"`
 	// SearchLargeFiles description: A list of file glob patterns where matching files will be indexed and searched regardless of their size. Files still need to be valid utf-8 to be indexed. The glob pattern syntax can be found here: https://github.com/bmatcuk/doublestar#patterns.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -17,12 +17,6 @@
       "type": "boolean",
       "group": "Search"
     },
-    "search.index.enabled": {
-      "description": "Whether indexed search is enabled. If : unset Sourcegraph detects the environment to decide if indexed search is enabled. Indexed search is RAM heavy, and is disabled by default in the single docker image. All other environments will have it enabled by default. The size of all your repository working copies is the amount of additional RAM required.",
-      "type": "boolean",
-      "!go": { "pointer": true },
-      "group": "Search"
-    },
     "search.index.symbols.enabled": {
       "description": "Whether indexed symbol search is enabled. This is contingent on the indexed search configuration, and is true by default for instances with indexed search enabled. Enabling this will cause every repository to re-index, which is a time consuming (several hours) operation. Additionally, it requires more storage and ram to accommodate the added symbols information in the search index.",
       "type": "boolean",


### PR DESCRIPTION
The `search.index.enabled` site config setting defaults to true for all deployment types (and has for ~2 years). It was possible to set `"search.index.enabled": false` in site config.

But this was broken; searches with `index:no` would show no results, and normal searches would show an error about index search being disabled. This setting made the instance completely unusable, so it is highly unlikely any instances were actually using it.

The need for this setting has also gone down dramatically with many more years of experience running indexed search at scale on many instances. If we need to bring back the ability to disable indexed search, we should reimplement it (because many code paths did not properly respect this setting).

## Test plan

n/a