### PR TITLE
Update linter script: go unused linters, but only report warning and never fails builds. 

### DIFF
--- a/.golangci-warn.yml
+++ b/.golangci-warn.yml
@@ -2,57 +2,7 @@
 linters:
   disable-all: true
   enable:
-    - bodyclose
-    - depguard
-    - forbidigo
-    - gocritic
-    - goimports
-    - gosimple
-    - govet
-    - ineffassign
-    - nolintlint
-    - staticcheck
-    - typecheck
-    - unconvert
-    # - unused
-    - unparam
-    - exportloopref
-
-linters-settings:
-  depguard:
-    list-type: denylist
-    include-go-root: true
-    packages-with-error-message:
-      # Deprecated packages
-      - io/ioutil: "The ioutil package has been deprecated"
-      # Blacklisted error packages
-      - errors: "Use github.com/sourcegraph/sourcegraph/lib/errors instead"
-      - github.com/pkg/errors: "Use github.com/sourcegraph/sourcegraph/lib/errors instead"
-      - github.com/cockroachdb/errors: "Use github.com/sourcegraph/sourcegraph/lib/errors instead"
-      - github.com/hashicorp/go-multierror: "Use github.com/sourcegraph/sourcegraph/lib/errors instead"
-      # More performant regexp
-      - regexp: "Use github.com/grafana/regexp instead"
-  gocritic:
-    disabled-checks:
-      - appendAssign # Too many false positives
-      - assignOp # Maybe worth adding, but likely not worth the noise
-      - commentFormatting # No strong benefit
-      - deprecatedComment # Unnecessary
-      - exitAfterDefer # Only occurs in auxiliary tools
-      - ifElseChain # Noisy for not much gain
-      - singleCaseSwitch # Noisy for not much gain
-  unparam:
-
-  govet:
-    disable:
-      - composites
-  staticcheck:
-    checks:
-      - "all"
-  forbidigo:
-    forbid:
-      # Use errors.Newf instead
-      - '^fmt\.Errorf$'
+    - unused
 
 issues:
   exclude-rules:

--- a/dev/check/go-lint.sh
+++ b/dev/check/go-lint.sh
@@ -46,7 +46,7 @@ run() {
 
   if [ $EXIT_CODE_WARN -ne 0 ]; then
     mkdir -p "$base/annotations"
-    echo -e "$OUT" >>"$base/annotations/go-lint-warnings"
+    echo -e "$OUT" >>"$base/annotations/WARN_go-lint"
     echo "^^^ +++"
   fi
 }

