### PR TITLE
Fix single child expansion for new directory list

### DIFF
--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -365,7 +365,7 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
                 />
             )}
             <section className={classNames('test-tree-entries container mb-3 px-0', styles.section)}>
-                <FilesCard diffStats={diffStats} entries={tree.entries} className={styles.files} />
+                <FilesCard diffStats={diffStats} entries={tree.entries} className={styles.files} filePath={filePath} />
 
                 <Card className={styles.commits}>
                     <CardHeader className={panelStyles.cardColHeaderWrapper}>

--- a/client/web/src/repo/tree/TreePagePanels.tsx
+++ b/client/web/src/repo/tree/TreePagePanels.tsx
@@ -17,10 +17,10 @@ import {
     useElementObscuredArea,
 } from '@sourcegraph/wildcard'
 
+import { dirname } from '../../util/path'
 import { RenderedFile } from '../blob/RenderedFile'
 
 import styles from './TreePagePanels.module.scss'
-import { dirname } from '../../util/path'
 
 interface ReadmePreviewCardProps {
     readmeHTML: string

--- a/client/web/src/repo/tree/TreePagePanels.tsx
+++ b/client/web/src/repo/tree/TreePagePanels.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useRef, useState } from 'react'
+import React, { FC, useCallback, useRef, useState, useMemo } from 'react'
 
 import { mdiFileDocumentOutline, mdiFolderOutline, mdiMenuDown, mdiMenuUp } from '@mdi/js'
 import classNames from 'classnames'
@@ -20,6 +20,7 @@ import {
 import { RenderedFile } from '../blob/RenderedFile'
 
 import styles from './TreePagePanels.module.scss'
+import { dirname } from '../../util/path'
 
 interface ReadmePreviewCardProps {
     readmeHTML: string
@@ -62,13 +63,49 @@ export interface DiffStat {
 }
 
 export interface FilePanelProps {
-    entries: Pick<TreeFields['entries'][number], 'name' | 'url' | 'isDirectory' | 'path'>[]
+    entries: Pick<TreeFields['entries'][number], 'name' | 'url' | 'isDirectory' | 'path' | 'isSingleChild'>[]
     diffStats?: DiffStat[]
     className?: string
+    filePath: string
 }
 
 export const FilesCard: FC<FilePanelProps> = props => {
-    const { entries, diffStats, className } = props
+    const { entries, diffStats, className, filePath } = props
+
+    const entriesWithSingleChildExpanded = useMemo(
+        () =>
+            entries.flatMap((entry, index) => {
+                // The GraphQL query with "recurse single child" will return entries
+                // that are not in the current directory. We filter them out for the
+                // view here.
+                let parentDir = dirname(entry.path)
+                if (parentDir === '.') {
+                    parentDir = ''
+                }
+                if (parentDir !== filePath) {
+                    return []
+                }
+
+                // Single child nodes may be expanded so we can skip over them more
+                // efficiently.
+                if (entry.isSingleChild) {
+                    // Find the entry before the one that is no longer a single child
+                    // and add this to the list of entries to render instead of the
+                    // entry.
+                    let idx
+                    for (idx = index; idx < entries.length && entries[idx].isSingleChild; idx++) {
+                        // Do nothing
+                    }
+                    if (idx > index && idx < entries.length && idx > 1) {
+                        const lastSingleChild = entries[idx - 1]
+                        return [lastSingleChild]
+                    }
+                }
+
+                return [entry]
+            }),
+        [entries, filePath]
+    )
 
     const [sortColumn, setSortColumn] = useState<{
         column: 'Files' | 'Activity'
@@ -86,7 +123,7 @@ export const FilesCard: FC<FilePanelProps> = props => {
         }
     }
 
-    let sortedEntries = [...entries]
+    let sortedEntries = [...entriesWithSingleChildExpanded]
     const { column, direction } = sortColumn
     switch (column) {
         case 'Files':
@@ -95,7 +132,7 @@ export const FilesCard: FC<FilePanelProps> = props => {
             }
             break
         case 'Activity':
-            sortedEntries = [...entries]
+            sortedEntries = [...entriesWithSingleChildExpanded]
             if (diffStats) {
                 sortedEntries.sort((entry1, entry2) => {
                     const stats1: DiffStat = diffStatsByPath[entry1.name]
@@ -242,7 +279,13 @@ export const FilesCard: FC<FilePanelProps> = props => {
                                             svgPath={entry.isDirectory ? mdiFolderOutline : mdiFileDocumentOutline}
                                             aria-hidden={true}
                                         />
-                                        {entry.name}
+                                        {
+                                            // In case of single child expansion, we need to get the name relative to
+                                            // the start of the directory (to include subdirectories)
+                                        }
+                                        {entry.isSingleChild && filePath !== ''
+                                            ? entry.path.slice(filePath.length + 1)
+                                            : entry.name}
                                         {entry.isDirectory && '/'}
                                     </span>
                                 </div>


### PR DESCRIPTION
This fixes single child directories in the new tree list.

Here's the current state, for reference: https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/client/jetbrains/src/main/java

## Test plan

<img width="1314" alt="Screenshot 2023-01-18 at 12 58 27" src="https://user-images.githubusercontent.com/458591/213166042-9d6a69d1-8791-45dd-9f16-42311a8042a7.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-fix-single-child-expansion-in.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
