### PR TITLE
Add option to unlock user accounts to site admin users menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Added a button "Reindex now" to the index status page. Admins can now force an immediate reindex of a repository. [#45533](https://github.com/sourcegraph/sourcegraph/pull/45533)
+- Added an option "Unlock user" to the actions dropdown on the Site Admin Users page. Admins can unlock user accounts that wer locked after too many sign-in attempts. [#45650](https://github.com/sourcegraph/sourcegraph/pull/45650)
 
 ### Changed
 

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/UsersList.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/UsersList.tsx
@@ -9,6 +9,7 @@ import {
     mdiClipboardMinus,
     mdiClipboardPlus,
     mdiClose,
+    mdiLockOpen,
 } from '@mdi/js'
 import classNames from 'classnames'
 import { formatDistanceToNowStrict, startOfDay, endOfDay } from 'date-fns'
@@ -167,6 +168,7 @@ export const UsersList: React.FunctionComponent<UsersListProps> = ({ onActionEnd
         handleForceSignOutUsers,
         handleRevokeSiteAdmin,
         handlePromoteToSiteAdmin,
+        handleUnlockUser,
         handleResetUserPassword,
         notification,
         handleDismissNotification,
@@ -284,6 +286,13 @@ export const UsersList: React.FunctionComponent<UsersListProps> = ({ onActionEnd
                                 icon: mdiClipboardPlus,
                                 onClick: handlePromoteToSiteAdmin,
                                 condition: ([user]) => !user?.siteAdmin && !user?.deletedAt,
+                            },
+                            {
+                                key: 'unlock-user',
+                                label: 'Unlock user',
+                                icon: mdiLockOpen,
+                                onClick: handleUnlockUser,
+                                condition: ([user]) => !user?.deletedAt,
                             },
                             {
                                 key: 'delete',
@@ -508,6 +517,7 @@ export interface UseUserListActionReturnType {
     handleDeleteUsersForever: ActionHandler
     handlePromoteToSiteAdmin: ActionHandler
     handleRevokeSiteAdmin: ActionHandler
+    handleUnlockUser: ActionHandler
     notification: { text: React.ReactNode; isError?: boolean } | undefined
     handleDismissNotification: () => void
     handleResetUserPassword: ActionHandler

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/UsersList.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/UsersList.tsx
@@ -9,6 +9,7 @@ import {
     mdiClipboardMinus,
     mdiClipboardPlus,
     mdiClose,
+    mdiLock,
     mdiLockOpen,
 } from '@mdi/js'
 import classNames from 'classnames'
@@ -31,6 +32,7 @@ import {
     Popover,
     Position,
     PopoverOpenEvent,
+    Tooltip,
 } from '@sourcegraph/wildcard'
 
 import {
@@ -292,7 +294,7 @@ export const UsersList: React.FunctionComponent<UsersListProps> = ({ onActionEnd
                                 label: 'Unlock user',
                                 icon: mdiLockOpen,
                                 onClick: handleUnlockUser,
-                                condition: ([user]) => !user?.deletedAt,
+                                condition: ([user]) => !user?.deletedAt && user?.locked,
                             },
                             {
                                 key: 'delete',
@@ -470,7 +472,7 @@ export const UsersList: React.FunctionComponent<UsersListProps> = ({ onActionEnd
     )
 }
 
-function RenderUsernameAndEmail({ username, email, displayName, deletedAt }: SiteUser): JSX.Element {
+function RenderUsernameAndEmail({ username, email, displayName, deletedAt, locked }: SiteUser): JSX.Element {
     const [isOpen, setIsOpen] = useState<boolean>(false)
     const handleOpenChange = useCallback((event: PopoverOpenEvent): void => {
         setIsOpen(event.isOpen)
@@ -483,9 +485,16 @@ function RenderUsernameAndEmail({ username, email, displayName, deletedAt }: Sit
             })}
         >
             {!deletedAt ? (
-                <Link to={`/users/${username}`} className="text-truncate">
-                    @{username}
-                </Link>
+                <>
+                    {locked && (
+                        <Tooltip content="This user is locked and cannot sign in.">
+                            <Icon aria-label="Account locked" svgPath={mdiLock} />
+                        </Tooltip>
+                    )}{' '}
+                    <Link to={`/users/${username}`} className="text-truncate">
+                        @{username}
+                    </Link>
+                </>
             ) : (
                 <Text className="mb-0 text-truncate">@{username}</Text>
             )}

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/useUserListActions.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/useUserListActions.tsx
@@ -141,7 +141,8 @@ export function useUserListActions(onEnd: (error?: any) => void): UseUserListAct
                                     Successfully unlocked user <strong>{user.username}</strong>{' '}
                                 </Text>,
                                 true
-                            )
+                            )()
+                            return
                         }
 
                         response

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/useUserListActions.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/useUserListActions.tsx
@@ -125,7 +125,11 @@ export function useUserListActions(onEnd: (error?: any) => void): UseUserListAct
 
     const handleUnlockUser = useCallback(
         ([user]: SiteUser[]) => {
-            if (confirm('Are you sure you want to unlock the selected user?')) {
+            if (
+                confirm(
+                    'This will allow the selected user to sign in again if their account has been locked. Are you sure you want to proceed?'
+                )
+            ) {
                 fetch('unlock-user-account', {
                     method: 'POST',
                     headers: {

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/useUserListActions.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/useUserListActions.tsx
@@ -125,27 +125,32 @@ export function useUserListActions(onEnd: (error?: any) => void): UseUserListAct
 
     const handleUnlockUser = useCallback(
         ([user]: SiteUser[]) => {
-            if (
-                confirm(
-                    'This will allow the selected user to sign in again if their account has been locked. Are you sure you want to proceed?'
-                )
-            ) {
-                fetch('unlock-user-account', {
+            if (confirm("Are you sure you want to unlock this user's account?")) {
+                fetch('/-/unlock-user-account', {
                     method: 'POST',
                     headers: {
                         Accept: 'application/json',
                         'Content-Type': 'application/json',
                     },
-                    body: JSON.stringify({ userId: user.id }),
+                    body: JSON.stringify({ username: user.username }),
                 })
-                    .then(
-                        createOnSuccess(
-                            <Text as="span">
-                                Successfully unlocked user <strong>{user.username}</strong>{' '}
-                            </Text>,
-                            true
-                        )
-                    )
+                    .then(response => {
+                        if (response.status === 200) {
+                            createOnSuccess(
+                                <Text as="span">
+                                    Successfully unlocked user <strong>{user.username}</strong>{' '}
+                                </Text>,
+                                true
+                            )
+                        }
+
+                        response
+                            .text()
+                            .then(text => {
+                                onError(new Error('Failed to unlock user: ' + text))
+                            })
+                            .catch(onError)
+                    })
                     .catch(onError)
             }
         },

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/useUserListActions.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/useUserListActions.tsx
@@ -123,6 +123,31 @@ export function useUserListActions(onEnd: (error?: any) => void): UseUserListAct
         [onError, createOnSuccess]
     )
 
+    const handleUnlockUser = useCallback(
+        ([user]: SiteUser[]) => {
+            if (confirm('Are you sure you want to unlock the selected user?')) {
+                fetch('unlock-user-account', {
+                    method: 'POST',
+                    headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({ userId: user.id }),
+                })
+                    .then(
+                        createOnSuccess(
+                            <Text as="span">
+                                Successfully unlocked user <strong>{user.username}</strong>{' '}
+                            </Text>,
+                            true
+                        )
+                    )
+                    .catch(onError)
+            }
+        },
+        [onError, createOnSuccess]
+    )
+
     const handleRevokeSiteAdmin = useCallback(
         ([user]: SiteUser[]) => {
             if (confirm('Are you sure you want to revoke the selected user from site admin?')) {
@@ -179,6 +204,7 @@ export function useUserListActions(onEnd: (error?: any) => void): UseUserListAct
         handleDeleteUsers,
         handleDeleteUsersForever,
         handlePromoteToSiteAdmin,
+        handleUnlockUser,
         handleRevokeSiteAdmin,
         handleResetUserPassword,
         handleDismissNotification,

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/queries.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/queries.tsx
@@ -51,6 +51,7 @@ export const USERS_MANAGEMENT_USERS_LIST = gql`
                     createdAt
                     lastActiveAt
                     deletedAt
+                    locked
                 }
             }
         }

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/index.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/index.tsx
@@ -197,6 +197,15 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                                 </Button>
                             ))}{' '}
                         {this.props.node.id !== this.props.authenticatedUser.id && (
+                            <Button
+                                key="promote"
+                                disabled={this.state.loading}
+                                variant="secondary"
+                                size="sm"
+                            >
+                                Unlock user
+                            </Button>)}
+                        {this.props.node.id !== this.props.authenticatedUser.id && (
                             <Button onClick={this.deleteUser} disabled={this.state.loading} variant="danger" size="sm">
                                 Delete
                             </Button>

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/index.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/index.tsx
@@ -197,14 +197,10 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                                 </Button>
                             ))}{' '}
                         {this.props.node.id !== this.props.authenticatedUser.id && (
-                            <Button
-                                key="promote"
-                                disabled={this.state.loading}
-                                variant="secondary"
-                                size="sm"
-                            >
+                            <Button key="promote" disabled={this.state.loading} variant="secondary" size="sm">
                                 Unlock user
-                            </Button>)}
+                            </Button>
+                        )}
                         {this.props.node.id !== this.props.authenticatedUser.id && (
                             <Button onClick={this.deleteUser} disabled={this.state.loading} variant="danger" size="sm">
                                 Delete

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/index.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/index.tsx
@@ -197,11 +197,6 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                                 </Button>
                             ))}{' '}
                         {this.props.node.id !== this.props.authenticatedUser.id && (
-                            <Button key="promote" disabled={this.state.loading} variant="secondary" size="sm">
-                                Unlock user
-                            </Button>
-                        )}
-                        {this.props.node.id !== this.props.authenticatedUser.id && (
                             <Button onClick={this.deleteUser} disabled={this.state.loading} variant="danger" size="sm">
                                 Delete
                             </Button>

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -7040,6 +7040,10 @@ type SiteUser {
     Total number of user's event_logs.
     """
     eventsCount: Float!
+    """
+    Whether or not the user account is locked.
+    """
+    locked: Boolean!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/site_users.go
+++ b/cmd/frontend/graphqlbackend/site_users.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/users"
 )
 
@@ -19,7 +21,8 @@ func (s *siteResolver) Users(ctx context.Context, args *struct {
 	LastActiveAt *users.UsersStatsDateTimeRange
 	DeletedAt    *users.UsersStatsDateTimeRange
 	EventsCount  *users.UsersStatsNumberRange
-}) (*siteUsersResolver, error) {
+},
+) (*siteUsersResolver, error) {
 	// 🚨 SECURITY: Only site admins can see users.
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, s.db); err != nil {
 		return nil, err
@@ -35,7 +38,8 @@ func (s *siteResolver) Users(ctx context.Context, args *struct {
 			DeletedAt:    args.DeletedAt,
 			CreatedAt:    args.CreatedAt,
 			EventsCount:  args.EventsCount,
-		}}}, nil
+		}},
+	}, nil
 }
 
 type siteUsersResolver struct {
@@ -51,20 +55,31 @@ func (s *siteUsersResolver) Nodes(ctx context.Context, args *struct {
 	Descending *bool
 	Limit      *int32
 	Offset     *int32
-}) ([]*siteUserResolver, error) {
+},
+) ([]*siteUserResolver, error) {
 	users, err := s.userStats.ListUsers(ctx, &users.UsersStatsListUsersFilters{OrderBy: args.OrderBy, Descending: args.Descending, Limit: args.Limit, Offset: args.Offset})
 	if err != nil {
 		return nil, err
 	}
+
+	lockoutOptions := conf.AuthLockout()
+	lockoutStore := userpasswd.NewLockoutStore(
+		lockoutOptions.FailedAttemptThreshold,
+		time.Duration(lockoutOptions.LockoutPeriod)*time.Second,
+		time.Duration(lockoutOptions.ConsecutivePeriod)*time.Second,
+		nil,
+	)
+
 	userResolvers := make([]*siteUserResolver, len(users))
 	for i, user := range users {
-		userResolvers[i] = &siteUserResolver{user}
+		userResolvers[i] = &siteUserResolver{user: user, lockoutStore: lockoutStore}
 	}
 	return userResolvers, nil
 }
 
 type siteUserResolver struct {
-	user *users.UserStatItem
+	user         *users.UserStatItem
+	lockoutStore userpasswd.LockoutStore
 }
 
 func (s *siteUserResolver) ID(ctx context.Context) graphql.ID { return MarshalUserID(s.user.Id) }
@@ -98,3 +113,8 @@ func (s *siteUserResolver) DeletedAt(ctx context.Context) *string {
 func (s *siteUserResolver) SiteAdmin(ctx context.Context) bool { return s.user.SiteAdmin }
 
 func (s *siteUserResolver) EventsCount(ctx context.Context) float64 { return s.user.EventsCount }
+
+func (s *siteUserResolver) Locked(ctx context.Context) bool {
+	_, isLocked := s.lockoutStore.IsLockedOut(s.user.Id)
+	return isLocked
+}

--- a/cmd/frontend/graphqlbackend/site_users.go
+++ b/cmd/frontend/graphqlbackend/site_users.go
@@ -62,13 +62,7 @@ func (s *siteUsersResolver) Nodes(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	lockoutOptions := conf.AuthLockout()
-	lockoutStore := userpasswd.NewLockoutStore(
-		lockoutOptions.FailedAttemptThreshold,
-		time.Duration(lockoutOptions.LockoutPeriod)*time.Second,
-		time.Duration(lockoutOptions.ConsecutivePeriod)*time.Second,
-		nil,
-	)
+	lockoutStore := userpasswd.NewLockoutStoreFromConf(conf.AuthLockout())
 
 	userResolvers := make([]*siteUserResolver, len(users))
 	for i, user := range users {

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -69,9 +69,9 @@ type UserResolver struct {
 // NewUserResolver returns a new UserResolver with given user object.
 func NewUserResolver(db database.DB, user *types.User) *UserResolver {
 	return &UserResolver{
-		db: db, user: user, logger: log.Scoped("userResolver", "resolves a specific user").With(
-			log.Object("repo",
-				log.String("user", user.Username))),
+		db:     db,
+		user:   user,
+		logger: log.Scoped("userResolver", "resolves a specific user").With(log.String("user", user.Username)),
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -68,9 +68,10 @@ type UserResolver struct {
 
 // NewUserResolver returns a new UserResolver with given user object.
 func NewUserResolver(db database.DB, user *types.User) *UserResolver {
-	return &UserResolver{db: db, user: user, logger: log.Scoped("userResolver", "resolves a specific user").With(
-		log.Object("repo",
-			log.String("user", user.Username))),
+	return &UserResolver{
+		db: db, user: user, logger: log.Scoped("userResolver", "resolves a specific user").With(
+			log.Object("repo",
+				log.String("user", user.Username))),
 	}
 }
 
@@ -358,7 +359,8 @@ func (r *UserResolver) PermissionsInfo(ctx context.Context) (PermissionsInfoReso
 func (r *schemaResolver) UpdatePassword(ctx context.Context, args *struct {
 	OldPassword string
 	NewPassword string
-}) (*EmptyResponse, error) {
+},
+) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Only the authenticated user can change their password.
 	user, err := r.db.Users().GetByCurrentAuthUser(ctx)
 	if err != nil {
@@ -382,7 +384,8 @@ func (r *schemaResolver) UpdatePassword(ctx context.Context, args *struct {
 
 func (r *schemaResolver) CreatePassword(ctx context.Context, args *struct {
 	NewPassword string
-}) (*EmptyResponse, error) {
+},
+) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Only the authenticated user can create their password.
 	user, err := r.db.Users().GetByCurrentAuthUser(ctx)
 	if err != nil {

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -54,13 +54,8 @@ func NewHandler(db database.DB, logger log.Logger, githubAppSetupHandler http.Ha
 
 	r.Get(router.UI).Handler(ui.Router())
 
-	lockoutOptions := conf.AuthLockout()
-	lockoutStore := userpasswd.NewLockoutStore(
-		lockoutOptions.FailedAttemptThreshold,
-		time.Duration(lockoutOptions.LockoutPeriod)*time.Second,
-		time.Duration(lockoutOptions.ConsecutivePeriod)*time.Second,
-		nil,
-	)
+	lockoutStore := userpasswd.NewLockoutStoreFromConf(conf.AuthLockout())
+
 	r.Get(router.SignUp).Handler(trace.Route(userpasswd.HandleSignUp(logger, db)))
 	r.Get(router.SiteInit).Handler(trace.Route(userpasswd.HandleSiteInit(logger, db)))
 	r.Get(router.SignIn).Handler(trace.Route(userpasswd.HandleSignIn(logger, db, lockoutStore)))

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/NYTimes/gziphandler"
 	"github.com/sourcegraph/log"

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -66,6 +66,7 @@ func NewHandler(db database.DB, logger log.Logger, githubAppSetupHandler http.Ha
 	r.Get(router.SignIn).Handler(trace.Route(userpasswd.HandleSignIn(logger, db, lockoutStore)))
 	r.Get(router.SignOut).Handler(trace.Route(serveSignOutHandler(db)))
 	r.Get(router.UnlockAccount).Handler(trace.Route(userpasswd.HandleUnlockAccount(logger, db, lockoutStore)))
+	r.Get(router.UnlockUserAccount).Handler(trace.Route(userpasswd.HandleUnlockUserAccount(logger, db, lockoutStore)))
 	r.Get(router.ResetPasswordInit).Handler(trace.Route(userpasswd.HandleResetPasswordInit(logger, db)))
 	r.Get(router.ResetPasswordCode).Handler(trace.Route(userpasswd.HandleResetPasswordCode(logger, db)))
 	r.Get(router.VerifyEmail).Handler(trace.Route(serveVerifyEmail(db)))

--- a/cmd/frontend/internal/app/router/router.go
+++ b/cmd/frontend/internal/app/router/router.go
@@ -25,6 +25,7 @@ const (
 	SignOut            = "sign-out"
 	SignUp             = "sign-up"
 	UnlockAccount      = "unlock-account"
+	UnlockUserAccount  = "unlock-user-account"
 	Welcome            = "welcome"
 	SiteInit           = "site-init"
 	VerifyEmail        = "verify-email"
@@ -80,6 +81,7 @@ func newRouter() *mux.Router {
 	base.Path("/-/sign-in").Methods("POST").Name(SignIn)
 	base.Path("/-/sign-out").Methods("GET").Name(SignOut)
 	base.Path("/-/unlock-account").Methods("POST").Name(UnlockAccount)
+	base.Path("/-/unlock-user-account").Methods("POST").Name(UnlockUserAccount)
 	base.Path("/-/reset-password-init").Methods("POST").Name(ResetPasswordInit)
 	base.Path("/-/reset-password-code").Methods("POST").Name(ResetPasswordCode)
 

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/session"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/suspiciousnames"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	iauth "github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/cookie"
@@ -42,6 +43,10 @@ type credentials struct {
 
 type unlockAccountInfo struct {
 	Token string `json:"token"`
+}
+
+type unlockUserAccountInfo struct {
+	UserID int32 `json:"userId"`
 }
 
 // HandleSignUp handles submission of the user signup form.
@@ -371,6 +376,36 @@ func HandleUnlockAccount(logger log.Logger, _ database.DB, store LockoutStore) h
 	}
 }
 
+func HandleUnlockUserAccount(logger log.Logger, db database.DB, store LockoutStore) http.HandlerFunc {
+	logger = logger.Scoped("HandleUnlockUserAccount", "unlock user account request handler for site admins")
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := iauth.CheckCurrentUserIsSiteAdmin(r.Context(), db); err != nil {
+			http.Error(w, "Only site admins can unlock user accounts", http.StatusUnauthorized)
+			return
+		}
+
+		if r.Method != http.MethodPost {
+			http.Error(w, fmt.Sprintf("Unsupported method %s", r.Method), http.StatusBadRequest)
+			return
+		}
+
+		var unlockUserAccountInfo unlockUserAccountInfo
+		if err := json.NewDecoder(r.Body).Decode(&unlockUserAccountInfo); err != nil {
+			http.Error(w, "Could not decode request body", http.StatusBadRequest)
+			return
+		}
+
+		if unlockUserAccountInfo.UserID == 0 {
+			http.Error(w, "Bad request: missing user id", http.StatusBadRequest)
+			return
+		}
+
+		store.Reset(unlockUserAccountInfo.UserID)
+
+		return
+	}
+}
+
 func logSignInEvent(r *http.Request, db database.DB, user *types.User, name *database.SecurityEventName) {
 	var anonymousID string
 	event := &database.SecurityEvent{
@@ -406,7 +441,6 @@ func HandleCheckUsernameTaken(logger log.Logger, db database.DB) http.HandlerFun
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		username, err := auth.NormalizeUsername(vars["username"])
-
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			return

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -376,8 +376,7 @@ func HandleUnlockAccount(logger log.Logger, _ database.DB, store LockoutStore) h
 	}
 }
 
-func HandleUnlockUserAccount(logger log.Logger, db database.DB, store LockoutStore) http.HandlerFunc {
-	logger = logger.Scoped("HandleUnlockUserAccount", "unlock user account request handler for site admins")
+func HandleUnlockUserAccount(_ log.Logger, db database.DB, store LockoutStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := iauth.CheckCurrentUserIsSiteAdmin(r.Context(), db); err != nil {
 			http.Error(w, "Only site admins can unlock user accounts", http.StatusUnauthorized)
@@ -417,8 +416,6 @@ func HandleUnlockUserAccount(logger log.Logger, db database.DB, store LockoutSto
 		}
 
 		store.Reset(user.ID)
-
-		return
 	}
 }
 

--- a/cmd/frontend/internal/auth/userpasswd/lockout.go
+++ b/cmd/frontend/internal/auth/userpasswd/lockout.go
@@ -202,7 +202,6 @@ func (s *lockoutStore) VerifyUnlockAccountTokenAndReset(urlToken string) (bool, 
 	token, err := jwt.ParseWithClaims(urlToken, &unlockAccountClaims{}, func(token *jwt.Token) (any, error) {
 		return base64.StdEncoding.DecodeString(signingKey)
 	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS512.Name}))
-
 	if err != nil {
 		return false, err
 	}

--- a/cmd/frontend/internal/auth/userpasswd/lockout.go
+++ b/cmd/frontend/internal/auth/userpasswd/lockout.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/txemail"
 	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 // LockoutStore provides semantics for account lockout management.
@@ -63,6 +64,16 @@ func NewLockoutStore(failedThreshold int, lockoutPeriod, consecutivePeriod time.
 		unlockEmailSent: rcache.NewWithTTL("account_lockout_email_sent", int(lockoutPeriod.Seconds())),
 		sendEmail:       sendEmailF,
 	}
+}
+
+// NewLockoutStoreFromConf returns a new LockoutStore with the provided options.
+func NewLockoutStoreFromConf(lockoutOptions *schema.AuthLockout) LockoutStore {
+	return NewLockoutStore(
+		lockoutOptions.FailedAttemptThreshold,
+		time.Duration(lockoutOptions.LockoutPeriod)*time.Second,
+		time.Duration(lockoutOptions.ConsecutivePeriod)*time.Second,
+		nil,
+	)
 }
 
 func key(userID int32) string {

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -872,6 +872,7 @@ SELECT id, created_at, deleted_at
 FROM users
 ORDER BY id ASC
 `
+
 const listUsersInactiveCond = `
 (NOT EXISTS (
 	SELECT 1 FROM event_logs
@@ -881,6 +882,7 @@ const listUsersInactiveCond = `
 		timestamp >= %s
 ))
 `
+
 const orgMembershipCond = `
 EXISTS (
 	SELECT 1
@@ -1153,7 +1155,6 @@ WHERE id=%s
       AND expired_at IS NULL
     )
 `, passwd, id, id))
-
 	if err != nil {
 		return errors.Wrap(err, "creating password")
 	}


### PR DESCRIPTION
Closes #40788 

Adds an extra option to the user options in the Site Admin user management panel, allowing site admins to unlock user accounts after too many sign-in attempts.

I went with expanding the rest endpoints, since user lockouts are backed by a redis store that is created in that handler setup.

![image](https://user-images.githubusercontent.com/6427795/207568237-f475aec0-4fb2-404e-80fc-9178e9cf31c4.png)

<img width="1023" alt="image" src="https://user-images.githubusercontent.com/6427795/207532095-f1c9476b-94fe-4583-a835-8f8c28764189.png">

![image](https://user-images.githubusercontent.com/6427795/207568366-986847f9-632f-4fb6-8c12-308c3e91323f.png)
## Test plan

Unit tests expanded.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
