### PR TITLE
Token selection: add back "go to definition" button

### DIFF
--- a/client/shared/src/commands/commands.ts
+++ b/client/shared/src/commands/commands.ts
@@ -43,6 +43,13 @@ export function registerBuiltinClientCommands(
 
     subscription.add(
         registerCommand({
+            command: 'invokeFunction',
+            run: (handler: () => Promise<void>) => handler(),
+        })
+    )
+
+    subscription.add(
+        registerCommand({
             command: 'openPanel',
             run: (viewID: string) => {
                 // As above for `open`, the `openPanel` client command is usually implemented by an HTML <a>

--- a/client/web/src/repo/blob/codemirror/token-selection/definition.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/definition.ts
@@ -18,10 +18,11 @@ import { hoveredOccurrenceField } from './hover'
 import { isModifierKey, isModifierKeyHeld } from './modifier-click'
 import { selectOccurrence, selectRange } from './selections'
 
-interface DefinitionResult {
+export interface DefinitionResult {
     handler: (position: Position) => void
     url?: string
     locations: Location[]
+    atTheDefinition?: boolean
 }
 const emptyDefinitionResult: DefinitionResult = { handler: () => {}, locations: [] }
 const definitionReady = Decoration.mark({
@@ -157,6 +158,7 @@ async function goToDefinition(
                 const refPanelURL = locationToURL(locationFrom, 'references')
                 return {
                     url: refPanelURL,
+                    atTheDefinition: true,
                     handler: position => {
                         showTemporaryTooltip(view, 'You are at the definition', position, 2000, { arrow: true })
                         const history = view.state.facet(blobPropsFacet).history

--- a/client/web/src/repo/blob/codemirror/tooltips/CodeIntelTooltip.tsx
+++ b/client/web/src/repo/blob/codemirror/tooltips/CodeIntelTooltip.tsx
@@ -1,5 +1,5 @@
 import { EditorView, Tooltip, TooltipView } from '@codemirror/view'
-import { of } from 'rxjs'
+import { concat, from, Observable, of } from 'rxjs'
 
 import { HoverMerged } from '@sourcegraph/client-api'
 import { MarkupKind } from '@sourcegraph/extension-api-classes'
@@ -12,6 +12,8 @@ import { blobPropsFacet } from '..'
 import { HovercardView, HoverData } from '../hovercard'
 import { rangeToCmSelection } from '../occurrence-utils'
 import { modifierClickDescription } from '../token-selection/modifier-click'
+import { DefinitionResult, goToDefinitionAtOccurrence } from '../token-selection/definition'
+import { map } from 'rxjs/operators'
 
 export interface HoverResult {
     markdownContents: string
@@ -19,6 +21,11 @@ export interface HoverResult {
     isPrecise?: boolean
 }
 export const emptyHoverResult: HoverResult = { markdownContents: '' }
+
+// Helper to handle the cases for "No definition found" and "You are at the definition".
+interface AsyncDefinitionResult extends DefinitionResult {
+    asyncHandler: () => Promise<void>
+}
 
 // CodeMirror tooltip wrapper around the "code intel" popover.  Implemented as a
 // class so that we can detect it with instanceof checks. This class
@@ -30,68 +37,116 @@ export class CodeIntelTooltip implements Tooltip {
     public readonly pos: number
     public readonly end: number
     public readonly create: () => TooltipView
-    constructor(view: EditorView, occurrence: Occurrence, hover: HoverResult) {
-        const { markdownContents } = hover
+    constructor(
+        private readonly view: EditorView,
+        private readonly occurrence: Occurrence,
+        private readonly hover: HoverResult
+    ) {
         const range = rangeToCmSelection(view.state, occurrence.range)
         this.pos = range.from
         this.end = range.to
         this.create = () => {
-            const blobInfo = view.state.facet(blobPropsFacet).blobInfo
-            const referencesURL = toPrettyBlobURL({
-                ...blobInfo,
-                range: occurrence.range.withIncrementedValues(),
-                viewState: 'references',
-            })
-            const actions: ActionItemAction[] = [
-                {
-                    active: true,
-                    action: {
-                        id: 'findReferences',
-                        title: 'Find references',
-                        command: 'open',
-                        commandArguments: [referencesURL],
-                    },
-                },
-            ]
-            if (hover.isPrecise && hasFindImplementationsSupport(view.state.facet(blobPropsFacet).blobInfo.mode)) {
-                const implementationsURL = toPrettyBlobURL({
-                    ...blobInfo,
-                    range: occurrence.range.withIncrementedValues(),
-                    viewState: `implementations_${blobInfo.mode}` as BlobViewState,
-                })
-                actions.push({
-                    active: true,
-                    action: {
-                        id: 'findImplementations',
-                        title: 'Find implementations',
-                        command: 'open',
-                        commandArguments: [implementationsURL],
-                    },
-                })
+            // To prevent the "Go to definition" from delaying the loading of
+            // the popover, we provide an instant result that doesn't handle the
+            // "No definition found" or "You are at the definition" cases. This
+            // instant result gets dynamically replaced the actual result once
+            // it finishes loading.
+            const instantDefinitionResult: AsyncDefinitionResult = {
+                locations: [{ uri: '' }],
+                handler: () => {},
+                asyncHandler: () =>
+                    goToDefinitionAtOccurrence(view, occurrence).then(
+                        ({ handler }) => handler(occurrence.range.start),
+                        () => {}
+                    ),
             }
+            const definitionResults: Observable<AsyncDefinitionResult> = concat(
+                // Show active "Go to definition" button until we have resolved
+                // a definition.
+                of(instantDefinitionResult),
+                // Trigger "Go to definition" to identify if this hover message
+                // is already at the definition or if there are no references.
+                from(goToDefinitionAtOccurrence(view, occurrence)).pipe(
+                    map(result => ({ ...result, asyncHandler: instantDefinitionResult.asyncHandler }))
+                )
+            )
+            const hovercardData: Observable<HoverData> = definitionResults.pipe(
+                map(result => this.hovercardData(result))
+            )
+            return new HovercardView(view, occurrence.range.withIncrementedValues(), false, hovercardData)
+        }
+    }
+    private hovercardData(definition: AsyncDefinitionResult): HoverData {
+        const { markdownContents } = this.hover
+        const blobInfo = this.view.state.facet(blobPropsFacet).blobInfo
+        const referencesURL = toPrettyBlobURL({
+            ...blobInfo,
+            range: this.occurrence.range.withIncrementedValues(),
+            viewState: 'references',
+        })
+        const noDefinitionFound = definition.locations.length === 0
+        const actions: ActionItemAction[] = [
+            {
+                active: true,
+                disabledWhen: noDefinitionFound || definition.atTheDefinition,
+                action: {
+                    id: 'invokeFunction',
+                    title: 'Go to definition',
+                    disabledTitle: noDefinitionFound ? 'No definition found' : 'You are at the definition',
+                    command: 'invokeFunction',
+                    commandArguments: [() => definition.asyncHandler()],
+                },
+            },
+            {
+                active: true,
+                action: {
+                    id: 'findReferences',
+                    title: 'Find references',
+                    command: 'open',
+                    commandArguments: [referencesURL],
+                },
+            },
+        ]
+        if (
+            this.hover.isPrecise &&
+            hasFindImplementationsSupport(this.view.state.facet(blobPropsFacet).blobInfo.mode)
+        ) {
+            const implementationsURL = toPrettyBlobURL({
+                ...blobInfo,
+                range: this.occurrence.range.withIncrementedValues(),
+                viewState: `implementations_${blobInfo.mode}` as BlobViewState,
+            })
             actions.push({
                 active: true,
                 action: {
-                    id: 'goToDefinition',
-                    title: '?', // special marker for the MDI "Help" icon.
-                    description: `Go to definition with ${modifierClickDescription}, long-click, or by pressing Enter with the keyboard. Display this popover by pressing Space with the keyboard.`,
-                    command: '',
+                    id: 'findImplementations',
+                    title: 'Find implementations',
+                    command: 'open',
+                    commandArguments: [implementationsURL],
                 },
             })
-            const data: HoverData = {
-                actionsOrError: actions,
-                hoverOrError: {
-                    range: occurrence.range,
-                    aggregatedBadges: hover.hoverMerged?.aggregatedBadges,
-                    contents: [
-                        {
-                            value: markdownContents,
-                            kind: MarkupKind.Markdown,
-                        },
-                    ],
-                },
-            }
-            return new HovercardView(view, occurrence.range.withIncrementedValues(), false, of(data))
+        }
+        actions.push({
+            active: true,
+            action: {
+                id: 'goToDefinition',
+                title: '?', // special marker for the MDI "Help" icon.
+                description: `Go to definition with ${modifierClickDescription}, long-click, or by pressing Enter with the keyboard. Display this popover by pressing Space with the keyboard.`,
+                command: '',
+            },
+        })
+        return {
+            actionsOrError: actions,
+            hoverOrError: {
+                range: this.occurrence.range,
+                aggregatedBadges: this.hover.hoverMerged?.aggregatedBadges,
+                contents: [
+                    {
+                        value: markdownContents,
+                        kind: MarkupKind.Markdown,
+                    },
+                ],
+            },
         }
     }
 }

--- a/client/web/src/repo/blob/codemirror/tooltips/CodeIntelTooltip.tsx
+++ b/client/web/src/repo/blob/codemirror/tooltips/CodeIntelTooltip.tsx
@@ -1,5 +1,6 @@
 import { EditorView, Tooltip, TooltipView } from '@codemirror/view'
 import { concat, from, Observable, of } from 'rxjs'
+import { map } from 'rxjs/operators'
 
 import { HoverMerged } from '@sourcegraph/client-api'
 import { MarkupKind } from '@sourcegraph/extension-api-classes'
@@ -11,9 +12,8 @@ import { BlobViewState, toPrettyBlobURL } from '@sourcegraph/shared/src/util/url
 import { blobPropsFacet } from '..'
 import { HovercardView, HoverData } from '../hovercard'
 import { rangeToCmSelection } from '../occurrence-utils'
-import { modifierClickDescription } from '../token-selection/modifier-click'
 import { DefinitionResult, goToDefinitionAtOccurrence } from '../token-selection/definition'
-import { map } from 'rxjs/operators'
+import { modifierClickDescription } from '../token-selection/modifier-click'
 
 export interface HoverResult {
     markdownContents: string


### PR DESCRIPTION
We received internal feedback asking what happened to the "Go to definition" button. This commits adds this button back to reduce disruption when rolling out token selection. The new button is no longer a link like it was before because links are not a suitable abstraction for "go to definition", as documented in
https://docs.google.com/document/d/1cXZEXfui1ylXBfNoB5iK7sUYhbNm51Y7wQMW36RScTA/edit#

In addition to the "You are at the definition", which the old navigation supported, this new implementation also displays "No definition found" when there are guaranteed no results.


## Test plan

Run locally and confirm the following:

* Popover shows "Go to definition" for references that have at least one definition

<img width="530" alt="CleanShot 2022-12-06 at 21 48 38@2x" src="https://user-images.githubusercontent.com/1408093/206019835-9f67a454-ec91-4d00-85aa-018815837603.png">

* Popover shows "No definition found" for references that have at no definition


<img width="446" alt="CleanShot 2022-12-06 at 21 42 24@2x" src="https://user-images.githubusercontent.com/1408093/206019732-a32d1054-5f91-494b-baac-e5d67effd9ad.png">

* Popover shows "You are at the definition" when hovering over a definition

<img width="602" alt="CleanShot 2022-12-06 at 21 48 19@2x" src="https://user-images.githubusercontent.com/1408093/206019768-9d6ed8fe-7638-4474-8881-8e5248259f01.png">


For no-definition/at-the-definition cases, you may notice a small flash in rare cases because the button loads first with "Go to definition" until it has finished resolving the definition. We do this to avoid delaying the popover if computing the definition is slower than computing the hover.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-token-selection.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
