### PR TITLE
Clear displayed README when switching into a sub dir that does not have a README file

### DIFF
--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -263,6 +263,7 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
             return null
         })()
         if (!readmeEntry) {
+            setReadmeInfo(undefined)
             return
         }
 
@@ -357,7 +358,6 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
         <>
             {readmeInfo && (
                 <ReadmePreviewCard
-                    key={readmeInfo.blob.richHTML}
                     readmeHTML={readmeInfo.blob.richHTML}
                     readmeURL={readmeInfo.entry.url}
                     location={props.location}


### PR DESCRIPTION
This fixes an issue with the new repo pages when navigating into a sub directory that does not have a README.

Previously, this would still show the previous README instead (see the test plan for a comparison) 

## Test plan

https://user-images.githubusercontent.com/458591/211787401-652056ff-dab2-4c69-8790-3bff29afe598.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-new-repo-page-clear-readme.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
