### PR TITLE
ui: change chevron directions in collapsibles

### DIFF
--- a/client/search-ui/src/results/sidebar/SearchFilterSection.tsx
+++ b/client/search-ui/src/results/sidebar/SearchFilterSection.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback, useEffect, useState, memo, FC, ReactElement, ReactNode } from 'react'
 
+import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
 import classNames from 'classnames'
-import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
-import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'
 
 import { Button, Collapse, CollapseHeader, CollapsePanel, Icon, H5, Input, H3 } from '@sourcegraph/wildcard'
 
@@ -169,7 +168,7 @@ export const SearchFilterSection: FC<SearchFilterSectionProps> = memo(props => {
                         </H5>
                         <H5 as="span">{postHeader}</H5>
                     </header>
-                    <Icon aria-hidden={true} as={isOpened ? ChevronDownIcon : ChevronLeftIcon} />
+                    <Icon aria-hidden={true} svgPath={isOpened ? mdiChevronUp : mdiChevronDown} />
                 </CollapseHeader>
 
                 <CollapsePanel forcedRender={forcedRender}>

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -1,6 +1,6 @@
 import React, { KeyboardEvent, MouseEvent, useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 
-import { mdiArrowCollapseRight, mdiChevronDown, mdiChevronRight, mdiFilterOutline } from '@mdi/js'
+import { mdiArrowCollapseRight, mdiChevronDown, mdiChevronUp, mdiFilterOutline } from '@mdi/js'
 import classNames from 'classnames'
 import * as H from 'history'
 import { capitalize, uniqBy } from 'lodash'
@@ -586,9 +586,9 @@ const CollapsibleLocationList: React.FunctionComponent<
                         className="d-flex p-0 justify-content-start w-100"
                     >
                         {isOpen ? (
-                            <Icon aria-hidden={true} svgPath={mdiChevronDown} />
+                            <Icon aria-hidden={true} svgPath={mdiChevronUp} />
                         ) : (
-                            <Icon aria-hidden={true} svgPath={mdiChevronRight} />
+                            <Icon aria-hidden={true} svgPath={mdiChevronDown} />
                         )}{' '}
                         <H4 className="mb-0">{capitalize(props.name)}</H4>
                         <span className={classNames('ml-2 text-muted small', styles.cardHeaderSmallText)}>
@@ -847,7 +847,7 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
                     type="button"
                     className={classNames('d-flex justify-content-start w-100', styles.repoLocationGroupHeader)}
                 >
-                    <Icon aria-hidden="true" svgPath={open ? mdiChevronDown : mdiChevronRight} />
+                    <Icon aria-hidden="true" svgPath={open ? mdiChevronUp : mdiChevronDown} />
                     <small>
                         <span className={classNames('text-small', styles.repoLocationGroupHeaderRepoName)}>
                             {displayRepoName(repoLocationGroup.repoName)}
@@ -972,9 +972,9 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                     )}
                 >
                     {open ? (
-                        <Icon aria-hidden={true} svgPath={mdiChevronDown} />
+                        <Icon aria-hidden={true} svgPath={mdiChevronUp} />
                     ) : (
-                        <Icon aria-hidden={true} svgPath={mdiChevronRight} />
+                        <Icon aria-hidden={true} svgPath={mdiChevronDown} />
                     )}
                     <small className={styles.locationGroupHeaderFilename}>
                         <span>

--- a/client/web/src/components/Collapsible.tsx
+++ b/client/web/src/components/Collapsible.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react'
 
-import { mdiChevronDown, mdiChevronRight } from '@mdi/js'
+import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
 import classNames from 'classnames'
 
 import { Button, Icon } from '@sourcegraph/wildcard'
@@ -98,7 +98,7 @@ export const Collapsible: React.FunctionComponent<Props> = ({
                     aria-label={isExpanded ? 'Collapse section' : 'Expand section'}
                     onClick={toggleIsExpanded}
                 >
-                    <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronDown : mdiChevronRight} />
+                    <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronUp : mdiChevronDown} />
                 </Button>
                 {!titleAtStart && titleNode}
             </div>

--- a/client/web/src/components/Timeline.tsx
+++ b/client/web/src/components/Timeline.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, ReactNode, useState } from 'react'
 
