### PR TITLE
Fix creating logger before log init

### DIFF
--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -474,19 +474,27 @@ var (
 	serviceConnectionsVal  conftypes.ServiceConnections
 	serviceConnectionsOnce sync.Once
 
-	gitservers = endpoint.New(func() string {
-		v := os.Getenv("SRC_GIT_SERVERS")
-		if v == "" {
-			// Detect 'go test' and setup default addresses in that case.
-			p, err := os.Executable()
-			if err == nil && strings.HasSuffix(p, ".test") {
-				return "gitserver:3178"
-			}
-			return "k8s+rpc://gitserver:3178?kind=sts"
-		}
-		return v
-	}())
+	gitserversVal  *endpoint.Map
+	gitserversOnce sync.Once
 )
+
+func gitservers() *endpoint.Map {
+	gitserversOnce.Do(func() {
+		gitserversVal = endpoint.New(func() string {
+			v := os.Getenv("SRC_GIT_SERVERS")
+			if v == "" {
+				// Detect 'go test' and setup default addresses in that case.
+				p, err := os.Executable()
+				if err == nil && strings.HasSuffix(p, ".test") {
+					return "gitserver:3178"
+				}
+				return "k8s+rpc://gitserver:3178?kind=sts"
+			}
+			return v
+		}())
+	})
+	return gitserversVal
+}
 
 func serviceConnections(logger log.Logger) conftypes.ServiceConnections {
 	serviceConnectionsOnce.Do(func() {
@@ -502,7 +510,7 @@ func serviceConnections(logger log.Logger) conftypes.ServiceConnections {
 		}
 	})
 
-	gitAddrs, err := gitservers.Endpoints()
+	gitAddrs, err := gitservers().Endpoints()
 	if err != nil {
 		logger.Error("failed to get gitserver endpoints for service connections", log.Error(err))
 	}


### PR DESCRIPTION
PR #45369 introduced an issue where new loggers were being created in a static context. This is a somewhat hacky fix to ensure that loggers are not created until after initialization. Ideally, the gitservers map is created with an explicit logger after initialization, but I'm just aiming to fix sg start right now.



## Test plan

`sg start` works

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
