### PR TITLE
gitserver: Fix misleading error text

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -986,7 +986,7 @@ func (e *RepoNotCloneableErr) NotFound() bool {
 }
 
 func (e *RepoNotCloneableErr) Error() string {
-	return fmt.Sprintf("repo not found (name=%s notfound=%v) because %s", e.repo, e.notFound, e.reason)
+	return fmt.Sprintf("repo not cloneable (name=%q notfound=%v) because %s", e.repo, e.notFound, e.reason)
 }
 
 func (c *clientImplementor) RepoCloneProgress(ctx context.Context, repos ...api.RepoName) (*protocol.RepoCloneProgressResponse, error) {


### PR DESCRIPTION
The text said "repo not found" when the actual error is about a repo not
being cloneable. This can be very confusing in logs and hides the root
cause.

## Test plan

None needed, just a text change