### PR TITLE
codeintel: fix extracting image name when including sha256sum in raw string

### DIFF
--- a/enterprise/internal/codeintel/shared/resolvers/index_resolvers.go
+++ b/enterprise/internal/codeintel/shared/resolvers/index_resolvers.go
@@ -120,7 +120,7 @@ func (r *indexResolver) ProjectRoot(ctx context.Context) (_ resolverstubs.GitTre
 
 func (r *indexResolver) Indexer() resolverstubs.CodeIntelIndexerResolver {
 	// drop the tag if it exists
-	if idx, ok := types.ImageToIndexer[strings.Split(r.index.Indexer, ":")[0]]; ok {
+	if idx, ok := types.ImageToIndexer[strings.Split(strings.Split(r.index.Indexer, "@sha256:")[0], ":")[0]]; ok {
 		return types.NewCodeIntelIndexerResolverFrom(idx)
 	}
 


### PR DESCRIPTION
No bueno fellas 🤓 we need to extract the right stuff out

![image](https://user-images.githubusercontent.com/18282288/209194570-261f7056-76b4-44f9-9280-90ab1f70ffe4.png)

## Test plan

See: https://go.dev/play/p/K07kRT4sW7b
