### PR TITLE
codeintel: Properly batch SCIP insertions

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/background/job_worker_handler_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_worker_handler_test.go
@@ -180,13 +180,11 @@ func TestHandleSCIP(t *testing.T) {
 	mockDBStore.DoneFunc.SetDefaultHook(func(err error) error { return err })
 
 	// Track writes to symbols table
-	symbolWriter := NewMockSymbolWriter()
-	mockLSIFStore.NewSymbolWriterFunc.SetDefaultReturn(symbolWriter, nil)
+	scipWriter := NewMockSCIPWriter()
+	mockLSIFStore.NewSCIPWriterFunc.SetDefaultReturn(scipWriter, nil)
 
-	id := 0
-	mockLSIFStore.InsertSCIPDocumentFunc.SetDefaultHook(func(_ context.Context, _ int, _ string, _ []byte, _ []byte) (int, error) {
-		id++
-		return id, nil
+	scipWriter.InsertDocumentFunc.SetDefaultHook(func(_ context.Context, _ string, _ []byte, _ []byte, _ []codeinteltypes.InvertedRangeIndex) error {
+		return nil
 	})
 
 	// Give correlation package a valid input dump
@@ -353,53 +351,33 @@ func TestHandleSCIP(t *testing.T) {
 			t.Errorf("unexpected processed metadata args (-want +got):\n%s", diff)
 		}
 	}
-	if len(mockLSIFStore.InsertSCIPDocumentFunc.History()) != 11 {
-		t.Errorf("unexpected number of of InsertSCIPDocumentFunc.History() calls. want=%d have=%d", 11, len(mockLSIFStore.InsertSCIPDocumentFunc.History()))
+	if len(scipWriter.InsertDocumentFunc.History()) != 11 {
+		t.Errorf("unexpected number of of InsertDocumentFunc.History() calls. want=%d have=%d", 11, len(scipWriter.InsertDocumentFunc.History()))
 	} else {
-		found := false
-		for _, call := range mockLSIFStore.InsertSCIPDocumentFunc.History() {
-			if call.Arg1 != 42 {
-				t.Fatalf("unexpected value for upload id. want=%d have=%d", 42, call.Arg1)
-			}
-			if call.Arg2 != "template/src/util/promise.ts" {
-				continue
-			}
+		foundDocument1 := false
+		foundDocument2 := false
 
-			found = true
-			expectedHash := "OnPkRp2fEy9AP4I4Z4YeXLpMMj4IvAnArO6t7Rc0+jE="
-			if diff := cmp.Diff(expectedHash, base64.StdEncoding.EncodeToString(call.Arg3)); diff != "" {
-				t.Errorf("unexpected hash (-want +got):\n%s", diff)
+		for _, call := range scipWriter.InsertDocumentFunc.History() {
+			switch call.Arg1 {
+			case "template/src/util/promise.ts":
+				foundDocument1 = true
+				expectedHash := "OnPkRp2fEy9AP4I4Z4YeXLpMMj4IvAnArO6t7Rc0+jE="
+				if diff := cmp.Diff(expectedHash, base64.StdEncoding.EncodeToString(call.Arg2)); diff != "" {
+					t.Errorf("unexpected hash (-want +got):\n%s", diff)
+				}
+
+			case "template/src/util/graphql.ts":
+				foundDocument2 = true
+				if diff := cmp.Diff(testedInvertedRangeIndex, call.Arg4); diff != "" {
+					t.Errorf("unexpected inverted range index (-want +got):\n%s", diff)
+				}
 			}
 		}
-		if !found {
-			t.Fatalf("target path not found")
+		if !foundDocument1 {
+			t.Fatalf("target path #1 not found")
 		}
-	}
-	if len(symbolWriter.WriteSCIPSymbolsFunc.History()) != 11 {
-		t.Errorf("unexpected number of of riteSCIPSymbolsFunc.History() calls. want=%d have=%d", 11, len(symbolWriter.WriteSCIPSymbolsFunc.History()))
-	} else {
-		found := false
-		for i, call := range mockLSIFStore.InsertSCIPDocumentFunc.History() {
-			const targetPath = "template/src/util/graphql.ts"
-			if call.Arg2 != targetPath {
-				continue
-			}
-
-			// this path is sixth in order of processing, guaranteed by canonicalization
-			expectedDocumentLookupID := 6
-
-			found = true
-			call := symbolWriter.WriteSCIPSymbolsFunc.History()[i]
-			if call.Arg1 != expectedDocumentLookupID {
-				t.Fatalf("unexpected value for upload id. want=%d have=%d", expectedDocumentLookupID, call.Arg1)
-			}
-			if diff := cmp.Diff(testedInvertedRangeIndex, call.Arg2); diff != "" {
-				t.Errorf("unexpected inverted range index (-want +got):\n%s", diff)
-			}
-		}
-
-		if !found {
-			t.Fatalf("target path not found")
+		if !foundDocument2 {
+			t.Fatalf("target path #2 not found")
 		}
 	}
 }
@@ -495,8 +473,8 @@ func TestHandleErrorScip(t *testing.T) {
 	mockDBStore.DoneFunc.SetDefaultHook(func(err error) error { return err })
 
 	// Track writes to symbols table
-	symbolWriter := NewMockSymbolWriter()
-	mockLSIFStore.NewSymbolWriterFunc.SetDefaultReturn(symbolWriter, nil)
+	scipWriter := NewMockSCIPWriter()
+	mockLSIFStore.NewSCIPWriterFunc.SetDefaultReturn(scipWriter, nil)
 
 	// Give correlation package a valid input dump
 	mockUploadStore.GetFunc.SetDefaultHook(copyTestDumpScip)

--- a/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
@@ -9891,12 +9891,9 @@ type MockLsifStore struct {
 	// InsertMetadataFunc is an instance of a mock function object
 	// controlling the behavior of the method InsertMetadata.
 	InsertMetadataFunc *LsifStoreInsertMetadataFunc
-	// InsertSCIPDocumentFunc is an instance of a mock function object
-	// controlling the behavior of the method InsertSCIPDocument.
-	InsertSCIPDocumentFunc *LsifStoreInsertSCIPDocumentFunc
-	// NewSymbolWriterFunc is an instance of a mock function object
-	// controlling the behavior of the method NewSymbolWriter.
-	NewSymbolWriterFunc *LsifStoreNewSymbolWriterFunc
+	// NewSCIPWriterFunc is an instance of a mock function object
+	// controlling the behavior of the method NewSCIPWriter.
+	NewSCIPWriterFunc *LsifStoreNewSCIPWriterFunc
 	// ReconcileCandidatesFunc is an instance of a mock function object
 	// controlling the behavior of the method ReconcileCandidates.
 	ReconcileCandidatesFunc *LsifStoreReconcileCandidatesFunc
@@ -9966,13 +9963,8 @@ func NewMockLsifStore() *MockLsifStore {
 				return
 			},
 		},
-		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
-			defaultHook: func(context.Context, int, string, []byte, []byte) (r0 int, r1 error) {
-				return
-			},
-		},
-		NewSymbolWriterFunc: &LsifStoreNewSymbolWriterFunc{
-			defaultHook: func(context.Context, int) (r0 lsifstore.SymbolWriter, r1 error) {
+		NewSCIPWriterFunc: &LsifStoreNewSCIPWriterFunc{
+			defaultHook: func(context.Context, int) (r0 lsifstore.SCIPWriter, r1 error) {
 				return
 			},
 		},
@@ -10068,14 +10060,9 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.InsertMetadata")
 			},
 		},
-		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
-			defaultHook: func(context.Context, int, string, []byte, []byte) (int, error) {
-				panic("unexpected invocation of MockLsifStore.InsertSCIPDocument")
-			},
-		},
-		NewSymbolWriterFunc: &LsifStoreNewSymbolWriterFunc{
-			defaultHook: func(context.Context, int) (lsifstore.SymbolWriter, error) {
-				panic("unexpected invocation of MockLsifStore.NewSymbolWriter")
+		NewSCIPWriterFunc: &LsifStoreNewSCIPWriterFunc{
+			defaultHook: func(context.Context, int) (lsifstore.SCIPWriter, error) {
+				panic("unexpected invocation of MockLsifStore.NewSCIPWriter")
 			},
 		},
 		ReconcileCandidatesFunc: &LsifStoreReconcileCandidatesFunc{
@@ -10158,11 +10145,8 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		InsertMetadataFunc: &LsifStoreInsertMetadataFunc{
 			defaultHook: i.InsertMetadata,
 		},
-		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
-			defaultHook: i.InsertSCIPDocument,
-		},
-		NewSymbolWriterFunc: &LsifStoreNewSymbolWriterFunc{
-			defaultHook: i.NewSymbolWriter,
+		NewSCIPWriterFunc: &LsifStoreNewSCIPWriterFunc{
+			defaultHook: i.NewSCIPWriter,
 		},
 		ReconcileCandidatesFunc: &LsifStoreReconcileCandidatesFunc{
 			defaultHook: i.ReconcileCandidates,
@@ -10867,153 +10851,35 @@ func (c LsifStoreInsertMetadataFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// LsifStoreInsertSCIPDocumentFunc describes the behavior when the
-// InsertSCIPDocument method of the parent MockLsifStore instance is
-// invoked.
-type LsifStoreInsertSCIPDocumentFunc struct {
-	defaultHook func(context.Context, int, string, []byte, []byte) (int, error)
-	hooks       []func(context.Context, int, string, []byte, []byte) (int, error)
-	history     []LsifStoreInsertSCIPDocumentFuncCall
+// LsifStoreNewSCIPWriterFunc describes the behavior when the NewSCIPWriter
+// method of the parent MockLsifStore instance is invoked.
+type LsifStoreNewSCIPWriterFunc struct {
+	defaultHook func(context.Context, int) (lsifstore.SCIPWriter, error)
+	hooks       []func(context.Context, int) (lsifstore.SCIPWriter, error)
+	history     []LsifStoreNewSCIPWriterFuncCall
 	mutex       sync.Mutex
 }
 
-// InsertSCIPDocument delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockLsifStore) InsertSCIPDocument(v0 context.Context, v1 int, v2 string, v3 []byte, v4 []byte) (int, error) {
-	r0, r1 := m.InsertSCIPDocumentFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.InsertSCIPDocumentFunc.appendCall(LsifStoreInsertSCIPDocumentFuncCall{v0, v1, v2, v3, v4, r0, r1})
+// NewSCIPWriter delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockLsifStore) NewSCIPWriter(v0 context.Context, v1 int) (lsifstore.SCIPWriter, error) {
+	r0, r1 := m.NewSCIPWriterFunc.nextHook()(v0, v1)
+	m.NewSCIPWriterFunc.appendCall(LsifStoreNewSCIPWriterFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the InsertSCIPDocument
-// method of the parent MockLsifStore instance is invoked and the hook queue
-// is empty.
-func (f *LsifStoreInsertSCIPDocumentFunc) SetDefaultHook(hook func(context.Context, int, string, []byte, []byte) (int, error)) {
+// SetDefaultHook sets function that is called when the NewSCIPWriter method
+// of the parent MockLsifStore instance is invoked and the hook queue is
+// empty.
+func (f *LsifStoreNewSCIPWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// InsertSCIPDocument method of the parent MockLsifStore instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *LsifStoreInsertSCIPDocumentFunc) PushHook(hook func(context.Context, int, string, []byte, []byte) (int, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *LsifStoreInsertSCIPDocumentFunc) SetDefaultReturn(r0 int, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, []byte, []byte) (int, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreInsertSCIPDocumentFunc) PushReturn(r0 int, r1 error) {
-	f.PushHook(func(context.Context, int, string, []byte, []byte) (int, error) {
-		return r0, r1
-	})
-}
-
-func (f *LsifStoreInsertSCIPDocumentFunc) nextHook() func(context.Context, int, string, []byte, []byte) (int, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *LsifStoreInsertSCIPDocumentFunc) appendCall(r0 LsifStoreInsertSCIPDocumentFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of LsifStoreInsertSCIPDocumentFuncCall objects
-// describing the invocations of this function.
-func (f *LsifStoreInsertSCIPDocumentFunc) History() []LsifStoreInsertSCIPDocumentFuncCall {
-	f.mutex.Lock()
-	history := make([]LsifStoreInsertSCIPDocumentFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// LsifStoreInsertSCIPDocumentFuncCall is an object that describes an
-// invocation of method InsertSCIPDocument on an instance of MockLsifStore.
-type LsifStoreInsertSCIPDocumentFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 []byte
-	// Arg4 is the value of the 5th argument passed to this method
-	// invocation.
-	Arg4 []byte
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 int
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c LsifStoreInsertSCIPDocumentFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c LsifStoreInsertSCIPDocumentFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// LsifStoreNewSymbolWriterFunc describes the behavior when the
-// NewSymbolWriter method of the parent MockLsifStore instance is invoked.
-type LsifStoreNewSymbolWriterFunc struct {
-	defaultHook func(context.Context, int) (lsifstore.SymbolWriter, error)
-	hooks       []func(context.Context, int) (lsifstore.SymbolWriter, error)
-	history     []LsifStoreNewSymbolWriterFuncCall
-	mutex       sync.Mutex
-}
-
-// NewSymbolWriter delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockLsifStore) NewSymbolWriter(v0 context.Context, v1 int) (lsifstore.SymbolWriter, error) {
-	r0, r1 := m.NewSymbolWriterFunc.nextHook()(v0, v1)
-	m.NewSymbolWriterFunc.appendCall(LsifStoreNewSymbolWriterFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the NewSymbolWriter
-// method of the parent MockLsifStore instance is invoked and the hook queue
-// is empty.
-func (f *LsifStoreNewSymbolWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SymbolWriter, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// NewSymbolWriter method of the parent MockLsifStore instance invokes the
+// NewSCIPWriter method of the parent MockLsifStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *LsifStoreNewSymbolWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SymbolWriter, error)) {
+func (f *LsifStoreNewSCIPWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -11021,20 +10887,20 @@ func (f *LsifStoreNewSymbolWriterFunc) PushHook(hook func(context.Context, int) 
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *LsifStoreNewSymbolWriterFunc) SetDefaultReturn(r0 lsifstore.SymbolWriter, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (lsifstore.SymbolWriter, error) {
+func (f *LsifStoreNewSCIPWriterFunc) SetDefaultReturn(r0 lsifstore.SCIPWriter, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreNewSymbolWriterFunc) PushReturn(r0 lsifstore.SymbolWriter, r1 error) {
-	f.PushHook(func(context.Context, int) (lsifstore.SymbolWriter, error) {
+func (f *LsifStoreNewSCIPWriterFunc) PushReturn(r0 lsifstore.SCIPWriter, r1 error) {
+	f.PushHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
 		return r0, r1
 	})
 }
 
-func (f *LsifStoreNewSymbolWriterFunc) nextHook() func(context.Context, int) (lsifstore.SymbolWriter, error) {
+func (f *LsifStoreNewSCIPWriterFunc) nextHook() func(context.Context, int) (lsifstore.SCIPWriter, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -11047,26 +10913,26 @@ func (f *LsifStoreNewSymbolWriterFunc) nextHook() func(context.Context, int) (ls
 	return hook
 }
 
-func (f *LsifStoreNewSymbolWriterFunc) appendCall(r0 LsifStoreNewSymbolWriterFuncCall) {
+func (f *LsifStoreNewSCIPWriterFunc) appendCall(r0 LsifStoreNewSCIPWriterFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of LsifStoreNewSymbolWriterFuncCall objects
+// History returns a sequence of LsifStoreNewSCIPWriterFuncCall objects
 // describing the invocations of this function.
-func (f *LsifStoreNewSymbolWriterFunc) History() []LsifStoreNewSymbolWriterFuncCall {
+func (f *LsifStoreNewSCIPWriterFunc) History() []LsifStoreNewSCIPWriterFuncCall {
 	f.mutex.Lock()
-	history := make([]LsifStoreNewSymbolWriterFuncCall, len(f.history))
+	history := make([]LsifStoreNewSCIPWriterFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// LsifStoreNewSymbolWriterFuncCall is an object that describes an
-// invocation of method NewSymbolWriter on an instance of MockLsifStore.
-type LsifStoreNewSymbolWriterFuncCall struct {
+// LsifStoreNewSCIPWriterFuncCall is an object that describes an invocation
+// of method NewSCIPWriter on an instance of MockLsifStore.
+type LsifStoreNewSCIPWriterFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -11075,7 +10941,7 @@ type LsifStoreNewSymbolWriterFuncCall struct {
 	Arg1 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 lsifstore.SymbolWriter
+	Result0 lsifstore.SCIPWriter
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -11083,13 +10949,13 @@ type LsifStoreNewSymbolWriterFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LsifStoreNewSymbolWriterFuncCall) Args() []interface{} {
+func (c LsifStoreNewSCIPWriterFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LsifStoreNewSymbolWriterFuncCall) Results() []interface{} {
+func (c LsifStoreNewSCIPWriterFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -12294,95 +12160,94 @@ func (c LsifStoreWriteResultChunksFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// MockSymbolWriter is a mock implementation of the SymbolWriter interface
-// (from the package
+// MockSCIPWriter is a mock implementation of the SCIPWriter interface (from
+// the package
 // github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/lsifstore)
 // used for unit testing.
-type MockSymbolWriter struct {
+type MockSCIPWriter struct {
 	// FlushFunc is an instance of a mock function object controlling the
 	// behavior of the method Flush.
-	FlushFunc *SymbolWriterFlushFunc
-	// WriteSCIPSymbolsFunc is an instance of a mock function object
-	// controlling the behavior of the method WriteSCIPSymbols.
-	WriteSCIPSymbolsFunc *SymbolWriterWriteSCIPSymbolsFunc
+	FlushFunc *SCIPWriterFlushFunc
+	// InsertDocumentFunc is an instance of a mock function object
+	// controlling the behavior of the method InsertDocument.
+	InsertDocumentFunc *SCIPWriterInsertDocumentFunc
 }
 
-// NewMockSymbolWriter creates a new mock of the SymbolWriter interface. All
+// NewMockSCIPWriter creates a new mock of the SCIPWriter interface. All
 // methods return zero values for all results, unless overwritten.
-func NewMockSymbolWriter() *MockSymbolWriter {
-	return &MockSymbolWriter{
-		FlushFunc: &SymbolWriterFlushFunc{
+func NewMockSCIPWriter() *MockSCIPWriter {
+	return &MockSCIPWriter{
+		FlushFunc: &SCIPWriterFlushFunc{
 			defaultHook: func(context.Context) (r0 uint32, r1 error) {
 				return
 			},
 		},
-		WriteSCIPSymbolsFunc: &SymbolWriterWriteSCIPSymbolsFunc{
-			defaultHook: func(context.Context, int, []types.InvertedRangeIndex) (r0 error) {
+		InsertDocumentFunc: &SCIPWriterInsertDocumentFunc{
+			defaultHook: func(context.Context, string, []byte, []byte, []types.InvertedRangeIndex) (r0 error) {
 				return
 			},
 		},
 	}
 }
 
-// NewStrictMockSymbolWriter creates a new mock of the SymbolWriter
-// interface. All methods panic on invocation, unless overwritten.
-func NewStrictMockSymbolWriter() *MockSymbolWriter {
-	return &MockSymbolWriter{
-		FlushFunc: &SymbolWriterFlushFunc{
+// NewStrictMockSCIPWriter creates a new mock of the SCIPWriter interface.
+// All methods panic on invocation, unless overwritten.
+func NewStrictMockSCIPWriter() *MockSCIPWriter {
+	return &MockSCIPWriter{
+		FlushFunc: &SCIPWriterFlushFunc{
 			defaultHook: func(context.Context) (uint32, error) {
-				panic("unexpected invocation of MockSymbolWriter.Flush")
+				panic("unexpected invocation of MockSCIPWriter.Flush")
 			},
 		},
-		WriteSCIPSymbolsFunc: &SymbolWriterWriteSCIPSymbolsFunc{
-			defaultHook: func(context.Context, int, []types.InvertedRangeIndex) error {
-				panic("unexpected invocation of MockSymbolWriter.WriteSCIPSymbols")
+		InsertDocumentFunc: &SCIPWriterInsertDocumentFunc{
+			defaultHook: func(context.Context, string, []byte, []byte, []types.InvertedRangeIndex) error {
+				panic("unexpected invocation of MockSCIPWriter.InsertDocument")
 			},
 		},
 	}
 }
 
-// NewMockSymbolWriterFrom creates a new mock of the MockSymbolWriter
-// interface. All methods delegate to the given implementation, unless
-// overwritten.
-func NewMockSymbolWriterFrom(i lsifstore.SymbolWriter) *MockSymbolWriter {
-	return &MockSymbolWriter{
-		FlushFunc: &SymbolWriterFlushFunc{
+// NewMockSCIPWriterFrom creates a new mock of the MockSCIPWriter interface.
+// All methods delegate to the given implementation, unless overwritten.
+func NewMockSCIPWriterFrom(i lsifstore.SCIPWriter) *MockSCIPWriter {
+	return &MockSCIPWriter{
+		FlushFunc: &SCIPWriterFlushFunc{
 			defaultHook: i.Flush,
 		},
-		WriteSCIPSymbolsFunc: &SymbolWriterWriteSCIPSymbolsFunc{
-			defaultHook: i.WriteSCIPSymbols,
+		InsertDocumentFunc: &SCIPWriterInsertDocumentFunc{
+			defaultHook: i.InsertDocument,
 		},
 	}
 }
 
-// SymbolWriterFlushFunc describes the behavior when the Flush method of the
-// parent MockSymbolWriter instance is invoked.
-type SymbolWriterFlushFunc struct {
+// SCIPWriterFlushFunc describes the behavior when the Flush method of the
+// parent MockSCIPWriter instance is invoked.
+type SCIPWriterFlushFunc struct {
 	defaultHook func(context.Context) (uint32, error)
 	hooks       []func(context.Context) (uint32, error)
-	history     []SymbolWriterFlushFuncCall
+	history     []SCIPWriterFlushFuncCall
 	mutex       sync.Mutex
 }
 
 // Flush delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockSymbolWriter) Flush(v0 context.Context) (uint32, error) {
+func (m *MockSCIPWriter) Flush(v0 context.Context) (uint32, error) {
 	r0, r1 := m.FlushFunc.nextHook()(v0)
-	m.FlushFunc.appendCall(SymbolWriterFlushFuncCall{v0, r0, r1})
+	m.FlushFunc.appendCall(SCIPWriterFlushFuncCall{v0, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the Flush method of the
-// parent MockSymbolWriter instance is invoked and the hook queue is empty.
-func (f *SymbolWriterFlushFunc) SetDefaultHook(hook func(context.Context) (uint32, error)) {
+// parent MockSCIPWriter instance is invoked and the hook queue is empty.
+func (f *SCIPWriterFlushFunc) SetDefaultHook(hook func(context.Context) (uint32, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// Flush method of the parent MockSymbolWriter instance invokes the hook at
+// Flush method of the parent MockSCIPWriter instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *SymbolWriterFlushFunc) PushHook(hook func(context.Context) (uint32, error)) {
+func (f *SCIPWriterFlushFunc) PushHook(hook func(context.Context) (uint32, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -12390,20 +12255,20 @@ func (f *SymbolWriterFlushFunc) PushHook(hook func(context.Context) (uint32, err
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *SymbolWriterFlushFunc) SetDefaultReturn(r0 uint32, r1 error) {
+func (f *SCIPWriterFlushFunc) SetDefaultReturn(r0 uint32, r1 error) {
 	f.SetDefaultHook(func(context.Context) (uint32, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *SymbolWriterFlushFunc) PushReturn(r0 uint32, r1 error) {
+func (f *SCIPWriterFlushFunc) PushReturn(r0 uint32, r1 error) {
 	f.PushHook(func(context.Context) (uint32, error) {
 		return r0, r1
 	})
 }
 
-func (f *SymbolWriterFlushFunc) nextHook() func(context.Context) (uint32, error) {
+func (f *SCIPWriterFlushFunc) nextHook() func(context.Context) (uint32, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -12416,26 +12281,26 @@ func (f *SymbolWriterFlushFunc) nextHook() func(context.Context) (uint32, error)
 	return hook
 }
 
-func (f *SymbolWriterFlushFunc) appendCall(r0 SymbolWriterFlushFuncCall) {
+func (f *SCIPWriterFlushFunc) appendCall(r0 SCIPWriterFlushFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of SymbolWriterFlushFuncCall objects
-// describing the invocations of this function.
-func (f *SymbolWriterFlushFunc) History() []SymbolWriterFlushFuncCall {
+// History returns a sequence of SCIPWriterFlushFuncCall objects describing
+// the invocations of this function.
+func (f *SCIPWriterFlushFunc) History() []SCIPWriterFlushFuncCall {
 	f.mutex.Lock()
-	history := make([]SymbolWriterFlushFuncCall, len(f.history))
+	history := make([]SCIPWriterFlushFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// SymbolWriterFlushFuncCall is an object that describes an invocation of
-// method Flush on an instance of MockSymbolWriter.
-type SymbolWriterFlushFuncCall struct {
+// SCIPWriterFlushFuncCall is an object that describes an invocation of
+// method Flush on an instance of MockSCIPWriter.
+type SCIPWriterFlushFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -12449,46 +12314,45 @@ type SymbolWriterFlushFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c SymbolWriterFlushFuncCall) Args() []interface{} {
+func (c SCIPWriterFlushFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c SymbolWriterFlushFuncCall) Results() []interface{} {
+func (c SCIPWriterFlushFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// SymbolWriterWriteSCIPSymbolsFunc describes the behavior when the
-// WriteSCIPSymbols method of the parent MockSymbolWriter instance is
-// invoked.
-type SymbolWriterWriteSCIPSymbolsFunc struct {
-	defaultHook func(context.Context, int, []types.InvertedRangeIndex) error
-	hooks       []func(context.Context, int, []types.InvertedRangeIndex) error
-	history     []SymbolWriterWriteSCIPSymbolsFuncCall
+// SCIPWriterInsertDocumentFunc describes the behavior when the
+// InsertDocument method of the parent MockSCIPWriter instance is invoked.
+type SCIPWriterInsertDocumentFunc struct {
+	defaultHook func(context.Context, string, []byte, []byte, []types.InvertedRangeIndex) error
+	hooks       []func(context.Context, string, []byte, []byte, []types.InvertedRangeIndex) error
+	history     []SCIPWriterInsertDocumentFuncCall
 	mutex       sync.Mutex
 }
 
-// WriteSCIPSymbols delegates to the next hook function in the queue and
+// InsertDocument delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockSymbolWriter) WriteSCIPSymbols(v0 context.Context, v1 int, v2 []types.InvertedRangeIndex) error {
-	r0 := m.WriteSCIPSymbolsFunc.nextHook()(v0, v1, v2)
-	m.WriteSCIPSymbolsFunc.appendCall(SymbolWriterWriteSCIPSymbolsFuncCall{v0, v1, v2, r0})
+func (m *MockSCIPWriter) InsertDocument(v0 context.Context, v1 string, v2 []byte, v3 []byte, v4 []types.InvertedRangeIndex) error {
+	r0 := m.InsertDocumentFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.InsertDocumentFunc.appendCall(SCIPWriterInsertDocumentFuncCall{v0, v1, v2, v3, v4, r0})
 	return r0
 }
 
-// SetDefaultHook sets function that is called when the WriteSCIPSymbols
-// method of the parent MockSymbolWriter instance is invoked and the hook
+// SetDefaultHook sets function that is called when the InsertDocument
+// method of the parent MockSCIPWriter instance is invoked and the hook
 // queue is empty.
-func (f *SymbolWriterWriteSCIPSymbolsFunc) SetDefaultHook(hook func(context.Context, int, []types.InvertedRangeIndex) error) {
+func (f *SCIPWriterInsertDocumentFunc) SetDefaultHook(hook func(context.Context, string, []byte, []byte, []types.InvertedRangeIndex) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// WriteSCIPSymbols method of the parent MockSymbolWriter instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *SymbolWriterWriteSCIPSymbolsFunc) PushHook(hook func(context.Context, int, []types.InvertedRangeIndex) error) {
+// InsertDocument method of the parent MockSCIPWriter instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *SCIPWriterInsertDocumentFunc) PushHook(hook func(context.Context, string, []byte, []byte, []types.InvertedRangeIndex) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -12496,20 +12360,20 @@ func (f *SymbolWriterWriteSCIPSymbolsFunc) PushHook(hook func(context.Context, i
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *SymbolWriterWriteSCIPSymbolsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int, []types.InvertedRangeIndex) error {
+func (f *SCIPWriterInsertDocumentFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, string, []byte, []byte, []types.InvertedRangeIndex) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *SymbolWriterWriteSCIPSymbolsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int, []types.InvertedRangeIndex) error {
+func (f *SCIPWriterInsertDocumentFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, string, []byte, []byte, []types.InvertedRangeIndex) error {
 		return r0
 	})
 }
 
-func (f *SymbolWriterWriteSCIPSymbolsFunc) nextHook() func(context.Context, int, []types.InvertedRangeIndex) error {
+func (f *SCIPWriterInsertDocumentFunc) nextHook() func(context.Context, string, []byte, []byte, []types.InvertedRangeIndex) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -12522,35 +12386,41 @@ func (f *SymbolWriterWriteSCIPSymbolsFunc) nextHook() func(context.Context, int,
 	return hook
 }
 
-func (f *SymbolWriterWriteSCIPSymbolsFunc) appendCall(r0 SymbolWriterWriteSCIPSymbolsFuncCall) {
+func (f *SCIPWriterInsertDocumentFunc) appendCall(r0 SCIPWriterInsertDocumentFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of SymbolWriterWriteSCIPSymbolsFuncCall
-// objects describing the invocations of this function.
-func (f *SymbolWriterWriteSCIPSymbolsFunc) History() []SymbolWriterWriteSCIPSymbolsFuncCall {
+// History returns a sequence of SCIPWriterInsertDocumentFuncCall objects
+// describing the invocations of this function.
+func (f *SCIPWriterInsertDocumentFunc) History() []SCIPWriterInsertDocumentFuncCall {
 	f.mutex.Lock()
-	history := make([]SymbolWriterWriteSCIPSymbolsFuncCall, len(f.history))
+	history := make([]SCIPWriterInsertDocumentFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// SymbolWriterWriteSCIPSymbolsFuncCall is an object that describes an
-// invocation of method WriteSCIPSymbols on an instance of MockSymbolWriter.
-type SymbolWriterWriteSCIPSymbolsFuncCall struct {
+// SCIPWriterInsertDocumentFuncCall is an object that describes an
+// invocation of method InsertDocument on an instance of MockSCIPWriter.
+type SCIPWriterInsertDocumentFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 int
+	Arg1 string
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 []types.InvertedRangeIndex
+	Arg2 []byte
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 []byte
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 []types.InvertedRangeIndex
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -12558,13 +12428,13 @@ type SymbolWriterWriteSCIPSymbolsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c SymbolWriterWriteSCIPSymbolsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c SCIPWriterInsertDocumentFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c SymbolWriterWriteSCIPSymbolsFuncCall) Results() []interface{} {
+func (c SCIPWriterInsertDocumentFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/enterprise/internal/codeintel/uploads/internal/background/scip.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/scip.go
@@ -347,32 +347,28 @@ func writeSCIPData(
 		return err
 	}
 
-	symbolWriter, err := tx.NewSymbolWriter(ctx, upload.ID)
+	scipWriter, err := tx.NewSCIPWriter(ctx, upload.ID)
 	if err != nil {
 		return err
 	}
 
 	var numDocuments uint32
 	for document := range correlatedSCIPData.Documents {
-		documentLookupID, err := tx.InsertSCIPDocument(
+		if err := scipWriter.InsertDocument(
 			ctx,
-			upload.ID,
 			document.DocumentPath,
 			document.Hash,
 			document.RawSCIPPayload,
-		)
-		if err != nil {
+			document.Symbols,
+		); err != nil {
 			return err
 		}
 
-		if err := symbolWriter.WriteSCIPSymbols(ctx, documentLookupID, document.Symbols); err != nil {
-			return err
-		}
 		numDocuments += 1
 	}
 	trace.Log(otlog.Uint32("numDocuments", numDocuments))
 
-	count, err := symbolWriter.Flush(ctx)
+	count, err := scipWriter.Flush(ctx)
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/codeintel/uploads/internal/background/scip_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/scip_test.go
@@ -86,7 +86,7 @@ func TestCorrelateSCIP(t *testing.T) {
 			t.Errorf("unexpected paths (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(testedInvertedRangeIndex, documentMap["template/src/util/graphql.ts"].Symbols); diff != "" {
+		if diff := cmp.Diff(testedInvertedRangeIndex, codeinteltypes.ExtractSymbolIndexes(documentMap["template/src/util/graphql.ts"].Document)); diff != "" {
 			t.Errorf("unexpected inverted symbols (-want +got):\n%s", diff)
 		}
 	}

--- a/enterprise/internal/codeintel/uploads/internal/background/scip_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/scip_test.go
@@ -60,7 +60,7 @@ func TestCorrelateSCIP(t *testing.T) {
 	} else {
 		documentMap := map[string]lsifstore.ProcessedSCIPDocument{}
 		for _, document := range documents {
-			documentMap[document.DocumentPath] = document
+			documentMap[document.Path] = document
 		}
 
 		var paths []string

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"time"
 
+	"github.com/sourcegraph/scip/bindings/go/scip"
+
 	codeintelshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
@@ -39,7 +40,7 @@ type LsifStore interface {
 }
 
 type SCIPWriter interface {
-	InsertDocument(ctx context.Context, documentPath string, hash []byte, rawSCIPPayload []byte, symbols []types.InvertedRangeIndex) error
+	InsertDocument(ctx context.Context, path string, scipDocument *scip.Document) error
 	Flush(ctx context.Context) (uint32, error)
 }
 

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore.go
@@ -19,8 +19,7 @@ type LsifStore interface {
 	DeleteLsifDataByUploadIds(ctx context.Context, bundleIDs ...int) (err error)
 
 	InsertMetadata(ctx context.Context, uploadID int, meta ProcessedMetadata) error
-	NewSymbolWriter(ctx context.Context, uploadID int) (SymbolWriter, error)
-	InsertSCIPDocument(ctx context.Context, uploadID int, documentPath string, hash []byte, rawSCIPPayload []byte) (int, error)
+	NewSCIPWriter(ctx context.Context, uploadID int) (SCIPWriter, error)
 
 	WriteMeta(ctx context.Context, bundleID int, meta precise.MetaData) error
 	WriteDocuments(ctx context.Context, bundleID int, documents chan precise.KeyedDocumentData) (count uint32, err error)
@@ -39,8 +38,8 @@ type LsifStore interface {
 	ScanLocations(ctx context.Context, id int, f func(scheme, identifier, monikerType string, locations []precise.LocationData) error) (err error)
 }
 
-type SymbolWriter interface {
-	WriteSCIPSymbols(ctx context.Context, documentLookupID int, symbols []types.InvertedRangeIndex) error
+type SCIPWriter interface {
+	InsertDocument(ctx context.Context, documentPath string, hash []byte, rawSCIPPayload []byte, symbols []types.InvertedRangeIndex) error
 	Flush(ctx context.Context) (uint32, error)
 }
 

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
@@ -16,7 +16,6 @@ type operations struct {
 	scanResultChunks            *observation.Operation
 	scanLocations               *observation.Operation
 	insertMetadata              *observation.Operation
-	insertSCIPDocument          *observation.Operation
 	writeMeta                   *observation.Operation
 	writeDocuments              *observation.Operation
 	writeResultChunks           *observation.Operation
@@ -55,7 +54,6 @@ func newOperations(observationCtx *observation.Context) *operations {
 		scanResultChunks:            op("ScanResultChunks"),
 		scanLocations:               op("ScanLocations"),
 		insertMetadata:              op("InsertMetadata"),
-		insertSCIPDocument:          op("InsertSCIPDocument"),
 		writeMeta:                   op("WriteMeta"),
 		writeDocuments:              op("WriteDocuments"),
 		writeResultChunks:           op("WriteResultChunks"),

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_compressor.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_compressor.go
@@ -1,4 +1,4 @@
-package background
+package lsifstore
 
 import (
 	"bytes"

--- a/enterprise/internal/codeintel/uploads/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/mocks_test.go
@@ -7562,12 +7562,9 @@ type MockLsifStore struct {
 	// InsertMetadataFunc is an instance of a mock function object
 	// controlling the behavior of the method InsertMetadata.
 	InsertMetadataFunc *LsifStoreInsertMetadataFunc
-	// InsertSCIPDocumentFunc is an instance of a mock function object
-	// controlling the behavior of the method InsertSCIPDocument.
-	InsertSCIPDocumentFunc *LsifStoreInsertSCIPDocumentFunc
-	// NewSymbolWriterFunc is an instance of a mock function object
-	// controlling the behavior of the method NewSymbolWriter.
-	NewSymbolWriterFunc *LsifStoreNewSymbolWriterFunc
+	// NewSCIPWriterFunc is an instance of a mock function object
+	// controlling the behavior of the method NewSCIPWriter.
+	NewSCIPWriterFunc *LsifStoreNewSCIPWriterFunc
 	// ReconcileCandidatesFunc is an instance of a mock function object
 	// controlling the behavior of the method ReconcileCandidates.
 	ReconcileCandidatesFunc *LsifStoreReconcileCandidatesFunc
@@ -7637,13 +7634,8 @@ func NewMockLsifStore() *MockLsifStore {
 				return
 			},
 		},
-		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
-			defaultHook: func(context.Context, int, string, []byte, []byte) (r0 int, r1 error) {
-				return
-			},
-		},
-		NewSymbolWriterFunc: &LsifStoreNewSymbolWriterFunc{
-			defaultHook: func(context.Context, int) (r0 lsifstore.SymbolWriter, r1 error) {
+		NewSCIPWriterFunc: &LsifStoreNewSCIPWriterFunc{
+			defaultHook: func(context.Context, int) (r0 lsifstore.SCIPWriter, r1 error) {
 				return
 			},
 		},
@@ -7739,14 +7731,9 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.InsertMetadata")
 			},
 		},
-		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
-			defaultHook: func(context.Context, int, string, []byte, []byte) (int, error) {
-				panic("unexpected invocation of MockLsifStore.InsertSCIPDocument")
-			},
-		},
-		NewSymbolWriterFunc: &LsifStoreNewSymbolWriterFunc{
-			defaultHook: func(context.Context, int) (lsifstore.SymbolWriter, error) {
-				panic("unexpected invocation of MockLsifStore.NewSymbolWriter")
+		NewSCIPWriterFunc: &LsifStoreNewSCIPWriterFunc{
+			defaultHook: func(context.Context, int) (lsifstore.SCIPWriter, error) {
+				panic("unexpected invocation of MockLsifStore.NewSCIPWriter")
 			},
 		},
 		ReconcileCandidatesFunc: &LsifStoreReconcileCandidatesFunc{
@@ -7829,11 +7816,8 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		InsertMetadataFunc: &LsifStoreInsertMetadataFunc{
 			defaultHook: i.InsertMetadata,
 		},
-		InsertSCIPDocumentFunc: &LsifStoreInsertSCIPDocumentFunc{
-			defaultHook: i.InsertSCIPDocument,
-		},
-		NewSymbolWriterFunc: &LsifStoreNewSymbolWriterFunc{
-			defaultHook: i.NewSymbolWriter,
+		NewSCIPWriterFunc: &LsifStoreNewSCIPWriterFunc{
+			defaultHook: i.NewSCIPWriter,
 		},
 		ReconcileCandidatesFunc: &LsifStoreReconcileCandidatesFunc{
 			defaultHook: i.ReconcileCandidates,
@@ -8538,153 +8522,35 @@ func (c LsifStoreInsertMetadataFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// LsifStoreInsertSCIPDocumentFunc describes the behavior when the
-// InsertSCIPDocument method of the parent MockLsifStore instance is
-// invoked.
-type LsifStoreInsertSCIPDocumentFunc struct {
-	defaultHook func(context.Context, int, string, []byte, []byte) (int, error)
-	hooks       []func(context.Context, int, string, []byte, []byte) (int, error)
-	history     []LsifStoreInsertSCIPDocumentFuncCall
+// LsifStoreNewSCIPWriterFunc describes the behavior when the NewSCIPWriter
+// method of the parent MockLsifStore instance is invoked.
+type LsifStoreNewSCIPWriterFunc struct {
+	defaultHook func(context.Context, int) (lsifstore.SCIPWriter, error)
+	hooks       []func(context.Context, int) (lsifstore.SCIPWriter, error)
+	history     []LsifStoreNewSCIPWriterFuncCall
 	mutex       sync.Mutex
 }
 
-// InsertSCIPDocument delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockLsifStore) InsertSCIPDocument(v0 context.Context, v1 int, v2 string, v3 []byte, v4 []byte) (int, error) {
-	r0, r1 := m.InsertSCIPDocumentFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.InsertSCIPDocumentFunc.appendCall(LsifStoreInsertSCIPDocumentFuncCall{v0, v1, v2, v3, v4, r0, r1})
+// NewSCIPWriter delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockLsifStore) NewSCIPWriter(v0 context.Context, v1 int) (lsifstore.SCIPWriter, error) {
+	r0, r1 := m.NewSCIPWriterFunc.nextHook()(v0, v1)
+	m.NewSCIPWriterFunc.appendCall(LsifStoreNewSCIPWriterFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the InsertSCIPDocument
-// method of the parent MockLsifStore instance is invoked and the hook queue
-// is empty.
-func (f *LsifStoreInsertSCIPDocumentFunc) SetDefaultHook(hook func(context.Context, int, string, []byte, []byte) (int, error)) {
+// SetDefaultHook sets function that is called when the NewSCIPWriter method
+// of the parent MockLsifStore instance is invoked and the hook queue is
+// empty.
+func (f *LsifStoreNewSCIPWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// InsertSCIPDocument method of the parent MockLsifStore instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *LsifStoreInsertSCIPDocumentFunc) PushHook(hook func(context.Context, int, string, []byte, []byte) (int, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *LsifStoreInsertSCIPDocumentFunc) SetDefaultReturn(r0 int, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, []byte, []byte) (int, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreInsertSCIPDocumentFunc) PushReturn(r0 int, r1 error) {
-	f.PushHook(func(context.Context, int, string, []byte, []byte) (int, error) {
-		return r0, r1
-	})
-}
-
-func (f *LsifStoreInsertSCIPDocumentFunc) nextHook() func(context.Context, int, string, []byte, []byte) (int, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *LsifStoreInsertSCIPDocumentFunc) appendCall(r0 LsifStoreInsertSCIPDocumentFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of LsifStoreInsertSCIPDocumentFuncCall objects
-// describing the invocations of this function.
-func (f *LsifStoreInsertSCIPDocumentFunc) History() []LsifStoreInsertSCIPDocumentFuncCall {
-	f.mutex.Lock()
-	history := make([]LsifStoreInsertSCIPDocumentFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// LsifStoreInsertSCIPDocumentFuncCall is an object that describes an
-// invocation of method InsertSCIPDocument on an instance of MockLsifStore.
-type LsifStoreInsertSCIPDocumentFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 string
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 []byte
-	// Arg4 is the value of the 5th argument passed to this method
-	// invocation.
-	Arg4 []byte
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 int
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c LsifStoreInsertSCIPDocumentFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c LsifStoreInsertSCIPDocumentFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// LsifStoreNewSymbolWriterFunc describes the behavior when the
-// NewSymbolWriter method of the parent MockLsifStore instance is invoked.
-type LsifStoreNewSymbolWriterFunc struct {
-	defaultHook func(context.Context, int) (lsifstore.SymbolWriter, error)
-	hooks       []func(context.Context, int) (lsifstore.SymbolWriter, error)
-	history     []LsifStoreNewSymbolWriterFuncCall
-	mutex       sync.Mutex
-}
-
-// NewSymbolWriter delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockLsifStore) NewSymbolWriter(v0 context.Context, v1 int) (lsifstore.SymbolWriter, error) {
-	r0, r1 := m.NewSymbolWriterFunc.nextHook()(v0, v1)
-	m.NewSymbolWriterFunc.appendCall(LsifStoreNewSymbolWriterFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the NewSymbolWriter
-// method of the parent MockLsifStore instance is invoked and the hook queue
-// is empty.
-func (f *LsifStoreNewSymbolWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SymbolWriter, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// NewSymbolWriter method of the parent MockLsifStore instance invokes the
+// NewSCIPWriter method of the parent MockLsifStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *LsifStoreNewSymbolWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SymbolWriter, error)) {
+func (f *LsifStoreNewSCIPWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -8692,20 +8558,20 @@ func (f *LsifStoreNewSymbolWriterFunc) PushHook(hook func(context.Context, int) 
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *LsifStoreNewSymbolWriterFunc) SetDefaultReturn(r0 lsifstore.SymbolWriter, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (lsifstore.SymbolWriter, error) {
+func (f *LsifStoreNewSCIPWriterFunc) SetDefaultReturn(r0 lsifstore.SCIPWriter, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreNewSymbolWriterFunc) PushReturn(r0 lsifstore.SymbolWriter, r1 error) {
-	f.PushHook(func(context.Context, int) (lsifstore.SymbolWriter, error) {
+func (f *LsifStoreNewSCIPWriterFunc) PushReturn(r0 lsifstore.SCIPWriter, r1 error) {
+	f.PushHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
 		return r0, r1
 	})
 }
 
-func (f *LsifStoreNewSymbolWriterFunc) nextHook() func(context.Context, int) (lsifstore.SymbolWriter, error) {
+func (f *LsifStoreNewSCIPWriterFunc) nextHook() func(context.Context, int) (lsifstore.SCIPWriter, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -8718,26 +8584,26 @@ func (f *LsifStoreNewSymbolWriterFunc) nextHook() func(context.Context, int) (ls
 	return hook
 }
 
-func (f *LsifStoreNewSymbolWriterFunc) appendCall(r0 LsifStoreNewSymbolWriterFuncCall) {
+func (f *LsifStoreNewSCIPWriterFunc) appendCall(r0 LsifStoreNewSCIPWriterFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of LsifStoreNewSymbolWriterFuncCall objects
+// History returns a sequence of LsifStoreNewSCIPWriterFuncCall objects
 // describing the invocations of this function.
-func (f *LsifStoreNewSymbolWriterFunc) History() []LsifStoreNewSymbolWriterFuncCall {
+func (f *LsifStoreNewSCIPWriterFunc) History() []LsifStoreNewSCIPWriterFuncCall {
 	f.mutex.Lock()
-	history := make([]LsifStoreNewSymbolWriterFuncCall, len(f.history))
+	history := make([]LsifStoreNewSCIPWriterFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// LsifStoreNewSymbolWriterFuncCall is an object that describes an
-// invocation of method NewSymbolWriter on an instance of MockLsifStore.
-type LsifStoreNewSymbolWriterFuncCall struct {
+// LsifStoreNewSCIPWriterFuncCall is an object that describes an invocation
+// of method NewSCIPWriter on an instance of MockLsifStore.
+type LsifStoreNewSCIPWriterFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -8746,7 +8612,7 @@ type LsifStoreNewSymbolWriterFuncCall struct {
 	Arg1 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 lsifstore.SymbolWriter
+	Result0 lsifstore.SCIPWriter
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -8754,13 +8620,13 @@ type LsifStoreNewSymbolWriterFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LsifStoreNewSymbolWriterFuncCall) Args() []interface{} {
+func (c LsifStoreNewSCIPWriterFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LsifStoreNewSymbolWriterFuncCall) Results() []interface{} {
+func (c LsifStoreNewSCIPWriterFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
@@ -482,8 +482,7 @@ CREATE TEMPORARY TABLE t_codeintel_scip_symbols (
 ) ON COMMIT DROP
 `
 
-// Write inserts a new document and document lookup row, and pushes all of the given
-// symbols into the batch inserter.
+// Write batches a new document, document lookup row, and all of its symbols for insertion.
 func (s *scipWriter) Write(
 	ctx context.Context,
 	path string,

--- a/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
@@ -474,6 +474,12 @@ func (s *scipWriter) Write(
 	path string,
 	scipDocument *ogscip.Document,
 ) error {
+	if s.batchPayloadSum >= MaxBatchPayloadSum {
+		if err := s.flush(ctx); err != nil {
+			return err
+		}
+	}
+
 	uniquePrefix := []byte(fmt.Sprintf(
 		"lsif-%d:%d:",
 		uploadID,
@@ -488,12 +494,6 @@ func (s *scipWriter) Write(
 	compressedPayload, err := compressor.compress(bytes.NewReader(payload))
 	if err != nil {
 		return err
-	}
-
-	if s.batchPayloadSum >= MaxBatchPayloadSum {
-		if err := s.flush(ctx); err != nil {
-			return err
-		}
 	}
 
 	s.batch = append(s.batch, bufferedDocument{

--- a/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
@@ -529,14 +529,13 @@ func (s *scipWriter) flush(ctx context.Context) (err error) {
 		documentLookupIDs = append(documentLookupIDs, documentLookupID)
 	}
 
+	symbolNameMap := map[string]struct{}{}
 	invertedRangeIndexes := make([][]types.InvertedRangeIndex, 0, len(documents))
 	for _, document := range documents {
-		invertedRangeIndexes = append(invertedRangeIndexes, types.ExtractSymbolIndexes(document.scipDocument))
-	}
+		index := types.ExtractSymbolIndexes(document.scipDocument)
+		invertedRangeIndexes = append(invertedRangeIndexes, index)
 
-	symbolNameMap := map[string]struct{}{}
-	for _, symbols := range invertedRangeIndexes {
-		for _, invertedRange := range symbols {
+		for _, invertedRange := range index {
 			symbolNameMap[invertedRange.SymbolName] = struct{}{}
 		}
 	}

--- a/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
@@ -329,7 +329,7 @@ func processDocument(
 		toPreciseTypes(document),
 	))
 
-	if err := scipWriter.Write(ctx, path, scipDocument); err != nil {
+	if err := scipWriter.InsertDocument(ctx, path, scipDocument); err != nil {
 		return err
 	}
 
@@ -482,8 +482,8 @@ CREATE TEMPORARY TABLE t_codeintel_scip_symbols (
 ) ON COMMIT DROP
 `
 
-// Write batches a new document, document lookup row, and all of its symbols for insertion.
-func (s *scipWriter) Write(
+// InsertDocument batches a new document, document lookup row, and all of its symbols for insertion.
+func (s *scipWriter) InsertDocument(
 	ctx context.Context,
 	path string,
 	scipDocument *ogscip.Document,

--- a/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
@@ -537,9 +537,12 @@ func (s *scipWriter) flush(ctx context.Context) (err error) {
 		documentLookupIDs = append(documentLookupIDs, documentLookupID)
 	}
 
-	for i, document := range documents {
-		symbols := types.ExtractSymbolIndexes(document.scipDocument)
+	invertedRangeIndexForDocuments := make([][]types.InvertedRangeIndex, 0, len(documents))
+	for _, document := range documents {
+		invertedRangeIndexForDocuments = append(invertedRangeIndexForDocuments, types.ExtractSymbolIndexes(document.scipDocument))
+	}
 
+	for i, symbols := range invertedRangeIndexForDocuments {
 		symbolNameMap := make(map[string]struct{}, len(symbols))
 		for _, invertedRange := range symbols {
 			symbolNameMap[invertedRange.SymbolName] = struct{}{}

--- a/mockgen.test.yaml
+++ b/mockgen.test.yaml
@@ -170,7 +170,7 @@
     - path: github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/lsifstore
       interfaces:
         - LSIFStore
-        - SymbolWriter
+        - SCIPWriter
     - path: github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store
       interfaces:
         - Store


### PR DESCRIPTION
Previously, we would insert two rows via a query, then issue a series of bulk insertions into a buffer (which will flush eventually at the end of the transaction). This is only necessary as we need the identifiers from the the first query before submitting the batch.

This PR ensures that we generate data as late as possible once we have an identifier so we don't have to hold it in as long in memory (this mainly applies to the data that we fanout and write to the `codeintel_scip_symbols` table. This allows us to bulk insert into several batches of insertions targeting different tables.

We now organize insertions into batches of documents, which we insert the payloads and document lookup records for as two batch insertion queries. This will generally write some ~few hundred rows into each table per batch (for medium/large indexes). We then feed a symbols table that, after flush of the first insertions, can reference the foreign keys of the new rows properly. In this new scheme we're no longer issuing a single query to insert a single document.

**Reviewers**: Review by commit may be helpful if scanning the diff is intimidating. Commits are small and well named.

**Note**: Code here seems duplicated because we don't want the `oobmigration` machinery to reference outside code as much as possible. It should be frozen-in-time, so we have a separate copy of its dependencies.

## Test plan

Existing unit tests. Tested by hand.