### PR TITLE
create disable feedback survey site config option

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -135,6 +135,7 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
     // TODO add a component layer as the parent of the Layout component rendering "top-level" routes that do not render the navbar,
     // so that Layout can always render the navbar.
     const needsSiteInit = window.context?.needsSiteInit
+    const disableFeedbackSurvey = window.context?.site['disableFeedbackSurvey']
     const isSiteInit = props.location.pathname === PageRoutes.SiteAdminInit
     const isSignInOrUp =
         props.location.pathname === PageRoutes.SignIn ||
@@ -218,7 +219,7 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
                 settingsCascade={props.settingsCascade}
                 isSourcegraphDotCom={props.isSourcegraphDotCom}
             />
-            {!isSiteInit && !isSignInOrUp && !props.isSourcegraphDotCom && (
+            {!isSiteInit && !isSignInOrUp && !props.isSourcegraphDotCom && !disableFeedbackSurvey && (
                 <SurveyToast authenticatedUser={props.authenticatedUser} />
             )}
             {!isSiteInit && !isSignInOrUp && (

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -135,7 +135,7 @@ export const Layout: React.FunctionComponent<React.PropsWithChildren<LayoutProps
     // TODO add a component layer as the parent of the Layout component rendering "top-level" routes that do not render the navbar,
     // so that Layout can always render the navbar.
     const needsSiteInit = window.context?.needsSiteInit
-    const disableFeedbackSurvey = window.context?.site['disableFeedbackSurvey']
+    const disableFeedbackSurvey = window.context?.disableFeedbackSurvey
     const isSiteInit = props.location.pathname === PageRoutes.SiteAdminInit
     const isSignInOrUp =
         props.location.pathname === PageRoutes.SignIn ||

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -67,7 +67,11 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
      */
     site: Pick<
         SiteConfiguration,
-        'auth.public' | 'update.channel' | 'disableNonCriticalTelemetry' | 'authz.enforceForSiteAdmins'
+        | 'auth.public'
+        | 'update.channel'
+        | 'disableNonCriticalTelemetry'
+        | 'authz.enforceForSiteAdmins'
+        | 'disableFeedbackSurvey'
     >
 
     /** Whether access tokens are enabled. */
@@ -171,6 +175,9 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
     RedirectUnsupportedBrowser?: boolean
 
     outboundRequestLogLimit?: number
+
+    /** Whether the feedback survey is enabled. */
+    disableFeedbackSurvey?: boolean
 }
 
 export interface BrandAssets {

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -67,11 +67,7 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
      */
     site: Pick<
         SiteConfiguration,
-        | 'auth.public'
-        | 'update.channel'
-        | 'disableNonCriticalTelemetry'
-        | 'authz.enforceForSiteAdmins'
-        | 'disableFeedbackSurvey'
+        'auth.public' | 'update.channel' | 'disableNonCriticalTelemetry' | 'authz.enforceForSiteAdmins'
     >
 
     /** Whether access tokens are enabled. */

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -118,6 +118,8 @@ type JSContext struct {
 	LicenseInfo *hooks.LicenseInfo `json:"licenseInfo"`
 
 	OutboundRequestLogLimit int `json:"outboundRequestLogLimit"`
+
+	DisableFeedbackSurvey bool `json:"disableFeedbackSurvey"`
 }
 
 // NewJSContextFromRequest populates a JSContext struct from the HTTP
@@ -254,6 +256,8 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		LicenseInfo: licenseInfo,
 
 		OutboundRequestLogLimit: conf.Get().OutboundRequestLogLimit,
+
+		DisableFeedbackSurvey: conf.Get().DisableFeedbackSurvey,
 	}
 }
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2298,6 +2298,8 @@ type SiteConfiguration struct {
 	DisableAutoCodeHostSyncs bool `json:"disableAutoCodeHostSyncs,omitempty"`
 	// DisableAutoGitUpdates description: Disable periodically fetching git contents for existing repositories.
 	DisableAutoGitUpdates bool `json:"disableAutoGitUpdates,omitempty"`
+	// DisableFeedbackSurvey description: Disable the feedback survey
+	DisableFeedbackSurvey bool `json:"disableFeedbackSurvey,omitempty"`
 	// DisableNonCriticalTelemetry description: Disable aggregated event counts from being sent to Sourcegraph.com via pings.
 	DisableNonCriticalTelemetry bool `json:"disableNonCriticalTelemetry,omitempty"`
 	// DisablePublicRepoRedirects description: Disable redirects to sourcegraph.com when visiting public repositories that can't exist on this server.
@@ -2504,6 +2506,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "defaultRateLimit")
 	delete(m, "disableAutoCodeHostSyncs")
 	delete(m, "disableAutoGitUpdates")
+	delete(m, "disableFeedbackSurvey")
 	delete(m, "disableNonCriticalTelemetry")
 	delete(m, "disablePublicRepoRedirects")
 	delete(m, "dotcom")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -617,6 +617,12 @@
       "default": false,
       "group": "Misc."
     },
+    "disableFeedbackSurvey": {
+      "description": "Disable the feedback survey",
+      "type": "boolean",
+      "default": false,
+      "group": "Misc."
+    },
     "disableAutoGitUpdates": {
       "description": "Disable periodically fetching git contents for existing repositories.",
       "type": "boolean",


### PR DESCRIPTION
Adding the ability to disable feedback survey from site config. 

Fixes [this](https://sourcegraph.slack.com/archives/C03TGHH1S3V/p1673402495952789) issue from #escalation-engineering. 

We struggled a bit to get this working because it seems that site config options are splatted into the `window.context` object, but the `window.context.site` object _also_ has a subset of the site configuration options, and it's not clear to me how that's populated and which we should be using. Using `window.context.disableFeedbackSurvey` works locally, but I'm not super confident things will work as expected elsewhere because I couldn't actually find where we query the site config and set those options. 

## Test plan
Tested manually that setting the site config option `disableFeedbackSurvey` stops the feedback survey from showing up.


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
