### PR TITLE
Fix session id refresh

### DIFF
--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -79,7 +79,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
     private firstSourceURL?: string
     private lastSourceURL?: string
     private deviceID = ''
-    private deviceSessionID = ''
+    private deviceSessionID?: string
     private eventID = 0
     private listeners: Set<(eventName: string) => void> = new Set()
     private originalReferrer?: string

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -79,7 +79,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
     private firstSourceURL?: string
     private lastSourceURL?: string
     private deviceID = ''
-    private deviceSessionID = ''
+    const deviceSessionID = ''
     private eventID = 0
     private listeners: Set<(eventName: string) => void> = new Set()
     private originalReferrer?: string

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -405,7 +405,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
         let deviceSessionID = cookies.get(DEVICE_SESSION_ID_KEY)
         if (!deviceSessionID || deviceSessionID === '') {
             // If device ID does not exist, use the anonymous user ID value so these are consolidated.
-            deviceID = anonymousUserID
+            deviceSessionID = anonymousUserID
         }
         cookies.set(DEVICE_SESSION_ID_KEY, deviceSessionID, this.deviceSessionCookieSettings)
 

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -313,7 +313,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
     public getDeviceSessionID(): string {
         // read from the cookie, otherwise check the global variable
         let localDeviceSessionID = this.deviceSessionID
-        let deviceSessionID = this.getDeviceSessionID() || localDeviceSessionID
+        let deviceSessionID = cookies.get(DEVICE_SESSION_ID_KEY) || localDeviceSessionID
         if (!deviceSessionID || deviceSessionID === '') {
             deviceSessionID = this.getAnonymousUserID()
         }
@@ -363,7 +363,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
 
     // Grabs and sets the deviceSessionID to renew the session expiration
     // Returns TRUE if successful, FALSE if deviceSessionID cannot be stored
-    private resetSessionCookieExpiration(): boolean {
+    private SessionCookieExpiration(): boolean {
         // Function getDeviceSessionID calls cookie.set() to refresh the expiry
         let localDeviceSessionID = this.deviceSessionID
         let deviceSessionID = this.getDeviceSessionID() || localDeviceSessionID

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -71,6 +71,8 @@ const browserExtensionMessageReceived: Observable<{ platform?: string; version?:
     refCount()
 )
 
+const deviceSessionID = ''
+
 export class EventLogger implements TelemetryService, SharedEventLogger {
     private hasStrippedQueryParameters = false
 
@@ -79,7 +81,6 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
     private firstSourceURL?: string
     private lastSourceURL?: string
     private deviceID = ''
-    const deviceSessionID = ''
     private eventID = 0
     private listeners: Set<(eventName: string) => void> = new Set()
     private originalReferrer?: string

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -149,7 +149,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
      */
     public logViewEvent(pageTitle: string, eventProperties?: any, logAsActiveUser = true): void {
         // call to refresh the session
-        this.getDeviceSessionID();
+        this.resetSessionCookieExpiration();
 
         if (window.context?.userAgentIsBot || !pageTitle) {
             return
@@ -165,7 +165,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
      */
     public logPageView(eventName: string, eventProperties?: any, logAsActiveUser = true): void {
         // call to refresh the session
-        this.getDeviceSessionID();
+        this.resetSessionCookieExpiration();
 
         if (window.context?.userAgentIsBot || !eventName) {
             return
@@ -187,7 +187,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
      */
     public log(eventLabel: string, eventProperties?: any, publicArgument?: any): void {
         // call to refresh the session
-        this.getDeviceSessionID();
+        this.resetSessionCookieExpiration();
 
         for (const listener of this.listeners) {
             listener(eventLabel)
@@ -357,6 +357,16 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
         } catch {
             return ''
         }
+    }
+
+    // Grabs and sets the deviceSessionID to renew the session expiration
+    // Returns TRUE if successful, FALSE if deviceSessionID cannot be stored
+    private resetSessionCookieExpiration(): boolean {
+        // Function getDeviceSessionID calls cookie.set() to refresh the expiry
+        let deviceSessionID = this.getDeviceSessionID()
+        if(!deviceSessionID || deviceSessionID == '')
+            return false
+        return true
     }
 
     /**

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -147,6 +147,9 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
      * Page titles should be specific and human-readable in pascal case, e.g. "SearchResults" or "Blob" or "NewOrg"
      */
     public logViewEvent(pageTitle: string, eventProperties?: any, logAsActiveUser = true): void {
+        // call to refresh the session
+        this.getDeviceSessionID();
+
         if (window.context?.userAgentIsBot || !pageTitle) {
             return
         }
@@ -160,6 +163,9 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
      * @param eventName should be specific and human-readable in pascal case, e.g. "SearchResults" or "Blob" or "NewOrg"
      */
     public logPageView(eventName: string, eventProperties?: any, logAsActiveUser = true): void {
+        // call to refresh the session
+        this.getDeviceSessionID();
+
         if (window.context?.userAgentIsBot || !eventName) {
             return
         }
@@ -179,6 +185,9 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
      * search queries. The contents of this parameter are sent to our analytics systems.
      */
     public log(eventLabel: string, eventProperties?: any, publicArgument?: any): void {
+        // call to refresh the session
+        this.getDeviceSessionID();
+
         for (const listener of this.listeners) {
             listener(eventLabel)
         }
@@ -304,8 +313,12 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
         let deviceSessionID = cookies.get(DEVICE_SESSION_ID_KEY)
         if (!deviceSessionID || deviceSessionID === '') {
             deviceSessionID = uuid.v4()
-            cookies.set(DEVICE_SESSION_ID_KEY, deviceSessionID, this.deviceSessionCookieSettings)
         }
+
+        // Use cookies instead of localStorage so that the ID can be shared with subdomains (about.sourcegraph.com).
+        // Always set to renew expiry and migrate from localStorage
+        cookies.set(DEVICE_SESSION_ID_KEY, deviceSessionID, this.deviceSessionCookieSettings)
+        this.deviceSessionID = deviceSessionID
         return deviceSessionID
     }
 

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -364,7 +364,9 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
     private resetSessionCookieExpiration(): boolean {
         // Function getDeviceSessionID calls cookie.set() to refresh the expiry
         let deviceSessionID = this.getDeviceSessionID()
-        if (!deviceSessionID || deviceSessionID == '') return false
+        if (!deviceSessionID || deviceSessionID === '') {
+            return false
+        }
         return true
     }
 

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -313,7 +313,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
     public getDeviceSessionID(): string {
         let deviceSessionID = cookies.get(DEVICE_SESSION_ID_KEY)
         if (!deviceSessionID || deviceSessionID === '') {
-            deviceSessionID = uuid.v4()
+            deviceSessionID = this.getAnonymousUserID()
         }
 
         // Use cookies instead of localStorage so that the ID can be shared with subdomains (about.sourcegraph.com).

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -364,7 +364,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
     // Returns TRUE if successful, FALSE if deviceSessionID cannot be stored
     private resetSessionCookieExpiration(): boolean {
         // Function getDeviceSessionID calls cookie.set() to refresh the expiry
-        let deviceSessionID = this.getDeviceSessionID() || this.deviceSessionID
+        const deviceSessionID = this.getDeviceSessionID()
         if (!deviceSessionID || deviceSessionID === '') {
             this.deviceSessionID = deviceSessionID
             return false

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -79,7 +79,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
     private firstSourceURL?: string
     private lastSourceURL?: string
     private deviceID = ''
-    private deviceSessionID = ''
+    private deviceSessionID?: string
     private eventID = 0
     private listeners: Set<(eventName: string) => void> = new Set()
     private originalReferrer?: string
@@ -312,8 +312,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
 
     public getDeviceSessionID(): string {
         // read from the cookie, otherwise check the global variable
-        let localDeviceSessionID = this.deviceSessionID
-        let deviceSessionID = cookies.get(DEVICE_SESSION_ID_KEY) || localDeviceSessionID
+        let deviceSessionID = cookies.get(DEVICE_SESSION_ID_KEY) || this.deviceSessionID
         if (!deviceSessionID || deviceSessionID === '') {
             deviceSessionID = this.getAnonymousUserID()
         }
@@ -365,9 +364,9 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
     // Returns TRUE if successful, FALSE if deviceSessionID cannot be stored
     private resetSessionCookieExpiration(): boolean {
         // Function getDeviceSessionID calls cookie.set() to refresh the expiry
-        let localDeviceSessionID = this.deviceSessionID
-        let deviceSessionID = this.getDeviceSessionID() || localDeviceSessionID
+        let deviceSessionID = this.getDeviceSessionID() || this.deviceSessionID
         if (!deviceSessionID || deviceSessionID === '') {
+            this.deviceSessionID = deviceSessionID
             return false
         }
         return true
@@ -386,6 +385,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
     private initializeLogParameters(): void {
         let anonymousUserID = cookies.get(ANONYMOUS_USER_ID_KEY) || localStorage.getItem(ANONYMOUS_USER_ID_KEY)
         let cohortID = cookies.get(COHORT_ID_KEY)
+        this.deviceSessionID = ''
         if (!anonymousUserID) {
             anonymousUserID = uuid.v4()
             cohortID = getPreviousMonday(new Date())

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -149,7 +149,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
      */
     public logViewEvent(pageTitle: string, eventProperties?: any, logAsActiveUser = true): void {
         // call to refresh the session
-        this.resetSessionCookieExpiration();
+        this.resetSessionCookieExpiration()
 
         if (window.context?.userAgentIsBot || !pageTitle) {
             return
@@ -165,7 +165,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
      */
     public logPageView(eventName: string, eventProperties?: any, logAsActiveUser = true): void {
         // call to refresh the session
-        this.resetSessionCookieExpiration();
+        this.resetSessionCookieExpiration()
 
         if (window.context?.userAgentIsBot || !eventName) {
             return
@@ -187,7 +187,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
      */
     public log(eventLabel: string, eventProperties?: any, publicArgument?: any): void {
         // call to refresh the session
-        this.resetSessionCookieExpiration();
+        this.resetSessionCookieExpiration()
 
         for (const listener of this.listeners) {
             listener(eventLabel)
@@ -364,8 +364,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
     private resetSessionCookieExpiration(): boolean {
         // Function getDeviceSessionID calls cookie.set() to refresh the expiry
         let deviceSessionID = this.getDeviceSessionID()
-        if(!deviceSessionID || deviceSessionID == '')
-            return false
+        if (!deviceSessionID || deviceSessionID == '') return false
         return true
     }
 

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -363,7 +363,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
 
     // Grabs and sets the deviceSessionID to renew the session expiration
     // Returns TRUE if successful, FALSE if deviceSessionID cannot be stored
-    private SessionCookieExpiration(): boolean {
+    private resetSessionCookieExpiration(): boolean {
         // Function getDeviceSessionID calls cookie.set() to refresh the expiry
         let localDeviceSessionID = this.deviceSessionID
         let deviceSessionID = this.getDeviceSessionID() || localDeviceSessionID

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -79,6 +79,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
     private firstSourceURL?: string
     private lastSourceURL?: string
     private deviceID = ''
+    private deviceSessionID = ''
     private eventID = 0
     private listeners: Set<(eventName: string) => void> = new Set()
     private originalReferrer?: string
@@ -380,16 +381,24 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
         // Always set to renew expiry and migrate from localStorage
         cookies.set(ANONYMOUS_USER_ID_KEY, anonymousUserID, this.cookieSettings)
         localStorage.removeItem(ANONYMOUS_USER_ID_KEY)
+
         if (cohortID) {
             cookies.set(COHORT_ID_KEY, cohortID, this.cookieSettings)
         }
 
         let deviceID = cookies.get(DEVICE_ID_KEY)
-        if (!deviceID) {
+        if (!deviceID || deviceID === '') {
             // If device ID does not exist, use the anonymous user ID value so these are consolidated.
             deviceID = anonymousUserID
-            cookies.set(DEVICE_ID_KEY, deviceID, this.cookieSettings)
         }
+        cookies.set(DEVICE_ID_KEY, deviceID, this.cookieSettings)
+
+        let deviceSessionID = cookies.get(DEVICE_SESSION_ID_KEY)
+        if (!deviceSessionID || deviceSessionID === '') {
+            // If device ID does not exist, use the anonymous user ID value so these are consolidated.
+            deviceID = anonymousUserID
+        }
+        cookies.set(DEVICE_SESSION_ID_KEY, deviceSessionID, this.deviceSessionCookieSettings)
 
         let originalReferrer = cookies.get(ORIGINAL_REFERRER_KEY)
         if (!originalReferrer) {
@@ -409,6 +418,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
         this.anonymousUserID = anonymousUserID
         this.cohortID = cohortID
         this.deviceID = deviceID
+        this.deviceSessionID = deviceSessionID
         this.originalReferrer = originalReferrer
         this.sessionReferrer = sessionReferrer
         this.sessionFirstURL = sessionFirstURL

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -312,7 +312,8 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
 
     public getDeviceSessionID(): string {
         // read from the cookie, otherwise check the global variable
-        let deviceSessionID = cookies.get(DEVICE_SESSION_ID_KEY) || this.deviceSessionID
+        let localDeviceSessionID = this.deviceSessionID
+        let deviceSessionID = this.getDeviceSessionID() || localDeviceSessionID
         if (!deviceSessionID || deviceSessionID === '') {
             deviceSessionID = this.getAnonymousUserID()
         }
@@ -362,9 +363,10 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
 
     // Grabs and sets the deviceSessionID to renew the session expiration
     // Returns TRUE if successful, FALSE if deviceSessionID cannot be stored
-    private resetSessionCookieExpiration(): boolean {
+    private SessionCookieExpiration(): boolean {
         // Function getDeviceSessionID calls cookie.set() to refresh the expiry
-        let deviceSessionID = this.getDeviceSessionID() || this.deviceSessionID
+        let localDeviceSessionID = this.deviceSessionID
+        let deviceSessionID = this.getDeviceSessionID() || localDeviceSessionID
         if (!deviceSessionID || deviceSessionID === '') {
             return false
         }
@@ -501,26 +503,4 @@ function pageViewQueryParameters(url: string): UTMMarker {
     }
 
     return utmProps
-}
-
-function createEvent(event: string, eventProperties?: unknown, publicArgument?: unknown): Event {
-    return {
-        event,
-        userCookieID: eventLogger.getAnonymousUserID(),
-        cohortID: eventLogger.getCohortID() || null,
-        firstSourceURL: eventLogger.getFirstSourceURL(),
-        lastSourceURL: eventLogger.getLastSourceURL(),
-        referrer: eventLogger.getReferrer(),
-        originalReferrer: eventLogger.getOriginalReferrer(),
-        sessionReferrer: eventLogger.getSessionReferrer(),
-        sessionFirstURL: eventLogger.getSessionFirstURL(),
-        deviceSessionID: eventLogger.getDeviceSessionID() || this.deviceSessionID,
-        url: window.location.href,
-        source: EventSource.WEB,
-        argument: eventProperties ? JSON.stringify(eventProperties) : null,
-        publicArgument: publicArgument ? JSON.stringify(publicArgument) : null,
-        deviceID: eventLogger.getDeviceID(),
-        eventID: eventLogger.getEventID(),
-        insertID: eventLogger.getInsertID(),
-    }
 }

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -79,7 +79,7 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
     private firstSourceURL?: string
     private lastSourceURL?: string
     private deviceID = ''
-    private deviceSessionID?: string
+    private deviceSessionID = ''
     private eventID = 0
     private listeners: Set<(eventName: string) => void> = new Set()
     private originalReferrer?: string
@@ -311,7 +311,8 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
     }
 
     public getDeviceSessionID(): string {
-        let deviceSessionID = cookies.get(DEVICE_SESSION_ID_KEY)
+        // read from the cookie, otherwise check the global variable
+        let deviceSessionID = cookies.get(DEVICE_SESSION_ID_KEY) || this.deviceSessionID
         if (!deviceSessionID || deviceSessionID === '') {
             deviceSessionID = this.getAnonymousUserID()
         }


### PR DESCRIPTION
## Test plan

This is a simple fix to ensure `cookie.set()` is called to refresh the expiry.

Logical code review + lint.

## App preview:

- [Web](https://sg-web-nd-fix-session-cookie-expiry.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
