### PR TITLE
Add enterprise gitserver image to server/build.sh

### DIFF
--- a/enterprise/cmd/server/build.sh
+++ b/enterprise/cmd/server/build.sh
@@ -8,6 +8,7 @@ export SERVER_PKG=${SERVER_PKG:-github.com/sourcegraph/sourcegraph/enterprise/cm
 
 ./cmd/server/build.sh \
   github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend \
+  github.com/sourcegraph/sourcegraph/enterprise/cmd/gitserver \
   github.com/sourcegraph/sourcegraph/enterprise/cmd/worker \
   github.com/sourcegraph/sourcegraph/enterprise/cmd/migrator \
   github.com/sourcegraph/sourcegraph/enterprise/cmd/repo-updater \


### PR DESCRIPTION
Updates the enterprise server build image to include the enterprise gitserver image.

## Test plan

Integration test should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
