### PR TITLE
e2e-cluster: get logs for _all_ deployments

### DIFF
--- a/dev/ci/integration/cluster/test.sh
+++ b/dev/ci/integration/cluster/test.sh
@@ -31,7 +31,7 @@ function cluster_capture_state() {
   kubectl describe pods >"$root_dir/describe_pods.log" 2>&1
 
   # Get logs for some deployments
-  IFS=' ' read -ra deployments <<< $(kubectl get deployments -o=jsonpath='{.items[*].metadata.name}')
+  IFS=' ' read -ra deployments <<< "$(kubectl get deployments -o=jsonpath='{.items[*].metadata.name}')"
   for dep in "${deployments[@]}"; do
     kubectl logs "deployment/$dep" --all-containers >"$root_dir/$dep.log" 2>&1
   done

--- a/dev/ci/integration/cluster/test.sh
+++ b/dev/ci/integration/cluster/test.sh
@@ -31,8 +31,10 @@ function cluster_capture_state() {
   kubectl describe pods >"$root_dir/describe_pods.log" 2>&1
 
   # Get logs for some deployments
-  kubectl logs deployment/sourcegraph-frontend --all-containers >"$root_dir/frontend_logs.log" 2>&1
-
+  IFS=' ' read -ra deployments <<< $(kubectl get deployments -o=jsonpath='{.items[*].metadata.name}')
+  for dep in "${deployments[@]}"; do
+    kubectl logs "deployment/$dep" --all-containers >"$root_dir/$dep.log" 2>&1
+  done
   set +x
 }
 


### PR DESCRIPTION
While looking to understand the failure at https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1670318410086819 I noticed that we're only getting the logs for a few containers, which not very handy. 

This change makes it so we get all of them. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested the kubctl command + script locally. 