### PR TITLE
web: bump `.card-header` specificity

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -181,7 +181,18 @@
     }
 }
 
-.card-header {
+// The nested selector is required to bump the selector specificity and resolve the issue
+// with different selector-order in the production bundle.
+// See https://github.com/sourcegraph/sourcegraph/issues/46081.
+//
+// It's not possible to use the `:where()` selector in the `CardHeader` CSS module because the
+// `typed-scss-modules` package that generates Typescript type definitions for CSS modules
+// relies on the outdated PostCSS version, which doesn't generate `:exports` statements for pseudo selectors correctly.
+// See related issues:
+// - https://github.com/skovy/typed-scss-modules/pull/166
+// - https://github.com/css-modules/css-modules-loader-core/pull/231
+/* stylelint-disable-next-line selector-max-compound-selectors */
+.panel .card-header {
     padding-top: 0.1rem;
     padding-bottom: 0.1rem;
     padding-left: 1rem;

--- a/client/wildcard/src/components/Card/components/CardHeader.module.scss
+++ b/client/wildcard/src/components/Card/components/CardHeader.module.scss
@@ -1,4 +1,4 @@
-.card-header {
+:where(.card-header) {
     padding: 0.5rem;
     background-color: var(--color-bg-2);
     border-bottom: 1px solid var(--card-border-color);

--- a/client/wildcard/src/components/Card/components/CardHeader.module.scss
+++ b/client/wildcard/src/components/Card/components/CardHeader.module.scss
@@ -1,4 +1,4 @@
-:where(.card-header) {
+.card-header {
     padding: 0.5rem;
     background-color: var(--color-bg-2);
     border-bottom: 1px solid var(--card-border-color);


### PR DESCRIPTION
## Context

- Closes https://github.com/sourcegraph/sourcegraph/issues/46081
- The underlying issue https://github.com/sourcegraph/sourcegraph/issues/42217

To address the root cause, we need to invest more time in restructuring Wildcard exports, as described in the linked issue.

> Restructure exports in packages with CSS modules to enable tree-shaking without relying on the `sideEffects` property.

## Test plan

1. `sg start web-standalone-prod`
2. Open the references panel and check the styles

<img width="609" alt="Screenshot 2023-01-04 at 14 24 38" src="https://user-images.githubusercontent.com/3846380/210496293-2733e035-865c-4f40-a1de-6c76aff75da1.png">

## App preview:

- [Web](https://sg-web-vb-references-header-css-order.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

