### PR TITLE
codeintel: Gzip SCIP document payloads

### DIFF
--- a/enterprise/internal/oobmigration/migrations/codeintel/scip_compressor.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/scip_compressor.go
@@ -1,0 +1,34 @@
+package codeintel
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"sync"
+)
+
+var compressor = &gzipCompressor{
+	writers: sync.Pool{
+		New: func() any { return gzip.NewWriter(nil) },
+	},
+}
+
+type gzipCompressor struct {
+	writers sync.Pool
+}
+
+func (c *gzipCompressor) compress(r io.Reader) ([]byte, error) {
+	gzipWriter := c.writers.Get().(*gzip.Writer)
+	defer c.writers.Put(gzipWriter)
+	compressBuf := new(bytes.Buffer)
+	gzipWriter.Reset(compressBuf)
+
+	if _, err := io.Copy(gzipWriter, r); err != nil {
+		return nil, err
+	}
+	if err := gzipWriter.Close(); err != nil {
+		return nil, err
+	}
+
+	return compressBuf.Bytes(), nil
+}

--- a/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
@@ -1,6 +1,7 @@
 package codeintel
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -249,7 +250,6 @@ func processDocument(
 	path string,
 	document DocumentData,
 ) error {
-
 	// We first read the relevant result chunks for this document into memory, writing them through to the
 	// shared result chunk cache to avoid re-fetching result chunks that are used to processed to documents
 	// in a row.
@@ -299,11 +299,16 @@ func processDocument(
 		return err
 	}
 
+	compressedPayload, err := compressor.compress(bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+
 	if err := scipWriter.Write(
 		ctx,
 		uploadID,
 		path,
-		payload,
+		compressedPayload,
 		hashPayload(payload),
 		types.ExtractSymbolIndexes(scipDocument),
 	); err != nil {


### PR DESCRIPTION
Compress SCIP document payloads in the database. There are a lot of repetitive content including hover text that gzip does a good job of compressing to about 25% of the original size.

## Test plan

WIP.