### PR TITLE
worker: add outbound webhook worker

### DIFF
--- a/cmd/worker/internal/outboundwebhooks/handler.go
+++ b/cmd/worker/internal/outboundwebhooks/handler.go
@@ -36,7 +36,7 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, job *types.Outb
 
 	webhooks, err := h.store.List(ctx, database.OutboundWebhookListOpts{
 		OutboundWebhookCountOpts: database.OutboundWebhookCountOpts{
-			ScopedEventTypes: []database.ScopedEventType{{
+			EventTypes: []database.FilterEventType{{
 				EventType: job.EventType,
 				Scope:     job.Scope,
 			}},

--- a/cmd/worker/internal/outboundwebhooks/handler.go
+++ b/cmd/worker/internal/outboundwebhooks/handler.go
@@ -1,0 +1,181 @@
+package outboundwebhooks
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/group"
+)
+
+type handler struct {
+	client   *http.Client
+	store    database.OutboundWebhookStore
+	logStore database.OutboundWebhookLogStore
+}
+
+var _ workerutil.Handler[*types.OutboundWebhookJob] = &handler{}
+
+func (h *handler) Handle(ctx context.Context, logger log.Logger, job *types.OutboundWebhookJob) error {
+	logger = logger.With(
+		log.Int64("job.id", job.ID),
+		log.String("job.event_type", job.EventType),
+		log.Stringp("job.scope", job.Scope),
+	)
+
+	webhooks, err := h.store.List(ctx, database.OutboundWebhookListOpts{
+		OutboundWebhookCountOpts: database.OutboundWebhookCountOpts{
+			ScopedEventTypes: []database.ScopedEventType{{
+				EventType: job.EventType,
+				Scope:     job.Scope,
+			}},
+		},
+	})
+	if err != nil {
+		logger.Error("error retrieving outbound webhooks", log.Error(err))
+		return errors.Wrap(err, "retrieving outbound webhooks")
+	}
+
+	// Since sending HTTP requests is (generally) cheap, and we've already done
+	// the relatively expensive parts of constructing the payload and retrieving
+	// the matching hooks, we're going to just fan these out with a high
+	// concurrency limit.
+	g := group.New().WithContext(ctx).WithMaxConcurrency(100)
+	for _, webhook := range webhooks {
+		g.Go(h.buildWebhookSender(
+			logger.With(log.Int64("webhook.id", webhook.ID)),
+			job, webhook,
+		))
+	}
+
+	// Errors will have been logged individually, so we can just return the
+	// error back out of the handler.
+	return g.Wait()
+}
+
+func (h *handler) buildWebhookSender(
+	logger log.Logger, job *types.OutboundWebhookJob,
+	webhook *types.OutboundWebhook,
+) func(context.Context) error {
+	return func(ctx context.Context) error {
+		return h.sendWebhook(ctx, logger, job, webhook)
+	}
+}
+
+func (h *handler) sendWebhook(
+	ctx context.Context, logger log.Logger,
+	job *types.OutboundWebhookJob, webhook *types.OutboundWebhook,
+) error {
+	logger.Debug("sending webhook payload")
+
+	// Set up an empty webhook log entry that we can build up over the course of
+	// execution.
+
+	url, err := webhook.URL.Decrypt(ctx)
+	if err != nil {
+		logger.Error("cannot decrypt webhook URL", log.Error(err))
+		return errors.Wrap(err, "decrypting webhook URL")
+	}
+
+	secret, err := webhook.Secret.Decrypt(ctx)
+	if err != nil {
+		logger.Error("cannot decrypt webhook secret", log.Error(err))
+		return errors.Wrap(err, "decrypting webhook secret")
+	}
+
+	payload, err := job.Payload.Decrypt(ctx)
+	if err != nil {
+		logger.Error("cannot decrypt payload", log.Error(err))
+		return errors.Wrap(err, "decrypting payload")
+	}
+
+	payloadReader := bytes.NewReader([]byte(payload))
+	sig, err := calculateSignature(secret, payloadReader)
+	if err != nil {
+		logger.Error("error signing payload", log.Error(err))
+		return errors.Wrap(err, "calculating payload signature")
+	}
+	payloadReader.Seek(0, io.SeekStart)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, payloadReader)
+	if err != nil {
+		logger.Error("cannot build webhook request", log.Error(err))
+		return errors.Wrap(err, "building request")
+	}
+
+	req.Header.Add("Content-Type", "application/json; charset=utf-8")
+	req.Header.Add("X-Sourcegraph-Webhook-Event-Type", job.EventType)
+	req.Header.Add("X-Sourcegraph-Webhook-Signature", sig)
+
+	// If we've reached here, then we're going to send the request, so let's set
+	// up the logging.
+	webhookLog := &types.OutboundWebhookLog{
+		JobID:             job.ID,
+		OutboundWebhookID: webhook.ID,
+		Request: types.NewUnencryptedWebhookLogMessage(types.WebhookLogMessage{
+			Header: req.Header,
+			Body:   []byte(payload),
+			Method: req.Method,
+			URL:    url,
+		}),
+		Response: types.NewUnencryptedWebhookLogMessage(types.WebhookLogMessage{}),
+		Error:    encryption.NewUnencrypted(""),
+	}
+	defer func() {
+		if err := h.logStore.Create(ctx, webhookLog); err != nil {
+			// We don't want to return an error from the overall send function
+			// if we can't write a log entry, so we'll log at a level that will
+			// hopefully gather some attention and then swallow the error.
+			logger.Warn("error writing outbound webhook log", log.Error(err))
+		}
+	}()
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		logger.Info("error sending webhook", log.Error(err))
+		webhookLog.Error = encryption.NewUnencrypted(err.Error())
+		return errors.Wrap(err, "sending webhook")
+	}
+	defer resp.Body.Close()
+	webhookLog.StatusCode = resp.StatusCode
+
+	response, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logger.Error("cannot read response body", log.Error(err))
+		return errors.Wrap(err, "reading response body")
+	}
+	webhookLog.Response = types.NewUnencryptedWebhookLogMessage(types.WebhookLogMessage{
+		Header: resp.Header,
+		Body:   response,
+		Method: req.Method,
+		URL:    url,
+	})
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		logger.Info("got unexpected status code from webhook", log.Int("status_code", resp.StatusCode))
+		return errors.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	logger.Debug("webhook sent successfully")
+	return nil
+}
+
+func calculateSignature(secret string, payload io.Reader) (string, error) {
+	mac := hmac.New(sha256.New, []byte(secret))
+	if _, err := io.Copy(mac, payload); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(mac.Sum(nil)), nil
+}

--- a/cmd/worker/internal/outboundwebhooks/handler_test.go
+++ b/cmd/worker/internal/outboundwebhooks/handler_test.go
@@ -1,0 +1,133 @@
+package outboundwebhooks
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	mockassert "github.com/derision-test/go-mockgen/testutil/assert"
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestHandler_Handle(t *testing.T) {
+	// This isn't a full blown integration test — we're going to mock pretty
+	// much all the dependencies. This is just to ensure that the expected knobs
+	// are twiddled in the expected scenarios.
+
+	t.Run("success", func(t *testing.T) {
+		ctx := context.Background()
+		logger := logtest.Scoped(t)
+
+		payload := []byte(`"test payload"`)
+		secret := "shared secret"
+
+		happyServer := newMockServer(t, payload, http.StatusOK)
+		sadServer := newMockServer(t, payload, http.StatusInternalServerError)
+
+		job := &types.OutboundWebhookJob{
+			ID:        1,
+			EventType: "event",
+			Payload:   encryption.NewUnencrypted(string(payload)),
+		}
+
+		happyWebhook := &types.OutboundWebhook{
+			ID:     1,
+			URL:    encryption.NewUnencrypted(happyServer.URL),
+			Secret: encryption.NewUnencrypted(secret),
+		}
+		sadWebhook := &types.OutboundWebhook{
+			ID:     2,
+			URL:    encryption.NewUnencrypted(sadServer.URL),
+			Secret: encryption.NewUnencrypted(secret),
+		}
+
+		store := database.NewMockOutboundWebhookStore()
+		store.ListFunc.SetDefaultReturn([]*types.OutboundWebhook{happyWebhook, sadWebhook}, nil)
+
+		logStore := database.NewMockOutboundWebhookLogStore()
+		webhooksSeen := newSeen[int64]()
+		logStore.CreateFunc.SetDefaultHook(func(ctx context.Context, log *types.OutboundWebhookLog) error {
+			assert.Equal(t, job.ID, log.JobID)
+			webhooksSeen.record(log.OutboundWebhookID)
+
+			return nil
+		})
+
+		h := &handler{
+			client:   http.DefaultClient,
+			store:    store,
+			logStore: logStore,
+		}
+
+		err := h.Handle(ctx, logger, job)
+		// We expect an error here because sadServer returned a 500.
+		assert.Error(t, err)
+
+		mockassert.CalledN(t, store.ListFunc, 1)
+		mockassert.CalledN(t, logStore.CreateFunc, 2)
+
+		assert.EqualValues(t, 1, happyServer.requestCount)
+		assert.EqualValues(t, 1, sadServer.requestCount)
+
+		assert.EqualValues(t, 1, webhooksSeen.count(happyWebhook.ID))
+		assert.EqualValues(t, 1, webhooksSeen.count(sadWebhook.ID))
+	})
+}
+
+type mockServer struct {
+	*httptest.Server
+	requestCount int32
+}
+
+func newMockServer(t *testing.T, expectedPayload []byte, statusCode int) *mockServer {
+	t.Helper()
+
+	ms := &mockServer{}
+	ms.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&ms.requestCount, 1)
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Equal(t, expectedPayload, body)
+
+		w.WriteHeader(statusCode)
+	}))
+	t.Cleanup(ms.Server.Close)
+
+	return ms
+}
+
+type seen[T comparable] struct {
+	mu   sync.RWMutex
+	seen map[T]int
+}
+
+func newSeen[T comparable]() *seen[T] {
+	return &seen[T]{
+		seen: map[T]int{},
+	}
+}
+
+func (s *seen[T]) count(value T) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.seen[value]
+}
+
+func (s *seen[T]) record(value T) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.seen[value] = s.seen[value] + 1
+}

