### PR TITLE
goroutine: only use named & error-logging background goroutines 

### DIFF
--- a/cmd/frontend/internal/httpapi/releasecache/http.go
+++ b/cmd/frontend/internal/httpapi/releasecache/http.go
@@ -71,7 +71,13 @@ func NewHandler(logger log.Logger) http.Handler {
 
 		// Otherwise, let's build a new release cache and start a fresh updater.
 		rc := config.NewReleaseCache(logger)
-		handler.updater = goroutine.NewPeriodicGoroutine(ctx, config.interval, rc)
+		handler.updater = goroutine.NewPeriodicGoroutine(
+			ctx,
+			"srccli.github-release-cache",
+			"caches src-cli versions polled periodically",
+			config.interval,
+			rc,
+		)
 		go goroutine.MonitorBackgroundRoutines(ctx, handler.updater)
 
 		handler.rc = rc

--- a/cmd/symbols/internal/database/janitor/cache_evicter.go
+++ b/cmd/symbols/internal/database/janitor/cache_evicter.go
@@ -30,11 +30,13 @@ var (
 )
 
 func NewCacheEvicter(interval time.Duration, cache diskcache.Store, maxCacheSizeBytes int64, metrics *Metrics) goroutine.BackgroundRoutine {
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, &cacheEvicter{
-		cache:             cache,
-		maxCacheSizeBytes: maxCacheSizeBytes,
-		metrics:           metrics,
-	})
+	return goroutine.NewPeriodicGoroutine(context.Background(), "codeintel.symbols-cache-evictor", "evicts entries from the symbols cache",
+		interval, &cacheEvicter{
+			cache:             cache,
+			maxCacheSizeBytes: maxCacheSizeBytes,
+			metrics:           metrics,
+		},
+	)
 }
 
 // Handle periodically checks the size of the cache and evicts/deletes items.

--- a/cmd/worker/internal/repostatistics/compactor.go
+++ b/cmd/worker/internal/repostatistics/compactor.go
@@ -36,10 +36,12 @@ func (j *compactor) Routines(startupCtx context.Context, observationCtx *observa
 	}
 
 	return []goroutine.BackgroundRoutine{
-		goroutine.NewPeriodicGoroutine(context.Background(), 30*time.Minute, &handler{
-			store:  db.RepoStatistics(),
-			logger: observationCtx.Logger,
-		}),
+		goroutine.NewPeriodicGoroutine(context.Background(), "repomgmt.statistics-compactor", "compacts repo statistics",
+			30*time.Minute, &handler{
+				store:  db.RepoStatistics(),
+				logger: observationCtx.Logger,
+			},
+		),
 	}, nil
 }
 

--- a/cmd/worker/internal/webhooks/janitor.go
+++ b/cmd/worker/internal/webhooks/janitor.go
@@ -41,8 +41,10 @@ func (j *janitor) Routines(startupCtx context.Context, observationCtx *observati
 		// hour aren't supported, and this is why: there's no point running this
 		// operation more frequently than that, given it's purely a debugging
 		// tool.
-		goroutine.NewPeriodicGoroutine(context.Background(), 1*time.Hour, &handler{
-			store: db.WebhookLogs(keyring.Default().WebhookLogKey),
-		}),
+		goroutine.NewPeriodicGoroutine(context.Background(), "batchchanges.webhook-log-janitor", "cleans up stale webhook logs",
+			1*time.Hour, &handler{
+				store: db.WebhookLogs(keyring.Default().WebhookLogKey),
+			},
+		),
 	}, nil
 }

--- a/cmd/worker/internal/zoektrepos/zoektrepos.go
+++ b/cmd/worker/internal/zoektrepos/zoektrepos.go
@@ -38,10 +38,12 @@ func (j *updater) Routines(startupCtx context.Context, observationCtx *observati
 	}
 
 	return []goroutine.BackgroundRoutine{
-		goroutine.NewPeriodicGoroutine(context.Background(), 1*time.Hour, &handler{
-			db:     db,
-			logger: observationCtx.Logger,
-		}),
+		goroutine.NewPeriodicGoroutine(context.Background(), "search.index-status-reconciler", "reconciles indexed status between zoekt and postgres",
+			1*time.Hour, &handler{
+				db:     db,
+				logger: observationCtx.Logger,
+			},
+		),
 	}, nil
 }
 

--- a/enterprise/cmd/executor/internal/janitor/orphaned_vms.go
+++ b/enterprise/cmd/executor/internal/janitor/orphaned_vms.go
@@ -19,8 +19,10 @@ type orphanedVMJanitor struct {
 	metrics *metrics
 }
 
-var _ goroutine.Handler = &orphanedVMJanitor{}
-var _ goroutine.ErrorHandler = &orphanedVMJanitor{}
+var (
+	_ goroutine.Handler      = &orphanedVMJanitor{}
+	_ goroutine.ErrorHandler = &orphanedVMJanitor{}
+)
 
 // NewOrphanedVMJanitor returns a background routine that periodically removes all VMs
 // on the host that are not known by the worker running within this executor instance.
