### PR TITLE
docs: fix links to install script

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -41,19 +41,19 @@ Sourcegraph is a code search and intelligence platform. Devs use it to search, u
 </div>
 <div class="grid">
   <!-- Azure -->
-  <a class="btn-app btn" href="/admin/deploy/single-node/script.md">
+  <a class="btn-app btn" href="/admin/deploy/single-node/script">
     <img alt="azure-logo" src="https://storage.googleapis.com/sourcegraph-resource-estimator/assets/azure.png"/>
     <h3>Azure</h3>
     <p>Deploy onto Microsoft Azure<br/>(install script)</p>
   </a>
   <!-- Digital Ocean -->
-  <a class="btn-app btn" href="/admin/deploy/single-node/script.md">
+  <a class="btn-app btn" href="/admin/deploy/single-node/script">
     <img alt="digital-ocean-logo" src="https://storage.googleapis.com/sourcegraph-resource-estimator/assets/DigitalOcean.png"/>
     <h3>DigitalOcean</h3>
     <p>Deploy onto DigitalOcean<br/>(install script)</p>
   </a>
   <!-- Others -->
-  <a class="btn-app btn" href="/admin/deploy/single-node/script.md">
+  <a class="btn-app btn" href="/admin/deploy/single-node/script">
     <img alt="private-cloud-logo" src="https://storage.googleapis.com/sourcegraph-resource-estimator/assets/cloud.png"/>
     <h3>Script install</h3>
     <p>Deploy on any Linux machine using our script</p>


### PR DESCRIPTION
## Issue

Clicking on Azure / DigitalOcean / Script Install in our[ current docs homepage](https://docs.sourcegraph.com/) will take users to an error page:
![image](https://user-images.githubusercontent.com/68532117/210312411-a7e305ee-a665-4d69-8fe5-52a501a84c8b.png)
![image](https://user-images.githubusercontent.com/68532117/210312444-d3a7767c-0d9a-45af-893b-abc2afee135a.png)

## PR Summary

This PR removes the `.md` from the URL to resolve the aforementioned issue. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

1. Run `yarn docsite:serve` to start docsite.
2. Click on Azure / DigitalOcean / Script Install at http://localhost:5080 to see the correct links