### PR TITLE
nix: bump nixpkgs for newer nodejs18 and go1.19

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659956501,
-        "narHash": "sha256-7cF2zOaTLWcxmhPBpI1ZoThUy11M1QiY5pat0OXwg3c=",
+        "lastModified": 1669833724,
+        "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6f38b43c8c84c800f93465b2241156419fd4fd52",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6f38b43c8c84c800f93465b2241156419fd4fd52",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "The Sourcegraph developer environment Nix Flake";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=6f38b43c8c84c800f93465b2241156419fd4fd52";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=4d2b37a84fad1091b9de401eb450aae66f1a741e";
   };
 
   outputs = { self, nixpkgs }:

--- a/shell.nix
+++ b/shell.nix
@@ -48,8 +48,7 @@ pkgs.mkShell {
     shellcheck
     golangci-lint
 
-    # Web tools. Need node 16.7 so we use unstable. Yarn should also be built
-    # against it.
+    # Web tools. Need node 18.12.x, and yarn should also be built against it.
     nodejs-18_x
     (yarn.override { nodejs = nodejs-18_x; })
     nodePackages.typescript

--- a/shell.nix
+++ b/shell.nix
@@ -35,7 +35,7 @@ pkgs.mkShell {
     universal-ctags
 
     # Build our backend.
-    go_1_19
+    go
 
     # Lots of our tooling and go tests rely on git et al.
     git
@@ -50,8 +50,8 @@ pkgs.mkShell {
 
     # Web tools. Need node 16.7 so we use unstable. Yarn should also be built
     # against it.
-    nodejs-16_x
-    (yarn.override { nodejs = nodejs-16_x; })
+    nodejs-18_x
+    (yarn.override { nodejs = nodejs-18_x; })
     nodePackages.typescript
 
     # Rust utils for syntax-highlighter service,


### PR DESCRIPTION
Updates nixpkgs for newer nodejs 18 and go 1.19, following on from https://github.com/sourcegraph/sourcegraph/pull/45331

## Test plan

Ran `nix develop` and `nix build .#p4-fusion` on Linux (not tested on Darwin)

## App preview:

- [Web](https://sg-web-nsc-bump-node-18-nix.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
