### PR TITLE
nix: bump nixpkgs for newer nodejs16

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659956501,
-        "narHash": "sha256-7cF2zOaTLWcxmhPBpI1ZoThUy11M1QiY5pat0OXwg3c=",
+        "lastModified": 1669833724,
+        "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6f38b43c8c84c800f93465b2241156419fd4fd52",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6f38b43c8c84c800f93465b2241156419fd4fd52",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "The Sourcegraph developer environment Nix Flake";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=6f38b43c8c84c800f93465b2241156419fd4fd52";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=4d2b37a84fad1091b9de401eb450aae66f1a741e";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
Need to bump nodejs due to https://sourcegraph.slack.com/archives/C01N83PS4TU/p1671046513225759

## Test plan

N/A, dev stuff
