### PR TITLE
Use cache-first as fetchPolicy for webhook logs

### DIFF
--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -1065,6 +1065,9 @@ export const useWebhookLogsConnection = (
             const { webhookLogs } = dataOrThrowErrors(result)
             return webhookLogs
         },
+        options: {
+            fetchPolicy: 'cache-first',
+        },
     })
 
 export const CREATE_WEBHOOK_QUERY = gql`


### PR DESCRIPTION
Closes #44720 

The default policy is 'network-only': https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/http-client/src/graphql/apollo/client.ts?L68

This is different from what the Apollo docs will tell you, because this is our own implementation.

This is what's causing the double requests. However, this should not reload the entire page, it simply determines how the final data is fetched. From what I can gather, the reloading (or rather, the replacing of the combined data with the initial data) is a bug in apollo <3.6 when using the `network-only` policy (and we're using apollo version 3.5): https://github.com/apollographql/apollo-client/issues/6916

One option is to update the apollo client version, but this feels risky given that we don't know if there could be other regressions that happen because of it. Instead, this PR sets the fetchPolicy to `cache-first` instead (which is recommended in that thread, and also how we handle it in other parts of the code base).

## Test plan

Confirmed to work manually

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-pjlast-44720-fix-webhook-logs.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
