### PR TITLE
oobmigration: Make the processDocument method in SCIP migrator pure

### DIFF
--- a/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator.go
@@ -212,18 +212,22 @@ func migrateUpload(
 		}
 
 		for path, document := range documentsByPath {
-			if err := processDocument(
+			scipDocument, err := processDocument(
 				ctx,
 				codeintelTx,
 				serializer,
-				scipWriter,
 				resultChunkCache,
 				uploadID,
 				numResultChunks,
 				indexerName,
 				path,
 				document,
-			); err != nil {
+			)
+			if err != nil {
+				return err
+			}
+
+			if err := scipWriter.InsertDocument(ctx, path, scipDocument); err != nil {
 				return err
 			}
 		}
@@ -277,14 +281,13 @@ func processDocument(
 	ctx context.Context,
 	tx *basestore.Store,
 	serializer *serializer,
-	scipWriter *scipWriter,
 	resultChunkCache *lru.Cache,
 	uploadID int,
 	numResultChunks int,
 	indexerName,
 	path string,
 	document DocumentData,
-) error {
+) (*ogscip.Document, error) {
 	// We first read the relevant result chunks for this document into memory, writing them through to the
 	// shared result chunk cache to avoid re-fetching result chunks that are used to processed to documents
 	// in a row.
@@ -299,7 +302,7 @@ func processDocument(
 		extractDefinitionResultIDs(document.Ranges),
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	definitionMatcher := func(
@@ -329,11 +332,7 @@ func processDocument(
 		toPreciseTypes(document),
 	))
 
-	if err := scipWriter.InsertDocument(ctx, path, scipDocument); err != nil {
-		return err
-	}
-
-	return nil
+	return scipDocument, nil
 }
 
 // fetchResultChunks queries for the set of result chunks containing one of the given result set


### PR DESCRIPTION
Improvements to the SCIP migrator prior to its registration in https://github.com/sourcegraph/sourcegraph/pull/45106. This PR refactors a function so that we don't have to thread the SCIP writer down so many layers.

## Test plan

Tested by hand.