### PR TITLE
Revert "metered_searcher.go: add temporary shim for logging search request data to separate logfile"

### DIFF
--- a/dev/sg/linters/go_checks.go
+++ b/dev/sg/linters/go_checks.go
@@ -93,9 +93,6 @@ func lintLoggingLibraries() *linter {
 			"cmd/frontend/internal/app/otlpadapter",
 			// Not worth fixing the deprecated package
 			"cmd/frontend/internal/usagestatsdeprecated",
-			// Search core needs direct usage of zap for our temporary metrics collection.
-			// See https://github.com/sourcegraph/sourcegraph/pull/45229 for more information.
-			"internal/search/backend/metered_searcher.go",
 		},
 		ErrorFunc: func(bannedImport string) error {
 			return errors.Newf(`banned usage of '%s': use "github.com/sourcegraph/log" instead`,

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -2,8 +2,6 @@ package backend
 
 import (
 	"context"
-	"encoding/json"
-	"os"
 	"sync"
 	"time"
 
@@ -15,9 +13,6 @@ import (
 	sglog "github.com/sourcegraph/log"
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/query"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
@@ -31,19 +26,6 @@ var requestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Help:    "Time (in seconds) spent on request.",
 	Buckets: prometheus.DefBuckets,
 }, []string{"hostname", "category", "code"})
-
-const tempSearchCoreMetricsLogPathEnv = "SEARCH_CORE_TEMP_SEARCH_METRICS_LOG_PATH"
-
-var (
-	tempSearchCoreMetricsLoggingEnabled = os.Getenv(tempSearchCoreMetricsLogPathEnv) != ""
-
-	// tempSearchMetricsLogger is a zap.Logger that logs writes metrics data to the log file specified
-	// in the SEARCH_CORE_TEMP_SEARCH_METRICS_LOG_PATH environment variable.
-	//
-	// Note: tempSearchMetricsLogger must be shared across all metered searcher instances in order to have all
-	// writes to the log file protected by the same lock.
-	tempSearchMetricsLogger = mustInitializeTempSearchCoreMetricsLogger()
-)
 
 type meteredSearcher struct {
 	zoekt.Streamer
@@ -238,17 +220,6 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 	// Record total duration of stream
 	requestDuration.WithLabelValues(m.hostname, cat, code).Observe(time.Since(start).Seconds())
 
-	if tempSearchCoreMetricsLoggingEnabled {
-		if fields := event.Fields(); len(fields) > 0 {
-			data, marshalErr := json.Marshal(fields)
-			if marshalErr != nil {
-				tempSearchMetricsLogger.Error("failed to marshal search metrics event data", zap.Error(marshalErr))
-			} else {
-				tempSearchMetricsLogger.Info("emitting search metrics", zap.Any("data", json.RawMessage(data)))
-			}
-		}
-	}
-
 	return err
 }
 
@@ -330,53 +301,4 @@ func queryString(q query.Q) string {
 		return "<nil>"
 	}
 	return q.String()
-}
-
-// mustInitializeTempSearchCoreMetricsLogger returns a zap.Logger that's suitable for logging search metrics
-// to the log file specified in the "SEARCH_CORE_TEMP_SEARCH_METRICS_LOG_PATH" environment variable.
-// If "SEARCH_CORE_TEMP_SEARCH_METRICS_LOG_PATH" is empty, a no-op logger is returned instead.
-func mustInitializeTempSearchCoreMetricsLogger() *zap.Logger {
-	logPath := os.Getenv(tempSearchCoreMetricsLogPathEnv)
-	if logPath == "" {
-		return zap.NewNop()
-	}
-
-	// truncate the logfile on startup (so that we don't emit duplicate logs)
-	if _, err := os.Stat(logPath); err == nil {
-		_ = os.Truncate(logPath, 0)
-	}
-
-	// we use a lumberjack logger to rotate the log file
-	// (so that we don't consume too much ephemeral disk space)
-	lumberjackSync := &lumberjack.Logger{
-		Filename:   logPath,
-		MaxSize:    20, // log file can be max 20 megabytes
-		MaxBackups: 0,  // no backups
-	}
-
-	// copied from https://github.com/sourcegraph/log/blob/7d93c6ad70375de4801d6e292f23b2de407eb859/internal/encoders/config.go#L15
-	encoderConfig := zapcore.EncoderConfig{
-		NameKey:        "InstrumentationScope",
-		TimeKey:        "Timestamp",
-		EncodeTime:     zapcore.EpochNanosTimeEncoder,
-		LevelKey:       "SeverityText",
-		EncodeLevel:    zapcore.CapitalLevelEncoder,
-		MessageKey:     "Body",
-		CallerKey:      "Caller",
-		FunctionKey:    "Function",
-		StacktraceKey:  "Stacktrace",
-		LineEnding:     zapcore.DefaultLineEnding,
-		EncodeDuration: zapcore.SecondsDurationEncoder,
-		EncodeCaller:   zapcore.ShortCallerEncoder,
-	}
-
-	// using a custom zap core disables sampling by default, according to
-	// https://github.com/uber-go/zap/issues/1211#issuecomment-1337897072
-	core := zapcore.NewCore(
-		zapcore.NewJSONEncoder(encoderConfig),
-		zapcore.AddSync(lumberjackSync),
-		zapcore.InfoLevel,
-	)
-
-	return zap.New(core, zap.AddCaller())
 }


### PR DESCRIPTION
This reverts commit 5b81eb0c749860b011eac1e38134d87e7a036c7c.

This reverts the temporary search metrics logs that were introduced in #45229. 24 hours worth of logs have been collected, so I'm doing this revert now so that this won't accidentally go out on Monday's branch cut. 


## Test plan

CI