### PR TITLE
dont trigger when PR is merged

### DIFF
--- a/.github/workflows/release-protector.yml
+++ b/.github/workflows/release-protector.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     types:
       [
-        closed,
         edited,
         opened,
         synchronize,


### PR DESCRIPTION
The workflow gets triggered when existing PRs that were created before this were either closed/merged. This ensures the action doesn't start for those cases.

[Sample](https://github.com/sourcegraph/sourcegraph/pull/46341#issuecomment-1382231205)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Fingers crossed.