### PR TITLE
Backport flakes from 4.2.x which were added in between 13 and now 

### DIFF
--- a/dev/ci/go-backcompat/flakefiles/v4.3.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.3.0.json
@@ -1,5 +1,10 @@
 [
   {
+    "path": "enterprise/internal/batches/store",
+    "prefix": "TestIntegration",
+    "reason": "Added a UNIQUE constraint on batch_specs.rand_id and changeset_specs.rand_id, some tests fail because we had some duplicate Rand ID creation in tests."
+  },
+  {
     "path": "enterprise/cmd/frontend/internal/batches/webhooks",
     "prefix": "TestWebhooksIntegration",
     "reason": "Test was having incomplete data, fails now that constraints are in place"

--- a/dev/ci/go-backcompat/flakefiles/v4.3.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.3.0.json
@@ -23,5 +23,55 @@
     "path": "enterprise/cmd/frontend/internal/batches/resolvers",
     "prefix": "TestRepositoryPermissions",
     "reason": "Test was having incomplete data, fails now that constraints are in place"
+  },
+  {
+    "path": "enterprise/internal/codeintel/codenav/internal/lsifstore",
+    "prefix": "TestDatabaseExists",
+    "reason": "Dropped symbol_name column on codeintel_scip_symbols"
+  },
+  {
+    "path": "enterprise/internal/codeintel/codenav/internal/lsifstore",
+    "prefix": "TestDatabaseHover",
+    "reason": "Dropped symbol_name column on codeintel_scip_symbols"
+  },
+  {
+    "path": "enterprise/internal/codeintel/codenav/internal/lsifstore",
+    "prefix": "TestDatabaseDefinitions",
+    "reason": "Dropped symbol_name column on codeintel_scip_symbols"
+  },
+  {
+    "path": "enterprise/internal/codeintel/codenav/internal/lsifstore",
+    "prefix": "TestDatabaseReferences",
+    "reason": "Dropped symbol_name column on codeintel_scip_symbols"
+  },
+  {
+    "path": "enterprise/internal/codeintel/codenav/internal/lsifstore",
+    "prefix": "TestDatabaseMonikersByPosition",
+    "reason": "Dropped symbol_name column on codeintel_scip_symbols"
+  },
+  {
+    "path": "enterprise/internal/codeintel/codenav/internal/lsifstore",
+    "prefix": "TestGetBulkMonikerLocations",
+    "reason": "Dropped symbol_name column on codeintel_scip_symbols"
+  },
+  {
+    "path": "enterprise/internal/codeintel/codenav/internal/lsifstore",
+    "prefix": "TestGetPackageInformation",
+    "reason": "Dropped symbol_name column on codeintel_scip_symbols"
+  },
+  {
+    "path": "enterprise/internal/codeintel/codenav/internal/lsifstore",
+    "prefix": "TestGetRanges",
+    "reason": "Dropped symbol_name column on codeintel_scip_symbols"
+  },
+  {
+    "path": "enterprise/internal/codeintel/codenav/internal/lsifstore",
+    "prefix": "TestStencil",
+    "reason": "Dropped symbol_name column on codeintel_scip_symbols"
+  },
+  {
+    "path": "enterprise/internal/codeintel/codenav/internal/lsifstore",
+    "prefix": "TestWriteSCIPSymbols",
+    "reason": "Dropped symbol_name column on codeintel_scip_symbols"
   }
 ]

--- a/dev/ci/go-backcompat/flakefiles/v4.3.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.3.0.json
@@ -1,0 +1,22 @@
+[
+  {
+    "path": "enterprise/internal/batches/store",
+    "prefix": "TestDeleteExpiredChangesetSpecs",
+    "reason": "Dropped IDs from batch changes table"
+  },
+  {
+    "path": "enterprise/cmd/frontend/internal/batches/resolvers",
+    "prefix": "TestChangesetApplyPreviewResolverWithPublicationStates",
+    "reason": "Dropped IDs from batch changes table"
+  },
+  {
+    "path": "enterprise/cmd/frontend/internal/batches/webhooks ",
+    "prefix": "TestWebhooksIntegration",
+    "reason": "Dropped IDs from batch changes table"
+  },
+  {
+    "path": "enterprise/internal/codeintel/codenav/internal/lsifstore",
+    "prefix": "",
+    "reason": "Dropped IDs from batch changes table"
+  }
+]

