### PR TITLE
externalServices: Stop fetching fields that are not needed

### DIFF
--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -135,14 +135,8 @@ export const EXTERNAL_SERVICE_CHECK_CONNECTION_BY_ID = gql`
                 hasConnectionCheck
                 checkConnection {
                     __typename
-                    ... on ExternalServiceAvailable {
-                        lastCheckedAt
-                    }
                     ... on ExternalServiceUnavailable {
                         suspectedReason
-                    }
-                    ... on ExternalServiceAvailabilityUnknown {
-                        implementationNote
                     }
                 }
             }


### PR DESCRIPTION
Part #44683 but does not block its completion. This is a cleanup / make things nicer PR.

We only check on the __typename for availability. And that is good enough.

I attempted to also simplify the GraphQL API in #46024 but it turns out object types with no fields are not allowed (TIL). There's an ongoing discussion [here](https://github.com/graphql/graphql-spec/issues/568) but doesn't look like it's close to happening anytime soon.

While stuff works in #46024, I started seeing linting failures which made me dig deeper and I attempted for a little more than an hour to wrangle with it. Here's what I tried in addition to the changes in #46024 but didn't commit:

Convert `ExternalServiceAvailability` into an `enum` and get rid of `ExternalServiceAvailabilityNotImplemented` altogether. But this does not work because we need to add another string variable for `suspectedReason`. Which then makes it quite dirtier and the current version looks cleaner compared to that.

Happy to hear additional thoughts on what we can do on the API.

## Test plan

1. Tested the "test connection" feature locally
1. Builds should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ig-simplify-api-call.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
