### PR TITLE
graphqlbackend: add `excludeRepoFromExternalService` query.

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -66,15 +66,6 @@ var availabilityCheck = map[string]bool{
 	extsvc.KindBitbucketCloud:  true,
 }
 
-var supportsRepoExclusion = map[string]bool{
-	extsvc.KindAWSCodeCommit:   true,
-	extsvc.KindBitbucketCloud:  true,
-	extsvc.KindBitbucketServer: true,
-	extsvc.KindGitHub:          true,
-	extsvc.KindGitLab:          true,
-	extsvc.KindGitolite:        true,
-}
-
 func externalServiceByID(ctx context.Context, db database.DB, gqlID graphql.ID) (*externalServiceResolver, error) {
 	// 🚨 SECURITY: check whether user is site-admin
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, db); err != nil {
@@ -302,7 +293,7 @@ func (r *externalServiceResolver) ImplementationNote() string {
 }
 
 func (r *externalServiceResolver) SupportsRepoExclusion() bool {
-	return supportsRepoExclusion[r.externalService.Kind]
+	return r.externalService.SupportsRepoExclusion()
 }
 
 type externalServiceSyncJobConnectionResolver struct {

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sourcegraph/sourcegraph/schema"
 
 	"github.com/sourcegraph/log"
 
@@ -157,6 +159,125 @@ func (r *schemaResolver) UpdateExternalService(ctx context.Context, args *update
 	}
 
 	return res, nil
+}
+
+type excludeRepoFromExternalServiceArgs struct {
+	ExternalService graphql.ID
+	Repo            graphql.ID
+}
+
+// ExcludeRepoFromExternalService excludes given repo from given external service config.
+//
+// Function is pretty beefy, what it does is:
+// - checks whether current user is site-admin and returns if not
+// - finds an external service by ID and checks if it supports repo exclusion
+// - adds repo to `exclude` config parameter and updates an external service
+// - triggers external service sync
+//
+// Note: Failing to trigger an external service sync doesn't fail the whole update.
+func (r *schemaResolver) ExcludeRepoFromExternalService(ctx context.Context, args *excludeRepoFromExternalServiceArgs) (*EmptyResponse, error) {
+	// 🚨 SECURITY: check whether user is site-admin
+	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return nil, err
+	}
+	extSvcID, err := UnmarshalExternalServiceID(args.ExternalService)
+	if err != nil {
+		return nil, err
+	}
+
+	repositoryID, err := UnmarshalRepositoryID(args.Repo)
+	if err != nil {
+		return nil, err
+	}
+
+	externalServices := r.db.ExternalServices()
+	externalService, err := externalServices.GetByID(ctx, extSvcID)
+	if err != nil {
+		return nil, err
+	}
+
+	// If external service doesn't support repo exclusion, then return.
+	if !externalService.SupportsRepoExclusion() {
+		return &EmptyResponse{}, nil
+	}
+
+	repository, err := r.db.Repos().Get(ctx, repositoryID)
+	if err != nil {
+		return nil, err
+	}
+
+	updatedConfig, err := addRepoToExclusion(ctx, externalService, repository)
+	if err != nil {
+		return nil, err
+	}
+
+	err = externalServices.Update(ctx, conf.Get().AuthProviders, extSvcID, &database.ExternalServiceUpdate{Config: &updatedConfig})
+	if err != nil {
+		return nil, err
+	}
+
+	// Error during triggering a sync is omitted, because this should not prevent
+	// from excluding the repo. The repo stays excluded and the sync will come
+	// eventually.
+	_, _ = r.SyncExternalService(ctx, &syncExternalServiceArgs{ID: args.ExternalService})
+	return &EmptyResponse{}, nil
+}
+
+func addRepoToExclusion(ctx context.Context, externalService *types.ExternalService, repository *types.Repo) (string, error) {
+	config, err := externalService.Configuration(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	switch c := config.(type) {
+	case *schema.AWSCodeCommitConnection:
+		exclusion := &schema.ExcludedAWSCodeCommitRepo{Id: strconv.FormatInt(int64(repository.ID), 10), Name: string(repository.Name)}
+		if !schemaContainsExclusion(c.Exclude, exclusion) {
+			c.Exclude = append(c.Exclude, &schema.ExcludedAWSCodeCommitRepo{Id: strconv.FormatInt(int64(repository.ID), 10), Name: string(repository.Name)})
+		}
+	case *schema.BitbucketCloudConnection:
+		exclusion := &schema.ExcludedBitbucketCloudRepo{Name: string(repository.Name)}
+		if !schemaContainsExclusion(c.Exclude, exclusion) {
+			c.Exclude = append(c.Exclude, &schema.ExcludedBitbucketCloudRepo{Name: string(repository.Name)})
+		}
+	case *schema.BitbucketServerConnection:
+		exclusion := &schema.ExcludedBitbucketServerRepo{Id: int(repository.ID), Name: string(repository.Name)}
+		if !schemaContainsExclusion(c.Exclude, exclusion) {
+			c.Exclude = append(c.Exclude, &schema.ExcludedBitbucketServerRepo{Id: int(repository.ID), Name: string(repository.Name)})
+		}
+	case *schema.GitHubConnection:
+		exclusion := &schema.ExcludedGitHubRepo{Id: strconv.FormatInt(int64(repository.ID), 10), Name: string(repository.Name)}
+		if !schemaContainsExclusion(c.Exclude, exclusion) {
+			c.Exclude = append(c.Exclude, &schema.ExcludedGitHubRepo{Id: strconv.FormatInt(int64(repository.ID), 10), Name: string(repository.Name)})
+		}
+	case *schema.GitLabConnection:
+		exclusion := &schema.ExcludedGitLabProject{Name: string(repository.Name)}
+		if !schemaContainsExclusion(c.Exclude, exclusion) {
+			c.Exclude = append(c.Exclude, &schema.ExcludedGitLabProject{Name: string(repository.Name)})
+		}
+	case *schema.GitoliteConnection:
+		exclusion := &schema.ExcludedGitoliteRepo{Name: string(repository.Name)}
+		if !schemaContainsExclusion(c.Exclude, exclusion) {
+			c.Exclude = append(c.Exclude, &schema.ExcludedGitoliteRepo{Name: string(repository.Name)})
+		}
+	default:
+		return "", err
+	}
+
+	strConfig, err := json.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+	return string(strConfig), nil
+}
+
+func schemaContainsExclusion[T comparable](exclusions []*T, newExclusion *T) bool {
+	for _, exclusion := range exclusions {
+		if *exclusion == *newExclusion {
+			return true
+		}
+	}
+	return false
 }
 
 type deleteExternalServiceArgs struct {
@@ -360,7 +481,13 @@ type syncExternalServiceArgs struct {
 	ID graphql.ID
 }
 
+// mockSyncExternalService mocks (*schemaResolver).SyncExternalService.
+var mockSyncExternalService func(context.Context, *syncExternalServiceArgs) (*EmptyResponse, error)
+
 func (r *schemaResolver) SyncExternalService(ctx context.Context, args *syncExternalServiceArgs) (*EmptyResponse, error) {
+	if mockSyncExternalService != nil {
+		return mockSyncExternalService(ctx, args)
+	}
 	start := time.Now()
 	var err error
 	defer reportExternalServiceDuration(start, Update, &err)

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/log/logtest"

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -127,13 +127,13 @@ type Mutation {
     """
     updateExternalService(input: UpdateExternalServiceInput!): ExternalService!
     """
-    Updates a external service. Only site admins may perform this mutation.
-    """
-    excludeRepoFromExternalService(externalService: ID!, repo: ID!): EmptyResponse!
-    """
     Delete an external service. Only site admins may perform this mutation.
     """
     deleteExternalService(externalService: ID!, async: Boolean = false): EmptyResponse!
+    """
+    Excludes a repo from external service config. Only site admins may perform this mutation.
+    """
+    excludeRepoFromExternalService(externalService: ID!, repo: ID!): EmptyResponse!
     """
     Tests the connection to a mirror repository's original source repository. This is an
     expensive and slow operation, so it should only be used for interactive diagnostics.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -127,6 +127,10 @@ type Mutation {
     """
     updateExternalService(input: UpdateExternalServiceInput!): ExternalService!
     """
+    Updates a external service. Only site admins may perform this mutation.
+    """
+    excludeRepoFromExternalService(externalService: ID!, repo: ID!): EmptyResponse!
+    """
     Delete an external service. Only site admins may perform this mutation.
     """
     deleteExternalService(externalService: ID!, async: Boolean = false): EmptyResponse!

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -374,6 +374,21 @@ func ParseServiceKind(s string) (string, bool) {
 	}
 }
 
+var supportsRepoExclusion = map[string]bool{
+	KindAWSCodeCommit:   true,
+	KindBitbucketCloud:  true,
+	KindBitbucketServer: true,
+	KindGitHub:          true,
+	KindGitLab:          true,
+	KindGitolite:        true,
+}
+
+// SupportsRepoExclusion returns true when given external service kind supports
+// repo exclusion.
+func SupportsRepoExclusion(extSvcKind string) bool {
+	return supportsRepoExclusion[extSvcKind]
+}
+
 // AccountID is a descriptive type for the external identifier of an external account on the
 // code host. It can be the string representation of an integer (e.g. GitLab), a GraphQL ID
 // (e.g. GitHub), or a username (e.g. Bitbucket Server) depends on the code host type.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -687,6 +687,12 @@ func (e *ExternalService) With(opts ...func(*ExternalService)) *ExternalService 
 	return clone
 }
 
+// SupportsRepoExclusion returns true when given external service supports repo
+// exclusion.
+func (e *ExternalService) SupportsRepoExclusion() bool {
+	return extsvc.SupportsRepoExclusion(e.Kind)
+}
+
 // ExternalServices is a utility type with convenience methods for operating on
 // lists of ExternalServices.
 type ExternalServices []*ExternalService


### PR DESCRIPTION
Test plan:
Unit tests added.

Part of https://github.com/sourcegraph/sourcegraph/issues/40504