### PR TITLE
Fix auto scroll logic between blob view and reference panel

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,12 +57,6 @@ const config = {
             message: 'Use the <Link /> component from @sourcegraph/wildcard instead.',
           },
           {
-            name: 'zustand',
-            importNames: ['default'],
-            message:
-              'Our Zustand stores should be created in a single place. Create this store in client/web/src/stores',
-          },
-          {
             name: 'chromatic/isChromatic',
             message: 'Please use `isChromatic` from the `@sourcegraph/storybook` package.',
           },

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -62,6 +62,7 @@ import {
 import { ReferencesPanelHighlightedBlobResult, ReferencesPanelHighlightedBlobVariables } from '../graphql-operations'
 import { Blob } from '../repo/blob/Blob'
 import { Blob as CodeMirrorBlob } from '../repo/blob/CodeMirrorBlob'
+import * as BlobAPI from '../repo/blob/use-blob-store'
 import { HoverThresholdProps } from '../repo/RepoContainer'
 import { useExperimentalFeatures } from '../stores'
 import { parseBrowserRepoURL } from '../util/url'
@@ -153,6 +154,12 @@ export const RevisionResolvingReferencesList: React.FunctionComponent<
     >
 > = props => {
     const { data, loading, error } = useRepoAndBlob(props.repoName, props.filePath, props.revision)
+
+    // Scroll blob UI to the selected symbol right after the reference panel is rendered
+    // and shifted the blob UI (scroll into view is needed because there are a few cases
+    // when ref panel may overlap with current symbol)
+    useEffect(() => BlobAPI.scrollIntoView({ line: props.line }), [props.line])
+
     if (loading && !data) {
         return <LoadingCodeIntel />
     }

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -34,6 +34,7 @@ import { tokenSelectionExtension } from './codemirror/token-selection/extension'
 import { selectionFromLocation, selectRange } from './codemirror/token-selection/selections'
 import { tokensAsLinks } from './codemirror/tokens-as-links'
 import { isValidLineRange } from './codemirror/utils'
+import { setBlobEditView } from './use-blob-store'
 
 const staticExtensions: Extension = [
     EditorState.readOnly.of(true),
@@ -235,6 +236,9 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
         updateOnExtensionChange: false,
     })
     editorRef.current = editor
+
+    // Sync editor store with global Zustand store API
+    useEffect(() => setBlobEditView(editor ?? null), [editor])
 
     // Reconfigure editor when blobInfo or core extensions changed
     useEffect(() => {

--- a/client/web/src/repo/blob/use-blob-store.ts
+++ b/client/web/src/repo/blob/use-blob-store.ts
@@ -4,25 +4,25 @@ import create from 'zustand'
 import { lineScrollEnforcing, SelectedLineRange, setSelectedLines } from './codemirror/linenumbers'
 
 interface BlobStore {
-    editView: EditorView | null
+    editorView: EditorView | null
 }
 
-export const useBlobUIStore = create<BlobStore>(() => ({ editView: null }))
+const useBlobUIStore = create<BlobStore>(() => ({ editorView: null }))
 
 /**
  * [PRIVATE/INTERNAL] blob UI API, it's supposed to be used only for set
  * edit view object and should not be used anywhere outside of blob UI component.
  */
 export const setBlobEditView = (editView: EditorView | null): void => {
-    useBlobUIStore.setState({ editView })
+    useBlobUIStore.setState({ editorView: editView })
 }
 
 // Public blob UI API
 export const scrollIntoView = (target: SelectedLineRange): void => {
-    const { editView } = useBlobUIStore.getState()
+    const { editorView } = useBlobUIStore.getState()
 
-    if (editView) {
-        editView.dispatch({
+    if (editorView) {
+        editorView.dispatch({
             effects: setSelectedLines.of(target),
             annotations: lineScrollEnforcing.of('scroll-enforcing'),
         })

--- a/client/web/src/repo/blob/use-blob-store.ts
+++ b/client/web/src/repo/blob/use-blob-store.ts
@@ -1,0 +1,30 @@
+import { EditorView } from '@codemirror/view'
+import create from 'zustand'
+
+import { lineScrollEnforcing, SelectedLineRange, setSelectedLines } from './codemirror/linenumbers'
+
+interface BlobStore {
+    editView: EditorView | null
+}
+
+export const useBlobUIStore = create<BlobStore>(() => ({ editView: null }))
+
+/**
+ * [PRIVATE/INTERNAL] blob UI API, it's supposed to be used only for set
+ * edit view object and should not be used anywhere outside of blob UI component.
+ */
+export const setBlobEditView = (editView: EditorView | null): void => {
+    useBlobUIStore.setState({ editView })
+}
+
+// Public blob UI API
+export const scrollIntoView = (target: SelectedLineRange): void => {
+    const { editView } = useBlobUIStore.getState()
+
+    if (editView) {
+        editView.dispatch({
+            effects: setSelectedLines.of(target),
+            annotations: lineScrollEnforcing.of('scroll-enforcing'),
+        })
+    }
+}

--- a/client/web/src/stores/experimentalFeatures.ts
+++ b/client/web/src/stores/experimentalFeatures.ts
@@ -8,7 +8,7 @@ const defaultSettings: SettingsExperimentalFeatures = {
     codeMonitoring: true,
     showEnterpriseHomePanels: false,
     /**
-     * Whether we show the mulitiline editor at /search/console
+     * Whether we show the multiline editor at /search/console
      */
     showMultilineSearchConsole: false,
     showSearchContext: true,


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/45942
[Original slack thread ](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1670914307194829)

## Background

So the flow is the following.
- You click on the symbol action (like find references)
- We write symbol occurrence in URL
- We open the ref panel
- After the ref panel is opened, we run blob-UI global API
- Blob UI listens to all actions from the `blobUIStore` and responds accordingly (scrolls current line in the symbol)  

This PR introduces yet another way to interact with blob view edit UI through the global zustand store. This is not good, but I hope we align approaches around code mirror UI states during the Precise Everywhere UI project. 

## Test plan
- Open any long file in blob UI 
- Open the ref panel, and the current symbol (focused symbol in the blob view) should be visible after the ref panel. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-blob-ref-panel-scroll.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
