### PR TITLE
add 2 env vars to speed up frontend builds

### DIFF
--- a/client/shared/gulpfile.js
+++ b/client/shared/gulpfile.js
@@ -49,6 +49,13 @@ async function shouldRegenerateGraphQlOperations(type, name) {
  * Generates the new query-specific types on file changes.
  */
 function watchGraphQlOperations() {
+  if (process.env.DEV_WEB_BUILDER_UNSAFE_FAST) {
+    // Setting the env var DEV_WEB_BUILDER_UNSAFE_FAST skips various operations in frontend dev.
+    // It's not safe, but if you know what you're doing, go ahead and use it. (CI will catch any
+    // issues you forgot about.)
+    return
+  }
+
   // Although graphql-codegen has watching capabilities, they don't appear to
   // use chokidar correctly and rely on polling. Instead, let's get gulp to
   // watch for us, since we know it'll do it more efficiently, and then we can

--- a/client/web/dev/esbuild/build.ts
+++ b/client/web/dev/esbuild/build.ts
@@ -25,6 +25,8 @@ import { manifestPlugin } from './manifestPlugin'
 const isEnterpriseBuild = ENVIRONMENT_CONFIG.ENTERPRISE
 const omitSlowDeps = ENVIRONMENT_CONFIG.DEV_WEB_BUILDER_OMIT_SLOW_DEPS
 
+const forceTreeShaking = ENVIRONMENT_CONFIG.DEV_WEB_BUILDER_ESBUILD_FORCE_TREESHAKING
+
 export const BUILD_OPTIONS: esbuild.BuildOptions = {
     entryPoints: {
         // Enterprise vs. OSS builds use different entrypoints. The enterprise entrypoint imports a
@@ -92,8 +94,8 @@ export const BUILD_OPTIONS: esbuild.BuildOptions = {
     // otherwise fixed), we can return to using tree shaking. Right now, esbuild's tree shaking has
     // a bug where the NavBar CSS is not loaded because the @sourcegraph/wildcard uses `export *
     // from` and has `"sideEffects": false` in its package.json.
-    ignoreAnnotations: true,
-    treeShaking: false,
+    ignoreAnnotations: !forceTreeShaking,
+    treeShaking: forceTreeShaking,
 }
 
 export const build = async (): Promise<void> => {

--- a/client/web/dev/utils/environment-config.ts
+++ b/client/web/dev/utils/environment-config.ts
@@ -67,6 +67,13 @@ export const ENVIRONMENT_CONFIG = {
     DEV_WEB_BUILDER_OMIT_SLOW_DEPS: Boolean(process.env.DEV_WEB_BUILDER_OMIT_SLOW_DEPS),
 
     /**
+     * Force tree-shaking in esbuild. Currently unsafe due to
+     * https://github.com/evanw/esbuild/pull/1458; see the other comments in this repository
+     * mentioning that PR for more information. (Esbuild only.)
+     */
+    DEV_WEB_BUILDER_ESBUILD_FORCE_TREESHAKING: Boolean(process.env.DEV_WEB_BUILDER_ESBUILD_FORCE_TREESHAKING),
+
+    /**
      * ----------------------------------------
      * Application features configuration.
      * ----------------------------------------


### PR DESCRIPTION
- DEV_WEB_BUILDER_ESBUILD_FORCE_TREESHAKING: forces tree-shaking. Requires using a fork of esbuild (https://github.com/evanw/esbuild/pull/1458) for now, but merging this will make it easier for more people to experiment with that esbuild fork.
- DEV_WEB_BUILDER_UNSAFE_FAST: Setting the env var DEV_WEB_BUILDER_UNSAFE_FAST skips various operations in frontend dev. It's not safe, but if you know what you're doing, go ahead and use it. (CI will catch any issues you forgot about.)




## Test plan

Dev only. No test plan needed.

## App preview:

- [Web](https://sg-web-sqs-esbuild-unsafe-dev-fast.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