-import { mdiChevronDown, mdiChevronRight } from '@mdi/js'
+import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
 import VisuallyHidden from '@reach/visually-hidden'
 import classNames from 'classnames'
 import { formatDistance } from 'date-fns/esm'
@@ -84,7 +84,7 @@ const TimelineStage: FunctionComponent<React.PropsWithChildren<TimelineStageProp
                 className="p-0 m-0 border-0 w-100 font-weight-normal d-flex justify-content-between align-items-center"
             >
                 {stageLabel}
-                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronDown : mdiChevronRight} className="mr-1" />
+                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronUp : mdiChevronDown} className="mr-1" />
             </CollapseHeader>
             <CollapsePanel className={styles.details}>{details}</CollapsePanel>
         </Collapse>

--- a/client/web/src/components/diff/FileDiffNode.tsx
+++ b/client/web/src/components/diff/FileDiffNode.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react'
 
-import { mdiChevronDown, mdiChevronRight } from '@mdi/js'
+import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
 import classNames from 'classnames'
 import * as H from 'history'
 import prettyBytes from 'pretty-bytes'
@@ -106,7 +106,7 @@ export const FileDiffNode: React.FunctionComponent<React.PropsWithChildren<FileD
                         onClick={toggleExpand}
                         size="sm"
                     >
-                        <Icon svgPath={expanded ? mdiChevronDown : mdiChevronRight} aria-hidden={true} />
+                        <Icon svgPath={expanded ? mdiChevronUp : mdiChevronDown} aria-hidden={true} />
                     </Button>
                     <div className={classNames('align-items-baseline', styles.headerPathStat)}>
                         {!node.oldPath && (

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react'
 
-import { mdiChevronDown, mdiChevronRight } from '@mdi/js'
+import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
 import * as H from 'history'
 import { parse as parseJSONC } from 'jsonc-parser'
 import { Redirect, useHistory } from 'react-router'
@@ -369,7 +369,7 @@ const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJob
                         aria-label={isExpanded ? 'Collapse section' : 'Expand section'}
                         onClick={toggleIsExpanded}
                     >
-                        <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronDown : mdiChevronRight} />
+                        <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronUp : mdiChevronDown} />
                     </Button>
                 </div>
                 <div className="d-flex mr-2 justify-content-left">

--- a/client/web/src/enterprise/batches/BatchSpecNode.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecNode.tsx
@@ -6,7 +6,7 @@ import {
     mdiCancel,
     mdiAlertCircle,
     mdiChevronDown,
-    mdiChevronRight,
+    mdiChevronUp,
     mdiStar,
     mdiPencil,
     mdiFileDownload,
@@ -74,7 +74,7 @@ export const BatchSpecNode: React.FunctionComponent<React.PropsWithChildren<Batc
                 aria-label={isExpanded ? 'Collapse section' : 'Expand section'}
                 onClick={toggleIsExpanded}
             >
-                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronDown : mdiChevronRight} />
+                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronUp : mdiChevronDown} />
             </Button>
             <div className="d-flex flex-column justify-content-center align-items-center px-2 pb-1">
                 <StateIcon source={node.source} state={node.state} />

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -8,7 +8,7 @@ import {
     mdiSync,
     mdiLinkVariantRemove,
     mdiChevronDown,
-    mdiChevronRight,
+    mdiChevronUp,
     mdiOpenInNew,
 } from '@mdi/js'
 import { VisuallyHidden } from '@reach/visually-hidden'
@@ -403,7 +403,7 @@ const ChangesetSpecNode: React.FunctionComponent<React.PropsWithChildren<Changes
                 as={Button}
                 className="w-100 p-0 m-0 border-0 d-flex align-items-center justify-content-between"
             >
-                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronDown : mdiChevronRight} className="mr-1" />
+                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronUp : mdiChevronDown} className="mr-1" />
                 <div className={styles.collapseHeader}>
                     <Heading as="h4" styleAs="h3" className="mb-0 d-inline-block mr-2">
                         <VisuallyHidden>Execution</VisuallyHidden>
