### PR TITLE
token selection: fix tooltip styles

### DIFF
--- a/client/web/src/repo/blob/codemirror/token-selection/hover.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/hover.ts
@@ -202,8 +202,8 @@ function isPrecise(hover: HoverMerged | null | undefined): boolean {
 // Tooltip styles is a combination of the default wildcard PopoverContent component (https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.module.scss#L1-L10)
 // and the floating tooltip-like storybook usage example (https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/story/Popover.story.module.scss#L54-L62)
 // ignoring the min/max width rules.
-const tooltipStyles = EditorView.baseTheme({
-    '.cm-tooltip.loading-tooltip': {
+const tooltipStyles = EditorView.theme({
+    '.cm-tooltip': {
         fontSize: '0.875rem',
         backgroundClip: 'padding-box',
         backgroundColor: 'var(--dropdown-bg)',

--- a/client/web/src/repo/blob/codemirror/token-selection/hover.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/hover.ts
@@ -199,10 +199,10 @@ function isPrecise(hover: HoverMerged | null | undefined): boolean {
     return false
 }
 
-// Tooltip styles is a combination of the default wildcard PopoverContent component (https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.module.scss#L1-L10)
-// and the floating tooltip-like storybook usage example (https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/story/Popover.story.module.scss#L54-L62)
-// ignoring the min/max width rules.
 const tooltipStyles = EditorView.theme({
+    // Tooltip styles is a combination of the default wildcard PopoverContent component (https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.module.scss#L1-L10)
+    // and the floating tooltip-like storybook usage example (https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/story/Popover.story.module.scss#L54-L62)
+    // ignoring the min/max width rules.
     '.cm-tooltip': {
         fontSize: '0.875rem',
         backgroundClip: 'padding-box',
@@ -212,5 +212,12 @@ const tooltipStyles = EditorView.theme({
         color: 'var(--body-color)',
         boxShadow: 'var(--dropdown-shadow)',
         padding: '0.5rem',
+    },
+
+    '.cm-tooltip-above .cm-tooltip-arrow:before': {
+        borderTopColor: 'var(--dropdown-border-color)',
+    },
+    '.cm-tooltip-above .cm-tooltip-arrow:after': {
+        borderTopColor: 'var(--dropdown-bg)',
     },
 })

--- a/client/web/src/repo/blob/codemirror/token-selection/hover.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/hover.ts
@@ -29,6 +29,7 @@ export function hoverExtension(): Extension {
         hoverCache,
         hoveredOccurrenceField,
         hoverTooltip((view, position) => getHoverTooltip(view, position), { hoverTime: 200, hideOnChange: true }),
+        tooltipStyles,
         hoverField,
         pinManager,
     ]
@@ -197,3 +198,19 @@ function isPrecise(hover: HoverMerged | null | undefined): boolean {
     }
     return false
 }
+
+// Tooltip styles is a combination of the default wildcard PopoverContent component (https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.module.scss#L1-L10)
+// and the floating tooltip-like storybook usage example (https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/story/Popover.story.module.scss#L54-L62)
+// ignoring the min/max width rules.
+const tooltipStyles = EditorView.baseTheme({
+    '.cm-tooltip.loading-tooltip': {
+        fontSize: '0.875rem',
+        backgroundClip: 'padding-box',
+        backgroundColor: 'var(--dropdown-bg)',
+        border: '1px solid var(--dropdown-border-color)',
+        borderRadius: 'var(--popover-border-radius)',
+        color: 'var(--body-color)',
+        boxShadow: 'var(--dropdown-shadow)',
+        padding: '0.5rem',
+    },
+})

--- a/client/web/src/repo/blob/codemirror/token-selection/hover.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/hover.ts
@@ -199,11 +199,11 @@ function isPrecise(hover: HoverMerged | null | undefined): boolean {
     return false
 }
 
+// Tooltip styles is a combination of the default wildcard PopoverContent component (https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.module.scss#L1-L10)
+// and the floating tooltip-like storybook usage example (https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/story/Popover.story.module.scss#L54-L62)
+// ignoring the min/max width rules.
 const tooltipStyles = EditorView.baseTheme({
     '.cm-tooltip.loading-tooltip': {
-        // Tooltip styles is a combination of the default wildcard PopoverContent component (https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.module.scss#L1-L10)
-        // and the floating tooltip-like storybook usage example (https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/story/Popover.story.module.scss#L54-L62)
-        // ignoring the min/max width rules.
         fontSize: '0.875rem',
         backgroundClip: 'padding-box',
         backgroundColor: 'var(--dropdown-bg)',
@@ -212,9 +212,5 @@ const tooltipStyles = EditorView.baseTheme({
         color: 'var(--body-color)',
         boxShadow: 'var(--dropdown-shadow)',
         padding: '0.5rem',
-
-        // negative left margin to cover the difference in left position between the CodeMirror .cm-tooltip-above
-        // and the code-intel popover.
-        marginLeft: '-0.5rem',
     },
 })

--- a/client/web/src/repo/blob/codemirror/token-selection/hover.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/hover.ts
@@ -199,11 +199,11 @@ function isPrecise(hover: HoverMerged | null | undefined): boolean {
     return false
 }
 
-// Tooltip styles is a combination of the default wildcard PopoverContent component (https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.module.scss#L1-L10)
-// and the floating tooltip-like storybook usage example (https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/story/Popover.story.module.scss#L54-L62)
-// ignoring the min/max width rules.
 const tooltipStyles = EditorView.baseTheme({
     '.cm-tooltip.loading-tooltip': {
+        // Tooltip styles is a combination of the default wildcard PopoverContent component (https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.module.scss#L1-L10)
+        // and the floating tooltip-like storybook usage example (https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/story/Popover.story.module.scss#L54-L62)
+        // ignoring the min/max width rules.
         fontSize: '0.875rem',
         backgroundClip: 'padding-box',
         backgroundColor: 'var(--dropdown-bg)',
@@ -212,5 +212,9 @@ const tooltipStyles = EditorView.baseTheme({
         color: 'var(--body-color)',
         boxShadow: 'var(--dropdown-shadow)',
         padding: '0.5rem',
+
+        // negative left margin to cover the difference in left position between the CodeMirror .cm-tooltip-above
+        // and the code-intel popover.
+        marginLeft: '-0.5rem',
     },
 })

--- a/client/web/src/repo/blob/codemirror/tooltips/LoadingTooltip.ts
+++ b/client/web/src/repo/blob/codemirror/tooltips/LoadingTooltip.ts
@@ -12,7 +12,6 @@ export class LoadingTooltip {
                 above: true,
                 create() {
                     const dom = document.createElement('div')
-                    dom.classList.add('loading-tooltip')
                     dom.textContent = 'Loading...'
                     return { dom }
                 },

--- a/client/web/src/repo/blob/codemirror/tooltips/LoadingTooltip.ts
+++ b/client/web/src/repo/blob/codemirror/tooltips/LoadingTooltip.ts
@@ -12,6 +12,7 @@ export class LoadingTooltip {
                 above: true,
                 create() {
                     const dom = document.createElement('div')
+                    dom.classList.add('loading-tooltip')
                     dom.textContent = 'Loading...'
                     return { dom }
                 },


### PR DESCRIPTION
Styles CodeMirror loading tooltip similarly to the wildcard `PopoverContent` component.

Closes https://github.com/sourcegraph/sourcegraph/issues/45573

Styles similarity is achieved by copying the [`PopoverContent` default styles](https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.module.scss#L1-L10) and adding [tooltip-like popover styles](https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/story/Popover.story.module.scss#L54-L62) from [this storybook example](https://storybook.sgdev.org/?path=/story/wildcard-popover--position-settings-gallery).
We don't render the `Popover` component tree as it requires the `PopoverTrigger` component for proper `PopoverContent` positioning ([1](https://github.com/sourcegraph/sourcegraph/blob/be30bf4b24b2022f6ccc87fe9ac2eef6a92a4ce4/client/wildcard/src/components/Popover/components/PopoverTrigger.tsx#L16-L19), [2](https://github.com/sourcegraph/sourcegraph/blob/be30bf4b24b2022f6ccc87fe9ac2eef6a92a4ce4/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.tsx#L105)). We can render and hide the `PopoverTrigger` component to achieve `PopoverContent` proper positioning, but it seems to affect the expected focus behavior and may have other side effects. Copying styles seems to be a more simple approach to me.

| Before | After |
| -- | -- |
| <img width="251" alt="Screenshot 2022-11-29 at 18 44 56" src="https://user-images.githubusercontent.com/25318659/204602325-df37e1d6-d11f-47fc-8e78-90ead1bb0959.png"> | <img width="340" alt="Screenshot 2022-12-18 at 21 34 23" src="https://user-images.githubusercontent.com/25318659/208315824-4827a5b9-354a-4104-a5b6-b89d2e68d0f5.png"> <img width="340" alt="Screenshot 2022-12-18 at 21 34 04" src="https://user-images.githubusercontent.com/25318659/208315825-c7548523-9a30-4a1d-9fa7-b04d018c8ea6.png">|

The difference in branded popovers spacing will be addressed in a separate issue:
- https://github.com/sourcegraph/sourcegraph/issues/45801

## Test plan
Tested manually (see screenshots).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-token-selection.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

