### PR TITLE
rbac: Create store methods for roles and permissions (Part 3)

### DIFF
--- a/enterprise/internal/database/mocks_temp.go
+++ b/enterprise/internal/database/mocks_temp.go
@@ -6880,6 +6880,9 @@ type MockEnterpriseDB struct {
 	// OrgsFunc is an instance of a mock function object controlling the
 	// behavior of the method Orgs.
 	OrgsFunc *EnterpriseDBOrgsFunc
+	// PermissionsFunc is an instance of a mock function object controlling
+	// the behavior of the method Permissions.
+	PermissionsFunc *EnterpriseDBPermissionsFunc
 	// PermsFunc is an instance of a mock function object controlling the
 	// behavior of the method Perms.
 	PermsFunc *EnterpriseDBPermsFunc
@@ -7059,6 +7062,11 @@ func NewMockEnterpriseDB() *MockEnterpriseDB {
 		},
 		OrgsFunc: &EnterpriseDBOrgsFunc{
 			defaultHook: func() (r0 database.OrgStore) {
+				return
+			},
+		},
+		PermissionsFunc: &EnterpriseDBPermissionsFunc{
+			defaultHook: func() (r0 database.PermissionStore) {
 				return
 			},
 		},
@@ -7289,6 +7297,11 @@ func NewStrictMockEnterpriseDB() *MockEnterpriseDB {
 				panic("unexpected invocation of MockEnterpriseDB.Orgs")
 			},
 		},
