### PR TITLE
emails: send code monitors, account updates to verified emails only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights no longer uses a custom index of commits to compress historical backfill and instead queries the repository log directly. This allows the compression algorithm to span any arbitrary time frame, and should improve the reliability of the compression in general. [#45644](https://github.com/sourcegraph/sourcegraph/pull/45644)
 - GitHub code host configuration: The error message for non-existent organizations has been clarified to indicate that the organization is one that the user manually specified in their code host configuration. [#45918](https://github.com/sourcegraph/sourcegraph/pull/45918)
 - Git blame view got a user-interface overhaul and now shows data in a more structured way with additional visual hints. [#44397](https://github.com/sourcegraph/sourcegraph/issues/44397)
+- Code monitor emails and account update emails will no longer attempt deliveries for unverified email addresses. [#46167](https://github.com/sourcegraph/sourcegraph/pull/46167)
 
 ### Fixed
 

--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -293,16 +293,16 @@ func (e *userEmails) ResendVerificationEmail(ctx context.Context, userID int32, 
 // SendUserEmailOnFieldUpdate sends the user an email that important account information has changed.
 // The change is the information we want to provide the user about the change
 func (e *userEmails) SendUserEmailOnFieldUpdate(ctx context.Context, id int32, change string) error {
-	logger := e.logger.Scoped("UserEmails", "handles user emails")
-	email, _, err := e.db.UserEmails().GetPrimaryEmail(ctx, id)
+	email, verified, err := e.db.UserEmails().GetPrimaryEmail(ctx, id)
 	if err != nil {
-		logger.Warn("Failed to get user email", log.Error(err))
-		return err
+		return errors.Wrap(err, "get user primary email")
+	}
+	if !verified {
+		return errors.New("unable to send email to user ID %d's unverified primary email address")
 	}
 	usr, err := e.db.Users().GetByID(ctx, id)
 	if err != nil {
-		logger.Warn("Failed to get user from database", log.Error(err))
-		return err
+		return errors.Wrap(err, "get user")
 	}
 
 	return txemail.Send(ctx, "user_account_update", txemail.Message{

--- a/enterprise/internal/codemonitors/background/email.go
+++ b/enterprise/internal/codemonitors/background/email.go
@@ -122,13 +122,17 @@ func NewTestTemplateDataForNewSearchResults(monitorDescription string) *Template
 }
 
 func sendEmail(ctx context.Context, db database.DB, userID int32, template txtypes.Templates, data any) error {
-	email, _, err := db.UserEmails().GetPrimaryEmail(ctx, userID)
+	email, verified, err := db.UserEmails().GetPrimaryEmail(ctx, userID)
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			return errors.Errorf("unable to send email to user ID %d with unknown email address", userID)
 		}
 		return errors.Errorf("internalapi.Client.UserEmailsGetEmail for userID=%d: %w", userID, err)
 	}
+	if !verified {
+		return errors.New("unable to send email to user ID %d's unverified primary email address")
+	}
+
 	if err := internalapi.Client.SendEmail(ctx, "code-monitor", txtypes.Message{
 		To:       []string{email},
 		Template: template,

--- a/internal/api/internalapi/client.go
+++ b/internal/api/internalapi/client.go
@@ -49,7 +49,14 @@ func (c *internalClient) ExternalURL(ctx context.Context) (string, error) {
 	return externalURL, nil
 }
 
-// TODO(slimsag): needs cleanup as part of upcoming configuration refactor.
+// SendEmail issues a request to send an email. All services outside the frontend should
+// use this to send emails.  Source is used to categorize metrics, and should indicate the
+// product feature that is sending this email.
+//
+// 🚨 SECURITY: If the email address is associated with a user, make sure to assess whether
+// the email should be verified or not, and conduct the appropriate checks before sending.
+// This helps reduce the chance that we damage email sender reputations when attempting to
+// send emails to nonexistent email addresses.
 func (c *internalClient) SendEmail(ctx context.Context, source string, message txtypes.Message) error {
 	return c.postInternal(ctx, "send-email", &txtypes.InternalAPIMessage{
 		Source:  source,

--- a/internal/txemail/txemail.go
+++ b/internal/txemail/txemail.go
@@ -67,11 +67,17 @@ func render(message Message) (*email.Email, error) {
 	return &m, nil
 }
 
-// Send sends a transactional email. Source is used to categorize metrics, and should
-// indicate the product feature that is sending this email.
+// Send sends a transactional email if SMTP is configured. All services within the frontend
+// should use this directly to send emails.  Source is used to categorize metrics, and
+// should indicate the product feature that is sending this email.
 //
 // Callers that do not live in the frontend should call internalapi.Client.SendEmail
-// instead. TODO(slimsag): needs cleanup as part of upcoming configuration refactor.
+// instead.
+//
+// 🚨 SECURITY: If the email address is associated with a user, make sure to assess whether
+// the email should be verified or not, and conduct the appropriate checks before sending.
+// This helps reduce the chance that we damage email sender reputations when attempting to
+// send emails to nonexistent email addresses.
 func Send(ctx context.Context, source string, message Message) (err error) {
 	if MockSend != nil {
 		return MockSend(ctx, message)


### PR DESCRIPTION
We want to avoid damaging email reputations by validating if emails are verified before sending certain types of non-essential emails to user primary emails:

- account update notifications
- code monitors

It looks like manually created users are always created with `VerifiedEmail: true` by default, however.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
