### PR TITLE
webhooks: log `eventTypeNotFoundError` as WARN

### DIFF
--- a/cmd/frontend/webhooks/bitbucketcloud_webhooks.go
+++ b/cmd/frontend/webhooks/bitbucketcloud_webhooks.go
@@ -36,11 +36,13 @@ func (wr *WebhookRouter) HandleBitbucketCloudWebhook(logger log.Logger, w http.R
 	// Route the request based on the event type.
 	err = wr.Dispatch(ctx, eventType, extsvc.KindBitbucketCloud, codeHostURN, e)
 	if err != nil {
-		logger.Error("Error handling bitbucket cloud webhook event", log.Error(err))
+		const errorMessage = "Error handling bitbucket cloud webhook event"
 		if errcode.IsNotFound(err) {
+			logger.Warn(errorMessage, log.Error(err))
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
 		}
+		logger.Error(errorMessage, log.Error(err))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/cmd/frontend/webhooks/bitbucketserver_webhooks.go
+++ b/cmd/frontend/webhooks/bitbucketserver_webhooks.go
@@ -28,11 +28,13 @@ func (wr *WebhookRouter) HandleBitBucketServerWebhook(logger log.Logger, w http.
 	// Route the request based on the event type.
 	err = wr.Dispatch(ctx, eventType, extsvc.KindBitbucketServer, codeHostURN, e)
 	if err != nil {
-		logger.Error("Error handling bitbucket server webhook event", log.Error(err))
+		const errorMessage = "Error handling bitbucket server webhook event"
 		if errcode.IsNotFound(err) {
+			logger.Warn(errorMessage, log.Error(err))
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
 		}
+		logger.Error(errorMessage, log.Error(err))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/cmd/frontend/webhooks/github_webhooks.go
+++ b/cmd/frontend/webhooks/github_webhooks.go
@@ -92,11 +92,13 @@ func (h *GitHubWebhook) HandleWebhook(logger log.Logger, w http.ResponseWriter, 
 	// match event handlers
 	err = h.Dispatch(ctx, eventType, extsvc.KindGitHub, codeHostURN, e)
 	if err != nil {
-		logger.Error("Error handling github webhook event", log.Error(err))
+		const errorMessage = "Error handling github webhook event"
 		if errcode.IsNotFound(err) {
+			logger.Warn(errorMessage, log.Error(err))
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
 		}
+		logger.Error(errorMessage, log.Error(err))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/cmd/frontend/webhooks/gitlab_webhooks.go
+++ b/cmd/frontend/webhooks/gitlab_webhooks.go
@@ -50,11 +50,13 @@ func (wr *WebhookRouter) HandleGitLabWebhook(logger log.Logger, w http.ResponseW
 	// Route the request based on the event type.
 	err = wr.Dispatch(ctx, eventKind.ObjectKind, extsvc.KindGitLab, codeHostURN, event)
 	if err != nil {
-		logger.Error("Error handling gitlab webhook event", log.Error(err))
+		const errorMessage = "Error handling gitlab webhook event"
 		if errcode.IsNotFound(err) {
+			logger.Warn(errorMessage, log.Error(err))
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
 		}
+		logger.Error(errorMessage, log.Error(err))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }


### PR DESCRIPTION
## Test plan
Log level change, existing unit tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
