### PR TITLE
FuzzyFinder: add a ctrl-g binding to close the popup

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -324,6 +324,9 @@ export const FuzzyModal: React.FunctionComponent<React.PropsWithChildren<FuzzyMo
                 case event.key === 'Escape':
                     onClose()
                     break
+                case event.key === 'g' && event.ctrlKey: // common Emacs binding to close things
+                    onClose()
+                    break
                 case event.key === 'n' && event.ctrlKey:
                     event.preventDefault()
                     setRoundedFocusIndex(1)


### PR DESCRIPTION
This adds a `Ctrl-g` (fixed, not translated to `Cmd` on OSX) to close the fuzzy finder. 

This is not a very common binding, but ...

Ctrl-g is a classic binding in emacs, it aborts any command in progress. It's the thing you smash when you want to quit interactive stuff, making it quite a logical additional option here. I got so used to it from my emacs days that I bound it at well in my neovim config and kept using it. 

It's also convenient for modal browser users (like Qutebrowser) because ESC is often intercepted as a way to get out of INSERT mode. So now, that's just a keypress, and the same one I'd type in emacs (or my heretical vim config). 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally, does what I wanted, I'm happy :) 

## App preview:

- [Web](https://sg-web-jh-fuzzy-ctrl-g.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
