### PR TITLE
CODEOWNERS storage

### DIFF
--- a/enterprise/internal/database/mocks_temp.go
+++ b/enterprise/internal/database/mocks_temp.go
@@ -6826,6 +6826,9 @@ type MockEnterpriseDB struct {
 	// CodeMonitorsFunc is an instance of a mock function object controlling
 	// the behavior of the method CodeMonitors.
 	CodeMonitorsFunc *EnterpriseDBCodeMonitorsFunc
+	// CodeownersFunc is an instance of a mock function object controlling
+	// the behavior of the method Codeowners.
+	CodeownersFunc *EnterpriseDBCodeownersFunc
 	// ConfFunc is an instance of a mock function object controlling the
 	// behavior of the method Conf.
 	ConfFunc *EnterpriseDBConfFunc
@@ -6978,6 +6981,11 @@ func NewMockEnterpriseDB() *MockEnterpriseDB {
 		},
 		CodeMonitorsFunc: &EnterpriseDBCodeMonitorsFunc{
 			defaultHook: func() (r0 CodeMonitorStore) {
+				return
+			},
+		},
+		CodeownersFunc: &EnterpriseDBCodeownersFunc{
+			defaultHook: func() (r0 database.CodeownersStore) {
 				return
 			},
 		},
@@ -7223,6 +7231,11 @@ func NewStrictMockEnterpriseDB() *MockEnterpriseDB {
 				panic("unexpected invocation of MockEnterpriseDB.CodeMonitors")
 			},
 		},
