### PR TITLE
Search suggestions: boost recently visited repos/files/symbols

### DIFF
--- a/client/search-ui/src/input/CodeMirrorQueryInput.tsx
+++ b/client/search-ui/src/input/CodeMirrorQueryInput.tsx
@@ -131,6 +131,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<
     // but added for future compatibility)
     fetchStreamSuggestions = defaultFetchStreamSuggestions,
     onCompletionItemSelected,
+    userHistory,
 }) => {
     // We use both, state and a ref, for the editor instance because we need to
     // re-run some hooks when the editor changes but we also need a stable
@@ -160,6 +161,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<
                 isSourcegraphDotCom,
                 history,
                 applyOnEnter: applySuggestionsOnEnter,
+                userHistory,
             }),
         [
             globbing,
@@ -168,6 +170,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<
             applySuggestionsOnEnter,
             fetchStreamSuggestions,
             selectedSearchContextSpec,
+            userHistory,
         ]
     )
 

--- a/client/search-ui/src/input/QueryInput.ts
+++ b/client/search-ui/src/input/QueryInput.ts
@@ -1,3 +1,4 @@
+import { UserHistory } from '@sourcegraph/shared/src/components/UserHistory'
 import {
     CaseSensitivityProps,
     QueryState,
@@ -47,4 +48,6 @@ export interface QueryInputProps
 
     ariaLabel?: string
     ariaLabelledby?: string
+
+    userHistory?: UserHistory
 }

--- a/client/search-ui/src/input/SearchBox.tsx
+++ b/client/search-ui/src/input/SearchBox.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useMemo, useRef } from 'react'
 import classNames from 'classnames'
 
 import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
+import { UserHistory } from '@sourcegraph/shared/src/components/UserHistory'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SearchContextInputProps, QueryState, SubmitSearchProps, EditorHint } from '@sourcegraph/shared/src/search'
 import { getGlobalSearchContextFilter } from '@sourcegraph/shared/src/search/query/query'
@@ -67,6 +68,8 @@ export interface SearchBoxProps
     showSearchHistory?: boolean
 
     recentSearches?: RecentSearch[]
+
+    userHistory?: UserHistory
 }
 
 export const SearchBox: React.FunctionComponent<React.PropsWithChildren<SearchBoxProps>> = props => {
@@ -78,6 +81,7 @@ export const SearchBox: React.FunctionComponent<React.PropsWithChildren<SearchBo
         onChange,
         selectedSearchContextSpec,
         recentSearches,
+        userHistory,
     } = props
 
     const [usedInlineHistory, setUsedInlineHistory] = useTemporarySetting('search.input.usedInlineHistory', false)
@@ -199,6 +203,7 @@ export const SearchBox: React.FunctionComponent<React.PropsWithChildren<SearchBo
                         applySuggestionsOnEnter={props.applySuggestionsOnEnter}
                         searchHistory={recentSearchesWithoutSearchContext}
                         onSelectSearchFromHistory={onInlineSearchHistorySelect}
+                        userHistory={userHistory}
                     />
                     <Toggles
                         patternType={props.patternType}

