### PR TITLE
codemirror blob: fix container placement

### DIFF
--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect } from 'react'
 
+import classNames from 'classnames'
 import { fromEvent, Observable } from 'rxjs'
 import { finalize, tap } from 'rxjs/operators'
 
@@ -36,6 +37,8 @@ export interface WebHoverOverlayProps
      */
     hoveredTokenClick?: Observable<unknown>
     nav?: (url: string) => void
+
+    hoverOverlayContainerClassName?: string
 }
 
 export const WebHoverOverlay: React.FunctionComponent<React.PropsWithChildren<WebHoverOverlayProps>> = props => {
@@ -130,7 +133,7 @@ export const WebHoverOverlay: React.FunctionComponent<React.PropsWithChildren<We
     return (
         <HoverOverlay
             {...propsToUse}
-            className={styles.webHoverOverlay}
+            className={classNames(styles.webHoverOverlay, props.hoverOverlayContainerClassName)}
             closeButtonClassName={styles.webHoverOverlayCloseButton}
             actionItemClassName="border-0"
             onAlertDismissed={onAlertDismissed}

--- a/client/web/src/repo/blob/codemirror/hovercard.tsx
+++ b/client/web/src/repo/blob/codemirror/hovercard.tsx
@@ -684,6 +684,7 @@ export class HovercardView implements TooltipView {
                                 this.nextPinned.next(true)
                             },
                         }}
+                        hoverOverlayContainerClassName="position-relative"
                     />
                 </div>
             </Container>

--- a/client/web/src/repo/blob/codemirror/token-selection/hover.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/hover.ts
@@ -211,7 +211,7 @@ const tooltipStyles = EditorView.theme({
         padding: '0.5rem',
     },
 
-    '.cm-tooltip-above:not(.tmp-tooltip)': {
+    '.cm-tooltip-above:not(.tmp-tooltip), .cm-tooltip-below:not(.tmp-tooltip)': {
         border: 'unset',
     },
 


### PR DESCRIPTION
Changes the` HoverOverlay` component CSS `position` property to allow CodeMirror to position the code-intel popover below the selected/highlighted token when there is not enough space above it. 


https://user-images.githubusercontent.com/25318659/209349052-0f0347ec-708d-488c-ba92-1be7ec1c9078.mov



## Test plan
Tested manually (video attached).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-codemirror-blob-fix.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

