### PR TITLE
search: log error to honeycomb

### DIFF
--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -212,7 +212,7 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 	tr.LogFields(fields...)
 	event.AddField("duration_ms", time.Since(start).Milliseconds())
 	if err != nil {
-		event.AddField("error", err)
+		event.AddField("error", err.Error())
 	}
 	event.AddLogFields(fields)
 	event.Send()


### PR DESCRIPTION
Previously we logged the error directly. However, honeycomb just passes the error to JSON marshalling, so when errors occur we often just get "{}" as the value logged. Instead we now log the error string.

Test Plan: go test