### PR TITLE
codeintel: Add SCIP to codeintel-qa

### DIFF
--- a/dev/ci/integration/code-intel/repos.json
+++ b/dev/ci/integration/code-intel/repos.json
@@ -8,7 +8,11 @@
         "sourcegraph-testing/etcd",
         "sourcegraph-testing/tidb",
         "sourcegraph-testing/titan",
-        "sourcegraph-testing/zap"
+        "sourcegraph-testing/zap",
+        "sourcegraph-testing/nacelle",
+        "sourcegraph-testing/nacelle-config",
+        "sourcegraph-testing/nacelle-service",
+        "sourcegraph/code-intel-extensions"
       ]
     }
   }

--- a/dev/ci/integration/code-intel/test.sh
+++ b/dev/ci/integration/code-intel/test.sh
@@ -31,8 +31,16 @@ echo '--- :zero: downloading test data from GCS'
 go run ./cmd/download
 echo '--- :one: clearing existing state'
 go run ./cmd/clear
-echo '--- :two: integration test ./dev/codeintel-qa/cmd/upload'
-go run ./cmd/upload --timeout=5m -verbose
-echo '--- :three: integration test ./dev/codeintel-qa/cmd/query'
-go run ./cmd/query -verbose
+echo '--- :two: Disabling LSIF -> SCIP migration'
+# Disable migration #19 (LSIF -> SCIP)
+"${root_dir}/init-sg" oobmigration -id T3V0T2ZCYW5kTWlncmF0aW9uOjE5 -down
+echo '--- :three: integration test ./dev/codeintel-qa/cmd/upload'
+go run ./cmd/upload --timeout=5m
+echo '--- :four: integration test ./dev/codeintel-qa/cmd/query'
+go run ./cmd/query
+echo '--- :five: Running LSIF -> SCIP migration'
+# Enable migration #19 (LSIF -> SCIP) and wait for it to complete
+"${root_dir}/init-sg" oobmigration -id T3V0T2ZCYW5kTWlncmF0aW9uOjE5
+echo '--- :six: integration test ./dev/codeintel-qa/cmd/query'
+go run ./cmd/query
 popd

