### PR TITLE
Code Insights: Do not render chart content if parent element isn't fully rendered/measured

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
@@ -66,43 +66,48 @@ export function BackendInsightChart<Datum>(props: BackendInsightChartProps<Datum
                 [styles.rootWithLegend]: isSeriesLikeInsight,
             })}
         >
-            {width && (
+            {width > 0 && (
                 <>
                     <ParentSize
                         debounceTime={0}
                         enableDebounceLeadingCall={true}
                         className={styles.responsiveContainer}
                     >
-                        {parent => (
-                            <>
-                                <BackendAlertOverlay
-                                    hasNoData={isEmptyDataset}
-                                    isFetchingHistoricalData={isFetchingHistoricalData}
-                                    className={styles.alertOverlay}
-                                />
+                        {parent =>
+                            // Render chart element only when we have real non-empty parent sizes
+                            // otherwise, the first chart render happens on a not fully rendered
+                            // element that causes the element's flickering
+                            parent.height * parent.width !== 0 && (
+                                <>
+                                    <BackendAlertOverlay
+                                        hasNoData={isEmptyDataset}
+                                        isFetchingHistoricalData={isFetchingHistoricalData}
+                                        className={styles.alertOverlay}
+                                    />
 
-                                {data.type === InsightContentType.Series ? (
-                                    <SeriesChart
-                                        type={SeriesBasedChartTypes.Line}
-                                        width={parent.width}
-                                        height={parent.height}
-                                        locked={locked}
-                                        className={styles.chart}
-                                        onDatumClick={onDatumClick}
-                                        zeroYAxisMin={zeroYAxisMin}
-                                        seriesToggleState={seriesToggleState}
-                                        series={data.series}
-                                    />
-                                ) : (
-                                    <BarChart
-                                        aria-label="Bar chart"
-                                        width={parent.width}
-                                        height={parent.height}
-                                        {...data.content}
-                                    />
-                                )}
-                            </>
-                        )}
+                                    {data.type === InsightContentType.Series ? (
+                                        <SeriesChart
+                                            type={SeriesBasedChartTypes.Line}
+                                            width={parent.width}
+                                            height={parent.height}
+                                            locked={locked}
+                                            className={styles.chart}
+                                            onDatumClick={onDatumClick}
+                                            zeroYAxisMin={zeroYAxisMin}
+                                            seriesToggleState={seriesToggleState}
+                                            series={data.series}
+                                        />
+                                    ) : (
+                                        <BarChart
+                                            aria-label="Bar chart"
+                                            width={parent.width}
+                                            height={parent.height}
+                                            {...data.content}
+                                        />
+                                    )}
+                                </>
+                            )
+                        }
                     </ParentSize>
 
                     {isSeriesLikeInsight && (

--- a/client/web/src/integration/insights/insight/insight-chart-focus.test.ts
+++ b/client/web/src/integration/insights/insight/insight-chart-focus.test.ts
@@ -65,9 +65,12 @@ describe('Code insights [Insight Card] should has a proper focus management ', (
         )
 
         const dataSeries = GET_INSIGHT_VIEW_SEARCH_BASED_INSIGHT.insightViews.nodes[0]?.dataSeries
+
         if (!dataSeries) {
             assert.fail('Insight errored')
         }
+
+        await driver.page.waitForSelector('[aria-label="Chart series"]')
 
         for (let lineIndex = 0; lineIndex < dataSeries.length; lineIndex++) {
             const series = dataSeries[lineIndex]

--- a/client/wildcard/src/components/Charts/components/line-chart/LineChart.test.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/LineChart.test.tsx
@@ -8,7 +8,18 @@ const defaultArgs: RenderChartArgs = { series: FLAT_SERIES }
 interface RenderChartArgs {
     series: typeof FLAT_SERIES
 }
-const renderChart = ({ series }: RenderChartArgs) => render(<LineChart width={400} height={400} series={series} />)
+
+/**
+ * Test padding set 1px to the left and bottom values in order to force
+ * content sync appearance. In browser runtime this padding is calculated
+ * based on chart axes sizes. In test environment size measurement API
+ * doesn't work, we have to set padding manually in order to force chart
+ * content appearance. See SVGContent component for more context.
+ */
+const TEST_PADDING = { top: 16, right: 18, bottom: 1, left: 1 }
+
+const renderChart = ({ series }: RenderChartArgs) =>
+    render(<LineChart width={400} height={400} series={series} padding={TEST_PADDING} />)
 
 describe('LineChart', () => {
     // Non-exhaustive smoke tests to check that the chart renders correctly

--- a/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
@@ -6,6 +6,7 @@ import { ScaleLinear, ScaleTime } from 'd3-scale'
 import { timeFormat } from 'd3-time-format'
 import { noop } from 'lodash'
 
+import { Padding } from '../../../Popover'
 import { SvgAxisBottom, SvgAxisLeft, SvgContent, SvgRoot } from '../../core'
 import { Series, SeriesLikeChart } from '../../types'
 
@@ -67,6 +68,9 @@ export interface LineChartProps<Datum> extends SeriesLikeChart<Datum>, SVGProps<
      * @returns a SeriesWithData array that has been filtered
      */
     getActiveSeries?: <S extends Pick<Series<Datum>, 'id'>>(dataSeries: S[]) => S[]
+
+    /** Visual content padding for the SVG element */
+    padding?: Padding
 }
 
 const identity = <T,>(argument: T): T => argument
@@ -87,6 +91,7 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
         getLineGroupStyle,
         getActiveSeries = identity,
         onDatumClick = noop,
+        padding = DEFAULT_LINE_CHART_PADDING,
         ...attributes
     } = props
 
@@ -138,7 +143,7 @@ export function LineChart<D>(props: LineChartProps<D>): ReactElement | null {
             height={height}
             xScale={xScale}
             yScale={yScale}
-            padding={DEFAULT_LINE_CHART_PADDING}
+            padding={padding}
         >
             <SvgAxisLeft />
 

--- a/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/LineChart.tsx
@@ -70,7 +70,7 @@ export interface LineChartProps<Datum> extends SeriesLikeChart<Datum>, SVGProps<
 }
 
 const identity = <T,>(argument: T): T => argument
-const DEFAULT_LINE_CHART_PADDING = { top: 16, right: 18, bottom: 20, left: 0 }
+const DEFAULT_LINE_CHART_PADDING = { top: 16, right: 18, bottom: 0, left: 0 }
 
 /**
  * Visual component that renders svg line chart with pre-defined sizes, tooltip,

--- a/client/wildcard/src/components/Charts/core/components/SvgRoot.tsx
+++ b/client/wildcard/src/components/Charts/core/components/SvgRoot.tsx
@@ -29,7 +29,7 @@ import { AxisBottom, AxisLeft } from './axis/Axis'
 import { getMaxTickWidth, Tick, TickProps } from './axis/Tick'
 import { GetScaleTicksOptions, getXScaleTicks } from './axis/tick-formatters'
 
-const DEFAULT_PADDING = { top: 16, right: 36, bottom: 20, left: 0 }
+const DEFAULT_PADDING = { top: 16, right: 36, bottom: 0, left: 0 }
 
 interface Padding {
     top: number
@@ -257,9 +257,15 @@ interface SvgContentProps<XScale extends AxisScale | ScaleTime<any, any>, YScale
  */
 export function SvgContent<XScale extends AxisScale = AxisScale, YScale extends AxisScale = AxisScale>(
     props: SvgContentProps<XScale, YScale>
-): ReactElement {
+): ReactElement | null {
     const { children } = props
     const { content, xScale, yScale } = useContext(SVGRootContext)
+
+    // Render content only when we already have measured axis (left and bottom)
+    // sizes in order to avoid content shift.
+    if (content.left * content.bottom === 0) {
+        return null
+    }
 
     return (
         <Group top={content.top} left={content.left} width={content.width} height={content.height}>


### PR DESCRIPTION
## Background

In this PR, we render the element only when the parent size element is fully rendered and chart axes elements are measured. 

| Before | After |
| ------ | ------ | 
| <video src="https://user-images.githubusercontent.com/18492575/206600412-215a7721-4c7b-4c3f-8d9a-543720bc0c81.mp4" /> | <video src="https://user-images.githubusercontent.com/18492575/206600555-06e461a6-9825-4f22-b081-0fc0032fe6ac.mp4" /> |


## Test plan
- Open the code insights dashboard page (dashboard with a big number of cards, all insights dashboard)
- Start to scroll fast
- Check that there is no visual chart flickering or visual content element growth 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-chart-flickers.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