+		PermissionsFunc: &EnterpriseDBPermissionsFunc{
+			defaultHook: func() database.PermissionStore {
+				panic("unexpected invocation of MockEnterpriseDB.Permissions")
+			},
+		},
 		PermsFunc: &EnterpriseDBPermsFunc{
 			defaultHook: func() PermsStore {
 				panic("unexpected invocation of MockEnterpriseDB.Perms")
@@ -7472,6 +7485,9 @@ func NewMockEnterpriseDBFrom(i EnterpriseDB) *MockEnterpriseDB {
 		},
 		OrgsFunc: &EnterpriseDBOrgsFunc{
 			defaultHook: i.Orgs,
+		},
+		PermissionsFunc: &EnterpriseDBPermissionsFunc{
+			defaultHook: i.Permissions,
 		},
 		PermsFunc: &EnterpriseDBPermsFunc{
 			defaultHook: i.Perms,
@@ -9750,6 +9766,105 @@ func (c EnterpriseDBOrgsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c EnterpriseDBOrgsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// EnterpriseDBPermissionsFunc describes the behavior when the Permissions
+// method of the parent MockEnterpriseDB instance is invoked.
+type EnterpriseDBPermissionsFunc struct {
+	defaultHook func() database.PermissionStore
+	hooks       []func() database.PermissionStore
+	history     []EnterpriseDBPermissionsFuncCall
+	mutex       sync.Mutex
+}
+
+// Permissions delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockEnterpriseDB) Permissions() database.PermissionStore {
+	r0 := m.PermissionsFunc.nextHook()()
+	m.PermissionsFunc.appendCall(EnterpriseDBPermissionsFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the Permissions method
+// of the parent MockEnterpriseDB instance is invoked and the hook queue is
+// empty.
+func (f *EnterpriseDBPermissionsFunc) SetDefaultHook(hook func() database.PermissionStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Permissions method of the parent MockEnterpriseDB instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *EnterpriseDBPermissionsFunc) PushHook(hook func() database.PermissionStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *EnterpriseDBPermissionsFunc) SetDefaultReturn(r0 database.PermissionStore) {
+	f.SetDefaultHook(func() database.PermissionStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *EnterpriseDBPermissionsFunc) PushReturn(r0 database.PermissionStore) {
+	f.PushHook(func() database.PermissionStore {
+		return r0
+	})
+}
+
+func (f *EnterpriseDBPermissionsFunc) nextHook() func() database.PermissionStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *EnterpriseDBPermissionsFunc) appendCall(r0 EnterpriseDBPermissionsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of EnterpriseDBPermissionsFuncCall objects
+// describing the invocations of this function.
+func (f *EnterpriseDBPermissionsFunc) History() []EnterpriseDBPermissionsFuncCall {
+	f.mutex.Lock()
+	history := make([]EnterpriseDBPermissionsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// EnterpriseDBPermissionsFuncCall is an object that describes an invocation
+// of method Permissions on an instance of MockEnterpriseDB.
+type EnterpriseDBPermissionsFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 database.PermissionStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c EnterpriseDBPermissionsFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c EnterpriseDBPermissionsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/CODENOTIFY
+++ b/internal/database/CODENOTIFY
@@ -3,3 +3,5 @@
 external* @eseliger
 namespaces* @eseliger
 repos* @eseliger @unknwon
+permission* @BolajiOlajide
+user_roles* @BolajiOlajide

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -36,6 +36,7 @@ type DB interface {
 	OrgMembers() OrgMemberStore
 	Orgs() OrgStore
 	OrgStats() OrgStatsStore
+	Permissions() PermissionStore
 	Phabricator() PhabricatorStore
 	Repos() RepoStore
 	RepoKVPs() RepoKVPStore
@@ -164,6 +165,10 @@ func (d *db) Orgs() OrgStore {
 
 func (d *db) OrgStats() OrgStatsStore {
 	return OrgStatsWith(d.Store)
+}
+
+func (d *db) Permissions() PermissionStore {
+	return &permissionStore{Store: d.Store}
 }
 
 func (d *db) Phabricator() PhabricatorStore {

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -3683,6 +3683,9 @@ type MockDB struct {
 	// OrgsFunc is an instance of a mock function object controlling the
 	// behavior of the method Orgs.
 	OrgsFunc *DBOrgsFunc
+	// PermissionsFunc is an instance of a mock function object controlling
+	// the behavior of the method Permissions.
+	PermissionsFunc *DBPermissionsFunc
 	// PhabricatorFunc is an instance of a mock function object controlling
 	// the behavior of the method Phabricator.
 	PhabricatorFunc *DBPhabricatorFunc
@@ -3854,6 +3857,11 @@ func NewMockDB() *MockDB {
 		},
 		OrgsFunc: &DBOrgsFunc{
 			defaultHook: func() (r0 OrgStore) {
+				return
+			},
+		},
+		PermissionsFunc: &DBPermissionsFunc{
+			defaultHook: func() (r0 PermissionStore) {
 				return
 			},
 		},
@@ -4074,6 +4082,11 @@ func NewStrictMockDB() *MockDB {
 				panic("unexpected invocation of MockDB.Orgs")
 			},
 		},
+		PermissionsFunc: &DBPermissionsFunc{
+			defaultHook: func() PermissionStore {
+				panic("unexpected invocation of MockDB.Permissions")
+			},
+		},
 		PhabricatorFunc: &DBPhabricatorFunc{
 			defaultHook: func() PhabricatorStore {
 				panic("unexpected invocation of MockDB.Phabricator")
@@ -4248,6 +4261,9 @@ func NewMockDBFrom(i DB) *MockDB {
 		},
 		OrgsFunc: &DBOrgsFunc{
 			defaultHook: i.Orgs,
+		},
+		PermissionsFunc: &DBPermissionsFunc{
+			defaultHook: i.Permissions,
 		},
 		PhabricatorFunc: &DBPhabricatorFunc{
 			defaultHook: i.Phabricator,
@@ -6404,6 +6420,104 @@ func (c DBOrgsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c DBOrgsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// DBPermissionsFunc describes the behavior when the Permissions method of
+// the parent MockDB instance is invoked.
+type DBPermissionsFunc struct {
+	defaultHook func() PermissionStore
+	hooks       []func() PermissionStore
+	history     []DBPermissionsFuncCall
+	mutex       sync.Mutex
+}
+
+// Permissions delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockDB) Permissions() PermissionStore {
+	r0 := m.PermissionsFunc.nextHook()()
+	m.PermissionsFunc.appendCall(DBPermissionsFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the Permissions method
+// of the parent MockDB instance is invoked and the hook queue is empty.
+func (f *DBPermissionsFunc) SetDefaultHook(hook func() PermissionStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Permissions method of the parent MockDB instance invokes the hook at the
+// front of the queue and discards it. After the queue is empty, the default
+// hook function is invoked for any future action.
+func (f *DBPermissionsFunc) PushHook(hook func() PermissionStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *DBPermissionsFunc) SetDefaultReturn(r0 PermissionStore) {
+	f.SetDefaultHook(func() PermissionStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *DBPermissionsFunc) PushReturn(r0 PermissionStore) {
+	f.PushHook(func() PermissionStore {
+		return r0
+	})
+}
+
+func (f *DBPermissionsFunc) nextHook() func() PermissionStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBPermissionsFunc) appendCall(r0 DBPermissionsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBPermissionsFuncCall objects describing
+// the invocations of this function.
+func (f *DBPermissionsFunc) History() []DBPermissionsFuncCall {
+	f.mutex.Lock()
+	history := make([]DBPermissionsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBPermissionsFuncCall is an object that describes an invocation of method
+// Permissions on an instance of MockDB.
+type DBPermissionsFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 PermissionStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DBPermissionsFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBPermissionsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/permissions.go
+++ b/internal/database/permissions.go
@@ -176,7 +176,11 @@ func (p *permissionStore) GetByID(ctx context.Context, opts GetPermissionOpts) (
 		return nil, errors.New("missing id from sql query")
 	}
 
-	q := sqlf.Sprintf(getPermissionQueryFmtStr, opts.ID)
+	q := sqlf.Sprintf(
+		getPermissionQueryFmtStr,
+		sqlf.Join(permissionColumns, ", "),
+		opts.ID,
+	)
 
 	permission, err := scanPermission(p.QueryRow(ctx, q))
 	if err != nil {

--- a/internal/database/permissions.go
+++ b/internal/database/permissions.go
@@ -1,0 +1,214 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var permissionColumns = []*sqlf.Query{
+	sqlf.Sprintf("permissions.id"),
+	sqlf.Sprintf("permissions.namespace"),
+	sqlf.Sprintf("permissions.action"),
+	sqlf.Sprintf("permissions.created_at"),
+}
+
+var permissionInsertColumns = []*sqlf.Query{
+	sqlf.Sprintf("namespace"),
+	sqlf.Sprintf("action"),
+}
+
+type PermissionStore interface {
+	basestore.ShareableStore
+
+	// Create inserts the given permission into the database.
+	Create(ctx context.Context, opts CreatePermissionOpts) (*types.Permission, error)
+	// BulkCreate inserts multiple permissions into the database
+	BulkCreate(ctx context.Context, opts []CreatePermissionOpts) ([]*types.Permission, error)
+	// Delete deletes a permission with the provided ID
+	Delete(ctx context.Context, opts DeletePermissionOpts) error
+	// GetByID returns the permission matching the given ID, or PermissionNotFoundErr if no such record exists.
+	GetByID(ctx context.Context, opts GetPermissionOpts) (*types.Permission, error)
+	// List returns all the permissions in the database.
+	List(ctx context.Context) ([]*types.Permission, error)
+}
+
+type CreatePermissionOpts struct {
+	Namespace string
+	Action    string
+}
+
+type PermissionOpts struct {
+	ID int32
+}
+
+type (
+	GetPermissionOpts    PermissionOpts
+	DeletePermissionOpts PermissionOpts
+)
+
+type PermissionNotFoundErr struct {
+	ID int32
+}
+
+func (p *PermissionNotFoundErr) Error() string {
+	return fmt.Sprintf("permission with ID %d not found", p.ID)
+}
+
+func (p *PermissionNotFoundErr) NotFound() bool {
+	return true
+}
+
+type permissionStore struct {
+	*basestore.Store
+}
+
+var _ PermissionStore = &permissionStore{}
+
+const permissionCreateQueryFmtStr = `
+INSERT INTO
+	permissions(%s)
+	VALUES %S
+	RETURNING %s
+`
+
+func (p *permissionStore) Create(ctx context.Context, opts CreatePermissionOpts) (*types.Permission, error) {
+	q := sqlf.Sprintf(
+		permissionCreateQueryFmtStr,
+		sqlf.Join(permissionInsertColumns, ", "),
+		sqlf.Sprintf("(%s, %s)", opts.Namespace, opts.Action),
+		sqlf.Join(permissionColumns, ", "),
+	)
+
+	permission, err := scanPermission(p.QueryRow(ctx, q))
+	if err != nil {
+		return nil, errors.Wrap(err, "scanning role")
+	}
+
+	return permission, nil
+}
+
+func scanPermission(sc dbutil.Scanner) (*types.Permission, error) {
+	var perm types.Permission
+	if err := sc.Scan(
+		&perm.ID,
+		&perm.Namespace,
+		&perm.Action,
+		&perm.CreatedAt,
+	); err != nil {
+		return nil, err
+	}
+
+	return &perm, nil
+}
+
+func (p *permissionStore) BulkCreate(ctx context.Context, opts []CreatePermissionOpts) ([]*types.Permission, error) {
+	var values []*sqlf.Query
+	for _, opt := range opts {
+		values = append(values, sqlf.Sprintf("(%s, %s)", opt.Namespace, opt.Action))
+	}
+
+	q := sqlf.Sprintf(
+		permissionCreateQueryFmtStr,
+		sqlf.Join(permissionInsertColumns, ", "),
+		sqlf.Join(values, ", "),
+		sqlf.Join(permissionColumns, ", "),
+	)
+
+	var perms []*types.Permission
+	rows, err := p.Query(ctx, q)
+	if err != nil {
+		return nil, errors.Wrap(err, "error running query")
+	}
+	defer rows.Close()
+	for rows.Next() {
+		perm, err := scanPermission(rows)
+		if err != nil {
+			return nil, err
+		}
+		perms = append(perms, perm)
+	}
+
+	return perms, rows.Err()
+}
+
+const permissionDeleteQueryFmtStr = `
+DELETE FROM permissions
+WHERE %s
+`
+
+func (p *permissionStore) Delete(ctx context.Context, opts DeletePermissionOpts) error {
+	if opts.ID == 0 {
+		return errors.New("missing id from sql query")
+	}
+
+	q := sqlf.Sprintf(permissionDeleteQueryFmtStr, sqlf.Sprintf("id = %s", opts.ID))
+	result, err := p.ExecResult(ctx, q)
+	if err != nil {
+		return errors.Wrap(err, "running delete query")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "checking deleted rows")
+	}
+
+	if rowsAffected == 0 {
+		return errors.Wrap(&RoleNotFoundErr{opts.ID}, "failed to delete permission")
+	}
+	return nil
+}
+
+const getPermissionQueryFmtStr = `
+SELECT %s FROM permissions
+WHERE id = %s;
+`
+
+func (p *permissionStore) GetByID(ctx context.Context, opts GetPermissionOpts) (*types.Permission, error) {
+	if opts.ID == 0 {
+		return nil, errors.New("missing id from sql query")
+	}
+
+	q := sqlf.Sprintf(getPermissionQueryFmtStr, opts.ID)
+
+	permission, err := scanPermission(p.QueryRow(ctx, q))
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, &PermissionNotFoundErr{ID: opts.ID}
+		}
+		return nil, errors.Wrap(err, "scanning permission")
+	}
+
+	return permission, nil
+}
+
+const permissionListQueryFmtStr = `
+SELECT * FROM permissions
+ORDER BY permissions.namespace ASC
+`
+
+func (p *permissionStore) List(ctx context.Context) ([]*types.Permission, error) {
+	var permissions []*types.Permission
+	rows, err := p.Query(ctx, sqlf.Sprintf(permissionListQueryFmtStr))
+	if err != nil {
+		return nil, errors.Wrap(err, "error running query")
+	}
+
+	defer rows.Close()
+	for rows.Next() {
+		perm, err := scanPermission(rows)
+		if err != nil {
+			return nil, err
+		}
+		permissions = append(permissions, perm)
+	}
+
+	return permissions, rows.Err()
+}

--- a/internal/database/permissions_test.go
+++ b/internal/database/permissions_test.go
@@ -1,0 +1,1 @@
+package database

--- a/internal/database/permissions_test.go
+++ b/internal/database/permissions_test.go
@@ -1,1 +1,150 @@
 package database
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+)
+
+func TestPermissionGetByID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	store := db.Permissions()
+
+	created, err := store.Create(ctx, CreatePermissionOpts{
+		Namespace: "BATCHCHANGES",
+		Action:    "READ",
+	})
+	if err != nil {
+		t.Fatal(err, "unable to create permission")
+	}
+
+	t.Run("no ID", func(t *testing.T) {
+		p, err := store.GetByID(ctx, GetPermissionOpts{})
+		assert.Error(t, err)
+		assert.Nil(t, p)
+		assert.Equal(t, err.Error(), "missing id from sql query")
+	})
+
+	t.Run("non-existent permission", func(t *testing.T) {
+		p, err := store.GetByID(ctx, GetPermissionOpts{ID: 100})
+		assert.Error(t, err)
+		assert.EqualError(t, err, "permission with ID 100 not found")
+		assert.Nil(t, p)
+	})
+
+	t.Run("existing permission", func(t *testing.T) {
+		permission, err := store.GetByID(ctx, GetPermissionOpts{ID: created.ID})
+		assert.NoError(t, err)
+		assert.NotNil(t, permission)
+		assert.Equal(t, permission.ID, created.ID)
+		assert.Equal(t, permission.Namespace, created.Namespace)
+		assert.Equal(t, permission.Action, created.Action)
+	})
+}
+
+func TestPermissionCreate(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	store := db.Permissions()
+
+	_, err := store.Create(ctx, CreatePermissionOpts{
+		Namespace: "BATCHCHANGES",
+		Action:    "READ",
+	})
+	assert.NoError(t, err)
+}
+
+func TestPermissionList(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	store := db.Permissions()
+
+	totalPerms := 10
+	for i := 1; i <= totalPerms; i++ {
+		_, err := store.Create(ctx, CreatePermissionOpts{
+			Namespace: fmt.Sprintf("PERMISSION-%d", i),
+			Action:    "READ",
+		})
+		assert.NoError(t, err)
+	}
+
+	ps, err := store.List(ctx)
+	assert.NoError(t, err)
+	assert.Len(t, ps, totalPerms)
+}
+
+func TestPermissionDelete(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	store := db.Permissions()
+
+	p, err := store.Create(ctx, CreatePermissionOpts{
+		Namespace: "BATCHCHANGES",
+		Action:    "READ",
+	})
+	assert.NoError(t, err)
+
+	t.Run("no ID", func(t *testing.T) {
+		err := store.Delete(ctx, DeletePermissionOpts{})
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "missing id from sql query")
+	})
+
+	t.Run("existing role", func(t *testing.T) {
+		err = store.Delete(ctx, DeletePermissionOpts{p.ID})
+		assert.NoError(t, err)
+
+		deleted, err := store.GetByID(ctx, GetPermissionOpts{ID: p.ID})
+		assert.Nil(t, deleted)
+		assert.Error(t, err)
+		assert.Equal(t, err, &PermissionNotFoundErr{p.ID})
+	})
+
+	t.Run("non-existent role", func(t *testing.T) {
+		nonExistentRoleID := int32(2381)
+		err := store.Delete(ctx, DeletePermissionOpts{nonExistentRoleID})
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "failed to delete permission")
+	})
+}
+
+func TestPermissionBulkCreate(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	store := db.Permissions()
+
+	var perms []CreatePermissionOpts
+	for i := 1; i <= 5; i++ {
+		var action string
+		if i%2 == 0 {
+			action = "READ"
+		} else {
+			action = "WRITE"
+		}
+		perms = append(perms, CreatePermissionOpts{
+			Action:    action,
+			Namespace: fmt.Sprintf("namespace-%d", i),
+		})
+	}
+
+	ps, err := store.BulkCreate(ctx, perms)
+	assert.NoError(t, err)
+	assert.NotNil(t, ps)
+	assert.Len(t, ps, 5)
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -800,7 +800,6 @@ type Permission struct {
 	Action    string
 	CreatedAt time.Time
 }
-
 type OrgMemberAutocompleteSearchItem struct {
 	ID          int32
 	Username    string


### PR DESCRIPTION
Part 3 [#45456](https://github.com/sourcegraph/sourcegraph/issues/45456)

This adds store methods for permissions.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Added unit tests for store methods