### PR TITLE
quieter info logs

### DIFF
--- a/cmd/frontend/globals/globals.go
+++ b/cmd/frontend/globals/globals.go
@@ -152,7 +152,7 @@ func WatchBranding() {
 
 		if before := Branding(); !reflect.DeepEqual(before, after) {
 			SetBranding(after)
-			log15.Info(
+			log15.Debug(
 				"globals.Branding",
 				"updated", true,
 				"before", before,

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -237,12 +237,12 @@ func runRoutinesConcurrently(observationCtx *observation.Context, jobs map[strin
 		observationCtx := observation.ContextWithLogger(jobLogger, observationCtx)
 
 		if !shouldRunJob(name) {
-			jobLogger.Info("Skipping job")
+			jobLogger.Debug("Skipping job")
 			continue
 		}
 
 		wg.Add(1)
-		jobLogger.Info("Running job")
+		jobLogger.Debug("Running job")
 
 		go func(name string) {
 			defer wg.Done()
@@ -251,7 +251,7 @@ func runRoutinesConcurrently(observationCtx *observation.Context, jobs map[strin
 			results <- routinesResult{name, routines, err}
 
 			if err == nil {
-				jobLogger.Info("Finished initializing job")
+				jobLogger.Debug("Finished initializing job")
 			} else {
 				cancel()
 			}

--- a/enterprise/cmd/executor/internal/run/run.go
+++ b/enterprise/cmd/executor/internal/run/run.go
@@ -37,7 +37,7 @@ func RunRun(cliCtx *cli.Context, logger log.Logger, cfg *config.Config) error {
 
 		return newQueueTelemetryOptions(ctx, cfg.UseFirecracker, logger)
 	}()
-	logger.Info("Telemetry information gathered", log.String("info", fmt.Sprintf("%+v", queueTelemetryOptions)))
+	logger.Debug("Telemetry information gathered", log.String("info", fmt.Sprintf("%+v", queueTelemetryOptions)))
 
 	opts := apiWorkerOptions(cfg, queueTelemetryOptions)
 

--- a/enterprise/cmd/executor/internal/worker/worker.go
+++ b/enterprise/cmd/executor/internal/worker/worker.go
@@ -115,7 +115,7 @@ func NewWorker(observationCtx *observation.Context, nameSet *janitor.NameSet, op
 // after a ping is successful and returns false if a user signal is received.
 func connectToFrontend(logger log.Logger, queueStore *queue.Client, options Options) bool {
 	start := time.Now()
-	logger.Info("Connecting to Sourcegraph instance", log.String("url", options.QueueOptions.BaseClientOptions.EndpointOptions.URL))
+	logger.Debug("Connecting to Sourcegraph instance", log.String("url", options.QueueOptions.BaseClientOptions.EndpointOptions.URL))
 
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
@@ -127,7 +127,7 @@ func connectToFrontend(logger log.Logger, queueStore *queue.Client, options Opti
 	for {
 		err := queueStore.Ping(context.Background(), options.QueueName, nil)
 		if err == nil {
-			logger.Info("Connected to Sourcegraph instance")
+			logger.Debug("Connected to Sourcegraph instance")
 			return true
 		}
 

--- a/enterprise/cmd/worker/internal/insights/job.go
+++ b/enterprise/cmd/worker/internal/insights/job.go
@@ -24,10 +24,10 @@ func (s *insightsJob) Config() []env.Config {
 
 func (s *insightsJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	if !insights.IsEnabled() {
-		observationCtx.Logger.Info("Code Insights Disabled. Disabling background jobs.")
+		observationCtx.Logger.Debug("Code Insights disabled. Disabling background jobs.")
 		return []goroutine.BackgroundRoutine{}, nil
 	}
-	observationCtx.Logger.Info("Code Insights Enabled. Enabling background jobs.")
+	observationCtx.Logger.Debug("Code Insights enabled. Enabling background jobs.")
 
 	db, err := workerdb.InitDB(observationCtx)
 	if err != nil {

--- a/enterprise/cmd/worker/internal/insights/query_runner_job.go
+++ b/enterprise/cmd/worker/internal/insights/query_runner_job.go
@@ -38,10 +38,10 @@ func (s *insightsQueryRunnerJob) Config() []env.Config {
 
 func (s *insightsQueryRunnerJob) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	if !insights.IsEnabled() {
-		observationCtx.Logger.Info("Code Insights Disabled. Disabling query runner.")
+		observationCtx.Logger.Debug("Code Insights disabled. Disabling query runner.")
 		return []goroutine.BackgroundRoutine{}, nil
 	}
-	observationCtx.Logger.Info("Code Insights Enabled. Enabling query runner.")
+	observationCtx.Logger.Debug("Code Insights enabled. Enabling query runner.")
 
 	db, err := workerdb.InitDB(observationCtx)
 	if err != nil {

--- a/enterprise/internal/authz/syncjobs/records_store.go
+++ b/enterprise/internal/authz/syncjobs/records_store.go
@@ -54,10 +54,10 @@ func (r *RecordsStore) Watch(c conftypes.WatchableSiteConfig) {
 		if ttlMinutes > 0 {
 			ttlSeconds := ttlMinutes * 60
 			r.cache = rcache.NewWithTTL(syncJobsRecordsPrefix, ttlSeconds)
-			r.logger.Info("enabled records store cache", log.Int("ttlSeconds", ttlSeconds))
+			r.logger.Debug("enabled records store cache", log.Int("ttlSeconds", ttlSeconds))
 		} else {
 			r.cache = noopCache{}
-			r.logger.Info("disabled records store cache")
+			r.logger.Debug("disabled records store cache")
 		}
 	})
 }

--- a/internal/repos/purge.go
+++ b/internal/repos/purge.go
@@ -117,7 +117,7 @@ func purge(ctx context.Context, logger log.Logger, db database.DB, options datab
 		return nil
 	})
 	// If we did something we log with a higher level.
-	statusLogger := logger.Info
+	statusLogger := logger.Debug
 	if failed > 0 {
 		statusLogger = logger.Warn
 	}

--- a/internal/tracer/watch.go
+++ b/internal/tracer/watch.go
@@ -45,7 +45,7 @@ func newConfWatcher(
 			// Set and log our new trace policy
 			if newPolicy != previousPolicy {
 				policy.SetTracePolicy(newPolicy)
-				logger.Info("updated TracePolicy",
+				logger.Debug("updated TracePolicy",
 					log.String("previous", string(previousPolicy)),
 					log.String("new", string(newPolicy)))
 			}


### PR DESCRIPTION
These log messages are not useful at the information level IMO, and they add a lot of log noise when running the single-Docker-container (or the future single-program) deployment methods.

## Test plan

n/a