### PR TITLE
monitoring: do not allow interval variables in alerts

### DIFF
--- a/monitoring/monitoring/variables.go
+++ b/monitoring/monitoring/variables.go
@@ -182,7 +182,7 @@ func (c *ContainerVariable) toGrafanaTemplateVar(injectLabelMatchers []*labels.M
 	return variable, nil
 }
 
-var numbers = regexp.MustCompile(`\d+`)
+var numbers = regexp.MustCompile(`^\d+`)
 
 // getSentinelValue provides an easily distuingishable sentinel example value for this
 // variable that allows a query with variables to be converted into a valid Prometheus
@@ -208,18 +208,37 @@ func (c *ContainerVariable) getSentinelValue() string {
 	return numbers.ReplaceAllString(example, sentinelNumber)
 }
 
+// newVariableApplier returns a VariableApplier with intervals.
 func newVariableApplier(vars []ContainerVariable) promql.VariableApplier {
+	return newVariableApplierWith(vars, true)
+}
+
+func newVariableApplierWith(vars []ContainerVariable, intervalVariables bool) promql.VariableApplier {
+	if intervalVariables {
+		// Make sure Grafana's '$__rate_interval' is interpolated with valid PromQL
+		vars = append(vars,
+			ContainerVariable{
+				// https://grafana.com/docs/grafana/latest/datasources/prometheus/#using-__rate_interval
+				Name: "__rate_interval",
+				Options: ContainerVariableOptions{
+					// We need a strange value here for getSentinelValue to reliably
+					// reverse the replacement to convert this into valid PromQL - it's a
+					// it hack, but not sure if we have a better option here.
+					Options: []string{"123m"},
+				},
+			})
+	}
+
 	applier := promql.VariableApplier{}
-	for _, v := range append(vars,
-		// Make sure default Grafana variables are applied too.
-		ContainerVariable{
-			// https://grafana.com/docs/grafana/latest/datasources/prometheus/#using-__rate_interval
-			Name: "__rate_interval",
-			Options: ContainerVariableOptions{
-				Options: []string{"123m"},
-			},
-		}) {
-		applier[v.Name] = v.getSentinelValue()
+	for _, v := range vars {
+		sentinel := v.getSentinelValue()
+
+		// If we are not allowing intervals, do not allow variables that are numeric.
+		if !intervalVariables && numbers.Match([]byte(sentinel)) {
+			continue
+		}
+
+		applier[v.Name] = sentinel
 	}
 	return applier
 }


### PR DESCRIPTION
tl;dr: with this change we now forbid the use of Grafana magic in `NoAlert: false` graphs - no existing observables are affected by this.

We have a mechanism today, `promql.VariableApplier`, that needs to be able to convert a PromQL query with Grafana variables, to a valid PromQL query _without_ Grafana variables, and then back to the original query again. This is used for label injection. For the reversion to work with numeric values without accidentally converting legitimate values, we "scramble" the numbers somewhat. This works poorly with alert queries, because we do not want a random interval on the alert query.

For now, we isolate the use cases with a new `promql.VariableApplier` constructor that omits interval variables when building alert queries. This will cause `Observable`s that use interval variables _and_ configure an alert to fail on generation. It appears we don't have any such `Observables`s at the moment, but this guards against accidental usage.

A potential future follow-up could be to design a mechanism such that alerts can configure values for interval variables, including `$__rate_interval`, that the alert can use when rendering the final PromQL alert query.

This change was prompted by [this conversation in Slack about adopting `$__rate_interval` more widely](https://sourcegraph.slack.com/archives/C07KZF47K/p1671028821586699).

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`go generate ./monitoring` and unit test