### PR TITLE
Fuzzy finder: add personalized ranking based on history

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -60,6 +60,7 @@ import { getExperimentalFeatures } from './util/get-experimental-features'
 import { parseBrowserRepoURL } from './util/url'
 
 import styles from './Layout.module.scss'
+import { useUserHistory } from './components/useUserHistory'
 
 export interface LayoutProps
     extends RouteComponentProps<{}>,
@@ -127,6 +128,7 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
     // enable fuzzy finder by default unless it's explicitly disabled in settings
     const fuzzyFinder = getExperimentalFeatures(props.settingsCascade.final).fuzzyFinder ?? true
     const [isFuzzyFinderVisible, setFuzzyFinderVisible] = useState(false)
+    const userHistory = useUserHistory(props.history, isRepositoryRelatedPage)
 
     const communitySearchContextPaths = communitySearchContextsRoutes.map(route => route.path)
     const isCommunitySearchContextPage = communitySearchContextPaths.includes(props.location.pathname)
@@ -295,6 +297,7 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
                     settingsCascade={props.settingsCascade}
                     telemetryService={props.telemetryService}
                     location={props.location}
+                    userHistory={userHistory}
                 />
             )}
         </div>

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -29,6 +29,7 @@ import { ErrorBoundary } from './components/ErrorBoundary'
 import { LazyFuzzyFinder } from './components/fuzzyFinder/LazyFuzzyFinder'
 import { KeyboardShortcutsHelp } from './components/KeyboardShortcutsHelp/KeyboardShortcutsHelp'
 import { useScrollToLocationHash } from './components/useScrollToLocationHash'
+import { useUserHistory } from './components/useUserHistory'
 import { GlobalContributions } from './contributions'
 import { useFeatureFlag } from './featureFlags/useFeatureFlag'
 import { GlobalAlerts } from './global/GlobalAlerts'
@@ -60,7 +61,6 @@ import { getExperimentalFeatures } from './util/get-experimental-features'
 import { parseBrowserRepoURL } from './util/url'
 
 import styles from './Layout.module.scss'
-import { useUserHistory } from './components/useUserHistory'
 
 export interface LayoutProps
     extends RouteComponentProps<{}>,

--- a/client/web/src/components/fuzzyFinder/FuzzyFiles.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFiles.tsx
@@ -5,7 +5,7 @@ import { getDocumentNode, gql } from '@sourcegraph/http-client'
 import { Icon } from '@sourcegraph/wildcard'
 
 import { getWebGraphQLClient } from '../../backend/graphql'
