### PR TITLE
repos ui: add 'corrupted' status filter

### DIFF
--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -191,6 +191,12 @@ const FILTERS: FilteredConnectionFilter[] = [
                 tooltip: 'Show only repositories that have failed to fetch or clone',
                 args: { failedFetch: true },
             },
+            {
+                label: 'Corrupted',
+                value: 'corrupted',
+                tooltip: 'Show only repositories which are corrupt',
+                args: { isCorrupted: true },
+            },
         ],
     },
 ]

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -195,7 +195,7 @@ const FILTERS: FilteredConnectionFilter[] = [
                 label: 'Corrupted',
                 value: 'corrupted',
                 tooltip: 'Show only repositories which are corrupt',
-                args: { isCorrupted: true },
+                args: { corrupted: true },
             },
         ],
     },

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -165,7 +165,7 @@ function fetchAllRepositories(args: Partial<RepositoriesVariables>): Observable<
                 $indexed: Boolean
                 $notIndexed: Boolean
                 $failedFetch: Boolean
-                $isCorrupted: Boolean
+                $corrupted: Boolean
                 $cloneStatus: CloneStatus
                 $orderBy: RepositoryOrderBy
                 $descending: Boolean
@@ -177,7 +177,7 @@ function fetchAllRepositories(args: Partial<RepositoriesVariables>): Observable<
                     indexed: $indexed
                     notIndexed: $notIndexed
                     failedFetch: $failedFetch
-                    isCorrupted: $isCorrupted
+                    corrupted: $corrupted
                     cloneStatus: $cloneStatus
                     orderBy: $orderBy
                     descending: $descending
@@ -199,7 +199,7 @@ function fetchAllRepositories(args: Partial<RepositoriesVariables>): Observable<
             indexed: args.indexed ?? true,
             notIndexed: args.notIndexed ?? true,
             failedFetch: args.failedFetch ?? false,
-            isCorrupted: args.isCorrupted ?? false,
+            corrupted: args.corrupted ?? false,
             first: args.first ?? null,
             query: args.query ?? null,
             cloneStatus: args.cloneStatus ?? null,

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -165,6 +165,7 @@ function fetchAllRepositories(args: Partial<RepositoriesVariables>): Observable<
                 $indexed: Boolean
                 $notIndexed: Boolean
                 $failedFetch: Boolean
+                $isCorrupted: Boolean
                 $cloneStatus: CloneStatus
                 $orderBy: RepositoryOrderBy
                 $descending: Boolean
@@ -176,6 +177,7 @@ function fetchAllRepositories(args: Partial<RepositoriesVariables>): Observable<
                     indexed: $indexed
                     notIndexed: $notIndexed
                     failedFetch: $failedFetch
+                    isCorrupted: $isCorrupted
                     cloneStatus: $cloneStatus
                     orderBy: $orderBy
                     descending: $descending
@@ -197,6 +199,7 @@ function fetchAllRepositories(args: Partial<RepositoriesVariables>): Observable<
             indexed: args.indexed ?? true,
             notIndexed: args.notIndexed ?? true,
             failedFetch: args.failedFetch ?? false,
+            isCorrupted: args.isCorrupted ?? false,
             first: args.first ?? null,
             query: args.query ?? null,
             cloneStatus: args.cloneStatus ?? null,

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -30,6 +30,7 @@ type repositoryArgs struct {
 
 	CloneStatus *string
 	FailedFetch bool
+	IsCorrupted bool
 
 	ExternalService *graphql.ID
 
@@ -77,6 +78,7 @@ func (args *repositoryArgs) toReposListOptions() (database.ReposListOptions, err
 	}
 
 	opt.FailedFetch = args.FailedFetch
+	opt.IsCorrupted = args.IsCorrupted
 
 	if !args.Cloned && !args.NotCloned {
 		return database.ReposListOptions{}, errors.New("excluding cloned and not cloned repos leaves an empty set")

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -30,7 +30,7 @@ type repositoryArgs struct {
 
 	CloneStatus *string
 	FailedFetch bool
-	IsCorrupted bool
+	Corrupted   bool
 
 	ExternalService *graphql.ID
 
@@ -78,7 +78,7 @@ func (args *repositoryArgs) toReposListOptions() (database.ReposListOptions, err
 	}
 
 	opt.FailedFetch = args.FailedFetch
-	opt.IsCorrupted = args.IsCorrupted
+	opt.OnlyCorrupted = args.Corrupted
 
 	if !args.Cloned && !args.NotCloned {
 		return database.ReposListOptions{}, errors.New("excluding cloned and not cloned repos leaves an empty set")

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1323,6 +1323,10 @@ type Query {
         """
         failedFetch: Boolean = false
         """
+        Include repositories that are corrupt
+        """
+        isCorrupted: Boolean = false
+        """
         Return repositories that are associated with the given external service.
         """
         externalService: ID

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1325,7 +1325,7 @@ type Query {
         """
         Include repositories that are corrupt
         """
-        isCorrupted: Boolean = false
+        corrupted: Boolean = false
         """
         Return repositories that are associated with the given external service.
         """

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -597,7 +597,7 @@ func TestRepos_List_FailedSync(t *testing.T) {
 	assertCount(t, ReposListOptions{}, 1)
 }
 
-func TestRepos_List_IsCorrupted(t *testing.T) {
+func TestRepos_List_OnlyCorrupted(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}


### PR DESCRIPTION
Add a status filter "corrupted" to filter the repositories on the admin
page, allowing an admin to see all corrupted repos

## Test plan
manual testing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
