### PR TITLE
build-tracker: track notifications for a build

### DIFF
--- a/dev/build-tracker/build.go
+++ b/dev/build-tracker/build.go
@@ -122,6 +122,14 @@ func (j *Job) failed() bool {
 	return !j.SoftFailed && j.exitStatus() > 0
 }
 
+func (j *Job) state() string {
+	return strp(j.State)
+}
+
+func (j *Job) hasTimedOut() bool {
+	return j.state() == "timed_out"
+}
+
 // Pipeline wraps a buildkite.Pipeline and provides convenience functions to access values of the wrapped pipeline is a safe maner
 type Pipeline struct {
 	buildkite.Pipeline `json:"pipeline"`

--- a/dev/build-tracker/build.go
+++ b/dev/build-tracker/build.go
@@ -27,7 +27,7 @@ type Build struct {
 	// Notification is the details about the notification that was sent for this build
 	Notification *SlackNotification
 
-	// Mutex is used to to control and stop other changes being made to the build
+	// Mutex is used to to control and stop other changes being made to the build.
 	sync.Mutex
 }
 

--- a/dev/build-tracker/build.go
+++ b/dev/build-tracker/build.go
@@ -24,7 +24,7 @@ type Build struct {
 	// ConsecutiveFailure indicates whether this build is the nth consecutive failure.
 	ConsecutiveFailure int `json:"consecutiveFailures"`
 
-	// Notification is the details about the notification that was sent for this build
+	// Notification is the details about the notification that was sent for this build.
 	Notification *SlackNotification
 
 	// Mutex is used to to control and stop other changes being made to the build.

--- a/dev/build-tracker/main.go
+++ b/dev/build-tracker/main.go
@@ -20,6 +20,13 @@ var ErrUnwantedEvent = errors.New("Unwanted event received")
 
 var nowFunc func() time.Time = time.Now
 
+// CleanUpInterval determines how often the old build cleaner should run
+var CleanUpInterval = 5 * time.Minute
+
+// BuildExpiryWindow defines the window for a build to be consider 'valid'. A build older than this window
+// will be eligible for clean up.
+var BuildExpiryWindow = 4 * time.Hour
+
 const DefaultChannel = "#william-buildchecker-webhook-test"
 
 // Server is the http server that listens for events from Buildkite. The server tracks builds and their associated jobs
@@ -286,7 +293,7 @@ func main() {
 	logger.Info("config loaded from environment", log.Object("config", log.String("SlackChannel", serverConf.SlackChannel), log.Bool("Production", serverConf.Production)))
 	server := NewServer(logger, *serverConf)
 
-	stopFn := server.startOldBuildCleaner(5*time.Minute, 24*time.Hour)
+	stopFn := server.startOldBuildCleaner(CleanUpInterval, BuildExpiryWindow)
 	defer stopFn()
 
 	if server.config.Production {

--- a/dev/build-tracker/main.go
+++ b/dev/build-tracker/main.go
@@ -206,7 +206,7 @@ func (s *Server) notifyIfFailed(build *Build) error {
 	if build.hasFailed() {
 		s.logger.Info("detected failed build - sending notification", log.Int("buildNumber", intp(build.Number)))
 		// We lock the build while we send a notificationn so that we can ensure any late jobs do not interfere with what
-		// we're about to send
+		// we're about to send.
 		build.Lock()
 		defer build.Unlock()
 		var err error

--- a/dev/build-tracker/slack.go
+++ b/dev/build-tracker/slack.go
@@ -85,7 +85,7 @@ func (c *NotificationClient) sendUpdatedMessage(build *Build, previous *SlackNot
 		return previous, err
 	}
 
-	// Slack responds with the message timestamp and a channel, which you have to use when you want to update the message
+	// Slack responds with the message timestamp and a channel, which you have to use when you want to update the message.
 	var id, channel string
 	logger.Debug("sending updated notification")
 	msgOptBlocks := slack.MsgOptionBlocks(blocks...)

--- a/dev/build-tracker/slack.go
+++ b/dev/build-tracker/slack.go
@@ -27,7 +27,7 @@ type SlackNotification struct {
 	//SentAt is the time the notification got sent
 	SentAt time.Time
 	// ID is the unique idenfifier which represents this notification in Slack. Typically this is the timestamp as
-	// is returned by the Slack API upon successful send of a notification
+	// is returned by the Slack API upon successful send of a notification.
 	ID string
 	// ChannelID is the channelID as returned by the Slack API after successful sending of a notification. It is NOT
 	// the traditional channel you're use to that starts with a '#'. Instead it's the global ID for that channel used by

--- a/dev/build-tracker/slack.go
+++ b/dev/build-tracker/slack.go
@@ -154,6 +154,9 @@ func (c *NotificationClient) createMessageBlocks(logger log.Logger, build *Build
 	for i := 0; i < JobShowLimit && i < len(failedJobs); i++ {
 		j := failedJobs[i]
 		jobSection += fmt.Sprintf("• %s", *j.Name)
+		if j.hasTimedOut() {
+			jobSection += "(Timed out)"
+		}
 		if j.WebURL != "" {
 			jobSection += fmt.Sprintf(" - <%s|logs>", j.WebURL)
 		}

--- a/dev/build-tracker/slack.go
+++ b/dev/build-tracker/slack.go
@@ -24,7 +24,7 @@ type NotificationClient struct {
 	channel string
 }
 type SlackNotification struct {
-	//SentAt is the time the notification got sent
+	// SentAt is the time the notification got sent.
 	SentAt time.Time
 	// ID is the unique idenfifier which represents this notification in Slack. Typically this is the timestamp as
 	// is returned by the Slack API upon successful send of a notification.
@@ -89,7 +89,7 @@ func (c *NotificationClient) sendUpdatedMessage(build *Build, previous *SlackNot
 	var id, channel string
 	logger.Debug("sending updated notification")
 	msgOptBlocks := slack.MsgOptionBlocks(blocks...)
-	// Note: for UpdateMessage using the #channel-name format doesn't work, you need the Slack ChannelID
+	// Note: for UpdateMessage using the #channel-name format doesn't work, you need the Slack ChannelID.
 	channel, id, _, err = c.slack.UpdateMessage(previous.ChannelID, previous.ID, msgOptBlocks)
 	if err != nil {
 		logger.Error("failed to update message", log.Error(err))
@@ -107,7 +107,7 @@ func (c *NotificationClient) sendNewMessage(build *Build) (*SlackNotification, e
 	if err != nil {
 		return build.Notification, err
 	}
-	// Slack responds with the message timestamp and a channel, which you have to use when you want to update the message
+	// Slack responds with the message timestamp and a channel, which you have to use when you want to update the message.
 	var id, channel string
 
 	logger.Debug("sending new notification")

--- a/dev/build-tracker/slack.go
+++ b/dev/build-tracker/slack.go
@@ -23,6 +23,33 @@ type NotificationClient struct {
 	logger  log.Logger
 	channel string
 }
+type SlackNotification struct {
+	//SentAt is the time the notification got sent
+	SentAt time.Time
+	// ID is the unique idenfifier which represents this notification in Slack. Typically this is the timestamp as
+	// is returned by the Slack API upon successful send of a notification
+	ID string
+	// ChannelID is the channelID as returned by the Slack API after successful sending of a notification. It is NOT
+	// the traditional channel you're use to that starts with a '#'. Instead it's the global ID for that channel used by
+	// Slack.
+	ChannelID string
+}
+
+func (n *SlackNotification) Equals(o *SlackNotification) bool {
+	if o == nil {
+		return false
+	}
+
+	return n.ID == o.ID && n.ChannelID == o.ChannelID && n.SentAt.Equal(o.SentAt)
+}
+
+func NewSlackNotification(id, channel string) *SlackNotification {
+	return &SlackNotification{
+		SentAt:    time.Now(),
+		ID:        id,
+		ChannelID: channel,
+	}
+}
 
 func NewNotificationClient(logger log.Logger, slackToken, githubToken, channel string) *NotificationClient {
 	debug := os.Getenv("BUILD_TRACKER_SLACK_DEBUG") == "1"
@@ -46,25 +73,53 @@ func (c *NotificationClient) getTeammateForBuild(build *Build) (*team.Teammate, 
 	return c.team.ResolveByCommitAuthor(context.Background(), "sourcegraph", "sourcegraph", build.commit())
 }
 
-func (c *NotificationClient) sendFailedBuild(build *Build) error {
+func (c *NotificationClient) sendUpdatedMessage(build *Build, previous *SlackNotification) (*SlackNotification, error) {
+	if previous == nil {
+		return nil, fmt.Errorf("cannot update message with nil notification")
+	}
 	logger := c.logger.With(log.Int("buildNumber", build.number()), log.String("channel", c.channel))
 	logger.Debug("creating slack json")
 
 	blocks, err := c.createMessageBlocks(logger, build)
 	if err != nil {
-		return err
+		return previous, err
 	}
 
-	logger.Debug("sending notification")
+	// Slack responds with the message timestamp and a channel, which you have to use when you want to update the message
+	var id, channel string
+	logger.Debug("sending updated notification")
 	msgOptBlocks := slack.MsgOptionBlocks(blocks...)
-	_, _, err = c.slack.PostMessage(c.channel, msgOptBlocks)
+	// Note: for UpdateMessage using the #channel-name format doesn't work, you need the Slack ChannelID
+	channel, id, _, err = c.slack.UpdateMessage(previous.ChannelID, previous.ID, msgOptBlocks)
+	if err != nil {
+		logger.Error("failed to update message", log.Error(err))
+		return previous, err
+	}
+
+	return NewSlackNotification(id, channel), nil
+}
+
+func (c *NotificationClient) sendNewMessage(build *Build) (*SlackNotification, error) {
+	logger := c.logger.With(log.Int("buildNumber", build.number()), log.String("channel", c.channel))
+	logger.Debug("creating slack json")
+
+	blocks, err := c.createMessageBlocks(logger, build)
+	if err != nil {
+		return build.Notification, err
+	}
+	// Slack responds with the message timestamp and a channel, which you have to use when you want to update the message
+	var id, channel string
+
+	logger.Debug("sending new notification")
+	msgOptBlocks := slack.MsgOptionBlocks(blocks...)
+	channel, id, err = c.slack.PostMessage(c.channel, msgOptBlocks)
 	if err != nil {
 		logger.Error("failed to post message", log.Error(err))
-		return err
+		return nil, err
 	}
 
 	logger.Info("notification posted")
-	return nil
+	return NewSlackNotification(id, channel), nil
 }
 
 func commitLink(msg, commit string) string {


### PR DESCRIPTION
Sometimes we would get notified by Buildkite that a build has failed and
send a notification, but we wouldn't have all the jobs of a build by the
time we send the notification. Then we got notified of a job that failed
for that build, but we already sent a notification - sometimes leading
  to a notification with an empty list of failed jobs.

So now, we track the last notification we sent for a build. If we have
sent a notification for a build AND we receive a job failed event for
that build, we update the message in Slack.

While adding jobs and sending notifications, the build is also now
locked. To ensure the jobs aren't modified while we're building a
notification.

## Test plan
Unit tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
