### PR TITLE
webhooks: make possible updates of BitBucket Cloud webhooks.

### DIFF
--- a/cmd/frontend/backend/webhooks_test.go
+++ b/cmd/frontend/backend/webhooks_test.go
@@ -133,7 +133,7 @@ func TestCreateUpdateDeleteWebhook(t *testing.T) {
 	newName := "new name"
 	newCodeHostKind := extsvc.KindGitLab
 	newCodeHostURL := "https://gitlab.com/"
-	newWebhook, err := ws.UpdateWebhook(ctx, webhook.ID, newName, newCodeHostKind, newCodeHostURL, newSecret)
+	newWebhook, err := ws.UpdateWebhook(ctx, webhook.ID, newName, newCodeHostKind, newCodeHostURL, &newSecret)
 	require.NoError(t, err)
 	// assert that it's still the same webhook
 	assert.Equal(t, webhook.ID, newWebhook.ID)

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
@@ -88,12 +88,8 @@ func (r *webhooksResolver) UpdateWebhook(ctx context.Context, args *graphqlbacke
 	if args.CodeHostURN != nil {
 		codeHostURN = *args.CodeHostURN
 	}
-	var secret string
-	if args.Secret != nil {
-		secret = *args.Secret
-	}
 
-	webhook, err := ws.UpdateWebhook(ctx, whID, name, codeHostKind, codeHostURN, secret)
+	webhook, err := ws.UpdateWebhook(ctx, whID, name, codeHostKind, codeHostURN, args.Secret)
 	if err != nil {
 		return nil, errors.Wrap(err, "update webhook")
 	}

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
@@ -784,6 +784,30 @@ func TestUpdateWebhook(t *testing.T) {
 		},
 	})
 
+	graphqlbackend.RunTest(t, &graphqlbackend.Test{
+		Label:   "BitBucket Cloud webhook successfully updated without a secret",
+		Context: ctx,
+		Schema:  gqlSchema,
+		Query:   mutateStr,
+		ExpectedResult: fmt.Sprintf(`
+				{
+					"updateWebhook": {
+						"name": "new name",
+						"id": "V2ViaG9vazox",
+						"uuid": "%s",
+                        "codeHostURN": "https://sg.bitbucket.org/"
+					}
+				}
+			`, whUUID),
+		Variables: map[string]any{
+			"id":           string(id),
+			"name":         "new name",
+			"codeHostKind": extsvc.KindBitbucketCloud,
+			"codeHostURN":  "https://sg.bitbucket.org",
+			"secret":       nil,
+		},
+	})
+
 	webhookStore.GetByIDFunc.SetDefaultReturn(nil, &database.WebhookNotFoundError{ID: 2})
 
 	graphqlbackend.RunTest(t, &graphqlbackend.Test{


### PR DESCRIPTION
Follow-up to [follow-up](https://github.com/sourcegraph/sourcegraph/pull/45207) :)

This commits brings back nullability of the secret and unblocks updates of BitBucket Cloud webhooks which don't support secrets.

This commit also adds a `WebhookService` interface so that exported `NewWebhookService` function doesn't return an unexported concrete type, but returns an exported interface.

Test plan:
GraphQL test added.