### PR TITLE
web: use CopyableText in WebhookInformation.

### DIFF
--- a/client/web/src/components/CopyableText.tsx
+++ b/client/web/src/components/CopyableText.tsx
@@ -15,13 +15,13 @@ interface Props {
     /** An optional class name. */
     className?: string
 
-    /** Whether or not the input should take up all horizontal space (flex:1) */
+    /** Whether the input should take up all horizontal space (flex:1) */
     flex?: boolean
 
     /** The size of the input element. */
     size?: number
 
-    /** Whether or not the text to be copied is a password. */
+    /** Whether the text to be copied is a password. */
     password?: boolean
 
     /** The label used for screen readers */

--- a/client/web/src/site-admin/WebhookInformation.tsx
+++ b/client/web/src/site-admin/WebhookInformation.tsx
@@ -5,10 +5,10 @@ import classNames from 'classnames'
 
 import { Button, Icon, Input } from '@sourcegraph/wildcard'
 
+import { CopyableText } from '../components/CopyableText'
 import { WebhookFields } from '../graphql-operations'
 
 import styles from './WebhookInformation.module.scss'
-import { CopyableText } from '../components/CopyableText'
 
 export interface WebhookInformationProps {
     webhook: WebhookFields

--- a/client/web/src/site-admin/WebhookInformation.tsx
+++ b/client/web/src/site-admin/WebhookInformation.tsx
@@ -1,14 +1,14 @@
 import { FC, useState } from 'react'
 
-import { mdiContentCopy, mdiEye } from '@mdi/js'
+import { mdiEye } from '@mdi/js'
 import classNames from 'classnames'
-import copy from 'copy-to-clipboard'
 
 import { Button, Icon, Input } from '@sourcegraph/wildcard'
 
 import { WebhookFields } from '../graphql-operations'
 
 import styles from './WebhookInformation.module.scss'
+import {CopyableText} from "../components/CopyableText";
 
 export interface WebhookInformationProps {
     webhook: WebhookFields
@@ -32,10 +32,7 @@ export const WebhookInformation: FC<WebhookInformationProps> = props => {
                 <tr>
                     <th className={styles.tableHeader}>Webhook endpoint</th>
                     <td className={styles.contentCell}>
-                        {webhook.url}
-                        <Button size="sm" className={styles.copyButton} onClick={() => copy(webhook.url)}>
-                            <Icon svgPath={mdiContentCopy} inline={true} aria-label="Copy webhook endpoint" />
-                        </Button>
+                        <CopyableText text={webhook.url} size={webhook.url.length}/>
                     </td>
                 </tr>
                 <tr>

--- a/client/web/src/site-admin/WebhookInformation.tsx
+++ b/client/web/src/site-admin/WebhookInformation.tsx
@@ -8,7 +8,7 @@ import { Button, Icon, Input } from '@sourcegraph/wildcard'
 import { WebhookFields } from '../graphql-operations'
 
 import styles from './WebhookInformation.module.scss'
-import {CopyableText} from "../components/CopyableText";
+import { CopyableText } from '../components/CopyableText'
 
 export interface WebhookInformationProps {
     webhook: WebhookFields
@@ -32,7 +32,7 @@ export const WebhookInformation: FC<WebhookInformationProps> = props => {
                 <tr>
                     <th className={styles.tableHeader}>Webhook endpoint</th>
                     <td className={styles.contentCell}>
-                        <CopyableText text={webhook.url} size={webhook.url.length}/>
+                        <CopyableText text={webhook.url} size={webhook.url.length} />
                     </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
Test plan:
Storybook.

Closes https://github.com/sourcegraph/sourcegraph/issues/45150

## App preview:

- [Web](https://sg-web-ao-ui-webhooks-use-copyabletext.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
