### PR TITLE
gRPC: propagate actors across RPC calls

### DIFF
--- a/internal/actor/grpc.go
+++ b/internal/actor/grpc.go
@@ -1,0 +1,57 @@
+package actor
+
+import (
+	"context"
+	"strconv"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// ActorPropagator implements the (internal/grpc).Propagator interface
+// for propagating actors across RPC calls. This is modeled directly on
+// the HTTP middleware in this package, and should work exactly the same.
+type ActorPropagator struct{}
+
+func (ActorPropagator) ExtractContext(ctx context.Context) metadata.MD {
+	actor := FromContext(ctx)
+	switch {
+	case actor.IsInternal():
+		return metadata.Pairs(headerKeyActorUID, headerValueInternalActor)
+	case actor.IsAuthenticated():
+		return metadata.Pairs(headerKeyActorUID, actor.UIDString())
+	default:
+		md := metadata.Pairs(headerKeyActorUID, headerValueNoActor)
+		if actor.AnonymousUID != "" {
+			md.Append(headerKeyActorAnonymousUID, actor.AnonymousUID)
+		}
+		return md
+	}
+}
+
+func (ActorPropagator) InjectContext(ctx context.Context, md metadata.MD) context.Context {
+	var uidStr string
+	if vals := md.Get(headerKeyActorUID); len(vals) > 0 {
+		uidStr = vals[0]
+	}
+
+	switch uidStr {
+	case headerValueInternalActor:
+		ctx = WithInternalActor(ctx)
+	case "", headerValueNoActor:
+		if vals := md.Get(headerKeyActorAnonymousUID); len(vals) > 0 {
+			ctx = WithActor(ctx, FromAnonymousUser(vals[0]))
+		}
+	default:
+		uid, err := strconv.Atoi(uidStr)
+		if err != nil {
+			// If the actor is invalid, ignore the error
+			// and do not set an actor on the context.
+			break
+		}
+
+		actor := FromUser(int32(uid))
+		ctx = WithActor(ctx, actor)
+	}
+
+	return ctx
+}

--- a/internal/actor/grpc.go
+++ b/internal/actor/grpc.go
@@ -12,7 +12,7 @@ import (
 // the HTTP middleware in this package, and should work exactly the same.
 type ActorPropagator struct{}
 
-func (ActorPropagator) ExtractContext(ctx context.Context) metadata.MD {
+func (ActorPropagator) FromContext(ctx context.Context) metadata.MD {
 	actor := FromContext(ctx)
 	switch {
 	case actor.IsInternal():

--- a/internal/actor/grpc_test.go
+++ b/internal/actor/grpc_test.go
@@ -1,0 +1,46 @@
+package actor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestActorPropagator(t *testing.T) {
+	t.Run("no actor", func(t *testing.T) {
+		ap := ActorPropagator{}
+		md := ap.ExtractContext(context.Background())
+		ctx := ap.InjectContext(context.Background(), md)
+		actor := FromContext(ctx)
+		require.False(t, actor.IsAuthenticated())
+	})
+
+	t.Run("internal actor", func(t *testing.T) {
+		ap := ActorPropagator{}
+		ctx1 := WithInternalActor(context.Background())
+		md := ap.ExtractContext(ctx1)
+		ctx2 := ap.InjectContext(context.Background(), md)
+		actor := FromContext(ctx2)
+		require.True(t, actor.IsInternal())
+	})
+
+	t.Run("user actor", func(t *testing.T) {
+		ap := ActorPropagator{}
+		ctx1 := WithActor(context.Background(), FromUser(16))
+		md := ap.ExtractContext(ctx1)
+		ctx2 := ap.InjectContext(context.Background(), md)
+		actor := FromContext(ctx2)
+		require.True(t, actor.IsAuthenticated())
+		require.Equal(t, int32(16), actor.UID)
+	})
+
+	t.Run("anonymous user actor", func(t *testing.T) {
+		ap := ActorPropagator{}
+		ctx1 := WithActor(context.Background(), FromAnonymousUser("anon123"))
+		md := ap.ExtractContext(ctx1)
+		ctx2 := ap.InjectContext(context.Background(), md)
+		actor := FromContext(ctx2)
+		require.Equal(t, "anon123", actor.AnonymousUID)
+	})
+}

--- a/internal/actor/grpc_test.go
+++ b/internal/actor/grpc_test.go
@@ -10,7 +10,7 @@ import (
 func TestActorPropagator(t *testing.T) {
 	t.Run("no actor", func(t *testing.T) {
 		ap := ActorPropagator{}
-		md := ap.ExtractContext(context.Background())
+		md := ap.FromContext(context.Background())
 		ctx := ap.InjectContext(context.Background(), md)
 		actor := FromContext(ctx)
 		require.False(t, actor.IsAuthenticated())
@@ -19,7 +19,7 @@ func TestActorPropagator(t *testing.T) {
 	t.Run("internal actor", func(t *testing.T) {
 		ap := ActorPropagator{}
 		ctx1 := WithInternalActor(context.Background())
-		md := ap.ExtractContext(ctx1)
+		md := ap.FromContext(ctx1)
 		ctx2 := ap.InjectContext(context.Background(), md)
 		actor := FromContext(ctx2)
 		require.True(t, actor.IsInternal())
@@ -28,7 +28,7 @@ func TestActorPropagator(t *testing.T) {
 	t.Run("user actor", func(t *testing.T) {
 		ap := ActorPropagator{}
 		ctx1 := WithActor(context.Background(), FromUser(16))
-		md := ap.ExtractContext(ctx1)
+		md := ap.FromContext(ctx1)
 		ctx2 := ap.InjectContext(context.Background(), md)
 		actor := FromContext(ctx2)
 		require.True(t, actor.IsAuthenticated())
@@ -38,7 +38,7 @@ func TestActorPropagator(t *testing.T) {
 	t.Run("anonymous user actor", func(t *testing.T) {
 		ap := ActorPropagator{}
 		ctx1 := WithActor(context.Background(), FromAnonymousUser("anon123"))
-		md := ap.ExtractContext(ctx1)
+		md := ap.FromContext(ctx1)
 		ctx2 := ap.InjectContext(context.Background(), md)
 		actor := FromContext(ctx2)
 		require.Equal(t, "anon123", actor.AnonymousUID)

--- a/internal/grpc/defaults/defaults.go
+++ b/internal/grpc/defaults/defaults.go
@@ -8,6 +8,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	internalgrpc "github.com/sourcegraph/sourcegraph/internal/grpc"
 	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 )
@@ -21,10 +22,12 @@ func DialOptions() []grpc.DialOption {
 	// that are not initialized during init time.
 	return []grpc.DialOption{
 		grpc.WithChainStreamInterceptor(
+			internalgrpc.StreamClientPropagator(actor.ActorPropagator{}),
 			internalgrpc.StreamClientPropagator(policy.ShouldTracePropagator{}),
 			otelgrpc.StreamClientInterceptor(),
 		),
 		grpc.WithChainUnaryInterceptor(
+			internalgrpc.UnaryClientPropagator(actor.ActorPropagator{}),
 			internalgrpc.UnaryClientPropagator(policy.ShouldTracePropagator{}),
 			otelgrpc.UnaryClientInterceptor(),
 		),
@@ -40,10 +43,12 @@ func ServerOptions() []grpc.ServerOption {
 	// that are not initialized during init time.
 	return []grpc.ServerOption{
 		grpc.ChainStreamInterceptor(
+			internalgrpc.StreamServerPropagator(actor.ActorPropagator{}),
 			internalgrpc.StreamServerPropagator(policy.ShouldTracePropagator{}),
 			otelgrpc.StreamServerInterceptor(),
 		),
 		grpc.ChainUnaryInterceptor(
+			internalgrpc.UnaryServerPropagator(actor.ActorPropagator{}),
 			internalgrpc.UnaryServerPropagator(policy.ShouldTracePropagator{}),
 			otelgrpc.UnaryServerInterceptor(),
 		),


### PR DESCRIPTION
We use actors to determine what user operations are running as. The current actor is stored in the context, and we need to propagate that across the network boundary when making an RPC request. 

This creates an `ActorPropagator` (similar to the `ShouldTracePropagator` in the previous PR in this stack) that pulls the actor off the context and serializes it as gRPC metadata. 

This is a minimal implementation of cross-RPC authentication that will likely be replaced by [ATLS](https://grpc.io/docs/languages/go/alts/) once we roll that out, but until that is rolled out across all services, we'll need to support the existing actor infrastructure

Stacked on #46611 

## Test plan

Added unit tests for `ActorPropagator` roundtrip.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
