### PR TITLE
Tabs: don't clobber size and other internal class names when passing <Tab className>

### DIFF
--- a/client/wildcard/src/components/Tabs/Tabs.tsx
+++ b/client/wildcard/src/components/Tabs/Tabs.tsx
@@ -213,14 +213,14 @@ const TabListPlain = React.forwardRef((props, reference) => {
 >
 
 export const Tab = React.forwardRef((props, reference) => {
-    const { as = 'button', ...reachProps } = props
+    const { as = 'button', className, ...reachProps } = props
     const {
         settings: { size, longTabList },
     } = useTabsState()
 
     return (
         <ReachTab
-            className={classNames(styles[size], longTabList === 'scroll' && styles.tabNowrap)}
+            className={classNames(styles[size], longTabList === 'scroll' && styles.tabNowrap, className)}
             data-testid="wildcard-tab"
             as={as}
             ref={reference}


### PR DESCRIPTION
Before this change, if you had `<Tabs size="medium">` and a `<Tab className="px-3">` for example, then the medium font size would not be applied to the `<Tab>` because it would be clobbered by `px-3`. The class names should be merged.

## Test plan

n/a

## App preview:

- [Web](https://sg-web-sqs-tabs-preserve-classname.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
