### PR TITLE
webhooks: Handle GitLab push events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added a button "Reindex now" to the index status page. Admins can now force an immediate reindex of a repository. [#45533](https://github.com/sourcegraph/sourcegraph/pull/45533)
 - Added an option "Unlock user" to the actions dropdown on the Site Admin Users page. Admins can unlock user accounts that wer locked after too many sign-in attempts. [#45650](https://github.com/sourcegraph/sourcegraph/pull/45650)
 - Templates for certain emails sent by Sourcegraph are now configurable via `email.templates` in site configuration. [#45671](https://github.com/sourcegraph/sourcegraph/pull/45671)
+- Added support for receiving GitLab webhook `push` events. [#45856](https://github.com/sourcegraph/sourcegraph/pull/45856)
 
 ### Changed
 

--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -27,7 +27,10 @@ type Services struct {
 	BatchesChangesFileExistsHandler http.Handler
 	BatchesChangesFileUploadHandler http.Handler
 
-	GitHubSyncWebhook           webhooks.Registerer
+	// Handle `push` events
+	GitHubSyncWebhook webhooks.Registerer
+	GitLabSyncWebhook webhooks.Registerer
+
 	PermissionsGitHubWebhook    webhooks.Registerer
 	NewCodeIntelUploadHandler   NewCodeIntelUploadHandler
 	RankingService              RankingService
@@ -75,6 +78,7 @@ type NewComputeStreamHandler func() http.Handler
 func DefaultServices() Services {
 	return Services{
 		GitHubSyncWebhook:               &emptyWebhookHandler{name: "github sync webhook"},
+		GitLabSyncWebhook:               &emptyWebhookHandler{name: "gitlab sync webhook"},
 		PermissionsGitHubWebhook:        &emptyWebhookHandler{name: "permissions github webhook"},
 		BatchesGitHubWebhook:            &emptyWebhookHandler{name: "batches github webhook"},
 		BatchesGitLabWebhook:            &emptyWebhookHandler{name: "batches gitlab webhook"},

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -301,6 +301,7 @@ func makeExternalAPI(db database.DB, logger sglog.Logger, schema *graphql.Schema
 		rateLimiter,
 		&httpapi.Handlers{
 			GitHubSyncWebhook:               enterprise.GitHubSyncWebhook,
+			GitLabSyncWebhook:               enterprise.GitLabSyncWebhook,
 			PermissionsGitHubWebhook:        enterprise.PermissionsGitHubWebhook,
 			BatchesGitHubWebhook:            enterprise.BatchesGitHubWebhook,
 			BatchesGitLabWebhook:            enterprise.BatchesGitLabWebhook,

--- a/cmd/frontend/internal/httpapi/api_test.go
+++ b/cmd/frontend/internal/httpapi/api_test.go
@@ -36,6 +36,7 @@ func newTest(t *testing.T) *httptestutil.Client {
 			BatchesGitHubWebhook:          enterpriseServices.BatchesGitHubWebhook,
 			BatchesGitLabWebhook:          enterpriseServices.BatchesGitLabWebhook,
 			GitHubSyncWebhook:             enterpriseServices.GitHubSyncWebhook,
+			GitLabSyncWebhook:             enterpriseServices.GitLabSyncWebhook,
 			BatchesBitbucketServerWebhook: enterpriseServices.BatchesBitbucketServerWebhook,
 			BatchesBitbucketCloudWebhook:  enterpriseServices.BatchesBitbucketCloudWebhook,
 			NewCodeIntelUploadHandler:     enterpriseServices.NewCodeIntelUploadHandler,

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -40,6 +40,7 @@ import (
 
 type Handlers struct {
 	GitHubSyncWebhook               webhooks.Registerer
+	GitLabSyncWebhook               webhooks.Registerer
 	PermissionsGitHubWebhook        webhooks.Registerer
 	BatchesGitHubWebhook            webhooks.Registerer
 	BatchesGitLabWebhook            webhooks.RegistererHandler
@@ -98,6 +99,7 @@ func NewHandler(
 	handlers.BatchesBitbucketServerWebhook.Register(&wh)
 	handlers.BatchesBitbucketCloudWebhook.Register(&wh)
 	handlers.GitHubSyncWebhook.Register(&wh)
+	handlers.GitLabSyncWebhook.Register(&wh)
 	handlers.PermissionsGitHubWebhook.Register(&wh)
 
 	// 🚨 SECURITY: This handler implements its own secret-based auth

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -12,7 +12,7 @@ See the table below for code host compatibility:
 Code host | [Batch changes](../../batch_changes/index.md) | Code push | User permissions
 --------- | :-: | :-: | :-:
 GitHub | 🟢 | 🟢 | 🟢
-GitLab | 🟢 | 🔴 | 🔴
+GitLab | 🟢 | 🟢 | 🔴
 Bitbucket Server / Datacenter | 🟢 | 🔴 | 🔴
 Bitbucket Cloud | 🟢 | 🔴 | 🔴
 
@@ -103,6 +103,10 @@ When one of these events occur, a permissions sync will trigger for the relevant
 Done! Sourcegraph will now receive webhook events from GitLab and use them to sync merge request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.
 
 **NOTE:** We currently do not support [system webhooks](https://docs.gitlab.com/ee/administration/system_hooks.html) as these provide a different set of payloads.
+
+#### Code push
+
+Follow the same steps as above, but ensure you include the `Push events` trigger.
 
 ### Bitbucket server
 

--- a/doc/admin/repo/webhooks.md
+++ b/doc/admin/repo/webhooks.md
@@ -22,7 +22,4 @@ For repositories that Sourcegraph is already aware of, it will periodically perf
 
 ## Code host webhooks
 
-### GitHub
-
-We support the `push` event for GitHub. In order to handle them you need to set up webhooks in GitHub and point it at a incoming webhook configured in Sourcegraph, as described [here](../config/webhooks.md).
-
+We support receiving webhooks directly from your code host for [GitHub](../config/webhooks.md#github) and [GitLab](../config/webhooks.md#gitlab).

--- a/enterprise/cmd/frontend/internal/repos/init.go
+++ b/enterprise/cmd/frontend/internal/repos/init.go
@@ -22,6 +22,7 @@ func Init(
 	enterpriseServices *enterprise.Services,
 ) error {
 	enterpriseServices.GitHubSyncWebhook = webhooks.NewGitHubWebhookHandler()
+	enterpriseServices.GitLabSyncWebhook = webhooks.NewGitLabWebhookHandler()
 	enterpriseServices.WebhooksResolver = resolvers.NewWebhooksResolver(db)
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/repos/webhooks/github_webhook_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/github_webhook_handler.go
@@ -60,7 +60,7 @@ func (g *GitHubWebhookHandler) handle(ctx context.Context, payload any) error {
 
 func githubNameFromEvent(event *gh.PushEvent) (api.RepoName, error) {
 	if event == nil || event.Repo == nil || event.Repo.URL == nil {
-		return "", errors.Newf("URL for repository not found")
+		return "", errors.New("URL for repository not found")
 	}
 	parsed, err := url.Parse(*event.Repo.URL)
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/repos/webhooks/github_webhook_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/github_webhook_handler.go
@@ -48,7 +48,7 @@ func (g *GitHubWebhookHandler) handlePushEvent(ctx context.Context, payload any)
 	if err != nil {
 		// Repo not existing on Sourcegraph is fine
 		if errcode.IsNotFound(err) {
-			g.logger.Warn("GitLab push webhook received for unknown repo", log.String("repo", string(repoName)))
+			g.logger.Warn("GitHub push webhook received for unknown repo", log.String("repo", string(repoName)))
 			return nil
 		}
 		return errors.Wrap(err, "handlePushEvent: EnqueueRepoUpdate failed")

--- a/enterprise/cmd/frontend/internal/repos/webhooks/github_webhook_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/github_webhook_handler.go
@@ -48,6 +48,7 @@ func (g *GitHubWebhookHandler) handle(ctx context.Context, payload any) error {
 	if err != nil {
 		// Repo not existing on Sourcegraph is fine
 		if errcode.IsNotFound(err) {
+			g.logger.Warn("GitLab push webhook received for unknown repo", log.String("repo", string(repoName)))
 			return nil
 		}
 		return errors.Wrap(err, "handle: EnqueueRepoUpdate failed")

--- a/enterprise/cmd/frontend/internal/repos/webhooks/github_webhook_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/github_webhook_handler_test.go
@@ -15,10 +15,13 @@ import (
 	"path/filepath"
 	"testing"
 
+	gh "github.com/google/go-github/v43/github"
 	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -27,6 +30,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -154,4 +158,43 @@ func sign(t *testing.T, message, secret []byte) string {
 	}
 
 	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func Test_githubNameFromEvent(t *testing.T) {
+	tests := []struct {
+		name    string
+		event   *gh.PushEvent
+		want    api.RepoName
+		wantErr error
+	}{
+		{
+			name: "valid event",
+			event: &gh.PushEvent{
+				Repo: &gh.PushEventRepository{
+					URL: stringp("https://github.com/sourcegraph/sourcegraph"),
+				},
+			},
+			want: api.RepoName("github.com/sourcegraph/sourcegraph"),
+		},
+		{
+			name:    "nil event",
+			event:   nil,
+			want:    api.RepoName(""),
+			wantErr: errors.New("URL for repository not found"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := githubNameFromEvent(tt.event)
+			if tt.wantErr != nil {
+				assert.EqualError(t, tt.wantErr, err.Error())
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func stringp(s string) *string {
+	return &s
 }

--- a/enterprise/cmd/frontend/internal/repos/webhooks/github_webhook_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/github_webhook_handler_test.go
@@ -160,7 +160,7 @@ func sign(t *testing.T, message, secret []byte) string {
 	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
 }
 
-func Test_githubNameFromEvent(t *testing.T) {
+func TestGithubNameFromEvent(t *testing.T) {
 	tests := []struct {
 		name    string
 		event   *gh.PushEvent

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler.go
@@ -46,7 +46,7 @@ func (g *GitLabWebhookHandler) handle(ctx context.Context, _ database.DB, _ exts
 		if errcode.IsNotFound(err) {
 			return nil
 		}
-		return errors.Wrap(err, "handleGitHubWebhook: EnqueueRepoUpdate failed")
+		return errors.Wrap(err, "handleGitLabWebhook: EnqueueRepoUpdate failed")
 	}
 
 	g.logger.Info("successfully updated", log.String("name", resp.Name))

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler.go
@@ -58,6 +58,9 @@ func (g *GitLabWebhookHandler) handle(ctx context.Context, payload any) error {
 }
 
 func gitlabNameFromEvent(event *gitlabwebhooks.PushEvent) (api.RepoName, error) {
+	if event == nil {
+		return api.RepoName(""), errors.New("nil PushEvent received")
+	}
 	parsed, err := url.Parse(event.Project.WebURL)
 	if err != nil {
 		return "", errors.Wrap(err, "parsing project URL")

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler.go
@@ -20,7 +20,9 @@ type GitLabWebhookHandler struct {
 }
 
 func (g *GitLabWebhookHandler) Register(router *webhooks.WebhookRouter) {
-	router.Register(g.handle, extsvc.KindGitLab, "push")
+	router.Register(func(ctx context.Context, _ database.DB, _ extsvc.CodeHostBaseURL, payload any) error {
+		return g.handle(ctx, payload)
+	}, extsvc.KindGitLab, "push")
 }
 
 func NewGitLabWebhookHandler() *GitLabWebhookHandler {
@@ -29,7 +31,7 @@ func NewGitLabWebhookHandler() *GitLabWebhookHandler {
 	}
 }
 
-func (g *GitLabWebhookHandler) handle(ctx context.Context, _ database.DB, _ extsvc.CodeHostBaseURL, payload any) error {
+func (g *GitLabWebhookHandler) handle(ctx context.Context, payload any) error {
 	event, ok := payload.(*gitlabwebhooks.PushEvent)
 	if !ok {
 		return errors.Newf("expected GitLab.PushEvent, got %T", payload)

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler.go
@@ -22,7 +22,7 @@ type GitLabWebhookHandler struct {
 
 func (g *GitLabWebhookHandler) Register(router *webhooks.WebhookRouter) {
 	router.Register(func(ctx context.Context, _ database.DB, _ extsvc.CodeHostBaseURL, payload any) error {
-		return g.handle(ctx, payload)
+		return g.handlePushEvent(ctx, payload)
 	}, extsvc.KindGitLab, "push")
 }
 
@@ -32,7 +32,7 @@ func NewGitLabWebhookHandler() *GitLabWebhookHandler {
 	}
 }
 
-func (g *GitLabWebhookHandler) handle(ctx context.Context, payload any) error {
+func (g *GitLabWebhookHandler) handlePushEvent(ctx context.Context, payload any) error {
 	event, ok := payload.(*gitlabwebhooks.PushEvent)
 	if !ok {
 		return errors.Newf("expected GitLab.PushEvent, got %T", payload)

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler.go
@@ -2,6 +2,7 @@ package webhooks
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/sourcegraph/log"
 
@@ -56,10 +57,9 @@ func (g *GitLabWebhookHandler) handle(ctx context.Context, payload any) error {
 }
 
 func gitlabNameFromEvent(event *gitlabwebhooks.PushEvent) (api.RepoName, error) {
-	url := event.Project.WebURL
-	if len(url) <= 8 {
-		return "", errors.Newf("expected URL length > 8, got %v", len(url))
+	parsed, err := url.Parse(event.Project.WebURL)
+	if err != nil {
+		return "", errors.Wrap(err, "parsing project URL")
 	}
-	repoName := url[8:] // [ https:// ] accounts for 8 chars
-	return api.RepoName(repoName), nil
+	return api.RepoName(parsed.Host + parsed.Path), nil
 }

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler.go
@@ -47,6 +47,7 @@ func (g *GitLabWebhookHandler) handle(ctx context.Context, payload any) error {
 	if err != nil {
 		// Repo not existing on Sourcegraph is fine
 		if errcode.IsNotFound(err) {
+			g.logger.Warn("GitLab push webhook received for unknown repo", log.String("repo", string(repoName)))
 			return nil
 		}
 		return errors.Wrap(err, "handleGitLabWebhook: EnqueueRepoUpdate failed")

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	gitlabwebhooks "github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func TestGitLabWebhookHandle(t *testing.T) {
-
 	repoName := "gitlab.com/ryanslade/ryan-test-private"
 	handler := NewGitLabWebhookHandler()
 	data, err := os.ReadFile("testdata/gitlab-push.json")
@@ -41,4 +42,41 @@ func TestGitLabWebhookHandle(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(t, repoName, updateQueued)
+}
+
+func Test_gitlabNameFromEvent(t *testing.T) {
+	tests := []struct {
+		name    string
+		event   *gitlabwebhooks.PushEvent
+		want    api.RepoName
+		wantErr error
+	}{
+		{
+			name: "valid event",
+			event: &gitlabwebhooks.PushEvent{
+				EventCommon: gitlabwebhooks.EventCommon{
+					Project: gitlab.ProjectCommon{
+						WebURL: "https://gitlab.com/sourcegraph/sourcegraph",
+					},
+				},
+			},
+			want: api.RepoName("gitlab.com/sourcegraph/sourcegraph"),
+		},
+		{
+			name:    "nil event",
+			event:   nil,
+			want:    api.RepoName(""),
+			wantErr: errors.New("nil PushEvent received"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := gitlabNameFromEvent(tt.event)
+			if tt.wantErr != nil {
+				assert.EqualError(t, tt.wantErr, err.Error())
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestGitLabWebhookHandle(t *testing.T) {
-	ctx := context.Background()
 
 	repoName := "gitlab.com/ryanslade/ryan-test-private"
 	handler := NewGitLabWebhookHandler()
@@ -38,7 +37,7 @@ func TestGitLabWebhookHandle(t *testing.T) {
 	}
 	t.Cleanup(func() { repoupdater.MockEnqueueRepoUpdate = nil })
 
-	if err := handler.handle(ctx, &payload); err != nil {
+	if err := handler.handle(context.Background(), &payload); err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, repoName, updateQueued)

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	gitlabwebhooks "github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
@@ -39,8 +38,7 @@ func TestGitLabWebhookHandle(t *testing.T) {
 	}
 	t.Cleanup(func() { repoupdater.MockEnqueueRepoUpdate = nil })
 
-	baseURL := extsvc.CodeHostBaseURL{} // Not used, can be empty
-	if err := handler.handle(ctx, nil, baseURL, &payload); err != nil {
+	if err := handler.handle(ctx, &payload); err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, repoName, updateQueued)

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler_test.go
@@ -1,0 +1,47 @@
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	gitlabwebhooks "github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
+	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
+	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
+)
+
+func TestGitLabWebhookHandle(t *testing.T) {
+	ctx := context.Background()
+
+	repoName := "gitlab.com/ryanslade/ryan-test-private"
+	handler := NewGitLabWebhookHandler()
+	data, err := os.ReadFile("testdata/gitlab-push.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload gitlabwebhooks.PushEvent
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatal(err)
+	}
+
+	var updateQueued string
+	repoupdater.MockEnqueueRepoUpdate = func(ctx context.Context, repo api.RepoName) (*protocol.RepoUpdateResponse, error) {
+		updateQueued = string(repo)
+		return &protocol.RepoUpdateResponse{
+			ID:   1,
+			Name: string(repo),
+		}, nil
+	}
+	t.Cleanup(func() { repoupdater.MockEnqueueRepoUpdate = nil })
+
+	baseURL := extsvc.CodeHostBaseURL{} // Not used, can be empty
+	if err := handler.handle(ctx, nil, baseURL, &payload); err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, repoName, updateQueued)
+}

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler_test.go
@@ -38,7 +38,7 @@ func TestGitLabWebhookHandle(t *testing.T) {
 	}
 	t.Cleanup(func() { repoupdater.MockEnqueueRepoUpdate = nil })
 
-	if err := handler.handle(context.Background(), &payload); err != nil {
+	if err := handler.handlePushEvent(context.Background(), &payload); err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, repoName, updateQueued)

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_webhook_handler_test.go
@@ -44,7 +44,7 @@ func TestGitLabWebhookHandle(t *testing.T) {
 	assert.Equal(t, repoName, updateQueued)
 }
 
-func Test_gitlabNameFromEvent(t *testing.T) {
+func TestGitlabNameFromEvent(t *testing.T) {
 	tests := []struct {
 		name    string
 		event   *gitlabwebhooks.PushEvent

--- a/enterprise/cmd/frontend/internal/repos/webhooks/testdata/gitlab-push.json
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/testdata/gitlab-push.json
@@ -1,0 +1,107 @@
+{
+  "object_kind": "push",
+  "event_name": "push",
+  "before": "65459a05eabb5923245e6b09843c9ea04e53f816",
+  "after": "48ceeed4ca3367e36c979e637914319bef306a5a",
+  "ref": "refs/heads/master",
+  "checkout_sha": "48ceeed4ca3367e36c979e637914319bef306a5a",
+  "message": null,
+  "user_id": 6975668,
+  "user_name": "Ryan Slade",
+  "user_username": "ryanslade",
+  "user_email": "",
+  "user_avatar": "https://secure.gravatar.com/avatar/7d7fe505cb4b9c27c81f707eb2a63b51?s=80&d=identicon",
+  "project_id": 26057560,
+  "project": {
+    "id": 26057560,
+    "name": "Ryan Test Private",
+    "description": "",
+    "web_url": "https://gitlab.com/ryanslade/ryan-test-private",
+    "avatar_url": null,
+    "git_ssh_url": "git@gitlab.com:ryanslade/ryan-test-private.git",
+    "git_http_url": "https://gitlab.com/ryanslade/ryan-test-private.git",
+    "namespace": "Ryan Slade",
+    "visibility_level": 0,
+    "path_with_namespace": "ryanslade/ryan-test-private",
+    "default_branch": "master",
+    "ci_config_path": "",
+    "homepage": "https://gitlab.com/ryanslade/ryan-test-private",
+    "url": "git@gitlab.com:ryanslade/ryan-test-private.git",
+    "ssh_url": "git@gitlab.com:ryanslade/ryan-test-private.git",
+    "http_url": "https://gitlab.com/ryanslade/ryan-test-private.git"
+  },
+  "commits": [
+    {
+      "id": "48ceeed4ca3367e36c979e637914319bef306a5a",
+      "message": "Add stuff\n",
+      "title": "Add stuff",
+      "timestamp": "2022-12-20T12:44:51+01:00",
+      "url": "https://gitlab.com/ryanslade/ryan-test-private/-/commit/48ceeed4ca3367e36c979e637914319bef306a5a",
+      "author": {
+        "name": "Ryan Slade",
+        "email": "[REDACTED]"
+      },
+      "added": [
+
+      ],
+      "modified": [
+        "README.md"
+      ],
+      "removed": [
+
+      ]
+    },
+    {
+      "id": "928b2277a2d4d1bac29279ee4355f086854c9b89",
+      "message": "Remove stuff\n",
+      "title": "Remove stuff",
+      "timestamp": "2022-12-20T12:21:35+01:00",
+      "url": "https://gitlab.com/ryanslade/ryan-test-private/-/commit/928b2277a2d4d1bac29279ee4355f086854c9b89",
+      "author": {
+        "name": "Ryan Slade",
+        "email": "[REDACTED]"
+      },
+      "added": [
+
+      ],
+      "modified": [
+        "README.md"
+      ],
+      "removed": [
+
+      ]
+    },
+    {
+      "id": "65459a05eabb5923245e6b09843c9ea04e53f816",
+      "message": "Add stuff\n",
+      "title": "Add stuff",
+      "timestamp": "2022-12-20T12:20:16+01:00",
+      "url": "https://gitlab.com/ryanslade/ryan-test-private/-/commit/65459a05eabb5923245e6b09843c9ea04e53f816",
+      "author": {
+        "name": "Ryan Slade",
+        "email": "[REDACTED]"
+      },
+      "added": [
+
+      ],
+      "modified": [
+        "README.md"
+      ],
+      "removed": [
+
+      ]
+    }
+  ],
+  "total_commits_count": 3,
+  "push_options": {
+  },
+  "repository": {
+    "name": "Ryan Test Private",
+    "url": "git@gitlab.com:ryanslade/ryan-test-private.git",
+    "description": "",
+    "homepage": "https://gitlab.com/ryanslade/ryan-test-private",
+    "git_http_url": "https://gitlab.com/ryanslade/ryan-test-private.git",
+    "git_ssh_url": "git@gitlab.com:ryanslade/ryan-test-private.git",
+    "visibility_level": 0
+  }
+}

--- a/internal/extsvc/gitlab/webhooks/events.go
+++ b/internal/extsvc/gitlab/webhooks/events.go
@@ -7,6 +7,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+const TokenHeaderName = "X-Gitlab-Token"
+
 // EventCommon contains fields that are common to all webhook event types.
 type EventCommon struct {
 	ObjectKind string               `json:"object_kind"`
@@ -22,6 +24,12 @@ type PipelineEvent struct {
 	User         gitlab.User          `json:"user"`
 	Pipeline     gitlab.Pipeline      `json:"object_attributes"`
 	MergeRequest *gitlab.MergeRequest `json:"merge_request"`
+}
+
+// PushEvent represents a push to a repository.
+// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#push-events
+type PushEvent struct {
+	EventCommon
 }
 
 var ErrObjectKindUnknown = errors.New("unknown object kind")
@@ -59,6 +67,8 @@ func UnmarshalEvent(data []byte) (any, error) {
 		typedEvent = &mergeRequestEvent{}
 	case "pipeline":
 		typedEvent = &PipelineEvent{}
+	case "push":
+		typedEvent = &PushEvent{}
 	default:
 		return nil, errors.Wrapf(ErrObjectKindUnknown, "kind: %s", event.ObjectKind)
 	}

--- a/internal/extsvc/gitlab/webhooks/webhooks.go
+++ b/internal/extsvc/gitlab/webhooks/webhooks.go
@@ -1,3 +1,0 @@
-package webhooks
-
-const TokenHeaderName = "X-Gitlab-Token"


### PR DESCRIPTION
This change adds support to handle incoming `push` webhooks from GitLab.

Closes #45762 

## Test plan

Tests added and manually tested the full flow of pushing to a repo and seeing it update locally.