### PR TITLE
Add webhook statistics to the header of the Incoming Webhooks page

### DIFF
--- a/client/web/src/site-admin/SiteAdminWebhooksPage.module.scss
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.module.scss
@@ -8,7 +8,7 @@
 
 .grid {
     display: grid;
-    grid-template-columns: max-content max-content 1fr max-content;
+    grid-template-columns: max-content max-content;
     column-gap: 1rem;
     row-gap: 1rem;
 

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.module.scss
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.module.scss
@@ -20,21 +20,3 @@
         grid-template-columns: 1fr max-content;
     }
 }
-
-.errors {
-    grid-column: 1 / 2;
-
-    @media (--sm-breakpoint-down) {
-        grid-column: 1 / 3;
-        grid-row: 1 / 2;
-    }
-}
-
-.services {
-    grid-column: 2 / 3;
-
-    @media (--sm-breakpoint-down) {
-        grid-column: 1 / 3;
-        grid-row: 2 / 3;
-    }
-}

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.module.scss
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.module.scss
@@ -5,3 +5,36 @@
         align-items: center;
     }
 }
+
+.grid {
+    display: grid;
+    grid-template-columns: max-content max-content 1fr max-content;
+    column-gap: 1rem;
+    row-gap: 1rem;
+
+    > * {
+        grid-row: 1 / 2;
+    }
+
+    @media (--sm-breakpoint-down) {
+        grid-template-columns: 1fr max-content;
+    }
+}
+
+.errors {
+    grid-column: 1 / 2;
+
+    @media (--sm-breakpoint-down) {
+        grid-column: 1 / 3;
+        grid-row: 1 / 2;
+    }
+}
+
+.services {
+    grid-column: 2 / 3;
+
+    @media (--sm-breakpoint-down) {
+        grid-column: 1 / 3;
+        grid-row: 2 / 3;
+    }
+}

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.story.tsx
@@ -10,7 +10,7 @@ import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { WebStory } from '../components/WebStory'
 import { WebhookFields } from '../graphql-operations'
 
-import { WEBHOOKS } from './backend'
+import { WEBHOOKS, WEBHOOK_PAGE_HEADER } from './backend'
 import { SiteAdminWebhooksPage } from './SiteAdminWebhooksPage'
 
 const decorator: DecoratorFn = Story => <Story />
@@ -44,6 +44,24 @@ export const NoWebhooksFound: Story = () => (
                                     },
                                 },
                             },
+                            nMatches: Number.POSITIVE_INFINITY,
+                        },
+                        {
+                            request: {
+                                query: getDocumentNode(WEBHOOK_PAGE_HEADER),
+                                variables: MATCH_ANY_PARAMETERS,
+                            },
+                            result: {
+                                data: {
+                                    webhooks: {
+                                        nodes: [],
+                                    },
+                                    webhookLogs: {
+                                        totalCount: 0,
+                                    },
+                                },
+                            },
+                            nMatches: Number.POSITIVE_INFINITY,
                         },
                     ])
                 }
@@ -109,6 +127,50 @@ export const FiveWebhooksFound: Story = () => (
                                     },
                                 },
                             },
+                            nMatches: Number.POSITIVE_INFINITY,
+                        },
+                        {
+                            request: {
+                                query: getDocumentNode(WEBHOOK_PAGE_HEADER),
+                                variables: MATCH_ANY_PARAMETERS,
+                            },
+                            result: {
+                                data: {
+                                    webhooks: {
+                                        nodes: [
+                                            {
+                                                webhookLogs: {
+                                                    totalCount: 2,
+                                                },
+                                            },
+                                            {
+                                                webhookLogs: {
+                                                    totalCount: 0,
+                                                },
+                                            },
+                                            {
+                                                webhookLogs: {
+                                                    totalCount: 1,
+                                                },
+                                            },
+                                            {
+                                                webhookLogs: {
+                                                    totalCount: 0,
+                                                },
+                                            },
+                                            {
+                                                webhookLogs: {
+                                                    totalCount: 2,
+                                                },
+                                            },
+                                        ],
+                                    },
+                                    webhookLogs: {
+                                        totalCount: 5,
+                                    },
+                                },
+                            },
+                            nMatches: Number.POSITIVE_INFINITY,
                         },
                     ])
                 }

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
@@ -22,6 +22,7 @@ import { useWebhooksConnection } from './backend'
 import { WebhookNode } from './WebhookNode'
 
 import styles from './SiteAdminWebhooksPage.module.scss'
+import { PerformanceGauge } from './webhooks/PerformanceGauge'
 
 interface Props extends RouteComponentProps<{}>, TelemetryProps {}
 
@@ -51,6 +52,10 @@ export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChild
             />
 
             <Container>
+                <div className={styles.grid}>
+                    <PerformanceGauge count={10} countClassName={'text-danger'} label="error" />
+                    <PerformanceGauge count={10} countClassName={'text-warning'} label="no event" />
+                </div>
                 <ConnectionContainer>
                     {error && <ConnectionError errors={[error.message]} />}
                     {loading && !connection && <ConnectionLoading />}

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
@@ -18,11 +18,11 @@ import {
 } from '../components/FilteredConnection/ui'
 import { PageTitle } from '../components/PageTitle'
 
-import { useWebhooksConnection } from './backend'
+import { useWebhooksConnection, useWebhookPageHeader } from './backend'
 import { WebhookNode } from './WebhookNode'
+import { PerformanceGauge } from './webhooks/PerformanceGauge'
 
 import styles from './SiteAdminWebhooksPage.module.scss'
-import { PerformanceGauge } from './webhooks/PerformanceGauge'
 
 interface Props extends RouteComponentProps<{}>, TelemetryProps {}
 
@@ -36,6 +36,7 @@ export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChild
     }, [telemetryService])
 
     const { loading, hasNextPage, fetchMore, connection, error } = useWebhooksConnection()
