### PR TITLE
diff page: add focus and pointer to mode selector

### DIFF
--- a/client/web/src/repo/commit/DiffModeSelector.module.scss
+++ b/client/web/src/repo/commit/DiffModeSelector.module.scss
@@ -1,4 +1,6 @@
 .button {
+    cursor: pointer;
+
     &:focus-within {
         box-shadow: var(--focus-box-shadow);
     }

--- a/client/web/src/repo/commit/DiffModeSelector.tsx
+++ b/client/web/src/repo/commit/DiffModeSelector.tsx
@@ -1,8 +1,12 @@
 import React from 'react'
 
+import classNames from 'classnames'
+
 import { Button, ButtonGroup, Input } from '@sourcegraph/wildcard'
 
 import { DiffMode } from './RepositoryCommitPage'
+
+import styles from './DiffModeSelector.module.scss'
 
 interface DiffModeSelectorProps {
     className?: string
@@ -23,7 +27,7 @@ export const DiffModeSelector: React.FunctionComponent<DiffModeSelectorProps> = 
                 size={small ? 'sm' : undefined}
                 variant="secondary"
                 outline={diffMode !== 'unified'}
-                className="mb-0"
+                className={classNames(styles.button, 'mb-0')}
                 as="label"
                 htmlFor="diff-mode-selector-unified"
             >
@@ -42,7 +46,7 @@ export const DiffModeSelector: React.FunctionComponent<DiffModeSelectorProps> = 
                 size={small ? 'sm' : undefined}
                 variant="secondary"
                 outline={diffMode !== 'split'}
-                className="mb-0"
+                className={classNames(styles.button, 'mb-0')}
                 as="label"
                 htmlFor="diff-mode-selector-split"
             >


### PR DESCRIPTION
Fixes some issues introduced when trying to make the diff mode selector screen-reader accessible:
- Diff mode selector show shows a pointer cursor when hovered over by the mode
- Diff mode selector now shows a focus outline for the currently-selected focus mode (use arrow keys to change selection).

## Test plan

Diff mode selector should now show a pointer cursor and should show a focus indicator

![image](https://user-images.githubusercontent.com/206864/206051060-b13693f0-da09-4b14-b622-a78795dde777.png)

## App preview:

- [Web](https://sg-web-jp-diffmodeselectorfocus.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
