### PR TITLE
Fuzzy finder: fix regression where  `Enter` stopped working

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -131,12 +131,13 @@ function fuzzySearch(
 }
 
 interface ResultProps {
+    fileIndex: number
     file: HighlightedLinkProps
     isSelected: boolean
     onClickItem: () => void
 }
 
-const Result: React.FC<ResultProps> = ({ file, isSelected, onClickItem }) => {
+const Result: React.FC<ResultProps> = ({ fileIndex, file, isSelected, onClickItem }) => {
     const ref = useRef<HTMLLIElement>(null)
 
     useEffect(() => {
@@ -147,6 +148,8 @@ const Result: React.FC<ResultProps> = ({ file, isSelected, onClickItem }) => {
 
     return (
         <li
+            // This ID is required to make the `Enter` shortcut work.
+            id={fuzzyResultId(fileIndex)}
             ref={ref}
             role="option"
             aria-selected={isSelected}
@@ -190,6 +193,7 @@ function renderFuzzyResults(
         <ul id={FUZZY_MODAL_RESULTS} role="listbox" aria-label="Fuzzy finder results" className="py-1 px-0 mb-0">
             {linksToRender.map((file, fileIndex) => (
                 <Result
+                    fileIndex={fileIndex}
                     key={file.url || file.text}
                     file={file}
                     isSelected={focusIndex === fileIndex}


### PR DESCRIPTION
The PR https://github.com/sourcegraph/sourcegraph/pull/45516 removed the `id` attribute that is needed to make `Enter` work. 

## Test plan

I tried to update the FuzzyFinder tests to include a case for triggering `Enter` but I wasn't able to get it working. We should get this merged before the imminent release cut so we'll need to live with manual tests for now.

First,
```
SOURCEGRAPHDOTCOM_MODE=true SOURCEGRAPH_API_URL=https://sourcegraph.com sg start web-standalone
```

Then, confirm that pressing `Enter` opens the highlighted result.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-enter-fuzzy.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
