### PR TITLE
batches: fix executor e2e test

### DIFF
--- a/enterprise/dev/ci/integration/executors/tester/main.go
+++ b/enterprise/dev/ci/integration/executors/tester/main.go
@@ -89,7 +89,7 @@ func main() {
 				Type:              "branch",
 				DiffStatAdded:     5,
 				DiffStatDeleted:   5,
-				BatchSpecID:       1,
+				BatchSpecID:       2,
 				BaseRepoID:        1,
 				UserID:            1,
 				BaseRev:           "1c94aaf85d51e9d016b8ce4639b9f022d94c52e6",


### PR DESCRIPTION
Fixes executors e2e test after https://github.com/sourcegraph/sourcegraph/pull/46341. Didn't realize this test had a dependency on that until it ran on `main`. The hardcoded batch spec ID needs to be 1 higher because there's now an initial empty batch spec before it.

## Test plan

Queued up main-dry-run build for this branch, [executor e2e passed](https://buildkite.com/sourcegraph/sourcegraph/builds/193583#0185b96a-bb9f-4b65-8773-e377ad00e9a4)!

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
