### PR TITLE
api: remove type api.Repo

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -65,22 +65,6 @@ func (rc RepoCommit) LogFields() []log.Field {
 	}
 }
 
-// Repo represents a source code repository.
-type Repo struct {
-	// ID is the unique numeric ID for this repository on Sourcegraph.
-	ID RepoID
-
-	// ExternalRepo identifies this repository by its ID on the external service where it resides (and the external
-	// service itself).
-	ExternalRepo *ExternalRepoSpec
-
-	// Name is the name of the repository (such as "github.com/user/repo").
-	Name RepoName
-	// Enabled is whether the repository is enabled. Disabled repositories are
-	// not accessible by users (except site admins).
-	Enabled bool
-}
-
 // ExternalRepoSpec specifies a repository on an external service (such as GitHub or GitLab).
 type ExternalRepoSpec struct {
 	// ID is the repository's ID on the external service. Its value is opaque except to the repo-updater.


### PR DESCRIPTION
type Repo is not used anywhere. Probably a leftover from a refactor.

## Test plan
- go test

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
