### PR TITLE
frontend: add GraphQL schema and resolvers for outbound webhooks

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -424,7 +424,7 @@ func NewSchema(
 	webhooksResolver WebhooksResolver,
 ) (*graphql.Schema, error) {
 	resolver := newSchemaResolver(db, gitserverClient)
-	schemas := []string{mainSchema}
+	schemas := []string{mainSchema, outboundWebhooksSchema}
 
 	if batchChanges != nil {
 		EnterpriseResolvers.batchChangesResolver = batchChanges
@@ -639,6 +639,9 @@ func newSchemaResolver(db database.DB, gitserverClient gitserver.Client) *schema
 		},
 		"ExecutorSecretAccessLog": func(ctx context.Context, id graphql.ID) (Node, error) {
 			return executorSecretAccessLogByID(ctx, db, id)
+		},
+		outboundWebhookIDKind: func(ctx context.Context, id graphql.ID) (Node, error) {
+			return OutboundWebhookByID(ctx, db, id)
 		},
 	}
 	return r

--- a/cmd/frontend/graphqlbackend/node.go
+++ b/cmd/frontend/graphqlbackend/node.go
@@ -318,3 +318,8 @@ func (r *NodeResolver) ToPermissionsSyncJob() (PermissionsSyncJobResolver, bool)
 	n, ok := r.Node.(PermissionsSyncJobResolver)
 	return n, ok
 }
+
+func (r *NodeResolver) ToOutboundWebhook() (OutboundWebhookResolver, bool) {
+	n, ok := r.Node.(OutboundWebhookResolver)
+	return n, ok
+}

