### PR TITLE
token selection: fix infer occurrence at position method

### DIFF
--- a/client/web/src/repo/blob/codemirror/occurrence-utils.ts
+++ b/client/web/src/repo/blob/codemirror/occurrence-utils.ts
@@ -98,7 +98,7 @@ export function highlightingOccurrenceAtPosition(state: EditorState, position: P
 export function inferOccurrenceAtPosition(state: EditorState, position: Position): Occurrence | undefined {
     const fallback = state.field(fallbackOccurrences)
     const cmLine = state.doc.line(position.line + 1)
-    const cmPosition = cmLine.from + position.character + 1
+    const cmPosition = cmLine.from + position.character
     // We rely on `Occurrence` reference equality in some downstream facets so
     // it's important to reuse instances between invocations.
     const fromCache = fallback.get(cmPosition)


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/46069

CodeMirror [`Line.from`](https://codemirror.net/docs/ref/#state.Line) value is 0-based so there's no need to increment [`Position.character`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@d49402057af9f4bffeb65eb0c503ec57e1593ea9/-/blob/client/shared/src/codeintel/legacy-extensions/api.ts?L701) by one when converting it to the CodeMirror position.

<img width="1443" alt="Screenshot 2023-01-06 at 17 54 41" src="https://user-images.githubusercontent.com/25318659/211048653-490c6445-7e0e-413b-85f5-020c39a9c685.png">


## Test plan
- `sg start web-standalone`
- ensure CodeMirror blob view and selection-driven navigation are enabled
- ensure selection, pin and hover tooltips work as expected

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-taras-yemets-token-selection-fix-z0zk.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

