### PR TITLE
rbac: remove default apply from schema

### DIFF
--- a/internal/rbac/types.go
+++ b/internal/rbac/types.go
@@ -8,7 +8,6 @@ type Schema struct {
 
 // Namespace represents a feature to be guarded by RBAC. (example: Batch Changes, Code Insights e.t.c)
 type Namespace struct {
-	Name         string   `json:"name"`
-	Actions      []string `json:"actions"`
-	DefaultApply bool     `json:"defaultApply"`
+	Name    string   `json:"name"`
+	Actions []string `json:"actions"`
 }


### PR DESCRIPTION
This got added initially but wasn't part of the roadmap for now. Removing it till we actually have a need for it so as not to overengineer the solution and focus on what's important.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Simple removal of a struct field