### PR TITLE
graphqlbackend: make `excludeRepoFromExternalService` accept an array of external services.

### DIFF
--- a/client/web/src/repo/settings/backend.ts
+++ b/client/web/src/repo/settings/backend.ts
@@ -78,9 +78,9 @@ export function fetchSettingsAreaRepository(name: string): Observable<SettingsAr
     )
 }
 
-export const EXCLUDE_REPO_FROM_EXTERNAL_SERVICE = gql`
-    mutation ExcludeRepoFromExternalService($externalService: ID!, $repo: ID!) {
-        excludeRepoFromExternalService(externalService: $externalService, repo: $repo) {
+export const EXCLUDE_REPO_FROM_EXTERNAL_SERVICES = gql`
+    mutation ExcludeRepoFromExternalServices($externalServices: [ID!]!, $repo: ID!) {
+        excludeRepoFromExternalServices(externalServices: $externalServices, repo: $repo) {
             alwaysNil
         }
     }

--- a/client/web/src/repo/settings/components/ExternalServiceEntry.tsx
+++ b/client/web/src/repo/settings/components/ExternalServiceEntry.tsx
@@ -10,12 +10,12 @@ import { Alert, Button, ErrorAlert, LoadingSpinner, renderError, Tooltip } from 
 import { ExternalServiceCard } from '../../../components/externalServices/ExternalServiceCard'
 import { defaultExternalServices } from '../../../components/externalServices/externalServices'
 import {
-    ExcludeRepoFromExternalServiceResult,
-    ExcludeRepoFromExternalServiceVariables,
+    ExcludeRepoFromExternalServicesResult,
+    ExcludeRepoFromExternalServicesVariables,
     SettingsAreaExternalServiceFields,
     SettingsAreaRepositoryFields,
 } from '../../../graphql-operations'
-import { EXCLUDE_REPO_FROM_EXTERNAL_SERVICE } from '../backend'
+import { EXCLUDE_REPO_FROM_EXTERNAL_SERVICES } from '../backend'
 
 import styles from './ExternalServiceEntry.module.scss'
 
@@ -47,9 +47,9 @@ export const ExternalServiceEntry: FC<ExternalServiceEntryProps> = ({
 }) => {
     const [ttl, setTtl] = useState<number | undefined>(3)
     const [excludeRepo, { error, data, loading: isExcluding }] = useMutation<
-        ExcludeRepoFromExternalServiceResult,
-        ExcludeRepoFromExternalServiceVariables
-    >(EXCLUDE_REPO_FROM_EXTERNAL_SERVICE, {
+        ExcludeRepoFromExternalServicesResult,
+        ExcludeRepoFromExternalServicesVariables
+    >(EXCLUDE_REPO_FROM_EXTERNAL_SERVICES, {
         onCompleted: () => {
             let count = 3
             setInterval(() => {
@@ -97,7 +97,7 @@ export const ExternalServiceEntry: FC<ExternalServiceEntryProps> = ({
                                 updateExclusionLoading(true)
                                 excludeRepo({
                                     variables: {
-                                        externalService: service.id,
+                                        externalServices: [service.id],
                                         repo: repo.id,
                                     },
                                 })

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -131,9 +131,9 @@ type Mutation {
     """
     deleteExternalService(externalService: ID!, async: Boolean = false): EmptyResponse!
     """
-    Excludes a repo from external service config. Only site admins may perform this mutation.
+    Excludes a repo from external services configs. Only site admins may perform this mutation.
     """
-    excludeRepoFromExternalService(externalService: ID!, repo: ID!): EmptyResponse!
+    excludeRepoFromExternalServices(externalServices: [ID!]!, repo: ID!): EmptyResponse!
     """
     Tests the connection to a mirror repository's original source repository. This is an
     expensive and slow operation, so it should only be used for interactive diagnostics.


### PR DESCRIPTION
Targeting the branch of my previous PR which is soon to be merged.

Test plan:
Updated/added tests, local sg run + check that exclusion buttons work.

Part of https://github.com/sourcegraph/sourcegraph/issues/46109