### PR TITLE
remove "Code host integrations" from search homepage footer

### DIFF
--- a/client/web/src/search/home/SearchPageFooter.tsx
+++ b/client/web/src/search/home/SearchPageFooter.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Link, H2, H4 } from '@sourcegraph/wildcard'
+import { Link, H2 } from '@sourcegraph/wildcard'
 
 import { BrandLogo } from '../../components/branding/BrandLogo'
 import { PageRoutes } from '../../routes.constants'
@@ -19,7 +19,6 @@ const footerLinkSections: { name: string; links: { name: string; to: string; eve
                 name: 'Docs',
                 to: 'https://docs.sourcegraph.com/',
             },
-            { name: 'Learn', to: 'https://learn.sourcegraph.com/' },
             { name: 'Blog', to: 'https://about.sourcegraph.com/blog/' },
         ],
     },
@@ -51,11 +50,6 @@ const footerLinkSections: { name: string; links: { name: string; to: string; eve
                 name: 'Editor plugins',
                 to: 'https://docs.sourcegraph.com/integration/editor',
                 eventName: 'EditorPlugins',
-            },
-            {
-                name: 'Code host integrations',
-                to: 'https://docs.sourcegraph.com/admin/external_service',
-                eventName: 'CodeHostIntegrations',
             },
         ],
     },
@@ -113,9 +107,6 @@ export const SearchPageFooter: React.FunctionComponent<
         </footer>
     ) : (
         <footer className={classNames(styles.serverFooter, 'd-flex flex-column flex-lg-row align-items-center')}>
-            <H4 as={H2} className="mb-2 mb-lg-0">
-                Explore and extend
-            </H4>
             <span className="d-flex flex-column flex-md-row align-items-center">
                 <span className="d-flex flex-row mb-2 mb-md-0">
                     <Link
@@ -151,16 +142,6 @@ export const SearchPageFooter: React.FunctionComponent<
                         onClick={() => logLinkClicked('EditorPlugins')}
                     >
                         Editor plugins
-                    </Link>
-                    <span aria-hidden="true" className="border-right d-none d-md-inline" />
-                    <Link
-                        className="pl-3"
-                        to="https://docs.sourcegraph.com/admin/external_service"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                        onClick={() => logLinkClicked('CodeHostIntegrations')}
-                    >
-                        Code host integrations
                     </Link>
                 </span>
             </span>


### PR DESCRIPTION
These integrations are not for end users, so they are confusing and add noise. Let's only show integrations here that are for end users.


## Test plan

Check that the footer no longer contains this.

## App preview:

- [Web](https://sg-web-sqs-homepage-footer-cleanup.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
