### PR TITLE
Move event logging into a job

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -19,12 +19,9 @@ import (
 	"github.com/sourcegraph/log"
 
 	searchlogs "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/logs"
-	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/deviceid"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
@@ -38,7 +35,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/internal/usagestats"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -356,89 +352,6 @@ var (
 	}, []string{"status", "alert_type", "source", "request_name"})
 )
 
-// LogSearchLatency records search durations in the event database. This
-// function may only be called after a search result is performed, because it
-// relies on the invariant that query and pattern error checking has already
-// been performed.
-func LogSearchLatency(ctx context.Context, db database.DB, si *search.Inputs, durationMs int32) {
-	tr, ctx := trace.New(ctx, "LogSearchLatency", "")
-	defer tr.Finish()
-	var types []string
-	resultTypes, _ := si.Query.StringValues(query.FieldType)
-	for _, typ := range resultTypes {
-		switch typ {
-		case "repo", "symbol", "diff", "commit":
-			types = append(types, typ)
-		case "path":
-			// Map type:path to file
-			types = append(types, "file")
-		case "file":
-			switch {
-			case si.PatternType == query.SearchTypeStandard:
-				types = append(types, "standard")
-			case si.PatternType == query.SearchTypeStructural:
-				types = append(types, "structural")
-			case si.PatternType == query.SearchTypeLiteral:
-				types = append(types, "literal")
-			case si.PatternType == query.SearchTypeRegex:
-				types = append(types, "regexp")
-			case si.PatternType == query.SearchTypeLucky:
-				types = append(types, "lucky")
-			}
-		}
-	}
-
-	// Don't record composite searches that specify more than one type:
-	// because we can't break down the search timings into multiple
-	// categories.
-	if len(types) > 1 {
-		return
-	}
-
-	q, err := query.ToBasicQuery(si.Query)
-	if err != nil {
-		// Can't convert to a basic query, can't guarantee accurate reporting.
-		return
-	}
-	if !query.IsPatternAtom(q) {
-		// Not an atomic pattern, can't guarantee accurate reporting.
-		return
-	}
-
-	// If no type: was explicitly specified, infer the result type.
-	if len(types) == 0 {
-		// If a pattern was specified, a content search happened.
-		if q.IsLiteral() {
-			types = append(types, "literal")
-		} else if q.IsRegexp() {
-			types = append(types, "regexp")
-		} else if q.IsStructural() {
-			types = append(types, "structural")
-		} else if si.Query.Exists(query.FieldFile) {
-			// No search pattern specified and file: is specified.
-			types = append(types, "file")
-		} else {
-			// No search pattern or file: is specified, assume repo.
-			// This includes accounting for searches of fields that
-			// specify repohasfile: and repohascommitafter:.
-			types = append(types, "repo")
-		}
-	}
-
-	// Only log the time if we successfully resolved one search type.
-	if len(types) == 1 {
-		a := actor.FromContext(ctx)
-		if a.IsAuthenticated() && !a.IsMockUser() { // Do not log in tests
-			value := fmt.Sprintf(`{"durationMs": %d}`, durationMs)
-			eventName := fmt.Sprintf("search.latencies.%s", types[0])
-			err := usagestats.LogBackendEvent(db, a.UID, deviceid.FromContext(ctx), eventName, json.RawMessage(value), json.RawMessage(value), featureflag.GetEvaluatedFlagSet(ctx), nil)
-			if err != nil {
-				log15.Warn("Could not log search latency", "err", err)
-			}
-		}
-	}
-}
-
 func logPrometheusBatch(status, alertType, requestSource, requestName string, elapsed time.Duration) {
 	searchResponseCounter.WithLabelValues(
 		status,
@@ -496,7 +409,6 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 	alert, err := r.client.Execute(ctx, agg, r.SearchInputs)
 	srr := r.resultsToResolver(agg.Results, alert, agg.Stats)
 	srr.elapsed = time.Since(start)
-	logBatch(ctx, r.SearchInputs, srr, err)
 	return srr, err
 }
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -600,6 +600,7 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 		if err != nil {
 			return nil, err
 		}
+		j = jobutil.NewLogJob(r.SearchInputs, j)
 		agg := streaming.NewAggregatingStream()
 		alert, err := j.Run(ctx, r.client.JobClients(), agg)
 		if err != nil {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -455,15 +455,7 @@ func logPrometheusBatch(status, alertType, requestSource, requestName string, el
 	).Observe(elapsed.Seconds())
 }
 
-func logBatch(ctx context.Context, db database.DB, searchInputs *search.Inputs, srr *SearchResultsResolver, err error) {
-	var wg sync.WaitGroup
-	defer wg.Wait()
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		LogSearchLatency(ctx, db, searchInputs, srr.ElapsedMilliseconds())
-	}()
-
+func logBatch(ctx context.Context, searchInputs *search.Inputs, srr *SearchResultsResolver, err error) {
 	var status, alertType string
 	status = DetermineStatusForLogs(srr.SearchAlert, srr.Stats, err)
 	if srr.SearchAlert != nil {
@@ -504,7 +496,7 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 	alert, err := r.client.Execute(ctx, agg, r.SearchInputs)
 	srr := r.resultsToResolver(agg.Results, alert, agg.Stats)
 	srr.elapsed = time.Since(start)
-	logBatch(ctx, r.db, r.SearchInputs, srr, err)
+	logBatch(ctx, r.SearchInputs, srr, err)
 	return srr, err
 }
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -409,6 +409,7 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 	alert, err := r.client.Execute(ctx, agg, r.SearchInputs)
 	srr := r.resultsToResolver(agg.Results, alert, agg.Stats)
 	srr.elapsed = time.Since(start)
+	logBatch(ctx, r.SearchInputs, srr, err)
 	return srr, err
 }
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -553,17 +553,6 @@ var (
 )
 
 func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, err error) {
-	// Override user context to ensure that stats for this query are cached
-	// regardless of the user context's cancellation. For example, if
-	// stats/sparklines are slow to load on the homepage and all users navigate
-	// away from that page before they load, no user would ever see them and we
-	// would never cache them. This fixes that by ensuring the first request
-	// 'kicks off loading' and places the result into cache regardless of
-	// whether or not the original querier of this information still wants it.
-	originalCtx := ctx
-	ctx = context.Background()
-	ctx = opentracing.ContextWithSpan(ctx, opentracing.SpanFromContext(originalCtx))
-
 	cacheKey := r.SearchInputs.OriginalQuery
 	// Check if value is in the cache.
 	jsonRes, ok := searchResultsStatsCache.Get(cacheKey)

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -141,17 +141,9 @@ func (h *streamHandler) serveHTTP(r *http.Request, tr *trace.Trace, eventWriter 
 		RepoNamer:    streamclient.RepoNamer(ctx, h.db),
 	}
 
-	var wgLogLatency sync.WaitGroup
-	defer wgLogLatency.Wait()
 	logLatency := func() {
-		wgLogLatency.Add(1)
-		go func() {
-			defer wgLogLatency.Done()
-			metricLatency.WithLabelValues(string(GuessSource(r))).
-				Observe(time.Since(start).Seconds())
-
-			graphqlbackend.LogSearchLatency(ctx, h.db, inputs, int32(time.Since(start).Milliseconds()))
-		}()
+		metricLatency.WithLabelValues(string(GuessSource(r))).
+			Observe(time.Since(start).Seconds())
 	}
 
 	// HACK: We awkwardly call an inline function here so that we can defer the

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -54,7 +54,9 @@ func NewPlanJob(inputs *search.Inputs, plan query.Plan) (job.Job, error) {
 		}
 	}
 
