### PR TITLE
Add Bitbucket Cloud permissions syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added a way to test code host connection from the `Manage code hosts` page. [#45972](https://github.com/sourcegraph/sourcegraph/pull/45972)
 - Updates to the site configuration from the site admin panel will now also record the user id of the author in the database in the `critical_and_site_config.author_user_id` column. [#46150](https://github.com/sourcegraph/sourcegraph/pull/46150)
 - Bitbucket Cloud can now be added as an authentication provider on Sourcegraph. [#46309](https://github.com/sourcegraph/sourcegraph/pull/46309)
+- Bitbucket Cloud code host connections now support permissions syncing. [#46312](https://github.com/sourcegraph/sourcegraph/pull/46312)
 
 ### Changed
 

--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -317,6 +317,7 @@ Sourcegraph instance:
 - Callback URL: `https://sourcegraph.example.com/.auth/bitbucketcloud/callback`
 - Permissions: 
   - `Account`: `Read`
+  - `Repositories`: `Read` (if user permissions syncing is desired)
 
 After the consumer is created, you will need the Key and the Secret, which can be found by expanding OAuth consumer in the list.
 Then add the following lines to your site configuration:

--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -317,7 +317,7 @@ Sourcegraph instance:
 - Callback URL: `https://sourcegraph.example.com/.auth/bitbucketcloud/callback`
 - Permissions: 
   - `Account`: `Read`
-  - `Repositories`: `Read` (if user permissions syncing is desired)
+  - `Repositories`: `Read` (if [permissions syncing](../repo/permissions.md) is desired)
 
 After the consumer is created, you will need the Key and the Secret, which can be found by expanding OAuth consumer in the list.
 Then add the following lines to your site configuration:

--- a/doc/admin/external_service/bitbucket_cloud.md
+++ b/doc/admin/external_service/bitbucket_cloud.md
@@ -33,6 +33,11 @@ If enabled, the default rate is set at 7200 per hour (2 per second), which can b
 
 **NOTE** Internal rate limiting is only currently applied when synchronizing changesets in [batch changes](../../batch_changes/index.md), repository permissions, and repository metadata from code hosts.
 
+## User authentication
+
+To configure Bitbucket Cloud as an authentication provider (which will enable sign-in via Bitbucket Cloud), see the
+[authentication documentation](../auth/index.md#bitbucket-cloud).
+
 ## Configuration
 
 Bitbucket Cloud connections support the following configuration options, which are specified in the JSON editor in the site admin "Manage code hosts" area.

--- a/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/config_test.go
+++ b/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/config_test.go
@@ -44,6 +44,7 @@ func TestParseConfig(t *testing.T) {
 						DisplayName:  "Bitbucket Cloud",
 						Type:         extsvc.TypeBitbucketCloud,
 						Url:          "https://bitbucket.org",
+						ApiScope:     "account,email",
 					},
 				}},
 			}}},
@@ -55,6 +56,7 @@ func TestParseConfig(t *testing.T) {
 						DisplayName:  "Bitbucket Cloud",
 						Type:         extsvc.TypeBitbucketCloud,
 						Url:          "https://bitbucket.org",
+						ApiScope:     "account,email",
 					},
 					Provider: provider("https://bitbucket.org/", oauth2.Config{
 						ClientID:     "myclientid",
@@ -78,6 +80,7 @@ func TestParseConfig(t *testing.T) {
 						DisplayName:  "Bitbucket Cloud",
 						Type:         extsvc.TypeBitbucketCloud,
 						Url:          "https://bitbucket.org",
+						ApiScope:     "account,email",
 					},
 				}, {
 					Bitbucketcloud: &schema.BitbucketCloudAuthProvider{
@@ -86,6 +89,7 @@ func TestParseConfig(t *testing.T) {
 						DisplayName:  "Bitbucket Cloud Duplicate",
 						Type:         extsvc.TypeBitbucketCloud,
 						Url:          "https://bitbucket.org",
+						ApiScope:     "account,email",
 					},
 				}},
 			}}},
