### PR TITLE
Code Insights: Extend processing insight state message

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
@@ -149,11 +149,7 @@ function generateSeries(chartContent: SeriesChartContent<BackendInsightDatum>, i
             diffQuery: 'type:diff',
         })),
         status: {
-            backfillQueuedAt: '2021-06-06T15:48:11Z',
-            completedJobs: 0,
-            pendingJobs: isFetchingHistoricalData ? 10 : 0,
-            failedJobs: 0,
-            isLoading: isFetchingHistoricalData,
+            isLoadingData: isFetchingHistoricalData,
             incompleteDatapoints: series.alerts
                 ? [{ __typename: 'TimeoutDatapointAlert', time: '2022-04-21T01:13:43Z' }]
                 : [],

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -6,7 +6,7 @@ import { useMergeRefs } from 'use-callback-ref'
 import { isDefined } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Link, useDebounce, useDeepMemo } from '@sourcegraph/wildcard'
+import { Link, useDebounce, useDeepMemo, Text } from '@sourcegraph/wildcard'
 
 import {
     SeriesDisplayOptionsInput,
@@ -167,6 +167,21 @@ export const BackendInsightView = forwardRef<HTMLElement, BackendInsightProps>((
                     >
                         {insight.title}
                     </Link>
+                }
+                subtitle={
+                    isFetchingHistoricalData && (
+                        <Text size="small" className="text-muted">
+                            Datapoints shown may be undercounted.{' '}
+                            <Link
+                                to="/help/code_insights/explanations/current_limitations_of_code_insights#performance-speed-considerations-for-a-data-series-running-over-all-repositories"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                Processing
+                            </Link>{' '}
+                            time may vary depending on the insight’s scope.
+                        </Text>
+                    )
                 }
             >
                 {isVisible && (

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-alerts/BackendInsightAlerts.module.scss
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-alerts/BackendInsightAlerts.module.scss
@@ -22,6 +22,7 @@
 
     &--description {
         color: var(--text-muted);
+        text-align: center;
     }
 }
 

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-alerts/BackendInsightAlerts.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/backend-insight-alerts/BackendInsightAlerts.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react'
+import { FC, ReactNode } from 'react'
 
 import { mdiAlertCircle as mdiAlertCircleOutline } from '@mdi/js'
 import classNames from 'classnames'
@@ -40,7 +40,6 @@ export const BackendAlertOverlay: FC<BackendAlertOverLayProps> = props => {
         return (
             <AlertOverlay
                 title="This insight is still being processed"
-                description="Datapoints shown may be undercounted."
                 icon={<ProgressWrench className={classNames('mb-3')} size={33} />}
                 className={className}
             />
@@ -62,19 +61,19 @@ export const BackendAlertOverlay: FC<BackendAlertOverLayProps> = props => {
 
 export interface AlertOverlayProps {
     title: string
-    description: string
-    icon?: React.ReactNode
+    description?: ReactNode
+    icon?: ReactNode
     className?: string
 }
 
-const AlertOverlay: React.FunctionComponent<React.PropsWithChildren<AlertOverlayProps>> = props => {
+const AlertOverlay: FC<AlertOverlayProps> = props => {
     const { title, description, icon, className } = props
 
     return (
         <div className={classNames(className, styles.alertOverlay)}>
             {icon && <div className={styles.alertOverlayIcon}>{icon}</div>}
             <H4 className={styles.alertOverlayTitle}>{title}</H4>
-            <small className={styles.alertOverlayDescription}>{description}</small>
+            {description && <small className={styles.alertOverlayDescription}>{description}</small>}
         </div>
     )
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/43673

In this PR we extend the process message with link to our docs about processing time and current speed limitation for the all repositories insight (and actually any insight that has a big repository to run over)

Note that this implementation is different compared to original design version. 

| Design | Current Implementation |
| ------- | -------- | 
| <img width="607" alt="Screenshot 2023-01-09 at 16 36 59" src="https://user-images.githubusercontent.com/18492575/211393611-c765992e-0861-4d41-8b19-8f3c7cb2a009.png"> | <img width="426" alt="Screenshot 2023-01-09 at 16 36 11" src="https://user-images.githubusercontent.com/18492575/211393646-42f8015a-93ce-4565-83c9-c9d5862ac70b.png"> |

I had to move process message to the top (below the title block) because we currently we have logic that on hover or chart focus we hide in progress layout. And this logic makes sense because we want to explore the data even if it's not fully complete but there is a problem that since this PR we have interactive element within this layout (processing link) and this logic makes this link unreachable through mouse or keyboard. I move this message to the separate subtitle block in order to solve this problem.

## Test plan
- Create all repositories insight
- Check that new in process state looks good for different card sizes.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-insight-in-progress-message.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