@@ -446,7 +446,7 @@ const ChangesetSpecNode: React.FunctionComponent<React.PropsWithChildren<Changes
                             <CollapseHeader as={Button} className="w-100 p-0 m-0 border-0 d-flex align-items-center">
                                 <Icon
                                     aria-hidden={true}
-                                    svgPath={areChangesExpanded ? mdiChevronDown : mdiChevronRight}
+                                    svgPath={areChangesExpanded ? mdiChevronUp : mdiChevronDown}
                                     className="mr-1"
                                 />
                                 <Heading className="mb-0" as="h4" styleAs="h3">
@@ -531,7 +531,7 @@ const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceSt
                 as={Button}
                 className="w-100 p-0 m-0 border-0 d-flex align-items-center justify-content-between"
             >
-                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronDown : mdiChevronRight} className="mr-1" />
+                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronUp : mdiChevronDown} className="mr-1" />
                 <div className={classNames(styles.collapseHeader, step.skipped && 'text-muted')}>
                     <StepStateIcon step={step} />
                     <H3 className={styles.stepNumber}>Step {step.number}</H3>

--- a/client/web/src/enterprise/batches/close/ExternalChangesetCloseNode.tsx
+++ b/client/web/src/enterprise/batches/close/ExternalChangesetCloseNode.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react'
 
-import { mdiChevronDown, mdiChevronRight } from '@mdi/js'
+import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
 import classNames from 'classnames'
 import * as H from 'history'
 
@@ -67,7 +67,7 @@ export const ExternalChangesetCloseNode: React.FunctionComponent<
                 aria-label={isExpanded ? 'Collapse section' : 'Expand section'}
                 onClick={toggleIsExpanded}
             >
