### PR TITLE
prevent ActionItemsBar from shrinking

### DIFF
--- a/client/web/src/extensions/components/ActionItemsBar.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.tsx
@@ -219,7 +219,7 @@ export const ActionItemsBar = React.memo<ActionItemsBarProps>(function ActionIte
         (settings?.['perforce.codeHostToSwarmMap'] as { [codeHost: string]: string } | undefined) || {}
 
     if (!isOpen) {
-        return <div className={styles.barCollapsed} />
+        return <div className={classNames(styles.bar, styles.barCollapsed)} />
     }
 
     return (


### PR DESCRIPTION
The `.bar` style (not just `.bar--collapsed`) should always be applied because its `flex: 0 0 auto` prevents the right gutter from shrinking (per CSS flexbox rules) when the contents of the page request more width.

This fixes a minor issue where in narrow windows, the right gutter shrinks and becomes inconsistently sized.




## Test plan

On a file or tree page, shrink the window and ensure the right gutter does not shrink.

## App preview:

- [Web](https://sg-web-sqs-no-actionitemsbar-shrink.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
