### PR TITLE
web: remove `FilteredConnection` and `requestGraphQL` usages from ExternalServicesPage.

### DIFF
--- a/client/web/src/components/FilteredConnection/hooks/useShowMorePagination.ts
+++ b/client/web/src/components/FilteredConnection/hooks/useShowMorePagination.ts
@@ -108,7 +108,7 @@ export const useShowMorePagination = <TResult, TVariables, TData>({
              */
             after: (options?.useURL && searchParameters.get('after')) || after,
         }),
-        // We only need these controls for the inital request. We do not care about dependency updates.
+        // We only need these controls for the initial request. We do not care about dependency updates.
         // eslint-disable-next-line react-hooks/exhaustive-deps
         []
     )
@@ -195,7 +195,7 @@ export const useShowMorePagination = <TResult, TVariables, TData>({
         })
     }, [connection?.nodes.length, refetch, variables])
 
-    // We use `refetchAll` to poll for all of the nodes currently loaded in the
+    // We use `refetchAll` to poll for all the nodes currently loaded in the
     // connection, vs. just providing a `pollInterval` to the underlying `useQuery`, which
     // would only poll for the first page of results.
     const { startExecution, stopExecution } = useInterval(refetchAll, options?.pollInterval || -1)

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useState } from 'react'
 
 import { mdiCircle, mdiCog, mdiDelete } from '@mdi/js'
 import classNames from 'classnames'
-import * as H from 'history'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { asError, isErrorLike, pluralize } from '@sourcegraph/common'
@@ -18,19 +17,13 @@ import styles from './ExternalServiceNode.module.scss'
 
 export interface ExternalServiceNodeProps {
     node: ListExternalServiceFields
-    onDidUpdate: () => void
-    history: H.History
     routingPrefix: string
-    afterDeleteRoute: string
     editingDisabled: boolean
 }
 
 export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildren<ExternalServiceNodeProps>> = ({
     node,
-    onDidUpdate,
-    history,
     routingPrefix,
-    afterDeleteRoute,
     editingDisabled,
 }) => {
     const [isDeleting, setIsDeleting] = useState<boolean | Error>(false)
@@ -42,14 +35,14 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
         try {
             await deleteExternalService(node.id)
             setIsDeleting(false)
-            onDidUpdate()
             // eslint-disable-next-line rxjs/no-ignored-subscription
             refreshSiteFlags().subscribe()
-            history.push(afterDeleteRoute)
         } catch (error) {
             setIsDeleting(asError(error))
+        } finally {
+            window.location.reload()
         }
-    }, [afterDeleteRoute, history, node.displayName, node.id, onDidUpdate])
+    }, [node])
 
     const IconComponent = defaultExternalServices[node.kind].icon
 
@@ -60,7 +53,7 @@ export const ExternalServiceNode: React.FunctionComponent<React.PropsWithChildre
         >
             <div className="d-flex align-items-center justify-content-between">
                 <div className="align-self-start">
