### PR TITLE
go.mod: bump zoekt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed issue where emails that have never been verified before would be unable to receive resent verification emails. [#46185](https://github.com/sourcegraph/sourcegraph/pull/46185)
 - Batch Changes: Fixed resolution of the `currentSpec` field for draft batch changes on the GraphQL API. [#46237](https://github.com/sourcegraph/sourcegraph/pull/46237)
 - Resolved issue preventing LSIF uploads larger than 2GiB (gzipped) from uploading successfully. [#46209](https://github.com/sourcegraph/sourcegraph/pull/46209)
+- Local vars in Typescript are now detected as symbols which will positively impact ranking of search results. [#10](https://github.com/sourcegraph/go-ctags/pull/10)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed issue where emails that have never been verified before would be unable to receive resent verification emails. [#46185](https://github.com/sourcegraph/sourcegraph/pull/46185)
 - Batch Changes: Fixed resolution of the `currentSpec` field for draft batch changes on the GraphQL API. [#46237](https://github.com/sourcegraph/sourcegraph/pull/46237)
 - Resolved issue preventing LSIF uploads larger than 2GiB (gzipped) from uploading successfully. [#46209](https://github.com/sourcegraph/sourcegraph/pull/46209)
-- Local vars in Typescript are now detected as symbols which will positively impact ranking of search results. [#10](https://github.com/sourcegraph/go-ctags/pull/10)
+- Local vars in Typescript are now detected as symbols which will positively impact ranking of search results. [go-ctags#10](https://github.com/sourcegraph/go-ctags/pull/10)
 
 ### Removed
 

--- a/go.mod
+++ b/go.mod
@@ -127,7 +127,7 @@ require (
 	github.com/slack-go/slack v0.10.1
 	github.com/smacker/go-tree-sitter v0.0.0-20220209044044-0d3022e933c3
 	github.com/snabb/sitemap v1.0.0
-	github.com/sourcegraph/go-ctags v0.0.0-20220611154803-db463692f037
+	github.com/sourcegraph/go-ctags v0.0.0-20230111110657-c27675da7f71
 	github.com/sourcegraph/go-diff v0.6.2-0.20221123165719-f8cd299c40f3
 	github.com/sourcegraph/go-jsonschema v0.0.0-20221230021921-34aaf28fc4ac
 	github.com/sourcegraph/go-langserver v2.0.1-0.20181108233942-4a51fa2e1238+incompatible
@@ -232,7 +232,7 @@ require (
 )
 
 require (
-	github.com/sourcegraph/zoekt v0.0.0-20230111101438-d541ae2d078d
+	github.com/sourcegraph/zoekt v0.0.0-20230112115613-e0cf62d238b9
 	github.com/stretchr/objx v0.5.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2074,8 +2074,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d h1:yKm7XZV6j9
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/conc v0.1.0 h1:9GeYVmWWa1jeOq3zGq17m10d9pjYZpiGTj/N4hQFl58=
 github.com/sourcegraph/conc v0.1.0/go.mod h1:sEXGtKMpRbfGhShfObhgMyxDpdu/5ABGrzSGYaigx5A=
-github.com/sourcegraph/go-ctags v0.0.0-20220611154803-db463692f037 h1:gk2cs5tfGFtpZfaK5sKnn3Y4iyzrpCfdpncZhTKLz5E=
-github.com/sourcegraph/go-ctags v0.0.0-20220611154803-db463692f037/go.mod h1:ZYjpRXoJrRlxjU9ZfpaUKJkk62AjhJPffN3rlw2aqxM=
+github.com/sourcegraph/go-ctags v0.0.0-20230111110657-c27675da7f71 h1:tsWE3F3StWvnwLnC4JWb0zX0UHY9GULQtu/aoQvLJvI=
+github.com/sourcegraph/go-ctags v0.0.0-20230111110657-c27675da7f71/go.mod h1:ZYjpRXoJrRlxjU9ZfpaUKJkk62AjhJPffN3rlw2aqxM=
 github.com/sourcegraph/go-diff v0.5.1/go.mod h1:j2dHj3m8aZgQO8lMTcTnBcXkRRRqi34cd2MNlA9u1mE=
 github.com/sourcegraph/go-diff v0.5.3/go.mod h1:v9JDtjCE4HHHCZGId75rg8gkKKa98RVjBcBGsVmMmak=
 github.com/sourcegraph/go-diff v0.6.2-0.20221123165719-f8cd299c40f3 h1:11miag7hlORpW7ici5mL7T9PyiEsmVmf+8PFOvJ/ZrA=
@@ -2112,8 +2112,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e h1:qpG
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20230111101438-d541ae2d078d h1:+mGDWQedGYriTQaXNXuqZW0Whk9yMgnasdqN9T9slps=
-github.com/sourcegraph/zoekt v0.0.0-20230111101438-d541ae2d078d/go.mod h1:MoGvSaF4Te3ciCtm93lqPmuLNvSKew4krlX/K/0POfQ=
+github.com/sourcegraph/zoekt v0.0.0-20230112115613-e0cf62d238b9 h1:/5j+ftuIYINCYnGLlC8TKk/EYNaijSPow5UVrA4AvpM=
+github.com/sourcegraph/zoekt v0.0.0-20230112115613-e0cf62d238b9/go.mod h1:EgK9KLlvkj/fXQYqnhlh8JuMDQxmlyhRSLchbbH/BJo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
Note: PR contains udpate to CHANGELOG

e0cf62d go.mod: go get github.com/sourcegraph/go-ctags 
d541ae2 shards: add test for no shards loading and crashes 
38d5f90 webserver: shutdown via close if using RPC 
5bbffb3 indexserver: fix hyperlinks on root page
6d5ed59 default to eager runeDocSection

## Test plan
Zoekt CI


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