@@ -30,11 +32,13 @@ func NewOrphanedVMJanitor(
 	interval time.Duration,
 	metrics *metrics,
 ) goroutine.BackgroundRoutine {
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, newOrphanedVMJanitor(
-		prefix,
-		names,
-		metrics,
-	))
+	return goroutine.NewPeriodicGoroutine(context.Background(), "executors.orphaned-vm-janitor", "deletes VMs from a previous executor instance",
+		interval, newOrphanedVMJanitor(
+			prefix,
+			names,
+			metrics,
+		),
+	)
 }
 
 func newOrphanedVMJanitor(

--- a/enterprise/cmd/frontend/worker/auth/sourcegraph_operator_cleaner.go
+++ b/enterprise/cmd/frontend/worker/auth/sourcegraph_operator_cleaner.go
@@ -53,6 +53,8 @@ func (j *sourcegraphOperatorCleaner) Routines(_ context.Context, observationCtx 
 	return []goroutine.BackgroundRoutine{
 		goroutine.NewPeriodicGoroutine(
 			context.Background(),
+			"auth.expired-soap-cleaner",
+			"deletes expired SOAP operator user accounts",
 			time.Minute,
 			&sourcegraphOperatorCleanHandler{
 				db:                db,

--- a/enterprise/cmd/worker/internal/batches/janitor/cache_entry_cleaner.go
+++ b/enterprise/cmd/worker/internal/batches/janitor/cache_entry_cleaner.go
@@ -22,8 +22,9 @@ func NewCacheEntryCleaner(ctx context.Context, s *store.Store) goroutine.Backgro
 
 	return goroutine.NewPeriodicGoroutine(
 		ctx,
+		"batchchanges.cache-cleaner", "cleaning up LRU batch spec execution cache entries",
 		cacheCleanInterval,
-		goroutine.NewHandlerWithErrorMessage("batchchanges.cache-cleaner", "cleaning up LRU batch spec execution cache entries", func(ctx context.Context) error {
+		goroutine.HandlerFunc(func(ctx context.Context) error {
 			return s.CleanBatchSpecExecutionCacheEntries(ctx, maxSizeByte)
 		}),
 	)

--- a/enterprise/cmd/worker/internal/batches/janitor/cache_entry_cleaner.go
+++ b/enterprise/cmd/worker/internal/batches/janitor/cache_entry_cleaner.go
@@ -23,7 +23,7 @@ func NewCacheEntryCleaner(ctx context.Context, s *store.Store) goroutine.Backgro
 	return goroutine.NewPeriodicGoroutine(
 		ctx,
 		cacheCleanInterval,
-		goroutine.NewHandlerWithErrorMessage("cleaning up LRU batch spec execution cache entries", func(ctx context.Context) error {
+		goroutine.NewHandlerWithErrorMessage("batchchanges.cache-cleaner", "cleaning up LRU batch spec execution cache entries", func(ctx context.Context) error {
 			return s.CleanBatchSpecExecutionCacheEntries(ctx, maxSizeByte)
 		}),
 	)

--- a/enterprise/cmd/worker/internal/batches/janitor/changeset_detached_cleaner.go
+++ b/enterprise/cmd/worker/internal/batches/janitor/changeset_detached_cleaner.go
@@ -18,7 +18,7 @@ func NewChangesetDetachedCleaner(ctx context.Context, s *store.Store) goroutine.
 	return goroutine.NewPeriodicGoroutine(
 		ctx,
 		changesetCleanInterval,
-		goroutine.NewHandlerWithErrorMessage("cleaning detached changeset entries", func(ctx context.Context) error {
+		goroutine.NewHandlerWithErrorMessage("batchchanges.detached-cleaner", "cleaning detached changeset entries", func(ctx context.Context) error {
 			// get the configuration value when the handler runs to get the latest value
 			retention := conf.Get().BatchChangesChangesetsRetention
 			if len(retention) > 0 {

--- a/enterprise/cmd/worker/internal/batches/janitor/changeset_detached_cleaner.go
+++ b/enterprise/cmd/worker/internal/batches/janitor/changeset_detached_cleaner.go
@@ -17,8 +17,9 @@ const changesetCleanInterval = 24 * time.Hour
 func NewChangesetDetachedCleaner(ctx context.Context, s *store.Store) goroutine.BackgroundRoutine {
 	return goroutine.NewPeriodicGoroutine(
 		ctx,
+		"batchchanges.detached-cleaner", "cleaning detached changeset entries",
 		changesetCleanInterval,
-		goroutine.NewHandlerWithErrorMessage("batchchanges.detached-cleaner", "cleaning detached changeset entries", func(ctx context.Context) error {
+		goroutine.HandlerFunc(func(ctx context.Context) error {
 			// get the configuration value when the handler runs to get the latest value
 			retention := conf.Get().BatchChangesChangesetsRetention
 			if len(retention) > 0 {

--- a/enterprise/cmd/worker/internal/batches/janitor/spec_expire.go
+++ b/enterprise/cmd/worker/internal/batches/janitor/spec_expire.go
@@ -15,7 +15,7 @@ func NewSpecExpirer(ctx context.Context, bstore *store.Store) goroutine.Backgrou
 	return goroutine.NewPeriodicGoroutine(
 		ctx,
 		specExpireInteral,
-		goroutine.NewHandlerWithErrorMessage("expire batch changes specs", func(ctx context.Context) error {
+		goroutine.NewHandlerWithErrorMessage("batchchanges.spec-expirer", "expire batch changes specs", func(ctx context.Context) error {
 			// Delete all unattached changeset specs...
 			if err := bstore.DeleteUnattachedExpiredChangesetSpecs(ctx); err != nil {
 				return errors.Wrap(err, "DeleteExpiredChangesetSpecs")

--- a/enterprise/cmd/worker/internal/batches/janitor/spec_expire.go
+++ b/enterprise/cmd/worker/internal/batches/janitor/spec_expire.go
@@ -14,8 +14,9 @@ const specExpireInteral = 60 * time.Minute
 func NewSpecExpirer(ctx context.Context, bstore *store.Store) goroutine.BackgroundRoutine {
 	return goroutine.NewPeriodicGoroutine(
 		ctx,
+		"batchchanges.spec-expirer", "expire batch changes specs",
 		specExpireInteral,
-		goroutine.NewHandlerWithErrorMessage("batchchanges.spec-expirer", "expire batch changes specs", func(ctx context.Context) error {
+		goroutine.HandlerFunc(func(ctx context.Context) error {
 			// Delete all unattached changeset specs...
 			if err := bstore.DeleteUnattachedExpiredChangesetSpecs(ctx); err != nil {
 				return errors.Wrap(err, "DeleteExpiredChangesetSpecs")

--- a/enterprise/cmd/worker/internal/executorqueue/reporter.go
+++ b/enterprise/cmd/worker/internal/executorqueue/reporter.go
@@ -38,10 +38,14 @@ func initExternalMetricReporters[T workerutil.Record](queueName string, store st
 	}
 
 	ctx := context.Background()
-	return goroutine.NewPeriodicGoroutine(ctx, 5*time.Second, &externalEmitter[T]{
-		queueName:  queueName,
-		store:      store,
-		reporters:  reporters,
-		allocation: metricsConfig.Allocations[queueName],
-	}), nil
+	return goroutine.NewPeriodicGoroutine(ctx,
+		"executors.autoscaler-metrics",
+		"emits metrics to GCP/AWS for auto-scaling",
+		5*time.Second, &externalEmitter[T]{
+			queueName:  queueName,
+			store:      store,
+			reporters:  reporters,
+			allocation: metricsConfig.Allocations[queueName],
+		},
+	), nil
 }

--- a/enterprise/cmd/worker/internal/executors/janitor_job.go
+++ b/enterprise/cmd/worker/internal/executors/janitor_job.go
@@ -31,7 +31,7 @@ func (j *janitorJob) Routines(startupCtx context.Context, observationCtx *observ
 	}
 
 	routines := []goroutine.BackgroundRoutine{
-		goroutine.NewPeriodicGoroutine(context.Background(), janitorConfigInst.CleanupTaskInterval, goroutine.HandlerFunc(func(ctx context.Context) error {
+		goroutine.NewPeriodicGoroutine(context.Background(), janitorConfigInst.CleanupTaskInterval, goroutine.NewHandlerWithErrorMessage("executor-heartbeat-janitor", func(ctx context.Context) error {
 			return db.Executors().DeleteInactiveHeartbeats(ctx, janitorConfigInst.HeartbeatRecordsMaxAge)
 		})),
 	}

--- a/enterprise/cmd/worker/internal/executors/janitor_job.go
+++ b/enterprise/cmd/worker/internal/executors/janitor_job.go
@@ -33,8 +33,9 @@ func (j *janitorJob) Routines(startupCtx context.Context, observationCtx *observ
 	routines := []goroutine.BackgroundRoutine{
 		goroutine.NewPeriodicGoroutine(
 			context.Background(),
+			"executor.heartbeat-janitor", "clean up executor heartbeat records for presumed dead executors",
 			janitorConfigInst.CleanupTaskInterval,
-			goroutine.NewHandlerWithErrorMessage("executor.heartbeat-janitor", "clean up executor heartbeat records for presumed dead executors", func(ctx context.Context) error {
+			goroutine.HandlerFunc(func(ctx context.Context) error {
 				return db.Executors().DeleteInactiveHeartbeats(ctx, janitorConfigInst.HeartbeatRecordsMaxAge)
 			}),
 		),

--- a/enterprise/cmd/worker/internal/executors/janitor_job.go
+++ b/enterprise/cmd/worker/internal/executors/janitor_job.go
@@ -31,9 +31,13 @@ func (j *janitorJob) Routines(startupCtx context.Context, observationCtx *observ
 	}
 
 	routines := []goroutine.BackgroundRoutine{
-		goroutine.NewPeriodicGoroutine(context.Background(), janitorConfigInst.CleanupTaskInterval, goroutine.NewHandlerWithErrorMessage("executor-heartbeat-janitor", func(ctx context.Context) error {
-			return db.Executors().DeleteInactiveHeartbeats(ctx, janitorConfigInst.HeartbeatRecordsMaxAge)
-		})),
+		goroutine.NewPeriodicGoroutine(
+			context.Background(),
+			janitorConfigInst.CleanupTaskInterval,
+			goroutine.NewHandlerWithErrorMessage("executor.heartbeat-janitor", "clean up executor heartbeat records for presumed dead executors", func(ctx context.Context) error {
+				return db.Executors().DeleteInactiveHeartbeats(ctx, janitorConfigInst.HeartbeatRecordsMaxAge)
+			}),
+		),
 	}
 
 	return routines, nil

--- a/enterprise/cmd/worker/internal/telemetry/telemetry_job.go
+++ b/enterprise/cmd/worker/internal/telemetry/telemetry_job.go
@@ -81,7 +81,7 @@ func queueSizeMetricJob(db database.DB) goroutine.BackgroundRoutine {
 			Help:      "Currently configured maximum throughput per second.",
 		}),
 	}
-	return goroutine.NewPeriodicGoroutine(context.Background(), time.Minute*5, job)
+	return goroutine.NewPeriodicGoroutine(context.Background(), "analytics.event-log-export-metrics", "event logs export backlog metrics", time.Minute*5, job)
 }
 
 type queueSizeJob struct {
@@ -115,7 +115,7 @@ func newBackgroundTelemetryJob(logger log.Logger, db database.DB) goroutine.Back
 	observationCtx := observation.NewContext(log.NoOp())
 	handlerMetrics := newHandlerMetrics(observationCtx)
 	th := newTelemetryHandler(logger, db.EventLogs(), db.UserEmails(), db.GlobalState(), newBookmarkStore(db), sendEvents, handlerMetrics)
-	return goroutine.NewPeriodicGoroutineWithMetrics(context.Background(), JobCooldownDuration, th, handlerMetrics.handler)
+	return goroutine.NewPeriodicGoroutineWithMetrics(context.Background(), "analytics.telemetry-export", "event logs telemetry sender", JobCooldownDuration, th, handlerMetrics.handler)
 }
 
 type sendEventsCallbackFunc func(ctx context.Context, event []*database.Event, config topicConfig, metadata instanceMetadata) error

--- a/enterprise/internal/batches/syncer/syncer.go
+++ b/enterprise/internal/batches/syncer/syncer.go
@@ -82,7 +82,7 @@ func (s *SyncRegistry) Start() {
 	externalServiceSyncer := goroutine.NewPeriodicGoroutine(
 		s.ctx,
 		externalServiceSyncerInterval,
-		goroutine.NewHandlerWithErrorMessage("Batch Changes syncer external service sync", func(ctx context.Context) error {
+		goroutine.NewHandlerWithErrorMessage("batchchanges.codehost-syncer", "Batch Changes syncer external service sync", func(ctx context.Context) error {
 			return s.syncCodeHosts(ctx)
 		}),
 	)

--- a/enterprise/internal/batches/syncer/syncer.go
+++ b/enterprise/internal/batches/syncer/syncer.go
@@ -81,8 +81,9 @@ func (s *SyncRegistry) Start() {
 
 	externalServiceSyncer := goroutine.NewPeriodicGoroutine(
 		s.ctx,
+		"batchchanges.codehost-syncer", "Batch Changes syncer external service sync",
 		externalServiceSyncerInterval,
-		goroutine.NewHandlerWithErrorMessage("batchchanges.codehost-syncer", "Batch Changes syncer external service sync", func(ctx context.Context) error {
+		goroutine.HandlerFunc(func(ctx context.Context) error {
 			return s.syncCodeHosts(ctx)
 		}),
 	)

--- a/enterprise/internal/codeintel/autoindexing/internal/background/job_cleanup.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/job_cleanup.go
@@ -40,7 +40,7 @@ func NewJanitor(
 	config JanitorConfig,
 ) goroutine.BackgroundRoutine {
 	metrics := NewJanitorMetrics(observationCtx)
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.HandlerFunc(func(ctx context.Context) error {
+	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("autoindexing-janitor", func(ctx context.Context) error {
 		job := janitorJob{
 			store:           store,
 			gitserverClient: gitserverClient,

--- a/enterprise/internal/codeintel/autoindexing/internal/background/job_cleanup.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/job_cleanup.go
@@ -42,8 +42,9 @@ func NewJanitor(
 	metrics := NewJanitorMetrics(observationCtx)
 	return goroutine.NewPeriodicGoroutine(
 		context.Background(),
+		"codeintel.autoindexing-janitor", "cleanup autoindexing jobs for unknown repos, commits etc",
 		interval,
-		goroutine.NewHandlerWithErrorMessage("codeintel.autoindexing-janitor", "cleanup autoindexing jobs for unknown repos, commits etc ", func(ctx context.Context) error {
+		goroutine.HandlerFunc(func(ctx context.Context) error {
 			job := janitorJob{
 				store:           store,
 				gitserverClient: gitserverClient,

--- a/enterprise/internal/codeintel/autoindexing/internal/background/job_scheduler.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/job_scheduler.go
@@ -62,8 +62,9 @@ func NewScheduler(
 
 	return goroutine.NewPeriodicGoroutineWithMetrics(
 		context.Background(),
+		"codeintel.autoindexing-background-scheduler", "schedule autoindexing jobs in the background using defined or inferred configurations",
 		interval,
-		goroutine.NewHandlerWithErrorMessage("codeintel.autoindexing-background-scheduler", "schedule autoindexing jobs in the background using defined or inferred configurations", func(ctx context.Context) error {
+		goroutine.HandlerFunc(func(ctx context.Context) error {
 			return job.handleScheduler(ctx, config.RepositoryProcessDelay, config.RepositoryBatchSize, config.PolicyBatchSize, config.InferenceConcurrency)
 		}),
 		observationCtx.Operation(observation.Op{
@@ -194,8 +195,9 @@ func (b indexSchedulerJob) handleRepository(ctx context.Context, repositoryID, p
 func NewOnDemandScheduler(store store.Store, indexEnqueuer IndexEnqueuer, interval time.Duration, batchSize int) goroutine.BackgroundRoutine {
 	return goroutine.NewPeriodicGoroutine(
 		context.Background(),
+		"codeintel.autoindexing-ondemand-scheduler", "schedule autoindexing jobs for explicitly requested repo+revhash combinations",
 		interval,
-		goroutine.NewHandlerWithErrorMessage("codeintel.autoindexing-ondemand-scheduler", "schedule autoindexing jobs for explicitly requested repo+revhash combinations", func(ctx context.Context) error {
+		goroutine.HandlerFunc(func(ctx context.Context) error {
 			if !autoIndexingEnabled() {
 				return nil
 			}

--- a/enterprise/internal/codeintel/autoindexing/internal/background/job_scheduler.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/job_scheduler.go
@@ -60,19 +60,24 @@ func NewScheduler(
 		)
 	})
 
-	return goroutine.NewPeriodicGoroutineWithMetrics(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("autoindexing-background-scheduler", func(ctx context.Context) error {
-		return job.handleScheduler(ctx, config.RepositoryProcessDelay, config.RepositoryBatchSize, config.PolicyBatchSize, config.InferenceConcurrency)
-	}), observationCtx.Operation(observation.Op{
-		Name:              "codeintel.indexing.HandleIndexSchedule",
-		MetricLabelValues: []string{"HandleIndexSchedule"},
-		Metrics:           metrics,
-		ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
-			if errors.As(err, &inference.LimitError{}) {
-				return observation.EmitForDefault.Without(observation.EmitForMetrics)
-			}
-			return observation.EmitForDefault
-		},
-	}))
+	return goroutine.NewPeriodicGoroutineWithMetrics(
+		context.Background(),
+		interval,
+		goroutine.NewHandlerWithErrorMessage("codeintel.autoindexing-background-scheduler", "schedule autoindexing jobs in the background using defined or inferred configurations", func(ctx context.Context) error {
+			return job.handleScheduler(ctx, config.RepositoryProcessDelay, config.RepositoryBatchSize, config.PolicyBatchSize, config.InferenceConcurrency)
+		}),
+		observationCtx.Operation(observation.Op{
+			Name:              "codeintel.indexing.HandleIndexSchedule",
+			MetricLabelValues: []string{"HandleIndexSchedule"},
+			Metrics:           metrics,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				if errors.As(err, &inference.LimitError{}) {
+					return observation.EmitForDefault.Without(observation.EmitForMetrics)
+				}
+				return observation.EmitForDefault
+			},
+		}),
+	)
 }
 
 func (b indexSchedulerJob) handleScheduler(
@@ -187,31 +192,35 @@ func (b indexSchedulerJob) handleRepository(ctx context.Context, repositoryID, p
 }
 
 func NewOnDemandScheduler(store store.Store, indexEnqueuer IndexEnqueuer, interval time.Duration, batchSize int) goroutine.BackgroundRoutine {
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("autoindexing-ondemand-scheduler", func(ctx context.Context) error {
-		if !autoIndexingEnabled() {
-			return nil
-		}
+	return goroutine.NewPeriodicGoroutine(
+		context.Background(),
+		interval,
+		goroutine.NewHandlerWithErrorMessage("codeintel.autoindexing-ondemand-scheduler", "schedule autoindexing jobs for explicitly requested repo+revhash combinations", func(ctx context.Context) error {
+			if !autoIndexingEnabled() {
+				return nil
+			}
 
-		tx, err := store.Transact(ctx)
-		if err != nil {
-			return err
-		}
-		defer func() { err = tx.Done(err) }()
+			tx, err := store.Transact(ctx)
+			if err != nil {
+				return err
+			}
+			defer func() { err = tx.Done(err) }()
 
-		repoRevs, err := tx.GetQueuedRepoRev(ctx, batchSize)
-		if err != nil {
-			return err
-		}
-
-		ids := make([]int, 0, len(repoRevs))
-		for _, repoRev := range repoRevs {
-			if _, err := indexEnqueuer.QueueIndexes(ctx, repoRev.RepositoryID, repoRev.Rev, "", false, false); err != nil {
+			repoRevs, err := tx.GetQueuedRepoRev(ctx, batchSize)
+			if err != nil {
 				return err
 			}
 
-			ids = append(ids, repoRev.ID)
-		}
+			ids := make([]int, 0, len(repoRevs))
+			for _, repoRev := range repoRevs {
+				if _, err := indexEnqueuer.QueueIndexes(ctx, repoRev.RepositoryID, repoRev.Rev, "", false, false); err != nil {
+					return err
+				}
 
-		return tx.MarkRepoRevsAsProcessed(ctx, ids)
-	}))
+				ids = append(ids, repoRev.ID)
+			}
+
+			return tx.MarkRepoRevsAsProcessed(ctx, ids)
+		}),
+	)
 }

--- a/enterprise/internal/codeintel/autoindexing/internal/background/job_scheduler.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/job_scheduler.go
@@ -60,7 +60,7 @@ func NewScheduler(
 		)
 	})
 
-	return goroutine.NewPeriodicGoroutineWithMetrics(context.Background(), interval, goroutine.HandlerFunc(func(ctx context.Context) error {
+	return goroutine.NewPeriodicGoroutineWithMetrics(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("autoindexing-background-scheduler", func(ctx context.Context) error {
 		return job.handleScheduler(ctx, config.RepositoryProcessDelay, config.RepositoryBatchSize, config.PolicyBatchSize, config.InferenceConcurrency)
 	}), observationCtx.Operation(observation.Op{
 		Name:              "codeintel.indexing.HandleIndexSchedule",
@@ -187,7 +187,7 @@ func (b indexSchedulerJob) handleRepository(ctx context.Context, repositoryID, p
 }
 
 func NewOnDemandScheduler(store store.Store, indexEnqueuer IndexEnqueuer, interval time.Duration, batchSize int) goroutine.BackgroundRoutine {
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.HandlerFunc(func(ctx context.Context) error {
+	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("autoindexing-ondemand-scheduler", func(ctx context.Context) error {
 		if !autoIndexingEnabled() {
 			return nil
 		}

--- a/enterprise/internal/codeintel/policies/internal/background/repomatcher.go
+++ b/enterprise/internal/codeintel/policies/internal/background/repomatcher.go
@@ -18,8 +18,9 @@ func NewRepositoryMatcher(store store.Store, observationCtx *observation.Context
 
 	return goroutine.NewPeriodicGoroutine(
 		context.Background(),
+		"codeintel.policies-matcher", "match repositories to autoindexing+retention policies",
 		interval,
-		goroutine.NewHandlerWithErrorMessage("codeintel.policies-matcher", "match repositories to autoindexing+retention policies", func(ctx context.Context) error {
+		goroutine.HandlerFunc(func(ctx context.Context) error {
 			return repoMatcher.handleRepositoryMatcherBatch(ctx, configurationPolicyMembershipBatchSize, metrics)
 		}),
 	)

--- a/enterprise/internal/codeintel/policies/internal/background/repomatcher.go
+++ b/enterprise/internal/codeintel/policies/internal/background/repomatcher.go
@@ -16,9 +16,13 @@ func NewRepositoryMatcher(store store.Store, observationCtx *observation.Context
 	}
 	metrics := newMetrics(observationCtx)
 
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("codeintel-policies-matcher", func(ctx context.Context) error {
-		return repoMatcher.handleRepositoryMatcherBatch(ctx, configurationPolicyMembershipBatchSize, metrics)
-	}))
+	return goroutine.NewPeriodicGoroutine(
+		context.Background(),
+		interval,
+		goroutine.NewHandlerWithErrorMessage("codeintel.policies-matcher", "match repositories to autoindexing+retention policies", func(ctx context.Context) error {
+			return repoMatcher.handleRepositoryMatcherBatch(ctx, configurationPolicyMembershipBatchSize, metrics)
+		}),
+	)
 }
 
 type repoMatcher struct {

--- a/enterprise/internal/codeintel/policies/internal/background/repomatcher.go
+++ b/enterprise/internal/codeintel/policies/internal/background/repomatcher.go
@@ -16,7 +16,7 @@ func NewRepositoryMatcher(store store.Store, observationCtx *observation.Context
 	}
 	metrics := newMetrics(observationCtx)
 
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.HandlerFunc(func(ctx context.Context) error {
+	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("codeintel-policies-matcher", func(ctx context.Context) error {
 		return repoMatcher.handleRepositoryMatcherBatch(ctx, configurationPolicyMembershipBatchSize, metrics)
 	}))
 }

--- a/enterprise/internal/codeintel/ranking/internal/background/indexer.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/indexer.go
@@ -23,9 +23,13 @@ func NewRepositoryIndexer(
 		symbolsClient:   symbolsClient,
 	}
 
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("pagerank-repo-indexer", func(ctx context.Context) error {
-		return indexer.indexRepositories(ctx)
-	}))
+	return goroutine.NewPeriodicGoroutine(
+		context.Background(),
+		interval,
+		goroutine.NewHandlerWithErrorMessage("pagerank.repo-indexer", "builds page-rank indexes for repositories", func(ctx context.Context) error {
+			return indexer.indexRepositories(ctx)
+		}),
+	)
 }
 
 // We currently disable this until we find a better way to calculate a graph locally

--- a/enterprise/internal/codeintel/ranking/internal/background/indexer.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/indexer.go
@@ -25,8 +25,9 @@ func NewRepositoryIndexer(
 
 	return goroutine.NewPeriodicGoroutine(
 		context.Background(),
+		"pagerank.repo-indexer", "builds page-rank indexes for repositories",
 		interval,
-		goroutine.NewHandlerWithErrorMessage("pagerank.repo-indexer", "builds page-rank indexes for repositories", func(ctx context.Context) error {
+		goroutine.HandlerFunc(func(ctx context.Context) error {
 			return indexer.indexRepositories(ctx)
 		}),
 	)

--- a/enterprise/internal/codeintel/ranking/internal/background/indexer.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/indexer.go
@@ -23,7 +23,7 @@ func NewRepositoryIndexer(
 		symbolsClient:   symbolsClient,
 	}
 
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.HandlerFunc(func(ctx context.Context) error {
+	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("pagerank-repo-indexer", func(ctx context.Context) error {
 		return indexer.indexRepositories(ctx)
 	}))
 }

--- a/enterprise/internal/codeintel/ranking/internal/background/loader.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/loader.go
@@ -47,9 +47,13 @@ func NewRankLoader(
 		metrics:       newLoaderMetrics(observationCtx),
 	}
 
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("pagerank-loader", func(ctx context.Context) error {
-		return loader.loadRanks(ctx, config)
-	}))
+	return goroutine.NewPeriodicGoroutine(
+		context.Background(),
+		interval,
+		goroutine.NewHandlerWithErrorMessage("pagerank.loader", "loads page-rank data into postgres auxiliary table from object store", func(ctx context.Context) error {
+			return loader.loadRanks(ctx, config)
+		}),
+	)
 }
 
 const (

--- a/enterprise/internal/codeintel/ranking/internal/background/loader.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/loader.go
@@ -47,7 +47,7 @@ func NewRankLoader(
 		metrics:       newLoaderMetrics(observationCtx),
 	}
 
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.HandlerFunc(func(ctx context.Context) error {
+	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("pagerank-loader", func(ctx context.Context) error {
 		return loader.loadRanks(ctx, config)
 	}))
 }

--- a/enterprise/internal/codeintel/ranking/internal/background/loader.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/loader.go
@@ -49,8 +49,9 @@ func NewRankLoader(
 
 	return goroutine.NewPeriodicGoroutine(
 		context.Background(),
+		"pagerank.loader", "loads page-rank data into postgres auxiliary table from object store",
 		interval,
-		goroutine.NewHandlerWithErrorMessage("pagerank.loader", "loads page-rank data into postgres auxiliary table from object store", func(ctx context.Context) error {
+		goroutine.HandlerFunc(func(ctx context.Context) error {
 			return loader.loadRanks(ctx, config)
 		}),
 	)

--- a/enterprise/internal/codeintel/ranking/internal/background/merger.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/merger.go
@@ -44,9 +44,13 @@ func NewRankMerger(
 		metrics:       newMergerMetrics(observationCtx),
 	}
 
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("pagerank-merger", func(ctx context.Context) error {
-		return merger.mergeRanks(ctx, config)
-	}))
+	return goroutine.NewPeriodicGoroutine(
+		context.Background(),
+		interval,
+		goroutine.NewHandlerWithErrorMessage("pagerank.merger", "reconciles page-rank data from auxiliary table", func(ctx context.Context) error {
+			return merger.mergeRanks(ctx, config)
+		}),
+	)
 }
 
 func (m *rankMerger) mergeRanks(ctx context.Context, config RankMergerConfig) (err error) {

--- a/enterprise/internal/codeintel/ranking/internal/background/merger.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/merger.go
@@ -46,8 +46,9 @@ func NewRankMerger(
 
 	return goroutine.NewPeriodicGoroutine(
 		context.Background(),
+		"pagerank.merger", "reconciles page-rank data from auxiliary table",
 		interval,
-		goroutine.NewHandlerWithErrorMessage("pagerank.merger", "reconciles page-rank data from auxiliary table", func(ctx context.Context) error {
+		goroutine.HandlerFunc(func(ctx context.Context) error {
 			return merger.mergeRanks(ctx, config)
 		}),
 	)

--- a/enterprise/internal/codeintel/ranking/internal/background/merger.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/merger.go
@@ -44,7 +44,7 @@ func NewRankMerger(
 		metrics:       newMergerMetrics(observationCtx),
 	}
 
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.HandlerFunc(func(ctx context.Context) error {
+	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("pagerank-merger", func(ctx context.Context) error {
 		return merger.mergeRanks(ctx, config)
 	}))
 }

--- a/enterprise/internal/codeintel/uploads/internal/background/job_backfill.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_backfill.go
@@ -17,8 +17,9 @@ func NewCommittedAtBackfiller(store store.Store, gitserverClient GitserverClient
 	}
 	return goroutine.NewPeriodicGoroutine(
 		context.Background(),
+		"codeintel.committed-at-backfiller", "backfills the committed_at column for code-intel uploads",
 		interval,
-		goroutine.NewHandlerWithErrorMessage("codeintel.committed-at-backfiller", "backfills the committed_at column for code-intel uploads", func(ctx context.Context) error {
+		goroutine.HandlerFunc(func(ctx context.Context) error {
 			return backfiller.BackfillCommittedAtBatch(ctx, batchSize)
 		}),
 	)

--- a/enterprise/internal/codeintel/uploads/internal/background/job_backfill.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_backfill.go
@@ -15,9 +15,13 @@ func NewCommittedAtBackfiller(store store.Store, gitserverClient GitserverClient
 		gitserverClient: gitserverClient,
 		batchSize:       batchSize,
 	}
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("committed-at-backfiller", func(ctx context.Context) error {
-		return backfiller.BackfillCommittedAtBatch(ctx, batchSize)
-	}))
+	return goroutine.NewPeriodicGoroutine(
+		context.Background(),
+		interval,
+		goroutine.NewHandlerWithErrorMessage("codeintel.committed-at-backfiller", "backfills the committed_at column for code-intel uploads", func(ctx context.Context) error {
+			return backfiller.BackfillCommittedAtBatch(ctx, batchSize)
+		}),
+	)
 }
 
 type backfiller struct {

--- a/enterprise/internal/codeintel/uploads/internal/background/job_backfill.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_backfill.go
@@ -13,13 +13,15 @@ func NewCommittedAtBackfiller(store store.Store, gitserverClient GitserverClient
 	backfiller := &backfiller{
 		store:           store,
 		gitserverClient: gitserverClient,
+		batchSize:       batchSize,
 	}
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.HandlerFunc(func(ctx context.Context) error {
+	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("committed-at-backfiller", func(ctx context.Context) error {
 		return backfiller.BackfillCommittedAtBatch(ctx, batchSize)
 	}))
 }
 
 type backfiller struct {
+	batchSize       int
 	store           store.Store
 	gitserverClient GitserverClient
 }

--- a/enterprise/internal/codeintel/uploads/internal/background/job_cleanup.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_cleanup.go
@@ -52,7 +52,7 @@ func NewJanitor(
 		clock:           clock,
 		gitserverClient: gitserverClient,
 	}
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.HandlerFunc(func(ctx context.Context) error {
+	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("upload-janitor", func(ctx context.Context) error {
 		return j.handleCleanup(ctx, config)
 	}))
 }

--- a/enterprise/internal/codeintel/uploads/internal/background/job_cleanup.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_cleanup.go
@@ -54,8 +54,9 @@ func NewJanitor(
 	}
 	return goroutine.NewPeriodicGoroutine(
 		context.Background(),
+		"codeintel.upload-janitor", "cleans up various code intel upload and metadata",
 		interval,
-		goroutine.NewHandlerWithErrorMessage("codeintel.upload-janitor", "cleans up various code intel upload and metadata", func(ctx context.Context) error {
+		goroutine.HandlerFunc(func(ctx context.Context) error {
 			return j.handleCleanup(ctx, config)
 		}),
 	)

--- a/enterprise/internal/codeintel/uploads/internal/background/job_cleanup.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_cleanup.go
@@ -52,9 +52,13 @@ func NewJanitor(
 		clock:           clock,
 		gitserverClient: gitserverClient,
 	}
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("upload-janitor", func(ctx context.Context) error {
-		return j.handleCleanup(ctx, config)
-	}))
+	return goroutine.NewPeriodicGoroutine(
+		context.Background(),
+		interval,
+		goroutine.NewHandlerWithErrorMessage("codeintel.upload-janitor", "cleans up various code intel upload and metadata", func(ctx context.Context) error {
+			return j.handleCleanup(ctx, config)
+		}),
+	)
 }
 
 func (b janitorJob) handleCleanup(ctx context.Context, cfg JanitorConfig) (errs error) {

--- a/enterprise/internal/codeintel/uploads/internal/background/job_commitgraph.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_commitgraph.go
@@ -25,9 +25,13 @@ func NewCommitGraphUpdater(
 		gitserverClient: gitserverClient,
 	}
 
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("commitgraph-updater", func(ctx context.Context) error {
-		return updater.UpdateAllDirtyCommitGraphs(ctx, maxAgeForNonStaleBranches, maxAgeForNonStaleTags)
-	}))
+	return goroutine.NewPeriodicGoroutine(
+		context.Background(),
+		interval,
+		goroutine.NewHandlerWithErrorMessage("codeintel.commitgraph-updater", "", func(ctx context.Context) error {
+			return updater.UpdateAllDirtyCommitGraphs(ctx, maxAgeForNonStaleBranches, maxAgeForNonStaleTags)
+		}),
+	)
 }
 
 type commitGraphUpdater struct {

--- a/enterprise/internal/codeintel/uploads/internal/background/job_commitgraph.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_commitgraph.go
@@ -27,8 +27,9 @@ func NewCommitGraphUpdater(
 
 	return goroutine.NewPeriodicGoroutine(
 		context.Background(),
+		"codeintel.commitgraph-updater", "updates the visibility commit graph for dirty repos",
 		interval,
-		goroutine.NewHandlerWithErrorMessage("codeintel.commitgraph-updater", "", func(ctx context.Context) error {
+		goroutine.HandlerFunc(func(ctx context.Context) error {
 			return updater.UpdateAllDirtyCommitGraphs(ctx, maxAgeForNonStaleBranches, maxAgeForNonStaleTags)
 		}),
 	)

--- a/enterprise/internal/codeintel/uploads/internal/background/job_expirer.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_expirer.go
@@ -37,9 +37,13 @@ func NewUploadExpirer(
 		policySvc:     policySvc,
 		policyMatcher: policyMatcher,
 	}
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("upload-expirer", func(ctx context.Context) error {
-		return expirer.HandleExpiredUploadsBatch(ctx, NewExpirationMetrics(observationCtx), config)
-	}))
+	return goroutine.NewPeriodicGoroutine(
+		context.Background(),
+		interval,
+		goroutine.NewHandlerWithErrorMessage("codeintel.upload-expirer", "marks uploads as expired based on retention policies", func(ctx context.Context) error {
+			return expirer.HandleExpiredUploadsBatch(ctx, NewExpirationMetrics(observationCtx), config)
+		}),
+	)
 }
 
 type expirer struct {

--- a/enterprise/internal/codeintel/uploads/internal/background/job_expirer.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_expirer.go
@@ -37,7 +37,7 @@ func NewUploadExpirer(
 		policySvc:     policySvc,
 		policyMatcher: policyMatcher,
 	}
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.HandlerFunc(func(ctx context.Context) error {
+	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("upload-expirer", func(ctx context.Context) error {
 		return expirer.HandleExpiredUploadsBatch(ctx, NewExpirationMetrics(observationCtx), config)
 	}))
 }

--- a/enterprise/internal/codeintel/uploads/internal/background/job_expirer.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_expirer.go
@@ -39,8 +39,9 @@ func NewUploadExpirer(
 	}
 	return goroutine.NewPeriodicGoroutine(
 		context.Background(),
+		"codeintel.upload-expirer", "marks uploads as expired based on retention policies",
 		interval,
-		goroutine.NewHandlerWithErrorMessage("codeintel.upload-expirer", "marks uploads as expired based on retention policies", func(ctx context.Context) error {
+		goroutine.HandlerFunc(func(ctx context.Context) error {
 			return expirer.HandleExpiredUploadsBatch(ctx, NewExpirationMetrics(observationCtx), config)
 		}),
 	)

--- a/enterprise/internal/codeintel/uploads/internal/background/job_graph_exporter.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_graph_exporter.go
@@ -14,15 +14,18 @@ func NewRankingGraphExporter(
 	numRankingRoutines int,
 	interval time.Duration,
 ) goroutine.BackgroundRoutine {
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("pagerank-graph-exporter", func(ctx context.Context) error {
-		if err := uploadsService.SerializeRankingGraph(ctx, numRankingRoutines); err != nil {
-			return err
-		}
+	return goroutine.NewPeriodicGoroutine(
+		context.Background(),
+		interval,
+		goroutine.NewHandlerWithErrorMessage("pagerank.graph-exporter", "exports new and purges old code-intel data as CSV", func(ctx context.Context) error {
+			if err := uploadsService.SerializeRankingGraph(ctx, numRankingRoutines); err != nil {
+				return err
+			}
 
-		if err := uploadsService.VacuumRankingGraph(ctx); err != nil {
-			return err
-		}
+			if err := uploadsService.VacuumRankingGraph(ctx); err != nil {
+				return err
+			}
 
-		return nil
-	}))
+			return nil
+		}))
 }

--- a/enterprise/internal/codeintel/uploads/internal/background/job_graph_exporter.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_graph_exporter.go
@@ -14,7 +14,7 @@ func NewRankingGraphExporter(
 	numRankingRoutines int,
 	interval time.Duration,
 ) goroutine.BackgroundRoutine {
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.HandlerFunc(func(ctx context.Context) error {
+	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("pagerank-graph-exporter", func(ctx context.Context) error {
 		if err := uploadsService.SerializeRankingGraph(ctx, numRankingRoutines); err != nil {
 			return err
 		}

--- a/enterprise/internal/codeintel/uploads/internal/background/job_graph_exporter.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_graph_exporter.go
@@ -16,8 +16,9 @@ func NewRankingGraphExporter(
 ) goroutine.BackgroundRoutine {
 	return goroutine.NewPeriodicGoroutine(
 		context.Background(),
+		"pagerank.graph-exporter", "exports new and purges old code-intel data as CSV",
 		interval,
-		goroutine.NewHandlerWithErrorMessage("pagerank.graph-exporter", "exports new and purges old code-intel data as CSV", func(ctx context.Context) error {
+		goroutine.HandlerFunc(func(ctx context.Context) error {
 			if err := uploadsService.SerializeRankingGraph(ctx, numRankingRoutines); err != nil {
 				return err
 			}

--- a/enterprise/internal/codeintel/uploads/internal/background/job_reconciler.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_reconciler.go
@@ -29,7 +29,7 @@ func NewReconciler(
 		operations: newOperations(observationCtx),
 	}
 
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.HandlerFunc(func(ctx context.Context) error {
+	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("codeintel-reconciler", func(ctx context.Context) error {
 		return job.handleReconcile(ctx, batchSize)
 	}))
 }

--- a/enterprise/internal/codeintel/uploads/internal/background/job_reconciler.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_reconciler.go
@@ -31,8 +31,9 @@ func NewReconciler(
 
 	return goroutine.NewPeriodicGoroutine(
 		context.Background(),
+		"codeintel.reconciler", "reconciles code-intel data drift",
 		interval,
-		goroutine.NewHandlerWithErrorMessage("codeintel.reconciler", "reconciles code-intel data drift", func(ctx context.Context) error {
+		goroutine.HandlerFunc(func(ctx context.Context) error {
 			return job.handleReconcile(ctx, batchSize)
 		}))
 }

--- a/enterprise/internal/codeintel/uploads/internal/background/job_reconciler.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_reconciler.go
@@ -29,9 +29,12 @@ func NewReconciler(
 		operations: newOperations(observationCtx),
 	}
 
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("codeintel-reconciler", func(ctx context.Context) error {
-		return job.handleReconcile(ctx, batchSize)
-	}))
+	return goroutine.NewPeriodicGoroutine(
+		context.Background(),
+		interval,
+		goroutine.NewHandlerWithErrorMessage("codeintel.reconciler", "reconciles code-intel data drift", func(ctx context.Context) error {
+			return job.handleReconcile(ctx, batchSize)
+		}))
 }
 
 func (j reconcilerJob) handleReconcile(ctx context.Context, batchSize int) (err error) {

--- a/enterprise/internal/codeintel/uploads/ranking.go
+++ b/enterprise/internal/codeintel/uploads/ranking.go
@@ -19,10 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/group"
 )
 
-func (s *Service) SerializeRankingGraph(
-	ctx context.Context,
-	numRankingRoutines int,
-) error {
+func (s *Service) SerializeRankingGraph(ctx context.Context, numRankingRoutines int) error {
 	if s.rankingBucket == nil {
 		return nil
 	}
@@ -75,9 +72,7 @@ func (s *Service) SerializeRankingGraph(
 	return nil
 }
 
-func (s *Service) VacuumRankingGraph(
-	ctx context.Context,
-) error {
+func (s *Service) VacuumRankingGraph(ctx context.Context) error {
 	if s.rankingBucket == nil {
 		return nil
 	}
@@ -156,7 +151,6 @@ func (s *Service) serializeAndPersistRankingGraphForUpload(
 		}
 
 		if n, err := io.Copy(ow, strings.NewReader(fmt.Sprintf(format, args...))); err != nil {
-
 			return err
 		} else {
 			ow.written += n

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -47,7 +47,7 @@ func newTriggerQueryRunner(ctx context.Context, observationCtx *observation.Cont
 
 func newTriggerQueryEnqueuer(ctx context.Context, store edb.CodeMonitorStore) goroutine.BackgroundRoutine {
 	enqueueActive := goroutine.NewHandlerWithErrorMessage(
-		"code_monitors_trigger_query_enqueuer",
+		"code_monitors.trigger_query_enqueuer", "enqueues code monitor trigger query jobs",
 		func(ctx context.Context) error {
 			_, err := store.EnqueueQueryTriggerJobs(ctx)
 			return err
@@ -72,7 +72,7 @@ func newTriggerQueryResetter(_ context.Context, observationCtx *observation.Cont
 
 func newTriggerJobsLogDeleter(ctx context.Context, store edb.CodeMonitorStore) goroutine.BackgroundRoutine {
 	deleteLogs := goroutine.NewHandlerWithErrorMessage(
-		"code_monitors_trigger_jobs_log_deleter",
+		"code_monitors.trigger_jobs_log_deleter", "deletes code job logs from code monitor triggers",
 		func(ctx context.Context) error {
 			return store.DeleteOldTriggerJobs(ctx, eventRetentionInDays)
 		})

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -46,13 +46,16 @@ func newTriggerQueryRunner(ctx context.Context, observationCtx *observation.Cont
 }
 
 func newTriggerQueryEnqueuer(ctx context.Context, store edb.CodeMonitorStore) goroutine.BackgroundRoutine {
-	enqueueActive := goroutine.NewHandlerWithErrorMessage(
-		"code_monitors.trigger_query_enqueuer", "enqueues code monitor trigger query jobs",
+	enqueueActive := goroutine.HandlerFunc(
+
 		func(ctx context.Context) error {
 			_, err := store.EnqueueQueryTriggerJobs(ctx)
 			return err
 		})
-	return goroutine.NewPeriodicGoroutine(ctx, 1*time.Minute, enqueueActive)
+	return goroutine.NewPeriodicGoroutine(
+		ctx, "code_monitors.trigger_query_enqueuer", "enqueues code monitor trigger query jobs",
+		1*time.Minute, enqueueActive,
+	)
 }
 
 func newTriggerQueryResetter(_ context.Context, observationCtx *observation.Context, s edb.CodeMonitorStore, metrics codeMonitorsMetrics) *dbworker.Resetter[*edb.TriggerJob] {
@@ -71,12 +74,11 @@ func newTriggerQueryResetter(_ context.Context, observationCtx *observation.Cont
 }
 
 func newTriggerJobsLogDeleter(ctx context.Context, store edb.CodeMonitorStore) goroutine.BackgroundRoutine {
-	deleteLogs := goroutine.NewHandlerWithErrorMessage(
-		"code_monitors.trigger_jobs_log_deleter", "deletes code job logs from code monitor triggers",
+	deleteLogs := goroutine.HandlerFunc(
 		func(ctx context.Context) error {
 			return store.DeleteOldTriggerJobs(ctx, eventRetentionInDays)
 		})
-	return goroutine.NewPeriodicGoroutine(ctx, 60*time.Minute, deleteLogs)
+	return goroutine.NewPeriodicGoroutine(ctx, "code_monitors.trigger_jobs_log_deleter", "deletes code job logs from code monitor triggers", 60*time.Minute, deleteLogs)
 }
 
 func newActionRunner(ctx context.Context, observationCtx *observation.Context, s edb.CodeMonitorStore, metrics codeMonitorsMetrics) *workerutil.Worker[*edb.ActionJob] {

--- a/enterprise/internal/insights/background/backfill_completed_check.go
+++ b/enterprise/internal/insights/background/backfill_completed_check.go
@@ -20,7 +20,7 @@ func NewBackfillCompletedCheckJob(ctx context.Context, postgres database.DB, ins
 	interval := time.Hour * 2
 
 	return goroutine.NewPeriodicGoroutine(ctx, interval,
-		goroutine.NewHandlerWithErrorMessage("insights_backill_completed_check", func(ctx context.Context) (err error) {
+		goroutine.NewHandlerWithErrorMessage("insights.backill_completed_check", "sets timestamps for when a series' backfilled operation has completed", func(ctx context.Context) (err error) {
 			return checkBackfillCompleted(ctx, postgres, insightsdb)
 		}))
 }

--- a/enterprise/internal/insights/background/backfill_completed_check.go
+++ b/enterprise/internal/insights/background/backfill_completed_check.go
@@ -19,10 +19,14 @@ import (
 func NewBackfillCompletedCheckJob(ctx context.Context, postgres database.DB, insightsdb edb.InsightsDB) goroutine.BackgroundRoutine {
 	interval := time.Hour * 2
 
-	return goroutine.NewPeriodicGoroutine(ctx, interval,
-		goroutine.NewHandlerWithErrorMessage("insights.backill_completed_check", "sets timestamps for when a series' backfilled operation has completed", func(ctx context.Context) (err error) {
+	return goroutine.NewPeriodicGoroutine(
+		ctx,
+		"insights.backill_completed_check", "sets timestamps for when a series' backfilled operation has completed",
+		interval,
+		goroutine.HandlerFunc(func(ctx context.Context) (err error) {
 			return checkBackfillCompleted(ctx, postgres, insightsdb)
-		}))
+		}),
+	)
 }
 
 func checkBackfillCompleted(ctx context.Context, postgres database.DB, insightsdb edb.InsightsDB) (err error) {

--- a/enterprise/internal/insights/background/data_prune.go
+++ b/enterprise/internal/insights/background/data_prune.go
@@ -21,7 +21,7 @@ func NewInsightsDataPrunerJob(ctx context.Context, postgres database.DB, insight
 	logger := log.Scoped("InsightsDataPrunerJob", "")
 
 	return goroutine.NewPeriodicGoroutine(ctx, interval,
-		goroutine.NewHandlerWithErrorMessage("insights_data_prune", func(ctx context.Context) (err error) {
+		goroutine.NewHandlerWithErrorMessage("insights.data_prune", "deletes series that have been marked as 'deleted'", func(ctx context.Context) (err error) {
 			return performPurge(ctx, postgres, insightsdb, logger, time.Now().Add(interval))
 		}))
 }

--- a/enterprise/internal/insights/background/data_prune.go
+++ b/enterprise/internal/insights/background/data_prune.go
@@ -20,8 +20,9 @@ func NewInsightsDataPrunerJob(ctx context.Context, postgres database.DB, insight
 	interval := time.Minute * 60
 	logger := log.Scoped("InsightsDataPrunerJob", "")
 
-	return goroutine.NewPeriodicGoroutine(ctx, interval,
-		goroutine.NewHandlerWithErrorMessage("insights.data_prune", "deletes series that have been marked as 'deleted'", func(ctx context.Context) (err error) {
+	return goroutine.NewPeriodicGoroutine(ctx,
+		"insights.data_prune", "deletes series that have been marked as 'deleted'",
+		interval, goroutine.HandlerFunc(func(ctx context.Context) (err error) {
 			return performPurge(ctx, postgres, insightsdb, logger, time.Now().Add(interval))
 		}))
 }

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -104,7 +104,7 @@ func newInsightHistoricalEnqueuer(ctx context.Context, observationCtx *observati
 
 	// We specify 30s here, so insights are queued regularly for processing. The queue itself is rate limited.
 	return goroutine.NewPeriodicGoroutineWithMetrics(ctx, 30*time.Second, goroutine.NewHandlerWithErrorMessage(
-		"insights_historical_enqueuer",
+		"insights.historical_enqueuer", "enqueues jobs to build series on historical data",
 		enq.Handler,
 	), operation)
 }

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -103,10 +103,9 @@ func newInsightHistoricalEnqueuer(ctx context.Context, observationCtx *observati
 	enq.featureFlagStore = ffs
 
 	// We specify 30s here, so insights are queued regularly for processing. The queue itself is rate limited.
-	return goroutine.NewPeriodicGoroutineWithMetrics(ctx, 30*time.Second, goroutine.NewHandlerWithErrorMessage(
-		"insights.historical_enqueuer", "enqueues jobs to build series on historical data",
-		enq.Handler,
-	), operation)
+	return goroutine.NewPeriodicGoroutineWithMetrics(ctx, "insights.historical_enqueuer", "enqueues jobs to build series on historical data",
+		30*time.Second, goroutine.HandlerFunc(enq.Handler), operation,
+	)
 }
 
 // func NewRepoScopedBackfiller(ctx context.Context, workerBaseStore *basestore.Store, dataSeriesStore store.DataSeriesStore, insightsStore *store.Store, iterator discovery.RepoIterator) error {

--- a/enterprise/internal/insights/background/insight_enqueuer.go
+++ b/enterprise/internal/insights/background/insight_enqueuer.go
@@ -40,7 +40,7 @@ func newInsightEnqueuer(ctx context.Context, observationCtx *observation.Context
 	// See also https://github.com/sourcegraph/sourcegraph/pull/17227#issuecomment-779515187 for some very rough
 	// data retention / scale concerns.
 	return goroutine.NewPeriodicGoroutineWithMetrics(ctx, 1*time.Hour, goroutine.NewHandlerWithErrorMessage(
-		"insights_enqueuer",
+		"insights.enqueuer", "enqueues query runner and webhook runner jobs",
 		func(ctx context.Context) error {
 			ie := NewInsightEnqueuer(time.Now, workerBaseStore)
 

--- a/enterprise/internal/insights/background/insight_enqueuer.go
+++ b/enterprise/internal/insights/background/insight_enqueuer.go
@@ -40,7 +40,7 @@ func newInsightEnqueuer(ctx context.Context, observationCtx *observation.Context
 	// See also https://github.com/sourcegraph/sourcegraph/pull/17227#issuecomment-779515187 for some very rough
 	// data retention / scale concerns.
 	return goroutine.NewPeriodicGoroutineWithMetrics(ctx, 1*time.Hour, goroutine.NewHandlerWithErrorMessage(
-		"insights.enqueuer", "enqueues query runner and webhook runner jobs",
+		"insights.enqueuer", "enqueues snapshot and current recording query jobs",
 		func(ctx context.Context) error {
 			ie := NewInsightEnqueuer(time.Now, workerBaseStore)
 

--- a/enterprise/internal/insights/background/insight_enqueuer.go
+++ b/enterprise/internal/insights/background/insight_enqueuer.go
@@ -39,14 +39,16 @@ func newInsightEnqueuer(ctx context.Context, observationCtx *observation.Context
 	//
 	// See also https://github.com/sourcegraph/sourcegraph/pull/17227#issuecomment-779515187 for some very rough
 	// data retention / scale concerns.
-	return goroutine.NewPeriodicGoroutineWithMetrics(ctx, 1*time.Hour, goroutine.NewHandlerWithErrorMessage(
-		"insights.enqueuer", "enqueues snapshot and current recording query jobs",
-		func(ctx context.Context) error {
-			ie := NewInsightEnqueuer(time.Now, workerBaseStore)
+	return goroutine.NewPeriodicGoroutineWithMetrics(
+		ctx, "insights.enqueuer", "enqueues snapshot and current recording query jobs",
+		1*time.Hour, goroutine.HandlerFunc(
+			func(ctx context.Context) error {
+				ie := NewInsightEnqueuer(time.Now, workerBaseStore)
 
-			return ie.discoverAndEnqueueInsights(ctx, insightStore, featureFlagStore)
-		},
-	), operation)
+				return ie.discoverAndEnqueueInsights(ctx, insightStore, featureFlagStore)
+			},
+		), operation,
+	)
 }
 
 type InsightEnqueuer struct {

--- a/enterprise/internal/insights/background/license_check.go
+++ b/enterprise/internal/insights/background/license_check.go
@@ -19,8 +19,9 @@ func NewLicenseCheckJob(ctx context.Context, postgres database.DB, insightsdb ed
 	interval := time.Minute * 15
 	logger := log.Scoped("CodeInsightsLicenseCheckJob", "")
 
-	return goroutine.NewPeriodicGoroutine(ctx, interval,
-		goroutine.NewHandlerWithErrorMessage("insights.license_check", "checks for code insights license and freezes insights when missing",
+	return goroutine.NewPeriodicGoroutine(
+		ctx, "insights.license_check", "checks for code insights license and freezes insights when missing",
+		interval, goroutine.HandlerFunc(
 			func(ctx context.Context) (err error) {
 				return checkAndEnforceLicense(ctx, insightsdb, logger)
 			},

--- a/enterprise/internal/insights/background/license_check.go
+++ b/enterprise/internal/insights/background/license_check.go
@@ -20,9 +20,12 @@ func NewLicenseCheckJob(ctx context.Context, postgres database.DB, insightsdb ed
 	logger := log.Scoped("CodeInsightsLicenseCheckJob", "")
 
 	return goroutine.NewPeriodicGoroutine(ctx, interval,
-		goroutine.NewHandlerWithErrorMessage("insights_license_check", func(ctx context.Context) (err error) {
-			return checkAndEnforceLicense(ctx, insightsdb, logger)
-		}))
+		goroutine.NewHandlerWithErrorMessage("insights.license_check", "checks for code insights license and freezes insights when missing",
+			func(ctx context.Context) (err error) {
+				return checkAndEnforceLicense(ctx, insightsdb, logger)
+			},
+		),
+	)
 }
 
 func checkAndEnforceLicense(ctx context.Context, insightsdb edb.InsightsDB, logger log.Logger) (err error) {

--- a/enterprise/internal/insights/background/pings/insights_ping_emitter.go
+++ b/enterprise/internal/insights/background/pings/insights_ping_emitter.go
@@ -25,8 +25,10 @@ func NewInsightsPingEmitterJob(ctx context.Context, base database.DB, insights e
 		insightsDb: insights,
 	}
 
-	return goroutine.NewPeriodicGoroutine(ctx, interval,
-		goroutine.NewHandlerWithErrorMessage("insights.pings_emitter", "emits enterprise telemetry pings", e.emit))
+	return goroutine.NewPeriodicGoroutine(
+		ctx, "insights.pings_emitter", "emits enterprise telemetry pings",
+		interval, goroutine.HandlerFunc(e.emit),
+	)
 }
 
 type InsightsPingEmitter struct {

--- a/enterprise/internal/insights/background/pings/insights_ping_emitter.go
+++ b/enterprise/internal/insights/background/pings/insights_ping_emitter.go
@@ -26,7 +26,7 @@ func NewInsightsPingEmitterJob(ctx context.Context, base database.DB, insights e
 	}
 
 	return goroutine.NewPeriodicGoroutine(ctx, interval,
-		goroutine.NewHandlerWithErrorMessage("insights_pings_emitter", e.emit))
+		goroutine.NewHandlerWithErrorMessage("insights.pings_emitter", "emits enterprise telemetry pings", e.emit))
 }
 
 type InsightsPingEmitter struct {
@@ -39,7 +39,7 @@ func (e *InsightsPingEmitter) emit(ctx context.Context) error {
 	e.logger.Info("Emitting Code Insights Pings")
 
 	type emitter func(ctx context.Context) error
-	var emitters = map[string]emitter{
+	emitters := map[string]emitter{
 		"emitInsightTotalCounts":      e.emitInsightTotalCounts,
 		"emitIntervalCounts":          e.emitIntervalCounts,
 		"emitOrgVisibleInsightCounts": e.emitOrgVisibleInsightCounts,

--- a/enterprise/internal/insights/background/queryrunner/cleaner.go
+++ b/enterprise/internal/insights/background/queryrunner/cleaner.go
@@ -31,7 +31,7 @@ func NewCleaner(ctx context.Context, observationCtx *observation.Context, worker
 
 	// We look for jobs to cleanup every hour.
 	return goroutine.NewPeriodicGoroutineWithMetrics(ctx, 1*time.Hour, goroutine.NewHandlerWithErrorMessage(
-		"insights_query_runner_cleaner",
+		"insights.query_runner_cleaner", "removes completed or failed query runner jobs",
 		func(ctx context.Context) error {
 			// TODO(slimsag): future: recording the number of jobs cleaned up in a metric would be nice.
 			_, err := cleanJobs(ctx, workerBaseStore)

--- a/enterprise/internal/insights/background/queryrunner/cleaner.go
+++ b/enterprise/internal/insights/background/queryrunner/cleaner.go
@@ -30,14 +30,16 @@ func NewCleaner(ctx context.Context, observationCtx *observation.Context, worker
 	})
 
 	// We look for jobs to cleanup every hour.
-	return goroutine.NewPeriodicGoroutineWithMetrics(ctx, 1*time.Hour, goroutine.NewHandlerWithErrorMessage(
-		"insights.query_runner_cleaner", "removes completed or failed query runner jobs",
-		func(ctx context.Context) error {
-			// TODO(slimsag): future: recording the number of jobs cleaned up in a metric would be nice.
-			_, err := cleanJobs(ctx, workerBaseStore)
-			return err
-		},
-	), operation)
+	return goroutine.NewPeriodicGoroutineWithMetrics(
+		ctx, "insights.query_runner_cleaner", "removes completed or failed query runner jobs",
+		1*time.Hour, goroutine.HandlerFunc(
+			func(ctx context.Context) error {
+				// TODO(slimsag): future: recording the number of jobs cleaned up in a metric would be nice.
+				_, err := cleanJobs(ctx, workerBaseStore)
+				return err
+			},
+		), operation,
+	)
 }
 
 // cleanJobs

--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -100,7 +100,7 @@ func (i *CommitIndexer) Handler(ctx context.Context, observationCtx *observation
 	interval := time.Minute * time.Duration(intervalMinutes)
 
 	return goroutine.NewPeriodicGoroutineWithMetrics(ctx, interval,
-		goroutine.NewHandlerWithErrorMessage("insights.commit_indexer_handler", "TODO", func(ctx context.Context) error {
+		goroutine.NewHandlerWithErrorMessage("insights.commit_indexer_handler", "updates index of repo commits", func(ctx context.Context) error {
 			return i.indexAll(ctx)
 		}), i.operations.worker)
 }

--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -99,10 +99,12 @@ func (i *CommitIndexer) Handler(ctx context.Context, observationCtx *observation
 	}
 	interval := time.Minute * time.Duration(intervalMinutes)
 
-	return goroutine.NewPeriodicGoroutineWithMetrics(ctx, interval,
-		goroutine.NewHandlerWithErrorMessage("insights.commit_indexer_handler", "updates index of repo commits", func(ctx context.Context) error {
+	return goroutine.NewPeriodicGoroutineWithMetrics(
+		ctx, "insights.commit_indexer_handler", "updates index of repo commits",
+		interval, goroutine.HandlerFunc(func(ctx context.Context) error {
 			return i.indexAll(ctx)
-		}), i.operations.worker)
+		}), i.operations.worker,
+	)
 }
 
 func (i *CommitIndexer) indexAll(ctx context.Context) error {

--- a/enterprise/internal/insights/compression/worker.go
+++ b/enterprise/internal/insights/compression/worker.go
@@ -100,7 +100,7 @@ func (i *CommitIndexer) Handler(ctx context.Context, observationCtx *observation
 	interval := time.Minute * time.Duration(intervalMinutes)
 
 	return goroutine.NewPeriodicGoroutineWithMetrics(ctx, interval,
-		goroutine.NewHandlerWithErrorMessage("commit_indexer_handler", func(ctx context.Context) error {
+		goroutine.NewHandlerWithErrorMessage("insights.commit_indexer_handler", "TODO", func(ctx context.Context) error {
 			return i.indexAll(ctx)
 		}), i.operations.worker)
 }

--- a/internal/codeintel/dependencies/internal/background/job_cratesyncer.go
+++ b/internal/codeintel/dependencies/internal/background/job_cratesyncer.go
@@ -61,7 +61,7 @@ func NewCrateSyncer(
 		operations:      newOperations(observationCtx),
 	}
 
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.HandlerFunc(func(ctx context.Context) error {
+	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("crates-syncer", func(ctx context.Context) error {
 		return job.handleCrateSyncer(ctx, interval)
 	}))
 }

--- a/internal/codeintel/dependencies/internal/background/job_cratesyncer.go
+++ b/internal/codeintel/dependencies/internal/background/job_cratesyncer.go
@@ -63,8 +63,9 @@ func NewCrateSyncer(
 
 	return goroutine.NewPeriodicGoroutine(
 		context.Background(),
+		"codeintel.crates-syncer", "syncs the crates list from the index to dependency repos table",
 		interval,
-		goroutine.NewHandlerWithErrorMessage("codeintel.crates-syncer", "syncs the crates list from the index to dependency repos table", func(ctx context.Context) error {
+		goroutine.HandlerFunc(func(ctx context.Context) error {
 			return job.handleCrateSyncer(ctx, interval)
 		}),
 	)

--- a/internal/codeintel/dependencies/internal/background/job_cratesyncer.go
+++ b/internal/codeintel/dependencies/internal/background/job_cratesyncer.go
@@ -61,9 +61,13 @@ func NewCrateSyncer(
 		operations:      newOperations(observationCtx),
 	}
 
-	return goroutine.NewPeriodicGoroutine(context.Background(), interval, goroutine.NewHandlerWithErrorMessage("crates-syncer", func(ctx context.Context) error {
-		return job.handleCrateSyncer(ctx, interval)
-	}))
+	return goroutine.NewPeriodicGoroutine(
+		context.Background(),
+		interval,
+		goroutine.NewHandlerWithErrorMessage("codeintel.crates-syncer", "syncs the crates list from the index to dependency repos table", func(ctx context.Context) error {
+			return job.handleCrateSyncer(ctx, interval)
+		}),
+	)
 }
 
 func (b *crateSyncerJob) handleCrateSyncer(ctx context.Context, interval time.Duration) (err error) {

--- a/internal/extsvc/versions/sync.go
+++ b/internal/extsvc/versions/sync.go
@@ -53,7 +53,7 @@ func (j *syncingJob) Routines(_ context.Context, observationCtx *observation.Con
 	sourcer := repos.NewSourcer(sourcerLogger, db, sourcerCF)
 
 	store := db.ExternalServices()
-	handler := goroutine.NewHandlerWithErrorMessage("repomgmt.version-syncer", "sync versions of external services", func(ctx context.Context) error {
+	handler := goroutine.HandlerFunc(func(ctx context.Context) error {
 		versions, err := loadVersions(ctx, observationCtx.Logger, store, sourcer)
 		if err != nil {
 			return err
@@ -63,7 +63,7 @@ func (j *syncingJob) Routines(_ context.Context, observationCtx *observation.Con
 
 	return []goroutine.BackgroundRoutine{
 		// Pass a fresh context, see docs for shared.Job
-		goroutine.NewPeriodicGoroutine(context.Background(), syncInterval, handler),
+		goroutine.NewPeriodicGoroutine(context.Background(), "repomgmt.version-syncer", "sync versions of external services", syncInterval, handler),
 	}, nil
 }
 

--- a/internal/extsvc/versions/sync.go
+++ b/internal/extsvc/versions/sync.go
@@ -53,7 +53,7 @@ func (j *syncingJob) Routines(_ context.Context, observationCtx *observation.Con
 	sourcer := repos.NewSourcer(sourcerLogger, db, sourcerCF)
 
 	store := db.ExternalServices()
-	handler := goroutine.NewHandlerWithErrorMessage("sync versions of external services", func(ctx context.Context) error {
+	handler := goroutine.NewHandlerWithErrorMessage("repomgmt.version-syncer", "sync versions of external services", func(ctx context.Context) error {
 		versions, err := loadVersions(ctx, observationCtx.Logger, store, sourcer)
 		if err != nil {
 			return err

--- a/internal/goroutine/example_test.go
+++ b/internal/goroutine/example_test.go
@@ -43,7 +43,7 @@ func ExampleBackgroundRoutine() {
 }
 
 func ExamplePeriodicGoroutine() {
-	h := NewHandlerWithErrorMessage("example background routine", func(ctx context.Context) error {
+	h := NewHandlerWithErrorMessage("example.background", "example background routine", func(ctx context.Context) error {
 		fmt.Println("Hello from the background!")
 		return nil
 	})

--- a/internal/goroutine/example_test.go
+++ b/internal/goroutine/example_test.go
@@ -43,14 +43,14 @@ func ExampleBackgroundRoutine() {
 }
 
 func ExamplePeriodicGoroutine() {
-	h := NewHandlerWithErrorMessage("example.background", "example background routine", func(ctx context.Context) error {
+	h := HandlerFunc(func(ctx context.Context) error {
 		fmt.Println("Hello from the background!")
 		return nil
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	r := NewPeriodicGoroutine(ctx, 200*time.Millisecond, h)
+	r := NewPeriodicGoroutine(ctx, "example.background", "example background routine", 200*time.Millisecond, h)
 
 	go MonitorBackgroundRoutines(ctx, r)
 

--- a/internal/goroutine/periodic.go
+++ b/internal/goroutine/periodic.go
@@ -49,16 +49,12 @@ type Finalizer interface {
 	OnShutdown()
 }
 
-// HandlerFunc wraps a function so it can be used as a Handler.
-type HandlerFunc func(ctx context.Context) error
-
-func (f HandlerFunc) Handle(ctx context.Context) error {
-	return f(ctx)
-}
+// handlerFunc wraps a function so it can be used as a Handler.
+type handlerFunc func(ctx context.Context) error
 
 type simpleHandler struct {
 	name    string
-	handler HandlerFunc
+	handler handlerFunc
 }
 
 // NewHandlerWithErrorMessage wraps the given function to be used as a handler, and

--- a/internal/goroutine/periodic.go
+++ b/internal/goroutine/periodic.go
@@ -5,7 +5,8 @@ import (
 	"time"
 
 	"github.com/derision-test/glock"
-	"github.com/inconshreveable/log15"
+
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -53,13 +54,13 @@ type Finalizer interface {
 type handlerFunc func(ctx context.Context) error
 
 type simpleHandler struct {
-	name    string
-	handler handlerFunc
+	name, description string
+	handler           handlerFunc
 }
 
 // NewHandlerWithErrorMessage wraps the given function to be used as a handler, and
 // prints a canned failure message containing the given name.
-func NewHandlerWithErrorMessage(name string, handler func(ctx context.Context) error) Handler {
+func NewHandlerWithErrorMessage(name, description string, handler handlerFunc) Handler {
 	return &simpleHandler{handler: handler, name: name}
 }
 
@@ -68,7 +69,7 @@ func (h *simpleHandler) Handle(ctx context.Context) error {
 }
 
 func (h *simpleHandler) HandleError(err error) {
-	log15.Error("An error occurred in a background task", "handler", h.name, "error", err)
+	log.Scoped(h.name, h.description).Error("An error occurred in a background task", log.String("handler", h.name), log.Error(err))
 }
 
 // NewPeriodicGoroutine creates a new PeriodicGoroutine with the given handler. The context provided will propagate into

--- a/internal/goroutine/periodic.go
+++ b/internal/goroutine/periodic.go
@@ -63,8 +63,9 @@ func (f HandlerFunc) Handle(ctx context.Context) error {
 }
 
 type simpleHandler struct {
-	name, description string
-	handler           HandlerFunc
+	name    string
+	scope   log.Logger
+	handler HandlerFunc
 }
 
 func (h *simpleHandler) Handle(ctx context.Context) error {
@@ -72,7 +73,7 @@ func (h *simpleHandler) Handle(ctx context.Context) error {
 }
 
 func (h *simpleHandler) HandleError(err error) {
-	log.Scoped(h.name, h.description).Error("An error occurred in a background task", log.String("handler", h.name), log.Error(err))
+	h.scope.Error("An error occurred in a background task", log.String("handler", h.name), log.Error(err))
 }
 
 // NewPeriodicGoroutine creates a new PeriodicGoroutine with the given handler. The context provided will propagate into
@@ -95,8 +96,8 @@ func newPeriodicGoroutine(ctx context.Context, name, description string, interva
 		h = uh
 	} else {
 		h = &simpleHandler{
-			name:        name,
-			description: description,
+			name:  name,
+			scope: log.Scoped(name, description),
 			handler: func(ctx context.Context) error {
 				return handler.Handle(ctx)
 			},

--- a/internal/goroutine/periodic_test.go
+++ b/internal/goroutine/periodic_test.go
@@ -20,7 +20,7 @@ func TestPeriodicGoroutine(t *testing.T) {
 		return nil
 	})
 
-	goroutine := newPeriodicGoroutine(context.Background(), time.Second, handler, nil, clock)
+	goroutine := newPeriodicGoroutine(context.Background(), t.Name(), "", time.Second, handler, nil, clock)
 	go goroutine.Start()
 	clock.BlockingAdvance(time.Second)
 	<-called
@@ -51,7 +51,7 @@ func TestPeriodicGoroutineError(t *testing.T) {
 		return err
 	})
 
-	goroutine := newPeriodicGoroutine(context.Background(), time.Second, handler, nil, clock)
+	goroutine := newPeriodicGoroutine(context.Background(), t.Name(), "", time.Second, handler, nil, clock)
 	go goroutine.Start()
 	clock.BlockingAdvance(time.Second)
 	<-called
@@ -81,7 +81,7 @@ func TestPeriodicGoroutineContextError(t *testing.T) {
 		return ctx.Err()
 	})
 
-	goroutine := newPeriodicGoroutine(context.Background(), time.Second, handler, nil, clock)
+	goroutine := newPeriodicGoroutine(context.Background(), t.Name(), "", time.Second, handler, nil, clock)
 	go goroutine.Start()
 	<-called
 	goroutine.Stop()
@@ -105,7 +105,7 @@ func TestPeriodicGoroutineFinalizer(t *testing.T) {
 		return nil
 	})
 
-	goroutine := newPeriodicGoroutine(context.Background(), time.Second, handler, nil, clock)
+	goroutine := newPeriodicGoroutine(context.Background(), t.Name(), "", time.Second, handler, nil, clock)
 	go goroutine.Start()
 	clock.BlockingAdvance(time.Second)
 	<-called

--- a/internal/repos/webhookworker/cleaner.go
+++ b/internal/repos/webhookworker/cleaner.go
@@ -23,13 +23,19 @@ func NewCleaner(ctx context.Context, observationCtx *observation.Context, worker
 		Metrics: metrics,
 	})
 
-	return goroutine.NewPeriodicGoroutineWithMetrics(ctx, 1*time.Hour, goroutine.NewHandlerWithErrorMessage(
-		"webhook.build_worker_cleaner", "deletes completed and failed sync webhooks",
-		func(ctx context.Context) error {
-			_, err := cleanJobs(ctx, workerBaseStore)
-			return err
-		},
-	), operation)
+	return goroutine.NewPeriodicGoroutineWithMetrics(
+		ctx,
+		"webhook.build_worker_cleaner",
+		"deletes completed and failed sync webhooks",
+		1*time.Hour,
+		goroutine.HandlerFunc(
+			func(ctx context.Context) error {
+				_, err := cleanJobs(ctx, workerBaseStore)
+				return err
+			},
+		),
+		operation,
+	)
 }
 
 func cleanJobs(ctx context.Context, workerBaseStore *basestore.Store) (numCleaned int, err error) {

--- a/internal/repos/webhookworker/cleaner.go
+++ b/internal/repos/webhookworker/cleaner.go
@@ -24,7 +24,7 @@ func NewCleaner(ctx context.Context, observationCtx *observation.Context, worker
 	})
 
 	return goroutine.NewPeriodicGoroutineWithMetrics(ctx, 1*time.Hour, goroutine.NewHandlerWithErrorMessage(
-		"webhook_build_worker_cleaner",
+		"webhook.build_worker_cleaner", "deletes completed and failed sync webhooks",
 		func(ctx context.Context) error {
 			_, err := cleanJobs(ctx, workerBaseStore)
 			return err

--- a/internal/uploadstore/expirer.go
+++ b/internal/uploadstore/expirer.go
@@ -14,7 +14,7 @@ type expirer struct {
 }
 
 func NewExpirer(ctx context.Context, store Store, prefix string, maxAge time.Duration, interval time.Duration) goroutine.BackgroundRoutine {
-	return goroutine.NewPeriodicGoroutine(ctx, interval, &expirer{
+	return goroutine.NewPeriodicGoroutine(ctx, "codeintel.upload-store-expirer", "expires entries in the code intel upload store", interval, &expirer{
 		store:  store,
 		prefix: prefix,
 		maxAge: maxAge,


### PR DESCRIPTION
Previously, there were three ways to construct periodic background goroutines:
1. wrap a function with `goroutine.HandlerFunc`
2. create a type that implements `goroutine.Handler`
3. pass a function to `goroutine.NewHandlerWithErrorMessage`

Approach 1 had the behaviour where they would not log errors returned from the handler, which is of course not ideal : ) approach 2 has that too if not implementing `goroutine.ErrorHandler`

This PR creates a unified way of constructing them, where they all will log on error in a predetermined way if an customized way is not defined, and modernises it with `sourcegraph/log` instead of log15.

## Test plan

Nothing really to test, just swapping out Thing X thats proven to work for Thing Y thats proven to work but better :shrug: 
