### PR TITLE
Docs: update docs for `src validate` command to add new `install` subcommand

### DIFF
--- a/doc/admin/validation.md
+++ b/doc/admin/validation.md
@@ -7,16 +7,16 @@
 Instance validation provides a quick way to check that a Sourcegraph instance functions properly after a fresh install
  or an update.
 
-The [`src` CLI](https://github.com/sourcegraph/src-cli) has an experimental command `validate` which drives the
+The [`src` CLI](https://github.com/sourcegraph/src-cli) has an experimental command `validate install` which drives the
  validation from a user-provided configuration file with a validation specification (in JSON or YAML format). If no validation specification file is provided it will execute the following: 
  
-* temporarily add an external service
-* wait for a repository to be cloned
-* perform a search on the cloned repo
-* perform a search on a non-indexed branch of the cloned repo
+* temporarily adds an external service
+* waits for a repository to be cloned
+* performs a search on the cloned repo
+* performs a search on a non-indexed branch of the cloned repo
 * creates basic code insight
-* remove the added external service
-* remove the added code insight
+* removes the added external service
+* removes the added code insight
 
 ### Validation specification
  

--- a/doc/admin/validation.md
+++ b/doc/admin/validation.md
@@ -139,10 +139,12 @@ With this configuration, the validation command executes the following steps:
  
 >NOTE: Every step is optional (if the corresponding top-level key is not present then the step is skipped).
 > 
+
 ### Passing in secrets
 
 Secrets are handled via environment variables. `src validate install` requires an environment variables to be set to authenticate to your code host.
->NOTE: currently only GitHub is supported as a code host.
+
+>NOTE: Currently only GitHub is supported as a code host.
 >
 
 `src validate install` requires an environment variable to be setup to authenticate against your code host.

--- a/doc/admin/validation.md
+++ b/doc/admin/validation.md
@@ -1,6 +1,6 @@
 # Sourcegraph Instance Validation
 
->NOTE: **Sourcegraph Instance Validation is currently experimental.** We're exploring this feature set. 
+>🚨 WARNING 🚨: **Sourcegraph Instance Validation is currently experimental.** We're exploring this feature set. 
 >Let us know what you think! [File an issue](https://github.com/sourcegraph/sourcegraph/issues/new/choose)
 >with feedback/problems/questions, or [contact us directly](https://about.sourcegraph.com/contact).
 
@@ -8,7 +8,7 @@ Instance validation provides a quick way to check that a Sourcegraph instance fu
  or an update.
 
 The [`src` CLI](https://github.com/sourcegraph/src-cli) has an experimental command `validate` which drives the
- validation from a user-provided configuration file with a validation specification (in JSON or YAML format). if no validation specification file is provided it will execute the following: 
+ validation from a user-provided configuration file with a validation specification (in JSON or YAML format). If no validation specification file is provided it will execute the following: 
  
 * temporarily add an external service
 * wait for a repository to be cloned
@@ -130,41 +130,45 @@ insight:
 
 With this configuration, the validation command executes the following steps: 
 
-* add an external service
-* wait for a repository to be cloned
-* perform a search
-* creates a code insight ( will need to be manually removed )
+* adds an external service
+* waits for a repository to be cloned
+* performs a search
+* removes the external service
+* creates a code insight
+* removes the code insight
  
 >NOTE: Every step is optional (if the corresponding top-level key is not present then the step is skipped).
 > 
 ### Passing in secrets
 
-It is often the case that the config file with the validation specification needs to declare passwords, tokens, or other
-secrets and these secrets should not be exposed or committed to a git repo.
+Secrets are handled via environment variables. `src validate install` requires an environment variables to be set to authenticate to your code host.
+>NOTE: currently only GitHub is supported as a code host.
+>
 
-The validation specification can refer to string values that come from a context specified outside the config file
-(see the `Usage` section below). References to string values from this outside context are specified like so:
-`{{ .some_key }}`. The context will have a string value defined under the key `some_key` and the validation execution will
-use that.
+`src validate install` requires an environment variable to be setup to authenticate against your code host.
+
+* `SRC_GITHUB_TOKEN` - defines the GitHub access token used to authenticate to the GitHub API. This must be set to use a GitHub code host.
+
+
+Example:
+```bash
+export SRC_GITHUB_TOKEN=token
+```
 
 ### Usage
 
 Use the [`src` CLI](https://github.com/sourcegraph/src-cli) to validate with a validation specification file:
 ```shell script
-src validate -context github_token=$GITHUB_TOKEN validate.yaml
+src validate install validate.yaml
 ```
 ```shell script
-src validate -context github_token=$GITHUB_TOKEN validate.json
+src validate install validate.json
 ```
 To execute default validation checks:
 
 ```shell script
-src validate -context github_token=$GITHUB_TOKEN
+src validate install
 ```
 
 The `src` binary finds the Sourcegraph instance to validate from the environment variables 
 [`SRC_ENDPOINT` and `SRC_ACCESS_TOKEN`](https://github.com/sourcegraph/src-cli#setup-with-your-sourcegraph-instance). 
-
-> Note: The `SRC_ACCESS_TOKEN` is not needed when a first admin user is declared in the validation specification.
-
-


### PR DESCRIPTION

![localhost_5080_admin_validation](https://user-images.githubusercontent.com/1760552/212193719-95a9e72a-9df8-4591-b092-72f0fa23d9db.png)

This is a documentation update for the new `install` subcommand for `src validate` that will be introduced in https://github.com/sourcegraph/src-cli/pull/921.

- [x] Updated examples to reflect new configuration layout
- [x] Updated references to `src validate` to be `src validate install`
- [x] Made warning that features are experimental more visible

## Test plan

Run `yarn docsite:serve` to stand up documentation.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
