### PR TITLE
insights: Filtering by context should OR together multiple repos 

### DIFF
--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -410,12 +410,18 @@ func seriesPointsPredicates(opts SeriesPointsOpts) []*sqlf.Query {
 		preds = append(preds, sqlf.Sprintf("perm.excluded_repo IS NULL"))
 	}
 	if len(opts.IncludeRepoRegex) > 0 {
+		includePreds := []*sqlf.Query{}
 		for _, regex := range opts.IncludeRepoRegex {
 			if len(regex) == 0 {
 				continue
 			}
-			preds = append(preds, sqlf.Sprintf("rn.name ~ %s", regex))
+			includePreds = append(includePreds, sqlf.Sprintf("rn.name ~ %s", regex))
 		}
+		if len(includePreds) > 0 {
+			includes := sqlf.Sprintf("(%s)", sqlf.Join(includePreds, "OR"))
+			preds = append(preds, includes)
+		}
+
 	}
 	if len(opts.ExcludeRepoRegex) > 0 {
 		for _, regex := range opts.ExcludeRepoRegex {


### PR DESCRIPTION
When filtering an insight by a search context that contains multiple repos, the generated sql was combining the repo name conditions with an `AND` which was excluding all of the data. 

This does not effect the exclude repos case which should continue to use an `AND` condition.

closes https://github.com/sourcegraph/sourcegraph/issues/45032
## Test plan
Create a search context with two repo filters
Generate an insight over those repos
Filter the insight by the search context - all data should remain
Edit the context to only be 1 repo - filtered insight should show 1 repo of data

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
