### PR TITLE
web: make `esbuild` work with `pnpm`

### DIFF
--- a/client/build-config/src/esbuild/stylePlugin.ts
+++ b/client/build-config/src/esbuild/stylePlugin.ts
@@ -10,7 +10,7 @@ import sass from 'sass'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import postcssConfig from '../../../../postcss.config'
-import { NODE_MODULES_PATH, ROOT_PATH } from '../paths'
+import { NODE_MODULES_PATH, ROOT_PATH, WORKSPACE_NODE_MODULES_PATHS } from '../paths'
 
 /**
  * An esbuild plugin that builds .css and .scss stylesheets (including support for CSS modules).
@@ -101,7 +101,7 @@ export const stylePlugin: esbuild.Plugin = {
         const resolver = ResolverFactory.createResolver({
             fileSystem: new CachedInputFileSystem(fs, 4000),
             extensions: ['.css', '.scss'],
-            modules: [NODE_MODULES_PATH],
+            modules: [NODE_MODULES_PATH, ...WORKSPACE_NODE_MODULES_PATHS],
             unsafeCache: true,
         })
 

--- a/client/build-config/src/paths.ts
+++ b/client/build-config/src/paths.ts
@@ -1,4 +1,5 @@
-import { realpathSync } from 'fs'
+/* eslint-disable no-sync */
+import fs from 'fs'
 import path from 'path'
 
 // NOTE: use fs.realpathSync() in addition to path.resolve() to resolve
@@ -9,7 +10,7 @@ export function resolveWithSymlink(...args: string[]): string {
     const resolvedPath = path.resolve(...args)
 
     try {
-        return realpathSync(resolvedPath)
+        return fs.realpathSync(resolvedPath)
     } catch {
         return resolvedPath
     }
@@ -21,3 +22,11 @@ export const NODE_MODULES_PATH = resolveWithSymlink(ROOT_PATH, 'node_modules')
 export const MONACO_EDITOR_PATH = resolveWithSymlink(NODE_MODULES_PATH, 'monaco-editor')
 export const STATIC_ASSETS_PATH = resolveWithSymlink(ROOT_PATH, 'ui/assets')
 export const STATIC_INDEX_PATH = resolveWithSymlink(STATIC_ASSETS_PATH, 'index.html')
+
+function getWorkspaceNodeModulesPaths(): string[] {
+    const workspaces = fs.readdirSync(WORKSPACES_PATH)
+    const nodeModulesPaths = workspaces.map(workspace => resolveWithSymlink(WORKSPACES_PATH, workspace, 'node_modules'))
+    return nodeModulesPaths
+}
+
+export const WORKSPACE_NODE_MODULES_PATHS = getWorkspaceNodeModulesPaths()


### PR DESCRIPTION
## Context

Get `esbuild` working with `pnpm`. 

Workspaces are linked through their `node_modules` folders instead of the root `node_modules` folder. So we need to tell `esbuild` where to look for them.

## Test plan

1. `DEV_WEB_BUILDER=esbuild sg start`
2. Open the web application.
3. It works! 

## App preview:

- [Web](https://sg-web-vb-fix-esbuild.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
