### PR TITLE
token selection: fix popover styles

### DIFF
--- a/client/web/src/repo/blob/codemirror/token-selection/hover.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/hover.ts
@@ -203,7 +203,7 @@ const tooltipStyles = EditorView.theme({
     // Tooltip styles is a combination of the default wildcard PopoverContent component (https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/components/popover-content/PopoverContent.module.scss#L1-L10)
     // and the floating tooltip-like storybook usage example (https://github.com/sourcegraph/sourcegraph/blob/5de30f6fa1c59d66341e4dfc0c374cab0ad17bff/client/wildcard/src/components/Popover/story/Popover.story.module.scss#L54-L62)
     // ignoring the min/max width rules.
-    '.cm-tooltip': {
+    '.cm-tooltip.tmp-tooltip': {
         fontSize: '0.875rem',
         backgroundClip: 'padding-box',
         backgroundColor: 'var(--dropdown-bg)',
@@ -214,10 +214,14 @@ const tooltipStyles = EditorView.theme({
         padding: '0.5rem',
     },
 
-    '.cm-tooltip-above .cm-tooltip-arrow:before': {
+    '.cm-tooltip-above:not(.tmp-tooltip)': {
+        border: 'unset',
+    },
+
+    '.cm-tooltip.cm-tooltip-above.tmp-tooltip .cm-tooltip-arrow:before': {
         borderTopColor: 'var(--dropdown-border-color)',
     },
-    '.cm-tooltip-above .cm-tooltip-arrow:after': {
+    '.cm-tooltip.cm-tooltip-above.tmp-tooltip .cm-tooltip-arrow:after': {
         borderTopColor: 'var(--dropdown-bg)',
     },
 })

--- a/client/web/src/repo/blob/codemirror/tooltips/LoadingTooltip.ts
+++ b/client/web/src/repo/blob/codemirror/tooltips/LoadingTooltip.ts
@@ -12,6 +12,7 @@ export class LoadingTooltip {
                 above: true,
                 create() {
                     const dom = document.createElement('div')
+                    dom.classList.add('tmp-tooltip')
                     dom.textContent = 'Loading...'
                     return { dom }
                 },

--- a/client/web/src/repo/blob/codemirror/tooltips/TemporaryTooltip.tsx
+++ b/client/web/src/repo/blob/codemirror/tooltips/TemporaryTooltip.tsx
@@ -13,6 +13,7 @@ class TemporaryTooltip implements Tooltip {
     ) {}
     public create(): TooltipView {
         const div = document.createElement('div')
+        div.classList.add('tmp-tooltip')
         div.textContent = this.message
         return { dom: div }
     }


### PR DESCRIPTION
Removes redundant borders from the code-intel popover wrapper.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="585" alt="Screenshot 2022-12-21 at 08 48 42" src="https://user-images.githubusercontent.com/25318659/208839873-c42ae62d-56e8-4277-a0bc-75ac187c3a47.png">
<img width="1306" alt="Screenshot 2022-12-21 at 08 49 49" src="https://user-images.githubusercontent.com/25318659/208839869-25d12df2-d97e-4882-9754-48fa6dda07e0.png">


</td>
<td>Code-intel popover has different wrappers nesting when rendered on hover and on 'Space' press.

Hover 👇🏻 
<img width="506" alt="Screenshot 2022-12-21 at 08 39 19" src="https://user-images.githubusercontent.com/25318659/208838834-a4265325-350e-4ac6-93e3-e26c61f52a58.png">

Space 👇🏻 
<img width="452" alt="Screenshot 2022-12-21 at 08 39 29" src="https://user-images.githubusercontent.com/25318659/208838873-f7ea7974-c023-4d8a-80f0-9f6c44db5c79.png">
</td>
</tr>
</tbody>
</table>


## Test plan
Ensure there are no redundant elements rendered near the code-intel popover.
 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-codemirror-blob-fix.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
