### PR TITLE
permissions-center: add user ID who triggered the perms sync.

### DIFF
--- a/internal/auth/site_admin.go
+++ b/internal/auth/site_admin.go
@@ -15,20 +15,31 @@ var ErrMustBeSiteAdmin = errors.New("must be site admin")
 
 // CheckCurrentUserIsSiteAdmin returns an error if the current user is NOT a site admin.
 func CheckCurrentUserIsSiteAdmin(ctx context.Context, db database.DB) error {
+	_, err := checkCurrentUserIsSiteAdmin(ctx, db)
+	return err
+}
+
+// CheckCurrentUserIsSiteAdminAndReturn returns an error if the current user is
+// NOT a site admin and returns a user otherwise.
+func CheckCurrentUserIsSiteAdminAndReturn(ctx context.Context, db database.DB) (*types.User, error) {
+	return checkCurrentUserIsSiteAdmin(ctx, db)
+}
+
+func checkCurrentUserIsSiteAdmin(ctx context.Context, db database.DB) (*types.User, error) {
 	if actor.FromContext(ctx).IsInternal() {
-		return nil
+		return nil, nil
 	}
 	user, err := CurrentUser(ctx, db)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if user == nil {
-		return ErrNotAuthenticated
+		return nil, ErrNotAuthenticated
 	}
 	if !user.SiteAdmin {
-		return ErrMustBeSiteAdmin
+		return nil, ErrMustBeSiteAdmin
 	}
-	return nil
+	return user, nil
 }
 
 // CheckUserIsSiteAdmin returns an error if the user is NOT a site admin.

