### PR TITLE
Token selection: don't warmup non-interactive tokens

### DIFF
--- a/client/web/src/repo/blob/codemirror/token-selection/selections.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/selections.ts
@@ -80,7 +80,7 @@ export const scrollRangeIntoView = (view: EditorView, range: Range): void => {
     scrollLineIntoView(view, lineBelow)
 }
 
-export const touchOccurrence = (view: EditorView, occurrence: Occurrence): void => {
+export const warmupOccurrence = (view: EditorView, occurrence: Occurrence): void => {
     if (!view.state.field(hoverCache).has(occurrence)) {
         hoverAtOccurrence(view, occurrence).then(
             () => {},
@@ -96,7 +96,7 @@ export const touchOccurrence = (view: EditorView, occurrence: Occurrence): void 
 }
 
 export const selectOccurrence = (view: EditorView, occurrence: Occurrence): void => {
-    touchOccurrence(view, occurrence)
+    warmupOccurrence(view, occurrence)
     selectRange(view, occurrence.range)
     view.dispatch({ effects: setHoveredOccurrenceEffect.of(occurrence) })
 }


### PR DESCRIPTION
Reduces the number of network requests when moving the mouse. Context https://sourcegraph.slack.com/archives/C03CSAER9LK/p1670235444143509


## Test plan

Manually tested locally and confirmed that it no longer sends network requests for punctuation tokens like `:=`, which are unlikely to have meaningful codeintel.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-selection-cache.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
