### PR TITLE
insights: Update the burst rate for historical git work that creates search jobs

### DIFF
--- a/enterprise/internal/insights/background/limiter/historical_test.go
+++ b/enterprise/internal/insights/background/limiter/historical_test.go
@@ -3,8 +3,6 @@ package limiter_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background/limiter"
 )
 
@@ -16,13 +14,6 @@ func TestGetHistoricLimit(t *testing.T) {
 		if limiter1 != limiter2 {
 			t.Error("both limiters should be the same instance")
 		}
-	})
-
-	t.Run("all instances see changes", func(t *testing.T) {
-		limiter1 := limiter.HistoricalWorkRate()
-		limiter2 := limiter.HistoricalWorkRate()
-		limiter1.SetLimit(99)
-		assert.Equal(t, limiter1.Limit(), limiter2.Limit(), 99)
 	})
 
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2363,6 +2363,8 @@ type SiteConfiguration struct {
 	InsightsBackfillInterruptAfter int `json:"insights.backfill.interruptAfter,omitempty"`
 	// InsightsHistoricalWorkerRateLimit description: Maximum number of historical Code Insights data frames that may be analyzed per second.
 	InsightsHistoricalWorkerRateLimit *float64 `json:"insights.historical.worker.rateLimit,omitempty"`
+	// InsightsHistoricalWorkerRateLimitBurst description: The allowed burst rate for the Code Insights historical worker rate limiter.
+	InsightsHistoricalWorkerRateLimitBurst int `json:"insights.historical.worker.rateLimitBurst,omitempty"`
 	// InsightsMaximumSampleSize description: The maximum number of data points that will be available to view for a series on a code insight. Points beyond that will be stored in a separate table and available for data export.
 	InsightsMaximumSampleSize int `json:"insights.maximumSampleSize,omitempty"`
 	// InsightsQueryWorkerConcurrency description: Number of concurrent executions of a code insight query on a worker node
@@ -2534,6 +2536,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "insights.aggregations.proactiveResultLimit")
 	delete(m, "insights.backfill.interruptAfter")
 	delete(m, "insights.historical.worker.rateLimit")
+	delete(m, "insights.historical.worker.rateLimitBurst")
 	delete(m, "insights.maximumSampleSize")
 	delete(m, "insights.query.worker.concurrency")
 	delete(m, "insights.query.worker.rateLimit")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1393,9 +1393,16 @@
       "description": "Maximum number of historical Code Insights data frames that may be analyzed per second.",
       "type": "number",
       "group": "CodeInsights",
-      "default": 10,
+      "default": 20,
       "examples": [50.0, 0.5],
       "!go": { "pointer": true }
+    },
+    "insights.historical.worker.rateLimitBurst": {
+      "description": "The allowed burst rate for the Code Insights historical worker rate limiter.",
+      "type": "integer",
+      "group": "CodeInsights",
+      "default": 20,
+      "examples": [10, 20]
     },
     "insights.aggregations.bufferSize": {
       "description": "The size of the buffer for aggregations ran in-memory. A higher limit might strain memory for the frontend",


### PR DESCRIPTION
We previously updated the ability to change the burst rate for the query running but didn't make the same change to the historical rate limiter which is used to limit requests to gitserver to find the commit to run historical searches against.  This was causing a slow down for backfilling insights when there were few searches to run that executed very quickly.
## Test plan
Backfilled an insight
Updated rate limit burst verified that new rate was applied.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
