### PR TITLE
insights: adjust query costing to add more weight to number of repos

### DIFF
--- a/enterprise/internal/insights/priority/analyzer.go
+++ b/enterprise/internal/insights/priority/analyzer.go
@@ -112,8 +112,8 @@ func RepositoriesCost(o *QueryObject) {
 		o.cost = 1 // if this handler is called on its own we still want it to impact the cost.
 	}
 
-	if o.NumberOfRepositories > 10000 {
-		o.cost *= ManyRepositoriesMultiplier
+	if o.NumberOfRepositories > 100 {
+		o.cost *= float64(o.NumberOfRepositories) / 100.0
 	}
 
 	var megarepo, gigarepo bool

--- a/enterprise/internal/insights/priority/analyzer_test.go
+++ b/enterprise/internal/insights/priority/analyzer_test.go
@@ -1,102 +1,199 @@
 package priority
 
 import (
+	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/query/querybuilder"
 )
 
 const (
-	Simple        float64 = 50
-	Slow          float64 = 500
-	Long          float64 = 5000
-	LikelyTimeout float64 = 10000
+	Simple        float64 = LiteralCost
+	Slow          float64 = RegexpCost
+	Long          float64 = StructuralCost
+	LikelyTimeout float64 = StructuralCost * 10
 ) // values that could associate a speed to a floating point
 
 func TestQueryAnalyzerCost(t *testing.T) {
 	defaultHandlers := []CostHeuristic{QueryCost, RepositoriesCost}
 
 	testCases := []struct {
-		name                 string
-		query                string
-		numberOfRepositories int64
-		repositoryByteSizes  []int64
-		handlers             []CostHeuristic
-		higherThan           float64
-		smallerThan          float64
+		name                   string
+		query1                 string
+		numberOfRepositoriesQ1 int64
+		repositoryByteSizesQ1  []int64
+		query2                 string
+		numberOfRepositoriesQ2 int64
+		repositoryByteSizesQ2  []int64
+		compare                assert.ComparisonAssertionFunc
+		handlers               []CostHeuristic
 	}{
 		{
-			name:        "literal diff query should be magnitudes higher",
-			query:       "Type:diff insights",
-			handlers:    defaultHandlers,
-			higherThan:  Long,
-			smallerThan: Long * 1000,
+			name:     "literal diff query should be more than literal query ",
+			query1:   "insights",
+			query2:   "Type:diff insights",
+			compare:  assert.Less,
+			handlers: defaultHandlers,
 		},
 		{
-			name:        "literal diff query with author should reduce complexity",
-			query:       "type:diff author:someone insights",
-			handlers:    defaultHandlers,
-			higherThan:  Slow,
-			smallerThan: Long,
+			name:     "literal diff query with author should reduce complexity",
+			query1:   "type:diff author:someone insights",
+			query2:   "type:diff insights",
+			compare:  assert.Less,
+			handlers: defaultHandlers,
 		},
 		{
-			name:        "regexp query with reduced complexity not slow",
-			query:       "patterntype:regexp [0-9]+ lang:go",
-			handlers:    defaultHandlers,
-			higherThan:  Simple,
-			smallerThan: Slow,
+			name:     "a filter should reduce complexity",
+			query1:   "patterntype:regexp [0-9]+ lang:go",
+			query2:   "patterntype:regexp [0-9]+",
+			compare:  assert.Less,
+			handlers: defaultHandlers,
 		},
 		{
-			name:        "very specific query super speedy",
-			query:       "file:insights lang:go DashboardResolver",
-			handlers:    defaultHandlers,
-			higherThan:  0.0,
-			smallerThan: Simple,
+			name:     "multiple filters further reduces complexity",
+			query1:   "file:insights lang:go DashboardResolver",
+			query2:   "lang:go DashboardResolver",
+			compare:  assert.Less,
+			handlers: defaultHandlers,
 		},
 		{
-			name:                 "regexp query with reduced complexity but many repos slow",
-			query:                "patterntype:regexp [0-9]+ lang:go",
-			numberOfRepositories: 30000,
-			handlers:             defaultHandlers,
-			higherThan:           Slow,
-			smallerThan:          Long,
+			name:                   "small difference in num repos no difference",
+			query1:                 "patterntype:regexp [0-9]+ lang:go",
+			numberOfRepositoriesQ1: 1,
+			query2:                 "patterntype:regexp [0-9]+ lang:go",
+			numberOfRepositoriesQ2: 5,
+			handlers:               defaultHandlers,
+			compare:                assert.Equal,
 		},
 		{
-			name:                "literal query on gigarepo is long but will complete",
-			query:               "patterntype:literal context.Context",
-			repositoryByteSizes: []int64{gigarepoSizethreshold},
-			handlers:            defaultHandlers,
-			higherThan:          Long,
-			smallerThan:         LikelyTimeout,
+			name:                   "large difference in num repos makes difference",
+			query1:                 "patterntype:regexp [0-9]+ lang:go",
+			numberOfRepositoriesQ1: 1,
+			query2:                 "patterntype:regexp [0-9]+ lang:go",
+			numberOfRepositoriesQ2: 20000,
+			handlers:               defaultHandlers,
+			compare:                assert.Less,
 		},
 		{
-			name:                 "total annihilation query",
-			query:                "patterntype:structural [a] archive:yes fork:yes index:no",
-			numberOfRepositories: 3,
-			repositoryByteSizes:  []int64{100, megarepoSizeThresold, gigarepoSizethreshold * 2},
-			handlers:             defaultHandlers,
-			higherThan:           LikelyTimeout * 10000,
-			smallerThan:          LikelyTimeout * 100000,
+			name:                   "num repos continues to scale",
+			query1:                 "patterntype:regexp [0-9]+ lang:go",
+			numberOfRepositoriesQ1: 20000,
+			query2:                 "patterntype:regexp [0-9]+ lang:go",
+			numberOfRepositoriesQ2: 40000,
+			handlers:               defaultHandlers,
+			compare:                assert.Less,
+		},
+		{
+			name:                   "queries over larege repos add complexity",
+			query1:                 "patterntype:structural [a] archive:yes fork:yes index:no",
+			numberOfRepositoriesQ1: 3,
+			repositoryByteSizesQ1:  []int64{100, 100, 100},
+			query2:                 "patterntype:structural [a] archive:yes fork:yes index:no",
+			numberOfRepositoriesQ2: 3,
+			repositoryByteSizesQ2:  []int64{100, megarepoSizeThresold, gigarepoSizethreshold},
+			handlers:               defaultHandlers,
+			compare:                assert.Less,
 		},
 	}
 	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			queryAnalyzer := NewQueryAnalyzer(tc.handlers...)
+			queryPlan1, err := querybuilder.ParseQuery(tc.query1, "literal")
+			if err != nil {
+				t.Fatal(err)
+			}
+			queryPlan2, err := querybuilder.ParseQuery(tc.query2, "literal")
+			if err != nil {
+				t.Fatal(err)
+			}
+			cost1 := queryAnalyzer.Cost(&QueryObject{
+				Query:                queryPlan1,
+				NumberOfRepositories: tc.numberOfRepositoriesQ1,
+				RepositoryByteSizes:  tc.repositoryByteSizesQ1,
+			})
+			cost2 := queryAnalyzer.Cost(&QueryObject{
+				Query:                queryPlan2,
+				NumberOfRepositories: tc.numberOfRepositoriesQ2,
+				RepositoryByteSizes:  tc.repositoryByteSizesQ2,
+			})
+			tc.compare(t, cost1, cost2)
+
+		})
+	}
+}
+
+func TestQueryAnalyzerCostSamples(t *testing.T) {
+	defaultHandlers := []CostHeuristic{QueryCost, RepositoriesCost}
+
+	type cost struct {
+		query    string
+		numRepos int
+		cost     float64
+	}
+
+	cases := []struct {
+		name     string
+		query    string
+		handlers []CostHeuristic
+	}{
+		{
+			name:     "terraform versions",
+			query:    `app.terraform.io/(.*)\n version =(.*)1.1.0 patternType:regexp lang:Terraform`,
+			handlers: defaultHandlers,
+		},
+		{
+			name:     "component useage",
+			query:    "from '@sourceLibrary/component' patternType:literal",
+			handlers: defaultHandlers,
+		},
+		{
+			name:     "structural pattern",
+			query:    "try {:[_]} catch (:[e]) { } finally {:[_]} patternType:structural",
+			handlers: defaultHandlers,
+		},
+		{
+			name:     "commits with reverts",
+			query:    "type:commit revert",
+			handlers: defaultHandlers,
+		},
+		{
+			name:     "diff",
+			query:    "type:diff insights",
+			handlers: defaultHandlers,
+		},
+	}
+
+	costs := []cost{}
+
+	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			queryAnalyzer := NewQueryAnalyzer(tc.handlers...)
 			queryPlan, err := querybuilder.ParseQuery(tc.query, "literal")
 			if err != nil {
 				t.Fatal(err)
 			}
-			cost := queryAnalyzer.Cost(&QueryObject{
-				Query:                queryPlan,
-				NumberOfRepositories: tc.numberOfRepositories,
-				RepositoryByteSizes:  tc.repositoryByteSizes,
-			})
-			if cost < tc.higherThan {
-				t.Errorf("expected cost to be higher than %f, got %f", tc.higherThan, cost)
-			}
-			if cost > tc.smallerThan {
-				t.Errorf("expected cost to be smaller than %f, got %f", tc.smallerThan, cost)
+			sizes := []int{1, 10, 500, 5000, 25000, 100000}
+			for _, size := range sizes {
+				queryCost := queryAnalyzer.Cost(&QueryObject{
+					Query:                queryPlan,
+					NumberOfRepositories: int64(size),
+				})
+				costs = append(costs, cost{
+					cost:     queryCost,
+					query:    tc.query,
+					numRepos: size,
+				})
 			}
 		})
 	}
