### PR TITLE
insights: add user friendly error message for live preview resolver

### DIFF
--- a/enterprise/internal/insights/query/compute_executor.go
+++ b/enterprise/internal/insights/query/compute_executor.go
@@ -69,7 +69,7 @@ func (c *ComputeExecutor) Execute(ctx context.Context, query, groupBy string, re
 
 		grouped, err := c.computeSearch(ctx, finalQuery.String())
 		if err != nil {
-			errorMsg := "failed to execute capture group search for repository:" + repository
+			errorMsg := "failed to execute compute search for repository:" + repository
 			return nil, errors.Wrap(err, errorMsg)
 		}
 

--- a/enterprise/internal/insights/query/streaming_query_executor.go
+++ b/enterprise/internal/insights/query/streaming_query_executor.go
@@ -54,7 +54,7 @@ func (c *StreamingQueryExecutor) ExecuteRepoList(ctx context.Context, query stri
 
 	repoResult := *selectRepoResult
 	if len(repoResult.SkippedReasons) > 0 {
-		c.logger.Error("repo search skipped results", log.String("reasons", fmt.Sprintf("%v", repoResult.SkippedReasons)), log.String("query", query))
+		c.logger.Error("repo search skipped results", log.String("reasons", fmt.Sprintf("%v", repoResult.SkippedReasons)), log.String("query", modified.String()))
 	}
 	if len(repoResult.Errors) > 0 {
 		return nil, errors.Errorf("repo streaming search: errors: %v", repoResult.Errors)
@@ -124,7 +124,7 @@ func (c *StreamingQueryExecutor) Execute(ctx context.Context, query string, seri
 
 			tr := *tabulationResult
 			if len(tr.SkippedReasons) > 0 {
-				c.logger.Error("search skipped results", log.String("reasons", fmt.Sprintf("%v", tr.SkippedReasons)), log.String("query", query))
+				c.logger.Error("search skipped results", log.String("reasons", fmt.Sprintf("%v", tr.SkippedReasons)), log.String("query", modified.String()))
 			}
 			if len(tr.Errors) > 0 {
 				return nil, errors.Errorf("streaming search: errors: %v", tr.Errors)

--- a/enterprise/internal/insights/query/streaming_query_executor.go
+++ b/enterprise/internal/insights/query/streaming_query_executor.go
@@ -119,18 +119,21 @@ func (c *StreamingQueryExecutor) Execute(ctx context.Context, query string, seri
 			c.logger.Debug("executing query", log.String("query", modified.String()))
 			err = streaming.Search(ctx, modified.String(), nil, decoder)
 			if err != nil {
-				return nil, errors.Wrap(err, "streaming.Search")
+				c.logger.Error("search errored", log.Error(err))
+				return nil, errors.New("query search encountered a general error")
 			}
 
 			tr := *tabulationResult
 			if len(tr.SkippedReasons) > 0 {
-				c.logger.Error("insights query issue", log.String("reasons", fmt.Sprintf("%v", tr.SkippedReasons)), log.String("query", query))
+				c.logger.Error("search skipped results", log.String("reasons", fmt.Sprintf("%v", tr.SkippedReasons)), log.String("query", query))
 			}
 			if len(tr.Errors) > 0 {
-				return nil, errors.Errorf("streaming search: errors: %v", tr.Errors)
+				c.logger.Error("search errored", log.String("errors", fmt.Sprintf("%v", tr.Errors)), log.String("query", query))
+				return nil, errors.New("query search encountered errors")
 			}
 			if len(tr.Alerts) > 0 {
-				return nil, errors.Errorf("streaming search: alerts: %v", tr.Alerts)
+				c.logger.Error("search alerted", log.String("alerts", fmt.Sprintf("%v", tr.Alerts)), log.String("query", query))
+				return nil, errors.New("query search encountered alerts")
 			}
 
 			points[execution.RecordingTime] += tr.TotalCount

--- a/enterprise/internal/insights/resolvers/live_preview_resolvers.go
+++ b/enterprise/internal/insights/resolvers/live_preview_resolvers.go
@@ -36,7 +36,7 @@ func (r *Resolver) SearchInsightLivePreview(ctx context.Context, args graphqlbac
 	return r.SearchInsightPreview(ctx, previewArgs)
 }
 
-const livePreviewHumanErrMsg = "the live preview could not be generated because executing a search for query %q errored"
+const livePreviewHumanErrMsg = "the live preview could not be generated because executing a search for the query %q errored"
 
 func (r *Resolver) SearchInsightPreview(ctx context.Context, args graphqlbackend.SearchInsightPreviewArgs) ([]graphqlbackend.SearchInsightLivePreviewSeriesResolver, error) {
 	if args.Input.TimeScope.StepInterval == nil {


### PR DESCRIPTION
backend part of #43674

Add an error friendly live preview error message: "the live preview could not be generated because executing a search for the query errored". Add query to message as we have per-series information.

## Test plan

Manually tested with injected errors (see both error and log message)

<img width="1036" alt="Screenshot 2022-12-07 at 11 41 15" src="https://user-images.githubusercontent.com/29406849/206175228-ab6ae0fe-5744-4103-be5c-92c1dfc900a9.png">

<img width="1056" alt="Screenshot 2022-12-07 at 11 46 05" src="https://user-images.githubusercontent.com/29406849/206175219-b50d8e2d-a632-4c40-8044-359b10a47243.png">
