### PR TITLE
web: add code host details page. INCLUDES MUST WATCH DEMO. THIS VIDEO IS SO...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added a way to test code host connection from the `Manage code hosts` page. [#45972](https://github.com/sourcegraph/sourcegraph/pull/45972)
 - Updates to the site configuration from the site admin panel will now also record the user id of the author in the database in the `critical_and_site_config.author_user_id` column. [#46150](https://github.com/sourcegraph/sourcegraph/pull/46150)
 - When setting and resetting passwords, if the user's primary email address is not yet verified, using the password reset link sent via email will now also verify the email address. [#46307](https://github.com/sourcegraph/sourcegraph/pull/46307)
+- Added new code host details and updated edit code host pages in site admin area. [#46327](https://github.com/sourcegraph/sourcegraph/pull/46327)
 
 ### Changed
 

--- a/client/web/src/components/externalServices/AddExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicePage.tsx
@@ -20,7 +20,6 @@ interface Props extends ThemeProps, TelemetryProps {
     history: H.History
     externalService: AddExternalServiceOptions
     routingPrefix: string
-    afterCreateRoute: string
     userID?: Scalars['ID']
     externalServicesFromFile: boolean
     allowEditExternalServicesWithFile: boolean
@@ -33,7 +32,6 @@ interface Props extends ThemeProps, TelemetryProps {
  * Page for adding a single external service.
  */
 export const AddExternalServicePage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
-    afterCreateRoute,
     externalService,
     history,
     isLightTheme,
@@ -93,9 +91,9 @@ export const AddExternalServicePage: React.FunctionComponent<React.PropsWithChil
             // reflect the latest configuration.
             // eslint-disable-next-line rxjs/no-ignored-subscription
             refreshSiteFlags().subscribe({ error: error => logger.error(error) })
-            history.push(afterCreateRoute)
+            history.push(`${routingPrefix}/external-services/${createdExternalService.id}`)
         }
-    }, [afterCreateRoute, createdExternalService, history])
+    }, [createdExternalService, routingPrefix, history])
 
     return (
         <>

--- a/client/web/src/components/externalServices/AddExternalServicesPage.story.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.story.tsx
@@ -29,7 +29,6 @@ export const Overview: Story = () => (
                 {...webProps}
                 routingPrefix="/site-admin"
                 telemetryService={NOOP_TELEMETRY_SERVICE}
-                afterCreateRoute="/site-admin/after"
                 codeHostExternalServices={codeHostExternalServices}
                 nonCodeHostExternalServices={nonCodeHostExternalServices}
                 autoFocusForm={false}
@@ -47,7 +46,6 @@ export const AddConnectionBykind: Story = () => (
                 {...webProps}
                 routingPrefix="/site-admin"
                 telemetryService={NOOP_TELEMETRY_SERVICE}
-                afterCreateRoute="/site-admin/after"
                 codeHostExternalServices={codeHostExternalServices}
                 nonCodeHostExternalServices={nonCodeHostExternalServices}
                 autoFocusForm={false}

--- a/client/web/src/components/externalServices/AddExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.tsx
@@ -19,7 +19,6 @@ import styles from './AddExternalServicesPage.module.scss'
 export interface AddExternalServicesPageProps extends ThemeProps, TelemetryProps {
     history: H.History
     routingPrefix: string
-    afterCreateRoute: string
     userID?: Scalars['ID']
 
     /**
@@ -46,7 +45,6 @@ export interface AddExternalServicesPageProps extends ThemeProps, TelemetryProps
 export const AddExternalServicesPage: React.FunctionComponent<
     React.PropsWithChildren<AddExternalServicesPageProps>
 > = ({
-    afterCreateRoute,
     codeHostExternalServices,
     history,
     isLightTheme,
@@ -71,7 +69,6 @@ export const AddExternalServicesPage: React.FunctionComponent<
         if (externalService) {
             return (
                 <AddExternalServicePage
-                    afterCreateRoute={afterCreateRoute}
                     history={history}
                     isLightTheme={isLightTheme}
                     routingPrefix={routingPrefix}

--- a/client/web/src/components/externalServices/ExternalServiceEditPage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditPage.story.tsx
@@ -1,16 +1,14 @@
 import { DecoratorFn, Story, Meta } from '@storybook/react'
-import { subMinutes } from 'date-fns'
-import { of } from 'rxjs'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
-import { ExternalServiceFields, ExternalServiceKind, ExternalServiceSyncJobState } from '../../graphql-operations'
+import { ExternalServiceFields, ExternalServiceKind } from '../../graphql-operations'
 import { WebStory } from '../WebStory'
 
-import { FETCH_EXTERNAL_SERVICE, queryExternalServiceSyncJobs as _queryExternalServiceSyncJobs } from './backend'
+import { FETCH_EXTERNAL_SERVICE } from './backend'
 import { ExternalServiceEditPage } from './ExternalServiceEditPage'
 
 const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
@@ -42,76 +40,13 @@ const externalService = {
     nextSyncAt: null,
     updatedAt: '2021-03-15T19:39:11Z',
     createdAt: '2021-03-15T19:39:11Z',
+    hasConnectionCheck: false,
     namespace: {
         id: 'userid',
         namespaceName: 'johndoe',
         url: '/users/johndoe',
     },
 }
-
-const queryExternalServiceSyncJobs: typeof _queryExternalServiceSyncJobs = () =>
-    of({
-        totalCount: 4,
-        pageInfo: { endCursor: null, hasNextPage: false },
-        nodes: [
-            {
-                __typename: 'ExternalServiceSyncJob',
-                failureMessage: null,
-                startedAt: subMinutes(new Date(), 25).toISOString(),
-                finishedAt: null,
-                id: 'SYNCJOB1',
-                state: ExternalServiceSyncJobState.CANCELING,
-                reposSynced: 5,
-                repoSyncErrors: 0,
-                reposAdded: 5,
-                reposDeleted: 0,
-                reposModified: 0,
-                reposUnmodified: 0,
-            },
-            {
-                __typename: 'ExternalServiceSyncJob',
-                failureMessage: null,
-                startedAt: subMinutes(new Date(), 25).toISOString(),
-                finishedAt: null,
-                id: 'SYNCJOB1',
-                state: ExternalServiceSyncJobState.PROCESSING,
-                reposSynced: 5,
-                repoSyncErrors: 0,
-                reposAdded: 5,
-                reposDeleted: 0,
-                reposModified: 0,
-                reposUnmodified: 0,
-            },
-            {
-                __typename: 'ExternalServiceSyncJob',
-                failureMessage: 'Very bad error syncing with the code host.',
-                startedAt: subMinutes(new Date(), 25).toISOString(),
-                finishedAt: subMinutes(new Date(), 25).toISOString(),
-                id: 'SYNCJOB1',
-                state: ExternalServiceSyncJobState.FAILED,
-                reposSynced: 5,
-                repoSyncErrors: 0,
-                reposAdded: 5,
-                reposDeleted: 0,
-                reposModified: 0,
-                reposUnmodified: 0,
-            },
-            {
-                __typename: 'ExternalServiceSyncJob',
-                failureMessage: null,
-                startedAt: subMinutes(new Date(), 25).toISOString(),
-                finishedAt: subMinutes(new Date(), 25).toISOString(),
-                id: 'SYNCJOB1',
-                state: ExternalServiceSyncJobState.COMPLETED,
-                reposSynced: 5,
-                repoSyncErrors: 0,
-                reposAdded: 5,
-                reposDeleted: 0,
-                reposModified: 0,
-                reposUnmodified: 0,
-            },
-        ],
-    })
 
 function newFetchMock(node: { __typename: 'ExternalService' } & ExternalServiceFields): WildcardMockLink {
     return new WildcardMockLink([
@@ -132,8 +67,7 @@ export const ViewConfig: Story = () => (
             <MockedTestProvider link={newFetchMock(externalService)}>
                 <ExternalServiceEditPage
                     {...webProps}
-                    queryExternalServiceSyncJobs={queryExternalServiceSyncJobs}
-                    afterUpdateRoute="/site-admin/after"
+                    routingPrefix="/site-admin"
                     telemetryService={NOOP_TELEMETRY_SERVICE}
                     externalServiceID="service123"
                     autoFocusForm={false}
@@ -153,8 +87,7 @@ export const ConfigWithInvalidUrl: Story = () => (
             <MockedTestProvider link={newFetchMock({ ...externalService, config: '{"url": "invalid-url"}' })}>
                 <ExternalServiceEditPage
                     {...webProps}
-                    queryExternalServiceSyncJobs={queryExternalServiceSyncJobs}
-                    afterUpdateRoute="/site-admin/after"
+                    routingPrefix="/site-admin"
                     telemetryService={NOOP_TELEMETRY_SERVICE}
                     externalServiceID="service123"
                     autoFocusForm={false}
@@ -176,8 +109,7 @@ export const ConfigWithWarning: Story = () => (
             >
                 <ExternalServiceEditPage
                     {...webProps}
-                    queryExternalServiceSyncJobs={queryExternalServiceSyncJobs}
-                    afterUpdateRoute="/site-admin/after"
+                    routingPrefix="/site-admin"
                     telemetryService={NOOP_TELEMETRY_SERVICE}
                     externalServiceID="service123"
                     autoFocusForm={false}
@@ -199,8 +131,7 @@ export const EditingDisabled: Story = () => (
             >
                 <ExternalServiceEditPage
                     {...webProps}
-                    queryExternalServiceSyncJobs={queryExternalServiceSyncJobs}
-                    afterUpdateRoute="/site-admin/after"
+                    routingPrefix="/site-admin"
                     telemetryService={NOOP_TELEMETRY_SERVICE}
                     externalServiceID="service123"
                     autoFocusForm={false}

--- a/client/web/src/components/externalServices/ExternalServiceForm.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceForm.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react'
 
-import classNames from 'classnames'
 import * as H from 'history'
 
 import { ErrorLike } from '@sourcegraph/common'
@@ -126,10 +125,9 @@ export const ExternalServiceForm: React.FunctionComponent<React.PropsWithChildre
             </div>
             <Button
                 type="submit"
-                className={classNames(
-                    'mb-3',
+                className={
                     mode === 'create' ? 'test-add-external-service-button' : 'test-update-external-service-button'
-                )}
+                }
                 disabled={loading || disabled}
                 variant="primary"
             >

--- a/client/web/src/components/externalServices/ExternalServiceInformation.module.scss
+++ b/client/web/src/components/externalServices/ExternalServiceInformation.module.scss
@@ -1,0 +1,16 @@
+.table {
+    table-layout: auto;
+    max-width: 100%;
+    vertical-align: center;
+
+    th,
+    td {
+        border: none;
+    }
+}
+
+.table-header {
+    width: 1%;
+    white-space: nowrap;
+    vertical-align: baseline !important;
+}

--- a/client/web/src/components/externalServices/ExternalServiceInformation.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceInformation.tsx
@@ -1,0 +1,51 @@
+import React, { FC } from 'react'
+
+import classNames from 'classnames'
+
+import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
+import { Icon, Link, Tooltip } from '@sourcegraph/wildcard'
+
+import styles from '../../site-admin/WebhookInformation.module.scss'
+
+interface ExternalServiceInformationProps {
+    /**
+     * Icon to show in the external service "button".
+     */
+    icon: React.ComponentType<React.PropsWithChildren<{ className?: string }>>
+    kind: ExternalServiceKind
+    displayName: string
+    codeHostID: string
+    reposNumber: number
+}
+
+export const ExternalServiceInformation: FC<ExternalServiceInformationProps> = props => {
+    const { icon, kind, displayName, codeHostID, reposNumber } = props
+
+    return (
+        <table className={classNames(styles.table, 'table')}>
+            <tbody>
+                <tr>
+                    <th className={styles.tableHeader}>Code host kind</th>
+                    <td>
+                        <Icon inline={true} as={icon} aria-label="Code host logo" className="mr-2" />
+                        {kind}
+                    </td>
+                </tr>
+                <tr>
+                    <th className={styles.tableHeader}>Display name</th>
+                    <td>{displayName}</td>
+                </tr>
+                <tr>
+                    <th className={styles.tableHeader}>Synced repositories</th>
+                    <td>
+                        <Tooltip content="Click to see the list of repositories">
+                            <Link to={`/site-admin/repositories?codeHost=${encodeURIComponent(codeHostID)}`}>
+                                {reposNumber}
+                            </Link>
+                        </Tooltip>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    )
+}

--- a/client/web/src/components/externalServices/ExternalServiceInformation.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceInformation.tsx
@@ -3,7 +3,7 @@ import React, { FC } from 'react'
 import classNames from 'classnames'
 
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
-import { Icon, Link, Tooltip } from '@sourcegraph/wildcard'
+import { Icon, Link, LoadingSpinner, Tooltip } from '@sourcegraph/wildcard'
 
 import styles from '../../site-admin/WebhookInformation.module.scss'
 
@@ -16,10 +16,11 @@ interface ExternalServiceInformationProps {
     displayName: string
     codeHostID: string
     reposNumber: number
+    syncInProgress: boolean
 }
 
 export const ExternalServiceInformation: FC<ExternalServiceInformationProps> = props => {
-    const { icon, kind, displayName, codeHostID, reposNumber } = props
+    const { icon, kind, displayName, codeHostID, reposNumber, syncInProgress } = props
 
     return (
         <table className={classNames(styles.table, 'table')}>
@@ -43,6 +44,13 @@ export const ExternalServiceInformation: FC<ExternalServiceInformationProps> = p
                                 {reposNumber}
                             </Link>
                         </Tooltip>
+                        {syncInProgress && (
+                            <>
+                                {' (Code host sync in progress...'}
+                                <LoadingSpinner inline={true} />
+                                )
+                            </>
+                        )}
                     </td>
                 </tr>
             </tbody>

--- a/client/web/src/components/externalServices/ExternalServiceInformation.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceInformation.tsx
@@ -37,7 +37,7 @@ export const ExternalServiceInformation: FC<ExternalServiceInformationProps> = p
                     <td>{displayName}</td>
                 </tr>
                 <tr>
-                    <th className={styles.tableHeader}>Synced repositories</th>
+                    <th className={styles.tableHeader}>Repositories</th>
                     <td>
                         <Tooltip content="Click to see the list of repositories">
                             <Link to={`/site-admin/repositories?codeHost=${encodeURIComponent(codeHostID)}`}>
@@ -46,9 +46,8 @@ export const ExternalServiceInformation: FC<ExternalServiceInformationProps> = p
                         </Tooltip>
                         {syncInProgress && (
                             <>
-                                {' (Code host sync in progress...'}
-                                <LoadingSpinner inline={true} />
-                                )
+                                {' (Syncing list of repositories from code host...'}
+                                <LoadingSpinner inline={true} />)
                             </>
                         )}
                     </td>

--- a/client/web/src/components/externalServices/ExternalServicePage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.story.tsx
@@ -1,0 +1,143 @@
+import { DecoratorFn, Story, Meta } from '@storybook/react'
+import { subMinutes } from 'date-fns'
+import { of } from 'rxjs'
+import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
+
+import { getDocumentNode } from '@sourcegraph/http-client'
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
+
+import { ExternalServiceFields, ExternalServiceKind, ExternalServiceSyncJobState } from '../../graphql-operations'
+import { WebStory } from '../WebStory'
+
+import { FETCH_EXTERNAL_SERVICE, queryExternalServiceSyncJobs as _queryExternalServiceSyncJobs } from './backend'
+import { ExternalServicePage } from './ExternalServicePage'
+
+const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+
+const config: Meta = {
+    title: 'web/External services/ExternalServicePage',
+    decorators: [decorator],
+}
+
+export default config
+
+const externalService = {
+    __typename: 'ExternalService' as const,
+    id: 'service123',
+    kind: ExternalServiceKind.GITHUB,
+    warning: null,
+    config: '{"githubconfig": true}',
+    displayName: 'GitHub.com',
+    webhookURL: null,
+    lastSyncError: null,
+    repoCount: 1337,
+    lastSyncAt: null,
+    nextSyncAt: null,
+    updatedAt: '2021-03-15T19:39:11Z',
+    createdAt: '2021-03-15T19:39:11Z',
+    hasConnectionCheck: true,
+    namespace: {
+        id: 'userid',
+        namespaceName: 'johndoe',
+        url: '/users/johndoe',
+    },
+}
+
+const queryExternalServiceSyncJobs: typeof _queryExternalServiceSyncJobs = () =>
+    of({
+        totalCount: 4,
+        pageInfo: { endCursor: null, hasNextPage: false },
+        nodes: [
+            {
+                __typename: 'ExternalServiceSyncJob',
+                failureMessage: null,
+                startedAt: subMinutes(new Date(), 25).toISOString(),
+                finishedAt: null,
+                id: 'SYNCJOB1',
+                state: ExternalServiceSyncJobState.CANCELING,
+                reposSynced: 5,
+                repoSyncErrors: 0,
+                reposAdded: 5,
+                reposDeleted: 0,
+                reposModified: 0,
+                reposUnmodified: 0,
+            },
+            {
+                __typename: 'ExternalServiceSyncJob',
+                failureMessage: null,
+                startedAt: subMinutes(new Date(), 25).toISOString(),
+                finishedAt: null,
+                id: 'SYNCJOB1',
+                state: ExternalServiceSyncJobState.PROCESSING,
+                reposSynced: 5,
+                repoSyncErrors: 0,
+                reposAdded: 5,
+                reposDeleted: 0,
+                reposModified: 0,
+                reposUnmodified: 0,
+            },
+            {
+                __typename: 'ExternalServiceSyncJob',
+                failureMessage: 'Very bad error syncing with the code host.',
+                startedAt: subMinutes(new Date(), 25).toISOString(),
+                finishedAt: subMinutes(new Date(), 25).toISOString(),
+                id: 'SYNCJOB1',
+                state: ExternalServiceSyncJobState.FAILED,
+                reposSynced: 5,
+                repoSyncErrors: 0,
+                reposAdded: 5,
+                reposDeleted: 0,
+                reposModified: 0,
+                reposUnmodified: 0,
+            },
+            {
+                __typename: 'ExternalServiceSyncJob',
+                failureMessage: null,
+                startedAt: subMinutes(new Date(), 25).toISOString(),
+                finishedAt: subMinutes(new Date(), 25).toISOString(),
+                id: 'SYNCJOB1',
+                state: ExternalServiceSyncJobState.COMPLETED,
+                reposSynced: 5,
+                repoSyncErrors: 0,
+                reposAdded: 5,
+                reposDeleted: 0,
+                reposModified: 0,
+                reposUnmodified: 0,
+            },
+        ],
+    })
+
+function newFetchMock(node: { __typename: 'ExternalService' } & ExternalServiceFields): WildcardMockLink {
+    return new WildcardMockLink([
+        {
+            request: {
+                query: getDocumentNode(FETCH_EXTERNAL_SERVICE),
+                variables: MATCH_ANY_PARAMETERS,
+            },
+            result: { data: { node } },
+            nMatches: Number.POSITIVE_INFINITY,
+        },
+    ])
+}
+
+export const ExternalServiceWithRepos: Story = () => (
+    <WebStory>
+        {webProps => (
+            <MockedTestProvider link={newFetchMock(externalService)}>
+                <ExternalServicePage
+                    {...webProps}
+                    routingPrefix="/site-admin"
+                    queryExternalServiceSyncJobs={queryExternalServiceSyncJobs}
+                    afterDeleteRoute="/site-admin/after-delete"
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                    externalServiceID="service123"
+                    externalServicesFromFile={false}
+                    allowEditExternalServicesWithFile={false}
+                />
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
+
+ExternalServiceWithRepos.storyName = 'External service with synced repos'

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -1,0 +1,280 @@
+import React, { useEffect, useState, useCallback, useMemo, FC } from 'react'
+
+import { mdiCog, mdiConnection, mdiDelete } from '@mdi/js'
+import * as H from 'history'
+import { Subject } from 'rxjs'
+
+import { asError, isErrorLike } from '@sourcegraph/common'
+import { useQuery } from '@sourcegraph/http-client'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { Alert, Button, Container, ErrorAlert, H2, Icon, Link, PageHeader, Tooltip } from '@sourcegraph/wildcard'
+
+import {
+    ExternalServiceFields,
+    Scalars,
+    ExternalServiceResult,
+    ExternalServiceVariables,
+} from '../../graphql-operations'
+import { DynamicallyImportedMonacoSettingsEditor } from '../../settings/DynamicallyImportedMonacoSettingsEditor'
+import { refreshSiteFlags } from '../../site/backend'
+import { CreatedByAndUpdatedByInfoByline } from '../Byline/CreatedByAndUpdatedByInfoByline'
+import { LoaderButton } from '../LoaderButton'
+import { PageTitle } from '../PageTitle'
+
+import {
+    useSyncExternalService,
+    queryExternalServiceSyncJobs as _queryExternalServiceSyncJobs,
+    FETCH_EXTERNAL_SERVICE,
+    deleteExternalService,
+    useExternalServiceCheckConnectionByIdLazyQuery,
+} from './backend'
+import { ExternalServiceInformation } from './ExternalServiceInformation'
+import { resolveExternalServiceCategory } from './externalServices'
+import { ExternalServiceSyncJobsList } from './ExternalServiceSyncJobsList'
+import { ExternalServiceWebhook } from './ExternalServiceWebhook'
+
+interface Props extends TelemetryProps {
+    externalServiceID: Scalars['ID']
+    isLightTheme: boolean
+    history: H.History
+    routingPrefix: string
+    afterDeleteRoute: string
+
+    externalServicesFromFile: boolean
+    allowEditExternalServicesWithFile: boolean
+
+    /** For testing only. */
+    queryExternalServiceSyncJobs?: typeof _queryExternalServiceSyncJobs
+}
+
+const getExternalService = (queryResult?: ExternalServiceResult): ExternalServiceFields | null =>
+    queryResult?.node?.__typename === 'ExternalService' ? queryResult.node : null
+
+export const ExternalServicePage: FC<React.PropsWithChildren<Props>> = props => {
+    const {
+        externalServiceID,
+        isLightTheme,
+        history,
+        routingPrefix,
+        telemetryService,
+        afterDeleteRoute,
+        externalServicesFromFile,
+        allowEditExternalServicesWithFile,
+        queryExternalServiceSyncJobs = _queryExternalServiceSyncJobs,
+    } = props
+
+    useEffect(() => {
+        telemetryService.logViewEvent('SiteAdminExternalService')
+    }, [telemetryService])
+
+    const [externalService, setExternalService] = useState<ExternalServiceFields>()
+
+    const { error: fetchError, loading: fetchLoading } = useQuery<ExternalServiceResult, ExternalServiceVariables>(
+        FETCH_EXTERNAL_SERVICE,
+        {
+            variables: { id: externalServiceID },
+            notifyOnNetworkStatusChange: false,
+            fetchPolicy: 'no-cache',
+            onCompleted: result => {
+                const data = getExternalService(result)
+                if (data) {
+                    setExternalService(data)
+                }
+            },
+        }
+    )
+
+    const [syncExternalService, { error: syncExternalServiceError, loading: syncExternalServiceLoading }] =
+        useSyncExternalService()
+
+    const syncJobUpdates = useMemo(() => new Subject<void>(), [])
+    const triggerSync = useCallback(
+        () =>
+            externalService &&
+            syncExternalService({ variables: { id: externalService.id } }).then(() => {
+                syncJobUpdates.next()
+            }),
+        [externalService, syncExternalService, syncJobUpdates]
+    )
+
+    const externalServiceCategory = resolveExternalServiceCategory(externalService)
+
+    const combinedError = fetchError
+    const combinedLoading = fetchLoading
+    const editingEnabled = allowEditExternalServicesWithFile || !externalServicesFromFile
+
+    const [isDeleting, setIsDeleting] = useState<boolean | Error>(false)
+    const onDelete = useCallback<React.MouseEventHandler>(async () => {
+        if (!externalService) {
+            return
+        }
+        if (!window.confirm(`Delete the external service ${externalService.displayName}?`)) {
+            return
+        }
+        setIsDeleting(true)
+        try {
+            await deleteExternalService(externalService.id)
+            setIsDeleting(false)
+            // eslint-disable-next-line rxjs/no-ignored-subscription
+            refreshSiteFlags().subscribe()
+            history.push(afterDeleteRoute)
+        } catch (error) {
+            setIsDeleting(asError(error))
+        }
+    }, [afterDeleteRoute, history, externalService])
+
+    // If external service is undefined, we won't use doCheckConnection anyway,
+    // that's why it's safe to pass an empty ID to useExternalServiceCheckConnectionByIdLazyQuery
+    const [doCheckConnection, { loading, data, error }] = useExternalServiceCheckConnectionByIdLazyQuery(
+        externalService?.id || ''
+    )
+
+    const checkConnectionNode = data?.node?.__typename === 'ExternalService' ? data.node.checkConnection : null
+
+    let externalServiceAvailabilityStatus
+    if (!error && !loading) {
+        if (checkConnectionNode?.__typename === 'ExternalServiceAvailable') {
+            externalServiceAvailabilityStatus = (
+                <Alert className="mt-2" variant="success">
+                    Code host is reachable.
+                </Alert>
+            )
+        } else if (checkConnectionNode?.__typename === 'ExternalServiceUnavailable') {
+            externalServiceAvailabilityStatus = (
+                <ErrorAlert
+                    className="mt-2"
+                    prefix="Error during code host connection check"
+                    error={checkConnectionNode.suspectedReason}
+                />
+            )
+        }
+    }
+
+    return (
+        <div>
+            {externalService ? (
+                <PageTitle title={`Code host - ${externalService.displayName}`} />
+            ) : (
+                <PageTitle title="Code host" />
+            )}
+            {combinedError !== undefined && !combinedLoading && <ErrorAlert className="mb-3" error={combinedError} />}
+
+            {externalService && (
+                <Container className="mb-3">
+                    <PageHeader
+                        path={[
+                            { icon: mdiCog },
+                            { to: '/site-admin/external-services', text: 'Code hosts' },
+                            { text: externalService.displayName },
+                        ]}
+                        byline={
+                            <CreatedByAndUpdatedByInfoByline
+                                createdAt={externalService.createdAt}
+                                updatedAt={externalService.updatedAt}
+                                noAuthor={true}
+                            />
+                        }
+                        className="mb-3"
+                        headingElement="h2"
+                        actions={
+                            <div className="d-flex align-items-center justify-content-between">
+                                <div className="align-self-start">
+                                    <Tooltip
+                                        content={
+                                            externalService.hasConnectionCheck
+                                                ? 'Test if code host is reachable from Sourcegraph'
+                                                : 'Connection check unavailable'
+                                        }
+                                    >
+                                        <Button
+                                            className="test-connection-external-service-button"
+                                            variant="secondary"
+                                            onClick={() => doCheckConnection()}
+                                            disabled={!externalService.hasConnectionCheck || loading}
+                                            size="sm"
+                                        >
+                                            <Icon aria-hidden={true} svgPath={mdiConnection} /> Test connection
+                                        </Button>
+                                    </Tooltip>
+                                </div>
+                                {editingEnabled && (
+                                    <div className="flex-grow-1 ml-1">
+                                        <Tooltip content="Edit code host connection settings">
+                                            <Button
+                                                className="test-edit-external-service-button"
+                                                to={`${routingPrefix}/external-services/${externalService.id}/edit`}
+                                                variant="primary"
+                                                size="sm"
+                                                as={Link}
+                                            >
+                                                <Icon aria-hidden={true} svgPath={mdiCog} />
+                                                {' Edit'}
+                                            </Button>
+                                        </Tooltip>
+                                    </div>
+                                )}
+                                <div className="flex-shrink-0 ml-1">
+                                    <Tooltip content="Delete code host connection">
+                                        <Button
+                                            aria-label="Delete"
+                                            className="test-delete-external-service-button"
+                                            onClick={onDelete}
+                                            disabled={isDeleting === true}
+                                            variant="danger"
+                                            size="sm"
+                                        >
+                                            <Icon aria-hidden={true} svgPath={mdiDelete} />
+                                            {' Delete'}
+                                        </Button>
+                                    </Tooltip>
+                                </div>
+                            </div>
+                        }
+                    />
+                    {isErrorLike(isDeleting) && <ErrorAlert className="mt-2" error={isDeleting} />}
+                    {externalServiceAvailabilityStatus}
+                    <H2>Information</H2>
+                    {externalServiceCategory && (
+                        <ExternalServiceInformation
+                            displayName={externalService.displayName}
+                            codeHostID={externalService.id}
+                            reposNumber={externalService.repoCount}
+                            {...externalServiceCategory}
+                        />
+                    )}
+                    <H2>Configuration</H2>
+                    {externalServiceCategory && (
+                        <DynamicallyImportedMonacoSettingsEditor
+                            value={externalService.config}
+                            jsonSchema={externalServiceCategory.jsonSchema}
+                            canEdit={false}
+                            loading={combinedLoading}
+                            height={350}
+                            readOnly={true}
+                            isLightTheme={isLightTheme}
+                            history={history}
+                            className="test-external-service-editor"
+                            telemetryService={telemetryService}
+                        />
+                    )}
+                    <LoaderButton
+                        label="Trigger manual sync"
+                        className="mt-3"
+                        alwaysShowLabel={true}
+                        variant="secondary"
+                        onClick={triggerSync}
+                        loading={syncExternalServiceLoading}
+                        disabled={syncExternalServiceLoading}
+                    />
+                    {syncExternalServiceError && <ErrorAlert error={syncExternalServiceError} />}
+                    <ExternalServiceWebhook externalService={externalService} className="mt-3" />
+                    <ExternalServiceSyncJobsList
+                        queryExternalServiceSyncJobs={queryExternalServiceSyncJobs}
+                        externalServiceID={externalService.id}
+                        updates={syncJobUpdates}
+                    />
+                </Container>
+            )}
+        </div>
+    )
+}

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -45,11 +45,7 @@ interface Props extends TelemetryProps {
 }
 
 const NotFoundPage: FC<React.PropsWithChildren<unknown>> = () => (
-    <HeroPage
-        icon={MapSearchIcon}
-        title="404: Not Found"
-        subtitle="Sorry, the requested code host page was not found."
-    />
+    <HeroPage icon={MapSearchIcon} title="404: Not Found" subtitle="Sorry, the requested code host was not found." />
 )
 
 export const ExternalServicePage: FC<React.PropsWithChildren<Props>> = props => {

--- a/client/web/src/components/externalServices/ExternalServiceSyncJobsList.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceSyncJobsList.tsx
@@ -4,7 +4,7 @@ import { useHistory } from 'react-router'
 import { Subject } from 'rxjs'
 import { delay, repeatWhen } from 'rxjs/operators'
 
-import { H3 } from '@sourcegraph/wildcard'
+import { H2 } from '@sourcegraph/wildcard'
 
 import {
     ExternalServiceSyncJobConnectionFields,
@@ -42,7 +42,7 @@ export const ExternalServiceSyncJobsList: React.FunctionComponent<ExternalServic
 
     return (
         <>
-            <H3 className="mt-3">Recent sync jobs</H3>
+            <H2 className="mt-3">Recent sync jobs</H2>
             <FilteredConnection<
                 ExternalServiceSyncJobListFields,
                 Omit<ExternalServiceSyncJobNodeProps, 'node'>,

--- a/client/web/src/components/externalServices/ExternalServiceSyncJobsList.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceSyncJobsList.tsx
@@ -2,23 +2,27 @@ import React, { useCallback } from 'react'
 
 import { useHistory } from 'react-router'
 import { Subject } from 'rxjs'
-import { delay, repeatWhen } from 'rxjs/operators'
+import { delay, repeatWhen, tap } from 'rxjs/operators'
 
 import { H2 } from '@sourcegraph/wildcard'
 
 import {
     ExternalServiceSyncJobConnectionFields,
     ExternalServiceSyncJobListFields,
+    ExternalServiceSyncJobState,
     Scalars,
 } from '../../graphql-operations'
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../FilteredConnection'
 
 import { queryExternalServiceSyncJobs as _queryExternalServiceSyncJobs } from './backend'
+import { EXTERNAL_SERVICE_SYNC_RUNNING_STATUSES } from './externalServices'
 import { ExternalServiceSyncJobNode, ExternalServiceSyncJobNodeProps } from './ExternalServiceSyncJobNode'
 
 interface ExternalServiceSyncJobsListProps {
     externalServiceID: Scalars['ID']
     updates: Subject<void>
+    updateSyncInProgress: (syncInProgress: boolean) => void
+    updateNumberOfRepos: (numberOfRepos: number) => void
 
     /** For testing only. */
     queryExternalServiceSyncJobs?: typeof _queryExternalServiceSyncJobs
@@ -27,6 +31,8 @@ interface ExternalServiceSyncJobsListProps {
 export const ExternalServiceSyncJobsList: React.FunctionComponent<ExternalServiceSyncJobsListProps> = ({
     externalServiceID,
     updates,
+    updateSyncInProgress,
+    updateNumberOfRepos,
     queryExternalServiceSyncJobs = _queryExternalServiceSyncJobs,
 }) => {
     const queryConnection = useCallback(
@@ -34,8 +40,20 @@ export const ExternalServiceSyncJobsList: React.FunctionComponent<ExternalServic
             queryExternalServiceSyncJobs({
                 first: args.first ?? null,
                 externalService: externalServiceID,
-            }).pipe(repeatWhen(obs => obs.pipe(delay(1500)))),
-        [externalServiceID, queryExternalServiceSyncJobs]
+            }).pipe(
+                tap(({ nodes }) => {
+                    if (nodes?.length > 0 && nodes[0]) {
+                        const syncJob = nodes[0]
+                        const state = syncJob.state
+                        updateSyncInProgress(EXTERNAL_SERVICE_SYNC_RUNNING_STATUSES.has(state))
+                        if (state === ExternalServiceSyncJobState.COMPLETED) {
+                            updateNumberOfRepos(syncJob.reposSynced)
+                        }
+                    }
+                }),
+                repeatWhen(obs => obs.pipe(delay(1500)))
+            ),
+        [externalServiceID, queryExternalServiceSyncJobs, updateSyncInProgress, updateNumberOfRepos]
     )
 
     const history = useHistory()

--- a/client/web/src/components/externalServices/__snapshots__/ExternalServiceForm.test.tsx.snap
+++ b/client/web/src/components/externalServices/__snapshots__/ExternalServiceForm.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`ExternalServiceForm create GitHub 1`] = `
     </div>
     <button
       aria-disabled="false"
-      class="btn btnPrimary mb-3 test-add-external-service-button"
+      class="btn btnPrimary test-add-external-service-button"
       type="submit"
     >
       Add repositories
@@ -87,7 +87,7 @@ exports[`ExternalServiceForm edit GitHub 1`] = `
     </div>
     <button
       aria-disabled="false"
-      class="btn btnPrimary mb-3 test-add-external-service-button"
+      class="btn btnPrimary test-add-external-service-button"
       type="submit"
     >
       Add repositories
@@ -136,7 +136,7 @@ exports[`ExternalServiceForm edit GitHub, loading 1`] = `
     </div>
     <button
       aria-disabled="true"
-      class="btn btnPrimary mb-3 test-add-external-service-button"
+      class="btn btnPrimary test-add-external-service-button"
       type="submit"
     >
       <div

--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -103,16 +103,6 @@ export function updateExternalService(
         .toPromise()
 }
 
-export const FETCH_EXTERNAL_SERVICE = gql`
-    query ExternalService($id: ID!) {
-        node(id: $id) {
-            __typename
-            ...ExternalServiceFields
-        }
-    }
-    ${externalServiceFragment}
-`
-
 export async function deleteExternalService(externalService: Scalars['ID']): Promise<void> {
     const result = await requestGraphQL<DeleteExternalServiceResult, DeleteExternalServiceVariables>(
         gql`
@@ -221,6 +211,17 @@ const LIST_EXTERNAL_SERVICE_FRAGMENT = gql`
         }
     }
 `
+
+export const FETCH_EXTERNAL_SERVICE = gql`
+    query ExternalService($id: ID!) {
+        node(id: $id) {
+            __typename
+            ...ListExternalServiceFields
+        }
+    }
+    ${LIST_EXTERNAL_SERVICE_FRAGMENT}
+`
+
 export const EXTERNAL_SERVICES = gql`
     query ExternalServices($first: Int, $after: String) {
         externalServices(first: $first, after: $after) {

--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -37,11 +37,12 @@ export const externalServiceFragment = gql`
         warning
         lastSyncError
         repoCount
-        webhookURL
         lastSyncAt
         nextSyncAt
         updatedAt
         createdAt
+        webhookURL
+        hasConnectionCheck
     }
 `
 

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -281,7 +281,7 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
                                 title="Code host connection"
                                 message={`Failed to connect to "${status.externalService.displayName}".`}
                                 messageHint="Repositories synced to Sourcegraph may not be up to date."
-                                linkTo={`/site-admin/external-services/${status.externalService.id}/edit`}
+                                linkTo={`/site-admin/external-services/${status.externalService.id}`}
                                 linkText="View code host configuration"
                                 linkOnClick={toggleIsOpen}
                                 entryType="error"

--- a/client/web/src/repo/settings/components/ExternalServiceEntry.tsx
+++ b/client/web/src/repo/settings/components/ExternalServiceEntry.tsx
@@ -63,7 +63,7 @@ export const ExternalServiceEntry: FC<ExternalServiceEntryProps> = ({
                 {data && !redirectAfterExclusion ? (
                     <Alert variant="success">
                         Code host configuration updated. Please see the updated code host configuration{' '}
-                        <Link to={`/site-admin/external-services/${service.id}/edit`}>here</Link>
+                        <Link to={`/site-admin/external-services/${service.id}`}>here</Link>
                     </Alert>
                 ) : (
                     <ExternalServiceCard
@@ -79,7 +79,7 @@ export const ExternalServiceEntry: FC<ExternalServiceEntryProps> = ({
                 {error && <ErrorAlert error={`Failed to exclude repository: ${renderError(error)}`} />}
                 {data && redirectAfterExclusion && (
                     <RedirectionAlert
-                        to={`/site-admin/external-services/${service.id}/edit`}
+                        to={`/site-admin/external-services/${service.id}`}
                         messagePrefix="Code host configuration updated."
                     />
                 )}

--- a/client/web/src/site-admin/SiteAdminExternalServicesArea.tsx
+++ b/client/web/src/site-admin/SiteAdminExternalServicesArea.tsx
@@ -25,7 +25,10 @@ const ExternalServiceEditPage = lazyComponent(
     () => import('../components/externalServices/ExternalServiceEditPage'),
     'ExternalServiceEditPage'
 )
-
+const ExternalServicePage = lazyComponent(
+    () => import('../components/externalServices/ExternalServicePage'),
+    'ExternalServicePage'
+)
 const AddExternalServicesPage = lazyComponent(
     () => import('../components/externalServices/AddExternalServicesPage'),
     'AddExternalServicesPage'
@@ -85,9 +88,23 @@ export const SiteAdminExternalServicesArea: React.FunctionComponent<React.PropsW
                         {...outerProps}
                         {...props}
                         routingPrefix="/site-admin"
-                        afterCreateRoute="/site-admin/repositories?repositoriesUpdated"
                         codeHostExternalServices={codeHostExternalServices}
                         nonCodeHostExternalServices={nonCodeHostExternalServices}
+                        externalServicesFromFile={data?.site?.externalServicesFromFile}
+                        allowEditExternalServicesWithFile={data?.site?.allowEditExternalServicesWithFile}
+                    />
+                )}
+                exact={true}
+            />
+            <Route
+                path={`${match.url}/:id`}
+                render={({ match, ...props }: RouteComponentProps<{ id: Scalars['ID'] }>) => (
+                    <ExternalServicePage
+                        {...outerProps}
+                        {...props}
+                        routingPrefix="/site-admin"
+                        afterDeleteRoute="/site-admin/external-services"
+                        externalServiceID={match.params.id}
                         externalServicesFromFile={data?.site?.externalServicesFromFile}
                         allowEditExternalServicesWithFile={data?.site?.allowEditExternalServicesWithFile}
                     />
@@ -100,8 +117,8 @@ export const SiteAdminExternalServicesArea: React.FunctionComponent<React.PropsW
                     <ExternalServiceEditPage
                         {...outerProps}
                         {...props}
+                        routingPrefix="/site-admin"
                         externalServiceID={match.params.id}
-                        afterUpdateRoute="/site-admin/repositories?repositoriesUpdated"
                         externalServicesFromFile={data?.site?.externalServicesFromFile}
                         allowEditExternalServicesWithFile={data?.site?.allowEditExternalServicesWithFile}
                     />

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -389,20 +389,22 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
                 {error && !loading && <ErrorAlert error={error} />}
                 {loading && !error && <LoadingSpinner />}
                 {legends && <ValueLegendList className="mb-3" items={legends} />}
-                <FilteredConnection<SiteAdminRepositoryFields, Omit<RepositoryNodeProps, 'node'>>
-                    className="mb-0"
-                    listClassName="list-group list-group-flush mb-0"
-                    summaryClassName="mt-2"
-                    withCenteredSummary={true}
-                    noun="repository"
-                    pluralNoun="repositories"
-                    queryConnection={queryRepositories}
-                    nodeComponent={RepositoryNode}
-                    inputClassName="ml-2 flex-1"
-                    filters={filters}
-                    history={history}
-                    location={location}
-                />
+                {extSvcs && (
+                    <FilteredConnection<SiteAdminRepositoryFields, Omit<RepositoryNodeProps, 'node'>>
+                        className="mb-0"
+                        listClassName="list-group list-group-flush mb-0"
+                        summaryClassName="mt-2"
+                        withCenteredSummary={true}
+                        noun="repository"
+                        pluralNoun="repositories"
+                        queryConnection={queryRepositories}
+                        nodeComponent={RepositoryNode}
+                        inputClassName="ml-2 flex-1"
+                        filters={filters}
+                        history={history}
+                        location={location}
+                    />
+                )}
             </Container>
         </div>
     )

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -397,7 +397,7 @@ func listAuthzProvidersHandler() http.HandlerFunc {
 			infos[i] = providerInfo{
 				ServiceType:        p.ServiceType(),
 				ServiceID:          p.ServiceID(),
-				ExternalServiceURL: fmt.Sprintf("%s/site-admin/external-services/%s/edit", globals.ExternalURL(), relay.MarshalID("ExternalService", id)),
+				ExternalServiceURL: fmt.Sprintf("%s/site-admin/external-services/%s", globals.ExternalURL(), relay.MarshalID("ExternalService", id)),
 			}
 		}
 


### PR DESCRIPTION
This commit pretty much touches all code host related pages:
- Adds redirects to details page after creating/updating a code host
- Adds links to details page from code host list page
- Removes connection check from code host list page
- Removes sync jobs list from update code host page
- New details page contains code host name and kind, number of synced repos (with a link to /repositories page), code host configuration and sync jobs. Also, it contains buttons for connection check and code host update/deletion.

Test plan:
Local sg run and manual tests with a full code host lifecycle checks, storybook.

## THORSTEN, YOU CANNOT MISS IT

https://user-images.githubusercontent.com/94846361/211809316-c71d3d1e-e82a-4fb9-a63a-015a727b87fe.mp4


Closes https://github.com/sourcegraph/sourcegraph/issues/46033