### PR TITLE
Add a build.sh file for enterprise gitserver

### DIFF
--- a/enterprise/cmd/gitserver/Dockerfile
+++ b/enterprise/cmd/gitserver/Dockerfile
@@ -1,0 +1,70 @@
+# This Dockerfile was generated from github.com/sourcegraph/godockerize. It
+# was not written by a human, and as such looks janky. As you change this
+# file, please don't be scared to make it more pleasant / remove hadolint
+# ignores.
+
+# Install p4 CLI (keep this up to date with cmd/server/Dockerfile)
+FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5 AS p4cli
+
+# hadolint ignore=DL3003
+RUN wget http://cdist2.perforce.com/perforce/r21.2/bin.linux26x86_64/p4 && \
+    mv p4 /usr/local/bin/p4 && \
+    chmod +x /usr/local/bin/p4
+
+FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5 AS p4-fusion
+
+COPY p4-fusion-install-alpine.sh /p4-fusion-install-alpine.sh
+RUN /p4-fusion-install-alpine.sh
+
+FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5 AS coursier
+
+# TODO(code-intel): replace with official streams when musl builds are upstreamed
+RUN wget -O coursier.zip https://github.com/sourcegraph/lsif-java/releases/download/v0.5.6/cs-musl.zip && \
+    unzip coursier.zip && \
+    mv cs-musl /usr/local/bin/coursier && \
+    chmod +x /usr/local/bin/coursier
+
+
+FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5
+
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
+
+RUN apk add --no-cache \
+    # We require git 2.38+ because we need a fix for this vulnerability to be included:
+    # https://github.blog/2022-04-12-git-security-vulnerability-announced/
+    'git>=2.38.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main  \
+    git-lfs \
+    git-p4 \
+    && apk add --no-cache  \
+    openssh-client \
+    # We require libstdc++ for p4-fusion
+    libstdc++ \
+    python2 \
+    python3 \
+    bash
+
+COPY --from=p4cli /usr/local/bin/p4 /usr/local/bin/p4
+
+COPY --from=p4-fusion /usr/local/bin/p4-fusion /usr/local/bin/p4-fusion
+
+COPY --from=coursier /usr/local/bin/coursier /usr/local/bin/coursier
+
+# This is a trick to include libraries required by p4,
+# please refer to https://blog.tilander.org/docker-perforce/
+# hadolint ignore=DL4006
+RUN wget -O - https://github.com/jtilander/p4d/raw/4600d741720f85d77852dcca7c182e96ad613358/lib/lib-x64.tgz | tar zx --directory /
+
+RUN mkdir -p /data/repos && chown -R sourcegraph:sourcegraph /data/repos
+USER sourcegraph
+
+WORKDIR /
+
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/gitserver"]
+COPY gitserver /usr/local/bin/

--- a/enterprise/cmd/gitserver/build.sh
+++ b/enterprise/cmd/gitserver/build.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# We want to build multiple go binaries, so we use a custom build step on CI.
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+set -ex
+
+OUTPUT=$(mktemp -d -t sgdockerbuild_XXXXXXX)
+
+cleanup() {
+  rm -rf "$OUTPUT"
+}
+
+trap cleanup EXIT
+
+cp -a ./cmd/gitserver/p4-fusion-install-alpine.sh "$OUTPUT"
+
+# Environment for building linux binaries
+export GO111MODULE=on
+export GOARCH=amd64
+export GOOS=linux
+export CGO_ENABLED=0
+
+pkg="github.com/sourcegraph/sourcegraph/enterprise/cmd/gitserver"
+go build -trimpath -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION  -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" -buildmode exe -tags dist -o "$OUTPUT/$(basename $pkg)" "$pkg"
+
+docker build -f enterprise/cmd/gitserver/Dockerfile -t "$IMAGE" "$OUTPUT" \
+  --progress=plain \
+  --build-arg COMMIT_SHA \
+  --build-arg DATE \
+  --build-arg VERSION