-	return NewAlertJob(inputs, jobTree), nil
+	job := NewAlertJob(inputs, jobTree)
+	job = NewLogJob(inputs, job)
+	return job, nil
 }
 
 // NewBasicJob converts a query.Basic into its job tree representation.

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -52,665 +52,689 @@ func TestNewPlanJob(t *testing.T) {
 		protocol:   search.Streaming,
 		searchType: query.SearchTypeLiteral,
 		want: autogold.Want("user search context", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . literal)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (SEQUENTIAL
-          (ensureUnique . false)
-          (REPOPAGER
-            (repoOpts.searchContextSpec . @userA)
-            (PARTIALREPOS
-              (ZOEKTREPOSUBSETTEXTSEARCH
-                (query . substr:"foo")
-                (type . text))))
-          (REPOPAGER
-            (repoOpts.searchContextSpec . @userA)
-            (PARTIALREPOS
-              (SEARCHERTEXTSEARCH
-                (indexed . false))))
-          (REPOSEARCH
-            (repoOpts.repoFilters.0 . foo)(repoOpts.searchContextSpec . @userA)
-            (repoNamePatterns . [(?i)foo])))
-        (REPOSCOMPUTEEXCLUDED
-          (repoOpts.searchContextSpec . @userA))
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . literal)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
         (PARALLEL
-          NoopJob
-          NoopJob)))))`),
+          (SEQUENTIAL
+            (ensureUnique . false)
+            (REPOPAGER
+              (repoOpts.searchContextSpec . @userA)
+              (PARTIALREPOS
+                (ZOEKTREPOSUBSETTEXTSEARCH
+                  (query . substr:"foo")
+                  (type . text))))
+            (REPOPAGER
+              (repoOpts.searchContextSpec . @userA)
+              (PARTIALREPOS
+                (SEARCHERTEXTSEARCH
+                  (indexed . false))))
+            (REPOSEARCH
+              (repoOpts.repoFilters.0 . foo)(repoOpts.searchContextSpec . @userA)
+              (repoNamePatterns . [(?i)foo])))
+          (REPOSCOMPUTEEXCLUDED
+            (repoOpts.searchContextSpec . @userA))
+          (PARALLEL
+            NoopJob
+            NoopJob))))))`),
 	}, {
 		query:      `foo context:global`,
 		protocol:   search.Streaming,
 		searchType: query.SearchTypeLiteral,
 		want: autogold.Want("global search explicit context", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . literal)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (SEQUENTIAL
-          (ensureUnique . false)
-          (ZOEKTGLOBALTEXTSEARCH
-            (query . substr:"foo")
-            (type . text)
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . literal)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
+        (PARALLEL
+          (SEQUENTIAL
+            (ensureUnique . false)
+            (ZOEKTGLOBALTEXTSEARCH
+              (query . substr:"foo")
+              (type . text)
+              (repoOpts.searchContextSpec . global))
+            (REPOSEARCH
+              (repoOpts.repoFilters.0 . foo)(repoOpts.searchContextSpec . global)
+              (repoNamePatterns . [(?i)foo])))
+          (REPOSCOMPUTEEXCLUDED
             (repoOpts.searchContextSpec . global))
-          (REPOSEARCH
-            (repoOpts.repoFilters.0 . foo)(repoOpts.searchContextSpec . global)
-            (repoNamePatterns . [(?i)foo])))
-        (REPOSCOMPUTEEXCLUDED
-          (repoOpts.searchContextSpec . global))
-        NoopJob))))`),
+          NoopJob)))))`),
 	}, {
 		query:      `foo`,
 		protocol:   search.Streaming,
 		searchType: query.SearchTypeLiteral,
 		want: autogold.Want("global search implicit context", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . literal)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (SEQUENTIAL
-          (ensureUnique . false)
-          (ZOEKTGLOBALTEXTSEARCH
-            (query . substr:"foo")
-            (type . text)
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . literal)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
+        (PARALLEL
+          (SEQUENTIAL
+            (ensureUnique . false)
+            (ZOEKTGLOBALTEXTSEARCH
+              (query . substr:"foo")
+              (type . text)
+              )
+            (REPOSEARCH
+              (repoOpts.repoFilters.0 . foo)
+              (repoNamePatterns . [(?i)foo])))
+          (REPOSCOMPUTEEXCLUDED
             )
-          (REPOSEARCH
-            (repoOpts.repoFilters.0 . foo)
-            (repoNamePatterns . [(?i)foo])))
-        (REPOSCOMPUTEEXCLUDED
-          )
-        NoopJob))))`),
+          NoopJob)))))`),
 	}, {
 		query:      `foo repo:sourcegraph/sourcegraph`,
 		protocol:   search.Streaming,
 		searchType: query.SearchTypeLiteral,
 		want: autogold.Want("nonglobal repo", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . literal)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (SEQUENTIAL
-          (ensureUnique . false)
-          (REPOPAGER
-            (repoOpts.repoFilters.0 . sourcegraph/sourcegraph)
-            (PARTIALREPOS
-              (ZOEKTREPOSUBSETTEXTSEARCH
-                (query . substr:"foo")
-                (type . text))))
-          (REPOPAGER
-            (repoOpts.repoFilters.0 . sourcegraph/sourcegraph)
-            (PARTIALREPOS
-              (SEARCHERTEXTSEARCH
-                (indexed . false))))
-          (REPOSEARCH
-            (repoOpts.repoFilters.0 . sourcegraph/sourcegraph)(repoOpts.repoFilters.1 . foo)
-            (repoNamePatterns . [(?i)sourcegraph/sourcegraph (?i)foo])))
-        (REPOSCOMPUTEEXCLUDED
-          (repoOpts.repoFilters.0 . sourcegraph/sourcegraph))
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . literal)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
         (PARALLEL
-          NoopJob
-          NoopJob)))))`),
+          (SEQUENTIAL
+            (ensureUnique . false)
+            (REPOPAGER
+              (repoOpts.repoFilters.0 . sourcegraph/sourcegraph)
+              (PARTIALREPOS
+                (ZOEKTREPOSUBSETTEXTSEARCH
+                  (query . substr:"foo")
+                  (type . text))))
+            (REPOPAGER
+              (repoOpts.repoFilters.0 . sourcegraph/sourcegraph)
+              (PARTIALREPOS
+                (SEARCHERTEXTSEARCH
+                  (indexed . false))))
+            (REPOSEARCH
+              (repoOpts.repoFilters.0 . sourcegraph/sourcegraph)(repoOpts.repoFilters.1 . foo)
+              (repoNamePatterns . [(?i)sourcegraph/sourcegraph (?i)foo])))
+          (REPOSCOMPUTEEXCLUDED
+            (repoOpts.repoFilters.0 . sourcegraph/sourcegraph))
+          (PARALLEL
+            NoopJob
+            NoopJob))))))`),
 	}, {
 		query:      `ok ok`,
 		protocol:   search.Streaming,
 		searchType: query.SearchTypeRegex,
 		want: autogold.Want("supported repo job", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . regex)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (SEQUENTIAL
-          (ensureUnique . false)
-          (ZOEKTGLOBALTEXTSEARCH
-            (query . regex:"ok(?-s:.)*?ok")
-            (type . text)
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . regex)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
+        (PARALLEL
+          (SEQUENTIAL
+            (ensureUnique . false)
+            (ZOEKTGLOBALTEXTSEARCH
+              (query . regex:"ok(?-s:.)*?ok")
+              (type . text)
+              )
+            (REPOSEARCH
+              (repoOpts.repoFilters.0 . (?:ok).*?(?:ok))
+              (repoNamePatterns . [(?i)(?:ok).*?(?:ok)])))
+          (REPOSCOMPUTEEXCLUDED
             )
-          (REPOSEARCH
-            (repoOpts.repoFilters.0 . (?:ok).*?(?:ok))
-            (repoNamePatterns . [(?i)(?:ok).*?(?:ok)])))
-        (REPOSCOMPUTEEXCLUDED
-          )
-        NoopJob))))`),
+          NoopJob)))))`),
 	}, {
 		query:      `ok @thing`,
 		protocol:   search.Streaming,
 		searchType: query.SearchTypeLiteral,
 		want: autogold.Want("supported repo job literal", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . literal)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (SEQUENTIAL
-          (ensureUnique . false)
-          (ZOEKTGLOBALTEXTSEARCH
-            (query . substr:"ok @thing")
-            (type . text)
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . literal)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
+        (PARALLEL
+          (SEQUENTIAL
+            (ensureUnique . false)
+            (ZOEKTGLOBALTEXTSEARCH
+              (query . substr:"ok @thing")
+              (type . text)
+              )
+            (REPOSEARCH
+              (repoOpts.repoFilters.0 . ok )
+              (repoNamePatterns . [(?i)ok ])))
+          (REPOSCOMPUTEEXCLUDED
             )
-          (REPOSEARCH
-            (repoOpts.repoFilters.0 . ok )
-            (repoNamePatterns . [(?i)ok ])))
-        (REPOSCOMPUTEEXCLUDED
-          )
-        NoopJob))))`),
+          NoopJob)))))`),
 	}, {
 		query:      `@nope`,
 		protocol:   search.Streaming,
 		searchType: query.SearchTypeRegex,
 		want: autogold.Want("unsupported repo job literal", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . regex)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (ZOEKTGLOBALTEXTSEARCH
-          (query . substr:"@nope")
-          (type . text)
-          )
-        (REPOSCOMPUTEEXCLUDED
-          )
-        NoopJob))))`),
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . regex)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
+        (PARALLEL
+          (ZOEKTGLOBALTEXTSEARCH
+            (query . substr:"@nope")
+            (type . text)
+            )
+          (REPOSCOMPUTEEXCLUDED
+            )
+          NoopJob)))))`),
 	}, {
 		query:      `foo @bar`,
 		protocol:   search.Streaming,
 		searchType: query.SearchTypeRegex,
 		want: autogold.Want("unsupported repo job regexp", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . regex)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (ZOEKTGLOBALTEXTSEARCH
-          (query . regex:"foo(?-s:.)*?@bar")
-          (type . text)
-          )
-        (REPOSCOMPUTEEXCLUDED
-          )
-        NoopJob))))`),
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . regex)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
+        (PARALLEL
+          (ZOEKTGLOBALTEXTSEARCH
+            (query . regex:"foo(?-s:.)*?@bar")
+            (type . text)
+            )
+          (REPOSCOMPUTEEXCLUDED
+            )
+          NoopJob)))))`),
 	}, {
 		query:      `type:symbol test`,
 		protocol:   search.Streaming,
 		searchType: query.SearchTypeRegex,
 		want: autogold.Want("symbol", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . regex)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (ZOEKTGLOBALSYMBOLSEARCH
-          (query . sym:substr:"test")
-          (type . symbol)
-          )
-        (REPOSCOMPUTEEXCLUDED
-          )
-        NoopJob))))`),
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . regex)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
+        (PARALLEL
+          (ZOEKTGLOBALSYMBOLSEARCH
+            (query . sym:substr:"test")
+            (type . symbol)
+            )
+          (REPOSCOMPUTEEXCLUDED
+            )
+          NoopJob)))))`),
 	}, {
 		query:      `type:commit test`,
 		protocol:   search.Streaming,
 		searchType: query.SearchTypeRegex,
 		want: autogold.Want("commit", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . regex)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (COMMITSEARCH
-          (query . *protocol.MessageMatches(test))
-          (repoOpts.onlyCloned . true)
-          (diff . false)
-          (limit . 500))
-        (REPOSCOMPUTEEXCLUDED
-          )
-        NoopJob))))`),
-	}, {
-		query:      `type:diff test`,
-		protocol:   search.Streaming,
-		searchType: query.SearchTypeRegex,
-		want: autogold.Want("diff", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . regex)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (DIFFSEARCH
-          (query . *protocol.DiffMatches(test))
-          (repoOpts.onlyCloned . true)
-          (diff . true)
-          (limit . 500))
-        (REPOSCOMPUTEEXCLUDED
-          )
-        NoopJob))))`),
-	}, {
-		query:      `type:file type:commit test`,
-		protocol:   search.Streaming,
-		searchType: query.SearchTypeRegex,
-		want: autogold.Want("streaming file or commit", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . regex)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (ZOEKTGLOBALTEXTSEARCH
-          (query . content_substr:"test")
-          (type . text)
-          )
-        (COMMITSEARCH
-          (query . *protocol.MessageMatches(test))
-          (repoOpts.onlyCloned . true)
-          (diff . false)
-          (limit . 500))
-        (REPOSCOMPUTEEXCLUDED
-          )
-        NoopJob))))`),
-	}, {
-		query:      `type:file type:path type:repo type:commit type:symbol repo:test test`,
-		protocol:   search.Streaming,
-		searchType: query.SearchTypeRegex,
-		want: autogold.Want("streaming many types", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . regex)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (SEQUENTIAL
-          (ensureUnique . false)
-          (REPOPAGER
-            (repoOpts.repoFilters.0 . test)
-            (PARTIALREPOS
-              (ZOEKTREPOSUBSETTEXTSEARCH
-                (query . substr:"test")
-                (type . text))))
-          (REPOPAGER
-            (repoOpts.repoFilters.0 . test)
-            (PARTIALREPOS
-              (SEARCHERTEXTSEARCH
-                (indexed . false))))
-          (REPOSEARCH
-            (repoOpts.repoFilters.0 . test)(repoOpts.repoFilters.1 . test)
-            (repoNamePatterns . [(?i)test (?i)test])))
-        (REPOPAGER
-          (repoOpts.repoFilters.0 . test)
-          (PARTIALREPOS
-            (ZOEKTSYMBOLSEARCH
-              (query . sym:substr:"test"))))
-        (COMMITSEARCH
-          (query . *protocol.MessageMatches(test))
-          (repoOpts.repoFilters.0 . test)(repoOpts.onlyCloned . true)
-          (diff . false)
-          (limit . 500))
-        (REPOSCOMPUTEEXCLUDED
-          (repoOpts.repoFilters.0 . test))
-        (PARALLEL
-          NoopJob
-          (REPOPAGER
-            (repoOpts.repoFilters.0 . test)
-            (PARTIALREPOS
-              (SEARCHERSYMBOLSEARCH
-                (patternInfo.pattern . test)(patternInfo.isRegexp . true)(patternInfo.fileMatchLimit . 500)(patternInfo.patternMatchesPath . true)
-                (numRepos . 0)
-                (limit . 500))))
-          NoopJob)))))`),
-	}, {
-		query:      `type:file type:commit test`,
-		protocol:   search.Streaming,
-		searchType: query.SearchTypeRegex,
-		want: autogold.Want("batched file or commit", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . regex)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (ZOEKTGLOBALTEXTSEARCH
-          (query . content_substr:"test")
-          (type . text)
-          )
-        (COMMITSEARCH
-          (query . *protocol.MessageMatches(test))
-          (repoOpts.onlyCloned . true)
-          (diff . false)
-          (limit . 500))
-        (REPOSCOMPUTEEXCLUDED
-          )
-        NoopJob))))`),
-	}, {
-		query:      `type:file type:path type:repo type:commit type:symbol repo:test test`,
-		protocol:   search.Streaming,
-		searchType: query.SearchTypeRegex,
-		want: autogold.Want("batched many types", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . regex)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (SEQUENTIAL
-          (ensureUnique . false)
-          (REPOPAGER
-            (repoOpts.repoFilters.0 . test)
-            (PARTIALREPOS
-              (ZOEKTREPOSUBSETTEXTSEARCH
-                (query . substr:"test")
-                (type . text))))
-          (REPOPAGER
-            (repoOpts.repoFilters.0 . test)
-            (PARTIALREPOS
-              (SEARCHERTEXTSEARCH
-                (indexed . false))))
-          (REPOSEARCH
-            (repoOpts.repoFilters.0 . test)(repoOpts.repoFilters.1 . test)
-            (repoNamePatterns . [(?i)test (?i)test])))
-        (REPOPAGER
-          (repoOpts.repoFilters.0 . test)
-          (PARTIALREPOS
-            (ZOEKTSYMBOLSEARCH
-              (query . sym:substr:"test"))))
-        (COMMITSEARCH
-          (query . *protocol.MessageMatches(test))
-          (repoOpts.repoFilters.0 . test)(repoOpts.onlyCloned . true)
-          (diff . false)
-          (limit . 500))
-        (REPOSCOMPUTEEXCLUDED
-          (repoOpts.repoFilters.0 . test))
-        (PARALLEL
-          NoopJob
-          (REPOPAGER
-            (repoOpts.repoFilters.0 . test)
-            (PARTIALREPOS
-              (SEARCHERSYMBOLSEARCH
-                (patternInfo.pattern . test)(patternInfo.isRegexp . true)(patternInfo.fileMatchLimit . 500)(patternInfo.patternMatchesPath . true)
-                (numRepos . 0)
-                (limit . 500))))
-          NoopJob)))))`),
-	}, {
-		query:      `(type:commit or type:diff) (a or b)`,
-		protocol:   search.Streaming,
-		searchType: query.SearchTypeRegex,
-		// TODO this output doesn't look right. There shouldn't be any zoekt or repo jobs
-		want: autogold.Want("complex commit diff", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . regex)
-  (OR
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . regex)
     (TIMEOUT
       (timeout . 20s)
       (LIMIT
         (limit . 500)
         (PARALLEL
           (COMMITSEARCH
-            (query . (*protocol.MessageMatches((?:a)|(?:b))))
+            (query . *protocol.MessageMatches(test))
             (repoOpts.onlyCloned . true)
             (diff . false)
             (limit . 500))
           (REPOSCOMPUTEEXCLUDED
             )
-          (OR
-            NoopJob
-            NoopJob))))
+          NoopJob)))))`),
+	}, {
+		query:      `type:diff test`,
+		protocol:   search.Streaming,
+		searchType: query.SearchTypeRegex,
+		want: autogold.Want("diff", `
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . regex)
     (TIMEOUT
       (timeout . 20s)
       (LIMIT
         (limit . 500)
         (PARALLEL
           (DIFFSEARCH
-            (query . (*protocol.DiffMatches((?:a)|(?:b))))
+            (query . *protocol.DiffMatches(test))
             (repoOpts.onlyCloned . true)
             (diff . true)
             (limit . 500))
           (REPOSCOMPUTEEXCLUDED
             )
-          (OR
-            NoopJob
-            NoopJob))))))`),
+          NoopJob)))))`),
 	}, {
-		query:      `(type:repo a) or (type:file b)`,
+		query:      `type:file type:commit test`,
 		protocol:   search.Streaming,
 		searchType: query.SearchTypeRegex,
-		want: autogold.Want("disjunct types", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . regex)
-  (OR
-    (TIMEOUT
-      (timeout . 20s)
-      (LIMIT
-        (limit . 500)
-        (PARALLEL
-          (REPOSCOMPUTEEXCLUDED
-            )
-          (REPOSEARCH
-            (repoOpts.repoFilters.0 . a)
-            (repoNamePatterns . [(?i)a])))))
+		want: autogold.Want("streaming file or commit", `
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . regex)
     (TIMEOUT
       (timeout . 20s)
       (LIMIT
         (limit . 500)
         (PARALLEL
           (ZOEKTGLOBALTEXTSEARCH
-            (query . content_substr:"b")
+            (query . content_substr:"test")
             (type . text)
             )
+          (COMMITSEARCH
+            (query . *protocol.MessageMatches(test))
+            (repoOpts.onlyCloned . true)
+            (diff . false)
+            (limit . 500))
           (REPOSCOMPUTEEXCLUDED
             )
           NoopJob)))))`),
+	}, {
+		query:      `type:file type:path type:repo type:commit type:symbol repo:test test`,
+		protocol:   search.Streaming,
+		searchType: query.SearchTypeRegex,
+		want: autogold.Want("streaming many types", `
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . regex)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
+        (PARALLEL
+          (SEQUENTIAL
+            (ensureUnique . false)
+            (REPOPAGER
+              (repoOpts.repoFilters.0 . test)
+              (PARTIALREPOS
+                (ZOEKTREPOSUBSETTEXTSEARCH
+                  (query . substr:"test")
+                  (type . text))))
+            (REPOPAGER
+              (repoOpts.repoFilters.0 . test)
+              (PARTIALREPOS
+                (SEARCHERTEXTSEARCH
+                  (indexed . false))))
+            (REPOSEARCH
+              (repoOpts.repoFilters.0 . test)(repoOpts.repoFilters.1 . test)
+              (repoNamePatterns . [(?i)test (?i)test])))
+          (REPOPAGER
+            (repoOpts.repoFilters.0 . test)
+            (PARTIALREPOS
+              (ZOEKTSYMBOLSEARCH
+                (query . sym:substr:"test"))))
+          (COMMITSEARCH
+            (query . *protocol.MessageMatches(test))
+            (repoOpts.repoFilters.0 . test)(repoOpts.onlyCloned . true)
+            (diff . false)
+            (limit . 500))
+          (REPOSCOMPUTEEXCLUDED
+            (repoOpts.repoFilters.0 . test))
+          (PARALLEL
+            NoopJob
+            (REPOPAGER
+              (repoOpts.repoFilters.0 . test)
+              (PARTIALREPOS
+                (SEARCHERSYMBOLSEARCH
+                  (patternInfo.pattern . test)(patternInfo.isRegexp . true)(patternInfo.fileMatchLimit . 500)(patternInfo.patternMatchesPath . true)
+                  (numRepos . 0)
+                  (limit . 500))))
+            NoopJob))))))`),
+	}, {
+		query:      `type:file type:commit test`,
+		protocol:   search.Streaming,
+		searchType: query.SearchTypeRegex,
+		want: autogold.Want("batched file or commit", `
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . regex)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
+        (PARALLEL
+          (ZOEKTGLOBALTEXTSEARCH
+            (query . content_substr:"test")
+            (type . text)
+            )
+          (COMMITSEARCH
+            (query . *protocol.MessageMatches(test))
+            (repoOpts.onlyCloned . true)
+            (diff . false)
+            (limit . 500))
+          (REPOSCOMPUTEEXCLUDED
+            )
+          NoopJob)))))`),
+	}, {
+		query:      `type:file type:path type:repo type:commit type:symbol repo:test test`,
+		protocol:   search.Streaming,
+		searchType: query.SearchTypeRegex,
+		want: autogold.Want("batched many types", `
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . regex)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
+        (PARALLEL
+          (SEQUENTIAL
+            (ensureUnique . false)
+            (REPOPAGER
+              (repoOpts.repoFilters.0 . test)
+              (PARTIALREPOS
+                (ZOEKTREPOSUBSETTEXTSEARCH
+                  (query . substr:"test")
+                  (type . text))))
+            (REPOPAGER
+              (repoOpts.repoFilters.0 . test)
+              (PARTIALREPOS
+                (SEARCHERTEXTSEARCH
+                  (indexed . false))))
+            (REPOSEARCH
+              (repoOpts.repoFilters.0 . test)(repoOpts.repoFilters.1 . test)
+              (repoNamePatterns . [(?i)test (?i)test])))
+          (REPOPAGER
+            (repoOpts.repoFilters.0 . test)
+            (PARTIALREPOS
+              (ZOEKTSYMBOLSEARCH
+                (query . sym:substr:"test"))))
+          (COMMITSEARCH
+            (query . *protocol.MessageMatches(test))
+            (repoOpts.repoFilters.0 . test)(repoOpts.onlyCloned . true)
+            (diff . false)
+            (limit . 500))
+          (REPOSCOMPUTEEXCLUDED
+            (repoOpts.repoFilters.0 . test))
+          (PARALLEL
+            NoopJob
+            (REPOPAGER
+              (repoOpts.repoFilters.0 . test)
+              (PARTIALREPOS
+                (SEARCHERSYMBOLSEARCH
+                  (patternInfo.pattern . test)(patternInfo.isRegexp . true)(patternInfo.fileMatchLimit . 500)(patternInfo.patternMatchesPath . true)
+                  (numRepos . 0)
+                  (limit . 500))))
+            NoopJob))))))`),
+	}, {
+		query:      `(type:commit or type:diff) (a or b)`,
+		protocol:   search.Streaming,
+		searchType: query.SearchTypeRegex,
+		// TODO this output doesn't look right. There shouldn't be any zoekt or repo jobs
+		want: autogold.Want("complex commit diff", `
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . regex)
+    (OR
+      (TIMEOUT
+        (timeout . 20s)
+        (LIMIT
+          (limit . 500)
+          (PARALLEL
+            (COMMITSEARCH
+              (query . (*protocol.MessageMatches((?:a)|(?:b))))
+              (repoOpts.onlyCloned . true)
+              (diff . false)
+              (limit . 500))
+            (REPOSCOMPUTEEXCLUDED
+              )
+            (OR
+              NoopJob
+              NoopJob))))
+      (TIMEOUT
+        (timeout . 20s)
+        (LIMIT
+          (limit . 500)
+          (PARALLEL
+            (DIFFSEARCH
+              (query . (*protocol.DiffMatches((?:a)|(?:b))))
+              (repoOpts.onlyCloned . true)
+              (diff . true)
+              (limit . 500))
+            (REPOSCOMPUTEEXCLUDED
+              )
+            (OR
+              NoopJob
+              NoopJob)))))))`),
+	}, {
+		query:      `(type:repo a) or (type:file b)`,
+		protocol:   search.Streaming,
+		searchType: query.SearchTypeRegex,
+		want: autogold.Want("disjunct types", `
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . regex)
+    (OR
+      (TIMEOUT
+        (timeout . 20s)
+        (LIMIT
+          (limit . 500)
+          (PARALLEL
+            (REPOSCOMPUTEEXCLUDED
+              )
+            (REPOSEARCH
+              (repoOpts.repoFilters.0 . a)
+              (repoNamePatterns . [(?i)a])))))
+      (TIMEOUT
+        (timeout . 20s)
+        (LIMIT
+          (limit . 500)
+          (PARALLEL
+            (ZOEKTGLOBALTEXTSEARCH
+              (query . content_substr:"b")
+              (type . text)
+              )
+            (REPOSCOMPUTEEXCLUDED
+              )
+            NoopJob))))))`),
 	}, {
 		query:      `type:symbol a or b`,
 		protocol:   search.Streaming,
 		searchType: query.SearchTypeRegex,
 		want: autogold.Want("symbol with or", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . regex)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (ZOEKTGLOBALSYMBOLSEARCH
-          (query . (or sym:substr:"a" sym:substr:"b"))
-          (type . symbol)
-          )
-        (REPOSCOMPUTEEXCLUDED
-          )
-        (OR
-          NoopJob
-          NoopJob)))))`),
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . regex)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
+        (PARALLEL
+          (ZOEKTGLOBALSYMBOLSEARCH
+            (query . (or sym:substr:"a" sym:substr:"b"))
+            (type . symbol)
+            )
+          (REPOSCOMPUTEEXCLUDED
+            )
+          (OR
+            NoopJob
+            NoopJob))))))`),
 	},
 		{
 			query:      `repo:contains.path(a) repo:contains.content(b)`,
 			protocol:   search.Streaming,
 			searchType: query.SearchTypeRegex,
 			want: autogold.Want("repo contains path and repo contains content", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . regex)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (REPOSCOMPUTEEXCLUDED
-          (repoOpts.hasFileContent[0].path . a)(repoOpts.hasFileContent[1].content . b))
-        (REPOSEARCH
-          (repoOpts.hasFileContent[0].path . a)(repoOpts.hasFileContent[1].content . b)
-          (repoNamePatterns . []))))))`),
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . regex)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
+        (PARALLEL
+          (REPOSCOMPUTEEXCLUDED
+            (repoOpts.hasFileContent[0].path . a)(repoOpts.hasFileContent[1].content . b))
+          (REPOSEARCH
+            (repoOpts.hasFileContent[0].path . a)(repoOpts.hasFileContent[1].content . b)
+            (repoNamePatterns . [])))))))`),
 		}, {
 			query:      `repo:contains.file(path:a content:b)`,
 			protocol:   search.Streaming,
 			searchType: query.SearchTypeRegex,
 			want: autogold.Want("repo contains path and content", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . regex)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (REPOSCOMPUTEEXCLUDED
-          (repoOpts.hasFileContent[0].path . a)(repoOpts.hasFileContent[0].content . b))
-        (REPOSEARCH
-          (repoOpts.hasFileContent[0].path . a)(repoOpts.hasFileContent[0].content . b)
-          (repoNamePatterns . []))))))`),
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . regex)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
+        (PARALLEL
+          (REPOSCOMPUTEEXCLUDED
+            (repoOpts.hasFileContent[0].path . a)(repoOpts.hasFileContent[0].content . b))
+          (REPOSEARCH
+            (repoOpts.hasFileContent[0].path . a)(repoOpts.hasFileContent[0].content . b)
+            (repoNamePatterns . [])))))))`),
 		}, {
 			query:      `repo:has(key:value)`,
 			protocol:   search.Streaming,
 			searchType: query.SearchTypeRegex,
 			want: autogold.Want("repo has kvp", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . regex)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (REPOSCOMPUTEEXCLUDED
-          (repoOpts.hasKVPs[0].key . key)(repoOpts.hasKVPs[0].value . value))
-        (REPOSEARCH
-          (repoOpts.hasKVPs[0].key . key)(repoOpts.hasKVPs[0].value . value)
-          (repoNamePatterns . []))))))`),
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . regex)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
+        (PARALLEL
+          (REPOSCOMPUTEEXCLUDED
+            (repoOpts.hasKVPs[0].key . key)(repoOpts.hasKVPs[0].value . value))
+          (REPOSEARCH
+            (repoOpts.hasKVPs[0].key . key)(repoOpts.hasKVPs[0].value . value)
+            (repoNamePatterns . [])))))))`),
 		}, {
 			query:      `repo:has.tag(tag)`,
 			protocol:   search.Streaming,
 			searchType: query.SearchTypeRegex,
 			want: autogold.Want("repo has tag", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . regex)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (REPOSCOMPUTEEXCLUDED
-          (repoOpts.hasKVPs[0].key . tag))
-        (REPOSEARCH
-          (repoOpts.hasKVPs[0].key . tag)
-          (repoNamePatterns . []))))))`),
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . regex)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
+        (PARALLEL
+          (REPOSCOMPUTEEXCLUDED
+            (repoOpts.hasKVPs[0].key . tag))
+          (REPOSEARCH
+            (repoOpts.hasKVPs[0].key . tag)
+            (repoNamePatterns . [])))))))`),
 		}, {
 			query:      `repo:has.tag(tag) foo`,
 			protocol:   search.Streaming,
 			searchType: query.SearchTypeRegex,
 			want: autogold.Want("repo has tag and foo", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . regex)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (SEQUENTIAL
-          (ensureUnique . false)
-          (REPOPAGER
-            (repoOpts.hasKVPs[0].key . tag)
-            (PARTIALREPOS
-              (ZOEKTREPOSUBSETTEXTSEARCH
-                (query . substr:"foo")
-                (type . text))))
-          (REPOPAGER
-            (repoOpts.hasKVPs[0].key . tag)
-            (PARTIALREPOS
-              (SEARCHERTEXTSEARCH
-                (indexed . false))))
-          (REPOSEARCH
-            (repoOpts.repoFilters.0 . foo)(repoOpts.hasKVPs[0].key . tag)
-            (repoNamePatterns . [(?i)foo])))
-        (REPOSCOMPUTEEXCLUDED
-          (repoOpts.hasKVPs[0].key . tag))
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . regex)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
         (PARALLEL
-          NoopJob
-          NoopJob)))))`),
+          (SEQUENTIAL
+            (ensureUnique . false)
+            (REPOPAGER
+              (repoOpts.hasKVPs[0].key . tag)
+              (PARTIALREPOS
+                (ZOEKTREPOSUBSETTEXTSEARCH
+                  (query . substr:"foo")
+                  (type . text))))
+            (REPOPAGER
+              (repoOpts.hasKVPs[0].key . tag)
+              (PARTIALREPOS
+                (SEARCHERTEXTSEARCH
+                  (indexed . false))))
+            (REPOSEARCH
+              (repoOpts.repoFilters.0 . foo)(repoOpts.hasKVPs[0].key . tag)
+              (repoNamePatterns . [(?i)foo])))
+          (REPOSCOMPUTEEXCLUDED
+            (repoOpts.hasKVPs[0].key . tag))
+          (PARALLEL
+            NoopJob
+            NoopJob))))))`),
 		}, {
 			query:      `(...)`,
 			protocol:   search.Streaming,
 			searchType: query.SearchTypeStructural,
 			want: autogold.Want("stream structural search", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . structural)
-  (TIMEOUT
-    (timeout . 20s)
-    (LIMIT
-      (limit . 500)
-      (PARALLEL
-        (REPOSCOMPUTEEXCLUDED
-          )
-        (STRUCTURALSEARCH
-          (patternInfo.pattern . (:[_]))(patternInfo.isStructural . true)(patternInfo.fileMatchLimit . 500)
-          )))))`),
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . structural)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
+        (PARALLEL
+          (REPOSCOMPUTEEXCLUDED
+            )
+          (STRUCTURALSEARCH
+            (patternInfo.pattern . (:[_]))(patternInfo.isStructural . true)(patternInfo.fileMatchLimit . 500)
+            ))))))`),
 		},
 	}
 

