### PR TITLE
web: add support of excluding a repo from all code hosts.

### DIFF
--- a/client/web/src/repo/settings/RepoSettingsOptionsPage.module.scss
+++ b/client/web/src/repo/settings/RepoSettingsOptionsPage.module.scss
@@ -1,0 +1,12 @@
+.invisible-text {
+    visibility: hidden;
+}
+.button {
+    position: relative;
+}
+
+.loader {
+    position: absolute;
+    top: 25%;
+    left: 48%;
+}

--- a/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -1,13 +1,26 @@
 import { FC, useCallback, useEffect, useState } from 'react'
 
+import { noop } from 'lodash'
 import { RouteComponentProps } from 'react-router'
 
-import { useQuery } from '@sourcegraph/http-client'
-import { Container, ErrorAlert, H2, LoadingSpinner, PageHeader, Text } from '@sourcegraph/wildcard'
+import { useMutation, useQuery } from '@sourcegraph/http-client'
+import {
+    Alert,
+    Button,
+    Container,
+    ErrorAlert,
+    H2,
+    LoadingSpinner,
+    PageHeader,
+    renderError,
+    Text,
+} from '@sourcegraph/wildcard'
 
 import { CopyableText } from '../../components/CopyableText'
 import { PageTitle } from '../../components/PageTitle'
 import {
+    ExcludeRepoFromExternalServicesResult,
+    ExcludeRepoFromExternalServicesVariables,
     SettingsAreaRepositoryFields,
     SettingsAreaRepositoryResult,
     SettingsAreaRepositoryVariables,
@@ -17,8 +30,10 @@ import {
 import { SITE_EXTERNAL_SERVICE_CONFIG } from '../../site-admin/backend'
 import { eventLogger } from '../../tracking/eventLogger'
 
-import { FETCH_SETTINGS_AREA_REPOSITORY_GQL } from './backend'
+import { EXCLUDE_REPO_FROM_EXTERNAL_SERVICES, FETCH_SETTINGS_AREA_REPOSITORY_GQL } from './backend'
 import { ExternalServiceEntry } from './components/ExternalServiceEntry'
+
+import styles from './RepoSettingsOptionsPage.module.scss'
 
 interface Props extends RouteComponentProps<{}> {
     repo: SettingsAreaRepositoryFields
@@ -38,6 +53,7 @@ export const RepoSettingsOptionsPage: FC<Props> = ({ repo, history }) => {
     )
 
     const [exclusionInProgress, setExclusionInProgress] = useState<boolean>(false)
+    const [ttl, setTtl] = useState<number>(3)
 
     const updateExclusion = useCallback((updatedExclusionState: boolean) => {
         setExclusionInProgress(updatedExclusionState)
@@ -49,6 +65,22 @@ export const RepoSettingsOptionsPage: FC<Props> = ({ repo, history }) => {
         SiteExternalServiceConfigResult,
         SiteExternalServiceConfigVariables
     >(SITE_EXTERNAL_SERVICE_CONFIG, {})
+
+    const [excludeRepo, { data: excludeData, error: excludeError, loading: isExcluding }] = useMutation<
+        ExcludeRepoFromExternalServicesResult,
+        ExcludeRepoFromExternalServicesVariables
+    >(EXCLUDE_REPO_FROM_EXTERNAL_SERVICES, {
+        onCompleted: () => {
+            let count = 3
+            setInterval(() => {
+                if (count === 0) {
+                    history.push('/site-admin/external-services')
+                }
+                setTtl(count)
+                count--
+            }, 700)
+        },
+    })
 
     const excludingDisabled =
         (!siteConfigError &&
@@ -81,12 +113,47 @@ export const RepoSettingsOptionsPage: FC<Props> = ({ repo, history }) => {
                         ))}
                         {services.length > 1 && (
                             <>
-                                <Text className="text-muted">
-                                    This repository is mirrored from multiple code hosts. To remove the repository from
-                                    this Sourcegraph instance, all code host configurations need to be updated.
+                                <Text>
+                                    This repository is mirrored by multiple code hosts. To change access, disable, or
+                                    remove this repository, the configuration must be updated on all code hosts.
                                 </Text>
+                                <Button
+                                    variant="primary"
+                                    className={styles.button}
+                                    onClick={event => {
+                                        event.preventDefault()
+                                        setExclusionInProgress(true)
+                                        excludeRepo({
+                                            variables: {
+                                                externalServices: services.map(svc => svc.id),
+                                                repo: repo.id,
+                                            },
+                                        })
+                                            .catch(
+                                                // noop here is used because update error is handled directly when useMutation is called
+                                                noop
+                                            )
+                                            .finally(() => {
+                                                setExclusionInProgress(false)
+                                            })
+                                    }}
+                                    disabled={excludingDisabled || (exclusionInProgress && !isExcluding)}
+                                >
+                                    <span className={exclusionInProgress ? styles.invisibleText : ''}>
+                                        Exclude repository from all code hosts
+                                    </span>
+                                    {exclusionInProgress && <LoadingSpinner className={styles.loader} />}
+                                </Button>
+                                {excludeError && (
+                                    <ErrorAlert error={`Failed to exclude repository: ${renderError(excludeError)}`} />
+                                )}
+                                {excludeData && (
+                                    <Alert className={'mt-2'} variant="success">
+                                        {`Code host configurations updated. You will be redirected in ${ttl}...`}
+                                    </Alert>
+                                )}
                             </>
-                        )}
+                        )}{' '}
                     </div>
                 )}
             </Container>

--- a/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -52,9 +52,12 @@ export const RepoSettingsOptionsPage: FC<Props> = ({ repo, history }) => {
         { variables: { name: repo.name } }
     )
 
+    // This state shows that any of possible "exclude" buttons (in this or child components) were pushed.
+    // It is used to disable all the "exclude" buttons except the button which was actually clicked.
     const [exclusionInProgress, setExclusionInProgress] = useState<boolean>(false)
     const [ttl, setTtl] = useState<number>(3)
 
+    // Callback used in child components (ExternalServiceEntry) to update the state in current component.
     const updateExclusion = useCallback((updatedExclusionState: boolean) => {
         setExclusionInProgress(updatedExclusionState)
     }, [])
@@ -72,8 +75,9 @@ export const RepoSettingsOptionsPage: FC<Props> = ({ repo, history }) => {
     >(EXCLUDE_REPO_FROM_EXTERNAL_SERVICES, {
         onCompleted: () => {
             let count = 3
-            setInterval(() => {
+            const interval = setInterval(() => {
                 if (count === 0) {
+                    clearInterval(interval)
                     history.push('/site-admin/external-services')
                 }
                 setTtl(count)
@@ -148,7 +152,7 @@ export const RepoSettingsOptionsPage: FC<Props> = ({ repo, history }) => {
                                     <ErrorAlert error={`Failed to exclude repository: ${renderError(excludeError)}`} />
                                 )}
                                 {excludeData && (
-                                    <Alert className={'mt-2'} variant="success">
+                                    <Alert className="mt-2" variant="success">
                                         {`Code host configurations updated. You will be redirected in ${ttl}...`}
                                     </Alert>
                                 )}

--- a/client/web/src/repo/settings/components/ExternalServiceEntry.tsx
+++ b/client/web/src/repo/settings/components/ExternalServiceEntry.tsx
@@ -45,8 +45,8 @@ export const ExternalServiceEntry: FC<ExternalServiceEntryProps> = ({
     updateExclusionLoading,
     history,
 }) => {
-    const [ttl, setTtl] = useState<number | undefined>(3)
-    const [excludeRepo, { error, data, loading: isExcluding }] = useMutation<
+    const [ttl, setTtl] = useState<number>(3)
+    const [excludeRepo, { data, error, loading: isExcluding }] = useMutation<
         ExcludeRepoFromExternalServicesResult,
         ExcludeRepoFromExternalServicesVariables
     >(EXCLUDE_REPO_FROM_EXTERNAL_SERVICES, {


### PR DESCRIPTION
Test plan:
Local sg run and manual test.

### Quick demo
https://user-images.githubusercontent.com/94846361/210589590-88ebc2aa-8fea-4965-a065-3d1aee31fcd0.mov

Closes https://github.com/sourcegraph/sourcegraph/issues/46109

## App preview:

- [Web](https://sg-web-ao-ui-exclude-from-all-code-hosts.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
