### PR TITLE
token selection: fix occurrence position in hover request

### DIFF
--- a/client/web/src/repo/blob/codemirror/token-selection/hover.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/hover.ts
@@ -104,7 +104,7 @@ export function hoverAtOccurrence(view: EditorView, occurrence: Occurrence): Pro
     }
     const uri = toURIWithPath(view.state.facet(blobPropsFacet).blobInfo)
     const contents = hoverRequest(view, occurrence, {
-        position: { line: occurrence.range.start.line, character: occurrence.range.start.character + 1 },
+        position: occurrence.range.start,
         textDocument: { uri },
     })
     cache.set(occurrence, contents)

--- a/client/web/src/repo/blob/codemirror/token-selection/hover.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/hover.ts
@@ -86,7 +86,7 @@ export async function getHoverTooltip(view: EditorView, pos: number): Promise<To
     const line = cmLine.number - 1
     const character = countColumn(cmLine.text, 1, pos - cmLine.from)
     const occurrence = occurrenceAtPosition(view.state, new Position(line, character))
-    if (!occurrence || !isInteractiveOccurrence(occurrence)) {
+    if (!occurrence) {
         return null
     }
     const result = await hoverAtOccurrence(view, occurrence)

--- a/client/web/src/repo/blob/codemirror/token-selection/hover.ts
+++ b/client/web/src/repo/blob/codemirror/token-selection/hover.ts
@@ -86,7 +86,7 @@ export async function getHoverTooltip(view: EditorView, pos: number): Promise<To
     const line = cmLine.number - 1
     const character = countColumn(cmLine.text, 1, pos - cmLine.from)
     const occurrence = occurrenceAtPosition(view.state, new Position(line, character))
-    if (!occurrence) {
+    if (!occurrence || !isInteractiveOccurrence(occurrence)) {
         return null
     }
     const result = await hoverAtOccurrence(view, occurrence)


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/46079

Use the occurrence range start position as-is for querying hover data.

Previously the modified occurrence range start position was used (position character incremented by one). This caused some non-interactive tokens to trigger rendering code-intel popovers on hover.


https://user-images.githubusercontent.com/25318659/210387156-bbb313c8-32cb-4431-baac-93c69cb5e778.mov



## Test plan
Tested manually (video attached).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-token-selection-lw1m.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
