### PR TITLE
Revert "Remove noop extension controler (#45926)"

### DIFF
--- a/client/shared/src/codeintel/api.ts
+++ b/client/shared/src/codeintel/api.ts
@@ -8,12 +8,16 @@ import {
     TextDocumentIdentifier,
     TextDocumentPositionParameters,
 } from '@sourcegraph/client-api'
+import { MaybeLoadingResult } from '@sourcegraph/codeintellify'
 // eslint-disable-next-line no-restricted-imports
 import { isDefined } from '@sourcegraph/common/src/types'
 import * as clientType from '@sourcegraph/extension-api-types'
 
 import { match } from '../api/client/types/textDocument'
+import { FlatExtensionHostAPI } from '../api/contract'
+import { proxySubscribable } from '../api/extension/api/common'
 import { toPosition } from '../api/extension/api/types'
+import { PanelViewData } from '../api/extension/extensionHostApi'
 import { getModeFromPath } from '../languages'
 import type { PlatformContext } from '../platform/context'
 import { isSettingsValid, Settings, SettingsCascade } from '../settings/settings'
@@ -191,4 +195,90 @@ function selectorForSpec(languageSpec: LanguageSpec): DocumentSelector {
 function newSettingsGetter(settingsCascade: SettingsCascade<Settings>): sourcegraph.SettingsGetter {
     return <T>(setting: string): T | undefined =>
         settingsCascade.final && (settingsCascade.final[setting] as T | undefined)
+}
+
+// Replaces codeintel functions from the "old" extension/webworker extension API
+// with new implementations of code that lives in this repository. The old
+// implementation invoked codeintel functions via webworkers, and the codeintel
+// implementation lived in a separate repository
+// https://github.com/sourcegraph/code-intel-extensions Ideally, we should
+// update all the usages of `comlink.Remote<FlatExtensionHostAPI>` with the new
+// `CodeIntelAPI` interfaces, but that would require refactoring a lot of files.
+// To minimize the risk of breaking changes caused by the deprecation of
+// extensions, we monkey patch the old implementation with new implementations.
+// The benefit of monkey patching is that we can optionally disable if for
+// customers that choose to enable the legacy extensions.
+export function injectNewCodeintel(
+    old: FlatExtensionHostAPI,
+    codeintelContext: sourcegraph.CodeIntelContext
+): FlatExtensionHostAPI {
+    const codeintel = createCodeIntelAPI(codeintelContext)
+    function thenMaybeLoadingResult<T>(promise: Observable<T>): Observable<MaybeLoadingResult<T>> {
+        return promise.pipe(
+            map(result => {
+                const maybeLoadingResult: MaybeLoadingResult<T> = { isLoading: false, result }
+                return maybeLoadingResult
+            })
+        )
+    }
+
+    const codeintelOverrides: Pick<
+        FlatExtensionHostAPI,
+        | 'getHover'
+        | 'getDocumentHighlights'
+        | 'getReferences'
+        | 'getDefinition'
+        | 'getLocations'
+        | 'hasReferenceProvidersForDocument'
+        | 'getPanelViews'
+    > = {
+        getPanelViews() {
+            const panels: PanelViewData[] = []
+            for (const spec of languageSpecs) {
+                if (spec.textDocumentImplemenationSupport) {
+                    const id = `implementations_${spec.languageID}`
+                    panels.push({
+                        id,
+                        content: '',
+                        component: { locationProvider: id },
+                        selector: selectorForSpec(spec),
+                        priority: 160,
+                        title: 'Implementations',
+                    })
+                }
+            }
+            return proxySubscribable(of(panels))
+        },
+        hasReferenceProvidersForDocument(textParameters) {
+            return proxySubscribable(codeintel.hasReferenceProvidersForDocument(textParameters))
+        },
+        getLocations(id, parameters) {
+            if (!id.startsWith('implementations_')) {
+                return proxySubscribable(thenMaybeLoadingResult(of([])))
+            }
+            return proxySubscribable(thenMaybeLoadingResult(codeintel.getImplementations(parameters)))
+        },
+        getDefinition(parameters) {
+            return proxySubscribable(thenMaybeLoadingResult(codeintel.getDefinition(parameters)))
+        },
+        getReferences(parameters, context) {
+            return proxySubscribable(thenMaybeLoadingResult(codeintel.getReferences(parameters, context)))
+        },
+        getDocumentHighlights: (textParameters: TextDocumentPositionParameters) =>
+            proxySubscribable(codeintel.getDocumentHighlights(textParameters)),
+        getHover: (textParameters: TextDocumentPositionParameters) =>
+            proxySubscribable(thenMaybeLoadingResult(codeintel.getHover(textParameters))),
+    }
+
+    return new Proxy(old, {
+        get(target, prop) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+            const codeintelFunction = (codeintelOverrides as any)[prop]
+            if (codeintelFunction) {
+                return codeintelFunction
+            }
+            // eslint-disable-next-line prefer-rest-params
+            return Reflect.get(target, prop, ...arguments)
+        },
+    })
 }

