### PR TITLE
Always display search syntax help button

### DIFF
--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -11,7 +11,6 @@ import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
-import { parseSearchURLQuery } from '..'
 import { AuthenticatedUser } from '../../auth'
 import { useExperimentalFeatures, useNavbarQueryState, setSearchCaseSensitivity } from '../../stores'
 import { NavbarQueryState, setSearchMode, setSearchPatternType } from '../../stores/navbarSearchQueryState'
@@ -49,10 +48,6 @@ const selectQueryState = ({
  * The search item in the navbar
  */
 export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<Props>> = (props: Props) => {
-    const isSearchPage = props.location.pathname === '/search' && Boolean(parseSearchURLQuery(props.location.search))
-    // This uses the same logic as in Layout.tsx until we have a better solution
-    // or remove the search help button
-
     const { queryState, setQueryState, submitSearch, searchCaseSensitivity, searchPatternType, searchMode } =
         useNavbarQueryState(selectQueryState, shallow)
 
@@ -108,7 +103,7 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
                 submitSearchOnSearchContextChange={submitSearchOnChange}
                 isExternalServicesUserModeAll={window.context.externalServicesUserMode === 'all'}
                 structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch === 'disabled'}
-                hideHelpButton={isSearchPage}
+                hideHelpButton={false}
                 showSearchHistory={true}
                 recentSearches={recentSearches}
             />


### PR DESCRIPTION
Previously: the search syntax help button was not visible in the `/search` page, which is the page where users are most likely to need help with the syntax. This special-case got added in this commit https://github.com/sourcegraph/sourcegraph/commit/3b1483197c12f88e8195347f98be770ec026e10d#diff-2fc185b787901924c9d5f03b8f28599b87896268a53070f3501afa42387e3d32R55 but without an explanation why the `/search` page is special cased. Removing the special case makes the button appear again.


## Test plan

First,
```
❯ SOURCEGRAPHDOTCOM_MODE=true SOURCEGRAPH_API_URL=https://sourcegraph.com sg start web-standalone
```
Next, confirm that the search help button is visible in a search result page


![CleanShot 2022-12-13 at 20 41 06@2x](https://user-images.githubusercontent.com/1408093/207429073-580d9ef5-f2b6-47a8-8a20-0efa06ed40c6.png)


The button was already visible on the landing page and in blob pages.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-always-show-search-help.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
