### PR TITLE
web: make ExternalServiceEditPage look like ExternalServicePage.

### DIFF
--- a/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
@@ -5,7 +5,7 @@ import { Redirect } from 'react-router'
 
 import { useQuery } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { LoadingSpinner, H2, Container, ErrorAlert } from '@sourcegraph/wildcard'
+import { Container, ErrorAlert, PageHeader, Icon, ButtonLink } from '@sourcegraph/wildcard'
 
 import {
     ExternalServiceFields,
@@ -17,10 +17,11 @@ import {
 import { PageTitle } from '../PageTitle'
 
 import { useUpdateExternalService, FETCH_EXTERNAL_SERVICE } from './backend'
-import { ExternalServiceCard } from './ExternalServiceCard'
 import { ExternalServiceForm } from './ExternalServiceForm'
 import { resolveExternalServiceCategory } from './externalServices'
 import { ExternalServiceWebhook } from './ExternalServiceWebhook'
+import { mdiCog } from '@mdi/js'
+import { CreatedByAndUpdatedByInfoByline } from '../Byline/CreatedByAndUpdatedByInfoByline'
 
 interface Props extends TelemetryProps {
     externalServiceID: Scalars['ID']
@@ -123,19 +124,49 @@ export const ExternalServiceEditPage: React.FunctionComponent<React.PropsWithChi
             ) : (
                 <PageTitle title="Code host" />
             )}
-            <H2>Update code host connection {combinedLoading && <LoadingSpinner inline={true} />}</H2>
             {combinedError !== undefined && !combinedLoading && <ErrorAlert className="mb-3" error={combinedError} />}
 
             {externalService && (
                 <Container className="mb-3">
-                    {externalServiceCategory && (
-                        <div className="mb-3">
-                            <ExternalServiceCard {...externalServiceCategory} />
-                        </div>
-                    )}
+                    <PageHeader
+                        path={[
+                            { icon: mdiCog },
+                            { to: '/site-admin/external-services', text: 'Code hosts' },
+                            {
+                                text: (
+                                    <>
+                                        {externalService.displayName}{' '}
+                                        {externalServiceCategory && (
+                                            <Icon
+                                                inline={true}
+                                                as={externalServiceCategory.icon}
+                                                aria-label="Code host logo"
+                                                className="mr-2"
+                                            />
+                                        )}
+                                    </>
+                                ),
+                            },
+                        ]}
+                        byline={
+                            <CreatedByAndUpdatedByInfoByline
+                                createdAt={externalService.createdAt}
+                                updatedAt={externalService.updatedAt}
+                                noAuthor={true}
+                            />
+                        }
+                        className="mb-3"
+                        headingElement="h2"
+                        actions={
+                            <ButtonLink to={`/site-admin/external-services/${externalServiceID}`} variant="secondary">
+                                Cancel
+                            </ButtonLink>
+                        }
+                    />
                     {externalServiceCategory && (
                         <ExternalServiceForm
                             input={{ ...externalService }}
+                            externalServiceID={externalServiceID}
                             editorActions={externalServiceCategory.editorActions}
                             jsonSchema={externalServiceCategory.jsonSchema}
                             error={updateExternalServiceError}

--- a/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useCallback } from 'react'
 
+import { mdiCog } from '@mdi/js'
 import * as H from 'history'
 import { Redirect } from 'react-router'
 
@@ -14,14 +15,13 @@ import {
     ExternalServiceResult,
     ExternalServiceVariables,
 } from '../../graphql-operations'
+import { CreatedByAndUpdatedByInfoByline } from '../Byline/CreatedByAndUpdatedByInfoByline'
 import { PageTitle } from '../PageTitle'
 
 import { useUpdateExternalService, FETCH_EXTERNAL_SERVICE } from './backend'
 import { ExternalServiceForm } from './ExternalServiceForm'
 import { resolveExternalServiceCategory } from './externalServices'
 import { ExternalServiceWebhook } from './ExternalServiceWebhook'
-import { mdiCog } from '@mdi/js'
-import { CreatedByAndUpdatedByInfoByline } from '../Byline/CreatedByAndUpdatedByInfoByline'
 
 interface Props extends TelemetryProps {
     externalServiceID: Scalars['ID']
@@ -135,13 +135,13 @@ export const ExternalServiceEditPage: React.FunctionComponent<React.PropsWithChi
                             {
                                 text: (
                                     <>
-                                        {externalService.displayName}{' '}
+                                        {externalService.displayName}
                                         {externalServiceCategory && (
                                             <Icon
                                                 inline={true}
                                                 as={externalServiceCategory.icon}
                                                 aria-label="Code host logo"
-                                                className="mr-2"
+                                                className="ml-2"
                                             />
                                         )}
                                     </>

--- a/client/web/src/components/externalServices/ExternalServiceForm.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceForm.tsx
@@ -5,7 +5,18 @@ import * as H from 'history'
 import { ErrorLike } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
-import { Button, LoadingSpinner, Alert, H4, Text, Input, ErrorAlert, ErrorMessage, Form } from '@sourcegraph/wildcard'
+import {
+    Button,
+    LoadingSpinner,
+    Alert,
+    H4,
+    Text,
+    Input,
+    ErrorAlert,
+    ErrorMessage,
+    Form,
+    ButtonLink,
+} from '@sourcegraph/wildcard'
 
 import { AddExternalServiceInput } from '../../graphql-operations'
 import { DynamicallyImportedMonacoSettingsEditor } from '../../settings/DynamicallyImportedMonacoSettingsEditor'
@@ -17,6 +28,7 @@ import { AddExternalServiceOptions } from './externalServices'
 interface Props extends Pick<AddExternalServiceOptions, 'jsonSchema' | 'editorActions'>, ThemeProps, TelemetryProps {
     history: H.History
     input: AddExternalServiceInput
+    externalServiceID?: string
     error?: ErrorLike
     warning?: string | null
     mode: 'edit' | 'create'
@@ -40,6 +52,7 @@ export const ExternalServiceForm: React.FunctionComponent<React.PropsWithChildre
     jsonSchema,
     editorActions,
     input,
+    externalServiceID,
     error,
     warning,
     mode,
@@ -123,17 +136,36 @@ export const ExternalServiceForm: React.FunctionComponent<React.PropsWithChildre
                     }
                 />
             </div>
-            <Button
-                type="submit"
-                className={
-                    mode === 'create' ? 'test-add-external-service-button' : 'test-update-external-service-button'
-                }
-                disabled={loading || disabled}
-                variant="primary"
-            >
-                {loading && <LoadingSpinner />}
-                {submitName ?? (mode === 'edit' ? 'Update configuration' : 'Add repositories')}
-            </Button>
+            {mode === 'edit' ? (
+                <div className="d-flex flex-shrink-0 mt-2">
+                    <div>
+                        <Button
+                            type="submit"
+                            className="test-update-external-service-button"
+                            disabled={loading || disabled}
+                            variant="primary"
+                        >
+                            {loading && <LoadingSpinner />}
+                            {submitName ?? 'Update configuration'}
+                        </Button>
+                    </div>
+                    <div className="ml-1">
+                        <ButtonLink to={`/site-admin/external-services/${externalServiceID}`} variant="secondary">
+                            Cancel
+                        </ButtonLink>
+                    </div>
+                </div>
+            ) : (
+                <Button
+                    type="submit"
+                    className="test-add-external-service-button"
+                    disabled={loading || disabled}
+                    variant="primary"
+                >
+                    {loading && <LoadingSpinner />}
+                    {submitName ?? 'Add repositories'}
+                </Button>
+            )}
         </Form>
     )
 }


### PR DESCRIPTION
This includes adding breadcrumbs and removing large code host kind icon panel. Also, "cancel" buttons are added at the top of the page and near "update" button at the bottom of the form.

Test plan:
Local sg run and manual tests.

### Quick demo

https://user-images.githubusercontent.com/94846361/212309347-628d4add-4c10-403d-aee7-2c31f1e680c0.mp4


## App preview:

- [Web](https://sg-web-ao-ui-ext-svc-page-improvements.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
