### PR TITLE
monitoring: change heatmap color scheme from viridis to turbo

### DIFF
--- a/monitoring/monitoring/panel_options.go
+++ b/monitoring/monitoring/panel_options.go
@@ -91,7 +91,7 @@ func (panelOptionsLibrary) basicPanel() ObservablePanelOption {
 				Expr: o.Query,
 			}}
 			h.Color.Mode = "spectrum"
-			h.Color.ColorScheme = "interpolateViridis"
+			h.Color.ColorScheme = "interpolateTurbo"
 			h.YAxis.LogBase = 2
 			h.Tooltip.Show = true
 			h.Tooltip.ShowHistogram = true


### PR DESCRIPTION
After exploring some different things we could do for the aggregate successful operation duration heatmap from the RED metrics (due to my complaints of the heatmap being of not great value due to the difficulty of seeing the data), we discovered a heatmap color scheme that makes the heatmaps _much_ more clear in the smaller count buckets.

Check out the before (left) vs the after (right) :man_cook::ok_hand: 

![image](https://user-images.githubusercontent.com/18282288/211395228-d0d2edd2-9a6a-4919-b4a9-82adbe43fd6b.png)


## Test plan

Ran grafana on dot-com data, had a :eye: and it looked :ok: 
