### PR TITLE
Support following single-file history across renames in GraphQL API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Keyboard navigation for search results is now enabled by default. Use Arrow Up/Down keys to navigate between search results, Arrow Left/Right to collapse and expand file matches, Enter to open the search result in the current tab, Ctrl/Cmd+Enter to open the result in a separate tab, / to refocus the search input, and Ctrl/Cmd+Arrow Down to jump from the search input to the first result. Arrow Left/Down/Up/Right in previous examples can be substituted with h/j/k/l for Vim-style bindings. Keyboard navigation can be disabled by creating the `search-results-keyboard-navigation` feature flag and setting it to false. [#45890](https://github.com/sourcegraph/sourcegraph/pull/45890)
 - Added support for receiving GitLab webhook `push` events. [#45856](https://github.com/sourcegraph/sourcegraph/pull/45856)
 - Added support for receiving Bitbucket Server / Datacenter webhook `push` events. [#45909](https://github.com/sourcegraph/sourcegraph/pull/45909)
+- The GraphQL API now supports listing single-file commit history across renames (with `GitCommit.ancestors(follow: true, path: "<some-path>")`). [#45882](https://github.com/sourcegraph/sourcegraph/pull/45882)
 
 ### Changed
 

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -323,6 +323,7 @@ func (r *GitCommitResolver) Ancestors(ctx context.Context, args *struct {
 	graphqlutil.ConnectionArgs
 	Query       *string
 	Path        *string
+	Follow      bool
 	After       *string
 	AfterCursor *string
 }) (*gitCommitConnectionResolver, error) {
@@ -333,6 +334,7 @@ func (r *GitCommitResolver) Ancestors(ctx context.Context, args *struct {
 		first:           args.ConnectionArgs.First,
 		query:           args.Query,
 		path:            args.Path,
+		follow:          args.Follow,
 		after:           args.After,
 		afterCursor:     args.AfterCursor,
 		repo:            r.repoResolver,

--- a/cmd/frontend/graphqlbackend/git_commits.go
+++ b/cmd/frontend/graphqlbackend/git_commits.go
@@ -21,6 +21,7 @@ type gitCommitConnectionResolver struct {
 	first  *int32
 	query  *string
 	path   *string
+	follow bool
 	author *string
 
 	// after corresponds to --after in the git log / git rev-spec commands. Not to be confused with
@@ -83,6 +84,7 @@ func (r *gitCommitConnectionResolver) compute(ctx context.Context) ([]*gitdomain
 			After:        toValue(r.after).(string),
 			Skip:         uint(afterCursor),
 			Path:         toValue(r.path).(string),
+			Follow:       r.follow,
 		})
 	}
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -4615,6 +4615,10 @@ type GitCommit implements Node {
         """
         path: String
         """
+        Follow history beyond renames (only works for a single file).
+        """
+        follow: Boolean = false
+        """
         Return commits more recent than the specified date.
         """
         after: String

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -1617,7 +1617,7 @@ func TestRepository_Commits(t *testing.T) {
 	runCommitsTests := func(checker authz.SubRepoPermissionChecker) {
 		for label, test := range tests {
 			t.Run(label, func(t *testing.T) {
-				testCommits(ctx, label, test.repo, CommitsOptions{Range: string(test.id)}, checker, test.wantTotal, test.wantCommits, t)
+				testCommits(ctx, label, test.repo, CommitsOptions{Range: string(test.id)}, checker, test.wantCommits, t)
 
 				// Test that trying to get a nonexistent commit returns RevisionNotFoundError.
 				if _, err := client.Commits(ctx, nil, test.repo, CommitsOptions{Range: string(NonExistentCommitID)}); !errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
@@ -1881,7 +1881,7 @@ func TestRepository_Commits_options(t *testing.T) {
 		for label, test := range tests {
 			t.Run(label, func(t *testing.T) {
 				repo := MakeGitRepository(t, gitCommands...)
-				testCommits(ctx, label, repo, test.opt, checker, test.wantTotal, test.wantCommits, t)
+				testCommits(ctx, label, repo, test.opt, checker, test.wantCommits, t)
 			})
 		}
 		// Added for awareness if this error message changes. Insights record last repo indexing and consider empty
@@ -1940,7 +1940,6 @@ func TestRepository_Commits_options_path(t *testing.T) {
 	tests := map[string]struct {
 		opt         CommitsOptions
 		wantCommits []*gitdomain.Commit
-		wantTotal   uint
 	}{
 		"git cmd Path 0": {
 			opt: CommitsOptions{
@@ -1948,7 +1947,6 @@ func TestRepository_Commits_options_path(t *testing.T) {
 				Path:  "doesnt-exist",
 			},
 			wantCommits: nil,
-			wantTotal:   0,
 		},
 		"git cmd Path 1": {
 			opt: CommitsOptions{
@@ -1956,7 +1954,6 @@ func TestRepository_Commits_options_path(t *testing.T) {
 				Path:  "file1",
 			},
 			wantCommits: wantGitCommits,
-			wantTotal:   1,
 		},
 	}
 
@@ -1964,7 +1961,7 @@ func TestRepository_Commits_options_path(t *testing.T) {
 		for label, test := range tests {
 			t.Run(label, func(t *testing.T) {
 				repo := MakeGitRepository(t, gitCommands...)
-				testCommits(ctx, label, repo, test.opt, checker, test.wantTotal, test.wantCommits, t)
+				testCommits(ctx, label, repo, test.opt, checker, test.wantCommits, t)
 			})
 		}
 	}
@@ -2337,7 +2334,7 @@ func TestCommitDate(t *testing.T) {
 	})
 }
 
-func testCommits(ctx context.Context, label string, repo api.RepoName, opt CommitsOptions, checker authz.SubRepoPermissionChecker, wantTotal uint, wantCommits []*gitdomain.Commit, t *testing.T) {
+func testCommits(ctx context.Context, label string, repo api.RepoName, opt CommitsOptions, checker authz.SubRepoPermissionChecker, wantCommits []*gitdomain.Commit, t *testing.T) {
 	t.Helper()
 	db := database.NewMockDB()
 	client := NewClient(db).(*clientImplementor)
@@ -2347,14 +2344,6 @@ func testCommits(ctx context.Context, label string, repo api.RepoName, opt Commi
 		return
 	}
 
-	total, err := client.commitCount(ctx, repo, opt)
-	if err != nil {
-		t.Errorf("%s: commitCount(): %s", label, err)
-		return
-	}
-	if total != wantTotal {
-		t.Errorf("%s: got %d total commits, want %d", label, total, wantTotal)
-	}
 	if len(commits) != len(wantCommits) {
 		t.Errorf("%s: got %d commits, want %d", label, len(commits), len(wantCommits))
 	}


### PR DESCRIPTION
Adds `GitCommit.ancestors(follow: Boolean)` to the GraphQL API to track a single file's commit history across renames.

Helps with #4383. See https://github.com/sourcegraph/sourcegraph/pull/45882#issuecomment-1364482590 for the additional backend, API, and UI work needed to close that issue.



## Test plan

Call `ancestors` in the GraphQL API with a `path` and `follow: true`. Ensure it shows commits before a rename.