### PR TITLE
search: add "Reindex now" to index status page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 - More complete stack traces for Outbound request log [#45151](https://github.com/sourcegraph/sourcegraph/pull/45151)
 - A new status message now reports how many repositories have already been indexed for search. [#45246](https://github.com/sourcegraph/sourcegraph/pull/45246)
 - Search contexts can now be starred (favorited) in the search context management page. Starred search contexts will appear first in the context dropdown menu next to the search box. [#45230](https://github.com/sourcegraph/sourcegraph/pull/45230)
+- Added a button "Reindex now" to the index status page. Admins can now force an immediate reindex of a repository. [#45178](https://github.com/sourcegraph/sourcegraph/pull/45178)
 
 ### Changed
 

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -100,9 +100,7 @@ function useForceReindex(id: Scalars['ID']): () => void {
         submitForceReindex({
             variables: { id },
         }).then(
-            () => {
-                window.location.reload()
-            },
+            () => {},
             () => {}
         )
     }, [submitForceReindex, id])
@@ -120,7 +118,7 @@ const TextSearchIndexedReference: React.FunctionComponent<
     const forceReindex = useForceReindex(repo.id)
 
     return (
-        <div>
+        <>
             <div className="mb-3">
                 <Button variant="primary" onClick={() => forceReindex()}>
                     Reindex now
@@ -162,7 +160,7 @@ const TextSearchIndexedReference: React.FunctionComponent<
                     <span>&nbsp;&mdash; initial indexing in progress</span>
                 )}
             </li>
-        </div>
+        </>
     )
 }
 

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -9,11 +9,11 @@ import { map, switchMap, tap } from 'rxjs/operators'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { createAggregateError, pluralize } from '@sourcegraph/common'
-import { gql } from '@sourcegraph/http-client'
+import { gql, useMutation } from '@sourcegraph/http-client'
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import { Button, Container, PageHeader, LoadingSpinner, Link, Alert, Icon, Code, H3 } from '@sourcegraph/wildcard'
 
-import { queryGraphQL, requestGraphQL } from '../../backend/graphql'
+import { queryGraphQL } from '../../backend/graphql'
 import { PageTitle } from '../../components/PageTitle'
 import { Timestamp } from '../../components/time/Timestamp'
 import {
@@ -86,19 +86,27 @@ function fetchRepositoryTextSearchIndex(id: Scalars['ID']): Observable<Repositor
     )
 }
 
