### PR TITLE
batches: merge xs and small viewport for preview changeset list

### DIFF
--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
@@ -112,7 +112,7 @@ export const ExternalChangesetNode: React.FunctionComponent<React.PropsWithChild
             <div
                 className={classNames(
                     styles.externalChangesetNodeStatuses,
-                    'd-flex d-md-none justify-content-start',
+                    'd-flex d-sm-none justify-content-start',
                     (node.checkState || node.reviewState || node.diffStat) && 'p-2'
                 )}
             >
@@ -134,7 +134,7 @@ export const ExternalChangesetNode: React.FunctionComponent<React.PropsWithChild
             </div>
             <span
                 className={classNames(
-                    'align-self-stretch d-none d-md-flex justify-content-center',
+                    'align-self-stretch d-none d-sm-flex justify-content-center',
                     node.checkState && 'p-2'
                 )}
             >
@@ -146,7 +146,7 @@ export const ExternalChangesetNode: React.FunctionComponent<React.PropsWithChild
             </span>
             <span
                 className={classNames(
-                    'align-self-stretch d-none d-md-flex justify-content-center',
+                    'align-self-stretch d-none d-sm-flex justify-content-center',
                     node.reviewState && 'p-2'
                 )}
             >
@@ -158,7 +158,7 @@ export const ExternalChangesetNode: React.FunctionComponent<React.PropsWithChild
             </span>
             <div
                 className={classNames(
-                    'align-self-center d-none d-md-flex justify-content-center',
+                    'align-self-center d-none d-sm-flex justify-content-center',
                     node.diffStat && 'p-2'
                 )}
             >

--- a/client/web/src/enterprise/batches/preview/list/ChangesetApplyPreviewNode.module.scss
+++ b/client/web/src/enterprise/batches/preview/list/ChangesetApplyPreviewNode.module.scss
@@ -7,7 +7,7 @@
         // Make it full width in the current row.
         grid-column: 1 / -1;
         border-top: 1px solid var(--border-color-2);
