### PR TITLE
chore: update `explicit_permissions_bitbucket_projects_jobs_worker` description.

### DIFF
--- a/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
+++ b/enterprise/cmd/worker/internal/permissions/bitbucket_projects.go
@@ -357,7 +357,7 @@ func newBitbucketProjectPermissionsWorker(ctx context.Context, observationCtx *o
 
 	options := workerutil.WorkerOptions{
 		Name:              "explicit_permissions_bitbucket_projects_jobs_worker",
-		Description:       "reads the `explicit_permissions_bitbucket_projects_jobs` table and executes the jobs",
+		Description:       "syncs Bitbucket Projects via Explicit Permissions API",
 		NumHandlers:       cfg.WorkerConcurrency,
 		Interval:          cfg.WorkerPollInterval,
 		HeartbeatInterval: 15 * time.Second,


### PR DESCRIPTION
Test plan:
N/A, not a functional change.

Follow-up to https://github.com/sourcegraph/sourcegraph/pull/46422