### PR TITLE
vscode: migrate to pnpm

### DIFF
--- a/client/vscode/.vscodeignore
+++ b/client/vscode/.vscodeignore
@@ -24,4 +24,4 @@ tests/**
 tsconfig.json
 webpack.config.js
 webviews/**
-yarn.lock
+pnpm-lock.yaml

--- a/client/vscode/scripts/package.ts
+++ b/client/vscode/scripts/package.ts
@@ -12,7 +12,7 @@ try {
     packageJson.name = 'sourcegraph'
     fs.writeFileSync('package.json', JSON.stringify(packageJson))
 
-    childProcess.execSync('vsce package --yarn --allow-star-activation -o dist', { stdio: 'inherit' })
+    childProcess.execSync('vsce package --no-dependencies --allow-star-activation -o dist', { stdio: 'inherit' })
 } finally {
     fs.writeFileSync('package.json', originalPackageJson)
 }

--- a/client/vscode/scripts/publish.ts
+++ b/client/vscode/scripts/publish.ts
@@ -15,7 +15,7 @@ import { version } from '../package.json'
 const originalPackageJson = fs.readFileSync('package.json').toString()
 /**
  * Build and publish the extension with the updated package name
- * using the tokens stored in the pipeline to run commands in yarn
+ * using the tokens stored in the pipeline to run commands in pnpm
  * and allows all events to activate the extension
  */
 const isPreRelease = semver.minor(version) % 2 !== 0 ? '--pre-release' : ''
@@ -29,15 +29,15 @@ const hasTokens = tokens.vscode !== undefined && tokens.openvsx !== undefined
 const commands = {
     vscode_info: 'vsce show sourcegraph.sourcegraph --json',
     // To publish to VS Code Marketplace
-    vscode_publish: `vsce publish ${isPreRelease} --pat $VSCODE_MARKETPLACE_TOKEN --yarn --allow-star-activation`,
+    vscode_publish: `vsce publish ${isPreRelease} --pat $VSCODE_MARKETPLACE_TOKEN --no-dependencies --allow-star-activation`,
     // To package the extension without publishing
-    vscode_package: `vsce package ${isPreRelease} --yarn --allow-star-activation`,
+    vscode_package: `vsce package ${isPreRelease} --no-dependencies --allow-star-activation`,
     // To publish to the open-vsx registry
-    openvsx_publish: 'npx --yes ovsx publish --yarn -p $VSCODE_OPENVSX_TOKEN',
+    openvsx_publish: 'npx --yes ovsx publish --no-dependencies -p $VSCODE_OPENVSX_TOKEN',
 }
 // Publish the extension with the correct extension name "sourcegraph"
 try {
-    childProcess.execSync('yarn build-inline-extensions && yarn build', { stdio: 'inherit' })
+    childProcess.execSync('pnpm build-inline-extensions && pnpm build', { stdio: 'inherit' })
     // Get the latest release version nubmer of the last release from VS Code Marketplace using the vsce cli tool
     const response = childProcess.execSync(commands.vscode_info).toString()
     /*

--- a/client/vscode/scripts/publish.ts
+++ b/client/vscode/scripts/publish.ts
@@ -64,11 +64,11 @@ try {
         // Run the publish commands
         childProcess.execSync(commands.vscode_publish, { stdio: 'inherit' })
         childProcess.execSync(commands.openvsx_publish, { stdio: 'inherit' })
-        console.log(`The extension has been ${hasTokens ? 'published' : 'packaged'} successfully`)
     } else {
         // Use vsce package command instead without publishing the extension for testing
         childProcess.execSync(commands.vscode_package, { stdio: 'inherit' })
     }
+    console.log(`The extension has been ${hasTokens ? 'published' : 'packaged'} successfully.`)
 } catch (error) {
     console.error('Failed to publish VSCE:', error)
     console.error('You may not run this script locally to publish the extension.')

--- a/client/vscode/webpack.config.js
+++ b/client/vscode/webpack.config.js
@@ -9,9 +9,11 @@ const {
   getMonacoWebpackPlugin,
   getCSSModulesLoader,
   getBasicCSSLoader,
+  getBabelLoader,
   getMonacoCSSRule,
   getCSSLoaders,
 } = require('@sourcegraph/build-config')
+
 /**
  * The VS Code extension core needs to be built for two targets:
  * - Node.js for VS Code desktop
@@ -57,7 +59,6 @@ function getExtensionCoreConfiguration(targetType) {
       vscode: 'commonjs vscode',
     },
     resolve: {
-      // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
       extensions: ['.ts', '.tsx', '.js', '.jsx'],
       alias:
         targetType === 'webworker'
@@ -88,12 +89,7 @@ function getExtensionCoreConfiguration(targetType) {
         {
           test: /\.tsx?$/,
           exclude: /node_modules/,
-          use: [
-            {
-              // TODO(tj): esbuild-loader https://github.com/privatenumber/esbuild-loader
-              loader: 'ts-loader',
-            },
-          ],
+          use: [getBabelLoader()],
         },
       ],
     },
@@ -178,7 +174,6 @@ const webviewConfig = {
       './RepoFileLink': path.resolve(__dirname, 'src', 'webview', 'search-panel', 'alias', 'RepoFileLink'),
       '../documentation/ModalVideo': path.resolve(__dirname, 'src', 'webview', 'search-panel', 'alias', 'ModalVideo'),
     },
-    // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
     extensions: ['.ts', '.tsx', '.js', '.jsx'],
     fallback: {
       path: require.resolve('path-browserify'),
@@ -192,11 +187,7 @@ const webviewConfig = {
       {
         test: /\.tsx?$/,
         exclude: [/node_modules/, extensionHostWorker],
-        use: [
-          {
-            loader: 'ts-loader',
-          },
-        ],
+        use: [getBabelLoader()],
       },
       {
         test: extensionHostWorker,
@@ -205,7 +196,7 @@ const webviewConfig = {
             loader: 'worker-loader',
             options: { inline: 'no-fallback' },
           },
-          'ts-loader',
+          getBabelLoader(),
         ],
       },
       {


### PR DESCRIPTION
## Context

Migrating to the VSCode extension release process to pnpm based on comments in this issue:
- https://github.com/microsoft/vscode-vsce/issues/421#issuecomment-1038911725

## Test plan

1. CI
2. `pnpm install && cd client/vscode && pnpm package && pnpm release`
