### PR TITLE
codeintel: Fix searchHover event recording

### DIFF
--- a/client/shared/src/codeintel/legacy-extensions/providers.ts
+++ b/client/shared/src/codeintel/legacy-extensions/providers.ts
@@ -582,6 +582,7 @@ export function createHoverProvider(
                     continue
                 }
 
+                emitter.emitOnce('searchHover')
                 logger?.log({ provider: 'hover', precise: false, ...commonLogFields })
 
                 if (hasPreciseDefinition) {


### PR DESCRIPTION
Inlining the code-intel-extensions in d6450f5508aa32a3ac4a22acc4c1f0cd40d9204f dropped [this line](https://sourcegraph.com/github.com/sourcegraph/code-intel-extensions@c66e756d3d68a1e19048c3f7515ba42a7e793767/-/blob/template/src/providers.ts?L562#tab=references) which recorded the search-based hover event in our event logs. This is what indicates events in the admin analytics dashboard as well as looker for those that have not opted-out of telemetry.

## Test plan

:stonks:

## App preview:

- [Web](https://sg-web-ef-restore-telemetry.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
