### PR TITLE
web: clean up create/edit/delete webhook buttons.

### DIFF
--- a/client/web/src/site-admin/SiteAdminWebhooksPage.module.scss
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.module.scss
@@ -1,11 +1,3 @@
-.webhooks {
-    &__grid {
-        display: grid;
-        grid-template-columns: [info] minmax(min-content, 1fr) [actions] max-content;
-        align-items: center;
-    }
-}
-
 .grid {
     display: grid;
     grid-template-columns: max-content max-content;

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react'
 
 import { mdiCog, mdiMapSearch, mdiPlus } from '@mdi/js'
-import classNames from 'classnames'
 import { RouteComponentProps } from 'react-router'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -27,8 +26,6 @@ import styles from './SiteAdminWebhooksPage.module.scss'
 interface Props extends RouteComponentProps<{}>, TelemetryProps {}
 
 export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
-    history,
-    location,
     telemetryService,
 }) => {
     useEffect(() => {
@@ -71,11 +68,7 @@ export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChild
                     {error && <ConnectionError errors={[error.message]} />}
                     {loading && !connection && <ConnectionLoading />}
                     {connection && connection.nodes?.length > 0 && <Header />}
-                    <ConnectionList
-                        as="ul"
-                        className={classNames(styles.webhooksGrid, 'list-group')}
-                        aria-label="Webhooks"
-                    >
+                    <ConnectionList as="ul" className="list-group" aria-label="Webhooks">
                         {connection?.nodes?.map(node => (
                             <WebhookNode
                                 key={node.id}
@@ -108,10 +101,7 @@ export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChild
 }
 
 const Header: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
-    <div className={styles.webhooksGrid}>
-        <H5 className="p-2 d-none d-md-block text-uppercase text-left text-nowrap">Webhook</H5>
-        <H5 className="d-none d-md-block text-uppercase text-center text-nowrap">Actions</H5>
-    </div>
+    <H5 className="p-2 d-none d-md-block text-uppercase text-left text-nowrap">Webhook</H5>
 )
 
 const EmptyList: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (

--- a/client/web/src/site-admin/WebhookNode.tsx
+++ b/client/web/src/site-admin/WebhookNode.tsx
@@ -1,16 +1,9 @@
 import React from 'react'
 
-import { mdiCog, mdiDelete } from '@mdi/js'
-import { noop } from 'lodash'
-
-import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
-import { useMutation } from '@sourcegraph/http-client'
-import { Button, ButtonLink, H3, Icon, Link, LoadingSpinner, Text, Tooltip } from '@sourcegraph/wildcard'
+import { H3, Icon, Link, Text } from '@sourcegraph/wildcard'
 
 import { defaultExternalServices } from '../components/externalServices/externalServices'
-import { DeleteWebhookResult, DeleteWebhookVariables, ExternalServiceKind } from '../graphql-operations'
-
-import { DELETE_WEBHOOK } from './backend'
+import { ExternalServiceKind } from '../graphql-operations'
 
 import styles from './WebhookNode.module.scss'
 
@@ -29,11 +22,6 @@ export const WebhookNode: React.FunctionComponent<React.PropsWithChildren<Webhoo
 }) => {
     const IconComponent = defaultExternalServices[codeHostKind].icon
 
-    const [deleteWebhook, { error, loading: isDeleting }] = useMutation<DeleteWebhookResult, DeleteWebhookVariables>(
-        DELETE_WEBHOOK,
-        { variables: { hookID: id }, onCompleted: () => window.location.reload() }
-    )
-
     return (
         <>
             <span className={styles.nodeSeparator} />
@@ -49,44 +37,6 @@ export const WebhookNode: React.FunctionComponent<React.PropsWithChildren<Webhoo
                     </Text>
                 </H3>
             </div>
-            <div className="d-flex flex-shrink-0 ml-3">
-                <div>
-                    <Tooltip content="Edit webhook">
-                        <ButtonLink
-                            to={`/site-admin/webhooks/${id}/edit`}
-                            className="test-edit-webhook"
-                            variant="secondary"
-                            size="sm"
-                        >
-                            <Icon aria-hidden={true} svgPath={mdiCog} /> Edit
-                        </ButtonLink>
-                    </Tooltip>
-                </div>
-                <div className="ml-1">
-                    <Tooltip content="Delete webhook">
-                        <Button
-                            aria-label="Delete"
-                            className="test-delete-webhook"
-                            variant="danger"
-                            size="sm"
-                            disabled={isDeleting}
-                            onClick={event => {
-                                event.preventDefault()
-                                deleteWebhook().catch(
-                                    // noop here is used because creation error is handled directly when useMutation is called
-                                    noop
-                                )
-                            }}
-                        >
-                            <>
-                                {isDeleting && <LoadingSpinner />}
-                                <Icon aria-hidden={true} svgPath={mdiDelete} />
-                            </>
-                        </Button>
-                    </Tooltip>
-                </div>
-            </div>
-            {error && <ErrorAlert className="mt-2" prefix="Error during webhook deletion" error={error} />}
         </>
     )
 }


### PR DESCRIPTION
That commit makes creating webhooks available only from a single place on list view and editing/deleting them from a single place which is a webhook details view.

Initial design can be found here https://www.figma.com/file/ngPEwLqRVFAfXQC7lE0WLz/Webhooks?node-id=0%3A1&t=3TiseT2MExsjoXGC-0

### Small demo of how it looks now

https://user-images.githubusercontent.com/94846361/206431361-9c28e142-ee23-4026-a5ca-a4441cbf42df.mov

### Test plan
Storybook, manual tests.

Closes https://github.com/sourcegraph/sourcegraph/issues/45401
Depends on https://github.com/sourcegraph/sourcegraph/pull/45383

## App preview:

- [Web](https://sg-web-ao-ui-webhooks-redesign-buttons.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