-        @media (--xs-breakpoint-down) {
+        @media (--sm-breakpoint-down) {
             margin-top: 1rem;
             padding-bottom: 1rem;
         }

--- a/client/web/src/enterprise/batches/preview/list/PreviewListHeader.module.scss
+++ b/client/web/src/enterprise/batches/preview/list/PreviewListHeader.module.scss
@@ -1,3 +1,12 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
 .list-item {
     display: contents;
+}
+
+.select-all {
+    @media (--sm-breakpoint-down) {
+        // Make it full width in the current row.
+        grid-column: 1 / -1;
+    }
 }

--- a/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
@@ -16,7 +16,7 @@ export const PreviewListHeader: React.FunctionComponent<React.PropsWithChildren<
     toggleSelectAll,
 }) => (
     <li className={styles.listItem}>
-        <span className="p-2 d-none d-sm-block" />
+        <span className="p-2 d-none d-md-block" />
         {toggleSelectAll && (
             <div className="d-flex p-2 align-items-center">
                 {/* eslint-disable-next-line no-restricted-syntax*/}
@@ -28,25 +28,25 @@ export const PreviewListHeader: React.FunctionComponent<React.PropsWithChildren<
                     aria-label="Click to select all changesets"
                     placement="right"
                 />
-                <span className="pl-2 d-block d-sm-none">Select all</span>
+                <span className="pl-2 d-block d-md-none">Select all</span>
             </div>
         )}
-        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-center" aria-hidden={true}>
+        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center" aria-hidden={true}>
             Current state
         </H5>
-        <H5 as={H3} className="d-none d-sm-block text-uppercase text-center" aria-hidden={true}>
+        <H5 as={H3} className="d-none d-md-block text-uppercase text-center" aria-hidden={true}>
             +<br />-
         </H5>
-        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-nowrap" aria-hidden={true}>
+        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-nowrap" aria-hidden={true}>
             Actions
         </H5>
-        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-nowrap" aria-hidden={true}>
+        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-nowrap" aria-hidden={true}>
             Changeset information
         </H5>
-        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-center text-nowrap" aria-hidden={true}>
+        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap" aria-hidden={true}>
             Commit changes
         </H5>
-        <H5 as={H3} className="p-2 d-none d-sm-block text-uppercase text-center text-nowrap" aria-hidden={true}>
+        <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center text-nowrap" aria-hidden={true}>
             Change state
         </H5>
     </li>

--- a/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
@@ -5,6 +5,7 @@ import { H3, H5 } from '@sourcegraph/wildcard'
 import { InputTooltip } from '../../../../components/InputTooltip'
 
 import styles from './PreviewListHeader.module.scss'
+import classNames from 'classnames'
 
 export interface PreviewListHeaderProps {
     allSelected?: boolean
@@ -18,7 +19,7 @@ export const PreviewListHeader: React.FunctionComponent<React.PropsWithChildren<
     <li className={styles.listItem}>
         <span className="p-2 d-none d-md-block" />
         {toggleSelectAll && (
-            <div className="d-flex p-2 align-items-center">
+            <div className={classNames(styles.selectAll, 'd-flex p-2 align-items-center')}>
                 {/* eslint-disable-next-line no-restricted-syntax*/}
                 <InputTooltip
                     type="checkbox"
@@ -31,6 +32,7 @@ export const PreviewListHeader: React.FunctionComponent<React.PropsWithChildren<
                 <span className="pl-2 d-block d-md-none">Select all</span>
             </div>
         )}
+
         <H5 as={H3} className="p-2 d-none d-md-block text-uppercase text-center" aria-hidden={true}>
             Current state
         </H5>

--- a/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 
+import classNames from 'classnames'
 import { H3, H5 } from '@sourcegraph/wildcard'
 
 import { InputTooltip } from '../../../../components/InputTooltip'
 
 import styles from './PreviewListHeader.module.scss'
-import classNames from 'classnames'
 
 export interface PreviewListHeaderProps {
     allSelected?: boolean

--- a/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewListHeader.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import classNames from 'classnames'
+
 import { H3, H5 } from '@sourcegraph/wildcard'
 
 import { InputTooltip } from '../../../../components/InputTooltip'

--- a/client/web/src/enterprise/batches/preview/list/PreviewNodeIndicator.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewNodeIndicator.tsx
@@ -9,7 +9,7 @@ import styles from './PreviewNodeIndicator.module.scss'
 
 const containerClassName = classNames(
     styles.previewNodeIndicatorContainer,
-    'd-none d-sm-flex flex-column align-items-center justify-content-center align-self-stretch'
+    'd-none d-md-flex flex-column align-items-center justify-content-center align-self-stretch'
 )
 
 export interface PreviewNodeIndicatorProps {

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.module.scss
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.module.scss
@@ -62,3 +62,10 @@
         }
     }
 }
+
+.publishable-result {
+    @media (--sm-breakpoint-down) {
+        // Make it full width in the current row.
+        grid-column: 1 / -1;
+    }
+}

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.module.scss
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.module.scss
@@ -5,29 +5,29 @@
     &__action,
     &__information,
     &__show-details {
-        @media (--xs-breakpoint-down) {
+        @media (--sm-breakpoint-down) {
             // Make it full width in the current row.
             grid-column: 1 / -1;
         }
     }
     &__bg-expanded {
         background-color: var(--body-bg);
-        @media (--sm-breakpoint-up) {
+        @media (--md-breakpoint-up) {
             border-top: 1px solid var(--border-color-2);
             padding: 1.5rem;
         }
     }
     &__status-cell {
         color: var(--muted);
-        @media (--sm-breakpoint-up) {
+        @media (--md-breakpoint-up) {
             background-color: var(--body-bg);
         }
     }
     &__list-cell {
-        @media (--sm-breakpoint-up) {
+        @media (--md-breakpoint-up) {
             padding: 0.5rem;
         }
-        @media (--xs-breakpoint-down) {
+        @media (--sm-breakpoint-down) {
             padding-top: 0.25rem;
             padding-bottom: 0.25rem;
         }

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -62,7 +62,7 @@ export const VisibleChangesetApplyPreviewNode: React.FunctionComponent<
         <>
             <Button
                 variant="icon"
-                className="test-batches-expand-preview d-none d-sm-block mx-1"
+                className="test-batches-expand-preview d-none d-md-block mx-1"
                 aria-label={isExpanded ? 'Collapse section' : 'Expand section'}
                 onClick={toggleIsExpanded}
             >
@@ -166,7 +166,7 @@ export const VisibleChangesetApplyPreviewNode: React.FunctionComponent<
                 onClick={toggleIsExpanded}
                 className={classNames(
                     styles.visibleChangesetApplyPreviewNodeShowDetails,
-                    'd-block d-sm-none test-batches-expand-preview'
+                    'd-block d-md-none test-batches-expand-preview'
                 )}
                 outline={true}
                 variant="secondary"
@@ -240,7 +240,7 @@ const SelectBox: React.FunctionComponent<
         <div className="d-flex p-2 align-items-center">
             {input}
             {isPublishableResult.publishable ? (
-                <span className="pl-2 d-block d-sm-none text-nowrap">Modify publication state</span>
+                <span className="pl-2 d-block d-md-none text-nowrap">Modify publication state</span>
             ) : null}
         </div>
     )

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -81,7 +81,7 @@ export const VisibleChangesetApplyPreviewNode: React.FunctionComponent<
                     styles.visibleChangesetApplyPreviewNodeListCell,
                     styles.visibleChangesetApplyPreviewNodeCurrentState,
                     styles.visibleChangesetApplyPreviewNodeStatusCell,
-                    'd-block d-xs-flex align-self-stretch'
+                    'd-block d-md-flex align-self-stretch'
                 )}
             />
             <PreviewNodeIndicator node={node} />

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -108,6 +108,7 @@ export const VisibleChangesetApplyPreviewNode: React.FunctionComponent<
                 </div>
             </div>
             <div className="d-flex justify-content-center align-content-center align-self-stretch">
+                {/* <div className="d-block d-md-flex justify-content-center align-content-center align-self-stretch"> */}
                 {node.delta.commitMessageChanged && (
                     <div
                         className={classNames(
@@ -237,7 +238,7 @@ const SelectBox: React.FunctionComponent<
     )
 
     return (
-        <div className="d-flex p-2 align-items-center">
+        <div className={classNames(styles.publishableResult, 'd-flex p-2 align-items-center')}>
             {input}
             {isPublishableResult.publishable ? (
                 <span className="pl-2 d-block d-md-none text-nowrap">Modify publication state</span>

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -81,7 +81,7 @@ export const VisibleChangesetApplyPreviewNode: React.FunctionComponent<
                     styles.visibleChangesetApplyPreviewNodeListCell,
                     styles.visibleChangesetApplyPreviewNodeCurrentState,
                     styles.visibleChangesetApplyPreviewNodeStatusCell,
-                    'd-block d-sm-flex align-self-stretch'
+                    'd-block d-xs-flex align-self-stretch'
                 )}
             />
             <PreviewNodeIndicator node={node} />

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -385,7 +385,7 @@ commands:
 
   caddy:
     ignoreStdout: true
-    ignoreStderr: true
+    ignoreStderr: false
     cmd: .bin/caddy_${CADDY_VERSION} run --watch --config=dev/Caddyfile
     install_func: installCaddy
     env:


### PR DESCRIPTION
Closes #44716

This is to prevent text from overflowing out of its container on smaller screens on preview list and changeset list page. The behavior and responsiveness for xs viewport is now the same for small viewports.

previous:
![image](https://user-images.githubusercontent.com/67931373/219049746-e07891b2-6ec3-4b16-a6f4-d055e0fa840d.png)

now:
<img width="727" alt="CleanShot 2023-02-15 at 09 21 37@2x" src="https://user-images.githubusercontent.com/67931373/219053662-0982da6c-cb9e-4e17-8dc6-5b6a4136d8b8.png">


## Test plan
Observed screen in smaller widths without overflowing text
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-aa-fix-preview-list.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
