### PR TITLE
web: ignore network events in the OpenTelemetry fetch instrumentation

### DIFF
--- a/client/web/src/monitoring/opentelemetry/initOpenTelemetry.ts
+++ b/client/web/src/monitoring/opentelemetry/initOpenTelemetry.ts
@@ -72,7 +72,11 @@ export function initOpenTelemetry(): void {
         registerInstrumentations({
             // Type-casting is required since the `FetchInstrumentation` is wrongly typed internally as `node.js` instrumentation.
             instrumentations: [
-                (new FetchInstrumentation() as unknown) as InstrumentationOption,
+                (new FetchInstrumentation({
+                    // Ignore adding network events as span events to reduce the volume of events
+                    // sent to OpenTelemetry backends such as Honeycomb.
+                    ignoreNetworkEvents: true,
+                }) as unknown) as InstrumentationOption,
                 new WindowLoadInstrumentation(),
                 new HistoryInstrumentation({
                     shouldCreatePageViewOnLocationChange: prevLocationInfo => {


### PR DESCRIPTION
## Context

Honeycomb treats span events in separate events, which a billable and contribute to the number of events we are allowed to ingest daily on our current plan. The fetch instrumentation creates 9 network events for each HTTP request span which significantly increases the volume of created spans. This PR disabled network events on HTTP request spans. 

See the breakdown of events sent to Honeycomb by name [here](https://ui.honeycomb.io/sourcegraph/environments/dotcom/datasets/web-app/usage/result/tXNG4R55bEJ):

<img width="1166" alt="Screenshot 2022-12-06 at 17 07 47" src="https://user-images.githubusercontent.com/3846380/205868255-e86952d3-ceee-4867-9e3a-e9c5e6dfffa4.png">

## Test plan

1. `ENABLE_OPEN_TELEMETRY=true sg start web-standalone`
4. Open the browser console and ensure that debug-level output is enabled.
5. Open the home page.
7. See HTTP spans created with no network events added to them.

<img width="300" alt="Screenshot 2022-12-06 at 17 10 38" src="https://user-images.githubusercontent.com/3846380/205868906-2871b987-ed56-4b3e-bbdf-6c08f3e0e8c8.png">

## App preview:

- [Web](https://sg-web-vb-ignore-network-events-in-otel.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
