### PR TITLE
codeintel: Add code graph data link next to settings in repo page

### DIFF
--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo } from 'react'
 
-import { mdiCloudDownload, mdiCog } from '@mdi/js'
+import { mdiCloudDownload, mdiCog, mdiBrain } from '@mdi/js'
 import { RouteComponentProps } from 'react-router'
 import { Observable } from 'rxjs'
 
@@ -72,6 +72,11 @@ const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Repository
                         <Icon aria-hidden={true} svgPath={mdiCloudDownload} /> Clone now
                     </Button>
                 )}{' '}
+                <Tooltip content="Repository code graph data">
+                    <Button to={`/${node.name}/-/code-graph`} variant="secondary" size="sm" as={Link}>
+                        <Icon aria-hidden={true} svgPath={mdiBrain} /> Code graph data
+                    </Button>
+                </Tooltip>{' '}
                 <Tooltip content="Repository settings">
                     <Button to={`/${node.name}/-/settings`} variant="secondary" size="sm" as={Link}>
                         <Icon aria-hidden={true} svgPath={mdiCog} /> Settings


### PR DESCRIPTION
Fixes #46462 by adding a button to the repos page next to the current settings button.

![image](https://user-images.githubusercontent.com/103087/212411663-159be4cf-58b1-48e8-9f46-9f8f595e488b.png)

## Test plan

Looked at UI, button was there.

## App preview:

- [Web](https://sg-web-ef-code-graph-link.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
