### PR TITLE
ci: Fix main by referring to correct casing

### DIFF
--- a/dev/authtest/site_admin_test.go
+++ b/dev/authtest/site_admin_test.go
@@ -171,10 +171,10 @@ mutation {
 	}
 }`,
 			}, {
-				name: "SetMigrationDirection",
+				name: "setMigrationDirection",
 				query: `
 mutation {
-	SetMigrationDirection(id: "TWlncmF0aW9uOjE=", applyReverse: false) {
+	setMigrationDirection(id: "TWlncmF0aW9uOjE=", applyReverse: false) {
 		alwaysNil
 	}
 }`,


### PR DESCRIPTION
I did a bad job in b897993699e0803f53d73d34b16503394e91c950.

## Test plan

CI passed didn't it?