### PR TITLE
fix apollo cache merge error for Repository by fetching ID in queries

### DIFF
--- a/client/shared/src/codeintel/legacy-extensions/util/api.ts
+++ b/client/shared/src/codeintel/legacy-extensions/util/api.ts
@@ -510,6 +510,7 @@ type LocalCodeIntelResponse = GenericBlobResponse<{ localCodeIntel: string }>
 const localCodeIntelQuery = gql`
     query LocalCodeIntel($repository: String!, $commit: String!, $path: String!) {
         repository(name: $repository) {
+            id
             commit(rev: $commit) {
                 blob(path: $path) {
                     localCodeIntel

--- a/client/web/src/batches/backend.ts
+++ b/client/web/src/batches/backend.ts
@@ -8,6 +8,7 @@ import { gql } from '@sourcegraph/http-client'
 export const REPO_CHANGESETS_STATS = gql`
     query RepoChangesetsStats($name: String!) {
         repository(name: $name) {
+            id
             changesetsStats {
                 open
                 merged

--- a/client/web/src/codeintel/ReferencesPanelQueries.ts
+++ b/client/web/src/codeintel/ReferencesPanelQueries.ts
@@ -213,6 +213,7 @@ export const CODE_INTEL_SEARCH_QUERY = gql`
                             content
                         }
                         repository {
+                            id
                             name
                         }
                         symbols {
@@ -250,6 +251,7 @@ export const CODE_INTEL_SEARCH_QUERY = gql`
 export const LOCAL_CODE_INTEL_QUERY = gql`
     query LocalCodeIntel($repository: String!, $commit: String!, $path: String!) {
         repository(name: $repository) {
+            id
             commit(rev: $commit) {
                 blob(path: $path) {
                     localCodeIntel

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.mock.ts
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.mock.ts
@@ -190,6 +190,7 @@ export const MOCK_BULK_OPERATIONS: BatchChangeBulkOperationsResult = {
                                     url: 'https://test.test/my/pr',
                                 },
                                 repository: {
+                                    id: 'a',
                                     name: 'sourcegraph/sourcegraph',
                                     url: '/github.com/sourcegraph/sourcegraph',
                                 },

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -80,6 +80,7 @@ const bulkOperationFragment = gql`
                         url
                     }
                     repository {
+                        id
                         name
                         url
                     }

--- a/client/web/src/integration/graphQlResponseHelpers.ts
+++ b/client/web/src/integration/graphQlResponseHelpers.ts
@@ -66,6 +66,7 @@ export const createFileExternalLinksResult = (
 
 export const createRepoChangesetsStatsResult = (): RepoChangesetsStatsResult => ({
     repository: {
+        id: 'a',
         changesetsStats: {
             open: 2,
             merged: 4,


### PR DESCRIPTION
This fixes an Apollo GraphQL client error (shown in the devtools console):

`Cache data may be lost when replacing the [...] field of a Query object. To address this problem (which is not a bug in Apollo Client), either ensure all objects of type Repository have IDs, ...`

The simple and safe fix is to query the `Repository.id` field so that Apollo knows how to merge that data into its cache for a given Repository node.

There are probably more places where this should be done, but this fixes all the ones I encountered.




## Test plan

No test plan needed; automated tests will catch any issues here.

## App preview:

- [Web](https://sg-web-sqs-fix-apollo-cache-error.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
