### PR TITLE
site-admin: allow filtering repositories by code host

### DIFF
--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -157,6 +157,17 @@ export const EXTERNAL_SERVICES = gql`
     ${listExternalServiceFragment}
 `
 
+export const EXTERNAL_SERVICE_IDS_AND_NAMES = gql`
+    query ExternalServiceIDsAndNames {
+        externalServices {
+            nodes {
+                id
+                displayName
+            }
+        }
+    }
+`
+
 export function queryExternalServices(
     variables: ExternalServicesVariables
 ): Observable<ExternalServicesResult['externalServices']> {

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -23,6 +23,7 @@ import {
     ErrorAlert,
 } from '@sourcegraph/wildcard'
 
+import { EXTERNAL_SERVICES } from '../components/externalServices/backend'
 import {
     FilteredConnection,
     FilteredConnectionFilter,
@@ -33,6 +34,8 @@ import {
     RepositoriesResult,
     RepositoryOrderBy,
     RepositoryStatsResult,
+    ExternalServicesResult,
+    ExternalServicesVariables,
     RepositoryStatsVariables,
     SiteAdminRepositoryFields,
 } from '../graphql-operations'
@@ -276,6 +279,49 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
         ]
     }, [data])
 
+    const {
+        loading: extSvcLoading,
+        data: extSvcs,
+        error: extSvcError,
+    } = useQuery<ExternalServicesResult, ExternalServicesVariables>(EXTERNAL_SERVICES, {
+        variables: {
+            first: null,
+            after: null,
+        },
+    })
+
+    const filters = useMemo(() => {
+        if (!extSvcs) {
+            return FILTERS
+        }
+
+        const values = [
+            {
+                label: 'All',
+                value: 'all',
+                tooltip: 'Show all repositories',
+                args: {},
+            },
+        ]
+        for (const extSvc of extSvcs.externalServices.nodes) {
+            values.push({
+                label: extSvc.displayName,
+                value: extSvc.id,
+                tooltip: `Show all repositories discovered on ${extSvc.displayName}`,
+                args: { externalService: extSvc.id },
+            })
+        }
+
+        const filtersWithExternalServices = FILTERS
+        filtersWithExternalServices.push({
+            id: 'codeHost',
+            label: 'Code Host',
+            type: 'select',
+            values: values,
+        })
+        return filtersWithExternalServices
+    }, [extSvcs])
+
     const queryRepositories = useCallback(
         (args: FilteredConnectionQueryArguments): Observable<RepositoriesResult['repositories']> =>
             fetchAllRepositoriesAndPollIfEmptyOrAnyCloning(args),
@@ -284,6 +330,9 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
     const showRepositoriesAddedBanner = new URLSearchParams(location.search).has('repositoriesUpdated')
 
     const licenseInfo = window.context.licenseInfo
+
+    const combinedError = error || extSvcError
+    const combinedLoading = loading || extSvcLoading
 
     return (
         <div className="site-admin-repositories-page">
@@ -327,8 +376,8 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
             )}
 
             <Container className="mb-3">
-                {error && !loading && <ErrorAlert error={error} />}
-                {loading && !error && <LoadingSpinner />}
+                {combinedError && !combinedLoading && <ErrorAlert error={combinedError} />}
+                {combinedLoading && !combinedError && <LoadingSpinner />}
                 {legends && <ValueLegendList className="mb-3" items={legends} />}
                 <FilteredConnection<SiteAdminRepositoryFields, Omit<RepositoryNodeProps, 'node'>>
                     className="mb-0"
@@ -339,8 +388,8 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
                     pluralNoun="repositories"
                     queryConnection={queryRepositories}
                     nodeComponent={RepositoryNode}
-                    inputClassName="flex-1"
-                    filters={FILTERS}
+                    inputClassName="ml-2 flex-1"
+                    filters={filters}
                     history={history}
                     location={location}
                 />

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -233,6 +233,7 @@ function fetchAllRepositories(args: Partial<RepositoriesVariables>): Observable<
                 $cloneStatus: CloneStatus
                 $orderBy: RepositoryOrderBy
                 $descending: Boolean
+                $externalService: ID
             ) {
                 repositories(
                     first: $first
@@ -243,6 +244,7 @@ function fetchAllRepositories(args: Partial<RepositoriesVariables>): Observable<
                     cloneStatus: $cloneStatus
                     orderBy: $orderBy
                     descending: $descending
+                    externalService: $externalService
                 ) {
                     nodes {
                         ...SiteAdminRepositoryFields
@@ -265,6 +267,7 @@ function fetchAllRepositories(args: Partial<RepositoriesVariables>): Observable<
             cloneStatus: args.cloneStatus ?? null,
             orderBy: args.orderBy ?? RepositoryOrderBy.REPOSITORY_NAME,
             descending: args.descending ?? false,
+            externalService: args.externalService ?? null,
         }
     ).pipe(
         map(dataOrThrowErrors),

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -29,6 +30,8 @@ type repositoryArgs struct {
 
 	CloneStatus *string
 	FailedFetch bool
+
+	ExternalService *graphql.ID
 
 	OrderBy    string
 	Descending bool
@@ -96,6 +99,14 @@ func (args *repositoryArgs) toReposListOptions() (database.ReposListOptions, err
 	}
 	if !args.NotIndexed {
 		opt.OnlyIndexed = true
+	}
+
+	if args.ExternalService != nil {
+		extSvcID, err := UnmarshalExternalServiceID(*args.ExternalService)
+		if err != nil {
+			return opt, err
+		}
+		opt.ExternalServiceIDs = append(opt.ExternalServiceIDs, extSvcID)
 	}
 
 	return opt, nil

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1323,6 +1323,10 @@ type Query {
         """
         failedFetch: Boolean = false
         """
+        Return repositories that are associated with the given external service.
+        """
+        externalService: ID
+        """
         Sort field.
         """
         orderBy: RepositoryOrderBy = REPOSITORY_NAME


### PR DESCRIPTION
Wanted to use the 45min until next meeting :)

This adds a new filter to the repositories page that lets users filter repositories by code host. That helps large customers a lot.

![screenshot_2022-12-20_14 43 39](https://user-images.githubusercontent.com/1185253/208681153-f70c0f31-99fe-4274-8a89-c0ab031b9283.gif)


## Test plan

- Manual testing