### PR TITLE
permissions-center: use `NextSyncAt` for delay between GitHub webhook is received and sync is scheduled.

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/webhooks/github.go
+++ b/enterprise/cmd/frontend/internal/authz/webhooks/github.go
@@ -166,11 +166,10 @@ func (h *GitHubWebhook) getUserAndSyncPerms(ctx context.Context, db database.DB,
 		return errors.Newf("no github external accounts found with account id %d", user.GetID())
 	}
 
-	// TODO: Here we should call another method to set `NextSyncAt` on the
-	// PermsSyncJob if that feature is enabled.
 	permssync.SchedulePermsSync(ctx, h.logger, db, protocol.PermsSyncRequest{
-		UserIDs: []int32{externalAccounts[0].UserID},
-		Reason:  reason,
+		UserIDs:    []int32{externalAccounts[0].UserID},
+		Reason:     reason,
+		NextSyncAt: time.Now().Add(sleepTime),
 	})
 
 	return err
@@ -184,11 +183,10 @@ func (h *GitHubWebhook) getRepoAndSyncPerms(ctx context.Context, db database.DB,
 		return err
 	}
 
-	// TODO: Here we should call another method to set `NextSyncAt` on the
-	// PermsSyncJob if that feature is enabled.
 	permssync.SchedulePermsSync(ctx, h.logger, db, protocol.PermsSyncRequest{
-		RepoIDs: []api.RepoID{repo.ID},
-		Reason:  reason,
+		RepoIDs:    []api.RepoID{repo.ID},
+		Reason:     reason,
+		NextSyncAt: time.Now().Add(sleepTime),
 	})
 
 	return nil

--- a/internal/authz/permssync/permssync.go
+++ b/internal/authz/permssync/permssync.go
@@ -82,6 +82,7 @@ func SchedulePermsSync(ctx context.Context, logger log.Logger, db database.DB, r
 				InvalidateCaches:  req.Options.InvalidateCaches,
 				Reason:            req.Reason,
 				TriggeredByUserID: req.TriggeredByUserID,
+				NextSyncAt:        req.NextSyncAt,
 			}
 			err := db.PermissionSyncJobs().CreateUserSyncJob(ctx, userID, opts)
 			if err != nil {
@@ -95,6 +96,7 @@ func SchedulePermsSync(ctx context.Context, logger log.Logger, db database.DB, r
 				InvalidateCaches:  req.Options.InvalidateCaches,
 				Reason:            req.Reason,
 				TriggeredByUserID: req.TriggeredByUserID,
+				NextSyncAt:        req.NextSyncAt,
 			}
 			err := db.PermissionSyncJobs().CreateRepoSyncJob(ctx, repoID, opts)
 			if err != nil {

--- a/internal/repoupdater/protocol/repoupdater.go
+++ b/internal/repoupdater/protocol/repoupdater.go
@@ -250,6 +250,7 @@ type PermsSyncRequest struct {
 	Options           authz.FetchPermsOptions `json:"options"`
 	Reason            string                  `json:"reason"`
 	TriggeredByUserID int32                   `json:"triggered_by_user_id"`
+	NextSyncAt        time.Time               `json:"next_sync_at"`
 }
 
 // PermsSyncResponse is a response to sync permissions.


### PR DESCRIPTION
We're doing a fixed delay of 10 seconds for now because it is a good starting point and it is what @pjlast found out during his investigation and chat with GitHub support.

Test plan:
Unit tests updated.

Closes https://github.com/sourcegraph/sourcegraph/issues/46323