### PR TITLE
Expose corruptedAt and CorruptionLog on Graphql API

### DIFF
--- a/client/web/src/repo/settings/backend.ts
+++ b/client/web/src/repo/settings/backend.ts
@@ -31,6 +31,11 @@ export const settingsAreaRepositoryFragment = gql`
             cloneProgress
             cloned
             updatedAt
+            corruptedAt
+            corruptionLogs {
+                timestamp
+                reason
+            }
             lastError
             updateSchedule {
                 due

--- a/client/web/src/repo/settings/backend.ts
+++ b/client/web/src/repo/settings/backend.ts
@@ -31,7 +31,7 @@ export const settingsAreaRepositoryFragment = gql`
             cloneProgress
             cloned
             updatedAt
-            corruptedAt
+            isCorrupted
             corruptionLogs {
                 timestamp
                 reason

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -121,6 +121,8 @@ const mirrorRepositoryInfoFieldsFragment = gql`
         cloned
         cloneInProgress
         updatedAt
+        corruptedAt
+        corruptionLog
         lastError
         byteSize
         shard

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -122,7 +122,9 @@ const mirrorRepositoryInfoFieldsFragment = gql`
         cloneInProgress
         updatedAt
         corruptedAt
-        corruptionLog
+        corruptionLogs {
+            timestamp
+        }
         lastError
         byteSize
         shard

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -121,7 +121,7 @@ const mirrorRepositoryInfoFieldsFragment = gql`
         cloned
         cloneInProgress
         updatedAt
-        corruptedAt
+        isCorrupted
         corruptionLogs {
             timestamp
         }

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -172,13 +172,30 @@ func (r *repositoryMirrorInfoResolver) CorruptedAt(ctx context.Context) (*gqluti
 	return &gqlutil.DateTime{Time: info.CorruptedAt}, nil
 }
 
-func (r *repositoryMirrorInfoResolver) CorruptionLog(ctx context.Context) ([]types.RepoCorruptionLog, error) {
+func (r *repositoryMirrorInfoResolver) CorruptionLogs(ctx context.Context) ([]*corruptionLogResolver, error) {
 	info, err := r.computeGitserverRepo(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return info.CorruptionLog, nil
+	logs := make([]*corruptionLogResolver, 0, len(info.CorruptionLogs))
+	for _, l := range info.CorruptionLogs {
+		logs = append(logs, &corruptionLogResolver{log: l})
+	}
+
+	return logs, nil
+}
+
+type corruptionLogResolver struct {
+	log types.RepoCorruptionLog
+}
+
+func (r *corruptionLogResolver) Timestamp() (*gqlutil.DateTime, error) {
+	return &gqlutil.DateTime{Time: r.log.Timestamp}, nil
+}
+
+func (r *corruptionLogResolver) Reason() (*string, error) {
+	return &r.log.Reason, nil
 }
 
 func (r *repositoryMirrorInfoResolver) ByteSize(ctx context.Context) (BigInt, error) {

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -160,6 +160,27 @@ func (r *repositoryMirrorInfoResolver) UpdatedAt(ctx context.Context) (*gqlutil.
 	return &gqlutil.DateTime{Time: info.LastFetched}, nil
 }
 
+func (r *repositoryMirrorInfoResolver) CorruptedAt(ctx context.Context) (*gqlutil.DateTime, error) {
+	info, err := r.computeGitserverRepo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if info.CorruptedAt.IsZero() {
+		return nil, err
+	}
+	return &gqlutil.DateTime{Time: info.CorruptedAt}, nil
+}
+
+func (r *repositoryMirrorInfoResolver) CorruptionLog(ctx context.Context) ([]types.RepoCorruptionLog, error) {
+	info, err := r.computeGitserverRepo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return info.CorruptionLog, nil
+}
+
 func (r *repositoryMirrorInfoResolver) ByteSize(ctx context.Context) (BigInt, error) {
 	info, err := r.computeGitserverRepo(ctx)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -160,16 +160,16 @@ func (r *repositoryMirrorInfoResolver) UpdatedAt(ctx context.Context) (*gqlutil.
 	return &gqlutil.DateTime{Time: info.LastFetched}, nil
 }
 
-func (r *repositoryMirrorInfoResolver) CorruptedAt(ctx context.Context) (*gqlutil.DateTime, error) {
+func (r *repositoryMirrorInfoResolver) IsCorrupted(ctx context.Context) (bool, error) {
 	info, err := r.computeGitserverRepo(ctx)
 	if err != nil {
-		return nil, err
+		return false, err
 	}
 
 	if info.CorruptedAt.IsZero() {
-		return nil, err
+		return false, err
 	}
-	return &gqlutil.DateTime{Time: info.CorruptedAt}, nil
+	return true, nil
 }
 
 func (r *repositoryMirrorInfoResolver) CorruptionLogs(ctx context.Context) ([]*corruptionLogResolver, error) {
@@ -190,12 +190,12 @@ type corruptionLogResolver struct {
 	log types.RepoCorruptionLog
 }
 
-func (r *corruptionLogResolver) Timestamp() (*gqlutil.DateTime, error) {
-	return &gqlutil.DateTime{Time: r.log.Timestamp}, nil
+func (r *corruptionLogResolver) Timestamp() (gqlutil.DateTime, error) {
+	return gqlutil.DateTime{Time: r.log.Timestamp}, nil
 }
 
-func (r *corruptionLogResolver) Reason() (*string, error) {
-	return &r.log.Reason, nil
+func (r *corruptionLogResolver) Reason() (string, error) {
+	return r.log.Reason, nil
 }
 
 func (r *repositoryMirrorInfoResolver) ByteSize(ctx context.Context) (BigInt, error) {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3428,7 +3428,7 @@ type MirrorRepositoryInfo {
     """
     cloned: Boolean!
     """
-    When the repositor was detected to be corrupt
+    When the repository was detected to be corrupt. If this is null, it's not corrupt.
     """
     corruptedAt: DateTime
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3428,9 +3428,9 @@ type MirrorRepositoryInfo {
     """
     cloned: Boolean!
     """
-    When the repository was detected to be corrupt. If this is null, it's not corrupt.
+    Whether the repository is currently corrupt.
     """
-    corruptedAt: DateTime
+    isCorrupted: Boolean!
     """
     A Log of the corruption events that have been detected on this repository. Only 10 events are kept and the events
     are ordered from most recent to least.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3435,7 +3435,7 @@ type MirrorRepositoryInfo {
     A Log of the corruption events that have been detected on this repository. Only 10 events are kept and the events
     are ordered from most recent to least.
     """
-    corruptionLogs: [RepoCorruptionLog]!
+    corruptionLogs: [RepoCorruptionLog!]!
     """
     When the repository was last successfully updated from the remote source repository..
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3471,11 +3471,11 @@ type RepoCorruptionLog {
     """
     The time at which the repository was detected to be corrupt
     """
-    timestamp: DateTime
+    timestamp: DateTime!
     """
     The reason why this repository was regarded as corrupt
     """
-    reason: String
+    reason: String!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3428,6 +3428,15 @@ type MirrorRepositoryInfo {
     """
     cloned: Boolean!
     """
+    When the repositor was detected to be corrupt
+    """
+    corruptedAt: DateTime
+    """
+    A Log of the corruption events that have been detected on this repository. Only 10 events are kept and the events
+    are ordered from most recent to least.
+    """
+    corruptionLogs: [RepoCorruptionLog]!
+    """
     When the repository was last successfully updated from the remote source repository..
     """
     updatedAt: DateTime
@@ -3452,6 +3461,21 @@ type MirrorRepositoryInfo {
     Only site admins can access this field.
     """
     shard: String
+}
+
+"""
+A corruption log entry that that records the time of when corruption was detected and a reason why the repo is regarded
+as corrupt
+"""
+type RepoCorruptionLog {
+    """
+    The time at which the repository was detected to be corrupt
+    """
+    timestamp: DateTime
+    """
+    The reason why this repository was regarded as corrupt
+    """
+    reason: String
 }
 
 """

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -4,7 +4,6 @@ package types
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"sort"
@@ -572,12 +571,6 @@ type RepoCorruptionLog struct {
 	Timestamp time.Time `json:"time"`
 	// Why the repo is considered to be corrupt. Can be git output stderr output or a short reason like "missing head"
 	Reason string `json:"reason"`
-}
-
-func UnmarshalCorruptionLog(data []byte) ([]RepoCorruptionLog, error) {
-	var logs []RepoCorruptionLog
-	err := json.Unmarshal(data, &logs)
-	return logs, err
 }
 
 // ExternalService is a connection to an external service.


### PR DESCRIPTION
Add corruptedAt and corruptionLogs to MirrorInfo so that when
repositories are queried these fields are also fetched

## Test plan
CI + unit tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
