### PR TITLE
asdf: update fd to 8.X 

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 golang 1.19.3
 nodejs 16.18.1
-fd 7.4.0
+fd 8.6.0
 shfmt 3.5.0
 shellcheck 0.7.1
 kubectl 1.21.7


### PR DESCRIPTION
Version 7.x doesn't play well with
https://github.com/nvim-telescope/telescope-file-browser.nvim anymore so let's update it :)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Locally tested, CI should raise issue if a dependent script breaks. 