### PR TITLE
web: add a spinner to code hosts being in sync.

### DIFF
--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -12,7 +12,7 @@ import { ListExternalServiceFields } from '../../graphql-operations'
 import { refreshSiteFlags } from '../../site/backend'
 
 import { deleteExternalService, useExternalServiceCheckConnectionByIdLazyQuery } from './backend'
-import { defaultExternalServices } from './externalServices'
+import { defaultExternalServices, EXTERNAL_SERVICE_SYNC_RUNNING_STATUSES } from './externalServices'
 
 import styles from './ExternalServiceNode.module.scss'
 
@@ -82,7 +82,13 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
         >
             <div className="d-flex align-items-center justify-content-between">
                 <div className="align-self-start">
-                    {node.lastSyncError === null && (
+                    {EXTERNAL_SERVICE_SYNC_RUNNING_STATUSES.has(node.syncJobs.nodes[0].state) ? (
+                        <Tooltip content="Sync is running">
+                            <div aria-label="Sync is running">
+                                <LoadingSpinner className="mr-2" inline={true} />
+                            </div>
+                        </Tooltip>
+                    ) : node.lastSyncError === null ? (
                         <Tooltip content="All good, no errors!">
                             <Icon
                                 svgPath={mdiCircle}
@@ -90,8 +96,7 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
                                 className="text-success mr-2"
                             />
                         </Tooltip>
-                    )}
-                    {node.lastSyncError !== null && (
+                    ) : (
                         <Tooltip content="Syncing failed, check the error message for details!">
                             <Icon
                                 svgPath={mdiCircle}

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -39,7 +39,11 @@ import {
 } from './backend'
 import { ExternalServiceCard } from './ExternalServiceCard'
 import { ExternalServiceForm } from './ExternalServiceForm'
-import { defaultExternalServices, codeHostExternalServices } from './externalServices'
+import {
+    defaultExternalServices,
+    codeHostExternalServices,
+    EXTERNAL_SERVICE_SYNC_RUNNING_STATUSES,
+} from './externalServices'
 import { ExternalServiceWebhook } from './ExternalServiceWebhook'
 
 import styles from './ExternalServicePage.module.scss'
@@ -67,6 +71,7 @@ function isValidURL(url: string): boolean {
         return false
     }
 }
+
 const getExternalService = (queryResult?: ExternalServiceResult): ExternalServiceFields | null =>
     queryResult?.node?.__typename === 'ExternalService' ? queryResult.node : null
 
@@ -164,11 +169,11 @@ export const ExternalServicePage: React.FunctionComponent<React.PropsWithChildre
             isValidURL(parsedConfig.url)
                 ? new URL(parsedConfig.url)
                 : undefined
-        // We have no way of finding out whether a externalservice of kind GITHUB is GitHub.com or GitHub enterprise, so we need to guess based on the URL.
+        // We have no way of finding out whether an external service is GITHUB or GitHub.com or GitHub enterprise, so we need to guess based on the URL.
         if (externalService.kind === ExternalServiceKind.GITHUB && url?.hostname !== 'github.com') {
             externalServiceCategory = codeHostExternalServices.ghe
         }
-        // We have no way of finding out whether a externalservice of kind GITLAB is Gitlab.com or Gitlab self-hosted, so we need to guess based on the URL.
+        // We have no way of finding out whether an external service is GITLAB or Gitlab.com or Gitlab self-hosted, so we need to guess based on the URL.
         if (externalService.kind === ExternalServiceKind.GITLAB && url?.hostname !== 'gitlab.com') {
             externalServiceCategory = codeHostExternalServices.gitlab
         }
@@ -349,12 +354,7 @@ const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJob
         ]
     }, [node])
 
-    const runningStatuses = new Set<ExternalServiceSyncJobState>([
-        ExternalServiceSyncJobState.QUEUED,
-        ExternalServiceSyncJobState.PROCESSING,
-        ExternalServiceSyncJobState.CANCELING,
-    ])
-    const [isExpanded, setIsExpanded] = useState(runningStatuses.has(node.state))
+    const [isExpanded, setIsExpanded] = useState(EXTERNAL_SERVICE_SYNC_RUNNING_STATUSES.has(node.state))
     const toggleIsExpanded = useCallback<React.MouseEventHandler<HTMLButtonElement>>(() => {
         setIsExpanded(!isExpanded)
     }, [isExpanded])
@@ -417,7 +417,7 @@ const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJob
                         </>
                     )}
                 </div>
