### PR TITLE
rcache: migrate most uses to direct KeyValue use

### DIFF
--- a/internal/redispool/keyvalue.go
+++ b/internal/redispool/keyvalue.go
@@ -26,12 +26,13 @@ type KeyValue interface {
 	Del(key string) error
 
 	HGet(key, field string) Value
+	HGetAll(key string) Values
 	HSet(key, field string, value any) error
 
 	LPush(key string, value any) error
 	LTrim(key string, start, stop int) error
 	LLen(key string) (int, error)
-	LRange(key string, start, stop int) Value
+	LRange(key string, start, stop int) Values
 
 	// WithContext will return a KeyValue that should respect ctx for all
 	// blocking operations.
@@ -62,12 +63,35 @@ func (v Value) Bytes() ([]byte, error) {
 	return redis.Bytes(v.reply, v.err)
 }
 
-func (v Value) ByteSlices() ([][]byte, error) {
+func (v Value) String() (string, error) {
+	return redis.String(v.reply, v.err)
+}
+
+func (v Value) values() Values {
+	return Values{reply: v.reply, err: v.err}
+}
+
+// Values is a response from an operation on KeyValue which returns multiple
+// items. It provides convenient methods to get at the underlying value of the
+// reply.
+//
+// Note: the available methods are based on current need. If you need to add
+// another helper go for it.
+type Values struct {
+	reply interface{}
+	err   error
+}
+
+func (v Values) ByteSlices() ([][]byte, error) {
 	return redis.ByteSlices(redis.Values(v.reply, v.err))
 }
 
-func (v Value) String() (string, error) {
-	return redis.String(v.reply, v.err)
+func (v Values) Strings() ([]string, error) {
+	return redis.Strings(v.reply, v.err)
+}
+
+func (v Values) StringMap() (map[string]string, error) {
+	return redis.StringMap(v.reply, v.err)
 }
 
 type redisKeyValue struct {
@@ -113,6 +137,10 @@ func (r *redisKeyValue) HGet(key, field string) Value {
 	return r.do("HGET", r.prefix+key, field)
 }
 
+func (r *redisKeyValue) HGetAll(key string) Values {
+	return r.do("HGETALL", r.prefix+key).values()
+}
+
 func (r *redisKeyValue) HSet(key, field string, val any) error {
 	return r.do("HSET", r.prefix+key, field, val).err
 }
@@ -127,8 +155,8 @@ func (r *redisKeyValue) LLen(key string) (int, error) {
 	raw := r.do("LLEN", r.prefix+key)
 	return redis.Int(raw.reply, raw.err)
 }
-func (r *redisKeyValue) LRange(key string, start, stop int) Value {
-	return r.do("LRANGE", r.prefix+key, start, stop)
+func (r *redisKeyValue) LRange(key string, start, stop int) Values {
+	return r.do("LRANGE", r.prefix+key, start, stop).values()
 }
 
 func (r *redisKeyValue) WithContext(ctx context.Context) KeyValue {

--- a/internal/redispool/keyvalue.go
+++ b/internal/redispool/keyvalue.go
@@ -67,10 +67,6 @@ func (v Value) String() (string, error) {
 	return redis.String(v.reply, v.err)
 }
 
-func (v Value) values() Values {
-	return Values{reply: v.reply, err: v.err}
-}
-
 // Values is a response from an operation on KeyValue which returns multiple
 // items. It provides convenient methods to get at the underlying value of the
 // reply.
@@ -138,7 +134,7 @@ func (r *redisKeyValue) HGet(key, field string) Value {
 }
 
 func (r *redisKeyValue) HGetAll(key string) Values {
-	return r.do("HGETALL", r.prefix+key).values()
+	return Values(r.do("HGETALL", r.prefix+key))
 }
 
 func (r *redisKeyValue) HSet(key, field string, val any) error {
@@ -156,7 +152,7 @@ func (r *redisKeyValue) LLen(key string) (int, error) {
 	return redis.Int(raw.reply, raw.err)
 }
 func (r *redisKeyValue) LRange(key string, start, stop int) Values {
-	return r.do("LRANGE", r.prefix+key, start, stop).values()
+	return Values(r.do("LRANGE", r.prefix+key, start, stop))
 }
 
 func (r *redisKeyValue) WithContext(ctx context.Context) KeyValue {


### PR DESCRIPTION
Additionally we update KeyValue to correctly model how redis returns lists. Lists are only returned from list like calls, so we introduce a Values type to prevent misuse. We also expand the KeyValue interface to accomodate a new use of HGetAll.

Test Plan: unit tests