### PR TITLE
perms syncer: improve human-readability of log message info

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -855,8 +855,8 @@ func (s *PermsSyncer) waitForRateLimit(ctx context.Context, urn string, n int, s
 func (s *PermsSyncer) syncPerms(ctx context.Context, syncGroups map[requestType]group.ContextGroup, request *syncRequest) {
 	logger := s.logger.Scoped("syncPerms", "process perms sync request").With(
 		log.Object("request",
-			log.Int("type", int(request.Type)),
-			log.Int32("id", request.ID),
+			log.String("type", request.Type.String()),
+			log.Int32(request.IDFieldName(), request.ID),
 		))
 
 	defer s.queue.remove(request.Type, request.ID, true)

--- a/enterprise/cmd/repo-updater/internal/authz/request_queue.go
+++ b/enterprise/cmd/repo-updater/internal/authz/request_queue.go
@@ -57,6 +57,16 @@ type requestMeta struct {
 	NoPerms    bool
 }
 
+func (r requestMeta) IDFieldName() string {
+	switch r.Type {
+	case requestTypeRepo:
+		return "repo_id"
+	case requestTypeUser:
+		return "user_id"
+	}
+	return "id"
+}
+
 // syncRequest is a permissions syncing request with its current status in the queue.
 type syncRequest struct {
 	*requestMeta


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/40313 by making the additional data in the log message more readable.

Commit aa8b47e193b26e25bce143cf9be8b08d7ba868d0 already improved the log messages by adding the `providerStates` to the messages, which gives us the auth provider details. This now makes the type of permission sync request more readable too.

## Test plan

- N/A
