### PR TITLE
batches: update scale alert on too-large workspaces preview

### DIFF
--- a/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
+++ b/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
@@ -465,16 +465,19 @@ export const mockImportingChangesets = (
     __typename: 'VisibleChangesetSpec'
 })[] => [...new Array(count).keys()].map(id => mockImportingChangeset(id))
 
-export const mockBatchSpecWorkspaces = (workspacesCount: number): BatchSpecWorkspacesPreviewResult => ({
+export const mockBatchSpecWorkspaces = (
+    workspacesCount: number,
+    totalCount?: number
+): BatchSpecWorkspacesPreviewResult => ({
     node: {
         __typename: 'BatchSpec',
         workspaceResolution: {
             __typename: 'BatchSpecWorkspaceResolution',
             workspaces: {
                 __typename: 'BatchSpecWorkspaceConnection',
-                totalCount: workspacesCount,
+                totalCount: totalCount ?? workspacesCount,
                 pageInfo: {
-                    hasNextPage: workspacesCount > 0,
+                    hasNextPage: !!totalCount,
                     endCursor: 'end-cursor',
                 },
                 nodes: mockPreviewWorkspaces(workspacesCount),
@@ -558,6 +561,33 @@ export const UNSTARTED_WITH_CACHE_CONNECTION_MOCKS: MockedResponses = [
             variables: MATCH_ANY_PARAMETERS,
         },
         result: { data: mockBatchSpecImportingChangesets(20) },
+        nMatches: Number.POSITIVE_INFINITY,
+    },
+    {
+        request: {
+            query: getDocumentNode(WORKSPACE_RESOLUTION_STATUS),
+            variables: MATCH_ANY_PARAMETERS,
+        },
+        result: { data: mockWorkspaceResolutionStatus(BatchSpecWorkspaceResolutionState.COMPLETED) },
+        nMatches: Number.POSITIVE_INFINITY,
+    },
+]
+
+export const LARGE_SUCCESS_CONNECTION_MOCKS: MockedResponses = [
+    {
+        request: {
+            query: getDocumentNode(WORKSPACES),
+            variables: MATCH_ANY_PARAMETERS,
+        },
+        result: { data: mockBatchSpecWorkspaces(50, 2200) },
+        nMatches: Number.POSITIVE_INFINITY,
+    },
+    {
+        request: {
+            query: getDocumentNode(IMPORTING_CHANGESETS),
+            variables: MATCH_ANY_PARAMETERS,
+        },
+        result: { data: mockBatchSpecImportingChangesets(0) },
         nMatches: Number.POSITIVE_INFINITY,
     },
     {

--- a/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
+++ b/client/web/src/enterprise/batches/batch-spec/batch-spec.mock.ts
@@ -24,10 +24,24 @@ import {
     ExecutorCompatibility,
 } from '../../../graphql-operations'
 import { EXECUTORS, IMPORTING_CHANGESETS, WORKSPACES, WORKSPACE_RESOLUTION_STATUS } from '../create/backend'
+import { GET_LICENSE_AND_USAGE_INFO } from '../list/backend'
+import { getLicenseAndUsageInfoResult } from '../list/testData'
 
 import helloWorldSample from './edit/library/hello-world.batch.yaml'
 
 const now = new Date()
+
+export const LICENSED_MOCK: WildcardMockedResponse = {
+    request: { query: getDocumentNode(GET_LICENSE_AND_USAGE_INFO), variables: MATCH_ANY_PARAMETERS },
+    result: { data: getLicenseAndUsageInfoResult(true, true) },
+    nMatches: Number.POSITIVE_INFINITY,
+}
+
+export const UNLICENSED_MOCK: WildcardMockedResponse = {
+    request: { query: getDocumentNode(GET_LICENSE_AND_USAGE_INFO), variables: MATCH_ANY_PARAMETERS },
+    result: { data: getLicenseAndUsageInfoResult(false, true) },
+    nMatches: Number.POSITIVE_INFINITY,
+}
 
 export const MOCK_USER_NAMESPACE = {
     __typename: 'User',
@@ -520,6 +534,7 @@ export const NO_ACTIVE_EXECUTORS_MOCK: WildcardMockedResponse = {
 }
 
 export const UNSTARTED_CONNECTION_MOCKS: MockedResponses = [
+    LICENSED_MOCK,
     {
         request: {
             query: getDocumentNode(WORKSPACES),
@@ -547,6 +562,7 @@ export const UNSTARTED_CONNECTION_MOCKS: MockedResponses = [
 ]
 
 export const UNSTARTED_WITH_CACHE_CONNECTION_MOCKS: MockedResponses = [
+    LICENSED_MOCK,
     {
         request: {
             query: getDocumentNode(WORKSPACES),
@@ -574,6 +590,7 @@ export const UNSTARTED_WITH_CACHE_CONNECTION_MOCKS: MockedResponses = [
 ]
 
 export const LARGE_SUCCESS_CONNECTION_MOCKS: MockedResponses = [
+    LICENSED_MOCK,
     {
         request: {
             query: getDocumentNode(WORKSPACES),

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.story.tsx
@@ -18,6 +18,7 @@ import {
     mockWorkspaceResolutionStatus,
     UNSTARTED_CONNECTION_MOCKS,
     UNSTARTED_WITH_CACHE_CONNECTION_MOCKS,
+    LARGE_SUCCESS_CONNECTION_MOCKS,
 } from '../../batch-spec.mock'
 import { BatchSpecContextProvider } from '../../BatchSpecContext'
 
@@ -403,6 +404,55 @@ export const ReadOnly: Story = () => (
 )
 
 ReadOnly.storyName = 'read-only'
+
+export const SucceededWithScaleAlert: Story = () => (
+    <WebStory>
+        {() => (
+            <MockedTestProvider link={new WildcardMockLink(LARGE_SUCCESS_CONNECTION_MOCKS)}>
+                <BatchSpecContextProvider
+                    batchChange={mockBatchChange()}
+                    batchSpec={mockBatchSpec()}
+                    refetchBatchChange={() => Promise.resolve()}
+                    testState={{
+                        workspacesPreview: {
+                            hasPreviewed: true,
+                            resolutionState: BatchSpecWorkspaceResolutionState.COMPLETED,
+                            preview: () => Promise.resolve(),
+                            cancel: noop,
+                            isInProgress: false,
+                            clearError: noop,
+                            setFilters: noop,
+                            isPreviewDisabled: false,
+                            noCache: false,
+                        },
+                    }}
+                >
+                    <WorkspacesPreview />
+                </BatchSpecContextProvider>
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
+
+SucceededWithScaleAlert.storyName = 'succeeded, with size alert'
+
+export const ReadOnlyWithScaleAlert: Story = () => (
+    <WebStory>
+        {props => (
+            <MockedTestProvider link={new WildcardMockLink(LARGE_SUCCESS_CONNECTION_MOCKS)}>
+                <BatchSpecContextProvider
+                    batchChange={mockBatchChange()}
+                    batchSpec={mockBatchSpec()}
+                    refetchBatchChange={() => Promise.resolve()}
+                >
+                    <WorkspacesPreview {...props} isReadOnly={true} />
+                </BatchSpecContextProvider>
+            </MockedTestProvider>
+        )}
+    </WebStory>
+)
+
+ReadOnlyWithScaleAlert.storyName = 'read-only, with size alert'
 
 export const UnstartedWithLicenseAlertConnectionResult: Story = () => (
     <WebStory>

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.story.tsx
@@ -8,8 +8,6 @@ import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../../../../../components/WebStory'
 import { IMPORTING_CHANGESETS, WORKSPACE_RESOLUTION_STATUS, WORKSPACES } from '../../../create/backend'
-import { GET_LICENSE_AND_USAGE_INFO } from '../../../list/backend'
-import { getLicenseAndUsageInfoResult } from '../../../list/testData'
 import {
     mockBatchChange,
     mockBatchSpec,
@@ -19,6 +17,8 @@ import {
     UNSTARTED_CONNECTION_MOCKS,
     UNSTARTED_WITH_CACHE_CONNECTION_MOCKS,
     LARGE_SUCCESS_CONNECTION_MOCKS,
+    UNLICENSED_MOCK,
+    LICENSED_MOCK,
 } from '../../batch-spec.mock'
 import { BatchSpecContextProvider } from '../../BatchSpecContext'
 
@@ -87,6 +87,7 @@ export const QueuedInProgress: Story = args => {
     const inProgressResolution = mockWorkspaceResolutionStatus(args.inProgressResolution)
 
     const inProgressConnectionMocks = new WildcardMockLink([
+        LICENSED_MOCK,
         {
             request: {
                 query: getDocumentNode(WORKSPACES),
@@ -150,6 +151,7 @@ export const QueuedInProgressWithCachedConnectionResult: Story = args => {
     const inProgressResolution = mockWorkspaceResolutionStatus(args.inProgressResolution)
 
     const inProgressConnectionMocks = new WildcardMockLink([
+        LICENSED_MOCK,
         {
             request: {
                 query: getDocumentNode(WORKSPACES),
@@ -212,6 +214,7 @@ export const FailedErrored: Story = args => {
     )
 
     const failedConnectionMocks = new WildcardMockLink([
+        LICENSED_MOCK,
         {
             request: {
                 query: getDocumentNode(WORKSPACES),
@@ -274,6 +277,7 @@ export const FailedErroredWithCachedConnectionResult: Story = args => {
     )
 
     const failedConnectionMocks = new WildcardMockLink([
+        LICENSED_MOCK,
         {
             request: {
                 query: getDocumentNode(WORKSPACES),
@@ -458,19 +462,7 @@ export const UnstartedWithLicenseAlertConnectionResult: Story = () => (
     <WebStory>
         {props => (
             <MockedTestProvider
-                link={
-                    new WildcardMockLink([
-                        ...UNSTARTED_WITH_CACHE_CONNECTION_MOCKS,
-                        {
-                            request: {
-                                query: getDocumentNode(GET_LICENSE_AND_USAGE_INFO),
-                                variables: MATCH_ANY_PARAMETERS,
-                            },
-                            result: { data: getLicenseAndUsageInfoResult(false, true) },
-                            nMatches: Number.POSITIVE_INFINITY,
-                        },
-                    ])
-                }
+                link={new WildcardMockLink([UNLICENSED_MOCK, ...UNSTARTED_WITH_CACHE_CONNECTION_MOCKS])}
             >
                 <BatchSpecContextProvider
                     batchChange={mockBatchChange()}
@@ -490,19 +482,7 @@ export const ReadOnlyWithLicenseAlert: Story = () => (
     <WebStory>
         {props => (
             <MockedTestProvider
-                link={
-                    new WildcardMockLink([
-                        ...UNSTARTED_WITH_CACHE_CONNECTION_MOCKS,
-                        {
-                            request: {
-                                query: getDocumentNode(GET_LICENSE_AND_USAGE_INFO),
-                                variables: MATCH_ANY_PARAMETERS,
-                            },
-                            result: { data: getLicenseAndUsageInfoResult(false, true) },
-                            nMatches: Number.POSITIVE_INFINITY,
-                        },
-                    ])
-                }
+                link={new WildcardMockLink([UNLICENSED_MOCK, ...UNSTARTED_WITH_CACHE_CONNECTION_MOCKS])}
             >
                 <BatchSpecContextProvider
                     batchChange={mockBatchChange()}

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
@@ -266,20 +266,6 @@ const MemoizedWorkspacesPreview: React.FunctionComponent<React.PropsWithChildren
                     {totalCountDisplay}
                 </WorkspacesListHeader>
                 {/* We wrap this section in its own div to prevent margin collapsing within the flex column */}
-                {exceedsLicense((totalCount ?? 0) + (importingChangesetsConnection?.connection?.totalCount ?? 0)) && (
-                    <div className="d-flex flex-column align-items-center w-100 mb-3">
-                        <Alert variant="info">
-                            <div className="mb-2">
-                                <strong>
-                                    Your license only allows for {maxUnlicensedChangesets} changesets per batch change
-                                </strong>
-                            </div>
-                            If more than {maxUnlicensedChangesets} changesets are generated, you won't be able to apply
-                            the batch change and actually publish the changesets to the code host.
-                        </Alert>
-                    </div>
-                )}
-                {/* We wrap this section in its own div to prevent margin collapsing within the flex column */}
                 {!isReadOnly && (
                     <div className="d-flex flex-column align-items-center w-100 mb-3">
                         {error && <ErrorAlert error={error} className="w-100 mb-0" />}
@@ -303,6 +289,12 @@ const MemoizedWorkspacesPreview: React.FunctionComponent<React.PropsWithChildren
                         <CTASizeWarning />
                     </div>
                 )}
+                {totalCount !== null &&
+                    exceedsLicense(totalCount + (importingChangesetsConnection?.connection?.totalCount ?? 0)) && (
+                        <div className="d-flex flex-column align-items-center w-100">
+                            <CTALicenseWarning maxCount={maxUnlicensedChangesets} />
+                        </div>
+                    )}
                 {(hasPreviewed || isReadOnly) && (
                     <WorkspacePreviewFilterRow onFiltersChange={setFilters} disabled={isWorkspacesPreviewInProgress} />
                 )}
@@ -357,5 +349,10 @@ const CTASizeWarning: React.FunctionComponent = () => (
         workspaces. Break your batch change down into several smaller batch changes for a better experience.
     </Alert>
 )
+
+const CTALicenseWarning: React.FunctionComponent<React.PropsWithChildren<{ maxCount: number }>> = ({ maxCount }) => (
+    <Alert variant="note" className="mb-2">
+        Your license only allows for {maxCount} changesets per batch change. If more than {maxCount} changesets are
+        generated, you won't be able to apply the batch change and actually publish the changesets to the code host.
     </Alert>
 )

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.tsx
@@ -299,8 +299,8 @@ const MemoizedWorkspacesPreview: React.FunctionComponent<React.PropsWithChildren
                     </div>
                 )}
                 {totalCount !== null && totalCount >= WORKSPACE_WARNING_MIN_TOTAL_COUNT && (
-                    <div className="d-flex flex-column align-items-center w-100 mb-3">
-                        <CTASizeWarning totalCount={totalCount} />
+                    <div className="d-flex flex-column align-items-center w-100">
+                        <CTASizeWarning />
                     </div>
                 )}
                 {(hasPreviewed || isReadOnly) && (
@@ -351,16 +351,11 @@ const CTAInstruction: React.FunctionComponent<React.PropsWithChildren<{ active: 
     )
 }
 
-const CTASizeWarning: React.FunctionComponent<React.PropsWithChildren<{ totalCount: number }>> = ({ totalCount }) => (
-    <Alert variant="warning">
-        <div className="mb-2">
-            <strong>
-                It's over <s>9000</s> {WORKSPACE_WARNING_MIN_TOTAL_COUNT}!
-            </strong>
-        </div>
-        Batch changes with more than {WORKSPACE_WARNING_MIN_TOTAL_COUNT} workspaces may be unwieldy to manage. We're
-        working on providing more filtering options, and you can continue with this batch change if you want, but you
-        may want to break it into {Math.ceil(totalCount / WORKSPACE_WARNING_MIN_TOTAL_COUNT)} or more batch changes if
-        you can.
+const CTASizeWarning: React.FunctionComponent = () => (
+    <Alert variant="note" className="mb-2">
+        The experience is currently optimized for batch changes targeting up to {WORKSPACE_WARNING_MIN_TOTAL_COUNT}{' '}
+        workspaces. Break your batch change down into several smaller batch changes for a better experience.
+    </Alert>
+)
     </Alert>
 )


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/43692.

Brings scale alert on too-large workspaces preview inline with other large scale warning patterns. I also updated the unlicensed alert style to match since the two communicate a similar type of degraded experience warning.

## Test plan

Added additional Storybook story coverage to verify appearance:

- [Completed workspaces preview, with size alert](https://5f0f381c0e50750022dc6bf7-cxprnmetag.chromatic.com/?path=/story/web-batches-batch-spec-edit-workspaces-preview-workspacespreview--succeeded-with-scale-alert)
- [Read-only workspaces preview, with size alert](https://5f0f381c0e50750022dc6bf7-cxprnmetag.chromatic.com/?path=/story/web-batches-batch-spec-edit-workspaces-preview-workspacespreview--read-only-with-scale-alert)
- [Unstarted cached workspaces preview, with unlicensed alert](https://5f0f381c0e50750022dc6bf7-cxprnmetag.chromatic.com/?path=/story/web-batches-batch-spec-edit-workspaces-preview-workspacespreview--unstarted-with-license-alert-connection-result)
- [Read-only workspaces preview, with unlicensed alert](https://5f0f381c0e50750022dc6bf7-cxprnmetag.chromatic.com/?path=/story/web-batches-batch-spec-edit-workspaces-preview-workspacespreview--read-only-with-license-alert)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

## App preview:

- [Web](https://sg-web-kr-scale-alert-warning.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
