### PR TITLE
batcheshelper: fix ctx not being passed

### DIFF
--- a/enterprise/cmd/batcheshelper/post.go
+++ b/enterprise/cmd/batcheshelper/post.go
@@ -20,10 +20,10 @@ func execPost(ctx context.Context, stepIdx int, executionInput batcheslib.Worksp
 	step := executionInput.Steps[stepIdx]
 
 	// Generate the diff.
-	if _, err := runGitCmd(context.Background(), "git", "add", "--all"); err != nil {
+	if _, err := runGitCmd(ctx, "git", "add", "--all"); err != nil {
 		return errors.Wrap(err, "git add --all failed")
 	}
-	diff, err := runGitCmd(context.Background(), "git", "diff", "--cached", "--no-prefix", "--binary")
+	diff, err := runGitCmd(ctx, "git", "diff", "--cached", "--no-prefix", "--binary")
 	if err != nil {
 		return errors.Wrap(err, "git diff --cached --no-prefix --binary failed")
 	}

--- a/enterprise/cmd/batcheshelper/pre.go
+++ b/enterprise/cmd/batcheshelper/pre.go
@@ -117,7 +117,7 @@ func execPre(ctx context.Context, stepIdx int, executionInput batcheslib.Workspa
 	if err := os.WriteFile(stepScriptPath, fullScript, os.ModePerm); err != nil {
 		return errors.Wrap(err, "failed to write step script file")
 	}
-	if _, err := exec.CommandContext(context.Background(), "chmod", "+x", stepScriptPath).CombinedOutput(); err != nil {
+	if _, err := exec.CommandContext(ctx, "chmod", "+x", stepScriptPath).CombinedOutput(); err != nil {
 		return errors.Wrap(err, "failed to chmod step script file")
 	}
 


### PR DESCRIPTION
Spotted a `context.Context` not being passed down the line, hence the quick fix :) 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 