### PR TITLE
migrations: Add column author_user_id to critical_and_site_config

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -7356,6 +7356,19 @@
       "Comment": "",
       "Columns": [
         {
+          "Name": "author_user_id",
+          "Index": 6,
+          "TypeName": "integer",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
           "Name": "contents",
           "Index": 3,
           "TypeName": "text",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -962,13 +962,14 @@ Indexes:
 
 # Table "public.critical_and_site_config"
 ```
-   Column   |           Type           | Collation | Nullable |                       Default                        
-------------+--------------------------+-----------+----------+------------------------------------------------------
- id         | integer                  |           | not null | nextval('critical_and_site_config_id_seq'::regclass)
- type       | critical_or_site         |           | not null | 
- contents   | text                     |           | not null | 
- created_at | timestamp with time zone |           | not null | now()
- updated_at | timestamp with time zone |           | not null | now()
+     Column     |           Type           | Collation | Nullable |                       Default                        
+----------------+--------------------------+-----------+----------+------------------------------------------------------
+ id             | integer                  |           | not null | nextval('critical_and_site_config_id_seq'::regclass)
+ type           | critical_or_site         |           | not null | 
+ contents       | text                     |           | not null | 
+ created_at     | timestamp with time zone |           | not null | now()
+ updated_at     | timestamp with time zone |           | not null | now()
+ author_user_id | integer                  |           |          | 
 Indexes:
     "critical_and_site_config_pkey" PRIMARY KEY, btree (id)
     "critical_and_site_config_unique" UNIQUE, btree (id, type)

--- a/migrations/frontend/1670933658_add_column_author_user_id_to_critical_and_site_config/down.sql
+++ b/migrations/frontend/1670933658_add_column_author_user_id_to_critical_and_site_config/down.sql
@@ -1,0 +1,4 @@
+-- Undo the changes made in the up migration
+
+ALTER TABLE critical_and_site_config
+      DROP COLUMN IF EXISTS author_user_id;

--- a/migrations/frontend/1670933658_add_column_author_user_id_to_critical_and_site_config/down.sql
+++ b/migrations/frontend/1670933658_add_column_author_user_id_to_critical_and_site_config/down.sql
@@ -1,4 +1,3 @@
--- Undo the changes made in the up migration
 
 ALTER TABLE critical_and_site_config
       DROP COLUMN IF EXISTS author_user_id;

--- a/migrations/frontend/1670933658_add_column_author_user_id_to_critical_and_site_config/metadata.yaml
+++ b/migrations/frontend/1670933658_add_column_author_user_id_to_critical_and_site_config/metadata.yaml
@@ -1,0 +1,2 @@
+name: add column author_user_id to critical_and_site_config
+parents: [1670350006, 1670543231]

--- a/migrations/frontend/1670933658_add_column_author_user_id_to_critical_and_site_config/up.sql
+++ b/migrations/frontend/1670933658_add_column_author_user_id_to_critical_and_site_config/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE critical_and_site_config
+      ADD COLUMN IF NOT EXISTS author_user_id integer;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -1696,7 +1696,8 @@ CREATE TABLE critical_and_site_config (
     type critical_or_site NOT NULL,
     contents text NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    author_user_id integer
 );
 
 CREATE SEQUENCE critical_and_site_config_id_seq


### PR DESCRIPTION
We recently had an [incident](https://sourcegraph.slack.com/archives/C04EQUH9M5L) where a site config was changed but didn't know who / why this was made. 

Adding an `author_user_id` to the table will help with auditing.

We needed this feature as part of #40377 anyway.


## Test plan

1. Tested locally with both `sg migration up` and `sg migration downto`.
2. Tested that `sg start` works
3. Builds should pass.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
