### PR TITLE
codeintel: Slap an `ORDER BY` on that baby

### DIFF
--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_monikers.go
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_monikers.go
@@ -299,6 +299,7 @@ WITH RECURSIVE
 	ORDER BY
 		(ss.upload_id, msn.symbol_name)
 )
+ORDER BY dump_id, scheme, identifier
 `
 
 func monikersToString(vs []precise.MonikerData) string {


### PR DESCRIPTION
`UNION ALL` does not keep order, while `UNION` does. When choosing `UNION ALL` to reduce duplicates, we threw out order. I think non-determinism in the result ordering over multiple pages has started to cause flakes in the codeintel-qa test suite.

## Test plan

Unit tests pass.