### PR TITLE
dbworker: do not return pointer to ResetterMetrics

### DIFF
--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -167,5 +167,5 @@ func newWorkerMetrics(observationCtx *observation.Context, workerName string) (w
 		return true
 	}))
 	resetterMetrics := dbworker.NewResetterMetrics(observationCtx, workerName)
-	return workerMetrics, *resetterMetrics
+	return workerMetrics, resetterMetrics
 }

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -79,7 +79,7 @@ func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*worker
 	resetter := dbworker.NewResetter(log.Scoped("", ""), workerStore, dbworker.ResetterOptions{
 		Name:     fmt.Sprintf("%s_resetter", name),
 		Interval: time.Second * 20,
-		Metrics:  *dbworker.NewResetterMetrics(config.ObservationCtx, name),
+		Metrics:  dbworker.NewResetterMetrics(config.ObservationCtx, name),
 	})
 
 	configLogger := log.Scoped("insightsInProgressConfigWatcher", "")

--- a/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
@@ -76,7 +76,7 @@ func makeNewBackfillWorker(ctx context.Context, config JobMonitorConfig) (*worke
 	resetter := dbworker.NewResetter(log.Scoped("BackfillNewResetter", ""), workerStore, dbworker.ResetterOptions{
 		Name:     fmt.Sprintf("%s_resetter", name),
 		Interval: time.Second * 20,
-		Metrics:  *dbworker.NewResetterMetrics(config.ObservationCtx, name),
+		Metrics:  dbworker.NewResetterMetrics(config.ObservationCtx, name),
 	})
 
 	return worker, resetter, workerStore

--- a/internal/repos/webhook_build_job.go
+++ b/internal/repos/webhook_build_job.go
@@ -60,5 +60,5 @@ func (w *webhookBuildJob) Routines(_ context.Context, observationCtx *observatio
 func newWebhookBuildWorkerMetrics(observationCtx *observation.Context, workerName string) (workerutil.WorkerObservability, dbworker.ResetterMetrics) {
 	workerMetrics := workerutil.NewMetrics(observationCtx, fmt.Sprintf("%s_processor", workerName))
 	resetterMetrics := dbworker.NewResetterMetrics(observationCtx, workerName)
-	return workerMetrics, *resetterMetrics
+	return workerMetrics, resetterMetrics
 }

--- a/internal/workerutil/dbworker/resetter.go
+++ b/internal/workerutil/dbworker/resetter.go
@@ -47,7 +47,7 @@ type ResetterMetrics struct {
 // standard naming convention. The base metric name should be the same metric
 // name provided to a `worker` ex. my_job_queue. Do not provide prefix "src" or
 // postfix "_record...".
-func NewResetterMetrics(observationCtx *observation.Context, metricNameRoot string) *ResetterMetrics {
+func NewResetterMetrics(observationCtx *observation.Context, metricNameRoot string) ResetterMetrics {
 	resets := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "src_" + metricNameRoot + "_record_resets_total",
 		Help: "The number of stalled record resets.",
@@ -67,7 +67,7 @@ func NewResetterMetrics(observationCtx *observation.Context, metricNameRoot stri
 	})
 	observationCtx.Registerer.MustRegister(resetErrors)
 
-	return &ResetterMetrics{
+	return ResetterMetrics{
 		RecordResets:        resets,
 		RecordResetFailures: resetFailures,
 		Errors:              resetErrors,


### PR DESCRIPTION
Tiny thing, but I ran into this on another PR: why return a pointer that's dereferenced at every call site? Just return that chonky struct


## Test plan

- Existing tests