### PR TITLE
Remove unused function parameter

### DIFF
--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -234,13 +234,13 @@ func (c *Client) Urn() string {
 // base path.
 func (c *Client) do(ctx context.Context, req *http.Request, result any) (responseHeader http.Header, responseCode int, err error) {
 	req.URL = c.baseURL.ResolveReference(req.URL)
-	return c.doWithBaseURL(ctx, GetOAuthContext(c.baseURL.String()), req, result)
+	return c.doWithBaseURL(ctx, req, result)
 }
 
 // doWithBaseURL doesn't amend the request URL. When an OAuth Bearer token is
 // used for authentication, it will try to refresh the token and retry the same
 // request when the token has expired.
-func (c *Client) doWithBaseURL(ctx context.Context, oauthContext *oauthutil.OAuthContext, req *http.Request, result any) (responseHeader http.Header, responseCode int, err error) {
+func (c *Client) doWithBaseURL(ctx context.Context, req *http.Request, result any) (responseHeader http.Header, responseCode int, err error) {
 	var responseStatus string
 
 	span, ctx := ot.StartSpanFromContext(ctx, "GitLab")
@@ -360,7 +360,7 @@ func (c *Client) GetAuthenticatedUserOAuthScopes(ctx context.Context) ([]string,
 		Scopes []string `json:"scopes,omitempty"`
 	}{}
 
-	_, _, err = c.doWithBaseURL(ctx, GetOAuthContext(c.baseURL.String()), req, &v)
+	_, _, err = c.doWithBaseURL(ctx, req, &v)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting oauth scopes")
 	}

--- a/internal/extsvc/gitlab/client_test.go
+++ b/internal/extsvc/gitlab/client_test.go
@@ -13,16 +13,14 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/regexp"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/oauth2"
-
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/oauthutil"
 	"github.com/sourcegraph/sourcegraph/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetAuthenticatedUserOAuthScopes(t *testing.T) {

--- a/internal/extsvc/gitlab/client_test.go
+++ b/internal/extsvc/gitlab/client_test.go
@@ -102,16 +102,6 @@ func TestClient_doWithBaseURL(t *testing.T) {
 
 	ctx := context.Background()
 
-	mockOauthContext := &oauthutil.OAuthContext{
-		ClientID:     "client_id",
-		ClientSecret: "client_secret",
-		Endpoint: oauth2.Endpoint{
-			AuthURL:  "url/oauth/authorize",
-			TokenURL: "url/oauth/token",
-		},
-		Scopes: []string{"read_user"},
-	}
-
 	provider := NewClientProvider("Test", baseURL, doer)
 
 	client := provider.getClient(&auth.OAuthBearerToken{Token: "bad token", RefreshToken: "refresh token", RefreshFunc: func(ctx context.Context, cli httpcli.Doer, obt *auth.OAuthBearerToken) (string, string, time.Time, error) {
@@ -125,7 +115,7 @@ func TestClient_doWithBaseURL(t *testing.T) {
 	require.NoError(t, err)
 
 	var result map[string]any
-	_, _, err = client.doWithBaseURL(ctx, mockOauthContext, req, &result)
+	_, _, err = client.doWithBaseURL(ctx, req, &result)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
This PR removes the OAuth context from the doWithBaseURL function, which isn't using it anymore.


## Test plan
Unit test was updated.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
