### PR TITLE
graphqlbackend: Implement connectionCheck field on externalServices

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -18,6 +18,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -32,9 +34,37 @@ type externalServiceResolver struct {
 	webhookURLOnce sync.Once
 	webhookURL     string
 	webhookErr     error
+
+	availability availabilityState
 }
 
+type availabilityState struct {
+	available   *externalServiceAvailable
+	unavailable *externalServiceUnavailable
+	unknown     *externalServiceUnknown
+}
+
+type externalServiceAvailable struct {
+	lastCheckedAt time.Time
+}
+
+type externalServiceUnavailable struct {
+	suspectedReason string
+}
+
+type externalServiceUnknown struct{}
+
 const externalServiceIDKind = "ExternalService"
+
+// availabilityCheck indicates which code host types have an availability check implemented. For any
+// new code hosts where this check is implemented, add a new entry for the respective kind and set
+// the value to true.
+var availabilityCheck = map[string]bool{
+	extsvc.KindGitHub:          true,
+	extsvc.KindGitLab:          true,
+	extsvc.KindBitbucketServer: true,
+	extsvc.KindBitbucketCloud:  true,
+}
 
 func externalServiceByID(ctx context.Context, db database.DB, gqlID graphql.ID) (*externalServiceResolver, error) {
 	// 🚨 SECURITY: check whether user is site-admin
@@ -187,44 +217,72 @@ func (r *externalServiceResolver) SyncJobs(args *externalServiceSyncJobsArgs) (*
 	return newExternalServiceSyncJobConnectionResolver(r.db, args, r.externalService.ID)
 }
 
-func (r *externalServiceResolver) CheckConnection(ctx context.Context) (*externalServiceAvailabilityResolver, error) {
-	return &externalServiceAvailabilityResolver{}, nil
+func (r *externalServiceResolver) CheckConnection(ctx context.Context) (*externalServiceResolver, error) {
+	if !r.HasConnectionCheck(ctx) {
+		r.availability = availabilityState{
+			unknown: &externalServiceUnknown{},
+		}
+
+		return r, nil
+	}
+
+	source, err := repos.NewSource(
+		ctx,
+		log.Scoped("externalServiceResolver.CheckConnection", ""),
+		r.db,
+		r.externalService,
+		httpcli.ExternalClientFactory,
+	)
+	if err != nil {
+		return r, errors.Wrap(err, "failed to create source")
+	}
+
+	if err := source.CheckConnection(ctx); err != nil {
+		r.availability = availabilityState{
+			unavailable: &externalServiceUnavailable{
+				suspectedReason: err.Error(),
+			},
+		}
+
+		return r, nil
+	}
+
+	r.availability = availabilityState{
+		available: &externalServiceAvailable{
+			lastCheckedAt: time.Now(),
+		},
+	}
+
+	return r, nil
 }
 
-func (r *externalServiceResolver) HasConnectionCheck(ctx context.Context) (bool, error) {
-	return false, nil
+func (r *externalServiceResolver) HasConnectionCheck(ctx context.Context) bool {
+	return availabilityCheck[r.externalService.Kind]
 }
 
-type externalServiceAvailabilityResolver struct{}
-
-func (r *externalServiceAvailabilityResolver) ToExternalServiceAvailable() (*externalServiceAvailableResolver, bool) {
-	return nil, false
+func (r *externalServiceResolver) ToExternalServiceAvailable() (*externalServiceResolver, bool) {
+	return r, r.availability.available != nil
 }
 
-func (r *externalServiceAvailabilityResolver) ToExternalServiceUnavailable() (*externalServiceUnavailableResolver, bool) {
-	return nil, false
+func (r *externalServiceResolver) ToExternalServiceUnavailable() (*externalServiceResolver, bool) {
+	return r, r.availability.unavailable != nil
+
 }
 
-func (r *externalServiceAvailabilityResolver) ToExternalServiceAvailabilityUnknown() (*externalServiceAvailabilityUnknownResolver, bool) {
-	return &externalServiceAvailabilityUnknownResolver{}, true
+func (r *externalServiceResolver) ToExternalServiceAvailabilityUnknown() (*externalServiceResolver, bool) {
+	return r, r.availability.unknown != nil
 }
 
-type externalServiceAvailableResolver struct{}
-
-func (r *externalServiceAvailableResolver) LastCheckedAt() (gqlutil.DateTime, error) {
-	return gqlutil.DateTime{Time: time.Now()}, errors.New("not implemented yet")
+func (r *externalServiceResolver) LastCheckedAt() (gqlutil.DateTime, error) {
+	return gqlutil.DateTime{Time: r.availability.available.lastCheckedAt}, nil
 }
 
-type externalServiceUnavailableResolver struct{}
-
-func (r *externalServiceUnavailableResolver) SuspectedReason() (string, error) {
-	return "", errors.New("not implemented yet")
+func (r *externalServiceResolver) SuspectedReason() (string, error) {
+	return r.availability.unavailable.suspectedReason, nil
 }
 
-type externalServiceAvailabilityUnknownResolver struct{}
-
-func (r *externalServiceAvailabilityUnknownResolver) ImplementationNote() (string, error) {
-	return "not implemented yet", nil
+func (r *externalServiceResolver) ImplementationNote() string {
+	return "not implemented"
 }
 
 type externalServiceSyncJobConnectionResolver struct {

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -217,7 +217,14 @@ func (r *externalServiceResolver) SyncJobs(args *externalServiceSyncJobsArgs) (*
 	return newExternalServiceSyncJobConnectionResolver(r.db, args, r.externalService.ID)
 }
 
+// mockCheckConnection mocks (*externalServiceResolver).CheckConnection.
+var mockCheckConnection func(context.Context, *externalServiceResolver) (*externalServiceResolver, error)
+
 func (r *externalServiceResolver) CheckConnection(ctx context.Context) (*externalServiceResolver, error) {
+	if mockCheckConnection != nil {
+		return mockCheckConnection(ctx, r)
+	}
+
 	if !r.HasConnectionCheck(ctx) {
 		r.availability = availabilityState{
 			unknown: &externalServiceUnknown{},

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -307,15 +307,14 @@ func TestExternalServices(t *testing.T) {
 		if opt.AfterID > 0 {
 			return []*types.ExternalService{
 				{ID: 2, Config: extsvc.NewEmptyConfig(), Kind: extsvc.KindGitHub},
+				{ID: 3, Config: extsvc.NewEmptyConfig(), Kind: extsvc.KindGitHub},
 			}, nil
 		}
 
-		cfg := extsvc.NewEmptyConfig()
-		cfg.Set(`{"url": "http://127.0.0.1:80"}`)
-
 		ess := []*types.ExternalService{
 			{ID: 1, Config: extsvc.NewEmptyConfig()},
-			{ID: 2, Config: cfg, Kind: extsvc.KindGitHub},
+			{ID: 2, Config: extsvc.NewEmptyConfig(), Kind: extsvc.KindGitHub},
+			{ID: 3, Config: extsvc.NewEmptyConfig(), Kind: extsvc.KindGitHub},
 		}
 		if opt.LimitOffset != nil {
 			return ess[:opt.LimitOffset.Limit], nil
@@ -335,6 +334,24 @@ func TestExternalServices(t *testing.T) {
 	db.UsersFunc.SetDefaultReturn(users)
 	db.ExternalServicesFunc.SetDefaultReturn(externalServices)
 
+	mockLastCheckedAt := time.Now()
+	mockCheckConnection = func(ctx context.Context, r *externalServiceResolver) (*externalServiceResolver, error) {
+		switch r.externalService.ID {
+		case 1:
+			r.availability.unknown = &externalServiceUnknown{}
+		case 2:
+			r.availability.unavailable = &externalServiceUnavailable{
+				suspectedReason: "failed to connect",
+			}
+		case 3:
+			r.availability.available = &externalServiceAvailable{
+				lastCheckedAt: mockLastCheckedAt,
+			}
+		}
+
+		return r, nil
+	}
+
 	// NOTE: all these tests run as site admin
 	RunTests(t, []*Test{
 		// Read all external services
@@ -352,8 +369,12 @@ func TestExternalServices(t *testing.T) {
 			ExpectedResult: `
 			{
 				"externalServices": {
-					"nodes": [{"id":"RXh0ZXJuYWxTZXJ2aWNlOjE="}, {"id":"RXh0ZXJuYWxTZXJ2aWNlOjI="}]
-				}
+					"nodes": [
+						{"id":"RXh0ZXJuYWxTZXJ2aWNlOjE="},
+						{"id":"RXh0ZXJuYWxTZXJ2aWNlOjI="},
+						{"id":"RXh0ZXJuYWxTZXJ2aWNlOjM="}
+                    ]
+                }
 			}
 		`,
 		},
@@ -375,7 +396,8 @@ func TestExternalServices(t *testing.T) {
 				"externalServices": {
 					"nodes": [
                         {"id":"RXh0ZXJuYWxTZXJ2aWNlOjE=","lastSyncError":"Oops"},
-                        {"id":"RXh0ZXJuYWxTZXJ2aWNlOjI=","lastSyncError":"Oops"}
+                        {"id":"RXh0ZXJuYWxTZXJ2aWNlOjI=","lastSyncError":"Oops"},
+						{"id":"RXh0ZXJuYWxTZXJ2aWNlOjM=","lastSyncError":"Oops"}
                     ]
 				}
 			}
@@ -390,10 +412,8 @@ func TestExternalServices(t *testing.T) {
 						nodes {
 							id
 							checkConnection {
-								// FIXME: Ignoreing the lastCheckedAt field for now. Find out a way
-								// to ignore comparison for this field while still checking that this
-								// field was returned maybe?
 								... on ExternalServiceAvailable {
+									lastCheckedAt
 								}
 								... on ExternalServiceUnavailable {
 									suspectedReason
@@ -407,29 +427,35 @@ func TestExternalServices(t *testing.T) {
 					}
 				}
 			`,
-			// FIXME: Ignoring checkConneciton.lastCheckedAt for now. Find out a way to ignore
-			// comparison for this field maybe?
-			ExpectedResult: `
-				{
-					"externalServices": {
-						"nodes": [
-							{
-								"id":"RXh0ZXJuYWxTZXJ2aWNlOjE=",
-								"checkConnection": {
-									"implementationNote": "not implemented"
-								},
-								"hasConnectionCheck": false
+			ExpectedResult: fmt.Sprintf(`
+			{
+				"externalServices": {
+					"nodes": [
+						{
+							"id": "RXh0ZXJuYWxTZXJ2aWNlOjE=",
+							"checkConnection": {
+								"implementationNote": "not implemented"
 							},
-							{
-								"id":"RXh0ZXJuYWxTZXJ2aWNlOjI=",
-								"checkConnection": {
-								},
-								"hasConnectionCheck": true
-							}
-						]
-					}
+							"hasConnectionCheck": false
+						},
+						{
+							"id": "RXh0ZXJuYWxTZXJ2aWNlOjI=",
+							"checkConnection": {
+								"suspectedReason": "failed to connect"
+							},
+							"hasConnectionCheck": true
+						},
+						{
+							"id": "RXh0ZXJuYWxTZXJ2aWNlOjM=",
+							"checkConnection": {
+								"lastCheckedAt": %q
+							},
+							"hasConnectionCheck": true
+						}
+					]
 				}
-			`,
+			}
+			`, mockLastCheckedAt.Format("2006-01-02T15:04:05Z")),
 		},
 		// Pagination
 		{
@@ -474,7 +500,7 @@ func TestExternalServices(t *testing.T) {
 			ExpectedResult: `
 			{
 				"externalServices": {
-					"nodes":[{"id":"RXh0ZXJuYWxTZXJ2aWNlOjI="}],
+					"nodes":[{"id":"RXh0ZXJuYWxTZXJ2aWNlOjI="},{"id":"RXh0ZXJuYWxTZXJ2aWNlOjM="}],
 					"pageInfo":{"endCursor":null,"hasNextPage":false}
 				}
 			}


### PR DESCRIPTION
Part of #44683.

In this commit, we also thin out the abstraction layers of the resolvers by tying down the checkConnection field to return the externalService resolver itself.

This simplifies and puts all the possible return types on the externalService resolver itself which makes it easy to read and understand the code.

Co-authored-by: Ryan Slade <ryanslade@gmail.com>


## Test plan

- Added tests
- Tested locally
- Builds should pass

**Not implemented and failed checks**

<img width="2056" alt="image" src="https://user-images.githubusercontent.com/2682729/209302187-edaf5f28-5966-4e0c-a3d5-7cbd6b24333c.png">

**Not implemented and successful checks**

<img width="2056" alt="image" src="https://user-images.githubusercontent.com/2682729/209302573-d29d42bc-af3b-45ce-9be0-c4eb92a170cf.png">



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
