### PR TITLE
blobstore: fix /data file permissions

### DIFF
--- a/docker-images/blobstore/Dockerfile
+++ b/docker-images/blobstore/Dockerfile
@@ -59,7 +59,9 @@ ENV \
     JCLOUDS_KEYSTONE_PROJECT_DOMAIN_NAME="" \
     JCLOUDS_FILESYSTEM_BASEDIR="/data"
 
-EXPOSE 9000
+RUN mkdir -p /data && chown -R sourcegraph:sourcegraph /data
 USER sourcegraph
+
+EXPOSE 9000
 WORKDIR /opt/s3proxy
 ENTRYPOINT ["/sbin/tini", "--", "/opt/s3proxy/run-docker-container.sh"]


### PR DESCRIPTION
As Quinn noted in an earlier PR, if `/data` is not writable by the container then we encounter these errors:

- `failed to create bucket: operation error S3: CreateBucket, https response error StatusCode: 403` from the precise-code-intel-worker service
- `sendSimpleErrorResponse: 403 AccessDenied Forbidden` in the blobstore Docker container logs

Docker inherits the permissions of the folder if it is created in the Dockerfile and I forgot to include the creation of the `/data` folder previously. Fixing this means we don't e.g. have to manually correct permissions in Docker Compose or pure-docker deployment types.

Helps #44254

## Test plan

Standard CI tests + confirmed `sg start codeintel` comes up as expected.

Doesn't affect `sourcegraph/server` (it has its own directory creation logic and so can't affect that.) This image is otherwise not used in production yet.
