### PR TITLE
Fix FirstEverCommit argument order

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -218,7 +218,7 @@ func (r *RepositoryResolver) FirstEverCommit(ctx context.Context) (*GitCommitRes
 		return nil, err
 	}
 
-	commit, err := r.gitserverClient.FirstEverCommit(ctx, repo.Name, authz.DefaultSubRepoPermsChecker)
+	commit, err := r.gitserverClient.FirstEverCommit(ctx, authz.DefaultSubRepoPermsChecker, repo.Name)
 	if err != nil {
 		if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
 			return nil, nil


### PR DESCRIPTION
Fixes a conflict between #45905 and #44287 that happened on `main`


## Test plan

```
                       🕯
              🕯             🕯
        🕯                          🕯
 
    🕯           please work            🕯

        🕯                          🕯
              🕯             🕯
                       🕯
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