--- a/internal/search/job/jobutil/log_job.go
+++ b/internal/search/job/jobutil/log_job.go
@@ -1,0 +1,44 @@
+package jobutil
+
+import (
+	"context"
+
+	"github.com/opentracing/opentracing-go/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/job"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+)
+
+func NewLogJob(child job.Job) job.Job {
+	return &LogJob{
+		child: child,
+	}
+}
+
+type LogJob struct {
+	child job.Job
+}
+
+func (l *LogJob) Run(ctx context.Context, clients job.RuntimeClients, s streaming.Sender) (alert *search.Alert, err error) {
+	_, ctx, s, finish := job.StartSpan(ctx, s, l)
+	defer func() { finish(alert, err) }()
+
+	return l.child.Run(ctx, clients, s)
+}
+
+func (l *LogJob) Name() string {
+	return "LogJob"
+}
+
+func (l *LogJob) Fields(v job.Verbosity) (res []log.Field) { return nil }
+
+func (l *LogJob) Children() []job.Describer {
+	return []job.Describer{l.child}
+}
+
+func (l *LogJob) MapChildren(fn job.MapFunc) job.Job {
+	cp := *l
+	cp.child = job.Map(l.child, fn)
+	return &cp
+}

--- a/internal/search/job/jobutil/log_job.go
+++ b/internal/search/job/jobutil/log_job.go
@@ -4,17 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"time"
 
 	otlog "github.com/opentracing/opentracing-go/log"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/deviceid"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -25,8 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/usagestats"
 )
 
