### PR TITLE
web: add support of created and updated dates without authors in CreatedByAndUpdatedByInfoByline.

### DIFF
--- a/client/web/src/components/Byline/CreatedByAndUpdatedByInfoByline.story.tsx
+++ b/client/web/src/components/Byline/CreatedByAndUpdatedByInfoByline.story.tsx
@@ -32,6 +32,22 @@ export const NeverUpdated: Story = () => (
 
 NeverUpdated.storyName = 'Never updated'
 
+export const CreatedByDeletedUser: Story = () => (
+    <WebStory>
+        {props => (
+            <CreatedByAndUpdatedByInfoByline
+                {...props}
+                createdAt={THREE_DAYS_AGO}
+                createdBy={null}
+                updatedAt={THREE_DAYS_AGO}
+                updatedBy={null}
+            />
+        )}
+    </WebStory>
+)
+
+CreatedByDeletedUser.storyName = 'Created by deleted user'
+
 export const NeverUpdatedSSBC: Story = () => (
     <WebStory>
         {props => (
@@ -79,3 +95,18 @@ export const UpdatedDifferentUser: Story = () => (
 )
 
 UpdatedDifferentUser.storyName = 'Updated (different users)'
+
+export const DatesWithoutAuthors: Story = () => (
+    <WebStory>
+        {props => (
+            <CreatedByAndUpdatedByInfoByline
+                {...props}
+                createdAt={THREE_DAYS_AGO}
+                updatedAt={subDays(new Date(), 1).toISOString()}
+                noAuthor={true}
+            />
+        )}
+    </WebStory>
+)
+
+DatesWithoutAuthors.storyName = 'Created and updated dates without authors'

--- a/client/web/src/components/Byline/CreatedByAndUpdatedByInfoByline.tsx
+++ b/client/web/src/components/Byline/CreatedByAndUpdatedByInfoByline.tsx
@@ -9,26 +9,43 @@ type UserData = Maybe<Pick<UserAreaUserFields, 'url' | 'username'>>
 
 interface BylineProps {
     createdAt: string
-    createdBy: UserData
+    createdBy?: UserData
     updatedAt: Maybe<string>
-    updatedBy: UserData
+    updatedBy?: UserData
+    noAuthor?: boolean
 }
 
 /**
  * The created/updated byline containing information about creator, creation date, updater and update date.
  */
-export const CreatedByAndUpdatedByInfoByline: FC<BylineProps> = ({ createdAt, createdBy, updatedAt, updatedBy }) => (
-    <>
-        Created <Timestamp date={createdAt} /> by{' '}
-        {createdBy ? <Link to={createdBy.url}>{createdBy.username}</Link> : 'a deleted user'}
-        {updatedAt !== null && updatedAt !== createdAt && (
-            <>
-                <span className="mx-2">|</span>
-                Updated <Timestamp date={updatedAt} />
-                {updatedBy?.username !== createdBy?.username && (
-                    <> by {updatedBy ? <Link to={updatedBy.url}>{updatedBy.username}</Link> : 'a deleted user'}</>
-                )}
-            </>
-        )}
-    </>
-)
+export const CreatedByAndUpdatedByInfoByline: FC<BylineProps> = ({
+    createdAt,
+    createdBy,
+    updatedAt,
+    updatedBy,
+    noAuthor,
+}) => {
+    const createdByPart = noAuthor ? (
+        ''
+    ) : (
+        <> by {createdBy ? <Link to={createdBy.url}>{createdBy.username}</Link> : 'a deleted user'}</>
+    )
+    const updatedPart = (
+        <>
+            {updatedAt !== null && updatedAt !== createdAt && (
+                <>
+                    <span className="mx-2">|</span>
+                    Updated <Timestamp date={updatedAt} />
+                    {updatedBy?.username !== createdBy?.username && (
+                        <> by {updatedBy ? <Link to={updatedBy.url}>{updatedBy.username}</Link> : 'a deleted user'}</>
+                    )}
+                </>
+            )}
+        </>
+    )
+    return (
+        <>
+            Created <Timestamp date={createdAt} /> {createdByPart} {updatedPart}
+        </>
+    )
+}

--- a/client/web/src/components/Byline/CreatedByAndUpdatedByInfoByline.tsx
+++ b/client/web/src/components/Byline/CreatedByAndUpdatedByInfoByline.tsx
@@ -25,9 +25,7 @@ export const CreatedByAndUpdatedByInfoByline: FC<BylineProps> = ({
     updatedBy,
     noAuthor,
 }) => {
-    const createdByPart = noAuthor ? (
-        ''
-    ) : (
+    const createdByPart = noAuthor ?? (
         <> by {createdBy ? <Link to={createdBy.url}>{createdBy.username}</Link> : 'a deleted user'}</>
     )
     const updatedPart = (


### PR DESCRIPTION
Note: We cannot derive `noAuthor` from checking that both `createdBy` and `updatedBy` are null, because it clashes with a case when there is only created date and the user is deleted (we need to show "by a deleted user" in this case).

Test plan:
Storybook, local sg run and manual checks.

Part of https://github.com/sourcegraph/sourcegraph/issues/46033 (external services doesn't have create/update authors for now, but we still need to show dates in header byline)

## App preview:

- [Web](https://sg-web-ao-ui-created-updated-byline-no.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