--- a/dev/check/go-lint.sh
+++ b/dev/check/go-lint.sh
@@ -42,10 +42,12 @@ run() {
   OUT=$("$lint_script" --config "$config_file_warn" run "$LINTER_ARG")
   EXIT_CODE_WARN=$?
   set -e
+  echo "--- golangci-lint (failing issues)"
   echo -e "$OUT"
 
   if [ $EXIT_CODE_WARN -ne 0 ]; then
     mkdir -p "$base/annotations"
+    echo "--- golangci-lint (warning issues)"
     echo -e "$OUT" >>"$base/annotations/WARN_go-lint"
     echo "^^^ +++"
   fi

--- a/dev/check/go-lint.sh
+++ b/dev/check/go-lint.sh
@@ -15,9 +15,9 @@ export GOBIN="$PWD/.bin"
 export PATH=$GOBIN:$PATH
 export GO111MODULE=on
 
-config_file="$(pwd)/.golangci.yml"
-config_file_warn="$(pwd)/.golangci-warn.yml"
-lint_script="$(pwd)/dev/golangci-lint.sh"
+config_file="${base}/.golangci.yml"
+config_file_warn="${base}/.golangci-warn.yml"
+lint_script="${base}/dev/golangci-lint.sh"
 
 run() {
   LINTER_ARG=${1}
@@ -42,12 +42,11 @@ run() {
   OUT=$("$lint_script" --config "$config_file_warn" run "$LINTER_ARG")
   EXIT_CODE_WARN=$?
   set -e
-  echo "--- golangci-lint (failing issues)"
+
   echo -e "$OUT"
 
   if [ $EXIT_CODE_WARN -ne 0 ]; then
     mkdir -p "$base/annotations"
-    echo "--- golangci-lint (warning issues)"
     echo -e "$OUT" >>"$base/annotations/WARN_go-lint"
     echo "^^^ +++"
   fi

--- a/dev/sg/internal/check/category.go
+++ b/dev/sg/internal/check/category.go
@@ -13,6 +13,10 @@ type Check[Args any] struct {
 	Name string
 	// Description can be used to provide additional context and manual fix instructions.
 	Description string
+	// LegacyAnnotations disables the automatic creation of annotations in the case of legacy
+	// scripts that are handling them on their own.
+	// Ex: ./dev/check/go-lint.sh
+	LegacyAnnotations bool
 
 	// Enabled can be implemented to indicate when this check should be skipped.
 	Enabled EnableFunc[Args]

--- a/dev/sg/internal/check/runner.go
+++ b/dev/sg/internal/check/runner.go
@@ -456,7 +456,7 @@ func (r *Runner[Args]) runAllCategoryChecks(ctx context.Context, args Args) *run
 						annotationSummary += fmt.Sprintf("\n\n%s", suggestion)
 					}
 
-					if r.GenerateAnnotations {
+					if r.GenerateAnnotations && !check.LegacyAnnotations {
 						generateAnnotation(category.Name, check.Name, annotationSummary)
 					}
 				}

--- a/dev/sg/linters/go_checks.go
+++ b/dev/sg/linters/go_checks.go
@@ -20,7 +20,7 @@ var (
 )
 
 func goLint() *linter {
-	return runCheck("Go lint", func(ctx context.Context, out *std.Output, args *repo.State) error {
+	check := runCheck("Go lint", func(ctx context.Context, out *std.Output, args *repo.State) error {
 		return root.Run(run.Bash(ctx, "dev/check/go-lint.sh")).
 			Map(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
 				// Ignore go mod download stuff
@@ -31,6 +31,8 @@ func goLint() *linter {
 			}).
 			StreamLines(out.Write)
 	})
+	check.LegacyAnnotations = true
+	return check
 }
 
 func lintSGExit() *linter {

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -27,6 +27,7 @@ func main() {
 	// Do not add initialization here, do all setup in sg.Before - this is a necessary
 	// workaround because we don't have control over the bash completion flag, which is
 	// part of urfave/cli internals.
+	// TRIGGER SOME GO CHANGE
 	if os.Args[len(os.Args)-1] == "--generate-bash-completion" {
 		bashCompletionsMode = true
 	}

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -27,7 +27,6 @@ func main() {
 	// Do not add initialization here, do all setup in sg.Before - this is a necessary
 	// workaround because we don't have control over the bash completion flag, which is
 	// part of urfave/cli internals.
-	// TRIGGER SOME GO CHANGE
 	if os.Args[len(os.Args)-1] == "--generate-bash-completion" {
 		bashCompletionsMode = true
 	}

--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -258,6 +258,13 @@ const (
 	AnnotationTypeInfo    AnnotationType = "info"
 	AnnotationTypeWarning AnnotationType = "warning"
 	AnnotationTypeError   AnnotationType = "error"
+	// AnnotationTypeAuto lets the annotated-cmd.sh script guess the annotation type
+	// based on the filename, e.g:
+	// - If file starts with "WARN_", it's a warning.
+	// - If file starts with "ERROR_", it's an error.
+	// - ...
+	// - Defaults to error if no prefix is present.
+	AnnotationTypeAuto AnnotationType = "auto"
 )
 
 type AnnotationOpts struct {

--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -357,11 +357,11 @@ func AnnotatedCmd(command string, opts AnnotatedCmdOpts) StepOpt {
 	// Options for annotations
 	var annotateOpts string
 	if opts.Annotations != nil {
-		// if opts.Annotations.Type == "" {
-		// 	annotateOpts += fmt.Sprintf(" -t %s", AnnotationTypeError)
-		// } else {
-		// 	annotateOpts += fmt.Sprintf(" -t %s", opts.Annotations.Type)
-		// }
+		if opts.Annotations.Type == "" {
+			annotateOpts += fmt.Sprintf(" -t %s", AnnotationTypeError)
+		} else {
+			annotateOpts += fmt.Sprintf(" -t %s", opts.Annotations.Type)
+		}
 		if opts.Annotations.MultiJobContext != "" {
 			annotateOpts += fmt.Sprintf(" -c %q", opts.Annotations.MultiJobContext)
 		}

--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -350,11 +350,11 @@ func AnnotatedCmd(command string, opts AnnotatedCmdOpts) StepOpt {
 	// Options for annotations
 	var annotateOpts string
 	if opts.Annotations != nil {
-		if opts.Annotations.Type == "" {
-			annotateOpts += fmt.Sprintf(" -t %s", AnnotationTypeError)
-		} else {
-			annotateOpts += fmt.Sprintf(" -t %s", opts.Annotations.Type)
-		}
+		// if opts.Annotations.Type == "" {
+		// 	annotateOpts += fmt.Sprintf(" -t %s", AnnotationTypeError)
+		// } else {
+		// 	annotateOpts += fmt.Sprintf(" -t %s", opts.Annotations.Type)
+		// }
 		if opts.Annotations.MultiJobContext != "" {
 			annotateOpts += fmt.Sprintf(" -c %q", opts.Annotations.MultiJobContext)
 		}

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -131,7 +131,10 @@ func addSgLints(targets []string) func(pipeline *bk.Pipeline) {
 		pipeline.AddStep(":pineapple::lint-roller: Run sg lint",
 			withYarnCache(),
 			bk.AnnotatedCmd(cmd, bk.AnnotatedCmdOpts{
-				Annotations: &bk.AnnotationOpts{IncludeNames: true},
+				Annotations: &bk.AnnotationOpts{
+					IncludeNames: true,
+					Type:         bk.AnnotationTypeAuto,
+				},
 			}))
 	}
 }

--- a/enterprise/dev/ci/scripts/annotated-command.sh
+++ b/enterprise/dev/ci/scripts/annotated-command.sh
@@ -48,11 +48,11 @@ if [ -n "${ANNOTATE_OPTS-''}" ]; then
     esac
 
     case "$name" in
-      "WARN_*") annotate_file_opts="$annotate_file_opts -t warning" ;;
-      "ERROR_*") annotate_file_opts="$annotate_file_opts -t error" ;;
-      "INFO_*") annotate_file_opts="$annotate_file_opts -t info" ;;
-      "SUCCESS_*") annotate_file_opts="$annotate_file_opts -t success" ;;
-      "*") annotate_file_opts="$annotate_file_opts -t error" ;;
+      WARN_*) annotate_file_opts="$annotate_file_opts -t warning" && echo "WARN" ;;
+      ERROR_*) annotate_file_opts="$annotate_file_opts -t error" ;;
+      INFO_*) annotate_file_opts="$annotate_file_opts -t info" ;;
+      SUCCESS_*) annotate_file_opts="$annotate_file_opts -t success" ;;
+      *) annotate_file_opts="$annotate_file_opts -t error" ;;
     esac
 
     if [ "$include_names" = "true" ]; then

--- a/enterprise/dev/ci/scripts/annotated-command.sh
+++ b/enterprise/dev/ci/scripts/annotated-command.sh
@@ -30,6 +30,11 @@ if [ -n "${ANNOTATE_OPTS-''}" ]; then
   shift 1
   # shellcheck disable=SC2124
   annotate_opts="$@"
+  auto_type=false
+  if [[ "$annotate_opts" == *"-t auto"* ]]; then
+    auto_type=true
+    annotate_opts=${annotate_opts/"-t auto"//}
+  fi
 
   echo "~~~ Uploading annotations"
   echo "include_names=$include_names, annotate_opts=$annotate_opts"
@@ -47,13 +52,15 @@ if [ -n "${ANNOTATE_OPTS-''}" ]; then
       *.md) annotate_file_opts="$annotate_file_opts -m" && name="${name%.*}" ;;
     esac
 
-    case "$name" in
-      WARN_*) annotate_file_opts="$annotate_file_opts -t warning" ;;
-      ERROR_*) annotate_file_opts="$annotate_file_opts -t error" ;;
-      INFO_*) annotate_file_opts="$annotate_file_opts -t info" ;;
-      SUCCESS_*) annotate_file_opts="$annotate_file_opts -t success" ;;
-      *) annotate_file_opts="$annotate_file_opts -t error" ;;
-    esac
+    if [ "$auto_type" = true ]; then
+      case "$name" in
+        WARN_*) annotate_file_opts="$annotate_file_opts -t warning" ;;
+        ERROR_*) annotate_file_opts="$annotate_file_opts -t error" ;;
+        INFO_*) annotate_file_opts="$annotate_file_opts -t info" ;;
+        SUCCESS_*) annotate_file_opts="$annotate_file_opts -t success" ;;
+        *) annotate_file_opts="$annotate_file_opts -t error" ;;
+      esac
+    fi
 
     if [ "$include_names" = "true" ]; then
       # Set the name of the file as the title of this annotation section
