### PR TITLE
nix: switch to unpinned nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,18 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659956501,
-        "narHash": "sha256-7cF2zOaTLWcxmhPBpI1ZoThUy11M1QiY5pat0OXwg3c=",
+        "lastModified": 1673704454,
+        "narHash": "sha256-5Wdj1MgdOgn3+dMFIBtg+IAYZApjF8JzwLWDPieg0C4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6f38b43c8c84c800f93465b2241156419fd4fd52",
+        "rev": "a83ed85c14fcf242653df6f4b0974b7e1c73c6c6",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "6f38b43c8c84c800f93465b2241156419fd4fd52",
-        "type": "github"
+        "id": "nixpkgs",
+        "ref": "nixos-22.11",
+        "type": "indirect"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "The Sourcegraph developer environment Nix Flake";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=6f38b43c8c84c800f93465b2241156419fd4fd52";
+    nixpkgs.url = "nixpkgs/nixos-22.11";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
Previously we had a pinned input with nix flakes. This switches to following nixos-22.11. This will allow us to update inputs now via nix flake update.

Note: I don't pretend to understand flakes properly yet, so this might be doing something wrong.

Test Plan: nix develop
