### PR TITLE
search: rename "Last updated" to "Last indexed at"

### DIFF
--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -208,7 +208,7 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                                         <table className={classNames('table mb-0', styles.stats)}>
                                             <tbody>
                                                 <tr>
-                                                    <th>Last updated</th>
+                                                    <th>Last indexed at</th>
                                                     <td>
                                                         <Timestamp date={this.state.textSearchIndex.status.updatedAt} />
                                                     </td>


### PR DESCRIPTION
Tiny change of the copy. I never know whether "Last updated" means "last commit we know about" or "last time we indexed". This should make it clearer.

## Test plan
N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-sh-index-page-update-copy.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
