### PR TITLE
batches: implement pagination for batch_spec_workspace_steps.output_lines

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
+++ b/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
@@ -616,3 +616,26 @@ export const LARGE_SUCCESS_CONNECTION_MOCKS: MockedResponses = [
         nMatches: Number.POSITIVE_INFINITY,
     },
 ]
+
+export const WORKSPACE_STEP_OUTPUT_LINES = {
+    node: {
+        __typename: 'VisibleBatchSpecWorkspace',
+        step: {
+            outputLines: {
+                __typename: 'BatchSpecWorkspaceStepOutputLineConnection',
+                nodes: [
+                    'stdout: Hello world 1',
+                    'stdout: Hello world 2',
+                    'stdout: Hello world 3',
+                    'stdout: Hello world 4',
+                    'stdout: Hello world 5',
+                ],
+                totalCount: 5,
+                pageInfo: {
+                    endCursor: null,
+                    hasNextPage: false,
+                },
+            },
+        },
+    },
+}

--- a/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
+++ b/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
@@ -616,19 +616,23 @@ export const LARGE_SUCCESS_CONNECTION_MOCKS: MockedResponses = [
     },
 ]
 
+const generateMockOutputLines = (start: number, end: number): string[] => {
+    const result: string[] = []
+
+    for (let i = start; i <= end; i++) {
+        result.push(`stdout: Hello world ${i}`)
+    }
+
+    return result
+}
+
 export const WORKSPACE_STEP_OUTPUT_LINES_PAGE_ONE = {
     node: {
         __typename: 'VisibleBatchSpecWorkspace',
         step: {
             outputLines: {
                 __typename: 'BatchSpecWorkspaceStepOutputLineConnection',
-                nodes: [
-                    'stdout: Hello world 1',
-                    'stdout: Hello world 2',
-                    'stdout: Hello world 3',
-                    'stdout: Hello world 4',
-                    'stdout: Hello world 5',
-                ],
+                nodes: generateMockOutputLines(1, 500),
                 totalCount: 10,
                 pageInfo: {
                     endCursor: "5",
@@ -645,13 +649,7 @@ export const WORKSPACE_STEP_OUTPUT_LINES_PAGE_TWO = {
         step: {
             outputLines: {
                 __typename: 'BatchSpecWorkspaceStepOutputLineConnection',
-                nodes: [
-                    'stdout: Hello world 6',
-                    'stdout: Hello world 7',
-                    'stdout: Hello world 8',
-                    'stdout: Hello world 9',
-                    'stdout: Hello world 10',
-                ],
+                nodes: generateMockOutputLines(501, 1000),
                 totalCount: 10,
                 pageInfo: {
                     endCursor: null,

--- a/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
+++ b/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
@@ -237,7 +237,6 @@ export const mockStep = (
     finishedAt: subMinutes(now, 1).toISOString(),
     ifCondition: null,
     number,
-    outputLines: ['stdout: Hello World', 'stdout: '],
     outputVariables: [],
     run: `echo Hello World Step ${number} | tee -a $(find -name README.md)`,
     skipped: false,

--- a/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
+++ b/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
@@ -619,8 +619,8 @@ export const LARGE_SUCCESS_CONNECTION_MOCKS: MockedResponses = [
 const generateMockOutputLines = (start: number, end: number): string[] => {
     const result: string[] = []
 
-    for (let i = start; i <= end; i++) {
-        result.push(`stdout: Hello world ${i}`)
+    for (let index = start; index <= end; index++) {
+        result.push(`stdout: Hello world ${index}`)
     }
 
     return result

--- a/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
+++ b/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
@@ -616,7 +616,7 @@ export const LARGE_SUCCESS_CONNECTION_MOCKS: MockedResponses = [
     },
 ]
 
-export const WORKSPACE_STEP_OUTPUT_LINES = {
+export const WORKSPACE_STEP_OUTPUT_LINES_PAGE_ONE = {
     node: {
         __typename: 'VisibleBatchSpecWorkspace',
         step: {
@@ -629,7 +629,30 @@ export const WORKSPACE_STEP_OUTPUT_LINES = {
                     'stdout: Hello world 4',
                     'stdout: Hello world 5',
                 ],
-                totalCount: 5,
+                totalCount: 10,
+                pageInfo: {
+                    endCursor: "5",
+                    hasNextPage: true,
+                },
+            },
+        },
+    },
+}
+
+export const WORKSPACE_STEP_OUTPUT_LINES_PAGE_TWO = {
+    node: {
+        __typename: 'VisibleBatchSpecWorkspace',
+        step: {
+            outputLines: {
+                __typename: 'BatchSpecWorkspaceStepOutputLineConnection',
+                nodes: [
+                    'stdout: Hello world 6',
+                    'stdout: Hello world 7',
+                    'stdout: Hello world 8',
+                    'stdout: Hello world 9',
+                    'stdout: Hello world 10',
+                ],
+                totalCount: 10,
                 pageInfo: {
                     endCursor: null,
                     hasNextPage: false,

--- a/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
+++ b/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
@@ -635,7 +635,7 @@ export const WORKSPACE_STEP_OUTPUT_LINES_PAGE_ONE = {
                 nodes: generateMockOutputLines(1, 500),
                 totalCount: 10,
                 pageInfo: {
-                    endCursor: "5",
+                    endCursor: '500',
                     hasNextPage: true,
                 },
             },

--- a/client/web/src/enterprise/batches/batch-spec/execute/backend.ts
+++ b/client/web/src/enterprise/batches/batch-spec/execute/backend.ts
@@ -257,7 +257,7 @@ export const BATCH_SPEC_WORKSPACE_STEP_BY_INDEX = gql`
             __typename
             ... on VisibleBatchSpecWorkspace {
                 step(index: $stepIndex) {
-                    outputLines(after: $after) {
+                    outputLines(first: 500, after: $after) {
                         ...BatchSpecWorkspaceStepOutputLines
                     }
                 }

--- a/client/web/src/enterprise/batches/batch-spec/execute/backend.ts
+++ b/client/web/src/enterprise/batches/batch-spec/execute/backend.ts
@@ -120,7 +120,7 @@ const batchSpecWorkspaceFieldsFragment = gql`
         ifCondition
         cachedResultFound
         skipped
-        outputLines {
+        outputLines(first: 500) {
             ...BatchSpecWorkspaceStepOutputLines
         }
         startedAt

--- a/client/web/src/enterprise/batches/batch-spec/execute/backend.ts
+++ b/client/web/src/enterprise/batches/batch-spec/execute/backend.ts
@@ -25,6 +25,17 @@ import {
     RetryWorkspaceExecutionVariables,
 } from '../../../../graphql-operations'
 
+export const batchSpecWorkspaceStepOutputLinesFieldsFragment = gql`
+    fragment BatchSpecWorkspaceStepOutputLines on BatchSpecWorkspaceStepOutputLines {
+        nodes
+        totalCount
+        pageInfo {
+            hasNextPage
+            endCursor
+        }
+    }
+`
+
 const batchSpecWorkspaceFieldsFragment = gql`
     fragment BatchSpecWorkspaceFields on BatchSpecWorkspace {
         __typename
@@ -110,7 +121,7 @@ const batchSpecWorkspaceFieldsFragment = gql`
         cachedResultFound
         skipped
         outputLines {
-            nodes
+            ...BatchSpecWorkspaceStepOutputLines
         }
         startedAt
         finishedAt
@@ -159,6 +170,8 @@ const batchSpecWorkspaceFieldsFragment = gql`
             }
         }
     }
+
+    ${batchSpecWorkspaceStepOutputLinesFieldsFragment}
 `
 
 const batchSpecWorkspaceStatsFragment = gql`
@@ -236,6 +249,23 @@ export const BATCH_SPEC_WORKSPACE_BY_ID = gql`
         }
     }
     ${batchSpecWorkspaceFieldsFragment}
+`
+
+export const BATCH_SPEC_WORKSPACE_STEP_BY_INDEX = gql`
+    query BatchSpecWorkspaceStepByIndex($workspaceID: ID!, $stepIndex: Int!, $after: Int!) {
+        node(id: $workspaceID) {
+            __typename
+            ... on VisibleBatchSpecWorkspace {
+                step(index: $stepIndex) {
+                    outputLines(after: $after) {
+                        ...BatchSpecWorkspaceStepOutputLines
+                    }
+                }
+            }
+        }
+    }
+
+    ${batchSpecWorkspaceStepOutputLinesFieldsFragment}
 `
 
 interface BatchSpecWorkspaceHookResult {

--- a/client/web/src/enterprise/batches/batch-spec/execute/backend.ts
+++ b/client/web/src/enterprise/batches/batch-spec/execute/backend.ts
@@ -109,7 +109,9 @@ const batchSpecWorkspaceFieldsFragment = gql`
         ifCondition
         cachedResultFound
         skipped
-        outputLines
+        outputLines {
+            nodes
+        }
         startedAt
         finishedAt
         exitCode

--- a/client/web/src/enterprise/batches/batch-spec/execute/backend.ts
+++ b/client/web/src/enterprise/batches/batch-spec/execute/backend.ts
@@ -27,6 +27,7 @@ import {
 
 export const batchSpecWorkspaceStepOutputLinesFieldsFragment = gql`
     fragment BatchSpecWorkspaceStepOutputLines on BatchSpecWorkspaceStepOutputLineConnection {
+        __typename
         nodes
         totalCount
         pageInfo {
@@ -120,9 +121,6 @@ const batchSpecWorkspaceFieldsFragment = gql`
         ifCondition
         cachedResultFound
         skipped
-        outputLines(first: 500) {
-            ...BatchSpecWorkspaceStepOutputLines
-        }
         startedAt
         finishedAt
         exitCode
@@ -170,8 +168,6 @@ const batchSpecWorkspaceFieldsFragment = gql`
             }
         }
     }
-
-    ${batchSpecWorkspaceStepOutputLinesFieldsFragment}
 `
 
 const batchSpecWorkspaceStatsFragment = gql`
@@ -251,13 +247,13 @@ export const BATCH_SPEC_WORKSPACE_BY_ID = gql`
     ${batchSpecWorkspaceFieldsFragment}
 `
 
-export const BATCH_SPEC_WORKSPACE_STEP_BY_INDEX = gql`
-    query BatchSpecWorkspaceStepByIndex($workspaceID: ID!, $stepIndex: Int!, $after: Int!) {
+export const BATCH_SPEC_WORKSPACE_STEP = gql`
+    query BatchSpecWorkspaceStep($workspaceID: ID!, $stepIndex: Int!, $first: Int!, $after: String) {
         node(id: $workspaceID) {
             __typename
             ... on VisibleBatchSpecWorkspace {
                 step(index: $stepIndex) {
-                    outputLines(first: 500, after: $after) {
+                    outputLines(first: $first, after: $after) {
                         ...BatchSpecWorkspaceStepOutputLines
                     }
                 }

--- a/client/web/src/enterprise/batches/batch-spec/execute/backend.ts
+++ b/client/web/src/enterprise/batches/batch-spec/execute/backend.ts
@@ -26,7 +26,7 @@ import {
 } from '../../../../graphql-operations'
 
 export const batchSpecWorkspaceStepOutputLinesFieldsFragment = gql`
-    fragment BatchSpecWorkspaceStepOutputLines on BatchSpecWorkspaceStepOutputLines {
+    fragment BatchSpecWorkspaceStepOutputLines on BatchSpecWorkspaceStepOutputLineConnection {
         nodes
         totalCount
         pageInfo {

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
@@ -70,6 +70,8 @@
     line-height: 0.75rem;
 }
 
+
+
 .step-diff-stat {
     // Bringing the element above the button so the tooltip is triggered on-hover
     isolation: isolate;
@@ -92,6 +94,10 @@
     }
 }
 
+.step-command-info {
+    padding-top: 0 !important;
+}
+
 .step-output-show-more-btn {
     margin: 0;
     background-color: var(--gray-10);
@@ -99,6 +105,7 @@
     width: 100%;
     text-align: left;
     padding-left: calc(var(--spacer) * 1) !important;
+    padding-top: 0 !important;
 
     &:hover {
         text-decoration-style: solid;
@@ -107,6 +114,7 @@
 }
 
 .step-tabs {
+
     [data-reach-tab],
     [data-reach-tab]:hover,
     [data-reach-tab][data-selected] {

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
@@ -94,10 +94,6 @@
     }
 }
 
-.step-command-info {
-    padding-top: 0 !important;
-}
-
 .step-output-show-more-btn {
     margin: 0;
     background-color: var(--gray-10);
@@ -105,7 +101,6 @@
     width: 100%;
     text-align: left;
     padding-left: calc(var(--spacer) * 1) !important;
-    padding-top: 0 !important;
 
     &:hover {
         text-decoration-style: solid;

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
@@ -92,6 +92,20 @@
     }
 }
 
+.step-output-show-more-btn {
+    margin: 0;
+    background-color: var(--gray-10);
+    color: var(--white);
+    width: 100%;
+    text-align: left;
+    padding-left: calc(var(--spacer) * 1) !important;
+
+    &:hover {
+        text-decoration-style: solid;
+        text-decoration-color: var(--white);
+    }
+}
+
 .step-tabs {
     [data-reach-tab],
     [data-reach-tab]:hover,

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
@@ -70,8 +70,6 @@
     line-height: 0.75rem;
 }
 
-
-
 .step-diff-stat {
     // Bringing the element above the button so the tooltip is triggered on-hover
     isolation: isolate;
@@ -109,7 +107,6 @@
 }
 
 .step-tabs {
-
     [data-reach-tab],
     [data-reach-tab]:hover,
     [data-reach-tab][data-selected] {

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
@@ -94,19 +94,24 @@
 
 .step-output-show-more-btn {
     margin: 0;
-    background-color: var(--gray-10);
     color: var(--white);
     width: 100%;
     text-align: left;
     padding-left: calc(var(--spacer) * 1) !important;
+    text-decoration: underline;
+    width: fit-content;
 
     &:hover {
-        text-decoration-style: solid;
-        text-decoration-color: var(--white);
+        color: var(--gray-05);
     }
 }
 
+.step-output-container {
+    background-color: var(--gray-10);
+}
+
 .step-tabs {
+
     [data-reach-tab],
     [data-reach-tab]:hover,
     [data-reach-tab][data-selected] {

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
@@ -95,7 +95,6 @@
 .step-output-show-more-btn {
     margin: 0;
     color: var(--white);
-    width: 100%;
     text-align: left;
     padding-left: calc(var(--spacer) * 1) !important;
     text-decoration: underline;
@@ -111,6 +110,7 @@
 }
 
 .step-tabs {
+
     [data-reach-tab],
     [data-reach-tab]:hover,
     [data-reach-tab][data-selected] {

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
@@ -110,7 +110,6 @@
 }
 
 .step-tabs {
-
     [data-reach-tab],
     [data-reach-tab]:hover,
     [data-reach-tab][data-selected] {

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.module.scss
@@ -111,7 +111,6 @@
 }
 
 .step-tabs {
-
     [data-reach-tab],
     [data-reach-tab]:hover,
     [data-reach-tab][data-selected] {

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.story.tsx
@@ -25,6 +25,7 @@ import {
 import {
     BATCH_SPEC_WORKSPACE_BY_ID,
     queryBatchSpecWorkspaceStepFileDiffs as _queryBatchSpecWorkspaceStepFileDiffs,
+    BATCH_SPEC_WORKSPACE_STEP,
 } from '../backend'
 
 import { WorkspaceDetails } from './WorkspaceDetails'
@@ -75,6 +76,35 @@ const BaseStory: React.FunctionComponent<BaseStoryProps> = ({ node, queries = {}
             result: { data: { node } },
             nMatches: Number.POSITIVE_INFINITY,
         },
+        {
+            request: {
+                query: getDocumentNode(BATCH_SPEC_WORKSPACE_STEP),
+                variables: MATCH_ANY_PARAMETERS,
+            },
+            result: { data: {
+               node: {
+                __typename: 'VisibleBatchSpecWorkspace',
+                    step: {
+                        outputLines: {
+                            __typename: 'BatchSpecWorkspaceStepOutputLineConnection',
+                            nodes: [
+                                'stdout: Hello world 1',
+                                'stdout: Hello world 2',
+                                'stdout: Hello world 3',
+                                'stdout: Hello world 4',
+                                'stdout: Hello world 5',
+                            ],
+                            totalCount: 5,
+                            pageInfo: {
+                                endCursor: null,
+                                hasNextPage: false,
+                            }
+                        }
+                    }
+               }
+            } },
+            nMatches: Number.POSITIVE_INFINITY,
+        }
     ])
 
     return (

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.story.tsx
@@ -21,6 +21,7 @@ import {
     FAILED_WORKSPACE,
     CANCELING_WORKSPACE,
     CANCELED_WORKSPACE,
+    WORKSPACE_STEP_OUTPUT_LINES,
 } from '../../batch-spec.mock'
 import {
     BATCH_SPEC_WORKSPACE_BY_ID,
@@ -81,30 +82,11 @@ const BaseStory: React.FunctionComponent<BaseStoryProps> = ({ node, queries = {}
                 query: getDocumentNode(BATCH_SPEC_WORKSPACE_STEP),
                 variables: MATCH_ANY_PARAMETERS,
             },
-            result: { data: {
-               node: {
-                __typename: 'VisibleBatchSpecWorkspace',
-                    step: {
-                        outputLines: {
-                            __typename: 'BatchSpecWorkspaceStepOutputLineConnection',
-                            nodes: [
-                                'stdout: Hello world 1',
-                                'stdout: Hello world 2',
-                                'stdout: Hello world 3',
-                                'stdout: Hello world 4',
-                                'stdout: Hello world 5',
-                            ],
-                            totalCount: 5,
-                            pageInfo: {
-                                endCursor: null,
-                                hasNextPage: false,
-                            }
-                        }
-                    }
-               }
-            } },
+            result: {
+                data: WORKSPACE_STEP_OUTPUT_LINES,
+            },
             nMatches: Number.POSITIVE_INFINITY,
-        }
+        },
     ])
 
     return (

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.story.tsx
@@ -30,7 +30,7 @@ import {
     BATCH_SPEC_WORKSPACE_STEP,
 } from '../backend'
 
-import { WorkspaceDetails, OUTPUT_LINES_PER_PAGE } from './WorkspaceDetails'
+import { WorkspaceDetails } from './WorkspaceDetails'
 
 const queryChangesetSpecFileDiffs = () =>
     of({ totalCount: 0, pageInfo: { endCursor: null, hasNextPage: false }, nodes: [] })

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.story.tsx
@@ -85,8 +85,8 @@ const BaseStory: React.FunctionComponent<BaseStoryProps> = ({ node, queries = {}
                     workspaceID: 'test-1234',
                     stepIndex: 1,
                     first: 500,
-                    after: null
-                }
+                    after: null,
+                },
             },
             result: {
                 data: WORKSPACE_STEP_OUTPUT_LINES_PAGE_ONE,
@@ -100,8 +100,8 @@ const BaseStory: React.FunctionComponent<BaseStoryProps> = ({ node, queries = {}
                     workspaceID: 'test-1234',
                     stepIndex: 1,
                     first: 500,
-                    after: "5"
-                }
+                    after: '500',
+                },
             },
             result: {
                 data: WORKSPACE_STEP_OUTPUT_LINES_PAGE_TWO,

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.story.tsx
@@ -21,7 +21,8 @@ import {
     FAILED_WORKSPACE,
     CANCELING_WORKSPACE,
     CANCELED_WORKSPACE,
-    WORKSPACE_STEP_OUTPUT_LINES,
+    WORKSPACE_STEP_OUTPUT_LINES_PAGE_ONE,
+    WORKSPACE_STEP_OUTPUT_LINES_PAGE_TWO,
 } from '../../batch-spec.mock'
 import {
     BATCH_SPEC_WORKSPACE_BY_ID,
@@ -29,7 +30,7 @@ import {
     BATCH_SPEC_WORKSPACE_STEP,
 } from '../backend'
 
-import { WorkspaceDetails } from './WorkspaceDetails'
+import { WorkspaceDetails, OUTPUT_LINES_PER_PAGE } from './WorkspaceDetails'
 
 const queryChangesetSpecFileDiffs = () =>
     of({ totalCount: 0, pageInfo: { endCursor: null, hasNextPage: false }, nodes: [] })
@@ -80,10 +81,30 @@ const BaseStory: React.FunctionComponent<BaseStoryProps> = ({ node, queries = {}
         {
             request: {
                 query: getDocumentNode(BATCH_SPEC_WORKSPACE_STEP),
-                variables: MATCH_ANY_PARAMETERS,
+                variables: {
+                    workspaceID: 'test-1234',
+                    stepIndex: 1,
+                    first: 500,
+                    after: null
+                }
             },
             result: {
-                data: WORKSPACE_STEP_OUTPUT_LINES,
+                data: WORKSPACE_STEP_OUTPUT_LINES_PAGE_ONE,
+            },
+            nMatches: Number.POSITIVE_INFINITY,
+        },
+        {
+            request: {
+                query: getDocumentNode(BATCH_SPEC_WORKSPACE_STEP),
+                variables: {
+                    workspaceID: 'test-1234',
+                    stepIndex: 1,
+                    first: 500,
+                    after: "5"
+                }
+            },
+            result: {
+                data: WORKSPACE_STEP_OUTPUT_LINES_PAGE_TWO,
             },
             nMatches: Number.POSITIVE_INFINITY,
         },
@@ -138,3 +159,6 @@ VisibleWorkspaceCanceling.storyName = 'Visible workspace: canceling'
 
 export const VisibleWorkspaceCanceled: Story = () => <BaseStory node={CANCELED_WORKSPACE} />
 VisibleWorkspaceCanceled.storyName = 'Visible workspace: canceled'
+
+export const VisibleWorkspaceLargeLogOutput: Story = () => <BaseStory node={CANCELED_WORKSPACE} />
+VisibleWorkspaceLargeLogOutput.storyName = 'Visible workspace: Large Log Output'

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.story.tsx
@@ -159,6 +159,3 @@ VisibleWorkspaceCanceling.storyName = 'Visible workspace: canceling'
 
 export const VisibleWorkspaceCanceled: Story = () => <BaseStory node={CANCELED_WORKSPACE} />
 VisibleWorkspaceCanceled.storyName = 'Visible workspace: canceled'
-
-export const VisibleWorkspaceLargeLogOutput: Story = () => <BaseStory node={CANCELED_WORKSPACE} />
-VisibleWorkspaceLargeLogOutput.storyName = 'Visible workspace: Large Log Output'

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback, useEffect, useMemo, useReducer, useState } from 'react'
+import React, { Fragment, useCallback, useMemo, useState } from 'react'
 
 import {
     mdiClose,
@@ -14,7 +14,6 @@ import {
 import { VisuallyHidden } from '@reach/visually-hidden'
 import { dataOrThrowErrors } from '@sourcegraph/http-client'
 import classNames from 'classnames'
-import { cloneDeep } from 'lodash'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import indicator from 'ordinal/indicator'
 import { useHistory } from 'react-router'
@@ -63,7 +62,6 @@ import {
     FileDiffFields,
     BatchSpecWorkspaceStepResult,
     BatchSpecWorkspaceStepVariables,
-    BatchSpecWorkspaceStepOutputLines,
 } from '../../../../../graphql-operations'
 import { eventLogger } from '../../../../../tracking/eventLogger'
 import { queryChangesetSpecFileDiffs as _queryChangesetSpecFileDiffs } from '../../../preview/list/backend'

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 
 import {
     mdiClose,
@@ -12,12 +12,12 @@ import {
     mdiOpenInNew,
 } from '@mdi/js'
 import { VisuallyHidden } from '@reach/visually-hidden'
-import { dataOrThrowErrors } from '@sourcegraph/http-client'
 import classNames from 'classnames'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import indicator from 'ordinal/indicator'
 import { useHistory } from 'react-router'
 
+import { dataOrThrowErrors } from '@sourcegraph/http-client'
 import { Maybe } from '@sourcegraph/shared/src/graphql-operations'
 import {
     Badge,
@@ -49,6 +49,7 @@ import {
 import { DiffStat } from '../../../../../components/diff/DiffStat'
 import { FileDiffNode, FileDiffNodeProps } from '../../../../../components/diff/FileDiffNode'
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../../../../../components/FilteredConnection'
+import { useShowMorePagination } from '../../../../../components/FilteredConnection/hooks/useShowMorePagination'
 import { HeroPage } from '../../../../../components/HeroPage'
 import { LogOutput } from '../../../../../components/LogOutput'
 import { Duration } from '../../../../../components/time/Duration'
@@ -78,7 +79,6 @@ import { StepStateIcon } from './StepStateIcon'
 import { WorkspaceStateIcon } from './WorkspaceStateIcon'
 
 import styles from './WorkspaceDetails.module.scss'
-import { useShowMorePagination } from '../../../../../components/FilteredConnection/hooks/useShowMorePagination'
 
 export interface WorkspaceDetailsProps {
     id: Scalars['ID']
@@ -558,7 +558,7 @@ export const WorkspaceStepOutputLines: React.FunctionComponent<
         <>
             {connection.nodes.length > 0 && <LogOutput text={connection.nodes.join('\n')} />}
             {hasNextPage && (
-                <Fragment>
+                <>
                     {loading ? (
                         <LoadingSpinner />
                     ) : (
@@ -566,7 +566,7 @@ export const WorkspaceStepOutputLines: React.FunctionComponent<
                             Load more ...
                         </Button>
                     )}
-                </Fragment>
+                </>
             )}
             <LogOutput text={additionalOutputLines.join('\n')} />
         </>

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -650,7 +650,7 @@ const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceSt
                                                         )}
                                                     </>
                                                 )}
-                                                {step.outputLines && <LogOutput text={stepOutputCommandInfo} className={styles.stepCommandInfo} />}
+                                                {step.outputLines && <LogOutput text={stepOutputCommandInfo} />}
                                             </>
                                         ) : (
                                             <Text className="text-muted mb-0">Step not started yet</Text>

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -13,10 +13,12 @@ import {
 } from '@mdi/js'
 import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
+import { cloneDeep } from 'lodash'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import indicator from 'ordinal/indicator'
 import { useHistory } from 'react-router'
 
+import { useLazyQuery } from '@sourcegraph/http-client'
 import { Maybe } from '@sourcegraph/shared/src/graphql-operations'
 import {
     Badge,
@@ -77,8 +79,6 @@ import { StepStateIcon } from './StepStateIcon'
 import { WorkspaceStateIcon } from './WorkspaceStateIcon'
 
 import styles from './WorkspaceDetails.module.scss'
-import { useLazyQuery } from '@sourcegraph/http-client'
-import { cloneDeep } from 'lodash'
 
 export interface WorkspaceDetailsProps {
     id: Scalars['ID']
@@ -485,12 +485,6 @@ interface WorkspaceStepProps {
     workspaceID: Scalars['ID']
     /** For testing purposes only */
     queryBatchSpecWorkspaceStepFileDiffs?: typeof _queryBatchSpecWorkspaceStepFileDiffs
-}
-
-type PageInfo = {
-        __typename?: "PageInfo" | undefined;
-        hasNextPage: boolean;
-        endCursor: string | null;
 }
 
 const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceStepProps>> = ({

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -511,11 +511,7 @@ export const WorkspaceStepOutputLines: React.FunctionComponent<
         getConnection: result => {
             const data = dataOrThrowErrors(result)
             if (data.node?.__typename !== 'VisibleBatchSpecWorkspace' || data.node.step === null) {
-                throw new Error('Not a visible batch spec workspace')
-            }
-
-            if (data.node.step.outputLines === null) {
-                throw new Error('Ouutput lines is empty')
+                throw new Error('unable to fetch workspace step')
             }
 
             return data.node.step.outputLines

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -493,9 +493,10 @@ const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceSt
 
     const outputLines = useMemo(() => {
         const outputLines = cloneDeep(step.outputLines)
-        if (outputLines !== null) {
+        console.log(outputLines, '<=====')
+        if (outputLines.nodes !== null) {
             if (
-                outputLines.every(
+                outputLines.nodes.every(
                     line =>
                         line
                             .replaceAll(/'^std(out|err):'/g, '')
@@ -503,15 +504,15 @@ const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceSt
                             .trim() === ''
                 )
             ) {
-                outputLines.push('stdout: This command did not produce any output')
+                outputLines.nodes.push('stdout: This command did not produce any output')
             }
 
             if (step.exitCode === 0) {
-                outputLines.push(`\nstdout: \nstdout: Command exited successfully with status ${step.exitCode}`)
+                outputLines.nodes.push(`\nstdout: \nstdout: Command exited successfully with status ${step.exitCode}`)
             }
 
             if (step.exitCode !== null && step.exitCode !== 0) {
-                outputLines.push(`stderr: Command failed with status ${step.exitCode}`)
+                outputLines.nodes.push(`stderr: Command failed with status ${step.exitCode}`)
             }
         }
 
@@ -581,7 +582,7 @@ const WorkspaceStep: React.FunctionComponent<React.PropsWithChildren<WorkspaceSt
                                         {!step.startedAt && (
                                             <Text className="text-muted mb-0">Step not started yet</Text>
                                         )}
-                                        {step.startedAt && outputLines && <LogOutput text={outputLines.join('\n')} />}
+                                        {step.startedAt && outputLines && outputLines.nodes.length > 0 && <LogOutput text={outputLines.nodes.join('\n')} />}
                                     </TabPanel>
                                     <TabPanel className="pt-2" key="output-variables">
                                         {!step.startedAt && (

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -555,12 +555,12 @@ export const WorkspaceStepOutputLines: React.FunctionComponent<
     }
 
     return (
-        <>
+        <div className={styles.stepOutputContainer}>
             {connection.nodes.length > 0 && <LogOutput text={connection.nodes.join('\n')} />}
             {hasNextPage && (
                 <>
                     {loading ? (
-                        <LoadingSpinner />
+                        <LoadingSpinner className="bg-transparent ml-3" />
                     ) : (
                         <Button size="sm" className={styles.stepOutputShowMoreBtn} onClick={fetchMore}>
                             Load more ...
@@ -569,7 +569,7 @@ export const WorkspaceStepOutputLines: React.FunctionComponent<
                 </>
             )}
             <LogOutput text={additionalOutputLines.join('\n')} />
-        </>
+        </div>
     )
 }
 

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.tsx
@@ -487,7 +487,7 @@ interface WorkspaceStepProps {
     queryBatchSpecWorkspaceStepFileDiffs?: typeof _queryBatchSpecWorkspaceStepFileDiffs
 }
 
-const OUTPUT_LINES_PER_PAGE = 500
+export const OUTPUT_LINES_PER_PAGE = 500
 
 export const WorkspaceStepOutputLines: React.FunctionComponent<
     React.PropsWithChildren<Pick<WorkspaceStepProps, 'step' | 'workspaceID'>>

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -914,7 +914,7 @@ type BatchSpecWorkspaceStepResolver interface {
 	IfCondition() *string
 	CachedResultFound() bool
 	Skipped() bool
-	OutputLines(ctx context.Context) (*[]string, error)
+	OutputLines(ctx context.Context, args *BatchSpecWorkspaceStepOutputLinesArgs) (*[]string, error)
 
 	StartedAt() *gqlutil.DateTime
 	FinishedAt() *gqlutil.DateTime

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -907,7 +907,7 @@ type BatchSpecWorkspaceStagesResolver interface {
 	Teardown() []ExecutionLogEntryResolver
 }
 
-type BatchSpecWorkspaceStepOutputLinesResolver interface {
+type BatchSpecWorkspaceStepOutputLineConnectionResolver interface {
 	TotalCount(ctx context.Context) int32
 	PageInfo(ctx context.Context) *graphqlutil.PageInfo
 	Nodes(ctx context.Context) []string
@@ -920,7 +920,7 @@ type BatchSpecWorkspaceStepResolver interface {
 	IfCondition() *string
 	CachedResultFound() bool
 	Skipped() bool
-	OutputLines(ctx context.Context, args *BatchSpecWorkspaceStepOutputLinesArgs) BatchSpecWorkspaceStepOutputLinesResolver
+	OutputLines(ctx context.Context, args *BatchSpecWorkspaceStepOutputLinesArgs) BatchSpecWorkspaceStepOutputLineConnectionResolver
 
 	StartedAt() *gqlutil.DateTime
 	FinishedAt() *gqlutil.DateTime

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -914,7 +914,7 @@ type BatchSpecWorkspaceStepResolver interface {
 	IfCondition() *string
 	CachedResultFound() bool
 	Skipped() bool
-	OutputLines(ctx context.Context, args *BatchSpecWorkspaceStepOutputLinesArgs) (*[]string, error)
+	OutputLines(ctx context.Context) (*[]string, error)
 
 	StartedAt() *gqlutil.DateTime
 	FinishedAt() *gqlutil.DateTime

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -907,6 +907,12 @@ type BatchSpecWorkspaceStagesResolver interface {
 	Teardown() []ExecutionLogEntryResolver
 }
 
+type BatchSpecWorkspaceStepOutputLinesResolver interface {
+	TotalCount(ctx context.Context) (int32, error)
+	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
+	Nodes(ctx context.Context) ([]string, error)
+}
+
 type BatchSpecWorkspaceStepResolver interface {
 	Number() int32
 	Run() string
@@ -914,7 +920,7 @@ type BatchSpecWorkspaceStepResolver interface {
 	IfCondition() *string
 	CachedResultFound() bool
 	Skipped() bool
-	OutputLines(ctx context.Context, args *BatchSpecWorkspaceStepOutputLinesArgs) (*[]string, error)
+	OutputLines(ctx context.Context, args *BatchSpecWorkspaceStepOutputLinesArgs) (BatchSpecWorkspaceStepOutputLinesResolver, error)
 
 	StartedAt() *gqlutil.DateTime
 	FinishedAt() *gqlutil.DateTime

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -908,9 +908,9 @@ type BatchSpecWorkspaceStagesResolver interface {
 }
 
 type BatchSpecWorkspaceStepOutputLinesResolver interface {
-	TotalCount(ctx context.Context) (int32, error)
-	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
-	Nodes(ctx context.Context) ([]string, error)
+	TotalCount(ctx context.Context) int32
+	PageInfo(ctx context.Context) *graphqlutil.PageInfo
+	Nodes(ctx context.Context) []string
 }
 
 type BatchSpecWorkspaceStepResolver interface {

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -920,7 +920,7 @@ type BatchSpecWorkspaceStepResolver interface {
 	IfCondition() *string
 	CachedResultFound() bool
 	Skipped() bool
-	OutputLines(ctx context.Context, args *BatchSpecWorkspaceStepOutputLinesArgs) (BatchSpecWorkspaceStepOutputLinesResolver, error)
+	OutputLines(ctx context.Context, args *BatchSpecWorkspaceStepOutputLinesArgs) BatchSpecWorkspaceStepOutputLinesResolver
 
 	StartedAt() *gqlutil.DateTime
 	FinishedAt() *gqlutil.DateTime

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -908,9 +908,9 @@ type BatchSpecWorkspaceStagesResolver interface {
 }
 
 type BatchSpecWorkspaceStepOutputLineConnectionResolver interface {
-	TotalCount(ctx context.Context) int32
-	PageInfo(ctx context.Context) *graphqlutil.PageInfo
-	Nodes(ctx context.Context) []string
+	TotalCount() int32
+	PageInfo() *graphqlutil.PageInfo
+	Nodes() []string
 }
 
 type BatchSpecWorkspaceStepResolver interface {

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -638,7 +638,7 @@ type ListRecentlyErroredWorkspacesArgs struct {
 
 type BatchSpecWorkspaceStepOutputLinesArgs struct {
 	First int32
-	After *int32
+	After *string
 }
 
 type BatchChangeResolver interface {
@@ -908,9 +908,9 @@ type BatchSpecWorkspaceStagesResolver interface {
 }
 
 type BatchSpecWorkspaceStepOutputLineConnectionResolver interface {
-	TotalCount() int32
-	PageInfo() *graphqlutil.PageInfo
-	Nodes() []string
+	TotalCount() (int32, error)
+	PageInfo() (*graphqlutil.PageInfo, error)
+	Nodes() ([]string, error)
 }
 
 type BatchSpecWorkspaceStepResolver interface {

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2477,16 +2477,7 @@ type BatchSpecWorkspaceStep {
     The output logs, prefixed with either "stdout " or "stderr ". Null, if the
     step has not run yet.
     """
-    outputLines(
-        """
-        Return the first N lines of logs.
-        """
-        first: Int = 500
-        """
-        Return the log lines after N lines.
-        """
-        after: Int
-    ): [String!]
+    outputLines: [String!]
 
     """
     The time when the step started processing. Null, if not yet started.

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2486,7 +2486,7 @@ type BatchSpecWorkspaceStep {
         Return the log lines after N lines.
         """
         after: Int
-    ): [String!]
+    ): BatchSpecWorkspaceStepOutputLines
 
     """
     The time when the step started processing. Null, if not yet started.
@@ -2522,6 +2522,12 @@ type BatchSpecWorkspaceStep {
     The generated diff from this step. Null, if not yet finished.
     """
     diff: PreviewRepositoryComparison
+}
+
+type BatchSpecWorkspaceStepOutputLines {
+    totalCount: Int!
+    pageInfo: PageInfo!
+    nodes: [String!]!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2486,7 +2486,7 @@ type BatchSpecWorkspaceStep {
         Return the log lines after N lines.
         """
         after: Int
-    ): BatchSpecWorkspaceStepOutputLines
+    ): BatchSpecWorkspaceStepOutputLineConnection
 
     """
     The time when the step started processing. Null, if not yet started.
@@ -2524,9 +2524,23 @@ type BatchSpecWorkspaceStep {
     diff: PreviewRepositoryComparison
 }
 
-type BatchSpecWorkspaceStepOutputLines {
+"""
+A list of Output lines from a Batch spec workspace.
+"""
+type BatchSpecWorkspaceStepOutputLineConnection {
+    """
+    The total number of output lines in the connection.
+    """
     totalCount: Int!
+
+    """
+    Pagination information.
+    """
     pageInfo: PageInfo!
+
+    """
+    A list of output lines.
+    """
     nodes: [String!]!
 }
 

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2486,7 +2486,7 @@ type BatchSpecWorkspaceStep {
         Return the log lines after N lines.
         """
         after: String
-    ): BatchSpecWorkspaceStepOutputLineConnection
+    ): BatchSpecWorkspaceStepOutputLineConnection!
 
     """
     The time when the step started processing. Null, if not yet started.

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2485,7 +2485,7 @@ type BatchSpecWorkspaceStep {
         """
         Return the log lines after N lines.
         """
-        after: Int
+        after: String
     ): BatchSpecWorkspaceStepOutputLineConnection
 
     """

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2477,7 +2477,16 @@ type BatchSpecWorkspaceStep {
     The output logs, prefixed with either "stdout " or "stderr ". Null, if the
     step has not run yet.
     """
-    outputLines: [String!]
+    outputLines(
+        """
+        Return the first N lines of logs.
+        """
+        first: Int = 500
+        """
+        Return the log lines after N lines.
+        """
+        after: Int
+    ): [String!]
 
     """
     The time when the step started processing. Null, if not yet started.

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
@@ -62,7 +62,7 @@ func (r *batchSpecWorkspaceStepV1Resolver) Skipped() bool {
 func (r *batchSpecWorkspaceStepV1Resolver) OutputLines(ctx context.Context, args *graphqlbackend.BatchSpecWorkspaceStepOutputLinesArgs) graphqlbackend.BatchSpecWorkspaceStepOutputLinesResolver {
 	lines := r.stepInfo.OutputLines
 
-	return &batchSpecWorkspaceOutputLiinesResolver{
+	return &batchSpecWorkspaceOutputLinesResolver{
 		lines: lines,
 		first: args.First,
 		after: args.After,
@@ -221,7 +221,7 @@ func (r *batchSpecWorkspaceStepV2Resolver) OutputLines(ctx context.Context, args
 	}
 
 	lines := strings.Split(r.logEntry.Out, "\n")
-	return &batchSpecWorkspaceOutputLiinesResolver{
+	return &batchSpecWorkspaceOutputLinesResolver{
 		lines: lines,
 		first: args.First,
 		after: args.After,
@@ -361,7 +361,7 @@ func (r *batchSpecWorkspaceOutputVariableResolver) Value() graphqlbackend.JSONVa
 	return graphqlbackend.JSONValue{Value: r.value}
 }
 
-type batchSpecWorkspaceOutputLiinesResolver struct {
+type batchSpecWorkspaceOutputLinesResolver struct {
 	lines []string
 	first int32
 	after *int32
@@ -373,9 +373,9 @@ type batchSpecWorkspaceOutputLiinesResolver struct {
 	endCursor   int32
 }
 
-var _ graphqlbackend.BatchSpecWorkspaceStepOutputLinesResolver = &batchSpecWorkspaceOutputLiinesResolver{}
+var _ graphqlbackend.BatchSpecWorkspaceStepOutputLinesResolver = &batchSpecWorkspaceOutputLinesResolver{}
 
-func (r *batchSpecWorkspaceOutputLiinesResolver) compute(ctx context.Context) ([]string, int32, bool) {
+func (r *batchSpecWorkspaceOutputLinesResolver) compute(ctx context.Context) ([]string, int32, bool) {
 	r.once.Do(func() {
 		totalLines := len(r.lines)
 		r.total = int32(totalLines)
@@ -402,20 +402,20 @@ func (r *batchSpecWorkspaceOutputLiinesResolver) compute(ctx context.Context) ([
 	return r.linesSubset, r.total, r.hasNextPage
 }
 
-func (r *batchSpecWorkspaceOutputLiinesResolver) TotalCount(ctx context.Context) (int32, error) {
+func (r *batchSpecWorkspaceOutputLinesResolver) TotalCount(ctx context.Context) int32 {
 	_, totalCount, _ := r.compute(ctx)
-	return totalCount, nil
+	return totalCount
 }
 
-func (r *batchSpecWorkspaceOutputLiinesResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+func (r *batchSpecWorkspaceOutputLinesResolver) PageInfo(ctx context.Context) *graphqlutil.PageInfo {
 	_, _, hasNextPage := r.compute(ctx)
 	if hasNextPage {
-		return graphqlutil.NextPageCursor(strconv.Itoa(int(r.endCursor))), nil
+		return graphqlutil.NextPageCursor(strconv.Itoa(int(r.endCursor)))
 	}
-	return graphqlutil.HasNextPage(hasNextPage), nil
+	return graphqlutil.HasNextPage(hasNextPage)
 }
 
-func (r *batchSpecWorkspaceOutputLiinesResolver) Nodes(ctx context.Context) ([]string, error) {
+func (r *batchSpecWorkspaceOutputLinesResolver) Nodes(ctx context.Context) []string {
 	lines, _, _ := r.compute(ctx)
-	return lines, nil
+	return lines
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
@@ -375,7 +375,7 @@ type batchSpecWorkspaceOutputLinesResolver struct {
 
 var _ graphqlbackend.BatchSpecWorkspaceStepOutputLineConnectionResolver = &batchSpecWorkspaceOutputLinesResolver{}
 
-func (r *batchSpecWorkspaceOutputLinesResolver) compute(ctx context.Context) ([]string, int32, bool) {
+func (r *batchSpecWorkspaceOutputLinesResolver) compute() ([]string, int32, bool) {
 	r.once.Do(func() {
 		totalLines := len(r.lines)
 		r.total = int32(totalLines)
@@ -402,20 +402,20 @@ func (r *batchSpecWorkspaceOutputLinesResolver) compute(ctx context.Context) ([]
 	return r.linesSubset, r.total, r.hasNextPage
 }
 
-func (r *batchSpecWorkspaceOutputLinesResolver) TotalCount(ctx context.Context) int32 {
-	_, totalCount, _ := r.compute(ctx)
+func (r *batchSpecWorkspaceOutputLinesResolver) TotalCount() int32 {
+	_, totalCount, _ := r.compute()
 	return totalCount
 }
 
-func (r *batchSpecWorkspaceOutputLinesResolver) PageInfo(ctx context.Context) *graphqlutil.PageInfo {
-	_, _, hasNextPage := r.compute(ctx)
+func (r *batchSpecWorkspaceOutputLinesResolver) PageInfo() *graphqlutil.PageInfo {
+	_, _, hasNextPage := r.compute()
 	if hasNextPage {
 		return graphqlutil.NextPageCursor(strconv.Itoa(int(r.endCursor)))
 	}
 	return graphqlutil.HasNextPage(hasNextPage)
 }
 
-func (r *batchSpecWorkspaceOutputLinesResolver) Nodes(ctx context.Context) []string {
-	lines, _, _ := r.compute(ctx)
+func (r *batchSpecWorkspaceOutputLinesResolver) Nodes() []string {
+	lines, _, _ := r.compute()
 	return lines
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
@@ -54,14 +54,8 @@ func (r *batchSpecWorkspaceStepV1Resolver) Skipped() bool {
 	return r.CachedResultFound() || r.stepInfo.Skipped
 }
 
-func (r *batchSpecWorkspaceStepV1Resolver) OutputLines(ctx context.Context, args *graphqlbackend.BatchSpecWorkspaceStepOutputLinesArgs) (*[]string, error) {
+func (r *batchSpecWorkspaceStepV1Resolver) OutputLines(ctx context.Context) (*[]string, error) {
 	lines := r.stepInfo.OutputLines
-	if args.After != nil {
-		lines = lines[*args.After:]
-	}
-	if int(args.First) < len(lines) {
-		lines = lines[:args.First]
-	}
 	// TODO: Return nil when execution not yet started.
 	return &lines, nil
 }
@@ -210,19 +204,12 @@ func (r *batchSpecWorkspaceStepV2Resolver) Skipped() bool {
 	return r.CachedResultFound() || r.skipped
 }
 
-func (r *batchSpecWorkspaceStepV2Resolver) OutputLines(ctx context.Context, args *graphqlbackend.BatchSpecWorkspaceStepOutputLinesArgs) (*[]string, error) {
+func (r *batchSpecWorkspaceStepV2Resolver) OutputLines(ctx context.Context) (*[]string, error) {
 	if !r.logEntryFound {
 		return nil, nil
 	}
 
 	lines := strings.Split(r.logEntry.Out, "\n")
-
-	if args.After != nil {
-		lines = lines[*args.After:]
-	}
-	if int(args.First) < len(lines) {
-		lines = lines[:args.First]
-	}
 	return &lines, nil
 }
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
@@ -59,7 +59,7 @@ func (r *batchSpecWorkspaceStepV1Resolver) Skipped() bool {
 	return r.CachedResultFound() || r.stepInfo.Skipped
 }
 
-func (r *batchSpecWorkspaceStepV1Resolver) OutputLines(ctx context.Context, args *graphqlbackend.BatchSpecWorkspaceStepOutputLinesArgs) graphqlbackend.BatchSpecWorkspaceStepOutputLinesResolver {
+func (r *batchSpecWorkspaceStepV1Resolver) OutputLines(ctx context.Context, args *graphqlbackend.BatchSpecWorkspaceStepOutputLinesArgs) graphqlbackend.BatchSpecWorkspaceStepOutputLineConnectionResolver {
 	lines := r.stepInfo.OutputLines
 
 	return &batchSpecWorkspaceOutputLinesResolver{
@@ -215,7 +215,7 @@ func (r *batchSpecWorkspaceStepV2Resolver) Skipped() bool {
 	return r.CachedResultFound() || r.skipped
 }
 
-func (r *batchSpecWorkspaceStepV2Resolver) OutputLines(ctx context.Context, args *graphqlbackend.BatchSpecWorkspaceStepOutputLinesArgs) graphqlbackend.BatchSpecWorkspaceStepOutputLinesResolver {
+func (r *batchSpecWorkspaceStepV2Resolver) OutputLines(ctx context.Context, args *graphqlbackend.BatchSpecWorkspaceStepOutputLinesArgs) graphqlbackend.BatchSpecWorkspaceStepOutputLineConnectionResolver {
 	if !r.logEntryFound {
 		return nil
 	}
@@ -373,7 +373,7 @@ type batchSpecWorkspaceOutputLinesResolver struct {
 	endCursor   int32
 }
 
-var _ graphqlbackend.BatchSpecWorkspaceStepOutputLinesResolver = &batchSpecWorkspaceOutputLinesResolver{}
+var _ graphqlbackend.BatchSpecWorkspaceStepOutputLineConnectionResolver = &batchSpecWorkspaceOutputLinesResolver{}
 
 func (r *batchSpecWorkspaceOutputLinesResolver) compute(ctx context.Context) ([]string, int32, bool) {
 	r.once.Do(func() {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
@@ -59,14 +59,14 @@ func (r *batchSpecWorkspaceStepV1Resolver) Skipped() bool {
 	return r.CachedResultFound() || r.stepInfo.Skipped
 }
 
-func (r *batchSpecWorkspaceStepV1Resolver) OutputLines(ctx context.Context, args *graphqlbackend.BatchSpecWorkspaceStepOutputLinesArgs) (graphqlbackend.BatchSpecWorkspaceStepOutputLinesResolver, error) {
+func (r *batchSpecWorkspaceStepV1Resolver) OutputLines(ctx context.Context, args *graphqlbackend.BatchSpecWorkspaceStepOutputLinesArgs) graphqlbackend.BatchSpecWorkspaceStepOutputLinesResolver {
 	lines := r.stepInfo.OutputLines
 
 	return &batchSpecWorkspaceOutputLiinesResolver{
 		lines: lines,
 		first: args.First,
 		after: args.After,
-	}, nil
+	}
 }
 
 func (r *batchSpecWorkspaceStepV1Resolver) StartedAt() *gqlutil.DateTime {
@@ -215,9 +215,9 @@ func (r *batchSpecWorkspaceStepV2Resolver) Skipped() bool {
 	return r.CachedResultFound() || r.skipped
 }
 
-func (r *batchSpecWorkspaceStepV2Resolver) OutputLines(ctx context.Context, args *graphqlbackend.BatchSpecWorkspaceStepOutputLinesArgs) (graphqlbackend.BatchSpecWorkspaceStepOutputLinesResolver, error) {
+func (r *batchSpecWorkspaceStepV2Resolver) OutputLines(ctx context.Context, args *graphqlbackend.BatchSpecWorkspaceStepOutputLinesArgs) graphqlbackend.BatchSpecWorkspaceStepOutputLinesResolver {
 	if !r.logEntryFound {
-		return nil, nil
+		return nil
 	}
 
 	lines := strings.Split(r.logEntry.Out, "\n")
@@ -225,7 +225,7 @@ func (r *batchSpecWorkspaceStepV2Resolver) OutputLines(ctx context.Context, args
 		lines: lines,
 		first: args.First,
 		after: args.After,
-	}, nil
+	}
 }
 
 func (r *batchSpecWorkspaceStepV2Resolver) StartedAt() *gqlutil.DateTime {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
@@ -54,8 +54,14 @@ func (r *batchSpecWorkspaceStepV1Resolver) Skipped() bool {
 	return r.CachedResultFound() || r.stepInfo.Skipped
 }
 
-func (r *batchSpecWorkspaceStepV1Resolver) OutputLines(ctx context.Context) (*[]string, error) {
+func (r *batchSpecWorkspaceStepV1Resolver) OutputLines(ctx context.Context, args *graphqlbackend.BatchSpecWorkspaceStepOutputLinesArgs) (*[]string, error) {
 	lines := r.stepInfo.OutputLines
+	if args.After != nil {
+		lines = lines[*args.After:]
+	}
+	if int(args.First) < len(lines) {
+		lines = lines[:args.First]
+	}
 	// TODO: Return nil when execution not yet started.
 	return &lines, nil
 }
@@ -204,12 +210,19 @@ func (r *batchSpecWorkspaceStepV2Resolver) Skipped() bool {
 	return r.CachedResultFound() || r.skipped
 }
 
-func (r *batchSpecWorkspaceStepV2Resolver) OutputLines(ctx context.Context) (*[]string, error) {
+func (r *batchSpecWorkspaceStepV2Resolver) OutputLines(ctx context.Context, args *graphqlbackend.BatchSpecWorkspaceStepOutputLinesArgs) (*[]string, error) {
 	if !r.logEntryFound {
 		return nil, nil
 	}
 
 	lines := strings.Split(r.logEntry.Out, "\n")
+
+	if args.After != nil {
+		lines = lines[*args.After:]
+	}
+	if int(args.First) < len(lines) {
+		lines = lines[:args.First]
+	}
 	return &lines, nil
 }
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
@@ -3,9 +3,11 @@ package resolvers
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/executor"
@@ -25,6 +27,8 @@ type batchSpecWorkspaceStepV1Resolver struct {
 
 	cachedResult *execution.AfterStepResult
 }
+
+var _ graphqlbackend.BatchSpecWorkspaceStepResolver = &batchSpecWorkspaceStepV1Resolver{}
 
 func (r *batchSpecWorkspaceStepV1Resolver) Number() int32 {
 	return int32(r.index + 1)
@@ -54,16 +58,14 @@ func (r *batchSpecWorkspaceStepV1Resolver) Skipped() bool {
 	return r.CachedResultFound() || r.stepInfo.Skipped
 }
 
-func (r *batchSpecWorkspaceStepV1Resolver) OutputLines(ctx context.Context, args *graphqlbackend.BatchSpecWorkspaceStepOutputLinesArgs) (*[]string, error) {
+func (r *batchSpecWorkspaceStepV1Resolver) OutputLines(ctx context.Context, args *graphqlbackend.BatchSpecWorkspaceStepOutputLinesArgs) (graphqlbackend.BatchSpecWorkspaceStepOutputLinesResolver, error) {
 	lines := r.stepInfo.OutputLines
-	if args.After != nil {
-		lines = lines[*args.After:]
-	}
-	if int(args.First) < len(lines) {
-		lines = lines[:args.First]
-	}
-	// TODO: Return nil when execution not yet started.
-	return &lines, nil
+
+	return &batchSpecWorkspaceOutputLiinesResolver{
+		lines: lines,
+		first: args.First,
+		after: args.After,
+	}, nil
 }
 
 func (r *batchSpecWorkspaceStepV1Resolver) StartedAt() *gqlutil.DateTime {
@@ -182,6 +184,8 @@ type batchSpecWorkspaceStepV2Resolver struct {
 	cachedResultFound bool
 }
 
+var _ graphqlbackend.BatchSpecWorkspaceStepResolver = &batchSpecWorkspaceStepV2Resolver{}
+
 func (r *batchSpecWorkspaceStepV2Resolver) Number() int32 {
 	return int32(r.index + 1)
 }
@@ -210,20 +214,17 @@ func (r *batchSpecWorkspaceStepV2Resolver) Skipped() bool {
 	return r.CachedResultFound() || r.skipped
 }
 
-func (r *batchSpecWorkspaceStepV2Resolver) OutputLines(ctx context.Context, args *graphqlbackend.BatchSpecWorkspaceStepOutputLinesArgs) (*[]string, error) {
+func (r *batchSpecWorkspaceStepV2Resolver) OutputLines(ctx context.Context, args *graphqlbackend.BatchSpecWorkspaceStepOutputLinesArgs) (graphqlbackend.BatchSpecWorkspaceStepOutputLinesResolver, error) {
 	if !r.logEntryFound {
 		return nil, nil
 	}
 
 	lines := strings.Split(r.logEntry.Out, "\n")
-
-	if args.After != nil {
-		lines = lines[*args.After:]
-	}
-	if int(args.First) < len(lines) {
-		lines = lines[:args.First]
-	}
-	return &lines, nil
+	return &batchSpecWorkspaceOutputLiinesResolver{
+		lines: lines,
+		first: args.First,
+		after: args.After,
+	}, nil
 }
 
 func (r *batchSpecWorkspaceStepV2Resolver) StartedAt() *gqlutil.DateTime {
@@ -357,4 +358,56 @@ func (r *batchSpecWorkspaceOutputVariableResolver) Name() string {
 }
 func (r *batchSpecWorkspaceOutputVariableResolver) Value() graphqlbackend.JSONValue {
 	return graphqlbackend.JSONValue{Value: r.value}
+}
+
+type batchSpecWorkspaceOutputLiinesResolver struct {
+	lines []string
+	first int32
+	after *int32
+
+	once        sync.Once
+	total       int32
+	linesSubset []string
+	hasNext     bool
+}
+
+var _ graphqlbackend.BatchSpecWorkspaceStepOutputLinesResolver = &batchSpecWorkspaceOutputLiinesResolver{}
+
+func (r *batchSpecWorkspaceOutputLiinesResolver) compute(ctx context.Context) ([]string, int32, bool) {
+	r.once.Do(func() {
+		totalLines := len(r.lines)
+		r.total = int32(totalLines)
+
+		var after int32
+		if r.after != nil {
+			after = *r.after
+		}
+
+		offset := (after + r.first)
+
+		if after < r.total {
+			r.linesSubset = r.lines[after:]
+		}
+
+		if int(r.first) < len(r.lines) && r.total > offset {
+			r.linesSubset = r.linesSubset[:r.first]
+		}
+		r.hasNext = r.total > offset
+	})
+	return r.linesSubset, r.total, r.hasNext
+}
+
+func (r *batchSpecWorkspaceOutputLiinesResolver) TotalCount(ctx context.Context) (int32, error) {
+	_, totalCount, _ := r.compute(ctx)
+	return totalCount, nil
+}
+
+func (r *batchSpecWorkspaceOutputLiinesResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	_, _, hasNext := r.compute(ctx)
+	return graphqlutil.HasNextPage(hasNext), nil
+}
+
+func (r *batchSpecWorkspaceOutputLiinesResolver) Nodes(ctx context.Context) ([]string, error) {
+	lines, _, _ := r.compute(ctx)
+	return lines, nil
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step_test.go
@@ -1,0 +1,7 @@
+package resolvers
+
+import "testing"
+
+func TestBatchSpecWorkspaceOutputLiinesResolver(t *testing.T) {
+
+}

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step_test.go
@@ -1,7 +1,54 @@
 package resolvers
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"testing"
 
-func TestBatchSpecWorkspaceOutputLiinesResolver(t *testing.T) {
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBatchSpecWorkspaceOutputLinesResolver(t *testing.T) {
+	var lines = make([]string, 100)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("Hello world: %d", i+1)
+	}
+	totalCount := int32(len(lines))
+	ctx := context.Background()
+
+	t.Run("with paginated output lines", func(t *testing.T) {
+		noOfLines := 50
+		resolver := &batchSpecWorkspaceOutputLinesResolver{
+			lines: lines,
+			first: int32(noOfLines),
+		}
+
+		assert.Equal(t, resolver.TotalCount(ctx), totalCount)
+		assert.Len(t, resolver.Nodes(ctx), 50)
+
+		pi := resolver.PageInfo(ctx)
+		assert.Equal(t, pi.HasNextPage(), true)
+		assert.Equal(t, *pi.EndCursor(), "50")
+	})
+
+	t.Run("cursor used to access paginated lines", func(t *testing.T) {
+		noOfLines := 50
+		endCursor := int32(50)
+
+		resolver := &batchSpecWorkspaceOutputLinesResolver{
+			lines: lines,
+			first: int32(noOfLines),
+			after: &endCursor,
+		}
+
+		assert.Equal(t, resolver.TotalCount(ctx), totalCount)
+		assert.Len(t, resolver.Nodes(ctx), 50)
+
+		pi := resolver.PageInfo(ctx)
+		assert.Equal(t, pi.HasNextPage(), false)
+		if pi.EndCursor() != nil {
+			t.Fatal("expected cursor to be nil")
+		}
+	})
 
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step_test.go
@@ -51,4 +51,23 @@ func TestBatchSpecWorkspaceOutputLinesResolver(t *testing.T) {
 		}
 	})
 
+	t.Run("offset greater than length of lines", func(t *testing.T) {
+		noOfLines := 150
+		endCursor := int32(50)
+
+		resolver := &batchSpecWorkspaceOutputLinesResolver{
+			lines: lines,
+			first: int32(noOfLines),
+			after: &endCursor,
+		}
+
+		assert.Equal(t, resolver.TotalCount(ctx), totalCount)
+		assert.Len(t, resolver.Nodes(ctx), 50)
+
+		pi := resolver.PageInfo(ctx)
+		assert.Equal(t, pi.HasNextPage(), false)
+		if pi.EndCursor() != nil {
+			t.Fatal("expected cursor to be nil")
+		}
+	})
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step_test.go
@@ -1,7 +1,6 @@
 package resolvers
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -14,7 +13,6 @@ func TestBatchSpecWorkspaceOutputLinesResolver(t *testing.T) {
 		lines[i] = fmt.Sprintf("Hello world: %d", i+1)
 	}
 	totalCount := int32(len(lines))
-	ctx := context.Background()
 
 	t.Run("with paginated output lines", func(t *testing.T) {
 		noOfLines := 50
@@ -23,17 +21,23 @@ func TestBatchSpecWorkspaceOutputLinesResolver(t *testing.T) {
 			first: int32(noOfLines),
 		}
 
-		assert.Equal(t, resolver.TotalCount(ctx), totalCount)
-		assert.Len(t, resolver.Nodes(ctx), 50)
+		tc, err := resolver.TotalCount()
+		assert.NoError(t, err)
+		assert.Equal(t, tc, totalCount)
 
-		pi := resolver.PageInfo(ctx)
+		nodes, err := resolver.Nodes()
+		assert.NoError(t, err)
+		assert.Len(t, nodes, 50)
+
+		pi, err := resolver.PageInfo()
+		assert.NoError(t, err)
 		assert.Equal(t, pi.HasNextPage(), true)
 		assert.Equal(t, *pi.EndCursor(), "50")
 	})
 
 	t.Run("cursor used to access paginated lines", func(t *testing.T) {
 		noOfLines := 50
-		endCursor := int32(50)
+		endCursor := "50"
 
 		resolver := &batchSpecWorkspaceOutputLinesResolver{
 			lines: lines,
@@ -41,10 +45,16 @@ func TestBatchSpecWorkspaceOutputLinesResolver(t *testing.T) {
 			after: &endCursor,
 		}
 
-		assert.Equal(t, resolver.TotalCount(ctx), totalCount)
-		assert.Len(t, resolver.Nodes(ctx), 50)
+		tc, err := resolver.TotalCount()
+		assert.NoError(t, err)
+		assert.Equal(t, tc, totalCount)
 
-		pi := resolver.PageInfo(ctx)
+		nodes, err := resolver.Nodes()
+		assert.NoError(t, err)
+		assert.Len(t, nodes, 50)
+
+		pi, err := resolver.PageInfo()
+		assert.NoError(t, err)
 		assert.Equal(t, pi.HasNextPage(), false)
 		if pi.EndCursor() != nil {
 			t.Fatal("expected cursor to be nil")
@@ -53,7 +63,7 @@ func TestBatchSpecWorkspaceOutputLinesResolver(t *testing.T) {
 
 	t.Run("offset greater than length of lines", func(t *testing.T) {
 		noOfLines := 150
-		endCursor := int32(50)
+		endCursor := "50"
 
 		resolver := &batchSpecWorkspaceOutputLinesResolver{
 			lines: lines,
@@ -61,10 +71,16 @@ func TestBatchSpecWorkspaceOutputLinesResolver(t *testing.T) {
 			after: &endCursor,
 		}
 
-		assert.Equal(t, resolver.TotalCount(ctx), totalCount)
-		assert.Len(t, resolver.Nodes(ctx), 50)
+		tc, err := resolver.TotalCount()
+		assert.NoError(t, err)
+		assert.Equal(t, tc, totalCount)
 
-		pi := resolver.PageInfo(ctx)
+		nodes, err := resolver.Nodes()
+		assert.NoError(t, err)
+		assert.Len(t, nodes, 50)
+
+		pi, err := resolver.PageInfo()
+		assert.NoError(t, err)
 		assert.Equal(t, pi.HasNextPage(), false)
 		if pi.EndCursor() != nil {
 			t.Fatal("expected cursor to be nil")


### PR DESCRIPTION
Reported [here](https://github.com/sourcegraph/customer/issues/1800).
Closes [#1800](https://github.com/sourcegraph/customer/issues/1800)

A customer reported that steps in their spec output were truncated. Started debugging by trying this out with `src-cli` and inspecting the log output to confirm if the output was truncated from `src-cli`; it wasn't.
I then proceeded to debug via SSBC route and discovered we stored the complete output in `batch_spec_workspace_execution_jobs.execution_logs` and found out the resolver for BatchSpecWorkspace steps was paginated and this meant that when using the `${{ previous_step.stdout }}` directive one wouldn't get the complete output from the previous steps and the output displayed was truncated.

The initial value for slicing the output lines was 500, I'm not 100% certain why that limit was placed but this PR removes the limit so we can get all lines in every step and also display the complete logs for users.

![CleanShot 2023-01-29 at 01 02 56](https://user-images.githubusercontent.com/25608335/215506170-99888120-5f02-4232-919b-4f82ff22dc12.gif)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Tested with a sample batch spec

```yaml
name: brevity-2
description: Add Hello World to READMEs

# Find the first 100 search results for README files.
# This could yield less than 100 repos/workspaces if some repos contain multiple READMEs.
on:
  - repository: github.com/sourcegraph-testing/markdowns

# In each repository, run this command. Each repository's resulting diff is captured.
steps:
  - run: |
        for i in $(seq 1 1000); do
          echo "Hello world: $i"
        done
    container: alpine:3

  - run: |
      cat /tmp/stuff
    container: alpine:3
    files:
      /tmp/stuff: |
        ${{ previous_step.stdout }}

# Describe the changeset (e.g., GitHub pull request) you want for each repository.
changesetTemplate:
  title: Brevity test
  body: My first batch change!
  branch: brev
  commit:
    message: Testing Testing

```

Confirmed all output lines are displayed.

[Loom](https://github.com/sourcegraph/sourcegraph/pull/46335)