### PR TITLE
show submenu below repo header, rather than on the right

### DIFF
--- a/client/web/src/repo/tree/TreePage.module.scss
+++ b/client/web/src/repo/tree/TreePage.module.scss
@@ -23,10 +23,11 @@
 
 .menu {
     .text {
-        @media (--lg-breakpoint-down) {
+        @media (--sm-breakpoint-down) {
             display: none;
         }
     }
+    width: 100%;
     flex-shrink: 0;
     padding-right: 0;
 }

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -195,7 +195,7 @@ export const TreePage: React.FunctionComponent<React.PropsWithChildren<Props>> =
 
     const RootHeaderSection = (): React.ReactElement => (
         <>
-            <div className="d-flex flex-wrap flex-lg-nowrap justify-content-between px-0">
+            <div className="d-flex flex-wrap justify-content-between px-0">
                 <div className={styles.header}>
                     <PageHeader className="mb-3 test-tree-page-title">
                         <PageHeader.Heading as="h2" styleAs="h1">
@@ -283,6 +283,7 @@ export const TreePage: React.FunctionComponent<React.PropsWithChildren<Props>> =
                                     aria-label="Repository settings"
                                 >
                                     <Icon aria-hidden={true} svgPath={mdiCog} />
+                                    <span className={styles.text}>Settings</span>
                                 </Button>
                             </Tooltip>
                         )}


### PR DESCRIPTION
Previously, submenu was shown on the right, which looked weird when the window was narrowed, because the menu intruded on the right bounding edge of the README below:

![image](https://user-images.githubusercontent.com/1646931/211955230-b48e7f76-f110-46ce-85a5-d89fe208b644.png)

Now, the submenu is shown below the repo header on the left:

![image](https://user-images.githubusercontent.com/1646931/211955404-13c86e1d-e84b-444d-b426-f39c1f83ecb8.png)

Narrow window:

![image](https://user-images.githubusercontent.com/1646931/211955412-a4e1c6a8-e5bd-4225-891c-3198e9217c4a.png)


## Test plan

Appearance-only change, tested locally.

## App preview:

- [Web](https://sg-web-bl-fix-spacing.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
