### PR TITLE
insights: make a single status query per series on the old backfill table

### DIFF
--- a/enterprise/internal/insights/background/queryrunner/worker.go
+++ b/enterprise/internal/insights/background/queryrunner/worker.go
@@ -302,7 +302,7 @@ func QueryJobsStatus(ctx context.Context, workerBaseStore *basestore.Store, seri
 }
 
 const queryJobsStatusSql = `
-SELECT state, count(*) from insights_query_runner_jobs WHERE series_id=%s GROUP BY state 
+SELECT state, COUNT(*) FROM insights_query_runner_jobs WHERE series_id=%s GROUP BY state 
 `
 
 func QueryAllSeriesStatus(ctx context.Context, workerBaseStore *basestore.Store) (_ []types.InsightSeriesStatus, err error) {

--- a/enterprise/internal/insights/background/queryrunner/worker.go
+++ b/enterprise/internal/insights/background/queryrunner/worker.go
@@ -304,7 +304,7 @@ func QueryJobsStatus(ctx context.Context, workerBaseStore *basestore.Store, seri
 }
 
 const queryJobsStatusSql = `
-SELECT state, count(*) from insights_query_runner_jobs WHERE series_id=%s GROUP BY state 
+SELECT state, COUNT(*) FROM insights_query_runner_jobs WHERE series_id=%s GROUP BY state 
 `
 
 func QueryAllSeriesStatus(ctx context.Context, workerBaseStore *basestore.Store) (_ []types.InsightSeriesStatus, err error) {


### PR DESCRIPTION
Small improvement on how we fetch backfill status on the old backfiller (we won't be able to remove this entirely, even with backfillerv2). 

one query per series now:
<img width="1449" alt="image" src="https://user-images.githubusercontent.com/29406849/205704528-2713d3c5-7e32-4161-882f-447a84ec4e71.png">

## Test plan

Added a unit test and fetched some insight views