### PR TITLE
bazel: add initial sass compilation

### DIFF
--- a/client/branded/BUILD.bazel
+++ b/client/branded/BUILD.bazel
@@ -1,0 +1,16 @@
+load("//dev:defs.bzl", "sass")
+
+sass(
+    name = "base-css",
+    srcs = [
+        "src/global-styles/base.scss",
+    ],
+    deps = glob(
+        ["src/global-styles/**/*.scss"],
+        exclude = ["src/global-styles/base.scss"],
+    ) + [
+        "//:node_modules/open-color",
+        "//client/shared:global-style-vars",
+        "//client/wildcard:global-style-vars",
+    ],
+)

--- a/client/shared/BUILD.bazel
+++ b/client/shared/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@aspect_rules_js//js:defs.bzl", "js_run_binary")
+load("//dev:defs.bzl", "sass_library")
 load("//client/shared/dev:generate_schema.bzl", "generate_schema")
 
 js_run_binary(
@@ -20,3 +21,11 @@ js_run_binary(
     "settings",
     "batch_spec",
 ]]
+
+sass_library(
+    name = "global-style-vars",
+    srcs = [
+        "src/global-styles/icons.scss",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/client/wildcard/BUILD.bazel
+++ b/client/wildcard/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//dev:defs.bzl", "sass_library")
+
+sass_library(
+    name = "global-style-vars",
+    srcs = [
+        "src/global-styles/breakpoints.scss",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/dev/defs.bzl
+++ b/dev/defs.bzl
@@ -1,4 +1,6 @@
 load("@aspect_rules_ts//ts:defs.bzl", _ts_project = "ts_project")
+load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@npm//:sass/package_json.bzl", sass_bin = "bin")
 
 def ts_project(name, deps = [], **kwargs):
     deps = deps + [
@@ -19,5 +21,32 @@ def ts_project(name, deps = [], **kwargs):
         source_map = True,
 
         # Allow any other args
+        **kwargs
+    )
+
+def sass(name, srcs, deps = [], **kwargs):
+    sass_bin.sass(
+        name = name,
+        srcs = srcs + deps,
+        outs = [src.replace(".scss", ".css") for src in srcs],
+        args = [
+            "--load-path=client",
+            "--load-path=node_modules",
+        ] + [
+            "$(execpath {}):{}/{}".format(src, native.package_name(), src.replace(".scss", ".css"))
+            for src in srcs
+        ],
+
+        # Default visiblity
+        visibility = kwargs.pop("visibility", ["//visibility:public"]),
+
+        # Allow any other args
+        **kwargs
+    )
+
+def sass_library(name, srcs, **kwargs):
+    copy_to_bin(
+        name = name,
+        srcs = srcs,
         **kwargs
     )


### PR DESCRIPTION
This is the initial `sass` macro and using it in a few places, nothing depends on that compiled css yet though.

## Test plan

Nothing atm, we need bazel on CI...

## App preview:

- [Web](https://sg-web-bazel-sass-init.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
