### PR TITLE
Obvious all-repos-out filters return errors

### DIFF
--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type repositoryArgs struct {
@@ -74,15 +75,22 @@ func (args *repositoryArgs) toReposListOptions() (database.ReposListOptions, err
 
 	opt.FailedFetch = args.FailedFetch
 
+	if !args.Cloned && !args.NotCloned {
+		return database.ReposListOptions{}, errors.New("excluding cloned and not cloned repos leaves an empty set")
+	}
 	if !args.Cloned {
 		opt.NoCloned = true
-	} else if !args.NotCloned {
+	}
+	if !args.NotCloned {
 		// notCloned is true by default.
 		// this condition is valid only if it has been
 		// explicitly set to false by the client.
 		opt.OnlyCloned = true
 	}
 
+	if !args.Indexed && !args.NotIndexed {
+		return database.ReposListOptions{}, errors.New("excluding indexed and not indexed repos leaves an empty set")
+	}
 	if !args.Indexed {
 		opt.NoIndexed = true
 	}

--- a/cmd/frontend/graphqlbackend/repositories_test.go
+++ b/cmd/frontend/graphqlbackend/repositories_test.go
@@ -232,17 +232,14 @@ func TestRepositoriesCloneStatusFiltering(t *testing.T) {
 					}
 				}
 			`,
-				ExpectedResult: `
-				{
-					"repositories": {
-						"nodes": [
-							{ "name": "repo1" },
-							{ "name": "repo2" }
-						],
-						"pageInfo": {"hasNextPage": false}
-					}
-				}
-			`,
+				ExpectedResult: "null",
+				ExpectedErrors: []*gqlerrors.QueryError{
+					{
+						Path:          []any{"repositories"},
+						Message:       "excluding cloned and not cloned repos leaves an empty set",
+						ResolverError: errors.New("excluding cloned and not cloned repos leaves an empty set"),
+					},
+				},
 			},
 			{
 				Schema: schema,
@@ -468,15 +465,14 @@ func TestRepositoriesIndexingFiltering(t *testing.T) {
 					}
 				}
 			`,
-			ExpectedResult: `
+			ExpectedResult: "null",
+			ExpectedErrors: []*gqlerrors.QueryError{
 				{
-					"repositories": {
-						"nodes": [],
-						"totalCount": 0,
-						"pageInfo": {"hasNextPage": false}
-					}
-				}
-			`,
+					Path:          []any{"repositories"},
+					Message:       "excluding indexed and not indexed repos leaves an empty set",
+					ResolverError: errors.New("excluding indexed and not indexed repos leaves an empty set"),
+				},
+			},
 		},
 	})
 }
@@ -622,7 +618,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 				{
 					Path:          []any{"repositories"},
 					Message:       `cannot unmarshal repository cursor type: ""`,
-					ResolverError: errors.Errorf(`cannot unmarshal repository cursor type: ""`),
+					ResolverError: errors.New(`cannot unmarshal repository cursor type: ""`),
 				},
 			},
 		})
@@ -796,12 +792,6 @@ func TestRepositories_Integration(t *testing.T) {
 			args:           "notIndexed: false",
 			wantRepos:      []string{"repo8"},
 			wantTotalCount: 1,
-		},
-		// indexed and notIndexed
-		{
-			args:           "indexed: false, notIndexed: false",
-			wantRepos:      nil,
-			wantTotalCount: 0,
 		},
 		{
 			args:           "orderBy:SIZE, descending:false, first: 5",


### PR DESCRIPTION
In GraphQL repo queries, filtering out all repos in form of `cloned: false, notCloned: false` or `indexed: false, notIndexed: false` results in an error as the query does not serve any use case and is probably an error.

Closes #39980 

## Test plan

Amend the small and large tests to reflect the behavior change.

👉 Prefer `errors.New` to `errors.Errorf` when no string formatting is used.
