### PR TITLE
Fix commits table name column sizes

### DIFF
--- a/client/web/src/repo/commits/GitCommitNode.module.scss
+++ b/client/web/src/repo/commits/GitCommitNode.module.scss
@@ -22,7 +22,7 @@
         min-width: 25%;
 
         @media (--md-breakpoint-up) {
-           width: 25%
+            width: 25%;
         }
 
         flex: none;

--- a/client/web/src/repo/commits/GitCommitNode.module.scss
+++ b/client/web/src/repo/commits/GitCommitNode.module.scss
@@ -20,6 +20,11 @@
 
     &--compact .byline {
         min-width: 25%;
+
+        @media (--md-breakpoint-up) {
+           width: 25%
+        }
+
         flex: none;
         padding-right: 1.5rem;
         overflow: hidden;

--- a/client/web/src/repo/commits/GitCommitNodeByline.tsx
+++ b/client/web/src/repo/commits/GitCommitNodeByline.tsx
@@ -91,7 +91,7 @@ export const GitCommitNodeByline: React.FunctionComponent<React.PropsWithChildre
                     />
                 </Tooltip>
             </div>
-            <div className="overflow-hidden">
+            <div className="text-truncate">
                 {!compact && (
                     <>
                         {messageElement}


### PR DESCRIPTION
The name column in the commits table of the repo page is sometimes causing the commit message to shift to the left. This then does not look like a table anymore so here's a quick fix for it.

## Before

<img width="823" alt="Screenshot 2023-01-10 at 12 18 22" src="https://user-images.githubusercontent.com/458591/211537629-c7134d2c-cf18-46e2-8867-310e786b473f.png">

## Test plan

https://user-images.githubusercontent.com/458591/211538730-572e0f44-61cb-43bc-96af-4bc8935a9a12.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
