### PR TITLE
CI: disable flakey test GetBulkMonikerLocations

### DIFF
--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_monikers_test.go
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_monikers_test.go
@@ -73,6 +73,7 @@ func TestDatabaseMonikersByPosition(t *testing.T) {
 }
 
 func TestGetBulkMonikerLocations(t *testing.T) {
+	t.Skip("skipping flakey test: https://github.com/sourcegraph/sourcegraph/issues/45609")
 	tableName := "references"
 	uploadIDs := []int{testLSIFUploadID, testSCIPUploadID}
 	monikers := []precise.MonikerData{


### PR DESCRIPTION
failed for https://github.com/sourcegraph/sourcegraph/pull/45533, which is completely unrelated.



## Test plan
N/A

