### PR TITLE
fuzzy finder: fix scroll behavior

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -1,6 +1,7 @@
 import React, {
     useState,
     useEffect,
+    useRef,
     useMemo,
     KeyboardEvent,
     useLayoutEffect,
@@ -41,7 +42,7 @@ import { mergedHandler } from '../../fuzzyFinder/WordSensitiveFuzzySearch'
 import { Keybindings } from '../KeyboardShortcutsHelp/KeyboardShortcutsHelp'
 
 import { fuzzyErrors, FuzzyState, FuzzyTabs, FuzzyTabKey, FuzzyScope } from './FuzzyTabs'
-import { HighlightedLink, linkStyle } from './HighlightedLink'
+import { HighlightedLink, HighlightedLinkProps, linkStyle } from './HighlightedLink'
 
 import styles from './FuzzyModal.module.scss'
 
@@ -129,6 +130,35 @@ function fuzzySearch(
     }
 }
 
+const Result: React.FC<{ file: HighlightedLinkProps; isSelected: boolean; onClickItem: () => void }> = ({
+    file,
+    isSelected,
+    onClickItem,
+}) => {
+    const ref = useRef<HTMLLIElement>(null)
+
+    useEffect(() => {
+        if (isSelected && ref.current) {
+            ref.current.scrollIntoView({ block: 'nearest' })
+        }
+    }, [isSelected])
+
+    return (
+        <li
+            ref={ref}
+            role="option"
+            aria-selected={isSelected}
+            className={classNames(
+                'd-flex align-items-center py-1 px-3 rounded-0',
+                styles.resultItem,
+                isSelected && styles.focused
+            )}
+        >
+            <HighlightedLink {...file} onClick={mergedHandler(file.onClick, onClickItem)} />
+        </li>
+    )
+}
+
 function renderFuzzyResults(
     props: RenderProps,
     focusIndex: number,
@@ -157,19 +187,12 @@ function renderFuzzyResults(
     const element = (
         <ul id={FUZZY_MODAL_RESULTS} role="listbox" aria-label="Fuzzy finder results" className="py-1 px-0 mb-0">
             {linksToRender.map((file, fileIndex) => (
-                <li
-                    id={fuzzyResultId(fileIndex)}
+                <Result
                     key={file.url || file.text}
-                    role="option"
-                    aria-selected={fileIndex === focusIndex}
-                    className={classNames(
-                        'd-flex align-items-center py-1 px-3 rounded-0',
-                        styles.resultItem,
-                        fileIndex === focusIndex && styles.focused
-                    )}
-                >
-                    <HighlightedLink {...file} onClick={mergedHandler(file.onClick, onClickItem)} />
-                </li>
+                    file={file}
+                    isSelected={focusIndex === fileIndex}
+                    onClickItem={onClickItem}
+                />
             ))}
         </ul>
     )
@@ -272,7 +295,6 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
             const index = newNumber % queryResult.resultCount
             const nextIndex = index < 0 ? queryResult.resultCount + index : index
             setFocusIndex(nextIndex)
-            document.querySelector(`#fuzzy-modal-result-${nextIndex}`)?.scrollIntoView({ block: 'center' })
         },
         [focusIndex, setFocusIndex, queryResult]
     )


### PR DESCRIPTION
Scroll to the nearest block instead of keeping the selected block in center.

https://user-images.githubusercontent.com/25318659/206981448-1a72f4c0-7657-4300-ad26-639ae0b13fdb.mov



## Test plan
Tested manually (video attached).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
