### PR TITLE
dev: add installer script for building a local universal-ctag 

### DIFF
--- a/dev/ctags-install.sh
+++ b/dev/ctags-install.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euf -o pipefail
+pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
+mkdir -p .bin
+
+# Commit hash of github.com/universal-ctags/ctags.
+# Last bumped 2022-04-04.
+# When bumping please remember to also update Zoekt: https://github.com/sourcegraph/zoekt/blob/d3a8fbd8385f0201dd54ab24114ebd588dfcf0d8/install-ctags-alpine.sh
+CTAGS_VERSION=f95bb3497f53748c2b6afc7f298cff218103ab90
+NAME="ctags-${CTAGS_VERSION}"
+TARGET="$PWD/.bin/${NAME}"
+tmpdir=$(mktemp -d -t sg.ctags-install.XXXXXX)
+
+function ctrl_c() {
+  rm -f "$tmpdir" &>/dev/null
+  printf "[-] Installation cancelled.\n"
+  exit 1
+}
+
+trap ctrl_c INT
+trap "rm -Rf \"$tmpdir\" &>/dev/null" EXIT
+
+function build_ctags {
+  case "$OSTYPE" in
+    darwin*)  NUMCPUS=$(sysctl -n hw.ncpu);; 
+    linux*)   NUMCPUS=$(grep -c '^processor' /proc/cpuinfo) ;;
+    bsd*)     NUMCPUS=$(grep -c '^processor' /proc/cpuinfo) ;;
+    *)        NUMCPUS="4" ;;
+  esac
+
+  curl --retry 5 "https://codeload.github.com/universal-ctags/ctags/tar.gz/$CTAGS_VERSION" | tar xz -C $tmpdir
+  cd "${tmpdir}/ctags-${CTAGS_VERSION}"
+  ./autogen.sh
+  ./configure --program-prefix=universal- --enable-json
+  make -j"$NUMCPUS" --load-average="$NUMCPUS"
+  cp ./ctags "$TARGET"
+}
+
+if [ ! -f "${TARGET}" ]; then 
+  echo "Installing universal-ctags $CTAGS_VERSION"
+  echo "Please make sure that libjansson is installed"
+  echo "  MacOs: brew install jansson"
+  echo "  Ubuntu: apt-get install libjansson-dev"
+  echo "---------------------------------------------"
+
+  build_ctags
+else
+  echo "universal-ctags $CTAGS_VERSION is already available at $TARGET"
+fi
+
+popd >/dev/null

--- a/dev/ctags-install.sh
+++ b/dev/ctags-install.sh
@@ -10,6 +10,12 @@ mkdir -p .bin
 CTAGS_VERSION=f95bb3497f53748c2b6afc7f298cff218103ab90
 NAME="ctags-${CTAGS_VERSION}"
 TARGET="$PWD/.bin/${NAME}"
+
+if [ $1 == "which" ]; then
+  echo $TARGET
+  exit 0
+fi
+
 tmpdir=$(mktemp -d -t sg.ctags-install.XXXXXX)
 
 function ctrl_c() {

--- a/dev/universal-ctags-dev
+++ b/dev/universal-ctags-dev
@@ -2,12 +2,21 @@
 
 # This script is a wrapper around `universal-ctags`.
 #
+# It checks if universal-ctags has been installed through ./dev/ctags-install.sh or falls back to a dockerized version.
+#
 # To use your own `universal-ctags` binary instead of this wrapper in your local dev server, use
 # `CTAGS_COMMAND=path/to/ctags sg start`.
 
-exec docker run --rm -i \
+root="$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
+TARGET=$($root/dev/ctags-install.sh which)
+
+if [ ! -f "${TARGET}" ]; then 
+  exec docker run --rm -i \
     -a stdin -a stdout -a stderr \
     --user guest \
     --name=universal-ctags-$$ \
     --entrypoint /usr/local/bin/universal-ctags \
     ctags "$@"
+else 
+  ${TARGET} "$@"
+fi

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -299,7 +299,7 @@ commands:
       go build -gcflags="$GCFLAGS" -o .bin/oss-symbols github.com/sourcegraph/sourcegraph/cmd/symbols
     checkBinary: .bin/oss-symbols
     env:
-      CTAGS_COMMAND: cmd/symbols/universal-ctags-dev
+      CTAGS_COMMAND: dev/universal-ctags-dev
       CTAGS_PROCESSES: 2
     watch:
       - lib
@@ -317,7 +317,7 @@ commands:
       go build -gcflags="$GCFLAGS" -o .bin/symbols github.com/sourcegraph/sourcegraph/enterprise/cmd/symbols
     checkBinary: .bin/symbols
     env:
-      CTAGS_COMMAND: cmd/symbols/universal-ctags-dev
+      CTAGS_COMMAND: dev/universal-ctags-dev
       CTAGS_PROCESSES: 2
       USE_ROCKSKIP: 'false'
     watch:
@@ -428,7 +428,7 @@ commands:
       go install github.com/sourcegraph/zoekt/cmd/zoekt-sourcegraph-indexserver
     checkBinary: .bin/zoekt-sourcegraph-indexserver
     env: &zoektenv
-      CTAGS_COMMAND: cmd/symbols/universal-ctags-dev
+      CTAGS_COMMAND: dev/universal-ctags-dev
 
   zoekt-index-0:
     <<: *zoekt_indexserver_template


### PR DESCRIPTION
Most of us are running the dockerized version of ctags because that's the default. It's totally possible to overrides this and provides your by setting a custom `CTAGS_COMMAND` in your `.sg.config.overrides.yaml` but that's a tad bit too much manual. 

This PR adds a `./dev/ctags-install.sh` which will attempt at building ctags with the correct version and put it under `.bin/` at the root of the repo. The universal ctags runner will then pick that up automatically instead of going for the docker container. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Locally tested. 