### PR TITLE
Code Insights: Fix capture group chart UI

### DIFF
--- a/client/web/src/enterprise/insights/core/backend/utils/create-line-chart-content.ts
+++ b/client/web/src/enterprise/insights/core/backend/utils/create-line-chart-content.ts
@@ -30,7 +30,11 @@ export function createLineChartContent(input: LineChartContentInput): BackendIns
     )
 
     return seriesData.map<BackendInsightSeries<BackendInsightDatum>>(line => ({
-        id: line.seriesId,
+        // " symbol breaks element query selectors in chart where we use id for
+        // points and lines. Since it's possible to have " symbols in id in case
+        // of capture-group insight replace all " symbols
+        // see https://github.com/sourcegraph/sourcegraph/issues/45376
+        id: line.seriesId.replaceAll('"', ''),
         alerts: showError ? line.status.incompleteDatapoints : [],
         data: line.points.map((point, index) => ({
             dateTime: new Date(point.dateTime),


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/45376

## Background
Usually, we use a standard ID format for the `seriesId` field which is base64, I believe. But for capture group insight where each series is generated, we don't have a normal ID, and to generate an id for generated series, we just concatenate the main series ID and series name. Series name can have any symbols, for example, """ symbol that apparently breaks `querySelector` method in browser.

## Test plan
- Open this insight https://k8s.sgdev.org/insights/insight/aW5zaWdodF92aWV3OiIyNDJsa2VGSjVSaklCV0p0aGw1WDBqdkpWVlgi and make sure that tooltip UI works for this properly 
- Check the console; there should be no errors about bad querySelector as you're hovering the chart 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
