### PR TITLE
web: Add Test connection button and API call to code host

### DIFF
--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -122,7 +122,7 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                                 {node.nextSyncAt === null && <>No next sync scheduled.</>}
                                 <br />
                                 {isErrorLike(checkConnectionError) && (
-                                    <span className='text-danger'>
+                                    <span className="text-danger">
                                         <Icon aria-hidden={true} svgPath={mdiAlertCircle} />{' '}
                                         <ErrorMessage error={checkConnectionError} />
                                     </span>
@@ -152,7 +152,9 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                                     checkConnectionData.node.checkConnection.suspectedReason && (
                                         <span className="text-danger">
                                             <Icon aria-hidden={true} svgPath={mdiAlertCircle} />{' '}
-                                            <ErrorMessage error={checkConnectionData.node.checkConnection.suspectedReason} />
+                                            <ErrorMessage
+                                                error={checkConnectionData.node.checkConnection.suspectedReason}
+                                            />
                                         </span>
                                     )}
                             </small>

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -51,23 +51,16 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
         }
     }, [afterDeleteRoute, history, node.displayName, node.id, onDidUpdate])
 
-    const [doCheckConnection, { loading, data }] = useExternalServiceCheckConnectionByIdLazyQuery(node.id)
-
-    const [checkConnectionError, setCheckConnectionError] = useState<boolean | Error>(false)
+    const [doCheckConnection, { loading, data, error }] = useExternalServiceCheckConnectionByIdLazyQuery(node.id)
 
     const onTestConnection = useCallback<React.MouseEventHandler>(async () => {
-        setCheckConnectionError(false)
-        try {
-            await doCheckConnection()
-        } catch (error) {
-            setCheckConnectionError(asError(error))
-        }
+        await doCheckConnection()
     }, [doCheckConnection])
 
     const checkConnectionNode = data?.node?.__typename === 'ExternalService' ? data.node.checkConnection : null
 
     let externalServiceAvailabilityStatus