--- a/dev/codeintel-qa/README.md
+++ b/dev/codeintel-qa/README.md
@@ -8,6 +8,8 @@ Ensure that the following tools are available on your path:
 
 - [`src`](https://github.com/sourcegraph/src-cli)
 - [`lsif-go`](https://github.com/sourcegraph/lsif-go)
+- [`scip-go`](https://github.com/sourcegraph/scip-go)
+- [`scip-typescript`](https://github.com/sourcegraph/scip-typescript)
 
 You should have enviornment variables that authenticate you to the `sourcegraph-dev` GCS project if you plan to upload or download index files (as we do in CI).
 
@@ -27,7 +29,11 @@ SOURCEGRAPH_SUDO_TOKEN=<YOUR SOURCEGRAPH API ACCESS TOKEN>
     "sourcegraph-testing/etcd",
     "sourcegraph-testing/tidb",
     "sourcegraph-testing/titan",
-    "sourcegraph-testing/zap"
+    "sourcegraph-testing/zap",
+    "sourcegraph-testing/nacelle",
+    "sourcegraph-testing/nacelle-config",
+    "sourcegraph-testing/nacelle-service",
+    "sourcegraph/code-intel-extensions"
   ],
 ```
 

--- a/dev/codeintel-qa/cmd/query/state.go
+++ b/dev/codeintel-qa/cmd/query/state.go
@@ -21,12 +21,17 @@ func checkInstanceState(ctx context.Context) error {
 }
 
 func instanceStateDiff(ctx context.Context) (string, error) {
-	commitsByRepo, err := internal.CommitsByRepo(indexDir)
+	extensionAndCommitsByRepo, err := internal.ExtensionAndCommitsByRepo(indexDir)
 	if err != nil {
 		return "", err
 	}
 	expectedCommitsByRepo := map[string][]string{}
-	for repoName, commits := range commitsByRepo {
+	for repoName, extensionAndCommits := range extensionAndCommitsByRepo {
+		commits := make([]string, 0, len(extensionAndCommits))
+		for _, e := range extensionAndCommits {
+			commits = append(commits, e.Commit)
+		}
+
 		sort.Strings(commits)
 		expectedCommitsByRepo[internal.MakeTestRepoName(repoName)] = commits
 	}

--- a/dev/codeintel-qa/cmd/query/test_cases.go
+++ b/dev/codeintel-qa/cmd/query/test_cases.go
@@ -10,15 +10,21 @@ type Location struct {
 }
 
 const (
-	repo_etcd  = "github.com/sourcegraph-testing/etcd"
-	repo_tidb  = "github.com/sourcegraph-testing/tidb"
-	repo_titan = "github.com/sourcegraph-testing/titan"
-	repo_zap   = "github.com/sourcegraph-testing/zap"
+	repo_etcd            = "github.com/sourcegraph-testing/etcd"
+	repo_tidb            = "github.com/sourcegraph-testing/tidb"
+	repo_titan           = "github.com/sourcegraph-testing/titan"
+	repo_zap             = "github.com/sourcegraph-testing/zap"
+	repo_nacelle         = "github.com/sourcegraph-testing/nacelle"
+	repo_nacelle_config  = "github.com/sourcegraph-testing/nacelle-config"
+	repo_nacelle_service = "github.com/sourcegraph-testing/nacelle-service"
+	repo_extensions      = "github.com/sourcegraph/code-intel-extensions"
 
 	commit_2aa9fa2 = "2aa9fa25da83bdfff756c36a91442edc9a84576c"
+	commit_4d4864d = "4d4864d3b5b046fe12154f3aae7a86a04690c4ae"
 	commit_9aab491 = "9aab49176993f9dc0ed2fcb9ef7e5125518e8b98"
 	commit_a6015e1 = "a6015e13fab9b744d96085308ce4e8f11bad1996"
 	commit_ad78480 = "ad7848014a051dbe3fcd6a4cff2c7befdd16d5a8"
+	commit_c66e756 = "c66e756d3d68a1e19048c3f7515ba42a7e793767"
 	commit_f8307e3 = "f8307e394c512b4263fc0cd67ccf9fd46f1ad9a5"
 )
 
@@ -36,6 +42,10 @@ const (
 // All the test cases for those repos find definitions and references for
 // the symbol `zap.String`, a global function defined in fields.go in both
 // versions.
+//
+// go-nacelle release tags:
+//  - `v5.0.0` for `nacelle-config at commit `4d4864d`, and
+//  - `v5.0.0` for `nacelle-service` at commit `0652f30`.
 
 var testCases = []struct {
 	Definition Location   // Symbol definition
@@ -1677,6 +1687,112 @@ var testCases = []struct {
 			{Repo: repo_zap, Rev: commit_a6015e1, Path: "zaptest/observer/observer_test.go", Line: 125, Character: 32},
 			{Repo: repo_zap, Rev: commit_a6015e1, Path: "zaptest/observer/observer_test.go", Line: 129, Character: 32},
 			{Repo: repo_zap, Rev: commit_a6015e1, Path: "zaptest/observer/observer_test.go", Line: 170, Character: 34},
+		},
+	},
+	{
+		Definition: Location{
+			Repo:      repo_nacelle_config,
+			Rev:       commit_4d4864d,
+			Path:      "sourcer.go",
+			Line:      6,
+			Character: 5,
+		},
+		References: []Location{
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "config.go", Line: 31, Character: 12},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "config.go", Line: 37, Character: 23},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "directory_sourcer.go", Line: 11, Character: 10},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "directory_sourcer.go", Line: 14, Character: 6},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "directory_sourcer.go", Line: 19, Character: 107},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "directory_sourcer.go", Line: 33, Character: 99},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "directory_sourcer.go", Line: 55, Character: 41},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "directory_sourcer.go", Line: 72, Character: 15},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "env_sourcer.go", Line: 13, Character: 6},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "env_sourcer.go", Line: 23, Character: 34},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "file_sourcer.go", Line: 20, Character: 6},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "file_sourcer.go", Line: 33, Character: 98},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "file_sourcer.go", Line: 47, Character: 90},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "file_sourcer.go", Line: 113, Character: 41},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "file_sourcer.go", Line: 118, Character: 41},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "flag_sourcer.go", Line: 12, Character: 6},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "flag_sourcer.go", Line: 16, Character: 54},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "glob_sourcer.go", Line: 6, Character: 89},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "glob_sourcer.go", Line: 9, Character: 15},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "multi_sourcer.go", Line: 7, Character: 12},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "multi_sourcer.go", Line: 11, Character: 6},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "multi_sourcer.go", Line: 15, Character: 33},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "multi_sourcer.go", Line: 15, Character: 42},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "test_env_sourcer.go", Line: 10, Character: 6},
+			{Repo: repo_nacelle_config, Rev: commit_4d4864d, Path: "test_env_sourcer.go", Line: 14, Character: 49},
+		},
+	},
+	{
+		Definition: Location{
+			Repo:      repo_extensions,
+			Rev:       commit_c66e756,
+			Path:      "template/src/util/graphql.ts",
+			Line:      16,
+			Character: 12,
+		},
+		References: []Location{
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/api.ts", Character: 9},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/api.ts", Line: 23, Character: 18},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/definition-hover.test.ts", Line: 5, Character: 9},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/definition-hover.test.ts", Line: 13, Character: 41},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/definition-hover.test.ts", Line: 46, Character: 41},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/definition-hover.test.ts", Line: 68, Character: 41},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/definition-hover.test.ts", Line: 91, Character: 41},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/definition-hover.ts", Line: 4, Character: 41},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/definition-hover.ts", Line: 81, Character: 18},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/implementations.ts", Line: 3, Character: 41},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/implementations.ts", Line: 75, Character: 18},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/implementations.ts", Line: 92, Character: 18},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/locations.ts", Line: 2, Character: 41},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/locations.ts", Line: 43, Character: 18},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/locations.ts", Line: 54, Character: 18},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.test.ts", Line: 5, Character: 9},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.test.ts", Line: 33, Character: 45},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.test.ts", Line: 76, Character: 45},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.test.ts", Line: 113, Character: 45},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.test.ts", Line: 126, Character: 45},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.test.ts", Line: 175, Character: 45},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.test.ts", Line: 205, Character: 45},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.test.ts", Line: 221, Character: 27},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.test.ts", Line: 222, Character: 27},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.test.ts", Line: 224, Character: 45},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.test.ts", Line: 270, Character: 45},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.test.ts", Line: 303, Character: 45},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.test.ts", Line: 334, Character: 45},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.test.ts", Line: 358, Character: 45},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.ts", Line: 7, Character: 41},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.ts", Line: 46, Character: 18},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.ts", Line: 108, Character: 18},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.ts", Line: 152, Character: 18},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.ts", Line: 207, Character: 18},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/providers.ts", Line: 262, Character: 18},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/ranges.test.ts", Line: 5, Character: 9},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/ranges.test.ts", Line: 33, Character: 41},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/ranges.test.ts", Line: 67, Character: 42},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/ranges.test.ts", Line: 78, Character: 42},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/ranges.test.ts", Line: 189, Character: 41},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/ranges.test.ts", Line: 249, Character: 41},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/ranges.ts", Line: 3, Character: 41},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/ranges.ts", Line: 63, Character: 18},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/ranges.ts", Line: 139, Character: 18},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/ranges.ts", Line: 268, Character: 44},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/ranges.ts", Line: 365, Character: 18},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/references.test.ts", Line: 5, Character: 9},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/references.test.ts", Line: 24, Character: 41},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/references.test.ts", Line: 47, Character: 41},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/references.test.ts", Line: 56, Character: 23},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/references.test.ts", Line: 57, Character: 23},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/references.test.ts", Line: 59, Character: 41},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/references.test.ts", Line: 102, Character: 41},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/references.ts", Line: 3, Character: 41},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/references.ts", Line: 75, Character: 18},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/references.ts", Line: 87, Character: 18},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/stencil.ts", Line: 4, Character: 9},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/stencil.ts", Line: 11, Character: 18},
+			{Repo: repo_extensions, Rev: commit_c66e756, Path: "template/src/lsif/stencil.ts", Line: 47, Character: 18},
 		},
 	},
 }

