### PR TITLE
frontend: Fix subtle bug in observeSystemIsLightTheme

### DIFF
--- a/client/shared/src/theme.ts
+++ b/client/shared/src/theme.ts
@@ -1,4 +1,4 @@
-import { concat, fromEvent, Observable, of } from 'rxjs'
+import { concat, defer, fromEvent, Observable, of } from 'rxjs'
 import { map } from 'rxjs/operators'
 
 /**
@@ -25,7 +25,9 @@ export const observeSystemIsLightTheme = (
     const mediaList = window_.matchMedia('(prefers-color-scheme: dark)')
     return {
         observable: concat(
-            of(!mediaList.matches),
+            // We want every subscriber to get the _current_ match value, hence
+            // we defer evaluation of until subscription.
+            defer(() => of(!mediaList.matches)),
             fromEvent<MediaQueryListEvent>(mediaList, 'change').pipe(map(event => !event.matches))
         ),
         initialValue: !mediaList.matches,


### PR DESCRIPTION
At the moment it's possible that the observable emits incorrect data to new subscribers. I assume the expectation is that the observable is only subscribed to once and that every callsite who wants this value calls `observeSystemIsLightTheme` to get a new observable. But that isn't obvious from the function itself and it's not possible to enforce this assumption.

If the observable is indeed reused it would emit the value of `!mediaList.matches` that it had at the time the function was called. The user might have changed their theme preference in the meantime.

By using `defer` we evaluate the value of `mediaList.matches` every time a subscriber subscribes.


## Test plan

Manual testing.

## App preview:

- [Web](https://sg-web-fkling-fix-theme-query.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
