### PR TITLE
batches: temporarily hide global stats bar for namespaced list

### DIFF
--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -192,7 +192,7 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
             )}
             {selectedTab === 'batchChanges' && (
                 <>
-                    <BatchChangeStatsBar className="mb-4" namespaceID={namespaceID} />
+                    {!namespaceID && <BatchChangeStatsBar className="mb-4" />}
                     <Container className="mb-4">
                         <ConnectionContainer>
                             <div className={styles.filtersRow}>

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -192,7 +192,7 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
             )}
             {selectedTab === 'batchChanges' && (
                 <>
-                    <BatchChangeStatsBar className="mb-4" />
+                    <BatchChangeStatsBar className="mb-4" namespaceID={namespaceID} />
                     <Container className="mb-4">
                         <ConnectionContainer>
                             <div className={styles.filtersRow}>

--- a/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
@@ -106,5 +106,5 @@ export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildre
                 </div>
             </div>
         </div>
-    ) : null
+    )
 }

--- a/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
@@ -40,7 +40,7 @@ export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildre
         return null
     }
 
-    return !namespaceID ? (
+    return (
         <div className={classNames(styles.statsBar, 'text-muted d-block d-sm-flex')}>
             <div className={styles.leftSide}>
                 <div className="pr-4">

--- a/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
@@ -43,7 +43,7 @@ export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildre
         return null
     }
 
-    return namespaceID ? (
+    return !namespaceID ? (
         <div className={classNames(styles.statsBar, 'text-muted d-block d-sm-flex')}>
             <div className={styles.leftSide}>
                 <div className="pr-4">

--- a/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
@@ -18,9 +18,12 @@ import styles from './BatchChangeStatsBar.module.scss'
 
 interface BatchChangeStatsBarProps {
     className?: string
+    namespaceID?: string
 }
 
-export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildren<BatchChangeStatsBarProps>> = () => {
+export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildren<BatchChangeStatsBarProps>> = ({
+    namespaceID,
+}) => {
     const [minSavedPerChangeset = DEFAULT_MINS_SAVED_PER_CHANGESET] =
         useTemporarySetting('batches.minSavedPerChangeset')
 
@@ -40,7 +43,7 @@ export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildre
         return null
     }
 
-    return (
+    return namespaceID ? (
         <div className={classNames(styles.statsBar, 'text-muted d-block d-sm-flex')}>
             <div className={styles.leftSide}>
                 <div className="pr-4">
@@ -106,5 +109,5 @@ export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildre
                 </div>
             </div>
         </div>
-    )
+    ) : null
 }

--- a/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
@@ -18,12 +18,9 @@ import styles from './BatchChangeStatsBar.module.scss'
 
 interface BatchChangeStatsBarProps {
     className?: string
-    namespaceID?: string
 }
 
-export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildren<BatchChangeStatsBarProps>> = ({
-    namespaceID,
-}) => {
+export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildren<BatchChangeStatsBarProps>> = ({}) => {
     const [minSavedPerChangeset = DEFAULT_MINS_SAVED_PER_CHANGESET] =
         useTemporarySetting('batches.minSavedPerChangeset')
 

--- a/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatsBar.tsx
@@ -20,7 +20,7 @@ interface BatchChangeStatsBarProps {
     className?: string
 }
 
-export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildren<BatchChangeStatsBarProps>> = ({}) => {
+export const BatchChangeStatsBar: React.FunctionComponent<React.PropsWithChildren<BatchChangeStatsBarProps>> = () => {
     const [minSavedPerChangeset = DEFAULT_MINS_SAVED_PER_CHANGESET] =
         useTemporarySetting('batches.minSavedPerChangeset')
 


### PR DESCRIPTION
Closes #45075

Temporarily hiding the global batch change stats bar on the namespaced list as the resolver currently does not support computing these stats in a specific namespace.

## Test plan
ensured the stats bar is only shown on global list
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-aa-remove-global-stats-bar.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
