### PR TITLE
Lock to the first visible line of code when switching git blame on/off

### DIFF
--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -277,7 +277,15 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
     // Update blame decorations
     useLayoutEffect(() => {
         if (editor) {
-            editor.dispatch({ effects: blameDecorationsCompartment.reconfigure(blameDecorations) })
+            const effects = [blameDecorationsCompartment.reconfigure(blameDecorations)]
+            const firstLine = firstVisibleLine(editor)
+            if (firstLine) {
+                // Avoid jumpy scrollbar when enabling git blame by forcing the
+                // scroll bar to preserve the top line number that's visible.
+                // Details https://github.com/sourcegraph/sourcegraph/issues/41413
+                effects.push(EditorView.scrollIntoView(firstLine.from, { y: 'start' }))
+            }
+            editor.dispatch({ effects })
         }
         // editor is not provided because this should only be triggered after the
         // editor was created (i.e. not on first render)

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -5,7 +5,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
 import { openSearchPanel } from '@codemirror/search'
-import { Compartment, EditorState, Extension, Line } from '@codemirror/state'
+import { Compartment, EditorState, Extension } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
 import { isEqual } from 'lodash'
 
@@ -26,7 +26,8 @@ import { blobPropsFacet } from './codemirror'
 import { createBlameDecorationsExtension } from './codemirror/blame-decorations'
 import { syntaxHighlight } from './codemirror/highlight'
 import { pin, updatePin } from './codemirror/hovercard'
-import { selectableLineNumbers, SelectedLineRange, selectLines, shouldScrollIntoView } from './codemirror/linenumbers'
+import { selectableLineNumbers, SelectedLineRange, selectLines } from './codemirror/linenumbers'
+import { lockFirstVisibleLine } from './codemirror/lock-line'
 import { navigateToLineOnAnyClickExtension } from './codemirror/navigate-to-any-line-on-click'
 import { search } from './codemirror/search'
 import { sourcegraphExtensions } from './codemirror/sourcegraph-extensions'
@@ -277,14 +278,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
     // Update blame decorations
     useLayoutEffect(() => {
         if (editor) {
-            const effects = [blameDecorationsCompartment.reconfigure(blameDecorations)]
-            const firstLine = firstVisibleLine(editor)
-            if (firstLine) {
-                // Avoid jumpy scrollbar when enabling git blame by forcing the
-                // scroll bar to preserve the top line number that's visible.
-                // Details https://github.com/sourcegraph/sourcegraph/issues/41413
-                effects.push(EditorView.scrollIntoView(firstLine.from, { y: 'start' }))
-            }
+            const effects = [blameDecorationsCompartment.reconfigure(blameDecorations), ...lockFirstVisibleLine(editor)]
             editor.dispatch({ effects })
         }
         // editor is not provided because this should only be triggered after the
@@ -305,14 +299,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
     // Update line wrapping
     useEffect(() => {
         if (editor) {
-            const effects = [wrapCodeCompartment.reconfigure(wrapCodeSettings)]
-            const firstLine = firstVisibleLine(editor)
-            if (firstLine) {
-                // Avoid jumpy scrollbar when enabling line wrapping by forcing the
-                // scroll bar to preserve the top line number that's visible.
-                // Details https://github.com/sourcegraph/sourcegraph/issues/41413
-                effects.push(EditorView.scrollIntoView(firstLine.from, { y: 'start' }))
-            }
+            const effects = [wrapCodeCompartment.reconfigure(wrapCodeSettings), ...lockFirstVisibleLine(editor)]
             editor.dispatch({ effects })
         }
         // editor is not provided because this should only be triggered after the
@@ -384,25 +371,4 @@ function useDistinctBlob(blobInfo: BlobInfo): BlobInfo {
         }
         return blobRef.current
     }, [blobInfo])
-}
-
-// Returns the first line that is visible in the editor. We can't directly use
-// the viewport for this functionality because the viewport includes lines that
-// are rendered but not visible.
-function firstVisibleLine(view: EditorView): Line | undefined {
-    for (const { from, to } of view.visibleRanges) {
-        for (let pos = from; pos < to; ) {
-            const line = view.state.doc.lineAt(pos)
-            // This may be an inefficient way to detect the first visible line
-            // but it appears to work correctly and this is unlikely to be a
-            // performance bottleneck since we should only use need to compute
-            // this for infrequently used code-paths like when enabling/disabling
-            // line wrapping, or when lazy syntax highlighting gets loaded.
-            if (!shouldScrollIntoView(view, { line: line.number + 1 })) {
-                return line
-            }
-            pos = line.to + 1
-        }
-    }
-    return undefined
 }

--- a/client/web/src/repo/blob/codemirror/lock-line.ts
+++ b/client/web/src/repo/blob/codemirror/lock-line.ts
@@ -1,0 +1,37 @@
+import { Line, StateEffect } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+
+import { shouldScrollIntoView } from './linenumbers'
+
+// Avoid jumpy scrollbar when the line dimensions change by locking on to the
+// first visible line.
+//
+// Details https://github.com/sourcegraph/sourcegraph/issues/41413
+export function lockFirstVisibleLine(view: EditorView): StateEffect<unknown>[] {
+    const firstLine = firstVisibleLine(view)
+    if (firstLine) {
+        return [EditorView.scrollIntoView(firstLine.from, { y: 'start' })]
+    }
+    return []
+}
+
+// Returns the first line that is visible in the editor. We can't directly use
+// the viewport for this functionality because the viewport includes lines that
+// are rendered but not visible.
+function firstVisibleLine(view: EditorView): Line | undefined {
+    for (const { from, to } of view.visibleRanges) {
+        for (let pos = from; pos < to; ) {
+            const line = view.state.doc.lineAt(pos)
+            // This may be an inefficient way to detect the first visible line
+            // but it appears to work correctly and this is unlikely to be a
+            // performance bottleneck since we should only use need to compute
+            // this for infrequently used code-paths like when enabling/disabling
+            // line wrapping, or when lazy syntax highlighting gets loaded.
+            if (!shouldScrollIntoView(view, { line: line.number + 1 })) {
+                return line
+            }
+            pos = line.to + 1
+        }
+    }
+    return undefined
+}


### PR DESCRIPTION
Another amazing piece of feedback by @coury-clark: When we toggle between git blame, we have increased the line height of the editor. This can cause _vast_ jumps in the currenlty visible position when you're further down in the document (e.g. the top line of 1000 could become 1500 with our 1.5x line-height multiplier).

To fix this, I’m reusing @olafurpg's fix for line wrapping that locks the editor's first visible line in place (he added it here: #45477).

## Test plan

https://user-images.githubusercontent.com/458591/213525631-fd37a900-5e0a-41a3-a964-cc1245fc36b6.mov

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-ps-lock-scroll-position-when.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
