### PR TITLE
graphql: add var to filter repos by corruption

### DIFF
--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -30,6 +30,7 @@ type repositoryArgs struct {
 
 	CloneStatus *string
 	FailedFetch bool
+	IsCorrupted bool
 
 	ExternalService *graphql.ID
 
@@ -77,6 +78,7 @@ func (args *repositoryArgs) toReposListOptions() (database.ReposListOptions, err
 	}
 
 	opt.FailedFetch = args.FailedFetch
+	opt.IsCorrupted = args.IsCorrupted
 
 	if !args.Cloned && !args.NotCloned {
 		return database.ReposListOptions{}, errors.New("excluding cloned and not cloned repos leaves an empty set")

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -30,7 +30,7 @@ type repositoryArgs struct {
 
 	CloneStatus *string
 	FailedFetch bool
-	IsCorrupted bool
+	Corrupted   bool
 
 	ExternalService *graphql.ID
 
@@ -78,7 +78,7 @@ func (args *repositoryArgs) toReposListOptions() (database.ReposListOptions, err
 	}
 
 	opt.FailedFetch = args.FailedFetch
-	opt.IsCorrupted = args.IsCorrupted
+	opt.OnlyCorrupted = args.Corrupted
 
 	if !args.Cloned && !args.NotCloned {
 		return database.ReposListOptions{}, errors.New("excluding cloned and not cloned repos leaves an empty set")

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1323,6 +1323,10 @@ type Query {
         """
         failedFetch: Boolean = false
         """
+        Include repositories that are corrupt
+        """
+        isCorrupted: Boolean = false
+        """
         Return repositories that are associated with the given external service.
         """
         externalService: ID

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1325,7 +1325,7 @@ type Query {
         """
         Include repositories that are corrupt
         """
-        isCorrupted: Boolean = false
+        corrupted: Boolean = false
         """
         Return repositories that are associated with the given external service.
         """

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -597,7 +597,7 @@ func TestRepos_List_FailedSync(t *testing.T) {
 	assertCount(t, ReposListOptions{}, 1)
 }
 
-func TestRepos_List_IsCorrupted(t *testing.T) {
+func TestRepos_List_OnlyCorrupted(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}


### PR DESCRIPTION
add a `isCorrupted` variable when listing repositories so that we can
query for corrupted repos

## Test plan
manual testing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