+    const totals = useWebhookPageHeader()
     return (
         <div className="site-admin-webhooks-page">
             <PageTitle title="Incoming webhooks" />
@@ -52,10 +53,20 @@ export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChild
             />
 
             <Container>
+            { !totals.loading &&
                 <div className={styles.grid}>
-                    <PerformanceGauge count={10} countClassName={'text-danger'} label="error" />
-                    <PerformanceGauge count={10} countClassName={'text-warning'} label="no event" />
+                    <PerformanceGauge
+                        count={totals.totalErrors}
+                        countClassName={totals.totalErrors > 0 ? 'text-danger' : ''}
+                        label="error"
+                    />
+                    <PerformanceGauge
+                        count={totals.totalNoEvents}
+                        countClassName={totals.totalNoEvents > 0 ? 'text-warning' : ''}
+                        label="no event"
+                    />
                 </div>
+            }
                 <ConnectionContainer>
                     {error && <ConnectionError errors={[error.message]} />}
                     {loading && !connection && <ConnectionLoading />}

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
@@ -36,7 +36,7 @@ export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChild
     }, [telemetryService])
 
     const { loading, hasNextPage, fetchMore, connection, error } = useWebhooksConnection()
-    const totals = useWebhookPageHeader()
+    const headerTotals = useWebhookPageHeader()
     return (
         <div className="site-admin-webhooks-page">
             <PageTitle title="Incoming webhooks" />
@@ -53,20 +53,20 @@ export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChild
             />
 
             <Container>
-            { !totals.loading &&
-                <div className={styles.grid}>
-                    <PerformanceGauge
-                        count={totals.totalErrors}
-                        countClassName={totals.totalErrors > 0 ? 'text-danger' : ''}
-                        label="error"
-                    />
-                    <PerformanceGauge
-                        count={totals.totalNoEvents}
-                        countClassName={totals.totalNoEvents > 0 ? 'text-warning' : ''}
-                        label="no event"
-                    />
-                </div>
-            }
+                {!headerTotals.loading && (
+                    <div className={styles.grid}>
+                        <PerformanceGauge
+                            count={headerTotals.totalErrors}
+                            countClassName={headerTotals.totalErrors > 0 ? 'text-danger' : ''}
+                            label="error"
+                        />
+                        <PerformanceGauge
+                            count={headerTotals.totalNoEvents}
+                            countClassName={headerTotals.totalNoEvents > 0 ? 'text-warning' : ''}
+                            label="no event"
+                        />
+                    </div>
+                )}
                 <ConnectionContainer>
                     {error && <ConnectionError errors={[error.message]} />}
                     {loading && !connection && <ConnectionLoading />}

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -1017,7 +1017,8 @@ export const WEBHOOK_PAGE_HEADER = gql`
         webhookLogs(onlyErrors: true) {
             totalCount
         }
-    }`
+    }
+`
 
 export const useWebhookPageHeader = (): { loading: boolean; totalErrors: number; totalNoEvents: number } => {
     const { data, loading } = useQuery<WebhookPageHeaderResult, WebhookPageHeaderVariables>(WEBHOOK_PAGE_HEADER, {})

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -1022,13 +1022,7 @@ export const WEBHOOK_PAGE_HEADER = gql`
 
 export const useWebhookPageHeader = (): { loading: boolean; totalErrors: number; totalNoEvents: number } => {
     const { data, loading } = useQuery<WebhookPageHeaderResult, WebhookPageHeaderVariables>(WEBHOOK_PAGE_HEADER, {})
-    const totalNoEvents =
-        data?.webhooks.nodes.reduce((numNoEvents, webhook) => {
-            if (webhook.webhookLogs?.totalCount === 0) {
-                return numNoEvents + 1
-            }
-            return numNoEvents
-        }, 0) || 0
+    const totalNoEvents = data?.webhooks.nodes.filter(webhook => webhook.webhookLogs?.totalCount === 0).length
     const totalErrors = data?.webhookLogs.totalCount || 0
     return { loading, totalErrors, totalNoEvents }
 }

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -1019,14 +1019,15 @@ export const WEBHOOK_PAGE_HEADER = gql`
         }
     }`
 
