### PR TITLE
web: prevent infinite loop on error in use-feature-flag

### DIFF
--- a/client/web/src/featureFlags/useFeatureFlag.ts
+++ b/client/web/src/featureFlags/useFeatureFlag.ts
@@ -47,7 +47,7 @@ export function useFeatureFlag(flagName: FeatureFlagName, defaultValue = false):
         }
 
         getValue().catch(error => {
-            if (isMounted()) {
+            if (isMounted() && status !== 'error') {
                 setResult(({ value }) => ({ value, status: 'error', error }))
             }
         })


### PR DESCRIPTION
## Context

On error in a feature flag fetching, we end up in the infinite loop where each error triggers the re-render and state change. This PR prevents the state change if we are in the error state already.

## Test plan

1. `sg start web-standalone`
2. Open the web application as an unauthorized user. It should be possible to navigate to the sign-in page. (it means that the infinite loop is not present)

## App preview:

- [Web](https://sg-web-vb-use-feature-flag-unauthorized.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
