### PR TITLE
Add a module for interacting with GSM

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -320,7 +320,7 @@ require (
 	github.com/google/go-github/v41 v41.0.0
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26 // indirect
-	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
+	github.com/googleapis/gax-go/v2 v2.7.0
 	github.com/gopherjs/gopherjs v0.0.0-20220104163920-15ed2e8cf2bd // indirect
 	github.com/gopherjs/gopherwasm v1.1.0 // indirect
 	github.com/gorilla/css v1.0.0 // indirect

--- a/internal/security/gsm/gsm.go
+++ b/internal/security/gsm/gsm.go
@@ -88,10 +88,6 @@ func Lock() {
 			panic(fmt.Sprintf("%q already registered", secrets[i].name))
 		}
 	}
-
-	expvar.Publish("secrets", expvar.Func(func() any {
-		return secrets
-	}))
 }
 
 func (c *GsmConfig) Get(name, description string) string {

--- a/internal/security/gsm/gsm.go
+++ b/internal/security/gsm/gsm.go
@@ -6,6 +6,7 @@ import (
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"github.com/googleapis/gax-go/v2"
 )
 
 type Secret struct {
@@ -15,7 +16,27 @@ type Secret struct {
 
 type SecretSet map[string]Secret
 
+type GSMClient interface {
+	AccessSecretVersion(
+		ctx context.Context,
+		req *secretmanagerpb.AccessSecretVersionRequest,
+		opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error)
+	Close() error
+}
+
+var Client GSMClient
+
+func Init(ctx context.Context) error {
+	var err error
+	Client, err = secretmanager.NewClient(ctx)
+
+	return err
+}
+
 // NewSecretSet returns a set of requested secrets from Google Secret Manager
+// it calls getSecretFromGSM and collects the errors. It doesn't fail when
+// secrets cannot be fetched. Error checking has to be done to make sure
+// the secrets you want to use have been fetched.
 func NewSecretSet(ctx context.Context, projectID string, requestedSecrets []struct {
 	Name        string
 	Description string
@@ -24,17 +45,8 @@ func NewSecretSet(ctx context.Context, projectID string, requestedSecrets []stru
 	var errs []error
 	var secrets = make(SecretSet)
 
-	// Create the client.
-	gsmClient, err := secretmanager.NewClient(ctx)
-
-	if err != nil {
-		errs = append(errs, err)
-		return secrets, errs
-	}
-	defer gsmClient.Close()
-
 	for _, rs := range requestedSecrets {
-		value, err := getSecretFromGSM(ctx, gsmClient, rs.Name, projectID)
+		value, err := getSecretFromGSM(ctx, rs.Name, projectID)
 		secrets[rs.Name] = Secret{
 			value,
 			rs.Description,
@@ -49,8 +61,9 @@ func NewSecretSet(ctx context.Context, projectID string, requestedSecrets []stru
 }
 
 // getSecretFromGSM calls Google SecretManager and attempts to fetch the latest
-// version of the secret specified by name.
-func getSecretFromGSM(ctx context.Context, client *secretmanager.Client, name string, projectID string) (string, error) {
+// version of the secret specified by name. Returns an empty string and an error
+// message when the secret cannot be found.
+func getSecretFromGSM(ctx context.Context, name string, projectID string) (string, error) {
 	// build the resource id and always fetch latest secret
 	secretId := fmt.Sprintf("projects/%s/secrets/%s/versions/latest", projectID, name)
 
@@ -58,7 +71,7 @@ func getSecretFromGSM(ctx context.Context, client *secretmanager.Client, name st
 		Name: secretId,
 	}
 
-	result, err := client.AccessSecretVersion(ctx, accessRequest)
+	result, err := Client.AccessSecretVersion(ctx, accessRequest)
 
 	if err != nil {
 		return "", err

--- a/internal/security/gsm/gsm.go
+++ b/internal/security/gsm/gsm.go
@@ -62,6 +62,12 @@ func Get(name, description string) string {
 			value:       value,
 		}
 
+		secrets = append(secrets, secret{
+			name:        name,
+			description: description,
+			value:       value,
+		})
+
 		return value
 	}
 

--- a/internal/security/gsm/gsm.go
+++ b/internal/security/gsm/gsm.go
@@ -1,0 +1,167 @@
+package gsm
+
+// based on sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/env/env.go
+
+import (
+	"context"
+	"expvar"
+	"fmt"
+	"os"
+	"sort"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type GsmConfig struct {
+	errs []error
+
+	// getter is used to mock the environment in tests
+	getter GetterFunc
+}
+
+type secret struct {
+	name        string
+	description string
+	value       string
+}
+
+var secrets []secret
+var secretmap = make(map[string]secret)
+var locked = false
+var client *secretmanager.Client
+
+// the secret should be present in the same project as the application
+var projectID = os.Getenv("GOOGLE_PROJECT_ID")
+
+type GetterFunc func(name, description string) string
+
+// Get returns the value of the given GSM secret. Get should only be called on package initialization.
+// Calls at a later point will cause a panic if Lock was called before. This should be used for only
+// *internal* secrets.
+func Get(name, description string) string {
+	if locked {
+		panic("gsm.Get has to be called on package initialization")
+	}
+
+	// if we already fetched the secret, return it
+	if gs, ok := secretmap[name]; ok {
+		return gs.value
+	} else {
+		value, err := getSecretFromGSM(name)
+
+		if err != nil {
+			return ""
+		}
+
+		secretmap[name] = secret{
+			name:        name,
+			description: description,
+			value:       value,
+		}
+
+		return value
+	}
+
+}
+
+// Lock makes later calls to Get fail with a panic. Call this at the beginning of the main function.
+func Lock() {
+	if locked {
+		panic("gsm.Lock must be called at most once")
+	}
+
+	locked = true
+
+	sort.Slice(secrets, func(i, j int) bool { return secrets[i].name < secrets[j].name })
+
+	for i := 1; i < len(secrets); i++ {
+		if secrets[i-1].name == secrets[i].name {
+			panic(fmt.Sprintf("%q already registered", secrets[i].name))
+		}
+	}
+
+	expvar.Publish("secrets", expvar.Func(func() any {
+		return secrets
+	}))
+}
+
+func (c *GsmConfig) Get(name, description string) string {
+	rawValue := c.get(name, description)
+	if rawValue == "" {
+		c.AddError(errors.Errorf("invalid value %q for GSM secret %s: no value supplied", rawValue, name))
+		return ""
+	}
+
+	return rawValue
+}
+
+// Validate makes sure that all secrets are fetched and that no error occurred while
+// fetching the secrets from GSM and that all secrets are loaded.
+func (c *GsmConfig) Validate() error {
+
+	if len(c.errs) == 0 {
+		return nil
+	}
+
+	err := c.errs[0]
+	for i := 1; i < len(c.errs); i++ {
+		err = errors.Append(err, c.errs[i])
+	}
+
+	return err
+}
+
+// AddError adds a validation error to the configuration object. This should be
+// called from within the Load method of a decorated configuration object to have
+// any effect.
+func (c *GsmConfig) AddError(err error) {
+	c.errs = append(c.errs, err)
+}
+
+func (c *GsmConfig) get(name, description string) string {
+	if c.getter != nil {
+		return c.getter(name, description)
+	}
+
+	return Get(name, description)
+}
+
+// getSecretFromGSM calls Google SecretManager and attempts to fetch the latest
+// version of the secret specified by name.
+func getSecretFromGSM(name string) (string, error) {
+
+	if projectID == "" {
+		return "", errors.Errorf("no GOOGLE_PROJECT_ID defined")
+	}
+
+	// Create the client.
+	ctx := context.Background()
+	var err error
+
+	if client == nil {
+		client, err = secretmanager.NewClient(ctx)
+	}
+
+	if err != nil {
+		return "", err
+	}
+	defer client.Close()
+
+	// build the resource id and always fetch latest secret
+	secretId := fmt.Sprintf("projects/%s/secrets/%s/versions/latest", projectID, name)
+
+	accessRequest := &secretmanagerpb.AccessSecretVersionRequest{
+		Name: secretId,
+	}
+
+	result, err := client.AccessSecretVersion(ctx, accessRequest)
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(result.Payload.Data), nil
+}

--- a/internal/security/gsm/gsm.go
+++ b/internal/security/gsm/gsm.go
@@ -1,157 +1,56 @@
 package gsm
 
-// based on sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/env/env.go
-
 import (
 	"context"
-	"expvar"
 	"fmt"
-	"os"
-	"sort"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
-
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-type GsmConfig struct {
-	errs []error
-
-	// getter is used to mock the environment in tests
-	getter GetterFunc
+type Secret struct {
+	Value       string
+	Description string
 }
 
-type secret struct {
-	name        string
-	description string
-	value       string
-}
+type SecretSet map[string]Secret
 
-var secrets []secret
-var secretmap = make(map[string]secret)
-var locked = false
-var client *secretmanager.Client
+// NewSecretSet returns a set of requested secrets from Google Secret Manager
+func NewSecretSet(ctx context.Context, projectID string, requestedSecrets []struct {
+	Name        string
+	Description string
+}) (SecretSet, []error) {
 
-// the secret should be present in the same project as the application
-var projectID = os.Getenv("GOOGLE_PROJECT_ID")
+	var errs []error
+	var secrets = make(SecretSet)
 
-type GetterFunc func(name, description string) string
+	// Create the client.
+	gsmClient, err := secretmanager.NewClient(ctx)
 
-// Get returns the value of the given GSM secret. Get should only be called on package initialization.
-// Calls at a later point will cause a panic if Lock was called before. This should be used for only
-// *internal* secrets.
-func Get(name, description string) string {
-	if locked {
-		panic("gsm.Get has to be called on package initialization")
+	if err != nil {
+		errs = append(errs, err)
+		return secrets, errs
 	}
+	defer gsmClient.Close()
 
-	// if we already fetched the secret, return it
-	if gs, ok := secretmap[name]; ok {
-		return gs.value
-	} else {
-		value, err := getSecretFromGSM(name)
+	for _, rs := range requestedSecrets {
+		value, err := getSecretFromGSM(ctx, gsmClient, rs.Name, projectID)
+		secrets[rs.Name] = Secret{
+			value,
+			rs.Description,
+		}
 
 		if err != nil {
-			return ""
-		}
-
-		secretmap[name] = secret{
-			name:        name,
-			description: description,
-			value:       value,
-		}
-
-		secrets = append(secrets, secret{
-			name:        name,
-			description: description,
-			value:       value,
-		})
-
-		return value
-	}
-
-}
-
-// Lock makes later calls to Get fail with a panic. Call this at the beginning of the main function.
-func Lock() {
-	if locked {
-		panic("gsm.Lock must be called at most once")
-	}
-
-	locked = true
-
-	sort.Slice(secrets, func(i, j int) bool { return secrets[i].name < secrets[j].name })
-
-	for i := 1; i < len(secrets); i++ {
-		if secrets[i-1].name == secrets[i].name {
-			panic(fmt.Sprintf("%q already registered", secrets[i].name))
+			errs = append(errs, err)
 		}
 	}
-}
 
-func (c *GsmConfig) Get(name, description string) string {
-	rawValue := c.get(name, description)
-	if rawValue == "" {
-		c.AddError(errors.Errorf("invalid value %q for GSM secret %s: no value supplied", rawValue, name))
-		return ""
-	}
-
-	return rawValue
-}
-
-// Validate makes sure that all secrets are fetched and that no error occurred while
-// fetching the secrets from GSM and that all secrets are loaded.
-func (c *GsmConfig) Validate() error {
-
-	if len(c.errs) == 0 {
-		return nil
-	}
-
-	err := c.errs[0]
-	for i := 1; i < len(c.errs); i++ {
-		err = errors.Append(err, c.errs[i])
-	}
-
-	return err
-}
-
-// AddError adds a validation error to the configuration object. This should be
-// called from within the Load method of a decorated configuration object to have
-// any effect.
-func (c *GsmConfig) AddError(err error) {
-	c.errs = append(c.errs, err)
-}
-
-func (c *GsmConfig) get(name, description string) string {
-	if c.getter != nil {
-		return c.getter(name, description)
-	}
-
-	return Get(name, description)
+	return secrets, errs
 }
 
 // getSecretFromGSM calls Google SecretManager and attempts to fetch the latest
 // version of the secret specified by name.
-func getSecretFromGSM(name string) (string, error) {
-
-	if projectID == "" {
-		return "", errors.Errorf("no GOOGLE_PROJECT_ID defined")
-	}
-
-	// Create the client.
-	ctx := context.Background()
-	var err error
-
-	if client == nil {
-		client, err = secretmanager.NewClient(ctx)
-	}
-
-	if err != nil {
-		return "", err
-	}
-	defer client.Close()
-
+func getSecretFromGSM(ctx context.Context, client *secretmanager.Client, name string, projectID string) (string, error) {
 	// build the resource id and always fetch latest secret
 	secretId := fmt.Sprintf("projects/%s/secrets/%s/versions/latest", projectID, name)
 

--- a/internal/security/gsm/gsm.go
+++ b/internal/security/gsm/gsm.go
@@ -30,12 +30,7 @@ type GSMClient interface {
 	Close() error
 }
 
-var MockClient GSMClient
-
-func getClient(ctx context.Context) (GSMClient, error) {
-	if MockClient != nil {
-		return MockClient, nil
-	}
+func GetClient(ctx context.Context) (GSMClient, error) {
 	return secretmanager.NewClient(ctx)
 }
 
@@ -43,16 +38,9 @@ func getClient(ctx context.Context) (GSMClient, error) {
 // it calls getSecretFromGSM and collects the errors. It doesn't fail when
 // secrets cannot be fetched. Error checking has to be done to make sure
 // the secrets you want to use have been fetched.
-func NewSecretSet(ctx context.Context, projectID string, requestedSecrets []SecretRequest) (SecretSet, error) {
+func NewSecretSet(ctx context.Context, client GSMClient, projectID string, requestedSecrets []SecretRequest) (SecretSet, error) {
 	var errs error
 	var secrets = make(SecretSet)
-
-	client, errs := getClient(ctx)
-
-	if errs != nil {
-		return secrets, errs
-	}
-	defer client.Close()
 
 	for _, rs := range requestedSecrets {
 		value, err := getSecretFromGSM(ctx, client, rs.Name, projectID)

--- a/internal/security/gsm/gsm_test.go
+++ b/internal/security/gsm/gsm_test.go
@@ -11,16 +11,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type MockClient struct {
+type mockClient struct {
 	AccessFunc func(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error)
 	CloseFunc  func() error
 }
 
-func (m *MockClient) AccessSecretVersion(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error) {
+func (m *mockClient) AccessSecretVersion(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error) {
 	return m.AccessFunc(ctx, req, opts...)
 }
 
-func (m *MockClient) Close() error {
+func (m *mockClient) Close() error {
 	return m.CloseFunc()
 }
 
@@ -28,7 +28,7 @@ func TestFetchGSM(t *testing.T) {
 
 	testcases := []struct {
 		name     string
-		client   *MockClient
+		client   *mockClient
 		project  string
 		secret   string
 		value    []byte
@@ -37,7 +37,7 @@ func TestFetchGSM(t *testing.T) {
 	}{
 		{
 			name: "Test cannot find secret returns empty secret",
-			client: &MockClient{
+			client: &mockClient{
 				AccessFunc: func(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error) {
 					return nil, errors.New(fmt.Sprintf("rpc error: code = NotFound desc = Secret [%s] not found or has no versions", req.Name))
 				},
@@ -51,7 +51,7 @@ func TestFetchGSM(t *testing.T) {
 		},
 		{
 			name: "Can find secret returns a secret",
-			client: &MockClient{
+			client: &mockClient{
 				AccessFunc: func(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error) {
 					var secret secretmanagerpb.AccessSecretVersionResponse
 					secret.Name = "message-signing-secret"
@@ -74,7 +74,7 @@ func TestFetchGSM(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			Client = tc.client
+			MockClient = tc.client
 
 			requestedSecrets := []SecretRequest{
 				{

--- a/internal/security/gsm/gsm_test.go
+++ b/internal/security/gsm/gsm_test.go
@@ -74,8 +74,6 @@ func TestFetchGSM(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			MockClient = tc.client
-
 			requestedSecrets := []SecretRequest{
 				{
 					Name:        "message-signing-secret",
@@ -83,7 +81,7 @@ func TestFetchGSM(t *testing.T) {
 				},
 			}
 
-			secrets, err := NewSecretSet(ctx, "foo", requestedSecrets)
+			secrets, err := NewSecretSet(ctx, tc.client, "foo", requestedSecrets)
 
 			for secret := range secrets {
 				assert.Equal(t, tc.value, secrets[secret].Value)

--- a/internal/security/gsm/gsm_test.go
+++ b/internal/security/gsm/gsm_test.go
@@ -1,0 +1,30 @@
+package gsm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFetchGSM(t *testing.T) {
+
+	t.Run("Error without GOOGLE_PROJECT_ID", func(t *testing.T) {
+		_, err := getSecretFromGSM("really-a-password")
+		assert.ErrorContains(t, err, "no GOOGLE_PROJECT_ID defined")
+	})
+
+	t.Run("Get() after Lock() panics", func(t *testing.T) {
+		assert.Panics(t, func() {
+			Lock()
+			Get("foo", "Foo secret for Baz")
+		})
+	})
+
+	t.Run("Double Get() panics", func(t *testing.T) {
+		assert.Panics(t, func() {
+			Get("foo", "Foo secret for Baz")
+			Get("foo", "Foo secret for Baz")
+		})
+	})
+
+}

--- a/internal/security/gsm/gsm_test.go
+++ b/internal/security/gsm/gsm_test.go
@@ -1,30 +1,68 @@
 package gsm
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"testing"
 
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"github.com/googleapis/gax-go/v2"
 	"github.com/stretchr/testify/assert"
 )
 
+type MockClient struct {
+	AccessFunc func(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error)
+	CloseFunc  func() error
+}
+
+func (m *MockClient) AccessSecretVersion(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error) {
+	return m.AccessFunc(ctx, req, opts...)
+}
+
+func (m *MockClient) Close() error {
+	return m.CloseFunc()
+}
+
 func TestFetchGSM(t *testing.T) {
 
-	t.Run("Error without GOOGLE_PROJECT_ID", func(t *testing.T) {
-		_, err := getSecretFromGSM("really-a-password")
-		assert.ErrorContains(t, err, "no GOOGLE_PROJECT_ID defined")
-	})
+	testcases := []struct {
+		name     string
+		client   *MockClient
+		project  string
+		secret   string
+		value    string
+		pass     bool
+		contains string
+	}{
+		{
+			name: "Test cannot find secret returns empty secret",
+			client: &MockClient{
+				AccessFunc: func(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error) {
+					return nil, errors.New(fmt.Sprintf("rpc error: code = NotFound desc = Secret [%s] not found or has no versions", req.Name))
+				},
+				CloseFunc: func() error { return nil },
+			},
+			project:  "foo",
+			secret:   "message-signing-secret",
+			value:    "",
+			pass:     false,
+			contains: fmt.Sprintf("projects/foo/secrets/message-signing-secret/versions/latest] not found"),
+		},
+	}
 
-	t.Run("Get() after Lock() panics", func(t *testing.T) {
-		assert.Panics(t, func() {
-			Lock()
-			Get("foo", "Foo secret for Baz")
-		})
-	})
+	ctx := context.Background()
 
-	t.Run("Double Get() panics", func(t *testing.T) {
-		assert.Panics(t, func() {
-			Get("foo", "Foo secret for Baz")
-			Get("foo", "Foo secret for Baz")
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			Client = tc.client
+			secret, err := getSecretFromGSM(ctx, tc.secret, tc.project)
+
+			assert.Equal(t, secret, tc.value)
+			if !tc.pass {
+				assert.ErrorContains(t, err, tc.contains)
+			}
 		})
-	})
+	}
 
 }


### PR DESCRIPTION
We want to move away from using environment variables for secrets, as they persist after bootstrapping the application. Using a config object allows us, like we do with `env`, to fetch secrets from GSM (Google Secret Manager) that will remain in memory. Besides not having secrets available in environment variables, the security team actively monitors the reading of secrets in GSM. 

Example usage:

```go
package main

import (
	"context"
	"fmt"

	"github.com/sourcegraph/sourcegraph/internal/env"
	"github.com/sourcegraph/sourcegraph/internal/security/gsm"
	"github.com/sourcegraph/sourcegraph/lib/errors"
)

type Config struct {
	env.BaseConfig

	EnvVar1       string
	SigningSecret string
	DatabaseCMEK1 string
}

func (g *Config) LoadGsmSecrets() {

	ctx := context.Background()
	client, err := gsm.GetClient(ctx)

	if err != nil {
		// properly handle err
		panic(err)
	}
	defer client.Close()

	secrets, err := gsm.NewSecretSet(ctx, client, "google-project-id-1", []gsm.SecretRequest{
		{Name: "message-signing-secret", Description: "Secret for signing messages"},
		{Name: "customer-encryption-key-1", Description: "CMEK for customer information"},
	})

	// verify if we have any errors
	var multiErr errors.MultiError
	if errors.As(err, &multiErr) {
		for _, err := range multiErr.Errors() {
			// actually handle errors here
			fmt.Printf("%s", err)
		}
	} else {
		// actually handle error here
		fmt.Printf("%s", err)
	}

	g.SigningSecret = string(secrets["executor-proxy-password"].Value)
	g.DatabaseCMEK1 = string(secrets["customer-encryption-key-1"].Value)
}

func (g *Config) Load() {

	g.LoadGsmSecrets()
	g.EnvVar1 = g.Get("EXAMPLE_VAR_1", "true", "Used as an example")
}

func main() {

	config := &Config{}
	config.Load()

	// Lock env after init
	env.Lock()

	if err := config.BaseConfig.Validate(); err != nil {
		// do something
	}

	// use secret, don't print production secrets :)
	fmt.Printf("%s\n", config.SigningSecret)

}
```

This snippet will also be documented in the [secure coding guidelines](https://sourcegraph.sourcegraph.com/notebooks/Tm90ZWJvb2s6Njc=)


## Test plan

- [x] manual review
- [ ] ci tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
