### PR TITLE
Tweak open-in-editor and git-blame icons

### DIFF
--- a/client/shared/src/components/icons.tsx
+++ b/client/shared/src/components/icons.tsx
@@ -127,21 +127,6 @@ export const WrapDisabledIcon: React.FunctionComponent<React.PropsWithChildren<I
     </svg>
 )
 
-export const OpenInEditorIcon: React.FunctionComponent<React.PropsWithChildren<IconProps>> = props => (
-    <svg {...props} viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <rect x="3" y="2" width="6" height="1.5" rx="0.75" fill="currentColor" />
-        <rect x="3" y="16" width="6" height="1.5" rx="0.75" fill="currentColor" />
-        <rect x="9" y="9" width="6" height="1.5" rx="0.75" fill="currentColor" />
-        <rect x="10" y="2" width="4" height="1.5" rx="0.75" fill="currentColor" />
-        <rect x="6" y="12.5" width="6" height="1.5" rx="0.75" fill="currentColor" />
-        <rect x="13" y="12.5" width="4" height="1.5" rx="0.75" fill="currentColor" />
-        <rect x="16" y="9" width="3" height="1.5" rx="0.75" fill="currentColor" />
-        <rect x="6" y="5.5" width="6" height="1.5" rx="0.75" fill="currentColor" />
-        <rect x="13" y="5.5" width="3" height="1.5" rx="0.75" fill="currentColor" />
-        <rect x="10" y="16" width="2" height="1.5" rx="0.75" fill="currentColor" />
-    </svg>
-)
-
 // TODO: Rename name when refresh design is complete
 // eslint-disable-next-line react/display-name
 export const CloudAlertIconRefresh = React.forwardRef((props, reference) => (

--- a/client/web/src/open-in-editor/OpenInEditorActionItem.tsx
+++ b/client/web/src/open-in-editor/OpenInEditorActionItem.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
+import { mdiApplicationEditOutline } from '@mdi/js'
 import { from } from 'rxjs'
 
 import { logger } from '@sourcegraph/common'
 import { SimpleActionItem } from '@sourcegraph/shared/src/actions/SimpleActionItem'
 import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
-import { mdiApplicationEditOutline } from '@mdi/js'
-
 import { isSettingsValid, Settings } from '@sourcegraph/shared/src/settings/settings'
 import {
     Button,

--- a/client/web/src/open-in-editor/OpenInEditorActionItem.tsx
+++ b/client/web/src/open-in-editor/OpenInEditorActionItem.tsx
@@ -5,11 +5,13 @@ import { from } from 'rxjs'
 
 import { logger } from '@sourcegraph/common'
 import { SimpleActionItem } from '@sourcegraph/shared/src/actions/SimpleActionItem'
-import { OpenInEditorIcon } from '@sourcegraph/shared/src/components/icons'
 import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
+import { mdiApplicationEditOutline } from '@mdi/js'
+
 import { isSettingsValid, Settings } from '@sourcegraph/shared/src/settings/settings'
 import {
     Button,
+    Icon,
     Popover,
     PopoverContent,
     PopoverTrigger,
@@ -136,7 +138,7 @@ export const OpenInEditorActionItem: React.FunctionComponent<OpenInEditorActionI
                     isActive={popoverOpen}
                     icon={
                         props.source === 'repoHeader' ? (
-                            <OpenInEditorIcon className={styles.icon} />
+                            <Icon aria-hidden={true} className={styles.icon} svgPath={mdiApplicationEditOutline} />
                         ) : (
                             <img
                                 src={`${assetsRoot}/img/open-in-editor.svg`}

--- a/client/web/src/repo/actions/ToggleBlameAction.module.scss
+++ b/client/web/src/repo/actions/ToggleBlameAction.module.scss
@@ -1,3 +1,0 @@
-.icon-active {
-    fill: #de5e3e !important;
-}

--- a/client/web/src/repo/actions/ToggleBlameAction.tsx
+++ b/client/web/src/repo/actions/ToggleBlameAction.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 
-import { mdiGit } from '@mdi/js'
+import { mdiAccountDetails, mdiAccountDetailsOutline } from '@mdi/js'
 import classNames from 'classnames'
 
 import { SimpleActionItem } from '@sourcegraph/shared/src/actions/SimpleActionItem'
@@ -32,7 +32,11 @@ export const ToggleBlameAction: React.FC<Props> = props => {
     }, [isBlameVisible, setIsBlameVisible])
 
     const icon = (
-        <Icon aria-hidden={true} svgPath={mdiGit} className={classNames(isBlameVisible && styles.iconActive)} />
+        <Icon
+            aria-hidden={true}
+            svgPath={isBlameVisible ? mdiAccountDetails : mdiAccountDetailsOutline}
+            className={classNames(isBlameVisible && styles.iconActive)}
+        />
     )
 
     if (props.source === 'actionItemsBar') {

--- a/client/web/src/repo/actions/ToggleBlameAction.tsx
+++ b/client/web/src/repo/actions/ToggleBlameAction.tsx
@@ -3,12 +3,12 @@ import { useCallback } from 'react'
 import { mdiAccountDetails, mdiAccountDetailsOutline } from '@mdi/js'
 
 import { SimpleActionItem } from '@sourcegraph/shared/src/actions/SimpleActionItem'
+import { RenderMode } from '@sourcegraph/shared/src/util/url'
 import { Button, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { eventLogger } from '../../tracking/eventLogger'
 import { useBlameVisibility } from '../blame/useBlameVisibility'
 import { RepoHeaderActionAnchor, RepoHeaderActionMenuLink } from '../components/RepoHeaderActions'
-import { RenderMode } from '@sourcegraph/shared/src/util/url'
 
 interface Props {
     source?: 'repoHeader' | 'actionItemsBar'

--- a/client/web/src/repo/actions/ToggleBlameAction.tsx
+++ b/client/web/src/repo/actions/ToggleBlameAction.tsx
@@ -1,7 +1,6 @@
 import { useCallback } from 'react'
 
 import { mdiAccountDetails, mdiAccountDetailsOutline } from '@mdi/js'
-import classNames from 'classnames'
 
 import { SimpleActionItem } from '@sourcegraph/shared/src/actions/SimpleActionItem'
 import { Button, Icon, Tooltip } from '@sourcegraph/wildcard'
@@ -9,8 +8,6 @@ import { Button, Icon, Tooltip } from '@sourcegraph/wildcard'
 import { eventLogger } from '../../tracking/eventLogger'
 import { useBlameVisibility } from '../blame/useBlameVisibility'
 import { RepoHeaderActionAnchor, RepoHeaderActionMenuLink } from '../components/RepoHeaderActions'
-
-import styles from './ToggleBlameAction.module.scss'
 
 interface Props {
     source?: 'repoHeader' | 'actionItemsBar'
@@ -31,13 +28,7 @@ export const ToggleBlameAction: React.FC<Props> = props => {
         }
     }, [isBlameVisible, setIsBlameVisible])
 
-    const icon = (
-        <Icon
-            aria-hidden={true}
-            svgPath={isBlameVisible ? mdiAccountDetails : mdiAccountDetailsOutline}
-            className={classNames(isBlameVisible && styles.iconActive)}
-        />
-    )
+    const icon = <Icon aria-hidden={true} svgPath={isBlameVisible ? mdiAccountDetails : mdiAccountDetailsOutline} />
 
     if (props.source === 'actionItemsBar') {
         return (

--- a/client/web/src/repo/actions/ToggleBlameAction.tsx
+++ b/client/web/src/repo/actions/ToggleBlameAction.tsx
@@ -8,15 +8,21 @@ import { Button, Icon, Tooltip } from '@sourcegraph/wildcard'
 import { eventLogger } from '../../tracking/eventLogger'
 import { useBlameVisibility } from '../blame/useBlameVisibility'
 import { RepoHeaderActionAnchor, RepoHeaderActionMenuLink } from '../components/RepoHeaderActions'
+import { RenderMode } from '@sourcegraph/shared/src/util/url'
 
 interface Props {
     source?: 'repoHeader' | 'actionItemsBar'
     actionType?: 'nav' | 'dropdown'
+    renderMode?: RenderMode
 }
 export const ToggleBlameAction: React.FC<Props> = props => {
     const [isBlameVisible, setIsBlameVisible] = useBlameVisibility()
 
-    const descriptiveText = `${isBlameVisible ? 'Hide' : 'Show'} Git blame line annotations`
+    const disabled = props.renderMode === 'rendered'
+
+    const descriptiveText = disabled
+        ? 'Git blame line annotations are not available when viewing a rendered document'
+        : `${isBlameVisible ? 'Hide' : 'Show'} Git blame line annotations`
 
     const toggleBlameState = useCallback(() => {
         if (isBlameVisible) {
@@ -28,7 +34,9 @@ export const ToggleBlameAction: React.FC<Props> = props => {
         }
     }, [isBlameVisible, setIsBlameVisible])
 
-    const icon = <Icon aria-hidden={true} svgPath={isBlameVisible ? mdiAccountDetails : mdiAccountDetailsOutline} />
+    const icon = (
+        <Icon aria-hidden={true} svgPath={isBlameVisible && !disabled ? mdiAccountDetails : mdiAccountDetailsOutline} />
+    )
 
     if (props.source === 'actionItemsBar') {
         return (
@@ -40,7 +48,7 @@ export const ToggleBlameAction: React.FC<Props> = props => {
 
     if (props.actionType === 'dropdown') {
         return (
-            <RepoHeaderActionMenuLink file={true} as={Button} onClick={toggleBlameState}>
+            <RepoHeaderActionMenuLink file={true} as={Button} onClick={toggleBlameState} disabled={disabled}>
                 {icon}
                 <span>{descriptiveText}</span>
             </RepoHeaderActionMenuLink>
@@ -49,7 +57,9 @@ export const ToggleBlameAction: React.FC<Props> = props => {
 
     return (
         <Tooltip content={descriptiveText}>
-            <RepoHeaderActionAnchor onSelect={toggleBlameState}>{icon}</RepoHeaderActionAnchor>
+            <RepoHeaderActionAnchor onSelect={toggleBlameState} disabled={disabled}>
+                {icon}
+            </RepoHeaderActionAnchor>
         </Tooltip>
     )
 }

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -386,7 +386,9 @@ export const BlobPage: React.FunctionComponent<React.PropsWithChildren<BlobPageP
                         id="toggle-blame-action"
                         repoHeaderContributionsLifecycleProps={props.repoHeaderContributionsLifecycleProps}
                     >
-                        {({ actionType }) => <ToggleBlameAction actionType={actionType} source="repoHeader" />}
+                        {({ actionType }) => (
+                            <ToggleBlameAction actionType={actionType} source="repoHeader" renderMode={renderMode} />
+                        )}
                     </RepoHeaderContributionPortal>
                 </>
             ) : null}


### PR DESCRIPTION
Follow-up from feedback received here: https://github.com/sourcegraph/sourcegraph/pull/46339#issuecomment-1387487844

This changes the open-in-editor icon when no editor is configured as well as the git blame icon to remove the dependency on git and show a different shape when the icon is activated to not violate WCAG.

## Test plan

<img width="1247" alt="Screenshot 2023-01-20 at 01 02 46" src="https://user-images.githubusercontent.com/458591/213588914-61127e28-0eff-42ed-85b6-a4bd776c6036.png">
<img width="1255" alt="Screenshot 2023-01-20 at 01 02 43" src="https://user-images.githubusercontent.com/458591/213588922-43662244-86c8-4daf-b4b0-545eff1296db.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-change-blame-and-open-in.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
