### PR TITLE
Fix repositories page legend redirect

### DIFF
--- a/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
+++ b/client/web/src/site-admin/analytics/components/ValueLegendList.tsx
@@ -17,6 +17,7 @@ interface ValueLegendItemProps {
     tooltip?: string
     className?: string
     filter?: { name: string; value: string }
+    onClick?: () => any
 }
 
 export const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({
@@ -26,6 +27,7 @@ export const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({
     tooltip,
     className,
     filter,
+    onClick,
 }) => {
     const formattedNumber = useMemo(() => (typeof value === 'number' ? formatNumber(value) : value), [value])
     const unformattedNumber = `${value}`
@@ -53,9 +55,9 @@ export const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({
                         {formattedNumber}
                     </Link>
                 ) : (
-                    <span style={{ color }} className={styles.count}>
+                    <Text as="span" alignment="center" style={{ color }} className={styles.count} onClick={onClick}>
                         {formattedNumber}
-                    </span>
+                    </Text>
                 )}
             </Tooltip>
             <Tooltip content={tooltip}>
@@ -72,6 +74,7 @@ export const ValueLegendItem: React.FunctionComponent<ValueLegendItemProps> = ({
                         as="span"
                         alignment="center"
                         className={classNames(styles.textWrap, tooltip && 'cursor-pointer', 'text-muted')}
+                        onClick={onClick}
                     >
                         {description}
                         {tooltip && <span className={styles.linkColor}>*</span>}


### PR DESCRIPTION
Fix for: https://sourcegraph.slack.com/archives/C03CSAER9LK/p1674489039551229
closes: https://github.com/sourcegraph/sourcegraph/issues/46958

The repositories page legends update the URL search parameters, whereas the filter's state flux is in the opposite direction. The URL is updated in response to changes in state and not otherwise. 

This PR fixes the issue of recursive state updates by making legends update the state using onClick.

## Test plan

- open site-admin/repositories
- click on value legend and check if URL, filters and page is updated. 

## App preview:

- [Web](https://sg-web-naman-fix-repositories-legends.onrender.com/search)

Check out the [client app preview documentation](https://docs.sourcegraph.com/dev/how-to/client_pr_previews) to learn more.
