### PR TITLE
remove beyang from CODENOTIFY files

### DIFF
--- a/cmd/searcher/CODENOTIFY
+++ b/cmd/searcher/CODENOTIFY
@@ -1,2 +1,1 @@
 **/* @keegancsmith
-**/* @beyang

--- a/enterprise/cmd/precise-code-intel-worker/CODENOTIFY
+++ b/enterprise/cmd/precise-code-intel-worker/CODENOTIFY
@@ -1,4 +1,3 @@
 # See https://github.com/sourcegraph/codenotify for documentation.
 
 **/* @efritz
-**/* @beyang

--- a/internal/search/CODENOTIFY
+++ b/internal/search/CODENOTIFY
@@ -1,3 +1,2 @@
 **/* @keegancsmith
-**/* @beyang
 **/* @camdencheek


### PR DESCRIPTION
In practice, I'm not doing any of these code reviews, and so the codenotify alerts just generate spam in my notifications inbox.

## Test plan

N/A, does not affect app