### PR TITLE
web: change format of `LastSyncedIcon` timestamp.

### DIFF
--- a/client/search-ui/src/components/LastSyncedIcon.tsx
+++ b/client/search-ui/src/components/LastSyncedIcon.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 export const LastSyncedIcon: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
-    const formattedTime = format(Date.parse(props.lastSyncedTime), "yyyy-MM-dd'T'HH:mm:ss")
+    const formattedTime = format(Date.parse(props.lastSyncedTime), 'yyyy-MM-dd pp')
 
     return (
         <Tooltip content={`Last synced: ${formattedTime}`}>


### PR DESCRIPTION
This format is used in `Timestamp` component, this way our timestamps are more uniform across the code. But the main trigger was a `T` sign in a timestamp which I wanted to remove.

### Before
<img src="https://user-images.githubusercontent.com/94846361/209124530-6e2e9b5f-dba1-4aa7-bc1b-625c6523096f.png" width="300">

### After
<img src="https://user-images.githubusercontent.com/94846361/209124561-7ebf8ad2-aa5e-4bd6-9c8f-905123499317.png" width="300">

Test plan:
Local sg run and visual check.

## App preview:

- [Web](https://sg-web-ao-ui-uniform-timestamp-format.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
