### PR TITLE
sg: add a check for docker daemon allocated memory

### DIFF
--- a/dev/sg/dependencies/shared.go
+++ b/dev/sg/dependencies/shared.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/grafana/regexp"
@@ -183,6 +184,26 @@ func categoryProgrammingLanguagesAndTools(additionalChecks ...*dependency) categ
 					`rm -rf ~/.asdf/shims`,
 					`asdf reshim`,
 				),
+			},
+			{
+				Name:        "docker memory limits",
+				Description: `Open the Docker Desktop appplication preferences, find the Resources section and set the memory to at least 2Gb.`,
+				Check: func(ctx context.Context, out *std.Output, args CheckArgs) error {
+					bytesCount, err := root.Run(usershell.Command(ctx, "docker info --format '{{ .MemTotal }}'")).String()
+					if err != nil {
+						return err
+					}
+					c, err := strconv.Atoi(bytesCount)
+					if err != nil {
+						return err
+					}
+
+					c = c / 1000 / 1000 / 1000 // Converts bytes to gigabytes
+					if c < 12 {
+						return errors.New("Docker daemon is configured to operate with less than 2 Gb of allocated memory")
+					}
+					return nil
+				},
 			},
 		},
 	}

--- a/dev/sg/dependencies/shared.go
+++ b/dev/sg/dependencies/shared.go
@@ -199,7 +199,7 @@ func categoryProgrammingLanguagesAndTools(additionalChecks ...*dependency) categ
 					}
 
 					c = c / 1000 / 1000 / 1000 // Converts bytes to gigabytes
-					if c < 12 {
+					if c < 2 {
 						return errors.New("Docker daemon is configured to operate with less than 2 Gb of allocated memory")
 					}
 					return nil


### PR DESCRIPTION
Quick coffee / pairing session with @chwarwick, where we added a check for something he recently encountered while running `sg start`.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally. 