### PR TITLE
search: return zoekt.Streamer from NewCachedSearcher

### DIFF
--- a/internal/search/backend/cached.go
+++ b/internal/search/backend/cached.go
@@ -21,7 +21,7 @@ type cachedSearcher struct {
 	cache map[listCacheKey]*listCacheValue
 }
 
-func NewCachedSearcher(ttl time.Duration, z zoekt.Streamer) *cachedSearcher {
+func NewCachedSearcher(ttl time.Duration, z zoekt.Streamer) zoekt.Streamer {
 	return &cachedSearcher{
 		Streamer: z,
 		ttl:      ttl,

--- a/internal/search/backend/cached_test.go
+++ b/internal/search/backend/cached_test.go
@@ -21,7 +21,7 @@ func TestCachedSearcher(t *testing.T) {
 	}
 
 	ttl := 30 * time.Second
-	s := NewCachedSearcher(ttl, ms)
+	s := NewCachedSearcher(ttl, ms).(*cachedSearcher)
 
 	now := time.Now()
 	s.now = func() time.Time { return now }


### PR DESCRIPTION
Previously we returned the concrete type which was not exported. Main reason for returning zoekt.Streamer is I just want to ensure that code-intel correctly finds all uses of List on zoekt.Streamer.

Test Plan: go test
