### PR TITLE
internal/database: Do not LIMIT 0 for default behaviour

### DIFF
--- a/internal/database/helpers.go
+++ b/internal/database/helpers.go
@@ -22,6 +22,11 @@ func (o *LimitOffset) SQL() *sqlf.Query {
 	if o == nil {
 		return &sqlf.Query{}
 	}
+
+	if o.Limit == 0 {
+		return sqlf.Sprintf("OFFSET %d", o.Offset)
+	}
+
 	return sqlf.Sprintf("LIMIT %d OFFSET %d", o.Limit, o.Offset)
 }
 


### PR DESCRIPTION
A limit 0 does not really make sense from an API consumer's perspective so it is expected that if no limit is set, the resulting DB query should not LIMIT 0 by default. And if a limit is set in LimitOffset, then the current behaviour is unchanged.

Let's see what breaks with this in the CI. 🤞🏽



## Test plan

WIP

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
