### PR TITLE
insights: chore: remove deprecated insights settings from dev config

### DIFF
--- a/dev/global-settings.json
+++ b/dev/global-settings.json
@@ -14,23 +14,6 @@
     "enableSidebarFilePrefetch": true
   },
   "codeIntel.referencesPanel": "tree-view",
-  "insights": [
-    {
-      "title": "fmt usage",
-      "description": "fmt.Errorf/fmt.Printf usage",
-      "series": [
-        {
-          "label": "fmt.Errorf",
-          "search": "errorf"
-        },
-        {
-          "label": "printf",
-          "search": "fmt.Printf"
-        }
-      ],
-      "id": "1"
-    }
-  ],
   "search.repositoryGroups": {
     "test": ["github.com/gorilla/mux", "github.com/gorilla/pat"]
   }


### PR DESCRIPTION

## Test plan

Removed locally, has no impact.