### PR TITLE
debt: make `authz.SubRepoPermissionChecker` a second parameter of all gitserver client methods.

### DIFF
--- a/cmd/frontend/backend/inventory.go
+++ b/cmd/frontend/backend/inventory.go
@@ -50,7 +50,7 @@ func InventoryContext(logger log.Logger, repo api.RepoName, gsClient gitserver.C
 			return gsClient.ReadDir(ctx, authz.DefaultSubRepoPermsChecker, repo, commitID, path, false)
 		},
 		NewFileReader: func(ctx context.Context, path string) (io.ReadCloser, error) {
-			return gsClient.NewFileReader(ctx, repo, commitID, path, authz.DefaultSubRepoPermsChecker)
+			return gsClient.NewFileReader(ctx, authz.DefaultSubRepoPermsChecker, repo, commitID, path)
 		},
 		CacheGet: func(e fs.FileInfo) (inventory.Inventory, bool) {
 			cacheKey := cacheKey(e)

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -316,7 +316,7 @@ func (s *repos) GetCommit(ctx context.Context, repo *types.Repo, commitID api.Co
 		return nil, errors.Errorf("non-absolute CommitID for Repos.GetCommit: %v", commitID)
 	}
 
-	return s.gitserverClient.GetCommit(ctx, repo.Name, commitID, gitserver.ResolveRevisionOptions{}, authz.DefaultSubRepoPermsChecker)
+	return s.gitserverClient.GetCommit(ctx, authz.DefaultSubRepoPermsChecker, repo.Name, commitID, gitserver.ResolveRevisionOptions{})
 }
 
 // ErrRepoSeeOther indicates that the repo does not exist on this server but might exist on an external Sourcegraph

--- a/cmd/frontend/backend/repos_test.go
+++ b/cmd/frontend/backend/repos_test.go
@@ -179,7 +179,7 @@ func TestReposGetInventory(t *testing.T) {
 			panic("unhandled mock ReadDir " + name)
 		}
 	})
-	gitserverClient.NewFileReaderFunc.SetDefaultHook(func(_ context.Context, _ api.RepoName, commit api.CommitID, name string, _ authz.SubRepoPermissionChecker) (io.ReadCloser, error) {
+	gitserverClient.NewFileReaderFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, commit api.CommitID, name string) (io.ReadCloser, error) {
 		if commit != wantCommitID {
 			t.Errorf("got commit %q, want %q", commit, wantCommitID)
 		}

--- a/cmd/frontend/backend/repos_vcs_test.go
+++ b/cmd/frontend/backend/repos_vcs_test.go
@@ -195,7 +195,7 @@ func TestRepos_GetCommit_repoupdaterError(t *testing.T) {
 	var calledVCSRepoGetCommit bool
 
 	gsClient := gitserver.NewMockClient()
-	gsClient.GetCommitFunc.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, gitserver.ResolveRevisionOptions, authz.SubRepoPermissionChecker) (*gitdomain.Commit, error) {
+	gsClient.GetCommitFunc.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, gitserver.ResolveRevisionOptions) (*gitdomain.Commit, error) {
 		calledVCSRepoGetCommit = true
 		return &gitdomain.Commit{ID: want}, nil
 	})

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -91,12 +91,12 @@ func (r *GitCommitResolver) resolveCommit(ctx context.Context) (*gitdomain.Commi
 		}
 
 		opts := gitserver.ResolveRevisionOptions{}
-		r.commit, r.commitErr = r.gitserverClient.GetCommit(ctx, r.gitRepo, api.CommitID(r.oid), opts, authz.DefaultSubRepoPermsChecker)
+		r.commit, r.commitErr = r.gitserverClient.GetCommit(ctx, authz.DefaultSubRepoPermsChecker, r.gitRepo, api.CommitID(r.oid), opts)
 	})
 	return r.commit, r.commitErr
 }
 
