### PR TITLE
Code Insights: Add totalCount to the insights connection api

### DIFF
--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -123,12 +123,6 @@ type InsightResolver interface {
 	ID() string
 }
 
-type InsightConnectionResolver interface {
-	Nodes(ctx context.Context) ([]InsightResolver, error)
-	TotalCount(ctx context.Context) (int32, error)
-	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
-}
-
 type InsightsDashboardsArgs struct {
 	First *int32
 	After *string
@@ -189,6 +183,7 @@ type DeleteInsightsDashboardArgs struct {
 
 type InsightViewConnectionResolver interface {
 	Nodes(ctx context.Context) ([]InsightViewResolver, error)
+	TotalCount(ctx context.Context) (int32, error)
 	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
 }
 

--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -183,7 +183,7 @@ type DeleteInsightsDashboardArgs struct {
 
 type InsightViewConnectionResolver interface {
 	Nodes(ctx context.Context) ([]InsightViewResolver, error)
-	TotalCount(ctx context.Context) (int32, error)
+	TotalCount(ctx context.Context) (*int32, error)
 	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
 }
 

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -1,4 +1,3 @@
-
 """
 An insight about code.
 """

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -1,22 +1,3 @@
-"""
-A list of insights.
-"""
-type InsightConnection {
-    """
-    A list of insights.
-    """
-    nodes: [Insight!]!
-
-    """
-    The total number of insights in the connection.
-    """
-    totalCount: Int!
-
-    """
-    Pagination information.
-    """
-    pageInfo: PageInfo!
-}
 
 """
 An insight about code.
@@ -367,6 +348,11 @@ type InsightViewConnection {
     Pagination information.
     """
     pageInfo: PageInfo!
+
+    """
+    The total number of insights in the connection.
+    """
+    totalCount: Int
 }
 
 """

--- a/enterprise/internal/insights/resolvers/dashboard_resolvers.go
+++ b/enterprise/internal/insights/resolvers/dashboard_resolvers.go
@@ -196,6 +196,20 @@ func (d *DashboardInsightViewConnectionResolver) PageInfo(ctx context.Context) (
 	return graphqlutil.HasNextPage(false), nil
 }
 
+func (d *DashboardInsightViewConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+	args := store.InsightsOnDashboardQueryArgs{DashboardID: d.dashboard.ID}
+
+	var err error
+	viewSeries, err := d.insightStore.GetAllOnDashboard(ctx, args)
+	if err != nil {
+		d.err = err
+		return 0, err
+	}
+
+	views := d.insightStore.GroupByView(ctx, viewSeries)
+	return int32(len(views)), nil
+}
+
 func (d *DashboardInsightViewConnectionResolver) computeConnectedViews(ctx context.Context) ([]types.Insight, string, error) {
 	d.once.Do(func() {
 		args := store.InsightsOnDashboardQueryArgs{DashboardID: d.dashboard.ID}

--- a/enterprise/internal/insights/resolvers/dashboard_resolvers.go
+++ b/enterprise/internal/insights/resolvers/dashboard_resolvers.go
@@ -196,18 +196,16 @@ func (d *DashboardInsightViewConnectionResolver) PageInfo(ctx context.Context) (
 	return graphqlutil.HasNextPage(false), nil
 }
 
-func (d *DashboardInsightViewConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+func (d *DashboardInsightViewConnectionResolver) TotalCount(ctx context.Context) (*int32, error) {
 	args := store.InsightsOnDashboardQueryArgs{DashboardID: d.dashboard.ID}
-
 	var err error
 	viewSeries, err := d.insightStore.GetAllOnDashboard(ctx, args)
 	if err != nil {
-		d.err = err
-		return 0, err
+		return nil, err
 	}
-
 	views := d.insightStore.GroupByView(ctx, viewSeries)
-	return int32(len(views)), nil
+	count := int32(len(views))
+	return &count, nil
 }
 
 func (d *DashboardInsightViewConnectionResolver) computeConnectedViews(ctx context.Context) ([]types.Insight, string, error) {

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -1224,6 +1224,23 @@ func (d *InsightViewQueryConnectionResolver) PageInfo(ctx context.Context) (*gra
 	return graphqlutil.HasNextPage(false), nil
 }
 
+func (r *InsightViewQueryConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+	orgStore := r.postgresDB.Orgs()
+	args := store.InsightQueryArgs{}
+
+	var err error
+	args.UserID, args.OrgID, err = getUserPermissions(ctx, orgStore)
+
+	if err != nil {
+		r.err = errors.Wrap(err, "getUserPermissions")
+		return 0, err
+	}
+
+	insights, err := r.insightStore.GetAllMapped(ctx, args)
+
+	return int32(len(insights)), err
+}
+
 func (r *InsightViewQueryConnectionResolver) computeViews(ctx context.Context) ([]types.Insight, string, error) {
 	r.once.Do(func() {
 		orgStore := r.postgresDB.Orgs()

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -1224,21 +1224,18 @@ func (d *InsightViewQueryConnectionResolver) PageInfo(ctx context.Context) (*gra
 	return graphqlutil.HasNextPage(false), nil
 }
 
-func (r *InsightViewQueryConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+func (r *InsightViewQueryConnectionResolver) TotalCount(ctx context.Context) (*int32, error) {
 	orgStore := r.postgresDB.Orgs()
 	args := store.InsightQueryArgs{}
 
 	var err error
 	args.UserID, args.OrgID, err = getUserPermissions(ctx, orgStore)
-
 	if err != nil {
-		r.err = errors.Wrap(err, "getUserPermissions")
-		return 0, err
+		return nil, errors.Wrap(err, "getUserPermissions")
 	}
-
 	insights, err := r.insightStore.GetAllMapped(ctx, args)
-
-	return int32(len(insights)), err
+	count := int32(len(insights))
+	return &count, err
 }
 
 func (r *InsightViewQueryConnectionResolver) computeViews(ctx context.Context) ([]types.Insight, string, error) {


### PR DESCRIPTION
Preparation for https://github.com/sourcegraph/sourcegraph/issues/43561
It adds missing totalCount field to the insights connection, We need to have this 
information for the pagination UI on the all insight view/tab in the client. 

Also it removes legacy InsightConnection types from schema and go types.

## Test plan
- Make sure that you can query totalCount field in the site admin panel 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
