### PR TITLE
codeintel: Share cached location resolver between uploads

### DIFF
--- a/enterprise/internal/codeintel/codenav/transport/graphql/gitblob_lsif_data_resolver.go
+++ b/enterprise/internal/codeintel/codenav/transport/graphql/gitblob_lsif_data_resolver.go
@@ -286,11 +286,13 @@ func (r *gitBlobLSIFDataResolver) LSIFUploads(ctx context.Context) (_ []resolver
 		dbUploads = append(dbUploads, sharedDumpToDbstoreUpload(u))
 	}
 
+	db := r.autoindexingSvc.GetUnsafeDB()
 	prefetcher := sharedresolvers.NewPrefetcher(r.autoindexingSvc, r.uploadSvc)
+	locationResolver := sharedresolvers.NewCachedLocationResolver(db, gitserver.NewClient(db))
 
 	resolvers := make([]resolverstubs.LSIFUploadResolver, 0, len(uploads))
 	for _, upload := range dbUploads {
-		resolvers = append(resolvers, sharedresolvers.NewUploadResolver(r.uploadSvc, r.autoindexingSvc, r.policiesSvc, upload, prefetcher, r.errTracer))
+		resolvers = append(resolvers, sharedresolvers.NewUploadResolver(r.uploadSvc, r.autoindexingSvc, r.policiesSvc, upload, prefetcher, locationResolver, r.errTracer))
 	}
 
 	return resolvers, nil

--- a/enterprise/internal/codeintel/shared/resolvers/index_resolver_connection.go
+++ b/enterprise/internal/codeintel/shared/resolvers/index_resolver_connection.go
@@ -40,7 +40,7 @@ func (r *IndexConnectionResolver) Nodes(ctx context.Context) ([]resolverstubs.LS
 
 	resolvers := make([]resolverstubs.LSIFIndexResolver, 0, len(r.indexesResolver.Indexes))
 	for i := range r.indexesResolver.Indexes {
-		resolvers = append(resolvers, NewIndexResolver(r.autoindexingSvc, r.uploadsSvc, r.policySvc, r.indexesResolver.Indexes[i], r.prefetcher, r.errTracer))
+		resolvers = append(resolvers, NewIndexResolver(r.autoindexingSvc, r.uploadsSvc, r.policySvc, r.indexesResolver.Indexes[i], r.prefetcher, r.locationResolver, r.errTracer))
 	}
 	return resolvers, nil
 }

