### PR TITLE
codeintel: Ensure we represent every referenced symbol in a SCIP index

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/background/scip.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/scip.go
@@ -73,6 +73,12 @@ func correlateSCIP(
 				if pkg, ok := packageFromSymbol(symbol.Symbol); ok {
 					packageSet[pkg] = false
 				}
+
+				for _, relationship := range symbol.Relationships {
+					if pkg, ok := packageFromSymbol(relationship.Symbol); ok {
+						packageSet[pkg] = false
+					}
+				}
 			}
 
 			for _, occurrence := range document.Occurrences {
@@ -260,6 +266,9 @@ func canonicalizeDocument(document *scip.Document, externalSymbolsByName map[str
 	// Order the remaining fields deterministically
 	_ = types.CanonicalizeDocument(document)
 }
+
+//
+// TODO - also do for relationships
 
 // injectExternalSymbols adds symbol information objects from the external symbols into the document
 // if there is an occurrence that references the external symbol name and no local symbol information


### PR DESCRIPTION
The method that injects external symbols into documents didn't account for references to symbols from relationships of other symbols. This makes the implementation complete, although I don't know what kind of psychopath might write an indexer that produces that kind of output.

## Test plan

👀 