### PR TITLE
codeintel: bring audit logs upload_size type in-line with lsif_uploads table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights: fixed an issue where filtering by a search context that included multiple repositories would exclude data. [#45574](https://github.com/sourcegraph/sourcegraph/pull/45574)
 - Ignore null JSON objects returned from GitHub API when listing public repositories. [#45969](https://github.com/sourcegraph/sourcegraph/pull/45969)
 - Fixed issue where emails that have never been verified before would be unable to receive resent verification emails. [#46185](https://github.com/sourcegraph/sourcegraph/pull/46185)
+- Resolved issue preventing LSIF uploads larger than 2GiB (gzipped) from uploading successfully. [#46209](https://github.com/sourcegraph/sourcegraph/pull/46209)
 
 ### Removed
 

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -14413,7 +14413,7 @@
         {
           "Name": "upload_size",
           "Index": 10,
-          "TypeName": "integer",
+          "TypeName": "bigint",
           "IsNullable": true,
           "Default": "",
           "CharacterMaximumLength": 0,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2149,7 +2149,7 @@ Stores metadata about an LSIF index uploaded by a user.
  uploaded_at         | timestamp with time zone |           | not null | 
  indexer             | text                     |           | not null | 
  indexer_version     | text                     |           |          | 
- upload_size         | integer                  |           |          | 
+ upload_size         | bigint                   |           |          | 
  associated_index_id | integer                  |           |          | 
  transition_columns  | USER-DEFINED[]           |           |          | 
  reason              | text                     |           |          | ''::text

--- a/migrations/frontend/1673019611_lsif_uploads_audit_logs_bigint_upload_size/down.sql
+++ b/migrations/frontend/1673019611_lsif_uploads_audit_logs_bigint_upload_size/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE lsif_uploads_audit_logs
+ALTER COLUMN upload_size
+TYPE integer;

--- a/migrations/frontend/1673019611_lsif_uploads_audit_logs_bigint_upload_size/metadata.yaml
+++ b/migrations/frontend/1673019611_lsif_uploads_audit_logs_bigint_upload_size/metadata.yaml
@@ -1,0 +1,2 @@
+name: lsif_uploads_audit_logs_bigint_upload_size
+parents: [1672884222]

--- a/migrations/frontend/1673019611_lsif_uploads_audit_logs_bigint_upload_size/up.sql
+++ b/migrations/frontend/1673019611_lsif_uploads_audit_logs_bigint_upload_size/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE lsif_uploads_audit_logs
+ALTER COLUMN upload_size
+TYPE bigint;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -2841,7 +2841,7 @@ CREATE TABLE lsif_uploads_audit_logs (
     uploaded_at timestamp with time zone NOT NULL,
     indexer text NOT NULL,
     indexer_version text,
-    upload_size integer,
+    upload_size bigint,
     associated_index_id integer,
     transition_columns hstore[],
     reason text DEFAULT ''::text,


### PR DESCRIPTION
This was causing an `ERROR: integer out of range (SQLSTATE 22003)` error that we thought originated from the `lsif_uploads` table, but turns out it was from within the trigger. This wouldve been made more obvious if our errors had more info, see the output from `psql`:
```
[local:/home/noah/.sourcegraph/postgres] noah@postgres=# INSERT INTO lsif_uploads (repository_id, commit, indexer, num_parts, uploaded_parts, upload_size) VALUES (1, 'f119e4f4af4c3070d4531ae324bfd995c9f0391d', 'lsif-clang', 1, '{0}', 9223372036854775806);
ERROR:  22003: integer out of range
CONTEXT:  SQL statement "INSERT INTO lsif_uploads_audit_logs
        (upload_id, commit, root, repository_id, uploaded_at,
        indexer, indexer_version, upload_size, associated_index_id,
        content_type,
        operation, transition_columns)
        VALUES (
            NEW.id, NEW.commit, NEW.root, NEW.repository_id, NEW.uploaded_at,
            NEW.indexer, NEW.indexer_version, NEW.upload_size, NEW.associated_index_id,
            NEW.content_type,
            'create', func_lsif_uploads_transition_columns_diff(
                (NULL, NULL, NULL, NULL, NULL, NULL),
                func_row_to_lsif_uploads_transition_columns(NEW)
            )
        )"
PL/pgSQL function func_lsif_uploads_insert() line 3 at SQL statement
LOCATION:  int84, int8.c:1290
Time: 6.587 ms
```

The down migration may cause issues if there are entries that exceed `integer` size, is this ok? @efritz 

## Test plan

Ran it locally and it solved the issue