### PR TITLE
goroutine: use FIFOList for recorder

### DIFF
--- a/internal/goroutine/recorder/reader.go
+++ b/internal/goroutine/recorder/reader.go
@@ -1,6 +1,7 @@
 package recorder
 
 import (
+	"context"
 	"encoding/json"
 	"sort"
 	"time"
@@ -250,7 +251,7 @@ func getRoutineInstanceInfo(c *rcache.Cache, jobName string, routineName string,
 
 // loadRecentRuns loads the recent runs for a routine, in no particular order.
 func loadRecentRuns(c *rcache.Cache, jobName string, routineName string, hostName string, count int) ([]RoutineRun, error) {
-	recentRuns, err := c.GetLastListItems(jobName+":"+routineName+":"+hostName+":"+"recentRuns", count)
+	recentRuns, err := getRecentRuns(c, jobName, routineName, hostName).Slice(context.Background(), 0, count)
 	if err != nil {
 		return nil, errors.Wrap(err, "load recent runs")
 	}

--- a/internal/goroutine/recorder/reader.go
+++ b/internal/goroutine/recorder/reader.go
@@ -259,7 +259,7 @@ func loadRecentRuns(c *rcache.Cache, jobName string, routineName string, hostNam
 	runs := make([]RoutineRun, 0, len(recentRuns))
 	for _, serializedRun := range recentRuns {
 		var run RoutineRun
-		err := json.Unmarshal([]byte(serializedRun), &run)
+		err := json.Unmarshal(serializedRun, &run)
 		if err != nil {
 			return nil, errors.Wrap(err, "deserialize run")
 		}

--- a/internal/goroutine/recorder/recorder.go
+++ b/internal/goroutine/recorder/recorder.go
@@ -151,7 +151,7 @@ func (m *Recorder) LogRun(r Recordable, duration time.Duration, runErr error) {
 	m.logger.Debug("Hello from " + r.Name() + "! 😄")
 }
 
-// saveRun saves a run in the Redis list under the "*:recentRuns" key and trims the list.
+// saveRun saves a run in the Redis list under the "*:recentRuns" key.
 func (m *Recorder) saveRun(jobName string, routineName string, hostName string, durationMs int32, err error) error {
 	errorMessage := ""
 	if err != nil {
@@ -173,15 +173,9 @@ func (m *Recorder) saveRun(jobName string, routineName string, hostName string, 
 	}
 
 	// Save run
-	err = m.rcache.AddToList(jobName+":"+routineName+":"+hostName+":"+"recentRuns", string(runJson))
+	err = getRecentRuns(m.rcache, jobName, routineName, hostName).Insert(runJson)
 	if err != nil {
 		return errors.Wrap(err, "save run")
-	}
-
-	// Trim list
-	err = m.rcache.LTrimList(jobName+":"+routineName+":"+hostName+":"+"recentRuns", maxRecentRunsLength)
-	if err != nil {
-		return errors.Wrap(err, "trim list")
 	}
 
 	return nil
@@ -229,4 +223,10 @@ func addRunToStats(stats RoutineRunStats, durationMs int32, errored bool) Routin
 		AvgDurationMs: durationMs,
 		MaxDurationMs: durationMs,
 	})
+}
+
+// getRecentRuns returns the FIFOList under the ":*recentRuns" key.
+func getRecentRuns(c *rcache.Cache, jobName string, routineName string, hostName string) *rcache.FIFOList {
+	key := jobName + ":" + routineName + ":" + hostName + ":" + "recentRuns"
+	return c.FIFOList(key, maxRecentRunsLength)
 }

--- a/internal/rcache/rcache.go
+++ b/internal/rcache/rcache.go
@@ -129,6 +129,11 @@ func (r *Cache) KeyTTL(key string) (int, bool) {
 	return ttl, ttl >= 0
 }
 
+// FIFOList returns a FIFOList namespaced in r.
+func (r *Cache) FIFOList(key string, maxSize int) *FIFOList {
+	return NewFIFOList(r.rkeyPrefix()+key, maxSize)
+}
+
 // SetHashItem sets a key in a HASH.
 // If the HASH does not exist, it is created.
 // If the key already exists and is a different type, an error is returned.
@@ -152,30 +157,6 @@ func (r *Cache) GetHashAll(key string) (map[string]string, error) {
 	c := poolGet()
 	defer c.Close()
 	return redis.StringMap(c.Do("HGETALL", r.rkeyPrefix()+key))
-}
-
-// AddToList adds a value to the end of a list.
-// If the list does not exist, it is created.
-func (r *Cache) AddToList(key string, value string) error {
-	c := poolGet()
-	defer c.Close()
-	_, err := c.Do("RPUSH", r.rkeyPrefix()+key, value)
-	return err
-}
-
-// GetLastListItems returns the last `count` items in the list.
-func (r *Cache) GetLastListItems(key string, count int) ([]string, error) {
-	c := poolGet()
-	defer c.Close()
-	return redis.Strings(c.Do("LRANGE", r.rkeyPrefix()+key, -count, -1))
-}
-
-// LTrimList trims the list to the last `count` items.
-func (r *Cache) LTrimList(key string, count int) error {
-	c := poolGet()
-	defer c.Close()
-	_, err := c.Do("LTRIM", r.rkeyPrefix()+key, -count, -1)
-	return err
 }
 
 // Delete implements httpcache.Cache.Delete

--- a/internal/rcache/rcache_test.go
+++ b/internal/rcache/rcache_test.go
@@ -222,26 +222,6 @@ func TestCache_SetWithTTL(t *testing.T) {
 	}
 }
 
-func TestCache_LTrimList(t *testing.T) {
-	SetupForTest(t)
-
-	c := NewWithTTL("some_prefix", 1)
-
-	c.AddToList("list", "1")
-	c.AddToList("list", "2")
-	c.AddToList("list", "3")
-	c.AddToList("list", "4")
-	c.AddToList("list", "5")
-
-	c.LTrimList("list", 2)
-
-	items, err := c.GetLastListItems("list", 8)
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(items))
-	assert.Equal(t, "4", items[0])
-	assert.Equal(t, "5", items[1])
-}
-
 func TestCache_Hashes(t *testing.T) {
 	SetupForTest(t)
 
@@ -267,29 +247,6 @@ func TestCache_Hashes(t *testing.T) {
 	all, err := c.GetHashAll("key")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"hashKey1": "value1", "hashKey2": "value2"}, all)
-}
-
-func TestCache_Lists(t *testing.T) {
-	SetupForTest(t)
-
-	// Use AddToList to fill list
-	c := NewWithTTL("simple_list", 1)
-	err := c.AddToList("key", "item1")
-	assert.NoError(t, err)
-	err = c.AddToList("key", "item2")
-	assert.NoError(t, err)
-	err = c.AddToList("key", "item3")
-	assert.NoError(t, err)
-
-	// Use GetLastListItems to get last 2 items
-	last2, err := c.GetLastListItems("key", 2)
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"item2", "item3"}, last2)
-
-	// Use GetLastListItems to get last 5 items (we only have 3)
-	last5, err := c.GetLastListItems("key", 5)
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"item1", "item2", "item3"}, last5)
 }
 
 func bytes(s ...string) [][]byte {


### PR DESCRIPTION
FIFOList directly supports the use case of what recorder wants (store the most recent N jobs). This makes it possible to remove the list operations added to rcache. Additionally I think the call sites are clearer.

Test Plan: go test