@@ -62,7 +69,7 @@ if [ -n "${ANNOTATE_OPTS-''}" ]; then
     fi
 
     # Generate annotation from file contents
-    eval "./enterprise/dev/ci/scripts/annotate.sh $annotate_file_opts <'$file'"
+    # eval "./enterprise/dev/ci/scripts/annotate.sh $annotate_file_opts <'$file'"
   done
 fi
 

--- a/enterprise/dev/ci/scripts/annotated-command.sh
+++ b/enterprise/dev/ci/scripts/annotated-command.sh
@@ -69,7 +69,7 @@ if [ -n "${ANNOTATE_OPTS-''}" ]; then
     fi
 
     # Generate annotation from file contents
-    # eval "./enterprise/dev/ci/scripts/annotate.sh $annotate_file_opts <'$file'"
+    eval "./enterprise/dev/ci/scripts/annotate.sh $annotate_file_opts <'$file'"
   done
 fi
 

--- a/enterprise/dev/ci/scripts/annotated-command.sh
+++ b/enterprise/dev/ci/scripts/annotated-command.sh
@@ -48,11 +48,11 @@ if [ -n "${ANNOTATE_OPTS-''}" ]; then
     esac
 
     case "$name" in
-      "WARN_*") annotate_file_opts="$annotate_file_opts -t warning"
-      "ERROR_*") annotate_file_opts="$annotate_file_opts -t error"
-      "INFO_*") annotate_file_opts="$annotate_file_opts -t info"
-      "SUCCESS_*") annotate_file_opts="$annotate_file_opts -t success"
-      "*") annotate_file_opts="$annotate_file_opts -t error"
+      "WARN_*") annotate_file_opts="$annotate_file_opts -t warning" ;;
+      "ERROR_*") annotate_file_opts="$annotate_file_opts -t error" ;;
+      "INFO_*") annotate_file_opts="$annotate_file_opts -t info" ;;
+      "SUCCESS_*") annotate_file_opts="$annotate_file_opts -t success" ;;
+      "*") annotate_file_opts="$annotate_file_opts -t error" ;;
     esac
 
     if [ "$include_names" = "true" ]; then

