### PR TITLE
Show search aggregation only in Enterprise version

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -48,7 +48,7 @@ import type { RepoSettingsAreaRoute } from './repo/settings/RepoSettingsArea'
 import type { RepoSettingsSideBarGroup } from './repo/settings/RepoSettingsSidebar'
 import type { LayoutRouteComponentProps, LayoutRouteProps } from './routes'
 import { EnterprisePageRoutes, PageRoutes } from './routes.constants'
-import { HomePanelsProps, parseSearchURLQuery, SearchStreamingProps } from './search'
+import { HomePanelsProps, parseSearchURLQuery, SearchAggregationProps, SearchStreamingProps } from './search'
 import { NotepadContainer } from './search/Notepad'
 import type { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import type { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
@@ -74,7 +74,8 @@ export interface LayoutProps
         CodeIntelligenceProps,
         BatchChangesProps,
         NotebookProps,
-        CodeMonitoringProps {
+        CodeMonitoringProps,
+        SearchAggregationProps {
     siteAdminAreaRoutes: readonly SiteAdminAreaRoute[]
     siteAdminSideBarGroups: SiteAdminSideBarGroups
     siteAdminOverviewComponents: readonly React.ComponentType<React.PropsWithChildren<unknown>>[]

--- a/client/web/src/OpenSourceWebApp.tsx
+++ b/client/web/src/OpenSourceWebApp.tsx
@@ -45,5 +45,6 @@ export const OpenSourceWebApp: React.FunctionComponent<React.PropsWithChildren<u
         searchContextsEnabled={false}
         notebooksEnabled={false}
         codeMonitoringEnabled={false}
+        searchAggregationEnabled={false}
     />
 )

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -72,7 +72,7 @@ import type { RepoSettingsAreaRoute } from './repo/settings/RepoSettingsArea'
 import type { RepoSettingsSideBarGroup } from './repo/settings/RepoSettingsSidebar'
 import type { LayoutRouteProps } from './routes'
 import { EnterprisePageRoutes } from './routes.constants'
-import { parseSearchURL, getQueryStateFromLocation } from './search'
+import { parseSearchURL, getQueryStateFromLocation, SearchAggregationProps } from './search'
 import { SearchResultsCacheProvider } from './search/results/SearchResultsCacheProvider'
 import type { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import type { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
@@ -102,7 +102,8 @@ export interface SourcegraphWebAppProps
         Pick<BatchChangesProps, 'batchChangesEnabled'>,
         Pick<SearchContextProps, 'searchContextsEnabled'>,
         NotebookProps,
-        CodeMonitoringProps {
+        CodeMonitoringProps,
+        SearchAggregationProps {
     siteAdminAreaRoutes: readonly SiteAdminAreaRoute[]
     siteAdminSideBarGroups: SiteAdminSideBarGroups
     siteAdminOverviewComponents: readonly React.ComponentType<React.PropsWithChildren<unknown>>[]

--- a/client/web/src/enterprise/EnterpriseWebApp.tsx
+++ b/client/web/src/enterprise/EnterpriseWebApp.tsx
@@ -52,5 +52,6 @@ export const EnterpriseWebApp: React.FunctionComponent<React.PropsWithChildren<u
         searchContextsEnabled={true}
         notebooksEnabled={true}
         codeMonitoringEnabled={true}
+        searchAggregationEnabled={true}
     />
 )

--- a/client/web/src/search/index.tsx
+++ b/client/web/src/search/index.tsx
@@ -14,6 +14,8 @@ import { createLiteral } from '@sourcegraph/shared/src/search/query/token'
 import { omitFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { AggregateStreamingSearchResults, StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
 
+export { SearchAggregationProps } from './results/sidebar/search-aggregation-types'
+
 /**
  * Parses the query out of the URL search params (the 'q' parameter). In non-interactive mode, if the 'q' parameter is not present, it
  * returns undefined. When parsing for interactive mode, each filter's individual query parameter

--- a/client/web/src/search/index.tsx
+++ b/client/web/src/search/index.tsx
@@ -14,7 +14,7 @@ import { createLiteral } from '@sourcegraph/shared/src/search/query/token'
 import { omitFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { AggregateStreamingSearchResults, StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
 
-export { SearchAggregationProps } from './results/sidebar/search-aggregation-types'
+export type { SearchAggregationProps } from './results/sidebar/search-aggregation-types'
 
 /**
  * Parses the query out of the URL search params (the 'q' parameter). In non-interactive mode, if the 'q' parameter is not present, it

--- a/client/web/src/search/results/StreamingSearchResults.story.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.story.tsx
@@ -57,6 +57,7 @@ const defaultProps: StreamingSearchResultsProps = {
     fetchHighlightedFileLineRanges: HIGHLIGHTED_FILE_LINES_LONG_REQUEST,
     isSourcegraphDotCom: false,
     searchContextsEnabled: true,
+    searchAggregationEnabled: true,
 }
 
 const decorator: DecoratorFn = Story => {

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -56,6 +56,7 @@ describe('StreamingSearchResults', () => {
         isLightTheme: true,
         isSourcegraphDotCom: false,
         searchContextsEnabled: true,
+        searchAggregationEnabled: false,
     }
 
     const revisionsMockResponses = generateMockedResponses(GitRefType.GIT_BRANCH, 5, 'github.com/golang/oauth2')

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -22,7 +22,7 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { useDeepMemo } from '@sourcegraph/wildcard'
 
-import { SearchStreamingProps } from '..'
+import { SearchAggregationProps, SearchStreamingProps } from '..'
 import { AuthenticatedUser } from '../../auth'
 import { PageTitle } from '../../components/PageTitle'
 import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
@@ -53,7 +53,8 @@ export interface StreamingSearchResultsProps
         PlatformContextProps<'settings' | 'requestGraphQL' | 'sourcegraphURL'>,
         TelemetryProps,
         ThemeProps,
-        CodeInsightsProps {
+        CodeInsightsProps,
+        SearchAggregationProps {
     authenticatedUser: AuthenticatedUser | null
     location: H.Location
     history: H.History
@@ -70,6 +71,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
         codeInsightsEnabled,
         isSourcegraphDotCom,
         extensionsController,
+        searchAggregationEnabled,
     } = props
 
     const history = useHistory()
@@ -300,9 +302,11 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
         })
     }
 
-    // Show aggregation panel by default and only if search doesn't have any matches
-    // hide aggregation panel from the sidebar
-    const showAggregationPanel = results?.state === 'complete' ? (results?.results.length ?? 0) > 0 : true
+    const hasResultsToAggregate = results?.state === 'complete' ? (results?.results.length ?? 0) > 0 : true
+
+    // Show aggregation panel only if we're in Enterprise versions and hide it in OSS and
+    // when search doesn't have any matches
+    const showAggregationPanel = searchAggregationEnabled && hasResultsToAggregate
 
     const onDisableSmartSearch = useCallback(
         () =>

--- a/client/web/src/search/results/sidebar/search-aggregation-types.ts
+++ b/client/web/src/search/results/sidebar/search-aggregation-types.ts
@@ -1,0 +1,3 @@
+export interface SearchAggregationProps {
+    searchAggregationEnabled: boolean
+}


### PR DESCRIPTION
Fixes https://github.com/orgs/sourcegraph/projects/291/views/6

## Test plan
- Run OSS version of sourcegraph 
- See that you see no aggregation UI on the search result page

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-hide-aggregation-in-oss.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
