### PR TITLE
Fix file tree preloading for folder entries

### DIFF
--- a/client/web/src/repo/RepositoryFileTreePage.tsx
+++ b/client/web/src/repo/RepositoryFileTreePage.tsx
@@ -120,7 +120,7 @@ export const RepositoryFileTreePage: React.FunctionComponent<
                             // TODO: see if we can render without resolvedRevision.commitID
                             <TreePage
                                 {...props}
-                                commitID={context.revision}
+                                commitID={resolvedRevision?.commitID}
                                 filePath={filePath}
                                 globbing={globbing}
                                 repo={repo}


### PR DESCRIPTION
This PR fixes an issue that renders the current preloading of the entries when hovering the file tree useless.

The issue is that we use a different commitID in the GraphQL query that we're preloading vs. the one that the entries page will actually make. As a result, the caching doesn't work and we have to make another network request.

Here's a video of the current behavior:

https://user-images.githubusercontent.com/458591/207090278-c6e20318-d686-4577-ba74-c897ce1f8907.mov

I think this issue was introduced via #40982 (cc @valerybugakov) 

## Test plan

- Open a folder view for any repo on the main branch
- Hover over a sub-folder in the sidebar and observe the network request being made
- Now click on the sub-folder that you're hovering. Observe that no other entries request is being made

https://user-images.githubusercontent.com/458591/207091154-06502ddc-daa8-4ee0-82e0-61758a0cbe56.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-preload-error.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