-import { SearchValue } from '../../fuzzyFinder/FuzzySearch'
+import { SearchValue } from '../../fuzzyFinder/SearchValue'
 import { createUrlFunction } from '../../fuzzyFinder/WordSensitiveFuzzySearch'
 import {
     FileNamesResult,
@@ -13,6 +13,7 @@ import {
     FuzzyFinderFilesResult,
     FuzzyFinderFilesVariables,
 } from '../../graphql-operations'
+import { UserHistory } from '../useUserHistory'
 
 import { FuzzyFSM, newFuzzyFSMFromValues } from './FuzzyFsm'
 import { emptyFuzzyCache, PersistableQueryResult } from './FuzzyLocalCache'
@@ -109,13 +110,15 @@ export class FuzzyRepoFiles {
         private readonly client: ApolloClient<object> | undefined,
         private readonly createURL: createUrlFunction,
         private readonly onNamesChanged: () => void,
-        private readonly repoRevision: FuzzyRepoRevision
+        private readonly repoRevision: FuzzyRepoRevision,
+        private readonly userHistory: UserHistory
     ) {}
     public fuzzyFSM(): FuzzyFSM {
         return this.fsm
     }
     public handleQuery(): void {
         if (this.fsm.key === 'empty') {
+            this.fsm = { key: 'downloading' }
             this.download().then(
                 () => {},
                 () => {}
@@ -124,7 +127,6 @@ export class FuzzyRepoFiles {
     }
     private async download(): Promise<PersistableQueryResult[]> {
         const client = this.client || (await getWebGraphQLClient())
-        this.fsm = { key: 'downloading' }
         const response = await client.query<FileNamesResult, FileNamesVariables>({
             query: getDocumentNode(FUZZY_GIT_LSFILES_QUERY),
             variables: {
@@ -133,9 +135,10 @@ export class FuzzyRepoFiles {
             },
         })
         const filenames = response.data.repository?.commit?.fileNames || []
-        const values: SearchValue[] = filenames.map(text => ({
+        const values: SearchValue[] = filenames.map<SearchValue>(text => ({
             text,
             icon: fileIcon(text),
+            historyRanking: () => this.userHistory.lastAccessedFilePath(this.repoRevision.repositoryName, text),
         }))
         this.updateFSM(newFuzzyFSMFromValues(values, this.createURL))
         this.loopIndexing()
@@ -169,17 +172,20 @@ export class FuzzyFiles extends FuzzyQuery {
     constructor(
         private readonly client: ApolloClient<object> | undefined,
         onNamesChanged: () => void,
-        private readonly repoRevision: React.MutableRefObject<FuzzyRepoRevision>
+        private readonly repoRevision: React.MutableRefObject<FuzzyRepoRevision>,
+        private readonly userHistory: UserHistory
     ) {
-        // Symbol results should not be cached because stale symbol data is complicated to evict/invalidate.
         super(onNamesChanged, emptyFuzzyCache)
     }
 
     /* override */ protected searchValues(): SearchValue[] {
-        return [...this.queryResults.values()].map(({ text, url }) => ({
+        return [...this.queryResults.values()].map<SearchValue>(({ text, url, repoName, filePath }) => ({
             text,
             url,
             icon: fileIcon(text),
+            historyRanking: () =>
+                repoName && filePath ? this.userHistory.lastAccessedFilePath(repoName, filePath) : undefined,
+            ranking: repoName ? this.userHistory.lastAccessedRepo(repoName) : undefined,
         }))
     }
 
@@ -199,6 +205,8 @@ export class FuzzyFiles extends FuzzyQuery {
         for (const result of results) {
             if (result.__typename === 'FileMatch') {
                 queryResults.push({
+                    repoName: result.repository.name,
+                    filePath: result.file.path,
                     text: `${result.repository.name}/${result.file.path}`,
                     url: `/${result.repository.name}/-/blob/${result.file.path}`,
                 })

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.mocks.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.mocks.tsx
@@ -13,6 +13,7 @@ import { FUZZY_GIT_LSFILES_QUERY } from './FuzzyFiles'
 import { FuzzyFinderContainer } from './FuzzyFinder'
 import { FUZZY_REPOS_QUERY } from './FuzzyRepos'
 import { FUZZY_SYMBOLS_QUERY } from './FuzzySymbols'
+import { UserHistory } from '../useUserHistory'
 
 export interface FuzzyWrapperProps {
     url: string
@@ -41,6 +42,7 @@ export const FuzzyWrapper: React.FunctionComponent<FuzzyWrapperProps> = props =>
                 },
             }}
             initialQuery={props.initialQuery}
+            userHistory={new UserHistory()}
         />
     )
 }

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.mocks.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.mocks.tsx
@@ -8,12 +8,12 @@ import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/teleme
 
 import { FileNamesResult, FuzzyFinderRepoResult, FuzzyFinderSymbolsResult, SymbolKind } from '../../graphql-operations'
 import { ThemePreference } from '../../theme'
+import { UserHistory } from '../useUserHistory'
 
 import { FUZZY_GIT_LSFILES_QUERY } from './FuzzyFiles'
 import { FuzzyFinderContainer } from './FuzzyFinder'
 import { FUZZY_REPOS_QUERY } from './FuzzyRepos'
 import { FUZZY_SYMBOLS_QUERY } from './FuzzySymbols'
-import { UserHistory } from '../useUserHistory'
 
 export interface FuzzyWrapperProps {
     url: string

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
@@ -30,7 +30,7 @@ export const FuzzyFinderContainer: React.FunctionComponent<FuzzyFinderContainerP
     const isVisibleRef = useRef(isVisible)
     isVisibleRef.current = isVisible
     const state = useFuzzyState(props)
-    const { tabs, activeTab, setActiveTab, repoRevision, scope, isScopeToggleDisabled, toggleScope } = state
+    const { tabs, setQuery, activeTab, setActiveTab, repoRevision, scope, isScopeToggleDisabled, toggleScope } = state
     const isScopeToggleDisabledRef = useRef(isScopeToggleDisabled)
     isScopeToggleDisabledRef.current = isScopeToggleDisabled
 
@@ -52,6 +52,13 @@ export const FuzzyFinderContainer: React.FunctionComponent<FuzzyFinderContainerP
             const activeTab = activeTabRef.current
             const isVisible = isVisibleRef.current
             if (!isVisible) {
+                if (activeTabRef.current !== tab) {
+                    // Reset the query when the user activates a different tab.
+                    // For example, if the user had "Repos" open, opens a repo,
+                    // and then triggers Cmd+P to activate the "Files" tab then
+                    // we discard the previous query from the "Repos" tab.
+                    setQuery('')
+                }
                 setIsVisible(true)
             }
             if (!isScopeToggleDisabledRef.current && isVisible && tab === activeTab) {

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
@@ -75,7 +75,7 @@ export const FuzzyFinderContainer: React.FunctionComponent<FuzzyFinderContainerP
                 }
             }
         },
-        [setActiveTab, setIsVisible, toggleScope]
+        [setActiveTab, setIsVisible, toggleScope, setQuery]
     )
 
     const shortcuts = useFuzzyShortcuts(props.settingsCascade.final)

--- a/client/web/src/components/fuzzyFinder/FuzzyFsm.ts
+++ b/client/web/src/components/fuzzyFinder/FuzzyFsm.ts
@@ -1,5 +1,6 @@
 import { CaseInsensitiveFuzzySearch } from '../../fuzzyFinder/CaseInsensitiveFuzzySearch'
-import { FuzzySearch, SearchIndexing, SearchValue } from '../../fuzzyFinder/FuzzySearch'
+import { FuzzySearch, SearchIndexing } from '../../fuzzyFinder/FuzzySearch'
+import { SearchValue } from '../../fuzzyFinder/SearchValue'
 import { createUrlFunction, WordSensitiveFuzzySearch } from '../../fuzzyFinder/WordSensitiveFuzzySearch'
 
 // The default value of 80k filenames is picked from the following observations:

--- a/client/web/src/components/fuzzyFinder/FuzzyLocalCache.ts
+++ b/client/web/src/components/fuzzyFinder/FuzzyLocalCache.ts
@@ -43,7 +43,7 @@ export class FuzzyStorageCache implements FuzzyLocalCache {
         const fromCache = this.storage.getItem(this.cacheKey) ?? '[]'
         try {
             return Promise.resolve(JSON.parse(fromCache) as PersistableQueryResult[])
-        } catch (error) {
+        } catch {
             return Promise.resolve([])
         }
     }

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -39,6 +39,7 @@ import {
 
 import { AggregateFuzzySearch } from '../../fuzzyFinder/AggregateFuzzySearch'
 import { FuzzySearch, FuzzySearchResult } from '../../fuzzyFinder/FuzzySearch'
+import { SearchValueRankingCache } from '../../fuzzyFinder/SearchValueRankingCache'
 import { mergedHandler } from '../../fuzzyFinder/WordSensitiveFuzzySearch'
 import { Keybindings } from '../KeyboardShortcutsHelp/KeyboardShortcutsHelp'
 
@@ -46,7 +47,6 @@ import { fuzzyErrors, FuzzyState, FuzzyTabs, FuzzyTabKey, FuzzyScope } from './F
 import { HighlightedLink, HighlightedLinkProps, linkStyle } from './HighlightedLink'
 
 import styles from './FuzzyModal.module.scss'
-import { SearchValueRankingCache } from '../../fuzzyFinder/SearchValueRankingCache'
 
 const FUZZY_MODAL_RESULTS = 'fuzzy-modal-results'
 

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -34,6 +34,7 @@ import {
     TabPanel,
     TabList,
     Badge,
+    LoadingSpinner,
 } from '@sourcegraph/wildcard'
 
 import { AggregateFuzzySearch } from '../../fuzzyFinder/AggregateFuzzySearch'
@@ -45,6 +46,7 @@ import { fuzzyErrors, FuzzyState, FuzzyTabs, FuzzyTabKey, FuzzyScope } from './F
 import { HighlightedLink, HighlightedLinkProps, linkStyle } from './HighlightedLink'
 
 import styles from './FuzzyModal.module.scss'
+import { SearchValueRankingCache } from '../../fuzzyFinder/SearchValueRankingCache'
 
 const FUZZY_MODAL_RESULTS = 'fuzzy-modal-results'
 
@@ -114,11 +116,12 @@ function fuzzySearch(
     scope: FuzzyScope,
     maxResults: number,
     tabs: FuzzyTabs,
-    fsmGeneration: number
+    fsmGeneration: number,
+    cache: SearchValueRankingCache
 ): RenderProps {
     const search = newFuzzySearch(query, activeTab, scope, tabs)
     const start = window.performance.now()
-    const result = search.search({ query, maxResults })
+    const result = search.search({ query, maxResults, cache })
     result.elapsedMilliseconds = window.performance.now() - start
     return {
         result,
@@ -231,6 +234,7 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
         onClose,
         onClickItem,
         fsmGeneration,
+        rankingCache,
         query,
         setQuery,
         tabs,
@@ -261,8 +265,8 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
     // depend on `focusIndex` so that we avoid re-running the fuzzy finder
     // whenever the user presses up/down to cycle through the results.
     const fuzzySearchResult = useMemo<RenderProps>(
-        () => fuzzySearch(query, activeTab, scope, maxResults, tabs, fsmGeneration),
-        [fsmGeneration, maxResults, query, activeTab, scope, tabs]
+        () => fuzzySearch(query, activeTab, scope, maxResults, tabs, fsmGeneration, rankingCache),
+        [fsmGeneration, maxResults, query, activeTab, scope, tabs, rankingCache]
     )
 
     // Stage 2: render results from the fuzzy matcher.
@@ -609,7 +613,7 @@ const FuzzyResultsSummary: React.FunctionComponent<React.PropsWithChildren<Fuzzy
             {plural('result', queryResult.resultCount, queryResult.isComplete)} out of{' '}
             {plural('total', queryResult.totalFileCount, true)}
             <ProgressBar value={indexedFiles} max={totalFiles} />
-            {/* downloadingTabs.length > 0 && <LoadingSpinner /> */}
+            {downloadingTabs.length > 0 && <LoadingSpinner />}
         </span>
     )
 }

--- a/client/web/src/components/fuzzyFinder/FuzzyQuery.ts
+++ b/client/web/src/components/fuzzyFinder/FuzzyQuery.ts
@@ -12,7 +12,7 @@ export abstract class FuzzyQuery {
     protected queryResults: Map<string, PersistableQueryResult> = new Map()
 
     constructor(private readonly onNamesChanged: () => void, private readonly cache: FuzzyLocalCache) {
-        this.addQuery('FuzzyQuery.fromCache()-constructor', this.cache.initialValues())
+        this.addQueryResults(this.cache.initialValues())
     }
 
     protected abstract searchValues(): SearchValue[]
@@ -20,7 +20,7 @@ export abstract class FuzzyQuery {
     protected abstract handleRawQueryPromise(query: string): Promise<PersistableQueryResult[]>
 
     public async removeStaleResults(): Promise<void> {
-        const fromCache = await this.cache.initialValues()
+        const fromCache = this.cache.initialValues()
         if (fromCache.length === 0) {
             // Nothing to invalidate.
             return

--- a/client/web/src/components/fuzzyFinder/FuzzyQuery.ts
+++ b/client/web/src/components/fuzzyFinder/FuzzyQuery.ts
@@ -1,5 +1,6 @@
 import { CaseInsensitiveFuzzySearch } from '../../fuzzyFinder/CaseInsensitiveFuzzySearch'
-import { FuzzySearch, IndexingFSM, SearchIndexing, SearchValue } from '../../fuzzyFinder/FuzzySearch'
+import { FuzzySearch, IndexingFSM, SearchIndexing } from '../../fuzzyFinder/FuzzySearch'
+import { SearchValue } from '../../fuzzyFinder/SearchValue'
 
 import { FuzzyFSM } from './FuzzyFsm'
 import { FuzzyLocalCache, PersistableQueryResult } from './FuzzyLocalCache'

--- a/client/web/src/components/fuzzyFinder/FuzzyRepos.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyRepos.tsx
@@ -5,11 +5,12 @@ import { getDocumentNode } from '@sourcegraph/http-client'
 import { CodeHostIcon, formatRepositoryStarCount, SearchResultStar } from '@sourcegraph/search-ui'
 
 import { getWebGraphQLClient } from '../../backend/graphql'
-import { SearchValue } from '../../fuzzyFinder/FuzzySearch'
+import { SearchValue } from '../../fuzzyFinder/SearchValue'
 import { FuzzyFinderRepoResult, FuzzyFinderRepoVariables } from '../../graphql-operations'
 
-import { FuzzyWebCache, PersistableQueryResult } from './FuzzyLocalCache'
+import { FuzzyStorageCache, PersistableQueryResult } from './FuzzyLocalCache'
 import { FuzzyQuery } from './FuzzyQuery'
+import { UserHistory } from '../useUserHistory'
 
 export const FUZZY_REPOS_QUERY = gql`
     query FuzzyFinderRepo($query: String!) {
@@ -25,8 +26,17 @@ export const FUZZY_REPOS_QUERY = gql`
 `
 
 export class FuzzyRepos extends FuzzyQuery {
-    constructor(private readonly client: ApolloClient<object> | undefined, onNamesChanged: () => void) {
-        super(onNamesChanged, new FuzzyWebCache('fuzzy-finder.repository-names', values => this.staleResults(values)))
+    constructor(
+        private readonly client: ApolloClient<object> | undefined,
+        onNamesChanged: () => void,
+        private userHistory: UserHistory
+    ) {
+        super(
+            onNamesChanged,
+            new FuzzyStorageCache(window.localStorage, 'fuzzy-finder.repository-names', values =>
+                this.staleResults(values)
+            )
+        )
     }
 
     /* override */ protected rawQuery(query: string): string {
@@ -34,7 +44,17 @@ export class FuzzyRepos extends FuzzyQuery {
     }
 
     /* override */ protected searchValues(): SearchValue[] {
-        return [...this.queryResults.values()].map(({ text, url, stars }) => {
+        const queryResults = [...this.queryResults.values()]
+        const queryResultRepos = new Set(queryResults.map(({ text }) => text))
+
+        // Include repositories from the user history even if they are not
+        // present in the local cache. This happens when the user has visited a
+        // repository that they haven't searched for in the fuzzy finder.
+        const fromHistory = this.userHistory
+            .visitedRepos()
+            .filter(repoName => !queryResultRepos.has(repoName))
+            .map<PersistableQueryResult>(repoName => ({ text: repoName, url: `/${repoName}` }))
+        return [...queryResults, ...fromHistory].map<SearchValue>(({ text, url, stars }) => {
             const formattedRepositoryStarCount = formatRepositoryStarCount(stars)
             const icon = <CodeHostIcon repoName={text} />
 
@@ -49,6 +69,7 @@ export class FuzzyRepos extends FuzzyQuery {
                             <span aria-hidden={true}>{formattedRepositoryStarCount}</span>
                         </span>
                     ) : undefined,
+                historyRanking: () => this.userHistory.lastAccessedRepo(text),
                 ranking: stars,
             }
         })

--- a/client/web/src/components/fuzzyFinder/FuzzyRepos.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyRepos.tsx
@@ -7,10 +7,10 @@ import { CodeHostIcon, formatRepositoryStarCount, SearchResultStar } from '@sour
 import { getWebGraphQLClient } from '../../backend/graphql'
 import { SearchValue } from '../../fuzzyFinder/SearchValue'
 import { FuzzyFinderRepoResult, FuzzyFinderRepoVariables } from '../../graphql-operations'
+import { UserHistory } from '../useUserHistory'
 
 import { FuzzyStorageCache, PersistableQueryResult } from './FuzzyLocalCache'
 import { FuzzyQuery } from './FuzzyQuery'
-import { UserHistory } from '../useUserHistory'
 
 export const FUZZY_REPOS_QUERY = gql`
     query FuzzyFinderRepo($query: String!) {

--- a/client/web/src/components/fuzzyFinder/FuzzySymbols.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzySymbols.tsx
@@ -7,11 +7,12 @@ import { isSettingsValid, SettingsCascadeOrError } from '@sourcegraph/shared/src
 import { SymbolKind } from '@sourcegraph/shared/src/symbols/SymbolKind'
 
 import { getWebGraphQLClient } from '../../backend/graphql'
-import { SearchValue } from '../../fuzzyFinder/FuzzySearch'
+import { SearchValue } from '../../fuzzyFinder/SearchValue'
 
 import { emptyFuzzyCache, PersistableQueryResult } from './FuzzyLocalCache'
 import { FuzzyQuery } from './FuzzyQuery'
 import { FuzzyRepoRevision, fuzzyRepoRevisionSearchFilter } from './FuzzyRepoRevision'
+import { UserHistory } from '../useUserHistory'
 
 export const FUZZY_SYMBOLS_QUERY = gql`
     fragment FileMatchFields on FileMatch {
@@ -50,7 +51,8 @@ export class FuzzySymbols extends FuzzyQuery {
         onNamesChanged: () => void,
         private readonly repoRevision: React.MutableRefObject<FuzzyRepoRevision>,
         private readonly isGlobalSymbols: boolean,
-        private readonly settingsCascade: SettingsCascadeOrError
+        private readonly settingsCascade: SettingsCascadeOrError,
+        private readonly userHistory: UserHistory
     ) {
         // Symbol results should not be cached because stale symbol data is complicated to evict/invalidate.
         super(onNamesChanged, emptyFuzzyCache)
@@ -67,9 +69,10 @@ export class FuzzySymbols extends FuzzyQuery {
         const repositoryText = `${repositoryName}/`
         const symbolKindTags =
             isSettingsValid(this.settingsCascade) && this.settingsCascade.final.experimentalFeatures?.symbolKindTags
-        return values.map(({ text, url, symbolKind }) => ({
+        return values.map<SearchValue>(({ text, url, symbolKind, repoName, filePath }) => ({
             text: repositoryFilter ? text.replace(repositoryText, '') : text,
             url,
+            ranking: repoName && filePath ? this.userHistory.lastAccessedFilePath(repoName, filePath) : undefined,
             icon: symbolKind ? (
                 <SymbolKind kind={symbolKind} className="mr-1" symbolKindTags={symbolKindTags} />
             ) : undefined,
@@ -95,6 +98,8 @@ export class FuzzySymbols extends FuzzyQuery {
                     const repository = result.repository.name ? `${result.repository.name}/` : ''
                     const containerName = symbol.containerName ? ` (${symbol.containerName})` : ''
                     queryResults.push({
+                        repoName: result.repository.name,
+                        filePath: result.file.path,
                         text: `${symbol.name}${containerName} - ${repository}${result.file.path} - ${symbol.language}`,
                         url: symbol.url,
                         symbolKind: symbol.kind,

--- a/client/web/src/components/fuzzyFinder/FuzzySymbols.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzySymbols.tsx
@@ -8,11 +8,11 @@ import { SymbolKind } from '@sourcegraph/shared/src/symbols/SymbolKind'
 
 import { getWebGraphQLClient } from '../../backend/graphql'
 import { SearchValue } from '../../fuzzyFinder/SearchValue'
+import { UserHistory } from '../useUserHistory'
 
 import { emptyFuzzyCache, PersistableQueryResult } from './FuzzyLocalCache'
 import { FuzzyQuery } from './FuzzyQuery'
 import { FuzzyRepoRevision, fuzzyRepoRevisionSearchFilter } from './FuzzyRepoRevision'
-import { UserHistory } from '../useUserHistory'
 
 export const FUZZY_SYMBOLS_QUERY = gql`
     fragment FileMatchFields on FileMatch {

--- a/client/web/src/components/fuzzyFinder/FuzzyTabs.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyTabs.tsx
@@ -218,11 +218,6 @@ export interface FuzzyTabsProps extends FuzzyActionProps {
     userHistory: UserHistory
 }
 
-interface FuzzyVisibility {
-    isVisible: boolean
-    activeTab: keyof Tabs
-}
-
 export function useFuzzyState(props: FuzzyTabsProps): FuzzyState {
     const {
         themeState,
@@ -260,7 +255,6 @@ export function useFuzzyState(props: FuzzyTabsProps): FuzzyState {
         getFuzzyFinderFeatureFlags(props.settingsCascade.final)
 
     const [activeTab, setActiveTab] = useState<FuzzyTabKey>('all')
-    const isVisibleHistory = useRef<FuzzyVisibility>({ isVisible, activeTab })
 
     // NOTE: the query is cached in session storage to mimic the file pickers in
     // IntelliJ (by default) and VS Code (when "Workbench > Quick Open >
@@ -272,10 +266,6 @@ export function useFuzzyState(props: FuzzyTabsProps): FuzzyState {
     // is cycling through results by repeatedly activating the fuzzy finder
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const rankingCache = useMemo(() => new SearchValueRankingCache(), [query])
-
-    useEffect(() => {
-        isVisibleHistory.current = { isVisible, activeTab }
-    }, [isVisible, activeTab])
 
     const queryRef = useRef(query)
     queryRef.current = query

--- a/client/web/src/components/fuzzyFinder/HighlightedLink.tsx
+++ b/client/web/src/components/fuzzyFinder/HighlightedLink.tsx
@@ -21,6 +21,9 @@ export interface HighlightedLinkProps {
     icon?: JSX.Element
     textSuffix?: JSX.Element
     onClick?: () => void
+    // Fuzzy finding score, used to sort aggregated results across different
+    // fuzzy finder tabs.
+    score?: number
 }
 
 export function offsetSum(props: HighlightedLinkProps): number {

--- a/client/web/src/components/useUserHistory.ts
+++ b/client/web/src/components/useUserHistory.ts
@@ -53,19 +53,7 @@ export class UserHistory {
         }
         repo.delete(entry.filePath)
     }
-    public onEntry(entry: UserHistoryEntry): void {
-        let repo = this.repos.get(entry.repoName)
-        if (!repo) {
-            repo = new Map()
-            this.repos.set(entry.repoName, repo)
-        }
-        repo.set(LAST_REPO_ACCESS_FILEPATH, entry.lastAccessed)
-        if (!entry.filePath) {
-            return
-        }
-        repo.set(entry.filePath, entry.lastAccessed)
-    }
-    public persist(): void {
+    private persist(): void {
         const entries: UserHistoryEntry[] = []
         for (const repoName of this.repos.keys()) {
             const repoMap = this.repos.get(repoName) ?? new Map<string, number>()
@@ -78,11 +66,21 @@ export class UserHistory {
         }
         this.saveEntries(entries)
     }
+    private onEntry(entry: UserHistoryEntry): void {
+        let repo = this.repos.get(entry.repoName)
+        if (!repo) {
+            repo = new Map()
+            this.repos.set(entry.repoName, repo)
+        }
+        repo.set(LAST_REPO_ACCESS_FILEPATH, entry.lastAccessed)
+        if (!entry.filePath) {
+            return
+        }
+        repo.set(entry.filePath, entry.lastAccessed)
+    }
     public onLocation(location: H.Location): boolean {
         try {
-            const { repoName = '', filePath = '' } = parseBrowserRepoURL(
-                location.pathname + location.search + location.hash
-            )
+            const { repoName, filePath } = parseBrowserRepoURL(location.pathname + location.search + location.hash)
             if (!repoName) {
                 return false
             }

--- a/client/web/src/components/useUserHistory.ts
+++ b/client/web/src/components/useUserHistory.ts
@@ -1,6 +1,7 @@
-import { useLocalStorage } from '@sourcegraph/wildcard'
+import { useMemo } from 'react'
+
 import * as H from 'history'
-import { useEffect, useMemo, useRef } from 'react'
+
 import { parseBrowserRepoURL } from '../util/url'
 
 export interface UserHistoryEntry {
@@ -23,7 +24,9 @@ export class UserHistory {
     private storage = window.localStorage
     private storageKey = 'user-history'
     constructor() {
-        this.loadEntries().forEach(entry => this.onEntry(entry))
+        for (const entry of this.loadEntries()) {
+            this.onEntry(entry)
+        }
     }
     private saveEntries(entries: UserHistoryEntry[]): void {
         this.storage.setItem(this.storageKey, JSON.stringify(entries))
@@ -67,9 +70,9 @@ export class UserHistory {
             this.onEntry({ repoName, filePath, lastAccessed: Date.now() })
             this.persist()
             return true
-        } catch (error) {
-            console.log(location, error)
-        } // Ignore errors
+        } catch {
+            // continue regardless of error
+        }
         return false
     }
     public visitedRepos(): string[] {

--- a/client/web/src/components/useUserHistory.ts
+++ b/client/web/src/components/useUserHistory.ts
@@ -1,0 +1,83 @@
+import { useLocalStorage } from '@sourcegraph/wildcard'
+import * as H from 'history'
+import { useEffect, useMemo, useRef } from 'react'
+import { parseBrowserRepoURL } from '../util/url'
+
+export interface UserHistoryEntry {
+    repoName: string
+    filePath?: string
+    lastAccessed: number
+}
+
+const LAST_REPO_ACCESS_FILEPATH = 'sourcegraph-last-repo-access.timestamp'
+
+/**
+ * Collects all browser history events and stores which repos/files are visited
+ * in local storage.  In the future, we should consider storing this history
+ * remotely in temporary settings (or similar). The history is used to
+ * personalize ranking in the fuzzy finder, but could theorically power other
+ * features like improve ranking in the search bar suggestions.
+ */
+export class UserHistory {
+    private repos: Map<string, Map<string, number>> = new Map()
+    constructor(private setEntries: React.Dispatch<React.SetStateAction<UserHistoryEntry[]>>) {}
+    public onEntry(entry: UserHistoryEntry): void {
+        let repo = this.repos.get(entry.repoName)
+        if (!repo) {
+            repo = new Map()
+            this.repos.set(entry.repoName, repo)
+        }
+        repo.set(LAST_REPO_ACCESS_FILEPATH, entry.lastAccessed)
+        if (!entry.filePath) {
+            return
+        }
+        repo.set(entry.filePath, entry.lastAccessed)
+    }
+    public persist(): void {
+        const entries: UserHistoryEntry[] = []
+        for (const repoName of this.repos.keys()) {
+            const repoMap = this.repos.get(repoName) ?? new Map<string, number>()
+            for (const filePath of repoMap.keys()) {
+                const lastAccessed = repoMap.get(filePath)
+                if (lastAccessed) {
+                    entries.push({ repoName, filePath, lastAccessed })
+                }
+            }
+        }
+        this.setEntries(entries)
+    }
+    public onLocation(location: H.Location): boolean {
+        try {
+            const { repoName = '', filePath = '' } = parseBrowserRepoURL(
+                location.pathname + location.search + location.hash
+            )
+            if (!repoName) {
+                return false
+            }
+            this.onEntry({ repoName, filePath, lastAccessed: Date.now() })
+            return true
+        } catch (error) {
+            console.log(location, error)
+        } // Ignore errors
+        return false
+    }
+    public visitedRepos(): string[] {
+        return [...this.repos.keys()]
+    }
+    public lastAccessedRepo(repoName: string): number | undefined {
+        return this.repos.get(repoName)?.get(LAST_REPO_ACCESS_FILEPATH)
+    }
+    public lastAccessedFilePath(repoName: string, filePath: string): number | undefined {
+        return this.repos.get(repoName)?.get(filePath)
+    }
+}
+
+export function useUserHistory(history: H.History, isRepositoryRelatedPage: boolean): UserHistory {
+    const [entries, setEntries] = useLocalStorage<UserHistoryEntry[]>('user-history', [])
+    const userHistory = useMemo(() => new UserHistory(setEntries), [setEntries])
+    useEffect(() => entries.forEach(entry => userHistory.onEntry(entry)), [])
+    if (isRepositoryRelatedPage) {
+        userHistory.onLocation(history.location)
+    }
+    return userHistory
+}

--- a/client/web/src/components/useUserHistory.ts
+++ b/client/web/src/components/useUserHistory.ts
@@ -106,14 +106,12 @@ export class UserHistory {
 }
 
 export function useUserHistory(history: H.History, isRepositoryRelatedPage: boolean): UserHistory {
-    const {
-        location: { pathname },
-    } = history
+    const { location } = history
     const userHistory = useMemo(() => new UserHistory(), [])
     useEffect(() => {
         if (isRepositoryRelatedPage) {
-            userHistory.onLocation(history.location)
+            userHistory.onLocation(location)
         }
-    }, [pathname])
+    }, [userHistory, location, isRepositoryRelatedPage])
     return userHistory
 }

--- a/client/web/src/fuzzyFinder/AggregateFuzzySearch.ts
+++ b/client/web/src/fuzzyFinder/AggregateFuzzySearch.ts
@@ -17,6 +17,8 @@ export class AggregateFuzzySearch extends FuzzySearch {
             result.links.push(...searchResult.links)
             result.isComplete = result.isComplete && searchResult.isComplete
         }
+        // Sort aggregated results based on fuzzy score.
+        result.links.sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
         return result
     }
 }

--- a/client/web/src/fuzzyFinder/FuzzySearch.ts
+++ b/client/web/src/fuzzyFinder/FuzzySearch.ts
@@ -1,4 +1,5 @@
 import { HighlightedLinkProps } from '../components/fuzzyFinder/HighlightedLink'
+
 import { SearchValueRankingCache } from './SearchValueRankingCache'
 
 export interface FuzzySearchParameters {

--- a/client/web/src/fuzzyFinder/FuzzySearch.ts
+++ b/client/web/src/fuzzyFinder/FuzzySearch.ts
@@ -1,8 +1,10 @@
 import { HighlightedLinkProps } from '../components/fuzzyFinder/HighlightedLink'
+import { SearchValueRankingCache } from './SearchValueRankingCache'
 
 export interface FuzzySearchParameters {
     query: string
     maxResults: number
+    cache?: SearchValueRankingCache
 }
 
 export interface FuzzySearchResult {
@@ -15,14 +17,6 @@ export interface FuzzySearchResult {
 export enum SearchIconKind {
     codeHost,
     symbol,
-}
-
-export interface SearchValue {
-    text: string
-    ranking?: number
-    url?: string
-    icon?: JSX.Element
-    onClick?: () => void
 }
 
 export type IndexingFSM = SearchIndexing | SearchReady

--- a/client/web/src/fuzzyFinder/SearchValue.ts
+++ b/client/web/src/fuzzyFinder/SearchValue.ts
@@ -1,8 +1,7 @@
 export interface SearchValue {
     text: string
     // Score for previously visited results. History ranking is a callback
-    // to allow the
-    //
+    // to allow flexible caching with `SearchValueRankingCache`.
     historyRanking?: () => number | undefined
     ranking?: number
     url?: string

--- a/client/web/src/fuzzyFinder/SearchValue.ts
+++ b/client/web/src/fuzzyFinder/SearchValue.ts
@@ -1,0 +1,11 @@
+export interface SearchValue {
+    text: string
+    // Score for previously visited results. History ranking is a callback
+    // to allow the
+    //
+    historyRanking?: () => number | undefined
+    ranking?: number
+    url?: string
+    icon?: JSX.Element
+    onClick?: () => void
+}

--- a/client/web/src/fuzzyFinder/SearchValueRankingCache.ts
+++ b/client/web/src/fuzzyFinder/SearchValueRankingCache.ts
@@ -1,8 +1,9 @@
 import { SearchValue } from './SearchValue'
 
-// Helper to cache the result of `SearchValue.historyRanking()`.  This
-// optimization helps in large repositories where we sort a large number of
-// files by their rank.
+// Helper to cache the result of `SearchValue.historyRanking()`, which is both
+// useful for 1) good UX to keep the ranking stable as long as the query is
+// unchanged and 2) performance in large repositories where we sort a large
+// number of files by their rank score.
 export class SearchValueRankingCache {
     private cache: Map<SearchValue, number> = new Map()
     public rank(value: SearchValue): number {

--- a/client/web/src/fuzzyFinder/SearchValueRankingCache.ts
+++ b/client/web/src/fuzzyFinder/SearchValueRankingCache.ts
@@ -1,0 +1,20 @@
+import { SearchValue } from './SearchValue'
+
+// Helper to cache the result of `SearchValue.historyRanking()`.  This
+// optimization helps in large repositories where we sort a large number of
+// files by their rank.
+export class SearchValueRankingCache {
+    private cache: Map<SearchValue, number> = new Map()
+    public rank(value: SearchValue): number {
+        if (value.historyRanking === undefined) {
+            return 0
+        }
+        const fromCache = this.cache.get(value)
+        if (fromCache !== undefined) {
+            return fromCache
+        }
+        const ranking = value.historyRanking() ?? 0
+        this.cache.set(value, ranking)
+        return ranking
+    }
+}

--- a/client/web/src/fuzzyFinder/WordSensitiveFuzzySearch.ts
+++ b/client/web/src/fuzzyFinder/WordSensitiveFuzzySearch.ts
@@ -2,7 +2,8 @@ import { BloomFilter } from 'bloomfilter'
 
 import { HighlightedLinkProps, offsetSum, RangePosition } from '../components/fuzzyFinder/HighlightedLink'
 
-import { FuzzySearch, IndexingFSM, FuzzySearchParameters, FuzzySearchResult, SearchValue } from './FuzzySearch'
+import { FuzzySearch, IndexingFSM, FuzzySearchParameters, FuzzySearchResult } from './FuzzySearch'
+import { SearchValue } from './SearchValue'
 import { Hasher } from './Hasher'
 
 /**

--- a/client/web/src/fuzzyFinder/WordSensitiveFuzzySearch.ts
+++ b/client/web/src/fuzzyFinder/WordSensitiveFuzzySearch.ts
@@ -3,8 +3,8 @@ import { BloomFilter } from 'bloomfilter'
 import { HighlightedLinkProps, offsetSum, RangePosition } from '../components/fuzzyFinder/HighlightedLink'
 
 import { FuzzySearch, IndexingFSM, FuzzySearchParameters, FuzzySearchResult } from './FuzzySearch'
-import { SearchValue } from './SearchValue'
 import { Hasher } from './Hasher'
+import { SearchValue } from './SearchValue'
 
 /**
  * We don't index filenames with length larger than this value.


### PR DESCRIPTION
Previously, the fuzzy finder did a bad job of surfacing frequently visited repos, symbols, and files. This PR adds personalized ranking by boosting results that the user has previously visited. This feature requires new infrastructure to collect the browsing history of the user. This PR stores the browser history in local storage but we may want to move this to a remote storage like temporary settings in the future.

Demo https://www.loom.com/share/54e39f710982443fa76689d5dd20153b


## Test plan

Start local server
```
SOURCEGRAPHDOTCOM_MODE=true SOURCEGRAPH_API_URL=https://sourcegraph.com sg start web-standalone
```

* Visit random repos and files
* Open fuzzy finder and observe that the visited repos and files get ranked at the top


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-fuzzy-history.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
