### PR TITLE
scaletesting: use config path in bitbucket copy

### DIFF
--- a/dev/scaletesting/codehostcopy/bitbucket.go
+++ b/dev/scaletesting/codehostcopy/bitbucket.go
@@ -171,16 +171,8 @@ func (bt *BitbucketCodeHost) projectKeyAndNameFrom(name string) (string, string)
 	if len(parts) == 2 {
 		return parts[0], parts[1]
 	}
-	// The name must originate from some other codehost, usually the form is <http|https>://<hostname>/<org>/<repo>.git
-	parts = strings.Split(name, "/")
-	if len(parts) <= 1 {
-		// WHELP, no clue how to deal with this so empty key and repoName
-		return "", ""
-	}
-	// The last two elements should be the org and repo name
-	org := parts[len(parts)-2]
-	repo := strings.TrimRight(parts[len(parts)-1], ".git")
-	return org, repo
+	// The name must originate from some other codehost so now we use the path from the config
+	return bt.def.Path, name
 }
 
 // CreateRepo creates a repo on bitbucket. It is assumed that the repo name has the following format: <project key>_-_<repo name>.

--- a/dev/scaletesting/codehostcopy/bitbucket.go
+++ b/dev/scaletesting/codehostcopy/bitbucket.go
@@ -165,17 +165,34 @@ func (bt *BitbucketCodeHost) Next(ctx context.Context) []*store.Repo {
 	return results
 }
 
+func (bt *BitbucketCodeHost) projectKeyAndNameFrom(name string) (string, string) {
+	parts := strings.Split(name, separator)
+	// If this name originates from a Bitbucket client it will have the format <project key>_-_<repo name>.
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	// The name must originate from some other codehost, usually the form is <http|https>://<hostname>/<org>/<repo>.git
+	parts = strings.Split(name, "/")
+	if len(parts) <= 1 {
+		// WHELP, no clue how to deal with this so empty key and repoName
+		return "", ""
+	}
+	// The last two elements should be the org and repo name
+	org := parts[len(parts)-2]
+	repo := strings.TrimRight(parts[len(parts)-1], ".git")
+	return org, repo
+}
+
 // CreateRepo creates a repo on bitbucket. It is assumed that the repo name has the following format: <project key>_-_<repo name>.
 // A repo can only be created under a project in bitbucket, therefore the project is extract from the repo name format and a
 // project is created first, if and only if, the project does not exist already. If the project already exists, the repo
 // will be created and the created repos git clone url will be returned.
 func (bt *BitbucketCodeHost) CreateRepo(ctx context.Context, name string) (*url.URL, error) {
-	parts := strings.Split(name, separator)
-	if len(parts) != 2 {
-		return nil, errors.New("invalid name format - expected <project key>_-_<repo name>")
+	key, repoName := bt.projectKeyAndNameFrom(name)
+
+	if len(key) == 0 || len(repoName) == 0 {
+		return nil, errors.Errorf("could not extract key and name from unknown repo format %q", name)
 	}
-	key := parts[0]
-	repoName := parts[1]
 
 	var apiErr *bitbucket.APIError
 	_, err := bt.c.GetProjectByKey(ctx, key)


### PR DESCRIPTION
If the repo name orignates from a non-bitbucket client, use the path
from the config as the project key.

## Test plan
It's running on the devx machine now

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