--- a/client/search-ui/src/input/codemirror/index.ts
+++ b/client/search-ui/src/input/codemirror/index.ts
@@ -72,6 +72,7 @@ export const createDefaultSuggestions = ({
     history,
     applyOnEnter,
     showWhenEmpty,
+    userHistory,
 }: Omit<DefaultSuggestionSourcesOptions, 'fetchSuggestions'> & {
     fetchSuggestions: (query: string) => Observable<SearchMatch[]>
     history?: H.History
@@ -89,6 +90,7 @@ export const createDefaultSuggestions = ({
             disableFilterCompletion,
             showWhenEmpty,
             applyOnEnter,
+            userHistory,
         }),
         history,
         applyOnEnter

--- a/client/shared/src/components/UserHistory.ts
+++ b/client/shared/src/components/UserHistory.ts
@@ -1,0 +1,101 @@
+import * as H from 'history'
+
+export interface UserHistoryEntry {
+    repoName: string
+    filePath?: string
+    lastAccessed: number
+}
+
+const LAST_REPO_ACCESS_FILEPATH = 'sourcegraph-last-repo-access.timestamp'
+const LOCAL_STORAGE_KEY = 'user-history'
+/** Maximum number of browser history entries to persist in local storage */
+const MAX_LOCAL_STORAGE_COUNT = 100
+
+/**
+ * Collects all browser history events and stores which repos/files are visited
+ * in local storage.  In the future, we should consider storing this history
+ * remotely in temporary settings (or similar). The history is used to
+ * personalize ranking in the fuzzy finder, but could theorically power other
+ * features like improve ranking in the search bar suggestions.
+ */
+
+export class UserHistory {
+    private repos: Map<string, Map<string, number>> = new Map()
+    private storage = window.localStorage
+    constructor(private readonly parseBrowserRepoURL: (url: string) => { repoName?: string; filePath?: string }) {
+        for (const entry of this.loadEntries()) {
+            this.onEntry(entry)
+        }
+    }
+    private saveEntries(entries: UserHistoryEntry[]): void {
+        entries.sort((a, b) => b.lastAccessed - a.lastAccessed)
+        const truncated = entries.slice(0, MAX_LOCAL_STORAGE_COUNT)
+        this.storage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(truncated))
+        for (let index = MAX_LOCAL_STORAGE_COUNT; index < entries.length; index++) {
+            // Synchronize persisted entries with in-memory entries so that
+            // reloading the page doesn't change which entries are available.
+            this.deleteEntry(entries[index])
+        }
+    }
+    private loadEntries(): UserHistoryEntry[] {
+        return JSON.parse(this.storage.getItem(LOCAL_STORAGE_KEY) ?? '[]')
+    }
+    private deleteEntry(entry: UserHistoryEntry): void {
+        if (!entry.filePath) {
+            return
+        }
+        const repo = this.repos.get(entry.repoName)
+        if (!repo) {
+            return
+        }
+        repo.delete(entry.filePath)
+    }
+    private persist(): void {
+        const entries: UserHistoryEntry[] = []
+        for (const repoName of this.repos.keys()) {
+            const repoMap = this.repos.get(repoName) ?? new Map<string, number>()
+            for (const filePath of repoMap.keys()) {
+                const lastAccessed = repoMap.get(filePath)
+                if (lastAccessed) {
+                    entries.push({ repoName, filePath, lastAccessed })
+                }
+            }
+        }
+        this.saveEntries(entries)
+    }
+    private onEntry(entry: UserHistoryEntry): void {
+        let repo = this.repos.get(entry.repoName)
+        if (!repo) {
+            repo = new Map()
+            this.repos.set(entry.repoName, repo)
+        }
+        repo.set(LAST_REPO_ACCESS_FILEPATH, entry.lastAccessed)
+        if (!entry.filePath) {
+            return
+        }
+        repo.set(entry.filePath, entry.lastAccessed)
+    }
+    public onLocation(location: H.Location): void {
+        try {
+            const { repoName, filePath } = this.parseBrowserRepoURL(location.pathname + location.search + location.hash)
+            if (!repoName) {
+                return
+            }
+            this.onEntry({ repoName, filePath, lastAccessed: Date.now() })
+            this.persist()
+            return
+        } catch {
+            // continue regardless of error
+        }
+        return
+    }
+    public visitedRepos(): string[] {
+        return [...this.repos.keys()]
+    }
+    public lastAccessedRepo(repoName: string): number | undefined {
+        return this.repos.get(repoName)?.get(LAST_REPO_ACCESS_FILEPATH)
+    }
+    public lastAccessedFilePath(repoName: string, filePath: string): number | undefined {
+        return this.repos.get(repoName)?.get(filePath)
+    }
+}

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -178,6 +178,7 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
     }
 
     const context: LayoutRouteComponentProps<any> = {
+        userHistory,
         ...props,
         ...themeProps,
         ...breadcrumbProps,
@@ -226,6 +227,7 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
                         !isSearchNotebooksPage
                     }
                     setFuzzyFinderIsVisible={setFuzzyFinderVisible}