--- a/enterprise/internal/codeintel/shared/resolvers/summary.go
+++ b/enterprise/internal/codeintel/shared/resolvers/summary.go
@@ -51,7 +51,7 @@ func (r *repositorySummaryResolver) RecentUploads() []resolverstubs.LSIFUploadsW
 	for _, upload := range r.summary.RecentUploads {
 		uploadResolvers := make([]resolverstubs.LSIFUploadResolver, 0, len(upload.Uploads))
 		for _, u := range upload.Uploads {
-			uploadResolvers = append(uploadResolvers, NewUploadResolver(r.uploadsSvc, r.autoindexingSvc, r.policySvc, u, r.prefetcher, r.errTracer))
+			uploadResolvers = append(uploadResolvers, NewUploadResolver(r.uploadsSvc, r.autoindexingSvc, r.policySvc, u, r.prefetcher, r.locationResolver, r.errTracer))
 		}
 
 		resolvers = append(resolvers, NewLSIFUploadsWithRepositoryNamespaceResolver(upload, uploadResolvers))
@@ -73,7 +73,7 @@ func (r *repositorySummaryResolver) RecentIndexes() []resolverstubs.LSIFIndexesW
 	for _, index := range r.summary.RecentIndexes {
 		indexResolvers := make([]resolverstubs.LSIFIndexResolver, 0, len(index.Indexes))
 		for _, idx := range index.Indexes {
-			indexResolvers = append(indexResolvers, NewIndexResolver(r.autoindexingSvc, r.uploadsSvc, r.policySvc, idx, r.prefetcher, r.errTracer))
+			indexResolvers = append(indexResolvers, NewIndexResolver(r.autoindexingSvc, r.uploadsSvc, r.policySvc, idx, r.prefetcher, r.locationResolver, r.errTracer))
 		}
 		resolvers = append(resolvers, NewLSIFIndexesWithRepositoryNamespaceResolver(index, indexResolvers))
 	}

--- a/enterprise/internal/codeintel/shared/resolvers/upload_resolver_connection.go
+++ b/enterprise/internal/codeintel/shared/resolvers/upload_resolver_connection.go
@@ -23,11 +23,12 @@ type UploadConnectionResolver struct {
 func NewUploadConnectionResolver(uploadsSvc UploadsService, autoindexingSvc AutoIndexingService, policySvc PolicyService, uploadsResolver *UploadsResolver, prefetcher *Prefetcher, traceErrs *observation.ErrCollector) resolverstubs.LSIFUploadConnectionResolver {
 	db := autoindexingSvc.GetUnsafeDB()
 	return &UploadConnectionResolver{
-		uploadsSvc:       uploadsSvc,
-		autoindexingSvc:  autoindexingSvc,
-		policySvc:        policySvc,
-		uploadsResolver:  uploadsResolver,
-		prefetcher:       prefetcher,
+		uploadsSvc:      uploadsSvc,
+		autoindexingSvc: autoindexingSvc,
+		policySvc:       policySvc,
+		uploadsResolver: uploadsResolver,
+		prefetcher:      prefetcher,
+		// TODO - not shared with each upload resolver
 		locationResolver: NewCachedLocationResolver(db, gitserver.NewClient(db)),
 		traceErrs:        traceErrs,
 	}

--- a/enterprise/internal/codeintel/shared/resolvers/upload_resolver_connection.go
+++ b/enterprise/internal/codeintel/shared/resolvers/upload_resolver_connection.go
@@ -23,12 +23,11 @@ type UploadConnectionResolver struct {
 func NewUploadConnectionResolver(uploadsSvc UploadsService, autoindexingSvc AutoIndexingService, policySvc PolicyService, uploadsResolver *UploadsResolver, prefetcher *Prefetcher, traceErrs *observation.ErrCollector) resolverstubs.LSIFUploadConnectionResolver {
 	db := autoindexingSvc.GetUnsafeDB()
 	return &UploadConnectionResolver{
-		uploadsSvc:      uploadsSvc,
-		autoindexingSvc: autoindexingSvc,
-		policySvc:       policySvc,
-		uploadsResolver: uploadsResolver,
-		prefetcher:      prefetcher,
-		// TODO - not shared with each upload resolver
+		uploadsSvc:       uploadsSvc,
+		autoindexingSvc:  autoindexingSvc,
+		policySvc:        policySvc,
+		uploadsResolver:  uploadsResolver,
+		prefetcher:       prefetcher,
 		locationResolver: NewCachedLocationResolver(db, gitserver.NewClient(db)),
 		traceErrs:        traceErrs,
 	}
@@ -43,7 +42,7 @@ func (r *UploadConnectionResolver) Nodes(ctx context.Context) (_ []resolverstubs
 
 	resolvers := make([]resolverstubs.LSIFUploadResolver, 0, len(r.uploadsResolver.Uploads))
 	for i := range r.uploadsResolver.Uploads {
-		resolvers = append(resolvers, NewUploadResolver(r.uploadsSvc, r.autoindexingSvc, r.policySvc, r.uploadsResolver.Uploads[i], r.prefetcher, r.traceErrs))
+		resolvers = append(resolvers, NewUploadResolver(r.uploadsSvc, r.autoindexingSvc, r.policySvc, r.uploadsResolver.Uploads[i], r.prefetcher, r.locationResolver, r.traceErrs))
 	}
 	return resolvers, nil
 }


### PR DESCRIPTION
Looks like the cached location resolver wasn't shared at any actual node in the GraphQL resolution. When we have a connection of uploads or indexes we need to use the location resolver that's cached over the entire request, not scoped to a single record.

This _may_ be one of the reasons the upload/index pages are so slow on dotcom (it requires each occurrence of the repository to be re-resolved). Might not be the only reason as traces have shown the main SQL query on these pages to take a while with the full count (so while an improvement is possible it shouldn't be expected).

## Test plan

Existing CI pipelines.