### PR TITLE
gitserver: Clearer error message when repo can't be updated

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -993,14 +993,13 @@ func (s *Server) handleIsRepoCloneable(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	var resp protocol.IsRepoCloneableResponse
+	resp := protocol.IsRepoCloneableResponse{
+		Cloned: repoCloned(s.dir(req.Repo)),
+	}
 	if err := syncer.IsCloneable(r.Context(), remoteURL); err == nil {
-		resp = protocol.IsRepoCloneableResponse{Cloneable: true}
+		resp.Cloneable = true
 	} else {
-		resp = protocol.IsRepoCloneableResponse{
-			Cloneable: false,
-			Reason:    err.Error(),
-		}
+		resp.Reason = err.Error()
 	}
 
 	if err := json.NewEncoder(w).Encode(resp); err != nil {

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -215,6 +215,7 @@ type IsRepoCloneableRequest struct {
 // IsRepoCloneableResponse is the response type for the IsRepoCloneableRequest.
 type IsRepoCloneableResponse struct {
 	Cloneable bool   // whether the repo is cloneable
+	Cloned    bool   // true if the repo was ever cloned in the past
 	Reason    string // if not cloneable, the reason why not
 }
 


### PR DESCRIPTION
We now track whether a repo was *ever* cloned and if it was amend the
error message to mention that the repo wasn't able to be updated rather
than the original "repo is not cloneable" message.

Follow up to https://github.com/sourcegraph/sourcegraph/pull/46408

## Test plan

Tested locally by making changing token to something invalid and confirming different message
depending on whether the repo was on disk or not.