### PR TITLE
graphqlbackend: move external service exclusion logic to `backend` package.

### DIFF
--- a/cmd/frontend/backend/external_services.go
+++ b/cmd/frontend/backend/external_services.go
@@ -214,7 +214,6 @@ func ExcludableRepoName(repository *types.Repo, logger log.Logger) (name string)
 		} else {
 			logger.Error("invalid repo metadata schema", log.String("extSvcType", extsvc.TypeBitbucketServer))
 		}
-
 	case extsvc.TypeGitHub:
 		if repo, ok := repository.Metadata.(*github.Repository); ok {
 			name = repo.NameWithOwner

--- a/cmd/frontend/backend/external_services.go
+++ b/cmd/frontend/backend/external_services.go
@@ -91,7 +91,7 @@ func (e *externalServices) ExcludeRepoFromExternalService(ctx context.Context, e
 
 	// If external service doesn't support repo exclusion, then return.
 	if !externalService.SupportsRepoExclusion() {
-		logger.Warn("Tried to exclude repo from external service, but its config does not support repo exclusion.")
+		logger.Warn("external service does not support repo exclusion")
 		return nil
 	}
 

--- a/cmd/frontend/backend/external_services.go
+++ b/cmd/frontend/backend/external_services.go
@@ -2,27 +2,47 @@ package backend
 
 import (
 	"context"
+	json "encoding/json"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/sourcegraph/log"
-
-	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-// repoupdaterClient is an interface with only the methods required in SyncExternalService. As a
-// result instead of using the entire repoupdater client implementation, we use a thinner API which
-// only needs the SyncExternalService method to be defined on the object.
-type repoupdaterClient interface {
-	SyncExternalService(ctx context.Context, externalServiceID int64) (*protocol.ExternalServiceSyncResult, error)
+const syncExternalServiceTimeout = 15 * time.Second
+
+type ExternalServicesService interface {
+	SyncExternalService(context.Context, *types.ExternalService, time.Duration) error
+	ExcludeRepoFromExternalService(context.Context, int64, api.RepoID) error
+}
+
+type externalServices struct {
+	logger            log.Logger
+	db                database.DB
+	repoupdaterClient *repoupdater.Client
+}
+
+func NewExternalServices(logger log.Logger, db database.DB, repoupdaterClient *repoupdater.Client) ExternalServicesService {
+	return &externalServices{
+		logger:            logger,
+		db:                db,
+		repoupdaterClient: repoupdaterClient,
+	}
 }
 
 // SyncExternalService will eagerly trigger a repo-updater sync. It accepts a
 // timeout as an argument which is recommended to be 5 seconds unless the caller
 // has special requirements for it to be larger or smaller.
-func SyncExternalService(ctx context.Context, logger log.Logger, svc *types.ExternalService, timeout time.Duration, client repoupdaterClient) (err error) {
-	logger = logger.Scoped("SyncExternalService", "handles triggering of repo-updater syncing for a particular external service")
+func (e *externalServices) SyncExternalService(ctx context.Context, svc *types.ExternalService, timeout time.Duration) (err error) {
+	logger := e.logger.Scoped("SyncExternalService", "handles triggering of repo-updater syncing for a particular external service")
 	// Set a timeout to validate external service sync. It usually fails in
 	// under 5s if there is a problem.
 	ctx, cancel := context.WithTimeout(ctx, timeout)
@@ -41,6 +61,132 @@ func SyncExternalService(ctx context.Context, logger log.Logger, svc *types.Exte
 		}
 	}()
 
-	_, err = client.SyncExternalService(ctx, svc.ID)
+	_, err = e.repoupdaterClient.SyncExternalService(ctx, svc.ID)
 	return err
+}
+
+// ExcludeRepoFromExternalService excludes given repo from given external service config.
+//
+// Function is pretty beefy, what it does is:
+// - finds an external service by ID and checks if it supports repo exclusion
+// - adds repo to `exclude` config parameter and updates an external service
+// - triggers external service sync
+func (e *externalServices) ExcludeRepoFromExternalService(ctx context.Context, externalServiceID int64, repoID api.RepoID) (err error) {
+	tx, err := e.db.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	externalServices := tx.ExternalServices()
+	externalService, err := externalServices.GetByID(ctx, externalServiceID)
+	if err != nil {
+		return err
+	}
+
+	logger := e.logger.Scoped("ExcludeRepoFromExternalService", "excluding a repo from external service config").With(
+		log.Int64("externalServiceID", externalServiceID),
+		log.Int32("repoID", int32(repoID)),
+	)
+
+	// If external service doesn't support repo exclusion, then return.
+	if !externalService.SupportsRepoExclusion() {
+		logger.Warn("Tried to exclude repo from external service, but its config does not support repo exclusion.")
+		return nil
+	}
+
+	repository, err := tx.Repos().Get(ctx, repoID)
+	if err != nil {
+		return err
+	}
+
+	updatedConfig, err := addRepoToExclude(ctx, externalService, repository)
+	if err != nil {
+		return err
+	}
+
+	err = externalServices.Update(ctx, conf.Get().AuthProviders, externalServiceID, &database.ExternalServiceUpdate{Config: &updatedConfig})
+	if err != nil {
+		return err
+	}
+
+	// Error during triggering a sync is omitted, because this should not prevent
+	// from excluding the repo. The repo stays excluded and the sync will come
+	// eventually.
+	err = e.SyncExternalService(ctx, externalService, syncExternalServiceTimeout)
+	if err != nil {
+		logger.Warn("Failed to trigger external service sync after adding a repo exclusion.")
+	}
+	return nil
+}
+
+func addRepoToExclude(ctx context.Context, externalService *types.ExternalService, repository *types.Repo) (string, error) {
+	config, err := externalService.Configuration(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	// we need to use a `org/repo` repo name format in `exclude` section of code host
+	// config, hence trimming the host: `github.com/sourcegraph/sourcegraph` becomes
+	// `sourcegraph/sourcegraph`.
+	repoName := trimHostFromRepoName(string(repository.Name))
+
+	switch c := config.(type) {
+	case *schema.AWSCodeCommitConnection:
+		exclusion := &schema.ExcludedAWSCodeCommitRepo{Id: strconv.FormatInt(int64(repository.ID), 10), Name: repoName}
+		if !schemaContainsExclusion(c.Exclude, exclusion) {
+			c.Exclude = append(c.Exclude, &schema.ExcludedAWSCodeCommitRepo{Id: strconv.FormatInt(int64(repository.ID), 10), Name: repoName})
+		}
+	case *schema.BitbucketCloudConnection:
+		exclusion := &schema.ExcludedBitbucketCloudRepo{Name: repoName}
+		if !schemaContainsExclusion(c.Exclude, exclusion) {
+			c.Exclude = append(c.Exclude, &schema.ExcludedBitbucketCloudRepo{Name: repoName})
+		}
+	case *schema.BitbucketServerConnection:
+		exclusion := &schema.ExcludedBitbucketServerRepo{Id: int(repository.ID), Name: repoName}
+		if !schemaContainsExclusion(c.Exclude, exclusion) {
+			c.Exclude = append(c.Exclude, &schema.ExcludedBitbucketServerRepo{Id: int(repository.ID), Name: repoName})
+		}
+	case *schema.GitHubConnection:
+		exclusion := &schema.ExcludedGitHubRepo{Id: strconv.FormatInt(int64(repository.ID), 10), Name: repoName}
+		if !schemaContainsExclusion(c.Exclude, exclusion) {
+			c.Exclude = append(c.Exclude, &schema.ExcludedGitHubRepo{Id: strconv.FormatInt(int64(repository.ID), 10), Name: repoName})
+		}
+	case *schema.GitLabConnection:
+		exclusion := &schema.ExcludedGitLabProject{Name: repoName}
+		if !schemaContainsExclusion(c.Exclude, exclusion) {
+			c.Exclude = append(c.Exclude, &schema.ExcludedGitLabProject{Name: repoName})
+		}
+	case *schema.GitoliteConnection:
+		exclusion := &schema.ExcludedGitoliteRepo{Name: repoName}
+		if !schemaContainsExclusion(c.Exclude, exclusion) {
+			c.Exclude = append(c.Exclude, &schema.ExcludedGitoliteRepo{Name: repoName})
+		}
+	}
+
+	strConfig, err := json.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+	return string(strConfig), nil
+}
+
+// trimHostFromRepoName removes host from full repo name. It does it in the same
+// way as it is done before rendering repo name on the UI. See RepoLink
+// component.
+func trimHostFromRepoName(name string) string {
+	parts := strings.Split(name, "/")
+	if len(parts) >= 3 && strings.Contains(parts[0], ".") {
+		return strings.Join(parts[1:], "/")
+	}
+	return strings.Join(parts, "/")
+}
+
+func schemaContainsExclusion[T comparable](exclusions []*T, newExclusion *T) bool {
+	for _, exclusion := range exclusions {
+		if *exclusion == *newExclusion {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/frontend/backend/external_services.go
+++ b/cmd/frontend/backend/external_services.go
@@ -198,7 +198,6 @@ func ExcludableRepoName(repository *types.Repo, logger log.Logger) (name string)
 			name = repo.Name
 		} else {
 			logger.Error("invalid repo metadata schema", log.String("extSvcType", extsvc.TypeAWSCodeCommit))
-			return
 		}
 	case extsvc.TypeBitbucketCloud:
 		if repo, ok := repository.Metadata.(*bitbucketcloud.Repo); ok {

--- a/cmd/frontend/backend/external_services_test.go
+++ b/cmd/frontend/backend/external_services_test.go
@@ -32,42 +32,42 @@ func TestAddRepoToExclude(t *testing.T) {
 		{
 			name:           "second attempt of excluding same repo is ignored for AWSCodeCommit schema",
 			kind:           extsvc.KindAWSCodeCommit,
-			repo:           MakeAWSCodeCommitRepo(),
+			repo:           makeAWSCodeCommitRepo(),
 			initialConfig:  `{"accessKeyID":"accessKeyID","gitCredentials":{"password":"","username":""},"region":"","secretAccessKey":""}`,
 			expectedConfig: `{"accessKeyID":"accessKeyID","exclude":[{"name":"test"}],"gitCredentials":{"password":"","username":""},"region":"","secretAccessKey":""}`,
 		},
 		{
 			name:           "second attempt of excluding same repo is ignored for BitbucketCloud schema",
 			kind:           extsvc.KindBitbucketCloud,
-			repo:           MakeBitbucketCloudRepo(),
+			repo:           makeBitbucketCloudRepo(),
 			initialConfig:  `{"appPassword":"","url":"https://bitbucket.org","username":""}`,
 			expectedConfig: `{"appPassword":"","exclude":[{"name":"sg/sourcegraph"}],"url":"https://bitbucket.org","username":""}`,
 		},
 		{
 			name:           "second attempt of excluding same repo is ignored for BitbucketServer schema",
 			kind:           extsvc.KindBitbucketServer,
-			repo:           MakeBitbucketServerRepo(),
+			repo:           makeBitbucketServerRepo(),
 			initialConfig:  `{"repositoryQuery":["none"],"token":"abc","url":"https://bitbucket.sg.org","username":""}`,
 			expectedConfig: `{"exclude":[{"name":"SOURCEGRAPH/jsonrpc2"}],"repositoryQuery":["none"],"token":"abc","url":"https://bitbucket.sg.org","username":""}`,
 		},
 		{
 			name:           "second attempt of excluding same repo is ignored for GitHub schema",
 			kind:           extsvc.KindGitHub,
-			repo:           MakeGithubRepo(),
+			repo:           makeGithubRepo(),
 			initialConfig:  `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
 			expectedConfig: `{"exclude":[{"name":"sourcegraph/conc"}],"repositoryQuery":["none"],"token":"abc","url":"https://github.com"}`,
 		},
 		{
 			name:           "second attempt of excluding same repo is ignored for GitLab schema",
 			kind:           extsvc.KindGitLab,
-			repo:           MakeGitlabRepo(),
+			repo:           makeGitlabRepo(),
 			initialConfig:  `{"projectQuery":null,"token":"abc","url":"https://gitlab.com"}`,
 			expectedConfig: `{"exclude":[{"name":"gitlab-org/gitaly"}],"projectQuery":null,"token":"abc","url":"https://gitlab.com"}`,
 		},
 		{
 			name:           "second attempt of excluding same repo is ignored for Gitolite schema",
 			kind:           extsvc.KindGitolite,
-			repo:           MakeGitoliteRepo(),
+			repo:           makeGitoliteRepo(),
 			initialConfig:  `{"host":"gitolite.com","prefix":""}`,
 			expectedConfig: `{"exclude":[{"name":"vegeta"}],"host":"gitolite.com","prefix":""}`,
 		},
@@ -102,14 +102,14 @@ func TestRepoExcludableRepoName(t *testing.T) {
 		repo         *types.Repo
 		expectedName string
 	}{
-		"Successful parsing of AWSCodeCommit repo excludable name":   {repo: MakeAWSCodeCommitRepo(), expectedName: "test"},
-		"Successful parsing of BitbucketCloud repo excludable name":  {repo: MakeBitbucketCloudRepo(), expectedName: "sg/sourcegraph"},
-		"Successful parsing of BitbucketServer repo excludable name": {repo: MakeBitbucketServerRepo(), expectedName: "SOURCEGRAPH/jsonrpc2"},
-		"Successful parsing of GitHub repo excludable name":          {repo: MakeGithubRepo(), expectedName: "sourcegraph/conc"},
-		"Successful parsing of GitLab repo excludable name":          {repo: MakeGitlabRepo(), expectedName: "gitlab-org/gitaly"},
-		"Successful parsing of Gitolite repo excludable name":        {repo: MakeGitoliteRepo(), expectedName: "vegeta"},
-		"GitoliteRepo doesn't have a name, empty result":             {repo: MakeGitoliteRepoParams(true, false), expectedName: ""},
-		"GitoliteRepo doesn't have metadata, empty result":           {repo: MakeGitoliteRepoParams(false, false), expectedName: ""},
+		"Successful parsing of AWSCodeCommit repo excludable name":   {repo: makeAWSCodeCommitRepo(), expectedName: "test"},
+		"Successful parsing of BitbucketCloud repo excludable name":  {repo: makeBitbucketCloudRepo(), expectedName: "sg/sourcegraph"},
+		"Successful parsing of BitbucketServer repo excludable name": {repo: makeBitbucketServerRepo(), expectedName: "SOURCEGRAPH/jsonrpc2"},
+		"Successful parsing of GitHub repo excludable name":          {repo: makeGithubRepo(), expectedName: "sourcegraph/conc"},
+		"Successful parsing of GitLab repo excludable name":          {repo: makeGitlabRepo(), expectedName: "gitlab-org/gitaly"},
+		"Successful parsing of Gitolite repo excludable name":        {repo: makeGitoliteRepo(), expectedName: "vegeta"},
+		"GitoliteRepo doesn't have a name, empty result":             {repo: makeGitoliteRepoParams(true, false), expectedName: ""},
+		"GitoliteRepo doesn't have metadata, empty result":           {repo: makeGitoliteRepoParams(false, false), expectedName: ""},
 	}
 
 	for testName, testCase := range testCases {
@@ -120,8 +120,8 @@ func TestRepoExcludableRepoName(t *testing.T) {
 	}
 }
 
-// MakeAWSCodeCommitRepo returns a configured AWS Code Commit repository.
-func MakeAWSCodeCommitRepo() *types.Repo {
+// makeAWSCodeCommitRepo returns a configured AWS Code Commit repository.
+func makeAWSCodeCommitRepo() *types.Repo {
 	repo := typestest.MakeRepo("git-codecommit.us-est-1.amazonaws.com/test", "arn:aws:codecommit:us-west-1:133780085999:", extsvc.TypeAWSCodeCommit)
 	repo.Metadata = &awscodecommit.Repository{
 		ARN:          "arn:aws:codecommit:us-west-1:133780085999:test",
@@ -133,8 +133,8 @@ func MakeAWSCodeCommitRepo() *types.Repo {
 	return repo
 }
 
-// MakeBitbucketCloudRepo returns a configured Bitbucket Cloud repository.
-func MakeBitbucketCloudRepo() *types.Repo {
+// makeBitbucketCloudRepo returns a configured Bitbucket Cloud repository.
+func makeBitbucketCloudRepo() *types.Repo {
 	repo := typestest.MakeRepo("bitbucket.org/sg/sourcegraph", "https://bitbucket.org/", extsvc.TypeBitbucketCloud)
 	mdStr := &bitbucketcloud.Repo{
 		FullName: "sg/sourcegraph",
@@ -143,8 +143,8 @@ func MakeBitbucketCloudRepo() *types.Repo {
 	return repo
 }
 
-// MakeBitbucketServerRepo returns a configured Bitbucket Server repository.
-func MakeBitbucketServerRepo() *types.Repo {
+// makeBitbucketServerRepo returns a configured Bitbucket Server repository.
+func makeBitbucketServerRepo() *types.Repo {
 	repo := typestest.MakeRepo("bitbucket.sgdev.org/SOURCEGRAPH/jsonrpc2", "https://bitbucket.sgdev.org/", extsvc.TypeBitbucketServer)
 	repo.Metadata = `{"id": 10066, "name": "jsonrpc2", "slug": "jsonrpc2", "links": {"self": [{"href": "https://bitbucket.sgdev.org/projects/SOURCEGRAPH/repos/jsonrpc2/browse"}], "clone": [{"href": "ssh://git@bitbucket.sgdev.org:7999/sourcegraph/jsonrpc2.git", "name": "ssh"}, {"href": "https://bitbucket.sgdev.org/scm/sourcegraph/jsonrpc2.git", "name": "http"}]}, "scmId": "git", "state": "AVAILABLE", "origin": null, "public": false, "project": {"id": 28, "key": "SOURCEGRAPH", "name": "Sourcegraph e2e testing", "type": "NORMAL", "links": {"self": [{"href": "https://bitbucket.sgdev.org/projects/SOURCEGRAPH"}]}, "public": false}, "forkable": true, "statusMessage": "Available"}`
 	repo.Metadata = &bitbucketserver.Repo{
@@ -160,8 +160,8 @@ func MakeBitbucketServerRepo() *types.Repo {
 	return repo
 }
 
-// MakeGithubRepo returns a configured Github repository.
-func MakeGithubRepo() *types.Repo {
+// makeGithubRepo returns a configured Github repository.
+func makeGithubRepo() *types.Repo {
 	repo := typestest.MakeRepo("github.com/sourcegraph/conc", "https://github.com/", extsvc.TypeGitHub)
 	repo.Metadata = &github.Repository{
 		ID:            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
@@ -173,8 +173,8 @@ func MakeGithubRepo() *types.Repo {
 	return repo
 }
 
-// MakeGitlabRepo returns a configured Gitlab repository.
-func MakeGitlabRepo() *types.Repo {
+// makeGitlabRepo returns a configured Gitlab repository.
+func makeGitlabRepo() *types.Repo {
 	repo := typestest.MakeRepo("gitlab.com/gitlab-org/gitaly", "https://gitlab.com/", extsvc.TypeGitLab)
 	repo.Metadata = &gitlab.Project{
 		ProjectCommon: gitlab.ProjectCommon{
@@ -191,8 +191,8 @@ func MakeGitlabRepo() *types.Repo {
 	return repo
 }
 
-// MakeGitoliteRepo returns a configured Gitolite repository.
-func MakeGitoliteRepoParams(addMetadata bool, includeName bool) *types.Repo {
+// makeGitoliteRepo returns a configured Gitolite repository.
+func makeGitoliteRepoParams(addMetadata bool, includeName bool) *types.Repo {
 	repo := typestest.MakeRepo("gitolite.sgdev.org/vegeta", "git@gitolite.sgdev.org", extsvc.TypeGitolite)
 	if addMetadata {
 		metadata := &gitolite.Repo{
@@ -206,6 +206,6 @@ func MakeGitoliteRepoParams(addMetadata bool, includeName bool) *types.Repo {
 	return repo
 }
 
-func MakeGitoliteRepo() *types.Repo {
-	return MakeGitoliteRepoParams(true, true)
+func makeGitoliteRepo() *types.Repo {
+	return makeGitoliteRepoParams(true, true)
 }

--- a/cmd/frontend/backend/external_services_test.go
+++ b/cmd/frontend/backend/external_services_test.go
@@ -1,0 +1,101 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrimHostFromRepoName(t *testing.T) {
+	testCases := map[string]struct {
+		inputRepoName       string
+		expectedTrimmedName string
+	}{
+		"repo has a hostname":               {inputRepoName: "github.com/sourcegraph/sourcegraph", expectedTrimmedName: "sourcegraph/sourcegraph"},
+		"repo doesn't have a hostname":      {inputRepoName: "sourcegraph/horsegraph", expectedTrimmedName: "sourcegraph/horsegraph"},
+		"non-hostname prefix isn't trimmed": {inputRepoName: "source/graph/horsegraph", expectedTrimmedName: "source/graph/horsegraph"},
+		"GitLab nested project is trimmed":  {inputRepoName: "gitlab.com/source/graph/horsegraph", expectedTrimmedName: "source/graph/horsegraph"},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			actualTrimmedName := trimHostFromRepoName(testCase.inputRepoName)
+			assert.Equal(t, testCase.expectedTrimmedName, actualTrimmedName)
+		})
+	}
+}
+
+func TestAddRepoToExclude(t *testing.T) {
+	ctx := context.Background()
+
+	testCases := []struct {
+		name           string
+		kind           string
+		initialConfig  string
+		expectedConfig string
+	}{
+		{
+			name:           "second attempt of excluding same repo is ignored for AWSCodeCommit schema",
+			kind:           extsvc.KindAWSCodeCommit,
+			initialConfig:  `{"accessKeyID":"accessKeyID","gitCredentials":{"password":"","username":""},"region":"","secretAccessKey":""}`,
+			expectedConfig: `{"accessKeyID":"accessKeyID","exclude":[{"id":"1","name":"sourcegraph/sourcegraph"}],"gitCredentials":{"password":"","username":""},"region":"","secretAccessKey":""}`,
+		},
+		{
+			name:           "second attempt of excluding same repo is ignored for BitbucketCloud schema",
+			kind:           extsvc.KindBitbucketCloud,
+			initialConfig:  `{"appPassword":"","url":"https://bitbucket.org","username":""}`,
+			expectedConfig: `{"appPassword":"","exclude":[{"name":"sourcegraph/sourcegraph"}],"url":"https://bitbucket.org","username":""}`,
+		},
+		{
+			name:           "second attempt of excluding same repo is ignored for BitbucketServer schema",
+			kind:           extsvc.KindBitbucketServer,
+			initialConfig:  `{"repositoryQuery":["none"],"token":"abc","url":"https://bitbucket.sg.org","username":""}`,
+			expectedConfig: `{"exclude":[{"id":1,"name":"sourcegraph/sourcegraph"}],"repositoryQuery":["none"],"token":"abc","url":"https://bitbucket.sg.org","username":""}`,
+		},
+		{
+			name:           "second attempt of excluding same repo is ignored for GitHub schema",
+			kind:           extsvc.KindGitHub,
+			initialConfig:  `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
+			expectedConfig: `{"exclude":[{"id":"1","name":"sourcegraph/sourcegraph"}],"repositoryQuery":["none"],"token":"abc","url":"https://github.com"}`,
+		},
+		{
+			name:           "second attempt of excluding same repo is ignored for GitLab schema",
+			kind:           extsvc.KindGitLab,
+			initialConfig:  `{"projectQuery":null,"token":"abc","url":"https://gitlab.com"}`,
+			expectedConfig: `{"exclude":[{"name":"sourcegraph/sourcegraph"}],"projectQuery":null,"token":"abc","url":"https://gitlab.com"}`,
+		},
+		{
+			name:           "second attempt of excluding same repo is ignored for Gitolite schema",
+			kind:           extsvc.KindGitolite,
+			initialConfig:  `{"host":"gitolite.com","prefix":""}`,
+			expectedConfig: `{"exclude":[{"name":"sourcegraph/sourcegraph"}],"host":"gitolite.com","prefix":""}`,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			extSvc := &types.ExternalService{
+				Kind:        test.kind,
+				DisplayName: fmt.Sprintf("%s #1", test.kind),
+				Config:      extsvc.NewUnencryptedConfig(test.initialConfig),
+			}
+			actualConfig, err := addRepoToExclude(ctx, extSvc, &types.Repo{ID: api.RepoID(1), Name: "sourcegraph/sourcegraph"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, test.expectedConfig, actualConfig)
+
+			actualConfig, err = addRepoToExclude(ctx, extSvc, &types.Repo{ID: api.RepoID(1), Name: "sourcegraph/sourcegraph"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Config shouldn't have been changed.
+			assert.Equal(t, test.expectedConfig, actualConfig)
+		})
+	}
+}

--- a/cmd/frontend/backend/external_services_test.go
+++ b/cmd/frontend/backend/external_services_test.go
@@ -5,33 +5,23 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/sourcegraph/log/logtest"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTrimHostFromRepoName(t *testing.T) {
-	testCases := map[string]struct {
-		inputRepoName       string
-		expectedTrimmedName string
-	}{
-		"repo has a hostname":               {inputRepoName: "github.com/sourcegraph/sourcegraph", expectedTrimmedName: "sourcegraph/sourcegraph"},
-		"repo doesn't have a hostname":      {inputRepoName: "sourcegraph/horsegraph", expectedTrimmedName: "sourcegraph/horsegraph"},
-		"non-hostname prefix isn't trimmed": {inputRepoName: "source/graph/horsegraph", expectedTrimmedName: "source/graph/horsegraph"},
-		"GitLab nested project is trimmed":  {inputRepoName: "gitlab.com/source/graph/horsegraph", expectedTrimmedName: "source/graph/horsegraph"},
-	}
-
-	for testName, testCase := range testCases {
-		t.Run(testName, func(t *testing.T) {
-			actualTrimmedName := trimHostFromRepoName(testCase.inputRepoName)
-			assert.Equal(t, testCase.expectedTrimmedName, actualTrimmedName)
-		})
-	}
-}
-
 func TestAddRepoToExclude(t *testing.T) {
 	ctx := context.Background()
+	logger := logtest.Scoped(t)
 
 	testCases := []struct {
 		name           string
@@ -43,7 +33,7 @@ func TestAddRepoToExclude(t *testing.T) {
 			name:           "second attempt of excluding same repo is ignored for AWSCodeCommit schema",
 			kind:           extsvc.KindAWSCodeCommit,
 			initialConfig:  `{"accessKeyID":"accessKeyID","gitCredentials":{"password":"","username":""},"region":"","secretAccessKey":""}`,
-			expectedConfig: `{"accessKeyID":"accessKeyID","exclude":[{"id":"1","name":"sourcegraph/sourcegraph"}],"gitCredentials":{"password":"","username":""},"region":"","secretAccessKey":""}`,
+			expectedConfig: `{"accessKeyID":"accessKeyID","exclude":[{"name":"sourcegraph/sourcegraph"}],"gitCredentials":{"password":"","username":""},"region":"","secretAccessKey":""}`,
 		},
 		{
 			name:           "second attempt of excluding same repo is ignored for BitbucketCloud schema",
@@ -55,13 +45,13 @@ func TestAddRepoToExclude(t *testing.T) {
 			name:           "second attempt of excluding same repo is ignored for BitbucketServer schema",
 			kind:           extsvc.KindBitbucketServer,
 			initialConfig:  `{"repositoryQuery":["none"],"token":"abc","url":"https://bitbucket.sg.org","username":""}`,
-			expectedConfig: `{"exclude":[{"id":1,"name":"sourcegraph/sourcegraph"}],"repositoryQuery":["none"],"token":"abc","url":"https://bitbucket.sg.org","username":""}`,
+			expectedConfig: `{"exclude":[{"name":"sourcegraph/sourcegraph"}],"repositoryQuery":["none"],"token":"abc","url":"https://bitbucket.sg.org","username":""}`,
 		},
 		{
 			name:           "second attempt of excluding same repo is ignored for GitHub schema",
 			kind:           extsvc.KindGitHub,
 			initialConfig:  `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
-			expectedConfig: `{"exclude":[{"id":"1","name":"sourcegraph/sourcegraph"}],"repositoryQuery":["none"],"token":"abc","url":"https://github.com"}`,
+			expectedConfig: `{"exclude":[{"name":"sourcegraph/sourcegraph"}],"repositoryQuery":["none"],"token":"abc","url":"https://github.com"}`,
 		},
 		{
 			name:           "second attempt of excluding same repo is ignored for GitLab schema",
@@ -84,13 +74,13 @@ func TestAddRepoToExclude(t *testing.T) {
 				DisplayName: fmt.Sprintf("%s #1", test.kind),
 				Config:      extsvc.NewUnencryptedConfig(test.initialConfig),
 			}
-			actualConfig, err := addRepoToExclude(ctx, extSvc, &types.Repo{ID: api.RepoID(1), Name: "sourcegraph/sourcegraph"})
+			actualConfig, err := addRepoToExclude(ctx, logger, extSvc, &types.Repo{ID: api.RepoID(1), Name: "sourcegraph/sourcegraph"})
 			if err != nil {
 				t.Fatal(err)
 			}
 			assert.Equal(t, test.expectedConfig, actualConfig)
 
-			actualConfig, err = addRepoToExclude(ctx, extSvc, &types.Repo{ID: api.RepoID(1), Name: "sourcegraph/sourcegraph"})
+			actualConfig, err = addRepoToExclude(ctx, logger, extSvc, &types.Repo{ID: api.RepoID(1), Name: "sourcegraph/sourcegraph"})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -98,4 +88,114 @@ func TestAddRepoToExclude(t *testing.T) {
 			assert.Equal(t, test.expectedConfig, actualConfig)
 		})
 	}
+}
+
+func TestRepoExcludableRepoName(t *testing.T) {
+	logger := logtest.Scoped(t)
+	testCases := map[string]struct {
+		repo         *types.Repo
+		expectedName string
+	}{
+		"Successful parsing of AWSCodeCommit repo excludable name":   {repo: MakeAWSCodeCommitRepo(), expectedName: "test"},
+		"Successful parsing of BitbucketCloud repo excludable name":  {repo: MakeBitbucketCloudRepo(), expectedName: "sg/sourcegraph"},
+		"Successful parsing of BitbucketServer repo excludable name": {repo: MakeBitbucketServerRepo(), expectedName: "SOURCEGRAPH/jsonrpc2"},
+		"Successful parsing of GitHub repo excludable name":          {repo: MakeGithubRepo(), expectedName: "sourcegraph/conc"},
+		"Successful parsing of GitLab repo excludable name":          {repo: MakeGitlabRepo(), expectedName: "gitlab-org/gitaly"},
+		"Successful parsing of Gitolite repo excludable name":        {repo: MakeGitoliteRepo(true, true), expectedName: "vegeta"},
+		"GitoliteRepo doesn't have a name, empty result":             {repo: MakeGitoliteRepo(true, false), expectedName: ""},
+		"GitoliteRepo doesn't have metadata, empty result":           {repo: MakeGitoliteRepo(false, false), expectedName: ""},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			actualName := ExcludableRepoName(testCase.repo, logger)
+			assert.Equal(t, testCase.expectedName, actualName)
+		})
+	}
+}
+
+// MakeAWSCodeCommitRepo returns a configured AWS Code Commit repository.
+func MakeAWSCodeCommitRepo() *types.Repo {
+	repo := typestest.MakeRepo("git-codecommit.us-est-1.amazonaws.com/test", "arn:aws:codecommit:us-west-1:133780085999:", extsvc.TypeAWSCodeCommit)
+	repo.Metadata = &awscodecommit.Repository{
+		ARN:          "arn:aws:codecommit:us-west-1:133780085999:test",
+		AccountID:    "999999999999",
+		ID:           "%s",
+		Name:         "test",
+		HTTPCloneURL: "https://git-codecommit.uae-west-1.amazonaws.com/v1/repos/test",
+	}
+	return repo
+}
+
+// MakeBitbucketCloudRepo returns a configured Bitbucket Cloud repository.
+func MakeBitbucketCloudRepo() *types.Repo {
+	repo := typestest.MakeRepo("bitbucket.org/sg/sourcegraph", "https://bitbucket.org/", extsvc.TypeBitbucketCloud)
+	mdStr := &bitbucketcloud.Repo{
+		FullName: "sg/sourcegraph",
+	}
+	repo.Metadata = mdStr
+	return repo
+}
+
+// MakeBitbucketServerRepo returns a configured Bitbucket Server repository.
+func MakeBitbucketServerRepo() *types.Repo {
+	repo := typestest.MakeRepo("bitbucket.sgdev.org/SOURCEGRAPH/jsonrpc2", "https://bitbucket.sgdev.org/", extsvc.TypeBitbucketServer)
+	repo.Metadata = `{"id": 10066, "name": "jsonrpc2", "slug": "jsonrpc2", "links": {"self": [{"href": "https://bitbucket.sgdev.org/projects/SOURCEGRAPH/repos/jsonrpc2/browse"}], "clone": [{"href": "ssh://git@bitbucket.sgdev.org:7999/sourcegraph/jsonrpc2.git", "name": "ssh"}, {"href": "https://bitbucket.sgdev.org/scm/sourcegraph/jsonrpc2.git", "name": "http"}]}, "scmId": "git", "state": "AVAILABLE", "origin": null, "public": false, "project": {"id": 28, "key": "SOURCEGRAPH", "name": "Sourcegraph e2e testing", "type": "NORMAL", "links": {"self": [{"href": "https://bitbucket.sgdev.org/projects/SOURCEGRAPH"}]}, "public": false}, "forkable": true, "statusMessage": "Available"}`
+	repo.Metadata = &bitbucketserver.Repo{
+		ID:   1,
+		Name: "jsonrpc2",
+		Slug: "jsonrpc2",
+		Project: &bitbucketserver.Project{
+			Key:  "SOURCEGRAPH",
+			Name: "SOURCEGRAPH",
+		},
+	}
+
+	return repo
+}
+
+// MakeGithubRepo returns a configured Github repository.
+func MakeGithubRepo() *types.Repo {
+	repo := typestest.MakeRepo("github.com/sourcegraph/conc", "https://github.com/", extsvc.TypeGitHub)
+	repo.Metadata = &github.Repository{
+		ID:            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+		URL:           "github.com/sourcegraph/conc",
+		DatabaseID:    1234,
+		Description:   "The description",
+		NameWithOwner: "sourcegraph/conc",
+	}
+	return repo
+}
+
+// MakeGitlabRepo returns a configured Gitlab repository.
+func MakeGitlabRepo() *types.Repo {
+	repo := typestest.MakeRepo("gitlab.com/gitlab-org/gitaly", "https://gitlab.com/", extsvc.TypeGitLab)
+	repo.Metadata = &gitlab.Project{
+		ProjectCommon: gitlab.ProjectCommon{
+			ID:                2009901,
+			PathWithNamespace: "gitlab-org/gitaly",
+			Description:       "Gitaly is a Git RPC service for handling all the git calls made by GitLab",
+			WebURL:            "https://gitlab.com/gitlab-org/gitaly",
+			HTTPURLToRepo:     "https://gitlab.com/gitlab-org/gitaly.git",
+			SSHURLToRepo:      "git@gitlab.com:gitlab-org/gitaly.git",
+		},
+		Visibility: "",
+		Archived:   false,
+	}
+	return repo
+}
+
+// MakeGitoliteRepo returns a configured Gitolite repository.
+func MakeGitoliteRepo(addMetadata bool, includeName bool) *types.Repo {
+	repo := typestest.MakeRepo("gitolite.sgdev.org/vegeta", "git@gitolite.sgdev.org", extsvc.TypeGitolite)
+	if addMetadata {
+		metadata := &gitolite.Repo{
+			URL: "git@gitolite.sgdev.org:vegeta",
+		}
+		if includeName {
+			metadata.Name = "vegeta"
+		}
+		repo.Metadata = metadata
+	}
+	return repo
 }

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -386,13 +386,7 @@ type syncExternalServiceArgs struct {
 	ID graphql.ID
 }
 
-// mockSyncExternalService mocks (*schemaResolver).SyncExternalService.
-var mockSyncExternalService func(context.Context, *syncExternalServiceArgs) (*EmptyResponse, error)
-
 func (r *schemaResolver) SyncExternalService(ctx context.Context, args *syncExternalServiceArgs) (*EmptyResponse, error) {
-	if mockSyncExternalService != nil {
-		return mockSyncExternalService(ctx, args)
-	}
 	start := time.Now()
 	var err error
 	defer reportExternalServiceDuration(start, Update, &err)

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -12,8 +11,6 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/sourcegraph/sourcegraph/schema"
-
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -79,7 +76,7 @@ func (r *schemaResolver) AddExternalService(ctx context.Context, args *addExtern
 	}
 
 	res := &externalServiceResolver{logger: r.logger.Scoped("externalServiceResolver", ""), db: r.db, externalService: externalService}
-	if err = backend.SyncExternalService(ctx, r.logger, externalService, syncExternalServiceTimeout, r.repoupdaterClient); err != nil {
+	if err = backend.NewExternalServices(r.logger, r.db, r.repoupdaterClient).SyncExternalService(ctx, externalService, syncExternalServiceTimeout); err != nil {
 		res.warning = fmt.Sprintf("External service created, but we encountered a problem while validating the external service: %s", err)
 	}
 
@@ -152,8 +149,7 @@ func (r *schemaResolver) UpdateExternalService(ctx context.Context, args *update
 	res := &externalServiceResolver{logger: r.logger.Scoped("externalServiceResolver", ""), db: r.db, externalService: es}
 
 	if oldConfig != newConfig {
-		err = backend.SyncExternalService(ctx, r.logger, es, syncExternalServiceTimeout, r.repoupdaterClient)
-		if err != nil {
+		if err = backend.NewExternalServices(r.logger, r.db, r.repoupdaterClient).SyncExternalService(ctx, es, syncExternalServiceTimeout); err != nil {
 			res.warning = fmt.Sprintf("External service updated, but we encountered a problem while validating the external service: %s", err)
 		}
 	}
@@ -167,19 +163,12 @@ type excludeRepoFromExternalServiceArgs struct {
 }
 
 // ExcludeRepoFromExternalService excludes given repo from given external service config.
-//
-// Function is pretty beefy, what it does is:
-// - checks whether current user is site-admin and returns if not
-// - finds an external service by ID and checks if it supports repo exclusion
-// - adds repo to `exclude` config parameter and updates an external service
-// - triggers external service sync
-//
-// Note: Failing to trigger an external service sync doesn't fail the whole update.
 func (r *schemaResolver) ExcludeRepoFromExternalService(ctx context.Context, args *excludeRepoFromExternalServiceArgs) (*EmptyResponse, error) {
 	// 🚨 SECURITY: check whether user is site-admin
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
+
 	extSvcID, err := UnmarshalExternalServiceID(args.ExternalService)
 	if err != nil {
 		return nil, err
@@ -190,117 +179,10 @@ func (r *schemaResolver) ExcludeRepoFromExternalService(ctx context.Context, arg
 		return nil, err
 	}
 
-	externalServices := r.db.ExternalServices()
-	externalService, err := externalServices.GetByID(ctx, extSvcID)
-	if err != nil {
+	if err = backend.NewExternalServices(r.logger, r.db, r.repoupdaterClient).ExcludeRepoFromExternalService(ctx, extSvcID, repositoryID); err != nil {
 		return nil, err
-	}
-
-	logger := r.logger.Scoped("ExcludeRepoFromExternalService", "excluding a repo from external service config").With(
-		log.Int64("externalServiceID", extSvcID),
-		log.Int32("repoID", int32(repositoryID)),
-	)
-
-	// If external service doesn't support repo exclusion, then return.
-	if !externalService.SupportsRepoExclusion() {
-		logger.Warn("Tried to exclude repo from external service, but its config does not support repo exclusion.")
-		return &EmptyResponse{}, nil
-	}
-
-	repository, err := r.db.Repos().Get(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-
-	updatedConfig, err := addRepoToExclude(ctx, externalService, repository)
-	if err != nil {
-		return nil, err
-	}
-
-	err = externalServices.Update(ctx, conf.Get().AuthProviders, extSvcID, &database.ExternalServiceUpdate{Config: &updatedConfig})
-	if err != nil {
-		return nil, err
-	}
-
-	// Error during triggering a sync is omitted, because this should not prevent
-	// from excluding the repo. The repo stays excluded and the sync will come
-	// eventually.
-	_, err = r.SyncExternalService(ctx, &syncExternalServiceArgs{ID: args.ExternalService})
-	if err != nil {
-		logger.Warn("Failed to trigger external service sync after adding a repo exclusion.")
 	}
 	return &EmptyResponse{}, nil
-}
-
-func addRepoToExclude(ctx context.Context, externalService *types.ExternalService, repository *types.Repo) (string, error) {
-	config, err := externalService.Configuration(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	// we need to use a `org/repo` repo name format in `exclude` section of code host
-	// config, hence trimming the host: `github.com/sourcegraph/sourcegraph` becomes
-	// `sourcegraph/sourcegraph`.
-	repoName := trimHostFromRepoName(string(repository.Name))
-
-	switch c := config.(type) {
-	case *schema.AWSCodeCommitConnection:
-		exclusion := &schema.ExcludedAWSCodeCommitRepo{Id: strconv.FormatInt(int64(repository.ID), 10), Name: repoName}
-		if !schemaContainsExclusion(c.Exclude, exclusion) {
-			c.Exclude = append(c.Exclude, &schema.ExcludedAWSCodeCommitRepo{Id: strconv.FormatInt(int64(repository.ID), 10), Name: repoName})
-		}
-	case *schema.BitbucketCloudConnection:
-		exclusion := &schema.ExcludedBitbucketCloudRepo{Name: repoName}
-		if !schemaContainsExclusion(c.Exclude, exclusion) {
-			c.Exclude = append(c.Exclude, &schema.ExcludedBitbucketCloudRepo{Name: repoName})
-		}
-	case *schema.BitbucketServerConnection:
-		exclusion := &schema.ExcludedBitbucketServerRepo{Id: int(repository.ID), Name: repoName}
-		if !schemaContainsExclusion(c.Exclude, exclusion) {
-			c.Exclude = append(c.Exclude, &schema.ExcludedBitbucketServerRepo{Id: int(repository.ID), Name: repoName})
-		}
-	case *schema.GitHubConnection:
-		exclusion := &schema.ExcludedGitHubRepo{Id: strconv.FormatInt(int64(repository.ID), 10), Name: repoName}
-		if !schemaContainsExclusion(c.Exclude, exclusion) {
-			c.Exclude = append(c.Exclude, &schema.ExcludedGitHubRepo{Id: strconv.FormatInt(int64(repository.ID), 10), Name: repoName})
-		}
-	case *schema.GitLabConnection:
-		exclusion := &schema.ExcludedGitLabProject{Name: repoName}
-		if !schemaContainsExclusion(c.Exclude, exclusion) {
-			c.Exclude = append(c.Exclude, &schema.ExcludedGitLabProject{Name: repoName})
-		}
-	case *schema.GitoliteConnection:
-		exclusion := &schema.ExcludedGitoliteRepo{Name: repoName}
-		if !schemaContainsExclusion(c.Exclude, exclusion) {
-			c.Exclude = append(c.Exclude, &schema.ExcludedGitoliteRepo{Name: repoName})
-		}
-	}
-
-	strConfig, err := json.Marshal(config)
-	if err != nil {
-		return "", err
-	}
-	return string(strConfig), nil
-}
-
-// trimHostFromRepoName removes host from full repo name. It does it in the same
-// way as it is done before rendering repo name on the UI. See RepoLink
-// component.
-func trimHostFromRepoName(name string) string {
-	parts := strings.Split(name, "/")
-	if len(parts) >= 3 && strings.Contains(parts[0], ".") {
-		return strings.Join(parts[1:], "/")
-	}
-	return strings.Join(parts, "/")
-}
-
-func schemaContainsExclusion[T comparable](exclusions []*T, newExclusion *T) bool {
-	for _, exclusion := range exclusions {
-		if *exclusion == *newExclusion {
-			return true
-		}
-	}
-	return false
 }
 
 type deleteExternalServiceArgs struct {

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -243,14 +243,14 @@ func TestExcludeRepoFromExternalService_ExternalServiceDoesntSupportRepoExclusio
 				}
 			}
 		`,
-		ExpectedResult: `
+		ExpectedErrors: []*gqlerrors.QueryError{
 			{
-				"excludeRepoFromExternalService": {
-					"alwaysNil": null
-				}
-			}
-		`,
-		Context: actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
+				Path:    []any{"excludeRepoFromExternalService"},
+				Message: "external service does not support repo exclusion",
+			},
+		},
+		ExpectedResult: "null",
+		Context:        actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
 	})
 
 	assert.Nil(t, cachedUpdate)

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -221,6 +221,11 @@ func TestExcludeRepoFromExternalService_ExternalServiceDoesntSupportRepoExclusio
 	})
 
 	db := database.NewMockDB()
+	db.TransactFunc.SetDefaultReturn(db, nil)
+	db.DoneFunc.SetDefaultHook(func(err error) error {
+		return err
+	})
+
 	db.UsersFunc.SetDefaultReturn(users)
 	db.ExternalServicesFunc.SetDefaultReturn(externalServices)
 
@@ -278,6 +283,11 @@ func TestExcludeRepoFromExternalService_NoExistingExcludedRepos_NewExcludedRepoA
 	t.Cleanup(func() { mockSyncExternalService = nil })
 
 	db := database.NewMockDB()
+	db.TransactFunc.SetDefaultReturn(db, nil)
+	db.DoneFunc.SetDefaultHook(func(err error) error {
+		return err
+	})
+
 	db.UsersFunc.SetDefaultReturn(users)
 	db.ExternalServicesFunc.SetDefaultReturn(externalServices)
 	db.ReposFunc.SetDefaultReturn(repos)
@@ -338,6 +348,10 @@ func TestExcludeRepoFromExternalService_ExcludedRepoExists_AnotherExcludedRepoAd
 	t.Cleanup(func() { mockSyncExternalService = nil })
 
 	db := database.NewMockDB()
+	db.TransactFunc.SetDefaultReturn(db, nil)
+	db.DoneFunc.SetDefaultHook(func(err error) error {
+		return err
+	})
 	db.UsersFunc.SetDefaultReturn(users)
 	db.ExternalServicesFunc.SetDefaultReturn(externalServices)
 	db.ReposFunc.SetDefaultReturn(repos)
@@ -397,6 +411,10 @@ func TestExcludeRepoFromExternalService_ExcludedRepoExists_SameRepoIsNotExcluded
 	t.Cleanup(func() { mockSyncExternalService = nil })
 
 	db := database.NewMockDB()
+	db.TransactFunc.SetDefaultReturn(db, nil)
+	db.DoneFunc.SetDefaultHook(func(err error) error {
+		return err
+	})
 	db.UsersFunc.SetDefaultReturn(users)
 	db.ExternalServicesFunc.SetDefaultReturn(externalServices)
 	db.ReposFunc.SetDefaultReturn(repos)
@@ -425,95 +443,6 @@ func TestExcludeRepoFromExternalService_ExcludedRepoExists_SameRepoIsNotExcluded
 
 	expectedConfig := `{"exclude":[{"id":"1","name":"sourcegraph/sourcegraph"},{"id":"2","name":"sourcegraph/horsegraph"}],"repositoryQuery":["none"],"token":"abc","url":"https://github.com"}`
 	assert.Equal(t, expectedConfig, *cachedUpdate.Config)
-}
-
-func TestTrimHostFromRepoName(t *testing.T) {
-	testCases := map[string]struct {
-		inputRepoName       string
-		expectedTrimmedName string
-	}{
-		"repo has a hostname":               {inputRepoName: "github.com/sourcegraph/sourcegraph", expectedTrimmedName: "sourcegraph/sourcegraph"},
-		"repo doesn't have a hostname":      {inputRepoName: "sourcegraph/horsegraph", expectedTrimmedName: "sourcegraph/horsegraph"},
-		"non-hostname prefix isn't trimmed": {inputRepoName: "source/graph/horsegraph", expectedTrimmedName: "source/graph/horsegraph"},
-		"GitLab nested project is trimmed":  {inputRepoName: "gitlab.com/source/graph/horsegraph", expectedTrimmedName: "source/graph/horsegraph"},
-	}
-
-	for testName, testCase := range testCases {
-		t.Run(testName, func(t *testing.T) {
-			actualTrimmedName := trimHostFromRepoName(testCase.inputRepoName)
-			assert.Equal(t, testCase.expectedTrimmedName, actualTrimmedName)
-		})
-	}
-}
-
-func TestAddRepoToExclude(t *testing.T) {
-	ctx := context.Background()
-
-	testCases := []struct {
-		name           string
-		kind           string
-		initialConfig  string
-		expectedConfig string
-	}{
-		{
-			name:           "second attempt of excluding same repo is ignored for AWSCodeCommit schema",
-			kind:           extsvc.KindAWSCodeCommit,
-			initialConfig:  `{"accessKeyID":"accessKeyID","gitCredentials":{"password":"","username":""},"region":"","secretAccessKey":""}`,
-			expectedConfig: `{"accessKeyID":"accessKeyID","exclude":[{"id":"1","name":"sourcegraph/sourcegraph"}],"gitCredentials":{"password":"","username":""},"region":"","secretAccessKey":""}`,
-		},
-		{
-			name:           "second attempt of excluding same repo is ignored for BitbucketCloud schema",
-			kind:           extsvc.KindBitbucketCloud,
-			initialConfig:  `{"appPassword":"","url":"https://bitbucket.org","username":""}`,
-			expectedConfig: `{"appPassword":"","exclude":[{"name":"sourcegraph/sourcegraph"}],"url":"https://bitbucket.org","username":""}`,
-		},
-		{
-			name:           "second attempt of excluding same repo is ignored for BitbucketServer schema",
-			kind:           extsvc.KindBitbucketServer,
-			initialConfig:  `{"repositoryQuery":["none"],"token":"abc","url":"https://bitbucket.sg.org","username":""}`,
-			expectedConfig: `{"exclude":[{"id":1,"name":"sourcegraph/sourcegraph"}],"repositoryQuery":["none"],"token":"abc","url":"https://bitbucket.sg.org","username":""}`,
-		},
-		{
-			name:           "second attempt of excluding same repo is ignored for GitHub schema",
-			kind:           extsvc.KindGitHub,
-			initialConfig:  `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
-			expectedConfig: `{"exclude":[{"id":"1","name":"sourcegraph/sourcegraph"}],"repositoryQuery":["none"],"token":"abc","url":"https://github.com"}`,
-		},
-		{
-			name:           "second attempt of excluding same repo is ignored for GitLab schema",
-			kind:           extsvc.KindGitLab,
-			initialConfig:  `{"projectQuery":null,"token":"abc","url":"https://gitlab.com"}`,
-			expectedConfig: `{"exclude":[{"name":"sourcegraph/sourcegraph"}],"projectQuery":null,"token":"abc","url":"https://gitlab.com"}`,
-		},
-		{
-			name:           "second attempt of excluding same repo is ignored for Gitolite schema",
-			kind:           extsvc.KindGitolite,
-			initialConfig:  `{"host":"gitolite.com","prefix":""}`,
-			expectedConfig: `{"exclude":[{"name":"sourcegraph/sourcegraph"}],"host":"gitolite.com","prefix":""}`,
-		},
-	}
-
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			extSvc := &types.ExternalService{
-				Kind:        test.kind,
-				DisplayName: fmt.Sprintf("%s #1", test.kind),
-				Config:      extsvc.NewUnencryptedConfig(test.initialConfig),
-			}
-			actualConfig, err := addRepoToExclude(ctx, extSvc, &types.Repo{ID: api.RepoID(1), Name: "sourcegraph/sourcegraph"})
-			if err != nil {
-				t.Fatal(err)
-			}
-			assert.Equal(t, test.expectedConfig, actualConfig)
-
-			actualConfig, err = addRepoToExclude(ctx, extSvc, &types.Repo{ID: api.RepoID(1), Name: "sourcegraph/sourcegraph"})
-			if err != nil {
-				t.Fatal(err)
-			}
-			// Config shouldn't have been changed.
-			assert.Equal(t, test.expectedConfig, actualConfig)
-		})
-	}
 }
 
 func TestDeleteExternalService(t *testing.T) {
@@ -988,7 +917,7 @@ func TestSyncExternalService_ContextTimeout(t *testing.T) {
 		Config: extsvc.NewEmptyConfig(),
 	}
 
-	err := backend.SyncExternalService(ctx, logtest.Scoped(t), svc, 0*time.Millisecond, repoupdater.NewClient(s.URL))
+	err := backend.NewExternalServices(logtest.Scoped(t), database.NewMockDB(), repoupdater.NewClient(s.URL)).SyncExternalService(ctx, svc, 0*time.Millisecond)
 
 	if err == nil {
 		t.Error("Expected error but got nil")

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -241,8 +241,14 @@ func (c *Client) SchedulePermsSync(ctx context.Context, args protocol.PermsSyncR
 	return errors.New(res.Error)
 }
 
+// MockSyncExternalService mocks (*Client).SyncExternalService for tests.
+var MockSyncExternalService func(ctx context.Context, externalServiceID int64) (*protocol.ExternalServiceSyncResult, error)
+
 // SyncExternalService requests the given external service to be synced.
 func (c *Client) SyncExternalService(ctx context.Context, externalServiceID int64) (*protocol.ExternalServiceSyncResult, error) {
+	if MockSyncExternalService != nil {
+		return MockSyncExternalService(ctx, externalServiceID)
+	}
 	req := &protocol.ExternalServiceSyncRequest{ExternalServiceID: externalServiceID}
 	resp, err := c.httpPost(ctx, "sync-external-service", req)
 	if err != nil {


### PR DESCRIPTION
I tried to move as much stuff as possible to `backend` package.
Some things like GraphQL ID unmarshalling are still in `graphqlbackend` package because moving them to `backend` package would have introduced circular dependencies.

Test plan:
Tests updated to reflect changes.

Follow up to https://github.com/sourcegraph/sourcegraph/pull/45986