### PR TITLE
web: disable flaky test

### DIFF
--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -125,7 +125,7 @@ describe('Search', () => {
 
     describe('Filter completion', () => {
         withSearchQueryInput(editorName => {
-            test(`Completing a negated filter should insert the filter with - prefix (${editorName})`, async () => {
+            test.skip(`Completing a negated filter should insert the filter with - prefix (${editorName})`, async () => {
                 testContext.overrideGraphQL({
                     ...commonSearchGraphQLResults,
                     ...createViewerSettingsGraphQLOverride(),


### PR DESCRIPTION
## Context

The issue to re-enable the test:
- https://github.com/sourcegraph/sourcegraph/issues/46467

## Test plan

CI

## App preview:

- [Web](https://sg-web-vb-disable-flaky-search-test-2.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
