### PR TITLE
Comby: move scanner error checking out of loop

### DIFF
--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -475,14 +475,14 @@ func runCombyAgainstTar(ctx context.Context, args comby.Args, tarInput comby.Tar
 
 		for scanner.Scan() {
 			b := scanner.Bytes()
-			if err := scanner.Err(); err != nil {
-				// warn on scanner errors and skip
-				log.NamedError("comby error: skipping scanner error line", err)
-				break
-			}
 			if r := comby.ToCombyFileMatchWithChunks(b); r != nil {
 				sender.Send(combyChunkMatchesToFileMatch(r.(*comby.FileMatchWithChunks)))
 			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			// warn on scanner errors and skip
+			log.NamedError("comby error: skipping scanner error line", err)
 		}
 	}()
 
@@ -523,12 +523,6 @@ func runCombyAgainstZip(ctx context.Context, args comby.Args, zipPath comby.ZipP
 
 		for scanner.Scan() {
 			b := scanner.Bytes()
-			if err := scanner.Err(); err != nil {
-				// warn on scanner errors and skip
-				log.NamedError("comby error: skipping scanner error line", err)
-				break
-			}
-
 			cfm := comby.ToFileMatch(b)
 			if cfm != nil {
 				fm, err := toFileMatch(&zipReader.Reader, cfm.(*comby.FileMatch))
@@ -538,6 +532,11 @@ func runCombyAgainstZip(ctx context.Context, args comby.Args, zipPath comby.ZipP
 				}
 				sender.Send(fm)
 			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			// warn on scanner errors and skip
+			log.NamedError("comby error: skipping scanner error line", err)
 		}
 	}()
 

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -140,14 +140,14 @@ func Run(ctx context.Context, args Args, unmarshal unmarshaller) (results []Resu
 		scanner.Buffer(make([]byte, 100), 10*bufio.MaxScanTokenSize)
 		for scanner.Scan() {
 			b := scanner.Bytes()
-			if err := scanner.Err(); err != nil {
-				// warn on scanner errors and skip
-				log15.Warn("comby error: skipping scanner error line", "err", err.Error())
-				continue
-			}
 			if r := unmarshal(b); r != nil {
 				results = append(results, r)
 			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			// warn on scanner errors and skip
+			log15.Warn("comby error: skipping scanner error line", "err", err.Error())
 		}
 	}()
 


### PR DESCRIPTION
`scanner.Scan()` returns false if there is an error, so the error will
never be checked if scanner.Err() is called inside the loop.

## Test plan

Unit tests cover basic functionality here. I will add more error-focused unit tests when I get to the point where errors are propagated past the goroutine boundaries (which I'm working on)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
