### PR TITLE
zoekt: remove newline workaround

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -593,7 +593,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 			},
 			{
 				name:  "indexed multiline search, nonzero result",
-				query: `repo:^github\.com/sgtest/java-langserver$ \nimport index:only patterntype:regexp type:file`,
+				query: `repo:^github\.com/sgtest/java-langserver$ runtime(.|\n)*BYTES_TO_GIGABYTES index:only patterntype:regexp type:file`,
 			},
 			{
 				name:  "unindexed multiline search, nonzero result",

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -24,15 +24,6 @@ func FileRe(pattern string, queryIsCaseSensitive bool) (zoektquery.Q, error) {
 	return parseRe(pattern, true, false, queryIsCaseSensitive)
 }
 
-func noOpAnyChar(re *syntax.Regexp) {
-	if re.Op == syntax.OpAnyChar {
-		re.Op = syntax.OpAnyCharNotNL
-	}
-	for _, s := range re.Sub {
-		noOpAnyChar(s)
-	}
-}
-
 const regexpFlags = syntax.ClassNL | syntax.PerlX | syntax.UnicodeGroups
 
 func parseRe(pattern string, filenameOnly bool, contentOnly bool, queryIsCaseSensitive bool) (zoektquery.Q, error) {
@@ -41,7 +32,6 @@ func parseRe(pattern string, filenameOnly bool, contentOnly bool, queryIsCaseSen
 	if err != nil {
 		return nil, err
 	}
-	noOpAnyChar(re)
 
 	// OptimizeRegexp currently only converts capture groups into non-capture
 	// groups (faster for stdlib regexp to execute).


### PR DESCRIPTION
this fixes #28429 by removing `noOpAnyChar`, which was introduced in https://github.com/sourcegraph/sourcegraph/pull/519

![image](https://user-images.githubusercontent.com/26413131/205933228-ca1c0477-2a6e-48c0-ba83-75e52cb05888.png)

## Test plan
- updated integration test


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
