### PR TITLE
permissions-center: add `reason` and `triggered_by_user_id` columns to `permission_sync_jobs` table.

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -16460,6 +16460,19 @@
           "Comment": ""
         },
         {
+          "Name": "reason",
+          "Index": 18,
+          "TypeName": "text",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "Specifies why permissions sync job was triggered."
+        },
+        {
           "Name": "repository_id",
           "Index": 14,
           "TypeName": "integer",
@@ -16497,6 +16510,19 @@
           "IsGenerated": "NEVER",
           "GenerationExpression": "",
           "Comment": ""
+        },
+        {
+          "Name": "triggered_by_user_id",
+          "Index": 19,
+          "TypeName": "integer",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "Specifies an ID of a user who triggered a sync."
         },
         {
           "Name": "user_id",

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -16603,7 +16603,15 @@
           "ConstraintDefinition": ""
         }
       ],
-      "Constraints": null,
+      "Constraints": [
+        {
+          "Name": "permission_sync_jobs_triggered_by_user_id_fkey",
+          "ConstraintType": "f",
+          "RefTableName": "users",
+          "IsDeferrable": true,
+          "ConstraintDefinition": "FOREIGN KEY (triggered_by_user_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE"
+        }
+      ],
       "Triggers": []
     },
     {

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2562,6 +2562,8 @@ Indexes:
     "permission_sync_jobs_repository_id" btree (repository_id)
     "permission_sync_jobs_state" btree (state)
     "permission_sync_jobs_user_id" btree (user_id)
+Foreign-key constraints:
+    "permission_sync_jobs_triggered_by_user_id_fkey" FOREIGN KEY (triggered_by_user_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
 
 ```
 
@@ -3330,6 +3332,7 @@ Referenced by:
     TABLE "org_invitations" CONSTRAINT "org_invitations_recipient_user_id_fkey" FOREIGN KEY (recipient_user_id) REFERENCES users(id)
     TABLE "org_invitations" CONSTRAINT "org_invitations_sender_user_id_fkey" FOREIGN KEY (sender_user_id) REFERENCES users(id)
     TABLE "org_members" CONSTRAINT "org_members_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE RESTRICT
+    TABLE "permission_sync_jobs" CONSTRAINT "permission_sync_jobs_triggered_by_user_id_fkey" FOREIGN KEY (triggered_by_user_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
     TABLE "product_subscriptions" CONSTRAINT "product_subscriptions_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id)
     TABLE "registry_extension_releases" CONSTRAINT "registry_extension_releases_creator_user_id_fkey" FOREIGN KEY (creator_user_id) REFERENCES users(id)
     TABLE "registry_extensions" CONSTRAINT "registry_extensions_publisher_user_id_fkey" FOREIGN KEY (publisher_user_id) REFERENCES users(id)

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2535,25 +2535,27 @@ Stores errors that occurred while performing an out-of-band migration.
 
 # Table "public.permission_sync_jobs"
 ```
-      Column       |           Type           | Collation | Nullable |                     Default                      
--------------------+--------------------------+-----------+----------+--------------------------------------------------
- id                | integer                  |           | not null | nextval('permission_sync_jobs_id_seq'::regclass)
- state             | text                     |           |          | 'queued'::text
- failure_message   | text                     |           |          | 
- queued_at         | timestamp with time zone |           |          | now()
- started_at        | timestamp with time zone |           |          | 
- finished_at       | timestamp with time zone |           |          | 
- process_after     | timestamp with time zone |           |          | 
- num_resets        | integer                  |           | not null | 0
- num_failures      | integer                  |           | not null | 0
- last_heartbeat_at | timestamp with time zone |           |          | 
- execution_logs    | json[]                   |           |          | 
- worker_hostname   | text                     |           | not null | ''::text
- cancel            | boolean                  |           | not null | false
- repository_id     | integer                  |           |          | 
- user_id           | integer                  |           |          | 
- high_priority     | boolean                  |           | not null | false
- invalidate_caches | boolean                  |           | not null | false
+        Column        |           Type           | Collation | Nullable |                     Default                      
+----------------------+--------------------------+-----------+----------+--------------------------------------------------
+ id                   | integer                  |           | not null | nextval('permission_sync_jobs_id_seq'::regclass)
+ state                | text                     |           |          | 'queued'::text
+ failure_message      | text                     |           |          | 
+ queued_at            | timestamp with time zone |           |          | now()
+ started_at           | timestamp with time zone |           |          | 
+ finished_at          | timestamp with time zone |           |          | 
+ process_after        | timestamp with time zone |           |          | 
+ num_resets           | integer                  |           | not null | 0
+ num_failures         | integer                  |           | not null | 0
+ last_heartbeat_at    | timestamp with time zone |           |          | 
+ execution_logs       | json[]                   |           |          | 
+ worker_hostname      | text                     |           | not null | ''::text
+ cancel               | boolean                  |           | not null | false
+ repository_id        | integer                  |           |          | 
+ user_id              | integer                  |           |          | 
+ high_priority        | boolean                  |           | not null | false
+ invalidate_caches    | boolean                  |           | not null | false
+ reason               | text                     |           |          | 
+ triggered_by_user_id | integer                  |           |          | 
 Indexes:
     "permission_sync_jobs_pkey" PRIMARY KEY, btree (id)
     "permission_sync_jobs_process_after" btree (process_after)
@@ -2562,6 +2564,10 @@ Indexes:
     "permission_sync_jobs_user_id" btree (user_id)
 
 ```
+
+**reason**: Specifies why permissions sync job was triggered.
+
+**triggered_by_user_id**: Specifies an ID of a user who triggered a sync.
 
 # Table "public.permissions"
 ```

--- a/migrations/frontend/1673871310_add_columns_to_permission_sync_jobs_table/down.sql
+++ b/migrations/frontend/1673871310_add_columns_to_permission_sync_jobs_table/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE permission_sync_jobs
+    DROP COLUMN IF EXISTS reason,
+    DROP COLUMN IF EXISTS triggered_by_user_id;

--- a/migrations/frontend/1673871310_add_columns_to_permission_sync_jobs_table/metadata.yaml
+++ b/migrations/frontend/1673871310_add_columns_to_permission_sync_jobs_table/metadata.yaml
@@ -1,0 +1,2 @@
+name: add columns to permission_sync_jobs table
+parents: [1669297489, 1673405886]

--- a/migrations/frontend/1673871310_add_columns_to_permission_sync_jobs_table/up.sql
+++ b/migrations/frontend/1673871310_add_columns_to_permission_sync_jobs_table/up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE permission_sync_jobs
+    ADD COLUMN IF NOT EXISTS reason TEXT,
+    ADD COLUMN IF NOT EXISTS triggered_by_user_id INTEGER;
+
+COMMENT ON COLUMN permission_sync_jobs.reason IS 'Specifies why permissions sync job was triggered.';
+COMMENT ON COLUMN permission_sync_jobs.triggered_by_user_id IS 'Specifies an ID of a user who triggered a sync.';

--- a/migrations/frontend/1673871310_add_columns_to_permission_sync_jobs_table/up.sql
+++ b/migrations/frontend/1673871310_add_columns_to_permission_sync_jobs_table/up.sql
@@ -1,6 +1,7 @@
 ALTER TABLE permission_sync_jobs
     ADD COLUMN IF NOT EXISTS reason TEXT,
-    ADD COLUMN IF NOT EXISTS triggered_by_user_id INTEGER;
+    ADD COLUMN IF NOT EXISTS triggered_by_user_id INTEGER,
+    ADD FOREIGN KEY (triggered_by_user_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE;
 
 COMMENT ON COLUMN permission_sync_jobs.reason IS 'Specifies why permissions sync job was triggered.';
 COMMENT ON COLUMN permission_sync_jobs.triggered_by_user_id IS 'Specifies an ID of a user who triggered a sync.';

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3180,8 +3180,14 @@ CREATE TABLE permission_sync_jobs (
     repository_id integer,
     user_id integer,
     high_priority boolean DEFAULT false NOT NULL,
-    invalidate_caches boolean DEFAULT false NOT NULL
+    invalidate_caches boolean DEFAULT false NOT NULL,
+    reason text,
+    triggered_by_user_id integer
 );
+
+COMMENT ON COLUMN permission_sync_jobs.reason IS 'Specifies why permissions sync job was triggered.';
+
+COMMENT ON COLUMN permission_sync_jobs.triggered_by_user_id IS 'Specifies an ID of a user who triggered a sync.';
 
 CREATE SEQUENCE permission_sync_jobs_id_seq
     AS integer

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -5192,6 +5192,9 @@ ALTER TABLE ONLY org_stats
 ALTER TABLE ONLY out_of_band_migrations_errors
     ADD CONSTRAINT out_of_band_migrations_errors_migration_id_fkey FOREIGN KEY (migration_id) REFERENCES out_of_band_migrations(id) ON DELETE CASCADE;
 
+ALTER TABLE ONLY permission_sync_jobs
+    ADD CONSTRAINT permission_sync_jobs_triggered_by_user_id_fkey FOREIGN KEY (triggered_by_user_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE;
+
 ALTER TABLE ONLY product_licenses
     ADD CONSTRAINT product_licenses_product_subscription_id_fkey FOREIGN KEY (product_subscription_id) REFERENCES product_subscriptions(id);
 


### PR DESCRIPTION
Test plan:
`sg migration up` -> `sg migration downto` -> `sg migration up`.

Part of https://github.com/sourcegraph/sourcegraph/issues/46319 with only migrations in place. Next commit will use these columns.