### PR TITLE
sg: Fix incorrect matching of comments in `sg lint -fix go`

### DIFF
--- a/cmd/server/shared/postgres.go
+++ b/cmd/server/shared/postgres.go
@@ -43,7 +43,7 @@ func maybePostgresProcFile() (string, error) {
 	// we configured above.
 	for prefix, database := range databases {
 		if !isPostgresConfigured(prefix) {
-			// Set *PGHOST to default to 127.0.0.1, NOT localhost, as localhost does not correctly resolve in some environments (CI:LOCALHOST_OK)
+			// Set *PGHOST to default to 127.0.0.1, NOT localhost, as localhost does not correctly resolve in some environments
 			// (see https://github.com/sourcegraph/issues/issues/34 and https://github.com/sourcegraph/sourcegraph/issues/9129).
 			SetDefaultEnv(prefix+"PGHOST", "127.0.0.1")
 			SetDefaultEnv(prefix+"PGUSER", "postgres")

--- a/dev/check/no-localhost-guard.sh
+++ b/dev/check/no-localhost-guard.sh
@@ -12,7 +12,7 @@ path_filter() {
 }
 
 set +e
-LOCALHOST_MATCHES=$(git grep -e localhost --and --not -e '^\s*//' --and --not -e 'CI\:LOCALHOST_OK' -- '*.go' \
+LOCALHOST_MATCHES=$(git grep -e localhost --and -e '^(?!\s*//)' --and --not -e 'CI\:LOCALHOST_OK' -- '*.go' \
   ':(exclude)*_test.go' \
   ':(exclude)cmd/server/shared/nginx.go' \
   ':(exclude)dev/sg/sg_setup.go' \

--- a/internal/txemail/txemail.go
+++ b/internal/txemail/txemail.go
@@ -131,7 +131,7 @@ func Send(ctx context.Context, source string, message Message) (err error) {
 
 	// NOTE: Some services (e.g. Google SMTP relay) require to echo desired hostname,
 	// our current email dependency "github.com/jordan-wright/email" has no option
-	// for it and always echoes "localhost" which makes it unusable. (CI:LOCALHOST_OK)
+	// for it and always echoes "localhost" which makes it unusable.
 	heloHostname := conf.EmailSmtp.Domain
 	if heloHostname == "" {
 		heloHostname = "localhost" // CI:LOCALHOST_OK


### PR DESCRIPTION
- Fixes unexpected behaviour described in https://github.com/sourcegraph/sourcegraph/pull/46151

For some reason, the `--not` flag used in `git grep` was not acknowledged. To achieve the intended behaviour, this PR introduces a negative lookahead instead and drops the `--not` flag.  
This also reverts the now obsolete `(CI:LOCAL_HOST_OK)` comments.

## Test plan
`sg lint -fix go` output without this change:
```console
❌ Check for localhost usage
   exit status 1
   
   --- no localhost guard
   
   Error: Found instances of "localhost":
     cmd/server/shared/postgres.go:                     // Set *PGHOST to default to 127.0.0.1, NOT localhost, as localhost does not correctly resolve in some environments
     internal/txemail/txemail.go:       // for it and always echoes "localhost" which makes it unusable.
   
   We generally prefer to use "127.0.0.1" instead of "localhost", because
   the Go DNS resolver fails to resolve "localhost" correctly in some
   situations (see https://github.com/sourcegraph/issues/issues/34 and
   https://github.com/sourcegraph/sourcegraph/issues/9129).
   
   If your usage of "localhost" is valid, then either
   1) add the comment "CI:LOCALHOST_OK" to the line where "localhost" occurs, or
   2) add an exclusion clause in the "git grep" command in  no-localhost-guard.sh
   
   ^^^ +++
```   

`sg lint -fix go` output with this change:
```console
✅ 1. go (24s)
✅ 2. format (47s)

👌 Everything looks good! Happy hacking!
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
