### PR TITLE
Fix CodeMirror line start to properly align tab characters when the new blame decorations is rendered

### DIFF
--- a/client/web/src/repo/blob/codemirror/blame-decorations.tsx
+++ b/client/web/src/repo/blob/codemirror/blame-decorations.tsx
@@ -149,15 +149,27 @@ export const showGitBlameDecorations = Facet.define<BlameHunk[], BlameHunk[]>({
         ),
         EditorView.theme({
             '.cm-line': {
-                paddingLeft: '0 !important', // line code content left padding is handled by .blame-decoration right margin
+                // Position relative so that the blame-decoration inside can be
+                // aligned to the start of the line
+                position: 'relative',
+                // Move the start of the line to after the blame decoration.
+                // This is necessary because the start of the line is used for
+                // aligning tab characters.
+                //
+                // 1rem is the default padding-left so we have to add it here
+                paddingLeft: 'calc(var(--blame-decoration-width) + 1rem) !important',
             },
 
             '.blame-decoration': {
+                // Remove the blame decoration from the content flow so that
+                // the tab start can be moved to the right
+                position: 'absolute',
+                left: '0',
+
                 display: 'inline-block',
                 background: 'var(--body-bg)',
                 verticalAlign: 'bottom',
                 width: 'var(--blame-decoration-width)',
-                marginRight: '1rem',
             },
 
             '.selected-line .blame-decoration, .highlighted-line .blame-decoration': {
@@ -165,8 +177,10 @@ export const showGitBlameDecorations = Facet.define<BlameHunk[], BlameHunk[]>({
             },
 
             '.cm-content': {
-                marginLeft: 'calc(var(--blame-decoration-width) * -1)', // Make .cm-content overflow .blame-gutter
-                zIndex: 201, // override default .cm-gutters z-index 200
+                // Make .cm-content overflow .blame-gutter
+                marginLeft: 'calc(var(--blame-decoration-width) * -1)',
+                // override default .cm-gutters z-index 200
+                zIndex: 201,
             },
         }),
     ],


### PR DESCRIPTION
Fixes #45240

The problem here is that tab characters (`\t`) are aligned to the start of the line (so that they are synced with the lines above and below). The way we rendered the blame decoration was causing the start of the line to be at an unexpected position (basically at the start of the blame instead of the start of the visible code line).

The fix here is to remove the blame decoration from the content flow (via `position: absolute;`) and move the start of the line to the left (`padding-left`).

## Test plan

Tested it here:

https://user-images.githubusercontent.com/458591/206161478-8a38e35b-02ba-4559-a0aa-4054df1e9892.mov

We've also checked that it reflows the same way when the browser width is decreased.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-tab-start-for-new-blame.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
