### PR TITLE
notebooks: Fix selected tab for non-authenticated user

### DIFF
--- a/client/web/src/notebooks/listPage/NotebooksListPage.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPage.tsx
@@ -37,10 +37,6 @@ type NotebooksTab = 'notebooks' | 'getting-started'
 type Tabs = { tab: NotebooksTab; title: string; isActive: boolean; logEventName: string }[]
 
 function getSelectedTabFromLocation(locationSearch: string, authenticatedUser: AuthenticatedUser | null): NotebooksTab {
-    if (!authenticatedUser) {
-        return 'getting-started'
-    }
-
     const urlParameters = new URLSearchParams(locationSearch)
     switch (urlParameters.get('tab')) {
         case 'notebooks':
@@ -48,7 +44,7 @@ function getSelectedTabFromLocation(locationSearch: string, authenticatedUser: A
         case 'getting-started':
             return 'getting-started'
     }
-    return 'notebooks'
+    return authenticatedUser ? 'notebooks' : 'getting-started'
 }
 
 function setSelectedLocationTab(location: H.Location, history: H.History, selectedTab: NotebooksTab): void {


### PR DESCRIPTION
When the user is not authenticated we are not selecting the tab that is referenced in the URL, which is confusing when navigating back and forth.

<img width="957" alt="2023-01-21_19-51" src="https://user-images.githubusercontent.com/179026/213882791-b990820a-82ad-4f62-a650-cc472bdf4456.png">

I understand that we want to show non-authenticated the "Getting started" page first, but we should respect the selected tab after they navigated there.

## Test plan

- Without being authenticated, go to https://sourcegraph.test:3443/notebooks
  - The "Getting started" tab should be selected
- Select the "Notebooks" tab
  - The URL should update to reflect the selected tab
- Got to any other page
- Click the browser's back button
  - The notebooks page is loaded with the "Notebooks" tab being selected, as it is specified in the URL.

## App preview:

- [Web](https://sg-web-fkling-fix-notebooks-selected-tab.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
