### PR TITLE
codeintel: Rewrite ranking graph export to use SCIP data

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/mocks_test.go
@@ -9901,12 +9901,6 @@ type MockLsifStore struct {
 	// ScanDocumentsFunc is an instance of a mock function object
 	// controlling the behavior of the method ScanDocuments.
 	ScanDocumentsFunc *LsifStoreScanDocumentsFunc
-	// ScanLocationsFunc is an instance of a mock function object
-	// controlling the behavior of the method ScanLocations.
-	ScanLocationsFunc *LsifStoreScanLocationsFunc
-	// ScanResultChunksFunc is an instance of a mock function object
-	// controlling the behavior of the method ScanResultChunks.
-	ScanResultChunksFunc *LsifStoreScanResultChunksFunc
 	// TransactFunc is an instance of a mock function object controlling the
 	// behavior of the method Transact.
 	TransactFunc *LsifStoreTransactFunc
@@ -9975,17 +9969,7 @@ func NewMockLsifStore() *MockLsifStore {
 			},
 		},
 		ScanDocumentsFunc: &LsifStoreScanDocumentsFunc{
-			defaultHook: func(context.Context, int, func(path string, ranges map[precise.ID]precise.RangeData) error) (r0 error) {
-				return
-			},
-		},
-		ScanLocationsFunc: &LsifStoreScanLocationsFunc{
-			defaultHook: func(context.Context, int, func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) (r0 error) {
-				return
-			},
-		},
-		ScanResultChunksFunc: &LsifStoreScanResultChunksFunc{
-			defaultHook: func(context.Context, int, func(idx int, resultChunk precise.ResultChunkData) error) (r0 error) {
+			defaultHook: func(context.Context, int, func(path string, document *scip.Document) error) (r0 error) {
 				return
 			},
 		},
@@ -10072,18 +10056,8 @@ func NewStrictMockLsifStore() *MockLsifStore {
 			},
 		},
 		ScanDocumentsFunc: &LsifStoreScanDocumentsFunc{
-			defaultHook: func(context.Context, int, func(path string, ranges map[precise.ID]precise.RangeData) error) error {
+			defaultHook: func(context.Context, int, func(path string, document *scip.Document) error) error {
 				panic("unexpected invocation of MockLsifStore.ScanDocuments")
-			},
-		},
-		ScanLocationsFunc: &LsifStoreScanLocationsFunc{
-			defaultHook: func(context.Context, int, func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) error {
-				panic("unexpected invocation of MockLsifStore.ScanLocations")
-			},
-		},
-		ScanResultChunksFunc: &LsifStoreScanResultChunksFunc{
-			defaultHook: func(context.Context, int, func(idx int, resultChunk precise.ResultChunkData) error) error {
-				panic("unexpected invocation of MockLsifStore.ScanResultChunks")
 			},
 		},
 		TransactFunc: &LsifStoreTransactFunc{
@@ -10154,12 +10128,6 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		},
 		ScanDocumentsFunc: &LsifStoreScanDocumentsFunc{
 			defaultHook: i.ScanDocuments,
-		},
-		ScanLocationsFunc: &LsifStoreScanLocationsFunc{
-			defaultHook: i.ScanLocations,
-		},
-		ScanResultChunksFunc: &LsifStoreScanResultChunksFunc{
-			defaultHook: i.ScanResultChunks,
 		},
 		TransactFunc: &LsifStoreTransactFunc{
 			defaultHook: i.Transact,
@@ -11072,15 +11040,15 @@ func (c LsifStoreReconcileCandidatesFuncCall) Results() []interface{} {
 // LsifStoreScanDocumentsFunc describes the behavior when the ScanDocuments
 // method of the parent MockLsifStore instance is invoked.
 type LsifStoreScanDocumentsFunc struct {
-	defaultHook func(context.Context, int, func(path string, ranges map[precise.ID]precise.RangeData) error) error
-	hooks       []func(context.Context, int, func(path string, ranges map[precise.ID]precise.RangeData) error) error
+	defaultHook func(context.Context, int, func(path string, document *scip.Document) error) error
+	hooks       []func(context.Context, int, func(path string, document *scip.Document) error) error
 	history     []LsifStoreScanDocumentsFuncCall
 	mutex       sync.Mutex
 }
 
 // ScanDocuments delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockLsifStore) ScanDocuments(v0 context.Context, v1 int, v2 func(path string, ranges map[precise.ID]precise.RangeData) error) error {
+func (m *MockLsifStore) ScanDocuments(v0 context.Context, v1 int, v2 func(path string, document *scip.Document) error) error {
 	r0 := m.ScanDocumentsFunc.nextHook()(v0, v1, v2)
 	m.ScanDocumentsFunc.appendCall(LsifStoreScanDocumentsFuncCall{v0, v1, v2, r0})
 	return r0
@@ -11089,7 +11057,7 @@ func (m *MockLsifStore) ScanDocuments(v0 context.Context, v1 int, v2 func(path s
 // SetDefaultHook sets function that is called when the ScanDocuments method
 // of the parent MockLsifStore instance is invoked and the hook queue is
 // empty.
-func (f *LsifStoreScanDocumentsFunc) SetDefaultHook(hook func(context.Context, int, func(path string, ranges map[precise.ID]precise.RangeData) error) error) {
+func (f *LsifStoreScanDocumentsFunc) SetDefaultHook(hook func(context.Context, int, func(path string, document *scip.Document) error) error) {
 	f.defaultHook = hook
 }
 
@@ -11097,7 +11065,7 @@ func (f *LsifStoreScanDocumentsFunc) SetDefaultHook(hook func(context.Context, i
 // ScanDocuments method of the parent MockLsifStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *LsifStoreScanDocumentsFunc) PushHook(hook func(context.Context, int, func(path string, ranges map[precise.ID]precise.RangeData) error) error) {
+func (f *LsifStoreScanDocumentsFunc) PushHook(hook func(context.Context, int, func(path string, document *scip.Document) error) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -11106,19 +11074,19 @@ func (f *LsifStoreScanDocumentsFunc) PushHook(hook func(context.Context, int, fu
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *LsifStoreScanDocumentsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int, func(path string, ranges map[precise.ID]precise.RangeData) error) error {
+	f.SetDefaultHook(func(context.Context, int, func(path string, document *scip.Document) error) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *LsifStoreScanDocumentsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int, func(path string, ranges map[precise.ID]precise.RangeData) error) error {
+	f.PushHook(func(context.Context, int, func(path string, document *scip.Document) error) error {
 		return r0
 	})
 }
 
-func (f *LsifStoreScanDocumentsFunc) nextHook() func(context.Context, int, func(path string, ranges map[precise.ID]precise.RangeData) error) error {
+func (f *LsifStoreScanDocumentsFunc) nextHook() func(context.Context, int, func(path string, document *scip.Document) error) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -11159,7 +11127,7 @@ type LsifStoreScanDocumentsFuncCall struct {
 	Arg1 int
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 func(path string, ranges map[precise.ID]precise.RangeData) error
+	Arg2 func(path string, document *scip.Document) error
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -11174,222 +11142,6 @@ func (c LsifStoreScanDocumentsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c LsifStoreScanDocumentsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
-}
-
-// LsifStoreScanLocationsFunc describes the behavior when the ScanLocations
-// method of the parent MockLsifStore instance is invoked.
-type LsifStoreScanLocationsFunc struct {
-	defaultHook func(context.Context, int, func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) error
-	hooks       []func(context.Context, int, func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) error
-	history     []LsifStoreScanLocationsFuncCall
-	mutex       sync.Mutex
-}
-
-// ScanLocations delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockLsifStore) ScanLocations(v0 context.Context, v1 int, v2 func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) error {
-	r0 := m.ScanLocationsFunc.nextHook()(v0, v1, v2)
-	m.ScanLocationsFunc.appendCall(LsifStoreScanLocationsFuncCall{v0, v1, v2, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the ScanLocations method
-// of the parent MockLsifStore instance is invoked and the hook queue is
-// empty.
-func (f *LsifStoreScanLocationsFunc) SetDefaultHook(hook func(context.Context, int, func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// ScanLocations method of the parent MockLsifStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *LsifStoreScanLocationsFunc) PushHook(hook func(context.Context, int, func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *LsifStoreScanLocationsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int, func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreScanLocationsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int, func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) error {
-		return r0
-	})
-}
-
-func (f *LsifStoreScanLocationsFunc) nextHook() func(context.Context, int, func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *LsifStoreScanLocationsFunc) appendCall(r0 LsifStoreScanLocationsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of LsifStoreScanLocationsFuncCall objects
-// describing the invocations of this function.
-func (f *LsifStoreScanLocationsFunc) History() []LsifStoreScanLocationsFuncCall {
-	f.mutex.Lock()
-	history := make([]LsifStoreScanLocationsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// LsifStoreScanLocationsFuncCall is an object that describes an invocation
-// of method ScanLocations on an instance of MockLsifStore.
-type LsifStoreScanLocationsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c LsifStoreScanLocationsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c LsifStoreScanLocationsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
-}
-
-// LsifStoreScanResultChunksFunc describes the behavior when the
-// ScanResultChunks method of the parent MockLsifStore instance is invoked.
-type LsifStoreScanResultChunksFunc struct {
-	defaultHook func(context.Context, int, func(idx int, resultChunk precise.ResultChunkData) error) error
-	hooks       []func(context.Context, int, func(idx int, resultChunk precise.ResultChunkData) error) error
-	history     []LsifStoreScanResultChunksFuncCall
-	mutex       sync.Mutex
-}
-
-// ScanResultChunks delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockLsifStore) ScanResultChunks(v0 context.Context, v1 int, v2 func(idx int, resultChunk precise.ResultChunkData) error) error {
-	r0 := m.ScanResultChunksFunc.nextHook()(v0, v1, v2)
-	m.ScanResultChunksFunc.appendCall(LsifStoreScanResultChunksFuncCall{v0, v1, v2, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the ScanResultChunks
-// method of the parent MockLsifStore instance is invoked and the hook queue
-// is empty.
-func (f *LsifStoreScanResultChunksFunc) SetDefaultHook(hook func(context.Context, int, func(idx int, resultChunk precise.ResultChunkData) error) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// ScanResultChunks method of the parent MockLsifStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *LsifStoreScanResultChunksFunc) PushHook(hook func(context.Context, int, func(idx int, resultChunk precise.ResultChunkData) error) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *LsifStoreScanResultChunksFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int, func(idx int, resultChunk precise.ResultChunkData) error) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreScanResultChunksFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int, func(idx int, resultChunk precise.ResultChunkData) error) error {
-		return r0
-	})
-}
-
-func (f *LsifStoreScanResultChunksFunc) nextHook() func(context.Context, int, func(idx int, resultChunk precise.ResultChunkData) error) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *LsifStoreScanResultChunksFunc) appendCall(r0 LsifStoreScanResultChunksFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of LsifStoreScanResultChunksFuncCall objects
-// describing the invocations of this function.
-func (f *LsifStoreScanResultChunksFunc) History() []LsifStoreScanResultChunksFuncCall {
-	f.mutex.Lock()
-	history := make([]LsifStoreScanResultChunksFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// LsifStoreScanResultChunksFuncCall is an object that describes an
-// invocation of method ScanResultChunks on an instance of MockLsifStore.
-type LsifStoreScanResultChunksFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 func(idx int, resultChunk precise.ResultChunkData) error
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c LsifStoreScanResultChunksFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c LsifStoreScanResultChunksFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/lsifstore.go
@@ -34,9 +34,7 @@ type LsifStore interface {
 	DeleteUnreferencedDocuments(ctx context.Context, batchSize int, maxAge time.Duration, now time.Time) (count int, err error)
 
 	// Stream
-	ScanDocuments(ctx context.Context, id int, f func(path string, ranges map[precise.ID]precise.RangeData) error) (err error)
-	ScanResultChunks(ctx context.Context, id int, f func(idx int, resultChunk precise.ResultChunkData) error) (err error)
-	ScanLocations(ctx context.Context, id int, f func(scheme, identifier, monikerType string, locations []precise.LocationData) error) (err error)
+	ScanDocuments(ctx context.Context, id int, f func(path string, document *scip.Document) error) (err error)
 }
 
 type SCIPWriter interface {

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/observability.go
@@ -13,8 +13,6 @@ type operations struct {
 	reconcileCandidates         *observation.Operation
 	getUploadDocumentsForPath   *observation.Operation
 	scanDocuments               *observation.Operation
-	scanResultChunks            *observation.Operation
-	scanLocations               *observation.Operation
 	insertMetadata              *observation.Operation
 	writeMeta                   *observation.Operation
 	writeDocuments              *observation.Operation
@@ -51,8 +49,6 @@ func newOperations(observationCtx *observation.Context) *operations {
 		reconcileCandidates:         op("ReconcileCandidates"),
 		getUploadDocumentsForPath:   op("GetUploadDocumentsForPath"),
 		scanDocuments:               op("ScanDocuments"),
-		scanResultChunks:            op("ScanResultChunks"),
-		scanLocations:               op("ScanLocations"),
 		insertMetadata:              op("InsertMetadata"),
 		writeMeta:                   op("WriteMeta"),
 		writeDocuments:              op("WriteDocuments"),

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_decompressor.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/scip_decompressor.go
@@ -1,0 +1,41 @@
+package lsifstore
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"sync"
+)
+
+var decompressor = &gzipDecompressor{
+	readers: sync.Pool{
+		New: func() any { return new(gzip.Reader) },
+	},
+}
+
+type gzipDecompressor struct {
+	readers sync.Pool
+}
+
+func (c *gzipDecompressor) decompress(r io.Reader) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	err := c.decompressInto(r, buf)
+	return buf.Bytes(), err
+}
+
+func (c *gzipDecompressor) decompressInto(r io.Reader, buf *bytes.Buffer) (err error) {
+	gzipReader := c.readers.Get().(*gzip.Reader)
+	defer c.readers.Put(gzipReader)
+
+	if err := gzipReader.Reset(r); err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := gzipReader.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	_, err = io.Copy(buf, gzipReader)
+	return err
+}

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/stream.go
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/stream.go
@@ -1,18 +1,20 @@
 package lsifstore
 
 import (
+	"bytes"
 	"context"
 
 	"github.com/keegancsmith/sqlf"
 	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/sourcegraph/scip/bindings/go/scip"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
-	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
 
-func (s *store) ScanDocuments(ctx context.Context, id int, f func(path string, ranges map[precise.ID]precise.RangeData) error) (err error) {
+func (s *store) ScanDocuments(ctx context.Context, id int, f func(path string, document *scip.Document) error) (err error) {
 	ctx, _, endObservation := s.operations.scanDocuments.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
 		otlog.Int("id", id),
 	}})
@@ -20,101 +22,33 @@ func (s *store) ScanDocuments(ctx context.Context, id int, f func(path string, r
 
 	return runQuery(ctx, s.db, sqlf.Sprintf(scanDocumentsQuery, id), func(dbs dbutil.Scanner) error {
 		var path string
-		var rawRanges []byte
-		if err := dbs.Scan(&path, &rawRanges); err != nil {
+		var compressedSCIPPayload []byte
+		if err := dbs.Scan(&path, &compressedSCIPPayload); err != nil {
 			return err
 		}
 
-		var ranges map[precise.ID]precise.RangeData
-		if err := s.serializer.decode(rawRanges, &ranges); err != nil {
+		scipPayload, err := decompressor.decompress(bytes.NewReader(compressedSCIPPayload))
+		if err != nil {
 			return err
 		}
 
-		return f(path, ranges)
+		var document scip.Document
+		if err := proto.Unmarshal(scipPayload, &document); err != nil {
+			return err
+		}
+
+		return f(path, &document)
 	})
 }
 
 const scanDocumentsQuery = `
-SELECT path, ranges
-FROM lsif_data_documents
-WHERE dump_id = %s
-ORDER BY path
-`
-
-func (s *store) ScanResultChunks(ctx context.Context, id int, f func(idx int, resultChunk precise.ResultChunkData) error) (err error) {
-	ctx, _, endObservation := s.operations.scanResultChunks.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
-		otlog.Int("id", id),
-	}})
-	defer endObservation(1, observation.Args{})
-
-	return runQuery(ctx, s.db, sqlf.Sprintf(scanResultChunksQuery, id), func(dbs dbutil.Scanner) error {
-		var idx int
-		var rawData []byte
-		if err := dbs.Scan(&idx, &rawData); err != nil {
-			return err
-		}
-
-		var resultChunk precise.ResultChunkData
-		if err := s.serializer.decode(rawData, &resultChunk); err != nil {
-			return err
-		}
-
-		return f(idx, resultChunk)
-	})
-}
-
-const scanResultChunksQuery = `
-SELECT idx, data
-FROM lsif_data_result_chunks
-WHERE dump_id = %s
-ORDER BY idx
-`
-
-func (s *store) ScanLocations(ctx context.Context, id int, f func(scheme, identifier, monikerType string, locations []precise.LocationData) error) (err error) {
-	ctx, _, endObservation := s.operations.scanLocations.With(ctx, &err, observation.Args{LogFields: []otlog.Field{
-		otlog.Int("id", id),
-	}})
-	defer endObservation(1, observation.Args{})
-
-	return runQuery(ctx, s.db, sqlf.Sprintf(scanLocationsQuery, id, id), func(dbs dbutil.Scanner) error {
-		var scheme, identifier, monikerType string
-		var rawData []byte
-		if err := dbs.Scan(&scheme, &identifier, &monikerType, &rawData); err != nil {
-			return err
-		}
-
-		var locations []precise.LocationData
-		if err := s.serializer.decode(rawData, &locations); err != nil {
-			return err
-		}
-
-		return f(scheme, identifier, monikerType, locations)
-	})
-}
-
-const scanLocationsQuery = `
-WITH
-defs AS (
-	SELECT
-		d.scheme,
-		d.identifier,
-		'export' AS type,
-		d.data
-	FROM lsif_data_definitions d
-	WHERE d.dump_id = %s
-	ORDER BY d.scheme, d.identifier
-),
-refs AS (
-	SELECT
-		r.scheme,
-		r.identifier,
-		'import' AS type,
-		r.data
-	FROM lsif_data_references r
-	WHERE r.dump_id = %s
-	ORDER BY r.scheme, r.identifier
-)
-SELECT * FROM defs UNION ALL SELECT * FROM refs
+SELECT
+	sid.document_path,
+	sd.raw_scip_payload
+FROM codeintel_scip_document_lookup sid
+JOIN codeintel_scip_documents sd ON sd.id = sid.document_id
+WHERE sid.upload_id = %s
+ORDER BY sid.document_path
 `
 
 func runQuery(ctx context.Context, store *basestore.Store, query *sqlf.Query, f func(dbutil.Scanner) error) (err error) {

--- a/enterprise/internal/codeintel/uploads/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/mocks_test.go
@@ -14,6 +14,7 @@ import (
 
 	regexp "github.com/grafana/regexp"
 	sqlf "github.com/keegancsmith/sqlf"
+	scip "github.com/sourcegraph/scip/bindings/go/scip"
 	enterprise "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies/enterprise"
 	shared1 "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies/shared"
 	types "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/types"
@@ -7571,12 +7572,6 @@ type MockLsifStore struct {
 	// ScanDocumentsFunc is an instance of a mock function object
 	// controlling the behavior of the method ScanDocuments.
 	ScanDocumentsFunc *LsifStoreScanDocumentsFunc
-	// ScanLocationsFunc is an instance of a mock function object
-	// controlling the behavior of the method ScanLocations.
-	ScanLocationsFunc *LsifStoreScanLocationsFunc
-	// ScanResultChunksFunc is an instance of a mock function object
-	// controlling the behavior of the method ScanResultChunks.
-	ScanResultChunksFunc *LsifStoreScanResultChunksFunc
 	// TransactFunc is an instance of a mock function object controlling the
 	// behavior of the method Transact.
 	TransactFunc *LsifStoreTransactFunc
@@ -7645,17 +7640,7 @@ func NewMockLsifStore() *MockLsifStore {
 			},
 		},
 		ScanDocumentsFunc: &LsifStoreScanDocumentsFunc{
-			defaultHook: func(context.Context, int, func(path string, ranges map[precise.ID]precise.RangeData) error) (r0 error) {
-				return
-			},
-		},
-		ScanLocationsFunc: &LsifStoreScanLocationsFunc{
-			defaultHook: func(context.Context, int, func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) (r0 error) {
-				return
-			},
-		},
-		ScanResultChunksFunc: &LsifStoreScanResultChunksFunc{
-			defaultHook: func(context.Context, int, func(idx int, resultChunk precise.ResultChunkData) error) (r0 error) {
+			defaultHook: func(context.Context, int, func(path string, document *scip.Document) error) (r0 error) {
 				return
 			},
 		},
@@ -7742,18 +7727,8 @@ func NewStrictMockLsifStore() *MockLsifStore {
 			},
 		},
 		ScanDocumentsFunc: &LsifStoreScanDocumentsFunc{
-			defaultHook: func(context.Context, int, func(path string, ranges map[precise.ID]precise.RangeData) error) error {
+			defaultHook: func(context.Context, int, func(path string, document *scip.Document) error) error {
 				panic("unexpected invocation of MockLsifStore.ScanDocuments")
-			},
-		},
-		ScanLocationsFunc: &LsifStoreScanLocationsFunc{
-			defaultHook: func(context.Context, int, func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) error {
-				panic("unexpected invocation of MockLsifStore.ScanLocations")
-			},
-		},
-		ScanResultChunksFunc: &LsifStoreScanResultChunksFunc{
-			defaultHook: func(context.Context, int, func(idx int, resultChunk precise.ResultChunkData) error) error {
-				panic("unexpected invocation of MockLsifStore.ScanResultChunks")
 			},
 		},
 		TransactFunc: &LsifStoreTransactFunc{
@@ -7824,12 +7799,6 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		},
 		ScanDocumentsFunc: &LsifStoreScanDocumentsFunc{
 			defaultHook: i.ScanDocuments,
-		},
-		ScanLocationsFunc: &LsifStoreScanLocationsFunc{
-			defaultHook: i.ScanLocations,
-		},
-		ScanResultChunksFunc: &LsifStoreScanResultChunksFunc{
-			defaultHook: i.ScanResultChunks,
 		},
 		TransactFunc: &LsifStoreTransactFunc{
 			defaultHook: i.Transact,
@@ -8742,15 +8711,15 @@ func (c LsifStoreReconcileCandidatesFuncCall) Results() []interface{} {
 // LsifStoreScanDocumentsFunc describes the behavior when the ScanDocuments
 // method of the parent MockLsifStore instance is invoked.
 type LsifStoreScanDocumentsFunc struct {
-	defaultHook func(context.Context, int, func(path string, ranges map[precise.ID]precise.RangeData) error) error
-	hooks       []func(context.Context, int, func(path string, ranges map[precise.ID]precise.RangeData) error) error
+	defaultHook func(context.Context, int, func(path string, document *scip.Document) error) error
+	hooks       []func(context.Context, int, func(path string, document *scip.Document) error) error
 	history     []LsifStoreScanDocumentsFuncCall
 	mutex       sync.Mutex
 }
 
 // ScanDocuments delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockLsifStore) ScanDocuments(v0 context.Context, v1 int, v2 func(path string, ranges map[precise.ID]precise.RangeData) error) error {
+func (m *MockLsifStore) ScanDocuments(v0 context.Context, v1 int, v2 func(path string, document *scip.Document) error) error {
 	r0 := m.ScanDocumentsFunc.nextHook()(v0, v1, v2)
 	m.ScanDocumentsFunc.appendCall(LsifStoreScanDocumentsFuncCall{v0, v1, v2, r0})
 	return r0
@@ -8759,7 +8728,7 @@ func (m *MockLsifStore) ScanDocuments(v0 context.Context, v1 int, v2 func(path s
 // SetDefaultHook sets function that is called when the ScanDocuments method
 // of the parent MockLsifStore instance is invoked and the hook queue is
 // empty.
-func (f *LsifStoreScanDocumentsFunc) SetDefaultHook(hook func(context.Context, int, func(path string, ranges map[precise.ID]precise.RangeData) error) error) {
+func (f *LsifStoreScanDocumentsFunc) SetDefaultHook(hook func(context.Context, int, func(path string, document *scip.Document) error) error) {
 	f.defaultHook = hook
 }
 
@@ -8767,7 +8736,7 @@ func (f *LsifStoreScanDocumentsFunc) SetDefaultHook(hook func(context.Context, i
 // ScanDocuments method of the parent MockLsifStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *LsifStoreScanDocumentsFunc) PushHook(hook func(context.Context, int, func(path string, ranges map[precise.ID]precise.RangeData) error) error) {
+func (f *LsifStoreScanDocumentsFunc) PushHook(hook func(context.Context, int, func(path string, document *scip.Document) error) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -8776,19 +8745,19 @@ func (f *LsifStoreScanDocumentsFunc) PushHook(hook func(context.Context, int, fu
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *LsifStoreScanDocumentsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int, func(path string, ranges map[precise.ID]precise.RangeData) error) error {
+	f.SetDefaultHook(func(context.Context, int, func(path string, document *scip.Document) error) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *LsifStoreScanDocumentsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int, func(path string, ranges map[precise.ID]precise.RangeData) error) error {
+	f.PushHook(func(context.Context, int, func(path string, document *scip.Document) error) error {
 		return r0
 	})
 }
 
-func (f *LsifStoreScanDocumentsFunc) nextHook() func(context.Context, int, func(path string, ranges map[precise.ID]precise.RangeData) error) error {
+func (f *LsifStoreScanDocumentsFunc) nextHook() func(context.Context, int, func(path string, document *scip.Document) error) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -8829,7 +8798,7 @@ type LsifStoreScanDocumentsFuncCall struct {
 	Arg1 int
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 func(path string, ranges map[precise.ID]precise.RangeData) error
+	Arg2 func(path string, document *scip.Document) error
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -8844,222 +8813,6 @@ func (c LsifStoreScanDocumentsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c LsifStoreScanDocumentsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
-}
-
-// LsifStoreScanLocationsFunc describes the behavior when the ScanLocations
-// method of the parent MockLsifStore instance is invoked.
-type LsifStoreScanLocationsFunc struct {
-	defaultHook func(context.Context, int, func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) error
-	hooks       []func(context.Context, int, func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) error
-	history     []LsifStoreScanLocationsFuncCall
-	mutex       sync.Mutex
-}
-
-// ScanLocations delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockLsifStore) ScanLocations(v0 context.Context, v1 int, v2 func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) error {
-	r0 := m.ScanLocationsFunc.nextHook()(v0, v1, v2)
-	m.ScanLocationsFunc.appendCall(LsifStoreScanLocationsFuncCall{v0, v1, v2, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the ScanLocations method
-// of the parent MockLsifStore instance is invoked and the hook queue is
-// empty.
-func (f *LsifStoreScanLocationsFunc) SetDefaultHook(hook func(context.Context, int, func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// ScanLocations method of the parent MockLsifStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *LsifStoreScanLocationsFunc) PushHook(hook func(context.Context, int, func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *LsifStoreScanLocationsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int, func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreScanLocationsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int, func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) error {
-		return r0
-	})
-}
-
-func (f *LsifStoreScanLocationsFunc) nextHook() func(context.Context, int, func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *LsifStoreScanLocationsFunc) appendCall(r0 LsifStoreScanLocationsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of LsifStoreScanLocationsFuncCall objects
-// describing the invocations of this function.
-func (f *LsifStoreScanLocationsFunc) History() []LsifStoreScanLocationsFuncCall {
-	f.mutex.Lock()
-	history := make([]LsifStoreScanLocationsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// LsifStoreScanLocationsFuncCall is an object that describes an invocation
-// of method ScanLocations on an instance of MockLsifStore.
-type LsifStoreScanLocationsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 func(scheme string, identifier string, monikerType string, locations []precise.LocationData) error
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c LsifStoreScanLocationsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c LsifStoreScanLocationsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
-}
-
-// LsifStoreScanResultChunksFunc describes the behavior when the
-// ScanResultChunks method of the parent MockLsifStore instance is invoked.
-type LsifStoreScanResultChunksFunc struct {
-	defaultHook func(context.Context, int, func(idx int, resultChunk precise.ResultChunkData) error) error
-	hooks       []func(context.Context, int, func(idx int, resultChunk precise.ResultChunkData) error) error
-	history     []LsifStoreScanResultChunksFuncCall
-	mutex       sync.Mutex
-}
-
-// ScanResultChunks delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockLsifStore) ScanResultChunks(v0 context.Context, v1 int, v2 func(idx int, resultChunk precise.ResultChunkData) error) error {
-	r0 := m.ScanResultChunksFunc.nextHook()(v0, v1, v2)
-	m.ScanResultChunksFunc.appendCall(LsifStoreScanResultChunksFuncCall{v0, v1, v2, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the ScanResultChunks
-// method of the parent MockLsifStore instance is invoked and the hook queue
-// is empty.
-func (f *LsifStoreScanResultChunksFunc) SetDefaultHook(hook func(context.Context, int, func(idx int, resultChunk precise.ResultChunkData) error) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// ScanResultChunks method of the parent MockLsifStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *LsifStoreScanResultChunksFunc) PushHook(hook func(context.Context, int, func(idx int, resultChunk precise.ResultChunkData) error) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *LsifStoreScanResultChunksFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int, func(idx int, resultChunk precise.ResultChunkData) error) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreScanResultChunksFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int, func(idx int, resultChunk precise.ResultChunkData) error) error {
-		return r0
-	})
-}
-
-func (f *LsifStoreScanResultChunksFunc) nextHook() func(context.Context, int, func(idx int, resultChunk precise.ResultChunkData) error) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *LsifStoreScanResultChunksFunc) appendCall(r0 LsifStoreScanResultChunksFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of LsifStoreScanResultChunksFuncCall objects
-// describing the invocations of this function.
-func (f *LsifStoreScanResultChunksFunc) History() []LsifStoreScanResultChunksFuncCall {
-	f.mutex.Lock()
-	history := make([]LsifStoreScanResultChunksFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// LsifStoreScanResultChunksFuncCall is an object that describes an
-// invocation of method ScanResultChunks on an instance of MockLsifStore.
-type LsifStoreScanResultChunksFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 func(idx int, resultChunk precise.ResultChunkData) error
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c LsifStoreScanResultChunksFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c LsifStoreScanResultChunksFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 


### PR DESCRIPTION
Fixes #45725. This PR rewrites the upload service's ranking graph export to read SCIP documents instead of LSIF data.

## Test plan

Tested by hand.