### PR TITLE
syntax-highlighter: add structured logging

### DIFF
--- a/docker-images/syntax-highlighter/Dockerfile
+++ b/docker-images/syntax-highlighter/Dockerfile
@@ -18,7 +18,7 @@ RUN cp ./target/release/syntect_server /syntax_highlighter
 FROM golang:1.19-alpine@sha256:70df3b8f9f099da7f60f0b32480015165e3d0b51bfacf9e255b59f3dd6bd2828 as hss
 
 RUN apk add --no-cache git>=2.26.3
-RUN git clone --branch v1.0.5 --single-branch https://github.com/sourcegraph/http-server-stabilizer /repo
+RUN git clone --branch v1.1.0 --single-branch https://github.com/sourcegraph/http-server-stabilizer /repo
 WORKDIR /repo
 RUN go build -o /http-server-stabilizer .
 


### PR DESCRIPTION
See https://github.com/sourcegraph/http-server-stabilizer/pull/2

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Edit `sg.config.yaml`:

```yaml
  syntax-highlighter:
    cmd: |
      docker run --name=syntax-highlighter --rm -p9238:9238 \
      -e WORKERS=1 -e ROCKET_ADDRESS=0.0.0.0 \
      sourcegraph/syntax-highlighter:dev
    install: |
      # Remove containers by the old name, too.
      docker inspect syntect_server >/dev/null 2>&1 && docker rm -f syntect_server || true
      docker inspect syntax-highlighter >/dev/null 2>&1 && docker rm -f syntax-highlighter || true

      IMAGE=sourcegraph/syntax-highlighter:dev docker-images/syntax-highlighter/build.sh
```

Start:

```
sg start
```

Wait:

```
⌛ Still waiting for syntax-highlighter to finish installing...
⌛ Yup, still waiting for syntax-highlighter to finish installing...
⌛ Looks like we're still waiting for syntax-highlighter to finish installing...
⌛ This is getting awkward now. We're still waiting for syntax-highlighter to finish installing...
🤷 Nothing more to say, I guess. Come on syntax-highlighter ...
🤷 It might be your computer? Still waiting for syntax-highlighter ...
🤷 Anyway... how are you? (Still waiting for syntax-highlighter ...)
🤷 Still waiting for syntax-highlighter to finish installing...
```

Old noisy logs don't show up anymore