### PR TITLE
CodeMirror blob: post correct selection position to extension API

### DIFF
--- a/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
+++ b/client/web/src/repo/blob/codemirror/sourcegraph-extensions.ts
@@ -237,9 +237,10 @@ class SelectionManager implements PluginValue {
             // Used to convert SelectedLineRange type to a valid LineOrPositionOrRange type to keep TypeScript happy
             let lprSelection: LineOrPositionOrRange = {}
             if (selection) {
-                lprSelection = selection.endLine
-                    ? { line: selection.line, endLine: selection.endLine }
-                    : { line: selection.line, character: selection.character }
+                lprSelection =
+                    selection.line !== selection.endLine
+                        ? { line: selection.line, endLine: selection.endLine }
+                        : { line: selection.line, character: selection.character }
             }
             context.extensionHostAPI
                 .setEditorSelections(context.viewerId, lprToSelectionsZeroIndexed(lprSelection))


### PR DESCRIPTION
Previously, the CodeMirror blob posted a startLine/endLine range (no characters) to the extension API whenever endLine was defined resulting in a bug where the "tabbed" reference panel didn't have the correct line/character position to query from. This commit fixes the bug by posting a line/character position unless startLine!=endLine.

Reported in https://sourcegraph.slack.com/archives/CHXHX7XAS/p1670428106288289

## Test plan

Manually tested by enabling the tabbed references panel (`"codeIntel.referencesPanel": "tabbed"` and triggering find references on a location with a single-line range location in the URL like https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph@b9a2844aa034efdee781f24799b1d237562f261e/-/blob/client/web/src/fuzzyFinder/FuzzySearch.ts?L5:5-5:15#tab=references.

![CleanShot 2022-12-07 at 20 23 01@2x](https://user-images.githubusercontent.com/1408093/206276220-31549324-c339-41da-935e-fbb0db1018c9.png)

![CleanShot 2022-12-07 at 20 22 32@2x](https://user-images.githubusercontent.com/1408093/206276224-8deb64a3-1c05-4ff9-a472-de46774cbd01.png)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-tabbed.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
