### PR TITLE
fix esbuild when using pnpm

### DIFF
--- a/client/build-config/src/esbuild/stylePlugin.ts
+++ b/client/build-config/src/esbuild/stylePlugin.ts
@@ -10,7 +10,7 @@ import sass from 'sass'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import postcssConfig from '../../../../postcss.config'
-import { NODE_MODULES_PATH, ROOT_PATH } from '../paths'
+import { NODE_MODULES_PATH, ROOT_PATH, WORKSPACES_PATH } from '../paths'
 
 /**
  * An esbuild plugin that builds .css and .scss stylesheets (including support for CSS modules).
@@ -101,7 +101,7 @@ export const stylePlugin: esbuild.Plugin = {
         const resolver = ResolverFactory.createResolver({
             fileSystem: new CachedInputFileSystem(fs, 4000),
             extensions: ['.css', '.scss'],
-            modules: [NODE_MODULES_PATH],
+            modules: [NODE_MODULES_PATH, path.join(WORKSPACES_PATH, 'web', 'node_modules')],
             unsafeCache: true,
         })
 


### PR DESCRIPTION
Now that we use pnpm, the `@sourcegraph/branded` and other cross-worksapce deps are symlinked from (eg) `client/web/node_modules/@sourcegraph/branded` not the root `node_modules/@sourcegraph/branded`. Eslint plugins that use their own module resolver need to be updated t o reflect this.




## Test plan

n/a; esbuild is an experimental dev option only

## App preview:

- [Web](https://sg-web-sqs-esbuild-pnpm-fix.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
