### PR TITLE
executor: remove unused logger param

### DIFF
--- a/enterprise/cmd/executor/internal/run/run.go
+++ b/enterprise/cmd/executor/internal/run/run.go
@@ -60,7 +60,7 @@ func RunRun(cliCtx *cli.Context, logger log.Logger, cfg *config.Config) error {
 		if err != nil {
 			return err
 		}
-		if err := validateSrcCLIVersion(cliCtx.Context, logger, client, opts.QueueOptions.BaseClientOptions.EndpointOptions); err != nil {
+		if err := validateSrcCLIVersion(cliCtx.Context, client, opts.QueueOptions.BaseClientOptions.EndpointOptions); err != nil {
 			return err
 		}
 

--- a/enterprise/cmd/executor/internal/run/validate.go
+++ b/enterprise/cmd/executor/internal/run/validate.go
@@ -43,7 +43,7 @@ func RunValidate(cliCtx *cli.Context, logger log.Logger, config *config.Config) 
 	// TODO: Validate access token.
 	// Validate src-cli is of a good version, rely on the connected instance to tell
 	// us what "good" means.
-	if err := validateSrcCLIVersion(cliCtx.Context, logger, client, copts.BaseClientOptions.EndpointOptions); err != nil {
+	if err := validateSrcCLIVersion(cliCtx.Context, client, copts.BaseClientOptions.EndpointOptions); err != nil {
 		return err
 	}
 
@@ -81,9 +81,9 @@ func validateGitVersion(ctx context.Context) error {
 }
 
 // validateSrcCLIVersion queries the latest recommended version of src-cli and makes sure it
-// matches what is installed. If not, a warning message recommending to use a different
-// version is logged.
-func validateSrcCLIVersion(ctx context.Context, logger log.Logger, client *apiclient.BaseClient, options apiclient.EndpointOptions) error {
+// matches what is installed. If not, an error recommending to use a different
+// version is returned.
+func validateSrcCLIVersion(ctx context.Context, client *apiclient.BaseClient, options apiclient.EndpointOptions) error {
 	latestVersion, err := latestSrcCLIVersion(ctx, client, options)
 	if err != nil {
 		return errors.Wrap(err, "cannot retrieve latest compatible src-cli version")


### PR DESCRIPTION
@eseliger: I stumbled across this while grinding for the unused params (I'm re-enabling the linters as the root cause that prevented it to be used is fixed). 

Changes are very trivial, but shipping it as a PR just in case you want to treat it differently, as there was a diff in the godoc and what the function was doing. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Trivial change, CI. 
