### PR TITLE
Code Insights: Add human-readable gateway error message

### DIFF
--- a/client/web/src/enterprise/insights/core/hooks/live-preview-insight/use-live-preview-series-insight.ts
+++ b/client/web/src/enterprise/insights/core/hooks/live-preview-insight/use-live-preview-series-insight.ts
@@ -97,7 +97,9 @@ export function useLivePreviewSeriesInsight(props: Props): Result<Series<Datum>[
             return {
                 state: {
                     status: LivePreviewStatus.Error,
-                    error: new Error('Live preview is not available for this chart as it did not complete in the allowed time'),
+                    error: new Error(
+                        'Live preview is not available for this chart as it did not complete in the allowed time'
+                    ),
                 },
                 refetch,
             }

--- a/client/web/src/enterprise/insights/core/hooks/live-preview-insight/use-live-preview-series-insight.ts
+++ b/client/web/src/enterprise/insights/core/hooks/live-preview-insight/use-live-preview-series-insight.ts
@@ -167,5 +167,5 @@ function createPreviewSeriesContent(props: PreviewProps): Series<Datum>[] {
 }
 
 function isGatewayTimeoutError(error: ApolloError): boolean {
-    return error.networkError instanceof HTTPStatusError && error.networkError.status === 504;
+    return error.networkError instanceof HTTPStatusError && error.networkError.status === 504
 }

--- a/client/web/src/enterprise/insights/core/hooks/live-preview-insight/use-live-preview-series-insight.ts
+++ b/client/web/src/enterprise/insights/core/hooks/live-preview-insight/use-live-preview-series-insight.ts
@@ -1,8 +1,9 @@
 import { useMemo } from 'react'
 
-import { gql, useQuery } from '@apollo/client'
+import { ApolloError, gql, useQuery } from '@apollo/client'
 import { Duration } from 'date-fns'
 
+import { HTTPStatusError } from '@sourcegraph/http-client'
 import { Series } from '@sourcegraph/wildcard'
 
 import {
@@ -92,6 +93,16 @@ export function useLivePreviewSeriesInsight(props: Props): Result<Series<Datum>[
     }
 
     if (error) {
+        if (isGatewayTimeoutError(error)) {
+            return {
+                state: {
+                    status: LivePreviewStatus.Error,
+                    error: new Error('Live preview is not available for this chart as it will take longer to generate'),
+                },
+                refetch,
+            }
+        }
+
         return { state: { status: LivePreviewStatus.Error, error }, refetch }
     }
 
@@ -153,4 +164,8 @@ function createPreviewSeriesContent(props: PreviewProps): Series<Datum>[] {
         getYValue: datum => datum.value,
         getXValue: datum => datum.dateTime,
     }))
+}
+
+function isGatewayTimeoutError(error: ApolloError): boolean {
+    return error.networkError instanceof HTTPStatusError && error.networkError.status === 504;
 }

--- a/client/web/src/enterprise/insights/core/hooks/live-preview-insight/use-live-preview-series-insight.ts
+++ b/client/web/src/enterprise/insights/core/hooks/live-preview-insight/use-live-preview-series-insight.ts
@@ -97,7 +97,7 @@ export function useLivePreviewSeriesInsight(props: Props): Result<Series<Datum>[
             return {
                 state: {
                     status: LivePreviewStatus.Error,
-                    error: new Error('Live preview is not available for this chart as it will take longer to generate'),
+                    error: new Error('Live preview is not available for this chart as it did not complete in the allowed time'),
                 },
                 refetch,
             }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/43674

In this PR we catch only 504 timeout errors and pass everything else since I don't have any generic error message for all possible 5xx or 4xx errors. 

## Test plan
- Go to the creation UI 
- Try to run live preview insight (with probably any query over `github.com/sgtest/megarepo`
- Check that live preview has proper timeout error 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-timeout-preview-error.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
