### PR TITLE
Implement Smart Search suggestions preview on No Results page

### DIFF
--- a/client/branded/src/search-ui/results/SmartSearchPreview.tsx
+++ b/client/branded/src/search-ui/results/SmartSearchPreview.tsx
@@ -1,0 +1,84 @@
+import { mdiArrowRight } from '@mdi/js'
+import { of } from 'rxjs'
+import { tap, filter, map } from 'rxjs/operators'
+
+import { SearchPatternType } from '../../../../shared/src/graphql-operations'
+import {
+    LATEST_VERSION,
+    aggregateStreamingSearch,
+    ProposedQuery,
+    StreamSearchOptions,
+} from '../../../../shared/src/search/stream'
+import { SearchMode } from '@sourcegraph/shared/src/search'
+
+import React, { useMemo } from 'react'
+import { Icon, useObservable } from '@sourcegraph/wildcard'
+
+interface SmartSearchPreviewProposedQueriesProps {
+    proposedQueries: ProposedQuery[]
+}
+const SmartSearchPreviewProposedQueries: React.FunctionComponent<SmartSearchPreviewProposedQueriesProps> = ({
+    proposedQueries,
+}) => {
+    return (
+        <ul>
+            {proposedQueries.map((proposedQuery, index) => (
+                <li key={index}>
+                    {/* <span>{proposedQuery.description}</span> */}
+                    <span>{proposedQuery.query}</span>
+                    <Icon className="" aria-hidden={true} svgPath={mdiArrowRight} />
+                    <span>
+                        {proposedQuery.annotations?.map(annotation => (
+                            <span>{annotation.value}</span>
+                        ))}
+                    </span>
+                </li>
+            ))}
+        </ul>
+    )
+}
+
+interface SmartSearchPreviewProps {
+    query: string
+}
+
+function smartSearchProposedQueriesSearch(query: string, options: StreamSearchOptions): Observable<ProposedQuery[]> {
+    return aggregateStreamingSearch(of(query), options).pipe(
+        filter(event => event && event.state === 'complete'),
+        filter(event => event.alert?.kind === 'smart-search-pure-results'),
+        map(event => event.alert?.proposedQueries),
+        tap(results => {
+            console.log('Smart search results:', results)
+        })
+    )
+}
+
+export const SmartSearchPreview: React.FunctionComponent<SmartSearchPreviewProps> = ({ query }) => {
+    const options = {
+        version: LATEST_VERSION,
+        patternType: SearchPatternType.standard,
+        caseSensitive: false,
+        trace: undefined,
+        searchMode: SearchMode.SmartSearch,
+    }
+
+    const proposedQueriesObservable = useMemo(() => smartSearchProposedQueriesSearch(query, options), [query])
+
+    const proposedQueries = useObservable<ProposedQuery[]>(proposedQueriesObservable)
+
+    // TODO: calculate the actual number from proposedQueries
+    const totalResultsCount = 100
+
+    return (
+        <div>
+            {proposedQueries ? (
+                <>
+                    <span>Smart Search found {totalResultsCount} results with variations of your query</span>
+                    <SmartSearchPreviewProposedQueries proposedQueries={proposedQueries} />
+                </>
+            ) : (
+                <div>Placeholder for loading indicator...</div>
+            )}
+        </div>
+    )
+}

--- a/client/branded/src/search-ui/results/StreamingSearchResultsFooter.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsFooter.tsx
@@ -9,6 +9,7 @@ import { Alert, LoadingSpinner, Code, Text, Link, ErrorAlert } from '@sourcegrap
 import { StreamingProgressCount } from './progress/StreamingProgressCount'
 
 import styles from './StreamingSearchResultsList.module.scss'
+import { SmartSearchPreview } from './SmartSearchPreview'
 
 export const StreamingSearchResultFooter: React.FunctionComponent<
     React.PropsWithChildren<{
@@ -50,6 +51,7 @@ export const StreamingSearchResultFooter: React.FunctionComponent<
                         , or use the tips below to improve your query.
                     </Text>
                 </Alert>
+                <SmartSearchPreview query="sourcegraph javascript" />
             </div>
         )}
 

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -252,7 +252,7 @@ interface Alert {
 // Same key values from internal/search/alert.go
 export type AnnotationName = 'ResultCount'
 
-interface ProposedQuery {
+export interface ProposedQuery {
     description?: string | null
     annotations?: { name: AnnotationName; value: string }[]
     query: string


### PR DESCRIPTION
Implements a preview of smart search variation suggestions on the No Results page.

Initial work by @st0nebraker 

See issue:
- #45774 

Closes #45774 

## PR plan

- [x] Create the `SmartSearchPreview` component
- [x] Fetch Smart Search proposed queries
- [ ] Use query and options that come from the original query, except with search mode changed to Smart Search
- [ ] Render proposed queries according to the design, with syntax-highlighted query strings
- [ ] Implement loading indicator (shimmering placeholder)
- [ ] Pass the correct query and options into `<SmartSearchPreview>`
- [ ] Calculate total number of results
- [ ] Modify results formatting from "X additional results" (in search response) to "X results" in the preview
- [ ] Add "enable smart search" link below
- [ ] Make sure we render the `SmartSearchPreview` only if Smart Search was disabled on the initial query

## Test plan

TODO

## App preview:

- [Web](https://sg-web-smart-search-preview.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.

