### PR TITLE
CodeMirror blob: enable lazy highlighting

### DIFF
--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -140,10 +140,10 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
         !enableSelectionDrivenCodeNavigation &&
         (isLegacyLinkDrivenFeatureFlagEnabled || experimentalCodeNavigation === 'link-driven')
 
-    const lineOrRange = useMemo(() => parseQueryAndHash(props.location.search, props.location.hash), [
-        props.location.search,
-        props.location.hash,
-    ])
+    const lineOrRange = useMemo(
+        () => parseQueryAndHash(props.location.search, props.location.hash),
+        [props.location.search, props.location.hash]
+    )
 
     // Log view event whenever a new Blob, or a Blob with a different render mode, is visited.
     useEffect(() => {

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -140,10 +140,10 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
         !enableSelectionDrivenCodeNavigation &&
         (isLegacyLinkDrivenFeatureFlagEnabled || experimentalCodeNavigation === 'link-driven')
 
-    const lineOrRange = useMemo(
-        () => parseQueryAndHash(props.location.search, props.location.hash),
-        [props.location.search, props.location.hash]
-    )
+    const lineOrRange = useMemo(() => parseQueryAndHash(props.location.search, props.location.hash), [
+        props.location.search,
+        props.location.hash,
+    ])
 
     // Log view event whenever a new Blob, or a Blob with a different render mode, is visited.
     useEffect(() => {
@@ -197,17 +197,9 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
      * so the user has useful content rather than a loading spinner
      */
     const formattedBlobInfoOrError = useObservable(
-        useMemo(() => {
-            // Note: Lazy syntax highlighting is currently buggy in CodeMirror.
-            // GitHub issue to fix: https://github.com/sourcegraph/sourcegraph/issues/41413
-            if (!enableLazyBlobSyntaxHighlighting || enableCodeMirror) {
-                return of(undefined)
-            }
-
-            return createActiveSpan(
-                reactManualTracer,
-                { name: 'formattedBlobInfoOrError', parentSpan: span },
-                fetchSpan =>
+        useMemo(
+            () =>
+                createActiveSpan(reactManualTracer, { name: 'formattedBlobInfoOrError', parentSpan: span }, fetchSpan =>
                     fetchBlob({
                         repoName,
                         revision,
@@ -238,8 +230,9 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
                             return blobInfo
                         })
                     )
-            )
-        }, [enableCodeMirror, enableLazyBlobSyntaxHighlighting, filePath, mode, repoName, revision, span])
+                ),
+            [filePath, mode, repoName, revision, span]
+        )
     )
 
     // Bundle latest blob with all other file info to pass to `Blob`

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -26,7 +26,7 @@ import { blobPropsFacet } from './codemirror'
 import { showBlameGutter, showGitBlameDecorations } from './codemirror/blame-decorations'
 import { syntaxHighlight } from './codemirror/highlight'
 import { pin, updatePin } from './codemirror/hovercard'
-import { selectableLineNumbers, SelectedLineRange, selectLines } from './codemirror/linenumbers'
+import { selectableLineNumbers, SelectedLineRange, selectLines, shouldScrollIntoView } from './codemirror/linenumbers'
 import { navigateToLineOnAnyClickExtension } from './codemirror/navigate-to-any-line-on-click'
 import { search } from './codemirror/search'
 import { sourcegraphExtensions } from './codemirror/sourcegraph-extensions'
@@ -214,13 +214,9 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
             blobPropsCompartment.of(blobProps),
             blameDecorationsCompartment.of(blameDecorations),
             blameVisibilityCompartment.of(blameVisibility),
-<<<<<<< HEAD
-            settingsCompartment.of(settings),
             navigateToLineOnAnyClick ? navigateToLineOnAnyClickExtension : [],
-=======
             settingsCompartment.of(themeSettings),
             wrapCodeCompartment.of(wrapCodeSettings),
->>>>>>> 0a15ef1e6e (Fix #41413 preserve scroll position when wrapping code)
             search({
                 // useFileSearch is not a dependency because the search
                 // extension manages its own state. This is just the initial

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -129,9 +129,10 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
     const themeSettings = useMemo(() => EditorView.darkTheme.of(isLightTheme === false), [isLightTheme])
     const wrapCodeSettings = useMemo<Extension>(() => (wrapCode ? EditorView.lineWrapping : []), [wrapCode])
 
-    const blameVisibility = useMemo(() => (isBlameVisible ? [showBlameGutter.of(isBlameVisible)] : []), [
-        isBlameVisible,
-    ])
+    const blameVisibility = useMemo(
+        () => (isBlameVisible ? [showBlameGutter.of(isBlameVisible)] : []),
+        [isBlameVisible]
+    )
     const blameDecorations = useMemo(
         () => (isBlameVisible && blameHunks?.current ? [showGitBlameDecorations.of(blameHunks.current)] : []),
         [isBlameVisible, blameHunks]

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -5,7 +5,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
 import { openSearchPanel } from '@codemirror/search'
-import { Compartment, EditorState, Extension } from '@codemirror/state'
+import { Compartment, EditorState, Extension, Line } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
 import { isEqual } from 'lodash'
 
@@ -88,6 +88,8 @@ const blameVisibilityCompartment = new Compartment()
 const blameDecorationsCompartment = new Compartment()
 // Compartment for propagating component props
 const blobPropsCompartment = new Compartment()
+// Compartment for line wrapping.
+const wrapCodeCompartment = new Compartment()
 
 export const Blob: React.FunctionComponent<BlobProps> = props => {
     const {
@@ -124,15 +126,12 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
 
     const blobProps = useMemo(() => blobPropsFacet.of(props), [props])
 
-    const settings = useMemo(
-        () => [wrapCode ? EditorView.lineWrapping : [], EditorView.darkTheme.of(isLightTheme === false)],
-        [wrapCode, isLightTheme]
-    )
+    const themeSettings = useMemo(() => EditorView.darkTheme.of(isLightTheme === false), [isLightTheme])
+    const wrapCodeSettings = useMemo<Extension>(() => (wrapCode ? EditorView.lineWrapping : []), [wrapCode])
 
-    const blameVisibility = useMemo(
-        () => (isBlameVisible ? [showBlameGutter.of(isBlameVisible)] : []),
-        [isBlameVisible]
-    )
+    const blameVisibility = useMemo(() => (isBlameVisible ? [showBlameGutter.of(isBlameVisible)] : []), [
+        isBlameVisible,
+    ])
     const blameDecorations = useMemo(
         () => (isBlameVisible && blameHunks?.current ? [showGitBlameDecorations.of(blameHunks.current)] : []),
         [isBlameVisible, blameHunks]
@@ -214,8 +213,13 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
             blobPropsCompartment.of(blobProps),
             blameDecorationsCompartment.of(blameDecorations),
             blameVisibilityCompartment.of(blameVisibility),
+<<<<<<< HEAD
             settingsCompartment.of(settings),
             navigateToLineOnAnyClick ? navigateToLineOnAnyClickExtension : [],
+=======
+            settingsCompartment.of(themeSettings),
+            wrapCodeCompartment.of(wrapCodeSettings),
+>>>>>>> 0a15ef1e6e (Fix #41413 preserve scroll position when wrapping code)
             search({
                 // useFileSearch is not a dependency because the search
                 // extension manages its own state. This is just the initial
@@ -301,15 +305,33 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [blameDecorations])
 
-    // Update settings
+    // Update theme
     useEffect(() => {
         if (editor) {
-            editor.dispatch({ effects: settingsCompartment.reconfigure(settings) })
+            editor.dispatch({ effects: settingsCompartment.reconfigure(themeSettings) })
         }
         // editor is not provided because this should only be triggered after the
         // editor was created (i.e. not on first render)
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [settings])
+    }, [themeSettings])
+
+    // Update line wrapping
+    useEffect(() => {
+        if (editor) {
+            const effects = [wrapCodeCompartment.reconfigure(wrapCodeSettings)]
+            const firstLine = firstVisibleLine(editor)
+            if (firstLine) {
+                // Avoid jumpy scrollbar when enabling line wrapping by forcing the
+                // scroll bar to preserve the top line number that's visible.
+                // Details https://github.com/sourcegraph/sourcegraph/issues/41413
+                effects.push(EditorView.scrollIntoView(firstLine.from, { y: 'start' }))
+            }
+            editor.dispatch({ effects })
+        }
+        // editor is not provided because this should only be triggered after the
+        // editor was created (i.e. not on first render)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [wrapCodeSettings])
 
     // Update selected lines when URL changes
     useEffect(() => {
@@ -375,4 +397,25 @@ function useDistinctBlob(blobInfo: BlobInfo): BlobInfo {
         }
         return blobRef.current
     }, [blobInfo])
+}
+
+// Returns the first line that is visible in the editor. We can't directly use
+// the viewport for this functionality because the viewport includes lines that
+// are rendered but not visible.
+function firstVisibleLine(view: EditorView): Line | undefined {
+    for (const { from, to } of view.visibleRanges) {
+        for (let pos = from; pos < to; ) {
+            const line = view.state.doc.lineAt(pos)
+            // This may be an inefficient way to detect the first visible line
+            // but it appears to work correctly and this is unlikely to be a
+            // performance bottleneck since we should only use need to compute
+            // this for infrequently used code-paths like when enabling/disabling
+            // line wrapping, or when lazy syntax highlighting gets loaded.
+            if (!shouldScrollIntoView(view, { line: line.number + 1 })) {
+                return line
+            }
+            pos = line.to + 1
+        }
+    }
+    return undefined
 }


### PR DESCRIPTION
Fixes #41413

Previously, we didn't enable lazy highlighting for the CodeMirror blob view because the code would jump when line wrapping was enabled/disabled. This PR fixes the issue by finding the top visible line and forcing the editor to scroll that line at the top. This bugfix makes it possible to enable lazy syntax highlighting for the CodeMirror blob view.

## Test plan

Use the following settings
```
  "experimentalFeatures": {
    "enableCodeMirrorFileView": true,
    "enableLazyBlobSyntaxHighlighting": true
  },
```

Make the browser window narrow so that enabling line wrapping will make lines wrap. Next, open the URL https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/enterprise/internal/database/mocks_temp.go?L7829

* Confirm that the file loads first without syntax highlighting
* Confirm that the the code does not jump when the syntax highlighting loads (confirm with line wrapping enabled and disabled)
* Confirm that manually enabling/disabling line wrapping keeps the top line focused (see demo below). It's unavoidable that some lines jump because we have to make vertical space for the wrapped lines but we can at least guarantee that the top visible line stays stable. There's an edge case where only half of the vertical height of the top line is visible, in which case the scroll jumps half the height of a single line. I don't think this edge case is a blocking issue.


![CleanShot 2022-12-09 at 13 00 38](https://user-images.githubusercontent.com/1408093/206700510-2f09bcdb-85ff-4524-bd8d-7010e2d35332.gif)


<!-- All pull requests REQUIRE
 a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-lazy-cm.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
