### PR TITLE
ci: skip flakey executor build

### DIFF
--- a/enterprise/dev/ci/images/images.go
+++ b/enterprise/dev/ci/images/images.go
@@ -86,8 +86,8 @@ var DeploySourcegraphDockerImages = []string{
 	"syntax-highlighter",
 	"worker",
 	"migrator",
-	"executor",
-	"executor-vm",
+	// "executor", 2023-01-20 skipping due to flakey upstream timeouts with no logs
+	// "executor-vm", 2023-01-20 skipping due to flakey upstream timeouts with no logs
 	"batcheshelper",
 	"opentelemetry-collector",
 }


### PR DESCRIPTION
Executor builds are [hanging](https://buildkite.com/sourcegraph/sourcegraph/builds/194537#0185ceed-3ed3-4e74-b05e-f7729bc8b5ec/1842-3193), with no logs. 

Skipping tests/builds while we investigate to unblock 

## Test plan

Green CI