### PR TITLE
monitoring: set UID to folder name as well

### DIFF
--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -307,7 +307,7 @@ func generateAll(
 	}
 
 	// Reload all Prometheus rules
-	if opts.PrometheusDir != "" && opts.Reload {
+	if opts.PrometheusDir != "" && opts.PrometheusURL != "" && opts.Reload {
 		rlog := logger.Scoped("prometheus", "prometheus alerts generation").
 			With(log.String("instance", opts.PrometheusURL))
 		// Reload all Prometheus rules

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -109,8 +109,24 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 			}
 			for _, folder := range folders {
 				if folder.Title == opts.GrafanaFolder {
-					gclog.Debug("Found existing folder", log.Int("folder.id", folder.ID))
-					grafanaFolderID = folder.ID
+					gclog.Debug("Found existing folder matching name",
+						log.String("folder.uid", folder.UID),
+						log.Int("folder.id", folder.ID))
+
+					if folder.UID != opts.GrafanaFolder {
+						// If UID does not match the folder name, then delete it so it can
+						// be recreated. We want folders to have stable UIDs
+						_, err := grafanaClient.DeleteFolderByUID(ctx, folder.UID)
+						if err != nil {
+							return errors.Wrapf(err, "Unable to delete misnamed folder %q",
+								folder.UID)
+						}
+					} else {
+						// Mark as found
+						grafanaFolderID = folder.ID
+					}
+
+					break
 				}
 			}
 
@@ -119,6 +135,7 @@ func Generate(logger log.Logger, opts GenerateOptions, dashboards ...*Dashboard)
 				gclog.Debug("No existing folder found, creating a new one")
 				folder, err := grafanaClient.CreateFolder(ctx, grafanasdk.Folder{
 					Title: opts.GrafanaFolder,
+					UID:   opts.GrafanaFolder,
 				})
 				if err != nil {
 					return errors.Wrapf(err, "Error creating new folder %s", opts.GrafanaFolder)


### PR DESCRIPTION
This will let us have link-able folders with stable UIDs in centralized observability:

> The unique identifier (uid) of a dashboard can be used for uniquely identify a dashboard between multiple Grafana installs. It’s automatically generated if not provided when creating a dashboard. The uid allows having consistent URLs for accessing dashboards and when syncing dashboards between multiple Grafana installs, see [dashboard provisioning](https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards) for more information. This means that changing the title of a dashboard will not break any bookmarked links to that dashboard.

https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg run grafana`

`go run ./dev/sg monitoring generate -grafana.folder=foobar -prometheus.url='' -reload`

<img width="1032" alt="image" src="https://user-images.githubusercontent.com/23356519/208166985-2f44cff5-96a5-4320-9ab2-715b5a51b4f7.png">
