### PR TITLE
web: eliminate type import circles between `shared` and `web`

### DIFF
--- a/client/shared/src/settings/temporary/TemporarySettings.ts
+++ b/client/shared/src/settings/temporary/TemporarySettings.ts
@@ -1,7 +1,5 @@
 import { Optional } from 'utility-types'
 
-// eslint-disable-next-line no-restricted-imports
-import { TourListState } from '@sourcegraph/web/src/tour/components/Tour/useTour'
 import { MultiSelectState } from '@sourcegraph/wildcard'
 
 import { BatchChangeState } from '../../graphql-operations'
@@ -9,6 +7,7 @@ import { BatchChangeState } from '../../graphql-operations'
 import { DiffMode } from './diffMode'
 import { RecentSearch } from './recentSearches'
 import { SectionID, NoResultsSectionID } from './searchSidebar'
+import { TourListState } from './tourState'
 
 /**
  * Schema for temporary settings.

--- a/client/shared/src/settings/temporary/index.ts
+++ b/client/shared/src/settings/temporary/index.ts
@@ -1,0 +1,2 @@
+export * from './tourState'
+export * from './useTemporarySetting'

--- a/client/shared/src/settings/temporary/tourState.ts
+++ b/client/shared/src/settings/temporary/tourState.ts
@@ -1,3 +1,5 @@
+import { Optional } from 'utility-types'
+
 /**
  * Tour supported languages
  */
@@ -56,3 +58,11 @@ export interface TourTaskStepType {
      */
     isCompleted?: boolean
 }
+
+export interface TourState {
+    completedStepIds?: string[]
+    status?: 'closed' | 'completed'
+    language?: TourLanguage
+}
+
+export type TourListState = Optional<Record<string, TourState>>

--- a/client/shared/src/settings/temporary/tourState.ts
+++ b/client/shared/src/settings/temporary/tourState.ts
@@ -1,3 +1,13 @@
+/**
+ * These types should be defined in the `web` package but because of the
+ * fact that temporary settings rely on the shared global type schema there's
+ * no way to inject web specific types into the `useTemporarySetting` hook.
+ *
+ * We need to introduce an ability to inject app specific temporary settings
+ * into the hook and split the global schema into respective packages.
+ * https://github.com/sourcegraph/sourcegraph/issues/45836
+ *
+ */
 import { Optional } from 'utility-types'
 
 /**

--- a/client/shared/src/testing/integration/context.ts
+++ b/client/shared/src/testing/integration/context.ts
@@ -16,8 +16,6 @@ import { first, timeoutWith } from 'rxjs/operators'
 import { STATIC_ASSETS_PATH } from '@sourcegraph/build-config'
 import { logger, asError, keyExistsIn } from '@sourcegraph/common'
 import { ErrorGraphQLResult, GraphQLResult } from '@sourcegraph/http-client'
-// eslint-disable-next-line no-restricted-imports
-import { SourcegraphContext } from '@sourcegraph/web/src/jscontext'
 
 import { getConfig } from '../config'
 import { recordCoverage } from '../coverage'
@@ -98,8 +96,12 @@ export interface IntegrationTestOptions {
     /**
      * Test specific JS context object override. It's used in order to override
      * standard JSContext object for some particulars test.
+     *
+     * The `SourcegraphContext` type from `client/web/src/jscontext` should be used here
+     * but it creates a circular dependency between packages. So until it's resolved the
+     * generic `object` type is used here.
      */
-    customContext?: Partial<SourcegraphContext>
+    customContext?: object
 }
 
 const DISPOSE_ACTION_TIMEOUT = 5 * 1000

--- a/client/web/src/tour/components/Tour/Tour.test.tsx
+++ b/client/web/src/tour/components/Tour/Tour.test.tsx
@@ -4,10 +4,10 @@ import { CompatRouter } from 'react-router-dom-v5-compat'
 import sinon from 'sinon'
 
 import { MockTemporarySettings } from '@sourcegraph/shared/src/settings/temporary/testUtils'
