### PR TITLE
Revert "search: display an error in index page during rollout (#45524)"

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/search"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func (r *RepositoryResolver) TextSearchIndex() *repositoryTextSearchIndexResolver {
@@ -50,11 +49,6 @@ func (r *repositoryTextSearchIndexResolver) resolve(ctx context.Context) (*zoekt
 				r.entry = entry
 				latest = t
 			}
-		}
-
-		// If we failed to find an entry, make sure it isn't due to rollouts.
-		if r.entry == nil && repoList.Crashes > 0 {
-			r.err = errors.New("no index found during zoekt rollout")
 		}
 	})
 	return r.entry, r.err


### PR DESCRIPTION
This reverts commit 413be80f9fb9de8895e0ba8f40cb79445d51fd94. It break QA tests.

Test Plan: CI