### PR TITLE
workers: rename resetter metrics method & document metrics

### DIFF
--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -152,6 +152,6 @@ func newWorkerMetrics(observationCtx *observation.Context, workerName string) (w
 	workerMetrics := workerutil.NewMetrics(observationCtx, workerName+"_processor", workerutil.WithSampler(func(job workerutil.Record) bool {
 		return true
 	}))
-	resetterMetrics := dbworker.NewMetrics(observationCtx, workerName)
+	resetterMetrics := dbworker.NewResetterMetrics(observationCtx, workerName)
 	return workerMetrics, *resetterMetrics
 }

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background/queryrunner"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/scheduler/iterator"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -78,7 +79,7 @@ func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*worker
 	resetter := dbworker.NewResetter(log.Scoped("", ""), workerStore, dbworker.ResetterOptions{
 		Name:     fmt.Sprintf("%s_resetter", name),
 		Interval: time.Second * 20,
-		Metrics:  *dbworker.NewMetrics(config.ObservationCtx, name),
+		Metrics:  *dbworker.NewResetterMetrics(config.ObservationCtx, name),
 	})
 
 	configLogger := log.Scoped("insightsInProgressConfigWatcher", "")

--- a/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
@@ -76,7 +76,7 @@ func makeNewBackfillWorker(ctx context.Context, config JobMonitorConfig) (*worke
 	resetter := dbworker.NewResetter(log.Scoped("BackfillNewResetter", ""), workerStore, dbworker.ResetterOptions{
 		Name:     fmt.Sprintf("%s_resetter", name),
 		Interval: time.Second * 20,
-		Metrics:  *dbworker.NewMetrics(config.ObservationCtx, name),
+		Metrics:  *dbworker.NewResetterMetrics(config.ObservationCtx, name),
 	})
 
 	return worker, resetter, workerStore

--- a/internal/repos/webhook_build_job.go
+++ b/internal/repos/webhook_build_job.go
@@ -59,6 +59,6 @@ func (w *webhookBuildJob) Routines(_ context.Context, observationCtx *observatio
 
 func newWebhookBuildWorkerMetrics(observationCtx *observation.Context, workerName string) (workerutil.WorkerObservability, dbworker.ResetterMetrics) {
 	workerMetrics := workerutil.NewMetrics(observationCtx, fmt.Sprintf("%s_processor", workerName))
-	resetterMetrics := dbworker.NewMetrics(observationCtx, workerName)
+	resetterMetrics := dbworker.NewResetterMetrics(observationCtx, workerName)
 	return workerMetrics, *resetterMetrics
 }

--- a/internal/workerutil/dbworker/resetter.go
+++ b/internal/workerutil/dbworker/resetter.go
@@ -43,9 +43,11 @@ type ResetterMetrics struct {
 	Errors              prometheus.Counter
 }
 
-// NewMetrics returns a metrics object for a resetter that follows standard naming convention. The base metric name should be
-// the same metric name provided to a `worker` ex. my_job_queue. Do not provide prefix "src" or postfix "_record...".
-func NewMetrics(observationCtx *observation.Context, metricNameRoot string) *ResetterMetrics {
+// NewResetterMetrics returns a metrics object for a resetter that follows
+// standard naming convention. The base metric name should be the same metric
+// name provided to a `worker` ex. my_job_queue. Do not provide prefix "src" or
+// postfix "_record...".
+func NewResetterMetrics(observationCtx *observation.Context, metricNameRoot string) *ResetterMetrics {
 	resets := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "src_" + metricNameRoot + "_record_resets_total",
 		Help: "The number of stalled record resets.",


### PR DESCRIPTION
This renames `dbworker.NewMetrics` to `dbworker.NewResetterMetrics` to make it more explicit what it is.

It also changes the documentation to show how to configure metrics for the `worker` and the `resetter`. If not configured we run into nil panics.


## Test plan

- N/A
