### PR TITLE
webhooks: Add deprecation notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ All notable changes to Sourcegraph are documented in this file.
 - A new status message now reports how many repositories have already been indexed for search. [#45246](https://github.com/sourcegraph/sourcegraph/pull/45246)
 - Search contexts can now be starred (favorited) in the search context management page. Starred search contexts will appear first in the context dropdown menu next to the search box. [#45230](https://github.com/sourcegraph/sourcegraph/pull/45230)
 - [search.largeFiles](https://docs.sourcegraph.com/admin/config/site_config#search-largeFiles) accepts an optional prefix `!` to negate a pattern. The order of the patterns within search.largeFiles is honored such that the last pattern matching overrides preceding patterns. For patterns that begin with a literal `!` prefix with a backslash, for example, `\!fileNameStartsWithExcl!.txt`. Previously indexed files that become excluded due to this change will remain in the index until the next reindex [#45318](https://github.com/sourcegraph/sourcegraph/pull/45318)
-- New [admin interface](http://localhost:5080/admin/config/webhooks) for webhooks added. Webhooks that were added via code host configuration are [deprecated](https://docs.sourcegraph.com/admin/config/webhooks#deprecation-notice) and will be removed in 4.6.0.
-- Added support for receiving webhook `push` events from GitHub to respond more quickly when code is committed.
+- [Webhooks](https://docs.sourcegraph.com/admin/config/webhooks) have been overhauled completely and can now be found under **Site admin > Repositories > Incoming webhooks**. Webhooks that were added via code host configuration are [deprecated](https://docs.sourcegraph.com/admin/config/webhooks#deprecation-notice) and will be removed in 4.6.0.
+- Added support for receiving webhook `push` events from GitHub which will trigger Sourcegraph to fetch the latest commit rather than relying on polling.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to Sourcegraph are documented in this file.
 - A new status message now reports how many repositories have already been indexed for search. [#45246](https://github.com/sourcegraph/sourcegraph/pull/45246)
 - Search contexts can now be starred (favorited) in the search context management page. Starred search contexts will appear first in the context dropdown menu next to the search box. [#45230](https://github.com/sourcegraph/sourcegraph/pull/45230)
 - [search.largeFiles](https://docs.sourcegraph.com/admin/config/site_config#search-largeFiles) accepts an optional prefix `!` to negate a pattern. The order of the patterns within search.largeFiles is honored such that the last pattern matching overrides preceding patterns. For patterns that begin with a literal `!` prefix with a backslash, for example, `\!fileNameStartsWithExcl!.txt`. Previously indexed files that become excluded due to this change will remain in the index until the next reindex [#45318](https://github.com/sourcegraph/sourcegraph/pull/45318)
+- New [admin interface](http://localhost:5080/admin/config/webhooks) for webhooks added. Webhooks that were added via code host configuration are [deprecated](https://docs.sourcegraph.com/admin/config/webhooks#deprecation-notice) and will be removed in 4.6.0.
+- Added support for receiving webhook `push` events from GitHub to respond more quickly when code is committed.
 
 ### Changed
 

--- a/client/web/src/components/externalServices/ExternalServiceWebhook.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceWebhook.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Alert, Link, H3, Text } from '@sourcegraph/wildcard'
+import { Alert, Link, H3, Text, H4 } from '@sourcegraph/wildcard'
 
 import { ExternalServiceFields, ExternalServiceKind } from '../../graphql-operations'
 import { CopyableText } from '../CopyableText'
@@ -59,6 +59,12 @@ export const ExternalServiceWebhook: React.FunctionComponent<React.PropsWithChil
     return (
         <Alert variant="info" className={className}>
             <H3>Batch changes webhooks</H3>
+            <H4>
+                Adding webhooks via code host connections has been{' '}
+                <Link to="https://docs.sourcegraph.com/admin/config/webhooks" target="_blank" rel="noopener noreferrer">
+                    deprecated.
+                </Link>
+            </H4>
             {description}
             <CopyableText className="mb-2" text={webhookURL} size={webhookURL.length} />
             <Text className="mb-0">

--- a/client/web/src/components/externalServices/ExternalServiceWebhook.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceWebhook.tsx
@@ -61,11 +61,7 @@ export const ExternalServiceWebhook: React.FunctionComponent<React.PropsWithChil
             <H3>Batch changes webhooks</H3>
             <H4>
                 Adding webhooks via code host connections has been{' '}
-                <Link
-                    to="https://docs.sourcegraph.com/admin/config/webhooks#deprecation-notice"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                >
+                <Link to="/help/admin/config/webhooks#deprecation-notice" target="_blank" rel="noopener noreferrer">
                     deprecated.
                 </Link>
             </H4>

--- a/client/web/src/components/externalServices/ExternalServiceWebhook.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceWebhook.tsx
@@ -61,7 +61,11 @@ export const ExternalServiceWebhook: React.FunctionComponent<React.PropsWithChil
             <H3>Batch changes webhooks</H3>
             <H4>
                 Adding webhooks via code host connections has been{' '}
-                <Link to="https://docs.sourcegraph.com/admin/config/webhooks#deprecation-notice" target="_blank" rel="noopener noreferrer">
+                <Link
+                    to="https://docs.sourcegraph.com/admin/config/webhooks#deprecation-notice"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
                     deprecated.
                 </Link>
             </H4>

--- a/client/web/src/components/externalServices/ExternalServiceWebhook.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceWebhook.tsx
@@ -61,7 +61,7 @@ export const ExternalServiceWebhook: React.FunctionComponent<React.PropsWithChil
             <H3>Batch changes webhooks</H3>
             <H4>
                 Adding webhooks via code host connections has been{' '}
-                <Link to="https://docs.sourcegraph.com/admin/config/webhooks" target="_blank" rel="noopener noreferrer">
+                <Link to="https://docs.sourcegraph.com/admin/config/webhooks#deprecation-notice" target="_blank" rel="noopener noreferrer">
                     deprecated.
                 </Link>
             </H4>

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2791,7 +2791,10 @@ type ExternalService implements Node {
         Only include webhook logs on or before this time.
         """
         until: DateTime
-    ): WebhookLogConnection! @deprecated(reason: "Webhook logs linked directly to an external service will be removed. See https://docs.sourcegraph.com/admin/config/webhooks")
+    ): WebhookLogConnection!
+        @deprecated(
+            reason: "Webhook logs linked directly to an external service will be removed. See https://docs.sourcegraph.com/admin/config/webhooks"
+        )
 
     """
     The list of recent sync jobs for this external service.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2763,6 +2763,8 @@ type ExternalService implements Node {
     Returns recently received webhooks on this external service.
 
     Only site admins may access this field.
+
+    DEPRECATED: Webhook logs linked directly to an external service will be removed. See https://docs.sourcegraph.com/admin/config/webhooks
     """
     webhookLogs(
         """
@@ -2789,7 +2791,7 @@ type ExternalService implements Node {
         Only include webhook logs on or before this time.
         """
         until: DateTime
-    ): WebhookLogConnection!
+    ): WebhookLogConnection! @deprecated(reason: "Webhook logs linked directly to an external service will be removed. See https://docs.sourcegraph.com/admin/config/webhooks")
 
     """
     The list of recent sync jobs for this external service.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2764,7 +2764,7 @@ type ExternalService implements Node {
 
     Only site admins may access this field.
 
-    DEPRECATED: Webhook logs linked directly to an external service will be removed. See https://docs.sourcegraph.com/admin/config/webhooks
+    DEPRECATED: Webhook logs linked directly to an external service will be removed. See https://docs.sourcegraph.com/admin/config/webhooks#deprecation-notice
     """
     webhookLogs(
         """
@@ -2793,7 +2793,7 @@ type ExternalService implements Node {
         until: DateTime
     ): WebhookLogConnection!
         @deprecated(
-            reason: "Webhook logs linked directly to an external service will be removed. See https://docs.sourcegraph.com/admin/config/webhooks"
+            reason: "Webhook logs linked directly to an external service will be removed. See https://docs.sourcegraph.com/admin/config/webhooks#deprecation-notice"
         )
 
     """

--- a/schema/bitbucket_cloud.schema.json
+++ b/schema/bitbucket_cloud.schema.json
@@ -112,7 +112,7 @@
     },
     "webhookSecret": {
       "description": "A shared secret used to authenticate incoming webhooks (minimum 12 characters).",
-      "deprecationMessage": "Deprecated in favour of first class webhooks. See https://docs.sourcegraph.com/admin/config/webhooks",
+      "deprecationMessage": "Deprecated in favour of first class webhooks. See https://docs.sourcegraph.com/admin/config/webhooks#deprecation-notice",
       "type": "string",
       "minLength": 12
     }

--- a/schema/bitbucket_cloud.schema.json
+++ b/schema/bitbucket_cloud.schema.json
@@ -112,6 +112,7 @@
     },
     "webhookSecret": {
       "description": "A shared secret used to authenticate incoming webhooks (minimum 12 characters).",
+      "deprecationMessage": "Deprecated in favour of first class webhooks. See https://docs.sourcegraph.com/admin/config/webhooks",
       "type": "string",
       "minLength": 12
     }

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -100,7 +100,7 @@
       "properties": {
         "webhooks": {
           "title": "BitbucketServerPluginWebhooks",
-          "deprecationMessage": "Deprecated in favour of first class webhooks. See https://docs.sourcegraph.com/admin/config/webhooks",
+          "deprecationMessage": "Deprecated in favour of first class webhooks. See https://docs.sourcegraph.com/admin/config/webhooks#deprecation-notice",
           "type": "object",
           "required": ["secret"],
           "properties": {

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -100,6 +100,7 @@
       "properties": {
         "webhooks": {
           "title": "BitbucketServerPluginWebhooks",
+          "deprecationMessage": "Deprecated in favour of first class webhooks. See https://docs.sourcegraph.com/admin/config/webhooks",
           "type": "object",
           "required": ["secret"],
           "properties": {

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -73,7 +73,7 @@
     },
     "webhooks": {
       "description": "An array of configurations defining existing GitHub webhooks that send updates back to Sourcegraph.",
-      "deprecationMessage": "Deprecated in favour of first class webhooks. See https://docs.sourcegraph.com/admin/config/webhooks",
+      "deprecationMessage": "Deprecated in favour of first class webhooks. See https://docs.sourcegraph.com/admin/config/webhooks#deprecation-notice",
       "type": "array",
       "items": {
         "type": "object",

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -73,6 +73,7 @@
     },
     "webhooks": {
       "description": "An array of configurations defining existing GitHub webhooks that send updates back to Sourcegraph.",
+      "deprecationMessage": "Deprecated in favour of first class webhooks. See https://docs.sourcegraph.com/admin/config/webhooks",
       "type": "array",
       "items": {
         "type": "object",

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -193,6 +193,7 @@
     },
     "webhooks": {
       "description": "An array of webhook configurations",
+      "deprecationMessage": "Deprecated in favour of first class webhooks. See https://docs.sourcegraph.com/admin/config/webhooks",
       "type": "array",
       "items": {
         "type": "object",

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -193,7 +193,7 @@
     },
     "webhooks": {
       "description": "An array of webhook configurations",
-      "deprecationMessage": "Deprecated in favour of first class webhooks. See https://docs.sourcegraph.com/admin/config/webhooks",
+      "deprecationMessage": "Deprecated in favour of first class webhooks. See https://docs.sourcegraph.com/admin/config/webhooks#deprecation-notice",
       "type": "array",
       "items": {
         "type": "object",


### PR DESCRIPTION
- Add deprecation message to external service config
- Deprecate WebhookLogs field on ExternalService
- Add deprecation notice to batch changes webhook banner
- Update CHANGELOG

Closes https://github.com/sourcegraph/sourcegraph/issues/43569

## Test plan

Only docs and schema changes
