### PR TITLE
internal/repos: Better error messaging for missing SourceInfo

### DIFF
--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -371,7 +371,7 @@ func (s *store) CreateExternalServiceRepo(ctx context.Context, svc *types.Extern
 
 	src := r.Sources[svc.URN()]
 	if src == nil {
-		return errors.New("CreateExternalServiceRepo: nil repo for external service")
+		return errors.New("CreateExternalServiceRepo: repo missing source info for external service")
 	} else if src.CloneURL == "" {
 		return errors.Newf("CreateExternalServiceRepo: repo (ID=%q) missing CloneURL for external service", src.ID)
 	}

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -370,8 +370,10 @@ func (s *store) CreateExternalServiceRepo(ctx context.Context, svc *types.Extern
 	)
 
 	src := r.Sources[svc.URN()]
-	if src == nil || src.CloneURL == "" {
-		return errors.New("CreateExternalServiceRepo: repo missing source info for external service")
+	if src == nil {
+		return errors.New("CreateExternalServiceRepo: nil repo for external service")
+	} else if src.CloneURL == "" {
+		return errors.Newf("CreateExternalServiceRepo: repo (ID=%q) missing CloneURL for external service", src.ID)
 	}
 
 	if !s.InTransaction() {


### PR DESCRIPTION
A [customer](https://github.com/sourcegraph/customer/issues/1688) is affected by this error.  Better messaging might have helped us understand it better.

## Test plan

No functional change.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
