### PR TITLE
search contexts: set default from individual page

### DIFF
--- a/client/web/src/enterprise/searchContexts/SearchContextPage.module.scss
+++ b/client/web/src/enterprise/searchContexts/SearchContextPage.module.scss
@@ -3,12 +3,6 @@
         word-break: break-all;
     }
 
-    &__private-badge {
-        font-size: 0.625rem;
-        position: relative;
-        bottom: 0.25rem;
-    }
-
     &__repo-revs-row {
         border-bottom: 1px solid var(--border-color-2);
         padding-top: 0.75rem;
@@ -43,4 +37,10 @@
     flex-direction: row;
     gap: 0.5rem;
     align-items: center;
+}
+
+.badge-container {
+    display: flex;
+    flex-direction: row;
+    gap: 0.25rem;
 }

--- a/client/web/src/enterprise/searchContexts/hooks/useDefaultContext.ts
+++ b/client/web/src/enterprise/searchContexts/hooks/useDefaultContext.ts
@@ -13,7 +13,7 @@ export const SET_DEFAULT_SEARCH_CONTEXT_MUTATION = gql`
 
 export function useDefaultContext(
     initialDefaultSearchContextId: string | undefined
-): { defaultContext: string | undefined; setAsDefault: (searchContextId: string, userId?: string) => Promise<void> } {
+): { defaultContext: string | undefined; setAsDefault: (searchContextId?: string, userId?: string) => Promise<void> } {
     const [defaultContext, setDefaultContext] = useState(initialDefaultSearchContextId)
     useEffect(() => {
         setDefaultContext(initialDefaultSearchContextId)
@@ -22,7 +22,7 @@ export function useDefaultContext(
     const [setAsDefaultMutation] = useMutation(SET_DEFAULT_SEARCH_CONTEXT_MUTATION)
 
     const setAsDefault = useCallback(
-        async (searchContextId: string, userId?: string) => {
+        async (searchContextId?: string, userId?: string) => {
             const errorPrefix = 'Failed to set search context as default'
 
             // Cannot set as default if user is not authenticated


### PR DESCRIPTION
Stacked on #45387

Part of #44903

- "use as default" button shows on individual context pages when the context is not the default
- All tags, including auto and default, are now shown in the individual context pages

![image](https://user-images.githubusercontent.com/206864/206317006-e800186c-3bc4-4c79-8870-4d4e18340696.png)

![image](https://user-images.githubusercontent.com/206864/206317051-9d3ef532-a013-4048-8d94-cc1b55c70c5d.png)

![image](https://user-images.githubusercontent.com/206864/206317081-95196a6c-80a9-4a72-bf78-2b2e5bf67cb8.png)


## Test plan

Test setting default works when connected and renders error when disconnected.

## App preview:

- [Web](https://sg-web-jp-defaultcontextindividual.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
