### PR TITLE
sg: remove ENABLE_STREAMING_REPOS_SYNCER from config

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -112,7 +112,6 @@ env:
   DB_STARTUP_TIMEOUT: 120s # codeinsights-db needs more time to start in some instances.
   DISABLE_CODE_INSIGHTS_HISTORICAL: true
   DISABLE_CODE_INSIGHTS: true
-  ENABLE_STREAMING_REPOS_SYNCER: true
 
   # # OpenTelemetry in dev - use single http/json endpoint
   # OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:4318


### PR DESCRIPTION
This variable was removed in 3.31.

Test Plan: sg start