### PR TITLE
web: add polling so that loading spinner can stop when the sync is complete on ExternalServicesPage.

### DIFF
--- a/client/web/src/components/externalServices/ExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.tsx
@@ -49,10 +49,19 @@ export const ExternalServicesPage: React.FunctionComponent<React.PropsWithChildr
     allowEditExternalServicesWithFile,
     queryExternalServices = _queryExternalServices,
 }) => {
+    const FIFTEEN_SECONDS = 15000
+    const updates = useMemo(() => new Subject<void>(), [])
+
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminExternalServices')
-    }, [telemetryService])
-    const updates = useMemo(() => new Subject<void>(), [])
+        const interval = setInterval(() => {
+            updates.next()
+        }, FIFTEEN_SECONDS)
+        return function cleanup() {
+            clearInterval(interval)
+        }
+    }, [updates, telemetryService])
+
     const onDidUpdateExternalServices = useCallback(() => updates.next(), [updates])
 
     const queryConnection = useCallback(

--- a/client/web/src/components/externalServices/ExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.tsx
@@ -49,17 +49,15 @@ export const ExternalServicesPage: React.FunctionComponent<React.PropsWithChildr
     allowEditExternalServicesWithFile,
     queryExternalServices = _queryExternalServices,
 }) => {
-    const FIFTEEN_SECONDS = 15000
+    const POLLING_INTERVAL = 15000
     const updates = useMemo(() => new Subject<void>(), [])
 
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminExternalServices')
         const interval = setInterval(() => {
             updates.next()
-        }, FIFTEEN_SECONDS)
-        return function cleanup() {
-            clearInterval(interval)
-        }
+        }, POLLING_INTERVAL)
+        return () => clearInterval(interval)
     }, [updates, telemetryService])
 
     const onDidUpdateExternalServices = useCallback(() => updates.next(), [updates])

--- a/client/web/src/site-admin/fixtures.ts
+++ b/client/web/src/site-admin/fixtures.ts
@@ -1,9 +1,7 @@
 import { formatRFC3339, subMinutes } from 'date-fns'
-import { of } from 'rxjs'
 
 import { ExternalServiceKind, ExternalServiceSyncJobState } from '@sourcegraph/shared/src/graphql-operations'
 
-import { queryExternalServices as _queryExternalServices } from '../components/externalServices/backend'
 import { ListExternalServiceFields, WebhookFields } from '../graphql-operations'
 
 export const TIMESTAMP_MOCK = new Date(2021, 10, 8, 16, 40, 30)
@@ -69,31 +67,3 @@ export function createWebhookMock(kind: ExternalServiceKind, urn: string): Webho
         },
     }
 }
-
-export const queryExternalServices: typeof _queryExternalServices = () =>
-    of({
-        totalCount: 17,
-        pageInfo: {
-            endCursor: null,
-            hasNextPage: false,
-        },
-        nodes: [
-            createExternalService(ExternalServiceKind.GITHUB, 'https://github.com'),
-            createExternalService(ExternalServiceKind.BITBUCKETCLOUD, 'https://bitbucket.org'),
-            createExternalService(ExternalServiceKind.BITBUCKETSERVER, 'https://sgdev.bitbucket.org'),
-            createExternalService(ExternalServiceKind.BITBUCKETSERVER, 'https://sgprod.bitbucket.org'),
-            createExternalService(ExternalServiceKind.GERRIT, 'https://gerrit.com'),
-            createExternalService(ExternalServiceKind.GITLAB, 'https://gitlab.com'),
-            createExternalService(ExternalServiceKind.GITOLITE, 'https://gitolite.com'),
-            createExternalService(ExternalServiceKind.GOMODULES, 'https://gomodules.com'),
-            createExternalService(ExternalServiceKind.JVMPACKAGES, 'https://jvmpackages.com'),
-            createExternalService(ExternalServiceKind.NPMPACKAGES, 'https://npmpackages.com'),
-            createExternalService(ExternalServiceKind.OTHER, 'https://other.com'),
-            createExternalService(ExternalServiceKind.PAGURE, 'https://pagure.com'),
-            createExternalService(ExternalServiceKind.PERFORCE, 'https://perforce.com'),
-            createExternalService(ExternalServiceKind.PHABRICATOR, 'https://phabricator.com'),
-            createExternalService(ExternalServiceKind.PYTHONPACKAGES, 'https://pythonpackages.com'),
-            createExternalService(ExternalServiceKind.RUSTPACKAGES, 'https://rustpackages.com'),
-            createExternalService(ExternalServiceKind.RUBYPACKAGES, 'https://rubypackages.com'),
-        ],
-    })


### PR DESCRIPTION
### Short demo
https://user-images.githubusercontent.com/94846361/210958599-a5f28306-bb7a-4758-af52-b74733145eed.mov

Closes https://github.com/sourcegraph/sourcegraph/issues/46152


Test plan:
Local sg run and visual check.

## App preview:

- [Web](https://sg-web-ao-ui-add-polling-to-code-hosts.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