-                    {EXTERNAL_SERVICE_SYNC_RUNNING_STATUSES.has(node.syncJobs.nodes[0]?.state) ? (
+                    {EXTERNAL_SERVICE_SYNC_RUNNING_STATUSES.has(node.syncJobs?.nodes[0]?.state) ? (
                         <Tooltip content="Sync is running">
                             <div aria-label="Sync is running">
                                 <LoadingSpinner className="mr-2" inline={true} />

--- a/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
@@ -1,13 +1,15 @@
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 import { subMinutes } from 'date-fns'
-import { of } from 'rxjs'
+import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
+import { getDocumentNode } from '@sourcegraph/http-client'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { ExternalServiceKind, ExternalServiceSyncJobState } from '../../graphql-operations'
 import { WebStory } from '../WebStory'
 
-import { queryExternalServices as _queryExternalServices } from './backend'
+import { EXTERNAL_SERVICES } from './backend'
 import { ExternalServicesPage } from './ExternalServicesPage'
 
 const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
@@ -19,106 +21,124 @@ const config: Meta = {
 
 export default config
 
-const queryExternalServices: typeof _queryExternalServices = () =>
-    of({
-        totalCount: 2,
-        pageInfo: {
-            endCursor: null,
-            hasNextPage: false,
-        },
-        nodes: [
-            {
-                id: 'service1',
-                kind: ExternalServiceKind.GITHUB,
-                displayName: 'GitHub #1',
-                config: '{"githubconfig":true}',
-                warning: null,
-                lastSyncError: null,
-                repoCount: 0,
-                lastSyncAt: null,
-                nextSyncAt: null,
-                updatedAt: '2021-03-15T19:39:11Z',
-                createdAt: '2021-03-15T19:39:11Z',
-                namespace: null,
-                webhookURL: null,
-                hasConnectionCheck: true,
-                syncJobs: {
-                    totalCount: 1,
-                    pageInfo: { endCursor: null, hasNextPage: false },
-                    nodes: [
-                        {
-                            __typename: 'ExternalServiceSyncJob',
-                            failureMessage: null,
-                            startedAt: subMinutes(new Date(), 25).toISOString(),
-                            finishedAt: null,
-                            id: 'SYNCJOB1',
-                            state: ExternalServiceSyncJobState.PROCESSING,
-                            reposSynced: 5,
-                            repoSyncErrors: 0,
-                            reposAdded: 5,
-                            reposDeleted: 0,
-                            reposModified: 0,
-                            reposUnmodified: 0,
-                        },
-                    ],
-                },
-            },
-            {
-                id: 'service2',
-                kind: ExternalServiceKind.GITHUB,
-                displayName: 'GitHub #2',
-                config: '{"githubconfig":true}',
-                warning: null,
-                lastSyncError: null,
-                repoCount: 0,
-                lastSyncAt: null,
-                nextSyncAt: null,
-                updatedAt: '2021-03-15T19:39:11Z',
-                createdAt: '2021-03-15T19:39:11Z',
-                namespace: {
-                    id: 'someuser-id',
-                    namespaceName: 'johndoe',
-                    url: '/users/johndoe',
-                },
-                webhookURL: null,
-                hasConnectionCheck: false,
-                syncJobs: {
-                    totalCount: 1,
-                    pageInfo: { endCursor: null, hasNextPage: false },
-                    nodes: [
-                        {
-                            __typename: 'ExternalServiceSyncJob',
-                            failureMessage: null,
-                            startedAt: subMinutes(new Date(), 25).toISOString(),
-                            finishedAt: null,
-                            id: 'SYNCJOB1',
-                            state: ExternalServiceSyncJobState.COMPLETED,
-                            reposSynced: 5,
-                            repoSyncErrors: 0,
-                            reposAdded: 5,
-                            reposDeleted: 0,
-                            reposModified: 0,
-                            reposUnmodified: 0,
-                        },
-                    ],
-                },
-            },
-        ],
-    })
-
 export const ListOfExternalServices: Story = () => (
     <WebStory>
         {webProps => (
-            <ExternalServicesPage
-                {...webProps}
-                routingPrefix="/site-admin"
-                afterDeleteRoute="/site-admin/after"
-                telemetryService={NOOP_TELEMETRY_SERVICE}
-                authenticatedUser={{ id: '123' }}
-                queryExternalServices={queryExternalServices}
-                externalServicesFromFile={false}
-                allowEditExternalServicesWithFile={false}
-            />
+            <MockedTestProvider
+                link={
+                    new WildcardMockLink([
+                        {
+                            request: {
+                                query: getDocumentNode(EXTERNAL_SERVICES),
+                                variables: MATCH_ANY_PARAMETERS,
+                            },
+                            nMatches: Number.POSITIVE_INFINITY,
+                            result: {
+                                data: {
+                                    externalServices: {
+                                        totalCount: 2,
+                                        pageInfo: {
+                                            endCursor: null,
+                                            hasNextPage: false,
+                                        },
+                                        nodes: [
+                                            {
+                                                __typename: 'ExternalService',
+                                                id: 'service1',
+                                                kind: ExternalServiceKind.GITHUB,
+                                                displayName: 'GitHub #1',
+                                                config: '{"githubconfig":true}',
+                                                warning: null,
+                                                lastSyncError: null,
+                                                repoCount: 0,
+                                                lastSyncAt: null,
+                                                nextSyncAt: null,
+                                                updatedAt: '2021-03-15T19:39:11Z',
+                                                createdAt: '2021-03-15T19:39:11Z',
+                                                namespace: null,
+                                                webhookURL: null,
+                                                hasConnectionCheck: true,
+                                                syncJobs: {
+                                                    __typename: 'ExternalServiceSyncJobConnection',
+                                                    totalCount: 1,
+                                                    pageInfo: { endCursor: null, hasNextPage: false },
+                                                    nodes: [
+                                                        {
+                                                            __typename: 'ExternalServiceSyncJob',
+                                                            failureMessage: null,
+                                                            startedAt: subMinutes(new Date(), 25).toISOString(),
+                                                            finishedAt: null,
+                                                            id: 'SYNCJOB1',
+                                                            state: ExternalServiceSyncJobState.PROCESSING,
+                                                            reposSynced: 5,
+                                                            repoSyncErrors: 0,
+                                                            reposAdded: 5,
+                                                            reposDeleted: 0,
+                                                            reposModified: 0,
+                                                            reposUnmodified: 0,
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                            {
+                                                __typename: 'ExternalService',
+                                                id: 'service2',
+                                                kind: ExternalServiceKind.GITHUB,
+                                                displayName: 'GitHub #2',
+                                                config: '{"githubconfig":true}',
+                                                warning: null,
+                                                lastSyncError: null,
+                                                repoCount: 0,
+                                                lastSyncAt: null,
+                                                nextSyncAt: null,
+                                                updatedAt: '2021-03-15T19:39:11Z',
+                                                createdAt: '2021-03-15T19:39:11Z',
+                                                namespace: {
+                                                    id: 'someuser-id',
+                                                    namespaceName: 'johndoe',
+                                                    url: '/users/johndoe',
+                                                },
+                                                webhookURL: null,
+                                                hasConnectionCheck: false,
+                                                syncJobs: {
+                                                    __typename: 'ExternalServiceSyncJobConnection',
+                                                    totalCount: 1,
+                                                    pageInfo: { endCursor: null, hasNextPage: false },
+                                                    nodes: [
+                                                        {
+                                                            __typename: 'ExternalServiceSyncJob',
+                                                            failureMessage: null,
+                                                            startedAt: subMinutes(new Date(), 25).toISOString(),
+                                                            finishedAt: null,
+                                                            id: 'SYNCJOB2',
+                                                            state: ExternalServiceSyncJobState.COMPLETED,
+                                                            reposSynced: 5,
+                                                            repoSyncErrors: 0,
+                                                            reposAdded: 5,
+                                                            reposDeleted: 0,
+                                                            reposModified: 0,
+                                                            reposUnmodified: 0,
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                        },
+                    ])
+                }
+            >
+                <ExternalServicesPage
+                    {...webProps}
+                    routingPrefix="/site-admin"
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                    authenticatedUser={{ id: '123' }}
+                    externalServicesFromFile={false}
+                    allowEditExternalServicesWithFile={false}
+                />
+            </MockedTestProvider>
         )}
     </WebStory>
 )

--- a/client/web/src/components/externalServices/ExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.tsx
@@ -1,93 +1,64 @@
-import React, { useEffect, useMemo, useCallback, useState } from 'react'
+import React, { useEffect } from 'react'
 
 import { mdiPlus } from '@mdi/js'
-import * as H from 'history'
 import { Redirect } from 'react-router'
-import { Subject } from 'rxjs'
 
-import { isErrorLike, ErrorLike } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, ButtonLink, Icon, PageHeader, Container } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
-import { ListExternalServiceFields, Scalars, ExternalServicesResult } from '../../graphql-operations'
-import { FilteredConnection, FilteredConnectionQueryArguments } from '../FilteredConnection'
+import { Scalars } from '../../graphql-operations'
+import {
+    ConnectionContainer,
+    ConnectionError,
+    ConnectionList,
+    ConnectionLoading,
+    ConnectionSummary,
+    ShowMoreButton,
+    SummaryContainer,
+} from '../FilteredConnection/ui'
 import { PageTitle } from '../PageTitle'
 
-import { queryExternalServices as _queryExternalServices } from './backend'
+import { useExternalServicesConnection } from './backend'
 import { ExternalServiceEditingDisabledAlert } from './ExternalServiceEditingDisabledAlert'
 import { ExternalServiceEditingTemporaryAlert } from './ExternalServiceEditingTemporaryAlert'
-import { ExternalServiceNodeProps, ExternalServiceNode } from './ExternalServiceNode'
+import { ExternalServiceNode } from './ExternalServiceNode'
 
 interface Props extends TelemetryProps {
-    history: H.History
-    location: H.Location
     routingPrefix: string
-    afterDeleteRoute: string
     userID?: Scalars['ID']
     authenticatedUser: Pick<AuthenticatedUser, 'id'>
 
     externalServicesFromFile: boolean
     allowEditExternalServicesWithFile: boolean
-
-    /** For testing only. */
-    queryExternalServices?: typeof _queryExternalServices
 }
 
 /**
  * A page displaying the external services on this site.
  */
 export const ExternalServicesPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
-    afterDeleteRoute,
-    history,
-    location,
     routingPrefix,
     userID,
     telemetryService,
     authenticatedUser,
     externalServicesFromFile,
     allowEditExternalServicesWithFile,
-    queryExternalServices = _queryExternalServices,
 }) => {
-    const POLLING_INTERVAL = 15000
-    const updates = useMemo(() => new Subject<void>(), [])
-
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminExternalServices')
-        const interval = setInterval(() => {
-            updates.next()
-        }, POLLING_INTERVAL)
-        return () => clearInterval(interval)
-    }, [updates, telemetryService])
+    }, [telemetryService])
 
-    const onDidUpdateExternalServices = useCallback(() => updates.next(), [updates])
+    const { loading, hasNextPage, fetchMore, connection, error } = useExternalServicesConnection({
+        first: null,
+        after: null,
+    })
 
-    const queryConnection = useCallback(
-        (args: FilteredConnectionQueryArguments) =>
-            queryExternalServices({
-                first: args.first ?? null,
-                after: args.after ?? null,
-            }),
-        [queryExternalServices]
-    )
-
-    const [noExternalServices, setNoExternalServices] = useState<boolean>(false)
-    const onUpdate = useCallback<
-        (connection: ExternalServicesResult['externalServices'] | ErrorLike | undefined) => void
-    >(connection => {
-        if (connection && !isErrorLike(connection)) {
-            setNoExternalServices(connection.totalCount === 0)
-        }
-    }, [])
-
-    const editingDisabled = !!externalServicesFromFile && !allowEditExternalServicesWithFile
-
+    const editingDisabled = externalServicesFromFile && !allowEditExternalServicesWithFile
     const isManagingOtherUser = !!userID && userID !== authenticatedUser.id
 
-    if (!isManagingOtherUser && noExternalServices) {
-        return <Redirect to={`${routingPrefix}/external-services/new`} />
-    }
-    return (
+    return !isManagingOtherUser && !loading && (connection?.nodes?.length ?? 0) === 0 ? (
+        <Redirect to={`${routingPrefix}/external-services/new`} />
+    ) : (
         <div className="site-admin-external-services-page">
             <PageTitle title="Manage code hosts" />
             <PageHeader
@@ -116,33 +87,34 @@ export const ExternalServicesPage: React.FunctionComponent<React.PropsWithChildr
             {externalServicesFromFile && allowEditExternalServicesWithFile && <ExternalServiceEditingTemporaryAlert />}
 
             <Container className="mb-3">
-                <FilteredConnection<
-                    ListExternalServiceFields,
-                    Omit<ExternalServiceNodeProps, 'node'>,
-                    {},
-                    ExternalServicesResult['externalServices']
-                >
-                    className="mb-0"
-                    listClassName="list-group list-group-flush mb-0"
-                    noun="code host"
-                    pluralNoun="code hosts"
-                    withCenteredSummary={true}
-                    queryConnection={queryConnection}
-                    nodeComponent={ExternalServiceNode}
-                    nodeComponentProps={{
-                        onDidUpdate: onDidUpdateExternalServices,
-                        history,
-                        routingPrefix,
-                        afterDeleteRoute,
-                        editingDisabled,
-                    }}
-                    hideSearch={true}
-                    cursorPaging={true}
-                    updates={updates}
-                    history={history}
-                    location={location}
-                    onUpdate={onUpdate}
-                />
+                <ConnectionContainer>
+                    {error && <ConnectionError errors={[error.message]} />}
+                    {loading && !connection && <ConnectionLoading />}
+                    <ConnectionList as="ul" className="list-group" aria-label="CodeHosts">
+                        {connection?.nodes?.map(node => (
+                            <ExternalServiceNode
+                                key={node.id}
+                                node={node}
+                                routingPrefix={routingPrefix}
+                                editingDisabled={editingDisabled}
+                            />
+                        ))}
+                    </ConnectionList>
+                    {connection && (
+                        <SummaryContainer className="mt-2" centered={true}>
+                            <ConnectionSummary
+                                noSummaryIfAllNodesVisible={false}
+                                first={connection.totalCount ?? 0}
+                                centered={true}
+                                connection={connection}
+                                noun="code host"
+                                pluralNoun="code hosts"
+                                hasNextPage={hasNextPage}
+                            />
+                            {hasNextPage && <ShowMoreButton centered={true} onClick={fetchMore} />}
+                        </SummaryContainer>
+                    )}
+                </ConnectionContainer>
             </Container>
         </div>
     )

--- a/client/web/src/site-admin/SiteAdminExternalServicesArea.tsx
+++ b/client/web/src/site-admin/SiteAdminExternalServicesArea.tsx
@@ -73,7 +73,6 @@ export const SiteAdminExternalServicesArea: React.FunctionComponent<React.PropsW
                         {...outerProps}
                         {...props}
                         routingPrefix="/site-admin"
-                        afterDeleteRoute="/site-admin/repositories?repositoriesUpdated"
                         externalServicesFromFile={data?.site?.externalServicesFromFile}
                         allowEditExternalServicesWithFile={data?.site?.allowEditExternalServicesWithFile}
                     />

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
@@ -80,7 +80,7 @@ export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChild
                         ))}
                     </ConnectionList>
                     {connection && (
-                        <SummaryContainer className="mt-2">
+                        <SummaryContainer className="mt-2" centered={true}>
                             <ConnectionSummary
                                 noSummaryIfAllNodesVisible={false}
                                 first={connection.totalCount ?? 0}


### PR DESCRIPTION
This unblocked usage of `pollInterval` option which does polling without refreshing the whole page as it was prior to this commit.

Test plan:
Storybook updated, local sg run and manual tests.

### Quick demo
https://user-images.githubusercontent.com/94846361/212106063-6cd94100-e498-45c7-b09d-1f2d03c81b07.mp4

Closes https://github.com/sourcegraph/sourcegraph/issues/46201

## App preview:

- [Web](https://sg-web-ao-ui-ext-svc-page-refactoring.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

