### PR TITLE
ci: get logs for all pods on cluster e2e job 

### DIFF
--- a/dev/ci/integration/cluster/test.sh
+++ b/dev/ci/integration/cluster/test.sh
@@ -31,8 +31,10 @@ function cluster_capture_state() {
   kubectl describe pods >"$root_dir/describe_pods.log" 2>&1
 
   # Get logs for some deployments
-  kubectl logs deployment/sourcegraph-frontend --all-containers >"$root_dir/frontend_logs.log" 2>&1
-
+  deployments=$(kubectl get deployments -o=jsonpath='{.items[*].metadata.name}')
+  for dep in "$deployments"; do
+    kubectl logs "deployment/$dep" --all-containers >"$root_dir/$dep.log" 2>&1
+  done
   set +x
 }
 

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -10,7 +10,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background/queryrunner"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/scheduler/iterator"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -31,8 +30,9 @@ import (
 )
 
 const (
-	defaultInterruptSeconds   = 60
-	inProgressPollingInterval = time.Second * 5
+	defaultInterruptSeconds    = 60
+	inProgressPollingInterval  = time.Second * 5
+	defaultErrorThresholdFloor = 50
 )
 
 func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*workerutil.Worker[*BaseJob], *dbworker.Resetter[*BaseJob], dbworkerstore.Store[*BaseJob]) {
@@ -108,11 +108,12 @@ type inProgressHandler struct {
 }
 
 type handlerConfig struct {
-	interruptAfter time.Duration
+	interruptAfter      time.Duration
+	errorThresholdFloor int
 }
 
 func newHandlerConfig() handlerConfig {
-	return handlerConfig{interruptAfter: getInterruptAfter()}
+	return handlerConfig{interruptAfter: getInterruptAfter(), errorThresholdFloor: getErrorThresholdFloor()}
 }
 
 var _ workerutil.Handler[*BaseJob] = &inProgressHandler{}
@@ -120,54 +121,50 @@ var _ workerutil.Handler[*BaseJob] = &inProgressHandler{}
 func (h *inProgressHandler) Handle(ctx context.Context, logger log.Logger, job *BaseJob) error {
 	ctx = actor.WithInternalActor(ctx)
 
-	backfillJob, err := h.backfillStore.loadBackfill(ctx, job.backfillId)
+	execution, err := h.load(ctx, logger, job.backfillId)
 	if err != nil {
-		return errors.Wrap(err, "loadBackfill")
+		return err
 	}
-	series, err := h.seriesReadComplete.GetDataSeriesByID(ctx, backfillJob.SeriesId)
-	if err != nil {
-		return errors.Wrap(err, "GetDataSeriesByID")
-	}
-
-	itr, err := backfillJob.repoIterator(ctx, h.backfillStore)
-	if err != nil {
-		return errors.Wrap(err, "repoIterator")
-	}
-
-	frames := timeseries.BuildFrames(12, timeseries.TimeInterval{
-		Unit:  itypes.IntervalUnit(series.SampleIntervalUnit),
-		Value: series.SampleIntervalValue,
-	}, series.CreatedAt.Truncate(time.Hour*24))
+	execution.config = h.config
 
 	logger.Info("insights backfill progress handler loaded",
 		log.Int("recordId", job.RecordID()),
 		log.Int("jobNumFailures", job.NumFailures),
-		log.Int("seriesId", series.ID),
-		log.String("seriesUniqueId", series.SeriesID),
-		log.Int("backfillId", backfillJob.Id),
-		log.Int("repoTotalCount", itr.TotalCount),
-		log.Float64("percentComplete", itr.PercentComplete),
-		log.Int("erroredRepos", itr.ErroredRepos()),
-		log.Int("totalErrors", itr.TotalErrors()))
+		log.Int("seriesId", execution.series.ID),
+		log.String("seriesUniqueId", execution.series.SeriesID),
+		log.Int("backfillId", execution.backfill.Id),
+		log.Int("repoTotalCount", execution.itr.TotalCount),
+		log.Float64("percentComplete", execution.itr.PercentComplete),
+		log.Int("erroredRepos", execution.itr.ErroredRepos()),
+		log.Int("totalErrors", execution.itr.TotalErrors()))
 
+	interrupt, err := h.doExecution(ctx, execution)
+	if err != nil {
+		return err
+	}
+	if interrupt {
+		return h.doInterrupt(ctx, job)
+	}
+	return nil
+}
+
+func (h *inProgressHandler) doExecution(ctx context.Context, execution *backfillExecution) (interrupt bool, err error) {
 	timeExpired := h.clock.After(h.config.interruptAfter)
 
 	itrConfig := iterator.IterationConfig{
 		MaxFailures: 3,
 		OnTerminal: func(ctx context.Context, tx *basestore.Store, repoId int32, terminalErr error) error {
 			reason := translateIncompleteReasons(terminalErr)
-			logger.Debug("insights backfill incomplete repo writing all datapoints",
-				log.Int32("repoId", repoId),
-				log.Int("seriesId", series.ID), log.String("seriesUniqueId", series.SeriesID),
-				log.Int("backfillId", backfillJob.Id),
-				log.Error(terminalErr),
-				log.String("reason", string(reason)))
+			execution.logger.Debug("insights backfill incomplete repo writing all datapoints",
+				execution.logFields(
+					log.Int32("repoId", repoId),
+					log.String("reason", string(reason)))...)
 
 			id := int(repoId)
-			for _, frame := range frames {
+			for _, frame := range execution.frames {
 				tss := h.insightsStore.WithOther(tx)
 				if err := tss.AddIncompleteDatapoint(ctx, store.AddIncompleteDatapointInput{
-					SeriesID: series.ID,
+					SeriesID: execution.series.ID,
 					RepoID:   &id,
 					Reason:   reason,
 					Time:     frame.From,
@@ -199,58 +196,154 @@ func (h *inProgressHandler) Handle(ctx context.Context, logger log.Logger, job *
 					continue
 				}
 
-				logger.Debug("doing iteration work", log.Int("repo_id", int(repoId)))
-				runErr := h.backfillRunner.Run(ctx, pipeline.BackfillRequest{Series: series, Repo: &types.MinimalRepo{ID: repo.ID, Name: repo.Name}, Frames: frames})
+				execution.logger.Debug("doing iteration work", log.Int("repo_id", int(repoId)))
+				runErr := h.backfillRunner.Run(ctx, pipeline.BackfillRequest{Series: execution.series, Repo: &types.MinimalRepo{ID: repo.ID, Name: repo.Name}, Frames: execution.frames})
 				if runErr != nil {
-					logger.Error("error during backfill execution", log.Int("seriesId", series.ID), log.Int("backfillId", backfillJob.Id), log.Error(runErr))
+					execution.logger.Error("error during backfill execution", execution.logFields(log.Error(runErr))...)
 				}
 				err = finish(ctx, h.backfillStore.Store, runErr)
 				if err != nil {
 					return false, err
+				}
+				if execution.exceedsErrorThreshold() {
+					err = h.disableBackfill(ctx, execution)
+					if err != nil {
+						return false, errors.Wrap(err, "disableBackfill")
+					}
 				}
 			}
 		}
 		return false, nil
 	}
 
-	logger.Debug("starting primary loop", log.Int("seriesId", series.ID), log.Int("backfillId", backfillJob.Id))
-	if interrupted, err := itrLoop(itr.NextWithFinish); err != nil {
-		return errors.Wrap(err, "InProgressHandler.PrimaryLoop")
+	execution.logger.Debug("starting primary loop", log.Int("seriesId", execution.series.ID), log.Int("backfillId", execution.backfill.Id))
+	if interrupted, err := itrLoop(execution.itr.NextWithFinish); err != nil {
+		return false, errors.Wrap(err, "InProgressHandler.PrimaryLoop")
 	} else if interrupted {
-		logger.Info("interrupted insight series backfill", log.Int("seriesId", series.ID), log.String("seriesUniqueId", series.SeriesID), log.Int("backfillId", backfillJob.Id))
-		return h.doInterrupt(ctx, job)
+		execution.logger.Info("interrupted insight series backfill", execution.logFields(log.Duration("interruptAfter", h.config.interruptAfter))...)
+		return true, nil
 	}
 
-	logger.Debug("starting retry loop", log.Int("seriesId", series.ID), log.Int("backfillId", backfillJob.Id))
-	if interrupted, err := itrLoop(itr.NextRetryWithFinish); err != nil {
-		return errors.Wrap(err, "InProgressHandler.RetryLoop")
+	execution.logger.Debug("starting retry loop", log.Int("seriesId", execution.series.ID), log.Int("backfillId", execution.backfill.Id))
+	if interrupted, err := itrLoop(execution.itr.NextRetryWithFinish); err != nil {
+		return false, errors.Wrap(err, "InProgressHandler.RetryLoop")
 	} else if interrupted {
-		logger.Info("interrupted insight series backfill retry", log.Int("seriesId", series.ID), log.String("seriesUniqueId", series.SeriesID), log.Int("backfillId", backfillJob.Id))
-		return h.doInterrupt(ctx, job)
+		execution.logger.Info("interrupted insight series backfill retry", execution.logFields(log.Duration("interruptAfter", h.config.interruptAfter))...)
+		return true, nil
 	}
 
-	if !itr.HasMore() && !itr.HasErrors() {
-		logger.Info("setting backfill to completed state", log.Int("seriesId", series.ID), log.String("seriesUniqueId", series.SeriesID), log.Int("backfillId", backfillJob.Id), log.Duration("totalDuration", itr.RuntimeDuration))
-		err = itr.MarkComplete(ctx, h.backfillStore.Store)
-		if err != nil {
-			return err
-		}
-
-		err = h.seriesReadComplete.SetSeriesBackfillComplete(ctx, series.SeriesID, itr.CompletedAt)
-		if err != nil {
-			return err
-		}
-
-		err = backfillJob.setState(ctx, h.backfillStore, BackfillStateCompleted)
-		if err != nil {
-			return err
-		}
+	if !execution.itr.HasMore() && !execution.itr.HasErrors() {
+		return false, h.finish(ctx, execution)
 	} else {
 		// in this state we have some errors that will need reprocessing, we will place this job back in queue
-		return h.doInterrupt(ctx, job)
+		return true, nil
+	}
+}
+
+func (h *inProgressHandler) finish(ctx context.Context, ex *backfillExecution) (err error) {
+	tx, err := h.backfillStore.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+	bfs := h.backfillStore.With(tx)
+
+	err = ex.itr.MarkComplete(ctx, tx.Store)
+	if err != nil {
+		return errors.Wrap(err, "iterator.MarkComplete")
+	}
+	err = h.seriesReadComplete.SetSeriesBackfillComplete(ctx, ex.series.SeriesID, ex.itr.CompletedAt)
+	if err != nil {
+		return err
+	}
+	err = ex.backfill.SetCompleted(ctx, bfs)
+	if err != nil {
+		return errors.Wrap(err, "backfill.SetCompleted")
+	}
+	ex.logger.Info("backfill set to completed state", ex.logFields()...)
+	return nil
+}
+
+func (h *inProgressHandler) disableBackfill(ctx context.Context, ex *backfillExecution) (err error) {
+	tx, err := h.backfillStore.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+	bfs := h.backfillStore.With(tx)
+
+	// fail the backfill, this should help prevent out of control jobs from consuming all of the resources
+	if err = ex.backfill.SetFailed(ctx, bfs); err != nil {
+		return errors.Wrap(err, "SetFailed")
+	}
+	if err = ex.itr.MarkComplete(ctx, tx.Store); err != nil {
+		return errors.Wrap(err, "itr.MarkComplete")
+	}
+	for _, frame := range ex.frames {
+		tss := h.insightsStore.WithOther(tx)
+		if err = tss.AddIncompleteDatapoint(ctx, store.AddIncompleteDatapointInput{
+			SeriesID: ex.series.ID,
+			Reason:   store.ReasonExceedsErrorLimit,
+			Time:     frame.From,
+		}); err != nil {
+			return errors.Wrap(err, "SetFailed.AddIncompleteDatapoint")
+		}
+	}
+	ex.logger.Info("backfill disabled due to exceeding error threshold", ex.logFields(log.Int("threshold", ex.getThreshold()))...)
+	return nil
+}
+
+func (h *inProgressHandler) load(ctx context.Context, logger log.Logger, backfillId int) (*backfillExecution, error) {
+	backfillJob, err := h.backfillStore.loadBackfill(ctx, backfillId)
+	if err != nil {
+		return nil, errors.Wrap(err, "loadBackfill")
+	}
+	series, err := h.seriesReadComplete.GetDataSeriesByID(ctx, backfillJob.SeriesId)
+	if err != nil {
+		return nil, errors.Wrap(err, "GetDataSeriesByID")
 	}
 
-	return nil
+	itr, err := backfillJob.repoIterator(ctx, h.backfillStore)
+	if err != nil {
+		return nil, errors.Wrap(err, "repoIterator")
+	}
+
+	frames := timeseries.BuildFrames(12, timeseries.TimeInterval{
+		Unit:  itypes.IntervalUnit(series.SampleIntervalUnit),
+		Value: series.SampleIntervalValue,
+	}, series.CreatedAt.Truncate(time.Hour*24))
+
+	return &backfillExecution{
+		series:   series,
+		backfill: backfillJob,
+		itr:      itr,
+		logger:   logger,
+		frames:   frames,
+	}, nil
+}
+
+type backfillExecution struct {
+	series   *itypes.InsightSeries
+	backfill *SeriesBackfill
+	itr      *iterator.PersistentRepoIterator
+	logger   log.Logger
+	frames   []itypes.Frame
+	config   handlerConfig
+}
+
+func (b *backfillExecution) logFields(extra ...log.Field) []log.Field {
+	fields := []log.Field{
+		log.Int("seriesId", b.series.ID),
+		log.String("seriesUniqueId", b.series.SeriesID),
+		log.Int("backfillId", b.backfill.Id),
+		log.Duration("totalDuration", b.itr.RuntimeDuration),
+		log.Int("repoTotalCount", b.itr.TotalCount),
+		log.Int("errorCount", b.itr.TotalErrors()),
+		log.Float64("percentComplete", b.itr.PercentComplete),
+		log.Int("erroredRepos", b.itr.ErroredRepos()),
+	}
+	fields = append(fields, extra...)
+	return fields
 }
 
 func (h *inProgressHandler) doInterrupt(ctx context.Context, job *BaseJob) error {
@@ -265,9 +358,29 @@ func getInterruptAfter() time.Duration {
 	return time.Duration(defaultInterruptSeconds) * time.Second
 }
 
+func getErrorThresholdFloor() int {
+	return defaultErrorThresholdFloor
+}
+
 func translateIncompleteReasons(err error) store.IncompleteReason {
 	if errors.Is(err, queryrunner.SearchTimeoutError) {
 		return store.ReasonTimeout
 	}
 	return store.ReasonGeneric
+}
+
+func (b *backfillExecution) exceedsErrorThreshold() bool {
+	return b.itr.TotalErrors() > calculateErrorThreshold(.05, b.config.errorThresholdFloor, b.itr.TotalCount)
+}
+
+func (b *backfillExecution) getThreshold() int {
+	return calculateErrorThreshold(.05, b.config.errorThresholdFloor, b.itr.TotalCount)
+}
+
+func calculateErrorThreshold(percent float64, floor int, cardinality int) int {
+	scaled := int(float64(cardinality) * percent)
+	if scaled <= floor {
+		return floor
+	}
+	return scaled
 }

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler_test.go
@@ -405,7 +405,6 @@ func Test_BackfillWithInterrupt(t *testing.T) {
 	}
 	handler.config.interruptAfter = time.Second * 5
 
-	// we should get an errored record here that will be retried by the overall queue
 	err = handler.Handle(ctx, logger, dequeue)
 	require.NoError(t, err)
 
@@ -425,5 +424,120 @@ func Test_BackfillWithInterrupt(t *testing.T) {
 	require.NoError(t, err)
 	if completedBackfill.State != BackfillStateCompleted {
 		t.Fatal(errors.New("backfill should be state completed"))
+	}
+}
+
+func Test_BackfillCrossingErrorThreshold(t *testing.T) {
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t))
+	permStore := store.NewInsightPermissionStore(database.NewMockDB())
+	repos := database.NewMockRepoStore()
+	repos.GetFunc.SetDefaultReturn(&itypes.Repo{ID: 1, Name: "repo1"}, nil)
+	insightsStore := store.NewInsightStore(insightsDB)
+	seriesStore := store.New(insightsDB, permStore)
+
+	now := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := glock.NewMockClockAt(now)
+	bfs := newBackfillStoreWithClock(insightsDB, clock)
+
+	config := JobMonitorConfig{
+		InsightsDB:     insightsDB,
+		RepoStore:      repos,
+		InsightStore:   seriesStore,
+		ObsContext:     &observation.TestContext,
+		BackfillRunner: &noopBackfillRunner{},
+		CostAnalyzer:   priority.NewQueryAnalyzer(),
+	}
+	monitor := NewBackgroundJobMonitor(ctx, config)
+
+	series, err := insightsStore.CreateSeries(ctx, types.InsightSeries{
+		SeriesID:            "series1",
+		Query:               "asdf",
+		SampleIntervalUnit:  string(types.Month),
+		Repositories:        []string{"repo1", "repo2"},
+		SampleIntervalValue: 1,
+		GenerationMethod:    types.Search,
+	})
+	require.NoError(t, err)
+
+	backfill, err := bfs.NewBackfill(ctx, series)
+	require.NoError(t, err)
+	backfill, err = backfill.SetScope(ctx, bfs, []int32{1, 2, 3, 4, 5, 6, 7, 8, 9}, 0)
+	require.NoError(t, err)
+	err = backfill.setState(ctx, bfs, BackfillStateProcessing)
+	require.NoError(t, err)
+
+	err = enqueueBackfill(ctx, bfs.Handle(), backfill)
+	require.NoError(t, err)
+
+	wantErr := errors.New("threshold-fake-err")
+
+	runner := delegateBackfillRunner{doSomething: func(ctx context.Context, req pipeline.BackfillRequest) error {
+		clock.Advance(time.Second * 6) // this will cause an interrupt on each iteration with a 5 second interrupt
+		return wantErr
+	}}
+
+	handlerConfig := newHandlerConfig()
+	handlerConfig.errorThresholdFloor = 3 // set this low enough that we will exceed it
+	handlerConfig.interruptAfter = time.Hour * 24
+
+	dequeue, _, _ := monitor.inProgressStore.Dequeue(ctx, "test", nil)
+	handler := inProgressHandler{
+		workerStore:        monitor.newBackfillStore,
+		backfillStore:      bfs,
+		seriesReadComplete: insightsStore,
+		repoStore:          repos,
+		insightsStore:      seriesStore,
+		backfillRunner:     &runner,
+		config:             handlerConfig,
+		clock:              clock,
+	}
+
+	err = handler.Handle(ctx, logger, dequeue)
+	require.NoError(t, err)
+
+	// we will check that it was interrupted by verifying the backfill has progress, but is not completed yet
+	reloaded, err := bfs.loadBackfill(ctx, backfill.Id)
+	require.NoError(t, err)
+	require.Equal(t, BackfillStateFailed, reloaded.State)
+	itr, err := iterator.LoadWithClock(ctx, basestore.NewWithHandle(insightsDB.Handle()), reloaded.repoIteratorId, clock)
+	require.NoError(t, err)
+	require.Equal(t, itr.PercentComplete, float64(1))
+
+	// check for incomplete points
+	incomplete, err := seriesStore.LoadAggregatedIncompleteDatapoints(ctx, series.ID)
+	require.NoError(t, err)
+	require.Len(t, incomplete, 12)
+	require.Equal(t, incomplete[0].Reason, store.ReasonExceedsErrorLimit)
+}
+
+func Test_calculateErrorThreshold(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    int
+		floor   int
+		percent float64
+		size    int
+	}{
+		{
+			name:    "test floor overrides percent",
+			want:    10,
+			floor:   10,
+			percent: .05,
+			size:    100,
+		},
+		{
+			name:    "test percent overrides floor",
+			want:    15,
+			floor:   10,
+			percent: .10,
+			size:    150,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, calculateErrorThreshold(test.percent, test.floor, test.size))
+		})
 	}
 }

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -833,6 +833,7 @@ type IncompleteDatapoint struct {
 type IncompleteReason string
 
 const (
-	ReasonTimeout IncompleteReason = "timeout"
-	ReasonGeneric IncompleteReason = "generic"
+	ReasonTimeout           IncompleteReason = "timeout"
+	ReasonGeneric           IncompleteReason = "generic"
+	ReasonExceedsErrorLimit IncompleteReason = "exceeds-error-limit"
 )


### PR DESCRIPTION
While looking to understand the failure at https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1670318410086819 I noticed that we're only getting the logs for a few containers, which not very handy. 

This change makes it so we get all of them. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested the kubctl command + script locally. 
