### PR TITLE
sct: fix a bug preventing errors to be returned

### DIFF
--- a/dev/scaletesting/bulkrepocreate/blank_repo.go
+++ b/dev/scaletesting/bulkrepocreate/blank_repo.go
@@ -89,7 +89,7 @@ func (r *blankRepo) addRemote(ctx context.Context, name string, gitURL string) e
 func (r *blankRepo) pushRemote(ctx context.Context, name string, retry int) error {
 	var err error
 	for i := 0; i < retry; i++ {
-		err := r.doPushRemote(ctx, name)
+		err = r.doPushRemote(ctx, name)
 		if err == nil {
 			break
 		}


### PR DESCRIPTION
Spotted this while working on the linters. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI + review. 