### PR TITLE
ui: Set warning status if disableAutoGitUpdates is true

### DIFF
--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -177,7 +177,7 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
         let iconProps
         if (
             data.statusMessages?.some(
-                ({ __typename: type }) => type === 'ExternalServiceSyncError' || type === 'SyncError'
+                ({ __typename: type }) => type === 'ExternalServiceSyncError' || type === 'SyncError' ||  type == 'GitUpdatesDisabled'
             )
         ) {
             codeHostMessage = 'Syncing repositories failed!'
@@ -227,6 +227,20 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
         return (
             <>
                 {data.statusMessages.map(status => {
+                    if (status.__typename === 'GitUpdatesDisabled') {
+                        return (
+                            <StatusMessagesNavItemEntry
+                                key={status.message}
+                                message={status.message}
+                                title="Git updates disabled"
+                                messageHint="Remove disableGitAutoUpdates or set it to false in the site configuration"
+                                linkTo="/site-admin/configuration"
+                                linkText="View site configuration"
+                                linkOnClick={toggleIsOpen}
+                                entryType="warning"
+                            />
+                        )
+                    }
                     if (status.__typename === 'CloningProgress') {
                         return (
                             <StatusMessagesNavItemEntry

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -177,7 +177,8 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
         let iconProps
         if (
             data.statusMessages?.some(
-                ({ __typename: type }) => type === 'ExternalServiceSyncError' || type === 'SyncError' ||  type == 'GitUpdatesDisabled'
+                ({ __typename: type }) =>
+                    type === 'ExternalServiceSyncError' || type === 'SyncError' || type === 'GitUpdatesDisabled'
             )
         ) {
             codeHostMessage = 'Syncing repositories failed!'

--- a/client/web/src/nav/StatusMessagesNavItemQueries.ts
+++ b/client/web/src/nav/StatusMessagesNavItemQueries.ts
@@ -3,6 +3,12 @@ import { gql } from '@sourcegraph/http-client'
 export const STATUS_MESSAGES = gql`
     query StatusMessages {
         statusMessages {
+            ... on GitUpdatesDisabled {
+                __typename
+
+                message
+            }
+
             ... on CloningProgress {
                 __typename
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -7757,6 +7757,17 @@ type Hover {
 }
 
 """
+FOR INTERNAL USE ONLY: A status message produced when disableAutoGitUpdates is
+set to true in the site configuration
+"""
+type GitUpdatesDisabled {
+    """
+    The message of this status message
+    """
+    message: String!
+}
+
+"""
 FOR INTERNAL USE ONLY: A status message produced when repositories are being
 cloned
 """
@@ -7811,7 +7822,7 @@ type IndexingProgress {
 """
 FOR INTERNAL USE ONLY: A status message
 """
-union StatusMessage = CloningProgress | ExternalServiceSyncError | SyncError | IndexingProgress
+union StatusMessage = GitUpdatesDisabled | CloningProgress | ExternalServiceSyncError | SyncError | IndexingProgress
 
 """
 An arbitrarily large integer encoded as a decimal string.

--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -175,6 +175,8 @@ func init() {
 
 	// Warn if customer is using GitLab on a version < 12.0.
 	AlertFuncs = append(AlertFuncs, gitlabVersionAlert)
+
+	AlertFuncs = append(AlertFuncs, gitUpdatesDisabledAlert)
 }
 
 func storageLimitReachedAlert(args AlertFuncArgs) []*Alert {
@@ -394,6 +396,27 @@ func gitlabVersionAlert(args AlertFuncArgs) []*Alert {
 				TypeValue:    AlertTypeError,
 				MessageValue: "One or more of your code hosts is running a version of GitLab below 12.0, which is not supported by Sourcegraph. Please upgrade your GitLab instance(s) to prevent disruption.",
 			}}
+		}
+	}
+
+	return nil
+}
+
+// gitUpdatedisabledAlert will put a alert banner on the UI for site admins if disableAutoGitUpdates
+// is set to true in the site config.
+//
+// This will be shown to site admin only.
+func gitUpdatesDisabledAlert(args AlertFuncArgs) []*Alert {
+	if !args.IsSiteAdmin {
+		return nil
+	}
+
+	if conf.Get().DisableAutoGitUpdates {
+		return []*Alert{
+			{
+				TypeValue:    AlertTypeError,
+				MessageValue: "Git updates are disabled, repos will not update or clone. Please remove disableAutoGitUpdates setting from the site configuration",
+			},
 		}
 	}
 

--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -175,8 +175,6 @@ func init() {
 
 	// Warn if customer is using GitLab on a version < 12.0.
 	AlertFuncs = append(AlertFuncs, gitlabVersionAlert)
-
-	AlertFuncs = append(AlertFuncs, gitUpdatesDisabledAlert)
 }
 
 func storageLimitReachedAlert(args AlertFuncArgs) []*Alert {
@@ -396,27 +394,6 @@ func gitlabVersionAlert(args AlertFuncArgs) []*Alert {
 				TypeValue:    AlertTypeError,
 				MessageValue: "One or more of your code hosts is running a version of GitLab below 12.0, which is not supported by Sourcegraph. Please upgrade your GitLab instance(s) to prevent disruption.",
 			}}
-		}
-	}
-
-	return nil
-}
-
-// gitUpdatedisabledAlert will put a alert banner on the UI for site admins if disableAutoGitUpdates
-// is set to true in the site config.
-//
-// This will be shown to site admin only.
-func gitUpdatesDisabledAlert(args AlertFuncArgs) []*Alert {
-	if !args.IsSiteAdmin {
-		return nil
-	}
-
-	if conf.Get().DisableAutoGitUpdates {
-		return []*Alert{
-			{
-				TypeValue:    AlertTypeError,
-				MessageValue: "Git updates are disabled, repos will not update or clone. Please remove disableAutoGitUpdates setting from the site configuration",
-			},
 		}
 	}
 

--- a/cmd/frontend/graphqlbackend/status_messages.go
+++ b/cmd/frontend/graphqlbackend/status_messages.go
@@ -35,6 +35,10 @@ type statusMessageResolver struct {
 	db      database.DB
 }
 
+func (r *statusMessageResolver) ToGitUpdatesDisabled() (*statusMessageResolver, bool) {
+	return r, r.message.GitUpdatesDisabled != nil
+}
+
 func (r *statusMessageResolver) ToCloningProgress() (*statusMessageResolver, bool) {
 	return r, r.message.Cloning != nil
 }
@@ -55,6 +59,9 @@ func (r *statusMessageResolver) ToIndexingProgress() (*indexingProgressMessageRe
 }
 
 func (r *statusMessageResolver) Message() (string, error) {
+	if r.message.GitUpdatesDisabled != nil {
+		return r.message.GitUpdatesDisabled.Message, nil
+	}
 	if r.message.Cloning != nil {
 		return r.message.Cloning.Message, nil
 	}

--- a/cmd/frontend/graphqlbackend/status_messages_test.go
+++ b/cmd/frontend/graphqlbackend/status_messages_test.go
@@ -98,7 +98,7 @@ func TestStatusMessages(t *testing.T) {
 		repos.MockStatusMessages = func(_ context.Context) ([]repos.StatusMessage, error) {
 			res := []repos.StatusMessage{
 				{
-					GitUpdatesDisabled: &repos.GitUpdatesStatus{
+					GitUpdatesDisabled: &repos.GitUpdatesDisabled{
 						Message: "Repos will not be cloned or updated.",
 					},
 				},

--- a/cmd/frontend/graphqlbackend/status_messages_test.go
+++ b/cmd/frontend/graphqlbackend/status_messages_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestStatusMessages(t *testing.T) {
@@ -17,6 +19,10 @@ func TestStatusMessages(t *testing.T) {
 		query StatusMessages {
 			statusMessages {
 				__typename
+
+				... on GitUpdatesDisabled {
+					message
+				}
 
 				... on CloningProgress {
 					message
@@ -92,6 +98,11 @@ func TestStatusMessages(t *testing.T) {
 		repos.MockStatusMessages = func(_ context.Context) ([]repos.StatusMessage, error) {
 			res := []repos.StatusMessage{
 				{
+					GitUpdatesDisabled: &repos.GitUpdatesStatus{
+						Message: "Repos will not be cloned or updated.",
+					},
+				},
+				{
 					Cloning: &repos.CloningProgress{
 						Message: "Currently cloning 5 repositories in parallel...",
 					},
@@ -110,15 +121,28 @@ func TestStatusMessages(t *testing.T) {
 			}
 			return res, nil
 		}
-		defer func() { repos.MockStatusMessages = nil }()
 
-		RunTests(t, []*Test{
-			{
-				Schema: mustParseGraphQLSchema(t, db),
-				Query:  graphqlQuery,
-				ExpectedResult: `
+		conf.Mock(&conf.Unified{
+			SiteConfiguration: schema.SiteConfiguration{
+				DisableAutoGitUpdates: true,
+			},
+		})
+
+		defer func() {
+			repos.MockStatusMessages = nil
+			conf.Mock(nil)
+		}()
+
+		RunTest(t, &Test{
+			Schema: mustParseGraphQLSchema(t, db),
+			Query:  graphqlQuery,
+			ExpectedResult: `
 					{
 						"statusMessages": [
+							{
+								"__typename": "GitUpdatesDisabled",
+        						"message": "Repos will not be cloned or updated."
+							},
 							{
 								"__typename": "CloningProgress",
 								"message": "Currently cloning 5 repositories in parallel..."
@@ -138,7 +162,6 @@ func TestStatusMessages(t *testing.T) {
 						]
 					}
 				`,
-			},
 		})
 	})
 }

--- a/internal/repos/status_messages.go
+++ b/internal/repos/status_messages.go
@@ -22,7 +22,7 @@ func FetchStatusMessages(ctx context.Context, db database.DB) ([]StatusMessage, 
 
 	if conf.Get().DisableAutoGitUpdates {
 		messages = append(messages, StatusMessage{
-			GitUpdatesDisabled: &GitUpdatesStatus{
+			GitUpdatesDisabled: &GitUpdatesDisabled{
 				Message: "Repos will not be cloned or updated.",
 			},
 		})
@@ -107,7 +107,7 @@ func pluralize(count int, singularNoun, pluralNoun string) string {
 	return pluralNoun
 }
 
-type GitUpdatesStatus struct {
+type GitUpdatesDisabled struct {
 	Message string
 }
 
@@ -130,7 +130,7 @@ type IndexingProgress struct {
 }
 
 type StatusMessage struct {
-	GitUpdatesDisabled       *GitUpdatesStatus         `json:"git_updates_disabled"`
+	GitUpdatesDisabled       *GitUpdatesDisabled       `json:"git_updates_disabled"`
 	Cloning                  *CloningProgress          `json:"cloning"`
 	ExternalServiceSyncError *ExternalServiceSyncError `json:"external_service_sync_error"`
 	SyncError                *SyncError                `json:"sync_error"`

--- a/internal/repos/status_messages.go
+++ b/internal/repos/status_messages.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -18,6 +19,14 @@ func FetchStatusMessages(ctx context.Context, db database.DB) ([]StatusMessage, 
 		return MockStatusMessages(ctx)
 	}
 	var messages []StatusMessage
+
+	if conf.Get().DisableAutoGitUpdates {
+		messages = append(messages, StatusMessage{
+			GitUpdatesDisabled: &GitUpdatesStatus{
+				Message: "Repos will not be cloned or updated.",
+			},
+		})
+	}
 
 	// We first fetch affiliated sync errors since this will also find all the
 	// external services the user cares about.
@@ -98,6 +107,10 @@ func pluralize(count int, singularNoun, pluralNoun string) string {
 	return pluralNoun
 }
 
+type GitUpdatesStatus struct {
+	Message string
+}
+
 type CloningProgress struct {
 	Message string
 }
@@ -111,14 +124,15 @@ type SyncError struct {
 	Message string
 }
 
+type IndexingProgress struct {
+	NotIndexed int
+	Indexed    int
+}
+
 type StatusMessage struct {
+	GitUpdatesDisabled       *GitUpdatesStatus         `json:"git_updates_disabled"`
 	Cloning                  *CloningProgress          `json:"cloning"`
 	ExternalServiceSyncError *ExternalServiceSyncError `json:"external_service_sync_error"`
 	SyncError                *SyncError                `json:"sync_error"`
 	Indexing                 *IndexingProgress         `json:"indexing"`
-}
-
-type IndexingProgress struct {
-	NotIndexed int
-	Indexed    int
 }

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/zoekt"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -23,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestStatusMessages(t *testing.T) {
@@ -46,8 +48,10 @@ func TestStatusMessages(t *testing.T) {
 	require.NoError(t, err)
 
 	testCases := []struct {
-		name  string
-		repos types.Repos
+		testSetup   func()
+		testCleanup func()
+		name        string
+		repos       types.Repos
 		// maps repoName to CloneStatus
 		cloneStatus map[string]types.CloneStatus
 		// indexed is list of repo names that are indexed
@@ -57,6 +61,26 @@ func TestStatusMessages(t *testing.T) {
 		res              []StatusMessage
 		err              string
 	}{
+		{
+			testSetup: func() {
+				conf.Mock(&conf.Unified{
+					SiteConfiguration: schema.SiteConfiguration{
+						DisableAutoGitUpdates: true,
+					},
+				})
+			},
+			testCleanup: func() {
+				conf.Mock(nil)
+			},
+			name: "disableAutoGitUpdates set to true",
+			res: []StatusMessage{
+				{
+					GitUpdatesDisabled: &GitUpdatesStatus{
+						Message: "Repos will not be cloned or updated.",
+					},
+				},
+			},
+		},
 		{
 			name:        "site-admin: all cloned and indexed",
 			cloneStatus: map[string]types.CloneStatus{"foobar": types.CloneStatusCloned},
@@ -191,6 +215,14 @@ func TestStatusMessages(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.testCleanup != nil {
+				defer tc.testCleanup()
+			}
+
+			if tc.testSetup != nil {
+				tc.testSetup()
+			}
+
 			stored := tc.repos.Clone()
 			for _, r := range stored {
 				r.ExternalRepo = api.ExternalRepoSpec{

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -75,7 +75,7 @@ func TestStatusMessages(t *testing.T) {
 			name: "disableAutoGitUpdates set to true",
 			res: []StatusMessage{
 				{
-					GitUpdatesDisabled: &GitUpdatesStatus{
+					GitUpdatesDisabled: &GitUpdatesDisabled{
 						Message: "Repos will not be cloned or updated.",
 					},
 				},


### PR DESCRIPTION
Resolving a recent [incident](https://sourcegraph.slack.com/archives/C04EQUH9M5L) could have been expedited if we had a warning status message. Adding to make it easier in the future.

## Test plan

1. Tested locally. Follow [this](https://sourcegraph.test:3443/api/console?trace=1#%7B%22query%22%3A%22query%20StatusMessages%20%7B%5Cn%20%20statusMessages%20%7B%5Cn%20%20%20%20...%20on%20GitUpdatesDisabled%20%7B%5Cn%20%20%20%20%20%20__typename%5Cn%20%20%20%20%20%20message%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%22%2C%22operationName%22%3A%22StatusMessages%22%7D) link to test the API in the API console of your local dev instance.

2. UI screenshots below

When **disableAutoGitUpdates: true**

<img width="2559" alt="image" src="https://user-images.githubusercontent.com/2682729/207529761-3b849f2e-dc9d-44f9-afe8-63833a485af4.png">


When **disableAutoGitUpdates: false**

<img width="2560" alt="image" src="https://user-images.githubusercontent.com/2682729/207530384-42f416f3-eb12-4d04-b746-6ed7036e62c2.png">


3. Interaction with Status

![CleanShot 2022-12-14 at 12 47 48](https://user-images.githubusercontent.com/2682729/207532264-0ab37db0-7452-42e6-b493-e13859cd51ce.gif)




4. Builds should pass



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
