### PR TITLE
Change symbols service discovery to default k8s

### DIFF
--- a/internal/symbols/client.go
+++ b/internal/symbols/client.go
@@ -32,7 +32,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var symbolsURL = env.Get("SYMBOLS_URL", "k8s+http://symbols:3184", "symbols service URL")
+var symbolsURL = env.Get("SYMBOLS_URL", "http://symbols:3184", "symbols service URL")
 
 var defaultDoer = func() httpcli.Doer {
 	d, err := httpcli.NewInternalClientFactory("symbols").Doer()


### PR DESCRIPTION
Use k8s native service discovery (DNS)
Not our custom resolver logic

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Manual review