-// NewLogJob wraps a job with a LogJob, which records stats about the duration
-// of the search, logs slow searches, and records an event in the EventLogs table.
+// NewLogJob wraps a job with a LogJob, which records an event in the EventLogs table.
 func NewLogJob(inputs *search.Inputs, child job.Job) job.Job {
 	return &LogJob{
 		child:  child,

--- a/internal/search/job/jobutil/log_job.go
+++ b/internal/search/job/jobutil/log_job.go
@@ -2,12 +2,30 @@ package jobutil
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"sync"
+	"time"
 
-	"github.com/opentracing/opentracing-go/log"
+	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/deviceid"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	"github.com/sourcegraph/sourcegraph/internal/honey"
+	searchhoney "github.com/sourcegraph/sourcegraph/internal/honey/search"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
+	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/usagestats"
 )
 
 func NewLogJob(child job.Job) job.Job {
@@ -17,21 +35,32 @@ func NewLogJob(child job.Job) job.Job {
 }
 
 type LogJob struct {
-	child job.Job
+	child  job.Job
+	inputs search.Inputs
 }
 
 func (l *LogJob) Run(ctx context.Context, clients job.RuntimeClients, s streaming.Sender) (alert *search.Alert, err error) {
 	_, ctx, s, finish := job.StartSpan(ctx, s, l)
 	defer func() { finish(alert, err) }()
 
-	return l.child.Run(ctx, clients, s)
+	start := time.Now()
+
+	statsStream := streaming.NewStatsObservingStream(s)
+	resultStream := streaming.NewResultCountingStream(statsStream)
+	alert, err = l.child.Run(ctx, clients, resultStream)
+
+	duration := time.Since(start)
+
+	l.logBatch(ctx, clients, l.inputs, statsStream.Stats, resultStream.Count(), duration, alert, err)
+
+	return alert, err
 }
 
 func (l *LogJob) Name() string {
 	return "LogJob"
 }
 
-func (l *LogJob) Fields(v job.Verbosity) (res []log.Field) { return nil }
+func (l *LogJob) Fields(v job.Verbosity) (res []otlog.Field) { return nil }
 
 func (l *LogJob) Children() []job.Describer {
 	return []job.Describer{l.child}
@@ -41,4 +70,202 @@ func (l *LogJob) MapChildren(fn job.MapFunc) job.Job {
 	cp := *l
 	cp.child = job.Map(l.child, fn)
 	return &cp
+}
+
+func (l *LogJob) logBatch(
+	ctx context.Context,
+	clients job.RuntimeClients,
+	inputs search.Inputs,
+	stats streaming.Stats,
+	resultCount int,
+	duration time.Duration,
+	alert *search.Alert,
+	err error,
+) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		l.logSearchLatency(ctx, clients, inputs, duration)
+	}()
+
+	var status, alertType string
+	status = DetermineStatusForLogs(alert, stats, err)
+	if alert != nil {
+		alertType = alert.PrometheusType
+	}
+	requestSource := string(trace.RequestSource(ctx))
+	requestName := trace.GraphQLRequestName(ctx)
+	logPrometheusBatch(status, alertType, requestSource, requestName, duration)
+
+	isSlow := duration > LogSlowSearchesThreshold()
+	if honey.Enabled() || isSlow {
+		ev := searchhoney.SearchEvent(ctx, searchhoney.SearchEventArgs{
+			OriginalQuery: inputs.OriginalQuery,
+			Typ:           requestName,
+			Source:        requestSource,
+			Status:        status,
+			AlertType:     alertType,
+			DurationMs:    duration.Milliseconds(),
+			ResultSize:    resultCount,
+			Error:         err,
+		})
+
+		_ = ev.Send()
+
+		if isSlow {
+			clients.Logger.Warn("slow search request",
+				log.String("query", inputs.OriginalQuery),
+				log.String("type", requestName),
+				log.String("source", requestSource),
+				log.String("status", status),
+				log.String("alertType", alertType),
+				log.Int64("durationMs", duration.Milliseconds()),
+				log.Int("resultSize", resultCount),
+				log.String("error", err.Error()),
+			)
+		}
+	}
+}
+
+// logSearchLatency records search durations in the event database. This
+// function may only be called after a search result is performed, because it
+// relies on the invariant that query and pattern error checking has already
+// been performed.
+func (l *LogJob) logSearchLatency(ctx context.Context, clients job.RuntimeClients, si search.Inputs, duration time.Duration) {
+	tr, ctx := trace.New(ctx, "LogSearchLatency", "")
+	defer tr.Finish()
+	var types []string
+	resultTypes, _ := si.Query.StringValues(query.FieldType)
+	for _, typ := range resultTypes {
+		switch typ {
+		case "repo", "symbol", "diff", "commit":
+			types = append(types, typ)
+		case "path":
+			// Map type:path to file
+			types = append(types, "file")
+		case "file":
+			switch {
+			case si.PatternType == query.SearchTypeStandard:
+				types = append(types, "standard")
+			case si.PatternType == query.SearchTypeStructural:
+				types = append(types, "structural")
+			case si.PatternType == query.SearchTypeLiteral:
+				types = append(types, "literal")
+			case si.PatternType == query.SearchTypeRegex:
+				types = append(types, "regexp")
+			case si.PatternType == query.SearchTypeLucky:
+				types = append(types, "lucky")
+			}
+		}
+	}
+
+	// Don't record composite searches that specify more than one type:
+	// because we can't break down the search timings into multiple
+	// categories.
+	if len(types) > 1 {
+		return
+	}
+
+	q, err := query.ToBasicQuery(si.Query)
+	if err != nil {
+		// Can't convert to a basic query, can't guarantee accurate reporting.
+		return
+	}
+	if !query.IsPatternAtom(q) {
+		// Not an atomic pattern, can't guarantee accurate reporting.
+		return
+	}
+
+	// If no type: was explicitly specified, infer the result type.
+	if len(types) == 0 {
+		// If a pattern was specified, a content search happened.
+		if q.IsLiteral() {
+			types = append(types, "literal")
+		} else if q.IsRegexp() {
+			types = append(types, "regexp")
+		} else if q.IsStructural() {
+			types = append(types, "structural")
+		} else if si.Query.Exists(query.FieldFile) {
+			// No search pattern specified and file: is specified.
+			types = append(types, "file")
+		} else {
+			// No search pattern or file: is specified, assume repo.
+			// This includes accounting for searches of fields that
+			// specify repohasfile: and repohascommitafter:.
+			types = append(types, "repo")
+		}
+	}
+
+	// Only log the time if we successfully resolved one search type.
+	if len(types) == 1 {
+		a := actor.FromContext(ctx)
+		if a.IsAuthenticated() && !a.IsMockUser() { // Do not log in tests
+			value := fmt.Sprintf(`{"durationMs": %d}`, duration.Milliseconds())
+			eventName := fmt.Sprintf("search.latencies.%s", types[0])
+			err := usagestats.LogBackendEvent(clients.DB, a.UID, deviceid.FromContext(ctx), eventName, json.RawMessage(value), json.RawMessage(value), featureflag.GetEvaluatedFlagSet(ctx), nil)
+			if err != nil {
+				clients.Logger.Warn("Could not log search latency", log.Error(err))
+			}
+		}
+	}
+}
+
+var (
+	searchResponseCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "src_graphql_search_response",
+		Help: "Number of searches that have ended in the given status (success, error, timeout, partial_timeout).",
+	}, []string{"status", "alert_type", "source", "request_name"})
+
+	searchLatencyHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "src_search_response_latency_seconds",
+		Help:    "Search response latencies in seconds that have ended in the given status (success, error, timeout, partial_timeout).",
+		Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 15, 20, 30},
+	}, []string{"status", "alert_type", "source", "request_name"})
+)
+
+func logPrometheusBatch(status, alertType, requestSource, requestName string, elapsed time.Duration) {
+	searchResponseCounter.WithLabelValues(
+		status,
+		alertType,
+		requestSource,
+		requestName,
+	).Inc()
+
+	searchLatencyHistogram.WithLabelValues(
+		status,
+		alertType,
+		requestSource,
+		requestName,
+	).Observe(elapsed.Seconds())
+}
+
+// DetermineStatusForLogs determines the final status of a search for logging
+// purposes.
+func DetermineStatusForLogs(alert *search.Alert, stats streaming.Stats, err error) string {
+	switch {
+	case err == context.DeadlineExceeded:
+		return "timeout"
+	case err != nil:
+		return "error"
+	case stats.Status.All(search.RepoStatusTimedout) && stats.Status.Len() == len(stats.Repos):
+		return "timeout"
+	case stats.Status.Any(search.RepoStatusTimedout):
+		return "partial_timeout"
+	case alert != nil:
+		return "alert"
+	default:
+		return "success"
+	}
+}
+
+// LogSlowSearchesThreshold returns the minimum duration configured in site
+// settings for logging slow searches.
+func LogSlowSearchesThreshold() time.Duration {
+	ms := conf.Get().ObservabilityLogSlowSearches
+	if ms == 0 {
+		return time.Duration(math.MaxInt64)
+	}
+	return time.Duration(ms) * time.Millisecond
 }

