### PR TITLE
internal: Persist author in site config

### DIFF
--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
@@ -122,11 +123,18 @@ func overrideSiteConfig(ctx context.Context, logger log.Logger, db database.DB) 
 		}
 		raw.Site = string(site)
 
-		// NOTE: authorUserID is nil because this code is on the start-up path and we will never
-		// have a non nil actor available here to determine the user ID. This is consistent with the
-		// behaviour of global settings as well. See settings.CreateIfUpToDate in
+		// NOTE: authorUserID is effectively 0 because this code is on the start-up path and we will
+		// never have a non nil actor available here to determine the user ID. This is consistent
+		// with the behaviour of global settings as well. See settings.CreateIfUpToDate in
 		// overrideGlobalSettings below.
-		err = cs.WriteWithOverride(ctx, raw, raw.ID, nil, true)
+		//
+		// A value of 0 will be treated as null when writing to the the database for this column.
+		//
+		// Nevertheless, we still use actor.FromContext() because it makes this code future proof in
+		// case some how this gets used in a non-startup path as well where an actor is available.
+		// In which case we will start populating the authorUserID in the database which is a good
+		// thing.
+		err = cs.WriteWithOverride(ctx, raw, raw.ID, actor.FromContext(ctx).UID, true)
 		if err != nil {
 			return errors.Wrap(err, "writing site config overrides to database")
 		}
@@ -454,11 +462,11 @@ func (c *configurationSource) Read(ctx context.Context) (conftypes.RawUnified, e
 	}, nil
 }
 
