### PR TITLE
Improve file tree warnings for large repos

### DIFF
--- a/client/web/src/tree/Directory.tsx
+++ b/client/web/src/tree/Directory.tsx
@@ -96,7 +96,7 @@ export const Directory: React.FunctionComponent<React.PropsWithChildren<Director
                 )}
             </TreeLayerRowContents>
 
-            {props.index === MAX_TREE_ENTRIES - (rendersDotDot(props.entryInfo.path, props.depth) ? 0 : 1) && (
+            {props.index === getIndexForMaxEntriesTest(props.entryInfo.path, props.depth) && (
                 <TreeRowAlert
                     variant="note"
                     className="p-2"
@@ -108,12 +108,19 @@ export const Directory: React.FunctionComponent<React.PropsWithChildren<Director
     </TreeRow>
 )
 
+// We use the index to the MAX_TREE_ENTRIESth entry to render the "too many
+// directories" error.
+//
 // Subdirectories that are rendered at the root of the tree are rendered with
-// `..` as the first entry. Since we depend on the relative index to render the
-// "too many directories" alert, we need to account for this.
-function rendersDotDot(path: string, depth: number): boolean {
+// `..` as the first entry, so we need to account for this when calculating the
+// index.
+function getIndexForMaxEntriesTest(path: string, depth: number): number {
+    let rendersDotDot = false
     if (depth > 0) {
-        return false
+        rendersDotDot = false
+    } else {
+        rendersDotDot = path.split('/').length >= 2
     }
-    return path.split('/').length >= 2
+
+    return MAX_TREE_ENTRIES - (rendersDotDot ? 0 : 1)
 }

--- a/client/web/src/tree/Directory.tsx
+++ b/client/web/src/tree/Directory.tsx
@@ -95,13 +95,25 @@ export const Directory: React.FunctionComponent<React.PropsWithChildren<Director
                     </div>
                 )}
             </TreeLayerRowContents>
-            {props.index === MAX_TREE_ENTRIES - 1 && (
+
+            {props.index === MAX_TREE_ENTRIES - (rendersDotDot(props.entryInfo.path, props.depth) ? 0 : 1) && (
                 <TreeRowAlert
-                    variant="warning"
+                    variant="note"
+                    className="p-2"
                     style={getTreeItemOffset(props.depth)}
-                    error="Too many entries. Use search to find a specific file."
+                    error="Full list of directories is too long to display. Use search to find specific directory."
                 />
             )}
         </TreeLayerCell>
     </TreeRow>
 )
+
+// Subdirectories that are rendered at the root of the tree are rendered with
+// `..` as the first entry. Since we depend on the relative index to render the
+// "too many directories" alert, we need to account for this.
+function rendersDotDot(path: string, depth: number): boolean {
+    if (depth > 0) {
+        return false
+    }
+    return path.split('/').length >= 2
+}

--- a/client/web/src/tree/File.tsx
+++ b/client/web/src/tree/File.tsx
@@ -165,9 +165,9 @@ export const File: React.FunctionComponent<React.PropsWithChildren<FileProps>> =
                     )}
                     {index === MAX_TREE_ENTRIES - 1 && (
                         <TreeRowAlert
-                            variant="warning"
+                            variant="note"
                             style={getTreeItemOffset(depth + 1)}
-                            error="Too many entries. Use search to find a specific file."
+                            error="Full list of files is too long to display. Use search to find specific file."
                         />
                     )}
                 </TreeLayerCell>


### PR DESCRIPTION
Closes #43691

This improves the warning text when a file node with over 2500 entries is rendered.

@AlicjaSuska The padding in this case is slightly lower than the one in your catches as it was easier for me to add this way (our helper classes have no sub-step between this and something that is larger than the one in your screen). Happy to fix if you feel strongly about it but I think this also works? The text is cut-off because the tree automatically adjusts the height to the longest path in the list. I think this is okay given that you can scroll.

## Test plan

- Tested locally

| Root | Subdir |
|------|--------|
| <img width="337" alt="Screenshot 2022-12-20 at 13 13 04" src="https://user-images.githubusercontent.com/458591/208665075-b4a8ec4d-9013-4bd5-9f49-584d0d7c7751.png"> | <img width="326" alt="Screenshot 2022-12-20 at 13 12 54" src="https://user-images.githubusercontent.com/458591/208665081-1b9776e8-f508-41e2-a53a-49974adb37f5.png"> |



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-improve-file-tree-warnings.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
