### PR TITLE
DEV_WEB_BUILDER_OMIT_SLOW_DEPS env var to speed up esbuild rebuild by ~40%

### DIFF
--- a/client/build-config/src/esbuild/packageResolutionPlugin.ts
+++ b/client/build-config/src/esbuild/packageResolutionPlugin.ts
@@ -23,10 +23,17 @@ export const packageResolutionPlugin = (resolutions: Resolutions): esbuild.Plugi
             extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],
             symlinks: true, // Resolve workspace symlinks
             modules: [NODE_MODULES_PATH],
+            unsafeCache: true,
         })
 
         build.onResolve({ filter, namespace: 'file' }, async args => {
-            if ((args.kind === 'import-statement' || args.kind === 'require-call') && resolutions[args.path]) {
+            if (
+                (args.kind === 'import-statement' || args.kind === 'require-call' || args.kind === 'dynamic-import') &&
+                resolutions[args.path]
+            ) {
+                if (resolutions[args.path] === '/dev/null') {
+                    return { namespace: 'devnull', path: '/dev/null' }
+                }
                 const resolvedPath = await new Promise<string>((resolve, reject) => {
                     resolver.resolve({}, args.resolveDir, resolutions[args.path], {}, (error, filepath) => {
                         if (filepath) {
@@ -40,6 +47,8 @@ export const packageResolutionPlugin = (resolutions: Resolutions): esbuild.Plugi
             }
             return undefined
         })
+
+        build.onLoad({ filter: new RegExp(''), namespace: 'devnull' }, () => ({ contents: '' }))
     },
 })
 

--- a/client/build-config/src/esbuild/stylePlugin.ts
+++ b/client/build-config/src/esbuild/stylePlugin.ts
@@ -101,8 +101,8 @@ export const stylePlugin: esbuild.Plugin = {
         const resolver = ResolverFactory.createResolver({
             fileSystem: new CachedInputFileSystem(fs, 4000),
             extensions: ['.css', '.scss'],
-            symlinks: true, // Resolve workspace symlinks
             modules: [NODE_MODULES_PATH],
+            unsafeCache: true,
         })
 
         build.onResolve({ filter: /\.s?css$/, namespace: 'file' }, async args => {

--- a/client/shared/src/components/NoMonacoEditor.tsx
+++ b/client/shared/src/components/NoMonacoEditor.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import { Code, Text } from '@sourcegraph/wildcard'
+
+/**
+ * Used when the env var `DEV_WEB_BUILDER_OMIT_SLOW_DEPS` is set.
+ */
+export const MonacoEditor: React.FunctionComponent = () => (
+    <Text className="border border-danger p-2">
+        Monaco editor is not included in this bundle because the environment variable{' '}
+        <Code>DEV_WEB_BUILDER_OMIT_SLOW_DEPS</Code> is set.
+    </Text>
+)

--- a/client/web/dev/esbuild/build.ts
+++ b/client/web/dev/esbuild/build.ts
@@ -16,12 +16,14 @@ import {
     experimentalNoticePlugin,
     buildTimerPlugin,
 } from '@sourcegraph/build-config'
+import { isDefined } from '@sourcegraph/common'
 
 import { ENVIRONMENT_CONFIG } from '../utils'
 
 import { manifestPlugin } from './manifestPlugin'
 
 const isEnterpriseBuild = ENVIRONMENT_CONFIG.ENTERPRISE
+const omitSlowDeps = ENVIRONMENT_CONFIG.DEV_WEB_BUILDER_OMIT_SLOW_DEPS
 
 export const BUILD_OPTIONS: esbuild.BuildOptions = {
     entryPoints: {
@@ -46,11 +48,29 @@ export const BUILD_OPTIONS: esbuild.BuildOptions = {
         packageResolutionPlugin({
             path: require.resolve('path-browserify'),
             ...RXJS_RESOLUTIONS,
+            ...(omitSlowDeps
+                ? {
+                      // Monaco
+                      '@sourcegraph/shared/src/components/MonacoEditor':
+                          '@sourcegraph/shared/src/components/NoMonacoEditor',
+                      'monaco-editor': '/dev/null',
+                      'monaco-editor/esm/vs/editor/editor.api': '/dev/null',
+                      'monaco-yaml': '/dev/null',
+
+                      // GraphiQL
+                      './api/ApiConsole': path.join(ROOT_PATH, 'client/web/src/api/NoApiConsole.tsx'),
+                      '@graphiql/react': '/dev/null',
+                      graphiql: '/dev/null',
+
+                      // Misc.
+                      recharts: '/dev/null',
+                  }
+                : null),
         }),
-        monacoPlugin(MONACO_LANGUAGES_AND_FEATURES),
+        omitSlowDeps ? null : monacoPlugin(MONACO_LANGUAGES_AND_FEATURES),
         buildTimerPlugin,
         experimentalNoticePlugin,
-    ],
+    ].filter(isDefined),
     define: {
         ...Object.fromEntries(
             Object.entries({ ...ENVIRONMENT_CONFIG, SOURCEGRAPH_API_URL: undefined }).map(([key, value]) => [
@@ -86,7 +106,9 @@ export const build = async (): Promise<void> => {
     if (metafile) {
         writeFileSync(metafile, JSON.stringify(result.metafile), 'utf-8')
     }
-    await buildMonaco(STATIC_ASSETS_PATH)
+    if (!omitSlowDeps) {
+        await buildMonaco(STATIC_ASSETS_PATH)
+    }
 }
 
 if (require.main === module) {

--- a/client/web/dev/esbuild/server.ts
+++ b/client/web/dev/esbuild/server.ts
@@ -7,7 +7,7 @@ import signale from 'signale'
 
 import { STATIC_ASSETS_PATH, buildMonaco } from '@sourcegraph/build-config'
 
-import { HTTPS_WEB_SERVER_URL, printSuccessBanner } from '../utils'
+import { ENVIRONMENT_CONFIG, HTTPS_WEB_SERVER_URL, printSuccessBanner } from '../utils'
 
 import { BUILD_OPTIONS } from './build'
 import { assetPathPrefix } from './manifestPlugin'
@@ -20,7 +20,9 @@ export const esbuildDevelopmentServer = async (
 
     // One-time build (these files only change when the monaco-editor npm package is changed, which
     // is rare enough to ignore here).
-    await buildMonaco(STATIC_ASSETS_PATH)
+    if (!ENVIRONMENT_CONFIG.DEV_WEB_BUILDER_OMIT_SLOW_DEPS) {
+        await buildMonaco(STATIC_ASSETS_PATH)
+    }
 
     // Start esbuild's server on a random local port.
     const {

--- a/client/web/dev/utils/environment-config.ts
+++ b/client/web/dev/utils/environment-config.ts
@@ -60,6 +60,13 @@ export const ENVIRONMENT_CONFIG = {
     DEV_WEB_BUILDER: (process.env.DEV_WEB_BUILDER === 'esbuild' ? 'esbuild' : 'webpack') as WEB_BUILDER,
 
     /**
+     * Omit slow deps (such as Monaco and GraphiQL) in the build to get a ~40% reduction in esbuild
+     * rebuild time. The web app will show placeholders if features needing these deps are used.
+     * (Esbuild only.)
+     */
+    DEV_WEB_BUILDER_OMIT_SLOW_DEPS: Boolean(process.env.DEV_WEB_BUILDER_OMIT_SLOW_DEPS),
+
+    /**
      * ----------------------------------------
      * Application features configuration.
      * ----------------------------------------

--- a/client/web/src/api/NoApiConsole.tsx
+++ b/client/web/src/api/NoApiConsole.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import { Code, Text } from '@sourcegraph/wildcard'
+
+/**
+ * Used when the env var `DEV_WEB_BUILDER_OMIT_SLOW_DEPS` is set.
+ */
+export const ApiConsole: React.FunctionComponent = () => (
+    <Text className="border border-danger p-2 mx-auto my-5">
+        GraphiQL is not included in this bundle because the environment variable{' '}
+        <Code>DEV_WEB_BUILDER_OMIT_SLOW_DEPS</Code> is set.
+    </Text>
+)


### PR DESCRIPTION
With the env var `DEV_WEB_BUILDER_OMIT_SLOW_DEPS` set (such as in `sg.config.overwrite.yaml`), esbuild rebuilds are ~40% faster. If you try to access pages that require these deps, you'll see a placeholder. This env var only takes effect when using esbuild (https://docs.sourcegraph.com/dev/background-information/web/build#esbuild), not Webpack.




## Test plan

Dev only, no test plan needed.

## App preview:

- [Web](https://sg-web-sqs-faster-esbuild-misc.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
