### PR TITLE
client: add decimal digits for gigabyte+ sizes of repos.

### DIFF
--- a/client/web/src/util/prettyBytesBigint.test.ts
+++ b/client/web/src/util/prettyBytesBigint.test.ts
@@ -1,0 +1,25 @@
+import { prettyBytesBigint } from './prettyBytesBigint'
+
+describe('prettyBytesBigint', () => {
+    test('pretty prints 1.23 Gb', () => {
+        expect(prettyBytesBigint(BigInt(1231234560))).toBe('1.23 GB')
+    })
+    test('pretty prints 1.02 Gb', () => {
+        expect(prettyBytesBigint(BigInt(1021234567))).toBe('1.02 GB')
+    })
+    test('pretty prints 500.50 Gb', () => {
+        expect(prettyBytesBigint(BigInt(500500001337))).toBe('500.50 GB')
+    })
+    test('pretty prints 50.05 Tb', () => {
+        expect(prettyBytesBigint(BigInt(50055550000000))).toBe('50.05 TB')
+    })
+    test('pretty prints 50 Gb', () => {
+        expect(prettyBytesBigint(BigInt(50005555000))).toBe('50 GB')
+    })
+    test('pretty prints 1 Mb', () => {
+        expect(prettyBytesBigint(BigInt(1230000))).toBe('1 MB')
+    })
+    test('pretty prints 999 Mb', () => {
+        expect(prettyBytesBigint(BigInt(999123000))).toBe('999 MB')
+    })
+})

--- a/client/web/src/util/prettyBytesBigint.ts
+++ b/client/web/src/util/prettyBytesBigint.ts
@@ -1,12 +1,28 @@
+/**
+ * Function used to print a number of bytes in a more readable format.
+ *
+ * It returns an integer value for sizes of magnitudes of bytes, kb and MB.
+ * For gigabytes and further it also includes 2 numbers after a decimal point if the size is not integral.
+ *
+ * @param bytes         Size in bytes.
+ *
+ * @returns Pretty printed size.
+ */
 export function prettyBytesBigint(bytes: bigint): string {
     let unit = 0
     const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
     const threshold = BigInt(1000)
+    // two decimal points
+    let decimal = 0
 
     while (bytes >= threshold) {
+        // `bytes % threshold` is always less than 1000, so the conversion to Number is safe
+        decimal = Number(bytes % threshold)
+        // taking first two digits
+        decimal = Math.floor(decimal / 10)
         bytes /= threshold
         unit += 1
     }
-
-    return bytes.toString() + ' ' + units[unit]
+    const resultNumber = bytes.toString() + (decimal !== 0 && unit > 2 ? `.${decimal.toString().padStart(2, '0')}` : '')
+    return resultNumber + ' ' + units[unit]
 }


### PR DESCRIPTION
Just a quick thing that I've noticed. IMO, such formatting gives more insight (1Gb versus 1.99Gb is twice the difference, but previously both resolved to `1 GB`).

### Before
![image](https://user-images.githubusercontent.com/94846361/208885857-55d9e576-7242-44be-9767-7db058253b42.png)

### After
![image](https://user-images.githubusercontent.com/94846361/208885918-3008a403-bd74-4fcd-ba74-1eb5c6cd7860.png)

Test plan:
Unit tests added, local sg run and visual check.

## App preview:

- [Web](https://sg-web-ao-ui-repo-size-with-decimals.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
