### PR TITLE
codeintel: Fix handling of duplicate SCIP documents on insertion

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_write.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_write.go
@@ -82,7 +82,7 @@ func (s *store) NewSCIPWriter(ctx context.Context, uploadID int) (SCIPWriter, er
 	if err := s.db.Exec(ctx, sqlf.Sprintf(newSCIPWriterTemporarySymbolNamesTableQuery)); err != nil {
 		return nil, err
 	}
-	if err := s.db.Exec(ctx, sqlf.Sprintf(newSCIpWriterTemporarySymbolsTableQuery)); err != nil {
+	if err := s.db.Exec(ctx, sqlf.Sprintf(newSCIPWriterTemporarySymbolsTableQuery)); err != nil {
 		return nil, err
 	}
 
@@ -128,7 +128,7 @@ CREATE TEMPORARY TABLE t_codeintel_scip_symbol_names (
 ) ON COMMIT DROP
 `
 
-const newSCIpWriterTemporarySymbolsTableQuery = `
+const newSCIPWriterTemporarySymbolsTableQuery = `
 CREATE TEMPORARY TABLE t_codeintel_scip_symbols (
 	symbol_id integer NOT NULL,
 	document_lookup_id integer NOT NULL,

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_write.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_write.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"sort"
 	"sync/atomic"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/batch"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -208,7 +210,7 @@ func (s *scipWriter) flush(ctx context.Context) error {
 			"payload_hash",
 			"raw_scip_payload",
 		},
-		"",
+		"ON CONFLICT DO NOTHING",
 		"id",
 		func(inserter *batch.Inserter) error {
 			for _, document := range documents {
@@ -224,7 +226,21 @@ func (s *scipWriter) flush(ctx context.Context) error {
 		return err
 	}
 	if len(documentIDs) != len(documents) {
-		return errors.New("unexpected number of document records inserted")
+		hashes := make([][]byte, 0, len(documents))
+		for _, document := range documents {
+			hashes = append(hashes, document.payloadHash)
+		}
+		idsByHash, err := scanIDsByHash(s.db.Query(ctx, sqlf.Sprintf(scipWriterWriteFetchDocumentsQuery, pq.Array(hashes))))
+		if err != nil {
+			return err
+		}
+		documentIDs = documentIDs[:0]
+		for _, document := range documents {
+			documentIDs = append(documentIDs, idsByHash[hex.EncodeToString(document.payloadHash)])
+		}
+		if len(idsByHash) != len(documents) {
+			return errors.New("unexpected number of document records inserted/retrieved")
+		}
 	}
 
 	documentLookupIDs, err := batch.WithInserterForIdentifiers(
@@ -343,6 +359,14 @@ func (s *scipWriter) flush(ctx context.Context) error {
 	return nil
 }
 
+const scipWriterWriteFetchDocumentsQuery = `
+SELECT
+	encode(payload_hash, 'hex'),
+	id
+FROM codeintel_scip_documents
+WHERE payload_hash = ANY(%s)
+`
+
 func (s *scipWriter) Flush(ctx context.Context) (uint32, error) {
 	// Flush all buffered documents
 	if err := s.flush(ctx); err != nil {
@@ -412,3 +436,8 @@ func hashPayload(payload []byte) []byte {
 	_, _ = hash.Write(payload)
 	return hash.Sum(nil)
 }
+
+var scanIDsByHash = basestore.NewMapScanner(func(s dbutil.Scanner) (hash string, id int, _ error) {
+	err := s.Scan(&hash, &id)
+	return hash, id, err
+})

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_write_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_write_test.go
@@ -31,8 +31,6 @@ func TestInsertMetadata(t *testing.T) {
 }
 
 func TestInsertSharedDocumentsConcurrently(t *testing.T) {
-	t.Skip()
-
 	logger := logtest.Scoped(t)
 	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(logger, t))
 	store := New(&observation.TestContext, codeIntelDB)

--- a/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
@@ -535,6 +535,12 @@ func (s *scipWriter) flush(ctx context.Context) (err error) {
 	s.batch = nil
 	s.batchPayloadSum = 0
 
+	// NOTE: This logic differs from similar logic in scip_write.go when processing SCIP uploads.
+	// In that scenario, we have to be careful of inserting a row with an existing `payload_hash`.
+	// Because we have a unique prefix containing the upload ID here, and we have no expectation
+	// that interned LSIF graphs will produce the same SCIP document, there should be no expected
+	// collisions on insertion here.
+
 	documentIDs, err := batch.WithInserterForIdentifiers(
 		ctx,
 		s.tx.Handle(),


### PR DESCRIPTION
I messed up in #45665. We had the following _lovely_ query which I removed without sufficient testing (I actually disabled and forgot to re-enable a test, and it made it into the PR).

```go
const insertSCIPDocumentQuery = `
WITH
new_shared_document AS (
	INSERT INTO codeintel_scip_documents (schema_version, payload_hash, raw_scip_payload)
	VALUES (%s, %s, %s)
	ON CONFLICT DO NOTHING
	RETURNING id
),
shared_document AS (
	SELECT id FROM new_shared_document
	UNION ALL
	SELECT id FROM codeintel_scip_documents WHERE payload_hash = %s
)
INSERT INTO codeintel_scip_document_lookup (upload_id, document_path, document_id)
SELECT %s, %s, id FROM shared_document LIMIT 1
RETURNING id
`
```

This PR restores the behavior that was removed along with this query. We keep the batch insert technique introduced in the linked PR, but will issue a secondary fetch for the identifiers of the documents in the batch if some had a conflict.

## Test plan

Re-enabled unit test.