### PR TITLE
security: redact unrecognized auth HTTP headers from logs

### DIFF
--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -62,7 +62,7 @@ func AccessTokenAuthMiddleware(db database.DB, logger log.Logger, next http.Hand
 					// We should parse the configuration to see if that's the case and only log if it's
 					// not defined over there.
 					logger.Warn(
-						"ignoring unrecognized Authorization header",
+						"ignoring unrecognized Authorization header, passing it down",
 						log.String("redacted_value", redactedValue),
 						log.Error(err),
 					)

--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -1,8 +1,10 @@
 package httpapi
 
 import (
+	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -43,9 +45,25 @@ func AccessTokenAuthMiddleware(db database.DB, logger log.Logger, next http.Hand
 			if err != nil {
 				if authz.IsUnrecognizedScheme(err) {
 					// Ignore Authorization headers that we don't handle.
+					// 🚨 SECURITY: md5sum the authorization header value so we redact it
+					// while still retaining the ability to link it back to a token, assuming
+					// the logs reader has the value in clear.
+					var redactedValue string
+					h := md5.New()
+					if _, err := io.WriteString(h, headerValue); err != nil {
+						redactedValue = "[REDACTED]"
+					} else {
+						redactedValue = fmt.Sprintf("md5sum:%x", h.Sum(nil))
+					}
+					// TODO: It is possible for the unrecognized header to be legitimate, in the case
+					// of a customer setting up a HTTP header based authentication and decide to still
+					// use the "Authorization" key.
+					//
+					// We should parse the configuration to see if that's the case and only log if it's
+					// not defined over there.
 					logger.Warn(
 						"ignoring unrecognized Authorization header",
-						log.String("value", headerValue),
+						log.String("redacted_value", redactedValue),
 						log.Error(err),
 					)
 					next.ServeHTTP(w, r)

--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -62,7 +62,7 @@ func AccessTokenAuthMiddleware(db database.DB, logger log.Logger, next http.Hand
 					// We should parse the configuration to see if that's the case and only log if it's
 					// not defined over there.
 					logger.Warn(
-						"ignoring unrecognized Authorization header, passing it down",
+						"ignoring unrecognized Authorization header, passing it down to the next layer",
 						log.String("redacted_value", redactedValue),
 						log.Error(err),
 					)


### PR DESCRIPTION
TL;DR The Authentication middleware currently logs custom authorization headers in clear.

When the Authentication middleware stumbled across a HTTP Header set to `Authorization: [name value]` and `name` is not one of the recognized Sourcegraph ones (i.e "token" or "sudo-token"), the logs were printing that value in clear.

While it's a rather limited concern as the logs are only accessible to ops and the use of custom authentication tokens are not a very frequent, it's still not okay to log them in clear.

The present code instead logs a md5sum in place of the value, allowing to still link back to the value we're expecting if we're debugging. If the hashing fails for any reason, the value is simply set to "[REDACTED]".

It is to be noted, that there are legitimate cases where can have unrecognized Authorization headers, and we should not log in those cases. As this would require to parse the current config, which requires more work, I decided for keeping this PR simple and focused on the security concern first.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Locally tested. Because the authorization header clashes with the one I'm testing my code with, I reproduced the customer setup with this addition to the site-config: 

```json
  "auth.providers": [
    // ...
    {
      "type": "http-header",
      "usernameHeader": "X-Forwarded-User",
      "emailHeader": "X-Forwarded-Email"
    }
```

And used the following `cURL`: 

```
~ $ curl -X POST -H 'Authorization: Bearer 2323' -H 'X-Forwarded-User: sourcegraph' -H 'Authorization: Bearer foobar' -d '{"query": "query { currentUser { username } }"}' 'https://sourcegraph.test:3443/.api/graphql'
```

Which then logs: 

```
[       frontend] WARN external.accessTokenAuth httpapi/auth.go:58 ignoring unrecognized Authorization header {"redacted_value": "md5sum:f3dce97acd1145b1274d05117a3847da", "error": "unrecognized HTTP Authorization request header scheme (supported values: \"token\", \"token-sudo\")"}
```

As expected. 