### PR TITLE
web: add support for removing of external service information from webhook logs.

### DIFF
--- a/client/web/src/site-admin/SiteAdminWebhookPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookPage.tsx
@@ -108,7 +108,7 @@ export const SiteAdminWebhookPage: FC<WebhookPageProps> = props => {
                 <ConnectionList aria-label="WebhookLogs" className={styles.logs}>
                     <Header />
                     {connection?.nodes?.map(node => (
-                        <WebhookLogNode key={node.id} node={node} />
+                        <WebhookLogNode doNotShowExternalService={true} key={node.id} node={node} />
                     ))}
                 </ConnectionList>
 
@@ -138,7 +138,8 @@ const Header: FC = () => (
         {/* element in the header row*/}
         <span className="d-md-block" />
         <H5 className="text-uppercase text-center text-nowrap">Status code</H5>
-        <H5 className="text-uppercase text-nowrap">External service</H5>
+        {/* Another empty element to fill in the empty middle of the grid */}
+        <span className="d-md-block" />
         <H5 className="text-uppercase text-nowrap">Received at</H5>
     </>
 )

--- a/client/web/src/site-admin/webhooks/WebhookLogNode.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogNode.tsx
@@ -15,6 +15,7 @@ import styles from './WebhookLogNode.module.scss'
 
 export interface Props {
     node: WebhookLogFields
+    doNotShowExternalService?: boolean
 
     // For storybook purposes only:
     initiallyExpanded?: boolean
@@ -22,6 +23,7 @@ export interface Props {
 }
 
 export const WebhookLogNode: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
+    doNotShowExternalService = false,
     initiallyExpanded,
     initialTabIndex,
     node: { externalService, receivedAt, request, response, statusCode },
@@ -45,7 +47,8 @@ export const WebhookLogNode: React.FunctionComponent<React.PropsWithChildren<Pro
                 <StatusCode code={statusCode} />
             </span>
             <span>
-                {externalService ? externalService.displayName : <span className="text-danger">Unmatched</span>}
+                {!doNotShowExternalService &&
+                    (externalService ? externalService.displayName : <span className="text-danger">Unmatched</span>)}
             </span>
             <span className={styles.receivedAt}>{format(Date.parse(receivedAt), 'Ppp')}</span>
             <span className={styles.smDetailsButton}>


### PR DESCRIPTION
Also remove external service information from SiteAdminWebhookPage.

Test plan:
Storybook.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ao-ui-webhooks-remove-ext-svc.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
