### PR TITLE
web: remove `Send test event` button.

### DIFF
--- a/client/web/src/site-admin/WebhookInfoLogPageHeader.module.scss
+++ b/client/web/src/site-admin/WebhookInfoLogPageHeader.module.scss
@@ -21,7 +21,7 @@
     grid-column: 1 / 2;
 }
 
-.buttons {
+.button {
     grid-column: 4 / 5;
     align-self: end;
 }

--- a/client/web/src/site-admin/WebhookInfoLogPageHeader.tsx
+++ b/client/web/src/site-admin/WebhookInfoLogPageHeader.tsx
@@ -41,7 +41,7 @@ export const WebhookInfoLogPageHeader: React.FunctionComponent<React.PropsWithCh
                     label="recent error"
                 />
             </div>
-            <div className={styles.buttons}>
+            <div className={styles.button}>
                 <Button variant="danger" onClick={onErrorToggle} outline={!onlyErrors}>
                     <Icon
                         className={classNames(styles.icon, onlyErrors && styles.enabled)}
@@ -49,9 +49,6 @@ export const WebhookInfoLogPageHeader: React.FunctionComponent<React.PropsWithCh
                         svgPath={mdiAlertCircle}
                     />
                     <span className="ml-1">Show errors</span>
-                </Button>
-                <Button variant="success" className="ml-2">
-                    <span className="ml-1">Send test event</span>
                 </Button>
             </div>
         </div>


### PR DESCRIPTION
part of https://github.com/sourcegraph/sourcegraph/issues/43050

Test plan:
Storybook.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ao-ui-webhooks-remove-send-test.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
