### PR TITLE
Add repo file tree filter

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -28,6 +28,7 @@ import {
 
 import settingsSchemaJSON from '../../../../schema/settings.schema.json'
 import { AuthenticatedUser } from '../auth'
+import { SearchStreamingProps } from '../search'
 import { GettingStartedTour } from '../tour/GettingStartedTour'
 import { Tree } from '../tree/Tree'
 
@@ -41,6 +42,7 @@ interface RepoRevisionSidebarProps
         ThemeProps,
         TelemetryProps,
         SettingsCascadeProps,
+        SearchStreamingProps,
         PlatformContextProps<'requestGraphQL'> {
     repoID?: Scalars['ID']
     isDir: boolean
@@ -174,6 +176,7 @@ export const RepoRevisionSidebar: React.FunctionComponent<
                                         telemetryService={props.telemetryService}
                                         enableMergedFileSymbolSidebar={!!enableMergedFileSymbolSidebar}
                                         platformContext={props.platformContext}
+                                        streamSearch={props.streamSearch}
                                     />
                                 </TabPanel>
                                 {!enableMergedFileSymbolSidebar && (

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -7,6 +7,7 @@ import * as H from 'history'
 import { isErrorLike } from '@sourcegraph/common'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
+import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
@@ -39,7 +40,8 @@ interface RepoRevisionSidebarProps
         ExtensionsControllerProps,
         ThemeProps,
         TelemetryProps,
-        SettingsCascadeProps {
+        SettingsCascadeProps,
+        PlatformContextProps<'requestGraphQL'> {
     repoID?: Scalars['ID']
     isDir: boolean
     defaultBranch: string
@@ -171,6 +173,7 @@ export const RepoRevisionSidebar: React.FunctionComponent<
                                         isLightTheme={props.isLightTheme}
                                         telemetryService={props.telemetryService}
                                         enableMergedFileSymbolSidebar={!!enableMergedFileSymbolSidebar}
+                                        platformContext={props.platformContext}
                                     />
                                 </TabPanel>
                                 {!enableMergedFileSymbolSidebar && (

--- a/client/web/src/repo/RepositoryFileTreePage.tsx
+++ b/client/web/src/repo/RepositoryFileTreePage.tsx
@@ -85,6 +85,7 @@ export const RepositoryFileTreePage: React.FunctionComponent<
                 authenticatedUser={context.authenticatedUser}
                 isSourcegraphDotCom={context.isSourcegraphDotCom}
                 extensionsController={context.extensionsController}
+                platformContext={context.platformContext}
                 commitID={resolvedRevision?.commitID}
                 filePath={filePath}
                 repoID={repo?.id}

--- a/client/web/src/repo/RepositoryFileTreePage.tsx
+++ b/client/web/src/repo/RepositoryFileTreePage.tsx
@@ -92,6 +92,7 @@ export const RepositoryFileTreePage: React.FunctionComponent<
                 repoName={repoName}
                 isDir={objectType === 'tree'}
                 defaultBranch={resolvedRevision?.defaultBranch || 'HEAD'}
+                streamSearch={context.streamSearch}
             />
             {!hideRepoRevisionContent && (
                 // Add `.blob-status-bar__container` because this is the

--- a/client/web/src/tree/TreeSearchResults.tsx
+++ b/client/web/src/tree/TreeSearchResults.tsx
@@ -7,16 +7,35 @@ import { memoizeObservable } from '@sourcegraph/common/src'
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client/src'
 import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import { RepoSpec, ResolvedRevisionSpec } from '@sourcegraph/shared/src/util/url'
-import { useObservable } from '@sourcegraph/wildcard/src'
+import { Alert, Code, Text, Link, useObservable, LoadingSpinner } from '@sourcegraph/wildcard/src'
 
-import { FilesResult, FilesVariables } from '../graphql-operations'
+import { useShowMorePagination } from '../components/FilteredConnection/hooks/useShowMorePagination'
+import { FilesResult, FilesVariables, SearchPatternType } from '../graphql-operations'
+import { SearchStreamingProps } from '../search'
+import { useCachedSearchResults } from '../search/results/SearchResultsCacheProvider'
+import { LATEST_VERSION, SearchMatch } from '@sourcegraph/shared/out/src/search/stream'
+import { ExtensionsControllerProps } from '@sourcegraph/shared/out/src/extensions/controller'
+import { TelemetryProps } from '@sourcegraph/shared/out/src/telemetry/telemetryService'
+import { VirtualList } from '@sourcegraph/shared/out/src/components/VirtualList'
+import classNames from 'classnames'
+import styles from '@sourcegraph/search-ui/src/results/StreamingSearchResultsList.module.scss'
+import { escapeRegExp } from 'lodash'
+// import { Link } from 'react-router-dom'
+
+import treeStyles from './Tree.module.scss'
 
 interface FileResult {
     name: string
     path: string
 }
 
-interface TreeSearchResultsProps extends RepoSpec, ResolvedRevisionSpec, Pick<PlatformContext, 'requestGraphQL'> {
+interface TreeSearchResultsProps
+    extends RepoSpec,
+        ResolvedRevisionSpec,
+        Pick<PlatformContext, 'requestGraphQL'>,
+        SearchStreamingProps,
+        ExtensionsControllerProps,
+        TelemetryProps {
     searchTerm: string
 }
 
@@ -94,24 +113,125 @@ const useTreeSearchResults = ({
     )
 }
 
-export const TreeSearchResults: React.FC<TreeSearchResultsProps> = props => {
-    const results = useTreeSearchResults(props)
+const useDebouncedSearchTerm = (searchTerm: string): string | undefined => {
+    const searchTermRef = useRef<Subject<string>>(new Subject())
 
-    return (
-        <ul>
-            {results?.map(file => (
-                <TreeSearchResult key={file.path} file={file} />
-            ))}
-        </ul>
+    useEffect(() => {
+        searchTermRef.current.next(searchTerm)
+    }, [searchTerm])
+
+    return useObservable(
+        useMemo(
+            () =>
+                searchTermRef.current.pipe(
+                    debounceTime(500),
+                    filter(value => !!value),
+                    distinct()
+                ),
+            []
+        )
     )
 }
 
-const TreeSearchResult: React.FC<{ file: FileResult }> = ({ file }) => {
-    const folderName = file.path.replace(new RegExp(`${file.name}$`), '')
+const TreeSearchResultList: React.FC<TreeSearchResultsProps> = props => {
+    const query = `repo:${props.repoName} revision:${props.commitID} type:path count:${RESULTS_COUNT} ${props.searchTerm}`
+    const trace = useMemo(() => new URLSearchParams(location.search).get('trace') ?? undefined, [])
+    const options = useMemo(
+        () => ({ version: LATEST_VERSION, patternType: SearchPatternType.regexp, caseSensitive: false, trace }),
+        [trace]
+    )
+    const results = useCachedSearchResults(
+        props.streamSearch,
+        query,
+        options,
+        props.extensionsController !== null && window.context.enableLegacyExtensions
+            ? props.extensionsController.extHostAPI
+            : null,
+        props.telemetryService
+    )
+
+    console.log(results)
+
+    const filePaths = results?.results.reduce((acc, result) => {
+        if (result.type === 'path') {
+            acc.push(result.path)
+        }
+        return acc
+    }, [] as string[])
+
     return (
-        <li>
-            <div>{file.name}</div>
-            <div>{folderName}</div>
+        <>
+            {filePaths ? (
+                <ul className="list-unstyled">
+                    {filePaths.map(path => (
+                        <TreeSearchResult key={path} path={path} searchTerm={props.searchTerm} />
+                    ))}
+                </ul>
+            ) : null}
+            {(!results || results?.state === 'loading') && (
+                <div className="text-center my-4" data-testid="loading-container">
+                    <LoadingSpinner />
+                </div>
+            )}
+            {results?.state === 'complete' &&
+                results.progress.skipped.some(skipped => skipped.reason.includes('-limit')) && (
+                    <Alert className="text-wrap" variant="info">
+                        <Text className="m-0 text-center">
+                            <strong>Result limit hit.</strong>
+                        </Text>
+                        <Text className="m-0">
+                            Go to <Link to="/search">search results page</Link> and modify your search with{' '}
+                            <Code>count:</Code> to return additional items.
+                        </Text>
+                    </Alert>
+                )}
+        </>
+    )
+}
+
+export const TreeSearchResults: React.FC<TreeSearchResultsProps> = props => {
+    const debouncedSearchTerm = useDebouncedSearchTerm(props.searchTerm)
+
+    if (!debouncedSearchTerm) {
+        return null
+    }
+
+    return <TreeSearchResultList {...props} searchTerm={debouncedSearchTerm} />
+}
+
+const toHighlightedElements = (items: string[], regex: RegExp): React.ReactNode[] =>
+    items
+        .filter(Boolean)
+        .map((item, index) => (regex.test(item) ? <mark key={index}>{item}</mark> : <span key={index}>{item}</span>))
+
+const TreeSearchResult: React.FC<{ path: string; searchTerm: string }> = ({ path, searchTerm }) => {
+    const regex = new RegExp(`(${escapeRegExp(searchTerm)})`, 'i')
+    const pathParts = path.split('/')
+    const fileName = pathParts[pathParts.length - 1]
+    const dirName = pathParts.slice(0, -1).join('/')
+
+    const fileNameParts = []
+    const dirNameParts = []
+
+    const fileNameMatches = fileName.split(regex)
+    if (fileNameMatches.length > 1) {
+        fileNameParts.push(...toHighlightedElements(fileNameMatches, regex))
+        dirNameParts.push(dirName)
+    } else {
+        fileNameParts.push(fileName)
+    }
+
+    if (dirNameParts.length === 0) {
+        const dirNameMatches = dirName.split(regex)
+        dirNameParts.push(...toHighlightedElements(dirNameMatches, regex))
+    }
+
+    return (
+        <li className={classNames(treeStyles.row, 'px-1 border-bottom')}>
+            <Link to={path} className="d-flex flex-column justify-space-between">
+                <span>{fileNameParts}</span>
+                <span>{dirNameParts}</span>
+            </Link>
         </li>
     )
 }

--- a/client/web/src/tree/TreeSearchResults.tsx
+++ b/client/web/src/tree/TreeSearchResults.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useMemo, useRef } from 'react'
+
+import { Subject, Observable } from 'rxjs'
+import { debounceTime, distinct, filter, map, mergeMap } from 'rxjs/operators'
+
+import { memoizeObservable } from '@sourcegraph/common/src'
+import { dataOrThrowErrors, gql } from '@sourcegraph/http-client/src'
+import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
+import { RepoSpec, ResolvedRevisionSpec } from '@sourcegraph/shared/src/util/url'
+import { useObservable } from '@sourcegraph/wildcard/src'
+
+import { FilesResult, FilesVariables } from '../graphql-operations'
+
+interface FileResult {
+    name: string
+    path: string
+}
+
+interface TreeSearchResultsProps extends RepoSpec, ResolvedRevisionSpec, Pick<PlatformContext, 'requestGraphQL'> {
+    searchTerm: string
+}
+
+const FILES_QUERY = gql`
+    query Files($query: String!) {
+        search(patternType: regexp, query: $query) {
+            results {
+                results {
+                    ... on FileMatch {
+                        __typename
+                        file {
+                            name
+                            path
+                        }
+                    }
+                }
+            }
+        }
+    }
+`
+
+const RESULTS_COUNT = 50
+
+const fetchFiles = memoizeObservable(
+    ({
+        requestGraphQL,
+        ...args
+    }: Pick<PlatformContext, 'requestGraphQL'> & FilesVariables): Observable<FileResult[] | undefined> =>
+        requestGraphQL<FilesResult, FilesVariables>({
+            request: FILES_QUERY,
+            variables: args,
+            mightContainPrivateInfo: true,
+        }).pipe(
+            map(dataOrThrowErrors),
+            map(({ search }) =>
+                search?.results.results?.reduce((acc, result) => {
+                    if (result.__typename === 'FileMatch') {
+                        acc.push(result.file)
+                    }
+                    return acc
+                }, [] as FileResult[])
+            )
+        ),
+    ({ query }) => query
+)
+
+const useTreeSearchResults = ({
+    searchTerm,
+    repoName,
+    commitID,
+    requestGraphQL,
+}: TreeSearchResultsProps): FileResult[] | undefined => {
+    const searchTermRef = useRef<Subject<string>>(new Subject())
+
+    useEffect(() => {
+        searchTermRef.current.next(searchTerm)
+    }, [searchTerm])
+
+    return useObservable(
+        useMemo(
+            () =>
+                searchTermRef.current.pipe(
+                    debounceTime(500),
+                    filter(Boolean),
+                    distinct(),
+                    mergeMap(term =>
+                        fetchFiles({
+                            requestGraphQL,
+                            query: `repo:${repoName} revision:${commitID} type:path count:${RESULTS_COUNT} ${term}`,
+                        })
+                    )
+                ),
+            [requestGraphQL, repoName, commitID]
+        )
+    )
+}
+
+export const TreeSearchResults: React.FC<TreeSearchResultsProps> = props => {
+    const results = useTreeSearchResults(props)
+
+    return (
+        <ul>
+            {results?.map(file => (
+                <TreeSearchResult key={file.path} file={file} />
+            ))}
+        </ul>
+    )
+}
+
+const TreeSearchResult: React.FC<{ file: FileResult }> = ({ file }) => {
+    const folderName = file.path.replace(new RegExp(`${file.name}$`), '')
+    return (
+        <li>
+            <div>{file.name}</div>
+            <div>{folderName}</div>
+        </li>
+    )
+}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/45265

Adds file search input to the file tree view. 

## Test plan
- CI passes
- Tested manually (TODO: add video/screenshots)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-blob-view-file-tree.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

