### PR TITLE
insights: During backfill rate limit prior to compression

### DIFF
--- a/enterprise/internal/insights/pipeline/backfill.go
+++ b/enterprise/internal/insights/pipeline/backfill.go
@@ -149,17 +149,12 @@ func makeSearchJobsFunc(logger log.Logger, commitClient GitCommitClient, compres
 
 			return &reqContext, jobs, err
 		}
-		filteredRecordingTimes := make([]time.Time, 0, len(req.SampleTimes))
-		for i := 0; i < len(req.SampleTimes); i++ {
-			if firstHEADCommit.Author.Date.Before(req.SampleTimes[i]) {
-				filteredRecordingTimes = append(filteredRecordingTimes, req.SampleTimes[i])
-			}
-		}
+		// Rate limit starting compression
 		err = rateLimit.Wait(ctx)
 		if err != nil {
 			return &reqContext, jobs, err
 		}
-		searchPlan := compressionPlan.Filter(ctx, filteredRecordingTimes, req.Repo.Name)
+		searchPlan := compressionPlan.Filter(ctx, req.SampleTimes, req.Repo.Name)
 		var ratio float64 = 1.0
 		if numberOfFrames > 0 {
 			ratio = (float64(len(searchPlan.Executions)) / float64(numberOfFrames))

--- a/enterprise/internal/insights/pipeline/backfill.go
+++ b/enterprise/internal/insights/pipeline/backfill.go
@@ -134,7 +134,7 @@ func makeSearchJobsFunc(logger log.Logger, commitClient GitCommitClient, compres
 			return &reqContext, jobs, errors.New("backfill request provided")
 		}
 		req := reqContext.backfillRequest
-		buildJob := makeHistoricalSearchJobFunc(logger, commitClient, rateLimit)
+		buildJob := makeHistoricalSearchJobFunc(logger, commitClient)
 		logger.Debug("making search plan")
 		// Find the first commit made to the repository on the default branch.
 		firstHEADCommit, err := commitClient.FirstCommit(ctx, req.Repo.Name)
@@ -149,7 +149,17 @@ func makeSearchJobsFunc(logger log.Logger, commitClient GitCommitClient, compres
 
 			return &reqContext, jobs, err
 		}
-		searchPlan := compressionPlan.Filter(ctx, req.SampleTimes, req.Repo.Name)
+		filteredRecordingTimes := make([]time.Time, 0, len(req.SampleTimes))
+		for i := 0; i < len(req.SampleTimes); i++ {
+			if firstHEADCommit.Author.Date.Before(req.SampleTimes[i]) {
+				filteredRecordingTimes = append(filteredRecordingTimes, req.SampleTimes[i])
+			}
+		}
+		err = rateLimit.Wait(ctx)
+		if err != nil {
+			return &reqContext, jobs, err
+		}
+		searchPlan := compressionPlan.Filter(ctx, filteredRecordingTimes, req.Repo.Name)
 		var ratio float64 = 1.0
 		if numberOfFrames > 0 {
 			ratio = (float64(len(searchPlan.Executions)) / float64(numberOfFrames))
@@ -208,7 +218,7 @@ type buildSeriesContext struct {
 
 type searchJobFunc func(ctx context.Context, bctx *buildSeriesContext) (err error, job *queryrunner.SearchJob, preempted []store.RecordSeriesPointArgs)
 
-func makeHistoricalSearchJobFunc(logger log.Logger, commitClient GitCommitClient, limiter *ratelimit.InstrumentedLimiter) searchJobFunc {
+func makeHistoricalSearchJobFunc(logger log.Logger, commitClient GitCommitClient) searchJobFunc {
 	return func(ctx context.Context, bctx *buildSeriesContext) (err error, job *queryrunner.SearchJob, preempted []store.RecordSeriesPointArgs) {
 		logger.Debug("making search job")
 		rawQuery := bctx.series.Query
@@ -231,10 +241,6 @@ func makeHistoricalSearchJobFunc(logger log.Logger, commitClient GitCommitClient
 
 		revision := bctx.execution.Revision
 		if len(bctx.execution.Revision) == 0 {
-			err = limiter.Wait(ctx)
-			if err != nil {
-				return
-			}
 			recentCommits, revErr := commitClient.RecentCommits(ctx, bctx.repoName, bctx.execution.RecordingTime, "")
 			if revErr != nil {
 				if errors.HasType(revErr, &gitdomain.RevisionNotFoundError{}) || gitdomain.IsRepoNotExist(revErr) {


### PR DESCRIPTION
Previously the rate limiting of git commands associated with finding historical revisions for a date was called each time a search job was attempted to be built.  However the compression logic does not eliminate recording times that occur before the first commit, which cased very poor compression rates for empty repos which then slowed because they waited on the rate limiting even though the git commands would not be run.  

## Test plan
Backfilled an insight
Measured improvement in time to create search jobs
<img width="794" alt="image" src="https://user-images.githubusercontent.com/6098507/212759322-6b7731ac-4fac-42c9-bf57-2d9dac15fe19.png">
 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
