### PR TITLE
Search suggestions: feed URLs to smart search

### DIFF
--- a/client/shared/src/search/query/providers-utils.ts
+++ b/client/shared/src/search/query/providers-utils.ts
@@ -47,6 +47,17 @@ export function getSuggestionQuery(tokens: Token[], tokenAtColumn: Token, sugges
         return ''
     }
 
+    // Feature request from https://twitter.com/mitchellh/status/1610353274540130304
+    // Fallback to smart search when the token value is a URL.
+    // This condition makes it possible to copy-paste a GitHub URL into the
+    // search bar and get search suggestions for the linked repo or file.
+    if (tokenValue.startsWith('https://')) {
+        if (tokenValue.includes('/blob/')) {
+            suggestionType = 'path'
+        }
+        return `${tokenValue} type:${suggestionType} count:${MAX_SUGGESTION_COUNT} patterntype:lucky`.trimStart()
+    }
+
     if (suggestionType === 'repo') {
         const relevantFilters = !hasAndOrOperators ? serializeFilters(tokens, REPO_SUGGESTION_FILTERS) : ''
         return `${relevantFilters} repo:${tokenValue} type:repo count:${MAX_SUGGESTION_COUNT}`.trimStart()


### PR DESCRIPTION
Feature request from https://twitter.com/mitchellh/status/1610353274540130304

Previously, it wasn't possible to copy-paste a GitHub repo URL in the Sourcegraph search bar to get to that repo. Our search bar showed no relevant suggestions.

With this change, if the token being suggested starts with `https://` then we feed it directly to smart search, which automatically figures out the repo, filepath and revision for us.

Demo https://www.loom.com/share/bd1c286e37a044938fed918110de4b82


## Test plan

* Open landing page
* Copy-paste GitHub URL like `https://github.com/sourcegraph/scip-typescript/blob/main/src/FileIndexer.ts`
* Confirm that the search suggestion takes you to https://sourcegraph.test:3443/github.com/sourcegraph/scip-typescript/-/blob/src/FileIndexer.ts
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-olafurpg-search-https.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

