### PR TITLE
Token selection: support shift-arrow selection

### DIFF
--- a/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
@@ -1,4 +1,5 @@
-import { KeyBinding } from '@codemirror/view'
+import { defaultKeymap } from '@codemirror/commands'
+import { KeyBinding, keymap } from '@codemirror/view'
 
 import { blobPropsFacet } from '..'
 import { syntaxHighlight } from '../highlight'
@@ -154,10 +155,14 @@ const remappedKeyBindings: Record<string, string> = {
     ArrowRight: 'l',
 }
 
-export const tokenSelectionKeyBindings = keybindings.flatMap(keybinding => {
-    const remappedKey = remappedKeyBindings[keybinding.key ?? '']
-    if (remappedKey) {
-        return [keybinding, { ...keybinding, key: remappedKey }]
-    }
-    return [keybinding]
-})
+export const tokenSelectionKeyBindings = [
+    ...keybindings.flatMap(keybinding => {
+        const remappedKey = remappedKeyBindings[keybinding.key ?? '']
+        if (remappedKey) {
+            return [keybinding, { ...keybinding, key: remappedKey }]
+        }
+        return [keybinding]
+    }),
+    // Fallback to the default arrow keys to allow, for example, Shift-ArrowLeft
+    ...defaultKeymap.filter(({ key }) => key?.includes('Arrow')),
+]

--- a/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/keybindings.ts
@@ -1,5 +1,5 @@
 import { defaultKeymap } from '@codemirror/commands'
-import { KeyBinding, keymap } from '@codemirror/view'
+import { KeyBinding } from '@codemirror/view'
 
 import { blobPropsFacet } from '..'
 import { syntaxHighlight } from '../highlight'


### PR DESCRIPTION
Fixes https://sourcegraph.slack.com/archives/C03CSAER9LK/p1670272799066689

Previously, shift-arrow keys had a buggy behavior where the selection flashes and then reverts back to selecting only the token. This behavior is unrelated to token selection, it's reproducible with all usages of CodeMirror. This behavior only became more obvious with token selection because it enables keyboard driven navigation.

This commit fixes the issue by registering the default keymap bindings for arrow-related shortcuts. Our custom `Arrow{Left,Right,Up,Down}` bindings take precedence so it still doesn't feel like using an editor.

![CleanShot 2022-12-06 at 10 55 16](https://user-images.githubusercontent.com/1408093/205878860-6038a9d1-1d07-44cc-ac89-da0b8c522e0e.gif)

## Test plan

Tested locally with the following steps:

* Click on token to select it
* Use Shift-Arrow keys and confirm the selection updates as expected. In particular, observe that Shift-ArrowUp/ArrowDown preserve the column position (`goalColumn`) when going through empty/short lines.
* Use Shift-Alt-ArrowLeft/ArrowRight keys to see that it jumps through words, as expected


Worth considering:
* Shift-Alt-ArrowUp/ArrowDown still reproduces the selection flash and we might want to register something, or a no-op shortcut to prevent the flash.
* With keyboard navigation, it's not possible to select any arbitrary range because we have custom right/left implementation where the "anchor" of the selection must match the beginning of a token. It's not a major UX issue, but it would be nice if we can allow any arbitrary selection with the keyboard.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-shift-arrow.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
