### PR TITLE
Token selection: implement pinned popover

### DIFF
--- a/client/web/src/repo/blob/codemirror/token-selection/extension.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/extension.ts
@@ -1,12 +1,12 @@
 import { Extension } from '@codemirror/state'
-import { EditorView, hoverTooltip, keymap } from '@codemirror/view'
+import { EditorView, keymap } from '@codemirror/view'
 
 import { isInteractiveOccurrence, occurrenceAtMouseEvent } from '../occurrence-utils'
 import { MOUSE_MAIN_BUTTON } from '../utils'
 
 import { definitionCache, goToDefinitionOnMouseEvent, underlinedDefinitionFacet } from './definition'
 import { documentHighlightsExtension } from './document-highlights'
-import { getHoverTooltip, hoverCache, hoveredOccurrenceField, hoverField, setHoveredOccurrenceEffect } from './hover'
+import { hoveredOccurrenceField, hoverExtension, setHoveredOccurrenceEffect } from './hover'
 import { tokenSelectionKeyBindings } from './keybindings'
 import { modifierClickFacet } from './modifier-click'
 import { selectedOccurrence, syncSelectionWithURL, tokenSelectionTheme, warmupOccurrence } from './selections'
@@ -53,10 +53,7 @@ export function tokenSelectionExtension(): Extension {
         selectedOccurrence.of(null),
         definitionCache,
         underlinedDefinitionFacet.of(null),
-        hoveredOccurrenceField,
-        hoverCache,
-        hoverTooltip((view, position) => getHoverTooltip(view, position), { hoverTime: 200, hideOnChange: true }),
-        hoverField,
+        hoverExtension(),
         keymap.of(tokenSelectionKeyBindings),
         syncSelectionWithURL,
         EditorView.domEventHandlers({

--- a/client/web/src/repo/blob/codemirror/token-selection/hover.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/hover.ts
@@ -1,15 +1,38 @@
-import { countColumn, StateEffect, StateField } from '@codemirror/state'
-import { closeHoverTooltips, EditorView, showTooltip, Tooltip } from '@codemirror/view'
+import { countColumn, Extension, StateEffect, StateField } from '@codemirror/state'
+import {
+    closeHoverTooltips,
+    EditorView,
+    hoverTooltip,
+    PluginValue,
+    showTooltip,
+    Tooltip,
+    ViewPlugin,
+    ViewUpdate,
+} from '@codemirror/view'
 
 import { HoverMerged, TextDocumentPositionParameters } from '@sourcegraph/client-api'
+import { formatSearchParameters, LineOrPositionOrRange } from '@sourcegraph/common'
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
 import { Occurrence, Position } from '@sourcegraph/shared/src/codeintel/scip'
 import { toURIWithPath } from '@sourcegraph/shared/src/util/url'
+import { BehaviorSubject, from, of, Subject, Subscription } from 'rxjs'
+import { map, switchMap } from 'rxjs/operators'
 
 import { blobPropsFacet } from '..'
+import { pin } from '../hovercard'
 import { isInteractiveOccurrence, occurrenceAtPosition } from '../occurrence-utils'
 import { CodeIntelTooltip, emptyHoverResult, HoverResult } from '../tooltips/CodeIntelTooltip'
+import { uiPositionToOffset } from '../utils'
 
+export function hoverExtension(): Extension {
+    return [
+        hoverCache,
+        hoveredOccurrenceField,
+        hoverTooltip((view, position) => getHoverTooltip(view, position), { hoverTime: 200, hideOnChange: true }),
+        hoverField,
+        pinManager,
+    ]
+}
 export const hoverCache = StateField.define<Map<Occurrence, Promise<HoverResult>>>({
     create: () => new Map(),
     update: value => value,
@@ -20,7 +43,6 @@ export const closeHover = (view: EditorView): void =>
     // fix an issue where the tooltip could get stuck if you rapidly press Space
     // before the tooltip finishes loading.
     view.dispatch({ effects: [setHoverEffect.of(null), closeHoverTooltips] })
-
 export const showHover = (view: EditorView, tooltip: Tooltip): void =>
     view.dispatch({ effects: setHoverEffect.of(tooltip) })
 
@@ -87,6 +109,61 @@ export function hoverAtOccurrence(view: EditorView, occurrence: Occurrence): Pro
     cache.set(occurrence, contents)
     return contents
 }
+
+// Extension that automatically displays the code-intel popover when the URL has
+// `popover=pinned`, and removed this URL parameter when the user clicks
+// anywhere on the file to dismiss the pinned popover.
+const pinManager = ViewPlugin.fromClass(
+    class implements PluginValue {
+        private nextPin: Subject<LineOrPositionOrRange | null>
+        private subscription: Subscription
+
+        constructor(view: EditorView) {
+            this.nextPin = new BehaviorSubject(view.state.field(pin))
+            this.subscription = this.nextPin
+                .pipe(
+                    map(pin => {
+                        if (!pin || !pin.line || !pin.character) {
+                            return null
+                        }
+
+                        return uiPositionToOffset(view.state.doc, { line: pin.line, character: pin.character })
+                    }),
+                    switchMap(pos => (pos ? from(getHoverTooltip(view, pos)) : of(null)))
+                )
+                .subscribe(tooltip =>
+                    // Scheduling the update for the next loop is necessary at the
+                    // moment because we are triggering this effect in response to an
+                    // editor update (pin field change) and you cannot synchronously
+                    // trigger an update from an update.
+                    window.requestAnimationFrame(() => view.dispatch({ effects: setHoverEffect.of(tooltip) }))
+                )
+        }
+
+        public update(update: ViewUpdate): void {
+            if (update.startState.field(pin) !== update.state.field(pin)) {
+                this.nextPin.next(update.state.field(pin))
+            }
+
+            if (update.selectionSet && update.state.field(pin)) {
+                // Remove `popover=pinned` from the URL when the user updates the selection.
+                const history = update.state.facet(blobPropsFacet).history
+                const params = new URLSearchParams(history.location.search)
+                params.delete('popover')
+                window.requestAnimationFrame(() =>
+                    // Use `history.push` instead of `history.replace` in case
+                    // the user accidentally clicked somewhere without intending to
+                    // dismiss the popover.
+                    history.push({ ...history.location, search: formatSearchParameters(params) })
+                )
+            }
+        }
+
+        public destroy(): void {
+            this.subscription.unsubscribe()
+        }
+    }
+)
 
 async function hoverRequest(
     view: EditorView,

--- a/client/web/src/repo/blob/codemirror/token-selection/hover.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/hover.ts
@@ -9,14 +9,14 @@ import {
     ViewPlugin,
     ViewUpdate,
 } from '@codemirror/view'
+import { BehaviorSubject, from, of, Subject, Subscription } from 'rxjs'
+import { map, switchMap } from 'rxjs/operators'
 
 import { HoverMerged, TextDocumentPositionParameters } from '@sourcegraph/client-api'
 import { formatSearchParameters, LineOrPositionOrRange } from '@sourcegraph/common'
 import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/common'
 import { Occurrence, Position } from '@sourcegraph/shared/src/codeintel/scip'
 import { toURIWithPath } from '@sourcegraph/shared/src/util/url'
-import { BehaviorSubject, from, of, Subject, Subscription } from 'rxjs'
-import { map, switchMap } from 'rxjs/operators'
 
 import { blobPropsFacet } from '..'
 import { pin } from '../hovercard'


### PR DESCRIPTION
Fixes #45571

Previously, the `popover=pinned` URL parameter was ignored when using selection-driven navigation. Now, the popover is loaded automatically when the URL is pinned, and the pinned popover can be dismissed by clicking anywhere in the page.

![CleanShot 2022-12-13 at 06 15 51](https://user-images.githubusercontent.com/1408093/207232668-7cb71404-c93d-4095-904c-cf1cc5332f78.gif)

## Test plan

First,
```
❯ SOURCEGRAPHDOTCOM_MODE=true SOURCEGRAPH_API_URL=https://sourcegraph.com sg start web-standalone
```

Next, confirm the following steps:

* Pin a popover by clicking on "Copy link"
* Reload the page, the pinned popover should automatically load
* Move the mouse, confirm that you see two popovers (pinned + mousemove). I originally planning to make it only show one popover at a time but realized this might be confusing behavior in the case when you have scrolled from the pinned popover so it's no longer visible in the viewport, in which case you might be surprised why moving the mouse doesn't show a popover.
* Dismiss the pinned popover by clicking anywhere in the view. Observe that `popover=pinned` gets removed from the URL.
* Un-dismiss the popover by going back in browser history. Observe that the URL gets updated to include `popover=pinned` again and the pinned popover loads again.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-pinned-popover.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
