### PR TITLE
perm syncer metrics: reduce cardinality of metrics

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/metrics.go
+++ b/enterprise/cmd/repo-updater/internal/authz/metrics.go
@@ -52,27 +52,23 @@ var (
 	metricsSuccessPermsSyncs = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "src_repoupdater_perms_syncer_success_syncs",
 		Help: "Total number of successful permissions syncs",
-	}, []string{"type", "id"})
+	}, []string{"type"})
 	metricsFailedPermsSyncs = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "src_repoupdater_perms_syncer_failed_syncs",
 		Help: "Total number of failed permissions syncs",
-	}, []string{"type", "id"})
+	}, []string{"type"})
 	metricsFirstPermsSyncs = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "src_repoupdater_perms_syncer_initial_syncs",
 		Help: "Total number of new user/repo permissions syncs",
-	}, []string{"type", "id"})
-	metricsPermsFound = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "src_repoupdater_perms_syncer_perms_found",
-		Help: "The number of perms found for user/repo after sync",
-	}, []string{"type", "id"})
+	}, []string{"type"})
 	metricsPermsConsecutiveSyncDelay = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "src_repoupdater_perms_syncer_perms_consecutive_sync_delay",
 		Help: "The duration in minutes between last and current complete premissions sync.",
-	}, []string{"type", "id"})
+	}, []string{"type"})
 	metricsPermsFirstSyncDelay = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "src_repoupdater_perms_syncer_perms_first_sync_delay",
 		Help: "The duration in minutes it took for first user/repo complete perms sync after creation",
-	}, []string{"type", "id"})
+	}, []string{"type"})
 	metricsItemsSyncScheduled = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "src_repoupdater_perms_syncer_items_sync_scheduled",
 		Help: "The number of users/repos scheduled for sync",

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -620,15 +620,13 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 		log.Object("fetchOpts", log.Bool("InvalidateCache", fetchOpts.InvalidateCaches)),
 	)
 
-	userLabel := strconv.Itoa(int(p.UserID))
-	metricsSuccessPermsSyncs.WithLabelValues("user", userLabel).Inc()
-	metricsPermsFound.WithLabelValues("user", userLabel).Set(float64(len(p.IDs)))
+	metricsSuccessPermsSyncs.WithLabelValues("user").Inc()
 
 	if !oldPerms.SyncedAt.IsZero() {
-		metricsPermsConsecutiveSyncDelay.WithLabelValues("user", userLabel).Set(p.SyncedAt.Sub(oldPerms.SyncedAt).Seconds())
+		metricsPermsConsecutiveSyncDelay.WithLabelValues("user").Set(p.SyncedAt.Sub(oldPerms.SyncedAt).Seconds())
 	} else {
-		metricsFirstPermsSyncs.WithLabelValues("user", userLabel).Inc()
-		metricsPermsFirstSyncDelay.WithLabelValues("user", userLabel).Set(p.SyncedAt.Sub(user.CreatedAt).Seconds())
+		metricsFirstPermsSyncs.WithLabelValues("user").Inc()
+		metricsPermsFirstSyncDelay.WithLabelValues("user").Set(p.SyncedAt.Sub(user.CreatedAt).Seconds())
 	}
 
 	return providerStates, nil
@@ -812,14 +810,13 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		log.Object("fetchOpts", log.Bool("invalidateCaches", fetchOpts.InvalidateCaches)),
 	)
 
-	metricsSuccessPermsSyncs.WithLabelValues("repo", string(p.RepoID)).Inc()
-	metricsPermsFound.WithLabelValues("repo", string(p.RepoID)).Set(float64(regularCount))
+	metricsSuccessPermsSyncs.WithLabelValues("repo").Inc()
 
 	if !oldPerms.SyncedAt.IsZero() {
-		metricsPermsConsecutiveSyncDelay.WithLabelValues("repo", string(p.RepoID)).Set(p.SyncedAt.Sub(oldPerms.SyncedAt).Seconds())
+		metricsPermsConsecutiveSyncDelay.WithLabelValues("repo").Set(p.SyncedAt.Sub(oldPerms.SyncedAt).Seconds())
 	} else {
-		metricsFirstPermsSyncs.WithLabelValues("repo", string(p.RepoID)).Inc()
-		metricsPermsFirstSyncDelay.WithLabelValues("repo", string(p.RepoID)).Set(p.SyncedAt.Sub(repo.CreatedAt).Seconds())
+		metricsFirstPermsSyncs.WithLabelValues("repo").Inc()
+		metricsPermsFirstSyncDelay.WithLabelValues("repo").Set(p.SyncedAt.Sub(repo.CreatedAt).Seconds())
 	}
 
 	return providerStates, nil
@@ -891,9 +888,9 @@ func (s *PermsSyncer) syncPerms(ctx context.Context, syncGroups map[requestType]
 				)
 
 				if request.Type == requestTypeUser {
-					metricsFailedPermsSyncs.WithLabelValues("user", string(request.ID)).Inc()
+					metricsFailedPermsSyncs.WithLabelValues("user").Inc()
 				} else {
-					metricsFailedPermsSyncs.WithLabelValues("repo", string(request.ID)).Inc()
+					metricsFailedPermsSyncs.WithLabelValues("repo").Inc()
 				}
 			} else {
 				logger.Debug("succeeded in syncing permissions",


### PR DESCRIPTION
High-cardinality metrics is not something that Prometheus is built for. This reduces the cardinality by reducing it to 2 in most cases: "repo" or "user" and "success" or "not success".

## Test plan

- Tested this locally by starting monitoring stack and looking at metrics