### PR TITLE
web: make Exclude repository button width consistent during loading + fix spinner.

### DIFF
--- a/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -122,10 +122,10 @@ export const RepoSettingsOptionsPage: FC<Props> = ({ repo, history }) => {
                                     }}
                                     disabled={excludingDisabled || (exclusionInProgress && !isExcluding)}
                                 >
-                                    <span className={exclusionInProgress ? styles.invisibleText : ''}>
+                                    <span className={exclusionInProgress && isExcluding ? styles.invisibleText : ''}>
                                         Exclude repository from all code hosts
                                     </span>
-                                    {exclusionInProgress && <LoadingSpinner className={styles.loader} />}
+                                    {exclusionInProgress && isExcluding && <LoadingSpinner className={styles.loader} />}
                                 </Button>
                                 {excludeError && (
                                     <ErrorAlert error={`Failed to exclude repository: ${renderError(excludeError)}`} />

--- a/client/web/src/repo/settings/components/ExternalServiceEntry.module.scss
+++ b/client/web/src/repo/settings/components/ExternalServiceEntry.module.scss
@@ -8,6 +8,19 @@
     grid-column: 1 / 2;
 }
 
-.button {
+.grid-button {
     grid-column: 3;
+}
+
+.invisible-text {
+    visibility: hidden;
+}
+.button {
+    position: relative;
+}
+
+.loader {
+    position: absolute;
+    top: 25%;
+    left: 48%;
 }

--- a/client/web/src/repo/settings/components/ExternalServiceEntry.tsx
+++ b/client/web/src/repo/settings/components/ExternalServiceEntry.tsx
@@ -85,7 +85,7 @@ export const ExternalServiceEntry: FC<ExternalServiceEntryProps> = ({
                 )}
             </div>
             {service.supportsRepoExclusion && !(data && !error) && (
-                <div className={classNames(styles.button, 'mt-3')}>
+                <div className={classNames(styles.gridButton, 'mt-3')}>
                     <Tooltip
                         content={
                             excludingDisabled
@@ -95,6 +95,7 @@ export const ExternalServiceEntry: FC<ExternalServiceEntryProps> = ({
                     >
                         <Button
                             variant="primary"
+                            className={styles.button}
                             onClick={event => {
                                 event.preventDefault()
                                 updateExclusionLoading(true)
@@ -114,7 +115,8 @@ export const ExternalServiceEntry: FC<ExternalServiceEntryProps> = ({
                             }}
                             disabled={excludingDisabled || (excludingLoading && !isExcluding)}
                         >
-                            {isExcluding ? <LoadingSpinner className="mr-5 ml-5" /> : 'Exclude repository'}
+                            <span className={isExcluding ? styles.invisibleText : ''}>Exclude repository</span>
+                            {isExcluding && <LoadingSpinner className={styles.loader} />}
                         </Button>
                     </Tooltip>
                 </div>


### PR DESCRIPTION
This also fixes a spinner on "Exclude from all" button showing when other buttons are pushed.

Test plan:
Local sg run and manual test.

### Before
![excludeButtonJumpingDemo](https://user-images.githubusercontent.com/94846361/211294774-1f755a31-3e85-442b-981c-d1a7857000e0.gif)

### After
![excludeButtonNotJumpingDemo](https://user-images.githubusercontent.com/94846361/211297102-cb384ce7-5670-4aaf-be02-95b328843f36.gif)

## App preview:

- [Web](https://sg-web-ao-ui-exclude-repo-button-width.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
