### PR TITLE
build: remove circular imports in client/*

### DIFF
--- a/client/search-ui/src/input/SearchHistoryDropdown.tsx
+++ b/client/search-ui/src/input/SearchHistoryDropdown.tsx
@@ -12,7 +12,6 @@ import { mdiClockOutline } from '@mdi/js'
 import classNames from 'classnames'
 
 import { pluralize } from '@sourcegraph/common'
-import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { RecentSearch } from '@sourcegraph/shared/src/settings/temporary/recentSearches'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 // eslint-disable-next-line no-restricted-imports
@@ -28,6 +27,8 @@ import {
     Tooltip,
     usePopoverContext,
 } from '@sourcegraph/wildcard'
+
+import { SyntaxHighlightedSearchQuery } from '../components'
 
 import styles from './SearchHistoryDropdown.module.scss'
 

--- a/client/search-ui/src/results/StreamingSearchResultsList.tsx
+++ b/client/search-ui/src/results/StreamingSearchResultsList.tsx
@@ -8,13 +8,6 @@ import { HoverMerged } from '@sourcegraph/client-api'
 import { Hoverifier } from '@sourcegraph/codeintellify'
 import { TraceSpanProvider } from '@sourcegraph/observability-client'
 import { SearchContextProps } from '@sourcegraph/search'
-import {
-    CommitSearchResult,
-    RepoSearchResult,
-    FileContentSearchResult,
-    FilePathSearchResult,
-    SymbolSearchResult,
-} from '@sourcegraph/search-ui'
 import { ActionItemAction } from '@sourcegraph/shared/src/actions/ActionItem'
 import { FetchFileParameters } from '@sourcegraph/shared/src/backend/file'
 import { FilePrefetcher, PrefetchableFile } from '@sourcegraph/shared/src/components/PrefetchableFile'
@@ -33,6 +26,11 @@ import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
+import { CommitSearchResult } from '../components/CommitSearchResult'
+import { FileContentSearchResult } from '../components/FileContentSearchResult'
+import { FilePathSearchResult } from '../components/FilePathSearchResult'
+import { RepoSearchResult } from '../components/RepoSearchResult'
+import { SymbolSearchResult } from '../components/SymbolSearchResult'
 import { smartSearchClickedEvent } from '../util/events'
 
 import { NoResultsPage } from './NoResultsPage'

--- a/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.tsx
@@ -5,7 +5,6 @@ import classNames from 'classnames'
 
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { pluralize, renderMarkdown } from '@sourcegraph/common'
-import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { Skipped } from '@sourcegraph/shared/src/search/stream'
 import {
     Button,
@@ -19,6 +18,8 @@ import {
     H3,
     Markdown,
 } from '@sourcegraph/wildcard'
+
+import { SyntaxHighlightedSearchQuery } from '../../components'
 
 import { StreamingProgressProps } from './StreamingProgress'
 import { limitHit } from './StreamingProgressCount'

--- a/client/search-ui/src/results/sidebar/FilterLink.tsx
+++ b/client/search-ui/src/results/sidebar/FilterLink.tsx
@@ -3,13 +3,14 @@ import React from 'react'
 import classNames from 'classnames'
 
 import { pluralize } from '@sourcegraph/common'
-import { SyntaxHighlightedSearchQuery, CodeHostIcon } from '@sourcegraph/search-ui'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { Filter } from '@sourcegraph/shared/src/search/stream'
 import { isSettingsValid, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { Button, Tooltip } from '@sourcegraph/wildcard'
+
+import { SyntaxHighlightedSearchQuery, CodeHostIcon } from '../../components'
 
 import { getFiltersOfKind } from './helpers'
 

--- a/client/shared/src/codeintel/legacy-extensions/api.ts
+++ b/client/shared/src/codeintel/legacy-extensions/api.ts
@@ -3,9 +3,9 @@
 import { Observable } from 'rxjs'
 
 import { GraphQLResult } from '@sourcegraph/http-client'
-import { Settings, SettingsCascade } from '@sourcegraph/shared/src/settings/settings'
 
 import { PlatformContext } from '../../platform/context'
+import { Settings, SettingsCascade } from '../../settings/settings'
 
 export interface Unsubscribable {
     unsubscribe(): void

--- a/client/shared/src/commandPalette/CommandList.tsx
+++ b/client/shared/src/commandPalette/CommandList.tsx
@@ -12,7 +12,6 @@ import { Key } from 'ts-key-enum'
 
 import { ContributableMenu, Contributions, Evaluated } from '@sourcegraph/client-api'
 import { memoizeObservable, logger } from '@sourcegraph/common'
-import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import {
     ButtonProps,
     ForwardReferenceComponent,
@@ -35,6 +34,7 @@ import { getContributedActionItems } from '../contributions/contributions'
 import { RequiredExtensionsControllerProps } from '../extensions/controller'
 import { KeyboardShortcut } from '../keyboardShortcuts'
 import { PlatformContextProps } from '../platform/context'
+import { Shortcut } from '../react-shortcuts'
 import { SettingsCascadeOrError } from '../settings/settings'
 import { TelemetryProps } from '../telemetry/telemetryService'
 

--- a/client/shared/src/components/MonacoEditor.tsx
+++ b/client/shared/src/components/MonacoEditor.tsx
@@ -5,9 +5,8 @@ import * as monaco from 'monaco-editor'
 import { Subscription, Subject } from 'rxjs'
 import { map, distinctUntilChanged } from 'rxjs/operators'
 
-import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
-
 import { KeyboardShortcut } from '../keyboardShortcuts'
+import { Shortcut } from '../react-shortcuts'
 import { ThemeProps } from '../theme'
 import { isInputElement } from '../util/dom'
 

--- a/client/shared/src/keyboardShortcuts.ts
+++ b/client/shared/src/keyboardShortcuts.ts
@@ -1,6 +1,7 @@
 import { isMacPlatform } from '@sourcegraph/common'
-import { ModifierKey, Key } from '@sourcegraph/shared/src/react-shortcuts'
-import { getModKey } from '@sourcegraph/shared/src/react-shortcuts/ShortcutManager'
+
+import { ModifierKey, Key } from './react-shortcuts/keys'
+import { getModKey } from './react-shortcuts/ShortcutManager'
 
 /**
  * An action and its associated keybindings.

--- a/client/shared/src/util/globbing.ts
+++ b/client/shared/src/util/globbing.ts
@@ -1,5 +1,6 @@
 import { isErrorLike } from '@sourcegraph/common'
-import { SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
+
+import { SettingsCascadeOrError } from '../settings/settings'
 
 /**
  * Returns "true" if search.globbing is set to true in the final settings, "false" otherwise

--- a/client/web/src/codeintel/ReferencesPanel.story.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.story.tsx
@@ -3,10 +3,11 @@ import * as H from 'history'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
-import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 
 import { ReferencesPanelWithMemoryRouter } from './ReferencesPanel'
 import { buildReferencePanelMocks, defaultProps } from './ReferencesPanel.mocks'
+
+import webStyles from '../SourcegraphWebApp.scss'
 
 const config: Meta = {
     title: 'wildcard/ReferencesPanel',

--- a/client/web/src/global/GlobalAlert.story.tsx
+++ b/client/web/src/global/GlobalAlert.story.tsx
@@ -1,12 +1,13 @@
 import { Meta, Story } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
-import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 import { H1, H2, Code, Text } from '@sourcegraph/wildcard'
 
 import { AlertType } from '../graphql-operations'
 
 import { GlobalAlert } from './GlobalAlert'
+
+import webStyles from '../SourcegraphWebApp.scss'
 
 const config: Meta = {
     title: 'web/GlobalAlert',

--- a/client/web/src/repo/RepoHeader.story.tsx
+++ b/client/web/src/repo/RepoHeader.story.tsx
@@ -6,7 +6,6 @@ import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
 import { CopyPathAction } from '@sourcegraph/search-ui'
 import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 import { Button, H1, H2, Icon, Link } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
@@ -16,6 +15,7 @@ import { FilePathBreadcrumbs } from './FilePathBreadcrumbs'
 import { RepoHeader, RepoHeaderContributionsLifecycleProps } from './RepoHeader'
 import { RepoRevisionContainerBreadcrumb } from './RepoRevisionContainer'
 
+import webStyles from '../SourcegraphWebApp.scss'
 import repoRevisionContainerStyles from './RepoRevisionContainer.module.scss'
 
 const mockUser = {

--- a/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/DateRangeSelect.story.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage/UserManagement/components/DateRangeSelect.story.tsx
@@ -2,9 +2,10 @@ import { DecoratorFn, Meta, Story } from '@storybook/react'
 import { startOfDay, subDays } from 'date-fns'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
-import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 
 import { DateRangeSelect } from './DateRangeSelect'
+
+import webStyles from '../../../../SourcegraphWebApp.scss'
 
 const decorator: DecoratorFn = story => (
     <BrandedStory styles={webStyles}>{() => <div className="container mt-3">{story()}</div>}</BrandedStory>

--- a/client/wildcard/src/components/Charts/components/line-chart/components/legend-list/LegendList.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/components/legend-list/LegendList.tsx
@@ -2,7 +2,7 @@ import { createContext, FC, forwardRef, ReactNode, useContext } from 'react'
 
 import classNames from 'classnames'
 
-import { ForwardReferenceComponent } from '@sourcegraph/wildcard'
+import { ForwardReferenceComponent } from '../../../../../../types'
 
 import styles from './LegendList.module.scss'
 

--- a/client/wildcard/src/components/ErrorAlert/ErrorAlert.tsx
+++ b/client/wildcard/src/components/ErrorAlert/ErrorAlert.tsx
@@ -1,7 +1,6 @@
 import React, { HTMLAttributes } from 'react'
 
-import { Alert, AlertProps } from '@sourcegraph/wildcard'
-
+import { Alert, AlertProps } from '../Alert'
 import { ErrorMessage } from '../ErrorMessage'
 
 export type ErrorAlertProps = {

--- a/client/wildcard/src/components/Form/LoaderInput/LoaderInput.tsx
+++ b/client/wildcard/src/components/Form/LoaderInput/LoaderInput.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { LoadingSpinner } from '@sourcegraph/wildcard'
+import { LoadingSpinner } from '../../LoadingSpinner/LoadingSpinner'
 
 import styles from './LoaderInput.module.scss'
 

--- a/client/wildcard/src/components/Link/LinkOrSpan/LinkOrSpan.tsx
+++ b/client/wildcard/src/components/Link/LinkOrSpan/LinkOrSpan.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
-import { ForwardReferenceComponent, Link } from '@sourcegraph/wildcard'
+import { ForwardReferenceComponent } from '../../../types'
+import { Link } from '../Link/Link'
 
 type LinkOrSpanProps = React.PropsWithChildren<
     {

--- a/client/wildcard/src/components/PageHeader/Breadcrumb/Breadcrumb.tsx
+++ b/client/wildcard/src/components/PageHeader/Breadcrumb/Breadcrumb.tsx
@@ -2,9 +2,8 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { LinkOrSpan } from '@sourcegraph/wildcard'
-
 import { Icon, IconType } from '../../Icon'
+import { LinkOrSpan } from '../../Link/LinkOrSpan/LinkOrSpan'
 
 import styles from './Breadcrumb.module.scss'
 

--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.story.tsx
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.story.tsx
@@ -4,7 +4,8 @@ import { DecoratorFn, Meta, Story } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
 import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
-import { Text } from '@sourcegraph/wildcard'
+
+import { Text } from '../Typography/Text/Text'
 
 import { PageSwitcher } from './PageSwitcher'
 

--- a/client/wildcard/src/hooks/useObservable.test.ts
+++ b/client/wildcard/src/hooks/useObservable.test.ts
@@ -1,5 +1,4 @@
 // causes false positive on act()
-/* eslint-disable @typescript-eslint/no-floating-promises */
 
 import { useMemo, useCallback } from 'react'
 

--- a/client/wildcard/src/utils/linkClickHandler.test.tsx
+++ b/client/wildcard/src/utils/linkClickHandler.test.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react'
 import { createMemoryHistory } from 'history'
 import * as sinon from 'sinon'
 
-import { Link } from '@sourcegraph/wildcard'
+import { Link } from '../components/Link/Link'
 
 import { createLinkClickHandler } from './linkClickHandler'
 


### PR DESCRIPTION
Circular dependencies won't work when compiling with bazel. I found these pretty quick, I assume there's more to come.

## Test plan

CI

## App preview:

- [Web](https://sg-web-bazel-circular-imports.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
