### PR TITLE
build: remove circular imports

### DIFF
--- a/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.tsx
@@ -19,9 +19,10 @@ import {
     Form,
 } from '@sourcegraph/wildcard'
 
+import { SyntaxHighlightedSearchQuery } from '../../components/SyntaxHighlightedSearchQuery'
+
 import { StreamingProgressProps } from './StreamingProgress'
 import { limitHit } from './StreamingProgressCount'
-import { SyntaxHighlightedSearchQuery } from '../../components/SyntaxHighlightedSearchQuery'
 
 import styles from './StreamingProgressSkippedPopover.module.scss'
 

--- a/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/search-ui/src/results/progress/StreamingProgressSkippedPopover.tsx
@@ -4,7 +4,6 @@ import { mdiAlertCircle, mdiChevronDown, mdiChevronLeft, mdiInformationOutline, 
 import classNames from 'classnames'
 
 import { pluralize, renderMarkdown } from '@sourcegraph/common'
-import { SyntaxHighlightedSearchQuery } from '@sourcegraph/search-ui'
 import { Skipped } from '@sourcegraph/shared/src/search/stream'
 import {
     Button,
@@ -22,6 +21,7 @@ import {
 
 import { StreamingProgressProps } from './StreamingProgress'
 import { limitHit } from './StreamingProgressCount'
+import { SyntaxHighlightedSearchQuery } from '../../components/SyntaxHighlightedSearchQuery'
 
 import styles from './StreamingProgressSkippedPopover.module.scss'
 

--- a/client/wildcard/src/components/ErrorAlert/ErrorAlert.tsx
+++ b/client/wildcard/src/components/ErrorAlert/ErrorAlert.tsx
@@ -1,7 +1,6 @@
 import React, { HTMLAttributes } from 'react'
 
-import { Alert, AlertProps } from '@sourcegraph/wildcard'
-
+import { Alert, AlertProps } from '../Alert/Alert'
 import { ErrorMessage } from '../ErrorMessage'
 
 export type ErrorAlertProps = {

--- a/client/wildcard/src/components/PageHeader/Breadcrumb/Breadcrumb.tsx
+++ b/client/wildcard/src/components/PageHeader/Breadcrumb/Breadcrumb.tsx
@@ -2,9 +2,8 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { LinkOrSpan } from '../../Link/LinkOrSpan'
-
 import { Icon, IconType } from '../../Icon'
+import { LinkOrSpan } from '../../Link/LinkOrSpan'
 
 import styles from './Breadcrumb.module.scss'
 

--- a/client/wildcard/src/components/PageHeader/Breadcrumb/Breadcrumb.tsx
+++ b/client/wildcard/src/components/PageHeader/Breadcrumb/Breadcrumb.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import classNames from 'classnames'
 
-import { LinkOrSpan } from '@sourcegraph/wildcard'
+import { LinkOrSpan } from '../../Link/LinkOrSpan'
 
 import { Icon, IconType } from '../../Icon'
 


### PR DESCRIPTION
I'm not sure if these are new since [last time](https://github.com/sourcegraph/sourcegraph/commit/08465618070e652a997569b6460fd527effc7d47) or just missed (because the bazel build wasn't compiling them yet).

## Test plan

CI

## App preview:

- [Web](https://sg-web-build-circles.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
