### PR TITLE
sg: ensure src-cli runs w/ client-only during setup

### DIFF
--- a/dev/sg/dependencies/helpers.go
+++ b/dev/sg/dependencies/helpers.go
@@ -245,12 +245,12 @@ func checkGitVersion(versionConstraint string) func(context.Context) error {
 
 func checkSrcCliVersion(versionConstraint string) func(context.Context) error {
 	return func(ctx context.Context) error {
-		lines, err := usershell.Command(ctx, "src version").StdOut().Run().Lines()
+		lines, err := usershell.Command(ctx, "src version -client-only").StdOut().Run().Lines()
 		if err != nil {
 			return errors.Wrapf(err, "failed to run 'src version'")
 		}
 
-		if len(lines) < 2 {
+		if len(lines) < 1 {
 			return errors.Newf("unexpected output from src: %s", strings.Join(lines, "\n"))
 		}
 		out := lines[0]

--- a/dev/sg/dependencies/mac.go
+++ b/dev/sg/dependencies/mac.go
@@ -133,7 +133,7 @@ var Mac = []category{
 		// src-cli is installed differently on Ubuntu and Mac
 		&dependency{
 			Name:  "src",
-			Check: checkAction(check.Combine(check.InPath("src"), checkSrcCliVersion(">= 4.0.2"))),
+			Check: checkAction(check.Combine(check.InPath("src"), checkSrcCliVersion(">= 4.2.0"))),
 			Fix:   cmdFix(`brew upgrade sourcegraph/src-cli/src-cli || brew install sourcegraph/src-cli/src-cli`),
 		},
 	),


### PR DESCRIPTION
Previously, src-cli version was ran without the --client-only flag, which triggered an external request. In some cases, users have their SRC_* env vars already set and pointing at their local instance, which will fail the check if the instance is not running already.

This is now corrected and the check will pass, because it only looks at the client version.

Test Plan: locally tested.

