### PR TITLE
Revert "search: fail ListAllIndexed if zoekt is partially available (#45519)"

### DIFF
--- a/internal/search/env.go
+++ b/internal/search/env.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/search/backend"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 var (
@@ -57,21 +56,11 @@ func Indexed() zoekt.Streamer {
 	return indexedSearch
 }
 
-// ListAllIndexed lists all indexed repositories with `Minimal: true`. If any
-// crashes occur an error is returned instead of returning partial results.
+// ListAllIndexed lists all indexed repositories with `Minimal: true`.
 func ListAllIndexed(ctx context.Context) (*zoekt.RepoList, error) {
 	q := &query.Const{Value: true}
 	opts := &zoekt.ListOptions{Minimal: true}
-	rl, err := Indexed().List(ctx, q, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	if rl.Crashes > 0 {
-		return nil, errors.New("zoekt.List call occurred while not all Zoekt replicas are available")
-	}
-
-	return rl, nil
+	return Indexed().List(ctx, q, opts)
 }
 
 func Indexers() *backend.Indexers {


### PR DESCRIPTION
This reverts commit 81352243cffd8e5b596bd4b0ffaf69995073e7a7.

As reported in https://sourcegraph.slack.com/archives/C023ELQLV7F/p1672835804462349.

Currently, Zoekt tries to report in its responses whether or not it has finished the initial load of all of its shards before performing the query. However, there was a bug that caused to still report that it hadn't finished loading _even if there were no shards to load_. This bug caused this error message to appear on the site admin page:

<img width="1611" alt="Screen Shot 2023-01-04 at 8 31 30 AM" src="https://user-images.githubusercontent.com/9022011/210616959-fb6700ef-f1e8-4bd7-b539-0a70d568d032.png">

This revert papers over this issue by restoring the old behavaior (not outright failing the ListAllIndexed call if a crash occurred during the response). After the revert, the site-admin page looks normal again:

<img width="1539" alt="Screen Shot 2023-01-04 at 8 29 04 AM" src="https://user-images.githubusercontent.com/9022011/210617213-dba60367-c89b-479f-807c-5a707833dda2.png">



_The underlying cause in Zoekt was fixed in https://github.com/sourcegraph/zoekt/pull/512. However, for the purposes of a 4.3.1 release I think this change is the smaller one to make to work around the issue (Zoekt has recieved other commits since 4.3.0 release, and I don't want to bring in more changes than we have to)._ 






## Test plan

Manual testing:

1. Run the local dev stack with the external service commented out:
	```jsonc
	{
	  // "GITHUB": [
	  //   {
	  //     "url": "https://github.com",
	  //     "token": "$REDACTED", // user: sourcegraph-dogfood-user token: dev-private-localdev
	  //     "repos": [
	  //       "sourcegraph/sourcegraph",
	  //       "hashicorp/go-multierror",
	  //       "hashicorp/errwrap",
	  //       "sourcegraph-testing/etcd",
	  //       "sourcegraph-testing/tidb",
	  //       "sourcegraph-testing/titan",
	  //       "sourcegraph-testing/zap"
	  //     ]
	  //   }
	  // ]
	}
	```
1. Go to the site admin page, and see this screenshot:
	<img width="1611" alt="Screen Shot 2023-01-04 at 8 31 30 AM" src="https://user-images.githubusercontent.com/9022011/210616959-fb6700ef-f1e8-4bd7-b539-0a70d568d032.png">
1. Revert 81352243cffd8e5b596bd4b0ffaf69995073e7a7, and go the site admin page again and see that the page looks normal again:
	<img width="1539" alt="Screen Shot 2023-01-04 at 8 29 04 AM" src="https://user-images.githubusercontent.com/9022011/210617213-dba60367-c89b-479f-807c-5a707833dda2.png">

