### PR TITLE
sg: rename `ci --view` into `ci --web`

### DIFF
--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -267,14 +267,13 @@ sg ci build --help
 		Usage:   "Get the status of the CI run associated with the currently checked out branch",
 		Flags: append(ciTargetFlags,
 			&cli.BoolFlag{
-				Name:    "wait",
-				Aliases: []string{"w"},
-				Usage:   "Wait by blocking until the build is finished",
+				Name:  "wait",
+				Usage: "Wait by blocking until the build is finished",
 			},
 			&cli.BoolFlag{
-				Name:    "view",
-				Aliases: []string{"v"},
-				Usage:   "Open build page in browser",
+				Name:    "web",
+				Aliases: []string{"view", "w"},
+				Usage:   "Open build page in web browser (--view is DEPRECATED and will be removed in the future)",
 			}),
 		Action: func(cmd *cli.Context) error {
 			client, err := bk.NewClient(cmd.Context, std.Out)

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -220,8 +220,8 @@ Flags:
 * `--commit, -c="<value>"`: Override branch detection with the latest build for `commit`
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--pipeline, -p="<value>"`: Select a custom Buildkite `pipeline` in the Sourcegraph org (default: sourcegraph)
-* `--view, -v`: Open build page in browser
-* `--wait, -w`: Wait by blocking until the build is finished
+* `--wait`: Wait by blocking until the build is finished
+* `--web, --view, -w`: Open build page in web browser (--view is DEPRECATED and will be removed in the future)
 
 ### sg ci build
 


### PR DESCRIPTION
This makes it more meaningful and on par with GitHub cli, from which it's modeled after.

Test Plan: tested locally

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
