### PR TITLE
search: show indexserver host on index status page

### DIFF
--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -54,9 +54,6 @@ function fetchRepositoryTextSearchIndex(id: Scalars['ID']): Observable<Repositor
                         newLinesCount
                         defaultBranchNewLinesCount
                         otherBranchesNewLinesCount
-                        host {
-                            name
-                        }
                     }
                     refs {
                         ref {
@@ -76,6 +73,9 @@ function fetchRepositoryTextSearchIndex(id: Scalars['ID']): Observable<Repositor
                                 url
                             }
                         }
+                    }
+                    host {
+                        name
                     }
                 }
             }
@@ -285,7 +285,7 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                                         ))}
                                     </ul>
                                 )}
-                                {this.state.textSearchIndex.status && (
+                                {this.state.textSearchIndex.status && this.state.textSearchIndex.host && (
                                     <>
                                         <H3>Statistics</H3>
                                         <table className={classNames('table mb-3', styles.stats)}>
@@ -336,7 +336,7 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                                             <tbody>
                                                 <tr>
                                                     <th>Hostname</th>
-                                                    <td>{this.state.textSearchIndex.status.host?.name}</td>
+                                                    <td>{this.state.textSearchIndex.host.name}</td>
                                                 </tr>
                                             </tbody>
                                         </table>

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -285,7 +285,7 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                                         ))}
                                     </ul>
                                 )}
