### PR TITLE
internal/repos: Add ping like check to checkConnection

### DIFF
--- a/internal/repos/check_connection.go
+++ b/internal/repos/check_connection.go
@@ -101,9 +101,7 @@ func ping(rawURL string) error {
 	if err != nil {
 		switch protocol {
 		// Assume HTTP if URL has no protocol or port.
-		case "":
-			port = "80"
-		case "http":
+		case "", "http":
 			port = "80"
 		case "https":
 			port = "443"

--- a/internal/repos/check_connection.go
+++ b/internal/repos/check_connection.go
@@ -3,20 +3,16 @@ package repos
 import (
 	"net"
 	"net/url"
+	"strings"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// checkConnection parses the rawURL and makes a best effort attempt to obtain a hostname. It then
-// performs an IP lookup on that hostname and returns a non-nil error on failure.
-//
-// At the moment this function is only limited to doing IP lookups. We may want/have to expand this
-// to support other code hosts or to add more checks (for example making a test API call to verify
-// the authorization, etc).
-func checkConnection(rawURL string) error {
+func getHostname(rawURL string) (string, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return errors.Wrap(err, "invalid or bad url for connection check")
+		return "", errors.Wrap(err, "invalid or bad url for connection check")
 	}
 
 	// Best effort at finding a hostname. For example if rawURL is sourcegraph.com, then u.Host is
@@ -33,18 +29,82 @@ func checkConnection(rawURL string) error {
 			// rawURL is most likely something like "sourcegraph.com:80", read from u.Path.
 			hostname = u.Path
 		} else {
-			return errors.Newf("unsupported url format (%q) for connection check", rawURL)
+			return "", errors.Newf("unsupported url format (%q) for connection check", rawURL)
 		}
+	}
+
+	return hostname, nil
+}
+
+// checkConnection parses the rawURL and makes a best effort attempt to obtain a hostname. It then
+// performs an IP lookup on that hostname and returns a non-nil error on failure.
+//
+// At the moment this function is only limited to doing IP lookups. We may want/have to expand this
+// to support other code hosts or to add more checks (for example making a test API call to verify
+// the authorization, etc).
+func checkConnection(rawURL string) error {
+	if err := dnsLookup(rawURL); err != nil {
+		return errors.Wrap(err, "DNS lookup failed")
+	}
+
+	if err := ping(rawURL); err != nil {
+		return errors.Wrap(err, "ping failed")
+	}
+
+	return nil
+}
+
+func dnsLookup(rawURL string) error {
+	hostname, err := getHostname(rawURL)
+	if err != nil {
+		return errors.Wrap(err, "getHostname failed")
 	}
 
 	ips, err := net.LookupIP(hostname)
 	if err != nil {
-		return errors.Wrap(err, "connection check failed")
+		return err
 	}
 
 	if len(ips) == 0 {
-		return errors.Newf("connection check failed, no IP addresses found for hostname %q", hostname)
+		return errors.Newf("no IP addresses found for hostname %q", hostname)
 	}
 
 	return nil
+}
+
+// ping attempts to connect to the given rawURL. Technically it is not exactly a ping request in the
+// UNIX sense since it uses TCP instead of ICMP. But we use the name to signifiy the intent here,
+// which is to check if we can connect to the URL.
+func ping(rawURL string) error {
+	var address string
+
+	hostname, err := getHostname(rawURL)
+	if err != nil {
+		return errors.Wrap(err, "getHostname failed")
+	}
+
+	baseURL := rawURL
+	if strings.Contains(rawURL, "://") {
+		parts := strings.Split(rawURL, "://")
+		// Technically we can never have this condition because of the getHostname check above which
+		// should detect any malformed URLs. But if I've learnt anything out of implementing the
+		// methods in this file, is that URL parsing in itself is very brittle so I don't want to
+		// take any chances with a panic here.
+		if len(parts) < 2 {
+			return errors.Newf("potentially malformed URL: %q", rawURL)
+		}
+
+		baseURL = parts[1]
+	}
+
+	// Check if the URL includes a port.
+	_, port, err := net.SplitHostPort(baseURL)
+	if err != nil {
+		// If no port is set, default to 80.
+		port = "80"
+	}
+
+	address = net.JoinHostPort(hostname, port)
+	_, err = net.DialTimeout("tcp", address, time.Duration(time.Second))
+	return err
 }

--- a/internal/repos/check_connection.go
+++ b/internal/repos/check_connection.go
@@ -113,6 +113,6 @@ func ping(rawURL string) error {
 	}
 
 	address := net.JoinHostPort(hostname, port)
-	_, err = net.DialTimeout("tcp", address, time.Duration(2*time.Second))
+	_, err = net.DialTimeout("tcp", address, 2*time.Second)
 	return err
 }

--- a/internal/repos/check_connection_test.go
+++ b/internal/repos/check_connection_test.go
@@ -43,6 +43,18 @@ func TestDnsLookup(t *testing.T) {
 }
 
 func TestPing(t *testing.T) {
+	t.Run("bad URL", func(t *testing.T) {
+		if err := ping("foo"); err == nil {
+			t.Error("Expected error but got nil")
+		}
+	})
+
+	t.Run("bad URL with non HTTP protocol", func(t *testing.T) {
+		if err := ping("ftp://foo"); err == nil {
+			t.Error("Expected error but got nil")
+		}
+	})
+
 	t.Run("hostname and port", func(t *testing.T) {
 		if err := ping("sourcegraph.com:80"); err != nil {
 			t.Errorf("Expected nil but got error: %v", err)
@@ -55,13 +67,25 @@ func TestPing(t *testing.T) {
 		}
 	})
 
-	t.Run("protocol and hostname", func(t *testing.T) {
+	t.Run("HTTP hostname", func(t *testing.T) {
+		if err := ping("http://ghe.sgdev.org"); err != nil {
+			t.Errorf("Expected nil but got error: %v", err)
+		}
+	})
+
+	t.Run("HTTP hostname and port", func(t *testing.T) {
+		if err := ping("http://ghe.sgdev.org:80"); err != nil {
+			t.Errorf("Expected nil but got error: %v", err)
+		}
+	})
+
+	t.Run("HTTPS hostname", func(t *testing.T) {
 		if err := ping("https://ghe.sgdev.org"); err != nil {
 			t.Errorf("Expected nil but got error: %v", err)
 		}
 	})
 
-	t.Run("protocol, hostname and port", func(t *testing.T) {
+	t.Run("HTTPS hostname and port", func(t *testing.T) {
 		if err := ping("https://ghe.sgdev.org:443"); err != nil {
 			t.Errorf("Expected nil but got error: %v", err)
 		}

--- a/internal/repos/check_connection_test.go
+++ b/internal/repos/check_connection_test.go
@@ -1,40 +1,68 @@
 package repos
 
-import "testing"
+import (
+	"testing"
+)
 
-func TestCheckConnection(t *testing.T) {
+func TestDnsLookup(t *testing.T) {
 	t.Run("bad URL", func(t *testing.T) {
-		if err := checkConnection("foo"); err == nil {
+		if err := dnsLookup("foo"); err == nil {
 			t.Error("Expected error but got nil")
 		}
 	})
 
 	t.Run("good URL", func(t *testing.T) {
-		if err := checkConnection("https://sourcegraph.com"); err != nil {
+		if err := dnsLookup("https://sourcegraph.com"); err != nil {
 			t.Errorf("Expected nil but got error: %v", err)
 		}
 	})
 
 	t.Run("good URL with port", func(t *testing.T) {
-		if err := checkConnection("https://sourcegraph.com:80"); err != nil {
+		if err := dnsLookup("https://sourcegraph.com:80"); err != nil {
 			t.Errorf("Expected nil but got error: %v", err)
 		}
 	})
 
 	t.Run("good URL without protocol", func(t *testing.T) {
-		if err := checkConnection("sourcegraph.com"); err != nil {
+		if err := dnsLookup("sourcegraph.com"); err != nil {
 			t.Errorf("Expected nil but got error: %v", err)
 		}
 	})
 
 	t.Run("good URL with port but without protocol", func(t *testing.T) {
-		if err := checkConnection("sourcegraph.com:80"); err != nil {
+		if err := dnsLookup("sourcegraph.com:80"); err != nil {
 			t.Errorf("Expected nil but got error: %v", err)
 		}
 	})
 
 	t.Run("good URL with username:password", func(t *testing.T) {
-		if err := checkConnection("https://username:password@sourcegraph.com"); err != nil {
+		if err := dnsLookup("https://username:password@sourcegraph.com"); err != nil {
+			t.Errorf("Expected nil but got error: %v", err)
+		}
+	})
+}
+
+func TestPing(t *testing.T) {
+	t.Run("hostname and port", func(t *testing.T) {
+		if err := ping("sourcegraph.com:80"); err != nil {
+			t.Errorf("Expected nil but got error: %v", err)
+		}
+	})
+
+	t.Run("hostname without port", func(t *testing.T) {
+		if err := ping("ghe.sgdev.org"); err != nil {
+			t.Errorf("Expected nil but got error: %v", err)
+		}
+	})
+
+	t.Run("protocol and hostname", func(t *testing.T) {
+		if err := ping("https://ghe.sgdev.org"); err != nil {
+			t.Errorf("Expected nil but got error: %v", err)
+		}
+	})
+
+	t.Run("protocol, hostname and port", func(t *testing.T) {
+		if err := ping("https://ghe.sgdev.org:443"); err != nil {
 			t.Errorf("Expected nil but got error: %v", err)
 		}
 	})


### PR DESCRIPTION
Follow up to #45900. Part of #44683.

👉 The only part I'm not sure if is the necessarily the right thing to do is assume port 80 for URLs with no port for a Dial check.

## Test plan

- Added tests
- Build should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
