### PR TITLE
Update cAdvisor to v0.46

### DIFF
--- a/docker-images/cadvisor/Dockerfile
+++ b/docker-images/cadvisor/Dockerfile
@@ -1,4 +1,5 @@
-FROM gcr.io/cadvisor/cadvisor@sha256:9360d7421c5e9b646ea13e5ced3f8e6da80017b0144733a04b7401dd8c01a5cb
+# IMPORTANT: Check the README before updating, as images are not correctly tagged by architecture
+FROM gcr.io/cadvisor/cadvisor@sha256:3cdd30ca47684279b14f14ba9d436c323ce894bf5b939c410229f45581875b91
 LABEL com.sourcegraph.cadvisor.version=v0.46.0
 
 ARG COMMIT_SHA="unknown"

--- a/docker-images/cadvisor/Dockerfile
+++ b/docker-images/cadvisor/Dockerfile
@@ -1,5 +1,5 @@
-# IMPORTANT: Check the README before updating, as images are not correctly tagged by architecture
-FROM gcr.io/cadvisor/cadvisor@sha256:3cdd30ca47684279b14f14ba9d436c323ce894bf5b939c410229f45581875b91
+# NOTE: Check the README before updating
+FROM gcr.io/cadvisor/cadvisor@sha256:8b0c7203efb4ff2d6a1f36474b2cd0bcf94d4009d3deaa0fe925ae9132b8ff1e
 LABEL com.sourcegraph.cadvisor.version=v0.46.0
 
 ARG COMMIT_SHA="unknown"

--- a/docker-images/cadvisor/README.md
+++ b/docker-images/cadvisor/README.md
@@ -6,7 +6,9 @@ Learn more about the Sourcegraph cAdvisor distribution in the [cAdvisor document
 
 This image **is not** currently built by CI and errors that can break builds may go undetected. This is already under the attention of the dev-experience team.
 
-The base images for cadvisor are hosted in gcr.io/cadvisor/cadvisor. Note that the images are not tagged by architecture. That needs to be verified manually:
+The base images for cadvisor are hosted in gcr.io/cadvisor/cadvisor. Note that the images are not tagged by architecture, and just using `docker pull gcr.io/cadvisor/cadvisor:v0.XX.0` to get the digest **will likely return an image for the wrong architecture**!
+
+Look through the [recently released images](https://console.cloud.google.com/gcr/images/cadvisor/GLOBAL/cadvisor) and manually identify the image for the correct architecture:
 
 1. Exec in the container with `docker run -it --entrypoint /bin/sh <image name>`
 2. Run `uname -a` in the container

--- a/docker-images/cadvisor/README.md
+++ b/docker-images/cadvisor/README.md
@@ -4,20 +4,25 @@ Learn more about the Sourcegraph cAdvisor distribution in the [cAdvisor document
 
 ## Updating the image
 
-This image **is not** currently built by CI and errors that can break builds may go undetected. This is already under the attention of the dev-experience team.
+The base images for cAdvisor are hosted on [gcr.io/cadvisor/cadvisor](https://gcr.io/cadvisor/cadvisor). Note that the images are not tagged by architecture. Historically, the image with the version tag (e.g. `v0.46.0`) is a multi-arch image which you can verify by selecting it and viewing the manifest. It should contain information about supported architectures, including:
 
-The base images for cadvisor are hosted in gcr.io/cadvisor/cadvisor. Note that the images are not tagged by architecture, and just using `docker pull gcr.io/cadvisor/cadvisor:v0.XX.0` to get the digest **will likely return an image for the wrong architecture**!
+```
+"platform": {
+  "architecture": "amd64",
+  "os": "linux"
+}
+```
 
-Look through the [recently released images](https://console.cloud.google.com/gcr/images/cadvisor/GLOBAL/cadvisor) and manually identify the image for the correct architecture:
+You can also verify this manually:
 
-1. Exec in the container with `docker run -it --entrypoint /bin/sh <image name>`
+1. Exec in the container with `docker run -it --entrypoint /bin/sh --platform linux/x86_64 <image name>`  (note that `--platform linux/x86_64` is required on Arm-based Macs to ensure it pulls the correct image)
 2. Run `uname -a` in the container
 3. Ensure it's `x86_64` architecture.
 
 For example:
 
 ```
-docker run -it --entrypoint /bin/sh gcr.io/cadvisor/cadvisor@sha256:8938726fe00fd7a3889f7c4fb50a54b728f1d02fb5f6cbdbea604824ad11ff3f
+docker run -it --entrypoint /bin/sh --platform linux/x86_64 gcr.io/cadvisor/cadvisor@sha256:8938726fe00fd7a3889f7c4fb50a54b728f1d02fb5f6cbdbea604824ad11ff3f
 Unable to find image 'gcr.io/cadvisor/cadvisor@sha256:8938726fe00fd7a3889f7c4fb50a54b728f1d02fb5f6cbdbea604824ad11ff3f' locally
 gcr.io/cadvisor/cadvisor@sha256:8938726fe00fd7a3889f7c4fb50a54b728f1d02fb5f6cbdbea604824ad11ff3f: Pulling from cadvisor/cadvisor
 df9b9388f04a: Already exists
@@ -31,3 +36,7 @@ Status: Downloaded newer image for gcr.io/cadvisor/cadvisor@sha256:8938726fe00fd
 / # uname -a
 Linux c74b74199c86 5.10.104-linuxkit #1 SMP Thu Mar 17 17:08:06 UTC 2022 x86_64 Linux
 ```
+
+To update sourcegraph/cadvisor, modify by the digest in the Dockerfile's `FROM:` line to the digest of the multi-arch image you identified above, and update the `com.sourcegraph.cadvisor.version` label.
+
+The image is built by Buildkite CI, so after merging it will be built and deployed automatically.

--- a/docker-images/cadvisor/README.md
+++ b/docker-images/cadvisor/README.md
@@ -15,7 +15,7 @@ The base images for cAdvisor are hosted on [gcr.io/cadvisor/cadvisor](https://gc
 
 You can also verify this manually:
 
-1. Exec in the container with `docker run -it --entrypoint /bin/sh --platform linux/x86_64 <image name>`  (note that `--platform linux/x86_64` is required on Arm-based Macs to ensure it pulls the correct image)
+1. Exec in the container with `docker run -it --entrypoint /bin/sh --platform linux/x86_64 <image name>` (note that `--platform linux/x86_64` is required on Arm-based Macs to ensure it pulls the correct image)
 2. Run `uname -a` in the container
 3. Ensure it's `x86_64` architecture.
 


### PR DESCRIPTION
Update readme to raise the architecture issue - the current digest pulls an aarch64 image, does this break anything in the current build?

@indradhanush I noticed that your [previous commit](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/commit/5d6d8d69885070137fe5c53f09d49d5c6535e479?visible=1) only updates the `com.sourcegraph.cadvisor.version` label and not the actual base image, so we were still running v0.45.0. The upgrading instructions weren't very clear so I've hopefully improved them - lmk what you think!

Updating to v0.46.0 fixes CVE-2022-40674 which is a nice little win, and how I noticed the discrepency.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- [ ] Run locally
- [ ] Check for additional testing required