### PR TITLE
Add sourcegraph user fields to stream blame resps

### DIFF
--- a/client/web/src/repo/blame/useBlameHunks.ts
+++ b/client/web/src/repo/blame/useBlameHunks.ts
@@ -149,6 +149,11 @@ interface RawStreamHunk {
     startLine: number
     filename: string
     message: string
+    user?: {
+      username: string,
+      displayName: string,
+      avatarURL: string,
+    }
 }
 
 /**
@@ -198,6 +203,11 @@ const fetchBlameViaStreaming = memoizeObservable(
                         if (event.event === 'hunk') {
                             const rawHunks: RawStreamHunk[] = JSON.parse(event.data)
                             for (const rawHunk of rawHunks) {
+                              // TODO: remove this, it's just a thing to highlight when we have the user while I'm passing this PR 
+                              // to Phillip.
+                              if (rawHunk.user != null) {
+                                console.log(rawHunk.user)
+                              }
                                 const hunk: Omit<BlameHunk, 'displayInfo'> = {
                                     startLine: rawHunk.startLine,
                                     endLine: rawHunk.endLine,
@@ -206,9 +216,9 @@ const fetchBlameViaStreaming = memoizeObservable(
                                     author: {
                                         date: rawHunk.author.Date,
                                         person: {
-                                            email: rawHunk.author.Email,
-                                            displayName: rawHunk.author.Name,
-                                            avatarURL: null,
+                                            email: rawHunk.user?.email,
+                                            displayName: rawHunk.user?.displayName,
+                                            avatarURL: rawHunk.user?.avatarURL,
                                             user: null,
                                         },
                                     },

--- a/client/web/src/repo/blame/useBlameHunks.ts
+++ b/client/web/src/repo/blame/useBlameHunks.ts
@@ -150,9 +150,9 @@ interface RawStreamHunk {
     filename: string
     message: string
     user?: {
-      username: string,
-      displayName: string,
-      avatarURL: string,
+        username: string
+        displayName: string | null
+        avatarURL: string | null
     }
 }
 
@@ -203,11 +203,6 @@ const fetchBlameViaStreaming = memoizeObservable(
                         if (event.event === 'hunk') {
                             const rawHunks: RawStreamHunk[] = JSON.parse(event.data)
                             for (const rawHunk of rawHunks) {
-                              // TODO: remove this, it's just a thing to highlight when we have the user while I'm passing this PR 
-                              // to Phillip.
-                              if (rawHunk.user != null) {
-                                console.log(rawHunk.user)
-                              }
                                 const hunk: Omit<BlameHunk, 'displayInfo'> = {
                                     startLine: rawHunk.startLine,
                                     endLine: rawHunk.endLine,
@@ -216,10 +211,10 @@ const fetchBlameViaStreaming = memoizeObservable(
                                     author: {
                                         date: rawHunk.author.Date,
                                         person: {
-                                            email: rawHunk.user?.email,
-                                            displayName: rawHunk.user?.displayName,
-                                            avatarURL: rawHunk.user?.avatarURL,
-                                            user: null,
+                                            email: rawHunk.author?.Email,
+                                            displayName: rawHunk.author.Name,
+                                            avatarURL: rawHunk.user?.avatarURL ?? null,
+                                            user: rawHunk.user ?? null,
                                         },
                                     },
                                     commit: {

--- a/client/web/src/repo/blob/BlameDecoration.tsx
+++ b/client/web/src/repo/blob/BlameDecoration.tsx
@@ -173,8 +173,8 @@ export const BlameDecoration: React.FunctionComponent<{
                     >
                         {hideRecency ? (
                             <span className={styles.content} data-line-decoration-attachment-content={true}>
-                                {`${displayInfo.dateString} • ${displayInfo.username}${
-                                    displayInfo.displayName
+                                {`${displayInfo.dateString} • ${displayInfo.displayName}${
+                                    displayInfo.username
                                 } [${truncate(displayInfo.message, { length: 45 })}]`}
                             </span>
                         ) : (
@@ -206,7 +206,7 @@ export const BlameDecoration: React.FunctionComponent<{
                                 <span className={styles.content} data-line-decoration-attachment-content={true}>
                                     {blameHunk.author.person ? (
                                         <>
-                                            {`${displayInfo.username}${displayInfo.displayName}`.split(' ')[0]}
+                                            {`${displayInfo.displayName}${displayInfo.username}`.split(' ')[0]}
                                             {' • '}
                                         </>
                                     ) : null}

--- a/cmd/frontend/internal/httpapi/stream_blame.go
+++ b/cmd/frontend/internal/httpapi/stream_blame.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/handlerutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -135,10 +136,19 @@ func handleStreamBlame(logger log.Logger, db database.DB, gitserverClient gitser
 
 				var blameHunkUserResponse *BlameHunkUserResponse
 				if user != nil {
+					displayName := &user.DisplayName
+					if *displayName == "" {
+						displayName = nil
+					}
+					avatarURL := &user.AvatarURL
+					if *avatarURL == "" {
+						avatarURL = nil
+					}
+
 					blameHunkUserResponse = &BlameHunkUserResponse{
 						Username:    user.Username,
-						DisplayName: user.DisplayName,
-						AvatarURL:   user.AvatarURL,
+						DisplayName: displayName,
+						AvatarURL:   avatarURL,
 					}
 				}
 
@@ -185,7 +195,7 @@ type BlameHunkCommitResponse struct {
 }
 
 type BlameHunkUserResponse struct {
-	Username    string `json:"username"`
-	DisplayName string `json:"displayName"`
-	AvatarURL   string `json:"avatarURL"`
+	Username    string  `json:"username"`
+	DisplayName *string `json:"displayName"`
+	AvatarURL   *string `json:"avatarURL"`
 }

--- a/cmd/frontend/internal/httpapi/stream_blame_test.go
+++ b/cmd/frontend/internal/httpapi/stream_blame_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
@@ -103,6 +104,12 @@ func TestStreamBlame(t *testing.T) {
 			return api.CommitID(""), &gitdomain.RevisionNotFoundError{Repo: repo.Name}
 		}
 	}
+	usersStore := database.NewMockUserStore()
+	errNotFound := &errcode.Mock{
+		IsNotFound: true,
+	}
+	usersStore.GetByVerifiedEmailFunc.SetDefaultReturn(nil, errNotFound)
+	db.UsersFunc.SetDefaultReturn(usersStore)
 
 	t.Cleanup(func() {
 		backend.Mocks.Repos = backend.MockRepos{}


### PR DESCRIPTION
@philipp-spiess here is the backend code and a bit of frontend to highlight that's doing what it's supposed to do.

This code is neccessary for @philipp-spiess to roll out the stream blame solution and make it GA. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

![image](https://user-images.githubusercontent.com/10151/212705590-1162b074-ac4f-4804-8a93-3720a1b3c101.png)
