### PR TITLE
sg: add deployments schedule documentation link to `sg live help`

### DIFF
--- a/dev/sg/sg_live.go
+++ b/dev/sg/sg_live.go
@@ -59,6 +59,10 @@ func constructLiveCmdLongHelp() string {
 		fmt.Fprintf(&out, "\n* %s", name)
 	}
 
+	fmt.Fprintf(&out, "\n\n")
+	fmt.Fprintf(&out, "See more information about the deployments schedule here:\n")
+	fmt.Fprintf(&out, "https://handbook.sourcegraph.com/departments/engineering/teams/dev-experience/#sourcegraph-instances-operated-by-us")
+
 	return out.String()
 }
 

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1325,6 +1325,9 @@ Available preset environments:
 * k8s
 * scaletesting
 
+See more information about the deployments schedule here:
+https://handbook.sourcegraph.com/departments/engineering/teams/dev-experience/#sourcegraph-instances-operated-by-us
+
 ```sh
 # See which version is deployed on a preset environment
 $ sg live s2


### PR DESCRIPTION
## Context

I was trying to figure out when [my PR](https://github.com/sourcegraph/sourcegraph/pull/45238) will be deployed to the DotCom instance. First, I ran `sg live help` to see if it could help me, and I didn't find the schedule information there. I did a quick Slack search and found @mrnugget's [question](https://sourcegraph.slack.com/archives/CMBA8F926/p1666703470548299) with the answer from @burmudar. 

Would it be good to have the answer in the `sg live help` output? Let me know if you have better ideas!

## Test plan

`go run ./dev/sg live help` 