### PR TITLE
search contexts: remove single no-op tab

### DIFF
--- a/client/web/src/enterprise/searchContexts/SearchContextsListPage.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextsListPage.tsx
@@ -74,21 +74,6 @@ export const SearchContextsListPage: React.FunctionComponent<SearchContextsListP
                     </PageHeader.Heading>
                 </PageHeader>
                 {alert && <Alert variant="danger">{alert}</Alert>}
-                <div id="search-context-tabs-list" className="nav nav-tabs">
-                    <div className="nav-item" role="tablist">
-                        <Link
-                            to="/contexts"
-                            role="tab"
-                            aria-selected={true}
-                            aria-controls="search-context-list"
-                            className="nav-link active"
-                        >
-                            <span className="text-content" data-tab-content="Your search contexts">
-                                Available contexts
-                            </span>
-                        </Link>
-                    </div>
-                </div>
                 <div role="tabpanel" id="search-context-list">
                     <SearchContextsList
                         authenticatedUser={authenticatedUser}


### PR DESCRIPTION
Remove single no-op tab from the search context list page ([Slack convo](https://sourcegraph.slack.com/archives/C0HMGV90V/p1673446919653429)).

## Test plan

Verify visually

![image](https://user-images.githubusercontent.com/206864/211884956-8fbdb692-649b-45d6-bb3e-4ed04ce133ba.png)

## App preview:

- [Web](https://sg-web-jp-removecontextstab.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
