### PR TITLE
Wildcard: Fix combobox ui

### DIFF
--- a/client/wildcard/src/components/Combobox/Combobox.tsx
+++ b/client/wildcard/src/components/Combobox/Combobox.tsx
@@ -116,7 +116,7 @@ export const ComboboxPopover = forwardRef<HTMLDivElement, ComboboxPopoverProps>(
             // strategies and so on, see Popover doc for more details)
             as={PopoverContent}
             isOpen={true}
-            targetElement={inputRef}
+            target={inputRef}
             // Suppress TS problem about position prop. ReachComboboxPopover and PopoverContent both
             // have position props with different interfaces. Since we swap component rendering with `as`
             // prop it's safe to suppress position type here due to PopoverContent position type is correct.


### PR DESCRIPTION
During one of migrations I changed popover target field name and by accident forgot to update it in combobox storybook, since it's optional field TS didn't complain about this change on CI.

## Test plan
- Check that combobox storybook stories works properly 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-fix-combobox-ui.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
