### PR TITLE
web: redesign repository settings page.

### DIFF
--- a/client/web/src/components/externalServices/ExternalServiceCard.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceCard.tsx
@@ -11,27 +11,33 @@ import styles from './ExternalServiceCard.module.scss'
 
 interface ExternalServiceCardProps {
     /**
-     * Title to show in the external service "button"
+     * Title to show in the external service "button".
      */
     title: string
 
     /**
-     * Icon to show in the external service "button"
+     * Icon to show in the external service "button".
      */
     icon: React.ComponentType<React.PropsWithChildren<{ className?: string }>>
 
     /**
-     * A short description that will appear in the external service "button" under the title
+     * A short description that will appear in the external service "button" under the title.
      */
     shortDescription?: string
 
     kind: ExternalServiceKind
 
     to?: string
+
+    /**
+     * ToIcon is an icon shown on the right-hand side of the card. Default value is right-pointed chevron.
+     */
+    toIcon: string | undefined | null
     className?: string
     enabled?: boolean
     badge?: string
     tooltip?: string
+    bordered?: boolean
 }
 
 export const ExternalServiceCard: React.FunctionComponent<React.PropsWithChildren<ExternalServiceCardProps>> = ({
@@ -39,16 +45,23 @@ export const ExternalServiceCard: React.FunctionComponent<React.PropsWithChildre
     icon: CardIcon,
     shortDescription,
     to,
+    toIcon = mdiChevronRight,
     kind,
     className = '',
     enabled = true,
     badge = '',
     tooltip = '',
+    bordered = true,
 }) => {
     let cardTitle = <H3 className={shortDescription ? 'mb-0' : 'mt-1 mb-0'}>{title}</H3>
     cardTitle = tooltip ? <Tooltip content={tooltip}>{cardTitle}</Tooltip> : cardTitle
     const children = (
-        <div className={classNames('p-3 d-flex align-items-start border' + (enabled ? '' : ' text-muted'), className)}>
+        <div
+            className={classNames(
+                'd-flex align-items-start' + (bordered ? ' p-3 border' : ' p-1') + (enabled ? '' : ' text-muted'),
+                className
+            )}
+        >
             <Icon
                 disabled={!enabled}
                 className={classNames('mb-0 mr-3', styles.icon)}
@@ -60,8 +73,8 @@ export const ExternalServiceCard: React.FunctionComponent<React.PropsWithChildre
                 {shortDescription && <Text className="mb-0 text-muted">{shortDescription}</Text>}
             </div>
             <div className="flex-1 align-self-center">
-                {to && enabled && (
-                    <Icon className="float-right" svgPath={mdiChevronRight} inline={false} aria-hidden={true} />
+                {to && enabled && toIcon && (
+                    <Icon className="float-right" svgPath={toIcon} inline={false} aria-hidden={true} />
                 )}
                 {badge && (
                     <Badge className="float-right" variant="outlineSecondary">

--- a/client/web/src/components/externalServices/ExternalServiceCard.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceCard.tsx
@@ -32,7 +32,7 @@ interface ExternalServiceCardProps {
     /**
      * ToIcon is an icon shown on the right-hand side of the card. Default value is right-pointed chevron.
      */
-    toIcon: string | undefined | null
+    toIcon?: string | undefined | null
     className?: string
     enabled?: boolean
     badge?: string

--- a/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -5,8 +5,9 @@ import { Subject, Subscription } from 'rxjs'
 import { switchMap } from 'rxjs/operators'
 
 import { asError } from '@sourcegraph/common'
-import { Container, PageHeader, LoadingSpinner, Input, Text, ErrorAlert, Form } from '@sourcegraph/wildcard'
+import { Container, PageHeader, LoadingSpinner, Text, ErrorAlert, H2 } from '@sourcegraph/wildcard'
 
+import { CopyableText } from '../../components/CopyableText'
 import { ExternalServiceCard } from '../../components/externalServices/ExternalServiceCard'
 import { defaultExternalServices } from '../../components/externalServices/externalServices'
 import { PageTitle } from '../../components/PageTitle'
@@ -67,6 +68,7 @@ export class RepoSettingsOptionsPage extends React.PureComponent<Props, State> {
                 <PageTitle title="Repository settings" />
                 <PageHeader path={[{ text: 'Settings' }]} headingElement="h2" className="mb-3" />
                 <Container className="repo-settings-options-page">
+                    <H2 className="mb-3">Code hosts</H2>
                     {this.state.loading && <LoadingSpinner />}
                     {this.state.error && <ErrorAlert error={this.state.error} />}
                     {services.length > 0 && (
@@ -79,6 +81,8 @@ export class RepoSettingsOptionsPage extends React.PureComponent<Props, State> {
                                         title={service.displayName}
                                         shortDescription="Update this external service configuration to manage repository mirroring."
                                         to={`/site-admin/external-services/${service.id}`}
+                                        toIcon={null}
+                                        bordered={false}
                                     />
                                 </div>
                             ))}
@@ -91,20 +95,8 @@ export class RepoSettingsOptionsPage extends React.PureComponent<Props, State> {
                             )}
                         </div>
                     )}
-                    <Form>
-                        <Input
-                            id="repo-settings-options-page__name"
-                            readOnly={true}
-                            disabled={true}
-                            value={this.state.repo.name}
-                            required={true}
-                            spellCheck={false}
-                            autoCapitalize="off"
-                            autoCorrect="off"
-                            label="Repository name"
-                            className="mb-0"
-                        />
-                    </Form>
+                    <H2 className="mb-3">Repository name</H2>
+                    <CopyableText text={this.state.repo.name} size={this.state.repo.name.length} />
                 </Container>
             </>
         )


### PR DESCRIPTION
It includes adding headings for "Code host" and "Repository name" sections, making code host list less heavy (stripping code host card borders and icon) and removing unnecessary form for repository name, substituting it with a CopyableText component.

## Before
<img width="933" alt="image" src="https://user-images.githubusercontent.com/94846361/209634397-4e7f5a06-8710-413b-be68-1de442571cad.png">

## After

### Single code host
<img width="921" alt="image" src="https://user-images.githubusercontent.com/94846361/209634509-3953b53c-3713-4791-bc75-97d846836917.png">

### Multiple code hosts
<img width="936" alt="image" src="https://user-images.githubusercontent.com/94846361/209634540-bce78048-a9c8-4271-b7e4-350a9b03638c.png">

Test plan:
Local sg run and visual checks.

Part of https://github.com/sourcegraph/sourcegraph/issues/40504

## App preview:

- [Web](https://sg-web-ao-ui-repo-settings-code-host.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
