### PR TITLE
add config to disable all codehost requests

### DIFF
--- a/doc/admin/external_service/index.md
+++ b/doc/admin/external_service/index.md
@@ -199,7 +199,7 @@ Please contact support@sourcegraph.com if you encounter rate limits.
 
 ### Temporarily disabling all git requests to codehost connections
 
-It may be the case that you'd like to temporarily disable all git requests from Sourcegraph to codehost connections. Adding the folowing json to your site configuration will this task.
+It may be the case that you'd like to temporarily disable all `git` requests from Sourcegraph to a code host. Adding the following to your site configuration will stop Sourcegraph from sending requests to the configured code host connections:
 
 ```json
 "disableAutoGitUpdates": true,    

--- a/doc/admin/external_service/index.md
+++ b/doc/admin/external_service/index.md
@@ -196,3 +196,14 @@ Some code hosts have higher rate limits for **paid** accounts and allow the crea
 Sourcegraph can leverage.
 
 Please contact support@sourcegraph.com if you encounter rate limits.
+
+### Temporarily disabling all git requests to codehost connections
+
+It may be the case that you'd like to temporarily disable all git requests from Sourcegraph to codehost connections. Adding the folowing json to your site configuration will this task.
+
+```json
+"disableAutoGitUpdates": true,    
+"disableAutoCodeHostSyncs": true,
+"gitMaxCodehostRequestsPerSecond": 0,
+```
+> WARNING: disabling all git requests to codehosts will also disable permissions syncs, batch changes, discovery of new repos and may other features. 

--- a/doc/admin/external_service/index.md
+++ b/doc/admin/external_service/index.md
@@ -201,9 +201,10 @@ Please contact support@sourcegraph.com if you encounter rate limits.
 
 It may be the case that you'd like to temporarily disable all `git` requests from Sourcegraph to a code host. Adding the following to your site configuration will stop Sourcegraph from sending requests to the configured code host connections:
 
+> WARNING: disabling all git requests to codehosts will also disable permissions syncs, batch changes, discovery of new repos and may other features. 
+
 ```json
 "disableAutoGitUpdates": true,    
 "disableAutoCodeHostSyncs": true,
 "gitMaxCodehostRequestsPerSecond": 0,
 ```
-> WARNING: disabling all git requests to codehosts will also disable permissions syncs, batch changes, discovery of new repos and may other features. 

--- a/doc/admin/external_service/index.md
+++ b/doc/admin/external_service/index.md
@@ -197,7 +197,7 @@ Sourcegraph can leverage.
 
 Please contact support@sourcegraph.com if you encounter rate limits.
 
-### Temporarily disabling all git requests to codehost connections
+### Temporarily disabling requests to code hosts
 
 It may be the case that you'd like to temporarily disable all `git` requests from Sourcegraph to a code host. Adding the following to your site configuration will stop Sourcegraph from sending requests to the configured code host connections:
 


### PR DESCRIPTION
This adds a not on how to disable all outgoing requests to codehosts 
## Test plan
docs update

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
