### PR TITLE
codeintel: Fix lenient query for bulk symbol name lookup

### DIFF
--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_hover.go
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_hover.go
@@ -205,7 +205,7 @@ matching_prefixes(upload_id, id, prefix, search) AS (
 -- that still have a non-empty search field, as this indicates a proper prefix and
 -- therefore a non-match. The remaining rows will all be exact matches.
 matching_symbol_names AS (
-	SELECT id, mp.prefix AS symbol_name
+	SELECT mp.upload_id, mp.id, mp.prefix AS symbol_name
 	FROM matching_prefixes mp
 	WHERE mp.search = ''
 )

--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_monikers.go
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_monikers.go
@@ -222,7 +222,6 @@ func (s *store) GetBulkMonikerLocations(ctx context.Context, tableName string, u
 		sqlf.Join(idQueries, ", "),
 		sqlf.Join(monikerQueries, ", "),
 		sqlf.Sprintf(fmt.Sprintf("%s_ranges", strings.TrimSuffix(tableName, "s"))),
-		sqlf.Join(idQueries, ", "),
 	)
 
 	locationData, err := s.scanQualifiedMonikerLocations(s.db.Query(ctx, query))
@@ -294,11 +293,9 @@ WITH RECURSIVE
 		NULL,
 		%s,
 		document_path
-	FROM codeintel_scip_symbols ss
+	FROM matching_symbol_names msn
+	JOIN codeintel_scip_symbols ss ON ss.upload_id = msn.upload_id AND ss.symbol_id = msn.id
 	JOIN codeintel_scip_document_lookup dl ON dl.id = ss.document_lookup_id
-	JOIN matching_symbol_names msn ON msn.id = ss.symbol_id
-	WHERE
-		ss.upload_id IN (%s)
 	ORDER BY
 		(ss.upload_id, msn.symbol_name)
 )


### PR DESCRIPTION
This PR ensures that we only return locations belonging to a matching (upload_id, symbol_name) pair, not where upload_id AND symbol_name match (but not necessarily as a pair).

## Test plan

Locally; this change caused codeintel-qa to pass with migrated SCIP uploads.