### PR TITLE
permissions-center: fill `reason` of permission syncs.

### DIFF
--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -141,7 +141,7 @@ func (e *userEmails) Remove(ctx context.Context, userID int32, email string) (er
 		// Eagerly attempt to sync permissions again. This needs to happen _after_ the
 		// transaction has committed so that it takes into account any changes triggered
 		// by the removal of the e-mail.
-		triggerPermissionsSync(ctx, logger, e.db, userID)
+		triggerPermissionsSync(ctx, logger, e.db, userID, permssync.ReasonUserEmailRemoved)
 	}()
 
 	if err := tx.UserEmails().Remove(ctx, userID, email); err != nil {
@@ -218,7 +218,7 @@ func (e *userEmails) SetVerified(ctx context.Context, userID int32, email string
 		// Eagerly attempt to sync permissions again. This needs to happen _after_ the
 		// transaction has committed so that it takes into account any changes triggered
 		// by changes in the verification status of the e-mail.
-		triggerPermissionsSync(ctx, logger, e.db, userID)
+		triggerPermissionsSync(ctx, logger, e.db, userID, permssync.ReasonUserEmailVerified)
 	}()
 
 	if err := tx.UserEmails().SetVerified(ctx, userID, email, verified); err != nil {
@@ -470,8 +470,9 @@ Please verify your email address on Sourcegraph ({{.Host}}) by clicking this lin
 
 // triggerPermissionsSync is a helper that attempts to schedule a new permissions
 // sync for the given user.
-func triggerPermissionsSync(ctx context.Context, logger log.Logger, db database.DB, userID int32) {
+func triggerPermissionsSync(ctx context.Context, logger log.Logger, db database.DB, userID int32, reason string) {
 	permssync.SchedulePermsSync(ctx, logger, db, protocol.PermsSyncRequest{
 		UserIDs: []int32{userID},
+		Reason:  reason,
 	})
 }

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -352,7 +352,7 @@ func (r *schemaResolver) RemoveUserFromOrganization(ctx context.Context, args *s
 	}
 
 	// Enqueue a sync job. Internally this will log an error if enqueuing failed.
-	permssync.SchedulePermsSync(ctx, r.logger, r.db, protocol.PermsSyncRequest{UserIDs: []int32{userID}})
+	permssync.SchedulePermsSync(ctx, r.logger, r.db, protocol.PermsSyncRequest{UserIDs: []int32{userID}, Reason: permssync.ReasonUserRemovedFromOrg})
 
 	return nil, nil
 }
@@ -398,7 +398,7 @@ func (r *schemaResolver) AddUserToOrganization(ctx context.Context, args *struct
 	}
 
 	// Schedule permission sync for newly added user. Internally it will log an error if enqueuing failed.
-	permssync.SchedulePermsSync(ctx, r.logger, r.db, protocol.PermsSyncRequest{UserIDs: []int32{userToInvite.ID}})
+	permssync.SchedulePermsSync(ctx, r.logger, r.db, protocol.PermsSyncRequest{UserIDs: []int32{userToInvite.ID}, Reason: permssync.ReasonUserAddedToOrg})
 
 	return &EmptyResponse{}, nil
 }

--- a/cmd/frontend/graphqlbackend/org_invitations.go
+++ b/cmd/frontend/graphqlbackend/org_invitations.go
@@ -326,7 +326,7 @@ func (r *schemaResolver) RespondToOrganizationInvitation(ctx context.Context, ar
 		}
 		if shouldMarkAsVerified && accept {
 			// ignore errors here as this is a best-effort action
-			r.db.UserEmails().SetVerified(ctx, a.UID, invitation.RecipientEmail, shouldMarkAsVerified)
+			_ = r.db.UserEmails().SetVerified(ctx, a.UID, invitation.RecipientEmail, shouldMarkAsVerified)
 		}
 	} else if invitation.RecipientUserID > 0 && invitation.RecipientUserID != a.UID {
 		// 🚨 SECURITY: Fail if the org invitation's recipient is not the one given
@@ -346,7 +346,7 @@ func (r *schemaResolver) RespondToOrganizationInvitation(ctx context.Context, ar
 		}
 
 		// Schedule permission sync for user that accepted the invite. Internally it will log an error if enqueuing fails.
-		permssync.SchedulePermsSync(ctx, r.logger, r.db, protocol.PermsSyncRequest{UserIDs: []int32{a.UID}})
+		permssync.SchedulePermsSync(ctx, r.logger, r.db, protocol.PermsSyncRequest{UserIDs: []int32{a.UID}, Reason: permssync.ReasonUserAcceptedOrgInvite})
 	}
 	return &EmptyResponse{}, nil
 }

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -168,7 +168,7 @@ func (r *Resolver) ScheduleRepositoryPermissionsSync(ctx context.Context, args *
 		return nil, err
 	}
 
