### PR TITLE
doc/admin/external_service: Remove redundant config to disable code host

### DIFF
--- a/doc/admin/external_service/index.md
+++ b/doc/admin/external_service/index.md
@@ -204,8 +204,7 @@ It may be the case that you'd like to temporarily disable all `git` and API requ
 > WARNING: disabling all git and API requests to codehosts will also disable permissions syncs, batch changes, discovery of new repos, and updates to currently synched repos. Synching with codehosts is a core functionality of Sourcegraph and many other features may also be affected. 
 
 ```json
-"disableAutoGitUpdates": true,    
+"disableAutoGitUpdates": true,
 "disableAutoCodeHostSyncs": true,
 "gitMaxCodehostRequestsPerSecond": 0,
-"gitMaxConcurrentClones": 0
 ```


### PR DESCRIPTION
gitMaxConcurrentClones is not needed if disableAutoGitUpdates is set to true.



## Test plan

N/A. Doc changes only.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
