### PR TITLE
references panel: fix double scrollbar

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -234,7 +234,7 @@
 // Left side of the panel, including token name, filter, list of locations
 .left-sub-panel {
     flex: 1;
-    overflow: auto;
+    overflow: hidden;
     height: 100%;
     background-color: var(--body-bg);
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/pull/46023#issuecomment-1369932164

## Test plan

Verify references panel no longer has a double scrollbar (or a single scrollbar if not enough content to scroll)

![image](https://user-images.githubusercontent.com/206864/210670191-7833033e-93fb-4a66-a681-13838e021143.png)
![image](https://user-images.githubusercontent.com/206864/210670216-44432029-247f-4fed-99e4-12b05bcee632.png)

## App preview:

- [Web](https://sg-web-jp-refpaneldoublescroll.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
