### PR TITLE
search results: remove n keybinding for selecting first result

### DIFF
--- a/client/search-ui/src/results/useSearchResultsKeyboardNavigation.ts
+++ b/client/search-ui/src/results/useSearchResultsKeyboardNavigation.ts
@@ -135,7 +135,7 @@ export function useSearchResultsKeyboardNavigation(
                 return
             }
 
-            if ((event.key === 'ArrowDown' && isMetaKey(event, isMacPlatform())) || event.key === 'n') {
+            if (event.key === 'ArrowDown' && isMetaKey(event, isMacPlatform())) {
                 selectFirstResult(root)
                 event.preventDefault()
             }


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

* Pressing `n` in search input should work again.