-    if (!checkConnectionError && !loading) {
+    if (!error && !loading) {
         if (checkConnectionNode?.__typename === 'ExternalServiceAvailable') {
             externalServiceAvailabilityStatus = (
                 <span className="text-success">
@@ -143,10 +136,10 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                                         <LoadingSpinner /> Checking connection...
                                     </span>
                                 )}
-                                {!loading && isErrorLike(checkConnectionError) && (
+                                {!loading && error && (
                                     <span className="text-danger">
                                         <Icon aria-hidden={true} svgPath={mdiAlertCircle} />{' '}
-                                        <ErrorMessage error={checkConnectionError} />
+                                        <ErrorMessage error={error} />
                                     </span>
                                 )}
                                 {externalServiceAvailabilityStatus}

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -150,7 +150,7 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                         <Button
                             className="test-connection-external-service-button"
                             variant="secondary"
-                            onClick={doCheckConnection}
+                            onClick={() => doCheckConnection()}
                             disabled={!node.hasConnectionCheck || loading}
                             size="sm"
                         >

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -53,10 +53,6 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
 
     const [doCheckConnection, { loading, data, error }] = useExternalServiceCheckConnectionByIdLazyQuery(node.id)
 
-    const onTestConnection = useCallback<React.MouseEventHandler>(async () => {
-        await doCheckConnection()
-    }, [doCheckConnection])
-
     const checkConnectionNode = data?.node?.__typename === 'ExternalService' ? data.node.checkConnection : null
 
     let externalServiceAvailabilityStatus
@@ -154,7 +150,7 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                         <Button
                             className="test-connection-external-service-button"
                             variant="secondary"
-                            onClick={onTestConnection}
+                            onClick={doCheckConnection}
                             disabled={!node.hasConnectionCheck || loading}
                             size="sm"
                         >

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -67,6 +67,11 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
         }
     }, [doCheckConnection])
 
+    const checkConnectionNode =
+        checkConnectionData?.node?.__typename === 'ExternalService' ? checkConnectionData.node.checkConnection : null
+    const isExternalServiceAvailable = checkConnectionNode?.__typename === 'ExternalServiceAvailable'
+    const isExternalServiceUnavailable = checkConnectionNode?.__typename === 'ExternalServiceUnavailable'
+
     const IconComponent = defaultExternalServices[node.kind].icon
 
     return (
@@ -135,11 +140,7 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                                 {!isErrorLike(checkConnectionError) &&
                                     !checkConnectionLoading &&
                                     checkConnectionCalled &&
-                                    checkConnectionData &&
-                                    checkConnectionData.node?.__typename === 'ExternalService' &&
-                                    checkConnectionData.node.checkConnection?.__typename ===
-                                        'ExternalServiceAvailable' &&
-                                    checkConnectionData.node.checkConnection.lastCheckedAt && (
+                                    isExternalServiceAvailable && (
                                         <span className="text-success">
                                             <Icon aria-hidden={true} svgPath={mdiCheckCircle} /> Code host is reachable.
                                         </span>
@@ -147,16 +148,11 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                                 {!isErrorLike(checkConnectionError) &&
                                     !checkConnectionLoading &&
                                     checkConnectionCalled &&
-                                    checkConnectionData &&
-                                    checkConnectionData.node?.__typename === 'ExternalService' &&
-                                    checkConnectionData.node.checkConnection?.__typename ===
-                                        'ExternalServiceUnavailable' &&
-                                    checkConnectionData.node.checkConnection.suspectedReason && (
+                                    isExternalServiceUnavailable &&
+                                    checkConnectionNode?.suspectedReason && (
                                         <span className="text-danger">
                                             <Icon aria-hidden={true} svgPath={mdiAlertCircle} />{' '}
-                                            <ErrorMessage
-                                                error={checkConnectionData.node.checkConnection.suspectedReason}
-                                            />
+                                            <ErrorMessage error={checkConnectionNode.suspectedReason} />
                                         </span>
                                     )}
                             </small>

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -6,7 +6,7 @@ import * as H from 'history'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { asError, isErrorLike, pluralize } from '@sourcegraph/common'
-import { Button, Link, LoadingSpinner, Icon, Tooltip, Text, ErrorAlert } from '@sourcegraph/wildcard'
+import { Button, ButtonProps, Link, LoadingSpinner, Icon, Tooltip, Text, ErrorAlert } from '@sourcegraph/wildcard'
 
 import { ListExternalServiceFields } from '../../graphql-operations'
 import { refreshSiteFlags } from '../../site/backend'
@@ -15,6 +15,7 @@ import { deleteExternalService, testExternalServiceConnection } from './backend'
 import { defaultExternalServices } from './externalServices'
 
 import styles from './ExternalServiceNode.module.scss'
+
 
 export interface ExternalServiceNodeProps {
     node: ListExternalServiceFields
@@ -55,7 +56,6 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
     const onTestConnection = useCallback<React.MouseEventHandler>(async () => {
         setIsTestInProgress(true)
         try {
-            // FIXME: Implement
             await testExternalServiceConnection(node.id)
             setIsTestInProgress(false)
             // FIXME: add on update callback
@@ -122,16 +122,20 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                     </div>
                 </div>
                 <div className="flex-shrink-0 ml-3">
-                    <Tooltip content={'Test connectivity to code host'}>
-                        <Button
-                            className="test-connection-external-service-button"
-                            variant="secondary"
-                            size="sm"
-                            onClick={onTestConnection}
-                        >
-                            <Icon aria-hidden={true} svgPath={mdiConnection} /> {'Test'}
-                        </Button>
-                    </Tooltip>{' '}
+                    <TestConnectionButton
+                        className="test-code-host-connection-button"
+                        title="Test"
+                        buttonVariant="secondary"
+                        // FIXME: Maybe update button if check in progress
+                        buttonLabel="Test"
+                        buttonSubtitle="Check code host connection"
+                        buttonDisabled={!node.hasConnectionCheck}
+                        flashText="Checking..."
+                        run={async () => {
+                            await testExternalServiceConnection(node.id)
+                        }}
+                    // history={}
+                    />
                     <Tooltip content={`${editingDisabled ? 'View' : 'Edit'} code host connection settings`}>
                         <Button
                             className="test-edit-external-service-button"
@@ -163,4 +167,98 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
             {isErrorLike(isDeleting) && <ErrorAlert className="mt-2" error={isDeleting} />}
         </li>
     )
+}
+
+interface Props {
+    title: React.ReactNode
+    buttonVariant?: ButtonProps['variant']
+    buttonLabel: React.ReactNode
+    buttonSubtitle?: string
+    buttonDisabled?: boolean
+    info?: React.ReactNode
+    className?: string
+
+    /** The message to briefly display below the button when the action is successful. */
+    flashText?: string
+
+    run: () => Promise<void>
+    history: H.History
+}
+
+interface State {
+    loading: boolean
+    flash: boolean
+    error?: string
+}
+
+
+class TestConnectionButton extends React.PureComponent<Props, State> {
+    public state: State = {
+        loading: false,
+        flash: false,
+    }
+
+    private timeoutHandle?: number
+
+    public componentWillUnmount(): void {
+        if (this.timeoutHandle) {
+            window.clearTimeout(this.timeoutHandle)
+        }
+    }
+
+    private onClick = (): void => {
+        this.setState({
+            error: undefined,
+            loading: true,
+        })
+
+        this.props.run().then(
+            () => {
+                this.setState({ loading: false, flash: true })
+                if (typeof this.timeoutHandle === 'number') {
+                    window.clearTimeout(this.timeoutHandle)
+                }
+                this.timeoutHandle = window.setTimeout(() => this.setState({ flash: false }), 1000)
+            },
+            error => this.setState({ loading: false, error: asError(error).message })
+        )
+    }
+
+    public render(): JSX.Element | null {
+        let content
+        if (!this.props.buttonDisabled) {
+            content = this.props.buttonSubtitle
+        } else {
+            content = "Connectivity check is not implemented for this code host"
+        }
+
+        let buttonLabelElement
+        if (this.state.loading) {
+            buttonLabelElement = <><LoadingSpinner /> Checking</>
+        } else {
+            buttonLabelElement=<><Icon aria-hidden={true} svgPath={mdiConnection} /> Test</>
+        }
+
+        return (
+            <>
+                <Tooltip content={content}>
+                    <Button
+                        className={this.props.className}
+                        variant={this.props.buttonVariant || "primary"}
+                        onClick={this.onClick}
+                        disabled={this.props.buttonDisabled || this.state.loading}
+                        size="sm"
+                    >
+                {buttonLabelElement}
+                </Button>
+                </Tooltip>{' '}
+
+                {this.props.flashText && this.state.flash && (
+                    <div className={classNames("flash")}>
+                        <small>{this.props.flashText}</small>
+                    </div>
+                )}
+            </>
+        )
+    }
 }

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -56,7 +56,6 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
 
     // const [isTestInProgress, setIsTestInProgress] = useState<boolean | Error>(false)
     const onTestConnection = useCallback<React.MouseEventHandler>(async () => {
-        console.log("ontest")
         try {
             await doCheckConnection()
         } catch (error) {
@@ -124,7 +123,7 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                                 )}
                                 {node.nextSyncAt === null && <>No next sync scheduled.</>}
                                 <br />
-            {checkConnectionCalled && checkConnectionData &&
+            {!checkConnectionLoading && checkConnectionCalled && checkConnectionData &&
                 checkConnectionData.node?.checkConnection?.__typename === 'ExternalServiceAvailable' &&
                 checkConnectionData.node.checkConnection.lastCheckedAt &&
                 <>
@@ -133,7 +132,7 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                 </>
             }
 
-            {checkConnectionCalled && checkConnectionData &&
+            {!checkConnectionLoading && checkConnectionCalled && checkConnectionData &&
                 checkConnectionData.node?.checkConnection?.__typename === 'ExternalServiceUnavailable' &&
                 checkConnectionData.node.checkConnection.suspectedReason &&
                 <>

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -1,17 +1,17 @@
 import React, { useCallback, useState } from 'react'
 
-import { mdiCircle, mdiCog, mdiDelete } from '@mdi/js'
+import { mdiCircle, mdiCog, mdiConnection, mdiDelete } from '@mdi/js'
 import classNames from 'classnames'
 import * as H from 'history'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { asError, isErrorLike, pluralize } from '@sourcegraph/common'
-import { Button, Link, Icon, Tooltip, Text, ErrorAlert } from '@sourcegraph/wildcard'
+import { Button, Link, LoadingSpinner, Icon, Tooltip, Text, ErrorAlert } from '@sourcegraph/wildcard'
 
 import { ListExternalServiceFields } from '../../graphql-operations'
 import { refreshSiteFlags } from '../../site/backend'
 
-import { deleteExternalService } from './backend'
+import { deleteExternalService, testExternalServiceConnection } from './backend'
 import { defaultExternalServices } from './externalServices'
 
 import styles from './ExternalServiceNode.module.scss'
@@ -50,6 +50,19 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
             setIsDeleting(asError(error))
         }
     }, [afterDeleteRoute, history, node.displayName, node.id, onDidUpdate])
+
+    const [isTestInProgress, setIsTestInProgress] = useState<boolean | Error>(false)
+    const onTestConnection = useCallback<React.MouseEventHandler>(async () => {
+        setIsTestInProgress(true)
+        try {
+            // FIXME: Implement
+            await testExternalServiceConnection(node.id)
+            setIsTestInProgress(false)
+            // FIXME: add on update callback
+        } catch (error) {
+            setIsTestInProgress(asError(error))
+        }
+    }, [])
 
     const IconComponent = defaultExternalServices[node.kind].icon
 
@@ -109,6 +122,16 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                     </div>
                 </div>
                 <div className="flex-shrink-0 ml-3">
+                    <Tooltip content={'Test connectivity to code host'}>
+                        <Button
+                            className="test-connection-external-service-button"
+                            variant="secondary"
+                            size="sm"
+                            onClick={onTestConnection}
+                        >
+                            <Icon aria-hidden={true} svgPath={mdiConnection} /> {'Test'}
+                        </Button>
+                    </Tooltip>{' '}
                     <Tooltip content={`${editingDisabled ? 'View' : 'Edit'} code host connection settings`}>
                         <Button
                             className="test-edit-external-service-button"

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -16,7 +16,6 @@ import { defaultExternalServices } from './externalServices'
 
 import styles from './ExternalServiceNode.module.scss'
 
-
 export interface ExternalServiceNodeProps {
     node: ListExternalServiceFields
     onDidUpdate: () => void
@@ -52,7 +51,10 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
         }
     }, [afterDeleteRoute, history, node.displayName, node.id, onDidUpdate])
 
-    const [doCheckConnection, {called: checkConnectionCalled, loading: checkConnectionLoading, data: checkConnectionData}] = useExternalServiceCheckConnectionByIdLazyQuery(node.id)
+    const [
+        doCheckConnection,
+        { called: checkConnectionCalled, loading: checkConnectionLoading, data: checkConnectionData },
+    ] = useExternalServiceCheckConnectionByIdLazyQuery(node.id)
 
     const onTestConnection = useCallback<React.MouseEventHandler>(async () => {
         try {
@@ -63,10 +65,10 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
     }, [])
 
     const capitalizeSuspectedReason = (s: string) => {
-      const firstCharacter = s.charAt(0).toUpperCase();
-      const restOfString = s.slice(1);
-      return firstCharacter + restOfString;
-    };
+        const firstCharacter = s.charAt(0).toUpperCase()
+        const restOfString = s.slice(1)
+        return firstCharacter + restOfString
+    }
 
     const IconComponent = defaultExternalServices[node.kind].icon
 
@@ -122,31 +124,45 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                                 )}
                                 {node.nextSyncAt === null && <>No next sync scheduled.</>}
                                 <br />
-                                {checkConnectionLoading &&
-                                    <span className={classNames("text-primary")}>
+                                {checkConnectionLoading && (
+                                    <span className={classNames('text-primary')}>
                                         <LoadingSpinner /> Checking connection...
                                     </span>
-                                }
-                                {!checkConnectionLoading && checkConnectionCalled && checkConnectionData &&
-                                    checkConnectionData.node?.checkConnection?.__typename === 'ExternalServiceAvailable' &&
-                                    checkConnectionData.node.checkConnection.lastCheckedAt &&
-                                    <span className="text-success">
-                                        <Icon aria-hidden={true} svgPath={mdiCheckCircle} /> Code host is reachable.<span/>
-                                    </span>
-                                }
-                                {!checkConnectionLoading && checkConnectionCalled && checkConnectionData &&
-                                    checkConnectionData.node?.checkConnection?.__typename === 'ExternalServiceUnavailable' &&
-                                    checkConnectionData.node.checkConnection.suspectedReason &&
-                                    <span className="text-danger">
-                                      <Icon aria-hidden={true} svgPath={mdiAlertCircle} /> {capitalizeSuspectedReason(checkConnectionData.node.checkConnection.suspectedReason)}
-                                    </span>
-                                }
+                                )}
+                                {!checkConnectionLoading &&
+                                    checkConnectionCalled &&
+                                    checkConnectionData &&
+                                    checkConnectionData.node?.checkConnection?.__typename ===
+                                        'ExternalServiceAvailable' &&
+                                    checkConnectionData.node.checkConnection.lastCheckedAt && (
+                                        <span className="text-success">
+                                            <Icon aria-hidden={true} svgPath={mdiCheckCircle} /> Code host is reachable.
+                                            <span />
+                                        </span>
+                                    )}
+                                {!checkConnectionLoading &&
+                                    checkConnectionCalled &&
+                                    checkConnectionData &&
+                                    checkConnectionData.node?.checkConnection?.__typename ===
+                                        'ExternalServiceUnavailable' &&
+                                    checkConnectionData.node.checkConnection.suspectedReason && (
+                                        <span className="text-danger">
+                                            <Icon aria-hidden={true} svgPath={mdiAlertCircle} />{' '}
+                                            {capitalizeSuspectedReason(
+                                                checkConnectionData.node.checkConnection.suspectedReason
+                                            )}
+                                        </span>
+                                    )}
                             </small>
                         </Text>
                     </div>
                 </div>
                 <div className="flex-shrink-0 ml-3">
-                    <Tooltip content={node?.hasConnectionCheck? "Test code host connection" : "Connection check unavailable" }>
+                    <Tooltip
+                        content={
+                            node?.hasConnectionCheck ? 'Test code host connection' : 'Connection check unavailable'
+                        }
+                    >
                         <Button
                             className="test-connection-external-service-button"
                             variant="secondary"
@@ -154,7 +170,7 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                             disabled={!node?.hasConnectionCheck || checkConnectionLoading}
                             size="sm"
                         >
-                        <Icon aria-hidden={true} svgPath={mdiConnection} /> Test
+                            <Icon aria-hidden={true} svgPath={mdiConnection} /> Test
                         </Button>
                     </Tooltip>{' '}
                     <Tooltip content={`${editingDisabled ? 'View' : 'Edit'} code host connection settings`}>

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -51,7 +51,7 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
         }
     }, [afterDeleteRoute, history, node.displayName, node.id, onDidUpdate])
 
-    const [doCheckConnection, { called, loading, data }] = useExternalServiceCheckConnectionByIdLazyQuery(node.id)
+    const [doCheckConnection, { loading, data }] = useExternalServiceCheckConnectionByIdLazyQuery(node.id)
 
     const [checkConnectionError, setCheckConnectionError] = useState<boolean | Error>(false)
 

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -136,7 +136,8 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                                     !checkConnectionLoading &&
                                     checkConnectionCalled &&
                                     checkConnectionData &&
-                                    checkConnectionData.node?.checkConnection?.__typename ===
+                                    checkConnectionData.node?.__typename == 'ExternalService' &&
+                                    checkConnectionData.node.checkConnection?.__typename ===
                                         'ExternalServiceAvailable' &&
                                     checkConnectionData.node.checkConnection.lastCheckedAt && (
                                         <span className="text-success">
@@ -147,7 +148,8 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                                     !checkConnectionLoading &&
                                     checkConnectionCalled &&
                                     checkConnectionData &&
-                                    checkConnectionData.node?.checkConnection?.__typename ===
+                                    checkConnectionData.node?.__typename == 'ExternalService' &&
+                                    checkConnectionData.node.checkConnection?.__typename ===
                                         'ExternalServiceUnavailable' &&
                                     checkConnectionData.node.checkConnection.suspectedReason && (
                                         <span className="text-danger">

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react'
 
-import { mdiCircle, mdiCog, mdiConnection, mdiDelete } from '@mdi/js'
+import { mdiAlertCircle, mdiCircle, mdiCheckCircle, mdiCog, mdiConnection, mdiDelete } from '@mdi/js'
 import classNames from 'classnames'
 import * as H from 'history'
 
@@ -123,25 +123,26 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                                 )}
                                 {node.nextSyncAt === null && <>No next sync scheduled.</>}
                                 <br />
-            {!checkConnectionLoading && checkConnectionCalled && checkConnectionData &&
-                checkConnectionData.node?.checkConnection?.__typename === 'ExternalServiceAvailable' &&
-                checkConnectionData.node.checkConnection.lastCheckedAt &&
-                <>
-                <span className="text-success">Code host is available. Last checked <Timestamp date={checkConnectionData.node.checkConnection.lastCheckedAt} />.
-                </span>
-                </>
-            }
-
-            {!checkConnectionLoading && checkConnectionCalled && checkConnectionData &&
-                checkConnectionData.node?.checkConnection?.__typename === 'ExternalServiceUnavailable' &&
-                checkConnectionData.node.checkConnection.suspectedReason &&
-                <>
-                <span className="text-danger">
-                {capitalizeSuspectedReason(checkConnectionData.node.checkConnection.suspectedReason)}
-                </span>
-                </>
-            }
-                           </small>
+                                {checkConnectionLoading &&
+                                    <span className={classNames("text-primary")}>
+                                        <LoadingSpinner /> Checking connection...
+                                    </span>
+                                }
+                                {!checkConnectionLoading && checkConnectionCalled && checkConnectionData &&
+                                    checkConnectionData.node?.checkConnection?.__typename === 'ExternalServiceAvailable' &&
+                                    checkConnectionData.node.checkConnection.lastCheckedAt &&
+                                    <span className="text-success">
+                                        <Icon aria-hidden={true} svgPath={mdiCheckCircle} /> Code host is reachable.<span/>
+                                    </span>
+                                }
+                                {!checkConnectionLoading && checkConnectionCalled && checkConnectionData &&
+                                    checkConnectionData.node?.checkConnection?.__typename === 'ExternalServiceUnavailable' &&
+                                    checkConnectionData.node.checkConnection.suspectedReason &&
+                                    <span className="text-danger">
+                                      <Icon aria-hidden={true} svgPath={mdiAlertCircle} /> {capitalizeSuspectedReason(checkConnectionData.node.checkConnection.suspectedReason)}
+                                    </span>
+                                }
+                            </small>
                         </Text>
                     </div>
                 </div>
@@ -154,8 +155,7 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                             disabled={!node?.hasConnectionCheck || checkConnectionLoading}
                             size="sm"
                         >
-                        {checkConnectionLoading && <><LoadingSpinner /> Checking</>}
-                        {!checkConnectionLoading && <><Icon aria-hidden={true} svgPath={mdiConnection} /> Test</>}
+                        <Icon aria-hidden={true} svgPath={mdiConnection} /> Test
                         </Button>
                     </Tooltip>{' '}
                     <Tooltip content={`${editingDisabled ? 'View' : 'Edit'} code host connection settings`}>

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -65,7 +65,7 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
         } catch (error) {
             setCheckConnectionError(asError(error))
         }
-    }, [])
+    }, [doCheckConnection])
 
     const IconComponent = defaultExternalServices[node.kind].icon
 
