### PR TITLE
rcache: allow maxSize == 0 for FIFOList

### DIFF
--- a/internal/rcache/fifo_list.go
+++ b/internal/rcache/fifo_list.go
@@ -33,6 +33,16 @@ func (l *FIFOList) Insert(b []byte) error {
 	}
 	key := l.globalPrefixKey()
 
+	// Special case maxSize 0 to mean keep the list empty. Used to handle
+	// disabling.
+	if l.maxSize == 0 {
+		_, err := c.Do("LTRIM", key, 0, 0)
+		if err != nil {
+			return errors.Wrap(err, "failed to execute redis command LTRIM")
+		}
+		return nil
+	}
+
 	// O(1) because we're just adding a single element.
 	_, err := c.Do("LPUSH", key, b)
 	if err != nil {

--- a/internal/rcache/fifo_list_test.go
+++ b/internal/rcache/fifo_list_test.go
@@ -36,6 +36,12 @@ func Test_FIFOList_All_OK(t *testing.T) {
 			inserts: bytes("a1", "a2"),
 			want:    bytes("a2", "a1"),
 		},
+		{
+			key:     "d",
+			size:    0,
+			inserts: bytes("a1", "a2", "a3"),
+			want:    bytes(),
+		},
 	}
 
 	for _, c := range cases {
@@ -100,6 +106,14 @@ func Test_FIFOList_Slice_OK(t *testing.T) {
 			want:    bytes("a5", "a4"),
 			from:    1,
 			to:      2,
+		},
+		{
+			key:     "d",
+			size:    0,
+			inserts: bytes("a1", "a2", "a3"),
+			want:    bytes(),
+			from:    0,
+			to:      -1,
 		},
 		{
 			key:     "e",

--- a/internal/rcache/rcache_test.go
+++ b/internal/rcache/rcache_test.go
@@ -284,9 +284,6 @@ func TestCache_ListKeys(t *testing.T) {
 }
 
 func bytes(s ...string) [][]byte {
-	if s == nil {
-		return nil
-	}
 	t := make([][]byte, len(s))
 	for i, v := range s {
 		t[i] = []byte(v)


### PR DESCRIPTION
This essentially disables the FIFOList. The outbound request logger has
this as a possibility which I intend to port to FIFOList.

Note: we have to special case maxSize 0, otherwise the LTRIM we send is
"LTRIM key 0 -1" which means don't trim anything.

Test Plan: go test

plz-review-url: https://plz.review/review/17318