--- a/enterprise/dev/ci/scripts/annotated-command.sh
+++ b/enterprise/dev/ci/scripts/annotated-command.sh
@@ -47,6 +47,14 @@ if [ -n "${ANNOTATE_OPTS-''}" ]; then
       *.md) annotate_file_opts="$annotate_file_opts -m" && name="${name%.*}" ;;
     esac
 
+    case "$name" in
+      "WARN_*") annotate_file_opts="$annotate_file_opts -t warning"
+      "ERROR_*") annotate_file_opts="$annotate_file_opts -t error"
+      "INFO_*") annotate_file_opts="$annotate_file_opts -t info"
+      "SUCCESS_*") annotate_file_opts="$annotate_file_opts -t success"
+      "*") annotate_file_opts="$annotate_file_opts -t error"
+    esac
+
     if [ "$include_names" = "true" ]; then
       # Set the name of the file as the title of this annotation section
       annotate_file_opts="-s '$name' $annotate_file_opts"

--- a/enterprise/dev/ci/scripts/annotated-command.sh
+++ b/enterprise/dev/ci/scripts/annotated-command.sh
@@ -47,8 +47,9 @@ if [ -n "${ANNOTATE_OPTS-''}" ]; then
       *.md) annotate_file_opts="$annotate_file_opts -m" && name="${name%.*}" ;;
     esac
 
