### PR TITLE
prometheus: disable web.enable-lifecycle and web.enable-admin-api outside of dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Git blame view got a user-interface overhaul and now shows data in a more structured way with additional visual hints. [#44397](https://github.com/sourcegraph/sourcegraph/issues/44397)
 - User emails marked as unverified will no longer receive code monitors and account update emails - unverified emails can be verified from the user settings page to continue receiving these emails. [#46184](https://github.com/sourcegraph/sourcegraph/pull/46184)
 - Zoekt by default eagerly unmarshals the symbol index into memory. Previously we would unmarshal on every request for the purposes of symbol searches or ranking. This lead to pressure on the Go garbage collector. On sourcegraph.com we have noticed time spent in the garbage collector halved. In the unlikely event this leads to more OOMs in zoekt-webserver, you can disable by setting the environment variable `ZOEKT_ENABLE_LAZY_DOC_SECTIONS=t`. [zoekt#503](https://github.com/sourcegraph/zoekt/pull/503)
+- The `sourcegraph/prometheus` image no longer starts with `--web.enable-lifecycle --web.enable-admin-api` by default - these flags can be re-enabled by configuring `PROMETHEUS_ADDITIONAL_FLAGS` on the container. [#46393](https://github.com/sourcegraph/sourcegraph/pull/46393)
 
 ### Fixed
 

--- a/docker-images/prometheus/prometheus.sh
+++ b/docker-images/prometheus/prometheus.sh
@@ -10,4 +10,4 @@ fi
 STORAGE_PATH="${STORAGE_PATH:-"/prometheus"}"
 
 # shellcheck disable=SC2086
-exec /bin/prometheus --config.file=$CONFIG_FILE --storage.tsdb.path=$STORAGE_PATH --web.enable-admin-api $PROMETHEUS_ADDITIONAL_FLAGS --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles --web.enable-lifecycle "$@"
+exec /bin/prometheus --config.file=$CONFIG_FILE --storage.tsdb.path=$STORAGE_PATH $PROMETHEUS_ADDITIONAL_FLAGS --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles "$@"

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -718,6 +718,7 @@ commands:
         -e SRC_FRONTEND_INTERNAL="${SRC_FRONTEND_INTERNAL}" \
         -e DISABLE_SOURCEGRAPH_CONFIG="${DISABLE_SOURCEGRAPH_CONFIG:-""}" \
         -e DISABLE_ALERTMANAGER="${DISABLE_ALERTMANAGER:-""}" \
+        -e PROMETHEUS_ADDITIONAL_FLAGS="--web.enable-lifecycle --web.enable-admin-api" \
         ${IMAGE} >"${PROMETHEUS_LOG_FILE}" 2>&1
     install: |
       mkdir -p "${PROMETHEUS_DISK}"


### PR DESCRIPTION
Closes https://github.com/sourcegraph/security-issues/issues/329 - we only need the reload API in development, in deployments the Prometheus configuration should never change.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

In separate tabs:

```
sg run prometheus
sg run grafana
sg run monitoring-generator
```

In logs, look for Prometheus reload working:

```
[monitoring-...r] INFO generate.prometheus monitoring/generator.go:298 Reloaded Prometheus instance {"instance": "http://127.0.0.1:9090"}
```

Then run directly:

```
docker run -p 0.0.0.0:9090:9090 sourcegraph/prometheus:dev
```

Reload API no longer works:

```
$ sg run monitoring-generator
 generate: Unexpected status code 403 while reloading Prometheus rules
```

