### PR TITLE
codeintel: use new upstream musl coursier builds

### DIFF
--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -18,12 +18,10 @@ RUN /p4-fusion-install-alpine.sh
 
 FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5 AS coursier
 
-# TODO(code-intel): replace with official streams when musl builds are upstreamed
-RUN wget -O coursier.zip https://github.com/sourcegraph/lsif-java/releases/download/v0.5.6/cs-musl.zip && \
+RUN wget -O coursier.zip https://github.com/coursier/coursier/releases/download/v2.1.0-RC4/cs-x86_64-pc-linux-static.gz && \
     unzip coursier.zip && \
-    mv cs-musl /usr/local/bin/coursier && \
+    mv cs-x86_64-pc-linux-static /usr/local/bin/coursier && \
     chmod +x /usr/local/bin/coursier
-
 
 FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5
 

--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -18,9 +18,9 @@ RUN /p4-fusion-install-alpine.sh
 
 FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5 AS coursier
 
-RUN wget -O coursier.zip https://github.com/coursier/coursier/releases/download/v2.1.0-RC4/cs-x86_64-pc-linux-static.gz && \
-    unzip coursier.zip && \
-    mv cs-x86_64-pc-linux-static /usr/local/bin/coursier && \
+RUN wget -O coursier.gz https://github.com/coursier/coursier/releases/download/v2.1.0-RC4/cs-x86_64-pc-linux-static.gz && \
+    gzip -d coursier.gz && \
+    mv coursier /usr/local/bin/coursier && \
     chmod +x /usr/local/bin/coursier
 
 FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5

--- a/cmd/repo-updater/Dockerfile
+++ b/cmd/repo-updater/Dockerfile
@@ -5,10 +5,9 @@
 
 FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5 AS coursier
 
-# TODO(code-intel): replace with official streams when musl builds are upstreamed
-RUN wget -O coursier.zip https://github.com/sourcegraph/lsif-java/releases/download/v0.5.6/cs-musl.zip && \
+RUN wget -O coursier.zip https://github.com/coursier/coursier/releases/download/v2.1.0-RC4/cs-x86_64-pc-linux-static.gz && \
     unzip coursier.zip && \
-    mv cs-musl /usr/local/bin/coursier && \
+    mv cs-x86_64-pc-linux-static /usr/local/bin/coursier && \
     chmod +x /usr/local/bin/coursier
 
 FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5

--- a/cmd/repo-updater/Dockerfile
+++ b/cmd/repo-updater/Dockerfile
@@ -5,9 +5,9 @@
 
 FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5 AS coursier
 
-RUN wget -O coursier.zip https://github.com/coursier/coursier/releases/download/v2.1.0-RC4/cs-x86_64-pc-linux-static.gz && \
-    unzip coursier.zip && \
-    mv cs-x86_64-pc-linux-static /usr/local/bin/coursier && \
+RUN wget -O coursier.gz https://github.com/coursier/coursier/releases/download/v2.1.0-RC4/cs-x86_64-pc-linux-static.gz && \
+    gzip -d coursier.gz && \
+    mv coursier /usr/local/bin/coursier && \
     chmod +x /usr/local/bin/coursier
 
 FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -15,10 +15,9 @@ RUN /p4-fusion-install-alpine.sh
 # Install coursier (keep this up to date with cmd/gitserver/Dockerfile)
 FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5 AS coursier
 
-# TODO(code-intel): replace with official streams when musl builds are upstreamed
-RUN wget -O coursier.zip https://github.com/sourcegraph/lsif-java/releases/download/v0.5.6/cs-musl.zip && \
+RUN wget -O coursier.zip https://github.com/coursier/coursier/releases/download/v2.1.0-RC4/cs-x86_64-pc-linux-static.gz && \
     unzip coursier.zip && \
-    mv cs-musl /usr/local/bin/coursier && \
+    mv cs-x86_64-pc-linux-static /usr/local/bin/coursier && \
     chmod +x /usr/local/bin/coursier
 
 FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -15,9 +15,9 @@ RUN /p4-fusion-install-alpine.sh
 # Install coursier (keep this up to date with cmd/gitserver/Dockerfile)
 FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5 AS coursier
 
