### PR TITLE
web: prettier ignore lock file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -40,3 +40,4 @@ client/jetbrains/.gradle
 .browserslistrc
 code-intel-extensions.json
 .direnv
+pnpm-lock.yaml


### PR DESCRIPTION
## Context

Do not format `pnpm-lock.yaml` with `prettier`.

## Test plan

CI
