### PR TITLE
Search Aggregation: Fix aggregation hover pings

### DIFF
--- a/client/web/src/search/results/components/aggregation/components/aggregation-chart-card/AggregationChartCard.tsx
+++ b/client/web/src/search/results/components/aggregation/components/aggregation-chart-card/AggregationChartCard.tsx
@@ -97,7 +97,7 @@ export function AggregationChartCard(props: AggregationChartCardProps): ReactEle
         onExtendTimeout,
     } = props
 
-    const onBarHoverDebounced = useDebouncedCallback(onBarHover, 1000)
+    const onBarHoverDebounced = useDebouncedCallback(onBarHover, 300)
 
     if (loading) {
         return (

--- a/client/web/src/search/results/components/aggregation/components/aggregation-chart-card/AggregationChartCard.tsx
+++ b/client/web/src/search/results/components/aggregation/components/aggregation-chart-card/AggregationChartCard.tsx
@@ -1,6 +1,7 @@
 import { Suspense, HTMLAttributes, ReactElement, MouseEvent } from 'react'
 
 import { mdiPlay } from '@mdi/js'
+import { useDebouncedCallback } from 'use-debounce'
 
 import { pluralize } from '@sourcegraph/common'
 import { NotAvailableReasonType, SearchAggregationMode } from '@sourcegraph/shared/src/graphql-operations'
@@ -76,8 +77,8 @@ interface AggregationChartCardProps extends HTMLAttributes<HTMLDivElement> {
     mode?: SearchAggregationMode | null
     size?: 'sm' | 'md'
     showLoading?: boolean
+    onBarHover: () => void
     onBarLinkClick?: (query: string, barIndex: number) => void
-    onBarHover?: () => void
     onExtendTimeout: () => void
 }
 
@@ -95,6 +96,8 @@ export function AggregationChartCard(props: AggregationChartCardProps): ReactEle
         onBarHover,
         onExtendTimeout,
     } = props
+
+    const onBarHoverDebounced = useDebouncedCallback(onBarHover, 1000)
 
     if (loading) {
         return (
@@ -155,6 +158,10 @@ export function AggregationChartCard(props: AggregationChartCardProps): ReactEle
         onBarLinkClick?.(getLink(datum), index)
     }
 
+    const handleMouseLeave = (): void => {
+        onBarHoverDebounced.cancel()
+    }
+
     return (
         <AggregationContent className={className}>
             <Suspense>
@@ -169,7 +176,8 @@ export function AggregationChartCard(props: AggregationChartCardProps): ReactEle
                     getDatumName={getName}
                     getDatumLink={getLink}
                     onDatumLinkClick={handleDatumLinkClick}
-                    onDatumHover={onBarHover}
+                    onDatumHover={onBarHoverDebounced}
+                    onMouseLeave={handleMouseLeave}
                     className={styles.chart}
                 />
 

--- a/client/web/src/search/results/components/aggregation/components/aggregation-mode-controls/AggregationModeControls.tsx
+++ b/client/web/src/search/results/components/aggregation/components/aggregation-mode-controls/AggregationModeControls.tsx
@@ -1,6 +1,7 @@
 import { FC, HTMLAttributes } from 'react'
 
 import classNames from 'classnames'
+import { useDebouncedCallback } from 'use-debounce'
 
 import { SearchAggregationMode } from '@sourcegraph/shared/src/graphql-operations'
 import { Button, Tooltip } from '@sourcegraph/wildcard'
@@ -20,6 +21,8 @@ interface AggregationModeControlsProps extends HTMLAttributes<HTMLDivElement> {
 
 export const AggregationModeControls: FC<AggregationModeControlsProps> = props => {
     const { mode, loading, availability = [], size, className, onModeChange, onModeHover, ...attributes } = props
+
+    const debouncedOnModeHover = useDebouncedCallback(onModeHover, 1000)
 
     const availabilityGroups = availability.reduce((store, availability) => {
         store[availability.mode] = availability
@@ -42,8 +45,12 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
         return isAvailable ?? true
     }
 
-    const handleModeHover = (aggregationMode: SearchAggregationMode): void => {
-        onModeHover(aggregationMode, isModeAvailable(aggregationMode))
+    const handleModeEnter = (aggregationMode: SearchAggregationMode): void => {
+        debouncedOnModeHover(aggregationMode, isModeAvailable(aggregationMode))
+    }
+
+    const handleMouseLeave = (): void => {
+        debouncedOnModeHover.cancel()
     }
 
     return (
@@ -55,7 +62,8 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
             <div
                 // Div onMouseEnter is needed here because button with disabled true doesn't
                 // emit any mouse or pointer events.
-                onMouseEnter={() => handleModeHover(SearchAggregationMode.REPO)}
+                onMouseEnter={() => handleModeEnter(SearchAggregationMode.REPO)}
+                onMouseLeave={handleMouseLeave}
             >
                 <Tooltip content={availabilityGroups[SearchAggregationMode.REPO]?.reasonUnavailable}>
                     <Button
@@ -71,7 +79,7 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
                 </Tooltip>
             </div>
 
-            <div onMouseEnter={() => handleModeHover(SearchAggregationMode.PATH)}>
+            <div onMouseEnter={() => handleModeEnter(SearchAggregationMode.PATH)} onMouseLeave={handleMouseLeave}>
                 <Tooltip content={availabilityGroups[SearchAggregationMode.PATH]?.reasonUnavailable}>
                     <Button
                         variant="secondary"
@@ -86,7 +94,7 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
                 </Tooltip>
             </div>
 
-            <div onMouseEnter={() => handleModeHover(SearchAggregationMode.AUTHOR)}>
+            <div onMouseEnter={() => handleModeEnter(SearchAggregationMode.AUTHOR)} onMouseLeave={handleMouseLeave}>
                 <Tooltip content={availabilityGroups[SearchAggregationMode.AUTHOR]?.reasonUnavailable}>
                     <Button
                         variant="secondary"
@@ -101,7 +109,10 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
                 </Tooltip>
             </div>
 
-            <div onMouseEnter={() => handleModeHover(SearchAggregationMode.CAPTURE_GROUP)}>
+            <div
+                onMouseEnter={() => handleModeEnter(SearchAggregationMode.CAPTURE_GROUP)}
+                onMouseLeave={handleMouseLeave}
+            >
                 <Tooltip content={availabilityGroups[SearchAggregationMode.CAPTURE_GROUP]?.reasonUnavailable}>
                     <Button
                         variant="secondary"

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChart.tsx
@@ -3,8 +3,8 @@ import { ReactElement, SVGProps, useMemo, MouseEvent } from 'react'
 import { scaleBand, scaleLinear } from '@visx/scale'
 import { ScaleBand } from 'd3-scale'
 
+import { SvgAxisBottom, SvgAxisLeft, SvgContent, SvgRoot } from '../../core'
 import { GetScaleTicksOptions } from '../../core/components/axis/tick-formatters'
-import { SvgAxisBottom, SvgAxisLeft, SvgContent, SvgRoot } from '../../core/components/SvgRoot'
 import { CategoricalLikeChart } from '../../types'
 
 import { BarChartContent } from './BarChartContent'


### PR DESCRIPTION
This PR fixes the sensitivity of the search aggregation disabled buttons and bar chart bars hover pings. 

## Test plan
- Check that `GroupAggregationModeDisabledHover` and `GroupResultsChartBarHover` still go to the backend with a log network request 
- You don't have these pings on every mouse interaction (only when you hold your cursor for more than 1s)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-aggregation-hover-pings.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
