### PR TITLE
standardise cloud trial period to 15 days within the Cloud docs

### DIFF
--- a/doc/cloud/index.md
+++ b/doc/cloud/index.md
@@ -11,7 +11,7 @@ Sourcegraph provisions each instance in an isolated and secure cloud environment
     <div class="cloud-cta-copy">
       <h2>Get Sourcegraph on your code.</h2>
       <h3>A single-tenant instance managed by Sourcegraph.</h3>
-      <p>Sign up for a 30 day trial for your team.</p>
+      <p>Sign up for a 15 day trial for your team.</p>
     </div>
     <div class="cloud-cta-btn-container">
       <div class="visual-btn">Get free trial now</div>
@@ -29,7 +29,7 @@ If your organization has fewer than 100 developers, we recommend trying [Sourceg
 
 If you're eligible for a cloud instance, you will receive a link to the instance URL once it's provisioned. This normally takes less than one hour during business hours. From there, we recommend using the [onboarding checklist](../getting-started/cloud-instance.md) to set up your instance quickly.
 
-Trials last 30 days. When the end of the trial approaches, Sourcegraph's Customer Support team will check in with you to either help you set up a Cloud subscription or end your trial.
+Trials last 15 days. When the end of the trial approaches, Sourcegraph's Customer Support team will check in with you to either help you set up a Cloud subscription or end your trial.
 
 ## Cloud subscription
 


### PR DESCRIPTION

## Test plan
This is just a simple update of docs static text markdown content verified manually  
