### PR TITLE
database/event_logs: add missing error handling

### DIFF
--- a/internal/database/event_logs_test.go
+++ b/internal/database/event_logs_test.go
@@ -1500,3 +1500,18 @@ func TestEventLogs_RequestsByLanguage(t *testing.T) {
 		t.Fatal(diff)
 	}
 }
+
+func TestEventLogs_IllegalPeriodType(t *testing.T) {
+	t.Run("calcStartDate", func(t *testing.T) {
+		_, err := calcStartDate(time.Now(), PeriodType("hackerman"), 3)
+		if err == nil {
+			t.Error("want err to not be nil")
+		}
+	})
+	t.Run("calcEndDate", func(t *testing.T) {
+		_, err := calcEndDate(time.Now(), PeriodType("hackerman"), 3)
+		if err == nil {
+			t.Error("want err to not be nil")
+		}
+	})
+}


### PR DESCRIPTION
@efritz while grinding through the linters warning for `unparam`, I stumbled across this bit of code. Basically, we're ignoring the safety check that `calc*Date` performs in the calling code, which causes a report about an unused returned value. 

Looking at the code, it looks legitimate that it wasn't checked, as someone would have to be really willing to break things to create an incorrect `PeriodType` out of thin air. Still, it's safe to simply handle the errors properly, though yeah, the code looks worse after. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Added a unit test. 