### PR TITLE
search: Fix/improve client side query parser

### DIFF
--- a/client/shared/src/search/query/parser.test.ts
+++ b/client/shared/src/search/query/parser.test.ts
@@ -12,45 +12,54 @@ describe('parseSearchQuery', () => {
         expect(parse('repo:foo a b c')).toMatchInlineSnapshot(`
             [
               {
-                "type": "parameter",
-                "field": "repo",
-                "value": "foo",
-                "negated": false,
+                "type": "sequence",
+                "nodes": [
+                  {
+                    "type": "parameter",
+                    "field": "repo",
+                    "value": "foo",
+                    "negated": false,
+                    "range": {
+                      "start": 0,
+                      "end": 8
+                    }
+                  },
+                  {
+                    "type": "pattern",
+                    "kind": 1,
+                    "value": "a",
+                    "quoted": false,
+                    "negated": false,
+                    "range": {
+                      "start": 9,
+                      "end": 10
+                    }
+                  },
+                  {
+                    "type": "pattern",
+                    "kind": 1,
+                    "value": "b",
+                    "quoted": false,
+                    "negated": false,
+                    "range": {
+                      "start": 11,
+                      "end": 12
+                    }
+                  },
+                  {
+                    "type": "pattern",
+                    "kind": 1,
+                    "value": "c",
+                    "quoted": false,
+                    "negated": false,
+                    "range": {
+                      "start": 13,
+                      "end": 14
+                    }
+                  }
+                ],
                 "range": {
                   "start": 0,
-                  "end": 8
-                }
-              },
-              {
-                "type": "pattern",
-                "kind": 1,
-                "value": "a",
-                "quoted": false,
-                "negated": false,
-                "range": {
-                  "start": 9,
-                  "end": 10
-                }
-              },
-              {
-                "type": "pattern",
-                "kind": 1,
-                "value": "b",
-                "quoted": false,
-                "negated": false,
-                "range": {
-                  "start": 11,
-                  "end": 12
-                }
-              },
-              {
-                "type": "pattern",
-                "kind": 1,
-                "value": "c",
-                "quoted": false,
-                "negated": false,
-                "range": {
-                  "start": 13,
                   "end": 14
                 }
               }
@@ -64,24 +73,33 @@ describe('parseSearchQuery', () => {
                 "type": "operator",
                 "operands": [
                   {
-                    "type": "pattern",
-                    "kind": 1,
-                    "value": "a",
-                    "quoted": false,
-                    "negated": false,
+                    "type": "sequence",
+                    "nodes": [
+                      {
+                        "type": "pattern",
+                        "kind": 1,
+                        "value": "a",
+                        "quoted": false,
+                        "negated": false,
+                        "range": {
+                          "start": 0,
+                          "end": 1
+                        }
+                      },
+                      {
+                        "type": "pattern",
+                        "kind": 1,
+                        "value": "b",
+                        "quoted": false,
+                        "negated": false,
+                        "range": {
+                          "start": 2,
+                          "end": 3
+                        }
+                      }
+                    ],
                     "range": {
                       "start": 0,
-                      "end": 1
-                    }
-                  },
-                  {
-                    "type": "pattern",
-                    "kind": 1,
-                    "value": "b",
-                    "quoted": false,
-                    "negated": false,
-                    "range": {
-                      "start": 2,
                       "end": 3
                     }
                   },
@@ -396,56 +414,123 @@ describe('parseSearchQuery', () => {
             ]
         `))
 
+    test('query with mixed explicit OR and implicit AND operators', () =>
+        expect(parse('aaa bbb or ccc')).toMatchInlineSnapshot(`
+            [
+              {
+                "type": "operator",
+                "operands": [
+                  {
+                    "type": "sequence",
+                    "nodes": [
+                      {
+                        "type": "pattern",
+                        "kind": 1,
+                        "value": "aaa",
+                        "quoted": false,
+                        "negated": false,
+                        "range": {
+                          "start": 0,
+                          "end": 3
+                        }
+                      },
+                      {
+                        "type": "pattern",
+                        "kind": 1,
+                        "value": "bbb",
+                        "quoted": false,
+                        "negated": false,
+                        "range": {
+                          "start": 4,
+                          "end": 7
+                        }
+                      }
+                    ],
+                    "range": {
+                      "start": 0,
+                      "end": 7
+                    }
+                  },
+                  {
+                    "type": "pattern",
+                    "kind": 1,
+                    "value": "ccc",
+                    "quoted": false,
+                    "negated": false,
+                    "range": {
+                      "start": 11,
+                      "end": 14
+                    }
+                  }
+                ],
+                "kind": "OR",
+                "range": {
+                  "start": 0,
+                  "end": 14
+                }
+              }
+            ]
+        `))
+
     test('query with mixed explicit and implicit operators inside parens', () =>
         expect(parse('(aaa bbb and ccc)')).toMatchInlineSnapshot(`
-                            [
-                              {
-                                "type": "operator",
-                                "operands": [
-                                  {
-                                    "type": "pattern",
-                                    "kind": 1,
-                                    "value": "aaa",
-                                    "quoted": false,
-                                    "negated": false,
-                                    "range": {
-                                      "start": 1,
-                                      "end": 4
-                                    }
-                                  },
-                                  {
-                                    "type": "pattern",
-                                    "kind": 1,
-                                    "value": "bbb",
-                                    "quoted": false,
-                                    "negated": false,
-                                    "range": {
-                                      "start": 5,
-                                      "end": 8
-                                    }
-                                  },
-                                  {
-                                    "type": "pattern",
-                                    "kind": 1,
-                                    "value": "ccc",
-                                    "quoted": false,
-                                    "negated": false,
-                                    "range": {
-                                      "start": 13,
-                                      "end": 16
-                                    }
-                                  }
-                                ],
-                                "kind": "AND",
-                                "range": {
-                                  "start": 1,
-                                  "end": 16
-                                },
-                                "groupRange": {
-                                  "start": 0,
-                                  "end": 17
-                                }
-                              }
-                            ]
-                    `))
+            [
+              {
+                "type": "operator",
+                "operands": [
+                  {
+                    "type": "sequence",
+                    "nodes": [
+                      {
+                        "type": "pattern",
+                        "kind": 1,
+                        "value": "aaa",
+                        "quoted": false,
+                        "negated": false,
+                        "range": {
+                          "start": 1,
+                          "end": 4
+                        }
+                      },
+                      {
+                        "type": "pattern",
+                        "kind": 1,
+                        "value": "bbb",
+                        "quoted": false,
+                        "negated": false,
+                        "range": {
+                          "start": 5,
+                          "end": 8
+                        }
+                      }
+                    ],
+                    "range": {
+                      "start": 1,
+                      "end": 8
+                    }
+                  },
+                  {
+                    "type": "pattern",
+                    "kind": 1,
+                    "value": "ccc",
+                    "quoted": false,
+                    "negated": false,
+                    "range": {
+                      "start": 13,
+                      "end": 16
+                    }
+                  }
+                ],
+                "kind": "AND",
+                "range": {
+                  "start": 1,
+                  "end": 16
+                },
+                "groupRange": {
+                  "start": 0,
+                  "end": 17
+                }
+              }
+            ]
+        `))
 })

--- a/client/shared/src/search/query/parser.test.ts
+++ b/client/shared/src/search/query/parser.test.ts
@@ -162,8 +162,35 @@ describe('parseSearchQuery', () => {
             ]
         `))
 
