### PR TITLE
permissions-center: rename `NextSyncAt` to `ProcessAfter` for consistency.

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/webhooks/github.go
+++ b/enterprise/cmd/frontend/internal/authz/webhooks/github.go
@@ -167,9 +167,9 @@ func (h *GitHubWebhook) getUserAndSyncPerms(ctx context.Context, db database.DB,
 	}
 
 	permssync.SchedulePermsSync(ctx, h.logger, db, protocol.PermsSyncRequest{
-		UserIDs:    []int32{externalAccounts[0].UserID},
-		Reason:     reason,
-		NextSyncAt: time.Now().Add(sleepTime),
+		UserIDs:      []int32{externalAccounts[0].UserID},
+		Reason:       reason,
+		ProcessAfter: time.Now().Add(sleepTime),
 	})
 
 	return err
@@ -184,9 +184,9 @@ func (h *GitHubWebhook) getRepoAndSyncPerms(ctx context.Context, db database.DB,
 	}
 
 	permssync.SchedulePermsSync(ctx, h.logger, db, protocol.PermsSyncRequest{
-		RepoIDs:    []api.RepoID{repo.ID},
-		Reason:     reason,
-		NextSyncAt: time.Now().Add(sleepTime),
+		RepoIDs:      []api.RepoID{repo.ID},
+		Reason:       reason,
+		ProcessAfter: time.Now().Add(sleepTime),
 	})
 
 	return nil

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -128,7 +128,7 @@ func (s *PermsSyncer) ScheduleUsers(ctx context.Context, opts authz.FetchPermsOp
 			priority: priorityHigh,
 			userID:   userIDs[i],
 			options:  opts,
-			// NOTE: Have nextSyncAt with zero value (i.e. not set) gives it higher priority,
+			// NOTE: Have processAfter with zero value (i.e. not set) gives it higher priority,
 			// as the request is most likely triggered by a user action from OSS namespace.
 		}
 	}
@@ -153,7 +153,7 @@ func (s *PermsSyncer) scheduleUsers(ctx context.Context, users ...scheduledUser)
 			Type:       requestTypeUser,
 			ID:         u.userID,
 			Options:    u.options,
-			NextSyncAt: u.nextSyncAt,
+			NextSyncAt: u.processAfter,
 			NoPerms:    u.noPerms,
 		})
 		logger.Debug("queue.enqueued", log.Int32("userID", u.userID), log.Bool("updated", updated))
@@ -178,7 +178,7 @@ func (s *PermsSyncer) ScheduleRepos(ctx context.Context, repoIDs ...api.RepoID) 
 		repositories[i] = scheduledRepo{
 			priority: priorityHigh,
 			repoID:   repoIDs[i],
-			// NOTE: Have nextSyncAt with zero value (i.e. not set) gives it higher priority,
+			// NOTE: Have processAfter with zero value (i.e. not set) gives it higher priority,
 			// as the request is most likely triggered by a user action from OSS namespace.
 		}
 	}
@@ -203,7 +203,7 @@ func (s *PermsSyncer) scheduleRepos(ctx context.Context, repos ...scheduledRepo)
 			Priority:   r.priority,
 			Type:       requestTypeRepo,
 			ID:         int32(r.repoID),
-			NextSyncAt: r.nextSyncAt,
+			NextSyncAt: r.processAfter,
 			NoPerms:    r.noPerms,
 		})
 		logger.Debug("queue.enqueued", log.Int32("repoID", int32(r.repoID)), log.Bool("updated", updated))
@@ -595,7 +595,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 		Type:   authz.PermRepos,
 		IDs:    map[int32]struct{}{},
 	}
-	s.permsStore.LoadUserPermissions(ctx, oldPerms)
+	_ = s.permsStore.LoadUserPermissions(ctx, oldPerms)
 
 	// Save new permissions to database
 	p := &authz.UserPermissions{
@@ -774,7 +774,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 		Perm:    authz.Read,
 		UserIDs: map[int32]struct{}{},
 	}
