### PR TITLE
chore: Fix local warning from sg lint -fix go

### DIFF
--- a/cmd/server/shared/postgres.go
+++ b/cmd/server/shared/postgres.go
@@ -43,7 +43,7 @@ func maybePostgresProcFile() (string, error) {
 	// we configured above.
 	for prefix, database := range databases {
 		if !isPostgresConfigured(prefix) {
-			// Set *PGHOST to default to 127.0.0.1, NOT localhost, as localhost does not correctly resolve in some environments
+			// Set *PGHOST to default to 127.0.0.1, NOT localhost, as localhost does not correctly resolve in some environments (CI:LOCALHOST_OK)
 			// (see https://github.com/sourcegraph/issues/issues/34 and https://github.com/sourcegraph/sourcegraph/issues/9129).
 			SetDefaultEnv(prefix+"PGHOST", "127.0.0.1")
 			SetDefaultEnv(prefix+"PGUSER", "postgres")

--- a/internal/txemail/txemail.go
+++ b/internal/txemail/txemail.go
@@ -131,7 +131,7 @@ func Send(ctx context.Context, source string, message Message) (err error) {
 
 	// NOTE: Some services (e.g. Google SMTP relay) require to echo desired hostname,
 	// our current email dependency "github.com/jordan-wright/email" has no option
-	// for it and always echoes "localhost" which makes it unusable.
+	// for it and always echoes "localhost" which makes it unusable. (CI:LOCALHOST_OK)
 	heloHostname := conf.EmailSmtp.Domain
 	if heloHostname == "" {
 		heloHostname = "localhost" // CI:LOCALHOST_OK


### PR DESCRIPTION
Ideally the localhost guard should skip comment blocks, but this is a quicker workaround for the time being.

The warning shows up locally for me.



## Test plan

Not applicable.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
