### PR TITLE
[Pagination] add new connection resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver.go
@@ -1,0 +1,279 @@
+package graphqlutil
+
+import (
+	"context"
+	"sync"
+
+	"github.com/graph-gophers/graphql-go"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+const DEFAULT_MAX_PAGE_SIZE = 100
+
+type ConnectionResolver[N ConnectionNode] struct {
+	store   ConnectionResolverStore[N]
+	args    *ConnectionResolverArgs
+	options *ConnectionResolverOptions
+	data    connectionData[N]
+	once    resolveOnce
+}
+
+type ConnectionNode interface {
+	ID() graphql.ID
+}
+
+type ConnectionResolverStore[N ConnectionNode] interface {
+	// ComputeTotal returns the total count of all the items in the connection, independent of pagination arguments.
+	ComputeTotal(context.Context) (*int32, error)
+	// ComputeNodes returns the list of nodes based on the pagination args.
+	ComputeNodes(context.Context, *database.PaginationArgs) ([]*N, error)
+	// MarshalCursor returns cursor for a node and is called for generating start and end cursors.
+	MarshalCursor(*N) (*string, error)
+	// UnmarshalCursor returns node id from after/before cursor string.
+	UnmarshalCursor(string) (*int, error)
+}
+
+type ConnectionResolverArgs struct {
+	First  *int32
+	Last   *int32
+	After  *string
+	Before *string
+}
+
+// Limit returns max nodes limit based on resolver arguments
+func (a *ConnectionResolverArgs) Limit(options *ConnectionResolverOptions) int {
+	var limit *int32
+
+	if a.First != nil {
+		limit = a.First
+	} else {
+		limit = a.Last
+	}
+
+	return options.ApplyMaxPageSize(limit)
+}
+
+type ConnectionResolverOptions struct {
+	maxPageSize *int
+}
+
+// MaxPageSize returns the configured max page limit for the connection
+func (o *ConnectionResolverOptions) MaxPageSize() int {
+	if o.maxPageSize != nil {
+		return *o.maxPageSize
+	}
+
+	return DEFAULT_MAX_PAGE_SIZE
+}
+
+// ApplyMaxPageSize return max page size by applying the configured max limit to the first, last arguments
+func (o *ConnectionResolverOptions) ApplyMaxPageSize(limit *int32) int {
+	maxPageSize := o.MaxPageSize()
+
+	if limit == nil {
+		return maxPageSize
+	}
+
+	if int(*limit) < maxPageSize {
+		return int(*limit)
+	}
+
+	return maxPageSize
+}
+
+type connectionData[N ConnectionNode] struct {
+	total      *int32
+	totalError error
+
+	nodes      []*N
+	nodesError error
+}
+
+type resolveOnce struct {
+	total sync.Once
+	nodes sync.Once
+}
+
+func (r *ConnectionResolver[N]) paginationArgs() (*database.PaginationArgs, error) {
+	if r.args == nil {
+		return nil, nil
+	}
+
+	paginationArgs := database.PaginationArgs{}
+
+	limit := r.pageSize() + 1
+	if r.args.First != nil {
+		paginationArgs.First = &limit
+	} else if r.args.Last != nil {
+		paginationArgs.Last = &limit
+	} else {
+		return nil, errors.New("you must provide a `first` or `last` value to properly paginate")
+	}
+
+	if r.args.After != nil {
+		after, err := r.store.UnmarshalCursor(*r.args.After)
+		if err != nil {
+			return nil, err
+		}
+
+		paginationArgs.After = after
+	}
+
+	if r.args.Before != nil {
+		before, err := r.store.UnmarshalCursor(*r.args.Before)
+		if err != nil {
+			return nil, err
+		}
+
+		paginationArgs.Before = before
+	}
+
+	return &paginationArgs, nil
+}
+
+func (r *ConnectionResolver[N]) pageSize() int {
+	return r.args.Limit(r.options)
+}
+
+// TotalCount returns value for connection.totalCount and is called by the graphql api.
+func (r *ConnectionResolver[N]) TotalCount(ctx context.Context) (int32, error) {
+	r.once.total.Do(func() {
+		r.data.total, r.data.totalError = r.store.ComputeTotal(ctx)
+	})
+
+	if r.data.totalError != nil || r.data.total == nil {
+		return 0, r.data.totalError
+	}
+
+	return *r.data.total, r.data.totalError
+}
+
+// Nodes returns value for connection.Nodes and is called by the graphql api.
+func (r *ConnectionResolver[N]) Nodes(ctx context.Context) ([]*N, error) {
+	r.once.nodes.Do(func() {
+		paginationArgs, err := r.paginationArgs()
+		if err != nil {
+			r.data.nodesError = err
+			return
+		}
+
+		r.data.nodes, r.data.nodesError = r.store.ComputeNodes(ctx, paginationArgs)
+
+		// NOTE(naman): with `last` argument the items are sorted in opposite
+		// direction in the SQL query. Here we are reversing the list to return
+		// them in correct order, to reduce complexity.
+		if r.args.Last != nil {
+			for i, j := 0, len(r.data.nodes)-1; i < j; i, j = i+1, j-1 {
+				r.data.nodes[i], r.data.nodes[j] = r.data.nodes[j], r.data.nodes[i]
+			}
+		}
+	})
+
+	nodes := r.data.nodes
+
+	// NOTE(naman): we pass actual_limit + 1 to SQL query so that we
+	// can check for `hasNextPage`. Here we need to remove the extra item,
+	// last item in case of `first` and first item in case of `last` as
+	// they are sorted in opposite directions in SQL query.
+	if len(nodes) > r.pageSize() {
+		if r.args.Last != nil {
+			nodes = nodes[1:]
+		} else {
+			nodes = nodes[:len(nodes)-1]
+		}
+	}
+
+	return nodes, r.data.nodesError
+}
+
+// PageInfo returns value for connection.pageInfo and is called by the graphql api.
+func (r *ConnectionResolver[N]) PageInfo(ctx context.Context) (*ConnectionPageInfo[N], error) {
+	nodes, err := r.Nodes(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ConnectionPageInfo[N]{
+		pageSize:          r.pageSize(),
+		fetchedNodesCount: len(r.data.nodes),
+		nodes:             nodes,
+		store:             r.store,
+		args:              r.args,
+	}, nil
+}
+
+type ConnectionPageInfo[N ConnectionNode] struct {
+	pageSize          int
+	fetchedNodesCount int
+	nodes             []*N
+	store             ConnectionResolverStore[N]
+	args              *ConnectionResolverArgs
+}
+
+// HasNextPage returns value for connection.pageInfo.hasNextPage and is called by the graphql api.
+func (p *ConnectionPageInfo[N]) HasNextPage() bool {
+	if p.args.First != nil {
+		return p.fetchedNodesCount > p.pageSize
+	}
+
+	if p.fetchedNodesCount == 0 {
+		return false
+	}
+
+	return p.args.Before != nil
+}
+
+// HasPreviousPage returns value for connection.pageInfo.hasPreviousPage and is called by the graphql api.
+func (p *ConnectionPageInfo[N]) HasPreviousPage() bool {
+	if p.args.Last != nil {
+		return p.fetchedNodesCount > p.pageSize
+	}
+
+	if p.fetchedNodesCount == 0 {
+		return false
+	}
+
+	return p.args.After != nil
+}
+
+// EndCursor returns value for connection.pageInfo.endCursor and is called by the graphql api.
+func (p *ConnectionPageInfo[N]) EndCursor() (cursor *string, err error) {
+	if len(p.nodes) == 0 {
+		return nil, nil
+	}
+
+	cursor, err = p.store.MarshalCursor(p.nodes[len(p.nodes)-1])
+
+	return
+}
+
+// StartCursor returns value for connection.pageInfo.startCursor and is called by the graphql api.
+func (p *ConnectionPageInfo[N]) StartCursor() (cursor *string, err error) {
+	if len(p.nodes) == 0 {
+		return nil, nil
+	}
+
+	cursor, err = p.store.MarshalCursor(p.nodes[0])
+
+	return
+}
+
+// NewConnectionResolver returns a new connection resolver built using the store and connection args.
+func NewConnectionResolver[N ConnectionNode](store ConnectionResolverStore[N], args *ConnectionResolverArgs, options *ConnectionResolverOptions) (*ConnectionResolver[N], error) {
+	if args == nil || (args.First == nil && args.Last == nil) {
+		return nil, errors.New("you must provide a `first` or `last` value to properly paginate")
+	}
+
+	if options == nil {
+		options = &ConnectionResolverOptions{}
+	}
+
+	return &ConnectionResolver[N]{
+		store:   store,
+		args:    args,
+		options: options,
+		data:    connectionData[N]{},
+	}, nil
+}

--- a/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver_test.go
@@ -1,0 +1,309 @@
+package graphqlutil
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/graph-gophers/graphql-go"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
+
+const testTotalCount = int32(10)
+
+type testConnectionNode struct {
+	id int
+}
+
+func (n testConnectionNode) ID() graphql.ID {
+	return graphql.ID(fmt.Sprintf("%d", n.id))
+}
+
+type testConnectionStore struct {
+	t                      *testing.T
+	expectedPaginationArgs *database.PaginationArgs
+	ComputeTotalCalled     int
+	ComputeNodesCalled     int
+}
+
+func (s *testConnectionStore) testPaginationArgs(args *database.PaginationArgs) {
+	if s.expectedPaginationArgs == nil {
+		return
+	}
+
+	if diff := cmp.Diff(s.expectedPaginationArgs, args); diff != "" {
+		s.t.Fatal(diff)
+	}
+}
+
+func (s *testConnectionStore) ComputeTotal(ctx context.Context) (*int32, error) {
+	s.ComputeTotalCalled = s.ComputeTotalCalled + 1
+	total := testTotalCount
+
+	return &total, nil
+}
+
+func (s *testConnectionStore) ComputeNodes(ctx context.Context, args *database.PaginationArgs) ([]*testConnectionNode, error) {
+	s.ComputeNodesCalled = s.ComputeNodesCalled + 1
+	s.testPaginationArgs(args)
+
+	nodes := []*testConnectionNode{{id: 0}, {id: 1}}
+
+	return nodes, nil
+}
+
+func (*testConnectionStore) MarshalCursor(n *testConnectionNode) (*string, error) {
+	cursor := string(n.ID())
+
+	return &cursor, nil
+}
+
+func (*testConnectionStore) UnmarshalCursor(cursor string) (*int, error) {
+	id, err := strconv.Atoi(cursor)
+	if err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func newInt(n int) *int {
+	return &n
+}
+
+func newInt32(n int) *int32 {
+	num := int32(n)
+
+	return &num
+}
+
+func withFirstCA(first int, a *ConnectionResolverArgs) *ConnectionResolverArgs {
+	a.First = newInt32(first)
+
+	return a
+}
+
+func withLastCA(last int, a *ConnectionResolverArgs) *ConnectionResolverArgs {
+	a.Last = newInt32(last)
+
+	return a
+}
+
+func withAfterCA(after string, a *ConnectionResolverArgs) *ConnectionResolverArgs {
+	a.After = &after
+
+	return a
+}
+
+func withBeforeCA(before string, a *ConnectionResolverArgs) *ConnectionResolverArgs {
+	a.Before = &before
+
+	return a
+}
+
+func withFirstPA(first int, a *database.PaginationArgs) *database.PaginationArgs {
+	a.First = &first
+
+	return a
+}
+
+func withLastPA(last int, a *database.PaginationArgs) *database.PaginationArgs {
+	a.Last = &last
+
+	return a
+}
+
+func withAfterPA(after int, a *database.PaginationArgs) *database.PaginationArgs {
+	a.After = &after
+
+	return a
+}
+
+func withBeforePA(before int, a *database.PaginationArgs) *database.PaginationArgs {
+	a.Before = &before
+
+	return a
+}
+
+func TestConnectionTotalCount(t *testing.T) {
+	ctx := context.Background()
+	store := &testConnectionStore{t: t}
+	resolver, err := NewConnectionResolver[testConnectionNode](store, withFirstCA(1, &ConnectionResolverArgs{}), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	count, err := resolver.TotalCount(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != testTotalCount {
+		t.Fatalf("wrong total count. want=%d, have=%d", testTotalCount, count)
+	}
+
+	resolver.TotalCount(ctx)
+	if store.ComputeTotalCalled != 1 {
+		t.Fatalf("wrong compute total called count. want=%d, have=%d", 1, store.ComputeTotalCalled)
+	}
+}
+
+func testResolverNodesResponse(t *testing.T, resolver *ConnectionResolver[testConnectionNode], store *testConnectionStore, count int) {
+	ctx := context.Background()
+	nodes, err := resolver.Nodes(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(count, len(nodes)); diff != "" {
+		t.Fatal(diff)
+	}
+
+	resolver.Nodes(ctx)
+	if store.ComputeNodesCalled != 1 {
+		t.Fatalf("wrong compute nodes called count. want=%d, have=%d", 1, store.ComputeNodesCalled)
+	}
+}
+
+func TestConnectionNodes(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		connectionArgs *ConnectionResolverArgs
+
+		wantPaginationArgs *database.PaginationArgs
+		wantNodes          int
+	}{
+		{
+			name:               "default",
+			connectionArgs:     withFirstCA(5, &ConnectionResolverArgs{}),
+			wantPaginationArgs: withFirstPA(6, &database.PaginationArgs{}),
+			wantNodes:          2,
+		},
+		{
+			name:               "last arg",
+			wantPaginationArgs: withLastPA(6, &database.PaginationArgs{}),
+			connectionArgs:     withLastCA(5, &ConnectionResolverArgs{}),
+			wantNodes:          2,
+		},
+		{
+			name:               "after arg",
+			wantPaginationArgs: withAfterPA(0, withFirstPA(6, &database.PaginationArgs{})),
+			connectionArgs:     withAfterCA("0", withFirstCA(5, &ConnectionResolverArgs{})),
+			wantNodes:          2,
+		},
+		{
+			name:               "before arg",
+			wantPaginationArgs: withBeforePA(0, withLastPA(6, &database.PaginationArgs{})),
+			connectionArgs:     withBeforeCA("0", withLastCA(5, &ConnectionResolverArgs{})),
+			wantNodes:          2,
+		},
+		{
+			name:               "with limit",
+			wantPaginationArgs: withBeforePA(0, withLastPA(2, &database.PaginationArgs{})),
+			connectionArgs:     withBeforeCA("0", withLastCA(1, &ConnectionResolverArgs{})),
+			wantNodes:          1,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store := &testConnectionStore{t: t, expectedPaginationArgs: test.wantPaginationArgs}
+			resolver, err := NewConnectionResolver[testConnectionNode](store, test.connectionArgs, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			testResolverNodesResponse(t, resolver, store, test.wantNodes)
+		})
+	}
+}
+
+type pageInfoResponse struct {
+	startCursor     string
+	endCursor       string
+	hasNextPage     bool
+	hasPreviousPage bool
+}
+
+func testResolverPageInfoResponse(t *testing.T, resolver *ConnectionResolver[testConnectionNode], store *testConnectionStore, expectedResponse *pageInfoResponse) {
+	ctx := context.Background()
+	pageInfo, err := resolver.PageInfo(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	startCursor, err := pageInfo.StartCursor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(expectedResponse.startCursor, *startCursor); diff != "" {
+		t.Fatal(diff)
+	}
+
+	endCursor, err := pageInfo.EndCursor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(expectedResponse.endCursor, *endCursor); diff != "" {
+		t.Fatal(diff)
+	}
+
+	if expectedResponse.hasNextPage != pageInfo.HasNextPage() {
+		t.Fatalf("hasNextPage should be %v, but is %v", expectedResponse.hasNextPage, pageInfo.HasNextPage())
+	}
+	if expectedResponse.hasPreviousPage != pageInfo.HasPreviousPage() {
+		t.Fatalf("hasPreviousPage should be %v, but is %v", expectedResponse.hasPreviousPage, pageInfo.HasPreviousPage())
+	}
+
+	resolver.PageInfo(ctx)
+	if diff := cmp.Diff(1, store.ComputeNodesCalled); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestConnectionPageInfo(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args *ConnectionResolverArgs
+		want *pageInfoResponse
+	}{
+		{
+			name: "default",
+			args: withFirstCA(20, &ConnectionResolverArgs{}),
+			want: &pageInfoResponse{startCursor: "0", endCursor: "1", hasNextPage: false, hasPreviousPage: false},
+		},
+		{
+			name: "first page",
+			args: withFirstCA(1, &ConnectionResolverArgs{}),
+			want: &pageInfoResponse{startCursor: "0", endCursor: "0", hasNextPage: true, hasPreviousPage: false},
+		},
+		{
+			name: "second page",
+			args: withAfterCA("0", withFirstCA(1, &ConnectionResolverArgs{})),
+			want: &pageInfoResponse{startCursor: "0", endCursor: "0", hasNextPage: true, hasPreviousPage: true},
+		},
+		{
+			name: "backward first page",
+			args: withBeforeCA("0", withLastCA(1, &ConnectionResolverArgs{})),
+			want: &pageInfoResponse{startCursor: "0", endCursor: "0", hasNextPage: true, hasPreviousPage: true},
+		},
+		{
+			name: "backward first page without cursor",
+			args: withLastCA(1, &ConnectionResolverArgs{}),
+			want: &pageInfoResponse{startCursor: "0", endCursor: "0", hasNextPage: false, hasPreviousPage: true},
+		},
+		{
+			name: "backward last page",
+			args: withBeforeCA("0", withBeforeCA("0", withLastCA(20, &ConnectionResolverArgs{}))),
+			want: &pageInfoResponse{startCursor: "1", endCursor: "0", hasNextPage: true, hasPreviousPage: false},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store := &testConnectionStore{t: t}
+			resolver, err := NewConnectionResolver[testConnectionNode](store, test.args, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			testResolverPageInfoResponse(t, resolver, store, test.want)
+		})
+	}
+}

--- a/internal/database/helpers.go
+++ b/internal/database/helpers.go
@@ -6,6 +6,8 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // LimitOffset specifies SQL LIMIT and OFFSET counts. A pointer to it is typically embedded in other options
@@ -35,4 +37,76 @@ func maybeQueryIsID(query string) (int32, bool) {
 	var id int32
 	err := relay.UnmarshalSpec(graphql.ID(query), &id)
 	return id, err == nil
+}
+
+type QueryArgs struct {
+	Where *sqlf.Query
+	Order *sqlf.Query
+	Limit *sqlf.Query
+}
+
+func (a *QueryArgs) AppendWhereToQuery(query *sqlf.Query) *sqlf.Query {
+	if a.Where == nil {
+		return query
+	}
+
+	return sqlf.Sprintf("%v WHERE %v", query, a.Where)
+}
+
+func (a *QueryArgs) AppendOrderToQuery(query *sqlf.Query) *sqlf.Query {
+	if a.Order == nil {
+		return query
+	}
+
+	return sqlf.Sprintf("%v ORDER BY %v", query, a.Order)
+}
+
+func (a *QueryArgs) AppendLimitToQuery(query *sqlf.Query) *sqlf.Query {
+	if a.Limit == nil {
+		return query
+	}
+
+	return sqlf.Sprintf("%v %v", query, a.Limit)
+}
+
+func (a *QueryArgs) AppendAllToQuery(query *sqlf.Query) *sqlf.Query {
+	query = a.AppendWhereToQuery(query)
+	query = a.AppendOrderToQuery(query)
+	query = a.AppendLimitToQuery(query)
+
+	return query
+}
+
+type PaginationArgs struct {
+	First  *int
+	Last   *int
+	After  *int
+	Before *int
+}
+
+func (p *PaginationArgs) SQL() (*QueryArgs, error) {
+	queryArgs := &QueryArgs{}
+
+	var conditions []*sqlf.Query
+	if p.After != nil {
+		conditions = append(conditions, sqlf.Sprintf("id < %v", p.After))
+	}
+	if p.Before != nil {
+		conditions = append(conditions, sqlf.Sprintf("id > %v", p.Before))
+	}
+	if len(conditions) > 0 {
+		queryArgs.Where = sqlf.Sprintf("%v", sqlf.Join(conditions, "AND "))
+	}
+
+	if p.First != nil {
+		queryArgs.Order = sqlf.Sprintf("id DESC")
+		queryArgs.Limit = sqlf.Sprintf("LIMIT %d", *p.First)
+	} else if p.Last != nil {
+		queryArgs.Order = sqlf.Sprintf("id ASC")
+		queryArgs.Limit = sqlf.Sprintf("LIMIT %d", *p.Last)
+	} else {
+		return nil, errors.New("First or Last must be set")
+	}
+
+	return queryArgs, nil
 }


### PR DESCRIPTION
Closes: https://github.com/sourcegraph/sourcegraph/issues/45247
This PR implements a new connection resolver helper, which is planned to be used to implement cursor-based bi-directional pagination throughout our software. This is the first PR which only implements the helper along with its basic unit tests. 

The upcoming PRs will include its integration with SavedSearches resolver. The custom sort and filters will be added separately as well.

## Test plan

Unit tests are added. 

To know more about how this helper will be used,[ check this out](https://github.com/sourcegraph/sourcegraph/pull/44347/files#diff-38da2cf9b89abf1529ca89b06fb51fcae0870e42a345e1d3b1fd8169c49cb308).