### PR TITLE
searcher: all hybrid logs go to same log scope

### DIFF
--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -40,12 +40,7 @@ var (
 // This only interacts with zoekt so that we can leverage the normal searcher
 // code paths for the unindexed parts. IE unsearched is expected to be used to
 // fetch a zip via the store and then do a normal unindexed search.
-func (s *Service) hybrid(ctx context.Context, p *protocol.Request, sender matchSender) (unsearched []string, ok bool, err error) {
-	rootLogger := logWithTrace(ctx, s.Log).Scoped("hybrid", "hybrid indexed and unindexed search").With(
-		log.String("repo", string(p.Repo)),
-		log.String("commit", string(p.Commit)),
-	)
-
+func (s *Service) hybrid(ctx context.Context, rootLogger log.Logger, p *protocol.Request, sender matchSender) (unsearched []string, ok bool, err error) {
 	// recordHybridFinalState is a wrapper around metricHybridState to make the
 	// callsites more succinct.
 	finalState := "unknown"

--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -235,16 +235,21 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 
 	hybrid := !p.IsStructuralPat && p.FeatHybrid
 	if hybrid {
-		unsearched, ok, err := s.hybrid(ctx, p, sender)
+		logger := logWithTrace(ctx, s.Log).Scoped("hybrid", "hybrid indexed and unindexed search").With(
+			log.String("repo", string(p.Repo)),
+			log.String("commit", string(p.Commit)),
+		)
+
+		unsearched, ok, err := s.hybrid(ctx, logger, p, sender)
 		if err != nil {
-			s.Log.Error("hybrid search failed",
+			logger.Error("hybrid search failed",
 				log.String("repo", string(p.Repo)),
 				log.String("commit", string(p.Commit)),
 				log.Error(err))
 			return errors.Wrap(err, "hybrid search failed")
 		}
 		if !ok {
-			s.Log.Debug("hybrid search is falling back to normal unindexed search",
+			logger.Debug("hybrid search is falling back to normal unindexed search",
 				log.String("repo", string(p.Repo)),
 				log.String("commit", string(p.Commit)))
 		} else {


### PR DESCRIPTION
This makes it easier to query for any log related to hybrid search.

Test Plan: doing hybrid searches in my devserver and viewing the corresponding log output.
