### PR TITLE
remove globalTypeFilter check

### DIFF
--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -85,13 +85,15 @@ export const SearchResultsInfoBar: React.FunctionComponent<
         [props.query]
     )
 
-    const canCreateMonitorFromQuery = useMemo(() => globalTypeFilter === 'diff' || globalTypeFilter === 'commit', [
-        globalTypeFilter,
-    ])
+    const canCreateMonitorFromQuery = useMemo(
+        () => globalTypeFilter === 'diff' || globalTypeFilter === 'commit',
+        [globalTypeFilter]
+    )
 
-    const canCreateBatchChangeFromQuery = useMemo(() => globalTypeFilter !== 'diff' && globalTypeFilter !== 'commit', [
-        globalTypeFilter,
-    ])
+    const canCreateBatchChangeFromQuery = useMemo(
+        () => globalTypeFilter !== 'diff' && globalTypeFilter !== 'commit',
+        [globalTypeFilter]
+    )
 
     // When adding a new create action check and update the $collapse-breakpoint in CreateActions.module.scss.
     // The collapse breakpoint indicates at which window size we hide the buttons and show the collapsed menu instead.

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -85,16 +85,13 @@ export const SearchResultsInfoBar: React.FunctionComponent<
         [props.query]
     )
 
-    const canCreateMonitorFromQuery = useMemo(() => {
-        return globalTypeFilter === 'diff' || globalTypeFilter === 'commit'
-    }, [globalTypeFilter])
+    const canCreateMonitorFromQuery = useMemo(() => globalTypeFilter === 'diff' || globalTypeFilter === 'commit', [
+        globalTypeFilter,
+    ])
 
-    const canCreateBatchChangeFromQuery = useMemo(() => {
-        if (!globalTypeFilter) {
-            return true
-        }
-        return globalTypeFilter !== 'diff' && globalTypeFilter !== 'commit'
-    }, [globalTypeFilter])
+    const canCreateBatchChangeFromQuery = useMemo(() => globalTypeFilter !== 'diff' && globalTypeFilter !== 'commit', [
+        globalTypeFilter,
+    ])
 
     // When adding a new create action check and update the $collapse-breakpoint in CreateActions.module.scss.
     // The collapse breakpoint indicates at which window size we hide the buttons and show the collapsed menu instead.

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -86,9 +86,6 @@ export const SearchResultsInfoBar: React.FunctionComponent<
     )
 
     const canCreateMonitorFromQuery = useMemo(() => {
-        if (globalTypeFilter) {
-            return false
-        }
         return globalTypeFilter === 'diff' || globalTypeFilter === 'commit'
     }, [globalTypeFilter])
 


### PR DESCRIPTION
Issue https://github.com/sourcegraph/sourcegraph/issues/45601 
The variable [canCreateMonitorFromQuery](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v4.1.3/-/blob/client/web/src/search/results/SearchResultsInfoBar.tsx?L85), will return false if any 'type' filter is used in the query. This will cause the menu button for 'create monitor' to be [disabled](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v4.1.3/-/blob/client/web/src/search/results/SearchActionsMenu.tsx?L109) when type diff or commit is used. This change removes the check for `globalTypeFilter` since we are checking if it is 'diff' or 'commit' [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v4.1.3/-/blob/client/web/src/search/results/SearchResultsInfoBar.tsx?L89).
## Test plan
Tested locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-gabe-fix-create-monitor-button.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
