### PR TITLE
webhooks: Handle Bitbucket Cloud push events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added support for receiving GitLab webhook `push` events. [#45856](https://github.com/sourcegraph/sourcegraph/pull/45856)
 - Added support for receiving Bitbucket Server / Datacenter webhook `push` events. [#45909](https://github.com/sourcegraph/sourcegraph/pull/45909)
 - The GraphQL API now supports listing single-file commit history across renames (with `GitCommit.ancestors(follow: true, path: "<some-path>")`). [#45882](https://github.com/sourcegraph/sourcegraph/pull/45882)
+- Added support for receiving Bitbucket Cloud webhook `push` events. [#45960](https://github.com/sourcegraph/sourcegraph/pull/45960)
 
 ### Changed
 

--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -31,6 +31,7 @@ type Services struct {
 	ReposGithubWebhook          webhooks.Registerer
 	ReposGitLabWebhook          webhooks.Registerer
 	ReposBitbucketServerWebhook webhooks.Registerer
+	ReposBitbucketCloudWebhook  webhooks.Registerer
 
 	PermissionsGitHubWebhook    webhooks.Registerer
 	NewCodeIntelUploadHandler   NewCodeIntelUploadHandler
@@ -81,6 +82,7 @@ func DefaultServices() Services {
 		ReposGithubWebhook:              &emptyWebhookHandler{name: "github sync webhook"},
 		ReposGitLabWebhook:              &emptyWebhookHandler{name: "gitlab sync webhook"},
 		ReposBitbucketServerWebhook:     &emptyWebhookHandler{name: "bitbucket server sync webhook"},
+		ReposBitbucketCloudWebhook:      &emptyWebhookHandler{name: "bitbucket cloud sync webhook"},
 		PermissionsGitHubWebhook:        &emptyWebhookHandler{name: "permissions github webhook"},
 		BatchesGitHubWebhook:            &emptyWebhookHandler{name: "batches github webhook"},
 		BatchesGitLabWebhook:            &emptyWebhookHandler{name: "batches gitlab webhook"},

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -303,6 +303,7 @@ func makeExternalAPI(db database.DB, logger sglog.Logger, schema *graphql.Schema
 			GitHubSyncWebhook:               enterprise.ReposGithubWebhook,
 			GitLabSyncWebhook:               enterprise.ReposGitLabWebhook,
 			BitbucketServerSyncWebhook:      enterprise.ReposBitbucketServerWebhook,
+			BitbucketCloudSyncWebhook:       enterprise.ReposBitbucketCloudWebhook,
 			PermissionsGitHubWebhook:        enterprise.PermissionsGitHubWebhook,
 			BatchesGitHubWebhook:            enterprise.BatchesGitHubWebhook,
 			BatchesGitLabWebhook:            enterprise.BatchesGitLabWebhook,

--- a/cmd/frontend/internal/httpapi/api_test.go
+++ b/cmd/frontend/internal/httpapi/api_test.go
@@ -38,6 +38,7 @@ func newTest(t *testing.T) *httptestutil.Client {
 			GitHubSyncWebhook:             enterpriseServices.ReposGithubWebhook,
 			GitLabSyncWebhook:             enterpriseServices.ReposGitLabWebhook,
 			BitbucketServerSyncWebhook:    enterpriseServices.ReposBitbucketServerWebhook,
+			BitbucketCloudSyncWebhook:     enterpriseServices.ReposBitbucketCloudWebhook,
 			BatchesBitbucketServerWebhook: enterpriseServices.BatchesBitbucketServerWebhook,
 			BatchesBitbucketCloudWebhook:  enterpriseServices.BatchesBitbucketCloudWebhook,
 			NewCodeIntelUploadHandler:     enterpriseServices.NewCodeIntelUploadHandler,

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -43,6 +43,7 @@ type Handlers struct {
 	GitHubSyncWebhook          webhooks.Registerer
 	GitLabSyncWebhook          webhooks.Registerer
 	BitbucketServerSyncWebhook webhooks.Registerer
+	BitbucketCloudSyncWebhook  webhooks.Registerer
 
 	// Permissions
 	PermissionsGitHubWebhook webhooks.Registerer
@@ -107,6 +108,7 @@ func NewHandler(
 	handlers.BatchesGitHubWebhook.Register(&wh)
 	handlers.BatchesGitLabWebhook.Register(&wh)
 	handlers.BitbucketServerSyncWebhook.Register(&wh)
+	handlers.BitbucketCloudSyncWebhook.Register(&wh)
 	handlers.BatchesBitbucketServerWebhook.Register(&wh)
 	handlers.BatchesBitbucketCloudWebhook.Register(&wh)
 	handlers.GitHubSyncWebhook.Register(&wh)

--- a/doc/admin/config/webhooks.md
+++ b/doc/admin/config/webhooks.md
@@ -14,7 +14,7 @@ Code host | [Batch changes](../../batch_changes/index.md) | Code push | User per
 GitHub | 🟢 | 🟢 | 🟢
 GitLab | 🟢 | 🟢 | 🔴
 Bitbucket Server / Datacenter | 🟢 | 🟢 | 🔴
-Bitbucket Cloud | 🟢 | 🔴 | 🔴
+Bitbucket Cloud | 🟢 | 🟢 | 🔴
 
 To receive webhooks both Sourcegraph and the code host need to be configured. To configure Sourcegraph, [add an incoming webhook](#adding-an-incoming-webhook). Then [configure webhooks on your code host](#configuring-webhooks-on-the-code-host)
 
@@ -146,6 +146,10 @@ Follow the same steps as above, but ensure you tick the `Push` option. If asked 
 1. Confirm that the new webhook is listed below **Repository hooks**.
 
 Done! Sourcegraph will now receive webhook events from Bitbucket Cloud and use them to sync pull request events, used by [batch changes](../../batch_changes/index.md), faster and more efficiently.
+
+#### Code push
+
+Follow the same steps as above, but ensure you tick the `Push` option.
 
 ## Webhook logging
 

--- a/doc/admin/repo/webhooks.md
+++ b/doc/admin/repo/webhooks.md
@@ -22,4 +22,4 @@ For repositories that Sourcegraph is already aware of, it will periodically perf
 
 ## Code host webhooks
 
-We support receiving webhooks directly from your code host for [GitHub](../config/webhooks.md#github), [GitLab](../config/webhooks.md#gitlab) and [Bitbucket Server](../config/webhooks.md#bitbucket-server).
+We support receiving webhooks directly from your code host for [GitHub](../config/webhooks.md#github), [GitLab](../config/webhooks.md#gitlab), [Bitbucket Server](../config/webhooks.md#bitbucket-server) and [Bitbucket Cloud](../config/webhooks.md#bitbucket-cloud).

--- a/enterprise/cmd/frontend/internal/repos/webhooks/handlers_test.go
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/handlers_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	gitlabwebhooks "github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab/webhooks"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -212,6 +213,42 @@ func TestBitbucketServerHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 	var payload bitbucketserver.PushEvent
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatal(err)
+	}
+
+	var updateQueued string
+	repoupdater.MockEnqueueRepoUpdate = func(ctx context.Context, repo api.RepoName) (*protocol.RepoUpdateResponse, error) {
+		updateQueued = string(repo)
+		return &protocol.RepoUpdateResponse{
+			ID:   1,
+			Name: string(repo),
+		}, nil
+	}
+	t.Cleanup(func() { repoupdater.MockEnqueueRepoUpdate = nil })
+
+	if err := handler.handlePushEvent(context.Background(), db, &payload); err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, repoName, updateQueued)
+}
+
+func TestBitbucketCloudHandler(t *testing.T) {
+	repoName := "bitbucket.org/sourcegraph-testing/sourcegraph"
+
+	db := database.NewMockDB()
+	repos := database.NewMockRepoStore()
+	repos.GetFirstRepoNameByCloneURLFunc.SetDefaultHook(func(ctx context.Context, s string) (api.RepoName, error) {
+		return "bitbucket.org/sourcegraph-testing/sourcegraph", nil
+	})
+	db.ReposFunc.SetDefaultReturn(repos)
+
+	handler := NewBitbucketCloudHandler()
+	data, err := os.ReadFile("testdata/bitbucket-cloud-push.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload bitbucketcloud.PushEvent
 	if err := json.Unmarshal(data, &payload); err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/repos/webhooks/testdata/bitbucket-cloud-push.json
+++ b/enterprise/cmd/frontend/internal/repos/webhooks/testdata/bitbucket-cloud-push.json
@@ -1,0 +1,346 @@
+{
+  "push": {
+    "changes": [
+      {
+        "old": {
+          "name": "rs/push-test",
+          "target": {
+            "type": "commit",
+            "hash": "50e13d91bf02e318063fd0be4077257cec8b51b7",
+            "date": "2022-12-23T15:21:03+00:00",
+            "author": {
+              "type": "author",
+              "raw": "Ryan Slade <ryanslade@gmail.com>",
+              "user": {
+                "display_name": "Ryan Slade",
+                "links": {
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/%7Bac50370e-c8bf-45ef-8a52-1b69253c29cc%7D"
+                  },
+                  "avatar": {
+                    "href": "https://secure.gravatar.com/avatar/7d7fe505cb4b9c27c81f707eb2a63b51?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FRS-6.png"
+                  },
+                  "html": {
+                    "href": "https://bitbucket.org/%7Bac50370e-c8bf-45ef-8a52-1b69253c29cc%7D/"
+                  }
+                },
+                "type": "user",
+                "uuid": "{ac50370e-c8bf-45ef-8a52-1b69253c29cc}",
+                "account_id": "70121:9c66d5bd-21a3-4280-b5ed-4a1f330fa27a",
+                "nickname": "Ryan Slade"
+              }
+            },
+            "message": "Blah\n",
+            "summary": {
+              "type": "rendered",
+              "raw": "Blah\n",
+              "markup": "markdown",
+              "html": "<p>Blah</p>"
+            },
+            "links": {
+              "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/sourcegraph-testing/sourcegraph/commit/50e13d91bf02e318063fd0be4077257cec8b51b7"
+              },
+              "html": {
+                "href": "https://bitbucket.org/sourcegraph-testing/sourcegraph/commits/50e13d91bf02e318063fd0be4077257cec8b51b7"
+              }
+            },
+            "parents": [
+              {
+                "type": "commit",
+                "hash": "092b2f01ecddecc1682feb33863feb1223f11f6e",
+                "links": {
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/sourcegraph-testing/sourcegraph/commit/092b2f01ecddecc1682feb33863feb1223f11f6e"
+                  },
+                  "html": {
+                    "href": "https://bitbucket.org/sourcegraph-testing/sourcegraph/commits/092b2f01ecddecc1682feb33863feb1223f11f6e"
+                  }
+                }
+              }
+            ],
+            "rendered": {},
+            "properties": {}
+          },
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/sourcegraph-testing/sourcegraph/refs/branches/rs/push-test"
+            },
+            "commits": {
+              "href": "https://api.bitbucket.org/2.0/repositories/sourcegraph-testing/sourcegraph/commits/rs/push-test"
+            },
+            "html": {
+              "href": "https://bitbucket.org/sourcegraph-testing/sourcegraph/branch/rs/push-test"
+            }
+          },
+          "type": "branch",
+          "merge_strategies": [
+            "merge_commit",
+            "squash",
+            "fast_forward"
+          ],
+          "default_merge_strategy": "merge_commit"
+        },
+        "new": {
+          "name": "rs/push-test",
+          "target": {
+            "type": "commit",
+            "hash": "98550882e23008012dbf4b813cfbb19a4c14982a",
+            "date": "2022-12-23T15:21:34+00:00",
+            "author": {
+              "type": "author",
+              "raw": "Ryan Slade <ryanslade@gmail.com>",
+              "user": {
+                "display_name": "Ryan Slade",
+                "links": {
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/%7Bac50370e-c8bf-45ef-8a52-1b69253c29cc%7D"
+                  },
+                  "avatar": {
+                    "href": "https://secure.gravatar.com/avatar/7d7fe505cb4b9c27c81f707eb2a63b51?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FRS-6.png"
+                  },
+                  "html": {
+                    "href": "https://bitbucket.org/%7Bac50370e-c8bf-45ef-8a52-1b69253c29cc%7D/"
+                  }
+                },
+                "type": "user",
+                "uuid": "{ac50370e-c8bf-45ef-8a52-1b69253c29cc}",
+                "account_id": "70121:9c66d5bd-21a3-4280-b5ed-4a1f330fa27a",
+                "nickname": "Ryan Slade"
+              }
+            },
+            "message": "test\n",
+            "summary": {
+              "type": "rendered",
+              "raw": "test\n",
+              "markup": "markdown",
+              "html": "<p>test</p>"
+            },
+            "links": {
+              "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/sourcegraph-testing/sourcegraph/commit/98550882e23008012dbf4b813cfbb19a4c14982a"
+              },
+              "html": {
+                "href": "https://bitbucket.org/sourcegraph-testing/sourcegraph/commits/98550882e23008012dbf4b813cfbb19a4c14982a"
+              }
+            },
+            "parents": [
+              {
+                "type": "commit",
+                "hash": "50e13d91bf02e318063fd0be4077257cec8b51b7",
+                "links": {
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/sourcegraph-testing/sourcegraph/commit/50e13d91bf02e318063fd0be4077257cec8b51b7"
+                  },
+                  "html": {
+                    "href": "https://bitbucket.org/sourcegraph-testing/sourcegraph/commits/50e13d91bf02e318063fd0be4077257cec8b51b7"
+                  }
+                }
+              }
+            ],
+            "rendered": {},
+            "properties": {}
+          },
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/sourcegraph-testing/sourcegraph/refs/branches/rs/push-test"
+            },
+            "commits": {
+              "href": "https://api.bitbucket.org/2.0/repositories/sourcegraph-testing/sourcegraph/commits/rs/push-test"
+            },
+            "html": {
+              "href": "https://bitbucket.org/sourcegraph-testing/sourcegraph/branch/rs/push-test"
+            }
+          },
+          "type": "branch",
+          "merge_strategies": [
+            "merge_commit",
+            "squash",
+            "fast_forward"
+          ],
+          "default_merge_strategy": "merge_commit"
+        },
+        "truncated": false,
+        "created": false,
+        "forced": false,
+        "closed": false,
+        "links": {
+          "commits": {
+            "href": "https://api.bitbucket.org/2.0/repositories/sourcegraph-testing/sourcegraph/commits?include=98550882e23008012dbf4b813cfbb19a4c14982a&exclude=50e13d91bf02e318063fd0be4077257cec8b51b7"
+          },
+          "diff": {
+            "href": "https://api.bitbucket.org/2.0/repositories/sourcegraph-testing/sourcegraph/diff/98550882e23008012dbf4b813cfbb19a4c14982a..50e13d91bf02e318063fd0be4077257cec8b51b7"
+          },
+          "html": {
+            "href": "https://bitbucket.org/sourcegraph-testing/sourcegraph/branches/compare/98550882e23008012dbf4b813cfbb19a4c14982a..50e13d91bf02e318063fd0be4077257cec8b51b7"
+          }
+        },
+        "commits": [
+          {
+            "type": "commit",
+            "hash": "98550882e23008012dbf4b813cfbb19a4c14982a",
+            "date": "2022-12-23T15:21:34+00:00",
+            "author": {
+              "type": "author",
+              "raw": "Ryan Slade <ryanslade@gmail.com>",
+              "user": {
+                "display_name": "Ryan Slade",
+                "links": {
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/%7Bac50370e-c8bf-45ef-8a52-1b69253c29cc%7D"
+                  },
+                  "avatar": {
+                    "href": "https://secure.gravatar.com/avatar/7d7fe505cb4b9c27c81f707eb2a63b51?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FRS-6.png"
+                  },
+                  "html": {
+                    "href": "https://bitbucket.org/%7Bac50370e-c8bf-45ef-8a52-1b69253c29cc%7D/"
+                  }
+                },
+                "type": "user",
+                "uuid": "{ac50370e-c8bf-45ef-8a52-1b69253c29cc}",
+                "account_id": "70121:9c66d5bd-21a3-4280-b5ed-4a1f330fa27a",
+                "nickname": "Ryan Slade"
+              }
+            },
+            "message": "test\n",
+            "summary": {
+              "type": "rendered",
+              "raw": "test\n",
+              "markup": "markdown",
+              "html": "<p>test</p>"
+            },
+            "links": {
+              "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/sourcegraph-testing/sourcegraph/commit/98550882e23008012dbf4b813cfbb19a4c14982a"
+              },
+              "html": {
+                "href": "https://bitbucket.org/sourcegraph-testing/sourcegraph/commits/98550882e23008012dbf4b813cfbb19a4c14982a"
+              },
+              "diff": {
+                "href": "https://api.bitbucket.org/2.0/repositories/sourcegraph-testing/sourcegraph/diff/98550882e23008012dbf4b813cfbb19a4c14982a"
+              },
+              "approve": {
+                "href": "https://api.bitbucket.org/2.0/repositories/sourcegraph-testing/sourcegraph/commit/98550882e23008012dbf4b813cfbb19a4c14982a/approve"
+              },
+              "comments": {
+                "href": "https://api.bitbucket.org/2.0/repositories/sourcegraph-testing/sourcegraph/commit/98550882e23008012dbf4b813cfbb19a4c14982a/comments"
+              },
+              "statuses": {
+                "href": "https://api.bitbucket.org/2.0/repositories/sourcegraph-testing/sourcegraph/commit/98550882e23008012dbf4b813cfbb19a4c14982a/statuses"
+              },
+              "patch": {
+                "href": "https://api.bitbucket.org/2.0/repositories/sourcegraph-testing/sourcegraph/patch/98550882e23008012dbf4b813cfbb19a4c14982a"
+              }
+            },
+            "parents": [
+              {
+                "type": "commit",
+                "hash": "50e13d91bf02e318063fd0be4077257cec8b51b7",
+                "links": {
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/sourcegraph-testing/sourcegraph/commit/50e13d91bf02e318063fd0be4077257cec8b51b7"
+                  },
+                  "html": {
+                    "href": "https://bitbucket.org/sourcegraph-testing/sourcegraph/commits/50e13d91bf02e318063fd0be4077257cec8b51b7"
+                  }
+                }
+              }
+            ],
+            "rendered": {},
+            "properties": {}
+          }
+        ]
+      }
+    ]
+  },
+  "repository": {
+    "type": "repository",
+    "full_name": "sourcegraph-testing/sourcegraph",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/sourcegraph-testing/sourcegraph"
+      },
+      "html": {
+        "href": "https://bitbucket.org/sourcegraph-testing/sourcegraph"
+      },
+      "avatar": {
+        "href": "https://bytebucket.org/ravatar/%7Bf46afc56-15a7-4579-9429-1b9329ad4c09%7D?ts=default"
+      }
+    },
+    "name": "sourcegraph",
+    "scm": "git",
+    "website": null,
+    "owner": {
+      "display_name": "Sourcegraph Testing",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/users/%7B4b85b785-1433-4092-8512-20302f4a03be%7D"
+        },
+        "avatar": {
+          "href": "https://secure.gravatar.com/avatar/f964dc31564db8243e952bdaeabbe884?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FST-2.png"
+        },
+        "html": {
+          "href": "https://bitbucket.org/%7B4b85b785-1433-4092-8512-20302f4a03be%7D/"
+        }
+      },
+      "type": "user",
+      "uuid": "{4b85b785-1433-4092-8512-20302f4a03be}",
+      "account_id": "623316f53fbb880068413f6b",
+      "nickname": "Sourcegraph Testing"
+    },
+    "workspace": {
+      "type": "workspace",
+      "uuid": "{4b85b785-1433-4092-8512-20302f4a03be}",
+      "name": "Sourcegraph Testing",
+      "slug": "sourcegraph-testing",
+      "links": {
+        "avatar": {
+          "href": "https://bitbucket.org/workspaces/sourcegraph-testing/avatar/?ts=1647515473"
+        },
+        "html": {
+          "href": "https://bitbucket.org/sourcegraph-testing/"
+        },
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/workspaces/sourcegraph-testing"
+        }
+      }
+    },
+    "is_private": true,
+    "project": {
+      "type": "project",
+      "key": "SOUR",
+      "uuid": "{a862a17c-1726-47a2-bcd1-d9b37313b350}",
+      "name": "sourcegraph-testing",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/workspaces/sourcegraph-testing/projects/SOUR"
+        },
+        "html": {
+          "href": "https://bitbucket.org/sourcegraph-testing/workspace/projects/SOUR"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/user/sourcegraph-testing/projects/SOUR/avatar/32?ts=1647515868"
+        }
+      }
+    },
+    "uuid": "{f46afc56-15a7-4579-9429-1b9329ad4c09}"
+  },
+  "actor": {
+    "display_name": "Sourcegraph Testing",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/users/%7B4b85b785-1433-4092-8512-20302f4a03be%7D"
+      },
+      "avatar": {
+        "href": "https://secure.gravatar.com/avatar/f964dc31564db8243e952bdaeabbe884?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FST-2.png"
+      },
+      "html": {
+        "href": "https://bitbucket.org/%7B4b85b785-1433-4092-8512-20302f4a03be%7D/"
+      }
+    },
+    "type": "user",
+    "uuid": "{4b85b785-1433-4092-8512-20302f4a03be}",
+    "account_id": "623316f53fbb880068413f6b",
+    "nickname": "Sourcegraph Testing"
+  }
+}

