### PR TITLE
JetBrains: 223.* compatibility

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [2.1.2]
+
+### Added
+
 - Compatibility with IntelliJ 2022.3
 
 ### Changed

--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Compatibility with IntelliJ 2022.3
+
 ### Changed
 
 ### Deprecated

--- a/client/jetbrains/build.gradle.kts
+++ b/client/jetbrains/build.gradle.kts
@@ -6,7 +6,7 @@ fun properties(key: String) = project.findProperty(key).toString()
 plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "1.7.0"
-    id("org.jetbrains.intellij") version "1.10.0"
+    id("org.jetbrains.intellij") version "1.11.0"
     id("org.jetbrains.changelog") version "1.3.1"
 }
 

--- a/client/jetbrains/build.gradle.kts
+++ b/client/jetbrains/build.gradle.kts
@@ -6,7 +6,7 @@ fun properties(key: String) = project.findProperty(key).toString()
 plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "1.7.0"
-    id("org.jetbrains.intellij") version "1.7.0"
+    id("org.jetbrains.intellij") version "1.10.0"
     id("org.jetbrains.changelog") version "1.3.1"
 }
 

--- a/client/jetbrains/gradle.properties
+++ b/client/jetbrains/gradle.properties
@@ -13,7 +13,7 @@ pluginVersion=2.1.2
 pluginSinceBuild=211.0
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IC
-platformVersion=2022.3
+platformVersion=2021.1
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins=Git4Idea,PerforceDirectPlugin

--- a/client/jetbrains/gradle.properties
+++ b/client/jetbrains/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup=com.sourcegraph.jetbrains
 pluginName=Sourcegraph
 # SemVer format -> https://semver.org
-pluginVersion=2.1.1
+pluginVersion=2.1.2
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 #  - 2020.2 was the first version to have JCEF enabled by default
@@ -13,7 +13,7 @@ pluginVersion=2.1.1
 pluginSinceBuild=211.0
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IC
-platformVersion=2022.2
+platformVersion=2022.3
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins=Git4Idea,PerforceDirectPlugin

--- a/client/jetbrains/gradle/wrapper/gradle-wrapper.properties
+++ b/client/jetbrains/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,6 @@
     <id>com.sourcegraph.jetbrains</id>
     <name>Sourcegraph</name>
     <vendor email="hi@sourcegraph.com" url="https://sourcegraph.com">Sourcegraph</vendor>
-    <idea-version since-build="211" until-build="223.*"/>
 
     <depends>com.intellij.modules.platform</depends>
     <depends optional="true" config-file="plugin-git.xml">Git4Idea</depends>

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -2,6 +2,7 @@
     <id>com.sourcegraph.jetbrains</id>
     <name>Sourcegraph</name>
     <vendor email="hi@sourcegraph.com" url="https://sourcegraph.com">Sourcegraph</vendor>
+    <idea-version since-build="211" until-build="223.*"/>
 
     <depends>com.intellij.modules.platform</depends>
     <depends optional="true" config-file="plugin-git.xml">Git4Idea</depends>

--- a/doc/integration/jetbrains/manual_testing.md
+++ b/doc/integration/jetbrains/manual_testing.md
@@ -71,7 +71,7 @@ Why: To make sure the popup is discoverable and generally works
     * It should not take more than ~five seconds
 3. Close the popup with ESC
     * The popup should become hidden
-4. Open “Find Action” (⌘⇧A) and search for “open sourcegraph search view” and select the first result
+4. Open “Find Action” (⌘⇧A) and search for “find with sourcegraph” and select the first result
     * The popup should become active
     * The popup should not be in the “loading” state
 5. Click the header of the IDE main window


### PR DESCRIPTION
Plugin was not officially compatible with IntelliJ 2022.3.*.

In this PR, I've done the necessary updates to make this compatible.

## Test plan

I did the manual tests and everything works fine. If JetBrains's CI passes we'll be good to go and the new version will be available.

## App preview:

- [Web](https://sg-web-dv-jetbrains-223-compatibility.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
