### PR TITLE
update license finder to 7.1.0

### DIFF
--- a/.github/workflows/licenses-check.yml
+++ b/.github/workflows/licenses-check.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-ruby@v1
-      with: { ruby-version: '2.6' }
+      with: { ruby-version: '3.1.1' }
     - uses: actions/setup-go@v2
       with: { go-version: '1.19' }
 
@@ -18,7 +18,7 @@ jobs:
       with: { node-version: '${{ steps.nvmrc.outputs.NODE_VERSION }}' }
 
     - name: Install license_finder
-      run: gem install license_finder:7.0.1 # sync with licenses-update.yml
+      run: gem install license_finder:7.1.0 # sync with licenses-update.yml
 
     - name: Check dependencies
       run: LICENSE_CHECK=true ./dev/licenses.sh

--- a/.github/workflows/licenses-update.yml
+++ b/.github/workflows/licenses-update.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-ruby@v1
-      with: { ruby-version: '2.6' }
+      with: { ruby-version: '3.1.1' }
     - name: Install asdf plugins
       uses: asdf-vm/actions/install@v1
 
@@ -20,7 +20,7 @@ jobs:
       run: yarn
 
     - name: Install license_finder
-      run: gem install license_finder:7.0.1 # sync with licenses-check.yml
+      run: gem install license_finder:7.1.0 # sync with licenses-check.yml
 
     - name: Generate report
       run: ./dev/licenses.sh

--- a/.tool-versions
+++ b/.tool-versions
@@ -15,3 +15,4 @@ kustomize 4.5.7
 awscli 2.4.7
 python system
 rust 1.62.0
+ruby 3.1.1


### PR DESCRIPTION
Use the latest license finder which fixes reading licenses from yarn
## Test plan
executed locally and checked `third-party-licenses/ThirdPartyLicenses.csv`. Yarn licenses were added.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
