### PR TITLE
graphqlbackend: Add API spec for site config history diff

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -8400,14 +8400,26 @@ A list of site config diffs.
 type siteConfigDiffConnection {
     """
     The number of nodes to return starting from the beginning (oldest).
-    Note: Use either first or last (see below) in the query. Setting both will return an error.
+    Note: Use either first or last (see below) in the query. Setting both will
+    return an error.
     """
     first: Int
     """
     The number of nodes to return starting from the end (latest).
-    Note: Use either last or first (see above) in the query. Setting both will return an error.
+    Note: Use either last or first (see above) in the query. Setting both will
+    return an error.
     """
     last: Int
+    """
+    Opaque pagination cursor to be used when paginating forwards that may be also used
+    in conjunction with "first" to return the first N nodes.
+    """
+    after: String
+    """
+    Opaque pagination cursor to be used when paginating backwards that may be
+    also used in conjunction with "last" to return the last N nodes.
+    """
+    before: String
     """
     A list of diffs in the site config
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -8449,7 +8449,9 @@ type SiteConfigChange {
     """
     id: ID!
     """
-    The ID of the previous site config against which this diff is generated.
+    The ID of the previous site config against which this diff is generated. If
+    empty, this indicates that this is the initial config that was applied at
+    instance creation so there is nothing before this to compare to.
     """
     previousID: ID
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -8393,3 +8393,61 @@ type ConnectionPageInfo {
     """
     hasPreviousPage: Boolean!
 }
+
+"""
+A list of site config diffs.
+"""
+type siteConfigDiffConnection {
+    """
+    The number of nodes to return starting from the beginning (oldest).
+    Note: Use either first or last (see below) in the query. Setting both will return an error.
+    """
+    first: Int
+    """
+    The number of nodes to return starting from the end (latest).
+    Note: Use either last or first (see above) in the query. Setting both will return an error.
+    """
+    last: Int
+    """
+    A list of diffs in the site config
+    """
+    nodes: [siteConfigDiff!]!
+    """
+    Pagination information.
+    """
+    pageInfo: BidirectionalPageInfo!
+}
+
+"""
+A diff representing the change in the site config compared to the previous version.
+"""
+type siteConfigDiff {
+    """
+    The ID of the site config in the history.
+    """
+    id: ID!
+    """
+    The ID of the previous site config against which this diff is generated.
+    """
+    previousID: ID!
+    """
+    The user who made this change. If empty, it indicates that either the
+    author's information is not available or the change in the site config was applied
+    via an internal process (example: site startup or SITE_CONFIG_FILE being reloaded).
+    """
+    author: User
+    """
+    The diff string when diffed against the site config at previousID.
+    """
+    diff: String!
+    """
+    The timestamp when this change in the site config was applied.
+    """
+    createdAt: DateTime!
+    """
+    The timestamp when this change in the site config was modified. Usually
+    this should be the same as createdAt as entries in the site config history are
+    considered immutable.
+    """
+    updatedAt: DateTime!
+}

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6470,6 +6470,34 @@ type SiteConfiguration {
     on the configuration (that can't be expressed in the JSON Schema).
     """
     validationMessages: [String!]!
+    """
+    A list of diffs to depict what changed since the previous version of this
+    configuration.
+    """
+    diffHistory(
+      """
+      The number of nodes to return starting from the beginning (oldest).
+      Note: Use either first or last (see below) in the query. Setting both will
+      return an error.
+      """
+      first: Int
+      """
+      The number of nodes to return starting from the end (latest).
+      Note: Use either last or first (see above) in the query. Setting both will
+      return an error.
+      """
+      last: Int
+      """
+      Opaque pagination cursor to be used when paginating forwards that may be also used
+      in conjunction with "first" to return the first N nodes.
+      """
+      after: String
+      """
+      Opaque pagination cursor to be used when paginating backwards that may be
+      also used in conjunction with "last" to return the last N nodes.
+      """
+      before: String
+    ): SiteConfigDiffConnection
 }
 
 """
@@ -8397,33 +8425,15 @@ type ConnectionPageInfo {
 """
 A list of site config diffs.
 """
-type siteConfigDiffConnection {
-    """
-    The number of nodes to return starting from the beginning (oldest).
-    Note: Use either first or last (see below) in the query. Setting both will
-    return an error.
-    """
-    first: Int
-    """
-    The number of nodes to return starting from the end (latest).
-    Note: Use either last or first (see above) in the query. Setting both will
-    return an error.
-    """
-    last: Int
-    """
-    Opaque pagination cursor to be used when paginating forwards that may be also used
-    in conjunction with "first" to return the first N nodes.
-    """
-    after: String
-    """
-    Opaque pagination cursor to be used when paginating backwards that may be
-    also used in conjunction with "last" to return the last N nodes.
-    """
-    before: String
+type SiteConfigDiffConnection {
     """
     A list of diffs in the site config
     """
-    nodes: [siteConfigDiff!]!
+    nodes: [SiteConfigDiff!]!
+    """
+    The total number of diffs in the connection.
+    """
+    totalCount: Int
     """
     Pagination information.
     """
@@ -8433,7 +8443,7 @@ type siteConfigDiffConnection {
 """
 A diff representing the change in the site config compared to the previous version.
 """
-type siteConfigDiff {
+type SiteConfigDiff {
     """
     The ID of the site config in the history.
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6471,10 +6471,10 @@ type SiteConfiguration {
     """
     validationMessages: [String!]!
     """
-    A list of diffs to depict what changed since the previous version of this
+    EXPERIMENTAL: A list of diffs to depict what changed since the previous version of this
     configuration.
     """
-    diffHistory(
+    history(
       """
       The number of nodes to return starting from the beginning (oldest).
       Note: Use either first or last (see below) in the query. Setting both will
@@ -6497,7 +6497,7 @@ type SiteConfiguration {
       also used in conjunction with "last" to return the last N nodes.
       """
       before: String
-    ): SiteConfigDiffConnection
+    ): SiteConfigHistoryConnection
 }
 
 """
@@ -8425,11 +8425,11 @@ type ConnectionPageInfo {
 """
 A list of site config diffs.
 """
-type SiteConfigDiffConnection {
+type SiteConfigHistoryConnection {
     """
     A list of diffs in the site config
     """
-    nodes: [SiteConfigDiff!]!
+    nodes: [SiteConfigChange!]!
     """
     The total number of diffs in the connection.
     """
@@ -8437,13 +8437,13 @@ type SiteConfigDiffConnection {
     """
     Pagination information.
     """
-    pageInfo: BidirectionalPageInfo!
+    pageInfo: ConnectionPageInfo!
 }
 
 """
 A diff representing the change in the site config compared to the previous version.
 """
-type SiteConfigDiff {
+type SiteConfigChange {
     """
     The ID of the site config in the history.
     """
@@ -8451,7 +8451,7 @@ type SiteConfigDiff {
     """
     The ID of the previous site config against which this diff is generated.
     """
-    previousID: ID!
+    previousID: ID
     """
     The user who made this change. If empty, it indicates that either the
     author's information is not available or the change in the site config was applied

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -8433,7 +8433,7 @@ type SiteConfigHistoryConnection {
     """
     The total number of diffs in the connection.
     """
-    totalCount: Int
+    totalCount: Int!
     """
     Pagination information.
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6497,7 +6497,7 @@ type SiteConfiguration {
       also used in conjunction with "last" to return the last N nodes.
       """
       before: String
-    ): SiteConfigHistoryConnection
+    ): SiteConfigChangeConnection
 }
 
 """
@@ -8425,7 +8425,7 @@ type ConnectionPageInfo {
 """
 A list of site config diffs.
 """
-type SiteConfigHistoryConnection {
+type SiteConfigChangeConnection {
     """
     A list of diffs in the site config
     """


### PR DESCRIPTION
Part of #46031.

# What

An API to return the diff between two consecutive entries in the `critical_and_site_config` table which stores the entire site config as a new row each time it is updated.

# Why

We want to show the history of changes to the site config in the site-admin UI as a site-admin UX improvement.

## Test plan



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
