### PR TITLE
gitlab/oauth: remove nil+unused param

### DIFF
--- a/enterprise/internal/authz/gitlab/authz.go
+++ b/enterprise/internal/authz/gitlab/authz.go
@@ -126,7 +126,7 @@ func newAuthzProvider(db database.DB, urn string, a *schema.GitLabAuthorization,
 
 // NewOAuthProvider is a mockable constructor for new OAuthProvider instances.
 var NewOAuthProvider = func(op OAuthProviderOp) authz.Provider {
-	return newOAuthProvider(op, nil, nil)
+	return newOAuthProvider(op, nil)
 }
 
 // NewSudoProvider is a mockable constructor for new SudoProvider instances.

--- a/enterprise/internal/authz/gitlab/oauth.go
+++ b/enterprise/internal/authz/gitlab/oauth.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
-	"github.com/sourcegraph/sourcegraph/internal/oauthutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -49,7 +48,7 @@ type OAuthProviderOp struct {
 	DB database.DB
 }
 
-func newOAuthProvider(op OAuthProviderOp, cli httpcli.Doer, tokenRefresher oauthutil.TokenRefresher) *OAuthProvider {
+func newOAuthProvider(op OAuthProviderOp, cli httpcli.Doer) *OAuthProvider {
 	return &OAuthProvider{
 		token:     op.Token,
 		tokenType: op.TokenType,

--- a/enterprise/internal/authz/gitlab/oauth_test.go
+++ b/enterprise/internal/authz/gitlab/oauth_test.go
@@ -33,7 +33,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 	t.Run("nil account", func(t *testing.T) {
 		p := newOAuthProvider(OAuthProviderOp{
 			BaseURL: mustURL(t, "https://gitlab.com"),
-		}, nil, nil)
+		}, nil)
 		_, err := p.FetchUserPerms(context.Background(), nil, authz.FetchPermsOptions{})
 		want := "no account provided"
 		got := fmt.Sprintf("%v", err)
@@ -45,7 +45,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 	t.Run("not the code host of the account", func(t *testing.T) {
 		p := newOAuthProvider(OAuthProviderOp{
 			BaseURL: mustURL(t, "https://gitlab.com"),
-		}, nil, nil)
+		}, nil)
 		_, err := p.FetchUserPerms(context.Background(),
 			&extsvc.Account{
 				AccountSpec: extsvc.AccountSpec{
@@ -100,7 +100,6 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 				}, nil
 			},
 		},
-		nil,
 	)
 
 	gitlab.MockGetOAuthContext = func() *oauthutil.OAuthContext {
@@ -143,7 +142,7 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 	t.Run("nil repository", func(t *testing.T) {
 		p := newOAuthProvider(OAuthProviderOp{
 			BaseURL: mustURL(t, "https://gitlab.com"),
-		}, nil, nil)
+		}, nil)
 		_, err := p.FetchRepoPerms(context.Background(), nil, authz.FetchPermsOptions{})
 		want := "no repository provided"
 		got := fmt.Sprintf("%v", err)
@@ -155,7 +154,7 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 	t.Run("not the code host of the repository", func(t *testing.T) {
 		p := newOAuthProvider(OAuthProviderOp{
 			BaseURL: mustURL(t, "https://gitlab.com"),
-		}, nil, nil)
+		}, nil)
 		_, err := p.FetchRepoPerms(context.Background(),
 			&extsvc.Repository{
 				URI: "github.com/user/repo",
@@ -211,7 +210,6 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 					}, nil
 				},
 			},
-			nil,
 		)
 
 		accountIDs, err := p.FetchRepoPerms(context.Background(),
@@ -269,7 +267,6 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 					}, nil
 				},
 			},
-			nil,
 		)
 
 		accountIDs, err := p.FetchRepoPerms(context.Background(),

--- a/enterprise/internal/authz/gitlab/sudo_test.go
+++ b/enterprise/internal/authz/gitlab/sudo_test.go
@@ -397,7 +397,6 @@ func TestSudoProvider_FetchRepoPerms(t *testing.T) {
 				}, nil
 			},
 		},
-		nil,
 	)
 
 	accountIDs, err := p.FetchRepoPerms(context.Background(),


### PR DESCRIPTION
Removed an unused param that is always set to nil. 

@miveronese I think you forgot this one while dealing with #45336 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI. 