### PR TITLE
web: eliminate `client-api` & `shared` circle

### DIFF
--- a/client/client-api/src/contribution.ts
+++ b/client/client-api/src/contribution.ts
@@ -1,7 +1,14 @@
 import { Primitive } from 'utility-types'
 
-import { KeyPath } from '@sourcegraph/shared/src/api/client/services/settings'
 import { Expression, TemplateExpression } from '@sourcegraph/template-parser'
+
+/**
+ * A key path that refers to a location in a JSON document.
+ *
+ * Each successive array element specifies an index in an object or array to descend into. For example, in the
+ * object `{"a": ["x", "y"]}`, the key path `["a", 1]` refers to the value `"y"`.
+ */
+export type KeyPath = (string | number)[]
 
 /**
  * The given contribution type as it's specified in a package.json (expressions as strings)

--- a/client/client-api/tsconfig.json
+++ b/client/client-api/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "references": [{ "path": "../common" }],
   "compilerOptions": {
     "jsx": "react-jsx",
     "module": "commonjs",
@@ -12,5 +11,6 @@
       "*": ["../common/src/types/*"],
     },
   },
+  "references": [{ "path": "../template-parser" }],
   "include": ["./src/**/*", "./*.ts"],
 }

--- a/client/shared/src/api/client/services/settings.ts
+++ b/client/shared/src/api/client/services/settings.ts
@@ -1,16 +1,10 @@
 import { from } from 'rxjs'
 import { first } from 'rxjs/operators'
 
+import { KeyPath } from '@sourcegraph/client-api'
+
 import { PlatformContext } from '../../../platform/context'
 import { isSettingsValid } from '../../../settings/settings'
-
-/**
- * A key path that refers to a location in a JSON document.
- *
- * Each successive array element specifies an index in an object or array to descend into. For example, in the
- * object `{"a": ["x", "y"]}`, the key path `["a", 1]` refers to the value `"y"`.
- */
-export type KeyPath = (string | number)[]
 
 /**
  * An edit to apply to settings.

--- a/client/shared/src/commands/commands.ts
+++ b/client/shared/src/commands/commands.ts
@@ -3,13 +3,13 @@ import { concat, from, of, Subscription, Unsubscribable } from 'rxjs'
 import { first } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 
-import { ActionContributionClientCommandUpdateConfiguration, Evaluated } from '@sourcegraph/client-api'
+import { ActionContributionClientCommandUpdateConfiguration, Evaluated, KeyPath } from '@sourcegraph/client-api'
 import { formatSearchParameters } from '@sourcegraph/common'
 import { Position } from '@sourcegraph/extension-api-types'
 
 import { wrapRemoteObservable } from '../api/client/api/common'
 import { CommandEntry } from '../api/client/mainthread-api'
-import { KeyPath, SettingsEdit, updateSettings } from '../api/client/services/settings'
+import { SettingsEdit, updateSettings } from '../api/client/services/settings'
 import { FlatExtensionHostAPI } from '../api/contract'
 import { PlatformContext } from '../platform/context'
 


### PR DESCRIPTION
## Context

Eliminates `client-api` & `shared` packages circular depenendecy. See [the Client packages cyclic dependencies document](https://docs.google.com/document/d/1AbRH8k7CqQzq2MIFupyL7FOMq-SiUIWkYxZE8fyRqBg/edit) for more context.

## Test plan

CI

## App preview:

- [Web](https://sg-web-vb-client-api-and-shared-circle.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

