### PR TITLE
faster function-incomplete local dev builds without cgo

### DIFF
--- a/cmd/symbols/internal/api/handler_cgo.go
+++ b/cmd/symbols/internal/api/handler_cgo.go
@@ -1,0 +1,23 @@
+//go:build cgo
+
+package api
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/sourcegraph/sourcegraph/cmd/symbols/squirrel"
+	"github.com/sourcegraph/sourcegraph/cmd/symbols/types"
+	internaltypes "github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+// addHandlers adds handlers that require cgo.
+func addHandlers(
+	mux *http.ServeMux,
+	searchFunc types.SearchFunc,
+	readFileFunc func(context.Context, internaltypes.RepoCommitPath) ([]byte, error),
+) {
+	mux.HandleFunc("/localCodeIntel", squirrel.LocalCodeIntelHandler(readFileFunc))
+	mux.HandleFunc("/debugLocalCodeIntel", squirrel.DebugLocalCodeIntelHandler)
+	mux.HandleFunc("/symbolInfo", squirrel.NewSymbolInfoHandler(searchFunc, readFileFunc))
+}

--- a/cmd/symbols/internal/api/handler_nocgo.go
+++ b/cmd/symbols/internal/api/handler_nocgo.go
@@ -1,0 +1,42 @@
+//go:build !cgo
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/sourcegraph/sourcegraph/cmd/symbols/types"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	internaltypes "github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+// addHandlers adds handlers that do not require cgo, which speeds up compile times but omits local
+// code intelligence features. This non-cgo variant must only be used for development. Release
+// builds of Sourcegraph must be built with cgo, or else they'll miss critical features.
+func addHandlers(
+	mux *http.ServeMux,
+	searchFunc types.SearchFunc,
+	readFileFunc func(context.Context, internaltypes.RepoCommitPath) ([]byte, error),
+) {
+	if !env.InsecureDev {
+		panic("must build with cgo (non-cgo variant is only for local dev)")
+	}
+
+	mux.HandleFunc("/localCodeIntel", jsonResponseHandler(internaltypes.LocalCodeIntelPayload{Symbols: []internaltypes.Symbol{}}))
+	mux.HandleFunc("/debugLocalCodeIntel", notEnabledHandler)
+	mux.HandleFunc("/symbolInfo", jsonResponseHandler(internaltypes.SymbolInfo{}))
+}
+
+func notEnabledHandler(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "feature not enabled in this build", http.StatusNotImplemented)
+}
+
+func jsonResponseHandler(v any) http.HandlerFunc {
+	data, _ := json.Marshal(v)
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data)
+	}
+}

--- a/cmd/symbols/squirrel/breadcrumbs.go
+++ b/cmd/symbols/squirrel/breadcrumbs.go
@@ -32,7 +32,7 @@ type Breadcrumbs []Breadcrumb
 //	  vvv other breadcrumb
 //
 // 78 | func f(f Foo) {
-func (bs *Breadcrumbs) pretty(w *strings.Builder, readFile ReadFileFunc) {
+func (bs *Breadcrumbs) pretty(w *strings.Builder, readFile readFileFunc) {
 	// First collect all the breadcrumbs in a map (path -> line -> breadcrumb) for easier printing.
 	pathToLineToBreadcrumbs := map[types.RepoCommitPath]map[int][]Breadcrumb{}
 	for _, breadcrumb := range *bs {
@@ -124,13 +124,13 @@ func itermSource(absPath string, line int, msg string) string {
 	return ""
 }
 
-func (bs *Breadcrumbs) prettyPrint(readFile ReadFileFunc) {
+func (bs *Breadcrumbs) prettyPrint(readFile readFileFunc) {
 	fmt.Println(" ")
 	fmt.Println(bracket(bs.prettyString(readFile)))
 	fmt.Println(" ")
 }
 
-func (bs *Breadcrumbs) prettyString(readFile ReadFileFunc) string {
+func (bs *Breadcrumbs) prettyString(readFile readFileFunc) string {
 	sb := &strings.Builder{}
 	bs.pretty(sb, readFile)
 	return sb.String()

--- a/cmd/symbols/squirrel/http_handlers.go
+++ b/cmd/symbols/squirrel/http_handlers.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Responds to /localCodeIntel
-func LocalCodeIntelHandler(readFile ReadFileFunc) func(w http.ResponseWriter, r *http.Request) {
+func LocalCodeIntelHandler(readFile readFileFunc) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Read the args from the request body.
 		body, err := io.ReadAll(r.Body)
@@ -80,7 +80,7 @@ func LocalCodeIntelHandler(readFile ReadFileFunc) func(w http.ResponseWriter, r 
 }
 
 // Responds to /symbolInfo
-func NewSymbolInfoHandler(symbolSearch symbolsTypes.SearchFunc, readFile ReadFileFunc) func(w http.ResponseWriter, r *http.Request) {
+func NewSymbolInfoHandler(symbolSearch symbolsTypes.SearchFunc, readFile readFileFunc) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Read the args from the request body.
 		body, err := io.ReadAll(r.Body)

--- a/cmd/symbols/squirrel/service.go
+++ b/cmd/symbols/squirrel/service.go
@@ -17,12 +17,12 @@ import (
 )
 
 // How to read a file.
-type ReadFileFunc func(context.Context, types.RepoCommitPath) ([]byte, error)
+type readFileFunc func(context.Context, types.RepoCommitPath) ([]byte, error)
 
 // SquirrelService uses tree-sitter and the symbols service to analyze and traverse files to find
 // symbols.
 type SquirrelService struct {
-	readFile            ReadFileFunc
+	readFile            readFileFunc
 	symbolSearch        symbolsTypes.SearchFunc
 	breadcrumbs         Breadcrumbs
 	parser              *sitter.Parser
@@ -32,7 +32,7 @@ type SquirrelService struct {
 }
 
 // Creates a new SquirrelService.
-func New(readFile ReadFileFunc, symbolSearch symbolsTypes.SearchFunc) *SquirrelService {
+func New(readFile readFileFunc, symbolSearch symbolsTypes.SearchFunc) *SquirrelService {
 	return &SquirrelService{
 		readFile:            readFile,
 		symbolSearch:        symbolSearch,


### PR DESCRIPTION
The squirrel package requires cgo, which significantly increases the build (linking) time of the `frontend` build (by about 2x). During local development, omitting the local code intel functionality that requires cgo speeds up the build significantly. For production builds, cgo is still needed.

To use this, just build with `CGO_ENABLED=0`. Before this commit, that produces a compile error. After this commit, that compiles, but search-based code intel will show an error in the hovers. As such, and because we generally want dev to not diverge from prod builds, this will remain an undocumented dev setting until further notice.


## Test plan

The squirrel test suite will catch any issues.