### PR TITLE
codeintel: fix upload expiration dashboard

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -24416,7 +24416,7 @@ Query: `max(src_codeintel_commit_graph_queued_duration_seconds_total{job=~"^${so
 
 ### Code Intelligence > Uploads: Codeintel: Uploads > Expiration task
 
-#### codeintel-uploads: codeintel_background_repositories_scanned_total_total
+#### codeintel-uploads: codeintel_background_repositories_scanned_total
 
 <p class="subtitle">Lsif upload repository scan repositories scanned every 5m</p>
 
@@ -24431,13 +24431,13 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_background_repositories_scanned_total_total{job=~"^${source:regex}.*"}[5m]))`
+Query: `sum(increase(src_codeintel_background_repositories_scanned_total{job=~"^${source:regex}.*"}[5m]))`
 
 </details>
 
 <br />
 
-#### codeintel-uploads: codeintel_background_upload_records_scanned_total_total
+#### codeintel-uploads: codeintel_background_upload_records_scanned_total
 
 <p class="subtitle">Lsif upload records scan records scanned every 5m</p>
 
@@ -24452,13 +24452,13 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_background_upload_records_scanned_total_total{job=~"^${source:regex}.*"}[5m]))`
+Query: `sum(increase(src_codeintel_background_upload_records_scanned_total{job=~"^${source:regex}.*"}[5m]))`
 
 </details>
 
 <br />
 
-#### codeintel-uploads: codeintel_background_commits_scanned_total_total
+#### codeintel-uploads: codeintel_background_commits_scanned_total
 
 <p class="subtitle">Lsif upload commits scanned commits scanned every 5m</p>
 
@@ -24473,13 +24473,13 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_background_commits_scanned_total_total{job=~"^${source:regex}.*"}[5m]))`
+Query: `sum(increase(src_codeintel_background_commits_scanned_total{job=~"^${source:regex}.*"}[5m]))`
 
 </details>
 
 <br />
 
-#### codeintel-uploads: codeintel_background_upload_records_expired_total_total
+#### codeintel-uploads: codeintel_background_upload_records_expired_total
 
 <p class="subtitle">Lsif upload records expired uploads scanned every 5m</p>
 
@@ -24494,7 +24494,7 @@ To see this panel, visit `/-/debug/grafana/d/codeintel-uploads/codeintel-uploads
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_codeintel_background_upload_records_expired_total_total{job=~"^${source:regex}.*"}[5m]))`
+Query: `sum(increase(src_codeintel_background_upload_records_expired_total{job=~"^${source:regex}.*"}[5m]))`
 
 </details>
 

--- a/monitoring/definitions/shared/codeintel_uploads.go
+++ b/monitoring/definitions/shared/codeintel_uploads.go
@@ -231,28 +231,28 @@ func (codeIntelligence) NewUploadsExpirationTaskGroup(containerName string) moni
 		Rows: []monitoring.Row{
 			{
 				Standard.Count("repositories scanned")(ObservableConstructorOptions{
-					MetricNameRoot:        "codeintel_background_repositories_scanned_total",
+					MetricNameRoot:        "codeintel_background_repositories_scanned",
 					MetricDescriptionRoot: "lsif upload repository scan",
 				})(containerName, monitoring.ObservableOwnerCodeIntel).WithNoAlerts(`
 					Number of repositories scanned for data retention
 				`).Observable(),
 
 				Standard.Count("records scanned")(ObservableConstructorOptions{
-					MetricNameRoot:        "codeintel_background_upload_records_scanned_total",
+					MetricNameRoot:        "codeintel_background_upload_records_scanned",
 					MetricDescriptionRoot: "lsif upload records scan",
 				})(containerName, monitoring.ObservableOwnerCodeIntel).WithNoAlerts(`
 					Number of codeintel upload records scanned for data retention
 				`).Observable(),
 
 				Standard.Count("commits scanned")(ObservableConstructorOptions{
-					MetricNameRoot:        "codeintel_background_commits_scanned_total",
+					MetricNameRoot:        "codeintel_background_commits_scanned",
 					MetricDescriptionRoot: "lsif upload commits scanned",
 				})(containerName, monitoring.ObservableOwnerCodeIntel).WithNoAlerts(`
 					Number of commits reachable from a codeintel upload record scanned for data retention
 				`).Observable(),
 
 				Standard.Count("uploads scanned")(ObservableConstructorOptions{
-					MetricNameRoot:        "codeintel_background_upload_records_expired_total",
+					MetricNameRoot:        "codeintel_background_upload_records_expired",
 					MetricDescriptionRoot: "lsif upload records expired",
 				})(containerName, monitoring.ObservableOwnerCodeIntel).WithNoAlerts(`
 					Number of codeintel upload records marked as expired


### PR DESCRIPTION
Incorrectly had `_total_total` as the suffix (as `_total` is appended to the provided metric name)

See:
![image](https://user-images.githubusercontent.com/18282288/211339454-45b1c229-865e-4503-9dab-b5864365d374.png)



## Test plan

Generated dashboards.md looks correct, matches the names in https://sourcegraph.com/github.com/sourcegraph/sourcegraph@75ac20a1fa3ce797c97d06853163e581c051a82d/-/blob/enterprise/internal/codeintel/uploads/internal/background/metrics_expirer.go?L28%3A36-44%3A1
