### PR TITLE
gha: disable comments if release-protector complains

### DIFF
--- a/.github/workflows/release-protector.yml
+++ b/.github/workflows/release-protector.yml
@@ -109,15 +109,3 @@ jobs:
             echo "📅 Not enabled, we're not yet on ${freeze_date} and release code freeze has not started yet."
             exit 0
           fi
-      - name: "Post comment if failed"
-        uses: actions/github-script@v6
-        if: ${{always() && steps.check-date-and-labels.outcome != 'success'}} 
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: "❌ **Problem**: the label `i-acknowledge-this-goes-into-the-release` is absent.\n👉 **What to do**: we're in the next Sourcegraph release code freeze period. If you are 100% sure your changes should get released or provide no risk to the release, add the label your PR with `i-acknowledge-this-goes-into-the-release`."
-            })


### PR DESCRIPTION
Prevents stuff like 👇  while I fix it. 

![image](https://user-images.githubusercontent.com/10151/212361913-9895a22e-33a3-431c-92ea-cf3e03f43f01.png)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

That specific comment doesn't appear on that PR. 