### PR TITLE
all: update git to 2.39.1

### DIFF
--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -35,9 +35,9 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 RUN apk add --no-cache \
-    # We require git 2.38+ because we need a fix for this vulnerability to be included:
-    # https://github.blog/2022-04-12-git-security-vulnerability-announced/
-    'git>=2.38.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main  \
+    # We require git 2.39.1+ because we need a fix for this vulnerability to be included:
+    # https://github.blog/2023-01-17-git-security-vulnerabilities-announced-2/
+    'git>=2.39.1-r1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
     git-lfs \
     git-p4 \
     && apk add --no-cache  \

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -40,9 +40,9 @@ LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/comm
 
 RUN apk add --no-cache --verbose \
     # [NOTE: git-version-min-requirement]
-    # We require git 2.38+ because we need a fix for this vulnerability to be included:
-    # https://github.blog/2022-04-12-git-security-vulnerability-announced/
-    'git>=2.38.1' \
+    # We require git 2.39.1+ because we need a fix for this vulnerability to be included:
+    # https://github.blog/2023-01-17-git-security-vulnerabilities-announced-2/
+    'git>=2.39.1-r1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
     git-lfs \
     git-p4 \
     --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main  \

--- a/enterprise/cmd/batcheshelper/Dockerfile
+++ b/enterprise/cmd/batcheshelper/Dockerfile
@@ -15,8 +15,8 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 RUN apk add --no-cache \
-    # We require git 2.38+ because we need a fix for this vulnerability to be included:
-    # https://github.blog/2022-04-12-git-security-vulnerability-announced/
-    'git>=2.38.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main
+    # We require git 2.39.1+ because we need a fix for this vulnerability to be included:
+    # https://github.blog/2023-01-17-git-security-vulnerabilities-announced-2/
+    'git>=2.39.1-r1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 
 COPY batcheshelper /usr/local/bin/

--- a/enterprise/cmd/executor/docker-image/Dockerfile
+++ b/enterprise/cmd/executor/docker-image/Dockerfile
@@ -19,7 +19,9 @@ ENV EXECUTOR_USE_FIRECRACKER=false
 
 # Install git and docker. We use the same version here as we use in gitserver.
 RUN apk add --no-cache \
-    'git>=2.34.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main \
+    # We require git 2.39.1+ because we need a fix for this vulnerability to be included:
+    # https://github.blog/2023-01-17-git-security-vulnerabilities-announced-2/
+    'git>=2.39.1-r1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
     docker \
     ca-certificates
 

--- a/enterprise/cmd/gitserver/Dockerfile
+++ b/enterprise/cmd/gitserver/Dockerfile
@@ -35,9 +35,9 @@ LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
 
 RUN apk add --no-cache \
-    # We require git 2.38+ because we need a fix for this vulnerability to be included:
-    # https://github.blog/2022-04-12-git-security-vulnerability-announced/
-    'git>=2.38.1' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main  \
+    # We require git 2.39.1+ because we need a fix for this vulnerability to be included:
+    # https://github.blog/2023-01-17-git-security-vulnerabilities-announced-2/
+    'git>=2.39.1-r1' --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
     git-lfs \
     git-p4 \
     && apk add --no-cache  \


### PR DESCRIPTION
There is a new git vulnerability which may affect us since we do run "git archive". Security scanners are not yet reporting this, but more details can be found at
https://github.blog/2023-01-17-git-security-vulnerabilities-announced-2/

Note: alpine@edge is currently at 2.39.1-r1.

Test Plan: get CI to build images, pull them and confirm git version via

```
docker run --entrypoint=git IMAGE version
```