### PR TITLE
e2e: disable flaky test (admin/overview)

### DIFF
--- a/client/web/src/end-to-end/frontend-platform/site-admin.test.ts
+++ b/client/web/src/end-to-end/frontend-platform/site-admin.test.ts
@@ -28,7 +28,8 @@ describe('Site Admin', () => {
     afterEachSaveScreenshotIfFailed(() => driver.page)
     afterEachRecordCoverage(() => driver)
 
-    test('Overview', async () => {
+    // Flaky https://github.com/sourcegraph/sourcegraph/issues/45531
+    test.skip('Overview', async () => {
         await driver.page.goto(sourcegraphBaseUrl + '/site-admin')
         await driver.page.waitForSelector('[data-testid="product-certificate"', { visible: true })
     })


### PR DESCRIPTION
See https://github.com/sourcegraph/sourcegraph/issues/45531

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Should not flake anymore. 

## App preview:

- [Web](https://sg-web-jh-disable-flaky-admin-e2e-test.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
