### PR TITLE
search: add "Reindex now" to index status page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
--
+- Added a button "Reindex now" to the index status page. Admins can now force an immediate reindex of a repository. [#45533](https://github.com/sourcegraph/sourcegraph/pull/45533)
 
 ### Changed
 
@@ -49,7 +49,6 @@ All notable changes to Sourcegraph are documented in this file.
 - [search.largeFiles](https://docs.sourcegraph.com/admin/config/site_config#search-largeFiles) accepts an optional prefix `!` to negate a pattern. The order of the patterns within search.largeFiles is honored such that the last pattern matching overrides preceding patterns. For patterns that begin with a literal `!` prefix with a backslash, for example, `\!fileNameStartsWithExcl!.txt`. Previously indexed files that become excluded due to this change will remain in the index until the next reindex [#45318](https://github.com/sourcegraph/sourcegraph/pull/45318)
 - [Webhooks](https://docs.sourcegraph.com/admin/config/webhooks) have been overhauled completely and can now be found under **Site admin > Repositories > Incoming webhooks**. Webhooks that were added via code host configuration are [deprecated](https://docs.sourcegraph.com/admin/config/webhooks#deprecation-notice) and will be removed in 4.6.0.
 - Added support for receiving webhook `push` events from GitHub which will trigger Sourcegraph to fetch the latest commit rather than relying on polling.
-- Added a button "Reindex now" to the index status page. Admins can now force an immediate reindex of a repository. [#45178](https://github.com/sourcegraph/sourcegraph/pull/45178)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to Sourcegraph are documented in this file.
 - [search.largeFiles](https://docs.sourcegraph.com/admin/config/site_config#search-largeFiles) accepts an optional prefix `!` to negate a pattern. The order of the patterns within search.largeFiles is honored such that the last pattern matching overrides preceding patterns. For patterns that begin with a literal `!` prefix with a backslash, for example, `\!fileNameStartsWithExcl!.txt`. Previously indexed files that become excluded due to this change will remain in the index until the next reindex [#45318](https://github.com/sourcegraph/sourcegraph/pull/45318)
 - [Webhooks](https://docs.sourcegraph.com/admin/config/webhooks) have been overhauled completely and can now be found under **Site admin > Repositories > Incoming webhooks**. Webhooks that were added via code host configuration are [deprecated](https://docs.sourcegraph.com/admin/config/webhooks#deprecation-notice) and will be removed in 4.6.0.
 - Added support for receiving webhook `push` events from GitHub which will trigger Sourcegraph to fetch the latest commit rather than relying on polling.
+- Added a button "Reindex now" to the index status page. Admins can now force an immediate reindex of a repository. [#45178](https://github.com/sourcegraph/sourcegraph/pull/45178)
 
 ### Changed
 

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -9,16 +9,24 @@ import { map, switchMap, tap } from 'rxjs/operators'
 
 import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
 import { createAggregateError, pluralize } from '@sourcegraph/common'
-import { gql } from '@sourcegraph/http-client'
+import { gql, useMutation } from '@sourcegraph/http-client'
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
-import { Container, PageHeader, LoadingSpinner, Link, Alert, Icon, Code, H3 } from '@sourcegraph/wildcard'
+import { Button, Container, PageHeader, LoadingSpinner, Link, Alert, Icon, Code, H3 } from '@sourcegraph/wildcard'
 
 import { queryGraphQL } from '../../backend/graphql'
 import { PageTitle } from '../../components/PageTitle'
 import { Timestamp } from '../../components/time/Timestamp'
-import { RepositoryTextSearchIndexRepository, Scalars, SettingsAreaRepositoryFields } from '../../graphql-operations'
+import {
+    reindexResult,
+    reindexVariables,
+    RepositoryTextSearchIndexRepository,
+    Scalars,
+    SettingsAreaRepositoryFields,
+} from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
 import { prettyBytesBigint } from '../../util/prettyBytesBigint'
+
+import { BaseActionContainer } from './components/ActionContainer'
 
 import styles from './RepoSettingsIndexPage.module.scss'
 
@@ -77,6 +85,78 @@ function fetchRepositoryTextSearchIndex(id: Scalars['ID']): Observable<Repositor
             }
             return (data.node as RepositoryTextSearchIndexRepository).textSearchIndex
         })
+    )
+}
+
+const Reindex: React.FunctionComponent<React.PropsWithChildren<{ id: Scalars['ID'] }>> = ({ id }) => {
+    const [error, setError] = React.useState<Error | null>(null)
+    const [success, setSuccess] = React.useState<boolean>(false)
+    const [loading, setLoading] = React.useState<boolean>(false)
+
+    const useForceReindex = (id: Scalars['ID']): (() => void) => {
+        const [submitForceReindex] = useMutation<reindexResult, reindexVariables>(
+            gql`
+                mutation reindex($id: ID!) {
+                    reindexRepository(repository: $id) {
+                        alwaysNil
+                    }
+                }
+            `
+        )
+        const forceReindex = React.useCallback(() => {
+            submitForceReindex({
+                variables: { id },
+            }).then(
+                () => {
+                    setLoading(false)
+                    setSuccess(true)
+                },
+                error => {
+                    setLoading(false)
+                    setError(error)
+                }
+            )
+        }, [submitForceReindex, id])
+        return forceReindex
+    }
+
+    const forceReindex = useForceReindex(id)
+
+    return (
+        <BaseActionContainer
+            title="Trigger Reindex"
+            description={<span>Send a request to Zoekt indexserver and force an immediate reindex.</span>}
+            action={
+                <Button
+                    variant="primary"
+                    onClick={() => {
+                        setLoading(true)
+                        setError(null)
+                        setSuccess(false)
+                        forceReindex()
+                    }}
+                >
+                    Reindex now
+                </Button>
+            }
+            details={
+                <>
+                    {error && <ErrorAlert className="mt-4 mb-0" error={error} icon={false} />}
+                    {loading && (
+                        <Alert className="mt-4 mb-0" variant="primary">
+                            <LoadingSpinner /> Triggering reindex ...
+                        </Alert>
+                    )}
+                    {success && (
+                        <Alert className="mt-4 mb-0" variant="success">
+                            {' '}
+                            Reindex triggered{' '}
+                        </Alert>
+                    )}
+                </>
+            }
+            className="mt-0 mb-3"
+        />
     )
 }
 
@@ -191,6 +271,7 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                         !this.state.loading &&
                         (this.state.textSearchIndex ? (
                             <>
+                                <Reindex id={this.props.repo.id} />
                                 {this.state.textSearchIndex.refs && (
                                     <ul className={styles.refs}>
                                         {this.state.textSearchIndex.refs.map((reference, index) => (

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -149,8 +149,7 @@ const Reindex: React.FunctionComponent<React.PropsWithChildren<{ id: Scalars['ID
                     )}
                     {success && (
                         <Alert className="mt-4 mb-0" variant="success">
-                            {' '}
-                            Reindex triggered{' '}
+                            Reindex triggered
                         </Alert>
                     )}
                 </>


### PR DESCRIPTION
This is my second attempt to add a new button "Reindex now" to the index status page. See #45178 for the first attempt.

![Kapture 2022-12-12 at 13 25 20](https://user-images.githubusercontent.com/26413131/207052036-837bc6b2-1913-4027-9322-133ac0b02224.gif)

![Kapture 2022-12-12 at 14 23 47](https://user-images.githubusercontent.com/26413131/207055833-17e38b44-115e-4495-be73-9bc9d1807080.gif)


What is different from #45178?
- Use of BaseActionContainer instead of Button, hence we indicate the process states: success, failure, loading. 
- All new logic is contained in a function component

Note: 
- I didn't end up rewriting RepoSettingsIndexPage as function component, mostly because I didn't get it to work ;-). 
- The backend needs to send better error messages -> separate PR #45534 
## Test plan
- manual testing: the happy path is easily tested by just clicking "Reindex now" and inspecting the logs. For the failure case I sabotaged indexserver to cause a faulty socket connection. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-sh-add-reindex-button-2.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

