### PR TITLE
search contexts: remove auto-defined contexts graphql api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Removed
 
 - The extension registry no longer supports browsing, creating, or updating legacy extensions. Existing extensions may still be enabled or disabled in user settings and may be listed via the API. (The extension API was deprecated in 2022-09 but is still available if the `enableLegacyExtensions` site config experimental features flag is enabled.)
+- User and organization auto-defined search contexts have been permanently removed along with the `autoDefinedSearchContexts` GraphQL query. The only auto-defined context now is the `global` context. [#46083](https://github.com/sourcegraph/sourcegraph/pull/46083)
 
 ## 4.3.0
 

--- a/cmd/frontend/graphqlbackend/search_contexts.go
+++ b/cmd/frontend/graphqlbackend/search_contexts.go
@@ -20,7 +20,6 @@ const (
 
 type SearchContextsResolver interface {
 	SearchContexts(ctx context.Context, args *ListSearchContextsArgs) (SearchContextConnectionResolver, error)
-	AutoDefinedSearchContexts(ctx context.Context) ([]SearchContextResolver, error)
 
 	SearchContextByID(ctx context.Context, id graphql.ID) (SearchContextResolver, error)
 	SearchContextBySpec(ctx context.Context, args SearchContextBySpecArgs) (SearchContextResolver, error)

--- a/cmd/frontend/graphqlbackend/search_contexts.graphql
+++ b/cmd/frontend/graphqlbackend/search_contexts.graphql
@@ -52,11 +52,6 @@ extend type Mutation {
 
 extend type Query {
     """
-    DEPRECATED: Auto-defined contexts are now included in the searchContexts query.
-    Auto-defined search contexts available to the current user.
-    """
-    autoDefinedSearchContexts: [SearchContext!]!
-    """
     All available user-defined search contexts. Excludes auto-defined contexts.
     """
     searchContexts(
@@ -134,9 +129,8 @@ type SearchContext implements Node {
     """
     spec: String!
     """
-    Whether the search context is autodefined by Sourcegraph. Current examples include:
-    global search context ("global"), default user search context ("@user"), and
-    default organization search context ("@org").
+    Whether the search context is autodefined by Sourcegraph.
+    The only autodefined context currently is the global search context ("global").
     """
     autoDefined: Boolean!
     """

--- a/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
@@ -56,14 +56,6 @@ func (r *Resolver) SearchContextsToResolvers(searchContexts []*types.SearchConte
 	return searchContextResolvers
 }
 
-func (r *Resolver) AutoDefinedSearchContexts(ctx context.Context) ([]graphqlbackend.SearchContextResolver, error) {
-	searchContexts, err := searchcontexts.GetAutoDefinedSearchContexts(ctx, r.db)
-	if err != nil {
-		return nil, err
-	}
-	return r.SearchContextsToResolvers(searchContexts), nil
-}
-
 func (r *Resolver) SearchContextBySpec(ctx context.Context, args graphqlbackend.SearchContextBySpecArgs) (graphqlbackend.SearchContextResolver, error) {
 	searchContext, err := searchcontexts.ResolveSearchContextSpec(ctx, r.db, args.Spec)
 	if err != nil {


### PR DESCRIPTION
This is cleanup from #44903 which removed auto-defined contexts for all practical purposes.

## Test plan

Verify all other context behavior is still as expected.