### PR TITLE
Add redactOutboundRequestHeaders setting

### DIFF
--- a/internal/conf/init.go
+++ b/internal/conf/init.go
@@ -22,16 +22,26 @@ func Init() {
 	// package dependency cycles, since conf itself uses httpcli's internal
 	// client. This is gross, and the whole conf package is gross.
 	go Watch(func() {
+		// TLS external config
 		tlsBefore := httpcli.TLSExternalConfig()
 		tlsAfter := Get().ExperimentalFeatures.TlsExternal
 		if !reflect.DeepEqual(tlsBefore, tlsAfter) {
 			httpcli.SetTLSExternalConfig(tlsAfter)
 		}
 
+		// Outbound request log limit and redact headers
 		outboundRequestLogLimitBefore := httpcli.OutboundRequestLogLimit()
 		outboundRequestLogLimitAfter := int32(Get().OutboundRequestLogLimit)
 		if outboundRequestLogLimitBefore != outboundRequestLogLimitAfter {
 			httpcli.SetOutboundRequestLogLimit(outboundRequestLogLimitAfter)
+		}
+		redactOutboundRequestHeadersBefore := httpcli.RedactOutboundRequestHeaders()
+		redactOutboundRequestHeadersAfter := true
+		if Get().RedactOutboundRequestHeaders != nil {
+			redactOutboundRequestHeadersAfter = *Get().RedactOutboundRequestHeaders
+		}
+		if redactOutboundRequestHeadersBefore != redactOutboundRequestHeadersAfter {
+			httpcli.SetRedactOutboundRequestHeaders(redactOutboundRequestHeadersAfter)
 		}
 	})
 }

--- a/internal/httpcli/external.go
+++ b/internal/httpcli/external.go
@@ -28,6 +28,7 @@ var tlsExternalConfig struct {
 }
 
 var outboundRequestLogLimit atomic.Int32
+var redactOutboundRequestHeaders atomic.Bool
 
 // SetTLSExternalConfig is called by the conf package whenever TLSExternalConfig changes.
 // This is needed to avoid circular imports.
