### PR TITLE
search ui: make actions buttone more explicit

### DIFF
--- a/client/web/src/search/results/SearchActionsMenu.tsx
+++ b/client/web/src/search/results/SearchActionsMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 
-import { mdiArrowCollapseUp, mdiArrowExpandDown, mdiBookmarkOutline, mdiDotsHorizontal, mdiDownload } from '@mdi/js'
+import { mdiArrowCollapseUp, mdiArrowExpandDown, mdiBookmarkOutline, mdiChevronDown, mdiDownload } from '@mdi/js'
 import classNames from 'classnames'
 
 import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
@@ -67,7 +67,8 @@ export const SearchActionsMenu: React.FunctionComponent<SearchActionsMenuProps> 
                         outline={true}
                         size="sm"
                     >
-                        <Icon aria-hidden={true} svgPath={mdiDotsHorizontal} />
+                        Actions
+                        <Icon aria-hidden={true} data-caret={true} className="ml-1" svgPath={mdiChevronDown} />
                     </MenuButton>
                     <MenuList tabIndex={0} position={Position.bottomEnd} aria-label="Search Actions. Open menu">
                         {resultsFound && (

--- a/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
+++ b/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
@@ -65,9 +65,11 @@ exports[`SearchResultsInfoBar code monitoring feature flag disabled 1`] = `
             id="menu-button-2"
             type="button"
           >
+            Actions
             <svg
               aria-hidden="true"
-              class="mdi-icon iconInline"
+              class="mdi-icon iconInline ml-1"
+              data-caret="true"
               fill="currentColor"
               height="24"
               role="img"
@@ -75,7 +77,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag disabled 1`] = `
               width="24"
             >
               <path
-                d="M16,12A2,2 0 0,1 18,10A2,2 0 0,1 20,12A2,2 0 0,1 18,14A2,2 0 0,1 16,12M10,12A2,2 0 0,1 12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14A2,2 0 0,1 10,12M4,12A2,2 0 0,1 6,10A2,2 0 0,1 8,12A2,2 0 0,1 6,14A2,2 0 0,1 4,12Z"
+                d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
               />
             </svg>
           </button>
@@ -172,9 +174,11 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
             id="menu-button-6"
             type="button"
           >
+            Actions
             <svg
               aria-hidden="true"
-              class="mdi-icon iconInline"
+              class="mdi-icon iconInline ml-1"
+              data-caret="true"
               fill="currentColor"
               height="24"
               role="img"
@@ -182,7 +186,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
               width="24"
             >
               <path
-                d="M16,12A2,2 0 0,1 18,10A2,2 0 0,1 20,12A2,2 0 0,1 18,14A2,2 0 0,1 16,12M10,12A2,2 0 0,1 12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14A2,2 0 0,1 10,12M4,12A2,2 0 0,1 6,10A2,2 0 0,1 8,12A2,2 0 0,1 6,14A2,2 0 0,1 4,12Z"
+                d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
               />
             </svg>
           </button>
@@ -279,9 +283,11 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
             id="menu-button-8"
             type="button"
           >
+            Actions
             <svg
               aria-hidden="true"
-              class="mdi-icon iconInline"
+              class="mdi-icon iconInline ml-1"
+              data-caret="true"
               fill="currentColor"
               height="24"
               role="img"
@@ -289,7 +295,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
               width="24"
             >
               <path
-                d="M16,12A2,2 0 0,1 18,10A2,2 0 0,1 20,12A2,2 0 0,1 18,14A2,2 0 0,1 16,12M10,12A2,2 0 0,1 12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14A2,2 0 0,1 10,12M4,12A2,2 0 0,1 6,10A2,2 0 0,1 8,12A2,2 0 0,1 6,14A2,2 0 0,1 4,12Z"
+                d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
               />
             </svg>
           </button>
@@ -386,9 +392,11 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, cannot creat
             id="menu-button-4"
             type="button"
           >
+            Actions
             <svg
               aria-hidden="true"
-              class="mdi-icon iconInline"
+              class="mdi-icon iconInline ml-1"
+              data-caret="true"
               fill="currentColor"
               height="24"
               role="img"
@@ -396,7 +404,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, cannot creat
               width="24"
             >
               <path
-                d="M16,12A2,2 0 0,1 18,10A2,2 0 0,1 20,12A2,2 0 0,1 18,14A2,2 0 0,1 16,12M10,12A2,2 0 0,1 12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14A2,2 0 0,1 10,12M4,12A2,2 0 0,1 6,10A2,2 0 0,1 8,12A2,2 0 0,1 6,14A2,2 0 0,1 4,12Z"
+                d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
               />
             </svg>
           </button>
@@ -493,9 +501,11 @@ exports[`SearchResultsInfoBar unauthenticated user 1`] = `
             id="menu-button-10"
             type="button"
           >
+            Actions
             <svg
               aria-hidden="true"
-              class="mdi-icon iconInline"
+              class="mdi-icon iconInline ml-1"
+              data-caret="true"
               fill="currentColor"
               height="24"
               role="img"
@@ -503,7 +513,7 @@ exports[`SearchResultsInfoBar unauthenticated user 1`] = `
               width="24"
             >
               <path
-                d="M16,12A2,2 0 0,1 18,10A2,2 0 0,1 20,12A2,2 0 0,1 18,14A2,2 0 0,1 16,12M10,12A2,2 0 0,1 12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14A2,2 0 0,1 10,12M4,12A2,2 0 0,1 6,10A2,2 0 0,1 8,12A2,2 0 0,1 6,14A2,2 0 0,1 4,12Z"
+                d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
               />
             </svg>
           </button>


### PR DESCRIPTION
Customers have been [struggling to find the actions menu](https://sourcegraph.slack.com/archives/C0W2E592M/p1670396723595189) since it's such a small button with no text. This adds some text to the button to make it more obvious and discoverable. 

![CleanShot 2023-01-02 at 15 24 22](https://user-images.githubusercontent.com/206864/210284583-2aa0fdf2-7265-4682-8c36-9f88b7bb799a.png)

## Test plan

Content-only change, behavior is still identical.

## App preview:

- [Web](https://sg-web-jp-actionsbutton.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
