### PR TITLE
batches: temporarily hide webhook alert banner

### DIFF
--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -32,7 +32,6 @@ import { ChangesetsArchivedNotice } from './ChangesetsArchivedNotice'
 import { ClosedNotice } from './ClosedNotice'
 import { SupersedingBatchSpecAlert } from './SupersedingBatchSpecAlert'
 import { UnpublishedNotice } from './UnpublishedNotice'
-import { WebhookAlert } from './WebhookAlert'
 
 export interface BatchChangeDetailsPageProps extends BatchChangeDetailsProps, SettingsCascadeProps<Settings> {
     /** The namespace ID. */
@@ -169,12 +168,14 @@ export const BatchChangeDetailsPage: React.FunctionComponent<
                 />
             )}
             <ChangesetsArchivedNotice history={history} location={location} />
-            {batchChange.currentSpec && (
+            {/* Temporarily disabled due to bug with discovery. */}
+            {/* See https://github.com/sourcegraph/sourcegraph/issues/45919 */}
+            {/* {batchChange.currentSpec && (
                 <WebhookAlert
                     batchChangeID={batchChange.id}
                     codeHostsWithoutWebhooks={batchChange.currentSpec.codeHostsWithoutWebhooks}
                 />
-            )}
+            )} */}
             <BatchChangeStatsCard batchChange={batchChange} className="mb-3" />
             <Description description={batchChange.description} />
             <BatchChangeDetailsTabs batchChange={batchChange} refetchBatchChange={refetch} {...props} />


### PR DESCRIPTION
This disables the alert banner that shows on any batch change page if we detect the instance does not have webhooks configured for a code host one or more of the changesets are on. This is because there's currently [a bug](https://github.com/sourcegraph/sourcegraph/issues/45919) with discovering those webhooks that makes it look like they aren't configured, even if they are, which affects at least Bitbucket and GitHub (and might affect others too).

The banner should be restored when the underlying issue is fixed.

## Test plan

Tested banner no longer erroneously appears on batch change with changesets on GitHub.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-disable-webhook-banner.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
