### PR TITLE
cmd/blobstore: add test stubs, implement bucket creation

### DIFF
--- a/cmd/blobstore/internal/blobstore/blobstore.go
+++ b/cmd/blobstore/internal/blobstore/blobstore.go
@@ -2,14 +2,19 @@
 package blobstore
 
 import (
+	"context"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	sglog "github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // Service is the blobstore service. It is an http.Handler.
@@ -21,12 +26,44 @@ type Service struct {
 
 // ServeHTTP handles HTTP based search requests
 func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
 	metricRunning.Inc()
 	defer metricRunning.Dec()
 
-	// TODO(blobstore): handle requests
-	_ = ctx
+	err := s.serve(w, r)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		s.Log.Error("serving request", sglog.Error(err))
+		fmt.Fprintf(w, "error: %v", err)
+		return
+	}
+}
+
+func (s *Service) serve(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+	path := strings.FieldsFunc(r.URL.Path, func(r rune) bool { return r == '/' })
+	switch r.Method {
+	case "PUT":
+		if len(path) == 1 { // PUT /<bucket>
+			if r.ContentLength != 0 {
+				return errors.Newf("expected CreateBucket request to have content length 0: %s %s", r.Method, r.URL)
+			}
+			if err := s.createBucket(ctx, path[0]); err != nil {
+				return err
+			}
+			w.WriteHeader(http.StatusOK)
+			return nil
+		}
+		return errors.Newf("unexpected request(0): %s %s", r.Method, r.URL)
+	case "GET":
+		return errors.Newf("unexpected request(1): %s %s", r.Method, r.URL)
+	default:
+		return errors.Newf("unexpected request(2): %s %s", r.Method, r.URL)
+	}
+}
+
+func (s *Service) createBucket(ctx context.Context, name string) error {
+	fmt.Println("TODO(blobstore): create bucket", name)
+	return nil
 }
 
 var (

--- a/cmd/blobstore/internal/blobstore/blobstore.go
+++ b/cmd/blobstore/internal/blobstore/blobstore.go
@@ -57,7 +57,9 @@ func (s *Service) serve(w http.ResponseWriter, r *http.Request) error {
 	path := strings.FieldsFunc(r.URL.Path, func(r rune) bool { return r == '/' })
 	switch r.Method {
 	case "PUT":
-		if len(path) == 1 { // PUT /<bucket>
+		if len(path) == 1 {
+			// PUT /<bucket>
+			// https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html
 			if r.ContentLength != 0 {
 				return errors.Newf("expected CreateBucket request to have content length 0: %s %s", r.Method, r.URL)
 			}
@@ -67,11 +69,18 @@ func (s *Service) serve(w http.ResponseWriter, r *http.Request) error {
 			w.WriteHeader(http.StatusOK)
 			return nil
 		}
-		return errors.Newf("unexpected request(0): %s %s", r.Method, r.URL)
+		return errors.Newf("unexpected PUT request: %s", r.URL)
 	case "GET":
-		return errors.Newf("unexpected request(1): %s %s", r.Method, r.URL)
+		if len(path) == 2 && r.URL.Query().Get("x-id") == "GetObject" {
+			// GET /<bucket>/<key>?x-id=GetObject
+			// https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html
+			// TODO(blobstore): implement me!
+			w.WriteHeader(http.StatusNotFound)
+			return nil
+		}
+		return errors.Newf("unexpected GET request: %s", r.URL)
 	default:
-		return errors.Newf("unexpected request(2): %s %s", r.Method, r.URL)
+		return errors.Newf("unexpected request: %s %s", r.Method, r.URL)
 	}
 }
 

--- a/cmd/blobstore/internal/blobstore/blobstore_test.go
+++ b/cmd/blobstore/internal/blobstore/blobstore_test.go
@@ -2,7 +2,7 @@ package blobstore_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -35,7 +35,7 @@ func TestGetNotExists(t *testing.T) {
 		t.Fatal("expected a reader, got an error", err)
 	}
 	defer reader.Close()
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/cmd/blobstore/internal/blobstore/blobstore_test.go
+++ b/cmd/blobstore/internal/blobstore/blobstore_test.go
@@ -1,20 +1,115 @@
 package blobstore_test
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/cmd/blobstore/internal/blobstore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/uploadstore"
 )
 
-func TestBlobstore(t *testing.T) {
+// Tests that initializing an uploadstore with blobstore as the backend works (performing no operations.)
+func TestInit(t *testing.T) {
+	ctx := context.Background()
+	store, server := initTestStore(ctx, t)
+	defer server.Close()
+
+	_ = store
+}
+
+// Tests that getting an object that does not exist works.
+func TestGetNotExists(t *testing.T) {
+	ctx := context.Background()
+	store, server := initTestStore(ctx, t)
+	defer server.Close()
+
+	_ = store
+}
+
+// Tests uploading an object works.
+func TestUpload(t *testing.T) {
+	ctx := context.Background()
+	store, server := initTestStore(ctx, t)
+	defer server.Close()
+
+	// TODO(blobstore): call store.Upload(ctx context.Context, key string, r io.Reader) (int64, error)
+	_ = store
+}
+
+// Tests uploading an object and getting it back works.
+func TestGetExists(t *testing.T) {
+	ctx := context.Background()
+	store, server := initTestStore(ctx, t)
+	defer server.Close()
+
+	// TODO(blobstore): call store.Get(ctx context.Context, key string) (io.ReadCloser, error)
+	_ = store
+}
+
+// Tests uploading two objects and then composing them together works.
+func TestCompose(t *testing.T) {
+	ctx := context.Background()
+	store, server := initTestStore(ctx, t)
+	defer server.Close()
+
+	// TODO(blobstore): call store.Compose(ctx context.Context, destination string, sources ...string) (int64, error)
+	//
+	// Compose will concatenate the given source objects together and write to the given
+	// destination object. The source objects will be removed if the composed write is
+	// successful.
+	_ = store
+}
+
+// Tests deleting an object works.
+func TestDelete(t *testing.T) {
+	ctx := context.Background()
+	store, server := initTestStore(ctx, t)
+	defer server.Close()
+
+	// TODO(blobstore): call store.Delete(ctx context.Context, key string) error
+	_ = store
+}
+
+// Tests expiring objects works.
+func TestExpireObjects(t *testing.T) {
+	ctx := context.Background()
+	store, server := initTestStore(ctx, t)
+	defer server.Close()
+
+	// TODO(blobstore): call store.ExpireObjects(ctx context.Context, prefix string, maxAge time.Duration) error
+	_ = store
+}
+
+func initTestStore(ctx context.Context, t *testing.T) (uploadstore.Store, *httptest.Server) {
+	observationCtx := observation.TestContextTB(t)
 	ts := httptest.NewServer(&blobstore.Service{
 		DataDir:        t.TempDir(),
 		Log:            logtest.Scoped(t),
-		ObservationCtx: observation.TestContextTB(t),
+		ObservationCtx: observationCtx,
 	})
-	defer ts.Close()
+
+	config := uploadstore.Config{
+		Backend:      "blobstore",
+		ManageBucket: false,
+		Bucket:       "lsif-uploads",
+		TTL:          168 * time.Hour,
+		S3: uploadstore.S3Config{
+			Region:       "us-east-1",
+			Endpoint:     ts.URL,
+			UsePathStyle: false,
+		},
+	}
+	store, err := uploadstore.CreateLazy(ctx, config, uploadstore.NewOperations(observationCtx, "test", "lsifstore"))
+	if err != nil {
+		t.Fatal("CreateLazy", err)
+	}
+	if err := store.Init(ctx); err != nil {
+		t.Fatal("Init", err)
+	}
+	return store, ts
 }

--- a/cmd/blobstore/internal/blobstore/blobstore_test.go
+++ b/cmd/blobstore/internal/blobstore/blobstore_test.go
@@ -2,7 +2,9 @@ package blobstore_test
 
 import (
 	"context"
+	"io/ioutil"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,7 +30,21 @@ func TestGetNotExists(t *testing.T) {
 	store, server := initTestStore(ctx, t)
 	defer server.Close()
 
-	_ = store
+	reader, err := store.Get(ctx, "does-not-exist-key")
+	if err != nil {
+		t.Fatal("expected a reader, got an error", err)
+	}
+	defer reader.Close()
+	data, err := ioutil.ReadAll(reader)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "NotFound") {
+		t.Fatalf("expected NotFound error, got %+v", err)
+	}
+	if len(data) != 0 {
+		t.Fatal("expected no data")
+	}
 }
 
 // Tests uploading an object works.


### PR DESCRIPTION
Again in the spirit of sending more smaller PRs, I am sending this:

* Adds test stubs for all the functionality we need to work.
* Makes use of `uploadstore` to test our implementation is working correctly.
* Implements bucket creation, adds initial bucket locking logic, etc.

The remainder of the tests/functionality will be implemented in future PRs.

Helps #45594

## Test plan

Added unit tests.
