### PR TITLE
Add an icon on selected reference panel lines that explains that another click opens the line in the blob view

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -110,13 +110,13 @@
     }
 
     &--active-icon {
-        width: 20px;
-        height: 18px;
+        width: 1.25rem;
+        height: 100%;
         position: absolute;
         right: 0;
         top: 0;
         background-color: var(--color-bg-1);
-        padding-left: 2px;
+        padding-left: 0.25rem;
     }
 
     &--link:hover {

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -99,6 +99,7 @@
     display: flex;
     flex-direction: column;
     min-height: 18px;
+    position: relative;
 
     &:not(:last-child) > &--link {
         border-bottom: 1px solid var(--body-bg);
@@ -106,6 +107,16 @@
 
     &--active {
         background-color: var(--color-bg-3);
+    }
+
+    &--active-icon {
+        width: 20px;
+        height: 18px;
+        position: absolute;
+        right: 0;
+        top: 0;
+        background-color: var(--color-bg-1);
+        padding-left: 2px;
     }
 
     &--link:hover {

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -117,6 +117,9 @@
         top: 0;
         background-color: var(--color-bg-1);
         padding-left: 0.25rem;
+        display: flex;
+        justify-content: center;
+        align-items: center;
     }
 
     &--link:hover {

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -111,6 +111,7 @@
 
     &--active-icon {
         width: 1.35rem;
+        // stylelint-disable-next-line declaration-property-unit-allowed-list
         height: calc(100% - 1px);
         position: absolute;
         right: 0;

--- a/client/web/src/codeintel/ReferencesPanel.module.scss
+++ b/client/web/src/codeintel/ReferencesPanel.module.scss
@@ -110,13 +110,14 @@
     }
 
     &--active-icon {
-        width: 1.25rem;
-        height: 100%;
+        width: 1.35rem;
+        height: calc(100% - 1px);
         position: absolute;
         right: 0;
         top: 0;
-        background-color: var(--color-bg-1);
+        background-color: var(--color-bg-3);
         padding-left: 0.25rem;
+        padding-right: 0.1rem;
         display: flex;
         justify-content: center;
         align-items: center;

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -1,13 +1,12 @@
 import React, { KeyboardEvent, MouseEvent, useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 
-import { mdiArrowCollapseRight, mdiChevronDown, mdiChevronUp, mdiFilterOutline } from '@mdi/js'
+import { mdiArrowCollapseRight, mdiChevronDown, mdiChevronUp, mdiFilterOutline, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 import * as H from 'history'
 import { capitalize, uniqBy } from 'lodash'
 import { MemoryRouter, useLocation } from 'react-router'
 import { Observable, of } from 'rxjs'
 import { map } from 'rxjs/operators'
-import { mdiOpenInNew } from '@mdi/js'
 
 import { HoveredToken } from '@sourcegraph/codeintellify'
 import {

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -7,6 +7,7 @@ import { capitalize, uniqBy } from 'lodash'
 import { MemoryRouter, useLocation } from 'react-router'
 import { Observable, of } from 'rxjs'
 import { map } from 'rxjs/operators'
+import { mdiOpenInNew } from '@mdi/js'
 
 import { HoveredToken } from '@sourcegraph/codeintellify'
 import {
@@ -1013,6 +1014,8 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                         <ul className="list-unstyled mb-0">
                             {group.locations.map((reference, index) => {
                                 const isActive = isActiveLocation(reference)
+                                const isFirstInActive =
+                                    isActive && !(index > 0 && isActiveLocation(group.locations[index - 1]))
                                 const locationActive = isActive ? styles.locationActive : ''
                                 const selectReference = (
                                     event: KeyboardEvent<HTMLElement> | MouseEvent<HTMLElement>
@@ -1061,6 +1064,20 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                                                     fetchPlainTextFileRangeLines(reference)
                                                 }
                                             />
+                                            {isFirstInActive ? (
+                                                <span className={classNames('ml-2', styles.locationActiveIcon)}>
+                                                    <Tooltip
+                                                        content="Click again to open line in full view"
+                                                        placement="left"
+                                                    >
+                                                        <Icon
+                                                            aria-label="Open line in full view"
+                                                            size="sm"
+                                                            svgPath={mdiOpenInNew}
+                                                        />
+                                                    </Tooltip>
+                                                </span>
+                                            ) : null}
                                         </div>
                                     </li>
                                 )


### PR DESCRIPTION
Follow-up to the discussion from https://github.com/sourcegraph/sourcegraph/pull/46052#discussion_r1061283093

We currently have a little-known feature in the references panel where clicking a reference that is already selected again will open the line in the blob view. 

Since I myself wasn't aware of this feature, I thought that maybe an icon can be used to explain what's going on. I decided to only show this icon when the line is selected to avoid visual clutter. If there are multiple matches on the selected line, only the first will show the icon.

What do you think about this?

## Test plan

![](https://user-images.githubusercontent.com/458591/211781559-c488bf87-1a8e-43fc-a7eb-5fe74dd7c270.png)

I also tested this feature via:
- Tab navigation (the icon is tab-navigateable and will show the tooltip on focus)
- Increasing browser zoom level
- Increasing root font-size


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-explain-double-click-to-open.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
