### PR TITLE
go tests: do not use rich go - unblock the pipeline

### DIFF
--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -40,7 +40,7 @@ function go_test() {
     -covermode=atomic \
     -race \
     -v \
-    $test_packages | tee "$tmpfile" | richgo testfilter
+    $test_packages | tee "$tmpfile"
   # Save the test exit code so we can return it after saving the test report
   test_exit_code="${PIPESTATUS[0]}"
   echo "--- Tests complete with status $test_exit_code"


### PR DESCRIPTION
richgo starting failing on the pipeline ... it only brings nice colours so we're killing it to unblock
## Test plan
executed `./dev/ci/go-test.sh` locally
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