+    test('query with not', () =>
+        expect(parse('not a')).toMatchInlineSnapshot(`
+            [
+              {
+                "type": "operator",
+                "operands": [
+                  {
+                    "type": "pattern",
+                    "kind": 1,
+                    "value": "a",
+                    "quoted": false,
+                    "negated": false,
+                    "range": {
+                      "start": 4,
+                      "end": 5
+                    }
+                  }
+                ],
+                "kind": "NOT",
+                "range": {
+                  "start": 0,
+                  "end": 5
+                }
+              }
+            ]
+        `))
+
     test('query with and/or operator precedence', () =>
-        expect(parse('a or b and c')).toMatchInlineSnapshot(`
+        expect(parse('a or b and not c')).toMatchInlineSnapshot(`
             [
               {
                 "type": "operator",
@@ -194,28 +221,38 @@ describe('parseSearchQuery', () => {
                         }
                       },
                       {
-                        "type": "pattern",
-                        "kind": 1,
-                        "value": "c",
-                        "quoted": false,
-                        "negated": false,
+                        "type": "operator",
+                        "operands": [
+                          {
+                            "type": "pattern",
+                            "kind": 1,
+                            "value": "c",
+                            "quoted": false,
+                            "negated": false,
+                            "range": {
+                              "start": 15,
+                              "end": 16
+                            }
+                          }
+                        ],
+                        "kind": "NOT",
                         "range": {
                           "start": 11,
-                          "end": 12
+                          "end": 16
                         }
                       }
                     ],
                     "kind": "AND",
                     "range": {
                       "start": 5,
-                      "end": 12
+                      "end": 16
                     }
                   }
                 ],
                 "kind": "OR",
                 "range": {
                   "start": 0,
-                  "end": 12
+                  "end": 16
                 }
               }
             ]
