### PR TITLE
adminanalytics: remove unread boolean return in cache calls

### DIFF
--- a/internal/adminanalytics/cache.go
+++ b/internal/adminanalytics/cache.go
@@ -49,35 +49,31 @@ func getItemFromCache[T interface{}](cacheKey string) (*T, error) {
 	return &summary, nil
 }
 
-func setDataToCache(key string, data string, expireSeconds int) (bool, error) {
+func setDataToCache(key string, data string, expireSeconds int) error {
 	if cacheDisabledInTest {
-		return true, nil
+		return nil
 	}
 
 	if expireSeconds == 0 {
 		expireSeconds = 24 * 60 * 60 // 1 day
 	}
 
-	if err := store.SetEx(scopeKey+key, expireSeconds, data); err != nil {
-		return false, err
-	}
-
-	return true, nil
+	return store.SetEx(scopeKey+key, expireSeconds, data)
 }
 
-func setArrayToCache[T interface{}](cacheKey string, nodes []*T) (bool, error) {
+func setArrayToCache[T interface{}](cacheKey string, nodes []*T) error {
 	data, err := json.Marshal(nodes)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	return setDataToCache(cacheKey, string(data), 0)
 }
 
-func setItemToCache[T interface{}](cacheKey string, summary *T) (bool, error) {
+func setItemToCache[T interface{}](cacheKey string, summary *T) error {
 	data, err := json.Marshal(summary)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	return setDataToCache(cacheKey, string(data), 0)

--- a/internal/adminanalytics/codeintelbylanguage.go
+++ b/internal/adminanalytics/codeintelbylanguage.go
@@ -69,7 +69,7 @@ func GetCodeIntelByLanguage(ctx context.Context, db database.DB, cache bool, dat
 		items = append(items, &item)
 	}
 
-	if _, err := setArrayToCache(cacheKey, items); err != nil {
+	if err := setArrayToCache(cacheKey, items); err != nil {
 		return nil, err
 	}
 

--- a/internal/adminanalytics/codeinteltoprepositories.go
+++ b/internal/adminanalytics/codeinteltoprepositories.go
@@ -112,7 +112,7 @@ func GetCodeIntelTopRepositories(ctx context.Context, db database.DB, cache bool
 		items = append(items, &item)
 	}
 
-	if _, err := setArrayToCache(cacheKey, items); err != nil {
+	if err := setArrayToCache(cacheKey, items); err != nil {
 		return nil, err
 	}
 

--- a/internal/adminanalytics/fetcher.go
+++ b/internal/adminanalytics/fetcher.go
@@ -106,7 +106,7 @@ func (f *AnalyticsFetcher) Nodes(ctx context.Context) ([]*AnalyticsNode, error) 
 		allNodes = append(allNodes, node)
 	}
 
-	if _, err := setArrayToCache(cacheKey, allNodes); err != nil {
+	if err := setArrayToCache(cacheKey, allNodes); err != nil {
 		return nil, err
 	}
 
@@ -151,7 +151,7 @@ func (f *AnalyticsFetcher) Summary(ctx context.Context) (*AnalyticsSummary, erro
 
 	summary := &AnalyticsSummary{data}
 
-	if _, err := setItemToCache(cacheKey, summary); err != nil {
+	if err := setItemToCache(cacheKey, summary); err != nil {
 		return nil, err
 	}
 

--- a/internal/adminanalytics/repos.go
+++ b/internal/adminanalytics/repos.go
@@ -37,7 +37,7 @@ func (r *Repos) Summary(ctx context.Context) (*ReposSummary, error) {
 
 	summary := &ReposSummary{data}
 
-	if _, err := setItemToCache(cacheKey, summary); err != nil {
+	if err := setItemToCache(cacheKey, summary); err != nil {
 		return nil, err
 	}
 

--- a/internal/adminanalytics/users.go
+++ b/internal/adminanalytics/users.go
@@ -113,7 +113,7 @@ func (f *Users) Frequencies(ctx context.Context) ([]*UsersFrequencyNode, error) 
 		nodes = append(nodes, &UsersFrequencyNode{data})
 	}
 
-	if _, err := setArrayToCache(cacheKey, nodes); err != nil {
+	if err := setArrayToCache(cacheKey, nodes); err != nil {
 		return nil, err
 	}
 
@@ -187,7 +187,7 @@ func (f *Users) MonthlyActiveUsers(ctx context.Context) ([]*MonthlyActiveUsersRo
 		nodes = append(nodes, &MonthlyActiveUsersRow{data})
 	}
 
-	if _, err := setArrayToCache(cacheKey, nodes); err != nil {
+	if err := setArrayToCache(cacheKey, nodes); err != nil {
 		return nil, err
 	}
 

--- a/internal/adminanalytics/utils.go
+++ b/internal/adminanalytics/utils.go
@@ -100,7 +100,7 @@ func getSgEmpUserIDs(ctx context.Context, db database.DB, cache bool) ([]*int32,
 		return ids, err
 	}
 
-	if _, err := setDataToCache(employeeUserIdsCacheKey, string(cacheData), employeeUserIdsCacheExpirySeconds); err != nil {
+	if err := setDataToCache(employeeUserIdsCacheKey, string(cacheData), employeeUserIdsCacheExpirySeconds); err != nil {
 		return ids, err
 	}
 


### PR DESCRIPTION
The boolean was never read. Additionally it's value was always err !=
nil.

Test Plan: go test

plz-review-url: https://plz.review/review/17480