### PR TITLE
executors: Add support for private docker registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to Sourcegraph are documented in this file.
 - [search.largeFiles](https://docs.sourcegraph.com/admin/config/site_config#search-largeFiles) accepts an optional prefix `!` to negate a pattern. The order of the patterns within search.largeFiles is honored such that the last pattern matching overrides preceding patterns. For patterns that begin with a literal `!` prefix with a backslash, for example, `\!fileNameStartsWithExcl!.txt`. Previously indexed files that become excluded due to this change will remain in the index until the next reindex [#45318](https://github.com/sourcegraph/sourcegraph/pull/45318)
 - [Webhooks](https://docs.sourcegraph.com/admin/config/webhooks) have been overhauled completely and can now be found under **Site admin > Repositories > Incoming webhooks**. Webhooks that were added via code host configuration are [deprecated](https://docs.sourcegraph.com/admin/config/webhooks#deprecation-notice) and will be removed in 4.6.0.
 - Added support for receiving webhook `push` events from GitHub which will trigger Sourcegraph to fetch the latest commit rather than relying on polling.
+- Added support for private container registries in Sourcegraph executors. [Using private registries](https://docs.sourcegraph.com/admin/deploy_executors#using-private-registries)
 
 ### Changed
 

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -11,17 +11,17 @@ import styles from './BatchChangesListIntro.module.scss'
 export const BatchChangesChangelogAlert: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => (
     <DismissibleAlert
         className={styles.batchChangesListIntroAlert}
-        partialStorageKey="batch-changes-list-intro-changelog-4.3"
+        partialStorageKey="batch-changes-list-intro-changelog-4.4"
     >
         <Card className={classNames(styles.batchChangesListIntroCard, 'h-100')}>
             <CardBody>
-                <H4 as={H3}>Batch Changes updates in version 4.3</H4>
+                <H4 as={H3}>Batch Changes updates in version 4.4</H4>
                 <ul className="mb-0 pl-3">
                     <li>
-                        <Link to="/help/batch_changes/how-tos/server_side_file_mounts" rel="noopener" target="_blank">
-                            Mounted files
+                        <Link to="/help/admin/deploy_executors#using-private-registries" rel="noopener" target="_blank">
+                            Using private container registries
                         </Link>{' '}
-                        are now accessible via the UI.
+                        is now supported in server-side batch changes.
                     </li>
                 </ul>
             </CardBody>

--- a/client/web/src/enterprise/executors/secrets/AddSecretModal.story.tsx
+++ b/client/web/src/enterprise/executors/secrets/AddSecretModal.story.tsx
@@ -36,3 +36,20 @@ export const GitHub: Story = () => (
 )
 
 GitHub.storyName = 'Add secret'
+
+export const DockerAuthConfig: Story = () => (
+    <WebStory>
+        {props => (
+            <AddSecretModal
+                {...props}
+                namespaceID="user-id-1"
+                scope={ExecutorSecretScope.BATCHES}
+                afterCreate={noop}
+                onCancel={noop}
+                initialKey="DOCKER_AUTH_CONFIG"
+            />
+        )}
+    </WebStory>
+)
+
+DockerAuthConfig.storyName = 'Docker auth config'

--- a/client/web/src/enterprise/executors/secrets/AddSecretModal.tsx
+++ b/client/web/src/enterprise/executors/secrets/AddSecretModal.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from 'react'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { logger } from '@sourcegraph/common'
-import { Button, Modal, Input, H3, Text, Alert } from '@sourcegraph/wildcard'
+import { Button, Modal, Input, H3, Text, Alert, Link } from '@sourcegraph/wildcard'
 
 import { LoaderButton } from '../../../components/LoaderButton'
 import { ExecutorSecretScope, Scalars } from '../../../graphql-operations'
@@ -85,7 +85,15 @@ export const AddSecretModal: React.FunctionComponent<React.PropsWithChildren<Add
                         message={
                             <>
                                 Must be uppercase characters, digits and underscores only. Must start with an uppercase
-                                character. DOCKER_AUTH_CONFIG will be used to authenticate with private registries.
+                                character.{' '}
+                                <Link
+                                    to="/help/admin/deploy_executors#using-private-registries"
+                                    rel="noopener"
+                                    target="_blank"
+                                >
+                                    DOCKER_AUTH_CONFIG will be used to authenticate with private registries.
+                                </Link>
+                                .
                             </>
                         }
                         label="Key"

--- a/client/web/src/enterprise/executors/secrets/AddSecretModal.tsx
+++ b/client/web/src/enterprise/executors/secrets/AddSecretModal.tsx
@@ -15,6 +15,9 @@ export interface AddSecretModalProps {
     afterCreate: () => void
     namespaceID: Scalars['ID'] | null
     scope: ExecutorSecretScope
+
+    /** For testing only */
+    initialKey?: string
 }
 
 export const AddSecretModal: React.FunctionComponent<React.PropsWithChildren<AddSecretModalProps>> = ({
@@ -22,10 +25,11 @@ export const AddSecretModal: React.FunctionComponent<React.PropsWithChildren<Add
     afterCreate,
     namespaceID,
     scope,
+    initialKey = '',
 }) => {
     const labelId = 'addSecret'
 
-    const [key, setKey] = useState<string>('')
+    const [key, setKey] = useState<string>(initialKey)
     const onChangeKey = useCallback<React.ChangeEventHandler<HTMLInputElement>>(event => {
         setKey(event.target.value)
     }, [])
@@ -91,7 +95,7 @@ export const AddSecretModal: React.FunctionComponent<React.PropsWithChildren<Add
                                     rel="noopener"
                                     target="_blank"
                                 >
-                                    DOCKER_AUTH_CONFIG will be used to authenticate with private registries.
+                                    DOCKER_AUTH_CONFIG will be used to authenticate with private registries
                                 </Link>
                                 .
                             </>

--- a/client/web/src/enterprise/executors/secrets/AddSecretModal.tsx
+++ b/client/web/src/enterprise/executors/secrets/AddSecretModal.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from 'react'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { logger } from '@sourcegraph/common'
-import { Button, Modal, Input, H3, Text } from '@sourcegraph/wildcard'
+import { Button, Modal, Input, H3, Text, Alert } from '@sourcegraph/wildcard'
 
 import { LoaderButton } from '../../../components/LoaderButton'
 import { ExecutorSecretScope, Scalars } from '../../../graphql-operations'
@@ -85,11 +85,17 @@ export const AddSecretModal: React.FunctionComponent<React.PropsWithChildren<Add
                         message={
                             <>
                                 Must be uppercase characters, digits and underscores only. Must start with an uppercase
-                                character.
+                                character. DOCKER_AUTH_CONFIG will be used to authenticate with private registries.
                             </>
                         }
                         label="Key"
                     />
+                    {key === 'DOCKER_AUTH_CONFIG' && (
+                        <Alert variant="info" className="mt-2">
+                            This secret value will be used to configure docker client authentication with private
+                            registries.
+                        </Alert>
+                    )}
                 </div>
                 <div className="form-group">
                     <Input

--- a/client/web/src/enterprise/executors/secrets/ExecutorSecretNode.tsx
+++ b/client/web/src/enterprise/executors/secrets/ExecutorSecretNode.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useRef, useState } from 'react'
 
+import { mdiDocker, mdiLock } from '@mdi/js'
 import classNames from 'classnames'
-import LockIcon from 'mdi-react/LockIcon'
 
-import { Badge, Button, Icon, H3, Link, Text } from '@sourcegraph/wildcard'
+import { Badge, Button, Icon, H3, Link, Text, Tooltip } from '@sourcegraph/wildcard'
 
 import { ExecutorSecretFields, Scalars } from '../../../graphql-operations'
 
@@ -62,7 +62,19 @@ export const ExecutorSecretNode: React.FunctionComponent<React.PropsWithChildren
                 >
                     <div className="d-flex align-items-center">
                         <H3 className="text-nowrap mb-0 mr-2">
-                            <Icon className="mx-2" aria-hidden={true} as={LockIcon} /> {node.key}
+                            {node.key === 'DOCKER_AUTH_CONFIG' ? (
+                                <Tooltip content="This secret value will be used to configure docker client authentication with private registries.">
+                                    <Icon
+                                        className="mx-2"
+                                        svgPath={mdiDocker}
+                                        aria-label="This secret value will be used to configure docker client authentication with
+                                    private registries."
+                                    />
+                                </Tooltip>
+                            ) : (
+                                <Icon className="mx-2" aria-hidden={true} svgPath={mdiLock} />
+                            )}{' '}
+                            {node.key}
                         </H3>
                         {node.namespace === null && (
                             <span>

--- a/client/web/src/enterprise/executors/secrets/ExecutorSecretsListPage.story.tsx
+++ b/client/web/src/enterprise/executors/secrets/ExecutorSecretsListPage.story.tsx
@@ -43,7 +43,7 @@ const EXECUTOR_SECRET_LIST_MOCK: MockedResponse<UserExecutorSecretsResult> = {
                 __typename: 'User',
                 executorSecrets: {
                     pageInfo: { hasNextPage: false, endCursor: null },
-                    totalCount: 4,
+                    totalCount: 5,
                     nodes: [
                         // Global secret.
                         {
@@ -121,6 +121,24 @@ const EXECUTOR_SECRET_LIST_MOCK: MockedResponse<UserExecutorSecretsResult> = {
                                 namespaceName: 'jdoe',
                                 url: '/users/jdoe',
                             },
+                            overwritesGlobalSecret: false,
+                            scope: ExecutorSecretScope.BATCHES,
+                            createdAt: subDays(new Date(), 1).toISOString(),
+                            updatedAt: subDays(new Date(), 1).toISOString(),
+                        },
+                        // Docker auth secret.
+                        {
+                            __typename: 'ExecutorSecret',
+                            id: 'secret5',
+                            creator: {
+                                __typename: 'User',
+                                id: 'user1',
+                                displayName: 'John Doe',
+                                url: '/users/jdoe',
+                                username: 'jdoe',
+                            },
+                            key: 'DOCKER_AUTH_CONFIG',
+                            namespace: null,
                             overwritesGlobalSecret: false,
                             scope: ExecutorSecretScope.BATCHES,
                             createdAt: subDays(new Date(), 1).toISOString(),

--- a/client/web/src/enterprise/executors/secrets/UpdateSecretModal.story.tsx
+++ b/client/web/src/enterprise/executors/secrets/UpdateSecretModal.story.tsx
@@ -51,3 +51,35 @@ export const Update: Story = () => (
         )}
     </WebStory>
 )
+
+export const DockerAuthConfig: Story = () => (
+    <WebStory>
+        {props => (
+            <UpdateSecretModal
+                {...props}
+                secret={{
+                    __typename: 'ExecutorSecret',
+                    id: 'secret1',
+                    creator: {
+                        __typename: 'User',
+                        username: 'test',
+                        displayName: 'Test user',
+                        id: 'testID',
+                        url: '/users/test',
+                    },
+                    key: 'DOCKER_AUTH_CONFIG',
+                    scope: ExecutorSecretScope.BATCHES,
+                    overwritesGlobalSecret: false,
+                    // Global secret.
+                    namespace: null,
+                    createdAt: subDays(new Date(), 1).toISOString(),
+                    updatedAt: subHours(new Date(), 12).toISOString(),
+                }}
+                onCancel={noop}
+                afterUpdate={noop}
+            />
+        )}
+    </WebStory>
+)
+
+DockerAuthConfig.storyName = 'Docker auth config'

--- a/client/web/src/enterprise/executors/secrets/UpdateSecretModal.tsx
+++ b/client/web/src/enterprise/executors/secrets/UpdateSecretModal.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from 'react'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { logger } from '@sourcegraph/common'
-import { Button, Modal, Input, H3, Text } from '@sourcegraph/wildcard'
+import { Button, Modal, Input, H3, Text, Alert } from '@sourcegraph/wildcard'
 
 import { LoaderButton } from '../../../components/LoaderButton'
 import { ExecutorSecretFields } from '../../../graphql-operations'
@@ -59,6 +59,11 @@ export const UpdateSecretModal: React.FunctionComponent<React.PropsWithChildren<
                 Executor secrets are available to executor jobs as environment variables. They will never appear in
                 logs.
             </Text>
+            {secret.key === 'DOCKER_AUTH_CONFIG' && (
+                <Alert variant="info" className="mt-2">
+                    This secret value will be used to configure docker client authentication with private registries.
+                </Alert>
+            )}
 
             {error && <ErrorAlert error={error} />}
 

--- a/client/web/src/enterprise/executors/secrets/UpdateSecretModal.tsx
+++ b/client/web/src/enterprise/executors/secrets/UpdateSecretModal.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from 'react'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { logger } from '@sourcegraph/common'
-import { Button, Modal, Input, H3, Text, Alert } from '@sourcegraph/wildcard'
+import { Button, Modal, Input, H3, Text, Alert, Link } from '@sourcegraph/wildcard'
 
 import { LoaderButton } from '../../../components/LoaderButton'
 import { ExecutorSecretFields } from '../../../graphql-operations'
@@ -61,7 +61,11 @@ export const UpdateSecretModal: React.FunctionComponent<React.PropsWithChildren<
             </Text>
             {secret.key === 'DOCKER_AUTH_CONFIG' && (
                 <Alert variant="info" className="mt-2">
-                    This secret value will be used to configure docker client authentication with private registries.
+                    This secret value will be used to{' '}
+                    <Link to="/help/admin/deploy_executors#using-private-registries" rel="noopener" target="_blank">
+                        configure docker client authentication with private registries
+                    </Link>
+                    .
                 </Alert>
             )}
 

--- a/cmd/frontend/graphqlbackend/executor_secrets.go
+++ b/cmd/frontend/graphqlbackend/executor_secrets.go
@@ -1,7 +1,9 @@
 package graphqlbackend
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"strings"
 
 	"github.com/grafana/regexp"
@@ -62,16 +64,17 @@ func (r *schemaResolver) CreateExecutorSecret(ctx context.Context, args CreateEx
 		return nil, errors.New("invalid key format, should be a valid env var name")
 	}
 
-	if len(args.Value) == 0 {
-		return nil, errors.New("value cannot be empty string")
-	}
-
 	secret := &database.ExecutorSecret{
 		Key:             args.Key,
 		CreatorID:       a.UID,
 		NamespaceUserID: userID,
 		NamespaceOrgID:  orgID,
 	}
+
+	if err := validateExecutorSecret(secret, args.Value); err != nil {
+		return nil, err
+	}
+
 	if err := store.Create(ctx, args.Scope.ToDatabaseScope(), secret, args.Value); err != nil {
 		if err == database.ErrDuplicateExecutorSecret {
 			return nil, &ErrDuplicateExecutorSecret{}
@@ -113,10 +116,6 @@ func (r *schemaResolver) UpdateExecutorSecret(ctx context.Context, args UpdateEx
 		return nil, errors.New("scope mismatch")
 	}
 
-	if len(args.Value) == 0 {
-		return nil, errors.New("value cannot be empty string")
-	}
-
 	store := r.db.ExecutorSecrets(keyring.Default().ExecutorSecretKey)
 
 	tx, err := store.Transact(ctx)
@@ -132,6 +131,10 @@ func (r *schemaResolver) UpdateExecutorSecret(ctx context.Context, args UpdateEx
 
 	// 🚨 SECURITY: Check namespace access.
 	if err := checkNamespaceAccess(ctx, r.db, secret.NamespaceUserID, secret.NamespaceOrgID); err != nil {
+		return nil, err
+	}
+
+	if err := validateExecutorSecret(secret, args.Value); err != nil {
 		return nil, err
 	}
 
@@ -282,4 +285,43 @@ func checkNamespaceAccess(ctx context.Context, db database.DB, namespaceUserID, 
 	}
 
 	return auth.CheckCurrentUserIsSiteAdmin(ctx, db)
+}
+
+func validateExecutorSecret(secret *database.ExecutorSecret, value string) error {
+	if len(value) == 0 {
+		return errors.New("value cannot be empty string")
+	}
+	// Validate a docker auth config is correctly formatted before storing it to avoid
+	// confusion and broken config.
+	if secret.Key == "DOCKER_AUTH_CONFIG" {
+		var dac dockerAuthConfig
+		if err := json.Unmarshal([]byte(value), &dac); err != nil {
+			return errors.Wrap(err, "failed to unmarshal docker auth config for validation")
+		}
+		if len(dac.CredHelpers) > 0 {
+			return errors.New("cannot use credential helpers in docker auth config set via secrets")
+		}
+		if dac.CredsStore != "" {
+			return errors.New("cannot use credential stores in docker auth config set via secrets")
+		}
+		for key, auth := range dac.Auths {
+			if !bytes.Contains(auth.Auth, []byte(":")) {
+				return errors.Newf("invalid credential in auths section for %q format has to be base64(username:password)", key)
+			}
+		}
+	}
+
+	return nil
+}
+
+type dockerAuthConfig struct {
+	Auths       dockerAuthConfigAuths `json:"auths"`
+	CredsStore  string                `json:"credsStore"`
+	CredHelpers map[string]string     `json:"credHelpers"`
+}
+
+type dockerAuthConfigAuths map[string]dockerAuthConfigAuth
+
+type dockerAuthConfigAuth struct {
+	Auth []byte `json:"auth"`
 }

--- a/cmd/frontend/graphqlbackend/executor_secrets.go
+++ b/cmd/frontend/graphqlbackend/executor_secrets.go
@@ -287,6 +287,8 @@ func checkNamespaceAccess(ctx context.Context, db database.DB, namespaceUserID, 
 	return auth.CheckCurrentUserIsSiteAdmin(ctx, db)
 }
 
+// validateExecutorSecret validates that the secret value is non-empty and if the
+// secret key is DOCKER_AUTH_CONFIG that the value is acceptable.
 func validateExecutorSecret(secret *database.ExecutorSecret, value string) error {
 	if len(value) == 0 {
 		return errors.New("value cannot be empty string")

--- a/cmd/frontend/graphqlbackend/executor_secrets.go
+++ b/cmd/frontend/graphqlbackend/executor_secrets.go
@@ -295,7 +295,9 @@ func validateExecutorSecret(secret *database.ExecutorSecret, value string) error
 	// confusion and broken config.
 	if secret.Key == "DOCKER_AUTH_CONFIG" {
 		var dac dockerAuthConfig
-		if err := json.Unmarshal([]byte(value), &dac); err != nil {
+		dec := json.NewDecoder(strings.NewReader(value))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&dac); err != nil {
 			return errors.Wrap(err, "failed to unmarshal docker auth config for validation")
 		}
 		if len(dac.CredHelpers) > 0 {

--- a/cmd/frontend/graphqlbackend/executor_secrets_test.go
+++ b/cmd/frontend/graphqlbackend/executor_secrets_test.go
@@ -808,6 +808,12 @@ func TestValidateExecutorSecret(t *testing.T) {
 			wantErr: "cannot use credential stores in docker auth config set via secrets",
 		},
 		{
+			name:    "docker auth config with additional property",
+			key:     "DOCKER_AUTH_CONFIG",
+			value:   `{"additionalProperty": true}`,
+			wantErr: "failed to unmarshal docker auth config for validation: json: unknown field \"additionalProperty\"",
+		},
+		{
 			name:    "docker auth config with invalid auth value",
 			key:     "DOCKER_AUTH_CONFIG",
 			value:   `{"auths": { "hub.docker.com": { "auth": "bm90d2l0aGNvbG9u" }}}`, // content: base64(notwithcolon)

--- a/cmd/frontend/graphqlbackend/executor_secrets_test.go
+++ b/cmd/frontend/graphqlbackend/executor_secrets_test.go
@@ -770,3 +770,71 @@ type executorSecretsIntegrationTestResponseAccessLogExecutorSecret struct {
 type executorSecretsIntegrationTestResponseAccessLogUser struct {
 	ID graphql.ID `json:"id"`
 }
+
+func TestValidateExecutorSecret(t *testing.T) {
+	tts := []struct {
+		name    string
+		key     string
+		value   string
+		wantErr string
+	}{
+		{
+			name:    "empty value",
+			value:   "",
+			wantErr: "value cannot be empty string",
+		},
+		{
+			name:    "valid secret",
+			value:   "set",
+			key:     "ANY",
+			wantErr: "",
+		},
+		{
+			name:    "unparseable docker auth config",
+			key:     "DOCKER_AUTH_CONFIG",
+			value:   "notjson",
+			wantErr: "failed to unmarshal docker auth config for validation: invalid character 'o' in literal null (expecting 'u')",
+		},
+		{
+			name:    "docker auth config with cred helper",
+			key:     "DOCKER_AUTH_CONFIG",
+			value:   `{"credHelpers": { "hub.docker.com": "sg-login" }}`,
+			wantErr: "cannot use credential helpers in docker auth config set via secrets",
+		},
+		{
+			name:    "docker auth config with cred helper",
+			key:     "DOCKER_AUTH_CONFIG",
+			value:   `{"credsStore": "desktop"}`,
+			wantErr: "cannot use credential stores in docker auth config set via secrets",
+		},
+		{
+			name:    "docker auth config with invalid auth value",
+			key:     "DOCKER_AUTH_CONFIG",
+			value:   `{"auths": { "hub.docker.com": { "auth": "bm90d2l0aGNvbG9u" }}}`, // content: base64(notwithcolon)
+			wantErr: "invalid credential in auths section for \"hub.docker.com\" format has to be base64(username:password)",
+		},
+		{
+			name:    "docker auth config with valid auth value",
+			key:     "DOCKER_AUTH_CONFIG",
+			value:   `{"auths": { "hub.docker.com": { "auth": "dXNlcm5hbWU6cGFzc3dvcmQ=" }}}`, // content: base64(username:password)
+			wantErr: "",
+		},
+	}
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			have := validateExecutorSecret(&database.ExecutorSecret{Key: tt.key}, tt.value)
+			if have == nil && tt.wantErr == "" {
+				return
+			}
+			if have != nil && tt.wantErr == "" {
+				t.Fatalf("invalid non-nil error returned %s", have)
+			}
+			if have == nil && tt.wantErr != "" {
+				t.Fatalf("invalid nil error returned")
+			}
+			if have.Error() != tt.wantErr {
+				t.Fatalf("invalid error, want=%q have =%q", tt.wantErr, have.Error())
+			}
+		})
+	}
+}

--- a/doc/admin/deploy_executors.md
+++ b/doc/admin/deploy_executors.md
@@ -122,7 +122,7 @@ and then paste the result of that into a JSON string like this:
 }
 ```
 
-For Google Container Registry, [follow this guide](https://cloud.google.com/container-registry/docs/advanced-authentication) for how to obtain long-lived static credentials.
+For Google Container Registry, [follow this guide](https://cloud.google.com/container-registry/docs/advanced-authentication#json-key) for how to obtain long-lived static credentials.
 
 ### Configuring the auth config for use in executors
 

--- a/doc/admin/deploy_executors.md
+++ b/doc/admin/deploy_executors.md
@@ -53,3 +53,77 @@ Once the shared secret is set in Sourcegraph, you can start setting up executors
 If executor instances boot correctly and can authenticate with the Sourcegraph frontend, they will show up in the _Executors_ page under _Site Admin_ > _Maintenance_.
 
 ![Executor list in UI](https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/sg-3.34/executor-ui-test.png)
+
+## Using private registries
+
+If you want to use docker images stored in a private registry that requires authentication, follow this section to configure it.
+
+Depending on the executor runtime that is being used, different options exist for provisioning access to private container registries:
+
+- Through a special secret called `DOCKER_AUTH_CONFIG`, set in [executor secrets](./executor_secrets.md) in Sourcegraph.
+- Through the `EXECUTOR_DOCKER_AUTH_CONFIG` environment variable (also available as a variable in the terraform modules for executors).
+- Through the [`config.json` file in `~/.docker`](https://docs.docker.com/engine/reference/commandline/login/). **If using executors with firecracker enabled (recommended) this option is not available.**
+
+When multiple of the above options are combined, executors will use them in the following order:
+
+- If a `DOCKER_AUTH_CONFIG` executor secret is configured, that will be preferred. That is so that users can overwrite the credentials being used in their user-settings. This is the only option available in Sourcegraph Cloud.
+- If the `EXECUTOR_DOCKER_AUTH_CONFIG` environment variable is set, this will be used as the next option.
+- Finally, if neither of the above are set, executors will fall back to the `config.json` file in the user home directory of the user that is owning the executor process. NOTE: This is not available in the firecracker runtime, as the rootfs is not shared with the host.
+
+The docker CLI supports three ways to use credentials:
+
+- Using static credentials
+- Using [credential helpers](https://docs.docker.com/engine/reference/commandline/login/#credential-helpers)
+- Using [credential stores](https://docs.docker.com/engine/reference/commandline/login/#credentials-store)
+
+Credential helpers and credential stores are only available for use with the `config.json` configuration option, as they require additional infrastructural changes. Thus, those options are not available on Sourcegraph Cloud.
+
+### Using static credentials
+
+The `EXECUTOR_DOCKER_AUTH_CONFIG` environment variable and the `DOCKER_AUTH_CONFIG` secret expect a docker config with only the necessary properties set for configuring authentication.
+The format of this config supports multiple registries to be configured and looks like this:
+
+```json
+{
+  "auths": {
+    "myregistry.example.com[:port]": {
+      "auth": "base64(username:password)"
+    },
+    "myregistry2.example.com[:port]": {
+      "auth": "base64(username:password)"
+    }
+  }
+}
+```
+
+You can either create this config yourself by hand, or let docker do it for you by running:
+
+```bash
+TMP_FILE="$(mktemp -d)" bash -c 'echo "<password>" | docker --config "${TMP_FILE}" login --username "<username>" --password-stdin "<registryurl>" && cat "${TMP_FILE}/config.json" && rm -rf "${TMP_FILE}"'
+```
+
+> NOTE: This doesn't work on Docker for Mac if "Securely store Docker logins in macOS keychain" is enabled, as it would store it in the credentials store instead.
+
+You can also run the following:
+
+```bash
+echo "username:password" | base64
+```
+
+and then paste the result of that into a JSON string like this:
+
+```json
+{
+  "auths": {
+    "myregistry.example.com[:port]": {
+      "auth": "<the value from above>"
+    }
+  }
+}
+```
+
+For Google Container Registry, [follow this guide](https://cloud.google.com/container-registry/docs/advanced-authentication) for how to obtain long-lived static credentials.
+
+### Configuring the auth config for use in executors
+
+Now that the config has been obtained, it can be used for the `EXECUTOR_DOCKER_AUTH_CONFIG` environment variable (and terraform variable `docker_auth_config`) or you can create an [executor secret](./executor_secrets.md#creating-a-new-secret) called `DOCKER_AUTH_CONFIG`. Global executor secrets will be available to every execution, while user and organization level executor secrets will only be available to the namespaces executions.

--- a/enterprise/cmd/executor/internal/command/docker.go
+++ b/enterprise/cmd/executor/internal/command/docker.go
@@ -15,7 +15,7 @@ const ScriptsPath = ".sourcegraph-executor"
 // of a one-shot docker container subject to the resource limits specified in the
 // given options.
 func formatRawOrDockerCommand(spec CommandSpec, dir string, options Options, dockerConfigPath string) command {
-	// TODO - make this a non-special case
+	// TODO - remove this once src-cli is not required anymore for SSBC.
 	if spec.Image == "" {
 		return command{
 			Key:       spec.Key,

--- a/enterprise/cmd/executor/internal/command/docker.go
+++ b/enterprise/cmd/executor/internal/command/docker.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"fmt"
 	"path/filepath"
 	"strconv"
 )
@@ -17,11 +18,15 @@ const ScriptsPath = ".sourcegraph-executor"
 func formatRawOrDockerCommand(spec CommandSpec, dir string, options Options, dockerConfigPath string) command {
 	// TODO - remove this once src-cli is not required anymore for SSBC.
 	if spec.Image == "" {
+		env := spec.Env
+		if dockerConfigPath != "" {
+			env = append(env, fmt.Sprintf("DOCKER_CONFIG=%s", dockerConfigPath))
+		}
 		return command{
 			Key:       spec.Key,
 			Command:   spec.Command,
 			Dir:       filepath.Join(dir, spec.Dir),
-			Env:       spec.Env,
+			Env:       env,
 			Operation: spec.Operation,
 		}
 	}

--- a/enterprise/cmd/executor/internal/command/docker.go
+++ b/enterprise/cmd/executor/internal/command/docker.go
@@ -14,7 +14,7 @@ const ScriptsPath = ".sourcegraph-executor"
 // will be run _directly_ on the host. Otherwise, the command will be run inside
 // of a one-shot docker container subject to the resource limits specified in the
 // given options.
-func formatRawOrDockerCommand(spec CommandSpec, dir string, options Options) command {
+func formatRawOrDockerCommand(spec CommandSpec, dir string, options Options, dockerConfigPath string) command {
 	// TODO - make this a non-special case
 	if spec.Image == "" {
 		return command{
@@ -34,7 +34,9 @@ func formatRawOrDockerCommand(spec CommandSpec, dir string, options Options) com
 	return command{
 		Key: spec.Key,
 		Command: flatten(
-			"docker", "run", "--rm",
+			"docker",
+			dockerConfigFlag(dockerConfigPath),
+			"run", "--rm",
 			dockerResourceFlags(options.ResourceOptions),
 			dockerVolumeFlags(hostDir),
 			dockerWorkingdirectoryFlags(spec.Dir),
@@ -61,6 +63,13 @@ func dockerResourceFlags(options ResourceOptions) []string {
 
 func dockerVolumeFlags(wd string) []string {
 	return []string{"-v", wd + ":/data"}
+}
+
+func dockerConfigFlag(dockerConfigPath string) []string {
+	if dockerConfigPath == "" {
+		return nil
+	}
+	return []string{"--config", dockerConfigPath}
 }
 
 func dockerWorkingdirectoryFlags(dir string) []string {

--- a/enterprise/cmd/executor/internal/command/docker_test.go
+++ b/enterprise/cmd/executor/internal/command/docker_test.go
@@ -19,6 +19,7 @@ func TestFormatRawOrDockerCommandRaw(t *testing.T) {
 		},
 		"/proj/src",
 		Options{},
+		"/tmp/docker-config",
 	)
 
 	expected := command{
@@ -50,11 +51,14 @@ func TestFormatRawOrDockerCommandDockerScript(t *testing.T) {
 				Memory:  "20G",
 			},
 		},
+		"/tmp/docker-config",
 	)
 
 	expected := command{
 		Command: []string{
-			"docker", "run", "--rm",
+			"docker",
+			"--config", "/tmp/docker-config",
+			"run", "--rm",
 			"--cpus", "4",
 			"--memory", "20G",
 			"-v", "/proj/src:/data",
@@ -89,11 +93,14 @@ func TestFormatRawOrDockerCommandDockerScriptWithoutResourceAllocation(t *testin
 				Memory:  "0",
 			},
 		},
+		"/tmp/docker-config",
 	)
 
 	expected := command{
 		Command: []string{
-			"docker", "run", "--rm",
+			"docker",
+			"--config", "/tmp/docker-config",
+			"run", "--rm",
 			"-v", "/proj/src:/data",
 			"-w", "/data/subdir",
 			"--entrypoint",
@@ -123,11 +130,14 @@ func TestFormatRawOrDockerCommandDockerScriptWithDockerHostMountPath(t *testing.
 				DockerHostMountPath: "/containers/rootfs/mount_fs",
 			},
 		},
+		"/tmp/docker-config",
 	)
 
 	expected := command{
 		Command: []string{
-			"docker", "run", "--rm",
+			"docker",
+			"--config", "/tmp/docker-config",
+			"run", "--rm",
 			"--cpus", "4",
 			"--memory", "20G",
 			"-v", "/containers/rootfs/mount_fs/workspace:/data",

--- a/enterprise/cmd/executor/internal/command/docker_test.go
+++ b/enterprise/cmd/executor/internal/command/docker_test.go
@@ -9,6 +9,44 @@ import (
 func TestFormatRawOrDockerCommandRaw(t *testing.T) {
 	actual := formatRawOrDockerCommand(
 		CommandSpec{
+			Image:   "sourcegraph/sourcegraph",
+			Command: []string{"ls", "-a"},
+			Dir:     "subdir",
+			Env: []string{
+				`TEST=true`,
+				`CONTAINS_WHITESPACE=yes it does`,
+			},
+			Operation: makeTestOperation(),
+		},
+		"/proj/src",
+		Options{},
+		"/tmp/docker-config",
+	)
+
+	expected := command{
+		Command: []string{
+			"docker",
+			"--config", "/tmp/docker-config",
+			"run",
+			"--rm",
+			"-v", "/proj/src:/data",
+			"-w", "/data/subdir",
+			"-e", "TEST=true",
+			"-e", "CONTAINS_WHITESPACE=yes it does",
+			"--entrypoint", "/bin/sh",
+			"sourcegraph/sourcegraph",
+			"/data/.sourcegraph-executor",
+		},
+	}
+	if diff := cmp.Diff(expected, actual, commandComparer); diff != "" {
+		t.Errorf("unexpected command (-want +got):\n%s", diff)
+	}
+}
+
+func TestFormatRawOrDockerCommandRaw_SrcCli(t *testing.T) {
+	actual := formatRawOrDockerCommand(
+		CommandSpec{
+			Image:   "",
 			Command: []string{"ls", "-a"},
 			Dir:     "subdir",
 			Env: []string{
@@ -25,7 +63,7 @@ func TestFormatRawOrDockerCommandRaw(t *testing.T) {
 	expected := command{
 		Command: []string{"ls", "-a"},
 		Dir:     "/proj/src/subdir",
-		Env:     []string{"TEST=true", "CONTAINS_WHITESPACE=yes it does"},
+		Env:     []string{"TEST=true", "CONTAINS_WHITESPACE=yes it does", "DOCKER_CONFIG=/tmp/docker-config"},
 	}
 	if diff := cmp.Diff(expected, actual, commandComparer); diff != "" {
 		t.Errorf("unexpected command (-want +got):\n%s", diff)

--- a/enterprise/cmd/executor/internal/command/firecracker.go
+++ b/enterprise/cmd/executor/internal/command/firecracker.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -34,8 +35,8 @@ const firecrackerContainerDir = "/work"
 // The name value supplied here refers to the Firecracker virtual machine, which must have
 // also been the name supplied to a successful invocation of setupFirecracker. Additionally,
 // the virtual machine must not yet have been torn down (via teardownFirecracker).
-func formatFirecrackerCommand(spec CommandSpec, name string, options Options) command {
-	rawOrDockerCommand := formatRawOrDockerCommand(spec, firecrackerContainerDir, options)
+func formatFirecrackerCommand(spec CommandSpec, name string, options Options, dockerConfigPath string) command {
+	rawOrDockerCommand := formatRawOrDockerCommand(spec, firecrackerContainerDir, options, dockerConfigPath)
 
 	innerCommand := shellquote.Join(rawOrDockerCommand.Command...)
 
@@ -141,27 +142,42 @@ func newDockerDaemonConfig(tmpDir string, mirrorAddresses []string) (_ string, e
 // setupFirecracker invokes a set of commands to provision and prepare a Firecracker virtual
 // machine instance. If a startup script path (an executable file on the host) is supplied,
 // it will be mounted into the new virtual machine instance and executed.
-func setupFirecracker(ctx context.Context, runner commandRunner, logger Logger, name, workspaceDevice, tmpDir string, options Options, operations *Operations) error {
+func setupFirecracker(ctx context.Context, runner commandRunner, logger Logger, name, workspaceDevice, tmpDir string, options Options, operations *Operations) (dockerConfigPath string, err error) {
 	var daemonConfigFile string
 	if len(options.FirecrackerOptions.DockerRegistryMirrorURLs) > 0 {
 		var err error
 		daemonConfigFile, err = newDockerDaemonConfig(tmpDir, options.FirecrackerOptions.DockerRegistryMirrorURLs)
 		if err != nil {
-			return err
+			return "", err
+		}
+	}
+
+	// If docker auth config is present, write it.
+	if len(options.DockerOptions.DockerAuthConfig.Auths) > 0 {
+		d, err := json.Marshal(options.DockerOptions.DockerAuthConfig)
+		if err != nil {
+			return "", err
+		}
+		dockerConfigPath, err = os.MkdirTemp(tmpDir, "docker_auth")
+		if err != nil {
+			return "", err
+		}
+		if err := os.WriteFile(filepath.Join(dockerConfigPath, "config.json"), d, os.ModePerm); err != nil {
+			return "", err
 		}
 	}
 
 	// Make subdirectory called "cni" to store CNI config in. All files from a directory
 	// will be considered so this has to be it's own directory with just our config file.
 	cniConfigDir := path.Join(tmpDir, "cni")
-	err := os.Mkdir(cniConfigDir, os.ModePerm)
+	err = os.Mkdir(cniConfigDir, os.ModePerm)
 	if err != nil {
-		return err
+		return "", err
 	}
 	cniConfigFile := path.Join(cniConfigDir, "10-sourcegraph-executors.conflist")
 	err = os.WriteFile(cniConfigFile, []byte(cniConfig(options.ResourceOptions.MaxIngressBandwidth, options.ResourceOptions.MaxEgressBandwidth)), os.ModePerm)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Start the VM and wait for the SSH server to become available.
@@ -175,7 +191,7 @@ func setupFirecracker(ctx context.Context, runner commandRunner, logger Logger, 
 			"--runtime", "docker",
 			"--network-plugin", "cni",
 			firecrackerResourceFlags(options.ResourceOptions),
-			firecrackerCopyfileFlags(options.FirecrackerOptions.VMStartupScriptPath, daemonConfigFile),
+			firecrackerCopyfileFlags(options.FirecrackerOptions.VMStartupScriptPath, daemonConfigFile, dockerConfigPath),
 			firecrackerVolumeFlags(workspaceDevice, firecrackerContainerDir),
 			"--ssh",
 			"--name", name,
@@ -188,7 +204,7 @@ func setupFirecracker(ctx context.Context, runner commandRunner, logger Logger, 
 	}
 
 	if err := runner.RunCommand(ctx, startCommand, logger); err != nil {
-		return errors.Wrap(err, "failed to start firecracker vm")
+		return "", errors.Wrap(err, "failed to start firecracker vm")
 	}
 
 	if options.FirecrackerOptions.VMStartupScriptPath != "" {
@@ -198,11 +214,11 @@ func setupFirecracker(ctx context.Context, runner commandRunner, logger Logger, 
 			Operation: operations.SetupStartupScript,
 		}
 		if err := runner.RunCommand(ctx, startupScriptCommand, logger); err != nil {
-			return errors.Wrap(err, "failed to run startup script")
+			return "", errors.Wrap(err, "failed to run startup script")
 		}
 	}
 
-	return nil
+	return dockerConfigPath, nil
 }
 
 // teardownFirecracker issues a stop and a remove request for the Firecracker VM with
@@ -232,7 +248,7 @@ func firecrackerResourceFlags(options ResourceOptions) []string {
 	}
 }
 
-func firecrackerCopyfileFlags(vmStartupScriptPath, daemonConfigFile string) []string {
+func firecrackerCopyfileFlags(vmStartupScriptPath, daemonConfigFile, dockerConfigPath string) []string {
 	copyfiles := make([]string, 0, 2)
 	if vmStartupScriptPath != "" {
 		copyfiles = append(copyfiles, fmt.Sprintf("%s:%s", vmStartupScriptPath, vmStartupScriptPath))
@@ -240,6 +256,10 @@ func firecrackerCopyfileFlags(vmStartupScriptPath, daemonConfigFile string) []st
 
 	if daemonConfigFile != "" {
 		copyfiles = append(copyfiles, fmt.Sprintf("%s:%s", daemonConfigFile, "/etc/docker/daemon.json"))
+	}
+
+	if dockerConfigPath != "" {
+		copyfiles = append(copyfiles, fmt.Sprintf("%s:%s", dockerConfigPath, dockerConfigPath))
 	}
 
 	sort.Strings(copyfiles)

--- a/enterprise/cmd/executor/internal/command/firecracker_test.go
+++ b/enterprise/cmd/executor/internal/command/firecracker_test.go
@@ -31,7 +31,7 @@ func TestFormatFirecrackerCommandRaw(t *testing.T) {
 	expected := command{
 		Command: []string{
 			"ignite", "exec", "deadbeef", "--",
-			`cd '/work/sub dir' && TEST=true CONTAINS_WHITESPACE='yes it does' ls -a`,
+			`cd '/work/sub dir' && TEST=true CONTAINS_WHITESPACE='yes it does' DOCKER_CONFIG=/tmp/docker-config ls -a`,
 		},
 	}
 	if diff := cmp.Diff(expected, actual, commandComparer); diff != "" {

--- a/enterprise/cmd/executor/internal/command/firecracker_test.go
+++ b/enterprise/cmd/executor/internal/command/firecracker_test.go
@@ -25,6 +25,7 @@ func TestFormatFirecrackerCommandRaw(t *testing.T) {
 		},
 		"deadbeef",
 		Options{},
+		"/tmp/docker-config",
 	)
 
 	expected := command{
@@ -57,13 +58,16 @@ func TestFormatFirecrackerCommandDockerScript(t *testing.T) {
 				Memory:  "20G",
 			},
 		},
+		"/tmp/docker-config",
 	)
 
 	expected := command{
 		Command: []string{
 			"ignite", "exec", "deadbeef", "--",
 			strings.Join([]string{
-				"docker", "run", "--rm",
+				"docker",
+				"--config", "/tmp/docker-config",
+				"run", "--rm",
 				"--cpus", "4",
 				"--memory", "20G",
 				"-v", "/work:/data",
@@ -91,13 +95,16 @@ func TestFormatFirecrackerCommandDockerScript_NoInjection(t *testing.T) {
 		},
 		"deadbeef",
 		Options{},
+		"/tmp/docker-config",
 	)
 
 	expected := command{
 		Command: []string{
 			"ignite", "exec", "deadbeef", "--",
 			strings.Join([]string{
-				"docker", "run", "--rm",
+				"docker",
+				"--config", "/tmp/docker-config",
+				"run", "--rm",
 				"-v", "/work:/data",
 				"-w", "/data",
 				"--entrypoint /bin/sh",
@@ -135,7 +142,7 @@ func TestSetupFirecracker(t *testing.T) {
 		t.Fatal(err)
 	}
 	logger := NewMockLogger()
-	if err := setupFirecracker(context.Background(), runner, logger, "deadbeef", "/dev/loopX", tmpDir, options, operations); err != nil {
+	if _, err := setupFirecracker(context.Background(), runner, logger, "deadbeef", "/dev/loopX", tmpDir, options, operations); err != nil {
 		t.Fatalf("unexpected error setting up virtual machine: %s", err)
 	}
 

--- a/enterprise/cmd/executor/internal/command/runner.go
+++ b/enterprise/cmd/executor/internal/command/runner.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/executor"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -59,7 +60,7 @@ type Options struct {
 type DockerOptions struct {
 	// DockerAuthConfig, if set, will be used to configure the docker CLI to authenticate to
 	// registries.
-	DockerAuthConfig DockerAuthConfig
+	DockerAuthConfig executor.DockerAuthConfig
 }
 
 type FirecrackerOptions struct {
@@ -217,20 +218,4 @@ var defaultRunner = &runnerWrapper{}
 
 func (runnerWrapper) RunCommand(ctx context.Context, command command, logger Logger) error {
 	return runCommand(ctx, command, logger)
-}
-
-// DockerAuthConfig represents a subset of the docker cli config with the necessary
-// fields to make authentication work.
-type DockerAuthConfig struct {
-	// Auths is a map from registry URL to auth object.
-	Auths DockerAuthConfigAuths `json:"auths"`
-}
-
-// DockerAuthConfigAuths maps a registry URL to an auth object.
-type DockerAuthConfigAuths map[string]DockerAuthConfigAuth
-
-// DockerAuthConfigAuth is a single registrys auth configuration.
-type DockerAuthConfigAuth struct {
-	// Auth is the base64 encoded credential in the format user:password.
-	Auth []byte `json:"auth"`
 }

--- a/enterprise/cmd/executor/internal/config/config.go
+++ b/enterprise/cmd/executor/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/google/uuid"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/executor"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/hostname"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -17,33 +18,35 @@ import (
 type Config struct {
 	env.BaseConfig
 
-	FrontendURL                   string
-	FrontendAuthorizationToken    string
-	QueueName                     string
-	QueuePollInterval             time.Duration
-	MaximumNumJobs                int
-	FirecrackerImage              string
-	FirecrackerKernelImage        string
-	FirecrackerSandboxImage       string
-	VMStartupScriptPath           string
-	VMPrefix                      string
-	KeepWorkspaces                bool
-	DockerHostMountPath           string
-	UseFirecracker                bool
-	JobNumCPUs                    int
-	JobMemory                     string
-	FirecrackerDiskSpace          string
-	FirecrackerBandwidthIngress   int
-	FirecrackerBandwidthEgress    int
-	MaximumRuntimePerJob          time.Duration
-	CleanupTaskInterval           time.Duration
-	NumTotalJobs                  int
-	MaxActiveTime                 time.Duration
-	NodeExporterURL               string
-	DockerRegistryNodeExporterURL string
-	WorkerHostname                string
-	DockerRegistryMirrorURL       string
-	DockerAuthConfig              string
+	FrontendURL                    string
+	FrontendAuthorizationToken     string
+	QueueName                      string
+	QueuePollInterval              time.Duration
+	MaximumNumJobs                 int
+	FirecrackerImage               string
+	FirecrackerKernelImage         string
+	FirecrackerSandboxImage        string
+	VMStartupScriptPath            string
+	VMPrefix                       string
+	KeepWorkspaces                 bool
+	DockerHostMountPath            string
+	UseFirecracker                 bool
+	JobNumCPUs                     int
+	JobMemory                      string
+	FirecrackerDiskSpace           string
+	FirecrackerBandwidthIngress    int
+	FirecrackerBandwidthEgress     int
+	MaximumRuntimePerJob           time.Duration
+	CleanupTaskInterval            time.Duration
+	NumTotalJobs                   int
+	MaxActiveTime                  time.Duration
+	NodeExporterURL                string
+	DockerRegistryNodeExporterURL  string
+	WorkerHostname                 string
+	DockerRegistryMirrorURL        string
+	DockerAuthConfig               executor.DockerAuthConfig
+	dockerAuthConfigStr            string
+	dockerAuthConfigUnmarshalError error
 }
 
 func (c *Config) Load() {
@@ -72,7 +75,11 @@ func (c *Config) Load() {
 	c.DockerRegistryNodeExporterURL = c.GetOptional("DOCKER_REGISTRY_NODE_EXPORTER_URL", "The URL of the Docker Registry instance's node_exporter, without the /metrics path.")
 	c.MaxActiveTime = c.GetInterval("EXECUTOR_MAX_ACTIVE_TIME", "0", "The maximum time that can be spent by the worker dequeueing records to be handled.")
 	c.DockerRegistryMirrorURL = c.GetOptional("EXECUTOR_DOCKER_REGISTRY_MIRROR_URL", "The address of a docker registry mirror to use in firecracker VMs. Supports multiple values, separated with a comma.")
-	c.DockerAuthConfig = c.GetOptional("EXECUTOR_DOCKER_AUTH_CONFIG", "The content of the docker config file including auth for services. If using firecracker, only static credentials are supported, not credential stores nor credential helpers.")
+	c.dockerAuthConfigStr = c.GetOptional("EXECUTOR_DOCKER_AUTH_CONFIG", "The content of the docker config file including auth for services. If using firecracker, only static credentials are supported, not credential stores nor credential helpers.")
+
+	if c.dockerAuthConfigStr != "" {
+		c.dockerAuthConfigUnmarshalError = json.Unmarshal([]byte(c.dockerAuthConfigStr), &c.DockerAuthConfig)
+	}
 
 	hn := hostname.Get()
 	// Be unique but also descriptive.
@@ -84,10 +91,8 @@ func (c *Config) Validate() error {
 		c.AddError(errors.New("EXECUTOR_QUEUE_NAME must be set to 'batches' or 'codeintel'"))
 	}
 
-	if c.DockerAuthConfig != "" {
-		if err := json.Unmarshal([]byte(c.DockerAuthConfig), &dockerAuthConfig{}); err != nil {
-			c.AddError(errors.Wrap(err, "invalid EXECUTOR_DOCKER_AUTH_CONFIG, failed to parse"))
-		}
+	if c.dockerAuthConfigUnmarshalError != nil {
+		c.AddError(errors.Wrap(c.dockerAuthConfigUnmarshalError, "invalid EXECUTOR_DOCKER_AUTH_CONFIG, failed to parse"))
 	}
 
 	if c.UseFirecracker {
@@ -112,14 +117,4 @@ func (c *Config) Validate() error {
 	}
 
 	return c.BaseConfig.Validate()
-}
-
-type dockerAuthConfig struct {
-	Auths dockerAuthConfigAuths `json:"auths"`
-}
-
-type dockerAuthConfigAuths map[string]dockerAuthConfigAuth
-
-type dockerAuthConfigAuth struct {
-	Auth []byte `json:"auth"`
 }

--- a/enterprise/cmd/executor/internal/run/testvm.go
+++ b/enterprise/cmd/executor/internal/run/testvm.go
@@ -97,6 +97,7 @@ func createVM(ctx context.Context, config *config.Config, repositoryName, revisi
 	runner := command.NewRunner(workspace.Path(), commandLogger, command.Options{
 		ExecutorName:       name,
 		ResourceOptions:    resourceOptions(config),
+		DockerOptions:      dockerOptions(config),
 		FirecrackerOptions: fopts,
 	}, operations)
 

--- a/enterprise/cmd/executor/internal/run/util.go
+++ b/enterprise/cmd/executor/internal/run/util.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"runtime"
@@ -96,6 +97,7 @@ func apiWorkerOptions(c *config.Config, queueTelemetryOptions queue.TelemetryOpt
 		KeepWorkspaces:     c.KeepWorkspaces,
 		QueueName:          c.QueueName,
 		WorkerOptions:      workerOptions(c),
+		DockerOptions:      dockerOptions(c),
 		FirecrackerOptions: firecrackerOptions(c),
 		ResourceOptions:    resourceOptions(c),
 		GitServicePath:     "/.executors/git",
@@ -123,6 +125,18 @@ func workerOptions(c *config.Config) workerutil.WorkerOptions {
 		MaxActiveTime:        c.MaxActiveTime,
 		WorkerHostname:       c.WorkerHostname,
 		MaximumRuntimePerJob: c.MaximumRuntimePerJob,
+	}
+}
+
+func dockerOptions(c *config.Config) command.DockerOptions {
+	var a command.DockerAuthConfig
+	if c.DockerAuthConfig != "" {
+		if err := json.Unmarshal([]byte(c.DockerAuthConfig), &a); err != nil {
+			panic("invalid")
+		}
+	}
+	return command.DockerOptions{
+		DockerAuthConfig: a,
 	}
 }
 

--- a/enterprise/cmd/executor/internal/run/util.go
+++ b/enterprise/cmd/executor/internal/run/util.go
@@ -2,7 +2,6 @@ package run
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os/exec"
 	"runtime"
@@ -129,14 +128,8 @@ func workerOptions(c *config.Config) workerutil.WorkerOptions {
 }
 
 func dockerOptions(c *config.Config) command.DockerOptions {
-	var a command.DockerAuthConfig
-	if c.DockerAuthConfig != "" {
-		if err := json.Unmarshal([]byte(c.DockerAuthConfig), &a); err != nil {
-			panic("invalid")
-		}
-	}
 	return command.DockerOptions{
-		DockerAuthConfig: a,
+		DockerAuthConfig: c.DockerAuthConfig,
 	}
 }
 

--- a/enterprise/cmd/executor/internal/worker/handler.go
+++ b/enterprise/cmd/executor/internal/worker/handler.go
@@ -2,7 +2,6 @@ package worker
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -123,10 +122,9 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, job executor.Jo
 		FirecrackerOptions: h.options.FirecrackerOptions,
 		ResourceOptions:    h.options.ResourceOptions,
 	}
-	if job.DockerAuthConfig != "" {
-		if err := json.Unmarshal([]byte(job.DockerAuthConfig), &options.DockerOptions.DockerAuthConfig); err != nil {
-			return err
-		}
+	// If the job has docker auth config set, prioritize that over the env var.
+	if len(job.DockerAuthConfig.Auths) > 0 {
+		options.DockerOptions.DockerAuthConfig = job.DockerAuthConfig
 	}
 	runner := h.runnerFactory(workspace.Path(), commandLogger, options, h.operations)
 

--- a/enterprise/cmd/executor/internal/worker/handler.go
+++ b/enterprise/cmd/executor/internal/worker/handler.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -118,8 +119,14 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, job executor.Jo
 
 	options := command.Options{
 		ExecutorName:       name,
+		DockerOptions:      h.options.DockerOptions,
 		FirecrackerOptions: h.options.FirecrackerOptions,
 		ResourceOptions:    h.options.ResourceOptions,
+	}
+	if job.DockerAuthConfig != "" {
+		if err := json.Unmarshal([]byte(job.DockerAuthConfig), &options.DockerOptions.DockerAuthConfig); err != nil {
+			return err
+		}
 	}
 	runner := h.runnerFactory(workspace.Path(), commandLogger, options, h.operations)
 

--- a/enterprise/cmd/executor/internal/worker/worker.go
+++ b/enterprise/cmd/executor/internal/worker/worker.go
@@ -60,6 +60,9 @@ type Options struct {
 	// FilesOptions configures the client that interacts with the files API.
 	FilesOptions apiclient.BaseClientOptions
 
+	// DockerOptions configures the behavior of Firecracker virtual machine creation.
+	DockerOptions command.DockerOptions
+
 	// FirecrackerOptions configures the behavior of Firecracker virtual machine creation.
 	FirecrackerOptions command.FirecrackerOptions
 

--- a/enterprise/cmd/executor/internal/worker/worker.go
+++ b/enterprise/cmd/executor/internal/worker/worker.go
@@ -60,7 +60,7 @@ type Options struct {
 	// FilesOptions configures the client that interacts with the files API.
 	FilesOptions apiclient.BaseClientOptions
 
-	// DockerOptions configures the behavior of Firecracker virtual machine creation.
+	// DockerOptions configures the behavior of docker container creation.
 	DockerOptions command.DockerOptions
 
 	// FirecrackerOptions configures the behavior of Firecracker virtual machine creation.

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
@@ -319,5 +319,23 @@ func transformRecord(ctx context.Context, logger log.Logger, s BatchesStore, job
 		}
 	}
 
+	// Append docker auth config.
+	esStore := s.DatabaseDB().ExecutorSecrets(keyring.Default().ExecutorSecretKey)
+	secrets, _, err = esStore.List(ctx, database.ExecutorSecretScopeBatches, database.ExecutorSecretsListOpts{
+		NamespaceUserID: batchSpec.NamespaceUserID,
+		NamespaceOrgID:  batchSpec.NamespaceOrgID,
+		Keys:            []string{"DOCKER_AUTH_CONFIG"},
+	})
+	if err != nil {
+		return apiclient.Job{}, err
+	}
+	if len(secrets) == 1 {
+		val, err := secrets[0].Value(ctx, s.DatabaseDB().ExecutorSecretAccessLogs())
+		if err != nil {
+			return apiclient.Job{}, err
+		}
+		aj.DockerAuthConfig = val
+	}
+
 	return aj, nil
 }

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform.go
@@ -334,7 +334,9 @@ func transformRecord(ctx context.Context, logger log.Logger, s BatchesStore, job
 		if err != nil {
 			return apiclient.Job{}, err
 		}
-		aj.DockerAuthConfig = val
+		if err := json.Unmarshal([]byte(val), &aj.DockerAuthConfig); err != nil {
+			return aj, err
+		}
 	}
 
 	return aj, nil

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
@@ -39,17 +39,18 @@ func TestTransformRecord(t *testing.T) {
 	})
 
 	secs := database.NewMockExecutorSecretStore()
-	secs.ListFunc.SetDefaultReturn(
-		[]*database.ExecutorSecret{
+	secs.ListFunc.SetDefaultHook(func(ctx context.Context, ess database.ExecutorSecretScope, eslo database.ExecutorSecretsListOpts) ([]*database.ExecutorSecret, int, error) {
+		if len(eslo.Keys) == 1 && eslo.Keys[0] == "DOCKER_AUTH_CONFIG" {
+			return nil, 0, nil
+		}
+		return []*database.ExecutorSecret{
 			database.NewMockExecutorSecret(&database.ExecutorSecret{
 				Key:       "FOO",
 				Scope:     database.ExecutorSecretScopeBatches,
 				CreatorID: 1,
 			}, "bar"),
-		},
-		0,
-		nil,
-	)
+		}, 0, nil
+	})
 	db.ExecutorSecretsFunc.SetDefaultReturn(secs)
 
 	sal := database.NewMockExecutorSecretAccessLogStore()
@@ -178,7 +179,7 @@ steps:
 			t.Errorf("unexpected job (-want +got):\n%s", diff)
 		}
 
-		mockassert.CalledOnce(t, secs.ListFunc)
+		mockassert.CalledN(t, secs.ListFunc, 2)
 		mockassert.CalledOnce(t, sal.CreateFunc)
 	})
 
@@ -237,8 +238,81 @@ steps:
 			t.Errorf("unexpected job (-want +got):\n%s", diff)
 		}
 
-		mockassert.CalledN(t, secs.ListFunc, 2)
+		mockassert.CalledN(t, secs.ListFunc, 4)
 		mockassert.CalledN(t, sal.CreateFunc, 2)
+	})
+
+	t.Run("with docker auth config", func(t *testing.T) {
+		// Copy.
+		workspace := *workspace
+		workspace.CachedResultFound = false
+		workspace.StepCacheResults = map[int]btypes.StepCacheResult{}
+		workspace.ChangesetSpecIDs = []int64{}
+		store.GetBatchSpecWorkspaceFunc.PushReturn(&workspace, nil)
+
+		secs.ListFunc.PushReturn(secs.List(context.Background(), database.ExecutorSecretScopeBatches, database.ExecutorSecretsListOpts{}))
+		secs.ListFunc.PushReturn(
+			[]*database.ExecutorSecret{
+				database.NewMockExecutorSecret(&database.ExecutorSecret{
+					Key:       "DOCKER_AUTH_CONFIG",
+					Scope:     database.ExecutorSecretScopeBatches,
+					CreatorID: 1,
+				}, "bar"),
+			},
+			0,
+			nil,
+		)
+
+		job, err := transformRecord(context.Background(), logtest.Scoped(t), store, workspaceExecutionJob, "0.0.0-dev")
+		if err != nil {
+			t.Fatalf("unexpected error transforming record: %s", err)
+		}
+
+		marshaledInput, err := json.Marshal(wantInput(false, execution.AfterStepResult{}))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := apiclient.Job{
+			ID:                  int(workspaceExecutionJob.ID),
+			RepositoryName:      "github.com/sourcegraph/sourcegraph",
+			RepositoryDirectory: "repository",
+			Commit:              workspace.Commit,
+			ShallowClone:        true,
+			SparseCheckout:      []string{"a/b/c/*"},
+			VirtualMachineFiles: map[string]apiclient.VirtualMachineFile{
+				"input.json": {Content: marshaledInput},
+			},
+			CliSteps: []apiclient.CliStep{
+				{
+					Key: "batch-exec",
+					Commands: []string{
+						"batch",
+						"exec",
+						"-f",
+						"input.json",
+						"-repo",
+						"repository",
+						"-tmp",
+						".src-tmp",
+					},
+					Dir: ".",
+					Env: []string{
+						"FOO=bar",
+					},
+				},
+			},
+			RedactedValues: map[string]string{
+				"bar": "${{ secrets.FOO }}",
+			},
+			DockerAuthConfig: "bar",
+		}
+		if diff := cmp.Diff(expected, job); diff != "" {
+			t.Errorf("unexpected job (-want +got):\n%s", diff)
+		}
+
+		mockassert.CalledN(t, secs.ListFunc, 7)
+		mockassert.CalledN(t, sal.CreateFunc, 4)
 	})
 
 	t.Run("workspace file", func(t *testing.T) {
@@ -311,7 +385,7 @@ steps:
 			t.Errorf("unexpected job (-want +got):\n%s", diff)
 		}
 
-		mockassert.CalledN(t, secs.ListFunc, 3)
-		mockassert.CalledN(t, sal.CreateFunc, 3)
+		mockassert.CalledN(t, secs.ListFunc, 9)
+		mockassert.CalledN(t, sal.CreateFunc, 5)
 	})
 }

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
@@ -257,7 +257,7 @@ steps:
 					Key:       "DOCKER_AUTH_CONFIG",
 					Scope:     database.ExecutorSecretScopeBatches,
 					CreatorID: 1,
-				}, "bar"),
+				}, `{"auths": { "hub.docker.com": { "auth": "hunter2" }}}`),
 			},
 			0,
 			nil,
@@ -305,7 +305,13 @@ steps:
 			RedactedValues: map[string]string{
 				"bar": "${{ secrets.FOO }}",
 			},
-			DockerAuthConfig: "bar",
+			DockerAuthConfig: apiclient.DockerAuthConfig{
+				Auths: apiclient.DockerAuthConfigAuths{
+					"hub.docker.com": apiclient.DockerAuthConfigAuth{
+						Auth: []byte("hunter2"),
+					},
+				},
+			},
 		}
 		if diff := cmp.Diff(expected, job); diff != "" {
 			t.Errorf("unexpected job (-want +got):\n%s", diff)

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
@@ -257,7 +257,7 @@ steps:
 					Key:       "DOCKER_AUTH_CONFIG",
 					Scope:     database.ExecutorSecretScopeBatches,
 					CreatorID: 1,
-				}, `{"auths": { "hub.docker.com": { "auth": "hunter2" }}}`),
+				}, `{"auths": { "hub.docker.com": { "auth": "aHVudGVyOmh1bnRlcjI=" }}}`),
 			},
 			0,
 			nil,

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/batches/transform_test.go
@@ -308,7 +308,7 @@ steps:
 			DockerAuthConfig: apiclient.DockerAuthConfig{
 				Auths: apiclient.DockerAuthConfigAuths{
 					"hub.docker.com": apiclient.DockerAuthConfigAuth{
-						Auth: []byte("hunter2"),
+						Auth: []byte("hunter:hunter2"),
 					},
 				},
 			},

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/queue.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/queue.go
@@ -14,7 +14,7 @@ import (
 
 func QueueOptions(observationCtx *observation.Context, db database.DB, accessToken func() string) handler.QueueOptions[types.Index] {
 	recordTransformer := func(ctx context.Context, _ string, record types.Index, resourceMetadata handler.ResourceMetadata) (apiclient.Job, error) {
-		return transformRecord(ctx, record, db, resourceMetadata, accessToken())
+		return transformRecord(ctx, db, record, resourceMetadata, accessToken())
 	}
 
 	store := store.New(observationCtx, db.Handle(), autoindexing.IndexWorkerStoreOptions)

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform.go
@@ -2,6 +2,7 @@ package codeintel
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -175,7 +176,9 @@ func transformRecord(ctx context.Context, db database.DB, index types.Index, res
 		if err != nil {
 			return apiclient.Job{}, err
 		}
-		aj.DockerAuthConfig = val
+		if err := json.Unmarshal([]byte(val), &aj.DockerAuthConfig); err != nil {
+			return aj, err
+		}
 	}
 
 	return aj, nil

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform_test.go
@@ -380,7 +380,7 @@ func TestTransformRecordDockerAuthConfig(t *testing.T) {
 			Key:       "DOCKER_AUTH_CONFIG",
 			Scope:     database.ExecutorSecretScopeCodeIntel,
 			CreatorID: 1,
-		}, `{"auths": { "hub.docker.com": { "auth": "hunter2" }}}`),
+		}, `{"auths": { "hub.docker.com": { "auth": "aHVudGVyOmh1bnRlcjI=" }}}`),
 	}, 0, nil)
 	db.ExecutorSecretAccessLogsFunc.SetDefaultReturn(database.NewMockExecutorSecretAccessLogStore())
 
@@ -408,7 +408,7 @@ func TestTransformRecordDockerAuthConfig(t *testing.T) {
 		DockerAuthConfig: apiclient.DockerAuthConfig{
 			Auths: apiclient.DockerAuthConfigAuths{
 				"hub.docker.com": apiclient.DockerAuthConfigAuth{
-					Auth: []byte("hunter2"),
+					Auth: []byte("hunter:hunter2"),
 				},
 			},
 		},

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform_test.go
@@ -396,7 +396,7 @@ func TestTransformRecordDockerAuthConfig(t *testing.T) {
 		DockerSteps: []apiclient.DockerStep{
 			{
 				Key:      "upload",
-				Image:    "sourcegraph/src-cli:4.3.0",
+				Image:    fmt.Sprintf("sourcegraph/src-cli:%s", srccli.MinimumVersion),
 				Commands: []string{"src lsif upload -no-progress -repo '' -commit '' -root . -upload-route /.executors/lsif/upload -file dump.lsif -associated-index-id 42"},
 				Env:      []string{"SRC_ENDPOINT=", "SRC_HEADER_AUTHORIZATION=token-executor hunter2"},
 			},

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform_test.go
@@ -380,7 +380,7 @@ func TestTransformRecordDockerAuthConfig(t *testing.T) {
 			Key:       "DOCKER_AUTH_CONFIG",
 			Scope:     database.ExecutorSecretScopeCodeIntel,
 			CreatorID: 1,
-		}, "bar"),
+		}, `{"auths": { "hub.docker.com": { "auth": "hunter2" }}}`),
 	}, 0, nil)
 	db.ExecutorSecretAccessLogsFunc.SetDefaultReturn(database.NewMockExecutorSecretAccessLogStore())
 
@@ -405,7 +405,13 @@ func TestTransformRecordDockerAuthConfig(t *testing.T) {
 			"hunter2":                "PASSWORD_REMOVED",
 			"token-executor hunter2": "token-executor REDACTED",
 		},
-		DockerAuthConfig: "bar",
+		DockerAuthConfig: apiclient.DockerAuthConfig{
+			Auths: apiclient.DockerAuthConfigAuths{
+				"hub.docker.com": apiclient.DockerAuthConfigAuth{
+					Auth: []byte("hunter2"),
+				},
+			},
+		},
 	}
 	if diff := cmp.Diff(expected, job); diff != "" {
 		t.Errorf("unexpected job (-want +got):\n%s", diff)

--- a/enterprise/internal/executor/client_types.go
+++ b/enterprise/internal/executor/client_types.go
@@ -65,7 +65,7 @@ type Job struct {
 	// when spawning containers. Used to authenticate to private registries. When set, this
 	// takes precedence over a potentially configured EXECUTOR_DOCKER_AUTH_CONFIG environment
 	// variable.
-	DockerAuthConfig DockerAuthConfig `json:"dockerAuthConfig"`
+	DockerAuthConfig DockerAuthConfig `json:"dockerAuthConfig,omitempty"`
 }
 
 func (j Job) MarshalJSON() ([]byte, error) {
@@ -185,7 +185,7 @@ type v2Job struct {
 	DockerSteps         []DockerStep                    `json:"dockerSteps"`
 	CliSteps            []CliStep                       `json:"cliSteps"`
 	RedactedValues      map[string]string               `json:"redactedValues"`
-	DockerAuthConfig    DockerAuthConfig                `json:"dockerAuthConfig"`
+	DockerAuthConfig    DockerAuthConfig                `json:"dockerAuthConfig,omitempty"`
 }
 
 type v1Job struct {
@@ -344,7 +344,7 @@ type CanceledJobsRequest struct {
 // fields to make authentication work.
 type DockerAuthConfig struct {
 	// Auths is a map from registry URL to auth object.
-	Auths DockerAuthConfigAuths `json:"auths"`
+	Auths DockerAuthConfigAuths `json:"auths,omitempty"`
 }
 
 // DockerAuthConfigAuths maps a registry URL to an auth object.

--- a/enterprise/internal/executor/client_types.go
+++ b/enterprise/internal/executor/client_types.go
@@ -60,6 +60,8 @@ type Job struct {
 	// environment variables, as well as secret values passed along with the dequeued job
 	// payload, which may be sensitive (e.g. shared API tokens, URLs with credentials).
 	RedactedValues map[string]string `json:"redactedValues"`
+
+	DockerAuthConfig string `json:"dockerAuthConfig"`
 }
 
 func (j Job) MarshalJSON() ([]byte, error) {
@@ -76,6 +78,7 @@ func (j Job) MarshalJSON() ([]byte, error) {
 			DockerSteps:         j.DockerSteps,
 			CliSteps:            j.CliSteps,
 			RedactedValues:      j.RedactedValues,
+			DockerAuthConfig:    j.DockerAuthConfig,
 		}
 		v2.VirtualMachineFiles = make(map[string]v2VirtualMachineFile, len(j.VirtualMachineFiles))
 		for k, v := range j.VirtualMachineFiles {
@@ -132,6 +135,7 @@ func (j *Job) UnmarshalJSON(data []byte) error {
 		j.DockerSteps = v2.DockerSteps
 		j.CliSteps = v2.CliSteps
 		j.RedactedValues = v2.RedactedValues
+		j.DockerAuthConfig = v2.DockerAuthConfig
 		return nil
 	}
 	var v1 v1Job
@@ -177,6 +181,7 @@ type v2Job struct {
 	DockerSteps         []DockerStep                    `json:"dockerSteps"`
 	CliSteps            []CliStep                       `json:"cliSteps"`
 	RedactedValues      map[string]string               `json:"redactedValues"`
+	DockerAuthConfig    string                          `json:"dockerAuthConfig"`
 }
 
 type v1Job struct {

--- a/enterprise/internal/executor/client_types.go
+++ b/enterprise/internal/executor/client_types.go
@@ -65,7 +65,7 @@ type Job struct {
 	// when spawning containers. Used to authenticate to private registries. When set, this
 	// takes precedence over a potentially configured EXECUTOR_DOCKER_AUTH_CONFIG environment
 	// variable.
-	DockerAuthConfig string `json:"dockerAuthConfig"`
+	DockerAuthConfig DockerAuthConfig `json:"dockerAuthConfig"`
 }
 
 func (j Job) MarshalJSON() ([]byte, error) {
@@ -185,7 +185,7 @@ type v2Job struct {
 	DockerSteps         []DockerStep                    `json:"dockerSteps"`
 	CliSteps            []CliStep                       `json:"cliSteps"`
 	RedactedValues      map[string]string               `json:"redactedValues"`
-	DockerAuthConfig    string                          `json:"dockerAuthConfig"`
+	DockerAuthConfig    DockerAuthConfig                `json:"dockerAuthConfig"`
 }
 
 type v1Job struct {
@@ -338,4 +338,20 @@ type HeartbeatResponse struct {
 type CanceledJobsRequest struct {
 	KnownJobIDs  []int  `json:"knownJobIds"`
 	ExecutorName string `json:"executorName"`
+}
+
+// DockerAuthConfig represents a subset of the docker cli config with the necessary
+// fields to make authentication work.
+type DockerAuthConfig struct {
+	// Auths is a map from registry URL to auth object.
+	Auths DockerAuthConfigAuths `json:"auths"`
+}
+
+// DockerAuthConfigAuths maps a registry URL to an auth object.
+type DockerAuthConfigAuths map[string]DockerAuthConfigAuth
+
+// DockerAuthConfigAuth is a single registrys auth configuration.
+type DockerAuthConfigAuth struct {
+	// Auth is the base64 encoded credential in the format user:password.
+	Auth []byte `json:"auth"`
 }

--- a/enterprise/internal/executor/client_types.go
+++ b/enterprise/internal/executor/client_types.go
@@ -61,6 +61,10 @@ type Job struct {
 	// payload, which may be sensitive (e.g. shared API tokens, URLs with credentials).
 	RedactedValues map[string]string `json:"redactedValues"`
 
+	// DockerAuthConfig can optionally set the content of the docker CLI config to be used
+	// when spawning containers. Used to authenticate to private registries. When set, this
+	// takes precedence over a potentially configured EXECUTOR_DOCKER_AUTH_CONFIG environment
+	// variable.
 	DockerAuthConfig string `json:"dockerAuthConfig"`
 }
 

--- a/enterprise/internal/executor/client_types_test.go
+++ b/enterprise/internal/executor/client_types_test.go
@@ -78,6 +78,7 @@ func TestJob_MarshalJSON(t *testing.T) {
 				"modifiedAt": "2022-10-07T18:55:45.831031-06:00"
 			}
 		},
+		"dockerAuthConfig": {},
 		"dockerSteps": [{
 			"image": "my-image",
 			"commands": ["run"],


### PR DESCRIPTION
This PR adds support for private registries to executors, so for code intel auto-indexing and server-side batch changes.
It does so by introducing a new environment variable and a magic secret DOCKER_AUTH_CONFIG that can be set to authenticate to a protected docker registry. See the inline docs change for how this works exactly. I've also added storybooks coverage for the new components, so make sure to check out the UI review check.

There are two pending TODOs left but they shouldn't affect the code much so opening up for review now to get eyes on this!

Pending TODOs:

- I need to roll this out to a dogfood cluster and test in firecracker (not on Mac 🙃)

Sister PRs:

- https://github.com/sourcegraph/terraform-google-executors/pull/74
- https://github.com/sourcegraph/terraform-aws-executors/pull/57

Closes https://github.com/sourcegraph/sourcegraph/issues/40479

## Test plan

Verified all documented variants work locally and will test before merge on a dogfood instance to verify firecracker works as well.