### PR TITLE
Add pagination support for commit ancestors

### DIFF
--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -326,7 +326,7 @@ func (r *GitCommitResolver) Ancestors(ctx context.Context, args *struct {
 	Query       *string
 	Path        *string
 	After       *string
-	AfterCursor *int32
+	AfterCursor *string
 }) (*gitCommitConnectionResolver, error) {
 	return &gitCommitConnectionResolver{
 		db:              r.db,

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -323,9 +323,10 @@ func (r *GitCommitResolver) LanguageStatistics(ctx context.Context) ([]*language
 
 func (r *GitCommitResolver) Ancestors(ctx context.Context, args *struct {
 	graphqlutil.ConnectionArgs
-	Query *string
-	Path  *string
-	After *string
+	Query  *string
+	Path   *string
+	After  *string
+	Offset *int32
 }) (*gitCommitConnectionResolver, error) {
 	return &gitCommitConnectionResolver{
 		db:              r.db,
@@ -335,6 +336,7 @@ func (r *GitCommitResolver) Ancestors(ctx context.Context, args *struct {
 		query:           args.Query,
 		path:            args.Path,
 		after:           args.After,
+		offset:          args.Offset,
 		repo:            r.repoResolver,
 	}, nil
 }

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -24,8 +24,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-const gitCommitKind = "GitCommit"
-
 func (r *schemaResolver) gitCommitByID(ctx context.Context, id graphql.ID) (*GitCommitResolver, error) {
 	repoID, commitID, err := unmarshalGitCommitID(id)
 	if err != nil {
@@ -106,7 +104,7 @@ type gitCommitGQLID struct {
 }
 
 func marshalGitCommitID(repo graphql.ID, commitID GitObjectID) graphql.ID {
-	return relay.MarshalID(gitCommitKind, gitCommitGQLID{Repository: repo, CommitID: commitID})
+	return relay.MarshalID("GitCommit", gitCommitGQLID{Repository: repo, CommitID: commitID})
 }
 
 func unmarshalGitCommitID(id graphql.ID) (repoID graphql.ID, commitID GitObjectID, err error) {

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -24,6 +24,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+const gitCommitKind = "GitCommit"
+
 func (r *schemaResolver) gitCommitByID(ctx context.Context, id graphql.ID) (*GitCommitResolver, error) {
 	repoID, commitID, err := unmarshalGitCommitID(id)
 	if err != nil {
@@ -104,7 +106,7 @@ type gitCommitGQLID struct {
 }
 
 func marshalGitCommitID(repo graphql.ID, commitID GitObjectID) graphql.ID {
-	return relay.MarshalID("GitCommit", gitCommitGQLID{Repository: repo, CommitID: commitID})
+	return relay.MarshalID(gitCommitKind, gitCommitGQLID{Repository: repo, CommitID: commitID})
 }
 
 func unmarshalGitCommitID(id graphql.ID) (repoID graphql.ID, commitID GitObjectID, err error) {

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -323,10 +323,10 @@ func (r *GitCommitResolver) LanguageStatistics(ctx context.Context) ([]*language
 
 func (r *GitCommitResolver) Ancestors(ctx context.Context, args *struct {
 	graphqlutil.ConnectionArgs
-	Query  *string
-	Path   *string
-	After  *string
-	Offset *int32
+	Query       *string
+	Path        *string
+	After       *string
+	AfterCursor *int32
 }) (*gitCommitConnectionResolver, error) {
 	return &gitCommitConnectionResolver{
 		db:              r.db,
@@ -336,7 +336,7 @@ func (r *GitCommitResolver) Ancestors(ctx context.Context, args *struct {
 		query:           args.Query,
 		path:            args.Path,
 		after:           args.After,
-		offset:          args.Offset,
+		afterCursor:     args.AfterCursor,
 		repo:            r.repoResolver,
 	}, nil
 }

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -208,9 +208,7 @@ func TestGitCommitAncestors(t *testing.T) {
 	}
 	c2 := gitdomain.Commit{
 		ID: api.CommitID("ccdde12345"),
-		Parents: []api.CommitID{
-			c1.ID,
-		},
+		Parents: []api.CommitID{c1.ID},
 	}
 	c3 := gitdomain.Commit{
 		ID:      api.CommitID("eeffg12345"),

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -182,14 +182,10 @@ func TestGitCommitFileNames(t *testing.T) {
 }
 
 func TestGitCommitAncestors(t *testing.T) {
-	externalServices := database.NewMockExternalServiceStore()
-	externalServices.ListFunc.SetDefaultReturn(nil, nil)
-
 	repos := database.NewMockRepoStore()
 	repos.GetFunc.SetDefaultReturn(&types.Repo{ID: 2, Name: "github.com/gorilla/mux"}, nil)
 
 	db := database.NewMockDB()
-	db.ExternalServicesFunc.SetDefaultReturn(externalServices)
 	db.ReposFunc.SetDefaultReturn(repos)
 
 	backend.Mocks.Repos.ResolveRev = func(ctx context.Context, repo *types.Repo, rev string) (api.CommitID, error) {

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -207,7 +207,7 @@ func TestGitCommitAncestors(t *testing.T) {
 		ID: api.CommitID("aabbc12345"),
 	}
 	c2 := gitdomain.Commit{
-		ID: api.CommitID("ccdde12345"),
+		ID:      api.CommitID("ccdde12345"),
 		Parents: []api.CommitID{c1.ID},
 	}
 	c3 := gitdomain.Commit{

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -292,7 +292,7 @@ func TestGitCommitAncestors(t *testing.T) {
 				}`,
 		},
 
-		// Start at commit c1 with offset:1.
+		// Start at commit c1 with afterCursor:1.
 		// Expect c2 and c3 in the nodes. 3 in the endCursor.
 		{
 			Schema: mustParseGraphQLSchemaWithClient(t, db, client),
@@ -300,7 +300,7 @@ func TestGitCommitAncestors(t *testing.T) {
 				{
 				  repository(name: "github.com/gorilla/mux") {
 					commit(rev: "aabbc12345") {
-					  ancestors(first: 2, path: "bill-of-materials.json", offset: 1) {
+					  ancestors(first: 2, path: "bill-of-materials.json", afterCursor: 1) {
 						nodes {
 						  id
 						  oid
@@ -342,7 +342,7 @@ func TestGitCommitAncestors(t *testing.T) {
 				}`,
 		},
 
-		// Start at commit c1 with offset:2
+		// Start at commit c1 with afterCursor:2
 		// Expect c3, c4, c5 in the nodes. No endCursor because there will be no new commits.
 		{
 			Schema: mustParseGraphQLSchemaWithClient(t, db, client),
@@ -350,7 +350,7 @@ func TestGitCommitAncestors(t *testing.T) {
 				{
 				  repository(name: "github.com/gorilla/mux") {
 					commit(rev: "aabbc12345") {
-					  ancestors(first: 3, path: "bill-of-materials.json", offset: 2) {
+					  ancestors(first: 3, path: "bill-of-materials.json", afterCursor: 2) {
 						nodes {
 						  id
 						  oid

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -300,7 +300,7 @@ func TestGitCommitAncestors(t *testing.T) {
 				{
 				  repository(name: "github.com/gorilla/mux") {
 					commit(rev: "aabbc12345") {
-					  ancestors(first: 2, path: "bill-of-materials.json", afterCursor: 1) {
+					  ancestors(first: 2, path: "bill-of-materials.json", afterCursor: "1") {
 						nodes {
 						  id
 						  oid
@@ -350,7 +350,7 @@ func TestGitCommitAncestors(t *testing.T) {
 				{
 				  repository(name: "github.com/gorilla/mux") {
 					commit(rev: "aabbc12345") {
-					  ancestors(first: 3, path: "bill-of-materials.json", afterCursor: 2) {
+					  ancestors(first: 3, path: "bill-of-materials.json", afterCursor: "2") {
 						nodes {
 						  id
 						  oid

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -279,6 +279,82 @@ func TestGitCommitAncestors(t *testing.T) {
 				}`,
 		},
 
+		// When first:0 and commits exist.
+		// Expect no nodes, but hasNextPage: true.
+		{
+			Schema: mustParseGraphQLSchemaWithClient(t, db, client),
+			Query: `
+				{
+				  repository(name: "github.com/gorilla/mux") {
+					commit(rev: "aabbc12345") {
+					  ancestors(first: 0, path: "bill-of-materials.json") {
+						nodes {
+						  id
+						  oid
+						  abbreviatedOID
+						}
+						pageInfo {
+						  endCursor
+						  hasNextPage
+						}
+					  }
+					}
+				  }
+				}`,
+			ExpectedResult: `
+				{
+				  "repository": {
+					"commit": {
+					  "ancestors": {
+						"nodes": [],
+						"pageInfo": {
+						  "endCursor": "0",
+						  "hasNextPage": true
+						}
+					  }
+					}
+				  }
+				}`,
+		},
+
+		// When first:0 and afterCursor: 5, no commits exist.
+		// Expect no nodes, but hasNextPage: false.
+		{
+			Schema: mustParseGraphQLSchemaWithClient(t, db, client),
+			Query: `
+				{
+				  repository(name: "github.com/gorilla/mux") {
+					commit(rev: "aabbc12345") {
+					  ancestors(first: 0, path: "bill-of-materials.json", afterCursor: "5") {
+						nodes {
+						  id
+						  oid
+						  abbreviatedOID
+						}
+						pageInfo {
+						  endCursor
+						  hasNextPage
+						}
+					  }
+					}
+				  }
+				}`,
+			ExpectedResult: `
+				{
+				  "repository": {
+					"commit": {
+					  "ancestors": {
+						"nodes": [],
+						"pageInfo": {
+                          "endCursor": null,
+						  "hasNextPage": false
+						}
+					  }
+					}
+				  }
+				}`,
+		},
+
 		// Start at commit c1.
 		// Expect c1 and c2 in the nodes. 2 in the endCursor.
 		{

--- a/cmd/frontend/graphqlbackend/git_commits.go
+++ b/cmd/frontend/graphqlbackend/git_commits.go
@@ -72,7 +72,7 @@ func (r *gitCommitConnectionResolver) compute(ctx context.Context) ([]*gitdomain
 		// same as not setting the flag.
 		afterCursor, err := r.afterCursorAsInt()
 		if err != nil {
-
+			return []*gitdomain.Commit{}, errors.Wrap(err, "failed to parse afterCursor")
 		}
 
 		return r.gitserverClient.Commits(ctx, r.repo.RepoName(), gitserver.CommitsOptions{

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -4549,7 +4549,7 @@ type GitCommit implements Node {
         """
         Skip the first N commits of the repo before returning the number of commits as set in the field "first".
         """
-        afterCursor: Int
+        afterCursor: String
     ): GitCommitConnection!
     """
     Returns the number of commits that this commit is behind and ahead of revspec.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -4549,7 +4549,7 @@ type GitCommit implements Node {
         """
         Skip the first N commits of the repo before returning the number of commits as set in the field "first".
         """
-        offset: Int
+        afterCursor: Int
     ): GitCommitConnection!
     """
     Returns the number of commits that this commit is behind and ahead of revspec.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -4545,6 +4545,11 @@ type GitCommit implements Node {
         Return commits more recent than the specified date.
         """
         after: String
+
+        """
+        Skip the first N commits of the repo before returning the number of commits as set in the field "first".
+        """
+        offset: Int
     ): GitCommitConnection!
     """
     Returns the number of commits that this commit is behind and ahead of revspec.


### PR DESCRIPTION
Updates GraphQL API for https://github.com/sourcegraph/sourcegraph/issues/44993. 

## Notes on approach

### Update 2022-12-08
After reviews and suggestions, approach has been updated. See [comment
](https://github.com/sourcegraph/sourcegraph/pull/45157#issuecomment-1343098557)

The section below is outdated but offers insight into the thought process that went into this PR early on.

Here are the following approaches (in order) that I tried and reverted at various stages before settling on the final solution proposed in this PR:

1. Add an `after` arg based on pagination guidelines from Relay [GraphQL Cursor Connections Specification](https://relay.dev/graphql/connections.htm)
	1. There is already a argument on the `ancestors` object named `after` which corresponds to the `--after` flag in the `git rev-list` / `git log` command and is used to indicate commits after a specific timestamp
2. Considered adding `afterCommit` with the following idea in mind:
	1. Deprecate `after` and add `afterTImestamp` to take its place
	2. Remove `after`
	3. Deprecate `afterCommit` add add `after` which would now imply to indicate after which commit the API should return the results

This approach sounded too long and complicated and I finally considered adding a field `revision` to the `ancestors` fragment.

But the cleanest way of all right now is to rely on the `GitCommit.Range` field since it already accepts a `rev` argument to indicate which commit should be returned by the API. In combination with the `first` argument to the `ancestors` field which is already in use.

The problem to be solved is simplified to only return a `cursor` in the `pageInfo` object so that clients can determine the next value for `rev` in subsequent API calls. 

In this PR, the `pageInfo` object will now contain an `endCursor` which is in accordance to the recommended pagination guidelines in the GraphQL spec. The only divergence here is not using an argument named `after` or `offset` in the `ancestors` field - a divergence which is well justified instead of trying to stick to the convention in exchange for a complicated API.

The final step before a client can use the value in the `endCursor` field is that they will need to decode the base64 string to reteive the commit spec - which is in the same format as that of a `GitCommit.ID` in our API that is a GraphQL ID.

## Test plan

1. Builds pass
2. Added tests
3. Tested locally

Example API call to test locally can be seen by following [this](https://sourcegraph.test:3443/api/console?trace=1#%7B%22query%22%3A%22query%20FetchCommits(%24repo%3A%20ID!%2C%20%24revision%3A%20String!%2C%20%24first%3A%20Int%2C%20%24currentPath%3A%20String%2C%20%24query%3A%20String%2C%20%24afterCursor%3A%20String)%20%7B%5Cn%20%20node(id%3A%20%24repo)%20%7B%5Cn%20%20%20%20__typename%5Cn%20%20%20%20...%20on%20Repository%20%7B%5Cn%20%20%20%20%20%20commit(rev%3A%20%24revision)%20%7B%5Cn%20%20%20%20%20%20%20%20ancestors(first%3A%20%24first%2C%20query%3A%20%24query%2C%20path%3A%20%24currentPath%2C%20afterCursor%3A%20%24afterCursor)%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20...CommitAncestorsConnectionFields%5Cn%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%5Cnfragment%20CommitAncestorsConnectionFields%20on%20GitCommitConnection%20%7B%5Cn%20%20nodes%20%7B%5Cn%20%20%20%20...GitCommitFields%5Cn%20%20%7D%5Cn%20%20pageInfo%20%7B%5Cn%20%20%20%20hasNextPage%5Cn%20%20%20%20endCursor%5Cn%20%20%7D%5Cn%7D%5Cn%5Cnfragment%20GitCommitFields%20on%20GitCommit%20%7B%5Cn%20%20abbreviatedOID%5Cn%20%20subject%5Cn%20%20author%20%7B%5Cn%20%20%20%20person%20%7B%5Cn%20%20%20%20%20%20name%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%22%2C%22operationName%22%3A%22FetchCommits%22%2C%22variables%22%3A%22%7B%5Cn%20%20%5C%22currentPath%5C%22%3A%20%5C%22bill-of-materials.json%5C%22%2C%5Cn%20%20%5C%22first%5C%22%3A%205%2C%5Cn%20%20%5C%22afterCursor%5C%22%3A%20%5C%222%5C%22%2C%5Cn%20%20%5C%22query%5C%22%3A%20%5C%22%5C%22%2C%5Cn%20%20%5C%22repo%5C%22%3A%20%5C%22UmVwb3NpdG9yeToz%5C%22%2C%5Cn%20%20%5C%22revision%5C%22%3A%20%5C%2209304a4%5C%22%5Cn%7D%22%7D) link provided your local dev instance already has the `github.com/sourcegraph-testing/etcd` repo cloned and available to serve search requests. 

You will probably need to update the value of `repo` in the variables to reflect the ID from your database.



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
