### PR TITLE
Document how to run Sourcegraph behind `ngrok`

### DIFF
--- a/doc/dev/how-to/index.md
+++ b/doc/dev/how-to/index.md
@@ -40,6 +40,7 @@
 - [How to use client app PR previews](client_pr_previews.md)
 - [How to receive a Slack notification if a specific CI step failed](receive_slack_notification_on_a_failed_ci_step.md)
 - [How to allow a CI step to fail without breaking the build and still receive a notification](ci_soft_failure_and_still_notify.md)
+- [Run a local Sourcegraph instance behind ngrok](sourcegraph_ngrok.md)
 <!-- [Sync repositories from gitolite.sgdev.org](sync_repositories_from_gitolite_sgdev_org.md) -->
 
 ## Profiling

--- a/doc/dev/how-to/sourcegraph_ngrok.md
+++ b/doc/dev/how-to/sourcegraph_ngrok.md
@@ -1,0 +1,16 @@
+# Run a local Sourcegraph instance behind ngrok
+
+Sometimes it's useful to have the Sourcegraph instance you're running on your
+local machine be reachable over the internet. If you're testing webhooks, for
+example, where a code host needs to be able to send requests to your instances.
+
+One way to do that is to use [ngrok](https://ngrok.io/), a reverse proxy that
+allows you to expose your instance to the internet.
+
+1. Install `ngrok`: `brew install ngrok`
+1. Start your Sourcegraph instance: `sg start`
+1. Start `ngrok` and point it at Sourcegraph: `ngrok http --host-header=rewrite 3080`
+1. Copy the `Forwarding` URL `ngrok` displays. e.g.: `https://630b-87-170-68-206.eu.ngrok.io`
+1. Edit your site-config (i.e. `../dev-private/enterprise/dev/site-config.json`) and update the `"externalURL"` to point to your ngrok: `"externalURL": "https://630b-87-170-68-206.eu.ngrok.io"`
+1. Open the ngrok URL in browser to make sure you see your instance
+1. Done

--- a/doc/dev/how-to/sourcegraph_ngrok.md
+++ b/doc/dev/how-to/sourcegraph_ngrok.md
@@ -1,7 +1,7 @@
 # Run a local Sourcegraph instance behind ngrok
 
 Sometimes it's useful to have the Sourcegraph instance you're running on your
-local machine be reachable over the internet. If you're testing webhooks, for
+local machine to be reachable over the internet. If you're testing webhooks, for
 example, where a code host needs to be able to send requests to your instances.
 
 One way to do that is to use [ngrok](https://ngrok.io/), a reverse proxy that

--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -183,6 +183,7 @@ Guides to help with troubleshooting, configuring test instances, debugging, and 
 ### Testing
 
 - [How to write and run tests](how-to/testing.md)
+- [Run a local Sourcegraph instance behind ngrok](how-to/sourcegraph_ngrok.md)
 - Testing against code hosts
   - [Configure a test instance of Phabricator and Gitolite](how-to/configure_phabricator_gitolite.md)
   - [Test a Phabricator and Gitolite instance](how-to/test_phabricator.md)


### PR DESCRIPTION
We're testing webhooks right now in #repo-management/#iam and I thought this would be useful to have in docs.

## Test plan

CI