-// gitCommitGQLID is a type used for marshaling and unmarshaling a Git commit's
+// gitCommitGQLID is a type used for marshaling and unmarshalling a Git commit's
 // GraphQL ID.
 type gitCommitGQLID struct {
 	Repository graphql.ID  `json:"r"`

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -63,7 +63,7 @@ func TestGitCommitResolver(t *testing.T) {
 
 	t.Run("Lazy loading", func(t *testing.T) {
 		client := gitserver.NewMockClient()
-		client.GetCommitFunc.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, gitserver.ResolveRevisionOptions, authz.SubRepoPermissionChecker) (*gitdomain.Commit, error) {
+		client.GetCommitFunc.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, gitserver.ResolveRevisionOptions) (*gitdomain.Commit, error) {
 			return commit, nil
 		})
 
@@ -226,9 +226,9 @@ func TestGitCommitAncestors(t *testing.T) {
 
 	client.CommitsFunc.SetDefaultHook(func(
 		ctx context.Context,
+		authz authz.SubRepoPermissionChecker,
 		repo api.RepoName,
-		opt gitserver.CommitsOptions,
-		authz authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error) {
+		opt gitserver.CommitsOptions) ([]*gitdomain.Commit, error) {
 
 		// Offset the returned list of commits based on the value of the Skip option.
 		return commits[opt.Skip:], nil

--- a/cmd/frontend/graphqlbackend/git_commits.go
+++ b/cmd/frontend/graphqlbackend/git_commits.go
@@ -75,7 +75,7 @@ func (r *gitCommitConnectionResolver) compute(ctx context.Context) ([]*gitdomain
 			return []*gitdomain.Commit{}, errors.Wrap(err, "failed to parse afterCursor")
 		}
 
-		return r.gitserverClient.Commits(ctx, r.repo.RepoName(), gitserver.CommitsOptions{
+		return r.gitserverClient.Commits(ctx, authz.DefaultSubRepoPermsChecker, r.repo.RepoName(), gitserver.CommitsOptions{
 			Range:        r.revisionRange,
 			N:            uint(n),
 			MessageQuery: toValue(r.query).(string),
@@ -83,7 +83,7 @@ func (r *gitCommitConnectionResolver) compute(ctx context.Context) ([]*gitdomain
 			After:        toValue(r.after).(string),
 			Skip:         uint(afterCursor),
 			Path:         toValue(r.path).(string),
-		}, authz.DefaultSubRepoPermsChecker)
+		})
 	}
 
 	r.once.Do(func() { r.commits, r.err = do() })

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -80,10 +80,10 @@ func (r *GitTreeEntryResolver) Content(ctx context.Context) (string, error) {
 
 		r.content, r.contentErr = r.gitserverClient.ReadFile(
 			ctx,
+			authz.DefaultSubRepoPermsChecker,
 			r.commit.repoResolver.RepoName(),
 			api.CommitID(r.commit.OID()),
 			r.Path(),
-			authz.DefaultSubRepoPermsChecker,
 		)
 	})
 

--- a/cmd/frontend/graphqlbackend/git_tree_entry_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry_test.go
@@ -35,7 +35,7 @@ func TestGitTreeEntry_Content(t *testing.T) {
 	db := database.NewMockDB()
 	gitserverClient := gitserver.NewMockClient()
 
-	gitserverClient.ReadFileFunc.SetDefaultHook(func(_ context.Context, _ api.RepoName, _ api.CommitID, name string, _ authz.SubRepoPermissionChecker) ([]byte, error) {
+	gitserverClient.ReadFileFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, _ api.CommitID, name string) ([]byte, error) {
 		if name != wantPath {
 			t.Fatalf("wrong name in ReadFile call. want=%q, have=%q", wantPath, name)
 		}

--- a/cmd/frontend/graphqlbackend/preview_repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/preview_repository_comparison_test.go
@@ -240,7 +240,7 @@ index 9bd8209..d2acfa9 100644
 		}
 		fileDiff := fileDiffs[0]
 
-		gitserverClient.ReadFileFunc.SetDefaultHook(func(_ context.Context, _ api.RepoName, _ api.CommitID, name string, _ authz.SubRepoPermissionChecker) ([]byte, error) {
+		gitserverClient.ReadFileFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, _ api.CommitID, name string) ([]byte, error) {
 			if name != "INSTALL.md" {
 				t.Fatalf("ReadFile received call for wrong file: %s", name)
 			}

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -243,13 +243,13 @@ func computeRepositoryComparisonDiff(cmp *RepositoryComparisonResolver) ComputeD
 			}
 
 			var iter *gitserver.DiffFileIterator
-			iter, err = cmp.gitserverClient.Diff(ctx, gitserver.DiffOptions{
+			iter, err = cmp.gitserverClient.Diff(ctx, authz.DefaultSubRepoPermsChecker, gitserver.DiffOptions{
 				Repo:      cmp.repo.RepoName(),
 				Base:      base,
 				Head:      string(cmp.head.OID()),
 				RangeType: cmp.rangeType,
 				Paths:     paths,
-			}, authz.DefaultSubRepoPermsChecker)
+			})
 			if err != nil {
 				return
 			}

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -135,7 +135,7 @@ func TestRepositoryComparison(t *testing.T) {
 		}
 
 		mockGSClient := gitserver.NewMockClient()
-		mockGSClient.CommitsFunc.SetDefaultHook(func(_ context.Context, _ api.RepoName, opts gitserver.CommitsOptions, _ authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error) {
+		mockGSClient.CommitsFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, opts gitserver.CommitsOptions) ([]*gitdomain.Commit, error) {
 			wantRange := fmt.Sprintf("%s..%s", wantBaseRevision, wantHeadRevision)
 
 			if have, want := opts.Range, wantRange; have != want {
@@ -185,7 +185,7 @@ func TestRepositoryComparison(t *testing.T) {
 		}
 
 		mockGSClient := gitserver.NewMockClient()
-		mockGSClient.CommitsFunc.SetDefaultHook(func(_ context.Context, _ api.RepoName, opts gitserver.CommitsOptions, _ authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error) {
+		mockGSClient.CommitsFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, opts gitserver.CommitsOptions) ([]*gitdomain.Commit, error) {
 			if opts.Path == "" {
 				t.Fatalf("expected a path as part of commits args")
 			}

--- a/cmd/frontend/graphqlbackend/repository_git_refs.go
+++ b/cmd/frontend/graphqlbackend/repository_git_refs.go
@@ -159,7 +159,7 @@ func hydrateBranchCommits(ctx context.Context, gitserverClient gitserver.Client,
 	}
 
 	for _, branch := range branches {
-		branch.Commit, err = gitserverClient.GetCommit(ctx, repo, branch.Head, gitserver.ResolveRevisionOptions{}, authz.DefaultSubRepoPermsChecker)
+		branch.Commit, err = gitserverClient.GetCommit(ctx, authz.DefaultSubRepoPermsChecker, repo, branch.Head, gitserver.ResolveRevisionOptions{})
 		if err != nil {
 			if parentCtx.Err() == nil && ctx.Err() != nil {
 				// reached interactive timeout

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -29,7 +29,7 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 	rcache.SetupForTest(t)
 
 	gsClient := gitserver.NewMockClient()
-	gsClient.NewFileReaderFunc.SetDefaultHook(func(_ context.Context, _ api.RepoName, commit api.CommitID, name string, _ authz.SubRepoPermissionChecker) (io.ReadCloser, error) {
+	gsClient.NewFileReaderFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, _ api.RepoName, commit api.CommitID, name string) (io.ReadCloser, error) {
 		if commit != wantCommitID {
 			t.Errorf("got commit %q, want %q", commit, wantCommitID)
 		}

--- a/cmd/frontend/graphqlbackend/user_collaborators_test.go
+++ b/cmd/frontend/graphqlbackend/user_collaborators_test.go
@@ -26,7 +26,7 @@ func TestUserCollaborators_gitserverParallelRecentCommitters(t *testing.T) {
 		callsMu sync.Mutex
 		calls   []args
 	)
-	gitCommitsFunc := func(ctx context.Context, repoName api.RepoName, opt gitserver.CommitsOptions, perms authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error) {
+	gitCommitsFunc := func(ctx context.Context, perms authz.SubRepoPermissionChecker, repoName api.RepoName, opt gitserver.CommitsOptions) ([]*gitdomain.Commit, error) {
 		callsMu.Lock()
 		calls = append(calls, args{repoName, opt})
 		callsMu.Unlock()

--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -272,7 +272,7 @@ func serveRaw(db database.DB, gitserverClient gitserver.Client) handlerFunc {
 			// File
 			requestType = "file"
 			size = fi.Size()
-			f, err := gitserverClient.NewFileReader(r.Context(), common.Repo.Name, common.CommitID, requestedPath, authz.DefaultSubRepoPermsChecker)
+			f, err := gitserverClient.NewFileReader(r.Context(), authz.DefaultSubRepoPermsChecker, common.Repo.Name, common.CommitID, requestedPath)
 			if err != nil {
 				return err
 			}

--- a/cmd/frontend/internal/app/ui/raw_test.go
+++ b/cmd/frontend/internal/app/ui/raw_test.go
@@ -319,7 +319,7 @@ c.go`
 
 		gitserverClient := gitserver.NewMockClient()
 		gitserverClient.StatFunc.SetDefaultReturn(&fileutil.FileInfo{Mode_: 0}, nil)
-		gitserverClient.NewFileReaderFunc.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (io.ReadCloser, error) {
+		gitserverClient.NewFileReaderFunc.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (io.ReadCloser, error) {
 			return io.NopCloser(strings.NewReader("this is a test file")), nil
 		})
 
@@ -352,7 +352,7 @@ c.go`
 
 		gitserverClient := gitserver.NewMockClient()
 		gitserverClient.StatFunc.SetDefaultReturn(&fileutil.FileInfo{Mode_: 0}, nil)
-		gitserverClient.NewFileReaderFunc.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (io.ReadCloser, error) {
+		gitserverClient.NewFileReaderFunc.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (io.ReadCloser, error) {
 			return io.NopCloser(strings.NewReader("this is a test file")), nil
 		})
 

--- a/cmd/frontend/internal/httpapi/stream_blame.go
+++ b/cmd/frontend/internal/httpapi/stream_blame.go
@@ -116,7 +116,7 @@ func handleStreamBlame(logger log.Logger, db database.DB, gitserverClient gitser
 				if p, ok := parentsCache[h.CommitID]; ok {
 					parents = p
 				} else {
-					c, err := gitserverClient.GetCommit(ctx, repo.Name, h.CommitID, gitserver.ResolveRevisionOptions{}, authz.DefaultSubRepoPermsChecker)
+					c, err := gitserverClient.GetCommit(ctx, authz.DefaultSubRepoPermsChecker, repo.Name, h.CommitID, gitserver.ResolveRevisionOptions{})
 					if err != nil {
 						tr.SetError(err)
 						http.Error(w, html.EscapeString(err.Error()), http.StatusInternalServerError)

--- a/cmd/frontend/internal/httpapi/stream_blame_test.go
+++ b/cmd/frontend/internal/httpapi/stream_blame_test.go
@@ -27,10 +27,10 @@ func setupMockGSClient(t *testing.T, wantRev api.CommitID, returnErr error, hunk
 	gsClient := gitserver.NewMockClient()
 	gsClient.GetCommitFunc.SetDefaultHook(
 		func(_ context.Context,
+			checker authz.SubRepoPermissionChecker,
 			repoName api.RepoName,
 			commit api.CommitID,
 			opts gitserver.ResolveRevisionOptions,
-			checker authz.SubRepoPermissionChecker,
 		) (*gitdomain.Commit, error) {
 			return &gitdomain.Commit{
 				Parents: []api.CommitID{"xxx", "yyy"},

--- a/cmd/frontend/internal/search/decorate.go
+++ b/cmd/frontend/internal/search/decorate.go
@@ -168,7 +168,7 @@ func DecorateFileHunksHTML(ctx context.Context, db database.DB, fm *result.FileM
 }
 
 func fetchContent(ctx context.Context, db database.DB, repo api.RepoName, commit api.CommitID, path string) (content []byte, err error) {
-	content, err = gitserver.NewClient(db).ReadFile(ctx, repo, commit, path, authz.DefaultSubRepoPermsChecker)
+	content, err = gitserver.NewClient(db).ReadFile(ctx, authz.DefaultSubRepoPermsChecker, repo, commit, path)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/searcher/internal/search/filter.go
+++ b/cmd/searcher/internal/search/filter.go
@@ -19,7 +19,7 @@ import (
 // NewFilter calls gitserver to retrieve the ignore-file. If the file doesn't
 // exist we return an empty ignore.Matcher.
 func NewFilter(ctx context.Context, client gitserver.Client, repo api.RepoName, commit api.CommitID) (FilterFunc, error) {
-	ignoreFile, err := client.ReadFile(ctx, repo, commit, ignore.IgnoreFile, nil)
+	ignoreFile, err := client.ReadFile(ctx, nil, repo, commit, ignore.IgnoreFile)
 	if err != nil {
 		// We do not ignore anything if the ignore file does not exist.
 		if strings.Contains(err.Error(), "file does not exist") {

--- a/cmd/symbols/gitserver/client.go
+++ b/cmd/symbols/gitserver/client.go
@@ -97,7 +97,7 @@ func (c *gitserverClient) GitDiff(ctx context.Context, repo api.RepoName, commit
 }
 
 func (c *gitserverClient) ReadFile(ctx context.Context, repoCommitPath types.RepoCommitPath) ([]byte, error) {
-	data, err := c.innerClient.ReadFile(ctx, api.RepoName(repoCommitPath.Repo), api.CommitID(repoCommitPath.Commit), repoCommitPath.Path, nil)
+	data, err := c.innerClient.ReadFile(ctx, nil, api.RepoName(repoCommitPath.Repo), api.CommitID(repoCommitPath.Commit), repoCommitPath.Path)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get file contents")
 	}

--- a/enterprise/internal/batches/state/state.go
+++ b/enterprise/internal/batches/state/state.go
@@ -614,11 +614,11 @@ func selectReviewState(states map[btypes.ChangesetReviewState]bool) btypes.Chang
 // computeDiffStat computes the up to date diffstat for the changeset, based on
 // the values in c.SyncState.
 func computeDiffStat(ctx context.Context, client gitserver.Client, c *btypes.Changeset, repo api.RepoName) (*diff.Stat, error) {
-	iter, err := client.Diff(ctx, gitserver.DiffOptions{
+	iter, err := client.Diff(ctx, authz.DefaultSubRepoPermsChecker, gitserver.DiffOptions{
 		Repo: repo,
 		Base: c.SyncState.BaseRefOid,
 		Head: c.SyncState.HeadRefOid,
-	}, authz.DefaultSubRepoPermsChecker)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/batches/testing/mock_sync_state.go
+++ b/enterprise/internal/batches/testing/mock_sync_state.go
@@ -43,7 +43,7 @@ func MockChangesetSyncState(repo *protocol.RepoInfo) *MockedChangesetSyncState {
 	}
 
 	gitserverClient := gitserver.NewMockClient()
-	gitserverClient.DiffFunc.SetDefaultHook(func(_ context.Context, opts gitserver.DiffOptions, _ authz.SubRepoPermissionChecker) (*gitserver.DiffFileIterator, error) {
+	gitserverClient.DiffFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, opts gitserver.DiffOptions) (*gitserver.DiffFileIterator, error) {
 		// This provides a diff that will resolve to 1 added line, 1 changed
 		// line, and 3 deleted lines.
 		const testGitHubDiff = `

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/iface.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/iface.go
@@ -39,7 +39,7 @@ func NewDefaultGitService(checker authz.SubRepoPermissionChecker, db database.DB
 }
 
 func (s *gitService) ListFiles(ctx context.Context, repo api.RepoName, commit string, pattern *regexp.Regexp) ([]string, error) {
-	return gitserver.NewClient(s.db).ListFiles(ctx, repo, api.CommitID(commit), pattern, authz.DefaultSubRepoPermsChecker)
+	return gitserver.NewClient(s.db).ListFiles(ctx, authz.DefaultSubRepoPermsChecker, repo, api.CommitID(commit), pattern)
 }
 
 func (s *gitService) Archive(ctx context.Context, repo api.RepoName, opts gitserver.ArchiveOptions) (io.ReadCloser, error) {

--- a/enterprise/internal/codeintel/shared/gitserver/client.go
+++ b/enterprise/internal/codeintel/shared/gitserver/client.go
@@ -72,7 +72,7 @@ func (c *Client) CommitExists(ctx context.Context, repositoryID int, commit stri
 	if err != nil {
 		return false, err
 	}
-	return c.gitserverClient.CommitExists(ctx, repo, api.CommitID(commit), authz.DefaultSubRepoPermsChecker)
+	return c.gitserverClient.CommitExists(ctx, authz.DefaultSubRepoPermsChecker, repo, api.CommitID(commit))
 }
 
 type RepositoryCommit struct {
@@ -125,7 +125,7 @@ func (c *Client) CommitsExist(ctx context.Context, commits []RepositoryCommit) (
 		originalIndexes = append(originalIndexes, i)
 	}
 
-	exists, err := c.gitserverClient.CommitsExist(ctx, repoCommits, authz.DefaultSubRepoPermsChecker)
+	exists, err := c.gitserverClient.CommitsExist(ctx, authz.DefaultSubRepoPermsChecker, repoCommits)
 	if err != nil {
 		return nil, err
 	}
@@ -163,11 +163,11 @@ func (c *Client) Head(ctx context.Context, repositoryID int) (_ string, revision
 		return "", false, err
 	}
 
-	return c.gitserverClient.Head(ctx, repo, authz.DefaultSubRepoPermsChecker)
+	return c.gitserverClient.Head(ctx, authz.DefaultSubRepoPermsChecker, repo)
 }
 
 func (c *Client) HeadFromName(ctx context.Context, repo api.RepoName) (_ string, revisionExists bool, err error) {
-	return c.gitserverClient.Head(ctx, repo, authz.DefaultSubRepoPermsChecker)
+	return c.gitserverClient.Head(ctx, authz.DefaultSubRepoPermsChecker, repo)
 }
 
 // CommitDate returns the time that the given commit was committed. If the given revision does not exist,
@@ -184,7 +184,7 @@ func (c *Client) CommitDate(ctx context.Context, repositoryID int, commit string
 		return "", time.Time{}, false, nil
 	}
 
-	rev, tm, ok, err := c.gitserverClient.CommitDate(ctx, repo, api.CommitID(commit), authz.DefaultSubRepoPermsChecker)
+	rev, tm, ok, err := c.gitserverClient.CommitDate(ctx, authz.DefaultSubRepoPermsChecker, repo, api.CommitID(commit))
 	if err == nil {
 		return rev, tm, ok, nil
 	}
@@ -255,7 +255,7 @@ func (c *Client) RefDescriptions(ctx context.Context, repositoryID int, pointedA
 		return nil, err
 	}
 
-	return c.gitserverClient.RefDescriptions(ctx, repo, authz.DefaultSubRepoPermsChecker, pointedAt...)
+	return c.gitserverClient.RefDescriptions(ctx, authz.DefaultSubRepoPermsChecker, repo, pointedAt...)
 }
 
 // CommitsUniqueToBranch returns a map from commits that exist on a particular branch in the given repository to
@@ -275,7 +275,7 @@ func (c *Client) CommitsUniqueToBranch(ctx context.Context, repositoryID int, br
 		return nil, err
 	}
 
-	return c.gitserverClient.CommitsUniqueToBranch(ctx, repo, branchName, isDefaultBranch, maxAge, authz.DefaultSubRepoPermsChecker)
+	return c.gitserverClient.CommitsUniqueToBranch(ctx, authz.DefaultSubRepoPermsChecker, repo, branchName, isDefaultBranch, maxAge)
 }
 
 // branchesContaining returns a map from branch names to branch tip hashes for each branch
@@ -285,7 +285,7 @@ func (c *Client) branchesContaining(ctx context.Context, repositoryID int, commi
 	if err != nil {
 		return nil, err
 	}
-	return c.gitserverClient.BranchesContaining(ctx, repo, api.CommitID(commit), authz.DefaultSubRepoPermsChecker)
+	return c.gitserverClient.BranchesContaining(ctx, authz.DefaultSubRepoPermsChecker, repo, api.CommitID(commit))
 }
 
 // DefaultBranchContains tells if the default branch contains the given commit ID.
@@ -332,7 +332,7 @@ func (c *Client) RawContents(ctx context.Context, repositoryID int, commit, file
 		return nil, err
 	}
 
-	out, err := c.gitserverClient.ReadFile(ctx, repo, api.CommitID(commit), file, authz.DefaultSubRepoPermsChecker)
+	out, err := c.gitserverClient.ReadFile(ctx, authz.DefaultSubRepoPermsChecker, repo, api.CommitID(commit), file)
 	if err == nil {
 		return out, nil
 	}
@@ -437,7 +437,7 @@ func (c *Client) ListFiles(ctx context.Context, repositoryID int, commit string,
 }
 
 func (c *Client) ListFilesForRepo(ctx context.Context, repo api.RepoName, commit string, pattern *regexp.Regexp) (_ []string, err error) {
-	matching, err := c.gitserverClient.ListFiles(ctx, repo, api.CommitID(commit), pattern, authz.DefaultSubRepoPermsChecker)
+	matching, err := c.gitserverClient.ListFiles(ctx, authz.DefaultSubRepoPermsChecker, repo, api.CommitID(commit), pattern)
 	if err == nil {
 		return matching, nil
 	}

--- a/enterprise/internal/codeintel/shared/resolvers/git_tree_entry_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/git_tree_entry_resolver.go
@@ -68,10 +68,10 @@ func (r *GitTreeEntryResolver) Content(ctx context.Context) (string, error) {
 
 		r.content, r.contentErr = gitserver.NewClient(r.db).ReadFile(
 			ctx,
+			authz.DefaultSubRepoPermsChecker,
 			api.RepoName(r.commit.Repository().Name()),
 			api.CommitID(r.commit.OID()),
 			r.Path(),
-			authz.DefaultSubRepoPermsChecker,
 		)
 	})
 

--- a/enterprise/internal/compute/replace_command.go
+++ b/enterprise/internal/compute/replace_command.go
@@ -53,7 +53,7 @@ func replace(ctx context.Context, content []byte, matchPattern MatchPattern, rep
 func (c *Replace) Run(ctx context.Context, db database.DB, r result.Match) (Result, error) {
 	switch m := r.(type) {
 	case *result.FileMatch:
-		content, err := gitserver.NewClient(db).ReadFile(ctx, m.Repo.Name, m.CommitID, m.Path, authz.DefaultSubRepoPermsChecker)
+		content, err := gitserver.NewClient(db).ReadFile(ctx, authz.DefaultSubRepoPermsChecker, m.Repo.Name, m.CommitID, m.Path)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/internal/insights/gitserver/client.go
+++ b/enterprise/internal/insights/gitserver/client.go
@@ -33,5 +33,5 @@ func (g *GitCommitClient) RecentCommits(ctx context.Context, repoName api.RepoNa
 	if len(revision) > 0 {
 		options.Range = revision
 	}
-	return g.Gitclient.Commits(ctx, repoName, options, authz.DefaultSubRepoPermsChecker)
+	return g.Gitclient.Commits(ctx, authz.DefaultSubRepoPermsChecker, repoName, options)
 }

--- a/enterprise/internal/insights/gitserver/first_commit.go
+++ b/enterprise/internal/insights/gitserver/first_commit.go
@@ -31,7 +31,7 @@ func isFirstCommitEmptyRepoError(err error) bool {
 }
 
 func GitFirstEverCommit(ctx context.Context, db database.DB, repoName api.RepoName) (*gitdomain.Commit, error) {
-	commit, err := gitserver.NewClient(db).FirstEverCommit(ctx, repoName, authz.DefaultSubRepoPermsChecker)
+	commit, err := gitserver.NewClient(db).FirstEverCommit(ctx, authz.DefaultSubRepoPermsChecker, repoName)
 	if err != nil && isFirstCommitEmptyRepoError(err) {
 		return nil, errors.Wrap(EmptyRepoErr, err.Error())
 	}

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -117,7 +117,7 @@ func NewTestClient(cli httpcli.Doer, db database.DB, addrs []string) Client {
 func NewMockClientWithExecReader(execReader func(context.Context, api.RepoName, []string) (io.ReadCloser, error)) *MockClient {
 	client := NewMockClient()
 	// NOTE: This hook is the same as DiffFunc, but with `execReader` used above
-	client.DiffFunc.SetDefaultHook(func(ctx context.Context, opts DiffOptions, checker authz.SubRepoPermissionChecker) (*DiffFileIterator, error) {
+	client.DiffFunc.SetDefaultHook(func(ctx context.Context, checker authz.SubRepoPermissionChecker, opts DiffOptions) (*DiffFileIterator, error) {
 		if opts.Base == DevNullSHA {
 			opts.RangeType = ".."
 		} else if opts.RangeType != ".." {
@@ -259,7 +259,7 @@ type Client interface {
 
 	// HasCommitAfter indicates the staleness of a repository. It returns a boolean indicating if a repository
 	// contains a commit past a specified date.
-	HasCommitAfter(ctx context.Context, repo api.RepoName, date string, revspec string, checker authz.SubRepoPermissionChecker) (bool, error)
+	HasCommitAfter(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, date string, revspec string) (bool, error)
 
 	// IsRepoCloneable returns nil if the repository is cloneable.
 	IsRepoCloneable(context.Context, api.RepoName) error
@@ -343,20 +343,20 @@ type Client interface {
 
 	// NewFileReader returns an io.ReadCloser reading from the named file at commit.
 	// The caller should always close the reader after use
-	NewFileReader(ctx context.Context, repo api.RepoName, commit api.CommitID, name string, checker authz.SubRepoPermissionChecker) (io.ReadCloser, error)
+	NewFileReader(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, name string) (io.ReadCloser, error)
 
 	// DiffSymbols performs a diff command which is expected to be parsed by our symbols package
 	DiffSymbols(ctx context.Context, repo api.RepoName, commitA, commitB api.CommitID) ([]byte, error)
 
 	// ListFiles returns a list of root-relative file paths matching the given
 	// pattern in a particular commit of a repository.
-	ListFiles(ctx context.Context, repo api.RepoName, commit api.CommitID, pattern *regexp.Regexp, checker authz.SubRepoPermissionChecker) ([]string, error)
+	ListFiles(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, pattern *regexp.Regexp) ([]string, error)
 
 	// Commits returns all commits matching the options.
-	Commits(ctx context.Context, repo api.RepoName, opt CommitsOptions, checker authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error)
+	Commits(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, opt CommitsOptions) ([]*gitdomain.Commit, error)
 
 	// FirstEverCommit returns the first commit ever made to the repository.
-	FirstEverCommit(ctx context.Context, repo api.RepoName, checker authz.SubRepoPermissionChecker) (*gitdomain.Commit, error)
+	FirstEverCommit(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName) (*gitdomain.Commit, error)
 
 	// ListTags returns a list of all tags in the repository. If commitObjs is non-empty, only all tags pointing at those commits are returned.
 	ListTags(ctx context.Context, repo api.RepoName, commitObjs ...string) ([]*gitdomain.Tag, error)
@@ -369,38 +369,38 @@ type Client interface {
 	// Diff returns an iterator that can be used to access the diff between two
 	// commits on a per-file basis. The iterator must be closed with Close when no
 	// longer required.
-	Diff(ctx context.Context, opts DiffOptions, checker authz.SubRepoPermissionChecker) (*DiffFileIterator, error)
+	Diff(ctx context.Context, checker authz.SubRepoPermissionChecker, opts DiffOptions) (*DiffFileIterator, error)
 
 	// ReadFile returns the first maxBytes of the named file at commit. If maxBytes <= 0, the entire
 	// file is read. (If you just need to check a file's existence, use Stat, not ReadFile.)
-	ReadFile(ctx context.Context, repo api.RepoName, commit api.CommitID, name string, checker authz.SubRepoPermissionChecker) ([]byte, error)
+	ReadFile(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, name string) ([]byte, error)
 
 	// BranchesContaining returns a map from branch names to branch tip hashes for
 	// each branch containing the given commit.
-	BranchesContaining(ctx context.Context, repo api.RepoName, commit api.CommitID, checker authz.SubRepoPermissionChecker) ([]string, error)
+	BranchesContaining(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID) ([]string, error)
 
 	// RefDescriptions returns a map from commits to descriptions of the tip of each
 	// branch and tag of the given repository.
-	RefDescriptions(ctx context.Context, repo api.RepoName, checker authz.SubRepoPermissionChecker, gitObjs ...string) (map[string][]gitdomain.RefDescription, error)
+	RefDescriptions(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, gitObjs ...string) (map[string][]gitdomain.RefDescription, error)
 
 	// CommitExists determines if the given commit exists in the given repository.
-	CommitExists(ctx context.Context, repo api.RepoName, id api.CommitID, checker authz.SubRepoPermissionChecker) (bool, error)
+	CommitExists(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, id api.CommitID) (bool, error)
 
 	// CommitsExist determines if the given commits exists in the given repositories. This function returns
 	// a slice of the same size as the input slice, true indicating that the commit at the symmetric index
 	// exists.
-	CommitsExist(ctx context.Context, repoCommits []api.RepoCommit, checker authz.SubRepoPermissionChecker) ([]bool, error)
+	CommitsExist(ctx context.Context, checker authz.SubRepoPermissionChecker, repoCommits []api.RepoCommit) ([]bool, error)
 
 	// Head determines the tip commit of the default branch for the given repository.
 	// If no HEAD revision exists for the given repository (which occurs with empty
 	// repositories), a false-valued flag is returned along with a nil error and
 	// empty revision.
-	Head(ctx context.Context, repo api.RepoName, checker authz.SubRepoPermissionChecker) (string, bool, error)
+	Head(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName) (string, bool, error)
 
 	// CommitDate returns the time that the given commit was committed. If the given
 	// revision does not exist, a false-valued flag is returned along with a nil
 	// error and zero-valued time.
-	CommitDate(ctx context.Context, repo api.RepoName, commit api.CommitID, checker authz.SubRepoPermissionChecker) (string, time.Time, bool, error)
+	CommitDate(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID) (string, time.Time, bool, error)
 
 	// CommitGraph returns the commit graph for the given repository as a mapping
 	// from a commit to its parents. If a commit is supplied, the returned graph will
@@ -414,7 +414,7 @@ type Client interface {
 	// commits on {branchName} not also on the tip of the default branch. If the
 	// supplied branch name is the default branch, then this method instead returns
 	// all commits reachable from HEAD.
-	CommitsUniqueToBranch(ctx context.Context, repo api.RepoName, branchName string, isDefaultBranch bool, maxAge *time.Time, checker authz.SubRepoPermissionChecker) (map[string]time.Time, error)
+	CommitsUniqueToBranch(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, branchName string, isDefaultBranch bool, maxAge *time.Time) (map[string]time.Time, error)
 
 	// LsFiles returns the output of `git ls-files`
 	LsFiles(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, pathspecs ...gitdomain.Pathspec) ([]string, error)
@@ -422,7 +422,7 @@ type Client interface {
 	// LFSSmudge returns a reader of the contents from LFS of the LFS pointer
 	// at path. If the path is not an LFS pointer, the file contents from git
 	// are returned instead.
-	LFSSmudge(ctx context.Context, repo api.RepoName, commit api.CommitID, path string, checker authz.SubRepoPermissionChecker) (io.ReadCloser, error)
+	LFSSmudge(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, path string) (io.ReadCloser, error)
 
 	// GetCommits returns a git commit object describing each of the given repository and commit pairs. This
 	// function returns a slice of the same size as the input slice. Values in the output slice may be nil if
@@ -430,7 +430,7 @@ type Client interface {
 	//
 	// If ignoreErrors is true, then errors arising from any single failed git log operation will cause the
 	// resulting commit to be nil, but not fail the entire operation.
-	GetCommits(ctx context.Context, repoCommits []api.RepoCommit, ignoreErrors bool, checker authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error)
+	GetCommits(ctx context.Context, checker authz.SubRepoPermissionChecker, repoCommits []api.RepoCommit, ignoreErrors bool) ([]*gitdomain.Commit, error)
 
 	// GetCommit returns the commit with the given commit ID, or ErrCommitNotFound if no such commit
 	// exists.
@@ -438,7 +438,7 @@ type Client interface {
 	// The remoteURLFunc is called to get the Git remote URL if it's not set in repo and if it is
 	// needed. The Git remote URL is only required if the gitserver doesn't already contain a clone of
 	// the repository or if the commit must be fetched from the remote.
-	GetCommit(ctx context.Context, repo api.RepoName, id api.CommitID, opt ResolveRevisionOptions, checker authz.SubRepoPermissionChecker) (*gitdomain.Commit, error)
+	GetCommit(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, id api.CommitID, opt ResolveRevisionOptions) (*gitdomain.Commit, error)
 
 	// GetBehindAhead returns the behind/ahead commit counts information for right vs. left (both Git
 	// revspecs).

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -3141,7 +3141,7 @@ filename format.go
 
 var testGitBlameOutputHunks = []*Hunk{
 	{
-		StartLine: 1, EndLine: 5, StartByte: 0, EndByte: 43,
+		StartLine: 1, EndLine: 5, StartByte: 0, EndByte: 41,
 		CommitID: "3f61310114082d6179c23f75950b88d1842fe2de",
 		Author: gitdomain.Signature{
 			Name:  "Thorsten Ball",
@@ -3152,7 +3152,7 @@ var testGitBlameOutputHunks = []*Hunk{
 		Filename: "release.sh",
 	},
 	{
-		StartLine: 5, EndLine: 15, StartByte: 43, EndByte: 252,
+		StartLine: 5, EndLine: 15, StartByte: 41, EndByte: 249,
 		CommitID: "fbb98e0b7ff0752798463d9f49d922858a4188f6",
 		Author: gitdomain.Signature{
 			Name:  "Adam Harvey",
@@ -3163,7 +3163,7 @@ var testGitBlameOutputHunks = []*Hunk{
 		Filename: "release.sh",
 	},
 	{
-		StartLine: 15, EndLine: 16, StartByte: 252, EndByte: 331,
+		StartLine: 15, EndLine: 16, StartByte: 249, EndByte: 328,
 		CommitID: "8a75c6f8b4cbe2a2f3c8be0f2c50bc766499f498",
 		Author: gitdomain.Signature{
 			Name:  "Adam Harvey",
@@ -3174,7 +3174,7 @@ var testGitBlameOutputHunks = []*Hunk{
 		Filename: "release.sh",
 	},
 	{
-		StartLine: 16, EndLine: 20, StartByte: 331, EndByte: 398,
+		StartLine: 16, EndLine: 20, StartByte: 328, EndByte: 394,
 		CommitID: "3f61310114082d6179c23f75950b88d1842fe2de",
 		Author: gitdomain.Signature{
 			Name:  "Thorsten Ball",
@@ -3185,7 +3185,7 @@ var testGitBlameOutputHunks = []*Hunk{
 		Filename: "release.sh",
 	},
 	{
-		StartLine: 20, EndLine: 21, StartByte: 398, EndByte: 508,
+		StartLine: 20, EndLine: 21, StartByte: 394, EndByte: 504,
 		CommitID: "67b7b725a7ff913da520b997d71c840230351e30",
 		Author: gitdomain.Signature{
 			Name:  "Thorsten Ball",
@@ -3196,7 +3196,7 @@ var testGitBlameOutputHunks = []*Hunk{
 		Filename: "release.sh",
 	},
 	{
-		StartLine: 21, EndLine: 22, StartByte: 508, EndByte: 557,
+		StartLine: 21, EndLine: 22, StartByte: 504, EndByte: 553,
 		CommitID: "3f61310114082d6179c23f75950b88d1842fe2de",
 		Author: gitdomain.Signature{
 			Name:  "Thorsten Ball",
@@ -3207,7 +3207,7 @@ var testGitBlameOutputHunks = []*Hunk{
 		Filename: "release.sh",
 	},
 	{
-		StartLine: 22, EndLine: 24, StartByte: 557, EndByte: 699,
+		StartLine: 22, EndLine: 24, StartByte: 553, EndByte: 695,
 		CommitID: "67b7b725a7ff913da520b997d71c840230351e30",
 		Author: gitdomain.Signature{
 			Name:  "Thorsten Ball",

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -152,7 +152,7 @@ func TestDiffWithSubRepoFiltering(t *testing.T) {
 		t.Run(tc.label, func(t *testing.T) {
 			repo := MakeGitRepository(t, append(cmds, tc.extraGitCommands...)...)
 			c := NewClient(db)
-			commits, err := c.Commits(ctx, repo, CommitsOptions{}, nil)
+			commits, err := c.Commits(ctx, nil, repo, CommitsOptions{})
 			if err != nil {
 				t.Fatalf("err fetching commits: %s", err)
 			}
@@ -162,7 +162,7 @@ func TestDiffWithSubRepoFiltering(t *testing.T) {
 				baseCommit = commits[len(commits)-1]
 			}
 
-			iter, err := c.Diff(ctx, DiffOptions{Base: string(baseCommit.ID), Head: string(headCommit.ID), Repo: repo}, checker)
+			iter, err := c.Diff(ctx, checker, DiffOptions{Base: string(baseCommit.ID), Head: string(headCommit.ID), Repo: repo})
 			if err != nil {
 				t.Fatalf("error fetching diff: %s", err)
 			}
@@ -206,7 +206,7 @@ func TestDiff(t *testing.T) {
 			".foo",
 		} {
 			t.Run("invalid base: "+input, func(t *testing.T) {
-				i, err := NewClient(db).Diff(ctx, DiffOptions{Base: input}, nil)
+				i, err := NewClient(db).Diff(ctx, nil, DiffOptions{Base: input})
 				if i != nil {
 					t.Errorf("unexpected non-nil iterator: %+v", i)
 				}
@@ -232,7 +232,7 @@ func TestDiff(t *testing.T) {
 					}
 					return nil, nil
 				})
-				_, _ = c.Diff(ctx, tc.opts, nil)
+				_, _ = c.Diff(ctx, nil, tc.opts)
 			})
 		}
 	})
@@ -241,7 +241,7 @@ func TestDiff(t *testing.T) {
 		c := NewMockClientWithExecReader(func(_ context.Context, _ api.RepoName, args []string) (io.ReadCloser, error) {
 			return nil, errors.New("ExecReader error")
 		})
-		i, err := c.Diff(ctx, DiffOptions{Base: "foo", Head: "bar"}, nil)
+		i, err := c.Diff(ctx, nil, DiffOptions{Base: "foo", Head: "bar"})
 		if i != nil {
 			t.Errorf("unexpected non-nil iterator: %+v", i)
 		}
@@ -320,7 +320,7 @@ index 9bd8209..d2acfa9 100644
 			return io.NopCloser(strings.NewReader(testDiff)), nil
 		})
 
-		i, err := c.Diff(ctx, DiffOptions{Base: "foo", Head: "bar"}, nil)
+		i, err := c.Diff(ctx, nil, DiffOptions{Base: "foo", Head: "bar"})
 		if i == nil {
 			t.Error("unexpected nil iterator")
 		}
@@ -1221,7 +1221,7 @@ func TestRepository_GetCommit(t *testing.T) {
 				resolveRevisionOptions := ResolveRevisionOptions{
 					NoEnsureRevision: test.noEnsureRevision,
 				}
-				commit, err := client.GetCommit(ctx, testRepo, test.id, resolveRevisionOptions, checker)
+				commit, err := client.GetCommit(ctx, checker, testRepo, test.id, resolveRevisionOptions)
 				if err != nil {
 					if test.revisionNotFoundError {
 						if !errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
@@ -1238,7 +1238,7 @@ func TestRepository_GetCommit(t *testing.T) {
 				}
 
 				// Test that trying to get a nonexistent commit returns RevisionNotFoundError.
-				if _, err := client.GetCommit(ctx, testRepo, NonExistentCommitID, resolveRevisionOptions, checker); !errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
+				if _, err := client.GetCommit(ctx, checker, testRepo, NonExistentCommitID, resolveRevisionOptions); !errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
 					t.Errorf("%s: for nonexistent commit: got err %v, want RevisionNotFoundError", label, err)
 				}
 
@@ -1383,7 +1383,7 @@ func TestRepository_HasCommitAfter(t *testing.T) {
 					gitCommands[i] = fmt.Sprintf("GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=%s git commit --allow-empty -m foo --author='a <a@a.com>'", date)
 				}
 				repo := MakeGitRepository(t, gitCommands...)
-				got, err := client.HasCommitAfter(ctx, repo, tc.after, tc.revspec, nil)
+				got, err := client.HasCommitAfter(ctx, nil, repo, tc.after, tc.revspec)
 				if err != nil || got != tc.want {
 					t.Errorf("got %t hascommitafter, want %t", got, tc.want)
 				}
@@ -1403,7 +1403,7 @@ func TestRepository_HasCommitAfter(t *testing.T) {
 				// Case where user can't view commit 2, but can view commits 0 and 1. In each test case the result should match the case where no sub-repo perms enabled
 				checker := getTestSubRepoPermsChecker("file2")
 				repo := MakeGitRepository(t, gitCommands...)
-				got, err := client.HasCommitAfter(ctx, repo, tc.after, tc.revspec, checker)
+				got, err := client.HasCommitAfter(ctx, checker, repo, tc.after, tc.revspec)
 				if err != nil {
 					t.Errorf("got error: %s", err)
 				}
@@ -1413,7 +1413,7 @@ func TestRepository_HasCommitAfter(t *testing.T) {
 
 				// Case where user can't view commit 1 or commit 2, which will mean in some cases since HasCommitAfter will be false due to those commits not being visible.
 				checker = getTestSubRepoPermsChecker("file1", "file2")
-				got, err = client.HasCommitAfter(ctx, repo, tc.after, tc.revspec, checker)
+				got, err = client.HasCommitAfter(ctx, checker, repo, tc.after, tc.revspec)
 				if err != nil {
 					t.Errorf("got error: %s", err)
 				}
@@ -1464,7 +1464,7 @@ func TestRepository_FirstEverCommit(t *testing.T) {
 			}
 
 			repo := MakeGitRepository(t, gitCommands...)
-			gotCommit, err := client.FirstEverCommit(ctx, repo, nil)
+			gotCommit, err := client.FirstEverCommit(ctx, nil, repo)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1478,7 +1478,7 @@ func TestRepository_FirstEverCommit(t *testing.T) {
 	// Added for awareness if this error message changes. Insights skip over empty repos and check against error message
 	t.Run("empty repo", func(t *testing.T) {
 		repo := MakeGitRepository(t)
-		_, err := client.FirstEverCommit(ctx, repo, nil)
+		_, err := client.FirstEverCommit(ctx, nil, repo)
 		wantErr := `git command [rev-list --reverse --date-order --max-parents=0 HEAD] failed (output: ""): exit status 128`
 		if err.Error() != wantErr {
 			t.Errorf("expected :%s, got :%s", wantErr, err)
@@ -1499,12 +1499,12 @@ func TestRepository_FirstEverCommit(t *testing.T) {
 
 			repo := MakeGitRepository(t, gitCommands...)
 			// Try to get first commit when user doesn't have permission to view
-			_, err := client.FirstEverCommit(ctx, repo, checkerWithoutAccessFirstCommit)
+			_, err := client.FirstEverCommit(ctx, checkerWithoutAccessFirstCommit, repo)
 			if !errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
 				t.Errorf("expected a RevisionNotFoundError since the user does not have access to view this commit, got :%s", err)
 			}
 			// Try to get first commit when user does have permission to view, should succeed
-			gotCommit, err := client.FirstEverCommit(ctx, repo, checkerWithAccessFirstCommit)
+			gotCommit, err := client.FirstEverCommit(ctx, checkerWithAccessFirstCommit, repo)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1517,7 +1517,7 @@ func TestRepository_FirstEverCommit(t *testing.T) {
 				UID:      1,
 				Internal: true,
 			})
-			gotCommit, err = client.FirstEverCommit(newCtx, repo, checkerWithoutAccessFirstCommit)
+			gotCommit, err = client.FirstEverCommit(newCtx, checkerWithoutAccessFirstCommit, repo)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1541,7 +1541,7 @@ func TestCommitExists(t *testing.T) {
 		t.Run(label, func(t *testing.T) {
 			repo := MakeGitRepository(t, gitCommands...)
 
-			exists, err := client.CommitExists(ctx, repo, commitID, checker)
+			exists, err := client.CommitExists(ctx, checker, repo, commitID)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1549,7 +1549,7 @@ func TestCommitExists(t *testing.T) {
 				t.Fatal("Should exist")
 			}
 
-			exists, err = client.CommitExists(ctx, repo, nonExistentCommitID, checker)
+			exists, err = client.CommitExists(ctx, checker, repo, nonExistentCommitID)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1620,7 +1620,7 @@ func TestRepository_Commits(t *testing.T) {
 				testCommits(ctx, label, test.repo, CommitsOptions{Range: string(test.id)}, checker, test.wantTotal, test.wantCommits, t)
 
 				// Test that trying to get a nonexistent commit returns RevisionNotFoundError.
-				if _, err := client.Commits(ctx, test.repo, CommitsOptions{Range: string(NonExistentCommitID)}, nil); !errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
+				if _, err := client.Commits(ctx, nil, test.repo, CommitsOptions{Range: string(NonExistentCommitID)}); !errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
 					t.Errorf("%s: for nonexistent commit: got err %v, want RevisionNotFoundError", label, err)
 				}
 			})
@@ -1705,7 +1705,7 @@ func TestCommits_SubRepoPerms(t *testing.T) {
 	for label, test := range tests {
 		t.Run(label, func(t *testing.T) {
 			checker := getTestSubRepoPermsChecker(test.noAccessPaths...)
-			commits, err := NewClient(database.NewMockDB()).Commits(ctx, repo, test.opt, checker)
+			commits, err := NewClient(database.NewMockDB()).Commits(ctx, checker, repo, test.opt)
 			if err != nil {
 				t.Errorf("%s: Commits(): %s", label, err)
 				return
@@ -1801,7 +1801,7 @@ func TestCommits_SubRepoPerms_ReturnNCommits(t *testing.T) {
 	for label, test := range tests {
 		t.Run(label, func(t *testing.T) {
 			checker := getTestSubRepoPermsChecker(test.noAccessPaths...)
-			commits, err := client.Commits(ctx, test.repo, test.opt, checker)
+			commits, err := client.Commits(ctx, checker, test.repo, test.opt)
 			if err != nil {
 				t.Errorf("%s: Commits(): %s", label, err)
 				return
@@ -1894,7 +1894,7 @@ func TestRepository_Commits_options(t *testing.T) {
 			repo := MakeGitRepository(t)
 			before := ""
 			after := time.Date(2022, 11, 11, 12, 10, 0, 4, time.UTC).Format(time.RFC3339)
-			_, err := NewClient(database.NewMockDB()).Commits(ctx, repo, CommitsOptions{N: 0, DateOrder: true, NoEnsureRevision: true, After: after, Before: before}, checker)
+			_, err := NewClient(database.NewMockDB()).Commits(ctx, checker, repo, CommitsOptions{N: 0, DateOrder: true, NoEnsureRevision: true, After: after, Before: before})
 			if err == nil {
 				t.Error("expected error, got nil")
 			}
@@ -2223,7 +2223,7 @@ func TestRefDescriptions(t *testing.T) { // KEEP
 	}
 
 	t.Run("basic", func(t *testing.T) {
-		refDescriptions, err := client.RefDescriptions(ctx, repo, nil)
+		refDescriptions, err := client.RefDescriptions(ctx, nil, repo)
 		if err != nil {
 			t.Errorf("err calling RefDescriptions: %s", err)
 		}
@@ -2239,7 +2239,7 @@ func TestRefDescriptions(t *testing.T) { // KEEP
 
 	t.Run("with sub-repo enabled", func(t *testing.T) {
 		checker := getTestSubRepoPermsChecker("file-with-no-access")
-		refDescriptions, err := client.RefDescriptions(ctx, repo, checker)
+		refDescriptions, err := client.RefDescriptions(ctx, checker, repo)
 		if err != nil {
 			t.Errorf("err calling RefDescriptions: %s", err)
 		}
@@ -2266,7 +2266,7 @@ func TestCommitsUniqueToBranch(t *testing.T) {
 	repo := MakeGitRepository(t, gitCommands...)
 
 	t.Run("basic", func(t *testing.T) {
-		commits, err := client.CommitsUniqueToBranch(ctx, repo, "my-branch", true, &time.Time{}, nil)
+		commits, err := client.CommitsUniqueToBranch(ctx, nil, repo, "my-branch", true, &time.Time{})
 		if err != nil {
 			t.Errorf("err calling RefDescriptions: %s", err)
 		}
@@ -2283,7 +2283,7 @@ func TestCommitsUniqueToBranch(t *testing.T) {
 
 	t.Run("with sub-repo enabled", func(t *testing.T) {
 		checker := getTestSubRepoPermsChecker("file-with-no-access")
-		commits, err := client.CommitsUniqueToBranch(ctx, repo, "my-branch", true, &time.Time{}, checker)
+		commits, err := client.CommitsUniqueToBranch(ctx, checker, repo, "my-branch", true, &time.Time{})
 		if err != nil {
 			t.Errorf("err calling RefDescriptions: %s", err)
 		}
@@ -2310,7 +2310,7 @@ func TestCommitDate(t *testing.T) {
 	repo := MakeGitRepository(t, gitCommands...)
 
 	t.Run("basic", func(t *testing.T) {
-		_, date, commitExists, err := client.CommitDate(ctx, repo, "d38233a79e037d2ab8170b0d0bc0aa438473e6da", nil)
+		_, date, commitExists, err := client.CommitDate(ctx, nil, repo, "d38233a79e037d2ab8170b0d0bc0aa438473e6da")
 		if err != nil {
 			t.Errorf("error fetching CommitDate: %s", err)
 		}
@@ -2324,7 +2324,7 @@ func TestCommitDate(t *testing.T) {
 
 	t.Run("with sub-repo permissions enabled", func(t *testing.T) {
 		checker := getTestSubRepoPermsChecker("file1")
-		_, date, commitExists, err := client.CommitDate(ctx, repo, "d38233a79e037d2ab8170b0d0bc0aa438473e6da", checker)
+		_, date, commitExists, err := client.CommitDate(ctx, checker, repo, "d38233a79e037d2ab8170b0d0bc0aa438473e6da")
 		if err != nil {
 			t.Errorf("error fetching CommitDate: %s", err)
 		}
@@ -2341,7 +2341,7 @@ func testCommits(ctx context.Context, label string, repo api.RepoName, opt Commi
 	t.Helper()
 	db := database.NewMockDB()
 	client := NewClient(db).(*clientImplementor)
-	commits, err := client.Commits(ctx, repo, opt, checker)
+	commits, err := client.Commits(ctx, checker, repo, opt)
 	if err != nil {
 		t.Errorf("%s: Commits(): %s", label, err)
 		return
@@ -2582,7 +2582,7 @@ func TestRead(t *testing.T) {
 			UID: 1,
 		})
 		t.Run(name+"-ReadFile", func(t *testing.T) {
-			data, err := client.ReadFile(ctx, repo, commitID, test.file, nil)
+			data, err := client.ReadFile(ctx, nil, repo, commitID, test.file)
 			test.checkFn(t, err, data)
 		})
 		t.Run(name+"-ReadFile-with-sub-repo-permissions-no-op", func(t *testing.T) {
@@ -2595,7 +2595,7 @@ func TestRead(t *testing.T) {
 				}
 				return authz.None, nil
 			})
-			data, err := client.ReadFile(ctx, repo, commitID, test.file, checker)
+			data, err := client.ReadFile(ctx, checker, repo, commitID, test.file)
 			test.checkFn(t, err, data)
 		})
 		t.Run(name+"-ReadFile-with-sub-repo-permissions-filters-file", func(t *testing.T) {
@@ -2605,7 +2605,7 @@ func TestRead(t *testing.T) {
 			checker.PermissionsFunc.SetDefaultHook(func(ctx context.Context, i int32, content authz.RepoContent) (authz.Perms, error) {
 				return authz.None, nil
 			})
-			data, err := client.ReadFile(ctx, repo, commitID, test.file, checker)
+			data, err := client.ReadFile(ctx, checker, repo, commitID, test.file)
 			if err != os.ErrNotExist {
 				t.Errorf("unexpected error reading file: %s", err)
 			}
@@ -2635,7 +2635,7 @@ func TestRead(t *testing.T) {
 			checker.PermissionsFunc.SetDefaultHook(func(ctx context.Context, i int32, content authz.RepoContent) (authz.Perms, error) {
 				return authz.None, nil
 			})
-			rc, err := client.NewFileReader(ctx, repo, commitID, test.file, checker)
+			rc, err := client.NewFileReader(ctx, checker, repo, commitID, test.file)
 			if err != os.ErrNotExist {
 				t.Fatalf("unexpected error: %s", err)
 			}
@@ -2649,7 +2649,7 @@ func TestRead(t *testing.T) {
 func runNewFileReaderTest(ctx context.Context, t *testing.T, repo api.RepoName, commitID api.CommitID, file string,
 	checker authz.SubRepoPermissionChecker, checkFn func(*testing.T, error, []byte)) {
 	t.Helper()
-	rc, err := NewClient(database.NewMockDB()).NewFileReader(ctx, repo, commitID, file, checker)
+	rc, err := NewClient(database.NewMockDB()).NewFileReader(ctx, checker, repo, commitID, file)
 	if err != nil {
 		checkFn(t, err, nil)
 		return
@@ -2890,7 +2890,7 @@ func TestLFSSmudge(t *testing.T) {
 
 	// Check that LFSSmudge always returns the file contents
 	for path, content := range files {
-		r, err := c.LFSSmudge(ctx, repo, head, path, nil)
+		r, err := c.LFSSmudge(ctx, nil, repo, head, path)
 		if err != nil {
 			t.Fatalf("failed to run lfs-smudge on %q: %v", path, err)
 		}
@@ -2911,7 +2911,7 @@ func TestLFSSmudge(t *testing.T) {
 		if path == "in-lfs.txt" {
 			continue
 		}
-		b, err := c.ReadFile(ctx, repo, head, path, nil)
+		b, err := c.ReadFile(ctx, nil, repo, head, path)
 		if err != nil {
 			t.Fatalf("failed to read file %q: %v", path, err)
 		}
@@ -2925,7 +2925,7 @@ func TestLFSSmudge(t *testing.T) {
 oid sha256:6779da4a4fc9920a86eeb6f7a01062513dbbcc8f221028c7345993884e89a508
 size 12
 `
-	b, err := c.ReadFile(ctx, repo, head, "in-lfs.txt", nil)
+	b, err := c.ReadFile(ctx, nil, repo, head, "in-lfs.txt")
 	if err != nil {
 		t.Fatalf("failed to read file in-lfs.txt: %v", err)
 	}
@@ -2953,11 +2953,11 @@ previous ec809e79094cbcd05825446ee14c6d072466a0b7 release.sh
 filename release.sh
 	#!/usr/bin/env bash
 3f61310114082d6179c23f75950b88d1842fe2de 2 2
-	
+
 3f61310114082d6179c23f75950b88d1842fe2de 3 3
 	set -euf -o pipefail
 3f61310114082d6179c23f75950b88d1842fe2de 4 4
-	
+
 fbb98e0b7ff0752798463d9f49d922858a4188f6 5 5 10
 author Adam Harvey
 author-mail <aharvey@sourcegraph.com>
@@ -2988,7 +2988,7 @@ fbb98e0b7ff0752798463d9f49d922858a4188f6 12 12
 fbb98e0b7ff0752798463d9f49d922858a4188f6 13 13
 	esac
 fbb98e0b7ff0752798463d9f49d922858a4188f6 14 14
-	
+
 8a75c6f8b4cbe2a2f3c8be0f2c50bc766499f498 15 15 1
 author Adam Harvey
 author-mail <adam@adamharvey.name>
@@ -3009,7 +3009,7 @@ filename release.sh
 3f61310114082d6179c23f75950b88d1842fe2de 8 18
 	fi
 3f61310114082d6179c23f75950b88d1842fe2de 9 19
-	
+
 67b7b725a7ff913da520b997d71c840230351e30 10 20 1
 author Thorsten Ball
 author-mail <mrnugget@gmail.com>

--- a/internal/gitserver/integration_tests/commits_test.go
+++ b/internal/gitserver/integration_tests/commits_test.go
@@ -79,7 +79,7 @@ func TestGetCommits(t *testing.T) {
 			nil,
 		}
 
-		commits, err := gitserver.NewTestClient(http.DefaultClient, db, gitserverAddresses).GetCommits(ctx, repoCommits, true, nil)
+		commits, err := gitserver.NewTestClient(http.DefaultClient, db, gitserverAddresses).GetCommits(ctx, nil, repoCommits, true)
 		if err != nil {
 			t.Fatalf("unexpected error calling getCommits: %s", err)
 		}
@@ -117,7 +117,7 @@ func TestGetCommits(t *testing.T) {
 			nil,
 		}
 
-		commits, err := gitserver.NewTestClient(http.DefaultClient, db, gitserverAddresses).GetCommits(ctx, repoCommits, true, getTestSubRepoPermsChecker("file1", "file3"))
+		commits, err := gitserver.NewTestClient(http.DefaultClient, db, gitserverAddresses).GetCommits(ctx, getTestSubRepoPermsChecker("file1", "file3"), repoCommits, true)
 		if err != nil {
 			t.Fatalf("unexpected error calling getCommits: %s", err)
 		}
@@ -173,7 +173,7 @@ func TestHead(t *testing.T) {
 		repo := MakeGitRepository(t, gitCommands...)
 		ctx := context.Background()
 
-		head, exists, err := client.Head(ctx, repo, nil)
+		head, exists, err := client.Head(ctx, nil, repo)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -198,7 +198,7 @@ func TestHead(t *testing.T) {
 		})
 		checker := getTestSubRepoPermsChecker("file")
 		// call Head() when user doesn't have access to view the commit
-		_, exists, err := client.Head(ctx, repo, checker)
+		_, exists, err := client.Head(ctx, checker, repo)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -207,7 +207,7 @@ func TestHead(t *testing.T) {
 		}
 		readAllChecker := getTestSubRepoPermsChecker()
 		// call Head() when user has access to view the commit; should return expected commit
-		head, exists, err := client.Head(ctx, repo, readAllChecker)
+		head, exists, err := client.Head(ctx, readAllChecker, repo)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/gitserver/integration_tests/tree_test.go
+++ b/internal/gitserver/integration_tests/tree_test.go
@@ -173,7 +173,7 @@ func TestRepository_FileSystem(t *testing.T) {
 		}
 
 		// dir1/file1 should exist, contain "infile1", have the right mtime, and be a file.
-		file1Data, err := client.ReadFile(ctx, test.repo, test.first, "dir1/file1", nil)
+		file1Data, err := client.ReadFile(ctx, nil, test.repo, test.first, "dir1/file1")
 		if err != nil {
 			t.Errorf("%s: fs1.ReadFile(dir1/file1): %s", label, err)
 			continue
@@ -197,13 +197,13 @@ func TestRepository_FileSystem(t *testing.T) {
 		}
 
 		// file 2 shouldn't exist in the 1st commit.
-		_, err = client.ReadFile(ctx, test.repo, test.first, "file 2", nil)
+		_, err = client.ReadFile(ctx, nil, test.repo, test.first, "file 2")
 		if !os.IsNotExist(err) {
 			t.Errorf("%s: fs1.Open(file 2): got err %v, want os.IsNotExist (file 2 should not exist in this commit)", label, err)
 		}
 
 		// file 2 should exist in the 2nd commit.
-		_, err = client.ReadFile(ctx, test.repo, test.second, "file 2", nil)
+		_, err = client.ReadFile(ctx, nil, test.repo, test.second, "file 2")
 		if err != nil {
 			t.Errorf("%s: fs2.Open(file 2): %s", label, err)
 			continue
@@ -214,7 +214,7 @@ func TestRepository_FileSystem(t *testing.T) {
 			t.Errorf("%s: fs2.Stat(dir1/file1): %s", label, err)
 			continue
 		}
-		if _, err := client.ReadFile(ctx, test.repo, test.second, "dir1/file1", nil); err != nil {
+		if _, err := client.ReadFile(ctx, nil, test.repo, test.second, "dir1/file1"); err != nil {
 			t.Errorf("%s: fs2.Open(dir1/file1): %s", label, err)
 			continue
 		}
@@ -424,7 +424,7 @@ func TestRepository_FileSystem_gitSubmodules(t *testing.T) {
 		// .gitmodules file is entries[0]
 		checkSubmoduleFileInfo(label+" (ReadDir)", entries[1])
 
-		_, err = client.ReadFile(ctx, test.repo, commitID, "submod", nil)
+		_, err = client.ReadFile(ctx, nil, test.repo, commitID, "submod")
 		if err != nil {
 			t.Errorf("%s: fs.Open(submod): %s", label, err)
 			continue

--- a/internal/gitserver/mocks_temp.go
+++ b/internal/gitserver/mocks_temp.go
@@ -220,17 +220,17 @@ func NewMockClient() *MockClient {
 			},
 		},
 		BranchesContainingFunc: &ClientBranchesContainingFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) (r0 []string, r1 error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) (r0 []string, r1 error) {
 				return
 			},
 		},
 		CommitDateFunc: &ClientCommitDateFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) (r0 string, r1 time.Time, r2 bool, r3 error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) (r0 string, r1 time.Time, r2 bool, r3 error) {
 				return
 			},
 		},
 		CommitExistsFunc: &ClientCommitExistsFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) (r0 bool, r1 error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) (r0 bool, r1 error) {
 				return
 			},
 		},
@@ -240,17 +240,17 @@ func NewMockClient() *MockClient {
 			},
 		},
 		CommitsFunc: &ClientCommitsFunc{
-			defaultHook: func(context.Context, api.RepoName, CommitsOptions, authz.SubRepoPermissionChecker) (r0 []*gitdomain.Commit, r1 error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, CommitsOptions) (r0 []*gitdomain.Commit, r1 error) {
 				return
 			},
 		},
 		CommitsExistFunc: &ClientCommitsExistFunc{
-			defaultHook: func(context.Context, []api.RepoCommit, authz.SubRepoPermissionChecker) (r0 []bool, r1 error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, []api.RepoCommit) (r0 []bool, r1 error) {
 				return
 			},
 		},
 		CommitsUniqueToBranchFunc: &ClientCommitsUniqueToBranchFunc{
-			defaultHook: func(context.Context, api.RepoName, string, bool, *time.Time, authz.SubRepoPermissionChecker) (r0 map[string]time.Time, r1 error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, string, bool, *time.Time) (r0 map[string]time.Time, r1 error) {
 				return
 			},
 		},
@@ -265,7 +265,7 @@ func NewMockClient() *MockClient {
 			},
 		},
 		DiffFunc: &ClientDiffFunc{
-			defaultHook: func(context.Context, DiffOptions, authz.SubRepoPermissionChecker) (r0 *DiffFileIterator, r1 error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, DiffOptions) (r0 *DiffFileIterator, r1 error) {
 				return
 			},
 		},
@@ -280,7 +280,7 @@ func NewMockClient() *MockClient {
 			},
 		},
 		FirstEverCommitFunc: &ClientFirstEverCommitFunc{
-			defaultHook: func(context.Context, api.RepoName, authz.SubRepoPermissionChecker) (r0 *gitdomain.Commit, r1 error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName) (r0 *gitdomain.Commit, r1 error) {
 				return
 			},
 		},
@@ -290,12 +290,12 @@ func NewMockClient() *MockClient {
 			},
 		},
 		GetCommitFunc: &ClientGetCommitFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, ResolveRevisionOptions, authz.SubRepoPermissionChecker) (r0 *gitdomain.Commit, r1 error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, ResolveRevisionOptions) (r0 *gitdomain.Commit, r1 error) {
 				return
 			},
 		},
 		GetCommitsFunc: &ClientGetCommitsFunc{
-			defaultHook: func(context.Context, []api.RepoCommit, bool, authz.SubRepoPermissionChecker) (r0 []*gitdomain.Commit, r1 error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, []api.RepoCommit, bool) (r0 []*gitdomain.Commit, r1 error) {
 				return
 			},
 		},
@@ -310,12 +310,12 @@ func NewMockClient() *MockClient {
 			},
 		},
 		HasCommitAfterFunc: &ClientHasCommitAfterFunc{
-			defaultHook: func(context.Context, api.RepoName, string, string, authz.SubRepoPermissionChecker) (r0 bool, r1 error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, string, string) (r0 bool, r1 error) {
 				return
 			},
 		},
 		HeadFunc: &ClientHeadFunc{
-			defaultHook: func(context.Context, api.RepoName, authz.SubRepoPermissionChecker) (r0 string, r1 bool, r2 error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName) (r0 string, r1 bool, r2 error) {
 				return
 			},
 		},
@@ -325,7 +325,7 @@ func NewMockClient() *MockClient {
 			},
 		},
 		LFSSmudgeFunc: &ClientLFSSmudgeFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (r0 io.ReadCloser, r1 error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (r0 io.ReadCloser, r1 error) {
 				return
 			},
 		},
@@ -340,7 +340,7 @@ func NewMockClient() *MockClient {
 			},
 		},
 		ListFilesFunc: &ClientListFilesFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, *regexp.Regexp, authz.SubRepoPermissionChecker) (r0 []string, r1 error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, *regexp.Regexp) (r0 []string, r1 error) {
 				return
 			},
 		},
@@ -370,7 +370,7 @@ func NewMockClient() *MockClient {
 			},
 		},
 		NewFileReaderFunc: &ClientNewFileReaderFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (r0 io.ReadCloser, r1 error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (r0 io.ReadCloser, r1 error) {
 				return
 			},
 		},
@@ -385,12 +385,12 @@ func NewMockClient() *MockClient {
 			},
 		},
 		ReadFileFunc: &ClientReadFileFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (r0 []byte, r1 error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (r0 []byte, r1 error) {
 				return
 			},
 		},
 		RefDescriptionsFunc: &ClientRefDescriptionsFunc{
-			defaultHook: func(context.Context, api.RepoName, authz.SubRepoPermissionChecker, ...string) (r0 map[string][]gitdomain.RefDescription, r1 error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, ...string) (r0 map[string][]gitdomain.RefDescription, r1 error) {
 				return
 			},
 		},
@@ -497,17 +497,17 @@ func NewStrictMockClient() *MockClient {
 			},
 		},
 		BranchesContainingFunc: &ClientBranchesContainingFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) ([]string, error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) ([]string, error) {
 				panic("unexpected invocation of MockClient.BranchesContaining")
 			},
 		},
 		CommitDateFunc: &ClientCommitDateFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) (string, time.Time, bool, error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) (string, time.Time, bool, error) {
 				panic("unexpected invocation of MockClient.CommitDate")
 			},
 		},
 		CommitExistsFunc: &ClientCommitExistsFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) (bool, error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) (bool, error) {
 				panic("unexpected invocation of MockClient.CommitExists")
 			},
 		},
@@ -517,17 +517,17 @@ func NewStrictMockClient() *MockClient {
 			},
 		},
 		CommitsFunc: &ClientCommitsFunc{
-			defaultHook: func(context.Context, api.RepoName, CommitsOptions, authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, CommitsOptions) ([]*gitdomain.Commit, error) {
 				panic("unexpected invocation of MockClient.Commits")
 			},
 		},
 		CommitsExistFunc: &ClientCommitsExistFunc{
-			defaultHook: func(context.Context, []api.RepoCommit, authz.SubRepoPermissionChecker) ([]bool, error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, []api.RepoCommit) ([]bool, error) {
 				panic("unexpected invocation of MockClient.CommitsExist")
 			},
 		},
 		CommitsUniqueToBranchFunc: &ClientCommitsUniqueToBranchFunc{
-			defaultHook: func(context.Context, api.RepoName, string, bool, *time.Time, authz.SubRepoPermissionChecker) (map[string]time.Time, error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, string, bool, *time.Time) (map[string]time.Time, error) {
 				panic("unexpected invocation of MockClient.CommitsUniqueToBranch")
 			},
 		},
@@ -542,7 +542,7 @@ func NewStrictMockClient() *MockClient {
 			},
 		},
 		DiffFunc: &ClientDiffFunc{
-			defaultHook: func(context.Context, DiffOptions, authz.SubRepoPermissionChecker) (*DiffFileIterator, error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, DiffOptions) (*DiffFileIterator, error) {
 				panic("unexpected invocation of MockClient.Diff")
 			},
 		},
@@ -557,7 +557,7 @@ func NewStrictMockClient() *MockClient {
 			},
 		},
 		FirstEverCommitFunc: &ClientFirstEverCommitFunc{
-			defaultHook: func(context.Context, api.RepoName, authz.SubRepoPermissionChecker) (*gitdomain.Commit, error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName) (*gitdomain.Commit, error) {
 				panic("unexpected invocation of MockClient.FirstEverCommit")
 			},
 		},
@@ -567,12 +567,12 @@ func NewStrictMockClient() *MockClient {
 			},
 		},
 		GetCommitFunc: &ClientGetCommitFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, ResolveRevisionOptions, authz.SubRepoPermissionChecker) (*gitdomain.Commit, error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, ResolveRevisionOptions) (*gitdomain.Commit, error) {
 				panic("unexpected invocation of MockClient.GetCommit")
 			},
 		},
 		GetCommitsFunc: &ClientGetCommitsFunc{
-			defaultHook: func(context.Context, []api.RepoCommit, bool, authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, []api.RepoCommit, bool) ([]*gitdomain.Commit, error) {
 				panic("unexpected invocation of MockClient.GetCommits")
 			},
 		},
@@ -587,12 +587,12 @@ func NewStrictMockClient() *MockClient {
 			},
 		},
 		HasCommitAfterFunc: &ClientHasCommitAfterFunc{
-			defaultHook: func(context.Context, api.RepoName, string, string, authz.SubRepoPermissionChecker) (bool, error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, string, string) (bool, error) {
 				panic("unexpected invocation of MockClient.HasCommitAfter")
 			},
 		},
 		HeadFunc: &ClientHeadFunc{
-			defaultHook: func(context.Context, api.RepoName, authz.SubRepoPermissionChecker) (string, bool, error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName) (string, bool, error) {
 				panic("unexpected invocation of MockClient.Head")
 			},
 		},
@@ -602,7 +602,7 @@ func NewStrictMockClient() *MockClient {
 			},
 		},
 		LFSSmudgeFunc: &ClientLFSSmudgeFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (io.ReadCloser, error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (io.ReadCloser, error) {
 				panic("unexpected invocation of MockClient.LFSSmudge")
 			},
 		},
@@ -617,7 +617,7 @@ func NewStrictMockClient() *MockClient {
 			},
 		},
 		ListFilesFunc: &ClientListFilesFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, *regexp.Regexp, authz.SubRepoPermissionChecker) ([]string, error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, *regexp.Regexp) ([]string, error) {
 				panic("unexpected invocation of MockClient.ListFiles")
 			},
 		},
@@ -647,7 +647,7 @@ func NewStrictMockClient() *MockClient {
 			},
 		},
 		NewFileReaderFunc: &ClientNewFileReaderFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (io.ReadCloser, error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (io.ReadCloser, error) {
 				panic("unexpected invocation of MockClient.NewFileReader")
 			},
 		},
@@ -662,12 +662,12 @@ func NewStrictMockClient() *MockClient {
 			},
 		},
 		ReadFileFunc: &ClientReadFileFunc{
-			defaultHook: func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) ([]byte, error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) ([]byte, error) {
 				panic("unexpected invocation of MockClient.ReadFile")
 			},
 		},
 		RefDescriptionsFunc: &ClientRefDescriptionsFunc{
-			defaultHook: func(context.Context, api.RepoName, authz.SubRepoPermissionChecker, ...string) (map[string][]gitdomain.RefDescription, error) {
+			defaultHook: func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, ...string) (map[string][]gitdomain.RefDescription, error) {
 				panic("unexpected invocation of MockClient.RefDescriptions")
 			},
 		},
@@ -1457,15 +1457,15 @@ func (c ClientBlameFileFuncCall) Results() []interface{} {
 // ClientBranchesContainingFunc describes the behavior when the
 // BranchesContaining method of the parent MockClient instance is invoked.
 type ClientBranchesContainingFunc struct {
-	defaultHook func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) ([]string, error)
-	hooks       []func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) ([]string, error)
+	defaultHook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) ([]string, error)
+	hooks       []func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) ([]string, error)
 	history     []ClientBranchesContainingFuncCall
 	mutex       sync.Mutex
 }
 
 // BranchesContaining delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockClient) BranchesContaining(v0 context.Context, v1 api.RepoName, v2 api.CommitID, v3 authz.SubRepoPermissionChecker) ([]string, error) {
