### PR TITLE
webhooks: deprecate `site-admin/batch-changes/webhook-logs` and add a link to `/site-admin/webhooks/` page.

### DIFF
--- a/client/web/src/site-admin/webhooks/WebhookLogPage.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogPage.tsx
@@ -51,8 +51,9 @@ export const WebhookLogPage: React.FunctionComponent<React.PropsWithChildren<Pro
                 description="Use these logs of received webhooks to debug integrations"
                 className="mb-3"
             />
-            <Alert variant={'warning'}>
-                This webhooks page has been deprecated, please see our <Link to="/site-admin/webhooks/">new webhooks page</Link>.
+            <Alert variant="warning">
+                This webhooks page has been deprecated, please see our{' '}
+                <Link to="/site-admin/webhooks/">new webhooks page</Link>.
             </Alert>
             <Container>
                 <WebhookLogPageHeader

--- a/client/web/src/site-admin/webhooks/WebhookLogPage.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogPage.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from 'react'
 import classNames from 'classnames'
 import { RouteComponentProps } from 'react-router'
 
-import { Container, PageHeader, H5 } from '@sourcegraph/wildcard'
+import { Alert, Container, PageHeader, H5, Link } from '@sourcegraph/wildcard'
 
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../../components/FilteredConnection'
 import { PageTitle } from '../../components/PageTitle'
@@ -51,6 +51,9 @@ export const WebhookLogPage: React.FunctionComponent<React.PropsWithChildren<Pro
                 description="Use these logs of received webhooks to debug integrations"
                 className="mb-3"
             />
+            <Alert variant={'warning'}>
+                This webhooks page has been deprecated, please see our <Link to="/site-admin/webhooks/">new webhooks page</Link>.
+            </Alert>
             <Container>
                 <WebhookLogPageHeader
                     onlyErrors={onlyErrors}


### PR DESCRIPTION
<img width="1139" alt="image" src="https://user-images.githubusercontent.com/94846361/209117084-80b55231-5e07-4749-b1e5-425014dbcdd6.png">

Test plan:
Storybook.

Closes https://github.com/sourcegraph/sourcegraph/issues/45906

## App preview:

- [Web](https://sg-web-ao-ui-webhooks-deprecation-note.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
