### PR TITLE
Update release config for 4.4.0 release

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -11,16 +11,16 @@
 {
     // Captain information
     // To get your slack username, navigate to Profile -> More -> Account settings -> Username (at the bottom) -> Expand
-    "captainSlackUsername": "geoffrey",
-    "captainGitHubUsername": "ggilmore",
+    "captainSlackUsername": "bolaji.olajide",
+    "captainGitHubUsername": "BolajiOlajide",
     // Release versions
     "previousRelease": "4.3.0",
-    "upcomingRelease": "4.3.1",
-    "oneWorkingWeekBeforeRelease": "29 December 2022 10:00 PST",
-    "threeWorkingDaysBeforeRelease": "2 January 2023 10:00 PST",
-    "releaseDate": "5 January 2023 10:00 PST",
-    "oneWorkingDayAfterRelease": "6 January 2023 10:00 PST",
-    "oneWorkingWeekAfterRelease": "13 January 2023 10:00 PST",
+    "upcomingRelease": "4.4.0",
+    "oneWorkingWeekBeforeRelease": "13 January 2022 10:00 PST",
+    "threeWorkingDaysBeforeRelease": "17 January 2022 10:00 PST",
+    "releaseDate": "20 January 2023 10:00 PST",
+    "oneWorkingDayAfterRelease": "23 January 2022 10:00 PST",
+    "oneWorkingWeekAfterRelease": "27 January 2022 10:00 PST",
     // Channel where messages from the tooling are posted
     "slackAnnounceChannel": "eng-announce",
     // Email for preparing calendar events


### PR DESCRIPTION
This reverts commit e1ab2735d73c5d7e59ed661dcae15666e43ea12d, which updates the release config for the 4.3.1 patch. This reverts it back to the config for the 4.4.0 release.

## Test plan

Manual inspection.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cc-update-release-config.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
