### PR TITLE
remove unused styles for old repo changer

### DIFF
--- a/client/web/src/repo/RepoContainer.module.scss
+++ b/client/web/src/repo/RepoContainer.module.scss
@@ -2,8 +2,3 @@
     margin-left: auto;
     margin-right: auto;
 }
-
-.repo-change {
-    padding-left: 0.25rem;
-    padding-right: 0.25rem;
-}


### PR DESCRIPTION
In the repo header, there used to be a jump-to-other-repo menu next to the repo name. That was removed. The `.repo-change` style was for that long-removed menu and is not used anywhere else.




## Test plan

n/a

## App preview:

- [Web](https://sg-web-sqs-rm-unused-styles-repo-switcher.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
