### PR TITLE
search contexts: permanently enable management page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ All notable changes to Sourcegraph are documented in this file.
 - Added a best-effort migration such that existing Code Insights will display zero results instead of missing points at the start and end of a graph. [#44928](https://github.com/sourcegraph/sourcegraph/pull/44928)
 - More complete stack traces for Outbound request log [#45151](https://github.com/sourcegraph/sourcegraph/pull/45151)
 - A new status message now reports how many repositories have already been indexed for search. [#45246](https://github.com/sourcegraph/sourcegraph/pull/45246)
-- Search contexts can now be starred (favorited) in the search context management page. Starred search contexts will appear first in the context dropdown menu next to the search box. The setting `experimentalFeatures.showSearchContextManagement` must be enabled to access the management page (this is enabled by default). [#45230](https://github.com/sourcegraph/sourcegraph/pull/45230)
+- The experimental setting `showSearchContextManagement` has been removed and the search context management page is now available to all users with access to search contexts. [#45230](https://github.com/sourcegraph/sourcegraph/pull/45230)
+- Search contexts can now be starred (favorited) in the search context management page. Starred search contexts will appear first in the context dropdown menu next to the search box. [#45230](https://github.com/sourcegraph/sourcegraph/pull/45230)
 
 ### Changed
 

--- a/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
+++ b/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
@@ -23,7 +23,7 @@ import { CommunitySearchContextPage, CommunitySearchContextPageProps } from './C
 import { temporal } from './Temporal'
 
 const decorator: DecoratorFn = Story => {
-    useExperimentalFeatures.setState({ showSearchContext: true, showSearchContextManagement: false })
+    useExperimentalFeatures.setState({ showSearchContext: true })
     return <Story />
 }
 

--- a/client/web/src/enterprise/routes.tsx
+++ b/client/web/src/enterprise/routes.tsx
@@ -17,9 +17,7 @@ const CreateNotebookPage = lazyComponent(
 const NotebooksListPage = lazyComponent(() => import('../notebooks/listPage/NotebooksListPage'), 'NotebooksListPage')
 
 const isSearchContextsManagementEnabled = (settingsCascade: SettingsCascadeOrError): boolean =>
-    !isErrorLike(settingsCascade.final) &&
-    settingsCascade.final?.experimentalFeatures?.showSearchContext !== false &&
-    settingsCascade.final?.experimentalFeatures?.showSearchContextManagement !== false
+    !isErrorLike(settingsCascade.final) && settingsCascade.final?.experimentalFeatures?.showSearchContext !== false
 
 export const enterpriseRoutes: readonly LayoutRouteProps<any>[] = [
     {

--- a/client/web/src/integration/search-contexts.test.ts
+++ b/client/web/src/integration/search-contexts.test.ts
@@ -45,7 +45,6 @@ describe('Search contexts', () => {
             user: {
                 experimentalFeatures: {
                     showSearchContext: true,
-                    showSearchContextManagement: true,
                 },
             },
         }),
@@ -93,7 +92,6 @@ describe('Search contexts', () => {
                     user: {
                         experimentalFeatures: {
                             showSearchContext: true,
-                            showSearchContextManagement: true,
                             ...enableEditor(editorName).experimentalFeatures,
                         },
                     },

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -67,9 +67,6 @@ const queryStateSelector = (
 export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Props>> = (props: Props) => {
     const { caseSensitive, patternType, searchMode } = useNavbarQueryState(queryStateSelector, shallow)
     const showSearchContext = useExperimentalFeatures(features => features.showSearchContext ?? false)
-    const showSearchContextManagement = useExperimentalFeatures(
-        features => features.showSearchContextManagement ?? false
-    )
     const editorComponent = useExperimentalFeatures(features => features.editor ?? 'codemirror6')
     const applySuggestionsOnEnter =
         useExperimentalFeatures(features => features.applySearchQuerySuggestionOnEnter) ?? true
@@ -129,7 +126,7 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
                             {...props}
                             editorComponent={editorComponent}
                             showSearchContext={showSearchContext}
-                            showSearchContextManagement={showSearchContextManagement}
+                            showSearchContextManagement={true}
                             caseSensitive={caseSensitive}
                             patternType={patternType}
                             setPatternType={setSearchPatternType}

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -63,9 +63,6 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
     } = useNavbarQueryState(selectQueryState, shallow)
 
     const showSearchContext = useExperimentalFeatures(features => features.showSearchContext ?? false)
-    const showSearchContextManagement = useExperimentalFeatures(
-        features => features.showSearchContextManagement ?? false
-    )
     const editorComponent = useExperimentalFeatures(features => features.editor ?? 'codemirror6')
     const applySuggestionsOnEnter =
         useExperimentalFeatures(features => features.applySearchQuerySuggestionOnEnter) ?? true
@@ -104,7 +101,7 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
                 editorComponent={editorComponent}
                 applySuggestionsOnEnter={applySuggestionsOnEnter}
                 showSearchContext={showSearchContext}
-                showSearchContextManagement={showSearchContextManagement}
+                showSearchContextManagement={true}
                 caseSensitive={searchCaseSensitivity}
                 setCaseSensitivity={setSearchCaseSensitivity}
                 patternType={searchPatternType}

--- a/client/web/src/stores/experimentalFeatures.ts
+++ b/client/web/src/stores/experimentalFeatures.ts
@@ -12,7 +12,6 @@ const defaultSettings: SettingsExperimentalFeatures = {
      */
     showMultilineSearchConsole: false,
     showSearchContext: true,
-    showSearchContextManagement: true,
     showSearchNotebook: true,
     showComputeComponent: false,
     codeMonitoringWebHooks: true,

--- a/doc/admin/how-to/converting-version-contexts-to-search-contexts.md
+++ b/doc/admin/how-to/converting-version-contexts-to-search-contexts.md
@@ -12,7 +12,6 @@ Site admins can enable search contexts on private Sourcegraph instances in **glo
 ```json
 "experimentalFeatures": {  
   "showSearchContext": true,
-  "showSearchContextManagement": true
 }
 ```
 

--- a/doc/code_search/explanations/features.md
+++ b/doc/code_search/explanations/features.md
@@ -94,8 +94,7 @@ Your site admin can enable search contexts on your private instance in **global 
 
 ```json
 "experimentalFeatures": {  
-  "showSearchContext": true,
-  "showSearchContextManagement": true
+  "showSearchContext": true
 }
 ```
 

--- a/doc/code_search/how-to/create_search_context_graphql.md
+++ b/doc/code_search/how-to/create_search_context_graphql.md
@@ -17,7 +17,7 @@ Step 1: Add to global configuration (must be site-admin):
 ```json
 {
     "experimentalFeatures": {
-      "showSearchContext": true,
+      "showSearchContext": true
   }
 }
 ```

--- a/doc/code_search/how-to/create_search_context_graphql.md
+++ b/doc/code_search/how-to/create_search_context_graphql.md
@@ -18,7 +18,6 @@ Step 1: Add to global configuration (must be site-admin):
 {
     "experimentalFeatures": {
       "showSearchContext": true,
-      "showSearchContextManagement": true
   }
 }
 ```

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1971,7 +1971,7 @@ type SettingsExperimentalFeatures struct {
 	ShowRepogroupHomepage *bool `json:"showRepogroupHomepage,omitempty"`
 	// ShowSearchContext description: Enables the search context dropdown.
 	ShowSearchContext *bool `json:"showSearchContext,omitempty"`
-	// ShowSearchContextManagement description: Enables search context management.
+	// ShowSearchContextManagement description: REMOVED.
 	ShowSearchContextManagement *bool `json:"showSearchContextManagement,omitempty"`
 	// ShowSearchNotebook description: Enables the search notebook at search/notebook
 	ShowSearchNotebook *bool `json:"showSearchNotebook,omitempty"`

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -134,7 +134,7 @@
           }
         },
         "showSearchContextManagement": {
-          "description": "Enables search context management.",
+          "description": "REMOVED.",
           "type": "boolean",
           "default": false,
           "!go": {


### PR DESCRIPTION
Stacked on #45289

Part of #44903

The experimental setting `showSearchContextManagement` should now be permanently enabled. This way, all users with access to search contexts can access the management page to star contexts/set as default.

The experimental setting `showSearchContext` is still required to be enabled for contexts to be shown (this is on by default).

## Test plan

All existing tests should continue passing