### PR TITLE
Feature Flags: reduce DB roundtrips

### DIFF
--- a/internal/database/feature_flags.go
+++ b/internal/database/feature_flags.go
@@ -180,6 +180,50 @@ func (f *featureFlagStore) CreateBool(ctx context.Context, name string, value bo
 
 var ErrInvalidColumnState = errors.New("encountered column that is unexpectedly null based on column type")
 
+func scanFeatureFlagAndOverride(scanner dbutil.Scanner) (*ff.FeatureFlag, *bool, error) {
+	var (
+		res      ff.FeatureFlag
+		flagType string
+		boolVal  *bool
+		rollout  *int32
+		override *bool
+	)
+	err := scanner.Scan(
+		&res.Name,
+		&flagType,
+		&boolVal,
+		&rollout,
+		&res.CreatedAt,
+		&res.UpdatedAt,
+		&res.DeletedAt,
+		&override,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	switch flagType {
+	case "bool":
+		if boolVal == nil {
+			return nil, nil, ErrInvalidColumnState
+		}
+		res.Bool = &ff.FeatureFlagBool{
+			Value: *boolVal,
+		}
+	case "rollout":
+		if rollout == nil {
+			return nil, nil, ErrInvalidColumnState
+		}
+		res.Rollout = &ff.FeatureFlagRollout{
+			Rollout: *rollout,
+		}
+	default:
+		return nil, nil, ErrInvalidColumnState
+	}
+
+	return &res, override, nil
+}
+
 func scanFeatureFlag(scanner dbutil.Scanner) (*ff.FeatureFlag, error) {
 	var (
 		res      ff.FeatureFlag
@@ -474,50 +518,62 @@ func scanFeatureFlagOverride(scanner dbutil.Scanner) (*ff.Override, error) {
 // be the primary entrypoint for getting the user flags since it handles retrieving all the flags,
 // the org overrides, and the user overrides, and merges them in priority order.
 func (f *featureFlagStore) GetUserFlags(ctx context.Context, userID int32) (map[string]bool, error) {
-	g, ctx := errgroup.WithContext(ctx)
-
-	var flags []*ff.FeatureFlag
-	g.Go(func() error {
-		res, err := f.GetFeatureFlags(ctx)
-		flags = res
-		return err
-	})
-
-	var orgOverrides []*ff.Override
-	g.Go(func() error {
-		res, err := f.GetOrgOverridesForUser(ctx, userID)
-		orgOverrides = res
-		return err
-	})
-
-	var userOverrides []*ff.Override
-	g.Go(func() error {
-		res, err := f.GetUserOverrides(ctx, userID)
-		userOverrides = res
-		return err
-	})
-
-	if err := g.Wait(); err != nil {
+	const listUserOverridesFmtString = `
+		WITH user_overrides AS (
+			SELECT
+				flag_name,
+				flag_value
+			FROM feature_flag_overrides
+			WHERE namespace_user_id = %s
+				AND deleted_at IS NULL
+		), org_overrides AS (
+			SELECT
+				flag_name,
+				-- We only want one org override to apply, so just take the last-created one
+				LAST_VALUE(flag_value) OVER (PARTITION BY flag_name ORDER BY created_at) AS flag_value
+			FROM feature_flag_overrides
+			WHERE EXISTS (
+				SELECT org_id
+				FROM org_members
+				WHERE org_members.user_id = %s
+					AND feature_flag_overrides.namespace_org_id = org_members.org_id
+			) AND deleted_at IS NULL
+		)
+		SELECT
+			ff.flag_name,
+			flag_type,
+			bool_value,
+			rollout,
+			created_at,
+			updated_at,
+			deleted_at,
+			-- We prioritize user overrides over org overrides.
+			-- If neither exist override will be NULL.
+			COALESCE(uo.flag_value, oo.flag_value) AS override
+		FROM feature_flags ff
+		LEFT JOIN org_overrides oo ON ff.flag_name = oo.flag_name
+		LEFT JOIN user_overrides uo ON ff.flag_name = uo.flag_name
+		WHERE deleted_at IS NULL
+	`
+	rows, err := f.Query(ctx, sqlf.Sprintf(listUserOverridesFmtString, userID, userID))
+	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
-	res := make(map[string]bool, len(flags))
-
-	for _, ff := range flags {
-		res[ff.Name] = ff.EvaluateForUser(userID)
+	res := make(map[string]bool)
+	for rows.Next() {
+		ff, override, err := scanFeatureFlagAndOverride(rows)
+		if err != nil {
+			return nil, err
+		}
+		if override != nil {
+			res[ff.Name] = *override
+		} else {
+			res[ff.Name] = ff.EvaluateForUser(userID)
+		}
 	}
-
-	// Org overrides are higher priority than default
-	for _, oo := range orgOverrides {
-		res[oo.FlagName] = oo.Value
-	}
-
-	// User overrides are higher priority than org overrides
-	for _, uo := range userOverrides {
-		res[uo.FlagName] = uo.Value
-	}
-
-	return res, nil
+	return res, rows.Err()
 }
 
 // GetAnonymousUserFlags returns the calculated values for feature flags for the given anonymousUID

--- a/internal/database/feature_flags_test.go
+++ b/internal/database/feature_flags_test.go
@@ -505,6 +505,22 @@ func testUserFlags(t *testing.T) {
 		require.Equal(t, expected, got)
 	})
 
+	t.Run("newer org override beats older org override", func(t *testing.T) {
+		t.Cleanup(cleanup(t, db))
+		o1 := mkOrg("o1")
+		o2 := mkOrg("o2")
+		u1 := mkUser("u", o1.ID, o2.ID)
+		mkFFBoolVar("f1", 10000)
+		mkFFBoolVar("f2", 0)
+		mkOrgOverride(o1.ID, "f2", true)
+		mkOrgOverride(o2.ID, "f2", false)
+
+		got, err := flagStore.GetUserFlags(ctx, u1.ID)
+		require.NoError(t, err)
+		expected := map[string]bool{"f1": true, "f2": false}
+		require.Equal(t, expected, got)
+	})
+
 	t.Run("delete flag with override", func(t *testing.T) {
 		t.Cleanup(cleanup(t, db))
 		o1 := mkOrg("o1")


### PR DESCRIPTION
Previously, we made three different DB roundtrips to calculate feature flags for a user. One to get the list of defined feature flags, one to get the list of user-specific overrides, and one to get the list of org-specific overrides. We did this concurrently for performance. However, doing this concurrently meant we frequently hit the "no concurrent transactions" errors and log messages.

This updates our feature flag evaluation to use only a single database query, joining the overrides with the defined flags in one fell swoop.

## Test plan

Existing tests are quite extensive. I added one test to check test stable priority when multiple org overrides exist.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