-	// 🚨 SECURITY: Only site admins can query repository permissions.
+	// 🚨 SECURITY: Only site admins can trigger repository permissions syncs.
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
@@ -178,9 +178,8 @@ func (r *Resolver) ScheduleRepositoryPermissionsSync(ctx context.Context, args *
 		return nil, err
 	}
 
-	permssync.SchedulePermsSync(ctx, r.logger, r.db, protocol.PermsSyncRequest{
-		RepoIDs: []api.RepoID{repoID},
-	})
+	req := protocol.PermsSyncRequest{RepoIDs: []api.RepoID{repoID}, Reason: permssync.ReasonManualRepoSync}
+	permssync.SchedulePermsSync(ctx, r.logger, r.db, req)
 
 	return &graphqlbackend.EmptyResponse{}, nil
 }
@@ -190,7 +189,7 @@ func (r *Resolver) ScheduleUserPermissionsSync(ctx context.Context, args *graphq
 		return nil, err
 	}
 
-	// 🚨 SECURITY: Only site admins can query repository permissions.
+	// 🚨 SECURITY: Only site admins can trigger user permissions syncs.
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
@@ -200,7 +199,7 @@ func (r *Resolver) ScheduleUserPermissionsSync(ctx context.Context, args *graphq
 		return nil, err
 	}
 
-	req := protocol.PermsSyncRequest{UserIDs: []int32{userID}}
+	req := protocol.PermsSyncRequest{UserIDs: []int32{userID}, Reason: permssync.ReasonManualUserSync}
 	if args.Options != nil && args.Options.InvalidateCaches != nil && *args.Options.InvalidateCaches {
 		req.Options.InvalidateCaches = true
 	}

--- a/enterprise/cmd/frontend/internal/authz/webhooks/github.go
+++ b/enterprise/cmd/frontend/internal/authz/webhooks/github.go
@@ -54,7 +54,7 @@ func TestSetGitHubHandlerSleepTime(t *testing.T, val time.Duration) {
 	sleepTime = val
 }
 
