### PR TITLE
test: move client/shared testHelpers to src/testing/

### DIFF
--- a/client/browser/src/shared/code-hosts/shared/codeHost.test.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.test.tsx
@@ -16,10 +16,10 @@ import { wrapRemoteObservable } from '@sourcegraph/shared/src/api/client/api/com
 import { FlatExtensionHostAPI } from '@sourcegraph/shared/src/api/contract'
 import { ExtensionCodeEditor } from '@sourcegraph/shared/src/api/extension/api/codeEditor'
 import { NotificationType } from '@sourcegraph/shared/src/api/extension/extensionHostApi'
-import { integrationTestContext } from '@sourcegraph/shared/src/api/integration-test/testHelpers'
 import { Controller } from '@sourcegraph/shared/src/extensions/controller'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockIntersectionObserver } from '@sourcegraph/shared/src/testing/MockIntersectionObserver'
+import { integrationTestContext } from '@sourcegraph/shared/src/testing/testHelpers'
 import { toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
 
 import { ResolveRepoResult } from '../../../graphql-operations'

--- a/client/browser/src/shared/code-hosts/shared/views.test.ts
+++ b/client/browser/src/shared/code-hosts/shared/views.test.ts
@@ -3,7 +3,7 @@ import { from, Observable, of, Subject, Subscription, NEVER } from 'rxjs'
 import { bufferCount, map, switchMap, toArray } from 'rxjs/operators'
 import * as sinon from 'sinon'
 
-import { createBarrier } from '@sourcegraph/shared/src/api/integration-test/testHelpers'
+import { createBarrier } from '@sourcegraph/shared/src/testing/testHelpers'
 
 import { MutationRecordLike } from '../../util/dom'
 

--- a/client/shared/src/actions/ActionItem.test.tsx
+++ b/client/shared/src/actions/ActionItem.test.tsx
@@ -6,8 +6,8 @@ import { NEVER } from 'rxjs'
 import { assertAriaEnabled } from '@sourcegraph/testing'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
-import { createBarrier } from '../api/integration-test/testHelpers'
 import { NOOP_TELEMETRY_SERVICE } from '../telemetry/telemetryService'
+import { createBarrier } from '../testing/testHelpers'
 
 import { ActionItem } from './ActionItem'
 

--- a/client/shared/src/api/integration-test/codeEditor.test.ts
+++ b/client/shared/src/api/integration-test/codeEditor.test.ts
@@ -3,7 +3,7 @@ import { distinctUntilChanged, switchMap, take, toArray } from 'rxjs/operators'
 
 import { Selection } from '@sourcegraph/extension-api-classes'
 
-import { assertToJSON, integrationTestContext } from './testHelpers'
+import { assertToJSON, integrationTestContext } from '../../testing/testHelpers'
 
 describe('CodeEditor (integration)', () => {
     describe('selection', () => {

--- a/client/shared/src/api/integration-test/commands.test.ts
+++ b/client/shared/src/api/integration-test/commands.test.ts
@@ -1,4 +1,4 @@
-import { integrationTestContext } from './testHelpers'
+import { integrationTestContext } from '../../testing/testHelpers'
 
 describe('Commands (integration)', () => {
     describe('commands.registerCommand', () => {

--- a/client/shared/src/api/integration-test/configuration.test.ts
+++ b/client/shared/src/api/integration-test/configuration.test.ts
@@ -1,9 +1,8 @@
 import { BehaviorSubject, of } from 'rxjs'
 
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeOrError } from '../../settings/settings'
+import { assertToJSON, integrationTestContext } from '../../testing/testHelpers'
 import { SettingsEdit } from '../client/services/settings'
-
-import { assertToJSON, integrationTestContext } from './testHelpers'
 
 describe('Configuration (integration)', () => {
     test('is synchronously available', async () => {

--- a/client/shared/src/api/integration-test/documents.test.ts
+++ b/client/shared/src/api/integration-test/documents.test.ts
@@ -1,6 +1,5 @@
 import type { TextDocument } from '../../codeintel/legacy-extensions/api'
-
-import { assertToJSON, collectSubscribableValues, integrationTestContext } from './testHelpers'
+import { assertToJSON, collectSubscribableValues, integrationTestContext } from '../../testing/testHelpers'
 
 describe('Documents (integration)', () => {
     describe('workspace.textDocuments', () => {

--- a/client/shared/src/api/integration-test/internal.test.ts
+++ b/client/shared/src/api/integration-test/internal.test.ts
@@ -1,4 +1,4 @@
-import { integrationTestContext } from './testHelpers'
+import { integrationTestContext } from '../../testing/testHelpers'
 
 describe('Internal (integration)', () => {
     test('constant values', async () => {

--- a/client/shared/src/api/integration-test/languageFeatures.test.ts
+++ b/client/shared/src/api/integration-test/languageFeatures.test.ts
@@ -7,10 +7,9 @@ import { MaybeLoadingResult } from '@sourcegraph/codeintellify'
 import { MarkupKind } from '@sourcegraph/extension-api-classes'
 import { Location } from '@sourcegraph/extension-api-types'
 
+import { assertToJSON, createBarrier, integrationTestContext } from '../../testing/testHelpers'
 import { wrapRemoteObservable } from '../client/api/common'
 import { FlatExtensionHostAPI } from '../contract'
-
-import { assertToJSON, createBarrier, integrationTestContext } from './testHelpers'
 
 describe('LanguageFeatures (integration)', () => {
     testLocationProvider<sourcegraph.HoverProvider>({

--- a/client/shared/src/api/integration-test/roots.test.ts
+++ b/client/shared/src/api/integration-test/roots.test.ts
@@ -1,6 +1,5 @@
 import type { WorkspaceRoot } from '../../codeintel/legacy-extensions/api'
-
-import { collectSubscribableValues, integrationTestContext } from './testHelpers'
+import { collectSubscribableValues, integrationTestContext } from '../../testing/testHelpers'
 
 describe('Workspace roots (integration)', () => {
     describe('workspace.roots', () => {

--- a/client/shared/src/api/integration-test/search.test.ts
+++ b/client/shared/src/api/integration-test/search.test.ts
@@ -1,8 +1,7 @@
 import { take } from 'rxjs/operators'
 
+import { integrationTestContext } from '../../testing/testHelpers'
 import { wrapRemoteObservable } from '../client/api/common'
-
-import { integrationTestContext } from './testHelpers'
 
 describe('search (integration)', () => {
     test('registers a query transformer', async () => {

--- a/client/shared/src/api/integration-test/selections.test.ts
+++ b/client/shared/src/api/integration-test/selections.test.ts
@@ -3,7 +3,7 @@ import { distinctUntilChanged, filter, switchMap } from 'rxjs/operators'
 
 import { isDefined, isTaggedUnionMember } from '@sourcegraph/common'
 
-import { assertToJSON, collectSubscribableValues, integrationTestContext } from './testHelpers'
+import { assertToJSON, collectSubscribableValues, integrationTestContext } from '../../testing/testHelpers'
 
 describe('Selections (integration)', () => {
     describe('editor.selectionsChanged', () => {

--- a/client/shared/src/api/integration-test/views.test.ts
+++ b/client/shared/src/api/integration-test/views.test.ts
@@ -3,9 +3,8 @@ import { first, take, toArray } from 'rxjs/operators'
 
 import { ContributableViewContainer } from '@sourcegraph/client-api'
 
+import { assertToJSON, integrationTestContext } from '../../testing/testHelpers'
 import { wrapRemoteObservable } from '../client/api/common'
-
-import { assertToJSON, integrationTestContext } from './testHelpers'
 
 describe('Views (integration)', () => {
     describe('app.createPanelView', () => {

--- a/client/shared/src/api/integration-test/windows.test.ts
+++ b/client/shared/src/api/integration-test/windows.test.ts
@@ -3,11 +3,10 @@ import { from, of } from 'rxjs'
 import { switchMap, take, toArray, first } from 'rxjs/operators'
 import type { ViewComponent, Window } from 'sourcegraph'
 
+import { assertToJSON, integrationTestContext } from '../../testing/testHelpers'
 import { wrapRemoteObservable } from '../client/api/common'
 import { NotificationType } from '../extension/extensionHostApi'
 import { TextDocumentData } from '../viewerTypes'
-
-import { assertToJSON, integrationTestContext } from './testHelpers'
 
 describe('Windows (integration)', () => {
     describe('app.activeWindow', () => {

--- a/client/shared/src/hover/actions.test.ts
+++ b/client/shared/src/hover/actions.test.ts
@@ -17,8 +17,8 @@ import { ActionItemAction } from '../actions/ActionItem'
 import { ExposedToClient } from '../api/client/mainthread-api'
 import { FlatExtensionHostAPI } from '../api/contract'
 import { WorkspaceRootWithMetadata } from '../api/extension/extensionHostApi'
-import { integrationTestContext } from '../api/integration-test/testHelpers'
 import { PlatformContext, URLToFileContext } from '../platform/context'
+import { integrationTestContext } from '../testing/testHelpers'
 import {
     FileSpec,
     UIPositionSpec,

--- a/client/shared/src/testing/testHelpers.ts
+++ b/client/shared/src/testing/testHelpers.ts
@@ -4,13 +4,13 @@ import { Remote } from 'comlink'
 import { throwError, of, Subscription, Unsubscribable, Subscribable } from 'rxjs'
 import * as sourcegraph from 'sourcegraph'
 
-import { EndpointPair, PlatformContext } from '../../platform/context'
-import { createExtensionHostClientConnection } from '../client/connection'
-import { ExposedToClient } from '../client/mainthread-api'
-import { FlatExtensionHostAPI, MainThreadAPI } from '../contract'
-import { InitData, startExtensionHost } from '../extension/extensionHost'
-import { WorkspaceRootWithMetadata } from '../extension/extensionHostApi'
-import { TextDocumentData, ViewerData } from '../viewerTypes'
+import { createExtensionHostClientConnection } from '../api/client/connection'
+import { ExposedToClient } from '../api/client/mainthread-api'
+import { FlatExtensionHostAPI, MainThreadAPI } from '../api/contract'
+import { InitData, startExtensionHost } from '../api/extension/extensionHost'
+import { WorkspaceRootWithMetadata } from '../api/extension/extensionHostApi'
+import { TextDocumentData, ViewerData } from '../api/viewerTypes'
+import { EndpointPair, PlatformContext } from '../platform/context'
 
 export function assertToJSON(a: any, expected: any): void {
     const raw = JSON.stringify(a)


### PR DESCRIPTION
I think unit tests should not be depending on things from integration tests?

With bazel we're assuming (and enforcing) consistent conventions for things like `*.spec.ts`, `/testing/` etc. One of those conventions is `/integration-test/` being for integration tests and not including in the unit test build.

## Test plan

CI

## App preview:

- [Web](https://sg-web-bazel-test-utils-dir.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
