### PR TITLE
repos: Add the ConnectionChecker interface

### DIFF
--- a/internal/repos/awscodecommit.go
+++ b/internal/repos/awscodecommit.go
@@ -112,13 +112,6 @@ func newAWSCodeCommitSource(svc *types.ExternalService, c *schema.AWSCodeCommitC
 	return s, nil
 }
 
-// CheckConnection at this point assumes availability and relies on errors returned
-// from the subsequent calls. This is going to be expanded as part of issue #44683
-// to actually only return true if the source can serve requests.
-func (s *AWSCodeCommitSource) CheckConnection(ctx context.Context) error {
-	return nil
-}
-
 // ListRepos returns all AWS Code Commit repositories accessible to all
 // connections configured in Sourcegraph via the external services
 // configuration.

--- a/internal/repos/gerrit.go
+++ b/internal/repos/gerrit.go
@@ -59,13 +59,6 @@ func NewGerritSource(ctx context.Context, svc *types.ExternalService, cf *httpcl
 	}, nil
 }
 
-// CheckConnection at this point assumes availability and relies on errors returned
-// from the subsequent calls. This is going to be expanded as part of issue #44683
-// to actually only return true if the source can serve requests.
-func (s *GerritSource) CheckConnection(ctx context.Context) error {
-	return nil
-}
-
 // ListRepos returns all Gerrit repositories configured with this GerritSource's config.
 func (s *GerritSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	args := gerrit.ListProjectsArgs{

--- a/internal/repos/gitolite.go
+++ b/internal/repos/gitolite.go
@@ -70,13 +70,6 @@ func NewGitoliteSource(ctx context.Context, svc *types.ExternalService, cf *http
 	}, nil
 }
 
-// CheckConnection at this point assumes availability and relies on errors returned
-// from the subsequent calls. This is going to be expanded as part of issue #44683
-// to actually only return true if the source can serve requests.
-func (s *GitoliteSource) CheckConnection(ctx context.Context) error {
-	return nil
-}
-
 // ListRepos returns all Gitolite repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
 func (s *GitoliteSource) ListRepos(ctx context.Context, results chan SourceResult) {

--- a/internal/repos/other.go
+++ b/internal/repos/other.go
@@ -61,13 +61,6 @@ func NewOtherSource(ctx context.Context, svc *types.ExternalService, cf *httpcli
 	return &OtherSource{svc: svc, conn: &c, client: cli, logger: logger}, nil
 }
 
-// CheckConnection at this point assumes availability and relies on errors returned
-// from the subsequent calls. This is going to be expanded as part of issue #44683
-// to actually only return true if the source can serve requests.
-func (s OtherSource) CheckConnection(ctx context.Context) error {
-	return nil
-}
-
 // ListRepos returns all Other repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
 func (s OtherSource) ListRepos(ctx context.Context, results chan SourceResult) {

--- a/internal/repos/packages.go
+++ b/internal/repos/packages.go
@@ -46,13 +46,6 @@ type packagesDownloadSource interface {
 
 var _ Source = &PackagesSource{}
 
-// CheckConnection at this point assumes availability and relies on errors returned
-// from the subsequent calls. This is going to be expanded as part of issue #44683
-// to actually only return true if the source can serve requests.
-func (s *PackagesSource) CheckConnection(ctx context.Context) error {
-	return nil
-}
-
 func (s *PackagesSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	deps, err := s.configDependencies(s.configDeps)
 	if err != nil {

--- a/internal/repos/pagure.go
+++ b/internal/repos/pagure.go
@@ -59,13 +59,6 @@ func NewPagureSource(ctx context.Context, svc *types.ExternalService, cf *httpcl
 	}, nil
 }
 
-// CheckConnection at this point assumes availability and relies on errors returned
-// from the subsequent calls. This is going to be expanded as part of issue #44683
-// to actually only return true if the source can serve requests.
-func (s *PagureSource) CheckConnection(ctx context.Context) error {
-	return nil
-}
-
 // ListRepos returns all Pagure repositories configured with this PagureSource's config.
 func (s *PagureSource) ListRepos(ctx context.Context, results chan SourceResult) {
 	args := pagure.ListProjectsArgs{

--- a/internal/repos/perforce.go
+++ b/internal/repos/perforce.go
@@ -43,13 +43,6 @@ func newPerforceSource(svc *types.ExternalService, c *schema.PerforceConnection)
 	}, nil
 }
 
-// CheckConnection at this point assumes availability and relies on errors returned
-// from the subsequent calls. This is going to be expanded as part of issue #44683
-// to actually only return true if the source can serve requests.
-func (s PerforceSource) CheckConnection(ctx context.Context) error {
-	return nil
-}
-
 // ListRepos returns all Perforce depots accessible to all connections
 // configured in Sourcegraph via the external services configuration.
 func (s PerforceSource) ListRepos(ctx context.Context, results chan SourceResult) {

--- a/internal/repos/phabricator.go
+++ b/internal/repos/phabricator.go
@@ -45,13 +45,6 @@ func NewPhabricatorSource(ctx context.Context, logger log.Logger, svc *types.Ext
 	return &PhabricatorSource{logger: logger, svc: svc, conn: &c, cf: cf}, nil
 }
 
-// CheckConnection at this point assumes availability and relies on errors returned
-// from the subsequent calls. This is going to be expanded as part of issue #44683
-// to actually only return true if the source can serve requests.
-func (s *PhabricatorSource) CheckConnection(ctx context.Context) error {
-	return nil
-}
-
 // ListRepos returns all Phabricator repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
 func (s *PhabricatorSource) ListRepos(ctx context.Context, results chan SourceResult) {

--- a/internal/repos/sources.go
+++ b/internal/repos/sources.go
@@ -91,12 +91,17 @@ type Source interface {
 	// ListRepos sends all the repos a source yields over the passed in channel
 	// as SourceResults
 	ListRepos(context.Context, chan SourceResult)
+
+	// ExternalServices returns the ExternalServices for the Source.
+	ExternalServices() types.ExternalServices
+}
+
+// ConnectionChecker is an optional interface implemented by some sources.
+type ConnectionChecker interface {
 	// CheckConnection returns an error if the Source service is not reachable
 	// or available to serve requests. The error is descriptive and can be displayed
 	// to the user.
 	CheckConnection(context.Context) error
-	// ExternalServices returns the ExternalServices for the Source.
-	ExternalServices() types.ExternalServices
 }
 
 // RepoGetter captures the optional GetRepo method of a Source. It's used on

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -545,8 +545,10 @@ func (s *Syncer) SyncExternalService(
 		return err
 	}
 
-	if err := src.CheckConnection(ctx); err != nil {
-		return err
+	if checker, ok := src.(ConnectionChecker); ok {
+		if err := checker.CheckConnection(ctx); err != nil {
+			return err
+		}
 	}
 
 	results := make(chan SourceResult)


### PR DESCRIPTION
Remove it from the Source interface and only include it on sources that
actually support connection checking.
