### PR TITLE
codeintel: Ensure configuration edit page doesn't lie about its own scope

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/components/BranchTargetSettings.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/BranchTargetSettings.tsx
@@ -11,7 +11,6 @@ import { ObjectsMatchingGitPattern } from './ObjectsMatchingGitPattern'
 import { ReposMatchingPatternList } from './ReposMatchingPatternList'
 
 export interface BranchTargetSettingsProps {
-    repoId?: string
     policy: CodeIntelligenceConfigurationPolicyFields
     setPolicy: (
         updater: (
@@ -22,7 +21,6 @@ export interface BranchTargetSettingsProps {
 }
 
 export const BranchTargetSettings: FunctionComponent<React.PropsWithChildren<BranchTargetSettingsProps>> = ({
-    repoId,
     policy,
     setPolicy,
     disabled = false,
@@ -46,7 +44,7 @@ export const BranchTargetSettings: FunctionComponent<React.PropsWithChildren<Bra
                 message="Required."
             />
 
-            {repoId || policy.repository ? (
+            {policy.repository ? (
                 <div className="mb-3">
                     This configuration policy applies only to {policy.repository?.name || 'the current repository'}.
                 </div>
@@ -73,7 +71,7 @@ export const BranchTargetSettings: FunctionComponent<React.PropsWithChildren<Bra
             />
 
             <ObjectsMatchingGitPattern
-                repoId={repoId || policy.repository?.id}
+                repoId={policy.repository?.id}
                 type={policy.type}
                 pattern={policy.pattern}
                 setPattern={pattern => updatePolicy({ ...(policy || nullPolicy), pattern })}

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.story.tsx
@@ -174,7 +174,7 @@ GlobalPage.args = {
 export const RepositoryPage = Template.bind({})
 RepositoryPage.args = {
     ...defaults,
-    repo: { id: '42' },
+    repo: { id: '42', name: 'github.com/test/repo' },
 }
 RepositoryPage.parameters = {
     // Keep snapshots for one variant

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
@@ -24,7 +24,7 @@ export interface CodeIntelConfigurationPolicyPageProps
     extends RouteComponentProps<{ id: string }>,
         ThemeProps,
         TelemetryProps {
-    repo?: { id: string }
+    repo?: { id: string; name: string }
     indexingEnabled?: boolean
     history: H.History
 }
@@ -165,14 +165,11 @@ export const CodeIntelConfigurationPolicyPage: FunctionComponent<
 
             <Container className="container form mb-3">
                 <BranchTargetSettings
-                    repoId={repo?.id}
-                    policy={policy}
+                    policy={{ ...policy, ...(!policy.id ? { repository: repo } : {}) }}
                     setPolicy={setPolicy}
                     disabled={policy.protected}
                 />
-
                 <RetentionSettings policy={policy} setPolicy={setPolicy} />
-
                 {indexingEnabled && <IndexingSettings repo={repo} policy={policy} setPolicy={setPolicy} />}
             </Container>
 

--- a/client/web/src/enterprise/codeintel/repo/RepositoryCodeIntelArea.tsx
+++ b/client/web/src/enterprise/codeintel/repo/RepositoryCodeIntelArea.tsx
@@ -24,7 +24,7 @@ import { CodeIntelUploadsPageProps } from '../uploads/pages/CodeIntelUploadsPage
 import { CodeIntelSidebar, CodeIntelSideBarGroups } from './CodeIntelSidebar'
 
 export interface CodeIntelAreaRouteContext extends ThemeProps, TelemetryProps {
-    repo: { id: string }
+    repo: { id: string; name: string }
     authenticatedUser: AuthenticatedUser | null
 }
 


### PR DESCRIPTION
The old frontend behavior made global policies look as if they were scoped to a single repository when viewed from that repository's settings page (all matching configuration policies are visible from the repo settings page, which include global policies). This allowed a user to edit a global policy to auto-index what they _thought_ (and was very clearly indicated as such by the UI) was scoped to a single repository when in actuality they turned on indexing for every branch of every repo.

**That's a dumb UI.**

This PR fixes this UI quirk by using the repository implied by the URL route only when there's no policy identifier - when it's loaded from the DB we use whatever it's assigned, regardless if it's empty or not.

Fixes #46463.

## Test plan

Tested what appears in the frontend under different routes.

## App preview:

- [Web](https://sg-web-ef-fix-ui-lies.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