@@ -136,7 +136,7 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                                     !checkConnectionLoading &&
                                     checkConnectionCalled &&
                                     checkConnectionData &&
-                                    checkConnectionData.node?.__typename == 'ExternalService' &&
+                                    checkConnectionData.node?.__typename === 'ExternalService' &&
                                     checkConnectionData.node.checkConnection?.__typename ===
                                         'ExternalServiceAvailable' &&
                                     checkConnectionData.node.checkConnection.lastCheckedAt && (
@@ -148,7 +148,7 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                                     !checkConnectionLoading &&
                                     checkConnectionCalled &&
                                     checkConnectionData &&
-                                    checkConnectionData.node?.__typename == 'ExternalService' &&
+                                    checkConnectionData.node?.__typename === 'ExternalService' &&
                                     checkConnectionData.node.checkConnection?.__typename ===
                                         'ExternalServiceUnavailable' &&
                                     checkConnectionData.node.checkConnection.suspectedReason && (

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -54,12 +54,11 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
 
     const [doCheckConnection, {called: checkConnectionCalled, loading: checkConnectionLoading, data: checkConnectionData}] = useExternalServiceCheckConnectionByIdLazyQuery(node.id)
 
-    // const [isTestInProgress, setIsTestInProgress] = useState<boolean | Error>(false)
     const onTestConnection = useCallback<React.MouseEventHandler>(async () => {
         try {
             await doCheckConnection()
         } catch (error) {
-
+            // FIXME
         }
     }, [])
 

--- a/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
@@ -29,7 +29,7 @@ const queryExternalServices: typeof _queryExternalServices = () =>
             {
                 id: 'service1',
                 kind: ExternalServiceKind.GITHUB,
-                displayName: 'GitHub.com',
+                displayName: 'GitHub #1',
                 config: '{"githubconfig":true}',
                 warning: null,
                 lastSyncError: null,
@@ -40,11 +40,12 @@ const queryExternalServices: typeof _queryExternalServices = () =>
                 createdAt: '2021-03-15T19:39:11Z',
                 namespace: null,
                 webhookURL: null,
+                hasConnectionCheck: true,
             },
             {
                 id: 'service2',
                 kind: ExternalServiceKind.GITHUB,
-                displayName: 'GitHub.com',
+                displayName: 'GitHub #2',
                 config: '{"githubconfig":true}',
                 warning: null,
                 lastSyncError: null,
@@ -59,6 +60,7 @@ const queryExternalServices: typeof _queryExternalServices = () =>
                     url: '/users/johndoe',
                 },
                 webhookURL: null,
+                hasConnectionCheck: false,
             },
         ],
     })

