### PR TITLE
monitoring: export (*Dashboard).RenderPrometheusRules()

### DIFF
--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -265,7 +265,7 @@ func generateAll(
 
 	// Generate additional Prometheus assets
 	if opts.PrometheusDir != "" {
-		customRules, err := customPrometheusRules(opts.InjectLabelMatchers)
+		customRules, err := CustomPrometheusRules(opts.InjectLabelMatchers)
 		if err != nil {
 			return generatedAssets, errors.Wrap(err, "failed to generate custom rules")
 		}

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -246,7 +246,7 @@ func generateAll(
 			plog := dlog.Scoped("prometheus", "prometheus rules generation")
 
 			plog.Debug("Rendering Prometheus assets")
-			promAlertsFile, err := dashboard.renderRules(opts.InjectLabelMatchers)
+			promAlertsFile, err := dashboard.RenderPrometheusRules(opts.InjectLabelMatchers)
 			if err != nil {
 				return generatedAssets, errors.Wrapf(err, "Unable to generate alerts for dashboard %q", dashboard.Title)
 			}

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -333,13 +333,13 @@ func (c *Dashboard) alertDescription(o Observable, alert *ObservableAlertDefinit
 	return description, nil
 }
 
-// renderRules generates the Prometheus rules file which defines our
+// RenderPrometheusRules generates the Prometheus rules file which defines our
 // high-level alerting metrics for the container. For more information about
 // how these work, see:
 //
 // https://docs.sourcegraph.com/admin/observability/metrics#high-level-alerting-metrics
-func (c *Dashboard) renderRules(injectLabelMatchers []*labels.Matcher) (*promRulesFile, error) {
-	group := promGroup{Name: c.Name}
+func (c *Dashboard) RenderPrometheusRules(injectLabelMatchers []*labels.Matcher) (*prometheusRules, error) {
+	group := prometheusGroup{Name: c.Name}
 	for groupIndex, g := range c.Groups {
 		for rowIndex, r := range g.Rows {
 			for observableIndex, o := range r {
@@ -389,8 +389,8 @@ func (c *Dashboard) renderRules(injectLabelMatchers []*labels.Matcher) (*promRul
 	if err := group.validate(); err != nil {
 		return nil, err
 	}
-	return &promRulesFile{
-		Groups: []promGroup{group},
+	return &prometheusRules{
+		Groups: []prometheusGroup{group},
 	}, nil
 }
 

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -339,7 +339,7 @@ func (c *Dashboard) alertDescription(o Observable, alert *ObservableAlertDefinit
 //
 // https://docs.sourcegraph.com/admin/observability/metrics#high-level-alerting-metrics
 func (c *Dashboard) RenderPrometheusRules(injectLabelMatchers []*labels.Matcher) (*PrometheusRules, error) {
-	group := PrometheusGroup{Name: c.Name}
+	group := newPrometheusRuleGroup(c.Name)
 	for groupIndex, g := range c.Groups {
 		for rowIndex, r := range g.Rows {
 			for observableIndex, o := range r {
@@ -390,7 +390,7 @@ func (c *Dashboard) RenderPrometheusRules(injectLabelMatchers []*labels.Matcher)
 		return nil, err
 	}
 	return &PrometheusRules{
-		Groups: []PrometheusGroup{group},
+		Groups: []PrometheusRuleGroup{group},
 	}, nil
 }
 

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -338,8 +338,8 @@ func (c *Dashboard) alertDescription(o Observable, alert *ObservableAlertDefinit
 // how these work, see:
 //
 // https://docs.sourcegraph.com/admin/observability/metrics#high-level-alerting-metrics
-func (c *Dashboard) RenderPrometheusRules(injectLabelMatchers []*labels.Matcher) (*prometheusRules, error) {
-	group := prometheusGroup{Name: c.Name}
+func (c *Dashboard) RenderPrometheusRules(injectLabelMatchers []*labels.Matcher) (*PrometheusRules, error) {
+	group := PrometheusGroup{Name: c.Name}
 	for groupIndex, g := range c.Groups {
 		for rowIndex, r := range g.Rows {
 			for observableIndex, o := range r {
@@ -389,8 +389,8 @@ func (c *Dashboard) RenderPrometheusRules(injectLabelMatchers []*labels.Matcher)
 	if err := group.validate(); err != nil {
 		return nil, err
 	}
-	return &prometheusRules{
-		Groups: []prometheusGroup{group},
+	return &PrometheusRules{
+		Groups: []PrometheusGroup{group},
 	}, nil
 }
 

--- a/monitoring/monitoring/prometheus.go
+++ b/monitoring/monitoring/prometheus.go
@@ -43,20 +43,20 @@ func (r *promRule) validate() error {
 	return nil
 }
 
-// promRulesFile represents a Prometheus recording rules file (which we use for defining our alerts)
+// prometheusRules represents a Prometheus recording rules file (which we use for defining our alerts)
 // see:
 //
 // https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
-type promRulesFile struct {
-	Groups []promGroup
+type prometheusRules struct {
+	Groups []prometheusGroup
 }
 
-type promGroup struct {
+type prometheusGroup struct {
 	Name  string
 	Rules []promRule
 }
 
-func (g *promGroup) validate() error {
+func (g *prometheusGroup) validate() error {
 	if g.Name == "" {
 		return errors.New("promGroup requires name")
 	}
@@ -68,7 +68,7 @@ func (g *promGroup) validate() error {
 	return nil
 }
 
-func (g *promGroup) appendRow(alertQuery string, labels map[string]string, duration time.Duration) {
+func (g *prometheusGroup) appendRow(alertQuery string, labels map[string]string, duration time.Duration) {
 	labels["alert_type"] = "builtin" // indicate alert is generated
 	var forDuration *model.Duration
 	if duration > 0 {
@@ -97,7 +97,7 @@ func (g *promGroup) appendRow(alertQuery string, labels map[string]string, durat
 		})
 }
 
-func customPrometheusRules(injectLabelMatchers []*labels.Matcher) (*promRulesFile, error) {
+func customPrometheusRules(injectLabelMatchers []*labels.Matcher) (*prometheusRules, error) {
 	// Hardcode the desired label matcher values as labels
 	labels := make(map[string]string)
 	for _, matcher := range injectLabelMatchers {
@@ -113,8 +113,8 @@ func customPrometheusRules(injectLabelMatchers []*labels.Matcher) (*promRulesFil
 		return injected
 	}
 
-	rulesFile := &promRulesFile{
-		Groups: []promGroup{{
+	rulesFile := &prometheusRules{
+		Groups: []prometheusGroup{{
 			Name: "cadvisor.rules",
 			Rules: []promRule{{
 				// The number of CPUs allocated to the container according to the configured Docker / Kubernetes limits.

--- a/monitoring/monitoring/prometheus.go
+++ b/monitoring/monitoring/prometheus.go
@@ -15,7 +15,7 @@ const (
 	alertRulesFileSuffix = "_alert_rules.yml"
 )
 
-var defaultRuleEvaluationInterval = 30 * time.Second
+var defaultRuleEvaluationInterval = model.Duration(30 * time.Second)
 
 // prometheusAlertName creates an alertname that is unique given the combination of parameters
 func prometheusAlertName(level, service, name string) string {
@@ -56,7 +56,7 @@ type PrometheusRules struct {
 type PrometheusRuleGroup struct {
 	Name     string           `json:"name"`
 	Rules    []PrometheusRule `json:"rules"`
-	Interval *time.Duration   `json:"interval"`
+	Interval *model.Duration  `json:"interval"`
 }
 
 func newPrometheusRuleGroup(name string) PrometheusRuleGroup {

--- a/monitoring/monitoring/prometheus.go
+++ b/monitoring/monitoring/prometheus.go
@@ -23,14 +23,14 @@ func prometheusAlertName(level, service, name string) string {
 // PrometheusRule is a subset of a Prometheus recording or alert rule definition.
 type PrometheusRule struct {
 	// either Record or Alert
-	Record string `yaml:",omitempty"` // https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
-	Alert  string `yaml:",omitempty"` // https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+	Record string `yaml:",omitempty" json:"record,omitempty"` // https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
+	Alert  string `yaml:",omitempty" json:"alert,omitempty"`  // https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
 
-	Labels map[string]string `yaml:",omitempty"`
-	Expr   string
+	Labels map[string]string `yaml:",omitempty" json:"labels,omitempty"`
+	Expr   string            `json:"expr,omitempty"`
 
 	// for Alert only
-	For *model.Duration `yaml:",omitempty"`
+	For *model.Duration `yaml:",omitempty" json:"for,omitempty"`
 }
 
 func (r *PrometheusRule) validate() error {
@@ -48,12 +48,12 @@ func (r *PrometheusRule) validate() error {
 //
 // https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
 type PrometheusRules struct {
-	Groups []PrometheusGroup
+	Groups []PrometheusGroup `json:"groups"`
 }
 
 type PrometheusGroup struct {
-	Name  string
-	Rules []PrometheusRule
+	Name  string           `json:"name"`
+	Rules []PrometheusRule `json:"rules"`
 }
 
 func (g *PrometheusGroup) validate() error {


### PR DESCRIPTION
Allows Cloud to deploy rules separately from our Prometheus instance, directly into Managed Prometheus.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI passes, https://github.com/sourcegraph/controller/pull/232