### PR TITLE
repos: expose corrupted statistic on graphql api

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_stats.go
+++ b/cmd/frontend/graphqlbackend/repository_stats.go
@@ -140,6 +140,14 @@ func (r *repositoryStatsResolver) FailedFetch(ctx context.Context) (int32, error
 	return int32(counts.FailedFetch), nil
 }
 
+func (r *repositoryStatsResolver) Corrupted(ctx context.Context) (int32, error) {
+	counts, err := r.computeRepoStatistics(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return int32(counts.Corrupted), nil
+}
+
 func (r *repositoryStatsResolver) computeRepoStatistics(ctx context.Context) (database.RepoStatistics, error) {
 	r.repoStatisticsOnce.Do(func() {
 		r.repoStatistics, r.repoStatisticsErr = r.db.RepoStatistics().GetRepoStatistics(ctx)

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -7730,6 +7730,10 @@ type RepositoryStats {
     The number of indexed repositories
     """
     indexed: Int!
+    """
+    The number of repositories that are currently corrupt
+    """
+    corrupted: Int!
 }
 
 """


### PR DESCRIPTION
Adds the corrupted stat to the other repository statistics

## Test plan
manual testing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
