### PR TITLE
Revert "Revert "Revert "don't special-case dev mode for SRC_HTTP_ADDR default (#45139)"""

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -62,7 +62,12 @@ var (
 
 	printLogo, _ = strconv.ParseBool(env.Get("LOGO", "false", "print Sourcegraph logo upon startup"))
 
-	httpAddr         = env.Get("SRC_HTTP_ADDR", ":3080", "HTTP listen address for app and HTTP API")
+	httpAddr = env.Get("SRC_HTTP_ADDR", func() string {
+		if env.InsecureDev {
+			return "127.0.0.1:3080"
+		}
+		return ":3080"
+	}(), "HTTP listen address for app and HTTP API")
 	httpAddrInternal = envvar.HTTPAddrInternal
 
 	nginxAddr = env.Get("SRC_NGINX_HTTP_ADDR", "", "HTTP listen address for nginx reverse proxy to SRC_HTTP_ADDR. Has preference over SRC_HTTP_ADDR for ExternalURL.")

--- a/internal/httpserver/listener.go
+++ b/internal/httpserver/listener.go
@@ -2,6 +2,8 @@ package httpserver
 
 import (
 	"net"
+
+	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 
 // NewListener returns a TCP listener accepting connections
@@ -21,14 +23,15 @@ func NewListener(addr string) (_ net.Listener, err error) {
 }
 
 // SanitizeAddr replaces the host in the given address with
-// 127.0.0.1 if no host is supplied.
+// 127.0.0.1 if no host is supplied or if running in insecure
+// dev mode.
 func SanitizeAddr(addr string) (string, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return "", err
 	}
 
-	if host == "" {
+	if host == "" && env.InsecureDev {
 		host = "127.0.0.1"
 	}
 


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#45233, which was thought to be a flake, but isn't in the end, as it failed 4 times in a row on main: https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1670318410086819 

# Test plan

Revert a revert of a revert, which is according is a revert 🧞‍♂️ 