### PR TITLE
ci: fix go test failures not being annotated

### DIFF
--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -3,6 +3,7 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"/../..
 
 set -euo pipefail
+base=$(pwd)
 
 function usage {
   cat <<EOF
@@ -46,8 +47,9 @@ function go_test() {
   if [ "$test_exit_code" -ne 0 ]; then
     echo "~~~ Creating test failures anotation"
     mkdir -p ./annotations
-    sed '0,/=== Failed$/d'<"$tmpfile" >>./annotations/go-test
-    set +x
+    # in $base, because we're this function with a cwd set to where we 
+    # found the go.mod.
+    sed '0,/=== Failed$/d'<"$tmpfile" >> "${base}/annotations/go-test"
   fi
 
   return "$test_exit_code"


### PR DESCRIPTION
Fixes go tests annotations not appearing on test failures. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

QA'ed locally. 