### PR TITLE
Code Insight Fix code insight auth routing (simplify auth handling)

### DIFF
--- a/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react'
+import React, { useContext, useMemo, FC } from 'react'
 
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import { RouteComponentProps, Switch, Route, useRouteMatch } from 'react-router'
@@ -6,13 +6,15 @@ import { Redirect } from 'react-router-dom'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
-import { LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
+import { useObservable } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { withAuthenticatedUser } from '../../auth/withAuthenticatedUser'
 import { HeroPage } from '../../components/HeroPage'
 
 import { CodeInsightsBackendContext } from './core'
+import { useApi } from './hooks'
+import { useLicense } from './hooks/use-license'
 import { GaConfirmationModal } from './modals/GaConfirmationModal'
 import { CodeInsightsRootPage, CodeInsightsRootPageTab } from './pages/CodeInsightsRootPage'
 import { InsightsDashboardCreationPage } from './pages/dashboards/creation/InsightsDashboardCreationPage'
@@ -29,66 +31,51 @@ const NotFoundPage: React.FunctionComponent<React.PropsWithChildren<unknown>> = 
     <HeroPage icon={MapSearchIcon} title="404: Not Found" />
 )
 
-const CODE_INSIGHT_STANDALONE_PAGE = true
-
-/**
- * This interface has to receive union type props derived from all child components
- * Because we need to pass all required prop from main Sourcegraph.tsx component to
- * subcomponents withing app tree.
- */
 export interface CodeInsightsAppRouter extends TelemetryProps {
-    /**
-     * Authenticated user info, Used to decide where code insight will appear
-     * in personal dashboard (private) or in organisation dashboard (public)
-     */
     authenticatedUser: AuthenticatedUser
 }
 
-/**
- * Main Insight routing component. Main entry point to code insights UI.
- */
 export const CodeInsightsAppRouter = withAuthenticatedUser<CodeInsightsAppRouter>(props => {
-    const { telemetryService, authenticatedUser } = props
+    const { telemetryService } = props
     const match = useRouteMatch()
 
+    const fetched = useLicense()
+    const api = useApi()
+
+    if (!fetched) {
+        return null
+    }
+
     return (
-        <>
+        <CodeInsightsBackendContext.Provider value={api}>
             <Route path="*" component={GaConfirmationModal} />
 
             <Switch>
                 <Route path={`${match.url}/create`}>
-                    <CreationRoutes authenticatedUser={authenticatedUser} telemetryService={telemetryService} />
+                    <CreationRoutes telemetryService={telemetryService} />
                 </Route>
 
-                {CODE_INSIGHT_STANDALONE_PAGE && (
-                    <Route
-                        path={`${match.url}/insight/:id`}
-                        render={(props: RouteComponentProps<{ id: string }>) => (
-                            <CodeInsightIndependentPage
-                                insightId={props.match.params.id}
-                                telemetryService={telemetryService}
-                            />
-                        )}
-                    />
-                )}
+                <Route
+                    path={`${match.url}/insight/:id`}
+                    render={(props: RouteComponentProps<{ id: string }>) => (
+                        <CodeInsightIndependentPage
+                            insightId={props.match.params.id}
+                            telemetryService={telemetryService}
+                        />
+                    )}
+                />
 
                 <Route
                     path={`${match.url}/edit/:insightID`}
                     render={(props: RouteComponentProps<{ insightID: string }>) => (
-                        <EditInsightLazyPage
-                            authenticatedUser={authenticatedUser}
-                            insightID={props.match.params.insightID}
-                        />
+                        <EditInsightLazyPage insightID={props.match.params.insightID} />
                     )}
                 />
 
                 <Route
                     path={`${match.url}/dashboards/:dashboardId/edit`}
                     render={(routeProps: RouteComponentProps<{ dashboardId: string }>) => (
-                        <EditDashboardPage
-                            authenticatedUser={authenticatedUser}
-                            dashboardId={routeProps.match.params.dashboardId}
-                        />
+                        <EditDashboardPage dashboardId={routeProps.match.params.dashboardId} />
                     )}
                 />
 
@@ -116,18 +103,18 @@ export const CodeInsightsAppRouter = withAuthenticatedUser<CodeInsightsAppRouter
 
                 <Route component={NotFoundPage} key="hardcoded-key" />
             </Switch>
-        </>
+        </CodeInsightsBackendContext.Provider>
     )
 })
 
