### PR TITLE
graphqlutil: Fix bug with truncating extra item for pagination and switch reverse to false by default

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver_test.go
@@ -79,24 +79,24 @@ func (*testConnectionStore) UnmarshalCursor(cursor string) (*int, error) {
 	return &id, nil
 }
 
-func newInt(n int) *int {
-	return &n
-}
-
-func newInt32(n int) *int32 {
+func int32Ptr(n int) *int32 {
 	num := int32(n)
 
 	return &num
 }
 
+func stringPtr(s string) *string {
+	return &s
+}
+
 func withFirstCA(first int, a *ConnectionResolverArgs) *ConnectionResolverArgs {
-	a.First = newInt32(first)
+	a.First = int32Ptr(first)
 
 	return a
 }
 
 func withLastCA(last int, a *ConnectionResolverArgs) *ConnectionResolverArgs {
-	a.Last = newInt32(last)
+	a.Last = int32Ptr(last)
 
 	return a
 }
@@ -277,33 +277,45 @@ func TestConnectionPageInfo(t *testing.T) {
 	}{
 		{
 			name: "default",
-			args: withFirstCA(20, &ConnectionResolverArgs{}),
+			args: &ConnectionResolverArgs{
+				First: int32Ptr(20),
+			},
 			want: &pageInfoResponse{startCursor: "0", endCursor: "1", hasNextPage: false, hasPreviousPage: false},
 		},
 		{
 			name: "first page",
-			args: withFirstCA(1, &ConnectionResolverArgs{}),
+			args: &ConnectionResolverArgs{
+				First: int32Ptr(1),
+			},
 			want: &pageInfoResponse{startCursor: "0", endCursor: "0", hasNextPage: true, hasPreviousPage: false},
 		},
 		{
 			name: "second page",
-			args: withAfterCA("0", withFirstCA(1, &ConnectionResolverArgs{})),
+			args: &ConnectionResolverArgs{
+				First: int32Ptr(1),
+				After: stringPtr("0"),
+			},
 			want: &pageInfoResponse{startCursor: "0", endCursor: "0", hasNextPage: true, hasPreviousPage: true},
 		},
 		{
 			name: "backward first page",
-			args: withBeforeCA("0", withLastCA(1, &ConnectionResolverArgs{})),
+			args: &ConnectionResolverArgs{
+				Last:   int32Ptr(1),
+				Before: stringPtr("0"),
+			},
 			want: &pageInfoResponse{startCursor: "1", endCursor: "1", hasNextPage: true, hasPreviousPage: true},
 		},
 		{
 			name: "backward first page without cursor",
-			args: withLastCA(1, &ConnectionResolverArgs{}),
+			args: &ConnectionResolverArgs{
+				Last: int32Ptr(1),
+			},
 			want: &pageInfoResponse{startCursor: "1", endCursor: "1", hasNextPage: false, hasPreviousPage: true},
 		},
 		{
 			name: "backward last page",
 			args: &ConnectionResolverArgs{
-				Last:   newInt32(20),
+				Last:   int32Ptr(20),
 				Before: stringPtr("0"),
 			},
 			want: &pageInfoResponse{startCursor: "1", endCursor: "0", hasNextPage: true, hasPreviousPage: false},
@@ -318,8 +330,4 @@ func TestConnectionPageInfo(t *testing.T) {
 			testResolverPageInfoResponse(t, resolver, store, test.want)
 		})
 	}
-}
-
-func stringPtr(s string) *string {
-	return &s
 }

--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -35,8 +35,8 @@ func (r *RepositoryResolver) Contributors(args *struct {
 		connectionArgs: connectionArgs,
 		repo:           r,
 	}
-	reverse := false
-	return graphqlutil.NewConnectionResolver[repositoryContributorResolver](connectionStore, connectionArgs, &graphqlutil.ConnectionResolverOptions{Reverse: &reverse})
+
+	return graphqlutil.NewConnectionResolver[repositoryContributorResolver](connectionStore, connectionArgs, &graphqlutil.ConnectionResolverOptions{})
 }
 
 type repositoryContributorConnectionStore struct {


### PR DESCRIPTION
## Note to reviewers, please read before reading the code

Originally I wanted to create two separate PRs - one to fix the bug with truncating the last item and the second to make the `Reverse` option `false` by default instead of `true` which is the current behaviour.

But as I was working with this, both these two are closely related with each other and it became difficult to keep them separate - which would have added more work on the second PR to fix the tests that I was already fixing in this one to account for the new default behavior.


So the end result against my own wishes is a single PR that does two things. I will explain the motivation behind each individually, although the source is the same - this PR being a result of working on #46475.


### Motivation #1: Bug fix of truncating the last item

This fixes two bugs with the truncating logic.

1. Truncating from the head when `last` is used is incorrect since the data set is already reversed as a result of underlying SQL query having to run the ORDER BY DESC operation.

2. Additionally, the current logic does not take the value of the `Reverse` option into account before truncating the first or the last item.

Explained with an example with in-line comments why even for `last` in the query args, truncating the last item from the slice is the right thing to do and vice versa for when `Reverse` is set to `true`.

### Motivation #2: Switch Reverse to false by default

Setting the value of `Reverse` to `true` will flip the resulting data set. This is also the default at the moment in the connection resolver library. This leads to the library sneakily reversing the data set by default which was a source of great confusion when I was working on #46475 and had me digging to understand why this was so. In my test cases I was struggling with off-by-one errors as a result of the combination of this and the above bug.

A library should not make default assumptions on the data set it handles. Instead this should be left as an explicit decision for the consumers of the library itself. If a developer uses this library to implement support for querying the API with both `first` and `last`, they would implement `ORDER BY ASC` in their SQL query to support `first` and `ORDER BY DESC` in their SQL query to support `last`. This then becomes an explicit expectation to receive the data set in the API in reverse when `last` is used. But when the internal library sneakily reverses it by default it leads to a breakdown of this expectation. 

~~Additionally, with `Reverse` set to `true` by default will mean that when the API is queried with `first`, even then the resulting data set is going to be reversed. This appears to have little utility from an API consumers viewpoint.~~

In the only current usage of `Reverse` (in the `RepositoryContributors` API) we explicitly set `Reverse` to false. And in my implementation in #46475, I found myself doing the same. 

Finally, in Go boolean default is `false` and it seems counter-intuitive that in our code we assume a nil value to be interpreted as `true`. And if the struct is also initialised with default values, then a non-nil default would set `Reverse` to `false` which would be against what the docs for the option describe as.




## Test plan

1. Updated tests
1. Builds should pass
1. Tested this change against the code in #46475 which has its own additional tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
