### PR TITLE
Outbound requests: Fix problem and add tests

### DIFF
--- a/internal/httpcli/redis_logger_middleware.go
+++ b/internal/httpcli/redis_logger_middleware.go
@@ -234,6 +234,7 @@ func formatStackFrame(function string, file string, line int) string {
 
 	// Reconstruct the frame file path so that we don't include the local path on the machine that built this instance
 	fileName := strings.TrimPrefix(filepath.Join(tree, filepath.Base(file)), sourcegraphPrefix) // cmd/frontend/graphqlbackend/trace.go
+	fileName = strings.TrimPrefix(fileName, "/")                                                // Strip prefix `/` if there is one
 
 	return fmt.Sprintf("%s:%d (Function: %s)", fileName, line, funcName)
 }

--- a/internal/httpcli/redis_logger_middleware.go
+++ b/internal/httpcli/redis_logger_middleware.go
@@ -230,7 +230,7 @@ func formatStackFrame(function string, file string, line int) string {
 	funcName := strings.Join(dotPieces[1:], ".")  // (*requestTracer).TraceQuery
 
 	tree := strings.Join(treeAndFunc[:len(treeAndFunc)-1], "/") + "/" + pckName // github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend
-	strings.TrimPrefix(tree, sourcegraphPrefix)
+	tree = strings.TrimPrefix(tree, sourcegraphPrefix)
 
 	// Reconstruct the frame file path so that we don't include the local path on the machine that built this instance
 	fileName := strings.TrimPrefix(filepath.Join(tree, filepath.Base(file)), sourcegraphPrefix) // cmd/frontend/graphqlbackend/trace.go

--- a/internal/httpcli/redis_logger_middleware.go
+++ b/internal/httpcli/redis_logger_middleware.go
@@ -230,15 +230,10 @@ func formatStackFrame(function string, file string, line int) string {
 	funcName := strings.Join(dotPieces[1:], ".")  // (*requestTracer).TraceQuery
 
 	tree := strings.Join(treeAndFunc[:len(treeAndFunc)-1], "/") + "/" + pckName // github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend
-	if strings.HasPrefix(tree, sourcegraphPrefix) {
-		tree = tree[len(sourcegraphPrefix):]
-	}
+	strings.TrimPrefix(tree, sourcegraphPrefix)
 
 	// Reconstruct the frame file path so that we don't include the local path on the machine that built this instance
-	fileName := filepath.Join(tree, filepath.Base(file))
-	if strings.HasPrefix(fileName, "/main/") {
-		fileName = fileName[6:]
-	}
+	fileName := strings.TrimPrefix(filepath.Join(tree, filepath.Base(file)), sourcegraphPrefix) // cmd/frontend/graphqlbackend/trace.go
 
 	return fmt.Sprintf("%s:%d (Function: %s)", fileName, line, funcName)
 }

--- a/internal/httpcli/redis_logger_middleware.go
+++ b/internal/httpcli/redis_logger_middleware.go
@@ -20,6 +20,8 @@ import (
 
 var outboundRequestsRedisCache = rcache.NewWithTTL("outbound-requests", 604800)
 
+const sourcegraphPrefix = "github.com/sourcegraph/sourcegraph/"
+
 func redisLoggerMiddleware() Middleware {
 	creatorStackFrame, _ := getFrames(4).Next()
 	return func(cli Doer) Doer {
@@ -84,7 +86,7 @@ func redisLoggerMiddleware() Middleware {
 				ResponseHeaders:    responseHeaders,
 				Duration:           duration.Seconds(),
 				ErrorMessage:       errorMessage,
-				CreationStackFrame: formatStackFrame(creatorStackFrame),
+				CreationStackFrame: formatStackFrame(creatorStackFrame.Function, creatorStackFrame.File, creatorStackFrame.Line),
 				CallStackFrame:     formatStackFrames(callerStackFrames),
 			}
 
@@ -214,22 +216,31 @@ func formatStackFrames(frames *runtime.Frames) string {
 		if !more {
 			break
 		}
-		sb.WriteString(formatStackFrame(frame))
+		sb.WriteString(formatStackFrame(frame.Function, frame.File, frame.Line))
 		sb.WriteString("\n")
 	}
 	return strings.TrimRight(sb.String(), "\n")
 }
 
-func formatStackFrame(frame runtime.Frame) string {
-	packageTreeAndFunctionName := strings.Join(strings.Split(frame.Function, "/")[3:], "/")
-	dotPieces := strings.Split(packageTreeAndFunctionName, ".")
-	packageTree := dotPieces[0]
-	functionName := dotPieces[len(dotPieces)-1]
+func formatStackFrame(function string, file string, line int) string {
+	treeAndFunc := strings.Split(function, "/")   // github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend.(*requestTracer).TraceQuery
+	pckAndFunc := treeAndFunc[len(treeAndFunc)-1] // graphqlbackend.(*requestTracer).TraceQuery
+	dotPieces := strings.Split(pckAndFunc, ".")   // ["graphqlbackend" , "(*requestTracer)", "TraceQuery"]
+	pckName := dotPieces[0]                       // graphqlbackend
+	funcName := strings.Join(dotPieces[1:], ".")  // (*requestTracer).TraceQuery
+
+	tree := strings.Join(treeAndFunc[:len(treeAndFunc)-1], "/") + "/" + pckName // github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend
+	if strings.HasPrefix(tree, sourcegraphPrefix) {
+		tree = tree[len(sourcegraphPrefix):]
+	}
 
 	// Reconstruct the frame file path so that we don't include the local path on the machine that built this instance
-	fileName := filepath.Join(packageTree, filepath.Base(frame.File))
+	fileName := filepath.Join(tree, filepath.Base(file))
+	if strings.HasPrefix(fileName, "/main/") {
+		fileName = fileName[6:]
+	}
 
-	return fmt.Sprintf("%s:%d (Function: %s)", fileName, frame.Line, functionName)
+	return fmt.Sprintf("%s:%d (Function: %s)", fileName, line, funcName)
 }
 
 const pcLen = 1024

--- a/internal/httpcli/redis_logger_middleware_test.go
+++ b/internal/httpcli/redis_logger_middleware_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/strings/slices"
+
+	"github.com/sourcegraph/sourcegraph/internal/rcache"
 )
 
 func TestRedisLoggerMiddleware_getAllValuesAfter(t *testing.T) {
@@ -121,7 +122,7 @@ func TestRedisLoggerMiddleware_formatStackFrame(t *testing.T) {
 			function: "main.f",
 			file:     "/Users/x/file.go",
 			line:     11,
-			want:     "file.go:11 (Function: f)",
+			want:     "main/file.go:11 (Function: f)",
 		},
 	}
 

--- a/internal/httpcli/redis_logger_middleware_test.go
+++ b/internal/httpcli/redis_logger_middleware_test.go
@@ -67,7 +67,7 @@ func TestRedisLoggerMiddleware_redactSensitiveHeaders(t *testing.T) {
 	}
 }
 
-func TestCache_DeleteFirstN(t *testing.T) {
+func TestRedisLoggerMiddleware_DeleteFirstN(t *testing.T) {
 	rcache.SetupForTest(t)
 	c := rcache.NewWithTTL("some_prefix", 1)
 
@@ -92,4 +92,45 @@ func TestCache_DeleteFirstN(t *testing.T) {
 
 	assert.Contains(t, got, "key6") // 6 through 9 (4 items) should be kept
 	assert.Contains(t, got, "key9")
+}
+
+func TestRedisLoggerMiddleware_formatStackFrame(t *testing.T) {
+	tests := []struct {
+		name     string
+		function string
+		file     string
+		line     int
+		want     string
+	}{
+		{
+			name:     "Sourcegraph internal package",
+			function: "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend.(*requestTracer).TraceQuery",
+			file:     "/Users/x/github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlbackend.go",
+			line:     51,
+			want:     "cmd/frontend/graphqlbackend/graphqlbackend.go:51 (Function: (*requestTracer).TraceQuery)",
+		},
+		{
+			name:     "third-party package",
+			function: "third-party/library.f",
+			file:     "/Users/x/github.com/third-party/library/file.go",
+			line:     11,
+			want:     "third-party/library/file.go:11 (Function: f)",
+		},
+		{
+			name:     "main package",
+			function: "main.f",
+			file:     "/Users/x/file.go",
+			line:     11,
+			want:     "file.go:11 (Function: f)",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := formatStackFrame(test.function, test.file, test.line)
+			if got != test.want {
+				t.Errorf("got %q, want %q", got, test.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
The implementation was too naive: it didn't consider the possibility of getting a shallow package tree.
It should be a lot more reliable now.

## Test plan

- Added automated tests
- Checked the stack traces in the "Outgoing requests" feature
- Tests should pass