### PR TITLE
web: do not redirect after excluding the repo in case of many code hosts.

### DIFF
--- a/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -112,6 +112,7 @@ export const RepoSettingsOptionsPage: FC<Props> = ({ repo, history }) => {
                                 excludingLoading={exclusionInProgress}
                                 updateExclusionLoading={updateExclusion}
                                 repo={repo}
+                                redirectAfterExclusion={services.length < 2}
                                 history={history}
                             />
                         ))}

--- a/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -4,17 +4,7 @@ import { noop } from 'lodash'
 import { RouteComponentProps } from 'react-router'
 
 import { useMutation, useQuery } from '@sourcegraph/http-client'
-import {
-    Alert,
-    Button,
-    Container,
-    ErrorAlert,
-    H2,
-    LoadingSpinner,
-    PageHeader,
-    renderError,
-    Text,
-} from '@sourcegraph/wildcard'
+import { Button, Container, ErrorAlert, H2, LoadingSpinner, PageHeader, renderError, Text } from '@sourcegraph/wildcard'
 
 import { CopyableText } from '../../components/CopyableText'
 import { PageTitle } from '../../components/PageTitle'
@@ -32,6 +22,7 @@ import { eventLogger } from '../../tracking/eventLogger'
 
 import { EXCLUDE_REPO_FROM_EXTERNAL_SERVICES, FETCH_SETTINGS_AREA_REPOSITORY_GQL } from './backend'
 import { ExternalServiceEntry } from './components/ExternalServiceEntry'
+import { RedirectionAlert } from './components/RedirectionAlert'
 
 import styles from './RepoSettingsOptionsPage.module.scss'
 
