### PR TITLE
use term `code host` instead of `external service` `ExternalServicePage` component

### DIFF
--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -184,9 +184,9 @@ export const ExternalServicePage: React.FunctionComponent<React.PropsWithChildre
     return (
         <div>
             {externalService ? (
-                <PageTitle title={`External service - ${externalService.displayName}`} />
+                <PageTitle title={`Code host - ${externalService.displayName}`} />
             ) : (
-                <PageTitle title="External service" />
+                <PageTitle title="Code host" />
             )}
             <H2>Update code host connection {combinedLoading && <LoadingSpinner inline={true} />}</H2>
             {combinedError !== undefined && !combinedLoading && <ErrorAlert className="mb-3" error={combinedError} />}


### PR DESCRIPTION
This is a preferred wording to use on UI.

Test plan:
No functional change, CI.

## App preview:

- [Web](https://sg-web-ao-ui-use-code-host-naming.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
