### PR TITLE
Upgrade node-exporter

### DIFF
--- a/docker-images/node-exporter/build.sh
+++ b/docker-images/node-exporter/build.sh
@@ -4,7 +4,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 set -ex
 
 # Retag the upstream node-exporter release
-VERSION="v1.4.0@sha256:4dc469c325388dee18dd0a9e53ea30194abed43abc6330d4ffd6d451727ba3e6"
+VERSION="v1.5.0@sha256:fa8e5700b7762fffe0674e944762f44bb787a7e44d97569fe55348260453bf80"
 
 docker pull prom/node-exporter:$VERSION
 docker tag prom/node-exporter:$VERSION "$IMAGE"


### PR DESCRIPTION
Upgrades node-exporter to use the latest stable version (1.5.0). I verified that the new image works by checking the "data disk i/o metrics" in the zoekt dashboard, as instructed by @ggilmore:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/11207474/212799705-91d681be-81e5-4a2d-bc0d-b1bc50355de7.png">
 
## Test plan
CI checks + local test
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