+                    userHistory={userHistory}
                     isRepositoryRelatedPage={isRepositoryRelatedPage}
                     showKeyboardShortcutsHelp={showKeyboardShortcutsHelp}
                     showFeedbackModal={showFeedbackModal}

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.mocks.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.mocks.tsx
@@ -3,12 +3,13 @@ import { MockedResponse } from '@apollo/client/testing'
 import * as H from 'history'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { UserHistory } from '@sourcegraph/shared/src/components/UserHistory'
 import { Settings } from '@sourcegraph/shared/src/settings/settings'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { FileNamesResult, FuzzyFinderRepoResult, FuzzyFinderSymbolsResult, SymbolKind } from '../../graphql-operations'
 import { ThemePreference } from '../../theme'
-import { UserHistory } from '../useUserHistory'
+import { parseBrowserRepoURL } from '../../util/url'
 
 import { FUZZY_GIT_LSFILES_QUERY } from './FuzzyFiles'
 import { FuzzyFinderContainer } from './FuzzyFinder'
@@ -42,7 +43,7 @@ export const FuzzyWrapper: React.FunctionComponent<FuzzyWrapperProps> = props =>
                 },
             }}
             initialQuery={props.initialQuery}
-            userHistory={new UserHistory()}
+            userHistory={new UserHistory(parseBrowserRepoURL)}
         />
     )
 }