-                {runningStatuses.has(node.state) && (
+                {EXTERNAL_SERVICE_SYNC_RUNNING_STATUSES.has(node.state) && (
                     <LoaderButton
                         label="Cancel"
                         alwaysShowLabel={true}

--- a/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
@@ -1,4 +1,5 @@
 import { DecoratorFn, Meta, Story } from '@storybook/react'
+import { subMinutes } from 'date-fns'
 import { of } from 'rxjs'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -8,7 +9,6 @@ import { WebStory } from '../WebStory'
 
 import { queryExternalServices as _queryExternalServices } from './backend'
 import { ExternalServicesPage } from './ExternalServicesPage'
-import { subMinutes } from 'date-fns'
 
 const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
 

--- a/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
@@ -3,11 +3,12 @@ import { of } from 'rxjs'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
-import { ExternalServiceKind } from '../../graphql-operations'
+import { ExternalServiceKind, ExternalServiceSyncJobState } from '../../graphql-operations'
 import { WebStory } from '../WebStory'
 
 import { queryExternalServices as _queryExternalServices } from './backend'
 import { ExternalServicesPage } from './ExternalServicesPage'
+import { subMinutes } from 'date-fns'
 
 const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
 
@@ -41,6 +42,26 @@ const queryExternalServices: typeof _queryExternalServices = () =>
                 namespace: null,
                 webhookURL: null,
                 hasConnectionCheck: true,
+                syncJobs: {
+                    totalCount: 1,
+                    pageInfo: { endCursor: null, hasNextPage: false },
+                    nodes: [
+                        {
+                            __typename: 'ExternalServiceSyncJob',
+                            failureMessage: null,
+                            startedAt: subMinutes(new Date(), 25).toISOString(),
+                            finishedAt: null,
+                            id: 'SYNCJOB1',
+                            state: ExternalServiceSyncJobState.PROCESSING,
+                            reposSynced: 5,
+                            repoSyncErrors: 0,
+                            reposAdded: 5,
+                            reposDeleted: 0,
+                            reposModified: 0,
+                            reposUnmodified: 0,
+                        },
+                    ],
+                },
             },
             {
                 id: 'service2',
@@ -61,6 +82,26 @@ const queryExternalServices: typeof _queryExternalServices = () =>
                 },
                 webhookURL: null,
                 hasConnectionCheck: false,
+                syncJobs: {
+                    totalCount: 1,
+                    pageInfo: { endCursor: null, hasNextPage: false },
+                    nodes: [
+                        {
+                            __typename: 'ExternalServiceSyncJob',
+                            failureMessage: null,
+                            startedAt: subMinutes(new Date(), 25).toISOString(),
+                            finishedAt: null,
+                            id: 'SYNCJOB1',
+                            state: ExternalServiceSyncJobState.COMPLETED,
+                            reposSynced: 5,
+                            repoSyncErrors: 0,
+                            reposAdded: 5,
+                            reposDeleted: 0,
+                            reposModified: 0,
+                            reposUnmodified: 0,
+                        },
+                    ],
+                },
             },
         ],
     })

--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -160,7 +160,53 @@ export const useExternalServiceCheckConnectionByIdLazyQuery = (
         }
     )
 
-export const listExternalServiceFragment = gql`
+const EXTERNAL_SERVICE_SYNC_JOB_LIST_FIELDS_FRAGMENT = gql`
+    fragment ExternalServiceSyncJobListFields on ExternalServiceSyncJob {
+        __typename
+        id
+        state
+        startedAt
+        finishedAt
+        failureMessage
+        reposSynced
+        repoSyncErrors
+        reposAdded
+        reposDeleted
+        reposModified
+        reposUnmodified
+    }
+`
+
+const EXTERNAL_SERVICE_SYNC_JOB_CONNECTION_FIELDS_FRAGMENT = gql`
+    ${EXTERNAL_SERVICE_SYNC_JOB_LIST_FIELDS_FRAGMENT}
+    fragment ExternalServiceSyncJobConnectionFields on ExternalServiceSyncJobConnection {
+        totalCount
+        pageInfo {
+            endCursor
+            hasNextPage
+        }
+        nodes {
+            ...ExternalServiceSyncJobListFields
+        }
+    }
+`
+
+export const EXTERNAL_SERVICE_SYNC_JOBS = gql`
+    ${EXTERNAL_SERVICE_SYNC_JOB_CONNECTION_FIELDS_FRAGMENT}
+    query ExternalServiceSyncJobs($first: Int, $externalService: ID!) {
+        node(id: $externalService) {
+            __typename
+            ... on ExternalService {
+                syncJobs(first: $first) {
+                    ...ExternalServiceSyncJobConnectionFields
+                }
+            }
+        }
+    }
+`
+
+const LIST_EXTERNAL_SERVICE_FRAGMENT = gql`
+    ${EXTERNAL_SERVICE_SYNC_JOB_CONNECTION_FIELDS_FRAGMENT}
     fragment ListExternalServiceFields on ExternalService {
         id
         kind
@@ -175,6 +221,9 @@ export const listExternalServiceFragment = gql`
         createdAt
         webhookURL
         hasConnectionCheck
+        syncJobs(first: 1) {
+            ...ExternalServiceSyncJobConnectionFields
+        }
     }
 `
 export const EXTERNAL_SERVICES = gql`
@@ -191,7 +240,7 @@ export const EXTERNAL_SERVICES = gql`
         }
     }
 
