### PR TITLE
ci: Add version checks in CI upgrade test

### DIFF
--- a/dev/ci/integration/upgrade/test.sh
+++ b/dev/ci/integration/upgrade/test.sh
@@ -35,7 +35,7 @@ popd
 source /root/.sg_envrc
 
 SOURCEGRAPH_REPORTED_VERSION_OLD=$(curl -fs "$URL/__version")
-echo "Sourcegraph instance (old) is reporting version: \"$SOURCEGRAPH_REPORTED_VERSION_OLD\""
+echo "--- Sourcegraph instance (before upgrade) is reporting version: '$SOURCEGRAPH_REPORTED_VERSION_OLD'"
 
 # Stop old Sourcegraph release
 docker container stop "$CONTAINER"
@@ -80,7 +80,12 @@ curl -f "$URL"
 curl -f "$URL"/healthz
 
 SOURCEGRAPH_REPORTED_VERSION_NEW=$(curl -fs "$URL/__version")
-echo "Sourcegraph instance (upgraded) is reporting version: \"$SOURCEGRAPH_REPORTED_VERSION_NEW\""
+echo "--- Sourcegraph instance (after upgrade) is reporting version: '$SOURCEGRAPH_REPORTED_VERSION_NEW'"
+
+if [ "$SOURCEGRAPH_REPORTED_VERSION_NEW" == "$SOURCEGRAPH_REPORTED_VERSION_OLD" ]; then
+  echo "Error: Instance version unchanged after upgrade" 1>&2
+  exit 1
+fi
 
 echo "--- TEST: Running tests"
 pushd client/web

--- a/dev/ci/integration/upgrade/test.sh
+++ b/dev/ci/integration/upgrade/test.sh
@@ -34,6 +34,9 @@ popd
 # shellcheck disable=SC1091
 source /root/.sg_envrc
 
+SOURCEGRAPH_REPORTED_VERSION_OLD=$(curl -fs "$URL/__version")
+echo "Sourcegraph instance (old) is reporting version: \"$SOURCEGRAPH_REPORTED_VERSION_OLD\""
+
 # Stop old Sourcegraph release
 docker container stop "$CONTAINER"
 sleep 5
@@ -75,6 +78,10 @@ sleep 15
 echo "--- TEST: Checking Sourcegraph instance is accessible"
 curl -f "$URL"
 curl -f "$URL"/healthz
+
+SOURCEGRAPH_REPORTED_VERSION_NEW=$(curl -fs "$URL/__version")
+echo "Sourcegraph instance (upgraded) is reporting version: \"$SOURCEGRAPH_REPORTED_VERSION_NEW\""
+
 echo "--- TEST: Running tests"
 pushd client/web
 yarn run test:regression:core

--- a/dev/ci/integration/upgrade/test.sh
+++ b/dev/ci/integration/upgrade/test.sh
@@ -35,6 +35,7 @@ popd
 source /root/.sg_envrc
 
 SOURCEGRAPH_REPORTED_VERSION_OLD=$(curl -fs "$URL/__version")
+echo
 echo "--- Sourcegraph instance (before upgrade) is reporting version: '$SOURCEGRAPH_REPORTED_VERSION_OLD'"
 
 # Stop old Sourcegraph release
@@ -80,6 +81,7 @@ curl -f "$URL"
 curl -f "$URL"/healthz
 
 SOURCEGRAPH_REPORTED_VERSION_NEW=$(curl -fs "$URL/__version")
+echo
 echo "--- Sourcegraph instance (after upgrade) is reporting version: '$SOURCEGRAPH_REPORTED_VERSION_NEW'"
 
 if [ "$SOURCEGRAPH_REPORTED_VERSION_NEW" == "$SOURCEGRAPH_REPORTED_VERSION_OLD" ]; then


### PR DESCRIPTION
Currently the upgrade test doesn't log the versions of the instance before or after running the upgrade.

This adds a message that logs the actual reported Sourcegraph version (from the `/__version` endpoint) before upgrade and after upgrade.

It also adds a check that the reported versions are not equal, to catch the hypothetical situation where the upgrade doesn't do anything while going unnoticed.

## Test plan

Run in CI
