### PR TITLE
fix webhook endpoint input sizing

### DIFF
--- a/client/web/src/site-admin/WebhookInformation.tsx
+++ b/client/web/src/site-admin/WebhookInformation.tsx
@@ -32,7 +32,7 @@ export const WebhookInformation: FC<WebhookInformationProps> = props => {
                 <tr>
                     <th className={styles.tableHeader}>Webhook endpoint</th>
                     <td className={styles.contentCell}>
-                        <CopyableText text={webhook.url} size={webhook.url.length > 60 ? 60 : webhook.url.length} />
+                        <CopyableText text={webhook.url} size={60} />
                     </td>
                 </tr>
                 <tr>

--- a/client/web/src/site-admin/WebhookInformation.tsx
+++ b/client/web/src/site-admin/WebhookInformation.tsx
@@ -32,7 +32,7 @@ export const WebhookInformation: FC<WebhookInformationProps> = props => {
                 <tr>
                     <th className={styles.tableHeader}>Webhook endpoint</th>
                     <td className={styles.contentCell}>
-                        <CopyableText text={webhook.url} size={webhook.url.length} />
+                        <CopyableText text={webhook.url} size={webhook.url.length > 60 ? 60 : webhook.url.length} />
                     </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/45249

Small change to fix the input field from overlapping with the copy button

https://user-images.githubusercontent.com/20795805/205960218-449a5b54-e5f9-4f28-b1c3-abe024710b5b.mp4


## Test plan
Ran locally, verified no overlap

## App preview:

- [Web](https://sg-web-iv-webhook-bug.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