--- a/cmd/frontend/graphqlbackend/outbound_webhook_logs.go
+++ b/cmd/frontend/graphqlbackend/outbound_webhook_logs.go
@@ -1,0 +1,248 @@
+package graphqlbackend
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/syncx"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+const (
+	outboundWebhookJobIDKind = "OutboundWebhookJob"
+	outboundWebhookLogIDKind = "OutboundWebhookLog"
+)
+
+type OutboundWebhookLogStatsResolver interface {
+	Total() int32
+	Errored() int32
+}
+
+type OutboundWebhookLogConnectionResolver interface {
+	Nodes() ([]OutboundWebhookLogResolver, error)
+	TotalCount() (int32, error)
+	PageInfo() (*graphqlutil.PageInfo, error)
+}
+
+type OutboundWebhookLogResolver interface {
+	ID() graphql.ID
+	Job(context.Context) OutboundWebhookJobResolver
+	SentAt() gqlutil.DateTime
+	StatusCode() int32
+	Request(context.Context) (*webhookLogRequestResolver, error)
+	Response(context.Context) (*webhookLogMessageResolver, error)
+	Error(context.Context) (*string, error)
+}
+
+type OutboundWebhookJobResolver interface {
+	ID() graphql.ID
+	EventType() (string, error)
+	Scope() (*string, error)
+	Payload(context.Context) (string, error)
+}
+
+type outboundWebhookLogStatsResolver struct {
+	total, errored int64
+}
+
+func (r *outboundWebhookLogStatsResolver) Total() int32 {
+	return int32(r.total)
+}
+
+func (r *outboundWebhookLogStatsResolver) Errored() int32 {
+	return int32(r.errored)
+}
+
+type outboundWebhookLogConnectionResolver struct {
+	nodes      func() ([]*types.OutboundWebhookLog, error)
+	resolvers  func() ([]OutboundWebhookLogResolver, error)
+	totalCount func() (int32, error)
+	first      int
+	offset     int
+}
+
+func newOutboundWebhookLogConnectionResolver(
+	ctx context.Context, store database.OutboundWebhookStore,
+	opts database.OutboundWebhookLogListOpts,
+) OutboundWebhookLogConnectionResolver {
+	logStore := store.ToLogStore()
+	nodes := syncx.OnceValues(func() ([]*types.OutboundWebhookLog, error) {
+		opts.Limit += 1
+		return logStore.ListForOutboundWebhook(ctx, opts)
+	})
+
+	return &outboundWebhookLogConnectionResolver{
+		nodes: nodes,
+		resolvers: syncx.OnceValues(func() ([]OutboundWebhookLogResolver, error) {
+			logs, err := nodes()
+			if err != nil {
+				return nil, err
+			}
+
+			if len(logs) > opts.Limit {
+				logs = logs[0:opts.Limit]
+			}
+
+			resolvers := make([]OutboundWebhookLogResolver, len(logs))
+			for i := range logs {
+				resolvers[i] = &outboundWebhookLogResolver{
+					store: store,
+					log:   logs[i],
+				}
+			}
+
+			return resolvers, nil
+		}),
+		totalCount: syncx.OnceValues(func() (int32, error) {
+			total, errored, err := logStore.CountsForOutboundWebhook(ctx, opts.OutboundWebhookID)
+			if opts.OnlyErrors {
+				return int32(errored), err
+			}
+			return int32(total), err
+		}),
+		first:  opts.Limit,
+		offset: opts.Offset,
+	}
+}
+
+func (r *outboundWebhookLogConnectionResolver) Nodes() ([]OutboundWebhookLogResolver, error) {
+	return r.resolvers()
+}
+
+func (r *outboundWebhookLogConnectionResolver) TotalCount() (int32, error) {
+	return r.totalCount()
+}
+
+func (r *outboundWebhookLogConnectionResolver) PageInfo() (*graphqlutil.PageInfo, error) {
+	nodes, err := r.nodes()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(nodes) > r.first {
+		return graphqlutil.NextPageCursor(strconv.Itoa(r.first + r.offset)), nil
+	}
+	return graphqlutil.HasNextPage(false), nil
+}
+
+type outboundWebhookLogResolver struct {
+	store database.OutboundWebhookStore
+	log   *types.OutboundWebhookLog
+}
+
+func (r *outboundWebhookLogResolver) ID() graphql.ID {
+	return marshalOutboundWebhookLogID(r.log.ID)
+}
+
+func (r *outboundWebhookLogResolver) Job(ctx context.Context) OutboundWebhookJobResolver {
+	return newOutboundWebhookJobResolver(ctx, r.store.ToJobStore(), r.log.JobID)
+}
+
+func (r *outboundWebhookLogResolver) SentAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.log.SentAt}
+}
+
+func (r *outboundWebhookLogResolver) StatusCode() int32 {
+	return int32(r.log.StatusCode)
+}
+
+func (r *outboundWebhookLogResolver) Request(ctx context.Context) (*webhookLogRequestResolver, error) {
+	request, err := r.log.Request.Decrypt(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &webhookLogRequestResolver{webhookLogMessageResolver{&request}}, nil
+}
+
+func (r *outboundWebhookLogResolver) Response(ctx context.Context) (*webhookLogMessageResolver, error) {
+	if r.log.StatusCode == types.OutboundWebhookLogUnsentStatusCode {
+		return nil, nil
+	}
+
+	response, err := r.log.Response.Decrypt(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &webhookLogMessageResolver{&response}, nil
+}
+
+func (r *outboundWebhookLogResolver) Error(ctx context.Context) (*string, error) {
+	if r.log.StatusCode != types.OutboundWebhookLogUnsentStatusCode {
+		return nil, nil
+	}
+
+	message, err := r.log.Error.Decrypt(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &message, nil
+}
+
+type outboundWebhookJobResolver struct {
+	id  int64
+	job func() (*types.OutboundWebhookJob, error)
+}
+
+func newOutboundWebhookJobResolver(
+	ctx context.Context, store database.OutboundWebhookJobStore,
+	id int64,
+) OutboundWebhookJobResolver {
+	return &outboundWebhookJobResolver{
+		job: syncx.OnceValues(func() (*types.OutboundWebhookJob, error) {
+			return store.GetByID(ctx, id)
+		}),
+	}
+}
+
+func (r *outboundWebhookJobResolver) ID() graphql.ID {
+	return marshalOutboundWebhookJobID(r.id)
+}
+
+func (r *outboundWebhookJobResolver) EventType() (string, error) {
+	job, err := r.job()
+	if err != nil {
+		return "", err
+	}
+
+	return job.EventType, nil
+}
+
+func (r *outboundWebhookJobResolver) Scope() (*string, error) {
+	job, err := r.job()
+	if err != nil {
+		return nil, err
+	}
+
+	return job.Scope, nil
+}
+
+func (r *outboundWebhookJobResolver) Payload(ctx context.Context) (string, error) {
+	job, err := r.job()
+	if err != nil {
+		return "", err
+	}
+
+	payload, err := job.Payload.Decrypt(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return payload, nil
+}
+
+func marshalOutboundWebhookJobID(id int64) graphql.ID {
+	return relay.MarshalID(outboundWebhookJobIDKind, id)
+}
+
+func marshalOutboundWebhookLogID(id int64) graphql.ID {
+	return relay.MarshalID(outboundWebhookLogIDKind, id)
+}

--- a/cmd/frontend/graphqlbackend/outbound_webhook_logs.go
+++ b/cmd/frontend/graphqlbackend/outbound_webhook_logs.go
@@ -71,7 +71,9 @@ func newOutboundWebhookLogConnectionResolver(
 	ctx context.Context, store database.OutboundWebhookStore,
 	opts database.OutboundWebhookLogListOpts,
 ) OutboundWebhookLogConnectionResolver {
+	limit := opts.Limit
 	logStore := store.ToLogStore()
+
 	nodes := syncx.OnceValues(func() ([]*types.OutboundWebhookLog, error) {
 		opts.Limit += 1
 		return logStore.ListForOutboundWebhook(ctx, opts)
@@ -85,8 +87,8 @@ func newOutboundWebhookLogConnectionResolver(
 				return nil, err
 			}
 
-			if len(logs) > opts.Limit {
-				logs = logs[0:opts.Limit]
+			if len(logs) > limit {
+				logs = logs[0:limit]
 			}
 
 			resolvers := make([]OutboundWebhookLogResolver, len(logs))

--- a/cmd/frontend/graphqlbackend/outbound_webhook_logs_test.go
+++ b/cmd/frontend/graphqlbackend/outbound_webhook_logs_test.go
@@ -48,7 +48,7 @@ func TestOutboundWebhookLogs(t *testing.T) {
 			StatusCode:        500,
 			Request: types.NewUnencryptedWebhookLogMessage(types.WebhookLogMessage{
 				Header: map[string][]string{
-					"content-type": []string{"application/json"},
+					"content-type": {"application/json"},
 				},
 				Body:   []byte(jobPayload),
 				Method: "POST",
@@ -56,7 +56,7 @@ func TestOutboundWebhookLogs(t *testing.T) {
 			}),
 			Response: types.NewUnencryptedWebhookLogMessage(types.WebhookLogMessage{
 				Header: map[string][]string{
-					"content-type": []string{"application/json"},
+					"content-type": {"application/json"},
 				},
 				Body: []byte(`"roger roger"`),
 			}),
@@ -70,7 +70,7 @@ func TestOutboundWebhookLogs(t *testing.T) {
 			StatusCode:        0,
 			Request: types.NewUnencryptedWebhookLogMessage(types.WebhookLogMessage{
 				Header: map[string][]string{
-					"content-type": []string{"application/json"},
+					"content-type": {"application/json"},
 				},
 				Body:   []byte(jobPayload),
 				Method: "POST",

--- a/cmd/frontend/graphqlbackend/outbound_webhook_logs_test.go
+++ b/cmd/frontend/graphqlbackend/outbound_webhook_logs_test.go
@@ -1,0 +1,235 @@
+package graphqlbackend
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestOutboundWebhookLogs(t *testing.T) {
+	// This is intentionally a pretty minimal test — for the most part, we're
+	// going to be happy if the right parameters are marshalled into the right
+	// database options.
+
+	t.Parallel()
+
+	eventType := "test:event"
+	url := "http://example.com/"
+	webhook := &types.OutboundWebhook{
+		ID:     1,
+		URL:    encryption.NewUnencrypted(url),
+		Secret: encryption.NewUnencrypted("secret"),
+		EventTypes: []types.OutboundWebhookEventType{
+			{EventType: eventType},
+		},
+	}
+
+	base := time.Date(2022, 12, 30, 11, 22, 33, 0, time.UTC)
+
+	jobPayload := `{"webhook": "body"}`
+	job := &types.OutboundWebhookJob{
+		ID:        10,
+		EventType: eventType,
+		Payload:   encryption.NewUnencrypted(jobPayload),
+	}
+
+	logs := []*types.OutboundWebhookLog{
+		{
+			ID:                20,
+			JobID:             job.ID,
+			OutboundWebhookID: webhook.ID,
+			SentAt:            base.Add(time.Minute),
+			StatusCode:        500,
+			Request: types.NewUnencryptedWebhookLogMessage(types.WebhookLogMessage{
+				Header: map[string][]string{
+					"content-type": []string{"application/json"},
+				},
+				Body:   []byte(jobPayload),
+				Method: "POST",
+				URL:    url,
+			}),
+			Response: types.NewUnencryptedWebhookLogMessage(types.WebhookLogMessage{
+				Header: map[string][]string{
+					"content-type": []string{"application/json"},
+				},
+				Body: []byte(`"roger roger"`),
+			}),
+			Error: encryption.NewUnencrypted(""),
+		},
+		{
+			ID:                21,
+			JobID:             job.ID,
+			OutboundWebhookID: webhook.ID,
+			SentAt:            base,
+			StatusCode:        0,
+			Request: types.NewUnencryptedWebhookLogMessage(types.WebhookLogMessage{
+				Header: map[string][]string{
+					"content-type": []string{"application/json"},
+				},
+				Body:   []byte(jobPayload),
+				Method: "POST",
+				URL:    url,
+			}),
+			Response: types.NewUnencryptedWebhookLogMessage(types.WebhookLogMessage{}),
+			Error:    encryption.NewUnencrypted("bad pipes"),
+		},
+	}
+
+	jobStore := database.NewMockOutboundWebhookJobStore()
+	jobStore.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int64) (*types.OutboundWebhookJob, error) {
+		assert.EqualValues(t, job.ID, id)
+		return job, nil
+	})
+
+	logStore := database.NewMockOutboundWebhookLogStore()
+	logStore.CountsForOutboundWebhookFunc.SetDefaultHook(func(ctx context.Context, id int64) (int64, int64, error) {
+		assert.EqualValues(t, webhook.ID, id)
+		return 4, 2, nil
+	})
+	logStore.ListForOutboundWebhookFunc.SetDefaultHook(func(ctx context.Context, opts database.OutboundWebhookLogListOpts) ([]*types.OutboundWebhookLog, error) {
+		assert.EqualValues(t, webhook.ID, opts.OutboundWebhookID)
+		assert.EqualValues(t, 5+1, opts.Limit)
+		assert.True(t, opts.OnlyErrors)
+		return logs, nil
+	})
+
+	store := database.NewMockOutboundWebhookStore()
+	store.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int64) (*types.OutboundWebhook, error) {
+		assert.EqualValues(t, webhook.ID, id)
+		return webhook, nil
+	})
+	store.ToJobStoreFunc.SetDefaultReturn(jobStore)
+	store.ToLogStoreFunc.SetDefaultReturn(logStore)
+
+	db := database.NewMockDB()
+	db.OutboundWebhooksFunc.SetDefaultReturn(store)
+	ctx, _, _ := fakeUser(t, context.Background(), db, true)
+
+	RunTest(t, &Test{
+		Context: ctx,
+		Schema:  mustParseGraphQLSchema(t, db),
+		Query: `
+			{
+				node(id: "T3V0Ym91bmRXZWJob29rOjE=") {
+					... on OutboundWebhook {
+						stats {
+							total
+							errored
+						}
+						logs(first: 5, onlyErrors: true) {
+							nodes {
+								id
+								job {
+									id
+									eventType
+									payload
+								}
+								sentAt
+								statusCode
+								request {
+									headers {
+										name
+										values
+									}
+									body
+									method
+									url
+								}
+								response {
+									headers {
+										name
+										values
+									}
+									body
+								}
+								error
+							}
+							totalCount
+							pageInfo {
+								hasNextPage
+							}
+						}
+					}
+				}
+			}
+		`,
+		ExpectedResult: `
+			{
+				"node": {
+					"logs": {
+						"nodes": [
+							{
+								"id": "T3V0Ym91bmRXZWJob29rTG9nOjIw",
+								"job": {
+									"id": "T3V0Ym91bmRXZWJob29rSm9iOjA=",
+									"eventType": "test:event",
+									"payload": "{\"webhook\": \"body\"}"
+								},
+								"sentAt": "2022-12-30T11:23:33Z",
+								"statusCode": 500,
+								"request": {
+									"headers": [
+										{
+											"name": "content-type",
+											"values": ["application/json"]
+										}
+									],
+									"body": "{\"webhook\": \"body\"}",
+									"method": "POST",
+									"url": "http://example.com/"
+								},
+								"response": {
+									"headers": [
+										{
+											"name": "content-type",
+											"values": ["application/json"]
+										}
+									],
+									"body": "\"roger roger\""
+								},
+								"error": null
+							},
+							{
+								"id": "T3V0Ym91bmRXZWJob29rTG9nOjIx",
+								"job": {
+									"id": "T3V0Ym91bmRXZWJob29rSm9iOjA=",
+									"eventType": "test:event",
+									"payload": "{\"webhook\": \"body\"}"
+								},
+								"sentAt": "2022-12-30T11:22:33Z",
+								"statusCode": 0,
+								"request": {
+									"headers": [
+										{
+											"name": "content-type",
+											"values": ["application/json"]
+										}
+									],
+									"body": "{\"webhook\": \"body\"}",
+									"method": "POST",
+									"url": "http://example.com/"
+								},
+								"response": null,
+								"error": "bad pipes"
+							}
+						],
+						"totalCount": 2,
+						"pageInfo": {
+							"hasNextPage": false
+						}
+					},
+					"stats": {
+						"total": 4,
+						"errored": 2
+					}
+				}
+			}
+		`,
+	})
+}

--- a/cmd/frontend/graphqlbackend/outbound_webhooks.go
+++ b/cmd/frontend/graphqlbackend/outbound_webhooks.go
@@ -1,0 +1,438 @@
+package graphqlbackend
+
+import (
+	"context"
+	"sort"
+	"strconv"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
+	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
+	"github.com/sourcegraph/sourcegraph/internal/syncx"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/webhooks/outbound"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+const outboundWebhookIDKind = "OutboundWebhook"
+
+type OutboundWebhookConnectionResolver interface {
+	Nodes() ([]OutboundWebhookResolver, error)
+	TotalCount() (int32, error)
+	PageInfo() (*graphqlutil.PageInfo, error)
+}
+
+type OutboundWebhookEventTypeResolver interface {
+	Key() string
+	Description() string
+}
+
+type OutboundWebhookResolver interface {
+	ID() graphql.ID
+	URL(context.Context) (string, error)
+	EventTypes() ([]OutboundWebhookScopedEventTypeResolver, error)
+	Stats(context.Context) (OutboundWebhookLogStatsResolver, error)
+	Logs(context.Context, OutboundWebhookLogsArgs) (OutboundWebhookLogConnectionResolver, error)
+}
+
+type OutboundWebhookScopedEventTypeResolver interface {
+	EventType() string
+	Scope() *string
+}
+
+type CreateOutboundWebhookArgs struct {
+	Input OutboundWebhookCreateInput `json:"input"`
+}
+
+type DeleteOutboundWebhookArgs struct {
+	ID graphql.ID `json:"id"`
+}
+
+type UpdateOutboundWebhookArgs struct {
+	ID    graphql.ID                 `json:"id"`
+	Input OutboundWebhookUpdateInput `json:"input"`
+}
+
+type ListOutboundWebhooksArgs struct {
+	First     int32   `json:"first"`
+	After     *string `json:"after"`
+	EventType *string `json:"eventType"`
+}
+
+type OutboundWebhookLogsArgs struct {
+	First      int32   `json:"first"`
+	After      *string `json:"after"`
+	OnlyErrors *bool   `json:"onlyErrors"`
+}
+
+type OutboundWebhookCreateInput struct {
+	OutboundWebhookUpdateInput
+	Secret string `json:"secret"`
+}
+
+type OutboundWebhookScopedEventTypeInput struct {
+	EventType string  `json:"eventType"`
+	Scope     *string `json:"scope"`
+}
+
+type OutboundWebhookUpdateInput struct {
+	URL        string                                `json:"url"`
+	EventTypes []OutboundWebhookScopedEventTypeInput `json:"eventTypes"`
+}
+
+func (r *schemaResolver) OutboundWebhooks(ctx context.Context, args ListOutboundWebhooksArgs) (OutboundWebhookConnectionResolver, error) {
+	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return nil, err
+	}
+
+	opts := database.OutboundWebhookListOpts{
+		LimitOffset: &database.LimitOffset{
+			Limit: int(args.First),
+		},
+	}
+	if args.After != nil {
+		offset, err := strconv.Atoi(*args.After)
+		if err != nil {
+			return nil, errors.Newf("cannot parse offset %q", *args.After)
+		}
+		opts.Offset = offset
+	}
+	if args.EventType != nil {
+		opts.EventTypes = []string{*args.EventType}
+	}
+
+	return newOutboundWebhookConnectionResolver(ctx, outboundWebhookStore(r.db), opts), nil
+}
+
+func (r *schemaResolver) OutboundWebhookEventTypes(ctx context.Context) ([]OutboundWebhookEventTypeResolver, error) {
+	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return nil, err
+	}
+
+	types := outbound.GetRegisteredEventTypes()
+	sort.Slice(types, func(i, j int) bool {
+		return types[i].Key < types[j].Key
+	})
+	resolvers := make([]OutboundWebhookEventTypeResolver, len(types))
+	for i, et := range types {
+		resolvers[i] = &outboundWebhookEventTypeResolver{et}
+	}
+
+	return resolvers, nil
+}
+
+func (r *schemaResolver) CreateOutboundWebhook(ctx context.Context, args CreateOutboundWebhookArgs) (OutboundWebhookResolver, error) {
+	user, err := auth.CurrentUser(ctx, r.db)
+	if err != nil {
+		return nil, err
+	}
+	if !user.SiteAdmin {
+		return nil, auth.ErrMustBeSiteAdmin
+	}
+
+	webhook := &types.OutboundWebhook{
+		CreatedBy:  user.ID,
+		UpdatedBy:  user.ID,
+		URL:        encryption.NewUnencrypted(args.Input.URL),
+		Secret:     encryption.NewUnencrypted(args.Input.Secret),
+		EventTypes: outboundWebhookEventTypes(args.Input.EventTypes),
+	}
+
+	store := outboundWebhookStore(r.db)
+	if err := store.Create(ctx, webhook); err != nil {
+		return nil, err
+	}
+
+	return newOutboundWebhookResolverFromWebhook(store, webhook), nil
+}
+
+func (r *schemaResolver) DeleteOutboundWebhook(ctx context.Context, args DeleteOutboundWebhookArgs) (*EmptyResponse, error) {
+	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return nil, err
+	}
+
+	id, err := unmarshalOutboundWebhookID(args.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	store := outboundWebhookStore(r.db)
+	if err := store.Delete(ctx, id); err != nil {
+		return nil, err
+	}
+
+	return &EmptyResponse{}, nil
+}
+
+func (r *schemaResolver) UpdateOutboundWebhook(ctx context.Context, args UpdateOutboundWebhookArgs) (OutboundWebhookResolver, error) {
+	user, err := auth.CurrentUser(ctx, r.db)
+	if err != nil {
+		return nil, err
+	}
+	if !user.SiteAdmin {
+		return nil, auth.ErrMustBeSiteAdmin
+	}
+
+	id, err := unmarshalOutboundWebhookID(args.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	store, err := outboundWebhookStore(r.db).Transact(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { err = store.Done(err) }()
+
+	webhook, err := store.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	webhook.UpdatedBy = user.ID
+	webhook.URL = encryption.NewUnencrypted(args.Input.URL)
+	webhook.EventTypes = outboundWebhookEventTypes(args.Input.EventTypes)
+
+	if err := store.Update(ctx, webhook); err != nil {
+		return nil, err
+	}
+
+	return newOutboundWebhookResolverFromWebhook(store, webhook), nil
+}
+
+func OutboundWebhookByID(ctx context.Context, db database.DB, gql graphql.ID) (OutboundWebhookResolver, error) {
+	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, db); err != nil {
+		return nil, err
+	}
+
+	id, err := unmarshalOutboundWebhookID(gql)
+	if err != nil {
+		return nil, err
+	}
+
+	return newOutboundWebhookResolverFromDatabase(ctx, outboundWebhookStore(db), id), nil
+}
+
+func marshalOutboundWebhookID(id int64) graphql.ID {
+	return relay.MarshalID(outboundWebhookIDKind, id)
+}
+
+func unmarshalOutboundWebhookID(gql graphql.ID) (id int64, err error) {
+	if kind := relay.UnmarshalKind(gql); kind != outboundWebhookIDKind {
+		return 0, errors.Newf("invalid outbound webhook id of kind %q", kind)
+	}
+
+	err = relay.UnmarshalSpec(gql, &id)
+	return
+}
+
+type outboundWebhookConnectionResolver struct {
+	nodes      func() ([]*types.OutboundWebhook, error)
+	resolvers  func() ([]OutboundWebhookResolver, error)
+	totalCount func() (int32, error)
+	first      int
+	offset     int
+}
+
+func newOutboundWebhookConnectionResolver(
+	ctx context.Context, store database.OutboundWebhookStore,
+	opts database.OutboundWebhookListOpts,
+) OutboundWebhookConnectionResolver {
+	nodes := syncx.OnceValues(func() ([]*types.OutboundWebhook, error) {
+		opts.Limit += 1
+		return store.List(ctx, opts)
+	})
+
+	return &outboundWebhookConnectionResolver{
+		nodes: nodes,
+		resolvers: syncx.OnceValues(func() ([]OutboundWebhookResolver, error) {
+			webhooks, err := nodes()
+			if err != nil {
+				return nil, err
+			}
+
+			if len(webhooks) > opts.Limit {
+				webhooks = webhooks[0:opts.Limit]
+			}
+
+			resolvers := make([]OutboundWebhookResolver, len(webhooks))
+			for i := range webhooks {
+				resolvers[i] = newOutboundWebhookResolverFromWebhook(store, webhooks[i])
+			}
+
+			return resolvers, nil
+		}),
+		totalCount: syncx.OnceValues(func() (int32, error) {
+			count, err := store.Count(ctx, opts.OutboundWebhookCountOpts)
+			return int32(count), err
+		}),
+		first:  opts.Limit,
+		offset: opts.Offset,
+	}
+}
+
+func (r *outboundWebhookConnectionResolver) Nodes() ([]OutboundWebhookResolver, error) {
+	return r.resolvers()
+}
+
+func (r *outboundWebhookConnectionResolver) TotalCount() (int32, error) {
+	return r.totalCount()
+}
+
+func (r *outboundWebhookConnectionResolver) PageInfo() (*graphqlutil.PageInfo, error) {
+	nodes, err := r.nodes()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(nodes) > r.first {
+		return graphqlutil.NextPageCursor(strconv.Itoa(r.first + r.offset)), nil
+	}
+	return graphqlutil.HasNextPage(false), nil
+}
+
+type outboundWebhookEventTypeResolver struct {
+	eventType outbound.EventType
+}
+
+func (r *outboundWebhookEventTypeResolver) Key() string {
+	return r.eventType.Key
+}
+
+func (r *outboundWebhookEventTypeResolver) Description() string {
+	return r.eventType.Description
+}
+
+type outboundWebhookResolver struct {
+	store   database.OutboundWebhookStore
+	id      graphql.ID
+	webhook func() (*types.OutboundWebhook, error)
+}
+
+func newOutboundWebhookResolverFromDatabase(ctx context.Context, store database.OutboundWebhookStore, id int64) OutboundWebhookResolver {
+	return &outboundWebhookResolver{
+		store: store,
+		id:    marshalOutboundWebhookID(id),
+		webhook: syncx.OnceValues(func() (*types.OutboundWebhook, error) {
+			return store.GetByID(ctx, id)
+		}),
+	}
+}
+
+func newOutboundWebhookResolverFromWebhook(store database.OutboundWebhookStore, webhook *types.OutboundWebhook) OutboundWebhookResolver {
+	return &outboundWebhookResolver{
+		store: store,
+		id:    marshalOutboundWebhookID(webhook.ID),
+		webhook: func() (*types.OutboundWebhook, error) {
+			return webhook, nil
+		},
+	}
+}
+
+func (r *outboundWebhookResolver) ID() graphql.ID {
+	return r.id
+}
+
+func (r *outboundWebhookResolver) URL(ctx context.Context) (string, error) {
+	webhook, err := r.webhook()
+	if err != nil {
+		return "", err
+	}
+
+	return webhook.URL.Decrypt(ctx)
+}
+
+func (r *outboundWebhookResolver) EventTypes() ([]OutboundWebhookScopedEventTypeResolver, error) {
+	webhook, err := r.webhook()
+	if err != nil {
+		return nil, err
+	}
+
+	types := make([]OutboundWebhookScopedEventTypeResolver, len(webhook.EventTypes))
+	for i, et := range webhook.EventTypes {
+		types[i] = &outboundWebhookScopedEventTypeResolver{
+			eventType: et.EventType,
+			scope:     et.Scope,
+		}
+	}
+	return types, nil
+}
+
+func (r *outboundWebhookResolver) Stats(ctx context.Context) (OutboundWebhookLogStatsResolver, error) {
+	id, err := unmarshalOutboundWebhookID(r.id)
+	if err != nil {
+		return nil, err
+	}
+
+	store := r.store.ToLogStore()
+	total, errored, err := store.CountsForOutboundWebhook(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &outboundWebhookLogStatsResolver{
+		total:   total,
+		errored: errored,
+	}, nil
+}
+
+func (r *outboundWebhookResolver) Logs(ctx context.Context, args OutboundWebhookLogsArgs) (OutboundWebhookLogConnectionResolver, error) {
+	id, err := unmarshalOutboundWebhookID(r.id)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := database.OutboundWebhookLogListOpts{
+		LimitOffset: &database.LimitOffset{
+			Limit: int(args.First),
+		},
+		OnlyErrors:        false,
+		OutboundWebhookID: id,
+	}
+
+	if args.After != nil {
+		offset, err := strconv.Atoi(*args.After)
+		if err != nil {
+			return nil, errors.Newf("cannot parse offset %q", *args.After)
+		}
+		opts.Offset = offset
+	}
+
+	if args.OnlyErrors != nil && *args.OnlyErrors {
+		opts.OnlyErrors = true
+	}
+
+	return newOutboundWebhookLogConnectionResolver(ctx, r.store, opts), nil
+}
+
+type outboundWebhookScopedEventTypeResolver struct {
+	eventType string
+	scope     *string
+}
+
+func (r *outboundWebhookScopedEventTypeResolver) EventType() string {
+	return r.eventType
+}
+
+func (r *outboundWebhookScopedEventTypeResolver) Scope() *string {
+	return r.scope
+}
+
+func outboundWebhookEventTypes(inputs []OutboundWebhookScopedEventTypeInput) []types.OutboundWebhookEventType {
+	eventTypes := make([]types.OutboundWebhookEventType, len(inputs))
+	for i, t := range inputs {
+		eventTypes[i].EventType = t.EventType
+		eventTypes[i].Scope = t.Scope
+	}
+
+	return eventTypes
+}
+
+func outboundWebhookStore(db database.DB) database.OutboundWebhookStore {
+	return database.OutboundWebhooksWith(db, keyring.Default().OutboundWebhookKey)
+}

--- a/cmd/frontend/graphqlbackend/outbound_webhooks.go
+++ b/cmd/frontend/graphqlbackend/outbound_webhooks.go
@@ -243,6 +243,8 @@ func newOutboundWebhookConnectionResolver(
 	ctx context.Context, store database.OutboundWebhookStore,
 	opts database.OutboundWebhookListOpts,
 ) OutboundWebhookConnectionResolver {
+	limit := opts.Limit
+
 	nodes := syncx.OnceValues(func() ([]*types.OutboundWebhook, error) {
 		opts.Limit += 1
 		return store.List(ctx, opts)
@@ -256,8 +258,8 @@ func newOutboundWebhookConnectionResolver(
 				return nil, err
 			}
 
-			if len(webhooks) > opts.Limit {
-				webhooks = webhooks[0:opts.Limit]
+			if len(webhooks) > limit {
+				webhooks = webhooks[0:limit]
 			}
 
 			resolvers := make([]OutboundWebhookResolver, len(webhooks))
@@ -434,5 +436,5 @@ func outboundWebhookEventTypes(inputs []OutboundWebhookScopedEventTypeInput) []t
 }
 
 func outboundWebhookStore(db database.DB) database.OutboundWebhookStore {
-	return database.OutboundWebhooksWith(db, keyring.Default().OutboundWebhookKey)
+	return db.OutboundWebhooks(keyring.Default().OutboundWebhookKey)
 }

--- a/cmd/frontend/graphqlbackend/outbound_webhooks.go
+++ b/cmd/frontend/graphqlbackend/outbound_webhooks.go
@@ -136,6 +136,12 @@ func (r *schemaResolver) CreateOutboundWebhook(ctx context.Context, args CreateO
 		return nil, auth.ErrMustBeSiteAdmin
 	}
 
+	// Validate the URL
+	err = outbound.CheckAddress(args.Input.URL)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid webhook address")
+	}
+
 	webhook := &types.OutboundWebhook{
 		CreatedBy:  user.ID,
 		UpdatedBy:  user.ID,

--- a/cmd/frontend/graphqlbackend/outbound_webhooks.go
+++ b/cmd/frontend/graphqlbackend/outbound_webhooks.go
@@ -62,6 +62,7 @@ type ListOutboundWebhooksArgs struct {
 	First     int32   `json:"first"`
 	After     *string `json:"after"`
 	EventType *string `json:"eventType"`
+	Scope     *string `json:"scope"`
 }
 
 type OutboundWebhookLogsArgs struct {
@@ -103,7 +104,7 @@ func (r *schemaResolver) OutboundWebhooks(ctx context.Context, args ListOutbound
 		opts.Offset = offset
 	}
 	if args.EventType != nil {
-		opts.EventTypes = []string{*args.EventType}
+		opts.EventTypes = []database.FilterEventType{{EventType: *args.EventType, Scope: args.Scope}}
 	}
 
 	return newOutboundWebhookConnectionResolver(ctx, outboundWebhookStore(r.db), opts), nil

--- a/cmd/frontend/graphqlbackend/outbound_webhooks.graphql
+++ b/cmd/frontend/graphqlbackend/outbound_webhooks.graphql
@@ -1,0 +1,78 @@
+extend type Query {
+    outboundWebhooks(first: Int = 50, after: String, eventType: String): OutboundWebhookConnection!
+    outboundWebhookEventTypes: [OutboundWebhookEventType!]!
+}
+
+extend type Mutation {
+    createOutboundWebhook(input: OutboundWebhookCreateInput!): OutboundWebhook!
+    deleteOutboundWebhook(id: ID!): EmptyResponse!
+    updateOutboundWebhook(id: ID!, input: OutboundWebhookUpdateInput!): OutboundWebhook!
+}
+
+type OutboundWebhook implements Node {
+    id: ID!
+    url: String!
+    eventTypes: [OutboundWebhookScopedEventType]!
+    stats: OutboundWebhookLogStats!
+    logs(first: Int = 50, after: String, onlyErrors: Boolean): OutboundWebhookLogConnection!
+}
+
+type OutboundWebhookConnection {
+    nodes: [OutboundWebhook!]!
+    totalCount: Int!
+    pageInfo: PageInfo!
+}
+
+type OutboundWebhookEventType {
+    key: String!
+    description: String!
+}
+
+input OutboundWebhookCreateInput {
+    url: String!
+    secret: String!
+    eventTypes: [OutboundWebhookScopedEventTypeInput!]!
+}
+
+input OutboundWebhookUpdateInput {
+    url: String!
+    eventTypes: [OutboundWebhookScopedEventTypeInput!]!
+}
+
+input OutboundWebhookScopedEventTypeInput {
+    eventType: String!
+    scope: String
+}
+
+type OutboundWebhookScopedEventType {
+    eventType: String!
+    scope: String
+}
+
+type OutboundWebhookLogConnection {
+    nodes: [OutboundWebhookLog!]!
+    totalCount: Int!
+    pageInfo: PageInfo!
+}
+
+type OutboundWebhookJob {
+    id: ID!
+    eventType: String!
+    scope: String
+    payload: String!
+}
+
+type OutboundWebhookLogStats {
+    total: Int!
+    errored: Int!
+}
+
+type OutboundWebhookLog {
+    id: ID!
+    job: OutboundWebhookJob!
+    sentAt: DateTime!
+    statusCode: Int!
+    request: WebhookLogRequest!
+    response: WebhookLogResponse
+    error: String
+}

--- a/cmd/frontend/graphqlbackend/outbound_webhooks.graphql
+++ b/cmd/frontend/graphqlbackend/outbound_webhooks.graphql
@@ -1,78 +1,294 @@
 extend type Query {
+    """
+    Returns the outbound webhooks registered within Sourcegraph, optionally
+    filtered by event type. If the event type is omitted, all webhooks are
+    returned.
+
+    Only site admins have access to this query.
+    """
     outboundWebhooks(first: Int = 50, after: String, eventType: String): OutboundWebhookConnection!
+
+    """
+    Returns all possible outbound webhook event types.
+
+    Only site admins have access to this query.
+    """
     outboundWebhookEventTypes: [OutboundWebhookEventType!]!
 }
 
 extend type Mutation {
+    """
+    Creates a new outbound webhook.
+
+    Only site admins have access to this mutation.
+    """
     createOutboundWebhook(input: OutboundWebhookCreateInput!): OutboundWebhook!
+
+    """
+    Deletes an outbound webhook.
+
+    Only site admins have access to this mutation.
+    """
     deleteOutboundWebhook(id: ID!): EmptyResponse!
+
+    """
+    Updates an outbound webhook.
+
+    Only site admins have access to this mutation.
+    """
     updateOutboundWebhook(id: ID!, input: OutboundWebhookUpdateInput!): OutboundWebhook!
 }
 
+"""
+An outbound webhook registered within Sourcegraph.
+"""
 type OutboundWebhook implements Node {
+    """
+    The outbound webhook ID.
+    """
     id: ID!
+
+    """
+    The outbound webhook URL.
+    """
     url: String!
+
+    """
+    The event types that the outbound webhook will receive.
+    """
     eventTypes: [OutboundWebhookScopedEventType]!
+
+    """
+    Stats on the payloads dispatched to this outbound webhook within the webhook
+    log retention period.
+    """
     stats: OutboundWebhookLogStats!
+
+    """
+    Logged payloads sent to this outbound webhook, optionally filtered by error
+    state. Logs are considered "errored" when either a network error occurred
+    while dispatching the payload, or when a HTTP response outside the range
+    [100, 399].
+
+    Logs will be returned in time order, from newest to oldest.
+    """
     logs(first: Int = 50, after: String, onlyErrors: Boolean): OutboundWebhookLogConnection!
 }
 
+"""
+A list of outbound webhooks.
+"""
 type OutboundWebhookConnection {
+    """
+    The outbound webhooks in the current page.
+    """
     nodes: [OutboundWebhook!]!
+
+    """
+    The total number of matching outbound webhooks.
+    """
     totalCount: Int!
+
+    """
+    Connection page metadata.
+    """
     pageInfo: PageInfo!
 }
 
+"""
+An event type that a webhook can be registered to be notified of.
+"""
 type OutboundWebhookEventType {
+    """
+    The event type key, as used when constructing
+    OutboundWebhookScopedEventTypeInput instances and as returned in
+    OutboundWebhook.eventTypes.
+    """
     key: String!
+
+    """
+    A human readable description of the event type.
+    """
     description: String!
 }
 
+"""
+Input for the createOutboundWebhook mutation.
+"""
 input OutboundWebhookCreateInput {
+    """
+    The outbound webhook URL.
+    """
     url: String!
+
+    """
+    The secret shared with the outbound webhook.
+    """
     secret: String!
+
+    """
+    The event types the outbound webhook will receive.
+
+    At least one event type must be provided.
+    """
     eventTypes: [OutboundWebhookScopedEventTypeInput!]!
 }
 
+"""
+Input for the updateOutboundWebhook mutation.
+"""
 input OutboundWebhookUpdateInput {
+    """
+    The outbound webhook URL.
+    """
     url: String!
+
+    """
+    The event types the outbound webhook will receive. This list replaces the
+    event types previously registered on the webhook.
+
+    At least one event type must be provided.
+    """
     eventTypes: [OutboundWebhookScopedEventTypeInput!]!
 }
 
+"""
+Event type input for the outbound webhook mutations.
+"""
 input OutboundWebhookScopedEventTypeInput {
+    """
+    The event type, which must match a key returned from
+    outboundWebhookEventTypes.
+    """
     eventType: String!
+
+    """
+    An optional scope for the event type.
+
+    Currently unused.
+    """
     scope: String
 }
 
+"""
+An event type an outbound webhook has opted to receive.
+"""
 type OutboundWebhookScopedEventType {
+    """
+    The event type, which must match a key returned from
+    outboundWebhookEventTypes.
+    """
     eventType: String!
+
+    """
+    An optional scope for the event type.
+
+    Currently unused.
+    """
     scope: String
 }
 
+"""
+A list of outbound webhook logs.
+"""
 type OutboundWebhookLogConnection {
+    """
+    The logs in the current page.
+    """
     nodes: [OutboundWebhookLog!]!
+
+    """
+    The total number of matching outbound webhook logs.
+    """
     totalCount: Int!
+
+    """
+    Connection page metadata.
+    """
     pageInfo: PageInfo!
 }
 
+"""
+An outbound webhook job, which singularly represents an individual event that
+may generate one or more webhook payloads.
+"""
 type OutboundWebhookJob {
+    """
+    The outbound webhook job ID.
+    """
     id: ID!
+
+    """
+    The event type.
+    """
     eventType: String!
+
+    """
+    The scope. Currently unused.
+    """
     scope: String
+
+    """
+    The payload sent to each outbound webhook registered for this event type.
+    """
     payload: String!
 }
 
+"""
+Stats on outbound webhook logs.
+"""
 type OutboundWebhookLogStats {
+    """
+    The total number of webhook payloads logged over the webhook log retention
+    period.
+    """
     total: Int!
+
+    """
+    The total number of webhook payloads logged over the webhook log retention
+    period that resulted in errors from the webhook.
+    """
     errored: Int!
 }
 
+"""
+A single logged request sent to an outbound webhook.
+"""
 type OutboundWebhookLog {
+    """
+    The log ID.
+    """
     id: ID!
+
+    """
+    The outbound webhook job that triggered the request.
+    """
     job: OutboundWebhookJob!
+
+    """
+    When the request was sent.
+    """
     sentAt: DateTime!
+
+    """
+    The status code returned from the outbound webhook, or 0 if a network error
+    occurred.
+    """
     statusCode: Int!
+
+    """
+    The request sent to the outbound webhook.
+    """
     request: WebhookLogRequest!
+
+    """
+    The response received from the outbound webhook, or null if no response was
+    received due to a network error.
+    """
     response: WebhookLogResponse
+
+    """
+    The error message if a network error occurred.
+    """
     error: String
 }

--- a/cmd/frontend/graphqlbackend/outbound_webhooks.graphql
+++ b/cmd/frontend/graphqlbackend/outbound_webhooks.graphql
@@ -1,12 +1,12 @@
 extend type Query {
     """
-    Returns the outbound webhooks registered within Sourcegraph, optionally
-    filtered by event type. If the event type is omitted, all webhooks are
-    returned.
+    Returns the outbound webhooks registered within Sourcegraph, optionally filtered by
+    event type and scope. To filter by scope, event type is also required. If the event
+    type and scope are both omitted, all webhooks are returned.
 
     Only site admins have access to this query.
     """
-    outboundWebhooks(first: Int = 50, after: String, eventType: String): OutboundWebhookConnection!
+    outboundWebhooks(first: Int = 50, after: String, eventType: String, scope: String): OutboundWebhookConnection!
 
     """
     Returns all possible outbound webhook event types.

--- a/cmd/frontend/graphqlbackend/outbound_webhooks_test.go
+++ b/cmd/frontend/graphqlbackend/outbound_webhooks_test.go
@@ -1,0 +1,531 @@
+package graphqlbackend
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	mockassert "github.com/derision-test/go-mockgen/testutil/assert"
+	gqlerrors "github.com/graph-gophers/graphql-go/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/webhooks/outbound"
+)
+
+func TestSchemaResolver_OutboundWebhooks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not site admin", func(t *testing.T) {
+		t.Parallel()
+
+		db := database.NewMockDB()
+		ctx, _, _ := fakeUser(t, context.Background(), db, false)
+
+		runMustBeSiteAdminTest(t, []any{"outboundWebhooks"}, &Test{
+			Context: ctx,
+			Schema:  mustParseGraphQLSchema(t, db),
+			Query: `
+				{
+					outboundWebhooks {
+						nodes {
+							url
+						}
+						totalCount
+						pageInfo {
+							hasNextPage
+						}
+					}
+				}
+			`,
+		})
+	})
+
+	t.Run("site admin", func(t *testing.T) {
+		t.Parallel()
+
+		for name, tc := range map[string]struct {
+			params    string
+			first     int32
+			after     int32
+			eventType string
+		}{
+			"first only": {
+				params: `first: 2`,
+				first:  2,
+			},
+			"first and after": {
+				params: `first: 2, after: "1"`,
+				first:  2,
+				after:  1,
+			},
+			"event type": {
+				params:    `first:2, eventType: "foo"`,
+				first:     2,
+				eventType: "foo",
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				assertEventTypes := func(t *testing.T, have []string) {
+					t.Helper()
+
+					if tc.eventType == "" {
+						assert.Empty(t, have)
+					} else {
+						assert.Equal(t, []string{tc.eventType}, have)
+					}
+				}
+
+				store := database.NewMockOutboundWebhookStore()
+				store.CountFunc.SetDefaultHook(func(ctx context.Context, opts database.OutboundWebhookCountOpts) (int64, error) {
+					assertEventTypes(t, opts.EventTypes)
+					return 4, nil
+				})
+				store.ListFunc.SetDefaultHook(func(ctx context.Context, opts database.OutboundWebhookListOpts) ([]*types.OutboundWebhook, error) {
+					// The limit is +1 because the resolver adds an extra item
+					// for pagination purposes.
+					assert.EqualValues(t, tc.first+1, opts.Limit)
+					assert.EqualValues(t, tc.after, opts.Offset)
+					assertEventTypes(t, opts.EventTypes)
+
+					return []*types.OutboundWebhook{
+						{URL: encryption.NewUnencrypted("http://example.com/1")},
+						{URL: encryption.NewUnencrypted("http://example.com/2")},
+						{URL: encryption.NewUnencrypted("http://example.com/3")},
+					}, nil
+				})
+
+				db := database.NewMockDB()
+				db.OutboundWebhooksFunc.SetDefaultReturn(store)
+				ctx, _, _ := fakeUser(t, context.Background(), db, true)
+
+				RunTest(t, &Test{
+					Context: ctx,
+					Schema:  mustParseGraphQLSchema(t, db),
+					Query: `
+						{
+							outboundWebhooks(` + tc.params + `) {
+								nodes {
+									url
+								}
+								totalCount
+								pageInfo {
+									hasNextPage
+								}
+							}
+						}
+					`,
+					ExpectedResult: `
+						{
+							"outboundWebhooks": {
+								"nodes": [
+									{
+										"url": "http://example.com/1"
+									},
+									{
+										"url": "http://example.com/2"
+									}
+								],
+								"totalCount": 4,
+								"pageInfo": {
+									"hasNextPage": true
+								}
+							}
+						}
+					`,
+				})
+
+				mockassert.CalledOnce(t, store.CountFunc)
+				mockassert.CalledOnce(t, store.ListFunc)
+			})
+		}
+	})
+}
+
+func TestSchemaResolver_OutboundWebhookEventTypes(t *testing.T) {
+	t.Run("not site admin", func(t *testing.T) {
+		db := database.NewMockDB()
+		ctx, _, _ := fakeUser(t, context.Background(), db, false)
+
+		runMustBeSiteAdminTest(t, []any{"outboundWebhookEventTypes"}, &Test{
+			Context: ctx,
+			Schema:  mustParseGraphQLSchema(t, db),
+			Query: `
+				{
+					outboundWebhookEventTypes {
+						key
+						description
+					}
+				}
+			`,
+		})
+	})
+
+	t.Run("site admin", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			eventTypes []outbound.EventType
+			want       string
+		}{
+			"empty": {
+				eventTypes: []outbound.EventType{},
+				want:       `{"outboundWebhookEventTypes":[]}`,
+			},
+			"not empty": {
+				eventTypes: []outbound.EventType{
+					{Key: "test:a", Description: "a test"},
+					{Key: "test:b", Description: "b test"},
+				},
+				want: `
+					{
+						"outboundWebhookEventTypes": [
+							{
+								"key": "test:a",
+								"description": "a test"
+							},
+							{
+								"key": "test:b",
+								"description": "b test"
+							}
+						]
+					}
+				`,
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				outbound.MockGetRegisteredEventTypes = func() []outbound.EventType {
+					return tc.eventTypes
+				}
+				t.Cleanup(func() {
+					outbound.MockGetRegisteredEventTypes = nil
+				})
+
+				db := database.NewMockDB()
+				ctx, _, _ := fakeUser(t, context.Background(), db, true)
+
+				RunTest(t, &Test{
+					Context: ctx,
+					Schema:  mustParseGraphQLSchema(t, db),
+					Query: `
+						{
+							outboundWebhookEventTypes {
+								key
+								description
+							}
+						}
+					`,
+					ExpectedResult: tc.want,
+				})
+			})
+		}
+	})
+}
+
+func TestSchemaResolver_CreateOutboundWebhook(t *testing.T) {
+	t.Parallel()
+
+	var (
+		url       = "http://example.com"
+		secret    = "super secret"
+		eventType = "test:event"
+		inputVars = map[string]any{
+			"input": map[string]any{
+				"url":    url,
+				"secret": secret,
+				"eventTypes": []any{
+					map[string]any{"eventType": eventType},
+				},
+			},
+		}
+	)
+
+	t.Run("not site admin", func(t *testing.T) {
+		t.Parallel()
+
+		db := database.NewMockDB()
+		ctx, _, _ := fakeUser(t, context.Background(), db, false)
+
+		runMustBeSiteAdminTest(t, []any{"createOutboundWebhook"}, &Test{
+			Context: ctx,
+			Schema:  mustParseGraphQLSchema(t, db),
+			Query: `
+				mutation CreateOutboundWebhook($input: OutboundWebhookCreateInput!) {
+					createOutboundWebhook(input: $input) {
+						id
+					}
+				}
+			`,
+			Variables: inputVars,
+		})
+	})
+
+	t.Run("site admin", func(t *testing.T) {
+		t.Parallel()
+
+		store := database.NewMockOutboundWebhookStore()
+		store.CreateFunc.SetDefaultHook(func(ctx context.Context, webhook *types.OutboundWebhook) error {
+			valueOf := func(e *encryption.Encryptable) string {
+				t.Helper()
+
+				value, err := e.Decrypt(ctx)
+				require.NoError(t, err)
+
+				return value
+			}
+
+			assert.Equal(t, url, valueOf(webhook.URL))
+			assert.Equal(t, secret, valueOf(webhook.Secret))
+			assert.Equal(t, []types.OutboundWebhookEventType{
+				{EventType: eventType},
+			}, webhook.EventTypes)
+
+			webhook.ID = 1
+			return nil
+		})
+
+		db := database.NewMockDB()
+		db.OutboundWebhooksFunc.SetDefaultReturn(store)
+		ctx, _, _ := fakeUser(t, context.Background(), db, true)
+
+		RunTest(t, &Test{
+			Context: ctx,
+			Schema:  mustParseGraphQLSchema(t, db),
+			Query: `
+				mutation CreateOutboundWebhook($input: OutboundWebhookCreateInput!) {
+					createOutboundWebhook(input: $input) {
+						id
+						url
+						eventTypes {
+							eventType
+						}
+					}
+				}
+			`,
+			Variables: inputVars,
+			ExpectedResult: `
+				{
+					"createOutboundWebhook": {
+						"id": "T3V0Ym91bmRXZWJob29rOjE=",
+						"url": "` + url + `",
+						"eventTypes": [
+							{
+								"eventType": "` + eventType + `"
+							}
+						]
+					}
+				}
+			`,
+		})
+
+		mockassert.CalledOnce(t, store.CreateFunc)
+	})
+}
+
+func TestSchemaResolver_DeleteOutboundWebhook(t *testing.T) {
+	t.Parallel()
+
+	// Outbound webhook ID 1.
+	id := "T3V0Ym91bmRXZWJob29rOjE="
+
+	t.Run("not site admin", func(t *testing.T) {
+		t.Parallel()
+
+		db := database.NewMockDB()
+		ctx, _, _ := fakeUser(t, context.Background(), db, false)
+
+		runMustBeSiteAdminTest(t, []any{"deleteOutboundWebhook"}, &Test{
+			Context: ctx,
+			Schema:  mustParseGraphQLSchema(t, db),
+			Query: `
+				mutation DeleteOutboundWebhook($id: ID!) {
+					deleteOutboundWebhook(id: $id) {
+						alwaysNil
+					}
+				}
+			`,
+			Variables: map[string]any{"id": id},
+		})
+	})
+
+	t.Run("site admin", func(t *testing.T) {
+		t.Parallel()
+
+		store := database.NewMockOutboundWebhookStore()
+		store.DeleteFunc.SetDefaultHook(func(ctx context.Context, id int64) error {
+			assert.EqualValues(t, 1, id)
+			return nil
+		})
+
+		db := database.NewMockDB()
+		db.OutboundWebhooksFunc.SetDefaultReturn(store)
+		ctx, _, _ := fakeUser(t, context.Background(), db, true)
+
+		RunTest(t, &Test{
+			Context: ctx,
+			Schema:  mustParseGraphQLSchema(t, db),
+			Query: `
+				mutation DeleteOutboundWebhook($id: ID!) {
+					deleteOutboundWebhook(id: $id) {
+						alwaysNil
+					}
+				}
+			`,
+			Variables: map[string]any{"id": id},
+			ExpectedResult: `
+				{
+					"deleteOutboundWebhook": {
+						"alwaysNil": null
+					}
+				}
+			`,
+		})
+
+		mockassert.CalledOnce(t, store.DeleteFunc)
+	})
+}
+
+func TestSchemaResolver_UpdateOutboundWebhook(t *testing.T) {
+	t.Parallel()
+
+	var (
+		id        = "T3V0Ym91bmRXZWJob29rOjE="
+		url       = "http://example.com"
+		eventType = "test:event"
+		inputVars = map[string]any{
+			"id": id,
+			"input": map[string]any{
+				"url": url,
+				"eventTypes": []any{
+					map[string]any{"eventType": eventType},
+				},
+			},
+		}
+	)
+
+	t.Run("not site admin", func(t *testing.T) {
+		t.Parallel()
+
+		db := database.NewMockDB()
+		ctx, _, _ := fakeUser(t, context.Background(), db, false)
+
+		runMustBeSiteAdminTest(t, []any{"updateOutboundWebhook"}, &Test{
+			Context: ctx,
+			Schema:  mustParseGraphQLSchema(t, db),
+			Query: `
+				mutation UpdateOutboundWebhook($id: ID!, $input: OutboundWebhookUpdateInput!) {
+					updateOutboundWebhook(id: $id, input: $input) {
+						id
+					}
+				}
+			`,
+			Variables: inputVars,
+		})
+	})
+
+	t.Run("site admin", func(t *testing.T) {
+		t.Parallel()
+
+		webhook := &types.OutboundWebhook{
+			ID:  1,
+			URL: encryption.NewUnencrypted(url),
+			EventTypes: []types.OutboundWebhookEventType{
+				{EventType: eventType},
+			},
+		}
+
+		store := database.NewMockOutboundWebhookStore()
+
+		// The update happens in a transaction, so we need to mock those methods
+		// as well.
+		store.DoneFunc.SetDefaultReturn(nil)
+		store.TransactFunc.SetDefaultReturn(store, nil)
+
+		store.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int64) (*types.OutboundWebhook, error) {
+			assert.EqualValues(t, 1, webhook.ID)
+			return webhook, nil
+		})
+		store.UpdateFunc.SetDefaultHook(func(ctx context.Context, have *types.OutboundWebhook) error {
+			assert.Same(t, webhook, have)
+			return nil
+		})
+
+		db := database.NewMockDB()
+		db.OutboundWebhooksFunc.SetDefaultReturn(store)
+		ctx, _, _ := fakeUser(t, context.Background(), db, true)
+
+		RunTest(t, &Test{
+			Context: ctx,
+			Schema:  mustParseGraphQLSchema(t, db),
+			Query: `
+				mutation UpdateOutboundWebhook($id: ID!, $input: OutboundWebhookUpdateInput!) {
+					updateOutboundWebhook(id: $id, input: $input) {
+						id
+						url
+						eventTypes {
+							eventType
+						}
+					}
+				}
+			`,
+			Variables: inputVars,
+			ExpectedResult: `
+				{
+					"updateOutboundWebhook": {
+						"id": "T3V0Ym91bmRXZWJob29rOjE=",
+						"url": "` + url + `",
+						"eventTypes": [
+							{
+								"eventType": "` + eventType + `"
+							}
+						]
+					}
+				}
+			`,
+		})
+
+		mockassert.CalledOnce(t, store.GetByIDFunc)
+		mockassert.CalledOnce(t, store.UpdateFunc)
+	})
+}
+
+var fakeUserID int32
+
+func fakeUser(t *testing.T, inputCtx context.Context, db *database.MockDB, siteAdmin bool) (ctx context.Context, user *types.User, store *database.MockUserStore) {
+	t.Helper()
+
+	user = &types.User{
+		ID:        atomic.AddInt32(&fakeUserID, 1),
+		SiteAdmin: siteAdmin,
+	}
+
+	store = database.NewMockUserStore()
+	store.GetByCurrentAuthUserFunc.SetDefaultReturn(user, nil)
+	db.UsersFunc.SetDefaultReturn(store)
+
+	ctx = actor.WithActor(inputCtx, &actor.Actor{UID: user.ID})
+
+	return
+}
+
+func runMustBeSiteAdminTest(t *testing.T, path []any, test *Test) {
+	t.Helper()
+
+	// Check that the test doesn't already have expectations.
+	require.Empty(t, test.ExpectedErrors)
+	require.Empty(t, test.ExpectedResult)
+
+	test.ExpectedErrors = []*gqlerrors.QueryError{
+		{
+			Message: "must be site admin",
+			Path:    path,
+		},
+	}
+
+	// Yes, the literal string "null".
+	test.ExpectedResult = "null"
+
+	RunTest(t, test)
+}

--- a/cmd/frontend/graphqlbackend/outbound_webhooks_test.go
+++ b/cmd/frontend/graphqlbackend/outbound_webhooks_test.go
@@ -70,13 +70,13 @@ func TestSchemaResolver_OutboundWebhooks(t *testing.T) {
 			},
 		} {
 			t.Run(name, func(t *testing.T) {
-				assertEventTypes := func(t *testing.T, have []string) {
+				assertEventTypes := func(t *testing.T, have []database.FilterEventType) {
 					t.Helper()
 
 					if tc.eventType == "" {
 						assert.Empty(t, have)
 					} else {
-						assert.Equal(t, []string{tc.eventType}, have)
+						assert.Equal(t, []database.FilterEventType{{EventType: tc.eventType}}, have)
 					}
 				}
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -63,3 +63,8 @@ var notebooksSchema string
 //
 //go:embed insights_aggregations.graphql
 var insightsAggregationsSchema string
+
+// outboundWebhooksSchema is the outbound webhook raw GraphQL schema.
+//
+//go:embed outbound_webhooks.graphql
+var outboundWebhooksSchema string

--- a/internal/webhooks/outbound/event_types.go
+++ b/internal/webhooks/outbound/event_types.go
@@ -15,14 +15,20 @@ type eventTypes struct {
 var registeredEventTypes = eventTypes{types: []EventType{}}
 
 func GetRegisteredEventTypes() (types []EventType) {
+	if MockGetRegisteredEventTypes != nil {
+		return MockGetRegisteredEventTypes()
+	}
+
 	registeredEventTypes.RLock()
 	defer registeredEventTypes.RUnlock()
 
 	return append(types, registeredEventTypes.types...)
 }
 
-// RegisterEventType registers a new outbound webhook event type, thereby making it
-// available in the webhook admin UI.
+var MockGetRegisteredEventTypes func() []EventType
+
+// RegisterEventType registers a new outbound webhook event type, thereby making
+// it available in the webhook admin UI.
 //
 // It is generally expected that this will be invoked from init() functions. It MUST NOT
 // be invoked before init().


### PR DESCRIPTION
This is part 5 of #38278.

This PR adds the GraphQL schema and resolvers required for the site admin UI for outbound webhooks.

As a matter of taste, I've split the schema into a separate file, even though this work is not inherently enterprise licensed. It just felt cleaner.

Node resolvers have intentionally not been added for `OutboundWebhookJob` and `OutboundWebhookLog`; it's presently hard to imagine a scenario in which it would make sense to directly retrieve either, and this (slightly) reduces the API surface area.

As noted in #46010, there's some reuse of existing code here around `WebhookLogMessage` and friends. A HTTP message is ultimately a HTTP message. (And, honestly, I always secretly hoped I'd get to reuse the work I did in #27179 for outbound webhooks. I just didn't expect it to take over a year!)

## Test plan

This has good unit test coverage for the resolvers. Functional testing has happened as part of #45833.