-	s.permsStore.LoadRepoPermissions(ctx, oldPerms)
+	_ = s.permsStore.LoadRepoPermissions(ctx, oldPerms)
 
 	// Save permissions to database
 	p := &authz.RepoPermissions{
@@ -1003,7 +1003,7 @@ func (s *PermsSyncer) scheduleUsersWithNoPerms(ctx context.Context) ([]scheduled
 		users[i] = scheduledUser{
 			priority: priorityLow,
 			userID:   id,
-			// NOTE: Have nextSyncAt with zero value (i.e. not set) gives it higher priority.
+			// NOTE: Have processAfter with zero value (i.e. not set) gives it higher priority.
 			noPerms: true,
 		}
 	}
@@ -1019,20 +1019,20 @@ func (s *PermsSyncer) scheduleReposWithNoPerms(ctx context.Context) ([]scheduled
 	}
 	metricsNoPerms.WithLabelValues("repo").Set(float64(len(ids)))
 
-	repos := make([]scheduledRepo, len(ids))
+	repositories := make([]scheduledRepo, len(ids))
 	for i, id := range ids {
-		repos[i] = scheduledRepo{
+		repositories[i] = scheduledRepo{
 			priority: priorityLow,
 			repoID:   id,
-			// NOTE: Have nextSyncAt with zero value (i.e. not set) gives it higher priority.
+			// NOTE: Have processAfter with zero value (i.e. not set) gives it higher priority.
 			noPerms: true,
 		}
 	}
-	return repos, nil
+	return repositories, nil
 }
 
-// scheduleUsersWithOldestPerms returns computed schedules for users who have oldest
-// permissions in database and capped results by the limit.
+// scheduleUsersWithOldestPerms returns computed schedules for users who have the
+// oldest permissions in database and capped results by the limit.
 func (s *PermsSyncer) scheduleUsersWithOldestPerms(ctx context.Context, limit int, age time.Duration) ([]scheduledUser, error) {
 	results, err := s.permsStore.UserIDsWithOldestPerms(ctx, limit, age)
 	if err != nil {
@@ -1042,9 +1042,9 @@ func (s *PermsSyncer) scheduleUsersWithOldestPerms(ctx context.Context, limit in
 	users := make([]scheduledUser, 0, len(results))
 	for id, t := range results {
 		users = append(users, scheduledUser{
-			priority:   priorityLow,
-			userID:     id,
-			nextSyncAt: t,
+			priority:     priorityLow,
+			userID:       id,
+			processAfter: t,
 		})
 	}
 	return users, nil
@@ -1058,15 +1058,15 @@ func (s *PermsSyncer) scheduleReposWithOldestPerms(ctx context.Context, limit in
 		return nil, err
 	}
 
-	repos := make([]scheduledRepo, 0, len(results))
+	repositories := make([]scheduledRepo, 0, len(results))
 	for id, t := range results {
-		repos = append(repos, scheduledRepo{
-			priority:   priorityLow,
-			repoID:     id,
-			nextSyncAt: t,
+		repositories = append(repositories, scheduledRepo{
+			priority:     priorityLow,
+			repoID:       id,
+			processAfter: t,
 		})
 	}
-	return repos, nil
+	return repositories, nil
 }
 
 // schedule contains information for scheduling users and repositories.
@@ -1077,10 +1077,10 @@ type schedule struct {
 
 // scheduledUser contains information for scheduling a user.
 type scheduledUser struct {
-	priority   priority
-	userID     int32
-	options    authz.FetchPermsOptions
-	nextSyncAt time.Time
+	priority     priority
+	userID       int32
+	options      authz.FetchPermsOptions
+	processAfter time.Time
 
 	// Whether the user has no permissions when scheduled. Currently used to
 	// accept partial results from authz provider in case of error.
@@ -1089,9 +1089,9 @@ type scheduledUser struct {
 
 // scheduledRepo contains for scheduling a repository.
 type scheduledRepo struct {
-	priority   priority
-	repoID     api.RepoID
-	nextSyncAt time.Time
+	priority     priority
+	repoID       api.RepoID
+	processAfter time.Time
 
 	// Whether the repository has no permissions when scheduled. Currently used
 	// to accept partial results from authz provider in case of error.
@@ -1200,7 +1200,7 @@ func (s *PermsSyncer) runSchedule(ctx context.Context) {
 				if u.noPerms {
 					reason = permssync.ReasonUserNoPermissions
 				}
-				opts := database.PermissionSyncJobOpts{NextSyncAt: u.nextSyncAt, Reason: reason}
+				opts := database.PermissionSyncJobOpts{ProcessAfter: u.processAfter, Reason: reason}
 				if err := store.CreateUserSyncJob(ctx, u.userID, opts); err != nil {
 					logger.Error("failed to create user sync job", log.Error(err))
 					continue
@@ -1212,7 +1212,7 @@ func (s *PermsSyncer) runSchedule(ctx context.Context) {
 				if r.noPerms {
 					reason = permssync.ReasonRepoNoPermissions
 				}
-				opts := database.PermissionSyncJobOpts{NextSyncAt: r.nextSyncAt, Reason: reason}
+				opts := database.PermissionSyncJobOpts{ProcessAfter: r.processAfter, Reason: reason}
 				if err := store.CreateRepoSyncJob(ctx, r.repoID, opts); err != nil {
 					logger.Error("failed to create repo sync job", log.Error(err))
 					continue

--- a/internal/authz/permssync/permssync.go
+++ b/internal/authz/permssync/permssync.go
@@ -82,7 +82,7 @@ func SchedulePermsSync(ctx context.Context, logger log.Logger, db database.DB, r
 				InvalidateCaches:  req.Options.InvalidateCaches,
 				Reason:            req.Reason,
 				TriggeredByUserID: req.TriggeredByUserID,
-				NextSyncAt:        req.NextSyncAt,
+				ProcessAfter:      req.ProcessAfter,
 			}
 			err := db.PermissionSyncJobs().CreateUserSyncJob(ctx, userID, opts)
 			if err != nil {
@@ -96,7 +96,7 @@ func SchedulePermsSync(ctx context.Context, logger log.Logger, db database.DB, r
 				InvalidateCaches:  req.Options.InvalidateCaches,
 				Reason:            req.Reason,
 				TriggeredByUserID: req.TriggeredByUserID,
-				NextSyncAt:        req.NextSyncAt,
+				ProcessAfter:      req.ProcessAfter,
 			}
 			err := db.PermissionSyncJobs().CreateRepoSyncJob(ctx, repoID, opts)
 			if err != nil {

--- a/internal/authz/permssync/permssync_test.go
+++ b/internal/authz/permssync/permssync_test.go
@@ -28,7 +28,7 @@ func TestSchedulePermsSync_UserPermsTest(t *testing.T) {
 	db.FeatureFlagsFunc.SetDefaultReturn(featureFlags)
 
 	syncTime := time.Now().Add(13 * time.Second)
-	request := protocol.PermsSyncRequest{UserIDs: []int32{1}, Reason: ReasonManualUserSync, TriggeredByUserID: int32(123), NextSyncAt: syncTime}
+	request := protocol.PermsSyncRequest{UserIDs: []int32{1}, Reason: ReasonManualUserSync, TriggeredByUserID: int32(123), ProcessAfter: syncTime}
 	SchedulePermsSync(ctx, logger, db, request)
 	assert.Len(t, permsSyncStore.CreateUserSyncJobFunc.History(), 1)
 	assert.Empty(t, permsSyncStore.CreateRepoSyncJobFunc.History())
@@ -36,7 +36,7 @@ func TestSchedulePermsSync_UserPermsTest(t *testing.T) {
 	assert.NotNil(t, permsSyncStore.CreateUserSyncJobFunc.History()[0].Arg2)
 	assert.Equal(t, ReasonManualUserSync, permsSyncStore.CreateUserSyncJobFunc.History()[0].Arg2.Reason)
 	assert.Equal(t, int32(123), permsSyncStore.CreateUserSyncJobFunc.History()[0].Arg2.TriggeredByUserID)
-	assert.Equal(t, syncTime, permsSyncStore.CreateUserSyncJobFunc.History()[0].Arg2.NextSyncAt)
+	assert.Equal(t, syncTime, permsSyncStore.CreateUserSyncJobFunc.History()[0].Arg2.ProcessAfter)
 }
 
 func TestSchedulePermsSync_RepoPermsTest(t *testing.T) {
@@ -55,7 +55,7 @@ func TestSchedulePermsSync_RepoPermsTest(t *testing.T) {
 	db.FeatureFlagsFunc.SetDefaultReturn(featureFlags)
 
 	syncTime := time.Now().Add(37 * time.Second)
-	request := protocol.PermsSyncRequest{RepoIDs: []api.RepoID{1}, Reason: ReasonManualRepoSync, NextSyncAt: syncTime}
+	request := protocol.PermsSyncRequest{RepoIDs: []api.RepoID{1}, Reason: ReasonManualRepoSync, ProcessAfter: syncTime}
 	SchedulePermsSync(ctx, logger, db, request)
 	assert.Len(t, permsSyncStore.CreateRepoSyncJobFunc.History(), 1)
 	assert.Empty(t, permsSyncStore.CreateUserSyncJobFunc.History())
@@ -63,5 +63,5 @@ func TestSchedulePermsSync_RepoPermsTest(t *testing.T) {
 	assert.NotNil(t, permsSyncStore.CreateRepoSyncJobFunc.History()[0].Arg1)
 	assert.Equal(t, ReasonManualRepoSync, permsSyncStore.CreateRepoSyncJobFunc.History()[0].Arg2.Reason)
 	assert.Equal(t, int32(0), permsSyncStore.CreateRepoSyncJobFunc.History()[0].Arg2.TriggeredByUserID)
-	assert.Equal(t, syncTime, permsSyncStore.CreateRepoSyncJobFunc.History()[0].Arg2.NextSyncAt)
+	assert.Equal(t, syncTime, permsSyncStore.CreateRepoSyncJobFunc.History()[0].Arg2.ProcessAfter)
 }

--- a/internal/database/permission_sync_jobs.go
+++ b/internal/database/permission_sync_jobs.go
@@ -23,7 +23,7 @@ import (
 type PermissionSyncJobOpts struct {
 	HighPriority      bool
 	InvalidateCaches  bool
-	NextSyncAt        time.Time
+	ProcessAfter      time.Time
 	Reason            string
 	TriggeredByUserID int32
 }
@@ -78,8 +78,8 @@ func (s *permissionSyncJobStore) CreateUserSyncJob(ctx context.Context, user int
 		Reason:            opts.Reason,
 		TriggeredByUserID: opts.TriggeredByUserID,
 	}
-	if !opts.NextSyncAt.IsZero() {
-		job.ProcessAfter = opts.NextSyncAt
+	if !opts.ProcessAfter.IsZero() {
+		job.ProcessAfter = opts.ProcessAfter
 	}
 	return s.createSyncJob(ctx, job)
 }
@@ -92,8 +92,8 @@ func (s *permissionSyncJobStore) CreateRepoSyncJob(ctx context.Context, repo api
 		Reason:            opts.Reason,
 		TriggeredByUserID: opts.TriggeredByUserID,
 	}
-	if !opts.NextSyncAt.IsZero() {
-		job.ProcessAfter = opts.NextSyncAt
+	if !opts.ProcessAfter.IsZero() {
+		job.ProcessAfter = opts.ProcessAfter
 	}
 	return s.createSyncJob(ctx, job)
 }

--- a/internal/database/permission_sync_jobs_test.go
+++ b/internal/database/permission_sync_jobs_test.go
@@ -44,8 +44,8 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 	err = store.CreateRepoSyncJob(ctx, 99, opts)
 	assert.NoError(t, err)
 
-	nextSyncAt := clock.Now().Add(5 * time.Minute)
-	opts = PermissionSyncJobOpts{HighPriority: false, InvalidateCaches: true, NextSyncAt: nextSyncAt, Reason: ReasonManualUserSync}
+	processAfter := clock.Now().Add(5 * time.Minute)
+	opts = PermissionSyncJobOpts{HighPriority: false, InvalidateCaches: true, ProcessAfter: processAfter, Reason: ReasonManualUserSync}
 	err = store.CreateUserSyncJob(ctx, 77, opts)
 	assert.NoError(t, err)
 
@@ -69,7 +69,7 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 			State:            "queued",
 			UserID:           77,
 			InvalidateCaches: true,
-			ProcessAfter:     nextSyncAt,
+			ProcessAfter:     processAfter,
 			Reason:           ReasonManualUserSync,
 		},
 	}
@@ -171,8 +171,8 @@ func TestPermissionSyncJobs_Deduplication(t *testing.T) {
 	// 4) Insert some low priority jobs with process_after for both users. All of them should be inserted.
 	fiveMinutesLater := clock.Now().Add(5 * time.Minute)
 	tenMinutesLater := clock.Now().Add(10 * time.Minute)
-	user1LowPrioDelayedJob := PermissionSyncJobOpts{NextSyncAt: fiveMinutesLater, Reason: ReasonManualUserSync, TriggeredByUserID: user1.ID}
-	user2LowPrioDelayedJob := PermissionSyncJobOpts{NextSyncAt: tenMinutesLater, Reason: ReasonManualUserSync, TriggeredByUserID: user1.ID}
+	user1LowPrioDelayedJob := PermissionSyncJobOpts{ProcessAfter: fiveMinutesLater, Reason: ReasonManualUserSync, TriggeredByUserID: user1.ID}
+	user2LowPrioDelayedJob := PermissionSyncJobOpts{ProcessAfter: tenMinutesLater, Reason: ReasonManualUserSync, TriggeredByUserID: user1.ID}
 
 	err = store.CreateUserSyncJob(ctx, 1, user1LowPrioDelayedJob)
 	assert.NoError(t, err)

--- a/internal/repoupdater/protocol/repoupdater.go
+++ b/internal/repoupdater/protocol/repoupdater.go
@@ -250,7 +250,7 @@ type PermsSyncRequest struct {
 	Options           authz.FetchPermsOptions `json:"options"`
 	Reason            string                  `json:"reason"`
 	TriggeredByUserID int32                   `json:"triggered_by_user_id"`
-	NextSyncAt        time.Time               `json:"next_sync_at"`
+	ProcessAfter      time.Time               `json:"process_after"`
 }
 
 // PermsSyncResponse is a response to sync permissions.


### PR DESCRIPTION
Test plan:
Existing tests.

Closes https://github.com/sourcegraph/sourcegraph/issues/46697