### PR TITLE
fuzzy finder: increase modal height

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
@@ -2,7 +2,7 @@
 
 .modal {
     height: 80vh;
-    max-height: 426px;
+    max-height: 850px;
     // `!important` is required to ensure that this rule is applied in the production bundle.
     // It can be removed after addressing the following issue:
     // https://github.com/sourcegraph/sourcegraph/issues/42217


### PR DESCRIPTION
Increases the fuzzy finder modal size for better content readability.

## Test plan
Tested manually (screenshots attached to https://github.com/sourcegraph/sourcegraph/pull/45326#issuecomment-1340625343)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-fuzzy-finder.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

