### PR TITLE
web: add a warning when there are no webhook logs.

### DIFF
--- a/client/web/src/site-admin/SiteAdminWebhookPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookPage.tsx
@@ -7,7 +7,18 @@ import { RouteComponentProps } from 'react-router'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { useMutation } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, ButtonLink, Container, H2, H5, LoadingSpinner, PageHeader, Tooltip } from '@sourcegraph/wildcard'
+import {
+    Alert,
+    Button,
+    ButtonLink,
+    Container,
+    H2,
+    H4,
+    H5,
+    LoadingSpinner,
+    PageHeader,
+    Tooltip,
+} from '@sourcegraph/wildcard'
 
 import { CreatedByAndUpdatedByInfoByline } from '../components/Byline/CreatedByAndUpdatedByInfoByline'
 import {
@@ -131,6 +142,13 @@ export const SiteAdminWebhookPage: FC<WebhookPageProps> = props => {
                 />
             )}
 
+            {connection?.nodes?.length === 0 && (
+                <Alert className="mt-2" variant="warning">
+                    <H4>Webhook receiver created</H4>
+                    You must create a webhook on the external code host using the endpoint below to enable this
+                    functionality.
+                </Alert>
+            )}
             <H2>Information</H2>
             {webhookData?.node && webhookData.node.__typename === 'Webhook' && (
                 <WebhookInformation webhook={webhookData.node as WebhookFields} />

--- a/client/web/src/site-admin/SiteAdminWebhookPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookPage.tsx
@@ -183,7 +183,7 @@ const Header: FC = () => (
 )
 
 const EmptyList: FC = () => (
-    <div className="m-4 w-100 text-center">
+    <div className="m-4 w-100 text-center text-muted">
         No requests received yet. Be sure to{' '}
         <Link to="/help/admin/config/webhooks#configuring-webhooks-on-the-code-host">
             configure the webhook on the code host

--- a/client/web/src/site-admin/SiteAdminWebhookPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookPage.tsx
@@ -7,18 +7,7 @@ import { RouteComponentProps } from 'react-router'
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { useMutation } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import {
-    Alert,
-    Button,
-    ButtonLink,
-    Container,
-    H2,
-    H4,
-    H5,
-    LoadingSpinner,
-    PageHeader,
-    Tooltip,
-} from '@sourcegraph/wildcard'
+import { Button, ButtonLink, Container, H2, H5, Link, LoadingSpinner, PageHeader, Tooltip } from '@sourcegraph/wildcard'
 
 import { CreatedByAndUpdatedByInfoByline } from '../components/Byline/CreatedByAndUpdatedByInfoByline'
 import {
@@ -142,13 +131,6 @@ export const SiteAdminWebhookPage: FC<WebhookPageProps> = props => {
                 />
             )}
 
-            {connection?.nodes?.length === 0 && (
-                <Alert className="mt-2" variant="warning">
-                    <H4>Webhook receiver created</H4>
-                    You must create a webhook on the external code host using the endpoint below to enable this
-                    functionality.
-                </Alert>
-            )}
             <H2>Information</H2>
             {webhookData?.node && webhookData.node.__typename === 'Webhook' && (
                 <WebhookInformation webhook={webhookData.node as WebhookFields} />
@@ -200,4 +182,12 @@ const Header: FC = () => (
     </>
 )
 
-const EmptyList: FC = () => <div className="m-4 w-100 text-center">No webhook logs found</div>
+const EmptyList: FC = () => (
+    <div className="m-4 w-100 text-center">
+        No requests received yet. Be sure to{' '}
+        <Link to="/help/admin/config/webhooks#configuring-webhooks-on-the-code-host">
+            configure the webhook on the code host
+        </Link>
+        .
+    </div>
+)


### PR DESCRIPTION
Test plan:
Storybook.

Closes https://github.com/sourcegraph/sourcegraph/issues/45325

## App preview:

- [Web](https://sg-web-ao-ui-webhooks-no-logs-warning.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
