### PR TITLE
Add min_access_level to GitLab groups query

### DIFF
--- a/internal/extsvc/gitlab/groups.go
+++ b/internal/extsvc/gitlab/groups.go
@@ -19,7 +19,7 @@ func (c *Client) ListGroups(ctx context.Context, page int) (groups []*Group, has
 		return MockListGroups(ctx, page)
 	}
 
-	url := fmt.Sprintf("groups?per_page=100&page=%d", page)
+	url := fmt.Sprintf("groups?per_page=100&page=%d&min_access_level=10", page)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, false, err


### PR DESCRIPTION
When checking if a user belongs to a GitLab group to restrict signup, we hit the [/groups](https://docs.gitlab.com/ee/api/groups.html) endpoint and check whether any of the returned groups are in that endpoint.

However, this endpoint returns all _visible_ groups. Just because a group is visible to a user does not imply the user is a member of that group.

We need to add `min_access_level=10` to the query, so that the user has to, at minimum, be a guest on the group.

## Test plan

Manual verification

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
