### PR TITLE
GraphQL schema extended with code host availability check

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2757,6 +2757,51 @@ type ExternalService implements Node {
     The list of recent sync jobs for this external service.
     """
     syncJobs(first: Int): ExternalServiceSyncJobConnection!
+
+    """
+    External service availability
+    """
+    availability: ExternalServiceAvailability!
+}
+
+"""
+Avaiability status of an external service for diagnostic purposes.
+
+This is so that the UI can surface whether the external service
+can serve requests, and if not, why is the reason for that.
+"""
+type ExternalServiceAvailability = ExternalServiceAvailable | ExternalServiceUnavailable | ExternalServiceAvaialbilityUnknown
+
+"""
+Indicator that the external service was recently found to be available.
+"""
+type ExternalServiceAvailable {
+    """
+    The timestamp of the last successful availability check that was performed.
+    """
+    lastCheckedAt DateTime!
+}
+
+"""
+Indicator that the external service was recently not found available.
+"""
+type ExternalServiceUnavailable {
+    """
+    User-friendly textual description of suposed reason why the service is not available.
+    """
+    suspectedReason: String!
+}
+
+"""
+Availability for some external services may not be determined, or only partially
+supported. In that case unknown variant of ExternalServiceAvailability is returned.
+"""
+type ExternalServiceAvailabilityUnknown {
+    """
+    User-friendly textual description of the implementation status of availablity.
+    This is expected to be tied to specific kinds of external services.
+    """
+    implementationNote: String
 }
 
 """


### PR DESCRIPTION
Part of #44683

## Test plan

- Unit test the queries to graphQL api with a [dummy](https://martinfowler.com/bliki/TestDouble.html) back end implementation.
