### PR TITLE
redispool: correctly call and test SetEx

### DIFF
--- a/internal/redispool/keyvalue.go
+++ b/internal/redispool/keyvalue.go
@@ -102,7 +102,7 @@ func (r *redisKeyValue) Set(key string, val any) error {
 }
 
 func (r *redisKeyValue) SetEx(key string, ttlSeconds int, val any) error {
-	return r.do("SET", r.prefix+key, ttlSeconds, val).err
+	return r.do("SETEX", r.prefix+key, ttlSeconds, val).err
 }
 
 func (r *redisKeyValue) Del(key string) error {

--- a/internal/redispool/keyvalue_test.go
+++ b/internal/redispool/keyvalue_test.go
@@ -170,7 +170,12 @@ func testKeyValue(t *testing.T, kv redispool.KeyValue) {
 	assertEqual(kv.LRange("list", 0, 4), bytes("1", "2", "3"))
 	assertListLen("list", 3)
 
-	// We intentionally do not test EXPIRE since I don't like sleeps in tests.
+	// SetEx
+	assertWorks(kv.SetEx("expires", 60, "1"))
+	assertEqual(kv.Get("expires"), "1")
+	assertWorks(kv.SetEx("expires", 1, "2"))
+	time.Sleep(1100 * time.Millisecond)
+	assertEqual(kv.Get("expires"), nil)
 }
 
 // Mostly copy-pasta from rache. Will clean up later as the relationship


### PR DESCRIPTION
Look at that delicious comment about intentionally not testing expire.

Test Plan: go test