-export const useWebhookPageHeader = (): {loading: boolean, totalErrors: number, totalNoEvents: number} => {
-    let { data, loading } = useQuery<WebhookPageHeaderResult, WebhookPageHeaderVariables>(WEBHOOK_PAGE_HEADER, {})
-    const totalNoEvents = data?.webhooks.nodes.reduce((numNoEvents, webhook) => {
-                            if (webhook.webhookLogs?.totalCount === 0) {
-                                return numNoEvents + 1
-                            }
-                            return numNoEvents
-                        }, 0) || 0
+export const useWebhookPageHeader = (): { loading: boolean; totalErrors: number; totalNoEvents: number } => {
+    const { data, loading } = useQuery<WebhookPageHeaderResult, WebhookPageHeaderVariables>(WEBHOOK_PAGE_HEADER, {})
+    const totalNoEvents =
+        data?.webhooks.nodes.reduce((numNoEvents, webhook) => {
+            if (webhook.webhookLogs?.totalCount === 0) {
+                return numNoEvents + 1
+            }
+            return numNoEvents
+        }, 0) || 0
     const totalErrors = data?.webhookLogs.totalCount || 0
     return { loading, totalErrors, totalNoEvents }
 }

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -1044,3 +1044,8 @@ export const CREATE_WEBHOOK_QUERY = gql`
         }
     }
 `
+
+export const useWebhooksHeaderStats = () =>
+    useQuery<>(WEBHOOK_HEADER_STATS, {
+
+    })

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -71,6 +71,8 @@ import {
     WebhookLogFields,
     WebhookLogsByWebhookIDResult,
     WebhookLogsByWebhookIDVariables,
+    WebhookPageHeaderResult,
+    WebhookPageHeaderVariables,
     WebhooksListResult,
     WebhooksListVariables,
 } from '../graphql-operations'
@@ -1002,6 +1004,33 @@ export const DELETE_WEBHOOK = gql`
     }
 `
 
+export const WEBHOOK_PAGE_HEADER = gql`
+    query WebhookPageHeader {
+        webhooks {
+            nodes {
+                webhookLogs {
+                    totalCount
+                }
+            }
+        }
+
+        webhookLogs(onlyErrors: true) {
+            totalCount
+        }
+    }`
+
+export const useWebhookPageHeader = (): {loading: boolean, totalErrors: number, totalNoEvents: number} => {
+    let { data, loading } = useQuery<WebhookPageHeaderResult, WebhookPageHeaderVariables>(WEBHOOK_PAGE_HEADER, {})
+    const totalNoEvents = data?.webhooks.nodes.reduce((numNoEvents, webhook) => {
+                            if (webhook.webhookLogs?.totalCount === 0) {
+                                return numNoEvents + 1
+                            }
+                            return numNoEvents
+                        }, 0) || 0
+    const totalErrors = data?.webhookLogs.totalCount || 0
+    return { loading, totalErrors, totalNoEvents }
+}
+
 export const useWebhooksConnection = (): UseShowMorePaginationResult<WebhookFields> =>
     useShowMorePagination<WebhooksListResult, WebhooksListVariables, WebhookFields>({
         query: WEBHOOKS,
@@ -1044,8 +1073,3 @@ export const CREATE_WEBHOOK_QUERY = gql`
         }
     }
 `
-
-export const useWebhooksHeaderStats = () =>
-    useQuery<>(WEBHOOK_HEADER_STATS, {
-
-    })

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -1022,7 +1022,7 @@ export const WEBHOOK_PAGE_HEADER = gql`
 
 export const useWebhookPageHeader = (): { loading: boolean; totalErrors: number; totalNoEvents: number } => {
     const { data, loading } = useQuery<WebhookPageHeaderResult, WebhookPageHeaderVariables>(WEBHOOK_PAGE_HEADER, {})
-    const totalNoEvents = data?.webhooks.nodes.filter(webhook => webhook.webhookLogs?.totalCount === 0).length
+    const totalNoEvents = data?.webhooks.nodes.filter(webhook => webhook.webhookLogs?.totalCount === 0).length || 0
     const totalErrors = data?.webhookLogs.totalCount || 0
     return { loading, totalErrors, totalNoEvents }
 }

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -1014,8 +1014,12 @@ export const WEBHOOK_PAGE_HEADER = gql`
             }
         }
 
-        webhookLogs(onlyErrors: true) {
-            totalCount
+        errorsOnly: webhooks {
+            nodes {
+                webhookLogs(onlyErrors: true) {
+                    totalCount
+                }
+            }
         }
     }
 `
@@ -1023,7 +1027,8 @@ export const WEBHOOK_PAGE_HEADER = gql`
 export const useWebhookPageHeader = (): { loading: boolean; totalErrors: number; totalNoEvents: number } => {
     const { data, loading } = useQuery<WebhookPageHeaderResult, WebhookPageHeaderVariables>(WEBHOOK_PAGE_HEADER, {})
     const totalNoEvents = data?.webhooks.nodes.filter(webhook => webhook.webhookLogs?.totalCount === 0).length || 0
-    const totalErrors = data?.webhookLogs.totalCount || 0
+    const totalErrors =
+        data?.errorsOnly.nodes.reduce((sum, webhook) => sum + (webhook.webhookLogs?.totalCount || 0), 0) || 0
     return { loading, totalErrors, totalNoEvents }
 }
 

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -175,8 +175,8 @@ func (r *externalServiceResolver) NextSyncAt() *gqlutil.DateTime {
 	return &gqlutil.DateTime{Time: r.externalService.NextSyncAt}
 }
 
-func (r *externalServiceResolver) WebhookLogs(ctx context.Context, args *webhookLogsArgs) (*webhookLogConnectionResolver, error) {
-	return newWebhookLogConnectionResolver(ctx, r.db, args, webhookLogsExternalServiceID(r.externalService.ID))
+func (r *externalServiceResolver) WebhookLogs(ctx context.Context, args *WebhookLogsArgs) (*WebhookLogConnectionResolver, error) {
+	return NewWebhookLogConnectionResolver(ctx, r.db, args, webhookLogsExternalServiceID(r.externalService.ID))
 }
 
 type externalServiceSyncJobsArgs struct {

--- a/cmd/frontend/graphqlbackend/node.go
+++ b/cmd/frontend/graphqlbackend/node.go
@@ -269,8 +269,8 @@ func (r *NodeResolver) ToInsightView() (InsightViewResolver, bool) {
 	return n, ok
 }
 
-func (r *NodeResolver) ToWebhookLog() (*webhookLogResolver, bool) {
-	n, ok := r.Node.(*webhookLogResolver)
+func (r *NodeResolver) ToWebhookLog() (*WebhookLogResolver, bool) {
+	n, ok := r.Node.(*WebhookLogResolver)
 	return n, ok
 }
 

--- a/cmd/frontend/graphqlbackend/node.go
+++ b/cmd/frontend/graphqlbackend/node.go
@@ -269,8 +269,8 @@ func (r *NodeResolver) ToInsightView() (InsightViewResolver, bool) {
 	return n, ok
 }
 
-func (r *NodeResolver) ToWebhookLog() (*WebhookLogResolver, bool) {
-	n, ok := r.Node.(*WebhookLogResolver)
+func (r *NodeResolver) ToWebhookLog() (*webhookLogResolver, bool) {
+	n, ok := r.Node.(*webhookLogResolver)
 	return n, ok
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -8004,6 +8004,10 @@ type Webhook implements Node {
     Null if the user was deleted.
     """
     createdBy: User
+    """
+    The logs related to this webhook.
+    """
+    webhookLogs: WebhookLogConnection
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -8007,7 +8007,32 @@ type Webhook implements Node {
     """
     The logs related to this webhook.
     """
-    webhookLogs: WebhookLogConnection
+    webhookLogs(
+        """
+        Returns the first n webhook logs.
+        """
+        first: Int
+
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+
+        """
+        Only include webhook logs that resulted in errors.
+        """
+        onlyErrors: Boolean
+
+        """
+        Only include webhook logs on or after this time.
+        """
+        since: DateTime
+
+        """
+        Only include webhook logs on or before this time.
+        """
+        until: DateTime
+    ): WebhookLogConnection!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/webhook_logs.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs.go
@@ -141,18 +141,18 @@ func NewWebhookLogConnectionResolver(
 	}, nil
 }
 
-func (r *WebhookLogConnectionResolver) Nodes(ctx context.Context) ([]*WebhookLogResolver, error) {
+func (r *WebhookLogConnectionResolver) Nodes(ctx context.Context) ([]*webhookLogResolver, error) {
 	logs, _, err := r.compute(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	nodes := make([]*WebhookLogResolver, len(logs))
+	nodes := make([]*webhookLogResolver, len(logs))
 	db := database.NewDBWith(r.logger, r.store)
 	for i, log := range logs {
-		nodes[i] = &WebhookLogResolver{
-			DB:  db,
-			Log: log,
+		nodes[i] = &webhookLogResolver{
+			db:  db,
+			log: log,
 		}
 	}
 
@@ -197,9 +197,9 @@ func (r *WebhookLogConnectionResolver) compute(ctx context.Context) ([]*types.We
 	return r.logs, r.next, r.err
 }
 
-type WebhookLogResolver struct {
-	DB  database.DB
-	Log *types.WebhookLog
+type webhookLogResolver struct {
+	db  database.DB
+	log *types.WebhookLog
 }
 
 func marshalWebhookLogID(id int64) graphql.ID {
@@ -211,7 +211,7 @@ func unmarshalWebhookLogID(id graphql.ID) (logID int64, err error) {
 	return
 }
 
-func webhookLogByID(ctx context.Context, db database.DB, gqlID graphql.ID) (*WebhookLogResolver, error) {
+func webhookLogByID(ctx context.Context, db database.DB, gqlID graphql.ID) (*webhookLogResolver, error) {
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, db); err != nil {
 		return nil, err
 	}
@@ -226,31 +226,31 @@ func webhookLogByID(ctx context.Context, db database.DB, gqlID graphql.ID) (*Web
 		return nil, err
 	}
 
-	return &WebhookLogResolver{DB: db, Log: log}, nil
+	return &webhookLogResolver{db: db, log: log}, nil
 }
 
-func (r *WebhookLogResolver) ID() graphql.ID {
-	return marshalWebhookLogID(r.Log.ID)
+func (r *webhookLogResolver) ID() graphql.ID {
+	return marshalWebhookLogID(r.log.ID)
 }
 
-func (r *WebhookLogResolver) ReceivedAt() gqlutil.DateTime {
-	return gqlutil.DateTime{Time: r.Log.ReceivedAt}
+func (r *webhookLogResolver) ReceivedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.log.ReceivedAt}
 }
 
-func (r *WebhookLogResolver) ExternalService(ctx context.Context) (*externalServiceResolver, error) {
-	if r.Log.ExternalServiceID == nil {
+func (r *webhookLogResolver) ExternalService(ctx context.Context) (*externalServiceResolver, error) {
+	if r.log.ExternalServiceID == nil {
 		return nil, nil
 	}
 
-	return externalServiceByID(ctx, r.DB, MarshalExternalServiceID(*r.Log.ExternalServiceID))
+	return externalServiceByID(ctx, r.db, MarshalExternalServiceID(*r.log.ExternalServiceID))
 }
 
-func (r *WebhookLogResolver) StatusCode() int32 {
-	return int32(r.Log.StatusCode)
+func (r *webhookLogResolver) StatusCode() int32 {
+	return int32(r.log.StatusCode)
 }
 
-func (r *WebhookLogResolver) Request(ctx context.Context) (*webhookLogRequestResolver, error) {
-	message, err := r.Log.Request.Decrypt(ctx)
+func (r *webhookLogResolver) Request(ctx context.Context) (*webhookLogRequestResolver, error) {
+	message, err := r.log.Request.Decrypt(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -258,8 +258,8 @@ func (r *WebhookLogResolver) Request(ctx context.Context) (*webhookLogRequestRes
 	return &webhookLogRequestResolver{webhookLogMessageResolver{message: &message}}, nil
 }
 
-func (r *WebhookLogResolver) Response(ctx context.Context) (*webhookLogMessageResolver, error) {
-	message, err := r.Log.Response.Decrypt(ctx)
+func (r *webhookLogResolver) Response(ctx context.Context) (*webhookLogMessageResolver, error) {
+	message, err := r.log.Response.Decrypt(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/webhook_logs_test.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs_test.go
@@ -39,7 +39,7 @@ func TestWebhookLogsArgs(t *testing.T) {
 				},
 			},
 			"OnlyErrors false": {
-				id: WebhookLogsAllExternalServices,
+				id: WebhookLogsUnmatchedExternalService,
 				input: WebhookLogsArgs{
 					OnlyErrors: boolPtr(false),
 				},
@@ -88,7 +88,7 @@ func TestWebhookLogsArgs(t *testing.T) {
 			"foo",
 		} {
 			t.Run(input, func(t *testing.T) {
-				_, err := (&WebhookLogsArgs{After: &input}).toListOpts(WebhookLogsAllExternalServices)
+				_, err := (&WebhookLogsArgs{After: &input}).toListOpts(WebhookLogsUnmatchedExternalService)
 				assert.NotNil(t, err)
 			})
 		}
@@ -105,7 +105,7 @@ func TestNewWebhookLogConnectionResolver(t *testing.T) {
 		db := database.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		_, err := NewWebhookLogConnectionResolver(context.Background(), db, nil, WebhookLogsAllExternalServices)
+		_, err := NewWebhookLogConnectionResolver(context.Background(), db, nil, WebhookLogsUnmatchedExternalService)
 		assert.ErrorIs(t, err, auth.ErrNotAuthenticated)
 	})
 
@@ -116,7 +116,7 @@ func TestNewWebhookLogConnectionResolver(t *testing.T) {
 		db := database.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		_, err := NewWebhookLogConnectionResolver(context.Background(), db, nil, WebhookLogsAllExternalServices)
+		_, err := NewWebhookLogConnectionResolver(context.Background(), db, nil, WebhookLogsUnmatchedExternalService)
 		assert.ErrorIs(t, err, auth.ErrMustBeSiteAdmin)
 	})
 

--- a/cmd/frontend/graphqlbackend/webhook_logs_test.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs_test.go
@@ -39,7 +39,7 @@ func TestWebhookLogsArgs(t *testing.T) {
 				},
 			},
 			"OnlyErrors false": {
-				id: webhookLogsAllExternalServices,
+				id: WebhookLogsAllExternalServices,
 				input: WebhookLogsArgs{
 					OnlyErrors: boolPtr(false),
 				},
@@ -88,7 +88,7 @@ func TestWebhookLogsArgs(t *testing.T) {
 			"foo",
 		} {
 			t.Run(input, func(t *testing.T) {
-				_, err := (&WebhookLogsArgs{After: &input}).toListOpts(webhookLogsAllExternalServices)
+				_, err := (&WebhookLogsArgs{After: &input}).toListOpts(WebhookLogsAllExternalServices)
 				assert.NotNil(t, err)
 			})
 		}
@@ -105,7 +105,7 @@ func TestNewWebhookLogConnectionResolver(t *testing.T) {
 		db := database.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		_, err := NewWebhookLogConnectionResolver(context.Background(), db, nil, webhookLogsAllExternalServices)
+		_, err := NewWebhookLogConnectionResolver(context.Background(), db, nil, WebhookLogsAllExternalServices)
 		assert.ErrorIs(t, err, auth.ErrNotAuthenticated)
 	})
 
@@ -116,7 +116,7 @@ func TestNewWebhookLogConnectionResolver(t *testing.T) {
 		db := database.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		_, err := NewWebhookLogConnectionResolver(context.Background(), db, nil, webhookLogsAllExternalServices)
+		_, err := NewWebhookLogConnectionResolver(context.Background(), db, nil, WebhookLogsAllExternalServices)
 		assert.ErrorIs(t, err, auth.ErrMustBeSiteAdmin)
 	})
 
@@ -127,7 +127,7 @@ func TestNewWebhookLogConnectionResolver(t *testing.T) {
 		db := database.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		_, err := NewWebhookLogConnectionResolver(context.Background(), db, nil, webhookLogsAllExternalServices)
+		_, err := NewWebhookLogConnectionResolver(context.Background(), db, nil, WebhookLogsAllExternalServices)
 		assert.Nil(t, err)
 	})
 }

--- a/cmd/frontend/graphqlbackend/webhook_logs_test.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs_test.go
@@ -39,7 +39,7 @@ func TestWebhookLogsArgs(t *testing.T) {
 				},
 			},
 			"OnlyErrors false": {
-				id: WebhookLogsUnmatchedExternalService,
+				id: webhookLogsAllExternalServices,
 				input: WebhookLogsArgs{
 					OnlyErrors: boolPtr(false),
 				},
@@ -88,7 +88,7 @@ func TestWebhookLogsArgs(t *testing.T) {
 			"foo",
 		} {
 			t.Run(input, func(t *testing.T) {
-				_, err := (&WebhookLogsArgs{After: &input}).toListOpts(WebhookLogsUnmatchedExternalService)
+				_, err := (&WebhookLogsArgs{After: &input}).toListOpts(webhookLogsAllExternalServices)
 				assert.NotNil(t, err)
 			})
 		}
@@ -105,7 +105,7 @@ func TestNewWebhookLogConnectionResolver(t *testing.T) {
 		db := database.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		_, err := NewWebhookLogConnectionResolver(context.Background(), db, nil, WebhookLogsUnmatchedExternalService)
+		_, err := NewWebhookLogConnectionResolver(context.Background(), db, nil, webhookLogsAllExternalServices)
 		assert.ErrorIs(t, err, auth.ErrNotAuthenticated)
 	})
 
@@ -116,7 +116,7 @@ func TestNewWebhookLogConnectionResolver(t *testing.T) {
 		db := database.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		_, err := NewWebhookLogConnectionResolver(context.Background(), db, nil, WebhookLogsUnmatchedExternalService)
+		_, err := NewWebhookLogConnectionResolver(context.Background(), db, nil, webhookLogsAllExternalServices)
 		assert.ErrorIs(t, err, auth.ErrMustBeSiteAdmin)
 	})
 
@@ -127,7 +127,7 @@ func TestNewWebhookLogConnectionResolver(t *testing.T) {
 		db := database.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		_, err := NewWebhookLogConnectionResolver(context.Background(), db, nil, WebhookLogsUnmatchedExternalService)
+		_, err := NewWebhookLogConnectionResolver(context.Background(), db, nil, webhookLogsAllExternalServices)
 		assert.Nil(t, err)
 	})
 }

--- a/cmd/frontend/graphqlbackend/webhook_logs_test.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs_test.go
@@ -197,7 +197,7 @@ func TestWebhookLogConnectionResolver(t *testing.T) {
 
 		nodes, err := r.Nodes(ctx)
 		for i, node := range nodes {
-			assert.Equal(t, logs[i], node.Log)
+			assert.Equal(t, logs[i], node.log)
 		}
 		assert.Nil(t, err)
 

--- a/cmd/frontend/graphqlbackend/webhook_logs_test.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs_test.go
@@ -28,19 +28,19 @@ func TestWebhookLogsArgs(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		for name, tc := range map[string]struct {
 			id    webhookLogsExternalServiceID
-			input webhookLogsArgs
+			input WebhookLogsArgs
 			want  database.WebhookLogListOpts
 		}{
 			"no arguments": {
-				id:    webhookLogsAllExternalServices,
-				input: webhookLogsArgs{},
+				id:    WebhookLogsAllExternalServices,
+				input: WebhookLogsArgs{},
 				want: database.WebhookLogListOpts{
 					Limit: 50,
 				},
 			},
 			"OnlyErrors false": {
-				id: webhookLogsUnmatchedExternalService,
-				input: webhookLogsArgs{
+				id: WebhookLogsUnmatchedExternalService,
+				input: WebhookLogsArgs{
 					OnlyErrors: boolPtr(false),
 				},
 				want: database.WebhookLogListOpts{
@@ -51,7 +51,7 @@ func TestWebhookLogsArgs(t *testing.T) {
 			},
 			"all arguments": {
 				id: webhookLogsExternalServiceID(1),
-				input: webhookLogsArgs{
+				input: WebhookLogsArgs{
 					ConnectionArgs: graphqlutil.ConnectionArgs{
 						First: int32Ptr(25),
 					},
@@ -88,7 +88,7 @@ func TestWebhookLogsArgs(t *testing.T) {
 			"foo",
 		} {
 			t.Run(input, func(t *testing.T) {
-				_, err := (&webhookLogsArgs{After: &input}).toListOpts(webhookLogsUnmatchedExternalService)
+				_, err := (&WebhookLogsArgs{After: &input}).toListOpts(WebhookLogsUnmatchedExternalService)
 				assert.NotNil(t, err)
 			})
 		}
@@ -105,7 +105,7 @@ func TestNewWebhookLogConnectionResolver(t *testing.T) {
 		db := database.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		_, err := newWebhookLogConnectionResolver(context.Background(), db, nil, webhookLogsUnmatchedExternalService)
+		_, err := NewWebhookLogConnectionResolver(context.Background(), db, nil, WebhookLogsUnmatchedExternalService)
 		assert.ErrorIs(t, err, auth.ErrNotAuthenticated)
 	})
 
@@ -116,7 +116,7 @@ func TestNewWebhookLogConnectionResolver(t *testing.T) {
 		db := database.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		_, err := newWebhookLogConnectionResolver(context.Background(), db, nil, webhookLogsUnmatchedExternalService)
+		_, err := NewWebhookLogConnectionResolver(context.Background(), db, nil, WebhookLogsUnmatchedExternalService)
 		assert.ErrorIs(t, err, auth.ErrMustBeSiteAdmin)
 	})
 
@@ -127,7 +127,7 @@ func TestNewWebhookLogConnectionResolver(t *testing.T) {
 		db := database.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		_, err := newWebhookLogConnectionResolver(context.Background(), db, nil, webhookLogsUnmatchedExternalService)
+		_, err := NewWebhookLogConnectionResolver(context.Background(), db, nil, WebhookLogsUnmatchedExternalService)
 		assert.Nil(t, err)
 	})
 }
@@ -152,8 +152,8 @@ func TestWebhookLogConnectionResolver(t *testing.T) {
 	t.Run("empty and has no further pages", func(t *testing.T) {
 		store := createMockStore([]*types.WebhookLog{}, 0, nil)
 
-		r := &webhookLogConnectionResolver{
-			args: &webhookLogsArgs{
+		r := &WebhookLogConnectionResolver{
+			args: &WebhookLogsArgs{
 				ConnectionArgs: graphqlutil.ConnectionArgs{
 					First: int32Ptr(20),
 				},
@@ -185,8 +185,8 @@ func TestWebhookLogConnectionResolver(t *testing.T) {
 	t.Run("full and has next page", func(t *testing.T) {
 		store := createMockStore(logs, 20, nil)
 
-		r := &webhookLogConnectionResolver{
-			args: &webhookLogsArgs{
+		r := &WebhookLogConnectionResolver{
+			args: &WebhookLogsArgs{
 				ConnectionArgs: graphqlutil.ConnectionArgs{
 					First: int32Ptr(20),
 				},
@@ -197,7 +197,7 @@ func TestWebhookLogConnectionResolver(t *testing.T) {
 
 		nodes, err := r.Nodes(ctx)
 		for i, node := range nodes {
-			assert.Equal(t, logs[i], node.log)
+			assert.Equal(t, logs[i], node.Log)
 		}
 		assert.Nil(t, err)
 
@@ -221,8 +221,8 @@ func TestWebhookLogConnectionResolver(t *testing.T) {
 		want := errors.New("error")
 		store := createMockStore(nil, 0, want)
 
-		r := &webhookLogConnectionResolver{
-			args: &webhookLogsArgs{
+		r := &WebhookLogConnectionResolver{
+			args: &WebhookLogsArgs{
 				ConnectionArgs: graphqlutil.ConnectionArgs{
 					First: int32Ptr(20),
 				},
@@ -241,8 +241,8 @@ func TestWebhookLogConnectionResolver_TotalCount(t *testing.T) {
 		store := database.NewMockWebhookLogStore()
 		store.CountFunc.SetDefaultReturn(40, nil)
 
-		r := &webhookLogConnectionResolver{
-			args: &webhookLogsArgs{
+		r := &WebhookLogConnectionResolver{
+			args: &WebhookLogsArgs{
 				OnlyErrors: boolPtr(true),
 			},
 			externalServiceID: webhookLogsExternalServiceID(1),
@@ -271,8 +271,8 @@ func TestWebhookLogConnectionResolver_TotalCount(t *testing.T) {
 		store := database.NewMockWebhookLogStore()
 		store.CountFunc.SetDefaultReturn(0, want)
 
-		r := &webhookLogConnectionResolver{
-			args: &webhookLogsArgs{
+		r := &WebhookLogConnectionResolver{
+			args: &WebhookLogsArgs{
 				OnlyErrors: boolPtr(true),
 			},
 			externalServiceID: webhookLogsExternalServiceID(1),

--- a/cmd/frontend/graphqlbackend/webhooks.go
+++ b/cmd/frontend/graphqlbackend/webhooks.go
@@ -38,6 +38,7 @@ type WebhookResolver interface {
 	UpdatedAt() gqlutil.DateTime
 	CreatedBy(ctx context.Context) (*UserResolver, error)
 	UpdatedBy(ctx context.Context) (*UserResolver, error)
+	WebhookLogs(ctx context.Context) (*WebhookLogConnectionResolver, error)
 }
 
 type CreateWebhookArgs struct {

--- a/cmd/frontend/graphqlbackend/webhooks.go
+++ b/cmd/frontend/graphqlbackend/webhooks.go
@@ -38,7 +38,7 @@ type WebhookResolver interface {
 	UpdatedAt() gqlutil.DateTime
 	CreatedBy(ctx context.Context) (*UserResolver, error)
 	UpdatedBy(ctx context.Context) (*UserResolver, error)
-	WebhookLogs(ctx context.Context) (*WebhookLogConnectionResolver, error)
+	WebhookLogs(ctx context.Context, args *WebhookLogsArgs) (*WebhookLogConnectionResolver, error)
 }
 
 type CreateWebhookArgs struct {

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
@@ -326,15 +326,9 @@ func (r *webhookResolver) WebhookLogs(ctx context.Context, args *graphqlbackend.
 	gqlID := marshalWebhookID(r.hook.ID)
 	// We need to make a new args struct, otherwise the pointer gets shared
 	// between resolvers.
-	resolverArgs := &graphqlbackend.WebhookLogsArgs{
-		WebhookID:  &gqlID,
-		After:      args.After,
-		OnlyErrors: args.OnlyErrors,
-		Since:      args.Since,
-		Until:      args.Until,
-	}
-	res, err := graphqlbackend.NewWebhookLogConnectionResolver(ctx, r.db, resolverArgs, graphqlbackend.WebhookLogsAllExternalServices)
-	return res, err
+	resolverArgs := *args
+	resolverArgs.WebhookID = &gqlID
+	return graphqlbackend.NewWebhookLogConnectionResolver(ctx, r.db, &resolverArgs, graphqlbackend.WebhookLogsAllExternalServices)
 }
 
 func marshalWebhookID(id int32) graphql.ID {

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
@@ -322,6 +322,13 @@ func (r *webhookResolver) UpdatedBy(ctx context.Context) (*graphqlbackend.UserRe
 	return user, err
 }
 
+func (r *webhookResolver) WebhookLogs(ctx context.Context) (*graphqlbackend.WebhookLogConnectionResolver, error) {
+	gqlID := marshalWebhookID(r.hook.ID)
+	args := &graphqlbackend.WebhookLogsArgs{WebhookID: &gqlID}
+	res, err := graphqlbackend.NewWebhookLogConnectionResolver(ctx, r.db, args, graphqlbackend.WebhookLogsAllExternalServices)
+	return res, err
+}
+
 func marshalWebhookID(id int32) graphql.ID {
 	return relay.MarshalID("Webhook", id)
 }

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
@@ -322,10 +322,18 @@ func (r *webhookResolver) UpdatedBy(ctx context.Context) (*graphqlbackend.UserRe
 	return user, err
 }
 
-func (r *webhookResolver) WebhookLogs(ctx context.Context) (*graphqlbackend.WebhookLogConnectionResolver, error) {
+func (r *webhookResolver) WebhookLogs(ctx context.Context, args *graphqlbackend.WebhookLogsArgs) (*graphqlbackend.WebhookLogConnectionResolver, error) {
 	gqlID := marshalWebhookID(r.hook.ID)
-	args := &graphqlbackend.WebhookLogsArgs{WebhookID: &gqlID}
-	res, err := graphqlbackend.NewWebhookLogConnectionResolver(ctx, r.db, args, graphqlbackend.WebhookLogsAllExternalServices)
+	// We need to make a new args struct, otherwise the pointer gets shared
+	// between resolvers.
+	resolverArgs := &graphqlbackend.WebhookLogsArgs{
+		WebhookID:  &gqlID,
+		After:      args.After,
+		OnlyErrors: args.OnlyErrors,
+		Since:      args.Since,
+		Until:      args.Until,
+	}
+	res, err := graphqlbackend.NewWebhookLogConnectionResolver(ctx, r.db, resolverArgs, graphqlbackend.WebhookLogsAllExternalServices)
 	return res, err
 }
 

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
@@ -285,32 +285,10 @@ func TestListWebhooks(t *testing.T) {
 			ExpectedResult: `{"webhooks":
 				{
 					"nodes":[
-						{
-							"id":"V2ViaG9vazox",
-                            "webhookLogs": {
-                                "totalCount": 2
-                            }
-						},
-						{
-							"id":"V2ViaG9vazoy",
-                            "webhookLogs": {
-                                "totalCount": 1
-                            }
-						},
-						{
-							"id":"V2ViaG9vazoz",
-                            "webhookLogs": {
-                                "totalCount": 0
-                            }
-
-						},
-						{
-							"id":"V2ViaG9vazo0",
-                            "webhookLogs": {
-                                "totalCount": 0
-                            }
-
-						}
+						{ "id":"V2ViaG9vazox", "webhookLogs": { "totalCount": 2 } },
+						{ "id":"V2ViaG9vazoy", "webhookLogs": { "totalCount": 1 } },
+						{ "id":"V2ViaG9vazoz", "webhookLogs": { "totalCount": 0 } },
+						{ "id":"V2ViaG9vazo0", "webhookLogs": { "totalCount": 0 } }
 					],
 					"totalCount":4,
 					"pageInfo":{"hasNextPage":false}
@@ -337,32 +315,10 @@ func TestListWebhooks(t *testing.T) {
 			ExpectedResult: `{"webhooks":
 				{
 					"nodes":[
-						{
-							"id":"V2ViaG9vazox",
-                            "webhookLogs": {
-                                "totalCount": 1
-                            }
-						},
-						{
-							"id":"V2ViaG9vazoy",
-                            "webhookLogs": {
-                                "totalCount": 1
-                            }
-						},
-						{
-							"id":"V2ViaG9vazoz",
-                            "webhookLogs": {
-                                "totalCount": 0
-                            }
-
-						},
-						{
-							"id":"V2ViaG9vazo0",
-                            "webhookLogs": {
-                                "totalCount": 0
-                            }
-
-						}
+						{ "id":"V2ViaG9vazox", "webhookLogs": { "totalCount": 1 } },
+						{ "id":"V2ViaG9vazoy", "webhookLogs": { "totalCount": 1 } },
+						{ "id":"V2ViaG9vazoz", "webhookLogs": { "totalCount": 0 } },
+						{ "id":"V2ViaG9vazo0", "webhookLogs": { "totalCount": 0 } }
 					],
 					"totalCount":4,
 					"pageInfo":{"hasNextPage":false}

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
@@ -81,9 +81,51 @@ func TestListWebhooks(t *testing.T) {
 		return len(whs), err
 	})
 
+	webhookLogsStore := database.NewMockWebhookLogStore()
+	webhookLogs := []*types.WebhookLog{
+		{
+			ID:         1,
+			WebhookID:  &webhooks[0].ID,
+			StatusCode: 404,
+		},
+		{
+			ID:         2,
+			WebhookID:  &webhooks[0].ID,
+			StatusCode: 200,
+		},
+		{
+			ID:         3,
+			WebhookID:  &webhooks[1].ID,
+			StatusCode: 404,
+		},
+	}
+	webhookLogsStore.ListFunc.SetDefaultHook(func(ctx2 context.Context, opts database.WebhookLogListOpts) ([]*types.WebhookLog, int64, error) {
+		if opts.WebhookID == nil {
+			return webhookLogs, 0, nil
+		}
+		filteredWebhooks := []*types.WebhookLog{}
+		for _, webhookLog := range webhookLogs {
+			if *webhookLog.WebhookID == *opts.WebhookID {
+				if opts.OnlyErrors {
+					if webhookLog.StatusCode >= 400 {
+						filteredWebhooks = append(filteredWebhooks, webhookLog)
+					}
+				} else {
+					filteredWebhooks = append(filteredWebhooks, webhookLog)
+				}
+			}
+		}
+		return filteredWebhooks, 0, nil
+	})
+	webhookLogsStore.CountFunc.SetDefaultHook(func(ctx2 context.Context, opts database.WebhookLogListOpts) (int64, error) {
+		whs, _, err := webhookLogsStore.List(ctx2, opts)
+		return int64(len(whs)), err
+	})
+
 	db := database.NewMockDB()
 	db.WebhooksFunc.SetDefaultReturn(webhookStore)
 	db.UsersFunc.SetDefaultReturn(users)
+	db.WebhookLogsFunc.SetDefaultReturn(webhookLogsStore)
 	gqlSchema := createGqlSchema(t, db)
 	graphqlbackend.RunTests(t, []*graphqlbackend.Test{
 		{
@@ -219,6 +261,110 @@ func TestListWebhooks(t *testing.T) {
 						{"id":"V2ViaG9vazo0"}
 					],
 					"totalCount":2,
+					"pageInfo":{"hasNextPage":false}
+				}}`,
+		},
+		{
+			Label:   "with logs",
+			Context: ctx,
+			Schema:  gqlSchema,
+			Query: `
+				{
+					webhooks {
+						nodes {
+							id
+                            webhookLogs {
+                                totalCount
+                            }
+						}
+						totalCount
+						pageInfo { hasNextPage }
+					}
+				}
+			`,
+			ExpectedResult: `{"webhooks":
+				{
+					"nodes":[
+						{
+							"id":"V2ViaG9vazox",
+                            "webhookLogs": {
+                                "totalCount": 2
+                            }
+						},
+						{
+							"id":"V2ViaG9vazoy",
+                            "webhookLogs": {
+                                "totalCount": 1
+                            }
+						},
+						{
+							"id":"V2ViaG9vazoz",
+                            "webhookLogs": {
+                                "totalCount": 0
+                            }
+
+						},
+						{
+							"id":"V2ViaG9vazo0",
+                            "webhookLogs": {
+                                "totalCount": 0
+                            }
+
+						}
+					],
+					"totalCount":4,
+					"pageInfo":{"hasNextPage":false}
+				}}`,
+		},
+		{
+			Label:   "with logs only errors",
+			Context: ctx,
+			Schema:  gqlSchema,
+			Query: `
+				{
+					webhooks {
+						nodes {
+							id
+                            webhookLogs(onlyErrors: true) {
+                                totalCount
+                            }
+						}
+						totalCount
+						pageInfo { hasNextPage }
+					}
+				}
+			`,
+			ExpectedResult: `{"webhooks":
+				{
+					"nodes":[
+						{
+							"id":"V2ViaG9vazox",
+                            "webhookLogs": {
+                                "totalCount": 1
+                            }
+						},
+						{
+							"id":"V2ViaG9vazoy",
+                            "webhookLogs": {
+                                "totalCount": 1
+                            }
+						},
+						{
+							"id":"V2ViaG9vazoz",
+                            "webhookLogs": {
+                                "totalCount": 0
+                            }
+
+						},
+						{
+							"id":"V2ViaG9vazo0",
+                            "webhookLogs": {
+                                "totalCount": 0
+                            }
+
+						}
+					],
+					"totalCount":4,
 					"pageInfo":{"hasNextPage":false}
 				}}`,
 		},

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
@@ -303,9 +303,9 @@ func TestListWebhooks(t *testing.T) {
 					webhooks {
 						nodes {
 							id
-                            webhookLogs(onlyErrors: true) {
-                                totalCount
-                            }
+							webhookLogs(onlyErrors: true) {
+								totalCount
+							}
 						}
 						totalCount
 						pageInfo { hasNextPage }

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
@@ -273,9 +273,9 @@ func TestListWebhooks(t *testing.T) {
 					webhooks {
 						nodes {
 							id
-                            webhookLogs {
-                                totalCount
-                            }
+							webhookLogs {
+								totalCount
+ 							}
 						}
 						totalCount
 						pageInfo { hasNextPage }


### PR DESCRIPTION
Closes #44000 

Adds stats to the header of the Incoming webhooks page.

<img width="963" alt="image" src="https://user-images.githubusercontent.com/6427795/206431595-38a32016-185d-47ed-86cf-ba3e3543e8b4.png">

## Test plan

Storybook updated, tests added for GraphQL resolver updates.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
