### PR TITLE
scaletesting: codehostcopy: use iterator pattern to pull and push repos concurrently for GHE as source

### DIFF
--- a/dev/scaletesting/codehostcopy/config.example.cue
+++ b/dev/scaletesting/codehostcopy/config.example.cue
@@ -1,11 +1,13 @@
 {
 	from: {
-		kind:     "github"
-		token:    "1235"
-		url:      "https://$GHE_HOST"
-		path:     "baz" // Use @myusername if you're targeting a user instead of an organization
-		username: "my-user"
-		password: "my-password"
+		kind:            "github"
+		token:           "1235"
+		url:             "https://$GHE_HOST"
+		path:            "baz" // Use @myusername if you're targeting a user instead of an organization
+		username:        "my-user"
+		password:        "my-password"
+		sshKey:          "/path/to/.ssh/id_rsa.pub"
+		repositoryLimit: 5000 // defines the amount of repositories to copy from the source. GHE fails to accurately list >50k private repos owned by the source, so define the exact amount here.
 	}
 	destination: {
 		kind:     "gitlab"

--- a/dev/scaletesting/codehostcopy/config.go
+++ b/dev/scaletesting/codehostcopy/config.go
@@ -8,14 +8,14 @@ import (
 )
 
 var schema = `#CodeHost: {
-	kind:        "github" | "gitlab" | "bitbucket"
-	token:       string
-	url:         string
-	path:        string
-	username?:   string
-	password?:   string
-    sshKey:      string
-    totalRepos?: number
+	kind:             "github" | "gitlab" | "bitbucket"
+	token:            string
+	url:              string
+	path:             string
+	username?:        string
+	password?:        string
+    sshKey:           string
+    repositoryLimit?: number
 }
 
 #Config: {
@@ -24,14 +24,14 @@ var schema = `#CodeHost: {
 }`
 
 type CodeHostDefinition struct {
-	Kind       string
-	Token      string
-	URL        string
-	Path       string
-	Username   string
-	Password   string
-	SSHKey     string
-	TotalRepos int
+	Kind            string
+	Token           string
+	URL             string
+	Path            string
+	Username        string
+	Password        string
+	SSHKey          string
+	RepositoryLimit int
 }
 
 type Config struct {

--- a/dev/scaletesting/codehostcopy/config.go
+++ b/dev/scaletesting/codehostcopy/config.go
@@ -8,13 +8,14 @@ import (
 )
 
 var schema = `#CodeHost: {
-	kind:      "github" | "gitlab" | "bitbucket"
-	token:     string
-	url:       string
-	path:      string
-	username?: string
-	password?: string
-    sshKey: string
+	kind:        "github" | "gitlab" | "bitbucket"
+	token:       string
+	url:         string
+	path:        string
+	username?:   string
+	password?:   string
+    sshKey:      string
+    totalRepos?: number
 }
 
 #Config: {
