### PR TITLE
gosyntect: IsTreesitterSupported can be a func, not a method

### DIFF
--- a/cmd/frontend/internal/highlight/highlight.go
+++ b/cmd/frontend/internal/highlight/highlight.go
@@ -345,7 +345,7 @@ func Code(ctx context.Context, p Params) (response *HighlightedCode, aborted boo
 	// TODO: It could be worthwhile to log that this language isn't supported or something
 	// like that? Otherwise there is no feedback that this configuration isn't currently working,
 	// which is a bit of a confusing situation for the user.
-	if !client.IsTreesitterSupported(filetypeQuery.Language) {
+	if !gosyntect.IsTreesitterSupported(filetypeQuery.Language) {
 		filetypeQuery.Engine = EngineSyntect
 	}
 

--- a/internal/gosyntect/gosyntect.go
+++ b/internal/gosyntect/gosyntect.go
@@ -157,7 +157,7 @@ func normalizeFiletype(filetype string) string {
 	return normalized
 }
 
-func (c *Client) IsTreesitterSupported(filetype string) bool {
+func IsTreesitterSupported(filetype string) bool {
 	_, contained := supportedFiletypes[normalizeFiletype(filetype)]
 	return contained
 }
@@ -173,7 +173,7 @@ func (c *Client) Highlight(ctx context.Context, q *Query, format HighlightRespon
 	// Normalize filetype
 	q.Filetype = normalizeFiletype(q.Filetype)
 
-	if q.Engine == SyntaxEngineTreesitter && !c.IsTreesitterSupported(q.Filetype) {
+	if q.Engine == SyntaxEngineTreesitter && !IsTreesitterSupported(q.Filetype) {
 		return nil, errors.New("Not a valid treesitter filetype")
 	}
 


### PR DESCRIPTION
Minor refactor.

## Test plan

Just a refactor, no manual test needed.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->