### PR TITLE
Only include webhook page in enterprise

### DIFF
--- a/client/web/src/enterprise/site-admin/sidebaritems.ts
+++ b/client/web/src/enterprise/site-admin/sidebaritems.ts
@@ -9,7 +9,7 @@ import {
     configurationGroup as ossConfigurationGroup,
     maintenanceGroup as ossMaintenanceGroup,
     overviewGroup,
-    repositoriesGroup,
+    repositoriesGroup as ossRepositoriesGroup,
     usersGroup,
 } from '../../site-admin/sidebaritems'
 import { SiteAdminSideBarGroup, SiteAdminSideBarGroups } from '../../site-admin/SiteAdminSidebar'
@@ -126,6 +126,17 @@ const codeIntelGroup: SiteAdminSideBarGroup = {
         {
             to: '/site-admin/code-graph/inference-configuration',
             label: 'Inference',
+        },
+    ],
+}
+
+const repositoriesGroup: SiteAdminSideBarGroup = {
+    ...ossRepositoriesGroup,
+    items: [
+        ...ossRepositoriesGroup.items,
+        {
+            label: 'Incoming webhooks',
+            to: '/site-admin/webhooks',
         },
     ],
 }

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -64,10 +64,6 @@ export const repositoriesGroup: SiteAdminSideBarGroup = {
             label: 'Repositories',
             to: '/site-admin/repositories',
         },
-        {
-            label: 'Incoming webhooks',
-            to: '/site-admin/webhooks',
-        },
     ],
 }
 


### PR DESCRIPTION

![CleanShot 2022-12-12 at 16 44 23@2x](https://user-images.githubusercontent.com/25608335/207090135-9a90eaca-79d9-44f0-a45d-8b5f74b8a432.png)

![CleanShot 2022-12-12 at 16 48 55@2x](https://user-images.githubusercontent.com/25608335/207090351-57d96cd1-d3a7-4e82-9147-0f83f22264dd.png)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Manually verified on enterprise and oss

## App preview:

- [Web](https://sg-web-bo-remove-webhooks-page-oss.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
