### PR TITLE
passwords: also verify email when resetting passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added support for receiving Bitbucket Cloud webhook `push` events. [#45960](https://github.com/sourcegraph/sourcegraph/pull/45960)
 - Added a way to test code host connection from the `Manage code hosts` page. [#45972](https://github.com/sourcegraph/sourcegraph/pull/45972)
 - Updates to the site configuration from the site admin panel will now also record the user id of the author in the database in the `critical_and_site_config.author_user_id` column. [#46150](https://github.com/sourcegraph/sourcegraph/pull/46150)
+- When setting and resetting passwords, if the user's primary email address is not yet verified, using the password reset link sent via email will now also verify the email address. [#46307](https://github.com/sourcegraph/sourcegraph/pull/46307)
 
 ### Changed
 

--- a/client/web/src/auth/ResetPasswordPage.tsx
+++ b/client/web/src/auth/ResetPasswordPage.tsx
@@ -145,6 +145,8 @@ class ResetPasswordInitForm extends React.PureComponent<{}, ResetPasswordInitFor
 interface ResetPasswordCodeFormProps {
     userID: number
     code: string
+    email: string | null
+    emailVerifyCode: string | null
 }
 
 interface ResetPasswordCodeFormState {
@@ -231,6 +233,8 @@ class ResetPasswordCodeForm extends React.PureComponent<ResetPasswordCodeFormPro
                 userID: this.props.userID,
                 code: this.props.code,
                 password: this.state.password,
+                email: this.props.email,
+                emailVerifyCode: this.props.emailVerifyCode,
             }),
         })
             .then(async response => {
@@ -269,8 +273,17 @@ export const ResetPasswordPage: React.FunctionComponent<ResetPasswordPageProps> 
         if (searchParameters.has('code') || searchParameters.has('userID')) {
             const code = searchParameters.get('code')
             const userID = parseInt(searchParameters.get('userID') || '', 10)
+            const email = searchParameters.get('email')
+            const emailVerifyCode = searchParameters.get('emailVerifyCode')
             if (code && !isNaN(userID)) {
-                body = <ResetPasswordCodeForm code={code} userID={userID} />
+                body = (
+                    <ResetPasswordCodeForm
+                        code={code}
+                        userID={userID}
+                        email={email}
+                        emailVerifyCode={emailVerifyCode}
+                    />
+                )
             } else {
                 body = <Alert variant="danger">The password reset link you followed is invalid.</Alert>
             }

--- a/cmd/frontend/internal/auth/userpasswd/set_password.go
+++ b/cmd/frontend/internal/auth/userpasswd/set_password.go
@@ -8,31 +8,16 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/txemail"
-	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var defaultSetPasswordEmailTemplate = txemail.MustValidate(txtypes.Templates{
-	Subject: `Set your Sourcegraph password ({{.Host}})`,
-	Text: `
-Your administrator created an account for you on Sourcegraph ({{.Host}}).
-
-To set the password for {{.Username}} on Sourcegraph, follow this link:
-
-  {{.URL}}
-`,
-	HTML: `
-<p>
-  Your administrator created an account for you on Sourcegraph ({{.Host}}).
-</p>
-
-<p><strong><a href="{{.URL}}">Set password for {{.Username}}</a></strong></p>
-`,
-})
-
-// HandleSetPasswordEmail sends the password reset email directly to the user for users created by site admins.
+// HandleSetPasswordEmail sends the password reset email directly to the user for users
+// created by site admins.
+//
+// If the primary user's email is not verified, a special version of the reset link is
+// emailed that also verifies the email.
 func HandleSetPasswordEmail(ctx context.Context, db database.DB, id int32) (string, error) {
-	e, _, err := db.UserEmails().GetPrimaryEmail(ctx, id)
+	email, verified, err := db.UserEmails().GetPrimaryEmail(ctx, id)
 	if err != nil {
 		return "", errors.Wrap(err, "get user primary email")
 	}
@@ -42,11 +27,22 @@ func HandleSetPasswordEmail(ctx context.Context, db database.DB, id int32) (stri
 		return "", errors.Wrap(err, "get user by ID")
 	}
 
-	ru, err := backend.MakePasswordResetURL(ctx, db, id)
+	resetURL, err := backend.MakePasswordResetURL(ctx, db, id)
 	if err == database.ErrPasswordResetRateLimit {
 		return "", err
 	} else if err != nil {
 		return "", errors.Wrap(err, "make password reset URL")
+	}
+
+	shareableResetURL := globals.ExternalURL().ResolveReference(resetURL).String()
+	emailedResetURL := shareableResetURL
+
+	if !verified {
+		newURL, err := AttachEmailVerificationToPasswordReset(ctx, db.UserEmails(), *resetURL, id, email)
+		if err != nil {
+			return shareableResetURL, errors.Wrap(err, "attach email verification")
+		}
+		emailedResetURL = globals.ExternalURL().ResolveReference(newURL).String()
 	}
 
 	// Configure the template
@@ -55,22 +51,17 @@ func HandleSetPasswordEmail(ctx context.Context, db database.DB, id int32) (stri
 		emailTemplate = txemail.FromSiteConfigTemplateWithDefault(customTemplates.SetPassword, emailTemplate)
 	}
 
-	rus := globals.ExternalURL().ResolveReference(ru).String()
 	if err := txemail.Send(ctx, "password_set", txemail.Message{
-		To:       []string{e},
+		To:       []string{email},
 		Template: emailTemplate,
-		Data: struct {
-			Username string
-			URL      string
-			Host     string
-		}{
+		Data: passwordEmailTemplateData{
 			Username: usr.Username,
-			URL:      rus,
+			URL:      emailedResetURL,
 			Host:     globals.ExternalURL().Host,
 		},
 	}); err != nil {
-		return "", err
+		return shareableResetURL, err
 	}
 
-	return rus, nil
+	return shareableResetURL, nil
 }

--- a/cmd/frontend/internal/auth/userpasswd/set_password_test.go
+++ b/cmd/frontend/internal/auth/userpasswd/set_password_test.go
@@ -3,9 +3,11 @@ package userpasswd
 import (
 	"context"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -18,12 +20,6 @@ func TestHandleSetPasswordEmail(t *testing.T) {
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1})
 
-	var sent *txemail.Message
-	txemail.MockSend = func(ctx context.Context, message txemail.Message) error {
-		sent = &message
-		return nil
-	}
-	defer func() { txemail.MockSend = nil }()
 	defer func() { backend.MockMakePasswordResetURL = nil }()
 
 	backend.MockMakePasswordResetURL = func(context.Context, int32) (*url.URL, error) {
@@ -33,36 +29,56 @@ func TestHandleSetPasswordEmail(t *testing.T) {
 		return &url.URL{Path: "/password-reset", RawQuery: query.Encode()}, nil
 	}
 
-	userEmails := database.NewMockUserEmailsStore()
-	userEmails.GetPrimaryEmailFunc.SetDefaultReturn("a@example.com", true, nil)
-
-	users := database.NewMockUserStore()
-	users.GetByIDFunc.SetDefaultReturn(&types.User{ID: 1, Username: "test"}, nil)
-
-	db := database.NewMockDB()
-	db.UserEmailsFunc.SetDefaultReturn(userEmails)
-	db.UsersFunc.SetDefaultReturn(users)
-
 	tests := []struct {
-		name    string
-		id      int32
-		ctx     context.Context
-		wantURL string
-		wantErr bool
-		email   string
+		name          string
+		id            int32
+		emailVerified bool
+		ctx           context.Context
+		wantURL       string
+		wantEmailURL  string
+		wantErr       bool
+		email         string
 	}{
 		{
-			name:    "Valid ID",
-			id:      1,
-			ctx:     ctx,
-			wantURL: "http://example.com/password-reset?code=foo&userID=1",
-			wantErr: false,
-			email:   "a@example.com",
+			name:          "valid ID",
+			id:            1,
+			emailVerified: true,
+			ctx:           ctx,
+			wantURL:       "http://example.com/password-reset?code=foo&userID=1",
+			wantErr:       false,
+			email:         "a@example.com",
+		},
+		{
+			name:          "unverified email",
+			id:            1,
+			emailVerified: false,
+			ctx:           ctx,
+			wantURL:       "http://example.com/password-reset?code=foo&userID=1",
+			wantEmailURL:  "http://example.com/password-reset?code=foo&userID=1&email=a%40example.com&emailVerifyCode=",
+			wantErr:       false,
+			email:         "a@example.com",
 		},
 	}
 
 	for _, tst := range tests {
 		t.Run(tst.name, func(t *testing.T) {
+			userEmails := database.NewMockUserEmailsStore()
+			userEmails.GetPrimaryEmailFunc.SetDefaultReturn("a@example.com", tst.emailVerified, nil)
+
+			users := database.NewMockUserStore()
+			users.GetByIDFunc.SetDefaultReturn(&types.User{ID: 1, Username: "test"}, nil)
+
+			db := database.NewMockDB()
+			db.UserEmailsFunc.SetDefaultReturn(userEmails)
+			db.UsersFunc.SetDefaultReturn(users)
+
+			var gotEmail txemail.Message
+			txemail.MockSend = func(ctx context.Context, message txemail.Message) error {
+				gotEmail = message
+				return nil
+			}
+			t.Cleanup(func() { txemail.MockSend = nil })
+
 			got, err := HandleSetPasswordEmail(tst.ctx, db, tst.id)
 			if diff := cmp.Diff(tst.wantURL, got); diff != "" {
 				t.Errorf("Message mismatch (-want +got):\n%s", diff)
@@ -75,36 +91,31 @@ func TestHandleSetPasswordEmail(t *testing.T) {
 				}
 			}
 
-			if sent == nil {
-				t.Fatal("want sent != nil")
-			}
-
-			gotEmail := &txemail.Message{
-				To:       []string{tst.email},
-				Template: defaultSetPasswordEmailTemplate,
-				Data: struct {
-					Username string
-					URL      string
-				}{
-					Username: "test",
-					URL:      got,
-				},
-			}
-
 			want := &txemail.Message{
 				To:       []string{tst.email},
 				Template: defaultSetPasswordEmailTemplate,
-				Data: struct {
-					Username string
-					URL      string
-				}{
+				Data: passwordEmailTemplateData{
 					Username: "test",
-					URL:      tst.wantURL,
+					URL: func() string {
+						if tst.wantEmailURL != "" {
+							return tst.wantEmailURL
+						}
+						return tst.wantURL
+					}(),
+					Host: "example.com",
 				},
 			}
 
-			if diff := cmp.Diff(want, gotEmail); diff != "" {
-				t.Errorf("Message mismatch (-want +got):\n%s", diff)
+			assert.Equal(t, []string{tst.email}, gotEmail.To)
+			assert.Equal(t, defaultSetPasswordEmailTemplate, gotEmail.Template)
+			gotEmailData := want.Data.(passwordEmailTemplateData)
+			assert.Equal(t, "test", gotEmailData.Username)
+			assert.Equal(t, "example.com", gotEmailData.Host)
+			if tst.wantEmailURL != "" {
+				assert.True(t, strings.Contains(gotEmailData.URL, tst.wantEmailURL),
+					"expected %q in %q", tst.wantEmailURL, gotEmailData.URL)
+			} else {
+				assert.Equal(t, tst.wantURL, gotEmailData.URL)
 			}
 		})
 	}

--- a/cmd/frontend/internal/auth/userpasswd/template.go
+++ b/cmd/frontend/internal/auth/userpasswd/template.go
@@ -1,0 +1,49 @@
+package userpasswd
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/txemail"
+	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
+)
+
+type passwordEmailTemplateData struct {
+	Username string
+	URL      string
+	Host     string
+}
+
+var defaultSetPasswordEmailTemplate = txemail.MustValidate(txtypes.Templates{
+	Subject: `Set your Sourcegraph password ({{.Host}})`,
+	Text: `
+Your administrator created an account for you on Sourcegraph ({{.Host}}).
+
+To set the password for {{.Username}} on Sourcegraph, follow this link:
+
+  {{.URL}}
+`,
+	HTML: `
+<p>
+  Your administrator created an account for you on Sourcegraph ({{.Host}}).
+</p>
+
+<p><strong><a href="{{.URL}}">Set password for {{.Username}}</a></strong></p>
+`,
+})
+
+var defaultResetPasswordEmailTemplates = txemail.MustValidate(txtypes.Templates{
+	Subject: `Reset your Sourcegraph password ({{.Host}})`,
+	Text: `
+Somebody (likely you) requested a password reset for the user {{.Username}} on Sourcegraph ({{.Host}}).
+
+To reset the password for {{.Username}} on Sourcegraph, follow this link:
+
+  {{.URL}}
+`,
+	HTML: `
+<p>
+  Somebody (likely you) requested a password reset for <strong>{{.Username}}</strong>
+  on Sourcegraph ({{.Host}}).
+</p>
+
+<p><strong><a href="{{.URL}}">Reset password for {{.Username}}</a></strong></p>
+`,
+})

--- a/cmd/frontend/internal/auth/userpasswd/verify_email.go
+++ b/cmd/frontend/internal/auth/userpasswd/verify_email.go
@@ -1,0 +1,28 @@
+package userpasswd
+
+import (
+	"context"
+	"net/url"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func AttachEmailVerificationToPasswordReset(ctx context.Context, db database.UserEmailsStore, resetURL url.URL, userID int32, email string) (*url.URL, error) {
+	code, err := backend.MakeEmailVerificationCode()
+	if err != nil {
+		return nil, errors.Wrap(err, "make password verification")
+	}
+	err = db.SetLastVerification(ctx, userID, email, code, time.Now())
+	if err != nil {
+		return nil, err
+	}
+
+	q := resetURL.Query()
+	q.Set("emailVerifyCode", code)
+	q.Set("email", email)
+	resetURL.RawQuery = q.Encode()
+	return &resetURL, nil
+}

--- a/cmd/frontend/internal/auth/userpasswd/verify_email_test.go
+++ b/cmd/frontend/internal/auth/userpasswd/verify_email_test.go
@@ -1,0 +1,32 @@
+package userpasswd
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
+
+func TestAttachEmailVerificationToPasswordReset(t *testing.T) {
+	resetURL, err := url.Parse("/password-reset?code=foo&userID=42")
+	require.NoError(t, err)
+
+	db := database.NewMockUserEmailsStore()
+	db.SetLastVerificationFunc.SetDefaultReturn(nil)
+
+	newURL, err := AttachEmailVerificationToPasswordReset(context.Background(), db, *resetURL, 42, "foobar@bobheadxi.dev")
+	assert.NoError(t, err)
+
+	rendered := newURL.String()
+	t.Log(rendered)
+	assert.NotEqual(t, resetURL.String(), rendered)
+	assert.True(t, strings.Contains(rendered, "userID=42"))
+	assert.True(t, strings.Contains(rendered, "code=foo"))
+	assert.True(t, strings.Contains(rendered, "email=foobar%40bobheadxi.dev"))
+	assert.True(t, strings.Contains(rendered, "emailVerifyCode="))
+}


### PR DESCRIPTION
With this change, when setting and resetting passwords, if the primary email is not verified the _emailed link_ (not the copy-paste-able one) will now also verify the email when a user resets their password.

Addresses https://github.com/sourcegraph/sourcegraph/pull/46187#issuecomment-1373337503 as part of https://github.com/sourcegraph/customer/issues/1790.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

1. `sg start` with SMTP configuration
2. Create account
3. User settings -> emails -> mark as unverified
4. Site admin -> users -> send reset
5. Click reset URL **in email** (_not_ the copy-pasted one)
6. Rest password and log in
7. Email is now verified!