### PR TITLE
adding customer replica repo to release stage step

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -701,7 +701,11 @@ Batch change: ${batchChangeURL}`,
             // Push final tags
             const branch = `${release.major}.${release.minor}`
             const tag = `v${release.version}`
-            for (const repo of ['deploy-sourcegraph', 'deploy-sourcegraph-docker', 'deploy-sourcegraph-docker-customer-replica-1']) {
+            for (const repo of [
+                'deploy-sourcegraph',
+                'deploy-sourcegraph-docker',
+                'deploy-sourcegraph-docker-customer-replica-1',
+            ]) {
                 try {
                     await createTag(
                         await getAuthenticatedGitHubClient(),

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -701,7 +701,7 @@ Batch change: ${batchChangeURL}`,
             // Push final tags
             const branch = `${release.major}.${release.minor}`
             const tag = `v${release.version}`
-            for (const repo of ['deploy-sourcegraph', 'deploy-sourcegraph-docker']) {
+            for (const repo of ['deploy-sourcegraph', 'deploy-sourcegraph-docker', 'deploy-sourcegraph-docker-customer-replica-1']) {
                 try {
                     await createTag(
                         await getAuthenticatedGitHubClient(),

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -592,9 +592,7 @@ cc @${config.captainGitHubUsername}
                         commitMessage: defaultPRMessage,
                         title: defaultPRMessage,
                         edits: [`tools/update-docker-tags.sh ${release.version}`],
-                        ...prBodyAndDraftState([
-                            'Follow the [release guide](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/RELEASING.md#releasing-pure-docker) to complete this PR',
-                        ]),
+                        ...prBodyAndDraftState([]),
                     },
                     {
                         owner: 'sourcegraph',

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -586,6 +586,18 @@ cc @${config.captainGitHubUsername}
                     },
                     {
                         owner: 'sourcegraph',
+                        repo: 'https://github.com/sourcegraph/deploy-sourcegraph-docker-customer-replica-1',
+                        base: `${release.major}.${release.minor}`,
+                        head: `publish-${release.version}`,
+                        commitMessage: defaultPRMessage,
+                        title: defaultPRMessage,
+                        edits: [`tools/update-docker-tags.sh ${release.version}`],
+                        ...prBodyAndDraftState([
+                            'Follow the [release guide](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/RELEASING.md#releasing-pure-docker) to complete this PR',
+                        ]),
+                    },
+                    {
+                        owner: 'sourcegraph',
                         repo: 'deploy-sourcegraph-aws',
                         base: 'master',
                         head: `publish-${release.version}`,


### PR DESCRIPTION
This adds a step similar to deploy-sourcegraph-docker for a new copy of the repo for customer-replica. This is somewhat experimental, and if there are any issues during the 4.4 release we should remove it.

## Test plan
N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-cclark-adding-customer-replica-to.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
