### PR TITLE
map host.docker.internal in executors to the Docker host

### DIFF
--- a/enterprise/cmd/executor/internal/command/docker.go
+++ b/enterprise/cmd/executor/internal/command/docker.go
@@ -2,12 +2,8 @@ package command
 
 import (
 	"fmt"
-	"net/url"
 	"path/filepath"
 	"strconv"
-	"strings"
-
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 )
 
 // ScriptsPath is the location relative to the executor workspace where the executor
@@ -46,7 +42,7 @@ func formatRawOrDockerCommand(spec CommandSpec, dir string, options Options, doc
 			"docker",
 			dockerConfigFlag(dockerConfigPath),
 			"run", "--rm",
-			dockerHostGatewayFlag(),
+			dockerHostGatewayFlag(options.DockerOptions.AddHostGateway),
 			dockerResourceFlags(options.ResourceOptions),
 			dockerVolumeFlags(hostDir),
 			dockerWorkingdirectoryFlags(spec.Dir),
@@ -64,10 +60,8 @@ func formatRawOrDockerCommand(spec CommandSpec, dir string, options Options, doc
 // running uncontainerized in the Docker host. This *only* takes effect if the site config
 // `executors.frontendURL` is a URL with hostname `host.docker.internal`, to reduce the risk of
 // unexpected compatibility or security issues with using --add-host=...  when it is not needed.
-func dockerHostGatewayFlag() []string {
-	const hostDockerInternal = "host.docker.internal"
-	frontendURL, _ := url.Parse(conf.ExecutorsFrontendURL())
-	if frontendURL != nil && frontendURL.Host == hostDockerInternal || strings.HasPrefix(frontendURL.Host, hostDockerInternal+":") {
+func dockerHostGatewayFlag(shouldAdd bool) []string {
+	if shouldAdd {
 		return []string{"--add-host=host.docker.internal:host-gateway"}
 	}
 	return nil

--- a/enterprise/cmd/executor/internal/command/docker_test.go
+++ b/enterprise/cmd/executor/internal/command/docker_test.go
@@ -4,43 +4,82 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestFormatRawOrDockerCommandRaw(t *testing.T) {
-	actual := formatRawOrDockerCommand(
-		CommandSpec{
-			Image:   "sourcegraph/sourcegraph",
-			Command: []string{"ls", "-a"},
-			Dir:     "subdir",
-			Env: []string{
-				`TEST=true`,
-				`CONTAINS_WHITESPACE=yes it does`,
+	t.Run("docker", func(t *testing.T) {
+		actual := formatRawOrDockerCommand(
+			CommandSpec{
+				Image:   "sourcegraph/sourcegraph",
+				Command: []string{"ls", "-a"},
+				Dir:     "subdir",
+				Env: []string{
+					`TEST=true`,
+					`CONTAINS_WHITESPACE=yes it does`,
+				},
+				Operation: makeTestOperation(),
 			},
-			Operation: makeTestOperation(),
-		},
-		"/proj/src",
-		Options{},
-		"/tmp/docker-config",
-	)
+			"/proj/src",
+			Options{},
+			"/tmp/docker-config",
+		)
 
-	expected := command{
-		Command: []string{
-			"docker",
-			"--config", "/tmp/docker-config",
-			"run",
-			"--rm",
-			"-v", "/proj/src:/data",
-			"-w", "/data/subdir",
-			"-e", "TEST=true",
-			"-e", "CONTAINS_WHITESPACE=yes it does",
-			"--entrypoint", "/bin/sh",
-			"sourcegraph/sourcegraph",
-			"/data/.sourcegraph-executor",
-		},
-	}
-	if diff := cmp.Diff(expected, actual, commandComparer); diff != "" {
-		t.Errorf("unexpected command (-want +got):\n%s", diff)
-	}
+		expected := command{
+			Command: []string{
+				"docker",
+				"--config", "/tmp/docker-config",
+				"run",
+				"--rm",
+				"-v", "/proj/src:/data",
+				"-w", "/data/subdir",
+				"-e", "TEST=true",
+				"-e", "CONTAINS_WHITESPACE=yes it does",
+				"--entrypoint", "/bin/sh",
+				"sourcegraph/sourcegraph",
+				"/data/.sourcegraph-executor",
+			},
+		}
+		if diff := cmp.Diff(expected, actual, commandComparer); diff != "" {
+			t.Errorf("unexpected command (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("docker with host gateway", func(t *testing.T) {
+		conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{
+			ExecutorsFrontendURL: "http://host.docker.internal:3080",
+		}})
+		defer conf.Mock(nil)
+
+		actual := formatRawOrDockerCommand(
+			CommandSpec{
+				Image:     "sourcegraph/sourcegraph",
+				Env:       []string{},
+				Operation: makeTestOperation(),
+			},
+			"/proj/src",
+			Options{},
+			"",
+		)
+
+		expected := command{
+			Command: []string{
+				"docker",
+				"run",
+				"--rm",
+				"--add-host=host.docker.internal:host-gateway",
+				"-v", "/proj/src:/data",
+				"-w", "/data",
+				"--entrypoint", "/bin/sh",
+				"sourcegraph/sourcegraph",
+				"/data/.sourcegraph-executor",
+			},
+		}
+		if diff := cmp.Diff(expected, actual, commandComparer); diff != "" {
+			t.Errorf("unexpected command (-want +got):\n%s", diff)
+		}
+	})
 }
 
 func TestFormatRawOrDockerCommandRaw_SrcCli(t *testing.T) {

--- a/enterprise/cmd/executor/internal/command/docker_test.go
+++ b/enterprise/cmd/executor/internal/command/docker_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestFormatRawOrDockerCommandRaw(t *testing.T) {
@@ -47,11 +45,6 @@ func TestFormatRawOrDockerCommandRaw(t *testing.T) {
 	})
 
 	t.Run("docker with host gateway", func(t *testing.T) {
-		conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{
-			ExecutorsFrontendURL: "http://host.docker.internal:3080",
-		}})
-		defer conf.Mock(nil)
-
 		actual := formatRawOrDockerCommand(
 			CommandSpec{
 				Image:     "sourcegraph/sourcegraph",
@@ -59,7 +52,11 @@ func TestFormatRawOrDockerCommandRaw(t *testing.T) {
 				Operation: makeTestOperation(),
 			},
 			"/proj/src",
-			Options{},
+			Options{
+				DockerOptions: DockerOptions{
+					AddHostGateway: true,
+				},
+			},
 			"",
 		)
 

--- a/enterprise/cmd/executor/internal/command/runner.go
+++ b/enterprise/cmd/executor/internal/command/runner.go
@@ -60,6 +60,10 @@ type DockerOptions struct {
 	// DockerAuthConfig, if set, will be used to configure the docker CLI to authenticate to
 	// registries.
 	DockerAuthConfig executor.DockerAuthConfig
+	// AddHostGateway, if set, will add a host entry and route to the daemon host to the
+	// container. This can be useful to add host.docker.internal as an endpoint inside
+	// the container.
+	AddHostGateway bool
 }
 
 type FirecrackerOptions struct {

--- a/enterprise/cmd/executor/internal/run/util.go
+++ b/enterprise/cmd/executor/internal/run/util.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -128,8 +129,13 @@ func workerOptions(c *config.Config) workerutil.WorkerOptions {
 }
 
 func dockerOptions(c *config.Config) command.DockerOptions {
+	u, _ := url.Parse(c.FrontendURL)
 	return command.DockerOptions{
 		DockerAuthConfig: c.DockerAuthConfig,
+		// If the configured Sourcegraph endpoint is host.docker.internal add a
+		// host entry and route to it to the containers. This is used for LSIF
+		// uploads and should not be required anymore once we support native uploads.
+		AddHostGateway: u.Hostname() == "host.docker.internal",
 	}
 }
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2323,7 +2323,7 @@ type SiteConfiguration struct {
 	ExecutorsBatcheshelperImage string `json:"executors.batcheshelperImage,omitempty"`
 	// ExecutorsBatcheshelperImageTag description: The tag to use for the batcheshelper image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.
 	ExecutorsBatcheshelperImageTag string `json:"executors.batcheshelperImageTag,omitempty"`
-	// ExecutorsFrontendURL description: The frontend URL for Sourcegraph. Only root URLs are allowed. If not set, falls back to externalURL
+	// ExecutorsFrontendURL description: The URL where Sourcegraph executors can reach the Sourcegraph instance. If not set, defaults to externalURL. URLs with a path (other than `/`) are not allowed. For Docker executors, the special hostname `host.docker.internal` can be used to refer to the Docker container's host.
 	ExecutorsFrontendURL string `json:"executors.frontendURL,omitempty"`
 	// ExecutorsSrcCLIImage description: The image to use for src-cli in executors. Use this value to pull from a custom image registry.
 	ExecutorsSrcCLIImage string `json:"executors.srcCLIImage,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1079,7 +1079,7 @@
       "group": "Email"
     },
     "executors.frontendURL": {
-      "description": "The frontend URL for Sourcegraph. Only root URLs are allowed. If not set, falls back to externalURL",
+      "description": "The URL where Sourcegraph executors can reach the Sourcegraph instance. If not set, defaults to externalURL. URLs with a path (other than `/`) are not allowed. For Docker executors, the special hostname `host.docker.internal` can be used to refer to the Docker container's host.",
       "type": "string",
       "examples": ["https://sourcegraph.example.com"]
     },


### PR DESCRIPTION
This makes it possible to use executors when externalURL is http://localhost:3080 or similar (which is the case for local installations). In that case, executors.frontendURL needs to be set to http://host.docker.internal:3080, because localhost in the executor container would resolve to the container's localhost.

While the `--add-host=HOST:host-gateway` option is (strangely) not documented in Docker docs, it is supported on Docker for Windows, macOS, and Linux.

Also rewrites the site config description for executor.frontendURL to be a bit clearer.




## Test plan

The CI tests ensure that executors work as expected; i.e., this does not harm the existing expected behavior.