+func (m *MockClient) BranchesContaining(v0 context.Context, v1 authz.SubRepoPermissionChecker, v2 api.RepoName, v3 api.CommitID) ([]string, error) {
 	r0, r1 := m.BranchesContainingFunc.nextHook()(v0, v1, v2, v3)
 	m.BranchesContainingFunc.appendCall(ClientBranchesContainingFuncCall{v0, v1, v2, v3, r0, r1})
 	return r0, r1
@@ -1474,7 +1474,7 @@ func (m *MockClient) BranchesContaining(v0 context.Context, v1 api.RepoName, v2 
 // SetDefaultHook sets function that is called when the BranchesContaining
 // method of the parent MockClient instance is invoked and the hook queue is
 // empty.
-func (f *ClientBranchesContainingFunc) SetDefaultHook(hook func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) ([]string, error)) {
+func (f *ClientBranchesContainingFunc) SetDefaultHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) ([]string, error)) {
 	f.defaultHook = hook
 }
 
@@ -1482,7 +1482,7 @@ func (f *ClientBranchesContainingFunc) SetDefaultHook(hook func(context.Context,
 // BranchesContaining method of the parent MockClient instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *ClientBranchesContainingFunc) PushHook(hook func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) ([]string, error)) {
+func (f *ClientBranchesContainingFunc) PushHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) ([]string, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1491,19 +1491,19 @@ func (f *ClientBranchesContainingFunc) PushHook(hook func(context.Context, api.R
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientBranchesContainingFunc) SetDefaultReturn(r0 []string, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) ([]string, error) {
+	f.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) ([]string, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientBranchesContainingFunc) PushReturn(r0 []string, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) ([]string, error) {
+	f.PushHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) ([]string, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientBranchesContainingFunc) nextHook() func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) ([]string, error) {
+func (f *ClientBranchesContainingFunc) nextHook() func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) ([]string, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1541,13 +1541,13 @@ type ClientBranchesContainingFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 api.RepoName
+	Arg1 authz.SubRepoPermissionChecker
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 api.CommitID
+	Arg2 api.RepoName
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 authz.SubRepoPermissionChecker
+	Arg3 api.CommitID
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []string
@@ -1571,15 +1571,15 @@ func (c ClientBranchesContainingFuncCall) Results() []interface{} {
 // ClientCommitDateFunc describes the behavior when the CommitDate method of
 // the parent MockClient instance is invoked.
 type ClientCommitDateFunc struct {
-	defaultHook func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) (string, time.Time, bool, error)
-	hooks       []func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) (string, time.Time, bool, error)
+	defaultHook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) (string, time.Time, bool, error)
+	hooks       []func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) (string, time.Time, bool, error)
 	history     []ClientCommitDateFuncCall
 	mutex       sync.Mutex
 }
 
 // CommitDate delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockClient) CommitDate(v0 context.Context, v1 api.RepoName, v2 api.CommitID, v3 authz.SubRepoPermissionChecker) (string, time.Time, bool, error) {
