### PR TITLE
monitoring(emails): update dashboards

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -4131,11 +4131,11 @@ Query: `sum(increase(src_email_send{success="false"}[30m]))`
 
 <br />
 
-#### frontend: email_deliveries_by_source
+#### frontend: email_deliveries_total
 
-<p class="subtitle">Emails successfully delivered every 5 minutes by source</p>
+<p class="subtitle">Total emails successfully delivered every 30 minutes</p>
 
-Emails successfully delivered by source.
+Total emails successfully delivered.
 
 This panel has no related alerts.
 
@@ -4146,17 +4146,17 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103110`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum by (email_source) (increase(src_email_send{success="true"}[5m]))`
+Query: `sum (increase(src_email_send{success="true"}[30m]))`
 
 </details>
 
 <br />
 
-#### frontend: email_deliveries_total
+#### frontend: email_deliveries_by_source
 
-<p class="subtitle">Total emails successfully delivered every 5 minutes</p>
+<p class="subtitle">Emails successfully delivered every 30 minutes by source</p>
 
-Total emails successfully delivered.
+Emails successfully delivered by source, i.e. product feature.
 
 This panel has no related alerts.
 
@@ -4167,7 +4167,7 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103111`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum (increase(src_email_send{success="true"}[5m]))`
+Query: `sum by (email_source) (increase(src_email_send{success="true"}[30m]))`
 
 </details>
 

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -710,26 +710,32 @@ func Frontend() *monitoring.Dashboard {
 					},
 				}, {
 					{
-						Name:        "email_deliveries_by_source",
-						Description: "emails successfully delivered every 5 minutes by source",
-						Query:       `sum by (email_source) (increase(src_email_send{success="true"}[5m]))`,
-						Panel:       monitoring.Panel().LegendFormat("{{email_source}}"),
-						NoAlert:     true, // this is a purely informational panel
-
-						Owner:          monitoring.ObservableOwnerDevOps,
-						Interpretation: "Emails successfully delivered by source.",
-					},
-					{
 						Name:        "email_deliveries_total",
-						Description: "total emails successfully delivered every 5 minutes",
-						Query:       `sum (increase(src_email_send{success="true"}[5m]))`,
-						Panel:       monitoring.Panel().LegendFormat("count"),
+						Description: "total emails successfully delivered every 30 minutes",
+						Query:       `sum (increase(src_email_send{success="true"}[30m]))`,
+						Panel:       monitoring.Panel().LegendFormat("emails"),
 						NoAlert:     true, // this is a purely informational panel
 
 						Owner:          monitoring.ObservableOwnerDevOps,
 						Interpretation: "Total emails successfully delivered.",
 
 						// use to observe behaviour of email usage across instances
+						MultiInstance: true,
+					},
+					{
+						Name:        "email_deliveries_by_source",
+						Description: "emails successfully delivered every 30 minutes by source",
+						Query:       `sum by (email_source) (increase(src_email_send{success="true"}[30m]))`,
+						Panel: monitoring.Panel().LegendFormat("{{email_source}}").
+							With(monitoring.PanelOptions.LegendOnRight()),
+						NoAlert: true, // this is a purely informational panel
+
+						Owner:          monitoring.ObservableOwnerDevOps,
+						Interpretation: "Emails successfully delivered by source, i.e. product feature.",
+
+						// use to observe behaviour of email usage across instances.
+						// cardinality is 2-4, but it is useful to be able to see the
+						// breakdown regardless across instances.
 						MultiInstance: true,
 					},
 				}},


### PR DESCRIPTION
Email throughput is not high, so the 5m aggregation is not very useful. We bump email dashboards up to 1h aggregations, and also make the per-source breakdown multi-instance so that we can examine email volume by product feature in Cloud.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

n/a