### PR TITLE
web: ensure that repo count is not showing 0 before external service is loaded.

### DIFF
--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -242,7 +242,7 @@ export const ExternalServicePage: FC<React.PropsWithChildren<Props>> = props => 
                         <ExternalServiceInformation
                             displayName={externalService.displayName}
                             codeHostID={externalService.id}
-                            reposNumber={numberOfRepos}
+                            reposNumber={numberOfRepos === 0 ? externalService.repoCount : numberOfRepos}
                             syncInProgress={syncInProgress}
                             {...externalServiceCategory}
                         />


### PR DESCRIPTION
Test plan:
Local sg run and manual test.

### Before

https://user-images.githubusercontent.com/94846361/212057522-98c6b711-da58-4387-8f8b-748af4c75f2e.mp4

### After

https://user-images.githubusercontent.com/94846361/212057543-3de8f29c-63f2-4228-a5e6-167baa89b9e9.mp4

## App preview:

- [Web](https://sg-web-ao-ui-code-host-repo-count.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
