### PR TITLE
fix "React does not recognize the svgPath attribute on a DOM element" warning

### DIFF
--- a/client/wildcard/src/components/Icon/Icon.tsx
+++ b/client/wildcard/src/components/Icon/Icon.tsx
@@ -58,7 +58,10 @@ export type IconProps = HiddenIconProps | ScreenReaderIconProps
  */
 // eslint-disable-next-line react/display-name
 export const Icon = React.memo(
-    React.forwardRef(function Icon({ children, className, size, role = 'img', inline = true, ...props }, reference) {
+    React.forwardRef(function Icon(
+        { children, className, size, role = 'img', inline = true, svgPath, ...props },
+        reference
+    ) {
         const iconStyle = classNames(
             'mdi-icon',
             inline && styles.iconInline,
@@ -66,15 +69,8 @@ export const Icon = React.memo(
             className
         )
 
-        if (props.svgPath) {
-            const {
-                svgPath,
-                height = 24,
-                width = 24,
-                viewBox = '0 0 24 24',
-                fill = 'currentColor',
-                ...attributes
-            } = props
+        if (svgPath) {
+            const { height = 24, width = 24, viewBox = '0 0 24 24', fill = 'currentColor', ...attributes } = props
 
             return (
                 <svg


### PR DESCRIPTION
This occurs in dev mode when a non-standard icon is used. The `svgPath` DOM attribute *value* is undefined, but it is still set, thus the warning. This does not actually cause any problems, but it's annoying in the browser devtools console.




## Test plan

n/a; dev only

## App preview:

- [Web](https://sg-web-sqs-fix-svgpath-react-warning.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