+import { TourLanguage, TourTaskStepType, TourTaskType } from '@sourcegraph/shared/src/settings/temporary'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { Tour } from './Tour'
-import { TourLanguage, TourTaskStepType, TourTaskType } from './types'
 
 const TourId = 'MockTour'
 const StepVideo: TourTaskStepType = {

--- a/client/web/src/tour/components/Tour/Tour.test.tsx
+++ b/client/web/src/tour/components/Tour/Tour.test.tsx
@@ -3,8 +3,8 @@ import { MemoryRouter } from 'react-router'
 import { CompatRouter } from 'react-router-dom-v5-compat'
 import sinon from 'sinon'
 
-import { MockTemporarySettings } from '@sourcegraph/shared/src/settings/temporary/testUtils'
 import { TourLanguage, TourTaskStepType, TourTaskType } from '@sourcegraph/shared/src/settings/temporary'
+import { MockTemporarySettings } from '@sourcegraph/shared/src/settings/temporary/testUtils'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { Tour } from './Tour'

--- a/client/web/src/tour/components/Tour/Tour.tsx
+++ b/client/web/src/tour/components/Tour/Tour.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useEffect, useMemo } from 'react'
 
+import { TourLanguage, TourTaskStepType, TourTaskType } from '@sourcegraph/shared/src/settings/temporary'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { TourContext } from './context'
 import { TourAgent } from './TourAgent'
 import { TourContent } from './TourContent'
-import { TourTaskType, TourLanguage, TourTaskStepType } from './types'
 import { useTour } from './useTour'
 import { isLanguageRequired } from './utils'
 

--- a/client/web/src/tour/components/Tour/TourAgent.tsx
+++ b/client/web/src/tour/components/Tour/TourAgent.tsx
@@ -4,11 +4,11 @@ import { mdiCheckCircle } from '@mdi/js'
 import ReactDOM from 'react-dom'
 import { useLocation } from 'react-router-dom'
 
+import { TourTaskStepType, TourTaskType } from '@sourcegraph/shared/src/settings/temporary'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Icon } from '@sourcegraph/wildcard'
 
 import { GETTING_STARTED_TOUR_MARKER } from './TourInfo'
-import { TourTaskType, TourTaskStepType } from './types'
 import { parseURIMarkers } from './utils'
 
 import styles from './Tour.module.scss'

--- a/client/web/src/tour/components/Tour/TourContent.tsx
+++ b/client/web/src/tour/components/Tour/TourContent.tsx
@@ -9,6 +9,8 @@ import { Button, Icon, Text } from '@sourcegraph/wildcard'
 
 import { MarketingBlock } from '../../../components/MarketingBlock'
 
