### PR TITLE
search: separate repo and rev before attempting to compile RepoNamePatterns regexps

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -447,11 +447,16 @@ func NewFlatJob(searchInputs *search.Inputs, f query.Flat) (job.Job, error) {
 
 					repoNamePatterns := make([]*regexp.Regexp, 0, len(repoOptions.RepoFilters))
 					for _, repoFilter := range repoOptions.RepoFilters {
-						if repoOptions.CaseSensitiveRepoFilters {
-							// escaping regexp meta characters in literal patterns is handled by call to PatternString() above
-							repoNamePatterns = append(repoNamePatterns, regexp.MustCompile(repoFilter))
-						} else {
-							repoNamePatterns = append(repoNamePatterns, regexp.MustCompile(`(?i)`+repoFilter))
+						repoFilterPrefix := strings.SplitN(repoFilter, "@", 2)
+						if repoFilterPrefix[0] != "" {
+							// Because we pass the result of f.ToBasic().PatternString() to addPatternAsRepoFilter()
+							// above, regexp meta characters in literal patterns are already escaped before the
+							// pattern is added to repoOptions, so no need to check that before compiling to regex
+							if repoOptions.CaseSensitiveRepoFilters {
+								repoNamePatterns = append(repoNamePatterns, regexp.MustCompile(repoFilterPrefix[0]))
+							} else {
+								repoNamePatterns = append(repoNamePatterns, regexp.MustCompile(`(?i)`+repoFilterPrefix[0]))
+							}
 						}
 					}
 

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -250,6 +250,26 @@ func TestNewPlanJob(t *testing.T) {
             )
           NoopJob)))))`),
 	}, {
+		query:      `repo:sourcegraph/sourcegraph rev:*refs/heads/*`,
+		protocol:   search.Streaming,
+		searchType: query.SearchTypeLucky,
+		want: autogold.Want("repo: and rev:", `
+(ALERT
+  (query . )
+  (originalQuery . )
+  (patternType . lucky)
+  (FEELINGLUCKYSEARCH
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 500)
+        (PARALLEL
+          (REPOSCOMPUTEEXCLUDED
+            (repoOpts.repoFilters.0 . sourcegraph/sourcegraph@*refs/heads/*))
+          (REPOSEARCH
+            (repoOpts.repoFilters.0 . sourcegraph/sourcegraph@*refs/heads/*)
+            (repoNamePatterns . [(?i)sourcegraph/sourcegraph])))))))`),
+	}, {
 		query:      `foo @bar`,
 		protocol:   search.Streaming,
 		searchType: query.SearchTypeRegex,

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -254,21 +254,43 @@ func TestNewPlanJob(t *testing.T) {
 		protocol:   search.Streaming,
 		searchType: query.SearchTypeLucky,
 		want: autogold.Want("repo: and rev:", `
-(ALERT
-  (query . )
-  (originalQuery . )
-  (patternType . lucky)
-  (FEELINGLUCKYSEARCH
-    (TIMEOUT
-      (timeout . 20s)
-      (LIMIT
-        (limit . 500)
-        (PARALLEL
-          (REPOSCOMPUTEEXCLUDED
-            (repoOpts.repoFilters.0 . sourcegraph/sourcegraph@*refs/heads/*))
-          (REPOSEARCH
-            (repoOpts.repoFilters.0 . sourcegraph/sourcegraph@*refs/heads/*)
-            (repoNamePatterns . [(?i)sourcegraph/sourcegraph])))))))`),
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . lucky)
+    (FEELINGLUCKYSEARCH
+      (TIMEOUT
+        (timeout . 20s)
+        (LIMIT
+          (limit . 500)
+          (PARALLEL
+            (REPOSCOMPUTEEXCLUDED
+              (repoOpts.repoFilters.0 . sourcegraph/sourcegraph@*refs/heads/*))
+            (REPOSEARCH
+              (repoOpts.repoFilters.0 . sourcegraph/sourcegraph@*refs/heads/*)
+              (repoNamePatterns . [(?i)sourcegraph/sourcegraph]))))))))`),
+	}, {
+		query:      `repo:sourcegraph/sourcegraph@*refs/heads/*`,
+		protocol:   search.Streaming,
+		searchType: query.SearchTypeLucky,
+		want: autogold.Want("repo@rev", `
+(LOG
+  (ALERT
+    (query . )
+    (originalQuery . )
+    (patternType . lucky)
+    (FEELINGLUCKYSEARCH
+      (TIMEOUT
+        (timeout . 20s)
+        (LIMIT
+          (limit . 500)
+          (PARALLEL
+            (REPOSCOMPUTEEXCLUDED
+              (repoOpts.repoFilters.0 . sourcegraph/sourcegraph@*refs/heads/*))
+            (REPOSEARCH
+              (repoOpts.repoFilters.0 . sourcegraph/sourcegraph@*refs/heads/*)
+              (repoNamePatterns . [(?i)sourcegraph/sourcegraph]))))))))`),
 	}, {
 		query:      `foo @bar`,
 		protocol:   search.Streaming,


### PR DESCRIPTION
For the purpose of highlighting repo name matches, during `RepoSearchJob` construction we attempt to compile each value in `RepoOptions.RepoFilters` to regex and then populate `RepoSearchJob.RepoNamePatterns` with those compiled regexps. However, we weren't separating the revision from the overall repo filter pattern before doing this, so if the revision happened to be invalid regex then the code would panic.

This separates the repo and rev portions of each repo filter pattern so that we only try to compile the repo portion to regex. Also, it seems like when this code panicked it prevented the "Invalid revision syntax" error from being surfaced. Now that error seems to be back as expected:

![Screen Shot 2022-12-12 at 9 48 31 AM](https://user-images.githubusercontent.com/70350613/207090146-64ed21dc-bbe3-4289-81fd-0699464cb83b.png)


## Test plan
Added unit tests to verify value of `repoNamePatterns` when rev is specified:
![Screen Shot 2022-12-12 at 10 09 08 AM](https://user-images.githubusercontent.com/70350613/207095322-f8c97947-3a5c-4942-b938-235de30460a2.png)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
