### PR TITLE
codeintel: dont swallow errors in upload retry mechanism

### DIFF
--- a/lib/codeintel/upload/retry.go
+++ b/lib/codeintel/upload/retry.go
@@ -7,24 +7,26 @@ import "time"
 type RetryableFunc = func(attempt int) (bool, error)
 
 // makeRetry returns a function that calls retry with the given max attempt and interval values.
-func makeRetry(n int, interval time.Duration) func(f RetryableFunc) error {
-	return func(f RetryableFunc) error {
+func makeRetry(n int, interval time.Duration) func(f RetryableFunc) []error {
+	return func(f RetryableFunc) []error {
 		return retry(f, n, interval)
 	}
 }
 
 // retry will re-invoke the given function until it returns a nil error value, the function returns
 // a non-retryable error (as indicated by its boolean return value), or until the maximum number of
-// retries have been attempted. The returned error will be the last error to occur.
-func retry(f RetryableFunc, n int, interval time.Duration) (err error) {
-	var retry bool
+// retries have been attempted. All errors encountered will be returned.
+func retry(f RetryableFunc, n int, interval time.Duration) (errs []error) {
 	for i := 0; i <= n; i++ {
-		if retry, err = f(i); err == nil || !retry {
+		retry, err := f(i)
+		if err == nil || !retry {
 			break
 		}
+
+		errs = append(errs, err)
 
 		time.Sleep(interval)
 	}
 
-	return err
+	return errs
 }

--- a/lib/codeintel/upload/retry.go
+++ b/lib/codeintel/upload/retry.go
@@ -1,14 +1,18 @@
 package upload
 
-import "time"
+import (
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
 
 // RetryableFunc is a function that takes the invocation index and returns an error as well as a
 // boolean-value flag indicating whether or not the error is considered retryable.
 type RetryableFunc = func(attempt int) (bool, error)
 
 // makeRetry returns a function that calls retry with the given max attempt and interval values.
-func makeRetry(n int, interval time.Duration) func(f RetryableFunc) []error {
-	return func(f RetryableFunc) []error {
+func makeRetry(n int, interval time.Duration) func(f RetryableFunc) error {
+	return func(f RetryableFunc) error {
 		return retry(f, n, interval)
 	}
 }
@@ -16,14 +20,15 @@ func makeRetry(n int, interval time.Duration) func(f RetryableFunc) []error {
 // retry will re-invoke the given function until it returns a nil error value, the function returns
 // a non-retryable error (as indicated by its boolean return value), or until the maximum number of
 // retries have been attempted. All errors encountered will be returned.
-func retry(f RetryableFunc, n int, interval time.Duration) (errs []error) {
+func retry(f RetryableFunc, n int, interval time.Duration) (errs error) {
 	for i := 0; i <= n; i++ {
 		retry, err := f(i)
+
+		errs = errors.CombineErrors(errs, err)
+
 		if err == nil || !retry {
 			break
 		}
-
-		errs = append(errs, err)
 
 		time.Sleep(interval)
 	}


### PR DESCRIPTION
Previously, only the final error in the retry chain would be displayed on error. This caused an issue where a prior error (that was the actual issue) was being swallowed, and the follow-on errors changed due to backend behaviour, obscuring the original cause. Needs a bump in https://github.com/sourcegraph/src-cli too.

New example output:

```
✅ Index compressed
💡 Indexed compressed (36806.72MB -> 4161.87MB).
✅ Prepared multipart upload
✅ Index parts uploaded
❌ Failed to finalize multipart upload (will retry; attempt #1)
❌ Failed to finalize multipart upload (will retry; attempt #2)
❌ Failed to finalize multipart upload (will retry; attempt #3)
❌ Failed to finalize multipart upload (will retry; attempt #4)
❌ Failed to finalize multipart upload (will retry; attempt #5)
❌ Failed to finalize multipart upload
6 errors occurred:
        * unexpected status code: 500 (failed to enqueue payload: ERROR: smallint out of range (SQLSTATE 22003))
        * unexpected status code: 500 (failed to enqueue payload: 42 errors occurred:
        * failed to upload part: api error NoSuchKey: The specified key does not exist.
        <SNIP>)
        * unexpected status code: 500 (failed to enqueue payload: 42 errors occurred:
        * failed to upload part: api error NoSuchKey: The specified key does not exist.
        <SNIP>)
        * unexpected status code: 500 (failed to enqueue payload: 42 errors occurred:
        * failed to upload part: api error NoSuchKey: The specified key does not exist.
        <SNIP>)
        * unexpected status code: 500 (failed to enqueue payload: 42 errors occurred:
        * failed to upload part: api error NoSuchKey: The specified key does not exist.
        <SNIP>)
        * unexpected status code: 500 (failed to enqueue payload: 42 errors occurred:
        * failed to upload part: api error NoSuchKey: The specified key does not exist.
       <SNIP>)
```

## Test plan

Tested locally by changing audit logs `upload_size` to smallint :slightly_smiling_face: 
