### PR TITLE
cloud: fix grammar in doc

### DIFF
--- a/doc/cloud/index.md
+++ b/doc/cloud/index.md
@@ -99,7 +99,7 @@ All Sourcegraph Cloud instances are provisioned with a Sourcegraph-managed SMTP 
 
 - [Code Monitoring](../code_monitoring/index.md) notifications
 - Inviting other users to a Sourcegraph instance, or to an organization/team on a Sourcegraph instance
-- Important updates to a user accounts (for example, creation of API keys)
+- Important updates to user accounts (for example, creation of API keys)
 - For [`builtin` authentication](../admin/auth/index.md#builtin-password-authentication), password resets and email verification
 
 By default, emails will be sent from an `@cloud.sourcegraph.com` email address. To test email delivery, refer to [sending a test email](../admin/config/email.md#sending-a-test-email).


### PR DESCRIPTION
Not a native speaker but this doesn't read right to me.

## Test plan

n/a
