### PR TITLE
Remove underline when hovering over a line in the references panel

### DIFF
--- a/client/web/src/repo/blob/codemirror/navigate-to-any-line-on-click.ts
+++ b/client/web/src/repo/blob/codemirror/navigate-to-any-line-on-click.ts
@@ -29,7 +29,11 @@ class LineLinkManager implements PluginValue {
                 builder.add(
                     line.from,
                     line.to,
-                    Decoration.mark({ tagName: 'a', attributes: { href, 'data-line-link': '' } })
+                    Decoration.mark({
+                        tagName: 'a',
+                        attributes: { href, 'data-line-link': '' },
+                        class: 'text-decoration-none',
+                    })
                 )
                 pos = line.to + 1
             }


### PR DESCRIPTION
I’m not sure the underline was added on purpose?

## Before

<img width="603" alt="Screenshot 2023-01-11 at 12 00 29" src="https://user-images.githubusercontent.com/458591/211790086-5e2c5479-abd9-411e-b46d-1c4580d0026d.png">

## Test plan

<img width="507" alt="Screenshot 2023-01-11 at 12 00 52" src="https://user-images.githubusercontent.com/458591/211790099-7466caad-c665-4b1c-b163-495a43a858d8.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-remove-underline-in-ref-panel.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
