### PR TITLE
Refactor removal of sub-repo permissions

### DIFF
--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -351,13 +351,9 @@ func deleteStalePerforceExternalAccounts(ctx context.Context, db database.DB, us
 
 	// Since we deleted an external account for the user we can no longer trust user
 	// based permissions, so we clear them out.
+	// This also removes the user's sub-repo permissions.
 	if err := db.Authz().RevokeUserPermissions(ctx, &database.RevokeUserPermissionsArgs{UserID: userID}); err != nil {
 		return errors.Wrapf(err, "revoking user permissions for user with ID %d", userID)
-	}
-
-	// We also need to delete sub-repo permissions granted to the user.
-	if err := db.SubRepoPerms().DeleteByUser(ctx, userID); err != nil {
-		return errors.Wrapf(err, "removing sub-repo permissions for user with ID %d", userID)
 	}
 
 	return nil

--- a/cmd/frontend/backend/user_emails_test.go
+++ b/cmd/frontend/backend/user_emails_test.go
@@ -504,18 +504,6 @@ func TestRemoveStalePerforceAccount(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Len(t, accounts, 0)
-
-		// Confirm that sub-repo permissions are gone
-		perms, err := db.SubRepoPerms().Get(ctx, createdUser.ID, createdRepo.ID)
-		require.NoError(t, err)
-		assert.Empty(t, perms.Paths)
-
-		// Confirm that user permissions were revoked
-		authedRepos, err := db.Authz().AuthorizedRepos(ctx, &database.AuthorizedReposArgs{
-			UserID: createdUser.ID,
-		})
-		require.NoError(t, err)
-		assert.Empty(t, authedRepos)
 	}
 
 	t.Run("OnDelete", func(t *testing.T) {

--- a/enterprise/internal/database/authz.go
+++ b/enterprise/internal/database/authz.go
@@ -17,21 +17,24 @@ import (
 // NewAuthzStore returns an OSS database.AuthzStore set with enterprise implementation.
 func NewAuthzStore(logger log.Logger, db database.DB, clock func() time.Time) database.AuthzStore {
 	return &authzStore{
-		logger: logger,
-		store:  Perms(logger, db, clock),
+		logger:   logger,
+		store:    Perms(logger, db, clock),
+		srpStore: database.SubRepoPermsWith(basestore.NewWithHandle(db.Handle())),
 	}
 }
 
 func NewAuthzStoreWith(logger log.Logger, other basestore.ShareableStore, clock func() time.Time) database.AuthzStore {
 	return &authzStore{
-		logger: logger,
-		store:  PermsWith(logger, other, clock),
+		logger:   logger,
+		store:    PermsWith(logger, other, clock),
+		srpStore: database.SubRepoPermsWith(other),
 	}
 }
 
 type authzStore struct {
-	logger log.Logger
-	store  PermsStore
+	logger   log.Logger
+	store    PermsStore
+	srpStore database.SubRepoPermsStore
 }
 
 // GrantPendingPermissions grants pending permissions for a user, which implements the database.AuthzStore interface.
@@ -176,6 +179,10 @@ func (s *authzStore) RevokeUserPermissionsList(ctx context.Context, argsList []*
 			if err := txs.DeleteAllUserPendingPermissions(ctx, accounts); err != nil {
 				return errors.Wrap(err, "delete all user pending permissions")
 			}
+		}
+
+		if err = s.srpStore.DeleteByUser(ctx, args.UserID); err != nil {
+			return errors.Wrap(err, "delete all user sub-repo permissions")
 		}
 	}
 	return nil

--- a/enterprise/internal/database/authz_test.go
+++ b/enterprise/internal/database/authz_test.go
@@ -339,7 +339,7 @@ func TestAuthzStore_RevokeUserPermissions(t *testing.T) {
 	if err := s.store.SetRepoPermissions(ctx, &authz.RepoPermissions{
 		RepoID:  int32(repo.ID),
 		Perm:    authz.Read,
-		UserIDs: toMapset(1),
+		UserIDs: toMapset(user.ID),
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -364,7 +364,7 @@ func TestAuthzStore_RevokeUserPermissions(t *testing.T) {
 
 	// Revoke all of them
 	if err := s.RevokeUserPermissions(ctx, &database.RevokeUserPermissionsArgs{
-		UserID:   1,
+		UserID:   user.ID,
 		Accounts: []*extsvc.Accounts{accounts},
 	}); err != nil {
 		t.Fatal(err)
@@ -372,7 +372,7 @@ func TestAuthzStore_RevokeUserPermissions(t *testing.T) {
 
 	// The user should not have any permissions now
 	err = s.store.LoadUserPermissions(ctx, &authz.UserPermissions{
-		UserID: 1,
+		UserID: user.ID,
 		Perm:   authz.Read,
 		Type:   authz.PermRepos,
 	})
@@ -380,7 +380,7 @@ func TestAuthzStore_RevokeUserPermissions(t *testing.T) {
 		t.Fatalf("err: want %q but got %v", authz.ErrPermsNotFound, err)
 	}
 
-	srpMap, err := db.SubRepoPerms().GetByUser(ctx, 1)
+	srpMap, err := db.SubRepoPerms().GetByUser(ctx, user.ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/database/authz_test.go
+++ b/enterprise/internal/database/authz_test.go
@@ -320,14 +320,24 @@ func TestAuthzStore_AuthorizedRepos(t *testing.T) {
 
 func TestAuthzStore_RevokeUserPermissions(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewEnterpriseDB(database.NewDB(logger, dbtest.NewDB(logger, t)))
 	ctx := context.Background()
 
 	s := NewAuthzStore(logger, db, clock).(*authzStore)
 
+	user, err := db.Users().Create(ctx, database.NewUser{Username: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := &types.Repo{ID: 1, Name: "github.com/sourcegraph/sourcegraph"}
+	if err := db.Repos().Create(ctx, repo); err != nil {
+		t.Fatal(err)
+	}
+
 	// Set both effective and pending permissions for a user
 	if err := s.store.SetRepoPermissions(ctx, &authz.RepoPermissions{
-		RepoID:  1,
+		RepoID:  int32(repo.ID),
 		Perm:    authz.Read,
 		UserIDs: toMapset(1),
 	}); err != nil {
@@ -340,9 +350,15 @@ func TestAuthzStore_RevokeUserPermissions(t *testing.T) {
 		AccountIDs:  []string{"alice", "alice@example.com"},
 	}
 	if err := s.store.SetRepoPendingPermissions(ctx, accounts, &authz.RepoPermissions{
-		RepoID: 1,
+		RepoID: int32(repo.ID),
 		Perm:   authz.Read,
 	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.SubRepoPerms().Upsert(
+		ctx, user.ID, repo.ID, authz.SubRepoPermissions{Paths: []string{"**"}},
+	); err != nil {
 		t.Fatal(err)
 	}
 
@@ -355,13 +371,22 @@ func TestAuthzStore_RevokeUserPermissions(t *testing.T) {
 	}
 
 	// The user should not have any permissions now
-	err := s.store.LoadUserPermissions(ctx, &authz.UserPermissions{
+	err = s.store.LoadUserPermissions(ctx, &authz.UserPermissions{
 		UserID: 1,
 		Perm:   authz.Read,
 		Type:   authz.PermRepos,
 	})
 	if err != authz.ErrPermsNotFound {
 		t.Fatalf("err: want %q but got %v", authz.ErrPermsNotFound, err)
+	}
+
+	srpMap, err := db.SubRepoPerms().GetByUser(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if numPerms := len(srpMap); numPerms != 0 {
+		t.Fatalf("expected no sub-repo perms, got %d", numPerms)
 	}
 
 	for _, bindID := range accounts.AccountIDs {


### PR DESCRIPTION
When removing user permissions using `db.Authz`, sub-repo permissions are removed as well.

It makes logical sense that this would happen, but it also removes the hard coupling between `db.SubRepoPerms` and the `UserEmails` service, allowing us to move all sub-repo perms code to `enterprise`.

## Test plan
Tests adjusted.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
