### PR TITLE
webhooks: Update all `push` handlers to use ReposourceCloneURLToRepoName

### DIFF
--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -196,7 +196,7 @@ func cloneURLToRepoName(ctx context.Context, db database.DB, cloneURL string) (s
 	span, ctx := ot.StartSpanFromContext(ctx, "cloneURLToRepoName") //nolint:staticcheck // OT is deprecated
 	defer span.Finish()
 
-	repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, db, cloneURL)
+	repoName, err := cloneurls.RepoSourceCloneURLToRepoName(ctx, db, cloneURL)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -794,7 +794,7 @@ func (r *schemaResolver) RepositoryRedirect(ctx context.Context, args *repositor
 	} else if args.CloneURL != nil {
 		// Query by git clone URL
 		var err error
-		name, err = cloneurls.ReposourceCloneURLToRepoName(ctx, r.db, *args.CloneURL)
+		name, err = cloneurls.RepoSourceCloneURLToRepoName(ctx, r.db, *args.CloneURL)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -108,7 +108,7 @@ func (r *editorRequest) searchRedirect(ctx context.Context) (string, error) {
 	var repoFilter string
 	if s.remoteURL != "" {
 		// Search in this repository.
-		repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, r.db, s.remoteURL)
+		repoName, err := cloneurls.RepoSourceCloneURLToRepoName(ctx, r.db, s.remoteURL)
 		if err != nil {
 			return "", err
 		}
@@ -159,7 +159,7 @@ func (r *editorRequest) searchRedirect(ctx context.Context) (string, error) {
 func (r *editorRequest) openFileRedirect(ctx context.Context) (string, error) {
 	of := r.openFileRequest
 	// Determine the repo name and branch.
-	repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, r.db, of.remoteURL)
+	repoName, err := cloneurls.RepoSourceCloneURLToRepoName(ctx, r.db, of.remoteURL)
 	if err != nil {
 		return "", err
 	}

--- a/enterprise/cmd/frontend/internal/repos/webhooks/bitbucket_server_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/bitbucket_server_handler.go
@@ -43,7 +43,7 @@ func (g *BitbucketServerHandler) handlePushEvent(ctx context.Context, payload an
 	if err != nil {
 		return errors.Wrap(err, "getting clone URL from event")
 	}
-	repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, g.db, cloneURL)
+	repoName, err := cloneurls.RepoSourceCloneURLToRepoName(ctx, g.db, cloneURL)
 	if err != nil {
 		return errors.Wrap(err, "getting repo name from clone URL")
 	}

--- a/enterprise/cmd/frontend/internal/repos/webhooks/bitbucket_server_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/bitbucket_server_handler.go
@@ -47,6 +47,9 @@ func (g *BitbucketServerHandler) handlePushEvent(ctx context.Context, payload an
 	if err != nil {
 		return errors.Wrap(err, "getting repo name from clone URL")
 	}
+	if repoName == "" {
+		return errors.New("could not determine repo from CloneURL")
+	}
 
 	resp, err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, repoName)
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/repos/webhooks/bitbucket_server_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/bitbucket_server_handler.go
@@ -2,13 +2,11 @@ package webhooks
 
 import (
 	"context"
-	"net/url"
-	"strings"
 
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
-	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/cloneurls"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -18,6 +16,7 @@ import (
 )
 
 type BitbucketServerHandler struct {
+	db     database.DB
 	logger log.Logger
 }
 
@@ -27,8 +26,9 @@ func (g *BitbucketServerHandler) Register(router *webhooks.Router) {
 	}, extsvc.KindBitbucketServer, "repo:refs_changed")
 }
 
-func NewBitbucketServerHandler() *BitbucketServerHandler {
+func NewBitbucketServerHandler(db database.DB) *BitbucketServerHandler {
 	return &BitbucketServerHandler{
+		db:     db,
 		logger: log.Scoped("webhooks.BitbucketServerHandler", "bitbucket server webhook handler"),
 	}
 }
@@ -39,9 +39,13 @@ func (g *BitbucketServerHandler) handlePushEvent(ctx context.Context, payload an
 		return errors.Newf("expected BitbucketServer.PushEvent, got %T", payload)
 	}
 
-	repoName, err := bitbucketServerNameFromEvent(event)
+	cloneURL, err := bitbucketServerCloneURLFromEvent(event)
 	if err != nil {
-		return errors.Wrap(err, "handlePushEvent: get name failed")
+		return errors.Wrap(err, "getting clone URL from event")
+	}
+	repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, g.db, cloneURL)
+	if err != nil {
+		return errors.Wrap(err, "getting repo name from clone URL")
 	}
 
 	resp, err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, repoName)
