### PR TITLE
web: disable flaky `in-document search` test

### DIFF
--- a/client/web/src/integration/codemirror-blob-view.test.ts
+++ b/client/web/src/integration/codemirror-blob-view.test.ts
@@ -857,7 +857,7 @@ describe('CodeMirror blob view', () => {
             )
         }
 
-        it('renders a working in-document search', async () => {
+        it.skip('renders a working in-document search', async () => {
             await driver.page.goto(`${driver.sourcegraphBaseUrl}${filePaths['test.ts']}`)
             await driver.page.waitForSelector(blobSelector)
             // Wait for page to "settle" so that focus management works better


### PR DESCRIPTION
## Context

Disable the flaky test. Here's the issue to re-enable this test later: 
- https://github.com/sourcegraph/sourcegraph/issues/45870

## Test plan

CI

## App preview:

- [Web](https://sg-web-vb-disable-flaky-search-test.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
