### PR TITLE
don't special-case dev mode for SRC_HTTP_ADDR default

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -65,12 +65,7 @@ var (
 
 	printLogo, _ = strconv.ParseBool(env.Get("LOGO", "false", "print Sourcegraph logo upon startup"))
 
-	httpAddr = env.Get("SRC_HTTP_ADDR", func() string {
-		if env.InsecureDev {
-			return "127.0.0.1:3080"
-		}
-		return ":3080"
-	}(), "HTTP listen address for app and HTTP API")
+	httpAddr         = env.Get("SRC_HTTP_ADDR", ":3080", "HTTP listen address for app and HTTP API")
 	httpAddrInternal = envvar.HTTPAddrInternal
 
 	nginxAddr = env.Get("SRC_NGINX_HTTP_ADDR", "", "HTTP listen address for nginx reverse proxy to SRC_HTTP_ADDR. Has preference over SRC_HTTP_ADDR for ExternalURL.")

--- a/internal/httpserver/listener.go
+++ b/internal/httpserver/listener.go
@@ -2,8 +2,6 @@ package httpserver
 
 import (
 	"net"
-
-	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 
 // NewListener returns a TCP listener accepting connections
@@ -23,15 +21,14 @@ func NewListener(addr string) (_ net.Listener, err error) {
 }
 
 // SanitizeAddr replaces the host in the given address with
-// 127.0.0.1 if no host is supplied or if running in insecure
-// dev mode.
+// 127.0.0.1 if no host is supplied.
 func SanitizeAddr(addr string) (string, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return "", err
 	}
 
-	if host == "" && env.InsecureDev {
+	if host == "" {
 		host = "127.0.0.1"
 	}
 


### PR DESCRIPTION
sg.config.yaml sets this to :3082 anyway, which means it listens on all ports.




## Test plan

n/a (this only changes the behavior when running in dev mode, and sg.config.yaml specifies a value here, which means it overrides the default anyway)