### PR TITLE
migration: Fix graphql casing

### DIFF
--- a/cmd/frontend/graphqlbackend/oobmigrations.go
+++ b/cmd/frontend/graphqlbackend/oobmigrations.go
@@ -70,7 +70,7 @@ func (r *schemaResolver) SetMigrationDirection(ctx context.Context, args *struct
 		return nil, err
 	}
 
-	return nil, nil
+	return &EmptyResponse{}, nil
 }
 
 // MarshalOutOfBandMigrationID converts an internal out of band migration id into a GraphQL id.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -656,7 +656,7 @@ type Mutation {
     a format that is readable by the previous Sourcegraph instance. Recently introduced migrations
     should be applied in reverse prior to downgrading the instance.
     """
-    SetMigrationDirection(id: ID!, applyReverse: Boolean!): EmptyResponse!
+    setMigrationDirection(id: ID!, applyReverse: Boolean!): EmptyResponse!
 
     """
     (experimental) Create a new feature flag


### PR DESCRIPTION
and I quote

> Why is SetMigrationDirection capitalized :smiling_face_with_tear:

## Test plan

Not yet used.