### PR TITLE
Remove lint exception for package that doesn't exist

### DIFF
--- a/dev/sg/linters/go_checks.go
+++ b/dev/sg/linters/go_checks.go
@@ -91,8 +91,6 @@ func lintLoggingLibraries() *linter {
 			"internal/logging/main.go",
 			// Dependencies require direct usage of zap
 			"cmd/frontend/internal/app/otlpadapter",
-			// Not worth fixing the deprecated package
-			"cmd/frontend/internal/usagestatsdeprecated",
 		},
 		ErrorFunc: func(bannedImport string) error {
 			return errors.Newf(`banned usage of '%s': use "github.com/sourcegraph/log" instead`,


### PR DESCRIPTION
`usagestatsdeprecated` was removed, so no need to have a lint exception for it anymore.

## Test plan
CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
