### PR TITLE
internal/repos: Implement connectionCheck

### DIFF
--- a/internal/repos/bitbucketcloud.go
+++ b/internal/repos/bitbucketcloud.go
@@ -80,11 +80,8 @@ func newBitbucketCloudSource(logger log.Logger, svc *types.ExternalService, c *s
 	}, nil
 }
 
-// CheckConnection at this point assumes availability and relies on errors returned
-// from the subsequent calls. This is going to be expanded as part of issue #44683
-// to actually only return true if the source can serve requests.
 func (s BitbucketCloudSource) CheckConnection(ctx context.Context) error {
-	return nil
+	return checkConnection(s.config.Url)
 }
 
 // ListRepos returns all Bitbucket Cloud repositories accessible to all connections configured

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -89,11 +89,8 @@ func newBitbucketServerSource(logger log.Logger, svc *types.ExternalService, c *
 	}, nil
 }
 
-// CheckConnection at this point assumes availability and relies on errors returned
-// from the subsequent calls. This is going to be expanded as part of issue #44683
-// to actually only return true if the source can serve requests.
 func (s BitbucketServerSource) CheckConnection(ctx context.Context) error {
-	return nil
+	return checkConnection(s.config.Url)
 }
 
 // ListRepos returns all BitbucketServer repositories accessible to all connections configured

--- a/internal/repos/check_connection.go
+++ b/internal/repos/check_connection.go
@@ -16,7 +16,7 @@ import (
 func checkConnection(rawURL string) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return errors.Wrap(err, "connection check failed")
+		return errors.Wrap(err, "invalid or bad url for connection check")
 	}
 
 	// Best effort at finding a hostname. For example if rawURL is sourcegraph.com, then u.Host is

--- a/internal/repos/check_connection.go
+++ b/internal/repos/check_connection.go
@@ -7,10 +7,16 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+// checkConnection will parse the rawURL and make a best effort attempt to obtain a hostname. It
+// then performs an IP lookup on that hostname and will return a non-nil error on failure.
+//
+// At the moment this function is only limited to doing IP lookups. We may want / have to expand
+// this to support other code hosts or to add more checks (example making a test API call to verify
+// the authorization etc)
 func checkConnection(rawURL string) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "connection check failed")
 	}
 
 	// Best effort at finding a hostname. For example if rawURL is sourcegraph.com, then u.Host is
@@ -18,18 +24,18 @@ func checkConnection(rawURL string) error {
 	//
 	// 👉 Also, we need to use u.Hostname() here because we want to strip any port numbers if they
 	// are present in u.Host.
-	addr := u.Hostname()
-	if addr == "" {
-		addr = u.Path
+	hostname := u.Hostname()
+	if hostname == "" {
+		hostname = u.Path
 	}
 
-	ips, err := net.LookupIP(addr)
+	ips, err := net.LookupIP(hostname)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "connection check failed")
 	}
 
 	if len(ips) == 0 {
-		return errors.Newf("no IPs found for: %q", addr)
+		return errors.Newf("connection check failed, no IP addresses found for hostname %q", hostname)
 	}
 
 	return nil

--- a/internal/repos/check_connection.go
+++ b/internal/repos/check_connection.go
@@ -1,0 +1,36 @@
+package repos
+
+import (
+	"net"
+	"net/url"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func checkConnection(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return err
+	}
+
+	// Best effort at finding a hostname. For example if rawURL is sourcegraph.com, then u.Host is
+	// empty but Path is sourcegraph.com. Use that as a result.
+	//
+	// 👉 Also, we need to use u.Hostname() here because we want to strip any port numbers if they
+	// are present in u.Host.
+	addr := u.Hostname()
+	if addr == "" {
+		addr = u.Path
+	}
+
+	ips, err := net.LookupIP(addr)
+	if err != nil {
+		return err
+	}
+
+	if len(ips) == 0 {
+		return errors.Newf("no IPs found for: %q", addr)
+	}
+
+	return nil
+}

--- a/internal/repos/check_connection_test.go
+++ b/internal/repos/check_connection_test.go
@@ -2,7 +2,7 @@ package repos
 
 import "testing"
 
