### PR TITLE
[Users Management] update sorting nulls last

### DIFF
--- a/internal/users/stats.go
+++ b/internal/users/stats.go
@@ -220,7 +220,7 @@ func (s *UsersStats) ListUsers(ctx context.Context, filters *UsersStatsListUsers
 	}
 
 	query := sqlf.Sprintf(statsCTEQuery, sqlf.Sprintf(`
-	SELECT id, username, display_name, primary_email, created_at, last_active_at, deleted_at, site_admin, events_count FROM aggregated_stats WHERE %s ORDER BY %s LIMIT %s OFFSET %s`, sqlf.Join(conds, "AND"), orderBy, limit, offset))
+	SELECT id, username, display_name, primary_email, created_at, last_active_at, deleted_at, site_admin, events_count FROM aggregated_stats WHERE %s ORDER BY %s NULLS LAST LIMIT %s OFFSET %s`, sqlf.Join(conds, "AND"), orderBy, limit, offset))
 
 	rows, err := s.DB.QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 


### PR DESCRIPTION
closes: https://github.com/sourcegraph/sourcegraph/issues/42708

This PR, by default, add a `NULLS LAST` order to all sort options.
## Test plan

<img width="971" alt="image" src="https://user-images.githubusercontent.com/22571395/209955320-bf0c6ffc-fd56-4d44-9de5-08802d84482c.png">


<img width="962" alt="image" src="https://user-images.githubusercontent.com/22571395/209955342-6817807c-9ea0-47fe-928b-f5d9fe2bdf0b.png">
