### PR TITLE
docs: First class webhooks

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -7964,7 +7964,7 @@ type TemporarySettings {
 }
 
 """
-Represents a webhook receiver from a code host.
+Represents an incoming webhook from a code host.
 """
 type Webhook implements Node {
     """

--- a/doc/admin/config/batch_changes.md
+++ b/doc/admin/config/batch_changes.md
@@ -123,44 +123,7 @@ To only allow changesets to be reconciled at 1 changeset per minute on (UTC) wee
 
 > NOTE: This feature was added in Sourcegraph 3.33.
 
-Sourcegraph can track incoming webhooks from code hosts to more easily debug issues with webhook delivery. These webhooks can be viewed by going to **Site Admin > Batch Changes > Incoming webhooks**.
-
-By default, sites without [database encryption](encryption.md) enabled will retain three days of webhook logs. Sites with encryption will not retain webhook logs by default, as webhooks may include sensitive information; these sites can enable webhook logging and optionally configure encryption for them by using the settings below.
-
-### Enabling webhook logging
-
-Webhook logging is controlled by the `webhook.logging` site configuration
-option. This option is an object with the following keys:
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `enabled` | `boolean` | If `true`, incoming webhooks will be stored. | `true` if no site encryption is enabled; `false` otherwise. |
-| `retention` | `string` | The length of time to retain the webhooks, expressed as a valid [Go duration](https://pkg.go.dev/time#ParseDuration). | `72h` |
-
-#### Examples
-
-To disable webhook logging:
-
-```json
-{
-  "webhook.logging": {"enabled": false}
-}
-```
-
-To retain webhook logs for one day:
-
-```json
-{
-  "webhook.logging": {
-    "enabled": false,
-    "retention": "24h"
-  }
-}
-```
-
-### Encrypting webhook logs
-
-Webhook logs can be encrypted by specifying a `webhookLogKey` in the [on-disk database encryption site configuration](encryption.md).
+Details [here](../../admin/config/webhooks.md#webhook-logging)
 
 ## Forks
 

--- a/doc/admin/config/batch_changes.md
+++ b/doc/admin/config/batch_changes.md
@@ -123,7 +123,7 @@ To only allow changesets to be reconciled at 1 changeset per minute on (UTC) wee
 
 > NOTE: This feature was added in Sourcegraph 3.33.
 
-Details [here](../../admin/config/webhooks.md#webhook-logging)
+Sourcegraph can track incoming webhooks from code hosts to more easily debug issues with webhook delivery. Learn [how to setup webhooks and configure logging](../../admin/config/webhooks.md#webhook-logging).
 
 ## Forks
 

--- a/doc/admin/config/index.md
+++ b/doc/admin/config/index.md
@@ -23,6 +23,7 @@ This page documents how to configure a Sourcegraph instance. For deployment conf
 - [Using external services (PostgreSQL, Redis, S3/GCS)](../external_services/index.md)
 - [PostgreSQL Config](./postgres-conf.md)
 - [Disabling user invitations](./user_invitations.md)
+- [Configuring incoming webhooks](./webhooks.md)
 
 ## Advanced tasks
 

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -21,7 +21,7 @@ As of Sourcegraph 4.3.0 webhooks added via code host configuration are deprecate
 This includes any webhooks pointed at URLs starting with the following:
 
 * `.api/github-webhooks`
-* `.api//gitlab-webhooks`
+* `.api/gitlab-webhooks`
 * `.api/bitbucket-server-webhooks`
 * `.api/bitbucket-cloud-webhooks`
 

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -27,8 +27,8 @@ The incoming webhook will be configured to accept events from a specific code ho
 1. Navigate to **Site Admin > Incoming webhooks**
 1. Click **Add webhook**
 1. Fill out the form:
-   1. **Webhook name**: Descriptive name for the webhook, initially populate by the code host URN.
-   1. **Code host type**: Select from the dropdown. This will be filtered based on code host connections added on your instance. 
+   1. **Webhook name**: Descriptive name for the webhook.
+   1. **Code host type**: Select from the dropdown. This will be filtered based on code host connections added on your instance.
    1. **Code host URN**: The URN for the code host. Again, this will be filtered by code host connections added on your instance.
    1. **Secret**: An arbitrary shared secret between Sourcegraph and the code host. A default value is provided, but you are free to change it.
        > NOTE: Secrets are not supported for BitBucket cloud
@@ -97,11 +97,11 @@ The [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#
 1. Install the [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#sourcegraph-bitbucket-server-plugin) on your Bitbucket Server / Bitbucket Data Center instance.
 1. On your Bitbucket Server / Bitbucket Data Center instance, go to **Administration > Add-ons > Sourcegraph**
 1. Fill in the **Add a webhook** form
-   * **Name**: A unique name representing your Sourcegraph instance
-   * **Scope**: `global`
-   * **Endpoint**: The URL found after creating a webhook receiver
+   * **Name**: A unique name representing your Sourcegraph instance.
+   * **Scope**: `global`.
+   * **Endpoint**: The URL found after creating an incoming webhook.
    * **Events**: `repo:build_status`, `pr:activity:status`, `pr:activity:event`, `pr:activity:rescope`, `pr:activity:merge`, `pr:activity:comment`, `pr:activity:reviewers`, `pr:participant:status`
-   * **Secret**: The secret you configured when creating the incoming webhook
+   * **Secret**: The secret you configured when creating the incoming webhook.
 1. Confirm that the new webhook is listed under **All webhooks** with a timestamp in the **Last successful** column.
 
 Done! Sourcegraph will now receive webhook events from Bitbucket Server / Bitbucket Data Center and use them to sync pull request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.
@@ -115,9 +115,9 @@ Done! Sourcegraph will now receive webhook events from Bitbucket Server / Bitbuc
 1. On Bitbucket Cloud, go to each repository, and then **Repository settings > Webhooks**.
 1. Click **Add webhook**.
 1. Fill in the webhook form:
-   * **Title**: any title.
-   * **URL**: the URL found after creating an incoming webhook
-   * **Triggers**: select **Build status created** and **Build status updated** under **Repository**, and every item under **Pull request**.
+   * **Title**: Any title.
+   * **URL**: The URL found after creating an incoming webhook.
+   * **Triggers**: Select **Build status created** and **Build status updated** under **Repository**, and every item under **Pull request**.
 1. Click **Save**.
 1. Confirm that the new webhook is listed below **Repository hooks**.
 

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -89,9 +89,6 @@ To retain webhook logs for one day:
 ### Encrypting webhook logs
 
 Webhook logs can be encrypted by specifying a `webhookLogKey` in the [on-disk database encryption site configuration](encryption.md).
-
-
-
 Recent received webhook payloads can be seen on the webhook details page for each receiver.
   
  > NOTE: Deprecated webhooks added via code host configuration can be viewed in **Site Admin > Batch Changes > Incoming webhooks**. Webhook logging can be configured through the [incoming webhooks site configuration](../../admin/config/batch_changes.md#incoming-webhooks).

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -13,6 +13,20 @@ Bitbucket Cloud | 🟢 | 🔴
 
 Webhooks need to be configured both on the sending side, the code host and receiveing side, Sourcegraph.
 
+
+## Deprecation notice
+
+As of Sourcegraph 4.3.0 webhooks added via code host configuration are deprecated and support will be removed in release 4.6.0.
+
+This includes any webhooks pointed at URLs starting with the following:
+
+* `.api/github-webhooks`
+* `.api//gitlab-webhooks`
+* `.api/bitbucket-server-webhooks`
+* `.api/bitbucket-cloud-webhooks`
+
+In order to continue using webhooks you need to follow the steps below to [add a receiver](#adding-a-receiver) and then update the webhook configured on your code host with the new webhook url which will look something like `https://sourcegraph-instance/.api/webhooks/{UUID}`
+
 ## Adding a receiver
 
 Before adding a webhook receiver you should ensure that you have at least one [code host connection](../external_service) configured. 
@@ -31,6 +45,56 @@ In order to receive webhook events you need to add a receiver. The receiver will
 The receiver will now be created and you will be redirected to a page showing more details of the created webhook.
 
 Most importantly, you will be presented with the unique URL for this webhook which is required when configuring the webhook on your code host.
+
+## Webhook logging
+
+Sourcegraph can track incoming webhooks from code hosts to more easily debug issues with webhook delivery. These webhooks can be viewed in two places depending on how they were added:
+
+1. Via code host connection: **Site Admin > Batch Changes > Incoming webhooks**.
+1. Via **Site Admin > Incoming webhooks**:  In the details are for each added receiver.
+
+By default, sites without [database encryption](encryption.md) enabled will retain three days of webhook logs. Sites with encryption will not retain webhook logs by default, as webhooks may include sensitive information; these sites can enable webhook logging and optionally configure encryption for them by using the settings below.
+
+### Enabling webhook logging
+
+Webhook logging is controlled by the `webhook.logging` site configuration
+option. This option is an object with the following keys:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | `boolean` | If `true`, incoming webhooks will be stored. | `true` if no site encryption is enabled; `false` otherwise. |
+| `retention` | `string` | The length of time to retain the webhooks, expressed as a valid [Go duration](https://pkg.go.dev/time#ParseDuration). | `72h` |
+
+#### Examples
+
+To disable webhook logging:
+
+```json
+{
+  "webhook.logging": {"enabled": false}
+}
+```
+
+To retain webhook logs for one day:
+
+```json
+{
+  "webhook.logging": {
+    "enabled": false,
+    "retention": "24h"
+  }
+}
+```
+
+### Encrypting webhook logs
+
+Webhook logs can be encrypted by specifying a `webhookLogKey` in the [on-disk database encryption site configuration](encryption.md).
+
+
+
+Recent received webhook payloads can be seen on the webhook details page for each receiver.
+  
+ > NOTE: Deprecated webhooks added via code host configuration can be viewed in **Site Admin > Batch Changes > Incoming webhooks**. Webhook logging can be configured through the [incoming webhooks site configuration](../../admin/config/batch_changes.md#incoming-webhooks).
 
 ## Configuring webhooks on the code host
 

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -11,7 +11,7 @@ GitLab | 🟢 | 🔴
 Bitbucket Server / Datacenter | 🟢 | 🔴 
 Bitbucket Cloud | 🟢 | 🔴
 
-Webhooks need to be configured both on the sending side, the code host and receiveing side, Sourcegraph.
+Webhooks need to be configured both on the sending side, the code host and receiving side, Sourcegraph respectivley.
 
 ## Deprecation notice
 

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -34,7 +34,7 @@ Before adding a webhook receiver you should ensure that you have at least one [c
 In order to receive webhook events you need to add a receiver. The receiver will be configured to accept events from a specific code host connection based on it's type and URN.
 
 1. Navigate to **Site Admin > Incoming webhooks**
-1. Click `Add webhook`
+1. Click **Add webhook**
 1. You'll be presented with a form to create a new webhook receiver:
    1. Webhook name: Optional descriptive name for the webhook
    1. Code host type: Select from the dropdown. This will be filtered based on code host connections added on your instance. 

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -16,7 +16,7 @@ GitLab | 🟢 | 🔴
 Bitbucket Server / Datacenter | 🟢 | 🔴 
 Bitbucket Cloud | 🟢 | 🔴
 
-Webhooks need to be configured both on the sending side, the code host and receiving side, Sourcegraph respectivley.
+To receive webhooks both the receiving and sending side need to be configured. To configure the receiving side, [add an incoming webhook](#adding-an-incoming-webhook). Set up the sending side by [configuring webhooks on your code host](#configuring-webhooks-on-the-code-host)
 
 ## Deprecation notice
 

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -1,10 +1,15 @@
 # Incoming webhooks
 
-Incoming webhooks can be configured on a Sourcegraph instance in order to receive webhook events from code hosts. This allows Sourcegraph to react more quickly to events that occur outside of the instance. 
+Incoming webhooks can be configured on a Sourcegraph instance in order to receive webhook events from code hosts. This allows Sourcegraph to react more quickly to events that occur outside of the instance instead of polling for changes.
 
-We currently support webhooks for the following:
+Webhooks are currently implemented to speed up two types of external events:
 
-Code host | [Batch changes](../../batch_changes/index.md) | Repository push
+* Keeping batch changes changeset details up to date
+* Keeping code on Sourcegraph fresh by responding to new code being pushed to a repository
+
+See the table below for code host compatibility:
+
+Code host | [Batch changes](../../batch_changes/index.md) | Code push
 --------- | :-: | :-:
 GitHub | 🟢 | 🟢 
 GitLab | 🟢 | 🔴
@@ -74,7 +79,7 @@ The instructions for setting up webhooks on the code host are specific to each c
 
 Done! Sourcegraph will now receive webhook events from GitHub and use them to sync pull request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.
 
-#### Repository push
+#### Code push
 
 Follow the same steps as above, but ensure you include the `push` event under **Let me select individual events**
 

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -36,10 +36,10 @@ In order to receive webhook events you need to add a receiver. The receiver will
 1. Navigate to **Site Admin > Incoming webhooks**
 1. Click **Add webhook**
 1. You'll be presented with a form to create a new webhook receiver:
-   1. Webhook name: Optional descriptive name for the webhook
-   1. Code host type: Select from the dropdown. This will be filtered based on code host connections added on your instance. 
-   1. Code host URN: The URN for the code host. Again, this will be filtered by code host connections added on your instance.
-   1. Secret: If supported by the code host, this is an arbitrary shared secret between Sourcegraph and the code host. A default value is provided but you are free to change it.
+   1. **Webhook name**: Optional descriptive name for the webhook
+   1. **Code host type**: Select from the dropdown. This will be filtered based on code host connections added on your instance. 
+   1. **Code host URN**: The URN for the code host. Again, this will be filtered by code host connections added on your instance.
+   1. **Secret**: If supported by the code host, this is an arbitrary shared secret between Sourcegraph and the code host. A default value is provided but you are free to change it.
 1. Click **Create**
 
 The receiver will now be created and you will be redirected to a page showing more details of the created webhook.

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -1,6 +1,6 @@
 # Incoming webhooks
 
-Incoming webhooks can be configured on a Sourcegraph instance in order to receive webhook events from code hosts. This allows Sourcegraph to react more quickly to events that occur outside of the instance instead of polling for changes.
+Incoming webhooks can be configured on a Sourcegraph instance in order to receive webhook events from code hosts. This allows Sourcegraph to react more quickly to events that occur outside the instance instead of polling for changes.
 
 Webhooks are currently implemented to speed up two types of external events:
 
@@ -35,7 +35,7 @@ In order to continue using webhooks you need to follow the steps below to [add a
 
 Before adding an incoming webhook you should ensure that you have at least one [code host connection](../external_services/index.md) configured. 
 
-The incoming webhook will be configured to accept events from a specific code host connection based on it's type and URN.
+The incoming webhook will be configured to accept events from a specific code host connection based on its type and URN.
 
 1. Navigate to **Site Admin > Incoming webhooks**
 1. Click **Add webhook**
@@ -43,11 +43,11 @@ The incoming webhook will be configured to accept events from a specific code ho
    1. **Webhook name**: Descriptive name for the webhook, initially populate by the code host URN.
    1. **Code host type**: Select from the dropdown. This will be filtered based on code host connections added on your instance. 
    1. **Code host URN**: The URN for the code host. Again, this will be filtered by code host connections added on your instance.
-   1. **Secret**: An arbitrary shared secret between Sourcegraph and the code host. A default value is provided but you are free to change it.
+   1. **Secret**: An arbitrary shared secret between Sourcegraph and the code host. A default value is provided, but you are free to change it.
        > NOTE: Secrets are not supported for BitBucket cloud
 1. Click **Create**
 
-The incoming webhook will now be created and you will be redirected to a page showing more details.
+The incoming webhook will now be created, and you will be redirected to a page showing more details.
 
 Use the unique URL present on the details page to configure [the webhook on your code host](#configuring-webhooks-on-the-code-host).
 

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -35,14 +35,14 @@ In order to receive webhook events you need to add a receiver. The receiver will
 
 1. Navigate to **Site Admin > Incoming webhooks**
 1. Click **Add webhook**
-1. You'll be presented with a form to create a new webhook receiver:
+1. Fill out the form:
    1. **Webhook name**: Optional descriptive name for the webhook
    1. **Code host type**: Select from the dropdown. This will be filtered based on code host connections added on your instance. 
    1. **Code host URN**: The URN for the code host. Again, this will be filtered by code host connections added on your instance.
    1. **Secret**: If supported by the code host, this is an arbitrary shared secret between Sourcegraph and the code host. A default value is provided but you are free to change it.
 1. Click **Create**
 
-The receiver will now be created and you will be redirected to a page showing more details of the created webhook.
+The incoming webhook will now be created and you will be redirected to a page showing more details.
 
 Most importantly, you will be presented with the unique URL for this webhook which is required when configuring the webhook on your code host.
 

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -33,7 +33,7 @@ Before adding a webhook receiver you should ensure that you have at least one [c
 
 In order to receive webhook events you need to add a receiver. The receiver will be configured to accept events from a specific code host connection based on it's type and URN.
 
-1. Navigate to Site Admin > Incoming webhooks
+1. Navigate to **Site Admin > Incoming webhooks**
 1. Click `Add webhook`
 1. You'll be presented with a form to create a new webhook receiver:
    1. Webhook name: Optional descriptive name for the webhook

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -1,0 +1,118 @@
+# Webhooks
+
+Webhook receivers can be configured on a Sourcegraph instance in order to receive webhook events from code hosts. This allows Sourcegraph to react more quickly to events that occur outside of the instance. 
+
+We currently support webhooks for the following:
+
+Code host | [Batch changes](../../batch_changes/index.md) | Repository push
+--------- | :-: | :-:
+GitHub | 🟢 | 🟢 
+GitLab | 🟢 | 🔴
+Bitbucket Server / Datacenter | 🟢 | 🔴 
+Bitbucket Cloud | 🟢 | 🔴
+
+Webhooks need to be configured both on the sending side, the code host and receiveing side, Sourcegraph.
+
+## Adding a receiver
+
+Before adding a webhook receiver you should ensure that you have at least one [code host connection](../external_service) configured. 
+
+In order to receive webhook events you need to add a receiver. The receiver will be configured to accept events from a specific code host connection based on it's type and URN.
+
+1. Navigate to Site Admin > Incoming webhooks
+1. Click `Add webhook`
+1. You'll be presented with a form to create a new webhook receiver:
+   1. Webhook name: Optional descriptive name for the webhook
+   1. Code host type: Select from the dropdown. This will be filtered based on code host connections added on your instance. 
+   1. Code host URN: The URN for the code host. Again, this will be filtered by code host connections added on your instance.
+   1. Secret: If supported by the code host, this is an arbitrary shared secret between Sourcegraph and the code host. A default value is provided but you are free to change it.
+1. Click `Create`
+
+The receiver will now be created and you will be redirected to a page showing more details of the created webhook.
+
+Most importantly, you will be presented with the unique URL for this webhook which is required when configuring the webhook on your code host.
+
+## Configuring webhooks on the code host
+
+The instructions for setting up webhooks on the code host are specific to each code host type.
+
+### GitHub
+
+#### Batch changes
+
+1. Copy the webhook URL displayed after adding the receiver as mentioned [above](#adding-a-receiver)
+1. On GitHub, go to the settings page of your organization. From there, click **Settings**, then **Webhooks**, then **Add webhook**.
+1. Fill in the webhook form:
+   * **Payload URL**: the URL you copied above from Sourcegraph.
+   * **Content type**: this must be set to `application/json`.
+   * **Secret**: the secret token you configured Sourcegraph to use above.
+   * **Which events**: select **Let me select individual events**, and then enable:
+     - Issue comments
+     - Pull requests
+     - Pull request reviews
+     - Pull request review comments
+     - Check runs
+     - Check suites
+     - Statuses
+   * **Active**: ensure this is enabled.
+1. Click **Add webhook**.
+1. Confirm that the new webhook is listed.
+
+Done! Sourcegraph will now receive webhook events from GitHub and use them to sync pull request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.
+
+#### Repository push
+
+Follow the same steps as above, but ensure you include the `push` event under **Let me select individual events**
+
+### GitLab
+
+#### Batch changes
+
+1. Copy the webhook URL displayed after adding the receiver as mentioned [above](#adding-a-receiver)
+1. On GitLab, go to your project, and then **Settings > Webhooks** (or **Settings > Integration** on older GitLab versions that don't have the **Webhooks** option).
+1. Fill in the webhook form:
+   * **URL**: the URL you copied above from Sourcegraph.
+   * **Secret token**: the secret token you configured Sourcegraph to use above.
+   * **Trigger**: select **Merge request events** and **Pipeline events**.
+   * **Enable SSL verification**: ensure this is enabled if you have configured SSL with a valid certificate in your Sourcegraph instance.
+1. Click **Add webhook**.
+1. Confirm that the new webhook is listed below **Project Hooks**.
+
+Done! Sourcegraph will now receive webhook events from GitLab and use them to sync merge request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.
+
+**NOTE:** We currently do not support [system webhooks](https://docs.gitlab.com/ee/administration/system_hooks.html) as these provide a different set of payloads.
+
+### Bitbucket server
+
+#### Batch changes
+
+The [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#sourcegraph-bitbucket-server-plugin) enables the Bitbucket Server / Bitbucket Data Center instance to send webhooks to Sourcegraph.
+
+1. Install the [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#sourcegraph-bitbucket-server-plugin) on your Bitbucket Server / Bitbucket Data Center instance.
+1. On your Bitbucket Server / Bitbucket Data Center instance, go to **Administration > Add-ons > Sourcegraph**
+1. Fill in the **Add a webhook** form
+   * **Name**: A unique name representing your Sourcegraph instance
+   * **Scope**: `global`
+   * **Endpoint**: The URL found after creating a webhook receiver
+   * **Events**: `repo:build_status`, `pr:activity:status`, `pr:activity:event`, `pr:activity:rescope`, `pr:activity:merge`, `pr:activity:comment`, `pr:activity:reviewers`, `pr:participant:status`
+   * **Secret**: The secret you configured when creating the webhook receiver
+1. Confirm that the new webhook is listed under **All webhooks** with a timestamp in the **Last successful** column.
+
+Done! Sourcegraph will now receive webhook events from Bitbucket Server / Bitbucket Data Center and use them to sync pull request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.
+
+### Bitbucket cloud
+
+#### Batch changes
+
+> NOTE: Experimental webhook support for Bitbucket Cloud was added in Sourcegraph 3.40. Please <a href="https://about.sourcegraph.com/contact">contact us</a> with any issues found while using webhooks.
+
+1. On Bitbucket Cloud, go to each repository, and then **Repository settings > Webhooks**.
+1. Click **Add webhook**.
+1. Fill in the webhook form:
+   * **Title**: any title.
+   * **URL**: the URL found after creating a webhokk receiver
+   * **Triggers**: select **Build status created** and **Build status updated** under **Repository**, and every item under **Pull request**.
+1. Click **Save**.
+1. Confirm that the new webhook is listed below **Repository hooks**.
+
+Done! Sourcegraph will now receive webhook events from Bitbucket Cloud and use them to sync pull request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -40,7 +40,7 @@ The incoming webhook will be configured to accept events from a specific code ho
 1. Navigate to **Site Admin > Incoming webhooks**
 1. Click **Add webhook**
 1. Fill out the form:
-   1. **Webhook name**: Optional descriptive name for the webhook
+   1. **Webhook name**: Descriptive name for the webhook, initially populate by the code host URN.
    1. **Code host type**: Select from the dropdown. This will be filtered based on code host connections added on your instance. 
    1. **Code host URN**: The URN for the code host. Again, this will be filtered by code host connections added on your instance.
    1. **Secret**: An arbitrary shared secret between Sourcegraph and the code host. A default value is provided but you are free to change it.

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -51,7 +51,7 @@ Most importantly, you will be presented with the unique URL for this webhook whi
 Sourcegraph can track incoming webhooks from code hosts to more easily debug issues with webhook delivery. These webhooks can be viewed in two places depending on how they were added:
 
 1. Via code host connection: **Site Admin > Batch Changes > Incoming webhooks**.
-1. Via **Site Admin > Incoming webhooks**:  In the details are for each added receiver.
+1. Via **Site Admin > Incoming webhooks**
 
 By default, sites without [database encryption](encryption.md) enabled will retain three days of webhook logs. Sites with encryption will not retain webhook logs by default, as webhooks may include sensitive information; these sites can enable webhook logging and optionally configure encryption for them by using the settings below.
 

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -18,19 +18,6 @@ Bitbucket Cloud | 🟢 | 🔴
 
 To receive webhooks both the receiving and sending side need to be configured. To configure the receiving side, [add an incoming webhook](#adding-an-incoming-webhook). Set up the sending side by [configuring webhooks on your code host](#configuring-webhooks-on-the-code-host)
 
-## Deprecation notice
-
-As of Sourcegraph 4.3.0 webhooks added via code host configuration are deprecated and support will be removed in release 4.6.0.
-
-This includes any webhooks pointed at URLs starting with the following:
-
-* `.api/github-webhooks`
-* `.api/gitlab-webhooks`
-* `.api/bitbucket-server-webhooks`
-* `.api/bitbucket-cloud-webhooks`
-
-In order to continue using webhooks you need to follow the steps below to [add an incoming webhook](#adding-an-incoming-webhook) and then update the webhook configured on your code host with the new webhook url which will look something like `https://sourcegraph-instance/.api/webhooks/{UUID}`
-
 ## Adding an incoming webhook
 
 Before adding an incoming webhook you should ensure that you have at least one [code host connection](../external_services/index.md) configured. 
@@ -179,3 +166,16 @@ To retain webhook logs for one day:
 ### Encrypting webhook logs
 
 Webhook logs can be encrypted by specifying a `webhookLogKey` in the [on-disk database encryption site configuration](encryption.md).
+
+## Deprecation notice
+
+As of Sourcegraph 4.3.0 webhooks added via code host configuration are deprecated and support will be removed in release 4.6.0.
+
+This includes any webhooks pointed at URLs starting with the following:
+
+* `.api/github-webhooks`
+* `.api/gitlab-webhooks`
+* `.api/bitbucket-server-webhooks`
+* `.api/bitbucket-cloud-webhooks`
+
+In order to continue using webhooks you need to follow the steps below to [add an incoming webhook](#adding-an-incoming-webhook) and then update the webhook configured on your code host with the new webhook url which will look something like `https://sourcegraph-instance/.api/webhooks/{UUID}`

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -43,7 +43,7 @@ The incoming webhook will be configured to accept events from a specific code ho
 
 The incoming webhook will now be created and you will be redirected to a page showing more details.
 
-Most importantly, you will be presented with the unique URL for this webhook which is required when configuring the webhook on your code host.
+Use the unique URL present on the details page to configure [the webhook on your code host](#configuring-webhooks-on-the-code-host).
 
 ## Configuring webhooks on the code host
 
@@ -173,6 +173,3 @@ To retain webhook logs for one day:
 ### Encrypting webhook logs
 
 Webhook logs can be encrypted by specifying a `webhookLogKey` in the [on-disk database encryption site configuration](encryption.md).
-Recent received webhook payloads can be seen on the webhook details page for each incoming webhook.
-  
- > NOTE: Deprecated webhooks added via code host configuration can be viewed in **Site Admin > Batch Changes > Incoming webhooks**. Webhook logging can be configured through the [incoming webhooks site configuration](../../admin/config/batch_changes.md#incoming-webhooks).

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -1,6 +1,6 @@
-# Webhooks
+# Incoming webhooks
 
-Webhook receivers can be configured on a Sourcegraph instance in order to receive webhook events from code hosts. This allows Sourcegraph to react more quickly to events that occur outside of the instance. 
+Incoming webhooks can be configured on a Sourcegraph instance in order to receive webhook events from code hosts. This allows Sourcegraph to react more quickly to events that occur outside of the instance. 
 
 We currently support webhooks for the following:
 
@@ -25,13 +25,13 @@ This includes any webhooks pointed at URLs starting with the following:
 * `.api/bitbucket-server-webhooks`
 * `.api/bitbucket-cloud-webhooks`
 
-In order to continue using webhooks you need to follow the steps below to [add a receiver](#adding-a-receiver) and then update the webhook configured on your code host with the new webhook url which will look something like `https://sourcegraph-instance/.api/webhooks/{UUID}`
+In order to continue using webhooks you need to follow the steps below to [add an incoming webhook](#adding-an-incoming-webhook) and then update the webhook configured on your code host with the new webhook url which will look something like `https://sourcegraph-instance/.api/webhooks/{UUID}`
 
-## Adding a receiver
+## Adding an incoming webhook
 
-Before adding a webhook receiver you should ensure that you have at least one [code host connection](../external_services/index.md) configured. 
+Before adding an incoming webhook you should ensure that you have at least one [code host connection](../external_services/index.md) configured. 
 
-In order to receive webhook events you need to add a receiver. The receiver will be configured to accept events from a specific code host connection based on it's type and URN.
+The incoming webhook will be configured to accept events from a specific code host connection based on it's type and URN.
 
 1. Navigate to **Site Admin > Incoming webhooks**
 1. Click **Add webhook**
@@ -50,8 +50,8 @@ Most importantly, you will be presented with the unique URL for this webhook whi
 
 Sourcegraph can track incoming webhooks from code hosts to more easily debug issues with webhook delivery. These webhooks can be viewed in two places depending on how they were added:
 
-1. Via code host connection: **Site Admin > Batch Changes > Incoming webhooks**.
 1. Via **Site Admin > Incoming webhooks**
+1. **Deprecated** Via code host connection: **Site Admin > Batch Changes > Incoming webhooks**
 
 By default, sites without [database encryption](encryption.md) enabled will retain three days of webhook logs. Sites with encryption will not retain webhook logs by default, as webhooks may include sensitive information; these sites can enable webhook logging and optionally configure encryption for them by using the settings below.
 
@@ -89,7 +89,7 @@ To retain webhook logs for one day:
 ### Encrypting webhook logs
 
 Webhook logs can be encrypted by specifying a `webhookLogKey` in the [on-disk database encryption site configuration](encryption.md).
-Recent received webhook payloads can be seen on the webhook details page for each receiver.
+Recent received webhook payloads can be seen on the webhook details page for each incoming webhook.
   
  > NOTE: Deprecated webhooks added via code host configuration can be viewed in **Site Admin > Batch Changes > Incoming webhooks**. Webhook logging can be configured through the [incoming webhooks site configuration](../../admin/config/batch_changes.md#incoming-webhooks).
 
@@ -101,7 +101,7 @@ The instructions for setting up webhooks on the code host are specific to each c
 
 #### Batch changes
 
-1. Copy the webhook URL displayed after adding the receiver as mentioned [above](#adding-a-receiver)
+1. Copy the webhook URL displayed after adding the incoming webhook as mentioned [above](#adding-an-incoming-webhook)
 1. On GitHub, go to the settings page of your organization. From there, click **Settings**, then **Webhooks**, then **Add webhook**.
 1. Fill in the webhook form:
    * **Payload URL**: the URL you copied above from Sourcegraph.
@@ -129,7 +129,7 @@ Follow the same steps as above, but ensure you include the `push` event under **
 
 #### Batch changes
 
-1. Copy the webhook URL displayed after adding the receiver as mentioned [above](#adding-a-receiver)
+1. Copy the webhook URL displayed after adding the incoming webhook as mentioned [above](#adding-an-incoming-webhook)
 1. On GitLab, go to your project, and then **Settings > Webhooks** (or **Settings > Integration** on older GitLab versions that don't have the **Webhooks** option).
 1. Fill in the webhook form:
    * **URL**: the URL you copied above from Sourcegraph.
@@ -156,7 +156,7 @@ The [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#
    * **Scope**: `global`
    * **Endpoint**: The URL found after creating a webhook receiver
    * **Events**: `repo:build_status`, `pr:activity:status`, `pr:activity:event`, `pr:activity:rescope`, `pr:activity:merge`, `pr:activity:comment`, `pr:activity:reviewers`, `pr:participant:status`
-   * **Secret**: The secret you configured when creating the webhook receiver
+   * **Secret**: The secret you configured when creating the incoming webhook
 1. Confirm that the new webhook is listed under **All webhooks** with a timestamp in the **Last successful** column.
 
 Done! Sourcegraph will now receive webhook events from Bitbucket Server / Bitbucket Data Center and use them to sync pull request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.
@@ -171,7 +171,7 @@ Done! Sourcegraph will now receive webhook events from Bitbucket Server / Bitbuc
 1. Click **Add webhook**.
 1. Fill in the webhook form:
    * **Title**: any title.
-   * **URL**: the URL found after creating a webhokk receiver
+   * **URL**: the URL found after creating an incoming webhook
    * **Triggers**: select **Build status created** and **Build status updated** under **Repository**, and every item under **Pull request**.
 1. Click **Save**.
 1. Confirm that the new webhook is listed below **Repository hooks**.

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -29,7 +29,7 @@ In order to continue using webhooks you need to follow the steps below to [add a
 
 ## Adding a receiver
 
-Before adding a webhook receiver you should ensure that you have at least one [code host connection](../external_service) configured. 
+Before adding a webhook receiver you should ensure that you have at least one [code host connection](../external_services/index.md) configured. 
 
 In order to receive webhook events you need to add a receiver. The receiver will be configured to accept events from a specific code host connection based on it's type and URN.
 

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -40,7 +40,7 @@ In order to receive webhook events you need to add a receiver. The receiver will
    1. Code host type: Select from the dropdown. This will be filtered based on code host connections added on your instance. 
    1. Code host URN: The URN for the code host. Again, this will be filtered by code host connections added on your instance.
    1. Secret: If supported by the code host, this is an arbitrary shared secret between Sourcegraph and the code host. A default value is provided but you are free to change it.
-1. Click `Create`
+1. Click **Create**
 
 The receiver will now be created and you will be redirected to a page showing more details of the created webhook.
 

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -13,7 +13,6 @@ Bitbucket Cloud | 🟢 | 🔴
 
 Webhooks need to be configured both on the sending side, the code host and receiveing side, Sourcegraph.
 
-
 ## Deprecation notice
 
 As of Sourcegraph 4.3.0 webhooks added via code host configuration are deprecated and support will be removed in release 4.6.0.
@@ -45,53 +44,6 @@ The incoming webhook will be configured to accept events from a specific code ho
 The incoming webhook will now be created and you will be redirected to a page showing more details.
 
 Most importantly, you will be presented with the unique URL for this webhook which is required when configuring the webhook on your code host.
-
-## Webhook logging
-
-Sourcegraph can track incoming webhooks from code hosts to more easily debug issues with webhook delivery. These webhooks can be viewed in two places depending on how they were added:
-
-1. Via **Site Admin > Incoming webhooks**
-1. **Deprecated** Via code host connection: **Site Admin > Batch Changes > Incoming webhooks**
-
-By default, sites without [database encryption](encryption.md) enabled will retain three days of webhook logs. Sites with encryption will not retain webhook logs by default, as webhooks may include sensitive information; these sites can enable webhook logging and optionally configure encryption for them by using the settings below.
-
-### Enabling webhook logging
-
-Webhook logging is controlled by the `webhook.logging` site configuration
-option. This option is an object with the following keys:
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `enabled` | `boolean` | If `true`, incoming webhooks will be stored. | `true` if no site encryption is enabled; `false` otherwise. |
-| `retention` | `string` | The length of time to retain the webhooks, expressed as a valid [Go duration](https://pkg.go.dev/time#ParseDuration). | `72h` |
-
-#### Examples
-
-To disable webhook logging:
-
-```json
-{
-  "webhook.logging": {"enabled": false}
-}
-```
-
-To retain webhook logs for one day:
-
-```json
-{
-  "webhook.logging": {
-    "enabled": false,
-    "retention": "24h"
-  }
-}
-```
-
-### Encrypting webhook logs
-
-Webhook logs can be encrypted by specifying a `webhookLogKey` in the [on-disk database encryption site configuration](encryption.md).
-Recent received webhook payloads can be seen on the webhook details page for each incoming webhook.
-  
- > NOTE: Deprecated webhooks added via code host configuration can be viewed in **Site Admin > Batch Changes > Incoming webhooks**. Webhook logging can be configured through the [incoming webhooks site configuration](../../admin/config/batch_changes.md#incoming-webhooks).
 
 ## Configuring webhooks on the code host
 
@@ -177,3 +129,50 @@ Done! Sourcegraph will now receive webhook events from Bitbucket Server / Bitbuc
 1. Confirm that the new webhook is listed below **Repository hooks**.
 
 Done! Sourcegraph will now receive webhook events from Bitbucket Cloud and use them to sync pull request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.
+
+## Webhook logging
+
+Sourcegraph can track incoming webhooks from code hosts to more easily debug issues with webhook delivery. These webhooks can be viewed in two places depending on how they were added:
+
+1. Via **Site Admin > Incoming webhooks**
+1. **Deprecated** Via code host connection: **Site Admin > Batch Changes > Incoming webhooks**
+
+By default, sites without [database encryption](encryption.md) enabled will retain three days of webhook logs. Sites with encryption will not retain webhook logs by default, as webhooks may include sensitive information; these sites can enable webhook logging and optionally configure encryption for them by using the settings below.
+
+### Enabling webhook logging
+
+Webhook logging is controlled by the `webhook.logging` site configuration
+option. This option is an object with the following keys:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | `boolean` | If `true`, incoming webhooks will be stored. | `true` if no site encryption is enabled; `false` otherwise. |
+| `retention` | `string` | The length of time to retain the webhooks, expressed as a valid [Go duration](https://pkg.go.dev/time#ParseDuration). | `72h` |
+
+#### Examples
+
+To disable webhook logging:
+
+```json
+{
+  "webhook.logging": {"enabled": false}
+}
+```
+
+To retain webhook logs for one day:
+
+```json
+{
+  "webhook.logging": {
+    "enabled": false,
+    "retention": "24h"
+  }
+}
+```
+
+### Encrypting webhook logs
+
+Webhook logs can be encrypted by specifying a `webhookLogKey` in the [on-disk database encryption site configuration](encryption.md).
+Recent received webhook payloads can be seen on the webhook details page for each incoming webhook.
+  
+ > NOTE: Deprecated webhooks added via code host configuration can be viewed in **Site Admin > Batch Changes > Incoming webhooks**. Webhook logging can be configured through the [incoming webhooks site configuration](../../admin/config/batch_changes.md#incoming-webhooks).

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -38,7 +38,8 @@ The incoming webhook will be configured to accept events from a specific code ho
    1. **Webhook name**: Optional descriptive name for the webhook
    1. **Code host type**: Select from the dropdown. This will be filtered based on code host connections added on your instance. 
    1. **Code host URN**: The URN for the code host. Again, this will be filtered by code host connections added on your instance.
-   1. **Secret**: If supported by the code host, this is an arbitrary shared secret between Sourcegraph and the code host. A default value is provided but you are free to change it.
+   1. **Secret**: An arbitrary shared secret between Sourcegraph and the code host. A default value is provided but you are free to change it.
+       > NOTE: Secrets are not supported for BitBucket cloud
 1. Click **Create**
 
 The incoming webhook will now be created and you will be redirected to a page showing more details.

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -150,10 +150,10 @@ By default, sites without [database encryption](encryption.md) enabled will reta
 Webhook logging is controlled by the `webhook.logging` site configuration
 option. This option is an object with the following keys:
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `enabled` | `boolean` | If `true`, incoming webhooks will be stored. | `true` if no site encryption is enabled; `false` otherwise. |
-| `retention` | `string` | The length of time to retain the webhooks, expressed as a valid [Go duration](https://pkg.go.dev/time#ParseDuration). | `72h` |
+| Key         | Type      | Default                                                                                                               | Description                                                 |
+|-------------|-----------|-----------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
+| `enabled`   | `boolean` | If `true`, incoming webhooks will be stored.                                                                          | `true` if no site encryption is enabled; `false` otherwise. |
+| `retention` | `string`  | The length of time to retain the webhooks, expressed as a valid [Go duration](https://pkg.go.dev/time#ParseDuration). | `72h`                                                       |
 
 #### Examples
 

--- a/doc/admin/external_service/bitbucket_cloud.md
+++ b/doc/admin/external_service/bitbucket_cloud.md
@@ -41,31 +41,6 @@ Bitbucket Cloud connections support the following configuration options, which a
 
 ## Webhooks
 
-> NOTE: Experimental webhook support for Bitbucket Cloud was added in Sourcegraph 3.40. Please <a href="https://about.sourcegraph.com/contact">contact us</a> with any issues found while using webhooks.
+Using the `webhooks` property on the external service has been deprecated.
 
-To set up authentication for webhooks, set the `webhookSecret` setting, which is then used to authenticate incoming webhook requests to `/.api/bitbucket-cloud-webhooks`.
-
-```json
-{
-  "webhookSecret": "verylongrandomsecret"
-}
-```
-
-Using webhooks is highly recommended when using [Batch Changes](../../batch_changes/index.md) since they speed up the syncing of pull request data between Bitbucket Cloud and Sourcegraph and make it more efficient.
-
-To set up webhooks:
-
-1. In Sourcegraph, go to **Site admin > Manage code hosts** and edit the Bitbucket Cloud configuration.
-1. Add the `"webhookSecret"` property to the configuration (you can generate a secret with `openssl rand -hex 32`):<br /> `"webhookSecret": "verylongrandomsecret"`
-1. Click **Update repositories**.
-1. Copy the webhook URL displayed below the **Update repositories** button.
-1. On Bitbucket Cloud, go to each repository, and then **Repository settings > Webhooks**.
-1. Click **Add webhook**.
-1. Fill in the webhook form:
-   * **Title**: any title.
-   * **URL**: the URL you copied above from Sourcegraph.
-   * **Triggers**: select **Build status created** and **Build status updated** under **Repository**, and every item under **Pull request**.
-1. Click **Save**.
-1. Confirm that the new webhook is listed below **Repository hooks**.
-
-Done! Sourcegraph will now receive webhook events from Bitbucket Cloud and use them to sync pull request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.
+Please consult [this page](../config/webhooks.md) in order to configure webhooks.

--- a/doc/admin/external_service/bitbucket_server.md
+++ b/doc/admin/external_service/bitbucket_server.md
@@ -32,28 +32,9 @@ There are four fields for configuring which repositories are mirrored:
 
 ## Webhooks
 
-The [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#sourcegraph-bitbucket-server-plugin) enables the Bitbucket Server / Bitbucket Data Center instance to send webhooks to Sourcegraph.
+Using the `webhooks` property on the external service has been deprecated.
 
-Using webhooks is highly recommended when using [batch changes](../../batch_changes/index.md), since they speed up the syncing of pull request data between Bitbucket Server / Bitbucket Data Center and Sourcegraph and make it more efficient.
-
-To set up webhooks:
-
-1. Connect Bitbucket Server / Bitbucket Data Center to Sourcegraph (_see instructions above_).
-1. Install the [Sourcegraph Bitbucket Server plugin](../../integration/bitbucket_server.md#sourcegraph-bitbucket-server-plugin) on your Bitbucket Server / Bitbucket Data Center instance.
-1. In Sourcegraph, go to **Site admin > Manage code hosts** and edit the Bitbucket Server / Bitbucket Data Center configuration.
-1. Add the `"webhooks"` property to `"plugin"` (you can generate a secret with `openssl rand -hex 32`):<br /> `"plugin": {"webhooks": {"secret": "verylongrandomsecret"}}`
-1. Click **Update repositories**.
-1. Note the webhook URL displayed below the **Update repositories** button.
-1. On your Bitbucket Server / Bitbucket Data Center instance, go to **Administration > Add-ons > Sourcegraph**
-1. Fill in the **Add a webhook** form
-   * **Name**: A unique name representing your Sourcegraph instance
-   * **Scope**: `global`
-   * **Endpoint**: The URL from step 6
-   * **Events**: `repo:build_status`, `pr:activity:status`, `pr:activity:event`, `pr:activity:rescope`, `pr:activity:merge`, `pr:activity:comment`, `pr:activity:reviewers`, `pr:participant:status`
-   * **Secret**: The secret you configured in step 4
-1. Confirm that the new webhook is listed under **All webhooks** with a timestamp in the **Last successful** column.
-
-Done! Sourcegraph will now receive webhook events from Bitbucket Server / Bitbucket Data Center and use them to sync pull request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.
+Please consult [this page](../config/webhooks.md) in order to configure webhooks.
 
 ## Repository permissions
 

--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -116,40 +116,9 @@ To configure GitHub as an authentication provider (which will enable sign-in via
 
 ## Webhooks
 
-The `webhooks` setting allows specifying the organization webhook secrets necessary to authenticate incoming webhook requests to `/.api/github-webhooks`.
+Using the `webhooks` property on the external service has been deprecated.
 
-```json
-"webhooks": [
-  {"org": "your_org", "secret": "verylongrandomsecret"}
-]
-```
-
-Using webhooks is highly recommended when using [batch changes](../../batch_changes/index.md), since they speed up the syncing of pull request data between GitHub and Sourcegraph and make it more efficient.
-
-To set up webhooks:
-
-1. In Sourcegraph, go to **Site admin > Manage code hosts** and edit the GitHub configuration.
-1. Add the `"webhooks"` property to the configuration (you can generate a secret with `openssl rand -hex 32`):<br /> `"webhooks": [{"org": "your_org", "secret": "verylongrandomsecret"}]`
-1. Click **Update configuration**.
-1. Copy the webhook URL displayed below the **Update configuration** button.
-1. On GitHub, go to the settings page of your organization. From there, click **Settings**, then **Webhooks**, then **Add webhook**.
-1. Fill in the webhook form:
-   * **Payload URL**: the URL you copied above from Sourcegraph.
-   * **Content type**: this must be set to `application/json`.
-   * **Secret**: the secret token you configured Sourcegraph to use above.
-   * **Which events**: select **Let me select individual events**, and then enable:
-     - Issue comments
-     - Pull requests
-     - Pull request reviews
-     - Pull request review comments
-     - Check runs
-     - Check suites
-     - Statuses
-   * **Active**: ensure this is enabled.
-1. Click **Add webhook**.
-1. Confirm that the new webhook is listed.
-
-Done! Sourcegraph will now receive webhook events from GitHub and use them to sync pull request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.
+Please consult [this page](../config/webhooks.md) in order to configure webhooks.
 
 ## Configuration
 

--- a/doc/admin/external_service/gitlab.md
+++ b/doc/admin/external_service/gitlab.md
@@ -98,33 +98,8 @@ We are actively collaborating with GitLab to improve our integration (e.g. the [
 | [`GET /projects/:id/repository/tree`](https://docs.gitlab.com/ee/api/repositories.html#list-repository-tree) | `api` or `read_api` | If using GitLab OAuth and repository permissions, used to verify a given user has access to the file contents of a repository within a project (i.e. does not merely have `Guest` permissions). |
 | Batch Changes requests | `api` or `read_api`, `read_repository`, `write_repository` | [Batch Changes](../../batch_changes/index.md) require write access to push commits and create, update and close merge requests on GitLab repositories. See "[Code host interactions in batch changes](../../batch_changes/explanations/permissions_in_batch_changes.md#code-host-interactions-in-batch-changes)" for details. |
 
-## Webhook setup
+## Webhooks
 
-The `webhooks` setting allows specifying the webhook secrets necessary to authenticate incoming webhook requests to `/.api/gitlab-webhooks`.
+Using the `webhooks` property on the external service has been deprecated.
 
-```json
-"webhooks": [
-  {"secret": "verylongrandomsecret"}
-]
-```
-
-Using webhooks is highly recommended when using [batch changes](../../batch_changes/index.md), since they speed up the syncing of pull request data between GitLab and Sourcegraph and make it more efficient.
-
-To set up webhooks:
-
-1. In Sourcegraph, go to **Site admin > Manage code hosts** and edit the GitLab configuration.
-1. Add the `"webhooks"` property to the configuration (you can generate a secret with `openssl rand -hex 32`):<br /> `"webhooks": [{"secret": "verylongrandomsecret"}]`
-1. Click **Update repositories**.
-1. Copy the webhook URL displayed below the **Update repositories** button.
-1. On GitLab, go to your project, and then **Settings > Webhooks** (or **Settings > Integration** on older GitLab versions that don't have the **Webhooks** option).
-1. Fill in the webhook form:
-   * **URL**: the URL you copied above from Sourcegraph.
-   * **Secret token**: the secret token you configured Sourcegraph to use above.
-   * **Trigger**: select **Merge request events** and **Pipeline events**.
-   * **Enable SSL verification**: ensure this is enabled if you have configured SSL with a valid certificate in your Sourcegraph instance.
-1. Click **Add webhook**.
-1. Confirm that the new webhook is listed below **Project Hooks**.
-
-Done! Sourcegraph will now receive webhook events from GitLab and use them to sync merge request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.
-
-**NOTE:** We currently do not support [system webhooks](https://docs.gitlab.com/ee/administration/system_hooks.html) as these provide a different set of payloads.
+Please consult [this page](../config/webhooks.md) in order to configure webhooks.

--- a/doc/admin/repo/webhooks.md
+++ b/doc/admin/repo/webhooks.md
@@ -19,3 +19,10 @@ curl -XPOST -H 'Authorization: token $ACCESS_TOKEN' $SOURCEGRAPH_ORIGIN/.api/rep
 Sourcegraph will periodically ask your code-host to list its repositories (e.g. via its HTTP API) to _discover repositories_. You can control how often this occurs by changing [`repoListUpdateInterval`](../config/site_config.md) in the site config.
 
 For repositories that Sourcegraph is already aware of, it will periodically perform background Git repository updates. You can disable this if you wish by setting [`disableAutoGitUpdates`](../config/site_config.md) to `true`. In which case, the repository will only update when the webhook is used or, e.g., if a user visits the repository directly. This may be desirable in cases where you wish to rely solely on the repository update webhook, for example.
+
+## Code host webhooks
+
+### GitHub
+
+We support the `push` event for GitHub. In order to handle them you need to set up webhooks in GitHub and point it at a webhook receiver configured in Sourcegraph, as described [here](../config/webhooks.md).
+

--- a/doc/admin/repo/webhooks.md
+++ b/doc/admin/repo/webhooks.md
@@ -24,5 +24,5 @@ For repositories that Sourcegraph is already aware of, it will periodically perf
 
 ### GitHub
 
-We support the `push` event for GitHub. In order to handle them you need to set up webhooks in GitHub and point it at a webhook receiver configured in Sourcegraph, as described [here](../config/webhooks.md).
+We support the `push` event for GitHub. In order to handle them you need to set up webhooks in GitHub and point it at a incoming webhook configured in Sourcegraph, as described [here](../config/webhooks.md).
 

--- a/doc/batch_changes/how-tos/site_admin_configuration.md
+++ b/doc/batch_changes/how-tos/site_admin_configuration.md
@@ -8,13 +8,7 @@
 
 1. [Configure credentials](configuring_credentials.md).
 
-1. Setup webhooks to make sure changesets sync fast. See [Batch Changes effect on codehost rate limits](../references/requirements.md#batch-changes-effect-on-code-host-rate-limits).
-    * [GitHub](../../admin/external_service/github.md#webhooks)
-    * [Bitbucket Server / Bitbucket Data Center](../../admin/external_service/bitbucket_server.md#webhooks)
-    * [Bitbucket Cloud](../../admin/external_service/bitbucket_cloud.md#webhooks)
-    * [GitLab](../../admin/external_service/gitlab.md#webhook-setup)
-
-    > NOTE: Incoming webhooks can be viewed in **Site Admin > Batch Changes > Incoming webhooks**. Webhook logging can be configured through the [incoming webhooks site configuration](../../admin/config/batch_changes.md#incoming-webhooks).
+1. [Setup webhooks](../../admin/config/webhooks.md) to make sure changesets sync fast. See [Batch Changes effect on codehost rate limits](../references/requirements.md#batch-changes-effect-on-code-host-rate-limits).
 
 1. Configure any desired optional features, such as:
     * [Rollout windows]("../../../admin/config/batch_changes#rollout-windows"), which control the rate at which Batch Changes will publish changesets on code hosts.


### PR DESCRIPTION
Adds a new top level webhook docs page.
Describes how to create a webhook the "new way".
Adds a deprecation notice.
Moved a bunch of batch changes instruction into the central doc and links to it.
Moved webhook logging docs.

TODO:

- [ ] Add screenshots once UI is done (This can be done in another PR)

I'll be in meetings for the rest of the day so wanted to push this up for a first pass review.

Part of https://github.com/sourcegraph/sourcegraph/issues/44723

## Test plan

Docs only