-func (h *GitHubWebhook) handleGitHubWebhook(ctx context.Context, db database.DB, codeHostURN extsvc.CodeHostBaseURL, payload any) error {
+func (h *GitHubWebhook) handleGitHubWebhook(_ context.Context, db database.DB, codeHostURN extsvc.CodeHostBaseURL, payload any) error {
 	// TODO: This MUST be removed once permissions syncing jobs are database backed!
 	// If we react too quickly to a webhook, the changes may not yet have properly
 	// propagated on GitHub's system, and we'll get old results, making the
@@ -68,15 +68,15 @@ func (h *GitHubWebhook) handleGitHubWebhook(ctx context.Context, db database.DB,
 
 		switch e := payload.(type) {
 		case *gh.RepositoryEvent:
-			h.handleRepositoryEvent(eventContext, db, e)
+			_ = h.handleRepositoryEvent(eventContext, db, e)
 		case *gh.MemberEvent:
-			h.handleMemberEvent(eventContext, db, e, codeHostURN)
+			_ = h.handleMemberEvent(eventContext, db, e, codeHostURN)
 		case *gh.OrganizationEvent:
-			h.handleOrganizationEvent(eventContext, db, e, codeHostURN)
+			_ = h.handleOrganizationEvent(eventContext, db, e, codeHostURN)
 		case *gh.MembershipEvent:
-			h.handleMembershipEvent(eventContext, db, e, codeHostURN)
+			_ = h.handleMembershipEvent(eventContext, db, e, codeHostURN)
 		case *gh.TeamEvent:
-			h.handleTeamEvent(eventContext, e, db)
+			_ = h.handleTeamEvent(eventContext, e, db)
 		}
 	}()
 	return nil
@@ -88,46 +88,71 @@ func (h *GitHubWebhook) handleRepositoryEvent(ctx context.Context, db database.D
 		return nil
 	}
 
-	return h.getRepoAndSyncPerms(ctx, db, e)
+	return h.getRepoAndSyncPerms(ctx, db, e, permssync.ReasonGitHubRepoMadePrivateEvent)
 }
 
 func (h *GitHubWebhook) handleMemberEvent(ctx context.Context, db database.DB, e *gh.MemberEvent, codeHostURN extsvc.CodeHostBaseURL) error {
-	if e.GetAction() != "added" && e.GetAction() != "removed" {
+	action := e.GetAction()
+	var reason string
+	if action == "added" {
+		reason = permssync.ReasonGitHubUserAddedEvent
+	} else if action == "removed" {
+		reason = permssync.ReasonGitHubUserRemovedEvent
+	} else {
+		// unknown event type
 		return nil
 	}
 	user := e.GetMember()
 
-	return h.getUserAndSyncPerms(ctx, db, user, codeHostURN)
+	return h.getUserAndSyncPerms(ctx, db, user, codeHostURN, reason)
 }
 
 func (h *GitHubWebhook) handleOrganizationEvent(ctx context.Context, db database.DB, e *gh.OrganizationEvent, codeHostURN extsvc.CodeHostBaseURL) error {
-	if e.GetAction() != "member_added" && e.GetAction() != "member_removed" {
+	action := e.GetAction()
+	var reason string
+	if action == "member_added" {
+		reason = permssync.ReasonGitHubOrgMemberAddedEvent
+	} else if action == "member_removed" {
+		reason = permssync.ReasonGitHubOrgMemberRemovedEvent
+	} else {
 		return nil
 	}
 
 	user := e.GetMembership().GetUser()
 
-	return h.getUserAndSyncPerms(ctx, db, user, codeHostURN)
+	return h.getUserAndSyncPerms(ctx, db, user, codeHostURN, reason)
 }
 
 func (h *GitHubWebhook) handleMembershipEvent(ctx context.Context, db database.DB, e *gh.MembershipEvent, codeHostURN extsvc.CodeHostBaseURL) error {
-	if e.GetAction() != "added" && e.GetAction() != "removed" {
+	action := e.GetAction()
+	var reason string
+	if action == "added" {
+		reason = permssync.ReasonGitHubUserMembershipAddedEvent
+	} else if action == "removed" {
+		reason = permssync.ReasonGitHubUserMembershipRemovedEvent
+	} else {
 		return nil
 	}
 	user := e.GetMember()
 
-	return h.getUserAndSyncPerms(ctx, db, user, codeHostURN)
+	return h.getUserAndSyncPerms(ctx, db, user, codeHostURN, reason)
 }
 
 func (h *GitHubWebhook) handleTeamEvent(ctx context.Context, e *gh.TeamEvent, db database.DB) error {
-	if e.GetAction() != "added_to_repository" && e.GetAction() != "removed_from_repository" {
+	action := e.GetAction()
+	var reason string
+	if action == "added_to_repository" {
+		reason = permssync.ReasonGitHubTeamAddedToRepoEvent
+	} else if action == "removed_from_repository" {
+		reason = permssync.ReasonGitHubTeamRemovedFromRepoEvent
+	} else {
 		return nil
 	}
 
-	return h.getRepoAndSyncPerms(ctx, db, e)
+	return h.getRepoAndSyncPerms(ctx, db, e, reason)
 }
 
-func (h *GitHubWebhook) getUserAndSyncPerms(ctx context.Context, db database.DB, user *gh.User, codeHostURN extsvc.CodeHostBaseURL) error {
+func (h *GitHubWebhook) getUserAndSyncPerms(ctx context.Context, db database.DB, user *gh.User, codeHostURN extsvc.CodeHostBaseURL, reason string) error {
 	externalAccounts, err := db.UserExternalAccounts().List(ctx, database.ExternalAccountsListOptions{
 		ServiceID:      codeHostURN.String(),
 		AccountID:      strconv.Itoa(int(user.GetID())),
@@ -145,12 +170,13 @@ func (h *GitHubWebhook) getUserAndSyncPerms(ctx context.Context, db database.DB,
 	// PermsSyncJob if that feature is enabled.
 	permssync.SchedulePermsSync(ctx, h.logger, db, protocol.PermsSyncRequest{
 		UserIDs: []int32{externalAccounts[0].UserID},
+		Reason:  reason,
 	})
 
 	return err
 }
 
-func (h *GitHubWebhook) getRepoAndSyncPerms(ctx context.Context, db database.DB, e interface{ GetRepo() *gh.Repository }) error {
+func (h *GitHubWebhook) getRepoAndSyncPerms(ctx context.Context, db database.DB, e interface{ GetRepo() *gh.Repository }, reason string) error {
 	ghRepo := e.GetRepo()
 
 	repo, err := db.Repos().GetFirstRepoByCloneURL(ctx, strings.TrimSuffix(ghRepo.GetCloneURL(), ".git"))
@@ -162,6 +188,7 @@ func (h *GitHubWebhook) getRepoAndSyncPerms(ctx context.Context, db database.DB,
 	// PermsSyncJob if that feature is enabled.
 	permssync.SchedulePermsSync(ctx, h.logger, db, protocol.PermsSyncRequest{
 		RepoIDs: []api.RepoID{repo.ID},
+		Reason:  reason,
 	})
 
 	return nil

--- a/enterprise/cmd/repo-updater/shared/shared.go
+++ b/enterprise/cmd/repo-updater/shared/shared.go
@@ -36,7 +36,7 @@ func EnterpriseInit(
 	keyring keyring.Ring,
 	cf *httpcli.Factory,
 	server *repoupdater.Server,
-) (debugDumpers map[string]debugserver.Dumper, enqueueRepoPermsJob func(context.Context, api.RepoID) error) {
+) (debugDumpers map[string]debugserver.Dumper, enqueueRepoPermsJob func(context.Context, api.RepoID, string) error) {
 	debug, _ := strconv.ParseBool(os.Getenv("DEBUG"))
 	if debug {
 		observationCtx.Logger.Info("enterprise edition")
@@ -58,17 +58,17 @@ func EnterpriseInit(
 	permsSyncer := authz.NewPermsSyncer(observationCtx.Logger.Scoped("PermsSyncer", "repository and user permissions syncer"), db, repoStore, permsStore, timeutil.Now, ratelimit.DefaultRegistry)
 
 	permsJobStore := db.PermissionSyncJobs()
-	enqueueRepoPermsJob = func(ctx context.Context, repo api.RepoID) error {
+	enqueueRepoPermsJob = func(ctx context.Context, repo api.RepoID, reason string) error {
 		if authz.PermissionSyncingDisabled() {
 			return nil
 		}
 
 		// If the feature flag is enabled, create job...
 		if permssync.PermissionSyncWorkerEnabled(ctx, db, observationCtx.Logger) {
-			opts := ossDB.PermissionSyncJobOpts{HighPriority: true}
+			opts := ossDB.PermissionSyncJobOpts{HighPriority: true, Reason: reason}
 			return permsJobStore.CreateRepoSyncJob(ctx, repo, opts)
 		}
-		// .. otherwise we just call the PermsSyncer
+		// ... otherwise, we just call the PermsSyncer
 		permsSyncer.ScheduleRepos(ctx, repo)
 		return nil
 	}

--- a/internal/authz/permssync/permssync.go
+++ b/internal/authz/permssync/permssync.go
@@ -80,6 +80,7 @@ func SchedulePermsSync(ctx context.Context, logger log.Logger, db database.DB, r
 			opts := database.PermissionSyncJobOpts{
 				HighPriority:     true,
 				InvalidateCaches: req.Options.InvalidateCaches,
+				Reason:           req.Reason,
 			}
 			err := db.PermissionSyncJobs().CreateUserSyncJob(ctx, userID, opts)
 			if err != nil {
@@ -91,6 +92,7 @@ func SchedulePermsSync(ctx context.Context, logger log.Logger, db database.DB, r
 			opts := database.PermissionSyncJobOpts{
 				HighPriority:     true,
 				InvalidateCaches: req.Options.InvalidateCaches,
+				Reason:           req.Reason,
 			}
 			err := db.PermissionSyncJobs().CreateRepoSyncJob(ctx, repoID, opts)
 			if err != nil {

--- a/internal/authz/permssync/permssync.go
+++ b/internal/authz/permssync/permssync.go
@@ -10,7 +10,41 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 )
 
-const featureFlagName = "database-permission-sync-worker"
+const (
+	featureFlagName = "database-permission-sync-worker"
+
+	// ReasonUserOutdatedPermissions and below are reasons of scheduled permission
+	// syncs.
+	ReasonUserOutdatedPermissions = "REASON_USER_OUTDATED_PERMS"
+	ReasonUserNoPermissions       = "REASON_USER_NO_PERMS"
+	ReasonUserEmailRemoved        = "REASON_USER_EMAIL_REMOVED"
+	ReasonUserEmailVerified       = "REASON_USER_EMAIL_VERIFIED"
+	ReasonUserAddedToOrg          = "REASON_USER_ADDED_TO_ORG"
+	ReasonUserRemovedFromOrg      = "REASON_USER_REMOVED_FROM_ORG"
+	ReasonUserAcceptedOrgInvite   = "REASON_USER_ACCEPTED_ORG_INVITE"
+	ReasonRepoOutdatedPermissions = "REASON_REPO_OUTDATED_PERMS"
+	ReasonRepoNoPermissions       = "REASON_REPO_NO_PERMS"
+	ReasonRepoUpdatedFromCodeHost = "REASON_REPO_UPDATED_FROM_CODE_HOST"
+
+	// ReasonGitHubUserEvent and below are reasons of permission syncs triggered by
+	// webhook events.
+	ReasonGitHubUserEvent                  = "REASON_GITHUB_USER_EVENT"
+	ReasonGitHubUserAddedEvent             = "REASON_GITHUB_USER_ADDED_EVENT"
+	ReasonGitHubUserRemovedEvent           = "REASON_GITHUB_USER_REMOVED_EVENT"
+	ReasonGitHubUserMembershipAddedEvent   = "REASON_GITHUB_USER_MEMBERSHIP_ADDED_EVENT"
+	ReasonGitHubUserMembershipRemovedEvent = "REASON_GITHUB_USER_MEMBERSHIP_REMOVED_EVENT"
+	ReasonGitHubTeamAddedToRepoEvent       = "REASON_GITHUB_TEAM_ADDED_TO_REPO_EVENT"
+	ReasonGitHubTeamRemovedFromRepoEvent   = "REASON_GITHUB_TEAM_REMOVED_FROM_REPO_EVENT"
+	ReasonGitHubOrgMemberAddedEvent        = "REASON_GITHUB_ORG_MEMBER_ADDED_EVENT"
+	ReasonGitHubOrgMemberRemovedEvent      = "REASON_GITHUB_ORG_MEMBER_REMOVED_EVENT"
+	ReasonGitHubRepoEvent                  = "REASON_GITHUB_REPO_EVENT"
+	ReasonGitHubRepoMadePrivateEvent       = "REASON_GITHUB_REPO_MADE_PRIVATE_EVENT"
+
+	// ReasonManualRepoSync and below are reasons of permission syncs triggered
+	// manually.
+	ReasonManualRepoSync = "REASON_MANUAL_REPO_SYNC"
+	ReasonManualUserSync = "REASON_MANUAL_USER_SYNC"
+)
 
 func PermissionSyncWorkerEnabled(ctx context.Context, db database.DB, logger log.Logger) bool {
 	globalFeatureFlags, err := db.FeatureFlags().GetGlobalFeatureFlags(ctx)
@@ -26,9 +60,11 @@ func PermissionSyncWorkerEnabled(ctx context.Context, db database.DB, logger log
 var MockSchedulePermsSync func(ctx context.Context, logger log.Logger, db database.DB, req protocol.PermsSyncRequest)
 
 // SchedulePermsSync enqueues a permission sync job for the given
-// PermsSyncRequest. If the feature flag for the database-backed permission
-// sync worker is enabled then that will be used. Otherwise a request to
-// repo-updater will be sent to enqueue a sync job directly on the PermsSyncer.
+// PermsSyncRequest.
+//
+// If the feature flag for the database-backed permission sync worker is enabled
+// then that will be used. Otherwise, a request to repo-updater will be sent to
+// enqueue a sync job directly on the PermsSyncer.
 //
 // Errors are not fatal since our background permissions syncer will eventually
 // sync the user anyway, so we just log any errors and don't return them here.

--- a/internal/authz/permssync/permssync_test.go
+++ b/internal/authz/permssync/permssync_test.go
@@ -26,10 +26,12 @@ func TestSchedulePermsSync_UserPermsTest(t *testing.T) {
 	db.PermissionSyncJobsFunc.SetDefaultReturn(permsSyncStore)
 	db.FeatureFlagsFunc.SetDefaultReturn(featureFlags)
 
-	SchedulePermsSync(ctx, logger, db, protocol.PermsSyncRequest{UserIDs: []int32{1}})
+	SchedulePermsSync(ctx, logger, db, protocol.PermsSyncRequest{UserIDs: []int32{1}, Reason: ReasonManualUserSync})
 	assert.Len(t, permsSyncStore.CreateUserSyncJobFunc.History(), 1)
 	assert.Empty(t, permsSyncStore.CreateRepoSyncJobFunc.History())
 	assert.Equal(t, int32(1), permsSyncStore.CreateUserSyncJobFunc.History()[0].Arg1)
+	assert.NotNil(t, permsSyncStore.CreateUserSyncJobFunc.History()[0].Arg2)
+	assert.Equal(t, ReasonManualUserSync, permsSyncStore.CreateUserSyncJobFunc.History()[0].Arg2.Reason)
 }
 
 func TestSchedulePermsSync_RepoPermsTest(t *testing.T) {
@@ -47,8 +49,10 @@ func TestSchedulePermsSync_RepoPermsTest(t *testing.T) {
 	db.PermissionSyncJobsFunc.SetDefaultReturn(permsSyncStore)
 	db.FeatureFlagsFunc.SetDefaultReturn(featureFlags)
 
-	SchedulePermsSync(ctx, logger, db, protocol.PermsSyncRequest{RepoIDs: []api.RepoID{1}})
+	SchedulePermsSync(ctx, logger, db, protocol.PermsSyncRequest{RepoIDs: []api.RepoID{1}, Reason: ReasonManualRepoSync})
 	assert.Len(t, permsSyncStore.CreateRepoSyncJobFunc.History(), 1)
 	assert.Empty(t, permsSyncStore.CreateUserSyncJobFunc.History())
 	assert.Equal(t, api.RepoID(1), permsSyncStore.CreateRepoSyncJobFunc.History()[0].Arg1)
+	assert.NotNil(t, permsSyncStore.CreateRepoSyncJobFunc.History()[0].Arg1)
+	assert.Equal(t, ReasonManualRepoSync, permsSyncStore.CreateRepoSyncJobFunc.History()[0].Arg2.Reason)
 }

--- a/internal/database/permission_sync_jobs_test.go
+++ b/internal/database/permission_sync_jobs_test.go
@@ -8,9 +8,15 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
+)
+
+const (
+	// ReasonManualRepoSync and ReasonManualUserSync are copied from permssync
+	// package to avoid import cycles.
+	ReasonManualRepoSync = "REASON_MANUAL_REPO_SYNC"
+	ReasonManualUserSync = "REASON_MANUAL_USER_SYNC"
 )
 
 func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
@@ -34,13 +40,13 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 		t.Fatalf("jobs returned even though database is empty")
 	}
 
-	opts := PermissionSyncJobOpts{HighPriority: true, InvalidateCaches: true}
+	opts := PermissionSyncJobOpts{HighPriority: true, InvalidateCaches: true, Reason: ReasonManualRepoSync}
 	if err := store.CreateRepoSyncJob(ctx, 99, opts); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
 	nextSyncAt := clock.Now().Add(5 * time.Minute)
-	opts = PermissionSyncJobOpts{HighPriority: false, InvalidateCaches: true, NextSyncAt: nextSyncAt}
+	opts = PermissionSyncJobOpts{HighPriority: false, InvalidateCaches: true, NextSyncAt: nextSyncAt, Reason: ReasonManualUserSync}
 	if err := store.CreateUserSyncJob(ctx, 77, opts); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -61,6 +67,7 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 			RepositoryID:     99,
 			HighPriority:     true,
 			InvalidateCaches: true,
+			Reason:           ReasonManualRepoSync,
 		},
 		{
 			ID:               jobs[1].ID,
@@ -68,6 +75,7 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 			UserID:           77,
 			InvalidateCaches: true,
 			ProcessAfter:     nextSyncAt,
+			Reason:           ReasonManualUserSync,
 		},
 	}
 	if diff := cmp.Diff(jobs, wantJobs, cmpopts.IgnoreFields(PermissionSyncJob{}, "QueuedAt")); diff != "" {

--- a/internal/repoupdater/protocol/repoupdater.go
+++ b/internal/repoupdater/protocol/repoupdater.go
@@ -248,6 +248,7 @@ type PermsSyncRequest struct {
 	UserIDs []int32                 `json:"user_ids"`
 	RepoIDs []api.RepoID            `json:"repo_ids"`
 	Options authz.FetchPermsOptions `json:"options"`
+	Reason  string                  `json:"reason"`
 }
 
 // PermsSyncResponse is a response to sync permissions.


### PR DESCRIPTION
Test plan:
Unit test updated.

Part of https://github.com/sourcegraph/sourcegraph/issues/46319.

After this PR next step is to add ID of user who triggered the sync.