--- a/cmd/worker/internal/outboundwebhooks/janitor.go
+++ b/cmd/worker/internal/outboundwebhooks/janitor.go
@@ -1,0 +1,43 @@
+package outboundwebhooks
+
+import (
+	"context"
+	"time"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+// makeJanitor creates a background goroutine to expunge old outbound webhook
+// jobs and logs from the database.
+func makeJanitor(observationCtx *observation.Context, store database.OutboundWebhookJobStore) goroutine.BackgroundRoutine {
+	return goroutine.NewPeriodicGoroutine(context.Background(), "outbound-webhooks.janitor", "cleans up stale outbound webhook jobs",
+		1*time.Hour, goroutine.HandlerFunc(func(ctx context.Context) error {
+			err := store.DeleteBefore(ctx, time.Now().Add(-1*calculateRetention(observationCtx.Logger, conf.Get())))
+			if err != nil {
+				observationCtx.Logger.Error("outbound webhook janitor error", log.Error(err))
+			}
+			return err
+		}),
+	)
+}
+
+// This matches the documented value in the site configuration schema.
+const defaultRetention = 72 * time.Hour
+
+func calculateRetention(logger log.Logger, c *conf.Unified) time.Duration {
+	if cfg := c.WebhookLogging; cfg != nil {
+		retention, err := time.ParseDuration(cfg.Retention)
+		if err != nil {
+			logger.Warn("invalid webhook log retention period; ignoring", log.String("raw", cfg.Retention), log.Error(err))
+		} else {
+			return retention
+		}
+	}
+
+	return defaultRetention
+}

--- a/cmd/worker/internal/outboundwebhooks/job.go
+++ b/cmd/worker/internal/outboundwebhooks/job.go
@@ -1,0 +1,98 @@
+package outboundwebhooks
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
+	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type sender struct{}
+
+func NewSender() job.Job {
+	return &sender{}
+}
+
+func (s *sender) Description() string {
+	return "Outbound webhook sender"
+}
+
+func (*sender) Config() []env.Config {
+	return nil
+}
+
+func (s *sender) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+	observationCtx = observation.NewContext(observationCtx.Logger.Scoped("sender", "outbound webhook sender"))
+	ctx := actor.WithInternalActor(context.Background())
+
+	db, err := workerdb.InitDB(observationCtx)
+	if err != nil {
+		return nil, errors.Wrap(err, "initialising database")
+	}
+
+	client := httpcli.ExternalClient
+	key := keyring.Default().OutboundWebhookKey
+	workerStore := makeStore(observationCtx, db.Handle(), key)
+
+	return []goroutine.BackgroundRoutine{
+		makeWorker(
+			ctx, observationCtx, workerStore, client,
+			database.OutboundWebhooksWith(db, key),
+			database.OutboundWebhookLogsWith(db, key),
+		),
+		makeResetter(observationCtx, workerStore),
+		// TODO: add janitor job to clean up logs beyond retention.
+	}, nil
+}
+
+func makeWorker(
+	ctx context.Context,
+	observationCtx *observation.Context,
+	workerStore store.Store[*types.OutboundWebhookJob],
+	client *http.Client,
+	webhookStore database.OutboundWebhookStore,
+	logStore database.OutboundWebhookLogStore,
+) *workerutil.Worker[*types.OutboundWebhookJob] {
+	handler := &handler{
+		client:   client,
+		store:    webhookStore,
+		logStore: logStore,
+	}
+
+	return dbworker.NewWorker[*types.OutboundWebhookJob](
+		ctx, workerStore, handler, workerutil.WorkerOptions{
+			Name:              "outbound_webhook_job_worker",
+			Interval:          time.Second,
+			NumHandlers:       1,
+			HeartbeatInterval: 10 * time.Second,
+			Metrics:           workerutil.NewMetrics(observationCtx, "outbound_webhook_job_worker"),
+		},
+	)
+}
+
+func makeResetter(
+	observationCtx *observation.Context,
+	workerStore store.Store[*types.OutboundWebhookJob],
+) *dbworker.Resetter[*types.OutboundWebhookJob] {
+	return dbworker.NewResetter(
+		observationCtx.Logger, workerStore, dbworker.ResetterOptions{
+			Name:     "outbound_webhook_job_resetter",
+			Interval: 5 * time.Minute,
+			Metrics:  *dbworker.NewResetterMetrics(observationCtx, "outbound_webhook_job_resetter"),
+		},
+	)
+}