-func (c *configurationSource) Write(ctx context.Context, input conftypes.RawUnified, lastID int32, authorUserID *int32) error {
+func (c *configurationSource) Write(ctx context.Context, input conftypes.RawUnified, lastID int32, authorUserID int32) error {
 	return c.WriteWithOverride(ctx, input, lastID, authorUserID, false)
 }
 
-func (c *configurationSource) WriteWithOverride(ctx context.Context, input conftypes.RawUnified, lastID int32, authorUserID *int32, isOverride bool) error {
+func (c *configurationSource) WriteWithOverride(ctx context.Context, input conftypes.RawUnified, lastID int32, authorUserID int32, isOverride bool) error {
 	site, err := c.db.Conf().SiteGetLatest(ctx)
 	if err != nil {
 		return errors.Wrap(err, "ConfStore.SiteGetLatest")
@@ -466,7 +474,7 @@ func (c *configurationSource) WriteWithOverride(ctx context.Context, input conft
 	if site.ID != lastID {
 		return errors.New("site config has been modified by another request, write not allowed")
 	}
-	_, err = c.db.Conf().SiteCreateIfUpToDate(ctx, &site.ID, input.Site, authorUserID, isOverride)
+	_, err = c.db.Conf().SiteCreateIfUpToDate(ctx, &site.ID, authorUserID, input.Site, isOverride)
 	if err != nil {
 		log.Error(errors.Wrap(err, "SiteConfig creation failed"))
 		return errors.Wrap(err, "ConfStore.SiteCreateIfUpToDate")

--- a/cmd/frontend/internal/cli/config_test.go
+++ b/cmd/frontend/internal/cli/config_test.go
@@ -51,13 +51,12 @@ func TestWriteSiteConfig(t *testing.T) {
 	confSource := newConfigurationSource(logger, db)
 
 	t.Run("error when incorrect last ID", func(t *testing.T) {
-		err := confSource.Write(context.Background(), conftypes.RawUnified{}, conf.ID-1, nil)
+		err := confSource.Write(context.Background(), conftypes.RawUnified{}, conf.ID-1, 0)
 		assert.Error(t, err)
 	})
 
-	authorUserID := int32(1)
 	t.Run("no error when correct last ID", func(t *testing.T) {
-		err := confSource.Write(context.Background(), conftypes.RawUnified{}, conf.ID, &authorUserID)
+		err := confSource.Write(context.Background(), conftypes.RawUnified{}, conf.ID, 1)
 		assert.NoError(t, err)
 	})
 }

--- a/cmd/frontend/internal/cli/config_test.go
+++ b/cmd/frontend/internal/cli/config_test.go
@@ -51,12 +51,13 @@ func TestWriteSiteConfig(t *testing.T) {
 	confSource := newConfigurationSource(logger, db)
 
 	t.Run("error when incorrect last ID", func(t *testing.T) {
-		err := confSource.Write(context.Background(), conftypes.RawUnified{}, conf.ID-1)
+		err := confSource.Write(context.Background(), conftypes.RawUnified{}, conf.ID-1, nil)
 		assert.Error(t, err)
 	})
 
+	authorUserID := int32(1)
 	t.Run("no error when correct last ID", func(t *testing.T) {
-		err := confSource.Write(context.Background(), conftypes.RawUnified{}, conf.ID)
+		err := confSource.Write(context.Background(), conftypes.RawUnified{}, conf.ID, &authorUserID)
 		assert.NoError(t, err)
 	})
 }

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -146,10 +146,10 @@ func (c *cachedConfigurationSource) Read(ctx context.Context) (conftypes.RawUnif
 	return *c.entry, nil
 }
 
-func (c *cachedConfigurationSource) Write(ctx context.Context, input conftypes.RawUnified, lastID int32) error {
+func (c *cachedConfigurationSource) Write(ctx context.Context, input conftypes.RawUnified, lastID int32, authorUserID *int32) error {
 	c.entryMu.Lock()
 	defer c.entryMu.Unlock()
-	if err := c.source.Write(ctx, input, lastID); err != nil {
+	if err := c.source.Write(ctx, input, lastID, authorUserID); err != nil {
 		return err
 	}
 	c.entry = &input
@@ -253,7 +253,11 @@ func startSiteConfigEscapeHatchWorker(c ConfigurationSource) {
 					continue
 				}
 				config.Site = string(newFileContents)
-				err = c.Write(ctx, config, lastKnownConfigID)
+
+				// NOTE: authorUserID is nil because this code is on the start-up path and we will
+				// never have a non-nil actor available here to determine the user ID. This is
+				// consistent with the behaviour of site config creation via SITE_CONFIG_FILE.
+				err = c.Write(ctx, config, lastKnownConfigID, nil)
 				if err != nil {
 					logger.Warn("failed to save edit to database, trying again in 1s (write error)", sglog.Error(err))
 					time.Sleep(1 * time.Second)

--- a/internal/conf/mocks_test.go
+++ b/internal/conf/mocks_test.go
@@ -36,7 +36,7 @@ func NewMockConfigurationSource() *MockConfigurationSource {
 			},
 		},
 		WriteFunc: &ConfigurationSourceWriteFunc{
-			defaultHook: func(context.Context, conftypes.RawUnified, int32) (r0 error) {
+			defaultHook: func(context.Context, conftypes.RawUnified, int32, *int32) (r0 error) {
 				return
 			},
 		},
@@ -54,7 +54,7 @@ func NewStrictMockConfigurationSource() *MockConfigurationSource {
 			},
 		},
 		WriteFunc: &ConfigurationSourceWriteFunc{
-			defaultHook: func(context.Context, conftypes.RawUnified, int32) error {
+			defaultHook: func(context.Context, conftypes.RawUnified, int32, *int32) error {
 				panic("unexpected invocation of MockConfigurationSource.Write")
 			},
 		},
@@ -183,24 +183,24 @@ func (c ConfigurationSourceReadFuncCall) Results() []interface{} {
 // ConfigurationSourceWriteFunc describes the behavior when the Write method
 // of the parent MockConfigurationSource instance is invoked.
 type ConfigurationSourceWriteFunc struct {
-	defaultHook func(context.Context, conftypes.RawUnified, int32) error
-	hooks       []func(context.Context, conftypes.RawUnified, int32) error
+	defaultHook func(context.Context, conftypes.RawUnified, int32, *int32) error
+	hooks       []func(context.Context, conftypes.RawUnified, int32, *int32) error
 	history     []ConfigurationSourceWriteFuncCall
 	mutex       sync.Mutex
 }
 
 // Write delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockConfigurationSource) Write(v0 context.Context, v1 conftypes.RawUnified, v2 int32) error {
-	r0 := m.WriteFunc.nextHook()(v0, v1, v2)
-	m.WriteFunc.appendCall(ConfigurationSourceWriteFuncCall{v0, v1, v2, r0})
+func (m *MockConfigurationSource) Write(v0 context.Context, v1 conftypes.RawUnified, v2 int32, v3 *int32) error {
+	r0 := m.WriteFunc.nextHook()(v0, v1, v2, v3)
+	m.WriteFunc.appendCall(ConfigurationSourceWriteFuncCall{v0, v1, v2, v3, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the Write method of the
 // parent MockConfigurationSource instance is invoked and the hook queue is
 // empty.
-func (f *ConfigurationSourceWriteFunc) SetDefaultHook(hook func(context.Context, conftypes.RawUnified, int32) error) {
+func (f *ConfigurationSourceWriteFunc) SetDefaultHook(hook func(context.Context, conftypes.RawUnified, int32, *int32) error) {
 	f.defaultHook = hook
 }
 
@@ -208,7 +208,7 @@ func (f *ConfigurationSourceWriteFunc) SetDefaultHook(hook func(context.Context,
 // Write method of the parent MockConfigurationSource instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *ConfigurationSourceWriteFunc) PushHook(hook func(context.Context, conftypes.RawUnified, int32) error) {
+func (f *ConfigurationSourceWriteFunc) PushHook(hook func(context.Context, conftypes.RawUnified, int32, *int32) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -217,19 +217,19 @@ func (f *ConfigurationSourceWriteFunc) PushHook(hook func(context.Context, conft
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ConfigurationSourceWriteFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, conftypes.RawUnified, int32) error {
+	f.SetDefaultHook(func(context.Context, conftypes.RawUnified, int32, *int32) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ConfigurationSourceWriteFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, conftypes.RawUnified, int32) error {
+	f.PushHook(func(context.Context, conftypes.RawUnified, int32, *int32) error {
 		return r0
 	})
 }
 
-func (f *ConfigurationSourceWriteFunc) nextHook() func(context.Context, conftypes.RawUnified, int32) error {
+func (f *ConfigurationSourceWriteFunc) nextHook() func(context.Context, conftypes.RawUnified, int32, *int32) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -271,6 +271,9 @@ type ConfigurationSourceWriteFuncCall struct {
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
 	Arg2 int32
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 *int32
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -279,7 +282,7 @@ type ConfigurationSourceWriteFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ConfigurationSourceWriteFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/conf/mocks_test.go
+++ b/internal/conf/mocks_test.go
@@ -36,7 +36,7 @@ func NewMockConfigurationSource() *MockConfigurationSource {
 			},
 		},
 		WriteFunc: &ConfigurationSourceWriteFunc{
-			defaultHook: func(context.Context, conftypes.RawUnified, int32, *int32) (r0 error) {
+			defaultHook: func(context.Context, conftypes.RawUnified, int32, int32) (r0 error) {
 				return
 			},
 		},
@@ -54,7 +54,7 @@ func NewStrictMockConfigurationSource() *MockConfigurationSource {
 			},
 		},
 		WriteFunc: &ConfigurationSourceWriteFunc{
-			defaultHook: func(context.Context, conftypes.RawUnified, int32, *int32) error {
+			defaultHook: func(context.Context, conftypes.RawUnified, int32, int32) error {
 				panic("unexpected invocation of MockConfigurationSource.Write")
 			},
 		},
@@ -183,15 +183,15 @@ func (c ConfigurationSourceReadFuncCall) Results() []interface{} {
 // ConfigurationSourceWriteFunc describes the behavior when the Write method
 // of the parent MockConfigurationSource instance is invoked.
 type ConfigurationSourceWriteFunc struct {
-	defaultHook func(context.Context, conftypes.RawUnified, int32, *int32) error
-	hooks       []func(context.Context, conftypes.RawUnified, int32, *int32) error
+	defaultHook func(context.Context, conftypes.RawUnified, int32, int32) error
+	hooks       []func(context.Context, conftypes.RawUnified, int32, int32) error
 	history     []ConfigurationSourceWriteFuncCall
 	mutex       sync.Mutex
 }
 
 // Write delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockConfigurationSource) Write(v0 context.Context, v1 conftypes.RawUnified, v2 int32, v3 *int32) error {
+func (m *MockConfigurationSource) Write(v0 context.Context, v1 conftypes.RawUnified, v2 int32, v3 int32) error {
 	r0 := m.WriteFunc.nextHook()(v0, v1, v2, v3)
 	m.WriteFunc.appendCall(ConfigurationSourceWriteFuncCall{v0, v1, v2, v3, r0})
 	return r0
@@ -200,7 +200,7 @@ func (m *MockConfigurationSource) Write(v0 context.Context, v1 conftypes.RawUnif
 // SetDefaultHook sets function that is called when the Write method of the
 // parent MockConfigurationSource instance is invoked and the hook queue is
 // empty.
-func (f *ConfigurationSourceWriteFunc) SetDefaultHook(hook func(context.Context, conftypes.RawUnified, int32, *int32) error) {
+func (f *ConfigurationSourceWriteFunc) SetDefaultHook(hook func(context.Context, conftypes.RawUnified, int32, int32) error) {
 	f.defaultHook = hook
 }
 
@@ -208,7 +208,7 @@ func (f *ConfigurationSourceWriteFunc) SetDefaultHook(hook func(context.Context,
 // Write method of the parent MockConfigurationSource instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *ConfigurationSourceWriteFunc) PushHook(hook func(context.Context, conftypes.RawUnified, int32, *int32) error) {
+func (f *ConfigurationSourceWriteFunc) PushHook(hook func(context.Context, conftypes.RawUnified, int32, int32) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -217,19 +217,19 @@ func (f *ConfigurationSourceWriteFunc) PushHook(hook func(context.Context, conft
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ConfigurationSourceWriteFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, conftypes.RawUnified, int32, *int32) error {
+	f.SetDefaultHook(func(context.Context, conftypes.RawUnified, int32, int32) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ConfigurationSourceWriteFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, conftypes.RawUnified, int32, *int32) error {
+	f.PushHook(func(context.Context, conftypes.RawUnified, int32, int32) error {
 		return r0
 	})
 }
 
-func (f *ConfigurationSourceWriteFunc) nextHook() func(context.Context, conftypes.RawUnified, int32, *int32) error {
+func (f *ConfigurationSourceWriteFunc) nextHook() func(context.Context, conftypes.RawUnified, int32, int32) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -273,7 +273,7 @@ type ConfigurationSourceWriteFuncCall struct {
 	Arg2 int32
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 *int32
+	Arg3 int32
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error

--- a/internal/conf/server.go
+++ b/internal/conf/server.go
@@ -11,7 +11,7 @@ import (
 // "raw" configuration.
 type ConfigurationSource interface {
 	// Write updates the configuration. The Deployment field is ignored.
-	Write(ctx context.Context, data conftypes.RawUnified, lastID int32) error
+	Write(ctx context.Context, data conftypes.RawUnified, lastID int32, authorUserID *int32) error
 	Read(ctx context.Context) (conftypes.RawUnified, error)
 }
 
@@ -41,7 +41,7 @@ func NewServer(source ConfigurationSource) *Server {
 }
 
 // Write validates and writes input to the server's source.
-func (s *Server) Write(ctx context.Context, input conftypes.RawUnified, lastID int32) error {
+func (s *Server) Write(ctx context.Context, input conftypes.RawUnified, lastID int32, authorUserID int32) error {
 	// Parse the configuration so that we can diff it (this also validates it
 	// is proper JSON).
 	_, err := ParseConfig(input)
@@ -49,7 +49,7 @@ func (s *Server) Write(ctx context.Context, input conftypes.RawUnified, lastID i
 		return err
 	}
 
-	err = s.source.Write(ctx, input, lastID)
+	err = s.source.Write(ctx, input, lastID, &authorUserID)
 	if err != nil {
 		return err
 	}

--- a/internal/conf/server.go
+++ b/internal/conf/server.go
@@ -11,7 +11,7 @@ import (
 // "raw" configuration.
 type ConfigurationSource interface {
 	// Write updates the configuration. The Deployment field is ignored.
-	Write(ctx context.Context, data conftypes.RawUnified, lastID int32, authorUserID *int32) error
+	Write(ctx context.Context, data conftypes.RawUnified, lastID int32, authorUserID int32) error
 	Read(ctx context.Context) (conftypes.RawUnified, error)
 }
 
@@ -49,7 +49,7 @@ func (s *Server) Write(ctx context.Context, input conftypes.RawUnified, lastID i
 		return err
 	}
 
-	err = s.source.Write(ctx, input, lastID, &authorUserID)
+	err = s.source.Write(ctx, input, lastID, authorUserID)
 	if err != nil {
 		return err
 	}

--- a/internal/database/conf_test.go
+++ b/internal/database/conf_test.go
@@ -43,7 +43,7 @@ func TestSiteCreate_RejectInvalidJSON(t *testing.T) {
 
 	malformedJSON := "[This is malformed.}"
 
-	_, err := db.Conf().SiteCreateIfUpToDate(ctx, nil, malformedJSON, false)
+	_, err := db.Conf().SiteCreateIfUpToDate(ctx, nil, malformedJSON, nil, false)
 
 	if err == nil || !strings.Contains(err.Error(), "failed to parse JSON") {
 		t.Fatalf("expected parse error after creating configuration with malformed JSON, got: %+v", err)
@@ -177,7 +177,7 @@ func TestSiteCreateIfUpToDate(t *testing.T) {
 			db := NewDB(logger, dbtest.NewDB(logger, t))
 			ctx := context.Background()
 			for _, p := range test.sequence {
-				output, err := db.Conf().SiteCreateIfUpToDate(ctx, &p.input.lastID, p.input.contents, false)
+				output, err := db.Conf().SiteCreateIfUpToDate(ctx, &p.input.lastID, p.input.contents, nil, false)
 				if err != nil {
 					if errors.Is(err, p.expected.err) {
 						continue

--- a/internal/database/conf_test.go
+++ b/internal/database/conf_test.go
@@ -196,7 +196,7 @@ func TestSiteCreateIfUpToDate(t *testing.T) {
 			db := NewDB(logger, dbtest.NewDB(logger, t))
 			ctx := context.Background()
 			for _, p := range test.sequence {
-				output, err := db.Conf().SiteCreateIfUpToDate(ctx, &p.input.lastID, p.input.contents, nil, false)
+				output, err := db.Conf().SiteCreateIfUpToDate(ctx, &p.input.lastID, 0, p.input.contents, false)
 				if err != nil {
 					if errors.Is(err, p.expected.err) {
 						continue

--- a/internal/database/conf_test.go
+++ b/internal/database/conf_test.go
@@ -43,7 +43,7 @@ func TestSiteCreate_RejectInvalidJSON(t *testing.T) {
 
 	malformedJSON := "[This is malformed.}"
 
-	_, err := db.Conf().SiteCreateIfUpToDate(ctx, nil, malformedJSON, nil, false)
+	_, err := db.Conf().SiteCreateIfUpToDate(ctx, nil, 0, malformedJSON, false)
 
 	if err == nil || !strings.Contains(err.Error(), "failed to parse JSON") {
 		t.Fatalf("expected parse error after creating configuration with malformed JSON, got: %+v", err)

--- a/internal/database/conf_test.go
+++ b/internal/database/conf_test.go
@@ -55,14 +55,16 @@ func TestSiteCreateIfUpToDate(t *testing.T) {
 	logger := logtest.Scoped(t)
 
 	type input struct {
-		lastID   int32
-		contents string
+		lastID         int32
+		author_user_id int32
+		contents       string
 	}
 
 	type output struct {
-		ID       int32
-		contents string
-		err      error
+		ID             int32
+		author_user_id int32
+		contents       string
+		err            error
 	}
 
 	type pair struct {
@@ -76,6 +78,23 @@ func TestSiteCreateIfUpToDate(t *testing.T) {
 	}
 
 	for _, test := range []test{
+		{
+			name: "create_with_author_user_id",
+			sequence: []pair{
+				{
+					input{
+						lastID:         0,
+						author_user_id: 1,
+						contents:       `{"defaultRateLimit": 0,"auth.providers": []}`,
+					},
+					output{
+						ID:             2,
+						author_user_id: 1,
+						contents:       `{"defaultRateLimit": 0,"auth.providers": []}`,
+					},
+				},
+			},
+		},
 		{
 			name: "create_one",
 			sequence: []pair{

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -3019,7 +3019,7 @@ func NewMockConfStore() *MockConfStore {
 			},
 		},
 		SiteCreateIfUpToDateFunc: &ConfStoreSiteCreateIfUpToDateFunc{
-			defaultHook: func(context.Context, *int32, string, bool) (r0 *SiteConfig, r1 error) {
+			defaultHook: func(context.Context, *int32, string, *int32, bool) (r0 *SiteConfig, r1 error) {
 				return
 			},
 		},
@@ -3051,7 +3051,7 @@ func NewStrictMockConfStore() *MockConfStore {
 			},
 		},
 		SiteCreateIfUpToDateFunc: &ConfStoreSiteCreateIfUpToDateFunc{
-			defaultHook: func(context.Context, *int32, string, bool) (*SiteConfig, error) {
+			defaultHook: func(context.Context, *int32, string, *int32, bool) (*SiteConfig, error) {
 				panic("unexpected invocation of MockConfStore.SiteCreateIfUpToDate")
 			},
 		},
@@ -3293,24 +3293,24 @@ func (c ConfStoreHandleFuncCall) Results() []interface{} {
 // SiteCreateIfUpToDate method of the parent MockConfStore instance is
 // invoked.
 type ConfStoreSiteCreateIfUpToDateFunc struct {
-	defaultHook func(context.Context, *int32, string, bool) (*SiteConfig, error)
-	hooks       []func(context.Context, *int32, string, bool) (*SiteConfig, error)
+	defaultHook func(context.Context, *int32, string, *int32, bool) (*SiteConfig, error)
+	hooks       []func(context.Context, *int32, string, *int32, bool) (*SiteConfig, error)
 	history     []ConfStoreSiteCreateIfUpToDateFuncCall
 	mutex       sync.Mutex
 }
 
 // SiteCreateIfUpToDate delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockConfStore) SiteCreateIfUpToDate(v0 context.Context, v1 *int32, v2 string, v3 bool) (*SiteConfig, error) {
-	r0, r1 := m.SiteCreateIfUpToDateFunc.nextHook()(v0, v1, v2, v3)
-	m.SiteCreateIfUpToDateFunc.appendCall(ConfStoreSiteCreateIfUpToDateFuncCall{v0, v1, v2, v3, r0, r1})
+func (m *MockConfStore) SiteCreateIfUpToDate(v0 context.Context, v1 *int32, v2 string, v3 *int32, v4 bool) (*SiteConfig, error) {
+	r0, r1 := m.SiteCreateIfUpToDateFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.SiteCreateIfUpToDateFunc.appendCall(ConfStoreSiteCreateIfUpToDateFuncCall{v0, v1, v2, v3, v4, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the SiteCreateIfUpToDate
 // method of the parent MockConfStore instance is invoked and the hook queue
 // is empty.
-func (f *ConfStoreSiteCreateIfUpToDateFunc) SetDefaultHook(hook func(context.Context, *int32, string, bool) (*SiteConfig, error)) {
+func (f *ConfStoreSiteCreateIfUpToDateFunc) SetDefaultHook(hook func(context.Context, *int32, string, *int32, bool) (*SiteConfig, error)) {
 	f.defaultHook = hook
 }
 
@@ -3318,7 +3318,7 @@ func (f *ConfStoreSiteCreateIfUpToDateFunc) SetDefaultHook(hook func(context.Con
 // SiteCreateIfUpToDate method of the parent MockConfStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *ConfStoreSiteCreateIfUpToDateFunc) PushHook(hook func(context.Context, *int32, string, bool) (*SiteConfig, error)) {
+func (f *ConfStoreSiteCreateIfUpToDateFunc) PushHook(hook func(context.Context, *int32, string, *int32, bool) (*SiteConfig, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3327,19 +3327,19 @@ func (f *ConfStoreSiteCreateIfUpToDateFunc) PushHook(hook func(context.Context, 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ConfStoreSiteCreateIfUpToDateFunc) SetDefaultReturn(r0 *SiteConfig, r1 error) {
-	f.SetDefaultHook(func(context.Context, *int32, string, bool) (*SiteConfig, error) {
+	f.SetDefaultHook(func(context.Context, *int32, string, *int32, bool) (*SiteConfig, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ConfStoreSiteCreateIfUpToDateFunc) PushReturn(r0 *SiteConfig, r1 error) {
-	f.PushHook(func(context.Context, *int32, string, bool) (*SiteConfig, error) {
+	f.PushHook(func(context.Context, *int32, string, *int32, bool) (*SiteConfig, error) {
 		return r0, r1
 	})
 }
 
-func (f *ConfStoreSiteCreateIfUpToDateFunc) nextHook() func(context.Context, *int32, string, bool) (*SiteConfig, error) {
+func (f *ConfStoreSiteCreateIfUpToDateFunc) nextHook() func(context.Context, *int32, string, *int32, bool) (*SiteConfig, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3384,7 +3384,10 @@ type ConfStoreSiteCreateIfUpToDateFuncCall struct {
 	Arg2 string
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 bool
+	Arg3 *int32
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 bool
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *SiteConfig
@@ -3396,7 +3399,7 @@ type ConfStoreSiteCreateIfUpToDateFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ConfStoreSiteCreateIfUpToDateFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -3019,7 +3019,7 @@ func NewMockConfStore() *MockConfStore {
 			},
 		},
 		SiteCreateIfUpToDateFunc: &ConfStoreSiteCreateIfUpToDateFunc{
-			defaultHook: func(context.Context, *int32, string, *int32, bool) (r0 *SiteConfig, r1 error) {
+			defaultHook: func(context.Context, *int32, int32, string, bool) (r0 *SiteConfig, r1 error) {
 				return
 			},
 		},
@@ -3051,7 +3051,7 @@ func NewStrictMockConfStore() *MockConfStore {
 			},
 		},
 		SiteCreateIfUpToDateFunc: &ConfStoreSiteCreateIfUpToDateFunc{
-			defaultHook: func(context.Context, *int32, string, *int32, bool) (*SiteConfig, error) {
+			defaultHook: func(context.Context, *int32, int32, string, bool) (*SiteConfig, error) {
 				panic("unexpected invocation of MockConfStore.SiteCreateIfUpToDate")
 			},
 		},
@@ -3293,15 +3293,15 @@ func (c ConfStoreHandleFuncCall) Results() []interface{} {
 // SiteCreateIfUpToDate method of the parent MockConfStore instance is
 // invoked.
 type ConfStoreSiteCreateIfUpToDateFunc struct {
-	defaultHook func(context.Context, *int32, string, *int32, bool) (*SiteConfig, error)
-	hooks       []func(context.Context, *int32, string, *int32, bool) (*SiteConfig, error)
+	defaultHook func(context.Context, *int32, int32, string, bool) (*SiteConfig, error)
+	hooks       []func(context.Context, *int32, int32, string, bool) (*SiteConfig, error)
 	history     []ConfStoreSiteCreateIfUpToDateFuncCall
 	mutex       sync.Mutex
 }
 
 // SiteCreateIfUpToDate delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockConfStore) SiteCreateIfUpToDate(v0 context.Context, v1 *int32, v2 string, v3 *int32, v4 bool) (*SiteConfig, error) {
+func (m *MockConfStore) SiteCreateIfUpToDate(v0 context.Context, v1 *int32, v2 int32, v3 string, v4 bool) (*SiteConfig, error) {
 	r0, r1 := m.SiteCreateIfUpToDateFunc.nextHook()(v0, v1, v2, v3, v4)
 	m.SiteCreateIfUpToDateFunc.appendCall(ConfStoreSiteCreateIfUpToDateFuncCall{v0, v1, v2, v3, v4, r0, r1})
 	return r0, r1
@@ -3310,7 +3310,7 @@ func (m *MockConfStore) SiteCreateIfUpToDate(v0 context.Context, v1 *int32, v2 s
 // SetDefaultHook sets function that is called when the SiteCreateIfUpToDate
 // method of the parent MockConfStore instance is invoked and the hook queue
 // is empty.
-func (f *ConfStoreSiteCreateIfUpToDateFunc) SetDefaultHook(hook func(context.Context, *int32, string, *int32, bool) (*SiteConfig, error)) {
+func (f *ConfStoreSiteCreateIfUpToDateFunc) SetDefaultHook(hook func(context.Context, *int32, int32, string, bool) (*SiteConfig, error)) {
 	f.defaultHook = hook
 }
 
@@ -3318,7 +3318,7 @@ func (f *ConfStoreSiteCreateIfUpToDateFunc) SetDefaultHook(hook func(context.Con
 // SiteCreateIfUpToDate method of the parent MockConfStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *ConfStoreSiteCreateIfUpToDateFunc) PushHook(hook func(context.Context, *int32, string, *int32, bool) (*SiteConfig, error)) {
+func (f *ConfStoreSiteCreateIfUpToDateFunc) PushHook(hook func(context.Context, *int32, int32, string, bool) (*SiteConfig, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3327,19 +3327,19 @@ func (f *ConfStoreSiteCreateIfUpToDateFunc) PushHook(hook func(context.Context, 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ConfStoreSiteCreateIfUpToDateFunc) SetDefaultReturn(r0 *SiteConfig, r1 error) {
-	f.SetDefaultHook(func(context.Context, *int32, string, *int32, bool) (*SiteConfig, error) {
+	f.SetDefaultHook(func(context.Context, *int32, int32, string, bool) (*SiteConfig, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ConfStoreSiteCreateIfUpToDateFunc) PushReturn(r0 *SiteConfig, r1 error) {
-	f.PushHook(func(context.Context, *int32, string, *int32, bool) (*SiteConfig, error) {
+	f.PushHook(func(context.Context, *int32, int32, string, bool) (*SiteConfig, error) {
 		return r0, r1
 	})
 }
 
-func (f *ConfStoreSiteCreateIfUpToDateFunc) nextHook() func(context.Context, *int32, string, *int32, bool) (*SiteConfig, error) {
+func (f *ConfStoreSiteCreateIfUpToDateFunc) nextHook() func(context.Context, *int32, int32, string, bool) (*SiteConfig, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3381,10 +3381,10 @@ type ConfStoreSiteCreateIfUpToDateFuncCall struct {
 	Arg1 *int32
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 string
+	Arg2 int32
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 *int32
+	Arg3 string
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
 	Arg4 bool

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -7372,6 +7372,19 @@
       "Comment": "",
       "Columns": [
         {
+          "Name": "author_user_id",
+          "Index": 6,
+          "TypeName": "integer",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
           "Name": "contents",
           "Index": 3,
           "TypeName": "text",

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -7382,7 +7382,7 @@
           "IdentityGeneration": "",
           "IsGenerated": "NEVER",
           "GenerationExpression": "",
-          "Comment": ""
+          "Comment": "A null value indicates that this config was most likely added by code on the start-up path, for example from the SITE_CONFIG_FILE unless the config itself was added before this column existed in which case it could also have been a user."
         },
         {
           "Name": "contents",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -963,13 +963,14 @@ Indexes:
 
 # Table "public.critical_and_site_config"
 ```
-   Column   |           Type           | Collation | Nullable |                       Default                        
-------------+--------------------------+-----------+----------+------------------------------------------------------
- id         | integer                  |           | not null | nextval('critical_and_site_config_id_seq'::regclass)
- type       | critical_or_site         |           | not null | 
- contents   | text                     |           | not null | 
- created_at | timestamp with time zone |           | not null | now()
- updated_at | timestamp with time zone |           | not null | now()
+     Column     |           Type           | Collation | Nullable |                       Default                        
+----------------+--------------------------+-----------+----------+------------------------------------------------------
+ id             | integer                  |           | not null | nextval('critical_and_site_config_id_seq'::regclass)
+ type           | critical_or_site         |           | not null | 
+ contents       | text                     |           | not null | 
+ created_at     | timestamp with time zone |           | not null | now()
+ updated_at     | timestamp with time zone |           | not null | now()
+ author_user_id | integer                  |           |          | 
 Indexes:
     "critical_and_site_config_pkey" PRIMARY KEY, btree (id)
     "critical_and_site_config_unique" UNIQUE, btree (id, type)

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -977,6 +977,8 @@ Indexes:
 
 ```
 
+**author_user_id**: A null value indicates that this config was most likely added by code on the start-up path, for example from the SITE_CONFIG_FILE unless the config itself was added before this column existed in which case it could also have been a user.
+
 # Table "public.discussion_comments"
 ```
      Column     |           Type           | Collation | Nullable |                     Default                     

--- a/migrations/frontend/1672897105_add_column_author_user_id_to_critical_and_site_config/down.sql
+++ b/migrations/frontend/1672897105_add_column_author_user_id_to_critical_and_site_config/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE critical_and_site_config
+      DROP COLUMN IF EXISTS author_user_id;

--- a/migrations/frontend/1672897105_add_column_author_user_id_to_critical_and_site_config/metadata.yaml
+++ b/migrations/frontend/1672897105_add_column_author_user_id_to_critical_and_site_config/metadata.yaml
@@ -1,0 +1,2 @@
+name: add column author_user_id to critical_and_site_config
+parents: [1669645608, 1670870072, 1670600028]

--- a/migrations/frontend/1672897105_add_column_author_user_id_to_critical_and_site_config/up.sql
+++ b/migrations/frontend/1672897105_add_column_author_user_id_to_critical_and_site_config/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE critical_and_site_config
+      ADD COLUMN IF NOT EXISTS author_user_id integer;

--- a/migrations/frontend/1672897105_add_column_author_user_id_to_critical_and_site_config/up.sql
+++ b/migrations/frontend/1672897105_add_column_author_user_id_to_critical_and_site_config/up.sql
@@ -1,2 +1,3 @@
 ALTER TABLE critical_and_site_config
       ADD COLUMN IF NOT EXISTS author_user_id integer;
+COMMENT ON COLUMN critical_and_site_config.author_user_id IS 'A null value indicates that this config was most likely added by code on the start-up path, for example from the SITE_CONFIG_FILE unless the config itself was added before this column existed in which case it could also have been a user.';

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -1697,7 +1697,8 @@ CREATE TABLE critical_and_site_config (
     type critical_or_site NOT NULL,
     contents text NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    author_user_id integer
 );
 
 CREATE SEQUENCE critical_and_site_config_id_seq

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -1701,6 +1701,8 @@ CREATE TABLE critical_and_site_config (
     author_user_id integer
 );
 
+COMMENT ON COLUMN critical_and_site_config.author_user_id IS 'A null value indicates that this config was most likely added by code on the start-up path, for example from the SITE_CONFIG_FILE unless the config itself was added before this column existed in which case it could also have been a user.';
+
 CREATE SEQUENCE critical_and_site_config_id_seq
     START WITH 1
     INCREMENT BY 1


### PR DESCRIPTION
Part of #46031. Follow up on #45618.

## Why

We want to be able to show the site admin who made a specific change to the config.

## Test plan

1. Tested locally.

(Wanted to upload the GIF but its more than 10MB and its 2022 and GitHub restricts file size to 10MB. 😭) 

<img width="1281" alt="image" src="https://user-images.githubusercontent.com/2682729/210781982-451b856a-d54f-4eda-ae9c-fbaa05451780.png">


2. Builds pass.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
