### PR TITLE
web: remove redundant dep

### DIFF
--- a/client/wildcard/package.json
+++ b/client/wildcard/package.json
@@ -13,7 +13,6 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@sourcegraph/storybook": "workspace:*",
     "@sourcegraph/testing": "workspace:*"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1035,12 +1035,10 @@ importers:
   client/wildcard:
     specifiers:
       '@sourcegraph/common': workspace:*
-      '@sourcegraph/storybook': workspace:*
       '@sourcegraph/testing': workspace:*
     dependencies:
       '@sourcegraph/common': link:../common
     devDependencies:
-      '@sourcegraph/storybook': link:../storybook
       '@sourcegraph/testing': link:../testing
 
   dev/release:


### PR DESCRIPTION
## Context

Remove redundant workspace dependency.

## Test plan

1. `cd client/wildcard && pnpm storybook`

## App preview:

- [Web](https://sg-web-vb-remove-redundant-dep.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
