### PR TITLE
asdf: update to Ruby 3.1.3

### DIFF
--- a/.github/workflows/licenses-check.yml
+++ b/.github/workflows/licenses-check.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1.1' # Not needed with a .ruby-version file   - uses: actions/setup-ruby@v1
+        ruby-version: '3.1.3' # Not needed with a .ruby-version file   - uses: actions/setup-ruby@v1
     - uses: actions/setup-go@v2
       with: { go-version: '1.19' }
 

--- a/.github/workflows/licenses-update.yml
+++ b/.github/workflows/licenses-update.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1.1' # Not needed with a .ruby-version file   - uses: actions/setup-ruby@v1
+        ruby-version: '3.1.3' # Not needed with a .ruby-version file   - uses: actions/setup-ruby@v1
     - name: Install asdf plugins
       uses: asdf-vm/actions/install@v1
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -15,4 +15,4 @@ kustomize 4.5.7
 awscli 2.4.7
 python system
 rust 1.62.0
-ruby 3.1.1
+ruby 3.1.3


### PR DESCRIPTION
Ruby 3.1.0 and 3.1.1 can have problems on M1 Macs due to https://github.com/rbenv/ruby-build/discussions/1933. Since the newest stable version is 3.1.3 anyway, we may as well upgrade.

## Test plan

Tested local installation with `asdf install`; testing the licence check with this very PR.