--- a/client/web/src/components/fuzzyFinder/FuzzySymbols.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzySymbols.tsx
@@ -3,12 +3,12 @@ import { FuzzyFinderSymbolsResult, FuzzyFinderSymbolsVariables } from 'src/graph
 import gql from 'tagged-template-noop'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { UserHistory } from '@sourcegraph/shared/src/components/UserHistory'
 import { isSettingsValid, SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
 import { SymbolKind } from '@sourcegraph/shared/src/symbols/SymbolKind'
 
 import { getWebGraphQLClient } from '../../backend/graphql'
 import { SearchValue } from '../../fuzzyFinder/SearchValue'
-import { UserHistory } from '../useUserHistory'
 
 import { emptyFuzzyCache, PersistableQueryResult } from './FuzzyLocalCache'
 import { FuzzyQuery } from './FuzzyQuery'
@@ -52,7 +52,7 @@ export class FuzzySymbols extends FuzzyQuery {
         private readonly repoRevision: React.MutableRefObject<FuzzyRepoRevision>,
         private readonly isGlobalSymbols: boolean,
         private readonly settingsCascade: SettingsCascadeOrError,
-        private readonly userHistory: UserHistory
+        private readonly userHistory?: UserHistory
     ) {
         // Symbol results should not be cached because stale symbol data is complicated to evict/invalidate.
         super(onNamesChanged, emptyFuzzyCache)
@@ -72,7 +72,10 @@ export class FuzzySymbols extends FuzzyQuery {
         return values.map<SearchValue>(({ text, url, symbolKind, repoName, filePath }) => ({
             text: repositoryFilter ? text.replace(repositoryText, '') : text,
             url,
-            ranking: repoName && filePath ? this.userHistory.lastAccessedFilePath(repoName, filePath) : undefined,
+            ranking:
+                repoName && filePath && this.userHistory
+                    ? this.userHistory.lastAccessedFilePath(repoName, filePath)
+                    : undefined,
             icon: symbolKind ? (
                 <SymbolKind kind={symbolKind} className="mr-1" symbolKindTags={symbolKindTags} />
             ) : undefined,

--- a/client/web/src/components/fuzzyFinder/FuzzyTabs.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyTabs.tsx
@@ -3,6 +3,7 @@ import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef, useS
 import { ApolloClient } from '@apollo/client'
 import * as H from 'history'
 
+import { UserHistory } from '@sourcegraph/shared/src/components/UserHistory'
 import { KEYBOARD_SHORTCUTS } from '@sourcegraph/shared/src/keyboardShortcuts/keyboardShortcuts'
 import { Settings, SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
 import { toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
@@ -11,7 +12,6 @@ import { useSessionStorage } from '@sourcegraph/wildcard'
 import { SearchValueRankingCache } from '../../fuzzyFinder/SearchValueRankingCache'
 import { parseBrowserRepoURL } from '../../util/url'
 import { Keybindings, plaintextKeybindings } from '../KeyboardShortcutsHelp/KeyboardShortcutsHelp'
-import { UserHistory } from '../useUserHistory'
 
 import { createActionsFSM, FuzzyActionProps, getAllFuzzyActions } from './FuzzyActions'
 import { FuzzyFiles, FuzzyRepoFiles } from './FuzzyFiles'
@@ -215,7 +215,7 @@ export interface FuzzyTabsProps extends FuzzyActionProps {
     client?: ApolloClient<object>
     initialQuery?: string
     isVisible: boolean
-    userHistory: UserHistory
+    userHistory?: UserHistory
 }
 
 export function useFuzzyState(props: FuzzyTabsProps): FuzzyState {

--- a/client/web/src/components/useUserHistory.ts
+++ b/client/web/src/components/useUserHistory.ts
@@ -2,114 +2,20 @@ import { useEffect, useMemo } from 'react'
 
 import * as H from 'history'
 
+import { UserHistory } from '@sourcegraph/shared/src/components/UserHistory'
+
+import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
 import { parseBrowserRepoURL } from '../util/url'
 
-export interface UserHistoryEntry {
-    repoName: string
-    filePath?: string
-    lastAccessed: number
-}
-
-const LAST_REPO_ACCESS_FILEPATH = 'sourcegraph-last-repo-access.timestamp'
-const LOCAL_STORAGE_KEY = 'user-history'
-/** Maximum number of browser history entries to persist in local storage */
-const MAX_LOCAL_STORAGE_COUNT = 100
-
-/**
- * Collects all browser history events and stores which repos/files are visited
- * in local storage.  In the future, we should consider storing this history
- * remotely in temporary settings (or similar). The history is used to
- * personalize ranking in the fuzzy finder, but could theorically power other
- * features like improve ranking in the search bar suggestions.
- */
-export class UserHistory {
-    private repos: Map<string, Map<string, number>> = new Map()
-    private storage = window.localStorage
-    constructor() {
-        for (const entry of this.loadEntries()) {
-            this.onEntry(entry)
-        }
-    }
-    private saveEntries(entries: UserHistoryEntry[]): void {
-        entries.sort((a, b) => b.lastAccessed - a.lastAccessed)
-        const truncated = entries.slice(0, MAX_LOCAL_STORAGE_COUNT)
-        this.storage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(truncated))
-        for (let index = MAX_LOCAL_STORAGE_COUNT; index < entries.length; index++) {
-            // Synchronize persisted entries with in-memory entries so that
-            // reloading the page doesn't change which entries are available.
-            this.deleteEntry(entries[index])
-        }
-    }
-    private loadEntries(): UserHistoryEntry[] {
-        return JSON.parse(this.storage.getItem(LOCAL_STORAGE_KEY) ?? '[]')
-    }
-    private deleteEntry(entry: UserHistoryEntry): void {
-        if (!entry.filePath) {
-            return
-        }
-        const repo = this.repos.get(entry.repoName)
-        if (!repo) {
-            return
-        }
-        repo.delete(entry.filePath)
-    }
-    private persist(): void {
-        const entries: UserHistoryEntry[] = []
-        for (const repoName of this.repos.keys()) {
-            const repoMap = this.repos.get(repoName) ?? new Map<string, number>()
-            for (const filePath of repoMap.keys()) {
-                const lastAccessed = repoMap.get(filePath)
-                if (lastAccessed) {
-                    entries.push({ repoName, filePath, lastAccessed })
-                }
-            }
-        }
-        this.saveEntries(entries)
-    }
-    private onEntry(entry: UserHistoryEntry): void {
-        let repo = this.repos.get(entry.repoName)
-        if (!repo) {
-            repo = new Map()
-            this.repos.set(entry.repoName, repo)
-        }
-        repo.set(LAST_REPO_ACCESS_FILEPATH, entry.lastAccessed)
-        if (!entry.filePath) {
-            return
-        }
-        repo.set(entry.filePath, entry.lastAccessed)
-    }
-    public onLocation(location: H.Location): boolean {
-        try {
-            const { repoName, filePath } = parseBrowserRepoURL(location.pathname + location.search + location.hash)
-            if (!repoName) {
-                return false
-            }
-            this.onEntry({ repoName, filePath, lastAccessed: Date.now() })
-            this.persist()
-            return true
-        } catch {
-            // continue regardless of error
-        }
-        return false
-    }
-    public visitedRepos(): string[] {
-        return [...this.repos.keys()]
-    }
-    public lastAccessedRepo(repoName: string): number | undefined {
-        return this.repos.get(repoName)?.get(LAST_REPO_ACCESS_FILEPATH)
-    }
-    public lastAccessedFilePath(repoName: string, filePath: string): number | undefined {
-        return this.repos.get(repoName)?.get(filePath)
-    }
-}
-
-export function useUserHistory(history: H.History, isRepositoryRelatedPage: boolean): UserHistory {
+export function useUserHistory(history: H.History, isRepositoryRelatedPage: boolean): UserHistory | undefined {
     const { location } = history
-    const userHistory = useMemo(() => new UserHistory(), [])
+    const [isFeatureEnabled, status] = useFeatureFlag('user-history-ranking', true)
+    const isEnabled = status === 'loaded' && isFeatureEnabled
+    const userHistory = useMemo(() => new UserHistory(parseBrowserRepoURL), [])
     useEffect(() => {
-        if (isRepositoryRelatedPage) {
+        if (isEnabled && isRepositoryRelatedPage) {
             userHistory.onLocation(location)
         }
-    }, [userHistory, location, isRepositoryRelatedPage])
-    return userHistory
+    }, [isEnabled, userHistory, location, isRepositoryRelatedPage])
+    return isEnabled ? userHistory : undefined
 }

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -17,6 +17,7 @@ export type FeatureFlagName =
     | 'enable-streaming-git-blame'
     | 'plg-enable-add-codehost-widget'
     | 'enable-rbac'
+    | 'user-history-ranking'
 
 interface OrgFlagOverride {
     orgID: string

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -8,6 +8,7 @@ import MagnifyIcon from 'mdi-react/MagnifyIcon'
 
 import { ContributableMenu } from '@sourcegraph/client-api'
 import { isErrorLike, isMacPlatform } from '@sourcegraph/common'
+import { UserHistory } from '@sourcegraph/shared/src/components/UserHistory'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { shortcutDisplayName } from '@sourcegraph/shared/src/keyboardShortcuts'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
@@ -76,6 +77,7 @@ export interface GlobalNavbarProps
     showFeedbackModal: () => void
 
     setFuzzyFinderIsVisible: React.Dispatch<SetStateAction<boolean>>
+    userHistory?: UserHistory
 }
 
 /**
@@ -373,6 +375,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                         isSourcegraphDotCom={isSourcegraphDotCom}
                         searchContextsEnabled={searchContextsEnabled}
                         isRepositoryRelatedPage={isRepositoryRelatedPage}
+                        userHistory={props.userHistory}
                     />
                 </div>
             )}

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 
 import { Redirect, RouteComponentProps } from 'react-router'
 
+import { UserHistory } from '@sourcegraph/shared/src/components/UserHistory'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -37,6 +38,7 @@ export interface LayoutRouteComponentProps<RouteParameters extends { [K in keyof
         BatchChangesProps {
     isSourcegraphDotCom: boolean
     isMacPlatform: boolean
+    userHistory?: UserHistory
 }
 
 export interface LayoutRouteProps<Parameters_ extends { [K in keyof Parameters_]?: string }> {

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react'
 import classNames from 'classnames'
 import * as H from 'history'
 
+import { UserHistory } from '@sourcegraph/shared/src/components/UserHistory'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
@@ -44,6 +45,7 @@ export interface SearchPageProps
 
     // Whether globbing is enabled for filters.
     globbing: boolean
+    userHistory?: UserHistory
 }
 
 /**

--- a/client/web/src/search/home/SearchPageInput.tsx
+++ b/client/web/src/search/home/SearchPageInput.tsx
@@ -9,6 +9,7 @@ import { SearchBox } from '@sourcegraph/search-ui'
 // The experimental search input should be shown on the search home page
 // eslint-disable-next-line  no-restricted-imports
 import { LazyCodeMirrorQueryInput } from '@sourcegraph/search-ui/src/experimental'
+import { UserHistory } from '@sourcegraph/shared/src/components/UserHistory'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import {
@@ -60,6 +61,7 @@ interface Props
     autoFocus?: boolean
     queryState: QueryState
     setQueryState: (newState: QueryState) => void
+    userHistory?: UserHistory
 }
 
 const queryStateSelector = (
@@ -147,6 +149,7 @@ export const SearchPageInput: React.FunctionComponent<React.PropsWithChildren<Pr
             applySuggestionsOnEnter={applySuggestionsOnEnter}
             showSearchHistory={true}
             recentSearches={recentSearches}
+            userHistory={props.userHistory}
         />
     )
     return (

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -4,6 +4,7 @@ import * as H from 'history'
 import shallow from 'zustand/shallow'
 
 import { SearchBox } from '@sourcegraph/search-ui'
+import { UserHistory } from '@sourcegraph/shared/src/components/UserHistory'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SearchContextInputProps, SubmitSearchParameters } from '@sourcegraph/shared/src/search'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
@@ -30,6 +31,7 @@ interface Props
     globbing: boolean
     isSearchAutoFocusRequired?: boolean
     isRepositoryRelatedPage?: boolean
+    userHistory?: UserHistory
 }
 
 const selectQueryState = ({


### PR DESCRIPTION
Followup of https://github.com/sourcegraph/sourcegraph/pull/46084 but for search suggestions (not the fuzzy finder).

Previously, search suggestions didn't use personalized ranking. For example, repos were only sorted by star count and didn't take into account what repositories the user is visiting most frequently.

This PR reorders search suggestions so that recently visited repos/files/symbols get ordered above results that the user has never visited. This feature is enabled by the new `UserHistory` infrastructure that was added for the fuzzy finder.


## Test plan

```
❯ SOURCEGRAPHDOTCOM_MODE=true SOURCEGRAPH_API_URL=https://sourcegraph.com sg start web-standalone
```

* Browse random repos and files
* Type search queries for files/repos/symbols in the files/repos you opened
* Observe that the repos/files/symbols from the visited files/repos get boosted at the top
* For example, visit any file in sourcegraph/sourcegraph repo and observe that the query `source` boosts sourcegraph/sourcegraph above bradtraversy/design-resources-for-developers, which is the top suggestion on sourcegraph.com because it has more GitHub stars than the sourcegraph/sourcegraph repo

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-suggestion-ranking.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

