### PR TITLE
build: remove branded/shared circular dep

### DIFF
--- a/client/http-client/package.json
+++ b/client/http-client/package.json
@@ -11,7 +11,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "@sourcegraph/common": "workspace:*",
-    "@sourcegraph/shared": "workspace:*"
+    "@sourcegraph/common": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -894,10 +894,8 @@ importers:
   client/http-client:
     specifiers:
       '@sourcegraph/common': workspace:*
-      '@sourcegraph/shared': workspace:*
     dependencies:
       '@sourcegraph/common': link:../common
-      '@sourcegraph/shared': link:../shared
 
   client/jetbrains:
     specifiers:


### PR DESCRIPTION
Looks like this is an unnecessary circle dep?

## Test plan

CI

## App preview:

- [Web](https://sg-web-build-shared-http-circle.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
