### PR TITLE
[hotfix]: adding logs to git tree resolver

### DIFF
--- a/enterprise/internal/codeintel/shared/resolvers/git_tree_entry_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/git_tree_entry_resolver.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/cloneurls"
@@ -36,10 +38,12 @@ type GitTreeEntryResolver struct {
 	// stat is this tree entry's file info. Its Name method must return the full path relative to
 	// the root, not the basename.
 	stat fs.FileInfo
+
+	logger log.Logger
 }
 
 func NewGitTreeEntryResolver(db database.DB, commit *GitCommitResolver, stat fs.FileInfo) *GitTreeEntryResolver {
-	return &GitTreeEntryResolver{db: db, commit: commit, stat: stat}
+	return &GitTreeEntryResolver{db: db, commit: commit, stat: stat, logger: log.Scoped("git tree entry resolver", "")}
 }
 func (r *GitTreeEntryResolver) Path() string { return r.stat.Name() }
 func (r *GitTreeEntryResolver) Name() string { return path.Base(r.stat.Name()) }
@@ -47,6 +51,7 @@ func (r *GitTreeEntryResolver) Name() string { return path.Base(r.stat.Name()) }
 func (r *GitTreeEntryResolver) ToGitTree() (resolverstubs.GitTreeEntryResolver, bool) {
 	return r, r.IsDirectory()
 }
+
 func (r *GitTreeEntryResolver) ToGitBlob() (resolverstubs.GitTreeEntryResolver, bool) {
 	return r, !r.IsDirectory()
 }
@@ -102,9 +107,18 @@ func (r *GitTreeEntryResolver) URL(ctx context.Context) (string, error) {
 	return r.url(ctx).String(), nil
 }
 
-func (r *GitTreeEntryResolver) Submodule() resolverstubs.GitSubmoduleResolver {
+func (r *GitTreeEntryResolver) Submodule() resolverstubs.GitSubmoduleResolver { // HERE
+	if r == nil {
+		r.logger.Error("git tree entry resolver is nil", log.Error(errors.New("git tree entry resolver is nil")))
+		return nil
+	}
+
+	if r.stat == nil {
+		r.logger.Error("stat is nil", log.Error(errors.New("stat is nil")))
+		return nil
+	}
+
 	if submoduleInfo, ok := r.stat.Sys().(gitdomain.Submodule); ok {
-		// return &gitSubmoduleResolver{submodule: submoduleInfo}
 		return NewGitSubmoduleResolver(submoduleInfo)
 	}
 	return nil

--- a/enterprise/internal/codeintel/shared/resolvers/git_tree_entry_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/git_tree_entry_resolver.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/cloneurls"

--- a/enterprise/internal/codeintel/shared/resolvers/git_tree_entry_resolver.go
+++ b/enterprise/internal/codeintel/shared/resolvers/git_tree_entry_resolver.go
@@ -105,7 +105,7 @@ func (r *GitTreeEntryResolver) URL(ctx context.Context) (string, error) {
 	return r.url(ctx).String(), nil
 }
 
-func (r *GitTreeEntryResolver) Submodule() resolverstubs.GitSubmoduleResolver { // HERE
+func (r *GitTreeEntryResolver) Submodule() resolverstubs.GitSubmoduleResolver {
 	if r == nil {
 		r.logger.Error("git tree entry resolver is nil", log.Error(errors.New("git tree entry resolver is nil")))
 		return nil


### PR DESCRIPTION
Adds logs and prevents a panic for Git Tree Entry Resolver

See slack discussion [here](https://sourcegraph.slack.com/archives/CHXHX7XAS/p1674055605496149)


## Test plan
No test required. Just added logs.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
