### PR TITLE
codeintel: Fix reference moniker translation

### DIFF
--- a/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator_test.go
+++ b/enterprise/internal/oobmigration/migrations/codeintel/scip_migrator_test.go
@@ -77,7 +77,7 @@ func TestSCIPMigrator(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error counting symbols: %s", err)
 	}
-	if expected := 3307; symbolsCount != expected {
+	if expected := 4221; symbolsCount != expected {
 		t.Fatalf("unexpected number of documents. want=%d have=%d", expected, symbolsCount)
 	}
 }

--- a/lib/codeintel/lsif/scip/document.go
+++ b/lib/codeintel/lsif/scip/document.go
@@ -232,11 +232,11 @@ func convertRange(
 		for _, targetRangeID := range targetRangeFetcher(r.DefinitionResultID) {
 			// Add reference to the defining range identifier
 			addOccurrence(constructSymbolName(uploadID, targetRangeID), role)
+		}
 
-			// Add reference to each moniker
-			for _, moniker := range monikers {
-				addOccurrence(moniker, role)
-			}
+		// Add reference to each moniker
+		for _, moniker := range monikers {
+			addOccurrence(moniker, role)
 		}
 	}
 

--- a/lib/codeintel/lsif/scip/index_test.go
+++ b/lib/codeintel/lsif/scip/index_test.go
@@ -46,11 +46,13 @@ func TestConvertLSIF(t *testing.T) {
 			{
 				RelativePath: "bar.go",
 				Occurrences: []*scip.Occurrence{
+					{Range: []int32{4, 5, 6, 7}, Symbol: "scheme A . pkg A v0.1.0 `ident A`."},
 					{Range: []int32{6, 7, 8, 9}, Symbol: "lsif . 42 . `7`."},
 					{Range: []int32{6, 7, 8, 9}, Symbol: "scheme B . pkg B v1.2.3 `ident B`."},
 				},
 				Symbols: []*scip.SymbolInformation{
 					{Symbol: "lsif . 42 . `7`.", Documentation: []string{"```go\ntext A\n```"}},
+					{Symbol: "scheme A . pkg A v0.1.0 `ident A`."},
 					{Symbol: "scheme B . pkg B v1.2.3 `ident B`.", Documentation: []string{"```go\ntext A\n```"}},
 				},
 			},


### PR DESCRIPTION
Emit a reference occurrence for each moniker - not for each moniker _for each definition_. This completely omits x-repo references 🤦 

## Test plan

Tested by hand.