### PR TITLE
web: add webhook creation page.

### DIFF
--- a/client/web/src/site-admin/SiteAdminWebhookCreatePage.module.scss
+++ b/client/web/src/site-admin/SiteAdminWebhookCreatePage.module.scss
@@ -1,0 +1,16 @@
+.grid {
+    display: grid;
+    grid-template-columns: max-content max-content;
+    column-gap: 1rem;
+    row-gap: 0.5rem;
+}
+
+.first {
+    grid-column: 1 / 2;
+    min-width: 16rem;
+}
+
+.second {
+    grid-column: 2 / 3;
+    min-width: 16rem;
+}

--- a/client/web/src/site-admin/SiteAdminWebhookCreatePage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookCreatePage.story.tsx
@@ -1,0 +1,107 @@
+import { DecoratorFn, Meta, Story } from '@storybook/react'
+import * as H from 'history'
+import { of, throwError } from 'rxjs'
+
+import { asError } from '@sourcegraph/common'
+import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
+
+import { queryExternalServices as _queryExternalServices } from '../components/externalServices/backend'
+import { WebStory } from '../components/WebStory'
+import { ListExternalServiceFields } from '../graphql-operations'
+
+import { SiteAdminWebhookCreatePage } from './SiteAdminWebhookCreatePage'
+
+const decorator: DecoratorFn = Story => <Story />
+
+const config: Meta = {
+    title: 'web/src/site-admin/SiteAdminWebhookCreatePage',
+    decorators: [decorator],
+}
+
+export default config
+
+const queryExternalServices: typeof _queryExternalServices = () =>
+    of({
+        totalCount: 17,
+        pageInfo: {
+            endCursor: null,
+            hasNextPage: false,
+        },
+        nodes: [
+            createExternalService(ExternalServiceKind.GITHUB, 'https://github.com'),
+            createExternalService(ExternalServiceKind.BITBUCKETCLOUD, 'https://bitbucket.org'),
+            createExternalService(ExternalServiceKind.BITBUCKETSERVER, 'https://sgdev.bitbucket.org'),
+            createExternalService(ExternalServiceKind.BITBUCKETSERVER, 'https://sgprod.bitbucket.org'),
+            createExternalService(ExternalServiceKind.GERRIT, 'https://gerrit.com'),
+            createExternalService(ExternalServiceKind.GITLAB, 'https://gitlab.com'),
+            createExternalService(ExternalServiceKind.GITOLITE, 'https://gitolite.com'),
+            createExternalService(ExternalServiceKind.GOMODULES, 'https://gomodules.com'),
+            createExternalService(ExternalServiceKind.JVMPACKAGES, 'https://jvmpackages.com'),
+            createExternalService(ExternalServiceKind.NPMPACKAGES, 'https://npmpackages.com'),
+            createExternalService(ExternalServiceKind.OTHER, 'https://other.com'),
+            createExternalService(ExternalServiceKind.PAGURE, 'https://pagure.com'),
+            createExternalService(ExternalServiceKind.PERFORCE, 'https://perforce.com'),
+            createExternalService(ExternalServiceKind.PHABRICATOR, 'https://phabricator.com'),
+            createExternalService(ExternalServiceKind.PYTHONPACKAGES, 'https://pythonpackages.com'),
+            createExternalService(ExternalServiceKind.RUSTPACKAGES, 'https://rustpackages.com'),
+            createExternalService(ExternalServiceKind.RUBYPACKAGES, 'https://rubypackages.com'),
+        ],
+    })
+
+function createExternalService(kind: ExternalServiceKind, url: string): ListExternalServiceFields {
+    return {
+        id: 'service1',
+        kind,
+        displayName: `${kind}-123`,
+        config: `{"url": "${url}"}`,
+        warning: null,
+        lastSyncError: null,
+        repoCount: 0,
+        lastSyncAt: null,
+        nextSyncAt: null,
+        updatedAt: '2021-03-15T19:39:11Z',
+        createdAt: '2021-03-15T19:39:11Z',
+        namespace: null,
+        webhookURL: null
+    }
+}
+
+export const WebhookCreatePage: Story = () => (
+    <WebStory>
+        {() => (
+            <MockedTestProvider>
+                <SiteAdminWebhookCreatePage
+                    match={{} as any}
+                    history={H.createMemoryHistory()}
+                    location={{} as any}
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                    queryExternalServices={queryExternalServices}
+                />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
+
+WebhookCreatePage.storyName = 'Create webhook'
+
+const queryExternalServicesError: typeof _queryExternalServices = () => throwError(asError('oops'))
+
+export const WebhookCreatePageWithError: Story = () => (
+    <WebStory>
+        {() => (
+            <MockedTestProvider>
+                <SiteAdminWebhookCreatePage
+                    match={{} as any}
+                    history={H.createMemoryHistory()}
+                    location={{} as any}
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                    queryExternalServices={queryExternalServicesError}
+                />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
+
+WebhookCreatePageWithError.storyName = 'Error during external services fetch'

--- a/client/web/src/site-admin/SiteAdminWebhookCreatePage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookCreatePage.story.tsx
@@ -63,8 +63,7 @@ function createExternalService(kind: ExternalServiceKind, url: string): ListExte
         nextSyncAt: null,
         updatedAt: '2021-03-15T19:39:11Z',
         createdAt: '2021-03-15T19:39:11Z',
-        namespace: null,
-        webhookURL: null
+        webhookURL: null,
     }
 }
 

--- a/client/web/src/site-admin/SiteAdminWebhookCreatePage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookCreatePage.tsx
@@ -50,7 +50,6 @@ export const SiteAdminWebhookCreatePage: FC<SiteAdminWebhookCreatePageProps> = (
         telemetryService.logPageView('SiteAdminWebhookCreatePage')
     }, [telemetryService])
 
-    const [kinds, setKinds] = useState<ExternalServiceKind[]>([])
     const [webhook, setWebhook] = useState<Webhook>({
         name: '',
         codeHostKind: null,
@@ -88,7 +87,6 @@ export const SiteAdminWebhookCreatePage: FC<SiteAdminWebhookCreatePageProps> = (
             // If there are no external services, then the warning is shown and webhook creation is blocked
             if (kindToUrlMap.size > 0) {
                 const kindsArray = Array.from(kindToUrlMap.keys())
-                setKinds(kindsArray)
                 const currentKind = kindsArray[0]
                 // we always generate a secret once and assign it to the webhook. Bitbucket Cloud special case
                 // is handled is an Input and during GraphQL query creation.
@@ -172,10 +170,10 @@ export const SiteAdminWebhookCreatePage: FC<SiteAdminWebhookCreatePageProps> = (
                                     label={<span className="small">Code host type</span>}
                                     required={true}
                                     onChange={onCodeHostTypeChange}
-                                    disabled={loading || kinds.length === 0}
+                                    disabled={loading || kindsToUrls.size === 0}
                                 >
-                                    {kinds.length > 0 &&
-                                        kinds.map(kind => (
+                                    {kindsToUrls.size > 0 &&
+                                        Array.from(kindsToUrls.keys()).map(kind => (
                                             <option value={kind} key={kind}>
                                                 {prettyPrintExternalServiceKind(kind)}
                                             </option>

--- a/client/web/src/site-admin/SiteAdminWebhookCreatePage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookCreatePage.tsx
@@ -4,10 +4,10 @@ import { mdiCog } from '@mdi/js'
 import classNames from 'classnames'
 import { noop } from 'lodash'
 import { RouteComponentProps } from 'react-router'
-import {catchError} from 'rxjs/operators';
+import { catchError } from 'rxjs/operators'
 
 import { Form } from '@sourcegraph/branded/src/components/Form'
-import {asError, ErrorLike, isErrorLike} from '@sourcegraph/common'
+import { asError, ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { useMutation } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Alert, Button, Container, H2, Input, PageHeader, Select, useObservable } from '@sourcegraph/wildcard'
@@ -58,11 +58,14 @@ export const SiteAdminWebhookCreatePage: FC<SiteAdminWebhookCreatePageProps> = (
     const [kindsToUrls, setKindsToUrls] = useState<Map<ExternalServiceKind, string[]>>(new Map())
 
     const extSvcKindsOrError: ExternalServicesResult['externalServices'] | undefined | ErrorLike = useObservable(
-        useMemo(() => queryExternalServices({
+        useMemo(
+            () =>
+                queryExternalServices({
                     first: null,
                     after: null,
-                    namespace: null,
-                }).pipe(catchError(error => [asError(error)])), [queryExternalServices])
+                }).pipe(catchError(error => [asError(error)])),
+            [queryExternalServices]
+        )
     )
 
     useMemo(() => {

--- a/client/web/src/site-admin/SiteAdminWebhookCreatePage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookCreatePage.tsx
@@ -1,0 +1,279 @@
+import React, { FC, useCallback, useEffect, useMemo, useState } from 'react'
+
+import { mdiCog } from '@mdi/js'
+import classNames from 'classnames'
+import { noop } from 'lodash'
+import { RouteComponentProps } from 'react-router'
+import {catchError} from 'rxjs/operators';
+
+import { Form } from '@sourcegraph/branded/src/components/Form'
+import {asError, ErrorLike, isErrorLike} from '@sourcegraph/common'
+import { useMutation } from '@sourcegraph/http-client'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { Alert, Button, Container, H2, Input, PageHeader, Select, useObservable } from '@sourcegraph/wildcard'
+
+import { queryExternalServices as _queryExternalServices } from '../components/externalServices/backend'
+import { PageTitle } from '../components/PageTitle'
+import {
+    CreateWebhookResult,
+    CreateWebhookVariables,
+    ExternalServiceKind,
+    ExternalServicesResult,
+} from '../graphql-operations'
+
+import { CREATE_WEBHOOK_QUERY } from './backend'
+
+import styles from './SiteAdminWebhookCreatePage.module.scss'
+
+export interface SiteAdminWebhookCreatePageProps extends TelemetryProps, RouteComponentProps<{}> {
+    /** For testing only. */
+    queryExternalServices?: typeof _queryExternalServices
+}
+
+interface Webhook {
+    name: string
+    codeHostKind: ExternalServiceKind | null
+    codeHostURN: string
+    secret: string | null
+}
+
+export const SiteAdminWebhookCreatePage: FC<SiteAdminWebhookCreatePageProps> = ({
+    telemetryService,
+    history,
+    queryExternalServices = _queryExternalServices,
+}) => {
+    const [loading, setLoading] = useState(true)
+
+    useEffect(() => {
+        telemetryService.logPageView('SiteAdminWebhookCreatePage')
+    }, [telemetryService])
+
+    const [kinds, setKinds] = useState<ExternalServiceKind[]>([])
+    const [webhook, setWebhook] = useState<Webhook>({
+        name: '',
+        codeHostKind: null,
+        codeHostURN: '',
+        secret: null,
+    })
+    const [kindsToUrls, setKindsToUrls] = useState<Map<ExternalServiceKind, string[]>>(new Map())
+
+    const extSvcKindsOrError: ExternalServicesResult['externalServices'] | undefined | ErrorLike = useObservable(
+        useMemo(() => queryExternalServices({
+                    first: null,
+                    after: null,
+                    namespace: null,
+                }).pipe(catchError(error => [asError(error)])), [queryExternalServices])
+    )
+
+    useMemo(() => {
+        if (extSvcKindsOrError && !isErrorLike(extSvcKindsOrError)) {
+            const kindToUrlMap = extSvcKindsOrError.nodes.reduce(
+                (svcMap, extSvc) =>
+                    svcMap.set(extSvc.kind, (svcMap.get(extSvc.kind) || []).concat([JSON.parse(extSvc.config).url])),
+                new Map<ExternalServiceKind, string[]>()
+            )
+            setKindsToUrls(kindToUrlMap)
+            // If there are no external services, then the warning is shown and webhook creation is blocked
+            if (kindToUrlMap.size > 0) {
+                const extSvcKinds = new Set(extSvcKindsOrError.nodes.map(node => node.kind))
+                const kindsArray = Array.from(extSvcKinds)
+                setKinds(kindsArray)
+                const currentKind = kindsArray[0]
+                setWebhook(webhook => ({
+                    ...webhook,
+                    secret: generateSecret(),
+                    codeHostURN: kindToUrlMap.get(currentKind)?.[0] || '',
+                    codeHostKind: currentKind,
+                }))
+            }
+            setLoading(false)
+        }
+    }, [extSvcKindsOrError])
+
+    const onCodeHostTypeChange = useCallback<React.ChangeEventHandler<HTMLSelectElement>>(
+        event => {
+            const selected = event.target.value as ExternalServiceKind
+            setWebhook(webhook => ({
+                ...webhook,
+                codeHostKind: selected,
+                codeHostURN: kindsToUrls.get(selected)?.[0] || '',
+            }))
+        },
+        [kindsToUrls]
+    )
+    const onCodeHostUrnChange = useCallback<React.ChangeEventHandler<HTMLSelectElement>>(event => {
+        setWebhook(webhook => ({ ...webhook, codeHostURN: event.target.value }))
+    }, [])
+    const onNameChange = useCallback((name: string): void => {
+        setWebhook(webhook => ({ ...webhook, name }))
+    }, [])
+    const onSecretChange = useCallback((secret: string): void => {
+        setWebhook(webhook => ({ ...webhook, secret: secret.length === 0 ? null : secret }))
+    }, [])
+
+    const [createWebhook, { error: createWebhookError, loading: creationLoading }] = useMutation<
+        CreateWebhookResult,
+        CreateWebhookVariables
+    >(CREATE_WEBHOOK_QUERY, { onCompleted: data => history.push(`/site-admin/webhooks/${data.createWebhook.id}`) })
+
+    return (
+        <Container>
+            <PageTitle title="Incoming webhook" />
+            <PageHeader
+                path={[{ icon: mdiCog }, { to: '/site-admin/webhooks', text: 'Incoming webhooks' }, { text: 'Create' }]}
+                className="mb-3"
+                headingElement="h2"
+            />
+
+            {isErrorLike(extSvcKindsOrError) && (
+                <Alert variant="danger" className="mt-2">
+                    Error during getting external services.
+                </Alert>
+            )}
+            {!isErrorLike(extSvcKindsOrError) && kindsToUrls.size === 0 && (
+                <Alert variant="warning" className="mt-2">
+                    Please add an external service to proceed with webhooks creation.
+                </Alert>
+            )}
+            {!isErrorLike(extSvcKindsOrError) && kindsToUrls.size > 0 && (
+                <div>
+                    <H2>Information</H2>
+                    <Form
+                        onSubmit={event => {
+                            event.preventDefault()
+                            createWebhook({ variables: convertWebhookToCreateWebhookVariables(webhook) }).catch(noop)
+                        }}
+                    >
+                        <div className={styles.grid}>
+                            <Input
+                                className={classNames(styles.first, 'flex-1 mb-0')}
+                                label={<span className="small">Webhook name</span>}
+                                pattern="^[a-zA-Z0-9_'\-\/\.\s]+$"
+                                required={true}
+                                onChange={event => {
+                                    onNameChange(event.target.value)
+                                }}
+                                maxLength={100}
+                            />
+                            <Select
+                                id="code-host-type-select"
+                                className={classNames(styles.first, 'flex-1 mb-0')}
+                                label={<span className="small">Code host type</span>}
+                                required={true}
+                                onChange={onCodeHostTypeChange}
+                                disabled={loading || kinds.length === 0}
+                            >
+                                {kinds.length > 0 &&
+                                    kinds.map(kind => (
+                                        <option value={kind} key={kind}>
+                                            {prettyPrintExternalServiceKind(kind)}
+                                        </option>
+                                    ))}
+                                {kinds.length === 0 && <option>Please create external service</option>}
+                            </Select>
+                            <Select
+                                id="code-host-urn-select"
+                                className={classNames(styles.second, 'flex-1 mb-0')}
+                                label={<span className="small">Code host URN</span>}
+                                required={true}
+                                onChange={onCodeHostUrnChange}
+                                disabled={loading || !webhook.codeHostKind}
+                            >
+                                {webhook.codeHostKind &&
+                                    kindsToUrls.get(webhook.codeHostKind) &&
+                                    kindsToUrls.get(webhook.codeHostKind)?.map(urn => (
+                                        <option value={urn} key={urn}>
+                                            {urn}
+                                        </option>
+                                    ))}
+                            </Select>
+                            <Input
+                                className={classNames(styles.first, 'flex-1 mb-0')}
+                                message={<small>Randomly generated. Alter as required. </small>}
+                                label={<span className="small">Secret</span>}
+                                pattern="^[a-zA-Z0-9]+$"
+                                onChange={event => {
+                                    onSecretChange(event.target.value)
+                                }}
+                                value={webhook.secret || ''}
+                                maxLength={100}
+                            />
+                        </div>
+                        <Button
+                            className="mt-2"
+                            type="submit"
+                            variant="primary"
+                            disabled={creationLoading || webhook.name.trim() === ''}
+                        >
+                            Create
+                        </Button>
+                        {createWebhookError && (
+                            <Alert variant="danger" className="mt-2">
+                                Failed to create webhook: {createWebhookError.message}
+                            </Alert>
+                        )}
+                    </Form>
+                </div>
+            )}
+        </Container>
+    )
+}
+
+function prettyPrintExternalServiceKind(kind: ExternalServiceKind): string {
+    switch (kind) {
+        case ExternalServiceKind.AWSCODECOMMIT:
+            return 'AWS CodeCommit'
+        case ExternalServiceKind.BITBUCKETCLOUD:
+            return 'Bitbucket Cloud'
+        case ExternalServiceKind.BITBUCKETSERVER:
+            return 'Bitbucket Server'
+        case ExternalServiceKind.GERRIT:
+            return 'Gerrit'
+        case ExternalServiceKind.GITHUB:
+            return 'GitHub'
+        case ExternalServiceKind.GITLAB:
+            return 'GitLab'
+        case ExternalServiceKind.GITOLITE:
+            return 'Gitolite'
+        case ExternalServiceKind.GOMODULES:
+            return 'Go Modules'
+        case ExternalServiceKind.JVMPACKAGES:
+            return 'JVM packages'
+        case ExternalServiceKind.NPMPACKAGES:
+            return 'NPM packages'
+        case ExternalServiceKind.OTHER:
+            return 'Other'
+        case ExternalServiceKind.PAGURE:
+            return 'Pagure'
+        case ExternalServiceKind.PERFORCE:
+            return 'Perforce'
+        case ExternalServiceKind.PHABRICATOR:
+            return 'Phabricator'
+        case ExternalServiceKind.PYTHONPACKAGES:
+            return 'Python packages'
+        case ExternalServiceKind.RUSTPACKAGES:
+            return 'Rust packages'
+        case ExternalServiceKind.RUBYPACKAGES:
+            return 'Ruby packages'
+        default:
+            return kind
+    }
+}
+
+function convertWebhookToCreateWebhookVariables(webhook: Webhook): CreateWebhookVariables {
+    return {
+        name: webhook.name,
+        codeHostKind: webhook.codeHostKind || ExternalServiceKind.OTHER,
+        codeHostURN: webhook.codeHostURN,
+        secret: webhook.secret,
+    }
+}
+
+function generateSecret(): string {
+    let text = ''
+    const possible = 'ABCDEF0123456789'
+    for (let index = 0; index < 12; index++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length))
+    }
+    return text
+}

--- a/client/web/src/site-admin/SiteAdminWebhookPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookPage.tsx
@@ -63,12 +63,13 @@ export const SiteAdminWebhookPage: FC<WebhookPageProps> = props => {
                             updatedBy={webhookData.node.updatedBy}
                         />
                     }
-                    className="test-batch-change-close-page mb-3"
+                    className="mb-3"
                     headingElement="h2"
                     actions={
                         <div className="d-flex flex-row-reverse align-items-center">
                             <div className="flex-grow mr-2">
                                 <ButtonLink
+                                    to="/site-admin/webhooks/create"
                                     className="test-create-webhook"
                                     size="sm"
                                     variant="primary"

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
@@ -44,7 +44,7 @@ export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChild
                 description="All configured incoming webhooks"
                 className="mb-3"
                 actions={
-                    <ButtonLink className="test-create-webhook" variant="primary">
+                    <ButtonLink to="/site-admin/webhooks/create" className="test-create-webhook" variant="primary">
                         <Icon aria-hidden={true} svgPath={mdiPlus} /> Add webhook
                     </ButtonLink>
                 }

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -1029,3 +1029,11 @@ export const useWebhookLogsConnection = (
             return webhookLogs
         },
     })
+
+export const CREATE_WEBHOOK_QUERY = gql`
+    mutation CreateWebhook($name: String!, $codeHostKind: String!, $codeHostURN: String!, $secret: String) {
+        createWebhook(name: $name, codeHostKind: $codeHostKind, codeHostURN: $codeHostURN, secret: $secret) {
+            id
+        }
+    }
+`

--- a/client/web/src/site-admin/routes.tsx
+++ b/client/web/src/site-admin/routes.tsx
@@ -105,6 +105,11 @@ export const siteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
         render: lazyComponent(() => import('./SiteAdminWebhooksPage'), 'SiteAdminWebhooksPage'),
     },
     {
+        path: '/webhooks/create',
+        exact: true,
+        render: lazyComponent(() => import('./SiteAdminWebhookCreatePage'), 'SiteAdminWebhookCreatePage'),
+    },
+    {
         path: '/webhooks/:id',
         exact: true,
         render: lazyComponent(() => import('./SiteAdminWebhookPage'), 'SiteAdminWebhookPage'),


### PR DESCRIPTION
### Quick demo

https://user-images.githubusercontent.com/94846361/205638661-ce6254a7-179b-4019-8dce-65c46d3cbeac.mov

### Test plan
Storybook and local sg run.

Closes https://github.com/sourcegraph/sourcegraph/issues/43488. (finally)

## App preview:

- [Web](https://sg-web-ao-ui-webhooks-create-webhook-view.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
