### PR TITLE
repos: add option to filter by corrupted repos

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -706,6 +706,10 @@ type ReposListOptions struct {
 	// last_error value in the gitserver_repos table.
 	FailedFetch bool
 
+	// IsCorrupted, if true, will filter to only repos that where corruption has been detected.
+	// A repository is corrupt in the gitserver_repos table it has a non-null value for corruptedAt
+	IsCorrupted bool
+
 	// MinLastChanged finds repository metadata or data that has changed since
 	// MinLastChanged. It filters against repos.UpdatedAt,
 	// gitserver.LastChanged and searchcontexts.UpdatedAt.
@@ -1041,6 +1045,11 @@ func (s *repoStore) listSQL(ctx context.Context, tr *trace.Trace, opt ReposListO
 	if opt.FailedFetch {
 		where = append(where, sqlf.Sprintf("gr.last_error IS NOT NULL"))
 	}
+
+	if opt.IsCorrupted {
+		where = append(where, sqlf.Sprintf("gr.corrupted_at IS NOT NULL"))
+	}
+
 	if !opt.MinLastChanged.IsZero() {
 		conds := []*sqlf.Query{
 			sqlf.Sprintf("EXISTS (SELECT 1 FROM gitserver_repos gr WHERE gr.repo_id = repo.id AND gr.last_changed >= %s)", opt.MinLastChanged),
@@ -1105,7 +1114,7 @@ func (s *repoStore) listSQL(ctx context.Context, tr *trace.Trace, opt ReposListO
 		where = append(where, sqlf.Sprintf("external_service_repos.org_id = %d", opt.OrgID))
 	}
 
-	if opt.NoCloned || opt.OnlyCloned || opt.FailedFetch || opt.joinGitserverRepos ||
+	if opt.NoCloned || opt.OnlyCloned || opt.FailedFetch || opt.IsCorrupted || opt.joinGitserverRepos ||
 		opt.CloneStatus != types.CloneStatusUnknown || containsSizeField(opt.OrderBy) {
 		joins = append(joins, sqlf.Sprintf("JOIN gitserver_repos gr ON gr.repo_id = repo.id"))
 	}

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -706,9 +706,9 @@ type ReposListOptions struct {
 	// last_error value in the gitserver_repos table.
 	FailedFetch bool
 
-	// IsCorrupted, if true, will filter to only repos that where corruption has been detected.
-	// A repository is corrupt in the gitserver_repos table it has a non-null value for corruptedAt
-	IsCorrupted bool
+	// OnlyCorrupted, if true, will filter to only repos where corruption has been detected.
+	// A repository is corrupt in the gitserver_repos table if it has a non-null value in gitserver_repos.corrupted_at
+	OnlyCorrupted bool
 
 	// MinLastChanged finds repository metadata or data that has changed since
 	// MinLastChanged. It filters against repos.UpdatedAt,
@@ -1046,7 +1046,7 @@ func (s *repoStore) listSQL(ctx context.Context, tr *trace.Trace, opt ReposListO
 		where = append(where, sqlf.Sprintf("gr.last_error IS NOT NULL"))
 	}
 
-	if opt.IsCorrupted {
+	if opt.OnlyCorrupted {
 		where = append(where, sqlf.Sprintf("gr.corrupted_at IS NOT NULL"))
 	}
 
@@ -1114,7 +1114,7 @@ func (s *repoStore) listSQL(ctx context.Context, tr *trace.Trace, opt ReposListO
 		where = append(where, sqlf.Sprintf("external_service_repos.org_id = %d", opt.OrgID))
 	}
 
-	if opt.NoCloned || opt.OnlyCloned || opt.FailedFetch || opt.IsCorrupted || opt.joinGitserverRepos ||
+	if opt.NoCloned || opt.OnlyCloned || opt.FailedFetch || opt.OnlyCorrupted || opt.joinGitserverRepos ||
 		opt.CloneStatus != types.CloneStatusUnknown || containsSizeField(opt.OrderBy) {
 		joins = append(joins, sqlf.Sprintf("JOIN gitserver_repos gr ON gr.repo_id = repo.id"))
 	}

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -621,10 +621,10 @@ func TestRepos_List_IsCorrupted(t *testing.T) {
 	repo := mustCreate(ctx, t, db, &types.Repo{Name: "repo1"})
 	setGitserverRepoCloneStatus(t, db, repo.Name, types.CloneStatusCloned)
 	assertCount(t, ReposListOptions{}, 1)
-	assertCount(t, ReposListOptions{IsCorrupted: true}, 0)
+	assertCount(t, ReposListOptions{OnlyCorrupted: true}, 0)
 
 	logCorruption(t, db, repo.Name, "", "some corruption")
-	assertCount(t, ReposListOptions{IsCorrupted: true}, 1)
+	assertCount(t, ReposListOptions{OnlyCorrupted: true}, 1)
 	assertCount(t, ReposListOptions{}, 1)
 }
 

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -597,6 +597,37 @@ func TestRepos_List_FailedSync(t *testing.T) {
 	assertCount(t, ReposListOptions{}, 1)
 }
 
+func TestRepos_List_IsCorrupted(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	t.Parallel()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := actor.WithInternalActor(context.Background())
+
+	assertCount := func(t *testing.T, opts ReposListOptions, want int) {
+		t.Helper()
+		count, err := db.Repos().Count(ctx, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != want {
+			t.Fatalf("Expected %d repos, got %d", want, count)
+		}
+	}
+
+	repo := mustCreate(ctx, t, db, &types.Repo{Name: "repo1"})
+	setGitserverRepoCloneStatus(t, db, repo.Name, types.CloneStatusCloned)
+	assertCount(t, ReposListOptions{}, 1)
+	assertCount(t, ReposListOptions{IsCorrupted: true}, 0)
+
+	logCorruption(t, db, repo.Name, "", "some corruption")
+	assertCount(t, ReposListOptions{IsCorrupted: true}, 1)
+	assertCount(t, ReposListOptions{}, 1)
+}
+
 func TestRepos_List_cloned(t *testing.T) {
 	if testing.Short() {
 		t.Skip()


### PR DESCRIPTION
Updated the list query so that we can list repos that are currently
corrupted

__Has a dependency on this PR https://github.com/sourcegraph/sourcegraph/pull/46410/files#diff-ecf09f27f6070b658ad2960a93501a26b9b2f0acb6acb187b3f05ee8dc01a004R434 which I forgot_

## Test plan
unit tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
