### PR TITLE
Code Insights: Fix code insight redirection URL after editing or creating flow

### DIFF
--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/hooks/use-edit-page-handlers.ts
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/hooks/use-edit-page-handlers.ts
@@ -4,7 +4,6 @@ import { useHistory } from 'react-router-dom'
 
 import { eventLogger } from '../../../../../../tracking/eventLogger'
 import { SubmissionErrors } from '../../../../components'
-import { ALL_INSIGHTS_DASHBOARD } from '../../../../constants'
 import { CodeInsightsBackendContext, CreationInsightInput } from '../../../../core'
 import { useQueryParameters } from '../../../../hooks'
 import { getTrackingTypeByInsightType } from '../../../../pings'
@@ -22,8 +21,8 @@ export function useEditPageHandlers(props: { id: string | undefined }): useHandl
     const { updateInsight } = useContext(CodeInsightsBackendContext)
     const history = useHistory()
 
-    const { dashboardId = ALL_INSIGHTS_DASHBOARD.id, insight } = useQueryParameters(['dashboardId', 'insight'])
-    const redirectUrl = insight ? `/insights/insight/${insight}` : `/insights/dashboards/${dashboardId}`
+    const { dashboardId, insight } = useQueryParameters(['dashboardId', 'insight'])
+    const redirectUrl = getReturnToLink(insight, dashboardId)
 
     const handleSubmit = async (newInsight: CreationInsightInput): Promise<SubmissionErrors> => {
         if (!id) {
@@ -45,4 +44,16 @@ export function useEditPageHandlers(props: { id: string | undefined }): useHandl
     }
 
     return { handleSubmit, handleCancel }
+}
+
+function getReturnToLink(insightId: string | undefined, dashboardId: string | undefined): string {
+    if (insightId) {
+        return `/insights/insight/${insightId}`
+    }
+
+    if (dashboardId) {
+        return `/insights/dashboards/${dashboardId}`
+    }
+
+    return '/insights/all'
 }

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/dashboard-pills/StandaloneInsightDashboardPills.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/dashboard-pills/StandaloneInsightDashboardPills.tsx
@@ -6,7 +6,6 @@ import classNames from 'classnames'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Icon, Link, Text } from '@sourcegraph/wildcard'
 
-import { ALL_INSIGHTS_DASHBOARD } from '../../../../../constants'
 import { InsightDashboardReference } from '../../../../../core'
 
 import styles from './StandaloneInsightDashboardPills.module.scss'
@@ -29,7 +28,22 @@ export const StandaloneInsightDashboardPills: FunctionComponent<StandaloneInsigh
                 Insight added to:
             </Text>
 
-            {[ALL_INSIGHTS_DASHBOARD, ...dashboards].map(dashboard => (
+            <Button
+                as={Link}
+                to={`/insights/all?focused=${insightId}`}
+                variant="secondary"
+                outline={true}
+                size="sm"
+                target="_blank"
+                rel="noopener"
+                className={styles.pill}
+                onClick={handleDashboardClick}
+            >
+                <Icon aria-hidden={true} svgPath={mdiViewDashboard} />
+                All Insights
+            </Button>
+
+            {dashboards.map(dashboard => (
                 <Button
                     key={dashboard.id}
                     as={Link}

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -27,7 +27,6 @@ import {
     DrillDownInsightCreationFormValues,
     parseSeriesLimit,
 } from '../../../../../components/insights-view-grid/components/backend-insight/components'
-import { ALL_INSIGHTS_DASHBOARD } from '../../../../../constants'
 import {
     BackendInsightData,
     BackendInsight,
@@ -133,7 +132,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
         })
 
         setOriginalInsightFilters(filters)
-        history.push(`/insights/dashboards/${ALL_INSIGHTS_DASHBOARD.id}`)
+        history.push('/insights/all')
         telemetryService.log('CodeInsightsSearchBasedFilterInsightCreation')
     }
 

--- a/doc/code_insights/how-tos/creating_a_custom_dashboard_of_code_insights.md
+++ b/doc/code_insights/how-tos/creating_a_custom_dashboard_of_code_insights.md
@@ -4,7 +4,7 @@ This how-to assumes that you already have created some code insights to add to a
 
 ## 1. Navigate to the Code Insights page 
 
-Start on the code insights page by clicking the Code Insights navbar item or going to `/insights/dashboards/all`. 
+Start on the code insights page by clicking the Code Insights navbar item or going to `/insights/all`. 
 
 ## 2. Create and name a new dashboard
 


### PR DESCRIPTION
Follow up for https://github.com/sourcegraph/sourcegraph/pull/45004

Reported by @chwarwick here https://github.com/sourcegraph/sourcegraph/pull/45004#issuecomment-1352055604

This PR fixes legacy `/insights/dashbaord/all` redirection that has been changed and now it's `/insights/all`

## Test plan
- Make sure that after the edit page, you are redirected to `/insights/all` URL if you came from this URL 
- Make sure that all insights dashboard pill on the insight standalone page leads to the `/insights/all` tab
- Check that save as a new view on the insight standalone page leads to the `/insights/all`

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
