### PR TITLE
add logic for release cycle to release protector

### DIFF
--- a/.github/workflows/release-protector.yml
+++ b/.github/workflows/release-protector.yml
@@ -1,8 +1,17 @@
 name: Release protector
 on:
   pull_request:
-    types: [ closed, edited, opened, synchronize, ready_for_review, labeled, unlabeled]
-    branches: 
+    types:
+      [
+        closed,
+        edited,
+        opened,
+        synchronize,
+        ready_for_review,
+        labeled,
+        unlabeled,
+      ]
+    branches:
       # only run on branches targeting the `main` branch.
       - main
 
@@ -13,30 +22,8 @@ jobs:
       - name: Check date and labels
         id: check-date-and-labels
         run: |
+          # Does this PR have the acknowledgement label?
           has_label="${{contains(github.event.pull_request.labels.*.name, 'i-acknowledge-this-goes-into-the-release')}}"
 
-          # When to start the freeze period, at 00:00 on that day
-          freeze_day=19 
-          # When to stop the freeze period, at 23:59 on that day
-          release_day=21 
-          today=$(date +'%Y%m%d%H%M')
-
-          current_month=$(date +'%B')
-          current_year=$(date +'%Y')
-          freeze_date=$(date -d "${current_month} ${freeze_day}, ${current_year}" +'%Y%m%d0000')
-          freeze_date_human=$(date -d "${current_month} ${freeze_day}, ${current_year}" +'%Y-%m-%d-00:00')
-          release_date=$(date -d "${current_month} ${release_day}, ${current_year}" +'%Y%m%d2359')
-
-          if [ "${today}" -ge "${freeze_date}" ] && [ "${today}" -lt "${release_date}" ]; then
-            if [ "${has_label}" = "true" ]; then
-              echo "✅ Label 'i-acknowledge-this-goes-into-the-release' is present"
-              exit 0
-            else
-              echo "❌ Label 'i-acknowledge-this-goes-into-the-release' is absent"
-              echo "👉 We're in the next Sourcegraph release code freeze period. If you are 100% sure your changes should get released or provide no risk to the release, add the label your PR with 'i-acknowledge-this-goes-into-the-release'"
-              exit 1
-            fi
-          else
-            echo "📅 Not enabled, we're not yet on ${freeze_date_human} and release code freeze has not started yet." 
-            exit 0
-          fi
+          # Pass the value of the above check into the shell script
+          ./.github/workflows/release_protector.sh $has_label

