### PR TITLE
ci: increase trivy timeout deadline

### DIFF
--- a/dev/ci/trivy/trivy-scan-high-critical.sh
+++ b/dev/ci/trivy/trivy-scan-high-critical.sh
@@ -42,6 +42,11 @@ trivy_scan() {
     "--output"
     "${outputFile}"
 
+    # workaround for scans failing due to exceeding timeout deadline
+    # (e.g. https://buildkite.com/sourcegraph/sourcegraph/builds/192926#0185a568-ee3e-494a-abbf-7b8f9c3f226f/118-173)
+    "--timeout"
+    "15m"
+
     # scan the docker image named "target"
     "${target}"
   )


### PR DESCRIPTION
Trivy is timing out on vulnerability scans ([example](https://buildkite.com/sourcegraph/sourcegraph/builds/192926#0185a568-ee3e-494a-abbf-7b8f9c3f226f/118-173)). This PR increases the deadline to 15 minutes in order to unblock main.

## Test plan
Trivy scans are green again

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
