### PR TITLE
graphqlbackend: add `supportsRepoExclusion` query of externalServiceResolver.

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -66,6 +66,15 @@ var availabilityCheck = map[string]bool{
 	extsvc.KindBitbucketCloud:  true,
 }
 
+var supportsRepoExclusion = map[string]bool{
+	extsvc.KindAWSCodeCommit:   true,
+	extsvc.KindBitbucketCloud:  true,
+	extsvc.KindBitbucketServer: true,
+	extsvc.KindGitHub:          true,
+	extsvc.KindGitLab:          true,
+	extsvc.KindGitolite:        true,
+}
+
 func externalServiceByID(ctx context.Context, db database.DB, gqlID graphql.ID) (*externalServiceResolver, error) {
 	// 🚨 SECURITY: check whether user is site-admin
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, db); err != nil {
@@ -225,7 +234,7 @@ func (r *externalServiceResolver) CheckConnection(ctx context.Context) (*externa
 		return mockCheckConnection(ctx, r)
 	}
 
-	if !r.HasConnectionCheck(ctx) {
+	if !r.HasConnectionCheck() {
 		r.availability = availabilityState{
 			unknown: &externalServiceUnknown{},
 		}
@@ -263,7 +272,7 @@ func (r *externalServiceResolver) CheckConnection(ctx context.Context) (*externa
 	return r, nil
 }
 
-func (r *externalServiceResolver) HasConnectionCheck(ctx context.Context) bool {
+func (r *externalServiceResolver) HasConnectionCheck() bool {
 	return availabilityCheck[r.externalService.Kind]
 }
 
@@ -290,6 +299,10 @@ func (r *externalServiceResolver) SuspectedReason() (string, error) {
 
 func (r *externalServiceResolver) ImplementationNote() string {
 	return "not implemented"
+}
+
+func (r *externalServiceResolver) SupportsRepoExclusion() bool {
+	return supportsRepoExclusion[r.externalService.Kind]
 }
 
 type externalServiceSyncJobConnectionResolver struct {

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -307,7 +307,7 @@ type computedExternalServiceConnectionResolver struct {
 	db               database.DB
 }
 
-func (r *computedExternalServiceConnectionResolver) Nodes(ctx context.Context) []*externalServiceResolver {
+func (r *computedExternalServiceConnectionResolver) Nodes(_ context.Context) []*externalServiceResolver {
 	svcs := r.externalServices
 	if r.args.First != nil && int(*r.args.First) < len(svcs) {
 		svcs = svcs[:*r.args.First]
@@ -319,11 +319,11 @@ func (r *computedExternalServiceConnectionResolver) Nodes(ctx context.Context) [
 	return resolvers
 }
 
-func (r *computedExternalServiceConnectionResolver) TotalCount(ctx context.Context) int32 {
+func (r *computedExternalServiceConnectionResolver) TotalCount(_ context.Context) int32 {
 	return int32(len(r.externalServices))
 }
 
-func (r *computedExternalServiceConnectionResolver) PageInfo(ctx context.Context) *graphqlutil.PageInfo {
+func (r *computedExternalServiceConnectionResolver) PageInfo(_ context.Context) *graphqlutil.PageInfo {
 	return graphqlutil.HasNextPage(r.args.First != nil && len(r.externalServices) >= int(*r.args.First))
 }
 
@@ -333,7 +333,6 @@ const (
 	Add ExternalServiceMutationType = iota
 	Update
 	Delete
-	SetRepos
 )
 
 func (d ExternalServiceMutationType) String() string {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2833,6 +2833,11 @@ type ExternalService implements Node {
     If this is false, then checkConnection responds with ExternalServiceAvailabilityUnknown.
     """
     hasConnectionCheck: Boolean!
+
+    """
+    True if this external service configuration supports `exclude` parameter.
+    """
+    supportsRepoExclusion: Boolean!
 }
 
 """


### PR DESCRIPTION
Test plan:
Unit tests added.

Part of https://github.com/sourcegraph/sourcegraph/issues/40504