### PR TITLE
linters: re-enable nolintlint and staticcheck SA1019

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,7 +52,6 @@ linters-settings:
   staticcheck:
     checks:
       - "all"
-      - "-SA1019" #TODO(burmudar): Mostly because of opentracing deprecatio
   forbidigo:
     forbid:
       # Use errors.Newf instead

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,8 +10,7 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    # this is flakey: https://github.com/sourcegraph/sourcegraph/issues/34304
-    # - nolintlint
+    - nolintlint
     - staticcheck
     - typecheck
     - unconvert

--- a/cmd/blobstore/shared/shared.go
+++ b/cmd/blobstore/shared/shared.go
@@ -126,7 +126,7 @@ func run(logger log.Logger) error {
 
 func Main() {
 	stdlog.SetFlags(0)
-	logging.Init()
+	logging.Init() //nolint:staticcheck // Deprecated, but logs unmigrated to sourcegraph/log look really bad without this.
 	liblog := log.Init(log.Resource{
 		Name:       env.MyName,
 		Version:    version.Version(),

--- a/cmd/frontend/backend/mocks.go
+++ b/cmd/frontend/backend/mocks.go
@@ -19,7 +19,7 @@ func testContext() context.Context {
 
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1})
-	_, ctx = ot.StartSpanFromContext(ctx, "dummy")
+	_, ctx = ot.StartSpanFromContext(ctx, "dummy") //nolint:staticcheck // OT is deprecated
 
 	return ctx
 }

--- a/cmd/frontend/backend/trace.go
+++ b/cmd/frontend/backend/trace.go
@@ -30,7 +30,7 @@ var requestGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 func trace(ctx context.Context, server, method string, arg any, err *error) (context.Context, func()) {
 	requestGauge.WithLabelValues(server + "." + method).Inc()
 
-	span, ctx := ot.StartSpanFromContext(ctx, server+"."+method)
+	span, ctx := ot.StartSpanFromContext(ctx, server+"."+method) //nolint:staticcheck // OT is deprecated
 	span.SetTag("Server", server)
 	span.SetTag("Method", method)
 	span.SetTag("Argument", fmt.Sprintf("%#v", arg))

--- a/cmd/frontend/graphqlbackend/externallink/repository.go
+++ b/cmd/frontend/graphqlbackend/externallink/repository.go
@@ -100,7 +100,7 @@ func linksForRepository(
 	db database.DB,
 	repo *types.Repo,
 ) (phabRepo *types.PhabricatorRepo, links *protocol.RepoLinks, serviceType string) {
-	span, ctx := ot.StartSpanFromContext(ctx, "externallink.linksForRepository")
+	span, ctx := ot.StartSpanFromContext(ctx, "externallink.linksForRepository") //nolint:staticcheck // OT is deprecated
 	defer span.Finish()
 	span.SetTag("Repo", repo.Name)
 	span.SetTag("ExternalRepo", repo.ExternalRepo)

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -260,7 +260,7 @@ func (r *GitCommitResolver) Path(ctx context.Context, args *struct {
 }
 
 func (r *GitCommitResolver) path(ctx context.Context, path string, validate func(fs.FileInfo) error) (*GitTreeEntryResolver, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "commit.path")
+	span, ctx := ot.StartSpanFromContext(ctx, "commit.path") //nolint:staticcheck // OT is deprecated
 	defer span.Finish()
 	span.SetTag("path", path)
 

--- a/cmd/frontend/graphqlbackend/git_tree.go
+++ b/cmd/frontend/graphqlbackend/git_tree.go
@@ -39,7 +39,7 @@ func (r *GitTreeEntryResolver) Files(ctx context.Context, args *gitTreeEntryConn
 }
 
 func (r *GitTreeEntryResolver) entries(ctx context.Context, args *gitTreeEntryConnectionArgs, filter func(fi fs.FileInfo) bool) ([]*GitTreeEntryResolver, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "tree.entries")
+	span, ctx := ot.StartSpanFromContext(ctx, "tree.entries") //nolint:staticcheck // OT is deprecated
 	defer span.Finish()
 
 	entries, err := r.gitserverClient.ReadDir(ctx, authz.DefaultSubRepoPermsChecker, r.commit.repoResolver.RepoName(), api.CommitID(r.commit.OID()), r.Path(), r.isRecursive || args.Recursive)

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -128,7 +128,7 @@ func (r *GitTreeEntryResolver) URL(ctx context.Context) (string, error) {
 }
 
 func (r *GitTreeEntryResolver) url(ctx context.Context) *url.URL {
-	span, ctx := ot.StartSpanFromContext(ctx, "treeentry.URL")
+	span, ctx := ot.StartSpanFromContext(ctx, "treeentry.URL") //nolint:staticcheck // OT is deprecated
 	defer span.Finish()
 
 	if submodule := r.Submodule(); submodule != nil {
@@ -193,7 +193,7 @@ func (r *GitTreeEntryResolver) Submodule() *gitSubmoduleResolver {
 }
 
 func cloneURLToRepoName(ctx context.Context, db database.DB, cloneURL string) (string, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "cloneURLToRepoName")
+	span, ctx := ot.StartSpanFromContext(ctx, "cloneURLToRepoName") //nolint:staticcheck // OT is deprecated
 	defer span.Finish()
 
 	repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, db, cloneURL)

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -188,7 +188,7 @@ type RepositoryCommitArgs struct {
 }
 
 func (r *RepositoryResolver) Commit(ctx context.Context, args *RepositoryCommitArgs) (*GitCommitResolver, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "repository.commit")
+	span, ctx := ot.StartSpanFromContext(ctx, "repository.commit") //nolint:staticcheck // OT is deprecated
 	defer span.Finish()
 	span.SetTag("commit", args.Rev)
 

--- a/cmd/frontend/graphqlbackend/repository_stats.go
+++ b/cmd/frontend/graphqlbackend/repository_stats.go
@@ -93,7 +93,7 @@ func (r *repositoryStatsResolver) computeIndexedStats(ctx context.Context) (int3
 			r.indexedStatsErr = err
 			return
 		}
-		r.indexedRepos = int32(len(repos.Minimal))
+		r.indexedRepos = int32(len(repos.Minimal)) //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 		r.indexedLinesCount = int64(repos.Stats.DefaultBranchNewLinesCount) + int64(repos.Stats.OtherBranchesNewLinesCount)
 	})
 

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -3,7 +3,7 @@ package graphqlbackend
 import (
 	"context"
 	"fmt"
-	"regexp/syntax" // nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
+	"regexp/syntax" //nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
 	"sync"
 	"time"
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -235,7 +235,7 @@ func (sf *searchFilterResolver) Kind() string {
 // blameFileMatch blames the specified file match to produce the time at which
 // the first line match inside of it was authored.
 func (sr *SearchResultsResolver) blameFileMatch(ctx context.Context, fm *result.FileMatch) (t time.Time, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "blameFileMatch")
+	span, ctx := ot.StartSpanFromContext(ctx, "blameFileMatch") //nolint:staticcheck // OT is deprecated
 	defer func() {
 		if err != nil {
 			ext.Error.Set(span, true)

--- a/cmd/frontend/graphqlbackend/site_monitoring.go
+++ b/cmd/frontend/graphqlbackend/site_monitoring.go
@@ -42,7 +42,7 @@ type siteMonitoringStatisticsResolver struct {
 
 func (r *siteMonitoringStatisticsResolver) Alerts(ctx context.Context) ([]*MonitoringAlert, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	span, ctx := ot.StartSpanFromContext(ctx, "site.MonitoringStatistics.alerts")
+	span, ctx := ot.StartSpanFromContext(ctx, "site.MonitoringStatistics.alerts") //nolint:staticcheck // OT is deprecated
 
 	var err error
 	defer func() {

--- a/cmd/frontend/internal/app/ui/landing.go
+++ b/cmd/frontend/internal/app/ui/landing.go
@@ -41,7 +41,7 @@ func serveRepoLanding(db database.DB) func(http.ResponseWriter, *http.Request) e
 }
 
 func serveDefLanding(w http.ResponseWriter, r *http.Request) (err error) {
-	span, ctx := ot.StartSpanFromContext(r.Context(), "serveDefLanding")
+	span, ctx := ot.StartSpanFromContext(r.Context(), "serveDefLanding") //nolint:staticcheck // OT is deprecated
 	r = r.WithContext(ctx)
 	defer func() {
 		if err != nil {

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -162,7 +162,7 @@ func Main(enterpriseSetupHook func(database.DB, conftypes.UnifiedWatchable) ente
 
 	// Filter trace logs
 	d, _ := time.ParseDuration(traceThreshold)
-	logging.Init(logging.Filter(loghandlers.Trace(strings.Fields(traceFields), d)))
+	logging.Init(logging.Filter(loghandlers.Trace(strings.Fields(traceFields), d))) //nolint:staticcheck // Deprecated, but logs unmigrated to sourcegraph/log look really bad without this.
 	tracer.Init(sglog.Scoped("tracer", "internal tracer package"), conf.DefaultClient())
 	profiler.Init()
 

--- a/cmd/frontend/internal/highlight/highlight.go
+++ b/cmd/frontend/internal/highlight/highlight.go
@@ -18,6 +18,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
 	"google.golang.org/protobuf/proto"
@@ -433,7 +434,7 @@ func Code(ctx context.Context, p Params) (response *HighlightedCode, aborted boo
 		Code:             code,
 		Filepath:         p.Filepath,
 		StabilizeTimeout: stabilizeTimeout,
-		Tracer:           ot.GetTracer(ctx),
+		Tracer:           ot.GetTracer(ctx), //nolint:staticcheck // Drop once we get rid of OpenTracing
 		LineLengthLimit:  maxLineLength,
 		CSS:              true,
 		Engine:           getEngineParameter(filetypeQuery.Engine),
@@ -460,7 +461,7 @@ func Code(ctx context.Context, p Params) (response *HighlightedCode, aborted boo
 			"revision", p.Metadata.Revision,
 			"snippet", fmt.Sprintf("%q…", firstCharacters(code, 80)),
 		)
-		trace.Log(otlog.Bool("timeout", true))
+		trace.AddEvent("syntaxHighlighting", attribute.Bool("timeout", true))
 		prometheusStatus = "timeout"
 
 		// Timeout, so render plain table.

--- a/cmd/frontend/internal/highlight/highlight.go
+++ b/cmd/frontend/internal/highlight/highlight.go
@@ -485,7 +485,7 @@ func Code(ctx context.Context, p Params) (response *HighlightedCode, aborted boo
 			// A problem that can sometimes be expected has occurred. We will
 			// identify such problems through metrics/logs and resolve them on
 			// a case-by-case basis.
-			trace.Log(otlog.Bool(problem, true))
+			trace.AddEvent("TODO Domain Owner", attribute.Bool(problem, true))
 			prometheusStatus = problem
 		}
 

--- a/cmd/frontend/internal/highlight/html_test.go
+++ b/cmd/frontend/internal/highlight/html_test.go
@@ -47,7 +47,7 @@ func TestMultilineOccurrence2(t *testing.T) {
 			// Valid range at the beginning, should be skipped.
 			{
 				Range:      []int32{0, 0, 8},
-				SyntaxKind: scip.SyntaxKind_IdentifierModule,
+				SyntaxKind: scip.SyntaxKind_IdentifierNamespace,
 			},
 
 			// Past end range occurrence, should not cause panic
@@ -60,14 +60,14 @@ func TestMultilineOccurrence2(t *testing.T) {
 
 	// Should stay false, because we should skip this identifier
 	// due to the valid lines that is passed to lsifToHTML
-	sawModuleIdentifier := false
+	sawNamespaceIdentifier := false
 
 	rowsSeen := map[int32]bool{}
 	lsifToHTML(code, document, func(row int32) {
 		rowsSeen[row] = true
 	}, func(kind scip.SyntaxKind, line string) {
-		if kind == scip.SyntaxKind_IdentifierModule {
-			sawModuleIdentifier = true
+		if kind == scip.SyntaxKind_IdentifierNamespace {
+			sawNamespaceIdentifier = true
 		}
 
 	}, map[int32]bool{
@@ -82,7 +82,7 @@ func TestMultilineOccurrence2(t *testing.T) {
 		t.Error("Should only add the rows from 2 until the end (due to weird multiline occurrence)")
 	}
 
-	if sawModuleIdentifier {
+	if sawNamespaceIdentifier {
 		t.Error("Should not have seen identifier for module, because line was skipped")
 	}
 }

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -71,7 +71,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Log events to trace
-	streamWriter.StatHook = eventStreamOTHook(tr.LogFields)
+	streamWriter.StatHook = eventStreamOTHook(tr.LogFields) //nolint:staticcheck // TODO when updating observation package
 
 	eventWriter := newEventWriter(streamWriter)
 	defer eventWriter.Done()

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sourcegraph/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -92,11 +93,11 @@ func (h *streamHandler) serveHTTP(r *http.Request, tr *trace.Trace, eventWriter 
 	if err != nil {
 		return err
 	}
-	tr.TagFields(
-		otlog.String("query", args.Query),
-		otlog.String("version", args.Version),
-		otlog.String("pattern_type", args.PatternType),
-		otlog.Int("search_mode", args.SearchMode),
+	tr.SetAttributes(
+		attribute.String("query", args.Query),
+		attribute.String("version", args.Version),
+		attribute.String("pattern_type", args.PatternType),
+		attribute.Int("search_mode", args.SearchMode),
 	)
 
 	settings, err := graphqlbackend.DecodedViewerFinalSettings(ctx, h.db)

--- a/cmd/frontend/registry/client/client.go
+++ b/cmd/frontend/registry/client/client.go
@@ -34,7 +34,7 @@ const (
 
 // List lists extensions on the remote registry matching the query (or all if the query is empty).
 func List(ctx context.Context, registry *url.URL, query string) (xs []*Extension, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "registry/client.List")
+	span, ctx := ot.StartSpanFromContext(ctx, "registry/client.List") //nolint:staticcheck // OT is deprecated
 	span.SetTag("registry", registry.String())
 	span.SetTag("query", query)
 	defer func() {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1446,7 +1446,7 @@ func (s *Server) handleBatchLog(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			return http.StatusBadRequest, err
 		}
-		logger.Log(req.LogFields()...)
+		logger.AddEvent("read request.body", req.SpanAttributes()...)
 
 		// Validate request parameters
 		if len(req.RepoCommits) == 0 {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -106,7 +106,7 @@ func runCommand(ctx context.Context, cmd *exec.Cmd) (exitCode int, err error) {
 	if runCommandMock != nil {
 		return runCommandMock(ctx, cmd)
 	}
-	span, _ := ot.StartSpanFromContext(ctx, "runCommand")
+	span, _ := ot.StartSpanFromContext(ctx, "runCommand") //nolint:staticcheck // OT is deprecated
 	span.SetTag("path", cmd.Path)
 	span.SetTag("args", cmd.Args)
 	span.SetTag("dir", cmd.Dir)
@@ -132,7 +132,7 @@ func runCommand(ctx context.Context, cmd *exec.Cmd) (exitCode int, err error) {
 // allow it to gracefully shutdown. All clients of this function should pass in a
 // command *without* a context.
 func runCommandGraceful(ctx context.Context, logger log.Logger, cmd *exec.Cmd) (exitCode int, err error) {
-	span, _ := ot.StartSpanFromContext(ctx, "runCommandGraceful")
+	span, _ := ot.StartSpanFromContext(ctx, "runCommandGraceful") //nolint:staticcheck // OT is deprecated
 	span.SetTag("path", cmd.Path)
 	span.SetTag("args", cmd.Args)
 	span.SetTag("dir", cmd.Dir)
@@ -535,7 +535,7 @@ func (s *Server) Handler() http.Handler {
 	getObjectFunc := gitdomain.GetObjectFunc(func(ctx context.Context, repo api.RepoName, objectName string) (*gitdomain.GitObject, error) {
 		// Tracing is server concern, so add it here. Once generics lands we should be
 		// able to create some simple wrappers
-		span, ctx := ot.StartSpanFromContext(ctx, "Git: GetObject")
+		span, ctx := ot.StartSpanFromContext(ctx, "Git: GetObject") //nolint:staticcheck // OT is deprecated
 		span.SetTag("objectName", objectName)
 		defer span.Finish()
 		return getObjectService.GetObject(ctx, repo, objectName)
@@ -2469,7 +2469,7 @@ func honeySampleRate(cmd string, actor *actor.Actor) uint {
 var headBranchPattern = lazyregexp.New(`HEAD branch: (.+?)\n`)
 
 func (s *Server) doRepoUpdate(ctx context.Context, repo api.RepoName, revspec string) error {
-	span, ctx := ot.StartSpanFromContext(ctx, "Server.doRepoUpdate")
+	span, ctx := ot.StartSpanFromContext(ctx, "Server.doRepoUpdate") //nolint:staticcheck // OT is deprecated
 	span.SetTag("repo", repo)
 	defer span.Finish()
 

--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -78,7 +78,7 @@ var (
 func Main() {
 	ctx := context.Background()
 
-	logging.Init()
+	logging.Init() //nolint:staticcheck // Deprecated, but logs unmigrated to sourcegraph/log look really bad without this.
 
 	liblog := log.Init(log.Resource{
 		Name:       env.MyName,

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -72,7 +72,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	// 	(i.e. bypass repository authorization).
 	ctx := actor.WithInternalActor(context.Background())
 
-	logging.Init()
+	logging.Init() //nolint:staticcheck // Deprecated, but logs unmigrated to sourcegraph/log look really bad without this.
 
 	liblog := log.Init(log.Resource{
 		Name:       env.MyName,

--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -3,7 +3,7 @@ package search
 import (
 	"bytes"
 	"context"
-	"regexp/syntax" // nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
+	"regexp/syntax" //nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
 	"sort"
 	"time"
 

--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -331,7 +331,7 @@ func zoektIndexedCommit(ctx context.Context, client zoekt.Streamer, repo api.Rep
 		return "", false, err
 	}
 
-	for _, v := range resp.Minimal {
+	for _, v := range resp.Minimal { //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 		return api.CommitID(v.Branches[0].Version), true, nil
 	}
 

--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"regexp/syntax" // nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
+	"regexp/syntax" //nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
 	"strings"
 	"time"
 	"unicode/utf8"

--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -263,7 +263,7 @@ func regexSearchBatch(ctx context.Context, rg *readerGrep, zf *zipFile, limit in
 // regexSearch concurrently searches files in zr looking for matches using rg.
 func regexSearch(ctx context.Context, rg *readerGrep, zf *zipFile, patternMatchesContent, patternMatchesPaths bool, isPatternNegated bool, sender matchSender) error {
 	var err error
-	span, ctx := ot.StartSpanFromContext(ctx, "RegexSearch")
+	span, ctx := ot.StartSpanFromContext(ctx, "RegexSearch") //nolint:staticcheck // OT is deprecated
 	ext.Component.Set(span, "regex_search")
 	if rg.re != nil {
 		span.SetTag("re", rg.re.String())

--- a/cmd/searcher/internal/search/search_regex_test.go
+++ b/cmd/searcher/internal/search/search_regex_test.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"os"
 	"reflect"
-	"regexp/syntax" // nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
+	"regexp/syntax" //nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
 	"sort"
 	"strconv"
 	"testing"

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -392,7 +392,7 @@ type subset []string
 var all universalSet = struct{}{}
 
 func structuralSearch(ctx context.Context, inputType comby.Input, paths filePatterns, extensionHint, pattern, rule string, languages []string, repo api.RepoName, sender matchSender) (err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "StructuralSearch")
+	span, ctx := ot.StartSpanFromContext(ctx, "StructuralSearch") //nolint:staticcheck // OT is deprecated
 	span.SetTag("repo", repo)
 	defer func() {
 		if err != nil {

--- a/cmd/searcher/internal/search/store.go
+++ b/cmd/searcher/internal/search/store.go
@@ -136,7 +136,7 @@ func (s *Store) PrepareZip(ctx context.Context, repo api.RepoName, commit api.Co
 }
 
 func (s *Store) PrepareZipPaths(ctx context.Context, repo api.RepoName, commit api.CommitID, paths []string) (path string, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Store.prepareZip")
+	span, ctx := ot.StartSpanFromContext(ctx, "Store.prepareZip") //nolint:staticcheck // OT is deprecated
 	ext.Component.Set(span, "store")
 	var cacheHit bool
 	start := time.Now()
@@ -235,7 +235,7 @@ func (s *Store) fetch(ctx context.Context, repo api.RepoName, commit api.CommitI
 	ctx, cancel := context.WithCancel(ctx)
 
 	metricFetching.Inc()
-	span, ctx := ot.StartSpanFromContext(ctx, "Store.fetch")
+	span, ctx := ot.StartSpanFromContext(ctx, "Store.fetch") //nolint:staticcheck // OT is deprecated
 	ext.Component.Set(span, "store")
 	span.SetTag("repo", repo)
 	span.SetTag("commit", commit)

--- a/cmd/searcher/shared/shared.go
+++ b/cmd/searcher/shared/shared.go
@@ -244,7 +244,7 @@ func run(logger log.Logger) error {
 
 func Main() {
 	stdlog.SetFlags(0)
-	logging.Init()
+	logging.Init() //nolint:staticcheck // Deprecated, but logs unmigrated to sourcegraph/log look really bad without this.
 	liblog := log.Init(log.Resource{
 		Name:       env.MyName,
 		Version:    version.Version(),

--- a/cmd/symbols/fetcher/repository_fetcher.go
+++ b/cmd/symbols/fetcher/repository_fetcher.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -148,11 +149,11 @@ func readTar(ctx context.Context, tarReader *tar.Reader, callback func(request P
 		}
 
 		data := make([]byte, int(tarHeader.Size))
-		traceLog.Log(log.Event("reading tar file contents"))
+		traceLog.AddEvent("readTar", attribute.String("event", "reading tar file contents"))
 		if _, err := io.ReadFull(tarReader, data); err != nil {
 			return err
 		}
-		traceLog.Log(log.Int("n", int(tarHeader.Size)))
+		traceLog.AddEvent("readTar", attribute.Int64("size", tarHeader.Size))
 		callback(ParseRequest{Path: tarHeader.Name, Data: data})
 	}
 }

--- a/cmd/symbols/internal/api/search_sqlite.go
+++ b/cmd/symbols/internal/api/search_sqlite.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
@@ -84,7 +85,7 @@ func MakeSqliteSearchFunc(observationCtx *observation.Context, cachedDatabaseWri
 		if err != nil {
 			return nil, errors.Wrap(err, "databaseWriter.GetOrCreateDatabaseFile")
 		}
-		trace.Log(log.String("dbFile", dbFile))
+		trace.AddEvent("databaseWriter", attribute.String("dbFile", dbFile))
 
 		var res result.Symbols
 		err = store.WithSQLiteStore(observationCtx, dbFile, func(db store.Store) (err error) {

--- a/cmd/symbols/parser/parser.go
+++ b/cmd/symbols/parser/parser.go
@@ -9,6 +9,7 @@ import (
 	"github.com/inconshreveable/log15"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/go-ctags"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/log/std"
@@ -145,7 +146,7 @@ func (p *parser) handleParseRequest(ctx context.Context, symbolOrErrors chan<- S
 	if err != nil {
 		return err
 	}
-	trace.Log(otlog.Event("acquired parser from pool"))
+	trace.AddEvent("parser", attribute.String("event", "acquired parser from pool"))
 
 	defer func() {
 		if err == nil {
@@ -172,7 +173,7 @@ func (p *parser) handleParseRequest(ctx context.Context, symbolOrErrors chan<- S
 	if err != nil {
 		return errors.Wrap(err, "parser.Parse")
 	}
-	trace.Log(otlog.Int("numEntries", len(entries)))
+	trace.AddEvent("parser.Parse", attribute.Int("numEntries", len(entries)))
 
 	lines := strings.Split(string(parseRequest.Data), "\n")
 

--- a/cmd/symbols/shared/main.go
+++ b/cmd/symbols/shared/main.go
@@ -53,7 +53,7 @@ type SetupFunc func(observationCtx *observation.Context, db database.DB, gitserv
 func Main(setup SetupFunc) {
 	// Initialization
 	env.HandleHelpFlag()
-	logging.Init()
+	logging.Init() //nolint:staticcheck // Deprecated, but logs unmigrated to sourcegraph/log look really bad without this.
 	liblog := log.Init(log.Resource{
 		Name:       env.MyName,
 		Version:    version.Version(),

--- a/cmd/worker/internal/zoektrepos/zoektrepos.go
+++ b/cmd/worker/internal/zoektrepos/zoektrepos.go
@@ -63,7 +63,7 @@ func (h *handler) Handle(ctx context.Context) error {
 		return err
 	}
 
-	return h.db.ZoektRepos().UpdateIndexStatuses(ctx, indexed.Minimal)
+	return h.db.ZoektRepos().UpdateIndexStatuses(ctx, indexed.Minimal) //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 }
 
 func (h *handler) HandleError(err error) {

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -65,7 +65,7 @@ func Start(observationCtx *observation.Context, additionalJobs map[string]job.Jo
 	env.Lock()
 	env.HandleHelpFlag()
 	conf.Init()
-	logging.Init()
+	logging.Init() //nolint:staticcheck // Deprecated, but logs unmigrated to sourcegraph/log look really bad without this.
 	tracer.Init(log.Scoped("tracer", "internal tracer package"), conf.DefaultClient())
 	profiler.Init()
 

--- a/dev/sg/adr/adr.go
+++ b/dev/sg/adr/adr.go
@@ -48,8 +48,10 @@ var (
 //
 // Must be kept in sync with the generator in Create.
 func VisitAll(adrDir string, visit func(adr ArchitectureDecisionRecord) error) error {
-	// nolint:staticcheck,gosimple
 	return filepath.WalkDir(adrDir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
 		if entry.IsDir() {
 			return nil
 		}

--- a/dev/sg/analytics.go
+++ b/dev/sg/analytics.go
@@ -51,7 +51,7 @@ func addAnalyticsHooks(commandPath []string, commands []*cli.Command) {
 					std.Out.WriteWarningf("Encountered panic - please open an issue with the command output:\n\t%s",
 						sgBugReportTemplate)
 					message := fmt.Sprintf("%v:\n%s", p, getRelevantStack("addAnalyticsHooks"))
-					actionErr = cli.NewExitError(message, 1)
+					actionErr = cli.Exit(message, 1)
 
 					// Log event
 					span.RecordError("panic", actionErr)

--- a/dev/sg/internal/check/check.go
+++ b/dev/sg/internal/check/check.go
@@ -55,7 +55,7 @@ func CommandOutputContains(cmd, contains string) CheckFunc {
 
 func FileExists(path string) func(context.Context) error {
 	return func(_ context.Context) error {
-		if filepath.HasPrefix(path, "~/") {
+		if strings.HasPrefix(path, "~/") {
 			home, err := os.UserHomeDir()
 			if err != nil {
 				return err

--- a/dev/sg/internal/secrets/store.go
+++ b/dev/sg/internal/secrets/store.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
-	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -157,7 +157,7 @@ var sg = &cli.App{
 				std.Out.WriteWarningf("Encountered panic - please open an issue with the command output:\n\t%s",
 					sgBugReportTemplate)
 				message := fmt.Sprintf("%v:\n%s", p, getRelevantStack())
-				err = cli.NewExitError(message, 1)
+				err = cli.Exit(message, 1)
 			}
 		}()
 

--- a/dev/sg/sg_cloud.go
+++ b/dev/sg/sg_cloud.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/sourcegraph/run"
@@ -47,7 +48,7 @@ var cloudCommand = &cli.Command{
 				if existingPath, err := exec.LookPath(executable); err == nil {
 					// If this mi2 installation is installed elsewhere, remove it to
 					// avoid conflicts
-					if !filepath.HasPrefix(existingPath, locationDir) {
+					if !strings.HasPrefix(existingPath, locationDir) {
 						std.Out.WriteNoticef("Removing existing installation at of %q at %q",
 							executable, existingPath)
 						_ = os.Remove(existingPath)

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -317,7 +317,7 @@ func addExec(ctx *cli.Context) error {
 		return cli.NewExitError("no migration name specified", 1)
 	}
 	if len(args) != 1 {
-		return cli.NewExitError("too many arguments", 1)
+		return cli.Exit("too many arguments", 1)
 	}
 
 	var (
@@ -325,7 +325,7 @@ func addExec(ctx *cli.Context) error {
 		database, ok = db.DatabaseByName(databaseName)
 	)
 	if !ok {
-		return cli.NewExitError(fmt.Sprintf("database %q not found :(", databaseName), 1)
+		return cli.Exit(fmt.Sprintf("database %q not found :(", databaseName), 1)
 	}
 
 	return migration.Add(database, args[0])
@@ -334,10 +334,10 @@ func addExec(ctx *cli.Context) error {
 func revertExec(ctx *cli.Context) error {
 	args := ctx.Args().Slice()
 	if len(args) == 0 {
-		return cli.NewExitError("no commit specified", 1)
+		return cli.Exit("no commit specified", 1)
 	}
 	if len(args) != 1 {
-		return cli.NewExitError("too many arguments", 1)
+		return cli.Exit("too many arguments", 1)
 	}
 
 	return migration.Revert(db.Databases(), args[0])
@@ -346,10 +346,10 @@ func revertExec(ctx *cli.Context) error {
 func squashExec(ctx *cli.Context) (err error) {
 	args := ctx.Args().Slice()
 	if len(args) == 0 {
-		return cli.NewExitError("no current-version specified", 1)
+		return cli.Exit("no current-version specified", 1)
 	}
 	if len(args) != 1 {
-		return cli.NewExitError("too many arguments", 1)
+		return cli.Exit("too many arguments", 1)
 	}
 
 	var (
@@ -357,7 +357,7 @@ func squashExec(ctx *cli.Context) (err error) {
 		database, ok = db.DatabaseByName(databaseName)
 	)
 	if !ok {
-		return cli.NewExitError(fmt.Sprintf("database %q not found :(", databaseName), 1)
+		return cli.Exit(fmt.Sprintf("database %q not found :(", databaseName), 1)
 	}
 
 	// Get the last migration that existed in the version _before_ `minimumMigrationSquashDistance` releases ago
@@ -373,11 +373,11 @@ func squashExec(ctx *cli.Context) (err error) {
 func visualizeExec(ctx *cli.Context) (err error) {
 	args := ctx.Args().Slice()
 	if len(args) != 0 {
-		return cli.NewExitError("too many arguments", 1)
+		return cli.Exit("too many arguments", 1)
 	}
 
 	if outputFilepath == "" {
-		return cli.NewExitError("Supply an output file with -f", 1)
+		return cli.Exit("Supply an output file with -f", 1)
 	}
 
 	var (
@@ -386,7 +386,7 @@ func visualizeExec(ctx *cli.Context) (err error) {
 	)
 
 	if !ok {
-		return cli.NewExitError(fmt.Sprintf("database %q not found :(", databaseName), 1)
+		return cli.Exit(fmt.Sprintf("database %q not found :(", databaseName), 1)
 	}
 
 	return migration.Visualize(database, outputFilepath)
@@ -395,11 +395,11 @@ func visualizeExec(ctx *cli.Context) (err error) {
 func rewriteExec(ctx *cli.Context) (err error) {
 	args := ctx.Args().Slice()
 	if len(args) != 0 {
-		return cli.NewExitError("too many arguments", 1)
+		return cli.Exit("too many arguments", 1)
 	}
 
 	if targetRevision == "" {
-		return cli.NewExitError("Supply a target revision with -rev", 1)
+		return cli.Exit("Supply a target revision with -rev", 1)
 	}
 
 	var (
@@ -408,7 +408,7 @@ func rewriteExec(ctx *cli.Context) (err error) {
 	)
 
 	if !ok {
-		return cli.NewExitError(fmt.Sprintf("database %q not found :(", databaseName), 1)
+		return cli.Exit(fmt.Sprintf("database %q not found :(", databaseName), 1)
 	}
 
 	return migration.Rewrite(database, targetRevision)
@@ -417,11 +417,11 @@ func rewriteExec(ctx *cli.Context) (err error) {
 func squashAllExec(ctx *cli.Context) (err error) {
 	args := ctx.Args().Slice()
 	if len(args) != 0 {
-		return cli.NewExitError("too many arguments", 1)
+		return cli.Exit("too many arguments", 1)
 	}
 
 	if outputFilepath == "" {
-		return cli.NewExitError("Supply an output file with -f", 1)
+		return cli.Exit("Supply an output file with -f", 1)
 	}
 
 	var (
@@ -430,7 +430,7 @@ func squashAllExec(ctx *cli.Context) (err error) {
 	)
 
 	if !ok {
-		return cli.NewExitError(fmt.Sprintf("database %q not found :(", databaseName), 1)
+		return cli.Exit(fmt.Sprintf("database %q not found :(", databaseName), 1)
 	}
 
 	return migration.SquashAll(database, squashInContainer || squashInTimescaleDBContainer, squashInTimescaleDBContainer, skipTeardown, skipSquashData, outputFilepath)
@@ -439,10 +439,10 @@ func squashAllExec(ctx *cli.Context) (err error) {
 func leavesExec(ctx *cli.Context) (err error) {
 	args := ctx.Args().Slice()
 	if len(args) == 0 {
-		return cli.NewExitError("no commit specified", 1)
+		return cli.Exit("no commit specified", 1)
 	}
 	if len(args) != 1 {
-		return cli.NewExitError("too many arguments", 1)
+		return cli.Exit("too many arguments", 1)
 	}
 
 	return migration.LeavesForCommit(db.Databases(), args[0])

--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -314,7 +314,7 @@ func resolveSchema(name string) (*schemas.Schema, error) {
 func addExec(ctx *cli.Context) error {
 	args := ctx.Args().Slice()
 	if len(args) == 0 {
-		return cli.NewExitError("no migration name specified", 1)
+		return cli.Exit("no migration name specified", 1)
 	}
 	if len(args) != 1 {
 		return cli.Exit("too many arguments", 1)

--- a/enterprise/cmd/executor/shared/shared.go
+++ b/enterprise/cmd/executor/shared/shared.go
@@ -26,7 +26,7 @@ func Main() {
 
 	env.Lock()
 
-	logging.Init()
+	logging.Init() //nolint:staticcheck // Deprecated, but logs unmigrated to sourcegraph/log look really bad without this.
 	liblog := log.Init(log.Resource{
 		Name:       env.MyName,
 		Version:    version.Version(),

--- a/enterprise/cmd/frontend/internal/batches/httpapi/file_handler.go
+++ b/enterprise/cmd/frontend/internal/batches/httpapi/file_handler.go
@@ -137,7 +137,7 @@ func (h *FileHandler) exists(r *http.Request) (statusCode int, err error) {
 	}
 }
 
-func getPathParts(r *http.Request) (string, string, error) { // nolint:unparam // unused return val 0 is kept for semantics
+func getPathParts(r *http.Request) (string, string, error) { //nolint:unparam // unused return val 0 is kept for semantics
 	rawBatchSpecRandID := mux.Vars(r)["spec"]
 	if rawBatchSpecRandID == "" {
 		return "", "", errors.New("spec ID not provided")

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -273,7 +273,6 @@ func TestIsAllowedToCreate(t *testing.T) {
 	}
 }
 
-// nolint:unused
 func graphqlUserID(id int32) graphql.ID {
 	return relay.MarshalID("User", id)
 }

--- a/enterprise/cmd/frontend/internal/compute/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/stream.go
@@ -91,7 +91,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer eventWriter.Event("done", map[string]any{})
 
 	// Log events to trace
-	eventWriter.StatHook = eventStreamOTHook(tr.LogFields)
+	eventWriter.StatHook = eventStreamOTHook(tr.LogFields) //nolint:staticcheck // Deprecated: Ok until we update the observation package
 
 	events, getResults := NewComputeStream(ctx, h.logger, h.db, searchQuery, computeQuery.Command)
 	events = batchEvents(events, 50*time.Millisecond)

--- a/enterprise/cmd/precise-code-intel-worker/shared/shared.go
+++ b/enterprise/cmd/precise-code-intel-worker/shared/shared.go
@@ -43,7 +43,7 @@ func Main() {
 
 	env.Lock()
 	env.HandleHelpFlag()
-	logging.Init()
+	logging.Init() //nolint:staticcheck // Deprecated, but logs unmigrated to sourcegraph/log look really bad without this.
 	liblog := log.Init(log.Resource{
 		Name:       env.MyName,
 		Version:    version.Version(),

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -8,10 +8,10 @@ import (
 	"sync"
 	"time"
 
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sourcegraph/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
@@ -1235,7 +1235,7 @@ func (s *PermsSyncer) observe(ctx context.Context, family, title string) (contex
 
 	return ctx, func(typ requestType, id int32, err *error) {
 		defer tr.Finish()
-		tr.LogFields(otlog.Int32("id", id))
+		tr.SetAttributes(attribute.Int64("id", int64(id)))
 
 		var typLabel string
 		switch typ {

--- a/enterprise/cmd/worker/internal/executorqueue/gcp_reporter.go
+++ b/enterprise/cmd/worker/internal/executorqueue/gcp_reporter.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
+	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	"github.com/inconshreveable/log15"
 	"google.golang.org/api/option"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	"google.golang.org/genproto/googleapis/api/monitoredres"
-	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/sourcegraph/sourcegraph/internal/env"

--- a/enterprise/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/internal/authz/bitbucketserver/provider.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	otlog "github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
@@ -85,10 +85,9 @@ func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*exts
 
 	tr, ctx := trace.New(ctx, "bitbucket.authz.provider.FetchAccount", "")
 	defer func() {
-		tr.LogFields(
-			otlog.String("user.name", user.Username),
-			otlog.Int32("user.id", user.ID),
-		)
+		tr.SetAttributes(
+			attribute.String("user.name", user.Username),
+			attribute.Int64("user.id", int64(user.ID)))
 
 		if err != nil {
 			tr.SetError(err)

--- a/enterprise/internal/authz/github/github_test.go
+++ b/enterprise/internal/authz/github/github_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-//nolint:unparam // unparam complains that `u` always has same value across call-sites, but that's OK
 func mustURL(t *testing.T, u string) *url.URL {
 	parsed, err := url.Parse(u)
 	if err != nil {
@@ -108,7 +107,6 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 			},
 		}
 
-		//nolint:unparam // Returning constant value for 'int' result is OK
 		mockListAffiliatedRepositories = func(_ context.Context, _ github.Visibility, page int, _ ...github.RepositoryAffiliation) ([]*github.Repository, bool, int, error) {
 			switch page {
 			case 1:
@@ -125,10 +123,9 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 			return []*github.Repository{}, false, 1, nil
 		}
 
-		mockOrgNoRead  = &github.OrgDetails{Org: github.Org{Login: "not-sourcegraph"}, DefaultRepositoryPermission: "none"}
-		mockOrgNoRead2 = &github.OrgDetails{Org: github.Org{Login: "not-sourcegraph-2"}, DefaultRepositoryPermission: "none"}
-		mockOrgRead    = &github.OrgDetails{Org: github.Org{Login: "sourcegraph"}, DefaultRepositoryPermission: "read"}
-		//nolint:unparam // Returning constant value for 'int' result is OK
+		mockOrgNoRead      = &github.OrgDetails{Org: github.Org{Login: "not-sourcegraph"}, DefaultRepositoryPermission: "none"}
+		mockOrgNoRead2     = &github.OrgDetails{Org: github.Org{Login: "not-sourcegraph-2"}, DefaultRepositoryPermission: "none"}
+		mockOrgRead        = &github.OrgDetails{Org: github.Org{Login: "sourcegraph"}, DefaultRepositoryPermission: "read"}
 		mockListOrgDetails = func(_ context.Context, page int) (orgs []github.OrgDetailsAndMembership, hasNextPage bool, rateLimitCost int, err error) {
 			switch page {
 			case 1:
@@ -150,7 +147,6 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 			return nil, false, 1, nil
 		}
 
-		//nolint:unparam // Returning constant value for 'int' result is OK
 		mockListOrgRepositories = func(_ context.Context, org string, page int, _ string) (repos []*github.Repository, hasNextPage bool, rateLimitCost int, err error) {
 			switch org {
 			case mockOrgRead.Login:
@@ -640,7 +636,6 @@ func TestProvider_FetchRepoPerms(t *testing.T) {
 			},
 		}
 
-		//nolint:unparam // Allow returning nil error on all code paths
 		mockListCollaborators = func(_ context.Context, _, _ string, page int, _ github.CollaboratorAffiliation) ([]*github.Collaborator, bool, error) {
 			switch page {
 			case 1:

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -3056,7 +3056,6 @@ func testBatchSpec(user int32) *btypes.BatchSpec {
 	}
 }
 
-//nolint:unparam // unparam complains that `extState` always has same value across call-sites, but that's OK
 func testChangeset(repoID api.RepoID, batchChange int64, extState btypes.ChangesetExternalState) *btypes.Changeset {
 	changeset := &btypes.Changeset{
 		RepoID:              repoID,

--- a/enterprise/internal/batches/sources/gitlab_test.go
+++ b/enterprise/internal/batches/sources/gitlab_test.go
@@ -1051,7 +1051,6 @@ func (p *gitLabChangesetSourceTestProvider) mockGetMergeRequest(expected gitlab.
 	}
 }
 
-//nolint:unparam // unparam complains that `pageSize` always has same value across call-sites, but that's OK
 func (p *gitLabChangesetSourceTestProvider) mockGetMergeRequestNotes(expectedIID gitlab.ID, notes []*gitlab.Note, pageSize int, err error) {
 	gitlab.MockGetMergeRequestNotes = func(client *gitlab.Client, ctx context.Context, project *gitlab.Project, iid gitlab.ID) func() ([]*gitlab.Note, error) {
 		p.testCommonParams(ctx, client, project)
@@ -1066,7 +1065,6 @@ func (p *gitLabChangesetSourceTestProvider) mockGetMergeRequestNotes(expectedIID
 	}
 }
 
-//nolint:unparam // unparam complains that `pageSize` always has same value across call-sites, but that's OK
 func (p *gitLabChangesetSourceTestProvider) mockGetMergeRequestResourceStateEvents(expectedIID gitlab.ID, events []*gitlab.ResourceStateEvent, pageSize int, err error) {
 	gitlab.MockGetMergeRequestResourceStateEvents = func(client *gitlab.Client, ctx context.Context, project *gitlab.Project, iid gitlab.ID) func() ([]*gitlab.ResourceStateEvent, error) {
 		p.testCommonParams(ctx, client, project)
@@ -1081,7 +1079,6 @@ func (p *gitLabChangesetSourceTestProvider) mockGetMergeRequestResourceStateEven
 	}
 }
 
-//nolint:unparam // unparam complains that `pageSize` always has same value across call-sites, but that's OK
 func (p *gitLabChangesetSourceTestProvider) mockGetMergeRequestPipelines(expectedIID gitlab.ID, pipelines []*gitlab.Pipeline, pageSize int, err error) {
 	gitlab.MockGetMergeRequestPipelines = func(client *gitlab.Client, ctx context.Context, project *gitlab.Project, iid gitlab.ID) func() ([]*gitlab.Pipeline, error) {
 		p.testCommonParams(ctx, client, project)

--- a/enterprise/internal/batches/state/counts_test.go
+++ b/enterprise/internal/batches/state/counts_test.go
@@ -1475,7 +1475,6 @@ func bbsChangeset(id int64, t time.Time) *btypes.Changeset {
 	}
 }
 
-//nolint:unparam // unparam complains that `id` always has same value across call-sites, but that's OK
 func glChangeset(id int64, t time.Time) *btypes.Changeset {
 	return &btypes.Changeset{
 		ID:       id,
@@ -1550,7 +1549,6 @@ func ghReviewDismissed(id int64, t time.Time, login, reviewer string) *btypes.Ch
 	}
 }
 
-//nolint:unparam // unparam complains that `id` always has same value across call-sites, but that's OK
 func ghReadyForReview(id int64, t time.Time, login string) *btypes.ChangesetEvent {
 	return &btypes.ChangesetEvent{
 		ChangesetID: id,
@@ -1577,7 +1575,6 @@ func ghConvertToDraft(id int64, t time.Time, login string) *btypes.ChangesetEven
 	}
 }
 
-//nolint:unparam // unparam complains that `id` always has same value across call-sites, but that's OK
 func glUnmarkWorkInProgress(id int64, t time.Time, login string) *btypes.ChangesetEvent {
 	return &btypes.ChangesetEvent{
 		ChangesetID: id,

--- a/enterprise/internal/batches/state/state_test.go
+++ b/enterprise/internal/batches/state/state_test.go
@@ -867,7 +867,6 @@ func TestComputeLabels(t *testing.T) {
 	}
 }
 
-//nolint:unparam // unparam complains that `state` always has same value across call-sites, but that's OK
 func bitbucketChangeset(updatedAt time.Time, state, reviewStatus string) *btypes.Changeset {
 	return &btypes.Changeset{
 		ExternalServiceType: extsvc.TypeBitbucketServer,

--- a/enterprise/internal/codeintel/autoindexing/internal/enqueuer/enqueuer.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/enqueuer/enqueuer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	otlog "github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/inference"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/jobselector"
@@ -63,7 +64,7 @@ func (s *IndexEnqueuer) QueueIndexes(ctx context.Context, repositoryID int, rev,
 		return nil, errors.Wrap(err, "gitserver.ResolveRevision")
 	}
 	commit := string(commitID)
-	trace.Log(otlog.String("commit", commit))
+	trace.AddEvent("ResolveRevision", attribute.String("commit", commit))
 
 	return s.queueIndexForRepositoryAndCommit(ctx, repositoryID, commit, configuration, force, bypassLimit)
 }
@@ -85,8 +86,9 @@ func (s *IndexEnqueuer) QueueIndexesForPackage(ctx context.Context, pkg precise.
 	if !ok {
 		return nil
 	}
-	trace.Log(otlog.String("repoName", string(repoName)))
-	trace.Log(otlog.String("revision", revision))
+	trace.AddEvent("InferRepositoryAndRevision",
+		attribute.String("repoName", string(repoName)),
+		attribute.String("revision", revision))
 
 	resp, err := s.repoUpdater.EnqueueRepoUpdate(ctx, repoName)
 	if err != nil {

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/service.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/service.go
@@ -11,6 +11,7 @@ import (
 
 	otelog "github.com/opentracing/opentracing-go/log"
 	baselua "github.com/yuin/gopher-lua"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/inference/lua"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/inference/luatypes"
@@ -334,7 +335,7 @@ func (s *Service) resolvePaths(
 
 	start := time.Now()
 	rateLimitErr := s.limiter.Wait(ctx)
-	traceLogger.Log(otelog.Int("wait_duration_ms", int(time.Since(start).Milliseconds())))
+	traceLogger.AddEvent("rate_limit", attribute.Int("wait_duration_ms", int(time.Since(start).Milliseconds())))
 	if rateLimitErr != nil {
 		return nil, err
 	}
@@ -368,7 +369,7 @@ func (s *Service) resolveFileContents(
 
 	start := time.Now()
 	rateLimitErr := s.limiter.Wait(ctx)
-	traceLogger.Log(otelog.Int("wait_duration_ms", int(time.Since(start).Milliseconds())))
+	traceLogger.AddEvent("rate_limit", attribute.Int("wait_duration_ms", int(time.Since(start).Milliseconds())))
 	if rateLimitErr != nil {
 		return nil, err
 	}

--- a/enterprise/internal/codeintel/autoindexing/internal/store/store_indexes.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/store/store_indexes.go
@@ -7,6 +7,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 	"github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
@@ -128,10 +129,9 @@ func (s *store) GetIndexes(ctx context.Context, opts shared.GetIndexesOptions) (
 	if err != nil {
 		return nil, 0, err
 	}
-	trace.Log(
-		log.Int("totalCount", totalCount),
-		log.Int("numIndexes", len(indexes)),
-	)
+	trace.AddEvent("scanIndexesWithCount",
+		attribute.Int("totalCount", totalCount),
+		attribute.Int("numIndexes", len(indexes)))
 
 	return indexes, totalCount, nil
 }
@@ -524,10 +524,9 @@ func (s *store) DeleteIndexesWithoutRepository(ctx context.Context, now time.Tim
 	for _, numDeleted := range repositories {
 		count += numDeleted
 	}
-	trace.Log(
-		log.Int("count", count),
-		log.Int("numRepositories", len(repositories)),
-	)
+	trace.AddEvent("scanCounts",
+		attribute.Int("count", count),
+		attribute.Int("numRepositories", len(repositories)))
 
 	return repositories, nil
 }
@@ -726,7 +725,7 @@ func (s *store) GetRecentIndexesSummary(ctx context.Context, repositoryID int) (
 	if err != nil {
 		return nil, err
 	}
-	logger.Log(log.Int("numIndexes", len(indexes)))
+	logger.AddEvent("scanIndexes", attribute.Int("numIndexes", len(indexes)))
 
 	groupedIndexes := make([]shared.IndexesWithRepositoryNamespace, 1, len(indexes)+1)
 	for _, index := range indexes {

--- a/enterprise/internal/codeintel/autoindexing/service.go
+++ b/enterprise/internal/codeintel/autoindexing/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/regexp"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/enqueuer"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/jobselector"
@@ -179,7 +180,7 @@ func (s *Service) InferIndexConfiguration(ctx context.Context, repositoryID int,
 			return nil, nil, errors.Newf("revision %s not found for %d", commit, repositoryID)
 		}
 	}
-	trace.Log(otlog.String("commit", commit))
+	trace.AddEvent("found", attribute.String("commit", commit))
 
 	indexJobs, err := s.InferIndexJobsFromRepositoryStructure(ctx, repositoryID, commit, bypassLimit)
 	if err != nil {

--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_diagnostics.go
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_diagnostics.go
@@ -6,6 +6,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/scip/bindings/go/scip"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/codenav/shared"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -33,7 +34,7 @@ func (s *store) GetDiagnostics(ctx context.Context, bundleID int, prefix string,
 	if err != nil {
 		return nil, 0, err
 	}
-	trace.Log(log.Int("numDocuments", len(documentData)))
+	trace.AddEvent("scanDocumentData", attribute.Int("numDocuments", len(documentData)))
 
 	totalCount := 0
 	for _, documentData := range documentData {
@@ -45,7 +46,7 @@ func (s *store) GetDiagnostics(ctx context.Context, bundleID int, prefix string,
 			totalCount += len(documentData.LSIFData.Diagnostics)
 		}
 	}
-	trace.Log(log.Int("totalCount", totalCount))
+	trace.AddEvent("found", attribute.Int("totalCount", totalCount))
 
 	diagnostics := make([]shared.Diagnostic, 0, limit)
 	for _, documentData := range documentData {

--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_locations.go
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_locations.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/scip/bindings/go/scip"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/codenav/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
@@ -67,9 +68,9 @@ func (s *store) getLocations(
 	}
 
 	if documentData.SCIPData != nil {
-		trace.Log(log.Int("numOccurrences", len(documentData.SCIPData.Occurrences)))
+		trace.AddEvent("SCIPData", attribute.Int("numOccurrences", len(documentData.SCIPData.Occurrences)))
 		occurrences := types.FindOccurrences(documentData.SCIPData.Occurrences, int32(line), int32(character))
-		trace.Log(log.Int("numIntersectingOccurrences", len(occurrences)))
+		trace.AddEvent("FindOccurences", attribute.Int("numIntersectingOccurrences", len(occurrences)))
 
 		for _, occurrence := range occurrences {
 			var locations []shared.Location
@@ -121,16 +122,16 @@ func (s *store) getLocations(
 		return nil, 0, nil
 	}
 
-	trace.Log(log.Int("numRanges", len(documentData.LSIFData.Ranges)))
+	trace.AddEvent("LSIF Data ranges", attribute.Int("numRanges", len(documentData.LSIFData.Ranges)))
 	ranges := precise.FindRanges(documentData.LSIFData.Ranges, line, character)
-	trace.Log(log.Int("numIntersectingRanges", len(ranges)))
+	trace.AddEvent("FindRanges", attribute.Int("numIntersectingRanges", len(ranges)))
 
 	orderedResultIDs := extractResultIDs(ranges, lsifExtractor)
 	locationsMap, totalCount, err := s.locations(ctx, bundleID, orderedResultIDs, limit, offset)
 	if err != nil {
 		return nil, 0, err
 	}
-	trace.Log(log.Int("totalCount", totalCount))
+	trace.AddEvent("locations", attribute.Int("totalCount", totalCount))
 
 	locations := make([]shared.Location, 0, limit)
 	for _, resultID := range orderedResultIDs {
@@ -219,9 +220,9 @@ func (s *store) locations(ctx context.Context, bundleID int, ids []precise.ID, l
 	if err != nil {
 		return nil, 0, err
 	}
-	trace.Log(
-		log.Int("numIndexes", len(indexes)),
-		log.String("indexes", intsToString(indexes)),
+	trace.AddEvent("indexes",
+		attribute.Int("numIndexes", len(indexes)),
+		attribute.String("indexes", intsToString(indexes)),
 	)
 
 	// Read the result sets and construct the set of documents we need to open to resolve range
@@ -230,16 +231,15 @@ func (s *store) locations(ctx context.Context, bundleID int, ids []precise.ID, l
 	if err != nil {
 		return nil, 0, err
 	}
-	trace.Log(log.Int("totalCount", totalCount))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("totalCount", totalCount))
 
 	// Filter out all data in rangeIDsByResultID that falls outside of the current page. This
 	// also returns the set of paths for documents we will need to fetch to resolve the results
 	// of the current page.
 	rangeIDsByResultID, paths := limitResultMap(ids, rangeIDsByResultID, limit, offset)
-	trace.Log(
-		log.Int("numPaths", len(paths)),
-		log.String("paths", strings.Join(paths, ", ")),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("numPaths", len(paths)),
+		attribute.String("paths", strings.Join(paths, ", ")))
 
 	// Hydrate the locations result set by replacing range ids with their actual data from their
 	// containing document. This refines the map constructed in the previous step.
@@ -431,11 +431,10 @@ func (s *store) readRangesFromDocument(bundleID int, rangeIDsByResultID map[prec
 				})
 			}
 		}
-		trace.Log(
-			log.String("id", string(id)),
-			log.String("path", path),
-			log.Int("numLocationsForIDInPath", len(locations)),
-		)
+		trace.AddEvent("TODO Domain Owner",
+			attribute.String("id", string(id)),
+			attribute.String("path", path),
+			attribute.Int("numLocationsForIDInPath", len(locations)))
 
 		totalCount += len(locations)
 		locationsByResultID[id] = append(locationsByResultID[id], locations...)

--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_monikers.go
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_monikers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/scip/bindings/go/scip"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/codenav/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
@@ -42,9 +43,9 @@ func (s *store) GetMonikersByPosition(ctx context.Context, uploadID int, path st
 	}
 
 	if documentData.SCIPData != nil {
-		trace.Log(log.Int("numOccurrences", len(documentData.SCIPData.Occurrences)))
+		trace.AddEvent("TODO Domain Owner", attribute.Int("numOccurrences", len(documentData.SCIPData.Occurrences)))
 		occurrences := types.FindOccurrences(documentData.SCIPData.Occurrences, int32(line), int32(character))
-		trace.Log(log.Int("numIntersectingOccurrences", len(occurrences)))
+		trace.AddEvent("TODO Domain Owner", attribute.Int("numIntersectingOccurrences", len(occurrences)))
 
 		// Make lookup map of symbol information by name
 		symbolMap := map[string]*scip.SymbolInformation{}
@@ -94,14 +95,14 @@ func (s *store) GetMonikersByPosition(ctx context.Context, uploadID int, path st
 
 			monikerData = append(monikerData, occurrenceMonikers)
 		}
-		trace.Log(log.Int("numMonikers", len(monikerData)))
+		trace.AddEvent("TODO Domain Owner", attribute.Int("numMonikers", len(monikerData)))
 
 		return monikerData, nil
 	}
 
-	trace.Log(log.Int("numRanges", len(documentData.LSIFData.Ranges)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numRanges", len(documentData.LSIFData.Ranges)))
 	ranges := precise.FindRanges(documentData.LSIFData.Ranges, line, character)
-	trace.Log(log.Int("numIntersectingRanges", len(ranges)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numIntersectingRanges", len(ranges)))
 
 	monikerData := make([][]precise.MonikerData, 0, len(ranges))
 	for _, r := range ranges {
@@ -111,11 +112,11 @@ func (s *store) GetMonikersByPosition(ctx context.Context, uploadID int, path st
 				batch = append(batch, moniker)
 			}
 		}
-		trace.Log(log.Int("numMonikersForRange", len(batch)))
+		trace.AddEvent("TODO Domain Owner", attribute.Int("numMonikersForRange", len(batch)))
 
 		monikerData = append(monikerData, batch)
 	}
-	trace.Log(log.Int("numMonikers", len(monikerData)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numMonikers", len(monikerData)))
 
 	return monikerData, nil
 }
@@ -233,10 +234,9 @@ func (s *store) GetBulkMonikerLocations(ctx context.Context, tableName string, u
 	for _, monikerLocations := range locationData {
 		totalCount += len(monikerLocations.Locations)
 	}
-	trace.Log(
-		log.Int("numDumps", len(locationData)),
-		log.Int("totalCount", totalCount),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("numDumps", len(locationData)),
+		attribute.Int("totalCount", totalCount))
 
 	max := totalCount
 	if totalCount > limit {
@@ -263,7 +263,7 @@ outer:
 			}
 		}
 	}
-	trace.Log(log.Int("numLocations", len(locations)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numLocations", len(locations)))
 
 	return locations, totalCount, nil
 }

--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_ranges.go
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_ranges.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/scip/bindings/go/scip"
 
@@ -61,9 +62,9 @@ func (s *store) GetRanges(ctx context.Context, bundleID int, path string, startL
 		return ranges, nil
 	}
 
-	trace.Log(log.Int("numRanges", len(documentData.LSIFData.Ranges)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numRanges", len(documentData.LSIFData.Ranges)))
 	ranges := precise.FindRangesInWindow(documentData.LSIFData.Ranges, startLine, endLine)
-	trace.Log(log.Int("numIntersectingRanges", len(ranges)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numIntersectingRanges", len(ranges)))
 
 	definitionResultIDs := extractResultIDs(ranges, func(r precise.RangeData) precise.ID { return r.DefinitionResultID })
 	definitionLocations, _, err := s.locations(ctx, bundleID, definitionResultIDs, MaximumRangesDefinitionLocations, 0)
@@ -159,10 +160,9 @@ func (s *store) getLocationsWithinFile(ctx context.Context, bundleID int, ids []
 	if err != nil {
 		return nil, err
 	}
-	trace.Log(
-		log.Int("numIndexes", len(indexes)),
-		log.String("indexes", intsToString(indexes)),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("numIndexes", len(indexes)),
+		attribute.String("indexes", intsToString(indexes)))
 
 	// Read the result sets and gather the set of range identifiers we need to resolve with
 	// the given document data.
@@ -175,7 +175,7 @@ func (s *store) getLocationsWithinFile(ctx context.Context, bundleID int, ids []
 	// containing document. This refines the map constructed in the previous step.
 	locationsByResultID := make(map[precise.ID][]shared.Location, len(ids))
 	totalCount := s.readRangesFromDocument(bundleID, rangeIDsByResultID, locationsByResultID, path, documentData, trace)
-	trace.Log(log.Int("numLocations", totalCount))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numLocations", totalCount))
 
 	return locationsByResultID, nil
 }

--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_stencil.go
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/lsifstore_stencil.go
@@ -6,6 +6,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/scip/bindings/go/scip"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -31,7 +32,7 @@ func (s *store) GetStencil(ctx context.Context, bundleID int, path string) (_ []
 	}
 
 	if documentData.SCIPData != nil {
-		trace.Log(log.Int("numOccurrences", len(documentData.SCIPData.Occurrences)))
+		trace.AddEvent("TODO Domain Owner", attribute.Int("numOccurrences", len(documentData.SCIPData.Occurrences)))
 
 		ranges := make([]types.Range, 0, len(documentData.SCIPData.Occurrences))
 		for _, occurrence := range documentData.SCIPData.Occurrences {
@@ -41,7 +42,7 @@ func (s *store) GetStencil(ctx context.Context, bundleID int, path string) (_ []
 		return ranges, nil
 	}
 
-	trace.Log(log.Int("numRanges", len(documentData.LSIFData.Ranges)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numRanges", len(documentData.LSIFData.Ranges)))
 
 	ranges := make([]types.Range, 0, len(documentData.LSIFData.Ranges))
 	for _, r := range documentData.LSIFData.Ranges {

--- a/enterprise/internal/codeintel/codenav/service.go
+++ b/enterprise/internal/codeintel/codenav/service.go
@@ -1178,10 +1178,9 @@ func (s *Service) GetClosestDumpsForBlob(ctx context.Context, repositoryID int, 
 
 		filtered = append(filtered, uploadCandidates[i])
 	}
-	trace.Log(
-		traceLog.Int("numFiltered", len(filtered)),
-		traceLog.String("filtered", uploadIDsToString(filtered)),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("numFiltered", len(filtered)),
+		attribute.String("filtered", uploadIDsToString(filtered)))
 
 	return filtered, nil
 }

--- a/enterprise/internal/codeintel/codenav/service.go
+++ b/enterprise/internal/codeintel/codenav/service.go
@@ -6,6 +6,7 @@ import (
 
 	traceLog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/codenav/internal/lsifstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/codenav/internal/store"
@@ -78,7 +79,7 @@ func (s *Service) GetHover(ctx context.Context, args shared.RequestArgs, request
 	cachedUploads := requestState.GetCacheUploads()
 	for i := range adjustedUploads {
 		adjustedUpload := adjustedUploads[i]
-		trace.Log(traceLog.Int("uploadID", adjustedUpload.Upload.ID))
+		trace.AddEvent("TODO Domain Owner", attribute.Int("uploadID", adjustedUpload.Upload.ID))
 
 		// Fetch hover text from the index
 		text, rn, exists, err := s.lsifstore.GetHover(
@@ -128,10 +129,9 @@ func (s *Service) GetHover(ctx context.Context, args shared.RequestArgs, request
 	if err != nil {
 		return "", types.Range{}, false, err
 	}
-	trace.Log(
-		traceLog.Int("numMonikers", len(orderedMonikers)),
-		traceLog.String("monikers", monikersToString(orderedMonikers)),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("numMonikers", len(orderedMonikers)),
+		attribute.String("monikers", monikersToString(orderedMonikers)))
 
 	// Determine the set of uploads over which we need to perform a moniker search. This will
 	// include all all indexes which define one of the ordered monikers. This should not include
@@ -140,10 +140,9 @@ func (s *Service) GetHover(ctx context.Context, args shared.RequestArgs, request
 	if err != nil {
 		return "", types.Range{}, false, err
 	}
-	trace.Log(
-		traceLog.Int("numDefinitionUploads", len(uploads)),
-		traceLog.String("definitionUploads", uploadIDsToString(uploads)),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("numDefinitionUploads", len(uploads)),
+		attribute.String("definitionUploads", uploadIDsToString(uploads)))
 
 	// Perform the moniker search. This returns a set of locations defining one of the monikers
 	// attached to one of the source ranges.
@@ -151,7 +150,7 @@ func (s *Service) GetHover(ctx context.Context, args shared.RequestArgs, request
 	if err != nil {
 		return "", types.Range{}, false, err
 	}
-	trace.Log(traceLog.Int("numLocations", len(locations)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numLocations", len(locations)))
 
 	for i := range locations {
 		// Fetch hover text attached to a definition in the defining index
@@ -212,10 +211,9 @@ func (s *Service) GetReferences(ctx context.Context, args shared.RequestArgs, re
 			return nil, cursor, err
 		}
 	}
-	trace.Log(
-		traceLog.Int("numMonikers", len(cursor.OrderedMonikers)),
-		traceLog.String("monikers", monikersToString(cursor.OrderedMonikers)),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("numMonikers", len(cursor.OrderedMonikers)),
+		attribute.String("monikers", monikersToString(cursor.OrderedMonikers)))
 
 	// Phase 1: Gather all "local" locations via LSIF graph traversal. We'll continue to request additional
 	// locations until we fill an entire page (the size of which is denoted by the given limit) or there are
@@ -279,7 +277,7 @@ func (s *Service) GetReferences(ctx context.Context, args shared.RequestArgs, re
 		}
 	}
 
-	trace.Log(traceLog.Int("numLocations", len(locations)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numLocations", len(locations)))
 
 	// Adjust the locations back to the appropriate range in the target commits. This adjusts
 	// locations within the repository the user is browsing so that it appears all references
@@ -288,7 +286,7 @@ func (s *Service) GetReferences(ctx context.Context, args shared.RequestArgs, re
 	if err != nil {
 		return nil, cursor, err
 	}
-	trace.Log(traceLog.Int("numReferenceLocations", len(referenceLocations)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numReferenceLocations", len(referenceLocations)))
 
 	return referenceLocations, cursor, nil
 }
@@ -392,7 +390,7 @@ func (s *Service) getPageLocalLocations(ctx context.Context, getLocations getLoc
 		}
 
 		numLocations := len(locations)
-		trace.Log(traceLog.Int("pageLocalLocations.numLocations", numLocations))
+		trace.AddEvent("TODO Domain Owner", attribute.Int("pageLocalLocations.numLocations", numLocations))
 		cursor.LocationOffset += numLocations
 
 		if cursor.LocationOffset >= totalCount {
@@ -469,7 +467,7 @@ func (s *Service) getPageRemoteLocations(
 	}
 
 	numLocations := len(locations)
-	trace.Log(traceLog.Int("pageLocalLocations.numLocations", numLocations))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("pageLocalLocations.numLocations", numLocations))
 	cursor.LocationOffset += numLocations
 
 	if cursor.LocationOffset >= totalCount {
@@ -686,20 +684,18 @@ func (s *Service) GetImplementations(ctx context.Context, args shared.RequestArg
 			return nil, cursor, err
 		}
 	}
-	trace.Log(
-		traceLog.Int("numImplementationMonikers", len(cursor.OrderedImplementationMonikers)),
-		traceLog.String("implementationMonikers", monikersToString(cursor.OrderedImplementationMonikers)),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("numImplementationMonikers", len(cursor.OrderedImplementationMonikers)),
+		attribute.String("implementationMonikers", monikersToString(cursor.OrderedImplementationMonikers)))
 
 	if cursor.OrderedExportMonikers == nil {
 		if cursor.OrderedExportMonikers, err = s.getOrderedMonikers(ctx, visibleUploads, "export"); err != nil {
 			return nil, cursor, err
 		}
 	}
-	trace.Log(
-		traceLog.Int("numExportMonikers", len(cursor.OrderedExportMonikers)),
-		traceLog.String("exportMonikers", monikersToString(cursor.OrderedExportMonikers)),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("numExportMonikers", len(cursor.OrderedExportMonikers)),
+		attribute.String("exportMonikers", monikersToString(cursor.OrderedExportMonikers)))
 
 	// Phase 1: Gather all "local" locations via LSIF graph traversal. We'll continue to request additional
 	// locations until we fill an entire page (the size of which is denoted by the given limit) or there are
@@ -728,10 +724,9 @@ func (s *Service) GetImplementations(ctx context.Context, args shared.RequestArg
 		if err != nil {
 			return nil, cursor, err
 		}
-		trace.Log(
-			traceLog.Int("numGetUploadsWithDefinitionsForMonikers", len(uploads)),
-			traceLog.String("getUploadsWithDefinitionsForMonikers", uploadIDsToString(uploads)),
-		)
+		trace.AddEvent("TODO Domain Owner",
+			attribute.Int("numGetUploadsWithDefinitionsForMonikers", len(uploads)),
+			attribute.String("getUploadsWithDefinitionsForMonikers", uploadIDsToString(uploads)))
 
 		definitionLocations, _, err := s.getBulkMonikerLocations(ctx, uploads, cursor.OrderedImplementationMonikers, "definitions", DefinitionsLimit, 0)
 		if err != nil {
@@ -758,7 +753,7 @@ func (s *Service) GetImplementations(ctx context.Context, args shared.RequestArg
 		}
 	}
 
-	trace.Log(traceLog.Int("numLocations", len(locations)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numLocations", len(locations)))
 
 	// Adjust the locations back to the appropriate range in the target commits. This adjusts
 	// locations within the repository the user is browsing so that it appears all implementations
@@ -768,7 +763,7 @@ func (s *Service) GetImplementations(ctx context.Context, args shared.RequestArg
 	if err != nil {
 		return nil, cursor, err
 	}
-	trace.Log(traceLog.Int("numImplementationsLocations", len(implementationLocations)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numImplementationsLocations", len(implementationLocations)))
 
 	return implementationLocations, cursor, nil
 }
@@ -799,7 +794,7 @@ func (s *Service) GetDefinitions(ctx context.Context, args shared.RequestArgs, r
 	// If the definition exists within the index, it should be reachable via an LSIF graph
 	// traversal and should not require an additional moniker search in the same index.
 	for i := range visibleUploads {
-		trace.Log(traceLog.Int("uploadID", visibleUploads[i].Upload.ID))
+		trace.AddEvent("TODO Domain Owner", attribute.Int("uploadID", visibleUploads[i].Upload.ID))
 
 		locations, _, err := s.lsifstore.GetDefinitionLocations(
 			ctx,
@@ -824,10 +819,9 @@ func (s *Service) GetDefinitions(ctx context.Context, args shared.RequestArgs, r
 	if err != nil {
 		return nil, err
 	}
-	trace.Log(
-		traceLog.Int("numMonikers", len(orderedMonikers)),
-		traceLog.String("monikers", monikersToString(orderedMonikers)),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("numMonikers", len(orderedMonikers)),
+		attribute.String("monikers", monikersToString(orderedMonikers)))
 
 	// Determine the set of uploads over which we need to perform a moniker search. This will
 	// include all all indexes which define one of the ordered monikers. This should not include
@@ -836,17 +830,16 @@ func (s *Service) GetDefinitions(ctx context.Context, args shared.RequestArgs, r
 	if err != nil {
 		return nil, err
 	}
-	trace.Log(
-		traceLog.Int("numXrepoDefinitionUploads", len(uploads)),
-		traceLog.String("xrepoDefinitionUploads", uploadIDsToString(uploads)),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("numXrepoDefinitionUploads", len(uploads)),
+		attribute.String("xrepoDefinitionUploads", uploadIDsToString(uploads)))
 
 	// Perform the moniker search
 	locations, _, err := s.getBulkMonikerLocations(ctx, uploads, orderedMonikers, "definitions", DefinitionsLimit, 0)
 	if err != nil {
 		return nil, err
 	}
-	trace.Log(traceLog.Int("numXrepoLocations", len(locations)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numXrepoLocations", len(locations)))
 
 	// Adjust the locations back to the appropriate range in the target commits. This adjusts
 	// locations within the repository the user is browsing so that it appears all definitions
@@ -856,7 +849,7 @@ func (s *Service) GetDefinitions(ctx context.Context, args shared.RequestArgs, r
 	if err != nil {
 		return nil, err
 	}
-	trace.Log(traceLog.Int("numAdjustedXrepoLocations", len(adjustedLocations)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numAdjustedXrepoLocations", len(adjustedLocations)))
 
 	return adjustedLocations, nil
 }
@@ -887,7 +880,7 @@ func (s *Service) GetDiagnostics(ctx context.Context, args shared.RequestArgs, r
 		a = actor.FromContext(ctx)
 	}
 	for i := range visibleUploads {
-		trace.Log(traceLog.Int("uploadID", visibleUploads[i].Upload.ID))
+		trace.AddEvent("TODO Domain Owner", attribute.Int("uploadID", visibleUploads[i].Upload.ID))
 
 		diagnostics, count, err := s.lsifstore.GetDiagnostics(
 			ctx,
@@ -925,10 +918,9 @@ func (s *Service) GetDiagnostics(ctx context.Context, args shared.RequestArgs, r
 	if len(diagnosticsAtUploads) > args.Limit {
 		diagnosticsAtUploads = diagnosticsAtUploads[:args.Limit]
 	}
-	trace.Log(
-		traceLog.Int("totalCount", totalCount),
-		traceLog.Int("numDiagnostics", len(diagnosticsAtUploads)),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("totalCount", totalCount),
+		attribute.Int("numDiagnostics", len(diagnosticsAtUploads)))
 
 	return diagnosticsAtUploads, totalCount, nil
 }
@@ -1016,7 +1008,7 @@ func (s *Service) GetRanges(ctx context.Context, args shared.RequestArgs, reques
 	}
 
 	for i := range uploadsWithPath {
-		trace.Log(traceLog.Int("uploadID", uploadsWithPath[i].Upload.ID))
+		trace.AddEvent("TODO Domain Owner", attribute.Int("uploadID", uploadsWithPath[i].Upload.ID))
 
 		ranges, err := s.lsifstore.GetRanges(
 			ctx,
@@ -1041,7 +1033,7 @@ func (s *Service) GetRanges(ctx context.Context, args shared.RequestArgs, reques
 			adjustedRanges = append(adjustedRanges, adjustedRange)
 		}
 	}
-	trace.Log(traceLog.Int("numRanges", len(adjustedRanges)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numRanges", len(adjustedRanges)))
 
 	return adjustedRanges, nil
 }
@@ -1098,7 +1090,7 @@ func (s *Service) GetStencil(ctx context.Context, args shared.RequestArgs, reque
 	}
 
 	for i := range adjustedUploads {
-		trace.Log(traceLog.Int("uploadID", adjustedUploads[i].Upload.ID))
+		trace.AddEvent("TODO Domain Owner", attribute.Int("uploadID", adjustedUploads[i].Upload.ID))
 
 		ranges, err := s.lsifstore.GetStencil(
 			ctx,
@@ -1121,7 +1113,7 @@ func (s *Service) GetStencil(ctx context.Context, args shared.RequestArgs, reque
 			adjustedRanges = append(adjustedRanges, adjustedRange)
 		}
 	}
-	trace.Log(traceLog.Int("numRanges", len(adjustedRanges)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numRanges", len(adjustedRanges)))
 
 	sortedRanges := sortRanges(adjustedRanges)
 	return dedupeRanges(sortedRanges), nil
@@ -1152,10 +1144,9 @@ func (s *Service) GetClosestDumpsForBlob(ctx context.Context, repositoryID int, 
 	}
 
 	uploadCandidates := copyDumps(candidates)
-	trace.Log(
-		traceLog.Int("numCandidates", len(candidates)),
-		traceLog.String("candidates", uploadIDsToString(uploadCandidates)),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("numCandidates", len(candidates)),
+		attribute.String("candidates", uploadIDsToString(uploadCandidates)))
 
 	commitChecker := NewCommitCache(s.gitserver)
 	commitChecker.SetResolvableCommit(repositoryID, commit)
@@ -1164,10 +1155,9 @@ func (s *Service) GetClosestDumpsForBlob(ctx context.Context, repositoryID int, 
 	if err != nil {
 		return nil, err
 	}
-	trace.Log(
-		traceLog.Int("numCandidatesWithCommits", len(candidatesWithCommits)),
-		traceLog.String("candidatesWithCommits", uploadIDsToString(candidatesWithCommits)),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("numCandidatesWithCommits", len(candidatesWithCommits)),
+		attribute.String("candidatesWithCommits", uploadIDsToString(candidatesWithCommits)))
 
 	// Filter in-place
 	filtered := candidatesWithCommits[:0]

--- a/enterprise/internal/codeintel/codenav/transport/graphql/observability.go
+++ b/enterprise/internal/codeintel/codenav/transport/graphql/observability.go
@@ -60,7 +60,7 @@ func observeResolver(
 	operation *observation.Operation,
 	threshold time.Duration, //nolint:unparam // same value everywhere but probably want to keep this
 	observationArgs observation.Args,
-) (context.Context, observation.TraceLogger, func()) { // nolint:unparam // observation.TraceLogger is never used, but it makes sense API wise
+) (context.Context, observation.TraceLogger, func()) { //nolint:unparam // observation.TraceLogger is never used, but it makes sense API wise
 	start := time.Now()
 	ctx, trace, endObservation := operation.With(ctx, err, observationArgs)
 

--- a/enterprise/internal/codeintel/policies/internal/store/store_configuration.go
+++ b/enterprise/internal/codeintel/policies/internal/store/store_configuration.go
@@ -7,6 +7,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 	"github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	policiesshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
@@ -68,7 +69,7 @@ func (s *store) GetConfigurationPolicies(ctx context.Context, opts policiesshare
 	if err != nil {
 		return nil, 0, err
 	}
-	trace.Log(log.Int("totalCount", totalCount))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("totalCount", totalCount))
 
 	configurationPolicies, err := scanConfigurationPolicies(tx.Query(ctx, sqlf.Sprintf(
 		getConfigurationPoliciesLimitedQuery,
@@ -79,7 +80,7 @@ func (s *store) GetConfigurationPolicies(ctx context.Context, opts policiesshare
 	if err != nil {
 		return nil, 0, err
 	}
-	trace.Log(log.Int("numConfigurationPolicies", len(configurationPolicies)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numConfigurationPolicies", len(configurationPolicies)))
 
 	return configurationPolicies, totalCount, nil
 }

--- a/enterprise/internal/codeintel/policies/internal/store/store_repos.go
+++ b/enterprise/internal/codeintel/policies/internal/store/store_repos.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -180,7 +181,7 @@ func (s *store) SelectPoliciesForRepositoryMembershipUpdate(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	trace.Log(log.Int("numConfigurationPolicies", len(configurationPolicies)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numConfigurationPolicies", len(configurationPolicies)))
 
 	return configurationPolicies, nil
 }

--- a/enterprise/internal/codeintel/uploads/internal/background/job_worker_handler.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_worker_handler.go
@@ -13,6 +13,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	codeinteltypes "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/lsifstore"
@@ -206,7 +207,7 @@ func (s *handler) HandleRawUpload(ctx context.Context, logger log.Logger, upload
 		return false, errors.Wrap(err, "gitserver.DefaultBranchContains")
 	}
 
-	trace.Log(otlog.Bool("defaultBranch", isDefaultBranch))
+	trace.AddEvent("TODO Domain Owner", attribute.Bool("defaultBranch", isDefaultBranch))
 
 	getChildren := func(ctx context.Context, dirnames []string) (map[string][]string, error) {
 		directoryChildren, err := s.gitserverClient.DirectoryChildren(ctx, upload.RepositoryID, upload.Commit, dirnames)
@@ -248,7 +249,7 @@ func (s *handler) HandleRawUpload(ctx context.Context, logger log.Logger, upload
 		if !revisionExists {
 			return errCommitDoesNotExist
 		}
-		trace.Log(otlog.String("commitDate", commitDate.String()))
+		trace.AddEvent("TODO Domain Owner", attribute.String("commitDate", commitDate.String()))
 
 		// We do the update here outside of the transaction started below to reduce the long blocking
 		// behavior we see when multiple uploads are being processed for the same repository and commit.
@@ -269,7 +270,7 @@ func (s *handler) HandleRawUpload(ctx context.Context, logger log.Logger, upload
 					// safely assume that the entire index's data is in the codeintel database, as it's
 					// parsed deterministically and written atomically.
 					logger.Warn("LSIF data already exists for upload record")
-					trace.Log(otlog.Bool("rewriting", true))
+					trace.AddEvent("TODO Domain Owner", attribute.Bool("rewriting", true))
 				} else {
 					return err
 				}
@@ -284,7 +285,7 @@ func (s *handler) HandleRawUpload(ctx context.Context, logger log.Logger, upload
 					// safely assume that the entire index's data is in the codeintel database, as it's
 					// parsed deterministically and written atomically.
 					logger.Warn("SCIP data already exists for upload record")
-					trace.Log(otlog.Bool("rewriting", true))
+					trace.AddEvent("TODO Domain Onwer", attribute.Bool("rewriting", true))
 				} else {
 					return err
 				}
@@ -304,12 +305,12 @@ func (s *handler) HandleRawUpload(ctx context.Context, logger log.Logger, upload
 			}
 
 			if upload.ContentType == lsifContentType {
-				trace.Log(otlog.Int("packages", len(groupedBundleData.Packages)))
+				trace.AddEvent("TODO Domain Owner", attribute.Int("packages", len(groupedBundleData.Packages)))
 				// Update package and package reference data to support cross-repo queries.
 				if err := tx.UpdatePackages(ctx, upload.ID, groupedBundleData.Packages); err != nil {
 					return errors.Wrap(err, "store.UpdatePackages")
 				}
-				trace.Log(otlog.Int("packageReferences", len(groupedBundleData.Packages)))
+				trace.AddEvent("TODO Domain Owner", attribute.Int("packageReferences", len(groupedBundleData.Packages)))
 				if err := tx.UpdatePackageReferences(ctx, upload.ID, groupedBundleData.PackageReferences); err != nil {
 					return errors.Wrap(err, "store.UpdatePackageReferences")
 				}
@@ -319,12 +320,12 @@ func (s *handler) HandleRawUpload(ctx context.Context, logger log.Logger, upload
 					return err
 				}
 
-				trace.Log(otlog.Int("packages", len(packages)))
+				trace.AddEvent("TODO Domain Owner", attribute.Int("packages", len(packages)))
 				// Update package and package reference data to support cross-repo queries.
 				if err := tx.UpdatePackages(ctx, upload.ID, packages); err != nil {
 					return errors.Wrap(err, "store.UpdatePackages")
 				}
-				trace.Log(otlog.Int("packageReferences", len(packages)))
+				trace.AddEvent("TODO Domain Owner", attribute.Int("packageReferences", len(packages)))
 				if err := tx.UpdatePackageReferences(ctx, upload.ID, packageReferences); err != nil {
 					return errors.Wrap(err, "store.UpdatePackageReferences")
 				}
@@ -404,7 +405,7 @@ func requeueIfCloningOrCommitUnknown(ctx context.Context, logger log.Logger, rep
 func withUploadData(ctx context.Context, logger log.Logger, uploadStore uploadstore.Store, id int, trace observation.TraceLogger, fn func(r io.Reader) error) error {
 	uploadFilename := fmt.Sprintf("upload-%d.lsif.gz", id)
 
-	trace.Log(otlog.String("uploadFilename", uploadFilename))
+	trace.AddEvent("TODO Domain Owner", attribute.String("uploadFilename", uploadFilename))
 
 	// Pull raw uploaded data from bucket
 	rc, err := uploadStore.Get(ctx, uploadFilename)
@@ -447,31 +448,31 @@ func writeData(ctx context.Context, lsifStore lsifstore.LsifStore, upload codein
 	if err != nil {
 		return errors.Wrap(err, "store.WriteDocuments")
 	}
-	trace.Log(otlog.Uint32("numDocuments", count))
+	trace.AddEvent("TODO Domain Owner", attribute.Int64("numDocuments", int64(count)))
 
 	count, err = tx.WriteResultChunks(ctx, upload.ID, groupedBundleData.ResultChunks)
 	if err != nil {
 		return errors.Wrap(err, "store.WriteResultChunks")
 	}
-	trace.Log(otlog.Uint32("numResultChunks", count))
+	trace.AddEvent("TODO Domain Owner", attribute.Int64("numResultChunks", int64(count)))
 
 	count, err = tx.WriteDefinitions(ctx, upload.ID, groupedBundleData.Definitions)
 	if err != nil {
 		return errors.Wrap(err, "store.WriteDefinitions")
 	}
-	trace.Log(otlog.Uint32("numDefinitions", count))
+	trace.AddEvent("TODO Domain Owner", attribute.Int64("numDefinitions", int64(count)))
 
 	count, err = tx.WriteReferences(ctx, upload.ID, groupedBundleData.References)
 	if err != nil {
 		return errors.Wrap(err, "store.WriteReferences")
 	}
-	trace.Log(otlog.Uint32("numReferences", count))
+	trace.AddEvent("TODO Domain Owner", attribute.Int64("numReferences", int64(count)))
 
 	count, err = tx.WriteImplementations(ctx, upload.ID, groupedBundleData.Implementations)
 	if err != nil {
 		return errors.Wrap(err, "store.WriteImplementations")
 	}
-	trace.Log(otlog.Uint32("numImplementations", count))
+	trace.AddEvent("TODO Domain Owner", attribute.Int64("numImplementations", int64(count)))
 
 	return nil
 }

--- a/enterprise/internal/codeintel/uploads/internal/background/scip.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/scip.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"sort"
 
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/scip/bindings/go/scip"
+	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
@@ -333,13 +333,13 @@ func writeSCIPData(
 
 		numDocuments += 1
 	}
-	trace.Log(otlog.Uint32("numDocuments", numDocuments))
+	trace.AddEvent("TODO Domain Owner", attribute.Int64("numDocuments", int64(numDocuments)))
 
 	count, err := scipWriter.Flush(ctx)
 	if err != nil {
 		return err
 	}
-	trace.Log(otlog.Uint32("numSymbols", count))
+	trace.AddEvent("TODO Domain Owner", attribute.Int64("numSymbols", int64(count)))
 
 	return nil
 }

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/data_write.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/data_write.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/batch"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -98,7 +99,7 @@ func (s *store) WriteDocuments(ctx context.Context, bundleID int, documents chan
 	); err != nil {
 		return 0, err
 	}
-	trace.Log(log.Int("numDocumentRecords", int(count)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numDocumentRecords", int(count)))
 
 	// Insert the values from the temporary table into the target table. We select a
 	// parameterized dump id and schema version here since it is the same for all rows
@@ -169,7 +170,7 @@ func (s *store) WriteResultChunks(ctx context.Context, bundleID int, resultChunk
 	); err != nil {
 		return 0, err
 	}
-	trace.Log(log.Int("numResultChunkRecords", int(count)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numResultChunkRecords", int(count)))
 
 	// Insert the values from the temporary table into the target table. We select a
 	// parameterized dump id here since it is the same for all rows in this operation.
@@ -258,7 +259,7 @@ func (s *store) writeMonikers(ctx context.Context, bundleID int, tableName strin
 	); err != nil {
 		return 0, err
 	}
-	trace.Log(log.Int("numRecords", int(count)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numRecords", int(count)))
 
 	// Insert the values from the temporary table into the target table. We select a
 	// parameterized dump id and schema version here since it is the same for all rows

--- a/enterprise/internal/codeintel/uploads/internal/store/store_commits.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_commits.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -45,10 +46,9 @@ func (s *store) GetStaleSourcedCommits(ctx context.Context, minimumTimeSinceLast
 	for _, commits := range sourcedCommits {
 		numCommits += len(commits.Commits)
 	}
-	trace.Log(
-		log.Int("numRepositories", len(sourcedCommits)),
-		log.Int("numCommits", numCommits),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("numRepositories", len(sourcedCommits)),
+		attribute.Int("numCommits", numCommits))
 
 	return sourcedCommits, nil
 }
@@ -100,7 +100,7 @@ func (s *store) UpdateSourcedCommits(ctx context.Context, repositoryID int, comm
 	if err != nil {
 		return 0, err
 	}
-	trace.Log(log.Int("uploadsUpdated", uploadsUpdated))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("uploadsUpdated", uploadsUpdated))
 
 	return uploadsUpdated, nil
 }
@@ -160,10 +160,9 @@ func (s *store) DeleteSourcedCommits(ctx context.Context, repositoryID int, comm
 	if err != nil {
 		return 0, 0, err
 	}
-	trace.Log(
-		log.Int("uploadsUpdated", uploadsUpdated),
-		log.Int("uploadsDeleted", uploadsDeleted),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("uploadsUpdated", uploadsUpdated),
+		attribute.Int("uploadsDeleted", uploadsDeleted))
 
 	return uploadsUpdated, uploadsDeleted, nil
 }

--- a/enterprise/internal/codeintel/uploads/internal/store/store_dumps.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_dumps.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/commitgraph"
@@ -60,7 +61,7 @@ func (s *store) FindClosestDumps(ctx context.Context, repositoryID int, commit, 
 	if err != nil {
 		return nil, err
 	}
-	trace.Log(log.Int("numDumps", len(dumps)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numDumps", len(dumps)))
 
 	return dumps, nil
 }
@@ -123,10 +124,9 @@ func (s *store) FindClosestDumpsFromGraphFragment(ctx context.Context, repositor
 	if err != nil {
 		return nil, err
 	}
-	trace.Log(
-		log.Int("numCommitGraphViewMetaKeys", len(commitGraphView.Meta)),
-		log.Int("numCommitGraphViewTokenKeys", len(commitGraphView.Tokens)),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("numCommitGraphViewMetaKeys", len(commitGraphView.Meta)),
+		attribute.Int("numCommitGraphViewTokenKeys", len(commitGraphView.Tokens)))
 
 	var ids []*sqlf.Query
 	for _, uploadMeta := range commitgraph.NewGraph(commitGraph, commitGraphView).UploadsVisibleAtCommit(commit) {
@@ -143,7 +143,7 @@ func (s *store) FindClosestDumpsFromGraphFragment(ctx context.Context, repositor
 	if err != nil {
 		return nil, err
 	}
-	trace.Log(log.Int("numDumps", len(dumps)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numDumps", len(dumps)))
 
 	return dumps, nil
 }
@@ -213,7 +213,7 @@ func (s *store) GetDumpsWithDefinitionsForMonikers(ctx context.Context, monikers
 	if err != nil {
 		return nil, err
 	}
-	trace.Log(log.Int("numDumps", len(dumps)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numDumps", len(dumps)))
 
 	return dumps, nil
 }
@@ -287,7 +287,7 @@ func (s *store) GetDumpsByIDs(ctx context.Context, ids []int) (_ []types.Dump, e
 	if err != nil {
 		return nil, err
 	}
-	trace.Log(log.Int("numDumps", len(dumps)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numDumps", len(dumps)))
 
 	return dumps, nil
 }
@@ -332,7 +332,7 @@ func (s *store) DeleteOverlappingDumps(ctx context.Context, repositoryID int, co
 	if err != nil {
 		return err
 	}
-	trace.Log(log.Int("count", count))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("count", count))
 
 	return nil
 }

--- a/enterprise/internal/codeintel/uploads/internal/store/store_dumps_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_dumps_test.go
@@ -904,7 +904,6 @@ func insertNearestUploads(t testing.TB, db database.DB, repositoryID int, upload
 	}
 }
 
-//nolint:unparam // unparam complains that `repositoryID` always has same value across call-sites, but that's OK
 func insertLinks(t testing.TB, db database.DB, repositoryID int, links map[string]commitgraph.LinkRelationship) {
 	if len(links) == 0 {
 		return

--- a/enterprise/internal/codeintel/uploads/internal/store/store_repositories.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_repositories.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 	"github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -270,7 +271,7 @@ func (s *store) GetDirtyRepositories(ctx context.Context) (_ map[int]int, err er
 	if err != nil {
 		return nil, err
 	}
-	trace.Log(log.Int("numRepositories", len(repositories)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numRepositories", len(repositories)))
 
 	return repositories, nil
 }

--- a/enterprise/internal/codeintel/uploads/internal/store/store_uploads.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_uploads.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 	"github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
@@ -331,7 +332,7 @@ func (s *store) GetRecentUploadsSummary(ctx context.Context, repositoryID int) (
 	if err != nil {
 		return nil, err
 	}
-	logger.Log(log.Int("numUploads", len(uploads)))
+	logger.AddEvent("scanUploadComplete", attribute.Int("numUploads", len(uploads)))
 
 	groupedUploads := make([]shared.UploadsWithRepositoryNamespace, 1, len(uploads)+1)
 	for _, index := range uploads {

--- a/enterprise/internal/codeintel/uploads/internal/store/store_uploads.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_uploads.go
@@ -59,10 +59,9 @@ func (s *store) GetUploads(ctx context.Context, opts shared.GetUploadsOptions) (
 	if err != nil {
 		return nil, 0, err
 	}
-	trace.Log(
-		log.Int("totalCount", totalCount),
-		log.Int("numUploads", len(uploads)),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("totalCount", totalCount),
+		attribute.Int("numUploads", len(uploads)))
 
 	return uploads, totalCount, nil
 }
@@ -475,10 +474,9 @@ func (s *store) DeleteUploadsWithoutRepository(ctx context.Context, now time.Tim
 	for _, numDeleted := range repositories {
 		count += numDeleted
 	}
-	trace.Log(
-		log.Int("count", count),
-		log.Int("numRepositories", len(repositories)),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("count", count),
+		attribute.Int("numRepositories", len(repositories)))
 
 	return repositories, nil
 }
@@ -523,7 +521,7 @@ func (s *store) DeleteUploadsStuckUploading(ctx context.Context, uploadedBefore 
 	if err != nil {
 		return 0, err
 	}
-	trace.Log(log.Int("count", count))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("count", count))
 
 	return count, nil
 }
@@ -577,10 +575,9 @@ func (s *store) SoftDeleteExpiredUploads(ctx context.Context, batchSize int) (co
 	for _, numUpdated := range repositories {
 		count += numUpdated
 	}
-	trace.Log(
-		log.Int("count", count),
-		log.Int("numRepositories", len(repositories)),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("count", count),
+		attribute.Int("numRepositories", len(repositories)))
 
 	for repositoryID := range repositories {
 		if err := s.setRepositoryAsDirtyWithTx(ctx, repositoryID, tx); err != nil {
@@ -746,10 +743,9 @@ func (s *store) SoftDeleteExpiredUploadsViaTraversal(ctx context.Context, traver
 	for _, numUpdated := range repositories {
 		count += numUpdated
 	}
-	trace.Log(
-		log.Int("count", count),
-		log.Int("numRepositories", len(repositories)),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("count", count),
+		attribute.Int("numRepositories", len(repositories)))
 
 	for repositoryID := range repositories {
 		if err := s.setRepositoryAsDirtyWithTx(ctx, repositoryID, tx); err != nil {
@@ -1151,10 +1147,9 @@ func (s *store) UpdateUploadsVisibleToCommits(
 	if err != nil {
 		return err
 	}
-	trace.Log(
-		log.String("maxAgeForNonStaleBranches", maxAgeForNonStaleBranches.String()),
-		log.String("maxAgeForNonStaleTags", maxAgeForNonStaleTags.String()),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.String("maxAgeForNonStaleBranches", maxAgeForNonStaleBranches.String()),
+		attribute.String("maxAgeForNonStaleTags", maxAgeForNonStaleTags.String()))
 
 	// Pull all queryable upload metadata known to this repository so we can correlate
 	// it with the current  commit graph.
@@ -1162,10 +1157,9 @@ func (s *store) UpdateUploadsVisibleToCommits(
 	if err != nil {
 		return err
 	}
-	trace.Log(
-		log.Int("numCommitGraphViewMetaKeys", len(commitGraphView.Meta)),
-		log.Int("numCommitGraphViewTokenKeys", len(commitGraphView.Tokens)),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("numCommitGraphViewMetaKeys", len(commitGraphView.Meta)),
+		attribute.Int("numCommitGraphViewTokenKeys", len(commitGraphView.Tokens)))
 
 	// Determine which uploads are visible to which commits for this repository
 	graph := commitgraph.NewGraph(commitGraph, commitGraphView)
@@ -1308,10 +1302,9 @@ func (s *store) GetUploadIDsWithReferences(
 		filtered[packageReference.DumpID] = struct{}{}
 	}
 
-	trace.Log(
-		log.Int("uploadIDsWithReferences.numFiltered", len(filtered)),
-		log.Int("uploadIDsWithReferences.numRecordsScanned", recordsScanned),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("uploadIDsWithReferences.numFiltered", len(filtered)),
+		attribute.Int("uploadIDsWithReferences.numRecordsScanned", recordsScanned))
 
 	flattened := make([]int, 0, len(filtered))
 	for k := range filtered {
@@ -1361,7 +1354,7 @@ func (s *store) GetVisibleUploadsMatchingMonikers(ctx context.Context, repositor
 	if err != nil {
 		return nil, 0, err
 	}
-	trace.Log(log.Int("totalCount", totalCount))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("totalCount", totalCount))
 
 	query := sqlf.Sprintf(referenceIDsQuery, visibleUploadsQuery, repositoryID, sqlf.Join(qs, ", "), authzConds, limit, offset)
 	rows, err := s.db.Query(ctx, query)
@@ -1599,11 +1592,10 @@ func (s *store) writeVisibleUploads(ctx context.Context, sanitizedInput *sanitiz
 	if err := g.Wait(); err != nil {
 		return err
 	}
-	trace.Log(
-		log.Int("numNearestUploadsRecords", int(sanitizedInput.numNearestUploadsRecords)),
-		log.Int("numNearestUploadsLinksRecords", int(sanitizedInput.numNearestUploadsLinksRecords)),
-		log.Int("numUploadsVisibleAtTipRecords", int(sanitizedInput.numUploadsVisibleAtTipRecords)),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("numNearestUploadsRecords", int(sanitizedInput.numNearestUploadsRecords)),
+		attribute.Int("numNearestUploadsLinksRecords", int(sanitizedInput.numNearestUploadsLinksRecords)),
+		attribute.Int("numUploadsVisibleAtTipRecords", int(sanitizedInput.numUploadsVisibleAtTipRecords)))
 
 	return nil
 }
@@ -1624,11 +1616,10 @@ func (s *store) persistNearestUploads(ctx context.Context, repositoryID int, tx 
 	if err != nil {
 		return err
 	}
-	trace.Log(
-		log.Int("lsif_nearest_uploads.ins", rowsInserted),
-		log.Int("lsif_nearest_uploads.upd", rowsUpdated),
-		log.Int("lsif_nearest_uploads.del", rowsDeleted),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("lsif_nearest_uploads.ins", rowsInserted),
+		attribute.Int("lsif_nearest_uploads.upd", rowsUpdated),
+		attribute.Int("lsif_nearest_uploads.del", rowsDeleted))
 
 	return nil
 }
@@ -1673,11 +1664,10 @@ func (s *store) persistNearestUploadsLinks(ctx context.Context, repositoryID int
 	if err != nil {
 		return err
 	}
-	trace.Log(
-		log.Int("lsif_nearest_uploads_links.ins", rowsInserted),
-		log.Int("lsif_nearest_uploads_links.upd", rowsUpdated),
-		log.Int("lsif_nearest_uploads_links.del", rowsDeleted),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("lsif_nearest_uploads_links.ins", rowsInserted),
+		attribute.Int("lsif_nearest_uploads_links.upd", rowsUpdated),
+		attribute.Int("lsif_nearest_uploads_links.del", rowsDeleted))
 
 	return nil
 }
@@ -1720,11 +1710,10 @@ func (s *store) persistUploadsVisibleAtTip(ctx context.Context, repositoryID int
 	if err != nil {
 		return err
 	}
-	trace.Log(
-		log.Int("lsif_uploads_visible_at_tip.ins", rowsInserted),
-		log.Int("lsif_uploads_visible_at_tip.upd", rowsUpdated),
-		log.Int("lsif_uploads_visible_at_tip.del", rowsDeleted),
-	)
+	trace.AddEvent("TODO Domain Owner",
+		attribute.Int("lsif_uploads_visible_at_tip.ins", rowsInserted),
+		attribute.Int("lsif_uploads_visible_at_tip.upd", rowsUpdated),
+		attribute.Int("lsif_uploads_visible_at_tip.del", rowsDeleted))
 
 	return nil
 }
@@ -1978,7 +1967,7 @@ func nilTimeToString(t *time.Time) string {
 }
 
 func buildGetConditionsAndCte(opts shared.GetUploadsOptions) (*sqlf.Query, []*sqlf.Query, []cteDefinition) {
-	conds := make([]*sqlf.Query, 0, 12)
+	conds := make([]*sqlf.Query, 0, 13)
 
 	allowDeletedUploads := opts.AllowDeletedUpload && (opts.State == "" || opts.State == "deleted")
 

--- a/enterprise/internal/codeintel/uploads/internal/store/store_uploads_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store_uploads_test.go
@@ -2159,7 +2159,6 @@ func insertVisibleAtTipInternal(t testing.TB, db database.DB, repositoryID int, 
 	}
 }
 
-//nolint:unparam // unparam complains that `repositoryID` always has same value across call-sites, but that's OK
 func getVisibleUploads(t testing.TB, db database.DB, repositoryID int, commits []string) map[string][]int {
 	idsByCommit := map[string][]int{}
 	for _, commit := range commits {
@@ -2181,7 +2180,6 @@ func getVisibleUploads(t testing.TB, db database.DB, repositoryID int, commits [
 	return idsByCommit
 }
 
-//nolint:unparam // unparam complains that `repositoryID` always has same value across call-sites, but that's OK
 func getUploadsVisibleAtTip(t testing.TB, db database.DB, repositoryID int) []int {
 	query := sqlf.Sprintf(
 		`SELECT upload_id FROM lsif_uploads_visible_at_tip WHERE repository_id = %s AND is_default_branch ORDER BY upload_id`,

--- a/enterprise/internal/codeintel/uploads/transport/http/auth/middleware.go
+++ b/enterprise/internal/codeintel/uploads/transport/http/auth/middleware.go
@@ -7,8 +7,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/opentracing/opentracing-go/log"
 	sglog "github.com/sourcegraph/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -48,7 +48,7 @@ func AuthMiddleware(next http.Handler, userStore UserStore, authValidators AuthV
 			// user is a site admin (who can upload LSIF to any repository on the instance), or
 			// if the request a subsequent request of a multi-part upload.
 			if !conf.Get().LsifEnforceAuth || isSiteAdmin(ctx, userStore, operation.Logger) || hasQuery(r, "uploadId") {
-				trace.Log(log.Event("bypassing code host auth check"))
+				trace.AddEvent("bypassing code host auth check")
 				return 0, nil
 			}
 
@@ -59,7 +59,7 @@ func AuthMiddleware(next http.Handler, userStore UserStore, authValidators AuthV
 				if !strings.HasPrefix(repositoryName, codeHost) {
 					continue
 				}
-				trace.Log(log.String("codeHost", codeHost))
+				trace.AddEvent("TODO Domain Owner", attribute.String("codeHost", codeHost))
 
 				return validator(ctx, query, repositoryName)
 			}

--- a/enterprise/internal/compute/template.go
+++ b/enterprise/internal/compute/template.go
@@ -10,6 +10,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/go-enry/go-enry/v2"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
@@ -234,7 +236,7 @@ func templatize(pattern string, env *MetaEnvironment) string {
 				case "date":
 					templatized = append(templatized, env.Date.Format("2006-01-02"))
 				default:
-					templateVar := strings.Title(a.Name[1:])
+					templateVar := cases.Title(language.English).String(a.Name[1:])
 					templatized = append(templatized, `{{.`+templateVar+`}}`)
 				}
 				continue

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -1768,7 +1768,7 @@ func (s *permsStore) observe(ctx context.Context, family, title string) (context
 
 		fs = append(fs, otlog.String("Duration", took.String()))
 
-		tr.LogFields(fs...)
+		tr.LogFields(fs...) //nolint:staticcheck // TODO when updating the observation package
 
 		success := err == nil || *err == nil
 		if !success {

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -492,7 +492,7 @@ func (h *historicalEnqueuer) buildFrames(ctx context.Context, definitions []ityp
 }
 
 func (a *backfillAnalyzer) buildForRepo(ctx context.Context, definitions []itypes.InsightSeries, repoName string, id api.RepoID) (jobs []*queryrunner.Job, err error, softErr error) {
-	span, ctx := ot.StartSpanFromContext(policy.WithShouldTrace(ctx, true), "historical_enqueuer.buildForRepo")
+	span, ctx := ot.StartSpanFromContext(policy.WithShouldTrace(ctx, true), "historical_enqueuer.buildForRepo") //nolint:staticcheck // OT is deprecated
 	span.SetTag("repo_id", id)
 	defer func() {
 		if err != nil {

--- a/internal/cloneurls/clone_urls.go
+++ b/internal/cloneurls/clone_urls.go
@@ -23,7 +23,7 @@ import (
 // error if a matching code host could not be found. This function does not actually check the code
 // host to see if the repository actually exists.
 func ReposourceCloneURLToRepoName(ctx context.Context, db database.DB, cloneURL string) (repoName api.RepoName, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "ReposourceCloneURLToRepoName")
+	span, ctx := ot.StartSpanFromContext(ctx, "ReposourceCloneURLToRepoName") //nolint:staticcheck // OT is deprecated
 	defer span.Finish()
 
 	if repoName := reposource.CustomCloneURLToRepoName(cloneURL); repoName != "" {
@@ -102,7 +102,7 @@ func ReposourceCloneURLToRepoName(ctx context.Context, db database.DB, cloneURL 
 }
 
 func getRepoNameFromService(ctx context.Context, cloneURL string, svc *types.ExternalService) (api.RepoName, error) {
-	span, _ := ot.StartSpanFromContext(ctx, "getRepoNameFromService")
+	span, _ := ot.StartSpanFromContext(ctx, "getRepoNameFromService") //nolint:staticcheck // OT is deprecated
 	defer span.Finish()
 	span.SetTag("ExternalService.ID", svc.ID)
 	span.SetTag("ExternalService.Kind", svc.Kind)

--- a/internal/codeintel/resolvers/all.go
+++ b/internal/codeintel/resolvers/all.go
@@ -2,7 +2,7 @@ package resolvers
 
 import (
 	"context"
-	"regexp" // nolint:depguard // regexps are passed to bluemonday, which expects the std ones
+	"regexp" //nolint:depguard // regexps are passed to bluemonday, which expects the std ones
 	"sync"
 
 	"github.com/graph-gophers/graphql-go"

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -221,7 +221,7 @@ func StartAndWaitForCompletion(cmd *exec.Cmd) error {
 
 // Matches returns all matches in all files for which comby finds matches.
 func Matches(ctx context.Context, args Args) ([]*FileMatch, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Comby.Matches")
+	span, ctx := ot.StartSpanFromContext(ctx, "Comby.Matches") //nolint:staticcheck // OT is deprecated
 	defer span.Finish()
 
 	args.ResultKind = MatchOnly
@@ -238,7 +238,7 @@ func Matches(ctx context.Context, args Args) ([]*FileMatch, error) {
 
 // Replacements performs in-place replacement for match and rewrite template.
 func Replacements(ctx context.Context, args Args) ([]*FileReplacement, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Comby.Replacements")
+	span, ctx := ot.StartSpanFromContext(ctx, "Comby.Replacements") //nolint:staticcheck // OT is deprecated
 	defer span.Finish()
 
 	results, err := Run(ctx, args, toFileReplacement)
@@ -255,7 +255,7 @@ func Replacements(ctx context.Context, args Args) ([]*FileReplacement, error) {
 // Outputs performs substitution of all variables captured in a match
 // pattern in a rewrite template and outputs the result, newline-sparated.
 func Outputs(ctx context.Context, args Args) (string, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Comby.Outputs")
+	span, ctx := ot.StartSpanFromContext(ctx, "Comby.Outputs") //nolint:staticcheck // OT is deprecated
 	defer span.Finish()
 
 	results, err := Run(ctx, args, toOutput)

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -385,7 +385,7 @@ func (s *userExternalAccountsStore) List(ctx context.Context, opt ExternalAccoun
 			tr.SetError(err)
 		}
 
-		tr.LogFields(
+		tr.LogFields( //nolint:staticcheck // TODO unpack the object
 			otlog.Object("opt", opt),
 			otlog.Int("accounts.count", len(acct)),
 		)

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -1340,7 +1340,7 @@ ORDER BY es.id, essj.finished_at DESC
 }
 
 func (e *externalServiceStore) List(ctx context.Context, opt ExternalServicesListOptions) ([]*types.ExternalService, error) {
-	span, _ := ot.StartSpanFromContext(ctx, "ExternalServiceStore.list")
+	span, _ := ot.StartSpanFromContext(ctx, "ExternalServiceStore.list") //nolint:staticcheck // OT is deprecated
 	defer span.Finish()
 
 	if opt.OrderByDirection != "ASC" {
@@ -1435,7 +1435,7 @@ func (e *externalServiceStore) List(ctx context.Context, opt ExternalServicesLis
 }
 
 func (e *externalServiceStore) ListRepos(ctx context.Context, opt ExternalServiceReposListOptions) ([]*types.ExternalServiceRepo, error) {
-	span, _ := ot.StartSpanFromContext(ctx, "ExternalServiceStore.listRepos")
+	span, _ := ot.StartSpanFromContext(ctx, "ExternalServiceStore.listRepos") //nolint:staticcheck // OT is deprecated
 	defer span.Finish()
 
 	predicate := sqlf.Sprintf("TRUE")

--- a/internal/database/saved_searches.go
+++ b/internal/database/saved_searches.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 
 	"github.com/keegancsmith/sqlf"
-	otlog "github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -70,7 +70,7 @@ func (s *savedSearchStore) ListAll(ctx context.Context) (savedSearches []api.Sav
 	tr, ctx := trace.New(ctx, "database.SavedSearches.ListAll", "")
 	defer func() {
 		tr.SetError(err)
-		tr.LogFields(otlog.Int("count", len(savedSearches)))
+		tr.SetAttributes(attribute.Int("count", len(savedSearches)))
 		tr.Finish()
 	}()
 

--- a/internal/diskcache/cache.go
+++ b/internal/diskcache/cache.go
@@ -147,7 +147,7 @@ func (s *store) OpenWithPath(ctx context.Context, key []string, fetcher FetcherW
 	}
 
 	path := s.path(key)
-	trace.Log(otelog.String("key", fmt.Sprint(key)), otelog.String("path", path))
+	trace.AddEvent("TODO Domain Owner", attribute.String("key", fmt.Sprint(key)), attribute.String("path", path))
 
 	err = os.MkdirAll(filepath.Dir(path), os.ModePerm)
 	if err != nil {
@@ -222,10 +222,7 @@ func doFetch(ctx context.Context, path string, fetcher FetcherWithPath, trace ob
 	urlMu.Lock()
 	defer urlMu.Unlock()
 
-	trace.Log(
-		otelog.Event("acquired url lock"),
-		otelog.Int64("urlLock.durationMs", time.Since(t).Milliseconds()),
-	)
+	trace.AddEvent("acquired url lock", attribute.Int64("urlLock.durationMs", time.Since(t).Milliseconds()))
 
 	// Since we acquired the lock we may have timed out.
 	if ctx.Err() != nil {
@@ -365,7 +362,7 @@ func (s *store) Evict(maxCacheSizeBytes int64) (stats EvictStats, err error) {
 		}
 		err = os.Remove(path)
 		if err != nil {
-			trace.Log(otelog.Message("failed to remove disk cache entry"), otelog.String("path", path), otelog.Error(err))
+			trace.AddEvent("failed to remove disk cache entry", attribute.String("path", path), attribute.String("error", err.Error()))
 			log.Printf("failed to remove %s: %s", path, err)
 			continue
 		}

--- a/internal/diskcache/cache.go
+++ b/internal/diskcache/cache.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/opentracing/opentracing-go/ext"
 	otelog "github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -156,12 +157,12 @@ func (s *store) OpenWithPath(ctx context.Context, key []string, fetcher FetcherW
 	// First do a fast-path, assume already on disk
 	f, err := os.Open(path)
 	if err == nil {
-		trace.Tag(otelog.String("source", "fast"))
+		trace.SetAttributes(attribute.String("source", "fast"))
 		return &File{File: f, Path: path}, nil
 	}
 
 	// We (probably) have to fetch
-	trace.Tag(otelog.String("source", "fetch"))
+	trace.SetAttributes(attribute.String("source", "fetch"))
 
 	// Do the fetch in another goroutine so we can respect ctx cancellation.
 	type result struct {
@@ -372,10 +373,10 @@ func (s *store) Evict(maxCacheSizeBytes int64) (stats EvictStats, err error) {
 		size -= entry.info.Size()
 	}
 
-	trace.Tag(
-		otelog.Int("evicted", stats.Evicted),
-		otelog.Int64("beforeSizeBytes", stats.CacheSize),
-		otelog.Int64("afterSizeBytes", size),
+	trace.SetAttributes(
+		attribute.Int("evicted", stats.Evicted),
+		attribute.Int64("beforeSizeBytes", stats.CacheSize),
+		attribute.Int64("afterSizeBytes", size),
 	)
 
 	return stats, nil

--- a/internal/encryption/cloudkms/cloud_kms.go
+++ b/internal/encryption/cloudkms/cloud_kms.go
@@ -10,7 +10,7 @@ import (
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"google.golang.org/api/option"
-	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
+	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1" //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45843
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -42,7 +42,7 @@ type Key struct {
 }
 
 func (k *Key) Version(ctx context.Context) (encryption.KeyVersion, error) {
-	key, err := k.client.GetCryptoKey(ctx, &kmspb.GetCryptoKeyRequest{
+	key, err := k.client.GetCryptoKey(ctx, &kmspb.GetCryptoKeyRequest{ //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45843
 		Name: k.name,
 	})
 	if err != nil {
@@ -79,7 +79,7 @@ func (k *Key) Decrypt(ctx context.Context, cipherText []byte) (_ *encryption.Sec
 		return nil, errors.New("invalid key name, are you trying to decrypt something with the wrong key?")
 	}
 	// decrypt ciphertext
-	res, err := k.client.Decrypt(ctx, &kmspb.DecryptRequest{
+	res, err := k.client.Decrypt(ctx, &kmspb.DecryptRequest{ //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45843
 		Name:       k.name,
 		Ciphertext: ev.Ciphertext,
 	})
@@ -103,7 +103,7 @@ func (k *Key) Encrypt(ctx context.Context, plaintext []byte) (_ []byte, err erro
 	}()
 
 	// encrypt plaintext
-	res, err := k.client.Encrypt(ctx, &kmspb.EncryptRequest{
+	res, err := k.client.Encrypt(ctx, &kmspb.EncryptRequest{ //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45843
 		Name:            k.name,
 		Plaintext:       plaintext,
 		PlaintextCrc32C: wrapperspb.Int64(int64(crc32Sum(plaintext))),

--- a/internal/encryption/helpers.go
+++ b/internal/encryption/helpers.go
@@ -20,14 +20,14 @@ func MaybeEncrypt(ctx context.Context, key Key, data string) (_, keyIdent string
 		return data, "", nil
 	}
 
-	span, ctx := ot.StartSpanFromContext(ctx, "key.Encrypt")
+	span, ctx := ot.StartSpanFromContext(ctx, "key.Encrypt") //nolint:staticcheck // OT is deprecated
 	encrypted, err := key.Encrypt(ctx, []byte(data))
 	span.Finish()
 	if err != nil {
 		return "", "", err
 	}
 
-	span, ctx = ot.StartSpanFromContext(ctx, "key.Version")
+	span, ctx = ot.StartSpanFromContext(ctx, "key.Version") //nolint:staticcheck // OT is deprecated
 	version, err := key.Version(ctx)
 	span.Finish()
 	if err != nil {
@@ -50,11 +50,11 @@ func MaybeDecrypt(ctx context.Context, key Key, data, keyIdent string) (string, 
 		return data, errors.Errorf("key mismatch: value is encrypted but no encryption key available in site-config")
 	}
 
-	span, ctx := ot.StartSpanFromContext(ctx, "key.Decrypt")
+	span, ctx := ot.StartSpanFromContext(ctx, "key.Decrypt") //nolint:staticcheck // OT is deprecated
 	decrypted, err := key.Decrypt(ctx, []byte(data))
 	span.Finish()
 	if err != nil {
-		span, ctx = ot.StartSpanFromContext(ctx, "key.Version")
+		span, ctx = ot.StartSpanFromContext(ctx, "key.Version") //nolint:staticcheck // OT is deprecated
 		version, versionErr := key.Version(ctx)
 		span.Finish()
 		if versionErr == nil && keyIdent != version.JSON() {

--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -194,7 +194,7 @@ func (c *client) do(ctx context.Context, req *http.Request, result any) error {
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	}
 
-	req, ht := nethttp.TraceRequest(ot.GetTracer(ctx),
+	req, ht := nethttp.TraceRequest(ot.GetTracer(ctx), //nolint:staticcheck // Drop once we get rid of OpenTracing
 		req.WithContext(ctx),
 		nethttp.OperationName("Bitbucket Cloud"),
 		nethttp.ClientTrace(false))

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -948,7 +948,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, result any) (*http.R
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	}
 
-	req, ht := nethttp.TraceRequest(ot.GetTracer(ctx),
+	req, ht := nethttp.TraceRequest(ot.GetTracer(ctx), //nolint:staticcheck // Drop once we get rid of OpenTracing
 		req.WithContext(ctx),
 		nethttp.OperationName("Bitbucket Server"),
 		nethttp.ClientTrace(false))

--- a/internal/extsvc/gerrit/client.go
+++ b/internal/extsvc/gerrit/client.go
@@ -166,7 +166,7 @@ func (c *Client) ListProjects(ctx context.Context, opts ListProjectsArgs) (proje
 	return &respCodeProjects, nextPage, nil
 }
 
-// nolint:unparam
+//nolint:unparam // http.Response is never used, but it makes sense API wise.
 func (c *Client) do(ctx context.Context, req *http.Request, result any) (*http.Response, error) {
 	req.URL = c.URL.ResolveReference(req.URL)
 

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1531,7 +1531,7 @@ func doRequest(ctx context.Context, logger log.Logger, apiURL *url.URL, auther a
 
 	var resp *http.Response
 
-	span, ctx := ot.StartSpanFromContext(ctx, "GitHub")
+	span, ctx := ot.StartSpanFromContext(ctx, "GitHub") //nolint:staticcheck // OT is deprecated
 	span.SetTag("URL", req.URL.String())
 	defer func() {
 		if err != nil {

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -147,7 +147,6 @@ func (c *V3Client) get(ctx context.Context, requestURI string, result any) (*htt
 	return c.request(ctx, req, result)
 }
 
-//nolint:unparam // Return *httpResponseState for consistency with other methods
 func (c *V3Client) post(ctx context.Context, requestURI string, payload, result any) (*httpResponseState, error) {
 	body, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -243,7 +243,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, result any) (respons
 func (c *Client) doWithBaseURL(ctx context.Context, req *http.Request, result any) (responseHeader http.Header, responseCode int, err error) {
 	var responseStatus string
 
-	span, ctx := ot.StartSpanFromContext(ctx, "GitLab")
+	span, ctx := ot.StartSpanFromContext(ctx, "GitLab") //nolint:staticcheck // OT is deprecated
 	span.SetTag("URL", req.URL.String())
 	defer func() {
 		if err != nil {

--- a/internal/extsvc/jvmpackages/coursier/coursier.go
+++ b/internal/extsvc/jvmpackages/coursier/coursier.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	otlog "github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -187,7 +188,7 @@ func runCoursierCommand(ctx context.Context, config *schema.JVMPackagesConnectio
 	if err := cmd.Run(); err != nil {
 		return nil, errors.Wrapf(err, "coursier command %q failed with stderr %q and stdout %q", cmd, stderr, &stdout)
 	}
-	trace.Log(otlog.String("stdout", stdout.String()), otlog.String("stderr", stderr.String()))
+	trace.AddEvent("TODO Domain Owner", attribute.String("stdout", stdout.String()), attribute.String("stderr", stderr.String()))
 
 	if stdout.String() == "" {
 		return []string{}, nil

--- a/internal/extsvc/npm/npm.go
+++ b/internal/extsvc/npm/npm.go
@@ -112,7 +112,7 @@ func (i illFormedJSONError) Error() string {
 }
 
 func (client *HTTPClient) do(ctx context.Context, req *http.Request) (*http.Response, error) {
-	req, ht := nethttp.TraceRequest(ot.GetTracer(ctx),
+	req, ht := nethttp.TraceRequest(ot.GetTracer(ctx), //nolint:staticcheck // Drop once we get rid of OpenTracing
 		req.WithContext(ctx),
 		nethttp.OperationName("npm"),
 		nethttp.ClientTrace(false))

--- a/internal/featureflag/middleware_test.go
+++ b/internal/featureflag/middleware_test.go
@@ -186,5 +186,5 @@ func setupRedisTest(t *testing.T) {
 		return nil, nil
 	}))
 
-	pool = redis.NewPool(func() (redis.Conn, error) { return mockConn, nil }, 10)
+	pool = &redis.Pool{Dial: func() (redis.Conn, error) { return mockConn, nil }, MaxIdle: 10}
 }

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -605,7 +605,7 @@ func (e badRequestError) BadRequest() bool { return true }
 func (c *RemoteGitCommand) sendExec(ctx context.Context) (_ io.ReadCloser, _ http.Header, errRes error) {
 	repoName := protocol.NormalizeRepo(c.repo)
 
-	span, ctx := ot.StartSpanFromContext(ctx, "Client.sendExec")
+	span, ctx := ot.StartSpanFromContext(ctx, "Client.sendExec") //nolint:staticcheck // OT is deprecated
 	defer func() {
 		if errRes != nil {
 			ext.Error.Set(span, true)
@@ -655,7 +655,7 @@ func (c *RemoteGitCommand) sendExec(ctx context.Context) (_ io.ReadCloser, _ htt
 }
 
 func (c *clientImplementor) Search(ctx context.Context, args *protocol.SearchRequest, onMatches func([]protocol.CommitMatch)) (limitHit bool, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "GitserverClient.Search")
+	span, ctx := ot.StartSpanFromContext(ctx, "GitserverClient.Search") //nolint:staticcheck // OT is deprecated
 	span.SetTag("repo", string(args.Repo))
 	span.SetTag("query", args.Query.String())
 	span.SetTag("diff", args.IncludeDiff)
@@ -717,7 +717,7 @@ func (c *clientImplementor) Search(ctx context.Context, args *protocol.SearchReq
 }
 
 func (c *clientImplementor) P4Exec(ctx context.Context, host, user, password string, args ...string) (_ io.ReadCloser, _ http.Header, errRes error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Client.P4Exec")
+	span, ctx := ot.StartSpanFromContext(ctx, "Client.P4Exec") //nolint:staticcheck // OT is deprecated
 	defer func() {
 		if errRes != nil {
 			ext.Error.Set(span, true)
@@ -1241,7 +1241,7 @@ func (c *clientImplementor) do(ctx context.Context, repo api.RepoName, method, u
 		return nil, errors.Wrap(err, "do")
 	}
 
-	span, ctx := ot.StartSpanFromContext(ctx, "Client.do")
+	span, ctx := ot.StartSpanFromContext(ctx, "Client.do") //nolint:staticcheck // OT is deprecated
 	defer func() {
 		if repo != "" {
 			span.LogKV("repo", string(repo), "method", method, "path", parsedURL.Path)

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 
@@ -805,7 +806,7 @@ func (c *clientImplementor) BatchLog(ctx context.Context, opts BatchLogOptions, 
 			return err
 		}
 		defer resp.Body.Close()
-		logger.Log(log.Int("resp.StatusCode", resp.StatusCode))
+		logger.AddEvent("POST", attribute.Int("resp.StatusCode", resp.StatusCode))
 
 		if resp.StatusCode != http.StatusOK {
 			return errors.Newf("http status %d: %s", resp.StatusCode, readResponseBody(io.LimitReader(resp.Body, 200)))
@@ -815,7 +816,7 @@ func (c *clientImplementor) BatchLog(ctx context.Context, opts BatchLogOptions, 
 		if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 			return err
 		}
-		logger.Log(log.Int("numResults", len(response.Results)))
+		logger.AddEvent("read response", attribute.Int("numResults", len(response.Results)))
 
 		for _, result := range response.Results {
 			var err error

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -157,7 +157,7 @@ type ContributorOptions struct {
 }
 
 func (c *clientImplementor) ContributorCount(ctx context.Context, repo api.RepoName, opt ContributorOptions) ([]*gitdomain.ContributorCount, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: ShortLog")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: ShortLog") //nolint:staticcheck // OT is deprecated
 	span.SetTag("Opt", opt)
 	defer span.Finish()
 
@@ -191,7 +191,7 @@ func (c *clientImplementor) ContributorCount(ctx context.Context, repo api.RepoN
 // execReader should NOT be exported. We want to limit direct git calls to this
 // package.
 func (c *clientImplementor) execReader(ctx context.Context, repo api.RepoName, args []string) (io.ReadCloser, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: ExecReader")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: ExecReader") //nolint:staticcheck // OT is deprecated
 	span.SetTag("args", args)
 	defer span.Finish()
 
@@ -365,7 +365,7 @@ func (c *clientImplementor) DiffSymbols(ctx context.Context, repo api.RepoName, 
 
 // ReadDir reads the contents of the named directory at commit.
 func (c *clientImplementor) ReadDir(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, path string, recurse bool) ([]fs.FileInfo, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: ReadDir")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: ReadDir") //nolint:staticcheck // OT is deprecated
 	span.SetTag("Commit", commit)
 	span.SetTag("Path", path)
 	span.SetTag("Recurse", recurse)
@@ -454,7 +454,7 @@ func (oid objectInfo) OID() gitdomain.OID { return gitdomain.OID(oid) }
 // symbolic link, the returned FileInfo describes the symbolic link. lStat makes
 // no attempt to follow the link.
 func (c *clientImplementor) lStat(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, path string) (fs.FileInfo, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: lStat")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: lStat") //nolint:staticcheck // OT is deprecated
 	span.SetTag("Commit", commit)
 	span.SetTag("Path", path)
 	defer span.Finish()
@@ -689,7 +689,7 @@ type Hunk struct {
 
 // StreamBlameFile returns Git blame information about a file.
 func (c *clientImplementor) StreamBlameFile(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, path string, opt *BlameOptions) (HunkReader, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: StreamBlameFile")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: StreamBlameFile") //nolint:staticcheck // OT is deprecated
 	span.SetTag("repo", repo)
 	span.SetTag("path", path)
 	span.SetTag("opt", opt)
@@ -742,7 +742,7 @@ func streamBlameFileCmd(ctx context.Context, checker authz.SubRepoPermissionChec
 
 // BlameFile returns Git blame information about a file.
 func (c *clientImplementor) BlameFile(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, path string, opt *BlameOptions) ([]*Hunk, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: BlameFile")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: BlameFile") //nolint:staticcheck // OT is deprecated
 	span.SetTag("repo", repo)
 	span.SetTag("path", path)
 	span.SetTag("opt", opt)
@@ -933,7 +933,7 @@ func (c *clientImplementor) ResolveRevision(ctx context.Context, repo api.RepoNa
 	}
 	resolveRevisionCounter.WithLabelValues(labelEnsureRevisionValue).Inc()
 
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: ResolveRevision")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: ResolveRevision") //nolint:staticcheck // OT is deprecated
 	span.SetTag("Spec", spec)
 	span.SetTag("Opt", fmt.Sprintf("%+v", opt))
 	defer span.Finish()
@@ -1145,7 +1145,7 @@ func parseDirectoryChildren(dirnames, paths []string) map[string][]string {
 }
 
 func (c *clientImplementor) LFSSmudge(ctx context.Context, repo api.RepoName, commit api.CommitID, path string, checker authz.SubRepoPermissionChecker) (_ io.ReadCloser, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: LFSSmudge")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: LFSSmudge") //nolint:staticcheck // OT is deprecated
 	defer func() {
 		if err != nil {
 			ext.Error.Set(span, true)
@@ -1191,7 +1191,7 @@ type withCloser struct {
 
 // ListTags returns a list of all tags in the repository. If commitObjs is non-empty, only all tags pointing at those commits are returned.
 func (c *clientImplementor) ListTags(ctx context.Context, repo api.RepoName, commitObjs ...string) ([]*gitdomain.Tag, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: Tags")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: Tags") //nolint:staticcheck // OT is deprecated
 	defer span.Finish()
 
 	// Support both lightweight tags and tag objects. For creatordate, use an %(if) to prefer the
@@ -1280,7 +1280,7 @@ func (c *clientImplementor) GetDefaultBranch(ctx context.Context, repo api.RepoN
 
 // MergeBase returns the merge base commit for the specified commits.
 func (c *clientImplementor) MergeBase(ctx context.Context, repo api.RepoName, a, b api.CommitID) (api.CommitID, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: MergeBase")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: MergeBase") //nolint:staticcheck // OT is deprecated
 	span.SetTag("A", a)
 	span.SetTag("B", b)
 	defer span.Finish()
@@ -1316,7 +1316,7 @@ func RevListArgs(givenCommit string) []string {
 // GetBehindAhead returns the behind/ahead commit counts information for right vs. left (both Git
 // revspecs).
 func (c *clientImplementor) GetBehindAhead(ctx context.Context, repo api.RepoName, left, right string) (*gitdomain.BehindAhead, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: BehindAhead")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: BehindAhead") //nolint:staticcheck // OT is deprecated
 	defer span.Finish()
 
 	if err := checkSpecArgSafety(left); err != nil {
@@ -1346,7 +1346,7 @@ func (c *clientImplementor) GetBehindAhead(ctx context.Context, repo api.RepoNam
 // ReadFile returns the first maxBytes of the named file at commit. If maxBytes <= 0, the entire
 // file is read. (If you just need to check a file's existence, use Stat, not ReadFile.)
 func (c *clientImplementor) ReadFile(ctx context.Context, repo api.RepoName, commit api.CommitID, name string, checker authz.SubRepoPermissionChecker) ([]byte, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: ReadFile")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: ReadFile") //nolint:staticcheck // OT is deprecated
 	span.SetTag("Name", name)
 	defer span.Finish()
 
@@ -1374,7 +1374,7 @@ func (c *clientImplementor) NewFileReader(ctx context.Context, repo api.RepoName
 		return nil, os.ErrNotExist
 	}
 
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: GetFileReader")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: GetFileReader") //nolint:staticcheck // OT is deprecated
 	span.SetTag("Name", name)
 	defer span.Finish()
 
@@ -1459,7 +1459,7 @@ func (br *blobReader) convertError(err error) error {
 
 // Stat returns a FileInfo describing the named file at commit.
 func (c *clientImplementor) Stat(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, path string) (fs.FileInfo, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: Stat")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: Stat") //nolint:staticcheck // OT is deprecated
 	span.SetTag("Commit", commit)
 	span.SetTag("Path", path)
 	defer span.Finish()
@@ -1560,7 +1560,7 @@ func (c *clientImplementor) getCommit(ctx context.Context, repo api.RepoName, id
 // needed. The Git remote URL is only required if the gitserver doesn't already contain a clone of
 // the repository or if the commit must be fetched from the remote.
 func (c *clientImplementor) GetCommit(ctx context.Context, repo api.RepoName, id api.CommitID, opt ResolveRevisionOptions, checker authz.SubRepoPermissionChecker) (*gitdomain.Commit, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: GetCommit")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: GetCommit") //nolint:staticcheck // OT is deprecated
 	span.SetTag("Commit", id)
 	defer span.Finish()
 
@@ -1570,7 +1570,7 @@ func (c *clientImplementor) GetCommit(ctx context.Context, repo api.RepoName, id
 // Commits returns all commits matching the options.
 func (c *clientImplementor) Commits(ctx context.Context, repo api.RepoName, opt CommitsOptions, checker authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error) {
 	opt = addNameOnly(opt, checker)
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: Commits")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: Commits") //nolint:staticcheck // OT is deprecated
 	span.SetTag("Opt", opt)
 	defer span.Finish()
 
@@ -1689,7 +1689,7 @@ func (c *clientImplementor) HasCommitAfter(ctx context.Context, repo api.RepoNam
 	if authz.SubRepoEnabled(checker) {
 		return c.hasCommitAfterWithFiltering(ctx, repo, date, revspec, checker)
 	}
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: HasCommitAfter")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: HasCommitAfter") //nolint:staticcheck // OT is deprecated
 	span.SetTag("Date", date)
 	span.SetTag("RevSpec", revspec)
 	defer span.Finish()
@@ -1911,7 +1911,7 @@ func commitLogArgs(initialArgs []string, opt CommitsOptions) (args []string, err
 
 // commitCount returns the number of commits that would be returned by Commits.
 func (c *clientImplementor) commitCount(ctx context.Context, repo api.RepoName, opt CommitsOptions) (uint, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: CommitCount")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: CommitCount") //nolint:staticcheck // OT is deprecated
 	span.SetTag("Opt", opt)
 	defer span.Finish()
 
@@ -1937,7 +1937,7 @@ func (c *clientImplementor) commitCount(ctx context.Context, repo api.RepoName, 
 
 // FirstEverCommit returns the first commit ever made to the repository.
 func (c *clientImplementor) FirstEverCommit(ctx context.Context, repo api.RepoName, checker authz.SubRepoPermissionChecker) (*gitdomain.Commit, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: FirstEverCommit")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: FirstEverCommit") //nolint:staticcheck // OT is deprecated
 	defer span.Finish()
 
 	args := []string{"rev-list", "--reverse", "--date-order", "--max-parents=0", "HEAD"}
@@ -1992,7 +1992,7 @@ func (c *clientImplementor) CommitsExist(ctx context.Context, repoCommits []api.
 // If ignoreErrors is true, then errors arising from any single failed git log operation will cause the
 // resulting commit to be nil, but not fail the entire operation.
 func (c *clientImplementor) GetCommits(ctx context.Context, repoCommits []api.RepoCommit, ignoreErrors bool, checker authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: getCommits")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: getCommits") //nolint:staticcheck // OT is deprecated
 	span.SetTag("numRepoCommits", len(repoCommits))
 	defer span.Finish()
 
@@ -2436,7 +2436,7 @@ func (c *clientImplementor) ArchiveReader(
 	if ClientMocks.Archive != nil {
 		return ClientMocks.Archive(ctx, repo, options)
 	}
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: Archive")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: Archive") //nolint:staticcheck // OT is deprecated
 	span.SetTag("Repo", repo)
 	span.SetTag("Treeish", options.Treeish)
 	defer func() {
@@ -2543,7 +2543,7 @@ func (f branchFilter) add(list []string) {
 
 // ListBranches returns a list of all branches in the repository.
 func (c *clientImplementor) ListBranches(ctx context.Context, repo api.RepoName, opt BranchesOptions) ([]*gitdomain.Branch, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: Branches")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: Branches") //nolint:staticcheck // OT is deprecated
 	span.SetTag("Opt", opt)
 	defer span.Finish()
 
@@ -2618,7 +2618,7 @@ func (p byteSlices) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 // ListRefs returns a list of all refs in the repository.
 func (c *clientImplementor) ListRefs(ctx context.Context, repo api.RepoName) ([]gitdomain.Ref, error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Git: ListRefs")
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: ListRefs") //nolint:staticcheck // OT is deprecated
 	defer span.Finish()
 	return c.showRef(ctx, repo)
 }

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
@@ -115,6 +116,13 @@ func (req BatchLogRequest) LogFields() []log.Field {
 	return []log.Field{
 		log.Int("numRepoCommits", len(req.RepoCommits)),
 		log.String("format", req.Format),
+	}
+}
+
+func (req BatchLogRequest) SpanAttributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.Int("numRepoCommits", len(req.RepoCommits)),
+		attribute.String("format", req.Format),
 	}
 }
 

--- a/internal/gitserver/proxy.go
+++ b/internal/gitserver/proxy.go
@@ -37,7 +37,7 @@ type ReverseProxy struct {
 // to gitserver. The director must rewrite the request to the correct gitserver address, which
 // should be obtained via a gitserver client's AddrForRepo method.
 func (p *ReverseProxy) ServeHTTP(repo api.RepoName, method, op string, director func(req *http.Request), res http.ResponseWriter, req *http.Request) {
-	span, _ := ot.StartSpanFromContext(req.Context(), "ReverseProxy.ServeHTTP")
+	span, _ := ot.StartSpanFromContext(req.Context(), "ReverseProxy.ServeHTTP") //nolint:staticcheck // OT is deprecated
 	defer func() {
 		span.LogKV("repo", string(repo), "method", method, "op", op)
 		span.Finish()

--- a/internal/httpcli/client_test.go
+++ b/internal/httpcli/client_test.go
@@ -190,7 +190,7 @@ func TestNewCertPool(t *testing.T) {
 			certs: []string{cert},
 			assert: func(t testing.TB, cli *http.Client) {
 				pool := cli.Transport.(*http.Transport).TLSClientConfig.RootCAs
-				for _, have := range pool.Subjects() {
+				for _, have := range pool.Subjects() { //nolint:staticcheck // pool.Subjects, see https://github.com/golang/go/issues/46287
 					if bytes.Contains(have, []byte(subject)) {
 						return
 					}

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -136,7 +136,7 @@ func (t *traceLogger) initWithTags(fields ...otlog.Field) {
 		}
 	}
 	if t.trace != nil {
-		t.trace.TagFields(fields...)
+		t.trace.TagFields(fields...) //nolint:staticcheck // Workaround until we drop OpenTracing
 	}
 }
 

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -168,7 +168,7 @@ func (t *traceLogger) Log(fields ...otlog.Field) {
 		}
 	}
 	if t.trace != nil {
-		t.trace.LogFields(fields...) //nolint:staticcheck // TODO when updating the observation package
+		t.trace.LogFields(fields...)
 		if enableTraceLog {
 			t.Logger.
 				AddCallerSkip(1). // Log() -> Logger

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -168,7 +168,7 @@ func (t *traceLogger) Log(fields ...otlog.Field) {
 		}
 	}
 	if t.trace != nil {
-		t.trace.LogFields(fields...)
+		t.trace.LogFields(fields...) //nolint:staticcheck // TODO when updating the observation package
 		if enableTraceLog {
 			t.Logger.
 				AddCallerSkip(1). // Log() -> Logger
@@ -425,7 +425,7 @@ func (op *Operation) finishTrace(err *error, tr *trace.Trace, logFields []otlog.
 		tr.SetError(*err)
 	}
 
-	tr.LogFields(logFields...)
+	tr.LogFields(logFields...) //nolint:staticcheck // TODO when updating the observation package
 	tr.Finish()
 }
 

--- a/internal/oobmigration/store_test.go
+++ b/internal/oobmigration/store_test.go
@@ -489,7 +489,6 @@ var testEnterpriseMigrations = []Migration{
 
 func timePtr(t time.Time) *time.Time { return &t }
 
-//nolint:unparam // unparam complains that `major` always has same value across call-sites, but that's OK
 func newVersionPtr(major, minor int) *Version {
 	v := NewVersion(major, minor)
 	return &v

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
-	otlog "github.com/opentracing/opentracing-go/log"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/log"
 
@@ -178,7 +178,7 @@ func (s *store) transact(ctx context.Context) (stx *store, err error) {
 // Done calls into the inner Store Done method.
 func (s *store) Done(err error) error {
 	tr := s.txtrace
-	tr.LogFields(otlog.String("event", "Store.Done"))
+	tr.SetAttributes(attribute.String("event", "Store.Done"))
 	logger := trace.Logger(s.txctx, s.Logger)
 
 	defer func(began time.Time) {
@@ -215,9 +215,9 @@ func (s *store) trace(ctx context.Context, family string) (*trace.Trace, context
 
 func (s *store) DeleteExternalServiceReposNotIn(ctx context.Context, svc *types.ExternalService, ids map[api.RepoID]struct{}) (deleted []api.RepoID, err error) {
 	tr, ctx := s.trace(ctx, "Store.DeleteExternalServiceReposNotIn")
-	tr.LogFields(
-		otlog.Int("len(ids)", len(ids)),
-		otlog.Int64("external_service_id", svc.ID),
+	tr.SetAttributes(
+		attribute.Int("len(ids)", len(ids)),
+		attribute.Int64("external_service_id", svc.ID),
 	)
 	logger := trace.Logger(ctx, s.Logger).With(log.Int64("externalServiceID", svc.ID), log.Int("len(ids)", len(ids)))
 
@@ -266,9 +266,9 @@ WHERE external_service_id = %s AND repo_id != ALL(%s)
 
 func (s *store) DeleteExternalServiceRepo(ctx context.Context, svc *types.ExternalService, id api.RepoID) (err error) {
 	tr, ctx := s.trace(ctx, "Store.DeleteExternalServiceRepo")
-	tr.LogFields(
-		otlog.Int32("id", int32(id)),
-		otlog.Int64("external_service_id", svc.ID),
+	tr.SetAttributes(
+		attribute.Int64("id", int64(id)),
+		attribute.Int64("external_service_id", svc.ID),
 	)
 	logger := trace.Logger(ctx, s.Logger).With(log.Int64("externalServiceID", svc.ID), log.Int("repoID", int(id)))
 
@@ -322,10 +322,10 @@ WHERE id = %s AND NOT EXISTS (
 
 func (s *store) CreateExternalServiceRepo(ctx context.Context, svc *types.ExternalService, r *types.Repo) (err error) {
 	tr, ctx := s.trace(ctx, "Store.CreateExternalServiceRepo")
-	tr.LogFields(
-		otlog.String("name", string(r.Name)),
-		otlog.Int64("external_service_id", svc.ID),
-		otlog.String("external_repo_spec", r.ExternalRepo.String()),
+	tr.SetAttributes(
+		attribute.String("name", string(r.Name)),
+		attribute.Int64("external_service_id", svc.ID),
+		attribute.String("external_repo_spec", r.ExternalRepo.String()),
 	)
 	logger := trace.Logger(ctx, s.Logger).With(
 		log.Int("externalServiceID", int(svc.ID)),
@@ -430,9 +430,9 @@ WHERE
 
 func (s *store) UpdateRepo(ctx context.Context, r *types.Repo) (saved *types.Repo, err error) {
 	tr, ctx := s.trace(ctx, "Store.UpdateRepo")
-	tr.LogFields(
-		otlog.String("name", string(r.Name)),
-		otlog.Int32("id", int32(r.ID)),
+	tr.SetAttributes(
+		attribute.String("name", string(r.Name)),
+		attribute.Int64("id", int64(r.ID)),
 	)
 	logger := trace.Logger(ctx, s.Logger).With(
 		log.Int32("id", int32(r.ID)),
@@ -483,10 +483,10 @@ func (s *store) UpdateRepo(ctx context.Context, r *types.Repo) (saved *types.Rep
 
 func (s *store) UpdateExternalServiceRepo(ctx context.Context, svc *types.ExternalService, r *types.Repo) (err error) {
 	tr, ctx := s.trace(ctx, "Store.UpdateExternalServiceRepo")
-	tr.LogFields(
-		otlog.String("name", string(r.Name)),
-		otlog.Int64("external_service_id", svc.ID),
-		otlog.String("external_repo_spec", r.ExternalRepo.String()),
+	tr.SetAttributes(
+		attribute.String("name", string(r.Name)),
+		attribute.Int64("external_service_id", svc.ID),
+		attribute.String("external_repo_spec", r.ExternalRepo.String()),
 	)
 	logger := trace.Logger(ctx, s.Logger).With(
 		log.Int("externalServiceID", int(svc.ID)),

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -74,7 +74,7 @@ func (c *Client) RepoLookup(
 		return MockRepoLookup(args)
 	}
 
-	span, ctx := ot.StartSpanFromContext(ctx, "Client.RepoLookup")
+	span, ctx := ot.StartSpanFromContext(ctx, "Client.RepoLookup") //nolint:staticcheck // OT is deprecated
 	defer func() {
 		if result != nil {
 			span.SetTag("found", result.Repo != nil)
@@ -285,7 +285,7 @@ func (c *Client) httpPost(ctx context.Context, method string, payload any) (resp
 }
 
 func (c *Client) do(ctx context.Context, req *http.Request) (_ *http.Response, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Client.do")
+	span, ctx := ot.StartSpanFromContext(ctx, "Client.do") //nolint:staticcheck // OT is deprecated
 	defer func() {
 		if err != nil {
 			ext.Error.Set(span, true)

--- a/internal/search/backend/fake.go
+++ b/internal/search/backend/fake.go
@@ -53,10 +53,10 @@ func (ss *FakeSearcher) List(ctx context.Context, q zoektquery.Q, opt *zoekt.Lis
 	}
 
 	list := &zoekt.RepoList{}
-	if opt != nil && opt.Minimal {
-		list.Minimal = make(map[uint32]*zoekt.MinimalRepoListEntry, len(ss.Repos))
+	if opt != nil && opt.Minimal { //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
+		list.Minimal = make(map[uint32]*zoekt.MinimalRepoListEntry, len(ss.Repos)) //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 		for _, r := range ss.Repos {
-			list.Minimal[r.Repository.ID] = &zoekt.MinimalRepoListEntry{
+			list.Minimal[r.Repository.ID] = &zoekt.MinimalRepoListEntry{ //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 				HasSymbols: r.Repository.HasSymbols,
 				Branches:   r.Repository.Branches,
 			}

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -11,12 +11,12 @@ import (
 	"sync"
 	"time"
 
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/query"
 	"github.com/sourcegraph/zoekt/stream"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -754,9 +754,9 @@ func isZoektRolloutError(ctx context.Context, err error) bool {
 
 	metricIgnoredError.WithLabelValues(reason).Inc()
 	if span := trace.TraceFromContext(ctx); span != nil {
-		span.LogFields(
-			otlog.String("rollout.reason", reason),
-			otlog.String("rollout.error", err.Error()))
+		span.AddEvent("rollout",
+			attribute.String("rollout.reason", reason),
+			attribute.String("rollout.error", err.Error()))
 	}
 
 	return true

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -581,8 +581,8 @@ func (s *HorizontalSearcher) List(ctx context.Context, q query.Q, opts *zoekt.Li
 		aggregate.Crashes += r.rl.Crashes
 		aggregate.Stats.Add(&r.rl.Stats)
 
-		for k, v := range r.rl.Minimal {
-			aggregate.Minimal[k] = v
+		for k, v := range r.rl.Minimal { //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
+			aggregate.Minimal[k] = v //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 		}
 	}
 

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -113,7 +113,7 @@ func TestHorizontalSearcher(t *testing.T) {
 			t.Fatal(err)
 		}
 		got = []string{}
-		for r := range rle.Minimal {
+		for r := range rle.Minimal { //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 			got = append(got, strconv.Itoa(int(r)))
 		}
 		sort.Strings(got)

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -236,7 +236,7 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q, opts *zoekt.ListO
 	if m.hostname == "" {
 		cat = "ListAll"
 	} else {
-		if opts == nil || !opts.Minimal {
+		if opts == nil || !opts.Minimal { //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 			cat = "List"
 		} else {
 			cat = "ListMinimal"
@@ -258,7 +258,7 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q, opts *zoekt.ListO
 		event = honey.NewEvent("search-zoekt")
 		event.AddField("category", cat)
 		event.AddField("query", qStr)
-		event.AddField("opts.minimal", opts != nil && opts.Minimal)
+		event.AddField("opts.minimal", opts != nil && opts.Minimal) //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 		for _, t := range tags {
 			event.AddField(t.Key, t.Value)
 		}
@@ -274,7 +274,7 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q, opts *zoekt.ListO
 	event.AddField("duration_ms", time.Since(start).Milliseconds())
 	if zsl != nil {
 		event.AddField("repos", len(zsl.Repos))
-		event.AddField("minimal_repos", len(zsl.Minimal))
+		event.AddField("minimal_repos", len(zsl.Minimal)) //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 		event.AddField("stats.crashes", zsl.Crashes)
 	}
 	if err != nil {

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -13,6 +13,7 @@ import (
 	sglog "github.com/sourcegraph/log"
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/query"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
@@ -93,7 +94,7 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 			log.Int("opts.max_doc_display_count", opts.MaxDocDisplayCount),
 			log.Bool("opts.use_document_ranks", opts.UseDocumentRanks),
 		}
-		tr.LogFields(fields...)
+		tr.LogFields(fields...) //nolint:staticcheck // TODO when upgrading the observation package
 		event.AddLogFields(fields)
 	}
 
@@ -101,7 +102,7 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 	// out the marshalled size of the query.
 	if gobCache, ok := q.(*query.GobCache); ok {
 		b, _ := gobCache.GobEncode()
-		tr.LogFields(log.Int("query.size", len(b)))
+		tr.SetAttributes(attribute.Int("query.size", len(b)))
 		event.AddField("query.size", len(b))
 	}
 
@@ -124,7 +125,7 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 	if isLeaf {
 		ctx = rpc.WithClientTrace(ctx, &rpc.ClientTrace{
 			WriteRequestStart: func() {
-				tr.LogFields(log.String("event", "rpc.write_request_start"))
+				tr.SetAttributes(attribute.String("event", "rpc.write_request_start"))
 				writeRequestStart = time.Now()
 			},
 
@@ -133,7 +134,7 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 				if err != nil {
 					fields = append(fields, log.String("rpc.write_request.error", err.Error()))
 				}
-				tr.LogFields(fields...)
+				tr.LogFields(fields...) //nolint:staticcheck // TODO when updating the observation package
 				writeRequestDone = time.Now()
 			},
 		})
@@ -154,13 +155,13 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 		first.Do(func() {
 			if isLeaf {
 				if !writeRequestStart.IsZero() {
-					tr.LogFields(
-						log.Int64("rpc.queue_latency_ms", writeRequestStart.Sub(start).Milliseconds()),
-						log.Int64("rpc.write_duration_ms", writeRequestDone.Sub(writeRequestStart).Milliseconds()),
+					tr.SetAttributes(
+						attribute.Int64("rpc.queue_latency_ms", writeRequestStart.Sub(start).Milliseconds()),
+						attribute.Int64("rpc.write_duration_ms", writeRequestDone.Sub(writeRequestStart).Milliseconds()),
 					)
 				}
-				tr.LogFields(
-					log.Int64("stream.latency_ms", time.Since(start).Milliseconds()),
+				tr.SetAttributes(
+					attribute.Int64("stream.latency_ms", time.Since(start).Milliseconds()),
 				)
 			}
 		})
@@ -209,7 +210,7 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 		log.Int("stats.regexps_considered", statsAgg.RegexpsConsidered),
 		log.String("stats.flush_reason", statsAgg.FlushReason.String()),
 	}
-	tr.LogFields(fields...)
+	tr.LogFields(fields...) //nolint:staticcheck // TODO when updating the observation package
 	event.AddField("duration_ms", time.Since(start).Milliseconds())
 	if err != nil {
 		event.AddField("error", err.Error())
@@ -251,7 +252,7 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q, opts *zoekt.ListO
 	qStr := queryString(q)
 
 	tr, ctx := trace.New(ctx, "zoekt."+cat, qStr, tags...)
-	tr.LogFields(trace.Stringer("opts", opts))
+	tr.LogFields(trace.Stringer("opts", opts)) //nolint:staticcheck // TODO deal with stringer thing
 
 	event := honey.NoopEvent()
 	if honey.Enabled() && cat == "ListAll" {
@@ -286,7 +287,7 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q, opts *zoekt.ListO
 
 	tr.SetError(err)
 	if zsl != nil {
-		tr.LogFields(log.Int("repos", len(zsl.Repos)))
+		tr.SetAttributes(attribute.Int("repos", len(zsl.Repos)))
 	}
 	tr.Finish()
 

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -110,7 +110,7 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 		spanContext := make(map[string]string)
 		if span := opentracing.SpanFromContext(ctx); span == nil {
 			m.log.Warn("ctx does not have a trace span associated with it")
-		} else if err := ot.GetTracer(ctx).Inject(span.Context(), opentracing.TextMap, opentracing.TextMapCarrier(spanContext)); err == nil {
+		} else if err := ot.GetTracer(ctx).Inject(span.Context(), opentracing.TextMap, opentracing.TextMapCarrier(spanContext)); err == nil { //nolint:staticcheck // Drop once we get rid of OpenTracing
 			newOpts := *opts
 			newOpts.SpanContext = spanContext
 			opts = &newOpts

--- a/internal/search/casetransform/lower_regexp.go
+++ b/internal/search/casetransform/lower_regexp.go
@@ -1,7 +1,7 @@
 package casetransform
 
 import (
-	"regexp/syntax" // nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
+	"regexp/syntax" //nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
 	"unicode"
 	"unicode/utf8"
 )

--- a/internal/search/casetransform/lower_regexp_test.go
+++ b/internal/search/casetransform/lower_regexp_test.go
@@ -3,7 +3,7 @@ package casetransform
 import (
 	"testing"
 
-	"regexp/syntax" // nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
+	"regexp/syntax" //nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
 )
 
 func TestLowerRegexpASCII(t *testing.T) {

--- a/internal/search/casetransform/regexp.go
+++ b/internal/search/casetransform/regexp.go
@@ -1,7 +1,7 @@
 package casetransform
 
 import (
-	"regexp/syntax" // nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
+	"regexp/syntax" //nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
 
 	"github.com/grafana/regexp"
 	"github.com/sourcegraph/zoekt/query"

--- a/internal/search/env.go
+++ b/internal/search/env.go
@@ -95,7 +95,7 @@ func reposAtEndpoint(dial func(string) zoekt.Streamer) func(context.Context, str
 			return map[uint32]*zoekt.MinimalRepoListEntry{}
 		}
 
-		return resp.Minimal
+		return resp.Minimal //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 	}
 }
 

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"regexp/syntax" // nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
+	"regexp/syntax" //nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
 	"sort"
 	"testing"
 	"time"

--- a/internal/search/job/jobutil/repos.go
+++ b/internal/search/job/jobutil/repos.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/regexp"
 	"github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -30,7 +31,7 @@ func (s *RepoSearchJob) Run(ctx context.Context, clients job.RuntimeClients, str
 
 	repos := searchrepos.NewResolver(clients.Logger, clients.DB, clients.Gitserver, clients.SearcherURLs, clients.Zoekt)
 	err = repos.Paginate(ctx, s.RepoOpts, func(page *searchrepos.Resolved) error {
-		tr.LogFields(log.Int("resolved.len", len(page.RepoRevs)))
+		tr.SetAttributes(attribute.Int("resolved.len", len(page.RepoRevs)))
 
 		page.MaybeSendStats(stream)
 

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/grafana/regexp"
 	regexpsyntax "github.com/grafana/regexp/syntax"
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/zoekt"
 	zoektquery "github.com/sourcegraph/zoekt/query"
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -543,7 +543,7 @@ func (r *Resolver) filterRepoHasFileContent(
 	err error,
 ) {
 	tr, ctx := trace.New(ctx, "Resolve.FilterHasFileContent", "")
-	tr.LogFields(otlog.Int("inputRevCount", len(repoRevs)))
+	tr.SetAttributes(attribute.Int("inputRevCount", len(repoRevs)))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -705,10 +705,9 @@ func (r *Resolver) filterRepoHasFileContent(
 		}
 	}
 
-	tr.LogFields(
-		otlog.Int("filteredRevCount", len(matchedRepoRevs)),
-		otlog.Int("backendsMissing", backendsMissing),
-	)
+	tr.SetAttributes(
+		attribute.Int("filteredRevCount", len(matchedRepoRevs)),
+		attribute.Int("backendsMissing", backendsMissing))
 	return matchedRepoRevs, missing, backendsMissing, nil
 }
 

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -635,7 +635,7 @@ func (r *Resolver) filterRepoHasFileContent(
 				addBackendsMissing(repos.Crashes)
 
 				foundRevs := Set[repoAndRev]{}
-				for repoID, repo := range repos.Minimal {
+				for repoID, repo := range repos.Minimal { //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 					inputRevs := indexed.RepoRevs[api.RepoID(repoID)].Revs
 					for _, branch := range repo.Branches {
 						for _, inputRev := range inputRevs {

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -133,7 +133,7 @@ func textSearchStream(ctx context.Context, url string, body []byte, cb func([]*p
 	}
 	req = req.WithContext(ctx)
 
-	req, ht := nethttp.TraceRequest(ot.GetTracer(ctx), req,
+	req, ht := nethttp.TraceRequest(ot.GetTracer(ctx), req, //nolint:staticcheck // Drop once we get rid of OpenTracing
 		nethttp.OperationName("Searcher Client"),
 		nethttp.ClientTrace(false))
 	defer ht.Finish()

--- a/internal/search/searcher/symbol_search_job.go
+++ b/internal/search/searcher/symbol_search_job.go
@@ -97,7 +97,7 @@ func (s *SymbolSearchJob) Children() []job.Describer       { return nil }
 func (s *SymbolSearchJob) MapChildren(job.MapFunc) job.Job { return s }
 
 func searchInRepo(ctx context.Context, db database.DB, repoRevs *search.RepositoryRevisions, patternInfo *search.TextPatternInfo, limit int) (res []result.Match, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "Search symbols in repo")
+	span, ctx := ot.StartSpanFromContext(ctx, "Search symbols in repo") //nolint:staticcheck // OT is deprecated
 	defer func() {
 		if err != nil {
 			ext.Error.Set(span, true)

--- a/internal/search/searcher/symbol_search_job.go
+++ b/internal/search/searcher/symbol_search_job.go
@@ -7,6 +7,7 @@ import (
 	"github.com/neelance/parallel"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -61,7 +62,7 @@ func (s *SymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClients, s
 				},
 			})
 			if err != nil {
-				tr.LogFields(log.String("repo", string(repoRevs.Repo.Name)), log.Error(err))
+				tr.SetAttributes(attribute.String("repo", string(repoRevs.Repo.Name)), attribute.String("error", err.Error()))
 				// Only record error if we haven't timed out.
 				if ctx.Err() == nil {
 					cancel()

--- a/internal/search/smartsearch/rules.go
+++ b/internal/search/smartsearch/rules.go
@@ -3,7 +3,7 @@ package smartsearch
 import (
 	"fmt"
 	"net/url"
-	"regexp/syntax" // nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
+	"regexp/syntax" //nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
 	"strings"
 
 	"github.com/go-enry/go-enry/v2"

--- a/internal/search/symbol/symbol.go
+++ b/internal/search/symbol/symbol.go
@@ -37,7 +37,7 @@ func indexedSymbolsBranch(ctx context.Context, repo *types.MinimalRepo, commit s
 		return ""
 	}
 
-	r, ok := list.Minimal[uint32(repo.ID)]
+	r, ok := list.Minimal[uint32(repo.ID)] //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 	if !ok || !r.HasSymbols {
 		return ""
 	}

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -228,7 +228,7 @@ func PartitionRepos(
 	tr.LogFields(otlog.Int("all_indexed_set.size", len(list.Minimal)))
 
 	// Split based on indexed vs unindexed
-	indexed, unindexed = zoektIndexedRepos(list.Minimal, repos, filter)
+	indexed, unindexed = zoektIndexedRepos(list.Minimal, repos, filter) //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 
 	tr.LogFields(
 		otlog.Int("indexed.size", len(indexed.RepoRevs)),

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/zoekt"
 	zoektquery "github.com/sourcegraph/zoekt/query"
+	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/atomic"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -225,15 +226,14 @@ func PartitionRepos(
 	// Note: We do not need to handle list.Crashes since we will fallback to
 	// unindexed search for any repository unavailable due to rollout.
 
-	tr.LogFields(otlog.Int("all_indexed_set.size", len(list.Minimal)))
+	tr.SetAttributes(attribute.Int("all_indexed_set.size", len(list.Minimal)))
 
 	// Split based on indexed vs unindexed
 	indexed, unindexed = zoektIndexedRepos(list.Minimal, repos, filter) //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 
-	tr.LogFields(
-		otlog.Int("indexed.size", len(indexed.RepoRevs)),
-		otlog.Int("unindexed.size", len(unindexed)),
-	)
+	tr.SetAttributes(
+		attribute.Int("indexed.size", len(indexed.RepoRevs)),
+		attribute.Int("unindexed.size", len(unindexed)))
 
 	// Disable unindexed search
 	if useIndex == query.Only {
@@ -759,7 +759,7 @@ func privateReposForActor(ctx context.Context, logger log.Logger, db database.DB
 			return nil
 		}
 	}
-	tr.LogFields(otlog.Int32("userID", userID))
+	tr.SetAttributes(attribute.Int64("userID", int64(userID)))
 
 	// TODO: We should use repos.Resolve here. However, the logic for
 	// UserID is different to repos.Resolve, so we need to work out how

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -226,7 +226,7 @@ func PartitionRepos(
 	// Note: We do not need to handle list.Crashes since we will fallback to
 	// unindexed search for any repository unavailable due to rollout.
 
-	tr.SetAttributes(attribute.Int("all_indexed_set.size", len(list.Minimal)))
+	tr.SetAttributes(attribute.Int("all_indexed_set.size", len(list.Minimal))) //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 
 	// Split based on indexed vs unindexed
 	indexed, unindexed = zoektIndexedRepos(list.Minimal, repos, filter) //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -321,7 +321,7 @@ func zoektSearch(ctx context.Context, repos *IndexedRepoRevs, q zoektquery.Q, pa
 
 	foundResults := atomic.Bool{}
 	err := client.StreamSearch(ctx, finalQuery, searchOpts, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
-		foundResults.CAS(false, event.FileCount != 0 || event.MatchCount != 0)
+		foundResults.CompareAndSwap(false, event.FileCount != 0 || event.MatchCount != 0)
 		sendMatches(event, pathRegexps, repos.getRepoInputRev, typ, selector, c)
 	}))
 	if err != nil {

--- a/internal/search/zoekt/query.go
+++ b/internal/search/zoekt/query.go
@@ -1,7 +1,7 @@
 package zoekt
 
 import (
-	"regexp/syntax" // nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
+	"regexp/syntax" //nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
 
 	"github.com/go-enry/go-enry/v2"
 	"github.com/grafana/regexp"

--- a/internal/search/zoekt/symbol_search.go
+++ b/internal/search/zoekt/symbol_search.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/opentracing/opentracing-go/log"
 	zoektquery "github.com/sourcegraph/zoekt/query"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
@@ -45,7 +46,7 @@ func (z *SymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClients, s
 
 	err = zoektSearch(ctx, z.Repos, z.Query, nil, search.SymbolRequest, clients.Zoekt, z.FileMatchLimit, z.Select, z.Features, since, stream)
 	if err != nil {
-		tr.LogFields(log.Error(err))
+		tr.SetAttributes(attribute.String("error", err.Error()))
 		// Only record error if we haven't timed out.
 		if ctx.Err() == nil {
 			cancel()
@@ -102,7 +103,7 @@ func (s *GlobalSymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClie
 	// always search for symbols in indexed repositories when searching the repo universe.
 	err = DoZoektSearchGlobal(ctx, clients.Zoekt, s.ZoektArgs, nil, stream)
 	if err != nil {
-		tr.LogFields(log.Error(err))
+		tr.SetAttributes(attribute.String("error", err.Error()))
 		// Only record error if we haven't timed out.
 		if ctx.Err() == nil {
 			return nil, err

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -62,7 +62,7 @@ func getSpanContext(ctx context.Context) (shouldTrace bool, spanContext map[stri
 
 	spanContext = make(map[string]string)
 	if span := opentracing.SpanFromContext(ctx); span != nil {
-		if err := ot.GetTracer(ctx).Inject(span.Context(), opentracing.TextMap, opentracing.TextMapCarrier(spanContext)); err != nil {
+		if err := ot.GetTracer(ctx).Inject(span.Context(), opentracing.TextMap, opentracing.TextMapCarrier(spanContext)); err != nil { //nolint:staticcheck // Drop once we get rid of OpenTracing
 			log15.Warn("Error injecting span context into map: %s", err)
 			return true, nil
 		}

--- a/internal/symbols/client.go
+++ b/internal/symbols/client.go
@@ -131,7 +131,7 @@ func (c *Client) ListLanguageMappings(ctx context.Context, repo api.RepoName) (_
 
 // Search performs a symbol search on the symbols service.
 func (c *Client) Search(ctx context.Context, args search.SymbolsParameters) (symbols result.Symbols, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "symbols.Client.Search")
+	span, ctx := ot.StartSpanFromContext(ctx, "symbols.Client.Search") //nolint:staticcheck // OT is deprecated
 	defer func() {
 		if err != nil {
 			ext.Error.Set(span, true)
@@ -200,7 +200,7 @@ func (c *Client) Search(ctx context.Context, args search.SymbolsParameters) (sym
 }
 
 func (c *Client) LocalCodeIntel(ctx context.Context, args types.RepoCommitPath) (result *types.LocalCodeIntelPayload, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "squirrel.Client.LocalCodeIntel")
+	span, ctx := ot.StartSpanFromContext(ctx, "squirrel.Client.LocalCodeIntel") //nolint:staticcheck // OT is deprecated
 	defer func() {
 		if err != nil {
 			ext.Error.Set(span, true)
@@ -236,7 +236,7 @@ func (c *Client) LocalCodeIntel(ctx context.Context, args types.RepoCommitPath) 
 }
 
 func (c *Client) SymbolInfo(ctx context.Context, args types.RepoCommitPathPoint) (result *types.SymbolInfo, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "squirrel.Client.SymbolInfo")
+	span, ctx := ot.StartSpanFromContext(ctx, "squirrel.Client.SymbolInfo") //nolint:staticcheck // OT is deprecated
 	defer func() {
 		if err != nil {
 			ext.Error.Set(span, true)
@@ -301,7 +301,7 @@ func (c *Client) httpPost(
 	repo api.RepoName,
 	payload any,
 ) (resp *http.Response, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "symbols.Client.httpPost")
+	span, ctx := ot.StartSpanFromContext(ctx, "symbols.Client.httpPost") //nolint:staticcheck // OT is deprecated
 	defer func() {
 		if err != nil {
 			ext.Error.Set(span, true)

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -115,7 +115,7 @@ func HTTPMiddleware(logger log.Logger, next http.Handler, siteConfig conftypes.S
 		ctx := r.Context()
 
 		// extract propagated span
-		wireContext, err := ot.GetTracer(ctx).Extract(
+		wireContext, err := ot.GetTracer(ctx).Extract( //lint:ignore SA1019 // OT is deprecated
 			opentracing.HTTPHeaders,
 			opentracing.HTTPHeadersCarrier(r.Header))
 		if err != nil && err != opentracing.ErrSpanContextNotFound {
@@ -123,7 +123,7 @@ func HTTPMiddleware(logger log.Logger, next http.Handler, siteConfig conftypes.S
 		}
 
 		// start new span
-		span, ctx := ot.StartSpanFromContext(ctx, "", ext.RPCServerOption(wireContext))
+		span, ctx := ot.StartSpanFromContext(ctx, "", ext.RPCServerOption(wireContext)) //lint:ignore SA1019 // OT is deprecated
 		ext.HTTPUrl.Set(span, r.URL.String())
 		ext.HTTPMethod.Set(span, r.Method)
 		span.SetTag("http.referer", r.Header.Get("referer"))

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -115,7 +115,7 @@ func HTTPMiddleware(logger log.Logger, next http.Handler, siteConfig conftypes.S
 		ctx := r.Context()
 
 		// extract propagated span
-		wireContext, err := ot.GetTracer(ctx).Extract( //nolint:statickcheck // OT is deprecated
+		wireContext, err := ot.GetTracer(ctx).Extract( //nolint:staticcheck // OT is deprecated
 			opentracing.HTTPHeaders,
 			opentracing.HTTPHeadersCarrier(r.Header))
 		if err != nil && err != opentracing.ErrSpanContextNotFound {
@@ -123,7 +123,7 @@ func HTTPMiddleware(logger log.Logger, next http.Handler, siteConfig conftypes.S
 		}
 
 		// start new span
-		span, ctx := ot.StartSpanFromContext(ctx, "", ext.RPCServerOption(wireContext)) //lint:ignore SA1019 // OT is deprecated
+		span, ctx := ot.StartSpanFromContext(ctx, "", ext.RPCServerOption(wireContext)) //nolint:staticcheck // OT is deprecated
 		ext.HTTPUrl.Set(span, r.URL.String())
 		ext.HTTPMethod.Set(span, r.Method)
 		span.SetTag("http.referer", r.Header.Get("referer"))

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -115,7 +115,7 @@ func HTTPMiddleware(logger log.Logger, next http.Handler, siteConfig conftypes.S
 		ctx := r.Context()
 
 		// extract propagated span
-		wireContext, err := ot.GetTracer(ctx).Extract( //lint:ignore SA1019 // OT is deprecated
+		wireContext, err := ot.GetTracer(ctx).Extract( //nolint:statickcheck // OT is deprecated
 			opentracing.HTTPHeaders,
 			opentracing.HTTPHeadersCarrier(r.Header))
 		if err != nil && err != opentracing.ErrSpanContextNotFound {

--- a/internal/uploadhandler/upload_handler.go
+++ b/internal/uploadhandler/upload_handler.go
@@ -95,7 +95,7 @@ func (h *UploadHandler[T]) handleEnqueue(w http.ResponseWriter, r *http.Request)
 			log.Int("index", uploadState.index),
 			log.Bool("done", uploadState.done),
 			log.Object("metadata", uploadState.metadata),
-		)
+		) //nolint:staticcheck // Need to convert this to attribute.* methods, might be not so easy with metadata
 
 		if uploadHandlerFunc := h.selectUploadHandlerFunc(uploadState); uploadHandlerFunc != nil {
 			return uploadHandlerFunc(ctx, uploadState, r.Body)

--- a/internal/uploadhandler/upload_handler.go
+++ b/internal/uploadhandler/upload_handler.go
@@ -86,7 +86,7 @@ func (h *UploadHandler[T]) handleEnqueue(w http.ResponseWriter, r *http.Request)
 		if err != nil {
 			return nil, statusCode, err
 		}
-		trace.Log(
+		trace.Log( //nolint:staticcheck // Need to convert this to attribute.* methods, might be not so easy with metadata
 			log.Int("uploadID", uploadState.uploadID),
 			log.Int("numParts", uploadState.numParts),
 			log.Int("numUploadedParts", len(uploadState.uploadedParts)),
@@ -95,7 +95,7 @@ func (h *UploadHandler[T]) handleEnqueue(w http.ResponseWriter, r *http.Request)
 			log.Int("index", uploadState.index),
 			log.Bool("done", uploadState.done),
 			log.Object("metadata", uploadState.metadata),
-		) //nolint:staticcheck // Need to convert this to attribute.* methods, might be not so easy with metadata
+		)
 
 		if uploadHandlerFunc := h.selectUploadHandlerFunc(uploadState); uploadHandlerFunc != nil {
 			return uploadHandlerFunc(ctx, uploadState, r.Body)

--- a/internal/uploadhandler/upload_handler_single.go
+++ b/internal/uploadhandler/upload_handler_single.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	sglog "github.com/sourcegraph/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/opentracing/opentracing-go/log"
 
@@ -40,13 +41,13 @@ func (h *UploadHandler[T]) handleEnqueueSinglePayload(ctx context.Context, uploa
 	if err != nil {
 		return nil, http.StatusInternalServerError, err
 	}
-	trace.Log(log.Int("uploadID", id))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("uploadID", id))
 
 	size, err := h.uploadStore.Upload(ctx, fmt.Sprintf("upload-%d.lsif.gz", id), body)
 	if err != nil {
 		return nil, http.StatusInternalServerError, err
 	}
-	trace.Log(log.Int("gzippedUploadSize", int(size)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("gzippedUploadSize", int(size)))
 
 	if err := tx.MarkQueued(ctx, id, &size); err != nil {
 		return nil, http.StatusInternalServerError, err

--- a/internal/workerutil/dbworker/store/store.go
+++ b/internal/workerutil/dbworker/store/store.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 	otlog "github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/log"
 
@@ -533,7 +534,7 @@ func (s *store[T]) Dequeue(ctx context.Context, workerHostname string, condition
 	if len(records) == 0 {
 		return ret, false, nil
 	}
-	trace.Log(otlog.Int("recordID", records[0].RecordID()))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("recordID", records[0].RecordID()))
 
 	return records[0], true, nil
 }
@@ -950,7 +951,7 @@ func (s *store[T]) ResetStalled(ctx context.Context) (resetLastHeartbeatsByIDs, 
 	if err != nil {
 		return resetLastHeartbeatsByIDs, failedLastHeartbeatsByIDs, err
 	}
-	trace.Log(otlog.Int("numResetIDs", len(resetLastHeartbeatsByIDs)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numResetIDs", len(resetLastHeartbeatsByIDs)))
 
 	resetFailureMessage := s.options.ResetFailureMessage
 	if resetFailureMessage == "" {
@@ -972,7 +973,7 @@ func (s *store[T]) ResetStalled(ctx context.Context) (resetLastHeartbeatsByIDs, 
 	if err != nil {
 		return resetLastHeartbeatsByIDs, failedLastHeartbeatsByIDs, err
 	}
-	trace.Log(otlog.Int("numErroredIDs", len(failedLastHeartbeatsByIDs)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numErroredIDs", len(failedLastHeartbeatsByIDs)))
 
 	return resetLastHeartbeatsByIDs, failedLastHeartbeatsByIDs, nil
 }

--- a/internal/workerutil/worker.go
+++ b/internal/workerutil/worker.go
@@ -288,7 +288,7 @@ func (w *Worker[T]) dequeueAndHandle() (dequeued bool, err error) {
 	}
 
 	// Create context and span based on the root context
-	workerSpan, workerCtxWithSpan := ot.StartSpanFromContext(
+	workerSpan, workerCtxWithSpan := ot.StartSpanFromContext( //nolint:staticcheck // OT is deprecated
 		// TODO tail-based sampling once its a thing, until then, we can configure on a per-job basis
 		policy.WithShouldTrace(w.rootCtx, w.options.Metrics.traceSampler(record)),
 		w.options.Name,

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -9,6 +9,8 @@ import (
 	"github.com/grafana-tools/sdk"
 	"github.com/grafana/regexp"
 	"github.com/prometheus/prometheus/model/labels"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring/internal/grafana"
@@ -55,8 +57,10 @@ func (c *Dashboard) validate() error {
 	if !isValidGrafanaUID(c.Name) {
 		return errors.Errorf("Name must be lowercase alphanumeric + dashes; found \"%s\"", c.Name)
 	}
-	if c.Title != strings.Title(c.Title) {
-		return errors.Errorf("Title must be in Title Case; found \"%s\" want \"%s\"", c.Title, strings.Title(c.Title))
+
+	titler := cases.Title(language.English)
+	if c.Title != titler.String(c.Title) {
+		return errors.Errorf("Title must be in Title Case; found \"%s\" want \"%s\"", c.Title, titler.String(c.Title))
 	}
 	if c.Description != withPeriod(c.Description) || c.Description != upperFirst(c.Description) {
 		return errors.Errorf("Description must be sentence starting with an uppercase letter and ending with period; found \"%s\"", c.Description)

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -9,8 +9,6 @@ import (
 	"github.com/grafana-tools/sdk"
 	"github.com/grafana/regexp"
 	"github.com/prometheus/prometheus/model/labels"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring/internal/grafana"
@@ -58,9 +56,8 @@ func (c *Dashboard) validate() error {
 		return errors.Errorf("Name must be lowercase alphanumeric + dashes; found \"%s\"", c.Name)
 	}
 
-	titler := cases.Title(language.English)
-	if c.Title != titler.String(c.Title) {
-		return errors.Errorf("Title must be in Title Case; found \"%s\" want \"%s\"", c.Title, titler.String(c.Title))
+	if c.Title != Title(c.Title) {
+		return errors.Errorf("Title must be in Title Case; found \"%s\" want \"%s\"", c.Title, Title(c.Title))
 	}
 	if c.Description != withPeriod(c.Description) || c.Description != upperFirst(c.Description) {
 		return errors.Errorf("Description must be sentence starting with an uppercase letter and ending with period; found \"%s\"", c.Description)

--- a/monitoring/monitoring/util.go
+++ b/monitoring/monitoring/util.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // upperFirst returns s with an uppercase first rune.
@@ -73,4 +75,26 @@ func toMarkdown(m string, forceList bool) (string, error) {
 	}
 
 	return m, nil
+}
+
+var titleExceptions = map[string]string{
+	"Github": "GitHub",
+	"Gitlab": "GitLab",
+}
+
+// Title format s with a title case, accounting for exceptions for a few brands.
+//
+// We're doing this because strings.Title is deprecated.
+func Title(s string) string {
+	t := cases.Title(language.English).String(s)
+	words := strings.Split(t, " ")
+	res := make([]string, len(words))
+	for i, w := range strings.Split(t, " ") {
+		if exception, ok := titleExceptions[w]; ok {
+			res[i] = exception
+		} else {
+			res[i] = w
+		}
+	}
+	return strings.Join(res, " ")
 }


### PR DESCRIPTION
This PR re-enables:

- `nolintlint` which flags `nolint` comments without a proper explanation 
- `staticcheck SA1019` which flags deprecated code usage. 

While the former is pretty trivial, the latter was quite a pain to deal with as we previously disabled it when updating the observability code. 

For those in particular, while I did update as many I as I could, we still have a few of them that I left untouched + a nolint directive as it wasn't that trivial to fix (and I'm sure that you understand that when I'm going through 300 linter errors, I don't want to spend too much time on each of these). 

For many `tr.LogFields(fields...)` -> `tr.AddEvent("DESC", attrs...)` instead of coming up with a bad description, at the risk of not making it obvious that this should be updated, I went with `"TODO Domain Owner"` as a description of the event, which I hope will trigger code owners to update these as they see fit. 

As for the other few deprecations, they were either trivial, or I created a ticket to track as they're best to be addressed by their respective owners: 

- https://github.com/sourcegraph/sourcegraph/issues/45814
- https://github.com/sourcegraph/sourcegraph/issues/45843

## FAQ 

> How do you want me to review a 140 files PR? 

You can't really do that, it's a very mechanical PR. 

> Why don't we remove the deprecation for OT stuff if we have do add so many `nolint` directives? 

The deprecation warning are guaranteeing that we're not adding any new use of these. We originally deactivated that linter, because we thought we could do it quicker, but it didn't end up that way as the task is pretty big. 

So the current approach is to re-enable `staticcheck`, so we don't miss other deprecations and are sure to not add new stuff. 

Fixes https://github.com/sourcegraph/sourcegraph/issues/34304

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI + main dry run (🟢  https://buildkite.com/sourcegraph/sourcegraph/builds/190135) 