### PR TITLE
insights: surface error information from global queries that are terminally failed

### DIFF
--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -24,7 +24,8 @@ var _ workerutil.Handler[*Job] = &workHandler{}
 // workHandler implements the dbworker.Handler interface by executing search queries and
 // inserting insights about them to the insights database.
 type workHandler struct {
-	baseWorkerStore *basestore.Store
+	// baseWorkerStore *basestore.Store
+	baseWorkerStore *workerStoreExtra
 	insightsStore   *store.Store
 	repoStore       discovery.RepoStore
 	metadadataStore *store.InsightStore
@@ -75,6 +76,10 @@ func (r *workHandler) Handle(ctx context.Context, logger log.Logger, record *Job
 	// 🚨 SECURITY: The request is performed without authentication, we get back results from every
 	// repository on Sourcegraph - results will be filtered when users query for insight data based on the
 	// repositories they can see.
+	isGlobal := false
+	if record.RecordTime == nil {
+		isGlobal = true
+	}
 
 	ctx = actor.WithInternalActor(ctx)
 	defer func() {
@@ -82,19 +87,19 @@ func (r *workHandler) Handle(ctx context.Context, logger log.Logger, record *Job
 			r.logger.Error("insights.queryrunner.workHandler", log.Error(err))
 		}
 	}()
-
+	ss := basestore.NewWithHandle(r.baseWorkerStore.Handle())
 	// storing trace with query for debugging
 	traceID := trace.ID(ctx)
 	if traceID != "" {
 		// intentionally ignoring error
-		r.baseWorkerStore.Exec(ctx, sqlf.Sprintf("update insights_query_runner_jobs set trace_id = %s where id = %s", traceID, record.RecordID()))
+		ss.Exec(ctx, sqlf.Sprintf("update insights_query_runner_jobs set trace_id = %s where id = %s", traceID, record.RecordID()))
 	}
 
 	err = r.limiter.Wait(ctx)
 	if err != nil {
 		return errors.Wrap(err, "limiter.Wait")
 	}
-	job, err := dequeueJob(ctx, r.baseWorkerStore, record.RecordID())
+	job, err := dequeueJob(ctx, ss, record.RecordID())
 	if err != nil {
 		return errors.Wrap(err, "dequeueJob")
 	}
@@ -119,7 +124,30 @@ func (r *workHandler) Handle(ctx context.Context, logger log.Logger, record *Job
 
 	recordings, err := executableHandler(ctx, &job.SearchJob, series, recordTime)
 	if err != nil {
+		if !r.baseWorkerStore.WillRetry(job) && isGlobal {
+			reason := TranslateIncompleteReasons(err)
+			logger.Debug("insights recording global query timeout",
+				log.Int("seriesId", series.ID), log.String("seriesUniqueId", series.SeriesID),
+				log.Error(err),
+				log.String("reason", string(reason)))
+
+			if err := r.insightsStore.AddIncompleteDatapoint(ctx, store.AddIncompleteDatapointInput{
+				SeriesID: series.ID,
+				Reason:   reason,
+				Time:     recordTime,
+			}); err != nil {
+				return errors.Wrap(err, "workHandler.AddIncompleteDatapoint")
+			}
+		}
 		return err
 	}
+
 	return r.persistRecordings(ctx, &job.SearchJob, series, recordings, recordTime)
+}
+
+func TranslateIncompleteReasons(err error) store.IncompleteReason {
+	if errors.Is(err, SearchTimeoutError) {
+		return store.ReasonTimeout
+	}
+	return store.ReasonGeneric
 }

--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/log"
@@ -131,12 +132,12 @@ func (r *workHandler) Handle(ctx context.Context, logger log.Logger, record *Job
 				log.Error(err),
 				log.String("reason", string(reason)))
 
-			if err := r.insightsStore.AddIncompleteDatapoint(ctx, store.AddIncompleteDatapointInput{
+			if addErr := r.insightsStore.AddIncompleteDatapoint(ctx, store.AddIncompleteDatapointInput{
 				SeriesID: series.ID,
 				Reason:   reason,
 				Time:     recordTime,
-			}); err != nil {
-				return errors.Wrap(err, "workHandler.AddIncompleteDatapoint")
+			}); addErr != nil {
+				return multierror.Append(err, errors.Wrap(addErr, "workHandler.AddIncompleteDatapoint"))
 			}
 		}
 		return err

--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/log"
@@ -137,7 +136,7 @@ func (r *workHandler) Handle(ctx context.Context, logger log.Logger, record *Job
 				Reason:   reason,
 				Time:     recordTime,
 			}); addErr != nil {
-				return multierror.Append(err, errors.Wrap(addErr, "workHandler.AddIncompleteDatapoint"))
+				return errors.Append(err, errors.Wrap(addErr, "workHandler.AddIncompleteDatapoint"))
 			}
 		}
 		return err