@@ -97,6 +101,7 @@ func TestParseConfig(t *testing.T) {
 						DisplayName:  "Bitbucket Cloud",
 						Type:         extsvc.TypeBitbucketCloud,
 						Url:          "https://bitbucket.org",
+						ApiScope:     "account,email",
 					},
 					Provider: provider("https://bitbucket.org/", oauth2.Config{
 						ClientID:     "myclientid",

--- a/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/middleware_test.go
@@ -230,6 +230,7 @@ func newMockProvider(t *testing.T, db database.DB, clientID, clientSecret, baseU
 		Url:          baseURL,
 		ClientSecret: clientSecret,
 		ClientKey:    clientID,
+		ApiScope:     "account,email",
 	}}
 	mp.Provider, problems = parseProvider(logtest.Scoped(t), cfg.Bitbucketcloud, db, cfg)
 	if len(problems) > 0 {

--- a/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/provider.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/dghubble/gologin"
 	"github.com/dghubble/gologin/bitbucket"
@@ -48,7 +49,7 @@ func parseProvider(logger log.Logger, p *schema.BitbucketCloudAuthProvider, db d
 			return oauth2.Config{
 				ClientID:     p.ClientKey,
 				ClientSecret: p.ClientSecret,
-				Scopes:       requestedScopes(),
+				Scopes:       requestedScopes(p.ApiScope),
 				Endpoint: oauth2.Endpoint{
 					AuthURL:  parsedURL.ResolveReference(&url.URL{Path: "/site/oauth2/authorize"}).String(),
 					TokenURL: parsedURL.ResolveReference(&url.URL{Path: "/site/oauth2/access_token"}).String(),
@@ -106,8 +107,6 @@ func validateClientKeyOrSecret(clientKeyOrSecret string) (valid bool) {
 	return clientKeySecretValidator.MatchString(clientKeyOrSecret)
 }
 
-func requestedScopes() []string {
-	scopes := []string{"account", "email"}
-
-	return scopes
+func requestedScopes(apiScopes string) []string {
+	return strings.Split(apiScopes, ",")
 }

--- a/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/provider_test.go
+++ b/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/provider_test.go
@@ -18,13 +18,15 @@ func TestRequestedScopes(t *testing.T) {
 		expScopes []string
 	}{
 		{
-			schema:    &schema.BitbucketCloudAuthProvider{},
-			expScopes: []string{"account", "email"},
+			schema: &schema.BitbucketCloudAuthProvider{
+				ApiScope: "account,email,repository",
+			},
+			expScopes: []string{"account", "email", "repository"},
 		},
 	}
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			scopes := requestedScopes()
+			scopes := requestedScopes(test.schema.ApiScope)
 			sort.Strings(scopes)
 			if diff := cmp.Diff(test.expScopes, scopes); diff != "" {
 				t.Fatalf("scopes: %s", diff)

--- a/enterprise/internal/authz/authz_test.go
+++ b/enterprise/internal/authz/authz_test.go
@@ -489,7 +489,7 @@ func TestAuthzProvidersFromConfig(t *testing.T) {
 								Config: extsvc.NewUnencryptedConfig(mustMarshalJSONString(bbs)),
 							})
 						}
-					case extsvc.KindGitHub, extsvc.KindPerforce:
+					case extsvc.KindGitHub, extsvc.KindPerforce, extsvc.KindBitbucketCloud:
 					default:
 						return nil, errors.Errorf("unexpected kind: %s", kind)
 					}
@@ -521,6 +521,7 @@ func TestAuthzProvidersEnabledACLsDisabled(t *testing.T) {
 		bitbucketServerConnections []*schema.BitbucketServerConnection
 		githubConnections          []*schema.GitHubConnection
 		perforceConnections        []*schema.PerforceConnection
+		bitbucketCloudConnections  []*schema.BitbucketCloudConnection
 
 		expInvalidConnections []string
 		expSeriousProblems    []string
@@ -577,7 +578,7 @@ func TestAuthzProvidersEnabledACLsDisabled(t *testing.T) {
 			expInvalidConnections: []string{"gitlab"},
 		},
 		{
-			description: "Bitbucket connection with authz enabled but missing license for ACLs",
+			description: "Bitbucket Server connection with authz enabled but missing license for ACLs",
 			cfg:         conf.Unified{},
 			bitbucketServerConnections: []*schema.BitbucketServerConnection{
 				{
@@ -599,6 +600,20 @@ func TestAuthzProvidersEnabledACLsDisabled(t *testing.T) {
 			},
 			expSeriousProblems:    []string{"failed"},
 			expInvalidConnections: []string{"bitbucketServer"},
+		},
+		{
+			description: "Bitbucket Cloud connection with authz enabled but missing license for ACLs",
+			cfg:         conf.Unified{},
+			bitbucketCloudConnections: []*schema.BitbucketCloudConnection{
+				{
+					Authorization: &schema.BitbucketCloudAuthorization{},
+					Url:           "https://bitbucket.org",
+					Username:      "admin",
+					AppPassword:   "secret-password",
+				},
+			},
+			expSeriousProblems:    []string{"failed"},
+			expInvalidConnections: []string{"bitbucketCloud"},
 		},
 		{
 			description: "Perforce connection with authz enabled but missing license for ACLs",
@@ -652,6 +667,13 @@ func TestAuthzProvidersEnabledACLsDisabled(t *testing.T) {
 							svcs = append(svcs, &types.ExternalService{
 								Kind:   kind,
 								Config: extsvc.NewUnencryptedConfig(mustMarshalJSONString(gh)),
+							})
+						}
+					case extsvc.KindBitbucketCloud:
+						for _, bbcloud := range test.bitbucketCloudConnections {
+							svcs = append(svcs, &types.ExternalService{
+								Kind:   kind,
+								Config: extsvc.NewUnencryptedConfig(mustMarshalJSONString(bbcloud)),
 							})
 						}
 					case extsvc.KindPerforce:

--- a/enterprise/internal/authz/bitbucketcloud/authz.go
+++ b/enterprise/internal/authz/bitbucketcloud/authz.go
@@ -1,0 +1,97 @@
+package bitbucketcloud
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
+
+	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// NewAuthzProviders returns the set of Bitbucket Cloud authz providers derived from the connections.
+//
+// It also returns any simple validation problems with the config, separating these into "serious problems"
+// and "warnings". "Serious problems" are those that should make Sourcegraph set authz.allowAccessByDefault
+// to false. "Warnings" are all other validation problems.
+//
+// This constructor does not and should not directly check connectivity to external services - if
+// desired, callers should use `(*Provider).ValidateConnection` directly to get warnings related
+// to connection issues.
+func NewAuthzProviders(db database.DB, conns []*types.BitbucketCloudConnection, authProviders []schema.AuthProviders) (ps []authz.Provider, problems []string, warnings []string, invalidConnections []string) {
+	bbcloudAuthProviders := make(map[string]*schema.BitbucketCloudAuthProvider)
+	for _, p := range authProviders {
+		if p.Bitbucketcloud != nil {
+			var id string
+			bbURL, err := url.Parse(p.Bitbucketcloud.GetURL())
+			if err != nil {
+				// error reporting for this should happen elsewhere, for now just use what is given
+				id = p.Bitbucketcloud.GetURL()
+			} else {
+				// use codehost normalized URL as ID
+				ch := extsvc.NewCodeHost(bbURL, p.Bitbucketcloud.Type)
+				id = ch.ServiceID
+			}
+			bbcloudAuthProviders[id] = p.Bitbucketcloud
+		}
+	}
+
+	for _, c := range conns {
+		p, err := newAuthzProvider(db, c)
+		if err != nil {
+			invalidConnections = append(invalidConnections, extsvc.TypeBitbucketCloud)
+			problems = append(problems, err.Error())
+		}
+		if p == nil {
+			continue
+		}
+
+		if _, exists := bbcloudAuthProviders[p.ServiceID()]; !exists {
+			warnings = append(warnings,
+				fmt.Sprintf("Bitbucket Cloud config for %[1]s has `authorization` enabled, "+
+					"but no authentication provider matching %[1]q was found. "+
+					"Check the [**site configuration**](/site-admin/configuration) to "+
+					"verify an entry in [`auth.providers`](https://docs.sourcegraph.com/admin/auth) exists for %[1]s.",
+					p.ServiceID()))
+		}
+
+		ps = append(ps, p)
+	}
+
+	return ps, problems, warnings, invalidConnections
+}
+
+func newAuthzProvider(
+	db database.DB,
+	c *types.BitbucketCloudConnection,
+) (authz.Provider, error) {
+	// If authorization is not set for this connection, we do not need an
+	// authz provider.
+	if c.Authorization == nil {
+		return nil, nil
+	}
+	if err := licensing.Check(licensing.FeatureACLs); err != nil {
+		return nil, err
+	}
+
+	bbClient, err := bitbucketcloud.NewClient(c.URN, c.BitbucketCloudConnection, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewProvider(db, c, ProviderOptions{
+		BitbucketCloudClient: bbClient,
+	}), nil
+}
+
+// ValidateAuthz validates the authorization fields of the given Perforce
+// external service config.
+func ValidateAuthz(_ *schema.BitbucketCloudConnection) error {
+	// newAuthzProvider always succeeds, so directly return nil here.
+	return nil
+}

--- a/enterprise/internal/authz/bitbucketcloud/authz_test.go
+++ b/enterprise/internal/authz/bitbucketcloud/authz_test.go
@@ -1,0 +1,109 @@
+package bitbucketcloud
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestNewAuthzProviders(t *testing.T) {
+	db := database.NewMockDB()
+	db.ExternalServicesFunc.SetDefaultReturn(database.NewMockExternalServiceStore())
+	t.Run("no authorization", func(t *testing.T) {
+		providers, problems, warnings, invalidConnections := NewAuthzProviders(
+			db,
+			[]*types.BitbucketCloudConnection{{
+				BitbucketCloudConnection: &schema.BitbucketCloudConnection{
+					Url: schema.DefaultBitbucketCloudURL,
+				},
+			}},
+			[]schema.AuthProviders{},
+		)
+
+		assert := assert.New(t)
+
+		assert.Len(providers, 0, "unexpected a providers: %+v", providers)
+		assert.Len(problems, 0, "unexpected problems: %+v", problems)
+		assert.Len(warnings, 0, "unexpected warnings: %+v", warnings)
+		assert.Len(invalidConnections, 0, "unexpected invalidConnections: %+v", invalidConnections)
+	})
+
+	t.Run("no matching auth provider", func(t *testing.T) {
+		licensing.MockCheckFeatureError("")
+		providers, problems, warnings, invalidConnections := NewAuthzProviders(
+			db,
+			[]*types.BitbucketCloudConnection{
+				{
+					BitbucketCloudConnection: &schema.BitbucketCloudConnection{
+						Url:           "https://bitbucket.org/my-org", // incorrect
+						Authorization: &schema.BitbucketCloudAuthorization{},
+					},
+				},
+			},
+			[]schema.AuthProviders{{Bitbucketcloud: &schema.BitbucketCloudAuthProvider{}}},
+		)
+
+		require.Len(t, providers, 1, "expect exactly one provider")
+		assert.NotNil(t, providers[0])
+
+		assert.Empty(t, problems)
+		assert.Empty(t, invalidConnections)
+
+		require.Len(t, warnings, 1, "expect exactly one warning")
+		assert.Contains(t, warnings[0], "no authentication provider")
+	})
+
+	t.Run("matching auth provider found", func(t *testing.T) {
+		t.Run("default case", func(t *testing.T) {
+			licensing.MockCheckFeatureError("")
+			providers, problems, warnings, invalidConnections := NewAuthzProviders(
+				db,
+				[]*types.BitbucketCloudConnection{
+					{
+						BitbucketCloudConnection: &schema.BitbucketCloudConnection{
+							Url:           schema.DefaultBitbucketCloudURL,
+							Authorization: &schema.BitbucketCloudAuthorization{},
+						},
+					},
+				},
+				[]schema.AuthProviders{{Bitbucketcloud: &schema.BitbucketCloudAuthProvider{}}},
+			)
+
+			require.Len(t, providers, 1, "expect exactly one provider")
+			assert.NotNil(t, providers[0])
+
+			assert.Empty(t, problems)
+			assert.Empty(t, warnings)
+			assert.Empty(t, invalidConnections)
+		})
+
+		t.Run("license does not have ACLs feature", func(t *testing.T) {
+			licensing.MockCheckFeatureError("failed")
+			providers, problems, warnings, invalidConnections := NewAuthzProviders(
+				db,
+				[]*types.BitbucketCloudConnection{
+					{
+						BitbucketCloudConnection: &schema.BitbucketCloudConnection{
+							Url:           schema.DefaultBitbucketCloudURL,
+							Authorization: &schema.BitbucketCloudAuthorization{},
+						},
+					},
+				},
+				[]schema.AuthProviders{{Bitbucketcloud: &schema.BitbucketCloudAuthProvider{}}},
+			)
+
+			expectedError := []string{"failed"}
+			expInvalidConnectionErr := []string{"bitbucketCloud"}
+			assert.Equal(t, expectedError, problems)
+			assert.Equal(t, expInvalidConnectionErr, invalidConnections)
+			assert.Empty(t, providers)
+			assert.Empty(t, warnings)
+		})
+	})
+}

--- a/enterprise/internal/authz/bitbucketcloud/provider.go
+++ b/enterprise/internal/authz/bitbucketcloud/provider.go
@@ -149,6 +149,9 @@ func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, 
 
 	users, next, err := p.client.ListExplicitUserPermsForRepo(ctx, nil, repoOwner, repoName)
 	users, err = bitbucketcloud.FetchAll(ctx, p.client, users, next, err)
+	if err != nil {
+		return nil, err
+	}
 
 	// Bitbucket Cloud API does not return the owner of the repository as part
 	// of the explicit permissions list, so we need to fetch and add them.

--- a/enterprise/internal/authz/bitbucketcloud/provider.go
+++ b/enterprise/internal/authz/bitbucketcloud/provider.go
@@ -174,7 +174,7 @@ func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, 
 		users = append(users, bbCloudRepo.Owner)
 	}
 
-	userIDs := make([]extsvc.AccountID, 0, len(users))
+	userIDs := make([]extsvc.AccountID, len(users))
 	for i, user := range users {
 		userIDs[i] = extsvc.AccountID(user.UUID)
 	}

--- a/enterprise/internal/authz/bitbucketcloud/provider.go
+++ b/enterprise/internal/authz/bitbucketcloud/provider.go
@@ -119,6 +119,9 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 
 	repos, next, err := client.Repos(ctx, nil, "", &bitbucketcloud.ReposOptions{Role: "member"})
 	repos, err = bitbucketcloud.FetchAll(ctx, client, repos, next, err)
+	if err != nil {
+		return nil, err
+	}
 
 	extIDs := make([]extsvc.RepoID, 0, len(repos))
 	for _, repo := range repos {

--- a/enterprise/internal/authz/bitbucketcloud/provider.go
+++ b/enterprise/internal/authz/bitbucketcloud/provider.go
@@ -1,0 +1,183 @@
+// Package bitbucketcloud contains an authorization provider for Bitbucket Cloud.
+package bitbucketcloud
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// Provider is an implementation of AuthzProvider that provides repository and
+// user permissions as determined from Bitbucket Cloud.
+type Provider struct {
+	urn      string
+	codeHost *extsvc.CodeHost
+	client   bitbucketcloud.Client
+	pageSize int // Page size to use in paginated requests.
+	db       database.DB
+}
+
+type ProviderOptions struct {
+	BitbucketCloudClient bitbucketcloud.Client
+}
+
+var _ authz.Provider = (*Provider)(nil)
+
+// NewProvider returns a new Bitbucket Cloud authorization provider that uses
+// the given bitbucket.Client to talk to the Bitbucket Cloud API that is
+// the source of truth for permissions. Sourcegraph users will need a valid
+// Bitbucket Cloud external account for permissions to sync correctly.
+func NewProvider(db database.DB, conn *types.BitbucketCloudConnection, opts ProviderOptions) *Provider {
+	baseURL, err := url.Parse(conn.Url)
+	if err != nil {
+		return nil
+	}
+
+	if opts.BitbucketCloudClient == nil {
+		opts.BitbucketCloudClient, err = bitbucketcloud.NewClient(conn.URN, conn.BitbucketCloudConnection, httpcli.ExternalClient)
+		if err != nil {
+			return nil
+		}
+	}
+
+	return &Provider{
+		urn:      conn.URN,
+		codeHost: extsvc.NewCodeHost(baseURL, extsvc.TypeBitbucketCloud),
+		client:   opts.BitbucketCloudClient,
+		pageSize: 1000,
+		db:       db,
+	}
+}
+
+// ValidateConnection validates that the Provider has access to the Bitbucket Server API
+// with the OAuth credentials it was configured with.
+func (p *Provider) ValidateConnection(ctx context.Context) []string {
+	return nil
+}
+
+func (p *Provider) URN() string {
+	return p.urn
+}
+
+// ServiceID returns the absolute URL that identifies the Bitbucket Server instance
+// this provider is configured with.
+func (p *Provider) ServiceID() string { return p.codeHost.ServiceID }
+
+// ServiceType returns the type of this Provider, namely, "bitbucketCloud".
+func (p *Provider) ServiceType() string { return p.codeHost.ServiceType }
+
+// FetchAccount satisfies the authz.Provider interface.
+func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*extsvc.Account, _ []string) (acct *extsvc.Account, err error) {
+	return nil, nil
+}
+
+// FetchUserPerms returns a list of repository IDs (on code host) that the given account
+// has read access on the code host. The repository ID has the same value as it would be
+// used as api.ExternalRepoSpec.ID. The returned list only includes private repository IDs.
+//
+// This method may return partial but valid results in case of error, and it is up to
+// callers to decide whether to discard.
+//
+// API docs: https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html#idm8296923984
+func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, opts authz.FetchPermsOptions) (*authz.ExternalUserPermissions, error) {
+	switch {
+	case account == nil:
+		return nil, errors.New("no account provided")
+	case !extsvc.IsHostOfAccount(p.codeHost, account):
+		return nil, errors.Errorf("not a code host of the account: want %q but have %q",
+			p.codeHost.ServiceID, account.AccountSpec.ServiceID)
+	case account.Data == nil:
+		return nil, errors.New("no account data provided")
+	}
+
+	_, tok, err := bitbucketcloud.GetExternalAccountData(ctx, &account.AccountData)
+	if err != nil {
+		return nil, err
+	}
+	oauthToken := &auth.OAuthBearerToken{
+		Token:        tok.AccessToken,
+		RefreshToken: tok.RefreshToken,
+		Expiry:       tok.Expiry,
+	}
+
+	oauthToken.RefreshFunc = database.GetAccountRefreshAndStoreOAuthTokenFunc(p.db, account.ID, bitbucketcloud.GetOAuthContext(p.codeHost.BaseURL.String()))
+	oauthToken.NeedsRefreshBuffer = 5
+
+	client := p.client.WithAuthenticator(oauthToken)
+	repos, next, err := client.Repos(ctx, nil, "", &bitbucketcloud.ReposOptions{Role: "member"})
+	if err != nil {
+		return nil, err
+	}
+	for next.HasMore() {
+		var nextRepos []*bitbucketcloud.Repo
+		nextRepos, next, err = client.Repos(ctx, next, "", &bitbucketcloud.ReposOptions{Role: "member"})
+		if err != nil {
+			return nil, err
+		}
+		repos = append(repos, nextRepos...)
+	}
+
+	extIDs := make([]extsvc.RepoID, 0, len(repos))
+	for _, repo := range repos {
+		extIDs = append(extIDs, extsvc.RepoID(repo.UUID))
+	}
+
+	return &authz.ExternalUserPermissions{
+		Exacts: extIDs,
+	}, err
+}
+
+// FetchRepoPerms returns a list of user IDs (on code host) who have read access to
+// the given repo on the code host. The user ID has the same value as it would
+// be used as extsvc.Account.AccountID. The returned list includes both direct access
+// and inherited from the group membership.
+//
+// This method may return partial but valid results in case of error, and it is up to
+// callers to decide whether to discard.
+//
+// API docs: https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html#idm8283203728
+func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, opts authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
+	repoNameParts := strings.Split(repo.URI, "/")
+	repoOwner := repoNameParts[1]
+	repoName := repoNameParts[2]
+	users, next, err := p.client.ListExplicitUserPermsForRepo(ctx, nil, repoOwner, repoName)
+	if err != nil {
+		return nil, err
+	}
+
+	for next.HasMore() {
+		var nextUsers []*bitbucketcloud.Account
+		nextUsers, next, err = p.client.ListExplicitUserPermsForRepo(ctx, next, repoOwner, repoName)
+		if err != nil {
+			return nil, err
+		}
+		users = append(users, nextUsers...)
+	}
+
+	// Bitbucket Cloud API does not return the owner of the repository as part
+	// of the explicit permissions list, so we need to fetch and add them.
+	bbCloudRepo, err := p.client.Repo(ctx, repoOwner, repoName)
+	if err != nil {
+		return nil, err
+	}
+
+	if bbCloudRepo.Owner != nil {
+		users = append(users, bbCloudRepo.Owner)
+	}
+
+	userIDs := make([]extsvc.AccountID, 0, len(users))
+	for i, user := range users {
+		userIDs[i] = extsvc.AccountID(user.UUID)
+	}
+
+	return userIDs, nil
+}

--- a/enterprise/internal/authz/bitbucketcloud/provider.go
+++ b/enterprise/internal/authz/bitbucketcloud/provider.go
@@ -117,8 +117,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 
 	client := p.client.WithAuthenticator(oauthToken)
 
-	repos, next, err := client.Repos(ctx, nil, "", &bitbucketcloud.ReposOptions{Role: "member"})
-	repos, err = bitbucketcloud.FetchAll(ctx, client, repos, next, err)
+	repos, _, err := client.Repos(ctx, nil, "", &bitbucketcloud.ReposOptions{RequestOptions: bitbucketcloud.RequestOptions{FetchAll: true}, Role: "member"})
 	if err != nil {
 		return nil, err
 	}
@@ -147,8 +146,7 @@ func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, 
 	repoOwner := repoNameParts[1]
 	repoName := repoNameParts[2]
 
-	users, next, err := p.client.ListExplicitUserPermsForRepo(ctx, nil, repoOwner, repoName)
-	users, err = bitbucketcloud.FetchAll(ctx, p.client, users, next, err)
+	users, _, err := p.client.ListExplicitUserPermsForRepo(ctx, nil, repoOwner, repoName, &bitbucketcloud.RequestOptions{FetchAll: true})
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/authz/bitbucketcloud/provider_test.go
+++ b/enterprise/internal/authz/bitbucketcloud/provider_test.go
@@ -1,0 +1,216 @@
+package bitbucketcloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
+	"golang.org/x/oauth2"
+)
+
+type mockDoer struct {
+	do func(*http.Request) (*http.Response, error)
+}
+
+func (c *mockDoer) Do(r *http.Request) (*http.Response, error) {
+	return c.do(r)
+}
+
+func mustURL(t *testing.T, u string) *url.URL {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
+}
+
+func createTestServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/repositories") {
+			json.NewEncoder(w).Encode(struct {
+				Values []bitbucketcloud.Repo `json:"values"`
+			}{
+				Values: []bitbucketcloud.Repo{
+					{UUID: "1"},
+					{UUID: "2"},
+					{UUID: "3"},
+				},
+			})
+			return
+		}
+
+		if strings.HasSuffix(r.URL.Path, "/permissions-config/users") {
+			json.NewEncoder(w).Encode(struct {
+				Values []bitbucketcloud.ExplicitUserPermsResponse `json:"values"`
+			}{
+				Values: []bitbucketcloud.ExplicitUserPermsResponse{
+					{User: &bitbucketcloud.Account{UUID: "1"}},
+					{User: &bitbucketcloud.Account{UUID: "2"}},
+					{User: &bitbucketcloud.Account{UUID: "3"}},
+				},
+			})
+			return
+		}
+
+		if strings.HasSuffix(r.URL.Path, "/repositories/user/repo") {
+			json.NewEncoder(w).Encode(bitbucketcloud.Repo{
+				Owner: &bitbucketcloud.Account{UUID: "4"},
+			})
+			return
+		}
+	}))
+}
+
+func TestProvider_FetchUserPerms(t *testing.T) {
+	db := database.NewMockDB()
+	t.Run("nil account", func(t *testing.T) {
+		p := NewProvider(db,
+			&types.BitbucketCloudConnection{
+				BitbucketCloudConnection: &schema.BitbucketCloudConnection{
+					ApiURL: "https://bitbucket.org",
+					Url:    "https://bitbucket.org",
+				},
+			}, ProviderOptions{})
+		_, err := p.FetchUserPerms(context.Background(), nil, authz.FetchPermsOptions{})
+		want := "no account provided"
+		got := fmt.Sprintf("%v", err)
+		if got != want {
+			t.Fatalf("err: want %q but got %q", want, got)
+		}
+	})
+
+	t.Run("not the code host of the account", func(t *testing.T) {
+		p := NewProvider(db,
+			&types.BitbucketCloudConnection{
+				BitbucketCloudConnection: &schema.BitbucketCloudConnection{
+					ApiURL: "https://bitbucket.org",
+					Url:    "https://bitbucket.org",
+				},
+			}, ProviderOptions{})
+		_, err := p.FetchUserPerms(context.Background(),
+			&extsvc.Account{
+				AccountSpec: extsvc.AccountSpec{
+					ServiceType: extsvc.TypeGitHub,
+					ServiceID:   "https://github.com/",
+				},
+			},
+			authz.FetchPermsOptions{},
+		)
+		want := `not a code host of the account: want "https://bitbucket.org/" but have "https://github.com/"`
+		got := fmt.Sprintf("%v", err)
+		if got != want {
+			t.Fatalf("err: want %q but got %q", want, got)
+		}
+	})
+
+	t.Run("no account data provided", func(t *testing.T) {
+		p := NewProvider(db,
+			&types.BitbucketCloudConnection{
+				BitbucketCloudConnection: &schema.BitbucketCloudConnection{
+					ApiURL: "https://bitbucket.org",
+					Url:    "https://bitbucket.org",
+				},
+			}, ProviderOptions{})
+		_, err := p.FetchUserPerms(context.Background(),
+			&extsvc.Account{
+				AccountSpec: extsvc.AccountSpec{
+					ServiceType: extsvc.TypeBitbucketCloud,
+					ServiceID:   "https://bitbucket.org/",
+				},
+			},
+			authz.FetchPermsOptions{},
+		)
+		want := `no account data provided`
+		got := fmt.Sprintf("%v", err)
+		if got != want {
+			t.Fatalf("err: want %q but got %q", want, got)
+		}
+	})
+
+	server := createTestServer()
+	defer server.Close()
+
+	t.Run("fetch user permissions", func(t *testing.T) {
+		conn := &schema.BitbucketCloudConnection{
+			ApiURL: server.URL,
+			Url:    server.URL,
+		}
+		client, err := bitbucketcloud.NewClient(server.URL, conn, http.DefaultClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		p := NewProvider(db,
+			&types.BitbucketCloudConnection{
+				BitbucketCloudConnection: conn,
+			}, ProviderOptions{BitbucketCloudClient: client})
+
+		var acctData extsvc.AccountData
+		err = bitbucketcloud.SetExternalAccountData(&acctData, &bitbucketcloud.Account{}, &oauth2.Token{AccessToken: "my-access-token"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		account := &extsvc.Account{
+			AccountSpec: extsvc.AccountSpec{
+				ServiceType: extsvc.TypeBitbucketCloud,
+				ServiceID:   extsvc.NormalizeBaseURL(mustURL(t, server.URL)).String(),
+			},
+			AccountData: acctData,
+		}
+		userPerms, err := p.FetchUserPerms(context.Background(), account, authz.FetchPermsOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expRepoIDs := []extsvc.RepoID{"1", "2", "3"}
+		if diff := cmp.Diff(expRepoIDs, userPerms.Exacts); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+}
+
+func TestProvider_FetchRepoPerms(t *testing.T) {
+	server := createTestServer()
+	defer server.Close()
+	db := database.NewMockDB()
+
+	conn := &schema.BitbucketCloudConnection{
+		ApiURL: server.URL,
+		Url:    server.URL,
+	}
+	client, err := bitbucketcloud.NewClient(server.URL, conn, http.DefaultClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := NewProvider(db,
+		&types.BitbucketCloudConnection{
+			BitbucketCloudConnection: conn,
+		}, ProviderOptions{BitbucketCloudClient: client})
+
+	perms, err := p.FetchRepoPerms(context.Background(), &extsvc.Repository{
+		URI: "bitbucket.org/user/repo",
+	}, authz.FetchPermsOptions{})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expUserIDs := []extsvc.AccountID{"1", "2", "3", "4"}
+	if diff := cmp.Diff(expUserIDs, perms); diff != "" {
+		t.Fatal(diff)
+	}
+}

--- a/enterprise/internal/batches/sources/mocks_test.go
+++ b/enterprise/internal/batches/sources/mocks_test.go
@@ -3616,6 +3616,10 @@ type MockBitbucketCloudClient struct {
 	// GetPullRequestStatusesFunc is an instance of a mock function object
 	// controlling the behavior of the method GetPullRequestStatuses.
 	GetPullRequestStatusesFunc *BitbucketCloudClientGetPullRequestStatusesFunc
+	// ListExplicitUserPermsForRepoFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// ListExplicitUserPermsForRepo.
+	ListExplicitUserPermsForRepoFunc *BitbucketCloudClientListExplicitUserPermsForRepoFunc
 	// MergePullRequestFunc is an instance of a mock function object
 	// controlling the behavior of the method MergePullRequest.
 	MergePullRequestFunc *BitbucketCloudClientMergePullRequestFunc
@@ -3685,6 +3689,11 @@ func NewMockBitbucketCloudClient() *MockBitbucketCloudClient {
 				return
 			},
 		},
+		ListExplicitUserPermsForRepoFunc: &BitbucketCloudClientListExplicitUserPermsForRepoFunc{
+			defaultHook: func(context.Context, *bitbucketcloud.PageToken, string, string) (r0 []*bitbucketcloud.Account, r1 *bitbucketcloud.PageToken, r2 error) {
+				return
+			},
+		},
 		MergePullRequestFunc: &BitbucketCloudClientMergePullRequestFunc{
 			defaultHook: func(context.Context, *bitbucketcloud.Repo, int64, bitbucketcloud.MergePullRequestOpts) (r0 *bitbucketcloud.PullRequest, r1 error) {
 				return
@@ -3701,7 +3710,7 @@ func NewMockBitbucketCloudClient() *MockBitbucketCloudClient {
 			},
 		},
 		ReposFunc: &BitbucketCloudClientReposFunc{
-			defaultHook: func(context.Context, *bitbucketcloud.PageToken, string) (r0 []*bitbucketcloud.Repo, r1 *bitbucketcloud.PageToken, r2 error) {
+			defaultHook: func(context.Context, *bitbucketcloud.PageToken, string, *bitbucketcloud.ReposOptions) (r0 []*bitbucketcloud.Repo, r1 *bitbucketcloud.PageToken, r2 error) {
 				return
 			},
 		},
@@ -3767,6 +3776,11 @@ func NewStrictMockBitbucketCloudClient() *MockBitbucketCloudClient {
 				panic("unexpected invocation of MockBitbucketCloudClient.GetPullRequestStatuses")
 			},
 		},
+		ListExplicitUserPermsForRepoFunc: &BitbucketCloudClientListExplicitUserPermsForRepoFunc{
+			defaultHook: func(context.Context, *bitbucketcloud.PageToken, string, string) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error) {
+				panic("unexpected invocation of MockBitbucketCloudClient.ListExplicitUserPermsForRepo")
+			},
+		},
 		MergePullRequestFunc: &BitbucketCloudClientMergePullRequestFunc{
 			defaultHook: func(context.Context, *bitbucketcloud.Repo, int64, bitbucketcloud.MergePullRequestOpts) (*bitbucketcloud.PullRequest, error) {
 				panic("unexpected invocation of MockBitbucketCloudClient.MergePullRequest")
@@ -3783,7 +3797,7 @@ func NewStrictMockBitbucketCloudClient() *MockBitbucketCloudClient {
 			},
 		},
 		ReposFunc: &BitbucketCloudClientReposFunc{
-			defaultHook: func(context.Context, *bitbucketcloud.PageToken, string) ([]*bitbucketcloud.Repo, *bitbucketcloud.PageToken, error) {
+			defaultHook: func(context.Context, *bitbucketcloud.PageToken, string, *bitbucketcloud.ReposOptions) ([]*bitbucketcloud.Repo, *bitbucketcloud.PageToken, error) {
 				panic("unexpected invocation of MockBitbucketCloudClient.Repos")
 			},
 		},
@@ -3831,6 +3845,9 @@ func NewMockBitbucketCloudClientFrom(i bitbucketcloud.Client) *MockBitbucketClou
 		},
 		GetPullRequestStatusesFunc: &BitbucketCloudClientGetPullRequestStatusesFunc{
 			defaultHook: i.GetPullRequestStatuses,
+		},
+		ListExplicitUserPermsForRepoFunc: &BitbucketCloudClientListExplicitUserPermsForRepoFunc{
+			defaultHook: i.ListExplicitUserPermsForRepo,
 		},
 		MergePullRequestFunc: &BitbucketCloudClientMergePullRequestFunc{
 			defaultHook: i.MergePullRequest,
@@ -4866,6 +4883,127 @@ func (c BitbucketCloudClientGetPullRequestStatusesFuncCall) Results() []interfac
 	return []interface{}{c.Result0, c.Result1}
 }
 
+// BitbucketCloudClientListExplicitUserPermsForRepoFunc describes the
+// behavior when the ListExplicitUserPermsForRepo method of the parent
+// MockBitbucketCloudClient instance is invoked.
+type BitbucketCloudClientListExplicitUserPermsForRepoFunc struct {
+	defaultHook func(context.Context, *bitbucketcloud.PageToken, string, string) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error)
+	hooks       []func(context.Context, *bitbucketcloud.PageToken, string, string) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error)
+	history     []BitbucketCloudClientListExplicitUserPermsForRepoFuncCall
+	mutex       sync.Mutex
+}
+
+// ListExplicitUserPermsForRepo delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockBitbucketCloudClient) ListExplicitUserPermsForRepo(v0 context.Context, v1 *bitbucketcloud.PageToken, v2 string, v3 string) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error) {
+	r0, r1, r2 := m.ListExplicitUserPermsForRepoFunc.nextHook()(v0, v1, v2, v3)
+	m.ListExplicitUserPermsForRepoFunc.appendCall(BitbucketCloudClientListExplicitUserPermsForRepoFuncCall{v0, v1, v2, v3, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the
+// ListExplicitUserPermsForRepo method of the parent
+// MockBitbucketCloudClient instance is invoked and the hook queue is empty.
+func (f *BitbucketCloudClientListExplicitUserPermsForRepoFunc) SetDefaultHook(hook func(context.Context, *bitbucketcloud.PageToken, string, string) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ListExplicitUserPermsForRepo method of the parent
+// MockBitbucketCloudClient instance invokes the hook at the front of the
+// queue and discards it. After the queue is empty, the default hook
+// function is invoked for any future action.
+func (f *BitbucketCloudClientListExplicitUserPermsForRepoFunc) PushHook(hook func(context.Context, *bitbucketcloud.PageToken, string, string) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *BitbucketCloudClientListExplicitUserPermsForRepoFunc) SetDefaultReturn(r0 []*bitbucketcloud.Account, r1 *bitbucketcloud.PageToken, r2 error) {
+	f.SetDefaultHook(func(context.Context, *bitbucketcloud.PageToken, string, string) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *BitbucketCloudClientListExplicitUserPermsForRepoFunc) PushReturn(r0 []*bitbucketcloud.Account, r1 *bitbucketcloud.PageToken, r2 error) {
+	f.PushHook(func(context.Context, *bitbucketcloud.PageToken, string, string) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *BitbucketCloudClientListExplicitUserPermsForRepoFunc) nextHook() func(context.Context, *bitbucketcloud.PageToken, string, string) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *BitbucketCloudClientListExplicitUserPermsForRepoFunc) appendCall(r0 BitbucketCloudClientListExplicitUserPermsForRepoFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// BitbucketCloudClientListExplicitUserPermsForRepoFuncCall objects
+// describing the invocations of this function.
+func (f *BitbucketCloudClientListExplicitUserPermsForRepoFunc) History() []BitbucketCloudClientListExplicitUserPermsForRepoFuncCall {
+	f.mutex.Lock()
+	history := make([]BitbucketCloudClientListExplicitUserPermsForRepoFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// BitbucketCloudClientListExplicitUserPermsForRepoFuncCall is an object
+// that describes an invocation of method ListExplicitUserPermsForRepo on an
+// instance of MockBitbucketCloudClient.
+type BitbucketCloudClientListExplicitUserPermsForRepoFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 *bitbucketcloud.PageToken
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []*bitbucketcloud.Account
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 *bitbucketcloud.PageToken
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c BitbucketCloudClientListExplicitUserPermsForRepoFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c BitbucketCloudClientListExplicitUserPermsForRepoFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
 // BitbucketCloudClientMergePullRequestFunc describes the behavior when the
 // MergePullRequest method of the parent MockBitbucketCloudClient instance
 // is invoked.
@@ -5200,24 +5338,24 @@ func (c BitbucketCloudClientRepoFuncCall) Results() []interface{} {
 // BitbucketCloudClientReposFunc describes the behavior when the Repos
 // method of the parent MockBitbucketCloudClient instance is invoked.
 type BitbucketCloudClientReposFunc struct {
-	defaultHook func(context.Context, *bitbucketcloud.PageToken, string) ([]*bitbucketcloud.Repo, *bitbucketcloud.PageToken, error)
-	hooks       []func(context.Context, *bitbucketcloud.PageToken, string) ([]*bitbucketcloud.Repo, *bitbucketcloud.PageToken, error)
+	defaultHook func(context.Context, *bitbucketcloud.PageToken, string, *bitbucketcloud.ReposOptions) ([]*bitbucketcloud.Repo, *bitbucketcloud.PageToken, error)
+	hooks       []func(context.Context, *bitbucketcloud.PageToken, string, *bitbucketcloud.ReposOptions) ([]*bitbucketcloud.Repo, *bitbucketcloud.PageToken, error)
 	history     []BitbucketCloudClientReposFuncCall
 	mutex       sync.Mutex
 }
 
 // Repos delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockBitbucketCloudClient) Repos(v0 context.Context, v1 *bitbucketcloud.PageToken, v2 string) ([]*bitbucketcloud.Repo, *bitbucketcloud.PageToken, error) {
-	r0, r1, r2 := m.ReposFunc.nextHook()(v0, v1, v2)
-	m.ReposFunc.appendCall(BitbucketCloudClientReposFuncCall{v0, v1, v2, r0, r1, r2})
+func (m *MockBitbucketCloudClient) Repos(v0 context.Context, v1 *bitbucketcloud.PageToken, v2 string, v3 *bitbucketcloud.ReposOptions) ([]*bitbucketcloud.Repo, *bitbucketcloud.PageToken, error) {
+	r0, r1, r2 := m.ReposFunc.nextHook()(v0, v1, v2, v3)
+	m.ReposFunc.appendCall(BitbucketCloudClientReposFuncCall{v0, v1, v2, v3, r0, r1, r2})
 	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the Repos method of the
 // parent MockBitbucketCloudClient instance is invoked and the hook queue is
 // empty.
-func (f *BitbucketCloudClientReposFunc) SetDefaultHook(hook func(context.Context, *bitbucketcloud.PageToken, string) ([]*bitbucketcloud.Repo, *bitbucketcloud.PageToken, error)) {
+func (f *BitbucketCloudClientReposFunc) SetDefaultHook(hook func(context.Context, *bitbucketcloud.PageToken, string, *bitbucketcloud.ReposOptions) ([]*bitbucketcloud.Repo, *bitbucketcloud.PageToken, error)) {
 	f.defaultHook = hook
 }
 
@@ -5225,7 +5363,7 @@ func (f *BitbucketCloudClientReposFunc) SetDefaultHook(hook func(context.Context
 // Repos method of the parent MockBitbucketCloudClient instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *BitbucketCloudClientReposFunc) PushHook(hook func(context.Context, *bitbucketcloud.PageToken, string) ([]*bitbucketcloud.Repo, *bitbucketcloud.PageToken, error)) {
+func (f *BitbucketCloudClientReposFunc) PushHook(hook func(context.Context, *bitbucketcloud.PageToken, string, *bitbucketcloud.ReposOptions) ([]*bitbucketcloud.Repo, *bitbucketcloud.PageToken, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -5234,19 +5372,19 @@ func (f *BitbucketCloudClientReposFunc) PushHook(hook func(context.Context, *bit
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *BitbucketCloudClientReposFunc) SetDefaultReturn(r0 []*bitbucketcloud.Repo, r1 *bitbucketcloud.PageToken, r2 error) {
-	f.SetDefaultHook(func(context.Context, *bitbucketcloud.PageToken, string) ([]*bitbucketcloud.Repo, *bitbucketcloud.PageToken, error) {
+	f.SetDefaultHook(func(context.Context, *bitbucketcloud.PageToken, string, *bitbucketcloud.ReposOptions) ([]*bitbucketcloud.Repo, *bitbucketcloud.PageToken, error) {
 		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *BitbucketCloudClientReposFunc) PushReturn(r0 []*bitbucketcloud.Repo, r1 *bitbucketcloud.PageToken, r2 error) {
-	f.PushHook(func(context.Context, *bitbucketcloud.PageToken, string) ([]*bitbucketcloud.Repo, *bitbucketcloud.PageToken, error) {
+	f.PushHook(func(context.Context, *bitbucketcloud.PageToken, string, *bitbucketcloud.ReposOptions) ([]*bitbucketcloud.Repo, *bitbucketcloud.PageToken, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *BitbucketCloudClientReposFunc) nextHook() func(context.Context, *bitbucketcloud.PageToken, string) ([]*bitbucketcloud.Repo, *bitbucketcloud.PageToken, error) {
+func (f *BitbucketCloudClientReposFunc) nextHook() func(context.Context, *bitbucketcloud.PageToken, string, *bitbucketcloud.ReposOptions) ([]*bitbucketcloud.Repo, *bitbucketcloud.PageToken, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -5288,6 +5426,9 @@ type BitbucketCloudClientReposFuncCall struct {
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
 	Arg2 string
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 *bitbucketcloud.ReposOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []*bitbucketcloud.Repo
@@ -5302,7 +5443,7 @@ type BitbucketCloudClientReposFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c BitbucketCloudClientReposFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this

--- a/enterprise/internal/batches/sources/mocks_test.go
+++ b/enterprise/internal/batches/sources/mocks_test.go
@@ -3690,7 +3690,7 @@ func NewMockBitbucketCloudClient() *MockBitbucketCloudClient {
 			},
 		},
 		ListExplicitUserPermsForRepoFunc: &BitbucketCloudClientListExplicitUserPermsForRepoFunc{
-			defaultHook: func(context.Context, *bitbucketcloud.PageToken, string, string) (r0 []*bitbucketcloud.Account, r1 *bitbucketcloud.PageToken, r2 error) {
+			defaultHook: func(context.Context, *bitbucketcloud.PageToken, string, string, *bitbucketcloud.RequestOptions) (r0 []*bitbucketcloud.Account, r1 *bitbucketcloud.PageToken, r2 error) {
 				return
 			},
 		},
@@ -3777,7 +3777,7 @@ func NewStrictMockBitbucketCloudClient() *MockBitbucketCloudClient {
 			},
 		},
 		ListExplicitUserPermsForRepoFunc: &BitbucketCloudClientListExplicitUserPermsForRepoFunc{
-			defaultHook: func(context.Context, *bitbucketcloud.PageToken, string, string) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error) {
+			defaultHook: func(context.Context, *bitbucketcloud.PageToken, string, string, *bitbucketcloud.RequestOptions) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error) {
 				panic("unexpected invocation of MockBitbucketCloudClient.ListExplicitUserPermsForRepo")
 			},
 		},
@@ -4887,24 +4887,24 @@ func (c BitbucketCloudClientGetPullRequestStatusesFuncCall) Results() []interfac
 // behavior when the ListExplicitUserPermsForRepo method of the parent
 // MockBitbucketCloudClient instance is invoked.
 type BitbucketCloudClientListExplicitUserPermsForRepoFunc struct {
-	defaultHook func(context.Context, *bitbucketcloud.PageToken, string, string) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error)
-	hooks       []func(context.Context, *bitbucketcloud.PageToken, string, string) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error)
+	defaultHook func(context.Context, *bitbucketcloud.PageToken, string, string, *bitbucketcloud.RequestOptions) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error)
+	hooks       []func(context.Context, *bitbucketcloud.PageToken, string, string, *bitbucketcloud.RequestOptions) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error)
 	history     []BitbucketCloudClientListExplicitUserPermsForRepoFuncCall
 	mutex       sync.Mutex
 }
 
 // ListExplicitUserPermsForRepo delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockBitbucketCloudClient) ListExplicitUserPermsForRepo(v0 context.Context, v1 *bitbucketcloud.PageToken, v2 string, v3 string) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error) {
-	r0, r1, r2 := m.ListExplicitUserPermsForRepoFunc.nextHook()(v0, v1, v2, v3)
-	m.ListExplicitUserPermsForRepoFunc.appendCall(BitbucketCloudClientListExplicitUserPermsForRepoFuncCall{v0, v1, v2, v3, r0, r1, r2})
+func (m *MockBitbucketCloudClient) ListExplicitUserPermsForRepo(v0 context.Context, v1 *bitbucketcloud.PageToken, v2 string, v3 string, v4 *bitbucketcloud.RequestOptions) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error) {
+	r0, r1, r2 := m.ListExplicitUserPermsForRepoFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.ListExplicitUserPermsForRepoFunc.appendCall(BitbucketCloudClientListExplicitUserPermsForRepoFuncCall{v0, v1, v2, v3, v4, r0, r1, r2})
 	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the
 // ListExplicitUserPermsForRepo method of the parent
 // MockBitbucketCloudClient instance is invoked and the hook queue is empty.
-func (f *BitbucketCloudClientListExplicitUserPermsForRepoFunc) SetDefaultHook(hook func(context.Context, *bitbucketcloud.PageToken, string, string) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error)) {
+func (f *BitbucketCloudClientListExplicitUserPermsForRepoFunc) SetDefaultHook(hook func(context.Context, *bitbucketcloud.PageToken, string, string, *bitbucketcloud.RequestOptions) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error)) {
 	f.defaultHook = hook
 }
 
@@ -4913,7 +4913,7 @@ func (f *BitbucketCloudClientListExplicitUserPermsForRepoFunc) SetDefaultHook(ho
 // MockBitbucketCloudClient instance invokes the hook at the front of the
 // queue and discards it. After the queue is empty, the default hook
 // function is invoked for any future action.
-func (f *BitbucketCloudClientListExplicitUserPermsForRepoFunc) PushHook(hook func(context.Context, *bitbucketcloud.PageToken, string, string) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error)) {
+func (f *BitbucketCloudClientListExplicitUserPermsForRepoFunc) PushHook(hook func(context.Context, *bitbucketcloud.PageToken, string, string, *bitbucketcloud.RequestOptions) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -4922,19 +4922,19 @@ func (f *BitbucketCloudClientListExplicitUserPermsForRepoFunc) PushHook(hook fun
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *BitbucketCloudClientListExplicitUserPermsForRepoFunc) SetDefaultReturn(r0 []*bitbucketcloud.Account, r1 *bitbucketcloud.PageToken, r2 error) {
-	f.SetDefaultHook(func(context.Context, *bitbucketcloud.PageToken, string, string) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error) {
+	f.SetDefaultHook(func(context.Context, *bitbucketcloud.PageToken, string, string, *bitbucketcloud.RequestOptions) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error) {
 		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *BitbucketCloudClientListExplicitUserPermsForRepoFunc) PushReturn(r0 []*bitbucketcloud.Account, r1 *bitbucketcloud.PageToken, r2 error) {
-	f.PushHook(func(context.Context, *bitbucketcloud.PageToken, string, string) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error) {
+	f.PushHook(func(context.Context, *bitbucketcloud.PageToken, string, string, *bitbucketcloud.RequestOptions) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *BitbucketCloudClientListExplicitUserPermsForRepoFunc) nextHook() func(context.Context, *bitbucketcloud.PageToken, string, string) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error) {
+func (f *BitbucketCloudClientListExplicitUserPermsForRepoFunc) nextHook() func(context.Context, *bitbucketcloud.PageToken, string, string, *bitbucketcloud.RequestOptions) ([]*bitbucketcloud.Account, *bitbucketcloud.PageToken, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -4981,6 +4981,9 @@ type BitbucketCloudClientListExplicitUserPermsForRepoFuncCall struct {
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
 	Arg3 string
+	// Arg4 is the value of the 5th argument passed to this method
+	// invocation.
+	Arg4 *bitbucketcloud.RequestOptions
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []*bitbucketcloud.Account
@@ -4995,7 +4998,7 @@ type BitbucketCloudClientListExplicitUserPermsForRepoFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c BitbucketCloudClientListExplicitUserPermsForRepoFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -150,8 +150,8 @@ func (c *client) Ping(ctx context.Context) error {
 
 func FetchAll[T any](ctx context.Context, c Client, results []T, next *PageToken, err error) ([]T, error) {
 	cli := c.(*client)
+	var page []T
 	for err == nil && next.HasMore() {
-		var page []T
 		next, err = cli.page(ctx, next.Next, next.Values(), next, &page)
 		results = append(results, page...)
 	}

--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -148,6 +148,17 @@ func (c *client) Ping(ctx context.Context) error {
 	return nil
 }
 
+func FetchAll[T any](ctx context.Context, c Client, results []T, next *PageToken, err error) ([]T, error) {
+	cli := c.(*client)
+	for err == nil && next.HasMore() {
+		var page []T
+		next, err = cli.page(ctx, next.Next, next.Values(), next, &page)
+		results = append(results, page...)
+	}
+
+	return results, err
+}
+
 func (c *client) page(ctx context.Context, path string, qry url.Values, token *PageToken, results any) (*PageToken, error) {
 	if qry == nil {
 		qry = make(url.Values)

--- a/internal/extsvc/bitbucketcloud/common.go
+++ b/internal/extsvc/bitbucketcloud/common.go
@@ -1,0 +1,41 @@
+package bitbucketcloud
+
+import (
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/oauthutil"
+	"golang.org/x/oauth2"
+)
+
+var MockGetOAuthContext func() *oauthutil.OAuthContext
+
+func GetOAuthContext(baseURL string) *oauthutil.OAuthContext {
+	if MockGetOAuthContext != nil {
+		return MockGetOAuthContext()
+	}
+
+	for _, authProvider := range conf.SiteConfig().AuthProviders {
+		if authProvider.Bitbucketcloud != nil {
+			p := authProvider.Bitbucketcloud
+			rawURL := p.Url
+			if rawURL == "" {
+				rawURL = "https://bitbucket.org"
+			}
+			bbURL := strings.TrimSuffix(rawURL, "/")
+			if !strings.HasPrefix(baseURL, bbURL) {
+				continue
+			}
+
+			return &oauthutil.OAuthContext{
+				ClientID:     p.ClientKey,
+				ClientSecret: p.ClientSecret,
+				Endpoint: oauth2.Endpoint{
+					AuthURL:  bbURL + "/site/oauth2/authorize",
+					TokenURL: bbURL + "/site/oauth2/access_token",
+				},
+			}
+		}
+	}
+	return nil
+}

--- a/internal/extsvc/bitbucketcloud/common.go
+++ b/internal/extsvc/bitbucketcloud/common.go
@@ -1,6 +1,7 @@
 package bitbucketcloud
 
 import (
+	"net/url"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -22,8 +23,16 @@ func GetOAuthContext(baseURL string) *oauthutil.OAuthContext {
 			if rawURL == "" {
 				rawURL = "https://bitbucket.org"
 			}
-			bbURL := strings.TrimSuffix(rawURL, "/")
-			if !strings.HasPrefix(baseURL, bbURL) {
+			rawURL = strings.TrimSuffix(rawURL, "/")
+			if !strings.HasPrefix(baseURL, rawURL) {
+				continue
+			}
+			authURL, err := url.JoinPath(rawURL, "/site/oauth2/authorize")
+			if err != nil {
+				continue
+			}
+			tokenURL, err := url.JoinPath(rawURL, "/site/oauth2/access_token")
+			if err != nil {
 				continue
 			}
 
@@ -31,8 +40,8 @@ func GetOAuthContext(baseURL string) *oauthutil.OAuthContext {
 				ClientID:     p.ClientKey,
 				ClientSecret: p.ClientSecret,
 				Endpoint: oauth2.Endpoint{
-					AuthURL:  bbURL + "/site/oauth2/authorize",
-					TokenURL: bbURL + "/site/oauth2/access_token",
+					AuthURL:  authURL,
+					TokenURL: tokenURL,
 				},
 			}
 		}

--- a/internal/extsvc/bitbucketcloud/repositories.go
+++ b/internal/extsvc/bitbucketcloud/repositories.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -25,22 +26,65 @@ func (c *client) Repo(ctx context.Context, namespace, slug string) (*Repo, error
 	return &repo, nil
 }
 
+type ReposOptions struct {
+	Role string `url:"role,omitempty"`
+}
+
 // Repos returns a list of repositories that are fetched and populated based on given account
 // name and pagination criteria. If the account requested is a team, results will be filtered
 // down to the ones that the app password's user has access to.
 // If the argument pageToken.Next is not empty, it will be used directly as the URL to make
 // the request. The PageToken it returns may also contain the URL to the next page for
 // succeeding requests if any.
-func (c *client) Repos(ctx context.Context, pageToken *PageToken, accountName string) ([]*Repo, *PageToken, error) {
-	var repos []*Repo
-	var next *PageToken
-	var err error
+// If the argument accountName is empty, it will return all repositories for
+// the authenticated user.
+func (c *client) Repos(ctx context.Context, pageToken *PageToken, accountName string, opts *ReposOptions) (repos []*Repo, next *PageToken, err error) {
 	if pageToken.HasMore() {
 		next, err = c.reqPage(ctx, pageToken.Next, &repos)
-	} else {
-		next, err = c.page(ctx, fmt.Sprintf("/2.0/repositories/%s", accountName), nil, pageToken, &repos)
+		return
 	}
+
+	var reposURL string
+	if accountName == "" {
+		reposURL = "/2.0/repositories"
+	} else {
+		reposURL = fmt.Sprintf("/2.0/repositories/%s", accountName)
+	}
+
+	var urlValues url.Values
+	if opts != nil && opts.Role != "" {
+		urlValues = make(url.Values)
+		urlValues.Set("role", opts.Role)
+	}
+
+	next, err = c.page(ctx, reposURL, urlValues, pageToken, &repos)
 	return repos, next, err
+}
+
+type ExplicitUserPermsResponse struct {
+	User       *Account `json:"user"`
+	Permission string   `json:"permission"`
+}
+
+func (c *client) ListExplicitUserPermsForRepo(ctx context.Context, pageToken *PageToken, namespace, slug string) (users []*Account, next *PageToken, err error) {
+	var resp []ExplicitUserPermsResponse
+	if pageToken.HasMore() {
+		next, err = c.reqPage(ctx, pageToken.Next, &resp)
+	} else {
+		userPermsURL := fmt.Sprintf("/2.0/repositories/%s/%s/permissions-config/users", namespace, slug)
+		next, err = c.page(ctx, userPermsURL, nil, pageToken, &resp)
+	}
+
+	if err != nil {
+		return
+	}
+
+	users = make([]*Account, len(resp))
+	for i, r := range resp {
+		users[i] = r.User
+	}
+
+	return
 }
 
 type ForkInputProject struct {

--- a/internal/extsvc/bitbucketcloud/repositories.go
+++ b/internal/extsvc/bitbucketcloud/repositories.go
@@ -48,7 +48,7 @@ func (c *client) Repos(ctx context.Context, pageToken *PageToken, accountName st
 	if accountName == "" {
 		reposURL = "/2.0/repositories"
 	} else {
-		reposURL = fmt.Sprintf("/2.0/repositories/%s", accountName)
+		reposURL = fmt.Sprintf("/2.0/repositories/%s", url.PathEscape(accountName))
 	}
 
 	var urlValues url.Values
@@ -71,7 +71,7 @@ func (c *client) ListExplicitUserPermsForRepo(ctx context.Context, pageToken *Pa
 	if pageToken.HasMore() {
 		next, err = c.reqPage(ctx, pageToken.Next, &resp)
 	} else {
-		userPermsURL := fmt.Sprintf("/2.0/repositories/%s/%s/permissions-config/users", namespace, slug)
+		userPermsURL := fmt.Sprintf("/2.0/repositories/%s/%s/permissions-config/users", url.PathEscape(namespace), url.PathEscape(slug))
 		next, err = c.page(ctx, userPermsURL, nil, pageToken, &resp)
 	}
 

--- a/internal/extsvc/bitbucketcloud/repositories_test.go
+++ b/internal/extsvc/bitbucketcloud/repositories_test.go
@@ -131,7 +131,7 @@ func TestClient_Repos(t *testing.T) {
 				tc.err = "<nil>"
 			}
 
-			repos, next, err := cli.Repos(tc.ctx, tc.page, tc.account)
+			repos, next, err := cli.Repos(tc.ctx, tc.page, tc.account, nil)
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
 			}

--- a/internal/extsvc/bitbucketcloud/repositories_test.go
+++ b/internal/extsvc/bitbucketcloud/repositories_test.go
@@ -61,6 +61,16 @@ func TestClient_Repos(t *testing.T) {
 				HTML: Link{Href: "https://bitbucket.org/sourcegraph-testing/src-cli"},
 			},
 			ForkPolicy: ForkPolicyNoPublic,
+			Owner: &Account{
+				Links: Links{
+					"avatar": Link{Href: "https://secure.gravatar.com/avatar/f964dc31564db8243e952bdaeabbe884?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FST-2.png"},
+					"html":   Link{Href: "https://bitbucket.org/%7B4b85b785-1433-4092-8512-20302f4a03be%7D/"},
+					"self":   Link{Href: "https://api.bitbucket.org/2.0/users/%7B4b85b785-1433-4092-8512-20302f4a03be%7D"},
+				},
+				Nickname:    "Sourcegraph Testing",
+				DisplayName: "Sourcegraph Testing",
+				UUID:        "{4b85b785-1433-4092-8512-20302f4a03be}",
+			},
 		},
 		"sourcegraph": {
 			Slug:      "sourcegraph",
@@ -77,6 +87,16 @@ func TestClient_Repos(t *testing.T) {
 				HTML: Link{Href: "https://bitbucket.org/sourcegraph-testing/sourcegraph"},
 			},
 			ForkPolicy: ForkPolicyNoPublic,
+			Owner: &Account{
+				Links: Links{
+					"avatar": Link{Href: "https://secure.gravatar.com/avatar/f964dc31564db8243e952bdaeabbe884?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FST-2.png"},
+					"html":   Link{Href: "https://bitbucket.org/%7B4b85b785-1433-4092-8512-20302f4a03be%7D/"},
+					"self":   Link{Href: "https://api.bitbucket.org/2.0/users/%7B4b85b785-1433-4092-8512-20302f4a03be%7D"},
+				},
+				Nickname:    "Sourcegraph Testing",
+				DisplayName: "Sourcegraph Testing",
+				UUID:        "{4b85b785-1433-4092-8512-20302f4a03be}",
+			},
 		},
 	}
 

--- a/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-CreatePullRequest-Fork-recreated
+++ b/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-CreatePullRequest-Fork-recreated
@@ -101,7 +101,8 @@
       "href": "https://bitbucket.org/aharvey-sg/src-cli-testing"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    },
    "branch": {
     "name": "branch-fork-00",
@@ -128,7 +129,8 @@
       "href": "https://bitbucket.org/sourcegraph-testing/src-cli"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    },
    "branch": {
     "name": "master",

--- a/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-CreatePullRequest-Fork-valid-omitted-destination-branch
+++ b/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-CreatePullRequest-Fork-valid-omitted-destination-branch
@@ -101,7 +101,8 @@
       "href": "https://bitbucket.org/aharvey-sg/src-cli-testing"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    },
    "branch": {
     "name": "branch-fork-00",
@@ -128,7 +129,8 @@
       "href": "https://bitbucket.org/sourcegraph-testing/src-cli"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    },
    "branch": {
     "name": "master",

--- a/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-CreatePullRequest-SameOrigin-recreated
+++ b/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-CreatePullRequest-SameOrigin-recreated
@@ -101,7 +101,8 @@
       "href": "https://bitbucket.org/sourcegraph-testing/src-cli"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    },
    "branch": {
     "name": "branch-00",
@@ -128,7 +129,8 @@
       "href": "https://bitbucket.org/sourcegraph-testing/src-cli"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    },
    "branch": {
     "name": "master",

--- a/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-CreatePullRequest-SameOrigin-valid-destination-branch
+++ b/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-CreatePullRequest-SameOrigin-valid-destination-branch
@@ -101,7 +101,8 @@
       "href": "https://bitbucket.org/sourcegraph-testing/src-cli"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    },
    "branch": {
     "name": "branch-00",
@@ -128,7 +129,8 @@
       "href": "https://bitbucket.org/sourcegraph-testing/src-cli"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    },
    "branch": {
     "name": "master",

--- a/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-DeclinePullRequest-found
+++ b/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-DeclinePullRequest-found
@@ -101,7 +101,8 @@
       "href": "https://bitbucket.org/sourcegraph-testing/src-cli"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    },
    "branch": {
     "name": "branch-00",
@@ -128,7 +129,8 @@
       "href": "https://bitbucket.org/sourcegraph-testing/src-cli"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    },
    "branch": {
     "name": "master",

--- a/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-ForkRepository-success
+++ b/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-ForkRepository-success
@@ -20,7 +20,8 @@
      "href": "https://bitbucket.org/sourcegraph-testing/src-cli"
     }
    },
-   "fork_policy": ""
+   "fork_policy": "",
+   "owner": null
   },
   "is_private": true,
   "links": {
@@ -38,5 +39,25 @@
     "href": "https://bitbucket.org/sourcegraph-testing/src-cli-fork-00"
    }
   },
-  "fork_policy": "no_public_forks"
+  "fork_policy": "no_public_forks",
+  "owner": {
+   "links": {
+    "avatar": {
+     "href": "https://secure.gravatar.com/avatar/f964dc31564db8243e952bdaeabbe884?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FST-2.png"
+    },
+    "html": {
+     "href": "https://bitbucket.org/%7B4b85b785-1433-4092-8512-20302f4a03be%7D/"
+    },
+    "self": {
+     "href": "https://api.bitbucket.org/2.0/users/%7B4b85b785-1433-4092-8512-20302f4a03be%7D"
+    }
+   },
+   "username": "",
+   "nickname": "Sourcegraph Testing",
+   "account_status": "",
+   "display_name": "Sourcegraph Testing",
+   "website": "",
+   "created_on": "0001-01-01T00:00:00Z",
+   "uuid": "{4b85b785-1433-4092-8512-20302f4a03be}"
+  }
  }

--- a/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-GetPullRequest-found
+++ b/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-GetPullRequest-found
@@ -101,7 +101,8 @@
       "href": "https://bitbucket.org/sourcegraph-testing/src-cli"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    },
    "branch": {
     "name": "always-open",
@@ -128,7 +129,8 @@
       "href": "https://bitbucket.org/sourcegraph-testing/src-cli"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    },
    "branch": {
     "name": "master",

--- a/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-MergePullRequest-found
+++ b/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-MergePullRequest-found
@@ -101,7 +101,8 @@
       "href": "https://bitbucket.org/sourcegraph-testing/src-cli"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    },
    "branch": {
     "name": "merge-test-01",
@@ -128,7 +129,8 @@
       "href": "https://bitbucket.org/sourcegraph-testing/src-cli"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    },
    "branch": {
     "name": "master",

--- a/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-Repo-valid-repo
+++ b/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-Repo-valid-repo
@@ -22,5 +22,25 @@
     "href": "https://bitbucket.org/sourcegraph-testing/sourcegraph"
    }
   },
-  "fork_policy": "no_public_forks"
+  "fork_policy": "no_public_forks",
+  "owner": {
+   "links": {
+    "avatar": {
+     "href": "https://secure.gravatar.com/avatar/f964dc31564db8243e952bdaeabbe884?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FST-2.png"
+    },
+    "html": {
+     "href": "https://bitbucket.org/%7B4b85b785-1433-4092-8512-20302f4a03be%7D/"
+    },
+    "self": {
+     "href": "https://api.bitbucket.org/2.0/users/%7B4b85b785-1433-4092-8512-20302f4a03be%7D"
+    }
+   },
+   "username": "",
+   "nickname": "Sourcegraph Testing",
+   "account_status": "",
+   "display_name": "Sourcegraph Testing",
+   "website": "",
+   "created_on": "0001-01-01T00:00:00Z",
+   "uuid": "{4b85b785-1433-4092-8512-20302f4a03be}"
+  }
  }

--- a/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-UpdatePullRequest-found
+++ b/internal/extsvc/bitbucketcloud/testdata/golden/TestClient-UpdatePullRequest-found
@@ -101,7 +101,8 @@
       "href": "https://bitbucket.org/sourcegraph-testing/src-cli"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    },
    "branch": {
     "name": "always-open",
@@ -128,7 +129,8 @@
       "href": "https://bitbucket.org/sourcegraph-testing/src-cli"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    },
    "branch": {
     "name": "master",

--- a/internal/extsvc/bitbucketcloud/types.go
+++ b/internal/extsvc/bitbucketcloud/types.go
@@ -194,6 +194,7 @@ type Repo struct {
 	IsPrivate   bool       `json:"is_private"`
 	Links       RepoLinks  `json:"links"`
 	ForkPolicy  ForkPolicy `json:"fork_policy"`
+	Owner       *Account   `json:"owner"`
 }
 
 func (r *Repo) Namespace() (string, error) {

--- a/internal/repos/bitbucketcloud.go
+++ b/internal/repos/bitbucketcloud.go
@@ -179,7 +179,7 @@ func (s *BitbucketCloudSource) listAllRepos(ctx context.Context, results chan So
 		var err error
 		var repos []*bitbucketcloud.Repo
 		for page.HasMore() || page.Page == 0 {
-			if repos, page, err = s.client.Repos(ctx, page, s.config.Username); err != nil {
+			if repos, page, err = s.client.Repos(ctx, page, s.config.Username, nil); err != nil {
 				ch <- batch{err: errors.Wrapf(err, "bitbucketcloud.repos: item=%q, page=%+v", s.config.Username, page)}
 				break
 			}
@@ -198,7 +198,7 @@ func (s *BitbucketCloudSource) listAllRepos(ctx context.Context, results chan So
 			var err error
 			var repos []*bitbucketcloud.Repo
 			for page.HasMore() || page.Page == 0 {
-				if repos, page, err = s.client.Repos(ctx, page, t); err != nil {
+				if repos, page, err = s.client.Repos(ctx, page, t, nil); err != nil {
 					ch <- batch{err: errors.Wrapf(err, "bitbucketcloud.teams: item=%q, page=%+v", t, page)}
 					break
 				}

--- a/internal/repos/testdata/golden/BitbucketCloudSource_makeRepo_path-pattern
+++ b/internal/repos/testdata/golden/BitbucketCloudSource_makeRepo_path-pattern
@@ -45,7 +45,8 @@
       "href": "https://bitbucket.org/sg/go-langserver"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    }
   },
   {
@@ -94,7 +95,8 @@
       "href": "https://bitbucket.org/sg/python-langserver"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    }
   },
   {
@@ -141,7 +143,8 @@
        "href": "https://bitbucket.org/sg/python-langserver"
       }
      },
-     "fork_policy": ""
+     "fork_policy": "",
+     "owner": null
     },
     "is_private": false,
     "links": {
@@ -159,7 +162,8 @@
       "href": "https://bitbucket.org/sg/python-langserver-fork"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    }
   }
  ]

--- a/internal/repos/testdata/golden/BitbucketCloudSource_makeRepo_simple
+++ b/internal/repos/testdata/golden/BitbucketCloudSource_makeRepo_simple
@@ -45,7 +45,8 @@
       "href": "https://bitbucket.org/sg/go-langserver"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    }
   },
   {
@@ -94,7 +95,8 @@
       "href": "https://bitbucket.org/sg/python-langserver"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    }
   },
   {
@@ -141,7 +143,8 @@
        "href": "https://bitbucket.org/sg/python-langserver"
       }
      },
-     "fork_policy": ""
+     "fork_policy": "",
+     "owner": null
     },
     "is_private": false,
     "links": {
@@ -159,7 +162,8 @@
       "href": "https://bitbucket.org/sg/python-langserver-fork"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    }
   }
  ]

--- a/internal/repos/testdata/golden/BitbucketCloudSource_makeRepo_ssh
+++ b/internal/repos/testdata/golden/BitbucketCloudSource_makeRepo_ssh
@@ -45,7 +45,8 @@
       "href": "https://bitbucket.org/sg/go-langserver"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    }
   },
   {
@@ -94,7 +95,8 @@
       "href": "https://bitbucket.org/sg/python-langserver"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    }
   },
   {
@@ -141,7 +143,8 @@
        "href": "https://bitbucket.org/sg/python-langserver"
       }
      },
-     "fork_policy": ""
+     "fork_policy": "",
+     "owner": null
     },
     "is_private": false,
     "links": {
@@ -159,7 +162,8 @@
       "href": "https://bitbucket.org/sg/python-langserver-fork"
      }
     },
-    "fork_policy": ""
+    "fork_policy": "",
+    "owner": null
    }
   }
  ]

--- a/internal/types/external_services.go
+++ b/internal/types/external_services.go
@@ -22,6 +22,12 @@ type GitLabConnection struct {
 	*schema.GitLabConnection
 }
 
+type BitbucketCloudConnection struct {
+	// The unique resource identifier of the external service.
+	URN string
+	*schema.BitbucketCloudConnection
+}
+
 type PerforceConnection struct {
 	// The unique resource identifier of the external service.
 	URN string

--- a/schema/bitbucket_cloud.schema.json
+++ b/schema/bitbucket_cloud.schema.json
@@ -53,6 +53,17 @@
         "requestsPerHour": 7200
       }
     },
+    "authorization": {
+      "title": "BitbucketCloudAuthorization",
+      "description": "If non-null, enforces Bitbucket Cloud repository permissions. This requires that there is an item in the [site configuration json](https://docs.sourcegraph.com/admin/config/site_config#auth-providers) `auth.providers` field, of type \"bitbucketcloud\" with the same `url` field as specified in this `BitbucketCloudConnection`.",
+      "type": "object",
+      "properties": {
+        "identityProvider": {
+          "description": "The identity provider to use for user information. If not set, the `url` field is used.",
+          "type": "string"
+        }
+      }
+    },
     "username": {
       "description": "The username to use when authenticating to the Bitbucket Cloud. Also set the corresponding \"appPassword\" field.",
       "type": "string"

--- a/schema/bitbucketcloud_util.go
+++ b/schema/bitbucketcloud_util.go
@@ -1,0 +1,11 @@
+package schema
+
+var DefaultBitbucketCloudURL = "https://bitbucket.org"
+
+// GetURL retrieves the configured GitHub URL or a default if one is not set.
+func (p *BitbucketCloudAuthProvider) GetURL() string {
+	if p != nil && p.Url != "" {
+		return p.Url
+	}
+	return DefaultBitbucketCloudURL
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -235,12 +235,20 @@ type BitbucketCloudAuthProvider struct {
 	Url string `json:"url,omitempty"`
 }
 
+// BitbucketCloudAuthorization description: If non-null, enforces Bitbucket Cloud repository permissions. This requires that there is an item in the [site configuration json](https://docs.sourcegraph.com/admin/config/site_config#auth-providers) `auth.providers` field, of type "bitbucketcloud" with the same `url` field as specified in this `BitbucketCloudConnection`.
+type BitbucketCloudAuthorization struct {
+	// IdentityProvider description: The identity provider to use for user information. If not set, the `url` field is used.
+	IdentityProvider string `json:"identityProvider,omitempty"`
+}
+
 // BitbucketCloudConnection description: Configuration for a connection to Bitbucket Cloud.
 type BitbucketCloudConnection struct {
 	// ApiURL description: The API URL of Bitbucket Cloud, such as https://api.bitbucket.org. Generally, admin should not modify the value of this option because Bitbucket Cloud is a public hosting platform.
 	ApiURL string `json:"apiURL,omitempty"`
 	// AppPassword description: The app password to use when authenticating to the Bitbucket Cloud. Also set the corresponding "username" field.
 	AppPassword string `json:"appPassword"`
+	// Authorization description: If non-null, enforces Bitbucket Cloud repository permissions. This requires that there is an item in the [site configuration json](https://docs.sourcegraph.com/admin/config/site_config#auth-providers) `auth.providers` field, of type "bitbucketcloud" with the same `url` field as specified in this `BitbucketCloudConnection`.
+	Authorization *BitbucketCloudAuthorization `json:"authorization,omitempty"`
 	// Exclude description: A list of repositories to never mirror from Bitbucket Cloud. Takes precedence over "teams" configuration.
 	//
 	// Supports excluding by name ({"name": "myorg/myrepo"}) or by UUID ({"uuid": "{fceb73c7-cef6-4abe-956d-e471281126bd}"}).

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2107,7 +2107,7 @@
           "type": "string",
           "description": "The OAuth API scope that should be used",
           "default": "account,email,repository",
-          "enum": ["account", "email", "repository:read"]
+          "enum": ["account", "email", "repository"]
         },
         "allowSignup": {
           "description": "Allows new visitors to sign up for accounts via Bitbucket Cloud authentication. If false, users signing in via Bitbucket Cloud must have an existing Sourcegraph account, which will be linked to their Bitbucket Cloud identity after sign-in.",


### PR DESCRIPTION
Adds permissions syncing for Bitbucket Cloud code host connections.

Loom: https://www.loom.com/share/1378727858244c8394d0ce705e4a85ae

## Test plan

Unit tests added. I also did manual verifications and confirmed things like token refreshing.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
