### PR TITLE
disable flaky nolintlint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,7 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - nolintlint
+    #- nolintlint see https://github.com/golangci/golangci-lint/issues/3228.
     - staticcheck
     - typecheck
     - unconvert
@@ -41,7 +41,7 @@ linters-settings:
       - exitAfterDefer # Only occurs in auxiliary tools
       - ifElseChain # Noisy for not much gain
       - singleCaseSwitch # Noisy for not much gain
-  unparam:
+  #unparam:
 
   govet:
     disable:


### PR DESCRIPTION
Disabling Linter for now to unblock. Nolintlint is reporting false positives.
relates to:  https://github.com/golangci/golangci-lint/issues/3228
## Test plan
N/A
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
