### PR TITLE
Wildcard [LineChart]: Fix line chart runtime data processing

### DIFF
--- a/client/wildcard/src/components/Charts/components/line-chart/keyboard-navigation.ts
+++ b/client/wildcard/src/components/Charts/components/line-chart/keyboard-navigation.ts
@@ -244,7 +244,9 @@ function getBelowPointId<Datum>(
  * Returns sorted series list by the first datum value in each series dataset.
  */
 export function getSortedByFirstPointSeries<Datum>(series: SeriesWithData<Datum>[]): SeriesWithData<Datum>[] {
-    return [...series].sort((a, b) => getDatumValue(a.data[0]) - getDatumValue(b.data[0]))
+    return [...series]
+        .filter(series => series.data.length > 0)
+        .sort((a, b) => getDatumValue(a.data[0]) - getDatumValue(b.data[0]))
 }
 
 function findLastWithSameValue<T, D>(list: T[], mapper: (item: T) => D): T | null {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/45782

## Problem 
In the line chart, we have to sort series elements by their first element values for the proper 2d keyboard navigation grid order. But in code insight, we have a case when the series (line data) is empty but has a representation in the legend. Empty data set means that there is no first element value, and because of this, we had the following screen in the code insights UI 

<img width="521" alt="Screenshot 2022-12-17 at 22 11 49" src="https://user-images.githubusercontent.com/18492575/208272318-0b6425b0-33ad-4005-bd81-e4d57fe2d88a.png">

## Test plan
- Make sure that [this insight](https://sourcegraph.test:3443/insights/insight/aW5zaWdodF92aWV3OiIyRTJTZGtwc2xMZ3A1SmJOT1o2WFF0SXRGMW8i) (this is a link to the insight from the `sourcegraph.sourcegraph.com` staging) is rendered properly on the code insight dashboard and insight standalone pages.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-line-chart-data-processing.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
