### PR TITLE
sg: disable docs linter (flaky)

### DIFF
--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -50,8 +50,9 @@ var Targets = []Target{
 	{
 		Name:        "docs",
 		Description: "Documentation checks",
-		Checks: []*linter{
-			runScript("Docsite lint", "dev/docsite.sh check"),
+		Checks:      []*linter{
+			// Flaky https://buildkite.com/sourcegraph/sourcegraph/builds/189124
+			// runScript("Docsite lint", "dev/docsite.sh check"),
 		},
 	},
 	{


### PR DESCRIPTION
Disable `sg lint docs` (flaky: https://buildkite.com/sourcegraph/sourcegraph/builds/189124) 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Just disabled the docs linter. 