### PR TITLE
If a token refresh fails, return the original response and error

### DIFF
--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1514,21 +1514,6 @@ func doRequest(ctx context.Context, logger log.Logger, apiURL *url.URL, auther a
 	// to cache server-side
 	req.Header.Set("Cache-Control", "max-age=0")
 
-	var autherWithRefresh auth.AuthenticatorWithRefresh
-	if auther != nil {
-		var ok bool
-		autherWithRefresh, ok = auther.(auth.AuthenticatorWithRefresh)
-		// Check if we should pre-emptively refresh
-		if ok && autherWithRefresh.NeedsRefresh() {
-			if err := autherWithRefresh.Refresh(ctx, httpClient); err != nil {
-				logger.Warn("doRequest: refreshing of the token failed", log.Error(err))
-			}
-		}
-		if err := auther.Authenticate(req); err != nil {
-			return nil, errors.Wrap(err, "authenticating request")
-		}
-	}
-
 	var resp *http.Response
 
 	span, ctx := ot.StartSpanFromContext(ctx, "GitHub") //nolint:staticcheck // OT is deprecated
@@ -1543,16 +1528,9 @@ func doRequest(ctx context.Context, logger log.Logger, apiURL *url.URL, auther a
 		span.Finish()
 	}()
 
-	if autherWithRefresh != nil {
-		resp, err = oauthutil.DoRequest(ctx, httpClient, req, autherWithRefresh)
-		if err != nil {
-			return nil, errors.Wrap(err, "do request with refresh and retry failed")
-		}
-	} else {
-		resp, err = httpClient.Do(req.WithContext(ctx))
-		if err != nil {
-			return nil, errors.Wrap(err, "http request failed")
-		}
+	resp, err = oauthutil.DoRequest(ctx, logger, httpClient, req, auther)
+	if err != nil {
+		return nil, errors.Wrap(err, "request failed")
 	}
 	defer resp.Body.Close()
 

--- a/internal/oauthutil/oauth2.go
+++ b/internal/oauthutil/oauth2.go
@@ -62,10 +62,10 @@ func getOAuthErrorDetails(body []byte) error {
 type TokenRefresher func(ctx context.Context, doer httpcli.Doer, oauthCtx OAuthContext) (*auth.OAuthBearerToken, error)
 
 // DoRequest is a function that uses the httpcli.Doer interface to make HTTP
-// requests and to handle "401 Unauthorized" errors. When the 401 error is due to
-// a token being expired, it will use the supplied AuthenticatorWithRefresh to
-// update the token. If the token is updated successfully, the same request will
-// be retried exactly once.
+// requests. It authenticates the request using the supplied Authenticator.
+// If the Authenticator implements the AuthenticatorWithRefresh interface,
+// it will also attempt to refresh the token in case of a 401 response.
+// If the token is updated successfully, the same request will be retried exactly once.
 func DoRequest(ctx context.Context, logger log.Logger, doer httpcli.Doer, req *http.Request, auther auth.Authenticator) (*http.Response, error) {
 	if auther == nil {
 		return doer.Do(req.WithContext(ctx))

--- a/internal/oauthutil/oauth2.go
+++ b/internal/oauthutil/oauth2.go
@@ -62,7 +62,7 @@ type TokenRefresher func(ctx context.Context, doer httpcli.Doer, oauthCtx OAuthC
 
 // DoRequest is a function that uses the httpcli.Doer interface to make HTTP
 // requests and to handle "401 Unauthorized" errors. When the 401 error is due to
-// a token being expired, it will use the supplied TokenRefresher function to
+// a token being expired, it will use the supplied AuthenticatorWithRefresh to
 // update the token. If the token is updated successfully, the same request will
 // be retried exactly once.
 // autherWithRefresh should not be nil.

--- a/internal/oauthutil/oauth2.go
+++ b/internal/oauthutil/oauth2.go
@@ -65,32 +65,30 @@ type TokenRefresher func(ctx context.Context, doer httpcli.Doer, oauthCtx OAuthC
 // a token being expired, it will use the supplied TokenRefresher function to
 // update the token. If the token is updated successfully, the same request will
 // be retried exactly once.
+// autherWithRefresh should not be nil.
 func DoRequest(ctx context.Context, doer httpcli.Doer, req *http.Request, autherWithRefresh auth.AuthenticatorWithRefresh) (resp *http.Response, err error) {
-	for i := 0; i < 2; i++ {
-		if autherWithRefresh != nil {
-			if err := autherWithRefresh.Authenticate(req); err != nil {
-				return nil, errors.Wrap(err, "authenticate")
-			}
-		}
-
-		resp, err = doer.Do(req.WithContext(ctx))
-		if err != nil {
-			return resp, errors.Wrap(err, "do request")
-		}
-
-		if resp.StatusCode == http.StatusUnauthorized && autherWithRefresh != nil {
-			// If a refresher is present, we can then refresh the token and update the authenticator.
-			// The next request should then succeed.
-			err = autherWithRefresh.Refresh(ctx, doer)
-			if err != nil {
-				// Return the response
-				return resp, nil
-			}
-
-			// Refresh successful, restart the loop
-			continue
-		}
-		return resp, nil
+	// Do first request
+	resp, err = authAndDoRequest(ctx, doer, req, autherWithRefresh)
+	if err != nil {
+		return resp, err
 	}
-	return resp, errors.Wrap(err, "retries exceeded")
+
+	// If response is unauthorised, attempt a token refresh
+	if resp.StatusCode == http.StatusUnauthorized {
+		if err = autherWithRefresh.Refresh(ctx, doer); err != nil {
+			// If the refresh failed, return the original response
+			return resp, nil
+		}
+	}
+
+	// Do second request with refreshed token
+	return authAndDoRequest(ctx, doer, req, autherWithRefresh)
+}
+
+func authAndDoRequest(ctx context.Context, doer httpcli.Doer, req *http.Request, autherWithRefresh auth.AuthenticatorWithRefresh) (resp *http.Response, err error) {
+	if err := autherWithRefresh.Authenticate(req); err != nil {
+		return nil, errors.Wrap(err, "could not authenticate request")
+	}
+
+	return doer.Do(req.WithContext(ctx))
 }

--- a/internal/oauthutil/oauth2.go
+++ b/internal/oauthutil/oauth2.go
@@ -81,9 +81,10 @@ func DoRequest(ctx context.Context, doer httpcli.Doer, req *http.Request, auther
 		if resp.StatusCode == http.StatusUnauthorized && autherWithRefresh != nil {
 			// If a refresher is present, we can then refresh the token and update the authenticator.
 			// The next request should then succeed.
-			err = autherWithRefresh.Refresh(ctx, doer)
-			if err != nil {
-				return resp, errors.Wrap(err, "unauthorized request and could not refresh token")
+			refreshErr := autherWithRefresh.Refresh(ctx, doer)
+			if refreshErr != nil {
+				// Return the response and error from the original request
+				return resp, err
 			}
 			continue
 		}

--- a/internal/oauthutil/oauth2.go
+++ b/internal/oauthutil/oauth2.go
@@ -81,11 +81,13 @@ func DoRequest(ctx context.Context, doer httpcli.Doer, req *http.Request, auther
 		if resp.StatusCode == http.StatusUnauthorized && autherWithRefresh != nil {
 			// If a refresher is present, we can then refresh the token and update the authenticator.
 			// The next request should then succeed.
-			refreshErr := autherWithRefresh.Refresh(ctx, doer)
-			if refreshErr != nil {
-				// Return the response and error from the original request
-				return resp, err
+			err = autherWithRefresh.Refresh(ctx, doer)
+			if err != nil {
+				// Return the response
+				return resp, nil
 			}
+
+			// Refresh successful, restart the loop
 			continue
 		}
 		return resp, nil

--- a/internal/oauthutil/oauth2_test.go
+++ b/internal/oauthutil/oauth2_test.go
@@ -84,17 +84,14 @@ func TestDoRequest(t *testing.T) {
 			var auther auth.Authenticator
 
 			if test.authToken != "" {
-				oauthToken := &auth.OAuthBearerToken{Token: test.authToken}
-
-				if test.refreshToken != "" {
-					oauthToken.RefreshToken = refreshToken
-					oauthToken.Expiry = time.Now().Add(time.Duration(test.expiresIn) * time.Minute)
-					oauthToken.RefreshFunc = func(_ context.Context, _ httpcli.Doer, _ *auth.OAuthBearerToken) (string, string, time.Time, error) {
+				auther = &auth.OAuthBearerToken{
+					Token:        test.authToken,
+					RefreshToken: test.refreshToken,
+					Expiry:       time.Now().Add(time.Duration(test.expiresIn) * time.Minute),
+					RefreshFunc: func(_ context.Context, _ httpcli.Doer, _ *auth.OAuthBearerToken) (string, string, time.Time, error) {
 						return refreshedAuthToken, "", time.Time{}, nil
-					}
+					},
 				}
-
-				auther = oauthToken
 			}
 
 			resp, err := DoRequest(ctx, logger, http.DefaultClient, req, auther)

--- a/internal/oauthutil/oauth2_test.go
+++ b/internal/oauthutil/oauth2_test.go
@@ -3,7 +3,7 @@ package oauthutil
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -102,7 +102,7 @@ func TestDoRequest(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/oauthutil/oauth2_test.go
+++ b/internal/oauthutil/oauth2_test.go
@@ -1,0 +1,116 @@
+package oauthutil
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+)
+
+func TestDoRequest(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+
+	authToken := "original-auth"
+	unauthedToken := "unauthed-token"
+	refreshToken := "refresh-token"
+	refreshedAuthToken := "refreshed-auth"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			w.Write([]byte("unauthed"))
+			return
+		}
+
+		if strings.HasSuffix(authHeader, unauthedToken) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		if strings.HasPrefix(authHeader, "Bearer ") {
+			w.Write([]byte(fmt.Sprintf("authed %s", strings.TrimPrefix(authHeader, "Bearer "))))
+			return
+		}
+	}))
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name         string
+		wantBody     string
+		authToken    string
+		refreshToken string
+		expiresIn    int // minutes til expiry
+	}{
+		{
+			name:     "unauthed request",
+			wantBody: "unauthed",
+		},
+		{
+			name:      "authed request no refresher",
+			wantBody:  fmt.Sprintf("authed %s", authToken),
+			authToken: authToken,
+		},
+		{
+			name:         "expired auth with refresher",
+			wantBody:     fmt.Sprintf("authed %s", refreshedAuthToken),
+			authToken:    authToken,
+			refreshToken: refreshToken,
+			expiresIn:    -20, // Expired 20 minutes ago
+		},
+		{
+			name:         "not expired but unauthed with refresher",
+			wantBody:     fmt.Sprintf("authed %s", refreshedAuthToken),
+			authToken:    unauthedToken,
+			refreshToken: refreshToken,
+			expiresIn:    20, // Expires in 20 minutes
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var auther auth.Authenticator
+
+			if test.authToken != "" {
+				oauthToken := &auth.OAuthBearerToken{Token: test.authToken}
+
+				if test.refreshToken != "" {
+					oauthToken.RefreshToken = refreshToken
+					oauthToken.Expiry = time.Now().Add(time.Duration(test.expiresIn) * time.Minute)
+					oauthToken.RefreshFunc = func(_ context.Context, _ httpcli.Doer, _ *auth.OAuthBearerToken) (string, string, time.Time, error) {
+						return refreshedAuthToken, "", time.Time{}, nil
+					}
+				}
+
+				auther = oauthToken
+			}
+
+			resp, err := DoRequest(ctx, logger, http.DefaultClient, req, auther)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			if string(body) != test.wantBody {
+				t.Fatalf("expected %q, got %q", test.wantBody, string(body))
+			}
+		})
+	}
+}


### PR DESCRIPTION
When a token refresh fails for whatever reason (such as the token not being refreshable to begin with), return the original error from the code host instead of mentioning refresh tokens.

The mention of refresh tokens causes a lot of confusion when the focus should be "the request is unauthorised".

Now users are shown the original error from the code host instead.

Before:
![image](https://user-images.githubusercontent.com/6427795/208892190-ebffb99d-2613-40fd-b391-6abead91c46c.png)

After:
<img width="900" alt="image" src="https://user-images.githubusercontent.com/6427795/208892153-968c3a0a-a201-4f61-bc1c-bec0be5b264f.png">

## Test plan

Same tests should still pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
