### PR TITLE
insights: update live preview to support repo selection via search

### DIFF
--- a/enterprise/internal/insights/query/querybuilder/builder_test.go
+++ b/enterprise/internal/insights/query/querybuilder/builder_test.go
@@ -631,3 +631,37 @@ func TestRepositoryScopeQuery(t *testing.T) {
 		})
 	}
 }
+
+func TestWithCount(t *testing.T) {
+	tests := []struct {
+		input BasicQuery
+		want  autogold.Value
+	}{
+		{
+			BasicQuery("repo:sourcegraph"),
+			autogold.Want("adds count", BasicQuery("repo:sourcegraph count:99")),
+		},
+		{
+			BasicQuery("repo:s or repo:l"),
+			autogold.Want("compound query", BasicQuery("(repo:s count:99 OR repo:l count:99)")),
+		},
+		{
+			BasicQuery("repo:a count:1"),
+			autogold.Want("overwrites count values", BasicQuery("repo:a count:99")),
+		},
+		{
+			BasicQuery("repo:a count:all"),
+			autogold.Want("overwrites count all", BasicQuery("repo:a count:99")),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.want.Name(), func(t *testing.T) {
+			got, err := test.input.WithCount("99")
+			if err != nil {
+				test.want.Equal(t, err.Error())
+			} else {
+				test.want.Equal(t, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
If requested this  runs a repo search to get the list of repos to run live preview over.  Limits the repo search  to +1 the number of repos that are permitted for live preview to avoid pulling unnecessary data.

part of https://github.com/sourcegraph/sourcegraph/issues/45219

## Test plan
Verified live preview continues to work
Manually tested passing repo search for the repos selection:

```graphql
query GetInsightPreview($input: SearchInsightPreviewInput!) {
  searchInsightPreview(input: $input) {
    points {
      dateTime
      value
      __typename
    }
    label
    __typename
  }
}
```

Verified - results for input
```json
{
  "input": {
    "series": [
      {
        "query": "InsightSeries",
        "label": "seriesa",
        "generatedFromCaptureGroups": false
      }
    ],
    "repositoryScope": {
      "repositories": [],
      "repositoryCriteria": "-repo:^github.com/sgtest/megarepo$"
    },
    "timeScope": {
      "stepInterval": {
        "unit": "MONTH",
        "value": 2
      }
    }
  }
}
```

Verified correct error messages (limited repos to 5 for testing purposes)
```json
{
  "errors": [
    {
      "message": "live preview is limited to 5 repositories",
      "path": [
        "searchInsightPreview"
      ]
    }
  ],
  "data": null
}

{
  "errors": [
    {
      "message": "group by insights do not support a repository search",
      "path": [
        "searchInsightPreview"
      ]
    }
  ],
  "data": null
}
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
