### PR TITLE
Insights: handle repo revs when filtering by search context

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
-
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/search"
 
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
@@ -69,7 +69,10 @@ func unwrapSearchContexts(ctx context.Context, loader SearchContextLoader, rawCo
 				return nil, nil, errors.Wrapf(err, "failed to parse search query for search context: %s", rawContext)
 			}
 			inc, exc := plan.ToQ().Repositories()
-			include = append(include, inc...)
+			for _, repoFilter := range inc {
+				repo, _ := search.ParseRepositoryRevisions(repoFilter)
+				include = append(include, repo)
+			}
 			exclude = append(exclude, exc...)
 		}
 	}

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -70,7 +70,11 @@ func unwrapSearchContexts(ctx context.Context, loader SearchContextLoader, rawCo
 			}
 			inc, exc := plan.ToQ().Repositories()
 			for _, repoFilter := range inc {
-				repo, _ := search.ParseRepositoryRevisions(repoFilter)
+				repo, repoRevs := search.ParseRepositoryRevisions(repoFilter)
+
+				if len(repoRevs) > 0 {
+					return nil, nil, errors.Errorf("search context filters cannot include repo revisions: %s", rawContext)
+				}
 				include = append(include, repo)
 			}
 			exclude = append(exclude, exc...)

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers_test.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers_test.go
@@ -101,6 +101,30 @@ func TestFilterRepositories(t *testing.T) {
 			want: []string{"gitlab.com/myrepo/repo", "gitlab.com/yourrepo/yourrepo"},
 		},
 		{
+			name:         "test context include with revision",
+			repositories: []string{"github.com/sourcegraph/sourcegraph", "gitlab.com/myrepo/repo"},
+			filters:      types.InsightViewFilters{SearchContexts: []string{"@dev/mycontext123"}},
+			searchContexts: []struct {
+				name  string
+				query string
+			}{
+				{name: "@dev/mycontext123", query: "repo:^github\\.com/sourcegraph/.*$ rev:v1.0.0"},
+			},
+			want: []string{"github.com/sourcegraph/sourcegraph"},
+		},
+		{
+			name:         "test context include with repo revision",
+			repositories: []string{"github.com/sourcegraph/sourcegraph", "gitlab.com/myrepo/repo"},
+			filters:      types.InsightViewFilters{SearchContexts: []string{"@dev/mycontext123"}},
+			searchContexts: []struct {
+				name  string
+				query string
+			}{
+				{name: "@dev/mycontext123", query: "repo:^github\\.com/sourcegraph/.*$@:v1.0.0"},
+			},
+			want: []string{"github.com/sourcegraph/sourcegraph"},
+		},
+		{
 			name:         "test context exclude include",
 			repositories: []string{"github.com/sourcegraph/sourcegraph", "gitlab.com/myrepo/repo", "gitlab.com/yourrepo/yourrepo"},
 			filters:      types.InsightViewFilters{SearchContexts: []string{"@dev/mycontext123"}},

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers_test.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	internalTypes "github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func addrStr(input string) *string {
@@ -35,6 +36,7 @@ func TestFilterRepositories(t *testing.T) {
 		repositories   []string
 		filters        types.InsightViewFilters
 		want           []string
+		wantErr        error
 		searchContexts []struct {
 			name  string
 			query string
@@ -110,7 +112,7 @@ func TestFilterRepositories(t *testing.T) {
 			}{
 				{name: "@dev/mycontext123", query: "repo:^github\\.com/sourcegraph/.*$ rev:v1.0.0"},
 			},
-			want: []string{"github.com/sourcegraph/sourcegraph"},
+			wantErr: errors.New("search context filters cannot include repo revisions: @dev/mycontext123"),
 		},
 		{
 			name:         "test context include with repo revision",
@@ -122,7 +124,7 @@ func TestFilterRepositories(t *testing.T) {
 			}{
 				{name: "@dev/mycontext123", query: "repo:^github\\.com/sourcegraph/.*$@:v1.0.0"},
 			},
-			want: []string{"github.com/sourcegraph/sourcegraph"},
+			wantErr: errors.New("search context filters cannot include repo revisions: @dev/mycontext123"),
 		},
 		{
 			name:         "test context exclude include",
@@ -181,15 +183,16 @@ func TestFilterRepositories(t *testing.T) {
 			}
 
 			got, err := filterRepositories(ctx, test.filters, test.repositories, &fakeSearchContextLoader{mocks: mocks})
-			if err != nil {
-				t.Error(err)
+			if !errors.Is(err, test.wantErr) {
+				t.Errorf("unexpected error, want: %v, got: %v", test.wantErr, err)
 			}
+
 			// sort for test determinism
 			sort.Slice(got, func(i, j int) bool {
 				return got[i] < got[j]
 			})
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("unexpected repository result (want/got): %v", diff)
+				t.Errorf("unexpected repository result (want/got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Code insights allows filtering the repositories on-the-fly using a search
context. To support this, the insights code loads the search context query,
extracts its repo filter, and compiles the filter regex.

The search context repo filters can contain revisions too. The logic doesn't
account for this and just compiles the whole repo@revision string. This filter
will never match any repos. If the revision is not a valid regex, then it can
also fail to compile and cause a cryptic error.

Now we parse the repo filter and return an error when any revisions are
present. This lets the user know their context won't work as intended.

## Test plan

Added cases to `insight_view_resolvers_test.go`, light manual testing
