### PR TITLE
codeintel: show commit tags in dependents/dependencies list for upload

### DIFF
--- a/client/web/src/enterprise/codeintel/uploads/components/DependencyOrDependentNode.tsx
+++ b/client/web/src/enterprise/codeintel/uploads/components/DependencyOrDependentNode.tsx
@@ -8,6 +8,7 @@ import { Link, H3, Icon } from '@sourcegraph/wildcard'
 import { LsifUploadFields } from '../../../../graphql-operations'
 import { CodeIntelState } from '../../shared/components/CodeIntelState'
 import { CodeIntelUploadOrIndexCommit } from '../../shared/components/CodeIntelUploadOrIndexCommit'
+import { CodeIntelUploadOrIndexCommitTags } from '../../shared/components/CodeIntelUploadOrIndexCommitTags'
 import { CodeIntelUploadOrIndexRepository } from '../../shared/components/CodeIntelUploadOrIndexerRepository'
 import { CodeIntelUploadOrIndexIndexer } from '../../shared/components/CodeIntelUploadOrIndexIndexer'
 import { CodeIntelUploadOrIndexRoot } from '../../shared/components/CodeIntelUploadOrIndexRoot'
@@ -35,7 +36,13 @@ export const DependencyOrDependentNode: FunctionComponent<React.PropsWithChildre
             <div>
                 <span className="mr-2 d-block d-mdinline-block">
                     Directory <CodeIntelUploadOrIndexRoot node={node} /> indexed at commit{' '}
-                    <CodeIntelUploadOrIndexCommit node={node} /> by <CodeIntelUploadOrIndexIndexer node={node} />
+                    <CodeIntelUploadOrIndexCommit node={node} />
+                    {node.tags.length > 0 && (
+                        <>
+                            , <CodeIntelUploadOrIndexCommitTags tags={node.tags} />,
+                        </>
+                    )}{' '}
+                    by <CodeIntelUploadOrIndexIndexer node={node} />
                 </span>
             </div>
         </div>


### PR DESCRIPTION
Displays the tags in dependencies/dependents of an upload, instead of only the commit

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/18282288/211317942-c06fb192-8561-4196-8fa4-bede11a32655.png)


</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/18282288/211317881-cd4648aa-0150-4d68-9951-6a1b5ff66d39.png)


</details>

## Test plan

Viewed the storybook :)

## App preview:

- [Web](https://sg-web-nsc-dependent-dependencies-tags.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
