### PR TITLE
search: include error type in honeycomb error

### DIFF
--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -212,7 +213,9 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 	tr.LogFields(fields...)
 	event.AddField("duration_ms", time.Since(start).Milliseconds())
 	if err != nil {
-		event.AddField("error", err.Error())
+		// 2022-12-12 (keegan) we are getting error strings of just "{}" in
+		// honeycomb. To help track this down, lets include the error type.
+		event.AddField("error", fmt.Sprintf("%T %v", err, err))
 	}
 	event.AddLogFields(fields)
 	event.Send()


### PR DESCRIPTION
We are getting error strings of just "{}" in honeycomb. To help track this down, lets include the error type. The previous commit here I thought would fix it, but the strangeness persists.

Test Plan: go test