--- a/dev/codeintel-qa/cmd/upload/main.go
+++ b/dev/codeintel-qa/cmd/upload/main.go
@@ -54,13 +54,13 @@ func mainErr(ctx context.Context) error {
 		return err
 	}
 
-	commitsByRepo, err := internal.CommitsByRepo(indexDir)
+	extensionAndCommitsByRepo, err := internal.ExtensionAndCommitsByRepo(indexDir)
 	if err != nil {
 		return err
 	}
 
-	repoNames := make([]string, 0, len(commitsByRepo))
-	for name := range commitsByRepo {
+	repoNames := make([]string, 0, len(extensionAndCommitsByRepo))
+	for name := range extensionAndCommitsByRepo {
 		repoNames = append(repoNames, name)
 	}
 	sort.Strings(repoNames)
@@ -68,7 +68,7 @@ func mainErr(ctx context.Context) error {
 	limiter := internal.NewLimiter(numConcurrentUploads)
 	defer limiter.Close()
 
-	uploads, err := uploadAll(ctx, commitsByRepo, limiter)
+	uploads, err := uploadAll(ctx, extensionAndCommitsByRepo, limiter)
 	if err != nil {
 		return err
 	}

--- a/dev/codeintel-qa/internal/indexes.go
+++ b/dev/codeintel-qa/internal/indexes.go
@@ -7,22 +7,28 @@ import (
 	"github.com/grafana/regexp"
 )
 
-var indexFilenamePattern = regexp.MustCompile(`^([^.]+)\.([^.]+)\.\d+\.([0-9A-Fa-f]{40})\.dump$`)
+var indexFilenamePattern = regexp.MustCompile(`^([^.]+)\.([^.]+)\.\d+\.([0-9A-Fa-f]{40})\.(scip|dump)$`)
 
-// CommitsByRepo returns a map from org+repository name to a slice of commits for that repository. The
-// repositories and commits are read from the filesystem state of the index directory supplied by the user.
-// This method assumes that index files have been downloaded or generated locally.
-func CommitsByRepo(indexDir string) (map[string][]string, error) {
+type ExtensionAndCommit struct {
+	Extension string
+	Commit    string
+}
+
+// ExtensionAndCommitsByRepo returns a map from org+repository name to a slice of commit and extension
+// pairs for that repository. The repositories and commits are read from the filesystem state of the
+// index directory supplied by the user. This method assumes that index files have been downloaded or
+// generated locally.
+func ExtensionAndCommitsByRepo(indexDir string) (map[string][]ExtensionAndCommit, error) {
 	infos, err := os.ReadDir(indexDir)
 	if err != nil {
 		return nil, err
 	}
 
-	commitsByRepo := map[string][]string{}
+	commitsByRepo := map[string][]ExtensionAndCommit{}
 	for _, info := range infos {
 		if matches := indexFilenamePattern.FindStringSubmatch(info.Name()); len(matches) > 0 {
 			orgRepo := fmt.Sprintf("%s/%s", matches[1], matches[2])
-			commitsByRepo[orgRepo] = append(commitsByRepo[orgRepo], matches[3])
+			commitsByRepo[orgRepo] = append(commitsByRepo[orgRepo], ExtensionAndCommit{Extension: matches[4], Commit: matches[3]})
 		}
 	}
 

--- a/internal/cmd/init-sg/main.go
+++ b/internal/cmd/init-sg/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 
@@ -16,8 +18,9 @@ import (
 var (
 	client *gqltestutil.Client
 
-	initSG   = flag.NewFlagSet("initserver", flag.ExitOnError)
-	addRepos = flag.NewFlagSet("addrepos", flag.ExitOnError)
+	initSG       = flag.NewFlagSet("initserver", flag.ExitOnError)
+	addRepos     = flag.NewFlagSet("addrepos", flag.ExitOnError)
+	oobmigration = flag.NewFlagSet("oobmigration", flag.ExitOnError)
 
 	baseURL  = initSG.String("baseurl", os.Getenv("SOURCEGRAPH_BASE_URL"), "The base URL of the Sourcegraph instance. (Required)")
 	email    = initSG.String("email", os.Getenv("TEST_USER_EMAIL"), "The email of the admin user. (Required)")
@@ -27,6 +30,9 @@ var (
 	githubToken    = addRepos.String("githubtoken", os.Getenv("GITHUB_TOKEN"), "The github access token that will be used to authenticate an external service. (Required)")
 	addReposConfig = addRepos.String("config", "", "Path to the external service config. (Required)")
 
+	migrationID       = oobmigration.String("id", "", "The target oobmigration identifier. (Required)")
+	migrationDownFlag = oobmigration.Bool("down", false, "Supply to change the migration from up (default) to down.")
+
 	home    = os.Getenv("HOME")
 	profile = home + "/.sg_envrc"
 )
@@ -35,7 +41,7 @@ func main() {
 	flag.Parse()
 
 	if len(os.Args) < 2 {
-		fmt.Println("initSG or addRepos subcommand is required")
+		fmt.Println("initSG, addRepos, or oobmigration subcommand is required")
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
@@ -47,6 +53,9 @@ func main() {
 	case "addRepos":
 		addRepos.Parse(os.Args[2:])
 		addReposCommand()
+	case "oobmigration":
+		oobmigration.Parse(os.Args[2:])
+		oobmigrationCommand()
 	case "default":
 		flag.PrintDefaults()
 		os.Exit(1)
@@ -159,7 +168,6 @@ func addReposCommand() {
 	jsoniter.Unmarshal(byteValue, &externalsvcs)
 
 	for i := range externalsvcs {
-
 		// Set up external service
 		esID, err := client.AddExternalService(gqltestutil.AddExternalServiceInput{
 			Kind:        externalsvcs[i].Kind,
@@ -189,5 +197,40 @@ func addReposCommand() {
 		} else {
 			log.Print(esID)
 		}
+	}
+}
+
+const MigrationTimeout = time.Minute * 5
+
+func oobmigrationCommand() {
+	if *migrationID == "" {
+		log.Fatal("migration identifier (-id) is not supplied")
+	}
+	id := *migrationID
+	up := !*migrationDownFlag
+
+	client, err := gqltestutil.SignIn(*baseURL, *email, *password)
+	if err != nil {
+		log.Fatal("Failed to sign in:", err)
+	}
+	log.Println("Site admin authenticated:", *username)
+
+	if err := client.SetMigrationDirection(id, up); err != nil {
+		log.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), MigrationTimeout)
+	defer cancel()
+
+	if err := client.PollMigration(ctx, id, func(progress float64) bool {
+		if up {
+			log.Printf("Waiting for migration %s to complete (%.2f%% done).", id, progress*100)
+		} else {
+			log.Printf("Waiting for migration %s to rollback (%.2f%% done).", id, (1-progress)*100)
+		}
+
+		return (up && progress == 1) || (!up && progress == 0)
+	}); err != nil {
+		log.Fatal(err)
 	}
 }

--- a/internal/gqltestutil/migration.go
+++ b/internal/gqltestutil/migration.go
@@ -1,0 +1,82 @@
+package gqltestutil
+
+import (
+	"context"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var MigrationPollInterval = time.Second
+
+// PollMigration will invoke the given function periodically with the current progress of the
+// given migration. The loop will break once the function returns true or the given context
+// is canceled.
+func (c *Client) PollMigration(ctx context.Context, id string, f func(float64) bool) error {
+	for {
+		progress, err := c.GetMigrationProgress(id)
+		if err != nil {
+			return err
+		}
+		if f(progress) {
+			return nil
+		}
+
+		select {
+		case <-time.After(MigrationPollInterval):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (c *Client) GetMigrationProgress(id string) (float64, error) {
+	const query = `
+		query GetMigrationStatus {
+			outOfBandMigrations {
+				id
+				progress
+			}
+		}
+	`
+
+	var envelope struct {
+		Data struct {
+			OutOfBandMigrations []struct {
+				ID       string
+				Progress float64
+			}
+		}
+	}
+	if err := c.GraphQL("", query, nil, &envelope); err != nil {
+		return 0, errors.Wrap(err, "request GraphQL")
+	}
+
+	for _, migration := range envelope.Data.OutOfBandMigrations {
+		if migration.ID == id {
+			return migration.Progress, nil
+		}
+	}
+
+	return 0, errors.Newf("unknown oobmigration %q", id)
+}
+
+func (c *Client) SetMigrationDirection(id string, up bool) error {
+	const query = `
+		mutation SetMigrationDirection($id: ID!, $applyReverse: Boolean!) {
+			setMigrationDirection(id: $id, applyReverse: $applyReverse) {
+				alwaysNil
+			}
+		}
+	`
+
+	variables := map[string]any{
+		"id":           id,
+		"applyReverse": !up,
+	}
+	if err := c.GraphQL("", query, variables, nil); err != nil {
+		return errors.Wrap(err, "request GraphQL")
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds support and test cases for SCIP data in the codeintel-qa pipeline.

## Test plan

- [main-dry-run](https://buildkite.com/sourcegraph/sourcegraph/builds/193101)