### PR TITLE
search: record error and crashes for zoekt.List to honeycomb 

### DIFF
--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -213,9 +212,7 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 	tr.LogFields(fields...)
 	event.AddField("duration_ms", time.Since(start).Milliseconds())
 	if err != nil {
-		// 2022-12-12 (keegan) we are getting error strings of just "{}" in
-		// honeycomb. To help track this down, lets include the error type.
-		event.AddField("error", fmt.Sprintf("%T %v", err, err))
+		event.AddField("error", err.Error())
 	}
 	event.AddLogFields(fields)
 	event.Send()

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -275,9 +275,10 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q, opts *zoekt.ListO
 	if zsl != nil {
 		event.AddField("repos", len(zsl.Repos))
 		event.AddField("minimal_repos", len(zsl.Minimal))
+		event.AddField("stats.crashes", zsl.Crashes)
 	}
 	if err != nil {
-		event.AddField("error", err)
+		event.AddField("error", err.Error())
 	}
 	event.Send()
 


### PR DESCRIPTION
This is why I was still seeing "{}" in honeycomb. I didn't update the
instrumentation around the List call. While I am here I also added in
the crashes stat since we now rely on it, even for List.

Test Plan: go test
