### PR TITLE
Make delete button actually delete the webhook

### DIFF
--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -26,6 +26,8 @@ import {
     DeleteOrganizationVariables,
     DeleteUserResult,
     DeleteUserVariables,
+    DeleteWebhookResult,
+    DeleteWebhookVariables,
     ExternalServiceKind,
     FeatureFlagFields,
     FeatureFlagsResult,
@@ -995,6 +997,14 @@ export const WEBHOOK_BY_ID = gql`
     }
 `
 
+export const DELETE_WEBHOOK = gql`
+    mutation DeleteWebhook($hookID: ID!) {
+        deleteWebhook(id: $hookID) {
+            alwaysNil
+        }
+    }
+`
+
 export const useWebhooksConnection = (): UseShowMorePaginationResult<WebhookFields> =>
     useShowMorePagination<WebhooksListResult, WebhooksListVariables, WebhookFields>({
         query: WEBHOOKS,
@@ -1037,3 +1047,8 @@ export const CREATE_WEBHOOK_QUERY = gql`
         }
     }
 `
+
+export const deleteWebhook = (hookID: Scalars['ID']): Promise<void> =>
+    requestGraphQL<DeleteWebhookResult, DeleteWebhookVariables>(DELETE_WEBHOOK, { hookID })
+        .pipe(map(dataOrThrowErrors), mapTo(undefined))
+        .toPromise()

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -26,8 +26,6 @@ import {
     DeleteOrganizationVariables,
     DeleteUserResult,
     DeleteUserVariables,
-    DeleteWebhookResult,
-    DeleteWebhookVariables,
     ExternalServiceKind,
     FeatureFlagFields,
     FeatureFlagsResult,
@@ -1047,8 +1045,3 @@ export const CREATE_WEBHOOK_QUERY = gql`
         }
     }
 `
-
-export const deleteWebhook = (hookID: Scalars['ID']): Promise<void> =>
-    requestGraphQL<DeleteWebhookResult, DeleteWebhookVariables>(DELETE_WEBHOOK, { hookID })
-        .pipe(map(dataOrThrowErrors), mapTo(undefined))
-        .toPromise()


### PR DESCRIPTION
Delete button now deletes the webhook.

Closes https://github.com/sourcegraph/sourcegraph/issues/45237

## App preview:

- [Web](https://sg-web-rs-webhook-delete.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

## Test plan

Tested locally
