### PR TITLE
migrator: print extra postgres error details on migration failure

### DIFF
--- a/internal/database/migration/runner/run.go
+++ b/internal/database/migration/runner/run.go
@@ -592,7 +592,6 @@ func renderQuery(definition definition.Definition, up bool) string {
 	}
 
 	return query.Query(sqlf.PostgresBindVar)
-
 }
 
 // hashDefinitionIDs returns a deterministic hash of the given definition IDs.

--- a/internal/database/migration/store/store.go
+++ b/internal/database/migration/store/store.go
@@ -333,12 +333,43 @@ func (s *Store) lockKey() int32 {
 	return locker.StringKey(fmt.Sprintf("%s:migrations", s.schemaName))
 }
 
+type wrappedPgError struct {
+	*pgconn.PgError
+}
+
+func (w wrappedPgError) Error() string {
+	var s strings.Builder
+
+	s.WriteString(w.PgError.Error())
+
+	if w.Detail != "" {
+		s.WriteRune('\n')
+		s.WriteString("DETAIL: ")
+		s.WriteString(w.Detail)
+	}
+
+	if w.Hint != "" {
+		s.WriteRune('\n')
+		s.WriteString("HINT: ")
+		s.WriteString(w.Hint)
+	}
+
+	return s.String()
+}
+
 // Up runs the given definition's up query.
 func (s *Store) Up(ctx context.Context, definition definition.Definition) (err error) {
 	ctx, _, endObservation := s.operations.up.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	return s.Exec(ctx, definition.UpQuery)
+	err = s.Exec(ctx, definition.UpQuery)
+
+	var pgError *pgconn.PgError
+	if errors.As(err, &pgError) {
+		return wrappedPgError{pgError}
+	}
+
+	return
 }
 
 // Down runs the given definition's down query.
@@ -346,7 +377,14 @@ func (s *Store) Down(ctx context.Context, definition definition.Definition) (err
 	ctx, _, endObservation := s.operations.down.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	return s.Exec(ctx, definition.DownQuery)
+	err = s.Exec(ctx, definition.UpQuery)
+
+	var pgError *pgconn.PgError
+	if errors.As(err, &pgError) {
+		return wrappedPgError{pgError}
+	}
+
+	return
 }
 
 // IndexStatus returns an object describing the current validity status and creation progress of the

--- a/internal/database/migration/store/store.go
+++ b/internal/database/migration/store/store.go
@@ -377,7 +377,7 @@ func (s *Store) Down(ctx context.Context, definition definition.Definition) (err
 	ctx, _, endObservation := s.operations.down.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	err = s.Exec(ctx, definition.UpQuery)
+	err = s.Exec(ctx, definition.DownQuery)
 
 	var pgError *pgconn.PgError
 	if errors.As(err, &pgError) {

--- a/internal/database/migration/store/store_test.go
+++ b/internal/database/migration/store/store_test.go
@@ -389,7 +389,7 @@ func TestWrappedUp(t *testing.T) {
 	})
 
 	t.Run("query failure", func(t *testing.T) {
-		expectedErrorMessage := "SQL Error"
+		expectedErrorMessage := "ERROR: relation"
 
 		definition := definition.Definition{
 			ID: 17,
@@ -522,7 +522,7 @@ func TestWrappedDown(t *testing.T) {
 	})
 
 	t.Run("query failure", func(t *testing.T) {
-		expectedErrorMessage := "SQL Error"
+		expectedErrorMessage := "ERROR: syntax error at or near"
 
 		definition := definition.Definition{
 			ID: 13,


### PR DESCRIPTION
Postgres errors may contain additional information (as part of the `details` and `hint` struct fields) that were not being printed here. 

<details>
<summary>Before</summary>

```
❌ failed to run migration for schema "frontend": failed to apply migration 1670600028:

-- LOADS OF SQL HERE
: ERROR: duplicate key value violates unique constraint "executor_secret_access_logs_pkey" (SQLSTATE 23505)
```
</details>

<details>
<summary>After</summary>

```
❌ failed to run migration for schema "frontend": failed to apply migration 1670600028:

-- LOADS OF SQL HERE
: ERROR: duplicate key value violates unique constraint "executor_secret_access_logs_pkey" (SQLSTATE 23505)
DETAIL: Key (id)=(420) already exists.
HINT: This up-migration attempts to re-insert executor secret access logs from a backup table that would have lost information due to the associated down-migration changing the table schema. In doing so, a unique violation exception occurred and will have to be resolved manually. The backed up access logs are stored in the executor_secret_access_logs_machineuser_bak_1670600028 table.
```

</details>


## Test plan

Ran it locally, inspected variables in debugger :eye: 
