### PR TITLE
Fix blame component when class contains plus

### DIFF
--- a/client/web/src/repo/blob/BlameColumn.tsx
+++ b/client/web/src/repo/blob/BlameColumn.tsx
@@ -128,6 +128,9 @@ export const BlameColumn = React.memo<BlameColumnProps>(({ isBlameVisible, codeV
                         onSelect={selectRow}
                         onDeselect={deselectRow}
                     />,
+                    // The classname can contain a +, so we would either need to escape it (boo!),
+                    // or just use getElementsByClassName.
+                    // eslint-disable-next-line unicorn/prefer-query-selector
                     portalRoot.getElementsByClassName(styles.wrapper)[0] as HTMLDivElement
                 )
             )}

--- a/client/web/src/repo/blob/BlameColumn.tsx
+++ b/client/web/src/repo/blob/BlameColumn.tsx
@@ -128,7 +128,7 @@ export const BlameColumn = React.memo<BlameColumnProps>(({ isBlameVisible, codeV
                         onSelect={selectRow}
                         onDeselect={deselectRow}
                     />,
-                    portalRoot.querySelector(`.${styles.wrapper}`) as HTMLDivElement
+                    portalRoot.querySelector(`.${styles.wrapper.replaceAll('+', '\\+')}`) as HTMLDivElement
                 )
             )}
         </>

--- a/client/web/src/repo/blob/BlameColumn.tsx
+++ b/client/web/src/repo/blob/BlameColumn.tsx
@@ -128,7 +128,7 @@ export const BlameColumn = React.memo<BlameColumnProps>(({ isBlameVisible, codeV
                         onSelect={selectRow}
                         onDeselect={deselectRow}
                     />,
-                    portalRoot.querySelector(`.${styles.wrapper.replaceAll('+', '\\+')}`) as HTMLDivElement
+                    portalRoot.getElementsByClassName(styles.wrapper)[0] as HTMLDivElement
                 )
             )}
         </>


### PR DESCRIPTION
Okay so weird bug here: The sass classname has a suffix that is the file hash, base64 encoded and then the first 5 characters of that. The base64 charset includes the `+` character, and that character has a special meaning in `querySelector`. This fixes it by properly encoding it.

## Test plan

Verified modules with a + don't break the code blob UI anymore.

## App preview:

- [Web](https://sg-web-es-fix-css-selector.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
