### PR TITLE
status messages: use word `Repository` instead of `Repo`

### DIFF
--- a/cmd/frontend/graphqlbackend/status_messages_test.go
+++ b/cmd/frontend/graphqlbackend/status_messages_test.go
@@ -66,7 +66,9 @@ func TestStatusMessages(t *testing.T) {
 		repos.MockStatusMessages = func(_ context.Context) ([]repos.StatusMessage, error) {
 			return []repos.StatusMessage{}, nil
 		}
-		defer func() { repos.MockStatusMessages = nil }()
+		t.Cleanup(func() {
+			repos.MockStatusMessages = nil
+		})
 
 		RunTests(t, []*Test{
 			{
@@ -99,7 +101,7 @@ func TestStatusMessages(t *testing.T) {
 			res := []repos.StatusMessage{
 				{
 					GitUpdatesDisabled: &repos.GitUpdatesDisabled{
-						Message: "Repos will not be cloned or updated.",
+						Message: "Repositories will not be cloned or updated.",
 					},
 				},
 				{
@@ -128,10 +130,10 @@ func TestStatusMessages(t *testing.T) {
 			},
 		})
 
-		defer func() {
+		t.Cleanup(func() {
 			repos.MockStatusMessages = nil
 			conf.Mock(nil)
-		}()
+		})
 
 		RunTest(t, &Test{
 			Schema: mustParseGraphQLSchema(t, db),
@@ -141,7 +143,7 @@ func TestStatusMessages(t *testing.T) {
 						"statusMessages": [
 							{
 								"__typename": "GitUpdatesDisabled",
-        						"message": "Repos will not be cloned or updated."
+        						"message": "Repositories will not be cloned or updated."
 							},
 							{
 								"__typename": "CloningProgress",

--- a/internal/repos/status_messages.go
+++ b/internal/repos/status_messages.go
@@ -23,7 +23,7 @@ func FetchStatusMessages(ctx context.Context, db database.DB) ([]StatusMessage, 
 	if conf.Get().DisableAutoGitUpdates {
 		messages = append(messages, StatusMessage{
 			GitUpdatesDisabled: &GitUpdatesDisabled{
-				Message: "Repos will not be cloned or updated.",
+				Message: "Repositories will not be cloned or updated.",
 			},
 		})
 	}

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -76,7 +76,7 @@ func TestStatusMessages(t *testing.T) {
 			res: []StatusMessage{
 				{
 					GitUpdatesDisabled: &GitUpdatesDisabled{
-						Message: "Repos will not be cloned or updated.",
+						Message: "Repositories will not be cloned or updated.",
 					},
 				},
 			},
@@ -216,7 +216,7 @@ func TestStatusMessages(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.testCleanup != nil {
-				defer tc.testCleanup()
+				t.Cleanup(tc.testCleanup)
 			}
 
 			if tc.testSetup != nil {


### PR DESCRIPTION
and use `t.Cleanup` instead of mixing cleanups and defers.

Test plan:
No functional change, tests updated.

follow-up to https://github.com/sourcegraph/sourcegraph/pull/45619