### PR TITLE
Add BaseURL helper method to ExternalService

### DIFF
--- a/cmd/frontend/webhooks/github_webhooks.go
+++ b/cmd/frontend/webhooks/github_webhooks.go
@@ -51,15 +51,10 @@ func (h *GitHubWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	SetExternalServiceID(r.Context(), extSvc.ID)
 
-	codeHostURN, ok, err := extSvc.BaseURL(r.Context())
+	codeHostURN, err := extSvc.BaseURL(r.Context())
 	if err != nil {
-		log15.Error("Could not parse code host URL from config", "error", err)
+		log15.Error("Could not get code host URL from config", "error", err)
 		http.Error(w, "Invalid code host URL", http.StatusInternalServerError)
-		return
-	}
-	if !ok {
-		log15.Error("External service config is not a GitHub config with a URL")
-		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
 		return
 	}
 

--- a/cmd/frontend/webhooks/github_webhooks.go
+++ b/cmd/frontend/webhooks/github_webhooks.go
@@ -51,24 +51,15 @@ func (h *GitHubWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	SetExternalServiceID(r.Context(), extSvc.ID)
 
-	c, err := extSvc.Configuration(r.Context())
-	if err != nil {
-		log15.Error("Could not decode external service config", "error", err)
-		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
-		return
-	}
-
-	config, ok := c.(*schema.GitHubConnection)
-	if !ok {
-		log15.Error("External service config is not a GitHub config")
-		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
-		return
-	}
-
-	codeHostURN, err := extsvc.NewCodeHostBaseURL(config.Url)
+	codeHostURN, ok, err := extSvc.BaseURL(r.Context())
 	if err != nil {
 		log15.Error("Could not parse code host URL from config", "error", err)
 		http.Error(w, "Invalid code host URL", http.StatusInternalServerError)
+		return
+	}
+	if !ok {
+		log15.Error("External service config is not a GitHub config with a URL")
+		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
 		return
 	}
 

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud.go
@@ -92,24 +92,12 @@ func (h *BitbucketCloudWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request
 	// internal actor on the context.
 	ctx := actor.WithInternalActor(r.Context())
 
-	c, err := extSvc.Configuration(ctx)
-	if err != nil {
-		h.logger.Error("Could not decode external service config", sglog.Error(err))
-		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
-		return
-	}
-
-	config, ok := c.(*schema.BitbucketCloudConnection)
-	if !ok {
-		h.logger.Error("Could not decode external service config", sglog.Error(err))
-		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
-		return
-	}
-
-	codeHostURN, err := extsvc.NewCodeHostBaseURL(config.Url)
+	codeHostURN, err := extSvc.BaseURL(ctx)
 	if err != nil {
 		respond(w, http.StatusInternalServerError, errors.Wrap(err, "parsing code host base url"))
+		return
 	}
+
 	err = h.handleEvent(ctx, h.Store.DatabaseDB(), codeHostURN, e)
 	if err != nil {
 		respond(w, http.StatusInternalServerError, err)

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver.go
@@ -87,24 +87,12 @@ func (h *BitbucketServerWebhook) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	// internal actor on the context.
 	ctx := actor.WithInternalActor(r.Context())
 
-	c, err := extSvc.Configuration(r.Context())
-	if err != nil {
-		h.logger.Error("Could not decode external service config", sglog.Error(err))
-		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
-		return
-	}
-
-	config, ok := c.(*schema.BitbucketServerConnection)
-	if !ok {
-		h.logger.Error("Could not decode external service config")
-		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
-		return
-	}
-
-	codeHostURN, err := extsvc.NewCodeHostBaseURL(config.Url)
+	codeHostURN, err := extSvc.BaseURL(r.Context())
 	if err != nil {
 		respond(w, http.StatusInternalServerError, errors.Wrap(err, "parsing code host base url"))
+		return
 	}
+
 	m := h.handleEvent(ctx, h.Store.DatabaseDB(), codeHostURN, e)
 	if m != nil {
 		respond(w, http.StatusInternalServerError, m)

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab.go
@@ -70,24 +70,9 @@ func (h *GitLabWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	fewebhooks.SetExternalServiceID(r.Context(), extSvc.ID)
 
-	c, err := extSvc.Configuration(r.Context())
+	codeHostURN, err := extSvc.BaseURL(r.Context())
 	if err != nil {
-		h.logger.Error("Could not decode external service config", sglog.Error(err))
-		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
-		return
-	}
-
-	config, ok := c.(*schema.GitLabConnection)
-	if !ok {
-		h.logger.Error("Could not decode external service config")
-		http.Error(w, "Invalid external service config", http.StatusInternalServerError)
-		return
-	}
-
-	codeHostURN, err := extsvc.NewCodeHostBaseURL(config.Url)
-	if err != nil {
-		h.logger.Error("Could not parse code host URL from config", sglog.Error(err))
-		http.Error(w, "Invalid code host URL", http.StatusInternalServerError)
+		respond(w, http.StatusInternalServerError, errors.Wrap(err, "parsing code host base url"))
 		return
 	}
 

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -551,6 +551,53 @@ func WebhookURL(kind string, externalServiceID int64, cfg any, externalURL strin
 	return u.String(), nil
 }
 
+func ExtractEncryptableBaseURL(ctx context.Context, kind string, config *EncryptableConfig) (CodeHostBaseURL, bool, error) {
+	parsed, err := ParseEncryptableConfig(ctx, kind, config)
+	if err != nil {
+		return CodeHostBaseURL{}, false, errors.Wrap(err, "loading service configuration")
+	}
+
+	url, ok, err := extractURL(parsed, kind)
+	if err != nil {
+		return CodeHostBaseURL{}, false, err
+	}
+	if !ok {
+		return CodeHostBaseURL{}, false, nil
+	}
+
+	baseUrl, err := NewCodeHostBaseURL(url)
+	return baseUrl, true, err
+}
+
+func extractURL(parsed any, kind string) (string, bool, error) {
+	switch c := parsed.(type) {
+	case *schema.GitHubConnection:
+		return c.Url, true, nil
+	case *schema.BitbucketServerConnection:
+		return c.Url, true, nil
+	case *schema.BitbucketCloudConnection:
+		return c.Url, true, nil
+	case *schema.PagureConnection:
+		return c.Url, true, nil
+	case *schema.PerforceConnection:
+		return "", false, nil
+	case *schema.JVMPackagesConnection:
+		return "", false, nil
+	case *schema.NpmPackagesConnection:
+		return c.Registry, true, nil
+	case *schema.GoModulesConnection:
+		return "", false, nil
+	case *schema.PythonPackagesConnection:
+		return "", false, nil
+	case *schema.RustPackagesConnection:
+		return "", false, nil
+	case *schema.RubyPackagesConnection:
+		return "", false, nil
+	default:
+		return "", false, errors.Errorf("unable to extract URL for service kind %q", kind)
+	}
+}
+
 func ExtractEncryptableToken(ctx context.Context, config *EncryptableConfig, kind string) (string, error) {
 	parsed, err := ParseEncryptableConfig(ctx, kind, config)
 	if err != nil {

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -551,50 +551,50 @@ func WebhookURL(kind string, externalServiceID int64, cfg any, externalURL strin
 	return u.String(), nil
 }
 
-func ExtractEncryptableBaseURL(ctx context.Context, kind string, config *EncryptableConfig) (CodeHostBaseURL, bool, error) {
+func ExtractEncryptableBaseURL(ctx context.Context, kind string, config *EncryptableConfig) (CodeHostBaseURL, error) {
 	parsed, err := ParseEncryptableConfig(ctx, kind, config)
 	if err != nil {
-		return CodeHostBaseURL{}, false, errors.Wrap(err, "loading service configuration")
+		return CodeHostBaseURL{}, errors.Wrap(err, "loading service configuration")
 	}
 
-	url, ok, err := extractURL(parsed, kind)
+	url, err := extractURL(parsed, kind)
 	if err != nil {
-		return CodeHostBaseURL{}, false, err
+		return CodeHostBaseURL{}, err
 	}
-	if !ok {
-		return CodeHostBaseURL{}, false, nil
+	if url == "" {
+		return CodeHostBaseURL{}, errors.New("service does not have a URL")
 	}
 
 	baseUrl, err := NewCodeHostBaseURL(url)
-	return baseUrl, true, err
+	return baseUrl, err
 }
 
-func extractURL(parsed any, kind string) (string, bool, error) {
+func extractURL(parsed any, kind string) (string, error) {
 	switch c := parsed.(type) {
 	case *schema.GitHubConnection:
-		return c.Url, true, nil
+		return c.Url, nil
 	case *schema.BitbucketServerConnection:
-		return c.Url, true, nil
+		return c.Url, nil
 	case *schema.BitbucketCloudConnection:
-		return c.Url, true, nil
+		return c.Url, nil
 	case *schema.PagureConnection:
-		return c.Url, true, nil
+		return c.Url, nil
 	case *schema.PerforceConnection:
-		return "", false, nil
+		return "", nil
 	case *schema.JVMPackagesConnection:
-		return "", false, nil
+		return "", nil
 	case *schema.NpmPackagesConnection:
-		return c.Registry, true, nil
+		return c.Registry, nil
 	case *schema.GoModulesConnection:
-		return "", false, nil
+		return "", nil
 	case *schema.PythonPackagesConnection:
-		return "", false, nil
+		return "", nil
 	case *schema.RustPackagesConnection:
-		return "", false, nil
+		return "", nil
 	case *schema.RubyPackagesConnection:
-		return "", false, nil
+		return "", nil
 	default:
-		return "", false, errors.Errorf("unable to extract URL for service kind %q", kind)
+		return "", errors.Errorf("unable to extract URL for service kind %q", kind)
 	}
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -728,9 +728,9 @@ func (e *ExternalService) Configuration(ctx context.Context) (cfg any, _ error) 
 }
 
 // BaseURL returns, if possible, the CodeHostbaseURL contained in the external
-// service config. If the external service can't have a URL the 2nd return
-// value is false.
-func (e *ExternalService) BaseURL(ctx context.Context) (extsvc.CodeHostBaseURL, bool, error) {
+// service config. If the external service can't have a URL or doesn't have a
+// URL set, it returns an error.
+func (e *ExternalService) BaseURL(ctx context.Context) (extsvc.CodeHostBaseURL, error) {
 	return extsvc.ExtractEncryptableBaseURL(ctx, e.Kind, e.Config)
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -727,6 +727,13 @@ func (e *ExternalService) Configuration(ctx context.Context) (cfg any, _ error) 
 	return extsvc.ParseEncryptableConfig(ctx, e.Kind, e.Config)
 }
 
+// BaseURL returns, if possible, the CodeHostbaseURL contained in the external
+// service config. If the external service can't have a URL the 2nd return
+// value is false.
+func (e *ExternalService) BaseURL(ctx context.Context) (extsvc.CodeHostBaseURL, bool, error) {
+	return extsvc.ExtractEncryptableBaseURL(ctx, e.Kind, e.Config)
+}
+
 // Clone returns a clone of the given external service.
 func (e *ExternalService) Clone() *ExternalService {
 	clone := *e


### PR DESCRIPTION
Not a huge improvement when looking at line count, but I think centralized helpers are better than 3 methods being called in 5 places.

## Test plan

- Existing tests