### PR TITLE
sg: start blobstore whenever worker is started

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -868,6 +868,7 @@ commandsets:
       - zoekt-index-1
       - zoekt-web-0
       - zoekt-web-1
+      - blobstore
 
   enterprise-e2e:
     <<: *enterprise_set
@@ -940,6 +941,7 @@ commandsets:
       - zoekt-index-1
       - zoekt-web-0
       - zoekt-web-1
+      - blobstore
     env:
       DISABLE_CODE_INSIGHTS_HISTORICAL: false
       DISABLE_CODE_INSIGHTS: false
@@ -964,6 +966,7 @@ commandsets:
       - zoekt-index-1
       - zoekt-web-0
       - zoekt-web-1
+      - blobstore
 
   batches:
     requiresDevPrivate: true
@@ -989,6 +992,7 @@ commandsets:
       - zoekt-index-1
       - zoekt-web-0
       - zoekt-web-1
+      - blobstore
       - batches-executor
       - batcheshelper-builder
 


### PR DESCRIPTION
code-intel jobs in `worker` rely on `blobstore` running. To avoid distracting logs such as below, we should startup `blobstore` with `worker` even if code-intel processes arent being used. 

```
[         worker] ERROR codeintel.upload-store-expirer goroutine/periodic.go:81 An error occurred in a background task {"handler": "codeintel.upload-store-expirer", "error": "failed to create bucket: operation error S3: CreateBucket, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , HostID: , request send failed, Put \"http://localhost:9000/lsif-uploads\": dial tcp 127.0.0.1:9000: connect: connection refused"}
```

There may be permission issues that need addressing in sg-setup or similar, but that may not be a problem anymore

## Test plan

N/A dev stuff