+import { TourTask } from './TourTask'
+
 import styles from './Tour.module.scss'
 
 interface TourContentProps {

--- a/client/web/src/tour/components/Tour/TourContent.tsx
+++ b/client/web/src/tour/components/Tour/TourContent.tsx
@@ -4,12 +4,10 @@ import { mdiClose, mdiCheckCircle } from '@mdi/js'
 import classNames from 'classnames'
 import { chunk, upperFirst } from 'lodash'
 
+import { TourTaskType } from '@sourcegraph/shared/src/settings/temporary'
 import { Button, Icon, Text } from '@sourcegraph/wildcard'
 
 import { MarketingBlock } from '../../../components/MarketingBlock'
-
-import { TourTask } from './TourTask'
-import { TourTaskType } from './types'
 
 import styles from './Tour.module.scss'
 

--- a/client/web/src/tour/components/Tour/TourNewTabLink.tsx
+++ b/client/web/src/tour/components/Tour/TourNewTabLink.tsx
@@ -1,8 +1,7 @@
 import { FunctionComponent } from 'react'
 
+import { TourTaskStepType } from '@sourcegraph/shared/src/settings/temporary'
 import { ButtonLink, Link } from '@sourcegraph/wildcard'
-
-import { TourTaskStepType } from './types'
 
 export interface NewTabLinkProps {
     step: TourTaskStepType

--- a/client/web/src/tour/components/Tour/TourTask.tsx
+++ b/client/web/src/tour/components/Tour/TourTask.tsx
@@ -7,13 +7,13 @@ import { useHistory } from 'react-router-dom'
 
 import { isExternalLink } from '@sourcegraph/common'
 import { ModalVideo } from '@sourcegraph/search-ui'
+import { TourLanguage, TourTaskStepType, TourTaskType } from '@sourcegraph/shared/src/settings/temporary'
 import { Button, Icon, Link, Text } from '@sourcegraph/wildcard'
 
 import { ItemPicker } from '../ItemPicker'
 
 import { TourContext } from './context'
 import { TourNewTabLink } from './TourNewTabLink'
-import { TourTaskType, TourLanguage, TourTaskStepType } from './types'
 import { isLanguageRequired, getTourTaskStepActionValue } from './utils'
 
 import styles from './Tour.module.scss'

--- a/client/web/src/tour/components/Tour/context.tsx
+++ b/client/web/src/tour/components/Tour/context.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { TourLanguage, TourTaskStepType } from './types'
+import { TourLanguage, TourTaskStepType } from '@sourcegraph/shared/src/settings/temporary'
 
 interface TourContextType {
     /**

--- a/client/web/src/tour/components/Tour/useTour.test.tsx
+++ b/client/web/src/tour/components/Tour/useTour.test.tsx
@@ -1,10 +1,10 @@
 import { renderHook, cleanup, act } from '@testing-library/react'
 import { WrapperComponent } from '@testing-library/react-hooks'
 
+import { TourLanguage } from '@sourcegraph/shared/src/settings/temporary'
 import { TemporarySettings } from '@sourcegraph/shared/src/settings/temporary/TemporarySettings'
 import { MockTemporarySettings } from '@sourcegraph/shared/src/settings/temporary/testUtils'
 
-import { TourLanguage } from './types'
 import { useTour, TourState } from './useTour'
 
 /**

--- a/client/web/src/tour/components/Tour/useTour.ts
+++ b/client/web/src/tour/components/Tour/useTour.ts
@@ -3,9 +3,7 @@ import { useCallback } from 'react'
 import { omit, uniq } from 'lodash'
 import { Optional } from 'utility-types'
 
-import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
-
-import { TourLanguage } from './types'
+import { useTemporarySetting, TourLanguage } from '@sourcegraph/shared/src/settings/temporary'
 
 export interface TourState {
     completedStepIds?: string[]

--- a/client/web/src/tour/components/Tour/utils.tsx
+++ b/client/web/src/tour/components/Tour/utils.tsx
@@ -1,6 +1,6 @@
 import isAbsoluteURL from 'is-absolute-url'
 
-import { TourLanguage, TourTaskStepType } from './types'
+import { TourLanguage, TourTaskStepType } from '@sourcegraph/shared/src/settings/temporary'
 
 /**
  * Returns a new URL w/ tour state tracking query parameters. This is used to show/hide tour task info box.

--- a/client/web/src/tour/data/index.tsx
+++ b/client/web/src/tour/data/index.tsx
@@ -1,8 +1,7 @@
 import { mdiCheckCircle, mdiMagnify, mdiPuzzleOutline, mdiShieldSearch, mdiNotebook, mdiCursorPointer } from '@mdi/js'
 
+import { TourLanguage, TourTaskType } from '@sourcegraph/shared/src/settings/temporary'
 import { Code, Icon } from '@sourcegraph/wildcard'
-
-import { TourLanguage, TourTaskType } from '../components/Tour/types'
 
 /**
  * Tour tasks for non-authenticated users


### PR DESCRIPTION
## Context

This PR removes part of the circular dependency between the `web` and `shared` packages. See [the Client packages cyclic dependencies document](https://docs.google.com/document/d/1AbRH8k7CqQzq2MIFupyL7FOMq-SiUIWkYxZE8fyRqBg/edit) for more context.

## Test plan

1. CI is green
2. There're no type imports from the `web` package into the `shared` package.

## App preview:

- [Web](https://sg-web-vb-web-shared-circle-1.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