--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -124,7 +124,7 @@ func (r *workHandler) Handle(ctx context.Context, logger log.Logger, record *Job
 
 	recordings, err := executableHandler(ctx, &job.SearchJob, series, recordTime)
 	if err != nil {
-		if !r.baseWorkerStore.WillRetry(job) && isGlobal {
+		if !r.baseWorkerStore.WillRetry(job) && isGlobal && job.PersistMode == string(store.RecordMode) {
 			reason := TranslateIncompleteReasons(err)
 			logger.Debug("insights recording global query timeout",
 				log.Int("seriesId", series.ID), log.String("seriesUniqueId", series.SeriesID),

--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -24,7 +24,6 @@ var _ workerutil.Handler[*Job] = &workHandler{}
 // workHandler implements the dbworker.Handler interface by executing search queries and
 // inserting insights about them to the insights database.
 type workHandler struct {
-	// baseWorkerStore *basestore.Store
 	baseWorkerStore *workerStoreExtra
 	insightsStore   *store.Store
 	repoStore       discovery.RepoStore

--- a/enterprise/internal/insights/background/queryrunner/work_handler_test.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler_test.go
@@ -131,6 +131,7 @@ func Test_HandleWithTerminalError(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		job.NumFailures = int32(previousFailures)
 		return job
 	}
 
@@ -146,7 +147,7 @@ func Test_HandleWithTerminalError(t *testing.T) {
 	}
 
 	t.Run("ensure max errors produces incomplete point entry", func(t *testing.T) {
-		job := queueIt(8)
+		job := queueIt(9)
 		err = handler.Handle(ctx, logger, job)
 		require.ErrorIs(t, err, fakeErr)
 		incompletes, err := tss.LoadAggregatedIncompleteDatapoints(ctx, series.ID)

--- a/enterprise/internal/insights/background/queryrunner/work_handler_test.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler_test.go
@@ -6,7 +6,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keegancsmith/sqlf"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+
 	"github.com/sourcegraph/log/logtest"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
+	store2 "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/hexops/autogold"
 
@@ -67,5 +77,99 @@ func TestGetSeries(t *testing.T) {
 			t.Fatal("unexpected error from getseries")
 		}
 		autogold.Equal(t, got, autogold.ExportedOnly())
+	})
+}
+
+func Test_HandleWithTerminalError(t *testing.T) {
+	logger := logtest.Scoped(t)
+	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
+	postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+	now := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC).Truncate(time.Microsecond).Round(0)
+	metadataStore := store.NewInsightStore(insightsDB)
+	metadataStore.Now = func() time.Time {
+		return now
+	}
+	ctx := context.Background()
+
+	series, err := metadataStore.CreateSeries(ctx, types.InsightSeries{
+		SeriesID:            "asdf",
+		Query:               "findme",
+		SampleIntervalUnit:  string(types.Month),
+		SampleIntervalValue: 5,
+		GenerationMethod:    types.Search,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tss := store.New(insightsDB, store.NewInsightPermissionStore(postgres))
+	fakeErr := errors.New("fake err")
+
+	handlers := make(map[types.GenerationMethod]InsightsHandler)
+	handlers[types.Search] = func(ctx context.Context, job *SearchJob, series *types.InsightSeries, recordTime time.Time) ([]store.RecordSeriesPointArgs, error) {
+		return nil, fakeErr
+	}
+	workerStore := CreateDBWorkerStore(observation.TestContextTB(t), basestore.NewWithHandle(postgres.Handle()))
+
+	queueIt := func(previousFailures int) *Job {
+		job := &Job{
+			SearchJob: SearchJob{
+				SeriesID:    series.SeriesID,
+				SearchQuery: "findme",
+				RecordTime:  nil, // set nil to emulate a global query
+				PersistMode: string(store.RecordMode),
+			},
+			State:    "queued",
+			Cost:     10,
+			Priority: 10,
+		}
+		job.ID, err = EnqueueJob(ctx, basestore.NewWithHandle(workerStore.Handle()), job)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = basestore.NewWithHandle(workerStore.Handle()).Exec(ctx, sqlf.Sprintf("update insights_query_runner_jobs set num_failures = %s where id = %s", previousFailures, job.ID))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return job
+	}
+
+	handler := &workHandler{
+		insightsStore:   tss,
+		baseWorkerStore: workerStore,
+		metadadataStore: metadataStore,
+		limiter:         ratelimit.NewInstrumentedLimiter("asdf", rate.NewLimiter(10, 5)),
+		logger:          logger,
+		mu:              sync.RWMutex{},
+		seriesCache:     make(map[string]*types.InsightSeries),
+		searchHandlers:  handlers,
+	}
+
+	t.Run("ensure max errors produces incomplete point entry", func(t *testing.T) {
+		job := queueIt(8)
+		err = handler.Handle(ctx, logger, job)
+		require.ErrorIs(t, err, fakeErr)
+		incompletes, err := tss.LoadAggregatedIncompleteDatapoints(ctx, series.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		require.Len(t, incompletes, 1)
+		_, err = workerStore.MarkComplete(ctx, job.ID, store2.MarkFinalOptions{})
+		require.NoError(t, err)
+	})
+	t.Run("ensure less than max errors does not produce an incomplete point entry", func(t *testing.T) {
+		job := queueIt(7)
+		err = handler.Handle(ctx, logger, job)
+		require.ErrorIs(t, err, fakeErr)
+		incompletes, err := tss.LoadAggregatedIncompleteDatapoints(ctx, series.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		require.Empty(t, incompletes)
+		_, err = workerStore.MarkComplete(ctx, job.ID, store2.MarkFinalOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		require.NoError(t, err)
 	})
 }

--- a/enterprise/internal/insights/background/queryrunner/worker.go
+++ b/enterprise/internal/insights/background/queryrunner/worker.go
@@ -119,7 +119,7 @@ type workerStoreExtra struct {
 // WillRetry will return true if the next iteration of this job is valid (would
 // retry) or false if this is the last iteration.
 func (w *workerStoreExtra) WillRetry(job *Job) bool {
-	return int(job.NumFailures)+1 < w.options.MaxNumRetries
+	return !(int(job.NumFailures)+1 < w.options.MaxNumRetries)
 }
 
 func getDependencies(ctx context.Context, workerBaseStore *basestore.Store, jobID int) (_ []time.Time, err error) {

--- a/enterprise/internal/insights/background/queryrunner/worker.go
+++ b/enterprise/internal/insights/background/queryrunner/worker.go
@@ -119,7 +119,7 @@ type workerStoreExtra struct {
 // WillRetry will return true if the next iteration of this job is valid (would
 // retry) or false if this is the last iteration.
 func (w *workerStoreExtra) WillRetry(job *Job) bool {
-	return !(int(job.NumFailures)+1 < w.options.MaxNumRetries)
+	return int(job.NumFailures)+1 < w.options.MaxNumRetries
 }
 
 func getDependencies(ctx context.Context, workerBaseStore *basestore.Store, jobID int) (_ []time.Time, err error) {


### PR DESCRIPTION
Closes #44371

Write an incomplete row for global queries that terminally fail.

## Test plan

Tested a query with `timeout:2s`

Here is the queue row after it moved to the failed state:
| state | finished\_at | num\_failures |
| :--- | :--- | :--- |
| failed | 2022-12-06 18:26:29.840695 +00:00 | 10 |

Here is the incomplete row that was written
| id | series\_id | reason | time | repo\_id |
| :--- | :--- | :--- | :--- | :--- |
| 162 | 46 | timeout | 2022-12-06 18:26:27.808281 | null |


