### PR TITLE
JetBrains: Bump org.jetbrains.intellij and add support for 2022.3

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added support for JetBrains 2022.3 products.
+
 ### Changed
 
 ### Deprecated
@@ -22,8 +24,10 @@
 
 ### Fixed
 
-- “Open in Browser” and “Copy Link” features now open the correct branch when it exists on the remote. [pull/44739](https://github.com/sourcegraph/sourcegraph/pull/44739)
-- Fixed a bug where if the tracked branch had a different name from the local branch, the local branch name was used in the URL, incorrectly
+- “Open in Browser” and “Copy Link” features now open the correct branch when it exists on the
+  remote. [pull/44739](https://github.com/sourcegraph/sourcegraph/pull/44739)
+- Fixed a bug where if the tracked branch had a different name from the local branch, the local branch name was used in
+  the URL, incorrectly
 
 ## [2.1.0]
 
@@ -45,13 +49,16 @@
 
 ### Removed
 
-- Removed tracking parameters from all shareable URLs [pull/42022](https://github.com/sourcegraph/sourcegraph/pull/42022)
+- Removed tracking parameters from all shareable
+  URLs [pull/42022](https://github.com/sourcegraph/sourcegraph/pull/42022)
 
 ### Fixed
 
 - Remove pointer cursor in the web view. [pull/41845](https://github.com/sourcegraph/sourcegraph/pull/41845)
-- Updated “Learn more” URL to link the blog post in the update notification [pull/41846](https://github.com/sourcegraph/sourcegraph/pull/41846)
-- Made the plugin compatible with versions 3.42.0 and below [pull/42105](https://github.com/sourcegraph/sourcegraph/pull/42105)
+- Updated “Learn more” URL to link the blog post in the update
+  notification [pull/41846](https://github.com/sourcegraph/sourcegraph/pull/41846)
+- Made the plugin compatible with versions 3.42.0 and
+  below [pull/42105](https://github.com/sourcegraph/sourcegraph/pull/42105)
 
 ## [2.0.1]
 
@@ -77,7 +84,8 @@
 
 ## [1.2.2] - Minor bug fixes
 
-- It is now possible to configure the plugin per-repository using a `.idea/sourcegraph.xml` file. See the README for details.
+- It is now possible to configure the plugin per-repository using a `.idea/sourcegraph.xml` file. See the README for
+  details.
 - Special thanks: @oliviernotteghem for contributing the new features in this release!
 - Fixed bugs where Open in Sourcegraph from the git menu does not work for repos with ssh url as their remote url
 
@@ -85,7 +93,8 @@
 
 - Added "Open In Sourcegraph" action to VCS History and Git Log to open a revision in the Sourcegraph diff view.
 - Added "defaultBranch" configuration option that allows opening files in a specific branch on Sourcegraph.
-- Added "remoteUrlReplacements" configuration option that allow users to replace specified values in the remote url with new strings.
+- Added "remoteUrlReplacements" configuration option that allow users to replace specified values in the remote url with
+  new strings.
 
 ## [1.2.0] - Copy link to file, search in repository, per-repository configuration, bug fixes & more
 
@@ -94,13 +103,15 @@
 - Menu entries (Open file, etc.) are now under a Sourcegraph sub-menu.
 - Added a "Copy link to file" action (alt+c / opt+c).
 - Added a "Search in repository" action (alt+r / opt+r).
-- It is now possible to configure the plugin per-repository using a `.idea/sourcegraph.xml` file. See the README for details.
+- It is now possible to configure the plugin per-repository using a `.idea/sourcegraph.xml` file. See the README for
+  details.
 - Special thanks: @oliviernotteghem for contributing the new features in this release!
 
 ## [1.1.2] - Minor bug fixes around searching.
 
 - Fixed an error that occurred when trying to search with no selection.
-- The git remote used for repository detection is now `sourcegraph` and then `origin`, instead of the previously poor choice of just the first git remote.
+- The git remote used for repository detection is now `sourcegraph` and then `origin`, instead of the previously poor
+  choice of just the first git remote.
 
 ## [1.1.1] - Fixed search shortcut
 

--- a/client/jetbrains/build.gradle.kts
+++ b/client/jetbrains/build.gradle.kts
@@ -6,7 +6,7 @@ fun properties(key: String) = project.findProperty(key).toString()
 plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "1.7.0"
-    id("org.jetbrains.intellij") version "1.7.0"
+    id("org.jetbrains.intellij") version "1.10.0"
     id("org.jetbrains.changelog") version "1.3.1"
 }
 
@@ -53,15 +53,15 @@ tasks {
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
         pluginDescription.set(
-                projectDir.resolve("README.md").readText().lines().run {
-                    val start = "<!-- Plugin description -->"
-                    val end = "<!-- Plugin description end -->"
+            projectDir.resolve("README.md").readText().lines().run {
+                val start = "<!-- Plugin description -->"
+                val end = "<!-- Plugin description end -->"
 
-                    if (!containsAll(listOf(start, end))) {
-                        throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
-                    }
-                    subList(indexOf(start) + 1, indexOf(end))
-                }.joinToString("\n").run { markdownToHTML(this) }
+                if (!containsAll(listOf(start, end))) {
+                    throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
+                }
+                subList(indexOf(start) + 1, indexOf(end))
+            }.joinToString("\n").run { markdownToHTML(this) }
         )
 
         // Get the latest available change notes from the changelog file

--- a/client/jetbrains/gradle.properties
+++ b/client/jetbrains/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup=com.sourcegraph.jetbrains
 pluginName=Sourcegraph
 # SemVer format -> https://semver.org
-pluginVersion=2.1.1
+pluginVersion=2.1.2
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 #  - 2020.2 was the first version to have JCEF enabled by default
@@ -13,7 +13,7 @@ pluginVersion=2.1.1
 pluginSinceBuild=211.0
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IC
-platformVersion=2022.2
+platformVersion=2022.3
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins=Git4Idea,PerforceDirectPlugin


### PR DESCRIPTION
This PR adds support for JetBrains 2022.3 products to our JetBrains extension.

## Test plan

<img width="1407" alt="Screenshot 2022-12-08 at 00 53 42" src="https://user-images.githubusercontent.com/458591/206322771-465acd60-38b3-4002-86d3-f2dbc90472df.png">
<img width="1411" alt="Screenshot 2022-12-08 at 00 53 36" src="https://user-images.githubusercontent.com/458591/206322779-552c6c3d-1a54-4a10-821a-4ae2bcad49dd.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-jetbrains-2022-3.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
