### PR TITLE
build: add missing npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -357,6 +357,7 @@
     "@opentelemetry/exporter-trace-otlp-http": "^0.31.0",
     "@opentelemetry/instrumentation": "^0.31.0",
     "@opentelemetry/instrumentation-fetch": "^0.31.0",
+    "@opentelemetry/resources": "1.5.0",
     "@opentelemetry/sdk-trace-web": "^1.5.0",
     "@opentelemetry/semantic-conventions": "^1.5.0",
     "@reach/accordion": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -358,6 +358,7 @@
     "@opentelemetry/instrumentation": "^0.31.0",
     "@opentelemetry/instrumentation-fetch": "^0.31.0",
     "@opentelemetry/resources": "1.5.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0",
     "@opentelemetry/sdk-trace-web": "^1.5.0",
     "@opentelemetry/semantic-conventions": "^1.5.0",
     "@reach/accordion": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -256,6 +256,7 @@
     "eslint-plugin-monorepo": "^0.3.2",
     "events": "^3.3.0",
     "execa": "^5.0.0",
+    "expect": "^27.5.1",
     "express": "^4.17.1",
     "express-static-gzip": "^2.1.1",
     "glob": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -348,6 +348,7 @@
     "@codemirror/search": "^6.0.1",
     "@codemirror/state": "^6.1.0",
     "@codemirror/view": "^6.4.0",
+    "@graphiql/react": "^0.10.0",
     "@lezer/highlight": "^1.0.0",
     "@mdi/js": "^6.7.96",
     "@microsoft/fetch-event-source": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27283,6 +27283,7 @@ __metadata:
     "@opentelemetry/instrumentation": ^0.31.0
     "@opentelemetry/instrumentation-fetch": ^0.31.0
     "@opentelemetry/resources": 1.5.0
+    "@opentelemetry/sdk-trace-base": 1.5.0
     "@opentelemetry/sdk-trace-web": ^1.5.0
     "@opentelemetry/semantic-conventions": ^1.5.0
     "@peculiar/webcrypto": ^1.1.7

--- a/yarn.lock
+++ b/yarn.lock
@@ -27470,6 +27470,7 @@ __metadata:
     events: ^3.3.0
     eventsource: 1.1.1
     execa: ^5.0.0
+    expect: ^27.5.1
     express: ^4.17.1
     express-static-gzip: ^2.1.1
     focus-visible: ^5.2.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -27264,6 +27264,7 @@ __metadata:
     "@gql2ts/from-schema": ^1.10.1
     "@gql2ts/language-typescript": ^1.9.0
     "@gql2ts/types": ^1.9.0
+    "@graphiql/react": ^0.10.0
     "@graphql-codegen/cli": ^2.16.1
     "@graphql-codegen/typescript": 2.8.5
     "@graphql-codegen/typescript-apollo-client-helpers": ^2.2.6

--- a/yarn.lock
+++ b/yarn.lock
@@ -27282,6 +27282,7 @@ __metadata:
     "@opentelemetry/exporter-trace-otlp-http": ^0.31.0
     "@opentelemetry/instrumentation": ^0.31.0
     "@opentelemetry/instrumentation-fetch": ^0.31.0
+    "@opentelemetry/resources": 1.5.0
     "@opentelemetry/sdk-trace-web": ^1.5.0
     "@opentelemetry/semantic-conventions": ^1.5.0
     "@peculiar/webcrypto": ^1.1.7


### PR DESCRIPTION
Missing direct dependencies which will be required when compiling under bazel. This is adding the same version already in the lockfile so should have no runtime change.

`@graphiql/react`:
* `client/web/src/api/ApiConsoleToolbar.tsx`:

`@opentelemetry/resources`
* `client/web/src/monitoring/opentelemetry/initOpenTelemetry.ts`

`@opentelemetry/sdk-trace-base dependency`
* ~10 places

`expect`:
* many places, I chose a version that didn't add a version to the yarn.lock

## Test plan

Build must be green.

## App preview:

- [Web](https://sg-web-deps-graphql-react.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

