### PR TITLE
Only display warning banner in batch changes if no associated legacy OR new webhook found.

### DIFF
--- a/enterprise/internal/batches/store/codehost.go
+++ b/enterprise/internal/batches/store/codehost.go
@@ -127,7 +127,7 @@ func listCodeHostsQuery(opts ListCodeHostsOpts) *sqlf.Query {
 
 	var aggregatePreds []*sqlf.Query
 	if opts.OnlyWithoutWebhooks {
-		aggregatePreds = append(aggregatePreds, sqlf.Sprintf("has_webhooks_count = 0"))
+		aggregatePreds = append(aggregatePreds, sqlf.Sprintf("has_webhooks_count = 0 AND external_service_id NOT IN (SELECT code_host_urn FROM webhooks)"))
 	} else {
 		aggregatePreds = append(aggregatePreds, sqlf.Sprintf("TRUE"))
 	}

--- a/enterprise/internal/batches/store/codehost.go
+++ b/enterprise/internal/batches/store/codehost.go
@@ -127,7 +127,7 @@ func listCodeHostsQuery(opts ListCodeHostsOpts) *sqlf.Query {
 
 	var aggregatePreds []*sqlf.Query
 	if opts.OnlyWithoutWebhooks {
-		aggregatePreds = append(aggregatePreds, sqlf.Sprintf("has_webhooks_count = 0 AND external_service_id NOT IN (SELECT code_host_urn FROM webhooks)"))
+		aggregatePreds = append(aggregatePreds, sqlf.Sprintf("has_webhooks_count = 0 AND external_service_id NOT IN (SELECT DISTINCT(code_host_urn) FROM webhooks)"))
 	} else {
 		aggregatePreds = append(aggregatePreds, sqlf.Sprintf("TRUE"))
 	}

--- a/enterprise/internal/batches/store/codehost_test.go
+++ b/enterprise/internal/batches/store/codehost_test.go
@@ -125,9 +125,7 @@ func testStoreCodeHost(t *testing.T, ctx context.Context, s *Store, clock bt.Clo
 						HasWebhooks:         false,
 					},
 				}
-				if diff := cmp.Diff(have, want); diff != "" {
-					t.Fatalf("Invalid code hosts returned. %s", diff)
-				}
+				assert.Equal(t, want, have)
 			})
 			t.Run("excludes codehosts w/ associated row in webhooks table", func(t *testing.T) {
 				ws := database.WebhooksWith(s.Store, nil)
@@ -145,9 +143,7 @@ func testStoreCodeHost(t *testing.T, ctx context.Context, s *Store, clock bt.Clo
 						HasWebhooks:         false,
 					},
 				}
-				if diff := cmp.Diff(have, want); diff != "" {
-					t.Fatalf("Invalid code hosts returned. %s", diff)
-				}
+				assert.Equal(t, want, have)
 			})
 		})
 	})

--- a/enterprise/internal/batches/store/codehost_test.go
+++ b/enterprise/internal/batches/store/codehost_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/log/logtest"
@@ -105,26 +107,48 @@ func testStoreCodeHost(t *testing.T, ctx context.Context, s *Store, clock bt.Clo
 			}
 		})
 		t.Run("OnlyWithoutWebhooks", func(t *testing.T) {
-			have, err := s.ListCodeHosts(ctx, ListCodeHostsOpts{OnlyWithoutWebhooks: true})
-			if err != nil {
-				t.Fatal(err)
-			}
-			want := []*btypes.CodeHost{
-				{
-					ExternalServiceType: extsvc.TypeBitbucketServer,
-					ExternalServiceID:   "https://bitbucketserver.com/",
-					RequiresSSH:         true,
-					HasWebhooks:         false,
-				},
-				{
-					ExternalServiceType: extsvc.TypeGitLab,
-					ExternalServiceID:   "https://gitlab.com/",
-					HasWebhooks:         false,
-				},
-			}
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatalf("Invalid code hosts returned. %s", diff)
-			}
+			t.Run("has_webhooks column is false", func(t *testing.T) {
+				have, err := s.ListCodeHosts(ctx, ListCodeHostsOpts{OnlyWithoutWebhooks: true})
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := []*btypes.CodeHost{
+					{
+						ExternalServiceType: extsvc.TypeBitbucketServer,
+						ExternalServiceID:   "https://bitbucketserver.com/",
+						RequiresSSH:         true,
+						HasWebhooks:         false,
+					},
+					{
+						ExternalServiceType: extsvc.TypeGitLab,
+						ExternalServiceID:   "https://gitlab.com/",
+						HasWebhooks:         false,
+					},
+				}
+				if diff := cmp.Diff(have, want); diff != "" {
+					t.Fatalf("Invalid code hosts returned. %s", diff)
+				}
+			})
+			t.Run("excludes codehosts w/ associated row in webhooks table", func(t *testing.T) {
+				ws := database.WebhooksWith(s.Store, nil)
+
+				_, err := ws.Create(ctx, "mytestwebhook", extsvc.KindBitbucketServer, "https://bitbucketserver.com/", 0, nil)
+				assert.NoError(t, err)
+				have, err := s.ListCodeHosts(ctx, ListCodeHostsOpts{OnlyWithoutWebhooks: true})
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := []*btypes.CodeHost{
+					{
+						ExternalServiceType: extsvc.TypeGitLab,
+						ExternalServiceID:   "https://gitlab.com/",
+						HasWebhooks:         false,
+					},
+				}
+				if diff := cmp.Diff(have, want); diff != "" {
+					t.Fatalf("Invalid code hosts returned. %s", diff)
+				}
+			})
 		})
 	})
 


### PR DESCRIPTION
When determining whether or not to display a banner in the batch changes UI to configure webhooks, we currently run a query against the `has_webhooks` column in the `external_services` table. This PR updates this to also check if there is an associated row in the `webhooks` table. So, we will only display the banner if there is no webhook set up (either in the legacy manner via the external service config, or in the webhooks table). We match a webhook to an external service repo via the url (i.e. the `code_host_urn` in the `webhooks` table and the `external_service_id` in the `repo` table.)

Closes https://github.com/sourcegraph/sourcegraph/issues/44732


## Test plan
Validate via the UI that this works as expected

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