-    ${listExternalServiceFragment}
+    ${LIST_EXTERNAL_SERVICE_FRAGMENT}
 `
 
 export const EXTERNAL_SERVICE_IDS_AND_NAMES = gql`
@@ -246,45 +295,6 @@ export function useCancelExternalServiceSync(): MutationTuple<
         CANCEL_EXTERNAL_SERVICE_SYNC
     )
 }
-
-export const EXTERNAL_SERVICE_SYNC_JOBS = gql`
-    query ExternalServiceSyncJobs($first: Int, $externalService: ID!) {
-        node(id: $externalService) {
-            __typename
-            ... on ExternalService {
-                syncJobs(first: $first) {
-                    ...ExternalServiceSyncJobConnectionFields
-                }
-            }
-        }
-    }
-
-    fragment ExternalServiceSyncJobConnectionFields on ExternalServiceSyncJobConnection {
-        totalCount
-        pageInfo {
-            endCursor
-            hasNextPage
-        }
-        nodes {
-            ...ExternalServiceSyncJobListFields
-        }
-    }
-
-    fragment ExternalServiceSyncJobListFields on ExternalServiceSyncJob {
-        __typename
-        id
-        state
-        startedAt
-        finishedAt
-        failureMessage
-        reposSynced
-        repoSyncErrors
-        reposAdded
-        reposDeleted
-        reposModified
-        reposUnmodified
-    }
-`
 
 export function queryExternalServiceSyncJobs(
     variables: ExternalServiceSyncJobsVariables

--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -33,7 +33,7 @@ import phabricatorSchemaJSON from '../../../../../schema/phabricator.schema.json
 import pythonPackagesJSON from '../../../../../schema/python-packages.schema.json'
 import rubyPackagesSchemaJSON from '../../../../../schema/ruby-packages.schema.json'
 import rustPackagesJSON from '../../../../../schema/rust-packages.schema.json'
-import { ExternalRepositoryFields, ExternalServiceKind } from '../../graphql-operations'
+import { ExternalRepositoryFields, ExternalServiceKind, ExternalServiceSyncJobState } from '../../graphql-operations'
 import { EditorAction } from '../../settings/EditorActionsGroup'
 
 /**
@@ -1504,3 +1504,9 @@ export const externalRepoIcon = (
     const externalServiceKind = externalRepo.serviceType.toUpperCase() as ExternalServiceKind
     return defaultExternalServices[externalServiceKind]?.icon ?? undefined
 }
+
+export const EXTERNAL_SERVICE_SYNC_RUNNING_STATUSES = new Set<ExternalServiceSyncJobState>([
+    ExternalServiceSyncJobState.QUEUED,
+    ExternalServiceSyncJobState.PROCESSING,
+    ExternalServiceSyncJobState.CANCELING,
+])

--- a/client/web/src/site-admin/fixtures.ts
+++ b/client/web/src/site-admin/fixtures.ts
@@ -1,7 +1,7 @@
-import { formatRFC3339 } from 'date-fns'
+import { formatRFC3339, subMinutes } from 'date-fns'
 import { of } from 'rxjs'
 
-import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
+import { ExternalServiceKind, ExternalServiceSyncJobState } from '@sourcegraph/shared/src/graphql-operations'
 
 import { queryExternalServices as _queryExternalServices } from '../components/externalServices/backend'
 import { ListExternalServiceFields, WebhookFields } from '../graphql-operations'
@@ -24,6 +24,26 @@ export function createExternalService(kind: ExternalServiceKind, url: string): L
         createdAt: '2021-03-15T19:39:11Z',
         webhookURL: null,
         hasConnectionCheck: true,
+        syncJobs: {
+            totalCount: 1,
+            pageInfo: { endCursor: null, hasNextPage: false },
+            nodes: [
+                {
+                    __typename: 'ExternalServiceSyncJob',
+                    failureMessage: null,
+                    startedAt: subMinutes(new Date(), 25).toISOString(),
+                    finishedAt: null,
+                    id: 'SYNCJOB1',
+                    state: ExternalServiceSyncJobState.PROCESSING,
+                    reposSynced: 5,
+                    repoSyncErrors: 0,
+                    reposAdded: 5,
+                    reposDeleted: 0,
+                    reposModified: 0,
+                    reposUnmodified: 0,
+                },
+            ],
+        },
     }
 }
 


### PR DESCRIPTION
Test plan:
Storybook updated. Local sg run and manual tests.

Part of https://github.com/sourcegraph/sourcegraph/issues/46036

<img width="1150" alt="image" src="https://user-images.githubusercontent.com/94846361/210749403-03346395-4564-4241-b78f-7b47e9bd9dcf.png">

## App preview:

- [Web](https://sg-web-ao-ui-code-host-sync-spinner.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
