### PR TITLE
sg: Allow dev build of src-cli in checks

### DIFF
--- a/dev/sg/dependencies/helpers.go
+++ b/dev/sg/dependencies/helpers.go
@@ -261,6 +261,11 @@ func checkSrcCliVersion(versionConstraint string) func(context.Context) error {
 		}
 
 		trimmed := strings.TrimSpace(elems[2])
+
+		// If the user is using a local dev build, let them get away.
+		if trimmed == "dev" {
+			return nil
+		}
 		return check.Version("src", trimmed, versionConstraint)
 	}
 }


### PR DESCRIPTION
As a person working on src-cli regularly, I usually have a dev build running. This makes sg setup complain - so should we easy this constraint? 


## Test plan

n/a