--- a/cmd/worker/internal/outboundwebhooks/job.go
+++ b/cmd/worker/internal/outboundwebhooks/job.go
@@ -55,7 +55,7 @@ func (s *sender) Routines(startupCtx context.Context, observationCtx *observatio
 			database.OutboundWebhookLogsWith(db, key),
 		),
 		makeResetter(observationCtx, workerStore),
-		// TODO: add janitor job to clean up logs beyond retention.
+		makeJanitor(observationCtx, db.OutboundWebhookJobs(key)),
 	}, nil
 }
 

--- a/cmd/worker/internal/outboundwebhooks/job.go
+++ b/cmd/worker/internal/outboundwebhooks/job.go
@@ -92,7 +92,7 @@ func makeResetter(
 		observationCtx.Logger, workerStore, dbworker.ResetterOptions{
 			Name:     "outbound_webhook_job_resetter",
 			Interval: 5 * time.Minute,
-			Metrics:  *dbworker.NewResetterMetrics(observationCtx, "outbound_webhook_job_resetter"),
+			Metrics:  dbworker.NewResetterMetrics(observationCtx, "outbound_webhook_job_resetter"),
 		},
 	)
 }

--- a/cmd/worker/internal/outboundwebhooks/store.go
+++ b/cmd/worker/internal/outboundwebhooks/store.go
@@ -1,0 +1,29 @@
+package outboundwebhooks
+
+import (
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
+)
+
+func makeStore(observationCtx *observation.Context, db basestore.TransactableHandle, key encryption.Key) store.Store[*types.OutboundWebhookJob] {
+	return store.New(observationCtx, db, store.Options[*types.OutboundWebhookJob]{
+		Name:              "outbound_webhooks_worker_store",
+		TableName:         "outbound_webhook_jobs",
+		ColumnExpressions: database.OutboundWebhookJobColumns,
+		Scan: store.BuildWorkerScan(func(sc dbutil.Scanner) (*types.OutboundWebhookJob, error) {
+			return database.ScanOutboundWebhookJob(key, sc)
+		}),
+		OrderByExpression: sqlf.Sprintf("id"),
+		MaxNumResets:      5,
+		StalledMaxAge:     10 * time.Second,
+	})
+}

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/gitserver"
 	workermigrations "github.com/sourcegraph/sourcegraph/cmd/worker/internal/migrations"
