### PR TITLE
Also drop IDs from batch changes table in migration

### DIFF
--- a/migrations/frontend/1669576792_make_batch_spec_of_batch_change_nullable/down.sql
+++ b/migrations/frontend/1669576792_make_batch_spec_of_batch_change_nullable/down.sql
@@ -1,1 +1,18 @@
+WITH reconstructed_batch_specs AS (
+    INSERT INTO batch_specs
+        (batch_change_id, user_id, namespace_user_id, namespace_org_id, rand_id, raw_spec, spec)
+    SELECT
+        id, creator_id, namespace_user_id, namespace_org_id, md5(CONCAT(id, name)::bytea), CONCAT('name: ', name), json_build_object('name', name)
+    FROM
+        batch_changes
+    WHERE
+        batch_spec_id IS NULL
+    RETURNING
+	    batch_change_id, id
+)
+UPDATE
+    batch_changes
+SET batch_spec_id = (SELECT id FROM reconstructed_batch_specs WHERE batch_change_id = batch_changes.id)
+WHERE id IN (SELECT batch_change_id FROM reconstructed_batch_specs);
+
 ALTER TABLE batch_changes ALTER COLUMN batch_spec_id SET NOT NULL;

--- a/migrations/frontend/1669576792_make_batch_spec_of_batch_change_nullable/up.sql
+++ b/migrations/frontend/1669576792_make_batch_spec_of_batch_change_nullable/up.sql
@@ -1,4 +1,13 @@
 ALTER TABLE batch_changes ALTER COLUMN batch_spec_id DROP NOT NULL;
 
+CREATE TEMPORARY TABLE minimal_batch_specs (id bigint);
+
+INSERT INTO minimal_batch_specs
+SELECT batch_spec_id FROM batch_changes WHERE batch_spec_id IS NOT NULL AND last_applied_at IS NULL;
+
+UPDATE batch_changes SET batch_spec_id = NULL WHERE batch_spec_id IN (SELECT id FROM minimal_batch_specs);
+
 -- Delete existing empty batch specs.
-DELETE FROM batch_specs WHERE id IN (SELECT batch_spec_id FROM batch_changes WHERE batch_spec_id IS NOT NULL AND last_applied_at IS NULL);-- Delete existing empty batch specs.
+DELETE FROM batch_specs WHERE id IN (SELECT id FROM minimal_batch_specs);-- Delete existing empty batch specs.
+
+DROP TABLE minimal_batch_specs;


### PR DESCRIPTION
There was no ON DELETE CASCADE on the foreign key constraint of batch_changes.batch_spec_id, since we use this as a safeguard to not delete in-use batch specs by accident, we don't want to change that and instead we store the candidates in a temporary table and unset the IDs.



## Test plan

Verified these pass locally with data in the DB.