--- a/internal/cloneurls/clone_urls.go
+++ b/internal/cloneurls/clone_urls.go
@@ -44,6 +44,7 @@ func RepoSourceCloneURLToRepoName(ctx context.Context, db database.DB, cloneURL 
 			extsvc.KindGitHub,
 			extsvc.KindGitLab,
 			extsvc.KindBitbucketServer,
+			extsvc.KindBitbucketCloud,
 			extsvc.KindAWSCodeCommit,
 			extsvc.KindGitolite,
 			extsvc.KindPhabricator,
@@ -123,6 +124,9 @@ func getRepoNameFromService(ctx context.Context, cloneURL string, svc *types.Ext
 		host = c.Url
 	case *schema.BitbucketServerConnection:
 		rs = reposource.BitbucketServer{BitbucketServerConnection: c}
+		host = c.Url
+	case *schema.BitbucketCloudConnection:
+		rs = reposource.BitbucketCloud{BitbucketCloudConnection: c}
 		host = c.Url
 	case *schema.AWSCodeCommitConnection:
 		rs = reposource.AWS{AWSCodeCommitConnection: c}

--- a/internal/extsvc/bitbucketcloud/events.go
+++ b/internal/extsvc/bitbucketcloud/events.go
@@ -47,7 +47,7 @@ func ParseWebhookEvent(eventKey string, payload []byte) (any, error) {
 
 // Types (and subtypes) that we can unmarshal from a webhook payload.
 //
-// This is (intentionally) most, but not all, of the payload types as of April
+// This is (intentionally) most, but not all, of the payload types as of December
 // 2022. Some repo events are unlikely to ever be useful to us, so we don't even
 // attempt to unmarshal them.
 

--- a/internal/extsvc/bitbucketcloud/events.go
+++ b/internal/extsvc/bitbucketcloud/events.go
@@ -33,6 +33,8 @@ func ParseWebhookEvent(eventKey string, payload []byte) (any, error) {
 		target = &RepoCommitStatusCreatedEvent{}
 	case "repo:commit_status_updated":
 		target = &RepoCommitStatusUpdatedEvent{}
+	case "repo:push":
+		target = &PushEvent{}
 	default:
 		return nil, UnknownWebhookEventKey(eventKey)
 	}
@@ -46,8 +48,12 @@ func ParseWebhookEvent(eventKey string, payload []byte) (any, error) {
 // Types (and subtypes) that we can unmarshal from a webhook payload.
 //
 // This is (intentionally) most, but not all, of the payload types as of April
-// 2022. Some of the repo events are unlikely to ever be useful to us, so we
-// don't even attempt to unmarshal them.
+// 2022. Some repo events are unlikely to ever be useful to us, so we don't even
+// attempt to unmarshal them.
+
+type PushEvent struct {
+	RepoEvent
+}
 
 type PullRequestEvent struct {
 	RepoEvent


### PR DESCRIPTION
Handle `push` webhook events for Bitbucket Cloud

Closes #45765

## Test plan

New unit tests added and manual end to end testing done locally.