### PR TITLE
show repo container UI even while a subcomponent is still loading

### DIFF
--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { Suspense, useEffect, useMemo, useState } from 'react'
 
 import { mdiSourceRepository } from '@mdi/js'
 import classNames from 'classnames'
@@ -423,38 +423,40 @@ export const RepoContainer: React.FunctionComponent<React.PropsWithChildren<Repo
             )}
 
             <ErrorBoundary location={props.location}>
-                <Switch>
-                    {[
-                        '',
-                        ...(rawRevision ? [`@${rawRevision}`] : []), // must exactly match how the revision was encoded in the URL
-                        '/-/blob',
-                        '/-/tree',
-                        '/-/commits',
-                        '/-/docs',
-                        '/-/branch',
-                        '/-/contributors',
-                        '/-/compare',
-                        '/-/tag',
-                        '/-/home',
-                    ].map(routePath => (
-                        <Route
-                            path={`${repoMatchURL}${routePath}`}
-                            key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                            exact={routePath === ''}
-                            render={routeComponentProps => (
-                                <RepoRevisionContainer
-                                    {...routeComponentProps}
-                                    {...repoRevisionContainerContext}
-                                    {...childBreadcrumbSetters}
-                                    routes={props.repoRevisionContainerRoutes}
-                                    // must exactly match how the revision was encoded in the URL
-                                    routePrefix={`${repoMatchURL}${rawRevision ? `@${rawRevision}` : ''}`}
-                                />
-                            )}
-                        />
-                    ))}
-                    {getRepoContainerContextRoutes()}
-                </Switch>
+                <Suspense fallback={null}>
+                    <Switch>
+                        {[
+                            '',
+                            ...(rawRevision ? [`@${rawRevision}`] : []), // must exactly match how the revision was encoded in the URL
+                            '/-/blob',
+                            '/-/tree',
+                            '/-/commits',
+                            '/-/docs',
+                            '/-/branch',
+                            '/-/contributors',
+                            '/-/compare',
+                            '/-/tag',
+                            '/-/home',
+                        ].map(routePath => (
+                            <Route
+                                path={`${repoMatchURL}${routePath}`}
+                                key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                exact={routePath === ''}
+                                render={routeComponentProps => (
+                                    <RepoRevisionContainer
+                                        {...routeComponentProps}
+                                        {...repoRevisionContainerContext}
+                                        {...childBreadcrumbSetters}
+                                        routes={props.repoRevisionContainerRoutes}
+                                        // must exactly match how the revision was encoded in the URL
+                                        routePrefix={`${repoMatchURL}${rawRevision ? `@${rawRevision}` : ''}`}
+                                    />
+                                )}
+                            />
+                        ))}
+                        {getRepoContainerContextRoutes()}
+                    </Switch>
+                </Suspense>
             </ErrorBoundary>
         </div>
     )


### PR DESCRIPTION
Previously, if the repo container was displaying a lazily-loaded component (for which a `fetch` was needed), the repo container header would not be displayed. This change makes it so that it is displayed. This improves the perceived loading time. It also fixes a bug where if a child component initially renders something and then shortly thereafter renders a suspended/lazily-loaded component, the entire repo container will blank out until that lazy-loaded component is loaded.




## Test plan

Load any repo page.

## App preview:

- [Web](https://sg-web-sqs-repocontainer-suspense.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
