### PR TITLE
site settings: restore 'search.index.enabled' as a removed option

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2238,6 +2238,8 @@ type SiteConfiguration struct {
 	RepoListUpdateInterval int `json:"repoListUpdateInterval,omitempty"`
 	// RepoPurgeWorker description: Configuration for repository purge worker.
 	RepoPurgeWorker *RepoPurgeWorker `json:"repoPurgeWorker,omitempty"`
+	// SearchIndexEnabled description: REMOVED.
+	SearchIndexEnabled *bool `json:"search.index.enabled,omitempty"`
 	// SearchIndexSymbolsEnabled description: Whether indexed symbol search is enabled. This is contingent on the indexed search configuration, and is true by default for instances with indexed search enabled. Enabling this will cause every repository to re-index, which is a time consuming (several hours) operation. Additionally, it requires more storage and ram to accommodate the added symbols information in the search index.
 	SearchIndexSymbolsEnabled *bool `json:"search.index.symbols.enabled,omitempty"`
 	// SearchLargeFiles description: A list of file glob patterns where matching files will be indexed and searched regardless of their size. Files still need to be valid utf-8 to be indexed. The glob pattern syntax can be found here: https://github.com/bmatcuk/doublestar#patterns.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -17,6 +17,12 @@
       "type": "boolean",
       "group": "Search"
     },
+    "search.index.enabled": {
+      "description": "REMOVED.",
+      "type": "boolean",
+      "!go": { "pointer": true },
+      "group": "Search"
+    },
     "search.index.symbols.enabled": {
       "description": "Whether indexed symbol search is enabled. This is contingent on the indexed search configuration, and is true by default for instances with indexed search enabled. Enabling this will cause every repository to re-index, which is a time consuming (several hours) operation. Additionally, it requires more storage and ram to accommodate the added symbols information in the search index.",
       "type": "boolean",


### PR DESCRIPTION
Fixes warning showing up if `search.index.enabled` still exists in the site settings after being removed in #45138:

![image](https://user-images.githubusercontent.com/206864/205763661-98af7cda-ab8e-423f-a52e-71b2da6a675f.png)

## Test plan

`search.index.enabled` option still exists (but does nothing) and no warning is shown.