### PR TITLE
Fix hidden 'show more' button

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarCommits.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarCommits.tsx
@@ -115,7 +115,7 @@ export const RepoRevisionSidebarCommits: React.FunctionComponent<React.PropsWith
             ))}
             {loading && <ConnectionLoading />}
             {!loading && connection && (
-                <SummaryContainer>{hasNextPage && <ShowMoreButton onClick={fetchMore} />}</SummaryContainer>
+                <SummaryContainer centered={true}>{hasNextPage && <ShowMoreButton centered={true} onClick={fetchMore} />}</SummaryContainer>
             )}
         </ConnectionContainer>
     )

--- a/client/web/src/repo/RepoRevisionSidebarCommits.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarCommits.tsx
@@ -115,7 +115,9 @@ export const RepoRevisionSidebarCommits: React.FunctionComponent<React.PropsWith
             ))}
             {loading && <ConnectionLoading />}
             {!loading && connection && (
-                <SummaryContainer centered={true}>{hasNextPage && <ShowMoreButton centered={true} onClick={fetchMore} />}</SummaryContainer>
+                <SummaryContainer centered={true}>
+                    {hasNextPage && <ShowMoreButton centered={true} onClick={fetchMore} />}
+                </SummaryContainer>
             )}
         </ConnectionContainer>
     )


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/44430

Centered the 'Show more' button on the history tab.
## Test plan
Tested locally
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-gabe-fix-hidden-button.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
