### PR TITLE
rcache: only get connection in Set if it will be used

### DIFF
--- a/internal/rcache/rcache.go
+++ b/internal/rcache/rcache.go
@@ -130,14 +130,14 @@ func (r *Cache) Get(key string) ([]byte, bool) {
 
 // Set implements httpcache.Cache.Set
 func (r *Cache) Set(key string, b []byte) {
-	c := poolGet()
-	defer c.Close()
-
 	if !utf8.Valid([]byte(key)) {
 		log15.Error("rcache: keys must be valid utf8", "key", []byte(key))
 	}
 
 	if r.ttlSeconds == 0 {
+		c := poolGet()
+		defer c.Close()
+
 		_, err := c.Do("SET", r.rkeyPrefix()+key, b)
 		if err != nil {
 			log15.Warn("failed to execute redis command", "cmd", "SET", "error", err)


### PR DESCRIPTION
Minor optimization, we would acquire a connection from the pool twice for Set with TTL since Set would acquire a connection but then just call SetWithTTL which does the same thing.

Test Plan: go test