### PR TITLE
ci: do not cache golangci-lint cache unless on main

### DIFF
--- a/enterprise/dev/ci/internal/buildkite/cache.go
+++ b/enterprise/dev/ci/internal/buildkite/cache.go
@@ -16,6 +16,7 @@ type CacheConfigPayload struct {
 	} `json:"tarball,omitempty"`
 	Paths []string             `json:"paths"`
 	S3    CacheConfigS3Payload `json:"s3"`
+	PR    string               `json:"pr,omitempty"`
 }
 
 type CacheConfigS3Payload struct {
@@ -28,14 +29,19 @@ type CacheConfigS3Payload struct {
 }
 
 type CacheOptions struct {
-	ID          string
-	Key         string
-	RestoreKeys []string
-	Paths       []string
-	Compress    bool
+	ID                string
+	Key               string
+	RestoreKeys       []string
+	Paths             []string
+	Compress          bool
+	IgnorePullRequest bool
 }
 
 func Cache(opts *CacheOptions) StepOpt {
+	var cachePR string
+	if opts.IgnorePullRequest {
+		cachePR = "off"
+	}
 	return flattenStepOpts(
 		// Overrides the aws command configuration to use the buildkite cache
 		// configuration instead.
@@ -48,6 +54,7 @@ func Cache(opts *CacheOptions) StepOpt {
 			Paths:       opts.Paths,
 			Compress:    opts.Compress,
 			Backend:     "s3",
+			PR:          cachePR,
 			S3: CacheConfigS3Payload{
 				Bucket:   "sourcegraph_buildkite_cache",
 				Profile:  "buildkite",

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -134,11 +134,12 @@ func addSgLints(targets []string) func(pipeline *bk.Pipeline) {
 			withPnpmCache(),
 			bk.Env("GOLANGCI_LINT_CACHE", lintCachePath),
 			buildkite.Cache(&bk.CacheOptions{
-				ID:          "golangci-lint",
-				Key:         "golangci-lint-{{ git.branch }}",
-				RestoreKeys: []string{"golangci-lint-{{ git.branch }}", "golangci-lint-main"},
-				Paths:       []string{".golangci-lint-cache"},
-				Compress:    true,
+				ID:                "golangci-lint",
+				Key:               "golangci-lint-{{ git.branch }}",
+				RestoreKeys:       []string{"golangci-lint-main"}, // We only restore the main branch cache.
+				Paths:             []string{".golangci-lint-cache"},
+				Compress:          true,
+				IgnorePullRequest: true,
 			}),
 			bk.AnnotatedCmd(cmd, bk.AnnotatedCmdOpts{
 				Annotations: &bk.AnnotationOpts{


### PR DESCRIPTION
The golangci-lint cache can yield strange results sometimes, this PR fixes it by only caching what's on the `main` branch and using that as a starting point in PR builds. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- checked the build plan locally. 