### PR TITLE
web: replace `WebStory` with `BrandedStory` in the `shared` package

### DIFF
--- a/client/shared/src/actions/ActionItem.story.tsx
+++ b/client/shared/src/actions/ActionItem.story.tsx
@@ -3,9 +3,8 @@ import { DecoratorFn, Meta, Story } from '@storybook/react'
 import * as H from 'history'
 import { NEVER } from 'rxjs'
 
+import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
 import { subtypeOf } from '@sourcegraph/common'
-// eslint-disable-next-line no-restricted-imports
-import { WebStory } from '@sourcegraph/web/src/components/WebStory'
 
 import { NOOP_TELEMETRY_SERVICE } from '../telemetry/telemetryService'
 
@@ -38,7 +37,7 @@ const commonProps = subtypeOf<Partial<ActionItemProps>>()({
     active: true,
 })
 
-const decorator: DecoratorFn = story => <WebStory>{() => <div className="p-4">{story()}</div>}</WebStory>
+const decorator: DecoratorFn = story => <BrandedStory>{() => <div className="p-4">{story()}</div>}</BrandedStory>
 
 const config: Meta = {
     title: 'shared/ActionItem',

--- a/client/shared/src/notifications/NotificationItem.story.tsx
+++ b/client/shared/src/notifications/NotificationItem.story.tsx
@@ -3,8 +3,8 @@ import { DecoratorFn, Meta, Story } from '@storybook/react'
 import { of } from 'rxjs'
 import { NotificationType as NotificationTypeType } from 'sourcegraph'
 
+import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
 import { NotificationType } from '@sourcegraph/extension-api-classes'
-import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 
 import { NotificationItem } from './NotificationItem'
 
@@ -19,11 +19,9 @@ const notificationClassNames = {
 const onDismiss = action('onDismiss')
 
 const decorator: DecoratorFn = story => (
-    <>
-        <style>{webStyles}</style>
-        <div style={{ maxWidth: '20rem', margin: '2rem' }}>{story()}</div>
-    </>
+    <BrandedStory>{() => <div style={{ maxWidth: '20rem', margin: '2rem' }}>{story()}</div>}</BrandedStory>
 )
+
 const config: Meta = {
     title: 'shared/NotificationItem',
     decorators: [decorator],

--- a/client/shared/src/symbols/SymbolTag.story.tsx
+++ b/client/shared/src/symbols/SymbolTag.story.tsx
@@ -1,7 +1,6 @@
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 
-// eslint-disable-next-line no-restricted-imports
-import { WebStory } from '@sourcegraph/web/src/components/WebStory'
+import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
 
 import { SymbolKind } from '../graphql-operations'
 
@@ -10,7 +9,7 @@ import { SymbolTag } from './SymbolTag'
 const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
-    title: 'client/shared/src/symbols/SymbolTag',
+    title: 'shared/SymbolTag',
     parameters: {
         chromatic: { disableSnapshots: false },
     },
@@ -22,7 +21,7 @@ export default config
 const symbolKinds = Object.values(SymbolKind)
 
 export const Default: Story = () => (
-    <WebStory>
+    <BrandedStory>
         {() => (
             <div>
                 {symbolKinds.map(symbolKind => (
@@ -32,5 +31,5 @@ export const Default: Story = () => (
                 ))}
             </div>
         )}
-    </WebStory>
+    </BrandedStory>
 )


### PR DESCRIPTION
## Context

This PR removes part of the circular dependency between the `web` and `shared` packages. See [the Client packages cyclic dependencies document](https://docs.google.com/document/d/1AbRH8k7CqQzq2MIFupyL7FOMq-SiUIWkYxZE8fyRqBg/edit) for more context.

## Test plan

1. CI is green
2. Web styles and the `WebStory` component are not imported into the `shared` package.

## App preview:

- [Web](https://sg-web-vb-web-shared-circle-2.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

