### PR TITLE
search contexts: show alert if default is not available

### DIFF
--- a/client/search-ui/src/input/SearchContextMenu.tsx
+++ b/client/search-ui/src/input/SearchContextMenu.tsx
@@ -79,9 +79,7 @@ export const SearchContextMenu: FC<SearchContextMenuProps> = props => {
     const infiniteScrollTrigger = useRef<HTMLDivElement | null>(null)
     const infiniteScrollList = useRef<HTMLUListElement | null>(null)
 
-    const loadNextPageUpdates = useRef(
-        new BehaviorSubject<NextPageUpdate>({ cursor: undefined, query: '' })
-    )
+    const loadNextPageUpdates = useRef(new BehaviorSubject<NextPageUpdate>({ cursor: undefined, query: '' }))
 
     const loadNextPage = useCallback((): void => {
         if (loadingState === 'DONE' && (!lastPageInfo || lastPageInfo.hasNextPage)) {


### PR DESCRIPTION
Stacked on #45489

Part of #44903

![image](https://user-images.githubusercontent.com/206864/206808595-ce474fb4-918e-453d-8d0d-3d1925bde491.png)

## Test plan

1. Using an admin user, create a public context on the global namespace
2. Log into a non-admin user and set that public context as default
3. Log back into the admin user and make that context private
4. Log back into the non-admin user and open the context dropdown. The message should now show.

Additionally, this message **shouldn't show** if a user with a default context runs a search on the menu and the results do not include the default context.