### PR TITLE
Add a note to fetch --all from reference repo.

### DIFF
--- a/doc/admin/deploy/kubernetes/configure.md
+++ b/doc/admin/deploy/kubernetes/configure.md
@@ -78,6 +78,11 @@ git clone https://github.com/<you/private-repository>.git
 ```bash
 git remote add upstream https://github.com/sourcegraph/deploy-sourcegraph
 ```
+- Fetch all from the reference repository.
+
+```bash
+git fetch --all
+```
 
 - Create a `release` branch to track all of your customizations to Sourcegraph. This branch will be used to [upgrade Sourcegraph](update.md) and [install your Sourcegraph instance](./index.md#installation).
 


### PR DESCRIPTION
Currently, the docs say to add the upstream, but they don't ask the user to fetch branches and commits. This leads to the following error being returned whenever they attempt to create a release branch after adding the reference repository.

`fatal: 'v4.3.1' is not a commit and a branch 'release' cannot be created from it`

Adds a `git fetch --all` step to the flow.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally.
