### PR TITLE
search: bring back search-debug

### DIFF
--- a/client/search-ui/src/components/FileContentSearchResult.tsx
+++ b/client/search-ui/src/components/FileContentSearchResult.tsx
@@ -267,6 +267,7 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
             repoStars={result.repoStars}
             className={classNames(styles.copyButtonContainer, containerClassName)}
             resultClassName={resultContainerStyles.highlightResult}
+            rankingDebug={result.debug}
             ref={rootRef}
         >
             <div data-testid="file-search-result" data-expanded={expanded}>

--- a/client/search-ui/src/components/FilePathSearchResult.tsx
+++ b/client/search-ui/src/components/FilePathSearchResult.tsx
@@ -59,6 +59,7 @@ export const FilePathSearchResult: React.FunctionComponent<FilePathSearchResult 
             onResultClicked={onSelect}
             repoName={result.repository}
             repoStars={result.repoStars}
+            rankingDebug={result.debug}
             className={classNames(styles.copyButtonContainer, containerClassName)}
         >
             <div className={classNames(styles.searchResultMatch, 'p-2')}>

--- a/client/search-ui/src/components/ResultContainer.tsx
+++ b/client/search-ui/src/components/ResultContainer.tsx
@@ -21,6 +21,7 @@ export interface ResultContainerProps {
     resultType?: SearchMatch['type']
     repoName: string
     className?: string
+    rankingDebug?: string
     onResultClicked?: () => void
 }
 
@@ -49,6 +50,7 @@ export const ResultContainer: ForwardReferenceExoticComponent<
         resultType,
         repoName,
         className,
+        rankingDebug,
         as: Component = 'div',
         onResultClicked,
     } = props
@@ -84,6 +86,7 @@ export const ResultContainer: ForwardReferenceExoticComponent<
                         </span>
                     )}
                 </div>
+                {rankingDebug && <div>{rankingDebug}</div>}
                 <div className={classNames(styles.result, resultClassName)}>{children}</div>
             </article>
         </Component>

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -326,6 +326,10 @@ func fromPathMatch(fm *result.FileMatch, repoCache map[api.RepoID]*types.Searche
 		pathEvent.Branches = []string{*fm.InputRev}
 	}
 
+	if fm.Debug != nil {
+		pathEvent.Debug = *fm.Debug
+	}
+
 	return pathEvent
 }
 

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -51,6 +51,7 @@ type EventPathMatch struct {
 	RepoLastFetched *time.Time `json:"repoLastFetched,omitempty"`
 	Branches        []string   `json:"branches,omitempty"`
 	Commit          string     `json:"commit,omitempty"`
+	Debug           string     `json:"debug,omitempty"`
 }
 
 func (e *EventPathMatch) eventMatch() {}


### PR DESCRIPTION
I wanted to debug a ranking issue and noticed that we don't display the ranking debug info anymore. The debug info was removed in #43155.  This PR brings it back and adds the debug info for path matches, too.

Note: the debug-info can be toggled per request with `&feat=search-debug` or globally via the feature flag `search-debug`.

### Content
<img width="1257" alt="Screenshot 2022-12-19 at 11 08 27" src="https://user-images.githubusercontent.com/26413131/208401060-cfee4d14-dc7f-4e56-be31-6b2e129d8bef.png">

### Path
<img width="1260" alt="Screenshot 2022-12-19 at 11 08 14" src="https://user-images.githubusercontent.com/26413131/208401092-ebb7f2bf-dd73-49f6-b52d-254a810669f2.png">


## Test plan
- Manual testing on a local Sourcegraph instance
