### PR TITLE
Note differences in sourcegraph.com

### DIFF
--- a/doc/dotcom/index.md
+++ b/doc/dotcom/index.md
@@ -6,7 +6,7 @@ To use Sourcegraph on your own (private) code, [use Sourcegraph Cloud](../cloud/
 
 - [Indexing open source code in Sourcegraph.com](indexing_open_source_code.md)
 
-> Note: Sourcegraph dotcom indexes and allows search over a lot of code for a lot of users! For this reason sourcegraph handles some features in dotcom differently.
+> Note: Sourcegraph.com is a special instance of Sourcegraph with some different behavior compared to that on Sourcegraph Cloud and self-hosted instances. If you're curious about the differences, search our codebase for [`envvar.SourcegraphDotComMode()`](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+envvar.SourcegraphDotComMode%28%29&patternType=standard&sm=1).
 >
 > For example, global searches do not search unindexed code by default on sourcegraph.com, whereas on a cloud or self-hosted instance this isn't the case.
 > 

--- a/doc/dotcom/index.md
+++ b/doc/dotcom/index.md
@@ -5,3 +5,9 @@
 To use Sourcegraph on your own (private) code, [use Sourcegraph Cloud](../cloud/index.md) or [deploy self-hosted Sourcegraph](../admin/deploy/index.md).
 
 - [Indexing open source code in Sourcegraph.com](indexing_open_source_code.md)
+
+> Note: Sourcegraph dotcom indexes and allows search over a lot of code for a lot of users! For this reason sourcegraph handles some features in dotcom differently.
+>
+> For example, global searches do not search unindexed code by default on sourcegraph.com, whereas on a cloud or self-hosted instance this isn't the case.
+> 
+> To learn more about where dotcom handles things differently checkout use of the [SourcegraphDotcomMode](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+if+envvar.SourcegraphDotComMode%28%29&patternType=standard&sm=1) env var in our codebase!


### PR DESCRIPTION
This is a minor note to inform users that sourcegraph.com handles some sourcegraph functions differently -- mainly this is meant to be pointed to in cases where an admin expects the same results on a cloud or self-hosted instances they get on dotcom

## Test plan
doc update

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
