### PR TITLE
Better Link in k8s https config

### DIFF
--- a/doc/admin/http_https_configuration.md
+++ b/doc/admin/http_https_configuration.md
@@ -42,7 +42,7 @@ docker container run \
 
 ### Sourcegraph Cluster (Kubernetes)
 
-We use the [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) for Sourcegraph Cluster running on Kubernetes. Refer to the [deploy-sourcegraph Configuration](deploy/kubernetes/configure.md) documentation for more information.
+We use the [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) for Sourcegraph Cluster running on Kubernetes. Refer to the [deploy-sourcegraph Configuration](deploy/kubernetes/configure.md#configure-network-access) documentation for more information.
 
 ### NGINX SSL/HTTPS configuration
 


### PR DESCRIPTION
This just jumps to the right heading as you nav through the docs -- this improves the readability of the hyperlinked docs

## Test plan
Doc

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
