### PR TITLE
build: remove unused imports

### DIFF
--- a/client/plugin-backstage/src/components/ExampleComponent/ExampleComponent.test.tsx
+++ b/client/plugin-backstage/src/components/ExampleComponent/ExampleComponent.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ExampleComponent } from './ExampleComponent';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';

--- a/client/plugin-backstage/src/components/ExampleComponent/ExampleComponent.tsx
+++ b/client/plugin-backstage/src/components/ExampleComponent/ExampleComponent.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Typography, Grid } from '@material-ui/core';
 import {
   InfoCard,

--- a/client/plugin-backstage/src/components/ExampleFetchComponent/ExampleFetchComponent.test.tsx
+++ b/client/plugin-backstage/src/components/ExampleFetchComponent/ExampleFetchComponent.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { ExampleFetchComponent } from './ExampleFetchComponent';
 import { rest } from 'msw';

--- a/client/plugin-backstage/src/components/ExampleFetchComponent/ExampleFetchComponent.tsx
+++ b/client/plugin-backstage/src/components/ExampleFetchComponent/ExampleFetchComponent.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { Table, TableColumn, Progress } from '@backstage/core-components';
 import Alert from '@material-ui/lab/Alert';


### PR DESCRIPTION
This is failing the bazel build. I'm not sure why it only fails in bazel but seems worth fixing either way.

## Test plan

CI

## App preview:

- [Web](https://sg-web-bazel-unused-imports.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
