### PR TITLE
remove LawnGnome from batches-notify.yml

### DIFF
--- a/.github/workflows/batches-notify.yml
+++ b/.github/workflows/batches-notify.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           body: |
-            Hey, @sourcegraph/batchers (@eseliger @LawnGnome @courier-new @adeola-ak @BolajiOlajide @Piszmog @malomarrec @chrispine @danielmarquespt) - we have been mentioned. Let's take a look.
+            Hey, @sourcegraph/batchers (@eseliger @courier-new @adeola-ak @BolajiOlajide @Piszmog @malomarrec @chrispine @danielmarquespt) - we have been mentioned. Let's take a look.


### PR DESCRIPTION
This removes LawnGnome from the list of folks to notify for Batch Change related issues.



## Test plan

Verify that LawnGnome is no longer pinged for Batch Change issues.
