### PR TITLE
Bail before posting a bundle-size report PR message on zero changes

### DIFF
--- a/client/web/scripts/report-bundle-diff.ts
+++ b/client/web/scripts/report-bundle-diff.ts
@@ -21,6 +21,12 @@ async function main(): Promise<void> {
         const [commitFilename, compareFilename] = process.argv.slice(-2)
 
         const report = parseReport(commitFilename, compareFilename)
+
+        if (hasZeroChanges(report)) {
+            console.log('No changes detected in the bundle size, skip posting the comment.')
+            process.exit(0)
+        }
+
         const body = reportToMarkdown(report)
         await createOrUpdateComment(body)
 
@@ -179,4 +185,13 @@ async function fetchPreviousComment(
 
 function shortRev(rev: string | null | undefined): string {
     return rev ? rev.slice(0, 7) : 'unknown'
+}
+
+function hasZeroChanges(report: Report): boolean {
+    for (const metric of report.slice(1) as Metric[]) {
+        if (metric.value !== 0) {
+            return false
+        }
+    }
+    return true
 }


### PR DESCRIPTION
c.f. https://sourcegraph.slack.com/archives/C01C3NCGD40/p1670352722040209

The bundle size bot is annoying when there are zero client bundle changes. Let's not post a recap if this is the case?

## Test plan

- This PR should not have a bundle size summary posted.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-dont-post-size-report-on-zero.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
