### PR TITLE
use minimal lodash imports to avoid bringing in duplicates

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarSymbols.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarSymbols.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo } from 'react'
 
 import classNames from 'classnames'
 import * as H from 'history'
-import { entries, escapeRegExp, flatMap, flow, groupBy, isEqual } from 'lodash/fp'
+import { escapeRegExp, isEqual, groupBy } from 'lodash'
 import { NavLink, useLocation } from 'react-router-dom'
 
 import { logger } from '@sourcegraph/common'
@@ -195,13 +195,11 @@ export const RepoRevisionSidebarSymbols: React.FunctionComponent<
         )
     }
 
-    const heirarchicalSymbols = useMemo(
+    const hierarchicalSymbols = useMemo<SymbolWithChildren[]>(
         () =>
-            flow(
-                groupBy<SymbolNodeFields>(symbol => symbol.location.resource.path),
-                entries,
-                flatMap(([, symbols]) => hierarchyOf(symbols))
-            )(connection?.nodes ?? []),
+            Object.values(groupBy(connection?.nodes ?? [], symbol => symbol.location.resource.path)).flatMap(symbols =>
+                hierarchyOf(symbols)
+            ),
         [connection?.nodes]
     )
 
@@ -226,7 +224,7 @@ export const RepoRevisionSidebarSymbols: React.FunctionComponent<
             )}
             {connection && (
                 <HierarchicalSymbols
-                    symbols={heirarchicalSymbols}
+                    symbols={hierarchicalSymbols}
                     render={args => (
                         <SymbolNode
                             node={args.symbol}


### PR DESCRIPTION
This makes tree-shaking more effective (~25kb saved in a rough experiment).

Also removes usage of a non-standard `flow` pattern and fixes a typo.




## Test plan

Automated tests will catch any issues.