### PR TITLE
codeintel: Use project root when converting LSIF to SCIP

### DIFF
--- a/lib/codeintel/lsif/conversion/group.go
+++ b/lib/codeintel/lsif/conversion/group.go
@@ -34,6 +34,7 @@ func groupBundleData(ctx context.Context, state *State) *precise.GroupedBundleDa
 	packageReferences := gatherPackageReferences(state, packages)
 
 	return &precise.GroupedBundleDataChans{
+		ProjectRoot:       state.ProjectRoot,
 		Meta:              meta,
 		Documents:         documents,
 		ResultChunks:      resultChunks,

--- a/lib/codeintel/lsif/scip/index.go
+++ b/lib/codeintel/lsif/scip/index.go
@@ -65,7 +65,7 @@ func ConvertLSIF(ctx context.Context, uploadID int, r io.Reader, root string) (*
 	metadata := &scip.Metadata{
 		Version:              0,
 		ToolInfo:             &scip.ToolInfo{Name: indexerName},
-		ProjectRoot:          root,
+		ProjectRoot:          groupedBundleData.ProjectRoot,
 		TextDocumentEncoding: scip.TextEncoding_UnspecifiedTextEncoding,
 	}
 

--- a/lib/codeintel/lsif/scip/index_test.go
+++ b/lib/codeintel/lsif/scip/index_test.go
@@ -37,7 +37,7 @@ func TestConvertLSIF(t *testing.T) {
 
 	expectedIndex := &scip.Index{
 		Metadata: &scip.Metadata{
-			ProjectRoot:          "root/",
+			ProjectRoot:          "file:///test/root/",
 			ToolInfo:             &scip.ToolInfo{Name: "lsif-test"},
 			TextDocumentEncoding: scip.TextEncoding_UnspecifiedTextEncoding,
 			Version:              scip.ProtocolVersion_UnspecifiedProtocolVersion,

--- a/lib/codeintel/precise/types.go
+++ b/lib/codeintel/precise/types.go
@@ -234,6 +234,7 @@ type PackageReference struct {
 // and parallelizing the work, while the Maps version can be modified for e.g. local development
 // via the REPL or patching for incremental indexing.
 type GroupedBundleDataChans struct {
+	ProjectRoot       string
 	Meta              MetaData
 	Documents         chan KeyedDocumentData
 	ResultChunks      chan IndexedResultChunkData


### PR DESCRIPTION
Doesn't really matter but this lets us run `scip snapshot` on the intermediate output of src cli.

## Test plan

What _is_ a test when you really think about it.