### PR TITLE
codeintel: Tombstone SCIP documents after last use

### DIFF
--- a/enterprise/internal/codeintel/uploads/config.go
+++ b/enterprise/internal/codeintel/uploads/config.go
@@ -27,6 +27,8 @@ type janitorConfig struct {
 	MinimumTimeSinceLastCheck      time.Duration
 	CommitResolverBatchSize        int
 	AuditLogMaxAge                 time.Duration
+	UnreferencedDocumentBatchSize  int
+	UnreferencedDocumentMaxAge     time.Duration
 	CommitResolverMaximumCommitLag time.Duration
 	UploadTimeout                  time.Duration
 	ReconcilerBatchSize            int
@@ -45,6 +47,8 @@ func (c *janitorConfig) Load() {
 	c.MinimumTimeSinceLastCheck = c.GetInterval(minimumTimeSinceLastCheckName, "24h", "The minimum time the commit resolver will re-check an upload or index record.")
 	c.CommitResolverBatchSize = c.GetInt(commitResolverBatchSizeName, "100", "The maximum number of unique commits to resolve at a time.")
 	c.AuditLogMaxAge = c.GetInterval(auditLogMaxAgeName, "720h", "The maximum time a code intel audit log record can remain on the database.")
+	c.UnreferencedDocumentBatchSize = c.GetInt("CODEINTEL_UPLOADS_UNREFERENCED_DOCUMENT_BATCH_SIZE", "100", "The number of unreferenced SCIP documents to consider for deletion at a time.")
+	c.UnreferencedDocumentMaxAge = c.GetInterval("CODEINTEL_UPLOADS_UNREFERENCED_DOCUMENT_MAX_AGE", "24h", "The maximum time an unreferenced SCIP document should remain in the database.")
 	c.CommitResolverMaximumCommitLag = c.GetInterval(commitResolverMaximumCommitLagName, "0s", "The maximum acceptable delay between accepting an upload and its commit becoming resolvable. Be cautious about setting this to a large value, as uploads for unresolvable commits will be retried periodically during this interval.")
 	c.UploadTimeout = c.GetInterval(uploadTimeoutName, "24h", "The maximum time an upload can be in the 'uploading' state.")
 	c.ReconcilerBatchSize = c.GetInt("CODEINTEL_UPLOADS_RECONCILER_BATCH_SIZE", "1000", "The number of uploads to reconcile in one cleanup routine invocation.")

--- a/enterprise/internal/codeintel/uploads/init.go
+++ b/enterprise/internal/codeintel/uploads/init.go
@@ -145,6 +145,8 @@ func NewJanitor(observationCtx *observation.Context, uploadSvc *Service, gitserv
 			background.JanitorConfig{
 				UploadTimeout:                  ConfigJanitorInst.UploadTimeout,
 				AuditLogMaxAge:                 ConfigJanitorInst.AuditLogMaxAge,
+				UnreferencedDocumentBatchSize:  ConfigJanitorInst.UnreferencedDocumentBatchSize,
+				UnreferencedDocumentMaxAge:     ConfigJanitorInst.UnreferencedDocumentMaxAge,
 				MinimumTimeSinceLastCheck:      ConfigJanitorInst.MinimumTimeSinceLastCheck,
 				CommitResolverBatchSize:        ConfigJanitorInst.CommitResolverBatchSize,
 				CommitResolverMaximumCommitLag: ConfigJanitorInst.CommitResolverMaximumCommitLag,

--- a/enterprise/internal/codeintel/uploads/internal/background/job_cleanup.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_cleanup.go
@@ -20,6 +20,8 @@ import (
 type JanitorConfig struct {
 	UploadTimeout                  time.Duration
 	AuditLogMaxAge                 time.Duration
+	UnreferencedDocumentBatchSize  int
+	UnreferencedDocumentMaxAge     time.Duration
 	MinimumTimeSinceLastCheck      time.Duration
 	CommitResolverBatchSize        int
 	CommitResolverMaximumCommitLag time.Duration
@@ -77,6 +79,11 @@ func (b janitorJob) handleCleanup(ctx context.Context, cfg JanitorConfig) (errs 
 		errs = errors.Append(errs, err)
 	}
 	if err := b.handleAuditLog(ctx, cfg); err != nil {
+		errs = errors.Append(errs, err)
+	}
+
+	// SCIP data
+	if err := b.handleSCIPDocuments(ctx, cfg); err != nil {
 		errs = errors.Append(errs, err)
 	}
 
@@ -290,6 +297,16 @@ func (b janitorJob) handleAuditLog(ctx context.Context, cfg JanitorConfig) (err 
 	}
 
 	b.metrics.numAuditLogRecordsExpired.Add(float64(count))
+	return nil
+}
+
+func (b janitorJob) handleSCIPDocuments(ctx context.Context, cfg JanitorConfig) (err error) {
+	count, err := b.lsifStore.DeleteUnreferencedDocuments(ctx, cfg.UnreferencedDocumentBatchSize, cfg.UnreferencedDocumentMaxAge, time.Now())
+	if err != nil {
+		return errors.Wrap(err, "uploadSvc.DeleteUnreferencedDocuments")
+	}
+
+	b.metrics.numSCIPDocumentRecordsRemoved.Add(float64(count))
 	return nil
 }
 

--- a/enterprise/internal/codeintel/uploads/internal/background/job_cleanup_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_cleanup_test.go
@@ -114,6 +114,7 @@ func testUnknownCommitsJanitor(t *testing.T, resolveRevisionFunc func(commit str
 			MinimumTimeSinceLastCheck:      1 * time.Hour,
 			CommitResolverBatchSize:        10,
 			AuditLogMaxAge:                 1 * time.Hour,
+			UnreferencedDocumentMaxAge:     1 * time.Hour,
 			CommitResolverMaximumCommitLag: 1 * time.Hour,
 			UploadTimeout:                  1 * time.Hour,
 		}); err != nil {

--- a/enterprise/internal/codeintel/uploads/internal/background/metrics_janitors.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/metrics_janitors.go
@@ -8,10 +8,11 @@ import (
 
 type janitorMetrics struct {
 	// Data retention metrics
-	numAuditLogRecordsExpired prometheus.Counter
-	numErrors                 prometheus.Counter
-	numUploadRecordsRemoved   prometheus.Counter
-	numUploadsPurged          prometheus.Counter
+	numAuditLogRecordsExpired     prometheus.Counter
+	numErrors                     prometheus.Counter
+	numUploadRecordsRemoved       prometheus.Counter
+	numUploadsPurged              prometheus.Counter
+	numSCIPDocumentRecordsRemoved prometheus.Counter
 }
 
 func NewJanitorMetrics(observationCtx *observation.Context) *janitorMetrics {
@@ -41,11 +42,16 @@ func NewJanitorMetrics(observationCtx *observation.Context) *janitorMetrics {
 		"src_codeintel_background_uploads_purged_total",
 		"The number of uploads for which records in the codeintel database were removed.",
 	)
+	numSCIPDocumentRecordsRemoved := counter(
+		"src_codeintel_background_scip_documents_purged_total",
+		"The number of SCIP documents for which records in the codeintel database were removed.",
+	)
 
 	return &janitorMetrics{
-		numAuditLogRecordsExpired: numAuditLogRecordsExpired,
-		numErrors:                 numErrors,
-		numUploadRecordsRemoved:   numUploadRecordsRemoved,
-		numUploadsPurged:          numUploadsPurged,
+		numAuditLogRecordsExpired:     numAuditLogRecordsExpired,
+		numErrors:                     numErrors,
+		numUploadRecordsRemoved:       numUploadRecordsRemoved,
+		numUploadsPurged:              numUploadsPurged,
+		numSCIPDocumentRecordsRemoved: numSCIPDocumentRecordsRemoved,
 	}
 }

--- a/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
@@ -9874,6 +9874,10 @@ type MockLsifStore struct {
 	// object controlling the behavior of the method
 	// DeleteLsifDataByUploadIds.
 	DeleteLsifDataByUploadIdsFunc *LsifStoreDeleteLsifDataByUploadIdsFunc
+	// DeleteUnreferencedDocumentsFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// DeleteUnreferencedDocuments.
+	DeleteUnreferencedDocumentsFunc *LsifStoreDeleteUnreferencedDocumentsFunc
 	// DoneFunc is an instance of a mock function object controlling the
 	// behavior of the method Done.
 	DoneFunc *LsifStoreDoneFunc
@@ -9934,6 +9938,11 @@ func NewMockLsifStore() *MockLsifStore {
 	return &MockLsifStore{
 		DeleteLsifDataByUploadIdsFunc: &LsifStoreDeleteLsifDataByUploadIdsFunc{
 			defaultHook: func(context.Context, ...int) (r0 error) {
+				return
+			},
+		},
+		DeleteUnreferencedDocumentsFunc: &LsifStoreDeleteUnreferencedDocumentsFunc{
+			defaultHook: func(context.Context, int, time.Duration, time.Time) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -10034,6 +10043,11 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.DeleteLsifDataByUploadIds")
 			},
 		},
+		DeleteUnreferencedDocumentsFunc: &LsifStoreDeleteUnreferencedDocumentsFunc{
+			defaultHook: func(context.Context, int, time.Duration, time.Time) (int, error) {
+				panic("unexpected invocation of MockLsifStore.DeleteUnreferencedDocuments")
+			},
+		},
 		DoneFunc: &LsifStoreDoneFunc{
 			defaultHook: func(error) error {
 				panic("unexpected invocation of MockLsifStore.Done")
@@ -10128,6 +10142,9 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 	return &MockLsifStore{
 		DeleteLsifDataByUploadIdsFunc: &LsifStoreDeleteLsifDataByUploadIdsFunc{
 			defaultHook: i.DeleteLsifDataByUploadIds,
+		},
+		DeleteUnreferencedDocumentsFunc: &LsifStoreDeleteUnreferencedDocumentsFunc{
+			defaultHook: i.DeleteUnreferencedDocuments,
 		},
 		DoneFunc: &LsifStoreDoneFunc{
 			defaultHook: i.Done,
@@ -10296,6 +10313,124 @@ func (c LsifStoreDeleteLsifDataByUploadIdsFuncCall) Args() []interface{} {
 // invocation.
 func (c LsifStoreDeleteLsifDataByUploadIdsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
+}
+
+// LsifStoreDeleteUnreferencedDocumentsFunc describes the behavior when the
+// DeleteUnreferencedDocuments method of the parent MockLsifStore instance
+// is invoked.
+type LsifStoreDeleteUnreferencedDocumentsFunc struct {
+	defaultHook func(context.Context, int, time.Duration, time.Time) (int, error)
+	hooks       []func(context.Context, int, time.Duration, time.Time) (int, error)
+	history     []LsifStoreDeleteUnreferencedDocumentsFuncCall
+	mutex       sync.Mutex
+}
+
+// DeleteUnreferencedDocuments delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockLsifStore) DeleteUnreferencedDocuments(v0 context.Context, v1 int, v2 time.Duration, v3 time.Time) (int, error) {
+	r0, r1 := m.DeleteUnreferencedDocumentsFunc.nextHook()(v0, v1, v2, v3)
+	m.DeleteUnreferencedDocumentsFunc.appendCall(LsifStoreDeleteUnreferencedDocumentsFuncCall{v0, v1, v2, v3, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// DeleteUnreferencedDocuments method of the parent MockLsifStore instance
+// is invoked and the hook queue is empty.
+func (f *LsifStoreDeleteUnreferencedDocumentsFunc) SetDefaultHook(hook func(context.Context, int, time.Duration, time.Time) (int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// DeleteUnreferencedDocuments method of the parent MockLsifStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *LsifStoreDeleteUnreferencedDocumentsFunc) PushHook(hook func(context.Context, int, time.Duration, time.Time) (int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreDeleteUnreferencedDocumentsFunc) SetDefaultReturn(r0 int, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, time.Duration, time.Time) (int, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreDeleteUnreferencedDocumentsFunc) PushReturn(r0 int, r1 error) {
+	f.PushHook(func(context.Context, int, time.Duration, time.Time) (int, error) {
+		return r0, r1
+	})
+}
+
+func (f *LsifStoreDeleteUnreferencedDocumentsFunc) nextHook() func(context.Context, int, time.Duration, time.Time) (int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreDeleteUnreferencedDocumentsFunc) appendCall(r0 LsifStoreDeleteUnreferencedDocumentsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// LsifStoreDeleteUnreferencedDocumentsFuncCall objects describing the
+// invocations of this function.
+func (f *LsifStoreDeleteUnreferencedDocumentsFunc) History() []LsifStoreDeleteUnreferencedDocumentsFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreDeleteUnreferencedDocumentsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreDeleteUnreferencedDocumentsFuncCall is an object that describes
+// an invocation of method DeleteUnreferencedDocuments on an instance of
+// MockLsifStore.
+type LsifStoreDeleteUnreferencedDocumentsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 time.Duration
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 time.Time
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreDeleteUnreferencedDocumentsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreDeleteUnreferencedDocumentsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // LsifStoreDoneFunc describes the behavior when the Done method of the

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore.go
@@ -2,6 +2,7 @@ package lsifstore
 
 import (
 	"context"
+	"time"
 
 	codeintelshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
@@ -30,6 +31,7 @@ type LsifStore interface {
 
 	IDsWithMeta(ctx context.Context, ids []int) ([]int, error)
 	ReconcileCandidates(ctx context.Context, batchSize int) ([]int, error)
+	DeleteUnreferencedDocuments(ctx context.Context, batchSize int, maxAge time.Duration, now time.Time) (count int, err error)
 
 	// Stream
 	ScanDocuments(ctx context.Context, id int, f func(path string, ranges map[precise.ID]precise.RangeData) error) (err error)

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_documents_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_documents_test.go
@@ -75,8 +75,8 @@ func populateTestStore(t testing.TB) LsifStore {
 	// span multiple lines.
 	for _, statement := range strings.Split(string(withoutComments), ";\n") {
 		if strings.Contains(statement, "_schema_versions") {
-			// Statements which insert into lsif_data_*_schema_versions should not be executed, as
-			// these are already inserted during regular DB up migrations.
+			// Statements which insert into *_schema_versions should not be executed, as these are
+			// already inserted during regular DB up migrations.
 			continue
 		}
 		if _, err := tx.ExecContext(context.Background(), statement); err != nil {

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_janitor.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_janitor.go
@@ -1,0 +1,58 @@
+package lsifstore
+
+import (
+	"context"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+	otlog "github.com/opentracing/opentracing-go/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+func (s *store) DeleteUnreferencedDocuments(ctx context.Context, batchSize int, maxAge time.Duration, now time.Time) (count int, err error) {
+	ctx, _, endObservation := s.operations.idsWithMeta.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
+		otlog.String("maxAge", maxAge.String()),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	count, _, err = basestore.ScanFirstInt(s.db.Query(ctx, sqlf.Sprintf(
+		deleteUnreferencedDocumentsQuery,
+		now,
+		maxAge/time.Second,
+		batchSize,
+	)))
+	return count, err
+}
+
+const deleteUnreferencedDocumentsQuery = `
+WITH
+candidates AS (
+	SELECT id, document_id
+	FROM codeintel_scip_documents_dereference_logs log
+	WHERE %s - log.last_removal_time > (%s * interval '1 second')
+	ORDER BY last_removal_time DESC, document_id
+	LIMIT %s
+	FOR UPDATE SKIP LOCKED
+),
+locked_documents AS (
+	SELECT sd.id
+	FROM candidates d
+	JOIN codeintel_scip_documents sd ON sd.id = d.document_id
+	WHERE NOT EXISTS (SELECT 1 FROM codeintel_scip_document_lookup sdl WHERE sdl.document_id = sd.id)
+	ORDER BY sd.id
+	FOR UPDATE
+),
+deleted_documents AS (
+	DELETE FROM codeintel_scip_documents
+	WHERE id IN (SELECT id FROM locked_documents)
+	RETURNING id
+),
+deleted_candidates AS (
+	DELETE FROM codeintel_scip_documents_dereference_logs
+	WHERE id IN (SELECT id FROM candidates)
+	RETURNING id
+)
+SELECT COUNT(*) FROM deleted_documents
+`

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_janitor.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_janitor.go
@@ -42,7 +42,7 @@ locked_documents AS (
 	JOIN codeintel_scip_documents sd ON sd.id = d.document_id
 	WHERE NOT EXISTS (SELECT 1 FROM codeintel_scip_document_lookup sdl WHERE sdl.document_id = sd.id)
 	ORDER BY sd.id
-	FOR UPDATE
+	FOR UPDATE OF sd
 ),
 deleted_documents AS (
 	DELETE FROM codeintel_scip_documents

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_janitor_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_janitor_test.go
@@ -1,0 +1,7 @@
+package lsifstore
+
+import "testing"
+
+func TestDeleteUnreferencedDocuments(t *testing.T) {
+	// TODO
+}

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_janitor_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore_janitor_test.go
@@ -1,7 +1,113 @@
 package lsifstore
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/log/logtest"
+
+	codeintelshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
 
 func TestDeleteUnreferencedDocuments(t *testing.T) {
-	// TODO
+	logger := logtest.Scoped(t)
+	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(logger, t))
+	store := newStore(&observation.TestContext, codeIntelDB)
+
+	for i := 0; i < 200; i++ {
+		insertDocumentQuery := sqlf.Sprintf(
+			`INSERT INTO codeintel_scip_documents(id, schema_version, payload_hash, raw_scip_payload) VALUES (%s, 1, %s, %s)`,
+			i+1,
+			fmt.Sprintf("hash-%d", i+1),
+			fmt.Sprintf("payload-%d", i+1),
+		)
+		if err := store.db.Exec(context.Background(), insertDocumentQuery); err != nil {
+			t.Fatalf("unexpected error setting up database: %s", err)
+		}
+	}
+
+	for i := 0; i < 200; i++ {
+		insertDocumentLookupQuery := sqlf.Sprintf(
+			`INSERT INTO codeintel_scip_document_lookup(upload_id, document_path, document_id) VALUES (%s, %s, %s)`,
+			42,
+			fmt.Sprintf("path-%d", i+1),
+			i+1,
+		)
+		if err := store.db.Exec(context.Background(), insertDocumentLookupQuery); err != nil {
+			t.Fatalf("unexpected error setting up database: %s", err)
+		}
+
+		if i%3 == 0 {
+			insertDocumentLookupQuery := sqlf.Sprintf(
+				`INSERT INTO codeintel_scip_document_lookup(upload_id, document_path, document_id) VALUES (%s, %s, %s)`,
+				43,
+				fmt.Sprintf("path-%d", i+1),
+				i+1,
+			)
+			if err := store.db.Exec(context.Background(), insertDocumentLookupQuery); err != nil {
+				t.Fatalf("unexpected error setting up database: %s", err)
+			}
+		}
+	}
+
+	deleteReferencesQuery := sqlf.Sprintf(`DELETE FROM codeintel_scip_document_lookup WHERE upload_id = 42`)
+	if err := store.db.Exec(context.Background(), deleteReferencesQuery); err != nil {
+		t.Fatalf("unexpected error setting up database: %s", err)
+	}
+
+	// Check too soon
+	count, err := store.DeleteUnreferencedDocuments(context.Background(), 20, time.Minute, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error deleting unreferenced documents: %s", err)
+	}
+	if count != 0 {
+		t.Fatalf("did not expect any expired records, have %d", count)
+	}
+
+	// Consume actual records. We expect 10 batches (200 records deleted / 20 per batch) to be required to
+	// process this workload.
+
+	totalCount := 0
+	for i := 0; i < 10; i++ {
+		count, err = store.DeleteUnreferencedDocuments(context.Background(), 20, time.Minute, time.Now().Add(time.Minute*5))
+		if err != nil {
+			t.Fatalf("unexpected error deleting unreferenced documents: %s", err)
+		}
+		totalCount += count
+	}
+	if expected := 2 * 200 / 3; totalCount != expected {
+		t.Fatalf("unexpected number of unreferenced documents deleted. want=%d have=%d", expected, totalCount)
+	}
+
+	// Assert no more records should be available for processing
+	count, err = store.DeleteUnreferencedDocuments(context.Background(), 20, time.Minute, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error deleting unreferenced documents: %s", err)
+	}
+	if count != 0 {
+		t.Fatalf("did not expect any unprocessed records, have %d", count)
+	}
+
+	documentIDsQuery := sqlf.Sprintf(`SELECT id FROM codeintel_scip_documents ORDER BY id`)
+	ids, err := basestore.ScanInts(store.db.Query(context.Background(), documentIDsQuery))
+	if err != nil {
+		t.Fatalf("unexpected error querying document ids: %s", err)
+	}
+
+	var expectedIDs []int
+	for i := 0; i < 200; i++ {
+		if i%3 == 0 {
+			expectedIDs = append(expectedIDs, i+1)
+		}
+	}
+	if diff := cmp.Diff(expectedIDs, ids); diff != "" {
+		t.Fatalf("unexpected remaining document identifiers (-want +got):\n%s", diff)
+	}
 }

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
@@ -8,21 +8,22 @@ import (
 )
 
 type operations struct {
-	deleteLsifDataByUploadIds *observation.Operation
-	idsWithMeta               *observation.Operation
-	reconcileCandidates       *observation.Operation
-	getUploadDocumentsForPath *observation.Operation
-	scanDocuments             *observation.Operation
-	scanResultChunks          *observation.Operation
-	scanLocations             *observation.Operation
-	insertMetadata            *observation.Operation
-	insertSCIPDocument        *observation.Operation
-	writeMeta                 *observation.Operation
-	writeDocuments            *observation.Operation
-	writeResultChunks         *observation.Operation
-	writeDefinitions          *observation.Operation
-	writeReferences           *observation.Operation
-	writeImplementations      *observation.Operation
+	deleteLsifDataByUploadIds   *observation.Operation
+	idsWithMeta                 *observation.Operation
+	reconcileCandidates         *observation.Operation
+	getUploadDocumentsForPath   *observation.Operation
+	scanDocuments               *observation.Operation
+	scanResultChunks            *observation.Operation
+	scanLocations               *observation.Operation
+	insertMetadata              *observation.Operation
+	insertSCIPDocument          *observation.Operation
+	writeMeta                   *observation.Operation
+	writeDocuments              *observation.Operation
+	writeResultChunks           *observation.Operation
+	writeDefinitions            *observation.Operation
+	writeReferences             *observation.Operation
+	writeImplementations        *observation.Operation
+	deleteUnreferencedDocuments *observation.Operation
 }
 
 var m = new(metrics.SingletonREDMetrics)
@@ -46,20 +47,21 @@ func newOperations(observationCtx *observation.Context) *operations {
 	}
 
 	return &operations{
-		deleteLsifDataByUploadIds: op("DeleteLsifDataByUploadIds"),
-		idsWithMeta:               op("IDsWithMeta"),
-		reconcileCandidates:       op("ReconcileCandidates"),
-		getUploadDocumentsForPath: op("GetUploadDocumentsForPath"),
-		scanDocuments:             op("ScanDocuments"),
-		scanResultChunks:          op("ScanResultChunks"),
-		scanLocations:             op("ScanLocations"),
-		insertMetadata:            op("InsertMetadata"),
-		insertSCIPDocument:        op("InsertSCIPDocument"),
-		writeMeta:                 op("WriteMeta"),
-		writeDocuments:            op("WriteDocuments"),
-		writeResultChunks:         op("WriteResultChunks"),
-		writeDefinitions:          op("WriteDefinitions"),
-		writeReferences:           op("WriteReferences"),
-		writeImplementations:      op("WriteImplementations"),
+		deleteLsifDataByUploadIds:   op("DeleteLsifDataByUploadIds"),
+		idsWithMeta:                 op("IDsWithMeta"),
+		reconcileCandidates:         op("ReconcileCandidates"),
+		getUploadDocumentsForPath:   op("GetUploadDocumentsForPath"),
+		scanDocuments:               op("ScanDocuments"),
+		scanResultChunks:            op("ScanResultChunks"),
+		scanLocations:               op("ScanLocations"),
+		insertMetadata:              op("InsertMetadata"),
+		insertSCIPDocument:          op("InsertSCIPDocument"),
+		writeMeta:                   op("WriteMeta"),
+		writeDocuments:              op("WriteDocuments"),
+		writeResultChunks:           op("WriteResultChunks"),
+		writeDefinitions:            op("WriteDefinitions"),
+		writeReferences:             op("WriteReferences"),
+		writeImplementations:        op("WriteImplementations"),
+		deleteUnreferencedDocuments: op("DeleteUnreferencedDocuments"),
 	}
 }

--- a/enterprise/internal/codeintel/uploads/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/mocks_test.go
@@ -7545,6 +7545,10 @@ type MockLsifStore struct {
 	// object controlling the behavior of the method
 	// DeleteLsifDataByUploadIds.
 	DeleteLsifDataByUploadIdsFunc *LsifStoreDeleteLsifDataByUploadIdsFunc
+	// DeleteUnreferencedDocumentsFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// DeleteUnreferencedDocuments.
+	DeleteUnreferencedDocumentsFunc *LsifStoreDeleteUnreferencedDocumentsFunc
 	// DoneFunc is an instance of a mock function object controlling the
 	// behavior of the method Done.
 	DoneFunc *LsifStoreDoneFunc
@@ -7605,6 +7609,11 @@ func NewMockLsifStore() *MockLsifStore {
 	return &MockLsifStore{
 		DeleteLsifDataByUploadIdsFunc: &LsifStoreDeleteLsifDataByUploadIdsFunc{
 			defaultHook: func(context.Context, ...int) (r0 error) {
+				return
+			},
+		},
+		DeleteUnreferencedDocumentsFunc: &LsifStoreDeleteUnreferencedDocumentsFunc{
+			defaultHook: func(context.Context, int, time.Duration, time.Time) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -7705,6 +7714,11 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.DeleteLsifDataByUploadIds")
 			},
 		},
+		DeleteUnreferencedDocumentsFunc: &LsifStoreDeleteUnreferencedDocumentsFunc{
+			defaultHook: func(context.Context, int, time.Duration, time.Time) (int, error) {
+				panic("unexpected invocation of MockLsifStore.DeleteUnreferencedDocuments")
+			},
+		},
 		DoneFunc: &LsifStoreDoneFunc{
 			defaultHook: func(error) error {
 				panic("unexpected invocation of MockLsifStore.Done")
@@ -7799,6 +7813,9 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 	return &MockLsifStore{
 		DeleteLsifDataByUploadIdsFunc: &LsifStoreDeleteLsifDataByUploadIdsFunc{
 			defaultHook: i.DeleteLsifDataByUploadIds,
+		},
+		DeleteUnreferencedDocumentsFunc: &LsifStoreDeleteUnreferencedDocumentsFunc{
+			defaultHook: i.DeleteUnreferencedDocuments,
 		},
 		DoneFunc: &LsifStoreDoneFunc{
 			defaultHook: i.Done,
@@ -7967,6 +7984,124 @@ func (c LsifStoreDeleteLsifDataByUploadIdsFuncCall) Args() []interface{} {
 // invocation.
 func (c LsifStoreDeleteLsifDataByUploadIdsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
+}
+
+// LsifStoreDeleteUnreferencedDocumentsFunc describes the behavior when the
+// DeleteUnreferencedDocuments method of the parent MockLsifStore instance
+// is invoked.
+type LsifStoreDeleteUnreferencedDocumentsFunc struct {
+	defaultHook func(context.Context, int, time.Duration, time.Time) (int, error)
+	hooks       []func(context.Context, int, time.Duration, time.Time) (int, error)
+	history     []LsifStoreDeleteUnreferencedDocumentsFuncCall
+	mutex       sync.Mutex
+}
+
+// DeleteUnreferencedDocuments delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockLsifStore) DeleteUnreferencedDocuments(v0 context.Context, v1 int, v2 time.Duration, v3 time.Time) (int, error) {
+	r0, r1 := m.DeleteUnreferencedDocumentsFunc.nextHook()(v0, v1, v2, v3)
+	m.DeleteUnreferencedDocumentsFunc.appendCall(LsifStoreDeleteUnreferencedDocumentsFuncCall{v0, v1, v2, v3, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// DeleteUnreferencedDocuments method of the parent MockLsifStore instance
+// is invoked and the hook queue is empty.
+func (f *LsifStoreDeleteUnreferencedDocumentsFunc) SetDefaultHook(hook func(context.Context, int, time.Duration, time.Time) (int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// DeleteUnreferencedDocuments method of the parent MockLsifStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *LsifStoreDeleteUnreferencedDocumentsFunc) PushHook(hook func(context.Context, int, time.Duration, time.Time) (int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreDeleteUnreferencedDocumentsFunc) SetDefaultReturn(r0 int, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, time.Duration, time.Time) (int, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreDeleteUnreferencedDocumentsFunc) PushReturn(r0 int, r1 error) {
+	f.PushHook(func(context.Context, int, time.Duration, time.Time) (int, error) {
+		return r0, r1
+	})
+}
+
+func (f *LsifStoreDeleteUnreferencedDocumentsFunc) nextHook() func(context.Context, int, time.Duration, time.Time) (int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreDeleteUnreferencedDocumentsFunc) appendCall(r0 LsifStoreDeleteUnreferencedDocumentsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// LsifStoreDeleteUnreferencedDocumentsFuncCall objects describing the
+// invocations of this function.
+func (f *LsifStoreDeleteUnreferencedDocumentsFunc) History() []LsifStoreDeleteUnreferencedDocumentsFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreDeleteUnreferencedDocumentsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreDeleteUnreferencedDocumentsFuncCall is an object that describes
+// an invocation of method DeleteUnreferencedDocuments on an instance of
+// MockLsifStore.
+type LsifStoreDeleteUnreferencedDocumentsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 time.Duration
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 time.Time
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreDeleteUnreferencedDocumentsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreDeleteUnreferencedDocumentsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // LsifStoreDoneFunc describes the behavior when the Done method of the

--- a/internal/database/schema.codeintel.json
+++ b/internal/database/schema.codeintel.json
@@ -27,6 +27,10 @@
       "Definition": "CREATE OR REPLACE FUNCTION public.update_codeintel_scip_document_lookup_schema_versions_insert()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$ BEGIN\n    INSERT INTO codeintel_scip_document_lookup_schema_versions\n    SELECT\n        upload_id,\n        MIN(schema_version) as min_schema_version,\n        MAX(schema_version) as max_schema_version\n    FROM newtab\n    JOIN codeintel_scip_documents ON codeintel_scip_documents.id = newtab.document_id\n    GROUP BY newtab.upload_id\n    ON CONFLICT (upload_id) DO UPDATE SET\n        -- Update with min(old_min, new_min) and max(old_max, new_max)\n        min_schema_version = LEAST(codeintel_scip_document_lookup_schema_versions.min_schema_version, EXCLUDED.min_schema_version),\n        max_schema_version = GREATEST(codeintel_scip_document_lookup_schema_versions.max_schema_version, EXCLUDED.max_schema_version);\n    RETURN NULL;\nEND $function$\n"
     },
     {
+      "Name": "update_codeintel_scip_documents_dereference_logs_delete",
+      "Definition": "CREATE OR REPLACE FUNCTION public.update_codeintel_scip_documents_dereference_logs_delete()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$ BEGIN\n    INSERT INTO codeintel_scip_documents_dereference_logs (document_id)\n    SELECT document_id FROM oldtab;\n    RETURN NULL;\nEND $function$\n"
+    },
+    {
       "Name": "update_codeintel_scip_documents_schema_versions_insert",
       "Definition": "CREATE OR REPLACE FUNCTION public.update_codeintel_scip_documents_schema_versions_insert()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$ BEGIN\n    INSERT INTO codeintel_scip_documents_schema_versions\n    SELECT\n        newtab.metadata_shard_id,\n        MIN(codeintel_scip_documents.schema_version) as min_schema_version,\n        MAX(codeintel_scip_documents.schema_version) as max_schema_version\n    FROM newtab\n    JOIN codeintel_scip_documents ON codeintel_scip_documents.metadata_shard_id = newtab.metadata_shard_id\n    GROUP BY newtab.metadata_shard_id\n    ON CONFLICT (metadata_shard_id) DO UPDATE SET\n        -- Update with min(old_min, new_min) and max(old_max, new_max)\n        min_schema_version = LEAST(codeintel_scip_documents_schema_versions.min_schema_version, EXCLUDED.min_schema_version),\n        max_schema_version = GREATEST(codeintel_scip_documents_schema_versions.max_schema_version, EXCLUDED.max_schema_version);\n    RETURN NULL;\nEND $function$\n"
     },
@@ -54,6 +58,15 @@
   "Sequences": [
     {
       "Name": "codeintel_scip_document_lookup_id_seq",
+      "TypeName": "bigint",
+      "StartValue": 1,
+      "MinimumValue": 1,
+      "MaximumValue": 9223372036854775807,
+      "Increment": 1,
+      "CycleOption": "NO"
+    },
+    {
+      "Name": "codeintel_scip_documents_dereference_logs_id_seq",
       "TypeName": "bigint",
       "StartValue": 1,
       "MinimumValue": 1,
@@ -275,6 +288,10 @@
         {
           "Name": "codeintel_scip_document_lookup_schema_versions_insert",
           "Definition": "CREATE TRIGGER codeintel_scip_document_lookup_schema_versions_insert AFTER INSERT ON codeintel_scip_document_lookup REFERENCING NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION update_codeintel_scip_document_lookup_schema_versions_insert()"
+        },
+        {
+          "Name": "codeintel_scip_documents_dereference_logs_insert",
+          "Definition": "CREATE TRIGGER codeintel_scip_documents_dereference_logs_insert AFTER DELETE ON codeintel_scip_document_lookup REFERENCING OLD TABLE AS oldtab FOR EACH STATEMENT EXECUTE FUNCTION update_codeintel_scip_documents_dereference_logs_delete()"
         }
       ]
     },
@@ -436,6 +453,75 @@
           "Definition": "CREATE TRIGGER codeintel_scip_documents_schema_versions_insert AFTER INSERT ON codeintel_scip_documents REFERENCING NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION update_codeintel_scip_documents_schema_versions_insert()"
         }
       ]
+    },
+    {
+      "Name": "codeintel_scip_documents_dereference_logs",
+      "Comment": "A list of document rows that were recently dereferenced by the deletion of an index.",
+      "Columns": [
+        {
+          "Name": "document_id",
+          "Index": 2,
+          "TypeName": "bigint",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "The identifier of the document that was dereferenced."
+        },
+        {
+          "Name": "id",
+          "Index": 1,
+          "TypeName": "bigint",
+          "IsNullable": false,
+          "Default": "nextval('codeintel_scip_documents_dereference_logs_id_seq'::regclass)",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "last_removal_time",
+          "Index": 3,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": false,
+          "Default": "now()",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "The time that the log entry was inserted."
+        }
+      ],
+      "Indexes": [
+        {
+          "Name": "codeintel_scip_documents_dereference_logs_pkey",
+          "IsPrimaryKey": true,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX codeintel_scip_documents_dereference_logs_pkey ON codeintel_scip_documents_dereference_logs USING btree (id)",
+          "ConstraintType": "p",
+          "ConstraintDefinition": "PRIMARY KEY (id)"
+        },
+        {
+          "Name": "codeintel_scip_documents_dereference_logs_last_removal_time_doc",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX codeintel_scip_documents_dereference_logs_last_removal_time_doc ON codeintel_scip_documents_dereference_logs USING btree (last_removal_time, document_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        }
+      ],
+      "Constraints": null,
+      "Triggers": []
     },
     {
       "Name": "codeintel_scip_documents_schema_versions",

--- a/internal/database/schema.codeintel.md
+++ b/internal/database/schema.codeintel.md
@@ -30,6 +30,7 @@ Referenced by:
     TABLE "codeintel_scip_symbols" CONSTRAINT "codeintel_scip_symbols_document_lookup_id_fk" FOREIGN KEY (document_lookup_id) REFERENCES codeintel_scip_document_lookup(id) ON DELETE CASCADE
 Triggers:
     codeintel_scip_document_lookup_schema_versions_insert AFTER INSERT ON codeintel_scip_document_lookup REFERENCING NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION update_codeintel_scip_document_lookup_schema_versions_insert()
+    codeintel_scip_documents_dereference_logs_insert AFTER DELETE ON codeintel_scip_document_lookup REFERENCING OLD TABLE AS oldtab FOR EACH STATEMENT EXECUTE FUNCTION update_codeintel_scip_documents_dereference_logs_delete()
 
 ```
 
@@ -93,6 +94,25 @@ A lookup of SCIP [Document](https://sourcegraph.com/search?q=context:%40sourcegr
 **raw_scip_payload**: The raw, canonicalized SCIP [Document](https://sourcegraph.com/search?q=context:%40sourcegraph/all+repo:%5Egithub%5C.com/sourcegraph/scip%24+file:%5Escip%5C.proto+message+Document&amp;patternType=standard) payload.
 
 **schema_version**: The schema version of this row - used to determine presence and encoding of (future) denormalized data.
+
+# Table "public.codeintel_scip_documents_dereference_logs"
+```
+      Column       |           Type           | Collation | Nullable |                                Default                                
+-------------------+--------------------------+-----------+----------+-----------------------------------------------------------------------
+ id                | bigint                   |           | not null | nextval('codeintel_scip_documents_dereference_logs_id_seq'::regclass)
+ document_id       | bigint                   |           | not null | 
+ last_removal_time | timestamp with time zone |           | not null | now()
+Indexes:
+    "codeintel_scip_documents_dereference_logs_pkey" PRIMARY KEY, btree (id)
+    "codeintel_scip_documents_dereference_logs_last_removal_time_doc" btree (last_removal_time, document_id)
+
+```
+
+A list of document rows that were recently dereferenced by the deletion of an index.
+
+**document_id**: The identifier of the document that was dereferenced.
+
+**last_removal_time**: The time that the log entry was inserted.
 
 # Table "public.codeintel_scip_documents_schema_versions"
 ```

--- a/migrations/codeintel/1670370058_process_unreferenced_documents/down.sql
+++ b/migrations/codeintel/1670370058_process_unreferenced_documents/down.sql
@@ -1,0 +1,3 @@
+DROP TRIGGER IF EXISTS codeintel_scip_documents_dereference_logs_insert ON codeintel_scip_document_lookup;
+DROP FUNCTION IF EXISTS update_codeintel_scip_documents_dereference_logs_delete;
+DROP TABlE IF EXISTS codeintel_scip_documents_dereference_logs;

--- a/migrations/codeintel/1670370058_process_unreferenced_documents/metadata.yaml
+++ b/migrations/codeintel/1670370058_process_unreferenced_documents/metadata.yaml
@@ -1,0 +1,2 @@
+name: Process unreferenced documents
+parents: [1670365552]

--- a/migrations/codeintel/1670370058_process_unreferenced_documents/up.sql
+++ b/migrations/codeintel/1670370058_process_unreferenced_documents/up.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS codeintel_scip_documents_dereference_logs (
+    id bigserial,
+    document_id bigint NOT NULL,
+    last_removal_time timestamp with time zone NOT NULL DEFAULT NOW(),
+    PRIMARY KEY(id)
+);
+
+COMMENT ON TABLE codeintel_scip_documents_dereference_logs IS 'A list of document rows that were recently dereferenced by the deletion of an index.';
+COMMENT ON COLUMN codeintel_scip_documents_dereference_logs.document_id IS 'The identifier of the document that was dereferenced.';
+COMMENT ON COLUMN codeintel_scip_documents_dereference_logs.last_removal_time IS 'The time that the log entry was inserted.';
+
+CREATE INDEX IF NOT EXISTS codeintel_scip_documents_dereference_logs_last_removal_time_document_id ON codeintel_scip_documents_dereference_logs(last_removal_time, document_id);
+
+CREATE OR REPLACE FUNCTION update_codeintel_scip_documents_dereference_logs_delete() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$ BEGIN
+    INSERT INTO codeintel_scip_documents_dereference_logs (document_id)
+    SELECT document_id FROM oldtab;
+    RETURN NULL;
+END $$;
+
+DROP TRIGGER IF EXISTS codeintel_scip_documents_dereference_logs_insert ON codeintel_scip_document_lookup;
+CREATE TRIGGER codeintel_scip_documents_dereference_logs_insert AFTER DELETE ON codeintel_scip_document_lookup
+REFERENCING OLD TABLE AS oldtab FOR EACH STATEMENT EXECUTE FUNCTION update_codeintel_scip_documents_dereference_logs_delete();


### PR DESCRIPTION
Fixes #45172. This PR adds a trigger on deletion of rows that reference a document. This table is periodically scanned for documents to remove if unreferenced. This allows us a grace period so that we don't encounter race conditions of a new document referencing something halfway deleted.

## Test plan

Tested by hand.