### PR TITLE
dev: download golangci-lint instead of building it

### DIFF
--- a/dev/golangci-lint.sh
+++ b/dev/golangci-lint.sh
@@ -8,13 +8,14 @@ mkdir -p .bin
 
 version="1.50.1"
 suffix="${version}-$(go env GOOS)-$(go env GOARCH)"
-target="$PWD/.bin/golangci-lint-${suffix}"
+name="golangci-lint-${suffix}"
+target="$PWD/.bin/${name}"
+url="https://github.com/golangci/golangci-lint/releases/download/v$version/golangci-lint-$suffix.tar.gz"
 
 if [ ! -f "${target}" ]; then
-  # Workaround for https://github.com/golangci/golangci-lint/issues/2374
   echo "installing golangci-lint" 1>&2
-  go install "github.com/golangci/golangci-lint/cmd/golangci-lint@v${version}" 1>&2
-  mv "$(which golangci-lint)" "${target}"
+  curl -sS -L -f "${url}" | tar -xz --to-stdout "${name}/golangci-lint" >"${target}.tmp"
+  mv "${target}.tmp" "${target}"
 fi
 
 chmod +x "${target}"


### PR DESCRIPTION
The doc is very clear, building it on your own can produce unexpected results, so this commit go back to downloading it, as the original issue that caused the problem has been closed.

I suspect this caused a lot of the weird issues we observed in the past.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Successful test run is at: https://buildkite.com/sourcegraph/sourcegraph/builds/187445#0184e7d6-07bb-4e5f-93f7-90051213152f