### PR TITLE
database: ReposListOptions.Query searches for ID

### DIFF
--- a/internal/database/helpers.go
+++ b/internal/database/helpers.go
@@ -1,6 +1,8 @@
 package database
 
 import (
+	"strconv"
+
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/keegancsmith/sqlf"
@@ -21,9 +23,16 @@ func (o *LimitOffset) SQL() *sqlf.Query {
 	return sqlf.Sprintf("LIMIT %d OFFSET %d", o.Limit, o.Offset)
 }
 
-// relayUnmarshalID is a best effort decoding of the ID from a marshalled
-// graphql.ID
-func relayUnmarshalID(s string) (id int32, ok bool) {
-	err := relay.UnmarshalSpec(graphql.ID(s), &id)
+// maybeQueryIsID returns a possible database ID if query looks like either a
+// database ID or a graphql.ID.
+func maybeQueryIsID(query string) (int32, bool) {
+	// Query looks like an ID
+	if id, err := strconv.ParseInt(query, 10, 32); err == nil {
+		return int32(id), true
+	}
+
+	// Query looks like a GraphQL ID
+	var id int32
+	err := relay.UnmarshalSpec(graphql.ID(query), &id)
 	return id, err == nil
 }

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -943,7 +943,18 @@ func (s *repoStore) listSQL(ctx context.Context, tr *trace.Trace, opt ReposListO
 	}
 
 	if opt.Query != "" {
-		where = append(where, sqlf.Sprintf("lower(name) LIKE %s", "%"+strings.ToLower(opt.Query)+"%"))
+		items := []*sqlf.Query{
+			sqlf.Sprintf("lower(name) LIKE %s", "%"+strings.ToLower(opt.Query)+"%"),
+		}
+		// Query looks like an ID
+		if id, err := strconv.Atoi(opt.Query); err == nil {
+			items = append(items, sqlf.Sprintf("id = %d", id))
+		}
+		// Query looks like a GraphQL ID
+		if id, ok := relayUnmarshalID(opt.Query); ok {
+			items = append(items, sqlf.Sprintf("id = %d", id))
+		}
+		where = append(where, sqlf.Sprintf("(%s)", sqlf.Join(items, " OR ")))
 	}
 
 	for _, includePattern := range opt.IncludePatterns {

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -947,11 +947,7 @@ func (s *repoStore) listSQL(ctx context.Context, tr *trace.Trace, opt ReposListO
 			sqlf.Sprintf("lower(name) LIKE %s", "%"+strings.ToLower(opt.Query)+"%"),
 		}
 		// Query looks like an ID
-		if id, err := strconv.Atoi(opt.Query); err == nil {
-			items = append(items, sqlf.Sprintf("id = %d", id))
-		}
-		// Query looks like a GraphQL ID
-		if id, ok := relayUnmarshalID(opt.Query); ok {
+		if id, ok := maybeQueryIsID(opt.Query); ok {
 			items = append(items, sqlf.Sprintf("id = %d", id))
 		}
 		where = append(where, sqlf.Sprintf("(%s)", sqlf.Join(items, " OR ")))

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -900,11 +900,7 @@ func (*userStore) listSQL(opt UsersListOptions) (conds []*sqlf.Query) {
 			sqlf.Sprintf("display_name ILIKE %s", query),
 		}
 		// Query looks like an ID
-		if id, err := strconv.Atoi(opt.Query); err == nil {
-			items = append(items, sqlf.Sprintf("id = %d", id))
-		}
-		// Query looks like a GraphQL ID
-		if id, ok := relayUnmarshalID(opt.Query); ok {
+		if id, ok := maybeQueryIsID(opt.Query); ok {
 			items = append(items, sqlf.Sprintf("id = %d", id))
 		}
 		conds = append(conds, sqlf.Sprintf("(%s)", sqlf.Join(items, " OR ")))


### PR DESCRIPTION
A common pain point I have is finding the repository for an ID that I come across in logs or honeycomb. This addition makes it possible to search for an ID or GraphQL ID in the site admin repository page and if it matches a repository that repository will be returned.

Note: ReposListOptions.Query is only used for repository search in the admin panel. Normal search uses the include/exclude fields.

This has the same motivation as the User based search in #45334.

Test Plan: unit test updated