### PR TITLE
Enable search results keyboard navigation by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added a button "Reindex now" to the index status page. Admins can now force an immediate reindex of a repository. [#45533](https://github.com/sourcegraph/sourcegraph/pull/45533)
 - Added an option "Unlock user" to the actions dropdown on the Site Admin Users page. Admins can unlock user accounts that wer locked after too many sign-in attempts. [#45650](https://github.com/sourcegraph/sourcegraph/pull/45650)
 - Templates for certain emails sent by Sourcegraph are now configurable via `email.templates` in site configuration. [#45671](https://github.com/sourcegraph/sourcegraph/pull/45671)
+- Keyboard navigation for search results is now enabled by default. Use Arrow Up/Down keys to navigate between search results, Arrow Left/Right to collapse and expand file matches, Enter to open the search result in the current tab, Ctrl/Cmd+Enter to open the result in a separate tab, / to refocus the search input, and Ctrl/Cmd+Arrow Down to jump from the search input to the first result. Arrow Left/Down/Up/Right in previous examples can be substituted with h/j/k/l for Vim-style bindings. Keyboard navigation can be disabled by creating the `search-results-keyboard-navigation` feature flag and setting it to false. [#45890](https://github.com/sourcegraph/sourcegraph/pull/45890)
 
 ### Changed
 

--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -66,8 +66,6 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
                          
                         <a
                           class="anchorLink"
-                          data-selectable-search-result="true"
-                          data-selectable-search-result-header-link="true"
                           href="/github.com/foo/bar/-/blob/?subtree=true"
                         >
                           <strong />
@@ -322,8 +320,6 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                          
                         <a
                           class="anchorLink"
-                          data-selectable-search-result="true"
-                          data-selectable-search-result-header-link="true"
                           href="/github.com/foo/bar/-/blob/file1.txt?subtree=true"
                         >
                           <strong>
@@ -526,8 +522,6 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
                          
                         <a
                           class="anchorLink"
-                          data-selectable-search-result="true"
-                          data-selectable-search-result-header-link="true"
                           href="/github.com/foo/bar/-/blob/?subtree=true"
                         >
                           <strong />

--- a/client/search-ui/src/components/CommitSearchResult.tsx
+++ b/client/search-ui/src/components/CommitSearchResult.tsx
@@ -46,11 +46,7 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({
                 <Link to={getRepositoryUrl(result.repository)}>{displayRepoName(result.repository)}</Link>
                 <span aria-hidden={true}> ›</span> <Link to={getCommitMatchUrl(result)}>{result.authorName}</Link>
                 <span aria-hidden={true}>{': '}</span>
-                <Link
-                    to={getCommitMatchUrl(result)}
-                    data-selectable-search-result="true"
-                    data-selectable-search-result-header-link="true"
-                >
+                <Link to={getCommitMatchUrl(result)} data-selectable-search-result="true">
                     {result.message.split('\n', 1)[0]}
                 </Link>
             </span>

--- a/client/search-ui/src/components/FileContentSearchResult.tsx
+++ b/client/search-ui/src/components/FileContentSearchResult.tsx
@@ -223,7 +223,6 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
                             : undefined
                     }
                     className={classNames(styles.titleInner, styles.mutedRepoFileLink)}
-                    isKeyboardSelectable={true}
                 />
                 <CopyPathAction
                     className={styles.copyButton}

--- a/client/search-ui/src/components/RepoFileLink.tsx
+++ b/client/search-ui/src/components/RepoFileLink.tsx
@@ -43,7 +43,6 @@ export const RepoFileLink: React.FunctionComponent<React.PropsWithChildren<Props
                     to={appendSubtreeQueryParameter(fileURL)}
                     ref={containerElement}
                     data-selectable-search-result={isKeyboardSelectable}
-                    data-selectable-search-result-header-link={isKeyboardSelectable}
                 >
                     {fileBase ? `${fileBase}/` : null}
                     <strong>{fileName}</strong>

--- a/client/search-ui/src/components/RepoSearchResult.tsx
+++ b/client/search-ui/src/components/RepoSearchResult.tsx
@@ -36,12 +36,7 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
     const title = (
         <div className={styles.title}>
             <span className={classNames('test-search-result-label', styles.titleInner, styles.mutedRepoFileLink)}>
-                <Link
-                    to={getRepoMatchUrl(result)}
-                    ref={repoNameElement}
-                    data-selectable-search-result="true"
-                    data-selectable-search-result-header-link="true"
-                >
+                <Link to={getRepoMatchUrl(result)} ref={repoNameElement} data-selectable-search-result="true">
                     {displayRepoName(getRepoMatchLabel(result))}
                 </Link>
             </span>

--- a/client/search-ui/src/components/SymbolSearchResult.tsx
+++ b/client/search-ui/src/components/SymbolSearchResult.tsx
@@ -64,7 +64,6 @@ export const SymbolSearchResult: React.FunctionComponent<SymbolSearchResultProps
                         : undefined
                 }
                 className={classNames(searchResultStyles.titleInner, searchResultStyles.mutedRepoFileLink)}
-                isKeyboardSelectable={true}
             />
             <CopyPathAction
                 filePath={result.path}

--- a/client/search-ui/src/results/useSearchResultsKeyboardNavigation.ts
+++ b/client/search-ui/src/results/useSearchResultsKeyboardNavigation.ts
@@ -30,25 +30,7 @@ export function useSearchResultsKeyboardNavigation(
                 case 'j':
                 case 'k': {
                     const direction = event.key === 'ArrowUp' || event.key === 'k' ? 'up' : 'down'
-
-                    const hasSelectedNextResult = isMetaKey(event, isMacPlatform())
-                        ? selectNextHeaderLink(selectableResults, selectedResult, direction)
-                        : selectNextResult(selectableResults, selectedResult, direction)
-
-                    if (hasSelectedNextResult) {
-                        event.stopPropagation()
-                        event.preventDefault()
-                    }
-                    break
-                }
-                case 'n':
-                case 'p': {
-                    const hasSelectedNextResult = selectNextHeaderLink(
-                        selectableResults,
-                        selectedResult,
-                        event.key === 'p' ? 'up' : 'down'
-                    )
-
+                    const hasSelectedNextResult = selectNextResult(selectableResults, selectedResult, direction)
                     if (hasSelectedNextResult) {
                         event.stopPropagation()
                         event.preventDefault()
@@ -69,14 +51,6 @@ export function useSearchResultsKeyboardNavigation(
                     if (selectedResult) {
                         selectedResult.dispatchEvent(
                             new CustomEvent('expandSearchResultsGroup', { bubbles: true, cancelable: true })
-                        )
-                        event.preventDefault()
-                    }
-                    break
-                case 'e':
-                    if (selectedResult) {
-                        selectedResult.dispatchEvent(
-                            new CustomEvent('toggleSearchResultsGroup', { bubbles: true, cancelable: true })
                         )
                         event.preventDefault()
                     }
@@ -135,7 +109,7 @@ export function useSearchResultsKeyboardNavigation(
                 return
             }
 
-            if (event.key === 'ArrowDown' && isMetaKey(event, isMacPlatform())) {
+            if ((event.key === 'ArrowDown' || event.key === 'j') && isMetaKey(event, isMacPlatform())) {
                 selectFirstResult(root)
                 event.preventDefault()
             }
@@ -187,28 +161,6 @@ function selectNextResult(
     const currentIndex = selectableResults.findIndex(selectable => selectable.isEqualNode(selectedResult))
     const nextIndex = direction === 'down' ? currentIndex + 1 : currentIndex - 1
     const nextSelected = nextIndex >= 0 && nextIndex < selectableResults.length ? selectableResults[nextIndex] : null
-
-    return selectElement(nextSelected)
-}
-
-function selectNextHeaderLink(
-    selectableResults: HTMLElement[],
-    selectedResult: HTMLElement | null,
-    direction: 'up' | 'down'
-): boolean {
-    if (!selectedResult || selectableResults.length === 0) {
-        return false
-    }
-
-    const currentIndex = selectableResults.findIndex(selectable => selectable.isEqualNode(selectedResult))
-    const selectableCandidates =
-        direction === 'down'
-            ? selectableResults.slice(currentIndex + 1)
-            : selectableResults.slice(0, currentIndex).reverse()
-
-    const nextSelected = selectableCandidates.find(
-        selectable => selectable.dataset.selectableSearchResultHeaderLink === 'true'
-    )
 
     return selectElement(nextSelected)
 }

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -77,7 +77,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
     const enableCodeMonitoring = useExperimentalFeatures(features => features.codeMonitoring ?? false)
     const showSearchContext = useExperimentalFeatures(features => features.showSearchContext ?? false)
     const prefetchFileEnabled = useExperimentalFeatures(features => features.enableSearchFilePrefetch ?? false)
-    const [enableSearchResultsKeyboardNavigation] = useFeatureFlag('search-results-keyboard-navigation', false)
+    const [enableSearchResultsKeyboardNavigation] = useFeatureFlag('search-results-keyboard-navigation', true)
     const prefetchBlobFormat = usePrefetchBlobFormat()
 
     const [sidebarCollapsed, setSidebarCollapsed] = useTemporarySetting('search.sidebar.collapsed', false)


### PR DESCRIPTION
Enables search results keyboard navigation by default

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Use Arrow Up/Down keys to navigate between search results, Arrow Left/Right to collapse and expand file matches, Enter to open the search result in the current tab, Ctrl/Cmd+Enter to open the result in a separate tab, / to refocus the search input, and Ctrl/Cmd+Arrow Down to jump from the search input to the first result. Arrow Left/Down/Up/Right in previous examples can be substituted with h/j/k/l for Vim-style bindings.

## App preview:

- [Web](https://sg-web-rn-enable-search-results-keyboard.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
