### PR TITLE
Add exclusion API for the insight connection gql field

### DIFF
--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -467,6 +467,7 @@ type InsightViewQueryArgs struct {
 	First                *int32
 	After                *string
 	Id                   *graphql.ID
+	ExcludeIds           *[]graphql.ID
 	Find                 *string
 	IsFrozen             *bool
 	Filters              *InsightViewFiltersInput

--- a/cmd/frontend/graphqlbackend/insights.graphql
+++ b/cmd/frontend/graphqlbackend/insights.graphql
@@ -188,6 +188,10 @@ extend type Query {
         after: String
         id: ID
         """
+        Allow you to exclude subset of insights by their ids.
+        """
+        excludeIds: [ID!]
+        """
         Allow you to search insight views by their title or data series labels.
         """
         find: String

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -1195,10 +1195,8 @@ func (r *InsightViewQueryConnectionResolver) computeViews(ctx context.Context) (
 				if r.err != nil {
 					return
 				}
-
 				insightIDs = append(insightIDs, unique)
 			}
-
 			args.ExcludeIDs = insightIDs
 		}
 

--- a/enterprise/internal/insights/resolvers/insight_view_resolvers.go
+++ b/enterprise/internal/insights/resolvers/insight_view_resolvers.go
@@ -1187,6 +1187,21 @@ func (r *InsightViewQueryConnectionResolver) computeViews(ctx context.Context) (
 			args.UniqueID = unique
 		}
 
+		if r.args.ExcludeIds != nil {
+			var insightIDs []string
+			for _, id := range *r.args.ExcludeIds {
+				var unique string
+				r.err = relay.UnmarshalSpec(id, &unique)
+				if r.err != nil {
+					return
+				}
+
+				insightIDs = append(insightIDs, unique)
+			}
+
+			args.ExcludeIDs = insightIDs
+		}
+
 		insights, err := r.insightStore.GetAllMapped(ctx, args)
 		if err != nil {
 			r.err = err

--- a/enterprise/internal/insights/store/insight_store.go
+++ b/enterprise/internal/insights/store/insight_store.go
@@ -47,6 +47,7 @@ func (s *InsightStore) Transact(ctx context.Context) (*InsightStore, error) {
 type InsightQueryArgs struct {
 	UniqueIDs   []string
 	UniqueID    string
+	ExcludeIDs  []string
 	UserID      []int
 	OrgID       []int
 	DashboardID int
@@ -104,6 +105,13 @@ func (s *InsightStore) GetAll(ctx context.Context, args InsightQueryArgs) ([]typ
 			elems = append(elems, sqlf.Sprintf("%s", id))
 		}
 		preds = append(preds, sqlf.Sprintf("iv.unique_id IN (%s)", sqlf.Join(elems, ",")))
+	}
+	if len(args.ExcludeIDs) > 0 {
+		exclusions := make([]*sqlf.Query, 0, len(args.UniqueIDs))
+		for _, id := range args.ExcludeIDs {
+			exclusions = append(exclusions, sqlf.Sprintf("%s", id))
+		}
+		preds = append(preds, sqlf.Sprintf("iv.unique_id NOT IN (%s)", sqlf.Join(exclusions, ",")))
 	}
 	if len(args.UniqueID) > 0 {
 		preds = append(preds, sqlf.Sprintf("iv.unique_id = %s", args.UniqueID))

--- a/enterprise/internal/insights/store/insight_store_test.go
+++ b/enterprise/internal/insights/store/insight_store_test.go
@@ -795,6 +795,65 @@ func TestGetAll(t *testing.T) {
 			t.Errorf("unexpected insight view series want/got: %s", diff)
 		}
 	})
+	t.Run("test exclude insight ids results", func(t *testing.T) {
+		store := NewInsightStore(insightsDB)
+		got, err := store.GetAll(ctx, InsightQueryArgs{ExcludeIDs: []string{"b", "e"}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		series1RepoCriteria := "repo:a"
+		want := []types.InsightViewSeries{
+			{
+				ViewID:               2,
+				UniqueID:             "d",
+				InsightSeriesID:      1,
+				SeriesID:             "series-id-1",
+				Title:                "user can view 1",
+				Description:          "",
+				Query:                "query-1",
+				CreatedAt:            now,
+				OldestHistoricalAt:   now,
+				LastRecordedAt:       now,
+				NextRecordingAfter:   now,
+				LastSnapshotAt:       now,
+				NextSnapshotAfter:    now,
+				Label:                "label2-1",
+				LineColor:            "color",
+				SampleIntervalUnit:   "MONTH",
+				SampleIntervalValue:  1,
+				PresentationType:     types.PresentationType("LINE"),
+				GenerationMethod:     types.GenerationMethod("search"),
+				SupportsAugmentation: true,
+				RepositoryCriteria:   &series1RepoCriteria,
+			},
+			{
+				ViewID:               2,
+				UniqueID:             "d",
+				InsightSeriesID:      2,
+				SeriesID:             "series-id-2",
+				Title:                "user can view 1",
+				Description:          "",
+				Query:                "query-2",
+				CreatedAt:            now,
+				OldestHistoricalAt:   now,
+				LastRecordedAt:       now,
+				NextRecordingAfter:   now,
+				LastSnapshotAt:       now,
+				NextSnapshotAfter:    now,
+				Label:                "label2-2",
+				LineColor:            "color",
+				SampleIntervalUnit:   "MONTH",
+				SampleIntervalValue:  1,
+				PresentationType:     types.PresentationType("LINE"),
+				GenerationMethod:     types.GenerationMethod("search"),
+				GroupBy:              &groupByRepo,
+				SupportsAugmentation: true,
+			},
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("unexpected insight view series want/got: %s", diff)
+		}
+	})
 }
 
 func TestGetAllOnDashboard(t *testing.T) {

--- a/enterprise/internal/insights/store/insight_store_test.go
+++ b/enterprise/internal/insights/store/insight_store_test.go
@@ -795,7 +795,7 @@ func TestGetAll(t *testing.T) {
 			t.Errorf("unexpected insight view series want/got: %s", diff)
 		}
 	})
-	t.Run("test exclude insight ids results", func(t *testing.T) {
+	t.Run("exclude insight ids from results", func(t *testing.T) {
 		store := NewInsightStore(insightsDB)
 		got, err := store.GetAll(ctx, InsightQueryArgs{ExcludeIDs: []string{"b", "e"}})
 		if err != nil {


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/46291

This PR adds exclusion API for the insight connection endpoint. We need to have it for the new add or remove insight UI where we will have a suggestion UI that shouldn't have insights that already have been included in the dashboard. 

## Test plan
- Check that response from insights gql request doesn't return insights with ids that you specified in the excludeIds argument 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