--- a/internal/search/job/jobutil/log_job.go
+++ b/internal/search/job/jobutil/log_job.go
@@ -28,15 +28,16 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/usagestats"
 )
 
-func NewLogJob(child job.Job) job.Job {
+func NewLogJob(inputs *search.Inputs, child job.Job) job.Job {
 	return &LogJob{
-		child: child,
+		child:  child,
+		inputs: inputs,
 	}
 }
 
 type LogJob struct {
 	child  job.Job
-	inputs search.Inputs
+	inputs *search.Inputs
 }
 
 func (l *LogJob) Run(ctx context.Context, clients job.RuntimeClients, s streaming.Sender) (alert *search.Alert, err error) {
@@ -75,7 +76,7 @@ func (l *LogJob) MapChildren(fn job.MapFunc) job.Job {
 func (l *LogJob) logBatch(
 	ctx context.Context,
 	clients job.RuntimeClients,
-	inputs search.Inputs,
+	inputs *search.Inputs,
 	stats streaming.Stats,
 	resultCount int,
 	duration time.Duration,
@@ -133,7 +134,7 @@ func (l *LogJob) logBatch(
 // function may only be called after a search result is performed, because it
 // relies on the invariant that query and pattern error checking has already
 // been performed.
-func (l *LogJob) logSearchDuration(ctx context.Context, clients job.RuntimeClients, si search.Inputs, duration time.Duration) {
+func (l *LogJob) logSearchDuration(ctx context.Context, clients job.RuntimeClients, si *search.Inputs, duration time.Duration) {
 	tr, ctx := trace.New(ctx, "LogSearchDuration", "")
 	defer tr.Finish()
 	var types []string


### PR DESCRIPTION
This mints a new search job type `LogJob` that has the responsibility of logging an event log at the end of a search. I plan to also move latency and duration metric collection into this job eventually too. 

The goal of this is to fix the problem that the `Stats` endpoint did not log an event for the calling user, so users were not being marked as active.

Fixes https://github.com/sourcegraph/sourcegraph/issues/45211

## Test plan

Manually tested that the Stats endpoint adds an event log.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