-                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronDown : mdiChevronRight} />
+                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronUp : mdiChevronDown} />
             </Button>
             {willClose ? (
                 <ChangesetCloseActionClose className={styles.externalChangesetCloseNodeAction} />
@@ -109,7 +109,7 @@ export const ExternalChangesetCloseNode: React.FunctionComponent<
                 outline={true}
                 variant="secondary"
             >
-                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronDown : mdiChevronRight} />{' '}
+                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronUp : mdiChevronDown} />{' '}
                 {isExpanded ? 'Hide' : 'Show'} details
             </Button>
             {isExpanded && (

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect } from 'react'
 
-import { mdiChevronDown, mdiChevronRight, mdiSync } from '@mdi/js'
+import { mdiChevronDown, mdiChevronUp, mdiSync } from '@mdi/js'
 import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 import * as H from 'history'
@@ -92,7 +92,7 @@ export const ExternalChangesetNode: React.FunctionComponent<React.PropsWithChild
                 aria-label={isExpanded ? 'Collapse section' : 'Expand section'}
                 onClick={toggleIsExpanded}
             >
-                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronDown : mdiChevronRight} />
+                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronUp : mdiChevronDown} />
             </Button>
             {selectable ? (
                 <div className="p-2">
@@ -195,7 +195,7 @@ export const ExternalChangesetNode: React.FunctionComponent<React.PropsWithChild
                 outline={true}
                 variant="secondary"
             >
-                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronDown : mdiChevronRight} />{' '}
+                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronUp : mdiChevronDown} />{' '}
                 {isExpanded ? 'Hide' : 'Show'} details
             </Button>
             {isExpanded && (

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -6,7 +6,7 @@ import {
     mdiAccountEdit,
     mdiCheckboxBlankCircle,
     mdiChevronDown,
-    mdiChevronRight,
+    mdiChevronUp,
 } from '@mdi/js'
 import classNames from 'classnames'
 import * as H from 'history'
@@ -79,7 +79,7 @@ export const VisibleChangesetApplyPreviewNode: React.FunctionComponent<
                 aria-label={isExpanded ? 'Collapse section' : 'Expand section'}
                 onClick={toggleIsExpanded}
             >
-                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronDown : mdiChevronRight} />
+                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronUp : mdiChevronDown} />
             </Button>
             {selectable ? (
                 <SelectBox node={node} selectable={selectable} />
@@ -184,7 +184,7 @@ export const VisibleChangesetApplyPreviewNode: React.FunctionComponent<
                 outline={true}
                 variant="secondary"
             >
-                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronDown : mdiChevronRight} />{' '}
+                <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronUp : mdiChevronDown} />{' '}
                 {isExpanded ? 'Hide' : 'Show'} details
             </Button>
             {isExpanded && (

--- a/client/web/src/enterprise/code-monitoring/components/logs/CollapsibleDetailsWithStatus.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/logs/CollapsibleDetailsWithStatus.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react'
 
-import { mdiChevronDown, mdiChevronRight } from '@mdi/js'
+import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
 
 import { Badge, Button, Icon } from '@sourcegraph/wildcard'
 
@@ -50,9 +50,9 @@ export const CollapsibleDetailsWithStatus: React.FunctionComponent<
         <li className={styles.wrapper}>
             <Button onClick={toggleExpanded} className={styles.expandButton}>
                 {expanded ? (
-                    <Icon svgPath={mdiChevronDown} className="mr-2" aria-label="Collapse details." />
+                    <Icon svgPath={mdiChevronUp} className="mr-2" aria-label="Collapse details." />
                 ) : (
-                    <Icon svgPath={mdiChevronRight} className="mr-2" aria-label="Expand details." />
+                    <Icon svgPath={mdiChevronDown} className="mr-2" aria-label="Expand details." />
                 )}
                 <span>{title}</span>
                 <Badge

--- a/client/web/src/enterprise/code-monitoring/components/logs/MonitorLogNode.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/logs/MonitorLogNode.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react'
 
-import { mdiAlertCircle, mdiCheckBold, mdiOpenInNew, mdiChevronDown, mdiChevronRight } from '@mdi/js'
+import { mdiAlertCircle, mdiCheckBold, mdiOpenInNew, mdiChevronDown, mdiChevronUp } from '@mdi/js'
 import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 
@@ -51,14 +51,14 @@ export const MonitorLogNode: React.FunctionComponent<
                     {expanded ? (
                         <Icon
                             className="mr-2 flex-shrink-0"
-                            svgPath={mdiChevronDown}
+                            svgPath={mdiChevronUp}
                             inline={false}
                             aria-label="Collapse code monitor"
                         />
                     ) : (
                         <Icon
                             className="mr-2 flex-shrink-0"
-                            svgPath={mdiChevronRight}
+                            svgPath={mdiChevronDown}
                             inline={false}
                             aria-label="Expand code monitor"
                         />

--- a/client/web/src/enterprise/code-monitoring/components/logs/TriggerEvent.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/logs/TriggerEvent.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react'
 
-import { mdiAlertCircle, mdiChevronDown, mdiChevronRight, mdiOpenInNew } from '@mdi/js'
+import { mdiAlertCircle, mdiChevronDown, mdiChevronUp, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
 import { pluralize } from '@sourcegraph/common'
@@ -61,9 +61,9 @@ export const TriggerEvent: React.FunctionComponent<
             <div className="d-flex align-items-center">
                 <Button onClick={toggleExpanded} className={classNames('d-block', styles.expandButton)}>
                     {expanded ? (
-                        <Icon svgPath={mdiChevronDown} className="mr-2" aria-label="Collapse run." />
+                        <Icon svgPath={mdiChevronUp} className="mr-2" aria-label="Collapse run." />
                     ) : (
-                        <Icon svgPath={mdiChevronRight} className="mr-2" aria-label="Expand run." />
+                        <Icon svgPath={mdiChevronDown} className="mr-2" aria-label="Expand run." />
                     )}
 
                     {hasError ? (

--- a/client/web/src/enterprise/codeintel/uploads/components/CodeIntelUploadNode.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/CodeIntelUploadNode.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react'
 
-import { mdiDotsVertical } from '@mdi/js'
+import { mdiChevronRight } from '@mdi/js'
 import classNames from 'classnames'
 
 import { Link, H3, Icon, Checkbox } from '@sourcegraph/wildcard'
@@ -69,7 +69,7 @@ export const CodeIntelUploadNode: FunctionComponent<React.PropsWithChildren<Code
         </span>
         <span>
             <Link to={`./uploads/${node.id}`}>
-                <Icon svgPath={mdiDotsVertical} inline={false} aria-label="View more information" />
+                <Icon svgPath={mdiChevronRight} inline={false} aria-label="View more information" />
             </Link>
         </span>
     </>

--- a/client/web/src/site-admin/overview/__snapshots__/SiteAdminOverviewPage.test.tsx.snap
+++ b/client/web/src/site-admin/overview/__snapshots__/SiteAdminOverviewPage.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`SiteAdminOverviewPage >= 2 users 1`] = `
               width="24"
             >
               <path
-                d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+                d="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z"
               />
             </svg>
           </button>

--- a/client/web/src/site-admin/webhooks/WebhookLogNode.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogNode.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react'
 
-import { mdiChevronDown, mdiChevronRight } from '@mdi/js'
+import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
 import classNames from 'classnames'
 import { format } from 'date-fns'
 
@@ -40,7 +40,7 @@ export const WebhookLogNode: React.FunctionComponent<React.PropsWithChildren<Pro
                     aria-label={isExpanded ? 'Collapse section' : 'Expand section'}
                     onClick={toggleExpanded}
                 >
-                    <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronDown : mdiChevronRight} />
+                    <Icon aria-hidden={true} svgPath={isExpanded ? mdiChevronUp : mdiChevronDown} />
                 </Button>
             </span>
             <span className={styles.statusCode}>
@@ -54,9 +54,9 @@ export const WebhookLogNode: React.FunctionComponent<React.PropsWithChildren<Pro
             <span className={styles.smDetailsButton}>
                 <Button onClick={toggleExpanded} outline={true} variant="secondary">
                     {isExpanded ? (
-                        <Icon aria-hidden={true} svgPath={mdiChevronDown} />
+                        <Icon aria-hidden={true} svgPath={mdiChevronUp} />
                     ) : (
-                        <Icon aria-hidden={true} svgPath={mdiChevronRight} />
+                        <Icon aria-hidden={true} svgPath={mdiChevronDown} />
                     )}{' '}
                     {isExpanded ? 'Hide' : 'Show'} details
                 </Button>


### PR DESCRIPTION
Previously, we used `>` for closed collapsibles and `v` for open collapsibles. At the same time, we also used `>` to navigate to sub-menus (see fig 1 at bottom), which is not great from a consistency and user expectation perspective.
 @danielmarquespt mentioned "I personally think that using `>` for expands is wrong. Especially because that affordance on mobile interfaces is to navigate to a sub-menu. That is what it feels like most of the time. I think expands should be `˅` `˄`  and `>` to navigate to secondary pages.", which matches the material design recommendation [as shown for example here](https://m1.material.io/components/expansion-panels.html).

This PR attempts to incorporate this in the places that I could find would be relevant. Not guaranteed to be all encompassing and complete.
Changes made:
- Replace collapsible closed icon, previously right chevron, with down chevron
- Replace collapsible open icon, previously down chevron, with up chevron
- Replace sub-menu/page licon icon, previously three vertical dots and previously before that again right chevron, with right chevron again

<details>
<summary>Fig 1 (submenu icon)</summary>

![image](https://user-images.githubusercontent.com/18282288/206586300-ea523b7e-50e6-4f48-9047-41497e848420.png)

</details>

<details>
<summary>Fig 2 (before collapsible icons)</summary>

![image](https://user-images.githubusercontent.com/18282288/206584280-b0da4eea-b225-4851-82c4-e595a4eb915d.png)

</details>

<details>
<summary>Fig 3 (after collapsible icons)</summary>

![image](https://user-images.githubusercontent.com/18282288/206584164-c1ea624f-3820-44c6-abe2-2b9cfb7dfe9b.png)

</details>

## Test plan

I opened the local instance and had a looksie : )

## App preview:

- [Web](https://sg-web-nsc-chevrons.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
