### PR TITLE
Add loading indicator text when loading large code files

### DIFF
--- a/client/web/src/repo/blob/BlobLoadingSpinner.tsx
+++ b/client/web/src/repo/blob/BlobLoadingSpinner.tsx
@@ -40,7 +40,8 @@ export function BlobLoadingSpinner(): JSX.Element {
                                 It’s taking much longer than expected to load this file. Try{' '}
                                 <Link to={location.pathname} onClick={reload}>
                                     reloading the page
-                                </Link>.
+                                </Link>
+                                .
                             </>
                         ) : afterSixSec ? (
                             'Loading a whole lot of bits and bytes here...'

--- a/client/web/src/repo/blob/BlobLoadingSpinner.tsx
+++ b/client/web/src/repo/blob/BlobLoadingSpinner.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react'
+
+import { useLocation } from 'react-router'
+
+import { Link, LoadingSpinner } from '@sourcegraph/wildcard'
+
+export function BlobLoadingSpinner(): JSX.Element {
+    const [afterOneSec, setAfterOneSec] = useState(false)
+    const [afterThreeSec, setAfterThreeSec] = useState(false)
+    const [afterSixSec, setAfterSixSec] = useState(false)
+    const [afterNineSec, setAfterNineSec] = useState(false)
+
+    useEffect(() => {
+        const timeout = setTimeout(() => setAfterOneSec(true), 1000)
+        return () => clearTimeout(timeout)
+    }, [])
+    useEffect(() => {
+        const timeout = setTimeout(() => setAfterThreeSec(true), 3000)
+        return () => clearTimeout(timeout)
+    }, [])
+    useEffect(() => {
+        const timeout = setTimeout(() => setAfterSixSec(true), 6000)
+        return () => clearTimeout(timeout)
+    }, [])
+    useEffect(() => {
+        const timeout = setTimeout(() => setAfterNineSec(true), 9000)
+        return () => clearTimeout(timeout)
+    }, [])
+
+    const location = useLocation()
+
+    return (
+        <div className="d-flex mt-3 justify-content-center">
+            {afterOneSec ? (
+                <div className="d-flex flex-column align-items-center">
+                    <LoadingSpinner />
+                    <div className="text-muted mt-2">
+                        {afterNineSec ? (
+                            <>
+                                It’s taking much longer than expected to load this file. Try{' '}
+                                <Link to={location.pathname} onClick={reload}>
+                                    reloading the page
+                                </Link>
+                            </>
+                        ) : afterSixSec ? (
+                            'Loading a whole lot of bits and bytes here...'
+                        ) : afterThreeSec ? (
+                            'Loading a large file...'
+                        ) : (
+                            ''
+                        )}
+                    </div>
+                </div>
+            ) : null}
+        </div>
+    )
+}
+
+function reload(event: React.MouseEvent<HTMLAnchorElement>): void {
+    window.location.reload()
+    event.preventDefault()
+}

--- a/client/web/src/repo/blob/BlobLoadingSpinner.tsx
+++ b/client/web/src/repo/blob/BlobLoadingSpinner.tsx
@@ -40,7 +40,7 @@ export function BlobLoadingSpinner(): JSX.Element {
                                 It’s taking much longer than expected to load this file. Try{' '}
                                 <Link to={location.pathname} onClick={reload}>
                                     reloading the page
-                                </Link>
+                                </Link>.
                             </>
                         ) : afterSixSec ? (
                             'Loading a whole lot of bits and bytes here...'

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -66,6 +66,7 @@ import { ToggleRenderedFileMode } from './actions/ToggleRenderedFileMode'
 import { getModeFromURL } from './actions/utils'
 import { fetchBlob, fetchStencil } from './backend'
 import { Blob, BlobInfo } from './Blob'
+import { BlobLoadingSpinner } from './BlobLoadingSpinner'
 import { Blob as CodeMirrorBlob } from './CodeMirrorBlob'
 import { GoToRawAction } from './GoToRawAction'
 import { BlobPanel } from './panel/BlobPanel'
@@ -441,11 +442,7 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
         return (
             <div className={styles.placeholder}>
                 {alwaysRender}
-                {!enableLazyBlobSyntaxHighlighting && (
-                    <div className="d-flex mt-3 justify-content-center">
-                        <LoadingSpinner />
-                    </div>
-                )}
+                {!enableLazyBlobSyntaxHighlighting && <BlobLoadingSpinner />}
             </div>
         )
     }


### PR DESCRIPTION
Fixes #44666

When opening large files, the file download can become quite slow and since we don't use any streaming APIs, [the bottleneck is often the time to first byte](https://github.com/sourcegraph/sourcegraph/issues/44666#issuecomment-1330789819). To improve the UX in the short term before we can [add larger scale fixes](https://github.com/sourcegraph/sourcegraph/issues/44666#issuecomment-1330796505) to this problem, this PR tweaks the loading experience and adds different subtitles when loading exceeds specific thresholds (1sec, 3sec, 6sec, and 9sec). https://www.figma.com/file/5CgqjaXqrRhquTG6GB3YGd/FE-scale-audit%3A-loading-big-files-in-search-results-list-bogs-down-the-browser-%2344666-WIP?node-id=275%3A1628&t=TaPSg9bCLwiM1A1N-4

Figma: https://www.figma.com/file/5CgqjaXqrRhquTG6GB3YGd/FE-scale-audit%3A-loading-big-files-in-search-results-list-bogs-down-the-browser-%2344666-WIP?node-id=275%3A1628&t=TaPSg9bCLwiM1A1N-4

## Test plan

You have to enable heavy network throttling to repro the 9 sec case (100kbps in my case):

https://user-images.githubusercontent.com/458591/205664147-c5ac41a3-d561-4e0b-96d7-70d3304a6f4b.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-large-file-loading.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
