### PR TITLE
all: remove watches for FIFOList

### DIFF
--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -106,7 +106,7 @@ func NewPermsSyncer(
 		clock:               clock,
 		rateLimiterRegistry: rateLimiterRegistry,
 		scheduleInterval:    scheduleInterval(),
-		recordsStore:        syncjobs.NewRecordsStore(logger.Scoped("records", "sync jobs records store")),
+		recordsStore:        syncjobs.NewRecordsStore(logger.Scoped("records", "sync jobs records store"), conf.DefaultClient()),
 	}
 }
 
@@ -1354,7 +1354,6 @@ func (s *PermsSyncer) collectMetrics(ctx context.Context) {
 func (s *PermsSyncer) Run(ctx context.Context) {
 	go s.runSync(ctx)
 	go s.runSchedule(ctx)
-	go s.recordsStore.Watch(conf.DefaultClient())
 
 	<-ctx.Done()
 }

--- a/enterprise/internal/authz/syncjobs/mocks_test.go
+++ b/enterprise/internal/authz/syncjobs/mocks_test.go
@@ -6,13 +6,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-type confWatcher struct {
-	update func()
-	conf   schema.SiteConfiguration
+type siteConfigQuerier struct {
+	conf schema.SiteConfiguration
 }
 
-func (c *confWatcher) Watch(fn func())                      { c.update = fn }
-func (c *confWatcher) SiteConfig() schema.SiteConfiguration { return c.conf }
+func (c *siteConfigQuerier) SiteConfig() schema.SiteConfiguration { return c.conf }
 
 type memCache struct {
 	// retain in []string for ease of autogold testing
@@ -23,9 +21,6 @@ func (m *memCache) Insert(v []byte) error {
 	m.values = append(m.values, string(v))
 	return nil
 }
-
-// no-op
-func (m *memCache) SetMaxSize(int) {}
 
 func (m *memCache) Slice(ctx context.Context, from, to int) (vals [][]byte, err error) {
 	for _, v := range m.values {

--- a/enterprise/internal/authz/syncjobs/records_reader_test.go
+++ b/enterprise/internal/authz/syncjobs/records_reader_test.go
@@ -8,14 +8,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestSyncJobRecordsRead(t *testing.T) {
 	c := &memCache{}
 
 	// Write multiple records
-	s := NewRecordsStore(logtest.Scoped(t))
+	s := NewRecordsStore(logtest.Scoped(t), configWithRecordsLimit(0))
 	s.cache = c
 	s.Record("repo", 12, []ProviderStatus{{
 		ProviderID:   "https://github.com",
@@ -57,4 +59,12 @@ func TestSyncJobRecordsRead(t *testing.T) {
 		assert.True(t, first.Completed.Before(second.Completed))
 		assert.True(t, second.Completed.Before(third.Completed))
 	})
+}
+
+func configWithRecordsLimit(limit int) conftypes.SiteConfigQuerier {
+	return &siteConfigQuerier{
+		conf: schema.SiteConfiguration{
+			AuthzSyncJobsRecordsLimit: limit,
+		},
+	}
 }

--- a/enterprise/internal/authz/syncjobs/records_store_test.go
+++ b/enterprise/internal/authz/syncjobs/records_store_test.go
@@ -6,34 +6,9 @@ import (
 
 	"github.com/hexops/autogold"
 	"github.com/sourcegraph/log/logtest"
-	"github.com/stretchr/testify/assert"
 
-	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
-
-func TestSyncJobsRecordsStoreWatch(t *testing.T) {
-	s := NewRecordsStore(logtest.Scoped(t))
-
-	// assert default
-	assert.Equal(t, defaultSyncJobsRecordsLimit, s.cache.(*rcache.FIFOList).MaxSize())
-
-	cw := confWatcher{
-		conf: schema.SiteConfiguration{
-			AuthzSyncJobsRecordsLimit: 5,
-		},
-	}
-
-	// register
-	s.Watch(&cw)
-
-	// proc the update
-	cw.update()
-
-	// assert updated
-	assert.Equal(t, 5, s.cache.(*rcache.FIFOList).MaxSize())
-}
 
 func TestSyncJobRecordsRecord(t *testing.T) {
 	mockTime, err := time.Parse(time.RFC1123, time.RFC1123)

--- a/internal/rcache/fifo_list.go
+++ b/internal/rcache/fifo_list.go
@@ -6,22 +6,29 @@ import (
 	"unicode/utf8"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"go.uber.org/atomic"
 )
 
 // FIFOList holds the most recently inserted items, discarding older ones if the total item count goes over the configured size.
 type FIFOList struct {
 	key     string
-	maxSize atomic.Int64 // invariant: non-negative integer
+	maxSize func() int
 }
 
 // NewFIFOList returns a FIFOList, storing only a fixed amount of elements, discarding old ones if needed.
 func NewFIFOList(key string, size int) *FIFOList {
-	l := &FIFOList{
-		key: key,
+	return &FIFOList{
+		key:     key,
+		maxSize: func() int { return size },
 	}
-	// SetMaxSize will adjust size to be a non-negative integer.
-	l.SetMaxSize(size)
+}
+
+// NewFIFOListDynamic is like NewFIFOList except size will be called each time
+// we enforce list size invariants.
+func NewFIFOListDynamic(key string, size func() int) *FIFOList {
+	l := &FIFOList{
+		key:     key,
+		maxSize: size,
+	}
 	return l
 }
 
@@ -64,19 +71,11 @@ func (l *FIFOList) Size() (int, error) {
 }
 
 func (l *FIFOList) MaxSize() int {
-	return int(l.maxSize.Load())
-}
-
-// SetMaxSize will change the size we truncate at. If maxSize is <= 0 the list
-// will remain empty.
-//
-// Note: this won't cause truncation to happen, instead truncation is done on
-// the next insert.
-func (l *FIFOList) SetMaxSize(maxSize int) {
+	maxSize := l.maxSize()
 	if maxSize < 0 {
-		maxSize = 0
+		return 0
 	}
-	l.maxSize.Store(int64(maxSize))
+	return maxSize
 }
 
 // All return all items stored in the FIFOList.

--- a/internal/rcache/fifo_list_test.go
+++ b/internal/rcache/fifo_list_test.go
@@ -158,8 +158,9 @@ func Test_FIFOList_Slice_OK(t *testing.T) {
 	}
 }
 
-func Test_FIFOList_SetMaxSize(t *testing.T) {
-	r := NewFIFOList("a", 3)
+func Test_NewFIFOListDynamic(t *testing.T) {
+	maxSize := 3
+	r := NewFIFOListDynamic("a", func() int { return maxSize })
 	for i := 0; i < 10; i++ {
 		err := r.Insert([]byte("a"))
 		if err != nil {
@@ -175,7 +176,7 @@ func Test_FIFOList_SetMaxSize(t *testing.T) {
 		t.Errorf("expected %v, but got %v", _str(want...), _str(got...))
 	}
 
-	r.SetMaxSize(2)
+	maxSize = 2
 	for i := 0; i < 10; i++ {
 		err := r.Insert([]byte("b"))
 		if err != nil {


### PR DESCRIPTION
This is something that I thought could be improved. In everycase we setup a watch for a FIFOList all we are doing it fetching a value. Instead of updating the FIFOList, we can pass in a function which FIFOList calls when it wants to know what size to trim to. This simplifies nearly all use cases and removes the need to have a SetMaxSize API.

The biggest change here was around syncjobs which had a few mocks setup which meant the change wasn't as clean. But all other call sites should look nicer.

Test Plan: go test