### PR TITLE
executor: improve error logging when running commands

### DIFF
--- a/enterprise/cmd/executor/internal/run/util.go
+++ b/enterprise/cmd/executor/internal/run/util.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func newQueueTelemetryOptions(ctx context.Context, useFirecracker bool, logger log.Logger) queue.TelemetryOptions {
@@ -87,7 +88,7 @@ func execOutput(ctx context.Context, name string, args ...string) (string, error
 	cmd.Stdout = &buf
 	if err := cmd.Run(); err != nil {
 		cmdLine := strings.Join(append([]string{name}, args...), " ")
-		return "", fmt.Errorf("'%s': error: %v output: %s", cmdLine, err, buf.String())
+		return "", errors.Wrap(err, fmt.Sprintf("'%s': %s", cmdLine, buf.String()))
 	}
 	return strings.TrimSpace(buf.String()), nil
 }


### PR DESCRIPTION
Prior to this change one could get ambiguous errors when executor does its startup checks, especially in the case of the single-binary deployment where some of these binaries may not e.g. be installed:

```
ERROR service run/util.go:40 Failed to get src-cli version {"error": "exit status 126"}
```

This change makes it so that the error at least includes what the command output was:

```
ERROR service run/util.go:41 Failed to get src-cli version {"error": "'src version -client-only': error: exit status 126 output: No preset version installed for command src\nPlease install a version by running one of the following:\n\nasdf install golang 1.19.3\n\nor add one of the following versions in your config file at /Users/stephen@sourcegraph.com/work/sourcegraph/.tool-versions\ngolang 1.18.1\n"}
```

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>

## Test plan

Confirmed the new behavior manually + existing tests.
