### PR TITLE
logging: support level none in stdlog and log15

### DIFF
--- a/dev/sg/linters/go_checks.go
+++ b/dev/sg/linters/go_checks.go
@@ -87,6 +87,8 @@ func lintLoggingLibraries() *linter {
 			"dev/sg/linters",
 			// We allow one usage of a direct zap import here
 			"internal/observation/fields.go",
+			// Inits old loggers
+			"internal/logging/main.go",
 			// Dependencies require direct usage of zap
 			"cmd/frontend/internal/app/otlpadapter",
 			// Not worth fixing the deprecated package

--- a/internal/logging/main.go
+++ b/internal/logging/main.go
@@ -3,6 +3,8 @@ package logging
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"log"
 	"os"
 
 	"github.com/fatih/color"
@@ -145,6 +147,10 @@ func Init(options ...Option) {
 	lvl, err := log15.LvlFromString(env.LogLevel)
 	if err == nil {
 		handler = log15.LvlFilterHandler(lvl, handler)
+	}
+	if env.LogLevel == "none" {
+		handler = log15.DiscardHandler()
+		log.SetOutput(io.Discard)
 	}
 	log15.Root().SetHandler(log15.LvlFilterHandler(lvl, handler))
 }


### PR DESCRIPTION
Since the introduction of sg/log we now have a new level we can choose: "none". However, log15 doesn't support that level. This commit updates are deprecated log setup code to disable logging in log15 and stdlib when this level is set.

Test Plan: SRC_LOG_LEVEL=none sg start oss
