### PR TITLE
Only display old webhooks on the Incoming webhook logs page

### DIFF
--- a/client/web/src/site-admin/webhooks/backend.ts
+++ b/client/web/src/site-admin/webhooks/backend.ts
@@ -81,9 +81,6 @@ export const queryWebhookLogs = (
 
     if (externalService === 'all' || externalService === 'unmatched') {
         return requestGraphQL<WebhookLogsResult, WebhookLogsVariables>(
-            // V2ViaG9vazow is webhook ID 0.
-            // This is so that all webhook logs that have a webhookID
-            // associated with them are excluded.
             gql`
                 query WebhookLogs($first: Int, $after: String, $onlyErrors: Boolean!, $onlyUnmatched: Boolean!) {
                     webhookLogs(
@@ -91,7 +88,7 @@ export const queryWebhookLogs = (
                         after: $after
                         onlyErrors: $onlyErrors
                         onlyUnmatched: $onlyUnmatched
-                        webhookID: "V2ViaG9vazow"
+                        legacyOnly: true
                     ) {
                         ...WebhookLogConnectionFields
                     }
@@ -143,9 +140,6 @@ export const queryWebhookLogs = (
     )
 }
 
-// V2ViaG9vazow is webhook ID 0.
-// This is so that webhook logs that have a webhook ID associated
-// with them are excluded.
 export const WEBHOOK_LOG_PAGE_HEADER = gql`
     query WebhookLogPageHeader {
         externalServices {
@@ -155,7 +149,7 @@ export const WEBHOOK_LOG_PAGE_HEADER = gql`
             totalCount
         }
 
-        webhookLogs(onlyErrors: true, webhookID: "V2ViaG9vazow") {
+        webhookLogs(onlyErrors: true, legacyOnly: true) {
             totalCount
         }
     }

--- a/client/web/src/site-admin/webhooks/backend.ts
+++ b/client/web/src/site-admin/webhooks/backend.ts
@@ -81,9 +81,18 @@ export const queryWebhookLogs = (
 
     if (externalService === 'all' || externalService === 'unmatched') {
         return requestGraphQL<WebhookLogsResult, WebhookLogsVariables>(
+            // V2ViaG9vazow is webhook ID 0.
+            // This is so that all webhook logs that have a webhookID
+            // associated with them are excluded.
             gql`
                 query WebhookLogs($first: Int, $after: String, $onlyErrors: Boolean!, $onlyUnmatched: Boolean!) {
-                    webhookLogs(first: $first, after: $after, onlyErrors: $onlyErrors, onlyUnmatched: $onlyUnmatched) {
+                    webhookLogs(
+                        first: $first
+                        after: $after
+                        onlyErrors: $onlyErrors
+                        onlyUnmatched: $onlyUnmatched
+                        webhookID: "V2ViaG9vazow"
+                    ) {
                         ...WebhookLogConnectionFields
                     }
                 }
@@ -134,6 +143,9 @@ export const queryWebhookLogs = (
     )
 }
 
+// V2ViaG9vazow is webhook ID 0.
+// This is so that webhook logs that have a webhook ID associated
+// with them are excluded.
 export const WEBHOOK_LOG_PAGE_HEADER = gql`
     query WebhookLogPageHeader {
         externalServices {
@@ -143,7 +155,7 @@ export const WEBHOOK_LOG_PAGE_HEADER = gql`
             totalCount
         }
 
-        webhookLogs(onlyErrors: true) {
+        webhookLogs(onlyErrors: true, webhookID: "V2ViaG9vazow") {
             totalCount
         }
     }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1618,6 +1618,10 @@ type Query {
         Only include webhook logs of given webhook ID.
         """
         webhookID: ID
+        """
+        Only include webhook logs that have no webhook ID set.
+        """
+        legacyOnly: Boolean
     ): WebhookLogConnection!
 
     """

--- a/cmd/frontend/graphqlbackend/webhook_logs.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs.go
@@ -31,6 +31,7 @@ type WebhookLogsArgs struct {
 	Since      *time.Time
 	Until      *time.Time
 	WebhookID  *graphql.ID
+	LegacyOnly *bool
 }
 
 // webhookLogsExternalServiceID is used to represent an external service ID,
@@ -89,9 +90,17 @@ func (args *WebhookLogsArgs) toListOpts(externalServiceID webhookLogsExternalSer
 		if err != nil {
 			return opts, errors.Wrap(err, "unmarshalling webhook ID")
 		}
-		if id >= 0 {
+		if id > 0 {
 			opts.WebhookID = &id
 		}
+	}
+
+	// If only legacy webhook logs is requested,
+	// set WebhookID to zero so that the database
+	// query only returns webhooks with no ID set.
+	if args.LegacyOnly != nil && *args.LegacyOnly {
+		zeroID := int32(0)
+		opts.WebhookID = &zeroID
 	}
 
 	return opts, nil

--- a/cmd/frontend/graphqlbackend/webhook_logs.go
+++ b/cmd/frontend/graphqlbackend/webhook_logs.go
@@ -89,7 +89,7 @@ func (args *WebhookLogsArgs) toListOpts(externalServiceID webhookLogsExternalSer
 		if err != nil {
 			return opts, errors.Wrap(err, "unmarshalling webhook ID")
 		}
-		if id > 0 {
+		if id >= 0 {
 			opts.WebhookID = &id
 		}
 	}


### PR DESCRIPTION
The old Incoming webhook logs page displayed logs from the new webhooks, causing a lot of noise since they have no External Service attached. See screenshots

Before:

![Screenshot 2022-12-08 at 16 00 55](https://user-images.githubusercontent.com/6427795/206467709-3cd4f727-f653-4de7-b234-c4b280c09c01.png)

After:

![Screenshot 2022-12-08 at 16 05 49](https://user-images.githubusercontent.com/6427795/206467800-2273f585-f402-4941-a753-0e5cba7782ab.png)

## Test plan

Verified manually

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
