### PR TITLE
trace: fix broken logger scope

### DIFF
--- a/internal/trace/logger.go
+++ b/internal/trace/logger.go
@@ -16,7 +16,7 @@ func Logger(ctx context.Context, l log.Logger) log.Logger {
 	// Attach details about internal/trace
 	if t := TraceFromContext(ctx); t != nil {
 		if t.family != "" {
-			l = l.Scoped(t.family, "trace family")
+			l = l.With(log.String("trace.family", t.family))
 		}
 	}
 	// Attach any trace (WithTrace no-ops if empty trace is provided)


### PR DESCRIPTION
Fixes logging scopes being joined by trace family ie: `>` and instead adds the `trace.family.name` as an attribute to the logger. 

Fixes https://github.com/sourcegraph/sourcegraph/issues/42934


## Test plan

CI checks