### PR TITLE
Add short descriptions for each DB worker

### DIFF
--- a/enterprise/cmd/worker/internal/batches/workers/batch_spec_resolution_worker.go
+++ b/enterprise/cmd/worker/internal/batches/workers/batch_spec_resolution_worker.go
@@ -29,6 +29,7 @@ func NewBatchSpecResolutionWorker(
 
 	options := workerutil.WorkerOptions{
 		Name:              "batch_changes_batch_spec_resolution_worker",
+		Description:       "runs the workspace resolutions for batch specs, for batch changes running server-side",
 		NumHandlers:       5,
 		Interval:          1 * time.Second,
 		HeartbeatInterval: 15 * time.Second,

--- a/enterprise/cmd/worker/internal/batches/workers/bulk_processor_worker.go
+++ b/enterprise/cmd/worker/internal/batches/workers/bulk_processor_worker.go
@@ -29,6 +29,7 @@ func NewBulkOperationWorker(
 
 	options := workerutil.WorkerOptions{
 		Name:              "batches_bulk_processor",
+		Description:       "executes the bulk operations in the background",
 		NumHandlers:       5,
 		HeartbeatInterval: 15 * time.Second,
 		Interval:          5 * time.Second,

--- a/enterprise/cmd/worker/internal/batches/workers/reconciler_worker.go
+++ b/enterprise/cmd/worker/internal/batches/workers/reconciler_worker.go
@@ -30,6 +30,7 @@ func NewReconcilerWorker(
 
 	options := workerutil.WorkerOptions{
 		Name:              "batches_reconciler_worker",
+		Description:       "changeset reconciler that publishes, modifies and closes changesets on the code host",
 		NumHandlers:       5,
 		Interval:          5 * time.Second,
 		HeartbeatInterval: 15 * time.Second,

--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
@@ -357,6 +357,7 @@ func newBitbucketProjectPermissionsWorker(ctx context.Context, observationCtx *o
 
 	options := workerutil.WorkerOptions{
 		Name:              "explicit_permissions_bitbucket_projects_jobs_worker",
+		Description:       "reads the `explicit_permissions_bitbucket_projects_jobs` table and executes the jobs",
 		NumHandlers:       cfg.WorkerConcurrency,
 		Interval:          cfg.WorkerPollInterval,
 		HeartbeatInterval: 15 * time.Second,

--- a/enterprise/internal/codeintel/autoindexing/internal/background/job_dependency_indexing_scheduler.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/job_dependency_indexing_scheduler.go
@@ -55,6 +55,7 @@ func NewDependencyIndexingScheduler(
 
 	return dbworker.NewWorker[shared.DependencyIndexingJob](rootContext, dependencyIndexingStore, handler, workerutil.WorkerOptions{
 		Name:              "precise_code_intel_dependency_indexing_scheduler_worker",
+		Description:       "queues indexing jobs for a remote executor instance to perform",
 		NumHandlers:       numHandlers,
 		Interval:          pollInterval,
 		Metrics:           metrics,

--- a/enterprise/internal/codeintel/autoindexing/internal/background/job_dependency_sync_scheduler.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/job_dependency_sync_scheduler.go
@@ -45,6 +45,7 @@ func NewDependencySyncScheduler(
 
 	return dbworker.NewWorker[shared.DependencySyncingJob](rootContext, dependencySyncStore, handler, workerutil.WorkerOptions{
 		Name:              "precise_code_intel_dependency_sync_scheduler_worker",
+		Description:       "periodically checks for dependency packages that can be auto-indexed",
 		NumHandlers:       1,
 		Interval:          pollInterval,
 		HeartbeatInterval: 1 * time.Second,

--- a/enterprise/internal/codeintel/uploads/internal/background/job_worker_handler.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/job_worker_handler.go
@@ -63,6 +63,7 @@ func NewUploadProcessorWorker(
 
 	return dbworker.NewWorker(rootContext, workerStore, handler, workerutil.WorkerOptions{
 		Name:                 "precise_code_intel_upload_worker",
+		Description:          "processes precise code intel uploads",
 		NumHandlers:          workerConcurrency,
 		Interval:             workerPollInterval,
 		HeartbeatInterval:    time.Second,

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -32,6 +32,7 @@ const (
 func newTriggerQueryRunner(ctx context.Context, observationCtx *observation.Context, db edb.EnterpriseDB, metrics codeMonitorsMetrics) *workerutil.Worker[*edb.TriggerJob] {
 	options := workerutil.WorkerOptions{
 		Name:                 "code_monitors_trigger_jobs_worker",
+		Description:          "runs trigger queries for code monitors",
 		NumHandlers:          4,
 		Interval:             5 * time.Second,
 		HeartbeatInterval:    15 * time.Second,
@@ -84,6 +85,7 @@ func newTriggerJobsLogDeleter(ctx context.Context, store edb.CodeMonitorStore) g
 func newActionRunner(ctx context.Context, observationCtx *observation.Context, s edb.CodeMonitorStore, metrics codeMonitorsMetrics) *workerutil.Worker[*edb.ActionJob] {
 	options := workerutil.WorkerOptions{
 		Name:              "code_monitors_action_jobs_worker",
+		Description:       "runs actions for code monitors",
 		NumHandlers:       1,
 		Interval:          5 * time.Second,
 		HeartbeatInterval: 15 * time.Second,

--- a/enterprise/internal/insights/background/queryrunner/worker.go
+++ b/enterprise/internal/insights/background/queryrunner/worker.go
@@ -46,6 +46,7 @@ func NewWorker(ctx context.Context, logger log.Logger, workerStore *workerStoreE
 
 	options := workerutil.WorkerOptions{
 		Name:              "insights_query_runner_worker",
+		Description:       "runs code insights queries",
 		NumHandlers:       numHandlers,
 		Interval:          5 * time.Second,
 		HeartbeatInterval: 15 * time.Second,
@@ -318,7 +319,7 @@ func QueryJobsStatus(ctx context.Context, workerBaseStore *basestore.Store, seri
 }
 
 const queryJobsStatusSql = `
-SELECT state, COUNT(*) FROM insights_query_runner_jobs WHERE series_id=%s GROUP BY state 
+SELECT state, COUNT(*) FROM insights_query_runner_jobs WHERE series_id=%s GROUP BY state
 `
 
 func QueryAllSeriesStatus(ctx context.Context, workerBaseStore *basestore.Store) (_ []types.InsightSeriesStatus, err error) {

--- a/enterprise/internal/insights/background/queryrunner/worker.go
+++ b/enterprise/internal/insights/background/queryrunner/worker.go
@@ -46,7 +46,7 @@ func NewWorker(ctx context.Context, logger log.Logger, workerStore *workerStoreE
 
 	options := workerutil.WorkerOptions{
 		Name:              "insights_query_runner_worker",
-		Description:       "runs code insights queries",
+		Description:       "runs code insights queries for daily snapshots and new recordings",
 		NumHandlers:       numHandlers,
 		Interval:          5 * time.Second,
 		HeartbeatInterval: 15 * time.Second,

--- a/enterprise/internal/insights/background/retention/worker.go
+++ b/enterprise/internal/insights/background/retention/worker.go
@@ -76,6 +76,7 @@ func getMaximumSampleSize(logger log.Logger) int {
 func NewWorker(ctx context.Context, logger log.Logger, workerStore dbworkerstore.Store[*DataRetentionJob], insightsStore *store.Store, metrics workerutil.WorkerObservability) *workerutil.Worker[*DataRetentionJob] {
 	options := workerutil.WorkerOptions{
 		Name:              "insights_data_retention_worker",
+		Description:       "archives code insights data points over the maximum sample size",
 		NumHandlers:       5,
 		Interval:          30 * time.Minute,
 		HeartbeatInterval: 15 * time.Second,

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -70,7 +70,7 @@ func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*worker
 
 	worker := dbworker.NewWorker(ctx, workerStore, workerutil.Handler[*BaseJob](task), workerutil.WorkerOptions{
 		Name:              name,
-		Description:       "handles in-progress backfills for code insights",
+		Description:       "generates and runs searches to backfill a code insight",
 		NumHandlers:       1,
 		Interval:          inProgressPollingInterval,
 		HeartbeatInterval: 15 * time.Second,

--- a/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -70,6 +70,7 @@ func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*worker
 
 	worker := dbworker.NewWorker(ctx, workerStore, workerutil.Handler[*BaseJob](task), workerutil.WorkerOptions{
 		Name:              name,
+		Description:       "handles in-progress backfills for code insights",
 		NumHandlers:       1,
 		Interval:          inProgressPollingInterval,
 		HeartbeatInterval: 15 * time.Second,

--- a/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
@@ -67,7 +67,7 @@ func makeNewBackfillWorker(ctx context.Context, config JobMonitorConfig) (*worke
 
 	worker := dbworker.NewWorker(ctx, workerStore, workerutil.Handler[*BaseJob](&task), workerutil.WorkerOptions{
 		Name:              name,
-		Description:       "handles backfills that are in the \"new\" state",
+		Description:       "determines the repos for a code insight and an approximate cost of the backfill",
 		NumHandlers:       1,
 		Interval:          5 * time.Second,
 		HeartbeatInterval: 15 * time.Second,

--- a/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
+++ b/enterprise/internal/insights/scheduler/backfill_state_new_handler.go
@@ -67,6 +67,7 @@ func makeNewBackfillWorker(ctx context.Context, config JobMonitorConfig) (*worke
 
 	worker := dbworker.NewWorker(ctx, workerStore, workerutil.Handler[*BaseJob](&task), workerutil.WorkerOptions{
 		Name:              name,
+		Description:       "handles backfills that are in the \"new\" state",
 		NumHandlers:       1,
 		Interval:          5 * time.Second,
 		HeartbeatInterval: 15 * time.Second,

--- a/internal/repos/sync_worker.go
+++ b/internal/repos/sync_worker.go
@@ -67,6 +67,7 @@ func NewSyncWorker(ctx context.Context, observationCtx *observation.Context, dbH
 
 	worker := dbworker.NewWorker(ctx, store, handler, workerutil.WorkerOptions{
 		Name:              "repo_sync_worker",
+		Description:       "syncs repos in a streaming fashion",
 		NumHandlers:       opts.NumHandlers,
 		Interval:          opts.WorkerInterval,
 		HeartbeatInterval: 15 * time.Second,

--- a/internal/repos/webhookworker/worker.go
+++ b/internal/repos/webhookworker/worker.go
@@ -20,6 +20,7 @@ import (
 func NewWorker(ctx context.Context, handler workerutil.Handler[*Job], workerStore workerstore.Store[*Job], metrics workerutil.WorkerObservability) *workerutil.Worker[*Job] {
 	options := workerutil.WorkerOptions{
 		Name:              "webhook_build_worker",
+		Description:       "creates webhooks",
 		NumHandlers:       3,
 		Interval:          5 * time.Second,
 		HeartbeatInterval: 15 * time.Second,

--- a/internal/workerutil/worker.go
+++ b/internal/workerutil/worker.go
@@ -47,6 +47,9 @@ type WorkerOptions struct {
 	// supplied.
 	Name string
 
+	// Description describes the worker for logging purposes.
+	Description string
+
 	// WorkerHostname denotes the hostname of the instance/container the worker
 	// is running on. If not supplied, it will be derived from either the `HOSTNAME`
 	// env var, or else from os.Hostname()


### PR DESCRIPTION
- This PR accompanies my larger effort to create a dashboard for our background jobs: https://github.com/sourcegraph/sourcegraph/pull/44901

I used the info from the [workers docs page](https://docs.sourcegraph.com/admin/workers) and my [spreadsheet](https://docs.google.com/spreadsheets/d/1Ck9LVsFqEB1ukgE2kziYTskTYis1c44wuxcyzIqg5Tw/edit#gid=0) to add a short description for each DB-backed worker.

Before merging this PR, I'd like to give an opportunity to everyone who owns workers to make the descriptions better. In some cases, I found very little about what a worker did, so I made my best guess.

We'll display the descriptions similarly to this (descriptions highlighted):

![CleanShot 2023-01-13 at 14 15 13@2x](https://user-images.githubusercontent.com/2552265/212328788-9e7483d1-4f93-488e-a5c9-4f63cacb3c0c.png)

I tried not to repeat what was obvious from the worker's name and to be concise and use a similar style for each item.
However, the pre-existing descriptions for periodic workers that are also on the list are pretty diverse in style, so the bar is not very high.

## Test plan

Check if everyone's happy with the descriptions