-                                {this.state.textSearchIndex.status && this.state.textSearchIndex.host && (
+                                {this.state.textSearchIndex.status && (
                                     <>
                                         <H3>Statistics</H3>
                                         <table className={classNames('table mb-3', styles.stats)}>
@@ -331,6 +331,10 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                                                 </tr>
                                             </tbody>
                                         </table>
+                                    </>
+                                )}
+                                {this.state.textSearchIndex.host && (
+                                    <>
                                         <H3>Indexserver</H3>
                                         <table className={classNames('table mb-0', styles.stats)}>
                                             <tbody>

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -333,9 +333,9 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                                         </table>
                                     </>
                                 )}
-                                {this.state.textSearchIndex.host && (
-                                    <>
-                                        <H3>Indexserver</H3>
+                                <>
+                                    <H3>Indexserver</H3>
+                                    {this.state.textSearchIndex.host ? (
                                         <table className={classNames('table mb-0', styles.stats)}>
                                             <tbody>
                                                 <tr>
@@ -344,8 +344,14 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                                                 </tr>
                                             </tbody>
                                         </table>
-                                    </>
-                                )}
+                                    ) : (
+                                        <Alert className="mb-0" variant="info">
+                                            We were unable to determine the indexserver that hosts the index. However,
+                                            this does not impact indexed search. The root cause is most likely a
+                                            limitation of the runtime environment.
+                                        </Alert>
+                                    )}
+                                </>
                             </>
                         ) : (
                             <Alert className="mb-0" variant="info">

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -54,6 +54,9 @@ function fetchRepositoryTextSearchIndex(id: Scalars['ID']): Observable<Repositor
                         newLinesCount
                         defaultBranchNewLinesCount
                         otherBranchesNewLinesCount
+                        host {
+                            name
+                        }
                     }
                     refs {
                         ref {
@@ -285,7 +288,7 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                                 {this.state.textSearchIndex.status && (
                                     <>
                                         <H3>Statistics</H3>
-                                        <table className={classNames('table mb-0', styles.stats)}>
+                                        <table className={classNames('table mb-3', styles.stats)}>
                                             <tbody>
                                                 <tr>
                                                     <th>Last indexed at</th>
@@ -325,6 +328,15 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                                                         {this.state.textSearchIndex.status.otherBranchesNewLinesCount.toLocaleString()}
                                                         )
                                                     </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                        <H3>Indexserver</H3>
+                                        <table className={classNames('table mb-0', styles.stats)}>
+                                            <tbody>
+                                                <tr>
+                                                    <th>Hostname</th>
+                                                    <td>{this.state.textSearchIndex.status.host?.name}</td>
                                                 </tr>
                                             </tbody>
                                         </table>

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -106,9 +106,13 @@ func (r *repositoryTextSearchIndexStatus) OtherBranchesNewLinesCount() int32 {
 }
 
 func (r *repositoryTextSearchIndexStatus) Host(ctx context.Context) (*repositoryIndexserverHostResolver, error) {
+	// We don't want to let the user wait for too long. If the socket
+	// connection is working, 500ms should be generous.
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(time.Millisecond*500))
+	defer cancel()
 	host, err := searchzoekt.GetIndexserverHost(ctx, api.RepoName(r.entry.Repository.Name))
 	if err != nil {
-		host = searchzoekt.Host{Name: fmt.Sprintf("unknown: %s", err)}
+		host = searchzoekt.Host{Name: "unknown"}
 
 	}
 	return &repositoryIndexserverHostResolver{

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -71,11 +71,11 @@ func (r *repositoryTextSearchIndexResolver) Status(ctx context.Context) (*reposi
 func (r *repositoryTextSearchIndexResolver) Host(ctx context.Context) (*repositoryIndexserverHostResolver, error) {
 	// We don't want to let the user wait for too long. If the socket
 	// connection is working, 500ms should be generous.
-	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(time.Millisecond*500))
+	ctx, cancel := context.WithTimeout(ctx, time.Millisecond*500)
 	defer cancel()
 	host, err := searchzoekt.GetIndexserverHost(ctx, r.repo.RepoName())
 	if err != nil {
-		host = searchzoekt.Host{Name: "unknown"}
+		return nil, nil
 	}
 	return &repositoryIndexserverHostResolver{
 		host,

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -113,7 +113,6 @@ func (r *repositoryTextSearchIndexStatus) Host(ctx context.Context) (*repository
 	host, err := searchzoekt.GetIndexserverHost(ctx, api.RepoName(r.entry.Repository.Name))
 	if err != nil {
 		host = searchzoekt.Host{Name: "unknown"}
-
 	}
 	return &repositoryIndexserverHostResolver{
 		host,

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3497,6 +3497,18 @@ type RepositoryTextSearchIndexStatus {
     EXPERIMENTAL: The number of newlines in the other branches.
     """
     otherBranchesNewLinesCount: Int!
+
+    host: repositoryIndexserverHost
+}
+
+"""
+The host as advertised by the indexserver hosting the repo's index.
+"""
+type repositoryIndexserverHost {
+    """
+    The hostname of the indexserver.
+    """
+    name: String!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3505,7 +3505,7 @@ type RepositoryTextSearchIndexStatus {
 }
 
 """
-The host as advertised by the indexserver hosting the repo's index.
+Information about the indexserver that hosts the repo's index.
 """
 type repositoryIndexserverHost {
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3456,6 +3456,10 @@ type RepositoryTextSearchIndex {
     Git refs in the repository that are configured for text search indexing.
     """
     refs: [RepositoryTextSearchIndexedRef!]!
+    """
+    Information about the indexserver that hosts the repo's index.
+    """
+    host: repositoryIndexserverHost
 }
 
 """
@@ -3497,11 +3501,6 @@ type RepositoryTextSearchIndexStatus {
     EXPERIMENTAL: The number of newlines in the other branches.
     """
     otherBranchesNewLinesCount: Int!
-
-    """
-    Information about the indexserver that hosts the repo's index.
-    """
-    host: repositoryIndexserverHost
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3498,6 +3498,9 @@ type RepositoryTextSearchIndexStatus {
     """
     otherBranchesNewLinesCount: Int!
 
+    """
+    Information about the indexserver that hosts the repo's index.
+    """
     host: repositoryIndexserverHost
 }
 

--- a/internal/search/zoekt/reindex.go
+++ b/internal/search/zoekt/reindex.go
@@ -2,6 +2,7 @@ package zoekt
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/url"
@@ -16,18 +17,7 @@ import (
 
 // Reindex forces indexserver to reindex the repo immediately.
 func Reindex(ctx context.Context, name api.RepoName, id api.RepoID) error {
-	// Find the Zoekt webserver hosting the index of the repo.
-	ep, err := search.Indexers().Map.Get(string(name))
-	if err != nil {
-		return err
-	}
-
-	// We add http:// on a best-effort basis, because it is not guaranteed that
-	// ep is a valid URL.
-	if !strings.HasPrefix(ep, "http://") {
-		ep = "http://" + ep
-	}
-	u, err := url.Parse(ep)
+	u, err := resolveIndexserver(name)
 	if err != nil {
 		return err
 	}
@@ -61,4 +51,60 @@ func Reindex(ctx context.Context, name api.RepoName, id api.RepoID) error {
 		}
 		return errors.Newf("%s: %q", resp.Status, string(b))
 	}
+}
+
+type Host struct {
+	Name string `json:"hostname"`
+}
+
+func GetIndexserverHost(ctx context.Context, name api.RepoName) (Host, error) {
+	u, err := resolveIndexserver(name)
+	if err != nil {
+		return Host{}, err
+	}
+	u = u.ResolveReference(&url.URL{Path: "/indexserver/debug/host"})
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return Host{}, err
+	}
+
+	resp, err := httpcli.InternalClient.Do(req)
+	if err != nil {
+		return Host{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return Host{}, errors.Newf("webserver responded with %d", resp.StatusCode)
+	}
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return Host{}, err
+	}
+
+	h := Host{}
+	err = json.Unmarshal(b, &h)
+	if err != nil {
+		return Host{}, err
+	}
+
+	return h, nil
+}
+
+// resolveIndexserver returns Zoekt webserver hosting the index of the repo.
+func resolveIndexserver(name api.RepoName) (*url.URL, error) {
+	ep, err := search.Indexers().Map.Get(string(name))
+	if err != nil {
+		return nil, err
+	}
+
+	// We add http:// on a best-effort basis, because it is not guaranteed that
+	// ep is a valid URL.
+	if !strings.HasPrefix(ep, "http://") {
+		ep = "http://" + ep
+	}
+
+	return url.Parse(ep)
 }

--- a/internal/search/zoekt/reindex.go
+++ b/internal/search/zoekt/reindex.go
@@ -93,7 +93,7 @@ func GetIndexserverHost(ctx context.Context, name api.RepoName) (Host, error) {
 	return h, nil
 }
 
-// resolveIndexserver returns Zoekt webserver hosting the index of the repo.
+// resolveIndexserver returns the Zoekt webserver hosting the index of the repo.
 func resolveIndexserver(name api.RepoName) (*url.URL, error) {
 	ep, err := search.Indexers().Map.Get(string(name))
 	if err != nil {


### PR DESCRIPTION
It's a common problem to figure out on which indexserver a repo's index resides. With this change we can finally look it up on the index status page.

<img width="1257" alt="Screenshot 2022-12-14 at 12 24 53" src="https://user-images.githubusercontent.com/26413131/207583032-dd49a5be-0ccf-4852-9a32-1acce535c7f5.png">

Note that this comes with the same limitation as the "Reindex now" button: The host can only be resolved if the socket connection between webserver and indexserver is working. Right now we know this isn't the case for docker-compose on Mac with VirtioFS enabled. 
Because webserver might retry for a long time to connect to indexserver, we give it a limited budget (500ms) before falling back to showing "unknown". In my tests, where I simulated a broken connection, the 500ms delay still felt responsive.

## Test plan
- manual testing on a local instance with a working and faulty socket connection.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
