### PR TITLE
zoekt: better error messages

### DIFF
--- a/internal/search/zoekt/reindex.go
+++ b/internal/search/zoekt/reindex.go
@@ -49,13 +49,16 @@ func Reindex(ctx context.Context, name api.RepoName, id api.RepoID) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusAccepted {
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return nil
+	case http.StatusBadGateway:
+		return errors.New("Invalid response from Zoekt indexserver. The most likely cause is a broken socket connection.")
+	default:
 		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
-		return errors.New(string(b))
+		return errors.Newf("%s: %q", resp.Status, string(b))
 	}
-
-	return nil
 }


### PR DESCRIPTION
In case indexserver fails to serve on indexserver.sock, webserver will respond to frontend with a 502 Bad Gateway. Here we make sure to inform the user about the faulty socket connection.  We also return the status code and body for all other errors.

## Test plan
- manual testing via API Console

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