+    error_level=""
     case "$name" in
-      WARN_*) annotate_file_opts="$annotate_file_opts -t warning" && echo "WARN" ;;
+      WARN_*) annotate_file_opts="$annotate_file_opts -t warning" ;;
       ERROR_*) annotate_file_opts="$annotate_file_opts -t error" ;;
       INFO_*) annotate_file_opts="$annotate_file_opts -t info" ;;
       SUCCESS_*) annotate_file_opts="$annotate_file_opts -t success" ;;
@@ -57,7 +58,8 @@ if [ -n "${ANNOTATE_OPTS-''}" ]; then
 
     if [ "$include_names" = "true" ]; then
       # Set the name of the file as the title of this annotation section
-      annotate_file_opts="-s '$name' $annotate_file_opts"
+      human_name=$(echo "$name" | sed -E -e "s/(WARN_)|(ERROR_)|(INFO_)|(SUCCESS_)//")
+      annotate_file_opts="-s '$human_name' $annotate_file_opts"
     fi
 
     # Generate annotation from file contents

--- a/enterprise/dev/ci/scripts/annotated-command.sh
+++ b/enterprise/dev/ci/scripts/annotated-command.sh
@@ -33,7 +33,7 @@ if [ -n "${ANNOTATE_OPTS-''}" ]; then
   auto_type=false
   if [[ "$annotate_opts" == *"-t auto"* ]]; then
     auto_type=true
-    annotate_opts=${annotate_opts/"-t auto"//}
+    annotate_opts=${annotate_opts/"-t auto"/}
   fi
 
   echo "~~~ Uploading annotations"
@@ -52,7 +52,7 @@ if [ -n "${ANNOTATE_OPTS-''}" ]; then
       *.md) annotate_file_opts="$annotate_file_opts -m" && name="${name%.*}" ;;
     esac
 
-    if [ "$auto_type" = true ]; then
+    if [ "$auto_type" = "true" ]; then
       case "$name" in
         WARN_*) annotate_file_opts="$annotate_file_opts -t warning" ;;
         ERROR_*) annotate_file_opts="$annotate_file_opts -t error" ;;

--- a/enterprise/dev/ci/scripts/annotated-command.sh
+++ b/enterprise/dev/ci/scripts/annotated-command.sh
@@ -47,7 +47,6 @@ if [ -n "${ANNOTATE_OPTS-''}" ]; then
       *.md) annotate_file_opts="$annotate_file_opts -m" && name="${name%.*}" ;;
     esac
 
-    error_level=""
     case "$name" in
       WARN_*) annotate_file_opts="$annotate_file_opts -t warning" ;;
       ERROR_*) annotate_file_opts="$annotate_file_opts -t error" ;;

--- a/enterprise/dev/ci/scripts/annotated-command.sh
+++ b/enterprise/dev/ci/scripts/annotated-command.sh
@@ -46,6 +46,7 @@ if [ -n "${ANNOTATE_OPTS-''}" ]; then
     echo "handling $file"
     name=$(basename "$file")
     annotate_file_opts=$annotate_opts
+    human_level=""
 
     case "$name" in
       # Append markdown annotations as markdown, and remove the suffix from the name
@@ -54,18 +55,33 @@ if [ -n "${ANNOTATE_OPTS-''}" ]; then
 
     if [ "$auto_type" = "true" ]; then
       case "$name" in
