### PR TITLE
cmd/server: likely fix server blobstore directory init problem

### DIFF
--- a/cmd/server/shared/blobstore.go
+++ b/cmd/server/shared/blobstore.go
@@ -52,6 +52,11 @@ func maybeBlobstore(logger sglog.Logger) []string {
 	// SetDefaultEnv("JCLOUDS_FILESYSTEM_BASEDIR", dataDir) // overridden above; here for equality with Dockerfile
 
 	// Configure blobstore service
+	blobstoreDataDir := os.Getenv("JCLOUDS_FILESYSTEM_BASEDIR")
+	if err := os.MkdirAll(blobstoreDataDir, os.ModePerm); err != nil {
+		logger.Error("failed to create blobstore data dir (JCLOUDS_FILESYSTEM_BASEDIR)", sglog.Error(err))
+	}
+
 	procline := `blobstore: /opt/s3proxy/run-docker-container.sh >> /var/opt/sourcegraph/blobstore.log 2>&1`
 	return []string{procline}
 }


### PR DESCRIPTION
This is an extremely low risk attempt to get a patch in for the `sourcegraph/server` issue described in https://docs.sourcegraph.com/admin/how-to/blobstore_update_notes#if-you-use-sourcegraph-server

This is the same exact logic which gitserver uses to create its data directory. If an error occurs, however, then we simply log the error instead of what gitserver does (fatal) - making this change extremely low risk. It will likely fix the issue.

## Test plan

Logically reviewed: This can only improve stability, or at the very least is guaranteed not to harm it.
