### PR TITLE
graphqlbackend: Simplify external service availability API

### DIFF
--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -135,14 +135,8 @@ export const EXTERNAL_SERVICE_CHECK_CONNECTION_BY_ID = gql`
                 hasConnectionCheck
                 checkConnection {
                     __typename
-                    ... on ExternalServiceAvailable {
-                        lastCheckedAt
-                    }
                     ... on ExternalServiceUnavailable {
                         suspectedReason
-                    }
-                    ... on ExternalServiceAvailabilityUnknown {
-                        implementationNote
                     }
                 }
             }

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -39,9 +39,9 @@ type externalServiceResolver struct {
 }
 
 type availabilityState struct {
-	available   *externalServiceAvailable
-	unavailable *externalServiceUnavailable
-	unknown     *externalServiceUnknown
+	available      *externalServiceAvailable
+	unavailable    *externalServiceUnavailable
+	notImplemented *externalServiceNotImplemented
 }
 
 type externalServiceAvailable struct {
@@ -52,7 +52,7 @@ type externalServiceUnavailable struct {
 	suspectedReason string
 }
 
-type externalServiceUnknown struct{}
+type externalServiceNotImplemented struct{}
 
 const externalServiceIDKind = "ExternalService"
 
@@ -227,7 +227,7 @@ func (r *externalServiceResolver) CheckConnection(ctx context.Context) (*externa
 
 	if !r.HasConnectionCheck() {
 		r.availability = availabilityState{
-			unknown: &externalServiceUnknown{},
+			notImplemented: &externalServiceNotImplemented{},
 		}
 
 		return r, nil
@@ -255,9 +255,7 @@ func (r *externalServiceResolver) CheckConnection(ctx context.Context) (*externa
 	}
 
 	r.availability = availabilityState{
-		available: &externalServiceAvailable{
-			lastCheckedAt: time.Now(),
-		},
+		available: &externalServiceAvailable{},
 	}
 
 	return r, nil
@@ -273,23 +271,14 @@ func (r *externalServiceResolver) ToExternalServiceAvailable() (*externalService
 
 func (r *externalServiceResolver) ToExternalServiceUnavailable() (*externalServiceResolver, bool) {
 	return r, r.availability.unavailable != nil
-
 }
 
-func (r *externalServiceResolver) ToExternalServiceAvailabilityUnknown() (*externalServiceResolver, bool) {
-	return r, r.availability.unknown != nil
-}
-
-func (r *externalServiceResolver) LastCheckedAt() (gqlutil.DateTime, error) {
-	return gqlutil.DateTime{Time: r.availability.available.lastCheckedAt}, nil
+func (r *externalServiceResolver) ToExternalServiceAvailabilityNotImplemented() (*externalServiceResolver, bool) {
+	return r, r.availability.notImplemented != nil
 }
 
 func (r *externalServiceResolver) SuspectedReason() (string, error) {
 	return r.availability.unavailable.suspectedReason, nil
-}
-
-func (r *externalServiceResolver) ImplementationNote() string {
-	return "not implemented"
 }
 
 func (r *externalServiceResolver) SupportsRepoExclusion() bool {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2834,7 +2834,7 @@ type ExternalService implements Node {
     """
     True if this external service can perform availability check by running checkConnection.
 
-    If this is false, then checkConnection responds with ExternalServiceAvailabilityUnknown.
+    If this is false, then checkConnection responds with ExternalServiceAvailabilityNotImplemented.
     """
     hasConnectionCheck: Boolean!
 
@@ -2853,17 +2853,14 @@ can serve requests, and if not, why is the reason for that.
 union ExternalServiceAvailability =
       ExternalServiceAvailable
     | ExternalServiceUnavailable
-    | ExternalServiceAvailabilityUnknown
+    | ExternalServiceAvailabilityNotImplemented
 
 """
-Indicator that the external service was recently found to be available.
+Indicator that the external service was found to be available after running
+some connection checks like DNS lookup and a connectivity check to the host:port
+of the code host.
 """
-type ExternalServiceAvailable {
-    """
-    The timestamp of the last successful availability check that was performed.
-    """
-    lastCheckedAt: DateTime!
-}
+type ExternalServiceAvailable
 
 """
 Indicator that the external service was recently not found available.
@@ -2876,16 +2873,9 @@ type ExternalServiceUnavailable {
 }
 
 """
-Availability for some external services may not be determined, or only partially
-supported. In that case unknown variant of ExternalServiceAvailability is returned.
+Availability checks for some external service types may not have been implemented.
 """
-type ExternalServiceAvailabilityUnknown {
-    """
-    User-friendly textual description of the implementation status of availablity.
-    This is expected to be tied to specific kinds of external services.
-    """
-    implementationNote: String!
-}
+type ExternalServiceAvailabilityNotImplemented
 
 """
 A list of external service sync jobs.


### PR DESCRIPTION
Follow up to #45972 where eventually we stopped using `lastCheckedAt` as it felt unnecessary after a certain point based on how the UI evolved.

Part of #44683.

The API has not been released and is only used in the one place in our codebase which has also been updated. Now is the right time to make breaking changes to this API. 🧨


## Test plan

1. Tested locally
1. Builds should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
