### PR TITLE
symbols: squirrel: remove /debugLocalCodeIntel endpoint

### DIFF
--- a/cmd/symbols/internal/api/handler_cgo.go
+++ b/cmd/symbols/internal/api/handler_cgo.go
@@ -18,6 +18,5 @@ func addHandlers(
 	readFileFunc func(context.Context, internaltypes.RepoCommitPath) ([]byte, error),
 ) {
 	mux.HandleFunc("/localCodeIntel", squirrel.LocalCodeIntelHandler(readFileFunc))
-	mux.HandleFunc("/debugLocalCodeIntel", squirrel.DebugLocalCodeIntelHandler)
 	mux.HandleFunc("/symbolInfo", squirrel.NewSymbolInfoHandler(searchFunc, readFileFunc))
 }

--- a/cmd/symbols/internal/api/handler_nocgo.go
+++ b/cmd/symbols/internal/api/handler_nocgo.go
@@ -25,12 +25,7 @@ func addHandlers(
 	}
 
 	mux.HandleFunc("/localCodeIntel", jsonResponseHandler(internaltypes.LocalCodeIntelPayload{Symbols: []internaltypes.Symbol{}}))
-	mux.HandleFunc("/debugLocalCodeIntel", notEnabledHandler)
 	mux.HandleFunc("/symbolInfo", jsonResponseHandler(internaltypes.SymbolInfo{}))
-}
-
-func notEnabledHandler(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "feature not enabled in this build", http.StatusNotImplemented)
 }
 
 func jsonResponseHandler(v any) http.HandlerFunc {

--- a/cmd/symbols/squirrel/http_handlers.go
+++ b/cmd/symbols/squirrel/http_handlers.go
@@ -2,10 +2,8 @@ package squirrel
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
-	"html"
 	"io"
 	"math/rand"
 	"net/http"
@@ -13,8 +11,6 @@ import (
 	"strings"
 
 	"github.com/inconshreveable/log15"
-	sitter "github.com/smacker/go-tree-sitter"
-
 	symbolsTypes "github.com/sourcegraph/sourcegraph/cmd/symbols/types"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -129,124 +125,6 @@ func NewSymbolInfoHandler(symbolSearch symbolsTypes.SearchFunc, readFile readFil
 			return
 		}
 	}
-}
-
-// Response to /debugLocalCodeIntel.
-func DebugLocalCodeIntelHandler(w http.ResponseWriter, r *http.Request) {
-	// Read ?ext=<ext> from the request.
-	ext := r.URL.Query().Get("ext")
-	if ext == "" {
-		http.Error(w, "missing ?ext=<ext> query parameter", http.StatusBadRequest)
-		return
-	}
-
-	w.Header().Set("Content-Type", "text/html")
-
-	path := types.RepoCommitPath{
-		Repo:   "foo",
-		Commit: "bar",
-		Path:   "example." + ext,
-	}
-
-	fileToRead := "/tmp/squirrel-example.txt"
-	readFile := func(ctx context.Context, args types.RepoCommitPath) ([]byte, error) {
-		return os.ReadFile("/tmp/squirrel-example.txt")
-	}
-
-	squirrel := New(readFile, nil)
-	defer squirrel.Close()
-
-	rangeToSymbolIx := map[types.Range]int{}
-	symbolIxToColor := map[int]string{}
-	payload, err := squirrel.localCodeIntel(r.Context(), path)
-	if err != nil {
-		fmt.Fprintf(w, "failed to generate local code intel payload: %s\n\n", err)
-	} else {
-		for ix := range payload.Symbols {
-			nonRed := []int{100, 120, 140, 160, 180, 200, 220, 240, 260}
-			symbolIxToColor[ix] = fmt.Sprintf("hsla(%d, 100%%, 50%%, 0.5)", sample(nonRed))
-		}
-
-		for ix, symbol := range payload.Symbols {
-			rangeToSymbolIx[symbol.Def] = ix
-			for _, ref := range symbol.Refs {
-				rangeToSymbolIx[ref] = ix
-			}
-		}
-	}
-
-	node, err := squirrel.parse(r.Context(), path)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	fmt.Fprintf(w, `
-		<style>
-			span:hover {
-				outline: 2px solid red;
-			}
-		</style>
-	`)
-
-	fmt.Fprintf(w, "<h3>Parsing as %s from file on disk %s</h3>\n", ext, fileToRead)
-
-	var nodeToHtml func(*sitter.Node, string) string
-	nodeToHtml = func(n *sitter.Node, stack string) string {
-
-		thisStack := stack + ">" + n.Type()
-
-		// Pick color
-		color := ""
-		if n.Type() == "ERROR" {
-			color = "hsla(0, 100%, 50%, 0.2)"
-		} else if ix, ok := rangeToSymbolIx[nodeToRange(n)]; ok {
-			if c, ok := symbolIxToColor[ix]; ok {
-				color = c
-			}
-		} else {
-			color = "hsla(0, 0%, 0%, 0.0)"
-		}
-
-		// Tooltip
-		title := fmt.Sprintf("%s %d:%d-%d:%d", thisStack, n.StartPoint().Row, n.StartPoint().Column, n.EndPoint().Row, n.EndPoint().Column)
-
-		if n.ChildCount() == 0 {
-
-			// Base case: no children
-
-			// Render
-			return fmt.Sprintf(
-				`<span style="background-color: %s", title="%s">%s</span>`,
-				color,
-				title,
-				html.EscapeString(string(node.Contents[n.StartByte():n.EndByte()])),
-			)
-		} else {
-
-			// Recursive case: with children
-
-			// Concatenate children
-			b := n.StartByte()
-			inner := &strings.Builder{}
-			for i := 0; i < int(n.ChildCount()); i++ {
-				inner.WriteString(html.EscapeString(string(node.Contents[b:n.Child(i).StartByte()])))
-				inner.WriteString(nodeToHtml(n.Child(i), thisStack))
-				b = n.Child(i).EndByte()
-			}
-			inner.WriteString(html.EscapeString(string(node.Contents[b:n.EndByte()])))
-
-			// Render
-			return fmt.Sprintf(
-				`<span style="background-color: %s", title="%s">%s</span>`,
-				color,
-				title,
-				inner.String(),
-			)
-		}
-	}
-
-	fmt.Fprint(w, "<pre>"+nodeToHtml(node.Node, "")+"</pre>")
 }
 
 func sample[T any](xs []T) T {


### PR DESCRIPTION
In the course of implementing #46523, I came across this `/debugLocalCodeIntel` route in the symbols service. This seems broken and is a route that nobody is currently using:

- It hard-codes a non-existent repository / commit as its repoCommitPath argument:

``` go 
types.RepoCommitPath {
		Repo:   "foo",
		Commit: "bar",
		Path:   "example." + ext,
}
```

- The file it refers to, `/tmp/squirrel-example.txt`, is both hard-coded and isn't located anywhere on disk 


## Test plan

CI
