### PR TITLE
Add context timeout to permissions webhook handlers

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/webhooks/github.go
+++ b/enterprise/cmd/frontend/internal/authz/webhooks/github.go
@@ -63,7 +63,8 @@ func (h *GitHubWebhook) handleGitHubWebhook(ctx context.Context, db database.DB,
 	// that we are getting fresh results.
 	go func() {
 		time.Sleep(sleepTime)
-		eventContext := context.Background()
+		eventContext, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		defer cancel()
 
 		switch e := payload.(type) {
 		case *gh.RepositoryEvent:


### PR DESCRIPTION
This is to prevent goroutines from becoming zombies if something blocks.

## Test plan

Tests pass and manual test.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
