### PR TITLE
web: fix redirect after excluding the repo.

### DIFF
--- a/client/web/src/repo/settings/components/ExternalServiceEntry.tsx
+++ b/client/web/src/repo/settings/components/ExternalServiceEntry.tsx
@@ -71,7 +71,7 @@ export const ExternalServiceEntry: FC<ExternalServiceEntryProps> = ({
                         kind={service.kind}
                         title={service.displayName}
                         shortDescription="Update this code host configuration to manage repository mirroring."
-                        to={`/site-admin/external-services/${service.id}/edit`}
+                        to={`/site-admin/external-services/${service.id}`}
                         toIcon={null}
                         bordered={false}
                     />


### PR DESCRIPTION
Previously it led to code host edit page, but it makes more sense to redirect a user to code host details page as new code host job is triggered after excluding a repo and this redirect would add more visibility.

Test plan:
Local sg run and visual check.

## App preview:

- [Web](https://sg-web-ao-ui-fix-redirect-after-repo.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
