### PR TITLE
Add license check to series card

### DIFF
--- a/client/web/src/enterprise/insights/components/creation-ui/form-series/FormSeries.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/form-series/FormSeries.tsx
@@ -69,7 +69,7 @@ export const FormSeries: FC<FormSeriesProps> = props => {
                     line && (
                         <SeriesCard
                             key={line.id}
-                            disabled={index >= 10}
+                            disabled={!licensed ? index >= 10 : false}
                             onEdit={() => editRequest(line.id)}
                             onRemove={() => deleteSeries(line.id)}
                             className={styles.formSeriesItem}


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/45575

It looks like data series over 10 are disabled for all users. Licensed users can add more than 10 data series, but the series card will be disabled. I added a check to only disable the data series card for unlicensed users if there are more than 10.

## Test plan
Tested locally
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-gabe-data-series-disabled.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
