### PR TITLE
extsvc: use iterator for Pagure

### DIFF
--- a/internal/extsvc/pagure/client_test.go
+++ b/internal/extsvc/pagure/client_test.go
@@ -18,18 +18,30 @@ func TestClient_ListProjects(t *testing.T) {
 	defer save()
 
 	ctx := context.Background()
+	limit := 5
 
 	args := ListProjectsArgs{
-		Cursor:  &Pagination{PerPage: 5, Page: 1},
+		Cursor:  &Pagination{PerPage: limit, Page: 1},
 		Fork:    true,
 		Pattern: "tmux",
 	}
 
-	resp, err := cli.ListProjects(ctx, args)
-	if err != nil {
+	it := cli.ListProjects(ctx, args)
+
+	var projects []*Project
+	for i := 0; i < limit && it.Next(); i++ {
+		projects = append(projects, it.Current())
+	}
+
+	if err := it.Err(); err != nil {
 		t.Fatal(err)
 	}
 
+	// TODO We wrap the golden to make the diff were we only return projects
+	// cleaner to review. Can be removed in future.
+	resp := map[string]any{
+		"projects": projects,
+	}
 	testutil.AssertGolden(t, "testdata/golden/ListProjects.json", *update, resp)
 }
 

--- a/internal/extsvc/pagure/client_test.go
+++ b/internal/extsvc/pagure/client_test.go
@@ -37,7 +37,7 @@ func TestClient_ListProjects(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// TODO We wrap the golden to make the diff were we only return projects
+	// TODO We wrap the golden to make the diff where we only return projects
 	// cleaner to review. Can be removed in future.
 	resp := map[string]any{
 		"projects": projects,

--- a/internal/extsvc/pagure/testdata/golden/ListProjects.json
+++ b/internal/extsvc/pagure/testdata/golden/ListProjects.json
@@ -1,13 +1,4 @@
 {
-  "pagination": {
-   "first": "https://src.fedoraproject.org/api/0/projects?per_page=5\u0026fork=true\u0026pattern=tmux\u0026page=1",
-   "last": "https://src.fedoraproject.org/api/0/projects?per_page=5\u0026fork=true\u0026pattern=tmux\u0026page=2",
-   "next": "https://src.fedoraproject.org/api/0/projects?per_page=5\u0026fork=true\u0026pattern=tmux\u0026page=2",
-   "page": 1,
-   "pages": 2,
-   "per_page": 5,
-   "prev": ""
-  },
   "projects": [
    {
     "description": "The tmux rpms",


### PR DESCRIPTION
This uses the recently introduced iterator for Pagure as an experiment for what the iterator API looks like. The changes to pagure.go feel like a big improvement, no handling of pagination and less nested loops.

Unfortunetly the pagure client tests asserted only one page of data, so we somewhat hack it and only collect 5 items from the iterator. Otherwise this feels cleaner.

Test Plan: go test