-RUN wget -O coursier.zip https://github.com/coursier/coursier/releases/download/v2.1.0-RC4/cs-x86_64-pc-linux-static.gz && \
-    unzip coursier.zip && \
-    mv cs-x86_64-pc-linux-static /usr/local/bin/coursier && \
+RUN wget -O coursier.gz https://github.com/coursier/coursier/releases/download/v2.1.0-RC4/cs-x86_64-pc-linux-static.gz && \
+    gzip -d coursier.gz && \
+    mv coursier /usr/local/bin/coursier && \
     chmod +x /usr/local/bin/coursier
 
 FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5

--- a/enterprise/cmd/gitserver/Dockerfile
+++ b/enterprise/cmd/gitserver/Dockerfile
@@ -18,12 +18,10 @@ RUN /p4-fusion-install-alpine.sh
 
 FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5 AS coursier
 
-# TODO(code-intel): replace with official streams when musl builds are upstreamed
-RUN wget -O coursier.zip https://github.com/sourcegraph/lsif-java/releases/download/v0.5.6/cs-musl.zip && \
+RUN wget -O coursier.zip https://github.com/coursier/coursier/releases/download/v2.1.0-RC4/cs-x86_64-pc-linux-static.gz && \
     unzip coursier.zip && \
-    mv cs-musl /usr/local/bin/coursier && \
+    mv cs-x86_64-pc-linux-static /usr/local/bin/coursier && \
     chmod +x /usr/local/bin/coursier
-
 
 FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5
 

--- a/enterprise/cmd/gitserver/Dockerfile
+++ b/enterprise/cmd/gitserver/Dockerfile
@@ -18,9 +18,9 @@ RUN /p4-fusion-install-alpine.sh
 
 FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5 AS coursier
 
-RUN wget -O coursier.zip https://github.com/coursier/coursier/releases/download/v2.1.0-RC4/cs-x86_64-pc-linux-static.gz && \
-    unzip coursier.zip && \
-    mv cs-x86_64-pc-linux-static /usr/local/bin/coursier && \
+RUN wget -O coursier.gz https://github.com/coursier/coursier/releases/download/v2.1.0-RC4/cs-x86_64-pc-linux-static.gz && \
+    gzip -d coursier.gz && \
+    mv coursier /usr/local/bin/coursier && \
     chmod +x /usr/local/bin/coursier
 
 FROM sourcegraph/alpine-3.14:190630_2022-12-22_6988b6221a72@sha256:782f094e3a6397a5f57305efac7b3f0e8c992eece31c98f93c1a518cc6c876e5


### PR DESCRIPTION
Migrate to upstream coursier musl builds now that theyre officially published :sunglasses: 

Closes https://github.com/sourcegraph/scip-java/issues/479

## Test plan

```
$ docker run -ti -v (pwd)/coursier-static:/home --rm --entrypoint /bin/sh alpine
# ldd ./cs-x86_64-pc-linux-static 
/lib/ld-musl-x86_64.so.1: ./cs-x86_64-pc-linux-static: Not a valid dynamic program
# ./cs-x86_64-pc-linux-static 
Usage: ./cs-x86_64-pc-linux-static <COMMAND>
Coursier is the Scala application and artifact manager.
It can install Scala applications and setup your Scala development environment.
It can also download and cache artifacts from the web.

Install application commands:
  install    Install an application from its descriptor.
  list       List all currently installed applications.
  setup      Setup a machine for Scala development.
  uninstall  Uninstall one or more applications.
  update     Update one or more applications.

Application channel commands:
  channel  Manage additional channels, used by coursier to resolve application descriptors.
  search   Search application names from known channels.

Java commands:
  java       Manage installed JVMs and run java.
  java-home  Print the home directory of a particular JVM.

Launcher commands:
  bootstrap  Create a binary launcher from a dependency or an application descriptor.
  launch     Launch an application from a dependency or an application descriptor.

Resolution commands:
  fetch    Transitively fetch the JARs of one or more dependencies or an application.
  resolve  Resolve and print the transitive dependencies of one or more dependencies or an application.

Other commands:
  version  Prints the coursier version
# 
```