@@ -55,7 +46,6 @@ export const RepoSettingsOptionsPage: FC<Props> = ({ repo, history }) => {
     // This state shows that any of possible "exclude" buttons (in this or child components) were pushed.
     // It is used to disable all the "exclude" buttons except the button which was actually clicked.
     const [exclusionInProgress, setExclusionInProgress] = useState<boolean>(false)
-    const [ttl, setTtl] = useState<number>(3)
 
     // Callback used in child components (ExternalServiceEntry) to update the state in current component.
     const updateExclusion = useCallback((updatedExclusionState: boolean) => {
@@ -72,19 +62,7 @@ export const RepoSettingsOptionsPage: FC<Props> = ({ repo, history }) => {
     const [excludeRepo, { data: excludeData, error: excludeError, loading: isExcluding }] = useMutation<
         ExcludeRepoFromExternalServicesResult,
         ExcludeRepoFromExternalServicesVariables
-    >(EXCLUDE_REPO_FROM_EXTERNAL_SERVICES, {
-        onCompleted: () => {
-            let count = 3
-            const interval = setInterval(() => {
-                if (count === 0) {
-                    clearInterval(interval)
-                    history.push('/site-admin/external-services')
-                }
-                setTtl(count)
-                count--
-            }, 700)
-        },
-    })
+    >(EXCLUDE_REPO_FROM_EXTERNAL_SERVICES)
 
     const excludingDisabled =
         (!siteConfigError &&
@@ -153,9 +131,11 @@ export const RepoSettingsOptionsPage: FC<Props> = ({ repo, history }) => {
                                     <ErrorAlert error={`Failed to exclude repository: ${renderError(excludeError)}`} />
                                 )}
                                 {excludeData && (
-                                    <Alert className="mt-2" variant="success">
-                                        {`Code host configurations updated. You will be redirected in ${ttl}...`}
-                                    </Alert>
+                                    <RedirectionAlert
+                                        to="/site-admin/external-services"
+                                        messagePrefix="Code host configurations updated."
+                                        className="mt-2"
+                                    />
                                 )}
                             </>
                         )}{' '}

--- a/client/web/src/repo/settings/components/ExternalServiceEntry.tsx
+++ b/client/web/src/repo/settings/components/ExternalServiceEntry.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react'
+import { FC } from 'react'
 
 import classNames from 'classnames'
 import { noop } from 'lodash'
@@ -16,6 +16,8 @@ import {
     SettingsAreaRepositoryFields,
 } from '../../../graphql-operations'
 import { EXCLUDE_REPO_FROM_EXTERNAL_SERVICES } from '../backend'
+
+import { RedirectionAlert } from './RedirectionAlert'
 
 import styles from './ExternalServiceEntry.module.scss'
 
@@ -49,27 +51,11 @@ export const ExternalServiceEntry: FC<ExternalServiceEntryProps> = ({
     excludingLoading,
     updateExclusionLoading,
     redirectAfterExclusion,
-    history,
 }) => {
-    const [ttl, setTtl] = useState<number>(3)
-    const mutationOptions = redirectAfterExclusion
-        ? {
-              onCompleted: () => {
-                  let count = 3
-                  setInterval(() => {
-                      if (count === 0) {
-                          history.push(`/site-admin/external-services/${service.id}`)
-                      }
-                      setTtl(count)
-                      count--
-                  }, 700)
-              },
-          }
-        : undefined
     const [excludeRepo, { data, error, loading: isExcluding }] = useMutation<
         ExcludeRepoFromExternalServicesResult,
         ExcludeRepoFromExternalServicesVariables
-    >(EXCLUDE_REPO_FROM_EXTERNAL_SERVICES, mutationOptions)
+    >(EXCLUDE_REPO_FROM_EXTERNAL_SERVICES)
 
     return (
         <div className={styles.grid} key={service.id}>
@@ -92,9 +78,10 @@ export const ExternalServiceEntry: FC<ExternalServiceEntryProps> = ({
                 )}
                 {error && <ErrorAlert error={`Failed to exclude repository: ${renderError(error)}`} />}
                 {data && redirectAfterExclusion && (
-                    <Alert variant="success">
-                        {`Code host configuration updated. You will be redirected in ${ttl}...`}
-                    </Alert>
+                    <RedirectionAlert
+                        to={`/site-admin/external-services/${service.id}`}
+                        messagePrefix="Code host configuration updated."
+                    />
                 )}
             </div>
             {service.supportsRepoExclusion && !(data && !error) && (

--- a/client/web/src/repo/settings/components/RedirectionAlert.tsx
+++ b/client/web/src/repo/settings/components/RedirectionAlert.tsx
@@ -1,0 +1,37 @@
+import { FC, useEffect, useState } from 'react'
+
+import { useHistory } from 'react-router'
+
+import { Alert } from '@sourcegraph/wildcard'
+
+interface Props {
+    to: string
+    messagePrefix: string
+    className?: string
+}
+
+/**
+ * The repository settings options page.
+ */
+export const RedirectionAlert: FC<Props> = ({ to, className, messagePrefix }) => {
+    const [ttl, setTtl] = useState(3)
+    const history = useHistory()
+
+    useEffect(() => {
+        const interval = setInterval(() => setTtl(ttl => ttl - 1), 700)
+
+        return () => clearInterval(interval)
+    }, [])
+
+    useEffect(() => {
+        if (ttl === 0) {
+            history.push(to)
+        }
+    }, [ttl, history, to])
+
+    return (
+        <Alert className={className} variant="success">
+            {messagePrefix} You will be redirected in {ttl}...
+        </Alert>
+    )
+}


### PR DESCRIPTION
This commit removes a redirect after excluding the repo when the repo is specified in multiple code host configurations. Redirect still happens when the repo belongs to only one code host.

Test plan:
Local sg run and manual tests.

Closes https://github.com/sourcegraph/sourcegraph/issues/46036

### Quick demo

https://user-images.githubusercontent.com/94846361/210992796-94ede96e-92f5-4b55-b5c8-4fd8ceec2ec4.mov


## App preview:

- [Web](https://sg-web-ao-ui-exclude-repo-message.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
