### PR TITLE
Fix spacing on search results page

### DIFF
--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -170,7 +170,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<
                 {props.stats}
 
                 {props.isSourcegraphDotCom && (
-                    <CloudCtaBanner className="mb-5" variant="outlined">
+                    <CloudCtaBanner className="mb-0" variant="outlined">
                         To search across your private repositories,{' '}
                         <Link
                             to="https://signup.sourcegraph.com"

--- a/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
+++ b/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag disabled 1`] = `
     >
       <div />
       <section
-        class="mb-5 d-flex justify-content-center outlined"
+        class="mb-0 d-flex justify-content-center outlined"
       >
         <svg
           aria-hidden="true"
@@ -120,7 +120,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
     >
       <div />
       <section
-        class="mb-5 d-flex justify-content-center outlined"
+        class="mb-0 d-flex justify-content-center outlined"
       >
         <svg
           aria-hidden="true"
@@ -227,7 +227,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
     >
       <div />
       <section
-        class="mb-5 d-flex justify-content-center outlined"
+        class="mb-0 d-flex justify-content-center outlined"
       >
         <svg
           aria-hidden="true"
@@ -334,7 +334,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, cannot creat
     >
       <div />
       <section
-        class="mb-5 d-flex justify-content-center outlined"
+        class="mb-0 d-flex justify-content-center outlined"
       >
         <svg
           aria-hidden="true"
@@ -441,7 +441,7 @@ exports[`SearchResultsInfoBar unauthenticated user 1`] = `
     >
       <div />
       <section
-        class="mb-5 d-flex justify-content-center outlined"
+        class="mb-0 d-flex justify-content-center outlined"
       >
         <svg
           aria-hidden="true"


### PR DESCRIPTION
This fixes a spacing issue on our search results page.

## Test plan
Ensure there is no unusual spacing between the CTA and the search results.

## App preview:

- [Web](https://sg-web-brett-search-results-cta-fix.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
