### PR TITLE
Use proper cursor pagination for git commit UIs

### DIFF
--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -788,6 +788,7 @@ describe('Repository', () => {
                                 pageInfo: {
                                     __typename: 'PageInfo',
                                     hasNextPage: true,
+                                    endCursor: 'abc',
                                 },
                             },
                         },

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -46,7 +46,7 @@ export const getCommonRepositoryGraphQlResults = (
     TreeCommits: () => ({
         node: {
             __typename: 'Repository',
-            commit: { ancestors: { nodes: [], pageInfo: { hasNextPage: false } } },
+            commit: { ancestors: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } },
         },
     }),
     Blob: ({ filePath }) => createBlobContentResult(`content for: ${filePath}\nsecond line\nthird line`),
@@ -263,7 +263,7 @@ describe('Repository', () => {
                                         },
                                     },
                                 ],
-                                pageInfo: { hasNextPage: false },
+                                pageInfo: { __typename: 'PageInfo', hasNextPage: false, endCursor: 'abc' },
                             },
                         },
                     },

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -624,7 +624,7 @@ describe('Repository', () => {
     })
 
     describe('commits page', () => {
-        it.only('loads commits of a repository', async () => {
+        it('loads commits of a repository', async () => {
             const shortRepositoryName = 'sourcegraph/sourcegraph'
             const repositoryName = `github.com/${shortRepositoryName}`
             testContext.overrideGraphQL({

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -808,6 +808,7 @@ describe('Repository', () => {
             })
             await driver.page.goto(driver.sourcegraphBaseUrl + '/github.com/sourcegraph/sourcegraph/-/commits')
             await driver.page.waitForSelector('[data-testid="commits-page"]', { visible: true })
+            await driver.page.waitForSelector('.list-group-item', { visible: true })
             await percySnapshotWithVariants(driver.page, 'Repository commits page')
             await accessibilityAudit(driver.page)
         })

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -624,7 +624,7 @@ describe('Repository', () => {
     })
 
     describe('commits page', () => {
-        it('loads commits of a repository', async () => {
+        it.only('loads commits of a repository', async () => {
             const shortRepositoryName = 'sourcegraph/sourcegraph'
             const repositoryName = `github.com/${shortRepositoryName}`
             testContext.overrideGraphQL({
@@ -633,13 +633,14 @@ describe('Repository', () => {
                 RepositoryGitCommits: () => ({
                     __typename: 'Query',
                     node: {
-                        __typename: 'GitCommit',
+                        __typename: 'Repository',
                         commit: {
                             __typename: 'GitCommit',
                             ancestors: {
                                 __typename: 'GitCommitConnection',
                                 nodes: [
                                     {
+                                        __typename: 'GitCommit',
                                         id: 'R2l0Q29tbWl0OnsiciI6IlVtVndiM05wZEc5eWVUb3hORGs9IiwiYyI6IjI4NGFiYTAyNGIxYjU1ODU5MGU4ZTJmOTdkYmMzNTUzYTVlMGM3NmIifQ==',
                                         oid: '284aba024b1b558590e8e2f97dbc3553a5e0c76b',
                                         abbreviatedOID: '284aba0',
@@ -647,7 +648,9 @@ describe('Repository', () => {
                                         subject: 'sg: create a test command to run e2e tests locally (#34627)',
                                         body: null,
                                         author: {
+                                            __typename: 'Signature',
                                             person: {
+                                                __typename: 'Person',
                                                 avatarURL: null,
                                                 name: 'Jean-Hadrien Chabran',
                                                 email: 'jr9@gmail.com',
@@ -657,7 +660,9 @@ describe('Repository', () => {
                                             date: subDays(now, 5).toISOString(),
                                         },
                                         committer: {
+                                            __typename: 'Signature',
                                             person: {
+                                                __typename: 'Person',
                                                 avatarURL: null,
                                                 name: 'GitHub',
                                                 email: 'noreply@yahoo.com',
@@ -679,7 +684,7 @@ describe('Repository', () => {
                                         externalURLs: [
                                             {
                                                 url: 'https://github.com/sourcegraph/sourcegraph/commit/284aba024b1b558590e8e2f97dbc3553a5e0c76b',
-                                                serviceKind: 'GITHUB',
+                                                serviceKind: ExternalServiceKind.GITHUB,
                                             },
                                         ],
                                         tree: {
@@ -688,6 +693,7 @@ describe('Repository', () => {
                                         },
                                     },
                                     {
+                                        __typename: 'GitCommit',
                                         id: 'R2l0Q29tbWl0OnsiciI6IlVtVndiM05wZEc5eWVUb3hORGs9IiwiYyI6ImEyZDFmZDQ3NGQ3OWRjMjlhZjZjN2I0YzMzZjAyZmUyMjI4N2JkMTEifQ==',
                                         oid: 'a2d1fd474d79dc29af6c7b4c33f02fe22287bd11',
                                         abbreviatedOID: 'a2d1fd4',
@@ -696,7 +702,9 @@ describe('Repository', () => {
                                         subject: 'Wildcard V2: <Checkbox /> migration (#34324)',
                                         body: 'Co-authored-by: gitstart-sourcegraph <gitstart@users.noreply.github.com>',
                                         author: {
+                                            __typename: 'Signature',
                                             person: {
+                                                __typename: 'Person',
                                                 avatarURL: null,
                                                 name: 'GitStart-SourceGraph',
                                                 email: '89894075h@facebook.net',
@@ -706,7 +714,9 @@ describe('Repository', () => {
                                             date: subDays(now, 5).toISOString(),
                                         },
                                         committer: {
+                                            __typename: 'Signature',
                                             person: {
+                                                __typename: 'Person',
                                                 avatarURL: null,
                                                 name: 'GitHub',
                                                 email: 'google@yahoo.com',
@@ -728,7 +738,7 @@ describe('Repository', () => {
                                         externalURLs: [
                                             {
                                                 url: 'https://github.com/sourcegraph/sourcegraph/commit/a2d1fd474d79dc29af6c7b4c33f02fe22287bd11',
-                                                serviceKind: 'GITHUB',
+                                                serviceKind: ExternalServiceKind.GITHUB,
                                             },
                                         ],
                                         tree: {
@@ -737,6 +747,7 @@ describe('Repository', () => {
                                         },
                                     },
                                     {
+                                        __typename: 'GitCommit',
                                         id: 'R2l0Q29tbWl0OnsiciI6IlVtVndiM05wZEc5eWVUb3hORGs9IiwiYyI6IjNhMTYzYjkyYjVjNDU5MjFmYmM3MzBmZjIwNDdmZjdlNjBkODY4OWIifQ==',
                                         oid: '3a163b92b5c45921fbc730ff2047ff7e60d8689b',
                                         abbreviatedOID: '3a163b9',
@@ -744,7 +755,9 @@ describe('Repository', () => {
                                         subject: 'web: ban `reactstrap` imports (#34881)',
                                         body: null,
                                         author: {
+                                            __typename: 'Signature',
                                             person: {
+                                                __typename: 'Person',
                                                 avatarURL: null,
                                                 name: 'Valery Bugakov',
                                                 email: 'user23@gmail.com',
@@ -754,7 +767,9 @@ describe('Repository', () => {
                                             date: subDays(now, 5).toISOString(),
                                         },
                                         committer: {
+                                            __typename: 'Signature',
                                             person: {
+                                                __typename: 'Person',
                                                 avatarURL: null,
                                                 name: 'GitHub',
                                                 email: 'user43@gmail.com',
@@ -776,7 +791,7 @@ describe('Repository', () => {
                                         externalURLs: [
                                             {
                                                 url: 'https://github.com/sourcegraph/sourcegraph/commit/3a163b92b5c45921fbc730ff2047ff7e60d8689b',
-                                                serviceKind: 'GITHUB',
+                                                serviceKind: ExternalServiceKind.GITHUB,
                                             },
                                         ],
                                         tree: {

--- a/client/web/src/repo/commits/RepositoryCommitsPage.tsx
+++ b/client/web/src/repo/commits/RepositoryCommitsPage.tsx
@@ -1,32 +1,40 @@
-import React, { useEffect, useCallback, useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 
 import * as H from 'history'
 import { RouteComponentProps } from 'react-router'
-import { Observable, of } from 'rxjs'
-import { map } from 'rxjs/operators'
 
-import { createAggregateError } from '@sourcegraph/common'
-import { gql } from '@sourcegraph/http-client'
+import { ErrorAlert } from '@sourcegraph/branded/src/components/alerts'
+import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { RevisionSpec } from '@sourcegraph/shared/src/util/url'
-import { Code, Heading, LoadingSpinner } from '@sourcegraph/wildcard'
+import { Code, Heading } from '@sourcegraph/wildcard'
 
-import { queryGraphQL } from '../../backend/graphql'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
-import { FilteredConnection, FilteredConnectionQueryArguments } from '../../components/FilteredConnection'
+import { useShowMorePagination } from '../../components/FilteredConnection/hooks/useShowMorePagination'
+import {
+    ConnectionContainer,
+    ConnectionList,
+    ConnectionLoading,
+    ConnectionSummary,
+    ShowMoreButton,
+    SummaryContainer,
+} from '../../components/FilteredConnection/ui'
 import { PageTitle } from '../../components/PageTitle'
-import { GitCommitFields, RepositoryFields, RepositoryGitCommitsResult, Scalars } from '../../graphql-operations'
+import {
+    GitCommitFields,
+    RepositoryFields,
+    RepositoryGitCommitsResult,
+    RepositoryGitCommitsVariables,
+} from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
 import { basename } from '../../util/path'
 import { externalLinkFieldsFragment } from '../backend'
 import { FilePathBreadcrumbs } from '../FilePathBreadcrumbs'
 
-import { GitCommitNode, GitCommitNodeProps } from './GitCommitNode'
+import { GitCommitNode } from './GitCommitNode'
 
 import styles from './RepositoryCommitsPage.module.scss'
-
-type RepositoryGitCommitsRepository = Extract<RepositoryGitCommitsResult['node'], { __typename?: 'Repository' }>
 
 export const gitCommitFragment = gql`
     fragment GitCommitFields on GitCommit {
@@ -76,46 +84,28 @@ export const gitCommitFragment = gql`
     ${externalLinkFieldsFragment}
 `
 
-const fetchGitCommits = (args: {
-    repo: Scalars['ID']
-    revspec: string
-    first?: number
-    query?: string
-    filePath?: string
-}): Observable<NonNullable<RepositoryGitCommitsRepository['commit']>['ancestors']> =>
-    queryGraphQL(
-        gql`
-            query RepositoryGitCommits($repo: ID!, $revspec: String!, $first: Int, $query: String, $filePath: String) {
-                node(id: $repo) {
-                    ... on Repository {
-                        commit(rev: $revspec) {
-                            ancestors(first: $first, query: $query, path: $filePath) {
-                                nodes {
-                                    ...GitCommitFields
-                                }
-                                pageInfo {
-                                    hasNextPage
-                                }
-                            }
+const REPOSITORY_GIT_COMMITS_PER_PAGE = 20
+
+const REPOSITORY_GIT_COMMITS_QUERY = gql`
+    query RepositoryGitCommits($repo: ID!, $revspec: String!, $first: Int, $afterCursor: String, $filePath: String) {
+        node(id: $repo) {
+            ... on Repository {
+                commit(rev: $revspec) {
+                    ancestors(first: $first, path: $filePath, afterCursor: $afterCursor) {
+                        nodes {
+                            ...GitCommitFields
+                        }
+                        pageInfo {
+                            hasNextPage
+                            endCursor
                         }
                     }
                 }
             }
-            ${gitCommitFragment}
-        `,
-        args
-    ).pipe(
-        map(({ data, errors }) => {
-            if (!data || !data.node) {
-                throw createAggregateError(errors)
-            }
-            const repo = data.node as RepositoryGitCommitsRepository
-            if (!repo.commit || !repo.commit.ancestors) {
-                throw createAggregateError(errors)
-            }
-            return repo.commit.ancestors
-        })
-    )
+        }
+    }
+    ${gitCommitFragment}
+`
 
 export interface RepositoryCommitsPageProps
     extends RevisionSpec,
@@ -124,7 +114,7 @@ export interface RepositoryCommitsPageProps
             filePath?: string | undefined
         }>,
         TelemetryProps {
-    repo: RepositoryFields | undefined
+    repo: RepositoryFields
 
     history: H.History
     location: H.Location
@@ -137,6 +127,38 @@ export const RepositoryCommitsPage: React.FunctionComponent<React.PropsWithChild
 }) => {
     const repo = props.repo
     const filePath = props.match.params.filePath
+
+    const { connection, error, loading, hasNextPage, fetchMore } = useShowMorePagination<
+        RepositoryGitCommitsResult,
+        RepositoryGitCommitsVariables,
+        GitCommitFields
+    >({
+        query: REPOSITORY_GIT_COMMITS_QUERY,
+        variables: {
+            repo: repo?.id,
+            revspec: props.revision,
+            filePath: filePath ?? null,
+            first: REPOSITORY_GIT_COMMITS_PER_PAGE,
+            afterCursor: null,
+        },
+        getConnection: result => {
+            const { node } = dataOrThrowErrors(result)
+            if (!node) {
+                return { nodes: [] }
+            }
+            if (node.__typename !== 'Repository') {
+                return { nodes: [] }
+            }
+            if (!node.commit?.ancestors) {
+                return { nodes: [] }
+            }
+            return node?.commit?.ancestors
+        },
+        options: {
+            fetchPolicy: 'cache-first',
+            useAlternateAfterCursor: true,
+        },
+    })
 
     useEffect(() => {
         eventLogger.logPageView('RepositoryCommits')
@@ -175,23 +197,6 @@ export const RepositoryCommitsPage: React.FunctionComponent<React.PropsWithChild
         }, [repo])
     )
 
-    const queryCommits = useCallback(
-        (
-            args: FilteredConnectionQueryArguments
-        ): Observable<NonNullable<RepositoryGitCommitsRepository['commit']>['ancestors']> => {
-            if (!repo?.id) {
-                return of()
-            }
-
-            return fetchGitCommits({ ...args, repo: repo?.id, revspec: props.revision, filePath })
-        },
-        [repo?.id, props.revision, filePath]
-    )
-
-    if (!repo) {
-        return <LoadingSpinner />
-    }
-
     const getPageTitle = (): string => {
         const repoString = displayRepoName(repo.name)
         if (filePath) {
@@ -205,31 +210,43 @@ export const RepositoryCommitsPage: React.FunctionComponent<React.PropsWithChild
             <PageTitle title={getPageTitle()} />
 
             <div className={styles.content}>
-                <Heading as="h2" styleAs="h1">
-                    {filePath ? (
-                        <>
-                            View commits inside <Code>{basename(filePath)}</Code>
-                        </>
-                    ) : (
-                        <>View commits from this repository</>
+                <ConnectionContainer>
+                    <Heading as="h2" styleAs="h1">
+                        {filePath ? (
+                            <>
+                                View commits inside <Code>{basename(filePath)}</Code>
+                            </>
+                        ) : (
+                            <>View commits from this repository</>
+                        )}
+                    </Heading>
+
+                    <Heading as="h3" styleAs="h2">
+                        Changes
+                    </Heading>
+
+                    {error && <ErrorAlert error={error} className="w-100 mb-0" />}
+                    <ConnectionList className="list-group list-group-flush w-100">
+                        {connection?.nodes.map(node => (
+                            <GitCommitNode key={node.id} className="list-group-item" wrapperElement="li" node={node} />
+                        ))}
+                    </ConnectionList>
+                    {loading && <ConnectionLoading />}
+                    {connection && (
+                        <SummaryContainer centered={true}>
+                            <ConnectionSummary
+                                centered={true}
+                                first={REPOSITORY_GIT_COMMITS_PER_PAGE}
+                                connection={connection}
+                                noun="commit"
+                                pluralNoun="commits"
+                                hasNextPage={hasNextPage}
+                                emptyElement={null}
+                            />
+                            {hasNextPage ? <ShowMoreButton centered={true} onClick={fetchMore} /> : null}
+                        </SummaryContainer>
                     )}
-                </Heading>
-                <FilteredConnection<
-                    GitCommitFields,
-                    Pick<GitCommitNodeProps, 'className' | 'compact' | 'wrapperElement'>
-                >
-                    listClassName="list-group list-group-flush"
-                    noun="commit"
-                    pluralNoun="commits"
-                    queryConnection={queryCommits}
-                    nodeComponent={GitCommitNode}
-                    nodeComponentProps={{ className: 'list-group-item', wrapperElement: 'li' }}
-                    defaultFirst={20}
-                    autoFocus={true}
-                    history={props.history}
-                    hideSearch={true}
-                    location={props.location}
-                />
+                </ConnectionContainer>
             </div>
         </div>
     )

--- a/client/web/src/repo/commits/RepositoryCommitsPage.tsx
+++ b/client/web/src/repo/commits/RepositoryCommitsPage.tsx
@@ -135,7 +135,7 @@ export const RepositoryCommitsPage: React.FunctionComponent<React.PropsWithChild
     >({
         query: REPOSITORY_GIT_COMMITS_QUERY,
         variables: {
-            repo: repo?.id,
+            repo: repo.id,
             revspec: props.revision,
             filePath: filePath ?? null,
             first: REPOSITORY_GIT_COMMITS_PER_PAGE,

--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -4,6 +4,7 @@ import { RouteComponentProps } from 'react-router-dom'
 
 import { TraceSpanProvider } from '@sourcegraph/observability-client'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
+import { LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { ActionItemsBarProps } from '../extensions/components/ActionItemsBar'
 
@@ -13,7 +14,6 @@ import { RepoContainerRoute } from './RepoContainer'
 import { RepoRevisionContainerContext, RepoRevisionContainerRoute } from './RepoRevisionContainer'
 import { RepositoryFileTreePageProps } from './RepositoryFileTreePage'
 import { RepositoryTagTab } from './tree/TagTab'
-import { LoadingSpinner } from '@sourcegraph/wildcard'
 
 const RepositoryCommitsPage = lazyComponent(() => import('./commits/RepositoryCommitsPage'), 'RepositoryCommitsPage')
 

--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -13,6 +13,7 @@ import { RepoContainerRoute } from './RepoContainer'
 import { RepoRevisionContainerContext, RepoRevisionContainerRoute } from './RepoRevisionContainer'
 import { RepositoryFileTreePageProps } from './RepositoryFileTreePage'
 import { RepositoryTagTab } from './tree/TagTab'
+import { LoadingSpinner } from '@sourcegraph/wildcard'
 
 const RepositoryCommitsPage = lazyComponent(() => import('./commits/RepositoryCommitsPage'), 'RepositoryCommitsPage')
 
@@ -111,7 +112,8 @@ export const RepoContributors: React.FunctionComponent<
 
 export const RepoCommits: React.FunctionComponent<
     Omit<RepositoryCommitsPageProps, 'repo'> & Pick<RepoRevisionContainerContext, 'repo'> & RouteComponentProps
-> = ({ revision, repo, ...context }) => <RepositoryCommitsPage {...context} repo={repo} revision={revision} />
+> = ({ revision, repo, ...context }) =>
+    repo ? <RepositoryCommitsPage {...context} repo={repo} revision={revision} /> : <LoadingSpinner />
 
 const blobPath = '/-/:objectType(blob)/:filePath*'
 const treePath = '/-/:objectType(tree)/:filePath*'

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -104,6 +104,7 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
             first: TREE_COMMITS_PER_PAGE,
             filePath,
             after,
+            afterCursor: null,
         },
         getConnection: result => {
             const { node } = dataOrThrowErrors(result)

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -44,17 +44,25 @@ import styles from './TreePage.module.scss'
 const TREE_COMMITS_PER_PAGE = 10
 
 const TREE_COMMITS_QUERY = gql`
-    query TreeCommits($repo: ID!, $revspec: String!, $first: Int, $filePath: String, $after: String) {
+    query TreeCommits(
+        $repo: ID!
+        $revspec: String!
+        $first: Int
+        $filePath: String
+        $after: String
+        $afterCursor: String
+    ) {
         node(id: $repo) {
             __typename
             ... on Repository {
                 commit(rev: $revspec) {
-                    ancestors(first: $first, path: $filePath, after: $after) {
+                    ancestors(first: $first, path: $filePath, after: $after, afterCursor: $afterCursor) {
                         nodes {
                             ...GitCommitFields
                         }
                         pageInfo {
                             hasNextPage
+                            endCursor
                         }
                     }
                 }
@@ -114,6 +122,7 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
         },
         options: {
             fetchPolicy: 'cache-first',
+            useAlternateAfterCursor: true,
         },
     })
 


### PR DESCRIPTION
Closes #43658

This builds on the work of @indradhanush and updates the commits page and the repo overview page (which also queries commits) to use the new `afterCursor` field.

## Test plan

https://user-images.githubusercontent.com/458591/207400073-edcf79dc-2559-40b6-af04-cb9a910d25da.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-paginate-commits.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