+
+	sort.SliceStable(costs, func(i, j int) bool {
+		return costs[i].cost < costs[j].cost
+	})
+	for _, qc := range costs {
+		t.Logf("| %d | %d | %s |", qc.numRepos, int(qc.cost), qc.query)
+	}
+	//t.Fail()
 }

--- a/enterprise/internal/insights/priority/cost.go
+++ b/enterprise/internal/insights/priority/cost.go
@@ -10,21 +10,21 @@ const (
 )
 
 const (
-	LiteralCost    float64 = 10
+	LiteralCost    float64 = 400
 	RegexpCost     float64 = 500
-	StructuralCost float64 = 5000
+	StructuralCost float64 = 1000
 
-	DiffMultiplier   float64 = 1000
-	CommitMultiplier float64 = 800
+	DiffMultiplier   float64 = 10
+	CommitMultiplier float64 = 8
 
-	AuthorMultiplier float64 = 0.1
+	AuthorMultiplier float64 = 0.7
 
 	UnindexedMultiplier float64 = 100
 	YesMultiplier       float64 = 1.5
 	OnlyMultiplier      float64 = 0.5
 
-	FileMultiplier float64 = 0.1
-	LangMultiplier float64 = 0.5
+	FileMultiplier float64 = 0.7
+	LangMultiplier float64 = 0.8
 
 	ManyRepositoriesMultiplier float64 = 10
 	MegarepoMultiplier         float64 = 100


### PR DESCRIPTION
This adjust the query costing logic add more weight to the number of repos the query will run over if provided and reduces some of the cost reductions of filters that were heavily influencing the final result.  The goal was to ensure that insights created over a small number of repos are prioritized over insights that were created over a large number of repos, even if the starting query was more costly.

closes https://github.com/sourcegraph/sourcegraph/issues/45411

## Test plan
updates to existing unit tests 

Ordered costing before changes for sample queries from the insights examples
| Num Repos | Cost   | Query                                                                        |
| --------- | ------ | ---------------------------------------------------------------------------- |
| 1         | 10     | from '@sourceLibrary/component' patternType:literal                          |
| 10        | 10     | from '@sourceLibrary/component' patternType:literal                          |
| 500       | 10     | from '@sourceLibrary/component' patternType:literal                          |
| 5000      | 10     | from '@sourceLibrary/component' patternType:literal                          |
| 25000     | 100    | from '@sourceLibrary/component' patternType:literal                          |
| 100000    | 100    | from '@sourceLibrary/component' patternType:literal                          |
| 1         | 250    | app.terraform.io/(._)\n version =(._)1.1.0 patternType:regexp lang:Terraform |
| 10        | 250    | app.terraform.io/(._)\n version =(._)1.1.0 patternType:regexp lang:Terraform |
| 500       | 250    | app.terraform.io/(._)\n version =(._)1.1.0 patternType:regexp lang:Terraform |
| 5000      | 250    | app.terraform.io/(._)\n version =(._)1.1.0 patternType:regexp lang:Terraform |
| 25000     | 2500   | app.terraform.io/(._)\n version =(._)1.1.0 patternType:regexp lang:Terraform |
| 100000    | 2500   | app.terraform.io/(._)\n version =(._)1.1.0 patternType:regexp lang:Terraform |
| 1         | 5000   | try {:[_]} catch (:[e]) { } finally {:[_]} patternType:structural            |
| 10        | 5000   | try {:[_]} catch (:[e]) { } finally {:[_]} patternType:structural            |
| 500       | 5000   | try {:[_]} catch (:[e]) { } finally {:[_]} patternType:structural            |
| 5000      | 5000   | try {:[_]} catch (:[e]) { } finally {:[_]} patternType:structural            |
| 1         | 8000   | type:commit revert                                                           |
| 10        | 8000   | type:commit revert                                                           |
| 500       | 8000   | type:commit revert                                                           |
| 5000      | 8000   | type:commit revert                                                           |
| 1         | 10000  | type:diff insights                                                           |
| 10        | 10000  | type:diff insights                                                           |
| 500       | 10000  | type:diff insights                                                           |
| 5000      | 10000  | type:diff insights                                                           |
| 25000     | 50000  | try {:[_]} catch (:[e]) { } finally {:[_]} patternType:structural            |
| 100000    | 50000  | try {:[_]} catch (:[e]) { } finally {:[_]} patternType:structural            |
| 25000     | 80000  | type:commit revert                                                           |
| 100000    | 80000  | type:commit revert                                                           |
| 25000     | 100000 | type:diff insights                                                           |
| 100000    | 100000 | type:diff insights                                                           |

Ordered costing after changes for sample queries from the insights examples
| Num Repos | Cost    | Query                                                                        |
| --------- | ------- | ---------------------------------------------------------------------------- |
| 1         | 400     | app.terraform.io/(._)\n version =(._)1.1.0 patternType:regexp lang:Terraform |
| 10        | 400     | app.terraform.io/(._)\n version =(._)1.1.0 patternType:regexp lang:Terraform |
| 1         | 400     | from '@sourceLibrary/component' patternType:literal                          |
| 10        | 400     | from '@sourceLibrary/component' patternType:literal                          |
| 1         | 1000    | try {:[_]} catch (:[e]) { } finally {:[_]} patternType:structural            |
| 10        | 1000    | try {:[_]} catch (:[e]) { } finally {:[_]} patternType:structural            |
| 500       | 2000    | app.terraform.io/(._)\n version =(._)1.1.0 patternType:regexp lang:Terraform |
| 500       | 2000    | from '@sourceLibrary/component' patternType:literal                          |
| 1         | 3200    | type:commit revert                                                           |
| 10        | 3200    | type:commit revert                                                           |
| 1         | 4000    | type:diff insights                                                           |
| 10        | 4000    | type:diff insights                                                           |
| 500       | 5000    | try {:[_]} catch (:[e]) { } finally {:[_]} patternType:structural            |
| 500       | 16000   | type:commit revert                                                           |
| 5000      | 20000   | app.terraform.io/(._)\n version =(._)1.1.0 patternType:regexp lang:Terraform |
| 5000      | 20000   | from '@sourceLibrary/component' patternType:literal                          |
| 500       | 20000   | type:diff insights                                                           |
| 5000      | 50000   | try {:[_]} catch (:[e]) { } finally {:[_]} patternType:structural            |
| 25000     | 100000  | app.terraform.io/(._)\n version =(._)1.1.0 patternType:regexp lang:Terraform |
| 25000     | 100000  | from '@sourceLibrary/component' patternType:literal                          |
| 5000      | 160000  | type:commit revert                                                           |
| 5000      | 200000  | type:diff insights                                                           |
| 25000     | 250000  | try {:[_]} catch (:[e]) { } finally {:[_]} patternType:structural            |
| 100000    | 400000  | app.terraform.io/(._)\n version =(._)1.1.0 patternType:regexp lang:Terraform |
| 100000    | 400000  | from '@sourceLibrary/component' patternType:literal                          |
| 25000     | 800000  | type:commit revert                                                           |
| 100000    | 1000000 | try {:[_]} catch (:[e]) { } finally {:[_]} patternType:structural            |
| 25000     | 1000000 | type:diff insights                                                           |
| 100000    | 3200000 | type:commit revert                                                           |
| 100000    | 4000000 | type:diff insights                                                           |
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
