### PR TITLE
search: increase debounce from 20ms to 150ms

### DIFF
--- a/client/shared/src/search/query/providers-utils.ts
+++ b/client/shared/src/search/query/providers-utils.ts
@@ -103,7 +103,7 @@ export function createCancelableFetchSuggestions(
                     // cancelled in the meantime.
                     // This prevents us from needlessly running multiple suggestion
                     // queries.
-                    delay(20),
+                    delay(150),
                     switchMap(query => (aborted ? Promise.resolve([]) : fetchSuggestions(query))),
                     takeUntil(abort)
                 )


### PR DESCRIPTION
Previously the debounce was 200ms, but then it got changed to 20ms in b897861176adf0f596ff309c50693c797be847b0 which is quite fast and generates a lot of requests to the server when typing fast.

150ms still feels snappy but reduces the number of search requests sent and canceled.


## Test plan

- Manual testing

## App preview:

- [Web](https://sg-web-mrn-increase-debounce.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
