### PR TITLE
gitserver: Demote intermittent error

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -2214,7 +2214,7 @@ func (s *Server) doClone(ctx context.Context, repo api.RepoName, dir GitDir, syn
 	removeBadRefs(ctx, tmp)
 
 	if err := setHEAD(ctx, logger, tmp, syncer, remoteURL); err != nil {
-		logger.Error("Failed to ensure HEAD exists", log.Error(err))
+		logger.Warn("Failed to ensure HEAD exists", log.Error(err))
 		return errors.Wrap(err, "failed to ensure HEAD exists")
 	}
 


### PR DESCRIPTION
We don't need to log this at Error level since it ends up in Sentry.
This is an intermittent error which can be logged at Warning level
instead.

## Test plan

None required, only changed log level.
