### PR TITLE
insights: api changes for strat scoped insights

### DIFF
--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -227,6 +227,7 @@ type SearchInsightDataSeriesDefinitionResolver interface {
 	SeriesId(ctx context.Context) (string, error)
 	Query(ctx context.Context) (string, error)
 	RepositoryScope(ctx context.Context) (InsightRepositoryScopeResolver, error)
+	RepositoryDefinition(ctx context.Context) (InsightRepositoryDefinition, error)
 	TimeScope(ctx context.Context) (InsightTimeScope, error)
 	GeneratedFromCaptureGroups() (bool, error)
 	IsCalculated() (bool, error)
@@ -249,6 +250,20 @@ type InsightIntervalTimeScope interface {
 
 type InsightRepositoryScopeResolver interface {
 	Repositories(ctx context.Context) ([]string, error)
+}
+
+type InsightRepositoryDefinition interface {
+	ToInsightRepositoryScope() (InsightRepositoryScopeResolver, bool)
+	ToAllRepositoriesScope() (AllRepositoriesScopeResolver, bool)
+	ToRepositorySearchScope() (RepositorySearchScopeResolver, bool)
+}
+
+type AllRepositoriesScopeResolver interface {
+	AllRepos() bool
+}
+
+type RepositorySearchScopeResolver interface {
+	Search() string
 }
 
 type InsightsDashboardPayloadResolver interface {
@@ -413,7 +428,8 @@ type LineChartDataSeriesOptionsInput struct {
 }
 
 type RepositoryScopeInput struct {
-	Repositories []string
+	Repositories       []string
+	RepositoryCriteria *string
 }
 
 type TimeScopeInput struct {

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -573,6 +573,8 @@ input RepositoryScopeInput {
     The list of repositories included in this scope.
     """
     repositories: [String!]!
+
+    repositoryCriteria: String
 }
 
 """
@@ -1019,7 +1021,12 @@ type SearchInsightDataSeriesDefinition {
     """
     A scope of repositories defined for this insight.
     """
-    repositoryScope: InsightRepositoryScope!
+    repositoryScope: InsightRepositoryScope! @deprecated(reason: "use repositoryDefinition instead")
+
+    """
+    A definition of Repositories this series will operate over.
+    """
+    repositoryDefinition: InsightRepositoryDefinition!
 
     """
     The scope of time for which the insight data is generated.
@@ -1042,6 +1049,16 @@ type SearchInsightDataSeriesDefinition {
     """
     groupBy: GroupByField
 }
+
+type AllRepositoriesScope {
+    allRepos: Boolean!
+}
+
+type RepositorySearchScope {
+    search: String!
+}
+
+union InsightRepositoryDefinition = AllRepositoriesScope | RepositorySearchScope | InsightRepositoryScope
 
 """
 View presentation for a line chart insight

--- a/enterprise/internal/insights/discovery/series_repo_iterator.go
+++ b/enterprise/internal/insights/discovery/series_repo_iterator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type seriesRepoIterator struct {
@@ -18,7 +19,12 @@ type SeriesRepoIterator interface {
 func (s *seriesRepoIterator) ForSeries(ctx context.Context, series *types.InsightSeries) (RepoIterator, error) {
 	switch len(series.Repositories) {
 	case 0:
-		return s.allRepoIterator, nil
+		if series.RepositoryCriteria == nil {
+			return s.allRepoIterator, nil
+		} else {
+			return nil, errors.New("search scoped repository series not implimented")
+		}
+
 	default:
 		return NewScopedRepoIterator(ctx, series.Repositories, s.repoStore)
 	}

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -301,7 +301,7 @@ func (s *InsightStore) GetDataSeries(ctx context.Context, args GetDataSeriesArgs
 		preds = append(preds, sqlf.Sprintf("id = %d", args.ID))
 	}
 	if args.GlobalOnly {
-		preds = append(preds, sqlf.Sprintf("(repositories IS NULL OR CARDINALITY(repositories) = 0)"))
+		preds = append(preds, sqlf.Sprintf("((repositories IS NULL OR CARDINALITY(repositories) = 0) AND repository_criteria IS NULL)"))
 	}
 	if args.ExcludeJustInTime {
 		preds = append(preds, sqlf.Sprintf("just_in_time = false"))


### PR DESCRIPTION
Adds changes to the mutations for create/edit and getting series to account for repo scoping.

My intention is to surface very specifically what the repo scoping is, so it's not bound to a specific UI.

## Test plan
tbd
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
