### PR TITLE
rbac: Create store methods for roles and permissions (Part 4) 

### DIFF
--- a/enterprise/internal/database/mocks_temp.go
+++ b/enterprise/internal/database/mocks_temp.go
@@ -6904,6 +6904,9 @@ type MockEnterpriseDB struct {
 	// ReposFunc is an instance of a mock function object controlling the
 	// behavior of the method Repos.
 	ReposFunc *EnterpriseDBReposFunc
+	// RolePermissionsFunc is an instance of a mock function object
+	// controlling the behavior of the method RolePermissions.
+	RolePermissionsFunc *EnterpriseDBRolePermissionsFunc
 	// RolesFunc is an instance of a mock function object controlling the
 	// behavior of the method Roles.
 	RolesFunc *EnterpriseDBRolesFunc
@@ -7105,6 +7108,11 @@ func NewMockEnterpriseDB() *MockEnterpriseDB {
 		},
 		ReposFunc: &EnterpriseDBReposFunc{
 			defaultHook: func() (r0 database.RepoStore) {
+				return
+			},
+		},
+		RolePermissionsFunc: &EnterpriseDBRolePermissionsFunc{
+			defaultHook: func() (r0 database.RolePermissionStore) {
 				return
 			},
 		},
@@ -7345,6 +7353,11 @@ func NewStrictMockEnterpriseDB() *MockEnterpriseDB {
 				panic("unexpected invocation of MockEnterpriseDB.Repos")
 			},
 		},
