### PR TITLE
Make line-number layout always align to top

### DIFF
--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -360,7 +360,6 @@ export function selectableLineNumbers(config: SelectableLineNumbersConfig): Exte
             '.cm-lineNumbers .cm-gutterElement': {
                 display: 'flex',
                 flexDirection: 'column',
-                justifyContent: 'center',
                 alignItems: 'flex-end',
             },
             '.cm-lineNumbers .cm-gutterElement:hover': {


### PR DESCRIPTION
With center aligned numbers in multiline mode it's hard to read the numbers from top to bottom and map it to actual line of code on the right. So make it always top aligned, this should help with visual mapping.

| Before | After |
| -------- | ------- |
| <img width="989" alt="Screenshot 2023-01-05 at 23 36 55" src="https://user-images.githubusercontent.com/18492575/210918845-d5aaa119-faf0-4d34-bc57-5f4de902a0df.png"> | <img width="989" alt="Screenshot 2023-01-05 at 23 36 23" src="https://user-images.githubusercontent.com/18492575/210918853-8885fda5-afe2-49fd-ac0b-b53f3b58e8ca.png"> |

## Test plan
- Check that line numbers layout looks correct in the blob view with line wrapping enabled/disabled

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-multiline-linenumber.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