--- a/.github/workflows/release_protector.sh
+++ b/.github/workflows/release_protector.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# According to the handbook [https://handbook.sourcegraph.com/departments/engineering/dev/process/releases/#when-we-release], we
+# release on the 22nd of each month, If the 22nd falls on a non-working day,
+# the release captain will shift the release earlier to the last working day before the 22nd.
+
+# ALL dates must be in the format YYYY-MM-DD
+
+# This returns true or false depending on if the date passed is a working day.
+# We use this to adjust the release date / freeze date from the usual date defined in
+# the handbook.
+function is_weekend() {
+  # Parse the date string
+  local date_string="$1"
+  # Get the day of the week (0-6, where Sunday is 0)
+  local day_of_week
+  day_of_week=$(date -d "$date_string" +%u)
+  # Check if the day of the week is 6 (Saturday) or 7 (Sunday)
+  if [ "$day_of_week" -eq 6 ] || [ "$day_of_week" -eq 7 ]; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+# Use the this to get the last working day before the date passed in as an argument
+function find_last_working_day() {
+  local date_string=$1
+  while $(is_weekend "$date_string"); do
+    date_string=$(date -d "$date_string 1 day ago" +%F)
+  done
+  echo "$date_string"
+}
+
+function get_closest_working_day() {
+  if [ -z "$1" ]; then
+    echo "Error: No date string argument passed. Please pass date in format YYYY-MM-DD" >&2
+    return 1
+  fi
+
+  local date_to_check=$1
+  if $(is_weekend "$date_to_check"); then
+    date_to_check=$(find_last_working_day "$date_to_check")
+  fi
+  echo "$date_to_check"
+}
+
+function get_epoch() {
+  if [ -z "$1" ]; then
+    echo "Error: No date string argument passed. Please pass date in format YYYY-MM-DD" >&2
+    return 1
+  fi
+
+  echo "$(date -d "$1" +%s)"
+}
+
+release_day=22
+current_month=$(date +'%m')
+current_year=$(date +'%Y')
+
+release_date=$(get_closest_working_day "${current_year}-${current_month}-${release_day}")
+cut_date=$(get_closest_working_day "$(date -d "$release_date - 3 days" +%F)")
+freeze_date=$(get_closest_working_day "$(date -d "$cut_date - 5 days" +%F)")
+todays_date=$(date +'%Y-%m-%d %H:%M')
+
+has_label=$1
+
+todays_date_epoch=$(get_epoch "$todays_date")
+freeze_date_epoch=$(get_epoch "$freeze_date 00:00")
+release_date_epoch=$(get_epoch "$release_date 23:59")
+
+if [ "$todays_date_epoch" -ge "$freeze_date_epoch" ] && [ "$todays_date_epoch" -lt "$release_date_epoch" ]; then
+  if [ "${has_label}" = "true" ]; then
+    echo "✅ Label 'i-acknowledge-this-goes-into-the-release' is present"
+    exit 0
+  else
+    echo "❌ Label 'i-acknowledge-this-goes-into-the-release' is absent"
+    echo "👉 We're in the next Sourcegraph release code freeze period. If you are 100% sure your changes should get released or provide no risk to the release, add the label your PR with 'i-acknowledge-this-goes-into-the-release'"
+    exit 1
+  fi
+else
+  echo "📅 Not enabled, we're not yet on ${freeze_date} and release code freeze has not started yet."
+  exit 0
+fi

--- a/.github/workflows/release_protector.sh
+++ b/.github/workflows/release_protector.sh
@@ -17,16 +17,16 @@ function is_weekend() {
   day_of_week=$(date -d "$date_string" +%u)
   # Check if the day of the week is 6 (Saturday) or 7 (Sunday)
   if [ "$day_of_week" -eq 6 ] || [ "$day_of_week" -eq 7 ]; then
-    echo "true"
+    return 0
   else
-    echo "false"
+    return 1
   fi
 }
 
 # Use the this to get the last working day before the date passed in as an argument
 function find_last_working_day() {
   local date_string=$1
-  while $(is_weekend "$date_string"); do
+  while is_weekend "$date_string"; do
     date_string=$(date -d "$date_string 1 day ago" +%F)
   done
   echo "$date_string"
@@ -39,7 +39,7 @@ function get_closest_working_day() {
   fi
 
   local date_to_check=$1
-  if $(is_weekend "$date_to_check"); then
+  if is_weekend "$date_to_check"; then
     date_to_check=$(find_last_working_day "$date_to_check")
   fi
   echo "$date_to_check"
@@ -51,7 +51,7 @@ function get_epoch() {
     return 1
   fi
 
-  echo "$(date -d "$1" +%s)"
+  date -d "$1" +%s
 }
 
 release_day=22

--- a/.github/workflows/release_protector.sh
+++ b/.github/workflows/release_protector.sh
@@ -60,7 +60,11 @@ current_year=$(date +'%Y')
 
 release_date=$(get_closest_working_day "${current_year}-${current_month}-${release_day}")
 cut_date=$(get_closest_working_day "$(date -d "$release_date - 3 days" +%F)")
-freeze_date=$(get_closest_working_day "$(date -d "$cut_date - 2 days" +%F)")
+if [ "$current_month" -eq "03" ]; then
+  freeze_date=$(get_closest_working_day "$(date -d "$cut_date - 4 days" +%F)")
+else
+  freeze_date=$(get_closest_working_day "$(date -d "$cut_date - 2 days" +%F)")
+fi
 todays_date=$(date +'%Y-%m-%d %H:%M')
 
 has_label=$1

--- a/.github/workflows/release_protector.sh
+++ b/.github/workflows/release_protector.sh
@@ -60,7 +60,7 @@ current_year=$(date +'%Y')
 
 release_date=$(get_closest_working_day "${current_year}-${current_month}-${release_day}")
 cut_date=$(get_closest_working_day "$(date -d "$release_date - 3 days" +%F)")
-freeze_date=$(get_closest_working_day "$(date -d "$cut_date - 5 days" +%F)")
+freeze_date=$(get_closest_working_day "$(date -d "$cut_date - 2 days" +%F)")
 todays_date=$(date +'%Y-%m-%d %H:%M')
 
 has_label=$1


### PR DESCRIPTION
Moved the script into its own file so its easier to read and edit. Happy to move it into the yaml if it isn't convenient.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Tested using an ubuntu container, so I think it should work. WIll need to revamp when we switch the cadence for releases at Sourcegraph.

My shell scripting isn't great so feedback is definitely appreciated and welcome.