### PR TITLE
split apart metrics used for precise-code-intel-worker vs. worker

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/background/job_worker_handler.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_worker_handler.go
@@ -100,7 +100,7 @@ func NewUploadProcessorHandler(
 	numProcessorRoutines int,
 	budgetMax int64,
 ) workerutil.Handler[codeinteltypes.Upload] {
-	operations := newOperations(observationCtx)
+	operations := newWorkerOperations(observationCtx)
 
 	return &handler{
 		store:           store,

--- a/enterprise/internal/codeintel/uploads/internal/background/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/observability.go
@@ -10,12 +10,35 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-type operations struct {
-	updateUploadsVisibleToCommits *observation.Operation
-
-	// Worker metrics
+type workerOperations struct {
 	uploadProcessor *observation.Operation
 	uploadSizeGuage prometheus.Gauge
+}
+
+func newWorkerOperations(observationCtx *observation.Context) *workerOperations {
+	honeyobservationCtx := *observationCtx
+	honeyobservationCtx.HoneyDataset = &honey.Dataset{Name: "codeintel-worker"}
+	uploadProcessor := honeyobservationCtx.Operation(observation.Op{
+		Name: "codeintel.uploadHandler",
+		ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+			return observation.EmitForTraces | observation.EmitForHoney
+		},
+	})
+
+	uploadSizeGuage := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "src_codeintel_upload_processor_upload_size",
+		Help: "The combined size of uploads being processed at this instant by this worker.",
+	})
+	observationCtx.Registerer.MustRegister(uploadSizeGuage)
+
+	return &workerOperations{
+		uploadProcessor: uploadProcessor,
+		uploadSizeGuage: uploadSizeGuage,
+	}
+}
+
+type operations struct {
+	updateUploadsVisibleToCommits *observation.Operation
 
 	numReconcileScansFromFrontend      prometheus.Counter
 	numReconcileDeletesFromFrontend    prometheus.Counter
@@ -70,27 +93,8 @@ func newOperations(observationCtx *observation.Context) *operations {
 		"The number of abandoned uploads deleted from the codeintel-db.",
 	)
 
-	honeyobservationCtx := *observationCtx
-	honeyobservationCtx.HoneyDataset = &honey.Dataset{Name: "codeintel-worker"}
-	uploadProcessor := honeyobservationCtx.Operation(observation.Op{
-		Name: "codeintel.uploadHandler",
-		ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
-			return observation.EmitForTraces | observation.EmitForHoney
-		},
-	})
-
-	uploadSizeGuage := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "src_codeintel_upload_processor_upload_size",
-		Help: "The combined size of uploads being processed at this instant by this worker.",
-	})
-	observationCtx.Registerer.MustRegister(uploadSizeGuage)
-
 	return &operations{
 		updateUploadsVisibleToCommits: op("UpdateUploadsVisibleToCommits"),
-
-		// Worker metrics
-		uploadProcessor: uploadProcessor,
-		uploadSizeGuage: uploadSizeGuage,
 
 		numReconcileScansFromFrontend:      numReconcileScansFromFrontend,
 		numReconcileDeletesFromFrontend:    numReconcileDeletesFromFrontend,


### PR DESCRIPTION
The `newOperations` func was called by both the precise-code-intel-worker and the worker. The `uploadProcessor` and `uploadSizeGuage` (sic) were used by the former but not the latter. This refactor makes it so that each service only instantiates the actual metrics it truly uses and needs.

(This is also useful for the experimental single-program distribution, where we want both services to run in the same process, but it's a plausible refactor on its own as well.)


## Test plan

Just a code refactor, no test plan needed.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->