### PR TITLE
Revert "web: disable flaky test"

### DIFF
--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -125,7 +125,7 @@ describe('Search', () => {
 
     describe('Filter completion', () => {
         withSearchQueryInput(editorName => {
-            test.skip(`Completing a negated filter should insert the filter with - prefix (${editorName})`, async () => {
+            test(`Completing a negated filter should insert the filter with - prefix (${editorName})`, async () => {
                 testContext.overrideGraphQL({
                     ...commonSearchGraphQLResults,
                     ...createViewerSettingsGraphQLOverride(),


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#46466

E2E is failing and main is blocked.

main-dry-run: https://github.com/sourcegraph/sourcegraph/tree/main-dry-run/revert-46466-vb/disable-flaky-search-test-2

# Test plan

CI should be green.