--- a/dev/ci/go-backcompat/flakefiles/v4.3.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.3.0.json
@@ -1,17 +1,22 @@
 [
   {
-    "path": "enterprise/internal/batches/store",
-    "prefix": "TestIntegration",
-    "reason": "Dropped IDs from batch changes table"
+    "path": "enterprise/cmd/frontend/internal/batches/webhooks",
+    "prefix": "TestWebhooksIntegration",
+    "reason": "Test was having incomplete data, fails now that constraints are in place"
   },
   {
     "path": "enterprise/cmd/frontend/internal/batches/resolvers",
     "prefix": "TestChangesetApplyPreviewResolverWithPublicationStates",
-    "reason": "Dropped IDs from batch changes table"
+    "reason": "Test was having incomplete data, fails now that constraints are in place"
   },
   {
-    "path": "enterprise/cmd/frontend/internal/batches/webhooks",
-    "prefix": "TestWebhooksIntegration",
-    "reason": "Dropped IDs from batch changes table"
+    "path": "enterprise/cmd/frontend/internal/batches/resolvers",
+    "prefix": "TestChangesetCountsOverTimeIntegration",
+    "reason": "Test was having incomplete data, fails now that constraints are in place"
+  },
+  {
+    "path": "enterprise/cmd/frontend/internal/batches/resolvers",
+    "prefix": "TestRepositoryPermissions",
+    "reason": "Test was having incomplete data, fails now that constraints are in place"
   }
 ]

--- a/dev/ci/go-backcompat/flakefiles/v4.3.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.3.0.json
@@ -10,13 +10,8 @@
     "reason": "Dropped IDs from batch changes table"
   },
   {
-    "path": "enterprise/cmd/frontend/internal/batches/webhooks ",
+    "path": "enterprise/cmd/frontend/internal/batches/webhooks",
     "prefix": "TestWebhooksIntegration",
-    "reason": "Dropped IDs from batch changes table"
-  },
-  {
-    "path": "enterprise/internal/codeintel/codenav/internal/lsifstore",
-    "prefix": "",
     "reason": "Dropped IDs from batch changes table"
   }
 ]

--- a/dev/ci/go-backcompat/flakefiles/v4.3.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.3.0.json
@@ -70,8 +70,13 @@
     "reason": "Dropped symbol_name column on codeintel_scip_symbols"
   },
   {
-    "path": "enterprise/internal/codeintel/codenav/internal/lsifstore",
+    "path": "enterprise/internal/codeintel/uploads/internal/lsifstore",
     "prefix": "TestWriteSCIPSymbols",
+    "reason": "Dropped symbol_name column on codeintel_scip_symbols"
+  },
+  {
+    "path": "enterprise/internal/oobmigration/migrations/codeintel",
+    "prefix": "TestSCIPMigrator",
     "reason": "Dropped symbol_name column on codeintel_scip_symbols"
   }
 ]

--- a/dev/ci/go-backcompat/flakefiles/v4.3.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.3.0.json
@@ -1,17 +1,7 @@
 [
   {
     "path": "enterprise/internal/batches/store",
-    "prefix": "TestIntegration/Store/ChangesetSpecs/DeleteExpiredChangesetSpecs",
-    "reason": "Dropped IDs from batch changes table"
-  },
-  {
-    "path": "enterprise/internal/batches/store",
-    "prefix": "TestIntegration/Store/ChangesetSpecs/GetRewirerMappings ",
-    "reason": "Dropped IDs from batch changes table"
-  },
-  {
-    "path": "enterprise/internal/batches/store",
-    "prefix": "TestIntegration/Store/ChangesetSpecs/ListChangesetSpecsWithConflictingHeadRef",
+    "prefix": "TestIntegration",
     "reason": "Dropped IDs from batch changes table"
   },
   {

--- a/dev/ci/go-backcompat/flakefiles/v4.3.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.3.0.json
@@ -1,7 +1,17 @@
 [
   {
     "path": "enterprise/internal/batches/store",
-    "prefix": "TestDeleteExpiredChangesetSpecs",
+    "prefix": "TestIntegration/Store/ChangesetSpecs/DeleteExpiredChangesetSpecs",
+    "reason": "Dropped IDs from batch changes table"
+  },
+  {
+    "path": "enterprise/internal/batches/store",
+    "prefix": "TestIntegration/Store/ChangesetSpecs/GetRewirerMappings ",
+    "reason": "Dropped IDs from batch changes table"
+  },
+  {
+    "path": "enterprise/internal/batches/store",
+    "prefix": "TestIntegration/Store/ChangesetSpecs/ListChangesetSpecsWithConflictingHeadRef",
     "reason": "Dropped IDs from batch changes table"
   },
   {


### PR DESCRIPTION
See title

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

greenbuild on CI 