@@ -58,7 +62,7 @@ func (g *BitbucketServerHandler) handlePushEvent(ctx context.Context, payload an
 	return nil
 }
 
-func bitbucketServerNameFromEvent(event *bitbucketserver.PushEvent) (api.RepoName, error) {
+func bitbucketServerCloneURLFromEvent(event *bitbucketserver.PushEvent) (string, error) {
 	if event == nil {
 		return "", errors.New("nil PushEvent received")
 	}
@@ -67,11 +71,7 @@ func bitbucketServerNameFromEvent(event *bitbucketserver.PushEvent) (api.RepoNam
 		if link.Name != "ssh" {
 			continue
 		}
-		parsed, err := url.Parse(link.Href)
-		if err != nil {
-			return "", errors.Wrap(err, "unable to parse repository URL")
-		}
-		return api.RepoName(parsed.Hostname() + strings.TrimSuffix(parsed.Path, ".git")), nil
+		return link.Href, nil
 	}
 	return "", errors.New("no ssh URLs found")
 }

--- a/enterprise/cmd/frontend/internal/repos/webhooks/bitbucket_server_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/bitbucket_server_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
@@ -17,7 +18,8 @@ import (
 
 func TestBitbucketServerHandler(t *testing.T) {
 	repoName := "bitbucket.sgdev.org/private/test-2020-06-01"
-	handler := NewBitbucketServerHandler()
+	db := database.NewMockDB()
+	handler := NewBitbucketServerHandler(db)
 	data, err := os.ReadFile("testdata/bitbucket-server-push.json")
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/cmd/frontend/internal/repos/webhooks/bitbucket_server_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/bitbucket_server_handler_test.go
@@ -13,12 +13,18 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func TestBitbucketServerHandler(t *testing.T) {
 	repoName := "bitbucket.sgdev.org/private/test-2020-06-01"
+
 	db := database.NewMockDB()
+	repos := database.NewMockRepoStore()
+	repos.GetFirstRepoNameByCloneURLFunc.SetDefaultHook(func(ctx context.Context, s string) (api.RepoName, error) {
+		return "bitbucket.sgdev.org/private/test-2020-06-01", nil
+	})
+	db.ReposFunc.SetDefaultReturn(repos)
+
 	handler := NewBitbucketServerHandler(db)
 	data, err := os.ReadFile("testdata/bitbucket-server-push.json")
 	if err != nil {
@@ -43,55 +49,4 @@ func TestBitbucketServerHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(t, repoName, updateQueued)
-}
-
-func TestBitbucketServerNameFromEvent(t *testing.T) {
-	makeEvent := func(name string, href string) *bitbucketserver.PushEvent {
-		return &bitbucketserver.PushEvent{
-			Repository: bitbucketserver.Repo{
-				Links: bitbucketserver.RepoLinks{
-					Clone: []bitbucketserver.Link{
-						{
-							Href: href,
-							Name: name,
-						},
-					},
-				},
-			},
-		}
-	}
-
-	tests := []struct {
-		name    string
-		event   *bitbucketserver.PushEvent
-		want    api.RepoName
-		wantErr error
-	}{
-		{
-			name:  "valid event",
-			event: makeEvent("ssh", "ssh://git@bitbucket.sgdev.org/private/test-2020-06-01"),
-			want:  api.RepoName("bitbucket.sgdev.org/private/test-2020-06-01"),
-		},
-		{
-			name:  "valid event with port",
-			event: makeEvent("ssh", "ssh://git@bitbucket.sgdev.org:7999/private/test-2020-06-01.git"),
-			want:  api.RepoName("bitbucket.sgdev.org/private/test-2020-06-01"),
-		},
-		{
-			name:    "nil event",
-			event:   nil,
-			want:    api.RepoName(""),
-			wantErr: errors.New("nil PushEvent received"),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := bitbucketServerCloneURLFromEvent(tt.event)
-			if tt.wantErr != nil {
-				assert.EqualError(t, tt.wantErr, err.Error())
-				return
-			}
-			assert.Equal(t, tt.want, got)
-		})
-	}
 }

--- a/enterprise/cmd/frontend/internal/repos/webhooks/bitbucket_server_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/bitbucket_server_handler_test.go
@@ -84,7 +84,7 @@ func TestBitbucketServerNameFromEvent(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := bitbucketServerNameFromEvent(tt.event)
+			got, err := bitbucketServerCloneURLFromEvent(tt.event)
 			if tt.wantErr != nil {
 				assert.EqualError(t, tt.wantErr, err.Error())
 				return

--- a/enterprise/cmd/frontend/internal/repos/webhooks/github_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/github_handler.go
@@ -48,6 +48,9 @@ func (g *GitHubHandler) handlePushEvent(ctx context.Context, payload any) error 
 	if err != nil {
 		return errors.Wrap(err, "getting repo name from clone URL")
 	}
+	if repoName == "" {
+		return errors.New("could not determine repo from CloneURL")
+	}
 
 	resp, err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, repoName)
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/repos/webhooks/github_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/github_handler.go
@@ -2,14 +2,13 @@ package webhooks
 
 import (
 	"context"
-	"net/url"
 
 	gh "github.com/google/go-github/v43/github"
 
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
-	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/cloneurls"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -18,6 +17,7 @@ import (
 )
 
 type GitHubHandler struct {
+	db     database.DB
 	logger log.Logger
 }
 
@@ -27,8 +27,9 @@ func (g *GitHubHandler) Register(router *webhooks.Router) {
 	}, extsvc.KindGitHub, "push")
 }
 
-func NewGitHubHandler() *GitHubHandler {
+func NewGitHubHandler(db database.DB) *GitHubHandler {
 	return &GitHubHandler{
+		db:     db,
 		logger: log.Scoped("webhooks.GitHubHandler", "github webhook handler"),
 	}
 }
@@ -39,9 +40,13 @@ func (g *GitHubHandler) handlePushEvent(ctx context.Context, payload any) error 
 		return errors.Newf("expected GitHub.PushEvent, got %T", payload)
 	}
 
-	repoName, err := githubNameFromEvent(event)
+	cloneURL, err := gitHubCloneURLFromEvent(event)
 	if err != nil {
-		return errors.Wrap(err, "handlePushEvent: get name failed")
+		return errors.Wrap(err, "getting clone URL from event")
+	}
+	repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, g.db, cloneURL)
+	if err != nil {
+		return errors.Wrap(err, "getting repo name from clone URL")
 	}
 
 	resp, err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, repoName)
