### PR TITLE
web: make `RepoSettingsOptionsPage` a functional component.

### DIFF
--- a/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -1,4 +1,8 @@
+import { FC, useEffect } from 'react'
+
 import { RouteComponentProps } from 'react-router'
+
+import { useQuery } from '@sourcegraph/http-client'
 import { Container, ErrorAlert, H2, LoadingSpinner, PageHeader, Text } from '@sourcegraph/wildcard'
 
 import { CopyableText } from '../../components/CopyableText'
@@ -13,8 +17,6 @@ import {
 import { eventLogger } from '../../tracking/eventLogger'
 
 import { FETCH_SETTINGS_AREA_REPOSITORY_GQL } from './backend'
-import { FC, useEffect } from 'react'
-import { useQuery } from '@sourcegraph/http-client'
 
 interface Props extends RouteComponentProps<{}> {
     repo: SettingsAreaRepositoryFields

--- a/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 import { RouteComponentProps } from 'react-router'
 import { Subject, Subscription } from 'rxjs'
 import { switchMap } from 'rxjs/operators'
@@ -15,90 +13,73 @@ import { SettingsAreaRepositoryFields } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
 
 import { fetchSettingsAreaRepository } from './backend'
+import { FC, useEffect, useState } from 'react'
 
 interface Props extends RouteComponentProps<{}> {
     repo: SettingsAreaRepositoryFields
 }
 
-interface State {
-    /**
-     * The repository object, refreshed after we make changes that modify it.
-     */
-    repo: SettingsAreaRepositoryFields
-
-    loading: boolean
-    error?: string
-}
-
 /**
  * The repository settings options page.
  */
-export class RepoSettingsOptionsPage extends React.PureComponent<Props, State> {
-    private repoUpdates = new Subject<void>()
-    private subscriptions = new Subscription()
+export const RepoSettingsOptionsPage: FC<Props> = ({ repo: propsRepo }) => {
+    const repoUpdates = new Subject<void>()
+    const subscriptions = new Subscription()
 
-    constructor(props: Props) {
-        super(props)
+    const [loading] = useState<boolean>(false)
+    const [repository, setRepository] = useState<SettingsAreaRepositoryFields>(propsRepo)
+    const [error, setError] = useState<string | undefined>(undefined)
 
-        this.state = {
-            loading: false,
-            repo: props.repo,
-        }
-    }
-
-    public componentDidMount(): void {
+    useEffect(() => {
         eventLogger.logViewEvent('RepoSettings')
-
-        this.subscriptions.add(
-            this.repoUpdates.pipe(switchMap(() => fetchSettingsAreaRepository(this.props.repo.name))).subscribe(
-                repo => this.setState({ repo }),
-                error => this.setState({ error: asError(error).message })
+        subscriptions.add(
+            repoUpdates.pipe(switchMap(() => fetchSettingsAreaRepository(propsRepo.name))).subscribe(
+                repoLocal => setRepository(repoLocal),
+                errorLocal => setError(asError(errorLocal).message)
             )
         )
-    }
+        return function cleanup() {
+            subscriptions.unsubscribe()
+        }
+    })
 
-    public componentWillUnmount(): void {
-        this.subscriptions.unsubscribe()
-    }
+    const services = repository.externalServices.nodes
 
-    public render(): JSX.Element | null {
-        const services = this.state.repo.externalServices.nodes
-        return (
-            <>
-                <PageTitle title="Repository settings" />
-                <PageHeader path={[{ text: 'Settings' }]} headingElement="h2" className="mb-3" />
-                <Container className="repo-settings-options-page">
-                    <H2 className="mb-3">Code hosts</H2>
-                    {this.state.loading && <LoadingSpinner />}
-                    {this.state.error && <ErrorAlert error={this.state.error} />}
-                    {services.length > 0 && (
-                        <div className="mb-3">
-                            {services.map(service => (
-                                <div className="mb-3" key={service.id}>
-                                    <ExternalServiceCard
-                                        {...defaultExternalServices[service.kind]}
-                                        kind={service.kind}
-                                        title={service.displayName}
-                                        shortDescription="Update this external service configuration to manage repository mirroring."
-                                        to={`/site-admin/external-services/${service.id}`}
-                                        toIcon={null}
-                                        bordered={false}
-                                    />
-                                </div>
-                            ))}
-                            {services.length > 1 && (
-                                <Text>
-                                    This repository is mirrored by multiple external services. To change access,
-                                    disable, or remove this repository, the configuration must be updated on all
-                                    external services.
-                                </Text>
-                            )}
-                        </div>
-                    )}
-                    <H2 className="mb-3">Repository name</H2>
-                    <CopyableText text={this.state.repo.name} size={this.state.repo.name.length} />
-                </Container>
-            </>
-        )
-    }
+    return (
+        <>
+            <PageTitle title="Repository settings" />
+            <PageHeader path={[{ text: 'Settings' }]} headingElement="h2" className="mb-3" />
+            <Container className="repo-settings-options-page">
+                <H2 className="mb-3">Code hosts</H2>
+                {loading && <LoadingSpinner />}
+                {error && <ErrorAlert error={error} />}
+                {services.length > 0 && (
+                    <div className="mb-3">
+                        {services.map(service => (
+                            <div className="mb-3" key={service.id}>
+                                <ExternalServiceCard
+                                    {...defaultExternalServices[service.kind]}
+                                    kind={service.kind}
+                                    title={service.displayName}
+                                    shortDescription="Update this external service configuration to manage repository mirroring."
+                                    to={`/site-admin/external-services/${service.id}`}
+                                    toIcon={null}
+                                    bordered={false}
+                                />
+                            </div>
+                        ))}
+                        {services.length > 1 && (
+                            <Text>
+                                This repository is mirrored by multiple external services. To change access,
+                                disable, or remove this repository, the configuration must be updated on all
+                                external services.
+                            </Text>
+                        )}
+                    </div>
+                )}
+                <H2 className="mb-3">Repository name</H2>
+                <CopyableText text={propsRepo.name} size={propsRepo.name.length} />
+            </Container>
+        </>
+    )
 }


### PR DESCRIPTION
### Main motivation
I need to add some buttons to [exclude repos from code hosts](https://github.com/sourcegraph/sourcegraph/issues/40504) and almost did it with all due struggle of not using hooks for many gql queries that I've added. In the end I gave up when I had to preserve individual state of each button (to add loading spinners to each of them) and decided to rewrite this component to be functional first and then go non-legacy way and use hooks all the way.

Test plan:
Local sg run and visual tests. Also tested that `componentDidMount`/`componentWillUnmount` is not called more than once with a change to `useEffect`.

Part of https://github.com/sourcegraph/sourcegraph/issues/40504

## App preview:

- [Web](https://sg-web-ao-ui-add-repo-settings-page-func.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