-        WARN_*) annotate_file_opts="$annotate_file_opts -t warning" ;;
-        ERROR_*) annotate_file_opts="$annotate_file_opts -t error" ;;
-        INFO_*) annotate_file_opts="$annotate_file_opts -t info" ;;
-        SUCCESS_*) annotate_file_opts="$annotate_file_opts -t success" ;;
-        *) annotate_file_opts="$annotate_file_opts -t error" ;;
+        WARN_*)
+          annotate_file_opts="$annotate_file_opts -t warning"
+          human_level="⚠️ "
+          ;;
+        ERROR_*)
+          annotate_file_opts="$annotate_file_opts -t error"
+          human_level="❌"
+          ;;
+        INFO_*)
+          annotate_file_opts="$annotate_file_opts -t info"
+          human_level="ℹ️ "
+          ;;
+        SUCCESS_*)
+          annotate_file_opts="$annotate_file_opts -t success"
+          human_level="✅"
+          ;;
+        *) 
+          annotate_file_opts="$annotate_file_opts -t error"
+          human_level="❌"
+          ;;
       esac
     fi
 
     if [ "$include_names" = "true" ]; then
       # Set the name of the file as the title of this annotation section
       human_name=$(echo "$name" | sed -E -e "s/(WARN_)|(ERROR_)|(INFO_)|(SUCCESS_)//")
-      annotate_file_opts="-s '$human_name' $annotate_file_opts"
+      annotate_file_opts="-s '$human_level $human_name' $annotate_file_opts"
     fi
 
     # Generate annotation from file contents

--- a/internal/uploadhandler/upload_handler.go
+++ b/internal/uploadhandler/upload_handler.go
@@ -86,7 +86,7 @@ func (h *UploadHandler[T]) handleEnqueue(w http.ResponseWriter, r *http.Request)
 		if err != nil {
 			return nil, statusCode, err
 		}
-		trace.Log( //nolint:staticcheck // Need to convert this to attribute.* methods, might be not so easy with metadata
+		trace.Log( //TODO trigger a lint failure
 			log.Int("uploadID", uploadState.uploadID),
 			log.Int("numParts", uploadState.numParts),
 			log.Int("numUploadedParts", len(uploadState.uploadedParts)),

--- a/internal/uploadhandler/upload_handler.go
+++ b/internal/uploadhandler/upload_handler.go
@@ -86,7 +86,7 @@ func (h *UploadHandler[T]) handleEnqueue(w http.ResponseWriter, r *http.Request)
 		if err != nil {
 			return nil, statusCode, err
 		}
-		trace.Log( //TODO trigger a lint failure
+		trace.Log( //nolint:staticcheck // Need to convert this to attribute.* methods, might be not so easy with metadata
 			log.Int("uploadID", uploadState.uploadID),
 			log.Int("numParts", uploadState.numParts),
 			log.Int("numUploadedParts", len(uploadState.uploadedParts)),


### PR DESCRIPTION
What we want is to have all go linter issues raising an error, with the exception of `unused`. 

Sadly, `golangci-lint` doesn't yet have a way to distinguish warning issues from error level issues. So I created a second config, which is ran after the first error pass to check for `unused` linter issues and report them at the warning level, but without failing the build.

<img width="1229" alt="CleanShot 2023-01-05 at 15 59 51@2x" src="https://user-images.githubusercontent.com/10151/210810466-6e51c9d0-f279-4de1-a74f-853905f90390.png">

<img width="1292" alt="CleanShot 2023-01-05 at 16 13 48@2x" src="https://user-images.githubusercontent.com/10151/210813634-96cc9849-96f9-483e-a059-c7014234b330.png">

---

This took me longer to ship than I thought, the amount of papercuts when QA'ing this is insane. I think this highlights the limits of the current annotation code on top of our scripts, as it doesn't map very well. TL;DR rabbithole. Anyway, it's workign now. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- See https://buildkite.com/sourcegraph/sourcegraph/builds/191837#annotation-0185826a-508a-4608-823a-e657f0dfc852-error for example output.
- Tested with failures + warnings, exit code is 1, as expected. 