### PR TITLE
search: reduce cache length in case of error or rollout

### DIFF
--- a/internal/search/backend/cached.go
+++ b/internal/search/backend/cached.go
@@ -108,6 +108,12 @@ func (c *cachedSearcher) update(ctx context.Context, q zoektquery.Q, k listCache
 		ts:   c.now(),
 	}
 
+	// If we encountered an error or a crash, shorten how long we wait before
+	// refreshing the cache.
+	if err != nil || list.Crashes > 0 {
+		v.ttl /= 4
+	}
+
 	c.cache[k] = v
 
 	return v


### PR DESCRIPTION
If we encounter an error or we are rolling out, lets not cache that information for as long. This caching behaviour only runs for ListAll queries. I expect the biggest impact for this is during rollouts of Zoekt we more quickly return to using Zoekt for all searches.

Test Plan: go test