### PR TITLE
insights: default insights backfillv2 to true

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -1185,7 +1185,11 @@ type fillSeriesStrategy func(context.Context, types.InsightSeries) error
 func makeFillSeriesStrategy(ctx context.Context, tx *store.InsightStore, scopedBackfiller *background.ScopedBackfiller, scheduler *scheduler.Scheduler, insightEnqueuer *background.InsightEnqueuer) fillSeriesStrategy {
 	flags := featureflag.FromContext(ctx)
 	deprecateJustInTime := flags.GetBoolOr("code_insights_deprecate_jit", true)
-	v2BackfillEnabled := conf.Get().ExperimentalFeatures.InsightsBackfillerV2
+	v2BackfillSetting := conf.Get().ExperimentalFeatures.InsightsBackfillerV2
+	v2BackfillEnabled := true
+	if v2BackfillSetting != nil {
+		v2BackfillEnabled = *v2BackfillSetting
+	}
 
 	return func(ctx context.Context, series types.InsightSeries) error {
 		if series.GroupBy != nil {

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -1185,7 +1185,7 @@ type fillSeriesStrategy func(context.Context, types.InsightSeries) error
 func makeFillSeriesStrategy(ctx context.Context, tx *store.InsightStore, scopedBackfiller *background.ScopedBackfiller, scheduler *scheduler.Scheduler, insightEnqueuer *background.InsightEnqueuer) fillSeriesStrategy {
 	flags := featureflag.FromContext(ctx)
 	deprecateJustInTime := flags.GetBoolOr("code_insights_deprecate_jit", true)
-	v2BackfillSetting := conf.Get().ExperimentalFeatures.InsightsBackfillerV2
+	v2BackfillSetting := conf.ExperimentalFeatures().InsightsBackfillerV2
 	v2BackfillEnabled := true
 	if v2BackfillSetting != nil {
 		v2BackfillEnabled = *v2BackfillSetting

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -644,7 +644,7 @@ type ExperimentalFeatures struct {
 	// InsightsAlternateLoadingStrategy description: Use an in-memory strategy of loading Code Insights. Should only be used for benchmarking on large instances, not for customer use currently.
 	InsightsAlternateLoadingStrategy bool `json:"insightsAlternateLoadingStrategy,omitempty"`
 	// InsightsBackfillerV2 description: Use v2 of the insights backfiller which backfills a series at a time.
-	InsightsBackfillerV2 bool `json:"insightsBackfillerV2,omitempty"`
+	InsightsBackfillerV2 *bool `json:"insightsBackfillerV2,omitempty"`
 	// JvmPackages description: Allow adding JVM package host connections
 	JvmPackages string `json:"jvmPackages,omitempty"`
 	// NpmPackages description: Allow adding npm package code host connections

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -578,7 +578,8 @@
         "insightsBackfillerV2": {
           "description": "Use v2 of the insights backfiller which backfills a series at a time.",
           "type": "boolean",
-          "default": false
+          "default": true,
+          "!go": { "pointer": true }
         }
       },
       "examples": [


### PR DESCRIPTION
Update the setting for the insights backfiller to default to using the new backfiller.
## Test plan
Manually checked which backfill ran when setting was nil and well and T/F

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
