### PR TITLE
mod: actually upgrade sourcegraph/log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -135,7 +135,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
 	github.com/sourcegraph/go-rendezvous v0.0.0-20210910070954-ef39ade5591d
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
-	github.com/sourcegraph/log v0.0.0-20221205123034-8d7451d85b3d
+	github.com/sourcegraph/log v0.0.0-20221206163500-7d93c6ad7037
 	github.com/sourcegraph/run v0.9.0
 	github.com/sourcegraph/scip v0.2.3
 	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220203145655-4d2a39d3038a

--- a/go.sum
+++ b/go.sum
@@ -2099,10 +2099,6 @@ github.com/sourcegraph/httpgzip v0.0.0-20211015085752-0bad89b3b4df h1:VaS8k40GiN
 github.com/sourcegraph/httpgzip v0.0.0-20211015085752-0bad89b3b4df/go.mod h1:RqWagzxNGCvucQQC9vX6aps474LCCOgshDpUTTyb+O8=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf h1:oAdWFqhStsWiiMP/vkkHiMXqFXzl1XfUNOdxKJbd6bI=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf/go.mod h1:ppFaPm6kpcHnZGqQTFhUIAQRIEhdQDWP1PCv4/ON354=
-github.com/sourcegraph/log v0.0.0-20221205074644-b7a37dee2e74 h1:2Y6VohZoLet7ag+Jef6Anjq6E5frWJyPG05PO0cChsE=
-github.com/sourcegraph/log v0.0.0-20221205074644-b7a37dee2e74/go.mod h1:y+sVdVKxHhp489iiiXeZgXIhSpFYijtp/pLD2coj96g=
-github.com/sourcegraph/log v0.0.0-20221205123034-8d7451d85b3d h1:CNpNE1AQXWQgkLA0Hs+fBdE9AHc+haPsyje36tCPOJY=
-github.com/sourcegraph/log v0.0.0-20221205123034-8d7451d85b3d/go.mod h1:y+sVdVKxHhp489iiiXeZgXIhSpFYijtp/pLD2coj96g=
 github.com/sourcegraph/log v0.0.0-20221206163500-7d93c6ad7037 h1:hgZHfGYG3KMlDDfACuPgzhMIaEjblCqZ+YltcPgd0tw=
 github.com/sourcegraph/log v0.0.0-20221206163500-7d93c6ad7037/go.mod h1:y+sVdVKxHhp489iiiXeZgXIhSpFYijtp/pLD2coj96g=
 github.com/sourcegraph/mountinfo v0.0.0-20221027185101-272dd8baaf4a h1:fD9C4qHZWr7girCD8EwBHdmdViIWtdVTBO6k9SInVQo=

--- a/go.sum
+++ b/go.sum
@@ -2103,6 +2103,8 @@ github.com/sourcegraph/log v0.0.0-20221205074644-b7a37dee2e74 h1:2Y6VohZoLet7ag+
 github.com/sourcegraph/log v0.0.0-20221205074644-b7a37dee2e74/go.mod h1:y+sVdVKxHhp489iiiXeZgXIhSpFYijtp/pLD2coj96g=
 github.com/sourcegraph/log v0.0.0-20221205123034-8d7451d85b3d h1:CNpNE1AQXWQgkLA0Hs+fBdE9AHc+haPsyje36tCPOJY=
 github.com/sourcegraph/log v0.0.0-20221205123034-8d7451d85b3d/go.mod h1:y+sVdVKxHhp489iiiXeZgXIhSpFYijtp/pLD2coj96g=
+github.com/sourcegraph/log v0.0.0-20221206163500-7d93c6ad7037 h1:hgZHfGYG3KMlDDfACuPgzhMIaEjblCqZ+YltcPgd0tw=
+github.com/sourcegraph/log v0.0.0-20221206163500-7d93c6ad7037/go.mod h1:y+sVdVKxHhp489iiiXeZgXIhSpFYijtp/pLD2coj96g=
 github.com/sourcegraph/mountinfo v0.0.0-20221027185101-272dd8baaf4a h1:fD9C4qHZWr7girCD8EwBHdmdViIWtdVTBO6k9SInVQo=
 github.com/sourcegraph/mountinfo v0.0.0-20221027185101-272dd8baaf4a/go.mod h1:SrU3BANBcV8XmM6ul5PBvBXDwTliGyjwiklR8OW61hI=
 github.com/sourcegraph/oauth2 v0.0.0-20210825125341-77c1d99ece3c h1:HGa4iJr6MGKnB5qbU7tI511NdGuHUHnNCqP67G6KmfE=


### PR DESCRIPTION
Serves me right for skimping on the manual test - this update _actually_ includes the fix for dev mode output, https://github.com/sourcegraph/log/pull/50, that was supposed to be included in #45272 .

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg start` outputs logs in the dev format we had before:

<img width="1108" alt="image" src="https://user-images.githubusercontent.com/23356519/205984219-bde7b8e4-1a2b-49eb-a85a-fa40e27eef24.png">
