### PR TITLE
externalServices: Better tooltip description of test button

### DIFF
--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -145,7 +145,11 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                 </div>
                 <div className="flex-shrink-0 ml-3">
                     <Tooltip
-                        content={node.hasConnectionCheck ? 'Test code host connection' : 'Connection check unavailable'}
+                        content={
+                            node.hasConnectionCheck
+                                ? 'Test if code host is reachable from Sourcegraph'
+                                : 'Connection check unavailable'
+                        }
                     >
                         <Button
                             className="test-connection-external-service-button"


### PR DESCRIPTION
Part of #44683

Follow up to https://github.com/sourcegraph/sourcegraph/pull/45972#discussion_r1059940281.




## Test plan

Tested locally.

<img width="969" alt="image" src="https://user-images.githubusercontent.com/2682729/210223952-7e9e7ee1-86e9-4ab6-81c4-395aeacca9d2.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ig-better-button-tooltip-v2.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