+		RolePermissionsFunc: &EnterpriseDBRolePermissionsFunc{
+			defaultHook: func() database.RolePermissionStore {
+				panic("unexpected invocation of MockEnterpriseDB.RolePermissions")
+			},
+		},
 		RolesFunc: &EnterpriseDBRolesFunc{
 			defaultHook: func() database.RoleStore {
 				panic("unexpected invocation of MockEnterpriseDB.Roles")
@@ -7522,6 +7535,9 @@ func NewMockEnterpriseDBFrom(i EnterpriseDB) *MockEnterpriseDB {
 		},
 		ReposFunc: &EnterpriseDBReposFunc{
 			defaultHook: i.Repos,
+		},
+		RolePermissionsFunc: &EnterpriseDBRolePermissionsFunc{
+			defaultHook: i.RolePermissions,
 		},
 		RolesFunc: &EnterpriseDBRolesFunc{
 			defaultHook: i.Roles,
@@ -10608,6 +10624,106 @@ func (c EnterpriseDBReposFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c EnterpriseDBReposFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// EnterpriseDBRolePermissionsFunc describes the behavior when the
+// RolePermissions method of the parent MockEnterpriseDB instance is
+// invoked.
+type EnterpriseDBRolePermissionsFunc struct {
+	defaultHook func() database.RolePermissionStore
+	hooks       []func() database.RolePermissionStore
+	history     []EnterpriseDBRolePermissionsFuncCall
+	mutex       sync.Mutex
+}
+
+// RolePermissions delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockEnterpriseDB) RolePermissions() database.RolePermissionStore {
+	r0 := m.RolePermissionsFunc.nextHook()()
+	m.RolePermissionsFunc.appendCall(EnterpriseDBRolePermissionsFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the RolePermissions
+// method of the parent MockEnterpriseDB instance is invoked and the hook
+// queue is empty.
+func (f *EnterpriseDBRolePermissionsFunc) SetDefaultHook(hook func() database.RolePermissionStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RolePermissions method of the parent MockEnterpriseDB instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *EnterpriseDBRolePermissionsFunc) PushHook(hook func() database.RolePermissionStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *EnterpriseDBRolePermissionsFunc) SetDefaultReturn(r0 database.RolePermissionStore) {
+	f.SetDefaultHook(func() database.RolePermissionStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *EnterpriseDBRolePermissionsFunc) PushReturn(r0 database.RolePermissionStore) {
+	f.PushHook(func() database.RolePermissionStore {
+		return r0
+	})
+}
+
+func (f *EnterpriseDBRolePermissionsFunc) nextHook() func() database.RolePermissionStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *EnterpriseDBRolePermissionsFunc) appendCall(r0 EnterpriseDBRolePermissionsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of EnterpriseDBRolePermissionsFuncCall objects
+// describing the invocations of this function.
+func (f *EnterpriseDBRolePermissionsFunc) History() []EnterpriseDBRolePermissionsFuncCall {
+	f.mutex.Lock()
+	history := make([]EnterpriseDBRolePermissionsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// EnterpriseDBRolePermissionsFuncCall is an object that describes an
+// invocation of method RolePermissions on an instance of MockEnterpriseDB.
+type EnterpriseDBRolePermissionsFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 database.RolePermissionStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c EnterpriseDBRolePermissionsFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c EnterpriseDBRolePermissionsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -40,6 +40,7 @@ type DB interface {
 	Phabricator() PhabricatorStore
 	Repos() RepoStore
 	RepoKVPs() RepoKVPStore
+	RolePermissions() RolePermissionStore
 	Roles() RoleStore
 	SavedSearches() SavedSearchStore
 	SearchContexts() SearchContextsStore
@@ -169,7 +170,7 @@ func (d *db) OrgStats() OrgStatsStore {
 }
 
 func (d *db) Permissions() PermissionStore {
-	return &permissionStore{Store: d.Store}
+	return PermissionsWith(d.Store)
 }
 
 func (d *db) Phabricator() PhabricatorStore {
@@ -182,6 +183,10 @@ func (d *db) Repos() RepoStore {
 
 func (d *db) RepoKVPs() RepoKVPStore {
 	return &repoKVPStore{d.Store}
+}
+
+func (d *db) RolePermissions() RolePermissionStore {
+	return RolePermissionsWith(d.Store)
 }
 
 func (d *db) Roles() RoleStore {

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -3704,6 +3704,9 @@ type MockDB struct {
 	// ReposFunc is an instance of a mock function object controlling the
 	// behavior of the method Repos.
 	ReposFunc *DBReposFunc
+	// RolePermissionsFunc is an instance of a mock function object
+	// controlling the behavior of the method RolePermissions.
+	RolePermissionsFunc *DBRolePermissionsFunc
 	// RolesFunc is an instance of a mock function object controlling the
 	// behavior of the method Roles.
 	RolesFunc *DBRolesFunc
@@ -3895,6 +3898,11 @@ func NewMockDB() *MockDB {
 		},
 		ReposFunc: &DBReposFunc{
 			defaultHook: func() (r0 RepoStore) {
+				return
+			},
+		},
+		RolePermissionsFunc: &DBRolePermissionsFunc{
+			defaultHook: func() (r0 RolePermissionStore) {
 				return
 			},
 		},
@@ -4125,6 +4133,11 @@ func NewStrictMockDB() *MockDB {
 				panic("unexpected invocation of MockDB.Repos")
 			},
 		},
+		RolePermissionsFunc: &DBRolePermissionsFunc{
+			defaultHook: func() RolePermissionStore {
+				panic("unexpected invocation of MockDB.RolePermissions")
+			},
+		},
 		RolesFunc: &DBRolesFunc{
 			defaultHook: func() RoleStore {
 				panic("unexpected invocation of MockDB.Roles")
@@ -4295,6 +4308,9 @@ func NewMockDBFrom(i DB) *MockDB {
 		},
 		ReposFunc: &DBReposFunc{
 			defaultHook: i.Repos,
+		},
+		RolePermissionsFunc: &DBRolePermissionsFunc{
+			defaultHook: i.RolePermissions,
 		},
 		RolesFunc: &DBRolesFunc{
 			defaultHook: i.Roles,
@@ -7159,6 +7175,105 @@ func (c DBReposFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c DBReposFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// DBRolePermissionsFunc describes the behavior when the RolePermissions
+// method of the parent MockDB instance is invoked.
+type DBRolePermissionsFunc struct {
+	defaultHook func() RolePermissionStore
+	hooks       []func() RolePermissionStore
+	history     []DBRolePermissionsFuncCall
+	mutex       sync.Mutex
+}
+
+// RolePermissions delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockDB) RolePermissions() RolePermissionStore {
+	r0 := m.RolePermissionsFunc.nextHook()()
+	m.RolePermissionsFunc.appendCall(DBRolePermissionsFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the RolePermissions
+// method of the parent MockDB instance is invoked and the hook queue is
+// empty.
+func (f *DBRolePermissionsFunc) SetDefaultHook(hook func() RolePermissionStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RolePermissions method of the parent MockDB instance invokes the hook at
+// the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *DBRolePermissionsFunc) PushHook(hook func() RolePermissionStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *DBRolePermissionsFunc) SetDefaultReturn(r0 RolePermissionStore) {
+	f.SetDefaultHook(func() RolePermissionStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *DBRolePermissionsFunc) PushReturn(r0 RolePermissionStore) {
+	f.PushHook(func() RolePermissionStore {
+		return r0
+	})
+}
+
+func (f *DBRolePermissionsFunc) nextHook() func() RolePermissionStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBRolePermissionsFunc) appendCall(r0 DBRolePermissionsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBRolePermissionsFuncCall objects
+// describing the invocations of this function.
+func (f *DBRolePermissionsFunc) History() []DBRolePermissionsFuncCall {
+	f.mutex.Lock()
+	history := make([]DBRolePermissionsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBRolePermissionsFuncCall is an object that describes an invocation of
+// method RolePermissions on an instance of MockDB.
+type DBRolePermissionsFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 RolePermissionStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DBRolePermissionsFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBRolePermissionsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/permissions.go
+++ b/internal/database/permissions.go
@@ -193,9 +193,13 @@ func (p *permissionStore) GetByID(ctx context.Context, opts GetPermissionOpts) (
 	return permission, nil
 }
 
+// The ORDER BY clause should not be changed because it ensures permissions retrieved
+// from the database are already sorted therefore making the rbac schema migration easy.
+// We compare permissions in the database to those generated from the schema and both
+// need to be sorted.
 const permissionListQueryFmtStr = `
 SELECT * FROM permissions
-ORDER BY permissions.namespace ASC
+ORDER BY permissions.namespace, permissions.action ASC
 `
 
 func (p *permissionStore) List(ctx context.Context) ([]*types.Permission, error) {

--- a/internal/database/permissions.go
+++ b/internal/database/permissions.go
@@ -72,6 +72,10 @@ type permissionStore struct {
 
 var _ PermissionStore = &permissionStore{}
 
+func PermissionsWith(other basestore.ShareableStore) PermissionStore {
+	return &permissionStore{Store: basestore.NewWithHandle(other.Handle())}
+}
+
 const permissionCreateQueryFmtStr = `
 INSERT INTO
 	permissions(%s)

--- a/internal/database/role_permissions.go
+++ b/internal/database/role_permissions.go
@@ -126,7 +126,7 @@ const getRolePermissionQueryFmtStr = `
 SELECT
 	%s
 FROM role_permissions
-WHERE %s;
+WHERE %s
 `
 
 func (rp *rolePermissionStore) get(ctx context.Context, w *sqlf.Query, scanFunc func(rows *sql.Rows) error) error {

--- a/internal/database/role_permissions.go
+++ b/internal/database/role_permissions.go
@@ -225,7 +225,7 @@ VALUES (
 	%s,
 	%s
 )
-RETURNING %s;
+RETURNING %s
 `
 
 func (rp *rolePermissionStore) Create(ctx context.Context, opts CreateRolePermissionOpts) (*types.RolePermission, error) {

--- a/internal/database/role_permissions.go
+++ b/internal/database/role_permissions.go
@@ -75,7 +75,7 @@ func (rp *rolePermissionStore) Transact(ctx context.Context) (RolePermissionStor
 
 const deleteRolePermissionQueryFmtStr = `
 DELETE FROM role_permissions
-WHERE %s;
+WHERE %s
 `
 
 func (rp *rolePermissionStore) Delete(ctx context.Context, opts DeleteRolePermissionOpts) error {

--- a/internal/database/role_permissions.go
+++ b/internal/database/role_permissions.go
@@ -1,0 +1,228 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var rolePermissionInsertColumns = []*sqlf.Query{
+	sqlf.Sprintf("role_id"),
+	sqlf.Sprintf("permission_id"),
+}
+
+var rolePermissionColumns = []*sqlf.Query{
+	sqlf.Sprintf("role_permissions.role_id"),
+	sqlf.Sprintf("role_permissions.permission_id"),
+	sqlf.Sprintf("role_permissions.created_at"),
+}
+
+type RolePermissionOpts struct {
+	PermissionID int32
+	RoleID       int32
+}
+
+type (
+	CreateRolePermissionOpts RolePermissionOpts
+	DeleteRolePermissionOpts RolePermissionOpts
+	GetRolePermissionOpts    RolePermissionOpts
+)
+
+type RolePermissionStore interface {
+	basestore.ShareableStore
+
+	// GetByRoleIDAndPermissionID returns one RolePermission associated with the provided role and permission.
+	GetByRoleIDAndPermissionID(ctx context.Context, opts GetRolePermissionOpts) (*types.RolePermission, error)
+	// GetByRoleID returns all RolePermission associated with the provided role ID
+	GetByRoleID(ctx context.Context, opts GetRolePermissionOpts) ([]*types.RolePermission, error)
+	// GetByPermissionID returns all RolePermission associated with the provided permission ID
+	GetByPermissionID(ctx context.Context, opts GetRolePermissionOpts) ([]*types.RolePermission, error)
+	// Delete deletes the permission and role relationship from the database.
+	Delete(ctx context.Context, opts DeleteRolePermissionOpts) error
+	// Transact creates a transaction for the RolePermissionStore.
+	Transact(context.Context) (RolePermissionStore, error)
+	// With is used to merge the store with another to pull data via other stores.
+	With(basestore.ShareableStore) RolePermissionStore
+}
+
+type rolePermissionStore struct {
+	*basestore.Store
+}
+
+var _ RolePermissionStore = &rolePermissionStore{}
+
+func RolePermissionsWith(other basestore.ShareableStore) RolePermissionStore {
+	return &rolePermissionStore{Store: basestore.NewWithHandle(other.Handle())}
+}
+
+func (rp *rolePermissionStore) With(other basestore.ShareableStore) RolePermissionStore {
+	return &rolePermissionStore{Store: rp.Store.With(other)}
+}
+
+func (rp *rolePermissionStore) Transact(ctx context.Context) (RolePermissionStore, error) {
+	tx, err := rp.Store.Transact(ctx)
+	return &rolePermissionStore{Store: tx}, err
+}
+
+const deleteRolePermissionQueryFmtStr = `
+DELETE FROM role_permissions
+WHERE %s;
+`
+
+func (rp *rolePermissionStore) Delete(ctx context.Context, opts DeleteRolePermissionOpts) error {
+	if opts.PermissionID == 0 {
+		return errors.New("missing permission id")
+	}
+
+	if opts.RoleID == 0 {
+		return errors.New("missing role id")
+	}
+
+	q := sqlf.Sprintf(
+		deleteRolePermissionQueryFmtStr,
+		sqlf.Sprintf("permission_id = %s AND role_id = %s", opts.PermissionID, opts.RoleID),
+	)
+
+	result, err := rp.ExecResult(ctx, q)
+	if err != nil {
+		return errors.Wrap(err, "running delete query")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "checking deleted rows")
+	}
+
+	if rowsAffected == 0 {
+		return errors.Wrap(&RolePermissionNotFoundErr{opts.PermissionID, opts.RoleID}, "failed to delete role permission")
+	}
+
+	return nil
+}
+
+func scanRolePermission(sc dbutil.Scanner) (*types.RolePermission, error) {
+	var rp types.RolePermission
+	if err := sc.Scan(
+		&rp.RoleID,
+		&rp.PermissionID,
+		&rp.CreatedAt,
+	); err != nil {
+		return nil, err
+	}
+
+	return &rp, nil
+}
+
+const getRolePermissionQueryFmtStr = `
+SELECT
+	%s
+FROM role_permissions
+WHERE %s;
+`
+
+func (rp *rolePermissionStore) GetByPermissionID(ctx context.Context, opts GetRolePermissionOpts) ([]*types.RolePermission, error) {
+	if opts.PermissionID == 0 {
+		return nil, errors.New("missing permission id")
+	}
+
+	var rps []*types.RolePermission
+
+	scanFunc := func(rows *sql.Rows) error {
+		rp, err := scanRolePermission(rows)
+		if err != nil {
+			return err
+		}
+		rps = append(rps, rp)
+		return nil
+	}
+
+	err := rp.get(ctx, sqlf.Sprintf("permission_id = %s", opts.PermissionID), scanFunc)
+	return rps, err
+}
+
+func (rp *rolePermissionStore) GetByRoleID(ctx context.Context, opts GetRolePermissionOpts) ([]*types.RolePermission, error) {
+	if opts.RoleID == 0 {
+		return nil, errors.New("missing role id")
+	}
+
+	var rps []*types.RolePermission
+
+	scanFunc := func(rows *sql.Rows) error {
+		rp, err := scanRolePermission(rows)
+		if err != nil {
+			return err
+		}
+		rps = append(rps, rp)
+		return nil
+	}
+
+	err := rp.get(ctx, sqlf.Sprintf("role_id = %s", opts.PermissionID), scanFunc)
+	return rps, err
+}
+
+func (rp *rolePermissionStore) get(ctx context.Context, w *sqlf.Query, scanFunc func(rows *sql.Rows) error) error {
+	q := sqlf.Sprintf(
+		getRolePermissionQueryFmtStr,
+		sqlf.Join(rolePermissionColumns, ", "),
+		w,
+	)
+
+	rows, err := rp.Query(ctx, q)
+	if err != nil {
+		return errors.Wrap(err, "error running query")
+	}
+	defer rows.Close()
+	for rows.Next() {
+		if err := scanFunc(rows); err != nil {
+			return err
+		}
+	}
+
+	return rows.Err()
+}
+
+func (rp *rolePermissionStore) GetByRoleIDAndPermissionID(ctx context.Context, opts GetRolePermissionOpts) (*types.RolePermission, error) {
+	if opts.PermissionID == 0 {
+		return nil, errors.New("missing permission id")
+	}
+
+	if opts.RoleID == 0 {
+		return nil, errors.New("missing role id")
+	}
+
+	q := sqlf.Sprintf(
+		getRolePermissionQueryFmtStr,
+		sqlf.Join(rolePermissionColumns, ", "),
+		sqlf.Sprintf("role_permissions.role_id = %s AND role_permissions.permission_id = %s", opts.RoleID, opts.PermissionID),
+	)
+
+	rolePermission, err := scanRolePermission(rp.QueryRow(ctx, q))
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, &RolePermissionNotFoundErr{PermissionID: opts.PermissionID, RoleID: opts.RoleID}
+		}
+		return nil, errors.Wrap(err, "scanning role permission")
+	}
+
+	return rolePermission, nil
+}
+
+type RolePermissionNotFoundErr struct {
+	PermissionID int32
+	RoleID       int32
+}
+
+func (e *RolePermissionNotFoundErr) Error() string {
+	return fmt.Sprintf("role permission for role %d and permission %d not found", e.RoleID, e.PermissionID)
+}
+
+func (e *RolePermissionNotFoundErr) NotFound() bool {
+	return true
+}

--- a/internal/database/role_permissions_test.go
+++ b/internal/database/role_permissions_test.go
@@ -1,0 +1,292 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestRolePermissionCreate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	store := db.RolePermissions()
+
+	r, p := createRoleAndPermission(ctx, t, db)
+
+	t.Run("without permission id", func(t *testing.T) {
+		rp, err := store.Create(ctx, CreateRolePermissionOpts{
+			RoleID: r.ID,
+		})
+		assert.Nil(t, rp)
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "missing permission id")
+	})
+
+	t.Run("without role id", func(t *testing.T) {
+		rp, err := store.Create(ctx, CreateRolePermissionOpts{
+			PermissionID: p.ID,
+		})
+		assert.Nil(t, rp)
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "missing role id")
+	})
+
+	t.Run("with correct args", func(t *testing.T) {
+		rp, err := store.Create(ctx, CreateRolePermissionOpts{
+			RoleID:       r.ID,
+			PermissionID: p.ID,
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, rp)
+		assert.Equal(t, rp.RoleID, r.ID)
+		assert.Equal(t, rp.PermissionID, p.ID)
+	})
+}
+
+func TestRolePermissionGetByRoleIDAndPermissionID(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	store := db.RolePermissions()
+
+	r, p := createRoleAndPermission(ctx, t, db)
+	_, err := store.Create(ctx, CreateRolePermissionOpts{
+		RoleID:       r.ID,
+		PermissionID: p.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("without permission ID", func(t *testing.T) {
+		rp, err := store.GetByRoleIDAndPermissionID(ctx, GetRolePermissionOpts{
+			RoleID: r.ID,
+		})
+		assert.Nil(t, rp)
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "missing permission id")
+	})
+
+	t.Run("without role ID", func(t *testing.T) {
+		rp, err := store.GetByRoleIDAndPermissionID(ctx, GetRolePermissionOpts{
+			PermissionID: p.ID,
+		})
+		assert.Nil(t, rp)
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "missing role id")
+	})
+
+	t.Run("non existent role id and permission id", func(t *testing.T) {
+		pid := int32(1083)
+		rid := int32(2342)
+		rp, err := store.GetByRoleIDAndPermissionID(ctx, GetRolePermissionOpts{
+			PermissionID: pid,
+			RoleID:       rid,
+		})
+
+		assert.Nil(t, rp)
+		assert.Error(t, err)
+		assert.Equal(t, err, &RolePermissionNotFoundErr{PermissionID: pid, RoleID: rid})
+	})
+
+	t.Run("with correct args", func(t *testing.T) {
+		rp, err := store.GetByRoleIDAndPermissionID(ctx, GetRolePermissionOpts{
+			PermissionID: p.ID,
+			RoleID:       r.ID,
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, rp.RoleID, r.ID)
+		assert.Equal(t, rp.PermissionID, p.ID)
+	})
+}
+
+func TestRolePermissionGetByRoleID(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	store := db.RolePermissions()
+
+	r := createTestRoleForRolePermission(ctx, "TEST ROLE", t, db)
+
+	totalRolePermissions := 5
+	for i := 1; i <= totalRolePermissions; i++ {
+		p := createTestPermissionForRolePermission(ctx, "BATCH CHANGES", fmt.Sprintf("action-%d", i), t, db)
+		_, err := store.Create(ctx, CreateRolePermissionOpts{
+			RoleID:       r.ID,
+			PermissionID: p.ID,
+		})
+
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("without role ID", func(t *testing.T) {
+		rp, err := store.GetByRoleID(ctx, GetRolePermissionOpts{})
+
+		assert.Nil(t, rp)
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "missing role id")
+	})
+
+	t.Run("with correct args", func(t *testing.T) {
+		rps, err := store.GetByRoleID(ctx, GetRolePermissionOpts{
+			RoleID: r.ID,
+		})
+
+		assert.NoError(t, err)
+		assert.Len(t, rps, totalRolePermissions)
+
+		for _, rp := range rps {
+			assert.Equal(t, rp.RoleID, r.ID)
+		}
+	})
+}
+
+func TestRolePermissionGetByPermissionID(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	store := db.RolePermissions()
+
+	p := createTestPermissionForRolePermission(ctx, "BATCH CHANGES", "READ", t, db)
+
+	totalRolePermissions := 5
+	for i := 1; i <= totalRolePermissions; i++ {
+		r := createTestRoleForRolePermission(ctx, fmt.Sprintf("TEST ROLE-%d", i), t, db)
+		_, err := store.Create(ctx, CreateRolePermissionOpts{
+			RoleID:       r.ID,
+			PermissionID: p.ID,
+		})
+
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("without permission ID", func(t *testing.T) {
+		rp, err := store.GetByPermissionID(ctx, GetRolePermissionOpts{})
+
+		assert.Nil(t, rp)
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "missing permission id")
+	})
+
+	t.Run("with correct args", func(t *testing.T) {
+		rps, err := store.GetByPermissionID(ctx, GetRolePermissionOpts{
+			PermissionID: p.ID,
+		})
+
+		assert.NoError(t, err)
+		assert.Len(t, rps, totalRolePermissions)
+
+		for _, rp := range rps {
+			assert.Equal(t, rp.PermissionID, p.ID)
+		}
+	})
+}
+
+func TestRolePermissionDelete(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	store := db.RolePermissions()
+
+	r, p := createRoleAndPermission(ctx, t, db)
+
+	_, err := store.Create(ctx, CreateRolePermissionOpts{
+		RoleID:       r.ID,
+		PermissionID: p.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("missing permission id", func(t *testing.T) {
+		err := store.Delete(ctx, DeleteRolePermissionOpts{})
+
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "missing permission id")
+	})
+
+	t.Run("missing role id", func(t *testing.T) {
+		err := store.Delete(ctx, DeleteRolePermissionOpts{
+			PermissionID: p.ID,
+		})
+
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "missing role id")
+	})
+
+	t.Run("with non-existent role permission", func(t *testing.T) {
+		roleID := int32(1234)
+		permissionID := int32(4321)
+
+		err := store.Delete(ctx, DeleteRolePermissionOpts{
+			RoleID:       roleID,
+			PermissionID: permissionID,
+		})
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "failed to delete role permission")
+	})
+
+	t.Run("with existing role permission", func(t *testing.T) {
+		err := store.Delete(ctx, DeleteRolePermissionOpts{
+			RoleID:       r.ID,
+			PermissionID: p.ID,
+		})
+		assert.NoError(t, err)
+
+		ur, err := store.GetByRoleIDAndPermissionID(ctx, GetRolePermissionOpts{
+			RoleID:       r.ID,
+			PermissionID: p.ID,
+		})
+		assert.Nil(t, ur)
+		assert.Error(t, err)
+		assert.Equal(t, err, &RolePermissionNotFoundErr{
+			RoleID:       r.ID,
+			PermissionID: p.ID,
+		})
+	})
+}
+
+func createTestPermissionForRolePermission(ctx context.Context, namespace, action string, t *testing.T, db DB) *types.Permission {
+	t.Helper()
+	p, err := db.Permissions().Create(ctx, CreatePermissionOpts{
+		Namespace: namespace,
+		Action:    action,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return p
+}
+
+func createRoleAndPermission(ctx context.Context, t *testing.T, db DB) (*types.Role, *types.Permission) {
+	t.Helper()
+	permission := createTestPermissionForRolePermission(ctx, "BATCHCHANGE", "READ", t, db)
+	role := createTestRoleForRolePermission(ctx, "TEST ROLE", t, db)
+	return role, permission
+}
+
+func createTestRoleForRolePermission(ctx context.Context, name string, t *testing.T, db DB) *types.Role {
+	t.Helper()
+	r, err := db.Roles().Create(ctx, name, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}

--- a/internal/database/user_roles.go
+++ b/internal/database/user_roles.go
@@ -122,7 +122,7 @@ func (e *UserRoleNotFoundErr) NotFound() bool {
 
 const deleteUserRoleQueryFmtStr = `
 DELETE FROM user_roles
-WHERE %s;
+WHERE %s
 `
 
 func (r *userRoleStore) Delete(ctx context.Context, opts DeleteUserRoleOpts) error {

--- a/internal/database/user_roles.go
+++ b/internal/database/user_roles.go
@@ -58,6 +58,8 @@ type userRoleStore struct {
 	*basestore.Store
 }
 
+var _ UserRoleStore = &userRoleStore{}
+
 func UserRolesWith(other basestore.ShareableStore) UserRoleStore {
 	return &userRoleStore{Store: basestore.NewWithHandle(other.Handle())}
 }
@@ -105,11 +107,6 @@ func (r *userRoleStore) Create(ctx context.Context, opts CreateUserRoleOpts) (*t
 	return rm, nil
 }
 
-const deleteUserRoleQueryFmtStr = `
-DELETE FROM user_roles
-WHERE %s;
-`
-
 type UserRoleNotFoundErr struct {
 	UserID int32
 	RoleID int32
@@ -122,6 +119,11 @@ func (e *UserRoleNotFoundErr) Error() string {
 func (e *UserRoleNotFoundErr) NotFound() bool {
 	return true
 }
+
+const deleteUserRoleQueryFmtStr = `
+DELETE FROM user_roles
+WHERE %s;
+`
 
 func (r *userRoleStore) Delete(ctx context.Context, opts DeleteUserRoleOpts) error {
 	if opts.UserID == 0 {

--- a/internal/database/user_roles.go
+++ b/internal/database/user_roles.go
@@ -76,11 +76,11 @@ func (r *userRoleStore) Transact(ctx context.Context) (UserRoleStore, error) {
 const userRoleCreateQueryFmtStr = `
 INSERT INTO
 	user_roles (%s)
-	VALUES (
-		%s,
-		%s
-	)
-	RETURNING %s;
+VALUES (
+	%s,
+	%s
+)
+RETURNING %s;
 `
 
 func (r *userRoleStore) Create(ctx context.Context, opts CreateUserRoleOpts) (*types.UserRole, error) {

--- a/internal/database/user_roles_test.go
+++ b/internal/database/user_roles_test.go
@@ -246,7 +246,7 @@ func TestUserRoleGetByRoleIDAndUserID(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, ur.RoleID, role.ID)
-		assert.Equal(t, ur.UserID, ur.UserID)
+		assert.Equal(t, ur.UserID, user.ID)
 	})
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -801,6 +801,12 @@ type Permission struct {
 	CreatedAt time.Time
 }
 
+type RolePermission struct {
+	RoleID       int32
+	PermissionID int32
+	CreatedAt    time.Time
+}
+
 type UserRole struct {
 	RoleID    int32
 	UserID    int32


### PR DESCRIPTION
Part 4 [#45456](https://github.com/sourcegraph/sourcegraph/issues/45456)
Closes [#45456](https://github.com/sourcegraph/sourcegraph/issues/45456)

This adds store methods for role permissions.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Added unit tests for store methods