### PR TITLE
Revert "search: add "Reindex now" to index status page (#45178)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ All notable changes to Sourcegraph are documented in this file.
 - More complete stack traces for Outbound request log [#45151](https://github.com/sourcegraph/sourcegraph/pull/45151)
 - A new status message now reports how many repositories have already been indexed for search. [#45246](https://github.com/sourcegraph/sourcegraph/pull/45246)
 - Search contexts can now be starred (favorited) in the search context management page. Starred search contexts will appear first in the context dropdown menu next to the search box. [#45230](https://github.com/sourcegraph/sourcegraph/pull/45230)
-- Added a button "Reindex now" to the index status page. Admins can now force an immediate reindex of a repository. [#45178](https://github.com/sourcegraph/sourcegraph/pull/45178)
 
 ### Changed
 

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -9,20 +9,14 @@ import { map, switchMap, tap } from 'rxjs/operators'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { createAggregateError, pluralize } from '@sourcegraph/common'
-import { gql, useMutation } from '@sourcegraph/http-client'
+import { gql } from '@sourcegraph/http-client'
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
-import { Button, Container, PageHeader, LoadingSpinner, Link, Alert, Icon, Code, H3 } from '@sourcegraph/wildcard'
+import { Container, PageHeader, LoadingSpinner, Link, Alert, Icon, Code, H3 } from '@sourcegraph/wildcard'
 
 import { queryGraphQL } from '../../backend/graphql'
 import { PageTitle } from '../../components/PageTitle'
 import { Timestamp } from '../../components/time/Timestamp'
-import {
-    reindexResult,
-    reindexVariables,
-    RepositoryTextSearchIndexRepository,
-    Scalars,
-    SettingsAreaRepositoryFields,
-} from '../../graphql-operations'
+import { RepositoryTextSearchIndexRepository, Scalars, SettingsAreaRepositoryFields } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
 import { prettyBytesBigint } from '../../util/prettyBytesBigint'
 
@@ -86,27 +80,6 @@ function fetchRepositoryTextSearchIndex(id: Scalars['ID']): Observable<Repositor
     )
 }
 
-function useForceReindex(id: Scalars['ID']): () => void {
-    const [submitForceReindex] = useMutation<reindexResult, reindexVariables>(
-        gql`
-            mutation reindex($id: ID!) {
-                reindexRepository(repository: $id) {
-                    alwaysNil
-                }
-            }
-        `
-    )
-    const forceReindex = React.useCallback(() => {
-        submitForceReindex({
-            variables: { id },
-        }).then(
-            () => {},
-            () => {}
-        )
-    }, [submitForceReindex, id])
-    return forceReindex
-}
-
 const TextSearchIndexedReference: React.FunctionComponent<
     React.PropsWithChildren<{
         repo: SettingsAreaRepositoryFields
@@ -115,52 +88,43 @@ const TextSearchIndexedReference: React.FunctionComponent<
 > = ({ repo, indexedRef }) => {
     const isCurrent = indexedRef.indexed && indexedRef.current
 
-    const forceReindex = useForceReindex(repo.id)
-
     return (
-        <>
-            <div className="mb-3">
-                <Button variant="primary" onClick={() => forceReindex()}>
-                    Reindex now
-                </Button>
-            </div>
-            <li className={styles.ref}>
-                <Icon
-                    className={classNames(styles.refIcon, isCurrent && styles.refIconCurrent)}
-                    svgPath={isCurrent ? mdiCheckCircle : undefined}
-                    as={!isCurrent ? LoadingSpinner : undefined}
-                    aria-hidden={true}
-                />
-                <LinkOrSpan to={indexedRef.ref.url}>
-                    <Code weight="bold">{indexedRef.ref.displayName}</Code>
-                </LinkOrSpan>{' '}
-                {indexedRef.indexed ? (
-                    <span>
-                        &nbsp;&mdash; indexed at{' '}
-                        <Code>
-                            <LinkOrSpan
-                                to={indexedRef.indexedCommit?.commit ? indexedRef.indexedCommit.commit.url : repo.url}
-                            >
-                                {indexedRef.indexedCommit!.abbreviatedOID}
-                            </LinkOrSpan>
-                        </Code>{' '}
-                        {indexedRef.current ? '(up to date)' : '(index update in progress)'}
-                        {indexedRef.skippedIndexed && Number(indexedRef.skippedIndexed.count) > 0 ? (
-                            <span>
-                                .&nbsp;
-                                <Link to={'/search?q=' + encodeURIComponent(indexedRef.skippedIndexed.query)}>
-                                    {indexedRef.skippedIndexed.count}{' '}
-                                    {pluralize('file', Number(indexedRef.skippedIndexed.count))} skipped during indexing
-                                </Link>
-                                .
-                            </span>
-                        ) : null}
-                    </span>
-                ) : (
-                    <span>&nbsp;&mdash; initial indexing in progress</span>
-                )}
-            </li>
-        </>
+        <li className={styles.ref}>
+            <Icon
+                className={classNames(styles.refIcon, isCurrent && styles.refIconCurrent)}
+                svgPath={isCurrent ? mdiCheckCircle : undefined}
+                as={!isCurrent ? LoadingSpinner : undefined}
+                aria-hidden={true}
+            />
+            <LinkOrSpan to={indexedRef.ref.url}>
+                <Code weight="bold">{indexedRef.ref.displayName}</Code>
+            </LinkOrSpan>{' '}
+            {indexedRef.indexed ? (
+                <span>
+                    &nbsp;&mdash; indexed at{' '}
+                    <Code>
+                        <LinkOrSpan
+                            to={indexedRef.indexedCommit?.commit ? indexedRef.indexedCommit.commit.url : repo.url}
+                        >
+                            {indexedRef.indexedCommit!.abbreviatedOID}
+                        </LinkOrSpan>
+                    </Code>{' '}
+                    {indexedRef.current ? '(up to date)' : '(index update in progress)'}
+                    {indexedRef.skippedIndexed && Number(indexedRef.skippedIndexed.count) > 0 ? (
+                        <span>
+                            .&nbsp;
+                            <Link to={'/search?q=' + encodeURIComponent(indexedRef.skippedIndexed.query)}>
+                                {indexedRef.skippedIndexed.count}{' '}
+                                {pluralize('file', Number(indexedRef.skippedIndexed.count))} skipped during indexing
+                            </Link>
+                            .
+                        </span>
+                    ) : null}
+                </span>
+            ) : (
+                <span>&nbsp;&mdash; initial indexing in progress</span>
+            )}
+        </li>
     )
 }
 


### PR DESCRIPTION
This reverts commit 2f79ae324f69967127a0e4667ee8f08e2865ac54.

I merged the original PR too early. It has too many kinks to go out with the next release.

## Test plan
N/A
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-sh-revert-45178.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
