### PR TITLE
docs: add search contexts starring/default and fix inconsistent links

### DIFF
--- a/doc/code_search/explanations/features.md
+++ b/doc/code_search/explanations/features.md
@@ -75,28 +75,7 @@ Search contexts help you search the code you care about on Sourcegraph. A search
 
 Every search on Sourcegraph uses a search context. Search contexts can be defined with the contexts selector shown in the search input, or entered directly in a search query.
 
-**Sourcegraph.com** supports a [set of predefined search contexts](https://sourcegraph.com/contexts?order=spec-asc&visible=17&owner=all) that include:
-
-- The global context, `context:global`, which includes all repositories on Sourcegraph.com.
-- Search contexts for various software communities like [CNCF](https://sourcegraph.com/search?q=context:CNCF), [crates.io](https://sourcegraph.com/search?q=context:crates.io), [JVM](https://sourcegraph.com/search?q=context:JVM), and more.  
-
-If no search context is specified, `context:global` is used.
-
-**Private Sourcegraph instances** support custom search contexts:
-
-- Contexts owned by a user, such as `context:@username/context-name`, which can be private to the user or public to all users on the Sourcegraph instance.
-- Contexts at the global level, such as `context:example-context`, which can be private to site admins or public to all users on the Sourcegraph instance.
-- The global context, `context:global`, which includes all repositories on the Sourcegraph instance.
-
-This feature is currently under active development for self-hosted Sourcegraph instances and is disabled by default.
-
-Your site admin can enable search contexts on your private instance in **global settings** using the following:
-
-```json
-"experimentalFeatures": {  
-  "showSearchContext": true
-}
-```
+See the [search contexts](../how-to/search_contexts.md) documentation for instructions for using and creating search contexts.
 
 ## Multi-branch indexing <span class="badge badge-primary">experimental</span>
 

--- a/doc/code_search/explanations/index.md
+++ b/doc/code_search/explanations/index.md
@@ -1,14 +1,15 @@
 # Explanations
 
-- [Search features](features.md)
+- [Search features](explanations/features.md)
   - Use regular expressions and exact queries to perform full-text searches.
   - Perform [language-aware structural search](features.md#language-aware-structural-code-search) on code structure.
   - Search any branch and commit, with no indexing required.
   - Search [commit diffs](features.md#commit-diff-search) and [commit messages](features.md#commit-message-search) to see how code has changed.
   - Narrow your search by repository and file pattern.
   - How our [Smart Search](features.md#smart-search) query assistant works.
+  - Use [search contexts](features.md#search-contexts) to search across a set of repositories at specific revisions.
   - Curate [saved searches](features.md#saved-searches) for yourself or your org.
-  - Set up notifications for code changes that match a query.
+  - Use [code monitoring](../../code_monitoring/index.md) to set up notifications for code changes that match a query.
   - View [language statistics](features.md#statistics) for search results.
 - [Search details](search_details.md)
 - [Search tips](tips.md)

--- a/doc/code_search/explanations/index.md
+++ b/doc/code_search/explanations/index.md
@@ -1,6 +1,6 @@
 # Explanations
 
-- [Search features](explanations/features.md)
+- [Search features](features.md)
   - Use regular expressions and exact queries to perform full-text searches.
   - Perform [language-aware structural search](features.md#language-aware-structural-code-search) on code structure.
   - Search any branch and commit, with no indexing required.

--- a/doc/code_search/how-to/search_contexts.md
+++ b/doc/code_search/how-to/search_contexts.md
@@ -43,7 +43,7 @@ If a user ever loses access to their default search context (eg. the search cont
 
 The default search context is always selected when loading the Sourcegraph webapp. The one exception is when opening a link to a search query that does not contain a `context:` filter, in which case the `global` context will be used.
 
-### Starrred contexts
+### Starred contexts
 
 Any authenticated user can star a search context. To star a context, click on the star icon in the search context management page. This will cause the context to appear near the top of their search contexts list. The `global` context cannot be starred.
 

--- a/doc/code_search/how-to/search_contexts.md
+++ b/doc/code_search/how-to/search_contexts.md
@@ -4,7 +4,20 @@ Search contexts help you search the code you care about on Sourcegraph. A search
 
 Every search on Sourcegraph uses a search context. Search contexts can be defined with the contexts selector shown in the search input, or entered directly in a search query.
 
+## Available contexts
+
+**Sourcegraph.com** supports a [set of predefined search contexts](https://sourcegraph.com/contexts?order=spec-asc&visible=17&owner=all) that include:
+
+- The global context, `context:global`, which includes all repositories on Sourcegraph.com.
+- Search contexts for various software communities like [CNCF](https://sourcegraph.com/search?q=context:CNCF), [crates.io](https://sourcegraph.com/search?q=context:crates.io), [JVM](https://sourcegraph.com/search?q=context:JVM), and more.  
+
 If no search context is specified, `context:global` is used.
+
+**Private Sourcegraph instances** support custom search contexts:
+
+- Contexts owned by a user, such as `context:@username/context-name`, which can be private to the user or public to all users on the Sourcegraph instance.
+- Contexts at the global level, such as `context:example-context`, which can be private to site admins or public to all users on the Sourcegraph instance.
+- The global context, `context:global`, which includes all repositories on the Sourcegraph instance.
 
 ## Using search contexts
 
@@ -17,6 +30,31 @@ Search contexts can also be used in the search query itself. Type `context:` to 
 You can also search across multiple contexts at once using the `OR` [boolean operator](../reference/queries.md#boolean-operators). For example:
 
 `(context:release1 OR context:release2 OR context:release3) someTerribleBug` 
+
+## Organzing search contexts
+
+To organize your search contexts better, you can use a specific context as your default and star any number of contexts. This affects what context is selected when loading Sourcegraph and how the list of contexts is sorted.
+
+### Default context
+
+Any authenticated user can use a search context as their default. To set a default, go to the search context management page, open the "..." menu for a context, and click on "Use as default". If the user doesn't have a default, `global` will be used.
+
+If a user ever loses access to their default search context (eg. the search context is made private), they will see a warning at the top of the search contexts dropdown menu list and `global` will be used. If a user's default search context is deleted, `global` will immediately be set as their default.
+
+The default search context is always selected when loading the Sourcegraph webapp. The one exception is when opening a link to a search query that does not contain a `context:` filter, in which case the `global` context will be used.
+
+### Starrred contexts
+
+Any authenticated user can star a search context. To star a context, click on the star icon in the search context management page. This will cause the context to appear near the top of their search contexts list. The `global` context cannot be starred.
+
+### Sort order
+
+The order of search contexts in the search results dropdown menu list and in the search context management page is always the following:
+
+- The `global` context first
+- The user's default context, if set
+- All of the user's starred contexts
+- Any remaining contexts available
 
 ## Creating search contexts
 

--- a/doc/code_search/index.md
+++ b/doc/code_search/index.md
@@ -74,6 +74,11 @@ Sourcegraph code search helps developers perform these tasks more quickly and ef
 - [Switch from Oracle OpenGrok to Sourcegraph](how-to/opengrok.md)
 - [Create a saved search](how-to/saved_searches.md)
 - [Create a custom search snippet](how-to/snippets.md)
+- [Using and creating search contexts](how-to/search_contexts.md)
+- [Exhaustive search](how-to/exhaustive.md)
+- [How to create a search context with the GraphQL API](how-to/create_search_context_graphql.md)
+- [How to convert repository groups to search contexts](how-to/convert_repository_groups_to_search_contexts.md)
+
 
 ## [Tutorials](tutorials/index.md)
 

--- a/doc/code_search/index.md
+++ b/doc/code_search/index.md
@@ -61,10 +61,10 @@ Sourcegraph code search helps developers perform these tasks more quickly and ef
   - Search any branch and commit, with no indexing required.
   - Search [commit diffs](explanations/features.md#commit-diff-search) and [commit messages](explanations/features.md#commit-message-search) to see how code has changed.
   - Narrow your search by repository and file pattern.
-  - Define saved [search scopes](explanations/features.md#search-scopes) for easier searching.
+  - How our [Smart Search](explanations/features.md#smart-search) query assistant works.
   - Use [search contexts](explanations/features.md#search-contexts) to search across a set of repositories at specific revisions.
   - Curate [saved searches](explanations/features.md#saved-searches) for yourself or your org.
-  - Use [Code monitoring](../code_monitoring/index.md) to set up notifications for code changes that match a query.
+  - Use [code monitoring](../code_monitoring/index.md) to set up notifications for code changes that match a query.
   - View [language statistics](explanations/features.md#statistics) for search results.
 - [Search details](explanations/search_details.md)
 - [Search tips](explanations/tips.md)


### PR DESCRIPTION
- Add docs on default and starred search contexts
- Fix inconsistent links between https://docs.sourcegraph.com/code_search/explanations and https://docs.sourcegraph.com/code_search#explanations
- Shuffle some docs around and update stale information (eg. search contexts are now enabled by default for everyone)

## Test plan

Docs-only change