### PR TITLE
resetPassword: check if email was sent in UI indicator

### DIFF
--- a/client/web/src/site-admin/UserManagement/components/useUserListActions.tsx
+++ b/client/web/src/site-admin/UserManagement/components/useUserListActions.tsx
@@ -182,8 +182,8 @@ export function useUserListActions(onEnd: (error?: any) => void): UseUserListAct
             if (confirm('Are you sure you want to reset the selected user password?')) {
                 randomizeUserPassword(user.id)
                     .toPromise()
-                    .then(({ resetPasswordURL }) => {
-                        if (resetPasswordURL === null) {
+                    .then(({ resetPasswordURL, emailSent }) => {
+                        if (resetPasswordURL === null || emailSent) {
                             createOnSuccess(
                                 <Text as="span">
                                     Password was reset. The reset link was sent to the primary email of the user:{' '}

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -547,6 +547,7 @@ export function randomizeUserPassword(
             mutation RandomizeUserPassword($user: ID!) {
                 randomizeUserPassword(user: $user) {
                     resetPasswordURL
+                    emailSent
                 }
             }
         `,


### PR DESCRIPTION
Uses the new field added in https://github.com/sourcegraph/sourcegraph/pull/45283 in the UI.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Reset password no longer says email wasn't sent when it was

## App preview:

- [Web](https://sg-web-01-05-resetpassword-check-if.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

