### PR TITLE
batches: restore increased limit of 10 changesets for unlicensed instances

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -82,7 +82,7 @@ func checkLicense() error {
 // maxUnlicensedChangesets is the maximum number of changesets that can be
 // attached to a batch change when Sourcegraph is unlicensed or the Batch
 // Changes feature is disabled.
-const maxUnlicensedChangesets = 5
+const maxUnlicensedChangesets = 10
 
 type batchSpecCreatedArg struct {
 	ChangesetSpecsCount int `json:"changeset_specs_count"`

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -1149,11 +1149,11 @@ func TestApplyBatchChangeWithLicenseFail(t *testing.T) {
 		},
 		{
 			name:          "ApplyBatchChange at limit",
-			numChangesets: 5,
+			numChangesets: 10,
 		},
 		{
 			name:          "ApplyBatchChange over limit",
-			numChangesets: 6,
+			numChangesets: 11,
 		},
 	}
 	for _, test := range tests {
@@ -2385,7 +2385,7 @@ func TestMaxUnlicensedChangesets(t *testing.T) {
 
 	apitest.MustExec(actorCtx, t, s, nil, &response, querymaxUnlicensedChangesets)
 
-	assert.Equal(t, int32(5), response.MaxUnlicensedChangesets)
+	assert.Equal(t, int32(10), response.MaxUnlicensedChangesets)
 }
 
 const querymaxUnlicensedChangesets = `


### PR DESCRIPTION
Came across this while investigating something unrelated. I believe https://github.com/sourcegraph/sourcegraph/pull/42548 unintentionally reverted the limit increase in changesets for batch changes on unlicensed instances. This PR restores the increased limit (10). 

## Test plan

Constant change. Verified resolver tests still pass and `maxUnlicensedChangesets` query now returns 10 again.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