--- a/enterprise/cmd/gitserver/p4-fusion-install-alpine.sh
+++ b/enterprise/cmd/gitserver/p4-fusion-install-alpine.sh
@@ -1,0 +1,116 @@
+#!/bin/sh
+
+# This script installs p4-fusion within an alpine container.
+
+set -eu
+
+tmpdir=$(mktemp -d)
+cd "$tmpdir"
+
+cleanup() {
+  echo "--- cleanup"
+  apk --no-cache --purge del p4-build-deps 2>/dev/null || true
+  cd /
+  rm -rf "$tmpdir" || true
+}
+
+trap cleanup EXIT
+
+test_p4_fusion() {
+  # Test that p4-fusion runs and is on the path
+  echo "--- p4-fusion test"
+  ldd "$(which p4-fusion)"
+  p4-fusion >/dev/null
+}
+
+set -x
+
+# Hello future traveler. Building p4-fusion is one of our slowest steps in CI.
+# Luckily the versions very rarely change and nearly everything is statically
+# linked. This means we can manually upload the output of this build script to
+# a bucket and save lots of time.
+#
+# If the version has changed please add it to the sha256sum in the prebuilt
+# binary check. You can run
+#
+#   docker build -t p4-fusion --target=p4-fusion .
+#
+# Then extract the binary from /usr/local/bin/p4-fusion. Please rename it
+# follow the format and upload to the bucket here
+# https://console.cloud.google.com/storage/browser/sourcegraph-artifacts/p4-fusion
+export P4_FUSION_VERSION=v1.12
+
+# Runtime dependencies
+echo "--- p4-fusion apk runtime-deps"
+apk add --no-cache libstdc++
+
+# Check if we have a prebuilt binary
+echo "--- p4-fusion prebuilt binary check"
+if wget https://storage.googleapis.com/sourcegraph-artifacts/p4-fusion/p4-fusion-"$P4_FUSION_VERSION"-musl-x86_64; then
+  src=p4-fusion-"$P4_FUSION_VERSION"-musl-x86_64
+  cat <<EOF | grep "$src" | sha256sum -c
+1b29ef8ba40f88219aece4339bfaf1b2c1722dd4875ba29d19a6fb0c86e12145  p4-fusion-v1.12-musl-x86_64
+EOF
+  chmod +x "$src"
+  mv "$src" /usr/local/bin/p4-fusion
+  test_p4_fusion
+  exit 0
+fi
+
+# Build dependencies
+echo "--- p4-fusion apk build-deps"
+apk add --no-cache \
+  --virtual p4-build-deps \
+  wget \
+  g++ \
+  gcc \
+  perl \
+  bash \
+  cmake \
+  make
+
+# Fetching p4 sources archive
+echo "--- p4-fusion fetch"
+mkdir p4-fusion-src
+wget https://github.com/salesforce/p4-fusion/archive/refs/tags/"$P4_FUSION_VERSION".tar.gz
+tar -C p4-fusion-src -xzf "$P4_FUSION_VERSION".tar.gz --strip 1
+
+# It should be possible to build against the latest 1.x version of OpenSSL.
+# However, Perforce recommends linking against the same minor version of
+# OpenSSL that is referenced in the Helix Core C++ API for best compatibility.
+# https://www.perforce.com/manuals/p4api/Content/P4API/client.programming.compiling.html#SSL_support
+echo "--- p4-fusion openssl fetch"
+mkdir openssl-src
+wget https://www.openssl.org/source/openssl-1.0.2t.tar.gz
+tar -C openssl-src -xzf openssl-1.0.2t.tar.gz --strip 1
+
+echo "--- p4-fusion openssl build"
+cd openssl-src
+./config
+# We only need libcrypto and libssl, which "build_libs" covers. Note: using
+# unbounded concurrency caused flakes on CI.
+make build_libs
+
+echo "--- p4-fusion openssl install"
+# TODO "install" includes "all". Can we avoid extra work?
+make install
+cd ..
+
+# We also need Helix Core C++ API to build p4-fusion
+echo "--- p4-fusion helix-core fetch"
+mkdir -p p4-fusion-src/vendor/helix-core-api/linux
+wget https://www.perforce.com/downloads/perforce/r22.1/bin.linux26x86_64/p4api.tgz
+tar -C p4-fusion-src/vendor/helix-core-api/linux -xzf p4api.tgz --strip 1
+
+# Build p4-fusion
+echo "--- p4-fusion build"
+cd p4-fusion-src
+./generate_cache.sh RelWithDebInfo
+./build.sh
+cd ..
+
+# Move exe file to /usr/local/bin where other executables are located
+echo "--- p4-fusion install"
+mv p4-fusion-src/build/p4-fusion/p4-fusion /usr/local/bin
+
+test_p4_fusion


### PR DESCRIPTION
Adds a `build.sh` for enterprise gitserver

## Test plan

🤞 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
