### PR TITLE
insights: ensure backfill retries that have only terminal errors don't retry

### DIFF
--- a/enterprise/internal/insights/scheduler/iterator/repo_iterator.go
+++ b/enterprise/internal/insights/scheduler/iterator/repo_iterator.go
@@ -428,6 +428,7 @@ func (p *PersistentRepoIterator) resetRetry(config IterationConfig) {
 	for repo, val := range p.errors {
 		if config.MaxFailures > 0 && val.FailureCount >= config.MaxFailures {
 			p.terminalErrors[repo] = val
+			delete(p.errors, repo)
 			continue
 		}
 		retry = append(retry, repo)

--- a/enterprise/internal/insights/scheduler/iterator/repo_iterator_test.go
+++ b/enterprise/internal/insights/scheduler/iterator/repo_iterator_test.go
@@ -369,7 +369,7 @@ func TestForNextRetryAndFinish(t *testing.T) {
 		require.Equal(t, float64(0), itr.PercentComplete)
 
 		jsonify, _ := json.Marshal(itr)
-		autogold.Want("ensure retry that exceeds max attempts calls back", nil).Equal(t, string(jsonify))
+		autogold.Want("ensure retry with only terminal errors reports no errors", nil).Equal(t, string(jsonify))
 	})
 }
 

--- a/enterprise/internal/insights/scheduler/iterator/repo_iterator_test.go
+++ b/enterprise/internal/insights/scheduler/iterator/repo_iterator_test.go
@@ -334,7 +334,42 @@ func TestForNextRetryAndFinish(t *testing.T) {
 		require.Equal(t, 2, terminalCount)
 
 		jsonify, _ := json.Marshal(itr)
-		autogold.Want("ensure retry that exceeds max attempts calls back", `{"Id":4,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"0001-01-01T00:00:00Z","RuntimeDuration":2000000000,"PercentComplete":0,"TotalCount":2,"SuccessCount":0,"Cursor":2}`).Equal(t, string(jsonify))
+		autogold.Want("ensure retry that exceeds max attempts calls back", `{"Id":5,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"0001-01-01T00:00:00Z","RuntimeDuration":0,"PercentComplete":0,"TotalCount":2,"SuccessCount":0,"Cursor":2}`).Equal(t, string(jsonify))
+	})
+
+	t.Run("ensure retry with all terminal errors has no errors to continue", func(t *testing.T) {
+		clock := glock.NewMockClock()
+		clock.SetCurrent(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
+		repos := []int32{1, 5}
+		itr, _ := NewWithClock(ctx, store, clock, repos)
+		var seen []api.RepoID
+
+		addError(ctx, itr, store, t)
+		addError(ctx, itr, store, t)
+		require.Equal(t, 2, itr.Cursor)
+		require.Equal(t, 2, len(itr.errors))
+		require.Equal(t, float64(0), itr.PercentComplete)
+		itr.retryRepos = nil
+
+		testForNextRetryAndFinish(t, itr, seen, func(ctx context.Context, id api.RepoID, fn FinishFunc) bool {
+			clock.Advance(time.Second * 1)
+
+			err := fn(ctx, store, errors.New("second err"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			return true
+		}, IterationConfig{MaxFailures: 1, OnTerminal: func(ctx context.Context, store *basestore.Store, repoId int32, terminalErr error) error {
+			return nil
+		}})
+
+		require.False(t, itr.HasErrors())
+		require.Equal(t, 2, len(itr.terminalErrors))
+		require.Equal(t, 2, itr.Cursor)
+		require.Equal(t, float64(0), itr.PercentComplete)
+
+		jsonify, _ := json.Marshal(itr)
+		autogold.Want("ensure retry that exceeds max attempts calls back", nil).Equal(t, string(jsonify))
 	})
 }
 

--- a/enterprise/internal/insights/scheduler/iterator/repo_iterator_test.go
+++ b/enterprise/internal/insights/scheduler/iterator/repo_iterator_test.go
@@ -334,7 +334,7 @@ func TestForNextRetryAndFinish(t *testing.T) {
 		require.Equal(t, 2, terminalCount)
 
 		jsonify, _ := json.Marshal(itr)
-		autogold.Want("ensure retry that exceeds max attempts calls back", `{"Id":5,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"0001-01-01T00:00:00Z","RuntimeDuration":0,"PercentComplete":0,"TotalCount":2,"SuccessCount":0,"Cursor":2}`).Equal(t, string(jsonify))
+		autogold.Want("ensure retry that exceeds max attempts calls back", `{"Id":4,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"0001-01-01T00:00:00Z","RuntimeDuration":2000000000,"PercentComplete":0,"TotalCount":2,"SuccessCount":0,"Cursor":2}`).Equal(t, string(jsonify))
 	})
 
 	t.Run("ensure retry with all terminal errors has no errors to continue", func(t *testing.T) {
@@ -369,7 +369,7 @@ func TestForNextRetryAndFinish(t *testing.T) {
 		require.Equal(t, float64(0), itr.PercentComplete)
 
 		jsonify, _ := json.Marshal(itr)
-		autogold.Want("ensure retry with only terminal errors reports no errors", nil).Equal(t, string(jsonify))
+		autogold.Want("ensure retry with only terminal errors reports no errors", `{"Id":5,"CreatedAt":"2021-01-01T00:00:00Z","StartedAt":"2021-01-01T00:00:00Z","CompletedAt":"0001-01-01T00:00:00Z","RuntimeDuration":0,"PercentComplete":0,"TotalCount":2,"SuccessCount":0,"Cursor":2}`).Equal(t, string(jsonify))
 	})
 }
 


### PR DESCRIPTION
This change removes terminal errors from the errors stored on the iterator when the errors are reset which happens after the backfill handler finishes iterator repos.  Without removing these errors, it  resulted in the backfill continually requeuing itself however no additional searches were run. 

closes https://github.com/sourcegraph/sourcegraph/issues/45386

## Test plan
unit test added
Recreated stuck backfill and ensured this moved it to complet
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
