### PR TITLE
internal/database: Implement List and Count for site config

### DIFF
--- a/internal/database/conf.go
+++ b/internal/database/conf.go
@@ -136,6 +136,19 @@ func (s *confStore) SiteGetLatest(ctx context.Context) (_ *SiteConfig, err error
 	return tx.getLatest(ctx)
 }
 
+const listSiteConfigsFmtStr = `
+SELECT
+	id,
+	author_user_id,
+	contents,
+	created_at,
+	updated_at
+FROM critical_and_site_config
+WHERE type = 'site'
+%s
+%s
+`
+
 var scanSiteConfigs = basestore.NewSliceScanner(scanSiteConfig)
 
 func scanSiteConfig(s dbutil.Scanner) (*SiteConfig, error) {
@@ -152,19 +165,6 @@ func scanSiteConfig(s dbutil.Scanner) (*SiteConfig, error) {
 	}
 	return &c, nil
 }
-
-const listSiteConfigsFmtStr = `
-SELECT
-	id,
-	author_user_id,
-	contents,
-	created_at,
-	updated_at
-FROM critical_and_site_config
-WHERE type = 'site'
-%s
-%s
-`
 
 func (s *confStore) ListSiteConfigs(ctx context.Context, opt SiteConfigListOptions) ([]*SiteConfig, error) {
 	// Ascending order by default.

--- a/internal/database/conf.go
+++ b/internal/database/conf.go
@@ -67,21 +67,13 @@ type confStore struct {
 // SiteConfig contains the contents of a site config along with associated me
 // tadata.
 type SiteConfig struct {
-	ID           int32 // the unique ID of this config
-	AuthorUserID int32 // the user id of the author that updated this config
-	Type         string
+	ID           int32  // the unique ID of this config
+	AuthorUserID int32  // the user id of the author that updated this config
 	Contents     string // the raw JSON content (with comments and trailing commas allowed)
 
 	CreatedAt time.Time // the date when this config was created
 	UpdatedAt time.Time // the date when this config was updated
 }
-
-type SiteConfigType string
-
-var (
-	SiteConfigTypeCritical SiteConfigType = "critical"
-	SiteConfigTypeSite     SiteConfigType = "site"
-)
 
 type SiteConfigListOptions struct {
 	*LimitOffset

--- a/internal/database/conf.go
+++ b/internal/database/conf.go
@@ -146,7 +146,6 @@ func (s *confStore) ListSiteConfig(ctx context.Context, opt SiteConfigListOption
 		SELECT
 			 id,
 			 author_user_id,
-			 type,
 			 contents,
 			 created_at,
 			 updated_at
@@ -170,7 +169,6 @@ func (s *confStore) ListSiteConfig(ctx context.Context, opt SiteConfigListOption
 		err := rows.Scan(
 			&c.ID,
 			&dbutil.NullInt32{N: &c.AuthorUserID},
-			&c.Type,
 			&c.Contents,
 			&c.CreatedAt,
 			&c.UpdatedAt,

--- a/internal/database/conf.go
+++ b/internal/database/conf.go
@@ -64,8 +64,7 @@ type confStore struct {
 	*basestore.Store
 }
 
-// SiteConfig contains the contents of a site config along with associated me
-// tadata.
+// SiteConfig contains the contents of a site config along with associated metadata.
 type SiteConfig struct {
 	ID           int32  // the unique ID of this config
 	AuthorUserID int32  // the user id of the author that updated this config

--- a/internal/database/conf_test.go
+++ b/internal/database/conf_test.go
@@ -238,21 +238,25 @@ func TestSiteCreateIfUpToDate(t *testing.T) {
 func createDummySiteConfigs(t *testing.T, ctx context.Context, s ConfStore) {
 	const config = `{"disableAutoGitUpdates": true, "auth.Providers": []}`
 
-	if _, err := s.SiteCreateIfUpToDate(ctx, nil, 0, config, false); err != nil {
+	siteConfig, err := s.SiteCreateIfUpToDate(ctx, nil, 0, config, false)
+	if err != nil {
 		t.Fatal(err)
 	}
 
 	// The first call to SiteCreatedIfUpToDate will always create a default entry if their are no
 	// rows in the table yet and then eventually create another entry.
-	lastID := int32(2)
+	//
+	// lastID should be 2 here.
+	lastID := siteConfig.ID
 
 	// Create two more entries.
 	for lastID < 4 {
-		if _, err := s.SiteCreateIfUpToDate(ctx, &lastID, 1, config, false); err != nil {
+		siteConfig, err := s.SiteCreateIfUpToDate(ctx, &lastID, 1, config, false)
+		if err != nil {
 			t.Fatal(err)
 		}
 
-		lastID += 1
+		lastID = siteConfig.ID
 	}
 
 	// By this point we have 4 entries instead of 3.

--- a/internal/database/conf_test.go
+++ b/internal/database/conf_test.go
@@ -234,3 +234,159 @@ func TestSiteCreateIfUpToDate(t *testing.T) {
 		})
 	}
 }
+
+func seedDB(t *testing.T, ctx context.Context, s ConfStore) {
+	if _, err := s.SiteCreateIfUpToDate(ctx, nil, 0, `{"disableAutoGitUpdates": true, "auth.Providers": []}`, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// The first call to SiteCreatedIfUpToDate will always create a default entry if their are no
+	// rows in the table yet and then eventually create another entry.
+	lastID := int32(2)
+
+	if _, err := s.SiteCreateIfUpToDate(ctx, &lastID, 1, `{"disableAutoGitUpdates": false, "auth.Providers": []}`, false); err != nil {
+		t.Fatal(err)
+	}
+
+	lastID = int32(3)
+
+	if _, err := s.SiteCreateIfUpToDate(ctx, &lastID, 1, `{"disableAutoGitUpdates": false, "auth.Providers": []}`, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// By this point we have 4 entries instead of 3.
+}
+
+func TestGetSiteConfigCount(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := context.Background()
+
+	s := db.Conf()
+	seedDB(t, ctx, s)
+
+	count, err := s.GetSiteConfigCount(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if count != 4 {
+		t.Fatalf("Expected 4 site config entries, but got %d", count)
+	}
+}
+
+func TestListSiteConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := context.Background()
+
+	s := db.Conf()
+	seedDB(t, ctx, s)
+
+	testCases := []struct {
+		name        string
+		listOptions SiteConfigListOptions
+		expectedIDs []int32
+	}{
+		{
+			name:        "empty list options",
+			listOptions: SiteConfigListOptions{},
+			expectedIDs: []int32{1, 2, 3, 4},
+		},
+		{
+			name: "order by asc",
+			listOptions: SiteConfigListOptions{
+				OrderByDirection: AscendingOrderByDirection,
+			},
+			expectedIDs: []int32{1, 2, 3, 4},
+		},
+		{
+			name: "order by desc",
+			listOptions: SiteConfigListOptions{
+				OrderByDirection: DescendingOrderByDirection,
+			},
+			expectedIDs: []int32{4, 3, 2, 1},
+		},
+		{
+			name: "limit",
+			listOptions: SiteConfigListOptions{
+				LimitOffset: &LimitOffset{
+					Limit: 3,
+				},
+			},
+			expectedIDs: []int32{1, 2, 3},
+		},
+		{
+			name: "offset",
+			listOptions: SiteConfigListOptions{
+				LimitOffset: &LimitOffset{
+					Offset: 1,
+				},
+			},
+			// NOTE: Current implementation of LimitOffset.SQL() will use the default Go value if
+			// Limit is not set but Offset is. Which means it adds a LIMIT 0 clause to the query. We
+			// should revisit that choice in a separate PR and when we do, this test should start
+			// failing.
+			expectedIDs: []int32{},
+		},
+		{
+			name: "limit and offset",
+			listOptions: SiteConfigListOptions{
+				LimitOffset: &LimitOffset{
+					Limit:  5,
+					Offset: 1,
+				},
+			},
+			expectedIDs: []int32{2, 3, 4},
+		},
+		{
+			name: "order by asc limit and offset",
+			listOptions: SiteConfigListOptions{
+				OrderByDirection: AscendingOrderByDirection,
+				LimitOffset: &LimitOffset{
+					Limit:  5,
+					Offset: 1,
+				},
+			},
+			expectedIDs: []int32{2, 3, 4},
+		},
+		{
+			name: "order by desc limit and offset",
+			listOptions: SiteConfigListOptions{
+				OrderByDirection: DescendingOrderByDirection,
+				LimitOffset: &LimitOffset{
+					Limit:  5,
+					Offset: 1,
+				},
+			},
+			expectedIDs: []int32{3, 2, 1},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			siteConfigs, err := s.ListSiteConfig(ctx, tc.listOptions)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(siteConfigs) != len(tc.expectedIDs) {
+				t.Fatalf("Expected %d site config entries but got %d", len(tc.expectedIDs), len(siteConfigs))
+			}
+
+			for i, siteConfig := range siteConfigs {
+				if tc.expectedIDs[i] != siteConfig.ID {
+					t.Errorf("Expected ID %d, but got %d", tc.expectedIDs[i], siteConfig.ID)
+				}
+			}
+		})
+	}
+}

--- a/internal/database/conf_test.go
+++ b/internal/database/conf_test.go
@@ -243,7 +243,7 @@ func createDummySiteConfigs(t *testing.T, ctx context.Context, s ConfStore) {
 		t.Fatal(err)
 	}
 
-	// The first call to SiteCreatedIfUpToDate will always create a default entry if their are no
+	// The first call to SiteCreatedIfUpToDate will always create a default entry if there are no
 	// rows in the table yet and then eventually create another entry.
 	//
 	// lastID should be 2 here.

--- a/internal/database/helpers.go
+++ b/internal/database/helpers.go
@@ -10,6 +10,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+type OrderByDirection string
+
+var (
+	AscendingOrderByDirection  OrderByDirection = "ASC"
+	DescendingOrderByDirection OrderByDirection = "DESC"
+)
+
 // LimitOffset specifies SQL LIMIT and OFFSET counts. A pointer to it is typically embedded in other options
 // structs that need to perform SQL queries with LIMIT and OFFSET.
 type LimitOffset struct {

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -2990,9 +2990,15 @@ type MockConfStore struct {
 	// DoneFunc is an instance of a mock function object controlling the
 	// behavior of the method Done.
 	DoneFunc *ConfStoreDoneFunc
+	// GetSiteConfigCountFunc is an instance of a mock function object
+	// controlling the behavior of the method GetSiteConfigCount.
+	GetSiteConfigCountFunc *ConfStoreGetSiteConfigCountFunc
 	// HandleFunc is an instance of a mock function object controlling the
 	// behavior of the method Handle.
 	HandleFunc *ConfStoreHandleFunc
+	// ListSiteConfigsFunc is an instance of a mock function object
+	// controlling the behavior of the method ListSiteConfigs.
+	ListSiteConfigsFunc *ConfStoreListSiteConfigsFunc
 	// SiteCreateIfUpToDateFunc is an instance of a mock function object
 	// controlling the behavior of the method SiteCreateIfUpToDate.
 	SiteCreateIfUpToDateFunc *ConfStoreSiteCreateIfUpToDateFunc
@@ -3013,8 +3019,18 @@ func NewMockConfStore() *MockConfStore {
 				return
 			},
 		},
+		GetSiteConfigCountFunc: &ConfStoreGetSiteConfigCountFunc{
+			defaultHook: func(context.Context) (r0 int, r1 error) {
+				return
+			},
+		},
 		HandleFunc: &ConfStoreHandleFunc{
 			defaultHook: func() (r0 basestore.TransactableHandle) {
+				return
+			},
+		},
+		ListSiteConfigsFunc: &ConfStoreListSiteConfigsFunc{
+			defaultHook: func(context.Context, SiteConfigListOptions) (r0 []*SiteConfig, r1 error) {
 				return
 			},
 		},
@@ -3045,9 +3061,19 @@ func NewStrictMockConfStore() *MockConfStore {
 				panic("unexpected invocation of MockConfStore.Done")
 			},
 		},
+		GetSiteConfigCountFunc: &ConfStoreGetSiteConfigCountFunc{
+			defaultHook: func(context.Context) (int, error) {
+				panic("unexpected invocation of MockConfStore.GetSiteConfigCount")
+			},
+		},
 		HandleFunc: &ConfStoreHandleFunc{
 			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockConfStore.Handle")
+			},
+		},
+		ListSiteConfigsFunc: &ConfStoreListSiteConfigsFunc{
+			defaultHook: func(context.Context, SiteConfigListOptions) ([]*SiteConfig, error) {
+				panic("unexpected invocation of MockConfStore.ListSiteConfigs")
 			},
 		},
 		SiteCreateIfUpToDateFunc: &ConfStoreSiteCreateIfUpToDateFunc{
@@ -3075,8 +3101,14 @@ func NewMockConfStoreFrom(i ConfStore) *MockConfStore {
 		DoneFunc: &ConfStoreDoneFunc{
 			defaultHook: i.Done,
 		},
+		GetSiteConfigCountFunc: &ConfStoreGetSiteConfigCountFunc{
+			defaultHook: i.GetSiteConfigCount,
+		},
 		HandleFunc: &ConfStoreHandleFunc{
 			defaultHook: i.Handle,
+		},
+		ListSiteConfigsFunc: &ConfStoreListSiteConfigsFunc{
+			defaultHook: i.ListSiteConfigs,
 		},
 		SiteCreateIfUpToDateFunc: &ConfStoreSiteCreateIfUpToDateFunc{
 			defaultHook: i.SiteCreateIfUpToDate,
@@ -3191,6 +3223,112 @@ func (c ConfStoreDoneFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
+// ConfStoreGetSiteConfigCountFunc describes the behavior when the
+// GetSiteConfigCount method of the parent MockConfStore instance is
+// invoked.
+type ConfStoreGetSiteConfigCountFunc struct {
+	defaultHook func(context.Context) (int, error)
+	hooks       []func(context.Context) (int, error)
+	history     []ConfStoreGetSiteConfigCountFuncCall
+	mutex       sync.Mutex
+}
+
+// GetSiteConfigCount delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockConfStore) GetSiteConfigCount(v0 context.Context) (int, error) {
+	r0, r1 := m.GetSiteConfigCountFunc.nextHook()(v0)
+	m.GetSiteConfigCountFunc.appendCall(ConfStoreGetSiteConfigCountFuncCall{v0, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the GetSiteConfigCount
+// method of the parent MockConfStore instance is invoked and the hook queue
+// is empty.
+func (f *ConfStoreGetSiteConfigCountFunc) SetDefaultHook(hook func(context.Context) (int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetSiteConfigCount method of the parent MockConfStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *ConfStoreGetSiteConfigCountFunc) PushHook(hook func(context.Context) (int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ConfStoreGetSiteConfigCountFunc) SetDefaultReturn(r0 int, r1 error) {
+	f.SetDefaultHook(func(context.Context) (int, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ConfStoreGetSiteConfigCountFunc) PushReturn(r0 int, r1 error) {
+	f.PushHook(func(context.Context) (int, error) {
+		return r0, r1
+	})
+}
+
+func (f *ConfStoreGetSiteConfigCountFunc) nextHook() func(context.Context) (int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ConfStoreGetSiteConfigCountFunc) appendCall(r0 ConfStoreGetSiteConfigCountFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ConfStoreGetSiteConfigCountFuncCall objects
+// describing the invocations of this function.
+func (f *ConfStoreGetSiteConfigCountFunc) History() []ConfStoreGetSiteConfigCountFuncCall {
+	f.mutex.Lock()
+	history := make([]ConfStoreGetSiteConfigCountFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ConfStoreGetSiteConfigCountFuncCall is an object that describes an
+// invocation of method GetSiteConfigCount on an instance of MockConfStore.
+type ConfStoreGetSiteConfigCountFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ConfStoreGetSiteConfigCountFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ConfStoreGetSiteConfigCountFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
 // ConfStoreHandleFunc describes the behavior when the Handle method of the
 // parent MockConfStore instance is invoked.
 type ConfStoreHandleFunc struct {
@@ -3287,6 +3425,114 @@ func (c ConfStoreHandleFuncCall) Args() []interface{} {
 // invocation.
 func (c ConfStoreHandleFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
+}
+
+// ConfStoreListSiteConfigsFunc describes the behavior when the
+// ListSiteConfigs method of the parent MockConfStore instance is invoked.
+type ConfStoreListSiteConfigsFunc struct {
+	defaultHook func(context.Context, SiteConfigListOptions) ([]*SiteConfig, error)
+	hooks       []func(context.Context, SiteConfigListOptions) ([]*SiteConfig, error)
+	history     []ConfStoreListSiteConfigsFuncCall
+	mutex       sync.Mutex
+}
+
+// ListSiteConfigs delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockConfStore) ListSiteConfigs(v0 context.Context, v1 SiteConfigListOptions) ([]*SiteConfig, error) {
+	r0, r1 := m.ListSiteConfigsFunc.nextHook()(v0, v1)
+	m.ListSiteConfigsFunc.appendCall(ConfStoreListSiteConfigsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the ListSiteConfigs
+// method of the parent MockConfStore instance is invoked and the hook queue
+// is empty.
+func (f *ConfStoreListSiteConfigsFunc) SetDefaultHook(hook func(context.Context, SiteConfigListOptions) ([]*SiteConfig, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ListSiteConfigs method of the parent MockConfStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *ConfStoreListSiteConfigsFunc) PushHook(hook func(context.Context, SiteConfigListOptions) ([]*SiteConfig, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *ConfStoreListSiteConfigsFunc) SetDefaultReturn(r0 []*SiteConfig, r1 error) {
+	f.SetDefaultHook(func(context.Context, SiteConfigListOptions) ([]*SiteConfig, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *ConfStoreListSiteConfigsFunc) PushReturn(r0 []*SiteConfig, r1 error) {
+	f.PushHook(func(context.Context, SiteConfigListOptions) ([]*SiteConfig, error) {
+		return r0, r1
+	})
+}
+
+func (f *ConfStoreListSiteConfigsFunc) nextHook() func(context.Context, SiteConfigListOptions) ([]*SiteConfig, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *ConfStoreListSiteConfigsFunc) appendCall(r0 ConfStoreListSiteConfigsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of ConfStoreListSiteConfigsFuncCall objects
+// describing the invocations of this function.
+func (f *ConfStoreListSiteConfigsFunc) History() []ConfStoreListSiteConfigsFuncCall {
+	f.mutex.Lock()
+	history := make([]ConfStoreListSiteConfigsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// ConfStoreListSiteConfigsFuncCall is an object that describes an
+// invocation of method ListSiteConfigs on an instance of MockConfStore.
+type ConfStoreListSiteConfigsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 SiteConfigListOptions
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []*SiteConfig
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c ConfStoreListSiteConfigsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c ConfStoreListSiteConfigsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // ConfStoreSiteCreateIfUpToDateFunc describes the behavior when the


### PR DESCRIPTION
Part of #46031 

This is needed to list the site configurations in the GQL API that is still under development.

Created a separate PR to expedite code review, feedback and progress.

## Test plan

1. Added tests
2. Builds should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
