### PR TITLE
Search: Add test for repo paging with missing revs

### DIFF
--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -105,7 +105,8 @@ func (r *Resolver) Paginate(ctx context.Context, opts search.RepoOptions, handle
 		page, err := r.Resolve(ctx, opts)
 		if err != nil {
 			errs = errors.Append(errs, err)
-			if !errors.Is(err, &MissingRepoRevsError{}) { // Non-fatal errors
+			// For missing repo revs, just collect the error and keep paging
+			if !errors.Is(err, &MissingRepoRevsError{}) {
 				break
 			}
 		}

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -297,7 +297,22 @@ func TestResolverPaginate(t *testing.T) {
 		}
 	}
 
-	all, err := NewResolver(logtest.Scoped(t), db, nil, nil, nil).Resolve(ctx, search.RepoOptions{})
+	gsClient := gitserver.NewMockClient()
+	gsClient.ResolveRevisionFunc.SetDefaultHook(func(_ context.Context, name api.RepoName, spec string, _ gitserver.ResolveRevisionOptions) (api.CommitID, error) {
+		// All repos have the revision except foo/bar5
+		if name == "github.com/foo/bar5" {
+			return "", &gitdomain.RevisionNotFoundError{}
+		}
+		return "", nil
+	})
+
+	resolver := NewResolver(logtest.Scoped(t), db, gsClient, nil, nil)
+	all, err := resolver.Resolve(ctx, search.RepoOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	allAtRev, err := resolver.Resolve(ctx, search.RepoOptions{RepoFilters: []string{"foo/bar[0-4]@rev"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -334,6 +349,37 @@ func TestResolverPaginate(t *testing.T) {
 			},
 		},
 		{
+			name: "with limit 3 and missing repo revs",
+			opts: search.RepoOptions{
+				Limit:       3,
+				RepoFilters: []string{"foo/bar[0-5]@rev"},
+			},
+			err: &MissingRepoRevsError{},
+			pages: []Resolved{
+				{
+					RepoRevs: allAtRev.RepoRevs[:2],
+					MissingRepoRevs: []RepoRevSpecs{
+						{
+							Repo: all.RepoRevs[0].Repo, // corresponds to foo/bar5
+							Revs: []search.RevisionSpecifier{
+								{
+									RevSpec: "rev",
+								},
+							},
+						},
+					},
+					Next: types.MultiCursor{
+						{Column: "stars", Direction: "prev", Value: fmt.Sprint(allAtRev.RepoRevs[2].Repo.Stars)},
+						{Column: "id", Direction: "prev", Value: fmt.Sprint(allAtRev.RepoRevs[2].Repo.ID)},
+					},
+				},
+				{
+					RepoRevs:        allAtRev.RepoRevs[2:],
+					MissingRepoRevs: []RepoRevSpecs{},
+				},
+			},
+		},
+		{
 			name: "with limit 3 and cursor",
 			opts: search.RepoOptions{
 				Limit: 3,
@@ -351,16 +397,13 @@ func TestResolverPaginate(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			r := NewResolver(logtest.Scoped(t), db, nil, nil, nil)
+			r := NewResolver(logtest.Scoped(t), db, gsClient, nil, nil)
 
 			var pages []Resolved
 			err := r.Paginate(ctx, tc.opts, func(page *Resolved) error {
 				pages = append(pages, *page)
 				return nil
 			})
-			if err != nil {
-				t.Error(err)
-			}
 
 			if !errors.Is(err, tc.err) {
 				t.Errorf("%s unexpected error (-have, +want):\n%s", tc.name, cmp.Diff(err, tc.err))


### PR DESCRIPTION
If there's an error while paging through repos, we immediately fail unless the
error is for missing revisions. In this case, we collect the error and move on.
This commit adds better tests for this behavior.

Relates to #45220

## Test plan

Test-only change