### PR TITLE
set process.env.NODE_DEBUG in esbuild

### DIFF
--- a/client/web/dev/utils/environment-config.ts
+++ b/client/web/dev/utils/environment-config.ts
@@ -10,6 +10,8 @@ type WEB_BUILDER = 'esbuild' | 'webpack'
 
 const NODE_ENV = process.env.NODE_ENV || 'development'
 
+const NODE_DEBUG = process.env.NODE_DEBUG
+
 export const IS_DEVELOPMENT = NODE_ENV === 'development'
 export const IS_PRODUCTION = NODE_ENV === 'production'
 
@@ -20,6 +22,7 @@ export const ENVIRONMENT_CONFIG = {
      * ----------------------------------------
      */
     NODE_ENV,
+    NODE_DEBUG,
     // Determines if build is running on CI.
     CI: getEnvironmentBoolean('CI'),
     // Determines if the build will be used for integration tests.


### PR DESCRIPTION
Fixes the following browser devtools console error (when using esbuild) that occurs when `process.env.NODE_DEBUG` is evaluated:

```
logger.ts:27 Error sending search context to extensions ReferenceError: process is not defined
    at node_modules/.pnpm/util@0.12.5/node_modules/util/util.js
```




## Test plan

n/a; esbuild is an experimental dev option only

## App preview:

- [Web](https://sg-web-sqs-esbuild-node-debug-fix.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
