### PR TITLE
Add cursor based pagination to repositories page

### DIFF
--- a/client/web/src/components/FilteredConnection/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.tsx
@@ -628,17 +628,19 @@ export class FilteredConnection<
         this.showMoreClicks.next()
     }
 
-    private buildArgs = (filterValues: Map<string, FilteredConnectionFilterValue>): FilteredConnectionArgs => {
-        let args: FilteredConnectionArgs = {}
-        for (const key of filterValues.keys()) {
-            const value = filterValues.get(key)
-            if (value === undefined) {
-                continue
-            }
-            args = { ...args, ...value.args }
+    private buildArgs = buildFilterArgs
+}
+
+export const buildFilterArgs = (filterValues: Map<string, FilteredConnectionFilterValue>): FilteredConnectionArgs => {
+    let args: FilteredConnectionArgs = {}
+    for (const key of filterValues.keys()) {
+        const value = filterValues.get(key)
+        if (value === undefined) {
+            continue
         }
-        return args
+        args = { ...args, ...value.args }
     }
+    return args
 }
 
 /**

--- a/client/web/src/components/FilteredConnection/hooks/usePageSwitcherPagination.ts
+++ b/client/web/src/components/FilteredConnection/hooks/usePageSwitcherPagination.ts
@@ -41,7 +41,7 @@ export interface UsePaginatedConnectionResult<TResult, TVariables, TNode> extend
     connection?: PaginatedConnection<TNode>
     loading: boolean
     error?: ApolloError
-    refetch: () => any
+    refetch: (variables?: TVariables) => any
 }
 
 interface UsePaginatedConnectionConfig<TResult> {
@@ -53,6 +53,8 @@ interface UsePaginatedConnectionConfig<TResult> {
     fetchPolicy?: WatchQueryFetchPolicy
     // Allows running an optional callback on any successful request
     onCompleted?: (data: TResult) => void
+    // Allows to provide polling interval to useQuery
+    pollInterval?: number
 }
 
 interface UsePaginatedConnectionParameters<TResult, TVariables extends PaginatedConnectionQueryArguments, TNode> {
@@ -98,6 +100,7 @@ export const usePageSwitcherPagination = <TResult, TVariables extends PaginatedC
         variables: queryVariables,
         fetchPolicy: options?.fetchPolicy,
         onCompleted: options?.onCompleted,
+        pollInterval: options?.pollInterval,
     })
 
     const connection = useMemo(() => {

--- a/client/web/src/components/FilteredConnection/utils.ts
+++ b/client/web/src/components/FilteredConnection/utils.ts
@@ -65,7 +65,7 @@ export const hasNextPage = (connection: Connection<unknown>): boolean =>
         : typeof connection.totalCount === 'number' && connection.nodes.length < connection.totalCount
 
 export interface GetUrlQueryParameters {
-    first: {
+    first?: {
         actual: number
         default: number
     }
@@ -93,7 +93,7 @@ export const getUrlQuery = ({
         searchParameters.set(QUERY_KEY, query)
     }
 
-    if (first.actual !== first.default) {
+    if (!!first && first.actual !== first.default) {
         searchParameters.set('first', String(first.actual))
     }
 
@@ -111,7 +111,7 @@ export const getUrlQuery = ({
         }
     }
 
-    if (visibleResultCount && visibleResultCount !== 0 && visibleResultCount !== first.actual) {
+    if (visibleResultCount && visibleResultCount !== 0 && visibleResultCount !== first?.actual) {
         searchParameters.set('visible', String(visibleResultCount))
     }
 

--- a/client/web/src/savedSearches/SavedSearchListPage.tsx
+++ b/client/web/src/savedSearches/SavedSearchListPage.tsx
@@ -147,7 +147,6 @@ export const SavedSearchListPage: React.FunctionComponent<Props> = props => {
         query: savedSearchesQuery,
         variables: { namespace: props.namespace.id },
         getConnection: ({ data }) => data?.savedSearches || undefined,
-        options: { pageSize: 2 },
     })
 
     return (

--- a/client/web/src/savedSearches/SavedSearchListPage.tsx
+++ b/client/web/src/savedSearches/SavedSearchListPage.tsx
@@ -147,6 +147,7 @@ export const SavedSearchListPage: React.FunctionComponent<Props> = props => {
         query: savedSearchesQuery,
         variables: { namespace: props.namespace.id },
         getConnection: ({ data }) => data?.savedSearches || undefined,
+        options: { pageSize: 2 },
     })
 
     return (

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useEffect, useMemo } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 
 import { mdiCloudDownload, mdiCog, mdiBrain } from '@mdi/js'
+import { isEqual } from 'lodash'
 import { RouteComponentProps } from 'react-router'
-import { Observable } from 'rxjs'
 
 import { logger } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
@@ -15,6 +15,7 @@ import {
     Container,
     H4,
     Icon,
+    Input,
     Link,
     LoadingSpinner,
     PageHeader,
@@ -22,17 +23,22 @@ import {
     Tooltip,
     ErrorAlert,
     LinkOrSpan,
+    PageSwitcher,
 } from '@sourcegraph/wildcard'
 
 import { EXTERNAL_SERVICE_IDS_AND_NAMES } from '../components/externalServices/backend'
 import {
-    FilteredConnection,
+    buildFilterArgs,
+    FilterControl,
+    FilteredConnectionFilterValue,
     FilteredConnectionFilter,
-    FilteredConnectionQueryArguments,
 } from '../components/FilteredConnection'
+import { usePageSwitcherPagination } from '../components/FilteredConnection/hooks/usePageSwitcherPagination'
+import { getFilterFromURL, getUrlQuery } from '../components/FilteredConnection/utils'
 import { PageTitle } from '../components/PageTitle'
 import {
     RepositoriesResult,
+    RepositoriesVariables,
     RepositoryOrderBy,
     RepositoryStatsResult,
     ExternalServiceIDsAndNamesVariables,
@@ -43,7 +49,7 @@ import {
 import { refreshSiteFlags } from '../site/backend'
 
 import { ValueLegendList, ValueLegendListProps } from './analytics/components/ValueLegendList'
-import { fetchAllRepositoriesAndPollIfEmptyOrAnyCloning, REPOSITORY_STATS, REPO_PAGE_POLL_INTERVAL } from './backend'
+import { REPOSITORY_STATS, REPO_PAGE_POLL_INTERVAL, REPOSITORIES_QUERY } from './backend'
 import { ExternalRepositoryIcon } from './components/ExternalRepositoryIcon'
 import { RepoMirrorInfo } from './components/RepoMirrorInfo'
 
@@ -355,17 +361,79 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
         return filtersWithExternalServices
     }, [extSvcs])
 
-    const queryRepositories = useCallback(
-        (args: FilteredConnectionQueryArguments): Observable<RepositoriesResult['repositories']> =>
-            fetchAllRepositoriesAndPollIfEmptyOrAnyCloning(args),
-        []
+    const [filterValues, setFilterValues] = useState<Map<string, FilteredConnectionFilterValue>>(() =>
+        getFilterFromURL(new URLSearchParams(location.search), filters)
     )
+
+    useEffect(() => {
+        setFilterValues(getFilterFromURL(new URLSearchParams(location.search), filters))
+    }, [filters, location.search])
+
+    const [searchQuery, setSearchQuery] = useState<string>(
+        () => new URLSearchParams(location.search).get('query') || ''
+    )
+
+    useEffect(() => {
+        const searchFragment = getUrlQuery({
+            query: searchQuery,
+            filters,
+            filterValues,
+            search: location.search,
+        })
+        const searchFragmentParams = new URLSearchParams(searchFragment)
+        searchFragmentParams.sort()
+
+        const oldParams = new URLSearchParams(location.search)
+        oldParams.sort()
+
+        if (!isEqual(Array.from(searchFragmentParams), Array.from(oldParams))) {
+            history.replace({
+                search: searchFragment,
+                hash: location.hash,
+                // Do not throw away flash messages
+                state: location.state,
+            })
+        }
+    }, [filters, filterValues, searchQuery, location, history])
+
+    const variables = useMemo<RepositoriesVariables>(() => {
+        const args = buildFilterArgs(filterValues)
+
+        return {
+            ...args,
+            query: searchQuery,
+            indexed: args.indexed ?? true,
+            notIndexed: args.notIndexed ?? true,
+            failedFetch: args.failedFetch ?? false,
+            corrupted: args.corrupted ?? false,
+            cloneStatus: args.cloneStatus ?? null,
+            externalService: args.externalService ?? null,
+        } as RepositoriesVariables
+    }, [searchQuery, filterValues])
+
+    const {
+        connection,
+        loading: reposLoading,
+        error: reposError,
+        refetch,
+        ...paginationProps
+    } = usePageSwitcherPagination<RepositoriesResult, RepositoriesVariables, SiteAdminRepositoryFields>({
+        query: REPOSITORIES_QUERY,
+        variables,
+        getConnection: ({ data }) => data?.repositories || undefined,
+        options: { pollInterval: 5000 },
+    })
+
+    useEffect(() => {
+        refetch(variables)
+    }, [refetch, variables])
+
     const showRepositoriesAddedBanner = new URLSearchParams(location.search).has('repositoriesUpdated')
 
     const licenseInfo = window.context.licenseInfo
 
-    const error = repoStatsError || extSvcError
-    const loading = repoStatsLoading || extSvcLoading
+    const error = repoStatsError || extSvcError || reposError
+    const loading = repoStatsLoading || extSvcLoading || reposLoading
 
     return (
         <div className="site-admin-repositories-page">
@@ -413,20 +481,44 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
                 {loading && !error && <LoadingSpinner />}
                 {legends && <ValueLegendList className="mb-3" items={legends} />}
                 {extSvcs && (
-                    <FilteredConnection<SiteAdminRepositoryFields, Omit<RepositoryNodeProps, 'node'>>
-                        className="mb-0"
-                        listClassName="list-group list-group-flush mb-0"
-                        summaryClassName="mt-2"
-                        withCenteredSummary={true}
-                        noun="repository"
-                        pluralNoun="repositories"
-                        queryConnection={queryRepositories}
-                        nodeComponent={RepositoryNode}
-                        inputClassName="ml-2 flex-1"
-                        filters={filters}
-                        history={history}
-                        location={location}
-                    />
+                    <>
+                        <div className="d-flex justify-content-center">
+                            <FilterControl
+                                filters={filters}
+                                values={filterValues}
+                                onValueSelect={(
+                                    filter: FilteredConnectionFilter,
+                                    value: FilteredConnectionFilterValue
+                                ) =>
+                                    setFilterValues(values => {
+                                        const newValues = new Map(values)
+                                        newValues.set(filter.id, value)
+                                        return newValues
+                                    })
+                                }
+                            />
+                            <Input
+                                type="search"
+                                className="flex-1"
+                                placeholder="Search repositories..."
+                                name="query"
+                                value={searchQuery}
+                                onChange={event => setSearchQuery(event.currentTarget.value)}
+                                autoComplete="off"
+                                autoCorrect="off"
+                                autoCapitalize="off"
+                                spellCheck={false}
+                                aria-label="Search repositories..."
+                                variant="regular"
+                            />
+                        </div>
+                        <ul className="list-group list-group-flush mt-4">
+                            {(connection?.nodes || []).map(node => (
+                                <RepositoryNode key={node.id} node={node} />
+                            ))}
+                        </ul>
+                        <PageSwitcher {...paginationProps} className="mt-4" totalCount={connection?.totalCount || 0} />
+                    </>
                 )}
             </Container>
         </div>

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -517,7 +517,12 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
                                 <RepositoryNode key={node.id} node={node} />
                             ))}
                         </ul>
-                        <PageSwitcher {...paginationProps} className="mt-4" totalCount={connection?.totalCount || 0} />
+                        <PageSwitcher
+                            {...paginationProps}
+                            className="mt-4"
+                            totalCount={connection?.totalCount ?? null}
+                            totalLabel="repositories"
+                        />
                     </>
                 )}
             </Container>

--- a/client/web/src/site-admin/analytics/AnalyticsOverviewPage/queries.ts
+++ b/client/web/src/site-admin/analytics/AnalyticsOverviewPage/queries.ts
@@ -20,7 +20,7 @@ export const OVERVIEW_STATISTICS = gql`
             totalCount
         }
         repositories {
-            totalCount(precise: true)
+            totalCount
         }
         repositoryStats {
             gitDirBytes

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -3,7 +3,7 @@ import { parse as parseJSONC } from 'jsonc-parser'
 import { Observable } from 'rxjs'
 import { map, mapTo, tap } from 'rxjs/operators'
 
-import { repeatUntil, resetAllMemoizationCaches } from '@sourcegraph/common'
+import { resetAllMemoizationCaches } from '@sourcegraph/common'
 import { createInvalidGraphQLMutationResponseError, dataOrThrowErrors, gql, useQuery } from '@sourcegraph/http-client'
 import { Settings } from '@sourcegraph/shared/src/settings/settings'
 
@@ -31,9 +31,6 @@ import {
     RandomizeUserPasswordResult,
     ReloadSiteResult,
     ReloadSiteVariables,
-    RepositoriesResult,
-    RepositoriesVariables,
-    RepositoryOrderBy,
     Scalars,
     ScheduleRepositoryPermissionsSyncResult,
     ScheduleRepositoryPermissionsSyncVariables,
@@ -136,6 +133,7 @@ const siteAdminRepositoryFieldsFragment = gql`
     ${externalRepositoryFieldsFragment}
 
     fragment SiteAdminRepositoryFields on Repository {
+        __typename
         id
         name
         createdAt
@@ -150,85 +148,54 @@ const siteAdminRepositoryFieldsFragment = gql`
         }
     }
 `
-
-/**
- * Fetches all repositories.
- *
- * @returns Observable that emits the list of repositories
- */
-function fetchAllRepositories(args: Partial<RepositoriesVariables>): Observable<RepositoriesResult['repositories']> {
-    return requestGraphQL<RepositoriesResult, RepositoriesVariables>(
-        gql`
-            query Repositories(
-                $first: Int
-                $query: String
-                $indexed: Boolean
-                $notIndexed: Boolean
-                $failedFetch: Boolean
-                $corrupted: Boolean
-                $cloneStatus: CloneStatus
-                $orderBy: RepositoryOrderBy
-                $descending: Boolean
-                $externalService: ID
-            ) {
-                repositories(
-                    first: $first
-                    query: $query
-                    indexed: $indexed
-                    notIndexed: $notIndexed
-                    failedFetch: $failedFetch
-                    corrupted: $corrupted
-                    cloneStatus: $cloneStatus
-                    orderBy: $orderBy
-                    descending: $descending
-                    externalService: $externalService
-                ) {
-                    nodes {
-                        ...SiteAdminRepositoryFields
-                    }
-                    totalCount(precise: true)
-                    pageInfo {
-                        hasNextPage
-                    }
-                }
+export const REPOSITORIES_QUERY = gql`
+    query Repositories(
+        $first: Int
+        $last: Int
+        $after: String
+        $before: String
+        $query: String
+        $indexed: Boolean
+        $notIndexed: Boolean
+        $failedFetch: Boolean
+        $corrupted: Boolean
+        $cloneStatus: CloneStatus
+        $orderBy: RepositoryOrderBy
+        $descending: Boolean
+        $externalService: ID
+    ) {
+        repositories(
+            first: $first
+            last: $last
+            after: $after
+            before: $before
+            query: $query
+            indexed: $indexed
+            notIndexed: $notIndexed
+            failedFetch: $failedFetch
+            corrupted: $corrupted
+            cloneStatus: $cloneStatus
+            orderBy: $orderBy
+            descending: $descending
+            externalService: $externalService
+        ) {
+            nodes {
+                ...SiteAdminRepositoryFields
             }
-
-            ${siteAdminRepositoryFieldsFragment}
-        `,
-        {
-            indexed: args.indexed ?? true,
-            notIndexed: args.notIndexed ?? true,
-            failedFetch: args.failedFetch ?? false,
-            corrupted: args.corrupted ?? false,
-            first: args.first ?? null,
-            query: args.query ?? null,
-            cloneStatus: args.cloneStatus ?? null,
-            orderBy: args.orderBy ?? RepositoryOrderBy.REPOSITORY_NAME,
-            descending: args.descending ?? false,
-            externalService: args.externalService ?? null,
+            totalCount
+            pageInfo {
+                hasNextPage
+                hasPreviousPage
+                startCursor
+                endCursor
+            }
         }
-    ).pipe(
-        map(dataOrThrowErrors),
-        map(data => data.repositories)
-    )
-}
+    }
+
+    ${siteAdminRepositoryFieldsFragment}
+`
 
 export const REPO_PAGE_POLL_INTERVAL = 5000
-
-export function fetchAllRepositoriesAndPollIfEmptyOrAnyCloning(
-    args: Partial<RepositoriesVariables>
-): Observable<RepositoriesResult['repositories']> {
-    return fetchAllRepositories(args).pipe(
-        // Poll every 5000ms if repositories are being cloned or the list is empty.
-        repeatUntil(
-            result =>
-                result.nodes &&
-                result.nodes.length > 0 &&
-                result.nodes.every(nodes => !nodes.mirrorInfo.cloneInProgress && nodes.mirrorInfo.cloned),
-            { delay: REPO_PAGE_POLL_INTERVAL }
-        )
-    )
-}
 
 export const SLOW_REQUESTS = gql`
     query SlowRequests($after: String) {

--- a/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver.go
@@ -24,9 +24,9 @@ type ConnectionResolverStore[N any] interface {
 	// ComputeNodes returns the list of nodes based on the pagination args.
 	ComputeNodes(context.Context, *database.PaginationArgs) ([]*N, error)
 	// MarshalCursor returns cursor for a node and is called for generating start and end cursors.
-	MarshalCursor(*N) (*string, error)
+	MarshalCursor(*N, database.OrderBy) (*string, error)
 	// UnmarshalCursor returns node id from after/before cursor string.
-	UnmarshalCursor(string) (*int, error)
+	UnmarshalCursor(string, database.OrderBy) (*string, error)
 }
 
 type ConnectionResolverArgs struct {
@@ -60,6 +60,10 @@ type ConnectionResolverOptions struct {
 	//
 	// Defaults to `true` when not set.
 	Reverse *bool
+	// Columns to order by
+	OrderBy database.OrderBy
+	// Order direction
+	Descending bool
 }
 
 // MaxPageSize returns the configured max page limit for the connection
@@ -104,7 +108,10 @@ func (r *ConnectionResolver[N]) paginationArgs() (*database.PaginationArgs, erro
 		return nil, nil
 	}
 
-	paginationArgs := database.PaginationArgs{}
+	paginationArgs := database.PaginationArgs{
+		OrderBy:    r.options.OrderBy,
+		Descending: r.options.Descending,
+	}
 
 	limit := r.pageSize() + 1
 	if r.args.First != nil {
@@ -116,7 +123,7 @@ func (r *ConnectionResolver[N]) paginationArgs() (*database.PaginationArgs, erro
 	}
 
 	if r.args.After != nil {
-		after, err := r.store.UnmarshalCursor(*r.args.After)
+		after, err := r.store.UnmarshalCursor(*r.args.After, r.options.OrderBy)
 		if err != nil {
 			return nil, err
 		}
@@ -125,7 +132,7 @@ func (r *ConnectionResolver[N]) paginationArgs() (*database.PaginationArgs, erro
 	}
 
 	if r.args.Before != nil {
-		before, err := r.store.UnmarshalCursor(*r.args.Before)
+		before, err := r.store.UnmarshalCursor(*r.args.Before, r.options.OrderBy)
 		if err != nil {
 			return nil, err
 		}
@@ -146,11 +153,11 @@ func (r *ConnectionResolver[N]) TotalCount(ctx context.Context) (int32, error) {
 		r.data.total, r.data.totalError = r.store.ComputeTotal(ctx)
 	})
 
-	if r.data.totalError != nil || r.data.total == nil {
-		return 0, r.data.totalError
+	if r.data.total != nil {
+		return *r.data.total, r.data.totalError
 	}
 
-	return *r.data.total, r.data.totalError
+	return 0, r.data.totalError
 }
 
 // Nodes returns value for connection.Nodes and is called by the graphql api.
@@ -208,6 +215,7 @@ func (r *ConnectionResolver[N]) PageInfo(ctx context.Context) (*ConnectionPageIn
 		nodes:             nodes,
 		store:             r.store,
 		args:              r.args,
+		orderBy:           r.options.OrderBy,
 	}, nil
 }
 
@@ -217,6 +225,7 @@ type ConnectionPageInfo[N any] struct {
 	nodes             []*N
 	store             ConnectionResolverStore[N]
 	args              *ConnectionResolverArgs
+	orderBy           database.OrderBy
 }
 
 // HasNextPage returns value for connection.pageInfo.hasNextPage and is called by the graphql api.
@@ -251,7 +260,7 @@ func (p *ConnectionPageInfo[N]) EndCursor() (cursor *string, err error) {
 		return nil, nil
 	}
 
-	cursor, err = p.store.MarshalCursor(p.nodes[len(p.nodes)-1])
+	cursor, err = p.store.MarshalCursor(p.nodes[len(p.nodes)-1], p.orderBy)
 
 	return
 }
@@ -262,7 +271,7 @@ func (p *ConnectionPageInfo[N]) StartCursor() (cursor *string, err error) {
 		return nil, nil
 	}
 
-	cursor, err = p.store.MarshalCursor(p.nodes[0])
+	cursor, err = p.store.MarshalCursor(p.nodes[0], p.orderBy)
 
 	return
 }

--- a/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver.go
@@ -63,7 +63,7 @@ type ConnectionResolverOptions struct {
 	// Columns to order by
 	OrderBy database.OrderBy
 	// Order direction
-	Descending bool
+	Ascending bool
 }
 
 // MaxPageSize returns the configured max page limit for the connection
@@ -109,8 +109,8 @@ func (r *ConnectionResolver[N]) paginationArgs() (*database.PaginationArgs, erro
 	}
 
 	paginationArgs := database.PaginationArgs{
-		OrderBy:    r.options.OrderBy,
-		Descending: r.options.Descending,
+		OrderBy:   r.options.OrderBy,
+		Ascending: r.options.Ascending,
 	}
 
 	limit := r.pageSize() + 1
@@ -279,7 +279,11 @@ func (p *ConnectionPageInfo[N]) StartCursor() (cursor *string, err error) {
 // NewConnectionResolver returns a new connection resolver built using the store and connection args.
 func NewConnectionResolver[N any](store ConnectionResolverStore[N], args *ConnectionResolverArgs, options *ConnectionResolverOptions) (*ConnectionResolver[N], error) {
 	if options == nil {
-		options = &ConnectionResolverOptions{}
+		options = &ConnectionResolverOptions{OrderBy: database.OrderBy{{Field: "id"}}}
+	}
+
+	if len(options.OrderBy) == 0 {
+		options.OrderBy = database.OrderBy{{Field: "id"}}
 	}
 
 	return &ConnectionResolver[N]{

--- a/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver_test.go
@@ -160,6 +160,14 @@ func testResolverNodesResponse(t *testing.T, resolver *ConnectionResolver[testCo
 	}
 }
 
+func buildPaginationArgs() *database.PaginationArgs {
+	args := database.PaginationArgs{
+		OrderBy: database.OrderBy{{Field: "id"}},
+	}
+
+	return &args
+}
+
 func TestConnectionNodes(t *testing.T) {
 	for _, test := range []struct {
 		name           string
@@ -171,30 +179,30 @@ func TestConnectionNodes(t *testing.T) {
 		{
 			name:               "default",
 			connectionArgs:     withFirstCA(5, &ConnectionResolverArgs{}),
-			wantPaginationArgs: withFirstPA(6, &database.PaginationArgs{}),
+			wantPaginationArgs: withFirstPA(6, buildPaginationArgs()),
 			wantNodes:          2,
 		},
 		{
 			name:               "last arg",
-			wantPaginationArgs: withLastPA(6, &database.PaginationArgs{}),
+			wantPaginationArgs: withLastPA(6, buildPaginationArgs()),
 			connectionArgs:     withLastCA(5, &ConnectionResolverArgs{}),
 			wantNodes:          2,
 		},
 		{
 			name:               "after arg",
-			wantPaginationArgs: withAfterPA("0", withFirstPA(6, &database.PaginationArgs{})),
+			wantPaginationArgs: withAfterPA("0", withFirstPA(6, buildPaginationArgs())),
 			connectionArgs:     withAfterCA("0", withFirstCA(5, &ConnectionResolverArgs{})),
 			wantNodes:          2,
 		},
 		{
 			name:               "before arg",
-			wantPaginationArgs: withBeforePA("0", withLastPA(6, &database.PaginationArgs{})),
+			wantPaginationArgs: withBeforePA("0", withLastPA(6, buildPaginationArgs())),
 			connectionArgs:     withBeforeCA("0", withLastCA(5, &ConnectionResolverArgs{})),
 			wantNodes:          2,
 		},
 		{
 			name:               "with limit",
-			wantPaginationArgs: withBeforePA("0", withLastPA(2, &database.PaginationArgs{})),
+			wantPaginationArgs: withBeforePA("0", withLastPA(2, buildPaginationArgs())),
 			connectionArgs:     withBeforeCA("0", withLastCA(1, &ConnectionResolverArgs{})),
 			wantNodes:          1,
 		},

--- a/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/connection_resolver_test.go
@@ -3,7 +3,6 @@ package graphqlutil
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -55,19 +54,14 @@ func (s *testConnectionStore) ComputeNodes(ctx context.Context, args *database.P
 	return nodes, nil
 }
 
-func (*testConnectionStore) MarshalCursor(n *testConnectionNode) (*string, error) {
+func (*testConnectionStore) MarshalCursor(n *testConnectionNode, _ database.OrderBy) (*string, error) {
 	cursor := string(n.ID())
 
 	return &cursor, nil
 }
 
-func (*testConnectionStore) UnmarshalCursor(cursor string) (*int, error) {
-	id, err := strconv.Atoi(cursor)
-	if err != nil {
-		return nil, err
-	}
-
-	return &id, nil
+func (*testConnectionStore) UnmarshalCursor(cursor string, _ database.OrderBy) (*string, error) {
+	return &cursor, nil
 }
 
 func newInt(n int) *int {
@@ -116,13 +110,13 @@ func withLastPA(last int, a *database.PaginationArgs) *database.PaginationArgs {
 	return a
 }
 
-func withAfterPA(after int, a *database.PaginationArgs) *database.PaginationArgs {
+func withAfterPA(after string, a *database.PaginationArgs) *database.PaginationArgs {
 	a.After = &after
 
 	return a
 }
 
-func withBeforePA(before int, a *database.PaginationArgs) *database.PaginationArgs {
+func withBeforePA(before string, a *database.PaginationArgs) *database.PaginationArgs {
 	a.Before = &before
 
 	return a
@@ -188,19 +182,19 @@ func TestConnectionNodes(t *testing.T) {
 		},
 		{
 			name:               "after arg",
-			wantPaginationArgs: withAfterPA(0, withFirstPA(6, &database.PaginationArgs{})),
+			wantPaginationArgs: withAfterPA("0", withFirstPA(6, &database.PaginationArgs{})),
 			connectionArgs:     withAfterCA("0", withFirstCA(5, &ConnectionResolverArgs{})),
 			wantNodes:          2,
 		},
 		{
 			name:               "before arg",
-			wantPaginationArgs: withBeforePA(0, withLastPA(6, &database.PaginationArgs{})),
+			wantPaginationArgs: withBeforePA("0", withLastPA(6, &database.PaginationArgs{})),
 			connectionArgs:     withBeforeCA("0", withLastCA(5, &ConnectionResolverArgs{})),
 			wantNodes:          2,
 		},
 		{
 			name:               "with limit",
-			wantPaginationArgs: withBeforePA(0, withLastPA(2, &database.PaginationArgs{})),
+			wantPaginationArgs: withBeforePA("0", withLastPA(2, &database.PaginationArgs{})),
 			connectionArgs:     withBeforeCA("0", withLastCA(1, &ConnectionResolverArgs{})),
 			wantNodes:          1,
 		},

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -156,12 +156,7 @@ func (o *OrgResolver) Members(ctx context.Context, args struct {
 		query: args.Query,
 	}
 
-	connectionOptions := graphqlutil.ConnectionResolverOptions{
-		OrderBy:    database.OrderBy{{Field: "id"}},
-		Descending: true,
-	}
-
-	return graphqlutil.NewConnectionResolver[UserResolver](connectionStore, &args.ConnectionResolverArgs, &connectionOptions)
+	return graphqlutil.NewConnectionResolver[UserResolver](connectionStore, &args.ConnectionResolverArgs, nil)
 }
 
 type membersConnectionStore struct {

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -156,7 +156,12 @@ func (o *OrgResolver) Members(ctx context.Context, args struct {
 		query: args.Query,
 	}
 
-	return graphqlutil.NewConnectionResolver[UserResolver](connectionStore, &args.ConnectionResolverArgs, nil)
+	connectionOptions := graphqlutil.ConnectionResolverOptions{
+		OrderBy:    database.OrderBy{{Field: "id"}},
+		Descending: true,
+	}
+
+	return graphqlutil.NewConnectionResolver[UserResolver](connectionStore, &args.ConnectionResolverArgs, &connectionOptions)
 }
 
 type membersConnectionStore struct {
@@ -195,7 +200,7 @@ func (s *membersConnectionStore) ComputeNodes(ctx context.Context, args *databas
 	return userResolvers, nil
 }
 
-func (s *membersConnectionStore) MarshalCursor(node *UserResolver) (*string, error) {
+func (s *membersConnectionStore) MarshalCursor(node *UserResolver, _ database.OrderBy) (*string, error) {
 	if node == nil {
 		return nil, errors.New(`node is nil`)
 	}
@@ -205,13 +210,13 @@ func (s *membersConnectionStore) MarshalCursor(node *UserResolver) (*string, err
 	return &cursor, nil
 }
 
-func (s *membersConnectionStore) UnmarshalCursor(cusror string) (*int, error) {
+func (s *membersConnectionStore) UnmarshalCursor(cusror string, _ database.OrderBy) (*string, error) {
 	nodeID, err := UnmarshalUserID(graphql.ID(cusror))
 	if err != nil {
 		return nil, err
 	}
 
-	id := int(nodeID)
+	id := string(nodeID)
 
 	return &id, nil
 }

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -117,7 +117,7 @@ func (r *schemaResolver) Repositories(ctx context.Context, args *repositoryArgs)
 	connectionOptions := graphqlutil.ConnectionResolverOptions{
 		MaxPageSize: &maxPageSize,
 		OrderBy:     database.OrderBy{{Field: string(ToDBRepoListColumn(orderBy))}, {Field: "id"}},
-		Descending:  args.Descending,
+		Ascending:   !args.Descending,
 	}
 
 	return graphqlutil.NewConnectionResolver[RepositoryResolver](connectionStore, &args.ConnectionResolverArgs, &connectionOptions)
@@ -165,6 +165,10 @@ func (s *repositoriesConnectionStore) UnmarshalCursor(cursor string, orderBy dat
 	repoCursor, err := UnmarshalRepositoryCursor(&cursor)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(orderBy) == 0 {
+		return nil, errors.New("no orderBy provided")
 	}
 
 	column := orderBy[0].Field

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -359,7 +359,6 @@ func (r *repositoryConnectionResolver) TotalCount(ctx context.Context, args *Tot
 		}()
 	}
 
-	i32ptr := func(v int32) *int32 { return &v }
 	count, err := r.db.Repos().Count(ctx, r.opt)
 	return i32ptr(int32(count)), err
 }

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -108,6 +108,7 @@ func (r *schemaResolver) Repositories(ctx context.Context, args *repositoryArgs)
 
 	maxPageSize := 1000
 
+	// `REPOSITORY_NAME` is the enum value in the graphql schema.
 	orderBy := "REPOSITORY_NAME"
 	if args.OrderBy != "" {
 		orderBy = args.OrderBy
@@ -177,12 +178,12 @@ func (s *repositoriesConnectionStore) UnmarshalCursor(cursor string, orderBy dat
 		return nil, errors.New(fmt.Sprintf("Invalid cursor. Expected Value: <%s>@<id> Actual Value: %s", column, repoCursor.Value))
 	}
 
-	switch column {
-	case string(database.RepoListName):
+	switch database.RepoListColumn(column) {
+	case database.RepoListName:
 		csv = fmt.Sprintf("'%v', %v", values[0], values[1])
-	case string(database.RepoListCreatedAt):
+	case database.RepoListCreatedAt:
 		csv = fmt.Sprintf("%v, %v", values[0], values[1])
-	case string(database.RepoListSize):
+	case database.RepoListSize:
 		csv = fmt.Sprintf("%v, %v", values[0], values[1])
 	default:
 		return nil, errors.New("Invalid OrderBy Field.")

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -168,13 +168,13 @@ func (s *repositoriesConnectionStore) UnmarshalCursor(cursor string, orderBy dat
 
 	column := orderBy[0].Field
 	if repoCursor.Column != column {
-		return nil, errors.New("Invalid cursor.")
+		return nil, errors.New(fmt.Sprintf("Invalid cursor. Expected: %s Actual: %s", column, repoCursor.Column))
 	}
 
 	csv := ""
 	values := strings.Split(repoCursor.Value, "@")
 	if len(values) != 2 {
-		return nil, errors.New("Invalid cursor.")
+		return nil, errors.New(fmt.Sprintf("Invalid cursor. Expected Value: <%s>@<id> Actual Value: %s", column, repoCursor.Value))
 	}
 
 	switch column {

--- a/cmd/frontend/graphqlbackend/repositories_test.go
+++ b/cmd/frontend/graphqlbackend/repositories_test.go
@@ -496,7 +496,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 		return MarshalRepositoryCursor(
 			&types.Cursor{
 				Column: "name",
-				Value:  fmt.Sprintf("%s@%v", node.Name, node.ID),
+				Value:  fmt.Sprintf("%s@%d", node.Name, node.ID),
 			},
 		)
 	}

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -292,6 +292,14 @@ func (r *RepositoryResolver) CreatedAt() gqlutil.DateTime {
 	return gqlutil.DateTime{Time: time.Now()}
 }
 
+func (r *RepositoryResolver) RawCreatedAt() string {
+	if r.innerRepo == nil {
+		return ""
+	}
+
+	return (*r.innerRepo).CreatedAt.Format(time.RFC3339)
+}
+
 func (r *RepositoryResolver) UpdatedAt() *gqlutil.DateTime {
 	return nil
 }

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -297,7 +297,7 @@ func (r *RepositoryResolver) RawCreatedAt() string {
 		return ""
 	}
 
-	return (*r.innerRepo).CreatedAt.Format(time.RFC3339)
+	return r.innerRepo.CreatedAt.Format(time.RFC3339)
 }
 
 func (r *RepositoryResolver) UpdatedAt() *gqlutil.DateTime {

--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -31,9 +31,7 @@ func (r *RepositoryResolver) Contributors(args *struct {
 	}
 	reverse := false
 	connectionOptions := graphqlutil.ConnectionResolverOptions{
-		OrderBy:    database.OrderBy{{Field: "id"}},
-		Descending: true,
-		Reverse:    &reverse,
+		Reverse: &reverse,
 	}
 	return graphqlutil.NewConnectionResolver[repositoryContributorResolver](connectionStore, &args.ConnectionResolverArgs, &connectionOptions)
 }

--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -23,20 +23,19 @@ func (r *RepositoryResolver) Contributors(args *struct {
 	repositoryContributorsArgs
 	graphqlutil.ConnectionResolverArgs
 }) (*graphqlutil.ConnectionResolver[repositoryContributorResolver], error) {
-	connectionArgs := &graphqlutil.ConnectionResolverArgs{
-		First:  args.First,
-		Last:   args.Last,
-		After:  args.After,
-		Before: args.Before,
-	}
 	connectionStore := &repositoryContributorConnectionStore{
 		db:             r.db,
 		args:           &args.repositoryContributorsArgs,
-		connectionArgs: connectionArgs,
+		connectionArgs: &args.ConnectionResolverArgs,
 		repo:           r,
 	}
 	reverse := false
-	return graphqlutil.NewConnectionResolver[repositoryContributorResolver](connectionStore, connectionArgs, &graphqlutil.ConnectionResolverOptions{Reverse: &reverse})
+	connectionOptions := graphqlutil.ConnectionResolverOptions{
+		OrderBy:    database.OrderBy{{Field: "id"}},
+		Descending: true,
+		Reverse:    &reverse,
+	}
+	return graphqlutil.NewConnectionResolver[repositoryContributorResolver](connectionStore, &args.ConnectionResolverArgs, &connectionOptions)
 }
 
 type repositoryContributorConnectionStore struct {
@@ -52,17 +51,13 @@ type repositoryContributorConnectionStore struct {
 	err     error
 }
 
-func (s *repositoryContributorConnectionStore) MarshalCursor(node *repositoryContributorResolver) (*string, error) {
+func (s *repositoryContributorConnectionStore) MarshalCursor(node *repositoryContributorResolver, _ database.OrderBy) (*string, error) {
 	position := strconv.Itoa(node.index)
 	return &position, nil
 }
 
-func (s *repositoryContributorConnectionStore) UnmarshalCursor(cursor string) (*int, error) {
-	position, err := strconv.Atoi(cursor)
-	if err != nil {
-		return nil, err
-	}
-	return &position, nil
+func (s *repositoryContributorConnectionStore) UnmarshalCursor(cursor string, _ database.OrderBy) (*string, error) {
+	return &cursor, nil
 }
 
 func (s *repositoryContributorConnectionStore) ComputeTotal(ctx context.Context) (*int32, error) {
@@ -123,13 +118,21 @@ func OffsetBasedCursorSlice[T any](nodes []T, args *database.PaginationArgs) ([]
 	totalFloat := float64(len(nodes))
 	if args.First != nil {
 		if args.After != nil {
-			start = int(math.Min(float64(*args.After)+1, totalFloat))
+			after, err := strconv.Atoi(*args.After)
+			if err != nil {
+				return nil, 0, err
+			}
+			start = int(math.Min(float64(after)+1, totalFloat))
 		}
 		end = int(math.Min(float64(start+*args.First), totalFloat))
 	} else if args.Last != nil {
 		end = int(totalFloat)
 		if args.Before != nil {
-			end = int(math.Max(float64(*args.Before), 0))
+			before, err := strconv.Atoi(*args.Before)
+			if err != nil {
+				return nil, 0, err
+			}
+			end = int(math.Max(float64(before), 0))
 		}
 		start = int(math.Max(float64(end-*args.Last), 0))
 	} else {

--- a/cmd/frontend/graphqlbackend/repository_contributors_test.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors_test.go
@@ -11,9 +11,9 @@ import (
 func TestOffsetBasedCursorSlice(t *testing.T) {
 	slice := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
-	int1 := 1
 	int2 := 2
-	int8 := 8
+	string1 := "1"
+	string8 := "8"
 
 	testCases := []struct {
 		name string
@@ -27,7 +27,7 @@ func TestOffsetBasedCursorSlice(t *testing.T) {
 		},
 		{
 			"next page",
-			&database.PaginationArgs{First: &int2, After: &int1},
+			&database.PaginationArgs{First: &int2, After: &string1},
 			autogold.Want("first two items", []int{3, 4}),
 		},
 		{
@@ -37,7 +37,7 @@ func TestOffsetBasedCursorSlice(t *testing.T) {
 		},
 		{
 			"previous page",
-			&database.PaginationArgs{Last: &int2, Before: &int8},
+			&database.PaginationArgs{Last: &int2, Before: &string8},
 			autogold.Want("first two items", []int{7, 8}),
 		},
 	}

--- a/cmd/frontend/graphqlbackend/saved_searches.go
+++ b/cmd/frontend/graphqlbackend/saved_searches.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -141,7 +142,12 @@ func (r *schemaResolver) SavedSearches(ctx context.Context, args savedSearchesAr
 		orgID:  &orgID,
 	}
 
-	return graphqlutil.NewConnectionResolver[savedSearchResolver](connectionStore, &args.ConnectionResolverArgs, nil)
+	connectionOptions := graphqlutil.ConnectionResolverOptions{
+		OrderBy:    database.OrderBy{{Field: "id"}},
+		Descending: true,
+	}
+
+	return graphqlutil.NewConnectionResolver[savedSearchResolver](connectionStore, &args.ConnectionResolverArgs, &connectionOptions)
 }
 
 type savedSearchesConnectionStore struct {
@@ -150,19 +156,19 @@ type savedSearchesConnectionStore struct {
 	orgID  *int32
 }
 
-func (s *savedSearchesConnectionStore) MarshalCursor(node *savedSearchResolver) (*string, error) {
+func (s *savedSearchesConnectionStore) MarshalCursor(node *savedSearchResolver, _ database.OrderBy) (*string, error) {
 	cursor := string(node.ID())
 
 	return &cursor, nil
 }
 
-func (s *savedSearchesConnectionStore) UnmarshalCursor(cursor string) (*int, error) {
+func (s *savedSearchesConnectionStore) UnmarshalCursor(cursor string, _ database.OrderBy) (*string, error) {
 	nodeID, err := unmarshalSavedSearchID(graphql.ID(cursor))
 	if err != nil {
 		return nil, err
 	}
 
-	id := int(nodeID)
+	id := strconv.Itoa(int(nodeID))
 
 	return &id, nil
 }

--- a/cmd/frontend/graphqlbackend/saved_searches.go
+++ b/cmd/frontend/graphqlbackend/saved_searches.go
@@ -142,12 +142,7 @@ func (r *schemaResolver) SavedSearches(ctx context.Context, args savedSearchesAr
 		orgID:  &orgID,
 	}
 
-	connectionOptions := graphqlutil.ConnectionResolverOptions{
-		OrderBy:    database.OrderBy{{Field: "id"}},
-		Descending: true,
-	}
-
-	return graphqlutil.NewConnectionResolver[savedSearchResolver](connectionStore, &args.ConnectionResolverArgs, &connectionOptions)
+	return graphqlutil.NewConnectionResolver[savedSearchResolver](connectionStore, &args.ConnectionResolverArgs, nil)
 }
 
 type savedSearchesConnectionStore struct {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1287,6 +1287,10 @@ type Query {
         """
         first: Int
         """
+        Returns the last n repositories from the list.
+        """
+        last: Int
+        """
         Return repositories whose names match the query.
         """
         query: String
@@ -1294,6 +1298,10 @@ type Query {
         An opaque cursor that is used for pagination.
         """
         after: String
+        """
+        An opaque cursor that is used for pagination.
+        """
+        before: String
         """
         Return repositories whose names are in the list.
         """
@@ -1338,7 +1346,7 @@ type Query {
         Sort direction.
         """
         descending: Boolean = false
-    ): RepositoryConnection!
+    ): NewRepositoryConnection!
 
     """
     Looks up a Phabricator repository by name.
@@ -3077,9 +3085,30 @@ type ExternalServiceSyncJob implements Node {
     """
     reposUnmodified: Int!
 }
-
 """
 A list of repositories.
+
+The old `RepositoryConnection` is depricated and is replaced by
+this new connection which support proper cursor based pagination.
+The new connection does not include `precise` argument for totalCount.
+"""
+type NewRepositoryConnection {
+    """
+    A list of repositories.
+    """
+    nodes: [Repository!]!
+    """
+    The total count of repositories in the connection.
+    """
+    totalCount: Int!
+    """
+    Pagination information.
+    """
+    pageInfo: ConnectionPageInfo!
+}
+
+"""
+Depricated! A list of repositories.
 """
 type RepositoryConnection {
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3088,7 +3088,7 @@ type ExternalServiceSyncJob implements Node {
 """
 A list of repositories.
 
-The old `RepositoryConnection` is depricated and is replaced by
+The old `RepositoryConnection` is deprecated and is replaced by
 this new connection which support proper cursor based pagination.
 The new connection does not include `precise` argument for totalCount.
 """
@@ -3108,7 +3108,7 @@ type NewRepositoryConnection {
 }
 
 """
-Depricated! A list of repositories.
+Deprecated! A list of repositories.
 """
 type RepositoryConnection {
     """

--- a/cmd/frontend/graphqlbackend/site_test.go
+++ b/cmd/frontend/graphqlbackend/site_test.go
@@ -71,7 +71,7 @@ func TestSiteConfigurationHistory(t *testing.T) {
 		},
 		{
 			name:                  "last: 20 (more items than what exists in the database)",
-			args:                  &graphqlutil.ConnectionResolverArgs{Last: int32Ptr(5)},
+			args:                  &graphqlutil.ConnectionResolverArgs{Last: int32Ptr(20)},
 			expectedSiteConfigIDs: []int32{5, 4, 3, 2, 1},
 		},
 		{

--- a/internal/database/conf_test.go
+++ b/internal/database/conf_test.go
@@ -286,6 +286,7 @@ func TestGetSiteConfigCount(t *testing.T) {
 
 func TestListSiteConfigs(t *testing.T) {
 	toIntPtr := func(n int) *int { return &n }
+	toStringPtr := func(n string) *string { return &n }
 
 	if testing.Short() {
 		t.Skip()
@@ -297,8 +298,9 @@ func TestListSiteConfigs(t *testing.T) {
 
 	s := db.Conf()
 	createDummySiteConfigs(t, ctx, s)
+	orderBy := []OrderByOption{{Field: "id"}}
 
-	if _, err := s.ListSiteConfigs(ctx, &PaginationArgs{}); err != nil {
+	if _, err := s.ListSiteConfigs(ctx, &PaginationArgs{OrderBy: orderBy, Descending: true}); err != nil {
 		t.Error("Expected non-nil error but got nil")
 	}
 
@@ -314,106 +316,134 @@ func TestListSiteConfigs(t *testing.T) {
 		{
 			name: "first: 2 (subset of data)",
 			listOptions: &PaginationArgs{
-				First: toIntPtr(2),
+				First:      toIntPtr(2),
+				OrderBy:    orderBy,
+				Descending: true,
 			},
 			expectedIDs: []int32{4, 3},
 		},
 		{
 			name: "last: 2 (subset of data)",
 			listOptions: &PaginationArgs{
-				Last: toIntPtr(2),
+				Last:       toIntPtr(2),
+				OrderBy:    orderBy,
+				Descending: true,
 			},
 			expectedIDs: []int32{1, 2},
 		},
 		{
 			name: "first: 4 (all of data)",
 			listOptions: &PaginationArgs{
-				First: toIntPtr(4),
+				First:      toIntPtr(4),
+				OrderBy:    orderBy,
+				Descending: true,
 			},
 			expectedIDs: []int32{4, 3, 2, 1},
 		},
 		{
 			name: "last: 4 (all of data)",
 			listOptions: &PaginationArgs{
-				Last: toIntPtr(4),
+				Last:       toIntPtr(4),
+				OrderBy:    orderBy,
+				Descending: true,
 			},
 			expectedIDs: []int32{1, 2, 3, 4},
 		},
 		{
 			name: "first: 10 (more than data)",
 			listOptions: &PaginationArgs{
-				First: toIntPtr(10),
+				First:      toIntPtr(10),
+				OrderBy:    orderBy,
+				Descending: true,
 			},
 			expectedIDs: []int32{4, 3, 2, 1},
 		},
 		{
 			name: "last: 4 (more than data)",
 			listOptions: &PaginationArgs{
-				Last: toIntPtr(10),
+				Last:       toIntPtr(10),
+				OrderBy:    orderBy,
+				Descending: true,
 			},
 			expectedIDs: []int32{1, 2, 3, 4},
 		},
 		{
 			name: "first: 2, after: 3",
 			listOptions: &PaginationArgs{
-				First: toIntPtr(2),
-				After: toIntPtr(3),
+				First:      toIntPtr(2),
+				After:      toStringPtr("3"),
+				OrderBy:    orderBy,
+				Descending: true,
 			},
 			expectedIDs: []int32{2, 1},
 		},
 		{
 			name: "first: 5, after: 3 (overflow)",
 			listOptions: &PaginationArgs{
-				First: toIntPtr(5),
-				After: toIntPtr(3),
+				First:      toIntPtr(5),
+				After:      toStringPtr("3"),
+				OrderBy:    orderBy,
+				Descending: true,
 			},
 			expectedIDs: []int32{2, 1},
 		},
 		{
 			name: "last: 2, after: 4",
 			listOptions: &PaginationArgs{
-				Last:  toIntPtr(2),
-				After: toIntPtr(4),
+				Last:       toIntPtr(2),
+				After:      toStringPtr("4"),
+				OrderBy:    orderBy,
+				Descending: true,
 			},
 			expectedIDs: []int32{1, 2},
 		},
 		{
 			name: "last: 5, after: 4 (overflow)",
 			listOptions: &PaginationArgs{
-				Last:  toIntPtr(5),
-				After: toIntPtr(4),
+				Last:       toIntPtr(5),
+				After:      toStringPtr("4"),
+				OrderBy:    orderBy,
+				Descending: true,
 			},
 			expectedIDs: []int32{1, 2, 3},
 		},
 		{
 			name: "first: 2, before: 1",
 			listOptions: &PaginationArgs{
-				First:  toIntPtr(2),
-				Before: toIntPtr(1),
+				First:      toIntPtr(2),
+				Before:     toStringPtr("1"),
+				OrderBy:    orderBy,
+				Descending: true,
 			},
 			expectedIDs: []int32{4, 3},
 		},
 		{
 			name: "first: 5, before: 1 (overflow)",
 			listOptions: &PaginationArgs{
-				First:  toIntPtr(5),
-				Before: toIntPtr(1),
+				First:      toIntPtr(5),
+				Before:     toStringPtr("1"),
+				OrderBy:    orderBy,
+				Descending: true,
 			},
 			expectedIDs: []int32{4, 3, 2},
 		},
 		{
 			name: "last: 2, before: 1",
 			listOptions: &PaginationArgs{
-				Last:   toIntPtr(2),
-				Before: toIntPtr(1),
+				Last:       toIntPtr(2),
+				Before:     toStringPtr("1"),
+				OrderBy:    orderBy,
+				Descending: true,
 			},
 			expectedIDs: []int32{2, 3},
 		},
 		{
 			name: "last: 5, before: 1 (overflow)",
 			listOptions: &PaginationArgs{
-				Last:   toIntPtr(5),
-				Before: toIntPtr(1),
+				Last:       toIntPtr(5),
+				Before:     toStringPtr("1"),
+				OrderBy:    orderBy,
+				Descending: true,
 			},
 			expectedIDs: []int32{2, 3, 4},
 		},

--- a/internal/database/conf_test.go
+++ b/internal/database/conf_test.go
@@ -298,9 +298,8 @@ func TestListSiteConfigs(t *testing.T) {
 
 	s := db.Conf()
 	createDummySiteConfigs(t, ctx, s)
-	orderBy := []OrderByOption{{Field: "id"}}
 
-	if _, err := s.ListSiteConfigs(ctx, &PaginationArgs{OrderBy: orderBy, Descending: true}); err != nil {
+	if _, err := s.ListSiteConfigs(ctx, &PaginationArgs{}); err != nil {
 		t.Error("Expected non-nil error but got nil")
 	}
 
@@ -316,134 +315,106 @@ func TestListSiteConfigs(t *testing.T) {
 		{
 			name: "first: 2 (subset of data)",
 			listOptions: &PaginationArgs{
-				First:      toIntPtr(2),
-				OrderBy:    orderBy,
-				Descending: true,
+				First: toIntPtr(2),
 			},
 			expectedIDs: []int32{4, 3},
 		},
 		{
 			name: "last: 2 (subset of data)",
 			listOptions: &PaginationArgs{
-				Last:       toIntPtr(2),
-				OrderBy:    orderBy,
-				Descending: true,
+				Last: toIntPtr(2),
 			},
 			expectedIDs: []int32{1, 2},
 		},
 		{
 			name: "first: 4 (all of data)",
 			listOptions: &PaginationArgs{
-				First:      toIntPtr(4),
-				OrderBy:    orderBy,
-				Descending: true,
+				First: toIntPtr(4),
 			},
 			expectedIDs: []int32{4, 3, 2, 1},
 		},
 		{
 			name: "last: 4 (all of data)",
 			listOptions: &PaginationArgs{
-				Last:       toIntPtr(4),
-				OrderBy:    orderBy,
-				Descending: true,
+				Last: toIntPtr(4),
 			},
 			expectedIDs: []int32{1, 2, 3, 4},
 		},
 		{
 			name: "first: 10 (more than data)",
 			listOptions: &PaginationArgs{
-				First:      toIntPtr(10),
-				OrderBy:    orderBy,
-				Descending: true,
+				First: toIntPtr(10),
 			},
 			expectedIDs: []int32{4, 3, 2, 1},
 		},
 		{
 			name: "last: 4 (more than data)",
 			listOptions: &PaginationArgs{
-				Last:       toIntPtr(10),
-				OrderBy:    orderBy,
-				Descending: true,
+				Last: toIntPtr(10),
 			},
 			expectedIDs: []int32{1, 2, 3, 4},
 		},
 		{
 			name: "first: 2, after: 3",
 			listOptions: &PaginationArgs{
-				First:      toIntPtr(2),
-				After:      toStringPtr("3"),
-				OrderBy:    orderBy,
-				Descending: true,
+				First: toIntPtr(2),
+				After: toStringPtr("3"),
 			},
 			expectedIDs: []int32{2, 1},
 		},
 		{
 			name: "first: 5, after: 3 (overflow)",
 			listOptions: &PaginationArgs{
-				First:      toIntPtr(5),
-				After:      toStringPtr("3"),
-				OrderBy:    orderBy,
-				Descending: true,
+				First: toIntPtr(5),
+				After: toStringPtr("3"),
 			},
 			expectedIDs: []int32{2, 1},
 		},
 		{
 			name: "last: 2, after: 4",
 			listOptions: &PaginationArgs{
-				Last:       toIntPtr(2),
-				After:      toStringPtr("4"),
-				OrderBy:    orderBy,
-				Descending: true,
+				Last:  toIntPtr(2),
+				After: toStringPtr("4"),
 			},
 			expectedIDs: []int32{1, 2},
 		},
 		{
 			name: "last: 5, after: 4 (overflow)",
 			listOptions: &PaginationArgs{
-				Last:       toIntPtr(5),
-				After:      toStringPtr("4"),
-				OrderBy:    orderBy,
-				Descending: true,
+				Last:  toIntPtr(5),
+				After: toStringPtr("4"),
 			},
 			expectedIDs: []int32{1, 2, 3},
 		},
 		{
 			name: "first: 2, before: 1",
 			listOptions: &PaginationArgs{
-				First:      toIntPtr(2),
-				Before:     toStringPtr("1"),
-				OrderBy:    orderBy,
-				Descending: true,
+				First:  toIntPtr(2),
+				Before: toStringPtr("1"),
 			},
 			expectedIDs: []int32{4, 3},
 		},
 		{
 			name: "first: 5, before: 1 (overflow)",
 			listOptions: &PaginationArgs{
-				First:      toIntPtr(5),
-				Before:     toStringPtr("1"),
-				OrderBy:    orderBy,
-				Descending: true,
+				First:  toIntPtr(5),
+				Before: toStringPtr("1"),
 			},
 			expectedIDs: []int32{4, 3, 2},
 		},
 		{
 			name: "last: 2, before: 1",
 			listOptions: &PaginationArgs{
-				Last:       toIntPtr(2),
-				Before:     toStringPtr("1"),
-				OrderBy:    orderBy,
-				Descending: true,
+				Last:   toIntPtr(2),
+				Before: toStringPtr("1"),
 			},
 			expectedIDs: []int32{2, 3},
 		},
 		{
 			name: "last: 5, before: 1 (overflow)",
 			listOptions: &PaginationArgs{
-				Last:       toIntPtr(5),
-				Before:     toStringPtr("1"),
-				OrderBy:    orderBy,
-				Descending: true,
+				Last:   toIntPtr(5),
+				Before: toStringPtr("1"),
 			},
 			expectedIDs: []int32{2, 3, 4},
 		},

--- a/internal/database/helpers.go
+++ b/internal/database/helpers.go
@@ -145,21 +145,21 @@ func (p *PaginationArgs) SQL() (*QueryArgs, error) {
 
 	if p.After != nil {
 		columnsStr := strings.Join(orderByColumns, ", ")
-		condition := fmt.Sprintf("(%v) >", columnsStr)
+		condition := fmt.Sprintf("(%s) >", columnsStr)
 		if p.Descending {
-			condition = fmt.Sprintf("(%v) <", columnsStr)
+			condition = fmt.Sprintf("(%s) <", columnsStr)
 		}
 
-		conditions = append(conditions, sqlf.Sprintf(fmt.Sprintf(condition+" (%v)", *p.After)))
+		conditions = append(conditions, sqlf.Sprintf(fmt.Sprintf(condition+" (%s)", *p.After)))
 	}
 	if p.Before != nil {
 		columnsStr := strings.Join(orderByColumns, ", ")
-		condition := fmt.Sprintf("(%v) <", columnsStr)
+		condition := fmt.Sprintf("(%s) <", columnsStr)
 		if p.Descending {
-			condition = fmt.Sprintf("(%v) >", columnsStr)
+			condition = fmt.Sprintf("(%s) >", columnsStr)
 		}
 
-		conditions = append(conditions, sqlf.Sprintf(fmt.Sprintf(condition+" (%v)", *p.Before)))
+		conditions = append(conditions, sqlf.Sprintf(fmt.Sprintf(condition+" (%s)", *p.Before)))
 	}
 
 	if len(conditions) > 0 {

--- a/internal/database/helpers.go
+++ b/internal/database/helpers.go
@@ -140,7 +140,7 @@ func (p *PaginationArgs) SQL() (*QueryArgs, error) {
 
 	orderByColumns := p.OrderBy.Columns()
 	if len(orderByColumns) < 1 {
-		return nil, errors.New("Atleast 1 sort column must be provided")
+		return nil, errors.New("no sort column provided")
 	}
 
 	if p.After != nil {

--- a/internal/database/helpers.go
+++ b/internal/database/helpers.go
@@ -109,7 +109,7 @@ type OrderByOption struct {
 func (o OrderByOption) SQL(descending bool) *sqlf.Query {
 	var sb strings.Builder
 
-	sb.WriteString(string(o.Field))
+	sb.WriteString(o.Field)
 
 	if descending {
 		sb.WriteString(" DESC")

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -739,6 +739,9 @@ type ReposListOptions struct {
 	// and if it doesn't end up being used this is wasted compute.
 	ExcludeSources bool
 
+	// cursor-based pagination args
+	PaginationArgs *PaginationArgs
+
 	*LimitOffset
 }
 
@@ -930,6 +933,22 @@ func (s *repoStore) list(ctx context.Context, tr *trace.Trace, opt ReposListOpti
 func (s *repoStore) listSQL(ctx context.Context, tr *trace.Trace, opt ReposListOptions) (*sqlf.Query, error) {
 	var ctes, joins, where []*sqlf.Query
 
+	querySuffix := sqlf.Sprintf("%s %s", opt.OrderBy.SQL(), opt.LimitOffset.SQL())
+
+	if opt.PaginationArgs != nil {
+		p, err := opt.PaginationArgs.SQL()
+		if err != nil {
+			return nil, err
+		}
+
+		if p.Where != nil {
+			where = append(where, p.Where)
+		}
+
+		querySuffix = p.AppendOrderToQuery(&sqlf.Query{})
+		querySuffix = p.AppendLimitToQuery(querySuffix)
+	}
+
 	// Cursor-based pagination requires parsing a handful of extra fields, which
 	// may result in additional query conditions.
 	if len(opt.Cursors) > 0 {
@@ -1115,7 +1134,7 @@ func (s *repoStore) listSQL(ctx context.Context, tr *trace.Trace, opt ReposListO
 	}
 
 	if opt.NoCloned || opt.OnlyCloned || opt.FailedFetch || opt.OnlyCorrupted || opt.joinGitserverRepos ||
-		opt.CloneStatus != types.CloneStatusUnknown || containsSizeField(opt.OrderBy) {
+		opt.CloneStatus != types.CloneStatusUnknown || containsSizeField(opt.OrderBy) || (opt.PaginationArgs != nil && containsOrderBySizeField(opt.PaginationArgs.OrderBy)) {
 		joins = append(joins, sqlf.Sprintf("JOIN gitserver_repos gr ON gr.repo_id = repo.id"))
 	}
 	if opt.OnlyIndexed || opt.NoIndexed {
@@ -1172,8 +1191,6 @@ func (s *repoStore) listSQL(ctx context.Context, tr *trace.Trace, opt ReposListO
 		queryPrefix = sqlf.Sprintf("WITH %s", sqlf.Join(ctes, ",\n"))
 	}
 
-	querySuffix := sqlf.Sprintf("%s %s", opt.OrderBy.SQL(), opt.LimitOffset.SQL())
-
 	columns := repoColumns
 	if !opt.ExcludeSources {
 		columns = append(columns, getSourcesByRepoQueryStr)
@@ -1204,6 +1221,15 @@ func (s *repoStore) listSQL(ctx context.Context, tr *trace.Trace, opt ReposListO
 func containsSizeField(orderBy RepoListOrderBy) bool {
 	for _, field := range orderBy {
 		if field.Field == RepoListSize {
+			return true
+		}
+	}
+	return false
+}
+
+func containsOrderBySizeField(orderBy OrderBy) bool {
+	for _, field := range orderBy {
+		if field.Field == string(RepoListSize) {
 			return true
 		}
 	}


### PR DESCRIPTION
closes: https://github.com/sourcegraph/sourcegraph/issues/43620

This PR implements a new connection resolver for `schema.repositories` which supports proper cursor based pagination.
The old resolver code is not removed as it is used to other APIs. 

We show PageSelector in place of `showMore` now. 

`precise` argument from `totalCount` field is also removed from the new resolver. 

## Test plan
Updated all graphql and integration tests. 

Default page size is 20, reduced to 5 only for taking screenshot
<img width="965" alt="image" src="https://user-images.githubusercontent.com/22571395/213400903-6a488115-5e43-4169-8a27-9289f3da02e9.png">
