### PR TITLE
docs: improve docs.sourcegraph.com homepage; clarify deployment types

### DIFF
--- a/doc/admin/deploy/docker-compose/aws.md
+++ b/doc/admin/deploy/docker-compose/aws.md
@@ -1,12 +1,8 @@
 # Install Sourcegraph on Amazon Web Services (AWS)
 
-## 🚧 Still supported, but no longer recommended. 🚧
+> ⚠️ We recommend new users use our [AWS AMI](../machine-images/aws-oneclick) or [script-install](../single-node/script.md) instructions, which are easier and offer more flexibility when configuring Sourcegraph. Existing customers can reach out to our Customer Engineering team support@sourcegraph.com if they wish to migrate to these deployment models.
 
-If you're starting a new Sourcegraph deployment: **consider using one of our [newer & simpler deployments](../../../index.md) instead.**
-
-(This deployment type is still supported, however.)
-
-## About Sourcegraph on AWS
+---
 
 This guide will take you through how to deploy Sourcegraph with [Docker Compose](https://docs.docker.com/compose/) to a single EC2 instance on Amazon Web Services (AWS).
 

--- a/doc/admin/deploy/docker-compose/aws.md
+++ b/doc/admin/deploy/docker-compose/aws.md
@@ -1,5 +1,13 @@
 # Install Sourcegraph on Amazon Web Services (AWS)
 
+## 🚧 Still supported, but no longer recommended. 🚧
+
+If you're starting a new Sourcegraph deployment: **consider using one of our [newer & simpler deployments](../../../index.md) instead.**
+
+(This deployment type is still supported, however.)
+
+## About Sourcegraph on AWS
+
 This guide will take you through how to deploy Sourcegraph with [Docker Compose](https://docs.docker.com/compose/) to a single EC2 instance on Amazon Web Services (AWS).
 
 <span class="badge badge-note">RECOMMENDED</span> Deploy a Sourcegraph instance with an [AWS AMI](../machine-images/aws-ami.md) or [AWS One-Click](../machine-images/aws-oneclick.md).

--- a/doc/admin/deploy/docker-compose/azure.md
+++ b/doc/admin/deploy/docker-compose/azure.md
@@ -1,12 +1,6 @@
 # Install Sourcegraph on Azure
 
-## 🚧 Still supported, but no longer recommended. 🚧
-
-If you're starting a new Sourcegraph deployment: **consider using one of our [newer & simpler deployments](../../../index.md) instead.**
-
-(This deployment type is still supported, however.)
-
-## About Sourcegraph on Azure
+> ⚠️ We recommend new users use our [machine image](../machine-images/index.md) or [script-install](../single-node/script.md) instructions, which are easier and offer more flexibility when configuring Sourcegraph. Existing customers can reach out to our Customer Engineering team support@sourcegraph.com if they wish to migrate to these deployment models.
 
 This guide will take you through how to set up a Sourcegraph instance on an Azure virtual machine with [Docker Compose](https://docs.docker.com/compose/).
 

--- a/doc/admin/deploy/docker-compose/azure.md
+++ b/doc/admin/deploy/docker-compose/azure.md
@@ -1,5 +1,13 @@
 # Install Sourcegraph on Azure
 
+## 🚧 Still supported, but no longer recommended. 🚧
+
+If you're starting a new Sourcegraph deployment: **consider using one of our [newer & simpler deployments](../../../index.md) instead.**
+
+(This deployment type is still supported, however.)
+
+## About Sourcegraph on Azure
+
 This guide will take you through how to set up a Sourcegraph instance on an Azure virtual machine with [Docker Compose](https://docs.docker.com/compose/).
 
 ---

--- a/doc/admin/deploy/docker-compose/configuration.md
+++ b/doc/admin/deploy/docker-compose/configuration.md
@@ -1,5 +1,13 @@
 # Configuration
 
+## 🚧 Still supported, but no longer recommended. 🚧
+
+If you're starting a new Sourcegraph deployment: **consider using one of our [newer & simpler deployments](../../../index.md) instead.**
+
+(This deployment type is still supported, however.)
+
+## About configuration
+
 You can find the default [docker-compose.yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) file inside the deployment repository.
 
 If you would like to make changes to the default configurations, we highly recommend you to create a new file called `docker-compose.override.yaml` in the same directory where the base file ([docker-compose.yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml)) is located, and make your customizations inside the `docker-compose.override.yaml` file.

--- a/doc/admin/deploy/docker-compose/configuration.md
+++ b/doc/admin/deploy/docker-compose/configuration.md
@@ -1,12 +1,8 @@
 # Configuration
 
-## 🚧 Still supported, but no longer recommended. 🚧
+> ⚠️ We recommend new users use our [machine image](../../index.md) or [script-install](../single-node/script.md) instructions, which are easier and offer more flexibility when configuring Sourcegraph. Existing customers can reach out to our Customer Engineering team support@sourcegraph.com if they wish to migrate to these deployment models.
 
-If you're starting a new Sourcegraph deployment: **consider using one of our [newer & simpler deployments](../../../index.md) instead.**
-
-(This deployment type is still supported, however.)
-
-## About configuration
+---
 
 You can find the default [docker-compose.yaml](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/docker-compose/docker-compose.yaml) file inside the deployment repository.
 

--- a/doc/admin/deploy/docker-compose/digitalocean.md
+++ b/doc/admin/deploy/docker-compose/digitalocean.md
@@ -4,6 +4,14 @@ title: Install Sourcegraph on DigitalOcean
 
 # Install Sourcegraph on DigitalOcean
 
+## 🚧 Still supported, but no longer recommended. 🚧
+
+If you're starting a new Sourcegraph deployment: **consider using one of our [newer & simpler deployments](../../../index.md) instead.**
+
+(This deployment type is still supported, however.)
+
+## About Sourcegraph on DigitalOcean
+
 This guide will take you through how to deploy a Sourcegraph instance to a single DigitalOcean Droplet with [Docker Compose](https://docs.docker.com/compose/).
 
 ---

--- a/doc/admin/deploy/docker-compose/digitalocean.md
+++ b/doc/admin/deploy/docker-compose/digitalocean.md
@@ -4,17 +4,11 @@ title: Install Sourcegraph on DigitalOcean
 
 # Install Sourcegraph on DigitalOcean
 
-## 🚧 Still supported, but no longer recommended. 🚧
-
-If you're starting a new Sourcegraph deployment: **consider using one of our [newer & simpler deployments](../../../index.md) instead.**
-
-(This deployment type is still supported, however.)
-
-## About Sourcegraph on DigitalOcean
-
-This guide will take you through how to deploy a Sourcegraph instance to a single DigitalOcean Droplet with [Docker Compose](https://docs.docker.com/compose/).
+> ⚠️ We recommend new users use our [machine image](../machine-images/index.md) or [script-install](../single-node/script.md) instructions, which are easier and offer more flexibility when configuring Sourcegraph. Existing customers can reach out to our Customer Engineering team support@sourcegraph.com if they wish to migrate to these deployment models.
 
 ---
+
+This guide will take you through how to deploy a Sourcegraph instance to a single DigitalOcean Droplet with [Docker Compose](https://docs.docker.com/compose/).
 
 ## Configure
 

--- a/doc/admin/deploy/docker-compose/google_cloud.md
+++ b/doc/admin/deploy/docker-compose/google_cloud.md
@@ -1,16 +1,10 @@
 # Install Sourcegraph on Google Cloud
 
-## 🚧 Still supported, but no longer recommended. 🚧
-
-If you're starting a new Sourcegraph deployment: **consider using one of our [newer & simpler deployments](../../../index.md) instead.**
-
-(This deployment type is still supported, however.)
-
-## About Sourcegraph on Google Cloud
-
-This guide will take you through how to deploy Sourcegraph with [Docker Compose](https://docs.docker.com/compose/) to a single node running on Google Cloud.
+> ⚠️ We recommend new users use our [GCE machine image](../machine-images/gce.md) or [script-install](../single-node/script.md) instructions, which are easier and offer more flexibility when configuring Sourcegraph. Existing customers can reach out to our Customer Engineering team support@sourcegraph.com if they wish to migrate to these deployment models.
 
 ---
+
+This guide will take you through how to deploy Sourcegraph with [Docker Compose](https://docs.docker.com/compose/) to a single node running on Google Cloud.
 
 ## Configure
 

--- a/doc/admin/deploy/docker-compose/google_cloud.md
+++ b/doc/admin/deploy/docker-compose/google_cloud.md
@@ -1,5 +1,13 @@
 # Install Sourcegraph on Google Cloud
 
+## 🚧 Still supported, but no longer recommended. 🚧
+
+If you're starting a new Sourcegraph deployment: **consider using one of our [newer & simpler deployments](../../../index.md) instead.**
+
+(This deployment type is still supported, however.)
+
+## About Sourcegraph on Google Cloud
+
 This guide will take you through how to deploy Sourcegraph with [Docker Compose](https://docs.docker.com/compose/) to a single node running on Google Cloud.
 
 ---

--- a/doc/admin/deploy/docker-compose/index.md
+++ b/doc/admin/deploy/docker-compose/index.md
@@ -1,5 +1,13 @@
 # Sourcegraph with Docker Compose
 
+## 🚧 Still supported, but no longer recommended. 🚧
+
+If you're starting a new Sourcegraph deployment: **consider using one of our [newer & simpler deployments](../../../index.md) instead.**
+
+(This deployment type is still supported, however.)
+
+## About Docker Compose
+
 Setting up Docker applications with [multiple containers](https://www.docker.com/resources/what-container) like Sourcegraph using Docker Compose allows us to start all the applications with a single command. It also makes configuring the applications easier through updating the docker-compose.yaml and docker-compose.override.yaml files. Please see the [official Docker Compose docs](https://docs.docker.com/compose/) to learn more about Docker Compose.
 
 This guide will take you through how to install Sourcegraph with Docker Compose on a server, which could be the local machine, a server on a local network, or cloud-hosted server. You can also follow one of the available *cloud-specific guides* listed below to prepare and install Sourcegraph on a supported cloud environment:

--- a/doc/admin/deploy/docker-compose/index.md
+++ b/doc/admin/deploy/docker-compose/index.md
@@ -1,12 +1,8 @@
 # Sourcegraph with Docker Compose
 
-## 🚧 Still supported, but no longer recommended. 🚧
+> ⚠️ We recommend new users use our [machine image](../machine-images/index.md) or [script-install](../single-node/script.md) instructions, which are easier and offer more flexibility when configuring Sourcegraph. Existing customers can reach out to our Customer Engineering team support@sourcegraph.com if they wish to migrate to these deployment models.
 
-If you're starting a new Sourcegraph deployment: **consider using one of our [newer & simpler deployments](../../../index.md) instead.**
-
-(This deployment type is still supported, however.)
-
-## About Docker Compose
+---
 
 Setting up Docker applications with [multiple containers](https://www.docker.com/resources/what-container) like Sourcegraph using Docker Compose allows us to start all the applications with a single command. It also makes configuring the applications easier through updating the docker-compose.yaml and docker-compose.override.yaml files. Please see the [official Docker Compose docs](https://docs.docker.com/compose/) to learn more about Docker Compose.
 

--- a/doc/admin/deploy/docker-compose/migrate.md
+++ b/doc/admin/deploy/docker-compose/migrate.md
@@ -1,12 +1,8 @@
 # Migrate from the single Docker image to Docker Compose
 
-## 🚧 Still supported, but no longer recommended. 🚧
+> ⚠️ We recommend new users use our [machine image](../machine-images/index.md) or [script-install](../single-node/script.md) instructions, which are easier and offer more flexibility when configuring Sourcegraph. Existing customers can reach out to our Customer Engineering team support@sourcegraph.com if they wish to migrate to these deployment models.
 
-If you're starting a new Sourcegraph deployment: **consider using one of our [newer & simpler deployments](../../../index.md) instead.**
-
-(This deployment type is still supported, however.)
-
-## About migrating to Docker Compose
+---
 
 Since Sourcegraph 3.13, deploying via Docker Compose is the recommended method for production deployments as it provides resource isolation between Sourcegraph services which makes it more scalable and stable. This page describes how to migrate from a single Docker image deployment to the Docker Compose deployment method.
 

--- a/doc/admin/deploy/docker-compose/migrate.md
+++ b/doc/admin/deploy/docker-compose/migrate.md
@@ -1,5 +1,13 @@
 # Migrate from the single Docker image to Docker Compose
 
+## 🚧 Still supported, but no longer recommended. 🚧
+
+If you're starting a new Sourcegraph deployment: **consider using one of our [newer & simpler deployments](../../../index.md) instead.**
+
+(This deployment type is still supported, however.)
+
+## About migrating to Docker Compose
+
 Since Sourcegraph 3.13, deploying via Docker Compose is the recommended method for production deployments as it provides resource isolation between Sourcegraph services which makes it more scalable and stable. This page describes how to migrate from a single Docker image deployment to the Docker Compose deployment method.
 
 Sourcegraph's core data (including user accounts, configuration, repository-metadata, etc.), can be migrated from the single Docker image (`sourcegraph/server`) to the Docker Compose deployment by dumping and restoring the Postgres database.

--- a/doc/admin/deploy/docker-compose/operations.md
+++ b/doc/admin/deploy/docker-compose/operations.md
@@ -1,6 +1,12 @@
 
 # Management Operations
 
+## 🚧 Still supported, but no longer recommended. 🚧
+
+If you're starting a new Sourcegraph deployment: **consider using one of our [newer & simpler deployments](../../../index.md) instead.**
+
+(This deployment type is still supported, however.)
+
 ## Manage storage
 
 The Sourcegraph Docker Compose yaml file uses [Docker volumes](https://docs.docker.com/storage/volumes/) to store its data. These volumes are stored at `/var/lib/docker/volumes` by [default on Linux](https://docs.docker.com/storage/#choose-the-right-type-of-mount).

--- a/doc/admin/deploy/docker-compose/operations.md
+++ b/doc/admin/deploy/docker-compose/operations.md
@@ -1,13 +1,9 @@
 
 # Management Operations
 
-## 🚧 Still supported, but no longer recommended. 🚧
+> ⚠️ We recommend new users use our [machine image](../machine-images/index.md) or [script-install](../single-node/script.md) instructions, which are easier and offer more flexibility when configuring Sourcegraph. Existing customers can reach out to our Customer Engineering team support@sourcegraph.com if they wish to migrate to these deployment models.
 
-If you're starting a new Sourcegraph deployment: **consider using one of our [newer & simpler deployments](../../../index.md) instead.**
-
-(This deployment type is still supported, however.)
-
-## Manage storage
+---
 
 The Sourcegraph Docker Compose yaml file uses [Docker volumes](https://docs.docker.com/storage/volumes/) to store its data. These volumes are stored at `/var/lib/docker/volumes` by [default on Linux](https://docs.docker.com/storage/#choose-the-right-type-of-mount).
 

--- a/doc/admin/deploy/docker-compose/upgrade.md
+++ b/doc/admin/deploy/docker-compose/upgrade.md
@@ -1,5 +1,13 @@
 # Upgrade Sourcegraph on Docker Compose
 
+## 🚧 Still supported, but no longer recommended. 🚧
+
+If you're starting a new Sourcegraph deployment: **consider using one of our [newer & simpler deployments](../../../index.md) instead.**
+
+(This deployment type is still supported, however.)
+
+## About upgrading a Docker Compose deployment
+
 This document describes the process to update a Docker Compose Sourcegraph instance.
 
 ### Standard upgrades

--- a/doc/admin/deploy/docker-compose/upgrade.md
+++ b/doc/admin/deploy/docker-compose/upgrade.md
@@ -1,12 +1,8 @@
 # Upgrade Sourcegraph on Docker Compose
 
-## 🚧 Still supported, but no longer recommended. 🚧
+> ⚠️ We recommend new users use our [machine image](../machine-images/index.md) or [script-install](../single-node/script.md) instructions, which are easier and offer more flexibility when configuring Sourcegraph. Existing customers can reach out to our Customer Engineering team support@sourcegraph.com if they wish to migrate to these deployment models.
 
-If you're starting a new Sourcegraph deployment: **consider using one of our [newer & simpler deployments](../../../index.md) instead.**
-
-(This deployment type is still supported, however.)
-
-## About upgrading a Docker Compose deployment
+---
 
 This document describes the process to update a Docker Compose Sourcegraph instance.
 

--- a/doc/admin/deploy/index.md
+++ b/doc/admin/deploy/index.md
@@ -50,30 +50,19 @@ Currently available in the following hosts:
   <a class="btn btn-secondary text-center" href="machine-images/gce"><span>Google Compute Images</span></a>
 </div>
 
-### [Docker Compose](docker-compose/index.md)
+### [Single-machine install-script](single-node/script.md) 
 
-We recommend Docker Compose for most production deployments due to how easily admins can install, configure, and upgrade Sourcegraph instances. It serves as a way to run multi-container applications on Docker using a defined Compose file format.
-
-Docker Compose is used for single-host instances such as AWS EC2 or GCP Compute Engine. It does not provide multi-machine capability such as high availability.
-
-Docker Compose scales to fit the needs of the majority of customers. Refer to the [resource estimator](resource_estimator.md) to find the appropriate instance for you.
-
-<div class="getting-started">
-  <a class="btn btn-secondary text-center" href="./docker-compose/aws"><span>AWS</span></a>
-  <a class="btn btn-secondary text-center" href="./docker-compose/azure"><span>Azure</span></a>
-  <a class="btn btn-secondary text-center" href="./docker-compose/digitalocean"><span>DigitalOcean</span></a>
-  <a class="btn btn-secondary text-center" href="./docker-compose/google_cloud"><span>Google Cloud</span></a>
-</div>
+Quickly install Sourcegraph onto a single Linux machine using our install script.
 
 ### [Kubernetes](kubernetes/index.md) or [Kubernetes with Helm](kubernetes/helm.md)
 
-Kubernetes is recommended for non-standard deployments where Docker Compose is not a viable option.
+Kubernetes is recommended for non-standard deployments where our Machine Images or install-script is not a viable option.
 
-This path will require advanced knowledge of Kubernetes. For teams without the ability to support this, please speak to your Sourcegraph contact about using Docker Compose instead.
+This path will require advanced knowledge of Kubernetes. For teams without the ability to support this, please speak to your Sourcegraph contact about using our other deployments instead.
 
 Helm provides a simple mechanism for deployment customizations, as well as a much simpler upgrade experience.
 
-If you are unable to use Helm to deploy, but still want to use Kubernetes, follow our [Kubernetes deployment documentation](kubernetes/index.md). This path will require advanced knowledge of Kubernetes. For teams without the ability to support this, please speak to your Sourcegraph contact about using Docker Compose instead.
+If you are unable to use Helm to deploy, but still want to use Kubernetes, follow our [Kubernetes deployment documentation](kubernetes/index.md). This path will require advanced knowledge of Kubernetes. For teams without the ability to support this, please speak to your Sourcegraph contact about using our other deployments instead.
 
 ---
 

--- a/doc/admin/deploy/machine-images/aws-oneclick.md
+++ b/doc/admin/deploy/machine-images/aws-oneclick.md
@@ -26,6 +26,8 @@ Launch a verified and pre-configured Sourcegraph instance with the following:
 - AWS Security Group
 - The latest version of Sourcegraph
 
+<small>Prefer manually installing on AWS yourself? See our [AMI installation options](aws-ami.md) and [script installation options](../single-node/script.md).</small>
+
 ---
 
 ## Instance Size Chart
@@ -35,7 +37,7 @@ Determine the instance type required to support the number of users and reposito
 For example, if you have 8,000 users with 80,000 repositories, your instance size would be **L**. If you have 1,000 users with 80,000 repositories, you should go with size **M**.
 
 |                      | **XS**      | **S**       | **M**       | **L**        | **XL**       |
-|----------------------|-------------|-------------|-------------|--------------|--------------|
+| -------------------- | ----------- | ----------- | ----------- | ------------ | ------------ |
 | **Users**            | _<=_ 500    | _<=_ 1,000  | _<=_ 5,000  | _<=_ 10,000  | _<=_ 20,000  |
 | **Repositories**     | _<=_ 5,000  | _<=_ 10,000 | _<=_ 50,000 | _<=_ 100,000 | _<=_ 250,000 |
 | **Recommended Type** | m6a.2xlarge | m6a.4xlarge | m6a.8xlarge | m6a.12xlarge | m6a.24xlarge |

--- a/doc/index.md
+++ b/doc/index.md
@@ -60,7 +60,7 @@ Sourcegraph is a code search and intelligence platform. Devs use it to search, u
   </a>
 </div>
 
-### Enterprise options
+## Enterprise options
 
 For our largest customers, we also offer a Kubernetes multi-node cluster deployment and enterprise support.
 
@@ -72,6 +72,27 @@ For our largest customers, we also offer a Kubernetes multi-node cluster deploym
 	  <p>Deploy a multi-node cluster</p>
     <p><strong>Enterprise-only</strong></p>
   </a>
+</div>
+
+## Non-production
+
+<div class="grid">
+  <a class="btn-app btn" href="/admin/deploy/docker-single-container">
+    <img alt="docker-logo" src="https://storage.googleapis.com/sourcegraph-resource-estimator/assets/Docker.png"/>
+    <h3>Docker Container</h3>
+    <p>Spin up a local Sourcegraph instance with pure docker</p>
+  </a>
+  <a class="btn-app btn" href="/admin/deploy/single-node/k3s">
+    <img alt="k3s-logo" src="/assets/other-logos/k3s.png"/>
+    <h3>K3s</h3>
+    <p>Spin up a local Sourcegraph instance with Kubernetes</p>
+  </a>
+  <a class="btn-app btn" href="/admin/deploy/single-node/minikube">
+    <img alt="minikube-logo" src="/assets/other-logos/minikube.png"/>
+    <h3>Minikube</h3>
+    <p>Spin up a local Sourcegraph instance with Kubernetes</p>
+  </a>
+  <div></div>
 </div>
 
 ## Quickstart
@@ -97,10 +118,6 @@ For our largest customers, we also offer a Kubernetes multi-node cluster deploym
 
 ## Explanations
 
-- Test sourcegraph on your local machine:
-  - [Docker single-container](admin/deploy/docker-single-container.md)
-  - [k3s](/admin/deploy/single-node/k3s.md)
-  - [minikube](/admin/deploy/single-node/minikube.md)
 - [About deploying Sourcegraph, upgrades, etc.](/admin/deploy.md)
 - [How GitHub code search compares to Sourcegraph](https://docs.sourcegraph.com/getting-started/github-vs-sourcegraph)
 - [How Sourcegraph is licensed](https://docs.sourcegraph.com/getting-started/oss-enterprise)

--- a/doc/index.md
+++ b/doc/index.md
@@ -27,12 +27,12 @@ Sourcegraph is runnable in a variety of environments, from cloud to self-hosted 
 ### Self-hosted
 
 <div class="grid">
-  <!-- AWS AMI-->
-  <a class="btn-app btn" href="/admin/deploy/machine-images/aws-ami">
+  <!-- AWS One Click-->
+  <a class="btn-app btn" href="/admin/deploy/machine-images/aws-oneclick">
     <img alt="aws-logo" src="/assets/other-logos/aws-light.svg" class="theme-light-only" />
     <img alt="aws-logo" src="/assets/other-logos/aws-dark.svg" class="theme-dark-only" />
-    <h3>AWS</h3>
-    <p>Launch a pre-configured Sourcegraph instance from an AWS AMI</p>
+    <h3>AWS One-Click</h3>
+    <p>Deploy onto AWS in one click</p>
   </a>
 </div>
 <div class="grid">
@@ -49,13 +49,6 @@ Sourcegraph is runnable in a variety of environments, from cloud to self-hosted 
     <img alt="azure-logo" src="https://storage.googleapis.com/sourcegraph-resource-estimator/assets/azure.png"/>
     <h3>Azure</h3>
     <p>Deploy onto Microsoft Azure</p>
-  </a>
-  <!-- AWS One Click-->
-  <a class="btn-app btn" href="/admin/deploy/machine-images/aws-oneclick">
-    <img alt="aws-logo" src="/assets/other-logos/aws-light.svg" class="theme-light-only" />
-    <img alt="aws-logo" src="/assets/other-logos/aws-dark.svg" class="theme-dark-only" />
-    <h3>AWS One-Click</h3>
-    <p>Deploy onto AWS in one click</p>
   </a>
   <!-- Digital Ocean -->
   <a class="btn-app btn" href="/admin/deploy/docker-compose/digitalocean">

--- a/doc/index.md
+++ b/doc/index.md
@@ -2,15 +2,11 @@
 
 Sourcegraph is a code search and intelligence platform. Devs use it to search, understand, and fix code across large codebases.
 
-To try Sourcegraph on 2 million open-source repositories, visit [Sourcegraph.com](https://sourcegraph.com/search).
+## [Sourcegraph.com/search](https://sourcegraph.com/search)
 
-## Deploy Sourcegraph
+[Sourcegraph.com](https://sourcegraph.com/search) lets you try Sourcegraph instantly on 2 million+ open-source repositories.
 
-Sourcegraph is runnable in a variety of environments, from cloud to self-hosted to your local machine.
-
-<a href="admin/deploy" target="_blank">Learn more about our deployment methods</a>
-
-### Cloud
+## Sourcegraph Cloud for private code
 
 <div>
   <a class="cloud-cta" href="https://signup.sourcegraph.com" target="_blank" rel="noopener noreferrer">
@@ -24,7 +20,7 @@ Sourcegraph is runnable in a variety of environments, from cloud to self-hosted 
   </a>
 </div>
 
-### Self-hosted
+## Self-hosted for private code
 
 <div class="grid">
   <!-- AWS One Click-->
@@ -32,7 +28,7 @@ Sourcegraph is runnable in a variety of environments, from cloud to self-hosted 
     <img alt="aws-logo" src="/assets/other-logos/aws-light.svg" class="theme-light-only" />
     <img alt="aws-logo" src="/assets/other-logos/aws-dark.svg" class="theme-dark-only" />
     <h3>AWS One-Click</h3>
-    <p>Deploy onto AWS in one click</p>
+    <p>Deploy onto AWS in one click (AMI)</p>
   </a>
 </div>
 <div class="grid">
@@ -40,34 +36,35 @@ Sourcegraph is runnable in a variety of environments, from cloud to self-hosted 
   <a class="btn-app btn" href="/admin/deploy/machine-images/gce">
     <img alt="aws-logo" src="https://storage.googleapis.com/sourcegraph-resource-estimator/assets/googlecloud.png" />
     <h3>Google Compute Engine</h3>
-    <p>Launch a pre-configured Sourcegraph instance from a GCE Image</p>
+    <p>Launch quickly using a GCE machine image</p>
   </a>
 </div>
 <div class="grid">
   <!-- Azure -->
-  <a class="btn-app btn" href="/admin/deploy/docker-compose/azure">
+  <a class="btn-app btn" href="/admin/deploy/single-node/script.md">
     <img alt="azure-logo" src="https://storage.googleapis.com/sourcegraph-resource-estimator/assets/azure.png"/>
     <h3>Azure</h3>
-    <p>Deploy onto Microsoft Azure</p>
+    <p>Deploy onto Microsoft Azure<br/>(install script)</p>
   </a>
   <!-- Digital Ocean -->
-  <a class="btn-app btn" href="/admin/deploy/docker-compose/digitalocean">
+  <a class="btn-app btn" href="/admin/deploy/single-node/script.md">
     <img alt="digital-ocean-logo" src="https://storage.googleapis.com/sourcegraph-resource-estimator/assets/DigitalOcean.png"/>
     <h3>DigitalOcean</h3>
-    <p>Deploy onto DigitalOcean</p>
-  </a>
-  <!-- Docker Compose -->
-  <a class="btn-app btn" href="/admin/deploy/docker-compose">
-    <img alt="docker-compose-logo" src="https://storage.googleapis.com/sourcegraph-resource-estimator/assets/Docker.png"/>
-    <h3>Docker Compose</h3>
-    <p>Deploy with Docker Compose</p>
+    <p>Deploy onto DigitalOcean<br/>(install script)</p>
   </a>
   <!-- Others -->
-  <a class="btn-app btn" href="/admin/deploy">
+  <a class="btn-app btn" href="/admin/deploy/single-node/script.md">
     <img alt="private-cloud-logo" src="https://storage.googleapis.com/sourcegraph-resource-estimator/assets/cloud.png"/>
-    <h3>Private cloud</h3>
-    <p>Deploy into a generic cloud environment</p>
+    <h3>Script install</h3>
+    <p>Deploy on any Linux machine using our script</p>
   </a>
+</div>
+
+### Enterprise options
+
+For our largest customers, we also offer a Kubernetes multi-node cluster deployment and enterprise support.
+
+<div class="grid">
   <!-- Kubernetes -->
   <a class="btn-app btn" href="/admin/deploy/kubernetes">
     <img alt="kubernetes-logo" src="https://storage.googleapis.com/sourcegraph-resource-estimator/assets/kubernetes.png"/>
@@ -76,29 +73,6 @@ Sourcegraph is runnable in a variety of environments, from cloud to self-hosted 
     <p><strong>Enterprise-only</strong></p>
   </a>
 </div>
-
-### Local machine
-
-<div class="grid">
-  <a class="btn-app btn" href="/admin/deploy/docker-single-container">
-    <img alt="docker-logo" src="https://storage.googleapis.com/sourcegraph-resource-estimator/assets/Docker.png"/>
-    <h3>Docker Container</h3>
-    <p>Spin up a local Sourcegraph instance with pure docker</p>
-  </a>
-  <a class="btn-app btn" href="/admin/deploy/single-node/k3s">
-    <img alt="k3s-logo" src="/assets/other-logos/k3s.png"/>
-    <h3>K3s</h3>
-    <p>Spin up a local Sourcegraph instance with Kubernetes</p>
-  </a>
-  <a class="btn-app btn" href="/admin/deploy/single-node/minikube">
-    <img alt="minikube-logo" src="/assets/other-logos/minikube.png"/>
-    <h3>Minikube</h3>
-    <p>Spin up a local Sourcegraph instance with Kubernetes</p>
-  </a>
-  <div></div>
-</div>
-
----
 
 ## Quickstart
 
@@ -123,5 +97,10 @@ Sourcegraph is runnable in a variety of environments, from cloud to self-hosted 
 
 ## Explanations
 
+- Test sourcegraph on your local machine:
+  - [Docker single-container](admin/deploy/docker-single-container.md)
+  - [k3s](/admin/deploy/single-node/k3s.md)
+  - [minikube](/admin/deploy/single-node/minikube.md)
+- [About deploying Sourcegraph, upgrades, etc.](/admin/deploy.md)
 - [How GitHub code search compares to Sourcegraph](https://docs.sourcegraph.com/getting-started/github-vs-sourcegraph)
 - [How Sourcegraph is licensed](https://docs.sourcegraph.com/getting-started/oss-enterprise)


### PR DESCRIPTION
@beyang I am tagging you since I'm not sure who else can approve this change. I think this is a strong improvement over our current docs homepage, and better reflects where we are at / where we are going with Delivery.

Very open to feedback from others here, but I need to move quick with this change.

## The homepage

**Screenshot: [image](https://user-images.githubusercontent.com/3173176/207742866-acf7596f-59c5-4c5c-a3c1-72c764a3c37a.png)**

* Removed Docker Compose deployment links
* Replaced Azure, DigitalOcean, and "Private Cloud" links to go to the new script installer instead (stop pushing Docker Composer.)
* Clarified that Kubernetes is for our largest enterprise customers.
* Embolden that sourcegraph.com/search can be used to try the product instantly.
* Reduce page clutter and improve legibility.
* Made "Test on local machine" deployment options a footnote, as most are confusing right now / you'd be better off using the "Script install" option on a Linux machine somewhere.

## Docker Compose

All Docker Compose pages have been updated to have "🚧 Still supported, but no longer recommended. 🚧" at the top:

<img width="1703" alt="image" src="https://user-images.githubusercontent.com/3173176/207742979-0ee1a7ba-acce-4114-8cf2-f085e1a66f75.png">

## Test plan

Docs change only, no testing required.