### PR TITLE
show JSON hovers, validation, and completion in Monaco editor when using esbuild

### DIFF
--- a/client/web/src/settings/MonacoSettingsEditor.tsx
+++ b/client/web/src/settings/MonacoSettingsEditor.tsx
@@ -362,3 +362,22 @@ function getPositionAt(text: string, offset: number): monaco.IPosition {
     }
     throw new Error(`offset ${offset} out of bounds in text of length ${text.length}`)
 }
+
+declare global {
+    interface Window {
+        MonacoEnvironment?: monaco.Environment | undefined
+    }
+}
+
+// When using esbuild, we need to manually configure the MonacoEnvironment for the Monaco editor.
+// This is not needed when using Webpack because the monaco-editor-webpack-plugin does this for us.
+if (process.env.DEV_WEB_BUILDER === 'esbuild' && !window.MonacoEnvironment) {
+    window.MonacoEnvironment = {
+        getWorkerUrl(_moduleId: string, label: string): string {
+            if (label === 'json') {
+                return window.context.assetsRoot + '/scripts/json.worker.bundle.js'
+            }
+            return window.context.assetsRoot + '/scripts/editor.worker.bundle.js'
+        },
+    }
+}


### PR DESCRIPTION
Now, hovers, validation, and completion show up when using esbuild (https://docs.sourcegraph.com/dev/background-information/web/build#esbuild) to build our web app. Previously they only worked when using Webpack.






## Test plan

Tested with `DEV_WEB_BUILDER=esbuild` and `DEV_WEB_BUILDER=webpack`. Hover over properties in the site config or global settings editors and see that there is documentation (when using esbuild). Ensure nothing broke in webpack.

## App preview:

- [Web](https://sg-web-sqs-esbuild-monaco-jsonschema.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
