### PR TITLE
webhooks: don't return error if can't dispatch

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -89,7 +89,8 @@ func NewHandler(
 	)
 
 	wh := webhooks.WebhookRouter{
-		DB: db,
+		Logger: logger.Scoped("WebhookRouter", "handling webhook requests and dispatching them to handlers"),
+		DB:     db,
 	}
 	webhookhandlers.Init(&wh)
 	handlers.BatchesGitHubWebhook.Register(&wh)

--- a/cmd/frontend/webhooks/github_webhooks_test.go
+++ b/cmd/frontend/webhooks/github_webhooks_test.go
@@ -45,12 +45,13 @@ func TestGithubWebhookDispatchSuccess(t *testing.T) {
 }
 
 func TestGithubWebhookDispatchNoHandler(t *testing.T) {
-	h := GitHubWebhook{WebhookRouter: &WebhookRouter{}}
+	logger := logtest.Scoped(t)
+	h := GitHubWebhook{WebhookRouter: &WebhookRouter{Logger: logger}}
 	ctx := context.Background()
 
 	eventType := "test-event-1"
 	err := h.Dispatch(ctx, eventType, extsvc.KindGitHub, extsvc.CodeHostBaseURL{}, nil)
-	assert.Equal(t, eventTypeNotFoundError{codeHostKind: extsvc.KindGitHub, eventType: eventType}, err)
+	assert.Nil(t, err)
 }
 
 func TestGithubWebhookDispatchSuccessMultiple(t *testing.T) {

--- a/cmd/frontend/webhooks/webhooks_test.go
+++ b/cmd/frontend/webhooks/webhooks_test.go
@@ -88,9 +88,7 @@ func TestWebhooksHandler(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	wr := WebhookRouter{
-		DB: db,
-	}
+	wr := WebhookRouter{Logger: logger, DB: db}
 	gwh := GitHubWebhook{WebhookRouter: &wr}
 
 	webhookMiddleware := NewLogMiddleware(
@@ -220,7 +218,7 @@ func TestWebhooksHandler(t *testing.T) {
 		assert.Equal(t, expectedEvent, wh.eventReceived)
 	})
 
-	t.Run("not found handler returns 404", func(t *testing.T) {
+	t.Run("not found handler returns 200", func(t *testing.T) {
 		requestURL := fmt.Sprintf("%s/.api/webhooks/%v", srv.URL, gitHubWH.UUID)
 
 		h := hmac.New(sha1.New, []byte("githubsecret"))
@@ -239,7 +237,7 @@ func TestWebhooksHandler(t *testing.T) {
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
 
-		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
 	t.Run("GitHub with no secret returns 200", func(t *testing.T) {


### PR DESCRIPTION
This changes the webhook router to not return an error if no handler for an webhook event can be found.


## Test plan

- Existing tests