### PR TITLE
Handle GitHub repo not found correctly and update Bitbucket Server docs

### DIFF
--- a/doc/admin/external_service/bitbucket_server.md
+++ b/doc/admin/external_service/bitbucket_server.md
@@ -49,7 +49,7 @@ To set up webhooks:
    * **Name**: A unique name representing your Sourcegraph instance
    * **Scope**: `global`
    * **Endpoint**: The URL from step 6
-   * **Events**: `repo:build_staus, pr:activity:status, pr:activity:event, pr:activity:rescope, pr:activity:merge, pr:activity:comment, pr:activity:reviewers, pr:participant:status`
+   * **Events**: `repo:build_status`, `pr:activity:status`, `pr:activity:event`, `pr:activity:rescope`, `pr:activity:merge`, `pr:activity:comment`, `pr:activity:reviewers`, `pr:participant:status`
    * **Secret**: The secret you configured in step 4
 1. Confirm that the new webhook is listed under **All webhooks** with a timestamp in the **Last successful** column.
 

--- a/doc/admin/external_service/bitbucket_server.md
+++ b/doc/admin/external_service/bitbucket_server.md
@@ -49,7 +49,7 @@ To set up webhooks:
    * **Name**: A unique name representing your Sourcegraph instance
    * **Scope**: `global`
    * **Endpoint**: The URL from step 6
-   * **Events**: `pr, repo`
+   * **Events**: `repo:build_staus, pr:activity:status, pr:activity:event, pr:activity:rescope, pr:activity:merge, pr:activity:comment, pr:activity:reviewers, pr:participant:status`
    * **Secret**: The secret you configured in step 4
 1. Confirm that the new webhook is listed under **All webhooks** with a timestamp in the **Last successful** column.
 


### PR DESCRIPTION
Title.

If we can't find a repo when responding to a push event, we should not respond with a 404.

Bitbucket server docs for setting up webhooks is incorrect and events have too broad scope.

## Test plan

Doc update mostly

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
