### PR TITLE
Token selection: implement document highlights

### DIFF
--- a/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
+++ b/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
@@ -138,7 +138,7 @@ export function sourcegraphExtensions({
         // when selection-driven navigation is enabled because it reimplements
         // hover logic in the file 'token-selection/hover.ts'.
         enableSelectionDrivenCodeNavigation ? [] : hovercardDataSource(contextObservable),
-        documentHighlightsDataSource(contextObservable),
+        enableSelectionDrivenCodeNavigation ? [] : documentHighlightsDataSource(contextObservable),
         disableDecorations ? [] : textDocumentDecorations(contextObservable),
         ViewPlugin.define(() => new SelectionManager(contextObservable)),
         disableStatusBar

--- a/client/web/src/repo/blob/codemirror/token-selection/document-highlights.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/document-highlights.ts
@@ -35,7 +35,7 @@ async function getDocumentHighlights(view: EditorView, occurrence: Occurrence): 
     cache.set(occurrence, promise)
     return await promise
 }
-export function documentHighlightsForOccurrence(view: EditorView, occurrence: Occurrence): void {
+export function getDocumentHighlightsForOccurrence(view: EditorView, occurrence: Occurrence): void {
     getDocumentHighlights(view, occurrence).then(
         result => view.dispatch({ effects: setDocumentHighlights.of(result) }),
         () => {}

--- a/client/web/src/repo/blob/codemirror/token-selection/document-highlights.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/document-highlights.ts
@@ -35,7 +35,7 @@ async function getDocumentHighlights(view: EditorView, occurrence: Occurrence): 
     cache.set(occurrence, promise)
     return await promise
 }
-export function getDocumentHighlightsForOccurrence(view: EditorView, occurrence: Occurrence): void {
+export function showDocumentHighlightsForOccurrence(view: EditorView, occurrence: Occurrence): void {
     getDocumentHighlights(view, occurrence).then(
         result => view.dispatch({ effects: setDocumentHighlights.of(result) }),
         () => {}

--- a/client/web/src/repo/blob/codemirror/token-selection/document-highlights.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/document-highlights.ts
@@ -1,0 +1,47 @@
+import { Extension, StateField } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { DocumentHighlight } from '@sourcegraph/codeintellify'
+import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
+import { Occurrence } from '@sourcegraph/shared/src/codeintel/scip'
+import { createUpdateableField } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
+import { toURIWithPath } from '@sourcegraph/shared/src/util/url'
+import { blobPropsFacet } from '..'
+import { showDocumentHighlights } from '../document-highlights'
+
+export const documentHighlightCache = StateField.define<Map<Occurrence, Promise<DocumentHighlight[]>>>({
+    create: () => new Map(),
+    update: value => value,
+})
+const [documentHighlightsField, , setDocumentHighlights] = createUpdateableField<DocumentHighlight[]>([], field =>
+    showDocumentHighlights.from(field)
+)
+
+async function getDocumentHighlights(view: EditorView, occurrence: Occurrence): Promise<DocumentHighlight[]> {
+    const cache = view.state.field(documentHighlightCache)
+    const fromCache = cache.get(occurrence)
+    if (fromCache) {
+        return await fromCache
+    }
+    const blobProps = view.state.facet(blobPropsFacet)
+    const api = await blobProps.extensionsController?.extHostAPI
+    if (!api) {
+        return []
+    }
+    const result = await api.getDocumentHighlights({
+        textDocument: { uri: toURIWithPath(blobProps.blobInfo) },
+        position: occurrence.range.start,
+    })
+    const promise = wrapRemoteObservable(result).toPromise()
+    cache.set(occurrence, promise)
+    return await promise
+}
+export function documentHighlightsForOccurrence(view: EditorView, occurrence: Occurrence): void {
+    getDocumentHighlights(view, occurrence).then(
+        result => view.dispatch({ effects: setDocumentHighlights.of(result) }),
+        () => {}
+    )
+}
+
+export function documentHighlightsExtension(): Extension {
+    return [documentHighlightCache, documentHighlightsField]
+}

--- a/client/web/src/repo/blob/codemirror/token-selection/document-highlights.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/document-highlights.ts
@@ -1,10 +1,12 @@
 import { Extension, StateField } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
+
 import { DocumentHighlight } from '@sourcegraph/codeintellify'
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
 import { Occurrence } from '@sourcegraph/shared/src/codeintel/scip'
 import { createUpdateableField } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 import { toURIWithPath } from '@sourcegraph/shared/src/util/url'
+
 import { blobPropsFacet } from '..'
 import { showDocumentHighlights } from '../document-highlights'
 
@@ -20,7 +22,7 @@ async function getDocumentHighlights(view: EditorView, occurrence: Occurrence): 
     const cache = view.state.field(documentHighlightCache)
     const fromCache = cache.get(occurrence)
     if (fromCache) {
-        return await fromCache
+        return fromCache
     }
     const blobProps = view.state.facet(blobPropsFacet)
     const api = await blobProps.extensionsController?.extHostAPI
@@ -33,7 +35,7 @@ async function getDocumentHighlights(view: EditorView, occurrence: Occurrence): 
     })
     const promise = wrapRemoteObservable(result).toPromise()
     cache.set(occurrence, promise)
-    return await promise
+    return promise
 }
 export function showDocumentHighlightsForOccurrence(view: EditorView, occurrence: Occurrence): void {
     getDocumentHighlights(view, occurrence).then(

--- a/client/web/src/repo/blob/codemirror/token-selection/extension.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/extension.ts
@@ -5,6 +5,7 @@ import { isInteractiveOccurrence, occurrenceAtMouseEvent } from '../occurrence-u
 import { MOUSE_MAIN_BUTTON } from '../utils'
 
 import { definitionCache, goToDefinitionOnMouseEvent, underlinedDefinitionFacet } from './definition'
+import { documentHighlightsExtension } from './document-highlights'
 import { getHoverTooltip, hoverCache, hoveredOccurrenceField, hoverField, setHoveredOccurrenceEffect } from './hover'
 import { tokenSelectionKeyBindings } from './keybindings'
 import { modifierClickFacet } from './modifier-click'
@@ -18,6 +19,7 @@ export function tokenSelectionExtension(): Extension {
     let longPressTimeout: NodeJS.Timeout | undefined
     let didLongpress = false
     return [
+        documentHighlightsExtension(),
         modifierClickFacet.of(false),
         tokenSelectionTheme,
         selectedOccurrence.of(null),

--- a/client/web/src/repo/blob/codemirror/token-selection/selections.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/selections.ts
@@ -11,8 +11,8 @@ import { cmSelectionToRange, occurrenceAtPosition, rangeToCmSelection } from '..
 import { isSelectionInsideDocument } from '../utils'
 
 import { definitionCache, goToDefinitionAtOccurrence } from './definition'
-import { hoverAtOccurrence, hoverCache, setHoveredOccurrenceEffect } from './hover'
 import { showDocumentHighlightsForOccurrence } from './document-highlights'
+import { hoverAtOccurrence, hoverCache, setHoveredOccurrenceEffect } from './hover'
 
 export const tokenSelectionTheme = EditorView.theme({
     '.cm-token-selection-definition-ready': {

--- a/client/web/src/repo/blob/codemirror/token-selection/selections.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/selections.ts
@@ -12,7 +12,7 @@ import { isSelectionInsideDocument } from '../utils'
 
 import { definitionCache, goToDefinitionAtOccurrence } from './definition'
 import { hoverAtOccurrence, hoverCache, setHoveredOccurrenceEffect } from './hover'
-import { documentHighlightsForOccurrence } from './document-highlights'
+import { showDocumentHighlightsForOccurrence } from './document-highlights'
 
 export const tokenSelectionTheme = EditorView.theme({
     '.cm-token-selection-definition-ready': {
@@ -98,7 +98,7 @@ export const warmupOccurrence = (view: EditorView, occurrence: Occurrence): void
 
 export const selectOccurrence = (view: EditorView, occurrence: Occurrence): void => {
     warmupOccurrence(view, occurrence)
-    documentHighlightsForOccurrence(view, occurrence)
+    showDocumentHighlightsForOccurrence(view, occurrence)
     selectRange(view, occurrence.range)
     view.dispatch({ effects: setHoveredOccurrenceEffect.of(occurrence) })
 }

--- a/client/web/src/repo/blob/codemirror/token-selection/selections.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/selections.ts
@@ -12,6 +12,7 @@ import { isSelectionInsideDocument } from '../utils'
 
 import { definitionCache, goToDefinitionAtOccurrence } from './definition'
 import { hoverAtOccurrence, hoverCache, setHoveredOccurrenceEffect } from './hover'
+import { documentHighlightsForOccurrence } from './document-highlights'
 
 export const tokenSelectionTheme = EditorView.theme({
     '.cm-token-selection-definition-ready': {
@@ -97,6 +98,7 @@ export const warmupOccurrence = (view: EditorView, occurrence: Occurrence): void
 
 export const selectOccurrence = (view: EditorView, occurrence: Occurrence): void => {
     warmupOccurrence(view, occurrence)
+    documentHighlightsForOccurrence(view, occurrence)
     selectRange(view, occurrence.range)
     view.dispatch({ effects: setHoveredOccurrenceEffect.of(occurrence) })
 }


### PR DESCRIPTION
Previously, we used the same document highlight implementation as the old blob view, which triggered document higlights on every mousemove event. This commit changes the behavior to trigger document highlights on token selection mirroring the behavior of IntelliJ and VS Code. One benefit of this approach is that it's compatible with keyboard navigation because we trigger higlights based on selection instead of mouse movements. Personally, I also like that I can now select a token and scroll through the file to see the matching occurrences (previously, moving the mouse would make the highlights disappear or change.

## Test plan

Manually tested with a local build.

![CleanShot 2022-12-05 at 19 37 52](https://user-images.githubusercontent.com/1408093/205716227-859875d6-bb2e-47d1-b3b8-0286250fb046.gif)



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-selection-networks.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
