### PR TITLE
doc: mention v4.2.1 blobstore bug in sourcegraph/server

### DIFF
--- a/client/web/src/enterprise/batches/create/useNamespaces.ts
+++ b/client/web/src/enterprise/batches/create/useNamespaces.ts
@@ -34,10 +34,10 @@ export const useNamespaces = (
     const organizationNamespaces = organizations.nodes
     const userNamespace = userDetails
 
-    const namespaces = useMemo(() => [userNamespace, ...organizationNamespaces], [
-        userNamespace,
-        organizationNamespaces,
-    ])
+    const namespaces = useMemo(
+        () => [userNamespace, ...organizationNamespaces],
+        [userNamespace, organizationNamespaces]
+    )
 
     // The default namespace selected from the dropdown should match whatever the initial
     // namespace was, or else default to the user's namespace.


### PR DESCRIPTION
This adds documentation to mention a v4.2.1 blobstore bug in `sourcegraph/server`.

```
failed to create bucket: operation error S3: CreateBucket, retry quota exceeded, 0 available, 5 requested
```

This only affects `sourcegraph/server`, and only happens when the data directory (e.g. `~/.sourcegraph`) does not yet exist. If the container tries to start a 2nd time, it resolves itself automatically without any intervention.

I've noted this in the update docs, and also explained it is possible to pre-emptively create the directory with the correct permissions to avoid running into the error at all, if desired.

Otherwise the bug is harmless, and the v4.3 release is due December 15th so anyone worried about this can wait a few days for v4.3.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>

## Test plan

Docs change only. Tested the commands in [this discussion](https://sourcegraph.slack.com/archives/C049MPS90VC/p1670529339782009?thread_ts=1670500595.675349&cid=C049MPS90VC)

## App preview:

- [Web](https://sg-web-sg-blobstore-bug.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
