### PR TITLE
rcache: allow negative max sizes in FIFOList

### DIFF
--- a/internal/rcache/fifo_list_test.go
+++ b/internal/rcache/fifo_list_test.go
@@ -42,6 +42,12 @@ func Test_FIFOList_All_OK(t *testing.T) {
 			inserts: bytes("a1", "a2", "a3"),
 			want:    bytes(),
 		},
+		{
+			key:     "f",
+			size:    -1,
+			inserts: bytes("a1", "a2", "a3"),
+			want:    bytes(),
+		},
 	}
 
 	for _, c := range cases {
@@ -121,6 +127,14 @@ func Test_FIFOList_Slice_OK(t *testing.T) {
 			inserts: bytes("a1", "a2", "a3", "a4", "a5", "a6"),
 			want:    bytes("a4"),
 			from:    2,
+			to:      -1,
+		},
+		{
+			key:     "f",
+			size:    -1,
+			inserts: bytes("a1", "a2", "a3"),
+			want:    bytes(),
+			from:    0,
 			to:      -1,
 		},
 	}


### PR DESCRIPTION
This is the same as using a value of zero. This is fixes a potential footgun when accidently passing in a negative value. Additionally another [PR](https://github.com/sourcegraph/sourcegraph/pull/46676#discussion_r1082105160) wants to use negative values as a signal to disable a feature.

Test Plan: added a test