--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -17,6 +17,8 @@ import {
     DeleteExternalServiceResult,
     ExternalServicesVariables,
     ExternalServicesResult,
+    TestExternalServiceConnectionVariables,
+    TestExternalServiceConnectionResult,
     SyncExternalServiceResult,
     SyncExternalServiceVariables,
     ExternalServiceSyncJobsVariables,
@@ -122,6 +124,35 @@ export async function deleteExternalService(externalService: Scalars['ID']): Pro
         { externalService }
     ).toPromise()
     dataOrThrowErrors(result)
+}
+
+export async function testExternalServiceConnection(id: Scalars['ID']): Promise<void> {
+    const result = await requestGraphQL<TestExternalServiceConnectionResult, TestExternalServiceConnectionVariables>(
+        gql`
+            query TestExternalServiceConnection($id: ID!) {
+                node(id: $id) {
+                    __typename
+                    ... on ExternalService {
+                        id
+                        hasConnectionCheck
+                        checkConnection {
+                            __typename
+                            ... on ExternalServiceAvailable {
+                                lastCheckedAt
+                            }
+                            ... on ExternalServiceUnavailable {
+                                suspectedReason
+                            }
+                            ... on ExternalServiceAvailabilityUnknown {
+                                implementationNote
+                            }
+                        }
+                    }
+                }
+            }
+        `,
+        { id }
+    ).toPromise()
 }
 
 export const listExternalServiceFragment = gql`

--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -1,4 +1,4 @@
-import { QueryResult, MutationTuple } from '@apollo/client'
+import { QueryTuple, MutationTuple } from '@apollo/client'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 
@@ -17,8 +17,8 @@ import {
     DeleteExternalServiceResult,
     ExternalServicesVariables,
     ExternalServicesResult,
-    TestExternalServiceConnectionVariables,
-    TestExternalServiceConnectionResult,
+    ExternalServiceCheckConnectionByIdVariables,
+    ExternalServiceCheckConnectionByIdResult,
     SyncExternalServiceResult,
     SyncExternalServiceVariables,
     ExternalServiceSyncJobsVariables,
@@ -152,8 +152,8 @@ export const EXTERNAL_SERVICE_CHECK_CONNECTION_BY_ID = gql`
 
 export const useExternalServiceCheckConnectionByIdLazyQuery = (
     id: string
-): QueryResult<ExternalServiceCheckConnectionResult, ExternalServiceCheckConnectionVariables> =>
-    useLazyQuery<ExternalServiceCheckConnectionResult, ExternalServiceCheckConnectionVariables>(
+): QueryTuple<ExternalServiceCheckConnectionByIdResult, ExternalServiceCheckConnectionByIdVariables> =>
+    useLazyQuery<ExternalServiceCheckConnectionByIdResult, ExternalServiceCheckConnectionByIdVariables>(
         EXTERNAL_SERVICE_CHECK_CONNECTION_BY_ID,
         {
             variables: { id },

--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -150,11 +150,15 @@ export const EXTERNAL_SERVICE_CHECK_CONNECTION_BY_ID = gql`
     }
 `
 
-export const useExternalServiceCheckConnectionByIdLazyQuery = (id: string): QueryResult<ExternalServiceCheckConnectionResult, ExternalServiceCheckConnectionVariables> =>
-    useLazyQuery<ExternalServiceCheckConnectionResult, ExternalServiceCheckConnectionVariables>(EXTERNAL_SERVICE_CHECK_CONNECTION_BY_ID, {
+export const useExternalServiceCheckConnectionByIdLazyQuery = (
+    id: string
+): QueryResult<ExternalServiceCheckConnectionResult, ExternalServiceCheckConnectionVariables> =>
+    useLazyQuery<ExternalServiceCheckConnectionResult, ExternalServiceCheckConnectionVariables>(
+        EXTERNAL_SERVICE_CHECK_CONNECTION_BY_ID,
+        {
             variables: { id },
-    })
-
+        }
+    )
 
 export const listExternalServiceFragment = gql`
     fragment ListExternalServiceFields on ExternalService {

--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -1,4 +1,4 @@
-import { MutationTuple } from '@apollo/client'
+import { QueryResult, MutationTuple } from '@apollo/client'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 
@@ -124,35 +124,6 @@ export async function deleteExternalService(externalService: Scalars['ID']): Pro
         { externalService }
     ).toPromise()
     dataOrThrowErrors(result)
-}
-
-export async function testExternalServiceConnection(id: Scalars['ID']): Promise<void> {
-    const result = await requestGraphQL<TestExternalServiceConnectionResult, TestExternalServiceConnectionVariables>(
-        gql`
-            query TestExternalServiceConnection($id: ID!) {
-                node(id: $id) {
-                    __typename
-                    ... on ExternalService {
-                        id
-                        hasConnectionCheck
-                        checkConnection {
-                            __typename
-                            ... on ExternalServiceAvailable {
-                                lastCheckedAt
-                            }
-                            ... on ExternalServiceUnavailable {
-                                suspectedReason
-                            }
-                            ... on ExternalServiceAvailabilityUnknown {
-                                implementationNote
-                            }
-                        }
-                    }
-                }
-            }
-        `,
-        { id }
-    ).toPromise()
 }
 
 export const EXTERNAL_SERVICE_CHECK_CONNECTION_BY_ID = gql`

--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -169,6 +169,7 @@ export const listExternalServiceFragment = gql`
         updatedAt
         createdAt
         webhookURL
+        hasConnectionCheck
     }
 `
 export const EXTERNAL_SERVICES = gql`

--- a/client/web/src/site-admin/fixtures.ts
+++ b/client/web/src/site-admin/fixtures.ts
@@ -23,6 +23,7 @@ export function createExternalService(kind: ExternalServiceKind, url: string): L
         updatedAt: '2021-03-15T19:39:11Z',
         createdAt: '2021-03-15T19:39:11Z',
         webhookURL: null,
+        hasConnectionCheck: true,
     }
 }
 


### PR DESCRIPTION
UI for #44683.


## Test plan

1. Tested locally

**Check connection unavailable**

<img width="956" alt="image" src="https://user-images.githubusercontent.com/2682729/209933969-f560327a-c00f-46ac-b4e7-e2bae36af6a8.png">

**Check connection available**

<img width="970" alt="image" src="https://user-images.githubusercontent.com/2682729/209934083-d8b58ad0-3fa9-4344-92f8-3498fab64172.png">

**Check connection successful**

<img width="969" alt="image" src="https://user-images.githubusercontent.com/2682729/209934122-e4699f84-d5ba-4b18-abea-012b9ce01a8d.png">

**Check connection failed**

<img width="967" alt="image" src="https://user-images.githubusercontent.com/2682729/209934265-678dbbfb-d56f-4cc6-9667-4f263eff0e50.png">

**Check connection errored (application error)**

<img width="967" alt="image" src="https://user-images.githubusercontent.com/2682729/209934407-a4aff481-9aee-47da-ade8-074e0d04ef1d.png">

**Test button in action 🎥 for success, failure and error modes**

![CleanShot 2022-12-29 at 15 47 47](https://user-images.githubusercontent.com/2682729/209937817-51c7e8be-84a0-47a8-a2ce-a124cc2b734a.gif)


2. Builds should pass



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ig-test-connection-button.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