@@ -58,13 +63,9 @@ func (g *GitHubHandler) handlePushEvent(ctx context.Context, payload any) error 
 	return nil
 }
 
-func githubNameFromEvent(event *gh.PushEvent) (api.RepoName, error) {
-	if event == nil || event.Repo == nil || event.Repo.URL == nil {
+func gitHubCloneURLFromEvent(event *gh.PushEvent) (string, error) {
+	if event == nil || event.Repo == nil || event.Repo.CloneURL == nil {
 		return "", errors.New("URL for repository not found")
 	}
-	parsed, err := url.Parse(*event.Repo.URL)
-	if err != nil {
-		return "", errors.Wrap(err, "unable to parse repository URL")
-	}
-	return api.RepoName(parsed.Hostname() + parsed.Path), nil
+	return event.GetRepo().GetCloneURL(), nil
 }

--- a/enterprise/cmd/frontend/internal/repos/webhooks/github_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/github_handler.go
@@ -44,7 +44,7 @@ func (g *GitHubHandler) handlePushEvent(ctx context.Context, payload any) error 
 	if err != nil {
 		return errors.Wrap(err, "getting clone URL from event")
 	}
-	repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, g.db, cloneURL)
+	repoName, err := cloneurls.RepoSourceCloneURLToRepoName(ctx, g.db, cloneURL)
 	if err != nil {
 		return errors.Wrap(err, "getting repo name from clone URL")
 	}

--- a/enterprise/cmd/frontend/internal/repos/webhooks/github_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/github_handler_test.go
@@ -185,7 +185,7 @@ func TestGithubNameFromEvent(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := githubNameFromEvent(tt.event)
+			got, err := gitHubCloneURLFromEvent(tt.event)
 			if tt.wantErr != nil {
 				assert.EqualError(t, tt.wantErr, err.Error())
 				return

--- a/enterprise/cmd/frontend/internal/repos/webhooks/github_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/github_handler_test.go
@@ -15,13 +15,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	gh "github.com/google/go-github/v43/github"
 	"github.com/sourcegraph/log/logtest"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -30,7 +27,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -158,43 +154,4 @@ func sign(t *testing.T, message, secret []byte) string {
 	}
 
 	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
-}
-
-func TestGithubNameFromEvent(t *testing.T) {
-	tests := []struct {
-		name    string
-		event   *gh.PushEvent
-		want    api.RepoName
-		wantErr error
-	}{
-		{
-			name: "valid event",
-			event: &gh.PushEvent{
-				Repo: &gh.PushEventRepository{
-					URL: stringp("https://github.com/sourcegraph/sourcegraph"),
-				},
-			},
-			want: api.RepoName("github.com/sourcegraph/sourcegraph"),
-		},
-		{
-			name:    "nil event",
-			event:   nil,
-			want:    api.RepoName(""),
-			wantErr: errors.New("URL for repository not found"),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := gitHubCloneURLFromEvent(tt.event)
-			if tt.wantErr != nil {
-				assert.EqualError(t, tt.wantErr, err.Error())
-				return
-			}
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func stringp(s string) *string {
-	return &s
 }

--- a/enterprise/cmd/frontend/internal/repos/webhooks/github_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/github_handler_test.go
@@ -52,9 +52,9 @@ func TestGitHubHandler(t *testing.T) {
 	}
 
 	conn := schema.GitHubConnection{
-		Url:      "https://github.com",
+		Url:      "https://ghe.sgdev.org",
 		Token:    "token",
-		Repos:    []string{"owner/name"},
+		Repos:    []string{"milton/test"},
 		Webhooks: []*schema.GitHubWebhook{{Org: "ghe.sgdev.org", Secret: "secret"}},
 	}
 
@@ -72,7 +72,7 @@ func TestGitHubHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	handler := NewGitHubHandler()
+	handler := NewGitHubHandler(db)
 	router := &webhooks.GitHubWebhook{
 		Router: &webhooks.Router{
 			DB: db,

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler.go
@@ -45,7 +45,7 @@ func (g *GitLabHandler) handlePushEvent(ctx context.Context, payload any) error 
 		return errors.Wrap(err, "getting clone URL from event")
 	}
 	fmt.Println("cloneURL:", cloneURL)
-	repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, g.db, cloneURL)
+	repoName, err := cloneurls.RepoSourceCloneURLToRepoName(ctx, g.db, cloneURL)
 	if err != nil {
 		return errors.Wrap(err, "getting repo name from clone URL")
 	}

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler.go
@@ -2,12 +2,12 @@ package webhooks
 
 import (
 	"context"
-	"net/url"
+	"fmt"
 
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
-	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/cloneurls"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -17,6 +17,7 @@ import (
 )
 
 type GitLabHandler struct {
+	db     database.DB
 	logger log.Logger
 }
 
@@ -26,8 +27,9 @@ func (g *GitLabHandler) Register(router *webhooks.Router) {
 	}, extsvc.KindGitLab, "push")
 }
 
-func NewGitLabHandler() *GitLabHandler {
+func NewGitLabHandler(db database.DB) *GitLabHandler {
 	return &GitLabHandler{
+		db:     db,
 		logger: log.Scoped("webhooks.GitLabHandler", "gitlab webhook handler"),
 	}
 }
@@ -38,9 +40,14 @@ func (g *GitLabHandler) handlePushEvent(ctx context.Context, payload any) error 
 		return errors.Newf("expected GitLab.PushEvent, got %T", payload)
 	}
 
-	repoName, err := gitlabNameFromEvent(event)
+	cloneURL, err := gitLabCloneURLFromEvent(event)
 	if err != nil {
-		return errors.Wrap(err, "handlePushEvent: get name failed")
+		return errors.Wrap(err, "getting clone URL from event")
+	}
+	fmt.Println("cloneURL:", cloneURL)
+	repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, g.db, cloneURL)
+	if err != nil {
+		return errors.Wrap(err, "getting repo name from clone URL")
 	}
 
 	resp, err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, repoName)
@@ -57,13 +64,9 @@ func (g *GitLabHandler) handlePushEvent(ctx context.Context, payload any) error 
 	return nil
 }
 