+func (m *MockClient) CommitDate(v0 context.Context, v1 authz.SubRepoPermissionChecker, v2 api.RepoName, v3 api.CommitID) (string, time.Time, bool, error) {
 	r0, r1, r2, r3 := m.CommitDateFunc.nextHook()(v0, v1, v2, v3)
 	m.CommitDateFunc.appendCall(ClientCommitDateFuncCall{v0, v1, v2, v3, r0, r1, r2, r3})
 	return r0, r1, r2, r3
@@ -1587,7 +1587,7 @@ func (m *MockClient) CommitDate(v0 context.Context, v1 api.RepoName, v2 api.Comm
 
 // SetDefaultHook sets function that is called when the CommitDate method of
 // the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientCommitDateFunc) SetDefaultHook(hook func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) (string, time.Time, bool, error)) {
+func (f *ClientCommitDateFunc) SetDefaultHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) (string, time.Time, bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -1595,7 +1595,7 @@ func (f *ClientCommitDateFunc) SetDefaultHook(hook func(context.Context, api.Rep
 // CommitDate method of the parent MockClient instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ClientCommitDateFunc) PushHook(hook func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) (string, time.Time, bool, error)) {
+func (f *ClientCommitDateFunc) PushHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) (string, time.Time, bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1604,19 +1604,19 @@ func (f *ClientCommitDateFunc) PushHook(hook func(context.Context, api.RepoName,
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientCommitDateFunc) SetDefaultReturn(r0 string, r1 time.Time, r2 bool, r3 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) (string, time.Time, bool, error) {
+	f.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) (string, time.Time, bool, error) {
 		return r0, r1, r2, r3
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientCommitDateFunc) PushReturn(r0 string, r1 time.Time, r2 bool, r3 error) {
-	f.PushHook(func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) (string, time.Time, bool, error) {
+	f.PushHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) (string, time.Time, bool, error) {
 		return r0, r1, r2, r3
 	})
 }
 
-func (f *ClientCommitDateFunc) nextHook() func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) (string, time.Time, bool, error) {
+func (f *ClientCommitDateFunc) nextHook() func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) (string, time.Time, bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1654,13 +1654,13 @@ type ClientCommitDateFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 api.RepoName
+	Arg1 authz.SubRepoPermissionChecker
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 api.CommitID
+	Arg2 api.RepoName
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 authz.SubRepoPermissionChecker
+	Arg3 api.CommitID
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 string
@@ -1690,15 +1690,15 @@ func (c ClientCommitDateFuncCall) Results() []interface{} {
 // ClientCommitExistsFunc describes the behavior when the CommitExists
 // method of the parent MockClient instance is invoked.
 type ClientCommitExistsFunc struct {
-	defaultHook func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) (bool, error)
-	hooks       []func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) (bool, error)
+	defaultHook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) (bool, error)
+	hooks       []func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) (bool, error)
 	history     []ClientCommitExistsFuncCall
 	mutex       sync.Mutex
 }
 
 // CommitExists delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockClient) CommitExists(v0 context.Context, v1 api.RepoName, v2 api.CommitID, v3 authz.SubRepoPermissionChecker) (bool, error) {
+func (m *MockClient) CommitExists(v0 context.Context, v1 authz.SubRepoPermissionChecker, v2 api.RepoName, v3 api.CommitID) (bool, error) {
 	r0, r1 := m.CommitExistsFunc.nextHook()(v0, v1, v2, v3)
 	m.CommitExistsFunc.appendCall(ClientCommitExistsFuncCall{v0, v1, v2, v3, r0, r1})
 	return r0, r1
@@ -1706,7 +1706,7 @@ func (m *MockClient) CommitExists(v0 context.Context, v1 api.RepoName, v2 api.Co
 
 // SetDefaultHook sets function that is called when the CommitExists method
 // of the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientCommitExistsFunc) SetDefaultHook(hook func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) (bool, error)) {
+func (f *ClientCommitExistsFunc) SetDefaultHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) (bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -1714,7 +1714,7 @@ func (f *ClientCommitExistsFunc) SetDefaultHook(hook func(context.Context, api.R
 // CommitExists method of the parent MockClient instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ClientCommitExistsFunc) PushHook(hook func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) (bool, error)) {
+func (f *ClientCommitExistsFunc) PushHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) (bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1723,19 +1723,19 @@ func (f *ClientCommitExistsFunc) PushHook(hook func(context.Context, api.RepoNam
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientCommitExistsFunc) SetDefaultReturn(r0 bool, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) (bool, error) {
+	f.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) (bool, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientCommitExistsFunc) PushReturn(r0 bool, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) (bool, error) {
+	f.PushHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) (bool, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientCommitExistsFunc) nextHook() func(context.Context, api.RepoName, api.CommitID, authz.SubRepoPermissionChecker) (bool, error) {
+func (f *ClientCommitExistsFunc) nextHook() func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID) (bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1773,13 +1773,13 @@ type ClientCommitExistsFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 api.RepoName
+	Arg1 authz.SubRepoPermissionChecker
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 api.CommitID
+	Arg2 api.RepoName
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 authz.SubRepoPermissionChecker
+	Arg3 api.CommitID
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 bool
@@ -1913,15 +1913,15 @@ func (c ClientCommitGraphFuncCall) Results() []interface{} {
 // ClientCommitsFunc describes the behavior when the Commits method of the
 // parent MockClient instance is invoked.
 type ClientCommitsFunc struct {
-	defaultHook func(context.Context, api.RepoName, CommitsOptions, authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error)
-	hooks       []func(context.Context, api.RepoName, CommitsOptions, authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error)
+	defaultHook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, CommitsOptions) ([]*gitdomain.Commit, error)
+	hooks       []func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, CommitsOptions) ([]*gitdomain.Commit, error)
 	history     []ClientCommitsFuncCall
 	mutex       sync.Mutex
 }
 
 // Commits delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockClient) Commits(v0 context.Context, v1 api.RepoName, v2 CommitsOptions, v3 authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error) {
+func (m *MockClient) Commits(v0 context.Context, v1 authz.SubRepoPermissionChecker, v2 api.RepoName, v3 CommitsOptions) ([]*gitdomain.Commit, error) {
 	r0, r1 := m.CommitsFunc.nextHook()(v0, v1, v2, v3)
 	m.CommitsFunc.appendCall(ClientCommitsFuncCall{v0, v1, v2, v3, r0, r1})
 	return r0, r1
@@ -1929,7 +1929,7 @@ func (m *MockClient) Commits(v0 context.Context, v1 api.RepoName, v2 CommitsOpti
 
 // SetDefaultHook sets function that is called when the Commits method of
 // the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientCommitsFunc) SetDefaultHook(hook func(context.Context, api.RepoName, CommitsOptions, authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error)) {
+func (f *ClientCommitsFunc) SetDefaultHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, CommitsOptions) ([]*gitdomain.Commit, error)) {
 	f.defaultHook = hook
 }
 
@@ -1937,7 +1937,7 @@ func (f *ClientCommitsFunc) SetDefaultHook(hook func(context.Context, api.RepoNa
 // Commits method of the parent MockClient instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *ClientCommitsFunc) PushHook(hook func(context.Context, api.RepoName, CommitsOptions, authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error)) {
+func (f *ClientCommitsFunc) PushHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, CommitsOptions) ([]*gitdomain.Commit, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1946,19 +1946,19 @@ func (f *ClientCommitsFunc) PushHook(hook func(context.Context, api.RepoName, Co
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientCommitsFunc) SetDefaultReturn(r0 []*gitdomain.Commit, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, CommitsOptions, authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error) {
+	f.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, CommitsOptions) ([]*gitdomain.Commit, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientCommitsFunc) PushReturn(r0 []*gitdomain.Commit, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, CommitsOptions, authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error) {
+	f.PushHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, CommitsOptions) ([]*gitdomain.Commit, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientCommitsFunc) nextHook() func(context.Context, api.RepoName, CommitsOptions, authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error) {
+func (f *ClientCommitsFunc) nextHook() func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, CommitsOptions) ([]*gitdomain.Commit, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1996,13 +1996,13 @@ type ClientCommitsFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 api.RepoName
+	Arg1 authz.SubRepoPermissionChecker
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 CommitsOptions
+	Arg2 api.RepoName
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 authz.SubRepoPermissionChecker
+	Arg3 CommitsOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []*gitdomain.Commit
@@ -2026,15 +2026,15 @@ func (c ClientCommitsFuncCall) Results() []interface{} {
 // ClientCommitsExistFunc describes the behavior when the CommitsExist
 // method of the parent MockClient instance is invoked.
 type ClientCommitsExistFunc struct {
-	defaultHook func(context.Context, []api.RepoCommit, authz.SubRepoPermissionChecker) ([]bool, error)
-	hooks       []func(context.Context, []api.RepoCommit, authz.SubRepoPermissionChecker) ([]bool, error)
+	defaultHook func(context.Context, authz.SubRepoPermissionChecker, []api.RepoCommit) ([]bool, error)
+	hooks       []func(context.Context, authz.SubRepoPermissionChecker, []api.RepoCommit) ([]bool, error)
 	history     []ClientCommitsExistFuncCall
 	mutex       sync.Mutex
 }
 
 // CommitsExist delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockClient) CommitsExist(v0 context.Context, v1 []api.RepoCommit, v2 authz.SubRepoPermissionChecker) ([]bool, error) {
+func (m *MockClient) CommitsExist(v0 context.Context, v1 authz.SubRepoPermissionChecker, v2 []api.RepoCommit) ([]bool, error) {
 	r0, r1 := m.CommitsExistFunc.nextHook()(v0, v1, v2)
 	m.CommitsExistFunc.appendCall(ClientCommitsExistFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
@@ -2042,7 +2042,7 @@ func (m *MockClient) CommitsExist(v0 context.Context, v1 []api.RepoCommit, v2 au
 
 // SetDefaultHook sets function that is called when the CommitsExist method
 // of the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientCommitsExistFunc) SetDefaultHook(hook func(context.Context, []api.RepoCommit, authz.SubRepoPermissionChecker) ([]bool, error)) {
+func (f *ClientCommitsExistFunc) SetDefaultHook(hook func(context.Context, authz.SubRepoPermissionChecker, []api.RepoCommit) ([]bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -2050,7 +2050,7 @@ func (f *ClientCommitsExistFunc) SetDefaultHook(hook func(context.Context, []api
 // CommitsExist method of the parent MockClient instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ClientCommitsExistFunc) PushHook(hook func(context.Context, []api.RepoCommit, authz.SubRepoPermissionChecker) ([]bool, error)) {
+func (f *ClientCommitsExistFunc) PushHook(hook func(context.Context, authz.SubRepoPermissionChecker, []api.RepoCommit) ([]bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2059,19 +2059,19 @@ func (f *ClientCommitsExistFunc) PushHook(hook func(context.Context, []api.RepoC
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientCommitsExistFunc) SetDefaultReturn(r0 []bool, r1 error) {
-	f.SetDefaultHook(func(context.Context, []api.RepoCommit, authz.SubRepoPermissionChecker) ([]bool, error) {
+	f.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, []api.RepoCommit) ([]bool, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientCommitsExistFunc) PushReturn(r0 []bool, r1 error) {
-	f.PushHook(func(context.Context, []api.RepoCommit, authz.SubRepoPermissionChecker) ([]bool, error) {
+	f.PushHook(func(context.Context, authz.SubRepoPermissionChecker, []api.RepoCommit) ([]bool, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientCommitsExistFunc) nextHook() func(context.Context, []api.RepoCommit, authz.SubRepoPermissionChecker) ([]bool, error) {
+func (f *ClientCommitsExistFunc) nextHook() func(context.Context, authz.SubRepoPermissionChecker, []api.RepoCommit) ([]bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2109,10 +2109,10 @@ type ClientCommitsExistFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 []api.RepoCommit
+	Arg1 authz.SubRepoPermissionChecker
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 authz.SubRepoPermissionChecker
+	Arg2 []api.RepoCommit
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []bool
@@ -2137,15 +2137,15 @@ func (c ClientCommitsExistFuncCall) Results() []interface{} {
 // CommitsUniqueToBranch method of the parent MockClient instance is
 // invoked.
 type ClientCommitsUniqueToBranchFunc struct {
-	defaultHook func(context.Context, api.RepoName, string, bool, *time.Time, authz.SubRepoPermissionChecker) (map[string]time.Time, error)
-	hooks       []func(context.Context, api.RepoName, string, bool, *time.Time, authz.SubRepoPermissionChecker) (map[string]time.Time, error)
+	defaultHook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, string, bool, *time.Time) (map[string]time.Time, error)
+	hooks       []func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, string, bool, *time.Time) (map[string]time.Time, error)
 	history     []ClientCommitsUniqueToBranchFuncCall
 	mutex       sync.Mutex
 }
 
 // CommitsUniqueToBranch delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockClient) CommitsUniqueToBranch(v0 context.Context, v1 api.RepoName, v2 string, v3 bool, v4 *time.Time, v5 authz.SubRepoPermissionChecker) (map[string]time.Time, error) {
+func (m *MockClient) CommitsUniqueToBranch(v0 context.Context, v1 authz.SubRepoPermissionChecker, v2 api.RepoName, v3 string, v4 bool, v5 *time.Time) (map[string]time.Time, error) {
 	r0, r1 := m.CommitsUniqueToBranchFunc.nextHook()(v0, v1, v2, v3, v4, v5)
 	m.CommitsUniqueToBranchFunc.appendCall(ClientCommitsUniqueToBranchFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
@@ -2154,7 +2154,7 @@ func (m *MockClient) CommitsUniqueToBranch(v0 context.Context, v1 api.RepoName, 
 // SetDefaultHook sets function that is called when the
 // CommitsUniqueToBranch method of the parent MockClient instance is invoked
 // and the hook queue is empty.
-func (f *ClientCommitsUniqueToBranchFunc) SetDefaultHook(hook func(context.Context, api.RepoName, string, bool, *time.Time, authz.SubRepoPermissionChecker) (map[string]time.Time, error)) {
+func (f *ClientCommitsUniqueToBranchFunc) SetDefaultHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, string, bool, *time.Time) (map[string]time.Time, error)) {
 	f.defaultHook = hook
 }
 
@@ -2162,7 +2162,7 @@ func (f *ClientCommitsUniqueToBranchFunc) SetDefaultHook(hook func(context.Conte
 // CommitsUniqueToBranch method of the parent MockClient instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *ClientCommitsUniqueToBranchFunc) PushHook(hook func(context.Context, api.RepoName, string, bool, *time.Time, authz.SubRepoPermissionChecker) (map[string]time.Time, error)) {
+func (f *ClientCommitsUniqueToBranchFunc) PushHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, string, bool, *time.Time) (map[string]time.Time, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2171,19 +2171,19 @@ func (f *ClientCommitsUniqueToBranchFunc) PushHook(hook func(context.Context, ap
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientCommitsUniqueToBranchFunc) SetDefaultReturn(r0 map[string]time.Time, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, string, bool, *time.Time, authz.SubRepoPermissionChecker) (map[string]time.Time, error) {
+	f.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, string, bool, *time.Time) (map[string]time.Time, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientCommitsUniqueToBranchFunc) PushReturn(r0 map[string]time.Time, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, string, bool, *time.Time, authz.SubRepoPermissionChecker) (map[string]time.Time, error) {
+	f.PushHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, string, bool, *time.Time) (map[string]time.Time, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientCommitsUniqueToBranchFunc) nextHook() func(context.Context, api.RepoName, string, bool, *time.Time, authz.SubRepoPermissionChecker) (map[string]time.Time, error) {
+func (f *ClientCommitsUniqueToBranchFunc) nextHook() func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, string, bool, *time.Time) (map[string]time.Time, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2221,19 +2221,19 @@ type ClientCommitsUniqueToBranchFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 api.RepoName
+	Arg1 authz.SubRepoPermissionChecker
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 string
+	Arg2 api.RepoName
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 bool
+	Arg3 string
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
-	Arg4 *time.Time
+	Arg4 bool
 	// Arg5 is the value of the 6th argument passed to this method
 	// invocation.
-	Arg5 authz.SubRepoPermissionChecker
+	Arg5 *time.Time
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 map[string]time.Time
@@ -2477,15 +2477,15 @@ func (c ClientCreateCommitFromPatchFuncCall) Results() []interface{} {
 // ClientDiffFunc describes the behavior when the Diff method of the parent
 // MockClient instance is invoked.
 type ClientDiffFunc struct {
-	defaultHook func(context.Context, DiffOptions, authz.SubRepoPermissionChecker) (*DiffFileIterator, error)
-	hooks       []func(context.Context, DiffOptions, authz.SubRepoPermissionChecker) (*DiffFileIterator, error)
+	defaultHook func(context.Context, authz.SubRepoPermissionChecker, DiffOptions) (*DiffFileIterator, error)
+	hooks       []func(context.Context, authz.SubRepoPermissionChecker, DiffOptions) (*DiffFileIterator, error)
 	history     []ClientDiffFuncCall
 	mutex       sync.Mutex
 }
 
 // Diff delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockClient) Diff(v0 context.Context, v1 DiffOptions, v2 authz.SubRepoPermissionChecker) (*DiffFileIterator, error) {
+func (m *MockClient) Diff(v0 context.Context, v1 authz.SubRepoPermissionChecker, v2 DiffOptions) (*DiffFileIterator, error) {
 	r0, r1 := m.DiffFunc.nextHook()(v0, v1, v2)
 	m.DiffFunc.appendCall(ClientDiffFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
@@ -2493,7 +2493,7 @@ func (m *MockClient) Diff(v0 context.Context, v1 DiffOptions, v2 authz.SubRepoPe
 
 // SetDefaultHook sets function that is called when the Diff method of the
 // parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientDiffFunc) SetDefaultHook(hook func(context.Context, DiffOptions, authz.SubRepoPermissionChecker) (*DiffFileIterator, error)) {
+func (f *ClientDiffFunc) SetDefaultHook(hook func(context.Context, authz.SubRepoPermissionChecker, DiffOptions) (*DiffFileIterator, error)) {
 	f.defaultHook = hook
 }
 
@@ -2501,7 +2501,7 @@ func (f *ClientDiffFunc) SetDefaultHook(hook func(context.Context, DiffOptions, 
 // Diff method of the parent MockClient instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *ClientDiffFunc) PushHook(hook func(context.Context, DiffOptions, authz.SubRepoPermissionChecker) (*DiffFileIterator, error)) {
+func (f *ClientDiffFunc) PushHook(hook func(context.Context, authz.SubRepoPermissionChecker, DiffOptions) (*DiffFileIterator, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2510,19 +2510,19 @@ func (f *ClientDiffFunc) PushHook(hook func(context.Context, DiffOptions, authz.
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientDiffFunc) SetDefaultReturn(r0 *DiffFileIterator, r1 error) {
-	f.SetDefaultHook(func(context.Context, DiffOptions, authz.SubRepoPermissionChecker) (*DiffFileIterator, error) {
+	f.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, DiffOptions) (*DiffFileIterator, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientDiffFunc) PushReturn(r0 *DiffFileIterator, r1 error) {
-	f.PushHook(func(context.Context, DiffOptions, authz.SubRepoPermissionChecker) (*DiffFileIterator, error) {
+	f.PushHook(func(context.Context, authz.SubRepoPermissionChecker, DiffOptions) (*DiffFileIterator, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientDiffFunc) nextHook() func(context.Context, DiffOptions, authz.SubRepoPermissionChecker) (*DiffFileIterator, error) {
+func (f *ClientDiffFunc) nextHook() func(context.Context, authz.SubRepoPermissionChecker, DiffOptions) (*DiffFileIterator, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2560,10 +2560,10 @@ type ClientDiffFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 DiffOptions
+	Arg1 authz.SubRepoPermissionChecker
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 authz.SubRepoPermissionChecker
+	Arg2 DiffOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *DiffFileIterator
@@ -2819,15 +2819,15 @@ func (c ClientDiffSymbolsFuncCall) Results() []interface{} {
 // ClientFirstEverCommitFunc describes the behavior when the FirstEverCommit
 // method of the parent MockClient instance is invoked.
 type ClientFirstEverCommitFunc struct {
-	defaultHook func(context.Context, api.RepoName, authz.SubRepoPermissionChecker) (*gitdomain.Commit, error)
-	hooks       []func(context.Context, api.RepoName, authz.SubRepoPermissionChecker) (*gitdomain.Commit, error)
+	defaultHook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName) (*gitdomain.Commit, error)
+	hooks       []func(context.Context, authz.SubRepoPermissionChecker, api.RepoName) (*gitdomain.Commit, error)
 	history     []ClientFirstEverCommitFuncCall
 	mutex       sync.Mutex
 }
 
 // FirstEverCommit delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockClient) FirstEverCommit(v0 context.Context, v1 api.RepoName, v2 authz.SubRepoPermissionChecker) (*gitdomain.Commit, error) {
+func (m *MockClient) FirstEverCommit(v0 context.Context, v1 authz.SubRepoPermissionChecker, v2 api.RepoName) (*gitdomain.Commit, error) {
 	r0, r1 := m.FirstEverCommitFunc.nextHook()(v0, v1, v2)
 	m.FirstEverCommitFunc.appendCall(ClientFirstEverCommitFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
@@ -2836,7 +2836,7 @@ func (m *MockClient) FirstEverCommit(v0 context.Context, v1 api.RepoName, v2 aut
 // SetDefaultHook sets function that is called when the FirstEverCommit
 // method of the parent MockClient instance is invoked and the hook queue is
 // empty.
-func (f *ClientFirstEverCommitFunc) SetDefaultHook(hook func(context.Context, api.RepoName, authz.SubRepoPermissionChecker) (*gitdomain.Commit, error)) {
+func (f *ClientFirstEverCommitFunc) SetDefaultHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName) (*gitdomain.Commit, error)) {
 	f.defaultHook = hook
 }
 
@@ -2844,7 +2844,7 @@ func (f *ClientFirstEverCommitFunc) SetDefaultHook(hook func(context.Context, ap
 // FirstEverCommit method of the parent MockClient instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ClientFirstEverCommitFunc) PushHook(hook func(context.Context, api.RepoName, authz.SubRepoPermissionChecker) (*gitdomain.Commit, error)) {
+func (f *ClientFirstEverCommitFunc) PushHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName) (*gitdomain.Commit, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2853,19 +2853,19 @@ func (f *ClientFirstEverCommitFunc) PushHook(hook func(context.Context, api.Repo
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientFirstEverCommitFunc) SetDefaultReturn(r0 *gitdomain.Commit, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, authz.SubRepoPermissionChecker) (*gitdomain.Commit, error) {
+	f.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName) (*gitdomain.Commit, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientFirstEverCommitFunc) PushReturn(r0 *gitdomain.Commit, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, authz.SubRepoPermissionChecker) (*gitdomain.Commit, error) {
+	f.PushHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName) (*gitdomain.Commit, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientFirstEverCommitFunc) nextHook() func(context.Context, api.RepoName, authz.SubRepoPermissionChecker) (*gitdomain.Commit, error) {
+func (f *ClientFirstEverCommitFunc) nextHook() func(context.Context, authz.SubRepoPermissionChecker, api.RepoName) (*gitdomain.Commit, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2903,10 +2903,10 @@ type ClientFirstEverCommitFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 api.RepoName
+	Arg1 authz.SubRepoPermissionChecker
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 authz.SubRepoPermissionChecker
+	Arg2 api.RepoName
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *gitdomain.Commit
@@ -3044,15 +3044,15 @@ func (c ClientGetBehindAheadFuncCall) Results() []interface{} {
 // ClientGetCommitFunc describes the behavior when the GetCommit method of
 // the parent MockClient instance is invoked.
 type ClientGetCommitFunc struct {
-	defaultHook func(context.Context, api.RepoName, api.CommitID, ResolveRevisionOptions, authz.SubRepoPermissionChecker) (*gitdomain.Commit, error)
-	hooks       []func(context.Context, api.RepoName, api.CommitID, ResolveRevisionOptions, authz.SubRepoPermissionChecker) (*gitdomain.Commit, error)
+	defaultHook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, ResolveRevisionOptions) (*gitdomain.Commit, error)
+	hooks       []func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, ResolveRevisionOptions) (*gitdomain.Commit, error)
 	history     []ClientGetCommitFuncCall
 	mutex       sync.Mutex
 }
 
 // GetCommit delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockClient) GetCommit(v0 context.Context, v1 api.RepoName, v2 api.CommitID, v3 ResolveRevisionOptions, v4 authz.SubRepoPermissionChecker) (*gitdomain.Commit, error) {
+func (m *MockClient) GetCommit(v0 context.Context, v1 authz.SubRepoPermissionChecker, v2 api.RepoName, v3 api.CommitID, v4 ResolveRevisionOptions) (*gitdomain.Commit, error) {
 	r0, r1 := m.GetCommitFunc.nextHook()(v0, v1, v2, v3, v4)
 	m.GetCommitFunc.appendCall(ClientGetCommitFuncCall{v0, v1, v2, v3, v4, r0, r1})
 	return r0, r1
@@ -3060,7 +3060,7 @@ func (m *MockClient) GetCommit(v0 context.Context, v1 api.RepoName, v2 api.Commi
 
 // SetDefaultHook sets function that is called when the GetCommit method of
 // the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientGetCommitFunc) SetDefaultHook(hook func(context.Context, api.RepoName, api.CommitID, ResolveRevisionOptions, authz.SubRepoPermissionChecker) (*gitdomain.Commit, error)) {
+func (f *ClientGetCommitFunc) SetDefaultHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, ResolveRevisionOptions) (*gitdomain.Commit, error)) {
 	f.defaultHook = hook
 }
 
@@ -3068,7 +3068,7 @@ func (f *ClientGetCommitFunc) SetDefaultHook(hook func(context.Context, api.Repo
 // GetCommit method of the parent MockClient instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ClientGetCommitFunc) PushHook(hook func(context.Context, api.RepoName, api.CommitID, ResolveRevisionOptions, authz.SubRepoPermissionChecker) (*gitdomain.Commit, error)) {
+func (f *ClientGetCommitFunc) PushHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, ResolveRevisionOptions) (*gitdomain.Commit, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3077,19 +3077,19 @@ func (f *ClientGetCommitFunc) PushHook(hook func(context.Context, api.RepoName, 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientGetCommitFunc) SetDefaultReturn(r0 *gitdomain.Commit, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, ResolveRevisionOptions, authz.SubRepoPermissionChecker) (*gitdomain.Commit, error) {
+	f.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, ResolveRevisionOptions) (*gitdomain.Commit, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientGetCommitFunc) PushReturn(r0 *gitdomain.Commit, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, api.CommitID, ResolveRevisionOptions, authz.SubRepoPermissionChecker) (*gitdomain.Commit, error) {
+	f.PushHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, ResolveRevisionOptions) (*gitdomain.Commit, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientGetCommitFunc) nextHook() func(context.Context, api.RepoName, api.CommitID, ResolveRevisionOptions, authz.SubRepoPermissionChecker) (*gitdomain.Commit, error) {
+func (f *ClientGetCommitFunc) nextHook() func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, ResolveRevisionOptions) (*gitdomain.Commit, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3127,16 +3127,16 @@ type ClientGetCommitFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 api.RepoName
+	Arg1 authz.SubRepoPermissionChecker
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 api.CommitID
+	Arg2 api.RepoName
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 ResolveRevisionOptions
+	Arg3 api.CommitID
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
-	Arg4 authz.SubRepoPermissionChecker
+	Arg4 ResolveRevisionOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *gitdomain.Commit
@@ -3160,15 +3160,15 @@ func (c ClientGetCommitFuncCall) Results() []interface{} {
 // ClientGetCommitsFunc describes the behavior when the GetCommits method of
 // the parent MockClient instance is invoked.
 type ClientGetCommitsFunc struct {
-	defaultHook func(context.Context, []api.RepoCommit, bool, authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error)
-	hooks       []func(context.Context, []api.RepoCommit, bool, authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error)
+	defaultHook func(context.Context, authz.SubRepoPermissionChecker, []api.RepoCommit, bool) ([]*gitdomain.Commit, error)
+	hooks       []func(context.Context, authz.SubRepoPermissionChecker, []api.RepoCommit, bool) ([]*gitdomain.Commit, error)
 	history     []ClientGetCommitsFuncCall
 	mutex       sync.Mutex
 }
 
 // GetCommits delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockClient) GetCommits(v0 context.Context, v1 []api.RepoCommit, v2 bool, v3 authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error) {
+func (m *MockClient) GetCommits(v0 context.Context, v1 authz.SubRepoPermissionChecker, v2 []api.RepoCommit, v3 bool) ([]*gitdomain.Commit, error) {
 	r0, r1 := m.GetCommitsFunc.nextHook()(v0, v1, v2, v3)
 	m.GetCommitsFunc.appendCall(ClientGetCommitsFuncCall{v0, v1, v2, v3, r0, r1})
 	return r0, r1
@@ -3176,7 +3176,7 @@ func (m *MockClient) GetCommits(v0 context.Context, v1 []api.RepoCommit, v2 bool
 
 // SetDefaultHook sets function that is called when the GetCommits method of
 // the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientGetCommitsFunc) SetDefaultHook(hook func(context.Context, []api.RepoCommit, bool, authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error)) {
+func (f *ClientGetCommitsFunc) SetDefaultHook(hook func(context.Context, authz.SubRepoPermissionChecker, []api.RepoCommit, bool) ([]*gitdomain.Commit, error)) {
 	f.defaultHook = hook
 }
 
@@ -3184,7 +3184,7 @@ func (f *ClientGetCommitsFunc) SetDefaultHook(hook func(context.Context, []api.R
 // GetCommits method of the parent MockClient instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ClientGetCommitsFunc) PushHook(hook func(context.Context, []api.RepoCommit, bool, authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error)) {
+func (f *ClientGetCommitsFunc) PushHook(hook func(context.Context, authz.SubRepoPermissionChecker, []api.RepoCommit, bool) ([]*gitdomain.Commit, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3193,19 +3193,19 @@ func (f *ClientGetCommitsFunc) PushHook(hook func(context.Context, []api.RepoCom
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientGetCommitsFunc) SetDefaultReturn(r0 []*gitdomain.Commit, r1 error) {
-	f.SetDefaultHook(func(context.Context, []api.RepoCommit, bool, authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error) {
+	f.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, []api.RepoCommit, bool) ([]*gitdomain.Commit, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientGetCommitsFunc) PushReturn(r0 []*gitdomain.Commit, r1 error) {
-	f.PushHook(func(context.Context, []api.RepoCommit, bool, authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error) {
+	f.PushHook(func(context.Context, authz.SubRepoPermissionChecker, []api.RepoCommit, bool) ([]*gitdomain.Commit, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientGetCommitsFunc) nextHook() func(context.Context, []api.RepoCommit, bool, authz.SubRepoPermissionChecker) ([]*gitdomain.Commit, error) {
+func (f *ClientGetCommitsFunc) nextHook() func(context.Context, authz.SubRepoPermissionChecker, []api.RepoCommit, bool) ([]*gitdomain.Commit, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3243,13 +3243,13 @@ type ClientGetCommitsFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 []api.RepoCommit
+	Arg1 authz.SubRepoPermissionChecker
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 bool
+	Arg2 []api.RepoCommit
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 authz.SubRepoPermissionChecker
+	Arg3 bool
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []*gitdomain.Commit
@@ -3497,15 +3497,15 @@ func (c ClientGetObjectFuncCall) Results() []interface{} {
 // ClientHasCommitAfterFunc describes the behavior when the HasCommitAfter
 // method of the parent MockClient instance is invoked.
 type ClientHasCommitAfterFunc struct {
-	defaultHook func(context.Context, api.RepoName, string, string, authz.SubRepoPermissionChecker) (bool, error)
-	hooks       []func(context.Context, api.RepoName, string, string, authz.SubRepoPermissionChecker) (bool, error)
+	defaultHook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, string, string) (bool, error)
+	hooks       []func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, string, string) (bool, error)
 	history     []ClientHasCommitAfterFuncCall
 	mutex       sync.Mutex
 }
 
 // HasCommitAfter delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockClient) HasCommitAfter(v0 context.Context, v1 api.RepoName, v2 string, v3 string, v4 authz.SubRepoPermissionChecker) (bool, error) {
+func (m *MockClient) HasCommitAfter(v0 context.Context, v1 authz.SubRepoPermissionChecker, v2 api.RepoName, v3 string, v4 string) (bool, error) {
 	r0, r1 := m.HasCommitAfterFunc.nextHook()(v0, v1, v2, v3, v4)
 	m.HasCommitAfterFunc.appendCall(ClientHasCommitAfterFuncCall{v0, v1, v2, v3, v4, r0, r1})
 	return r0, r1
@@ -3514,7 +3514,7 @@ func (m *MockClient) HasCommitAfter(v0 context.Context, v1 api.RepoName, v2 stri
 // SetDefaultHook sets function that is called when the HasCommitAfter
 // method of the parent MockClient instance is invoked and the hook queue is
 // empty.
-func (f *ClientHasCommitAfterFunc) SetDefaultHook(hook func(context.Context, api.RepoName, string, string, authz.SubRepoPermissionChecker) (bool, error)) {
+func (f *ClientHasCommitAfterFunc) SetDefaultHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, string, string) (bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -3522,7 +3522,7 @@ func (f *ClientHasCommitAfterFunc) SetDefaultHook(hook func(context.Context, api
 // HasCommitAfter method of the parent MockClient instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ClientHasCommitAfterFunc) PushHook(hook func(context.Context, api.RepoName, string, string, authz.SubRepoPermissionChecker) (bool, error)) {
+func (f *ClientHasCommitAfterFunc) PushHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, string, string) (bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3531,19 +3531,19 @@ func (f *ClientHasCommitAfterFunc) PushHook(hook func(context.Context, api.RepoN
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientHasCommitAfterFunc) SetDefaultReturn(r0 bool, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, string, string, authz.SubRepoPermissionChecker) (bool, error) {
+	f.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, string, string) (bool, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientHasCommitAfterFunc) PushReturn(r0 bool, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, string, string, authz.SubRepoPermissionChecker) (bool, error) {
+	f.PushHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, string, string) (bool, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientHasCommitAfterFunc) nextHook() func(context.Context, api.RepoName, string, string, authz.SubRepoPermissionChecker) (bool, error) {
+func (f *ClientHasCommitAfterFunc) nextHook() func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, string, string) (bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3581,16 +3581,16 @@ type ClientHasCommitAfterFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 api.RepoName
+	Arg1 authz.SubRepoPermissionChecker
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 string
+	Arg2 api.RepoName
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
 	Arg3 string
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
-	Arg4 authz.SubRepoPermissionChecker
+	Arg4 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 bool
@@ -3614,15 +3614,15 @@ func (c ClientHasCommitAfterFuncCall) Results() []interface{} {
 // ClientHeadFunc describes the behavior when the Head method of the parent
 // MockClient instance is invoked.
 type ClientHeadFunc struct {
-	defaultHook func(context.Context, api.RepoName, authz.SubRepoPermissionChecker) (string, bool, error)
-	hooks       []func(context.Context, api.RepoName, authz.SubRepoPermissionChecker) (string, bool, error)
+	defaultHook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName) (string, bool, error)
+	hooks       []func(context.Context, authz.SubRepoPermissionChecker, api.RepoName) (string, bool, error)
 	history     []ClientHeadFuncCall
 	mutex       sync.Mutex
 }
 
 // Head delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockClient) Head(v0 context.Context, v1 api.RepoName, v2 authz.SubRepoPermissionChecker) (string, bool, error) {
+func (m *MockClient) Head(v0 context.Context, v1 authz.SubRepoPermissionChecker, v2 api.RepoName) (string, bool, error) {
 	r0, r1, r2 := m.HeadFunc.nextHook()(v0, v1, v2)
 	m.HeadFunc.appendCall(ClientHeadFuncCall{v0, v1, v2, r0, r1, r2})
 	return r0, r1, r2
@@ -3630,7 +3630,7 @@ func (m *MockClient) Head(v0 context.Context, v1 api.RepoName, v2 authz.SubRepoP
 
 // SetDefaultHook sets function that is called when the Head method of the
 // parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientHeadFunc) SetDefaultHook(hook func(context.Context, api.RepoName, authz.SubRepoPermissionChecker) (string, bool, error)) {
+func (f *ClientHeadFunc) SetDefaultHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName) (string, bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -3638,7 +3638,7 @@ func (f *ClientHeadFunc) SetDefaultHook(hook func(context.Context, api.RepoName,
 // Head method of the parent MockClient instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *ClientHeadFunc) PushHook(hook func(context.Context, api.RepoName, authz.SubRepoPermissionChecker) (string, bool, error)) {
+func (f *ClientHeadFunc) PushHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName) (string, bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3647,19 +3647,19 @@ func (f *ClientHeadFunc) PushHook(hook func(context.Context, api.RepoName, authz
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientHeadFunc) SetDefaultReturn(r0 string, r1 bool, r2 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, authz.SubRepoPermissionChecker) (string, bool, error) {
+	f.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName) (string, bool, error) {
 		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientHeadFunc) PushReturn(r0 string, r1 bool, r2 error) {
-	f.PushHook(func(context.Context, api.RepoName, authz.SubRepoPermissionChecker) (string, bool, error) {
+	f.PushHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName) (string, bool, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *ClientHeadFunc) nextHook() func(context.Context, api.RepoName, authz.SubRepoPermissionChecker) (string, bool, error) {
+func (f *ClientHeadFunc) nextHook() func(context.Context, authz.SubRepoPermissionChecker, api.RepoName) (string, bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3697,10 +3697,10 @@ type ClientHeadFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 api.RepoName
+	Arg1 authz.SubRepoPermissionChecker
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 authz.SubRepoPermissionChecker
+	Arg2 api.RepoName
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 string
@@ -3832,15 +3832,15 @@ func (c ClientIsRepoCloneableFuncCall) Results() []interface{} {
 // ClientLFSSmudgeFunc describes the behavior when the LFSSmudge method of
 // the parent MockClient instance is invoked.
 type ClientLFSSmudgeFunc struct {
-	defaultHook func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (io.ReadCloser, error)
-	hooks       []func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (io.ReadCloser, error)
+	defaultHook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (io.ReadCloser, error)
+	hooks       []func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (io.ReadCloser, error)
 	history     []ClientLFSSmudgeFuncCall
 	mutex       sync.Mutex
 }
 
 // LFSSmudge delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockClient) LFSSmudge(v0 context.Context, v1 api.RepoName, v2 api.CommitID, v3 string, v4 authz.SubRepoPermissionChecker) (io.ReadCloser, error) {
+func (m *MockClient) LFSSmudge(v0 context.Context, v1 authz.SubRepoPermissionChecker, v2 api.RepoName, v3 api.CommitID, v4 string) (io.ReadCloser, error) {
 	r0, r1 := m.LFSSmudgeFunc.nextHook()(v0, v1, v2, v3, v4)
 	m.LFSSmudgeFunc.appendCall(ClientLFSSmudgeFuncCall{v0, v1, v2, v3, v4, r0, r1})
 	return r0, r1
@@ -3848,7 +3848,7 @@ func (m *MockClient) LFSSmudge(v0 context.Context, v1 api.RepoName, v2 api.Commi
 
 // SetDefaultHook sets function that is called when the LFSSmudge method of
 // the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientLFSSmudgeFunc) SetDefaultHook(hook func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (io.ReadCloser, error)) {
+func (f *ClientLFSSmudgeFunc) SetDefaultHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (io.ReadCloser, error)) {
 	f.defaultHook = hook
 }
 
@@ -3856,7 +3856,7 @@ func (f *ClientLFSSmudgeFunc) SetDefaultHook(hook func(context.Context, api.Repo
 // LFSSmudge method of the parent MockClient instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ClientLFSSmudgeFunc) PushHook(hook func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (io.ReadCloser, error)) {
+func (f *ClientLFSSmudgeFunc) PushHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (io.ReadCloser, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3865,19 +3865,19 @@ func (f *ClientLFSSmudgeFunc) PushHook(hook func(context.Context, api.RepoName, 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientLFSSmudgeFunc) SetDefaultReturn(r0 io.ReadCloser, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (io.ReadCloser, error) {
+	f.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (io.ReadCloser, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientLFSSmudgeFunc) PushReturn(r0 io.ReadCloser, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (io.ReadCloser, error) {
+	f.PushHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (io.ReadCloser, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientLFSSmudgeFunc) nextHook() func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (io.ReadCloser, error) {
+func (f *ClientLFSSmudgeFunc) nextHook() func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (io.ReadCloser, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3915,16 +3915,16 @@ type ClientLFSSmudgeFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 api.RepoName
+	Arg1 authz.SubRepoPermissionChecker
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 api.CommitID
+	Arg2 api.RepoName
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 string
+	Arg3 api.CommitID
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
-	Arg4 authz.SubRepoPermissionChecker
+	Arg4 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 io.ReadCloser
@@ -4176,15 +4176,15 @@ func (c ClientListDirectoryChildrenFuncCall) Results() []interface{} {
 // ClientListFilesFunc describes the behavior when the ListFiles method of
 // the parent MockClient instance is invoked.
 type ClientListFilesFunc struct {
-	defaultHook func(context.Context, api.RepoName, api.CommitID, *regexp.Regexp, authz.SubRepoPermissionChecker) ([]string, error)
-	hooks       []func(context.Context, api.RepoName, api.CommitID, *regexp.Regexp, authz.SubRepoPermissionChecker) ([]string, error)
+	defaultHook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, *regexp.Regexp) ([]string, error)
+	hooks       []func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, *regexp.Regexp) ([]string, error)
 	history     []ClientListFilesFuncCall
 	mutex       sync.Mutex
 }
 
 // ListFiles delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockClient) ListFiles(v0 context.Context, v1 api.RepoName, v2 api.CommitID, v3 *regexp.Regexp, v4 authz.SubRepoPermissionChecker) ([]string, error) {
+func (m *MockClient) ListFiles(v0 context.Context, v1 authz.SubRepoPermissionChecker, v2 api.RepoName, v3 api.CommitID, v4 *regexp.Regexp) ([]string, error) {
 	r0, r1 := m.ListFilesFunc.nextHook()(v0, v1, v2, v3, v4)
 	m.ListFilesFunc.appendCall(ClientListFilesFuncCall{v0, v1, v2, v3, v4, r0, r1})
 	return r0, r1
@@ -4192,7 +4192,7 @@ func (m *MockClient) ListFiles(v0 context.Context, v1 api.RepoName, v2 api.Commi
 
 // SetDefaultHook sets function that is called when the ListFiles method of
 // the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientListFilesFunc) SetDefaultHook(hook func(context.Context, api.RepoName, api.CommitID, *regexp.Regexp, authz.SubRepoPermissionChecker) ([]string, error)) {
+func (f *ClientListFilesFunc) SetDefaultHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, *regexp.Regexp) ([]string, error)) {
 	f.defaultHook = hook
 }
 
@@ -4200,7 +4200,7 @@ func (f *ClientListFilesFunc) SetDefaultHook(hook func(context.Context, api.Repo
 // ListFiles method of the parent MockClient instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ClientListFilesFunc) PushHook(hook func(context.Context, api.RepoName, api.CommitID, *regexp.Regexp, authz.SubRepoPermissionChecker) ([]string, error)) {
+func (f *ClientListFilesFunc) PushHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, *regexp.Regexp) ([]string, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -4209,19 +4209,19 @@ func (f *ClientListFilesFunc) PushHook(hook func(context.Context, api.RepoName, 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientListFilesFunc) SetDefaultReturn(r0 []string, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, *regexp.Regexp, authz.SubRepoPermissionChecker) ([]string, error) {
+	f.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, *regexp.Regexp) ([]string, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientListFilesFunc) PushReturn(r0 []string, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, api.CommitID, *regexp.Regexp, authz.SubRepoPermissionChecker) ([]string, error) {
+	f.PushHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, *regexp.Regexp) ([]string, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientListFilesFunc) nextHook() func(context.Context, api.RepoName, api.CommitID, *regexp.Regexp, authz.SubRepoPermissionChecker) ([]string, error) {
+func (f *ClientListFilesFunc) nextHook() func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, *regexp.Regexp) ([]string, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -4259,16 +4259,16 @@ type ClientListFilesFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 api.RepoName
+	Arg1 authz.SubRepoPermissionChecker
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 api.CommitID
+	Arg2 api.RepoName
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 *regexp.Regexp
+	Arg3 api.CommitID
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
-	Arg4 authz.SubRepoPermissionChecker
+	Arg4 *regexp.Regexp
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []string
@@ -4866,15 +4866,15 @@ func (c ClientMergeBaseFuncCall) Results() []interface{} {
 // ClientNewFileReaderFunc describes the behavior when the NewFileReader
 // method of the parent MockClient instance is invoked.
 type ClientNewFileReaderFunc struct {
-	defaultHook func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (io.ReadCloser, error)
-	hooks       []func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (io.ReadCloser, error)
+	defaultHook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (io.ReadCloser, error)
+	hooks       []func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (io.ReadCloser, error)
 	history     []ClientNewFileReaderFuncCall
 	mutex       sync.Mutex
 }
 
 // NewFileReader delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockClient) NewFileReader(v0 context.Context, v1 api.RepoName, v2 api.CommitID, v3 string, v4 authz.SubRepoPermissionChecker) (io.ReadCloser, error) {
+func (m *MockClient) NewFileReader(v0 context.Context, v1 authz.SubRepoPermissionChecker, v2 api.RepoName, v3 api.CommitID, v4 string) (io.ReadCloser, error) {
 	r0, r1 := m.NewFileReaderFunc.nextHook()(v0, v1, v2, v3, v4)
 	m.NewFileReaderFunc.appendCall(ClientNewFileReaderFuncCall{v0, v1, v2, v3, v4, r0, r1})
 	return r0, r1
@@ -4882,7 +4882,7 @@ func (m *MockClient) NewFileReader(v0 context.Context, v1 api.RepoName, v2 api.C
 
 // SetDefaultHook sets function that is called when the NewFileReader method
 // of the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientNewFileReaderFunc) SetDefaultHook(hook func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (io.ReadCloser, error)) {
+func (f *ClientNewFileReaderFunc) SetDefaultHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (io.ReadCloser, error)) {
 	f.defaultHook = hook
 }
 
@@ -4890,7 +4890,7 @@ func (f *ClientNewFileReaderFunc) SetDefaultHook(hook func(context.Context, api.
 // NewFileReader method of the parent MockClient instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ClientNewFileReaderFunc) PushHook(hook func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (io.ReadCloser, error)) {
+func (f *ClientNewFileReaderFunc) PushHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (io.ReadCloser, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -4899,19 +4899,19 @@ func (f *ClientNewFileReaderFunc) PushHook(hook func(context.Context, api.RepoNa
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientNewFileReaderFunc) SetDefaultReturn(r0 io.ReadCloser, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (io.ReadCloser, error) {
+	f.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (io.ReadCloser, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientNewFileReaderFunc) PushReturn(r0 io.ReadCloser, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (io.ReadCloser, error) {
+	f.PushHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (io.ReadCloser, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientNewFileReaderFunc) nextHook() func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) (io.ReadCloser, error) {
+func (f *ClientNewFileReaderFunc) nextHook() func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) (io.ReadCloser, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -4949,16 +4949,16 @@ type ClientNewFileReaderFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 api.RepoName
+	Arg1 authz.SubRepoPermissionChecker
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 api.CommitID
+	Arg2 api.RepoName
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 string
+	Arg3 api.CommitID
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
-	Arg4 authz.SubRepoPermissionChecker
+	Arg4 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 io.ReadCloser
@@ -5227,15 +5227,15 @@ func (c ClientReadDirFuncCall) Results() []interface{} {
 // ClientReadFileFunc describes the behavior when the ReadFile method of the
 // parent MockClient instance is invoked.
 type ClientReadFileFunc struct {
-	defaultHook func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) ([]byte, error)
-	hooks       []func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) ([]byte, error)
+	defaultHook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) ([]byte, error)
+	hooks       []func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) ([]byte, error)
 	history     []ClientReadFileFuncCall
 	mutex       sync.Mutex
 }
 
 // ReadFile delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockClient) ReadFile(v0 context.Context, v1 api.RepoName, v2 api.CommitID, v3 string, v4 authz.SubRepoPermissionChecker) ([]byte, error) {
+func (m *MockClient) ReadFile(v0 context.Context, v1 authz.SubRepoPermissionChecker, v2 api.RepoName, v3 api.CommitID, v4 string) ([]byte, error) {
 	r0, r1 := m.ReadFileFunc.nextHook()(v0, v1, v2, v3, v4)
 	m.ReadFileFunc.appendCall(ClientReadFileFuncCall{v0, v1, v2, v3, v4, r0, r1})
 	return r0, r1
@@ -5243,7 +5243,7 @@ func (m *MockClient) ReadFile(v0 context.Context, v1 api.RepoName, v2 api.Commit
 
 // SetDefaultHook sets function that is called when the ReadFile method of
 // the parent MockClient instance is invoked and the hook queue is empty.
-func (f *ClientReadFileFunc) SetDefaultHook(hook func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) ([]byte, error)) {
+func (f *ClientReadFileFunc) SetDefaultHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) ([]byte, error)) {
 	f.defaultHook = hook
 }
 
@@ -5251,7 +5251,7 @@ func (f *ClientReadFileFunc) SetDefaultHook(hook func(context.Context, api.RepoN
 // ReadFile method of the parent MockClient instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *ClientReadFileFunc) PushHook(hook func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) ([]byte, error)) {
+func (f *ClientReadFileFunc) PushHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) ([]byte, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5260,19 +5260,19 @@ func (f *ClientReadFileFunc) PushHook(hook func(context.Context, api.RepoName, a
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientReadFileFunc) SetDefaultReturn(r0 []byte, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) ([]byte, error) {
+	f.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) ([]byte, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientReadFileFunc) PushReturn(r0 []byte, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) ([]byte, error) {
+	f.PushHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) ([]byte, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientReadFileFunc) nextHook() func(context.Context, api.RepoName, api.CommitID, string, authz.SubRepoPermissionChecker) ([]byte, error) {
+func (f *ClientReadFileFunc) nextHook() func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, api.CommitID, string) ([]byte, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5310,16 +5310,16 @@ type ClientReadFileFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 api.RepoName
+	Arg1 authz.SubRepoPermissionChecker
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 api.CommitID
+	Arg2 api.RepoName
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 string
+	Arg3 api.CommitID
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
-	Arg4 authz.SubRepoPermissionChecker
+	Arg4 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []byte
@@ -5343,15 +5343,15 @@ func (c ClientReadFileFuncCall) Results() []interface{} {
 // ClientRefDescriptionsFunc describes the behavior when the RefDescriptions
 // method of the parent MockClient instance is invoked.
 type ClientRefDescriptionsFunc struct {
-	defaultHook func(context.Context, api.RepoName, authz.SubRepoPermissionChecker, ...string) (map[string][]gitdomain.RefDescription, error)
-	hooks       []func(context.Context, api.RepoName, authz.SubRepoPermissionChecker, ...string) (map[string][]gitdomain.RefDescription, error)
+	defaultHook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, ...string) (map[string][]gitdomain.RefDescription, error)
+	hooks       []func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, ...string) (map[string][]gitdomain.RefDescription, error)
 	history     []ClientRefDescriptionsFuncCall
 	mutex       sync.Mutex
 }
 
 // RefDescriptions delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockClient) RefDescriptions(v0 context.Context, v1 api.RepoName, v2 authz.SubRepoPermissionChecker, v3 ...string) (map[string][]gitdomain.RefDescription, error) {
+func (m *MockClient) RefDescriptions(v0 context.Context, v1 authz.SubRepoPermissionChecker, v2 api.RepoName, v3 ...string) (map[string][]gitdomain.RefDescription, error) {
 	r0, r1 := m.RefDescriptionsFunc.nextHook()(v0, v1, v2, v3...)
 	m.RefDescriptionsFunc.appendCall(ClientRefDescriptionsFuncCall{v0, v1, v2, v3, r0, r1})
 	return r0, r1
@@ -5360,7 +5360,7 @@ func (m *MockClient) RefDescriptions(v0 context.Context, v1 api.RepoName, v2 aut
 // SetDefaultHook sets function that is called when the RefDescriptions
 // method of the parent MockClient instance is invoked and the hook queue is
 // empty.
-func (f *ClientRefDescriptionsFunc) SetDefaultHook(hook func(context.Context, api.RepoName, authz.SubRepoPermissionChecker, ...string) (map[string][]gitdomain.RefDescription, error)) {
+func (f *ClientRefDescriptionsFunc) SetDefaultHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, ...string) (map[string][]gitdomain.RefDescription, error)) {
 	f.defaultHook = hook
 }
 
@@ -5368,7 +5368,7 @@ func (f *ClientRefDescriptionsFunc) SetDefaultHook(hook func(context.Context, ap
 // RefDescriptions method of the parent MockClient instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *ClientRefDescriptionsFunc) PushHook(hook func(context.Context, api.RepoName, authz.SubRepoPermissionChecker, ...string) (map[string][]gitdomain.RefDescription, error)) {
+func (f *ClientRefDescriptionsFunc) PushHook(hook func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, ...string) (map[string][]gitdomain.RefDescription, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5377,19 +5377,19 @@ func (f *ClientRefDescriptionsFunc) PushHook(hook func(context.Context, api.Repo
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ClientRefDescriptionsFunc) SetDefaultReturn(r0 map[string][]gitdomain.RefDescription, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, authz.SubRepoPermissionChecker, ...string) (map[string][]gitdomain.RefDescription, error) {
+	f.SetDefaultHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, ...string) (map[string][]gitdomain.RefDescription, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ClientRefDescriptionsFunc) PushReturn(r0 map[string][]gitdomain.RefDescription, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, authz.SubRepoPermissionChecker, ...string) (map[string][]gitdomain.RefDescription, error) {
+	f.PushHook(func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, ...string) (map[string][]gitdomain.RefDescription, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientRefDescriptionsFunc) nextHook() func(context.Context, api.RepoName, authz.SubRepoPermissionChecker, ...string) (map[string][]gitdomain.RefDescription, error) {
+func (f *ClientRefDescriptionsFunc) nextHook() func(context.Context, authz.SubRepoPermissionChecker, api.RepoName, ...string) (map[string][]gitdomain.RefDescription, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5427,10 +5427,10 @@ type ClientRefDescriptionsFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 api.RepoName
+	Arg1 authz.SubRepoPermissionChecker
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 authz.SubRepoPermissionChecker
+	Arg2 api.RepoName
 	// Arg3 is a slice containing the values of the variadic arguments
 	// passed to this method invocation.
 	Arg3 []string

--- a/internal/search/job/jobutil/sub_repo_perms_job.go
+++ b/internal/search/job/jobutil/sub_repo_perms_job.go
@@ -39,7 +39,7 @@ func (s *subRepoPermsFilterJob) Run(ctx context.Context, clients job.RuntimeClie
 
 	filteredStream := streaming.StreamFunc(func(event streaming.SearchEvent) {
 		var err error
-		event.Results, err = applySubRepoFiltering(ctx, clients.Logger, checker, event.Results)
+		event.Results, err = applySubRepoFiltering(ctx, checker, clients.Logger, event.Results)
 		if err != nil {
 			mu.Lock()
 			errs = errors.Append(errs, err)
@@ -73,7 +73,7 @@ func (s *subRepoPermsFilterJob) MapChildren(fn job.MapFunc) job.Job {
 
 // applySubRepoFiltering filters a set of matches using the provided
 // authz.SubRepoPermissionChecker
-func applySubRepoFiltering(ctx context.Context, logger log.Logger, checker authz.SubRepoPermissionChecker, matches []result.Match) ([]result.Match, error) {
+func applySubRepoFiltering(ctx context.Context, checker authz.SubRepoPermissionChecker, logger log.Logger, matches []result.Match) ([]result.Match, error) {
 	if !authz.SubRepoEnabled(checker) {
 		return matches, nil
 	}

--- a/internal/search/job/jobutil/sub_repo_perms_job_test.go
+++ b/internal/search/job/jobutil/sub_repo_perms_job_test.go
@@ -199,7 +199,7 @@ func TestApplySubRepoFiltering(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := actor.WithActor(context.Background(), tt.args.ctxActor)
-			matches, err := applySubRepoFiltering(ctx, logtest.Scoped(t), checker, tt.args.matches)
+			matches, err := applySubRepoFiltering(ctx, checker, logtest.Scoped(t), tt.args.matches)
 			if diff := cmp.Diff(matches, tt.wantMatches, cmpopts.IgnoreUnexported(search.RepoStatusMap{})); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -488,7 +488,7 @@ func (r *Resolver) filterHasCommitAfter(
 		for _, rev := range allRevs {
 			rev := rev
 			g.Go(func(ctx context.Context) error {
-				if hasCommitAfter, err := r.gitserver.HasCommitAfter(ctx, repoRev.Repo.Name, op.CommitAfter.TimeRef, rev, authz.DefaultSubRepoPermsChecker); err != nil {
+				if hasCommitAfter, err := r.gitserver.HasCommitAfter(ctx, authz.DefaultSubRepoPermsChecker, repoRev.Repo.Name, op.CommitAfter.TimeRef, rev); err != nil {
 					if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) || gitdomain.IsRepoNotExist(err) {
 						// If the revision does not exist or the repo does not exist,
 						// it certainly does not have any commits after some time.

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -730,7 +730,7 @@ func TestRepoHasCommitAfter(t *testing.T) {
 	}
 
 	mockGitserver := gitserver.NewMockClient()
-	mockGitserver.HasCommitAfterFunc.SetDefaultHook(func(_ context.Context, repoName api.RepoName, _ string, _ string, _ authz.SubRepoPermissionChecker) (bool, error) {
+	mockGitserver.HasCommitAfterFunc.SetDefaultHook(func(_ context.Context, _ authz.SubRepoPermissionChecker, repoName api.RepoName, _ string, _ string) (bool, error) {
 		switch repoName {
 		case repoA.Name:
 			return true, nil


### PR DESCRIPTION
Test plan:
It is refactoring, existing tests should pass.

Closes https://github.com/sourcegraph/sourcegraph/issues/44782