### PR TITLE
Smartsearch: map repo filters with GitHub clone URLs to the appropriate regex

### DIFF
--- a/internal/search/smartsearch/rules.go
+++ b/internal/search/smartsearch/rules.go
@@ -43,6 +43,10 @@ var rulesNarrow = []rule{
 		description: "expand URL to filters",
 		transform:   []transform{patternsToCodeHostFilters},
 	},
+	{
+		description: "rewrite repo URLs",
+		transform:   []transform{rewriteRepoFilter},
+	},
 }
 
 var rulesWiden = []rule{
@@ -369,6 +373,52 @@ func symbolPatterns(b query.Basic) *query.Basic {
 		Parameters: append(b.Parameters, selectParam, symbolParam),
 		Pattern:    pattern,
 	}
+}
+
+type repoFilterReplacement struct {
+	match   *regexp.Regexp
+	replace string
+}
+
+var repoFilterReplacements = []repoFilterReplacement{
+	{
+		match:   regexp.MustCompile(`^(?:https?:\/\/)github\.com\/([^\/]+)\/([^\/\?#]+)(?:.+)?$`),
+		replace: "^github.com/$1/$2$",
+	},
+}
+
+func rewriteRepoFilter(b query.Basic) *query.Basic {
+	newParams := make([]query.Parameter, 0, len(b.Parameters))
+	anyParamChanged := false
+	for _, param := range b.Parameters {
+		if param.Field != "repo" {
+			newParams = append(newParams, param)
+			continue
+		}
+
+		changed := false
+		for _, replacer := range repoFilterReplacements {
+			if replacer.match.MatchString(param.Value) {
+				newParams = append(newParams, query.Parameter{
+					Field:      param.Field,
+					Value:      replacer.match.ReplaceAllString(param.Value, replacer.replace),
+					Negated:    param.Negated,
+					Annotation: param.Annotation,
+				})
+				changed = true
+				anyParamChanged = true
+				break
+			}
+		}
+		if !changed {
+			newParams = append(newParams, param)
+		}
+	}
+	if !anyParamChanged {
+		return nil
+	}
+	newQuery := b.MapParameters(newParams)
+	return &newQuery
 }
 
 func langPatterns(b query.Basic) *query.Basic {

--- a/internal/search/smartsearch/rules_test.go
+++ b/internal/search/smartsearch/rules_test.go
@@ -165,3 +165,25 @@ func Test_patternsToCodeHostFilters(t *testing.T) {
 		})
 	}
 }
+
+func Test_rewriteRepoFilter(t *testing.T) {
+	rule := []transform{rewriteRepoFilter}
+	test := func(input string) string {
+		return apply(input, rule)
+	}
+
+	cases := []string{
+		`repo:https://github.com/sourcegraph/sourcegraph`,
+		`repo:http://github.com/sourcegraph/sourcegraph`,
+		`repo:https://github.com/sourcegraph/sourcegraph/blob/main/lib/README.md#L50`,
+		`repo:https://github.com/sourcegraph/sourcegraph/tree/main/lib`,
+		`repo:https://github.com/sourcegraph/sourcegraph/tree/2.12`,
+		`repo:https://github.com/sourcegraph/sourcegraph/commit/abc`,
+	}
+
+	for _, c := range cases {
+		t.Run("rewrite repo filter", func(t *testing.T) {
+			autogold.Equal(t, autogold.Raw(test(c)))
+		})
+	}
+}

--- a/internal/search/smartsearch/smart_search_job.go
+++ b/internal/search/smartsearch/smart_search_job.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/opentracing/opentracing-go/log"
+	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	alertobserver "github.com/sourcegraph/sourcegraph/internal/search/alert"
@@ -82,8 +83,8 @@ func (f *FeelingLuckySearchJob) Run(ctx context.Context, clients job.RuntimeClie
 	var maxAlerter search.MaxAlerter
 	var errs errors.MultiError
 	alert, err = f.initialJob.Run(ctx, clients, stream)
-	if err != nil {
-		return alert, err
+	if errForReal := errors.Ignore(err, errors.IsPred(searchrepos.ErrNoResolvedRepos)); errForReal != nil {
+		return alert, errForReal
 	}
 	maxAlerter.Add(alert)
 

--- a/internal/search/smartsearch/testdata/Test_rewriteRepoFilter/rewrite_repo_filter#01.golden
+++ b/internal/search/smartsearch/testdata/Test_rewriteRepoFilter/rewrite_repo_filter#01.golden
@@ -1,0 +1,4 @@
+{
+  "Input": "repo:http://github.com/sourcegraph/sourcegraph",
+  "Query": "repo:^github.com/sourcegraph/sourcegraph$"
+}

--- a/internal/search/smartsearch/testdata/Test_rewriteRepoFilter/rewrite_repo_filter#02.golden
+++ b/internal/search/smartsearch/testdata/Test_rewriteRepoFilter/rewrite_repo_filter#02.golden
@@ -1,0 +1,4 @@
+{
+  "Input": "repo:https://github.com/sourcegraph/sourcegraph/blob/main/lib/README.md#L50",
+  "Query": "repo:^github.com/sourcegraph/sourcegraph$"
+}

--- a/internal/search/smartsearch/testdata/Test_rewriteRepoFilter/rewrite_repo_filter#03.golden
+++ b/internal/search/smartsearch/testdata/Test_rewriteRepoFilter/rewrite_repo_filter#03.golden
@@ -1,0 +1,4 @@
+{
+  "Input": "repo:https://github.com/sourcegraph/sourcegraph/tree/main/lib",
+  "Query": "repo:^github.com/sourcegraph/sourcegraph$"
+}

--- a/internal/search/smartsearch/testdata/Test_rewriteRepoFilter/rewrite_repo_filter#04.golden
+++ b/internal/search/smartsearch/testdata/Test_rewriteRepoFilter/rewrite_repo_filter#04.golden
@@ -1,0 +1,4 @@
+{
+  "Input": "repo:https://github.com/sourcegraph/sourcegraph/tree/2.12",
+  "Query": "repo:^github.com/sourcegraph/sourcegraph$"
+}

--- a/internal/search/smartsearch/testdata/Test_rewriteRepoFilter/rewrite_repo_filter#05.golden
+++ b/internal/search/smartsearch/testdata/Test_rewriteRepoFilter/rewrite_repo_filter#05.golden
@@ -1,0 +1,4 @@
+{
+  "Input": "repo:https://github.com/sourcegraph/sourcegraph/commit/abc",
+  "Query": "repo:^github.com/sourcegraph/sourcegraph$"
+}

--- a/internal/search/smartsearch/testdata/Test_rewriteRepoFilter/rewrite_repo_filter.golden
+++ b/internal/search/smartsearch/testdata/Test_rewriteRepoFilter/rewrite_repo_filter.golden
@@ -1,0 +1,4 @@
+{
+  "Input": "repo:https://github.com/sourcegraph/sourcegraph",
+  "Query": "repo:^github.com/sourcegraph/sourcegraph$"
+}


### PR DESCRIPTION
User request: https://twitter.com/mitchellh/status/1610682504046051331

Note we already support a mapping like this if the query contains a naked GitHub URL along with another term (interpreted as a text search), but that does not trigger with the GitHub URL is the only term (because there are literal search results for that). I think that behavior is fine to leave as-is.

## Test plan

* Inspect added unit test
* Test with the a query like `repo:https://github.com/sourcegraph/sourcegraph` (this should map to `repo:^github.com/sourcegraph/sourcegraph$`