### PR TITLE
Search: reuse goroutine group across all repo revs

### DIFF
--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -56,7 +56,7 @@ type Resolved struct {
 }
 
 // MaybeSendStats is a convenience which will stream a stats event if r
-// contains any.
+// contains any missing backends.
 func (r *Resolved) MaybeSendStats(stream streaming.Sender) {
 	if r.BackendsMissing > 0 {
 		stream.Send(streaming.SearchEvent{


### PR DESCRIPTION
This reuses the same goroutine group across all repos for a commit search. This deserializes searching each page, so should it should speed up commit searches in the cases where there is one repo in a page that takes significantly longer to search than the other repos.

Stacked on #45599 

## Test plan

No change in behavior. Depending on existing unit and integration tests. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
