### PR TITLE
Search: make `DiffModifiesFile` predicate more efficient

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1311,6 +1311,8 @@ func (s *Server) search(ctx context.Context, args *protocol.SearchRequest, match
 			return err
 		}
 
+		// Ensure that we populate ModifiedFiles when we have a DiffModifiesFile filter.
+		// --name-status is not zero cost, so we don't do it on every search.
 		hasDiffModifiesFile := false
 		search.Visit(mt, func(mt search.MatchTree) {
 			switch mt.(type) {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1311,6 +1311,14 @@ func (s *Server) search(ctx context.Context, args *protocol.SearchRequest, match
 			return err
 		}
 
+		hasDiffModifiesFile := false
+		search.Visit(mt, func(mt search.MatchTree) {
+			switch mt.(type) {
+			case *search.DiffModifiesFile:
+				hasDiffModifiesFile = true
+			}
+		})
+
 		searcher := &search.CommitSearcher{
 			Logger:               s.Logger,
 			RepoName:             args.Repo,
@@ -1318,7 +1326,7 @@ func (s *Server) search(ctx context.Context, args *protocol.SearchRequest, match
 			Revisions:            args.Revisions,
 			Query:                mt,
 			IncludeDiff:          args.IncludeDiff,
-			IncludeModifiedFiles: args.IncludeModifiedFiles,
+			IncludeModifiedFiles: args.IncludeModifiedFiles || hasDiffModifiesFile,
 		}
 
 		return searcher.Search(ctx, func(match *protocol.CommitMatch) {

--- a/internal/gitserver/search/lazy_commit.go
+++ b/internal/gitserver/search/lazy_commit.go
@@ -91,7 +91,7 @@ func (l *LazyCommit) ModifiedFiles() []string {
 	for i < len(l.RawCommit.ModifiedFiles) {
 		if len(l.RawCommit.ModifiedFiles[i]) == 0 {
 			// SAFETY: don't trust input
-			break
+			return files
 		}
 		switch l.RawCommit.ModifiedFiles[i][0] {
 		case 'R':

--- a/internal/gitserver/search/lazy_commit.go
+++ b/internal/gitserver/search/lazy_commit.go
@@ -99,7 +99,7 @@ func (l *LazyCommit) ModifiedFiles() []string {
 		if len(l.RawCommit.ModifiedFiles[i]) == 0 {
 			break
 		}
-		switch l.RawCommit.ModifiedFiles[i][0] {
+		switch bytes.TrimSpace(l.RawCommit.ModifiedFiles[i])[0] {
 		case 'R':
 			// SAFETY: don't assume that we have the right number of things
 			if i+2 >= len(l.RawCommit.ModifiedFiles) {

--- a/internal/gitserver/search/search.go
+++ b/internal/gitserver/search/search.go
@@ -138,7 +138,7 @@ func (cs *CommitSearcher) feedBatches(ctx context.Context, jobs chan job, result
 	revArgs := revsToGitArgs(cs.Revisions)
 	args := append(logArgs, revArgs...)
 	if cs.IncludeModifiedFiles {
-		args = append(args, "--name-only")
+		args = append(args, "--name-status")
 	}
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = cs.RepoDir

--- a/internal/gitserver/search/search.go
+++ b/internal/gitserver/search/search.go
@@ -134,13 +134,17 @@ func (cs *CommitSearcher) Search(ctx context.Context, onMatch func(*protocol.Com
 	return g.Wait()
 }
 
-func (cs *CommitSearcher) feedBatches(ctx context.Context, jobs chan job, resultChans chan chan *protocol.CommitMatch) (err error) {
+func (cs *CommitSearcher) gitArgs() []string {
 	revArgs := revsToGitArgs(cs.Revisions)
 	args := append(logArgs, revArgs...)
 	if cs.IncludeModifiedFiles {
 		args = append(args, "--name-status")
 	}
-	cmd := exec.CommandContext(ctx, "git", args...)
+	return args
+}
+
+func (cs *CommitSearcher) feedBatches(ctx context.Context, jobs chan job, resultChans chan chan *protocol.CommitMatch) (err error) {
+	cmd := exec.CommandContext(ctx, "git", cs.gitArgs()...)
 	cmd.Dir = cs.RepoDir
 	stdoutReader, err := cmd.StdoutPipe()
 	if err != nil {
@@ -352,6 +356,16 @@ func (c *CommitScanner) Scan() bool {
 		return false
 	}
 
+	// Filter out empty modified files, which can happen due to how
+	// --name-status formats its output. Also trim spaces on the files
+	// for the same reason.
+	modifiedFiles := parts[11:11]
+	for _, part := range parts[11:] {
+		if len(part) > 0 {
+			modifiedFiles = append(modifiedFiles, bytes.TrimSpace(part))
+		}
+	}
+
 	c.next = &RawCommit{
 		Hash:           parts[0],
 		RefNames:       parts[1],
@@ -364,7 +378,7 @@ func (c *CommitScanner) Scan() bool {
 		CommitterDate:  parts[8],
 		Message:        bytes.TrimSpace(parts[9]),
 		ParentHashes:   parts[10],
-		ModifiedFiles:  parts[11:],
+		ModifiedFiles:  modifiedFiles,
 	}
 
 	return true

--- a/internal/gitserver/search/search_test.go
+++ b/internal/gitserver/search/search_test.go
@@ -159,8 +159,9 @@ func TestSearch(t *testing.T) {
 		tree, err := ToMatchTree(query)
 		require.NoError(t, err)
 		searcher := &CommitSearcher{
-			RepoDir: dir,
-			Query:   tree,
+			RepoDir:              dir,
+			Query:                tree,
+			IncludeModifiedFiles: true,
 		}
 		var matches []*protocol.CommitMatch
 		err = searcher.Search(context.Background(), func(match *protocol.CommitMatch) {
@@ -369,6 +370,12 @@ index 0000000000..7e54670557
 	lc := &LazyCommit{
 		RawCommit: &RawCommit{
 			AuthorName: []byte("Camden Cheek"),
+			ModifiedFiles: [][]byte{
+				[]byte("M"),
+				[]byte("internal/compute/match.go"),
+				[]byte("M"),
+				[]byte("internal/compute/match_test.go"),
+			},
 		},
 		diff: parsedDiff,
 	}

--- a/internal/gitserver/search/search_test.go
+++ b/internal/gitserver/search/search_test.go
@@ -49,7 +49,9 @@ func TestSearch(t *testing.T) {
 	cmds := []string{
 		"echo lorem ipsum dolor sit amet > file1",
 		"git add -A",
-		"GIT_COMMITTER_NAME=camden1 " +
+		"GIT_CONFIG_GLOBAL=/dev/null " +
+			"GIT_CONFIG_SYSTEM=/dev/null " +
+			"GIT_COMMITTER_NAME=camden1 " +
 			"GIT_COMMITTER_EMAIL=camden1@ccheek.com " +
 			"GIT_COMMITTER_DATE=2006-01-02T15:04:05Z " +
 			"GIT_AUTHOR_NAME=camden1 " +
@@ -59,7 +61,9 @@ func TestSearch(t *testing.T) {
 		"echo consectetur adipiscing elit > file2",
 		"echo consectetur adipiscing elit again > file3",
 		"git add -A",
-		"GIT_COMMITTER_NAME=camden2 " +
+		"GIT_CONFIG_GLOBAL=/dev/null " +
+			"GIT_CONFIG_SYSTEM=/dev/null " +
+			"GIT_COMMITTER_NAME=camden2 " +
 			"GIT_COMMITTER_EMAIL=camden2@ccheek.com " +
 			"GIT_COMMITTER_DATE=2006-01-02T15:04:05Z " +
 			"GIT_AUTHOR_NAME=camden2 " +
@@ -68,7 +72,9 @@ func TestSearch(t *testing.T) {
 			"git commit -m commit2",
 		"mv file1 file1a",
 		"git add -A",
-		"GIT_COMMITTER_NAME=camden3 " +
+		"GIT_CONFIG_GLOBAL=/dev/null " +
+			"GIT_CONFIG_SYSTEM=/dev/null " +
+			"GIT_COMMITTER_NAME=camden3 " +
 			"GIT_COMMITTER_EMAIL=camden3@ccheek.com " +
 			"GIT_COMMITTER_DATE=2006-01-02T15:04:05Z " +
 			"GIT_AUTHOR_NAME=camden3 " +
@@ -232,85 +238,160 @@ func TestSearch(t *testing.T) {
 }
 
 func TestCommitScanner(t *testing.T) {
+	cmds := []string{
+		"echo lorem ipsum dolor sit amet > file1",
+		"git add -A",
+		"GIT_CONFIG_GLOBAL=/dev/null " +
+			"GIT_CONFIG_SYSTEM=/dev/null " +
+			"GIT_COMMITTER_NAME=camden1 " +
+			"GIT_COMMITTER_EMAIL=camden1@ccheek.com " +
+			"GIT_COMMITTER_DATE=2006-01-02T15:04:05Z " +
+			"GIT_AUTHOR_NAME=camden1 " +
+			"GIT_AUTHOR_EMAIL=camden1@ccheek.com " +
+			"GIT_AUTHOR_DATE=2006-01-02T15:04:05Z " +
+			"git commit -m commit1 ",
+		"echo consectetur adipiscing elit > file2",
+		"echo consectetur adipiscing elit again > file3",
+		"git add -A",
+		"GIT_CONFIG_GLOBAL=/dev/null " +
+			"GIT_CONFIG_SYSTEM=/dev/null " +
+			"GIT_COMMITTER_NAME=camden2 " +
+			"GIT_COMMITTER_EMAIL=camden2@ccheek.com " +
+			"GIT_COMMITTER_DATE=2006-01-02T15:04:05Z " +
+			"GIT_AUTHOR_NAME=camden2 " +
+			"GIT_AUTHOR_EMAIL=camden2@ccheek.com " +
+			"GIT_AUTHOR_DATE=2006-01-02T15:04:05Z " +
+			"git commit -m commit2",
+		"mv file1 file1a",
+		"git add -A",
+		"GIT_CONFIG_GLOBAL=/dev/null " +
+			"GIT_CONFIG_SYSTEM=/dev/null " +
+			"GIT_COMMITTER_NAME=camden3 " +
+			"GIT_COMMITTER_EMAIL=camden3@ccheek.com " +
+			"GIT_COMMITTER_DATE=2006-01-02T15:04:05Z " +
+			"GIT_AUTHOR_NAME=camden3 " +
+			"GIT_AUTHOR_EMAIL=camden3@ccheek.com " +
+			"GIT_AUTHOR_DATE=2006-01-02T15:04:05Z " +
+			"git commit -m commit3",
+	}
+	dir := initGitRepository(t, cmds...)
+
+	getRaw := func(dir string, includeModifiedFiles bool) []byte {
+		var buf bytes.Buffer
+		cmd := exec.Command("git", (&CommitSearcher{IncludeModifiedFiles: includeModifiedFiles}).gitArgs()...)
+		cmd.Dir = dir
+		cmd.Stdout = &buf
+		cmd.Run()
+		return buf.Bytes()
+	}
+
 	cases := []struct {
 		input    []byte
 		expected []*RawCommit
 	}{
 		{
-			input: []byte(
-				"\x1E2061ba96d63cba38f20a76f039cf29ef68736b8a\x00\x00HEAD\x00Camden Cheek\x00camden@sourcegraph.com\x001632251505\x00Camden Cheek\x00camden@sourcegraph.com\x001632251505\x00fix import\n\x005230097b75dcbb2c214618dd171da4053aff18a6\x00\x00" +
-					"\x1E5230097b75dcbb2c214618dd171da4053aff18a6\x00\x00HEAD\x00Camden Cheek\x00camden@sourcegraph.com\x001632248499\x00Camden Cheek\x00camden@sourcegraph.com\x001632248499\x00only set matches if they exist\n\x00\x00",
-			),
+			input: getRaw(dir, true),
 			expected: []*RawCommit{
 				{
-					Hash:           []byte("2061ba96d63cba38f20a76f039cf29ef68736b8a"),
-					RefNames:       []byte(""),
+					Hash:           []byte("f45c8f639eeaaaeecd04e60be5800835382fb879"),
+					RefNames:       []byte("HEAD -> refs/heads/main"),
 					SourceRefs:     []byte("HEAD"),
-					AuthorName:     []byte("Camden Cheek"),
-					AuthorEmail:    []byte("camden@sourcegraph.com"),
-					AuthorDate:     []byte("1632251505"),
-					CommitterName:  []byte("Camden Cheek"),
-					CommitterEmail: []byte("camden@sourcegraph.com"),
-					CommitterDate:  []byte("1632251505"),
-					Message:        []byte("fix import"),
-					ParentHashes:   []byte("5230097b75dcbb2c214618dd171da4053aff18a6"),
-					ModifiedFiles:  [][]byte{{}, {}},
+					AuthorName:     []byte("camden3"),
+					AuthorEmail:    []byte("camden3@ccheek.com"),
+					AuthorDate:     []byte("1136214245"),
+					CommitterName:  []byte("camden3"),
+					CommitterEmail: []byte("camden3@ccheek.com"),
+					CommitterDate:  []byte("1136214245"),
+					Message:        []byte("commit3"),
+					ParentHashes:   []byte("fa733abad75875e568c949f54f03a38748435e9b"),
+					ModifiedFiles: [][]byte{
+						[]byte("R100"),
+						[]byte("file1"),
+						[]byte("file1a"),
+					},
 				},
 				{
-					Hash:           []byte("5230097b75dcbb2c214618dd171da4053aff18a6"),
+					Hash:           []byte("fa733abad75875e568c949f54f03a38748435e9b"),
 					RefNames:       []byte(""),
 					SourceRefs:     []byte("HEAD"),
-					AuthorName:     []byte("Camden Cheek"),
-					AuthorEmail:    []byte("camden@sourcegraph.com"),
-					AuthorDate:     []byte("1632248499"),
-					CommitterName:  []byte("Camden Cheek"),
-					CommitterEmail: []byte("camden@sourcegraph.com"),
-					CommitterDate:  []byte("1632248499"),
-					Message:        []byte("only set matches if they exist"),
+					AuthorName:     []byte("camden2"),
+					AuthorEmail:    []byte("camden2@ccheek.com"),
+					AuthorDate:     []byte("1136214245"),
+					CommitterName:  []byte("camden2"),
+					CommitterEmail: []byte("camden2@ccheek.com"),
+					CommitterDate:  []byte("1136214245"),
+					Message:        []byte("commit2"),
+					ParentHashes:   []byte("008b80cbf30c8608aec73608becb52168f12d558"),
+					ModifiedFiles: [][]byte{
+						[]byte("A"),
+						[]byte("file2"),
+						[]byte("A"),
+						[]byte("file3"),
+					},
+				},
+				{
+					Hash:           []byte("008b80cbf30c8608aec73608becb52168f12d558"),
+					RefNames:       []byte(""),
+					SourceRefs:     []byte("HEAD"),
+					AuthorName:     []byte("camden1"),
+					AuthorEmail:    []byte("camden1@ccheek.com"),
+					AuthorDate:     []byte("1136214245"),
+					CommitterName:  []byte("camden1"),
+					CommitterEmail: []byte("camden1@ccheek.com"),
+					CommitterDate:  []byte("1136214245"),
+					Message:        []byte("commit1"),
 					ParentHashes:   []byte(""),
-					ModifiedFiles:  [][]byte{{}},
+					ModifiedFiles: [][]byte{
+						[]byte("A"),
+						[]byte("file1"),
+					},
 				},
 			},
 		},
 		{
-			input: []byte(
-				"\x1E2061ba96d63cba38f20a76f039cf29ef68736b8a\x00\x00HEAD\x00Camden Cheek\x00camden@sourcegraph.com\x001632251505\x00Camden Cheek\x00camden@sourcegraph.com\x001632251505\x00fix import\n\x005230097b75dcbb2c214618dd171da4053aff18a6\x00\x00file1" +
-					"\x1E5230097b75dcbb2c214618dd171da4053aff18a6\x00\x00HEAD\x00Camden Cheek\x00camden@sourcegraph.com\x001632248499\x00Camden Cheek\x00camden@sourcegraph.com\x001632248499\x00only set matches if they exist\n\x00\x00file1\x00file2",
-			),
+			input: getRaw(dir, false),
 			expected: []*RawCommit{
 				{
-					Hash:           []byte("2061ba96d63cba38f20a76f039cf29ef68736b8a"),
-					RefNames:       []byte(""),
+					Hash:           []byte("f45c8f639eeaaaeecd04e60be5800835382fb879"),
+					RefNames:       []byte("HEAD -> refs/heads/main"),
 					SourceRefs:     []byte("HEAD"),
-					AuthorName:     []byte("Camden Cheek"),
-					AuthorEmail:    []byte("camden@sourcegraph.com"),
-					AuthorDate:     []byte("1632251505"),
-					CommitterName:  []byte("Camden Cheek"),
-					CommitterEmail: []byte("camden@sourcegraph.com"),
-					CommitterDate:  []byte("1632251505"),
-					Message:        []byte("fix import"),
-					ParentHashes:   []byte("5230097b75dcbb2c214618dd171da4053aff18a6"),
-					ModifiedFiles: [][]byte{
-						{},
-						[]byte("file1"),
-					},
+					AuthorName:     []byte("camden3"),
+					AuthorEmail:    []byte("camden3@ccheek.com"),
+					AuthorDate:     []byte("1136214245"),
+					CommitterName:  []byte("camden3"),
+					CommitterEmail: []byte("camden3@ccheek.com"),
+					CommitterDate:  []byte("1136214245"),
+					Message:        []byte("commit3"),
+					ParentHashes:   []byte("fa733abad75875e568c949f54f03a38748435e9b"),
+					ModifiedFiles:  [][]byte{},
 				},
 				{
-					Hash:           []byte("5230097b75dcbb2c214618dd171da4053aff18a6"),
+					Hash:           []byte("fa733abad75875e568c949f54f03a38748435e9b"),
 					RefNames:       []byte(""),
 					SourceRefs:     []byte("HEAD"),
-					AuthorName:     []byte("Camden Cheek"),
-					AuthorEmail:    []byte("camden@sourcegraph.com"),
-					AuthorDate:     []byte("1632248499"),
-					CommitterName:  []byte("Camden Cheek"),
-					CommitterEmail: []byte("camden@sourcegraph.com"),
-					CommitterDate:  []byte("1632248499"),
-					Message:        []byte("only set matches if they exist"),
+					AuthorName:     []byte("camden2"),
+					AuthorEmail:    []byte("camden2@ccheek.com"),
+					AuthorDate:     []byte("1136214245"),
+					CommitterName:  []byte("camden2"),
+					CommitterEmail: []byte("camden2@ccheek.com"),
+					CommitterDate:  []byte("1136214245"),
+					Message:        []byte("commit2"),
+					ParentHashes:   []byte("008b80cbf30c8608aec73608becb52168f12d558"),
+					ModifiedFiles:  [][]byte{},
+				},
+				{
+					Hash:           []byte("008b80cbf30c8608aec73608becb52168f12d558"),
+					RefNames:       []byte(""),
+					SourceRefs:     []byte("HEAD"),
+					AuthorName:     []byte("camden1"),
+					AuthorEmail:    []byte("camden1@ccheek.com"),
+					AuthorDate:     []byte("1136214245"),
+					CommitterName:  []byte("camden1"),
+					CommitterEmail: []byte("camden1@ccheek.com"),
+					CommitterDate:  []byte("1136214245"),
+					Message:        []byte("commit1"),
 					ParentHashes:   []byte(""),
-					ModifiedFiles: [][]byte{
-						[]byte("file1"),
-						[]byte("file2"),
-					},
+					ModifiedFiles:  [][]byte{},
 				},
 			},
 		},

--- a/internal/gitserver/search/search_test.go
+++ b/internal/gitserver/search/search_test.go
@@ -66,6 +66,15 @@ func TestSearch(t *testing.T) {
 			"GIT_AUTHOR_EMAIL=camden2@ccheek.com " +
 			"GIT_AUTHOR_DATE=2006-01-02T15:04:05Z " +
 			"git commit -m commit2",
+		"mv file1 file1a",
+		"git add -A",
+		"GIT_COMMITTER_NAME=camden3 " +
+			"GIT_COMMITTER_EMAIL=camden3@ccheek.com " +
+			"GIT_COMMITTER_DATE=2006-01-02T15:04:05Z " +
+			"GIT_AUTHOR_NAME=camden3 " +
+			"GIT_AUTHOR_EMAIL=camden3@ccheek.com " +
+			"GIT_AUTHOR_DATE=2006-01-02T15:04:05Z " +
+			"git commit -m commit3",
 	}
 	dir := initGitRepository(t, cmds...)
 
@@ -99,9 +108,10 @@ func TestSearch(t *testing.T) {
 			matches = append(matches, match)
 		})
 		require.NoError(t, err)
-		require.Len(t, matches, 2)
-		require.Equal(t, matches[0].Author.Name, "camden2")
-		require.Equal(t, matches[1].Author.Name, "camden1")
+		require.Len(t, matches, 3)
+		require.Equal(t, matches[0].Author.Name, "camden3")
+		require.Equal(t, matches[1].Author.Name, "camden2")
+		require.Equal(t, matches[2].Author.Name, "camden1")
 	})
 
 	t.Run("and with no operands matches all", func(t *testing.T) {
@@ -117,7 +127,7 @@ func TestSearch(t *testing.T) {
 			matches = append(matches, match)
 		})
 		require.NoError(t, err)
-		require.Len(t, matches, 2)
+		require.Len(t, matches, 3)
 	})
 
 	t.Run("match diff content", func(t *testing.T) {
@@ -133,8 +143,9 @@ func TestSearch(t *testing.T) {
 			matches = append(matches, match)
 		})
 		require.NoError(t, err)
-		require.Len(t, matches, 1)
-		require.Equal(t, matches[0].Author.Name, "camden1")
+		require.Len(t, matches, 2)
+		require.Equal(t, matches[0].Author.Name, "camden3")
+		require.Equal(t, matches[1].Author.Name, "camden1")
 	})
 
 	t.Run("author matches", func(t *testing.T) {
@@ -168,8 +179,9 @@ func TestSearch(t *testing.T) {
 			matches = append(matches, match)
 		})
 		require.NoError(t, err)
-		require.Len(t, matches, 1)
-		require.Equal(t, matches[0].Author.Name, "camden1")
+		require.Len(t, matches, 2)
+		require.Equal(t, matches[0].Author.Name, "camden3")
+		require.Equal(t, matches[1].Author.Name, "camden1")
 	})
 
 	t.Run("and match", func(t *testing.T) {
@@ -189,12 +201,13 @@ func TestSearch(t *testing.T) {
 			matches = append(matches, match)
 		})
 		require.NoError(t, err)
-		require.Len(t, matches, 1)
-		require.Equal(t, matches[0].Author.Name, "camden1")
-		require.Len(t, strings.Split(matches[0].Diff.Content, "\n"), 4)
+		require.Len(t, matches, 2)
+		require.Equal(t, matches[0].Author.Name, "camden3")
+		require.Equal(t, matches[1].Author.Name, "camden1")
+		require.Len(t, strings.Split(matches[1].Diff.Content, "\n"), 4)
 	})
 
-	t.Run("match both, in order with modified files", func(t *testing.T) {
+	t.Run("match all, in order with modified files", func(t *testing.T) {
 		query := &protocol.MessageMatches{Expr: "c"}
 		tree, err := ToMatchTree(query)
 		require.NoError(t, err)
@@ -208,11 +221,13 @@ func TestSearch(t *testing.T) {
 			matches = append(matches, match)
 		})
 		require.NoError(t, err)
-		require.Len(t, matches, 2)
-		require.Equal(t, matches[0].Author.Name, "camden2")
-		require.Equal(t, matches[1].Author.Name, "camden1")
-		require.Equal(t, []string{"file2", "file3"}, matches[0].ModifiedFiles)
-		require.Equal(t, []string{"file1"}, matches[1].ModifiedFiles)
+		require.Len(t, matches, 3)
+		require.Equal(t, matches[0].Author.Name, "camden3")
+		require.Equal(t, matches[1].Author.Name, "camden2")
+		require.Equal(t, matches[2].Author.Name, "camden1")
+		require.Equal(t, []string{"file1", "file1a"}, matches[0].ModifiedFiles)
+		require.Equal(t, []string{"file2", "file3"}, matches[1].ModifiedFiles)
+		require.Equal(t, []string{"file1"}, matches[2].ModifiedFiles)
 	})
 }
 

--- a/internal/gitserver/search/search_test.go
+++ b/internal/gitserver/search/search_test.go
@@ -41,7 +41,7 @@ func initGitRepository(t testing.TB, cmds ...string) string {
 func gitCommand(dir, name string, args ...string) *exec.Cmd {
 	c := exec.Command(name, args...)
 	c.Dir = dir
-	c.Env = append(os.Environ(), "GIT_CONFIG="+path.Join(dir, ".git", "config"), "GIT_CONFIG_NOSYSTEM=1")
+	c.Env = append(os.Environ(), "GIT_CONFIG="+path.Join(dir, ".git", "config"), "GIT_CONFIG_NOSYSTEM=1", "HOME=/dev/null")
 	return c
 }
 
@@ -49,9 +49,7 @@ func TestSearch(t *testing.T) {
 	cmds := []string{
 		"echo lorem ipsum dolor sit amet > file1",
 		"git add -A",
-		"GIT_CONFIG_GLOBAL=/dev/null " +
-			"GIT_CONFIG_SYSTEM=/dev/null " +
-			"GIT_COMMITTER_NAME=camden1 " +
+		"GIT_COMMITTER_NAME=camden1 " +
 			"GIT_COMMITTER_EMAIL=camden1@ccheek.com " +
 			"GIT_COMMITTER_DATE=2006-01-02T15:04:05Z " +
 			"GIT_AUTHOR_NAME=camden1 " +
@@ -61,9 +59,7 @@ func TestSearch(t *testing.T) {
 		"echo consectetur adipiscing elit > file2",
 		"echo consectetur adipiscing elit again > file3",
 		"git add -A",
-		"GIT_CONFIG_GLOBAL=/dev/null " +
-			"GIT_CONFIG_SYSTEM=/dev/null " +
-			"GIT_COMMITTER_NAME=camden2 " +
+		"GIT_COMMITTER_NAME=camden2 " +
 			"GIT_COMMITTER_EMAIL=camden2@ccheek.com " +
 			"GIT_COMMITTER_DATE=2006-01-02T15:04:05Z " +
 			"GIT_AUTHOR_NAME=camden2 " +
@@ -72,9 +68,7 @@ func TestSearch(t *testing.T) {
 			"git commit -m commit2",
 		"mv file1 file1a",
 		"git add -A",
-		"GIT_CONFIG_GLOBAL=/dev/null " +
-			"GIT_CONFIG_SYSTEM=/dev/null " +
-			"GIT_COMMITTER_NAME=camden3 " +
+		"GIT_COMMITTER_NAME=camden3 " +
 			"GIT_COMMITTER_EMAIL=camden3@ccheek.com " +
 			"GIT_COMMITTER_DATE=2006-01-02T15:04:05Z " +
 			"GIT_AUTHOR_NAME=camden3 " +
@@ -288,7 +282,7 @@ func TestCommitScanner(t *testing.T) {
 			expected: []*RawCommit{
 				{
 					Hash:           []byte("f45c8f639eeaaaeecd04e60be5800835382fb879"),
-					RefNames:       []byte("HEAD -> refs/heads/main"),
+					RefNames:       []byte("HEAD -> refs/heads/master"),
 					SourceRefs:     []byte("HEAD"),
 					AuthorName:     []byte("camden3"),
 					AuthorEmail:    []byte("camden3@ccheek.com"),
@@ -347,7 +341,7 @@ func TestCommitScanner(t *testing.T) {
 			expected: []*RawCommit{
 				{
 					Hash:           []byte("f45c8f639eeaaaeecd04e60be5800835382fb879"),
-					RefNames:       []byte("HEAD -> refs/heads/main"),
+					RefNames:       []byte("HEAD -> refs/heads/master"),
 					SourceRefs:     []byte("HEAD"),
 					AuthorName:     []byte("camden3"),
 					AuthorEmail:    []byte("camden3@ccheek.com"),
@@ -393,6 +387,7 @@ func TestCommitScanner(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("", func(t *testing.T) {
+			println(dir)
 			scanner := NewCommitScanner(bytes.NewReader(tc.input))
 			var output []*RawCommit
 			for scanner.Scan() {

--- a/internal/gitserver/search/search_test.go
+++ b/internal/gitserver/search/search_test.go
@@ -41,7 +41,7 @@ func initGitRepository(t testing.TB, cmds ...string) string {
 func gitCommand(dir, name string, args ...string) *exec.Cmd {
 	c := exec.Command(name, args...)
 	c.Dir = dir
-	c.Env = append(os.Environ(), "GIT_CONFIG="+path.Join(dir, ".git", "config"))
+	c.Env = append(os.Environ(), "GIT_CONFIG="+path.Join(dir, ".git", "config"), "GIT_CONFIG_NOSYSTEM=1")
 	return c
 }
 
@@ -241,9 +241,7 @@ func TestCommitScanner(t *testing.T) {
 	cmds := []string{
 		"echo lorem ipsum dolor sit amet > file1",
 		"git add -A",
-		"GIT_CONFIG_GLOBAL=/dev/null " +
-			"GIT_CONFIG_SYSTEM=/dev/null " +
-			"GIT_COMMITTER_NAME=camden1 " +
+		"GIT_COMMITTER_NAME=camden1 " +
 			"GIT_COMMITTER_EMAIL=camden1@ccheek.com " +
 			"GIT_COMMITTER_DATE=2006-01-02T15:04:05Z " +
 			"GIT_AUTHOR_NAME=camden1 " +
@@ -253,9 +251,7 @@ func TestCommitScanner(t *testing.T) {
 		"echo consectetur adipiscing elit > file2",
 		"echo consectetur adipiscing elit again > file3",
 		"git add -A",
-		"GIT_CONFIG_GLOBAL=/dev/null " +
-			"GIT_CONFIG_SYSTEM=/dev/null " +
-			"GIT_COMMITTER_NAME=camden2 " +
+		"GIT_COMMITTER_NAME=camden2 " +
 			"GIT_COMMITTER_EMAIL=camden2@ccheek.com " +
 			"GIT_COMMITTER_DATE=2006-01-02T15:04:05Z " +
 			"GIT_AUTHOR_NAME=camden2 " +
@@ -264,9 +260,7 @@ func TestCommitScanner(t *testing.T) {
 			"git commit -m commit2",
 		"mv file1 file1a",
 		"git add -A",
-		"GIT_CONFIG_GLOBAL=/dev/null " +
-			"GIT_CONFIG_SYSTEM=/dev/null " +
-			"GIT_COMMITTER_NAME=camden3 " +
+		"GIT_COMMITTER_NAME=camden3 " +
 			"GIT_COMMITTER_EMAIL=camden3@ccheek.com " +
 			"GIT_COMMITTER_DATE=2006-01-02T15:04:05Z " +
 			"GIT_AUTHOR_NAME=camden3 " +


### PR DESCRIPTION
@eseliger called out that searches like `type:commit file:\.graphql$` are not as efficient as they could be. The problem here is we're generating a full diff to determine whether one of the changed files matches the file filter, but it's much cheaper to just get a list of files changed with the `--name-status` flag for `git log` when we don't need the full diff. 

This PR updates the logic for commit search to pre-filter commits with the `--name-status` list of files when a search has a file filter. This avoids generating diffs when no matching files were changed, making commit and diff searches with a `file:` filter much faster. 

Locally, the search `r:^github\.com/sourcegraph/sourcegraph$ type:commit count:all file:.*\.graphql$` sped up from 13.1 seconds to 2.9 seconds. 

## Test plan

Updated unit tests, added unit tests, am running integration tests, and did some manual spot checking for our usual suspects (highlighting, diff search correctness, etc.)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
