### PR TITLE
[language-platform] adding should_reindex column to lsif_uploads

### DIFF
--- a/enterprise/internal/codeintel/autoindexing/internal/store/store_indexes.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/store/store_indexes.go
@@ -572,7 +572,8 @@ SELECT
 			repository_id = %s AND
 			commit = %s AND
 			state NOT IN ('deleting', 'deleted') AND
-			associated_index_id IS NULL
+			associated_index_id IS NULL AND
+			NOT u.should_reindex
 	)
 
 	OR

--- a/migrations/frontend/1670350006_add_should_reindex_to_lsif_uploads/down.sql
+++ b/migrations/frontend/1670350006_add_should_reindex_to_lsif_uploads/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE lsif_uploads DROP COLUMN IF EXISTS should_reindex;

--- a/migrations/frontend/1670350006_add_should_reindex_to_lsif_uploads/metadata.yaml
+++ b/migrations/frontend/1670350006_add_should_reindex_to_lsif_uploads/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_should_reindex_to_lsif_uploads
+parents: [1670256530, 1668813365]

--- a/migrations/frontend/1670350006_add_should_reindex_to_lsif_uploads/up.sql
+++ b/migrations/frontend/1670350006_add_should_reindex_to_lsif_uploads/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE lsif_uploads ADD COLUMN IF NOT EXISTS should_reindex boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
Fixes #45079 

Adds a column named `should_reindex` to the `lsif_uploads` table so that we can later mark all of our LSIF -> SCIP records as replaceable.

## Test plan
Ran all the tests.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
