### PR TITLE
build: add missing regenerator-runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -301,6 +301,7 @@
     "prettier": "2.8.1",
     "process": "^0.11.10",
     "puppeteer": "^13.5.1",
+    "regenerator-runtime": "^0.13.7",
     "rimraf": "^3.0.2",
     "sass": "^1.32.4",
     "sass-loader": "^13.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27765,6 +27765,7 @@ __metadata:
     react-sticky-box: 1.0.2
     react-visibility-sensor: ^5.1.1
     recharts: ^1.8.5
+    regenerator-runtime: ^0.13.7
     regexpp: ^3.1.0
     resize-observer-polyfill: ^1.5.1
     rimraf: ^3.0.2


### PR DESCRIPTION
This is used in `jest.config.base.js` but the dep is not declared.

## Test plan

CI

## App preview:

- [Web](https://sg-web-bazel-missing-reg-run.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
