### PR TITLE
search: handle backends missing when using repoHasContent

### DIFF
--- a/internal/search/commit/commit.go
+++ b/internal/search/commit/commit.go
@@ -98,6 +98,8 @@ func (j *SearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream 
 
 	repos := searchrepos.NewResolver(clients.Logger, clients.DB, clients.Gitserver, clients.SearcherURLs, clients.Zoekt)
 	return nil, repos.Paginate(ctx, j.RepoOpts, func(page *searchrepos.Resolved) error {
+		page.MaybeSendStats(stream)
+
 		g := group.New().WithContext(ctx).WithMaxConcurrency(j.Concurrency).WithFirstError()
 
 		for _, repoRev := range page.RepoRevs {

--- a/internal/search/job/jobutil/repo_pager_job.go
+++ b/internal/search/job/jobutil/repo_pager_job.go
@@ -85,6 +85,8 @@ func (p *repoPagerJob) Run(ctx context.Context, clients job.RuntimeClients, stre
 
 	repoResolver := repos.NewResolver(clients.Logger, clients.DB, clients.Gitserver, clients.SearcherURLs, clients.Zoekt)
 	pager := func(page *repos.Resolved) error {
+		page.MaybeSendStats(stream)
+
 		indexed, unindexed, err := zoekt.PartitionRepos(
 			ctx,
 			clients.Logger,

--- a/internal/search/job/jobutil/repos.go
+++ b/internal/search/job/jobutil/repos.go
@@ -32,6 +32,8 @@ func (s *RepoSearchJob) Run(ctx context.Context, clients job.RuntimeClients, str
 	err = repos.Paginate(ctx, s.RepoOpts, func(page *searchrepos.Resolved) error {
 		tr.LogFields(log.Int("resolved.len", len(page.RepoRevs)))
 
+		page.MaybeSendStats(stream)
+
 		descriptionMatches := make(map[api.RepoID][]result.Range)
 		if len(s.DescriptionPatterns) > 0 {
 			repoDescriptionsSet, err := s.repoDescriptions(ctx, clients.DB, page.RepoRevs)

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	searchzoekt "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -43,13 +44,30 @@ type Resolved struct {
 
 	MissingRepoRevs []RepoRevSpecs
 
+	// BackendsMissing is the number of search backends that failed to be
+	// searched. This is due to it being unreachable. The most common reason
+	// for this is during zoekt rollout.
+	BackendsMissing int
+
 	// Next points to the next page of resolved repository revisions. It will
 	// be nil if there are no more pages left.
 	Next types.MultiCursor
 }
 
+// MaybeSendStats is a convenience which will stream a stats event if r
+// contains any.
+func (r *Resolved) MaybeSendStats(stream streaming.Sender) {
+	if r.BackendsMissing > 0 {
+		stream.Send(streaming.SearchEvent{
+			Stats: streaming.Stats{
+				BackendsMissing: r.BackendsMissing,
+			},
+		})
+	}
+}
+
 func (r *Resolved) String() string {
-	return fmt.Sprintf("Resolved{RepoRevs=%d, MissingRepoRevs=%d}", len(r.RepoRevs), len(r.MissingRepoRevs))
+	return fmt.Sprintf("Resolved{RepoRevs=%d, MissingRepoRevs=%d BackendsMissing=%d}", len(r.RepoRevs), len(r.MissingRepoRevs), r.BackendsMissing)
 }
 
 func NewResolver(logger log.Logger, db database.DB, gitserverClient gitserver.Client, searcher *endpoint.Map, zoekt zoekt.Streamer) *Resolver {
@@ -91,7 +109,7 @@ func (r *Resolver) Paginate(ctx context.Context, opts search.RepoOptions, handle
 				break
 			}
 		}
-		tr.LazyPrintf("resolved %d repos, %d missing", len(page.RepoRevs), len(page.MissingRepoRevs))
+		tr.LazyPrintf("resolved %d repos, %d missing, %d backends missing", len(page.RepoRevs), len(page.MissingRepoRevs), page.BackendsMissing)
 
 		if err = handle(&page); err != nil {
 			errs = errors.Append(errs, err)
@@ -254,7 +272,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (_ Resolv
 	tr.LazyPrintf("completed rev filtering")
 
 	tr.LazyPrintf("starting contains filtering")
-	filteredRepoRevs, missingHasFileContentRevs, err := r.filterRepoHasFileContent(ctx, filteredRepoRevs, op)
+	filteredRepoRevs, missingHasFileContentRevs, backendsMissing, err := r.filterRepoHasFileContent(ctx, filteredRepoRevs, op)
 	missingRepoRevs = append(missingRepoRevs, missingHasFileContentRevs...)
 	if err != nil {
 		return Resolved{}, errors.Wrap(err, "filter has file content")
@@ -268,6 +286,7 @@ func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (_ Resolv
 	return Resolved{
 		RepoRevs:        filteredRepoRevs,
 		MissingRepoRevs: missingRepoRevs,
+		BackendsMissing: backendsMissing,
 		Next:            next,
 	}, err
 }
@@ -519,6 +538,7 @@ func (r *Resolver) filterRepoHasFileContent(
 ) (
 	_ []*search.RepositoryRevisions,
 	_ []RepoRevSpecs,
+	_ int,
 	err error,
 ) {
 	tr, ctx := trace.New(ctx, "Resolve.FilterHasFileContent", "")
@@ -530,7 +550,7 @@ func (r *Resolver) filterRepoHasFileContent(
 
 	// Early return if there are no filters
 	if len(op.HasFileContent) == 0 {
-		return repoRevs, nil, nil
+		return repoRevs, nil, 0, nil
 	}
 
 	indexed, unindexed, err := searchzoekt.PartitionRepos(
@@ -543,7 +563,7 @@ func (r *Resolver) filterRepoHasFileContent(
 		false,
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 
 	minimalRepoMap := make(map[api.RepoID]types.MinimalRepo, len(repoRevs))
@@ -571,6 +591,15 @@ func (r *Resolver) filterRepoHasFileContent(
 			}
 			repoRev.Revs = append(repoRev.Revs, rev)
 			filtered[id] = repoRev
+		}
+		backendsMissing    = 0
+		addBackendsMissing = func(c int) {
+			if c == 0 {
+				return
+			}
+			mu.Lock()
+			backendsMissing += c
+			mu.Unlock()
 		}
 	)
 
@@ -601,6 +630,8 @@ func (r *Resolver) filterRepoHasFileContent(
 				if err != nil {
 					return err
 				}
+
+				addBackendsMissing(repos.Crashes)
 
 				foundRevs := Set[repoAndRev]{}
 				for repoID, repo := range repos.Minimal {
@@ -662,7 +693,7 @@ func (r *Resolver) filterRepoHasFileContent(
 	}
 
 	if err := g.Wait(); err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 
 	// Filter the input revs to only those that matched all the contains conditions
@@ -673,8 +704,11 @@ func (r *Resolver) filterRepoHasFileContent(
 		}
 	}
 
-	tr.LogFields(otlog.Int("filteredRevCount", len(matchedRepoRevs)))
-	return matchedRepoRevs, missing, nil
+	tr.LogFields(
+		otlog.Int("filteredRevCount", len(matchedRepoRevs)),
+		otlog.Int("backendsMissing", backendsMissing),
+	)
+	return matchedRepoRevs, missing, backendsMissing, nil
 }
 
 func (r *Resolver) repoHasFileContentAtCommit(ctx context.Context, repo types.MinimalRepo, commitID api.CommitID, args query.RepoHasFileContentArgs) (bool, error) {

--- a/internal/search/structural/structural.go
+++ b/internal/search/structural/structural.go
@@ -164,6 +164,8 @@ func (s *SearchJob) Run(ctx context.Context, clients job.RuntimeClients, stream 
 
 	repos := searchrepos.NewResolver(clients.Logger, clients.DB, clients.Gitserver, clients.SearcherURLs, clients.Zoekt)
 	return nil, repos.Paginate(ctx, s.RepoOpts, func(page *searchrepos.Resolved) error {
+		page.MaybeSendStats(stream)
+
 		indexed, unindexed, err := zoektutil.PartitionRepos(
 			ctx,
 			clients.Logger,

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -222,6 +222,9 @@ func PartitionRepos(
 		return nil, repos, ctx.Err()
 	}
 
+	// Note: We do not need to handle list.Crashes since we will fallback to
+	// unindexed search for any repository unavailable due to rollout.
+
 	tr.LogFields(otlog.Int("all_indexed_set.size", len(list.Minimal)))
 
 	// Split based on indexed vs unindexed


### PR DESCRIPTION
If zoekt is rolling out it was possible that between the List done in PartitionRepos and the actual List call for reposHasContent that the underlying index has changed. We can't exactly protect for this with our current APIs. Instead, when a repoHasContent query is used during a rollout, we add a BackendsMissing event to the search. For clients like code-insights this will lead to retries/etc.

Note: I'm not a huge fan of needing to add the MaybeSendStats call. This feels like we should adjust the design so we don't need each callsite to do this. But just adding in stream to repos.Paginate feels wrong as well. So this was the compromise that felt more explicit.

Test Plan: go test and CI



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
