### PR TITLE
web: update dev-server config to fix caddy connection

### DIFF
--- a/client/web/dev/utils/constants.ts
+++ b/client/web/dev/utils/constants.ts
@@ -3,8 +3,8 @@ import path from 'path'
 import { ROOT_PATH } from '@sourcegraph/build-config'
 
 export const STATIC_ASSETS_URL = '/.assets/'
-export const DEV_SERVER_LISTEN_ADDR = { host: 'localhost', port: 3080 } as const
-export const DEV_SERVER_PROXY_TARGET_ADDR = { host: 'localhost', port: 3081 } as const
+export const DEV_SERVER_LISTEN_ADDR = { host: '127.0.0.1', port: 3080 } as const
+export const DEV_SERVER_PROXY_TARGET_ADDR = { host: '127.0.0.1', port: 3081 } as const
 export const DEFAULT_SITE_CONFIG_PATH = path.resolve(ROOT_PATH, '../dev-private/enterprise/dev/site-config.json')
 
 export const WEBPACK_STATS_OPTIONS = {


### PR DESCRIPTION
## Context

Fixes the caddy error: "dial tcp 127.0.0.1:3080: connect: connection refused" when running `sg start enterprise-e2e`. It's related to the update here: https://github.com/sourcegraph/sourcegraph/pull/38955. Reverting changes in the linked PR fixes the issue without updates introduced in this PR.

## Test plan

1. change `ignoreStderr` for caddy to `false` in `sg.config.yaml`
2. `sg start enterprise-e2e`
3. open https://sourcegraph.test:3443/
4. caddy is happy with no errors in the output

## App preview:

- [Web](https://sg-web-vb-caddy-proxy.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
