### PR TITLE
disable flake: TestUsers_PasswordResetExpiry/exired_link

### DIFF
--- a/internal/database/users_builtin_auth_test.go
+++ b/internal/database/users_builtin_auth_test.go
@@ -323,6 +323,8 @@ func TestUsers_PasswordResetExpiry(t *testing.T) {
 	time.Sleep(time.Second) // the lowest expiry is 1 second
 
 	t.Run("expired link", func(t *testing.T) {
+		// This flaked with a data race in https://buildkite.com/sourcegraph/sourcegraph/builds/193660#0185bb03-890a-486f-a119-e5e80dd2c29e
+		t.Skip()
 		conf.Mock(&conf.Unified{
 			SiteConfiguration: schema.SiteConfiguration{
 				AuthPasswordResetLinkExpiry: 1,


### PR DESCRIPTION
flaked with a data race in https://buildkite.com/sourcegraph/sourcegraph/builds/193660#0185bb03-890a-486f-a119-e5e80dd2c29e

## Test plan
none - disabling test
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
