### PR TITLE
web: Add "Incoming webhooks" to sidebar nav

### DIFF
--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -64,6 +64,10 @@ export const repositoriesGroup: SiteAdminSideBarGroup = {
             label: 'Repositories',
             to: '/site-admin/repositories',
         },
+        {
+            label: 'Incoming webhooks',
+            to: '/site-admin/webhooks',
+        },
     ],
 }
 


### PR DESCRIPTION
Under the repositories group

<img width="197" alt="Screenshot 2022-12-06 at 15 22 56" src="https://user-images.githubusercontent.com/25610/205937424-ecef2bf3-fe42-4f0c-9db0-71d8e7ab09ea.png">

Closes https://github.com/sourcegraph/sourcegraph/issues/45206

## Test plan

Tested locally

## App preview:

- [Web](https://sg-web-rs-webhooks-nav.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
