### PR TITLE
improve cacheability of tree commits list

### DIFF
--- a/client/web/src/repo/tree/commits/TreeCommits.tsx
+++ b/client/web/src/repo/tree/commits/TreeCommits.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState, useEffect, useMemo, useRef } from 'react'
 
 import classNames from 'classnames'
 import formatISO from 'date-fns/formatISO'
+import startOfDay from 'date-fns/startOfDay'
 import subYears from 'date-fns/subYears'
 
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
@@ -41,7 +42,10 @@ const DEFAULT_FIRST = 10
  */
 export const TreeCommits: React.FunctionComponent<Props> = ({ repo, commitID, filePath, className }) => {
     const [showOlderCommits, setShowOlderCommits] = useState(false)
-    const after = useMemo(() => (showOlderCommits ? null : formatISO(subYears(Date.now(), 1))), [showOlderCommits])
+    const after = useMemo(
+        () => (showOlderCommits ? null : formatISO(startOfDay(subYears(Date.now(), 1)))),
+        [showOlderCommits]
+    )
 
     const { connection, error, loading, hasNextPage, fetchMore, refetchAll } = useShowMorePagination<
         TreeCommitsResult,
@@ -100,7 +104,7 @@ export const TreeCommits: React.FunctionComponent<Props> = ({ repo, commitID, fi
             return node.commit.ancestors
         },
         options: {
-            fetchPolicy: 'cache-first',
+            fetchPolicy: 'cache-and-network',
             useAlternateAfterCursor: true,
         },
     })


### PR DESCRIPTION
The commits fetch cache hit rate on the tree page (TreeCommits) was extremely low because it would only be valid for 1 second (due to the `after` date, which is part of the cache key, changing every second).

- Start of day means the cache key does not change every second
- cache-and-network means it fetches fresh data from the server in the background (instead of showing stale data for a whole day)




## Test plan

Visit the tree page and view the list of commits.

## App preview:

- [Web](https://sg-web-sqs-tree-commits-cacheability.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
