### PR TITLE
batches: add delete cascade to foreign key constraint on `batch_spec_resolution_jobs.initiator_id` column

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -2047,7 +2047,7 @@
           "ConstraintType": "f",
           "RefTableName": "users",
           "IsDeferrable": true,
-          "ConstraintDefinition": "FOREIGN KEY (initiator_id) REFERENCES users(id) ON UPDATE CASCADE DEFERRABLE"
+          "ConstraintDefinition": "FOREIGN KEY (initiator_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE"
         }
       ],
       "Triggers": []

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -143,7 +143,7 @@ Indexes:
     "batch_spec_resolution_jobs_state" btree (state)
 Foreign-key constraints:
     "batch_spec_resolution_jobs_batch_spec_id_fkey" FOREIGN KEY (batch_spec_id) REFERENCES batch_specs(id) ON DELETE CASCADE DEFERRABLE
-    "batch_spec_resolution_jobs_initiator_id_fkey" FOREIGN KEY (initiator_id) REFERENCES users(id) ON UPDATE CASCADE DEFERRABLE
+    "batch_spec_resolution_jobs_initiator_id_fkey" FOREIGN KEY (initiator_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE
 
 ```
 
@@ -3303,7 +3303,7 @@ Referenced by:
     TABLE "batch_changes" CONSTRAINT "batch_changes_last_applier_id_fkey" FOREIGN KEY (last_applier_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
     TABLE "batch_changes" CONSTRAINT "batch_changes_namespace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
     TABLE "batch_spec_execution_cache_entries" CONSTRAINT "batch_spec_execution_cache_entries_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
-    TABLE "batch_spec_resolution_jobs" CONSTRAINT "batch_spec_resolution_jobs_initiator_id_fkey" FOREIGN KEY (initiator_id) REFERENCES users(id) ON UPDATE CASCADE DEFERRABLE
+    TABLE "batch_spec_resolution_jobs" CONSTRAINT "batch_spec_resolution_jobs_initiator_id_fkey" FOREIGN KEY (initiator_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE
     TABLE "batch_spec_workspace_execution_last_dequeues" CONSTRAINT "batch_spec_workspace_execution_last_dequeues_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
     TABLE "batch_specs" CONSTRAINT "batch_specs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
     TABLE "changeset_jobs" CONSTRAINT "changeset_jobs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE

--- a/migrations/frontend/1673897709_add_cascade_batch_spec_resolution_jobs/down.sql
+++ b/migrations/frontend/1673897709_add_cascade_batch_spec_resolution_jobs/down.sql
@@ -1,0 +1,12 @@
+ALTER TABLE 
+    batch_spec_resolution_jobs
+DROP 
+    CONSTRAINT IF EXISTS batch_spec_resolution_jobs_initiator_id_fkey;
+
+ALTER TABLE 
+    batch_spec_resolution_jobs
+ADD 
+    CONSTRAINT batch_spec_resolution_jobs_initiator_id_fkey 
+        FOREIGN KEY (initiator_id) 
+        REFERENCES users(id) 
+        ON UPDATE CASCADE DEFERRABLE;

--- a/migrations/frontend/1673897709_add_cascade_batch_spec_resolution_jobs/metadata.yaml
+++ b/migrations/frontend/1673897709_add_cascade_batch_spec_resolution_jobs/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_cascade_batch_spec_resolution_jobs
+parents: [1673351808, 1673871310]

--- a/migrations/frontend/1673897709_add_cascade_batch_spec_resolution_jobs/up.sql
+++ b/migrations/frontend/1673897709_add_cascade_batch_spec_resolution_jobs/up.sql
@@ -1,0 +1,14 @@
+ALTER TABLE 
+    batch_spec_resolution_jobs
+DROP 
+    CONSTRAINT IF EXISTS batch_spec_resolution_jobs_initiator_id_fkey;
+
+ALTER TABLE 
+    batch_spec_resolution_jobs
+ADD 
+    CONSTRAINT batch_spec_resolution_jobs_initiator_id_fkey 
+        FOREIGN KEY (initiator_id) 
+        REFERENCES users(id) 
+        ON DELETE CASCADE
+        ON UPDATE CASCADE 
+        DEFERRABLE;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -4931,7 +4931,7 @@ ALTER TABLE ONLY batch_spec_resolution_jobs
     ADD CONSTRAINT batch_spec_resolution_jobs_batch_spec_id_fkey FOREIGN KEY (batch_spec_id) REFERENCES batch_specs(id) ON DELETE CASCADE DEFERRABLE;
 
 ALTER TABLE ONLY batch_spec_resolution_jobs
-    ADD CONSTRAINT batch_spec_resolution_jobs_initiator_id_fkey FOREIGN KEY (initiator_id) REFERENCES users(id) ON UPDATE CASCADE DEFERRABLE;
+    ADD CONSTRAINT batch_spec_resolution_jobs_initiator_id_fkey FOREIGN KEY (initiator_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE;
 
 ALTER TABLE ONLY batch_spec_workspace_execution_jobs
     ADD CONSTRAINT batch_spec_workspace_execution_job_batch_spec_workspace_id_fkey FOREIGN KEY (batch_spec_workspace_id) REFERENCES batch_spec_workspaces(id) ON DELETE CASCADE DEFERRABLE;


### PR DESCRIPTION
Closes #45832

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested on my local instance.

Added `time.Sleep` to the `CreateBatchSpecResolutionJob` resolver to simulate a long-running resolution, then I deleted the initiator from the Sourcegraph UI.

<img width="920" alt="CleanShot 2023-01-17 at 03 02 25@2x" src="https://user-images.githubusercontent.com/25608335/212793620-2992dacc-69e9-43e8-a473-50fbbcc8e1b9.png">

The job was automatically removed by the worker. The heartbeat ensures deleted jobs are automatically canceled.

```
[         worker] ERROR store.batch_spec_resolution store/store.go:668 failed to fetch debug information for job {"recordID": 14, "error": "fetching debug information for record %!d(MISSING) didn't return rows"}
[         worker] ERROR store.batch_spec_resolution store/store.go:673 heartbeat lost a job {"recordID": 14, "debug": "", "options.workerHostname": ""}
[         worker] ERROR worker.batches-workspace-resolver.routines workerutil/worker.go:165 Removed unknown job from running set {"name": "batch_changes_batch_spec_resolution_worker", "id": 14}
```