### PR TITLE
Set server.PermsSyncer on enterprise repo-updater

### DIFF
--- a/enterprise/cmd/repo-updater/shared/shared.go
+++ b/enterprise/cmd/repo-updater/shared/shared.go
@@ -73,6 +73,10 @@ func EnterpriseInit(
 		return nil
 	}
 
+	if server != nil {
+		server.PermsSyncer = permsSyncer
+	}
+
 	workerStore := authz.MakeStore(observationCtx, db.Handle())
 	worker := authz.MakeWorker(ctx, observationCtx, workerStore, permsSyncer)
 	resetter := authz.MakeResetter(observationCtx, workerStore)


### PR DESCRIPTION
Fixes a regression introduced here: https://github.com/sourcegraph/sourcegraph/commit/6a48a769ac99cdfe5405987c20662bb2bbea02af#diff-287ca483a8d0fe7912baf07ffbea3a988d298e933144820ad7b015308e1aa361L58-L60

## Test plan

Verified that the "Schedule now" button in the user settings permissions page works again.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
