### PR TITLE
insights: series updates to exclude series with search based repo scopes from appearing like global

### DIFF
--- a/enterprise/internal/insights/discovery/series_repo_iterator.go
+++ b/enterprise/internal/insights/discovery/series_repo_iterator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type seriesRepoIterator struct {
@@ -18,7 +19,12 @@ type SeriesRepoIterator interface {
 func (s *seriesRepoIterator) ForSeries(ctx context.Context, series *types.InsightSeries) (RepoIterator, error) {
 	switch len(series.Repositories) {
 	case 0:
-		return s.allRepoIterator, nil
+		if series.RepositoryCriteria == nil {
+			return s.allRepoIterator, nil
+		} else {
+			return nil, errors.New("search scoped repository series not implimented")
+		}
+
 	default:
 		return NewScopedRepoIterator(ctx, series.Repositories, s.repoStore)
 	}

--- a/enterprise/internal/insights/discovery/series_repo_iterator.go
+++ b/enterprise/internal/insights/discovery/series_repo_iterator.go
@@ -22,7 +22,7 @@ func (s *seriesRepoIterator) ForSeries(ctx context.Context, series *types.Insigh
 		if series.RepositoryCriteria == nil {
 			return s.allRepoIterator, nil
 		} else {
-			return nil, errors.New("search scoped repository series not implimented")
+			return nil, errors.New("search scoped repository series not implemented")
 		}
 
 	default:

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -301,7 +301,7 @@ func (s *InsightStore) GetDataSeries(ctx context.Context, args GetDataSeriesArgs
 		preds = append(preds, sqlf.Sprintf("id = %d", args.ID))
 	}
 	if args.GlobalOnly {
-		preds = append(preds, sqlf.Sprintf("(repositories IS NULL OR CARDINALITY(repositories) = 0)"))
+		preds = append(preds, sqlf.Sprintf("((repositories IS NULL OR CARDINALITY(repositories) = 0) AND repository_criteria IS NULL)"))
 	}
 	if args.ExcludeJustInTime {
 		preds = append(preds, sqlf.Sprintf("just_in_time = false"))


### PR DESCRIPTION
Updates logic that was looking for "global" series that ran over all repos, to exclude series that have a search specified as their repo scope.

part of https://github.com/sourcegraph/sourcegraph/issues/42455
## Test plan
Unit tests pass
backfilled all repos & named repos insights
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