@@ -53,6 +54,17 @@ func SetOutboundRequestLogLimit(i int32) {
 // OutboundRequestLogLimit returns the current value of the global OutboundRequestLogLimit value.
 func OutboundRequestLogLimit() int32 {
 	return outboundRequestLogLimit.Load()
+}
+
+// SetRedactOutboundRequestHeaders is called by the conf package whenever the RedactOutboundRequestHeaders setting changes.
+// This is needed to avoid circular imports.
+func SetRedactOutboundRequestHeaders(b bool) {
+	redactOutboundRequestHeaders.Store(b)
+}
+
+// RedactOutboundRequestHeaders returns the current value of the global RedactOutboundRequestHeaders setting.
+func RedactOutboundRequestHeaders() bool {
+	return redactOutboundRequestHeaders.Load()
 }
 
 func (t *externalTransport) RoundTrip(r *http.Request) (*http.Response, error) {

--- a/internal/httpcli/redis_logger_middleware.go
+++ b/internal/httpcli/redis_logger_middleware.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -27,6 +28,7 @@ func redisLoggerMiddleware() Middleware {
 			resp, err := cli.Do(req)
 			duration := time.Since(start)
 			limit := OutboundRequestLogLimit()
+			shouldRedactSensitiveHeaders := !deploy.IsDev(deploy.Type()) || RedactOutboundRequestHeaders()
 
 			// Feature is turned off, do not log
 			if limit == 0 {
@@ -56,6 +58,14 @@ func redisLoggerMiddleware() Middleware {
 				}
 			}
 
+			// Redact sensitive headers
+			requestHeaders := req.Header
+			responseHeaders := resp.Header
+			if shouldRedactSensitiveHeaders {
+				requestHeaders = redactSensitiveHeaders(requestHeaders)
+				responseHeaders = redactSensitiveHeaders(responseHeaders)
+			}
+
 			// Create log item
 			var errorMessage string
 			if err != nil {
@@ -68,10 +78,10 @@ func redisLoggerMiddleware() Middleware {
 				StartedAt:          start,
 				Method:             req.Method,
 				URL:                req.URL.String(),
-				RequestHeaders:     removeSensitiveHeaders(req.Header),
+				RequestHeaders:     requestHeaders,
 				RequestBody:        string(requestBody),
 				StatusCode:         int32(resp.StatusCode),
-				ResponseHeaders:    removeSensitiveHeaders(resp.Header),
+				ResponseHeaders:    responseHeaders,
 				Duration:           duration.Seconds(),
 				ErrorMessage:       errorMessage,
 				CreationStackFrame: formatStackFrame(creatorStackFrame),
@@ -185,7 +195,7 @@ func getAllValuesAfter(ctx context.Context, c *rcache.Cache, after string, limit
 	return c.GetMulti(keys...), nil
 }
 
-func removeSensitiveHeaders(headers http.Header) http.Header {
+func redactSensitiveHeaders(headers http.Header) http.Header {
 	var cleanHeaders = make(http.Header)
 	for name, values := range headers {
 		if IsRiskyHeader(name, values) {

--- a/internal/httpcli/redis_logger_middleware_test.go
+++ b/internal/httpcli/redis_logger_middleware_test.go
@@ -34,7 +34,7 @@ func TestRedisLoggerMiddleware_getAllValuesAfter(t *testing.T) {
 	assert.Len(t, got, 2)
 }
 
-func TestRedisLoggerMiddleware_removeSensitiveHeaders(t *testing.T) {
+func TestRedisLoggerMiddleware_redactSensitiveHeaders(t *testing.T) {
 	input := http.Header{
 		"Authorization":   []string{"all values", "should be", "removed"},
 		"Bearer":          []string{"this should be kept as the risky value is only in the name"},
@@ -60,7 +60,7 @@ func TestRedisLoggerMiddleware_removeSensitiveHeaders(t *testing.T) {
 		}
 	}
 
-	cleanHeaders := removeSensitiveHeaders(input)
+	cleanHeaders := redactSensitiveHeaders(input)
 
 	if diff := cmp.Diff(cleanHeaders, want); diff != "" {
 		t.Errorf("unexpected request headers (-have +want):\n%s", diff)
@@ -79,7 +79,7 @@ func TestCache_DeleteFirstN(t *testing.T) {
 	c.SetMulti(pairs...)
 
 	// Delete the first 4 key-value pairs
-	deleteExcessItems(c, 4)
+	_ = deleteExcessItems(c, 4)
 
 	got, listErr := c.ListKeys(context.Background())
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2214,8 +2214,6 @@ type SiteConfiguration struct {
 	OrganizationInvitations *OrganizationInvitations `json:"organizationInvitations,omitempty"`
 	// OutboundRequestLogLimit description: The maximum number of outbound requests to retain. This is a global limit across all outbound requests. If the limit is exceeded, older items will be deleted. If the limit is 0, no outbound requests are logged.
 	OutboundRequestLogLimit int `json:"outboundRequestLogLimit,omitempty"`
-	// RedactOutboundRequestHeaders description: Enables redacting sensitive information from outbound requests. Important: We only respect this setting in development environments. In production, we always redact outbound requests.
-	RedactOutboundRequestHeaders *bool `json:"redactOutboundRequestHeaders,omitempty"`
 	// ParentSourcegraph description: URL to fetch unreachable repository details from. Defaults to "https://sourcegraph.com"
 	ParentSourcegraph *ParentSourcegraph `json:"parentSourcegraph,omitempty"`
 	// PermissionsSyncOldestRepos description: Number of repo permissions to schedule for syncing in single scheduler iteration.
@@ -2234,6 +2232,8 @@ type SiteConfiguration struct {
 	PermissionsUserMapping *PermissionsUserMapping `json:"permissions.userMapping,omitempty"`
 	// ProductResearchPageEnabled description: Enables users access to the product research page in their settings.
 	ProductResearchPageEnabled *bool `json:"productResearchPage.enabled,omitempty"`
+	// RedactOutboundRequestHeaders description: Enables redacting sensitive information from outbound requests. Important: We only respect this setting in development environments. In production, we always redact outbound requests.
+	RedactOutboundRequestHeaders *bool `json:"redactOutboundRequestHeaders,omitempty"`
 	// RepoConcurrentExternalServiceSyncers description: The number of concurrent external service syncers that can run.
 	RepoConcurrentExternalServiceSyncers int `json:"repoConcurrentExternalServiceSyncers,omitempty"`
 	// RepoListUpdateInterval description: Interval (in minutes) for checking code hosts (such as GitHub, Gitolite, etc.) for new repositories.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2214,6 +2214,8 @@ type SiteConfiguration struct {
 	OrganizationInvitations *OrganizationInvitations `json:"organizationInvitations,omitempty"`
 	// OutboundRequestLogLimit description: The maximum number of outbound requests to retain. This is a global limit across all outbound requests. If the limit is exceeded, older items will be deleted. If the limit is 0, no outbound requests are logged.
 	OutboundRequestLogLimit int `json:"outboundRequestLogLimit,omitempty"`
+	// RedactOutboundRequestHeaders description: Enables redacting sensitive information from outbound requests. Important: We only respect this setting in development environments. In production, we always redact outbound requests.
+	RedactOutboundRequestHeaders *bool `json:"redactOutboundRequestHeaders,omitempty"`
 	// ParentSourcegraph description: URL to fetch unreachable repository details from. Defaults to "https://sourcegraph.com"
 	ParentSourcegraph *ParentSourcegraph `json:"parentSourcegraph,omitempty"`
 	// PermissionsSyncOldestRepos description: Number of repo permissions to schedule for syncing in single scheduler iteration.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1886,10 +1886,19 @@
       "default": 50,
       "maximum": 500
     },
+    "redactOutboundRequestHeaders": {
+      "description": "Enables redacting sensitive information from outbound requests. Important: We only respect this setting in development environments. In production, we always redact outbound requests.",
+      "type": "boolean",
+      "!go": {
+        "pointer": true
+      }
+    },
     "organizationInvitations": {
       "description": "Configuration for organization invitations.",
       "type": "object",
-      "required": ["signingKey"],
+      "required": [
+        "signingKey"
+      ],
       "properties": {
         "expiryTime": {
           "description": "Time before the invitation expires, in hours (experimental, not enforced at the moment).",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1896,9 +1896,7 @@
     "organizationInvitations": {
       "description": "Configuration for organization invitations.",
       "type": "object",
-      "required": [
-        "signingKey"
-      ],
+      "required": ["signingKey"],
       "properties": {
         "expiryTime": {
           "description": "Time before the invitation expires, in hours (experimental, not enforced at the moment).",


### PR DESCRIPTION
We have a "Copy curl" feature on the "Outbound requests" admin page, but sensitive headers are replaced with the string "REDACTED" so we can't reproduce logged requests without further manual copy&pasting.

This PR adds the `redactOutboundRequestHeaders` setting to site config that disables the sensitive header redaction behavior, making the "Copy curl" feature more useful. **We only respect this setting in development environments** to make sure we're not storing sensitive customer info in Redis.

## Test plan

[Half-min Loom](https://www.loom.com/share/550570e0408a4eab94811e77daade55c)
 - When `redactOutboundRequestHeaders == true`, sensitive fields are **redacted**
 - When `redactOutboundRequestHeaders == false`, sensitive fields are **not** redacted
 - When `redactOutboundRequestHeaders` is missing, sensitive fields are **redacted**
 - (Not in the Loom) When the environment is anything else than `dev`, sensitive fields are **redacted**.
   - Tested this one by setting `redactOutboundRequestHeaders: false` and starting Sourcegraph with `export DEPLOY_TYPE="helm" && sg start`.
