### PR TITLE
Code Insights: Add insight export data UI

### DIFF
--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
@@ -109,7 +109,7 @@ export const InsightContextMenu: FC<InsightCardMenuProps> = props => {
                                     Get shareable link
                                 </MenuLink>
 
-                                {isLangStatsInsight(insight) && (
+                                {!isLangStatsInsight(insight) && (
                                     <MenuItem className={styles.item} onSelect={() => setShowExportDataConfirm(true)}>
                                         Export data
                                     </MenuItem>

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { FC, PropsWithChildren, useState } from 'react'
 
 import { mdiDotsVertical } from '@mdi/js'
 import classNames from 'classnames'
@@ -16,13 +16,15 @@ import {
     Checkbox,
     Tooltip,
     Icon,
+    MenuHeader,
 } from '@sourcegraph/wildcard'
 
 import { useExperimentalFeatures } from '../../../../../../stores'
-import { Insight, InsightDashboard, InsightType, isVirtualDashboard } from '../../../../core'
+import { Insight, InsightDashboard, InsightType, isLangStatsInsight, isVirtualDashboard } from '../../../../core'
 import { useUiFeatures } from '../../../../hooks'
 import { encodeDashboardIdQueryParam } from '../../../../routers.constant'
 import { ConfirmDeleteModal } from '../../../modals/ConfirmDeleteModal'
+import { ExportInsightDataModal } from '../../../modals/ExportInsightDataModal'
 import { ShareLinkModal } from '../../../modals/ShareLinkModal/ShareLinkModal'
 
 import { ConfirmRemoveModal } from './ConfirmRemoveModal'
@@ -39,11 +41,12 @@ export interface InsightCardMenuProps {
 /**
  * Renders context menu (three dots menu) for particular insight card.
  */
-export const InsightContextMenu: React.FunctionComponent<React.PropsWithChildren<InsightCardMenuProps>> = props => {
+export const InsightContextMenu: FC<InsightCardMenuProps> = props => {
     const { insight, currentDashboard, zeroYAxisMin, onToggleZeroYAxisMin = noop } = props
 
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
     const [showRemoveConfirm, setShowRemoveConfirm] = useState(false)
+    const [showExportDataConfirm, setShowExportDataConfirm] = useState(false)
     const [showShareModal, setShowShareModal] = useState(false)
 
     const { insight: insightPermissions } = useUiFeatures()
@@ -85,97 +88,142 @@ export const InsightContextMenu: React.FunctionComponent<React.PropsWithChildren
                             data-testid={`context-menu.${insight.id}`}
                             onKeyDown={event => event.stopPropagation()}
                         >
-                            <MenuLink
-                                as={Link}
-                                data-testid="InsightContextMenuEditLink"
-                                className={styles.item}
-                                to={encodeDashboardIdQueryParam(`/insights/${insight.id}/edit`, currentDashboard?.id)}
-                            >
-                                Edit
-                            </MenuLink>
-
-                            <MenuLink
-                                data-testid="InsightContextMenuShareLink"
-                                className={styles.item}
-                                onSelect={() => setShowShareModal(true)}
-                            >
-                                Get shareable link
-                            </MenuLink>
-
-                            {menuPermissions.showYAxis && (
-                                <MenuItem
-                                    role="menuitemcheckbox"
-                                    aria-checked={zeroYAxisMin}
+                            <MenuSection name="Insight">
+                                <MenuLink
+                                    as={Link}
                                     data-testid="InsightContextMenuEditLink"
                                     className={styles.item}
-                                    onSelect={onToggleZeroYAxisMin}
+                                    to={encodeDashboardIdQueryParam(
+                                        `/insights/${insight.id}/edit`,
+                                        currentDashboard?.id
+                                    )}
                                 >
-                                    <Checkbox
-                                        id="InsightContextMenuEditInput"
-                                        aria-hidden="true"
-                                        checked={zeroYAxisMin}
-                                        tabIndex={-1}
-                                        label={<span className="font-weight-normal">Start Y Axis at 0</span>}
-                                    />
-                                </MenuItem>
-                            )}
-
-                            {quickFixUrl && showQuickFix && (
-                                <MenuLink as={Link} className={styles.item} to={quickFixUrl}>
-                                    Golang quick fixes
+                                    Edit
                                 </MenuLink>
-                            )}
 
-                            {currentDashboard && (
-                                <Tooltip
-                                    content={
-                                        withinVirtualDashboard
-                                            ? "Removing insight isn't available for the All insights dashboard"
-                                            : undefined
-                                    }
-                                    placement="left"
+                                <MenuLink
+                                    data-testid="InsightContextMenuShareLink"
+                                    className={styles.item}
+                                    onSelect={() => setShowShareModal(true)}
                                 >
-                                    <MenuItem
-                                        data-testid="insight-context-remove-from-dashboard-button"
-                                        onSelect={() => setShowRemoveConfirm(true)}
-                                        disabled={withinVirtualDashboard}
-                                        className={styles.item}
-                                    >
-                                        Remove from this dashboard
+                                    Get shareable link
+                                </MenuLink>
+
+                                {isLangStatsInsight(insight) && (
+                                    <MenuItem className={styles.item} onSelect={() => setShowExportDataConfirm(true)}>
+                                        Export data
                                     </MenuItem>
-                                </Tooltip>
-                            )}
+                                )}
+                            </MenuSection>
 
-                            <MenuDivider />
+                            <MenuSection name="Chart settings">
+                                {menuPermissions.showYAxis && (
+                                    <MenuItem
+                                        role="menuitemcheckbox"
+                                        aria-checked={zeroYAxisMin}
+                                        data-testid="InsightContextMenuEditLink"
+                                        className={styles.item}
+                                        onSelect={onToggleZeroYAxisMin}
+                                    >
+                                        <Checkbox
+                                            id="InsightContextMenuEditInput"
+                                            aria-hidden="true"
+                                            checked={zeroYAxisMin}
+                                            tabIndex={-1}
+                                            label={<span className="font-weight-normal">Start Y Axis at 0</span>}
+                                        />
+                                    </MenuItem>
+                                )}
+                            </MenuSection>
 
-                            <MenuItem
-                                data-testid="insight-context-menu-delete-button"
-                                onSelect={() => setShowDeleteConfirm(true)}
-                                className={styles.item}
-                            >
-                                Delete
-                            </MenuItem>
+                            <MenuSection name="Others" divider={false}>
+                                {quickFixUrl && showQuickFix && (
+                                    <MenuLink as={Link} className={styles.item} to={quickFixUrl}>
+                                        Golang quick fixes
+                                    </MenuLink>
+                                )}
+
+                                {currentDashboard && (
+                                    <Tooltip
+                                        content={
+                                            withinVirtualDashboard
+                                                ? "Removing insight isn't available for the All insights dashboard"
+                                                : undefined
+                                        }
+                                        placement="left"
+                                    >
+                                        <MenuItem
+                                            data-testid="insight-context-remove-from-dashboard-button"
+                                            onSelect={() => setShowRemoveConfirm(true)}
+                                            disabled={withinVirtualDashboard}
+                                            className={styles.item}
+                                        >
+                                            Remove from this dashboard
+                                        </MenuItem>
+                                    </Tooltip>
+                                )}
+
+                                <MenuItem
+                                    data-testid="insight-context-menu-delete-button"
+                                    onSelect={() => setShowDeleteConfirm(true)}
+                                    className={styles.item}
+                                >
+                                    Delete
+                                </MenuItem>
+                            </MenuSection>
                         </MenuList>
                     </>
                 )}
             </Menu>
+
             <ConfirmDeleteModal
                 insight={insight}
                 showModal={showDeleteConfirm}
                 onCancel={() => setShowDeleteConfirm(false)}
             />
+
             <ConfirmRemoveModal
                 insight={insight}
                 dashboard={currentDashboard}
                 showModal={showRemoveConfirm}
                 onCancel={() => setShowRemoveConfirm(false)}
             />
+
             <ShareLinkModal
                 aria-label="Share insight"
                 insight={insight}
                 isOpen={showShareModal}
                 onDismiss={() => setShowShareModal(false)}
             />
+
+            <ExportInsightDataModal
+                insightId={insight.id}
+                insightTitle={insight.title}
+                showModal={showExportDataConfirm}
+                onCancel={() => setShowExportDataConfirm(false)}
+                onConfirm={() => setShowExportDataConfirm(false)}
+            />
+        </>
+    )
+}
+
+interface MenuSectionProps {
+    name: string
+    divider?: boolean
+}
+
+const MenuSection: FC<PropsWithChildren<MenuSectionProps>> = props => {
+    const { name, children, divider = true } = props
+
+    if (!children) {
+        return null
+    }
+
+    return (
+        <>
+            <MenuHeader>{name}</MenuHeader>
+            {children}
+            {divider && <MenuDivider />}
         </>
     )
 }

--- a/client/web/src/enterprise/insights/components/modals/ExportInsightDataModal.tsx
+++ b/client/web/src/enterprise/insights/components/modals/ExportInsightDataModal.tsx
@@ -1,0 +1,37 @@
+import { FC } from 'react'
+
+import { Button, Modal, Text, Link, H2 } from '@sourcegraph/wildcard'
+
+interface ExportInsightDataModalProps {
+    insightId: string
+    insightTitle: string
+    showModal: boolean
+    onCancel: () => void
+    onConfirm: () => void
+}
+
+export const ExportInsightDataModal: FC<ExportInsightDataModalProps> = props => {
+    const { insightId, insightTitle, showModal, onCancel, onConfirm } = props
+
+    return (
+        <Modal isOpen={showModal} position="center" aria-label="Export insight data modal" onDismiss={onCancel}>
+            <H2 className="font-weight-normal">Export data for '{insightTitle}' insight?</H2>
+
+            <Text className="mt-4 mb-2">
+                This will create a CVS archive of all data for this Code Insight, including data that has been archived.
+            </Text>
+            <Text>This will only include data that you are permitted to see.</Text>
+            <div className="d-flex justify-content-end mt-5">
+                <Button
+                    autoFocus={true}
+                    as={Link}
+                    to={`/api/insights/export/${insightId}`}
+                    variant="primary"
+                    onClick={onConfirm}
+                >
+                    Export CVS data
+                </Button>
+            </div>
+        </Modal>
+    )
+}

--- a/client/web/src/enterprise/insights/components/modals/ExportInsightDataModal.tsx
+++ b/client/web/src/enterprise/insights/components/modals/ExportInsightDataModal.tsx
@@ -30,7 +30,7 @@ export const ExportInsightDataModal: FC<ExportInsightDataModalProps> = props => 
                     variant="primary"
                     onClick={onConfirm}
                 >
-                    Export CVS data
+                    Export data as CSV
                 </Button>
             </div>
         </Modal>

--- a/client/web/src/enterprise/insights/components/modals/ExportInsightDataModal.tsx
+++ b/client/web/src/enterprise/insights/components/modals/ExportInsightDataModal.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 
-import { Button, Modal, Text, Link, H2 } from '@sourcegraph/wildcard'
+import { Button, Modal, Text, H2 } from '@sourcegraph/wildcard'
 
 interface ExportInsightDataModalProps {
     insightId: string
@@ -23,9 +23,10 @@ export const ExportInsightDataModal: FC<ExportInsightDataModalProps> = props => 
             <Text>This will only include data that you are permitted to see.</Text>
             <div className="d-flex justify-content-end mt-5">
                 <Button
+                    as="a"
+                    href={`/.api/insights/export/${insightId}`}
                     autoFocus={true}
-                    as={Link}
-                    to={`/api/insights/export/${insightId}`}
+                    download={true}
                     variant="primary"
                     onClick={onConfirm}
                 >

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.module.scss
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.module.scss
@@ -1,5 +1,5 @@
 .container {
     display: flex;
     flex-wrap: wrap;
-    gap: 1rem;
+    gap: 0.25rem;
 }

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
@@ -47,7 +47,7 @@ export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props
     return (
         <div className={styles.container}>
             {!isLangStatsInsight(insight) && (
-                <Button as={Link} to={`/api/insights/export/${insight.id}`} variant="secondary">
+                <Button as="a" href={`/.api/insights/export/${insight.id}`} download={true} variant="secondary">
                     Export data as CSV
                 </Button>
             )}

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
@@ -47,9 +47,11 @@ export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props
     return (
         <div className={styles.container}>
             {!isLangStatsInsight(insight) && (
-                <Button as="a" href={`/.api/insights/export/${insight.id}`} download={true} variant="secondary">
-                    Export data as CSV
-                </Button>
+                <Tooltip content="This will create a CVS archive of all data for this Code Insight, including data that has been archived.This will only include data that you are permitted to see.">
+                    <Button as="a" href={`/.api/insights/export/${insight.id}`} download={true} variant="secondary">
+                        Export data as CSV
+                    </Button>
+                </Tooltip>
             )}
 
             <Tooltip content={isCopied ? 'Copied!' : undefined}>

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
@@ -47,7 +47,7 @@ export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props
     return (
         <div className={styles.container}>
             {!isLangStatsInsight(insight) && (
-                <Tooltip content="This will create a CVS archive of all data for this Code Insight, including data that has been archived.This will only include data that you are permitted to see.">
+                <Tooltip content="This will create a CVS archive of all data for this Code Insight, including data that has been archived. This will only include data that you are permitted to see.">
                     <Button as="a" href={`/.api/insights/export/${insight.id}`} download={true} variant="secondary">
                         Export data as CSV
                     </Button>

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
@@ -48,7 +48,7 @@ export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props
         <div className={styles.container}>
             {!isLangStatsInsight(insight) && (
                 <Button as={Link} to={`/api/insights/export/${insight.id}`} variant="secondary">
-                    Export CVS data
+                    Export data as CSV
                 </Button>
             )}
 

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
@@ -7,13 +7,13 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { Button, Link, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { ConfirmDeleteModal } from '../../../../../components/modals/ConfirmDeleteModal'
-import { Insight } from '../../../../../core'
+import { Insight, isLangStatsInsight } from '../../../../../core'
 import { useCopyURLHandler } from '../../../../../hooks/use-copy-url-handler'
 
 import styles from './CodeInsightIndependentPageActions.module.scss'
 
 interface Props extends TelemetryProps {
-    insight: Pick<Insight, 'title' | 'id' | 'type'>
+    insight: Insight
 }
 
 export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props => {
@@ -46,6 +46,12 @@ export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props
 
     return (
         <div className={styles.container}>
+            {!isLangStatsInsight(insight) && (
+                <Button as={Link} to={`/api/insights/export/${insight.id}`} variant="secondary">
+                    Export CVS data
+                </Button>
+            )}
+
             <Tooltip content={isCopied ? 'Copied!' : undefined}>
                 <Button variant="secondary" ref={copyLinkButtonReference} onClick={handleCopyLinkClick}>
                     <Icon aria-hidden={true} svgPath={mdiLinkVariant} /> Copy link

--- a/client/web/src/integration/insights/insight/dashboard-cards.test.ts
+++ b/client/web/src/integration/insights/insight/dashboard-cards.test.ts
@@ -64,7 +64,7 @@ describe('Code insights [Dashboard card]', () => {
         // by special "Other" category (5 original rendered groups + one special Other group = 6)
         assert.strictEqual(numberHeadings, 6)
 
-        await checkOptionsMenu(driver)
+        await checkOptionsMenu(driver, { yAxis: false, exportData: false })
         await checkFilterMenu(driver, false)
     })
 
@@ -86,7 +86,7 @@ describe('Code insights [Dashboard card]', () => {
         assert.strictEqual(numberOfLines, 20)
         assert.strictEqual(numberOfPointLinks, 189)
 
-        await checkOptionsMenu(driver)
+        await checkOptionsMenu(driver, { yAxis: false, exportData: true })
         await checkFilterMenu(driver, true)
     })
 
@@ -109,7 +109,7 @@ describe('Code insights [Dashboard card]', () => {
         assert.strictEqual(numberOfLines, 2)
         assert.strictEqual(numberOfPointLinks, 27)
 
-        await checkOptionsMenu(driver, true)
+        await checkOptionsMenu(driver, { yAxis: true, exportData: true })
         await checkFilterMenu(driver, true)
     })
 
@@ -153,25 +153,41 @@ describe('Code insights [Dashboard card]', () => {
         // Visx also renders a rectangle for the chart background. 1 series + 1 background = 2 rectangles
         assert.strictEqual(numberOfBars, 2)
 
-        await checkOptionsMenu(driver)
+        await checkOptionsMenu(driver, { yAxis: false, exportData: true })
         await checkFilterMenu(driver, true)
     })
 })
 
+interface MenuOptions {
+    yAxis: boolean
+    exportData: boolean
+}
+
 /**
  * Asserts the options menu renders the correct options
  */
-async function checkOptionsMenu(driver: Driver, shouldHaveYAxis = false): Promise<void> {
+async function checkOptionsMenu(driver: Driver, options: MenuOptions): Promise<void> {
+    const { yAxis, exportData } = options
     await driver.page.click('[aria-label="Insight options"]')
 
     const menuOptions = await driver.page.$$eval('[role="dialog"][aria-modal="true"] [role="menuitem"]', elements =>
         elements.map(element => element.textContent)
     )
 
-    // Check that Line chart menu options
-    assert.deepStrictEqual(menuOptions, ['Edit', 'Get shareable link', 'Remove from this dashboard', 'Delete'])
+    if (exportData) {
+        // Check that Line chart menu options
+        assert.deepStrictEqual(menuOptions, [
+            'Edit',
+            'Get shareable link',
+            'Export data',
+            'Remove from this dashboard',
+            'Delete',
+        ])
+    } else {
+        assert.deepStrictEqual(menuOptions, ['Edit', 'Get shareable link', 'Remove from this dashboard', 'Delete'])
+    }
 
-    if (shouldHaveYAxis) {
+    if (yAxis) {
         const startYAxisAt0 = await driver.page.$eval(
             '[role="dialog"][aria-modal="true"] [role="menuitemcheckbox"]',
             element => element.textContent


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/46493

This PR adds export data UI, (link in the three dot context menu and button on the standalone insight page) This PR should be merged after the [BE link implementation](https://github.com/sourcegraph/sourcegraph/pull/46662) is merged. 

## Test plan
- Open the three dot context menu and export the data 
- It should be available for all insights except lang stats
- Go to the standalone insight page (click insight card title) 
- Try to export data with header export data button

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-vk-add-export-ui.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
