### PR TITLE
resendVerificationEmail: do not error if verification email was never sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Hourly code insights will now behave correctly and will no longer truncate to midnight UTC on the calendar date the insight was created. [#45644](https://github.com/sourcegraph/sourcegraph/pull/45644)
 - Code Insights: fixed an issue where filtering by a search context that included multiple repositories would exclude data. [#45574](https://github.com/sourcegraph/sourcegraph/pull/45574)
 - Ignore null JSON objects returned from GitHub API when listing public repositories. [#45969](https://github.com/sourcegraph/sourcegraph/pull/45969)
+- Fixed issue where emails that have never been verified before would be unable to receive resent verification emails. [#46185](https://github.com/sourcegraph/sourcegraph/pull/46185)
 
 ### Removed
 

--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -260,7 +260,7 @@ func (e *userEmails) ResendVerificationEmail(ctx context.Context, userID int32, 
 
 	userEmails := e.db.UserEmails()
 	lastSent, err := userEmails.GetLatestVerificationSentEmail(ctx, email)
-	if err != nil {
+	if err != nil && !errcode.IsNotFound(err) {
 		return err
 	}
 	if lastSent != nil &&

--- a/internal/database/user_emails.go
+++ b/internal/database/user_emails.go
@@ -271,7 +271,7 @@ LIMIT 1
 	if err != nil {
 		return nil, err
 	} else if len(emails) < 1 {
-		return nil, userEmailNotFoundError{[]any{fmt.Sprintf("email %q", email)}}
+		return nil, nil
 	}
 	return emails[0], nil
 }

--- a/internal/database/user_emails.go
+++ b/internal/database/user_emails.go
@@ -271,7 +271,7 @@ LIMIT 1
 	if err != nil {
 		return nil, err
 	} else if len(emails) < 1 {
-		return nil, nil
+		return nil, userEmailNotFoundError{[]any{fmt.Sprintf("email %q", email)}}
 	}
 	return emails[0], nil
 }


### PR DESCRIPTION
Users created with `mutation { createUser }` that marked their emails as unverified would previously be unable to send verification emails because the button would fail with "email not found".

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Sign up, mark password as unverified, and "resend verification" now works.

<img width="1209" alt="image" src="https://user-images.githubusercontent.com/23356519/210914248-536b5ce5-8020-4bcc-a800-fca891439e36.png">
