### PR TITLE
web: lower `.card` priority

### DIFF
--- a/client/wildcard/src/components/Card/Card.module.scss
+++ b/client/wildcard/src/components/Card/Card.module.scss
@@ -18,7 +18,7 @@
     border-width: 1px;
     border-style: solid;
     border-color: var(--card-border-color);
-    border-radius: var(--card-border-radius);
+    border-radius: var(--card-border-radius) !important;
 }
 
 button.card {

--- a/client/wildcard/src/components/Card/Card.module.scss
+++ b/client/wildcard/src/components/Card/Card.module.scss
@@ -1,4 +1,6 @@
-.card {
+// :where() is used to fix the CSS ordering issue with the Toast component
+// See https: //github.com/sourcegraph/sourcegraph/issues/42217
+:where(.card) {
     --card-bg: var(--color-bg-1);
     --card-border-color: var(--border-color-2);
     --card-border-radius: var(--border-radius);


### PR DESCRIPTION
## Context

- Fixes [the issue](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1673011815990209) with inconsistent CSS order in the production bundle for the `Card` component.
- The underlying issue https://github.com/sourcegraph/sourcegraph/issues/42217

To address the root cause, we need to invest more time in restructuring Wildcard exports, as described in the linked issue.

> Restructure exports in packages with CSS modules to enable tree-shaking without relying on the `sideEffects` property.

## Test plan

1. `sg start web-standalone-prod`
2. Check that the toast is styled correctly.

## App preview:

- [Web](https://sg-web-vb-card-css-order.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

