### PR TITLE
Outbound request log: Add complete call stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added "Outbound request log" feature for site admins [#44286](https://github.com/sourcegraph/sourcegraph/pull/44286)
 - Code Insights: the data series API now provides information about incomplete datapoints during processing
 - Added a best-effort migration such that existing Code Insights will display zero results instead of missing points at the start and end of a graph. [#44928](https://github.com/sourcegraph/sourcegraph/pull/44928)
+- More complete stack traces for Outbound request log [#45151](https://github.com/sourcegraph/sourcegraph/pull/45151)
 
 ### Changed
 

--- a/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
@@ -59,7 +59,7 @@ export function parseProductReference(productVersion: string): string {
         return parts.pop() || 'main'
     }
     // Special case for dev tag
-    if (productVersion === '0.0.0') {
+    if (productVersion.startsWith('0.0.0')) {
         return 'main'
     }
     // Otherwise assume product version is probably a tag

--- a/client/web/src/site-admin/SiteAdminOutboundRequestsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOutboundRequestsPage.tsx
@@ -260,11 +260,13 @@ const OutboundRequestNode: React.FunctionComponent<{ node: React.PropsWithChildr
                                     <strong>Request headers:</strong>{' '}
                                 </Text>
                                 <ul>
-                                    {node.requestHeaders.map(header => (
-                                        <li key={header.name}>
-                                            <strong>{header.name}</strong>: {header.values.join(', ')}
-                                        </li>
-                                    ))}
+                                    {[...node.requestHeaders]
+                                        .sort((a, b) => a.name.localeCompare(b.name))
+                                        .map(header => (
+                                            <li key={header.name}>
+                                                <strong>{header.name}</strong>: {header.values.join(', ')}
+                                            </li>
+                                        ))}
                                 </ul>
                             </>
                         ) : (
@@ -276,11 +278,13 @@ const OutboundRequestNode: React.FunctionComponent<{ node: React.PropsWithChildr
                                     <strong>Response headers:</strong>{' '}
                                 </Text>
                                 <ul>
-                                    {node.responseHeaders.map(header => (
-                                        <li key={header.name}>
-                                            <strong>{header.name}</strong>: {header.values.join(', ')}
-                                        </li>
-                                    ))}
+                                    {[...node.responseHeaders]
+                                        .sort((a, b) => a.name.localeCompare(b.name))
+                                        .map(header => (
+                                            <li key={header.name}>
+                                                <strong>{header.name}</strong>: {header.values.join(', ')}
+                                            </li>
+                                        ))}
                                 </ul>
                             </>
                         ) : (

--- a/client/web/src/site-admin/SiteAdminOutboundRequestsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOutboundRequestsPage.tsx
@@ -37,6 +37,7 @@ import { Timestamp } from '../components/time/Timestamp'
 import { OutboundRequestsResult, OutboundRequestsVariables } from '../graphql-operations'
 
 import { OUTBOUND_REQUESTS, OUTBOUND_REQUESTS_PAGE_POLL_INTERVAL } from './backend'
+import { parseProductReference } from './SiteAdminFeatureFlagsPage'
 
 import styles from './SiteAdminOutboundRequestsPage.module.scss'
 
@@ -323,17 +324,21 @@ function formatStackFrameLine(line: string): React.ReactNode {
         return line
     }
     const [, fileName, lineIndex, functionName] = match
-    const url = `https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/${fileName}?L${lineIndex}`
     return (
         <li key={`${fileName}:${lineIndex}`}>
             <Code>
-                <Link to={url} target="_blank" rel="noopener">
+                <Link to={buildSourcegraphUrl(fileName, parseInt(lineIndex, 10))} target="_blank" rel="noopener">
                     {fileName}:{lineIndex}
                 </Link>{' '}
                 (Function: {functionName})
             </Code>
         </li>
     )
+}
+
+function buildSourcegraphUrl(fileName: string, lineIndex: number): string {
+    const revision = parseProductReference(window.context.version)
+    return `https://sourcegraph.com/github.com/sourcegraph/sourcegraph@${revision}/-/blob/${fileName}?L${lineIndex}`
 }
 
 const SimplePopover: React.FunctionComponent<{ label: string; children: ReactNode }> = ({ label, children }) => {

--- a/client/web/src/site-admin/SiteAdminOutboundRequestsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOutboundRequestsPage.tsx
@@ -308,7 +308,7 @@ function formatStackFrame(callStack: string): React.ReactNode {
 
     return (
         <>
-            <ul>{...lines.map(formatStackFrameLine)}</ul>
+            <ul>{lines.map(formatStackFrameLine)}</ul>
         </>
     )
 }

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -308,7 +308,7 @@ export const OUTBOUND_REQUESTS = gql`
                 durationMs
                 errorMessage
                 creationStackFrame
-                callStackFrame
+                callStack
             }
         }
     }

--- a/cmd/frontend/graphqlbackend/outbound_requests.go
+++ b/cmd/frontend/graphqlbackend/outbound_requests.go
@@ -161,7 +161,7 @@ func (r *OutboundRequestResolver) ErrorMessage() string { return r.req.ErrorMess
 
 func (r *OutboundRequestResolver) CreationStackFrame() string { return r.req.CreationStackFrame }
 
-func (r *OutboundRequestResolver) CallStackFrame() string { return r.req.CallStackFrame }
+func (r *OutboundRequestResolver) CallStack() string { return r.req.CallStackFrame }
 
 func newHttpHeaders(headers map[string][]string) ([]*HttpHeaders, error) {
 	result := make([]*HttpHeaders, 0, len(headers))

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -8128,7 +8128,7 @@ type OutboundRequest implements Node {
     """
     Stack information to figure out where in the code base the request was initiated.
     """
-    callStackFrame: String!
+    callStack: String!
 }
 
 """

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1719,5 +1719,5 @@ type OutboundRequestLogItem struct {
 	Duration           float64             `json:"duration"`
 	ErrorMessage       string              `json:"errorMessage"`
 	CreationStackFrame string              `json:"creationStackFrame"`
-	CallStackFrame     string              `json:"callStackFrame"`
+	CallStackFrame     string              `json:"callStackFrame"` // Should be "CallStack" once this is final
 }


### PR DESCRIPTION
We wanted more complete stack traces for our new "Outbound request log" feature to help us figure out where calls were coming from.

This PR adds them:

![CleanShot 2022-12-05 at 10 52 23@2x](https://user-images.githubusercontent.com/2552265/205607402-b03b1060-1a7b-4e68-82da-29693ff2ee5f.png)

Notes:
- I still use a plain text format for the data transmission and parse it on the front end, which is not beautiful, but the effort to make this more sophisticated didn't seem to justify the effort needed.
- The Redis field should be called "CallStack" rather than "CallStackFrame" now, but I haven't renamed it because that'd need a migration / custom unmarshaling, and I deemed it not worth it at this point because I expect more changes to the data format. I could do a migration once the feature is more mature ("Duration" format also changed, [here](https://github.com/sourcegraph/sourcegraph/pull/44937/files#diff-04cd02aeaa5beaf427c64ffb260aeec0e03a7f2db5f68e19b79bccf88ef88b92L122)).
- Also sneaked in a small front-end improvement to sort the header items alphabetically (was pretty much random)

## Test plan

[40-sec Loom demo](https://www.loom.com/share/aa4b6316ae2e40cdb1f5fe13c26aa946)
- It shows the stack trace
- It's backward compatible

