### PR TITLE
doc: highlight steps for flaky test disabling.

### DIFF
--- a/dev/build-tracker/slack.go
+++ b/dev/build-tracker/slack.go
@@ -163,8 +163,9 @@ func (c *NotificationClient) createMessageBlocks(logger log.Logger, build *Build
 			&slack.TextBlockObject{
 				Type: slack.MarkdownType,
 				Text: `:books: *More information on flakes*
-• <https://docs.sourcegraph.com/dev/background-information/ci#flakes|How to disable flakey tests>
-• <https://docs.sourcegraph.com/dev/how-to/testing#assessing-flaky-client-steps|Recognizing flakey client steps and how to fix them>
+• <https://docs.sourcegraph.com/dev/background-information/ci#flakes|How to disable flaky tests>
+• <https://github.com/sourcegraph/sourcegraph/issues/new/choose|Create a flaky test issue>
+• <https://docs.sourcegraph.com/dev/how-to/testing#assessing-flaky-client-steps|Recognizing flaky client steps and how to fix them>
 
 _Disable flakes on sight and save your fellow teammate some time!_`,
 			},

--- a/doc/dev/background-information/ci/index.md
+++ b/doc/dev/background-information/ci/index.md
@@ -123,14 +123,16 @@ Typical reasons why a test may be flaky:
 - Unreliable test infrastructure (such as CI)
 - Reliance on third-party services that are inconsistent
 
-If a flaky test is discovered, immediately use language-specific functionality to skip a test and open a PR to disable the test:
+**If a flaky test is discovered:**
 
-- Go: [`testing.T.Skip`](https://pkg.go.dev/testing#hdr-Skipping)
-- Typescript: [`.skip()`](https://mochajs.org/#inclusive-tests)
+1. Immediately use language-specific functionality to skip a test and open a PR to disable the test:
 
-If the language or framework allows for a skip reason, include a link to the issue track re-enabling the test, or leave a docstring with a link.
+    - Go: [`testing.T.Skip`](https://pkg.go.dev/testing#hdr-Skipping)
+    - Typescript: [`.skip()`](https://mochajs.org/#inclusive-tests)
 
-Then open an issue to investigate the flaky test (use the [flaky test issue template](https://github.com/sourcegraph/sourcegraph/issues/new/choose)), and assign it to the most likely owner.
+   If the language or framework allows for a skip reason, include a link to the issue track re-enabling the test, or leave a docstring with a link.
+
+2. Open an issue to investigate the flaky test (use the [flaky test issue template](https://github.com/sourcegraph/sourcegraph/issues/new/choose)), and assign it to the most likely owner.
 
 ##### Flaky steps
 


### PR DESCRIPTION
It is easy to overlook current steps when a flaky test is discovered. This makes it a bit more visible IMO.

## Test plan
n/a