### PR TITLE
Outbound requests: more fixes

### DIFF
--- a/internal/httpcli/client_test.go
+++ b/internal/httpcli/client_test.go
@@ -633,12 +633,18 @@ func TestExpJitterDelay(t *testing.T) {
 	}
 }
 
-//nolint:unparam // unparam complains that `code` always has same value across call-sites, but that's OK
 func newFakeClient(code int, body []byte, err error) Doer {
+	return newFakeClientWithHeaders(map[string][]string{}, code, body, err)
+}
+
+func newFakeClientWithHeaders(respHeaders map[string][]string, code int, body []byte, err error) Doer {
 	return DoerFunc(func(r *http.Request) (*http.Response, error) {
 		rr := httptest.NewRecorder()
+		for k, v := range respHeaders {
+			rr.Header()[k] = v
+		}
 		_, _ = rr.Write(body)
-		rr.WriteHeader(code)
+		rr.Code = code
 		return rr.Result(), err
 	})
 }

--- a/internal/httpcli/redis_logger_middleware.go
+++ b/internal/httpcli/redis_logger_middleware.go
@@ -241,8 +241,7 @@ func formatStackFrame(function string, file string, line int) string {
 	tree = strings.TrimPrefix(tree, sourcegraphPrefix)
 
 	// Reconstruct the frame file path so that we don't include the local path on the machine that built this instance
-	fileName := strings.TrimPrefix(filepath.Join(tree, filepath.Base(file)), sourcegraphPrefix) // cmd/frontend/graphqlbackend/trace.go
-	fileName = strings.TrimPrefix(fileName, "/")                                                // Strip prefix `/` if there is one
+	fileName := strings.TrimPrefix(filepath.Join(tree, filepath.Base(file)), "/main/") // cmd/frontend/graphqlbackend/trace.go
 
 	return fmt.Sprintf("%s:%d (Function: %s)", fileName, line, funcName)
 }

--- a/internal/httpcli/redis_logger_middleware_test.go
+++ b/internal/httpcli/redis_logger_middleware_test.go
@@ -203,7 +203,7 @@ func TestRedisLoggerMiddleware_formatStackFrame(t *testing.T) {
 			function: "main.f",
 			file:     "/Users/x/file.go",
 			line:     11,
-			want:     "main/file.go:11 (Function: f)",
+			want:     "file.go:11 (Function: f)",
 		},
 	}
 

--- a/internal/httpcli/redis_logger_middleware_test.go
+++ b/internal/httpcli/redis_logger_middleware_test.go
@@ -48,7 +48,7 @@ func TestRedisLoggerMiddleware(t *testing.T) {
 		},
 		{
 			req:  complexReq,
-			name: "complex response",
+			name: "complex request",
 			cli:  newFakeClientWithHeaders(map[string][]string{"X-Test-Header": {"value1", "value2"}}, http.StatusForbidden, []byte(`{"permission":false}`), nil),
 			err:  "<nil>",
 			want: &types.OutboundRequestLogItem{

--- a/internal/httpcli/redis_logger_middleware_test.go
+++ b/internal/httpcli/redis_logger_middleware_test.go
@@ -21,28 +21,47 @@ import (
 func TestRedisLoggerMiddleware(t *testing.T) {
 	rcache.SetupForTest(t)
 
-	req, _ := http.NewRequest("GET", "http://dev/null", strings.NewReader("horse"))
+	normalReq, _ := http.NewRequest("GET", "http://dev/null", strings.NewReader("horse"))
+	complexReq, _ := http.NewRequest("PATCH", "http://test.aa?a=2", strings.NewReader("graph"))
+	complexReq.Header.Set("Cache-Control", "no-cache")
 
 	for _, tc := range []struct {
+		req  *http.Request
 		name string
 		cli  Doer
 		err  string
 		want *types.OutboundRequestLogItem
 	}{
 		{
+			req:  normalReq,
 			name: "normal response",
-			cli:  newFakeClient(http.StatusOK, []byte(`{"responseBody":true}`), nil),
+			cli:  newFakeClientWithHeaders(map[string][]string{"X-Test-Header": {"value"}}, http.StatusOK, []byte(`{"responseBody":true}`), nil),
 			err:  "<nil>",
 			want: &types.OutboundRequestLogItem{
-				Method:          req.Method,
-				URL:             req.URL.String(),
+				Method:          normalReq.Method,
+				URL:             normalReq.URL.String(),
 				RequestHeaders:  map[string][]string{},
 				RequestBody:     "horse",
-				StatusCode:      200,
-				ResponseHeaders: map[string][]string{"Content-Type": {"text/plain; charset=utf-8"}},
+				StatusCode:      http.StatusOK,
+				ResponseHeaders: map[string][]string{"Content-Type": {"text/plain; charset=utf-8"}, "X-Test-Header": {"value"}},
 			},
 		},
 		{
+			req:  complexReq,
+			name: "complex response",
+			cli:  newFakeClientWithHeaders(map[string][]string{"X-Test-Header": {"value1", "value2"}}, http.StatusForbidden, []byte(`{"permission":false}`), nil),
+			err:  "<nil>",
+			want: &types.OutboundRequestLogItem{
+				Method:          complexReq.Method,
+				URL:             complexReq.URL.String(),
+				RequestHeaders:  map[string][]string{"Cache-Control": {"no-cache"}},
+				RequestBody:     "graph",
+				StatusCode:      http.StatusForbidden,
+				ResponseHeaders: map[string][]string{"Content-Type": {"text/plain; charset=utf-8"}, "X-Test-Header": {"value1", "value2"}},
+			},
+		},
+		{
+			req:  normalReq,
 			name: "no response",
 			cli: DoerFunc(func(r *http.Request) (*http.Response, error) {
 				return nil, errors.New("oh no")
@@ -61,7 +80,7 @@ func TestRedisLoggerMiddleware(t *testing.T) {
 			cli := redisLoggerMiddleware()(tc.cli)
 
 			// Send request
-			_, err := cli.Do(req)
+			_, err := cli.Do(tc.req)
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Fatalf("have error: %q\nwant error: %q", have, want)
 			}


### PR DESCRIPTION
Three things:

1. Added special behavior in the case of the `main` package. This was my original intention with the third test case, but then CI failed and wanted me to use `TrimPrefix` rather than `HasPrefix`. I did a last-minute refactor in a rush and introduced two mistakes in the code. 🤦‍♂️  @mrnugget fixed it (thanks!) but not the way I originally intended.
2. I've added a test for response headers and a more complex test case to test for non-200 status codes and array values in headers.
3. I found and fixed a bug in `newFakeClient`. [Here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/internal/httpcli/client_test.go?L640) we wrote the body first, and _then_ tried to set the status code. That didn't actually work because `rr.Write(body)` already wrote a `200` into the status and closed the header by setting `rw.wroteHeader = true`. So line 641 didn't do anything. We never noticed this because we always set `status` to `200` in the existing tests.

## Test plan

Tests should pass