### PR TITLE
rcache: introduce FIFOList.SetMaxSize

### DIFF
--- a/cmd/frontend/graphqlbackend/slow_requests_tracer.go
+++ b/cmd/frontend/graphqlbackend/slow_requests_tracer.go
@@ -37,9 +37,7 @@ func captureSlowRequest(logger log.Logger, req *types.SlowRequest) {
 	slowRequestConfWatchOnce.Do(func() {
 		conf.Watch(func() {
 			limit := conf.Get().ObservabilityCaptureSlowGraphQLRequestsLimit
-			if limit != slowRequestRedisFIFOList.MaxSize() {
-				slowRequestRedisFIFOList = rcache.NewFIFOList("slow-graphql-requests-list", limit)
-			}
+			slowRequestRedisFIFOList.SetMaxSize(limit)
 		})
 	})
 

--- a/internal/rcache/fifo_list_test.go
+++ b/internal/rcache/fifo_list_test.go
@@ -144,6 +144,40 @@ func Test_FIFOList_Slice_OK(t *testing.T) {
 	}
 }
 
+func Test_FIFOList_SetMaxSize(t *testing.T) {
+	r := NewFIFOList("a", 3)
+	for i := 0; i < 10; i++ {
+		err := r.Insert([]byte("a"))
+		if err != nil {
+			t.Errorf("expected no error, got %q", err)
+		}
+	}
+
+	got, err := r.Slice(context.Background(), 0, -1)
+	if err != nil {
+		t.Errorf("expected no error, got %q", err)
+	}
+	if want := bytes("a", "a", "a"); !reflect.DeepEqual(want, got) {
+		t.Errorf("Expected %v, but got %v", _str(want...), _str(got...))
+	}
+
+	r.SetMaxSize(2)
+	for i := 0; i < 10; i++ {
+		err := r.Insert([]byte("b"))
+		if err != nil {
+			t.Errorf("expected no error, got %q", err)
+		}
+	}
+
+	got, err = r.Slice(context.Background(), 0, -1)
+	if err != nil {
+		t.Errorf("expected no error, got %q", err)
+	}
+	if want := bytes("b", "b"); !reflect.DeepEqual(want, got) {
+		t.Errorf("Expected %v, but got %v", _str(want...), _str(got...))
+	}
+}
+
 func Test_FIOListContextCancellation(t *testing.T) {
 	r := NewFIFOList("a", 3)
 	err := r.Insert([]byte("a"))

--- a/internal/rcache/fifo_list_test.go
+++ b/internal/rcache/fifo_list_test.go
@@ -158,7 +158,7 @@ func Test_FIFOList_SetMaxSize(t *testing.T) {
 		t.Errorf("expected no error, got %q", err)
 	}
 	if want := bytes("a", "a", "a"); !reflect.DeepEqual(want, got) {
-		t.Errorf("Expected %v, but got %v", _str(want...), _str(got...))
+		t.Errorf("expected %v, but got %v", _str(want...), _str(got...))
 	}
 
 	r.SetMaxSize(2)
@@ -174,7 +174,7 @@ func Test_FIFOList_SetMaxSize(t *testing.T) {
 		t.Errorf("expected no error, got %q", err)
 	}
 	if want := bytes("b", "b"); !reflect.DeepEqual(want, got) {
-		t.Errorf("Expected %v, but got %v", _str(want...), _str(got...))
+		t.Errorf("expected %v, but got %v", _str(want...), _str(got...))
 	}
 }
 


### PR DESCRIPTION
This is introduced to fix a rare race condition were we overwrite the
variable slowRequestRedisFIFOList while it could be read. Additionally,
if this store is not backed in redis we want to re-use the in memory
store.

Test Plan: go test

plz-review-url: https://plz.review/review/17319