### PR TITLE
insights(sus): remove unused parameter alert

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -1194,7 +1194,7 @@ func makeFillSeriesStrategy(ctx context.Context, tx *store.InsightStore, scopedB
 		if v2BackfillEnabled {
 			return v2HistoricFill(ctx, deprecateJustInTime, series, tx, scheduler)
 		}
-		return v1HistoricFill(ctx, deprecateJustInTime, series, tx, scopedBackfiller, insightEnqueuer)
+		return v1HistoricFill(ctx, deprecateJustInTime, series, tx, scopedBackfiller)
 	}
 }
 
@@ -1229,7 +1229,7 @@ func v2HistoricFill(ctx context.Context, deprecateJustInTime bool, series types.
 
 }
 
-func v1HistoricFill(ctx context.Context, deprecateJustInTime bool, series types.InsightSeries, tx *store.InsightStore, scopedBackfiller *background.ScopedBackfiller, insightEnqueuer *background.InsightEnqueuer) error {
+func v1HistoricFill(ctx context.Context, deprecateJustInTime bool, series types.InsightSeries, tx *store.InsightStore, scopedBackfiller *background.ScopedBackfiller) error {
 	if !deprecateJustInTime || len(series.Repositories) == 0 {
 		return nil
 	}

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -513,8 +513,7 @@ func (r *Resolver) CreateLineChartSearchInsight(ctx context.Context, args *graph
 	seriesFillStrategy := makeFillSeriesStrategy(ctx, insightTx, backfiller, r.scheduler, r.insightEnqueuer)
 
 	for _, series := range args.Input.DataSeries {
-		_, err := createAndAttachSeries(ctx, insightTx, seriesFillStrategy, view, series)
-		if err != nil {
+		if err := createAndAttachSeries(ctx, insightTx, seriesFillStrategy, view, series); err != nil {
 			return nil, errors.Wrap(err, "createAndAttachSeries")
 		}
 	}
@@ -625,16 +624,14 @@ func isCaptureGroupSeries(generatedFromCaptureGroups *bool) bool {
 func updateCaptureGroupInsight(ctx context.Context, input graphqlbackend.LineChartSearchInsightDataSeriesInput, existingSeries []types.InsightViewSeries, view types.InsightView, tx *store.InsightStore, seriesFillStrategy fillSeriesStrategy) error {
 	if len(existingSeries) == 0 {
 		// This should not happen, but if we somehow have no existing series for an insight, create one.
-		_, err := createAndAttachSeries(ctx, tx, seriesFillStrategy, view, input)
-		if err != nil {
+		if err := createAndAttachSeries(ctx, tx, seriesFillStrategy, view, input); err != nil {
 			return errors.Wrap(err, "createAndAttachSeries")
 		}
 	} else if existingSeriesHasChanged(input, existingSeries[0]) {
 		if err := tx.RemoveSeriesFromView(ctx, existingSeries[0].SeriesID, view.ID); err != nil {
 			return errors.Wrap(err, "RemoveSeriesFromView")
 		}
-		_, err := createAndAttachSeries(ctx, tx, seriesFillStrategy, view, input)
-		if err != nil {
+		if err := createAndAttachSeries(ctx, tx, seriesFillStrategy, view, input); err != nil {
 			return errors.Wrap(err, "createAndAttachSeries")
 		}
 	} else {
@@ -663,8 +660,7 @@ func updateSearchOrComputeInsight(ctx context.Context, input graphqlbackend.Upda
 		if series.SeriesId == nil {
 			// If this is a newly added series, create and attach it.
 			// Note: the frontend always generates a series ID so this path is never hit at the moment.
-			_, err := createAndAttachSeries(ctx, tx, seriesFillStrategy, view, series)
-			if err != nil {
+			if err := createAndAttachSeries(ctx, tx, seriesFillStrategy, view, series); err != nil {
 				return errors.Wrap(err, "createAndAttachSeries")
 			}
 		} else {
@@ -674,7 +670,7 @@ func updateSearchOrComputeInsight(ctx context.Context, input graphqlbackend.Upda
 					if err := tx.RemoveSeriesFromView(ctx, *series.SeriesId, view.ID); err != nil {
 						return errors.Wrap(err, "RemoveViewSeries")
 					}
-					if _, err := createAndAttachSeries(ctx, tx, seriesFillStrategy, view, series); err != nil {
+					if err := createAndAttachSeries(ctx, tx, seriesFillStrategy, view, series); err != nil {
 						return errors.Wrap(err, "createAndAttachSeries")
 					}
 				} else {
@@ -688,7 +684,7 @@ func updateSearchOrComputeInsight(ctx context.Context, input graphqlbackend.Upda
 				}
 			} else {
 				// This is a new series, so it needs to be calculated and attached.
-				if _, err := createAndAttachSeries(ctx, tx, seriesFillStrategy, view, series); err != nil {
+				if err := createAndAttachSeries(ctx, tx, seriesFillStrategy, view, series); err != nil {
 					return errors.Wrap(err, "createAndAttachSeries")
 				}
 			}
@@ -1249,7 +1245,7 @@ func v1HistoricFill(ctx context.Context, deprecateJustInTime bool, series types.
 	return nil
 }
 
-func createAndAttachSeries(ctx context.Context, tx *store.InsightStore, startSeriesFill fillSeriesStrategy, view types.InsightView, series graphqlbackend.LineChartSearchInsightDataSeriesInput) (*types.InsightSeries, error) {
+func createAndAttachSeries(ctx context.Context, tx *store.InsightStore, startSeriesFill fillSeriesStrategy, view types.InsightView, series graphqlbackend.LineChartSearchInsightDataSeriesInput) error {
 	var seriesToAdd, matchingSeries types.InsightSeries
 	var foundSeries bool
 	var err error
@@ -1257,11 +1253,11 @@ func createAndAttachSeries(ctx context.Context, tx *store.InsightStore, startSer
 	// Validate the query before creating anything; we don't want faulty insights running pointlessly.
 	if series.GroupBy != nil || series.GeneratedFromCaptureGroups != nil {
 		if _, err := querybuilder.ParseComputeQuery(series.Query); err != nil {
-			return nil, errors.Wrap(err, "query validation")
+			return errors.Wrap(err, "query validation")
 		}
 	} else {
 		if _, err := querybuilder.ParseQuery(series.Query, "literal"); err != nil {
-			return nil, errors.Wrap(err, "query validation")
+			return errors.Wrap(err, "query validation")
 		}
 	}
 
@@ -1289,7 +1285,7 @@ func createAndAttachSeries(ctx context.Context, tx *store.InsightStore, startSer
 			GroupBy:                   groupBy,
 		})
 		if err != nil {
-			return nil, errors.Wrap(err, "FindMatchingSeries")
+			return errors.Wrap(err, "FindMatchingSeries")
 		}
 	}
 
@@ -1313,11 +1309,11 @@ func createAndAttachSeries(ctx context.Context, tx *store.InsightStore, startSer
 			OldestHistoricalAt:         oldestHistoricalAt,
 		})
 		if err != nil {
-			return nil, errors.Wrap(err, "CreateSeries")
+			return errors.Wrap(err, "CreateSeries")
 		}
 		err := startSeriesFill(ctx, seriesToAdd)
 		if err != nil {
-			return nil, errors.Wrap(err, "startSeriesFill")
+			return errors.Wrap(err, "startSeriesFill")
 		}
 	} else {
 		seriesToAdd = matchingSeries
@@ -1331,10 +1327,10 @@ func createAndAttachSeries(ctx context.Context, tx *store.InsightStore, startSer
 		Stroke: emptyIfNil(series.Options.LineColor),
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "AttachSeriesToView")
+		return errors.Wrap(err, "AttachSeriesToView")
 	}
 
-	return &seriesToAdd, nil
+	return nil
 }
 
 func searchGenerationMethod(series graphqlbackend.LineChartSearchInsightDataSeriesInput) types.GenerationMethod {

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -603,11 +603,11 @@ func (r *Resolver) UpdateLineChartSearchInsight(ctx context.Context, args *graph
 	seriesFillStrategy := makeFillSeriesStrategy(ctx, tx, backfiller, r.scheduler, r.insightEnqueuer)
 
 	if captureGroupInsight {
-		if err := updateCaptureGroupInsight(ctx, args.Input.DataSeries[0], views[0].Series, view, tx, backfiller, seriesFillStrategy); err != nil {
+		if err := updateCaptureGroupInsight(ctx, args.Input.DataSeries[0], views[0].Series, view, tx, seriesFillStrategy); err != nil {
 			return nil, errors.Wrap(err, "updateCaptureGroupInsight")
 		}
 	} else {
-		if err := updateSearchOrComputeInsight(ctx, args.Input, views[0].Series, view, tx, backfiller, seriesFillStrategy); err != nil {
+		if err := updateSearchOrComputeInsight(ctx, args.Input, views[0].Series, view, tx, seriesFillStrategy); err != nil {
 			return nil, errors.Wrap(err, "updateSearchOrComputeInsight")
 		}
 	}
@@ -622,7 +622,7 @@ func isCaptureGroupSeries(generatedFromCaptureGroups *bool) bool {
 	return *generatedFromCaptureGroups
 }
 
-func updateCaptureGroupInsight(ctx context.Context, input graphqlbackend.LineChartSearchInsightDataSeriesInput, existingSeries []types.InsightViewSeries, view types.InsightView, tx *store.InsightStore, backfiller *background.ScopedBackfiller, seriesFillStrategy fillSeriesStrategy) error {
+func updateCaptureGroupInsight(ctx context.Context, input graphqlbackend.LineChartSearchInsightDataSeriesInput, existingSeries []types.InsightViewSeries, view types.InsightView, tx *store.InsightStore, seriesFillStrategy fillSeriesStrategy) error {
 	if len(existingSeries) == 0 {
 		// This should not happen, but if we somehow have no existing series for an insight, create one.
 		_, err := createAndAttachSeries(ctx, tx, seriesFillStrategy, view, input)
@@ -648,7 +648,7 @@ func updateCaptureGroupInsight(ctx context.Context, input graphqlbackend.LineCha
 	return nil
 }
 
-func updateSearchOrComputeInsight(ctx context.Context, input graphqlbackend.UpdateLineChartSearchInsightInput, existingSeries []types.InsightViewSeries, view types.InsightView, tx *store.InsightStore, backfiller *background.ScopedBackfiller, seriesFillStrategy fillSeriesStrategy) error {
+func updateSearchOrComputeInsight(ctx context.Context, input graphqlbackend.UpdateLineChartSearchInsightInput, existingSeries []types.InsightViewSeries, view types.InsightView, tx *store.InsightStore, seriesFillStrategy fillSeriesStrategy) error {
 	var existingSeriesMap = make(map[string]types.InsightViewSeries)
 	for _, existing := range existingSeries {
 		if !seriesFound(existing, input.DataSeries) {

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers_test.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers_test.go
@@ -284,7 +284,7 @@ func TestInsightViewDashboardConnections(t *testing.T) {
 	}
 
 	global := true
-	globalGrants := []store.DashboardGrant{{nil, nil, &global}}
+	globalGrants := []store.DashboardGrant{{UserID: nil, OrgID: nil, Global: &global}}
 	dashboard1 := types.Dashboard{ID: 1, Title: "dashboard with view", InsightIDs: []string{view.UniqueID}}
 	_, err = base.dashboardStore.CreateDashboard(ctx,
 		store.CreateDashboardArgs{
@@ -297,7 +297,7 @@ func TestInsightViewDashboardConnections(t *testing.T) {
 	}
 
 	userId := 1
-	privateCurrentUserGrants := []store.DashboardGrant{{&userId, nil, nil}}
+	privateCurrentUserGrants := []store.DashboardGrant{{UserID: &userId, OrgID: nil, Global: nil}}
 	dashboard2 := types.Dashboard{ID: 2, Title: "users private dashboard with view", InsightIDs: []string{view.UniqueID}}
 	_, err = base.dashboardStore.CreateDashboard(ctx,
 		store.CreateDashboardArgs{
@@ -308,7 +308,7 @@ func TestInsightViewDashboardConnections(t *testing.T) {
 		t.Fatal(err)
 	}
 	notUsersId := 2
-	privateDifferentUserGrants := []store.DashboardGrant{{&notUsersId, nil, nil}}
+	privateDifferentUserGrants := []store.DashboardGrant{{UserID: &notUsersId, OrgID: nil, Global: nil}}
 	dashboard3 := types.Dashboard{ID: 3, Title: "different users private dashboard with view", InsightIDs: []string{view.UniqueID}}
 	_, err = base.dashboardStore.CreateDashboard(ctx,
 		store.CreateDashboardArgs{

--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -497,7 +497,7 @@ func TestDeleteSnapshots(t *testing.T) {
 	}
 	recordingTimes := types.InsightSeriesRecordingTimes{
 		InsightSeriesID: 1,
-		RecordingTimes:  []types.RecordingTime{{current, true}, {current.Add(time.Hour), false}},
+		RecordingTimes:  []types.RecordingTime{{Timestamp: current, Snapshot: true}, {Timestamp: current.Add(time.Hour), Snapshot: false}},
 	}
 	if err := store.RecordSeriesPointsAndRecordingTimes(ctx, records, recordingTimes); err != nil {
 		t.Fatal(err)
@@ -533,7 +533,7 @@ func TestDeleteSnapshots(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantRecordingTimes := types.InsightSeriesRecordingTimes{1, []types.RecordingTime{{Timestamp: current.Add(time.Hour)}}}
+	wantRecordingTimes := types.InsightSeriesRecordingTimes{InsightSeriesID: 1, RecordingTimes: []types.RecordingTime{{Timestamp: current.Add(time.Hour)}}}
 	autogold.Want("snapshot recording time should have been deleted", gotRecordingTimes).Equal(t, wantRecordingTimes)
 }
 
@@ -715,12 +715,12 @@ func TestInsightSeriesRecordingTimes(t *testing.T) {
 	series1Times := []time.Time{now, now.AddDate(0, 1, 0)}
 	series2Times := []time.Time{now, now.AddDate(0, 1, 1), now.AddDate(0, -1, 1)}
 	series1 := types.InsightSeriesRecordingTimes{
-		1,
-		makeRecordings(series1Times, false),
+		InsightSeriesID: 1,
+		RecordingTimes:  makeRecordings(series1Times, false),
 	}
 	series2 := types.InsightSeriesRecordingTimes{
-		2,
-		makeRecordings(series2Times, false),
+		InsightSeriesID: 2,
+		RecordingTimes:  makeRecordings(series2Times, false),
 	}
 
 	err = timeseriesStore.SetInsightSeriesRecordingTimes(ctx, []types.InsightSeriesRecordingTimes{
@@ -755,12 +755,12 @@ func TestInsightSeriesRecordingTimes(t *testing.T) {
 			want:   autogold.Want("get all recording times for series1", stringifyTimes(series1Times)),
 		},
 		{
-			insert: &types.InsightSeriesRecordingTimes{1, makeRecordings([]time.Time{now}, true)},
+			insert: &types.InsightSeriesRecordingTimes{InsightSeriesID: 1, RecordingTimes: makeRecordings([]time.Time{now}, true)},
 			getFor: 1,
 			want:   autogold.Want("duplicates are not inserted", stringifyTimes(series1Times)),
 		},
 		{
-			insert: &types.InsightSeriesRecordingTimes{2, makeRecordings([]time.Time{now.Local()}, true)},
+			insert: &types.InsightSeriesRecordingTimes{InsightSeriesID: 2, RecordingTimes: makeRecordings([]time.Time{now.Local()}, true)},
 			getFor: 2,
 			want:   autogold.Want("UTC is always used", stringifyTimes(series2Times)),
 		},


### PR DESCRIPTION
Stumbled across this while re-enabling linters. I'm not sure to fully understand the logic and as I'm focused on the linters themselves, I'd rather let you have a second look to ensure nothing fishy is happening there. 

The unkeyed structs changes are unrelated, that's just me grinding through the warnings. 

- [ ] **TODO** remove the `sus` prefixing this commit

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI + careful review from @sourcegraph/code-insights  
