### PR TITLE
web: add confirmation popup for webhook deletion.

### DIFF
--- a/client/web/src/site-admin/SiteAdminWebhookPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookPage.tsx
@@ -77,15 +77,17 @@ export const SiteAdminWebhookPage: FC<WebhookPageProps> = props => {
                     actions={
                         <div className="d-flex flex-row-reverse align-items-center">
                             <div className="flex-grow mr-2">
-                                <ButtonLink
-                                    to={`/site-admin/webhooks/${id}/edit`}
-                                    className="test-edit-webhook"
-                                    size="sm"
-                                    variant="primary"
-                                    display="inline"
-                                >
-                                    Edit
-                                </ButtonLink>
+                                <Tooltip content="Edit webhook">
+                                    <ButtonLink
+                                        to={`/site-admin/webhooks/${id}/edit`}
+                                        className="test-edit-webhook"
+                                        size="sm"
+                                        variant="primary"
+                                        display="inline"
+                                    >
+                                        Edit
+                                    </ButtonLink>
+                                </Tooltip>
                             </div>
                             <div className="mr-1">
                                 <Tooltip content="Delete webhook">
@@ -97,6 +99,13 @@ export const SiteAdminWebhookPage: FC<WebhookPageProps> = props => {
                                         disabled={isDeleting}
                                         onClick={event => {
                                             event.preventDefault()
+                                            if (
+                                                !window.confirm(
+                                                    'Delete this webhook? Any external webhooks configured to point at this webhook will no longer be received.'
+                                                )
+                                            ) {
+                                                return
+                                            }
                                             deleteWebhook().catch(
                                                 // noop here is used because creation error is handled directly when useMutation is called
                                                 noop


### PR DESCRIPTION
Test plan:
Manual tests.

### Demo

https://user-images.githubusercontent.com/94846361/206484550-3331f561-a4ec-40f3-abab-9a5238b23845.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ao-ui-webhooks-delete-confirmation.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
