### PR TITLE
add backcompat for role.readonly column rename

### DIFF
--- a/dev/ci/go-backcompat/flakefiles/v4.4.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.4.0.json
@@ -1,0 +1,32 @@
+[
+  {
+    "path": "internal/database",
+    "prefix": "TestRolePermissionGetByRoleIDAndPermissionID",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestRolePermissionGetByRoleID",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestRolePermissionGetByPermissionID",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestRoleList/basic_no_opts",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestRoleList/with_pagination",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestRoleList",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  }
+]

--- a/dev/ci/go-backcompat/flakefiles/v4.4.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.4.0.json
@@ -63,5 +63,25 @@
     "path": "internal/database",
     "prefix": "TestUserRoleGetByRoleID",
     "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestRolePermissionGetByRoleIDAndPermissionID",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestRolePermissionGetByRoleID",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestRolePermissionGetByPermissionID",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestRolePermissionGetByRoleID",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
   }
 ]

--- a/dev/ci/go-backcompat/flakefiles/v4.4.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.4.0.json
@@ -123,5 +123,10 @@
     "path": "internal/database",
     "prefix": "TestRolePermissionDelete",
     "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestRoleCreate",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
   }
 ]

--- a/dev/ci/go-backcompat/flakefiles/v4.4.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.4.0.json
@@ -28,5 +28,40 @@
     "path": "internal/database",
     "prefix": "TestRoleList",
     "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestRoleCount",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestRoleUpdate",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestRoleUpdate/non-existent_role",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestRoleUpdate/existing_role",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestUserRoleGetByRoleIDAndUserID",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestUserRoleGetByUserID",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestUserRoleGetByRoleID",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
   }
 ]

--- a/dev/ci/go-backcompat/flakefiles/v4.4.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.4.0.json
@@ -61,7 +61,23 @@
   },
   {
     "path": "internal/database",
+    "prefix": "TestUserRoleDelete",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestUserRoleDelete/existing_role",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
     "prefix": "TestUserRoleGetByRoleID",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestRolePermissionCreate",
     "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
   },
   {

--- a/dev/ci/go-backcompat/flakefiles/v4.4.0.json
+++ b/dev/ci/go-backcompat/flakefiles/v4.4.0.json
@@ -61,6 +61,11 @@
   },
   {
     "path": "internal/database",
+    "prefix": "TestUserRoleCreate",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
     "prefix": "TestUserRoleDelete",
     "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
   },
@@ -73,11 +78,20 @@
     "path": "internal/database",
     "prefix": "TestUserRoleGetByRoleID",
     "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
-
   },
   {
     "path": "internal/database",
     "prefix": "TestRolePermissionCreate",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestRoleDelete",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestRoleDelete/existing_role",
     "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
   },
   {
@@ -98,6 +112,16 @@
   {
     "path": "internal/database",
     "prefix": "TestRolePermissionGetByRoleID",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestRoleGetByID",
+    "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
+  },
+  {
+    "path": "internal/database",
+    "prefix": "TestRolePermissionDelete",
     "reason": "The column `readonly` has been renamed to `system`, pre 4.4."
   }
 ]


### PR DESCRIPTION
After the branch cut, I renamed a column `roles.readonly` and that causes some backward compatibility issues since tests pre-branch cut had the `readonly` column existing.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
CI passes?