### PR TITLE
.github/workflows: Do not run release protector on draft PRs

### DIFF
--- a/.github/workflows/release-protector.yml
+++ b/.github/workflows/release-protector.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   protect-pr:
     runs-on: ubuntu-latest
-    if: github.repository == 'sourcegraph/sourcegraph'
+    if: ${{ github.repository == 'sourcegraph/sourcegraph' && !github.event.pull_request.draft }}
     steps:
       - name: Check date and labels
         id: check-date-and-labels


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