-func gitlabNameFromEvent(event *gitlabwebhooks.PushEvent) (api.RepoName, error) {
+func gitLabCloneURLFromEvent(event *gitlabwebhooks.PushEvent) (string, error) {
 	if event == nil {
 		return "", errors.New("nil PushEvent received")
 	}
-	parsed, err := url.Parse(event.Project.WebURL)
-	if err != nil {
-		return "", errors.Wrap(err, "parsing project URL")
-	}
-	return api.RepoName(parsed.Hostname() + parsed.Path), nil
+	return event.Repository.GitSSHURL, nil
 }

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler.go
@@ -49,6 +49,9 @@ func (g *GitLabHandler) handlePushEvent(ctx context.Context, payload any) error 
 	if err != nil {
 		return errors.Wrap(err, "getting repo name from clone URL")
 	}
+	if repoName == "" {
+		return errors.New("could not determine repo from CloneURL")
+	}
 
 	resp, err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, repoName)
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler_test.go
@@ -71,7 +71,7 @@ func TestGitlabNameFromEvent(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := gitlabNameFromEvent(tt.event)
+			got, err := gitLabCloneURLFromEvent(tt.event)
 			if tt.wantErr != nil {
 				assert.EqualError(t, tt.wantErr, err.Error())
 				return

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler_test.go
@@ -9,16 +9,16 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	gitlabwebhooks "github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func TestGitLabHandler(t *testing.T) {
 	repoName := "gitlab.com/ryanslade/ryan-test-private"
-	handler := NewGitLabHandler()
+	db := database.NewMockDB()
+	handler := NewGitLabHandler(db)
 	data, err := os.ReadFile("testdata/gitlab-push.json")
 	if err != nil {
 		t.Fatal(err)
@@ -42,41 +42,4 @@ func TestGitLabHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(t, repoName, updateQueued)
-}
-
-func TestGitlabNameFromEvent(t *testing.T) {
-	tests := []struct {
-		name    string
-		event   *gitlabwebhooks.PushEvent
-		want    api.RepoName
-		wantErr error
-	}{
-		{
-			name: "valid event",
-			event: &gitlabwebhooks.PushEvent{
-				EventCommon: gitlabwebhooks.EventCommon{
-					Project: gitlab.ProjectCommon{
-						WebURL: "https://gitlab.com/sourcegraph/sourcegraph",
-					},
-				},
-			},
-			want: api.RepoName("gitlab.com/sourcegraph/sourcegraph"),
-		},
-		{
-			name:    "nil event",
-			event:   nil,
-			want:    api.RepoName(""),
-			wantErr: errors.New("nil PushEvent received"),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := gitLabCloneURLFromEvent(tt.event)
-			if tt.wantErr != nil {
-				assert.EqualError(t, tt.wantErr, err.Error())
-				return
-			}
-			assert.Equal(t, tt.want, got)
-		})
-	}
 }

--- a/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/gitlab_handler_test.go
@@ -17,7 +17,14 @@ import (
 
 func TestGitLabHandler(t *testing.T) {
 	repoName := "gitlab.com/ryanslade/ryan-test-private"
+
 	db := database.NewMockDB()
+	repos := database.NewMockRepoStore()
+	repos.GetFirstRepoNameByCloneURLFunc.SetDefaultHook(func(ctx context.Context, s string) (api.RepoName, error) {
+		return api.RepoName(repoName), nil
+	})
+	db.ReposFunc.SetDefaultReturn(repos)
+
 	handler := NewGitLabHandler(db)
 	data, err := os.ReadFile("testdata/gitlab-push.json")
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/repos/webhooks/init.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/init.go
@@ -20,9 +20,9 @@ func Init(
 	_ conftypes.UnifiedWatchable,
 	enterpriseServices *enterprise.Services,
 ) error {
-	enterpriseServices.GitHubSyncWebhook = NewGitHubHandler()
-	enterpriseServices.GitLabSyncWebhook = NewGitLabHandler()
-	enterpriseServices.BitbucketServerSyncWebhook = NewBitbucketServerHandler()
+	enterpriseServices.GitHubSyncWebhook = NewGitHubHandler(db)
+	enterpriseServices.GitLabSyncWebhook = NewGitLabHandler(db)
+	enterpriseServices.BitbucketServerSyncWebhook = NewBitbucketServerHandler(db)
 
 	enterpriseServices.WebhooksResolver = resolvers.NewWebhooksResolver(db)
 	return nil

--- a/enterprise/internal/codeintel/shared/resolvers/git_tree_entry_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/git_tree_entry_resolver.go
@@ -143,7 +143,7 @@ func (r *GitTreeEntryResolver) urlPath(prefix *url.URL) *url.URL {
 }
 
 func cloneURLToRepoName(ctx context.Context, db database.DB, cloneURL string) (string, error) {
-	repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, db, cloneURL)
+	repoName, err := cloneurls.RepoSourceCloneURLToRepoName(ctx, db, cloneURL)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cloneurls/clone_urls.go
+++ b/internal/cloneurls/clone_urls.go
@@ -16,14 +16,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-// ReposourceCloneURLToRepoName maps a Git clone URL (format documented here:
+// RepoSourceCloneURLToRepoName maps a Git clone URL (format documented here:
 // https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a) to the corresponding repo name if there
 // exists a code host configuration that matches the clone URL. Implicitly, it includes a code host
 // configuration for github.com, even if one is not explicitly specified. Returns the empty string and nil
 // error if a matching code host could not be found. This function does not actually check the code
 // host to see if the repository actually exists.
-func ReposourceCloneURLToRepoName(ctx context.Context, db database.DB, cloneURL string) (repoName api.RepoName, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "ReposourceCloneURLToRepoName") //nolint:staticcheck // OT is deprecated
+func RepoSourceCloneURLToRepoName(ctx context.Context, db database.DB, cloneURL string) (repoName api.RepoName, err error) {
+	span, ctx := ot.StartSpanFromContext(ctx, "RepoSourceCloneURLToRepoName") //nolint:staticcheck // OT is deprecated
 	defer span.Finish()
 
 	if repoName := reposource.CustomCloneURLToRepoName(cloneURL); repoName != "" {

--- a/internal/cloneurls/clone_urls_test.go
+++ b/internal/cloneurls/clone_urls_test.go
@@ -57,7 +57,7 @@ func TestReposourceCloneURLToRepoName(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			repoName, err := ReposourceCloneURLToRepoName(ctx, db, test.cloneURL)
+			repoName, err := RepoSourceCloneURLToRepoName(ctx, db, test.cloneURL)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/extsvc/gitlab/webhooks/events.go
+++ b/internal/extsvc/gitlab/webhooks/events.go
@@ -29,7 +29,9 @@ type PipelineEvent struct {
 // PushEvent represents a push to a repository.
 // https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#push-events
 type PushEvent struct {
-	EventCommon
+	Repository struct {
+		GitSSHURL string `json:"git_ssh_url,omitempty"`
+	} `json:"repository"`
 }
 
 var ErrObjectKindUnknown = errors.New("unknown object kind")

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -221,7 +221,7 @@ func (s GitLabSource) makeRepo(proj *gitlab.Project) *types.Repo {
 	}
 }
 
-// remoteURL returns the GitLab projects's Git remote URL
+// remoteURL returns the GitLab project's Git remote URL
 //
 // note: this used to contain credentials but that is no longer the case
 // if you need to get an authenticated clone url use repos.CloneURL


### PR DESCRIPTION
This is the method we use in the rest of the codebase to determine the repo name based on clone URL,
so we should use it for webhooks too as it will be much more robust. 

## Test plan

Unit tests updated and a manually checked for all three code hosts locally.