### PR TITLE
webhooks: Remove redundant naming

### DIFF
--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -107,7 +107,7 @@ type emptyWebhookHandler struct {
 	name string
 }
 
-func (e *emptyWebhookHandler) Register(w *webhooks.WebhookRouter) {}
+func (e *emptyWebhookHandler) Register(w *webhooks.Router) {}
 
 func (e *emptyWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	makeNotFoundHandler(e.name)

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -89,8 +89,8 @@ func NewHandler(
 		db.WebhookLogs(keyring.Default().WebhookLogKey),
 	)
 
-	wh := webhooks.WebhookRouter{
-		Logger: logger.Scoped("WebhookRouter", "handling webhook requests and dispatching them to handlers"),
+	wh := webhooks.Router{
+		Logger: logger.Scoped("Router", "handling webhook requests and dispatching them to handlers"),
 		DB:     db,
 	}
 	webhookhandlers.Init(&wh)
@@ -105,7 +105,7 @@ func NewHandler(
 	// 🚨 SECURITY: This handler implements its own secret-based auth
 	webhookHandler := webhooks.NewHandler(logger, db, &wh)
 
-	gitHubWebhook := webhooks.GitHubWebhook{WebhookRouter: &wh}
+	gitHubWebhook := webhooks.GitHubWebhook{Router: &wh}
 
 	// New UUID based webhook handler
 	m.Get(apirouter.Webhooks).Handler(trace.Route(webhookMiddleware.Logger(webhookHandler)))

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
@@ -22,8 +22,8 @@ import (
 
 // handleGithubRepoAuthzEvent handles any github event containing a repository field, and enqueues the contained
 // repo for permissions synchronisation.
-func handleGitHubRepoAuthzEvent(opts authz.FetchPermsOptions) webhooks.WebhookHandler {
-	return webhooks.WebhookHandler(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
+func handleGitHubRepoAuthzEvent(opts authz.FetchPermsOptions) webhooks.Handler {
+	return webhooks.Handler(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		if !conf.ExperimentalFeatures().EnablePermissionsWebhooks {
 			return nil
 		}

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
@@ -21,8 +21,8 @@ import (
 
 // handleGitHubUserAuthzEvent handles a github webhook for the events described in webhookhandlers/handlers.go
 // extracting a user from the github event and scheduling it for a perms update in repo-updater
-func handleGitHubUserAuthzEvent(opts authz.FetchPermsOptions) webhooks.WebhookHandler {
-	return webhooks.WebhookHandler(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
+func handleGitHubUserAuthzEvent(opts authz.FetchPermsOptions) webhooks.Handler {
+	return webhooks.Handler(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		if !conf.ExperimentalFeatures().EnablePermissionsWebhooks {
 			return nil
 		}

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handlers.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handlers.go
@@ -5,7 +5,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 )
 
-func Init(w *webhooks.WebhookRouter) {
+func Init(w *webhooks.Router) {
 	// Refer to https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads
 	// for event types
 

--- a/cmd/frontend/webhooks/bitbucketcloud_webhooks.go
+++ b/cmd/frontend/webhooks/bitbucketcloud_webhooks.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func (wr *WebhookRouter) HandleBitbucketCloudWebhook(logger log.Logger, w http.ResponseWriter, r *http.Request, codeHostURN extsvc.CodeHostBaseURL) {
+func (wr *Router) HandleBitbucketCloudWebhook(logger log.Logger, w http.ResponseWriter, r *http.Request, codeHostURN extsvc.CodeHostBaseURL) {
 	payload, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Error while reading request body.", http.StatusInternalServerError)

--- a/cmd/frontend/webhooks/bitbucketserver_webhooks.go
+++ b/cmd/frontend/webhooks/bitbucketserver_webhooks.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func (wr *WebhookRouter) HandleBitBucketServerWebhook(logger log.Logger, w http.ResponseWriter, r *http.Request, codeHostURN extsvc.CodeHostBaseURL, payload []byte) {
+func (wr *Router) HandleBitBucketServerWebhook(logger log.Logger, w http.ResponseWriter, r *http.Request, codeHostURN extsvc.CodeHostBaseURL, payload []byte) {
 	// 🚨 SECURITY: now that the shared secret has been validated, we can use an
 	// internal actor on the context.
 	ctx := actor.WithInternalActor(r.Context())
@@ -46,7 +46,7 @@ func parseBitbucketServerEvent(r *http.Request, payload []byte) (any, string, er
 	return e, eventType, nil
 }
 
-func (wr *WebhookRouter) handleBitbucketServerWebhook(logger log.Logger, w http.ResponseWriter, r *http.Request, urn extsvc.CodeHostBaseURL, secret string) {
+func (wr *Router) handleBitbucketServerWebhook(logger log.Logger, w http.ResponseWriter, r *http.Request, urn extsvc.CodeHostBaseURL, secret string) {
 	payload, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Error while reading request body.", http.StatusInternalServerError)

--- a/cmd/frontend/webhooks/github_webhooks.go
+++ b/cmd/frontend/webhooks/github_webhooks.go
@@ -22,7 +22,7 @@ import (
 )
 
 type GitHubWebhook struct {
-	*WebhookRouter
+	*Router
 }
 
 func (h *GitHubWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/cmd/frontend/webhooks/github_webhooks_test.go
+++ b/cmd/frontend/webhooks/github_webhooks_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestGithubWebhookDispatchSuccess(t *testing.T) {
-	h := GitHubWebhook{WebhookRouter: &WebhookRouter{}}
+	h := GitHubWebhook{Router: &Router{}}
 	var called bool
 	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
 		called = true
@@ -46,7 +46,7 @@ func TestGithubWebhookDispatchSuccess(t *testing.T) {
 
 func TestGithubWebhookDispatchNoHandler(t *testing.T) {
 	logger := logtest.Scoped(t)
-	h := GitHubWebhook{WebhookRouter: &WebhookRouter{Logger: logger}}
+	h := GitHubWebhook{Router: &Router{Logger: logger}}
 	ctx := context.Background()
 
 	eventType := "test-event-1"
@@ -56,7 +56,7 @@ func TestGithubWebhookDispatchNoHandler(t *testing.T) {
 
 func TestGithubWebhookDispatchSuccessMultiple(t *testing.T) {
 	var (
-		h      = GitHubWebhook{WebhookRouter: &WebhookRouter{}}
+		h      = GitHubWebhook{Router: &Router{}}
 		called = make(chan struct{}, 2)
 	)
 	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
@@ -79,7 +79,7 @@ func TestGithubWebhookDispatchSuccessMultiple(t *testing.T) {
 
 func TestGithubWebhookDispatchError(t *testing.T) {
 	var (
-		h      = GitHubWebhook{WebhookRouter: &WebhookRouter{}}
+		h      = GitHubWebhook{Router: &Router{}}
 		called = make(chan struct{}, 2)
 	)
 	h.Register(func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
@@ -152,7 +152,7 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 	}
 
 	hook := GitHubWebhook{
-		WebhookRouter: &WebhookRouter{
+		Router: &Router{
 			DB: db,
 		},
 	}

--- a/cmd/frontend/webhooks/gitlab_webhooks.go
+++ b/cmd/frontend/webhooks/gitlab_webhooks.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func (wr *WebhookRouter) HandleGitLabWebhook(ctx context.Context, logger log.Logger, w http.ResponseWriter, codeHostURN extsvc.CodeHostBaseURL, payload []byte) {
+func (wr *Router) HandleGitLabWebhook(ctx context.Context, logger log.Logger, w http.ResponseWriter, codeHostURN extsvc.CodeHostBaseURL, payload []byte) {
 	// 🚨 SECURITY: now that the shared secret has been validated, we can use an
 	// internal actor on the context.
 	ctx = actor.WithInternalActor(ctx)
@@ -73,7 +73,7 @@ func gitlabValidatePayload(r *http.Request, secret string) ([]byte, error) {
 	return body, errors.Wrap(r.Body.Close(), "closing body")
 }
 
-func (wr *WebhookRouter) handleGitLabWebHook(logger log.Logger, w http.ResponseWriter, r *http.Request, urn extsvc.CodeHostBaseURL, secret string) {
+func (wr *Router) handleGitLabWebHook(logger log.Logger, w http.ResponseWriter, r *http.Request, urn extsvc.CodeHostBaseURL, secret string) {
 	if secret == "" {
 		payload, err := io.ReadAll(r.Body)
 		if err != nil {

--- a/cmd/frontend/webhooks/webhooks_test.go
+++ b/cmd/frontend/webhooks/webhooks_test.go
@@ -88,15 +88,15 @@ func TestWebhooksHandler(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	wr := WebhookRouter{Logger: logger, DB: db}
-	gwh := GitHubWebhook{WebhookRouter: &wr}
+	wr := Router{Logger: logger, DB: db}
+	gwh := GitHubWebhook{Router: &wr}
 
 	webhookMiddleware := NewLogMiddleware(
 		db.WebhookLogs(keyring.Default().WebhookLogKey),
 	)
 
 	base := mux.NewRouter()
-	base.Path("/.api/webhooks/{webhook_uuid}").Methods("POST").Handler(webhookMiddleware.Logger(NewHandler(logger, db, gwh.WebhookRouter)))
+	base.Path("/.api/webhooks/{webhook_uuid}").Methods("POST").Handler(webhookMiddleware.Logger(NewHandler(logger, db, gwh.Router)))
 	srv := httptest.NewServer(base)
 
 	t.Run("ping event from Github returns 200", func(t *testing.T) {
@@ -124,9 +124,9 @@ func TestWebhooksHandler(t *testing.T) {
 			ObjectKind: "pipeline",
 		}
 		wh := &fakeWebhookHandler{}
-		wr.handlers = map[string]webhookEventHandlers{
+		wr.handlers = map[string]eventHandlers{
 			extsvc.KindGitLab: {
-				"pipeline": []WebhookHandler{wh.handleEvent},
+				"pipeline": []Handler{wh.handleEvent},
 			},
 		}
 		payload, err := json.Marshal(event)
@@ -186,9 +186,9 @@ func TestWebhooksHandler(t *testing.T) {
 		res := h.Sum(nil)
 
 		wh := &fakeWebhookHandler{}
-		wr.handlers = map[string]webhookEventHandlers{
+		wr.handlers = map[string]eventHandlers{
 			extsvc.KindGitHub: {
-				"member": []WebhookHandler{wh.handleEvent},
+				"member": []Handler{wh.handleEvent},
 			},
 		}
 
@@ -226,7 +226,7 @@ func TestWebhooksHandler(t *testing.T) {
 		h.Write(payload)
 		res := h.Sum(nil)
 
-		wr.handlers = map[string]webhookEventHandlers{}
+		wr.handlers = map[string]eventHandlers{}
 
 		req, err := http.NewRequest("POST", requestURL, bytes.NewBuffer(payload))
 		require.NoError(t, err)
@@ -246,9 +246,9 @@ func TestWebhooksHandler(t *testing.T) {
 		payload := []byte(`{"body": "text"}`)
 
 		wh := &fakeWebhookHandler{}
-		wr.handlers = map[string]webhookEventHandlers{
+		wr.handlers = map[string]eventHandlers{
 			extsvc.KindGitHub: {
-				"member": []WebhookHandler{wh.handleEvent},
+				"member": []Handler{wh.handleEvent},
 			},
 		}
 
@@ -294,9 +294,9 @@ func TestWebhooksHandler(t *testing.T) {
 		res := h.Sum(nil)
 
 		wh := &fakeWebhookHandler{}
-		wr.handlers = map[string]webhookEventHandlers{
+		wr.handlers = map[string]eventHandlers{
 			extsvc.KindBitbucketServer: {
-				"ping": []WebhookHandler{wh.handleEvent},
+				"ping": []Handler{wh.handleEvent},
 			},
 		}
 
@@ -351,9 +351,9 @@ func TestWebhooksHandler(t *testing.T) {
 		payload, err := json.Marshal(event)
 		require.NoError(t, err)
 		wh := &fakeWebhookHandler{}
-		wr.handlers = map[string]webhookEventHandlers{
+		wr.handlers = map[string]eventHandlers{
 			extsvc.KindBitbucketCloud: {
-				"pullrequest:comment_created": []WebhookHandler{wh.handleEvent},
+				"pullrequest:comment_created": []Handler{wh.handleEvent},
 			},
 		}
 

--- a/enterprise/cmd/frontend/internal/authz/webhooks/github.go
+++ b/enterprise/cmd/frontend/internal/authz/webhooks/github.go
@@ -37,7 +37,7 @@ func NewGitHubWebhook(logger log.Logger) *GitHubWebhook {
 	return &GitHubWebhook{logger: logger}
 }
 
-func (h *GitHubWebhook) Register(router *webhooks.WebhookRouter) {
+func (h *GitHubWebhook) Register(router *webhooks.Router) {
 	router.Register(
 		h.handleGitHubWebhook,
 		extsvc.KindGitHub,

--- a/enterprise/cmd/frontend/internal/authz/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/authz/webhooks/github_test.go
@@ -113,8 +113,8 @@ func TestGitHubWebhooks(t *testing.T) {
 	wh, err := whStore.Create(ctx, "test-webhook", extsvc.KindGitHub, "https://github.com", u.ID, nil)
 	require.NoError(t, err)
 
-	hook := fewebhooks.GitHubWebhook{WebhookRouter: &fewebhooks.WebhookRouter{DB: db}}
-	ghWebhook.Register(hook.WebhookRouter)
+	hook := fewebhooks.GitHubWebhook{Router: &fewebhooks.Router{DB: db}}
+	ghWebhook.Register(hook.Router)
 
 	newReq := func(t *testing.T, eventType string, event any) *http.Request {
 		t.Helper()

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud.go
@@ -48,7 +48,7 @@ func NewBitbucketCloudWebhook(store *store.Store, gitserverClient gitserver.Clie
 	}
 }
 
-func (h *BitbucketCloudWebhook) Register(router *fewebhooks.WebhookRouter) {
+func (h *BitbucketCloudWebhook) Register(router *fewebhooks.Router) {
 	router.Register(
 		h.handleEvent,
 		extsvc.KindBitbucketCloud,

--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketserver.go
@@ -44,7 +44,7 @@ func NewBitbucketServerWebhook(store *store.Store, gitserverClient gitserver.Cli
 	}
 }
 
-func (h *BitbucketServerWebhook) Register(router *fewebhooks.WebhookRouter) {
+func (h *BitbucketServerWebhook) Register(router *fewebhooks.Router) {
 	router.Register(
 		h.handleEvent,
 		extsvc.KindBitbucketServer,

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github.go
@@ -45,7 +45,7 @@ func NewGitHubWebhook(store *store.Store, gitserverClient gitserver.Client, logg
 }
 
 // Register registers this webhook handler to handle events with the passed webhook router
-func (h *GitHubWebhook) Register(router *webhooks.WebhookRouter) {
+func (h *GitHubWebhook) Register(router *webhooks.Router) {
 	router.Register(
 		h.handleGitHubWebhook,
 		extsvc.KindGitHub,

--- a/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/github_test.go
@@ -186,11 +186,11 @@ func testGitHubWebhook(db database.DB, userID int32) func(*testing.T) {
 				for i := 0; i < 2; i++ {
 					for _, event := range tc.Payloads {
 						handler := webhooks.GitHubWebhook{
-							WebhookRouter: &webhooks.WebhookRouter{
+							Router: &webhooks.Router{
 								DB: db,
 							},
 						}
-						hook.Register(handler.WebhookRouter)
+						hook.Register(handler.Router)
 
 						u, err := extsvc.WebhookURL(extsvc.TypeGitHub, extSvc.ID, nil, "https://example.com/")
 						if err != nil {

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab.go
@@ -41,7 +41,7 @@ func NewGitLabWebhook(store *store.Store, gitserverClient gitserver.Client, logg
 	return &GitLabWebhook{webhook: &webhook{store, gitserverClient, logger, extsvc.TypeGitLab}}
 }
 
-func (h *GitLabWebhook) Register(router *fewebhooks.WebhookRouter) {
+func (h *GitLabWebhook) Register(router *fewebhooks.Router) {
 	router.Register(
 		h.handleEvent,
 		extsvc.KindGitLab,

--- a/enterprise/cmd/frontend/internal/repos/init.go
+++ b/enterprise/cmd/frontend/internal/repos/init.go
@@ -21,8 +21,8 @@ func Init(
 	_ conftypes.UnifiedWatchable,
 	enterpriseServices *enterprise.Services,
 ) error {
-	enterpriseServices.GitHubSyncWebhook = webhooks.NewGitHubWebhookHandler()
-	enterpriseServices.GitLabSyncWebhook = webhooks.NewGitLabWebhookHandler()
+	enterpriseServices.GitHubSyncWebhook = webhooks.NewGitHubHandler()
+	enterpriseServices.GitLabSyncWebhook = webhooks.NewGitLabHandler()
 	enterpriseServices.WebhooksResolver = resolvers.NewWebhooksResolver(db)
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/repos/webhooks/github_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/github_handler.go
@@ -17,23 +17,23 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-type GitHubWebhookHandler struct {
+type GitHubHandler struct {
 	logger log.Logger
 }
 
-func (g *GitHubWebhookHandler) Register(router *webhooks.WebhookRouter) {
+func (g *GitHubHandler) Register(router *webhooks.WebhookRouter) {
 	router.Register(func(ctx context.Context, _ database.DB, _ extsvc.CodeHostBaseURL, payload any) error {
 		return g.handlePushEvent(ctx, payload)
 	}, extsvc.KindGitHub, "push")
 }
 
-func NewGitHubWebhookHandler() *GitHubWebhookHandler {
-	return &GitHubWebhookHandler{
-		logger: log.Scoped("repos.GitHubWebhookHandler", "github webhook handler"),
+func NewGitHubHandler() *GitHubHandler {
+	return &GitHubHandler{
+		logger: log.Scoped("webhooks.GitHubHandler", "github webhook handler"),
 	}
 }
 
-func (g *GitHubWebhookHandler) handlePushEvent(ctx context.Context, payload any) error {
+func (g *GitHubHandler) handlePushEvent(ctx context.Context, payload any) error {
 	event, ok := payload.(*gh.PushEvent)
 	if !ok {
 		return errors.Newf("expected GitHub.PushEvent, got %T", payload)

--- a/enterprise/cmd/frontend/internal/repos/webhooks/github_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/github_handler.go
@@ -21,7 +21,7 @@ type GitHubHandler struct {
 	logger log.Logger
 }
 
-func (g *GitHubHandler) Register(router *webhooks.WebhookRouter) {
+func (g *GitHubHandler) Register(router *webhooks.Router) {
 	router.Register(func(ctx context.Context, _ database.DB, _ extsvc.CodeHostBaseURL, payload any) error {
 		return g.handlePushEvent(ctx, payload)
 	}, extsvc.KindGitHub, "push")

--- a/enterprise/cmd/frontend/internal/repos/webhooks/github_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/github_handler_test.go
@@ -74,11 +74,11 @@ func TestGitHubWebhookHandle(t *testing.T) {
 
 	handler := NewGitHubHandler()
 	router := &webhooks.GitHubWebhook{
-		WebhookRouter: &webhooks.WebhookRouter{
+		Router: &webhooks.Router{
 			DB: db,
 		},
 	}
-	handler.Register(router.WebhookRouter)
+	handler.Register(router.Router)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/enqueue-repo-update", func(w http.ResponseWriter, r *http.Request) {

--- a/enterprise/cmd/frontend/internal/repos/webhooks/github_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/github_handler_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-func TestGitHubWebhookHandle(t *testing.T) {
+func TestGitHubHandler(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 

--- a/enterprise/cmd/frontend/internal/repos/webhooks/github_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/github_handler_test.go
@@ -72,7 +72,7 @@ func TestGitHubWebhookHandle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	handler := NewGitHubWebhookHandler()
+	handler := NewGitHubHandler()
 	router := &webhooks.GitHubWebhook{
 		WebhookRouter: &webhooks.WebhookRouter{
 			DB: db,

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler.go
@@ -16,23 +16,23 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-type GitLabWebhookHandler struct {
+type GitLabHandler struct {
 	logger log.Logger
 }
 
-func (g *GitLabWebhookHandler) Register(router *webhooks.WebhookRouter) {
+func (g *GitLabHandler) Register(router *webhooks.WebhookRouter) {
 	router.Register(func(ctx context.Context, _ database.DB, _ extsvc.CodeHostBaseURL, payload any) error {
 		return g.handlePushEvent(ctx, payload)
 	}, extsvc.KindGitLab, "push")
 }
 
-func NewGitLabWebhookHandler() *GitLabWebhookHandler {
-	return &GitLabWebhookHandler{
-		logger: log.Scoped("repos.GitLabWebhookHandler", "gitlab webhook handler"),
+func NewGitLabHandler() *GitLabHandler {
+	return &GitLabHandler{
+		logger: log.Scoped("webhooks.GitLabHandler", "gitlab webhook handler"),
 	}
 }
 
-func (g *GitLabWebhookHandler) handlePushEvent(ctx context.Context, payload any) error {
+func (g *GitLabHandler) handlePushEvent(ctx context.Context, payload any) error {
 	event, ok := payload.(*gitlabwebhooks.PushEvent)
 	if !ok {
 		return errors.Newf("expected GitLab.PushEvent, got %T", payload)
@@ -50,7 +50,7 @@ func (g *GitLabWebhookHandler) handlePushEvent(ctx context.Context, payload any)
 			g.logger.Warn("GitLab push webhook received for unknown repo", log.String("repo", string(repoName)))
 			return nil
 		}
-		return errors.Wrap(err, "handleGitLabWebhook: EnqueueRepoUpdate failed")
+		return errors.Wrap(err, "handlePushEvent: EnqueueRepoUpdate failed")
 	}
 
 	g.logger.Info("successfully updated", log.String("name", resp.Name))

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler.go
@@ -20,7 +20,7 @@ type GitLabHandler struct {
 	logger log.Logger
 }
 
-func (g *GitLabHandler) Register(router *webhooks.WebhookRouter) {
+func (g *GitLabHandler) Register(router *webhooks.Router) {
 	router.Register(func(ctx context.Context, _ database.DB, _ extsvc.CodeHostBaseURL, payload any) error {
 		return g.handlePushEvent(ctx, payload)
 	}, extsvc.KindGitLab, "push")

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func TestGitLabWebhookHandle(t *testing.T) {
+func TestGitLabHandler(t *testing.T) {
 	repoName := "gitlab.com/ryanslade/ryan-test-private"
 	handler := NewGitLabHandler()
 	data, err := os.ReadFile("testdata/gitlab-push.json")

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestGitLabWebhookHandle(t *testing.T) {
 	repoName := "gitlab.com/ryanslade/ryan-test-private"
-	handler := NewGitLabWebhookHandler()
+	handler := NewGitLabHandler()
 	data, err := os.ReadFile("testdata/gitlab-push.json")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Remove redundant `webhook` in method and type names when they are already in `webhook` or `webhooks` packages.

## Test plan

Mechanical change using GoLand rename feature. All existing tests pass.