### PR TITLE
chore: Make variable name more specific

### DIFF
--- a/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
@@ -171,14 +171,14 @@ func migrateUpload(
 		return nil
 	}
 
-	cacheSize := scipMigratorResultChunkDefaultCacheSize
-	if numResultChunks < cacheSize {
-		cacheSize = numResultChunks
+	resultChunkCacheSize := scipMigratorResultChunkDefaultCacheSize
+	if numResultChunks < resultChunkCacheSize {
+		resultChunkCacheSize = numResultChunks
 	}
-	resultChunkCache := lru.New(cacheSize)
+	resultChunkCache := lru.New(resultChunkCacheSize)
 
 	// Warm result chunk cache if it will all fit in the cache
-	if numResultChunks <= cacheSize {
+	if numResultChunks <= resultChunkCacheSize {
 		ids := make([]ID, 0, numResultChunks)
 		for i := 0; i < numResultChunks; i++ {
 			ids = append(ids, ID(strconv.Itoa(i)))


### PR DESCRIPTION
Improvements to the SCIP migrator prior to its registration in #45106. This PR renames a variable to distinguish between different cache sizes.

## Test plan

Tested by hand.