### PR TITLE
Code Insights: Fix drill-down filters UI panel on the dashboard page

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-input/DrillDownInput.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-input/DrillDownInput.module.scss
@@ -2,7 +2,8 @@
     flex-shrink: 0;
     padding: 0.25rem 0.5rem;
     border: 1px solid var(--input-border-color);
-    background: var(--input-border-color);
+    border-right: none;
+    background: var(--subtle-bg);
     border-top-left-radius: var(--border-radius);
     border-bottom-left-radius: var(--border-radius);
     color: var(--link-color);

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.module.scss
@@ -55,15 +55,10 @@
 .popover {
     width: 100%;
     border-radius: 0;
-    padding: 0.75rem 1rem;
-
-    hr {
-        margin-left: -1rem;
-        margin-right: -1rem;
-    }
+    padding: 0.75rem;
 
     &--with-filters {
-        max-width: 34.375rem;
+        max-width: 33.375rem;
         min-width: 15rem;
     }
 

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-popover/DrillDownFiltersPopover.tsx
@@ -3,7 +3,16 @@ import { FC, RefObject, useRef, useState } from 'react'
 import { mdiFilterOutline } from '@mdi/js'
 import classNames from 'classnames'
 
-import { Button, Icon, Popover, PopoverContent, PopoverTrigger, Position, createRectangle } from '@sourcegraph/wildcard'
+import {
+    Button,
+    Icon,
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+    PopoverTail,
+    Position,
+    createRectangle,
+} from '@sourcegraph/wildcard'
 
 import { InsightFilters } from '../../../../../../core'
 import { FormChangeEvent, SubmissionResult } from '../../../../../form/hooks/useForm'
@@ -18,7 +27,7 @@ import {
 
 import styles from './DrillDownFiltersPopover.module.scss'
 
-const POPOVER_TARGET_PADDING = createRectangle(0, 0, 5, 5)
+const POPOVER_TARGET_PADDING = createRectangle(0, 0, 4, 4)
 const POPOVER_CONTAINER_PADDING = { top: 58 }
 
 interface DrillDownFiltersPopoverProps {
@@ -121,6 +130,8 @@ export const DrillDownFiltersPopover: FC<DrillDownFiltersPopoverProps> = props =
                     />
                 )}
             </PopoverContent>
+
+            <PopoverTail size="sm" />
         </Popover>
     )
 }


### PR DESCRIPTION
In this PR we add popover tail element (in order to visually connect insight card and its drill down UI panel) also tweak drill down fields prefix background to be closer to other filters color tokens, for example, on the home page - context picker)

<img width="906" alt="Screenshot 2023-01-03 at 17 37 29" src="https://user-images.githubusercontent.com/18492575/210437583-86e5bb9f-c6a9-48e0-b2ef-edff30b436ef.png">

## Test plan
- Make sure that you can see the drill down panel UI on the dashboard page

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-drilldown-popover-ui.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