-export function forceReindex(id: Scalars['ID']): Subscription {
-    return requestGraphQL<reindexResult, reindexVariables>(
+function useForceReindex(id: Scalars['ID']): () => void {
+    const [submitForceReindex] = useMutation<reindexResult, reindexVariables>(
         gql`
             mutation reindex($id: ID!) {
                 reindexRepository(repository: $id) {
                     alwaysNil
                 }
             }
-        `,
-        {
-            id,
-        }
-    ).subscribe()
+        `
+    )
+    const forceReindex = React.useCallback(() => {
+        submitForceReindex({
+            variables: { id },
+        }).then(
+            () => {
+                window.location.reload()
+            },
+            () => {}
+        )
+    }, [submitForceReindex, id])
+    return forceReindex
 }
 
 const TextSearchIndexedReference: React.FunctionComponent<
@@ -109,43 +117,52 @@ const TextSearchIndexedReference: React.FunctionComponent<
 > = ({ repo, indexedRef }) => {
     const isCurrent = indexedRef.indexed && indexedRef.current
 
+    const forceReindex = useForceReindex(repo.id)
+
     return (
-        <li className={styles.ref}>
-            <Icon
-                className={classNames(styles.refIcon, isCurrent && styles.refIconCurrent)}
-                svgPath={isCurrent ? mdiCheckCircle : undefined}
-                as={!isCurrent ? LoadingSpinner : undefined}
-                aria-hidden={true}
-            />
-            <LinkOrSpan to={indexedRef.ref.url}>
-                <Code weight="bold">{indexedRef.ref.displayName}</Code>
-            </LinkOrSpan>{' '}
-            {indexedRef.indexed ? (
-                <span>
-                    &nbsp;&mdash; indexed at{' '}
-                    <Code>
-                        <LinkOrSpan
-                            to={indexedRef.indexedCommit?.commit ? indexedRef.indexedCommit.commit.url : repo.url}
-                        >
-                            {indexedRef.indexedCommit!.abbreviatedOID}
-                        </LinkOrSpan>
-                    </Code>{' '}
-                    {indexedRef.current ? '(up to date)' : '(index update in progress)'}
-                    {indexedRef.skippedIndexed && Number(indexedRef.skippedIndexed.count) > 0 ? (
-                        <span>
-                            .&nbsp;
-                            <Link to={'/search?q=' + encodeURIComponent(indexedRef.skippedIndexed.query)}>
-                                {indexedRef.skippedIndexed.count}{' '}
-                                {pluralize('file', Number(indexedRef.skippedIndexed.count))} skipped during indexing
-                            </Link>
-                            .
-                        </span>
-                    ) : null}
-                </span>
-            ) : (
-                <span>&nbsp;&mdash; initial indexing in progress</span>
-            )}
-        </li>
+        <div>
+            <div className="mb-3">
+                <Button variant="primary" onClick={() => forceReindex()}>
+                    Reindex now
+                </Button>
+            </div>
+            <li className={styles.ref}>
+                <Icon
+                    className={classNames(styles.refIcon, isCurrent && styles.refIconCurrent)}
+                    svgPath={isCurrent ? mdiCheckCircle : undefined}
+                    as={!isCurrent ? LoadingSpinner : undefined}
+                    aria-hidden={true}
+                />
+                <LinkOrSpan to={indexedRef.ref.url}>
+                    <Code weight="bold">{indexedRef.ref.displayName}</Code>
+                </LinkOrSpan>{' '}
+                {indexedRef.indexed ? (
+                    <span>
+                        &nbsp;&mdash; indexed at{' '}
+                        <Code>
+                            <LinkOrSpan
+                                to={indexedRef.indexedCommit?.commit ? indexedRef.indexedCommit.commit.url : repo.url}
+                            >
+                                {indexedRef.indexedCommit!.abbreviatedOID}
+                            </LinkOrSpan>
+                        </Code>{' '}
+                        {indexedRef.current ? '(up to date)' : '(index update in progress)'}
+                        {indexedRef.skippedIndexed && Number(indexedRef.skippedIndexed.count) > 0 ? (
+                            <span>
+                                .&nbsp;
+                                <Link to={'/search?q=' + encodeURIComponent(indexedRef.skippedIndexed.query)}>
+                                    {indexedRef.skippedIndexed.count}{' '}
+                                    {pluralize('file', Number(indexedRef.skippedIndexed.count))} skipped during indexing
+                                </Link>
+                                .
+                            </span>
+                        ) : null}
+                    </span>
+                ) : (
+                    <span>&nbsp;&mdash; initial indexing in progress</span>
+                )}
+            </li>
+        </div>
     )
 }
 
@@ -203,11 +220,6 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                         ) : undefined
                     }
                 />
-                <div className="mb-3">
-                    <Button variant="primary" onClick={() => forceReindex(this.props.repo.id)}>
-                        Reindex now
-                    </Button>
-                </div>
                 <Container>
                     {this.state.loading && <LoadingSpinner />}
                     {this.state.error && (


### PR DESCRIPTION
This adds a new button "Reindex now" to the index status page.

Relevant backend changes: 
- https://github.com/sourcegraph/sourcegraph/pull/45056
- https://github.com/sourcegraph/zoekt/pull/487

![image](https://user-images.githubusercontent.com/26413131/206161087-72960b98-8572-408b-a90f-04eec4b32817.png)

## Test plan
- manual testing: I verified via the logs that clicking the button forces a reindex.
- CI

## App preview:

- [Web](https://sg-web-sh-add-reindex-button.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

