### PR TITLE
Scope signup to dot com

### DIFF
--- a/client/web/src/auth/SignInPage.test.tsx
+++ b/client/web/src/auth/SignInPage.test.tsx
@@ -43,6 +43,7 @@ describe('SignInPage', () => {
                                     xhrHeaders: {},
                                     experimentalFeatures: {},
                                 }}
+                                isSourcegraphDotCom={false}
                             />
                         }
                     />
@@ -105,6 +106,7 @@ describe('SignInPage', () => {
                                     xhrHeaders: {},
                                     experimentalFeatures: { hideSourcegraphOperatorLogin },
                                 }}
+                                isSourcegraphDotCom={false}
                             />
                         }
                     />
@@ -131,6 +133,7 @@ describe('SignInPage', () => {
                                     xhrHeaders: {},
                                     experimentalFeatures: {},
                                 }}
+                                isSourcegraphDotCom={false}
                             />
                         }
                     />
@@ -165,6 +168,7 @@ describe('SignInPage', () => {
                                     resetPasswordEnabled: true,
                                     experimentalFeatures: {},
                                 }}
+                                isSourcegraphDotCom={false}
                             />
                         }
                     />

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -32,6 +32,7 @@ interface SignInPageProps {
         | 'resetPasswordEnabled'
         | 'experimentalFeatures'
     >
+    isSourcegraphDotCom: boolean
 }
 
 export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInPageProps>> = props => {
@@ -115,9 +116,18 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                 {props.context.allowSignup ? (
                     <Text>
                         New to Sourcegraph?{' '}
-                        <Link to="https://signup.sourcegraph.com" target="_blank" rel="noopener noreferrer">
-                            Sign up
-                        </Link>
+                        {props.isSourcegraphDotCom ? (
+                            <Link
+                                to="https://signup.sourcegraph.com"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                onClick={() => eventLogger.log('ClickedOnCloudCTA')}
+                            >
+                                Sign up
+                            </Link>
+                        ) : (
+                            <Link to="/sign-up">Sign up</Link>
+                        )}
                     </Text>
                 ) : (
                     <Text className="text-muted">Need an account? Contact your site admin</Text>

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -174,9 +174,7 @@ exports[`SignInPage renders sign in page (cloud) 1`] = `
           New to Sourcegraph? 
           <a
             class="anchorLink"
-            href="https://signup.sourcegraph.com"
-            rel="noopener noreferrer"
-            target="_blank"
+            href="/sign-up"
           >
             Sign up
           </a>
@@ -353,9 +351,7 @@ exports[`SignInPage renders sign in page (server) 1`] = `
           New to Sourcegraph? 
           <a
             class="anchorLink"
-            href="https://signup.sourcegraph.com"
-            rel="noopener noreferrer"
-            target="_blank"
+            href="/sign-up"
           >
             Sign up
           </a>
@@ -532,9 +528,7 @@ exports[`SignInPage with Sourcegraph auth provider renders page with 2 providers
           New to Sourcegraph? 
           <a
             class="anchorLink"
-            href="https://signup.sourcegraph.com"
-            rel="noopener noreferrer"
-            target="_blank"
+            href="/sign-up"
           >
             Sign up
           </a>
@@ -721,9 +715,7 @@ exports[`SignInPage with Sourcegraph auth provider renders page with 3 providers
           New to Sourcegraph? 
           <a
             class="anchorLink"
-            href="https://signup.sourcegraph.com"
-            rel="noopener noreferrer"
-            target="_blank"
+            href="/sign-up"
           >
             Sign up
           </a>
@@ -910,9 +902,7 @@ exports[`SignInPage with Sourcegraph auth provider renders page with 3 providers
           New to Sourcegraph? 
           <a
             class="anchorLink"
-            href="https://signup.sourcegraph.com"
-            rel="noopener noreferrer"
-            target="_blank"
+            href="/sign-up"
           >
             Sign up
           </a>


### PR DESCRIPTION
This closes #45353 and scopes our signup link to dot com only. On prem/cloud instances will be able to navigate to `/sign-up` for creating local accounts.

## Test plan
Ensure sign up goes to signup.sourcegraph.com for dot com only

## App preview:

- [Web](https://sg-web-brett-scoped-signup.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
