### PR TITLE
webhooks: Move init code into webhooks package

### DIFF
--- a/enterprise/cmd/frontend/internal/repos/webhooks/init.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/init.go
@@ -1,10 +1,9 @@
-package repos
+package webhooks
 
 import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/repos/webhooks"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/repos/webhooks/resolvers"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
@@ -21,8 +20,8 @@ func Init(
 	_ conftypes.UnifiedWatchable,
 	enterpriseServices *enterprise.Services,
 ) error {
-	enterpriseServices.GitHubSyncWebhook = webhooks.NewGitHubHandler()
-	enterpriseServices.GitLabSyncWebhook = webhooks.NewGitLabHandler()
+	enterpriseServices.GitHubSyncWebhook = NewGitHubHandler()
+	enterpriseServices.GitLabSyncWebhook = NewGitLabHandler()
 	enterpriseServices.WebhooksResolver = resolvers.NewWebhooksResolver(db)
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"

--- a/enterprise/cmd/frontend/shared/shared.go
+++ b/enterprise/cmd/frontend/shared/shared.go
@@ -25,7 +25,7 @@ import (
 	licensing "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing/init"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/notebooks"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/registry"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/repos"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/repos/webhooks"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel"
 	codeintelshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared"
@@ -51,7 +51,7 @@ var initFunctions = map[string]EnterpriseInitializer{
 	"licensing":      licensing.Init,
 	"notebooks":      notebooks.Init,
 	"searchcontexts": searchcontexts.Init,
-	"repos":          repos.Init,
+	"repos.webhooks": webhooks.Init,
 }
 
 func EnterpriseSetupHook(db database.DB, conf conftypes.UnifiedWatchable) enterprise.Services {


### PR DESCRIPTION
The init code in the `repos` package was webhooks specific, so move it into the `webhooks` package.

## Test plan

Mechanical move, all tests pass