--- a/internal/authz/permssync/permssync.go
+++ b/internal/authz/permssync/permssync.go
@@ -78,9 +78,10 @@ func SchedulePermsSync(ctx context.Context, logger log.Logger, db database.DB, r
 	if PermissionSyncWorkerEnabled(ctx, db, logger) {
 		for _, userID := range req.UserIDs {
 			opts := database.PermissionSyncJobOpts{
-				HighPriority:     true,
-				InvalidateCaches: req.Options.InvalidateCaches,
-				Reason:           req.Reason,
+				HighPriority:      true,
+				InvalidateCaches:  req.Options.InvalidateCaches,
+				Reason:            req.Reason,
+				TriggeredByUserID: req.TriggeredByUserID,
 			}
 			err := db.PermissionSyncJobs().CreateUserSyncJob(ctx, userID, opts)
 			if err != nil {
@@ -90,9 +91,10 @@ func SchedulePermsSync(ctx context.Context, logger log.Logger, db database.DB, r
 
 		for _, repoID := range req.RepoIDs {
 			opts := database.PermissionSyncJobOpts{
-				HighPriority:     true,
-				InvalidateCaches: req.Options.InvalidateCaches,
-				Reason:           req.Reason,
+				HighPriority:      true,
+				InvalidateCaches:  req.Options.InvalidateCaches,
+				Reason:            req.Reason,
+				TriggeredByUserID: req.TriggeredByUserID,
 			}
 			err := db.PermissionSyncJobs().CreateRepoSyncJob(ctx, repoID, opts)
 			if err != nil {

--- a/internal/authz/permssync/permssync_test.go
+++ b/internal/authz/permssync/permssync_test.go
@@ -26,12 +26,14 @@ func TestSchedulePermsSync_UserPermsTest(t *testing.T) {
 	db.PermissionSyncJobsFunc.SetDefaultReturn(permsSyncStore)
 	db.FeatureFlagsFunc.SetDefaultReturn(featureFlags)
 
-	SchedulePermsSync(ctx, logger, db, protocol.PermsSyncRequest{UserIDs: []int32{1}, Reason: ReasonManualUserSync})
+	request := protocol.PermsSyncRequest{UserIDs: []int32{1}, Reason: ReasonManualUserSync, TriggeredByUserID: int32(123)}
+	SchedulePermsSync(ctx, logger, db, request)
 	assert.Len(t, permsSyncStore.CreateUserSyncJobFunc.History(), 1)
 	assert.Empty(t, permsSyncStore.CreateRepoSyncJobFunc.History())
 	assert.Equal(t, int32(1), permsSyncStore.CreateUserSyncJobFunc.History()[0].Arg1)
 	assert.NotNil(t, permsSyncStore.CreateUserSyncJobFunc.History()[0].Arg2)
 	assert.Equal(t, ReasonManualUserSync, permsSyncStore.CreateUserSyncJobFunc.History()[0].Arg2.Reason)
+	assert.Equal(t, int32(123), permsSyncStore.CreateUserSyncJobFunc.History()[0].Arg2.TriggeredByUserID)
 }
 
 func TestSchedulePermsSync_RepoPermsTest(t *testing.T) {
@@ -49,10 +51,12 @@ func TestSchedulePermsSync_RepoPermsTest(t *testing.T) {
 	db.PermissionSyncJobsFunc.SetDefaultReturn(permsSyncStore)
 	db.FeatureFlagsFunc.SetDefaultReturn(featureFlags)
 
-	SchedulePermsSync(ctx, logger, db, protocol.PermsSyncRequest{RepoIDs: []api.RepoID{1}, Reason: ReasonManualRepoSync})
+	request := protocol.PermsSyncRequest{RepoIDs: []api.RepoID{1}, Reason: ReasonManualRepoSync}
+	SchedulePermsSync(ctx, logger, db, request)
 	assert.Len(t, permsSyncStore.CreateRepoSyncJobFunc.History(), 1)
 	assert.Empty(t, permsSyncStore.CreateUserSyncJobFunc.History())
 	assert.Equal(t, api.RepoID(1), permsSyncStore.CreateRepoSyncJobFunc.History()[0].Arg1)
 	assert.NotNil(t, permsSyncStore.CreateRepoSyncJobFunc.History()[0].Arg1)
 	assert.Equal(t, ReasonManualRepoSync, permsSyncStore.CreateRepoSyncJobFunc.History()[0].Arg2.Reason)
+	assert.Equal(t, int32(0), permsSyncStore.CreateRepoSyncJobFunc.History()[0].Arg2.TriggeredByUserID)
 }

--- a/internal/database/dbutil/dbutil.go
+++ b/internal/database/dbutil/dbutil.go
@@ -26,7 +26,7 @@ func IsPostgresError(err error, codename string) bool {
 }
 
 // NullTime represents a time.Time that may be null. nullTime implements the
-// sql.Scanner interface so it can be used as a scan destination, similar to
+// sql.Scanner interface, so it can be used as a scan destination, similar to
 // sql.NullString. When the scanned value is null, Time is set to the zero value.
 type NullTime struct{ *time.Time }
 
@@ -53,7 +53,7 @@ func NullTimeColumn(t time.Time) *time.Time {
 }
 
 // NullString represents a string that may be null. NullString implements the
-// sql.Scanner interface so it can be used as a scan destination, similar to
+// sql.Scanner interface, so it can be used as a scan destination, similar to
 // sql.NullString. When the scanned value is null, String is set to the zero value.
 type NullString struct{ S *string }
 
@@ -93,9 +93,17 @@ func NullStringColumn(s string) *string {
 }
 
 // NullInt32 represents an int32 that may be null. NullInt32 implements the
-// sql.Scanner interface so it can be used as a scan destination, similar to
+// sql.Scanner interface, so it can be used as a scan destination, similar to
 // sql.NullString. When the scanned value is null, int32 is set to the zero value.
 type NullInt32 struct{ N *int32 }
+
+// NewNullInt32 returns a NullInt64 treating zero value as null.
+func NewNullInt32(i int32) NullInt32 {
+	if i == 0 {
+		return NullInt32{}
+	}
+	return NullInt32{N: &i}
+}
 
 // Scan implements the Scanner interface.
 func (n *NullInt32) Scan(value any) error {
@@ -129,7 +137,7 @@ func NullInt32Column(n int32) *int32 {
 }
 
 // NullInt64 represents an int64 that may be null. NullInt64 implements the
-// sql.Scanner interface so it can be used as a scan destination, similar to
+// sql.Scanner interface, so it can be used as a scan destination, similar to
 // sql.NullString. When the scanned value is null, int64 is set to the zero value.
 type NullInt64 struct{ N *int64 }
 
@@ -173,7 +181,7 @@ func NullInt64Column(n int64) *int64 {
 }
 
 // NullInt represents an int that may be null. NullInt implements the
-// sql.Scanner interface so it can be used as a scan destination, similar to
+// sql.Scanner interface, so it can be used as a scan destination, similar to
 // sql.NullString. When the scanned value is null, int is set to the zero value.
 type NullInt struct{ N *int }
 
@@ -209,7 +217,7 @@ func (n NullInt) Value() (driver.Value, error) {
 }
 
 // NullBool represents a bool that may be null. NullBool implements the
-// sql.Scanner interface so it can be used as a scan destination, similar to
+// sql.Scanner interface, so it can be used as a scan destination, similar to
 // sql.NullString. When the scanned value is null, B is set to false.
 type NullBool struct{ B *bool }
 
@@ -241,7 +249,7 @@ func (n NullBool) Value() (driver.Value, error) {
 }
 
 // JSONInt64Set represents an int64 set as a JSONB object where the keys are
-// the ids and the values are null. It implements the sql.Scanner interface so
+// the ids and the values are null. It implements the sql.Scanner interface, so
 // it can be used as a scan destination, similar to
 // sql.NullString.
 type JSONInt64Set struct{ Set *[]int64 }
@@ -282,7 +290,7 @@ func (n JSONInt64Set) Value() (driver.Value, error) {
 }
 
 // NullJSONRawMessage represents a json.RawMessage that may be null. NullJSONRawMessage implements the
-// sql.Scanner interface so it can be used as a scan destination, similar to
+// sql.Scanner interface, so it can be used as a scan destination, similar to
 // sql.NullString. When the scanned value is null, Raw is left as nil.
 type NullJSONRawMessage struct {
 	Raw json.RawMessage

--- a/internal/database/permission_sync_jobs_test.go
+++ b/internal/database/permission_sync_jobs_test.go
@@ -29,6 +29,9 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := NewDB(logger, dbtest.NewDB(logger, t))
 	user, err := db.Users().Create(context.Background(), NewUser{Username: "horse"})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
 	ctx := context.Background()
 
 	store := PermissionSyncJobsWith(logger, db)

--- a/internal/database/permission_sync_jobs_test.go
+++ b/internal/database/permission_sync_jobs_test.go
@@ -28,6 +28,7 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	db := NewDB(logger, dbtest.NewDB(logger, t))
+	user, err := db.Users().Create(context.Background(), NewUser{Username: "horse"})
 	ctx := context.Background()
 
 	store := PermissionSyncJobsWith(logger, db)
@@ -40,7 +41,7 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 		t.Fatalf("jobs returned even though database is empty")
 	}
 
-	opts := PermissionSyncJobOpts{HighPriority: true, InvalidateCaches: true, Reason: ReasonManualRepoSync}
+	opts := PermissionSyncJobOpts{HighPriority: true, InvalidateCaches: true, Reason: ReasonManualRepoSync, TriggeredByUserID: user.ID}
 	if err := store.CreateRepoSyncJob(ctx, 99, opts); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -62,12 +63,13 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 
 	wantJobs := []*PermissionSyncJob{
 		{
-			ID:               jobs[0].ID,
-			State:            "queued",
-			RepositoryID:     99,
-			HighPriority:     true,
-			InvalidateCaches: true,
-			Reason:           ReasonManualRepoSync,
+			ID:                jobs[0].ID,
+			State:             "queued",
+			RepositoryID:      99,
+			HighPriority:      true,
+			InvalidateCaches:  true,
+			Reason:            ReasonManualRepoSync,
+			TriggeredByUserID: user.ID,
 		},
 		{
 			ID:               jobs[1].ID,

--- a/internal/repoupdater/protocol/repoupdater.go
+++ b/internal/repoupdater/protocol/repoupdater.go
@@ -245,10 +245,11 @@ type ChangesetSyncResponse struct {
 // PermsSyncRequest is a request to sync permissions. The provided options are used to
 // sync all provided users and repos - to use different options, make a separate request.
 type PermsSyncRequest struct {
-	UserIDs []int32                 `json:"user_ids"`
-	RepoIDs []api.RepoID            `json:"repo_ids"`
-	Options authz.FetchPermsOptions `json:"options"`
-	Reason  string                  `json:"reason"`
+	UserIDs           []int32                 `json:"user_ids"`
+	RepoIDs           []api.RepoID            `json:"repo_ids"`
+	Options           authz.FetchPermsOptions `json:"options"`
+	Reason            string                  `json:"reason"`
+	TriggeredByUserID int32                   `json:"triggered_by_user_id"`
 }
 
 // PermsSyncResponse is a response to sync permissions.


### PR DESCRIPTION
Test plan:
Unit tests updated.

Closes https://github.com/sourcegraph/sourcegraph/issues/46319

@thenamankumar @mrnugget I think these are the only places for manual syncs for which it makes sense to include the user ID, but pls double-check me.