### PR TITLE
web: drop elm-loader from webpack config

### DIFF
--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -281,18 +281,6 @@ const config = {
       },
       { test: /\.ya?ml$/, type: 'asset/source' },
       { test: /\.(png|woff2)$/, type: 'asset/resource' },
-      {
-        test: /\.elm$/,
-        exclude: /elm-stuff/,
-        use: {
-          loader: 'elm-webpack-loader',
-          options: {
-            cwd: path.resolve(ROOT_PATH, 'client/web/src/search/results/components/compute'),
-            report: 'json',
-            pathToElm: path.resolve(ROOT_PATH, 'node_modules/.bin/elm'),
-          },
-        },
-      },
     ],
   },
 }


### PR DESCRIPTION
## Context

Drops the redundant loader from the Webpack config.

## Test plan

CI

## App preview:

- [Web](https://sg-web-vb-drop-elm-loader.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
