### PR TITLE
Search: Improve ref glob check for search context queries

### DIFF
--- a/internal/search/repo_revs.go
+++ b/internal/search/repo_revs.go
@@ -49,6 +49,10 @@ func (r1 RevisionSpecifier) Less(r2 RevisionSpecifier) bool {
 	return r1.ExcludeRefGlob < r2.ExcludeRefGlob
 }
 
+func (r1 RevisionSpecifier) HasRefGlob() bool {
+	return r1.RefGlob != "" || r1.ExcludeRefGlob != ""
+}
+
 // RepositoryRevisions specifies a repository and 0 or more revspecs and ref
 // globs.  If no revspecs and no ref globs are specified, then the
 // repository's default branch is used.

--- a/internal/search/searchcontexts/search_contexts.go
+++ b/internal/search/searchcontexts/search_contexts.go
@@ -219,7 +219,7 @@ func validateSearchContextQuery(contextQuery string) error {
 			repoRegex, revs := search.ParseRepositoryRevisions(value)
 
 			for _, rev := range revs {
-				if rev.RevSpec == "" {
+				if rev.HasRefGlob() {
 					errs = errors.Append(errs,
 						errors.Errorf("unsupported rev glob in search context query: %q", value))
 					return
@@ -514,7 +514,7 @@ func ParseRepoOpts(contextQuery string) ([]RepoOpts, error) {
 		for _, r := range repoFilters {
 			repoFilter, revs := search.ParseRepositoryRevisions(r)
 			for _, rev := range revs {
-				if rev.RevSpec != "" {
+				if !rev.HasRefGlob() {
 					rq.RevSpecs = append(rq.RevSpecs, rev.RevSpec)
 				}
 			}

--- a/internal/search/searchcontexts/search_contexts_test.go
+++ b/internal/search/searchcontexts/search_contexts_test.go
@@ -486,10 +486,21 @@ func TestCreatingSearchContexts(t *testing.T) {
 			userID:        user1.ID,
 		},
 		{
-			name:          "cannot create search context with unsupported repo field predicate in query",
-			searchContext: &types.SearchContext{Name: "unsupported_repo_predicate", Query: "repo:has.content(foo)"},
+			name:          "can create search context query with empty revision",
+			searchContext: &types.SearchContext{Name: "empty_revision", Query: "repo:foo/bar@"},
 			userID:        user1.ID,
-			wantErr:       fmt.Sprintf("unsupported repo field predicate in search context query: %q", "has.content(foo)"),
+		},
+		{
+			name:          "cannot create search context query with ref glob",
+			searchContext: &types.SearchContext{Name: "unsupported_ref_glob", Query: "repo:foo/bar@*refs/tags/*"},
+			userID:        user1.ID,
+			wantErr:       fmt.Sprintf("unsupported rev glob in search context query: %q", "foo/bar@*refs/tags/*"),
+		},
+		{
+			name:          "cannot create search context query with exclude ref glob",
+			searchContext: &types.SearchContext{Name: "uunsupported_ref_glob", Query: "repo:foo/bar@*!refs/tags/*"},
+			userID:        user1.ID,
+			wantErr:       fmt.Sprintf("unsupported rev glob in search context query: %q", "foo/bar@*!refs/tags/*"),
 		},
 	}
 

--- a/internal/search/searchcontexts/search_contexts_test.go
+++ b/internal/search/searchcontexts/search_contexts_test.go
@@ -486,6 +486,12 @@ func TestCreatingSearchContexts(t *testing.T) {
 			userID:        user1.ID,
 		},
 		{
+			name:          "cannot create search context with unsupported repo field predicate in query",
+			searchContext: &types.SearchContext{Name: "unsupported_repo_predicate", Query: "repo:has.content(foo)"},
+			userID:        user1.ID,
+			wantErr:       fmt.Sprintf("unsupported repo field predicate in search context query: %q", "has.content(foo)"),
+		},
+		{
 			name:          "can create search context query with empty revision",
 			searchContext: &types.SearchContext{Name: "empty_revision", Query: "repo:foo/bar@"},
 			userID:        user1.ID,


### PR DESCRIPTION
When a search context is based on a query, we don't allow the repo filter to
include ref globs. The check for this was a bit fragile -- it just checked
whether RevisionSpecifier.RevSpec was empty, with the assumption that one of
the other glob fields would be set. But we also use an empty RevSpec to
indicate the default branch, so there may be no ref globs at all.

This commit makes the check more robust and adds a test. Hopefully the new
method RevisionSpecifier.HasRefGlob prevents the same mistake from happening
again.

## Test plan

Added test cases to `search_contexts_tests.go`, light manual testing
