### PR TITLE
authz resolvers: use observation.Context, remove log15

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -194,6 +194,6 @@ func Init(
 		}
 	}()
 
-	enterpriseServices.AuthzResolver = resolvers.NewResolver(db, timeutil.Now)
+	enterpriseServices.AuthzResolver = resolvers.NewResolver(observationCtx, db, timeutil.Now)
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -52,7 +52,7 @@ func (r *Resolver) checkLicense(feature licensing.Feature) error {
 			return err
 		}
 
-		r.logger.Error("authz.Resolver.checkLicense", log.Error(err))
+		r.logger.Error("Unable to check license for feature", log.Error(err))
 		return errors.New("Unable to check license feature, please refer to logs for actual error message.")
 	}
 	return nil
@@ -60,7 +60,7 @@ func (r *Resolver) checkLicense(feature licensing.Feature) error {
 
 func NewResolver(observationCtx *observation.Context, db database.DB, clock func() time.Time) graphqlbackend.AuthzResolver {
 	return &Resolver{
-		logger:            observationCtx.Logger,
+		logger:            observationCtx.Logger.Scoped("authz.Resolver", ""),
 		db:                edb.NewEnterpriseDB(db),
 		repoupdaterClient: repoupdater.DefaultClient,
 		syncJobsRecords:   syncjobs.NewRecordsReader(),
@@ -352,7 +352,7 @@ func (r *Resolver) SetRepositoryPermissionsForBitbucketProject(
 		return nil, err
 	}
 
-	r.logger.Debug("SetRepositoryPermissionsForBitbucketProject: job enqueued", log.Int("jobID", jobID))
+	r.logger.Debug("Bitbucket project permissions job enqueued", log.Int("jobID", jobID))
 
 	return &graphqlbackend.EmptyResponse{}, nil
 }

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -6,7 +6,8 @@ import (
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
-	"github.com/inconshreveable/log15"
+
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
@@ -21,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -30,6 +32,7 @@ import (
 var errDisabledSourcegraphDotCom = errors.New("not enabled on sourcegraph.com")
 
 type Resolver struct {
+	logger            log.Logger
 	db                edb.EnterpriseDB
 	repoupdaterClient interface {
 		SchedulePermsSync(ctx context.Context, args protocol.PermsSyncRequest) error
@@ -49,14 +52,15 @@ func (r *Resolver) checkLicense(feature licensing.Feature) error {
 			return err
 		}
 
-		log15.Error("authz.Resolver.checkLicense", "err", err)
+		r.logger.Error("authz.Resolver.checkLicense", log.Error(err))
 		return errors.New("Unable to check license feature, please refer to logs for actual error message.")
 	}
 	return nil
 }
 
-func NewResolver(db database.DB, clock func() time.Time) graphqlbackend.AuthzResolver {
+func NewResolver(observationCtx *observation.Context, db database.DB, clock func() time.Time) graphqlbackend.AuthzResolver {
 	return &Resolver{
+		logger:            observationCtx.Logger,
 		db:                edb.NewEnterpriseDB(db),
 		repoupdaterClient: repoupdater.DefaultClient,
 		syncJobsRecords:   syncjobs.NewRecordsReader(),
@@ -348,7 +352,7 @@ func (r *Resolver) SetRepositoryPermissionsForBitbucketProject(
 		return nil, err
 	}
 
-	log15.Debug("SetRepositoryPermissionsForBitbucketProject: job enqueued", "jobID", jobID)
+	r.logger.Debug("SetRepositoryPermissionsForBitbucketProject: job enqueued", log.Int("jobID", jobID))
 
 	return &graphqlbackend.EmptyResponse{}, nil
 }

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
@@ -45,7 +46,8 @@ func clock() time.Time {
 func mustParseGraphQLSchema(t *testing.T, db database.DB) *graphql.Schema {
 	t.Helper()
 
-	parsedSchema, err := graphqlbackend.NewSchemaWithAuthzResolver(db, NewResolver(db, clock))
+	resolver := NewResolver(observation.TestContextTB(t), db, clock)
+	parsedSchema, err := graphqlbackend.NewSchemaWithAuthzResolver(db, resolver)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Noticed this while working on something else: we didn't have a `logger` on the resolver. This changes it.

Also adding @Strum355 as reviewer since he added `observation.Context` and I'm not sure yet whether I use it correctly.

## Test plan

- Existing tests