### PR TITLE
Adds a new runtype to work with Bazel commands without affecting others. 

### DIFF
--- a/dev/ci/runtype/runtype.go
+++ b/dev/ci/runtype/runtype.go
@@ -167,7 +167,8 @@ func (t RunType) String() string {
 	switch t {
 	case PullRequest:
 		return "Pull request"
-
+	case BazelExpBranch:
+		return "Bazel Exp Branch"
 	case ReleaseNightly:
 		return "Release branch nightly healthcheck build"
 	case BextNightly:

--- a/dev/ci/runtype/runtype.go
+++ b/dev/ci/runtype/runtype.go
@@ -13,7 +13,8 @@ type RunType int
 const (
 	// RunTypes should be defined by order of precedence.
 
-	PullRequest RunType = iota // pull request build
+	PullRequest    RunType = iota // pull request build
+	BazelExpBranch                // branch that runs specific bazel steps
 
 	// Nightly builds - must be first because they take precedence
 
@@ -130,7 +131,10 @@ func (t RunType) Matcher() *RunTypeMatcher {
 		return &RunTypeMatcher{
 			Branch: "main-dry-run/",
 		}
-
+	case BazelExpBranch:
+		return &RunTypeMatcher{
+			Branch: "bzl/",
+		}
 	case ImagePatch:
 		return &RunTypeMatcher{
 			Branch:                 "docker-images-patch/",

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -83,6 +83,21 @@ The default run type.
   - **Scan test builds**: Scan alpine-3.14, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan jaeger-agent, Scan jaeger-all-in-one, Scan blobstore2, Scan node-exporter, Scan postgres-12-alpine, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan symbols, Scan syntax-highlighter, Scan worker, Scan migrator, Scan executor, Scan executor-vm, Scan batcheshelper, Scan opentelemetry-collector, Scan sg
   - Upload build trace
 
+### 
+
+The run type for branches matching `bzl/`.
+You can create a build of this run type for your changes using:
+
+```sh
+sg ci build bzl
+```
+
+Base pipeline (more steps might be included based on branch changes):
+
+- **Metadata**: Pipeline metadata
+- Build //dev/sg
+- Upload build trace
+
 ### Release branch nightly healthcheck build
 
 The run type for environment including `{"RELEASE_NIGHTLY":"true"}`.

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -83,7 +83,7 @@ The default run type.
   - **Scan test builds**: Scan alpine-3.14, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan jaeger-agent, Scan jaeger-all-in-one, Scan blobstore2, Scan node-exporter, Scan postgres-12-alpine, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan symbols, Scan syntax-highlighter, Scan worker, Scan migrator, Scan executor, Scan executor-vm, Scan batcheshelper, Scan opentelemetry-collector, Scan sg
   - Upload build trace
 
-### 
+### Bazel Exp Branch
 
 The run type for branches matching `bzl/`.
 You can create a build of this run type for your changes using:

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -236,6 +236,7 @@ This command is useful when:
 
 Supported run types when providing an argument for 'sg ci build [runtype]':
 
+* bzl
 * main-dry-run
 * docker-images-patch
 * docker-images-patch-notest

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -1,0 +1,33 @@
+package ci
+
+import (
+	"fmt"
+	"strings"
+
+	bk "github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/buildkite"
+	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/ci/operations"
+)
+
+const bazelRemoteCacheURL = "https://storage.googleapis.com/sourcegraph_bazel_cache"
+
+func BazelOperations() *operations.Set {
+	ops := operations.NewSet()
+	ops.Append(build("//dev/sg"))
+	return ops
+}
+
+func build(target string) func(*bk.Pipeline) {
+	bazelCmd := []string{
+		fmt.Sprintf("bazel build %s", target),
+		"--remote_cache=$CI_BAZEL_REMOTE_CACHE",
+		"--google_credentials=/mnt/gcloud-service-account/gcloud-service-account.json",
+	}
+
+	return func(pipeline *bk.Pipeline) {
+		pipeline.AddStep(fmt.Sprintf(":bazel: Build %s", target),
+			bk.Env("CI_BAZEL_REMOTE_CACHE", bazelRemoteCacheURL),
+			bk.Cmd(strings.Join(bazelCmd, " ")),
+			bk.Agent("queue", "bazel"),
+		)
+	}
+}

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -89,6 +89,8 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	//
 	// PERF: Try to order steps such that slower steps are first.
 	switch c.RunType {
+	case runtype.BazelExpBranch:
+		ops.Merge(BazelOperations())
 	case runtype.PullRequest:
 		// First, we set up core test operations that apply both to PRs and to other run
 		// types such as main.


### PR DESCRIPTION
This PRs adds a new runtype that we can use to shortcircuit existing steps, allowing us to use the `bzl/` prefix to get a specific set of operations just for bazel. 

This is a temporary runtime, allowing us to build stuff with bazel easily until we integrate things more. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Did a test run over https://buildkite.com/sourcegraph/sourcegraph/builds/194253#0185c98c-90bd-434b-9100-14af55a9fe86 it fails when executed, but it properly runs on a different queue, so it's working as intended.

It's only build `//dev/sg` which does not exist in this PR, I'll circle back on this later. 