### PR TITLE
Add hover state for the insight card legend list items

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.module.scss
@@ -30,6 +30,10 @@
                 flex-wrap: nowrap;
                 flex-direction: column;
             }
+
+            .legend-list-item {
+                width: 100%;
+            }
         }
     }
 }
@@ -65,6 +69,8 @@
 
 .legend-list-container {
     grid-area: legend;
+    // Visually compensate legend list items padding spacings
+    margin: -0.125rem -0.25rem;
 
     &::-webkit-scrollbar {
         width: 0.25rem;
@@ -82,9 +88,15 @@
     }
 }
 
+.legend-list {
+    // Reset standard legend list gaps, list items will handle
+    // x and y spacing themselves.
+    column-gap: 0;
+    row-gap: 0;
+}
+
 .legend-list-item {
     // Reset wildcard button styles
-    padding: 0;
     margin: 0;
     font-weight: normal;
     font-size: inherit;
@@ -92,6 +104,14 @@
     line-height: inherit;
     display: flex;
     border: none;
+    padding: 0.125rem 0.25rem;
+
+    &--interactive {
+        &:hover,
+        &:focus {
+            background-color: var(--secondary-2);
+        }
+    }
 }
 
 .alert-overlay {

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-chart/BackendInsightChart.tsx
@@ -181,7 +181,7 @@ const SeriesLegends: FC<SeriesLegendsProps> = props => {
                     <Button
                         role="checkbox"
                         aria-checked={isSeriesSelected(`${item.id}`)}
-                        className={styles.legendListItem}
+                        className={classNames(styles.legendListItem, styles.legendListItemInteractive)}
                         onPointerEnter={() => setHoveredId(`${item.id}`)}
                         onPointerLeave={() => setHoveredId(undefined)}
                         onFocus={() => setHoveredId(`${item.id}`)}


### PR DESCRIPTION

This PR simply adds hover and focus state for the legend items within the code insights card 

<img width="510" alt="Screenshot 2022-12-18 at 01 19 06" src="https://user-images.githubusercontent.com/18492575/208281319-09d45510-b590-426e-91c9-54d9e5d987b6.png">

## Test plan
- Check that insight with more than just one series has a proper hover state over the series legend blocks 
- Check light and dark theme

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
