### PR TITLE
codeintel: Fix too many definitions in LSIF translation

### DIFF
--- a/lib/codeintel/lsif/scip/document.go
+++ b/lib/codeintel/lsif/scip/document.go
@@ -221,11 +221,6 @@ func convertRange(
 		for _, moniker := range monikers {
 			addOccurrence(moniker, role)
 		}
-
-		// Add definition of each implements relationship
-		for _, moniker := range implementsMonikers {
-			addOccurrence(moniker, role)
-		}
 	} else {
 		role := scip.SymbolRole_UnspecifiedSymbolRole
 


### PR DESCRIPTION
Do not emit implementation definitions - we already have the correct relationship by the symbol information metadata.

## Test plan

Tested by hand.