### PR TITLE
bump zoekt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -229,7 +229,7 @@ require (
 )
 
 require (
-	github.com/sourcegraph/zoekt v0.0.0-20221206194847-ec7da2382965
+	github.com/sourcegraph/zoekt v0.0.0-20221209103205-c301e5c82b6e
 	github.com/stretchr/objx v0.5.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2115,8 +2115,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20221206194847-ec7da2382965 h1:6yexxU0iuoBAbDmfORX7H8uBwGnTZEPCxigRu+SzVYA=
-github.com/sourcegraph/zoekt v0.0.0-20221206194847-ec7da2382965/go.mod h1:02oPEMQB2Rd74q+/BJFmyzjuNBTjv0OJbxpuw5GROXo=
+github.com/sourcegraph/zoekt v0.0.0-20221209103205-c301e5c82b6e h1:PcPZwloIMI1LbZjHYwYr38m7MXZtDXaWIlXUa8azJKQ=
+github.com/sourcegraph/zoekt v0.0.0-20221209103205-c301e5c82b6e/go.mod h1:MoGvSaF4Te3ciCtm93lqPmuLNvSKew4krlX/K/0POfQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
- 656906c9dd go get github.com/sourcegraph/log@main
- 9899a9b3f4 shards: introduce loaded.ready field
- cfd410d245 shards: implement markReady on shardedSearcher
- 4f8bcd5bed log: different msg depending on ctx error
- 16127e9492 Exclude files in search.largeFiles
- 788ed5c1d8 indexserver: don't exit if socket connection fails
- c301e5c82b indexserver: add endpoint /debug/reindex



## Test plan
Zoekt-CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
