### PR TITLE
build-tracker: notify after failed build

### DIFF
--- a/dev/build-tracker/build.go
+++ b/dev/build-tracker/build.go
@@ -175,6 +175,10 @@ func (b *Event) isBuildFinished() bool {
 	return b.Name == "build.finished"
 }
 
+func (b *Event) isJobFinished() bool {
+	return b.Name == "job.finished"
+}
+
 func (b *Event) jobName() string {
 	return strp(b.Job.Name)
 }


### PR DESCRIPTION
Previously we would only notify if the event was 'build.finished' but we
could still get failed finished jobs for a finished build.

With this change, in addition to checking if the event is for
build.finished, we now check if the build has failed AND that job has
failed for sending a notification

## Test plan
unit test

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