--- a/client/shared/src/extensions/createNoopLoadedController.ts
+++ b/client/shared/src/extensions/createNoopLoadedController.ts
@@ -1,0 +1,65 @@
+import { Remote } from 'comlink'
+import { from } from 'rxjs'
+import { switchMap } from 'rxjs/operators'
+
+import { ExposedToClient, initMainThreadAPI } from '../api/client/mainthread-api'
+import { FlatExtensionHostAPI } from '../api/contract'
+import { createExtensionHostAPI } from '../api/extension/extensionHostApi'
+import { createExtensionHostState } from '../api/extension/extensionHostState'
+import { pretendRemote, syncPromiseSubscription } from '../api/util'
+import { PlatformContext } from '../platform/context'
+import { isSettingsValid } from '../settings/settings'
+
+import { Controller } from './controller'
+
+export function createNoopController(platformContext: PlatformContext): Controller {
+    const api: Promise<{
+        remoteExtensionHostAPI: Remote<FlatExtensionHostAPI>
+        exposedToClient: ExposedToClient
+    }> = new Promise((resolve, reject) => {
+        platformContext.settings.subscribe(settingsCascade => {
+            ;(async () => {
+                const [injectNewCodeintel, newSettingsGetter] = await Promise.all([
+                    import('../codeintel/api').then(module => module.injectNewCodeintel),
+                    import('../codeintel/legacy-extensions/api').then(module => module.newSettingsGetter),
+                ])
+
+                if (!isSettingsValid(settingsCascade)) {
+                    throw new Error('Settings are not valid')
+                }
+
+                const extensionHostState = createExtensionHostState(
+                    {
+                        clientApplication: 'sourcegraph',
+                        initialSettings: settingsCascade,
+                    },
+                    null,
+                    null
+                )
+                const extensionHostAPI = injectNewCodeintel(createExtensionHostAPI(extensionHostState), {
+                    requestGraphQL: platformContext.requestGraphQL,
+                    telemetryService: platformContext.telemetryService,
+                    settings: newSettingsGetter(settingsCascade),
+                })
+                const remoteExtensionHostAPI = pretendRemote(extensionHostAPI)
+                const exposedToClient = initMainThreadAPI(remoteExtensionHostAPI, platformContext).exposedToClient
+
+                // We don't have to load any extensions so we are already done
+                extensionHostState.haveInitialExtensionsLoaded.next(true)
+
+                return { remoteExtensionHostAPI, exposedToClient }
+            })().then(resolve, reject)
+        })
+    })
+    return {
+        executeCommand: (parameters, suppressNotificationOnError) =>
+            api.then(({ exposedToClient }) => exposedToClient.executeCommand(parameters, suppressNotificationOnError)),
+        commandErrors: from(api).pipe(switchMap(({ exposedToClient }) => exposedToClient.commandErrors)),
+        registerCommand: entryToRegister =>
+            syncPromiseSubscription(
+                api.then(({ exposedToClient }) => exposedToClient.registerCommand(entryToRegister))
+            ),
+        extHostAPI: api.then(({ remoteExtensionHostAPI }) => remoteExtensionHostAPI),
+        unsubscribe: () => {},
+    }
+}

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -19,6 +19,7 @@ import { FetchFileParameters, fetchHighlightedFileLineRanges } from '@sourcegrap
 import { setCodeIntelSearchContext } from '@sourcegraph/shared/src/codeintel/searchContext'
 import { Controller as ExtensionsController } from '@sourcegraph/shared/src/extensions/controller'
 import { createController as createExtensionsController } from '@sourcegraph/shared/src/extensions/createLazyLoadedController'
+import { createNoopController } from '@sourcegraph/shared/src/extensions/createNoopLoadedController'
 import { BrandedNotificationItemStyleProps } from '@sourcegraph/shared/src/notifications/NotificationItem'
 import { Notifications } from '@sourcegraph/shared/src/notifications/Notifications'
 import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
@@ -178,7 +179,7 @@ export class SourcegraphWebApp extends React.Component<
     private readonly platformContext: PlatformContext = createPlatformContext()
     private readonly extensionsController: ExtensionsController | null = window.context.enableLegacyExtensions
         ? createExtensionsController(this.platformContext)
-        : null
+        : createNoopController(this.platformContext)
 
     constructor(props: SourcegraphWebAppProps) {
         super(props)


### PR DESCRIPTION
This reverts commit a0facbe1e0a883b3341e2fb98e21aaf69ae3b46e. (PR #45926)

I have mistakenly assumed that we have already changed the feature flags for code mirror and selection-driven navigation to be on by default which was only set for dotcom instead.

I’m reverting this for now and will land this again once I fix all wrong defaults in #46240. 

## Test plan

Tested locally with code mirror turned off and hover tooltips work again. Will also look out for CI errors.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-reenable-noop-extension.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
