### PR TITLE
insights: disallow rev: filter for insight queries

### DIFF
--- a/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-series-input/FormSeriesInput.tsx
@@ -139,8 +139,8 @@ export const FormSeriesInput: FC<FormSeriesInputProps> = props => {
                 message={
                     queryFieldDescription ?? (
                         <span>
-                            Do not include the <Code>context:</Code> or <Code>repo:</Code> filter; if needed,{' '}
-                            <Code>repo:</Code> will be added automatically.
+                            Do not include <Code>context:</Code> <Code>repo:</Code> or <Code>rev:</Code> filters; if
+                            needed, <Code>repo:</Code> will be added automatically.
                         </span>
                     )
                 }

--- a/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-series-input/validators.ts
+++ b/client/web/src/enterprise/insights/components/creation-ui/form-series/components/form-series-input/validators.ts
@@ -8,7 +8,7 @@ export const SERIES_QUERY_VALIDATORS = composeValidators([
     createRequiredValidator('Query is a required field for data series.'),
     (value: string | undefined): ValidationResult => {
         // TODO: decouple searchQueryValidator (do not use anything from capture group creation UI)
-        const { isNotContext, isNotRepo } = searchQueryValidator(value)
+        const { isNotContext, isNotRepo, isNotRev } = searchQueryValidator(value)
 
         if (!isNotContext) {
             return 'The `context:` filter is not supported; instead, run over all repositories and use the `context:` on the filter panel after creation'
@@ -16,6 +16,10 @@ export const SERIES_QUERY_VALIDATORS = composeValidators([
 
         if (!isNotRepo) {
             return 'Do not include a `repo:` filter; add targeted repositories above, or filter repos on the filter panel after creation'
+        }
+
+        if (!isNotRev) {
+            return 'The `rev:` filter is not currently supported.'
         }
     },
 ])

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/search-query-checks/SearchQueryChecks.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/search-query-checks/SearchQueryChecks.tsx
@@ -16,6 +16,7 @@ interface SearchQueryChecksProps {
         isNotRepo: true | false | undefined
         isNotCommitOrDiff: true | false | undefined
         isNoNewLines: true | false | undefined
+        isNotRev: true | false | undefined
     }
 }
 
@@ -43,6 +44,9 @@ export const SearchQueryChecks: FC<SearchQueryChecksProps> = ({ checks }) => (
         </CheckListItem>
         <CheckListItem errorMessage="shouldn't contain repo filter" valid={checks?.isNotRepo}>
             Does not contain <Code>repo:</Code> filter
+        </CheckListItem>
+        <CheckListItem errorMessage="shouldn't contain rev filter" valid={checks?.isNotRev}>
+            Does not contain <Code>rev:</Code> filter
         </CheckListItem>
         <CheckListItem errorMessage="shouldn't contain commit or diff search" valid={checks?.isNotCommitOrDiff}>
             Does not contain <Code>commit</Code> or <Code>diff</Code> search

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.test.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.test.ts
@@ -9,6 +9,7 @@ const PASSING_VALIDATION = {
     isNotContext: true,
     isNotCommitOrDiff: true,
     isNoNewLines: true,
+    isNotRev: true,
 }
 
 describe('searchQueryValidator', () => {
@@ -41,6 +42,13 @@ describe('searchQueryValidator', () => {
         expect(searchQueryValidator(`${GOOD_QUERY} \\n`)).toEqual({
             ...PASSING_VALIDATION,
             isNoNewLines: false,
+        })
+    })
+
+    it('validates not using `rev`', () => {
+        expect(searchQueryValidator(`${GOOD_QUERY} rev:any`)).toEqual({
+            ...PASSING_VALIDATION,
+            isNotRev: false,
         })
     })
 })

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.ts
@@ -9,6 +9,7 @@ export interface Checks {
     isNotContext: true | false | undefined
     isNotCommitOrDiff: true | false | undefined
     isNoNewLines: true | false | undefined
+    isNotRev: true | false | undefined
 }
 
 export const searchQueryValidator = (value: string | undefined): Checks => {
@@ -20,6 +21,7 @@ export const searchQueryValidator = (value: string | undefined): Checks => {
             isNotContext: undefined,
             isNotCommitOrDiff: undefined,
             isNoNewLines: undefined,
+            isNotRev: undefined,
         }
     }
 
@@ -49,6 +51,10 @@ export const searchQueryValidator = (value: string | undefined): Checks => {
             filter => resolveFilter(filter.field.value)?.type === FilterType.repo && filter.value
         )
 
+        const hasRev = filters.some(
+            filter => resolveFilter(filter.field.value)?.type === FilterType.rev && filter.value
+        )
+
         const hasContext = filters.some(
             filter => resolveFilter(filter.field.value)?.type === FilterType.context && filter.value
         )
@@ -70,6 +76,7 @@ export const searchQueryValidator = (value: string | undefined): Checks => {
             isNotContext: !hasContext,
             isNotCommitOrDiff: !hasCommit && !hasDiff,
             isNoNewLines: !hasNewLines,
+            isNotRev: !hasRev,
         }
     }
 
@@ -80,5 +87,6 @@ export const searchQueryValidator = (value: string | undefined): Checks => {
         isNotContext: false,
         isNotCommitOrDiff: false,
         isNoNewLines: false,
+        isNotRev: false,
     }
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeInsightCreationContent.tsx
@@ -158,8 +158,8 @@ export const ComputeInsightCreationContent: FC<ComputeInsightCreationContentProp
                         queryFieldDescription={
                             <ul className="pl-3">
                                 <li>
-                                    Do not include the <Code weight="bold">repo:</Code> filter as it will be added
-                                    automatically, if needed{' '}
+                                    Do not include <Code>context:</Code> <Code>repo:</Code> or <Code>rev:</Code>{' '}
+                                    filters; if needed, <Code>repo:</Code> will be added automatically.
                                 </li>
                                 <li>
                                     You can use <Code weight="bold">before:</Code> and <Code weight="bold">after:</Code>{' '}


### PR DESCRIPTION
When creating insights the `rev:` filters should not be allowed because they can only be used with `repo:` filters which are not allowed.

closes https://github.com/sourcegraph/sourcegraph/issues/43114

## Test plan
unit test added 
checked create screens for all insight types

<img width="561" alt="image" src="https://user-images.githubusercontent.com/6098507/206795552-ef7c81e9-6250-40c2-b698-723dcb422e5c.png">

Error message
<img width="594" alt="image" src="https://user-images.githubusercontent.com/6098507/206795480-a5795b76-9ff3-4866-a061-ce5933ed73b6.png">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cw-no-rev.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