+	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/outboundwebhooks"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/repostatistics"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/webhooks"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/zoektrepos"
@@ -59,6 +60,7 @@ func Start(observationCtx *observation.Context, additionalJobs map[string]job.Jo
 		"record-encrypter":          encryption.NewRecordEncrypterJob(),
 		"repo-statistics-compactor": repostatistics.NewCompactor(),
 		"zoekt-repos-updater":       zoektrepos.NewUpdater(),
+		"outbound-webhook-sender":   outboundwebhooks.NewSender(),
 	}
 
 	jobs := map[string]job.Job{}

--- a/doc/admin/workers.md
+++ b/doc/admin/workers.md
@@ -120,7 +120,7 @@ This job runs queries against the database pertaining to generate `gitserver` me
 
 #### `outbound-webhook-sender`
 
-This job dispatches HTTP requests for outbound webhooks.
+This job dispatches HTTP requests for outbound webhooks and periodically removes old logs entries for them.
 
 #### `repo-statistics-compactor`
 

--- a/doc/admin/workers.md
+++ b/doc/admin/workers.md
@@ -118,6 +118,10 @@ This job runs the workspace resolutions for batch specs. Used for batch changes 
 
 This job runs queries against the database pertaining to generate `gitserver` metrics. These queries are generally expensive to run and do not need to be run per-instance of `gitserver` so the worker allows them to only be run once per scrape.
 
+#### `outbound-webhook-sender`
+
+This job dispatches HTTP requests for outbound webhooks.
+
 #### `repo-statistics-compactor`
 
 This job periodically cleans up the `repo_statistics` table by rolling up all rows into a single row.


### PR DESCRIPTION
This is part 2 of #38278.

Building on #46007, this PR implements a worker to consume outbound webhook jobs from the job queue, dispatch them over HTTP, and record the results in the log table. It also implements a janitor to clean up the log table.

The default concurrency (100) is picked essentially at random, but I don't expect it to cause problems. I also expect the average deployment to have <5 webhooks in practice.

Note the use of the existing `WebhookLogMessage` types — this will come into play more in the GraphQL and site admin UI PRs. (Why reinvent a perfectly good wheel?)

## Test plan

Mostly functional testing as part of #45833, but I'm also pretty proud of the handler test. It hits the high points!