### PR TITLE
comparison: Fail on empty commit

### DIFF
--- a/cmd/frontend/graphqlbackend/preview_repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/preview_repository_comparison.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/sourcegraph/go-diff/diff"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -25,6 +27,12 @@ func NewPreviewRepositoryComparisonResolver(ctx context.Context, db database.DB,
 	commit, err := repo.Commit(ctx, args)
 	if err != nil {
 		return nil, err
+	}
+	if commit == nil {
+		return nil, &gitdomain.RevisionNotFoundError{
+			Repo: api.RepoName(repo.Name()),
+			Spec: baseRev,
+		}
 	}
 	return &previewRepositoryComparisonResolver{
 		db:     db,


### PR DESCRIPTION
If the preview is requested for a commit that doesn't exist, it would panic with a nil pointer deep down. This patch fixes it by properly returning an error if it's not found.



## Test plan

Verified no panic anymore.