+		CodeownersFunc: &EnterpriseDBCodeownersFunc{
+			defaultHook: func() database.CodeownersStore {
+				panic("unexpected invocation of MockEnterpriseDB.Codeowners")
+			},
+		},
 		ConfFunc: &EnterpriseDBConfFunc{
 			defaultHook: func() database.ConfStore {
 				panic("unexpected invocation of MockEnterpriseDB.Conf")
@@ -7457,6 +7470,9 @@ func NewMockEnterpriseDBFrom(i EnterpriseDB) *MockEnterpriseDB {
 		},
 		CodeMonitorsFunc: &EnterpriseDBCodeMonitorsFunc{
 			defaultHook: i.CodeMonitors,
+		},
+		CodeownersFunc: &EnterpriseDBCodeownersFunc{
+			defaultHook: i.Codeowners,
 		},
 		ConfFunc: &EnterpriseDBConfFunc{
 			defaultHook: i.Conf,
@@ -7986,6 +8002,105 @@ func (c EnterpriseDBCodeMonitorsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c EnterpriseDBCodeMonitorsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// EnterpriseDBCodeownersFunc describes the behavior when the Codeowners
+// method of the parent MockEnterpriseDB instance is invoked.
+type EnterpriseDBCodeownersFunc struct {
+	defaultHook func() database.CodeownersStore
+	hooks       []func() database.CodeownersStore
+	history     []EnterpriseDBCodeownersFuncCall
+	mutex       sync.Mutex
+}
+
+// Codeowners delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockEnterpriseDB) Codeowners() database.CodeownersStore {
+	r0 := m.CodeownersFunc.nextHook()()
+	m.CodeownersFunc.appendCall(EnterpriseDBCodeownersFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the Codeowners method of
+// the parent MockEnterpriseDB instance is invoked and the hook queue is
+// empty.
+func (f *EnterpriseDBCodeownersFunc) SetDefaultHook(hook func() database.CodeownersStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Codeowners method of the parent MockEnterpriseDB instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *EnterpriseDBCodeownersFunc) PushHook(hook func() database.CodeownersStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *EnterpriseDBCodeownersFunc) SetDefaultReturn(r0 database.CodeownersStore) {
+	f.SetDefaultHook(func() database.CodeownersStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *EnterpriseDBCodeownersFunc) PushReturn(r0 database.CodeownersStore) {
+	f.PushHook(func() database.CodeownersStore {
+		return r0
+	})
+}
+
+func (f *EnterpriseDBCodeownersFunc) nextHook() func() database.CodeownersStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *EnterpriseDBCodeownersFunc) appendCall(r0 EnterpriseDBCodeownersFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of EnterpriseDBCodeownersFuncCall objects
+// describing the invocations of this function.
+func (f *EnterpriseDBCodeownersFunc) History() []EnterpriseDBCodeownersFuncCall {
+	f.mutex.Lock()
+	history := make([]EnterpriseDBCodeownersFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// EnterpriseDBCodeownersFuncCall is an object that describes an invocation
+// of method Codeowners on an instance of MockEnterpriseDB.
+type EnterpriseDBCodeownersFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 database.CodeownersStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c EnterpriseDBCodeownersFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c EnterpriseDBCodeownersFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/codeowners.go
+++ b/internal/database/codeowners.go
@@ -1,0 +1,86 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+
+	codeownerspb "github.com/sourcegraph/sourcegraph/internal/own/codeowners/proto"
+)
+
+// CodeownersStore currently allows to store only the most recent version of CODEOWNERS
+// file for main branch of given repository.
+type CodeownersStore interface {
+	basestore.ShareableStore
+	// Put updates the newest CODEOWNERS file for given repository's HEAD.
+	PutHead(context.Context, api.RepoName, *codeownerspb.File) error
+	// GetHead returns the CODEOWNERS file associated with
+	// or nil, if there is none.
+	GetHead(ctx context.Context, repoName api.RepoName) (*codeownerspb.File, error)
+}
+
+var _ CodeownersStore = (*codeownersStore)(nil)
+
+type codeownersStore struct {
+	*basestore.Store
+}
+
+func (s *codeownersStore) PutHead(ctx context.Context, repoName api.RepoName, f *codeownerspb.File) error {
+	b, err := proto.Marshal(f)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("WRITE %v\n", b)
+	q := `
+		WITH inline_repo_bytes AS (
+			SELECT r.id AS repo_id, $1::bytea AS proto
+			FROM repo AS r
+			WHERE r.name = $2
+		)
+		INSERT INTO codeowners_head (repo_id, proto)
+		SELECT * FROM inline_repo_bytes
+		ON CONFLICT (repo_id)
+		DO UPDATE SET proto = $1::bytea
+		RETURNING repo_id
+	`
+	// Discard the result of the scan, but run it to see if repo
+	// with given name was found.
+	err = s.Handle().QueryRowContext(ctx, q, b, repoName).Scan(new(int))
+	if err == sql.ErrNoRows {
+		return errors.Wrapf(err, "repo %q not found", repoName)
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *codeownersStore) GetHead(ctx context.Context, repoName api.RepoName) (*codeownerspb.File, error) {
+	q := `
+		SELECT h.proto
+		FROM codeowners_head AS h
+		INNER JOIN repo AS r
+		ON h.repo_id = r.id
+		WHERE r.name = $1
+	`
+	var b []byte
+	err := s.Handle().QueryRowContext(ctx, q, repoName).Scan(&b)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("READ %v\n", b)
+	var p codeownerspb.File
+	if err := proto.Unmarshal(b, &p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}

--- a/internal/database/codeowners.go
+++ b/internal/database/codeowners.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"google.golang.org/protobuf/proto"
 
@@ -36,7 +35,6 @@ func (s *codeownersStore) PutHead(ctx context.Context, repoName api.RepoName, f 
 	if err != nil {
 		return err
 	}
-	fmt.Printf("WRITE %v\n", b)
 	q := `
 		WITH inline_repo_bytes AS (
 			SELECT r.id AS repo_id, $1::bytea AS proto
@@ -77,7 +75,6 @@ func (s *codeownersStore) GetHead(ctx context.Context, repoName api.RepoName) (*
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("READ %v\n", b)
 	var p codeownerspb.File
 	if err := proto.Unmarshal(b, &p); err != nil {
 		return nil, err

--- a/internal/database/codeowners_test.go
+++ b/internal/database/codeowners_test.go
@@ -20,7 +20,7 @@ import (
 	codeownerspb "github.com/sourcegraph/sourcegraph/internal/own/codeowners/proto"
 )
 
-func TestCodeowners_putAndGet(t *testing.T) {
+func TestCodeownersPutAndGet(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -45,7 +45,7 @@ func TestCodeowners_putAndGet(t *testing.T) {
 	assert.Equal(t, want.Repr(), got.Repr())
 }
 
-func TestCodeowners_getNoData(t *testing.T) {
+func TestCodeownersGetNoData(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -60,7 +60,7 @@ func TestCodeowners_getNoData(t *testing.T) {
 	assert.Nil(t, got)
 }
 
-func TestCodeowners_overwrite(t *testing.T) {
+func TestCodeownersOverwrite(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -98,7 +98,7 @@ func TestCodeowners_overwrite(t *testing.T) {
 	assert.Equal(t, second.Repr(), got.Repr())
 }
 
-func TestCodeowners_noRepo(t *testing.T) {
+func TestCodeownersNoRepo(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}

--- a/internal/database/codeowners_test.go
+++ b/internal/database/codeowners_test.go
@@ -1,0 +1,156 @@
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+
+	codeownerspb "github.com/sourcegraph/sourcegraph/internal/own/codeowners/proto"
+)
+
+func TestCodeowners_putAndGet(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := actor.WithInternalActor(context.Background())
+	r := makeRepo(ctx, t, db)
+	codeowners := db.Codeowners()
+	want := &codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{
+				Pattern: "/internal/database/*.go",
+				Owner:   []*codeownerspb.Owner{{Handle: "sourcegraphers"}},
+			},
+		},
+	}
+	err := codeowners.PutHead(ctx, r.Name, want)
+	require.NoError(t, err)
+	got, err := codeowners.GetHead(ctx, r.Name)
+	require.NoError(t, err)
+	assert.Equal(t, want.Repr(), got.Repr())
+}
+
+func TestCodeowners_getNoData(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := actor.WithInternalActor(context.Background())
+	r := makeRepo(ctx, t, db)
+	codeowners := db.Codeowners()
+	got, err := codeowners.GetHead(ctx, r.Name)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestCodeowners_overwrite(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := actor.WithInternalActor(context.Background())
+	r := makeRepo(ctx, t, db)
+	codeowners := db.Codeowners()
+	first := &codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{
+				Pattern: "/internal/database/*.go",
+				Owner:   []*codeownerspb.Owner{{Handle: "sourcegraphers"}},
+			},
+		},
+	}
+	err := codeowners.PutHead(ctx, r.Name, first)
+	require.NoError(t, err)
+	second := &codeownerspb.File{
+		Rule: []*codeownerspb.Rule{
+			{
+				Pattern: "/internal/database/*.go",
+				Owner: []*codeownerspb.Owner{
+					{Handle: "sourcegraphers"},
+					{Handle: "another-owner"},
+				},
+			},
+		},
+	}
+	err = codeowners.PutHead(ctx, r.Name, second)
+	require.NoError(t, err)
+	got, err := codeowners.GetHead(ctx, r.Name)
+	require.NoError(t, err)
+	assert.Equal(t, second.Repr(), got.Repr())
+}
+
+func TestCodeowners_noRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := actor.WithInternalActor(context.Background())
+	codeowners := db.Codeowners()
+	err := codeowners.PutHead(ctx, "I just made up this repo name", &codeownerspb.File{})
+	require.Error(t, err)
+}
+
+func makeRepo(ctx context.Context, t *testing.T, db DB) *types.Repo {
+	now := time.Now()
+
+	service := types.ExternalService{
+		Kind:        extsvc.KindGitHub,
+		DisplayName: "Github - Test",
+		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	confGet := func() *conf.Unified {
+		return &conf.Unified{}
+	}
+
+	err := db.ExternalServices().Create(ctx, confGet, &service)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return mustCreate(ctx, t, db, &types.Repo{
+		ExternalRepo: api.ExternalRepoSpec{
+			ID:          "r",
+			ServiceType: extsvc.TypeGitHub,
+			ServiceID:   "https://github.com",
+		},
+		Name:        "name",
+		Private:     true,
+		URI:         "uri",
+		Description: "description",
+		Fork:        true,
+		Archived:    true,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		Metadata:    new(github.Repository),
+		Sources: map[string]*types.SourceInfo{
+			service.URN(): {
+				ID:       service.URN(),
+				CloneURL: "git@github.com:foo/bar.git",
+			},
+		},
+	})
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -23,6 +23,7 @@ type DB interface {
 	AccessTokens() AccessTokenStore
 	Authz() AuthzStore
 	BitbucketProjectPermissions() BitbucketProjectPermissionsStore
+	Codeowners() CodeownersStore
 	Conf() ConfStore
 	EventLogs() EventLogStore
 	SecurityEventLogs() SecurityEventLogsStore
@@ -115,6 +116,10 @@ func (d *db) BitbucketProjectPermissions() BitbucketProjectPermissionsStore {
 
 func (d *db) Authz() AuthzStore {
 	return AuthzWith(d.Store)
+}
+
+func (d *db) Codeowners() CodeownersStore {
+	return &codeownersStore{Store: basestore.NewWithHandle(d.Handle())}
 }
 
 func (d *db) Conf() ConfStore {

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -3629,6 +3629,9 @@ type MockDB struct {
 	// object controlling the behavior of the method
 	// BitbucketProjectPermissions.
 	BitbucketProjectPermissionsFunc *DBBitbucketProjectPermissionsFunc
+	// CodeownersFunc is an instance of a mock function object controlling
+	// the behavior of the method Codeowners.
+	CodeownersFunc *DBCodeownersFunc
 	// ConfFunc is an instance of a mock function object controlling the
 	// behavior of the method Conf.
 	ConfFunc *DBConfFunc
@@ -3773,6 +3776,11 @@ func NewMockDB() *MockDB {
 		},
 		BitbucketProjectPermissionsFunc: &DBBitbucketProjectPermissionsFunc{
 			defaultHook: func() (r0 BitbucketProjectPermissionsStore) {
+				return
+			},
+		},
+		CodeownersFunc: &DBCodeownersFunc{
+			defaultHook: func() (r0 CodeownersStore) {
 				return
 			},
 		},
@@ -4008,6 +4016,11 @@ func NewStrictMockDB() *MockDB {
 				panic("unexpected invocation of MockDB.BitbucketProjectPermissions")
 			},
 		},
+		CodeownersFunc: &DBCodeownersFunc{
+			defaultHook: func() CodeownersStore {
+				panic("unexpected invocation of MockDB.Codeowners")
+			},
+		},
 		ConfFunc: &DBConfFunc{
 			defaultHook: func() ConfStore {
 				panic("unexpected invocation of MockDB.Conf")
@@ -4233,6 +4246,9 @@ func NewMockDBFrom(i DB) *MockDB {
 		},
 		BitbucketProjectPermissionsFunc: &DBBitbucketProjectPermissionsFunc{
 			defaultHook: i.BitbucketProjectPermissions,
+		},
+		CodeownersFunc: &DBCodeownersFunc{
+			defaultHook: i.Codeowners,
 		},
 		ConfFunc: &DBConfFunc{
 			defaultHook: i.Conf,
@@ -4657,6 +4673,104 @@ func (c DBBitbucketProjectPermissionsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c DBBitbucketProjectPermissionsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// DBCodeownersFunc describes the behavior when the Codeowners method of the
+// parent MockDB instance is invoked.
+type DBCodeownersFunc struct {
+	defaultHook func() CodeownersStore
+	hooks       []func() CodeownersStore
+	history     []DBCodeownersFuncCall
+	mutex       sync.Mutex
+}
+
+// Codeowners delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockDB) Codeowners() CodeownersStore {
+	r0 := m.CodeownersFunc.nextHook()()
+	m.CodeownersFunc.appendCall(DBCodeownersFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the Codeowners method of
+// the parent MockDB instance is invoked and the hook queue is empty.
+func (f *DBCodeownersFunc) SetDefaultHook(hook func() CodeownersStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Codeowners method of the parent MockDB instance invokes the hook at the
+// front of the queue and discards it. After the queue is empty, the default
+// hook function is invoked for any future action.
+func (f *DBCodeownersFunc) PushHook(hook func() CodeownersStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *DBCodeownersFunc) SetDefaultReturn(r0 CodeownersStore) {
+	f.SetDefaultHook(func() CodeownersStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *DBCodeownersFunc) PushReturn(r0 CodeownersStore) {
+	f.PushHook(func() CodeownersStore {
+		return r0
+	})
+}
+
+func (f *DBCodeownersFunc) nextHook() func() CodeownersStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBCodeownersFunc) appendCall(r0 DBCodeownersFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBCodeownersFuncCall objects describing the
+// invocations of this function.
+func (f *DBCodeownersFunc) History() []DBCodeownersFuncCall {
+	f.mutex.Lock()
+	history := make([]DBCodeownersFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBCodeownersFuncCall is an object that describes an invocation of method
+// Codeowners on an instance of MockDB.
+type DBCodeownersFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 CodeownersStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DBCodeownersFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBCodeownersFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -7251,6 +7251,86 @@
       "Triggers": []
     },
     {
+      "Name": "codeowners_head",
+      "Comment": "",
+      "Columns": [
+        {
+          "Name": "created_at",
+          "Index": 4,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": false,
+          "Default": "now()",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "proto",
+          "Index": 2,
+          "TypeName": "bytea",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "repo_id",
+          "Index": 1,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "updated_at",
+          "Index": 3,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": false,
+          "Default": "now()",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        }
+      ],
+      "Indexes": [
+        {
+          "Name": "codeowners_head_pkey",
+          "IsPrimaryKey": true,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX codeowners_head_pkey ON codeowners_head USING btree (repo_id)",
+          "ConstraintType": "p",
+          "ConstraintDefinition": "PRIMARY KEY (repo_id)"
+        }
+      ],
+      "Constraints": [
+        {
+          "Name": "codeowners_head_repo_id_fkey",
+          "ConstraintType": "f",
+          "RefTableName": "repo",
+          "IsDeferrable": true,
+          "ConstraintDefinition": "FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE"
+        }
+      ],
+      "Triggers": []
+    },
+    {
       "Name": "configuration_policies_audit_logs",
       "Comment": "",
       "Columns": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -939,6 +939,21 @@ Foreign-key constraints:
 
 ```
 
+# Table "public.codeowners_head"
+```
+   Column   |           Type           | Collation | Nullable | Default 
+------------+--------------------------+-----------+----------+---------
+ repo_id    | integer                  |           | not null | 
+ proto      | bytea                    |           | not null | 
+ updated_at | timestamp with time zone |           | not null | now()
+ created_at | timestamp with time zone |           | not null | now()
+Indexes:
+    "codeowners_head_pkey" PRIMARY KEY, btree (repo_id)
+Foreign-key constraints:
+    "codeowners_head_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE
+
+```
+
 # Table "public.configuration_policies_audit_logs"
 ```
        Column       |           Type           | Collation | Nullable |                          Default                           
@@ -2692,6 +2707,7 @@ Referenced by:
     TABLE "changeset_specs" CONSTRAINT "changeset_specs_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) DEFERRABLE
     TABLE "changesets" CONSTRAINT "changesets_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE
     TABLE "cm_last_searched" CONSTRAINT "cm_last_searched_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
+    TABLE "codeowners_head" CONSTRAINT "codeowners_head_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE
     TABLE "discussion_threads_target_repo" CONSTRAINT "discussion_threads_target_repo_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "external_service_repos" CONSTRAINT "external_service_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE
     TABLE "gitserver_repos" CONSTRAINT "gitserver_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE

--- a/internal/own/codeowners/proto/debugstring.go
+++ b/internal/own/codeowners/proto/debugstring.go
@@ -5,6 +5,11 @@ import (
 	"strings"
 )
 
+// Repr returns a string representation that resembles the syntax
+// of a CODEOWNERS file. Order matterns for every repeated field within
+// the proto (as within the CODEOWNERS file), so the returned text
+// representation is deterministic. This is useful in tests,
+// where deep comparison ma not work due to protobuf metadata.
 func (f *File) Repr() string {
 	w := new(strings.Builder)
 	var lastSeenSection string

--- a/internal/own/codeowners/proto/debugstring.go
+++ b/internal/own/codeowners/proto/debugstring.go
@@ -1,0 +1,28 @@
+package proto
+
+import (
+	"fmt"
+	"strings"
+)
+
+func (f *File) Repr() string {
+	w := new(strings.Builder)
+	var lastSeenSection string
+	for _, r := range f.Rule {
+		if s := r.SectionName; s != lastSeenSection {
+			fmt.Fprintf(w, "[%s]\n", s)
+			lastSeenSection = s
+		}
+		fmt.Fprint(w, r.Pattern)
+		for _, o := range r.Owner {
+			if h := o.GetHandle(); h != "" {
+				fmt.Fprintf(w, " @%s", h)
+			}
+			if e := o.GetEmail(); e != "" {
+				fmt.Fprintf(w, " %s", e)
+			}
+		}
+		fmt.Fprintln(w)
+	}
+	return w.String()
+}

--- a/migrations/frontend/1671742592_codeowners_table/down.sql
+++ b/migrations/frontend/1671742592_codeowners_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS codeowners_head;

--- a/migrations/frontend/1671742592_codeowners_table/metadata.yaml
+++ b/migrations/frontend/1671742592_codeowners_table/metadata.yaml
@@ -1,0 +1,2 @@
+name: codeowners_table
+parents: [1669645608, 1670870072, 1670600028]

--- a/migrations/frontend/1671742592_codeowners_table/up.sql
+++ b/migrations/frontend/1671742592_codeowners_table/up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS codeowners_head (
+  repo_id integer PRIMARY KEY REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE,
+  proto bytea NOT NULL,
+  updated_at timestamp with time zone DEFAULT now() NOT NULL,
+  created_at timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -1668,6 +1668,13 @@ CREATE SEQUENCE codeintel_ranking_exports_id_seq
 
 ALTER SEQUENCE codeintel_ranking_exports_id_seq OWNED BY codeintel_ranking_exports.id;
 
+CREATE TABLE codeowners_head (
+    repo_id integer NOT NULL,
+    proto bytea NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
 CREATE TABLE configuration_policies_audit_logs (
     log_timestamp timestamp with time zone DEFAULT clock_timestamp(),
     record_deleted_at timestamp with time zone,
@@ -4085,6 +4092,9 @@ ALTER TABLE ONLY codeintel_path_rank_inputs
 ALTER TABLE ONLY codeintel_ranking_exports
     ADD CONSTRAINT codeintel_ranking_exports_pkey PRIMARY KEY (id);
 
+ALTER TABLE ONLY codeowners_head
+    ADD CONSTRAINT codeowners_head_pkey PRIMARY KEY (repo_id);
+
 ALTER TABLE ONLY critical_and_site_config
     ADD CONSTRAINT critical_and_site_config_pkey PRIMARY KEY (id);
 
@@ -4960,6 +4970,9 @@ ALTER TABLE ONLY cm_webhooks
 
 ALTER TABLE ONLY codeintel_ranking_exports
     ADD CONSTRAINT codeintel_ranking_exports_upload_id_fkey FOREIGN KEY (upload_id) REFERENCES lsif_uploads(id) ON DELETE SET NULL;
+
+ALTER TABLE ONLY codeowners_head
+    ADD CONSTRAINT codeowners_head_repo_id_fkey FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE;
 
 ALTER TABLE ONLY discussion_comments
     ADD CONSTRAINT discussion_comments_author_user_id_fkey FOREIGN KEY (author_user_id) REFERENCES users(id) ON DELETE RESTRICT;


### PR DESCRIPTION
This pull request:

- Defines the `codeowners_head` table that stores current, main-branch CODEOWNERS file as a protocol buffer
- Implements a repository with `PutHead` and `GetHead` operations.

## Test plan

This pull request contains an exhaustive test suite with the database.
