### PR TITLE
repo-updater: remove noop-logger from observation context

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -89,8 +89,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	profiler.Init()
 
 	logger := log.Scoped("service", "repo-updater service")
-	// TODO: remove NoOp
-	observationCtx := observation.NewContext(log.NoOp())
+	observationCtx := observation.NewContext(logger)
 
 	// Signals health of startup
 	ready := make(chan struct{})


### PR DESCRIPTION
Feels like a pretty big miss that we didn't have a logger in there? Also explains why I didn't see any logs in the `EnterpriseInit` function where this is passed in.

I have no idea what I'm doing when it comes to the new `observation.Context` though, so guidance appreciated.

## Test plan

- Manual testing