### PR TITLE
monitoring: fix titleization for OpenTelemetry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -430,7 +430,7 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/mod v0.7.0
 	golang.org/x/term v0.3.0 // indirect
-	golang.org/x/text v0.5.0 // indirect
+	golang.org/x/text v0.5.0
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/grpc v1.51.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1935,8 +1935,6 @@ github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/prometheus v0.40.5 h1:wmk5yNrQlkQ2OvZucMhUB4k78AVfG34szb1UtopS8Vc=
 github.com/prometheus/prometheus v0.40.5/go.mod h1:bxgdmtoSNLmmIVPGmeTJ3OiP67VmuY4yalE4ZP6L/j8=
-github.com/prometheus/prometheus v0.40.7 h1:cYtp4YrR9M99YpTUfXbei/HjIJJ+En23NKsTCeZ2U2w=
-github.com/prometheus/prometheus v0.40.7/go.mod h1:nO+vI0cJo1ezp2DPGw5NEnTlYHGRpBFrqE4zb9O0g0U=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/protocolbuffers/txtpbfmt v0.0.0-20201118171849-f6a6b3f636fc h1:gSVONBi2HWMFXCa9jFdYvYk7IwW/mTLxWOF7rXS4LO0=
 github.com/pseudomuto/protoc-gen-doc v1.5.1 h1:Ah259kcrio7Ix1Rhb6u8FCaOkzf9qRBqXnvAufg061w=

--- a/monitoring/monitoring/util.go
+++ b/monitoring/monitoring/util.go
@@ -78,8 +78,9 @@ func toMarkdown(m string, forceList bool) (string, error) {
 }
 
 var titleExceptions = map[string]string{
-	"Github": "GitHub",
-	"Gitlab": "GitLab",
+	"Github":        "GitHub",
+	"Gitlab":        "GitLab",
+	"Opentelemetry": "OpenTelemetry",
 }
 
 // Title format s with a title case, accounting for exceptions for a few brands.


### PR DESCRIPTION
`main` was carrying a new dashboard that I didn't have in my PR, thus triggering a failure over https://buildkite.com/sourcegraph/sourcegraph/builds/190156#01852fed-2f92-4924-8183-23e559d558f3

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Locally reproduced and tested. Tests should be green.