@@ -345,6 +382,149 @@ describe('parseSearchQuery', () => {
               }
             ]
         `)
+
+        expect(parse('not (a or b) and c')).toMatchInlineSnapshot(`
+            [
+              {
+                "type": "operator",
+                "operands": [
+                  {
+                    "type": "operator",
+                    "operands": [
+                      {
+                        "type": "operator",
+                        "operands": [
+                          {
+                            "type": "pattern",
+                            "kind": 1,
+                            "value": "a",
+                            "quoted": false,
+                            "negated": false,
+                            "range": {
+                              "start": 5,
+                              "end": 6
+                            }
+                          },
+                          {
+                            "type": "pattern",
+                            "kind": 1,
+                            "value": "b",
+                            "quoted": false,
+                            "negated": false,
+                            "range": {
+                              "start": 10,
+                              "end": 11
+                            }
+                          }
+                        ],
+                        "kind": "OR",
+                        "range": {
+                          "start": 5,
+                          "end": 11
+                        },
+                        "groupRange": {
+                          "start": 4,
+                          "end": 12
+                        }
+                      }
+                    ],
+                    "kind": "NOT",
+                    "range": {
+                      "start": 0,
+                      "end": 12
+                    }
+                  },
+                  {
+                    "type": "pattern",
+                    "kind": 1,
+                    "value": "c",
+                    "quoted": false,
+                    "negated": false,
+                    "range": {
+                      "start": 17,
+                      "end": 18
+                    }
+                  }
+                ],
+                "kind": "AND",
+                "range": {
+                  "start": 0,
+                  "end": 18
+                }
+              }
+            ]
+        `)
+        expect(parse('not (a and b) or c')).toMatchInlineSnapshot(`
+            [
+              {
+                "type": "operator",
+                "operands": [
+                  {
+                    "type": "operator",
+                    "operands": [
+                      {
+                        "type": "operator",
+                        "operands": [
+                          {
+                            "type": "pattern",
+                            "kind": 1,
+                            "value": "a",
+                            "quoted": false,
+                            "negated": false,
+                            "range": {
+                              "start": 5,
+                              "end": 6
+                            }
+                          },
+                          {
+                            "type": "pattern",
+                            "kind": 1,
+                            "value": "b",
+                            "quoted": false,
+                            "negated": false,
+                            "range": {
+                              "start": 11,
+                              "end": 12
+                            }
+                          }
+                        ],
+                        "kind": "AND",
+                        "range": {
+                          "start": 5,
+                          "end": 12
+                        },
+                        "groupRange": {
+                          "start": 4,
+                          "end": 13
+                        }
+                      }
+                    ],
+                    "kind": "NOT",
+                    "range": {
+                      "start": 0,
+                      "end": 13
+                    }
+                  },
+                  {
+                    "type": "pattern",
+                    "kind": 1,
+                    "value": "c",
+                    "quoted": false,
+                    "negated": false,
+                    "range": {
+                      "start": 17,
+                      "end": 18
+                    }
+                  }
+                ],
+                "kind": "OR",
+                "range": {
+                  "start": 0,
+                  "end": 18
+                }
+              }
+            ]
+        `)
     })
 
     test('query with nested parentheses', () =>
@@ -409,6 +589,79 @@ describe('parseSearchQuery', () => {
                 "groupRange": {
                   "start": 0,
                   "end": 16
+                }
+              }
+            ]
+        `))
+
+    test('query with mixed parenthesis and implicit AND', () =>
+        expect(parse('(a AND b) c d')).toMatchInlineSnapshot(`
+            [
+              {
+                "type": "sequence",
+                "nodes": [
+                  {
+                    "type": "operator",
+                    "operands": [
+                      {
+                        "type": "pattern",
+                        "kind": 1,
+                        "value": "a",
+                        "quoted": false,
+                        "negated": false,
+                        "range": {
+                          "start": 1,
+                          "end": 2
+                        }
+                      },
+                      {
+                        "type": "pattern",
+                        "kind": 1,
+                        "value": "b",
+                        "quoted": false,
+                        "negated": false,
+                        "range": {
+                          "start": 7,
+                          "end": 8
+                        }
+                      }
+                    ],
+                    "kind": "AND",
+                    "range": {
+                      "start": 1,
+                      "end": 8
+                    },
+                    "groupRange": {
+                      "start": 0,
+                      "end": 9
+                    }
+                  },
+                  {
+                    "type": "pattern",
+                    "kind": 1,
+                    "value": "c",
+                    "quoted": false,
+                    "negated": false,
+                    "range": {
+                      "start": 10,
+                      "end": 11
+                    }
+                  },
+                  {
+                    "type": "pattern",
+                    "kind": 1,
+                    "value": "d",
+                    "quoted": false,
+                    "negated": false,
+                    "range": {
+                      "start": 12,
+                      "end": 13
+                    }
+                  }
+                ],
+                "range": {
+                  "start": 0,
+                  "end": 13
                 }
               }
             ]

--- a/client/shared/src/search/query/parser.ts
+++ b/client/shared/src/search/query/parser.ts
@@ -154,6 +154,11 @@ export const parseParenthesis = (tokens: Token[]): State => {
 
 const parseNot = (tokens: Token[]): State => {
     const keyword = tokens[0]
+
+    if (!(keyword.type === 'keyword' && keyword.kind === KeywordKind.Not)) {
+        throw new Error('parseNot is called at an invalid token position')
+    }
+
     tokens = tokens.slice(1) // consume NOT
 
     let nodes: Node[] = []
@@ -213,7 +218,7 @@ const parseSequence = (tokens: Token[]): State => {
         }
         if (current.type === 'keyword') {
             if (current.kind === KeywordKind.And || current.kind === KeywordKind.Or) {
-                return { result: createSequence(nodes), tokens } // Caller advances.
+                break // Caller advances.
             }
             if (current.kind === KeywordKind.Not) {
                 const state = parseNot(tokens)

--- a/client/shared/src/search/query/parser.ts
+++ b/client/shared/src/search/query/parser.ts
@@ -164,7 +164,7 @@ const parseNot = (tokens: Token[]): State => {
     }
 
     switch (operand.type) {
-        case 'openingParen':
+        case 'openingParen': {
             const state = parseParenthesis(tokens)
             if (state.result.type === 'error') {
                 return { result: state.result, tokens }
@@ -172,13 +172,15 @@ const parseNot = (tokens: Token[]): State => {
             nodes = state.result.nodes
             tokens = state.tokens
             break
-        default:
+        }
+        default: {
             const node = tokenToLeafNode(operand)
             if (node.type === 'error') {
                 return { result: node, tokens }
             }
             nodes = node.nodes
             tokens = tokens.slice(1)
+        }
     }
 
     return { result: createOperator(nodes, OperatorKind.Not, keyword.range.start), tokens }

--- a/client/shared/src/search/query/visitor.ts
+++ b/client/shared/src/search/query/visitor.ts
@@ -1,4 +1,4 @@
-import { Node, Operator, Parameter, Pattern, OperatorKind } from './parser'
+import { Node, Operator, Parameter, Pattern, OperatorKind, Sequence } from './parser'
 import { CharacterRange, PatternKind } from './token'
 
 export class Visitor {
@@ -20,6 +20,9 @@ export class Visitor {
                 case 'operator':
                     this.visitOperator(node)
                     break
+                case 'sequence':
+                    this.visitSequence(node)
+                    break
                 case 'parameter':
                     this.visitParameter(node)
                     break
@@ -37,6 +40,13 @@ export class Visitor {
         this.visit(node.operands)
     }
 
+    private visitSequence(node: Sequence): void {
+        if (this._visitors.visitSequence) {
+            this._visitors.visitSequence(node.nodes, node.range)
+        }
+        this.visit(node.nodes)
+    }
+
     private visitParameter(node: Parameter): void {
         if (this._visitors.visitParameter) {
             this._visitors.visitParameter(node.field, node.value, node.negated, node.range)
@@ -52,6 +62,7 @@ export class Visitor {
 
 export interface Visitors {
     visitOperator?(operands: Node[], kind: OperatorKind, range: CharacterRange, groupRange?: CharacterRange): void
+    visitSequence?(nodes: Node[], range: CharacterRange): void
     visitParameter?(field: string, value: string, negated: boolean, range: CharacterRange): void
     visitPattern?(value: string, kind: PatternKind, negated: boolean, quoted: boolean, range: CharacterRange): void
 }


### PR DESCRIPTION
The current implementation incorrectly handles "leaves". For example 'a b OR c' is parsed as

```
{
  type: 'operator',
  operands: [
    {type: 'pattern', value: 'a'},
    {type: 'pattern', value: 'b'},
    {type: 'pattern', value: 'c'},
  ]
}
```

which is wrong, or at least imprecise. Without more information it's not clear whether this node represents 'a OR b c' or 'a b OR c'.

With this commit consecutive "leaves" are represented as a "sequence" instead (see test output changes).

Additionally this commit adds support for parsing the NOT keyword.

## Test plan

Updated unit test.
Opened search home page, entered query `a b c AND D OR E ((a or b) and d)` and hovered over `AND` and `OR` operators. Their ranges are still highlighted correctly.

## App preview:

- [Web](https://sg-web-fkling-query-parser.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
