### PR TITLE
Show the Sourcegraph user in more places

### DIFF
--- a/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
+++ b/client/web/src/repo/stats/RepositoryStatsContributorsPage.tsx
@@ -171,6 +171,7 @@ const CONTRIBUTORS_QUERY = gql`
                 username
                 url
                 displayName
+                avatarURL
             }
         }
         count

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -459,6 +459,7 @@ const CONTRIBUTORS_QUERY = gql`
                 username
                 url
                 displayName
+                avatarURL
             }
         }
         count
@@ -585,7 +586,7 @@ const RepositoryContributorNode: React.FunctionComponent<React.PropsWithChildren
     return (
         <li className={classNames('list-group-item py-2', contributorsStyles.repositoryContributorNode)}>
             <div className={contributorsStyles.person}>
-                <UserAvatar inline={true} className="mr-2" user={node.person} />
+                <UserAvatar inline={true} className="mr-2" user={node.person.user ? node.person.user : node.person} />
                 <PersonLink userClassName="font-weight-bold" person={node.person} />
             </div>
             <div className={contributorsStyles.commits}>

--- a/cmd/frontend/graphqlbackend/hunk.go
+++ b/cmd/frontend/graphqlbackend/hunk.go
@@ -16,9 +16,10 @@ type hunkResolver struct {
 func (r *hunkResolver) Author() signatureResolver {
 	return signatureResolver{
 		person: &PersonResolver{
-			db:    r.db,
-			name:  r.hunk.Author.Name,
-			email: r.hunk.Author.Email,
+			db:              r.db,
+			name:            r.hunk.Author.Name,
+			email:           r.hunk.Author.Email,
+			includeUserInfo: true,
 		},
 		date: r.hunk.Author.Date,
 	}

--- a/cmd/frontend/graphqlbackend/repository_contributor.go
+++ b/cmd/frontend/graphqlbackend/repository_contributor.go
@@ -33,7 +33,7 @@ func (r repositoryContributorResolver) ID() graphql.ID {
 }
 
 func (r *repositoryContributorResolver) Person() *PersonResolver {
-	return &PersonResolver{db: r.db, name: r.name, email: r.email}
+	return &PersonResolver{db: r.db, name: r.name, email: r.email, includeUserInfo: true}
 }
 
 func (r *repositoryContributorResolver) Count() int32 { return r.count }


### PR DESCRIPTION
I noticed that my new git blame view looks a bit dull on `sourcegraph.com` and as it turns out it is not showing any of the beautiful faces but instead just shows a replacement avatar.

Digging deeper, it turns out that the backend needs a specific flag to resolve to the Sourcegraph user from a generic author. So this PR turns it on for git blame and for the contributors view.

I’m not sure if there are any security concerns here but we're already doing the same for the commits page so I assume as long as the email is not being added by a query param, this should be fine?

## Before

<img width="1220" alt="Screenshot 2023-01-11 at 18 08 17" src="https://user-images.githubusercontent.com/458591/211873019-866888bc-4d77-4c78-8d12-97c0f20297bd.png">
<img width="1705" alt="Screenshot 2023-01-11 at 18 06 56" src="https://user-images.githubusercontent.com/458591/211873025-f0478998-1489-45f4-a5ae-49902f8bfedf.png">
<img width="1706" alt="Screenshot 2023-01-11 at 18 07 05" src="https://user-images.githubusercontent.com/458591/211873194-6a95b200-177b-451c-b933-85dbdaeec23d.png">

## Test plan

<img width="849" alt="Screenshot 2023-01-11 at 18 15 50" src="https://user-images.githubusercontent.com/458591/211873068-90072f6a-717f-4e0d-be71-a74e4cabc98d.png">
<img width="1183" alt="Screenshot 2023-01-11 at 18 15 19" src="https://user-images.githubusercontent.com/458591/211873072-eae5813c-e475-43c8-b498-1f6f0a23f47b.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