-const CodeInsightsRedirect: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => {
+const CodeInsightsRedirect: FC = () => {
     const { hasInsights } = useContext(CodeInsightsBackendContext)
 
     const match = useRouteMatch()
     const isThereAvailableInsights = useObservable(useMemo(() => hasInsights(1), [hasInsights]))
 
     if (isThereAvailableInsights === undefined) {
-        return <LoadingSpinner />
+        return null
     }
 
     return isThereAvailableInsights ? (

--- a/client/web/src/enterprise/insights/CodeInsightsRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsRouter.tsx
@@ -1,13 +1,9 @@
-import React from 'react'
+import { FC } from 'react'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { AuthenticatedUser } from '../../auth'
-
-import { CodeInsightsBackendContext } from './core'
-import { useApi } from './hooks/use-api'
-import { useLicense } from './hooks/use-license'
 
 const CodeInsightsAppLazyRouter = lazyComponent(() => import('./CodeInsightsAppRouter'), 'CodeInsightsAppRouter')
 
@@ -16,35 +12,17 @@ const CodeInsightsDotComGetStartedLazy = lazyComponent(
     'CodeInsightsDotComGetStarted'
 )
 
-/**
- * This interface has to receive union type props derived from all child components
- * Because we need to pass all required prop from main Sourcegraph.tsx component to
- * subcomponents withing app tree.
- */
 export interface CodeInsightsRouterProps extends TelemetryProps {
-    /**
-     * Authenticated user info, Used to decide where code insight will appear
-     * in personal dashboard (private) or in organisation dashboard (public)
-     */
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean
 }
 
-export const CodeInsightsRouter: React.FunctionComponent<React.PropsWithChildren<CodeInsightsRouterProps>> = props => {
-    const fetched = useLicense()
-    const api = useApi()
+export const CodeInsightsRouter: FC<CodeInsightsRouterProps> = props => {
+    const { authenticatedUser, isSourcegraphDotCom, telemetryService } = props
 
-    if (!fetched) {
-        return null
+    if (isSourcegraphDotCom) {
+        return <CodeInsightsDotComGetStartedLazy telemetryService={telemetryService} />
     }
 
-    return (
-        <CodeInsightsBackendContext.Provider value={api}>
-            {props.isSourcegraphDotCom ? (
-                <CodeInsightsDotComGetStartedLazy telemetryService={props.telemetryService} />
-            ) : (
-                <CodeInsightsAppLazyRouter {...props} />
-            )}
-        </CodeInsightsBackendContext.Provider>
-    )
+    return <CodeInsightsAppLazyRouter authenticatedUser={authenticatedUser} telemetryService={telemetryService} />
 }

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.test.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.test.tsx
@@ -193,7 +193,7 @@ describe('DashboardsContent', () => {
     it('renders a loading indicator', () => {
         const screen = renderDashboardsContent('baz')
 
-        expect(screen.getByTestId('loading-spinner')).toBeInTheDocument()
+        expect(screen.getByLabelText('Loading')).toBeInTheDocument()
     })
 
     it('renders dashboard not found', async () => {

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-page/DashboardsContentPage.tsx
@@ -39,11 +39,7 @@ export const DashboardsContentPage: FC<DashboardsContentPageProps> = props => {
     }
 
     if (loading || !dashboards) {
-        return (
-            <div data-testid="loading-spinner">
-                <LoadingSpinner aria-live="off" inline={false} />
-            </div>
-        )
+        return <LoadingSpinner aria-live="off" inline={false} />
     }
 
     return (

--- a/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/edit-dashboard/EditDashobardPage.tsx
@@ -4,9 +4,8 @@ import classNames from 'classnames'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import { useHistory } from 'react-router'
 
-import { Badge, Button, Container, LoadingSpinner, PageHeader, useObservable, Link } from '@sourcegraph/wildcard'
+import { Button, Container, LoadingSpinner, PageHeader, useObservable, Link } from '@sourcegraph/wildcard'
 
-import { AuthenticatedUser } from '../../../../../auth'
 import { HeroPage } from '../../../../../components/HeroPage'
 import { LoaderButton } from '../../../../../components/LoaderButton'
 import { PageTitle } from '../../../../../components/PageTitle'
@@ -28,14 +27,13 @@ import styles from './EditDashboardPage.module.scss'
 
 interface EditDashboardPageProps {
     dashboardId: string
-    authenticatedUser: Pick<AuthenticatedUser, 'id' | 'organizations' | 'username'>
 }
 
 /**
  * Displays the edit (configure) dashboard page.
  */
 export const EditDashboardPage: React.FunctionComponent<React.PropsWithChildren<EditDashboardPageProps>> = props => {
-    const { dashboardId, authenticatedUser } = props
+    const { dashboardId } = props
     const history = useHistory()
 
     const { getDashboardOwners, updateDashboard } = useContext(CodeInsightsBackendContext)
@@ -52,21 +50,7 @@ export const EditDashboardPage: React.FunctionComponent<React.PropsWithChildren<
 
     // In case if we got null that means we couldn't find this dashboard
     if (dashboard === null || isVirtualDashboard(dashboard)) {
-        return (
-            <HeroPage
-                icon={MapSearchIcon}
-                title="Oops, we couldn't find the dashboard"
-                subtitle={
-                    <span>
-                        We couldn't find that dashboard. Try to find the dashboard with ID:
-                        <Badge variant="secondary" as="code">
-                            {dashboardId}
-                        </Badge>{' '}
-                        in your <Link to={`/users/${authenticatedUser?.username}/settings`}>user or org settings</Link>
-                    </span>
-                }
-            />
-        )
+        return <HeroPage icon={MapSearchIcon} title="Oops, we couldn't find the dashboard" />
     }
 
     const handleSubmit = async (dashboardValues: DashboardCreationFields): Promise<SubmissionErrors> => {

--- a/client/web/src/enterprise/insights/pages/insights/creation/CreationRoutes.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/CreationRoutes.tsx
@@ -5,7 +5,6 @@ import { Switch, Route, useRouteMatch } from 'react-router'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
-import { AuthenticatedUser } from '../../../../../auth'
 import { useExperimentalFeatures } from '../../../../../stores'
 
 import { InsightCreationPageType } from './InsightCreationPage'
@@ -13,13 +12,7 @@ import { InsightCreationPageType } from './InsightCreationPage'
 const IntroCreationLazyPage = lazyComponent(() => import('./intro/IntroCreationPage'), 'IntroCreationPage')
 const InsightCreationLazyPage = lazyComponent(() => import('./InsightCreationPage'), 'InsightCreationPage')
 
-interface CreationRoutesProps extends TelemetryProps {
-    /**
-     * Authenticated user info, Used to decide where code insight will appears
-     * in personal dashboard (private) or in organisation dashboard (public)
-     */
-    authenticatedUser: AuthenticatedUser
-}
+interface CreationRoutesProps extends TelemetryProps {}
 
 /**
  * Code insight sub-router for the creation area/routes.

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
@@ -2,9 +2,8 @@ import React, { useContext, useMemo } from 'react'
 
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 
-import { Badge, LoadingSpinner, useObservable, Link, PageHeader, Text } from '@sourcegraph/wildcard'
+import { LoadingSpinner, useObservable, Link, PageHeader, Text } from '@sourcegraph/wildcard'
 
-import { AuthenticatedUser } from '../../../../../auth'
 import { HeroPage } from '../../../../../components/HeroPage'
 import { PageTitle } from '../../../../../components/PageTitle'
 import { CodeInsightsIcon } from '../../../../../insights/Icons'
@@ -27,16 +26,10 @@ import { useEditPageHandlers } from './hooks/use-edit-page-handlers'
 export interface EditInsightPageProps {
     /** Normalized insight id <type insight>.insight.<name of insight> */
     insightID: string
-
-    /**
-     * Authenticated user info, Used to decide where code insight will appear
-     * in personal dashboard (private) or in organisation dashboard (public)
-     */
-    authenticatedUser: Pick<AuthenticatedUser, 'id' | 'organizations' | 'username'>
 }
 
 export const EditInsightPage: React.FunctionComponent<React.PropsWithChildren<EditInsightPageProps>> = props => {
-    const { insightID, authenticatedUser } = props
+    const { insightID } = props
 
     const { getInsightById } = useContext(CodeInsightsBackendContext)
     const { licensed, insight: insightFeatures } = useUiFeatures()
@@ -53,21 +46,7 @@ export const EditInsightPage: React.FunctionComponent<React.PropsWithChildren<Ed
     }
 
     if (!insight) {
-        return (
-            <HeroPage
-                icon={MapSearchIcon}
-                title="Oops, we couldn't find that insight"
-                subtitle={
-                    <span>
-                        We couldn't find that insight. Try to find the insight with ID:{' '}
-                        <Badge variant="secondary" as="code">
-                            {insightID}
-                        </Badge>{' '}
-                        in your <Link to={`/users/${authenticatedUser?.username}/settings`}>user or org settings</Link>
-                    </span>
-                }
-            />
-        )
+        return <HeroPage icon={MapSearchIcon} title="Oops, we couldn't find that insight" />
     }
 
     return (


### PR DESCRIPTION

## Preface

The current flow of web app auth flow 
- You go to your-instanse.sourcegrpah.com unauthorised. 
- Then we check conf.AuthPublic() and redirect you immediately to the sign-in flow or pass you through and show the home page (the home page doesn't have any client redirection logic, it's always public if BE doesn't redirect you)
- When you try to go to the code insights UI, for example, where we do have client redirection we redirect you to sign in page (because there is no case for code insights if you're unauthorized)

This PR fixes the auth gate for the code insights pages by moving the code insight license page check under the component that is gate kept under auth redirection. So code insight license check doesn't fail the whole flow for the unauth users.

And also removes auth user info from a few legacy hero pages (it made sense previously when we had insights in the auth user settings and we used authUser info in order to generate a link to the auth user settings in a few empty screens) 

## Test plan
- Check that code insight works as expected (open any Code Insight page) when you're signed in 
- Check that with signed out when you click on the insight global nav bar (or open /insight page directly) client redirects you to the `/sign-in` flow.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-remove-legacy-auth-user.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