@@ -23,13 +24,14 @@ var schema = `#CodeHost: {
 }`
 
 type CodeHostDefinition struct {
-	Kind     string
-	Token    string
-	URL      string
-	Path     string
-	Username string
-	Password string
-	SSHKey   string
+	Kind       string
+	Token      string
+	URL        string
+	Path       string
+	Username   string
+	Password   string
+	SSHKey     string
+	TotalRepos int
 }
 
 type Config struct {

--- a/dev/scaletesting/codehostcopy/github.go
+++ b/dev/scaletesting/codehostcopy/github.go
@@ -180,14 +180,12 @@ func (g *GithubCodeHost) CreateRepo(ctx context.Context, name string) (*url.URL,
 	return nil, errors.New("not implemented")
 }
 
-func (g *GithubCodeHost) listRepos(ctx context.Context)
-
 func (g *GithubCodeHost) Next(ctx context.Context) []*store.Repo {
 	if g.done {
 		return nil
 	}
 
-	results, next, err := g.ListRepos(ctx)
+	results, next, err := g.ListRepos(ctx, g.page, g.perPage)
 	if err != nil {
 		g.err = err
 		return nil

--- a/dev/scaletesting/codehostcopy/github.go
+++ b/dev/scaletesting/codehostcopy/github.go
@@ -21,7 +21,7 @@ type GithubCodeHost struct {
 	c   *github.Client
 }
 
-var _ CodeHostSource = (*GithubCodeHost)(nil)
+var _ CodeHostSource[[]*store.Repo] = (*GithubCodeHost)(nil)
 var _ CodeHostDestination = (*GithubCodeHost)(nil)
 
 func NewGithubCodeHost(ctx context.Context, def *CodeHostDefinition) (*GithubCodeHost, error) {
@@ -166,4 +166,19 @@ func (g *GithubCodeHost) ListRepos(ctx context.Context) ([]*store.Repo, error) {
 
 func (g *GithubCodeHost) CreateRepo(ctx context.Context, name string) (*url.URL, error) {
 	return nil, errors.New("not implemented")
+}
+
+func (g *GithubCodeHost) Err() error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (g *GithubCodeHost) Next(ctx context.Context) []*store.Repo {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (g *GithubCodeHost) Done() bool {
+	//TODO implement me
+	panic("implement me")
 }

--- a/dev/scaletesting/codehostcopy/github.go
+++ b/dev/scaletesting/codehostcopy/github.go
@@ -209,3 +209,15 @@ func (g *GithubCodeHost) Done() bool {
 func (g *GithubCodeHost) Err() error {
 	return g.err
 }
+
+func (g *GithubCodeHost) GetTotalPrivateRepos(ctx context.Context) (int, error) {
+	return 0, nil
+}
+
+func (g *GithubCodeHost) GetPath() string {
+	return g.def.Path
+}
+
+func (g *GithubCodeHost) SetPage(total int, remainder int) {
+	g.page = (total - remainder) / g.perPage
+}

--- a/dev/scaletesting/codehostcopy/github.go
+++ b/dev/scaletesting/codehostcopy/github.go
@@ -114,7 +114,7 @@ func (g *GithubCodeHost) DropSSHKey(ctx context.Context, keyID int64) error {
 	return nil
 }
 
-func (g *GithubCodeHost) ListRepos(ctx context.Context, start int, size int) ([]*store.Repo, int, error) {
+func (g *GithubCodeHost) listRepos(ctx context.Context, start int, size int) ([]*store.Repo, int, error) {
 	var repos []*github.Repository
 	var resp *github.Response
 	var err error
@@ -190,7 +190,7 @@ func (g *GithubCodeHost) Next(ctx context.Context) []*store.Repo {
 		return nil
 	}
 
-	results, next, err := g.ListRepos(ctx, g.page, g.perPage)
+	results, next, err := g.listRepos(ctx, g.page, g.perPage)
 	if err != nil {
 		g.err = err
 		return nil

--- a/dev/scaletesting/codehostcopy/github.go
+++ b/dev/scaletesting/codehostcopy/github.go
@@ -26,7 +26,7 @@ type GithubCodeHost struct {
 	err     error
 }
 
-var _ CodeHostSource[[]*store.Repo] = (*GithubCodeHost)(nil)
+var _ CodeHostSource = (*GithubCodeHost)(nil)
 var _ CodeHostDestination = (*GithubCodeHost)(nil)
 
 func NewGithubCodeHost(ctx context.Context, def *CodeHostDefinition) (*GithubCodeHost, error) {
@@ -179,6 +179,10 @@ func (g *GithubCodeHost) ListRepos(ctx context.Context, start int, size int) ([]
 
 func (g *GithubCodeHost) CreateRepo(ctx context.Context, name string) (*url.URL, error) {
 	return nil, errors.New("not implemented")
+}
+
+func (g *GithubCodeHost) Iterator() Iterator[[]*store.Repo] {
+	return g
 }
 
 func (g *GithubCodeHost) Next(ctx context.Context) []*store.Repo {

--- a/dev/scaletesting/codehostcopy/github.go
+++ b/dev/scaletesting/codehostcopy/github.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"math"
 	"net/url"
 	"os"
 	"strings"
@@ -244,5 +245,10 @@ func (g *GithubCodeHost) GetPath() string {
 }
 
 func (g *GithubCodeHost) SetPage(total int, remainder int) {
-	g.page = (total - remainder) / g.perPage
+	// setting per page is not implemented yet so use GH default
+	perPage := 10
+	if g.perPage != 0 {
+		perPage = g.perPage
+	}
+	g.page = int(math.Ceil(float64(total-remainder) / float64(perPage)))
 }

--- a/dev/scaletesting/codehostcopy/github.go
+++ b/dev/scaletesting/codehostcopy/github.go
@@ -217,7 +217,7 @@ func (g *GithubCodeHost) Err() error {
 
 func (g *GithubCodeHost) GetTotalPrivateRepos(ctx context.Context) (int, error) {
 	// not supplied in the config, so get whatever GitHub tells us is present (but might be incorrect)
-	if g.def.TotalRepos == 0 {
+	if g.def.RepositoryLimit == 0 {
 		if strings.HasPrefix(g.def.Path, "@") {
 			u, resp, err := g.c.Users.Get(ctx, strings.Replace(g.def.Path, "@", "", 1))
 			if err != nil {
@@ -240,7 +240,7 @@ func (g *GithubCodeHost) GetTotalPrivateRepos(ctx context.Context) (int, error) 
 			return o.GetOwnedPrivateRepos(), nil
 		}
 	} else {
-		return g.def.TotalRepos, nil
+		return g.def.RepositoryLimit, nil
 	}
 }
 

--- a/dev/scaletesting/codehostcopy/main.go
+++ b/dev/scaletesting/codehostcopy/main.go
@@ -25,23 +25,26 @@ type SSHKeyHandler interface {
 	DropSSHKey(ctx context.Context, keyID int64) error
 }
 
-type CodeHostSource[T any] interface {
+type CodeHostSource interface {
 	GitOpts() []GitOpt
 	SSHKeyHandler
 	ListRepos(ctx context.Context, start int, size int) ([]*store.Repo, int, error)
 	GetPath() string
 	GetTotalPrivateRepos(ctx context.Context) (int, error)
 	SetPage(total int, remainder int)
-
-	Err() error
-	Next(ctx context.Context) T
-	Done() bool
+	Iterator() Iterator[[]*store.Repo]
 }
 
 type CodeHostDestination interface {
 	GitOpts() []GitOpt
 	SSHKeyHandler
 	CreateRepo(ctx context.Context, name string) (*url.URL, error)
+}
+
+type Iterator[T any] interface {
+	Err() error
+	Next(ctx context.Context) T
+	Done() bool
 }
 
 var app = &cli.App{

--- a/dev/scaletesting/codehostcopy/main.go
+++ b/dev/scaletesting/codehostcopy/main.go
@@ -28,11 +28,7 @@ type SSHKeyHandler interface {
 type CodeHostSource interface {
 	GitOpts() []GitOpt
 	SSHKeyHandler
-	ListRepos(ctx context.Context, start int, size int) ([]*store.Repo, int, error)
 	InitializeFromState(ctx context.Context, stateRepos []*store.Repo) (int, int, error)
-	//GetPath() string
-	//getTotalPrivateRepos(ctx context.Context) (int, error)
-	//SetPage(total int, remainder int)
 	Iterator() Iterator[[]*store.Repo]
 }
 

--- a/dev/scaletesting/codehostcopy/main.go
+++ b/dev/scaletesting/codehostcopy/main.go
@@ -31,7 +31,7 @@ type CodeHostSource[T any] interface {
 	ListRepos(ctx context.Context, start int, size int) ([]*store.Repo, int, error)
 	GetPath() string
 	GetTotalPrivateRepos(ctx context.Context) (int, error)
-	SetPage(total int, remainer int)
+	SetPage(total int, remainder int)
 
 	Err() error
 	Next(ctx context.Context) T

--- a/dev/scaletesting/codehostcopy/main.go
+++ b/dev/scaletesting/codehostcopy/main.go
@@ -28,7 +28,7 @@ type SSHKeyHandler interface {
 type CodeHostSource[T any] interface {
 	GitOpts() []GitOpt
 	SSHKeyHandler
-	ListRepos(ctx context.Context) ([]*store.Repo, error)
+	ListRepos(ctx context.Context, start int, size int) ([]*store.Repo, int, error)
 
 	Err() error
 	Next(ctx context.Context) T

--- a/dev/scaletesting/codehostcopy/main.go
+++ b/dev/scaletesting/codehostcopy/main.go
@@ -29,6 +29,9 @@ type CodeHostSource[T any] interface {
 	GitOpts() []GitOpt
 	SSHKeyHandler
 	ListRepos(ctx context.Context, start int, size int) ([]*store.Repo, int, error)
+	GetPath() string
+	GetTotalPrivateRepos(ctx context.Context) (int, error)
+	SetPage(total int, remainer int)
 
 	Err() error
 	Next(ctx context.Context) T

--- a/dev/scaletesting/codehostcopy/main.go
+++ b/dev/scaletesting/codehostcopy/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/dev/scaletesting/internal/store"
 )
 
@@ -24,10 +25,14 @@ type SSHKeyHandler interface {
 	DropSSHKey(ctx context.Context, keyID int64) error
 }
 
-type CodeHostSource interface {
+type CodeHostSource[T any] interface {
 	GitOpts() []GitOpt
 	SSHKeyHandler
 	ListRepos(ctx context.Context) ([]*store.Repo, error)
+
+	Err() error
+	Next(ctx context.Context) T
+	Done() bool
 }
 
 type CodeHostDestination interface {

--- a/dev/scaletesting/codehostcopy/main.go
+++ b/dev/scaletesting/codehostcopy/main.go
@@ -29,9 +29,10 @@ type CodeHostSource interface {
 	GitOpts() []GitOpt
 	SSHKeyHandler
 	ListRepos(ctx context.Context, start int, size int) ([]*store.Repo, int, error)
-	GetPath() string
-	GetTotalPrivateRepos(ctx context.Context) (int, error)
-	SetPage(total int, remainder int)
+	InitializeFromState(ctx context.Context, stateRepos []*store.Repo) (int, int, error)
+	//GetPath() string
+	//getTotalPrivateRepos(ctx context.Context) (int, error)
+	//SetPage(total int, remainder int)
 	Iterator() Iterator[[]*store.Repo]
 }
 

--- a/dev/scaletesting/codehostcopy/runner.go
+++ b/dev/scaletesting/codehostcopy/runner.go
@@ -98,17 +98,12 @@ func (r *Runner) Run(ctx context.Context, concurrency int) error {
 		return err
 	}
 
-	t, err := r.source.GetTotalPrivateRepos(ctx)
+	t, remainder, err := r.source.InitializeFromState(ctx, srcRepos)
 	if err != nil {
-		r.logger.Fatal("failed to get total private repos size for source", log.String("source", r.source.GetPath()), log.Error(err))
+		r.logger.Fatal(err.Error())
 	}
-	remainder := t - len(srcRepos)
-	r.logger.Info(fmt.Sprintf("%d repositories processed, %d repositories left", len(srcRepos), remainder))
 
-	// Process started but not finished, set page to continue
-	if len(srcRepos) != 0 && remainder != 0 {
-		r.source.SetPage(t, remainder)
-	}
+	r.logger.Info(fmt.Sprintf("%d repositories processed, %d repositories left", len(srcRepos), remainder))
 
 	bars := []output.ProgressBar{
 		{Label: "Copying repos", Max: float64(t)},

--- a/dev/scaletesting/codehostcopy/runner.go
+++ b/dev/scaletesting/codehostcopy/runner.go
@@ -90,7 +90,7 @@ func (r *Runner) Run(ctx context.Context, concurrency int) error {
 	if err != nil {
 		r.logger.Fatal("failed to get total private repos size for source", log.String("source", r.source.GetPath()), log.Error(err))
 	}
-	remainder := len(srcRepos) - t
+	remainder := t - len(srcRepos)
 	r.logger.Info(fmt.Sprintf("%d repositories processed, %d repositories left", len(srcRepos), remainder))
 
 	// Process started but not finished, set page to continue
@@ -107,7 +107,7 @@ func (r *Runner) Run(ctx context.Context, concurrency int) error {
 
 	g := group.NewWithResults[error]().WithMaxConcurrency(concurrency)
 
-	for !r.source.Done() && r.source.Err() != nil {
+	for !r.source.Done() && r.source.Err() == nil {
 		repos := r.source.Next(ctx)
 		if err = r.store.Insert(repos); err != nil {
 			r.logger.Error("failed to insert repositories from source", log.Error(err))

--- a/dev/scaletesting/codehostcopy/runner.go
+++ b/dev/scaletesting/codehostcopy/runner.go
@@ -10,13 +10,14 @@ import (
 
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/run"
+
 	"github.com/sourcegraph/sourcegraph/dev/scaletesting/internal/store"
 	"github.com/sourcegraph/sourcegraph/lib/group"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
 type Runner struct {
-	source      CodeHostSource
+	source      CodeHostSource[[]*store.Repo]
 	destination CodeHostDestination
 	store       *store.Store
 	logger      log.Logger
@@ -35,7 +36,7 @@ func logRepo(r *store.Repo, fields ...log.Field) []log.Field {
 	}, fields...)
 }
 
-func NewRunner(logger log.Logger, s *store.Store, source CodeHostSource, dest CodeHostDestination) *Runner {
+func NewRunner(logger log.Logger, s *store.Store, source CodeHostSource[[]*store.Repo], dest CodeHostDestination) *Runner {
 	return &Runner{
 		logger:      logger,
 		source:      source,

--- a/dev/scaletesting/codehostcopy/runner.go
+++ b/dev/scaletesting/codehostcopy/runner.go
@@ -148,7 +148,8 @@ func (r *Runner) Run(ctx context.Context, concurrency int) error {
 				// Push the repo on destination.
 				if !currentRepo.Pushed && currentRepo.Created {
 					cErr := pushRepo(ctx, currentRepo, r.source.GitOpts(), r.destination.GitOpts())
-					if cErr != nil {
+					// state might be out of date so ignore existing repos
+					if cErr != nil && !strings.Contains(cErr.Error(), "has already been taken") {
 						currentRepo.Failed = cErr.Error()
 						r.logger.Error("failed to push repo", logRepo(currentRepo, log.Error(cErr))...)
 					} else {

--- a/dev/scaletesting/codehostcopy/runner.go
+++ b/dev/scaletesting/codehostcopy/runner.go
@@ -82,7 +82,7 @@ func (r *Runner) Run(ctx context.Context, concurrency int) error {
 		cleanup()
 	}
 
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c


### PR DESCRIPTION
Reusing the pattern from [codehostcopy](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/dev/scaletesting/codehostcopy) to switch from pulling all repos from the source before pushing to the destination to a paginated pull/push. This is a GitHub Enterprise specific implementation.

The [Organization entity](https://pkg.go.dev/github.com/google/go-github/v48/github#Organization) returned by the API exposes a `TotalPrivateRepos` field which does not return correct results (caps out at 50k). Since we only need this statistic to determine where to resume the process in case of a prematurely terminated run, as well as setting the progress bar cap, it's instead supplied as an optional config value now.

Additionally adds a handler for interrupts to remove SSH keys again.

## Test plan
Currently running to copy ~200k repos over to our dogfood GitLab.
