### PR TITLE
oobmigration: Improve error message for SCIP migration

### DIFF
--- a/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
@@ -102,6 +102,14 @@ func (m *scipMigrator) upSingle(ctx context.Context) (err error) {
 		return nil
 	}
 
+	defer func() {
+		if err != nil {
+			// Wrap any error after this point with the associated upload ID. This will present
+			// itself in the database/UI for site-admins/engineers to locate a poisonous record.
+			err = errors.Wrapf(err, "failed to migrate upload %d", uploadID)
+		}
+	}()
+
 	scipWriter, err := makeSCIPWriter(ctx, tx, uploadID)
 	if err != nil {
 		return err


### PR DESCRIPTION
Improvements to the SCIP migrator prior to its registration in #45106. This PR wraps the upload identifier along with error messages during migrations so that if an error does occur we can track it down from the records in the `out_of_band_migration_log_errors` table.

## Test plan

Tested by hand.