### PR TITLE
chore: update GitHub automation for growth team

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -5,7 +5,6 @@ team/code-exploration:
   - '@philipp-spiess'
 
 team/iam:
-  - '@unknwon'
   - '@jplahn'
   - '@miveronese'
   - '@ryphil'
@@ -13,3 +12,9 @@ team/iam:
   - '@quinnkeast'
   - '@pjlast'
   - '@kopancek'
+
+team/growth:
+  - '@unknwon'
+  - '@rafax'
+  - '@erzhtor'
+  - '@malomarrec'


### PR DESCRIPTION
Add GitHub automation to label new issues/PRs with "team/growth". If anyone wants to opt-put, please just make a suggestion to delete and commit.

## Test plan

n/a
