### PR TITLE
build: add @types/minimatch dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
     "@types/lru-cache": "^7.6.1",
     "@types/marked": "4.0.3",
     "@types/mime-types": "2.1.0",
+    "@types/minimatch": "^5.1.2",
     "@types/mocha": "8.2.0",
     "@types/mock-require": "^2.0.1",
     "@types/mockdate": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7954,6 +7954,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/minimatch@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "@types/minimatch@npm:5.1.2"
+  checksum: 0391a282860c7cb6fe262c12b99564732401bdaa5e395bee9ca323c312c1a0f45efbf34dce974682036e857db59a5c9b1da522f3d6055aeead7097264c8705a8
+  languageName: node
+  linkType: hard
+
 "@types/minimist@npm:^1.2.0":
   version: 1.2.0
   resolution: "@types/minimist@npm:1.2.0"
@@ -27570,6 +27577,7 @@ __metadata:
     "@types/lru-cache": ^7.6.1
     "@types/marked": 4.0.3
     "@types/mime-types": 2.1.0
+    "@types/minimatch": ^5.1.2
     "@types/mocha": 8.2.0
     "@types/mock-require": ^2.0.1
     "@types/mockdate": 2.0.0


### PR DESCRIPTION
The indirect dep was being used. Note the indirect dep is old so this is essentially an upgrade to the package.

## Test plan

CI

## App preview:

- [Web](https://sg-web-bazel-minimatch-types.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
