### PR TITLE
endpoint: allow empty Maps to disable Zoekt

### DIFF
--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -587,6 +587,9 @@ func computeIndexedEndpoints() *endpoint.Map {
 	indexedEndpointsOnce.Do(func() {
 		if addr := zoektAddr(os.Environ()); addr != "" {
 			indexedEndpoints = endpoint.New(addr)
+		} else {
+			// It is OK to have no indexed search endpoints.
+			indexedEndpoints = endpoint.Static()
 		}
 	})
 	return indexedEndpoints

--- a/internal/endpoint/k8s.go
+++ b/internal/endpoint/k8s.go
@@ -73,6 +73,16 @@ func k8sDiscovery(logger log.Logger, urlspec, ns string, clientFactory func() (*
 				log.Strings("endpoints", eps),
 			)
 
+			if len(eps) == 0 {
+				err := errors.Errorf(
+					"no %s endpoints could be found (this may indicate more %s replicas are needed, contact support@sourcegraph.com for assistance)",
+					u.Service,
+					u.Service,
+				)
+				disco <- endpoints{Service: u.Service, Error: err}
+				return
+			}
+
 			disco <- endpoints{Service: u.Service, Endpoints: eps}
 		}
 


### PR DESCRIPTION
This is an alternative implementation of https://github.com/sourcegraph/sourcegraph/pull/45797

The difference is instead of making all call sites explicitly handle an empty error, we allow empty maps and only return an error if you try to do a lookup on it. In practice most we won't do lookups if Endpoints returns an empty list.

See individual commits. What follows is the description for what this PR is.

The only service discovery we support is via k8s. We want to ensure that is working, so we have the invariant that if its empty we make all Map lookups fail. However, this means that even if we explicitly wanted an empty Map those would also fail (once communicated via config's ServiceConnections).

This moves the enforcement of the invariant from the discovery loop to just the k8s discovery code. Now our ServiceConnections based discovery can return an empty list.

Additionally this allows us to simplify the condition around how we take discovered endpoints/errors and update the map. This is because in all functions on Map if err is non-nil we return the error.

Finally we treat an empty zoekt host variable (which needs to be done explicitly) as a way to disable zoekt.

Test Plan: go test and manual testing. I disabled zoekt in my dev env with patch below. I then tested searching still worked as well as browsing things like the repos page in site admin.

``` diff
diff --git a/sg.config.yaml b/sg.config.yaml
index f13c208a82..8bd8f49e45 100644
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -23,7 +23,7 @@ env:
   SRC_GIT_SERVERS: 127.0.0.1:3501 127.0.0.1:3502

   # Enable sharded indexed search mode:
-  INDEXED_SEARCH_SERVERS: localhost:3070 localhost:3071
+  INDEXED_SEARCH_SERVERS: ''

   GO111MODULE: 'on'

@@ -839,10 +839,6 @@ commandsets:
       - docsite
       - syntax-highlighter
       - github-proxy
-      - zoekt-index-0
-      - zoekt-index-1
-      - zoekt-web-0
-      - zoekt-web-1

   enterprise: &enterprise_set
     requiresDevPrivate: true
```