-func TestIpLookup(t *testing.T) {
+func TestCheckConnection(t *testing.T) {
 	t.Run("bad URL", func(t *testing.T) {
 		if err := checkConnection("foo"); err == nil {
 			t.Error("Expected error but got nil")

--- a/internal/repos/check_connection_test.go
+++ b/internal/repos/check_connection_test.go
@@ -26,6 +26,7 @@ func TestCheckConnection(t *testing.T) {
 			t.Errorf("Expected nil but got error: %v", err)
 		}
 	})
+
 	t.Run("good URL with username:password", func(t *testing.T) {
 		if err := checkConnection("https://username:password@sourcegraph.com"); err != nil {
 			t.Errorf("Expected nil but got error: %v", err)

--- a/internal/repos/check_connection_test.go
+++ b/internal/repos/check_connection_test.go
@@ -1,0 +1,34 @@
+package repos
+
+import "testing"
+
+func TestIpLookup(t *testing.T) {
+	t.Run("bad URL", func(t *testing.T) {
+		if err := checkConnection("foo"); err == nil {
+			t.Error("Expected error but got nil")
+		}
+	})
+
+	t.Run("good URL", func(t *testing.T) {
+		if err := checkConnection("https://sourcegraph.com"); err != nil {
+			t.Errorf("Expected nil but got error: %v", err)
+		}
+	})
+
+	t.Run("good URL with port", func(t *testing.T) {
+		if err := checkConnection("https://sourcegraph.com:80"); err != nil {
+			t.Errorf("Expected nil but got error: %v", err)
+		}
+	})
+
+	t.Run("good URL without protocol", func(t *testing.T) {
+		if err := checkConnection("sourcegraph.com"); err != nil {
+			t.Errorf("Expected nil but got error: %v", err)
+		}
+	})
+	t.Run("good URL with username:password protocol", func(t *testing.T) {
+		if err := checkConnection("https://username:password@sourcegraph.com"); err != nil {
+			t.Errorf("Expected nil but got error: %v", err)
+		}
+	})
+}

--- a/internal/repos/check_connection_test.go
+++ b/internal/repos/check_connection_test.go
@@ -26,7 +26,7 @@ func TestCheckConnection(t *testing.T) {
 			t.Errorf("Expected nil but got error: %v", err)
 		}
 	})
-	t.Run("good URL with username:password protocol", func(t *testing.T) {
+	t.Run("good URL with username:password", func(t *testing.T) {
 		if err := checkConnection("https://username:password@sourcegraph.com"); err != nil {
 			t.Errorf("Expected nil but got error: %v", err)
 		}

--- a/internal/repos/check_connection_test.go
+++ b/internal/repos/check_connection_test.go
@@ -27,6 +27,12 @@ func TestCheckConnection(t *testing.T) {
 		}
 	})
 
+	t.Run("good URL with port but without protocol", func(t *testing.T) {
+		if err := checkConnection("sourcegraph.com:80"); err != nil {
+			t.Errorf("Expected nil but got error: %v", err)
+		}
+	})
+
 	t.Run("good URL with username:password", func(t *testing.T) {
 		if err := checkConnection("https://username:password@sourcegraph.com"); err != nil {
 			t.Errorf("Expected nil but got error: %v", err)

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -261,11 +261,8 @@ func (s *GitHubSource) Version(ctx context.Context) (string, error) {
 	return s.v3Client.GetVersion(ctx)
 }
 
-// CheckConnection at this point assumes availability and relies on errors returned
-// from the subsequent calls. This is going to be expanded as part of issue #44683
-// to actually only return true if the source can serve requests.
 func (s *GitHubSource) CheckConnection(ctx context.Context) error {
-	return nil
+	return checkConnection(s.config.Url)
 }
 
 // ListRepos returns all Github repositories accessible to all connections configured

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -161,11 +161,8 @@ func (s GitLabSource) ValidateAuthenticator(ctx context.Context) error {
 	return s.client.ValidateToken(ctx)
 }
 
-// CheckConnection at this point assumes availability and relies on errors returned
-// from the subsequent calls. This is going to be expanded as part of issue #44683
-// to actually only return true if the source can serve requests.
 func (s GitLabSource) CheckConnection(ctx context.Context) error {
-	return nil
+	return checkConnection(s.config.Url)
 }
 
 // ListRepos returns all GitLab repositories accessible to all connections configured


### PR DESCRIPTION
Part of #44683. 

This commit adds a connection check for the following code hosts:

1. Bitbucket cloud
2. Bitbucket server
3. GitHub
4. Gitlab


## Test plan

1. Added tests
2. Tested locally
3. Build should pass
4. [main-dry-run](https://github.com/sourcegraph/sourcegraph/tree/main-dry-run/ig/connection-check) should pass

**Connection check fails**
<img width="2056" alt="image" src="https://user-images.githubusercontent.com/2682729/208900825-aa74a2af-3d95-4005-a5f9-51ebed52cf37.png">


**Connection check passes**
<img width="2056" alt="image" src="https://user-images.githubusercontent.com/2682729/208900673-946631ec-2341-485d-b10e-417f104014b6.png">



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
