### PR TITLE
Set max FilterControl width

### DIFF
--- a/client/web/src/components/FilteredConnection/FilterControl.module.scss
+++ b/client/web/src/components/FilteredConnection/FilterControl.module.scss
@@ -3,4 +3,5 @@
     align-items: center;
     flex-wrap: wrap;
     gap: 1rem;
+    max-width: 60%;
 }

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -314,7 +314,7 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
             })
         }
 
-        const filtersWithExternalServices = FILTERS
+        const filtersWithExternalServices = FILTERS.slice() // use slice to copy array
         filtersWithExternalServices.push({
             id: 'codeHost',
             label: 'Code Host',


### PR DESCRIPTION
Sets the maximum width of FilterControls to 60%, otherwise it can overflow and squish the search bar, like this:

![image](https://user-images.githubusercontent.com/6427795/209948905-e4d55eb2-64be-4d1a-8f93-43bcecaecfae.png)

Now it will maximally squish the search bar to 40%:

![image](https://user-images.githubusercontent.com/6427795/209948996-0e0ff665-2dcb-4aa0-8de7-e106a5ae35c3.png)

Also fixes a bug where the global FILTERS array is changed on every page load.

## Test plan

Manual tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-pjlast-fix-repository-search-box.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
