### PR TITLE
config: Remove enableWebhookRepoSync

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -669,8 +669,6 @@ type ExperimentalFeatures struct {
 	EnablePermissionsWebhooks bool `json:"enablePermissionsWebhooks,omitempty"`
 	// EnablePostSignupFlow description: Enables post sign-up user flow to add code hosts and sync code
 	EnablePostSignupFlow bool `json:"enablePostSignupFlow,omitempty"`
-	// EnableWebhookRepoSync description: Enable webhooks for repo syncing
-	EnableWebhookRepoSync bool `json:"enableWebhookRepoSync,omitempty"`
 	// EventLogging description: Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.
 	EventLogging string `json:"eventLogging,omitempty"`
 	// Gerrit description: Allow adding Gerrit code host connections
@@ -758,7 +756,6 @@ func (v *ExperimentalFeatures) UnmarshalJSON(data []byte) error {
 	delete(m, "enableLegacyExtensions")
 	delete(m, "enablePermissionsWebhooks")
 	delete(m, "enablePostSignupFlow")
-	delete(m, "enableWebhookRepoSync")
 	delete(m, "eventLogging")
 	delete(m, "gerrit")
 	delete(m, "gitServerPinnedRepos")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -356,13 +356,6 @@
           "type": "boolean",
           "default": false
         },
-        "enableWebhookRepoSync": {
-          "description": "Enable webhooks for repo syncing",
-          "type": "boolean",
-          "default": false,
-          "!go": { "pointer": false },
-          "deprecationMessage": "This setting is deprecated and is ignored. Syncing repositories via webhooks is enabled by default."
-        },
         "enablePermissionsWebhooks": {
           "description": "Enables webhook consumers to sync permissions from external services faster than the defaults schedule",
           "type": "boolean",


### PR DESCRIPTION
This has always been experimental so is safe to remove.

Part of #46562 

## Test plan

Only config schema change