### PR TITLE
Code monitoring: skip commit set on timeout and log error

### DIFF
--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -132,7 +132,7 @@ func Search(ctx context.Context, logger log.Logger, db database.DB, query string
 
 	if featureflag.FromContext(ctx).GetBoolOr("cc-repo-aware-monitors", true) {
 		hook := func(ctx context.Context, db database.DB, gs commit.GitserverClient, args *gitprotocol.SearchRequest, repoID api.RepoID, doSearch commit.DoSearchFunc) error {
-			return hookWithID(ctx, db, gs, monitorID, repoID, args, doSearch)
+			return hookWithID(ctx, db, logger, gs, monitorID, repoID, args, doSearch)
 		}
 		{
 			// This block is a transitional block that can be removed in a
@@ -272,6 +272,7 @@ func addCodeMonitorHook(in job.Job, hook commit.CodeMonitorHook) (_ job.Job, err
 func hookWithID(
 	ctx context.Context,
 	db database.DB,
+	logger log.Logger,
 	gs commit.GitserverClient,
 	monitorID int64,
 	repoID api.RepoID,
@@ -311,10 +312,18 @@ func hookWithID(
 
 	// Execute the search
 	err = doSearch(&argsCopy)
-	// ignore any errors from early cancellation
-	err = errors.Ignore(err, errors.IsContextError)
 	if err != nil {
-		return err
+		if errors.IsContextError(err) {
+			logger.Error(
+				"commit search timed out, some commits may have been skipped",
+				log.Error(err),
+				log.String("repo", string(args.Repo)),
+				log.Strings("include", commitHashes),
+				log.Strings("exlcude", lastSearched),
+			)
+		} else {
+			return err
+		}
 	}
 
 	// If the search was successful, store the resolved hashes

--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -314,7 +314,7 @@ func hookWithID(
 	err = doSearch(&argsCopy)
 	if err != nil {
 		if errors.IsContextError(err) {
-			logger.Error(
+			logger.Warn(
 				"commit search timed out, some commits may have been skipped",
 				log.Error(err),
 				log.String("repo", string(args.Repo)),

--- a/enterprise/internal/codemonitors/search_test.go
+++ b/enterprise/internal/codemonitors/search_test.go
@@ -138,7 +138,7 @@ func TestCodeMonitorHook(t *testing.T) {
 		}})
 		return nil
 	}
-	err := hookWithID(ctx, db, gs, fixtures.Monitor.ID, fixtures.Repo.ID, &gitprotocol.SearchRequest{}, doSearch)
+	err := hookWithID(ctx, db, logger, gs, fixtures.Monitor.ID, fixtures.Repo.ID, &gitprotocol.SearchRequest{}, doSearch)
 	require.NoError(t, err)
 
 	// The next time, doSearch should receive the new resolved hashes plus the
@@ -155,6 +155,6 @@ func TestCodeMonitorHook(t *testing.T) {
 		}})
 		return nil
 	}
-	err = hookWithID(ctx, db, gs, fixtures.Monitor.ID, fixtures.Repo.ID, &gitprotocol.SearchRequest{}, doSearch)
+	err = hookWithID(ctx, db, logger, gs, fixtures.Monitor.ID, fixtures.Repo.ID, &gitprotocol.SearchRequest{}, doSearch)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
It's possible that a commit (or set of commits) will be too large to search in the normal timeout. Instead of repeatedly attempting the search and potentially re-sending the partial matches, this updates the logic to skip a commit set on timeout and log an error with diagnostic information.

## Test plan

Manual test on the problematic repo.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
