### PR TITLE
Git Blame Tweaks

### DIFF
--- a/client/web/src/repo/blob/BlameDecoration.module.scss
+++ b/client/web/src/repo/blob/BlameDecoration.module.scss
@@ -56,16 +56,9 @@
 
         .author {
             margin: 0 0.5rem;
-            margin-right: 1rem;
+            margin-right: 0.25rem;
             display: inline-block;
             text-decoration: none;
-
-            &-name {
-                margin-left: 0.25rem;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-            }
         }
 
         .content,

--- a/client/web/src/repo/blob/BlameDecoration.module.scss
+++ b/client/web/src/repo/blob/BlameDecoration.module.scss
@@ -1,6 +1,14 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
 :root {
     --blame-decoration-width: 300px;
     --blame-recency-width: 5px;
+}
+
+@media (--lg-breakpoint-up) {
+    :root {
+        --blame-decoration-width: 400px;
+    }
 }
 
 .blame {
@@ -32,10 +40,9 @@
         width: calc(100% - var(--blame-recency-width));
         max-width: calc(var(--blame-decoration-width) - var(--blame-recency-width));
         height: 1.5rem;
-
-        color: var(--body-color);
+        color: var(--text-muted);
         &:hover {
-            color: var(--body-color);
+            color: var(--text-muted);
         }
 
         .avatar {
@@ -44,12 +51,21 @@
             min-height: 1rem;
             height: 1rem;
             font-size: 0.5rem;
+            vertical-align: text-top;
         }
 
         .author {
             margin: 0 0.5rem;
+            margin-right: 1rem;
             display: inline-block;
             text-decoration: none;
+
+            &-name {
+                margin-left: 0.25rem;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
         }
 
         .content,

--- a/client/web/src/repo/blob/BlameDecoration.tsx
+++ b/client/web/src/repo/blob/BlameDecoration.tsx
@@ -196,9 +196,6 @@ export const BlameDecoration: React.FunctionComponent<{
                                                 }
                                                 size={16}
                                             />
-                                            <span className={styles.authorName}>
-                                                {`${displayInfo.username}${displayInfo.displayName}`.split(' ')[0]}
-                                            </span>
                                         </span>
                                     </>
                                 ) : (
@@ -207,6 +204,12 @@ export const BlameDecoration: React.FunctionComponent<{
                                     </span>
                                 )}
                                 <span className={styles.content} data-line-decoration-attachment-content={true}>
+                                    {blameHunk.author.person ? (
+                                        <>
+                                            {`${displayInfo.username}${displayInfo.displayName}`.split(' ')[0]}
+                                            {' • '}
+                                        </>
+                                    ) : null}
                                     {displayInfo.message}
                                 </span>
                             </>

--- a/client/web/src/repo/blob/BlameDecoration.tsx
+++ b/client/web/src/repo/blob/BlameDecoration.tsx
@@ -182,22 +182,30 @@ export const BlameDecoration: React.FunctionComponent<{
                                 <span className={styles.date} data-line-decoration-attachment-content={true}>
                                     {displayInfo.dateString}
                                 </span>
-                                <span className={styles.author} data-line-decoration-attachment-content={true}>
-                                    {blameHunk.author.person ? (
-                                        <UserAvatar
-                                            inline={true}
-                                            className={styles.avatar}
-                                            user={
-                                                blameHunk.author.person.user
-                                                    ? blameHunk.author.person.user
-                                                    : blameHunk.author.person
-                                            }
-                                            size={16}
-                                        />
-                                    ) : (
-                                        `${displayInfo.username}${displayInfo.displayName}`
-                                    )}
-                                </span>
+                                {blameHunk.author.person ? (
+                                    <>
+                                        <span className={styles.author} data-line-decoration-attachment-content={true}>
+                                            <UserAvatar
+                                                inline={true}
+                                                className={styles.avatar}
+                                                style={{ top: 1 }}
+                                                user={
+                                                    blameHunk.author.person.user
+                                                        ? blameHunk.author.person.user
+                                                        : blameHunk.author.person
+                                                }
+                                                size={16}
+                                            />
+                                            <span className={styles.authorName}>
+                                                {`${displayInfo.username}${displayInfo.displayName}`.split(' ')[0]}
+                                            </span>
+                                        </span>
+                                    </>
+                                ) : (
+                                    <span className={styles.author} data-line-decoration-attachment-content={true}>
+                                        {`${displayInfo.username}${displayInfo.displayName}`}
+                                    </span>
+                                )}
                                 <span className={styles.content} data-line-decoration-attachment-content={true}>
                                     {displayInfo.message}
                                 </span>


### PR DESCRIPTION
Some tweaks based on the feedback in [#feedback-dogfood](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1673561623641639).

- Adds the first name of the author for more clarity
- Increases the width of the blame gutter on large screens
- Fix the ellipsis icon and underline color (they were darker than the text color, whoopsie)
- Some spacing tweks

## Test plan

Manually tested 
<img width="1044" alt="Screenshot 2023-01-13 at 17 00 19" src="https://user-images.githubusercontent.com/458591/212364732-f87b289d-3f4a-4e27-9417-9ed33d6153e4.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-blame-tweaks.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
