### PR TITLE
codeintel: Create document batches in oobmigration

### DIFF
--- a/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
@@ -474,7 +474,6 @@ func (s *scipWriter) Write(
 	return nil
 }
 
-// TODO - document
 const DocumentsBatchSize = 256
 const MaxBatchPayloadSum = 1024 * 1024 * 32
 

--- a/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
@@ -384,9 +384,18 @@ WHERE
 `
 
 type scipWriter struct {
-	tx       *basestore.Store
-	inserter *batch.Inserter
-	uploadID int
+	tx              *basestore.Store
+	inserter        *batch.Inserter
+	uploadID        int
+	batchPayloadSum int
+	batch           []bufferedDocument
+}
+
+type bufferedDocument struct {
+	path        string
+	payload     []byte
+	payloadHash []byte
+	symbols     []types.InvertedRangeIndex
 }
 
 // makeSCIPWriter creates a small wrapper over batch inserts of SCIP data. Each document
@@ -442,40 +451,74 @@ func (s *scipWriter) Write(
 		time.Now().UnixNano()/int64(time.Millisecond)),
 	)
 
-	documentLookupID, _, err := basestore.ScanFirstInt(s.tx.Query(ctx, sqlf.Sprintf(
-		scipWriterWriteDocumentQuery,
-		append(uniquePrefix, payloadHash...),
-		payload,
-		uploadID,
-		path,
-	)))
-	if err != nil {
-		return err
+	if s.batchPayloadSum >= MaxBatchPayloadSum {
+		if err := s.flush(ctx); err != nil {
+			return err
+		}
 	}
 
-	for _, symbol := range symbols {
-		definitionRanges, err := types.EncodeRanges(symbol.DefinitionRanges)
-		if err != nil {
+	s.batch = append(s.batch, bufferedDocument{
+		path:        path,
+		payload:     payload,
+		payloadHash: append(uniquePrefix, hashPayload(payload)...),
+		symbols:     symbols,
+	})
+	s.batchPayloadSum += len(payload)
+
+	if len(s.batch) >= DocumentsBatchSize {
+		if err := s.flush(ctx); err != nil {
 			return err
 		}
-		referenceRanges, err := types.EncodeRanges(symbol.ReferenceRanges)
-		if err != nil {
-			return err
-		}
-		implementationRanges, err := types.EncodeRanges(symbol.ImplementationRanges)
+	}
+
+	return nil
+}
+
+// TODO - document
+const DocumentsBatchSize = 256
+const MaxBatchPayloadSum = 1024 * 1024 * 32
+
+func (s *scipWriter) flush(ctx context.Context) (err error) {
+	documents := s.batch
+	s.batch = nil
+	s.batchPayloadSum = 0
+
+	for _, document := range documents {
+		documentLookupID, _, err := basestore.ScanFirstInt(s.tx.Query(ctx, sqlf.Sprintf(
+			scipWriterWriteDocumentQuery,
+			document.payloadHash,
+			document.payload,
+			s.uploadID,
+			document.path,
+		)))
 		if err != nil {
 			return err
 		}
 
-		if err := s.inserter.Insert(
-			ctx,
-			documentLookupID,
-			symbol.SymbolName,
-			definitionRanges,
-			referenceRanges,
-			implementationRanges,
-		); err != nil {
-			return err
+		for _, symbol := range document.symbols {
+			definitionRanges, err := types.EncodeRanges(symbol.DefinitionRanges)
+			if err != nil {
+				return err
+			}
+			referenceRanges, err := types.EncodeRanges(symbol.ReferenceRanges)
+			if err != nil {
+				return err
+			}
+			implementationRanges, err := types.EncodeRanges(symbol.ImplementationRanges)
+			if err != nil {
+				return err
+			}
+
+			if err := s.inserter.Insert(
+				ctx,
+				documentLookupID,
+				symbol.SymbolName,
+				definitionRanges,
+				referenceRanges,
+				implementationRanges,
+			); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -497,6 +540,10 @@ RETURNING id
 // Flush ensures that all symbol writes have hit the database, and then moves all of the
 // rows from the temporary table into the permanent one.
 func (s *scipWriter) Flush(ctx context.Context) error {
+	if err := s.flush(ctx); err != nil {
+		return err
+	}
+
 	if err := s.inserter.Flush(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
This is a refactor step to make it so that multiple documents/symbols can be inserted at once. We will be able to use the new utilities introduced in #45588 to get a batch of new insertion ids in a standard way.

## Test plan

Tested by hand.