### PR TITLE
chore: remove duplicate dbutil.Scanner interfaces

### DIFF
--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/batch"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -154,7 +155,7 @@ func (s *Store) SeriesPoints(ctx context.Context, opts SeriesPointsOpts) ([]Seri
 	q := seriesPointsQuery(fullVectorSeriesAggregation, opts)
 	pointsMap := make(map[string]*SeriesPoint)
 	captureValues := make(map[string]struct{})
-	err = s.query(ctx, q, func(sc scanner) error {
+	err = s.query(ctx, q, func(sc dbutil.Scanner) error {
 		var point SeriesPoint
 		err := sc.Scan(
 			&point.SeriesID,
@@ -240,7 +241,7 @@ func (s *Store) LoadSeriesInMem(ctx context.Context, opts SeriesPointsOpts) (poi
 			  GROUP BY sp.series_id, interval_time, sp.repo_id, capture
 	;`
 	fullQ := seriesPointsQuery(q, opts)
-	err = s.query(ctx, fullQ, func(sc scanner) (err error) {
+	err = s.query(ctx, fullQ, func(sc dbutil.Scanner) (err error) {
 		var row loadStruct
 		err = sc.Scan(
 			&row.Time,
@@ -662,7 +663,7 @@ func (s *Store) GetInsightSeriesRecordingTimes(ctx context.Context, id int, from
 	timesQuery := sqlf.Sprintf(getInsightSeriesRecordingTimesStr, sqlf.Join(preds, "\n AND"))
 
 	recordingTimes := []types.RecordingTime{}
-	err = s.query(ctx, timesQuery, func(sc scanner) (err error) {
+	err = s.query(ctx, timesQuery, func(sc dbutil.Scanner) (err error) {
 		var recordingTime time.Time
 		err = sc.Scan(
 			&recordingTime,
@@ -775,14 +776,9 @@ func (s *Store) query(ctx context.Context, q *sqlf.Query, sc scanFunc) error {
 	return scanAll(rows, sc)
 }
 
-// scanner captures the Scan method of sql.Rows and sql.Row
-type scanner interface {
-	Scan(dst ...any) error
-}
-
 // a scanFunc scans one or more rows from a scanner, returning
 // the last id column scanned and the count of scanned rows.
-type scanFunc func(scanner) (err error)
+type scanFunc func(dbutil.Scanner) (err error)
 
 func scanAll(rows *sql.Rows, scan scanFunc) (err error) {
 	defer func() { err = basestore.CloseRows(rows, err) }()
@@ -806,7 +802,7 @@ func (s *Store) LoadAggregatedIncompleteDatapoints(ctx context.Context, seriesID
 	if err != nil {
 		return nil, err
 	}
-	return results, scanAll(rows, func(s scanner) (err error) {
+	return results, scanAll(rows, func(s dbutil.Scanner) (err error) {
 		var tmp IncompleteDatapoint
 		if err = rows.Scan(
 			&tmp.Reason,

--- a/enterprise/internal/oobmigration/migrations/codeintel/diagnostics_count.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/diagnostics_count.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 type diagnosticsCountMigrator struct {
@@ -36,7 +37,7 @@ func (m *diagnosticsCountMigrator) Interval() time.Duration { return time.Second
 
 // MigrateRowUp reads the payload of the given row and returns an updateSpec on how to
 // modify the record to conform to the new schema.
-func (m *diagnosticsCountMigrator) MigrateRowUp(scanner scanner) ([]any, error) {
+func (m *diagnosticsCountMigrator) MigrateRowUp(scanner dbutil.Scanner) ([]any, error) {
 	var path string
 	var rawData []byte
 
@@ -53,7 +54,7 @@ func (m *diagnosticsCountMigrator) MigrateRowUp(scanner scanner) ([]any, error) 
 }
 
 // MigrateRowDown sets num_diagnostics back to zero to undo the migration up direction.
-func (m *diagnosticsCountMigrator) MigrateRowDown(scanner scanner) ([]any, error) {
+func (m *diagnosticsCountMigrator) MigrateRowDown(scanner dbutil.Scanner) ([]any, error) {
 	var path string
 	var rawData []byte
 

--- a/enterprise/internal/oobmigration/migrations/codeintel/document_column_split.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/document_column_split.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 type documentColumnSplitMigrator struct {
@@ -41,7 +42,7 @@ func (m *documentColumnSplitMigrator) Interval() time.Duration { return time.Sec
 
 // MigrateRowUp reads the payload of the given row and returns an updateSpec on how to
 // modify the record to conform to the new schema.
-func (m *documentColumnSplitMigrator) MigrateRowUp(scanner scanner) ([]any, error) {
+func (m *documentColumnSplitMigrator) MigrateRowUp(scanner dbutil.Scanner) ([]any, error) {
 	var path string
 	var rawData, ignored []byte
 
@@ -79,7 +80,7 @@ func (m *documentColumnSplitMigrator) MigrateRowUp(scanner scanner) ([]any, erro
 
 // MigrateRowDown recombines the split payloads into a single column to undo the migration
 // up direction.
-func (m *documentColumnSplitMigrator) MigrateRowDown(scanner scanner) ([]any, error) {
+func (m *documentColumnSplitMigrator) MigrateRowDown(scanner dbutil.Scanner) ([]any, error) {
 	var path string
 	var rawData []byte
 	var encoded MarshalledDocumentData

--- a/enterprise/internal/oobmigration/migrations/codeintel/locations_count.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/locations_count.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 func NewDefinitionLocationsCountMigrator(store *basestore.Store, batchSize, numRoutines int) *migrator {
@@ -49,7 +50,7 @@ func (m *locationsCountMigrator) Interval() time.Duration { return m.interval }
 
 // MigrateRowUp reads the payload of the given row and returns an updateSpec on how to
 // modify the record to conform to the new schema.
-func (m *locationsCountMigrator) MigrateRowUp(scanner scanner) ([]any, error) {
+func (m *locationsCountMigrator) MigrateRowUp(scanner dbutil.Scanner) ([]any, error) {
 	var scheme, identifier string
 	var rawData []byte
 
@@ -66,7 +67,7 @@ func (m *locationsCountMigrator) MigrateRowUp(scanner scanner) ([]any, error) {
 }
 
 // MigrateRowDown sets num_locations back to zero to undo the migration up direction.
-func (m *locationsCountMigrator) MigrateRowDown(scanner scanner) ([]any, error) {
+func (m *locationsCountMigrator) MigrateRowDown(scanner dbutil.Scanner) ([]any, error) {
 	var scheme, identifier string
 	var rawData []byte
 

--- a/enterprise/internal/oobmigration/migrations/codeintel/migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/migrator_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 func TestMigratorRemovesBoundsWithoutData(t *testing.T) {
@@ -126,7 +127,7 @@ type testMigrationDriver struct{}
 func (m *testMigrationDriver) ID() int                 { return 10 }
 func (m *testMigrationDriver) Interval() time.Duration { return time.Second }
 
-func (m *testMigrationDriver) MigrateRowUp(scanner scanner) ([]any, error) {
+func (m *testMigrationDriver) MigrateRowUp(scanner dbutil.Scanner) ([]any, error) {
 	var a, b, c int
 	if err := scanner.Scan(&a, &b, &c); err != nil {
 		return nil, err
@@ -135,7 +136,7 @@ func (m *testMigrationDriver) MigrateRowUp(scanner scanner) ([]any, error) {
 	return []any{a, b + c}, nil
 }
 
-func (m *testMigrationDriver) MigrateRowDown(scanner scanner) ([]any, error) {
+func (m *testMigrationDriver) MigrateRowDown(scanner dbutil.Scanner) ([]any, error) {
 	var a, b, c int
 	if err := scanner.Scan(&a, &b, &c); err != nil {
 		return nil, err

--- a/internal/database/executor_secret_access_logs.go
+++ b/internal/database/executor_secret_access_logs.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 // ExecutorSecretAccessLog represents a row in the `executor_secret_access_logs` table.
@@ -239,9 +240,7 @@ INSERT INTO
 
 // scanExecutorSecretAccessLog scans an ExecutorSecretAccessLog from the given scanner
 // into the given ExecutorSecretAccessLog.
-func scanExecutorSecretAccessLog(log *ExecutorSecretAccessLog, s interface {
-	Scan(...any) error
-}) error {
+func scanExecutorSecretAccessLog(log *ExecutorSecretAccessLog, s dbutil.Scanner) error {
 	return s.Scan(
 		&log.ID,
 		&log.ExecutorSecretID,

--- a/internal/database/executor_secrets.go
+++ b/internal/database/executor_secrets.go
@@ -178,8 +178,10 @@ func (s *executorSecretStore) Transact(ctx context.Context) (ExecutorSecretStore
 	}, err
 }
 
-var ErrEmptyExecutorSecretKey = errors.New("empty executor secret key is not allowed")
-var ErrEmptyExecutorSecretValue = errors.New("empty executor secret value is not allowed")
+var (
+	ErrEmptyExecutorSecretKey   = errors.New("empty executor secret key is not allowed")
+	ErrEmptyExecutorSecretValue = errors.New("empty executor secret value is not allowed")
+)
 
 var ErrDuplicateExecutorSecret = errors.New("duplicate executor secret")
 
@@ -479,9 +481,7 @@ RETURNING %s
 
 // scanExecutorSecret scans a secret from the given scanner into the given
 // ExecutorSecret.
-func scanExecutorSecret(secret *ExecutorSecret, key encryption.Key, s interface {
-	Scan(...any) error
-}) error {
+func scanExecutorSecret(secret *ExecutorSecret, key encryption.Key, s dbutil.Scanner) error {
 	var (
 		value []byte
 		keyID string

--- a/internal/database/feature_flags.go
+++ b/internal/database/feature_flags.go
@@ -8,13 +8,12 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	ff "github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var (
-	clearRedisCache = ff.ClearEvaluatedFlagFromCache
-)
+var clearRedisCache = ff.ClearEvaluatedFlagFromCache
 
 type FeatureFlagStore interface {
 	basestore.ShareableStore
@@ -181,12 +180,7 @@ func (f *featureFlagStore) CreateBool(ctx context.Context, name string, value bo
 
 var ErrInvalidColumnState = errors.New("encountered column that is unexpectedly null based on column type")
 
-// rowScanner is an interface that can scan from either a sql.Row or sql.Rows
-type rowScanner interface {
-	Scan(...any) error
-}
-
-func scanFeatureFlag(scanner rowScanner) (*ff.FeatureFlag, error) {
+func scanFeatureFlag(scanner dbutil.Scanner) (*ff.FeatureFlag, error) {
 	var (
 		res      ff.FeatureFlag
 		flagType string
@@ -465,7 +459,7 @@ func scanFeatureFlagOverrides(rows *sql.Rows) ([]*ff.Override, error) {
 	return res, nil
 }
 
-func scanFeatureFlagOverride(scanner rowScanner) (*ff.Override, error) {
+func scanFeatureFlagOverride(scanner dbutil.Scanner) (*ff.Override, error) {
 	var res ff.Override
 	err := scanner.Scan(
 		&res.OrgID,

--- a/internal/database/user_credentials.go
+++ b/internal/database/user_credentials.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
@@ -463,9 +464,7 @@ RETURNING %s
 //
 // s is inspired by the BatchChange scanner type, but also matches sql.Row, which
 // is generally used directly in this module.
-func scanUserCredential(cred *UserCredential, key encryption.Key, s interface {
-	Scan(...any) error
-}) error {
+func scanUserCredential(cred *UserCredential, key encryption.Key, s dbutil.Scanner) error {
 	var (
 		credential []byte
 		keyID      string


### PR DESCRIPTION
Replace redundant copies of `dbutil.Scanner` interfaces with `dbutil.Scanner`

## Test plan

Equivalent interface change, compiler will guarantee is ok
