### PR TITLE
fix date-fns imports to improve tree-shaking

### DIFF
--- a/client/web/src/components/Timeline.tsx
+++ b/client/web/src/components/Timeline.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent, ReactNode, useState } from 'react'
 import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
 import VisuallyHidden from '@reach/visually-hidden'
 import classNames from 'classnames'
-import { formatDistance } from 'date-fns/esm'
+import { formatDistance } from 'date-fns'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { Button, Collapse, CollapseHeader, CollapsePanel, Icon } from '@sourcegraph/wildcard'


### PR DESCRIPTION
Importing the `date-fns/locale` module results in 900kb additional unnecessary locale data being bundled. With this change, it is no longer imported (in esbuild), and the import path matches that used for other date-fns imports (no needless `/esm` suffix).

## Test plan

Compiler will check

## App preview:

- [Web](https://sg-web-sqs-date-fns-lodash-imports.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
