### PR TITLE
Enable indexing progress status message by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights: the data series API now provides information about incomplete datapoints during processing
 - Added a best-effort migration such that existing Code Insights will display zero results instead of missing points at the start and end of a graph. [#44928](https://github.com/sourcegraph/sourcegraph/pull/44928)
 - More complete stack traces for Outbound request log [#45151](https://github.com/sourcegraph/sourcegraph/pull/45151)
+- A new status message now reports how many repositories have already been indexed for search. 
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights: the data series API now provides information about incomplete datapoints during processing
 - Added a best-effort migration such that existing Code Insights will display zero results instead of missing points at the start and end of a graph. [#44928](https://github.com/sourcegraph/sourcegraph/pull/44928)
 - More complete stack traces for Outbound request log [#45151](https://github.com/sourcegraph/sourcegraph/pull/45151)
-- A new status message now reports how many repositories have already been indexed for search. 
+- A new status message now reports how many repositories have already been indexed for search. [#45246](https://github.com/sourcegraph/sourcegraph/pull/45246)
 
 ### Changed
 

--- a/internal/repos/status_messages.go
+++ b/internal/repos/status_messages.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -75,11 +74,6 @@ func FetchStatusMessages(ctx context.Context, db database.DB) ([]StatusMessage, 
 	// instances.
 	// So for now we don't return the indexing message on sourcegraph.com.
 	if !envvar.SourcegraphDotComMode() {
-		// Check feature flag
-		if !featureflag.FromContext(ctx).GetBoolOr("indexing-status-message", false) {
-			return messages, nil
-		}
-
 		zoektRepoStats, err := db.ZoektRepos().GetStatistics(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "loading repo statistics")

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -33,8 +32,6 @@ func TestStatusMessages(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	memoryStore := featureflag.NewMemoryStore(nil, nil, map[string]bool{"indexing-status-message": true})
-	ctx = featureflag.WithFlags(ctx, memoryStore)
 
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	store := NewStore(logtest.Scoped(t), db)


### PR DESCRIPTION
This has been behind a feature flag for 2 months now. I think it's safe to enable this by default and get more customer feedback.

@ryphil said it's okay.

## Test plan

- N/A